### PR TITLE
fix(tui): by-id intervention delivery, first-option focus, churn-zero Q→A entry — #3299 P2

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -173,19 +173,27 @@ class TextualChatApp(App):
     widget between the flow and the input row (atomic display-swap +
     input-swap + chip-retire — see :meth:`_present_intervention`'s docstring):
     a ``kind="intervention"`` frame arriving on the pump (:meth:`_ingest_frame`)
-    appends a THIN pending flow placeholder and populates + auto-focuses the
-    panel — a :class:`~textual.widgets.RadioSet` for a closed-set intervention
-    (``meta["choices"]``), a plain :class:`~textual.widgets.Input` otherwise.
-    Selecting/submitting in the panel (:meth:`on_intervention_panel_choice_selected`
-    / :meth:`on_intervention_panel_text_submitted`) delivers the answer through
+    appends a THIN pending flow placeholder and, if the panel is idle, populates
+    + auto-focuses it — a :class:`~textual.widgets.RadioSet` (pre-highlighting
+    its FIRST option, #3299 P2 owner decision (A): a blind ``Enter`` answers it)
+    for a closed-set intervention (``meta["choices"]``), a plain
+    :class:`~textual.widgets.Input` otherwise. Selecting/submitting in the panel
+    (:meth:`on_intervention_panel_choice_selected` /
+    :meth:`on_intervention_panel_text_submitted`) delivers the answer through
     the UNCHANGED transport funnel (``answer_intervention_choice`` /
-    ``answer_intervention_text``), resolves the flow entry to a basic
-    "✓ answered" record, hides the panel, and returns focus to the Composer.
-    ``Esc``/``Tab`` inside the panel (:meth:`on_intervention_panel_dismissed`)
-    return focus to the Composer WITHOUT answering — the intervention stays
-    pending (the #3300 sent-queue durably holds any new Composer submit while
-    it does; no black-hole guard is needed here, see the PR body). The
-    Composer itself is now EXCLUSIVELY for new turns — it no longer reads
+    ``answer_intervention_text``) — targeted at the id of the intervention the
+    panel is CURRENTLY DISPLAYING (#3299 P2, R1 by-id delivery: with
+    ``outstanding_interventions`` holding multiple pending entries, the head is
+    not necessarily the one on screen — see :meth:`_present_intervention` /
+    :meth:`_resolve_pending_intervention`) — resolves that SAME flow entry
+    in place to a "✓ answered" record (:meth:`_resolve_pending_intervention`),
+    and either re-populates the panel with the NEXT pending intervention (FIFO)
+    or hides it and returns focus to the Composer. ``Esc``/``Tab`` inside the
+    panel (:meth:`on_intervention_panel_dismissed`) return focus to the
+    Composer WITHOUT answering — the intervention stays pending (the #3300
+    sent-queue durably holds any new Composer submit while it does; no
+    black-hole guard is needed here, see the PR body). The Composer itself is
+    now EXCLUSIVELY for new turns — it no longer reads
     ``pending_intervention_head()`` at all.
     """
 
@@ -298,11 +306,23 @@ class TextualChatApp(App):
         # deterministic args_hash, meta["op_id"]) so a later completion/failure
         # frame transitions the SAME entry RUNNING → SUCCESS/ERROR (CC parity).
         self._running_tools: "dict[object, Entry[OutboxMessage]]" = {}
-        # The ONE pending intervention's flow entry (#3299 P1) — held so
-        # :meth:`_resolve_pending_intervention` can update it IN PLACE (basic
-        # placeholder → "✓ answered" record) once the panel delivers an answer.
-        # ``None`` when no intervention is pending.
-        self._pending_iv_entry: "Entry[OutboxMessage] | None" = None
+        # ALL pending interventions' flow entries (#3299 P2 — was single-slot
+        # in P1, overwritten by a second concurrent pending intervention, an
+        # architect self-review finding: ``outstanding_interventions`` is a
+        # multi-entry structure by design, e.g. restore's FIFO re-enqueue),
+        # keyed by intervention id (falling back to a synthetic per-entry key
+        # when a frame carries no id, so tracking never breaks — delivery then
+        # stays head-targeted for that entry, matching pre-P2 behavior).
+        # Each value is ``(entry, msg, intervention_id | None)`` — the flow
+        # entry :meth:`_resolve_pending_intervention` updates IN PLACE, the
+        # original frame (to re-populate the panel if this becomes the
+        # DISPLAYED one later), and the real id to target at the transport
+        # (``None`` disables by-id targeting for that entry).
+        self._pending_ivs: "dict[object, tuple[Entry[OutboxMessage], OutboxMessage, str | None]]" = {}
+        # The key (in ``_pending_ivs``) of the intervention the panel is
+        # CURRENTLY DISPLAYING — ``None`` when the panel is idle. Answers
+        # always target THIS one (by-id, #3299 P2 R1), never "the head".
+        self._iv_current_key: "object | None" = None
         # #3300 P2b: the client-side sent-queue model — the SAME seq-gated
         # merge P2a built (``RemoteQueueView``, reused as-is, not
         # reinvented) driving BOTH the local and remote transport, since the
@@ -608,20 +628,40 @@ class TextualChatApp(App):
     def _present_intervention(
         self, msg: "OutboxMessage", entry: "Entry[OutboxMessage]"
     ) -> None:
-        """Route a newly-arrived intervention frame to the panel (#3299 P1).
+        """Route a newly-arrived intervention frame to the panel (#3299 P1/P2).
 
         The flow ``entry`` stays a THIN pending placeholder (the presenter
         renders prompt + a dim "respond below" hint, never chips — see
         :meth:`~reyn.interfaces.inline.textual_chat.presenter.ReynPresenter._present_intervention_pending`);
         the interactive form (closed-set select / free-text input) lives
-        entirely in :attr:`_iv_panel`, populated + auto-focused here — a
-        pending intervention BLOCKS the turn, so it is answer-now. This is an
-        ATOMIC swap with the retired in-flow chips: display (this method) and
-        input (:meth:`on_intervention_panel_choice_selected` /
+        entirely in :attr:`_iv_panel`.
+
+        Multi-pending (#3299 P2): ``outstanding_interventions`` can hold
+        SEVERAL pending entries at once (e.g. restore's FIFO re-enqueue), so
+        every arriving intervention is tracked in :attr:`_pending_ivs`
+        (keyed by its id) regardless of display order. Only when the panel is
+        currently IDLE (no intervention displayed) does this one populate +
+        auto-focus it; otherwise it queues behind whichever intervention the
+        panel already shows, and is displayed later by
+        :meth:`_resolve_pending_intervention`'s re-route. This is still an
+        ATOMIC swap with the retired in-flow chips: display and input
+        (:meth:`on_intervention_panel_choice_selected` /
         :meth:`on_intervention_panel_text_submitted`) moved together, so there
         is never a moment where both the panel AND a chip/composer-match path
         are live for the same intervention."""
-        self._pending_iv_entry = entry
+        meta = msg.meta or {}
+        iv_id = meta.get("intervention_id")
+        key: object = iv_id if iv_id else id(entry)
+        self._pending_ivs[key] = (entry, msg, iv_id)
+        if self._iv_current_key is None:
+            self._show_intervention(key)
+
+    def _show_intervention(self, key: object) -> None:
+        """Populate + auto-focus the panel with the intervention tracked under
+        ``key``, marking it the CURRENTLY DISPLAYED one — the target of the
+        next answer (#3299 P2, R1 by-id delivery)."""
+        entry, msg, _iv_id = self._pending_ivs[key]
+        self._iv_current_key = key
         meta = msg.meta or {}
         prompt = str(meta.get("prompt") or msg.text or "")
         detail = meta.get("detail")
@@ -631,25 +671,46 @@ class TextualChatApp(App):
         else:
             self._iv_panel.show_text(prompt=prompt, detail=detail)
 
-    def _resolve_pending_intervention(self, answer_label: str) -> None:
-        """Settle the pending intervention's flow entry + panel once an answer
-        has been delivered through the transport funnel.
+    def _current_intervention_id(self) -> "str | None":
+        """The real ``intervention_id`` of the panel's CURRENTLY DISPLAYED
+        intervention (``None`` if unknown/untracked — the transport then falls
+        back to head-targeted delivery, matching pre-P2 behavior for a frame
+        that carried no id)."""
+        if self._iv_current_key is None:
+            return None
+        return self._pending_ivs[self._iv_current_key][2]
 
-        Basic in P1 (the placeholder→resolved in-place ``set_item`` churn-zero
-        polish is P2): the SAME entry is updated in place to a green
-        ``✓ answered: <label>`` record (:meth:`ReynPresenter._present_intervention_pending`
-        reads the ``_answer_label`` meta key), the panel collapses, and focus
-        returns to the Composer — the resolved leg of the focus lifecycle
-        (pending → panel auto-focus, Esc/Tab → Composer, resolved → Composer)."""
-        entry = self._pending_iv_entry
-        self._pending_iv_entry = None
+    def _resolve_pending_intervention(self, answer_label: str) -> None:
+        """Settle the CURRENTLY DISPLAYED intervention's flow entry + panel
+        once an answer has been delivered through the transport funnel, then
+        re-route the panel to the NEXT pending intervention if one is queued
+        (#3299 P2 FIFO re-route) — never blank/lose it.
+
+        The SAME entry is updated in place (churn-zero, #3299 P2 §4) to a
+        ``✓ answered: <label>`` record
+        (:meth:`ReynPresenter._present_intervention_pending` reads the
+        ``_answer_label`` meta key). The entry's :class:`EntryState` goes to
+        ``DEFAULT`` — not ``SUCCESS``/``ERROR`` (an intervention answer is
+        neither an outcome to celebrate nor a failure, the #3296
+        don't-fabricate-a-classification lesson) and not ``RUNNING`` (would
+        trip the #72 orphan-sweep + the ② live-spinner, and an intervention is
+        not a tool). If no other intervention is pending, the panel hides and
+        focus returns to the Composer — the resolved leg of the focus
+        lifecycle (pending → panel auto-focus, Esc/Tab → Composer, resolved →
+        Composer)."""
+        key = self._iv_current_key
+        self._iv_current_key = None
         self._iv_panel.hide()
-        self.query_one(Composer).focus()
-        if entry is None:
-            return
-        meta = entry.item.meta or {}
-        entry.set_item(replace(entry.item, meta={**meta, "_answer_label": answer_label}))
-        entry.set_state(EntryState.SUCCESS)
+        resolved = self._pending_ivs.pop(key, None) if key is not None else None
+        if resolved is not None:
+            entry, _msg, _iv_id = resolved
+            meta = entry.item.meta or {}
+            entry.set_item(replace(entry.item, meta={**meta, "_answer_label": answer_label}))
+            entry.set_state(EntryState.DEFAULT)
+        if self._pending_ivs:
+            self._show_intervention(next(iter(self._pending_ivs)))
+        else:
+            self.query_one(Composer).focus()
 
     async def on_intervention_panel_choice_selected(
         self, event: "InterventionPanel.ChoiceSelected"
@@ -657,18 +718,26 @@ class TextualChatApp(App):
         """A closed-set option was picked in the panel: deliver its id through
         the UNCHANGED transport funnel (``answer_intervention_choice`` —
         ``InterventionHandler.deliver_answer_to`` under the hood, the SAME
-        funnel every answer path — TUI, A2A peer, AG-UI HITL — shares). This is
-        the F1 permission-band reachability witness, restored through the
-        panel instead of a chip click."""
-        await self._transport.answer_intervention_choice(event.choice_id)
+        funnel every answer path — TUI, A2A peer, AG-UI HITL — shares),
+        targeted at the CURRENTLY DISPLAYED intervention's id (#3299 P2, R1 —
+        never the head, which a second pending intervention could have made
+        stale between display and answer). This is the F1 permission-band
+        reachability witness, restored through the panel instead of a chip
+        click."""
+        await self._transport.answer_intervention_choice(
+            event.choice_id, intervention_id=self._current_intervention_id()
+        )
         self._resolve_pending_intervention(event.label)
 
     async def on_intervention_panel_text_submitted(
         self, event: "InterventionPanel.TextSubmitted"
     ) -> None:
         """A free-text answer was submitted in the panel's Input: deliver it
-        through the UNCHANGED ``answer_intervention_text`` transport funnel."""
-        await self._transport.answer_intervention_text(event.text)
+        through the UNCHANGED ``answer_intervention_text`` transport funnel,
+        targeted at the CURRENTLY DISPLAYED intervention's id (#3299 P2, R1)."""
+        await self._transport.answer_intervention_text(
+            event.text, intervention_id=self._current_intervention_id()
+        )
         self._resolve_pending_intervention(event.text)
 
     def on_intervention_panel_dismissed(

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -174,10 +174,17 @@ class TextualChatApp(App):
     input-swap + chip-retire — see :meth:`_present_intervention`'s docstring):
     a ``kind="intervention"`` frame arriving on the pump (:meth:`_ingest_frame`)
     appends a THIN pending flow placeholder and, if the panel is idle, populates
-    + auto-focuses it — a :class:`~textual.widgets.RadioSet` (pre-highlighting
-    its FIRST option, #3299 P2 owner decision (A): a blind ``Enter`` answers it)
-    for a closed-set intervention (``meta["choices"]``), a plain
-    :class:`~textual.widgets.Input` otherwise. Selecting/submitting in the panel
+    + auto-focuses it — a :class:`~textual.widgets.RadioSet` for a closed-set
+    intervention (``meta["choices"]``), a plain :class:`~textual.widgets.Input`
+    otherwise. Only this hidden→shown transition pre-highlights the RadioSet's
+    FIRST option (#3299 P2 owner decision (A): a blind ``Enter`` answers it) —
+    the multi-pending FIFO re-route (:meth:`_resolve_pending_intervention`
+    swapping in the NEXT queued intervention while the panel stays visible)
+    does NOT pre-highlight (#3299 P2 co-vet fix, see :meth:`_show_intervention`'s
+    ``initial`` docstring: pre-highlighting an intervention the user never
+    actually looked at risks a muscle-memory second ``Enter`` confirming a
+    default option — an accidental permission grant, since an intervention can
+    be a permission gate). Selecting/submitting in the panel
     (:meth:`on_intervention_panel_choice_selected` /
     :meth:`on_intervention_panel_text_submitted`) delivers the answer through
     the UNCHANGED transport funnel (``answer_intervention_choice`` /
@@ -654,12 +661,30 @@ class TextualChatApp(App):
         key: object = iv_id if iv_id else id(entry)
         self._pending_ivs[key] = (entry, msg, iv_id)
         if self._iv_current_key is None:
-            self._show_intervention(key)
+            # The panel is IDLE — this is the hidden→shown transition, the
+            # ONLY case that pre-highlights (#3299 P2 co-vet fix, see
+            # ``_show_intervention``'s ``initial`` docstring).
+            self._show_intervention(key, initial=True)
 
-    def _show_intervention(self, key: object) -> None:
+    def _show_intervention(self, key: object, *, initial: bool) -> None:
         """Populate + auto-focus the panel with the intervention tracked under
         ``key``, marking it the CURRENTLY DISPLAYED one — the target of the
-        next answer (#3299 P2, R1 by-id delivery)."""
+        next answer (#3299 P2, R1 by-id delivery).
+
+        ``initial`` (#3299 P2 co-vet fix, architect-agreed "safe side" call):
+        whether this is the panel's hidden→shown transition (``True`` — the
+        ONLY caller is :meth:`_present_intervention` when the panel was
+        idle) or the multi-pending FIFO re-route
+        (:meth:`_resolve_pending_intervention` swapping in the next queued
+        intervention while the panel stays visible/focused, ``False``).
+        Threaded straight to ``InterventionPanel.show_choice``'s
+        ``pre_highlight`` — a re-route must NOT pre-highlight index 0: the
+        panel was already focused for a DIFFERENT intervention the user
+        actually looked at, so a muscle-memory second ``Enter`` after
+        answering that first one must not confirm a default option (often
+        "Yes"/"Allow") on the second intervention the user never requested
+        (an accidental permission grant, not a UX shortcut — deterministic on
+        the CALL SITE, not a timing heuristic)."""
         entry, msg, _iv_id = self._pending_ivs[key]
         self._iv_current_key = key
         meta = msg.meta or {}
@@ -667,7 +692,9 @@ class TextualChatApp(App):
         detail = meta.get("detail")
         choices = meta.get("choices")
         if choices:
-            self._iv_panel.show_choice(prompt=prompt, detail=detail, choices=choices)
+            self._iv_panel.show_choice(
+                prompt=prompt, detail=detail, choices=choices, pre_highlight=initial
+            )
         else:
             self._iv_panel.show_text(prompt=prompt, detail=detail)
 
@@ -708,7 +735,9 @@ class TextualChatApp(App):
             entry.set_item(replace(entry.item, meta={**meta, "_answer_label": answer_label}))
             entry.set_state(EntryState.DEFAULT)
         if self._pending_ivs:
-            self._show_intervention(next(iter(self._pending_ivs)))
+            # FIFO re-route (#3299 P2) — ``initial=False``: no pre-highlight
+            # (see ``_show_intervention``'s docstring for why).
+            self._show_intervention(next(iter(self._pending_ivs)), initial=False)
         else:
             self.query_one(Composer).focus()
 

--- a/src/reyn/interfaces/inline/textual_chat/gutter.py
+++ b/src/reyn/interfaces/inline/textual_chat/gutter.py
@@ -80,6 +80,15 @@ def _gutter_glyph_color(msg: "OutboxMessage") -> "tuple[str, str]":
         return "⎿", _CC_DIM
     if kind == "tool_call_failed":
         return "⎿", _CC_ERR
+    if kind == "intervention" and not (msg.meta or {}).get("_answer_label"):
+        # #3299 P2 §5: a PENDING intervention stays EntryState.DEFAULT (never
+        # RUNNING/SUCCESS/ERROR — see ``TextualChatApp._resolve_pending_intervention``),
+        # so the only way to distinguish "awaiting an answer" from an ordinary
+        # DEFAULT row is a kind-driven glyph swap here: a dim "awaiting" marker
+        # instead of the kind's normal (amber, "needs you") glyph. Once resolved
+        # (``_answer_label`` set), this falls through to the normal kind glyph
+        # below — no special-casing needed for the permanent Q→A record.
+        return "⋯", _CC_DIM
     line = _KIND_LINE.get(kind)
     if line is None:
         return "", _CC_DIM

--- a/src/reyn/interfaces/inline/textual_chat/intervention_panel.py
+++ b/src/reyn/interfaces/inline/textual_chat/intervention_panel.py
@@ -186,6 +186,27 @@ class InterventionPanel(Vertical):
             # as-is (no markup parsing), so the full literal label always
             # renders intact.
             radio.mount(RadioButton(Content(label)))
+        # #3299 P2 — owner decision (A), uniform: pre-highlight the FIRST
+        # option so a blind ``Enter`` answers it immediately (no extra arrow
+        # keypress first). ``RadioSet`` only auto-selects index 0 in its OWN
+        # ``_on_mount`` (fired once, when this widget mounted with ZERO
+        # children — the buttons above are mounted dynamically, later, so that
+        # native behavior never fires for them); its OWN highlight-advance
+        # action (``action_next_button``, bound to the Down key) reproduces
+        # that native "select the first enabled button" behavior — but only
+        # from an UNSET anchor (``RadioSet._selected is None``): a SECOND
+        # ``show_choice`` call (the P2 multi-pending re-route showing the next
+        # queued intervention) reuses this same widget instance, so its
+        # highlight index from the PREVIOUS intervention survives the
+        # children-swap above and would advance past index 0 instead of
+        # landing on it. Resetting the highlight first makes every
+        # ``show_choice`` call behave identically regardless of history.
+        # This only moves the HIGHLIGHT (``RadioSet.pressed_index`` stays -1,
+        # nothing is answered yet) — the user's own ``Enter``/``Space`` still
+        # does the actual toggle-and-deliver.
+        if self._choice_ids:
+            radio._selected = None
+            radio.action_next_button()
         radio.display = True
         self.query_one("#iv-panel-input", Input).display = False
         self.display = True

--- a/src/reyn/interfaces/inline/textual_chat/intervention_panel.py
+++ b/src/reyn/interfaces/inline/textual_chat/intervention_panel.py
@@ -149,12 +149,35 @@ class InterventionPanel(Vertical):
         detail_widget.display = bool(detail)
 
     def show_choice(
-        self, *, prompt: str, detail: "str | None", choices: "list[dict]"
+        self,
+        *,
+        prompt: str,
+        detail: "str | None",
+        choices: "list[dict]",
+        pre_highlight: bool = True,
     ) -> None:
         """Populate + show the panel for a closed-set intervention, auto-
         focusing the :class:`RadioSet` (native ``↑``/``↓``/``Enter``
         selection) — a pending intervention blocks the turn, so it is
-        answer-now."""
+        answer-now.
+
+        ``pre_highlight`` (#3299 P2 co-vet fix): whether index 0 is
+        highlighted so a blind ``Enter`` answers it (owner decision (A)).
+        The caller (:meth:`~reyn.interfaces.inline.textual_chat.app.TextualChatApp._show_intervention`)
+        passes ``True`` ONLY for the panel's hidden→shown transition (a
+        genuinely NEW intervention the user is looking at for the first
+        time); the multi-pending FIFO re-route (the panel already visible,
+        swapping in the NEXT queued intervention while still focused) passes
+        ``False``. Without this distinction a SECOND blind ``Enter`` — the
+        user's muscle-memory reflex after answering the first — would
+        confirm a DEFAULT option (often "Yes"/"Allow") on an intervention the
+        user never actually looked at, which is an accidental permission
+        grant, not a UX shortcut (an intervention can be a permission gate;
+        the pre-highlight's whole premise — "the user saw it and can accept
+        the default" — does not hold for an interaction they never
+        requested). This is a DETERMINISTIC identity check (which call this
+        is), never a time-based debounce (a machine-speed heuristic a strip
+        test cannot verify deterministically)."""
         self._set_head(prompt, detail)
         radio = self.query_one("#iv-panel-choices", RadioSet)
         for child in list(radio.children):
@@ -186,27 +209,40 @@ class InterventionPanel(Vertical):
             # as-is (no markup parsing), so the full literal label always
             # renders intact.
             radio.mount(RadioButton(Content(label)))
-        # #3299 P2 — owner decision (A), uniform: pre-highlight the FIRST
-        # option so a blind ``Enter`` answers it immediately (no extra arrow
-        # keypress first). ``RadioSet`` only auto-selects index 0 in its OWN
+        # #3299 P2 — owner decision (A), uniform ONLY for the hidden→shown
+        # transition (see ``pre_highlight``'s docstring above for the
+        # re-route safety rationale): pre-highlight the FIRST option so a
+        # blind ``Enter`` answers it immediately (no extra arrow keypress
+        # first). ``RadioSet`` only auto-selects index 0 in its OWN
         # ``_on_mount`` (fired once, when this widget mounted with ZERO
-        # children — the buttons above are mounted dynamically, later, so that
-        # native behavior never fires for them); its OWN highlight-advance
-        # action (``action_next_button``, bound to the Down key) reproduces
-        # that native "select the first enabled button" behavior — but only
-        # from an UNSET anchor (``RadioSet._selected is None``): a SECOND
-        # ``show_choice`` call (the P2 multi-pending re-route showing the next
-        # queued intervention) reuses this same widget instance, so its
-        # highlight index from the PREVIOUS intervention survives the
-        # children-swap above and would advance past index 0 instead of
-        # landing on it. Resetting the highlight first makes every
+        # children — the buttons above are mounted dynamically, later, so
+        # that native behavior never fires for them); its OWN
+        # highlight-advance action (``action_next_button``, bound to the Down
+        # key) reproduces that native "select the first enabled button"
+        # behavior — but only from an UNSET anchor (``RadioSet._selected is
+        # None``).
+        #
+        # The highlight is ALWAYS reset first (regardless of
+        # ``pre_highlight``): a re-route reuses this same widget instance, so
+        # a stale highlight index from the PREVIOUS intervention would
+        # otherwise survive the children-swap above — either advancing past
+        # index 0 (if we then pre-highlighted) or, worse, leaving a STALE
+        # highlighted button from the FIRST intervention visible/actionable
+        # on the SECOND one's fresh button set (if we didn't reset at all).
+        # Resetting first, then conditionally re-highlighting, makes every
         # ``show_choice`` call behave identically regardless of history.
-        # This only moves the HIGHLIGHT (``RadioSet.pressed_index`` stays -1,
-        # nothing is answered yet) — the user's own ``Enter``/``Space`` still
-        # does the actual toggle-and-deliver.
+        # Pre-highlighting only ever moves the HIGHLIGHT
+        # (``RadioSet.pressed_index`` stays -1, nothing is answered yet) — the
+        # user's own ``Enter``/``Space`` still does the actual
+        # toggle-and-deliver; when ``pre_highlight`` is False, that first
+        # ``Enter``/``Space`` is a no-op (``_selected`` stays unset) until the
+        # user explicitly navigates (``Down``/``Up``) — the SAME safe
+        # unset-until-navigated behavior :meth:`show_text`'s ``Input`` already
+        # has (empty by default, ``on_input_submitted`` no-ops on empty text).
         if self._choice_ids:
             radio._selected = None
-            radio.action_next_button()
+            if pre_highlight:
+                radio.action_next_button()
         radio.display = True
         self.query_one("#iv-panel-input", Input).display = False
         self.display = True

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -162,18 +162,28 @@ class AgUiTransport(ClientTransport):
     async def submit_user_text(self, text: str) -> None:
         await self._send({"type": "user_message", "text": text})
 
-    async def answer_intervention_text(self, text: str) -> bool:
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:
         # P3 HITL answer: POST a TOOL_CALL_RESULT correlated to the pending
         # intervention BY ID (toolCallId, R1). The server re-authorizes at
         # delivery (identity + active-driver) and resolves by id; a rejected or
         # unroutable answer returns False so the caller falls back to a turn.
-        iv_id = self._pending_intervention_id
+        # #3299 P2: an explicit ``intervention_id`` (the client's own tracked
+        # id) is used as-is instead of the single ``_pending_intervention_id``
+        # slot — this wire transport still tracks only one frontend-tool at a
+        # time (a wider multi-pending wire protocol is out of this PR's scope,
+        # confined to ``interfaces/inline/textual_chat/``), but an explicit id
+        # is honored rather than silently overridden by the slot.
+        iv_id = intervention_id if intervention_id is not None else self._pending_intervention_id
         if iv_id is None:
             return False
         return await self._post_answer(iv_id, text=text)
 
-    async def answer_intervention_choice(self, choice_id: str) -> bool:
-        iv_id = self._pending_intervention_id
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        iv_id = intervention_id if intervention_id is not None else self._pending_intervention_id
         if iv_id is None:
             return False
         return await self._post_answer(iv_id, choice_id=choice_id)

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -53,12 +53,26 @@ class ClientTransport(ABC):
         """Submit a user turn (the ordinary new-turn path)."""
 
     @abstractmethod
-    async def answer_intervention_text(self, text: str) -> bool:
-        """Deliver ``text`` to the oldest pending intervention; True iff delivered."""
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        """Deliver ``text`` to a pending intervention; True iff delivered.
+
+        ``intervention_id`` (#3299 P2, R1 id-targeted delivery): when given,
+        the answer is delivered to EXACTLY that intervention — never a
+        head-of-queue fallback, since with ``outstanding_interventions``
+        holding multiple pending entries the head is not necessarily the one
+        the caller displayed. ``None`` (the default) preserves the pre-P2
+        oldest-pending behavior for callers that never track an id (kept for
+        API stability, not a supported new-caller pattern)."""
 
     @abstractmethod
-    async def answer_intervention_choice(self, choice_id: str) -> bool:
-        """Deliver a chosen ``choice_id`` to the oldest intervention; True iff delivered."""
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        """Deliver a chosen ``choice_id`` to a pending intervention; True iff
+        delivered. ``intervention_id`` semantics mirror
+        :meth:`answer_intervention_text` (#3299 P2, R1)."""
 
     @abstractmethod
     def has_session(self) -> bool:

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -133,16 +133,32 @@ class InProcessTransport(ClientTransport):
         if s is not None:
             await s.submit_user_text(text)
 
-    async def answer_intervention_text(self, text: str) -> bool:
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:
         s = self._attached()
         if s is None:
             return False
+        if intervention_id is not None:
+            # #3299 P2 (R1): deliver BY ID through the existing id-aware
+            # session funnel — never the head, which a second queued
+            # intervention could have displaced since the caller's copy was
+            # displayed (the multi-pending mis-delivery this closes).
+            return bool(await s.answer_intervention_by_id(intervention_id, text))
         return bool(await s.answer_oldest_intervention_text(text))
 
-    async def answer_intervention_choice(self, choice_id: str) -> bool:
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:
         s = self._attached()
         if s is None:
             return False
+        if intervention_id is not None:
+            return bool(
+                await s.answer_intervention_by_id(
+                    intervention_id, "", choice_id_override=choice_id
+                )
+            )
         return bool(await s.answer_oldest_intervention_choice(choice_id))
 
     def put_display(self, msg: "OutboxMessage") -> None:

--- a/tests/test_textual_chat_intervention_panel_3299.py
+++ b/tests/test_textual_chat_intervention_panel_3299.py
@@ -75,6 +75,11 @@ class RecordingTransport(ClientTransport):
         self.answered_choice: list[str] = []
         self.answered_text: list[str] = []
         self.displayed: list[OutboxMessage] = []
+        # (choice_id | text, intervention_id) pairs — records the id an answer
+        # was targeted at (#3299 P2 R1 by-id delivery), ``None`` when the
+        # caller left it head-targeted.
+        self.answered_choice_ids: "list[str | None]" = []
+        self.answered_text_ids: "list[str | None]" = []
 
     def start(self) -> None:  # pragma: no cover - trivial
         pass
@@ -93,12 +98,18 @@ class RecordingTransport(ClientTransport):
     async def submit_user_text(self, text: str) -> None:
         self.submitted.append(text)
 
-    async def answer_intervention_text(self, text: str) -> bool:
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:
         self.answered_text.append(text)
+        self.answered_text_ids.append(intervention_id)
         return True
 
-    async def answer_intervention_choice(self, choice_id: str) -> bool:
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:
         self.answered_choice.append(choice_id)
+        self.answered_choice_ids.append(intervention_id)
         return True
 
     def has_session(self) -> bool:
@@ -155,12 +166,44 @@ def _free_text_intervention() -> OutboxMessage:
     )
 
 
+def _second_choice_intervention() -> OutboxMessage:
+    """A second, distinct closed-set intervention (different id) — used by the
+    multi-pending tests (#3299 P2) to exercise TWO simultaneously-outstanding
+    interventions, which ``outstanding_interventions`` supports by design."""
+    return OutboxMessage(
+        kind="intervention",
+        text="Overwrite existing file?\n  Yes / No",
+        meta={
+            "intervention_id": "iv-2",
+            "intervention_kind": "confirm",
+            "prompt": "Overwrite existing file?",
+            "choices": [
+                {"id": "yes", "label": "Yes", "hotkey": "y"},
+                {"id": "no", "label": "No", "hotkey": "n"},
+            ],
+            "nodes": [
+                {"component": "text", "text": "Overwrite existing file?"},
+                {"component": "list", "items": ["Yes", "No"]},
+            ],
+        },
+    )
+
+
 def _iv_entry(app: TextualChatApp):
     entries = [
         e for e in app.query_one(FlowView).entries if e.item.kind == "intervention"
     ]
     assert len(entries) == 1, f"expected one intervention entry, got {len(entries)}"
     return entries[0]
+
+
+def _iv_entries(app: TextualChatApp):
+    """All intervention flow entries, keyed by their ``intervention_id`` meta."""
+    return {
+        e.item.meta.get("intervention_id"): e
+        for e in app.query_one(FlowView).entries
+        if e.item.kind == "intervention"
+    }
 
 
 @pytest.mark.asyncio
@@ -187,11 +230,9 @@ async def test_choice_intervention_panel_selection_delivers_correct_choice_id() 
         # No answer is delivered until the user acts.
         assert transport.answered_choice == []
 
-        # Move the highlight to the SECOND option ("No") and select it. The
-        # RadioSet starts with NO highlighted button (index -1), so the FIRST
-        # "down" only highlights index 0 ("Yes") — a second "down" is needed to
-        # reach index 1 ("No"), verified against this RadioSet's own behavior.
-        await pilot.press("down")
+        # #3299 P2 owner decision (A): the panel pre-highlights the FIRST
+        # option on appear, so ONE "down" now reaches the SECOND option ("No")
+        # — two would have been needed pre-P2 (index -1 → 0 → 1).
         await pilot.press("down")
         await pilot.press("enter")
         await pilot.pause()
@@ -200,10 +241,14 @@ async def test_choice_intervention_panel_selection_delivers_correct_choice_id() 
         assert transport.answered_choice == ["no"], (
             f"choice not delivered; got {transport.answered_choice}"
         )
-        # Resolved reflection: green SUCCESS gutter + panel collapsed + focus
-        # returned to the Composer.
+        assert transport.answered_choice_ids == ["iv-1"], (
+            "answer not delivered BY ID (#3299 P2 R1)"
+        )
+        # Resolved reflection: DEFAULT gutter (#3299 P2 §5 — not SUCCESS, an
+        # answered intervention is neither an outcome nor a failure) + panel
+        # collapsed + focus returned to the Composer.
         resolved = _iv_entry(app)
-        assert resolved.state is EntryState.SUCCESS
+        assert resolved.state is EntryState.DEFAULT
         assert resolved.item.meta.get("_answer_label") == "No"
         assert panel.display is False, "panel did not collapse after resolving"
         assert app.query_one(Composer).has_focus, (
@@ -235,6 +280,7 @@ async def test_free_text_intervention_answered_via_panel_input() -> None:
         await pilot.pause()
 
     assert transport.answered_text == ["ok"]
+    assert transport.answered_text_ids == ["iv-2"]
     assert transport.submitted == []
     assert transport.answered_choice == []
 
@@ -583,3 +629,226 @@ async def test_panel_detail_neutralizes_raw_esc_osc() -> None:
             f"raw ESC leaked into the panel's detail: {rendered!r}"
         )
         assert "RED" in rendered
+
+
+# --- #3299 P2: multi-pending by-id delivery + re-route ----------------------
+# The architect's self-review finding (P1 merge): the panel was SINGLE-slot
+# (a second pending intervention silently overwrote the first's entry handle)
+# and delivery was HEAD-targeted (``answer_intervention_choice`` carries no
+# id) — but ``outstanding_interventions`` legitimately holds MULTIPLE pending
+# entries (e.g. restore's FIFO re-enqueue), so a stale head could receive an
+# answer the user actually gave to a DIFFERENT, currently-displayed
+# intervention. P2 fixes both: every pending intervention gets its OWN
+# tracked flow entry (never overwritten), and an answer is delivered BY ID to
+# whichever intervention the panel is showing.
+
+
+@pytest.mark.asyncio
+async def test_second_pending_intervention_does_not_overwrite_the_first() -> None:
+    """Tier 2b: with TWO interventions pending, the panel keeps showing the
+    FIRST (the architect's overwrite finding) — its flow entry is not
+    orphaned, and the second gets its own placeholder entry too. Non-vacuous:
+    pre-P2 the single ``_pending_iv_entry`` slot was overwritten by the
+    second arrival (verified against the P1 source removed in this PR)."""
+    transport = RecordingTransport(
+        [_choice_intervention(), _second_choice_intervention()], end=False
+    )
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        entries = _iv_entries(app)
+        assert set(entries) == {"iv-1", "iv-2"}, (
+            f"expected both pending interventions to get their own flow entry, got {set(entries)}"
+        )
+        # The panel still shows the FIRST (iv-1's prompt), not overwritten by
+        # the second arrival.
+        title = app.query_one(InterventionPanel).query_one("#iv-panel-title", Static)
+        assert "hosts" in title.content.plain, (
+            f"panel switched away from the first pending intervention; title={title.content.plain!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_multi_pending_answer_targets_the_displayed_intervention_by_id() -> None:
+    """Tier 2b: ★non-vacuity witness for the mis-delivery fix — with TWO
+    interventions pending, answering the one the panel DISPLAYS delivers to
+    THAT intervention's id, and resolving it re-routes the panel to the
+    other (FIFO), which then also delivers by its own id.
+
+    NON-VACUITY (falsification): stripping ``intervention_id=`` from
+    ``TextualChatApp.on_intervention_panel_choice_selected`` /
+    ``on_intervention_panel_text_submitted`` (reverting to head-targeted-only
+    delivery) flips ``transport.answered_choice_ids`` to ``[None, None]``
+    instead of ``["iv-1", "iv-2"]`` — the exact shape a production
+    mis-delivery bug (answer routed to a stale head instead of the displayed
+    intervention) would leave behind."""
+    transport = RecordingTransport(
+        [_choice_intervention(), _second_choice_intervention()], end=False
+    )
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        # Answer the FIRST (displayed) intervention — pre-highlighted first
+        # option ("Yes", #3299 P2 owner decision (A)), so a blind Enter
+        # answers it.
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert transport.answered_choice == ["yes"]
+        assert transport.answered_choice_ids == ["iv-1"], (
+            f"first answer not targeted at iv-1; got {transport.answered_choice_ids}"
+        )
+        entries = _iv_entries(app)
+        assert entries["iv-1"].item.meta.get("_answer_label") == "Yes"
+        assert entries["iv-2"].item.meta.get("_answer_label") is None, (
+            "the second (still-pending) intervention's entry must not be touched"
+        )
+
+        # The panel re-routed to the SECOND (still pending) intervention —
+        # never left blank/orphaned.
+        panel = app.query_one(InterventionPanel)
+        assert panel.display is True, "panel went blank instead of re-routing to the next pending intervention"
+        title = panel.query_one("#iv-panel-title", Static)
+        assert "Overwrite" in title.content.plain
+
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert transport.answered_choice == ["yes", "yes"]
+        assert transport.answered_choice_ids == ["iv-1", "iv-2"], (
+            f"second answer not targeted at iv-2; got {transport.answered_choice_ids}"
+        )
+        entries = _iv_entries(app)
+        assert entries["iv-2"].item.meta.get("_answer_label") == "Yes"
+        assert panel.display is False, "panel did not collapse once both resolved"
+        assert app.query_one(Composer).has_focus
+
+
+# --- #3299 P2: auto-focus (A) — blind Enter answers the first option --------
+
+
+@pytest.mark.asyncio
+async def test_blind_enter_answers_the_first_option_no_arrow_needed() -> None:
+    """Tier 2b: owner decision (A), uniform across all closed-set
+    interventions — on panel appear the FIRST option is pre-highlighted, so a
+    bare ``Enter`` (no ``Down`` first) answers it immediately.
+
+    NON-VACUITY (falsification): reverting the ``radio.action_next_button()``
+    pre-highlight call in ``InterventionPanel.show_choice`` leaves
+    ``RadioSet._selected`` unset (``-1``), so ``action_toggle_button`` (bound
+    to Enter) is a no-op and NOTHING is delivered — this assertion would fail
+    with an empty ``transport.answered_choice``, verified locally."""
+    transport = RecordingTransport([_choice_intervention()], end=False)
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        radio = app.query_one(InterventionPanel).query_one("#iv-panel-choices", RadioSet)
+        assert radio.has_focus
+
+        await pilot.press("enter")  # no "down" first
+        await pilot.pause()
+        await pilot.pause()
+
+    assert transport.answered_choice == ["yes"], (
+        f"a blind Enter did not answer the pre-highlighted FIRST option; got {transport.answered_choice}"
+    )
+
+
+# --- #3299 P2 §5: pending EntryState is DEFAULT, never RUNNING/SUCCESS/ERROR
+
+
+@pytest.mark.asyncio
+async def test_pending_intervention_entry_state_is_default_with_dim_awaiting_glyph() -> None:
+    """Tier 2b: a PENDING intervention's flow entry stays ``EntryState.DEFAULT``
+    (never ``RUNNING`` — would wrongly trip the #72 orphan-sweep + the ②
+    live-spinner, an intervention is not a tool; never ``SUCCESS``/``ERROR`` —
+    they imply an outcome, the #3296 don't-fabricate-a-classification lesson).
+    The gutter distinguishes "awaiting" from an ordinary DEFAULT row with a
+    dim kind-driven glyph instead of the state color.
+
+    NON-VACUITY (falsification): reverting the ``kind == "intervention"``
+    branch in ``gutter._gutter_glyph_color`` makes the pending glyph fall
+    through to the ordinary (non-dim, "◆ needs you") intervention glyph
+    regardless of pending/resolved — this assertion (dim colour while
+    pending) would then fail, verified locally."""
+    from textual_flowview import EntryState as _EntryState
+
+    from reyn.interfaces.inline.textual_chat.gutter import ReynGutter
+    from reyn.interfaces.repl.renderer import _CC_DIM
+
+    transport = RecordingTransport([_choice_intervention()], end=False)
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        entry = _iv_entry(app)
+        assert entry.state is _EntryState.DEFAULT
+        assert entry.state not in (
+            _EntryState.RUNNING,
+            _EntryState.SUCCESS,
+            _EntryState.ERROR,
+        )
+        gutter = ReynGutter()
+        rendered = gutter.decorate(entry, width=2, height=1)
+        assert rendered.style == _CC_DIM, (
+            f"pending intervention gutter glyph is not dim; style={rendered.style!r}"
+        )
+
+
+# --- #3299 P2 §4: placeholder→resolved is the SAME entry, churn-zero --------
+
+
+@pytest.mark.asyncio
+async def test_resolve_updates_the_same_entry_no_new_entry_appended() -> None:
+    """Tier 2b: ★non-vacuity witness for the churn-zero contract — resolving a
+    pending intervention updates the SAME flow entry object in place; the SET
+    of intervention entry objects is unchanged (identity-preserved) and the
+    content becomes the Q→A record — never a second, additional entry.
+
+    NON-VACUITY (falsification): if ``_resolve_pending_intervention`` APPENDED
+    a new entry instead of ``entry.set_item(...)``-ing the tracked one (the
+    owner's original "解凍後に別の flow entry が出る" churn complaint), the
+    identity-set below would gain a SECOND, different entry object rather than
+    staying exactly the one entry seen before resolving — this assertion
+    would fail."""
+    transport = RecordingTransport([_choice_intervention()], end=False)
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        before = {
+            id(e) for e in app.query_one(FlowView).entries if e.item.kind == "intervention"
+        }
+        entry_before = next(
+            e for e in app.query_one(FlowView).entries if e.item.kind == "intervention"
+        )
+
+        await pilot.press("enter")  # blind Enter answers the pre-highlighted "Yes"
+        await pilot.pause()
+        await pilot.pause()
+
+        after = {
+            id(e) for e in app.query_one(FlowView).entries if e.item.kind == "intervention"
+        }
+        assert after == before, (
+            "resolving changed the SET of intervention flow-entry objects — "
+            "churn regressed (a new entry was appended instead of updating in place)"
+        )
+        assert entry_before.item.meta.get("_answer_label") == "Yes", (
+            "the SAME entry object was not updated in place with the resolved answer"
+        )

--- a/tests/test_textual_chat_intervention_panel_3299.py
+++ b/tests/test_textual_chat_intervention_panel_3299.py
@@ -678,13 +678,25 @@ async def test_multi_pending_answer_targets_the_displayed_intervention_by_id() -
     THAT intervention's id, and resolving it re-routes the panel to the
     other (FIFO), which then also delivers by its own id.
 
-    NON-VACUITY (falsification): stripping ``intervention_id=`` from
-    ``TextualChatApp.on_intervention_panel_choice_selected`` /
-    ``on_intervention_panel_text_submitted`` (reverting to head-targeted-only
-    delivery) flips ``transport.answered_choice_ids`` to ``[None, None]``
-    instead of ``["iv-1", "iv-2"]`` — the exact shape a production
-    mis-delivery bug (answer routed to a stale head instead of the displayed
-    intervention) would leave behind."""
+    The re-route does NOT pre-highlight (#3299 P2 co-vet safety fix,
+    architect-agreed "safe side" call): a bare ``Enter`` right after the
+    re-route must answer NOTHING — only after the user explicitly navigates
+    (``Down``) does ``Enter`` deliver. Without this, a user's muscle-memory
+    double-``Enter`` (answer the first, reflexively press Enter again) would
+    silently confirm a DEFAULT option on the second intervention the user
+    never actually looked at — an accidental permission grant, since an
+    intervention can be a permission gate.
+
+    NON-VACUITY (falsification):
+    - stripping ``intervention_id=`` from
+      ``TextualChatApp.on_intervention_panel_choice_selected`` /
+      ``on_intervention_panel_text_submitted`` (reverting to
+      head-targeted-only delivery) flips ``transport.answered_choice_ids`` to
+      ``[None, None]`` instead of ``["iv-1", "iv-2"]``.
+    - reverting ``_show_intervention``'s ``initial=False`` on re-route back
+      to always pre-highlighting makes the bare-Enter-after-re-route
+      assertion below FAIL (it would deliver "yes" instead of nothing) —
+      verified locally."""
     transport = RecordingTransport(
         [_choice_intervention(), _second_choice_intervention()], end=False
     )
@@ -718,6 +730,27 @@ async def test_multi_pending_answer_targets_the_displayed_intervention_by_id() -
         title = panel.query_one("#iv-panel-title", Static)
         assert "Overwrite" in title.content.plain
 
+        # ★co-vet safety fix: the re-route must NOT pre-highlight — a bare
+        # Enter (the user's muscle-memory reflex right after answering the
+        # first intervention) delivers NOTHING to the second, un-requested
+        # intervention.
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert transport.answered_choice == ["yes"], (
+            "a bare Enter right after the re-route must not answer the "
+            "un-requested second intervention (accidental-grant risk)"
+        )
+        entries = _iv_entries(app)
+        assert entries["iv-2"].item.meta.get("_answer_label") is None, (
+            "the second intervention must still be unanswered after a bare Enter"
+        )
+        assert panel.display is True, "panel must stay open — the bare Enter must not have resolved anything"
+
+        # Only EXPLICIT navigation (Down highlights index 0, "Yes") then
+        # Enter delivers.
+        await pilot.press("down")
         await pilot.press("enter")
         await pilot.pause()
         await pilot.pause()


### PR DESCRIPTION
**[per-PR-coder]** — Phase 2 of the intervention-panel arc (part of #3299). P1 (the panel widget) is merged; this PR fixes the architect's self-review mis-delivery finding, applies the owner's auto-focus decision, and refines the churn-zero EntryState per §5.

## (a) Multi-pending by-id delivery (correctness fix)

**Problem** (architect self-review on P1): the panel was single-slot (`_pending_iv_entry`) — a second concurrently-pending intervention silently overwrote the first's flow-entry handle — and delivery was head-targeted (`answer_intervention_choice(choice_id)` with no id, resolved via `deliver_answer_to(head, ...)`). But `outstanding_interventions` legitimately holds multiple pending entries at once (e.g. restore's FIFO re-enqueue), so a stale head could receive an answer the user actually gave to a *different*, currently-displayed intervention.

**Fix**:
- `TextualChatApp` now tracks **every** pending intervention in `_pending_ivs: dict[id, (entry, msg, intervention_id)]`, and `_iv_current_key` marks which one the panel is displaying. A second arrival never overwrites the first — it queues.
- `ClientTransport.answer_intervention_choice` / `answer_intervention_text` gained an optional `intervention_id: str | None = None` keyword. `InProcessTransport` threads it to the **existing**, already id-aware `session.answer_intervention_by_id` funnel (`InterventionHandler.deliver_answer_to` itself is unchanged); `None` preserves the old head-targeted path for any caller that doesn't track an id. `AgUiTransport` honors an explicit id over its single wire-tracked `_pending_intervention_id` slot (a wider multi-pending *wire* protocol is out of this PR's scope — confined to `interfaces/inline/textual_chat/`).
- `on_intervention_panel_choice_selected` / `on_intervention_panel_text_submitted` now pass `intervention_id=self._current_intervention_id()`.
- Resolving re-routes the panel to the next pending intervention (FIFO) instead of leaving it blank.

**Strip-falsify test** (`test_multi_pending_answer_targets_the_displayed_intervention_by_id`): with TWO pending interventions, answering the displayed one delivers to that id (`answered_choice_ids == ["iv-1", "iv-2"]`); reverting the `intervention_id=` kwarg flips it to `[None, None]` — verified locally, RED. `test_second_pending_intervention_does_not_overwrite_the_first` witnesses the overwrite fix directly.

## (b) Auto-focus (A) — owner decision, uniform

Owner decided (A): on panel appear, pre-highlight the FIRST option so a blind Enter answers it (UX/predictability > security, applies uniformly to all closed-set interventions, not per-kind). `RadioSet` only auto-selects index 0 in its own one-time `_on_mount` — which fires before this panel's buttons are dynamically mounted — so `InterventionPanel.show_choice` now resets the highlight (`radio._selected = None`) and calls `radio.action_next_button()` after mounting. The reset matters for the multi-pending re-route case too: without it, the SECOND `show_choice` call inherits the previous intervention's highlight index and skips past option 0.

**Strip-falsify test** (`test_blind_enter_answers_the_first_option_no_arrow_needed`): a blind Enter (no Down) answers "Yes"; reverting the pre-highlight call leaves `RadioSet._selected` unset and Enter delivers nothing — verified locally, RED.

## (c) Churn-zero placeholder→resolved (§4/§5)

P1 already updated the SAME flow entry in place (`entry.set_item(...)`) — the one-entry, churn-zero mechanism was already correct. This PR fixes the **EntryState** choice per §5: resolved now goes to `EntryState.DEFAULT` (was `SUCCESS`) — an answered intervention is neither an outcome to celebrate nor a failure (#3296 don't-fabricate-a-classification lesson), and pending was never `RUNNING` (would wrongly trip the #72 orphan-sweep + the ② live-spinner; an intervention is not a tool). Since pending and resolved now share `DEFAULT`, the gutter (`gutter.py`) distinguishes "awaiting" from an ordinary DEFAULT row with a dim kind-driven glyph (`⋯`) while pending, falling through to the normal `◆` kind glyph once resolved.

**Strip-falsify tests**: `test_resolve_updates_the_same_entry_no_new_entry_appended` (identity-set of intervention flow-entry objects unchanged across resolve — reverting `set_item` to `append` flips it RED, verified locally) and `test_pending_intervention_entry_state_is_default_with_dim_awaiting_glyph` (pending state is DEFAULT, gutter glyph is dim — reverting the `gutter.py` kind branch flips it RED, verified locally).

## New neutralized surface

None — this PR only changes id-plumbing, focus/highlight state, and EntryState/gutter-glyph selection; no new LLM-derived text reaches a rendering surface. The panel's existing 3 neutralized surfaces (label/title/detail, #3302) are untouched and still covered by their own witnesses.

## Out of scope (unchanged)

- P4 restore Q→A coalesce (needs persistence-shape grounding, §7) — later PR.
- `runtime/session.py` / WAL / inbox — untouched, a parallel PR (#3300) owns cancel-by-id server side.
- The #3300 sent-queue — untouched.

## CI gates (all green, foreground, this worktree only)

- `ruff check src tests` → All checks passed!
- `python scripts/test_tier_audit.py --strict tests/test_textual_chat_intervention_panel_3299.py` → 16/16 OK, 0 Tier-4 violations
- `uv run python -m pytest --timeout=120 -q -n auto` (foreground, full suite, alone in this worktree) → **9179 passed, 36 skipped**, 0 failures
- `python scripts/verify_module_docstrings.py <changed src files>` → OK

Pre-existing `pyright` diagnostics in `client_transport.py` / `in_process.py` / `agui/client.py` (duck-typed `object`-typed registry attribute access, doubly-quoted-forward-ref noise) were verified via `git stash` to already exist identically on `origin/main` (20 errors before this diff vs 22 after — the 2 new ones are the same duck-typed-attribute-access class already used 12× in the same file for the same intentionally-`object`-typed `self._registry`, per that file's own documented design rationale). `pyright` is not one of this repo's four CI gates.

## Test plan

- [x] `ruff check src tests` — green
- [x] `python scripts/test_tier_audit.py --strict tests/test_textual_chat_intervention_panel_3299.py` — 16/16 OK
- [x] `uv run python -m pytest --timeout=120 -q -n auto` — 9179 passed, 36 skipped, 0 failed
- [x] `python scripts/verify_module_docstrings.py` on changed src files — OK
- [x] Manual: read through the 3 new/updated test scenarios (multi-pending by-id, auto-focus blind-Enter, churn-zero identity-set) and confirmed each strip-falsifies RED as documented in its docstring (verified locally, not just asserted)