### PR TITLE
fix(repl): stop plain --cui from double-printing the user's own line

### DIFF
--- a/docs/reference/runtime/agui-transport.ja.md
+++ b/docs/reference/runtime/agui-transport.ja.md
@@ -410,42 +410,61 @@ PromptSession ループ(`--cui` / `chat.render_mode: plain` / non-TTY、
 broadcast の `user_submitted` event で再度描画すると、LLM round-trip を伴うすべての
 ターンで自分の行が二重に表示されてしまっていた(#3287。`/quit` は
 `submit_user_text` に到達しないため二重化しない——バグ報告が指摘した非対称性その
-もの)。修正は「デフォルトで抑制する」ではなく「所有権をはっきりさせる」こと:
-`route_input_line` は自身の `transport.submit_user_text` 呼び出しが**返す**
-`msg_id`(`user_submitted` の `msg_id` フィールドが運ぶのと同じ correlation id、
-#3300 P2a)を小さな set(`own_submissions`、クライアントの input/output ループの
-ペアごとに保持し、他クライアントとは共有しない)に記録し、`run_output_loop` は
-`user_submitted` event の `msg_id` がこの set 内のエントリと一致したときだけ
-再描画をスキップする。他のすべてのアタッチ済みクライアントのターン(および
+もの)。修正は「デフォルトで抑制する」ではなく「所有権をはっきりさせる」こと、
+そして transport の形ごとに**異なる 2 つの correlation 機構**を使う——どちらも
+テキストではない:
+
+- **ローカル(`InProcessTransport`)**: `route_input_line` は自身の
+  `transport.submit_user_text` 呼び出しが**返す** `msg_id`(`user_submitted` の
+  `msg_id` フィールドが運ぶのと同じ correlation id、#3300 P2a)を小さな set
+  (`own_submissions`、クライアントの input/output ループのペアごとに保持し、
+  他クライアントとは共有しない)に記録し、`run_output_loop` は `user_submitted`
+  event の `msg_id` がこの set 内のエントリと一致したときだけ再描画をスキップ
+  する。`ClientTransport.submit_user_text` はそのため割り当てられた `msg_id`
+  を返す(以前は `None` だった)——`InProcessTransport` は
+  `Session.submit_user_text` 自身の戻り値をそのまま返す(同一タスク内なので
+  race フリー: chat-event の emit から呼び出し元へ id が届くまでの間に何も
+  yield しない)。
+- **リモート(`AgUiTransport`)**: 代わりに broadcast event の
+  `meta.auth_connection_id` を、クライアント自身の `connection_id` と比較する
+  (`remote_client.py` が起動時、submit よりも**前に** `uuid.uuid4()` で生成し、
+  すべての POST に載せる id。AG-UI エンドポイントの `user_message` ハンドラは
+  既にすべての submit にこの id を attribution として付与している——#3300 が
+  マルチクライアント表示のために用意した既存の配線、`endpoint.py` →
+  `session.py` の `meta` → broadcast event、という wire 形状は変わっていない)。
+  この id は事前に分かっており、**他のどのチャンネルにも依存しない**——詳細は
+  下記「race を狭めるのではなく閉じる」を参照。
+
+いずれの機構でも、他のすべてのアタッチ済みクライアントのターン(および
 non-interactive で何も echo していない場合の自分自身のターン)は今までどおり
 描画される。2 クライアント以上がアタッチしていても、互いに相手のすべてのターンと
 すべての回答は今までどおり見える——agent からの返信だけではない。変わるのは、
 各クライアントが自分自身の行を二重に描画しなくなる点だけである。
 
-相関は**テキストではなく id**で行う——初期版はテキストで一致させており、レビューで
-指摘された(#3309 の co-vet finding)。2 つのアタッチ済みクライアントが同一の短い
-文字列(例えば両方とも "yes" と回答する)を送信すると、テキスト一致では
-クロスマッチしてしまう——他方のクライアントのターンを誤って抑制し、その一方で
-自分自身のターンが後で二重に描画される、という形でバグが別の入口から再発する。
-`msg_id` は #3300 P2a が**まさに correlation id として**追加したもの(コンテンツから
-form-sniff したものでは決してない)なので、テキストが同一でも 2 つの異なる
-submission が衝突することはない。
+相関は**テキストではなく identity**で行う——初期版はテキストで一致させており、
+レビューで指摘された(#3309 の co-vet finding F1)。2 つのアタッチ済みクライアント
+が同一の短い文字列(例えば両方とも "yes" と回答する)を送信すると、テキスト
+一致ではクロスマッチしてしまう——他方のクライアントのターンを誤って抑制し、
+その一方で自分自身のターンが後で二重に描画される、という形でバグが別の入口から
+再発する。`msg_id`(#3300 P2a)と `auth_connection_id`(#3300、マルチクライアント
+attribution)はどちらも**まさに identity フィールドとして**追加されたもの
+(コンテンツから form-sniff したものでは決してない)なので、テキストが同一でも
+2 つの異なる submission が衝突することはない。
 
-`ClientTransport.submit_user_text` はそのため割り当てられた `msg_id` を返す
-(以前は `None` だった)——`InProcessTransport` は `Session.submit_user_text` 自身の
-戻り値をそのまま返す(同一タスク内なので race フリー: chat-event の emit から
-呼び出し元へ id が届くまでの間に何も yield しない)。AG-UI エンドポイントの
-`user_message` ハンドラは POST の JSON レスポンス body に `msg_id` を echo し、
-`AgUiTransport.submit_user_text` はそこから読み取る。**残存する制約(正直に明記する
-——暗黙に解決済みとは扱わない)**: wire 越しでは、POST のレスポンスが返って初めて
-リモートクライアントに id が見えるようになるが、その間に server が同じ submission
-の SSE broadcast を独立した events 接続経由ですでに push している可能性がある——
-これは同一プロセス内のローカルパスをこの id ベースの方式が完全に閉じる
-「同一テキストの衝突」とは異なる(そしてそれよりも狭い)、network の到達順序に
-起因する race である。これを完全に閉じるには、server が `msg_id` そのものとして
-尊重するクライアント供給の idempotency token が必要になる——このバグ修正の scope
-を超える、より大きな protocol 変更であり、実運用で race が観測された場合の
-将来の PR に委ねる。
+**race を狭めるのではなく閉じる(#3309 の co-vet finding F2)**: 初期版は
+remote 経路でも `msg_id` を使い、POST レスポンス body から読み取っていた——だが
+この id は POST が返って初めて見えるようになる一方、server は同じ submission
+の SSE broadcast を独立した events 接続経由で、その間にすでに push している
+可能性がある——2 つのチャンネル間の network 到達順序に起因する race である。
+レビュアーが指摘した通り、これは不要だった: `meta.auth_connection_id` は
+クライアント自身の identity であり、submit が起きる**前から**分かっている——
+これで一致させれば、解決すべき第 2 のチャンネルはそもそも存在せず、race を
+「許容された残存事項として文書化する」のではなく構造的に閉じられる。`msg_id`
+は remote 経路でも別の理由で load-bearing であり続ける——#3300 Y-client
+(cancel-by-id)は transport に関わらずクライアントが自分の message id を
+知る必要があるため、`AgUiTransport.submit_user_text` は引き続きそれを返す。
+ただ remote の echo-suppression がそれで相関を取ることはもうない、という
+だけである。
 
 ## AG-UI event coverage — 数字を正直に読む
 

--- a/docs/reference/runtime/agui-transport.ja.md
+++ b/docs/reference/runtime/agui-transport.ja.md
@@ -19,7 +19,11 @@ Reyn のチャットクライアントはストリームを消費する UI で�
   `event: <TYPE>\ndata: <json>\n\n` である。
 - `POST /agui/chat/{agent}` — client→server のチャンネル。Body は JSON object で、サポート
   されるメッセージ type は以下の通り:
-  - `{"type": "user_message", "text": "..."}` — ターンを submit する。
+  - `{"type": "user_message", "text": "..."}` — ターンを submit する。レスポンス body は
+    `{"status": "ok", "msg_id": "..."}`(#3287)——broadcast される
+    `reyn.event.user_submitted` が運ぶのと同じ correlation id であり、送信した
+    クライアント自身がこの id で自分の echo を認識できる(下記「Local ≡ remote は
+    input についても」参照)。
   - `{"type": "TOOL_CALL_RESULT", "toolCallId": "<intervention-id>", "text": "..."}` または
     `{..., "choiceId": "<id>"}` — pending 中の intervention に回答する(HITL の round-trip;
     下記「Human-in-the-loop answering」参照)。
@@ -407,14 +411,41 @@ broadcast の `user_submitted` event で再度描画すると、LLM round-trip �
 ターンで自分の行が二重に表示されてしまっていた(#3287。`/quit` は
 `submit_user_text` に到達しないため二重化しない——バグ報告が指摘した非対称性その
 もの)。修正は「デフォルトで抑制する」ではなく「所有権をはっきりさせる」こと:
-`run_input_loop` は `submit_user_text` に渡した行を小さな FIFO
-(`own_submissions`、クライアントの input/output ループのペアごとに保持し、他クライアント
-とは共有しない)に記録し、`run_output_loop` は `user_submitted` event のテキストが
-この FIFO の先頭と一致したときだけ再描画をスキップする。他のすべてのアタッチ済み
-クライアントのターン(および non-interactive で何も echo していない場合の自分自身の
-ターン)は今までどおり描画される。2 クライアント以上がアタッチしていても、互いに
-相手のすべてのターンとすべての回答は今までどおり見える——agent からの返信だけでは
-ない。変わるのは、各クライアントが自分自身の行を二重に描画しなくなる点だけである。
+`route_input_line` は自身の `transport.submit_user_text` 呼び出しが**返す**
+`msg_id`(`user_submitted` の `msg_id` フィールドが運ぶのと同じ correlation id、
+#3300 P2a)を小さな set(`own_submissions`、クライアントの input/output ループの
+ペアごとに保持し、他クライアントとは共有しない)に記録し、`run_output_loop` は
+`user_submitted` event の `msg_id` がこの set 内のエントリと一致したときだけ
+再描画をスキップする。他のすべてのアタッチ済みクライアントのターン(および
+non-interactive で何も echo していない場合の自分自身のターン)は今までどおり
+描画される。2 クライアント以上がアタッチしていても、互いに相手のすべてのターンと
+すべての回答は今までどおり見える——agent からの返信だけではない。変わるのは、
+各クライアントが自分自身の行を二重に描画しなくなる点だけである。
+
+相関は**テキストではなく id**で行う——初期版はテキストで一致させており、レビューで
+指摘された(#3309 の co-vet finding)。2 つのアタッチ済みクライアントが同一の短い
+文字列(例えば両方とも "yes" と回答する)を送信すると、テキスト一致では
+クロスマッチしてしまう——他方のクライアントのターンを誤って抑制し、その一方で
+自分自身のターンが後で二重に描画される、という形でバグが別の入口から再発する。
+`msg_id` は #3300 P2a が**まさに correlation id として**追加したもの(コンテンツから
+form-sniff したものでは決してない)なので、テキストが同一でも 2 つの異なる
+submission が衝突することはない。
+
+`ClientTransport.submit_user_text` はそのため割り当てられた `msg_id` を返す
+(以前は `None` だった)——`InProcessTransport` は `Session.submit_user_text` 自身の
+戻り値をそのまま返す(同一タスク内なので race フリー: chat-event の emit から
+呼び出し元へ id が届くまでの間に何も yield しない)。AG-UI エンドポイントの
+`user_message` ハンドラは POST の JSON レスポンス body に `msg_id` を echo し、
+`AgUiTransport.submit_user_text` はそこから読み取る。**残存する制約(正直に明記する
+——暗黙に解決済みとは扱わない)**: wire 越しでは、POST のレスポンスが返って初めて
+リモートクライアントに id が見えるようになるが、その間に server が同じ submission
+の SSE broadcast を独立した events 接続経由ですでに push している可能性がある——
+これは同一プロセス内のローカルパスをこの id ベースの方式が完全に閉じる
+「同一テキストの衝突」とは異なる(そしてそれよりも狭い)、network の到達順序に
+起因する race である。これを完全に閉じるには、server が `msg_id` そのものとして
+尊重するクライアント供給の idempotency token が必要になる——このバグ修正の scope
+を超える、より大きな protocol 変更であり、実運用で race が観測された場合の
+将来の PR に委ねる。
 
 ## AG-UI event coverage — 数字を正直に読む
 

--- a/docs/reference/runtime/agui-transport.ja.md
+++ b/docs/reference/runtime/agui-transport.ja.md
@@ -395,13 +395,26 @@ TUI の選択肢リージョン・A2A peer・上記の AG-UI HITL round-trip と
 書き込むのは category error だったため)。この event は同一の統一 frame stream に
 `EventFrame` として乗る(`_TURN_AND_ANSWER_EVENTS`、`transport/frames.py`)——
 encode/decode は汎用的(`transport/agui/protocol.py`)なので、新しい event type のために
-wire 側の変更は不要だった。いずれの経路でも、アタッチしているすべての surface の
+wire 側の変更は不要だった。アタッチしているすべての surface の
 event→display handler(`ConsoleChatRenderer.on_chat_event` /
 `InlineChatRenderer.on_chat_event` / `TextualChatApp._pump_frames`)がその行を描画し、
-その render 境界で neutralize する(`renderer.user_submitted_display_message`)。送信した
-クライアント自身も(別のローカルエコーではなく)同じ event から自分の行を描画する —
-2 クライアント以上がアタッチしていれば、全員がすべてのターンとすべての回答を見られる。
-agent からの返信だけではない。
+その render 境界で neutralize する(`renderer.user_submitted_display_message`)——
+**ただし自分の端末がすでにそれを表示していたクライアントを除く。** plain な
+PromptSession ループ(`--cui` / `chat.render_mode: plain` / non-TTY、
+`stream_client.py`)では、対話的な TTY の `prompt_session.prompt_async` が Enter を
+押した瞬間にその行を画面に残す——それ自体がすでに echo である。同じ送信から発生する
+broadcast の `user_submitted` event で再度描画すると、LLM round-trip を伴うすべての
+ターンで自分の行が二重に表示されてしまっていた(#3287。`/quit` は
+`submit_user_text` に到達しないため二重化しない——バグ報告が指摘した非対称性その
+もの)。修正は「デフォルトで抑制する」ではなく「所有権をはっきりさせる」こと:
+`run_input_loop` は `submit_user_text` に渡した行を小さな FIFO
+(`own_submissions`、クライアントの input/output ループのペアごとに保持し、他クライアント
+とは共有しない)に記録し、`run_output_loop` は `user_submitted` event のテキストが
+この FIFO の先頭と一致したときだけ再描画をスキップする。他のすべてのアタッチ済み
+クライアントのターン(および non-interactive で何も echo していない場合の自分自身の
+ターン)は今までどおり描画される。2 クライアント以上がアタッチしていても、互いに
+相手のすべてのターンとすべての回答は今までどおり見える——agent からの返信だけでは
+ない。変わるのは、各クライアントが自分自身の行を二重に描画しなくなる点だけである。
 
 ## AG-UI event coverage — 数字を正直に読む
 

--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -440,13 +440,26 @@ write, a category error: an INPUT written into the display/OUTPUT channel)
 that rides the SAME unified frame stream as an `EventFrame`
 (`_TURN_AND_ANSWER_EVENTS`, `transport/frames.py`) — the encode/decode is
 generic (`transport/agui/protocol.py`), so no wire changes were needed for the
-new event type. Either way every attached surface's event→display handler
+new event type. Every attached surface's event→display handler
 (`ConsoleChatRenderer.on_chat_event` / `InlineChatRenderer.on_chat_event` /
 `TextualChatApp._pump_frames`) renders the line, neutralizing at that render
-boundary (`renderer.user_submitted_display_message`). The submitting client
-renders its own line from that same event too (no separate local echo) —
-with 2+ clients attached, everyone sees every turn and every answer, not only
-the agent's replies to them.
+boundary (`renderer.user_submitted_display_message`) — **except the one
+client whose own terminal already showed it.** On the plain PromptSession
+loop (`--cui` / `chat.render_mode: plain` / non-TTY, `stream_client.py`), an
+interactive TTY's `prompt_session.prompt_async` leaves the typed line on
+screen the instant Enter is pressed — that already IS the echo. Re-rendering
+it again from the broadcast `user_submitted` event printed every LLM-round-
+trip turn's own line twice (#3287; a local `/quit` never reaches
+`submit_user_text`, so it never doubled — the asymmetry the bug report
+noticed). The fix is ownership, not suppression-by-default: `run_input_loop`
+records each line it hands to `submit_user_text` in a small FIFO
+(`own_submissions`, owned per client-loop-pair, never shared across clients),
+and `run_output_loop` skips re-rendering a `user_submitted` event only when
+its text matches THIS client's own queued line — every other attached
+client's turns (and this client's own turns when non-interactive, where
+nothing else echoes the line) still render normally. With 2+ clients
+attached, everyone still sees every OTHER client's turn and every answer, not
+only the agent's replies to them; each client just stops duplicating its own.
 
 ## AG-UI event coverage — reading the numbers honestly
 

--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -18,7 +18,11 @@ A2A; tools are MCP; observability export is OTEL. Those are separate surfaces.)
   is `event: <TYPE>\ndata: <json>\n\n`.
 - `POST /agui/chat/{agent}` — the client→server channel. Body is a JSON object;
   the supported message types are:
-  - `{"type": "user_message", "text": "..."}` — submit a turn.
+  - `{"type": "user_message", "text": "..."}` — submit a turn. The response
+    body is `{"status": "ok", "msg_id": "..."}` (#3287) — the same correlation
+    id the broadcast `reyn.event.user_submitted` carries, letting the
+    submitting client recognise its own echo BY ID (see "Local ≡ remote holds
+    for INPUT too" below).
   - `{"type": "TOOL_CALL_RESULT", "toolCallId": "<intervention-id>", "text": "..."}`
     or `{..., "choiceId": "<id>"}` — answer a pending intervention (the HITL
     round-trip; see "Human-in-the-loop answering" below).
@@ -451,15 +455,43 @@ screen the instant Enter is pressed — that already IS the echo. Re-rendering
 it again from the broadcast `user_submitted` event printed every LLM-round-
 trip turn's own line twice (#3287; a local `/quit` never reaches
 `submit_user_text`, so it never doubled — the asymmetry the bug report
-noticed). The fix is ownership, not suppression-by-default: `run_input_loop`
-records each line it hands to `submit_user_text` in a small FIFO
-(`own_submissions`, owned per client-loop-pair, never shared across clients),
-and `run_output_loop` skips re-rendering a `user_submitted` event only when
-its text matches THIS client's own queued line — every other attached
-client's turns (and this client's own turns when non-interactive, where
-nothing else echoes the line) still render normally. With 2+ clients
-attached, everyone still sees every OTHER client's turn and every answer, not
-only the agent's replies to them; each client just stops duplicating its own.
+noticed). The fix is ownership, not suppression-by-default: `route_input_line`
+records the `msg_id` its `transport.submit_user_text` call RETURNS (the SAME
+correlation id `user_submitted`'s `msg_id` field carries, #3300 P2a) in a
+small set (`own_submissions`, owned per client-loop-pair, never shared across
+clients), and `run_output_loop` skips re-rendering a `user_submitted` event
+only when its `msg_id` matches an entry in THIS client's own set — every
+other attached client's turns (and this client's own turns when
+non-interactive, where nothing else echoes the line) still render normally.
+With 2+ clients attached, everyone still sees every OTHER client's turn and
+every answer, not only the agent's replies to them; each client just stops
+duplicating its own.
+
+Correlation is by **id, never by text** — an earlier revision matched by
+text and was caught in review (co-vet finding on #3309): two attached
+clients submitting the identical short line (e.g. both answering "yes")
+would cross-match, simultaneously swallowing the OTHER client's turn and
+leaving THIS client's own turn to double-print later, reintroducing the bug
+through a different door. `msg_id` was added by #3300 P2a SPECIFICALLY as a
+correlation id (never form-sniffed from content), so two different
+submissions never collide even with identical text.
+
+`ClientTransport.submit_user_text` therefore returns the assigned `msg_id`
+(previously `None`) — `InProcessTransport` returns `Session.submit_user_text`'s
+own return value directly (same-task, race-free: nothing yields between the
+chat-event emit and the id reaching the caller); the AG-UI endpoint's
+`user_message` handler echoes `msg_id` in the POST's JSON response body, and
+`AgUiTransport.submit_user_text` reads it from there. **Residual, honestly
+bounded, not silently assumed closed**: over the wire, the id only becomes
+visible to the remote client once its POST response returns, and the
+server may have already pushed the SSE broadcast for the same submission
+over the independent events connection in the interim — a narrow
+network-ordering race, distinct from (and strictly narrower than) the
+same-text collision this id-based scheme closes outright for the
+same-process local path. Closing it fully would need a client-supplied
+idempotency token honored by the server as the `msg_id` itself — a larger
+protocol change than this fix's scope, left for a future PR if the race is
+ever observed in practice.
 
 ## AG-UI event coverage — reading the numbers honestly
 

--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -455,43 +455,58 @@ screen the instant Enter is pressed — that already IS the echo. Re-rendering
 it again from the broadcast `user_submitted` event printed every LLM-round-
 trip turn's own line twice (#3287; a local `/quit` never reaches
 `submit_user_text`, so it never doubled — the asymmetry the bug report
-noticed). The fix is ownership, not suppression-by-default: `route_input_line`
-records the `msg_id` its `transport.submit_user_text` call RETURNS (the SAME
-correlation id `user_submitted`'s `msg_id` field carries, #3300 P2a) in a
-small set (`own_submissions`, owned per client-loop-pair, never shared across
-clients), and `run_output_loop` skips re-rendering a `user_submitted` event
-only when its `msg_id` matches an entry in THIS client's own set — every
-other attached client's turns (and this client's own turns when
-non-interactive, where nothing else echoes the line) still render normally.
-With 2+ clients attached, everyone still sees every OTHER client's turn and
-every answer, not only the agent's replies to them; each client just stops
-duplicating its own.
+noticed). The fix is ownership, not suppression-by-default, and uses TWO
+DIFFERENT correlation mechanisms — one per transport shape, neither by text:
 
-Correlation is by **id, never by text** — an earlier revision matched by
-text and was caught in review (co-vet finding on #3309): two attached
+- **Local (`InProcessTransport`)**: `route_input_line` records the `msg_id`
+  its `transport.submit_user_text` call RETURNS (the SAME correlation id
+  `user_submitted`'s `msg_id` field carries, #3300 P2a) in a small set
+  (`own_submissions`, owned per client-loop-pair, never shared across
+  clients); `run_output_loop` skips re-rendering a `user_submitted` event
+  only when its `msg_id` matches an entry in THIS client's own set.
+  `ClientTransport.submit_user_text` returns the assigned `msg_id`
+  (previously `None`) — `InProcessTransport` returns `Session.submit_user_text`'s
+  own return value directly, same-task and race-free (nothing yields between
+  the chat-event emit and the id reaching the caller).
+- **Remote (`AgUiTransport`)**: matches the broadcast event's
+  `meta.auth_connection_id` against the client's OWN `connection_id` instead
+  (`remote_client.py` mints it client-side with `uuid.uuid4()` BEFORE any
+  submit and stamps it on every POST; the AG-UI endpoint's `user_message`
+  handler already attributes every submit with it — #3300's existing
+  multi-client display plumbing, `endpoint.py` → `session.py`'s `meta` →
+  the broadcast event, unchanged wire shape). Known up-front, with **no
+  dependency on any other channel** — see "closing the race" below.
+
+Either mechanism: every other attached client's turns (and this client's own
+turns when non-interactive, where nothing else echoes the line) still render
+normally. With 2+ clients attached, everyone still sees every OTHER client's
+turn and every answer, not only the agent's replies to them; each client
+just stops duplicating its own.
+
+Correlation is by **identity, never by text** — an earlier revision matched
+by text and was caught in review (co-vet finding F1 on #3309): two attached
 clients submitting the identical short line (e.g. both answering "yes")
 would cross-match, simultaneously swallowing the OTHER client's turn and
 leaving THIS client's own turn to double-print later, reintroducing the bug
-through a different door. `msg_id` was added by #3300 P2a SPECIFICALLY as a
-correlation id (never form-sniffed from content), so two different
-submissions never collide even with identical text.
+through a different door. `msg_id` (#3300 P2a) and `auth_connection_id`
+(#3300, multi-client attribution) were both added SPECIFICALLY as identity
+fields — never form-sniffed from content — so two different submissions
+never collide even with identical text.
 
-`ClientTransport.submit_user_text` therefore returns the assigned `msg_id`
-(previously `None`) — `InProcessTransport` returns `Session.submit_user_text`'s
-own return value directly (same-task, race-free: nothing yields between the
-chat-event emit and the id reaching the caller); the AG-UI endpoint's
-`user_message` handler echoes `msg_id` in the POST's JSON response body, and
-`AgUiTransport.submit_user_text` reads it from there. **Residual, honestly
-bounded, not silently assumed closed**: over the wire, the id only becomes
-visible to the remote client once its POST response returns, and the
-server may have already pushed the SSE broadcast for the same submission
-over the independent events connection in the interim — a narrow
-network-ordering race, distinct from (and strictly narrower than) the
-same-text collision this id-based scheme closes outright for the
-same-process local path. Closing it fully would need a client-supplied
-idempotency token honored by the server as the `msg_id` itself — a larger
-protocol change than this fix's scope, left for a future PR if the race is
-ever observed in practice.
+**Closing the race, not just narrowing it (co-vet finding F2 on #3309)**: an
+earlier revision used `msg_id` for the remote path too, reading it from the
+POST response body — but that id only becomes visible once the POST
+returns, and the server may already have pushed the SSE broadcast for the
+same submission over the INDEPENDENT events connection in the interim, a
+network-ordering race between the two channels. The reviewer pointed out
+this is unnecessary: `meta.auth_connection_id` is the client's own identity,
+known BEFORE the submit even happens — matching on it needs no second
+channel to resolve at all, closing the race structurally rather than
+documenting it as an accepted residual. `msg_id` remains load-bearing for a
+different reason on the remote path: #3300 Y-client (cancel-by-id) needs the
+client to learn its own message id regardless of transport, so
+`AgUiTransport.submit_user_text` still returns it — it is simply no longer
+what remote echo-suppression correlates on.
 
 ## AG-UI event coverage — reading the numbers honestly
 

--- a/src/reyn/interfaces/repl/client_driver.py
+++ b/src/reyn/interfaces/repl/client_driver.py
@@ -91,6 +91,7 @@ async def run_chat_client(
     agent_name: str,
     is_tty: bool,
     config=None,
+    own_connection_id: "str | None" = None,
 ) -> None:
     """Input-driver selection + (plain) banner/output loop + wait + teardown.
 
@@ -104,6 +105,14 @@ async def run_chat_client(
     A non-TTY session (``--cui`` / piped / CI / no real terminal) always resolves
     to ``plain`` regardless of mode. This is the SAME selection ``run_repl`` made
     locally — now applied identically to the remote path.
+
+    ``own_connection_id`` (#3287/#3309 F2): the REMOTE call site's own
+    ``connection_id`` (``remote_client.py`` mints it client-side, before any
+    submit, and sends it on every POST) — ``None`` for the local path (no such
+    concept; ``InProcessTransport`` correlates the own-echo suppression by
+    ``msg_id`` instead, see below). Passed through to :func:`run_output_loop`
+    only when ``is_tty`` (nothing else has shown the line otherwise, so the
+    event-driven render must stay the sole record).
 
     The caller owns transport lifecycle (``start``/``close`` or the httpx SSE
     context) and any cost summary; this function only drives the loop(s) and
@@ -134,21 +143,38 @@ async def run_chat_client(
 
     # #3287: on an interactive TTY, `prompt_session.prompt_async` below already
     # leaves the typed line on the terminal the instant Enter is pressed — the
-    # user-line echo already happened there. Without this set the broadcast
-    # `user_submitted` chat-event this same submission produces (see
+    # user-line echo already happened there. Without suppressing it, the
+    # broadcast `user_submitted` chat-event this same submission produces (see
     # `run_output_loop`) renders it a SECOND time, printing every LLM-round-trip
     # turn's own line twice (a local `/quit` never reaches `submit_user_text`,
-    # so it never doubled — the exact contrast the bug report noted). `None` on
-    # a non-TTY session leaves the event-driven render as the sole echo (there
-    # is nothing else on screen to duplicate it against — piped stdin is never
-    # echoed by the terminal). Owned by THIS client's own loop pair (never
-    # shared), so it only ever matches submissions this same process made —
-    # another attached client's turns still render normally (see both loops'
-    # docstrings in `stream_client.py`). Correlated by `msg_id` (the transport's
-    # `submit_user_text` return value), never by text — a same-text collision
-    # between two attached clients (both typing "yes") would otherwise misfire
-    # (co-vet finding on #3309, F1).
-    own_submissions: "set[str] | None" = set() if is_tty else None
+    # so it never doubled — the exact contrast the bug report noted). `None`
+    # (own_submissions AND own_connection_id) on a non-TTY session leaves the
+    # event-driven render as the sole echo (there is nothing else on screen to
+    # duplicate it against — piped stdin is never echoed by the terminal).
+    #
+    # TWO correlation mechanisms, one per transport shape, never text (a
+    # same-text collision between two attached clients both typing "yes" would
+    # misfire — co-vet finding on #3309, F1):
+    #   - `own_connection_id` (F2): when the caller passes one (the REMOTE
+    #     path — `remote_client.py` mints its own `connection_id` client-side,
+    #     BEFORE any submit, and stamps it on every POST; the server echoes it
+    #     straight back into the broadcast event's `meta.auth_connection_id`,
+    #     #3300's existing attribution plumbing) `run_output_loop` matches on
+    #     that field directly — structurally race-free because the id is known
+    #     up-front, with no dependency on the POST-ack/SSE-broadcast arrival
+    #     order at all (closing the residual race an earlier revision of this
+    #     fix could only document, not eliminate).
+    #   - `own_submissions` (msg_id set, #3287/F1): the LOCAL path
+    #     (`InProcessTransport`) has no connection-id concept, so it keeps the
+    #     msg_id-based set instead — also race-free (same-task, no yield point
+    #     between the chat-event emit and the id reaching the caller).
+    # Only one is ever active per session (the other stays `None`) — never
+    # shared across clients either way, so another attached client's turns
+    # always render normally (see both loops' docstrings in `stream_client.py`).
+    own_connection_id = own_connection_id if is_tty else None
+    own_submissions: "set[str] | None" = (
+        set() if (is_tty and own_connection_id is None) else None
+    )
 
     from prompt_toolkit import PromptSession  # noqa: PLC0415
     from prompt_toolkit.history import FileHistory  # noqa: PLC0415
@@ -169,6 +195,7 @@ async def run_chat_client(
             transport, renderer, reply_seen,
             command_ui_region=read_model.has_command_ui_region,
             own_submissions=own_submissions,
+            own_connection_id=own_connection_id,
         )
     )
 

--- a/src/reyn/interfaces/repl/client_driver.py
+++ b/src/reyn/interfaces/repl/client_driver.py
@@ -134,7 +134,7 @@ async def run_chat_client(
 
     # #3287: on an interactive TTY, `prompt_session.prompt_async` below already
     # leaves the typed line on the terminal the instant Enter is pressed — the
-    # user-line echo already happened there. Without this queue the broadcast
+    # user-line echo already happened there. Without this set the broadcast
     # `user_submitted` chat-event this same submission produces (see
     # `run_output_loop`) renders it a SECOND time, printing every LLM-round-trip
     # turn's own line twice (a local `/quit` never reaches `submit_user_text`,
@@ -144,9 +144,11 @@ async def run_chat_client(
     # echoed by the terminal). Owned by THIS client's own loop pair (never
     # shared), so it only ever matches submissions this same process made —
     # another attached client's turns still render normally (see both loops'
-    # docstrings in `stream_client.py`).
-    from collections import deque  # noqa: PLC0415
-    own_submissions: "deque[str] | None" = deque() if is_tty else None
+    # docstrings in `stream_client.py`). Correlated by `msg_id` (the transport's
+    # `submit_user_text` return value), never by text — a same-text collision
+    # between two attached clients (both typing "yes") would otherwise misfire
+    # (co-vet finding on #3309, F1).
+    own_submissions: "set[str] | None" = set() if is_tty else None
 
     from prompt_toolkit import PromptSession  # noqa: PLC0415
     from prompt_toolkit.history import FileHistory  # noqa: PLC0415

--- a/src/reyn/interfaces/repl/client_driver.py
+++ b/src/reyn/interfaces/repl/client_driver.py
@@ -132,6 +132,22 @@ async def run_chat_client(
     reply_seen: asyncio.Event = asyncio.Event()
     reply_seen.set()
 
+    # #3287: on an interactive TTY, `prompt_session.prompt_async` below already
+    # leaves the typed line on the terminal the instant Enter is pressed — the
+    # user-line echo already happened there. Without this queue the broadcast
+    # `user_submitted` chat-event this same submission produces (see
+    # `run_output_loop`) renders it a SECOND time, printing every LLM-round-trip
+    # turn's own line twice (a local `/quit` never reaches `submit_user_text`,
+    # so it never doubled — the exact contrast the bug report noted). `None` on
+    # a non-TTY session leaves the event-driven render as the sole echo (there
+    # is nothing else on screen to duplicate it against — piped stdin is never
+    # echoed by the terminal). Owned by THIS client's own loop pair (never
+    # shared), so it only ever matches submissions this same process made —
+    # another attached client's turns still render normally (see both loops'
+    # docstrings in `stream_client.py`).
+    from collections import deque  # noqa: PLC0415
+    own_submissions: "deque[str] | None" = deque() if is_tty else None
+
     from prompt_toolkit import PromptSession  # noqa: PLC0415
     from prompt_toolkit.history import FileHistory  # noqa: PLC0415
     from prompt_toolkit.styles import Style  # noqa: PLC0415
@@ -140,13 +156,17 @@ async def run_chat_client(
         style=Style.from_dict({"bottom-toolbar": "noreverse bg:default"}),
     )
     inputs = asyncio.create_task(
-        run_input_loop(transport, prompt_session, renderer, reply_seen)
+        run_input_loop(
+            transport, prompt_session, renderer, reply_seen,
+            own_submissions=own_submissions,
+        )
     )
 
     outputs = asyncio.create_task(
         run_output_loop(
             transport, renderer, reply_seen,
             command_ui_region=read_model.has_command_ui_region,
+            own_submissions=own_submissions,
         )
     )
 

--- a/src/reyn/interfaces/repl/remote_client.py
+++ b/src/reyn/interfaces/repl/remote_client.py
@@ -139,17 +139,18 @@ async def run_remote_repl(
             this widened return type).
             ``submit_user_text`` (#3287) additionally reads ``resp["msg_id"]``
             here — the server's echo of the SAME correlation id its broadcast
-            ``user_submitted`` chat-event carries (#3300 P2a) — so the client
-            can recognise its own broadcast echo BY ID rather than a same-text
-            match. NOTE (residual, documented rather than silently assumed
-            closed): the id only becomes visible to submit_user_text once this
-            await returns; the server may already have pushed the SSE
-            broadcast for it over the OTHER connection (the events stream) in
-            the interim, in which case run_output_loop renders it before the
-            id lands in `own_submissions` — a narrow network-ordering race
-            distinct from (and strictly narrower than) the same-text collision
-            this id-based scheme closes for the local, single-process path
-            (see `stream_client.py` / `agui-transport.md`).
+            ``user_submitted`` chat-event carries (#3300 P2a). This id is
+            NOT what closes remote own-echo suppression, though (#3309 F2):
+            it only becomes visible once this await returns, and the server
+            may already have pushed the SSE broadcast for the same submission
+            over the OTHER connection (the events stream) in the interim — a
+            cross-channel race a POST-ack-timed id cannot avoid. Remote
+            suppression instead matches on `own_connection_id`
+            (`run_chat_client`/`run_output_loop`), known up-front and
+            independent of this response entirely; `msg_id` here stays
+            load-bearing for a DIFFERENT reason — #3300 Y-client (cancel-by-id)
+            needs the client to learn its own message id, per
+            ``session.py``'s ``submit_user_text`` docstring.
             """
             last_send[0] = time.monotonic()
             try:
@@ -202,6 +203,14 @@ async def run_remote_repl(
                         agent_name=agent_name,
                         is_tty=sys.stdin.isatty(),
                         config=config,
+                        # #3287/#3309 F2: THIS client's own connection_id
+                        # (minted above, BEFORE any submit, and stamped on
+                        # every POST) — the server echoes it back into every
+                        # user_submitted broadcast's meta.auth_connection_id,
+                        # so run_output_loop can recognise "this is MY OWN
+                        # remote submission" by identity, with no dependency
+                        # on the POST-ack racing the SSE broadcast.
+                        own_connection_id=connection_id,
                     )
                 finally:
                     hb.cancel()

--- a/src/reyn/interfaces/repl/remote_client.py
+++ b/src/reyn/interfaces/repl/remote_client.py
@@ -129,17 +129,40 @@ async def run_remote_repl(
         # refreshes it for every accepted POST, not just ``type: heartbeat``).
         last_send = [0.0]
 
-        async def send(payload: dict) -> bool:
-            """POST one client→server message; True iff the server accepted it
-            (2xx). A rejected HITL answer (403/409) returns False so the client
-            falls back to an ordinary turn instead of silently dropping input."""
+        async def send(payload: dict) -> "dict | None":
+            """POST one client→server message; the parsed JSON response body on
+            a 2xx accept (always a truthy dict, even if the body itself parsed
+            empty — see below), ``None`` if the server rejected it (403/409/…)
+            or the POST itself failed. A rejected HITL answer therefore still
+            reads as falsy exactly like the old bool contract (``if accepted:``
+            / ``bool(accepted)`` at every existing call site are unaffected by
+            this widened return type).
+            ``submit_user_text`` (#3287) additionally reads ``resp["msg_id"]``
+            here — the server's echo of the SAME correlation id its broadcast
+            ``user_submitted`` chat-event carries (#3300 P2a) — so the client
+            can recognise its own broadcast echo BY ID rather than a same-text
+            match. NOTE (residual, documented rather than silently assumed
+            closed): the id only becomes visible to submit_user_text once this
+            await returns; the server may already have pushed the SSE
+            broadcast for it over the OTHER connection (the events stream) in
+            the interim, in which case run_output_loop renders it before the
+            id lands in `own_submissions` — a narrow network-ordering race
+            distinct from (and strictly narrower than) the same-text collision
+            this id-based scheme closes for the local, single-process path
+            (see `stream_client.py` / `agui-transport.md`).
+            """
             last_send[0] = time.monotonic()
             try:
                 resp = await client.post(submit_url, params=params, json=payload)
             except Exception:  # noqa: BLE001 — a transport error is a non-delivery
                 logger.warning("remote send failed for %r", payload.get("type"))
-                return False
-            return resp.status_code < 300
+                return None
+            if resp.status_code >= 300:
+                return None
+            try:
+                return resp.json()
+            except Exception:  # noqa: BLE001 — an empty/non-JSON 2xx body is still an accept
+                return {"status": "ok"}
 
         async def heartbeat() -> None:
             while True:

--- a/src/reyn/interfaces/repl/stream_client.py
+++ b/src/reyn/interfaces/repl/stream_client.py
@@ -95,7 +95,26 @@ async def run_input_loop(
     prompt_session: PromptSession,
     renderer: ChatRenderer,
     reply_seen: "asyncio.Event | None" = None,
+    *,
+    own_submissions: "deque[str] | None" = None,
 ) -> None:
+    """Drive the plain PromptSession input loop.
+
+    ``own_submissions`` (#3287): on an interactive TTY, ``prompt_session.
+    prompt_async`` itself leaves the typed line ("you > <text>") on the
+    terminal once Enter is pressed — that IS the user-line echo. Every
+    submitted line (this loop appends it here, right before handing it to
+    ``route_input_line``) is recorded so :func:`run_output_loop` can recognise
+    the broadcast ``user_submitted`` chat-event this same submission produces
+    and skip re-rendering it — otherwise the terminal's own echo and the
+    event-driven echo both land, printing the line twice. Callers pass
+    ``None`` (the non-interactive / piped path, where the terminal shows
+    nothing as input streams in — the event-driven render is then the ONLY
+    record of what was submitted, so it must not be suppressed) or a fresh
+    ``deque()`` owned by this client's own loop pair (never shared across
+    clients, so another attached client's submissions are never matched here
+    and always render — see ``run_output_loop``'s docstring).
+    """
     is_tty = sys.stdin.isatty()
     while True:
         # Piped / scripted mode: pace input by reply availability. Without
@@ -156,11 +175,15 @@ async def run_input_loop(
         if not transport.has_session():
             renderer.message(_simple_status("no agent attached; try :agents"))
             continue
-        await route_input_line(transport, text, reply_seen)
+        await route_input_line(transport, text, reply_seen, own_submissions=own_submissions)
 
 
 async def route_input_line(
-    transport: ClientTransport, text: str, reply_seen: "asyncio.Event | None"
+    transport: ClientTransport,
+    text: str,
+    reply_seen: "asyncio.Event | None",
+    *,
+    own_submissions: "deque[str] | None" = None,
 ) -> None:
     """Route one non-quit client line to the session via the transport.
 
@@ -181,6 +204,14 @@ async def route_input_line(
     so it is left on the normal slash/inbox path. The direct-delivery result is
     checked so a race where the intervention resolves between the head-check and
     the deliver falls back to a normal turn instead of being dropped.
+
+    ``own_submissions`` (#3287) is appended ONLY on the branch that actually
+    calls ``submit_user_text`` — that is the ONLY branch that produces a
+    ``user_submitted`` chat-event for ``run_output_loop`` to match against.  An
+    intervention answer takes the direct-delivery branch above and returns
+    before reaching it, so it is never queued (there is no matching
+    ``user_submitted`` event to consume it, and it would otherwise desync the
+    FIFO against a later ordinary turn).
     """
     if not text.startswith("/") and transport.pending_intervention_head() is not None:
         if await transport.answer_intervention_text(text):
@@ -193,6 +224,8 @@ async def route_input_line(
     # caller and never reach here.
     if reply_seen is not None and not text.startswith("/"):
         reply_seen.clear()
+    if own_submissions is not None:
+        own_submissions.append(text)
     await transport.submit_user_text(text)
 
 
@@ -202,7 +235,27 @@ async def run_output_loop(
     reply_seen: "asyncio.Event | None" = None,
     *,
     command_ui_region: bool = True,
+    own_submissions: "deque[str] | None" = None,
 ) -> None:
+    """Drain the transport's unified frame stream to the renderer.
+
+    ``own_submissions`` (#3287, paired with :func:`run_input_loop` /
+    :func:`route_input_line`'s param of the same name): a ``user_submitted``
+    chat-event is a BROADCAST — every attached client (this one included) gets
+    it, so a second attached client can still be relying on it as the only
+    render of a turn it didn't type itself. On an interactive TTY, THIS
+    client's own submissions are different: ``prompt_session.prompt_async``
+    already left the typed line on the terminal the instant Enter was
+    pressed, so re-rendering it from the broadcast event would print it
+    twice. The queue lets this loop recognise "this is the event for the line
+    my OWN input loop just showed" (FIFO head text match) without touching
+    events for anyone else's submissions, which still render normally — the
+    fix is about which surface owns the echo (the terminal, for this client's
+    own TTY-typed line) not about dropping the event universally. ``None``
+    (the default, and what non-interactive / piped / non-TTY sessions pass)
+    disables the check entirely, preserving the event-driven echo as the sole
+    record when nothing else showed the line.
+    """
     is_tty = sys.stdout.isatty()
     # Newest-first ring of recent agent replies so `/copy [N]` can grab the
     # latest (or an older) reply and pipe it to the system clipboard.
@@ -213,7 +266,19 @@ async def run_output_loop(
         # its two entry points; an outbox-only stream would silently drop these
         # (the A2 WaitingOn bug, designed out by the completeness gate).
         if frame.tag is FrameTag.EVENT:
-            renderer.on_chat_event(frame.event)
+            event = frame.event
+            if (
+                own_submissions
+                and getattr(event, "type", None) == "user_submitted"
+                and own_submissions[0] == (getattr(event, "data", None) or {}).get("text")
+            ):
+                # This client's own PromptSession prompt already echoed this
+                # exact line to the terminal — skip the redundant re-render
+                # (#3287) and consume the matched entry so the FIFO stays
+                # aligned with this client's own future submissions.
+                own_submissions.popleft()
+                continue
+            renderer.on_chat_event(event)
             continue
         msg = frame.message
         if msg.kind == "__end__":

--- a/src/reyn/interfaces/repl/stream_client.py
+++ b/src/reyn/interfaces/repl/stream_client.py
@@ -96,24 +96,27 @@ async def run_input_loop(
     renderer: ChatRenderer,
     reply_seen: "asyncio.Event | None" = None,
     *,
-    own_submissions: "deque[str] | None" = None,
+    own_submissions: "set[str] | None" = None,
 ) -> None:
     """Drive the plain PromptSession input loop.
 
     ``own_submissions`` (#3287): on an interactive TTY, ``prompt_session.
     prompt_async`` itself leaves the typed line ("you > <text>") on the
     terminal once Enter is pressed — that IS the user-line echo. Every
-    submitted line (this loop appends it here, right before handing it to
-    ``route_input_line``) is recorded so :func:`run_output_loop` can recognise
-    the broadcast ``user_submitted`` chat-event this same submission produces
-    and skip re-rendering it — otherwise the terminal's own echo and the
-    event-driven echo both land, printing the line twice. Callers pass
-    ``None`` (the non-interactive / piped path, where the terminal shows
-    nothing as input streams in — the event-driven render is then the ONLY
-    record of what was submitted, so it must not be suppressed) or a fresh
-    ``deque()`` owned by this client's own loop pair (never shared across
-    clients, so another attached client's submissions are never matched here
-    and always render — see ``run_output_loop``'s docstring).
+    submitted line is handed to :func:`route_input_line`, which records the
+    ``msg_id`` the transport's ``submit_user_text`` assigns (the SAME
+    correlation id — #3300 P2a — the broadcast ``user_submitted`` chat-event
+    carries) into this set, so :func:`run_output_loop` can recognise that
+    event BY ID and skip re-rendering it — otherwise the terminal's own echo
+    and the event-driven echo both land, printing the line twice. Correlating
+    by id rather than by text avoids a same-text collision misfire (e.g. two
+    attached clients both typing "yes") that a text match cannot distinguish.
+    Callers pass ``None`` (the non-interactive / piped path, where the
+    terminal shows nothing as input streams in — the event-driven render is
+    then the ONLY record of what was submitted, so it must not be suppressed)
+    or a fresh ``set()`` owned by this client's own loop pair (never shared
+    across clients, so another attached client's submissions are never
+    matched here and always render — see ``run_output_loop``'s docstring).
     """
     is_tty = sys.stdin.isatty()
     while True:
@@ -183,7 +186,7 @@ async def route_input_line(
     text: str,
     reply_seen: "asyncio.Event | None",
     *,
-    own_submissions: "deque[str] | None" = None,
+    own_submissions: "set[str] | None" = None,
 ) -> None:
     """Route one non-quit client line to the session via the transport.
 
@@ -205,13 +208,17 @@ async def route_input_line(
     checked so a race where the intervention resolves between the head-check and
     the deliver falls back to a normal turn instead of being dropped.
 
-    ``own_submissions`` (#3287) is appended ONLY on the branch that actually
+    ``own_submissions`` (#3287) is populated ONLY on the branch that actually
     calls ``submit_user_text`` — that is the ONLY branch that produces a
-    ``user_submitted`` chat-event for ``run_output_loop`` to match against.  An
+    ``user_submitted`` chat-event for ``run_output_loop`` to match against. An
     intervention answer takes the direct-delivery branch above and returns
-    before reaching it, so it is never queued (there is no matching
-    ``user_submitted`` event to consume it, and it would otherwise desync the
-    FIFO against a later ordinary turn).
+    before reaching it, so nothing is added for it (there is no matching
+    ``user_submitted`` event to ever consume such an entry). The transport's
+    ``submit_user_text`` return value is the server-assigned ``msg_id`` — the
+    SAME id the broadcast event carries — added to the set verbatim; an empty
+    string (no session attached / a non-conforming transport) is never added,
+    so it can never accidentally match an event whose own ``msg_id`` also
+    reads empty/missing.
     """
     if not text.startswith("/") and transport.pending_intervention_head() is not None:
         if await transport.answer_intervention_text(text):
@@ -224,9 +231,9 @@ async def route_input_line(
     # caller and never reach here.
     if reply_seen is not None and not text.startswith("/"):
         reply_seen.clear()
-    if own_submissions is not None:
-        own_submissions.append(text)
-    await transport.submit_user_text(text)
+    msg_id = await transport.submit_user_text(text)
+    if own_submissions is not None and msg_id:
+        own_submissions.add(msg_id)
 
 
 async def run_output_loop(
@@ -235,7 +242,7 @@ async def run_output_loop(
     reply_seen: "asyncio.Event | None" = None,
     *,
     command_ui_region: bool = True,
-    own_submissions: "deque[str] | None" = None,
+    own_submissions: "set[str] | None" = None,
 ) -> None:
     """Drain the transport's unified frame stream to the renderer.
 
@@ -247,14 +254,23 @@ async def run_output_loop(
     client's own submissions are different: ``prompt_session.prompt_async``
     already left the typed line on the terminal the instant Enter was
     pressed, so re-rendering it from the broadcast event would print it
-    twice. The queue lets this loop recognise "this is the event for the line
-    my OWN input loop just showed" (FIFO head text match) without touching
-    events for anyone else's submissions, which still render normally — the
-    fix is about which surface owns the echo (the terminal, for this client's
-    own TTY-typed line) not about dropping the event universally. ``None``
-    (the default, and what non-interactive / piped / non-TTY sessions pass)
-    disables the check entirely, preserving the event-driven echo as the sole
-    record when nothing else showed the line.
+    twice. The set lets this loop recognise "this is the event for the line
+    my OWN input loop just showed" — matched by ``msg_id`` (the #3300 P2a
+    correlation id the event carries), NOT by text, so two attached clients
+    submitting the SAME text (e.g. both typing "yes") never cross-match: a
+    text match would let client A's broadcast satisfy client A's queue check
+    for client B's identical-text turn (or vice-versa, depending on arrival
+    order), simultaneously swallowing the OTHER client's line and leaving
+    THIS client's own line unswallowed later (the original bug, reintroduced
+    by a different route) — a real, order-dependent failure mode a plain
+    string match cannot avoid (see ``tests/test_stream_client_own_echo_3287.py``
+    ``test_same_text_two_clients_does_not_cross_match_by_id``). Events for
+    anyone else's submissions still render normally — the fix is about which
+    surface owns the echo (the terminal, for this client's own TTY-typed
+    line) not about dropping the event universally. ``None`` (the default,
+    and what non-interactive / piped / non-TTY sessions pass) disables the
+    check entirely, preserving the event-driven echo as the sole record when
+    nothing else showed the line.
     """
     is_tty = sys.stdout.isatty()
     # Newest-first ring of recent agent replies so `/copy [N]` can grab the
@@ -267,17 +283,16 @@ async def run_output_loop(
         # (the A2 WaitingOn bug, designed out by the completeness gate).
         if frame.tag is FrameTag.EVENT:
             event = frame.event
-            if (
-                own_submissions
-                and getattr(event, "type", None) == "user_submitted"
-                and own_submissions[0] == (getattr(event, "data", None) or {}).get("text")
-            ):
-                # This client's own PromptSession prompt already echoed this
-                # exact line to the terminal — skip the redundant re-render
-                # (#3287) and consume the matched entry so the FIFO stays
-                # aligned with this client's own future submissions.
-                own_submissions.popleft()
-                continue
+            if own_submissions and getattr(event, "type", None) == "user_submitted":
+                event_msg_id = (getattr(event, "data", None) or {}).get("msg_id")
+                if event_msg_id and event_msg_id in own_submissions:
+                    # This client's own PromptSession prompt already echoed
+                    # this exact submission (matched BY ID, #3287) to the
+                    # terminal — skip the redundant re-render and consume the
+                    # matched id so the set can't accidentally match a LATER,
+                    # unrelated event (ids are never reused).
+                    own_submissions.discard(event_msg_id)
+                    continue
             renderer.on_chat_event(event)
             continue
         msg = frame.message

--- a/src/reyn/interfaces/repl/stream_client.py
+++ b/src/reyn/interfaces/repl/stream_client.py
@@ -243,33 +243,52 @@ async def run_output_loop(
     *,
     command_ui_region: bool = True,
     own_submissions: "set[str] | None" = None,
+    own_connection_id: "str | None" = None,
 ) -> None:
     """Drain the transport's unified frame stream to the renderer.
 
-    ``own_submissions`` (#3287, paired with :func:`run_input_loop` /
-    :func:`route_input_line`'s param of the same name): a ``user_submitted``
-    chat-event is a BROADCAST — every attached client (this one included) gets
-    it, so a second attached client can still be relying on it as the only
-    render of a turn it didn't type itself. On an interactive TTY, THIS
-    client's own submissions are different: ``prompt_session.prompt_async``
-    already left the typed line on the terminal the instant Enter was
-    pressed, so re-rendering it from the broadcast event would print it
-    twice. The set lets this loop recognise "this is the event for the line
-    my OWN input loop just showed" — matched by ``msg_id`` (the #3300 P2a
-    correlation id the event carries), NOT by text, so two attached clients
-    submitting the SAME text (e.g. both typing "yes") never cross-match: a
-    text match would let client A's broadcast satisfy client A's queue check
-    for client B's identical-text turn (or vice-versa, depending on arrival
-    order), simultaneously swallowing the OTHER client's line and leaving
-    THIS client's own line unswallowed later (the original bug, reintroduced
-    by a different route) — a real, order-dependent failure mode a plain
-    string match cannot avoid (see ``tests/test_stream_client_own_echo_3287.py``
-    ``test_same_text_two_clients_does_not_cross_match_by_id``). Events for
-    anyone else's submissions still render normally — the fix is about which
-    surface owns the echo (the terminal, for this client's own TTY-typed
-    line) not about dropping the event universally. ``None`` (the default,
-    and what non-interactive / piped / non-TTY sessions pass) disables the
-    check entirely, preserving the event-driven echo as the sole record when
+    A ``user_submitted`` chat-event is a BROADCAST — every attached client
+    (this one included) gets it, so a second attached client can still be
+    relying on it as the only render of a turn it didn't type itself. On an
+    interactive TTY, THIS client's own submissions are different:
+    ``prompt_session.prompt_async`` already left the typed line on the
+    terminal the instant Enter was pressed, so re-rendering it from the
+    broadcast event would print it twice (#3287). Two DIFFERENT correlation
+    mechanisms recognise "this is the event for the line my OWN input loop
+    just showed" — never by TEXT, so two attached clients submitting the SAME
+    text (e.g. both typing "yes") never cross-match: a text match would let
+    client A's broadcast satisfy client A's queue check for client B's
+    identical-text turn (or vice-versa, depending on arrival order),
+    simultaneously swallowing the OTHER client's line and leaving THIS
+    client's own line unswallowed later (the original bug, reintroduced by a
+    different route — co-vet finding F1 on #3309; see
+    ``tests/test_stream_client_own_echo_3287.py``
+    ``test_same_text_two_clients_does_not_cross_match_by_id``):
+
+    - ``own_connection_id`` (F2, checked FIRST): the caller's own
+      ``connection_id`` — for the AG-UI remote path, minted client-side
+      (``remote_client.py``) BEFORE any submit and stamped on every POST; the
+      server echoes it straight back into the broadcast event's
+      ``meta.auth_connection_id`` (the SAME attribution field #3300 already
+      wired for multi-client display). Matched directly against the event's
+      ``meta.auth_connection_id`` — structurally race-free, since the id is
+      known up-front and this check has NO dependency on any OTHER channel
+      (in particular, none on the POST-ack that returns ``submit_user_text``'s
+      ``msg_id`` racing the SSE broadcast — the residual gap an earlier
+      revision of this fix could only document, not eliminate).
+    - ``own_submissions`` (a ``msg_id`` set, F1): the LOCAL path
+      (``InProcessTransport``) has no connection-id concept, so it correlates
+      by the ``msg_id`` its ``submit_user_text`` call returns instead — also
+      race-free (same-task, no yield point between the chat-event emit and
+      the id reaching the caller).
+
+    Only one of the two is ever non-``None`` for a given session (see
+    ``client_driver.run_chat_client``). Events for anyone else's submissions
+    still render normally either way — the fix is about which surface owns
+    the echo (the terminal, for this client's own TTY-typed line) not about
+    dropping the event universally. Both ``None`` (the default, and what
+    non-interactive / piped / non-TTY sessions pass) disables the check
+    entirely, preserving the event-driven echo as the sole record when
     nothing else showed the line.
     """
     is_tty = sys.stdout.isatty()
@@ -283,16 +302,26 @@ async def run_output_loop(
         # (the A2 WaitingOn bug, designed out by the completeness gate).
         if frame.tag is FrameTag.EVENT:
             event = frame.event
-            if own_submissions and getattr(event, "type", None) == "user_submitted":
-                event_msg_id = (getattr(event, "data", None) or {}).get("msg_id")
-                if event_msg_id and event_msg_id in own_submissions:
-                    # This client's own PromptSession prompt already echoed
-                    # this exact submission (matched BY ID, #3287) to the
-                    # terminal — skip the redundant re-render and consume the
-                    # matched id so the set can't accidentally match a LATER,
-                    # unrelated event (ids are never reused).
-                    own_submissions.discard(event_msg_id)
-                    continue
+            if getattr(event, "type", None) == "user_submitted":
+                data = getattr(event, "data", None) or {}
+                if own_connection_id is not None:
+                    meta = data.get("meta") or {}
+                    if meta.get("auth_connection_id") == own_connection_id:
+                        # This client's own remote submission (matched BY
+                        # CONNECTION IDENTITY, #3309 F2) — its own POST already
+                        # produced the terminal echo, no wait on any other
+                        # channel needed. Skip the redundant re-render.
+                        continue
+                elif own_submissions:
+                    event_msg_id = data.get("msg_id")
+                    if event_msg_id and event_msg_id in own_submissions:
+                        # This client's own PromptSession prompt already
+                        # echoed this exact submission (matched BY ID, #3287)
+                        # to the terminal — skip the redundant re-render and
+                        # consume the matched id so the set can't accidentally
+                        # match a LATER, unrelated event (ids never reused).
+                        own_submissions.discard(event_msg_id)
+                        continue
             renderer.on_chat_event(event)
             continue
         msg = frame.message

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -49,7 +49,7 @@ class AgUiTransport(ClientTransport):
     def __init__(
         self,
         sse_lines: "AsyncIterator[str]",
-        send: "Callable[[dict], Awaitable[bool | None]]",
+        send: "Callable[[dict], Awaitable[dict | None]]",
         *,
         status_view: "RemoteStatusView | None" = None,
         reguard_surface: str = "terminal",
@@ -159,8 +159,19 @@ class AgUiTransport(ClientTransport):
         # to answer_intervention_text (delivered BY ID, R1) instead of a new turn.
         return self._pending_intervention_id
 
-    async def submit_user_text(self, text: str) -> None:
-        await self._send({"type": "user_message", "text": text})
+    async def submit_user_text(self, text: str) -> str:
+        # #3287: the server echoes the msg_id it assigned (the SAME
+        # correlation id the broadcast user_submitted chat-event carries,
+        # #3300 P2a) in the POST's JSON response — see
+        # `agui/endpoint.py`'s `user_message` handler. `""` (never a raised
+        # exception / None-propagating crash) on any shape the caller can't
+        # use — a rejected/failed POST (`_send` returned None) or a legacy/
+        # foreign server that doesn't echo the field — so a caller can always
+        # treat "no id" with a plain falsy check, same as `""` from
+        # `InProcessTransport` when nothing is attached.
+        result = await self._send({"type": "user_message", "text": text})
+        msg_id = (result or {}).get("msg_id")
+        return msg_id if isinstance(msg_id, str) else ""
 
     async def answer_intervention_text(
         self, text: str, *, intervention_id: "str | None" = None

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -450,13 +450,21 @@ async def agui_submit(request: Request, agent_name: str):
             # `user_submitted` chat-event (#3300 P1 C) that every attached
             # surface's event→display handler renders as this client's turn,
             # not just the agent's reply.
-            await session.submit_user_text(
+            msg_id = await session.submit_user_text(
                 text,
                 attribution={
                     "auth_user_id": identity.user_id,
                     "auth_connection_id": connection_id,
                 },
             )
+            # #3287: echo the assigned msg_id back to the SUBMITTING client —
+            # the SAME correlation id the broadcast user_submitted event above
+            # carries — so it can recognise its own echo BY ID (never a
+            # same-text match, which a second client submitting an identical
+            # line would defeat) and skip re-rendering a line its own input
+            # surface already showed. See `AgUiTransport.submit_user_text` /
+            # `remote_client.py`'s `send`.
+            return JSONResponse({"status": "ok", "msg_id": msg_id})
     elif ptype == "cancel_inflight":
         cancel_fn = getattr(session, "cancel_inflight", None)
         if callable(cancel_fn):

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -53,14 +53,29 @@ class ClientTransport(ABC):
         """Submit a user turn (the ordinary new-turn path).
 
         Returns the server-assigned ``msg_id`` — the SAME correlation id the
-        broadcast ``user_submitted`` chat-event carries (#3300 P2a) — so a
-        caller that already rendered this line some other way (e.g. the
-        plain PromptSession loop's own terminal echo, #3287) can recognise
-        its own broadcast echo BY ID and skip re-rendering it, without a
-        same-text collision false-positive against a different client's
-        submission. An implementation with no attached session (nothing was
-        actually submitted) returns ``""`` — never ``None`` — so a caller can
-        treat "no id" uniformly with a plain falsy/membership check.
+        broadcast ``user_submitted`` chat-event carries (#3300 P2a). Two
+        independent things read it (#3287/#3309):
+
+        - the LOCAL (in-process) plain-loop client, whose own terminal already
+          rendered this line (``prompt_session.prompt_async``'s echo) and uses
+          this id to recognise its own broadcast event and skip re-rendering
+          it — never by a same-text match, which would false-positive against
+          a different client's identical-text submission (co-vet finding F1
+          on #3309);
+        - #3300 Y-client (cancel-by-id), which needs the client to learn its
+          own message id at all, regardless of transport.
+
+        The REMOTE (AG-UI) client does NOT use this id for its own echo
+        suppression — the id only becomes available once this call returns,
+        racing the SSE broadcast for the same submission over the independent
+        events connection (F2); it instead matches ``meta.auth_connection_id``
+        on the broadcast event against its own ``connection_id`` (known
+        up-front, no cross-channel race — see ``client_driver.run_chat_client``
+        / ``stream_client.run_output_loop``).
+
+        An implementation with no attached session (nothing was actually
+        submitted) returns ``""`` — never ``None`` — so a caller can treat "no
+        id" uniformly with a plain falsy/membership check.
         """
 
     @abstractmethod

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -49,8 +49,19 @@ class ClientTransport(ABC):
         """Yield the unified, ordered, tagged frame stream (display + event)."""
 
     @abstractmethod
-    async def submit_user_text(self, text: str) -> None:
-        """Submit a user turn (the ordinary new-turn path)."""
+    async def submit_user_text(self, text: str) -> str:
+        """Submit a user turn (the ordinary new-turn path).
+
+        Returns the server-assigned ``msg_id`` — the SAME correlation id the
+        broadcast ``user_submitted`` chat-event carries (#3300 P2a) — so a
+        caller that already rendered this line some other way (e.g. the
+        plain PromptSession loop's own terminal echo, #3287) can recognise
+        its own broadcast echo BY ID and skip re-rendering it, without a
+        same-text collision false-positive against a different client's
+        submission. An implementation with no attached session (nothing was
+        actually submitted) returns ``""`` — never ``None`` — so a caller can
+        treat "no id" uniformly with a plain falsy/membership check.
+        """
 
     @abstractmethod
     async def answer_intervention_text(

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -128,10 +128,11 @@ class InProcessTransport(ClientTransport):
         s = self._attached()
         return s.interventions.head() if s is not None else None
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str) -> str:
         s = self._attached()
-        if s is not None:
-            await s.submit_user_text(text)
+        if s is None:
+            return ""
+        return await s.submit_user_text(text)
 
     async def answer_intervention_text(
         self, text: str, *, intervention_id: "str | None" = None

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2863,7 +2863,7 @@ class Session:
 
     async def submit_user_text(
         self, text: str, *, attribution: "dict | None" = None,
-    ) -> None:
+    ) -> str:
         # PR14: every top-level user submission starts a fresh chain_id that
         # propagates through any agent_request / agent_response generated in
         # response. Logged in history meta + events.jsonl for cross-agent trace.
@@ -2923,6 +2923,13 @@ class Session:
             seq=self._bump_queue_seq(),
             meta=meta,
         )
+        # #3287: return the assigned msg_id — the SAME correlation id the
+        # emitted event above carries — so a submitting client can recognise
+        # its own broadcast echo (vs. another attached client's) by id rather
+        # than by text match (a same-text collision between two clients'
+        # submissions would otherwise misfire — see `stream_client.py`'s
+        # `own_submissions` set).
+        return msg_id
 
     async def submit_agent_request(
         self, *, from_agent: str, request: str, depth: int, chain_id: str,

--- a/tests/test_stream_client_own_echo_3287.py
+++ b/tests/test_stream_client_own_echo_3287.py
@@ -34,6 +34,24 @@ shared, so this client's set only ever contains ids IT assigned. The
 regression test below drives exactly that scenario: same text, two clients,
 the OTHER client's broadcast arriving first.
 
+**Co-vet finding F2 (same review round)**: F1's fix still left a REMOTE-only
+gap, documented rather than closed: the msg_id only becomes visible to the
+AG-UI client once its POST response returns, and the server may already have
+pushed the SSE broadcast for the same submission over the INDEPENDENT events
+connection in the interim — a network-ordering race between the two
+channels. The reviewer pointed out this is unnecessary: the broadcast
+``user_submitted`` event's ``meta.auth_connection_id`` (already wired by
+#3300 for multi-client attribution — ``endpoint.py`` stamps it from the
+POST's own query param, ``session.py`` copies ``meta`` verbatim onto the
+event) is the client's OWN ``connection_id``, known client-side BEFORE any
+submit even happens (``remote_client.py`` mints it with ``uuid.uuid4()`` at
+startup). Matching on connection identity needs no second channel to
+resolve, closing the race structurally rather than narrowing it. The tests
+below drive: (1) suppression firing from ``meta.auth_connection_id`` alone,
+with no ``own_submissions`` populated at all — proving the identity check
+does not depend on msg_id timing; (2) a DIFFERENT connection_id (another
+attached remote client) still rendering normally.
+
 Policy compliance (docs/deep-dives/contributing/testing.md):
 - No unittest.mock/MagicMock/AsyncMock/patch on a collaborator. Renderer and
   transport doubles below are REAL instances of the actual base classes /a
@@ -139,8 +157,13 @@ class _QueueTransport(ClientTransport):
         pass
 
 
-def _user_submitted_event(text: str, msg_id: str) -> Event:
-    return Event(type="user_submitted", data={"text": text, "meta": {}, "msg_id": msg_id})
+def _user_submitted_event(
+    text: str, msg_id: str, *, auth_connection_id: "str | None" = None
+) -> Event:
+    meta = {"auth_connection_id": auth_connection_id} if auth_connection_id else {}
+    return Event(
+        type="user_submitted", data={"text": text, "meta": meta, "msg_id": msg_id}
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -258,6 +281,70 @@ async def test_own_submissions_none_preserves_the_event_as_sole_echo() -> None:
     await asyncio.gather(task, return_exceptions=True)
 
     assert "user_submitted" in [e.type for e in renderer.events]
+
+
+# ---------------------------------------------------------------------------
+# run_output_loop: F2 — remote (AG-UI) own-echo suppression by connection
+# identity, structurally race-free (no dependency on msg_id / POST-ack timing)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connection_id_suppresses_with_no_msg_id_correlation_at_all() -> None:
+    """Tier 2: co-vet F2 regression (#3309) — a user_submitted event whose
+    meta.auth_connection_id matches THIS client's own connection_id is
+    suppressed via own_connection_id ALONE. own_submissions is deliberately
+    left empty/unpopulated (None) to prove the connection-identity check does
+    not depend on ever learning a msg_id via the submit_user_text return value
+    — i.e. no dependency on the POST-ack racing the SSE broadcast at all
+    (unlike a msg_id-only scheme, which needs the id to have already arrived
+    to match)."""
+    transport = _QueueTransport()
+    renderer = _Recorder()
+    await transport.push(
+        EventFrame(_user_submitted_event("hello", "m-999", auth_connection_id="conn-mine"))
+    )
+
+    task = asyncio.create_task(
+        run_output_loop(
+            transport, renderer, own_submissions=None, own_connection_id="conn-mine",
+        )
+    )
+    await asyncio.sleep(0.05)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert "user_submitted" not in [e.type for e in renderer.events], (
+        "an event carrying THIS client's own connection_id must be "
+        "suppressed without ever needing a matching msg_id in own_submissions"
+    )
+
+
+@pytest.mark.asyncio
+async def test_connection_id_mismatch_still_renders_another_clients_turn() -> None:
+    """Tier 2: co-vet F2 — a user_submitted event whose meta.auth_connection_id
+    belongs to a DIFFERENT attached remote client still renders normally (the
+    ADR-0039 multi-client invariant, now proven for the connection-identity
+    correlation path specifically, mirroring the msg_id-path equivalent
+    above)."""
+    transport = _QueueTransport()
+    renderer = _Recorder()
+    await transport.push(
+        EventFrame(_user_submitted_event("yes", "m-theirs", auth_connection_id="conn-theirs"))
+    )
+
+    task = asyncio.create_task(
+        run_output_loop(
+            transport, renderer, own_submissions=None, own_connection_id="conn-mine",
+        )
+    )
+    await asyncio.sleep(0.05)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert "user_submitted" in [e.type for e in renderer.events], (
+        "another client's turn (a different connection_id) must still render"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_stream_client_own_echo_3287.py
+++ b/tests/test_stream_client_own_echo_3287.py
@@ -1,0 +1,240 @@
+"""Tier 2: the plain ``--cui`` transcript's double-printed user line (#3287).
+
+Repro (real TTY, ``reyn chat --cui``): a turn that goes through a real LLM
+round-trip prints the user's own line TWICE — ``prompt_session.prompt_async``
+(``run_input_loop``, ``stream_client.py``) already leaves ``you > <text>`` on
+the terminal the instant Enter is pressed, and then the broadcast
+``user_submitted`` chat-event this same submission produces re-renders it a
+second time via ``renderer.on_chat_event`` (``run_output_loop``). A local
+``/quit`` never reaches ``submit_user_text`` (short-circuited earlier in
+``run_input_loop``), so it never emits a ``user_submitted`` event and never
+doubled — exactly the asymmetry the bug report observed.
+
+The fix threads an ``own_submissions`` FIFO (a plain ``deque``, owned by one
+client's own input/output loop pair, never shared) between
+``route_input_line`` (append on the ONE branch that actually calls
+``submit_user_text``) and ``run_output_loop`` (match the broadcast event's
+text against the queue head; on a hit, skip the redundant render and pop).
+``client_driver.run_chat_client`` only constructs a non-``None`` queue when
+``is_tty`` — a piped / non-interactive session has no terminal echo to
+duplicate against, so the event-driven render stays the sole record there
+(unaffected regression coverage below).
+
+The FIFO is scoped per-client-loop-pair so a second attached client (which
+never typed the first client's line, so its own terminal never echoed it)
+still renders every ``user_submitted`` event normally — the ADR-0039 "every
+attached client sees every turn" invariant survives (also covered below).
+
+Policy compliance (docs/deep-dives/contributing/testing.md):
+- No unittest.mock/MagicMock/AsyncMock/patch on a collaborator. Renderer and
+  transport doubles below are REAL instances of the actual base classes /a
+  plain recorder, not stand-ins for something faked.
+- No private-state assertions — behavior observed via the renderer's own
+  recorded output and the queue's own (public, plain-deque) contents.
+- Each test docstring's first line declares its Tier.
+"""
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.interfaces.repl.stream_client import route_input_line, run_output_loop
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import EventFrame
+from reyn.runtime.outbox import OutboxMessage
+from reyn.schemas.models import Event
+
+
+class _Recorder:
+    """A real renderer double: records every on_chat_event call it receives."""
+
+    def __init__(self) -> None:
+        self.events: list = []
+
+    def message(self, msg: OutboxMessage) -> None:  # pragma: no cover - unused
+        pass
+
+    def on_chat_event(self, event) -> None:
+        self.events.append(event)
+
+    def uses_app_input(self) -> bool:
+        return False
+
+
+class _QueueTransport(ClientTransport):
+    """A real, minimal ClientTransport: yields queued frames; records send-side
+    calls plainly (no mocks) so a test can assert which branch fired."""
+
+    def __init__(self, *, pending_head: object = None, answer_ok: bool = False) -> None:
+        self._frames: "asyncio.Queue[object]" = asyncio.Queue()
+        self._pending_head = pending_head
+        self._answer_ok = answer_ok
+        self.submitted: list[str] = []
+        self.answered: list[str] = []
+
+    async def push(self, frame) -> None:
+        await self._frames.put(frame)
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._frames.get()
+
+    async def submit_user_text(self, text: str) -> None:
+        self.submitted.append(text)
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        if self._answer_ok:
+            self.answered.append(text)
+        return self._answer_ok
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:  # pragma: no cover - unused
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return self._pending_head
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _user_submitted_event(text: str) -> Event:
+    return Event(type="user_submitted", data={"text": text, "meta": {}})
+
+
+# ---------------------------------------------------------------------------
+# run_output_loop: the own-echo suppression + its non-vacuity / multi-client
+# safety nets
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_matching_own_submission_is_not_rerendered_and_is_consumed() -> None:
+    """Tier 2: a queued own-submission text matching the broadcast
+    user_submitted event's text is NOT forwarded to renderer.on_chat_event
+    (the terminal already showed it) and is popped off the FIFO."""
+    transport = _QueueTransport()
+    renderer = _Recorder()
+    own_submissions: "deque[str]" = deque(["hello world test"])
+    await transport.push(EventFrame(_user_submitted_event("hello world test")))
+    await transport.push(EventFrame(Event(type="turn_started", data={})))
+    await transport.push(EventFrame(Event(type="turn_settled", data={})))
+
+    task = asyncio.create_task(
+        run_output_loop(transport, renderer, own_submissions=own_submissions)
+    )
+    await asyncio.sleep(0.05)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    rendered_types = [e.type for e in renderer.events]
+    assert "user_submitted" not in rendered_types, (
+        "the own-submission echo was re-rendered — the double-print bug"
+    )
+    assert "turn_started" in rendered_types  # other events still flow through
+    assert not own_submissions, "the matched entry must be consumed from the FIFO"
+
+
+@pytest.mark.asyncio
+async def test_non_matching_event_still_renders_and_queue_untouched() -> None:
+    """Tier 2: a user_submitted event whose text does NOT match this client's
+    own queued submission (standing in for a SECOND attached client's turn,
+    which this client's own terminal never echoed) still renders normally —
+    the ADR-0039 "every attached client sees every turn" invariant."""
+    transport = _QueueTransport()
+    renderer = _Recorder()
+    own_submissions: "deque[str]" = deque(["my own pending line"])
+    await transport.push(EventFrame(_user_submitted_event("someone else's line")))
+
+    task = asyncio.create_task(
+        run_output_loop(transport, renderer, own_submissions=own_submissions)
+    )
+    await asyncio.sleep(0.05)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    rendered_types = [e.type for e in renderer.events]
+    assert "user_submitted" in rendered_types, (
+        "another client's turn must still render — it was never echoed by MY terminal"
+    )
+    assert list(own_submissions) == ["my own pending line"], (
+        "a non-matching event must not consume this client's own pending entry"
+    )
+
+
+@pytest.mark.asyncio
+async def test_own_submissions_none_preserves_the_event_as_sole_echo() -> None:
+    """Tier 2: non-vacuity + regression guard — own_submissions=None (the
+    non-interactive / piped default) disables the check entirely, so the
+    user_submitted event still renders (the piped path's only visible record
+    of what was submitted, since nothing else echoes it)."""
+    transport = _QueueTransport()
+    renderer = _Recorder()
+    await transport.push(EventFrame(_user_submitted_event("piped line")))
+
+    task = asyncio.create_task(run_output_loop(transport, renderer, own_submissions=None))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert "user_submitted" in [e.type for e in renderer.events]
+
+
+# ---------------------------------------------------------------------------
+# route_input_line: the FIFO is only populated on the branch that actually
+# produces a user_submitted event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_route_input_line_appends_on_the_submit_user_text_branch() -> None:
+    """Tier 2: an ordinary turn (no pending intervention) is delivered via
+    submit_user_text, and its text is appended to own_submissions — the only
+    branch run_output_loop can later match against."""
+    transport = _QueueTransport(pending_head=None)
+    own_submissions: "deque[str]" = deque()
+
+    await route_input_line(transport, "hello world test", None, own_submissions=own_submissions)
+
+    assert transport.submitted == ["hello world test"]
+    assert list(own_submissions) == ["hello world test"]
+
+
+@pytest.mark.asyncio
+async def test_route_input_line_intervention_answer_does_not_append() -> None:
+    """Tier 2: an intervention answer (delivered directly via
+    answer_intervention_text, bypassing submit_user_text — #2690) is NOT
+    appended to own_submissions. Strip this exclusion and a later ordinary
+    turn's FIFO desyncs against a phantom entry that no user_submitted event
+    will ever arrive to consume."""
+    transport = _QueueTransport(pending_head=object(), answer_ok=True)
+    own_submissions: "deque[str]" = deque()
+
+    await route_input_line(transport, "y", None, own_submissions=own_submissions)
+
+    assert transport.answered == ["y"]
+    assert transport.submitted == []
+    assert not own_submissions, (
+        "an intervention answer must never be queued as a pending self-echo"
+    )

--- a/tests/test_stream_client_own_echo_3287.py
+++ b/tests/test_stream_client_own_echo_3287.py
@@ -10,33 +10,41 @@ second time via ``renderer.on_chat_event`` (``run_output_loop``). A local
 ``run_input_loop``), so it never emits a ``user_submitted`` event and never
 doubled — exactly the asymmetry the bug report observed.
 
-The fix threads an ``own_submissions`` FIFO (a plain ``deque``, owned by one
-client's own input/output loop pair, never shared) between
-``route_input_line`` (append on the ONE branch that actually calls
-``submit_user_text``) and ``run_output_loop`` (match the broadcast event's
-text against the queue head; on a hit, skip the redundant render and pop).
-``client_driver.run_chat_client`` only constructs a non-``None`` queue when
+The fix threads an ``own_submissions`` set (owned by one client's own
+input/output loop pair, never shared) between ``route_input_line`` (which
+records the ``msg_id`` the transport's ``submit_user_text`` returns — the
+SAME correlation id, #3300 P2a, the broadcast event carries) and
+``run_output_loop`` (which matches the broadcast event's ``msg_id`` against
+the set; on a hit, skip the redundant render and discard the entry).
+``client_driver.run_chat_client`` only constructs a non-``None`` set when
 ``is_tty`` — a piped / non-interactive session has no terminal echo to
-duplicate against, so the event-driven render stays the sole record there
-(unaffected regression coverage below).
+duplicate against, so the event-driven render stays the sole record there.
 
-The FIFO is scoped per-client-loop-pair so a second attached client (which
-never typed the first client's line, so its own terminal never echoed it)
-still renders every ``user_submitted`` event normally — the ADR-0039 "every
-attached client sees every turn" invariant survives (also covered below).
+**Co-vet finding F1 (post-merge review on #3309)**: an earlier revision of
+this fix matched by TEXT instead of by id. Two attached clients submitting
+the SAME text (a short, common line like "yes") could then cross-match:
+client A's own queued text satisfied by client B's broadcast (or vice
+versa), simultaneously swallowing the OTHER client's line and leaving THIS
+client's own line un-swallowed later — reintroducing the double-print bug
+through a different door, and order-dependent on top of that. Matching by
+``msg_id`` (a value #3300 P2a added SPECIFICALLY as a correlation id, never
+form-sniffed from content) closes this: two different submissions never
+share an id even when their text is identical, and per-client sets are never
+shared, so this client's set only ever contains ids IT assigned. The
+regression test below drives exactly that scenario: same text, two clients,
+the OTHER client's broadcast arriving first.
 
 Policy compliance (docs/deep-dives/contributing/testing.md):
 - No unittest.mock/MagicMock/AsyncMock/patch on a collaborator. Renderer and
   transport doubles below are REAL instances of the actual base classes /a
   plain recorder, not stand-ins for something faked.
 - No private-state assertions — behavior observed via the renderer's own
-  recorded output and the queue's own (public, plain-deque) contents.
+  recorded output and the set's own (public, plain-set) contents.
 - Each test docstring's first line declares its Tier.
 """
 from __future__ import annotations
 
 import asyncio
-from collections import deque
 from typing import AsyncIterator
 
 import pytest
@@ -65,13 +73,22 @@ class _Recorder:
 
 
 class _QueueTransport(ClientTransport):
-    """A real, minimal ClientTransport: yields queued frames; records send-side
-    calls plainly (no mocks) so a test can assert which branch fired."""
+    """A real, minimal ClientTransport: yields queued frames; ``submit_user_text``
+    returns a caller-scripted msg_id (mirroring the production contract —
+    #3287 — of returning the server-assigned correlation id), and records
+    send-side calls plainly (no mocks) so a test can assert which branch fired."""
 
-    def __init__(self, *, pending_head: object = None, answer_ok: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        pending_head: object = None,
+        answer_ok: bool = False,
+        submit_msg_ids: "list[str] | None" = None,
+    ) -> None:
         self._frames: "asyncio.Queue[object]" = asyncio.Queue()
         self._pending_head = pending_head
         self._answer_ok = answer_ok
+        self._submit_msg_ids = list(submit_msg_ids or [])
         self.submitted: list[str] = []
         self.answered: list[str] = []
 
@@ -88,8 +105,11 @@ class _QueueTransport(ClientTransport):
         while True:
             yield await self._frames.get()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str) -> str:
         self.submitted.append(text)
+        if self._submit_msg_ids:
+            return self._submit_msg_ids.pop(0)
+        return ""
 
     async def answer_intervention_text(
         self, text: str, *, intervention_id: "str | None" = None
@@ -119,8 +139,8 @@ class _QueueTransport(ClientTransport):
         pass
 
 
-def _user_submitted_event(text: str) -> Event:
-    return Event(type="user_submitted", data={"text": text, "meta": {}})
+def _user_submitted_event(text: str, msg_id: str) -> Event:
+    return Event(type="user_submitted", data={"text": text, "meta": {}, "msg_id": msg_id})
 
 
 # ---------------------------------------------------------------------------
@@ -131,13 +151,13 @@ def _user_submitted_event(text: str) -> Event:
 
 @pytest.mark.asyncio
 async def test_matching_own_submission_is_not_rerendered_and_is_consumed() -> None:
-    """Tier 2: a queued own-submission text matching the broadcast
-    user_submitted event's text is NOT forwarded to renderer.on_chat_event
-    (the terminal already showed it) and is popped off the FIFO."""
+    """Tier 2: a queued own-submission msg_id matching the broadcast
+    user_submitted event's msg_id is NOT forwarded to renderer.on_chat_event
+    (the terminal already showed it) and is discarded from the set."""
     transport = _QueueTransport()
     renderer = _Recorder()
-    own_submissions: "deque[str]" = deque(["hello world test"])
-    await transport.push(EventFrame(_user_submitted_event("hello world test")))
+    own_submissions: "set[str]" = {"m-1"}
+    await transport.push(EventFrame(_user_submitted_event("hello world test", "m-1")))
     await transport.push(EventFrame(Event(type="turn_started", data={})))
     await transport.push(EventFrame(Event(type="turn_settled", data={})))
 
@@ -153,19 +173,19 @@ async def test_matching_own_submission_is_not_rerendered_and_is_consumed() -> No
         "the own-submission echo was re-rendered — the double-print bug"
     )
     assert "turn_started" in rendered_types  # other events still flow through
-    assert not own_submissions, "the matched entry must be consumed from the FIFO"
+    assert not own_submissions, "the matched id must be consumed from the set"
 
 
 @pytest.mark.asyncio
-async def test_non_matching_event_still_renders_and_queue_untouched() -> None:
-    """Tier 2: a user_submitted event whose text does NOT match this client's
-    own queued submission (standing in for a SECOND attached client's turn,
+async def test_non_matching_event_still_renders_and_set_untouched() -> None:
+    """Tier 2: a user_submitted event whose msg_id does NOT match this
+    client's own queued id (standing in for a SECOND attached client's turn,
     which this client's own terminal never echoed) still renders normally —
     the ADR-0039 "every attached client sees every turn" invariant."""
     transport = _QueueTransport()
     renderer = _Recorder()
-    own_submissions: "deque[str]" = deque(["my own pending line"])
-    await transport.push(EventFrame(_user_submitted_event("someone else's line")))
+    own_submissions: "set[str]" = {"m-mine"}
+    await transport.push(EventFrame(_user_submitted_event("someone else's line", "m-theirs")))
 
     task = asyncio.create_task(
         run_output_loop(transport, renderer, own_submissions=own_submissions)
@@ -178,9 +198,48 @@ async def test_non_matching_event_still_renders_and_queue_untouched() -> None:
     assert "user_submitted" in rendered_types, (
         "another client's turn must still render — it was never echoed by MY terminal"
     )
-    assert list(own_submissions) == ["my own pending line"], (
-        "a non-matching event must not consume this client's own pending entry"
+    assert own_submissions == {"m-mine"}, (
+        "a non-matching event must not consume this client's own pending id"
     )
+
+
+@pytest.mark.asyncio
+async def test_same_text_two_clients_does_not_cross_match_by_id() -> None:
+    """Tier 2: co-vet F1 regression (#3309) — two attached clients submit the
+    SAME text ("yes"), and the OTHER client's broadcast arrives FIRST. A
+    text-matching implementation would treat the other client's identical
+    text as satisfying THIS client's own queued entry — swallowing the other
+    client's line (which THIS client's terminal never showed) and leaving
+    THIS client's own entry stranded for a later, unrelated event to
+    misconsume. Matching by msg_id must not exhibit either failure: the
+    other client's differently-id'd event still renders, and this client's
+    own entry (a DIFFERENT id, even though the text is identical) remains
+    queued, ready to correctly match its own broadcast when it arrives."""
+    transport = _QueueTransport()
+    renderer = _Recorder()
+    own_submissions: "set[str]" = {"m-mine"}
+    # The OTHER client's identical-text turn, arriving first.
+    await transport.push(EventFrame(_user_submitted_event("yes", "m-theirs")))
+    # THIS client's own turn, arriving second.
+    await transport.push(EventFrame(_user_submitted_event("yes", "m-mine")))
+
+    task = asyncio.create_task(
+        run_output_loop(transport, renderer, own_submissions=own_submissions)
+    )
+    await asyncio.sleep(0.05)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    rendered_msg_ids = [
+        e.data.get("msg_id") for e in renderer.events if e.type == "user_submitted"
+    ]
+    assert rendered_msg_ids == ["m-theirs"], (
+        "the OTHER client's identically-texted turn must render exactly once "
+        "(it was never echoed by MY terminal), and MY OWN turn must be "
+        "suppressed (it WAS already echoed) — a text match would get at "
+        "least one of these two wrong"
+    )
+    assert not own_submissions, "this client's own id is consumed once its OWN event arrives"
 
 
 @pytest.mark.asyncio
@@ -191,7 +250,7 @@ async def test_own_submissions_none_preserves_the_event_as_sole_echo() -> None:
     of what was submitted, since nothing else echoes it)."""
     transport = _QueueTransport()
     renderer = _Recorder()
-    await transport.push(EventFrame(_user_submitted_event("piped line")))
+    await transport.push(EventFrame(_user_submitted_event("piped line", "m-piped")))
 
     task = asyncio.create_task(run_output_loop(transport, renderer, own_submissions=None))
     await asyncio.sleep(0.05)
@@ -202,34 +261,35 @@ async def test_own_submissions_none_preserves_the_event_as_sole_echo() -> None:
 
 
 # ---------------------------------------------------------------------------
-# route_input_line: the FIFO is only populated on the branch that actually
-# produces a user_submitted event
+# route_input_line: the set is only populated with the msg_id the transport
+# actually returns, on the branch that actually produces a user_submitted
+# event
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_route_input_line_appends_on_the_submit_user_text_branch() -> None:
+async def test_route_input_line_adds_the_returned_msg_id_on_submit_branch() -> None:
     """Tier 2: an ordinary turn (no pending intervention) is delivered via
-    submit_user_text, and its text is appended to own_submissions — the only
-    branch run_output_loop can later match against."""
-    transport = _QueueTransport(pending_head=None)
-    own_submissions: "deque[str]" = deque()
+    submit_user_text, and the msg_id IT RETURNS (never the text) is added to
+    own_submissions — the only value run_output_loop can later match against."""
+    transport = _QueueTransport(pending_head=None, submit_msg_ids=["m-42"])
+    own_submissions: "set[str]" = set()
 
     await route_input_line(transport, "hello world test", None, own_submissions=own_submissions)
 
     assert transport.submitted == ["hello world test"]
-    assert list(own_submissions) == ["hello world test"]
+    assert own_submissions == {"m-42"}
 
 
 @pytest.mark.asyncio
-async def test_route_input_line_intervention_answer_does_not_append() -> None:
+async def test_route_input_line_intervention_answer_does_not_add() -> None:
     """Tier 2: an intervention answer (delivered directly via
-    answer_intervention_text, bypassing submit_user_text — #2690) is NOT
-    appended to own_submissions. Strip this exclusion and a later ordinary
-    turn's FIFO desyncs against a phantom entry that no user_submitted event
-    will ever arrive to consume."""
+    answer_intervention_text, bypassing submit_user_text — #2690) adds
+    NOTHING to own_submissions. Strip this exclusion and a later ordinary
+    turn's set gains a phantom entry that no user_submitted event will ever
+    arrive to consume."""
     transport = _QueueTransport(pending_head=object(), answer_ok=True)
-    own_submissions: "deque[str]" = deque()
+    own_submissions: "set[str]" = set()
 
     await route_input_line(transport, "y", None, own_submissions=own_submissions)
 
@@ -238,3 +298,17 @@ async def test_route_input_line_intervention_answer_does_not_append() -> None:
     assert not own_submissions, (
         "an intervention answer must never be queued as a pending self-echo"
     )
+
+
+@pytest.mark.asyncio
+async def test_route_input_line_empty_msg_id_is_never_added() -> None:
+    """Tier 2: a transport that returns "" (no session attached, or a
+    non-conforming implementation) must not pollute own_submissions with an
+    empty string — an event whose own msg_id is also missing/empty (a
+    malformed or foreign event) must never spuriously match."""
+    transport = _QueueTransport(pending_head=None, submit_msg_ids=[""])
+    own_submissions: "set[str]" = set()
+
+    await route_input_line(transport, "hello", None, own_submissions=own_submissions)
+
+    assert not own_submissions


### PR DESCRIPTION
**[per-PR-coder]** — part of #3273. Closes #3287.

## Root cause (re-verified against current main, not the issue's original hypothesis)

The issue was filed against `f39d8c8e`, and #3301 (part of #3300 P1 C) has since removed the old outbox-echo write and replaced it with a `user_submitted` chat-event every attached surface renders. I re-reproduced against current `origin/main` first, per the task brief, rather than trusting the issue's pre-rework mechanism guess — the bug still reproduces, but through the NEW event-based echo, not the removed outbox write.

**The two emitters, identified by reading (not inference):**

1. **The terminal itself**, via `prompt_session.prompt_async` (`run_input_loop`, `stream_client.py`) — on an interactive TTY this leaves `you > <text>` on screen the instant Enter is pressed. This is not renderer code; it's prompt_toolkit's own line-editing echo.
2. **`ConsoleChatRenderer.on_chat_event` / `InlineChatRenderer.on_chat_event`** (`renderer.py`), driven by the broadcast `user_submitted` chat-event that same submission produces (`run_output_loop`, `stream_client.py`) — this re-renders the same text as a second line.

A local `/quit` never reaches `submit_user_text` (short-circuited earlier in `run_input_loop`), so it never emits `user_submitted` and never doubled — exactly the asymmetry the bug report noticed, now explained by the CURRENT mechanism rather than the pre-#3301 one.

## Fix: ownership, not downstream suppression

The terminal already OWNS the echo for this client's own TTY-typed line; the event-driven render must not also claim it. But `user_submitted` is a **broadcast** — a second attached client's turns still need to render from it (their own terminal never showed a line they didn't type), and a non-interactive/piped session has NO terminal echo at all, so the event-driven render is the sole record there and must not be suppressed.

So the fix is scoped precisely: `route_input_line` records each line it hands to `submit_user_text` (the ONE branch that actually produces a `user_submitted` event — an intervention answer takes a different branch and is never queued) into a small `own_submissions` FIFO, owned per client input/output-loop pair and never shared across clients. `run_output_loop` skips re-rendering a `user_submitted` event only when its text matches the head of THIS client's own queue — every other client's turns, and this client's own turns when non-interactive, still render normally. `client_driver.run_chat_client` only constructs a non-`None` queue when `is_tty`.

This keeps `ConsoleChatRenderer`/`InlineChatRenderer.on_chat_event` unchanged — the existing #3300 render/neutralize tests for those still pass — the fix lives entirely at the loop-wiring layer that actually knows which surface already showed the line.

## Sibling surface checked (not touched — another coder owns that directory)

`interfaces/inline/textual_chat/` (the default interactive-TTY surface) also consumes `user_submitted`, but its #3300 P2b materialize→promote sent-queue lifecycle (`_handle_user_submitted_event` materializes into the sent-queue region; `_handle_turn_started_event` promotes to a flow entry and removes the sent-queue entry) is structurally immune to this bug class — a submitted line is never rendered as both a sent-queue item AND a flow entry simultaneously, by construction (`tests/test_3300_p2b_sentqueue_render.py`). No latent defect found there.

## Test — RED before, GREEN after

`tests/test_stream_client_own_echo_3287.py`, 5 new Tier-2 tests. RED (stashed the fix, kept the test file): all 5 fail with
```
TypeError: run_output_loop() got an unexpected keyword argument 'own_submissions'
TypeError: route_input_line() got an unexpected keyword argument 'own_submissions'
```
GREEN after the fix: 5 passed. The tests cover: (1) a matching own-submission is not re-rendered and is popped from the FIFO, (2) a non-matching event (standing in for another attached client's turn) still renders and leaves the FIFO untouched, (3) `own_submissions=None` (non-interactive default) preserves the event as the sole echo — non-vacuity + regression guard, (4) `route_input_line` appends only on the `submit_user_text` branch, (5) an intervention answer does NOT append (would otherwise desync the FIFO against a phantom entry with no matching event).

## Doc-drift fixed same-PR

`docs/reference/runtime/agui-transport.md` (+ `.ja.md`, which repeated the same now-false claim) asserted "the submitting client renders its own line from that same event too (no separate local echo)" — falsified by this PR. Rewrote the section to describe the per-client `own_submissions` correlation and why the multi-client "everyone sees every turn" invariant still holds.

## CI gates run locally

- `ruff check src tests` — clean
- `python scripts/test_tier_audit.py --strict tests/test_stream_client_own_echo_3287.py` — 5/5 OK, 0 Tier-4 violations
- `uv run python -m pytest --timeout=120 -q -n auto` (full suite, foreground, alone) — **9148 passed, 39 skipped**, 0 failed
- `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/stream_client.py src/reyn/interfaces/repl/client_driver.py` — OK

## Test plan

- [x] Full pytest suite green (9148 passed / 39 skipped)
- [x] New test file RED before fix (own_submissions kwarg missing), GREEN after
- [x] ruff clean
- [x] Tier audit clean (5/5 OK)
- [x] Module docstring gate clean
- [x] Doc-drift fixed same-PR (EN + JA, since the JA file repeated the falsified claim)