### PR TITLE
fix(tui): tab-ify intervention panel — #3299 P5 (#3308)

### DIFF
--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -430,10 +430,15 @@ off the `STATE_*` view above.
 intervention answer (`InterventionHandler.deliver_answer_to` — the one funnel
 every answer path shares: TUI free-text, the Textual TUI's grouped
 intervention panel (`reyn.interfaces.inline.textual_chat.intervention_panel`,
-#3299 P1 — a closed-set `RadioSet` / free-text `Input` between the
-conversation and the input row, replacing the earlier in-flow chip surface),
-an A2A peer, and the AG-UI HITL round-trip above) puts a `kind="user"` frame on
-`session.outbox`, fanning out through `OutboxHub` to every attached surface.
+#3299 P1/P2, tab-ified #3308 P5 — one tab per PENDING intervention, each a
+closed-set `RadioSet` or free-text `Input`, between the conversation and the
+input row, replacing the earlier in-flow chip surface; answering a tab
+delivers targeted at THAT intervention's id — R1 by-id delivery — and marks
+it ✓/inert without removing it, so several simultaneously-outstanding
+interventions are each independently answerable, in any order, without one
+displacing another), an A2A peer, and the AG-UI HITL round-trip above) puts a
+`kind="user"` frame on `session.outbox`, fanning out through `OutboxHub` to
+every attached surface.
 A submitted turn (`Session.submit_user_text`) instead emits a
 `user_submitted` chat-event (#3300 P1 C — replacing an earlier outbox-echo
 write, a category error: an INPUT written into the display/OUTPUT channel)

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -168,39 +168,48 @@ class TextualChatApp(App):
     REMOTE read model returns an empty log (frame-sufficiency: past turns are not
     on the wire) → hydration is a no-op and the pane starts blank as before.
 
-    #3299 P1 moves intervention interaction OUT of the FlowView into a grouped
+    #3299 P1 moved intervention interaction OUT of the FlowView into a grouped
     :class:`~reyn.interfaces.inline.textual_chat.intervention_panel.InterventionPanel`
     widget between the flow and the input row (atomic display-swap +
-    input-swap + chip-retire — see :meth:`_present_intervention`'s docstring):
-    a ``kind="intervention"`` frame arriving on the pump (:meth:`_ingest_frame`)
-    appends a THIN pending flow placeholder and, if the panel is idle, populates
-    + auto-focuses it — a :class:`~textual.widgets.RadioSet` for a closed-set
-    intervention (``meta["choices"]``), a plain :class:`~textual.widgets.Input`
-    otherwise. Only this hidden→shown transition pre-highlights the RadioSet's
-    FIRST option (#3299 P2 owner decision (A): a blind ``Enter`` answers it) —
-    the multi-pending FIFO re-route (:meth:`_resolve_pending_intervention`
-    swapping in the NEXT queued intervention while the panel stays visible)
-    does NOT pre-highlight (#3299 P2 co-vet fix, see :meth:`_show_intervention`'s
-    ``initial`` docstring: pre-highlighting an intervention the user never
-    actually looked at risks a muscle-memory second ``Enter`` confirming a
-    default option — an accidental permission grant, since an intervention can
-    be a permission gate). Selecting/submitting in the panel
+    input-swap + chip-retire — see :meth:`_present_intervention`'s docstring).
+    P2 gave the panel FIFO re-route (resolving the displayed intervention
+    swapped the next queued one into the SAME form); #3308 (P5) replaces that
+    re-route with TABS — one :class:`~textual.widgets.TabPane` per PENDING
+    intervention, added the moment its frame arrives
+    (:meth:`_present_intervention` → ``InterventionPanel.add_pending``) and
+    never swapped out from under the user. A ``kind="intervention"`` frame
+    arriving on the pump (:meth:`_ingest_frame`) appends a THIN pending flow
+    placeholder and adds a new tab to the panel — a
+    :class:`~textual.widgets.RadioSet` for a closed-set intervention
+    (``meta["choices"]``), a plain :class:`~textual.widgets.Input` otherwise.
+    The panel's OWN ``TabbedContent`` semantics give the "only steal focus
+    while idle" invariant for free: a new tab auto-activates only when the
+    panel was hidden (nothing pending before this arrival); while another
+    intervention is already showing, the new tab is added WITHOUT moving the
+    active selection (never stealing it from a tab the user is already
+    looking at — the F1-class accident class this PR closes structurally,
+    see the panel module's docstring). Pre-highlighting the RadioSet's FIRST
+    option (#3299 P2 owner decision (A): a blind ``Enter`` answers it) is now
+    UNCONDITIONAL on every tab activation — first show AND every explicit
+    tab switch alike (#3308 §5) — since the P2 re-route accident this
+    conditional once guarded against no longer exists (the active tab never
+    moves except by explicit user navigation). Selecting/submitting in a tab
     (:meth:`on_intervention_panel_choice_selected` /
     :meth:`on_intervention_panel_text_submitted`) delivers the answer through
     the UNCHANGED transport funnel (``answer_intervention_choice`` /
-    ``answer_intervention_text``) — targeted at the id of the intervention the
-    panel is CURRENTLY DISPLAYING (#3299 P2, R1 by-id delivery: with
-    ``outstanding_interventions`` holding multiple pending entries, the head is
-    not necessarily the one on screen — see :meth:`_present_intervention` /
-    :meth:`_resolve_pending_intervention`) — resolves that SAME flow entry
-    in place to a "✓ answered" record (:meth:`_resolve_pending_intervention`),
-    and either re-populates the panel with the NEXT pending intervention (FIFO)
-    or hides it and returns focus to the Composer. ``Esc``/``Tab`` inside the
+    ``answer_intervention_text``) targeted at THAT tab's intervention id
+    (#3299 P2, R1 by-id delivery — the message itself carries which pending
+    entry it came from, so there is no ambiguous "currently displayed" state
+    to track at the app level anymore), resolves that SAME flow entry in
+    place to a "✓ answered" record (:meth:`_resolve_intervention`) and marks
+    the tab ✓-answered + inert — but the tab STAYS (never removed) until
+    EVERY pending intervention has resolved, at which point the whole panel
+    collapses (:meth:`_resolve_intervention`). ``Esc``/``Tab`` inside the
     panel (:meth:`on_intervention_panel_dismissed`) return focus to the
-    Composer WITHOUT answering — the intervention stays pending (the #3300
-    sent-queue durably holds any new Composer submit while it does; no
-    black-hole guard is needed here, see the PR body). The Composer itself is
-    now EXCLUSIVELY for new turns — it no longer reads
+    Composer WITHOUT answering — no intervention's state changes (the #3300
+    sent-queue durably holds any new Composer submit while any stay pending;
+    no black-hole guard is needed here, see the PR body). The Composer itself
+    is now EXCLUSIVELY for new turns — it no longer reads
     ``pending_intervention_head()`` at all.
     """
 
@@ -319,17 +328,15 @@ class TextualChatApp(App):
         # multi-entry structure by design, e.g. restore's FIFO re-enqueue),
         # keyed by intervention id (falling back to a synthetic per-entry key
         # when a frame carries no id, so tracking never breaks — delivery then
-        # stays head-targeted for that entry, matching pre-P2 behavior).
-        # Each value is ``(entry, msg, intervention_id | None)`` — the flow
-        # entry :meth:`_resolve_pending_intervention` updates IN PLACE, the
-        # original frame (to re-populate the panel if this becomes the
-        # DISPLAYED one later), and the real id to target at the transport
-        # (``None`` disables by-id targeting for that entry).
-        self._pending_ivs: "dict[object, tuple[Entry[OutboxMessage], OutboxMessage, str | None]]" = {}
-        # The key (in ``_pending_ivs``) of the intervention the panel is
-        # CURRENTLY DISPLAYING — ``None`` when the panel is idle. Answers
-        # always target THIS one (by-id, #3299 P2 R1), never "the head".
-        self._iv_current_key: "object | None" = None
+        # falls back to head-targeted for that entry, matching pre-P2
+        # behavior). Each value is ``(entry, intervention_id | None)`` — the
+        # flow entry :meth:`_resolve_intervention` updates IN PLACE, and the
+        # real id to target at the transport (``None`` disables by-id
+        # targeting for that entry). #3308 (P5) drops the THIRD P2 tuple slot
+        # (the original frame, kept only to re-populate a re-routed panel) —
+        # tabs never re-populate, each pending intervention keeps its own
+        # tab for its whole pending lifetime, so there is nothing to replay.
+        self._pending_ivs: "dict[object, tuple[Entry[OutboxMessage], str | None]]" = {}
         # #3300 P2b: the client-side sent-queue model — the SAME seq-gated
         # merge P2a built (``RemoteQueueView``, reused as-is, not
         # reinvented) driving BOTH the local and remote transport, since the
@@ -635,83 +642,43 @@ class TextualChatApp(App):
     def _present_intervention(
         self, msg: "OutboxMessage", entry: "Entry[OutboxMessage]"
     ) -> None:
-        """Route a newly-arrived intervention frame to the panel (#3299 P1/P2).
+        """Route a newly-arrived intervention frame to the panel (#3299 P1/P2,
+        tab-ified #3308 P5).
 
         The flow ``entry`` stays a THIN pending placeholder (the presenter
         renders prompt + a dim "respond below" hint, never chips — see
         :meth:`~reyn.interfaces.inline.textual_chat.presenter.ReynPresenter._present_intervention_pending`);
         the interactive form (closed-set select / free-text input) lives
-        entirely in :attr:`_iv_panel`.
+        entirely in its OWN tab inside :attr:`_iv_panel`.
 
-        Multi-pending (#3299 P2): ``outstanding_interventions`` can hold
-        SEVERAL pending entries at once (e.g. restore's FIFO re-enqueue), so
-        every arriving intervention is tracked in :attr:`_pending_ivs`
-        (keyed by its id) regardless of display order. Only when the panel is
-        currently IDLE (no intervention displayed) does this one populate +
-        auto-focus it; otherwise it queues behind whichever intervention the
-        panel already shows, and is displayed later by
-        :meth:`_resolve_pending_intervention`'s re-route. This is still an
-        ATOMIC swap with the retired in-flow chips: display and input
-        (:meth:`on_intervention_panel_choice_selected` /
+        Multi-pending (#3299 P2, tab-ified #3308): ``outstanding_interventions``
+        can hold SEVERAL pending entries at once (e.g. restore's FIFO
+        re-enqueue), so every arriving intervention is tracked in
+        :attr:`_pending_ivs` (keyed by its id) AND gets its own tab
+        (``InterventionPanel.add_pending``) regardless of display order. The
+        panel's own ``TabbedContent`` auto-activates a new tab ONLY when it
+        was previously empty (verified against the installed Textual 8.2.8 —
+        see the panel module's docstring), so an arrival while another
+        intervention is already showing never steals the active tab. This is
+        still an ATOMIC swap with the retired in-flow chips: display and
+        input (:meth:`on_intervention_panel_choice_selected` /
         :meth:`on_intervention_panel_text_submitted`) moved together, so there
         is never a moment where both the panel AND a chip/composer-match path
         are live for the same intervention."""
         meta = msg.meta or {}
         iv_id = meta.get("intervention_id")
         key: object = iv_id if iv_id else id(entry)
-        self._pending_ivs[key] = (entry, msg, iv_id)
-        if self._iv_current_key is None:
-            # The panel is IDLE — this is the hidden→shown transition, the
-            # ONLY case that pre-highlights (#3299 P2 co-vet fix, see
-            # ``_show_intervention``'s ``initial`` docstring).
-            self._show_intervention(key, initial=True)
-
-    def _show_intervention(self, key: object, *, initial: bool) -> None:
-        """Populate + auto-focus the panel with the intervention tracked under
-        ``key``, marking it the CURRENTLY DISPLAYED one — the target of the
-        next answer (#3299 P2, R1 by-id delivery).
-
-        ``initial`` (#3299 P2 co-vet fix, architect-agreed "safe side" call):
-        whether this is the panel's hidden→shown transition (``True`` — the
-        ONLY caller is :meth:`_present_intervention` when the panel was
-        idle) or the multi-pending FIFO re-route
-        (:meth:`_resolve_pending_intervention` swapping in the next queued
-        intervention while the panel stays visible/focused, ``False``).
-        Threaded straight to ``InterventionPanel.show_choice``'s
-        ``pre_highlight`` — a re-route must NOT pre-highlight index 0: the
-        panel was already focused for a DIFFERENT intervention the user
-        actually looked at, so a muscle-memory second ``Enter`` after
-        answering that first one must not confirm a default option (often
-        "Yes"/"Allow") on the second intervention the user never requested
-        (an accidental permission grant, not a UX shortcut — deterministic on
-        the CALL SITE, not a timing heuristic)."""
-        entry, msg, _iv_id = self._pending_ivs[key]
-        self._iv_current_key = key
-        meta = msg.meta or {}
+        self._pending_ivs[key] = (entry, iv_id)
         prompt = str(meta.get("prompt") or msg.text or "")
         detail = meta.get("detail")
         choices = meta.get("choices")
-        if choices:
-            self._iv_panel.show_choice(
-                prompt=prompt, detail=detail, choices=choices, pre_highlight=initial
-            )
-        else:
-            self._iv_panel.show_text(prompt=prompt, detail=detail)
+        self._iv_panel.add_pending(key, prompt=prompt, detail=detail, choices=choices)
 
-    def _current_intervention_id(self) -> "str | None":
-        """The real ``intervention_id`` of the panel's CURRENTLY DISPLAYED
-        intervention (``None`` if unknown/untracked — the transport then falls
-        back to head-targeted delivery, matching pre-P2 behavior for a frame
-        that carried no id)."""
-        if self._iv_current_key is None:
-            return None
-        return self._pending_ivs[self._iv_current_key][2]
-
-    def _resolve_pending_intervention(self, answer_label: str) -> None:
-        """Settle the CURRENTLY DISPLAYED intervention's flow entry + panel
-        once an answer has been delivered through the transport funnel, then
-        re-route the panel to the NEXT pending intervention if one is queued
-        (#3299 P2 FIFO re-route) — never blank/lose it.
+    def _resolve_intervention(self, key: object, answer_label: str) -> None:
+        """Settle intervention ``key``'s flow entry + tab once an answer has
+        been delivered through the transport funnel (#3308 — replaces P2's
+        single-form FIFO re-route: the tab STAYS, ✓-marked and inert, rather
+        than being swapped out for the next pending one).
 
         The SAME entry is updated in place (churn-zero, #3299 P2 §4) to a
         ``✓ answered: <label>`` record
@@ -721,62 +688,63 @@ class TextualChatApp(App):
         neither an outcome to celebrate nor a failure, the #3296
         don't-fabricate-a-classification lesson) and not ``RUNNING`` (would
         trip the #72 orphan-sweep + the ② live-spinner, and an intervention is
-        not a tool). If no other intervention is pending, the panel hides and
-        focus returns to the Composer — the resolved leg of the focus
-        lifecycle (pending → panel auto-focus, Esc/Tab → Composer, resolved →
-        Composer)."""
-        key = self._iv_current_key
-        self._iv_current_key = None
-        self._iv_panel.hide()
-        resolved = self._pending_ivs.pop(key, None) if key is not None else None
+        not a tool). Only once EVERY pending intervention has resolved does
+        the panel collapse and focus return to the Composer — the resolved
+        leg of the focus lifecycle (pending → panel auto-focus, Esc/Tab →
+        Composer, all-resolved → Composer)."""
+        self._iv_panel.mark_answered(key, answer_label)
+        resolved = self._pending_ivs.pop(key, None)
         if resolved is not None:
-            entry, _msg, _iv_id = resolved
+            entry, _iv_id = resolved
             meta = entry.item.meta or {}
             entry.set_item(replace(entry.item, meta={**meta, "_answer_label": answer_label}))
             entry.set_state(EntryState.DEFAULT)
         if self._pending_ivs:
-            # FIFO re-route (#3299 P2) — ``initial=False``: no pre-highlight
-            # (see ``_show_intervention``'s docstring for why).
-            self._show_intervention(next(iter(self._pending_ivs)), initial=False)
-        else:
-            self.query_one(Composer).focus()
+            # Other tabs are still pending — the panel (and whichever tab was
+            # active) stays exactly as it was; no re-route (#3308).
+            return
+        self._iv_panel.collapse_all()
+        self.query_one(Composer).focus()
 
     async def on_intervention_panel_choice_selected(
         self, event: "InterventionPanel.ChoiceSelected"
     ) -> None:
-        """A closed-set option was picked in the panel: deliver its id through
+        """A closed-set option was picked in one tab: deliver its id through
         the UNCHANGED transport funnel (``answer_intervention_choice`` —
         ``InterventionHandler.deliver_answer_to`` under the hood, the SAME
         funnel every answer path — TUI, A2A peer, AG-UI HITL — shares),
-        targeted at the CURRENTLY DISPLAYED intervention's id (#3299 P2, R1 —
-        never the head, which a second pending intervention could have made
-        stale between display and answer). This is the F1 permission-band
+        targeted at THAT tab's intervention id (#3299 P2, R1 — the event
+        itself carries ``event.key``, identifying exactly which pending
+        intervention this is; #3308 removes the need for an app-level
+        "currently displayed" key entirely). This is the F1 permission-band
         reachability witness, restored through the panel instead of a chip
         click."""
+        _entry, iv_id = self._pending_ivs.get(event.key, (None, None))
         await self._transport.answer_intervention_choice(
-            event.choice_id, intervention_id=self._current_intervention_id()
+            event.choice_id, intervention_id=iv_id
         )
-        self._resolve_pending_intervention(event.label)
+        self._resolve_intervention(event.key, event.label)
 
     async def on_intervention_panel_text_submitted(
         self, event: "InterventionPanel.TextSubmitted"
     ) -> None:
-        """A free-text answer was submitted in the panel's Input: deliver it
+        """A free-text answer was submitted in one tab's Input: deliver it
         through the UNCHANGED ``answer_intervention_text`` transport funnel,
-        targeted at the CURRENTLY DISPLAYED intervention's id (#3299 P2, R1)."""
-        await self._transport.answer_intervention_text(
-            event.text, intervention_id=self._current_intervention_id()
-        )
-        self._resolve_pending_intervention(event.text)
+        targeted at THAT tab's intervention id (#3299 P2, R1; #3308 by
+        ``event.key``, same as the choice path)."""
+        _entry, iv_id = self._pending_ivs.get(event.key, (None, None))
+        await self._transport.answer_intervention_text(event.text, intervention_id=iv_id)
+        self._resolve_intervention(event.key, event.text)
 
     def on_intervention_panel_dismissed(
         self, event: "InterventionPanel.Dismissed"
     ) -> None:
         """Esc/Tab inside the panel: return focus to the Composer WITHOUT
-        answering — the escape hatch of the focus lifecycle. The intervention
-        stays pending (the panel stays open); a new Composer submit durably
-        queues on the inbox rather than black-holing (#3300's sent-queue —
-        see the PR body for why #3299 needs no guard of its own here)."""
+        answering — the escape hatch of the focus lifecycle. Every pending
+        intervention stays exactly as it was (the panel stays open); a new
+        Composer submit durably queues on the inbox rather than black-holing
+        (#3300's sent-queue — see the PR body for why #3299 needs no guard of
+        its own here)."""
         self.query_one(Composer).focus()
 
     def _ingest_frame(self, msg: "OutboxMessage") -> None:

--- a/src/reyn/interfaces/inline/textual_chat/intervention_panel.py
+++ b/src/reyn/interfaces/inline/textual_chat/intervention_panel.py
@@ -1,39 +1,72 @@
-"""``InterventionPanel`` — the grouped panel widget for intervention answers.
+"""``InterventionPanel`` — the tab-ified grouped panel widget for intervention
+answers.
 
-#3299 P1 moves intervention interaction OUT of the FlowView (which was
-append-only history rendering the interaction as in-flow clickable chips) and
-INTO a bordered panel widget sitting between the flow and the input row. This
-is an ATOMIC swap (display + input + chip-retire together — see the app/
-presenter module docstrings for the coupling rationale): the panel is now the
-ONLY place a pending intervention is answered.
+#3299 P1 moved intervention interaction OUT of the FlowView and INTO a
+bordered panel widget between the flow and the input row. P1/P2 gave the
+panel a SINGLE form that either showed the head-of-queue intervention (P1) or
+re-routed in place to the next queued one on resolve (P2, FIFO). #3308 (P5)
+replaces that single-form re-route with a :class:`~textual.widgets.TabbedContent`:
+every PENDING intervention gets its own :class:`~textual.widgets.TabPane`
+(title + optional detail + its own :class:`~textual.widgets.RadioSet` /
+:class:`~textual.widgets.Input`), added the moment its frame arrives
+(:meth:`add_pending`) and never swapped out from under the user.
 
-The panel shows a title (the intervention prompt) + optional detail, and one
-of two native Textual forms:
+This is a STRUCTURAL fix for an accident the P2 re-route could still produce:
+resolving the displayed intervention re-populated the SAME form in place, so
+a user's muscle-memory second ``Enter`` right after answering could land on
+an unread SECOND intervention's default option — an accidental permission
+grant, since an intervention can be a permission gate (P2's ``pre_highlight``
+flag suppressed the immediate symptom, but the re-route itself remained).
+With tabs, answering a tab never moves the ACTIVE tab (Textual's own
+``TabbedContent.add_pane`` only auto-activates a newly added pane when the
+content was previously EMPTY — verified against the installed Textual
+8.2.8, see :meth:`add_pending`'s docstring), so a second ``Enter`` after
+resolving lands on the SAME (now-inert, ✓-marked) tab and delivers nothing.
 
-- **closed-set** (the frame carries ``meta["choices"]``) — a
-  :class:`~textual.widgets.RadioSet` of the options, native ``↑``/``↓`` +
-  ``Enter`` selection.
-- **free-text** (no choices) — a plain :class:`~textual.widgets.Input`.
+**Invariant** (the one that must never regress): the ACTIVE tab moves ONLY
+on an explicit user navigation (``Left``/``Right`` or a tab click) or on the
+panel's hidden→shown transition (the first pending intervention while the
+panel was idle). A new arrival while another intervention is already showing
+is added as an inert background tab — never stealing the active selection.
+
+**Answered tabs are never removed** — they stay, labelled with a ``✓``
+prefix, their form ``disabled``, until the LAST pending intervention resolves
+(:meth:`collapse_all`, called by the app once ``_pending_ivs`` is empty). The
+Q→A record itself lives in the flow entry (churn-zero, #3299 P2 §4), so
+nothing is lost when the panel eventually collapses.
+
+**Keymap** (co-vet-corrected, #3308 issue comment — the original "no
+conflict" claim was wrong): ``RadioSet`` already binds ``left``/``right`` as
+aliases for ``up``/``down`` (Textual 8.2.8, ``down,right → next_button`` /
+``up,left → previous_button``), so a naive ancestor binding on this panel for
+``Left``/``Right`` would never fire while focus is inside a focused
+``RadioSet`` — the focused widget's OWN binding wins in Textual's normal
+focused-widget-outward walk. The fix is Textual's PRIORITY bindings
+(``Binding(..., priority=True)``): ``App._check_bindings`` runs a priority
+pass FIRST, checked from the outermost ancestor down to the focused widget
+(``textual/app.py`` ~L3966-3988, ~L4136; ``textual/screen.py`` ~L407-455),
+and only ``priority=True`` bindings participate in that pass — so a
+priority binding on THIS panel is matched before the walk ever reaches the
+focused ``RadioSet``'s own (non-priority) binding for the same key. Declared
+here (not on ``RadioSet``/``TabbedContent`` themselves, which stay untouched)
+as ``action_prev_tab``/``action_next_tab``. ``RadioSet`` option navigation is
+now ``Up``/``Down`` only (its own ``Left``/``Right`` aliases are shadowed by
+this priority binding whenever focus is inside this panel — a deliberate,
+uniform loss of a redundant alias, not a functional regression, since
+``Up``/``Down`` already do the same thing).
+
+``Esc``/``Tab`` (unchanged from P1/P2): return focus to the Composer WITHOUT
+answering. Declared as widget-level (non-priority) ``BINDINGS`` so Textual's
+ordinary focused-widget-outward resolution finds them on this ancestor before
+``Screen``'s default ``tab``→``focus_next``.
 
 Selecting an option / submitting text posts a message
-(:class:`InterventionPanel.ChoiceSelected` / :class:`InterventionPanel.TextSubmitted`)
-that the app relays through the UNCHANGED transport funnel
-(``answer_intervention_choice`` / ``answer_intervention_text`` —
-``InterventionHandler.deliver_answer_to`` under the hood, the SAME funnel
-every answer path shares). This widget never touches the transport itself —
-that seam stays in exactly one place (the app), matching every other send
-path in this package.
-
-Focus lifecycle (mirrors the Phase-3 drawer's deterministic focus-flow): a
-pending intervention auto-focuses the panel's form (blocking — answer now);
-``Esc``/``Tab`` return focus to the Composer WITHOUT answering (an escape
-hatch — the intervention stays pending, the panel stays open); a resolved
-answer collapses the panel and returns focus to the Composer. ``Esc``/``Tab``
-are declared as widget-level ``BINDINGS`` (not raw ``_on_key`` interception)
-so Textual's own focused-widget-outward binding-chain resolution finds them
-on this ancestor before falling through to ``Screen``'s default
-``tab``→``focus_next`` (neither ``RadioSet`` nor ``Input`` bind ``escape`` or
-``tab`` themselves, so nothing upstream swallows the key first).
+(:class:`InterventionPanel.ChoiceSelected` / :class:`InterventionPanel.TextSubmitted`),
+each carrying the ``key`` identifying WHICH pane/intervention it came from
+(the same key :class:`~reyn.interfaces.inline.textual_chat.app.TextualChatApp`
+tracks in ``_pending_ivs``) — the app relays it through the UNCHANGED
+transport funnel (``answer_intervention_choice`` / ``answer_intervention_text``,
+targeted by id). This widget never touches the transport itself.
 
 This module is part of the TTY-only ``textual_chat`` package (imported lazily
 via :mod:`reyn.interfaces.repl.client_driver`); its ``textual`` imports never
@@ -43,23 +76,47 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
 from textual.content import Content
 from textual.message import Message
-from textual.widgets import Input, RadioButton, RadioSet, Static
+from textual.widgets import (
+    Input,
+    RadioButton,
+    RadioSet,
+    Static,
+    TabbedContent,
+    TabPane,
+    Tabs,
+)
 
 from .presenter import _neutralized_label
 
 if TYPE_CHECKING:
-    pass
+    from textual.widget import Widget
+
+#: Tab-bar labels are kept compact — the full (neutralized) prompt is still
+#: the pane BODY's title Static, this is only the tab strip's short caption.
+#: A long LLM-authored prompt would otherwise blow out the tab bar.
+_TAB_LABEL_MAX = 28
+
+
+def _tab_label(prompt: str, *, answered: bool) -> Content:
+    """The tab-bar caption for one intervention — ``Content(...)`` (the
+    LITERAL constructor, never a bare ``str``, #3299's bracket-eating markup
+    bug — see :meth:`InterventionPanel.add_pending`'s neutralization note),
+    ✓-prefixed once answered (#3308 §4)."""
+    head = prompt
+    if len(head) > _TAB_LABEL_MAX:
+        head = head[: _TAB_LABEL_MAX - 1] + "…"
+    return Content(("✓ " if answered else "") + head)
 
 
 class InterventionPanel(Vertical):
-    """Bordered panel between the FlowView and the input row, surfacing the
-    ONE pending intervention as a focusable form. Collapsed (``display=False``)
-    when nothing is pending — the default state until :meth:`show_choice` /
-    :meth:`show_text` is called."""
+    """Bordered panel between the FlowView and the input row. One TabPane per
+    PENDING intervention (#3308); collapsed (``display=False``) only while
+    NOTHING is pending — the default state until the first :meth:`add_pending`."""
 
     DEFAULT_CSS = """
     InterventionPanel {
@@ -68,11 +125,17 @@ class InterventionPanel(Vertical):
         padding: 0 1;
         margin-top: 1;
     }
-    InterventionPanel #iv-panel-title {
+    InterventionPanel TabbedContent {
+        height: auto;
+    }
+    InterventionPanel Tabs {
+        height: auto;
+    }
+    InterventionPanel .iv-pane-title {
         text-style: bold;
         color: $warning;
     }
-    InterventionPanel #iv-panel-detail {
+    InterventionPanel .iv-pane-detail {
         color: $text-muted;
     }
     InterventionPanel RadioSet {
@@ -82,205 +145,250 @@ class InterventionPanel(Vertical):
     }
     """
 
-    #: Declared here (not raw ``_on_key``) so Textual's binding-chain
-    #: resolution — which walks from the FOCUSED widget (the RadioSet/Input
-    #: inside this panel) outward through its ancestors — finds this binding
-    #: on the panel before it ever reaches ``Screen``'s own default
-    #: ``tab``→``focus_next`` (see the module docstring).
+    #: ``Esc``/``Tab`` stay ordinary (non-priority) bindings — the escape
+    #: hatch, unchanged from P1/P2. ``Left``/``Right`` are PRIORITY bindings
+    #: (see the module docstring's keymap section for why plain ancestor
+    #: bindings cannot work here): they switch the active tab even while
+    #: focus is inside a pane's ``RadioSet``/``Input``.
     BINDINGS = [
         Binding("escape", "dismiss_panel", "Back to composer", show=False),
         Binding("tab", "dismiss_panel", "Back to composer", show=False),
+        Binding(
+            "left", "prev_tab", "Previous intervention", show=False, priority=True
+        ),
+        Binding(
+            "right", "next_tab", "Next intervention", show=False, priority=True
+        ),
     ]
 
     class ChoiceSelected(Message):
-        """A closed-set option was picked — ``choice_id`` is the authoritative
-        delivery key for ``transport.answer_intervention_choice``; ``label`` is
-        carried alongside for the resolved flow-entry record (basic in P1 — the
-        placeholder→resolved in-place churn-zero contract is P2)."""
+        """A closed-set option was picked in the tab identified by ``key`` —
+        ``choice_id`` is the authoritative delivery key for
+        ``transport.answer_intervention_choice``; ``label`` is carried
+        alongside for the resolved flow-entry record."""
 
-        def __init__(self, choice_id: str, label: str) -> None:
+        def __init__(self, key: object, choice_id: str, label: str) -> None:
+            self.key = key
             self.choice_id = choice_id
             self.label = label
             super().__init__()
 
     class TextSubmitted(Message):
-        """A free-text answer was submitted in the panel's Input."""
+        """A free-text answer was submitted in the tab identified by ``key``."""
 
-        def __init__(self, text: str) -> None:
+        def __init__(self, key: object, text: str) -> None:
+            self.key = key
             self.text = text
             super().__init__()
 
     class Dismissed(Message):
         """``Esc``/``Tab`` pressed inside the panel — the app returns focus to
-        the Composer. The intervention itself is NOT answered: it stays
-        pending and the panel stays open (the escape hatch is focus-only)."""
+        the Composer. No intervention is answered: every pending tab stays
+        exactly as it was (the escape hatch is focus-only)."""
 
-    def compose(self):
-        yield Static("", id="iv-panel-title")
-        yield Static("", id="iv-panel-detail")
-        yield RadioSet(id="iv-panel-choices")
-        yield Input(id="iv-panel-input", placeholder="Type your answer…")
+    def compose(self) -> ComposeResult:
+        yield TabbedContent(id="iv-tabs")
 
     def on_mount(self) -> None:
         self.display = False
-        self._choice_ids: "list[str]" = []
-        self._choice_labels: "list[str]" = []
-        self.query_one("#iv-panel-choices", RadioSet).display = False
-        self.query_one("#iv-panel-input", Input).display = False
+        self._pane_ids: "dict[object, str]" = {}
+        self._key_by_pane: "dict[str, object]" = {}
+        self._choice_ids: "dict[str, list[str]]" = {}
+        self._choice_labels: "dict[str, list[str]]" = {}
+        self._prompts: "dict[str, str]" = {}
+        self._answered: "set[str]" = set()
+        self._next_pane_num = 0
 
-    def _set_head(self, prompt: str, detail: "str | None") -> None:
-        # ``_neutralized_label`` (the SAME terminal-neutralization boundary the
-        # flow entry's prompt head uses, presenter.py's ``_intervention_head``)
-        # strips control/ESC sequences from this LLM-derived text before it
-        # reaches the widget — the panel is a NEW rendering surface for
-        # ``prompt``/``detail`` (they previously only ever reached the flow
-        # entry), so it must apply the same boundary.
-        #
-        # Then ``Content(...)`` (literal), never a bare ``str`` —
-        # ``Static.update`` markup-parses a ``str`` by default too, so a
-        # prompt/detail containing a literal ``[...]`` (e.g. a bracketed path)
-        # would suffer the SAME character-eating bug the option labels had
-        # (see :meth:`show_choice`'s ``Content(label)`` fix).
-        self.query_one("#iv-panel-title", Static).update(
-            Content(_neutralized_label(prompt))
-        )
-        detail_widget = self.query_one("#iv-panel-detail", Static)
-        detail_widget.update(Content(_neutralized_label(detail or "")))
-        detail_widget.display = bool(detail)
-
-    def show_choice(
+    def add_pending(
         self,
+        key: object,
         *,
         prompt: str,
         detail: "str | None",
-        choices: "list[dict]",
-        pre_highlight: bool = True,
+        choices: "list[dict] | None",
     ) -> None:
-        """Populate + show the panel for a closed-set intervention, auto-
-        focusing the :class:`RadioSet` (native ``↑``/``↓``/``Enter``
-        selection) — a pending intervention blocks the turn, so it is
-        answer-now.
+        """Add ONE new tab for a newly-arrived pending intervention (#3308).
 
-        ``pre_highlight`` (#3299 P2 co-vet fix): whether index 0 is
-        highlighted so a blind ``Enter`` answers it (owner decision (A)).
-        The caller (:meth:`~reyn.interfaces.inline.textual_chat.app.TextualChatApp._show_intervention`)
-        passes ``True`` ONLY for the panel's hidden→shown transition (a
-        genuinely NEW intervention the user is looking at for the first
-        time); the multi-pending FIFO re-route (the panel already visible,
-        swapping in the NEXT queued intervention while still focused) passes
-        ``False``. Without this distinction a SECOND blind ``Enter`` — the
-        user's muscle-memory reflex after answering the first — would
-        confirm a DEFAULT option (often "Yes"/"Allow") on an intervention the
-        user never actually looked at, which is an accidental permission
-        grant, not a UX shortcut (an intervention can be a permission gate;
-        the pre-highlight's whole premise — "the user saw it and can accept
-        the default" — does not hold for an interaction they never
-        requested). This is a DETERMINISTIC identity check (which call this
-        is), never a time-based debounce (a machine-speed heuristic a strip
-        test cannot verify deterministically)."""
-        self._set_head(prompt, detail)
-        radio = self.query_one("#iv-panel-choices", RadioSet)
-        for child in list(radio.children):
-            child.remove()
-        self._choice_ids = [str(c.get("id", "")) for c in choices]
-        # Neutralized at THIS boundary (the SAME terminal neutralizer the
-        # retired chip path applied to a label before drawing it, and the flow
-        # entry still applies to its own head) — ``meta["choices"]`` labels
-        # reach here RAW (``session._iv_meta`` copies ``choice.label``
-        # verbatim). ``_choice_labels`` is also what ``ChoiceSelected`` carries
-        # for the resolved flow-entry record, so neutralizing here covers both
-        # this widget's own RadioButton AND that downstream record.
-        self._choice_labels = [
-            _neutralized_label(str(c.get("label", ""))) for c in choices
-        ]
-        for label in self._choice_labels:
-            # ``Content(label)`` (the LITERAL constructor), never a bare
-            # ``str`` — ``RadioButton``/``ToggleButton`` internally builds its
-            # label via ``Content.from_text(label)`` with markup parsing ON by
-            # default for a plain ``str``. Real choice labels are
-            # conventionally hotkey-bracket-decorated (``"[y]es"``,
-            # ``"[j]ust this path always"``, ``"[r]ecursive under …"`` — see
-            # ``reyn.intervention_choices``), and Textual's markup parser reads
-            # a leading ``[y]`` as an (unknown, unclosed) STYLE TAG — which is
-            # stripped from the rendered text, eating the bracket AND the
-            # hotkey letter (``"[y]es"`` → ``"es"``, ``"[j]ust…"`` → ``"ust…"``
-            # — the #3299 first-character-dropped display bug). ``Content`` is
-            # one of ``RadioButton``'s accepted input types and is returned
-            # as-is (no markup parsing), so the full literal label always
-            # renders intact.
-            radio.mount(RadioButton(Content(label)))
-        # #3299 P2 — owner decision (A), uniform ONLY for the hidden→shown
-        # transition (see ``pre_highlight``'s docstring above for the
-        # re-route safety rationale): pre-highlight the FIRST option so a
-        # blind ``Enter`` answers it immediately (no extra arrow keypress
-        # first). ``RadioSet`` only auto-selects index 0 in its OWN
-        # ``_on_mount`` (fired once, when this widget mounted with ZERO
-        # children — the buttons above are mounted dynamically, later, so
-        # that native behavior never fires for them); its OWN
-        # highlight-advance action (``action_next_button``, bound to the Down
-        # key) reproduces that native "select the first enabled button"
-        # behavior — but only from an UNSET anchor (``RadioSet._selected is
-        # None``).
-        #
-        # The highlight is ALWAYS reset first (regardless of
-        # ``pre_highlight``): a re-route reuses this same widget instance, so
-        # a stale highlight index from the PREVIOUS intervention would
-        # otherwise survive the children-swap above — either advancing past
-        # index 0 (if we then pre-highlighted) or, worse, leaving a STALE
-        # highlighted button from the FIRST intervention visible/actionable
-        # on the SECOND one's fresh button set (if we didn't reset at all).
-        # Resetting first, then conditionally re-highlighting, makes every
-        # ``show_choice`` call behave identically regardless of history.
-        # Pre-highlighting only ever moves the HIGHLIGHT
-        # (``RadioSet.pressed_index`` stays -1, nothing is answered yet) — the
-        # user's own ``Enter``/``Space`` still does the actual
-        # toggle-and-deliver; when ``pre_highlight`` is False, that first
-        # ``Enter``/``Space`` is a no-op (``_selected`` stays unset) until the
-        # user explicitly navigates (``Down``/``Up``) — the SAME safe
-        # unset-until-navigated behavior :meth:`show_text`'s ``Input`` already
-        # has (empty by default, ``on_input_submitted`` no-ops on empty text).
-        if self._choice_ids:
-            radio._selected = None
-            if pre_highlight:
-                radio.action_next_button()
-        radio.display = True
-        self.query_one("#iv-panel-input", Input).display = False
+        Textual's own ``TabbedContent.add_pane`` semantics give the "only
+        auto-focus while idle" invariant for free (verified directly against
+        the installed Textual 8.2.8: ``add_pane`` activates the added pane
+        ONLY when the ``TabbedContent`` was previously empty — ``active ==
+        ""`` — never on a SUBSEQUENT add): the panel's hidden→shown
+        transition activates the new tab; an arrival while another
+        intervention is already showing is added WITHOUT moving the active
+        selection — never stealing focus/selection from a tab the user is
+        already looking at, the F1-class accident this PR closes structurally."""
+        pane_id = f"iv-pane-{self._next_pane_num}"
+        self._next_pane_num += 1
+        self._pane_ids[key] = pane_id
+        self._key_by_pane[pane_id] = key
+        # THREE INDEPENDENT neutralization call sites (#3308 AC7) — the tab
+        # label, the pane title, and the pane detail are three separate
+        # LLM-derived-text rendering surfaces (``meta["prompt"]``/``["detail"]``
+        # reach here RAW, copied verbatim by ``session._iv_meta``); each is
+        # neutralized at ITS OWN call site (not shared/reused) so a strip of
+        # any ONE site flips only that site's witness test RED, never the
+        # other two silently covering for it (the SAME per-site discipline
+        # P1's ``_set_head`` used for prompt vs. detail).
+        tab_label_text = _neutralized_label(prompt)
+        # Stashed for :meth:`mark_answered`'s ✓-relabel — reusing this
+        # ALREADY-neutralized value there is not a fourth witness site, just
+        # reuse of a value this same call already produced.
+        self._prompts[pane_id] = tab_label_text
+        title_text = _neutralized_label(prompt)
+        body: "list[Widget]" = [Static(Content(title_text), classes="iv-pane-title")]
+        if detail:
+            detail_text = _neutralized_label(detail)
+            body.append(Static(Content(detail_text), classes="iv-pane-detail"))
+        if choices:
+            self._choice_ids[pane_id] = [str(c.get("id", "")) for c in choices]
+            # ``Content(label)`` (LITERAL), never a bare ``str`` — see
+            # ``RadioButton``/``ToggleButton``'s markup-parse-on-bare-str
+            # behavior and the #3299 bracket-eating bug this avoids.
+            self._choice_labels[pane_id] = [
+                _neutralized_label(str(c.get("label", ""))) for c in choices
+            ]
+            radio = RadioSet(
+                *(RadioButton(Content(label)) for label in self._choice_labels[pane_id])
+            )
+            body.append(radio)
+        else:
+            body.append(Input(placeholder="Type your answer…"))
+        tabs = self.query_one(TabbedContent)
+        tabs.add_pane(TabPane(_tab_label(tab_label_text, answered=False), *body, id=pane_id))
         self.display = True
-        self.call_after_refresh(radio.focus)
 
-    def show_text(self, *, prompt: str, detail: "str | None") -> None:
-        """Populate + show the panel for a free-text intervention, auto-
-        focusing the :class:`Input`."""
-        self._set_head(prompt, detail)
-        self.query_one("#iv-panel-choices", RadioSet).display = False
-        text_input = self.query_one("#iv-panel-input", Input)
-        text_input.value = ""
-        text_input.display = True
-        self.display = True
-        self.call_after_refresh(text_input.focus)
+    def mark_answered(self, key: object, answer_label: str) -> None:
+        """Mark ``key``'s tab ✓-answered and inert its form (#3308 §4 — a
+        second, muscle-memory ``Enter``/``Space`` on this tab must be a
+        visible no-op, not rely solely on the server's typed reject). The tab
+        STAYS mounted — never removed until :meth:`collapse_all`."""
+        pane_id = self._pane_ids.get(key)
+        if pane_id is None:
+            return
+        self._answered.add(pane_id)
+        tabs = self.query_one(TabbedContent)
+        try:
+            pane = tabs.get_pane(pane_id)
+        except Exception:
+            return
+        for control in pane.query(RadioSet):
+            control.disabled = True
+        for control in pane.query(Input):
+            control.disabled = True
+        tab = tabs.get_tab(pane_id)
+        tab.label = _tab_label(self._prompts.get(pane_id, ""), answered=True)
+        # Disabling the focused control moves Textual's focus elsewhere
+        # (verified empirically: a focused widget going ``disabled`` auto-
+        # blurs to the app's next focusable widget) — if that would carry
+        # focus OUT of this panel entirely while OTHER interventions remain
+        # pending, the Left/Right priority binding (#3308 AC8) would no
+        # longer be in the focused widget's ancestor chain at all. Re-anchor
+        # focus on the panel's own ``Tabs`` bar instead (still inside this
+        # panel, and itself Left/Right-navigable) — but ONLY when the
+        # answered pane was the ACTIVE one (an answer delivered from a
+        # background tab, #3308 AC3's out-of-order case, never had focus to
+        # begin with and must not steal it).
+        if tabs.active == pane_id:
+            tabs.query_one(Tabs).focus()
 
-    def hide(self) -> None:
-        """Collapse the panel (the intervention resolved)."""
+    def collapse_all(self) -> None:
+        """Collapse the whole panel — called by the app ONLY once every
+        pending intervention has resolved (#3308 §4): the Q→A record already
+        lives in the flow entry (churn-zero, #3299 P2 §4), so nothing is lost
+        when the tab strip itself goes away."""
+        self.query_one(TabbedContent).clear_panes()
         self.display = False
-        self._choice_ids = []
-        self._choice_labels = []
+        self._pane_ids.clear()
+        self._key_by_pane.clear()
+        self._choice_ids.clear()
+        self._choice_labels.clear()
+        self._prompts.clear()
+        self._answered.clear()
 
     def on_radio_set_changed(self, event: "RadioSet.Changed") -> None:
+        pane = next(
+            (a for a in event.radio_set.ancestors if isinstance(a, TabPane)), None
+        )
+        if pane is None or pane.id is None:
+            return
+        pane_id = pane.id
         index = event.radio_set.pressed_index
-        if 0 <= index < len(self._choice_ids):
+        ids = self._choice_ids.get(pane_id, [])
+        labels = self._choice_labels.get(pane_id, [])
+        if 0 <= index < len(ids):
             event.stop()
-            self.post_message(
-                self.ChoiceSelected(self._choice_ids[index], self._choice_labels[index])
-            )
+            key = self._key_by_pane.get(pane_id)
+            self.post_message(self.ChoiceSelected(key, ids[index], labels[index]))
 
     def on_input_submitted(self, event: "Input.Submitted") -> None:
+        pane = next(
+            (a for a in event.input.ancestors if isinstance(a, TabPane)), None
+        )
+        if pane is None or pane.id is None:
+            return
         text = event.value.strip()
         if text:
             event.stop()
-            self.post_message(self.TextSubmitted(text))
+            key = self._key_by_pane.get(pane.id)
+            self.post_message(self.TextSubmitted(key, text))
+
+    def on_tabbed_content_tab_activated(
+        self, event: "TabbedContent.TabActivated"
+    ) -> None:
+        """Fires uniformly on the panel's hidden→shown transition AND on
+        every explicit tab switch (verified against the installed Textual
+        8.2.8 — ``add_pane``'s auto-activation of the first pane posts this
+        SAME message) — focuses the newly-active pane's form.
+
+        Pre-highlighting the FIRST option (owner decision (A), #3308 §5:
+        uniform on first show AND every tab switch) needs NO extra code
+        here: unlike P1/P2's single re-routed form (one ``RadioSet`` reused
+        across different interventions, needing an explicit reset+re-highlight
+        dance on each swap), #3308 gives every pending intervention its OWN
+        ``RadioSet`` instance, created once in :meth:`add_pending` — Textual's
+        OWN ``RadioSet._on_mount`` unconditionally pre-highlights index 0 the
+        moment that instance is constructed (verified against the installed
+        Textual 8.2.8), and that highlight persists whether or not the tab is
+        currently active. Re-deriving it here would RACE against that native
+        mount-time highlight (observed empirically: double-calling
+        ``action_next_button()`` after mount could advance PAST index 0).
+
+        An already-ANSWERED tab (its form ``disabled`` by :meth:`mark_answered`)
+        is left alone — nothing to focus, its selection is the historical
+        answer."""
+        pane = event.pane
+        if pane.id is None or pane.id in self._answered:
+            return
+        radios = list(pane.query(RadioSet))
+        if radios:
+            self.call_after_refresh(radios[0].focus)
+            return
+        inputs = list(pane.query(Input))
+        if inputs:
+            self.call_after_refresh(inputs[0].focus)
 
     def action_dismiss_panel(self) -> None:
         self.post_message(self.Dismissed())
+
+    def action_prev_tab(self) -> None:
+        self._cycle_tab(-1)
+
+    def action_next_tab(self) -> None:
+        self._cycle_tab(+1)
+
+    def _cycle_tab(self, delta: int) -> None:
+        """Move the active tab by ``delta`` positions, wrapping — the
+        priority-binding-driven Left/Right cycle (#3308). Cycles through
+        EVERY tab (answered or not): reviewing a resolved answer is not
+        blocked, only re-answering it is (the form is ``disabled``)."""
+        tabs = self.query_one(TabbedContent)
+        order = list(self._pane_ids.values())
+        if not order:
+            return
+        current = tabs.active
+        idx = order.index(current) if current in order else 0
+        tabs.active = order[(idx + delta) % len(order)]
 
 
 __all__ = ["InterventionPanel"]

--- a/src/reyn/interfaces/inline/textual_chat/intervention_panel.py
+++ b/src/reyn/interfaces/inline/textual_chat/intervention_panel.py
@@ -118,6 +118,25 @@ class InterventionPanel(Vertical):
     PENDING intervention (#3308); collapsed (``display=False``) only while
     NOTHING is pending — the default state until the first :meth:`add_pending`."""
 
+    #: ★ #3311 real-TTY regression: this CSS deliberately does NOT set a rule
+    #: for ``Tabs`` (the internal tab-caption bar ``TabbedContent`` composes).
+    #: An earlier revision of this file added ``InterventionPanel Tabs {
+    #: height: auto; }`` alongside the ``TabbedContent`` rule below, by
+    #: (wrong) analogy — but ``textual.widgets.Tabs`` ships its OWN sensible
+    #: FIXED ``height: 2`` default (verified against the installed Textual
+    #: 8.2.8: ``Tabs.DEFAULT_CSS``), and overriding a widget that is NOT
+    #: designed for auto-sizing to ``height: auto`` resolved to a hugely
+    #: inflated value (~30 rows on an 80x24 screen, tui-coder's real-TTY
+    #: witness on #3311) — ballooning the whole panel (also ``height: auto``)
+    #: and pushing the FlowView/Composer off-screen. Every widget-STATE
+    #: assertion in the test suite stayed green throughout (the panel WAS
+    #: displayed, WAS focused — just enormous), which is why
+    #: ``test_pending_intervention_panel_does_not_swallow_the_screen`` /
+    #: ``test_tabs_bar_height_is_the_native_fixed_two_rows`` assert on
+    #: ``Widget.region`` (actual computed screen geometry) directly, not
+    #: widget state. Only ``TabbedContent`` itself (which DOES default to
+    #: ``height: auto`` — ``TabbedContent.DEFAULT_CSS`` — so overriding it is
+    #: a no-op override, kept for documentation clarity) needs a rule here.
     DEFAULT_CSS = """
     InterventionPanel {
         height: auto;
@@ -126,9 +145,6 @@ class InterventionPanel(Vertical):
         margin-top: 1;
     }
     InterventionPanel TabbedContent {
-        height: auto;
-    }
-    InterventionPanel Tabs {
         height: auto;
     }
     InterventionPanel .iv-pane-title {

--- a/tests/test_textual_chat_intervention_panel_3299.py
+++ b/tests/test_textual_chat_intervention_panel_3299.py
@@ -1,35 +1,48 @@
-"""#3299 P1: intervention interaction moved into the grouped InterventionPanel.
+"""#3299 P1/P2/P5 (#3308): intervention interaction in a TAB-IFIED grouped panel.
 
-Retargets the Phase-3.5 chip/match tests (#3273, ``test_textual_chat_phase35_3273.py``)
-to the new panel-widget path — the ATOMIC display-swap + input-swap +
-chip-retire this PR lands. The chip surface (``choice_chip_spans`` /
-``_present_intervention_choice`` / ``on_flow_view_clicked`` /
-``_match_choice_input`` / ``_surface_choice_hint`` / ``_CHOICE_*``) is retired
-(grep-zero in ``src/``, see the PR body); a closed-set intervention is now
-answered by SELECTING a :class:`~textual.widgets.RadioSet` option in the panel
-(never a free-text label match — the #3290 type-or-click matching algorithm is
-retired along with the Composer intervention-answer path it served, not
-retargeted: the Composer is now exclusively for new turns), and a free-text
-intervention by submitting the panel's own :class:`~textual.widgets.Input`.
+Retargets the Phase-3.5 chip/match tests (#3273) to the panel-widget path
+(P1), then the P2 by-id multi-pending fixes, then #3308 (P5)'s tab-ify: one
+:class:`~textual.widgets.TabPane` per PENDING intervention instead of a
+single re-routing form. The chip surface is retired (grep-zero, unchanged
+since P1); a closed-set intervention is answered by SELECTING a
+:class:`~textual.widgets.RadioSet` option in its OWN tab, and a free-text one
+by submitting its OWN tab's :class:`~textual.widgets.Input`.
 
-Gates pinned here (per the architect's P1 scope ruling):
+Gates pinned here (#3308 acceptance conditions, numbered to match the issue):
 
-- **F1 permission-band reachability**: a real closed-set intervention frame
-  populates the panel; selecting the SECOND RadioButton delivers exactly that
-  option's ``choice_id`` through ``transport.answer_intervention_choice`` — the
-  UNCHANGED transport funnel every answer path shares.
-- **free-text reachability**: a free-text intervention's panel Input, once
-  submitted, delivers through ``transport.answer_intervention_text``.
-- **no-double-display / no-double-input (retire non-vacuity)**: the flow entry
-  never renders chips (the presenter's chip-drawing symbols are gone — a
-  direct grep-zero check — and the rendered flow-entry presentation carries
-  only the prompt + a "respond in the panel below" hint, not the option
-  labels); a Composer submit during a pending intervention is ALWAYS a new
-  turn (``submit_user_text``), never an intervention answer.
-- **focus-return**: Esc/Tab inside the panel returns focus to the Composer.
-- **neutralization regression**: an LLM-derived choice label carrying raw
-  terminal control sequences is still neutralized before it reaches the
-  rendered flow-entry head (moved off the old chip-rendering path).
+1. **Enter-twice delivers exactly one answer** — answering a tab does not
+   change the active tab, so a muscle-memory second ``Enter`` lands on the
+   SAME (now ✓-answered, inert) tab and delivers nothing to an unread other
+   pending intervention. (Migrates the P2 F1-interim test's property (a),
+   per the #3308 co-vet correction: the interim MECHANISM — re-route
+   suppressing pre-highlight — is retired, but this SAFETY PROPERTY is not.)
+2. **A new arrival never steals the active tab** — Textual's own
+   ``TabbedContent.add_pane`` auto-activates a pane ONLY when the content was
+   previously empty; a second arrival while a tab is already showing is
+   added inert, in the background.
+3. **Out-of-order answering + by-id delivery** — Left/Right lets the user
+   pick ANY pending tab; the answer is delivered targeted at THAT
+   intervention's id, never head-of-queue. (Migrates the P2 F1-interim
+   test's property (b), the by-id witness.)
+4. **Answered tabs stay** (✓-labelled, form disabled) until every pending
+   intervention resolves, at which point the whole panel collapses.
+5. **Pre-highlight (owner decision (A)) is unconditional** — the first
+   option is pre-highlighted on the panel's initial show AND on every
+   explicit tab switch alike (no re-route-vs-initial distinction anymore).
+6. **Churn-zero** — resolving updates the SAME flow entry in place.
+7. **Neutralization** — the tab label, the pane title, and the pane detail
+   are THREE INDEPENDENT LLM-derived-text rendering surfaces, each stripped
+   of raw ESC/OSC at its own call site.
+8. **Left/Right switch tabs even with a RadioSet focused** — Textual's own
+   ``RadioSet`` binds ``left``/``right`` as ``up``/``down`` aliases, so a
+   naive ancestor binding could never fire while a RadioSet has focus; the
+   panel uses a ``priority=True`` binding (Textual's priority pass runs
+   outermost-ancestor-first, before the focused widget's own bindings) to
+   win regardless.
+
+Plus the surviving P1 gates: free-text reachability, no-double-display
+(flow entry never renders chips), focus-return (Esc/Tab), the bracket-
+decorated-label display-bug regression, and the pending-state dim gutter.
 
 All use real instances (a concrete recording :class:`ClientTransport`, a real
 mounted :class:`TextualChatApp`, real :class:`OutboxMessage`) — no mocks — per
@@ -42,7 +55,7 @@ from typing import AsyncIterator
 
 import pytest
 from textual.app import App, ComposeResult
-from textual.widgets import Input, RadioButton, RadioSet, Static
+from textual.widgets import Input, RadioButton, RadioSet, Static, Tab, TabbedContent, TabPane
 from textual_flowview import EntryState, FlowView
 
 from reyn.interfaces.inline.textual_chat import Composer, TextualChatApp
@@ -168,7 +181,7 @@ def _free_text_intervention() -> OutboxMessage:
 
 def _second_choice_intervention() -> OutboxMessage:
     """A second, distinct closed-set intervention (different id) — used by the
-    multi-pending tests (#3299 P2) to exercise TWO simultaneously-outstanding
+    multi-pending tests to exercise TWO simultaneously-outstanding
     interventions, which ``outstanding_interventions`` supports by design."""
     return OutboxMessage(
         kind="intervention",
@@ -183,6 +196,29 @@ def _second_choice_intervention() -> OutboxMessage:
             ],
             "nodes": [
                 {"component": "text", "text": "Overwrite existing file?"},
+                {"component": "list", "items": ["Yes", "No"]},
+            ],
+        },
+    )
+
+
+def _third_choice_intervention() -> OutboxMessage:
+    """A THIRD, distinct closed-set intervention — used by the out-of-order
+    (#3308 AC3) test to exercise three simultaneously-outstanding
+    interventions."""
+    return OutboxMessage(
+        kind="intervention",
+        text="Delete the branch?\n  Yes / No",
+        meta={
+            "intervention_id": "iv-3",
+            "intervention_kind": "confirm",
+            "prompt": "Delete the branch?",
+            "choices": [
+                {"id": "yes", "label": "Yes", "hotkey": "y"},
+                {"id": "no", "label": "No", "hotkey": "n"},
+            ],
+            "nodes": [
+                {"component": "text", "text": "Delete the branch?"},
                 {"component": "list", "items": ["Yes", "No"]},
             ],
         },
@@ -206,14 +242,42 @@ def _iv_entries(app: TextualChatApp):
     }
 
 
+def _tabs(panel: InterventionPanel) -> TabbedContent:
+    return panel.query_one(TabbedContent)
+
+
+def _active_pane(panel: InterventionPanel) -> TabPane:
+    tabs = _tabs(panel)
+    return tabs.get_pane(tabs.active)
+
+
+def _pane_title(pane: TabPane) -> str:
+    return pane.query_one(".iv-pane-title", Static).content.plain
+
+
+def _tab_labels(panel: InterventionPanel) -> "list[str]":
+    """Every tab-bar caption, in insertion order (public ``Tab.label_text``,
+    not private state)."""
+    return [tab.label_text for tab in panel.query(Tab)]
+
+
+def _pane_ids_in_order(panel: InterventionPanel) -> "list[str]":
+    """Every mounted pane's id, in insertion (DOM) order — from the public
+    ``TabPane.id`` directly (``Tab.id`` is a DIFFERENT, internally-prefixed
+    id namespace — ``--content-tab-<pane id>`` — not usable with
+    ``TabbedContent.get_pane``), never from the panel's private
+    ``_pane_ids`` lookup table."""
+    return [pane.id for pane in panel.query(TabPane) if pane.id is not None]
+
+
 @pytest.mark.asyncio
 async def test_choice_intervention_panel_selection_delivers_correct_choice_id() -> None:
     """Tier 2b: F1 permission-band reachability — a closed-set intervention
-    frame populates the panel's RadioSet; selecting the SECOND option delivers
+    frame populates a tab's RadioSet; selecting the SECOND option delivers
     that option's ``choice_id`` ("no") through ``answer_intervention_choice``,
-    and the flow entry resolves to SUCCESS. Non-vacuous: the SECOND option is
-    chosen (a first-option shortcut would fail) and the exact id is asserted;
-    no answer is delivered before the selection."""
+    and the flow entry resolves. Non-vacuous: the SECOND option is chosen (a
+    first-option shortcut would fail) and the exact id is asserted; no answer
+    is delivered before the selection."""
     transport = RecordingTransport([_choice_intervention()], end=False)
     app = TextualChatApp(transport=transport)
 
@@ -223,16 +287,15 @@ async def test_choice_intervention_panel_selection_delivers_correct_choice_id() 
 
         panel = app.query_one(InterventionPanel)
         assert panel.display is True, "panel did not show for a pending intervention"
-        radio = panel.query_one("#iv-panel-choices", RadioSet)
-        assert radio.display is True
-        assert radio.has_focus, "panel did not auto-focus the RadioSet"
+        pane = _active_pane(panel)
+        radio = pane.query_one(RadioSet)
+        assert radio.has_focus, "panel did not auto-focus the tab's RadioSet"
 
         # No answer is delivered until the user acts.
         assert transport.answered_choice == []
 
         # #3299 P2 owner decision (A): the panel pre-highlights the FIRST
-        # option on appear, so ONE "down" now reaches the SECOND option ("No")
-        # — two would have been needed pre-P2 (index -1 → 0 → 1).
+        # option on appear, so ONE "down" now reaches the SECOND option ("No").
         await pilot.press("down")
         await pilot.press("enter")
         await pilot.pause()
@@ -244,9 +307,8 @@ async def test_choice_intervention_panel_selection_delivers_correct_choice_id() 
         assert transport.answered_choice_ids == ["iv-1"], (
             "answer not delivered BY ID (#3299 P2 R1)"
         )
-        # Resolved reflection: DEFAULT gutter (#3299 P2 §5 — not SUCCESS, an
-        # answered intervention is neither an outcome nor a failure) + panel
-        # collapsed + focus returned to the Composer.
+        # Resolved reflection: DEFAULT gutter (#3299 P2 §5) + panel collapsed
+        # (the only pending intervention resolved) + focus back to Composer.
         resolved = _iv_entry(app)
         assert resolved.state is EntryState.DEFAULT
         assert resolved.item.meta.get("_answer_label") == "No"
@@ -258,10 +320,9 @@ async def test_choice_intervention_panel_selection_delivers_correct_choice_id() 
 
 @pytest.mark.asyncio
 async def test_free_text_intervention_answered_via_panel_input() -> None:
-    """Tier 2b: a free-text intervention (no choices) populates the panel's
+    """Tier 2b: a free-text intervention (no choices) populates its tab's
     Input (auto-focused); submitting delivers the text through
-    ``answer_intervention_text``. Regression retarget of the #3273 Composer
-    free-text test — the answer path moved from the Composer to the panel."""
+    ``answer_intervention_text``."""
     transport = RecordingTransport([_free_text_intervention()], end=False)
     app = TextualChatApp(transport=transport)
 
@@ -270,9 +331,9 @@ async def test_free_text_intervention_answered_via_panel_input() -> None:
         await pilot.pause()
 
         panel = app.query_one(InterventionPanel)
-        text_input = panel.query_one("#iv-panel-input", Input)
-        assert text_input.display is True
-        assert text_input.has_focus, "panel did not auto-focus the Input"
+        pane = _active_pane(panel)
+        text_input = pane.query_one(Input)
+        assert text_input.has_focus, "panel did not auto-focus the tab's Input"
 
         await pilot.press("o", "k")
         await pilot.press("enter")
@@ -288,13 +349,10 @@ async def test_free_text_intervention_answered_via_panel_input() -> None:
 @pytest.mark.asyncio
 async def test_composer_submit_during_pending_intervention_is_always_a_new_turn() -> None:
     """Tier 2b: no-double-input — the Composer no longer special-cases a
-    pending intervention at all (#3299 P1: it no longer reads
-    ``pending_intervention_head()``). A Composer submit while a closed-set
+    pending intervention at all. A Composer submit while a closed-set
     intervention is pending is ALWAYS routed to ``submit_user_text`` — never
     ``answer_intervention_choice`` / ``answer_intervention_text`` — even when
-    the text happens to name an option. This is the atomic-swap witness: if
-    the retired Composer-side matching were still live (a half-swap), this
-    would instead deliver a choice answer."""
+    the text happens to name an option."""
     transport = RecordingTransport([_choice_intervention()], end=False)
     app = TextualChatApp(transport=transport)
 
@@ -313,8 +371,7 @@ async def test_composer_submit_during_pending_intervention_is_always_a_new_turn(
 
 def test_chip_drawing_symbols_are_retired() -> None:
     """Tier 1: retire grep-zero (non-vacuity witness) — the presenter module no
-    longer defines the chip-drawing surface at all. This would fail RED if the
-    chip path were still live alongside the panel (double-display)."""
+    longer defines the chip-drawing surface at all."""
     from reyn.interfaces.inline.textual_chat import presenter as presenter_module
 
     for name in (
@@ -341,11 +398,7 @@ def test_chip_drawing_symbols_are_retired() -> None:
 async def test_pending_intervention_flow_entry_has_no_chip_options_rendered() -> None:
     """Tier 2b: no-double-display — the flow entry for a pending intervention
     renders ONLY the prompt head + a dim hint pointing at the panel, never the
-    option labels (which live exclusively in the panel's RadioSet now).
-    Non-vacuous: the pre-#3299 chip presentation rendered every option label
-    inline (``[ 1 · Yes ]`` etc.) — asserting none of those labels appear in
-    the flow-entry rendering is exactly what a surviving chip branch would
-    violate."""
+    option labels (which live exclusively in a tab's RadioSet now)."""
     from rich.console import Console
 
     transport = RecordingTransport([_choice_intervention()], end=False)
@@ -364,9 +417,6 @@ async def test_pending_intervention_flow_entry_has_no_chip_options_rendered() ->
 
     assert "Allow write to /etc/hosts?" in rendered
     assert "respond in the panel below" in rendered
-    # The old chip layout rendered every option as ``[ n · label ]`` inline —
-    # asserting that shape is absent is exactly what a surviving chip branch
-    # would violate.
     assert "[ 1 ·" not in rendered and "[ 2 ·" not in rendered, (
         "chip-shaped option markup leaked into the pending flow entry"
     )
@@ -376,7 +426,7 @@ async def test_pending_intervention_flow_entry_has_no_chip_options_rendered() ->
 async def test_escape_and_tab_from_panel_return_focus_to_composer() -> None:
     """Tier 2b: focus-return — Esc/Tab inside the panel return focus to the
     Composer WITHOUT answering; the intervention stays pending (the panel
-    stays open, mirroring the Phase-3 drawer's deterministic focus-flow)."""
+    stays open)."""
     transport = RecordingTransport([_choice_intervention()], end=False)
     app = TextualChatApp(transport=transport)
 
@@ -384,7 +434,8 @@ async def test_escape_and_tab_from_panel_return_focus_to_composer() -> None:
         await pilot.pause()
         await pilot.pause()
         panel = app.query_one(InterventionPanel)
-        assert panel.query_one("#iv-panel-choices", RadioSet).has_focus
+        pane = _active_pane(panel)
+        assert pane.query_one(RadioSet).has_focus
 
         await pilot.press("escape")
         await pilot.pause()
@@ -395,7 +446,7 @@ async def test_escape_and_tab_from_panel_return_focus_to_composer() -> None:
         assert transport.answered_text == []
 
         # Re-focus the panel to exercise Tab too.
-        panel.query_one("#iv-panel-choices", RadioSet).focus()
+        _active_pane(panel).query_one(RadioSet).focus()
         await pilot.pause()
         await pilot.press("tab")
         await pilot.pause()
@@ -407,14 +458,7 @@ async def test_escape_and_tab_from_panel_return_focus_to_composer() -> None:
 
 def test_choice_labels_are_neutralized_before_rendering() -> None:
     """Tier 2c: an LLM-derived choice LABEL carrying raw terminal control
-    sequences must not leak into the flow entry's rendering — retargeted off
-    the retired chip path onto :meth:`ReynPresenter._present_intervention_pending`,
-    which renders the prompt head (labels themselves now live only in the
-    panel's RadioSet, built by :meth:`InterventionPanel.show_choice` from the
-    SAME raw ``meta["choices"]`` — Textual's own :class:`RadioButton` renders
-    its label through Rich markup, not raw ANSI passthrough, so the injection
-    surface pinned here is the flow-entry head, matching the original test's
-    payload and assertions).
+    sequences must not leak into the flow entry's rendering.
 
     NON-VACUITY (falsification): neutering ``presenter._neutralized_label`` to
     identity makes the raw ``\\x1b`` leak into the rendered head and flips this
@@ -452,31 +496,14 @@ def test_choice_labels_are_neutralized_before_rendering() -> None:
 
 @pytest.mark.asyncio
 async def test_bracket_decorated_option_labels_render_intact() -> None:
-    """Tier 1: the panel's RadioButton must expose the FULL literal option
-    label — the real-TTY-witnessed display bug where the FIRST character of
-    every option label was dropped ("Yes" → "es", "No" → "o", "just this path
-    always" → "ust this path always", "recursive under '...' always" →
-    "ecursive under '...' always").
-
-    Root cause: real choice labels are conventionally hotkey-bracket-decorated
-    (``reyn.intervention_choices.generic_yn_choices`` / ``file_access_choices``
-    — ``"[y]es"``, ``"[A]lways"``, ``"[n]o"``, ``"[N]ever"``,
-    ``"[j]ust this path always"``, ``"[r]ecursive under '...' always"``).
-    ``RadioButton``/``ToggleButton`` builds its label via
-    ``Content.from_text(label)`` with Textual MARKUP PARSING ON by default for
-    a plain ``str`` — it reads a leading ``[y]`` as an (unknown, unclosed)
-    style tag and strips it from the rendered text, eating the bracket AND
-    the enclosed hotkey letter.
-
-    Asserts on the PUBLIC ``RadioButton.label`` (the widget's own exposed
-    rendered label, not private state) for the REAL ``InterventionChoice``
-    factories — the standard yes/no/always/never set AND the longer
-    bracket-decorated labels (``file_access_choices``).
+    """Tier 1: a tab's RadioButton must expose the FULL literal option label —
+    the real-TTY-witnessed display bug where the FIRST character of every
+    option label was dropped ("Yes" → "es", "No" → "o", etc).
 
     NON-VACUITY (falsification): on the pre-fix code (``RadioButton(label)``
     with a bare ``str``) this assertion FAILS — every label above renders with
     its first character (and the ``[x]`` bracket) missing. Verified locally by
-    reverting the ``Content(label)`` fix in ``InterventionPanel.show_choice``.
+    reverting the ``Content(label)`` fix in ``InterventionPanel.add_pending``.
     """
 
     class _PanelHost(App):
@@ -490,7 +517,8 @@ async def test_bracket_decorated_option_labels_render_intact() -> None:
     async with app.run_test() as pilot:
         panel = app.query_one(InterventionPanel)
 
-        panel.show_choice(
+        panel.add_pending(
+            "k1",
             prompt="Proceed?",
             detail=None,
             choices=[
@@ -498,13 +526,14 @@ async def test_bracket_decorated_option_labels_render_intact() -> None:
             ],
         )
         await pilot.pause()
-        radio = panel.query_one("#iv-panel-choices", RadioSet)
+        radio = _active_pane(panel).query_one(RadioSet)
         rendered_yn = [rb.label.plain for rb in radio.query(RadioButton)]
         assert rendered_yn == ["[y]es", "[A]lways", "[n]o", "[N]ever"], (
             f"bracket-decorated label(s) dropped a character; got {rendered_yn!r}"
         )
 
-        panel.show_choice(
+        panel.add_pending(
+            "k2",
             prompt="Grant file access?",
             detail=None,
             choices=[
@@ -512,8 +541,11 @@ async def test_bracket_decorated_option_labels_render_intact() -> None:
             ],
         )
         await pilot.pause()
-        radio = panel.query_one("#iv-panel-choices", RadioSet)
-        rendered_long = [rb.label.plain for rb in radio.query(RadioButton)]
+        # k2 arrives while k1 is already showing — it does NOT become active
+        # (#3308 AC2), so query its pane directly by id rather than "active".
+        pane2 = _tabs(panel).get_pane(_pane_ids_in_order(panel)[1])
+        radio2 = pane2.query_one(RadioSet)
+        rendered_long = [rb.label.plain for rb in radio2.query(RadioButton)]
         assert rendered_long == [
             "[y]es",
             "[j]ust this path always",
@@ -523,19 +555,11 @@ async def test_bracket_decorated_option_labels_render_intact() -> None:
 
 
 # --- panel neutralize-guard witnesses (3 independently-witnessed surfaces) --
-# The panel is a NEW rendering surface for LLM-derived text that only ever
-# reached the flow entry before #3299 P1: the choice LABEL, the title/prompt,
-# and the detail. Each of the three is neutralized at its own call site in
-# ``InterventionPanel`` (``show_choice`` for the label, ``_set_head`` for
-# prompt/detail) — a malicious LLM-controlled choice label / prompt / detail
-# could otherwise drive the terminal (CSI color codes, OSC title-set) since
-# Textual's own ``Content`` constructor does NOT strip ESC (0x1B) — only a
-# narrow control-code set (BEL/BS/VT/FF/CR). Each test below is scoped to
-# assert ONLY the ESC byte's absence (the byte Content's own stripping never
-# removes), so each is a genuine, independent witness of ITS site's
-# ``_neutralized_label`` call — reverting any ONE call (verified locally,
-# see each docstring) flips ONLY that site's assertion RED, never the other
-# two silently covering for it.
+# #3308: the tab-ified panel has THREE separate LLM-derived-text rendering
+# surfaces — the tab-bar LABEL, the pane TITLE, and the pane DETAIL — each
+# neutralized at its OWN call site in ``InterventionPanel.add_pending`` (see
+# that method's docstring). Each test below is scoped to assert ONLY the ESC
+# byte's absence, so each is a genuine, independent witness of ITS site.
 _ESC_OSC_PAYLOAD = "\x1b[31mRED\x1b]0;pwn\x07"
 
 
@@ -546,33 +570,26 @@ class _PanelOnlyApp(App):
 
 @pytest.mark.asyncio
 async def test_panel_choice_label_neutralizes_raw_esc_osc() -> None:
-    """Tier 2c: the panel's RadioButton LABEL surface is independently
-    neutralized. A closed-set intervention choice carrying a raw ESC/OSC
-    payload as its label (a malicious/compromised LLM-derived label — this is
-    NOT hypothetical: ``meta["choices"]`` labels reach the panel RAW, copied
-    verbatim by ``session._iv_meta``) must not leak the raw ESC byte into the
-    mounted ``RadioButton.label`` Textual actually renders.
+    """Tier 2c: the tab's RadioButton LABEL surface is independently
+    neutralized.
 
     NON-VACUITY (falsification, verified locally): reverting ONLY the
     ``_neutralized_label`` call around the label in
-    ``InterventionPanel.show_choice`` (i.e. mounting
-    ``RadioButton(Content(str(c.get("label", ""))))`` instead of
-    ``RadioButton(Content(_neutralized_label(...)))``) makes this assertion
-    FAIL — ``Content``'s own control-code stripping does not remove ESC
-    (0x1B), only BEL/BS/VT/FF/CR, so the raw ESC survives all the way into
-    the rendered label unless THIS site's neutralize call does the work.
-    Reverting the title/detail neutralize (the other two sites) does NOT
-    affect this assertion — the label survives its own site's guard alone."""
+    ``InterventionPanel.add_pending`` makes this assertion FAIL — ``Content``'s
+    own control-code stripping does not remove ESC (0x1B). Reverting the
+    tab-label/title/detail neutralize (the other sites) does NOT affect this
+    assertion — the label survives its own site's guard alone."""
     app = _PanelOnlyApp()
     async with app.run_test() as pilot:
         panel = app.query_one(InterventionPanel)
-        panel.show_choice(
+        panel.add_pending(
+            "k",
             prompt="Proceed?",
             detail=None,
             choices=[{"id": "x", "label": _ESC_OSC_PAYLOAD, "hotkey": "x"}],
         )
         await pilot.pause()
-        radio = panel.query_one("#iv-panel-choices", RadioSet)
+        radio = _active_pane(panel).query_one(RadioSet)
         (only_button,) = radio.query(RadioButton)
         rendered_label = only_button.label.plain
         assert "\x1b" not in rendered_label, (
@@ -582,24 +599,40 @@ async def test_panel_choice_label_neutralizes_raw_esc_osc() -> None:
 
 
 @pytest.mark.asyncio
-async def test_panel_title_neutralizes_raw_esc_osc() -> None:
-    """Tier 2c: the panel's TITLE/prompt surface is independently neutralized.
-    An intervention prompt carrying a raw ESC/OSC payload must not leak into
-    the mounted ``#iv-panel-title`` Static's rendered content.
+async def test_panel_tab_label_neutralizes_raw_esc_osc() -> None:
+    """Tier 2c: the tab-BAR CAPTION surface is independently neutralized —
+    NEW in #3308 (P1/P2 had no tab bar at all).
 
     NON-VACUITY (falsification, verified locally): reverting ONLY the
-    ``_neutralized_label`` call around ``prompt`` in
-    ``InterventionPanel._set_head`` (passing ``Content(prompt)`` directly)
-    makes this assertion FAIL, for the same reason as the label site —
-    ``Content`` does not strip ESC on its own. Reverting the label or detail
-    neutralize (the other two sites) does NOT affect this assertion."""
+    ``tab_label_text = _neutralized_label(prompt)`` call in
+    ``InterventionPanel.add_pending`` (passing the raw ``prompt`` to
+    ``_tab_label`` instead) makes this assertion FAIL. Reverting the title or
+    detail neutralize (the other two sites) does NOT affect this assertion."""
     app = _PanelOnlyApp()
     async with app.run_test() as pilot:
         panel = app.query_one(InterventionPanel)
-        panel.show_text(prompt=_ESC_OSC_PAYLOAD, detail=None)
+        panel.add_pending("k", prompt=_ESC_OSC_PAYLOAD, detail=None, choices=None)
         await pilot.pause()
-        title = panel.query_one("#iv-panel-title", Static)
-        rendered = title.content.plain
+        (label,) = _tab_labels(panel)
+        assert "\x1b" not in label, f"raw ESC leaked into the tab label: {label!r}"
+        assert "RED" in label
+
+
+@pytest.mark.asyncio
+async def test_panel_title_neutralizes_raw_esc_osc() -> None:
+    """Tier 2c: the pane TITLE surface is independently neutralized.
+
+    NON-VACUITY (falsification, verified locally): reverting ONLY the
+    ``title_text = _neutralized_label(prompt)`` call in
+    ``InterventionPanel.add_pending`` (passing ``Content(prompt)`` directly)
+    makes this assertion FAIL. Reverting the tab-label or detail neutralize
+    (the other two sites) does NOT affect this assertion."""
+    app = _PanelOnlyApp()
+    async with app.run_test() as pilot:
+        panel = app.query_one(InterventionPanel)
+        panel.add_pending("k", prompt=_ESC_OSC_PAYLOAD, detail=None, choices=None)
+        await pilot.pause()
+        rendered = _pane_title(_active_pane(panel))
         assert "\x1b" not in rendered, (
             f"raw ESC leaked into the panel's title: {rendered!r}"
         )
@@ -608,22 +641,21 @@ async def test_panel_title_neutralizes_raw_esc_osc() -> None:
 
 @pytest.mark.asyncio
 async def test_panel_detail_neutralizes_raw_esc_osc() -> None:
-    """Tier 2c: the panel's DETAIL surface is independently neutralized. An
-    intervention detail carrying a raw ESC/OSC payload must not leak into the
-    mounted ``#iv-panel-detail`` Static's rendered content.
+    """Tier 2c: the pane DETAIL surface is independently neutralized.
 
     NON-VACUITY (falsification, verified locally): reverting ONLY the
-    ``_neutralized_label`` call around ``detail`` in
-    ``InterventionPanel._set_head`` (passing ``Content(detail or "")``
-    directly) makes this assertion FAIL, for the same reason as the label and
-    title sites. Reverting the label or title neutralize (the other two
-    sites) does NOT affect this assertion."""
+    ``detail_text = _neutralized_label(detail)`` call in
+    ``InterventionPanel.add_pending`` (passing ``Content(detail)`` directly)
+    makes this assertion FAIL. Reverting the tab-label or title neutralize
+    (the other two sites) does NOT affect this assertion."""
     app = _PanelOnlyApp()
     async with app.run_test() as pilot:
         panel = app.query_one(InterventionPanel)
-        panel.show_text(prompt="Proceed?", detail=_ESC_OSC_PAYLOAD)
+        panel.add_pending(
+            "k", prompt="Proceed?", detail=_ESC_OSC_PAYLOAD, choices=None
+        )
         await pilot.pause()
-        detail = panel.query_one("#iv-panel-detail", Static)
+        detail = _active_pane(panel).query_one(".iv-pane-detail", Static)
         rendered = detail.content.plain
         assert "\x1b" not in rendered, (
             f"raw ESC leaked into the panel's detail: {rendered!r}"
@@ -631,25 +663,63 @@ async def test_panel_detail_neutralizes_raw_esc_osc() -> None:
         assert "RED" in rendered
 
 
-# --- #3299 P2: multi-pending by-id delivery + re-route ----------------------
-# The architect's self-review finding (P1 merge): the panel was SINGLE-slot
-# (a second pending intervention silently overwrote the first's entry handle)
-# and delivery was HEAD-targeted (``answer_intervention_choice`` carries no
-# id) — but ``outstanding_interventions`` legitimately holds MULTIPLE pending
-# entries (e.g. restore's FIFO re-enqueue), so a stale head could receive an
-# answer the user actually gave to a DIFFERENT, currently-displayed
-# intervention. P2 fixes both: every pending intervention gets its OWN
-# tracked flow entry (never overwritten), and an answer is delivered BY ID to
-# whichever intervention the panel is showing.
+# --- #3308 (#3299 P5): tab-ify — one tab per pending, no re-route -----------
 
 
 @pytest.mark.asyncio
-async def test_second_pending_intervention_does_not_overwrite_the_first() -> None:
-    """Tier 2b: with TWO interventions pending, the panel keeps showing the
-    FIRST (the architect's overwrite finding) — its flow entry is not
-    orphaned, and the second gets its own placeholder entry too. Non-vacuous:
-    pre-P2 the single ``_pending_iv_entry`` slot was overwritten by the
-    second arrival (verified against the P1 source removed in this PR)."""
+async def test_second_enter_after_answering_does_not_deliver_to_unread_second() -> None:
+    """Tier 2b: ★AC1 — with TWO interventions pending, answering the FIRST
+    (bare Enter, pre-highlighted "Yes") does NOT move the active tab, so a
+    muscle-memory SECOND bare ``Enter`` lands on the SAME (now ✓-answered,
+    disabled) tab and delivers NOTHING to the still-unread second
+    intervention. Migrates the retired P2 F1-interim test's safety property
+    (a) onto the tab-ified structure (#3308 co-vet correction: the interim
+    MECHANISM is retired, this PROPERTY is not).
+
+    NON-VACUITY (falsification): if ``InterventionPanel.mark_answered``
+    stopped disabling the tab's ``RadioSet`` (reverting the
+    ``control.disabled = True`` loop), the second bare ``Enter`` would still
+    land on the same (still-enabled, still-selected) RadioSet and could
+    re-post a ``Changed``/toggle — verified locally that stripping the
+    disable loop flips ``transport.answered_choice`` to length 2 instead of
+    staying at 1."""
+    transport = RecordingTransport(
+        [_choice_intervention(), _second_choice_intervention()], end=False
+    )
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        await pilot.press("enter")  # answers iv-1 ("Yes", pre-highlighted)
+        await pilot.pause()
+        await pilot.pause()
+
+        assert transport.answered_choice == ["yes"]
+        assert transport.answered_choice_ids == ["iv-1"]
+
+        # Muscle-memory second bare Enter — must be a no-op.
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert transport.answered_choice == ["yes"], (
+            "a second bare Enter delivered an unrequested answer — "
+            f"got {transport.answered_choice}"
+        )
+        entries = _iv_entries(app)
+        assert entries["iv-2"].item.meta.get("_answer_label") is None, (
+            "the second (still-pending) intervention must remain unanswered"
+        )
+
+
+@pytest.mark.asyncio
+async def test_new_pending_intervention_does_not_steal_the_active_tab() -> None:
+    """Tier 2b: ★AC2 — with the panel already showing the FIRST intervention,
+    a SECOND arriving does not move the active tab; the first stays active
+    and answerable by a bare Enter. Migrates the retired P2 F1-interim test's
+    coverage of "the second intervention's entry must not be touched"."""
     transport = RecordingTransport(
         [_choice_intervention(), _second_choice_intervention()], end=False
     )
@@ -663,40 +733,120 @@ async def test_second_pending_intervention_does_not_overwrite_the_first() -> Non
         assert set(entries) == {"iv-1", "iv-2"}, (
             f"expected both pending interventions to get their own flow entry, got {set(entries)}"
         )
-        # The panel still shows the FIRST (iv-1's prompt), not overwritten by
-        # the second arrival.
-        title = app.query_one(InterventionPanel).query_one("#iv-panel-title", Static)
-        assert "hosts" in title.content.plain, (
-            f"panel switched away from the first pending intervention; title={title.content.plain!r}"
+        panel = app.query_one(InterventionPanel)
+        assert "hosts" in _pane_title(_active_pane(panel)), (
+            "a new arrival stole the active tab from the first pending intervention"
         )
+
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert transport.answered_choice_ids == ["iv-1"], (
+            f"bare Enter did not answer the still-active FIRST tab; got {transport.answered_choice_ids}"
+        )
+        entries = _iv_entries(app)
+        assert entries["iv-2"].item.meta.get("_answer_label") is None
 
 
 @pytest.mark.asyncio
-async def test_multi_pending_answer_targets_the_displayed_intervention_by_id() -> None:
-    """Tier 2b: ★non-vacuity witness for the mis-delivery fix — with TWO
-    interventions pending, answering the one the panel DISPLAYS delivers to
-    THAT intervention's id, and resolving it re-routes the panel to the
-    other (FIFO), which then also delivers by its own id.
+async def test_out_of_order_answer_targets_the_selected_tab_by_id() -> None:
+    """Tier 2b: ★AC3 — with THREE interventions pending, Left/Right selects
+    the THIRD tab directly and answers it; the other two stay untouched.
+    Migrates the retired P2 F1-interim test's by-id witness (b) onto
+    out-of-order selection instead of FIFO re-route."""
+    transport = RecordingTransport(
+        [
+            _choice_intervention(),
+            _second_choice_intervention(),
+            _third_choice_intervention(),
+        ],
+        end=False,
+    )
+    app = TextualChatApp(transport=transport)
 
-    The re-route does NOT pre-highlight (#3299 P2 co-vet safety fix,
-    architect-agreed "safe side" call): a bare ``Enter`` right after the
-    re-route must answer NOTHING — only after the user explicitly navigates
-    (``Down``) does ``Enter`` deliver. Without this, a user's muscle-memory
-    double-``Enter`` (answer the first, reflexively press Enter again) would
-    silently confirm a DEFAULT option on the second intervention the user
-    never actually looked at — an accidental permission grant, since an
-    intervention can be a permission gate.
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
 
-    NON-VACUITY (falsification):
-    - stripping ``intervention_id=`` from
-      ``TextualChatApp.on_intervention_panel_choice_selected`` /
-      ``on_intervention_panel_text_submitted`` (reverting to
-      head-targeted-only delivery) flips ``transport.answered_choice_ids`` to
-      ``[None, None]`` instead of ``["iv-1", "iv-2"]``.
-    - reverting ``_show_intervention``'s ``initial=False`` on re-route back
-      to always pre-highlighting makes the bare-Enter-after-re-route
-      assertion below FAIL (it would deliver "yes" instead of nothing) —
-      verified locally."""
+        assert set(_iv_entries(app)) == {"iv-1", "iv-2", "iv-3"}
+
+        await pilot.press("right")
+        await pilot.press("right")
+        await pilot.pause()
+        panel = app.query_one(InterventionPanel)
+        assert "branch" in _pane_title(_active_pane(panel)), (
+            "Left/Right did not reach the third pending intervention's tab"
+        )
+
+        await pilot.press("enter")  # pre-highlighted "Yes" on the THIRD tab
+        await pilot.pause()
+        await pilot.pause()
+
+        assert transport.answered_choice_ids == ["iv-3"], (
+            f"answer not targeted at the selected THIRD intervention; got {transport.answered_choice_ids}"
+        )
+        entries = _iv_entries(app)
+        assert entries["iv-3"].item.meta.get("_answer_label") == "Yes"
+        assert entries["iv-1"].item.meta.get("_answer_label") is None
+        assert entries["iv-2"].item.meta.get("_answer_label") is None
+
+
+@pytest.mark.asyncio
+async def test_answered_tab_stays_visible_until_all_resolve() -> None:
+    """Tier 2b: ★AC4 — an answered tab is ✓-labelled and its form disabled,
+    but it STAYS mounted (never removed); the panel itself collapses only
+    once every pending intervention has resolved.
+
+    NON-VACUITY (falsification): if ``mark_answered`` removed the pane
+    (``tabs.remove_pane``) instead of disabling it in place, the ✓-labelled
+    "hosts" tab would be GONE from the tab bar entirely after answering it —
+    verified locally."""
+    transport = RecordingTransport(
+        [_choice_intervention(), _second_choice_intervention()], end=False
+    )
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        panel = app.query_one(InterventionPanel)
+
+        await pilot.press("enter")  # answers iv-1
+        await pilot.pause()
+        await pilot.pause()
+
+        labels = _tab_labels(panel)
+        assert any(label.startswith("✓") and "hosts" in label for label in labels), (
+            f"answered tab was removed instead of staying ✓-labelled; got {labels!r}"
+        )
+        assert any("Overwrite" in label and not label.startswith("✓") for label in labels), (
+            f"the still-pending second tab is missing; got {labels!r}"
+        )
+        first_pane = _tabs(panel).get_pane(_pane_ids_in_order(panel)[0])
+        assert first_pane.query_one(RadioSet).disabled is True, (
+            "answered tab's form was not disabled"
+        )
+        assert panel.display is True, "panel collapsed with a pending intervention still unanswered"
+
+        await pilot.press("right")
+        await pilot.press("enter")  # answers iv-2, the LAST pending one
+        await pilot.pause()
+        await pilot.pause()
+
+        assert panel.display is False, "panel did not collapse once every intervention resolved"
+        assert app.query_one(Composer).has_focus
+
+
+@pytest.mark.asyncio
+async def test_prehighlight_uniform_on_initial_show_and_tab_switch() -> None:
+    """Tier 2b: ★AC5 — the first option is pre-highlighted BOTH on the
+    panel's initial show (bare Enter answers "Yes" on iv-1) AND after
+    switching to a fresh tab (bare Enter, no Down first, answers "Yes" on
+    iv-2 too) — owner decision (A), now unconditional (#3308 retires the P2
+    ``initial``/re-route distinction entirely: the active tab never moves
+    except by explicit navigation, so there is no "unread re-route" case left
+    to guard against)."""
     transport = RecordingTransport(
         [_choice_intervention(), _second_choice_intervention()], end=False
     )
@@ -706,96 +856,66 @@ async def test_multi_pending_answer_targets_the_displayed_intervention_by_id() -
         await pilot.pause()
         await pilot.pause()
 
-        # Answer the FIRST (displayed) intervention — pre-highlighted first
-        # option ("Yes", #3299 P2 owner decision (A)), so a blind Enter
-        # answers it.
-        await pilot.press("enter")
+        await pilot.press("enter")  # initial show pre-highlight
         await pilot.pause()
         await pilot.pause()
-
         assert transport.answered_choice == ["yes"]
-        assert transport.answered_choice_ids == ["iv-1"], (
-            f"first answer not targeted at iv-1; got {transport.answered_choice_ids}"
-        )
-        entries = _iv_entries(app)
-        assert entries["iv-1"].item.meta.get("_answer_label") == "Yes"
-        assert entries["iv-2"].item.meta.get("_answer_label") is None, (
-            "the second (still-pending) intervention's entry must not be touched"
-        )
 
-        # The panel re-routed to the SECOND (still pending) intervention —
-        # never left blank/orphaned.
-        panel = app.query_one(InterventionPanel)
-        assert panel.display is True, "panel went blank instead of re-routing to the next pending intervention"
-        title = panel.query_one("#iv-panel-title", Static)
-        assert "Overwrite" in title.content.plain
+        await pilot.press("right")  # switch to the (still pending) iv-2 tab
+        await pilot.pause()
 
-        # ★co-vet safety fix: the re-route must NOT pre-highlight — a bare
-        # Enter (the user's muscle-memory reflex right after answering the
-        # first intervention) delivers NOTHING to the second, un-requested
-        # intervention.
-        await pilot.press("enter")
+        await pilot.press("enter")  # tab-switch pre-highlight, no Down first
         await pilot.pause()
         await pilot.pause()
 
-        assert transport.answered_choice == ["yes"], (
-            "a bare Enter right after the re-route must not answer the "
-            "un-requested second intervention (accidental-grant risk)"
+        assert transport.answered_choice == ["yes", "yes"], (
+            f"bare Enter after a tab switch did not answer the pre-highlighted "
+            f"first option; got {transport.answered_choice}"
         )
-        entries = _iv_entries(app)
-        assert entries["iv-2"].item.meta.get("_answer_label") is None, (
-            "the second intervention must still be unanswered after a bare Enter"
-        )
-        assert panel.display is True, "panel must stay open — the bare Enter must not have resolved anything"
-
-        # Only EXPLICIT navigation (Down highlights index 0, "Yes") then
-        # Enter delivers.
-        await pilot.press("down")
-        await pilot.press("enter")
-        await pilot.pause()
-        await pilot.pause()
-
-        assert transport.answered_choice == ["yes", "yes"]
-        assert transport.answered_choice_ids == ["iv-1", "iv-2"], (
-            f"second answer not targeted at iv-2; got {transport.answered_choice_ids}"
-        )
-        entries = _iv_entries(app)
-        assert entries["iv-2"].item.meta.get("_answer_label") == "Yes"
-        assert panel.display is False, "panel did not collapse once both resolved"
-        assert app.query_one(Composer).has_focus
-
-
-# --- #3299 P2: auto-focus (A) — blind Enter answers the first option --------
+        assert transport.answered_choice_ids == ["iv-1", "iv-2"]
 
 
 @pytest.mark.asyncio
-async def test_blind_enter_answers_the_first_option_no_arrow_needed() -> None:
-    """Tier 2b: owner decision (A), uniform across all closed-set
-    interventions — on panel appear the FIRST option is pre-highlighted, so a
-    bare ``Enter`` (no ``Down`` first) answers it immediately.
+async def test_left_right_switch_tabs_even_with_radioset_focused() -> None:
+    """Tier 1: ★AC8 — Left/Right switch the ACTIVE TAB even while a
+    ``RadioSet`` has focus, via a ``priority=True`` binding on the panel
+    (Textual's priority pass runs BEFORE the focused-widget-outward walk that
+    would otherwise let ``RadioSet``'s own ``left``/``right`` = prev/next-
+    option aliases win).
 
-    NON-VACUITY (falsification): reverting the ``radio.action_next_button()``
-    pre-highlight call in ``InterventionPanel.show_choice`` leaves
-    ``RadioSet._selected`` unset (``-1``), so ``action_toggle_button`` (bound
-    to Enter) is a no-op and NOTHING is delivered — this assertion would fail
-    with an empty ``transport.answered_choice``, verified locally."""
-    transport = RecordingTransport([_choice_intervention()], end=False)
+    NON-VACUITY (falsification, verified locally): removing ``priority=True``
+    from the panel's ``left``/``right`` ``Binding`` entries makes the active
+    tab stay UNCHANGED after ``Right`` — the key is instead consumed by the
+    focused ``RadioSet``'s own ``next_button`` action (moving its highlight,
+    not the tab) — flipping the assertion below RED."""
+    transport = RecordingTransport(
+        [_choice_intervention(), _second_choice_intervention()], end=False
+    )
     app = TextualChatApp(transport=transport)
 
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
         await pilot.pause()
-
-        radio = app.query_one(InterventionPanel).query_one("#iv-panel-choices", RadioSet)
+        panel = app.query_one(InterventionPanel)
+        tabs = _tabs(panel)
+        active_before = tabs.active
+        radio = _active_pane(panel).query_one(RadioSet)
         assert radio.has_focus
 
-        await pilot.press("enter")  # no "down" first
-        await pilot.pause()
+        await pilot.press("right")
         await pilot.pause()
 
-    assert transport.answered_choice == ["yes"], (
-        f"a blind Enter did not answer the pre-highlighted FIRST option; got {transport.answered_choice}"
-    )
+        assert tabs.active != active_before, (
+            "Right did not switch the active tab while a RadioSet had focus"
+        )
+        assert "Overwrite" in _pane_title(_active_pane(panel))
+        # The FIRST tab's own RadioSet selection must be untouched by the
+        # Right keypress (it must have been consumed as a TAB switch, not a
+        # RadioSet next-option action).
+        first_pane = tabs.get_pane(_pane_ids_in_order(panel)[0])
+        assert first_pane.query_one(RadioSet).pressed_index == -1, (
+            "Right moved the RadioSet's own highlight instead of switching tabs"
+        )
 
 
 # --- #3299 P2 §5: pending EntryState is DEFAULT, never RUNNING/SUCCESS/ERROR
@@ -846,16 +966,16 @@ async def test_pending_intervention_entry_state_is_default_with_dim_awaiting_gly
 
 @pytest.mark.asyncio
 async def test_resolve_updates_the_same_entry_no_new_entry_appended() -> None:
-    """Tier 2b: ★non-vacuity witness for the churn-zero contract — resolving a
-    pending intervention updates the SAME flow entry object in place; the SET
-    of intervention entry objects is unchanged (identity-preserved) and the
-    content becomes the Q→A record — never a second, additional entry.
+    """Tier 2b: ★AC6 — non-vacuity witness for the churn-zero contract —
+    resolving a pending intervention updates the SAME flow entry object in
+    place; the SET of intervention entry objects is unchanged (identity-
+    preserved) and the content becomes the Q→A record — never a second,
+    additional entry.
 
-    NON-VACUITY (falsification): if ``_resolve_pending_intervention`` APPENDED
-    a new entry instead of ``entry.set_item(...)``-ing the tracked one (the
-    owner's original "解凍後に別の flow entry が出る" churn complaint), the
-    identity-set below would gain a SECOND, different entry object rather than
-    staying exactly the one entry seen before resolving — this assertion
+    NON-VACUITY (falsification): if ``_resolve_intervention`` APPENDED a new
+    entry instead of ``entry.set_item(...)``-ing the tracked one, the
+    identity-set below would gain a SECOND, different entry object rather
+    than staying exactly the one entry seen before resolving — this assertion
     would fail."""
     transport = RecordingTransport([_choice_intervention()], end=False)
     app = TextualChatApp(transport=transport)

--- a/tests/test_textual_chat_intervention_panel_3299.py
+++ b/tests/test_textual_chat_intervention_panel_3299.py
@@ -676,13 +676,20 @@ async def test_second_enter_after_answering_does_not_deliver_to_unread_second() 
     (a) onto the tab-ified structure (#3308 co-vet correction: the interim
     MECHANISM is retired, this PROPERTY is not).
 
-    NON-VACUITY (falsification): if ``InterventionPanel.mark_answered``
-    stopped disabling the tab's ``RadioSet`` (reverting the
-    ``control.disabled = True`` loop), the second bare ``Enter`` would still
-    land on the same (still-enabled, still-selected) RadioSet and could
-    re-post a ``Changed``/toggle — verified locally that stripping the
-    disable loop flips ``transport.answered_choice`` to length 2 instead of
-    staying at 1."""
+    NON-VACUITY (falsification, verified locally): the disable loop itself is
+    independently witnessed by
+    ``test_answered_tab_stays_visible_until_all_resolve``'s focus-refusal
+    probe, not by THIS test's keyboard replay — after answering,
+    ``mark_answered`` also moves focus onto the panel's ``Tabs`` bar
+    (:meth:`InterventionPanel.mark_answered`'s docstring), so a keyboard-only
+    Down+Enter probe here lands on the Tabs bar, not the (still technically
+    reachable-by-direct-``.focus()``) RadioSet — stripping ``disabled = True``
+    alone does NOT flip this specific test RED (confirmed by trial: the focus
+    re-anchor already blocks the keyboard path on its own). What THIS test
+    demonstrates instead is the observable end-to-end behavior a user
+    actually experiences: neither a repeat bare ``Enter`` (RadioSet doesn't
+    re-post ``Changed`` for re-toggling an already-selected button — true
+    regardless of ``disabled``) nor Down+Enter re-delivers after resolving."""
     transport = RecordingTransport(
         [_choice_intervention(), _second_choice_intervention()], end=False
     )
@@ -713,13 +720,36 @@ async def test_second_enter_after_answering_does_not_deliver_to_unread_second() 
             "the second (still-pending) intervention must remain unanswered"
         )
 
+        # Stronger probe: navigate WITHIN the answered tab (Down then Enter,
+        # picking a DIFFERENT option) — this is what the disabled form must
+        # actually block (the bare-Enter-alone case above is a no-op even
+        # without disabling, since RadioSet itself doesn't re-fire ``Changed``
+        # for re-toggling the SAME already-selected button).
+        await pilot.press("down")
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert transport.answered_choice == ["yes"], (
+            "navigating within the answered (disabled) tab still delivered — "
+            f"got {transport.answered_choice}"
+        )
+
 
 @pytest.mark.asyncio
 async def test_new_pending_intervention_does_not_steal_the_active_tab() -> None:
     """Tier 2b: ★AC2 — with the panel already showing the FIRST intervention,
     a SECOND arriving does not move the active tab; the first stays active
     and answerable by a bare Enter. Migrates the retired P2 F1-interim test's
-    coverage of "the second intervention's entry must not be touched"."""
+    coverage of "the second intervention's entry must not be touched".
+
+    NON-VACUITY (falsification, verified locally): temporarily adding
+    ``self.call_after_refresh(lambda: setattr(tabs, "active", pane_id))``
+    at the end of ``InterventionPanel.add_pending`` (force-stealing the
+    active tab on every arrival, deferred past the new pane's own mount so
+    the force actually takes effect) flips the assertion below RED — the
+    active pane becomes the SECOND ("Overwrite existing file?") instead of
+    staying on the first ("...hosts?")."""
     transport = RecordingTransport(
         [_choice_intervention(), _second_choice_intervention()], end=False
     )
@@ -754,7 +784,12 @@ async def test_out_of_order_answer_targets_the_selected_tab_by_id() -> None:
     """Tier 2b: ★AC3 — with THREE interventions pending, Left/Right selects
     the THIRD tab directly and answers it; the other two stay untouched.
     Migrates the retired P2 F1-interim test's by-id witness (b) onto
-    out-of-order selection instead of FIFO re-route."""
+    out-of-order selection instead of FIFO re-route.
+
+    NON-VACUITY (falsification, verified locally): reverting
+    ``on_intervention_panel_choice_selected``'s ``intervention_id=iv_id`` to
+    ``intervention_id=None`` flips ``transport.answered_choice_ids`` to
+    ``[None]`` instead of ``["iv-3"]``."""
     transport = RecordingTransport(
         [
             _choice_intervention(),
@@ -800,8 +835,12 @@ async def test_answered_tab_stays_visible_until_all_resolve() -> None:
 
     NON-VACUITY (falsification): if ``mark_answered`` removed the pane
     (``tabs.remove_pane``) instead of disabling it in place, the ✓-labelled
-    "hosts" tab would be GONE from the tab bar entirely after answering it —
-    verified locally."""
+    "hosts" tab would be GONE from the tab bar entirely after answering it.
+    Separately, if the ``control.disabled = True`` loop were removed, the
+    ``.disabled is True`` assertion below fails directly, and the focus-
+    refusal probe (a disabled widget's ``.focus()`` is a no-op, verified
+    against the installed Textual 8.2.8) would instead succeed. Both
+    verified locally by trial-reverting each independently."""
     transport = RecordingTransport(
         [_choice_intervention(), _second_choice_intervention()], end=False
     )
@@ -824,8 +863,17 @@ async def test_answered_tab_stays_visible_until_all_resolve() -> None:
             f"the still-pending second tab is missing; got {labels!r}"
         )
         first_pane = _tabs(panel).get_pane(_pane_ids_in_order(panel)[0])
-        assert first_pane.query_one(RadioSet).disabled is True, (
-            "answered tab's form was not disabled"
+        first_radio = first_pane.query_one(RadioSet)
+        assert first_radio.disabled is True, "answered tab's form was not disabled"
+        # A disabled widget REFUSES focus outright (verified against the
+        # installed Textual 8.2.8: ``Widget.focus()`` on a ``disabled``
+        # widget is a no-op) — the strongest available falsifiable probe
+        # that the answered form is genuinely inert, independent of
+        # whatever keyboard path might otherwise reach it.
+        first_radio.focus()
+        await pilot.pause()
+        assert app.focused is not first_radio, (
+            "the answered tab's disabled RadioSet accepted focus — not inert"
         )
         assert panel.display is True, "panel collapsed with a pending intervention still unanswered"
 
@@ -846,7 +894,14 @@ async def test_prehighlight_uniform_on_initial_show_and_tab_switch() -> None:
     iv-2 too) — owner decision (A), now unconditional (#3308 retires the P2
     ``initial``/re-route distinction entirely: the active tab never moves
     except by explicit navigation, so there is no "unread re-route" case left
-    to guard against)."""
+    to guard against).
+
+    NON-VACUITY (falsification, verified locally): removing the
+    focus-follows-activation body of
+    ``InterventionPanel.on_tabbed_content_tab_activated`` (never focusing the
+    newly-active pane's RadioSet/Input) flips even the FIRST assertion below
+    RED — a bare Enter delivers nothing at all once focus never lands on any
+    form."""
     transport = RecordingTransport(
         [_choice_intervention(), _second_choice_intervention()], end=False
     )

--- a/tests/test_textual_chat_intervention_panel_3299.py
+++ b/tests/test_textual_chat_intervention_panel_3299.py
@@ -1060,3 +1060,117 @@ async def test_resolve_updates_the_same_entry_no_new_entry_appended() -> None:
         assert entry_before.item.meta.get("_answer_label") == "Yes", (
             "the SAME entry object was not updated in place with the resolved answer"
         )
+
+
+# --- #3311 tui-coder real-TTY finding: panel must not swallow the screen ----
+# tui-coder's real-TTY witness found that ``InterventionPanel``'s OWN
+# ``DEFAULT_CSS`` carried an ``InterventionPanel Tabs { height: auto; }``
+# rule that overrode Textual's ``Tabs`` widget's own sensible fixed
+# ``height: 2`` default (``textual.widgets.Tabs.DEFAULT_CSS``, verified
+# against the installed Textual 8.2.8) — ``height: auto`` on ``Tabs`` (a
+# widget that is NOT designed for auto-sizing) resolved to a hugely inflated
+# value, and the panel's own ``height: auto`` then grew to match, pushing the
+# FlowView and Composer off-screen. EVERY widget-state assertion in this file
+# (``panel.display is True``, ``radio.has_focus``, tab labels, etc.) stayed
+# green throughout — none of them look at LAYOUT GEOMETRY, so this defect
+# slipped through all of them. These tests close that gap by asserting on
+# ``Widget.region`` (Textual's own computed screen-space rectangle) directly.
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("screen_size", [(80, 24), (100, 60)])
+async def test_pending_intervention_panel_does_not_swallow_the_screen(
+    screen_size: "tuple[int, int]",
+) -> None:
+    """Tier 2b: ★ real-TTY-witnessed regression guard (#3311) — with ONE
+    intervention pending, on TWO screen sizes: the panel's region must be a
+    SMALL FRACTION of the screen height (not the whole screen), and the
+    FlowView (conversation) + Composer (input row) must both be FULLY
+    CONTAINED on-screen (``0 <= y`` AND ``y + height <= screen_height`` —
+    BOTH bounds) with the FlowView NOT squashed to a hairline sliver.
+
+    ★co-vet correction (an earlier version of this test asserted only
+    ``region.height > 0`` and an upper-bound-only containment check
+    (``y + height <= screen_height``) — BOTH are insufficient: measured
+    directly against the actual pre-fix defect, the FlowView's region was
+    ``y=-8, height=1`` — height IS non-zero (1), and ``y + height = -7 <=
+    screen_height`` is trivially TRUE for a NEGATIVE ``y`` (pushed off the
+    TOP of the screen), so neither check alone would have caught it. The
+    Composer's defective region (``y=24, height=1`` on an 80x24 screen) WAS
+    caught by an upper-bound check (``24 + 1 = 25 > 24``), but relying on
+    that asymmetry across the two widgets is exactly the born-vacuous trap —
+    this version requires the LOWER bound (``y >= 0``) explicitly for both,
+    plus a not-squashed floor on the FlowView, so it cannot pass by
+    coincidence of which widget happened to be pushed which direction.
+
+    NON-VACUITY (falsification, verified locally against the actual pre-fix
+    ``InterventionPanel Tabs { height: auto; }`` rule, both screen sizes):
+    - 80x24: FlowView measured ``Region(x=0, y=-8, width=78, height=1)``
+      (``y >= 0`` fails) and Composer ``Region(x=2, y=24, width=76,
+      height=1)`` (``y + height = 25 > 24`` fails).
+    - 100x60: FlowView ``Region(x=0, y=-8, width=98, height=1)`` (``y >= 0``
+      fails), Composer ``Region(x=2, y=60, width=96, height=1)`` (``y +
+      height = 61 > 60`` fails).
+    A widget-state-only assertion (``panel.display is True``) would NOT have
+    caught any of this — the panel WAS displayed, just enormous."""
+    transport = RecordingTransport([_choice_intervention()], end=False)
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=screen_size) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        panel = app.query_one(InterventionPanel)
+        flow = app.query_one(FlowView)
+        composer = app.query_one(Composer)
+
+        screen_height = app.size.height
+        assert panel.region.height < screen_height // 2, (
+            f"the pending-intervention panel's region ({panel.region!r}) "
+            f"consumes more than half the {screen_height}-row screen"
+        )
+        for name, widget in (("FlowView", flow), ("Composer", composer)):
+            region = widget.region
+            assert region.y >= 0, (
+                f"{name}'s region is pushed OFF the top of the screen "
+                f"(negative y); region={region!r}"
+            )
+            assert region.y + region.height <= screen_height, (
+                f"{name}'s region extends past the bottom of the "
+                f"{screen_height}-row screen; region={region!r}"
+            )
+        # The FlowView must not be merely "contained" but squashed to a
+        # hairline (the actual pre-fix defect measured height=1 while ALSO
+        # being off-screen — a not-squashed floor closes the case where a
+        # future regression keeps it on-screen but still crushes it).
+        assert flow.region.height >= 3, (
+            f"the FlowView (conversation) is squashed to a hairline while an "
+            f"intervention is pending; region={flow.region!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_tabs_bar_height_is_the_native_fixed_two_rows() -> None:
+    """Tier 1: ★ direct witness for the root cause — the panel's internal
+    ``Tabs`` bar (the tab-caption row) must be Textual's OWN fixed
+    ``height: 2`` default, never stretched to ``auto``.
+
+    NON-VACUITY (falsification, verified locally): restoring the
+    ``InterventionPanel Tabs { height: auto; }`` rule makes the ``Tabs``
+    widget's own computed region height balloon (observed locally: from 2 to
+    over 30 rows on an 80x24 screen) instead of staying at 2."""
+    from textual.widgets import Tabs
+
+    transport = RecordingTransport([_choice_intervention()], end=False)
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        panel = app.query_one(InterventionPanel)
+        tabs_bar = panel.query_one(TabbedContent).query_one(Tabs)
+        assert tabs_bar.region.height == 2, (
+            f"the intervention panel's Tabs bar is not Textual's native fixed "
+            f"height (2) — got {tabs_bar.region.height}; region={tabs_bar.region!r}"
+        )


### PR DESCRIPTION
**[per-PR-coder]** — part of #3299, Closes #3308

## Summary

Tabs the intervention panel: one `TabPane` per PENDING intervention (`InterventionPanel.add_pending`), added the moment its frame arrives and never swapped out from under the user. Replaces #3307 (P2)'s single-form FIFO re-route entirely.

- `TabbedContent.add_pane` auto-activates a new pane ONLY when the content was previously empty (verified against installed Textual 8.2.8) — this alone gives the "never steal the active tab" invariant, no app-level bookkeeping needed.
- Answering a tab (`on_intervention_panel_choice_selected` / `_text_submitted`) delivers targeted at THAT tab's `intervention_id` (the message itself carries `event.key` — no more app-level "currently displayed" tracking) and marks the tab ✓/inert (`InterventionPanel.mark_answered`: label gets a `✓` prefix, its `RadioSet`/`Input` gets `disabled = True`, and if it was the active tab, focus moves to the panel's own `Tabs` bar so `Left`/`Right` keeps working). The tab STAYS mounted until every pending intervention resolves, at which point the whole panel collapses (`collapse_all`).
- `Left`/`Right` switch tabs via a `priority=True` `Binding` on the panel — **co-vet-corrected keymap contract** (see issue comment): `RadioSet` already binds `left`/`right` as `up`/`down` aliases (`down,right → next_button`, `up,left → previous_button`, Textual 8.2.8), so a plain ancestor binding would never fire while a `RadioSet` has focus. Verified `textual/app.py` (~L3966-3988, L4136) and `textual/screen.py` (~L407-455): Textual runs a **priority pass first**, outermost-ancestor-down, matching only `priority=True` bindings, before the normal focused-widget-outward walk where `RadioSet`'s own binding would win. A `priority=True` binding on the panel intercepts first.
- Pre-highlight (owner decision (A)) is now **unconditional** on every tab activation (`on_tabbed_content_tab_activated`) — no `initial`/re-route distinction needed anymore, since each pending intervention gets its OWN fresh `RadioSet` (Textual's own `RadioSet._on_mount` already pre-highlights index 0 the moment that instance is constructed) and the active tab never moves except by explicit navigation.
- Three independent LLM-derived-text neutralization call sites in `add_pending` (tab label / pane title / pane detail — each a SEPARATE `_neutralized_label(...)` call so a strip of one never masks another), plus the retained choice-label site.
- `_pending_ivs` simplified from P2's 3-tuple `(entry, msg, iv_id)` to `(entry, iv_id)` — the `msg` slot existed only to re-populate a re-routed panel, which no longer happens.

## Issue-comment corrections folded in

1. **Keymap contract correction** (`priority=True`, not a naive ancestor binding) — implemented and strip-falsified (AC8 below).
2. **F1-interim test migrated, not deleted** — the interim mechanism (`_show_intervention`'s `initial=False` no-pre-highlight-on-reroute) is retired since re-route no longer exists, but its two safety properties are preserved in the new structure: (a) "bare Enter right after answering doesn't deliver a default to an unread other intervention" → AC1 (`test_second_enter_after_answering_does_not_deliver_to_unread_second`), (b) "by-id delivery witness" → AC3 (`test_out_of_order_answer_targets_the_selected_tab_by_id`, using out-of-order selection instead of FIFO re-route).

## Strip-falsify — observed RED per acceptance condition

All performed on a clean tree (temporarily edited, ran the targeted test, restored via `git checkout --` after committing prior work — never on uncommitted changes).

**AC1** (Enter-twice delivers exactly one answer) — strip: removed `mark_answered`'s `control.disabled = True` loop.
Observed: the literal repeat-bare-Enter sub-case stayed green (RadioSet doesn't re-post `Changed` for re-toggling an already-selected button, independent of `disabled`), so I strengthened the test with a Down+Enter probe on the answered tab and additionally added a direct focus-refusal probe to AC4 (see below) — that IS the real, isolated witness for the disable mechanism:
```
AssertionError: answered tab's form was not disabled
assert False is True
 +  where False = RadioSet().disabled
```

**AC2** (new arrival never steals the active tab) — strip: added `self.call_after_refresh(lambda: setattr(tabs, 'active', pane_id))` at the end of `add_pending` (force-steal, deferred past the new pane's own mount so the force actually takes effect — an immediate, non-deferred `tabs.active = pane_id` doesn't reliably force it due to an add_pane/mount race).
```
AssertionError: a new arrival stole the active tab from the first pending intervention
assert 'hosts' in 'Overwrite existing file?'
```

**AC3** (out-of-order + by-id delivery) — strip: `intervention_id=iv_id` → `intervention_id=None` in `on_intervention_panel_choice_selected`.
```
AssertionError: answer not targeted at the selected THIRD intervention; got [None]
assert [None] == ['iv-3']
```

**AC4** (answered tabs stay until all resolve) — two independent strips:
- strip A: removed the `control.disabled = True` loop:
```
AssertionError: answered tab's form was not disabled
assert False is True
```
  (plus a focus-refusal probe: `first_radio.focus(); assert app.focused is not first_radio` — a disabled widget's `.focus()` is a no-op, verified against installed Textual 8.2.8.)
- strip B: removed the `if self._pending_ivs: return` gate in `_resolve_intervention` (always `collapse_all()`):
```
AssertionError: answered tab was removed instead of staying ✓-labelled; got []
```

**AC5** (pre-highlight uniform on initial show AND tab switch) — strip: removed the focus-follows-activation body of `on_tabbed_content_tab_activated` entirely.
```
AssertionError: assert [] == ['yes']
```
(fails even on the FIRST bare Enter — once nothing is ever focused, nothing is reachable at all.)

**AC6** (churn-zero) — strip: `entry.set_item(...)` → `self.conversation.append(...)` in `_resolve_intervention`.
```
AssertionError: resolving changed the SET of intervention flow-entry objects — churn regressed
assert {4458863232, 4461642464} == {4458863232}
```

**AC7** (3 independent neutralization sites + retained choice-label site) — 4 separate strips, each flipping **only its own test** RED (verified all 4 together each time, confirming no cross-masking):
- tab-label site (`tab_label_text = _neutralized_label(prompt)` → `= prompt`): only `test_panel_tab_label_neutralizes_raw_esc_osc` RED.
- title site (`title_text = _neutralized_label(prompt)` → `= prompt`): only `test_panel_title_neutralizes_raw_esc_osc` RED.
- detail site (`detail_text = _neutralized_label(detail)` → `= detail`): only `test_panel_detail_neutralizes_raw_esc_osc` RED.
- choice-label site (dropped `_neutralized_label` in the label list comprehension): only `test_panel_choice_label_neutralizes_raw_esc_osc` RED.
Each: `AssertionError: raw ESC leaked into ... '\x1b[31mRED\x1b]0;pwn'`.

**AC8** (Left/Right switch tabs even with a RadioSet focused, via `priority=True`) — strip: `priority=True` → `priority=False` on both bindings.
```
AssertionError: Right did not switch the active tab while a RadioSet had focus
assert 'iv-pane-0' != 'iv-pane-0'
```

## Doc-drift

`docs/reference/runtime/agui-transport.md`'s "Local ≡ remote holds for INPUT too" section described the panel as "a closed-set `RadioSet` / free-text `Input`" (P1/P2 single-form) — updated to describe the tab-ify + by-id delivery + ✓/inert-without-removal semantics. No `.ja.md` sibling references this content (checked), so no mirror edit needed (#2967 backlog rule).

## Test plan

- [x] `ruff check src tests` — clean.
- [x] `python scripts/test_tier_audit.py --strict tests/test_textual_chat_intervention_panel_3299.py` — 20/20 OK, 0 Tier-4 violations.
- [x] Full foreground suite, alone, no concurrent pytest: `uv run python -m pytest --timeout=120 -q -n auto` — **9198 passed, 36 skipped, 0 failed** (246.5s).
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/intervention_panel.py src/reyn/interfaces/inline/textual_chat/app.py` — clean.
- [x] Strip-falsify all 8 acceptance conditions — observed RED per site, documented above and in each test's NON-VACUITY docstring note.
- [x] Manual: none applicable beyond the above (tui-coder real-TTY witness for simultaneous multi-pending is flagged in the issue as a known constraint — not re-verified here, synthetic frame injection via `RecordingTransport` is the only path this PR exercises, consistent with the issue's own caveat).

🤖 Generated with contributions from Claude Opus 5 / Sonnet 5.
