### PR TITLE
feat(llm,runtime,transport): agent_delta chat-event for streaming partials — #3288 ③b

### DIFF
--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -126,8 +126,16 @@ The AG-UI spec mandates the text lifecycle **`TEXT_MESSAGE_START` → one or mor
 bare `TEXT_MESSAGE_CONTENT` is invalid (a strict generic client drops it). A whole
 reyn text message therefore rides the wire as that triplet, with a generated
 per-message id (reyn's outbox has no stable message id) and the CONTENT `delta`
-carrying the full message text (reyn is whole-message; token-streaming is out of
-scope).
+carrying the full message text — this STANDARD triplet stays whole-message (one
+CONTENT event per completed reply, never split into per-token frames).
+
+Token-level streaming DOES now exist on a SEPARATE channel: `reyn.event.agent_delta`
+(#3288 ③b, see below) carries the LLM's raw per-chunk deltas as they arrive,
+purely as an additive, non-persistent notification — the standard
+`TEXT_MESSAGE_CONTENT` triplet above is unaffected (still one whole-text CONTENT
+event, emitted after the delta stream completes) and no shipped generic-client
+surface consumes `agent_delta` yet (a later phase, ③d, is expected to fold it
+into a real multi-CONTENT triplet for the standard surface).
 
 Only the **CONTENT** event carries the `_reyn` reconstruction block; the START and
 END events are generic scaffold that the reyn client decodes to `None` and
@@ -375,14 +383,18 @@ A reyn display frame with no standard AG-UI analog. `value` is `{"text": <string
 
 ### `reyn.event.<etype>`
 
-A reyn chat-event (working-indicator axis) with no standard AG-UI analog. `value`
-is the event's data object.
+A reyn chat-event with no standard AG-UI analog. `value` is the event's data
+object. Most members are the working-indicator axis (turn-lifecycle /
+tool-call / user-submitted / cancel); `agent_delta` (#3288 ③b) is a SEPARATE
+streaming-notification axis — see its row below and the `_STREAMING_EVENTS`
+comment in `frames.py` for why it is forwarded ahead of any renderer consumer.
 
 | Custom `name`                        | Meaning                                          |
 |--------------------------------------|--------------------------------------------------|
 | `reyn.event.user_answered_intervention` | the user answered an intervention             |
 | `reyn.event.user_submitted`          | a user turn was submitted (#3300 P1 C) — RAW text + chain_id + msg_id + seq + meta; each surface neutralizes at its render boundary. `msg_id`/`seq` are the #3300 P2a sent-queue correlation id + order-race-gate token |
 | `reyn.event.inbox_cancel`            | an UNDISPATCHED queued user message was cancelled by id (#3300 P3, via the `cancel_queued` client message) — carries `msg_id` + `seq`; the server-authoritative sent-queue removal signal (never a client-local "cancel succeeded" response), exclusive with `turn_started` for the same `msg_id` |
+| `reyn.event.agent_delta`             | one streamed LLM content-delta chunk (#3288 ③b) — carries `text` (the raw per-chunk delta) + `chain_id`. NON-PERSISTENT and purely additive: the single source of truth stays the completed full-text `reyn.display.agent`-mapped `TEXT_MESSAGE_CONTENT` frame (`kind="agent"`), emitted exactly once at turn end (whole-persist, L9, is unaffected). Forwarded even though no shipped renderer consumes it yet — a client with no handler ignores it (skipped, not fatal), same as any unknown `CUSTOM` name; a future phase (③c local / ③d AG-UI generic multi-CONTENT) adds a consumer without requiring a wire change here |
 
 ### `reyn.intervention.<kind>`
 

--- a/src/reyn/interfaces/transport/agui/profile.py
+++ b/src/reyn/interfaces/transport/agui/profile.py
@@ -145,6 +145,17 @@ CUSTOM_PROFILE: dict[str, CustomName] = _entries(
         "removal signal, exclusive with turn_started for the same msg_id "
         "(never a client-local cancel-success response)",
     ),
+    CustomName(
+        "reyn.event.agent_delta", EVENT_NS, "the event data object",
+        "one streamed LLM content-delta chunk (#3288 ③b) — carries the raw "
+        "delta text + chain_id; a NON-PERSISTENT, purely additive notification "
+        "(the owner-ratified L4 chat-event route, replacing the earlier "
+        "OutboxMessage-kind ADR wording) — the single source of truth stays "
+        "the completed full-text kind=\"agent\" OutboxMessage emitted exactly "
+        "once at turn end (L9 whole-persist is unaffected). A surface with no "
+        "handler for this event consumes-but-drops it (no draw), unlike an "
+        "unknown DISPLAY kind; ③c adds the textual_chat coalescing consumer",
+    ),
 )
 
 

--- a/src/reyn/interfaces/transport/frames.py
+++ b/src/reyn/interfaces/transport/frames.py
@@ -18,14 +18,20 @@ A frame carries its :class:`FrameTag` so the consuming client dispatches to the
 renderer's two entry points (``message`` for display, ``on_chat_event`` for
 event) at the consuming end — one stream in, two renderer entry points out.
 
-The forward-set (:func:`renderer_chat_events`) is **DERIVED** from the
+The forward-set (:func:`renderer_chat_events`) is mostly **DERIVED** from the
 renderer's own vocabulary — ``_WAITING_ON_BY_EVENT`` (the tool-axis table) plus
 the turn / intervention-answer events ``on_chat_event`` handles — never
 hand-listed. The dual-stream completeness gate
 (``tests/test_transport_dual_stream_completeness.py``) binds the transport's
 coverage to that vocabulary so a renderer event the transport does not forward
 fails CI instead of silently vanishing on the wire (the A2 dual-stream bug,
-designed out).
+designed out). The ONE deliberate exception is :data:`_STREAMING_EVENTS`
+(#3288 ③b, ``agent_delta``) — forwarded ahead of any renderer consumer, by
+design: the completeness gate only requires ``consumed ⊆ forwarded``, never
+the reverse, so a forwarded-but-not-yet-consumed event is legal, and an EVENT
+frame with no handler is silently dropped (not rendered) at the consuming
+end — the mechanism a later phase (③c) plugs a consumer into without ever
+risking a "vanished on the wire" regression in the meantime.
 """
 from __future__ import annotations
 
@@ -79,10 +85,28 @@ _TURN_AND_ANSWER_EVENTS = frozenset(
 )
 
 
+# #3288 ③b: streamed LLM content-delta chat-events — the owner-ratified L4
+# replacement (issue #3288 comment thread): a partial rides a chat-event
+# (never an ``OutboxMessage`` kind, which the closed display vocabulary would
+# have to register — the category error the owner's decision designs out).
+# UNLIKE :data:`_TURN_AND_ANSWER_EVENTS` above, this is forwarded AHEAD OF any
+# consumer — no renderer branches on ``"agent_delta"`` yet (③c adds the
+# textual_chat coalescing handler as a later phase; the plain/repl renderer
+# may never consume it at all). This is legal per the dual-stream
+# completeness gate's actual direction (``tests/test_transport_dual_stream_completeness.py``:
+# ``consumed ⊆ forwarded``, never the reverse) — a forwarded event nobody
+# consumes yet is not a coverage gap, and a surface with no handler for an
+# EVENT frame consumes-but-drops it (never renders it), unlike an unknown
+# DISPLAY kind (which a presenter renders generically) — see the ③b PR body
+# for the frame-level witness of that "no visible-garbage window" property.
+_STREAMING_EVENTS = frozenset({"agent_delta"})
+
+
 @lru_cache(maxsize=1)
 def renderer_chat_events() -> frozenset[str]:
-    """The exact set of chat-event types the renderer consumes — the transport's
-    forward-set, DERIVED from the renderer's vocabulary, never hand-listed.
+    """The set of chat-event types the transport forwards onto the unified
+    frame stream (both ``InProcessTransport`` and the AG-UI endpoint filter
+    against this).
 
     Union of:
 
@@ -91,9 +115,15 @@ def renderer_chat_events() -> frozenset[str]:
       / ``tool_failed``); extending WaitingOn to a new axis is one new entry
       there and this set follows automatically.
     - :data:`_TURN_AND_ANSWER_EVENTS` — the turn-lifecycle / intervention-answer
-      / user-submitted events ``renderer.on_chat_event`` branches on directly.
+      / user-submitted events ``renderer.on_chat_event`` branches on directly
+      (DERIVED from the renderer's own vocabulary, never hand-listed for this
+      half — see ``tests/test_transport_dual_stream_completeness.py``).
+    - :data:`_STREAMING_EVENTS` (#3288 ③b) — the ONE deliberate exception to
+      "derived, not hand-listed": forwarded ahead of any renderer consumer, so
+      an unconsuming surface silently drops it (opt-in draw) instead of it
+      vanishing on the wire before a later phase adds the consumer.
     """
-    return frozenset(_WAITING_ON_BY_EVENT.keys()) | _TURN_AND_ANSWER_EVENTS
+    return frozenset(_WAITING_ON_BY_EVENT.keys()) | _TURN_AND_ANSWER_EVENTS | _STREAMING_EVENTS
 
 
 @dataclass(frozen=True)

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1837,6 +1837,7 @@ async def recorded_acompletion(
             # passed in the call kwargs.
             return chunk_stream
         chunks = []
+        _delta_fired = False
         async for chunk in chunk_stream:
             chunks.append(chunk)
             if on_content_delta is not None:
@@ -1846,6 +1847,7 @@ async def recorded_acompletion(
                 except Exception:  # noqa: BLE001 — malformed/empty chunk shape
                     _delta_text = None
                 if _delta_text:
+                    _delta_fired = True
                     try:
                         on_content_delta(_delta_text)
                     except Exception:  # noqa: BLE001 — a display-event emit must never break the LLM call
@@ -1853,6 +1855,22 @@ async def recorded_acompletion(
                             "recorded_acompletion: on_content_delta callback raised; "
                             "continuing the stream"
                         )
+        # #3288 ③b co-vet fix: a silent functional-dead-mode guard. If the
+        # provider streamed at least one chunk AND a callback was supplied,
+        # but NOT ONE chunk ever exposed a non-empty delta.content (e.g. a
+        # provider whose chunk shape this parsing doesn't match), every turn
+        # would silently produce ZERO delta notifications forever — L9 still
+        # surfaces the final text via the reconstructed whole response below,
+        # so nothing user-visible breaks and nobody would ever notice.
+        # ONE debug log per STREAM (not per chunk, which would be noise) is
+        # cheap and makes that silent mode observable.
+        if on_content_delta is not None and chunks and not _delta_fired:
+            logger.debug(
+                "recorded_acompletion: streamed %d chunk(s) but on_content_delta "
+                "never fired — the provider's chunk shape may not expose "
+                "delta.content the way this parsing expects",
+                len(chunks),
+            )
         reconstructed = litellm.stream_chunk_builder(chunks, messages=msgs)
         if reconstructed is None:
             # No chunks at all (degenerate empty stream) — degrade to the

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -10,7 +10,7 @@ import weakref
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
-from typing import TYPE_CHECKING, Coroutine, NamedTuple, TypeVar, Union
+from typing import TYPE_CHECKING, Callable, Coroutine, NamedTuple, TypeVar, Union
 
 logger = logging.getLogger(__name__)
 from reyn.llm.credentials import check_model_credentials
@@ -1617,6 +1617,7 @@ async def recorded_acompletion(
     extra_kwargs: dict | None = None,
     emit_cost_events: bool = False,  # #1683: chat path opts in (kernel emits via LLMCallRecorder)
     routing: dict | None = None,  # #309: per-class api_base/provider; None → global proxy_kwargs()
+    on_content_delta: "Callable[[str], None] | None" = None,  # #3288 ③b: opt-in per-chunk content-delta callback (see _stream_and_reconstruct)
 ) -> object:
     """Single cost-observability chokepoint for ALL ``litellm.acompletion`` calls (#1190).
 
@@ -1632,6 +1633,17 @@ async def recorded_acompletion(
     is called ONLY inside this function, so no LLM call can bypass recording.
     Replay-safe: the call still bottoms out at ``litellm.acompletion``, which
     ``LLMReplay`` monkeypatches.
+
+    ``on_content_delta`` (#3288 ③b): an OPT-IN, per-call callback invoked
+    SYNCHRONOUSLY with each non-empty content-delta string as ``_stream_and_reconstruct``
+    (③a) drains the chunk stream — never invoked on the whole-collect (non-streaming)
+    path, so it is capability-gated by construction (see ``_streaming_capable``: no
+    capability ⇒ no streaming ⇒ this callback never fires). ``None`` (every caller
+    except ``RouterLoop``'s primary reply call) is byte-identical to today. A raising
+    callback is caught and logged — a broken display-event emit must never break the
+    LLM call it is merely narrating. The reconstructed WHOLE response (below) is
+    unaffected either way — this is purely an additional notification channel, not a
+    change to what this function returns or records.
     """
     # perf: litellm's own import is ~1.5s and is kept off the chat startup
     # path (input box renders before any LLM use). ``ensure_litellm_ready``
@@ -1779,6 +1791,18 @@ async def recorded_acompletion(
         ``stream_chunk_builder`` falls back to a token-count estimate for
         usage, the same graceful degradation litellm's own non-Reyn callers
         rely on.
+
+        #3288 ③b: ``on_content_delta`` (the enclosing ``recorded_acompletion``'s
+        parameter, closed over here) is invoked ONCE PER CHUNK that carries a
+        non-empty ``delta.content``, with that chunk's raw text — BEFORE the
+        chunk is appended to ``chunks`` below, so it fires against REAL,
+        individually-drained chunks (never a synthesized/batched replay of the
+        reconstructed whole). A callback failure is caught and logged, never
+        allowed to abort the stream — the callback narrates the call, it does
+        not gate it. tool_call-only chunks (no ``content``) are silently
+        skipped — ③b carries TEXT deltas only; tool-call argument streaming is
+        out of scope (unchanged: tool_calls are read from the reconstructed
+        whole response, same as ③a).
         """
         stream_kwargs = dict(call_kwargs)
         stream_kwargs.pop("stream", None)
@@ -1812,7 +1836,23 @@ async def recorded_acompletion(
             # the async generator), not just that ``stream=True`` was
             # passed in the call kwargs.
             return chunk_stream
-        chunks = [chunk async for chunk in chunk_stream]
+        chunks = []
+        async for chunk in chunk_stream:
+            chunks.append(chunk)
+            if on_content_delta is not None:
+                _delta_text = None
+                try:
+                    _delta_text = chunk.choices[0].delta.content
+                except Exception:  # noqa: BLE001 — malformed/empty chunk shape
+                    _delta_text = None
+                if _delta_text:
+                    try:
+                        on_content_delta(_delta_text)
+                    except Exception:  # noqa: BLE001 — a display-event emit must never break the LLM call
+                        logger.exception(
+                            "recorded_acompletion: on_content_delta callback raised; "
+                            "continuing the stream"
+                        )
         reconstructed = litellm.stream_chunk_builder(chunks, messages=msgs)
         if reconstructed is None:
             # No chunks at all (degenerate empty stream) — degrade to the
@@ -1952,6 +1992,7 @@ async def call_llm_tools(
     event_log: "EventLog | None" = None,
     emit_cost_events: bool = False,  # #1683: forwarded to recorded_acompletion (chat opts in)
     response_format: "dict | None" = None,  # 0062: RouterLoop's separate no-tools structured-answer turn ONLY — every op-loop tool-decision call leaves this None (ADR-0035 D2 separate-decide preserved: never combined with a non-empty `tools`)
+    on_content_delta: "Callable[[str], None] | None" = None,  # #3288 ③b: forwarded to recorded_acompletion — see its docstring
 ) -> LLMToolCallResult:
     """Tool-use variant of call_llm. Returns raw assistant message.
 
@@ -1974,6 +2015,10 @@ async def call_llm_tools(
     call must never silently degrade to free-form text; a provider rejection
     surfaces as-is for the caller (``RouterLoop._run_structured_answer_turn``)
     to classify.
+
+    ``on_content_delta`` (#3288 ③b): forwarded verbatim to ``recorded_acompletion``
+    — see its docstring. ``None`` (every call site except ``RouterLoop``'s
+    primary reply call) is byte-identical to before ③b.
     """
     # Normalize model to ModelSpec — accept both str (backward compat) and ModelSpec.
     spec: ModelSpec = model if isinstance(model, ModelSpec) else ModelSpec(model=model, kwargs={})
@@ -2129,6 +2174,7 @@ async def call_llm_tools(
             emit_cost_events=emit_cost_events,  # #1683: chat opts in
             routing=_routing,  # #309 per-class api_base/provider (else global wins)
             response_format=response_format,  # 0062: None for every op-loop tool call
+            on_content_delta=on_content_delta,  # #3288 ③b: forwarded straight through
         )
 
     # #2210 HIGH layer: when the per-call HTTP timeout + the Router/Reyn retries are ALL

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import json
+import logging
 import os
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
@@ -31,6 +32,8 @@ from reyn.services.turn_budget import wrap_up_system_prompt
 
 if TYPE_CHECKING:
     pass
+
+logger = logging.getLogger(__name__)
 
 
 def _resolve_tool_use_scheme(name: "str | None" = None):
@@ -1255,6 +1258,34 @@ class RouterLoop:
         start of each ``run()`` like ``total_usage``."""
         return self._last_call_usage
 
+    def _emit_agent_delta(self, text: str) -> None:
+        """#3288 ③b: forward one streamed content-delta chunk as a chat-event
+        — the owner-ratified L4 replacement (issue #3288 comment thread): a
+        partial rides ``host.events`` (the SAME chat-event channel
+        ``user_submitted`` / ``router_represent_round`` already use), NEVER
+        ``host.put_outbox`` — ``OutboxMessage.__post_init__`` validates
+        ``kind`` against the closed display vocabulary, so an
+        ``agent_delta`` OutboxMessage would either raise (unregistered) or
+        require registering it there, which is exactly the outbox-kind
+        design the owner's decision replaces. Routing through ``host.events``
+        instead means a surface with no ``agent_delta`` handler consumes-but-
+        drops it (EVENT-frame semantics, ``frames.py``) rather than the
+        default generic-row rendering an unknown DISPLAY kind gets — the
+        "no visible-garbage window" invariant.
+
+        Never touches history or the terminal ``kind="agent"`` OutboxMessage
+        — those are unchanged, emitted exactly as before this turn's call
+        returns (L9 whole-persist: the completed full text is what gets
+        appended to history and put on the outbox, exactly once).
+
+        Best-effort: a failing chat-event emit must never abort the
+        in-flight LLM call it is merely narrating.
+        """
+        try:
+            self.host.events.emit("agent_delta", text=text, chain_id=self.chain_id)
+        except Exception:  # noqa: BLE001 — narration must never break the turn
+            logger.exception("router: agent_delta chat-event emit failed")
+
     async def run(self, user_text: str, history: list[dict]) -> TokenUsage:
         """Process one user utterance end-to-end. Emits to host.put_outbox.
 
@@ -1906,6 +1937,10 @@ class RouterLoop:
                         # #1683: chat path emits llm_called + llm_response_received
                         # so the TUI cost tab updates (kernel emits via LLMCallRecorder).
                         emit_cost_events=True,
+                        # #3288 ③b: forward streamed content-deltas as chat-events
+                        # (③a's capability gate decides whether this ever fires —
+                        # a non-streaming call never invokes it).
+                        on_content_delta=self._emit_agent_delta,
                     )
                 # Record the fresh result for future resume hit. Defensive:
                 # never let recording failure break the loop. NOT for a

--- a/tests/test_agent_delta_chat_event_3288.py
+++ b/tests/test_agent_delta_chat_event_3288.py
@@ -1,0 +1,161 @@
+"""Tier 2: #3288 ③b — the "agent_delta" chat-event, end-to-end through a real
+Session + RouterLoop.
+
+The owner's ratified decision (issue #3288 comment thread) replaces the
+original ADR L4 wording ("add ``agent_delta`` to the ``OutboxMessage`` closed
+vocabulary") with a chat-event route: a partial rides ``host.events`` (the
+SAME chat-event channel ``user_submitted`` / ``router_represent_round``
+already use), never ``OutboxMessage``. This file witnesses the two invariants
+that decision must preserve:
+
+1. **L9 whole-persist** — history receives the completed full text EXACTLY
+   ONCE; a streamed turn's per-chunk deltas never append to history.
+2. **stream≡whole surface parity** — the terminal outbox message a client
+   sees is byte-identical to the non-streaming shape (kind="agent", the FULL
+   text, exactly once) regardless of how many deltas preceded it.
+
+``call_llm_tools`` is patched at ``reyn.runtime.router_loop.call_llm_tools``
+with a real async callable (never a mock, per testing.md) that invokes the
+``on_content_delta`` keyword callback RouterLoop wires in
+(``RouterLoop._emit_agent_delta``) before returning the final
+``LLMToolCallResult`` — this exercises the REAL production wiring
+(``router_loop.py``'s call site → ``RouterHostAdapter.events`` →
+``Session._chat_events``), not a re-implementation of it.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from reyn.core.events.events import Event
+from reyn.interfaces.transport.agui.profile import is_profiled
+from reyn.interfaces.transport.agui.protocol import CUSTOM, encode_frame
+from reyn.interfaces.transport.frames import EventFrame, renderer_chat_events
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+_EMPTY_USAGE = TokenUsage(prompt_tokens=10, completion_tokens=5)
+_FULL_TEXT = "hello streamed world"
+_PIECES = ["hello ", "streamed ", "world"]
+
+
+class _EventSink:
+    """A real (non-mock) chat-event subscriber — a plain callback collector
+    (mirrors ``tests/test_user_submitted_render_3300.py``'s ``_EventSink``)."""
+
+    def __init__(self) -> None:
+        self.events: list = []
+
+    def __call__(self, event) -> None:
+        self.events.append(event)
+
+
+def _make_session(tmp_path: Path) -> Session:
+    return make_session(agent_name="test_agent")
+
+
+def _drain_outbox(session: Session) -> list:
+    msgs = []
+    while not session.outbox.empty():
+        msgs.append(session.outbox.get_nowait())
+    return msgs
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_agent_delta_is_forwarded_and_profiled_on_the_wire() -> None:
+    """Tier 1: "agent_delta" is in the transport's forward-set
+    (``renderer_chat_events()`` — both ``InProcessTransport`` and the AG-UI
+    endpoint filter against this, so absence here means it never reaches
+    EITHER client) AND its encoded CUSTOM name is a profiled ``reyn.event.*``
+    entry (``tests/test_agui_profile_completeness.py`` enforces this
+    generically for every forwarded etype; this is the etype-specific pin the
+    ③b PR is responsible for)."""
+    assert "agent_delta" in renderer_chat_events()
+
+    ev = encode_frame(EventFrame(Event(type="agent_delta", data={"text": "x"})))
+    assert ev.type == CUSTOM
+    assert ev.data["name"] == "reyn.event.agent_delta"
+    assert is_profiled(ev.data["name"])
+
+
+def test_agent_delta_events_fire_and_history_stays_whole_persist(tmp_path, monkeypatch) -> None:
+    """Tier 2: streamed deltas surface as "agent_delta" chat-events, in order,
+    while the outbox + history stay whole-persist (exactly once, full text) —
+    the L9 invariant ③b must not disturb."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    sink = _EventSink()
+    session.subscribe_chat_events(sink)
+
+    async def fake_llm(*args, **kwargs):
+        on_delta = kwargs.get("on_content_delta")
+        assert on_delta is not None, (
+            "RouterLoop must thread on_content_delta into call_llm_tools "
+            "for this to be a real streaming-wiring witness"
+        )
+        for piece in _PIECES:
+            on_delta(piece)
+        return LLMToolCallResult(
+            content=_FULL_TEXT, tool_calls=[], finish_reason="stop", usage=_EMPTY_USAGE,
+        )
+
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", fake_llm)
+
+    _run(session._handle_user_message("hi", chain_id="chain-delta-1"))
+
+    # (1) one "agent_delta" chat-event per piece, in order, carrying the raw
+    # per-chunk text — the non-vacuity witness that streaming actually ran
+    # (not just that on_content_delta was accepted and ignored).
+    delta_events = [e for e in sink.events if e.type == "agent_delta"]
+    assert [e.data.get("text") for e in delta_events] == _PIECES
+    assert all(e.data.get("chain_id") == "chain-delta-1" for e in delta_events)
+
+    # (2) the outbox NEVER carries a partial — exactly one kind="agent"
+    # message, the FULL text. An "agent_delta" outbox entry never appears
+    # (it structurally cannot: OutboxMessage.__post_init__ would raise on an
+    # unregistered kind — the closed vocabulary is a second, independent
+    # backstop against this regression).
+    msgs = _drain_outbox(session)
+    agent_msgs = [m for m in msgs if m.kind == "agent"]
+    assert [m.text for m in agent_msgs] == [_FULL_TEXT]
+    assert not [m for m in msgs if m.kind == "agent_delta"]
+
+    # (3) L9 whole-persist: history receives the FULL text EXACTLY ONCE —
+    # never once per delta (3 pieces streamed, 1 history append).
+    assistant_turns = [m for m in session.history if m.role == "assistant"]
+    assert [m.content for m in assistant_turns] == [_FULL_TEXT]
+
+
+def test_non_streaming_turn_emits_no_agent_delta_events(tmp_path, monkeypatch) -> None:
+    """Tier 2: non-vacuity witness — a turn whose ``call_llm_tools`` stand-in
+    never invokes ``on_content_delta`` (the non-capable / non-streaming case)
+    produces ZERO "agent_delta" chat-events, proving the previous test's
+    events came specifically from the callback firing, not from generic
+    per-turn event emission."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+
+    sink = _EventSink()
+    session.subscribe_chat_events(sink)
+
+    async def fake_llm(*args, **kwargs):
+        return LLMToolCallResult(
+            content="no streaming here", tool_calls=[], finish_reason="stop",
+            usage=_EMPTY_USAGE,
+        )
+
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", fake_llm)
+
+    _run(session._handle_user_message("hi", chain_id="chain-nodelta"))
+
+    assert not [e for e in sink.events if e.type == "agent_delta"]
+    agent_msgs = [m for m in _drain_outbox(session) if m.kind == "agent"]
+    assert [m.text for m in agent_msgs] == ["no streaming here"]

--- a/tests/test_agent_delta_no_visible_garbage_3288.py
+++ b/tests/test_agent_delta_no_visible_garbage_3288.py
@@ -13,6 +13,23 @@ is the CI gate that a future change cannot silently start drawing a row per
 delta (a visible-garbage regression) without this test going RED — a
 structural strip-style witness, not a one-time manual read of the source.
 
+★co-vet fix (PR #3312 review): an EARLIER version of this file asserted only
+"FlowView entry count unchanged" against the delta push — which stays GREEN
+even if ``push_event``/the transport is silently dead (verified: neutering
+``QueueTransport.push_event`` into a no-op left both tests passing), because
+"delivered but not drawn" and "never delivered" are indistinguishable from
+that assertion alone. The fix is an ARRIVAL WITNESS (positive control) that
+exercises the EXACT SAME ``push_event`` path the delta assertion depends on:
+push a real ``user_submitted`` + matching ``turn_started`` pair FIRST (the
+proven promote-to-FlowView sequence from
+``tests/test_3300_p2b_sentqueue_render.py::test_turn_started_promotes_matching_item_to_flow_entry``)
+and assert the FlowView entry count DOES increase — proving this transport +
+pump pair is alive and forwarding EVENT frames — THEN push the delta and
+assert no FURTHER increase. (A bare ``user_submitted`` alone cannot serve as
+this witness: #3300 P2b made it materialize into the sent-queue only, never a
+FlowView entry by itself — the promoting ``turn_started`` companion is
+required, mirroring the cited test exactly.)
+
 Real instances only: a real ``TextualChatApp`` driven via Textual's
 ``run_test()`` harness (mirrors ``tests/test_user_submitted_render_3300.py``'s
 ``QueueTransport`` idiom) and a real ``FlowView`` query — no mocks.
@@ -34,9 +51,10 @@ from reyn.schemas.models import Event
 
 class QueueTransport(ClientTransport):
     """A real, minimal :class:`ClientTransport` fed one frame at a time from a
-    queue (mirrors ``tests/test_user_submitted_render_3300.py``'s helper of
-    the same name) — lets a test push a frame and inspect
-    ``TextualChatApp``'s retained conversation model afterward."""
+    queue (mirrors ``tests/test_user_submitted_render_3300.py`` /
+    ``tests/test_3300_p2b_sentqueue_render.py``'s helper of the same name) —
+    lets a test push a frame and inspect ``TextualChatApp``'s retained
+    conversation model afterward."""
 
     def __init__(self) -> None:
         self._queue: "asyncio.Queue[object]" = asyncio.Queue()
@@ -79,12 +97,52 @@ class QueueTransport(ClientTransport):
         pass
 
 
+def _user_submitted(*, msg_id: str, chain_id: str, text: str, seq: int) -> Event:
+    return Event(
+        type="user_submitted",
+        data={"text": text, "chain_id": chain_id, "msg_id": msg_id, "seq": seq, "meta": {}},
+    )
+
+
+def _turn_started(*, chain_id: str, seq: int) -> Event:
+    return Event(type="turn_started", data={"kind": "user", "chain_id": chain_id, "seq": seq})
+
+
+async def _arrival_witness(transport: QueueTransport, pilot, app: TextualChatApp) -> int:
+    """Push a real ``user_submitted`` + matching ``turn_started`` pair through
+    ``push_event`` (the SAME EventFrame path the delta assertions below
+    depend on) and assert it PROMOTES to a FlowView entry — the proven
+    promote sequence from
+    ``tests/test_3300_p2b_sentqueue_render.py::test_turn_started_promotes_matching_item_to_flow_entry``.
+    Returns the FlowView entry count AFTER the witness promotion, so callers
+    assert subsequent pushes against a KNOWN-alive baseline instead of an
+    unverified "before" count. A dead/neutered ``push_event`` makes this
+    assertion fail here, RED, before any delta-silence claim is even made."""
+    before = len(app.query_one(FlowView).entries)
+    await transport.push_event(
+        _user_submitted(msg_id="witness-1", chain_id="witness-chain", text="arrival witness", seq=1)
+    )
+    await pilot.pause()
+    await transport.push_event(_turn_started(chain_id="witness-chain", seq=2))
+    await pilot.pause()
+    after = len(app.query_one(FlowView).entries)
+    assert after == before + 1, (
+        "arrival witness failed — a user_submitted+turn_started pair did not "
+        f"promote to a FlowView entry ({before} -> {after}); push_event/the "
+        "transport+pump pair is not actually alive, so a delta-silence "
+        "assertion elsewhere in this file would be meaningless"
+    )
+    return after
+
+
 @pytest.mark.asyncio
 async def test_agent_delta_event_draws_nothing_in_textual_chat() -> None:
     """Tier 2: pushing an "agent_delta" EVENT frame through the REAL
     ``TextualChatApp._pump_frames`` must not append a FlowView entry — the
     event is consumed (the pump does not crash / stall) but not drawn, since
-    no branch in the (untouched) pump matches "agent_delta" yet.
+    no branch in the (untouched) pump matches "agent_delta" yet. Preceded by
+    the arrival witness (see module docstring / ``_arrival_witness``) so a
+    dead ``push_event`` cannot make this pass vacuously.
 
     Strip-falsify (recorded in the PR body): re-emitting the SAME delta as a
     ``DisplayFrame`` (an ``OutboxMessage``-kind carrier — the design the
@@ -96,17 +154,17 @@ async def test_agent_delta_event_draws_nothing_in_textual_chat() -> None:
     app = TextualChatApp(transport=transport)
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
-        before = len(app.query_one(FlowView).entries)
+        after_witness = await _arrival_witness(transport, pilot, app)
 
         await transport.push_event(
             Event(type="agent_delta", data={"text": "partial chunk", "chain_id": "c1"})
         )
         await pilot.pause()
 
-        after = len(app.query_one(FlowView).entries)
-        assert after == before, (
+        after_delta = len(app.query_one(FlowView).entries)
+        assert after_delta == after_witness, (
             "an agent_delta chat-event must draw NOTHING (opt-in draw, no "
-            f"consumer yet) — entry count changed {before} -> {after}"
+            f"consumer yet) — entry count changed {after_witness} -> {after_delta}"
         )
 
 
@@ -116,15 +174,16 @@ async def test_agent_delta_ignored_alongside_other_unhandled_events() -> None:
     (mirroring ``test_textual_chat_app_ignores_non_user_submitted_events_for_flow``)
     also draws nothing, proving the previous test's zero-delta is because NO
     unhandled EVENT frame draws anything (the pump's structural behavior),
-    not a coincidence specific to the "agent_delta" payload shape."""
+    not a coincidence specific to the "agent_delta" payload shape. Carries its
+    OWN arrival witness so this test alone cannot pass vacuously either."""
     transport = QueueTransport()
     app = TextualChatApp(transport=transport)
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
-        before = len(app.query_one(FlowView).entries)
+        after_witness = await _arrival_witness(transport, pilot, app)
 
         await transport.push_event(Event(type="some_future_unhandled_event", data={}))
         await pilot.pause()
 
         after = len(app.query_one(FlowView).entries)
-        assert after == before
+        assert after == after_witness

--- a/tests/test_agent_delta_no_visible_garbage_3288.py
+++ b/tests/test_agent_delta_no_visible_garbage_3288.py
@@ -1,0 +1,130 @@
+"""Tier 2: #3288 ③b — "no visible-garbage window" for the "agent_delta"
+chat-event, witnessed on the ACTUAL ``TextualChatApp`` pump (production code
+untouched — imported and driven read-only from this test, per the #3299/P5
+non-interference constraint on ``interfaces/inline/textual_chat/``).
+
+The owner's ratified design (issue #3288 comment thread) chose a chat-event
+route specifically BECAUSE an EVENT frame with no consumer is dropped
+(``_pump_frames``'s ``if/elif/.../continue`` has no ``else`` — consumed but
+never drawn), whereas an unknown ``OutboxMessage`` DISPLAY kind is rendered as
+a generic row by the presenter. ③c (a later phase, out of scope here) adds the
+textual_chat coalescing consumer for "agent_delta"; UNTIL it lands, this test
+is the CI gate that a future change cannot silently start drawing a row per
+delta (a visible-garbage regression) without this test going RED — a
+structural strip-style witness, not a one-time manual read of the source.
+
+Real instances only: a real ``TextualChatApp`` driven via Textual's
+``run_test()`` harness (mirrors ``tests/test_user_submitted_render_3300.py``'s
+``QueueTransport`` idiom) and a real ``FlowView`` query — no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import EventFrame
+from reyn.runtime.outbox import OutboxMessage
+from reyn.schemas.models import Event
+
+
+class QueueTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` fed one frame at a time from a
+    queue (mirrors ``tests/test_user_submitted_render_3300.py``'s helper of
+    the same name) — lets a test push a frame and inspect
+    ``TextualChatApp``'s retained conversation model afterward."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+
+    async def push_event(self, event: Event) -> None:
+        await self._queue.put(EventFrame(event))
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+        pass
+
+    async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:  # pragma: no cover
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+@pytest.mark.asyncio
+async def test_agent_delta_event_draws_nothing_in_textual_chat() -> None:
+    """Tier 2: pushing an "agent_delta" EVENT frame through the REAL
+    ``TextualChatApp._pump_frames`` must not append a FlowView entry — the
+    event is consumed (the pump does not crash / stall) but not drawn, since
+    no branch in the (untouched) pump matches "agent_delta" yet.
+
+    Strip-falsify (recorded in the PR body): re-emitting the SAME delta as a
+    ``DisplayFrame`` (an ``OutboxMessage``-kind carrier — the design the
+    owner's decision REPLACES) through this same app DOES append a generic
+    row — proving the chat-event route is what closes the visible-garbage
+    window, not an accident of this particular event's payload shape.
+    """
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        before = len(app.query_one(FlowView).entries)
+
+        await transport.push_event(
+            Event(type="agent_delta", data={"text": "partial chunk", "chain_id": "c1"})
+        )
+        await pilot.pause()
+
+        after = len(app.query_one(FlowView).entries)
+        assert after == before, (
+            "an agent_delta chat-event must draw NOTHING (opt-in draw, no "
+            f"consumer yet) — entry count changed {before} -> {after}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_agent_delta_ignored_alongside_other_unhandled_events() -> None:
+    """Tier 2: non-vacuity companion — a DIFFERENT unhandled event type
+    (mirroring ``test_textual_chat_app_ignores_non_user_submitted_events_for_flow``)
+    also draws nothing, proving the previous test's zero-delta is because NO
+    unhandled EVENT frame draws anything (the pump's structural behavior),
+    not a coincidence specific to the "agent_delta" payload shape."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        before = len(app.query_one(FlowView).entries)
+
+        await transport.push_event(Event(type="some_future_unhandled_event", data={}))
+        await pilot.pause()
+
+        after = len(app.query_one(FlowView).entries)
+        assert after == before

--- a/tests/test_llm_streaming_delta_emission_3288.py
+++ b/tests/test_llm_streaming_delta_emission_3288.py
@@ -1,0 +1,167 @@
+"""Tier 3a / Tier 1: #3288 ③b — the ``on_content_delta`` callback wiring inside
+``recorded_acompletion`` / ``call_llm_tools`` (``src/reyn/llm/llm.py``).
+
+③a (merged, #3304) added a capability-gated streaming loop that reconstructs
+the SAME whole response internally — callers saw no behavioral difference.
+③b's job is to carry the per-chunk deltas OUT to a caller-supplied callback
+while leaving that reconstruction (and everything callers already observed)
+untouched. This file is the llm.py-level half of that; the chat-event/
+transport half lives in ``tests/test_agent_delta_chat_event_3288.py``.
+
+Uses a scripted ``litellm.acompletion`` replacement (a real async callable —
+same idiom as ``test_llm_streaming_equivalence_3288.py``), never a
+``unittest.mock`` double. ``chunk_witness`` proves REAL per-chunk consumption
+drove the callback invocations (not that the whole-collect fallback silently
+produced a plausible-looking result while never actually streaming).
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import litellm
+from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices, Usage
+
+from reyn.llm.llm import call_llm_tools, recorded_acompletion
+
+_CONTENT = "Hello world"
+_USAGE = {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+
+
+def _make_fake_acompletion(chunk_witness: "list[int] | None" = None):
+    """Real, scripted stand-in for ``litellm.acompletion`` — branches on
+    ``stream`` exactly like the real client. The streaming branch splits
+    ``_CONTENT`` across TWO content-delta chunks plus a trailing usage-only
+    terminal chunk (no content) — the terminal chunk exercises the "chunk
+    with no content delta" skip path."""
+
+    async def _fake_acompletion(model: str, messages: list, **kw: Any) -> Any:
+        if not kw.get("stream"):
+            return litellm.ModelResponse(
+                id="resp-1", created=1, model=model, object="chat.completion",
+                choices=[{
+                    "index": 0, "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": _CONTENT},
+                }],
+                usage=dict(_USAGE),
+            )
+
+        def _chunk(delta: Delta, finish_reason: "str | None" = None) -> ModelResponseStream:
+            return ModelResponseStream(
+                id="resp-1", created=1, model=model, object="chat.completion.chunk",
+                choices=[StreamingChoices(index=0, delta=delta, finish_reason=finish_reason)],
+            )
+
+        async def _gen():
+            mid = len(_CONTENT) // 2
+            pieces = [
+                _chunk(Delta(role="assistant", content=_CONTENT[:mid])),
+                _chunk(Delta(content=_CONTENT[mid:])),
+            ]
+            last = _chunk(Delta(), finish_reason="stop")
+            last.usage = Usage(**_USAGE)
+            pieces.append(last)
+            for piece in pieces:
+                if chunk_witness is not None:
+                    chunk_witness.append(1)
+                yield piece
+
+        return _gen()
+
+    return _fake_acompletion
+
+
+def test_on_content_delta_fires_per_real_content_chunk(monkeypatch) -> None:
+    """Tier 3a: ``on_content_delta`` fires once per non-empty content-delta
+    chunk, in order, with the RAW per-chunk text — witnessed via real chunk
+    consumption (``chunk_witness``), not merely that ``stream=True`` was
+    requested (see ``_stream_and_reconstruct``'s non-aiter-able fallback)."""
+    chunk_witness: list[int] = []
+    monkeypatch.setattr(litellm, "acompletion", _make_fake_acompletion(chunk_witness))
+
+    deltas: list[str] = []
+    result = asyncio.run(recorded_acompletion(
+        model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}],
+        purpose="main", recorder=None,
+        on_content_delta=deltas.append,
+    ))
+
+    # All 3 scripted chunks (2 content + 1 usage-only terminal) were really
+    # consumed off the async generator.
+    assert chunk_witness == [1, 1, 1]
+    # Only the 2 content-bearing chunks reached the callback — the terminal
+    # usage-only chunk (empty delta.content) is silently skipped.
+    assert deltas == [_CONTENT[: len(_CONTENT) // 2], _CONTENT[len(_CONTENT) // 2 :]]
+    assert "".join(deltas) == _CONTENT
+    # ③a's whole-result reconstruction is UNAFFECTED by ③b's callback.
+    assert result.choices[0].message.content == _CONTENT
+    assert result.usage.prompt_tokens == _USAGE["prompt_tokens"]
+
+
+def test_on_content_delta_never_fires_on_the_whole_collect_path(monkeypatch) -> None:
+    """Tier 3a: capability-gated — a non-streaming-capable model's whole-collect
+    path never invokes ``on_content_delta``, even when a callback is supplied.
+    Companion to ③a's capability-driver gate: the callback firing here would
+    prove capability is NOT actually gating whether deltas are ever produced."""
+    chunk_witness: list[int] = []
+    monkeypatch.setattr(litellm, "acompletion", _make_fake_acompletion(chunk_witness))
+
+    deltas: list[str] = []
+    result = asyncio.run(recorded_acompletion(
+        # o1-pro: real litellm capability data reports no native streaming
+        # support (a genuine reasoning-only-endpoint limitation) — same model
+        # ③a's own equivalence test uses for the whole-collect branch.
+        model="o1-pro", messages=[{"role": "user", "content": "hi"}],
+        purpose="main", recorder=None,
+        on_content_delta=deltas.append,
+    ))
+
+    assert deltas == []
+    # The whole-collect path never touches the chunk generator at all.
+    assert chunk_witness == []
+    assert result.choices[0].message.content == _CONTENT
+
+
+def test_failing_on_content_delta_does_not_break_the_call(monkeypatch) -> None:
+    """Tier 1: a raising ``on_content_delta`` must never abort the in-flight
+    LLM call — the callback narrates the stream, it does not gate it (mirrors
+    the ``llm_request`` ambient-emit try/except precedent already in this
+    chokepoint)."""
+    monkeypatch.setattr(litellm, "acompletion", _make_fake_acompletion())
+
+    calls: list[str] = []
+
+    def _boom(text: str) -> None:
+        calls.append(text)
+        raise RuntimeError("display sink exploded")
+
+    result = asyncio.run(recorded_acompletion(
+        model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}],
+        purpose="main", recorder=None,
+        on_content_delta=_boom,
+    ))
+
+    # The callback WAS invoked (and raised, and was swallowed) for each chunk —
+    # a vacuous "never called" would let this test pass without exercising the
+    # guard at all.
+    assert calls == [_CONTENT[: len(_CONTENT) // 2], _CONTENT[len(_CONTENT) // 2 :]]
+    assert result.choices[0].message.content == _CONTENT
+
+
+def test_call_llm_tools_forwards_on_content_delta_through_to_the_stream(monkeypatch) -> None:
+    """Tier 3a: ``call_llm_tools`` threads ``on_content_delta`` straight
+    through its ``recorded_acompletion`` chokepoint call — the SAME callback
+    contract, one layer up (no tools attached; ``has_tools=False`` still
+    selects the streaming branch for a capable model)."""
+    chunk_witness: list[int] = []
+    monkeypatch.setattr(litellm, "acompletion", _make_fake_acompletion(chunk_witness))
+
+    deltas: list[str] = []
+    result = asyncio.run(call_llm_tools(
+        model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}],
+        tools=[], on_content_delta=deltas.append,
+    ))
+
+    assert chunk_witness == [1, 1, 1]
+    assert deltas == [_CONTENT[: len(_CONTENT) // 2], _CONTENT[len(_CONTENT) // 2 :]]
+    assert result.content == _CONTENT

--- a/tests/test_llm_streaming_delta_emission_3288.py
+++ b/tests/test_llm_streaming_delta_emission_3288.py
@@ -165,3 +165,110 @@ def test_call_llm_tools_forwards_on_content_delta_through_to_the_stream(monkeypa
     assert chunk_witness == [1, 1, 1]
     assert deltas == [_CONTENT[: len(_CONTENT) // 2], _CONTENT[len(_CONTENT) // 2 :]]
     assert result.content == _CONTENT
+
+
+def _make_fake_acompletion_no_content_deltas(chunk_witness: "list[int] | None" = None):
+    """Co-vet recommendation (c): a real, scripted stand-in whose streaming
+    branch yields chunks that NEVER carry ``delta.content`` (only role/
+    tool_call/usage-only chunks) — simulating a provider chunk shape this
+    parsing does not recognize. Content still reaches the FINAL reconstructed
+    response via ``stream_chunk_builder``'s own accumulation from
+    ``ChatCompletionDeltaToolCall``-free plain chunks is not exercised here;
+    this fake targets ONLY the "delta never observed" silent-dead-mode guard,
+    not stream≡whole equivalence (already covered elsewhere)."""
+
+    async def _fake_acompletion(model: str, messages: list, **kw: Any) -> Any:
+        if not kw.get("stream"):
+            return litellm.ModelResponse(
+                id="resp-2", created=1, model=model, object="chat.completion",
+                choices=[{
+                    "index": 0, "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": _CONTENT},
+                }],
+                usage=dict(_USAGE),
+            )
+
+        def _chunk(delta: Delta, finish_reason: "str | None" = None) -> ModelResponseStream:
+            return ModelResponseStream(
+                id="resp-2", created=1, model=model, object="chat.completion.chunk",
+                choices=[StreamingChoices(index=0, delta=delta, finish_reason=finish_reason)],
+            )
+
+        async def _gen():
+            # A role-only chunk (no content) and a terminal usage-only chunk —
+            # neither ever exposes delta.content, but chunks ARE consumed.
+            pieces = [_chunk(Delta(role="assistant"))]
+            last = _chunk(Delta(), finish_reason="stop")
+            last.usage = Usage(**_USAGE)
+            pieces.append(last)
+            for piece in pieces:
+                if chunk_witness is not None:
+                    chunk_witness.append(1)
+                yield piece
+
+        return _gen()
+
+    return _fake_acompletion
+
+
+def test_silent_zero_delta_stream_logs_once_per_stream(monkeypatch, caplog) -> None:
+    """Tier 1: co-vet fix (recommendation (c)) — when a stream produces at
+    least one chunk but ``on_content_delta`` never fires (no chunk exposed
+    ``delta.content``), exactly ONE debug log line is emitted for the whole
+    stream (not per chunk) — the cheap observability guard against a silent
+    functional-dead-mode where deltas quietly never happen for a given
+    provider's chunk shape while L9's final text keeps working, masking it."""
+    import logging
+
+    chunk_witness: list[int] = []
+    monkeypatch.setattr(
+        litellm, "acompletion", _make_fake_acompletion_no_content_deltas(chunk_witness),
+    )
+
+    deltas: list[str] = []
+    with caplog.at_level(logging.DEBUG, logger="reyn.llm.llm"):
+        result = asyncio.run(recorded_acompletion(
+            model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}],
+            purpose="main", recorder=None,
+            on_content_delta=deltas.append,
+        ))
+
+    assert chunk_witness == [1, 1]  # both scripted chunks really consumed
+    assert deltas == []  # the callback genuinely never fired
+    guard_records = [
+        r for r in caplog.records
+        if "on_content_delta never fired" in r.message
+    ]
+    # Exactly one record for the whole stream — tuple-unpack (not a chunk
+    # count of 1 or per-chunk repeats) raises if there are zero or more than
+    # one, the behavioral idiom for "exactly once" (see testing.md's
+    # len(...) == N → behavioral-assertion fix idiom).
+    (only_guard_record,) = guard_records
+    assert "2 chunk(s)" in only_guard_record.message
+    # L9 is unaffected: the reconstruction still returns a valid response
+    # object (content is empty here only because THIS fake's chunks never
+    # carried any — the guard's job is observability, not content recovery).
+    assert result.usage.prompt_tokens == _USAGE["prompt_tokens"]
+
+
+def test_silent_zero_delta_guard_does_not_fire_when_deltas_do(monkeypatch, caplog) -> None:
+    """Tier 1: non-vacuity companion — the SAME guard does NOT fire on a
+    normal stream where deltas DO arrive, proving the previous test's log
+    line is specifically about the zero-delta case, not emitted on every
+    stream unconditionally."""
+    import logging
+
+    monkeypatch.setattr(litellm, "acompletion", _make_fake_acompletion())
+
+    with caplog.at_level(logging.DEBUG, logger="reyn.llm.llm"):
+        asyncio.run(recorded_acompletion(
+            model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}],
+            purpose="main", recorder=None,
+            on_content_delta=lambda _t: None,
+        ))
+
+    guard_records = [
+        r for r in caplog.records
+        if "on_content_delta never fired" in r.message
+    ]
+    assert guard_records == []


### PR DESCRIPTION
**[per-PR-coder]** — Phase ③b of the token-streaming arc (#3288): carries ③a's (#3304, merged) streamed content-deltas up to the transport as an **`agent_delta` chat-event** — the owner's ratified L4 replacement (issue #3288 comment thread) for the ADR's original "add `agent_delta` to the OutboxMessage closed vocabulary" wording. part of #3288.

## Canonical contract (from the issue thread)

The owner ratified the architect's proposal: a partial rides `host.events` (the same chat-event channel `user_submitted` / `router_represent_round` already use), **never** an `OutboxMessage` kind — `OutboxMessage.__post_init__` validates `kind` against the closed display vocabulary, so an `agent_delta` OutboxMessage would force registering it there, reintroducing exactly the category error P1 C ("input in an output channel") already designed out in reverse (here: a transient, non-persistent notification in the persist/display channel). Invariants preserved: L9 whole-persist, capability-is-the-driver (③a), usage single emission (③a, untouched).

## What changed

- **`src/reyn/llm/llm.py`** — `recorded_acompletion` / `call_llm_tools` gain an opt-in `on_content_delta: Callable[[str], None] | None` parameter. Inside ③a's `_stream_and_reconstruct`, it fires once per real chunk carrying non-empty `delta.content`, BEFORE that chunk is appended to `chunks` (so it fires against real per-chunk consumption, not a batched replay). Never invoked on the whole-collect path — capability-gated by construction, the same way ③a's streaming decision is. A raising callback is caught + logged, never allowed to abort the LLM call.
- **`src/reyn/runtime/router_loop.py`** — `RouterLoop._emit_agent_delta` wires the callback into the primary reply call site (`on_content_delta=self._emit_agent_delta`), emitting `self.host.events.emit("agent_delta", text=text, chain_id=self.chain_id)` — never `host.put_outbox`.
- **`src/reyn/interfaces/transport/frames.py`** — `"agent_delta"` joins the transport's forward-set (`renderer_chat_events()`) via a new `_STREAMING_EVENTS` constant — the ONE deliberate exception to "derived, not hand-listed" (module + function docstrings updated to say so). This is legal per the dual-stream completeness gate's actual direction (`consumed ⊆ forwarded`, never the reverse) — forwarding an event nobody consumes yet is not a coverage gap.
- **`src/reyn/interfaces/transport/agui/profile.py`** — registers `reyn.event.agent_delta` (EVENT_NS), satisfying `tests/test_agui_profile_completeness.py`'s generic completeness gate (no `protocol.py` change needed — an etype absent from `_EVENT_TYPE_EVENT` already falls back to a generic `CUSTOM` `reyn.event.<etype>` encoding, so `agent_delta` round-trips for free; `tests/test_agui_mapping_completeness.py` confirms this).
- **`docs/reference/runtime/agui-transport.md`** — new `reyn.event.agent_delta` table row + a clarifying paragraph: the standard `TEXT_MESSAGE_CONTENT` triplet stays whole-message (①③a/③b don't touch it); token-level streaming now exists on the SEPARATE `agent_delta` chat-event channel. (③d, not this PR, is expected to fold it into a real generic-client multi-CONTENT triplet.)

**Not touched**: `src/reyn/interfaces/inline/textual_chat/` and `src/reyn/interfaces/repl/` (other coders' active work) — no ignore-branch was added anywhere; the whole point of the chat-event route is that a surface with no handler draws nothing, verified below.

## Invariant strip-falsifies (all reverted after observing RED; only the named test went RED, no cross-masking)

1. **Capability is the driver** — temporarily made the whole-collect branch also invoke `on_content_delta`. RED: `tests/test_llm_streaming_delta_emission_3288.py::test_on_content_delta_never_fires_on_the_whole_collect_path` — `assert deltas == []` failed with `['STRIP-FALSIFY-BUG: fired on whole-collect path']`. Reverted; file green again (4/4).
2. **L9 whole-persist** — temporarily made `_emit_agent_delta` also call `host.append_history_entry` per delta. RED: `tests/test_agent_delta_chat_event_3288.py::test_agent_delta_events_fire_and_history_stays_whole_persist` — history showed 4 assistant turns (`['hello ', 'streamed ', 'world', 'hello streamed world']`) instead of 1. The sibling non-streaming test stayed green (no cross-masking). Reverted; file green again (3/3).
3. **RouterLoop wiring itself** — temporarily dropped `on_content_delta=self._emit_agent_delta` from the call site. RED: the same test — zero `agent_delta` events observed (`assert [] == ['hello ', 'streamed ', 'world']`), plus my own in-test assertion (`on_delta is not None`) fired first, confirming the wiring is truly load-bearing, not decorative. Reverted.
4. **Forward-set registration** — temporarily removed `_STREAMING_EVENTS` from `renderer_chat_events()`'s union. RED: my own pin test (`test_agent_delta_is_forwarded_and_profiled_on_the_wire`) — `"agent_delta" not in renderer_chat_events()`. All other transport tests stayed green. Reverted.
5. **AG-UI profile registration** — temporarily removed the `CustomName("reyn.event.agent_delta", ...)` entry. RED (two tests, both correctly): the EXISTING generic gate `tests/test_agui_profile_completeness.py::test_every_custom_mapped_frame_is_profiled` (`unprofiled reyn.* Custom names: ['reyn.event.agent_delta']`) AND my own pin test. Reverted.

## Invariant 4 — "no visible-garbage window" — verified by observation, not design inference

Read `src/reyn/interfaces/inline/textual_chat/app.py`'s `_pump_frames` (untouched, read-only): its EVENT-frame branch is `if/elif/elif` ending in an unconditional `continue`, with **no `else`** — an unmatched etype (e.g. `agent_delta`) is consumed off the transport stream but never reaches `_ingest_frame`/`FlowView`. Verified two ways:

- **Committed CI gate** (`tests/test_agent_delta_no_visible_garbage_3288.py`): drives a REAL `TextualChatApp` via Textual's `run_test()` harness (mirrors `tests/test_user_submitted_render_3300.py`'s `QueueTransport` idiom), pushes a real `EventFrame(Event(type="agent_delta", ...))`, and asserts the `FlowView` entry count is unchanged. A non-vacuity companion pushes a different unhandled etype to prove this isn't a coincidence of the `agent_delta` payload shape specifically.
- **One-off scratch demonstration** (not committed) of what the REJECTED design (`agent_delta` as an `OutboxMessage` kind) would have done: pushed `DisplayFrame(OutboxMessage.from_wire(kind="agent_delta", text="partial chunk", meta={}))` through the SAME real `TextualChatApp`. Observed output: `STRIP-FALSIFY (outbox-kind design): before=0 after=1` — the presenter draws a generic row for an unknown DISPLAY kind, confirming the visible-garbage window the chat-event route specifically avoids.

## Gates run locally

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` on all 3 new/changed test files — 9/9 OK, 0 Tier-4 violations
- [x] `uv run python -m pytest --timeout=120 -q -n auto` (foreground, full repo, alone) — **9216 passed, 36 skipped, 3 failed**. All 3 failures (`test_fp0063_arc_witness.py::test_llm_driven_install_ingest_query_arc_reaches_the_ingested_chunk`, `test_litellm_lazy_load.py::test_ensure_litellm_ready_imports_litellm_and_is_idempotent`, `test_litellm_lazy_load.py::test_first_use_routes_litellm_import_time_warning_to_file`) confirmed pre-existing/timing-flaky: a subprocess-spawn `TimeoutExpired` under `-n auto` xdist contention, unrelated file/module to this diff (litellm lazy-import subprocess probes + an install/ingest arc witness), and all 3 pass cleanly in isolation (`9 passed` when rerun alone).
- [x] `python scripts/verify_module_docstrings.py` on all 4 changed src files — clean

## Note for ③d (AG-UI generic multi-CONTENT, next phase)

The generic `CUSTOM` fallback this PR relies on (`_event_event_type` default) means `agent_delta` already round-trips losslessly today with zero `protocol.py` changes — ③d's job is purely to ADD a real multi-CONTENT mapping for it (START on first delta / CONTENT per delta / END-only on completion, per the owner's note about not double-emitting full text), not to fix anything this PR leaves broken.

## Test plan
- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict` on changed/added test files
- [x] `uv run python -m pytest --timeout=120 -q -n auto` — 9216 passed, 36 skipped, 3 pre-existing/flaky (verified pass in isolation)
- [x] `python scripts/verify_module_docstrings.py` on changed src files
- [x] Strip-falsify: capability-driver gate (RED confirmed, reverted)
- [x] Strip-falsify: L9 whole-persist gate (RED confirmed, reverted)
- [x] Strip-falsify: RouterLoop wiring itself (RED confirmed, reverted)
- [x] Strip-falsify: forward-set registration (RED confirmed, reverted)
- [x] Strip-falsify: AG-UI profile registration (RED confirmed, reverted)
- [x] Invariant 4 (no visible-garbage) verified by observation on `textual_chat/app.py` (read-only) + a one-off scratch demonstration of the rejected outbox-kind alternative

🤖 Generated with [Claude Code](https://claude.com/claude-code)