### PR TITLE
feat(transport): AG-UI generic multi-CONTENT streaming — #3288 ③d

### DIFF
--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -119,28 +119,50 @@ renderable display kinds):
   fail-safe for a future tap-point change, not a live wire kind. (Remote
   attach-label sync is designed separately, not via this legacy sentinel.)
 
-#### Text lifecycle (the conforming triplet)
+#### Text lifecycle (the conforming triplet, plain and streamed)
 
 The AG-UI spec mandates the text lifecycle **`TEXT_MESSAGE_START` → one or more
 `TEXT_MESSAGE_CONTENT` → `TEXT_MESSAGE_END`, all correlated by a `messageId`**; a
-bare `TEXT_MESSAGE_CONTENT` is invalid (a strict generic client drops it). A whole
-reyn text message therefore rides the wire as that triplet, with a generated
-per-message id (reyn's outbox has no stable message id) and the CONTENT `delta`
-carrying the full message text — this STANDARD triplet stays whole-message (one
-CONTENT event per completed reply, never split into per-token frames).
+bare `TEXT_MESSAGE_CONTENT` is invalid (a strict generic client drops it).
 
-Token-level streaming DOES now exist on a SEPARATE channel: `reyn.event.agent_delta`
-(#3288 ③b, see below) carries the LLM's raw per-chunk deltas as they arrive,
-purely as an additive, non-persistent notification — the standard
-`TEXT_MESSAGE_CONTENT` triplet above is unaffected (still one whole-text CONTENT
-event, emitted after the delta stream completes) and no shipped generic-client
-surface consumes `agent_delta` yet (a later phase, ③d, is expected to fold it
-into a real multi-CONTENT triplet for the standard surface).
+**A message that never streamed** (no provider capability, ADR-0039 P3a/③a) rides
+the wire as the plain whole-message triplet, with a generated per-message id
+(reyn's outbox has no stable message id) and the single CONTENT's `delta`
+carrying the full message text. Only the **CONTENT** event carries the `_reyn`
+reconstruction block; START/END are generic scaffold the reyn client decodes to
+`None` and ignores — the reconstruction invariant is **one frame ⇄ one
+`_reyn`-bearing event**.
 
-Only the **CONTENT** event carries the `_reyn` reconstruction block; the START and
-END events are generic scaffold that the reyn client decodes to `None` and
-ignores. So the reconstruction invariant stays **one frame ⇄ one `_reyn`-bearing
-event**, and the reyn client rebuilds exactly one display frame per message.
+**A message that DID stream** (#3288 ③b emits `reyn.event.agent_delta` for each
+raw LLM content-delta as it arrives; #3288 ③d maps it onto the STANDARD text
+surface) instead gets a REAL multi-CONTENT sequence: `TEXT_MESSAGE_START` at the
+first delta, one genuine `TEXT_MESSAGE_CONTENT` per delta (each carrying its OWN
+`_reyn`, reconstructing that exact `agent_delta` chat-event — so a reyn client's
+in-flight rendering, if any, is identical whether the frames arrived in-process
+or over this wire), then `TEXT_MESSAGE_END` at completion. ★The completion is
+mapped to **END ONLY — never a second CONTENT re-sending the full text** (a
+client that rendered the deltas live would double-render the body). The END
+instead carries its OWN `_reyn`, holding the completion's FULL persisted text —
+the **sole reconstruction authority** for a streamed message; a reyn client never
+reconstructs by concatenating deltas (they are non-persistent, derived,
+live-only narration — the reconnect `MESSAGES_SNAPSHOT` backlog, built only from
+persisted `OutboxMessage`s, never reads one either). This is also what closes the
+**late-joiner window**: a connection's per-connection `TextStreamTracker` state
+(`interfaces/transport/agui/emitter.py`) reflects only what THAT connection
+personally observed — a connection that witnessed zero deltas for a chain (never
+connected during the stream, or connected right as it finished) instead gets the
+unchanged plain whole-message triplet for the SAME completion frame (full text
+on CONTENT), so either way the client ends up with the complete, persisted text.
+No per-client "which deltas did you receive" bookkeeping is kept (rejected in the
+issue #3288 ③d design thread — it would add state for no benefit over reading the
+authoritative completion).
+
+So the reconstruction invariant is **re-decided for a streamed message
+specifically**: N `agent_delta` CONTENT events each carry their OWN `_reyn` (one
+per delta), and the terminal END carries a further, DISTINCT `_reyn` (the
+completion). N+1 `_reyn`-bearing events, not 1 — but the client's reconstruction
+authority is always the LAST one. A message that never streamed is unaffected by
+any of this (the plain triplet above, unchanged).
 
 #### Reasoning lifecycle (the conforming triplet)
 
@@ -388,13 +410,22 @@ object. Most members are the working-indicator axis (turn-lifecycle /
 tool-call / user-submitted / cancel); `agent_delta` (#3288 ③b) is a SEPARATE
 streaming-notification axis — see its row below and the `_STREAMING_EVENTS`
 comment in `frames.py` for why it is forwarded ahead of any renderer consumer.
+★This `CUSTOM` mapping is what `encode_frame`/`encode_frame_wire` (the plain,
+non-streaming codec path) produce for an `agent_delta` `EventFrame` — the AG-UI
+emitter's actual production call site (`emitter.py`) instead runs every frame
+through `encode_frame_wire_streaming`, which maps `agent_delta` onto the
+STANDARD `TEXT_MESSAGE_CONTENT` surface (#3288 ③d — see *Text lifecycle* above),
+never this `CUSTOM` name, on the wire a real client receives. This row documents
+what the plain codec functions do in isolation (still exercised directly by
+`tests/test_agent_delta_chat_event_3288.py`), not what ships on the connected
+wire.
 
 | Custom `name`                        | Meaning                                          |
 |--------------------------------------|--------------------------------------------------|
 | `reyn.event.user_answered_intervention` | the user answered an intervention             |
 | `reyn.event.user_submitted`          | a user turn was submitted (#3300 P1 C) — RAW text + chain_id + msg_id + seq + meta; each surface neutralizes at its render boundary. `msg_id`/`seq` are the #3300 P2a sent-queue correlation id + order-race-gate token |
 | `reyn.event.inbox_cancel`            | an UNDISPATCHED queued user message was cancelled by id (#3300 P3, via the `cancel_queued` client message) — carries `msg_id` + `seq`; the server-authoritative sent-queue removal signal (never a client-local "cancel succeeded" response), exclusive with `turn_started` for the same `msg_id` |
-| `reyn.event.agent_delta`             | one streamed LLM content-delta chunk (#3288 ③b) — carries `text` (the raw per-chunk delta) + `chain_id`. NON-PERSISTENT and purely additive: the single source of truth stays the completed full-text `reyn.display.agent`-mapped `TEXT_MESSAGE_CONTENT` frame (`kind="agent"`), emitted exactly once at turn end (whole-persist, L9, is unaffected). Forwarded even though no shipped renderer consumes it yet — a client with no handler ignores it (skipped, not fatal), same as any unknown `CUSTOM` name; a future phase (③c local / ③d AG-UI generic multi-CONTENT) adds a consumer without requiring a wire change here |
+| `reyn.event.agent_delta`             | one streamed LLM content-delta chunk (#3288 ③b) — carries `text` (the raw per-chunk delta) + `chain_id`. The plain codec's `CUSTOM` mapping (see the note above); on the actual AG-UI wire (`encode_frame_wire_streaming`, #3288 ③d) this rides `TEXT_MESSAGE_CONTENT` instead — see *Text lifecycle* above for the full streamed-message contract (END-only completion, reconstruction authority, late-joiner closure) |
 
 ### `reyn.intervention.<kind>`
 
@@ -478,7 +509,7 @@ loss.
 | State      | 3                | 3           | **complete** |
 | Lifecycle  | 5                | 3           | **intentional-scope** — the 2 Step events fold into the `STATE_*` read-model's `waiting_on` field instead of a separate standard event (see *STATE_\* — the status read-model* above) |
 | Tool       | 5                | 3           | **complete for the HITL round-trip** — `TOOL_CALL_START` + `TOOL_CALL_END` (with a standard `status` field) + `TOOL_CALL_RESULT` (the intervention frontend-tool answer round-trip); the `TOOL_CALL_ARGS`/`_CHUNK` pair is **intentional-scope** (a tool call is already complete by the time reyn emits it — there is no in-flight args stream to chunk) |
-| Text       | 4                | 3           | **conforming triplet** — a whole message rides `TEXT_MESSAGE_START` → `TEXT_MESSAGE_CONTENT` → `TEXT_MESSAGE_END`, correlated by `messageId`; only the streaming `TEXT_MESSAGE_CHUNK` is unmapped (**intentional-scope** — reyn's outbox delivers whole messages, not token deltas) |
+| Text       | 4                | 3           | **conforming triplet, plain and streamed** — a whole message rides `TEXT_MESSAGE_START` → `TEXT_MESSAGE_CONTENT` → `TEXT_MESSAGE_END`, correlated by `messageId`; a message that streamed (#3288 ③a/③b/③d) rides the SAME triplet with a REAL per-delta `TEXT_MESSAGE_CONTENT` for each chunk (see *Text lifecycle* above) — only the condensed single-event `TEXT_MESSAGE_CHUNK` variant is unmapped (**intentional-scope** — the triplet form already covers streaming; reyn has no use for the alternate condensed encoding) |
 | Special    | 2                | 1           | **intentional-scope** — reyn-private payloads are always structured (`CUSTOM`); the standard `RAW` passthrough event has no reyn use case |
 | Activity   | 2                | 0           | **intentional-scope** — reyn has no direct analog; the same information is already carried by the frame stream + `STATE_*` |
 | Reasoning  | 7                | 3           | **standard-mapped** — a whole reasoning message rides `REASONING_MESSAGE_START` → `REASONING_MESSAGE_CONTENT` → `REASONING_MESSAGE_END`, correlated by `messageId`; the outer `REASONING_START`/`REASONING_END` context wrapper and the streaming `REASONING_MESSAGE_CHUNK`/`REASONING_ENCRYPTED_VALUE` variants are **intentional-scope** (reyn is whole-message; no encrypted CoT) |

--- a/src/reyn/interfaces/transport/agui/emitter.py
+++ b/src/reyn/interfaces/transport/agui/emitter.py
@@ -10,12 +10,17 @@ transports feed off the identical frame source, *local ≡ remote by constructio
 
 On connect it replays the reconnect snapshots (A4): ``MESSAGES_SNAPSHOT`` (the
 display backlog) then ``STATE_SNAPSHOT`` (the status read-model). It then streams
-each frame as its AG-UI **wire sequence** (:func:`encode_frame_wire` — a whole
-text message is the canonical ``TEXT_MESSAGE_START`` → ``…_CONTENT`` →
-``…_END`` triplet, P4; every other frame is a single event), and after each frame
-emits a ``STATE_DELTA`` when the projected status changed — the current WaitingOn
-label is tracked off the chat-event stream so the remote status panel follows
-Thinking / Running / Waiting-for-you without a second source.
+each frame as its AG-UI **wire sequence** (:func:`encode_frame_wire_streaming` —
+a whole text message is the canonical ``TEXT_MESSAGE_START`` → ``…_CONTENT`` →
+``…_END`` triplet, P4; a message that streamed (#3288 ③b/③d, ``agent_delta``
+chat-events) instead gets a REAL multi-CONTENT sequence — one ``TEXT_MESSAGE_START``
+at the first delta, one ``TEXT_MESSAGE_CONTENT`` per delta, one ``TEXT_MESSAGE_END``
+at completion carrying the completion's full text — via a ``TextStreamTracker``
+this emitter owns, scoped to THIS connection; every other frame is a single
+event), and after each frame emits a ``STATE_DELTA`` when the projected status
+changed — the current WaitingOn label is tracked off the chat-event stream so the
+remote status panel follows Thinking / Running / Waiting-for-you without a
+second source.
 """
 from __future__ import annotations
 
@@ -23,7 +28,8 @@ from typing import AsyncIterator, Callable
 
 from reyn.interfaces.transport.agui.protocol import (
     CONTROL_FILTER_KINDS,
-    encode_frame_wire,
+    TextStreamTracker,
+    encode_frame_wire_streaming,
     encode_intervention_tool_result,
     encode_intervention_tool_start,
     encode_messages_snapshot,
@@ -73,6 +79,11 @@ class AgUiEmitter:
         self._backlog = list(backlog or [])
         self._model = StatusModel()
         self._waiting_on: str | None = None
+        # #3288 ③d: one tracker per connection so a streamed reply's
+        # START/END bracketing reflects exactly what THIS connection
+        # personally observed (the late-joiner-closing mechanism — see
+        # ``TextStreamTracker``'s docstring, protocol.py).
+        self._text_stream = TextStreamTracker()
 
     def _project(self) -> dict:
         return project_status(self._status_provider(), waiting_on=self._waiting_on)
@@ -102,11 +113,13 @@ class AgUiEmitter:
                     return
                 continue
             # A whole text message expands to the AG-UI START→CONTENT→END triplet
-            # (conformance); every other frame is a single event. Only the
-            # _reyn-bearing event round-trips to the reyn client — START/END are
+            # (conformance); a message that streamed (#3288 ③d) instead gets a
+            # real multi-CONTENT sequence via the per-connection tracker; every
+            # other frame is a single event. Only the _reyn-bearing event(s)
+            # round-trip to the reyn client — non-reconstructing START/END are
             # generic scaffold. An ``intervention`` kind is CUSTOM (a single
             # event), so the triplet never disturbs the frontend-tool path below.
-            for event in encode_frame_wire(frame):
+            for event in encode_frame_wire_streaming(frame, self._text_stream):
                 yield to_sse(event)
             # HITL frontend-tool lifecycle (ADR-0039 P3, R4). An intervention
             # rides the wire in TWO representations: the DisplayFrame above (the

--- a/src/reyn/interfaces/transport/agui/protocol.py
+++ b/src/reyn/interfaces/transport/agui/protocol.py
@@ -20,6 +20,28 @@ Design (the load-bearing invariants this module carries):
   foreign event with no ``_reyn`` block decodes to ``None`` (ignore-unknown /
   graceful degrade — the generic-client contract).
 
+- **Re-decided invariant (#3288 ③d): "1 frame ⇄ 1 ``_reyn``-bearing event"
+  now holds ONLY for a non-streamed whole message.** ③b introduced
+  ``agent_delta`` chat-events (token-level LLM deltas); ③d gives them a REAL
+  multi-CONTENT wire lifecycle via :func:`encode_frame_wire_streaming` (used
+  by :class:`~reyn.interfaces.transport.agui.emitter.AgUiEmitter` in place of
+  :func:`encode_frame_wire`). For a message that streamed: N ``agent_delta``
+  EventFrames each become their OWN ``TEXT_MESSAGE_CONTENT``, each carrying
+  its OWN ``_reyn`` (so a reyn client reconstructs the exact same per-chunk
+  ``agent_delta`` EventFrame it would get in-process); the terminal
+  ``kind="agent"`` completion then maps to ``TEXT_MESSAGE_END`` ONLY — never
+  a second CONTENT re-sending the full text (a client that accumulated the
+  deltas would render the body twice) — but that END carries its OWN
+  ``_reyn``, holding the completion's FULL text. So a streamed message has
+  N+1 ``_reyn``-bearing wire events, not 1. The reyn client's
+  **reconstruction AUTHORITY is always the LAST one** (the END's full
+  text) — NEVER a concatenation of the N deltas, which are non-persistent,
+  derived, live-only narration; the restore/reconnect (``MESSAGES_SNAPSHOT``)
+  path never reads a delta, only the persisted completion. A message that
+  never streamed (no capability, or the connection never observed a delta
+  for it) is untouched: the plain :func:`encode_frame_wire` triplet, CONTENT
+  carries ``_reyn``, START/END are scaffold — byte-identical to pre-③d.
+
 - **The mapping is a table, derived, not hand-listed at the call site.** The
   ``kind``/``type`` → AG-UI-event-type tables (:data:`_DISPLAY_KIND_EVENT` /
   :data:`_EVENT_TYPE_EVENT`) are the single source the completeness gate reads;
@@ -40,8 +62,13 @@ stock AG-UI client with zero reyn knowledge renders a functional chat:
   (reyn's outbox has no stable message id). Only the CONTENT event carries the
   ``_reyn`` reconstruction block — START/END are generic scaffold the reyn client
   decodes to ``None`` — so the invariant stays **1 frame ⇄ 1 ``_reyn``-bearing
-  event** and reyn bit-identity is unchanged. (Token-streaming is out of scope;
-  reyn is whole-message.)
+  event** and reyn bit-identity is unchanged, for a message that never streamed.
+  **A message that DID stream (#3288 ③d)** rides
+  :func:`encode_frame_wire_streaming` instead: a real per-chunk
+  ``TEXT_MESSAGE_CONTENT`` for every ``agent_delta``, bracketed by ONE
+  ``TEXT_MESSAGE_START`` (at the first delta) and ONE ``TEXT_MESSAGE_END`` (at
+  completion, carrying the completion's ``_reyn`` — see the module docstring's
+  re-decided invariant above) — never a second full-text CONTENT.
 - **Standard ``messages`` array.** ``MESSAGES_SNAPSHOT`` carries a standard
   ``[{role, content}]`` array of **conversation turns only** (``agent`` →
   ``assistant``, ``user`` → ``user``); reyn chrome (status / error / present /
@@ -347,6 +374,144 @@ def encode_frame_wire(frame: Frame) -> "list[AgUiEvent]":
     return [start, event, end]
 
 
+# Turn-lifecycle etypes that terminate a chain's stream even when it never
+# reaches a ``kind="agent"`` completion (e.g. a mid-stream cancel emits
+# ``kind="system"`` "turn interrupted" instead, router_loop.py:2422-2427).
+# Defensive-only: closes a dangling stream (START+CONTENT sent, no END yet) so
+# a strict generic client never sees a message left permanently open — the
+# "Spec validity" gate applies to this edge just as much as the happy path.
+_TURN_TERMINAL_ETYPES: "frozenset[str]" = frozenset(
+    {"turn_settled", "turn_completed", "turn_cancelled"}
+)
+
+
+class TextStreamTracker:
+    """Per-connection state correlating a streamed reply's ``agent_delta``
+    chat-events with its terminal ``kind="agent"`` completion (#3288 ③d),
+    keyed by ``chain_id`` — the turn-correlation id both carry
+    (``RouterLoop._emit_agent_delta`` stamps it on every delta;
+    ``RouterLoop.run``'s terminal ``put_outbox(meta={"chain_id": ...})`` stamps
+    the SAME id on the completion, ``router_loop.py``).
+
+    Owned one-per-connection by :class:`~reyn.interfaces.transport.agui.emitter.AgUiEmitter`
+    — so it reflects exactly what THIS connection personally observed. A
+    connection that witnesses at least one delta for a chain_id maps that
+    chain's completion to END-only; a connection that never witnessed a delta
+    for it (never connected, or connected after the whole turn already
+    finished) gets the unchanged plain whole-message triplet instead — which
+    is how the late-joiner window closes without any additional per-client
+    "which deltas did you receive" bookkeeping (explicitly rejected, issue
+    #3288 ③d design thread): whichever branch fires, the reyn client ends up
+    calling the SAME renderer entry point with the SAME persisted full text.
+    """
+
+    def __init__(self) -> None:
+        self._message_id_by_chain: "dict[str, str]" = {}
+
+    def begin_delta(self, chain_id: str) -> "tuple[str, bool]":
+        """Registers one delta for ``chain_id``; returns ``(messageId,
+        is_first_delta_for_this_chain)``."""
+        is_first = chain_id not in self._message_id_by_chain
+        message_id = self._message_id_by_chain.setdefault(chain_id, _new_message_id())
+        return message_id, is_first
+
+    def end_stream(self, chain_id: str) -> "str | None":
+        """Pops and returns the streamed ``messageId`` for ``chain_id`` — or
+        ``None`` when this connection never observed a delta for it (a plain
+        whole-message reply, or a chain this connection joined too late to
+        see any delta of)."""
+        return self._message_id_by_chain.pop(chain_id, None)
+
+
+def encode_frame_wire_streaming(
+    frame: Frame, tracker: TextStreamTracker
+) -> "list[AgUiEvent]":
+    """Encode one ``Frame`` to its AG-UI wire sequence WITH generic
+    multi-CONTENT text streaming (#3288 ③d — see the module docstring's
+    re-decided invariant for the full contract).
+
+    - An ``agent_delta`` ``EventFrame`` (③b) becomes a real
+      ``TEXT_MESSAGE_CONTENT``: the FIRST one observed for a ``chain_id`` (on
+      THIS connection, via ``tracker``) is preceded by a ``TEXT_MESSAGE_START``
+      so a strict generic client accepts it (ADR-0039 P4); every delta CONTENT
+      carries its own ``_reyn`` block.
+    - A ``kind="agent"`` completion ``DisplayFrame`` whose ``chain_id`` has an
+      active stream on ``tracker`` maps to ``TEXT_MESSAGE_END`` ONLY — never a
+      second CONTENT re-sending the full text. The END carries the
+      completion's OWN ``_reyn`` (the full text) — the sole reconstruction
+      authority for a streamed message; this is what closes the late-joiner
+      window (a connection that saw only some/no deltas for this chain still
+      gets the full text off THIS event, or off the plain fallback below).
+    - A ``kind="agent"`` completion whose ``chain_id`` was never streamed on
+      THIS connection (``tracker.end_stream`` returns ``None``) falls straight
+      through to the unchanged :func:`encode_frame_wire` triplet — byte-identical
+      to pre-③d.
+    - A turn-terminal event (``turn_settled``/``turn_completed``/``turn_cancelled``)
+      that arrives while a stream is still active for its ``chain_id`` (a
+      mid-stream cancel never reaches a ``kind="agent"`` completion) closes the
+      dangling stream defensively with a bare ``TEXT_MESSAGE_END`` (no ``_reyn``
+      — no full text exists to attach) ahead of that event's own encoding, so a
+      strict generic client never sees a message left permanently open.
+    - Every other frame is unaffected: :func:`encode_frame_wire` unchanged.
+    """
+    if isinstance(frame, EventFrame) and getattr(frame.event, "type", "") == "agent_delta":
+        edata = dict(getattr(frame.event, "data", {}) or {})
+        chain_id = str(edata.get("chain_id") or "")
+        text = str(edata.get("text") or "")
+        message_id, is_first = tracker.begin_delta(chain_id)
+        events: "list[AgUiEvent]" = []
+        if is_first:
+            events.append(
+                AgUiEvent(
+                    type=TEXT_MESSAGE_START,
+                    data={"messageId": message_id, "role": "assistant"},
+                )
+            )
+        reyn = {"frame": "event", "type": "agent_delta", "data": edata}
+        events.append(
+            AgUiEvent(
+                type=TEXT_MESSAGE_CONTENT,
+                data={
+                    "messageId": message_id,
+                    "role": "assistant",
+                    "delta": text,
+                    _REYN: reyn,
+                },
+            )
+        )
+        return events
+    if isinstance(frame, DisplayFrame) and frame.message.kind == "agent":
+        chain_id = str((frame.message.meta or {}).get("chain_id") or "")
+        message_id = tracker.end_stream(chain_id)
+        if message_id is not None:
+            msg = frame.message
+            reyn = {
+                "frame": "display",
+                "kind": msg.kind,
+                "text": msg.text,
+                "meta": dict(msg.meta or {}),
+            }
+            return [
+                AgUiEvent(
+                    type=TEXT_MESSAGE_END,
+                    data={"messageId": message_id, _REYN: reyn},
+                )
+            ]
+        return encode_frame_wire(frame)
+    if isinstance(frame, EventFrame) and getattr(frame.event, "type", "") in _TURN_TERMINAL_ETYPES:
+        edata = dict(getattr(frame.event, "data", {}) or {})
+        chain_id = str(edata.get("chain_id") or "")
+        message_id = tracker.end_stream(chain_id)
+        events = encode_frame_wire(frame)
+        if message_id is not None:
+            events = [
+                AgUiEvent(type=TEXT_MESSAGE_END, data={"messageId": message_id}),
+                *events,
+            ]
+        return events
+    return encode_frame_wire(frame)
+
+
 def encode_state_snapshot(snapshot: dict) -> AgUiEvent:
     """STATE_SNAPSHOT — the full status read-model, emitted on connect (A4)."""
     return AgUiEvent(
@@ -554,6 +719,8 @@ __all__ = [
     "CONTROL_FILTER_KINDS",
     "encode_frame",
     "encode_frame_wire",
+    "TextStreamTracker",
+    "encode_frame_wire_streaming",
     "encode_state_snapshot",
     "encode_state_delta",
     "encode_messages_snapshot",

--- a/tests/test_agui_multi_content_streaming_3288.py
+++ b/tests/test_agui_multi_content_streaming_3288.py
@@ -1,0 +1,422 @@
+"""Tier 2: #3288 ③d — AG-UI generic multi-CONTENT streaming.
+
+③b (#3305's sibling PR) put a streamed LLM reply's per-chunk deltas on a
+SEPARATE chat-event channel (``agent_delta``), forwarded on the wire as an
+opaque ``CUSTOM`` event — a generic AG-UI client could not render it as
+streaming text at all; it saw one whole-text ``TEXT_MESSAGE_CONTENT`` only,
+after the fact. ③d upgrades the wire encoding so a generic client streams
+natively: ``TEXT_MESSAGE_START`` at the first delta, one real
+``TEXT_MESSAGE_CONTENT`` per delta, ``TEXT_MESSAGE_END`` at completion — with
+NO second full-text CONTENT re-sent at the end (a client that accumulated the
+deltas would render the body twice).
+
+Design rulings this file witnesses (issue #3288 ③d comment thread):
+
+1. A streamed message's completion maps to END only (never a duplicate
+   full-text CONTENT).
+2. Reconstruction authority is the completion's full text, EXCLUSIVELY — the
+   deltas are non-persistent derived notifications; the terminal END's
+   ``_reyn`` block carries the actual full text, never a delta.
+3. The late-joiner window is closed: a connection's ``TextStreamTracker`` is
+   scoped to what THAT connection personally observed, so a connection that
+   witnessed zero deltas for a chain gets the unchanged whole-message triplet
+   (full text on CONTENT) instead of a bare END — no per-client "which deltas
+   did you receive" bookkeeping.
+4. Local ≡ remote: the reyn client's reconstruction (via ``decode_event``) is
+   the same set of Frames whether frames arrive via ``InProcessTransport`` or
+   over the AG-UI wire.
+
+Real instances only — the real codec (``protocol.py``), a real ``AgUiEmitter``
+over real SSE text, a real ``InProcessTransport`` / ``AgUiTransport`` pair; no
+mocks (per testing.md).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.core.events.events import Event, EventLog
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.agui.protocol import (
+    TEXT_MESSAGE_CONTENT,
+    TEXT_MESSAGE_END,
+    TEXT_MESSAGE_START,
+    AgUiEvent,
+    TextStreamTracker,
+    decode_event,
+    encode_frame_wire,
+    encode_frame_wire_streaming,
+    parse_sse_blocks,
+)
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.interfaces.transport.in_process import InProcessTransport
+from reyn.runtime.outbox import OutboxMessage
+
+_CHAIN = "chain-3288d-1"
+_PIECES = ["hello ", "streamed ", "world"]
+_FULL = "hello streamed world"
+
+
+def _delta_frames(chain_id: str = _CHAIN, pieces=_PIECES) -> "list[EventFrame]":
+    return [
+        EventFrame(Event(type="agent_delta", data={"text": p, "chain_id": chain_id}))
+        for p in pieces
+    ]
+
+
+def _completion_frame(chain_id: str = _CHAIN, text: str = _FULL) -> DisplayFrame:
+    return DisplayFrame(OutboxMessage(kind="agent", text=text, meta={"chain_id": chain_id}))
+
+
+def _encode_script(frames, tracker: "TextStreamTracker | None" = None) -> "list[AgUiEvent]":
+    tracker = tracker if tracker is not None else TextStreamTracker()
+    out: list[AgUiEvent] = []
+    for f in frames:
+        out.extend(encode_frame_wire_streaming(f, tracker))
+    return out
+
+
+async def _frame_source(frames):
+    for f in frames:
+        yield f
+
+
+async def _wire_events(frames) -> "list[AgUiEvent]":
+    """Route ``frames`` through a REAL ``AgUiEmitter`` and parse the real SSE
+    text back into events — exercises the actual production call site
+    (``emitter.py``'s ``encode_frame_wire_streaming(frame, self._text_stream)``),
+    not a re-implementation of it."""
+    emitter = AgUiEmitter(_frame_source(frames), lambda: None)
+    sse = "".join([chunk async for chunk in emitter.stream()])
+    events = parse_sse_blocks(sse.split("\n"))
+    # Drop the reconnect-snapshot preamble (MESSAGES_SNAPSHOT/STATE_SNAPSHOT)
+    # and any STATE_DELTA the emitter interleaves — irrelevant to this gate.
+    return [e for e in events if e.type not in ("MESSAGES_SNAPSHOT", "STATE_SNAPSHOT", "STATE_DELTA")]
+
+
+# ---------------------------------------------------------------------------
+# 1. No double body on a generic client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_streamed_reply_is_start_n_content_end_no_full_text_content() -> None:
+    """Tier 2: a streamed reply yields START + N CONTENT + END through the
+    REAL AgUiEmitter — and no CONTENT ever carries the accumulated full text
+    (only the per-chunk piece)."""
+    events = await _wire_events([*_delta_frames(), _completion_frame()])
+
+    assert [e.type for e in events] == [
+        TEXT_MESSAGE_START,
+        TEXT_MESSAGE_CONTENT,
+        TEXT_MESSAGE_CONTENT,
+        TEXT_MESSAGE_CONTENT,
+        TEXT_MESSAGE_END,
+    ]
+    contents = [e for e in events if e.type == TEXT_MESSAGE_CONTENT]
+    assert [c.data["delta"] for c in contents] == _PIECES
+    assert _FULL not in [c.data["delta"] for c in contents], (
+        "the full accumulated text must never appear as a CONTENT delta — "
+        "a client that rendered the deltas live would double-render the body"
+    )
+    end = events[-1]
+    assert "delta" not in end.data, "END must never carry a text delta"
+    # one shared messageId across the whole sequence (spec correlation)
+    assert len({e.data.get("messageId") for e in events}) == 1
+
+
+def test_falling_back_to_the_plain_triplet_would_double_the_body() -> None:
+    """Tier 2: non-vacuity (RED without the ③d gate) — the pre-③d
+    ``encode_frame_wire`` applied to the SAME completion frame emits a CONTENT
+    carrying the FULL text — exactly the double-render a client that already
+    rendered the deltas live would suffer, if the emitter fell back to this
+    instead of routing the completion through the tracker-gated
+    ``encode_frame_wire_streaming``. Demonstrates why gate 1 is load-bearing."""
+    plain = encode_frame_wire(_completion_frame())
+    content = next(e for e in plain if e.type == TEXT_MESSAGE_CONTENT)
+    assert content.data["delta"] == _FULL, (
+        "this is the double-render encode_frame_wire_streaming's END-only "
+        "mapping exists specifically to avoid"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Non-streamed path unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_non_streamed_completion_gets_the_unchanged_whole_message_triplet() -> None:
+    """Tier 2: a completion whose chain never streamed on this tracker (no
+    prior ``agent_delta`` observed) falls straight through to the SAME
+    sequence ``encode_frame_wire`` would produce — byte-identical to
+    pre-③d."""
+    tracker = TextStreamTracker()
+    streamed_path = encode_frame_wire_streaming(_completion_frame(), tracker)
+    plain_path = encode_frame_wire(_completion_frame())
+
+    assert [e.type for e in streamed_path] == [e.type for e in plain_path]
+    content = next(e for e in streamed_path if e.type == TEXT_MESSAGE_CONTENT)
+    assert content.data["delta"] == _FULL
+    assert "_reyn" in content.data
+    for e in streamed_path:
+        if e.type != TEXT_MESSAGE_CONTENT:
+            assert "_reyn" not in e.data
+
+
+@pytest.mark.asyncio
+async def test_non_streamed_reply_through_real_emitter_unchanged() -> None:
+    """Tier 2: end-to-end through the real AgUiEmitter, a whole (never
+    streamed) reply is exactly the pre-③d triplet."""
+    events = await _wire_events([_completion_frame()])
+    assert [e.type for e in events] == [
+        TEXT_MESSAGE_START,
+        TEXT_MESSAGE_CONTENT,
+        TEXT_MESSAGE_END,
+    ]
+    content = events[1]
+    assert content.data["delta"] == _FULL
+    assert "_reyn" not in events[0].data and "_reyn" not in events[2].data
+
+
+# ---------------------------------------------------------------------------
+# 3. ★Late-joiner: a client that connects mid-stream eventually obtains the
+#    full text (via the terminal completion's own reconstruction authority).
+# ---------------------------------------------------------------------------
+
+
+def _decoded_agent_display_texts(events) -> "list[str]":
+    out = []
+    for e in events:
+        decoded = decode_event(e.type, e.data)
+        if isinstance(decoded, DisplayFrame) and decoded.message.kind == "agent":
+            out.append(decoded.message.text)
+    return out
+
+
+def test_late_joiner_that_saw_some_deltas_still_reconstructs_full_text() -> None:
+    """Tier 2: ★late-joiner — a connection whose tracker only observed the
+    LAST delta (it attached mid-stream, missing START + earlier deltas)
+    still, eventually, reconstructs the completion's FULL text — off the
+    terminal END's own ``_reyn``, never off the deltas it did see."""
+    tracker = TextStreamTracker()
+    late_joiner_view = list(_delta_frames(pieces=_PIECES[-1:]))  # missed the rest
+    late_joiner_view.append(_completion_frame())
+
+    events = _encode_script(late_joiner_view, tracker)
+    texts = _decoded_agent_display_texts(events)
+    assert texts == [_FULL], "the late-joiner must obtain the FULL persisted text, not a partial"
+
+
+def test_late_joiner_that_saw_zero_deltas_also_reconstructs_full_text() -> None:
+    """Tier 2: ★late-joiner, the other corner — a connection that witnessed
+    NO delta at all for this chain (attached right as the turn finished)
+    falls through to the plain whole-message triplet and STILL gets the full
+    text — via gate 2's fallback, not via any delta."""
+    tracker = TextStreamTracker()
+    events = _encode_script([_completion_frame()], tracker)
+    assert _decoded_agent_display_texts(events) == [_FULL]
+
+
+def test_late_joiner_strip_without_end_reyn_loses_the_body() -> None:
+    """Tier 2: non-vacuity (RED without the fix) — a LOCAL broken
+    reimplementation that reproduces every other part of ③d's streaming
+    encode but omits the completion's ``_reyn`` from the END event — i.e. the
+    late-joiner-closing mechanism this PR adds — leaves a mid-stream joiner
+    with NO reconstructable full text anywhere in the sequence it received.
+    Proves the ``_reyn``-on-END step (not just END existing) is load-bearing."""
+
+    def _broken_encode(frame, tracker: TextStreamTracker):
+        if isinstance(frame, EventFrame) and frame.event.type == "agent_delta":
+            return encode_frame_wire_streaming(frame, tracker)  # deltas unaffected
+        if isinstance(frame, DisplayFrame) and frame.message.kind == "agent":
+            chain_id = str((frame.message.meta or {}).get("chain_id") or "")
+            message_id = tracker.end_stream(chain_id)
+            if message_id is not None:
+                # BUG: no _reyn attached — the exact step ③d's fix supplies.
+                return [AgUiEvent(type=TEXT_MESSAGE_END, data={"messageId": message_id})]
+        return encode_frame_wire(frame)
+
+    tracker = TextStreamTracker()
+    late_joiner_view = list(_delta_frames(pieces=_PIECES[-1:]))
+    late_joiner_view.append(_completion_frame())
+
+    out: list[AgUiEvent] = []
+    for f in late_joiner_view:
+        out.extend(_broken_encode(f, tracker))
+
+    assert _decoded_agent_display_texts(out) == [], (
+        "the broken (no-_reyn-on-END) encoder should leave the late-joiner "
+        "with a missing body — proves the real fix's _reyn-on-END is load-bearing"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. local ≡ remote parity
+# ---------------------------------------------------------------------------
+
+
+class _FakeRegistry:
+    def __init__(self) -> None:
+        self.repl_outbox: "asyncio.Queue" = asyncio.Queue()
+        self.chat_events = EventLog()
+        self._cb = None
+
+    def bind_focus_listeners(self, *, on_chat_event=None, intervention_channel=None) -> None:
+        self._cb = on_chat_event
+        if on_chat_event is not None:
+            self.chat_events.add_subscriber(on_chat_event)
+
+    def unbind_focus_listeners(self) -> None:
+        if self._cb is not None:
+            self.chat_events.remove_subscriber(self._cb)
+            self._cb = None
+
+    def attached_session(self):
+        return None
+
+
+def _norm(frames) -> "list[tuple]":
+    # ``__end__`` is a control sentinel with an ASYMMETRIC transport
+    # disposition BY DESIGN, unrelated to ③d: InProcessTransport forwards it
+    # (the local frame queue's own terminator), while the AG-UI emitter
+    # consumes-not-forwards it (``CONTROL_FILTER_KINDS`` — the server just
+    # stops streaming; the client's SSE loop ends on stream close instead).
+    # Excluded here so the comparison is about the ③d streaming content, not
+    # this pre-existing, already-covered disposition
+    # (``tests/test_agui_control_filter.py``).
+    out: list[tuple] = []
+    for f in frames:
+        if isinstance(f, EventFrame):
+            out.append(("event", f.event.type, dict(f.event.data)))
+        elif isinstance(f, DisplayFrame) and f.message.kind != "__end__":
+            out.append(("display", f.message.kind, f.message.text))
+    return out
+
+
+async def _collect(gen) -> list:
+    return [f async for f in gen]
+
+
+async def _via_in_process(script) -> list:
+    fake = _FakeRegistry()
+    transport = InProcessTransport(fake, intervention_channel="tui")
+    transport.start()
+    try:
+        for f in script:
+            if isinstance(f, EventFrame):
+                fake.chat_events.emit(f.event.type, **f.event.data)
+            else:
+                fake.repl_outbox.put_nowait(f.message)
+        fake.repl_outbox.put_nowait(OutboxMessage(kind="__end__", text=""))
+        return await asyncio.wait_for(_collect(transport.frames()), timeout=2.0)
+    finally:
+        transport.close()
+
+
+async def _sse_lines(text):
+    for line in text.split("\n"):
+        yield line
+
+
+async def _noop_send(_payload):
+    return None
+
+
+async def _via_agui(script) -> list:
+    full = [*script, DisplayFrame(OutboxMessage(kind="__end__", text=""))]
+    emitter = AgUiEmitter(_frame_source(full), lambda: None)
+    sse = "".join([chunk async for chunk in emitter.stream()])
+    transport = AgUiTransport(_sse_lines(sse), _noop_send)
+    return await asyncio.wait_for(_collect(transport.frames()), timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_local_and_remote_reconstruct_the_identical_streamed_sequence() -> None:
+    """Tier 2: ★local ≡ remote — the SAME script (N ``agent_delta`` chat-events
+    + the terminal ``kind="agent"`` completion) drives ``InProcessTransport``
+    and the AG-UI wire (real ``AgUiEmitter`` → real SSE → real
+    ``AgUiTransport``); the reyn client's reconstructed Frame sequence is
+    IDENTICAL (same events, same order, same text) across both transports."""
+    script = [*_delta_frames(), _completion_frame()]
+
+    ip_frames = await _via_in_process(script)
+    ag_frames = await _via_agui(script)
+
+    assert _norm(ip_frames) == _norm(ag_frames)
+    # non-trivial: the deltas actually made it across, not just the final text
+    assert len([f for f in ag_frames if isinstance(f, EventFrame)]) == len(_PIECES)
+
+
+@pytest.mark.asyncio
+async def test_local_remote_parity_check_is_not_vacuous() -> None:
+    """Tier 2: non-vacuity — the comparison in the parity test above actually
+    discriminates — dropping one delta from the AG-UI-side script (simulating
+    a forwarding regression on the wire side only) makes the two
+    reconstructions MISMATCH, proving the assertion is not tautologically
+    true regardless of what either side produces."""
+    full_script = [*_delta_frames(), _completion_frame()]
+    missing_one_delta = [*_delta_frames(pieces=_PIECES[1:]), _completion_frame()]
+
+    ip_frames = await _via_in_process(full_script)
+    ag_frames = await _via_agui(missing_one_delta)
+
+    assert _norm(ip_frames) != _norm(ag_frames), (
+        "the parity check must be sensitive to a dropped delta — otherwise "
+        "it would pass even when local and remote actually diverged"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Spec validity — no bare *_CONTENT without its START/END bracket
+# ---------------------------------------------------------------------------
+
+
+def _check_bracket_invariant(events) -> None:
+    started: "set[str]" = set()
+    for e in events:
+        mid = e.data.get("messageId")
+        if e.type == TEXT_MESSAGE_START:
+            assert mid not in started, f"duplicate START for messageId={mid}"
+            started.add(mid)
+        elif e.type == TEXT_MESSAGE_CONTENT:
+            assert mid in started, f"bare CONTENT with no preceding START: messageId={mid}"
+        elif e.type == TEXT_MESSAGE_END:
+            assert mid in started, f"END with no preceding START: messageId={mid}"
+            started.discard(mid)
+
+
+@pytest.mark.asyncio
+async def test_streamed_sequence_satisfies_the_start_content_end_bracket() -> None:
+    """Tier 2: every CONTENT/END produced for a streamed reply has a preceding
+    START for the SAME messageId — a strict generic client never drops a bare
+    CONTENT."""
+    events = await _wire_events([*_delta_frames(), _completion_frame()])
+    _check_bracket_invariant(events)
+
+
+def test_mid_stream_cancel_closes_the_dangling_stream() -> None:
+    """Tier 2: a mid-stream cancel (``turn_cancelled``, never reaching a
+    ``kind="agent"`` completion — router_loop.py's cancel path emits
+    ``kind="system"`` instead) still closes the open stream with a
+    defensive END, so the bracket invariant holds even on this edge."""
+    tracker = TextStreamTracker()
+    script = [
+        *_delta_frames(),
+        EventFrame(Event(type="turn_cancelled", data={"chain_id": _CHAIN})),
+    ]
+    events = _encode_script(script, tracker)
+    _check_bracket_invariant(events)
+    assert TEXT_MESSAGE_END in [e.type for e in events], (
+        "the dangling stream must be closed with an END even though the "
+        "cancel path never produces a kind=\"agent\" completion"
+    )
+
+
+def test_bracket_checker_is_not_vacuous() -> None:
+    """Tier 2: non-vacuity — the checker above actually rejects a bare CONTENT
+    with no START — proving it is a real assertion, not a no-op."""
+    bare = [AgUiEvent(type=TEXT_MESSAGE_CONTENT, data={"messageId": "orphan"})]
+    with pytest.raises(AssertionError):
+        _check_bracket_invariant(bare)


### PR DESCRIPTION
**[per-PR-coder]** — part of #3288 (③d: AG-UI generic multi-CONTENT streaming, following ③a/③b already merged).

## What this does

Today a whole `agent` message expands to the canonical AG-UI lifecycle triplet `TEXT_MESSAGE_START → TEXT_MESSAGE_CONTENT → TEXT_MESSAGE_END` (one CONTENT, the full text). ③d upgrades the **generic interop layer** so a generic AG-UI client streams natively: `TEXT_MESSAGE_START` at the first `agent_delta` (#3288 ③b), one REAL `TEXT_MESSAGE_CONTENT` per delta, `TEXT_MESSAGE_END` at completion.

- `src/reyn/interfaces/transport/agui/protocol.py`: new `TextStreamTracker` + `encode_frame_wire_streaming` — a per-connection stateful codec that correlates `agent_delta` `EventFrame`s with the terminal `kind="agent"` completion by `chain_id` (the id both already carry — `router_loop.py`'s `_emit_agent_delta` and the terminal `put_outbox(meta=...)`). `encode_frame_wire` itself is UNTOUCHED; a completion whose chain never streamed on this connection's tracker falls straight through to it (byte-identical to pre-③d).
- `src/reyn/interfaces/transport/agui/emitter.py`: one `TextStreamTracker` per connection, threaded through the wire loop in place of the bare `encode_frame_wire` call.
- `docs/reference/runtime/agui-transport.md`: rewrote the *Text lifecycle* section, the `reyn.event.agent_delta` profile row, and the Text coverage-table row to describe the streamed-vs-plain split and the re-decided reconstruction invariant.

## Design rulings implemented (issue #3288 ③d comment thread — not re-litigated)

1. **Completion maps to END only.** The full text is never re-sent as a second CONTENT — the END instead carries its OWN `_reyn` block holding the completion's full text.
2. **Reconstruction authority = the completion's full text, exclusively.** Deltas are non-persistent, derived, live-only narration. The restore/reconnect path (`MESSAGES_SNAPSHOT`) is built only from `DisplayFrame`s — `agent_delta` is structurally an `EventFrame`, so it is IMPOSSIBLE for the restore path to read a delta (no branch to remove — there was never a slot for one).
3. **★Late-joiner window closed, no per-client bookkeeping.** `TextStreamTracker` is scoped ONE-PER-CONNECTION: a connection that witnessed some deltas for a chain gets END-only (full text via END's `_reyn`); a connection that witnessed ZERO deltas for that chain (attached after it finished, or missed the whole stream) gets the SAME completion frame routed through the unchanged plain triplet instead (full text via CONTENT). Either way the client ends up with the complete, persisted text — no per-client "which deltas did you receive" state is kept (this was explicitly rejected in the design thread).
4. **Re-decided invariant.** "1 frame ⇄ 1 `_reyn`-bearing event" now holds only for a message that never streamed. A streamed message has N+1 `_reyn`-bearing wire events (N deltas + 1 completion) — the client's reconstruction authority is always the LAST one, never a delta concatenation. Written into both the module docstring and the doc.

## Gates (each strip-falsified, arrival-witness discipline applied)

All in `tests/test_agui_multi_content_streaming_3288.py`, run through the REAL `AgUiEmitter` (real SSE text) wherever the gate concerns the production wire path, not a hand-rolled reimplementation.

- **No double body on a generic client** (`test_streamed_reply_is_start_n_content_end_no_full_text_content`): a streamed reply → START + N CONTENT + END, no CONTENT ever carries the accumulated full text. Non-vacuity witness (`test_falling_back_to_the_plain_triplet_would_double_the_body`): the pre-③d plain `encode_frame_wire` applied to the SAME completion DOES emit a full-text CONTENT — RED observed (the double-render this PR's END-only mapping avoids).
- **Non-streamed path unchanged** (`test_non_streamed_completion_gets_the_unchanged_whole_message_triplet`, `test_non_streamed_reply_through_real_emitter_unchanged`): byte-identical triplet to pre-③d.
- **★Late-joiner** (`test_late_joiner_that_saw_some_deltas_still_reconstructs_full_text`, `test_late_joiner_that_saw_zero_deltas_also_reconstructs_full_text`): both corners reconstruct the full text. Strip witness (`test_late_joiner_strip_without_end_reyn_loses_the_body`): a local broken reimplementation that reproduces everything EXCEPT attaching `_reyn` to END leaves the late-joiner with **zero reconstructable full text** — RED observed, confirming `_reyn`-on-END (not just END existing) is the load-bearing step.
- **local ≡ remote parity** (`test_local_and_remote_reconstruct_the_identical_streamed_sequence`): the SAME script through `InProcessTransport` and the real AG-UI wire (`AgUiEmitter` → SSE → `AgUiTransport`) reconstructs an IDENTICAL Frame sequence, including all N delta EventFrames (arrival-witness: asserts `len(EventFrame) == len(_PIECES)` on the wire side, not just the final text). Non-vacuity (`test_local_remote_parity_check_is_not_vacuous`): dropping one delta from the AG-UI-side script makes the comparison MISMATCH — RED observed, proving the comparison discriminates.
- **Spec validity** (`test_streamed_sequence_satisfies_the_start_content_end_bracket`, `test_bracket_checker_is_not_vacuous`): every CONTENT/END has a preceding START for the same `messageId`. Non-vacuity: a bare CONTENT with no START fails the checker — RED observed. Extra edge case (`test_mid_stream_cancel_closes_the_dangling_stream`): a mid-stream cancel (`turn_cancelled`, which never reaches a `kind="agent"` completion — router_loop.py's cancel path emits `kind="system"` instead) still closes the dangling stream defensively.

## Test plan

- [x] `uv run python -m pytest --timeout=120 -q tests/test_agui_multi_content_streaming_3288.py` — 12 passed
- [x] `uv run python -m pytest --timeout=120 -q tests/ -k "agui"` — 97 passed, 8 skipped (no regressions across the whole AG-UI suite)
- [x] `uv run python -m pytest --timeout=120 -q tests/ -k "transport"` — 76 passed, 8 skipped
- [x] `ruff check src tests/test_agui_multi_content_streaming_3288.py` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_agui_multi_content_streaming_3288.py` — 12/12 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/transport/agui/protocol.py src/reyn/interfaces/transport/agui/emitter.py` — OK

Full-suite authority is CI, per repo policy — did not run the full local suite (shared machine).