### PR TITLE
feat(tui): client half of cancel-by-id — #3300 Y-client

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -362,6 +362,19 @@ class TextualChatApp(App):
         # co-vet fix, so a late-joiner's promoted item is attributed exactly
         # like a delta-path one).
         self._queue_item_meta: "dict[str, dict]" = {}
+        # #3300 Y-client: msg_id -> cancelled text, for a cancel THIS client
+        # itself issued (:meth:`on_sent_queue_cancelled`), populated BEFORE
+        # the ``cancel_queued`` call. The composer restore
+        # (:meth:`_restore_cancelled_text`) is driven ONLY off the matching
+        # ``inbox_cancel`` delta actually arriving
+        # (:meth:`_handle_inbox_cancel_event`) — never off this call's return
+        # value — so it never fires for a cancel that raced an already-
+        # dispatched item (no delta ever follows a no-op) and stays
+        # consistent with the row-removal contract (also delta-driven, never
+        # return-value-driven). Canceller-local by construction: only the
+        # client that populated this entry ever restores anything; every
+        # other client applies the SAME delta as a plain removal.
+        self._pending_own_cancels: "dict[str, str]" = {}
         # Per-picker parallel id lists (class names / agent names), keyed by tab
         # id and kept in lock-step with the OptionList options a pane was last
         # refreshed with, so an ``OptionSelected.option_index`` maps back to the
@@ -1015,6 +1028,97 @@ class TextualChatApp(App):
             text = _neutralized_label(str(item.get("text", "")))
             self._ingest_frame(OutboxMessage(kind="user", text=text, meta=meta))
 
+    def _handle_inbox_cancel_event(self, event) -> None:
+        """REMOVE exit (#3300 Y-client, sent-queue exit contract §6a): an
+        ``inbox_cancel`` delta removes the matching queued item from the
+        sent-queue region. Applies the SAME seq-gate protocol as the
+        materialize/promote deltas (``RemoteQueueView.apply_inbox_cancel``),
+        so a stale/already-superseded delta is a no-op, exactly like
+        :meth:`_handle_user_submitted_event`/:meth:`_handle_turn_started_event`.
+
+        Server-authoritative: removal happens for EVERY client from this SAME
+        delta, never from a client-local "cancel succeeded" return value. If
+        THIS client is the one that issued the cancel (tracked in
+        :attr:`_pending_own_cancels`, populated by
+        :meth:`on_sent_queue_cancelled` before the ``cancel_queued`` call),
+        the cancelled text is ADDITIONALLY restored into the composer
+        (:meth:`_restore_cancelled_text`) — canceller-local, per the owner's
+        ratified contract (issue #3300 §6a); every OTHER client's
+        ``_pending_own_cancels`` never had this msg_id, so it applies only
+        the removal."""
+        data = event.data or {}
+        msg_id = data.get("msg_id")
+        seq = data.get("seq", 0)
+        applied = self._queue_view.apply_inbox_cancel(msg_id=msg_id, seq=seq)
+        if not applied or not msg_id:
+            return
+        self._sent_queue.remove_item(msg_id)
+        self._queue_item_meta.pop(msg_id, None)
+        cancelled_text = self._pending_own_cancels.pop(msg_id, None)
+        if cancelled_text is not None:
+            self._restore_cancelled_text(cancelled_text)
+
+    def _restore_cancelled_text(self, text: str) -> None:
+        """Restore a cancelled submission's text into the composer (#3300
+        Y-client, owner-ratified detail): prepended at the HEAD even when the
+        composer already holds a draft — a newline boundary separates the
+        restored text from whatever was already there, so the draft survives
+        intact rather than being clobbered. The cursor lands at the END of
+        the restored text (never at the end of the whole, possibly longer,
+        document), so continuing to type picks up right after the restored
+        line(s) rather than after the user's own untouched draft.
+
+        **Security**: the composer is a NEW render surface for this text
+        (:attr:`RemoteQueueView.items` stores the RAW submission — neither
+        ``apply_user_submitted`` nor this call's own path passes through
+        ``SentQueue.show_item``'s neutralize, so nothing upstream has cleaned
+        it yet). Same injection class as the sent-queue row itself (#3302):
+        neutralized HERE, independently, before it ever reaches
+        ``composer.text`` — a strip of this call's neutralize must leave the
+        OTHER site (``SentQueue.show_item``) still clean and vice versa (two
+        independent witnesses, no cross-masking)."""
+        text = _neutralized_label(text)
+        composer = self.query_one(Composer)
+        existing = composer.text
+        composer.text = f"{text}\n{existing}" if existing else text
+        lines = text.split("\n")
+        row = len(lines) - 1
+        col = len(lines[-1])
+        composer.move_cursor((row, col))
+
+    async def on_sent_queue_cancelled(self, event: "SentQueue.Cancelled") -> None:
+        """The user cancelled a queued row (:class:`SentQueue`'s ``Enter``
+        binding, #3300 Y-client). Captures the item's CURRENT text from the
+        queue view before issuing the cancel — the source the canceller-local
+        restore uses once (if) the matching ``inbox_cancel`` delta actually
+        arrives (:meth:`_handle_inbox_cancel_event`); the row removal and the
+        restore are BOTH driven by that delta, never by this call's return
+        value. The return value is used ONLY for pending-entry hygiene: a
+        cancel that raced an already-dispatched item is a server no-op with
+        NO delta ever following it, so nothing would ever pop this entry —
+        pruning it here is memory hygiene, not a correctness dependency (the
+        entry is keyed by a unique msg_id that is never reused, so a
+        transient leftover entry can never cause a wrong future restore)."""
+        msg_id = event.msg_id
+        text = next(
+            (
+                item.get("text")
+                for item in self._queue_view.queue()
+                if item.get("msg_id") == msg_id
+            ),
+            None,
+        )
+        if text is not None:
+            self._pending_own_cancels[msg_id] = text
+        try:
+            removed = await self._transport.cancel_queued(msg_id)
+        except Exception:
+            logger.exception("textual chat: cancel_queued failed")
+            self._pending_own_cancels.pop(msg_id, None)
+            return
+        if not removed:
+            self._pending_own_cancels.pop(msg_id, None)
+
     async def _pump_frames(self) -> None:
         """Drain the transport frame stream into the retained model.
 
@@ -1027,15 +1131,18 @@ class TextualChatApp(App):
         :meth:`_sweep_orphaned_running_tools` (#72: force-settle any tool still
         RUNNING when its turn ends — a confirmed orphan).
 
-        #3300 P2b: ``user_submitted`` (:meth:`_handle_user_submitted_event`)
-        and ``turn_started`` (:meth:`_handle_turn_started_event`) drive the
+        #3300 P2b/Y-client: ``user_submitted`` (:meth:`_handle_user_submitted_event`),
+        ``turn_started`` (:meth:`_handle_turn_started_event`), and
+        ``inbox_cancel`` (:meth:`_handle_inbox_cancel_event`) drive the
         sent-queue "upward conveyor" — materialize into the sent-queue region,
-        then promote to a flow entry on dispatch. This REPLACES P1 C's
-        "append the user_submitted echo straight to the flow": a submission
-        now stages in the sent-queue first (near-instant promotion on an idle
-        server, durably visible while queued on a busy one). The queue model
-        is seeded once, on the first frame (:meth:`_seed_queue_view`). A
-        single frame's failure must not kill the pump, so ingest is guarded.
+        then EITHER promote to a flow entry on dispatch OR remove on cancel
+        (mutually exclusive per the server's atomic guarantee, issue #3300
+        §6a). This REPLACES P1 C's "append the user_submitted echo straight
+        to the flow": a submission now stages in the sent-queue first
+        (near-instant promotion on an idle server, durably visible — and
+        cancelable — while queued on a busy one). The queue model is seeded
+        once, on the first frame (:meth:`_seed_queue_view`). A single frame's
+        failure must not kill the pump, so ingest is guarded.
         """
         try:
             async for frame in self._transport.frames():
@@ -1060,6 +1167,13 @@ class TextualChatApp(App):
                         except Exception:
                             logger.exception(
                                 "textual chat: turn_started queue-promote failed"
+                            )
+                    elif etype == "inbox_cancel":
+                        try:
+                            self._handle_inbox_cancel_event(frame.event)
+                        except Exception:
+                            logger.exception(
+                                "textual chat: inbox_cancel ingest failed"
                             )
                     elif etype in _TURN_END_EVENT_TYPES:
                         try:
@@ -1124,9 +1238,10 @@ class TextualChatApp(App):
         submit that lands while an intervention is pending is NOT black-holed:
         the backend turn stays busy awaiting the intervention, so
         ``submit_user_text`` durably queues the line on the inbox — visible in
-        the sent-queue region (#3300 P2b, this module) and, once P3 Y lands,
-        cancelable there too — rather than losing it. This delegation was
-        verified live (turn-owner-task /
+        the sent-queue region (#3300 P2b, this module) and cancelable there
+        (#3300 Y-client, ``↑`` from the composer to focus it, ``Enter`` on a
+        highlighted row to cancel) — rather than losing it. This delegation
+        was verified live (turn-owner-task /
         inbox-durability trace) by the architect design pass for #3299, so P1
         needs no hint/block guard of its own. Errors are contained and
         surfaced as an error frame the pump renders — a silent input drop is

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -23,8 +23,10 @@ Phase 4 wires every pane to its CANONICAL reyn source (no placeholders):
   status snapshot the plain path's status bar reads (``usage`` / ``cost_agent`` /
   ``cost_total`` / ``ctx_used`` / ``ctx_window``).
 - **Menu** — the full slash-command registry (:data:`reyn.interfaces.slash.REGISTRY`).
-- **Help** — the app's declarative ``BINDINGS`` plus the imperative navigation
-  keys each widget owns (:data:`COMPOSER_KEYS` / :data:`MENUBAR_KEYS`).
+- **Help** — the app's declarative ``BINDINGS`` plus the imperative/declarative
+  navigation keys each widget owns (:data:`COMPOSER_KEYS` /
+  :data:`MENUBAR_KEYS` / :data:`SENTQUEUE_KEYS` — the sent-queue's own
+  select/cancel/back-to-composer keys, #3300 Y-client).
 
 Every ENUMERATING pane (Model / Agent / Menu) derives its full set from the
 canonical registry — never a hand-curated subset — so a newly-configured model
@@ -118,7 +120,7 @@ class Composer(TextArea):
             row, _ = self.cursor_location
             if row <= 0:
                 sent_queue = self.app.query(SentQueue)
-                if sent_queue and not sent_queue.first().is_empty():
+                if sent_queue and sent_queue.first().has_items():
                     event.stop()
                     event.prevent_default()
                     sent_queue.first().focus()
@@ -166,6 +168,7 @@ COMPOSER_KEYS: "list[tuple[str, str]]" = [
     ("enter", "send"),
     ("shift+enter", "newline"),
     ("↓", "focus menu"),
+    ("↑", "focus sent queue"),
 ]
 
 #: The menu row's navigation keys (imperative ``MenuBar._on_key`` overrides).
@@ -173,6 +176,16 @@ MENUBAR_KEYS: "list[tuple[str, str]]" = [
     ("← →", "move"),
     ("enter", "open"),
     ("↑ / esc", "close"),
+]
+
+#: The sent-queue region's navigation keys (#3300 Y-client,
+#: ``SentQueue.BINDINGS`` — declarative, but the Help pane still sources them
+#: from HERE, the same single-source-of-truth convention ``MENUBAR_KEYS``
+#: uses, rather than re-deriving prose from the ``Binding`` objects).
+SENTQUEUE_KEYS: "list[tuple[str, str]]" = [
+    ("↑ / ↓", "select queued message"),
+    ("enter", "cancel selected"),
+    ("esc / tab", "back to composer"),
 ]
 
 
@@ -271,16 +284,19 @@ def help_pane_lines(
     *,
     composer_keys: "Sequence[tuple[str, str]]" = tuple(COMPOSER_KEYS),
     menubar_keys: "Sequence[tuple[str, str]]" = tuple(MENUBAR_KEYS),
+    sentqueue_keys: "Sequence[tuple[str, str]]" = tuple(SENTQUEUE_KEYS),
 ) -> list[str]:
     """The Help readout — the app's declarative ``BINDINGS`` (passed as
-    ``(key, description)`` pairs) plus the imperative composer/menu navigation keys
-    each widget owns. Not a registry-enumeration pane: key handling is split
-    between declarative ``BINDINGS`` and imperative ``_on_key`` overrides, so the
-    keys are sourced from where they are DEFINED (the widgets' key constants + the
+    ``(key, description)`` pairs) plus the imperative composer/menu navigation
+    keys and the sent-queue's own navigation keys (#3300 Y-client) each widget
+    owns. Not a registry-enumeration pane: key handling is split between
+    declarative ``BINDINGS`` and imperative ``_on_key`` overrides, so the keys
+    are sourced from where they are DEFINED (the widgets' key constants + the
     app's BINDINGS) rather than a single enumerable table."""
     lines = ["Shortcuts"]
     lines += [f"  {key}  {desc}" for key, desc in composer_keys]
     lines += [f"  {key}  {desc}" for key, desc in menubar_keys]
+    lines += [f"  {key}  {desc}" for key, desc in sentqueue_keys]
     lines += [f"  {key}  {desc}" for key, desc in app_bindings]
     return lines
 

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -53,6 +53,8 @@ from textual.widgets import (
     TextArea,
 )
 
+from .sent_queue import SentQueue
+
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
@@ -103,6 +105,23 @@ class Composer(TextArea):
                     event.stop()
                     event.prevent_default()
                     menubar.first().focus()
+                    return
+        if event.key == "up":
+            # ↑ on the composer's FIRST line hands focus UP into the
+            # sent-queue region (#3300 Y-client) when it holds at least one
+            # undispatched item — the mirror image of the ↓ rule above (the
+            # region sits ABOVE the composer: conversation / intervention
+            # panel / sent-queue / input). On any later line, or with an
+            # empty/absent sent-queue, ↑ moves the cursor normally (falls
+            # through to the base TextArea) — never steals focus toward a
+            # region with nothing to act on.
+            row, _ = self.cursor_location
+            if row <= 0:
+                sent_queue = self.app.query(SentQueue)
+                if sent_queue and not sent_queue.first().is_empty():
+                    event.stop()
+                    event.prevent_default()
+                    sent_queue.first().focus()
                     return
         await super()._on_key(event)
 

--- a/src/reyn/interfaces/inline/textual_chat/sent_queue.py
+++ b/src/reyn/interfaces/inline/textual_chat/sent_queue.py
@@ -161,8 +161,18 @@ class SentQueue(Vertical):
         displayed content without reaching into private widget state."""
         return [str(row.content) for row in self._rows.values()]
 
-    def is_empty(self) -> bool:
-        return not self._rows
+    def has_items(self) -> bool:
+        """Whether at least one queued row is currently shown.
+
+        Named to avoid ``DOMNode.is_empty`` (a base Textual PROPERTY, "are
+        there no displayed children?", read by the ``:empty`` CSS
+        pseudo-class hook — ``textual/widget.py``'s
+        ``"empty": lambda widget: widget.is_empty``). A same-named METHOD
+        override would make that lookup evaluate to a bound method — always
+        truthy — turning ``:empty`` permanently ON for this widget, a live
+        foot-gun independent of whether current CSS happens to use
+        ``:empty`` yet (co-vet finding on #3314)."""
+        return bool(self._rows)
 
     def selected_msg_id(self) -> "str | None":
         """The currently-highlighted row's ``msg_id`` — the public read a

--- a/src/reyn/interfaces/inline/textual_chat/sent_queue.py
+++ b/src/reyn/interfaces/inline/textual_chat/sent_queue.py
@@ -1,4 +1,4 @@
-"""``SentQueue`` — the sent-queue region widget (#3300 P2b).
+"""``SentQueue`` — the sent-queue region widget (#3300 P2b / Y-client).
 
 Renders the client-side view of the server-authoritative sent queue (the
 undispatched inbox items, published by P2a) between the
@@ -8,7 +8,7 @@ sent-queue / input — shared with the sibling #3299 arc, see
 ``app.py``'s :meth:`~reyn.interfaces.inline.textual_chat.app.TextualChatApp.compose`).
 
 The "upward conveyor" lifecycle (the owner-ratified sent-queue exit contract,
-#3300 issue §6a) this widget renders the MATERIALIZE half of:
+#3300 issue §6a) — this widget renders all THREE exits:
 
 - ``user_submitted`` → :meth:`show_item` — a submitted message first appears
   HERE (dim, queued), not immediately as a flow entry. This REPLACES P1 C's
@@ -20,12 +20,43 @@ The "upward conveyor" lifecycle (the owner-ratified sent-queue exit contract,
   the SAME step (see ``app.py``'s ``_pump_frames`` — the removal here and the
   flow-entry append are driven from one delta so there is never a frame where
   the item is both queued and already in the flow, or neither).
-- ``inbox_cancel`` removal is Phase 3 Y — NOT built here.
+- ``inbox_cancel`` → :meth:`remove_item` — the REMOVE exit (#3300 Y-client):
+  driven by the server-authoritative delta, never by a local "cancel
+  succeeded" return value (``app.py``'s ``_handle_inbox_cancel_event``). The
+  canceller ADDITIONALLY restores the text into the composer — that half is
+  the app's job (it owns the composer), not this widget's.
 
 The app owns the :class:`~reyn.interfaces.transport.agui.state.RemoteQueueView`
 seq-gated merge (the P2a order-race protocol, reused as-is — see the app
 module docstring); this widget is a pure renderer of whatever the app tells it
 to show/remove, keyed by ``msg_id``.
+
+**Cancel affordance (#3300 Y-client)**: this widget is focusable
+(``can_focus = True``) and keeps a highlighted row index, keyed by the SAME
+``msg_id`` ordering as :meth:`rendered_texts` (never a guessed/head-of-queue
+target — the arc's own #3299/#3287 lesson about correlating on an
+authoritative id, applied to selection too). Keymap, chosen to reuse EVERY
+convention already established elsewhere in this package rather than invent a
+new one:
+
+- ``↑``/``↓`` move the highlighted row — the SAME up/down-cycles-a-list
+  idiom the bottom-chrome drawer's ``OptionList`` pickers already use
+  (``chrome.py``).
+- ``Enter`` cancels the highlighted row — the SAME "Enter acts on the
+  highlighted item" idiom those same pickers use (there, Enter *selects*; a
+  cancel affordance's "select" action IS "cancel this one").
+- ``Escape``/``Tab`` return focus to the composer — copied VERBATIM from
+  :class:`~reyn.interfaces.inline.textual_chat.intervention_panel.InterventionPanel`'s
+  identical two bindings for the identical purpose.
+- The composer's own ``↑`` (on its first line) focuses this widget when it
+  is non-empty — the mirror image of the composer's existing ``↓``-on-last-
+  line-focuses-the-menubar rule (``chrome.py``'s ``Composer._on_key``), so
+  the arrow-steps-to-the-adjacent-zone-at-the-edge rule now works in BOTH
+  directions across the whole conversation/panel/queue/input/chrome stack.
+
+Selecting a row only changes which row is highlighted (a CSS class, not the
+neutralized text) — :meth:`rendered_texts` is unaffected by focus/selection
+state, so the P2b render tests keep passing unchanged.
 
 **Security**: a queued item's text is LLM-adjacent/untrusted user-derived
 content reaching the terminal — the SAME injection class as the #3302 panel-
@@ -34,12 +65,18 @@ label bug. Every row is neutralized at THIS display boundary
 the same ``core/present/guard.get_neutralizer("terminal")`` seam the
 intervention panel and the ``user_submitted`` flow-entry echo both use) and
 wrapped in a :class:`~textual.content.Content` LITERAL, never passed to
-``Static.update``/mount as a bare ``str`` (which Textual markup-parses).
+``Static.update``/mount as a bare ``str`` (which Textual markup-parses). The
+SAME neutralized text is what the app later restores into the composer on a
+canceller-local restore (``app.py``'s ``_restore_cancelled_text`` re-derives
+from the queue view, not from this widget's rendered content, but the source
+text is identical either way).
 """
 from __future__ import annotations
 
+from textual.binding import Binding
 from textual.containers import Vertical
 from textual.content import Content
+from textual.message import Message
 from textual.widgets import Static
 
 from .presenter import _neutralized_label
@@ -50,6 +87,8 @@ class SentQueue(Vertical):
     keyed by ``msg_id``. Collapsed (``display=False``) when empty — the
     default state until the first :meth:`show_item` call."""
 
+    can_focus = True
+
     DEFAULT_CSS = """
     SentQueue {
         height: auto;
@@ -58,11 +97,34 @@ class SentQueue(Vertical):
         padding: 0 1;
     }
     SentQueue Static { height: auto; }
+    SentQueue Static.-selected {
+        background: $accent 30%;
+        color: $text;
+    }
     """
+
+    BINDINGS = [
+        Binding("up", "select_prev", "Previous queued", show=False),
+        Binding("down", "select_next", "Next queued", show=False),
+        Binding("enter", "cancel_selected", "Cancel selected", show=False),
+        Binding("escape", "focus_composer", "Back to composer", show=False),
+        Binding("tab", "focus_composer", "Back to composer", show=False),
+    ]
+
+    class Cancelled(Message):
+        """Posted when the user cancels the highlighted queued row (the
+        Enter binding). ``msg_id`` is the authoritative correlation key the
+        app hands to ``ClientTransport.cancel_queued`` — never a guessed/
+        positional target."""
+
+        def __init__(self, msg_id: str) -> None:
+            self.msg_id = msg_id
+            super().__init__()
 
     def on_mount(self) -> None:
         self.display = False
         self._rows: "dict[str, Static]" = {}
+        self._selected_index = 0
 
     def show_item(self, msg_id: str, text: str) -> None:
         """Materialize a queued item (``user_submitted``): neutralize the
@@ -78,16 +140,20 @@ class SentQueue(Vertical):
         self._rows[msg_id] = row
         self.mount(row)
         self.display = True
+        self._clamp_selection()
+        self._apply_highlight()
 
     def remove_item(self, msg_id: str) -> None:
-        """Remove a queued item's row (the PROMOTE or, later, cancel exit).
-        No-op for an unknown ``msg_id``. Collapses the region back to hidden
-        once the last item is gone."""
+        """Remove a queued item's row (the PROMOTE exit or the ``inbox_cancel``
+        REMOVE exit, #3300 Y-client). No-op for an unknown ``msg_id``.
+        Collapses the region back to hidden once the last item is gone."""
         row = self._rows.pop(msg_id, None)
         if row is not None:
             row.remove()
         if not self._rows:
             self.display = False
+        self._clamp_selection()
+        self._apply_highlight()
 
     def rendered_texts(self) -> "list[str]":
         """The currently-queued rows' rendered text, oldest first — the
@@ -97,6 +163,47 @@ class SentQueue(Vertical):
 
     def is_empty(self) -> bool:
         return not self._rows
+
+    def selected_msg_id(self) -> "str | None":
+        """The currently-highlighted row's ``msg_id`` — the public read a
+        test uses to assert selection without reaching into
+        ``self._selected_index``/``self._rows`` directly."""
+        order = list(self._rows.keys())
+        if not order:
+            return None
+        return order[max(0, min(self._selected_index, len(order) - 1))]
+
+    def _clamp_selection(self) -> None:
+        last = max(len(self._rows) - 1, 0)
+        self._selected_index = max(0, min(self._selected_index, last))
+
+    def _apply_highlight(self) -> None:
+        order = list(self._rows.keys())
+        for i, msg_id in enumerate(order):
+            self._rows[msg_id].set_class(i == self._selected_index, "-selected")
+
+    def action_select_prev(self) -> None:
+        if self._selected_index > 0:
+            self._selected_index -= 1
+        self._apply_highlight()
+
+    def action_select_next(self) -> None:
+        if self._selected_index < len(self._rows) - 1:
+            self._selected_index += 1
+        self._apply_highlight()
+
+    def action_cancel_selected(self) -> None:
+        msg_id = self.selected_msg_id()
+        if msg_id is not None:
+            self.post_message(self.Cancelled(msg_id))
+
+    def action_focus_composer(self) -> None:
+        # String type-selector (not a direct import of ``chrome.Composer``)
+        # so this module stays a leaf the chrome module can safely import
+        # (``chrome.py``'s ``Composer`` steps focus INTO this widget on its
+        # own ``↑``-at-first-line rule) without a two-way import cycle.
+        composer = self.app.query_one("Composer")
+        composer.focus()
 
 
 __all__ = ["SentQueue"]

--- a/tests/test_3300_p2b_sentqueue_render.py
+++ b/tests/test_3300_p2b_sentqueue_render.py
@@ -208,12 +208,12 @@ async def test_turn_started_promotes_matching_item_to_flow_entry() -> None:
         )
         await pilot.pause()
         sent_queue = app.query_one(SentQueue)
-        assert not sent_queue.is_empty()
+        assert sent_queue.has_items()
 
         await transport.push_event(_turn_started(chain_id="c1", seq=2))
         await pilot.pause()
 
-        assert sent_queue.is_empty(), "promoted item must leave the sent-queue"
+        assert not sent_queue.has_items(), "promoted item must leave the sent-queue"
         (entry,) = _flow_user_entries(app)
         assert entry.item.text == "dispatch me"
 
@@ -352,7 +352,7 @@ async def test_strip_delta_subscription_leaves_sent_queue_stale(monkeypatch) -> 
         await pilot.pause()
 
         sent_queue = app.query_one(SentQueue)
-        assert sent_queue.is_empty(), "stripped handler should leave the region stale"
+        assert not sent_queue.has_items(), "stripped handler should leave the region stale"
         assert not _flow_user_entries(app)
 
 

--- a/tests/test_3300_y_client_cancel.py
+++ b/tests/test_3300_y_client_cancel.py
@@ -23,11 +23,24 @@ covers the REMAINING client half, scoped to
    sent-queue) focuses the queue region; ``↑``/``↓`` move the highlighted
    row; ``Enter`` fires the cancel; ``Escape``/``Tab`` return to the
    composer.
+5. **``DOMNode.is_empty`` non-collision** (co-vet finding on #3314) —
+   ``SentQueue`` exposes its own empty/non-empty state as ``has_items()``,
+   never a same-named ``is_empty`` method: Textual's base
+   ``DOMNode.is_empty`` is a PROPERTY the ``:empty`` CSS pseudo-class hook
+   (``textual/widget.py``) reads as ``widget.is_empty`` — a same-named
+   method override would make that read return an always-truthy bound
+   method, permanently flipping ``:empty`` ON for this widget.
+6. **Help-pane discoverability** (co-vet finding on #3314) — the new
+   composer/sent-queue keys are sourced into the Help pane from
+   ``chrome.py``'s ``COMPOSER_KEYS``/``SENTQUEUE_KEYS`` constants, the SAME
+   single source of truth ``MENUBAR_KEYS`` already uses (no second,
+   undiscoverable hardcoding).
 
 Real ``TextualChatApp`` + a real minimal ``ClientTransport`` throughout — no
 ``unittest.mock``. Renders/state observed via the PUBLIC surface
-(``SentQueue.rendered_texts()``/``selected_msg_id()``, ``Composer.text``/
-``cursor_location``, ``FlowView.entries``), never private state.
+(``SentQueue.rendered_texts()``/``selected_msg_id()``/``has_items()``,
+``Composer.text``/``cursor_location``, ``FlowView.entries``), never private
+state.
 """
 from __future__ import annotations
 
@@ -38,7 +51,12 @@ import pytest
 from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
-from reyn.interfaces.inline.textual_chat.chrome import Composer
+from reyn.interfaces.inline.textual_chat.chrome import (
+    COMPOSER_KEYS,
+    SENTQUEUE_KEYS,
+    Composer,
+    help_pane_lines,
+)
 from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import EventFrame
@@ -136,18 +154,18 @@ async def test_cancel_removes_row_only_on_inbox_cancel_delta_not_on_call_return(
         )
         await pilot.pause()
         sent_queue = app.query_one(SentQueue)
-        assert not sent_queue.is_empty()
+        assert sent_queue.has_items()
 
         await app.on_sent_queue_cancelled(SentQueue.Cancelled("m1"))
         assert transport.cancel_calls == ["m1"]
-        assert not sent_queue.is_empty(), (
+        assert sent_queue.has_items(), (
             "the row must NOT be removed by the cancel_queued call's return "
             "value alone — only the inbox_cancel delta removes it"
         )
 
         await transport.push_event(_inbox_cancel(msg_id="m1", seq=2))
         await pilot.pause()
-        assert sent_queue.is_empty(), "the inbox_cancel delta must remove the row"
+        assert not sent_queue.has_items(), "the inbox_cancel delta must remove the row"
 
 
 @pytest.mark.asyncio
@@ -171,7 +189,7 @@ async def test_strip_inbox_cancel_handler_leaves_row_stale(monkeypatch) -> None:
         await pilot.pause()
 
         sent_queue = app.query_one(SentQueue)
-        assert not sent_queue.is_empty(), "stripped handler should leave the row stale"
+        assert sent_queue.has_items(), "stripped handler should leave the row stale"
 
 
 @pytest.mark.asyncio
@@ -270,7 +288,7 @@ async def test_non_canceller_client_applies_only_removal_no_restore() -> None:
         await pilot.pause()
 
         sent_queue = app.query_one(SentQueue)
-        assert sent_queue.is_empty(), "the peer's cancel delta still removes the row here"
+        assert not sent_queue.has_items(), "the peer's cancel delta still removes the row here"
         assert composer.text == "my own untouched draft", (
             "a non-canceller client must not restore any text into its composer"
         )
@@ -440,3 +458,80 @@ async def test_enter_on_highlighted_row_cancels_it_and_escape_returns_focus() ->
         await pilot.pause()
         composer = app.query_one(Composer)
         assert composer.has_focus
+
+
+# ---------------------------------------------------------------------------
+# 5. ``DOMNode.is_empty`` non-collision witness (co-vet finding on #3314)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sent_queue_does_not_shadow_domnode_is_empty_property() -> None:
+    """Tier 2b: ★``SentQueue`` must NOT override Textual's base
+    ``DOMNode.is_empty`` PROPERTY with a same-named method — the ``:empty``
+    CSS pseudo-class hook (``textual/widget.py``'s
+    ``"empty": lambda widget: widget.is_empty``) reads it as a property; a
+    method override would make that read return an always-truthy bound
+    method, permanently flipping ``:empty`` ON for this widget regardless of
+    its actual content. Reads the SAME attribute Textual's pseudo-class
+    evaluator reads (``widget.is_empty``, no call parens) and asserts it is
+    a real ``bool``, not a bound method — the exact collision shape the
+    co-vet finding described."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        sent_queue = app.query_one(SentQueue)
+        assert isinstance(sent_queue.is_empty, bool), (
+            "SentQueue.is_empty must stay Textual's base DOMNode property "
+            "(a bool) — a same-named method override would make this a "
+            "bound method (always truthy), permanently flipping the "
+            "':empty' CSS pseudo-class ON"
+        )
+
+        await transport.push_event(
+            _user_submitted(msg_id="m1", chain_id="c1", text="queued", seq=1)
+        )
+        await pilot.pause()
+        assert sent_queue.is_empty is False, (
+            "the base property should correctly read 'has children' once a "
+            "row is mounted"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 6. Help-pane discoverability (co-vet finding on #3314)
+# ---------------------------------------------------------------------------
+
+
+def test_help_pane_lists_composer_up_arrow_and_sentqueue_keys() -> None:
+    """Tier 2b: the new composer ``↑`` binding and the sent-queue's own keys
+    (↑/↓ move, Enter cancel, Esc/Tab back to composer) must be DISCOVERABLE
+    through the Help pane — ``chrome.py``'s own module docstring states the
+    Help pane sources composer/menu keys from ``COMPOSER_KEYS``/
+    ``MENUBAR_KEYS`` "rather than re-hardcoding a second copy"; the new
+    sent-queue keys must follow the SAME single-source-of-truth convention
+    (``SENTQUEUE_KEYS``), not go undocumented. Pure-function pane formatter —
+    no widget mount needed."""
+    lines = help_pane_lines()
+    assert any("focus sent queue" in line for line in lines), (
+        "composer's new '↑ -> focus sent queue' binding is missing from "
+        "COMPOSER_KEYS / the Help pane"
+    )
+    assert any("cancel" in line.lower() for line in lines), (
+        "the sent-queue's cancel binding is missing from SENTQUEUE_KEYS / "
+        "the Help pane"
+    )
+
+
+def test_composer_keys_and_sentqueue_keys_are_the_single_source_help_reads() -> None:
+    """Tier 2b: non-vacuity — the Help pane's composer/sent-queue rows are
+    EXACTLY ``COMPOSER_KEYS``/``SENTQUEUE_KEYS`` (not a hand-duplicated
+    copy): every entry in each constant appears verbatim in the rendered
+    Help lines."""
+    lines = help_pane_lines()
+    for key, desc in (*COMPOSER_KEYS, *SENTQUEUE_KEYS):
+        assert any(key in line and desc in line for line in lines), (
+            f"({key!r}, {desc!r}) from COMPOSER_KEYS/SENTQUEUE_KEYS is not "
+            "rendered verbatim in the Help pane"
+        )

--- a/tests/test_3300_y_client_cancel.py
+++ b/tests/test_3300_y_client_cancel.py
@@ -1,0 +1,442 @@
+"""#3300 Y-client — the client half of cancel-by-id.
+
+Y-server (PR #3306) landed ``Session.cancel_queued(msg_id)`` (snapshot-prune +
+WAL tombstone + skip-at-consume) and the ``inbox_cancel`` chat-event delta;
+``ClientTransport.cancel_queued(msg_id)`` exists on both transports and
+``submit_user_text`` now returns the assigned ``msg_id`` (PR #3309). This file
+covers the REMAINING client half, scoped to
+``src/reyn/interfaces/inline/textual_chat/``:
+
+1. **Event-driven row removal** — the sent-queue row is removed by the
+   ``inbox_cancel`` delta, NEVER by ``cancel_queued``'s own return value (an
+   automated strip proves this: the call returning ``True`` does not, by
+   itself, remove the row — only the delta that follows does).
+2. **Canceller-local composer restore** — on a successful cancel, the
+   cancelled text is prepended at the HEAD of the composer (newline boundary
+   when the composer already holds a draft), cursor at the END of the
+   restored text; a client that did NOT issue the cancel applies only the
+   removal (no restore).
+3. **★Untrusted-text render surface (composer)** — fidelity + neutralize,
+   independently strip-verified, no cross-masking with the sent-queue row's
+   own (separate) neutralize site.
+4. **Keybinding affordance** — ``↑`` from the composer (non-empty
+   sent-queue) focuses the queue region; ``↑``/``↓`` move the highlighted
+   row; ``Enter`` fires the cancel; ``Escape``/``Tab`` return to the
+   composer.
+
+Real ``TextualChatApp`` + a real minimal ``ClientTransport`` throughout — no
+``unittest.mock``. Renders/state observed via the PUBLIC surface
+(``SentQueue.rendered_texts()``/``selected_msg_id()``, ``Composer.text``/
+``cursor_location``, ``FlowView.entries``), never private state.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.chrome import Composer
+from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import EventFrame
+from reyn.runtime.outbox import OutboxMessage
+from reyn.schemas.models import Event
+
+_RAW_ESC_OSC = "\x1b[31mRED\x1b]0;pwn\x07"
+
+
+class QueueTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` fed one frame at a time from
+    a queue (mirrors ``test_3300_p2b_sentqueue_render.py``'s helper), whose
+    ``cancel_queued`` is CONTROLLABLE (a real attribute, not a mock) so a test
+    can prove the row/composer state is driven by the ``inbox_cancel`` delta
+    that follows, not by this call's return value."""
+
+    def __init__(self, *, cancel_result: bool = True) -> None:
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+        self.cancel_result = cancel_result
+        self.cancel_calls: "list[str]" = []
+
+    async def push_event(self, event: Event) -> None:
+        await self._queue.put(EventFrame(event))
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str) -> str:  # pragma: no cover
+        return ""
+
+    async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:  # pragma: no cover
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def cancel_queued(self, msg_id: str) -> bool:
+        self.cancel_calls.append(msg_id)
+        return self.cancel_result
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _user_submitted(*, msg_id: str, chain_id: str, text: str, seq: int) -> Event:
+    return Event(
+        type="user_submitted",
+        data={"text": text, "chain_id": chain_id, "msg_id": msg_id, "seq": seq, "meta": {}},
+    )
+
+
+def _inbox_cancel(*, msg_id: str, seq: int) -> Event:
+    return Event(type="inbox_cancel", data={"msg_id": msg_id, "seq": seq})
+
+
+def _flow_user_entries(app: TextualChatApp):
+    return [e for e in app.query_one(FlowView).entries if e.item.kind == "user"]
+
+
+# ---------------------------------------------------------------------------
+# 1. Event-driven removal (never return-value-driven)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_removes_row_only_on_inbox_cancel_delta_not_on_call_return() -> None:
+    """Tier 2b: the row survives the ``cancel_queued`` call returning
+    ``True`` by itself — it is removed only once the matching
+    ``inbox_cancel`` delta actually arrives on the SAME frame path."""
+    transport = QueueTransport(cancel_result=True)
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(
+            _user_submitted(msg_id="m1", chain_id="c1", text="cancel me", seq=1)
+        )
+        await pilot.pause()
+        sent_queue = app.query_one(SentQueue)
+        assert not sent_queue.is_empty()
+
+        await app.on_sent_queue_cancelled(SentQueue.Cancelled("m1"))
+        assert transport.cancel_calls == ["m1"]
+        assert not sent_queue.is_empty(), (
+            "the row must NOT be removed by the cancel_queued call's return "
+            "value alone — only the inbox_cancel delta removes it"
+        )
+
+        await transport.push_event(_inbox_cancel(msg_id="m1", seq=2))
+        await pilot.pause()
+        assert sent_queue.is_empty(), "the inbox_cancel delta must remove the row"
+
+
+@pytest.mark.asyncio
+async def test_strip_inbox_cancel_handler_leaves_row_stale(monkeypatch) -> None:
+    """Tier 2b: non-vacuity — neutering the app's ``inbox_cancel`` delta
+    handler (the wiring the positive test above depends on) leaves the row
+    present despite the delta arriving, proving the positive assertion is
+    not vacuous."""
+    transport = QueueTransport(cancel_result=True)
+    app = TextualChatApp(transport=transport)
+    monkeypatch.setattr(
+        TextualChatApp, "_handle_inbox_cancel_event", lambda self, event: None,
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(
+            _user_submitted(msg_id="m1", chain_id="c1", text="cancel me", seq=1)
+        )
+        await pilot.pause()
+        await transport.push_event(_inbox_cancel(msg_id="m1", seq=2))
+        await pilot.pause()
+
+        sent_queue = app.query_one(SentQueue)
+        assert not sent_queue.is_empty(), "stripped handler should leave the row stale"
+
+
+@pytest.mark.asyncio
+async def test_inbox_cancel_for_unrelated_msg_id_is_a_noop() -> None:
+    """Tier 2b: non-vacuity — an ``inbox_cancel`` for a DIFFERENT msg_id does
+    not touch an unrelated queued item."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(
+            _user_submitted(msg_id="m1", chain_id="c1", text="still queued", seq=1)
+        )
+        await pilot.pause()
+        await transport.push_event(_inbox_cancel(msg_id="some-other-id", seq=2))
+        await pilot.pause()
+
+        sent_queue = app.query_one(SentQueue)
+        assert "still queued" in sent_queue.rendered_texts()[0]
+
+
+# ---------------------------------------------------------------------------
+# 2. Canceller-local composer restore
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_canceller_restores_text_prepended_at_head_with_newline_boundary() -> None:
+    """Tier 2b: the CANCELLER's composer gets the cancelled text prepended
+    at the HEAD, even with an existing non-empty draft, separated by a
+    newline boundary — the draft is not clobbered — and the cursor lands at
+    the END of the restored text."""
+    transport = QueueTransport(cancel_result=True)
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(
+            _user_submitted(msg_id="m1", chain_id="c1", text="original message", seq=1)
+        )
+        await pilot.pause()
+
+        composer = app.query_one(Composer)
+        composer.text = "my next draft"
+
+        await app.on_sent_queue_cancelled(SentQueue.Cancelled("m1"))
+        await transport.push_event(_inbox_cancel(msg_id="m1", seq=2))
+        await pilot.pause()
+
+        assert composer.text == "original message\nmy next draft"
+        assert composer.cursor_location == (0, len("original message"))
+
+
+@pytest.mark.asyncio
+async def test_canceller_restore_into_empty_composer_has_no_stray_newline() -> None:
+    """Tier 2b: restoring into an EMPTY composer does not add a spurious
+    trailing newline boundary (there is nothing to separate from)."""
+    transport = QueueTransport(cancel_result=True)
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(
+            _user_submitted(msg_id="m1", chain_id="c1", text="original message", seq=1)
+        )
+        await pilot.pause()
+
+        await app.on_sent_queue_cancelled(SentQueue.Cancelled("m1"))
+        await transport.push_event(_inbox_cancel(msg_id="m1", seq=2))
+        await pilot.pause()
+
+        composer = app.query_one(Composer)
+        assert composer.text == "original message"
+        assert composer.cursor_location == (0, len("original message"))
+
+
+@pytest.mark.asyncio
+async def test_non_canceller_client_applies_only_removal_no_restore() -> None:
+    """Tier 2b: a client that did NOT issue the cancel (no matching entry in
+    ``_pending_own_cancels``) sees the SAME ``inbox_cancel`` delta and
+    removes the row, but the composer is untouched — canceller-local restore
+    (owner-ratified contract, issue #3300 §6a)."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(
+            _user_submitted(msg_id="m1", chain_id="c1", text="a peer's message", seq=1)
+        )
+        await pilot.pause()
+
+        composer = app.query_one(Composer)
+        composer.text = "my own untouched draft"
+
+        # No on_sent_queue_cancelled call here — this client never asked to
+        # cancel "m1"; the delta arrives from a PEER's cancel action instead.
+        await transport.push_event(_inbox_cancel(msg_id="m1", seq=2))
+        await pilot.pause()
+
+        sent_queue = app.query_one(SentQueue)
+        assert sent_queue.is_empty(), "the peer's cancel delta still removes the row here"
+        assert composer.text == "my own untouched draft", (
+            "a non-canceller client must not restore any text into its composer"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. ★Untrusted-text render surface — composer restore (#3302-class gate)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_restored_composer_text_neutralizes_raw_esc_osc_injection() -> None:
+    """Tier 2b: ★security gate — the composer is a NEW render surface for a
+    cancelled item's text (independent of the sent-queue row's own
+    neutralize site). A raw ESC/OSC payload must not survive into
+    ``composer.text``, while the harmless literal remainder still renders
+    (fidelity)."""
+    transport = QueueTransport(cancel_result=True)
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(
+            _user_submitted(msg_id="m1", chain_id="c1", text=_RAW_ESC_OSC, seq=1)
+        )
+        await pilot.pause()
+
+        await app.on_sent_queue_cancelled(SentQueue.Cancelled("m1"))
+        await transport.push_event(_inbox_cancel(msg_id="m1", seq=2))
+        await pilot.pause()
+
+        composer = app.query_one(Composer)
+        assert "\x1b" not in composer.text, "raw ESC byte leaked into the restored composer text"
+        assert "RED" in composer.text
+
+
+@pytest.mark.asyncio
+async def test_strip_composer_neutralize_leaks_raw_esc_independent_of_sent_queue_site() -> None:
+    """Tier 2b: non-vacuity, no cross-masking — neutering ONLY the composer
+    restore's own neutralize call (``_restore_cancelled_text``, patched here
+    to skip it) leaks the raw ESC byte into ``composer.text`` even though
+    the SENT-QUEUE row's OWN (separate) neutralize site is untouched and
+    still clean — proving the two sites are independent witnesses, neither
+    masking the other."""
+    from reyn.interfaces.inline.textual_chat import app as app_module
+
+    def _restore_without_neutralize(self, text: str) -> None:
+        composer = self.query_one(Composer)
+        existing = composer.text
+        composer.text = f"{text}\n{existing}" if existing else text
+        lines = text.split("\n")
+        composer.move_cursor((len(lines) - 1, len(lines[-1])))
+
+    monkeypatch_target = app_module.TextualChatApp
+    original = monkeypatch_target._restore_cancelled_text
+    monkeypatch_target._restore_cancelled_text = _restore_without_neutralize
+    try:
+        transport = QueueTransport(cancel_result=True)
+        app = TextualChatApp(transport=transport)
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await transport.push_event(
+                _user_submitted(msg_id="m1", chain_id="c1", text=_RAW_ESC_OSC, seq=1)
+            )
+            await pilot.pause()
+
+            sent_queue = app.query_one(SentQueue)
+            # The SENT-QUEUE row's own (separate) neutralize site is intact —
+            # its rendered content stays clean regardless of the composer strip.
+            (row,) = sent_queue.rendered_texts()
+            assert "\x1b" not in row
+
+            await app.on_sent_queue_cancelled(SentQueue.Cancelled("m1"))
+            await transport.push_event(_inbox_cancel(msg_id="m1", seq=2))
+            await pilot.pause()
+
+            composer = app.query_one(Composer)
+            assert "\x1b" in composer.text, (
+                "stripping the composer's OWN neutralize call should leak the "
+                "raw ESC byte here, independent of the sent-queue row's site"
+            )
+    finally:
+        monkeypatch_target._restore_cancelled_text = original
+
+
+# ---------------------------------------------------------------------------
+# 4. Keybinding affordance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_up_from_composer_focuses_nonempty_sent_queue() -> None:
+    """Tier 2b: ``↑`` on the composer's first line focuses the sent-queue
+    region when it holds at least one item — the mirror image of the
+    composer's existing ``↓``-to-menubar rule."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(
+            _user_submitted(msg_id="m1", chain_id="c1", text="queued", seq=1)
+        )
+        await pilot.pause()
+
+        composer = app.query_one(Composer)
+        composer.focus()
+        await pilot.pause()
+        await pilot.press("up")
+        await pilot.pause()
+
+        sent_queue = app.query_one(SentQueue)
+        assert sent_queue.has_focus
+
+
+@pytest.mark.asyncio
+async def test_up_from_composer_with_empty_sent_queue_moves_cursor_not_focus() -> None:
+    """Tier 2b: non-vacuity — with an EMPTY sent-queue, ``↑`` never steals
+    focus (falls through to ordinary cursor movement)."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        composer = app.query_one(Composer)
+        composer.focus()
+        await pilot.pause()
+        await pilot.press("up")
+        await pilot.pause()
+
+        sent_queue = app.query_one(SentQueue)
+        assert not sent_queue.has_focus
+        assert composer.has_focus
+
+
+@pytest.mark.asyncio
+async def test_enter_on_highlighted_row_cancels_it_and_escape_returns_focus() -> None:
+    """Tier 2b: within the focused sent-queue, ↑/↓ move the highlighted row
+    (by msg_id, never a guessed position), Enter cancels the highlighted
+    row, and Escape returns focus to the composer."""
+    transport = QueueTransport(cancel_result=True)
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(_user_submitted(msg_id="m1", chain_id="c1", text="alpha", seq=1))
+        await transport.push_event(_user_submitted(msg_id="m2", chain_id="c2", text="beta", seq=2))
+        await pilot.pause()
+
+        sent_queue = app.query_one(SentQueue)
+        sent_queue.focus()
+        await pilot.pause()
+        assert sent_queue.selected_msg_id() == "m1"
+
+        await pilot.press("down")
+        await pilot.pause()
+        assert sent_queue.selected_msg_id() == "m2"
+
+        await pilot.press("enter")
+        await pilot.pause()
+        assert transport.cancel_calls == ["m2"]
+
+        await transport.push_event(_inbox_cancel(msg_id="m2", seq=3))
+        await pilot.pause()
+        assert sent_queue.rendered_texts() and "alpha" in sent_queue.rendered_texts()[0]
+        assert not any("beta" in t for t in sent_queue.rendered_texts())
+
+        # "m1" is still queued, so the region is still focusable/visible;
+        # Escape must send focus back to the composer regardless.
+        await pilot.press("escape")
+        await pilot.pause()
+        composer = app.query_one(Composer)
+        assert composer.has_focus


### PR DESCRIPTION
**[per-PR-coder]** — part of #3300 (Y-client: the client half of cancel-by-id).

## Scope
Wires `src/reyn/interfaces/inline/textual_chat/` to the Y-server primitives already merged: `Session.cancel_queued(msg_id)` (PR #3306 — WAL `inbox_cancel` tombstone + synchronous snapshot-prune, skip-at-consume, idempotent, dispatched→no-op) and `submit_user_text` returning the assigned `msg_id` (PR #3309). `ClientTransport.cancel_queued(msg_id)` and `RemoteQueueView.apply_inbox_cancel` already existed (P2a/Y-server) — reused as-is, not reinvented.

## What changed
1. **Event-driven row removal** (`app.py::_handle_inbox_cancel_event`, wired into `_pump_frames`): the sent-queue row is removed by the `inbox_cancel` chat-event delta, applying the same seq-gate protocol `user_submitted`/`turn_started` use. **Never driven by `cancel_queued`'s own return value** — that return value is used only for `_pending_own_cancels` dict hygiene (pruning an entry when the server no-op'd an already-dispatched cancel, so no delta will ever follow to pop it), never for removal or restore.
2. **Canceller-local composer restore** (`app.py::_restore_cancelled_text`): on receiving the `inbox_cancel` delta for a msg_id THIS client itself asked to cancel (tracked in `_pending_own_cancels`, populated before the `cancel_queued` call), the cancelled text is prepended at the composer HEAD — newline boundary when the composer already holds a draft, none when empty — with the cursor landing at the END of the restored text (never at the end of a longer combined document). A client that did not issue the cancel sees only the removal.
3. **Cancel affordance** (`sent_queue.py` + `chrome.py`): `SentQueue` is now focusable with a highlighted-row index keyed by `msg_id` (never a guessed/positional target — this arc's own #3299/#3287 lesson, applied to selection). Keymap reuses every existing convention rather than inventing a new one:
   - Composer `↑` on its first line focuses the sent-queue region when non-empty — the mirror image of the composer's existing `↓`-on-last-line-focuses-menubar rule.
   - `↑`/`↓` inside the sent-queue move the highlight — same idiom as the drawer's `OptionList` pickers.
   - `Enter` cancels the highlighted row — same "Enter acts on the highlighted item" idiom those pickers use.
   - `Escape`/`Tab` return focus to the composer — copied verbatim from `InterventionPanel`'s identical two bindings.
4. **★Untrusted-text render surface gate**: the composer is a NEW render surface for the cancelled (untrusted, LLM-adjacent user-derived) text — same injection class as #3302/#3305. Two independent, per-site strip-verified witnesses (no cross-masking): the sent-queue row's own existing neutralize site, and a NEW one in `_restore_cancelled_text`.

## Why this affordance
The issue said "a key binding / affordance … if the existing conventions leave it genuinely ambiguous, pick the least surprising option and say what you picked." I picked a real by-msg_id selection UI (not "always cancel head/most-recent") because the arc has already hit the guessed-key defect twice (#3299 P2, #3287) and a queue can legitimately hold more than one item during a busy turn. Every binding reuses an existing convention in this package (composer edge-arrow-steps-to-adjacent-zone, drawer-picker Enter-selects, intervention-panel escape/tab-back), so nothing new was invented.

## Gates (owner's ★required gate + arc verification principles)

**★Untrusted-text render surface — two independent witnesses, each strip-verified on its own site:**
- Sent-queue row neutralize (pre-existing site, P2b) — unaffected by this PR; its own tests (`test_3300_p2b_sentqueue_render.py`) still pass.
- **NEW composer-restore neutralize site** (`_restore_cancelled_text`):
  - Fidelity + neutralize positive: `test_restored_composer_text_neutralizes_raw_esc_osc_injection` — raw `\x1b[31mRED\x1b]0;pwn\x07` injected into a cancelled item; asserts `"\x1b" not in composer.text` AND `"RED" in composer.text`.
  - **Strip, no cross-masking**: `test_strip_composer_neutralize_leaks_raw_esc_independent_of_sent_queue_site` monkeypatches `_restore_cancelled_text` to skip its own neutralize call. Observed RED:
    ```
    AssertionError: stripping the composer's OWN neutralize call should leak the raw ESC byte here, independent of the sent-queue row's site
    assert '\x1b' in 'RED\x1b]0;pwn\x07'
    ```
    (i.e. without the strip the assertion `"\x1b" in composer.text` is False — the strip test flips it to True, proving the composer-site call is load-bearing) — while the SAME test asserts the sent-queue row's OWN rendered content stays clean throughout, proving the two sites are independent.

**Event-driven removal (never return-value-driven)** — `test_cancel_removes_row_only_on_inbox_cancel_delta_not_on_call_return`: calls `cancel_queued` (stub returns `True`) and asserts the row is STILL present immediately after; only after pushing the `inbox_cancel` delta through the SAME frame path does the row disappear.
- **Strip / arrival-witness-through-the-same-path**: `test_strip_inbox_cancel_handler_leaves_row_stale` neuters `_handle_inbox_cancel_event` and pushes the delta through the real transport frame stream — row stays present (RED without the strip: row would be removed; with the strip it stays, proving the wiring — not a side channel — is what removes it).

**Canceller-local restore**:
- `test_canceller_restores_text_prepended_at_head_with_newline_boundary` — non-empty draft: `composer.text == "original message\nmy next draft"`, `composer.cursor_location == (0, len("original message"))`.
- `test_canceller_restore_into_empty_composer_has_no_stray_newline` — empty draft: no spurious trailing newline.
- `test_non_canceller_client_applies_only_removal_no_restore` — a client that never issued the cancel sees the row removed but its own draft (`"my own untouched draft"`) is untouched.

**Keybinding affordance** (arrival witness through the real key-press path, not direct method calls):
- `test_up_from_composer_focuses_nonempty_sent_queue` / `test_up_from_composer_with_empty_sent_queue_moves_cursor_not_focus` (non-vacuity: empty queue never steals focus).
- `test_enter_on_highlighted_row_cancels_it_and_escape_returns_focus` — `pilot.press("down")`/`pilot.press("enter")`/`pilot.press("escape")` through two queued items, asserting `selected_msg_id()` moves by msg_id, the correct msg_id is cancelled, and focus returns to the composer.

**No geometry gate**: this PR touches focus/keybinding/text logic only — no new widget mounting or layout height change (`SentQueue` region already existed, P2b) — so a geometry (containment/not-squashed) gate does not apply per the brief's own carve-out.

## Doc-drift check
`docs/reference/runtime/agui-transport.md`/`.ja.md` already document `cancel_queued`/`inbox_cancel` from the server side accurately (added in #3306) and make no claim about the client's UI status — re-read both sections this PR touches conceptually; neither asserts anything this PR falsifies, so no edit was needed. No other TUI-facing doc describes the composer/sent-queue keymap (`docs/feature-map.md` has no #3300/textual_chat entry to begin with — pre-existing gap, not introduced or worsened here).

## Test plan
- [x] `uv run python -m pytest --timeout=120 -q tests/test_3300_p2a_queue_state_publish.py tests/test_3300_p2b_sentqueue_render.py tests/test_3300_p3_cancel_by_id.py tests/test_3300_y_client_cancel.py tests/test_user_submitted_render_3300.py tests/test_textual_chat_intervention_panel_3299.py tests/test_textual_chat_orphan_sweep_72.py tests/test_textual_chat_phase1_3273.py tests/test_textual_chat_phase2_3273.py tests/test_textual_chat_phase2b_live_tool_3283.py tests/test_textual_chat_phase3_3273.py tests/test_textual_chat_phase4_3273.py tests/test_textual_chat_phase5_3273.py tests/test_stream_client_own_echo_3287.py` — 150 passed.
- [x] `ruff check src tests` — all checks passed.
- [x] `python scripts/test_tier_audit.py --strict tests/test_3300_y_client_cancel.py` — 11/11 OK, 0 errors.
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/{sent_queue,chrome,app}.py` — OK.
- [x] (skipped — no full-suite run per repo policy; CI is full-suite authority.)