### PR TITLE
feat(tui): coalesce streaming agent_delta chat-events into one flow entry — #3288 ③c

### DIFF
--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -284,6 +284,19 @@ Config-gated `litellm.Router` slot-in for provider-resilience. Default OFF (`llm
 
 > **Differentiation vs general agents:** provider-resilience is delegated entirely to litellm.Router (Retry-After, jitter, cooldown, cross-model fallback chain, credential rotation) rather than re-implemented — the on/off gate keeps the direct path byte-identical, so replay and cost-recording work unchanged whether or not the Router is active.
 
+#### LLM token streaming
+
+Capability-gated, provider-agnostic token streaming from the LLM call through to the rendered reply (#3288, phases ③a–③d). Streaming is a rendering optimization only — history/persistence and the final reconstructed result are byte-identical to the non-streaming path (stream ≡ whole equivalence).
+
+| Feature | Description | Documentation |
+|---------|-------------|---------------|
+| Capability-gated streaming loop | `recorded_acompletion` streams only when the resolved provider/model declares streaming capability (a `litellm` inline capability query, never a hardcoded per-provider allow/deny list); usage is chunk-summed and emitted once through the existing single-chokepoint `record_llm`, never per-chunk | [AG-UI transport](reference/runtime/agui-transport.md) |
+| `agent_delta` chat-event | Each streamed content-delta chunk rides a `agent_delta` chat-event (correlated by `chain_id`), never an `OutboxMessage` display kind — the completed reply still persists exactly once via the terminal `kind="agent"` outbox message (L9 whole-persist unchanged) | [AG-UI transport § reyn.event.\<etype\>](reference/runtime/agui-transport.md) |
+| AG-UI generic multi-CONTENT | On the AG-UI wire, a streamed reply rides a REAL `TEXT_MESSAGE_START` → N `TEXT_MESSAGE_CONTENT` → `TEXT_MESSAGE_END` sequence (never a re-sent full-text CONTENT at completion, which would double-render on an accumulating generic client); a mid-stream-joining connection is closed by the snapshot/restore path always supplying the authoritative full text, never the deltas | [AG-UI transport § Text lifecycle](reference/runtime/agui-transport.md) |
+| Textual TUI streamed-reply coalescing | The Textual TUI's L7 pump coalesces N deltas for one reply into exactly ONE `FlowView` entry (keyed by `chain_id`, updated in place via `Entry.set_item`), finalized by the terminal completion frame rather than appended a second time — the plain/repl renderer has no consumer and silently drops `agent_delta` (opt-in draw, no visible-garbage window) | [AG-UI transport § Textual TUI streamed-reply rendering](reference/runtime/agui-transport.md) |
+
+> **Differentiation vs general agents:** streaming is layered onto the SAME single-chokepoint `recorded_acompletion` call, the SAME `OutboxHub`/chat-event fan-out, and the SAME `FlowView` render model every other frame uses — no parallel streaming-only pipeline, no per-provider hardcoding, and no risk of a streamed reply diverging from its non-streamed reconstruction.
+
 ---
 
 ### Control IR Ops

--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -413,7 +413,11 @@ A reyn chat-event with no standard AG-UI analog. `value` is the event's data
 object. Most members are the working-indicator axis (turn-lifecycle /
 tool-call / user-submitted / cancel); `agent_delta` (#3288 ③b) is a SEPARATE
 streaming-notification axis — see its row below and the `_STREAMING_EVENTS`
-comment in `frames.py` for why it is forwarded ahead of any renderer consumer.
+comment in `frames.py` for why it was forwarded ahead of any consumer. The
+plain/repl renderer still has no `agent_delta` branch (and may never); the
+Textual TUI (`interfaces/inline/textual_chat`) is the one surface that
+consumes it, as of #3288 ③c — see *Textual TUI streamed-reply rendering*
+below.
 ★This `CUSTOM` mapping is what `encode_frame`/`encode_frame_wire` (the plain,
 non-streaming codec path) produce for an `agent_delta` `EventFrame` — the AG-UI
 emitter's actual production call site (`emitter.py`) instead runs every frame
@@ -430,6 +434,27 @@ wire.
 | `reyn.event.user_submitted`          | a user turn was submitted (#3300 P1 C) — RAW text + chain_id + msg_id + seq + meta; each surface neutralizes at its render boundary. `msg_id`/`seq` are the #3300 P2a sent-queue correlation id + order-race-gate token |
 | `reyn.event.inbox_cancel`            | an UNDISPATCHED queued user message was cancelled by id (#3300 P3, via the `cancel_queued` client message) — carries `msg_id` + `seq`; the server-authoritative sent-queue removal signal (never a client-local "cancel succeeded" response), exclusive with `turn_started` for the same `msg_id` |
 | `reyn.event.agent_delta`             | one streamed LLM content-delta chunk (#3288 ③b) — carries `text` (the raw per-chunk delta) + `chain_id`. The plain codec's `CUSTOM` mapping (see the note above); on the actual AG-UI wire (`encode_frame_wire_streaming`, #3288 ③d) this rides `TEXT_MESSAGE_CONTENT` instead — see *Text lifecycle* above for the full streamed-message contract (END-only completion, reconstruction authority, late-joiner closure) |
+
+### Textual TUI streamed-reply rendering (#3288 ③c)
+
+The Textual TUI (`interfaces/inline/textual_chat/app.py`) is the L7 consumer
+`agent_delta` was forwarded ahead of (see the note above): `TextualChatApp.
+_handle_agent_delta_event` coalesces N deltas for one reply into exactly ONE
+`FlowView` entry, keyed by `chain_id` — the SAME authoritative correlation id
+`RouterLoop._emit_agent_delta` stamps on every delta and the terminal
+`kind="agent"` `OutboxMessage` carries in its own `meta`. The first delta for
+a `chain_id` appends a new entry; every later delta for that same `chain_id`
+updates that SAME entry in place (`Entry.set_item`) rather than appending a
+second row. The terminal completion (a DISPLAY frame, not an event) then
+FINALIZES that same entry with the completion's authoritative full text
+(never the deltas — L9 whole-persist's source of truth) and stops tracking
+the `chain_id`, rather than appending a second entry of its own — this is
+what keeps a mid-stream-joining client (one that only ever received the TAIL
+of a reply's deltas, see *Text lifecycle*'s late-joiner closure above) to
+exactly one final entry instead of a duplicate. The plain/repl renderer has
+no equivalent branch and is unaffected — `agent_delta` there is still
+consumed-but-dropped (opt-in draw, no visible-garbage window), exactly as
+before ③c.
 
 ### `reyn.intervention.<kind>`
 

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -382,6 +382,22 @@ class TextualChatApp(App):
         # drawer refresh (:meth:`_refresh_pane`) from the SAME snapshot that built
         # the rows, so the option row and its id never drift.
         self._pane_selection_ids: "dict[str, list[str]]" = {}
+        # #3288 ③c: in-flight streamed reply, keyed by ``chain_id`` — the SAME
+        # authoritative correlation id ``RouterLoop._emit_agent_delta`` stamps
+        # on every ``agent_delta`` chat-event AND the one the terminal
+        # ``kind="agent"`` OutboxMessage carries in its ``meta["chain_id"]``
+        # (never a guessed key — text-match correlation was tried and
+        # reverted earlier in this arc, issue #3288/#3309). Each value is
+        # ``(entry, accumulated_text)``: the FIRST delta for a chain_id
+        # appends ONE new flow entry; every SUBSEQUENT delta for that SAME
+        # chain_id updates that SAME entry in place
+        # (:meth:`_handle_agent_delta_event`) rather than appending a second
+        # row. The terminal completion (:meth:`_ingest_frame`'s ``kind ==
+        # "agent"`` branch) pops this entry and finalizes it with the
+        # authoritative full text — the ONLY place a streamed reply's entry
+        # is removed from this map, so a chain_id can never leak past its
+        # turn's completion.
+        self._streaming_replies: "dict[str, tuple[Entry[OutboxMessage], str]]" = {}
 
     def compose(self) -> ComposeResult:
         # Held so the frame pump can start/stop the per-entry BODY animation
@@ -769,18 +785,31 @@ class TextualChatApp(App):
         started entry in place (:meth:`_coalesce_tool_result` — stop the ② live
         spinner, fold the ``⎿ result`` into the same entry, go SUCCESS/ERROR), so a
         call and its result read as ONE block (CC's ``⏺ tool(args)`` + ``⎿ result``,
-        the PoC's ``_present_tool_call`` grouping). Every OTHER frame — including a
+        the PoC's ``_present_tool_call`` grouping). A ``kind="agent"`` completion
+        whose ``meta["chain_id"]`` matches an in-flight streamed reply
+        (:attr:`_streaming_replies`, #3288 ③c) does not append a second entry
+        either: it FINALIZES the same entry the deltas coalesced into, with the
+        completion's authoritative full text (L9 whole-persist's source of
+        truth), and pops the tracked chain_id. Every OTHER frame — including a
         completion with NO matching started entry (already settled / uncorrelated)
         — is appended as its own entry: an ``intervention`` frame routes to
         :meth:`_present_intervention` (the panel, #3299 P1), everything else to
         :meth:`_apply_lifecycle_state`, so nothing regresses for the
         plain-fallback turn sequence."""
         kind = msg.kind
-        op_id = (msg.meta or {}).get("op_id")
+        meta = msg.meta or {}
+        op_id = meta.get("op_id")
         if kind in ("tool_call_completed", "tool_call_failed") and op_id is not None:
             started = self._running_tools.pop(op_id, None)
             if started is not None:
                 self._coalesce_tool_result(started, msg)
+                return
+        if kind == "agent":
+            chain_id = meta.get("chain_id")
+            streaming = self._streaming_replies.pop(chain_id, None) if chain_id else None
+            if streaming is not None:
+                entry, _partial_text = streaming
+                entry.set_item(replace(entry.item, text=msg.text, meta=meta))
                 return
         entry = self.conversation.append(msg)
         if kind == "intervention":
@@ -1058,6 +1087,64 @@ class TextualChatApp(App):
         if cancelled_text is not None:
             self._restore_cancelled_text(cancelled_text)
 
+    def _handle_agent_delta_event(self, event) -> None:
+        """Coalesce one streamed content-delta chunk into a SINGLE FlowView
+        entry per reply (#3288 ③c — the L7 consumer this arc's ③b/③d phases
+        deliberately left unbuilt: ③b's own gate is "an ``agent_delta`` with
+        no consumer draws nothing", and this method IS that consumer,
+        landing now).
+
+        Correlates on ``chain_id`` — the authoritative id ``RouterLoop.
+        _emit_agent_delta`` stamps on every delta and the terminal
+        ``kind="agent"`` OutboxMessage carries in its own meta — never a
+        guessed key (text-match correlation was tried and reverted earlier
+        in this arc, #3309).
+
+        First delta for a ``chain_id``: appends ONE new ``kind="agent"``
+        flow entry seeded with that delta's text (renders through the SAME
+        presenter path a terminal agent reply does — plain markdown body,
+        no special-cased streaming style). Every SUBSEQUENT delta for the
+        SAME ``chain_id`` accumulates onto the tracked text and updates
+        that SAME entry in place (``Entry.set_item`` — bumps the revision,
+        re-presents on the next viewport paint), never appending a second
+        row. This entry is finalized (and popped from
+        :attr:`_streaming_replies`) by the terminal completion frame in
+        :meth:`_ingest_frame`, never here — so a chain_id's tracked partial
+        never contests with the authoritative completed text (L9
+        whole-persist stays the completion's job).
+
+        A late-joining connection that only receives the TAIL of a stream
+        (the mid-stream-join case #3288 ③d proved on the wire, handed off
+        to ③c to close on the render side) is handled by this SAME code
+        path: whichever deltas this client actually receives seed/update
+        ONE entry exactly as above, and the terminal completion finalizes
+        it — no separate branch needed, since the coalesce is keyed by
+        chain_id, not by "have we seen the FIRST delta".
+
+        Best-effort: a malformed/empty delta (no ``chain_id`` or empty
+        ``text``) is silently dropped rather than crashing the pump — the
+        emitting side (``RouterLoop``) never emits invalid deltas, so this
+        is defensive only.
+        """
+        data = event.data or {}
+        chain_id = data.get("chain_id")
+        text = str(data.get("text", ""))
+        if not chain_id or not text:
+            return
+        existing = self._streaming_replies.get(chain_id)
+        if existing is None:
+            from reyn.runtime.outbox import OutboxMessage  # noqa: PLC0415
+
+            entry = self.conversation.append(
+                OutboxMessage(kind="agent", text=text, meta={"chain_id": chain_id})
+            )
+            self._streaming_replies[chain_id] = (entry, text)
+            return
+        entry, accumulated = existing
+        accumulated += text
+        entry.set_item(replace(entry.item, text=accumulated))
+        self._streaming_replies[chain_id] = (entry, accumulated)
+
     def _restore_cancelled_text(self, text: str) -> None:
         """Restore a cancelled submission's text into the composer (#3300
         Y-client, owner-ratified detail): prepended at the HEAD even when the
@@ -1131,6 +1218,12 @@ class TextualChatApp(App):
         :meth:`_sweep_orphaned_running_tools` (#72: force-settle any tool still
         RUNNING when its turn ends — a confirmed orphan).
 
+        #3288 ③c: ``agent_delta`` (:meth:`_handle_agent_delta_event`) coalesces
+        streamed reply chunks into ONE flow entry per ``chain_id`` — see that
+        method's docstring and :attr:`_streaming_replies`. The entry it
+        maintains is finalized by the terminal ``kind="agent"`` DISPLAY frame
+        in :meth:`_ingest_frame`, never appended a second time.
+
         #3300 P2b/Y-client: ``user_submitted`` (:meth:`_handle_user_submitted_event`),
         ``turn_started`` (:meth:`_handle_turn_started_event`), and
         ``inbox_cancel`` (:meth:`_handle_inbox_cancel_event`) drive the
@@ -1174,6 +1267,13 @@ class TextualChatApp(App):
                         except Exception:
                             logger.exception(
                                 "textual chat: inbox_cancel ingest failed"
+                            )
+                    elif etype == "agent_delta":
+                        try:
+                            self._handle_agent_delta_event(frame.event)
+                        except Exception:
+                            logger.exception(
+                                "textual chat: agent_delta coalesce failed"
                             )
                     elif etype in _TURN_END_EVENT_TYPES:
                         try:

--- a/src/reyn/interfaces/transport/frames.py
+++ b/src/reyn/interfaces/transport/frames.py
@@ -30,8 +30,11 @@ designed out). The ONE deliberate exception is :data:`_STREAMING_EVENTS`
 design: the completeness gate only requires ``consumed ⊆ forwarded``, never
 the reverse, so a forwarded-but-not-yet-consumed event is legal, and an EVENT
 frame with no handler is silently dropped (not rendered) at the consuming
-end — the mechanism a later phase (③c) plugs a consumer into without ever
-risking a "vanished on the wire" regression in the meantime.
+end — the mechanism ③c later plugged a consumer into
+(``TextualChatApp._handle_agent_delta_event``) without ever having risked a
+"vanished on the wire" regression in the meantime. The plain/repl renderer
+still has no ``agent_delta`` branch — the completeness gate does not require
+one (``consumed ⊆ forwarded``, never the reverse).
 """
 from __future__ import annotations
 
@@ -89,11 +92,11 @@ _TURN_AND_ANSWER_EVENTS = frozenset(
 # replacement (issue #3288 comment thread): a partial rides a chat-event
 # (never an ``OutboxMessage`` kind, which the closed display vocabulary would
 # have to register — the category error the owner's decision designs out).
-# UNLIKE :data:`_TURN_AND_ANSWER_EVENTS` above, this is forwarded AHEAD OF any
-# consumer — no renderer branches on ``"agent_delta"`` yet (③c adds the
-# textual_chat coalescing handler as a later phase; the plain/repl renderer
-# may never consume it at all). This is legal per the dual-stream
-# completeness gate's actual direction (``tests/test_transport_dual_stream_completeness.py``:
+# UNLIKE :data:`_TURN_AND_ANSWER_EVENTS` above, this was forwarded AHEAD OF
+# any consumer — ③c has since added the textual_chat coalescing handler
+# (``TextualChatApp._handle_agent_delta_event``), but the plain/repl renderer
+# still branches on nothing for it (and may never). This is legal per the
+# dual-stream completeness gate's actual direction (``tests/test_transport_dual_stream_completeness.py``:
 # ``consumed ⊆ forwarded``, never the reverse) — a forwarded event nobody
 # consumes yet is not a coverage gap, and a surface with no handler for an
 # EVENT frame consumes-but-drops it (never renders it), unlike an unknown
@@ -119,9 +122,13 @@ def renderer_chat_events() -> frozenset[str]:
       (DERIVED from the renderer's own vocabulary, never hand-listed for this
       half — see ``tests/test_transport_dual_stream_completeness.py``).
     - :data:`_STREAMING_EVENTS` (#3288 ③b) — the ONE deliberate exception to
-      "derived, not hand-listed": forwarded ahead of any renderer consumer, so
-      an unconsuming surface silently drops it (opt-in draw) instead of it
-      vanishing on the wire before a later phase adds the consumer.
+      "derived, not hand-listed": forwarded ahead of any consumer in THIS
+      (plain/repl) renderer, which still has no ``agent_delta`` branch and
+      may never — an unconsuming surface silently drops it (opt-in draw)
+      rather than it vanishing on the wire. ③c has since added the actual
+      consumer in a DIFFERENT surface (``TextualChatApp._handle_agent_delta_event``,
+      ``interfaces/inline/textual_chat/app.py``), proving the forward-ahead
+      design worked: the consumer landed with zero changes needed here.
     """
     return frozenset(_WAITING_ON_BY_EVENT.keys()) | _TURN_AND_ANSWER_EVENTS | _STREAMING_EVENTS
 

--- a/tests/test_3288_3c_tui_delta_coalesce.py
+++ b/tests/test_3288_3c_tui_delta_coalesce.py
@@ -1,0 +1,251 @@
+"""#3288 ③c — the TUI L7 consumer that coalesces streaming "agent_delta"
+chat-events into one FlowView entry per reply
+(:meth:`~reyn.interfaces.inline.textual_chat.app.TextualChatApp._handle_agent_delta_event`).
+
+This is the LAST phase of the token-streaming arc (③a core streaming, ③b
+chat-event emit, ③d AG-UI generic multi-CONTENT — all merged). Nothing
+consumed "agent_delta" in the TUI before this phase; ``tests/
+test_agent_delta_no_visible_garbage_3288.py`` (③b, re-pointed by this same
+PR) covers the core "N deltas -> exactly one coalesced entry" property with
+its own arrival witness. This file covers the two gates specific to ③c that
+are NOT redundant with that file:
+
+- **★mid-stream-join**: a connection that only starts receiving PARTIAL
+  content partway through a reply (it missed the earlier deltas — the ③d
+  co-vet's explicit hand-off to ③c: the server side of this was proven in
+  ③d, "not double-rendering that case depends on your coalesce") must still
+  end with exactly ONE entry, finalized to the completion's full text —
+  never a duplicate row from the completion arriving on top of a
+  differently-seeded partial entry.
+- **stream ≡ whole equivalence at the render level** (the load-bearing gate
+  of the whole #3288 arc): streaming ON (deltas + completion) and streaming
+  OFF (completion only, no deltas at all — the ``recorded_acompletion``
+  non-streaming path) must produce IDENTICAL final rendered content for the
+  same reply, through the SAME app code.
+
+Each gate below asserts at a MID-STREAM cross-section (before the terminal
+completion arrives) in addition to the post-completion state — asserting
+only the post-completion state would be vacuous, since the completion frame
+alone creates a one-entry, full-text result regardless of whether any delta
+coalescing ever happened (a correction raised mid-PR after an earlier draft
+of this gate only asserted post-completion).
+
+Real ``TextualChatApp`` + a real minimal ``ClientTransport`` (mirrors
+``tests/test_agent_delta_no_visible_garbage_3288.py``'s ``QueueTransport``
+idiom) throughout — no ``unittest.mock``. No widget tree / layout change was
+made in this phase (the consumer reuses the existing ``kind="agent"`` render
+path via ``FlowModel.append`` / ``Entry.set_item``), so no new geometry gate
+is required per this arc's established rule (a geometry gate is for
+widget-tree/layout changes; this PR adds none).
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.runtime.outbox import OutboxMessage
+from reyn.schemas.models import Event
+
+
+class QueueTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` fed one frame at a time from a
+    queue (mirrors ``tests/test_agent_delta_no_visible_garbage_3288.py``'s
+    helper of the same name)."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+
+    async def push_event(self, event: Event) -> None:
+        await self._queue.put(EventFrame(event))
+
+    async def push_display(self, msg: OutboxMessage) -> None:
+        await self._queue.put(DisplayFrame(msg))
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+        pass
+
+    async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:  # pragma: no cover
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _agent_delta(*, chain_id: str, text: str) -> Event:
+    return Event(type="agent_delta", data={"text": text, "chain_id": chain_id})
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_join_finalizes_to_one_entry_full_text() -> None:
+    """Tier 2: ★a client that joins mid-stream (misses the earlier deltas —
+    it only ever sees the TAIL of the partial content) must end with exactly
+    ONE entry, finalized to the completion's full text — never a second row
+    from the completion landing on top of the partial-seeded entry.
+
+    Mid-stream cross-section FIRST (not vacuous): after the one tail delta
+    this "late joiner" DOES receive, there must already be exactly one entry
+    whose content is that delta's own (incomplete, non-full) text — proving
+    the entry existed and was PARTIAL before the completion ever arrived,
+    not fabricated by the completion alone.
+
+    Strip-falsify (recorded in the PR body): reverting
+    ``_handle_agent_delta_event`` to a no-op makes the mid-stream
+    cross-section fail (no entry created by the tail delta) — the same
+    strip as the sibling ③b/③c file's, applied to the late-join framing
+    specifically requested by the ③d co-vet hand-off.
+    """
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        before = len(app.query_one(FlowView).entries)
+
+        # This client attaches mid-stream: the only delta it ever receives is
+        # the tail of the reply — a strict, non-trivial substring of the
+        # eventual full text, never the whole thing.
+        await transport.push_event(
+            _agent_delta(chain_id="late-join", text="...and that's the summary.")
+        )
+        await pilot.pause()
+
+        entries = app.query_one(FlowView).entries
+        assert len(entries) == before + 1, (
+            "the late-joiner's one tail delta must create exactly one entry — "
+            f"count {before} -> {len(entries)}"
+        )
+        assert entries[-1].item.text == "...and that's the summary.", (
+            "the mid-stream cross-section must show the PARTIAL (tail-only) "
+            f"text, got {entries[-1].item.text!r} — proves the entry is "
+            "seeded by the delta, not fabricated later by the completion"
+        )
+
+        full_text = (
+            "Here is the full reply this late-joining client never saw the "
+            "start of...and that's the summary."
+        )
+        await transport.push_display(
+            OutboxMessage(kind="agent", text=full_text, meta={"chain_id": "late-join"})
+        )
+        await pilot.pause()
+
+        entries = app.query_one(FlowView).entries
+        assert len(entries) == before + 1, (
+            "the completion for a mid-stream-joined chain_id must NOT append "
+            f"a second entry — count changed to {len(entries)} (double-render)"
+        )
+        assert entries[-1].item.text == full_text, (
+            "the late joiner must end up with the AUTHORITATIVE full text "
+            f"(never the partial tail it happened to see), got "
+            f"{entries[-1].item.text!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_stream_on_off_render_equivalence() -> None:
+    """Tier 2: ★load-bearing, whole #3288 arc — streaming ON (N deltas then
+    the completion) and streaming OFF (the completion alone, exactly what a
+    non-streaming-capable provider produces) must render IDENTICAL final
+    content through the SAME ``TextualChatApp`` consumer code — streaming is
+    a rendering OPTIMIZATION, never a semantic change, at the render layer
+    just as ③a proved it at the LLM-result layer.
+
+    Mid-stream cross-section on the streaming-ON app (not vacuous): before
+    its completion arrives, the streaming app must show exactly one entry
+    with PARTIAL (not yet full) text — proving the deltas actually drove the
+    entry rather than the comparison only exercising the (identical either
+    way) completion-only path.
+    """
+    reply_text = "The answer is 42, computed across three steps."
+
+    # Streaming OFF: exactly what a non-capability provider (or ③a's
+    # capability gate declining to stream) produces — one completion frame,
+    # no deltas at all.
+    off_transport = QueueTransport()
+    off_app = TextualChatApp(transport=off_transport)
+    async with off_app.run_test(size=(100, 30)) as off_pilot:
+        await off_pilot.pause()
+        await off_transport.push_display(
+            OutboxMessage(kind="agent", text=reply_text, meta={"chain_id": "off-chain"})
+        )
+        await off_pilot.pause()
+        off_entries = off_app.query_one(FlowView).entries
+        off_final_text = off_entries[-1].item.text
+        off_final_count = len(off_entries)
+
+    # Streaming ON: the SAME reply, chunked into deltas, then the SAME
+    # completion text.
+    on_transport = QueueTransport()
+    on_app = TextualChatApp(transport=on_transport)
+    async with on_app.run_test(size=(100, 30)) as on_pilot:
+        await on_pilot.pause()
+        before = len(on_app.query_one(FlowView).entries)
+        chunks = ["The answer is 42, ", "computed across ", "three steps."]
+        for chunk in chunks[:-1]:
+            await on_transport.push_event(_agent_delta(chain_id="on-chain", text=chunk))
+            await on_pilot.pause()
+
+        mid_entries = on_app.query_one(FlowView).entries
+        assert len(mid_entries) == before + 1, (
+            "mid-stream: the ON app must already have exactly one entry "
+            f"before its completion arrives — count {before} -> "
+            f"{len(mid_entries)}"
+        )
+        assert mid_entries[-1].item.text == "".join(chunks[:-1]), (
+            "mid-stream: the ON app's entry must hold the PARTIAL "
+            f"(not-yet-full) coalesced text, got {mid_entries[-1].item.text!r}"
+        )
+        assert mid_entries[-1].item.text != reply_text, (
+            "mid-stream cross-section is vacuous if the partial text already "
+            "equals the full text — the chunking must be non-trivial"
+        )
+
+        await on_transport.push_event(_agent_delta(chain_id="on-chain", text=chunks[-1]))
+        await on_pilot.pause()
+        await on_transport.push_display(
+            OutboxMessage(kind="agent", text=reply_text, meta={"chain_id": "on-chain"})
+        )
+        await on_pilot.pause()
+
+        on_entries = on_app.query_one(FlowView).entries
+        on_final_text = on_entries[-1].item.text
+        on_final_count = len(on_entries) - before
+
+    assert on_final_count == off_final_count == 1, (
+        "both streaming ON and OFF must settle to exactly one entry for the "
+        f"reply — on={on_final_count} off={off_final_count}"
+    )
+    assert on_final_text == off_final_text == reply_text, (
+        "streaming ON and OFF must render IDENTICAL final content for the "
+        f"same reply — on={on_final_text!r} off={off_final_text!r}"
+    )

--- a/tests/test_agent_delta_no_visible_garbage_3288.py
+++ b/tests/test_agent_delta_no_visible_garbage_3288.py
@@ -1,34 +1,47 @@
-"""Tier 2: #3288 ③b — "no visible-garbage window" for the "agent_delta"
-chat-event, witnessed on the ACTUAL ``TextualChatApp`` pump (production code
-untouched — imported and driven read-only from this test, per the #3299/P5
-non-interference constraint on ``interfaces/inline/textual_chat/``).
+"""Tier 2: #3288 ③b/③c — the "no visible-garbage window" property for the
+"agent_delta" chat-event, witnessed on the ACTUAL ``TextualChatApp`` pump
+(production code untouched — imported and driven read-only from this test,
+per the #3299/P5 non-interference constraint on
+``interfaces/inline/textual_chat/``).
 
-The owner's ratified design (issue #3288 comment thread) chose a chat-event
-route specifically BECAUSE an EVENT frame with no consumer is dropped
-(``_pump_frames``'s ``if/elif/.../continue`` has no ``else`` — consumed but
-never drawn), whereas an unknown ``OutboxMessage`` DISPLAY kind is rendered as
-a generic row by the presenter. ③c (a later phase, out of scope here) adds the
-textual_chat coalescing consumer for "agent_delta"; UNTIL it lands, this test
-is the CI gate that a future change cannot silently start drawing a row per
-delta (a visible-garbage regression) without this test going RED — a
-structural strip-style witness, not a one-time manual read of the source.
+★③c re-point (issue #3288 comment thread, ③c phase): ③b's original assertion
+here was "an agent_delta draws NOTHING" — true only UNTIL ③c lands a
+consumer. ③c's whole job is to make ``agent_delta`` coalesce into a flow
+entry (:meth:`TextualChatApp._handle_agent_delta_event`), which legitimately
+FALSIFIES that literal assertion. The PROPERTY worth keeping (per the ③c
+brief: "migrate, do not delete") is narrower and still true post-③c: **a
+delta never produces a junk row of its own** — N deltas for one reply
+produce exactly ONE flow entry (never N), and that entry's content is the
+progressively-coalesced text, not a generic/garbage rendering of the raw
+event payload. This file re-points the assertion to that property instead
+of dropping the file's witness.
 
-★co-vet fix (PR #3312 review): an EARLIER version of this file asserted only
-"FlowView entry count unchanged" against the delta push — which stays GREEN
-even if ``push_event``/the transport is silently dead (verified: neutering
-``QueueTransport.push_event`` into a no-op left both tests passing), because
-"delivered but not drawn" and "never delivered" are indistinguishable from
-that assertion alone. The fix is an ARRIVAL WITNESS (positive control) that
-exercises the EXACT SAME ``push_event`` path the delta assertion depends on:
-push a real ``user_submitted`` + matching ``turn_started`` pair FIRST (the
-proven promote-to-FlowView sequence from
+★co-vet fix (PR #3312 review, ③b): an EARLIER version of this file asserted
+only "FlowView entry count unchanged" against the delta push — which stays
+GREEN even if ``push_event``/the transport is silently dead (verified:
+neutering ``QueueTransport.push_event`` into a no-op left both tests
+passing), because "delivered but not drawn" and "never delivered" are
+indistinguishable from that assertion alone. The fix is an ARRIVAL WITNESS
+(positive control) that exercises the EXACT SAME ``push_event`` path the
+delta assertion depends on: push a real ``user_submitted`` + matching
+``turn_started`` pair FIRST (the proven promote-to-FlowView sequence from
 ``tests/test_3300_p2b_sentqueue_render.py::test_turn_started_promotes_matching_item_to_flow_entry``)
 and assert the FlowView entry count DOES increase — proving this transport +
-pump pair is alive and forwarding EVENT frames — THEN push the delta and
-assert no FURTHER increase. (A bare ``user_submitted`` alone cannot serve as
-this witness: #3300 P2b made it materialize into the sent-queue only, never a
-FlowView entry by itself — the promoting ``turn_started`` companion is
-required, mirroring the cited test exactly.)
+pump pair is alive and forwarding EVENT frames — THEN push the delta(s) and
+assert against that KNOWN-alive baseline. (A bare ``user_submitted`` alone
+cannot serve as this witness: #3300 P2b made it materialize into the
+sent-queue only, never a FlowView entry by itself — the promoting
+``turn_started`` companion is required, mirroring the cited test exactly.)
+
+★self-diagnosing failure (③c brief): if
+``test_agent_delta_draws_exactly_one_coalesced_entry`` below fails at its
+ARRIVAL-WITNESS step (before any delta is even pushed), the failure is a
+regression in the EVENT delivery path itself (``push_event`` / ``frames()`` /
+``turn_started`` promotion), NOT a ③c coalesce regression — the same
+``user_submitted``+``turn_started`` pair this file has used since ③b is
+reused unmodified as the positive control, so a failure there points at the
+delivery mechanism, not at the "agent_delta" consumer this file is actually
+about.
 
 Real instances only: a real ``TextualChatApp`` driven via Textual's
 ``run_test()`` harness (mirrors ``tests/test_user_submitted_render_3300.py``'s
@@ -44,7 +57,7 @@ from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.transport.client_transport import ClientTransport
-from reyn.interfaces.transport.frames import EventFrame
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
 
@@ -61,6 +74,9 @@ class QueueTransport(ClientTransport):
 
     async def push_event(self, event: Event) -> None:
         await self._queue.put(EventFrame(event))
+
+    async def push_display(self, msg: OutboxMessage) -> None:
+        await self._queue.put(DisplayFrame(msg))
 
     def start(self) -> None:  # pragma: no cover - trivial
         pass
@@ -136,46 +152,102 @@ async def _arrival_witness(transport: QueueTransport, pilot, app: TextualChatApp
 
 
 @pytest.mark.asyncio
-async def test_agent_delta_event_draws_nothing_in_textual_chat() -> None:
-    """Tier 2: pushing an "agent_delta" EVENT frame through the REAL
-    ``TextualChatApp._pump_frames`` must not append a FlowView entry — the
-    event is consumed (the pump does not crash / stall) but not drawn, since
-    no branch in the (untouched) pump matches "agent_delta" yet. Preceded by
-    the arrival witness (see module docstring / ``_arrival_witness``) so a
-    dead ``push_event`` cannot make this pass vacuously.
+async def test_agent_delta_draws_exactly_one_coalesced_entry() -> None:
+    """Tier 2: ③c re-point of ③b's "draws nothing" — N ``agent_delta``
+    chat-events for ONE reply must never produce more than ONE FlowView
+    entry, and that entry's content must be the progressively-coalesced
+    text — never a junk/generic row per delta (the property ③b's original
+    assertion was guarding, restated for a world where ③c's consumer
+    exists).
 
-    Strip-falsify (recorded in the PR body): re-emitting the SAME delta as a
-    ``DisplayFrame`` (an ``OutboxMessage``-kind carrier — the design the
-    owner's decision REPLACES) through this same app DOES append a generic
-    row — proving the chat-event route is what closes the visible-garbage
-    window, not an accident of this particular event's payload shape.
+    ★vacuity fix (lead-coder correction on this PR): asserting ONLY at/after
+    the terminal completion is itself vacuous — the completion frame alone
+    creates one full-text entry regardless of whether any delta was ever
+    delivered, so "1 entry, full text" would pass even with delta delivery
+    completely dead. This test instead asserts at THREE cross-sections:
+
+    1. after the arrival witness (baseline, proven alive) but BEFORE any
+       delta — establishes the pre-delta count;
+    2. after the FIRST delta only (mid-coalesce, no completion yet) — count
+       must be baseline+1 and the entry's content must be that first
+       delta's PARTIAL text (proves the delta itself is what created the
+       entry — not the later completion);
+    3. after a SECOND delta (still no completion) — count stays at
+       baseline+1 (no second row) and content is the ACCUMULATED partial
+       text of both deltas (proves in-place coalescing, not silent drop or
+       replace-by-latest);
+    4. after the terminal ``kind="agent"`` completion (same chain_id) —
+       count STILL stays at baseline+1 (no second entry from the
+       completion either) and content is the completion's authoritative
+       full text (finalize, not a third partial state).
+
+    Strip-falsify (recorded in the PR body): reverting the ③c consumer
+    (``TextualChatApp._handle_agent_delta_event``) to a no-op reproduces
+    ③b's old "draws nothing" behavior — step 2 then fails (count stays at
+    baseline instead of baseline+1) — confirming this assertion actually
+    depends on the ③c coalesce mechanism, not on a tautology.
     """
     transport = QueueTransport()
     app = TextualChatApp(transport=transport)
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
-        after_witness = await _arrival_witness(transport, pilot, app)
+        baseline = await _arrival_witness(transport, pilot, app)
 
         await transport.push_event(
-            Event(type="agent_delta", data={"text": "partial chunk", "chain_id": "c1"})
+            Event(type="agent_delta", data={"text": "Hello", "chain_id": "c1"})
         )
         await pilot.pause()
+        entries = app.query_one(FlowView).entries
+        assert len(entries) == baseline + 1, (
+            "a single agent_delta must create exactly ONE new flow entry — "
+            f"count {baseline} -> {len(entries)}; delta delivery/coalesce is "
+            "not creating an entry (possible regression to ③b's pre-③c "
+            "'draws nothing' behavior)"
+        )
+        assert entries[-1].item.text == "Hello", (
+            "the first delta's entry must render that delta's own (partial) "
+            f"text, got {entries[-1].item.text!r}"
+        )
 
-        after_delta = len(app.query_one(FlowView).entries)
-        assert after_delta == after_witness, (
-            "an agent_delta chat-event must draw NOTHING (opt-in draw, no "
-            f"consumer yet) — entry count changed {after_witness} -> {after_delta}"
+        await transport.push_event(
+            Event(type="agent_delta", data={"text": ", world", "chain_id": "c1"})
+        )
+        await pilot.pause()
+        entries = app.query_one(FlowView).entries
+        assert len(entries) == baseline + 1, (
+            "a SECOND delta for the SAME chain_id must coalesce into the "
+            f"SAME entry, not append a new row — count changed to {len(entries)}"
+        )
+        assert entries[-1].item.text == "Hello, world", (
+            "the second delta must ACCUMULATE onto the first, not replace "
+            f"or drop it, got {entries[-1].item.text!r}"
+        )
+
+        await transport.push_display(
+            OutboxMessage(kind="agent", text="Hello, world!", meta={"chain_id": "c1"})
+        )
+        await pilot.pause()
+        entries = app.query_one(FlowView).entries
+        assert len(entries) == baseline + 1, (
+            "the terminal completion for an already-streamed chain_id must "
+            f"FINALIZE the existing entry, not append a second one — count "
+            f"changed to {len(entries)}"
+        )
+        assert entries[-1].item.text == "Hello, world!", (
+            "the finalized entry must show the completion's AUTHORITATIVE "
+            f"full text (L9 whole-persist), got {entries[-1].item.text!r}"
         )
 
 
 @pytest.mark.asyncio
 async def test_agent_delta_ignored_alongside_other_unhandled_events() -> None:
-    """Tier 2: non-vacuity companion — a DIFFERENT unhandled event type
-    (mirroring ``test_textual_chat_app_ignores_non_user_submitted_events_for_flow``)
-    also draws nothing, proving the previous test's zero-delta is because NO
-    unhandled EVENT frame draws anything (the pump's structural behavior),
-    not a coincidence specific to the "agent_delta" payload shape. Carries its
-    OWN arrival witness so this test alone cannot pass vacuously either."""
+    """Tier 2: non-vacuity companion — a DIFFERENT, genuinely unhandled event
+    type (mirroring ``test_textual_chat_app_ignores_non_user_submitted_events_for_flow``)
+    still draws NOTHING, proving the opt-in-draw structural property
+    (``_pump_frames``'s ``if/elif/.../continue`` with no ``else``) survives
+    ③c's addition of an "agent_delta" branch — ③c added ONE new elif arm, it
+    did not turn the EVENT path into a default-draw path. Carries its OWN
+    arrival witness so this test alone cannot pass vacuously either."""
     transport = QueueTransport()
     app = TextualChatApp(transport=transport)
     async with app.run_test(size=(100, 30)) as pilot:


### PR DESCRIPTION
**[per-PR-coder]** — #3288 ③c: the TUI L7 consumer that coalesces streaming `agent_delta` chat-events into one `FlowView` entry per reply. This is the LAST phase of the token-streaming arc (③a/③b/③d already merged) — closes #3288.

## What

`TextualChatApp._handle_agent_delta_event` (`src/reyn/interfaces/inline/textual_chat/app.py`) tracks an in-flight streamed reply by `chain_id` — the SAME authoritative correlation id `RouterLoop._emit_agent_delta` stamps on every delta and the terminal `kind="agent"` `OutboxMessage` carries in its own `meta`:

- **First delta** for a `chain_id`: appends ONE new `kind="agent"` flow entry seeded with that delta's text.
- **Every later delta** for the SAME `chain_id`: accumulates and updates that SAME entry in place (`Entry.set_item`), never a second row.
- **The terminal completion** (a DISPLAY frame, `_ingest_frame`): FINALIZES that same entry with the completion's authoritative full text (L9 whole-persist's source of truth) and stops tracking the `chain_id` — never appends a second entry.

No widget-tree/layout change — the consumer reuses the existing `kind="agent"` render path (`FlowModel.append` / `Entry.set_item`), so no geometry gate is needed per this arc's established rule.

## Gates (each strip-falsified, observed RED recorded)

1. **N deltas → exactly one entry, content == completion's full text.** `tests/test_3288_3c_tui_delta_coalesce.py` + the re-pointed `tests/test_agent_delta_no_visible_garbage_3288.py::test_agent_delta_draws_exactly_one_coalesced_entry`. Strip (revert `_handle_agent_delta_event` to a no-op): entry count stays at baseline after the first delta instead of baseline+1 → **RED** (observed).
2. **No double render at completion.** Same tests assert entry count is UNCHANGED when the terminal completion arrives after deltas already coalesced an entry.
3. **★Mid-stream-join ends with 1 entry + full text.** `tests/test_3288_3c_tui_delta_coalesce.py::test_mid_stream_join_finalizes_to_one_entry_full_text` — a client that only ever receives the TAIL delta of a reply (never the start) ends with exactly one entry, finalized to the full text, never a duplicate. Strip (same no-op revert): the mid-stream cross-section (after the tail delta, before completion) fails — no entry exists yet → **RED** (observed).
4. **Stream ≡ whole equivalence at the render level** (load-bearing). `test_stream_on_off_render_equivalence` compares an app fed deltas+completion against an app fed the completion alone (no deltas — the non-streaming-capable-provider shape) and asserts byte-identical final rendered text + entry count. Strip: same no-op revert fails the ON app's mid-stream cross-section (partial-text assertion) → **RED** (observed).
5. **★Migrate ③b's "no visible-garbage" gate, don't delete it.** `tests/test_agent_delta_no_visible_garbage_3288.py`'s `test_agent_delta_event_draws_nothing_in_textual_chat` legitimately falsifies now that a consumer exists (a delta DOES draw — that's the whole point of ③c). Re-pointed to `test_agent_delta_draws_exactly_one_coalesced_entry`, preserving the property that actually mattered: **a delta never produces a junk row of its own**. The companion `test_agent_delta_ignored_alongside_other_unhandled_events` (a genuinely different, still-unhandled event type draws nothing) is kept unmodified — it's still true and still non-vacuous.
6. **Same-delivery-path arrival witness + self-diagnosing failure message.** The re-pointed test keeps ③b's `user_submitted`+`turn_started` arrival witness (proven promote-to-FlowView sequence) as the baseline before any delta assertion, and the module docstring now states explicitly: a failure at the arrival-witness step is an EVENT-delivery-path regression, not a ③c coalesce regression.

### Vacuity-fix note (mid-PR correction applied)

An earlier draft of gates 1/3/4 asserted ONLY at/after the terminal completion — which is vacuous, since the completion frame alone creates a one-entry, full-text result regardless of whether delta coalescing ever ran. Every gate now asserts a **mid-stream cross-section** (before the completion arrives: exactly one entry, PARTIAL/not-yet-full content) in addition to the post-completion state, closing that hole. Confirmed via the strip: with `_handle_agent_delta_event` neutered, the mid-stream cross-section fails (no entry / count unchanged) while a completion-only assertion would still have passed.

## Local verification (targeted only, per repo policy)

```
uv run --extra dev python -m pytest --timeout=120 -q \
  tests/test_3288_3c_tui_delta_coalesce.py \
  tests/test_agent_delta_no_visible_garbage_3288.py \
  tests/test_agent_delta_chat_event_3288.py \
  tests/test_agui_multi_content_streaming_3288.py \
  tests/test_llm_streaming_equivalence_3288.py \
  tests/test_llm_streaming_usage_single_emission_3288.py \
  tests/test_llm_streaming_capability_driver_3288.py \
  tests/test_llm_streaming_delta_emission_3288.py \
  tests/test_3300_p2a_queue_state_publish.py tests/test_3300_p2b_sentqueue_render.py \
  tests/test_3300_p3_cancel_by_id.py tests/test_3300_y_client_cancel.py \
  tests/test_textual_chat_intervention_panel_3299.py tests/test_textual_chat_orphan_sweep_72.py \
  tests/test_textual_chat_phase1_3273.py tests/test_textual_chat_phase2_3273.py \
  tests/test_textual_chat_phase2b_live_tool_3283.py tests/test_textual_chat_phase3_3273.py \
  tests/test_textual_chat_phase4_3273.py tests/test_textual_chat_phase5_3273.py \
  tests/test_user_submitted_render_3300.py tests/test_transport_dual_stream_completeness.py
# 180 passed
```

Also green: `ruff check src tests`, `python scripts/test_tier_audit.py --strict tests/test_3288_3c_tui_delta_coalesce.py tests/test_agent_delta_no_visible_garbage_3288.py`, `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/app.py src/reyn/interfaces/transport/frames.py`.

**Full-suite authority is CI** — not run locally per repo policy (shared machine, concurrent full-suite runs produce spurious timeouts).

## Doc-drift (same PR)

- `docs/reference/runtime/agui-transport.md`: updated the `reyn.event.<etype>` section's `agent_delta` note (was "forwarded ahead of any renderer consumer" — now names the TUI as the surface that consumes it as of ③c) and added a new **"Textual TUI streamed-reply rendering (#3288 ③c)"** subsection describing the coalesce/finalize mechanism and its late-joiner closure.
- `src/reyn/interfaces/transport/frames.py`: updated the module docstring and `_STREAMING_EVENTS`/`renderer_chat_events` comments from "a later phase (③c) will add a consumer" (future tense) to "③c has since added the consumer" (past tense, present state) — the plain/repl renderer still has none, which is unchanged and still correct.
- `docs/feature-map.md`: added an **"LLM token streaming"** subsection under Chat Engine covering all four landed phases (③a capability-gated loop, ③b `agent_delta` chat-event, ③d AG-UI multi-CONTENT, ③c TUI coalescing) — the whole arc previously had zero feature-map entries despite being fully user-facing complete as of this PR.

## Test plan

- [x] Targeted pytest run above — 180 passed.
- [x] Each gate's strip-falsify performed locally (revert `_handle_agent_delta_event` to a no-op) — observed RED at the mid-stream cross-section for gates 1/3/4, reverted after confirming.
- [x] `ruff check src tests`, tier audit (`--strict`), module-docstring verify — all green.
- [ ] Manual/visual: run the actual TUI against a streaming-capable model and watch a reply render token-by-token as one growing bubble (recommend the reviewer or CI dogfood pass do this — no live-provider harness available in this sandboxed session).

## Closes #3288

All four ADR phases (③a core streaming + capability, ③b `agent_delta` chat-event, ③c this PR's TUI coalescing consumer, ③d AG-UI generic multi-CONTENT) are merged. The issue's gate list (stream≡whole equivalence, capability-is-driver, usage single-emission, L9 whole-persist, L4/L7/L5 phase gates) is fully covered across the four PRs.
