### PR TITLE
fix(tui): neutralize + fidelity-guard the History drawer pane — #3302 fix-class sweep

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -50,6 +50,7 @@ from .chrome import (
     Composer,
     MenuBar,
     StatusLine,
+    _history_option_content,
     build_drawer_pane,
     pane_payload,
     status_line_text,
@@ -477,13 +478,22 @@ class TextualChatApp(App):
         so the History drawer is cross-session by construction: restoring the
         conversation into the model is what backs this pane's past-session view
         (no separate accessor call here — reading the model is sufficient once it
-        is hydrated)."""
+        is hydrated).
+
+        **Security**: this is LLM-/user-derived conversation content reaching
+        the History drawer's ``OptionList`` — the SAME injection class as the
+        #3302 panel-label bug, just a different widget. Neutralized (ESC/
+        control strip) HERE, at the source, before the row string is even
+        assembled — the fidelity half (never a bare ``str`` handed to
+        ``OptionList``) is a SEPARATE guard at the two widget-construction
+        call sites (:func:`~reyn.interfaces.inline.textual_chat.chrome.
+        build_drawer_pane` / :meth:`_refresh_pane`), not here."""
         rows: list[str] = []
         for entry in self.conversation:
             msg = entry.item
             if msg.kind not in ("user", "reply", "agent"):
                 continue
-            body = (msg.text or "").strip()
+            body = _neutralized_label(msg.text or "").strip()
             head = body.splitlines()[0][:60] if body else ""
             role = "you" if msg.kind == "user" else "reyn"
             rows.append(f"{role} · {head}")
@@ -632,7 +642,16 @@ class TextualChatApp(App):
         """Re-derive ``tab_id``'s pane content from the current canonical sources
         and update the mounted widget in place (``OptionList`` options or the
         ``Static`` text). One snapshot read feeds BOTH the rows and the parallel
-        selection ids, so an ``OptionSelected`` maps back to the right id."""
+        selection ids, so an ``OptionSelected`` maps back to the right id.
+
+        The History tab's rows get the SAME ``Content``-literal fidelity wrap
+        :func:`~reyn.interfaces.inline.textual_chat.chrome.build_drawer_pane`
+        applies at initial ``compose`` time (:func:`~reyn.interfaces.inline.
+        textual_chat.chrome._history_option_content`) — this refresh path is a
+        SEPARATE call site from that initial build (``OptionList.add_options``
+        vs the constructor), so it needs its own, independently-verified wrap;
+        the row TEXT itself is already neutralized upstream, in
+        :meth:`_history_turns`."""
         snap = self._snapshot()
         rows = self._pane_rows(tab_id, snap)
         self._pane_selection_ids[tab_id] = self._selection_ids(tab_id, snap)
@@ -640,7 +659,8 @@ class TextualChatApp(App):
         if isinstance(child, OptionList):
             child.clear_options()
             if rows:
-                child.add_options(rows)
+                options = _history_option_content(rows) if tab_id == "history" else rows
+                child.add_options(options)
         elif isinstance(child, Static):
             child.update("\n".join(rows))
 

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -46,6 +46,7 @@ from typing import TYPE_CHECKING
 
 from rich.text import Text
 from textual import events
+from textual.content import Content
 from textual.message import Message
 from textual.widget import Widget
 from textual.widgets import (
@@ -159,6 +160,20 @@ _MENU_TABS: "list[tuple[str, str]]" = [
 
 #: Menu items whose pane is an interactive :class:`OptionList` picker (keyboard
 #: selection); every other tab renders as a read-only Rich :class:`Static`.
+#:
+#: **Known display limitation (Model/Agent/Menu, NOT a security gap):**
+#: ``OptionList`` markup-parses a bare ``str`` option — only the "history"
+#: tab's rows get the :func:`_history_option_content` ``Content``-literal
+#: wrap, because only History carries LLM-/user-derived conversation text
+#: (#3302 fix-class). Model/Agent/Menu rows are operator/config-derived
+#: identifiers (configured model classes, loaded agent names, the
+#: ``@slash``-registered command table) — not live conversation content, so
+#: they are NOT neutralize-relevant and are left unwrapped. If an operator
+#: ever names a model class / agent / slash command with a `[...]`-shaped
+#: substring, THAT row's display will visually corrupt (the same bracket-
+#: eating rendering quirk, not an injection risk) — a known, accepted
+#: limitation of leaving those three panes unwrapped, not a claim that they
+#: are immune to the rendering quirk.
 _LIST_PANES = frozenset({"model", "agent", "history", "menu"})
 
 #: The composer's navigation keys, co-located with the widget that OWNS them (they
@@ -193,6 +208,36 @@ def pane_is_list(tab_id: str) -> bool:
     """Whether ``tab_id``'s drawer pane is an interactive :class:`OptionList`
     picker (vs a read-only :class:`Static` readout)."""
     return tab_id in _LIST_PANES
+
+
+#: The ONE list pane whose rows are LLM-/user-derived content (recent
+#: conversation turns) rather than operator/config-derived identifiers —
+#: see :func:`_history_option_content`'s docstring for why only this tab
+#: needs the fidelity wrap.
+_USER_CONTENT_LIST_PANE = "history"
+
+
+def _history_option_content(rows: "Sequence[str]") -> list[Content]:
+    """Wrap each History-pane row in a literal :class:`~textual.content.Content`
+    — never a bare ``str`` handed to :class:`~textual.widgets.OptionList`.
+
+    ``OptionList`` markup-parses a bare ``str`` option exactly like
+    ``Static``/``RadioButton`` do (``Option.prompt`` → ``textual.visual.
+    visualize(..., markup=True)`` by default, unset here) — the SAME
+    ``#3302`` bracket-eating class, just reached through a different widget.
+    History rows are the one drawer pane whose text is conversation content
+    (:func:`~reyn.interfaces.inline.textual_chat.app.TextualChatApp.
+    _history_turns`, already neutralized — ESC/control strip — at that
+    source), so ONLY this pane needs the wrap; Model/Agent/Menu rows are
+    operator/config-derived identifiers (see the module docstring), not
+    live conversation text.
+
+    Two call sites need this identically — the initial build
+    (:func:`build_drawer_pane`, at ``compose`` time) and the refresh
+    (``TextualChatApp._refresh_pane``, on every drawer re-open) — a fresh
+    History tab was, before this fix, safe at ONE of those and broken at
+    the other depending on which code path last touched it."""
+    return [Content(row) for row in rows]
 
 
 # ── per-pane pure formatters (registry inputs → display strings) ──────────────
@@ -349,9 +394,24 @@ def build_drawer_pane(tab_id: str, rows: "Sequence[str]") -> Widget:
     """Build the mounted drawer pane widget for ``tab_id`` from its display
     ``rows``: an :class:`OptionList` for a picker pane, a Rich :class:`Static`
     for a readout. The app rebuilds ``rows`` from a fresh snapshot on each open
-    (see :meth:`TextualChatApp._refresh_pane`)."""
+    (see :meth:`TextualChatApp._refresh_pane`).
+
+    Two rendering idioms co-exist here, deliberately NOT interchangeable:
+    the readout branch wraps in a Rich :class:`~rich.text.Text` LITERAL
+    (never markup-parsed regardless of content — Cost/Ctx/Help are always
+    internal-only figures, so this is fidelity-safe as-is); the History
+    OptionList branch wraps in :class:`~textual.content.Content`
+    (:func:`_history_option_content`) because ``OptionList`` DOES
+    markup-parse a bare ``str`` option — do not "simplify" one branch to
+    match the other, they guard against different widgets' different
+    default behaviors."""
     if pane_is_list(tab_id):
-        return OptionList(*rows, id=tab_id)
+        options = (
+            _history_option_content(rows)
+            if tab_id == _USER_CONTENT_LIST_PANE
+            else rows
+        )
+        return OptionList(*options, id=tab_id)
     return Static(Text("\n".join(rows)), id=tab_id)
 
 

--- a/tests/test_textual_chat_phase4_3273.py
+++ b/tests/test_textual_chat_phase4_3273.py
@@ -381,3 +381,133 @@ def test_phase4_wiring_imports_stay_tty_only() -> None:
     )
     assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
     assert "ISOLATION_OK" in proc.stdout, f"stdout={proc.stdout}\nstderr={proc.stderr}"
+
+
+# ── History drawer pane (#3302 fix-class): OptionList markup + neutralize ────
+# The History tab (``chrome.py``'s ``_LIST_PANES``) is the ONE drawer pane
+# whose rows are live conversation content — unlike Model/Agent/Menu
+# (operator/config-derived identifiers, out of scope — see the PR body), a
+# History row is LLM-/user-derived text reaching an ``OptionList``, which
+# markup-parses a bare ``str`` option exactly like ``Static``/``RadioButton``
+# do (verified live against the installed Textual 8.2.8:
+# ``OptionList("[y]es")`` renders as ``"es"`` — the SAME #3302 bracket-eating
+# class through a different widget). Two independent guards:
+#
+# - fidelity (``Content`` wrap, ``chrome._history_option_content``) — applied
+#   at TWO separate call sites (the initial ``build_drawer_pane`` construction
+#   at ``compose`` time, and ``TextualChatApp._refresh_pane``'s re-derive on
+#   every drawer open) — each gets its OWN witness below, so a fix landing at
+#   only one site cannot hide behind the other's green.
+# - neutralize (ESC/control strip, ``_neutralized_label``) — applied ONCE,
+#   upstream, in ``_history_turns`` — both consumers read that single output,
+#   so one witness covers both call sites for this half.
+
+
+def _history_option_plain(option_list, index: int) -> str:
+    """The rendered text of an ``OptionList`` row AFTER Textual's own
+    markup-parse (``OptionList._get_visual`` → ``textual.visual.visualize``)
+    — never ``option.prompt`` (the pre-render original, which stays intact
+    even when the render pipeline eats a bracket). Mirrors how the
+    intervention-panel tests read ``RadioButton.label.plain`` for the same
+    reason. Goes through the widget's own visual-cache accessor rather than
+    a full strip render (``OptionList._get_option_render``), which raises on
+    the currently-installed Textual/rich combination for unrelated reasons —
+    ``_get_visual(...).plain`` is the narrowest slice of the SAME production
+    call path that still observes the actual markup-parse outcome."""
+    option = option_list.get_option_at_index(index)
+    return option_list._get_visual(option).plain
+
+
+@pytest.mark.asyncio
+async def test_history_pane_initial_build_preserves_bracket_labels() -> None:
+    """Tier 1: the History pane's INITIAL build (``chrome.build_drawer_pane``,
+    the ``compose``-time call) must not markup-parse conversation text.
+
+    NON-VACUITY (falsification, verified locally): reverting ONLY
+    ``build_drawer_pane``'s ``Content`` wrap for the History tab (passing the
+    bare ``rows`` straight to ``OptionList`` unconditionally) makes this
+    assertion FAIL — ``"you · [y]es I did it"`` renders as
+    ``"you · es I did it"``, reproducing the #3302 defect through a
+    different widget. Reverting ONLY the REFRESH path's wrap (the sibling
+    test below) does NOT affect this assertion — this exercises compose-time
+    construction only, never ``_refresh_pane``."""
+    from textual.app import App, ComposeResult
+    from textual.widgets import OptionList
+
+    from reyn.interfaces.inline.textual_chat.chrome import build_drawer_pane
+
+    class _PaneHost(App):
+        def compose(self) -> ComposeResult:
+            yield build_drawer_pane("history", ["you · [y]es I did it"])
+
+    app = _PaneHost()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        ol = app.query_one(OptionList)
+        rendered = _history_option_plain(ol, 0)
+    assert rendered == "you · [y]es I did it", (
+        f"bracket-decorated History row dropped a character at initial build: {rendered!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_history_pane_refresh_preserves_bracket_labels() -> None:
+    """Tier 2: the History pane's REFRESH path (``TextualChatApp._refresh_pane``,
+    re-invoked every time the drawer is opened) must not markup-parse
+    conversation text either — a SEPARATE call site from the initial build.
+
+    NON-VACUITY (falsification, verified locally): reverting ONLY
+    ``_refresh_pane``'s ``Content`` wrap (calling ``child.add_options(rows)``
+    with the bare ``rows`` unconditionally) makes this assertion FAIL
+    identically. Reverting ONLY the INITIAL build's wrap (the sibling test
+    above) does NOT affect this assertion — opening the drawer ALWAYS
+    re-derives via ``_refresh_pane`` (``_open_drawer`` calls it
+    unconditionally), so a fix landing at only the initial-build site would
+    still leave the exploit reachable on every real open."""
+    from textual.widgets import OptionList
+
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+
+    app = TextualChatApp(
+        transport=ScriptedTransport(), read_model=_SnapshotReadModel(_SNAP)
+    )
+    app.conversation.append(OutboxMessage(kind="user", text="[y]es I did it"))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._open_drawer("history")
+        await pilot.pause()
+        ol = app.query_one("#history", OptionList)
+        rendered = _history_option_plain(ol, 0)
+    assert "[y]es I did it" in rendered, (
+        f"bracket-decorated History row dropped a character on refresh: {rendered!r}"
+    )
+
+
+def test_history_turns_neutralizes_raw_esc_osc() -> None:
+    """Tier 1: a conversation turn carrying raw terminal control sequences
+    must not leak into the History pane's row text — the SAME
+    ``core.present.guard.get_neutralizer("terminal")`` seam every other
+    #3302-class site uses. Both the initial-build and refresh consumers read
+    this SAME ``_history_turns()`` output, so this one witness covers both
+    call sites for the neutralize half (unlike fidelity, which is guarded
+    separately at each widget-construction site, above).
+
+    NON-VACUITY (falsification, verified locally): reverting ONLY the
+    ``_neutralized_label`` call in ``_history_turns`` (reading the raw
+    ``msg.text`` directly) makes this assertion FAIL — the raw ``\\x1b``
+    survives into the row string. Reverting either fidelity wrap above does
+    NOT affect this assertion — neutralize is checked here purely at the
+    string level, before any widget is involved."""
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+
+    app = TextualChatApp(
+        transport=ScriptedTransport(), read_model=_SnapshotReadModel(_SNAP)
+    )
+    payload = "\x1b[31mDANGER\x1b]0;pwn\x07"
+    app.conversation.append(OutboxMessage(kind="user", text=payload))
+    rows = app._history_turns()
+    assert rows, "the appended turn produced no History row at all"
+    blob = " ".join(rows)
+    assert "\x1b" not in blob, f"raw ESC leaked into the History row: {blob!r}"
+    assert "\x07" not in blob, f"raw BEL leaked into the History row: {blob!r}"
+    assert "DANGER" in blob


### PR DESCRIPTION
**[per-PR-coder]** — the bare-`str`-to-widget markup-parse hygiene sweep, the #3302 fix-class. Reference: #3302 (origin defect — `"[y]es"` rendered as `"es"` because Textual markup-parses a bare `str` passed to a widget).

## Enumeration (grounded from the code, not from a prior list)

Every text-to-widget/terminal site in `src/reyn/interfaces/inline/textual_chat/` (plus the shared `src/reyn/interfaces/repl/renderer.py` seam it reuses), classified by content origin and by the two required properties — **fidelity** (no markup-eating) and **neutralize** (ESC/OSC stripped at the display boundary, `core.present.guard.get_neutralizer("terminal")`):

| Site | Content origin | Fidelity | Neutralize | Status |
|---|---|---|---|---|
| `intervention_panel.py` `_tab_label`/`add_pending` — tab-bar caption | LLM prompt | `Content(...)` literal | `_neutralized_label` | already correct |
| `intervention_panel.py` `add_pending` — pane title `Static(Content(...))` | LLM prompt | `Content(...)` literal | `_neutralized_label` | already correct |
| `intervention_panel.py` `add_pending` — pane detail `Static(Content(...))` | LLM detail | `Content(...)` literal | `_neutralized_label` | already correct |
| `intervention_panel.py` `add_pending` — `RadioButton(Content(label))` choice labels | LLM choice labels | `Content(...)` literal | `_neutralized_label` | already correct |
| `sent_queue.py:139` `Static(Content(f"⧗ {label}"))` | user submission | `Content(...)` literal | `_neutralized_label` | already correct |
| `app.py` `_restore_cancelled_text` (composer restore, #3300 Y-client) | user submission (cancelled) | `TextArea.text=` (never markup-parses) | `_neutralized_label` | already correct |
| `app.py` `_handle_turn_started_event` (promote to flow entry) | user submission | `rich.Text` (never markup-parses) | `_neutralized_label` | already correct |
| `presenter.py` `_intervention_head` (flow-entry prompt/detail) | LLM prompt/detail | `rich.Text` (never markup-parses) | `_neutralized_label` | already correct |
| `chrome.py` `build_drawer_pane` **History tab**, initial `compose`-time build | recent conversation turns | bare `str` → `OptionList` markup-parses (verified live, Textual 8.2.8: `OptionList("[y]es")` → `"es"`) | none | **FIXED** (this PR) |
| `app.py` `_refresh_pane` **History tab**, `add_options` on every drawer open | recent conversation turns | same as above, separate call site | none | **FIXED** (this PR) |
| `app.py` `_history_turns` (row-text source for both sites above) | recent conversation turns | n/a | none | **FIXED** (this PR) |
| `chrome.py` Model/Agent/Menu `OptionList` panes | operator-configured model classes / loaded agent names / `@slash` registry | bare `str`, same markup-parse mechanism | n/a (not conversation content) | **out of scope**, documented as a known display-only limitation (see below) |
| `chrome.py`/`app.py` Cost/Ctx/Help `Static.update(str)` | internal formatted numbers/keybindings | bare `str` → `Static` markup-parses | n/a (never user/model content) | **out of scope** (internal-only) |
| `app.py:435` `Static("❯", id="inputgutter")`, `app.py:444` `Tab(label,...)` menubar labels | hardcoded literals | n/a | n/a | safe (no reachable input) |
| `gutter.py` `_gutter_glyph_color`/`decorate` glyphs | hardcoded single-char literals | n/a | n/a | safe |
| `presenter.py` `_body_and_background`/`_body_renderable` — the **agent reply / tool-call body** (rich Markdown/Text) | LLM reply text, tool args/results | `rich.Text`/`Markdown` (never markup-parses) | **not neutralized anywhere**, live or restored | **flagged, NOT fixed here** — see below |

### A previous list mislabelled the History-drawer site

An earlier attempt at this sweep listed `app.py:645` `child.update(...)` (a `Static`) as the History-drawer defect. That line is real but is reached only for the **Cost/Ctx/Help** tabs (internal-only content) — `chrome.py`'s `_LIST_PANES` includes `"history"`, so the History tab is built as an `OptionList` and `_refresh_pane` dispatches to it by `isinstance(child, OptionList)`, never reaching the `Static` branch for that tab. Verified by direct read of the dispatch code AND a live reproduction in this repo's installed Textual 8.2.8 (`OptionList("you · [y]es I did it")` renders as `"you · es I did it"` — `Option.prompt` → `textual.visual.visualize(..., markup=True)` by default, unset in `chrome.py`). The real defect sites are `chrome.py`'s `build_drawer_pane` (initial construction) and `app.py`'s `_refresh_pane` (`add_options` on every open) — fixed here, independently, at both call sites.

## Fix

- `chrome.py`: new `_history_option_content(rows)` wraps each History row in a `Content(...)` literal (the same idiom `Static`/`RadioButton` sites already use) — applied at `build_drawer_pane` (initial build).
- `app.py`: same wrap applied at `_refresh_pane`'s `add_options` call (a separate call site — fixing only one left the other exploitable).
- `app.py`: `_history_turns()` now runs each row's source text through `_neutralized_label` (ESC/OSC strip) before truncation — a single shared source both call sites read.
- `chrome.py`: documented, in-line, that Model/Agent/Menu OptionList rows are operator/config-derived identifiers, not conversation content — intentionally left unwrapped. **Known limitation** (not a security gap): if an operator ever names a model class / agent / slash command with a `[...]`-shaped substring, that row's *display* will corrupt the same way (a rendering quirk), not an injection risk.
- `chrome.py`: documented that the Cost/Ctx/Help `Static(Text(...))` / `Static.update(str)` idiom and the History `OptionList`/`Content` idiom are two deliberately different guards for two different widgets' default behaviors — not interchangeable.

## Out of scope (flagged, not fixed)

`presenter.py`'s generic flow-entry body path (`_body_and_background` → `_body_renderable`, shared with the plain REPL renderer in `repl/renderer.py`) renders the agent's own reply as `rich.Markdown` and tool args/results as `rich.Text` — fidelity-safe (rich renderables never markup-parse), but **never neutralized** anywhere (live or restored via `restore.py`). This is a real, pre-existing gap distinct from the #3302 bracket-eating pattern: it predates #3302, is not on the enumerated widget list this fix-class targets (`Static`/`RadioButton`/`OptionList`/`Content`), and touches a much larger surface shared by two renderers (plain REPL + Textual). Recommend a follow-up issue rather than expanding this PR's diff.

## Gates (strip-verified RED, per verification-hazards.md §10)

Three independent witnesses in `tests/test_textual_chat_phase4_3273.py`, each strip-verified alone (temporarily reverting ONLY that guard, confirming RED, then restoring — the other two stayed GREEN throughout, no cross-masking):

- `test_history_pane_initial_build_preserves_bracket_labels` — reverting `build_drawer_pane`'s `Content` wrap alone → RED (`"you · es I did it"`); the refresh test and the neutralize test stayed GREEN.
- `test_history_pane_refresh_preserves_bracket_labels` — reverting `_refresh_pane`'s `Content` wrap alone → RED identically; the initial-build test and the neutralize test stayed GREEN.
- `test_history_turns_neutralizes_raw_esc_osc` — reverting the `_neutralized_label` call in `_history_turns` alone → RED (raw `\x1b`/`\x07` present); both fidelity tests stayed GREEN.

## Test plan

- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict tests/test_textual_chat_phase4_3273.py`
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/app.py src/reyn/interfaces/inline/textual_chat/chrome.py`
- [x] `uv run python -m pytest --timeout=120 -q` targeted: all `test_textual_chat_*` files + `test_3288_3c_tui_delta_coalesce.py`, `test_3300_p2b_sentqueue_render.py`, `test_3300_p3_cancel_by_id.py`, `test_3300_y_client_cancel.py`, `test_agent_delta_no_visible_garbage_3288.py`, `test_stream_client_single_writer_boundary.py`, `test_user_submitted_render_3300.py` — all green (146 passed total across the two runs)
- [x] Manual: N/A (no user-facing behavior change beyond fixing an existing display bug — reviewed via the strip-verify REDs above instead of a manual TTY session)

No doc-drift: no `docs/` file describes the drawer/OptionList rendering mechanism (`agui-transport.md` covers only the wire-level `user_submitted`/`inbox_cancel` events, not widget rendering) — nothing to sync.
