### PR TITLE
fix(tui): restore an answered intervention as one self-contained Q→A entry — #3299 P4

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -280,17 +280,28 @@ class ReynPresenter:
         Pending (no ``_answer_label`` meta yet): the neutralized prompt head
         plus a dim ``⋯ respond in the panel below`` hint — the "◆ needs you"
         amber gutter (kind-driven) already marks the row. Resolved
-        (``_answer_label`` set by the app once the panel delivers an answer):
-        the head plus a green ``✓ answered: <label>`` line (basic — the
-        placeholder→resolved in-place churn-zero polish is P2, not built
-        here)."""
+        (``_answer_label`` set by the app once the panel delivers an answer,
+        OR by the restore projection reading a persisted answer straight off
+        history — #3299 P4): the head plus a green ``✓ answered: <label>``
+        line (basic — the placeholder→resolved in-place churn-zero polish is
+        P2, not built here). ``_answer_label`` is neutralized at THIS call
+        site — the SAME leaf-neutralization discipline ``_intervention_head``
+        already applies to ``prompt``/``detail`` (#2770) — because a matched
+        CLOSED-SET choice's label is model-supplied / untrusted the same way
+        the prompt is; a live choice answer arrives here ALREADY neutralized
+        (``InterventionPanel`` neutralizes labels at tab-build time) so this
+        is idempotent for it, but a RESTORED answer arrives RAW (persisted
+        RAW by design — neutralize only at display boundaries, never at
+        write time), making this the ONE real neutralization boundary for the
+        restore path's answer text."""
         meta = item.meta or {}
         head = _intervention_head(item)
         head_h = self._measure(head, width)
         answer = meta.get("_answer_label")
         if answer is not None:
             resolved = Text.assemble(
-                ("  ✓ answered: ", _CC_DIM), (str(answer), f"bold {_CC_DONE}")
+                ("  ✓ answered: ", _CC_DIM),
+                (_neutralized_label(str(answer)), f"bold {_CC_DONE}"),
             )
             return Presentation(height=head_h + 1, renderable=Group(head, resolved))
         hint = Text(_PENDING_HINT, style=_CC_DIM)

--- a/src/reyn/interfaces/inline/textual_chat/restore.py
+++ b/src/reyn/interfaces/inline/textual_chat/restore.py
@@ -61,6 +61,38 @@ so gutter colour and body agree either way. The ``system`` / ``summary``
 roles are Reyn-internal chrome (filtered at the LLM wire boundary), so both
 are skipped.
 
+**Answered intervention → ONE self-contained "Q→A" entry (#3299 P4).**
+``InterventionHandler.announce`` (``runtime/services/intervention_handler.py``)
+publishes an intervention's PROMPT only to the outbox — it never appends to
+history — so before this, only the ANSWER half existed in ``history.jsonl``
+(a ``role="user"`` entry stamped ``meta["intervention_id"]`` /
+``meta["intervention_kind"]`` by ``deliver_answer_to``). There was and is no
+separate "question" record to correlate the answer with, so — unlike the
+tool call/result coalesce above, which really does have two records — this
+does NOT correlate two entries: ``deliver_answer_to`` now folds the prompt
+(+ optional detail, + the resolved answer-display text — needed because a
+CLOSED-SET answer's own ``ChatMessage.content`` is an empty string; see
+``INTERVENTION_ANSWER_META_KEY``'s docstring) onto that SAME answer record
+(``INTERVENTION_PROMPT_META_KEY`` / ``INTERVENTION_DETAIL_META_KEY`` /
+``INTERVENTION_ANSWER_META_KEY``, :mod:`reyn.runtime.chat_message`). One
+history entry is already fully self-contained — this projection just reads
+it, with no join/correlation step and therefore no GUESSED-key risk (the
+#3287 / #3299 P2 defect class this arc hit twice before). It projects
+straight into the SAME ``kind="intervention"`` shape a LIVE resolved entry
+uses (``meta["prompt"]`` / ``meta["detail"]`` for the head,
+``meta["_answer_label"]`` for the "✓ answered: ..." line —
+``ReynPresenter._present_intervention_pending``'s RESOLVED branch, no
+presenter change needed), so a restored Q→A reads through the EXACT SAME
+render path — and hits the EXACT SAME neutralization boundary (the prompt /
+detail / a matched choice's label are all model-derived / untrusted; that
+presenter call site is where they get neutralized, never here) — a live
+resolved entry does. P5's out-of-order answering is safe by construction:
+each answer record carries its OWN question, so answering interventions in
+any order restores each with its correct pairing. An intervention that was
+NEVER answered leaves no history trace at all (``announce`` never appends)
+and so projects to nothing — the specified behavior (pinned by a dedicated
+test), not an accidental gap.
+
 **Recovery implication (truncate-falsify gate N/A for the typed flag too).**
 ``TOOL_STATUS_META_KEY`` is written straight into the persisted ``ChatMessage``
 at the SAME time ``content`` is (``router_loop.py``'s ``append_history_entry``
@@ -83,6 +115,9 @@ import json
 from typing import TYPE_CHECKING
 
 from reyn.runtime.chat_message import (
+    INTERVENTION_ANSWER_META_KEY,
+    INTERVENTION_DETAIL_META_KEY,
+    INTERVENTION_PROMPT_META_KEY,
     TOOL_ERROR_KIND_META_KEY,
     TOOL_ERROR_MESSAGE_META_KEY,
     TOOL_STATUS_ERROR,
@@ -177,6 +212,13 @@ def project_restored_frames(
     Oldest→newest, preserving conversation order. Mapping:
 
     - ``user`` (non-empty text)      → ``kind="user"``
+    - ``user`` carrying
+      ``meta[INTERVENTION_PROMPT_META_KEY]`` (#3299 P4) → a SINGLE
+      ``kind="intervention"`` frame (the RESOLVED Q→A shape — see the
+      dedicated docstring paragraph below), never a plain ``kind="user"``
+      row. An intervention that was never answered has no history entry at
+      all (``InterventionHandler.announce`` never appends to history) and so
+      projects to nothing — the specified behavior, not an omission.
     - ``assistant`` (non-empty text) → ``kind="agent"``
     - ``tool`` (a tool RESULT)       → a SINGLE ``kind="tool_call_started"``
       frame carrying the coalesced call+result shape (see the module
@@ -212,11 +254,46 @@ def project_restored_frames(
         if role in _SKIP_ROLES:
             continue
         if role == "user":
-            text = m.text
-            if text.strip():
+            meta = m.meta or {}
+            prompt = meta.get(INTERVENTION_PROMPT_META_KEY)
+            if prompt:
+                # #3299 P4: this history entry IS an answered intervention —
+                # ``InterventionHandler.deliver_answer_to`` folded the prompt
+                # (+ optional detail, + the resolved answer-display text) onto
+                # this SAME record (see chat_message.py's
+                # ``INTERVENTION_*_META_KEY`` docstrings — there is no
+                # separate "question" record to correlate with). Project it
+                # straight into the live ``kind="intervention"`` shape
+                # (``ReynPresenter._present_intervention_pending``'s RESOLVED
+                # branch — ``meta["prompt"]``/``meta["detail"]`` for the head,
+                # ``meta["_answer_label"]`` for the "✓ answered: ..." line) so
+                # a restored Q→A reads through the EXACT SAME render path —
+                # and the EXACT SAME neutralization boundary — a live resolved
+                # entry does. ALL THREE values are RAW here; neutralization
+                # happens only at that shared render call site, never here (a
+                # persisted record must stay the original, un-display-shaped
+                # value).  An intervention that was NEVER answered has no
+                # history trace at all (``announce`` never appends to
+                # history) — nothing to project, which is the specified
+                # behavior, not an omission.
                 frames.append(
-                    OutboxMessage(kind="user", text=text, meta={RESTORED_META_KEY: True})
+                    OutboxMessage(
+                        kind="intervention",
+                        text=str(prompt),
+                        meta={
+                            RESTORED_META_KEY: True,
+                            "prompt": prompt,
+                            "detail": meta.get(INTERVENTION_DETAIL_META_KEY),
+                            "_answer_label": meta.get(INTERVENTION_ANSWER_META_KEY, ""),
+                        },
+                    )
                 )
+            else:
+                text = m.text
+                if text.strip():
+                    frames.append(
+                        OutboxMessage(kind="user", text=text, meta={RESTORED_META_KEY: True})
+                    )
         elif role == "assistant":
             text = m.text
             if text.strip():

--- a/src/reyn/runtime/chat_message.py
+++ b/src/reyn/runtime/chat_message.py
@@ -33,6 +33,50 @@ TOOL_STATUS_ERROR = "error"
 TOOL_ERROR_KIND_META_KEY = "error_kind"
 TOOL_ERROR_MESSAGE_META_KEY = "error_message"
 
+# #3299 P4: the intervention PROMPT + resolved ANSWER, stamped on the
+# ``role="user"`` history entry ``InterventionHandler.deliver_answer_to``
+# already appends (mirroring ``intervention_id`` / ``intervention_kind``
+# alongside it). ``InterventionHandler.announce`` never writes to history —
+# it only publishes to the outbox — so before this, the QUESTION half of an
+# answered intervention did not exist anywhere in ``history.jsonl``; the TUI
+# restore projection (``interfaces/inline/textual_chat/restore.py``) could
+# not show it after a restart. Rather than inventing a correlation key to
+# join a separate prompt record (there is no such record, and P5's
+# out-of-order answering makes any GUESSED key a repeat of the #3287/#3299 P2
+# "guessed correlation key" defect class), the prompt is folded onto the
+# SAME answer record — one history entry is now fully self-contained, no
+# correlation needed at all.
+#
+# ★Untrusted / RAW (#2770 discipline: "the single truth is RAW, neutralize at
+# each display boundary"): ``ask_user`` prompts/suggestions come straight
+# from a model tool-call, and a selected CHOICE's label is one of those
+# model-supplied options too. These three values are stored EXACTLY as
+# ``UserIntervention`` carried them (no neutralization at write time) — a
+# consumer (restore projection, any future surface) MUST neutralize before
+# rendering, never persist a display-shaped (already-neutralized) copy, or
+# the audit/restore record stops being the original. The live TUI path's
+# equivalent leaf (``intervention_handler._neutralize_terminal`` /
+# ``presenter._neutralized_label``) neutralizes at ITS OWN render call site,
+# not at persist time — this mirrors that discipline for the restore path.
+#
+# These NEVER reach the LLM: ``RouterHistoryBuffer._serialise_turn`` builds
+# the wire dict from ``role`` / ``content`` / ``tool_calls`` / ``tool_call_id``
+# / ``name`` (+ the ``reasoning`` meta sub-key) only — arbitrary ``meta`` keys
+# (these three included) are never copied into the payload. So this addition
+# costs zero LLM context / tokens; it only grows the PERSISTED
+# ``history.jsonl`` (something that was already visible via the outbox
+# ``announce`` — this makes it durable, not newly exposed).
+INTERVENTION_PROMPT_META_KEY = "intervention_prompt"
+INTERVENTION_DETAIL_META_KEY = "intervention_detail"
+#: The resolved answer's DISPLAY text — a matched CHOICE's ``label`` (model-
+#: supplied, RAW/untrusted) or the raw free-text answer. Needed because a
+#: choice-selected answer's own ``ChatMessage.content`` is an EMPTY string
+#: (``InterventionHandler.deliver_answer_to`` passes ``text=""`` through the
+#: choice-id-override path — the choice id, not a label, is what the wire
+#: transport carries) — so ``m.text`` alone cannot reconstruct "what was
+#: answered" for a closed-set intervention; this key always carries it.
+INTERVENTION_ANSWER_META_KEY = "intervention_answer"
+
 
 @dataclass(init=False)
 class ChatMessage:

--- a/src/reyn/runtime/services/intervention_handler.py
+++ b/src/reyn/runtime/services/intervention_handler.py
@@ -20,6 +20,11 @@ from contextvars import ContextVar
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
+from reyn.runtime.chat_message import (
+    INTERVENTION_ANSWER_META_KEY,
+    INTERVENTION_DETAIL_META_KEY,
+    INTERVENTION_PROMPT_META_KEY,
+)
 from reyn.runtime.outbox import OutboxMessage
 from reyn.user_intervention import (
     InterventionAnswer,
@@ -286,12 +291,28 @@ class InterventionHandler:
         if external_source and self._threat_scan is not None:
             from reyn.security.content_guard import fence_if_enabled
             history_text = fence_if_enabled(text, self._threat_scan)
+        # #3299 P4: fold the QUESTION + resolved answer-display-text onto this
+        # SAME history record (see INTERVENTION_*_META_KEY docstrings in
+        # chat_message.py) — ``announce`` never appends to history, so this is
+        # the ONLY place the prompt can be persisted, and a self-contained
+        # record needs no correlation key even under P5's out-of-order
+        # answering. RAW (untrusted) — neutralize at the display boundary,
+        # never here. ``answer_label`` mirrors the ``display_text`` computed
+        # below (a matched choice's label, else the raw answer text) because a
+        # choice-selected answer's OWN ``history_text`` is empty (the
+        # choice-id-override path passes ``text=""``) — this key is the only
+        # place "what was answered" survives for a closed-set intervention.
+        answer_label = choice.label if choice is not None else text
         meta = {
             "answered_actor": iv.actor or "",
             "answered_run_id": iv.run_id or "",
             "intervention_id": iv.id,
             "intervention_kind": iv.kind,
+            INTERVENTION_PROMPT_META_KEY: iv.prompt,
+            INTERVENTION_ANSWER_META_KEY: answer_label,
         }
+        if iv.detail:
+            meta[INTERVENTION_DETAIL_META_KEY] = iv.detail
         if external_source:
             # #1827 S4: seam-agnostic untrusted-source taint marker. While this
             # external (A2A / webhook peer) answer is live in context, the agent

--- a/tests/test_3299_p4_intervention_restore_qa.py
+++ b/tests/test_3299_p4_intervention_restore_qa.py
@@ -1,0 +1,401 @@
+"""#3299 P4: a restored answered intervention shows the question AND the
+answer as ONE self-contained flow entry.
+
+**Design (owner-ratified in the issue thread — do not re-litigate).**
+``InterventionHandler.announce`` publishes an intervention's PROMPT only to
+the outbox; it never appends to history. So before this PR, only the ANSWER
+half existed in ``history.jsonl`` — there was, and is, no separate "question"
+record for a restore projection to correlate the answer with (unlike the
+#3295 tool call/result coalesce, which really does have two records). The
+approved fix (C) is NOT correlation: ``InterventionHandler.deliver_answer_to``
+now folds the prompt (+ optional detail, + the resolved answer-display text)
+onto the SAME answer record it already appends
+(``INTERVENTION_PROMPT_META_KEY`` / ``INTERVENTION_DETAIL_META_KEY`` /
+``INTERVENTION_ANSWER_META_KEY``, :mod:`reyn.runtime.chat_message`) — one
+history entry is already self-contained, so restore needs no correlation key
+at all (the #3287 / #3299 P2 "guessed key" defect class this arc hit twice).
+
+The persisted values are RAW (untrusted / LLM-derived — ``ask_user``
+prompts/suggestions and a matched choice's label all come from a model
+tool-call); neutralization happens ONLY at the display boundary
+(``ReynPresenter._present_intervention_pending``), never at persist time.
+
+Gates (mirroring the issue's gate list, each strip-falsified independently):
+
+1. One flow entry per answered intervention (not two).
+2. Both Q and A are present in that entry's rendered content.
+3. The LLM payload is byte-identical whether or not the new meta keys are
+   present (``RouterHistoryBuffer.build_history`` never copies arbitrary
+   ``meta`` into the wire dict).
+4. Correct Q/A pairing when several interventions are answered OUT OF ORDER
+   (P5's tabbed panel allows this) — each restored entry shows its OWN
+   question, never another's (self-contained records make mis-pairing
+   structurally impossible, no correlation step to get wrong).
+5. An unanswered intervention leaves ZERO trace in the restored flow — the
+   *specified* behavior (``announce`` never writes history), pinned so a
+   future change cannot start fabricating a half-entry.
+6. Restore-boundary neutralization — raw ESC/OSC in the persisted prompt /
+   detail / answer must not reach the rendered entry. Two independent call
+   sites (``_intervention_head`` for prompt/detail, the resolved-line
+   neutralize for the answer) — each has its own falsification note below.
+
+All tests use real ``ChatMessage`` / ``OutboxMessage`` / ``ReynPresenter``
+instances (module 1-6) plus a real, fully-wired ``InterventionHandler`` +
+``InterventionRegistry`` + ``SnapshotJournal`` (module 7 — the producer-side
+round trip proving the fixture the projection tests assume actually matches
+what the real handler writes) — no mocks, per the testing policy.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from rich.console import Console
+
+from reyn.core.events.event_store import EventStore
+from reyn.core.events.events import EventLog
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.inline.textual_chat.presenter import ReynPresenter
+from reyn.interfaces.inline.textual_chat.restore import project_restored_frames
+from reyn.runtime.chat_message import (
+    INTERVENTION_ANSWER_META_KEY,
+    INTERVENTION_DETAIL_META_KEY,
+    INTERVENTION_PROMPT_META_KEY,
+    ChatMessage,
+)
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.services.intervention_handler import InterventionHandler
+from reyn.runtime.services.intervention_registry import InterventionRegistry
+from reyn.runtime.services.snapshot_journal import SnapshotJournal
+from reyn.user_intervention import InterventionChoice, UserIntervention
+from tests._support.session import make_session as _make_router_session
+
+_ESC_OSC_PAYLOAD = "\x1b[31mRED\x1b]0;pwn\x07"
+
+
+def _render(msg: OutboxMessage) -> str:
+    """Render ``msg`` through the SAME presenter path a live/restored
+    intervention entry uses, returning the plain rendered text."""
+    presentation = ReynPresenter()._present_intervention_pending(msg, 80)
+    console = Console(width=80, no_color=True)
+    with console.capture() as cap:
+        console.print(presentation.renderable)
+    return cap.get()
+
+
+def _answered_message(
+    *, iv_id: str, prompt: str, answer: str, detail: str = "",
+) -> ChatMessage:
+    """A ``role='user'`` history entry shaped exactly like
+    ``InterventionHandler.deliver_answer_to``'s append (module docstring)."""
+    meta = {
+        "answered_actor": "demo",
+        "answered_run_id": "rA",
+        "intervention_id": iv_id,
+        "intervention_kind": "ask_user",
+        INTERVENTION_PROMPT_META_KEY: prompt,
+        INTERVENTION_ANSWER_META_KEY: answer,
+    }
+    if detail:
+        meta[INTERVENTION_DETAIL_META_KEY] = detail
+    # A choice-selected answer's OWN content is "" (deliver_answer_to passes
+    # text="" through the choice-id-override path) — modeled here too so the
+    # fixture matches BOTH the free-text and closed-set producer shapes.
+    return ChatMessage(role="user", content="", meta=meta)
+
+
+# ── Gate 1 + 2: one entry, both Q and A present ──────────────────────────────
+
+
+def test_restored_answered_intervention_is_one_entry_with_both_qa() -> None:
+    """Tier 1: a single answered-intervention history record projects to
+    EXACTLY ONE ``kind="intervention"`` frame (never two, never a bare
+    ``kind="user"`` echo of the empty answer text) whose rendered content
+    contains BOTH the question and the answer.
+
+    NON-VACUITY: before this PR, ``project_restored_frames`` had no
+    ``INTERVENTION_PROMPT_META_KEY`` branch at all — this message would have
+    fallen through to the plain ``role == "user"`` case and rendered as an
+    EMPTY row (``m.text == ""`` for a choice-style answer), losing BOTH the
+    question and the answer. Verified locally by reverting the ``if prompt:``
+    branch in ``restore.py``: the assertions below flip RED (no
+    ``kind="intervention"`` frame is produced at all)."""
+    msgs = [_answered_message(iv_id="iv-1", prompt="Proceed with deploy?", answer="Yes")]
+    frames = [f for f in project_restored_frames(msgs) if f.kind != "system"]
+    assert [f.kind for f in frames] == ["intervention"], (
+        f"expected exactly one intervention entry, got kinds={[f.kind for f in frames]}"
+    )
+
+    rendered = _render(frames[0])
+    assert "Proceed with deploy?" in rendered, f"question missing from render: {rendered!r}"
+    assert "Yes" in rendered, f"answer missing from render: {rendered!r}"
+
+
+def test_restored_free_text_answer_also_one_entry_with_both_qa() -> None:
+    """Tier 1: the free-text answer path (non-empty ``content``) is ALSO
+    folded into one entry — the new meta keys are read even though
+    ``m.text`` itself is non-empty for this path (the branch is keyed on
+    ``INTERVENTION_PROMPT_META_KEY`` presence, not on whether ``m.text`` is
+    empty)."""
+    msg = ChatMessage(
+        role="user",
+        content="Tokyo",
+        meta={
+            "intervention_id": "iv-2",
+            "intervention_kind": "ask_user",
+            INTERVENTION_PROMPT_META_KEY: "Which city?",
+            INTERVENTION_ANSWER_META_KEY: "Tokyo",
+        },
+    )
+    frames = [f for f in project_restored_frames([msg]) if f.kind != "system"]
+    assert [f.kind for f in frames] == ["intervention"], (
+        f"expected exactly one intervention entry, got kinds={[f.kind for f in frames]}"
+    )
+    rendered = _render(frames[0])
+    assert "Which city?" in rendered
+    assert "Tokyo" in rendered
+
+
+# ── Gate 3: LLM payload unchanged ────────────────────────────────────────────
+
+
+def test_llm_payload_unchanged_by_new_intervention_meta_keys(tmp_path: Path) -> None:
+    """Tier 2: ``RouterHistoryBuffer.build_history`` (the actual wire-dict
+    builder RouterLoop sends to the provider) produces a BYTE-IDENTICAL
+    result whether or not the history carries the new
+    ``INTERVENTION_PROMPT_META_KEY`` / ``INTERVENTION_DETAIL_META_KEY`` /
+    ``INTERVENTION_ANSWER_META_KEY`` meta — the owner's cost/context
+    invariant this whole design hinges on.
+
+    NON-VACUITY (verified locally): temporarily making
+    ``RouterHistoryBuffer._serialise_turn`` copy ``m.meta`` wholesale into the
+    wire dict (``msg["meta"] = m.meta``) flips this RED — the enriched
+    history's wire dicts then differ from the baseline's. Reverted after
+    confirming RED; the shipped code never does this."""
+    bare_meta = {
+        "answered_actor": "demo", "answered_run_id": "rA",
+        "intervention_id": "iv-1", "intervention_kind": "ask_user",
+    }
+    enriched_meta = {
+        **bare_meta,
+        INTERVENTION_PROMPT_META_KEY: "Proceed with deploy?",
+        INTERVENTION_DETAIL_META_KEY: "irreversible",
+        INTERVENTION_ANSWER_META_KEY: "Yes",
+    }
+
+    session_bare = _make_router_session(tmp_path / "bare")
+    session_bare.history.append(ChatMessage(role="user", content="", meta=bare_meta))
+    session_bare.history.append(ChatMessage(role="assistant", content="Deploying now."))
+    bare_payload = session_bare._history_buffer.build_history()
+
+    session_enriched = _make_router_session(tmp_path / "enriched")
+    session_enriched.history.append(ChatMessage(role="user", content="", meta=enriched_meta))
+    session_enriched.history.append(ChatMessage(role="assistant", content="Deploying now."))
+    enriched_payload = session_enriched._history_buffer.build_history()
+
+    assert bare_payload == enriched_payload, (
+        "LLM wire payload must be byte-identical regardless of the new "
+        f"intervention meta keys; bare={bare_payload!r} enriched={enriched_payload!r}"
+    )
+
+
+# ── Gate 4: correct pairing under out-of-order answers ───────────────────────
+
+
+def test_out_of_order_answers_each_restore_with_their_own_question() -> None:
+    """Tier 1: P5's tabbed panel lets interventions be answered in ANY order.
+    Persist two dispatched interventions' answer records in REVERSE order
+    (B answered before A, i.e. B's history entry comes first) and confirm
+    each restored entry shows its OWN question, never the other's — the
+    self-contained-record design makes mis-pairing structurally impossible
+    (there is no correlation step to get wrong)."""
+    msgs = [
+        _answered_message(iv_id="iv-B", prompt="Delete branch B?", answer="No"),
+        _answered_message(iv_id="iv-A", prompt="Delete branch A?", answer="Yes"),
+    ]
+    frames = [f for f in project_restored_frames(msgs) if f.kind != "system"]
+    assert [f.kind for f in frames] == ["intervention", "intervention"], (
+        f"expected exactly two intervention entries, got kinds={[f.kind for f in frames]}"
+    )
+    first, second = (_render(f) for f in frames)
+    assert "Delete branch B?" in first and "No" in first
+    assert "Delete branch A?" in second and "Yes" in second
+    # Cross-contamination would show up as the WRONG pairing:
+    assert "Delete branch A?" not in first
+    assert "Delete branch B?" not in second
+
+
+# ── Gate 5: unanswered intervention leaves zero trace ────────────────────────
+
+
+def test_unanswered_intervention_has_no_restored_trace() -> None:
+    """Tier 1: an intervention that was announced but never answered has NO
+    history entry at all (``InterventionHandler.announce`` never appends to
+    history) — so the restore projection shows nothing for it. This is the
+    SPECIFIED behavior (pinned here so a future change cannot start
+    fabricating a half-entry for it), not an accidental gap. Only the
+    surrounding, unrelated conversation turns are restored."""
+    msgs = [
+        ChatMessage(role="user", content="before"),
+        ChatMessage(role="assistant", content="ack"),
+        # No entry at all for the never-answered intervention.
+        ChatMessage(role="user", content="after"),
+    ]
+    frames = [f for f in project_restored_frames(msgs) if f.kind != "system"]
+    kinds = [f.kind for f in frames]
+    assert "intervention" not in kinds
+    assert kinds == ["user", "agent", "user"]
+
+
+def test_pre_p4_answer_record_without_prompt_meta_falls_back_gracefully() -> None:
+    """Tier 1: backward compat — a PRE-P4 persisted answer record (has
+    ``intervention_id``/``intervention_kind`` but none of the new
+    ``INTERVENTION_*_META_KEY`` keys, since it predates this PR) must not
+    crash and must not fabricate a question. It falls through to the
+    pre-existing plain ``user`` projection (empty text → no frame at all,
+    identical to today's existing behavior for a closed-set answer)."""
+    msg = ChatMessage(
+        role="user", content="",
+        meta={
+            "answered_actor": "demo", "answered_run_id": "rA",
+            "intervention_id": "iv-old", "intervention_kind": "ask_user",
+        },
+    )
+    frames = [f for f in project_restored_frames([msg]) if f.kind != "system"]
+    assert frames == []
+
+
+# ── Gate 6: restore-boundary neutralization (two independent sites) ─────────
+
+
+def test_restore_prompt_and_detail_neutralized_at_render() -> None:
+    """Tier 2c: a RAW ESC/OSC payload in the persisted prompt/detail must not
+    reach the rendered entry — neutralized at ``_intervention_head``'s call
+    site (``presenter.py``), the SAME site the live panel's prompt/detail
+    rendering already uses (#2770).
+
+    NON-VACUITY: verified locally by reverting ONLY ``_intervention_head``'s
+    ``_neutralized_label`` calls around ``prompt``/``detail`` — the raw
+    ``\\x1b`` then leaks into the rendered head and this assertion flips RED.
+    Reverting the ANSWER-label neutralize (the other site, see the next test)
+    does NOT affect this assertion."""
+    msgs = [_answered_message(
+        iv_id="iv-3", prompt=_ESC_OSC_PAYLOAD, answer="ack", detail=_ESC_OSC_PAYLOAD,
+    )]
+    frames = [f for f in project_restored_frames(msgs) if f.kind != "system"]
+    rendered = _render(frames[0])
+    assert "\x1b" not in rendered, f"raw ESC leaked into restored head: {rendered!r}"
+    assert "\x07" not in rendered, f"raw BEL leaked into restored head: {rendered!r}"
+    assert "RED" in rendered
+
+
+def test_restore_answer_label_neutralized_at_render() -> None:
+    """Tier 2c: a RAW ESC/OSC payload in the persisted ANSWER (e.g. a
+    selected closed-set choice's model-supplied label) must not reach the
+    rendered "✓ answered: ..." line — neutralized at
+    ``_present_intervention_pending``'s resolved-line call site, added by
+    this PR.
+
+    NON-VACUITY: verified locally by reverting ONLY the
+    ``_neutralized_label(str(answer))`` call this PR adds around the answer
+    (restoring the old ``str(answer)`` passthrough) — the raw ``\\x1b`` then
+    leaks into the rendered resolved line and this assertion flips RED.
+    Reverting the prompt/detail neutralize (the other site, previous test)
+    does NOT affect this assertion — the payload here lives in ``answer``,
+    not ``prompt``/``detail``, which stay plain."""
+    msgs = [_answered_message(
+        iv_id="iv-4", prompt="Proceed?", answer=_ESC_OSC_PAYLOAD,
+    )]
+    frames = [f for f in project_restored_frames(msgs) if f.kind != "system"]
+    rendered = _render(frames[0])
+    assert "\x1b" not in rendered, f"raw ESC leaked into restored answer line: {rendered!r}"
+    assert "\x07" not in rendered, f"raw BEL leaked into restored answer line: {rendered!r}"
+    assert "RED" in rendered
+
+
+# ── Producer round trip: the real InterventionHandler writes this exact shape ─
+
+
+def _build_handler(tmp_path: Path) -> tuple[InterventionHandler, InterventionRegistry, list]:
+    """A real, fully-wired InterventionHandler + InterventionRegistry +
+    SnapshotJournal (mirrors ``test_intervention_handler_invariants.py``'s
+    ``_build_handler`` — no mocks). Returns ``(handler, registry,
+    history_items)`` where ``history_items`` collects the exact
+    ``(role, text, ts, meta)`` tuples ``_append_history`` receives."""
+    state_log = StateLog(tmp_path / "state.wal")
+    event_store = EventStore(tmp_path / "events")
+    event_log = EventLog(subscribers=[event_store])
+    journal = SnapshotJournal(
+        agent_name="test_agent", snapshot_path=tmp_path / "snap.json", state_log=state_log,
+    )
+    history_items: list[dict] = []
+
+    async def _put_outbox(msg: OutboxMessage) -> None:
+        pass
+
+    def _append_history(role: str, text: str, ts: str, meta: dict) -> None:
+        history_items.append({"role": role, "text": text, "ts": ts, "meta": meta})
+
+    handler_ref: list[InterventionHandler] = []
+
+    async def _on_announce(iv: UserIntervention) -> None:
+        if handler_ref:
+            await handler_ref[0].announce(iv)
+
+    registry = InterventionRegistry(on_announce=_on_announce)
+    handler = InterventionHandler(
+        intervention_registry=registry, journal=journal, event_log=event_log,
+        put_outbox=_put_outbox, append_history=_append_history,
+    )
+    handler_ref.append(handler)
+    return handler, registry, history_items
+
+
+@pytest.mark.asyncio
+async def test_producer_closed_set_answer_round_trips_through_restore(tmp_path: Path) -> None:
+    """Tier 2: end-to-end — dispatch a REAL closed-set intervention through
+    the REAL ``InterventionHandler``, answer it by ``choice_id_override``
+    (the panel's delivery path), and feed the resulting ``history_items``
+    entry (recast as a ``ChatMessage``, exactly as ``Session._append_history``
+    would persist it) straight into ``project_restored_frames``. Proves the
+    fixture the projection-only tests above assume is not a guess — it is
+    what the real producer writes, including for the CLOSED-SET path where
+    ``ChatMessage.content`` is empty and the answer only survives via
+    ``INTERVENTION_ANSWER_META_KEY``."""
+    handler, registry, history_items = _build_handler(tmp_path)
+    iv = UserIntervention(
+        kind="ask_user",
+        prompt="Delete the branch?",
+        run_id="run-1",
+        choices=[
+            InterventionChoice(id="yes", label="Yes", hotkey="y"),
+            InterventionChoice(id="no", label="No", hotkey="n"),
+        ],
+    )
+    dispatch_task = asyncio.ensure_future(handler.dispatch(iv))
+    from _async_wait import wait_until  # noqa: E402 — shared #1751 test wait helper
+    await wait_until(lambda: bool(registry.list_active()))
+
+    resolved = await handler.deliver_answer_to(iv, "", choice_id_override="yes")
+    assert resolved is True
+    await asyncio.gather(dispatch_task, return_exceptions=True)
+
+    assert [h["role"] for h in history_items] == ["user"], (
+        f"expected exactly one appended history entry, got {history_items!r}"
+    )
+    entry = history_items[0]
+    assert entry["meta"][INTERVENTION_PROMPT_META_KEY] == "Delete the branch?"
+    assert entry["meta"][INTERVENTION_ANSWER_META_KEY] == "Yes"
+    # The closed-set path's OWN history text is empty — confirming the
+    # fixture used above (``content=""``) matches production.
+    assert entry["text"] == ""
+
+    msg = ChatMessage(role=entry["role"], content=entry["text"], meta=entry["meta"])
+    frames = [f for f in project_restored_frames([msg]) if f.kind != "system"]
+    assert [f.kind for f in frames] == ["intervention"], (
+        f"expected exactly one intervention entry, got kinds={[f.kind for f in frames]}"
+    )
+    rendered = _render(frames[0])
+    assert "Delete the branch?" in rendered
+    assert "Yes" in rendered


### PR DESCRIPTION
**[per-PR-coder]** — Phase 4 (final phase) of the intervention-out-of-FlowView arc (#3299): a restored answered intervention now shows the question AND the answer as ONE flow entry, not two (and not a blank/missing one).

Closes #3299

## Design (settled in the issue thread — architect + owner, do not re-litigate)

The original plan ("correlate the prompt record with the answer record, like #3295's tool call/result coalesce") turned out to be **impossible**: `InterventionHandler.announce` publishes the prompt to the outbox but never calls `_append_history` — the question text was never in `history.jsonl` at all. Only the answer was (a `role="user"` entry stamped `meta["intervention_id"]` / `meta["intervention_kind"]`).

**Approved fix (C)**: store the prompt on the **answer record's own `meta`**, so one history entry is self-contained — no correlation key needed at all (this arc hit the "guessed key" defect three times: #3299 P2 head-of-queue, #3287 text-matching, #3300). Self-contained records are also safe under P5's out-of-order answering (each answer carries its own question).

## What changed

- **`src/reyn/runtime/chat_message.py`**: three new meta-key constants, `INTERVENTION_PROMPT_META_KEY` (`"intervention_prompt"`), `INTERVENTION_DETAIL_META_KEY` (`"intervention_detail"`), `INTERVENTION_ANSWER_META_KEY` (`"intervention_answer"`) — mirroring the existing `TOOL_STATUS_META_KEY` pattern. `INTERVENTION_ANSWER_META_KEY` exists because a **closed-set** answer's own `ChatMessage.content` is `""` (the panel's `choice_id_override` path passes `text=""`) — so `m.text` alone can't reconstruct "what was answered" for that path; this key always carries the resolved answer-display text (a matched choice's `label`, or the raw free-text answer).
- **`src/reyn/runtime/services/intervention_handler.py`**: `InterventionHandler.deliver_answer_to` now stamps all three keys onto the SAME history record it already appends. RAW values (untrusted / LLM-derived — `ask_user` prompts and a matched choice's label both come from a model tool-call) — no neutralization at write time.
- **`src/reyn/interfaces/inline/textual_chat/restore.py`**: `project_restored_frames`'s `role == "user"` branch now checks for `INTERVENTION_PROMPT_META_KEY` first; when present, it projects straight into the SAME `kind="intervention"` shape a live resolved entry uses (`meta["prompt"]`/`meta["detail"]` for the head, `meta["_answer_label"]` for the "✓ answered: ..." line) — no presenter change needed for the shape, and no correlation/join step. Absent (pre-P4 history, or non-intervention `user` turns) → falls through to the pre-existing plain-`user` projection, unchanged.
- **`src/reyn/interfaces/inline/textual_chat/presenter.py`**: `ReynPresenter._present_intervention_pending`'s RESOLVED branch now neutralizes `_answer_label` at its render call site (previously only `prompt`/`detail` were neutralized there). This is idempotent for the LIVE path (a closed-set answer's label is already neutralized when the panel builds it; free-text is the user's own trusted input) but is the ONE real neutralization boundary for a RESTORED answer, which arrives RAW by design.

## Gates (each strip-falsified locally, observed RED, then reverted — `tests/test_3299_p4_intervention_restore_qa.py`)

1. **One entry per intervention** — `test_restored_answered_intervention_is_one_entry_with_both_qa` / `_free_text_...` / `_out_of_order_...` / `_producer_closed_set_...`. Strip: force `restore.py`'s `prompt` lookup to always be falsy (simulating "the branch doesn't exist") → all four RED (`[]` frames instead of `["intervention"]`).
2. **Both Q and A present** — same tests, rendered-text assertions.
3. **LLM payload unchanged** — `test_llm_payload_unchanged_by_new_intervention_meta_keys`: two real `Session`s' `_history_buffer.build_history()` outputs compared, with/without the new meta keys. Strip: made `RouterHistoryBuffer._serialise_turn` copy `m.meta` wholesale into the wire dict → RED (payloads differ). Reverted; `_serialise_turn` never touches arbitrary meta in the shipped code.
4. **Correct pairing under out-of-order answers** — `test_out_of_order_answers_each_restore_with_their_own_question`: two interventions' answer records persisted in reverse dispatch order; each restored entry shows its own Q/A, never the other's (falls out of the self-contained-record design — verified same strip as gate 1).
5. **Unanswered intervention leaves zero trace** — `test_unanswered_intervention_has_no_restored_trace` (pinned as specified behavior) + `test_pre_p4_answer_record_without_prompt_meta_falls_back_gracefully` (backward-compat: an old-shape answer record with no new meta keys degrades to the pre-existing behavior, no crash).
6. **★Restore-boundary neutralization, two independent sites**:
   - `test_restore_prompt_and_detail_neutralized_at_render` — strip: revert `_intervention_head`'s two `_neutralized_label` calls → RED (raw ESC leaks); the answer-label test is unaffected by this strip (independent site confirmed).
   - `test_restore_answer_label_neutralized_at_render` — strip: revert the answer's `_neutralized_label` call (this PR's addition) → RED; the prompt/detail test is unaffected by this strip.

All strips were applied to the actual source (not test doubles), observed RED, then reverted — confirmed via `git diff --stat` showing zero residual diff in the stripped files before final commit.

## Producer/fixture parity

`test_producer_closed_set_answer_round_trips_through_restore` builds a real `InterventionHandler` + `InterventionRegistry` + `SnapshotJournal` (no mocks), dispatches a real closed-set intervention, answers it via `choice_id_override` (the panel's actual delivery path), and feeds the REAL resulting history-append call's output straight into `project_restored_frames` — proving the fixtures the other tests use aren't a guess, they match what the real producer writes (including the empty-`content` closed-set case).

## Doc-drift check

Re-read `restore.py`'s whole module docstring (not just the touched lines) and added a dedicated section describing the new mapping + rationale, since the surrounding "Coalesced, resolved, never RUNNING" section no longer told the whole story once interventions got their own non-correlated coalesce path. Also updated the function docstring's per-role mapping list. Searched `docs/` (en + ja) for any doc enumerating the intervention-answer meta schema as closed or claiming prompts are "outbox only" / "never persisted" — none found; `docs/reference/runtime/agui-transport.md`'s `reyn.display.user` meta description was already non-exhaustive (doesn't claim a closed key list), so it stays accurate. No other doc changes needed.

## CI gates (all run locally, foreground)

- `ruff check src tests` — clean.
- `python scripts/test_tier_audit.py --strict tests/test_3299_p4_intervention_restore_qa.py` — 9/9 OK, 0 Tier-4, 0 warnings.
- `uv run python -m pytest --timeout=120 -q tests/test_3299_p4_intervention_restore_qa.py tests/test_textual_chat_phase5_3273.py tests/test_textual_chat_intervention_panel_3299.py tests/test_intervention_handler_invariants.py tests/test_intervention_restore.py` plus a broader targeted sweep across intervention/history/compaction-adjacent test files (86 + 163 tests across two runs) — all green.
- `python scripts/verify_module_docstrings.py` on the 4 changed src files — OK.
- Full suite is CI's job per policy (shared machine) — not run locally beyond the targeted sweep above.

## Test plan

- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict tests/test_3299_p4_intervention_restore_qa.py`
- [x] Targeted `pytest --timeout=120` sweep (intervention / restore / history-buffer / chat_message tests) — all green
- [x] `python scripts/verify_module_docstrings.py` on changed src files
- [x] Manual: each gate strip-falsified locally, RED observed, reverted before commit (see gate list above)