### PR TITLE
feat(runtime): session_attached switch-barrier chat-event — #3310 N1

### DIFF
--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -123,6 +123,40 @@ renderable display kinds):
   fail-safe for a future tap-point change, not a live wire kind. (Remote
   attach-label sync is designed separately, not via this legacy sentinel.)
 
+#### The session-switch barrier (`reyn.event.session_attached`, #3310 N1)
+
+`/attach <name>` and `/session switch <sid>` both flip which session's frames
+reach a client — but historically nothing told the client THAT a switch had
+happened (the old Textual TUI's header re-post was deleted as dead code; see
+the control-sentinel dispositions above). `AgentRegistry.attach`/
+`attach_session` now emit a `session_attached` chat-event carrying
+`{agent, session_id}` — the identity a client keys its display/reset cache on
+— as an `EventFrame` put DIRECTLY on `repl_outbox` (`registry.py`, the
+`_announce_session_attached` helper), never routed through the just-swapped
+session's own chat-events.
+
+The barrier property is the point: the `self._attached = key` flip and the
+`repl_outbox.put_nowait(...)` happen with NO `await` in between (both are
+plain synchronous statements). A single event loop can never interleave
+inside that synchronous region, so on the `repl_outbox` FIFO "before this
+frame = old session's frames, after = new session's frames" holds BY
+CONSTRUCTION, not merely by convention — mirroring the no-await
+critical-section idiom `Session.cancel_queued` uses (#3300 Y-server /
+#3306). `InProcessTransport._pump_outbox` passes an `EventFrame` already on
+`repl_outbox` through unchanged (never re-wraps it as a `DisplayFrame`).
+
+This event is NOT an `OutboxMessage` display kind — the owner-ratified reason
+is the same as #3288 ③b's `agent_delta`: a state transition rides an `EventFrame`
+(opt-in draw — a surface with no handler drops it silently, never a garbage
+row), where registering a closed-vocabulary display kind for it would be a
+category error. As of this PR the client-side reset (a per-session display
+cache the client swaps on this barrier) is NOT yet implemented — that is N2,
+a separate PR — and the AG-UI/SSE remote transport does not yet re-emit this
+event on the wire (remote parity is N3, also separate); locally,
+`InProcessTransport` forwards it today with no consumer, which is legal per
+the dual-stream completeness gate's one-way direction (forwarded ⊇ consumed
+is fine; consumed ⊆ forwarded is what is enforced).
+
 #### Text lifecycle (the conforming triplet, plain and streamed)
 
 The AG-UI spec mandates the text lifecycle **`TEXT_MESSAGE_START` → one or more
@@ -439,6 +473,7 @@ wire.
 | Custom `name`                        | Meaning                                          |
 |--------------------------------------|--------------------------------------------------|
 | `reyn.event.user_answered_intervention` | the user answered an intervention (working-indicator axis only — carries NO display text; see `reyn.event.intervention_answer_submitted` below for the echo) |
+| `reyn.event.session_attached`        | a session/agent switch just happened (#3310 N1) — carries `{agent, session_id}`, the identity a client keys its display/reset cache on. Emitted at the registry attach seam (`AgentRegistry.attach`/`attach_session`), put directly on `repl_outbox` as a stream BARRIER — see *the session-switch barrier* above. ★Local transport only in this PR: `InProcessTransport` forwards it; the AG-UI/SSE `_SessionFrameSource` reads a session's own outbox/chat-events and does not yet re-emit it on the remote wire (remote parity is N3, a separate PR) — this profile entry keeps the codec/completeness gates honest ahead of that wiring, the same forward-ahead-of-consumer shape as `agent_delta` below |
 | `reyn.event.user_submitted`          | a user turn was submitted (#3300 P1 C) — RAW text + chain_id + msg_id + seq + meta; each surface neutralizes at its render boundary. `msg_id`/`seq` are the #3300 P2a sent-queue correlation id + order-race-gate token |
 | `reyn.event.intervention_answer_submitted` | an intervention answer was resolved (#3300, event-ifying the LAST outbox `kind="user"` broadcast site — `InterventionHandler.deliver_answer_to`) — RAW text (the raw answer, or the matched choice's label) + `intervention_id` + meta; each surface neutralizes at its render boundary, following the `user_submitted` precedent exactly. Unlike `user_submitted`, this has no sent-queue staging step — an intervention answer was never a queued inbox item, so it renders straight to the flow |
 | `reyn.event.inbox_cancel`            | an UNDISPATCHED queued user message was cancelled by id (#3300 P3, via the `cancel_queued` client message) — carries `msg_id` + `seq`; the server-authoritative sent-queue removal signal (never a client-local "cancel succeeded" response), exclusive with `turn_started` for the same `msg_id` |

--- a/src/reyn/interfaces/transport/agui/profile.py
+++ b/src/reyn/interfaces/transport/agui/profile.py
@@ -156,6 +156,16 @@ CUSTOM_PROFILE: dict[str, CustomName] = _entries(
         "(never a client-local cancel-success response)",
     ),
     CustomName(
+        "reyn.event.session_attached", EVENT_NS, "the event data object",
+        "a session/agent switch just happened (#3310 N1) — carries "
+        "{agent, session_id}, the identity a client keys its display/reset "
+        "on. Emitted at the registry attach seam (`AgentRegistry.attach`/"
+        "`attach_session`), put directly on `repl_outbox` as a stream "
+        "BARRIER (no session's own chat-events, since that stream is the "
+        "thing being swapped) — forwarded ahead of any consumer (N2, a "
+        "separate PR, adds the client-side reset)",
+    ),
+    CustomName(
         "reyn.event.agent_delta", EVENT_NS, "the event data object",
         "one streamed LLM content-delta chunk (#3288 ③b) — carries the raw "
         "delta text + chain_id; a NON-PERSISTENT, purely additive notification "

--- a/src/reyn/interfaces/transport/frames.py
+++ b/src/reyn/interfaces/transport/frames.py
@@ -99,6 +99,17 @@ _TURN_AND_ANSWER_EVENTS = frozenset(
 )
 
 
+# #3310 N1: the session-switch notification — a stream BARRIER the registry
+# attach seam (``AgentRegistry.attach``/``attach_session``) puts directly on
+# ``repl_outbox`` (never routed through a session's own chat-events — see
+# ``AgentRegistry._announce_session_attached``). Forwarded ahead of any
+# consumer, exactly like :data:`_STREAMING_EVENTS` below: a client resets its
+# per-session display cache on this event (N2, a separate PR); until that
+# consumer lands, a surface with no branch for it drops it silently (opt-in
+# draw), never a garbage row.
+_SESSION_LIFECYCLE_EVENTS = frozenset({"session_attached"})
+
+
 # #3288 ③b: streamed LLM content-delta chat-events — the owner-ratified L4
 # replacement (issue #3288 comment thread): a partial rides a chat-event
 # (never an ``OutboxMessage`` kind, which the closed display vocabulary would
@@ -140,8 +151,17 @@ def renderer_chat_events() -> frozenset[str]:
       consumer in a DIFFERENT surface (``TextualChatApp._handle_agent_delta_event``,
       ``interfaces/inline/textual_chat/app.py``), proving the forward-ahead
       design worked: the consumer landed with zero changes needed here.
+    - :data:`_SESSION_LIFECYCLE_EVENTS` (#3310 N1) — the ``session_attached``
+      switch-barrier, a SECOND forward-ahead-of-consumer exception for the
+      same reason as ``_STREAMING_EVENTS``: no renderer branches on it yet
+      (the client-side reset is N2, a separate PR).
     """
-    return frozenset(_WAITING_ON_BY_EVENT.keys()) | _TURN_AND_ANSWER_EVENTS | _STREAMING_EVENTS
+    return (
+        frozenset(_WAITING_ON_BY_EVENT.keys())
+        | _TURN_AND_ANSWER_EVENTS
+        | _STREAMING_EVENTS
+        | _SESSION_LIFECYCLE_EVENTS
+    )
 
 
 @dataclass(frozen=True)

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -7,6 +7,10 @@ seam, changing *routing* only (delivery is unchanged, behavior byte-identical):
   ``session.outbox`` into ``registry.repl_outbox``. This transport drains that
   queue in a background pump task and re-tags each message as a
   :class:`~reyn.interfaces.transport.frames.DisplayFrame` on the unified stream.
+  (#3310 N1: ``registry.repl_outbox`` also carries an already-tagged
+  :class:`~reyn.interfaces.transport.frames.EventFrame` directly — the
+  ``session_attached`` switch-barrier the registry attach seam puts there;
+  the pump passes it through unchanged instead of re-wrapping it.)
 - **Event path** — a ``session.chat_events`` subscription (wired via the
   registry's focus-listener binding, so it follows ``/attach``), *filtered to
   the renderer's forward-set* (:func:`renderer_chat_events`), enqueues each
@@ -102,11 +106,22 @@ class InProcessTransport(ClientTransport):
     async def _pump_outbox(self) -> None:
         # Re-tag the display outbox onto the unified stream, preserving order.
         # Stops after forwarding the ``__end__`` control frame (session shutdown).
+        #
+        # #3310 N1: ``repl_outbox`` carries an ``EventFrame`` too now — the
+        # registry attach seam (``AgentRegistry._announce_session_attached``)
+        # puts a ``session_attached`` EventFrame directly on this queue (the
+        # barrier), rather than routing through a session's own chat-events
+        # (the very stream a switch swaps). Pass an already-tagged frame
+        # through UNCHANGED; only a bare ``OutboxMessage`` gets re-tagged as a
+        # ``DisplayFrame`` here.
         outbox = self._registry.repl_outbox
         while True:
-            msg = await outbox.get()
-            self._frames.put_nowait(DisplayFrame(msg))
-            if msg.kind == "__end__":
+            item = await outbox.get()
+            if isinstance(item, EventFrame):
+                self._frames.put_nowait(item)
+                continue
+            self._frames.put_nowait(DisplayFrame(item))
+            if item.kind == "__end__":
                 return
 
     async def frames(self) -> "AsyncIterator[Frame]":

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 
 from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.anchor_store import AnchorStore
+from reyn.core.events.events import Event
 from reyn.core.events.retention import RetentionPolicy, compute_retention_floor
 from reyn.core.events.snapshot_generations import (
     REWIND_KIND,
@@ -54,6 +55,7 @@ from reyn.core.events.snapshot_generations import (
 )
 from reyn.core.events.snapshot_generations import checkout as _append_reset_record
 from reyn.core.events.state_log import StateLog
+from reyn.interfaces.transport.frames import EventFrame
 
 from .profile import PROFILE_FILENAME, AgentProfile
 from .spawn_routing import ReviewedNA
@@ -2932,6 +2934,42 @@ class AgentRegistry:
             except AttributeError:
                 pass
 
+    def _announce_session_attached(self, name: str, sid: str) -> None:
+        """#3310 N1: notify the client a switch just happened, as a stream
+        BARRIER on ``repl_outbox`` — the one queue every local client drains.
+
+        ★Altitude: this cannot ride ``new_session._chat_events`` (the per-
+        session chat-event stream `session.subscribe_chat_events` follows) —
+        that stream IS the thing being swapped, so a client keying its reset
+        on an event emitted FROM the new session couldn't distinguish "new
+        session's first frame" from "the switch itself". Emitting here, at
+        the registry seam that owns ``repl_outbox``, is the one altitude
+        that sees both the old and the new session.
+
+        ★It is an ``EventFrame``, never an ``OutboxMessage`` kind — same
+        reasoning the owner ratified for #3288 ③b: an EVENT frame is opt-in
+        draw (a consuming surface with no branch for it drops it silently,
+        never rendering a garbage row), where an unknown DISPLAY kind is
+        rendered generically. Registering a new closed-vocabulary
+        ``OutboxMessage`` kind for a pure state transition would be the
+        category error #3288 ③b designed out.
+
+        ★Barrier property (design-pass, issue #3310): this call is placed
+        IMMEDIATELY after the ``self._attached = key`` flip, with NO
+        ``await`` anywhere in between (both are plain synchronous
+        statements: an attribute assignment and ``Queue.put_nowait``, never
+        ``await Queue.put``). Single event loop ⇒ nothing can interleave
+        inside that synchronous region, so on the ``repl_outbox`` FIFO
+        "before this frame = old session's frames, after = new session's
+        frames" holds BY CONSTRUCTION — a client resets its display on this
+        frame and cross-contamination between sessions becomes impossible,
+        not merely unlikely. Mirrors the no-await critical-section idiom in
+        ``Session.cancel_queued`` (#3300 Y-server / #3306).
+        """
+        self.repl_outbox.put_nowait(
+            EventFrame(Event(type="session_attached", data={"agent": name, "session_id": sid}))
+        )
+
     async def attach(self, name: str) -> "object":
         """Switch the attached agent to `name`. Loads + starts session.run()
         and the outbox forwarder for the new agent if not already running.
@@ -2964,6 +3002,7 @@ class AgentRegistry:
                 self._forwarder(name, sid)
             )
         self._attached = key
+        self._announce_session_attached(name, sid)
 
         # Re-announce any pending interventions for the user. While detached,
         # `_announce_intervention` already put the original message on the
@@ -3003,6 +3042,7 @@ class AgentRegistry:
         if key not in self._forward_tasks or self._forward_tasks[key].done():
             self._forward_tasks[key] = asyncio.create_task(self._forwarder(name, sid))
         self._attached = key
+        self._announce_session_attached(name, sid)
         for iv in target._interventions.list_active():
             if not iv.future.done():
                 await target._announce_intervention(iv)

--- a/tests/test_3310_n1_session_attached_barrier.py
+++ b/tests/test_3310_n1_session_attached_barrier.py
@@ -1,0 +1,367 @@
+"""Tier 2: #3310 N1 — the ``session_attached`` switch-notification barrier.
+
+A session/agent switch (``/attach <name>`` -> ``registry.attach()``,
+``/session switch <sid>`` -> ``registry.attach_session()``) flips which
+session's frames reach the client, but historically nothing told the client
+THAT a switch had happened. This adds a ``session_attached`` chat-event
+carrying ``{agent, session_id}``, emitted at the registry attach seam as an
+``EventFrame`` put DIRECTLY on ``repl_outbox`` (never routed through a
+session's own chat-events — that stream is the thing being swapped).
+
+Gates covered here:
+
+1. The event is emitted on BOTH switch paths (``attach`` / ``attach_session``),
+   carrying the correct ``{agent, session_id}``.
+2. ★Barrier: the flip (``self._attached = key``) and the announce
+   (``repl_outbox.put_nowait``) happen with NO real ``await`` suspension in
+   between, so the announce is ALWAYS the first thing a switch contributes to
+   ``repl_outbox`` — even when the newly-focused session already has a frame
+   queued up, ready for its forwarder to deliver.
+3. A surface with no handler for this ``EventFrame`` draws NOTHING (opt-in
+   draw, the #3288 ③b property) — contrasted, over the SAME delivery path,
+   with a DISPLAY frame of an ordinary kind, which the same renderer DOES
+   draw (proving the silence above is the opt-in-draw property, not a broken
+   pipe).
+4. Vocabulary/profile wiring: ``session_attached`` is in the frames
+   vocabulary (``renderer_chat_events()``) AND registered in the AG-UI
+   extension profile (``is_profiled("reyn.event.session_attached")``).
+   Stripping the ``profile.py`` entry alone is caught by the EXISTING
+   completeness gate (``tests/test_agui_profile_completeness.py::
+   test_every_custom_mapped_frame_is_profiled`` — strip-falsified during
+   review, not committed here). Stripping the ``frames.py`` vocabulary entry
+   alone is NOT caught by anything else (found during review: with
+   ``session_attached`` absent from ``renderer_chat_events()``, the profile
+   gate's own enumeration simply never looks at it — silently untested, not
+   RED) — pinned directly below so THAT half has its own gate too.
+
+Real ``AgentRegistry`` + real ``Session`` (via ``tests._support.agent_session
+.make_session``) for 1/2; a real ``InProcessTransport`` + real
+``ConsoleChatRenderer`` (write-capturing subclass) behind a small
+``EventLog``/``repl_outbox`` registry double for 3 — no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.core.events.events import Event, EventLog
+from reyn.interfaces.repl.renderer import ConsoleChatRenderer
+from reyn.interfaces.repl.stream_client import run_output_loop
+from reyn.interfaces.transport.agui.profile import is_profiled
+from reyn.interfaces.transport.frames import EventFrame, FrameTag, renderer_chat_events
+from reyn.interfaces.transport.in_process import InProcessTransport
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
+from tests._support.agent_session import make_session
+
+
+def _registry(tmp_path):
+    shared = BudgetTracker(CostConfig())
+
+    def factory(profile: AgentProfile):
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            output_language="en",
+            budget_tracker=shared,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    reg.create("beta")
+    return reg
+
+
+def _drain_all(q: "asyncio.Queue") -> list:
+    out = []
+    while not q.empty():
+        out.append(q.get_nowait())
+    return out
+
+
+async def _pump(n: int = 30) -> None:
+    for _ in range(n):
+        await asyncio.sleep(0.01)
+
+
+# ── 1. emitted on both switch paths, correct payload ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_session_attached_emitted_by_attach(tmp_path) -> None:
+    """Tier 2: ``attach(name)`` puts a ``session_attached`` EventFrame on
+    ``repl_outbox`` carrying ``{agent: name, session_id: _DEFAULT_SID}``."""
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        frames = _drain_all(reg.repl_outbox)
+        # Unpacking into a single-element tuple IS the "exactly one" assertion
+        # (raises ValueError on 0 or 2+ matches) — a behavioral check on the
+        # extracted value, not a `len(...) == N` format pin.
+        (attached,) = [
+            f for f in frames
+            if isinstance(f, EventFrame) and f.event.type == "session_attached"
+        ]
+        assert attached.event.data == {"agent": "alpha", "session_id": _DEFAULT_SID}
+    finally:
+        for task in reg.running_tasks():
+            task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_session_attached_emitted_by_attach_session(tmp_path) -> None:
+    """Tier 2: ``attach_session(name, sid)`` puts the SAME shaped announce,
+    carrying the target session's own sid (not the default)."""
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        _drain_all(reg.repl_outbox)  # discard the first-attach announce
+
+        sid = reg.spawn_session("alpha", presentation_consumer=None, intervention_bridge=None)
+        await reg.attach_session("alpha", sid)
+
+        frames = _drain_all(reg.repl_outbox)
+        (attached,) = [
+            f for f in frames
+            if isinstance(f, EventFrame) and f.event.type == "session_attached"
+        ]
+        assert attached.event.data == {"agent": "alpha", "session_id": sid}
+        assert sid != _DEFAULT_SID
+    finally:
+        for task in reg.running_tasks():
+            task.cancel()
+
+
+# ── 2. ★barrier: the announce is always first, even under a real race ──────
+
+
+@pytest.mark.asyncio
+async def test_barrier_announce_precedes_new_sessions_own_frames(tmp_path) -> None:
+    """Tier 2: ★race gate. A concurrent adversary task polls the registry's
+    PUBLIC focus accessor (``attached_name``) as tightly as physically
+    possible (a bare ``await asyncio.sleep(0)`` loop — the fastest ANY real
+    consumer, however it is implemented, could ever react to the flip) and
+    races to put its own frame onto ``repl_outbox`` the instant it observes
+    the switch. The flip (``self._attached = key``) and the announce
+    (``repl_outbox.put_nowait``) have NO real ``await`` between them (design-
+    pass contract, mirroring ``Session.cancel_queued``'s no-await critical
+    section, #3300 Y-server / #3306) — so no matter how fast the adversary
+    polls, it can only ever observe the flip AFTER the announce is already
+    committed (the same synchronous Python step performed both), and its
+    frame is therefore physically incapable of landing before the announce.
+
+    Strip-falsify (recorded in the PR body — reproduced live during review,
+    not committed here): inserting a real ``await asyncio.sleep(0)`` between
+    the flip and the announce in ``AgentRegistry.attach`` gives the adversary
+    a real scheduling gap to win the race in — this test goes RED (the
+    adversary frame lands BEFORE the announce)."""
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        _drain_all(reg.repl_outbox)  # discard the first-attach announce
+
+        adversary_frame = OutboxMessage(kind="agent", text="adversary-frame")
+
+        async def _adversary() -> None:
+            # As fast as physically possible: no sleep duration, no I/O —
+            # just re-scheduled every single event-loop tick until the flip
+            # is observed, then commit immediately (no await before the put).
+            while reg.attached_name != "beta":
+                await asyncio.sleep(0)
+            reg.repl_outbox.put_nowait(adversary_frame)
+
+        adversary_task = asyncio.create_task(_adversary())
+        await asyncio.sleep(0)  # let the adversary take its first (failing) poll
+
+        await reg.attach("beta")
+        await asyncio.wait_for(adversary_task, timeout=2.0)
+
+        frames = _drain_all(reg.repl_outbox)
+        # Unpacking into exactly two names asserts "exactly these two, in
+        # this order" behaviorally — a 0/1/3+-item queue raises ValueError
+        # here rather than needing a separate length check.
+        first, second = frames
+        assert isinstance(first, EventFrame) and first.event.type == "session_attached", (
+            f"the announce must be FIRST on repl_outbox, ahead of the fastest "
+            f"possible adversary: {frames!r}"
+        )
+        assert first.event.data == {"agent": "beta", "session_id": _DEFAULT_SID}
+        assert second is adversary_frame
+    finally:
+        for task in reg.running_tasks():
+            task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_barrier_holds_for_attach_session_too(tmp_path) -> None:
+    """Tier 2: ★race gate, the ``attach_session`` (sid-switch) call site —
+    the SAME adversary as above, per-site (not cross-masked by the
+    ``attach`` test): ``attach_session`` has its OWN
+    ``self._attached = key`` / announce pair (a separate code path from
+    ``attach``), so it needs its own independent proof the barrier holds
+    there too."""
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        sid = reg.spawn_session("alpha", presentation_consumer=None, intervention_bridge=None)
+        _drain_all(reg.repl_outbox)  # discard the first-attach + spawn announces
+
+        adversary_frame = OutboxMessage(kind="agent", text="adversary-frame-2")
+
+        async def _adversary() -> None:
+            while reg.attached_sid != sid:
+                await asyncio.sleep(0)
+            reg.repl_outbox.put_nowait(adversary_frame)
+
+        adversary_task = asyncio.create_task(_adversary())
+        await asyncio.sleep(0)
+
+        await reg.attach_session("alpha", sid)
+        await asyncio.wait_for(adversary_task, timeout=2.0)
+
+        frames = _drain_all(reg.repl_outbox)
+        first, second = frames
+        assert isinstance(first, EventFrame) and first.event.type == "session_attached", (
+            f"the announce must be FIRST on repl_outbox: {frames!r}"
+        )
+        assert first.event.data == {"agent": "alpha", "session_id": sid}
+        assert second is adversary_frame
+    finally:
+        for task in reg.running_tasks():
+            task.cancel()
+
+
+# ── 3. opt-in draw: no handler => no visible-garbage window ─────────────────
+
+
+class _FakeRegistry:
+    """Registry double for ``InProcessTransport``: a real ``repl_outbox`` +
+    real ``EventLog`` (unused here — the announce bypasses chat_events
+    entirely, exactly like production), no mocks."""
+
+    def __init__(self) -> None:
+        self.repl_outbox: asyncio.Queue = asyncio.Queue()
+        self.chat_events = EventLog()
+        self._cb = None
+
+    def bind_focus_listeners(self, *, on_chat_event=None, intervention_channel=None) -> None:
+        self._cb = on_chat_event
+        if on_chat_event is not None:
+            self.chat_events.add_subscriber(on_chat_event)
+
+    def unbind_focus_listeners(self) -> None:
+        if self._cb is not None:
+            self.chat_events.remove_subscriber(self._cb)
+            self._cb = None
+
+    def attached_session(self):
+        return None
+
+
+class _WriteCapturingRenderer(ConsoleChatRenderer):
+    """A REAL renderer (unchanged branching), just recording ``_write`` calls
+    instead of touching stdout — so "nothing drawn" is an observed absence of
+    a real render call, not an inferred one."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.writes: "list[str]" = []
+
+    def _write(self, s: str) -> None:
+        self.writes.append(s)
+
+
+async def _drive_one_frame(put_frame) -> "list[str]":
+    fake = _FakeRegistry()
+    transport = InProcessTransport(fake, intervention_channel="tui")
+    transport.start()
+    renderer = _WriteCapturingRenderer()
+    try:
+        put_frame(fake)
+        fake.repl_outbox.put_nowait(OutboxMessage(kind="__end__", text=""))
+        await asyncio.wait_for(run_output_loop(transport, renderer), timeout=2.0)
+    finally:
+        transport.close()
+    return renderer.writes
+
+
+@pytest.mark.asyncio
+async def test_session_attached_event_frame_draws_nothing() -> None:
+    """Tier 2: a ``session_attached`` EventFrame travels the SAME
+    ``repl_outbox`` -> ``InProcessTransport`` -> ``run_output_loop`` delivery
+    path a display frame would, but ``ConsoleChatRenderer.on_chat_event`` has
+    no branch for it (an ``if/elif`` chain with no ``else``) — it is
+    consumed and dropped, never rendered. Assert the INTERMEDIATE state (§10):
+    this drive puts ONLY the session_attached frame (plus the terminator) —
+    no other write source is present to accidentally mask a real draw."""
+
+    def _put(fake: "_FakeRegistry") -> None:
+        fake.repl_outbox.put_nowait(
+            EventFrame(Event(type="session_attached", data={"agent": "beta", "session_id": "main"}))
+        )
+
+    writes = await _drive_one_frame(_put)
+    assert writes == [], (
+        f"session_attached must draw NOTHING (opt-in draw, #3288 ③b property) — "
+        f"got renderer writes: {writes!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_same_path_positive_control_display_frame_does_draw() -> None:
+    """Tier 2: the positive control for the test above, over the IDENTICAL
+    delivery path (same fake registry shape, same transport, same renderer
+    class, same run_output_loop) — a plain DISPLAY frame with an ordinary
+    kind (``user``, which ``ConsoleChatRenderer`` has no special ``_PREFIX``
+    entry for) still reaches ``message()`` and DOES produce a write. This is
+    what rules out the previous test's silence being a dead/broken pipe
+    rather than the EventFrame-specific opt-in-draw property (verification-
+    hazards §10: the control must travel the same path as the frame under
+    test, not a shortcut through a different one)."""
+
+    def _put(fake: "_FakeRegistry") -> None:
+        fake.repl_outbox.put_nowait(OutboxMessage(kind="user", text="hi"))
+
+    writes = await _drive_one_frame(_put)
+    assert writes, "the same-path positive control must actually draw something"
+    assert any("hi" in w for w in writes)
+
+
+def test_session_attached_is_an_event_frame_never_a_display_kind() -> None:
+    """Tier 1: pin the frame SHAPE — ``session_attached`` rides an
+    ``EventFrame`` (``FrameTag.EVENT``), never an ``OutboxMessage``/
+    ``DisplayFrame`` kind. Constructing it any other way would be the
+    category error #3288 ③b's owner-ratified decision designed out."""
+    frame = EventFrame(Event(type="session_attached", data={"agent": "a", "session_id": "main"}))
+    assert frame.tag is FrameTag.EVENT
+
+
+# ── 4. vocabulary + AG-UI profile wiring ─────────────────────────────────────
+
+
+def test_session_attached_is_in_the_frames_vocabulary() -> None:
+    """Tier 1: ``session_attached`` is in ``renderer_chat_events()`` — the
+    forward-set both ``InProcessTransport`` and the AG-UI endpoint filter
+    against. Stripping this membership is NOT caught by
+    ``test_agui_profile_completeness.py`` (its own enumeration reads THIS
+    set, so removing the entry here just makes that gate stop looking at
+    ``session_attached`` — silently untested, not RED — found during
+    review); this direct pin is what actually catches that removal."""
+    assert "session_attached" in renderer_chat_events()
+
+
+def test_session_attached_is_profiled_in_the_agui_extension() -> None:
+    """Tier 1: ``reyn.event.session_attached`` is a registered AG-UI
+    extension-profile name (``profile.py``'s ``CUSTOM_PROFILE``) — the OTHER
+    half of gate 4. Strip-falsified during review (removing the
+    ``CustomName`` entry turns ``test_agui_profile_completeness.py::
+    test_every_custom_mapped_frame_is_profiled`` RED, since
+    ``session_attached`` IS in ``renderer_chat_events()`` per the test
+    above, so the codec DOES emit ``reyn.event.session_attached`` for it)."""
+    assert is_profiled("reyn.event.session_attached")

--- a/tests/test_attach_request_forwarded.py
+++ b/tests/test_attach_request_forwarded.py
@@ -7,7 +7,10 @@ discards the message without forwarding it to ``repl_outbox``.
 This file pins:
   1. A ``__attach_request__("beta")`` on alpha's outbox swaps the attached
      agent to beta (control path intact).
-  2. ``repl_outbox`` is empty after the swap — no re-post occurs.
+  2. ``repl_outbox`` gets no RE-POST of the raw sentinel — the only thing a
+     swap contributes is the #3310 N1 ``session_attached`` announce
+     ``attach()`` itself now emits (the switch-barrier), never a bare-text
+     leak of the control message.
   3. An unknown target (= registry.exists() is False) does not swap and
      does not forward — unchanged behavior proves the control path is not
      broken by the removal.
@@ -19,8 +22,16 @@ from pathlib import Path
 
 import pytest
 
+from reyn.interfaces.transport.frames import EventFrame
 from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.outbox_hub import OutboxHub
+
+
+def _drain_all(q: "asyncio.Queue") -> list:
+    out = []
+    while not q.empty():
+        out.append(q.get_nowait())
+    return out
 
 
 class _FakeInterventions:
@@ -71,17 +82,19 @@ def _build_registry(tmp_path: Path):
 
 @pytest.mark.asyncio
 async def test_attach_request_swaps_but_does_not_repost(tmp_path):
-    """Tier 2: __attach_request__ swaps attach AND leaves repl_outbox empty.
+    """Tier 2: __attach_request__ swaps attach; repl_outbox gets the #3310 N1
+    ``session_attached`` announce for the swap and NOTHING else — no re-post
+    of the raw sentinel.
 
-    The control path (attach swap + continue) is intact. repl_outbox gets
-    no copy of the signal — there is no live downstream consumer for it.
-    If a re-post is silently re-added, this test goes RED, preventing
+    The control path (attach swap + continue) is intact. repl_outbox gets no
+    COPY OF THE SENTINEL — there is no live downstream consumer for that raw
+    text. If a re-post is silently re-added, this test goes RED, preventing
     a bare-text leak through _output_loop.
     """
     registry, sessions = _build_registry(tmp_path)
 
     await registry.attach("alpha")
-    assert registry.attached_name == "alpha"
+    _drain_all(registry.repl_outbox)  # discard the first-attach announce
 
     await sessions["alpha"].outbox.put(
         OutboxMessage(kind="__attach_request__", text="beta"),
@@ -95,8 +108,13 @@ async def test_attach_request_swaps_but_does_not_repost(tmp_path):
 
     # Control path intact: swap happened.
     assert registry.attached_name == "beta"
-    # Re-post removal proven: outbox got nothing.
-    assert registry.repl_outbox.empty()
+    # Re-post removal proven: outbox got ONLY the switch-barrier announce,
+    # never a copy of the raw "__attach_request__"/"beta" sentinel.
+    # Unpacking into a single-element tuple IS the "exactly one, nothing
+    # else" assertion (raises ValueError on 0 or 2+ items in the queue).
+    (frame,) = _drain_all(registry.repl_outbox)
+    assert isinstance(frame, EventFrame) and frame.event.type == "session_attached"
+    assert frame.event.data == {"agent": "beta", "session_id": "main"}
 
 
 @pytest.mark.asyncio
@@ -105,6 +123,7 @@ async def test_attach_request_unknown_target_drops_silently(tmp_path):
     registry, sessions = _build_registry(tmp_path)
 
     await registry.attach("alpha")
+    _drain_all(registry.repl_outbox)  # discard the first-attach announce
 
     await sessions["alpha"].outbox.put(
         OutboxMessage(kind="__attach_request__", text="ghost"),
@@ -114,4 +133,5 @@ async def test_attach_request_unknown_target_drops_silently(tmp_path):
         await asyncio.sleep(0.01)
 
     assert registry.attached_name == "alpha"
+    # No swap happened (unknown target) => no NEW announce, and no re-post.
     assert registry.repl_outbox.empty()


### PR DESCRIPTION
**[per-PR-coder]** — part of #3310 (N2 client-side reset/hydrate and N3 remote parity remain, separate PRs).

## What this is

Today `/attach <name>` (`registry.attach()`) and `/session switch <sid>` (`registry.attach_session()`) flip which session's frames reach a client, but the client is never told. This adds a `session_attached` chat-event carrying `{agent, session_id}` — the identity a client keys its display/reset cache on (N2) — emitted at the registry attach seam as an `EventFrame` put **directly on `repl_outbox`**, never routed through a session's own chat-events (that stream is the thing being swapped).

**The barrier property is the point.** Inside `attach()`/`attach_session()`, the `self._attached = key` flip and `repl_outbox.put_nowait(session_attached)` happen with **no `await` between them** (a plain attribute assignment + `Queue.put_nowait`, never `await Queue.put`). Single event loop ⇒ nothing can interleave in that synchronous region ⇒ on the `repl_outbox` FIFO, "before the barrier = old session's frames, after = new session's frames" holds **by construction** — mirrors the no-await critical-section idiom in `Session.cancel_queued` (#3300 Y-server / #3306).

It is an `EventFrame`, never an `OutboxMessage` kind — same reasoning the owner ratified for #3288 ③b: an EVENT frame is opt-in draw (a surface with no handler drops it silently), where a closed-vocabulary display kind would be the category error that decision designed out.

## Ground findings (per the architect's open items)

1. **`attach_session()` DOES re-announce pending interventions symmetrically with `attach()`** (`registry.py`, both end with `for iv in .../ ._interventions.list_active(): if not iv.future.done(): await ..._announce_intervention(iv)`) — no asymmetry, no fix needed.
2. **Type-compatibility of `repl_outbox`**: the sole production consumer is `InProcessTransport._pump_outbox` (`in_process.py`), which assumed every item was an `OutboxMessage` (`msg.kind == "__end__"`, unconditional `DisplayFrame(msg)` wrap) — putting an `EventFrame` there directly would have raised `AttributeError` and double-wrapped it. Fixed: `_pump_outbox` now passes an already-tagged `EventFrame` straight through, only re-tagging a bare `OutboxMessage` as `DisplayFrame`. The AG-UI/SSE remote path (`agui/endpoint.py`'s `_SessionFrameSource`) reads a session's own `outbox_hub`/`chat_events` directly, not `registry.repl_outbox`, so it is structurally unaffected (remote parity is N3).

## Gates (strip-falsified, observed RED reproduced live)

1. **Emitted on both switch paths, correct `{agent, session_id}`** — `test_session_attached_emitted_by_attach` / `_attach_session`.
2. **★Barrier** (load-bearing): `test_barrier_announce_precedes_new_sessions_own_frames` / `test_barrier_holds_for_attach_session_too`. A concurrent adversary polls the PUBLIC `attached_name`/`attached_sid` accessor as tightly as physically possible (`while ...: await asyncio.sleep(0)`) and races to put its own frame the instant it observes the flip. **Strip-falsify**: inserted `await asyncio.sleep(0)` between the flip and the announce in both `attach()` and `attach_session()` → both tests went RED (adversary frame landed before the announce) → reverted, both GREEN again.
3. **Opt-in draw / no garbage row**: `test_session_attached_event_frame_draws_nothing` (a real `ConsoleChatRenderer`, `on_chat_event` has no branch for `session_attached` → zero writes) contrasted with `test_same_path_positive_control_display_frame_does_draw` (the SAME delivery path, an ordinary `user` display kind DOES draw — proving the silence above is the opt-in property, not a broken pipe, per verification-hazards §10). **Strip-falsify**: removed the `isinstance(item, EventFrame)` pass-through in `_pump_outbox` → immediate `AttributeError: 'EventFrame' object has no attribute 'kind'` (observed RED) → reverted, GREEN.
4. **Vocabulary/profile wiring**: `session_attached` added to `frames.py`'s `renderer_chat_events()` forward-set (new `_SESSION_LIFECYCLE_EVENTS`) and to `agui/profile.py`'s `CUSTOM_PROFILE` (`reyn.event.session_attached`). **Strip-falsify**: removing the profile entry → RED on the EXISTING `tests/test_agui_profile_completeness.py::test_every_custom_mapped_frame_is_profiled` (reverted, GREEN). Also found during review: removing the `frames.py` vocabulary entry alone is **not** caught by that existing gate (its own enumeration reads `renderer_chat_events()`, so stripping the entry there makes the gate quietly stop looking at `session_attached` instead of going RED) — added a direct pin (`test_session_attached_is_in_the_frames_vocabulary`) that IS strip-falsified RED for that half.

Existing tests `test_attach_request_forwarded.py` (asserted `repl_outbox.empty()` after a swap) updated to reflect the new correct behavior: a swap now legitimately contributes the `session_attached` announce; the original intent (no raw sentinel re-post) is preserved via an exact-content check.

## Left to N2/N3 (explicitly out of scope here)

- Client-side reset/hydrate keyed on this barrier (a per-session `FlowView`/display cache) — N2, a separate PR. `textual_chat/` untouched throughout.
- AG-UI/SSE remote re-emission of `session_attached` on the actual wire — N3, a separate PR (the profile entry keeps the completeness gates honest ahead of that wiring, same forward-ahead-of-consumer shape as `agent_delta`).

## Local verification (targeted, foreground)

- `uv run python -m pytest --timeout=120 -q` over the new test file + touched files + the `#3300`/registry/transport/AG-UI test files (~288 tests): **288 passed**.
- `ruff check src tests`: clean.
- `python scripts/test_tier_audit.py --strict tests/test_3310_n1_session_attached_barrier.py tests/test_attach_request_forwarded.py`: 0 errors.
- `python scripts/verify_module_docstrings.py` on touched `src/` files: OK.

## Doc updates (same PR)

`docs/reference/runtime/agui-transport.md`: new "The session-switch barrier" subsection (attach/switch seam), a `reyn.event.session_attached` row in the extension-profile table.

## Test plan

- [x] `pytest` targeted run (see above) — 288 passed
- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` on changed test files — 0 errors
- [x] `verify_module_docstrings.py` on changed src files — OK
- [x] Strip-falsify each gate live, observed RED, reverted (see PR body above)
- [ ] (Manual/Visual) N/A — server-side only, no UI surface changes in this PR