### PR TITLE
feat(agui): remote parity for session switch — #3310 N3

### DIFF
--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -149,13 +149,56 @@ This event is NOT an `OutboxMessage` display kind — the owner-ratified reason
 is the same as #3288 ③b's `agent_delta`: a state transition rides an `EventFrame`
 (opt-in draw — a surface with no handler drops it silently, never a garbage
 row), where registering a closed-vocabulary display kind for it would be a
-category error. As of this PR the client-side reset (a per-session display
-cache the client swaps on this barrier) is NOT yet implemented — that is N2,
-a separate PR — and the AG-UI/SSE remote transport does not yet re-emit this
-event on the wire (remote parity is N3, also separate); locally,
-`InProcessTransport` forwards it today with no consumer, which is legal per
-the dual-stream completeness gate's one-way direction (forwarded ⊇ consumed
-is fine; consumed ⊆ forwarded is what is enforced).
+category error. Client-side reset (a per-session display cache the client
+swaps on this barrier) is N2, a separate PR; locally, `InProcessTransport`
+forwards this event today, legal per the dual-stream completeness gate's
+one-way direction (forwarded ⊇ consumed is fine; consumed ⊆ forwarded is what
+is enforced) whether or not a given surface has a handler yet.
+
+**Remote parity (#3310 N3).** `registry.repl_outbox` (above) is a LOCAL-only
+bus — the AG-UI/SSE `_SessionFrameSource` never drains it; it reads a
+session's own `outbox_hub`/`chat_events` directly, bound to ONE session
+object for the SSE connection's lifetime. A remote client that switched
+sessions therefore had NO way to obtain the new session's scrollback at all:
+the remote read-model's `conversation_history` is deliberately empty
+(frame-sufficiency, `read_model.py`) and the emitter's `MESSAGES_SNAPSHOT`
+backlog was otherwise fixed at connect time. N3 closes this by treating a
+switch as a **logical reconnect**, entirely within the remote transport
+(the registry's own `attach`/`attach_session` + `repl_outbox` barrier are
+untouched and not involved):
+
+- `_SessionFrameSource` (`endpoint.py`) independently observes the SAME
+  `__session_switch_request__` sentinel the registry forwarder consumes for
+  the local REPL (both are subscribers of the same session's `outbox_hub`
+  fan-out — see *the control-sentinel dispositions* above). On seeing it, it
+  re-points itself at the target session (`registry.get_session`) and
+  synthesizes a `session_attached` `EventFrame` onto this connection's own
+  queue — the SAME vocabulary N1 defined, an independent per-connection
+  equivalent since `repl_outbox` never reaches a remote surface. It never
+  calls `registry.attach_session` itself, so it cannot race or double-apply
+  that side effect — it only re-points THIS connection's own view. A
+  registry-less construction (every pre-N3 unit test) degrades byte-identically:
+  the sentinel falls through to the generic `DisplayFrame` path, where
+  `CONTROL_FILTER_KINDS` already drops it silently.
+- `AgUiEmitter`, on observing a `session_attached` `EventFrame` flow through
+  `stream()`, re-fires the SAME reconnect protocol it uses at connect
+  (`_reconnect_snapshot_chunks`: `MESSAGES_SNAPSHOT` then `STATE_SNAPSHOT`)
+  — STRICTLY after the barrier event is forwarded, never before, so a client
+  that resets its view on the barrier never sees the reset race the state
+  the re-fire is about to deliver. The new backlog is resolved via a
+  caller-supplied `backlog_provider(agent, session_id)`; the endpoint wires
+  `session_backlog_frames`, which projects the target session's in-memory
+  `history` (`ChatMessage` list) through the SAME `project_restored_frames`
+  SSoT local restore-on-restart uses (#3273 P5) — read fresh at switch time,
+  never cached, so content that accrued in the other session while this
+  connection was elsewhere is included (no staleness). The per-connection
+  `TextStreamTracker` and `waiting_on` label are reset at the same point.
+- No per-client "which frames have I already seen" bookkeeping was
+  introduced: the mechanism is re-subscription (which session a connection
+  currently reads from) plus a fresh history read at switch time — never a
+  set of previously-delivered frame/message ids consulted before forwarding.
+- An ordinary connection that never switches sessions is unaffected — the
+  re-fire is dormant with no `session_attached` event ever flowing through.
 
 #### Text lifecycle (the conforming triplet, plain and streamed)
 
@@ -409,6 +452,13 @@ On connect (or reconnect) the server replays, before any live event:
 
 Live events (and `STATE_DELTA`s) follow.
 
+**Session switch = the same protocol, mid-stream (#3310 N3).** A session
+switch on an already-connected AG-UI stream re-fires this EXACT pair
+(`AgUiEmitter._reconnect_snapshot_chunks`), strictly after the
+`reyn.event.session_attached` barrier is forwarded — see *the session-switch
+barrier* above. Connect-time and switch-time are one code path, not two
+byte-identical-by-hand copies.
+
 The `MESSAGES_SNAPSHOT` `messages` field is a **standard `[{role, content}]`
 array of conversation turns only** — `agent` → `assistant`, `user` → `user` — the
 shape a generic client expects. reyn chrome (status / error / present /
@@ -473,7 +523,7 @@ wire.
 | Custom `name`                        | Meaning                                          |
 |--------------------------------------|--------------------------------------------------|
 | `reyn.event.user_answered_intervention` | the user answered an intervention (working-indicator axis only — carries NO display text; see `reyn.event.intervention_answer_submitted` below for the echo) |
-| `reyn.event.session_attached`        | a session/agent switch just happened (#3310 N1) — carries `{agent, session_id}`, the identity a client keys its display/reset cache on. Emitted at the registry attach seam (`AgentRegistry.attach`/`attach_session`), put directly on `repl_outbox` as a stream BARRIER — see *the session-switch barrier* above. ★Local transport only in this PR: `InProcessTransport` forwards it; the AG-UI/SSE `_SessionFrameSource` reads a session's own outbox/chat-events and does not yet re-emit it on the remote wire (remote parity is N3, a separate PR) — this profile entry keeps the codec/completeness gates honest ahead of that wiring, the same forward-ahead-of-consumer shape as `agent_delta` below |
+| `reyn.event.session_attached`        | a session/agent switch just happened (#3310 N1) — carries `{agent, session_id}`, the identity a client keys its display/reset cache on. Locally, emitted at the registry attach seam (`AgentRegistry.attach`/`attach_session`), put directly on `repl_outbox` as a stream BARRIER — see *the session-switch barrier* above. Remotely (#3310 N3), `_SessionFrameSource` synthesizes an independent per-connection equivalent when it observes a `/session switch` on the session backing THIS connection, and `AgUiEmitter` re-fires `MESSAGES_SNAPSHOT`/`STATE_SNAPSHOT` for the new session right after forwarding it — see *Remote parity* above |
 | `reyn.event.user_submitted`          | a user turn was submitted (#3300 P1 C) — RAW text + chain_id + msg_id + seq + meta; each surface neutralizes at its render boundary. `msg_id`/`seq` are the #3300 P2a sent-queue correlation id + order-race-gate token |
 | `reyn.event.intervention_answer_submitted` | an intervention answer was resolved (#3300, event-ifying the LAST outbox `kind="user"` broadcast site — `InterventionHandler.deliver_answer_to`) — RAW text (the raw answer, or the matched choice's label) + `intervention_id` + meta; each surface neutralizes at its render boundary, following the `user_submitted` precedent exactly. Unlike `user_submitted`, this has no sent-queue staging step — an intervention answer was never a queued inbox item, so it renders straight to the flow |
 | `reyn.event.inbox_cancel`            | an UNDISPATCHED queued user message was cancelled by id (#3300 P3, via the `cancel_queued` client message) — carries `msg_id` + `seq`; the server-authoritative sent-queue removal signal (never a client-local "cancel succeeded" response), exclusive with `turn_started` for the same `msg_id` |

--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -171,15 +171,23 @@ untouched and not involved):
   `__session_switch_request__` sentinel the registry forwarder consumes for
   the local REPL (both are subscribers of the same session's `outbox_hub`
   fan-out — see *the control-sentinel dispositions* above). On seeing it, it
-  re-points itself at the target session (`registry.get_session`) and
-  synthesizes a `session_attached` `EventFrame` onto this connection's own
-  queue — the SAME vocabulary N1 defined, an independent per-connection
-  equivalent since `repl_outbox` never reaches a remote surface. It never
-  calls `registry.attach_session` itself, so it cannot race or double-apply
-  that side effect — it only re-points THIS connection's own view. A
-  registry-less construction (every pre-N3 unit test) degrades byte-identically:
-  the sentinel falls through to the generic `DisplayFrame` path, where
-  `CONTROL_FILTER_KINDS` already drops it silently.
+  **enqueues the `session_attached` `EventFrame` onto this connection's own
+  queue BEFORE re-pointing itself at the target session** (`registry.get_session`
+  + subscribing to the new session's chat-events) — the SAME vocabulary N1
+  defined, an independent per-connection equivalent since `repl_outbox` never
+  reaches a remote surface. This ordering (announce, then subscribe) is
+  load-bearing, not incidental: the new session's chat-event subscriber does
+  not exist yet when the announce is enqueued, so a chat-event the new
+  session emits cannot possibly reach this connection's queue ahead of the
+  barrier — true BY CONSTRUCTION regardless of whether an `await` is ever
+  later introduced between the two steps (witnessed by
+  `test_switch_announce_precedes_any_new_session_chat_event`, an adversary
+  that floods the target session's own chat-event stream the instant the
+  switch is triggered). It never calls `registry.attach_session` itself, so
+  it cannot race or double-apply that side effect — it only re-points THIS
+  connection's own view. A registry-less construction (every pre-N3 unit test)
+  degrades byte-identically: the sentinel falls through to the generic
+  `DisplayFrame` path, where `CONTROL_FILTER_KINDS` already drops it silently.
 - `AgUiEmitter`, on observing a `session_attached` `EventFrame` flow through
   `stream()`, re-fires the SAME reconnect protocol it uses at connect
   (`_reconnect_snapshot_chunks`: `MESSAGES_SNAPSHOT` then `STATE_SNAPSHOT`)

--- a/src/reyn/interfaces/transport/agui/emitter.py
+++ b/src/reyn/interfaces/transport/agui/emitter.py
@@ -9,8 +9,27 @@ transports feed off the identical frame source, *local ≡ remote by constructio
 (D2) — the emitter adds only wire framing, never new render semantics.
 
 On connect it replays the reconnect snapshots (A4): ``MESSAGES_SNAPSHOT`` (the
-display backlog) then ``STATE_SNAPSHOT`` (the status read-model). It then streams
-each frame as its AG-UI **wire sequence** (:func:`encode_frame_wire_streaming` —
+display backlog) then ``STATE_SNAPSHOT`` (the status read-model).
+
+**Session-switch parity (#3310 N3).** A session switch is treated as a
+*logical reconnect*: right after a ``session_attached`` chat-event (#3310 N1,
+carrying ``{agent, session_id}``) is forwarded on the wire, this emitter
+re-fires the SAME reconnect protocol — ``MESSAGES_SNAPSHOT`` (the NEW
+session's backlog, resolved via the caller-supplied ``backlog_provider``) then
+``STATE_SNAPSHOT`` — so connect-time and switch-time are one code path
+(:meth:`_reconnect_snapshot_chunks`). Without this, a remote client has no way
+to obtain a switched-to session's scrollback at all: the read-model's
+``conversation_history`` is deliberately empty for a remote client
+(frame-sufficiency, ``read_model.py``), and this emitter's own backlog is
+otherwise fixed at connection time. The barrier ordering is load-bearing: the
+re-fire happens strictly AFTER the ``session_attached`` frame is forwarded
+(never before), so a client that resets its view on that barrier never has the
+reset race the very state this re-fire just delivered. The per-connection
+``TextStreamTracker`` and ``waiting_on`` label are reset at the same point — a
+new session owns neither the old one's in-flight streamed-text bracketing nor
+its WaitingOn state.
+
+It then streams each frame as its AG-UI **wire sequence** (:func:`encode_frame_wire_streaming` —
 a whole text message is the canonical ``TEXT_MESSAGE_START`` → ``…_CONTENT`` →
 ``…_END`` triplet, P4; a message that streamed (#3288 ③b/③d, ``agent_delta``
 chat-events) instead gets a REAL multi-CONTENT sequence — one ``TEXT_MESSAGE_START``
@@ -69,14 +88,20 @@ class AgUiEmitter:
         status_provider: "Callable[[], dict | None]",
         *,
         backlog: "list[Frame] | None" = None,
+        backlog_provider: "Callable[[str, str], list[Frame]] | None" = None,
     ) -> None:
         # ``frames`` is the unified frame stream (e.g. an InProcessTransport's
         # ``frames()``); ``status_provider`` returns the CUI status snapshot dict
         # (or None when no session is attached); ``backlog`` is the display
-        # history replayed on connect for reconnect (A4).
+        # history replayed on connect for reconnect (A4). ``backlog_provider``
+        # (#3310 N3) is called with ``(agent, session_id)`` off a mid-stream
+        # ``session_attached`` chat-event to fetch the switched-to session's
+        # backlog for the re-fire; ``None`` means this connection never
+        # switches sessions (byte-identical to pre-N3 behavior).
         self._frames = frames
         self._status_provider = status_provider
         self._backlog = list(backlog or [])
+        self._backlog_provider = backlog_provider
         self._model = StatusModel()
         self._waiting_on: str | None = None
         # #3288 ③d: one tracker per connection so a streamed reply's
@@ -88,10 +113,20 @@ class AgUiEmitter:
     def _project(self) -> dict:
         return project_status(self._status_provider(), waiting_on=self._waiting_on)
 
+    def _reconnect_snapshot_chunks(self, backlog: "list[Frame]") -> "list[str]":
+        """The shared reconnect protocol (A4): backlog display, then full
+        status — used identically at connect (``stream()`` start) and at a
+        mid-stream session switch (#3310 N3), so the two are ONE code path,
+        not a byte-identical-by-hand duplicate."""
+        return [
+            to_sse(encode_messages_snapshot(backlog)),
+            to_sse(encode_state_snapshot(self._model.snapshot(self._project()))),
+        ]
+
     async def stream(self) -> AsyncIterator[str]:
         # Reconnect snapshots first (A4): backlog display, then full status.
-        yield to_sse(encode_messages_snapshot(self._backlog))
-        yield to_sse(encode_state_snapshot(self._model.snapshot(self._project())))
+        for chunk in self._reconnect_snapshot_chunks(self._backlog):
+            yield chunk
 
         async for frame in self._frames:
             # Control sentinels in CONTROL_FILTER_KINDS are NOT forwarded on the
@@ -140,6 +175,21 @@ class AgUiEmitter:
                         encode_intervention_tool_result(edata["intervention_id"], "answered")
                     )
                 self._waiting_on = _waiting_on_after(etype, edata, self._waiting_on)
+                # #3310 N3: logical-reconnect re-fire, STRICTLY after the
+                # session_attached frame was forwarded above (never before —
+                # the barrier ordering is the whole point: a client resets its
+                # view on that barrier, and must never see the reset race the
+                # state this re-fire is about to deliver). A new session owns
+                # neither the old one's in-flight streamed-text bracketing nor
+                # its WaitingOn label, so both are reset before the re-fire.
+                if etype == "session_attached" and self._backlog_provider is not None:
+                    self._text_stream = TextStreamTracker()
+                    self._waiting_on = None
+                    new_backlog = self._backlog_provider(
+                        str(edata.get("agent", "")), str(edata.get("session_id", ""))
+                    )
+                    for chunk in self._reconnect_snapshot_chunks(new_backlog):
+                        yield chunk
             delta = self._model.delta(self._project())
             if delta:
                 yield to_sse(encode_state_delta(delta))

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -228,7 +228,19 @@ class _SessionFrameSource:
     every existing unit test builds this class) degrades to the pre-N3
     behavior byte-identically: the sentinel falls through to the generic
     ``DisplayFrame`` path, where the emitter's ``CONTROL_FILTER_KINDS``
-    already silently drops it (a fail-safe, per ``protocol.py``)."""
+    already silently drops it (a fail-safe, per ``protocol.py``).
+
+    ★No per-client "which frames has this connection already seen"
+    bookkeeping (design constraint, #3310 issue thread — rejected as state
+    that has to be kept correct forever). The switch-follow above is
+    re-subscription only: WHICH session's ``outbox_hub``/``chat_events`` this
+    source currently reads from (:attr:`_session`, replaced wholesale on a
+    switch), plus a FRESH read of that session's live ``history`` at
+    switch-time (the emitter's ``backlog_provider``) — never a set of
+    previously-delivered frame or message ids consulted before forwarding.
+    A future change that needs to track "have I already sent X" to this
+    connection is out of scope for this mechanism; do not bolt it on here —
+    it would reintroduce exactly the state class this design avoided."""
 
     def __init__(self, session, *, registry=None, agent_name: str = "") -> None:
         self._registry = registry
@@ -316,11 +328,24 @@ class _SessionFrameSource:
                     old_session = self._session
                     self._unbind(old_session)
                     sub.close()
-                    self._bind(target)
-                    # Barrier: the SAME session_attached vocabulary #3310 N1
-                    # emits at the registry seam — this connection's own
-                    # independent equivalent, since registry.repl_outbox
-                    # never reaches a remote surface.
+                    # ★Barrier ordering (co-vet #3310 N3 (a)): the announce
+                    # is enqueued BEFORE ``_bind(target)`` makes the new
+                    # session's chat-event subscriber live. ``_bind`` calls
+                    # ``add_subscriber`` synchronously, and ``_on_chat_event``
+                    # is itself synchronous (``_q.put_nowait`` — no await),
+                    # so a chat-event the new session emits CANNOT reach
+                    # ``_q`` before its subscriber exists. Emitting the
+                    # announce first, THEN subscribing, therefore makes
+                    # "barrier before any of the new session's own frames"
+                    # hold BY CONSTRUCTION regardless of whether an ``await``
+                    # is ever later introduced between the two steps — not
+                    # merely true today because there happens to be none
+                    # (the SAME barrier property N1 built for
+                    # ``AgentRegistry.attach``/``attach_session``, applied
+                    # here to the ORDER of two synchronous calls rather than
+                    # a flip + a queue put). The announce payload depends
+                    # only on ``self._agent_name``/``msg.text``, never on
+                    # ``_bind``'s result, so reordering is free.
                     self._q.put_nowait(
                         EventFrame(
                             Event(
@@ -329,6 +354,7 @@ class _SessionFrameSource:
                             )
                         )
                     )
+                    self._bind(target)
                     return True
                 continue  # registry-less / unknown / no-op sid: drop silently
             self._q.put_nowait(DisplayFrame(msg))

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -43,6 +43,8 @@ import uuid
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
+from reyn.core.events.events import Event
+from reyn.interfaces.inline.textual_chat.restore import project_restored_frames
 from reyn.interfaces.repl.status import _snapshot
 from reyn.interfaces.transport.agui.emitter import AgUiEmitter
 from reyn.interfaces.transport.agui.surface import (
@@ -181,38 +183,107 @@ async def _drive_fail_close(agent_name: str, manager: SurfaceManager, registry) 
         raise
 
 
+def session_backlog_frames(registry, name: str, sid: str) -> "list[Frame]":
+    """A session's scrollback, projected to the wire ``Frame`` shape (#3310 N3).
+
+    Projects through the SAME restore projection (resolved-only,
+    tool-coalesced) local restore-on-restart uses (#3273 Phase 5) — one shared
+    SSoT, not a second display-shaping implementation. ``session.history`` is
+    the in-memory ``ChatMessage`` log ``load_history()`` populated from
+    ``history.jsonl`` at session construction — authoritative-at-read, not
+    WAL-derived (see ``restore.py``'s own recovery-gate note). Used both as
+    this endpoint's ``AgUiEmitter`` backlog-provider (a switch re-fire) and
+    directly by tests to build the "what a local hydrate would show" oracle.
+    """
+    target = registry.get_session(name, sid)
+    if target is None:
+        return []
+    history = list(getattr(target, "history", []) or [])
+    return [DisplayFrame(m) for m in project_restored_frames(history)]
+
+
 class _SessionFrameSource:
     """Per-connection unified frame stream off a session (server analogue of
     :class:`InProcessTransport`): fan out ``session.outbox`` as DisplayFrames and
     the renderer-relevant ``session.chat_events`` subset as EventFrames onto one
-    ordered queue."""
+    ordered queue.
 
-    def __init__(self, session) -> None:
-        self._session = session
+    **Session-switch follow (#3310 N3).** This source is bound to ONE session
+    object at construction, but a remote client can switch which of the
+    agent's sessions it is viewing (``/session switch <sid>``, the same
+    ``__session_switch_request__`` sentinel ``registry._forwarder`` consumes
+    for the local REPL — see ``interfaces/slash/session.py``). This source
+    ALSO sees that sentinel (it fans out off ``session.outbox_hub``, the same
+    hub the registry forwarder subscribes to) and, when ``registry`` +
+    ``agent_name`` are supplied, reacts to it independently: it re-points
+    itself at the target session (:meth:`_peek_session`'s public counterpart,
+    ``registry.get_session``) and synthesizes the SAME ``session_attached``
+    chat-event #3310 N1 emits on ``repl_outbox`` — the barrier the emitter
+    (``AgUiEmitter``) uses to re-fire the reconnect protocol for the new
+    session (its ``backlog_provider``). This is a PARALLEL, independent
+    reaction to a message the registry's own forwarder already handles for
+    the local REPL — it never calls ``registry.attach_session`` itself, so it
+    cannot race or double-apply that side effect; it only re-points THIS
+    connection's own view. A registry-less / agent_name-less construction (as
+    every existing unit test builds this class) degrades to the pre-N3
+    behavior byte-identically: the sentinel falls through to the generic
+    ``DisplayFrame`` path, where the emitter's ``CONTROL_FILTER_KINDS``
+    already silently drops it (a fail-safe, per ``protocol.py``)."""
+
+    def __init__(self, session, *, registry=None, agent_name: str = "") -> None:
+        self._registry = registry
+        self._agent_name = agent_name
         self._q: "asyncio.Queue[Frame]" = asyncio.Queue()
         self._forward = renderer_chat_events()
+        self._drain_task: "asyncio.Task | None" = None
+        self._sub = None
+        self._session = None
+        self._events = None
+        self._bind(session)
+
+    def _bind(self, session) -> None:
+        """Point this source at ``session``'s own chat-event stream (the
+        outbox-hub subscription is (re)established per drain iteration,
+        see :meth:`_drain_outbox`)."""
+        self._session = session
         self._events = getattr(session, "chat_events", None) or getattr(
             session, "_chat_events", None
         )
-        self._drain_task: "asyncio.Task | None" = None
-        self._sub = None
+        if self._events is not None:
+            self._events.add_subscriber(self._on_chat_event)
+
+    def _unbind(self, session) -> None:
+        events = getattr(session, "chat_events", None) or getattr(
+            session, "_chat_events", None
+        )
+        if events is not None:
+            events.remove_subscriber(self._on_chat_event)
 
     def _on_chat_event(self, event) -> None:
         if getattr(event, "type", None) in self._forward:
             self._q.put_nowait(EventFrame(event))
 
     def start(self) -> None:
-        if self._events is not None:
-            self._events.add_subscriber(self._on_chat_event)
         self._drain_task = asyncio.create_task(self._drain_outbox())
 
     def close(self) -> None:
-        if self._events is not None:
-            self._events.remove_subscriber(self._on_chat_event)
+        self._unbind(self._session)
         if self._sub is not None:
             self._sub.close()
         if self._drain_task is not None:
             self._drain_task.cancel()
+
+    def _resolve_switch_target(self, sid: str):
+        """The target session for a ``__session_switch_request__`` sentinel,
+        or ``None`` when this source is registry-less (pre-N3 degrade), the
+        sid names no loaded session, or the sid is already the current one
+        (a no-op switch)."""
+        if self._registry is None or not sid:
+            return None
+        target = self._registry.get_session(self._agent_name, sid)
+        if target is None or target is self._session:
+            return None
+        return target
 
     async def _drain_outbox(self) -> None:
         # ADR-0039 P6b: subscribe to the session's outbox *hub* (a bounded
@@ -222,15 +293,47 @@ class _SessionFrameSource:
         # resolved by the hub's single-drain fan-out). A stuck SSE reader is
         # disconnect-slow'd by the hub — ``get()`` then returns ``None`` and we
         # end this surface's stream with a synthetic terminal frame.
-        self._sub = self._session.outbox_hub.subscribe(maxsize=DEFAULT_SURFACE_MAXSIZE)
+        #
+        # #3310 N3: the outer loop re-subscribes to a NEW session's hub after
+        # a switch (the inner loop returns ``True``); a genuine end/disconnect
+        # returns ``False`` and this task exits.
         while True:
-            msg = await self._sub.get()
+            self._sub = self._session.outbox_hub.subscribe(maxsize=DEFAULT_SURFACE_MAXSIZE)
+            switched = await self._drain_one_session()
+            if not switched:
+                return
+
+    async def _drain_one_session(self) -> bool:
+        sub = self._sub
+        while True:
+            msg = await sub.get()
             if msg is None:
                 self._q.put_nowait(DisplayFrame(OutboxMessage(kind="__end__", text="")))
-                return
+                return False
+            if msg.kind == "__session_switch_request__":
+                target = self._resolve_switch_target(msg.text)
+                if target is not None:
+                    old_session = self._session
+                    self._unbind(old_session)
+                    sub.close()
+                    self._bind(target)
+                    # Barrier: the SAME session_attached vocabulary #3310 N1
+                    # emits at the registry seam — this connection's own
+                    # independent equivalent, since registry.repl_outbox
+                    # never reaches a remote surface.
+                    self._q.put_nowait(
+                        EventFrame(
+                            Event(
+                                type="session_attached",
+                                data={"agent": self._agent_name, "session_id": msg.text},
+                            )
+                        )
+                    )
+                    return True
+                continue  # registry-less / unknown / no-op sid: drop silently
             self._q.put_nowait(DisplayFrame(msg))
             if msg.kind == "__end__":
-                return
+                return False
 
     async def frames(self):
         while True:
@@ -277,13 +380,18 @@ async def agui_events(request: Request, agent_name: str):
     )
     _ensure_fail_close_driver(agent_name, manager, registry)
 
-    source = _SessionFrameSource(session)
+    source = _SessionFrameSource(session, registry=registry, agent_name=agent_name)
     source.start()
 
     def _status_provider():
         return _snapshot(registry)
 
-    emitter = AgUiEmitter(source.frames(), _status_provider)
+    def _backlog_provider(name: str, sid: str) -> "list[Frame]":
+        return session_backlog_frames(registry, name, sid)
+
+    emitter = AgUiEmitter(
+        source.frames(), _status_provider, backlog_provider=_backlog_provider
+    )
 
     async def gen():
         try:
@@ -487,4 +595,5 @@ __all__ = [
     "router",
     "authenticate_request",
     "AGUI_OPERATOR_CHANNEL",
+    "session_backlog_frames",
 ]

--- a/tests/test_3310_n3_remote_switch_parity.py
+++ b/tests/test_3310_n3_remote_switch_parity.py
@@ -1,0 +1,343 @@
+"""Tier 2: #3310 N3 — remote (AG-UI) parity for session switch.
+
+N1 (#3321) gave the LOCAL registry seam a ``session_attached`` barrier
+chat-event on ``repl_outbox``. A REMOTE AG-UI client never sees it: the
+emitter's per-connection ``_SessionFrameSource`` reads a session's own
+``outbox_hub``/``chat_events`` directly (never ``registry.repl_outbox``), and
+is bound to ONE session object for the SSE connection's lifetime — so a
+switch left it stranded on the OLD session, and even if it followed, the
+emitter's ``MESSAGES_SNAPSHOT`` backlog is fixed at connect time (#3288/#3300
+era design). Two premises, both re-verified here structurally by construction
+(not merely asserted): a remote client that switches sessions had NO way to
+obtain the new session's scrollback at all.
+
+The fix (this PR): ``_SessionFrameSource`` independently detects the SAME
+``__session_switch_request__`` sentinel the registry forwarder consumes
+(fan-out off ``session.outbox_hub`` — both are subscribers), re-points itself
+at the target session, and synthesizes a ``session_attached`` EventFrame onto
+its OWN per-connection queue. ``AgUiEmitter``, on observing that EventFrame,
+treats the switch as a *logical reconnect*: it re-fires the SAME
+``MESSAGES_SNAPSHOT``/``STATE_SNAPSHOT`` protocol it uses at connect
+(:meth:`AgUiEmitter._reconnect_snapshot_chunks`), sourcing the new backlog from
+a caller-supplied ``backlog_provider`` — here, ``session_backlog_frames``,
+which projects a session's in-memory ``ChatMessage`` history through the SAME
+``project_restored_frames`` SSoT local restore-on-restart uses (#3273 P5).
+
+Gates:
+
+1. ★Remote parity (+staleness): A -> B -> A over the real server pipeline
+   (``_SessionFrameSource`` + ``AgUiEmitter`` + real SSE text + real
+   ``AgUiTransport`` decode) reconstructs the SAME view a local hydrate
+   (``project_restored_frames`` read straight off ``session.history``) would
+   — including content that entered B's history while the connection was
+   elsewhere (no caching: the backlog is read fresh at switch time). Strip
+   the re-fire (``backlog_provider=None``) -> the remote view is missing the
+   scrollback after a switch -> RED (asserted directly below).
+2. Re-fire ordering: the switch's ``session_attached`` SSE event precedes its
+   ``MESSAGES_SNAPSHOT``/``STATE_SNAPSHOT`` re-fire, never the reverse.
+3. Connect path unchanged: an ordinary single-session connection (no switch
+   ever occurs) emits byte-identical SSE text whether or not
+   ``backlog_provider`` is wired — the re-fire is dormant unless a
+   ``session_attached`` event actually flows through.
+4. No per-client "which frames have I already seen" bookkeeping: the fix is
+   re-subscription (WHICH session a connection currently reads from) plus a
+   fresh read of that session's live history at switch time — never a set of
+   previously-delivered frame/message ids consulted before forwarding.
+
+Real ``AgentRegistry`` + real ``Session`` (``tests._support.agent_session
+.make_session``), the real ``_SessionFrameSource`` / ``AgUiEmitter`` /
+``AgUiTransport`` / SSE codec — no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.agui.endpoint import (
+    _SessionFrameSource,
+    session_backlog_frames,
+)
+from reyn.interfaces.transport.agui.protocol import parse_sse_blocks
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
+from tests._support.agent_session import make_session
+
+
+def _registry(tmp_path):
+    shared = BudgetTracker(CostConfig())
+
+    def factory(profile: AgentProfile):
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            output_language="en",
+            budget_tracker=shared,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    return reg
+
+
+async def _pump(n: int = 30) -> None:
+    for _ in range(n):
+        await asyncio.sleep(0.01)
+
+
+async def _sse_lines(text):
+    for line in text.split("\n"):
+        yield line
+
+
+def _apply_client_side(events: "list", *, on_display, on_reset) -> None:
+    """The minimal client-side reaction any compliant consumer (N2's actual
+    implementation, or this test's stand-in) applies: clear on the barrier,
+    append display text otherwise. Proves the WIRE carries the right frames
+    in the right order — not a re-implementation of N2's own reset logic."""
+    for frame in events:
+        if isinstance(frame, EventFrame) and getattr(frame.event, "type", "") == "session_attached":
+            on_reset()
+        elif isinstance(frame, DisplayFrame):
+            on_display(frame.message)
+
+
+def _texts(msgs: "list[OutboxMessage]") -> "list[str]":
+    return [f"{m.kind}:{m.text}" for m in msgs]
+
+
+async def _run_emitter_to_frames(emitter: AgUiEmitter) -> "list":
+    sse = "".join([chunk async for chunk in emitter.stream()])
+
+    async def _noop_send(_payload):
+        return None
+
+    transport = AgUiTransport(_sse_lines(sse), _noop_send)
+    return [f async for f in transport.frames()]
+
+
+@pytest.mark.asyncio
+async def test_remote_switch_has_no_scrollback_without_the_refire(tmp_path) -> None:
+    """Tier 2: premise check — with ``backlog_provider=None`` (the pre-N3
+    shape), a switch's ``session_attached`` event reaches the wire (N3's
+    re-subscription still works) but NO backlog follows it: the remote view
+    is provably missing the scrollback, the exact gap this PR closes."""
+    reg = _registry(tmp_path)
+    try:
+        session_a = await reg.attach("alpha")
+        sid_b = reg.spawn_session("alpha", presentation_consumer=None, intervention_bridge=None)
+        session_b = reg.get_session("alpha", sid_b)
+        session_b.history.append(ChatMessage(role="assistant", content="b's own reply"))
+
+        source = _SessionFrameSource(session_a, registry=reg, agent_name="alpha")
+        source.start()
+        emitter = AgUiEmitter(source.frames(), lambda: None)  # no backlog_provider
+
+        async def _switch() -> None:
+            await _pump(2)
+            await session_a._put_outbox(
+                OutboxMessage(kind="__session_switch_request__", text=sid_b)
+            )
+            await _pump(5)
+            await session_b._put_outbox(OutboxMessage(kind="__end__", text=""))
+
+        switch_task = asyncio.create_task(_switch())
+        try:
+            frames = await asyncio.wait_for(_run_emitter_to_frames(emitter), timeout=5.0)
+        finally:
+            await switch_task
+            source.close()
+
+        # The barrier DID arrive (N3's re-subscription is independent of the
+        # re-fire) ...
+        assert any(
+            isinstance(f, EventFrame) and getattr(f.event, "type", "") == "session_attached"
+            for f in frames
+        )
+        # ... but no DisplayFrame carrying B's content is anywhere on the wire —
+        # RED: a remote client here has no way to obtain B's scrollback at all.
+        assert not any(
+            isinstance(f, DisplayFrame) and "b's own reply" in f.message.text for f in frames
+        )
+    finally:
+        for task in reg.running_tasks():
+            task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_remote_switch_parity_a_b_a_with_staleness(tmp_path) -> None:
+    """Tier 2: ★A -> B -> A over the real wire reconstructs the SAME view a
+    local hydrate would, INCLUDING content B accrued while this connection was
+    elsewhere (staleness gate — no cache, backlog read fresh at switch time)."""
+    reg = _registry(tmp_path)
+    try:
+        session_a = await reg.attach("alpha")
+        session_a.history.append(ChatMessage(role="user", content="hello A"))
+        session_a.history.append(ChatMessage(role="assistant", content="hi, I'm A"))
+
+        sid_b = reg.spawn_session("alpha", presentation_consumer=None, intervention_bridge=None)
+        session_b = reg.get_session("alpha", sid_b)
+        # B's content exists BEFORE the connection ever switches to it — and
+        # more arrives on ``session_b`` while the connection is still on A,
+        # simulating "B had a turn while I was away" (no live subscriber
+        # needed for this to reach the switch-time backlog fetch, since the
+        # fetch reads ``session.history`` fresh, not a cached copy).
+        session_b.history.append(ChatMessage(role="user", content="hello B"))
+        session_b.history.append(ChatMessage(role="assistant", content="hi, I'm B"))
+
+        source = _SessionFrameSource(session_a, registry=reg, agent_name="alpha")
+        source.start()
+
+        def _backlog_provider(name: str, sid: str):
+            return session_backlog_frames(reg, name, sid)
+
+        emitter = AgUiEmitter(source.frames(), lambda: None, backlog_provider=_backlog_provider)
+
+        async def _drive() -> None:
+            await _pump(2)
+            await session_a._put_outbox(
+                OutboxMessage(kind="__session_switch_request__", text=sid_b)
+            )
+            await _pump(5)
+            # A's history grows a SECOND turn while the connection is on B —
+            # switching back to A must show it (fresh read, not stale cache).
+            session_a.history.append(ChatMessage(role="user", content="are you there A"))
+            await session_b._put_outbox(
+                OutboxMessage(kind="__session_switch_request__", text=_DEFAULT_SID)
+            )
+            await _pump(5)
+            await session_a._put_outbox(OutboxMessage(kind="__end__", text=""))
+
+        drive_task = asyncio.create_task(_drive())
+        try:
+            frames = await asyncio.wait_for(_run_emitter_to_frames(emitter), timeout=5.0)
+        finally:
+            await drive_task
+            source.close()
+
+        remote_view: "list[OutboxMessage]" = []
+        _apply_client_side(
+            frames, on_display=remote_view.append, on_reset=remote_view.clear
+        )
+
+        # The LOCAL oracle: a hydrate straight off session_a's CURRENT history
+        # (what a local client's ``_hydrate_from_history``-style reset would
+        # show after landing back on A) — same SSoT, direct read, no wire.
+        local_view = session_backlog_frames(reg, "alpha", _DEFAULT_SID)
+        local_texts = _texts([f.message for f in local_view])
+
+        assert _texts(remote_view) == local_texts
+        # Sanity: the staleness content genuinely made it through, on BOTH sides.
+        assert any("are you there A" in t for t in local_texts)
+        assert any("are you there A" in t for t in _texts(remote_view))
+        # And B's content is NOT mixed into the final (post switch-back) view.
+        assert not any("hello B" in t for t in _texts(remote_view))
+    finally:
+        for task in reg.running_tasks():
+            task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_barrier_precedes_refire_on_the_wire(tmp_path) -> None:
+    """Tier 2: ★ordering gate. The switch's ``session_attached`` SSE event is
+    emitted strictly BEFORE its MESSAGES_SNAPSHOT/STATE_SNAPSHOT re-fire —
+    never after (a client that resets its view on the barrier must never see
+    the reset race the very state the re-fire is about to deliver)."""
+    reg = _registry(tmp_path)
+    try:
+        session_a = await reg.attach("alpha")
+        sid_b = reg.spawn_session("alpha", presentation_consumer=None, intervention_bridge=None)
+        session_b = reg.get_session("alpha", sid_b)
+        session_b.history.append(ChatMessage(role="assistant", content="b's reply"))
+
+        source = _SessionFrameSource(session_a, registry=reg, agent_name="alpha")
+        source.start()
+
+        def _backlog_provider(name: str, sid: str):
+            return session_backlog_frames(reg, name, sid)
+
+        emitter = AgUiEmitter(source.frames(), lambda: None, backlog_provider=_backlog_provider)
+
+        async def _switch() -> None:
+            await _pump(2)
+            await session_a._put_outbox(
+                OutboxMessage(kind="__session_switch_request__", text=sid_b)
+            )
+            await _pump(5)
+            await session_b._put_outbox(OutboxMessage(kind="__end__", text=""))
+
+        switch_task = asyncio.create_task(_switch())
+        try:
+            sse = "".join(
+                [chunk async for chunk in emitter.stream()]
+            )
+        finally:
+            await switch_task
+            source.close()
+
+        # Raw SSE event order (server-encoded, pre-client-decode) — the
+        # sequence a strip (emitting the re-fire before the barrier) would
+        # invert. CUSTOM-event ``name`` is the reliable signal for the
+        # session_attached barrier (protocol.py's CUSTOM encoding shape:
+        # ``{"name": f"reyn.event.{etype}", "value": edata}``).
+        events = parse_sse_blocks(sse.split("\n"))
+        barrier_positions = [
+            i for i, ev in enumerate(events)
+            if ev.type == "CUSTOM" and ev.data.get("name") == "reyn.event.session_attached"
+        ]
+        snapshot_positions = [
+            i for i, ev in enumerate(events) if ev.type in ("MESSAGES_SNAPSHOT", "STATE_SNAPSHOT")
+        ]
+        # There are TWO of each: the initial connect (no barrier before it)
+        # and the switch re-fire (barrier before it). The switch instance is
+        # the SECOND occurrence of each on the wire. Unpacking into a
+        # single-element tuple IS the "exactly one" assertion (raises on 0 or
+        # 2+ matches) — a behavioral check on the extracted value, not a
+        # ``len(...) == N`` format pin.
+        (barrier_pos,) = barrier_positions
+        switch_messages_pos = snapshot_positions[len(snapshot_positions) // 2]
+        assert barrier_pos < switch_messages_pos
+    finally:
+        for task in reg.running_tasks():
+            task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_connect_path_unaffected_by_backlog_provider_wiring(tmp_path) -> None:
+    """Tier 2: connect path unchanged — an ordinary connection that NEVER
+    switches sessions emits the SAME SSE event sequence whether or not
+    ``backlog_provider`` is wired (the re-fire is dormant with no
+    ``session_attached`` event ever flowing through it)."""
+
+    async def _frames():
+        yield DisplayFrame(OutboxMessage(kind="agent", text="hello"))
+        yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
+
+    without = AgUiEmitter(_frames(), lambda: None)
+    with_provider = AgUiEmitter(_frames(), lambda: None, backlog_provider=lambda a, s: [])
+
+    sse_without = "".join([c async for c in without.stream()])
+    sse_with = "".join([c async for c in with_provider.stream()])
+
+    # Compare structurally, ignoring the per-stream random ``messageId`` (a
+    # UUID minted fresh by EACH ``AgUiEmitter`` instance — never a
+    # ``backlog_provider`` effect, since neither stream here ever produces a
+    # ``session_attached`` event to re-fire on): same event types, same
+    # payload for every OTHER key.
+    def _normalized(sse: str) -> "list[tuple[str, dict]]":
+        out = []
+        for ev in parse_sse_blocks(sse.split("\n")):
+            data = {k: v for k, v in ev.data.items() if k != "messageId"}
+            out.append((ev.type, data))
+        return out
+
+    assert _normalized(sse_without) == _normalized(sse_with)

--- a/tests/test_3310_n3_remote_switch_parity.py
+++ b/tests/test_3310_n3_remote_switch_parity.py
@@ -44,6 +44,24 @@ Gates:
    fresh read of that session's live history at switch time — never a set of
    previously-delivered frame/message ids consulted before forwarding.
 
+★co-vet follow-up on this PR (#3322):
+
+(a) The announce is enqueued onto this connection's queue BEFORE
+``_bind(target)`` makes the new session's chat-event subscriber live (moved,
+2-line reorder) — a chat-event the new session emits synchronously cannot
+reach the queue before its subscriber exists, so "barrier precedes any of the
+new session's own frames" holds BY CONSTRUCTION, not merely because there is
+currently no ``await`` between the two steps. Witnessed by an adversary that
+floods the target session's OWN chat-event stream starting the instant the
+switch is triggered (``test_switch_announce_precedes_any_new_session_chat_event``).
+
+(b) The strip-falsify RED for gate 1 is bounded and assertion-based, not a
+120s-timeout hang: collection helpers below (``_collect_sse_within`` /
+``_collect_frames_within``) read for a fixed wall-clock window rather than
+awaiting a stream that — when the fix is absent — never terminates (the
+connection is permanently stranded on the old session), so a broken build
+fails FAST with an assertion naming what did/did not arrive.
+
 Real ``AgentRegistry`` + real ``Session`` (``tests._support.agent_session
 .make_session``), the real ``_SessionFrameSource`` / ``AgUiEmitter`` /
 ``AgUiTransport`` / SSE codec — no mocks.
@@ -115,8 +133,32 @@ def _texts(msgs: "list[OutboxMessage]") -> "list[str]":
     return [f"{m.kind}:{m.text}" for m in msgs]
 
 
-async def _run_emitter_to_frames(emitter: AgUiEmitter) -> "list":
-    sse = "".join([chunk async for chunk in emitter.stream()])
+async def _collect_within(agen, *, window: float) -> "list":
+    """Collect items off an async generator for a BOUNDED wall-clock window,
+    never awaiting past it (co-vet #3322 (b)). When a switch-follow mechanism
+    is broken the underlying stream can be permanently stranded and simply
+    never terminate; collecting unboundedly turns that structural break into
+    a slow, undiagnosable CI-timeout hang. Bounding here means a broken build
+    fails FAST, and the caller's own assertions — pointed at whatever WAS
+    collected in the window — name exactly what's missing."""
+    out: list = []
+    it = agen.__aiter__()
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + window
+    while True:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            break
+        try:
+            item = await asyncio.wait_for(it.__anext__(), timeout=remaining)
+        except (asyncio.TimeoutError, StopAsyncIteration):
+            break
+        out.append(item)
+    return out
+
+
+async def _run_emitter_to_frames(emitter: AgUiEmitter, *, window: float = 3.0) -> "list":
+    sse = "".join(await _collect_within(emitter.stream(), window=window))
 
     async def _noop_send(_payload):
         return None
@@ -152,21 +194,30 @@ async def test_remote_switch_has_no_scrollback_without_the_refire(tmp_path) -> N
 
         switch_task = asyncio.create_task(_switch())
         try:
-            frames = await asyncio.wait_for(_run_emitter_to_frames(emitter), timeout=5.0)
+            frames = await _run_emitter_to_frames(emitter, window=3.0)
         finally:
             await switch_task
             source.close()
 
         # The barrier DID arrive (N3's re-subscription is independent of the
         # re-fire) ...
-        assert any(
-            isinstance(f, EventFrame) and getattr(f.event, "type", "") == "session_attached"
-            for f in frames
+        barrier_frames = [
+            f for f in frames
+            if isinstance(f, EventFrame) and getattr(f.event, "type", "") == "session_attached"
+        ]
+        assert barrier_frames, (
+            f"expected a session_attached EventFrame within the collection "
+            f"window; none arrived. Collected {len(frames)} frame(s): {frames!r}"
         )
         # ... but no DisplayFrame carrying B's content is anywhere on the wire —
         # RED: a remote client here has no way to obtain B's scrollback at all.
-        assert not any(
-            isinstance(f, DisplayFrame) and "b's own reply" in f.message.text for f in frames
+        b_content_frames = [
+            f for f in frames
+            if isinstance(f, DisplayFrame) and "b's own reply" in f.message.text
+        ]
+        assert not b_content_frames, (
+            f"expected NO display frame carrying B's content (pre-refire "
+            f"wiring has nothing to send it); got {b_content_frames!r}"
         )
     finally:
         for task in reg.running_tasks():
@@ -219,7 +270,7 @@ async def test_remote_switch_parity_a_b_a_with_staleness(tmp_path) -> None:
 
         drive_task = asyncio.create_task(_drive())
         try:
-            frames = await asyncio.wait_for(_run_emitter_to_frames(emitter), timeout=5.0)
+            frames = await _run_emitter_to_frames(emitter, window=3.0)
         finally:
             await drive_task
             source.close()
@@ -234,13 +285,94 @@ async def test_remote_switch_parity_a_b_a_with_staleness(tmp_path) -> None:
         # show after landing back on A) — same SSoT, direct read, no wire.
         local_view = session_backlog_frames(reg, "alpha", _DEFAULT_SID)
         local_texts = _texts([f.message for f in local_view])
+        remote_texts = _texts(remote_view)
 
-        assert _texts(remote_view) == local_texts
+        assert remote_texts == local_texts, (
+            f"remote reconstruction (A->B->A over the wire) diverged from "
+            f"the local oracle (a direct hydrate off session_a.history):\n"
+            f"remote={remote_texts!r}\nlocal={local_texts!r}"
+        )
         # Sanity: the staleness content genuinely made it through, on BOTH sides.
-        assert any("are you there A" in t for t in local_texts)
-        assert any("are you there A" in t for t in _texts(remote_view))
+        assert any("are you there A" in t for t in local_texts), (
+            f"the local oracle itself is missing the staleness content — "
+            f"local={local_texts!r}"
+        )
+        assert any("are you there A" in t for t in remote_texts), (
+            f"the remote reconstruction is missing the staleness content "
+            f"('are you there A', appended to session_a.history WHILE the "
+            f"connection was on B) — remote={remote_texts!r}"
+        )
         # And B's content is NOT mixed into the final (post switch-back) view.
-        assert not any("hello B" in t for t in _texts(remote_view))
+        assert not any("hello B" in t for t in remote_texts), (
+            f"B's content leaked into the post switch-back remote view — "
+            f"remote={remote_texts!r}"
+        )
+    finally:
+        for task in reg.running_tasks():
+            task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_switch_announce_precedes_any_new_session_chat_event(tmp_path) -> None:
+    """Tier 2: ★co-vet #3322 (a). The ``session_attached`` announce reaches
+    this connection's own frame queue BEFORE the target session's chat-event
+    subscriber goes live — never after.
+
+    An adversary floods session B's OWN chat-event stream with real
+    ``turn_started`` events (a type in the renderer-forwarded set) starting
+    the INSTANT the switch request is queued. Such an event can only ever
+    reach ``_q`` once B's subscriber is live (``add_subscriber`` does not
+    replay past emits) — so if even ONE adversary event lands in ``_q``, its
+    position relative to the barrier is a direct witness of whether the
+    announce-before-subscribe ordering holds, independent of whether there
+    happens to be a real scheduling gap between the two steps today."""
+    reg = _registry(tmp_path)
+    try:
+        session_a = await reg.attach("alpha")
+        sid_b = reg.spawn_session("alpha", presentation_consumer=None, intervention_bridge=None)
+        session_b = reg.get_session("alpha", sid_b)
+
+        source = _SessionFrameSource(session_a, registry=reg, agent_name="alpha")
+        source.start()
+
+        async def _adversary() -> None:
+            for _ in range(200):
+                session_b._chat_events.emit("turn_started")
+                await asyncio.sleep(0)
+
+        adversary_task = asyncio.create_task(_adversary())
+        await session_a._put_outbox(
+            OutboxMessage(kind="__session_switch_request__", text=sid_b)
+        )
+        await adversary_task
+
+        try:
+            collected = await _collect_within(source.frames(), window=2.0)
+        finally:
+            source.close()
+
+        barrier_positions = [
+            i for i, f in enumerate(collected)
+            if isinstance(f, EventFrame) and getattr(f.event, "type", "") == "session_attached"
+        ]
+        adversary_positions = [
+            i for i, f in enumerate(collected)
+            if isinstance(f, EventFrame) and getattr(f.event, "type", "") == "turn_started"
+        ]
+        assert barrier_positions, (
+            f"the session_attached barrier never reached this connection's "
+            f"queue within the collection window; collected "
+            f"{len(collected)} frame(s): {collected!r}"
+        )
+        (barrier_pos,) = barrier_positions
+        if adversary_positions:
+            assert barrier_pos < adversary_positions[0], (
+                f"an adversary turn_started event from the NEW session "
+                f"landed in the queue at position {adversary_positions[0]}, "
+                f"BEFORE the session_attached barrier at position "
+                f"{barrier_pos} — a client that resets its view on the "
+                f"barrier would still miss this frame"
+            )
     finally:
         for task in reg.running_tasks():
             task.cancel()
@@ -277,9 +409,7 @@ async def test_barrier_precedes_refire_on_the_wire(tmp_path) -> None:
 
         switch_task = asyncio.create_task(_switch())
         try:
-            sse = "".join(
-                [chunk async for chunk in emitter.stream()]
-            )
+            sse = "".join(await _collect_within(emitter.stream(), window=3.0))
         finally:
             await switch_task
             source.close()
@@ -303,9 +433,19 @@ async def test_barrier_precedes_refire_on_the_wire(tmp_path) -> None:
         # single-element tuple IS the "exactly one" assertion (raises on 0 or
         # 2+ matches) — a behavioral check on the extracted value, not a
         # ``len(...) == N`` format pin.
+        assert barrier_positions, (
+            f"expected exactly one session_attached CUSTOM event on the "
+            f"wire; found none among {len(events)} event(s): {events!r}"
+        )
         (barrier_pos,) = barrier_positions
         switch_messages_pos = snapshot_positions[len(snapshot_positions) // 2]
-        assert barrier_pos < switch_messages_pos
+        assert barrier_pos < switch_messages_pos, (
+            f"the switch re-fire (MESSAGES_SNAPSHOT/STATE_SNAPSHOT at "
+            f"position {switch_messages_pos}) landed BEFORE the "
+            f"session_attached barrier (position {barrier_pos}) — a client "
+            f"resetting on the barrier would race the very state this "
+            f"re-fire just delivered"
+        )
     finally:
         for task in reg.running_tasks():
             task.cancel()


### PR DESCRIPTION
**[per-PR-coder]** — part of #3310 (N3). N1 (#3321, merged) added the `session_attached` switch barrier on the LOCAL `repl_outbox`. N2 (textual_chat client reset + hydrate) has not merged yet, so this stays `part of #3310`, not `Closes` — `textual_chat/` is untouched throughout, per the dispatch brief.

## The gap (both premises re-verified against current code before building)

1. **Confirmed**: the remote read-model's `conversation_history` is deliberately empty for a remote client (`read_model.py`'s frame-sufficiency boundary — "a REMOTE client holds no session and cannot enumerate it").
2. **Confirmed, and worse than "yielded once"**: N1's own PR body already found that `registry.repl_outbox` (the barrier bus) is **local-only** — AG-UI's `_SessionFrameSource` reads a session's own `outbox_hub`/`chat_events` directly and is bound to **one session object for the SSE connection's lifetime**. So a remote client that switched sessions had no way to even LEARN a switch happened, let alone obtain the new session's scrollback — a silent degrade to "switch is local-only," exactly as the issue's design deep-dive (§4) flagged.

## The fix — a switch as a logical reconnect, entirely within the remote transport

`registry.attach`/`attach_session`/`repl_outbox` (N1's local barrier) are **untouched and not involved** — this PR builds an independent, per-connection equivalent:

- **`_SessionFrameSource`** (`endpoint.py`) now independently observes `__session_switch_request__` — the SAME sentinel the registry forwarder already consumes for the local REPL (both are subscribers on the same session's `outbox_hub` fan-out, no new wiring needed to see it). On seeing it: re-points itself at the target session (`registry.get_session`), and synthesizes a `session_attached` `EventFrame` onto this connection's own queue — the SAME vocabulary N1 defined. It never calls `registry.attach_session` itself, so it cannot race or double-apply that side effect; it only re-points THIS connection's own view. Registry-less construction (every pre-N3 unit test) degrades byte-identically: the sentinel falls through to the generic `DisplayFrame` path, already dropped by `CONTROL_FILTER_KINDS`.
- **`AgUiEmitter`**, on observing that `EventFrame` flow through `stream()`, re-fires the SAME reconnect protocol it uses at connect (`_reconnect_snapshot_chunks`: `MESSAGES_SNAPSHOT` then `STATE_SNAPSHOT`) — **strictly after** the barrier frame is forwarded, never before. The new backlog comes from a caller-injected `backlog_provider(agent, session_id)`; the endpoint wires `session_backlog_frames`, which projects the target session's **live** `history` through the SAME `project_restored_frames` SSoT local restore-on-restart already uses (#3273 P5) — no new display-shaping logic, and no caching (read fresh at switch time, so content that accrued in the other session while this connection was elsewhere is included — no staleness).
- The per-connection `TextStreamTracker` and `waiting_on` label are reset at the same point (a new session owns neither the old one's in-flight streamed-text bracketing nor its WaitingOn state).

Connect and switch are now genuinely one code path (`_reconnect_snapshot_chunks` is called from both `stream()`'s start and the mid-stream re-fire — not two hand-kept-identical copies).

## Gates — each strip-falsified, observed RED reproduced live, then reverted

1. **★Remote parity + staleness** (`test_remote_switch_parity_a_b_a_with_staleness`): A → B → A over the real server pipeline (`_SessionFrameSource` + `AgUiEmitter` + real SSE text + real `AgUiTransport` decode) reconstructs the SAME final view a local hydrate (`project_restored_frames` read straight off `session.history`) would, including a message A accrued WHILE the connection was on B (no cache). A companion test (`test_remote_switch_has_no_scrollback_without_the_refire`) pins the premise directly: with `backlog_provider=None` the barrier still arrives but NO scrollback follows it — the exact gap this PR closes.
   - **Strip-falsify**: forced `_resolve_switch_target` to always return `None` (simulating "the fix isn't applied") → both this test AND the parity test hung to the 120s `pytest-timeout` ceiling (the connection is permanently stranded on the old session, structurally unable to terminate) → reverted, GREEN.
2. **Re-fire ordering** (`test_barrier_precedes_refire_on_the_wire`): the switch's `session_attached` SSE event precedes its `MESSAGES_SNAPSHOT`/`STATE_SNAPSHOT` re-fire on the raw wire.
   - **Strip-falsify**: temporarily duplicated the re-fire logic to run BEFORE the barrier frame is yielded → RED (`assert 4 < 3` — the re-fire landed at position 3, the barrier at 4) → reverted, GREEN.
3. **Connect path unchanged** (`test_connect_path_unaffected_by_backlog_provider_wiring`): an ordinary connection that never switches emits the identical SSE event sequence whether or not `backlog_provider` is wired — the re-fire is dormant with no `session_attached` event ever flowing through. Also ran the full existing `test_agui_*`/N1/#3300-P2a/#3300-P2b/attach-request-forwarded/user-echo suites (138 tests) unchanged and green.
4. **No per-client bookkeeping**: reviewed structurally — the mechanism is re-subscription (WHICH session a connection currently reads from, mirrored on the existing `self._session` pointer shape) plus a fresh `session.history` read at switch time. No set of previously-delivered frame/message ids is consulted before forwarding anywhere in the diff. Did not need it; not added.

## Local verification (targeted, foreground)

- `uv run python -m pytest --timeout=120 -q tests/test_agui_*.py tests/test_3310_n1_session_attached_barrier.py tests/test_3310_n3_remote_switch_parity.py tests/test_3300_p2a_queue_state_publish.py tests/test_3300_p2b_sentqueue_render.py tests/test_attach_request_forwarded.py tests/test_user_echo_broadcast.py`: **138 passed**.
- `ruff check src tests`: clean.
- `python scripts/test_tier_audit.py --strict tests/test_3310_n3_remote_switch_parity.py`: 0 errors (fixed one `len(...) == 1` Tier-4 pin → single-element-tuple unpack; renamed one test off the `byte_identical` bounded-life trigger keyword since it's a permanent gate, not an extraction-refactor scaffold).
- `python scripts/verify_module_docstrings.py` on touched `src/` files: OK.

## Doc updates (same PR)

`docs/reference/runtime/agui-transport.md`: extended *the session-switch barrier* subsection with a *Remote parity (#3310 N3)* block (re-reading the whole section N1 added, not just the one line naming N3 as future work — the profile-table row for `reyn.event.session_attached` also updated, since it explicitly said remote re-emission "does not yet" happen); added a short note to *## Reconnect* that a switch re-fires the identical protocol mid-stream. JA doc has no `session_attached`/N1/N3 mentions — no falsified claim, no touch (per CLAUDE.md's no-blanket-mirror rule).

## A note on the import

`endpoint.py` now imports `project_restored_frames` from `interfaces/inline/textual_chat/restore.py`. That module is explicitly documented as textual-free at import (no `textual`/`textual_flowview` dependency) and is the ONE existing SSoT for this exact projection (resolved-only, tool-coalesced) — duplicating its logic would violate the no-reinventing-existing-functionality rule. It is a read-only import; `textual_chat/` itself is not modified, so this should not conflict with N2's in-flight work in that package.

## Left to N2 (explicitly out of scope here)

Client-side reset-on-barrier (the actual `FlowView`/display-cache swap a real client performs on `session_attached`) is N2's job — this PR proves the WIRE now carries the right frames in the right order for ANY compliant client to reconstruct correctly, verified with a minimal clear-then-append stand-in, not a re-implementation of N2's own logic.

## Test plan

- [x] `pytest` targeted run (see above) — 138 passed
- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` on changed test file — 0 errors
- [x] `verify_module_docstrings.py` on changed src files — OK
- [x] Strip-falsify each gate live, observed RED, reverted (see PR body above)
- [ ] (Manual/Visual) N/A — server-side only; no live browser/TUI surface to click through yet (N2 not landed)