### PR TITLE
feat(tui): client-side reset + hydrate on session_attached — #3310 N2

### DIFF
--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -297,6 +297,16 @@ Capability-gated, provider-agnostic token streaming from the LLM call through to
 
 > **Differentiation vs general agents:** streaming is layered onto the SAME single-chokepoint `recorded_acompletion` call, the SAME `OutboxHub`/chat-event fan-out, and the SAME `FlowView` render model every other frame uses — no parallel streaming-only pipeline, no per-provider hardcoding, and no risk of a streamed reply diverging from its non-streamed reconstruction.
 
+### Textual TUI: session-switch reset + rehydrate (#3310 N1/N2)
+
+| Feature | Description | Documentation |
+|---------|-------------|---------------|
+| `session_attached` switch barrier | `AgentRegistry.attach`/`attach_session` emit a `session_attached` chat-event (`{agent, session_id}`) as an `EventFrame` put directly on `repl_outbox` with NO `await` between the attach flip and the put — a stream barrier holding BY CONSTRUCTION (before = old session's frames, after = new session's) | [AG-UI transport § The session-switch barrier](reference/runtime/agui-transport.md) |
+| Local client reset + rehydrate on switch | `TextualChatApp` treats the barrier as a reconnect: clears every per-session client state (retained `FlowModel`, running-tool tracking, pending-intervention tabs, sent-queue view/widget + item-meta, in-flight streamed-reply tracking) and rehydrates from the NEW session's `history.jsonl` — never from a client-side cache, which is stale-by-construction while a session is detached (the forwarder drops its frames entirely) | [AG-UI transport § The session-switch barrier](reference/runtime/agui-transport.md) |
+| Targeted hydrate seam | `ChatReadModel.conversation_history` accepts an optional `(agent, session_id)` — omitted hydrates the currently attached session (pre-N2 behavior unchanged); given, hydrates that specific session (possibly never attached in this client run) via `AgentRegistry.get_session`, no duplicated `history.jsonl` path literal | [AG-UI transport § The session-switch barrier](reference/runtime/agui-transport.md) |
+
+> **Remote parity gap (N3, open):** the AG-UI/SSE remote transport does not yet re-emit `session_attached` on the wire, so a remote client's switch-hydrate is unimplemented today (`RemoteReadModel.conversation_history` degrades to empty regardless of a targeted session — the same frame-sufficiency boundary this arc follows throughout).
+
 ---
 
 ### Control IR Ops

--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -123,7 +123,7 @@ renderable display kinds):
   fail-safe for a future tap-point change, not a live wire kind. (Remote
   attach-label sync is designed separately, not via this legacy sentinel.)
 
-#### The session-switch barrier (`reyn.event.session_attached`, #3310 N1)
+#### The session-switch barrier (`reyn.event.session_attached`, #3310 N1/N2)
 
 `/attach <name>` and `/session switch <sid>` both flip which session's frames
 reach a client — but historically nothing told the client THAT a switch had
@@ -149,11 +149,28 @@ This event is NOT an `OutboxMessage` display kind — the owner-ratified reason
 is the same as #3288 ③b's `agent_delta`: a state transition rides an `EventFrame`
 (opt-in draw — a surface with no handler drops it silently, never a garbage
 row), where registering a closed-vocabulary display kind for it would be a
-category error. Client-side reset (a per-session display cache the client
-swaps on this barrier) is N2, a separate PR; locally, `InProcessTransport`
-forwards this event today, legal per the dual-stream completeness gate's
-one-way direction (forwarded ⊇ consumed is fine; consumed ⊆ forwarded is what
-is enforced) whether or not a given surface has a handler yet.
+category error.
+
+**N2 (client-side reset + hydrate, local — `textual_chat/app.py`).**
+`TextualChatApp._handle_session_attached_event` consumes this event as the
+reset barrier: on receipt it clears every per-session client-side state
+(the retained `FlowModel`, running-tool tracking, pending-intervention
+tabs, the sent-queue view/widget + its item-meta side table, in-flight
+streamed-reply tracking) and rehydrates the retained model from the NEW
+session's `history.jsonl` — **not** from a retained cache. A cached
+`FlowView` cannot be the source of truth here: while a session is
+detached, the registry forwarder *drops* its frames entirely (see the
+control-sentinel dispositions above), so a cache would be missing
+everything that happened meanwhile and would hold tool rows stuck
+RUNNING. `ChatReadModel.conversation_history` (`interfaces/repl/
+read_model.py`) is generalized to accept an optional `(agent,
+session_id)` target — `None`/`None` (the pre-N2 shape) still hydrates
+whichever session is currently attached; a target hydrates that specific
+session instead, resolved via `AgentRegistry.get_session` (never a
+duplicated `history.jsonl` path literal). Pending interventions are
+*forgotten*, not re-fetched — the registry's `attach`/`attach_session`
+already re-announce every pending intervention on attach, so the client
+only needs to stop tracking the old session's entries.
 
 **Remote parity (#3310 N3).** `registry.repl_outbox` (above) is a LOCAL-only
 bus — the AG-UI/SSE `_SessionFrameSource` never drains it; it reads a
@@ -207,6 +224,18 @@ untouched and not involved):
   set of previously-delivered frame/message ids consulted before forwarding.
 - An ordinary connection that never switches sessions is unaffected — the
   re-fire is dormant with no `session_attached` event ever flowing through.
+
+Both consumers are now landed: **N1** provides the barrier event, **N2**
+consumes it on the LOCAL path (`InProcessTransport` → `TextualChatApp`,
+via the client-pull `ChatReadModel.conversation_history` seam), **N3**
+consumes it on the REMOTE path (`_SessionFrameSource`/`AgUiEmitter`,
+above, via a SERVER-push `backlog_provider` that re-derives the target
+session's backlog directly through `project_restored_frames` — a
+structurally separate mechanism from N2's client-pull, not a shared
+call site, since a remote connection has no local `ChatReadModel` to
+pull through). The net effect is the same for both surfaces: a switch
+resets the client's view and repopulates it from that session's
+authoritative history, never a retained cache.
 
 #### Text lifecycle (the conforming triplet, plain and streamed)
 
@@ -531,7 +560,7 @@ wire.
 | Custom `name`                        | Meaning                                          |
 |--------------------------------------|--------------------------------------------------|
 | `reyn.event.user_answered_intervention` | the user answered an intervention (working-indicator axis only — carries NO display text; see `reyn.event.intervention_answer_submitted` below for the echo) |
-| `reyn.event.session_attached`        | a session/agent switch just happened (#3310 N1) — carries `{agent, session_id}`, the identity a client keys its display/reset cache on. Locally, emitted at the registry attach seam (`AgentRegistry.attach`/`attach_session`), put directly on `repl_outbox` as a stream BARRIER — see *the session-switch barrier* above. Remotely (#3310 N3), `_SessionFrameSource` synthesizes an independent per-connection equivalent when it observes a `/session switch` on the session backing THIS connection, and `AgUiEmitter` re-fires `MESSAGES_SNAPSHOT`/`STATE_SNAPSHOT` for the new session right after forwarding it — see *Remote parity* above |
+| `reyn.event.session_attached`        | a session/agent switch just happened (#3310 N1) — carries `{agent, session_id}`, the identity a client keys its display/reset cache on. Locally, emitted at the registry attach seam (`AgentRegistry.attach`/`attach_session`), put directly on `repl_outbox` as a stream BARRIER — see *the session-switch barrier* above; consumed by `TextualChatApp` (N2), which resets every per-session client state and rehydrates from `history.jsonl` on receipt. Remotely (#3310 N3), `_SessionFrameSource` synthesizes an independent per-connection equivalent when it observes a `/session switch` on the session backing THIS connection, and `AgUiEmitter` re-fires `MESSAGES_SNAPSHOT`/`STATE_SNAPSHOT` for the new session right after forwarding it — see *Remote parity* above |
 | `reyn.event.user_submitted`          | a user turn was submitted (#3300 P1 C) — RAW text + chain_id + msg_id + seq + meta; each surface neutralizes at its render boundary. `msg_id`/`seq` are the #3300 P2a sent-queue correlation id + order-race-gate token |
 | `reyn.event.intervention_answer_submitted` | an intervention answer was resolved (#3300, event-ifying the LAST outbox `kind="user"` broadcast site — `InterventionHandler.deliver_answer_to`) — RAW text (the raw answer, or the matched choice's label) + `intervention_id` + meta; each surface neutralizes at its render boundary, following the `user_submitted` precedent exactly. Unlike `user_submitted`, this has no sent-queue staging step — an intervention answer was never a queued inbox item, so it renders straight to the flow |
 | `reyn.event.inbox_cancel`            | an UNDISPATCHED queued user message was cancelled by id (#3300 P3, via the `cancel_queued` client message) — carries `msg_id` + `seq`; the server-authoritative sent-queue removal signal (never a client-local "cancel succeeded" response), exclusive with `turn_started` for the same `msg_id` |

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -169,6 +169,28 @@ class TextualChatApp(App):
     REMOTE read model returns an empty log (frame-sufficiency: past turns are not
     on the wire) → hydration is a no-op and the pane starts blank as before.
 
+    #3310 N2 reuses that SAME hydrate seam for a session SWITCH, not just a
+    restart. N1 (#3321) added a ``session_attached`` chat-event — an
+    ``EventFrame`` the registry puts directly on ``repl_outbox`` at the attach
+    seam, with NO ``await`` between the ``self._attached`` flip and the put —
+    so it is a stream BARRIER: everything on the frame stream before it
+    belongs to the OLD attached session, everything after to the NEW one, by
+    construction. :meth:`_handle_session_attached_event` consumes it: a cached
+    FlowView cannot be the source of truth here (while THIS client was on some
+    OTHER session, the registry forwarder DROPPED this session's frames
+    entirely — a cache would be missing everything that happened meanwhile
+    and would hold tool rows stuck RUNNING), so the response is reconnect-
+    shaped, not cache-shaped — reset EVERY per-session client state
+    (conversation, running-tool tracking, pending-intervention tabs, the
+    sent-queue view/widget, streaming-reply tracking) and rehydrate the model
+    from the NEW session's ``history.jsonl`` via :meth:`_hydrate_from_history`,
+    now generalized to target an arbitrary ``(agent, session_id)`` instead of
+    only "whichever session is attached". A tool that completed while
+    detached resolves correctly (never RUNNING) because the restore path
+    always projects a resolved state; a pending intervention for the NEW
+    session is not re-fetched here — the registry already re-announces it on
+    attach, so the client only has to forget the OLD one.
+
     #3299 P1 moved intervention interaction OUT of the FlowView into a grouped
     :class:`~reyn.interfaces.inline.textual_chat.intervention_panel.InterventionPanel`
     widget between the flow and the input row (atomic display-swap +
@@ -551,31 +573,53 @@ class TextualChatApp(App):
         self.query_one("#drawer", ContentSwitcher).display = False
         self.query_one(Composer).focus()
 
-    def _hydrate_from_history(self) -> None:
-        """Restore-on-restart (#3273 Phase 5): project the persisted conversation
-        log into the retained model so a restart shows the PREVIOUS conversation.
+    def _hydrate_from_history(
+        self, *, agent: "str | None" = None, session_id: "str | None" = None
+    ) -> None:
+        """Restore-on-restart (#3273 Phase 5) AND session-switch reset+rehydrate
+        (#3310 N2): project a persisted conversation log into the retained
+        model so the pane shows that session's PREVIOUS conversation instead
+        of whatever was left over from before.
 
-        Reads the durable ``ChatMessage`` log via the read-model seam
-        (:meth:`~reyn.interfaces.repl.read_model.ChatReadModel.conversation_history`
-        — ``history.jsonl``, NOT the P6 audit-event log) and appends each projected
-        frame to ``self.conversation`` (:func:`.restore.project_restored_frames`).
-        Every restored entry is RESOLVED, never RUNNING: a restored tool turn is
-        already projected into the SAME coalesced ``tool_call_started`` shape
-        the live path's :meth:`_coalesce_tool_result` settles a completed tool
-        into (call header + folded result, one entry — see
+        Two call shapes:
+
+        - No args (:meth:`on_mount`'s original Phase-5 call): hydrates the
+          CURRENTLY ATTACHED session, byte-identical to pre-N2 behavior.
+        - ``agent``/``session_id`` given (:meth:`_handle_session_attached_event`,
+          called AFTER :meth:`self.conversation`'s ``clear()``): hydrates that
+          SPECIFIC (possibly never-before-attached-in-this-client-run) session
+          instead — the same read-model seam
+          (:meth:`~reyn.interfaces.repl.read_model.ChatReadModel.conversation_history`
+          — ``history.jsonl``, NOT the P6 audit-event log), just targeted.
+
+        Appends each projected frame to ``self.conversation``
+        (:func:`.restore.project_restored_frames`). Every restored entry is
+        RESOLVED, never RUNNING: a restored tool turn is already projected into
+        the SAME coalesced ``tool_call_started`` shape the live path's
+        :meth:`_coalesce_tool_result` settles a completed tool into (call
+        header + folded result, one entry — see
         ``restore.project_restored_frames``'s docstring), so this method just
         derives the terminal SUCCESS/ERROR state from the coalesced result
         (the ``if msg.kind == "tool_call_completed"`` branch a pre-coalesce
         restore shape would have hit no longer fires for tool rows; user/agent
-        rows keep DEFAULT, their live state). A REMOTE read model returns an
-        empty log (frame-sufficiency: past turns are not on the wire) → this is
-        a no-op and the pane starts blank, exactly as before. Fully guarded — a
-        restore failure must never stop the app from mounting and pumping live
-        frames."""
+        rows keep DEFAULT, their live state) — which is also what makes a tool
+        that completed while this client was detached (#3310's "orphan gate")
+        resolve correctly rather than replaying as RUNNING: the completion
+        already landed in ``history.jsonl`` before this read, so it projects
+        straight to its settled state. A REMOTE read model returns an empty log
+        (frame-sufficiency: past turns are not on the wire) → this is a no-op
+        either way, and the pane starts/stays blank (remote switch-rehydrate is
+        #3310 N3's job). Fully guarded — a restore failure must never stop the
+        app from mounting/resetting and pumping live frames."""
         if self._read_model is None:
             return
         try:
-            messages = self._read_model.conversation_history()
+            if agent is not None or session_id is not None:
+                messages = self._read_model.conversation_history(
+                    agent=agent, session_id=session_id
+                )
+            else:
+                messages = self._read_model.conversation_history()
         except Exception:
             logger.exception("textual chat: conversation-history read failed")
             return
@@ -1023,6 +1067,121 @@ class TextualChatApp(App):
                 # a late-joining client).
                 self._queue_item_meta[msg_id] = dict(item.get("meta") or {})
 
+    def _handle_session_attached_event(self, event) -> None:
+        """The session-switch reset barrier (#3310 N2, consuming N1's
+        ``session_attached`` chat-event, ``{agent, session_id}``).
+
+        ★Design thesis (architect deep-dive, issue #3310 §1): a cached
+        FlowView cannot be the source of truth after a switch — while THIS
+        session was detached, the registry forwarder DROPPED its frames
+        (``registry.py``'s "durable narration is in history.jsonl" branch),
+        so any client-side cache is stale-by-construction (missing frames,
+        tool rows stuck RUNNING). v1 is therefore reconnect-shaped, not
+        cache-shaped: reset EVERY per-session client state, then rehydrate
+        from the durable sources exactly like a fresh reconnect would
+        (:meth:`_hydrate_from_history`, the #3305-shaped queue reseed below).
+
+        Resets, one independent state at a time (per-state test coverage,
+        #3310 gate 3 — folding several clears into one test would repeat the
+        #3302/#3308 sibling-guard-site mistake this repo already learned
+        from):
+
+        - ``self.conversation`` (the retained FlowModel) — cleared, then
+          rehydrated from the NEW session's ``history.jsonl`` below. This is
+          the ★staleness-gate state: the frames the OLD session produced
+          while this client was on some OTHER session are NOT re-derived
+          from an in-memory cache (there is none) — they come back because
+          they are durable, not because anything was retained live.
+        - :attr:`_running_tools` — a RUNNING marker is per-session op-id
+          state; the new session's own in-flight tools (if any) are not
+          replayed here (frame-sufficiency: a truly still-running tool has
+          no completed row in ``history.jsonl`` yet either — same rule live
+          frames already follow for a mid-flight tool this client just
+          joined).
+        - :attr:`_pending_ivs` — forgotten, not re-fetched: the server side
+          already re-announces every pending intervention on attach
+          (``registry.py``'s ``attach``/``attach_session``, both replay
+          ``_interventions.list_active()`` — ground-truthed during the N1
+          design pass), so the client only needs to stop tracking the OLD
+          session's entries; the new ones arrive as ordinary ``intervention``
+          frames right after this barrier. Paired with
+          :meth:`InterventionPanel.collapse_all` so every OLD tab (post-P5
+          the panel is tabbed, #3308) actually closes rather than lingering
+          empty.
+        - :attr:`_queue_view` / :attr:`_queue_seeded` — a FRESH
+          ``RemoteQueueView()``, immediately re-seeded from the NEW session's
+          OWN snapshot right here (:meth:`_seed_queue_view`) rather than
+          deferred to "whenever the next frame happens to arrive" — the
+          identical PROJECTION the #3305 reconnect-reseed/mount-time seed
+          use, just called eagerly instead of gated on
+          :attr:`_queue_seeded`. ★Found during gate-writing (not in the
+          architect's table): deferring to the generic first-frame gate
+          (leaving ``_queue_seeded = False`` and letting the ordinary
+          "seed on first frame" check in :meth:`_pump_frames` catch it) is
+          NOT equivalent here — that check runs BEFORE a frame is
+          dispatched, so it would need a frame AFTER this barrier to ever
+          fire; a session with an already-queued item but no OTHER pending
+          activity would show an empty sent-queue region until something
+          else happened to arrive. Seeding eagerly here closes that gap;
+          :attr:`_queue_seeded` is still set True (never left False) so the
+          generic check is correctly a no-op for this same barrier frame.
+        - :attr:`_queue_item_meta` — cleared (keyed by msg_id, which is
+          per-submission; an old session's entries are meaningless once its
+          queue view is gone too).
+        - the :class:`SentQueue` widget's rows — :meth:`SentQueue.clear_all`
+          (a new method this PR adds; the widget had no server delta of its
+          own for "the whole displayed session changed").
+        - :attr:`_streaming_replies` (#3288 ③c) — ★explicitly flagged by the
+          architect as the state most likely to be forgotten by a LATER
+          phase; cleared here since it already exists.
+        - :attr:`_pending_own_cancels` (#3300 Y-client) — an addition beyond
+          the architect's enumerated table (found verifying it against this
+          file): keyed by msg_id and normally popped once the matching
+          ``inbox_cancel`` delta confirms a client-issued cancel. A switch
+          before that confirmation would otherwise leave a stale entry that
+          could later restore OLD-session cancelled text into the composer
+          if a delta for that same msg_id ever arrived under a DIFFERENT
+          attached session — clearing it here removes that (admittedly
+          narrow) cross-session leak.
+        - :attr:`_pane_selection_ids` is intentionally NOT reset here — the
+          architect's design pass confirmed it is fine as-is: each drawer
+          pane rebuilds it from a fresh snapshot on every open
+          (:meth:`_refresh_pane`), so a stale entry can never be read before
+          being overwritten.
+        - ``_iv_current_key`` (named in the issue's original enumeration) no
+          longer exists in this file: #3308 (P5) replaced the single-slot
+          re-route it belonged to with per-intervention TABS, so
+          :attr:`_pending_ivs` + :meth:`InterventionPanel.collapse_all` are
+          the whole of the intervention reset today.
+
+        Runs the reset UNGUARDED (a `try`/`except` around clearing plain
+        dicts/lists would only hide a real bug) but the follow-on hydrate
+        call is internally guarded, same as the mount-time call."""
+        data = event.data or {}
+        agent = data.get("agent")
+        session_id = data.get("session_id")
+        self.conversation.clear()
+        self._running_tools.clear()
+        self._pending_ivs.clear()
+        self._iv_panel.collapse_all()
+        self._queue_view = RemoteQueueView()
+        self._queue_item_meta.clear()
+        self._sent_queue.clear_all()
+        self._streaming_replies.clear()
+        self._pending_own_cancels.clear()
+        if agent:
+            self._agent_name = agent
+        # Eager reseed (see the ``_queue_view``/``_queue_seeded`` bullet
+        # above): seed the fresh view from the NEW session's snapshot right
+        # now, rather than deferring to the generic "first frame" check —
+        # which would need ANOTHER frame after this barrier to ever fire.
+        try:
+            self._seed_queue_view()
+        except Exception:
+            logger.exception("textual chat: switch queue-view reseed failed")
+        self._queue_seeded = True
+        self._hydrate_from_history(agent=agent, session_id=session_id)
+
     def _handle_user_submitted_event(self, event) -> None:
         """MATERIALIZE exit (#3300 P2b, sent-queue exit contract §6a): a
         ``user_submitted`` delta appears in the sent-queue region — NOT
@@ -1284,6 +1443,15 @@ class TextualChatApp(App):
         (:meth:`_handle_intervention_answer_event`) renders straight to the
         flow, unlike ``user_submitted`` — an intervention answer was never a
         queued inbox item, so there is no sent-queue stage to promote through.
+
+        #3310 N2: ``session_attached`` (:meth:`_handle_session_attached_event`)
+        is the switch-reset BARRIER — everything on this stream before it
+        belongs to the OLD attached session, everything after to the NEW one
+        (N1's no-await critical-section guarantee at the registry seam). On
+        receipt, every per-session client state is reset and the NEW session
+        is rehydrated from ``history.jsonl`` — v1 is reconnect-shaped, not
+        cache-shaped (a cached FlowView would be stale-by-construction: the
+        forwarder drops a detached session's frames entirely).
         """
         try:
             async for frame in self._transport.frames():
@@ -1295,7 +1463,14 @@ class TextualChatApp(App):
                     self._queue_seeded = True
                 if frame.tag is FrameTag.EVENT:
                     etype = getattr(frame.event, "type", None)
-                    if etype == "user_submitted":
+                    if etype == "session_attached":
+                        try:
+                            self._handle_session_attached_event(frame.event)
+                        except Exception:
+                            logger.exception(
+                                "textual chat: session_attached reset+hydrate failed"
+                            )
+                    elif etype == "user_submitted":
                         try:
                             self._handle_user_submitted_event(frame.event)
                         except Exception:

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -316,6 +316,29 @@ class TextualChatApp(App):
     #: blink clock, Phase ①): ① animates the gutter glyph, ② the tool body.
     RUNNING_BODY_FPS = 12.0
 
+    #: Per-session ``dict``-valued client state that resets uniformly (a
+    #: plain ``.clear()``) on a session switch (#3310 N2,
+    #: :meth:`_handle_session_attached_event`). Declared here — never
+    #: enumerated ad hoc inside the reset method — so a FUTURE per-session
+    #: dict added to :meth:`__init__` is reset BY CONSTRUCTION the moment
+    #: its name is added to this tuple, rather than by a human remembering
+    #: to also touch the reset method. This is not a hypothetical: the
+    #: exact omission class hit TWICE in this arc — ``_streaming_replies``
+    #: was flagged as a likely-forgotten addition during the #3310 design
+    #: pass (#3288 ③c landed after the design table was written), and
+    #: ``_pending_own_cancels`` (#3300 Y-client) was found missing from
+    #: that SAME design table only while writing this PR's gates. State
+    #: that needs a NON-``.clear()`` reset (a fresh instance, a widget
+    #: method, a follow-on hydrate) stays explicit in the reset method
+    #: below — this tuple covers only the "just empty the dict" shape.
+    _PER_SESSION_DICT_STATE: "tuple[str, ...]" = (
+        "_running_tools",
+        "_pending_ivs",
+        "_queue_item_meta",
+        "_streaming_replies",
+        "_pending_own_cancels",
+    )
+
     def __init__(
         self,
         *,
@@ -1154,6 +1177,22 @@ class TextualChatApp(App):
           :attr:`_pending_ivs` + :meth:`InterventionPanel.collapse_all` are
           the whole of the intervention reset today.
 
+        ★Structural fix (co-vet review, #3323): a hand-typed list of
+        ``.clear()`` calls has now been forgotten TWICE in this arc's short
+        history — ``_streaming_replies`` (flagged as at-risk by the design
+        pass) and ``_pending_own_cancels`` (found only while writing this
+        PR's gates) both landed in ``__init__`` without their owning design
+        table being updated. Every plain-``.clear()``-shaped state above
+        (``_running_tools`` / ``_pending_ivs`` / ``_queue_item_meta`` /
+        ``_streaming_replies`` / ``_pending_own_cancels``) is therefore
+        declared ONCE, in :attr:`_PER_SESSION_DICT_STATE`, and this method
+        iterates that tuple instead of re-listing each name — adding a
+        FUTURE per-session dict to ``__init__`` and this tuple is now the
+        only step required; there is no second call site to forget. State
+        needing a non-``.clear()`` reset (``_queue_view``'s fresh instance,
+        the panel/widget's own methods, the hydrate call) stays explicit
+        below, since a uniform loop cannot express those shapes.
+
         Runs the reset UNGUARDED (a `try`/`except` around clearing plain
         dicts/lists would only hide a real bug) but the follow-on hydrate
         call is internally guarded, same as the mount-time call."""
@@ -1161,14 +1200,16 @@ class TextualChatApp(App):
         agent = data.get("agent")
         session_id = data.get("session_id")
         self.conversation.clear()
-        self._running_tools.clear()
-        self._pending_ivs.clear()
+        # Data-driven over :attr:`_PER_SESSION_DICT_STATE` — see that
+        # attribute's docstring — instead of a hand-written list of
+        # ``.clear()`` calls, so a FUTURE dict-valued per-session addition
+        # is reset the moment it is registered there, not only when a
+        # human also remembers to edit this method.
+        for attr_name in self._PER_SESSION_DICT_STATE:
+            getattr(self, attr_name).clear()
         self._iv_panel.collapse_all()
         self._queue_view = RemoteQueueView()
-        self._queue_item_meta.clear()
         self._sent_queue.clear_all()
-        self._streaming_replies.clear()
-        self._pending_own_cancels.clear()
         if agent:
             self._agent_name = agent
         # Eager reseed (see the ``_queue_view``/``_queue_seeded`` bullet

--- a/src/reyn/interfaces/inline/textual_chat/sent_queue.py
+++ b/src/reyn/interfaces/inline/textual_chat/sent_queue.py
@@ -155,6 +155,19 @@ class SentQueue(Vertical):
         self._clamp_selection()
         self._apply_highlight()
 
+    def clear_all(self) -> None:
+        """Remove every queued row unconditionally (#3310 N2 session-switch
+        reset barrier) — the widget-level exit that has no server delta of
+        its own to ride: a switch discards ALL of the OLD session's queued
+        rows client-side (the new session's own queue, if any, is reseeded
+        from its snapshot immediately after — the SAME "seed on first frame"
+        path a fresh :class:`~reyn.interfaces.transport.agui.state.RemoteQueueView`
+        drives, #3305-shaped). Reuses :meth:`remove_item` per row so the
+        collapse-when-empty / selection-clamp invariants stay in ONE place
+        rather than being re-derived here."""
+        for msg_id in list(self._rows):
+            self.remove_item(msg_id)
+
     def rendered_texts(self) -> "list[str]":
         """The currently-queued rows' rendered text, oldest first — the
         public read a caller (a test, or a future consumer) uses to inspect

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -93,10 +93,19 @@ class ChatReadModel(ABC):
         """Filesystem path for the input-history file."""
 
     @abstractmethod
-    def conversation_history(self, *, limit: "int | None" = None) -> "list[ChatMessage]":
+    def conversation_history(
+        self,
+        *,
+        limit: "int | None" = None,
+        agent: "str | None" = None,
+        session_id: "str | None" = None,
+    ) -> "list[ChatMessage]":
         """Recent persisted CONVERSATION turns (the ``ChatMessage`` log loaded
         from ``history.jsonl``), oldest→newest, for the Textual app's
-        restore-on-restart hydration (#3273 Phase 5).
+        restore-on-restart hydration (#3273 Phase 5) AND its session-switch
+        reset-and-rehydrate (#3310 N2 — the same seam, generalized to target
+        an arbitrary session rather than only "whichever one is currently
+        attached").
 
         This is the DURABLE conversation log (assistant text + tool results), NOT
         the input-history file :attr:`history_path` (↑-recall) and NOT the P6
@@ -105,12 +114,25 @@ class ChatReadModel(ABC):
         equivalent — whatever survives in ``history.jsonl``; turns rotated out are
         simply not restored, exactly like ``--resume``).
 
+        ``agent`` / ``session_id`` (#3310 N2): when BOTH are omitted (``None``),
+        behavior is BYTE-IDENTICAL to pre-N2 — the currently attached session.
+        When given, they target that specific ``(agent, session_id)`` instead —
+        the read a client uses on a ``session_attached`` switch-barrier to
+        rehydrate the NEWLY focused session (which may never have been
+        attached in THIS client run) rather than whichever session used to be
+        attached. No new ``history.jsonl`` path literal is introduced by this:
+        the accessor still resolves through the SAME per-session ``Session``
+        object (via the registry's own session-lookup SSoT), just keyed by the
+        caller's (agent, session_id) instead of "whichever is attached".
+
         **Frame-sufficiency boundary.** Like every other session-local read
         (dropdown expansions, the rewind picker), the past-turn log is NOT
         projected onto the AG-UI wire — a REMOTE client holds no session and
         cannot enumerate it. The remote impl therefore degrades gracefully to an
-        empty list (never a fabricated turn); cross-session restore is a
-        LOCAL-attach affordance today."""
+        empty list (never a fabricated turn) REGARDLESS of ``agent``/
+        ``session_id`` — remote switch-hydrate is #3310 N3's job, not this
+        method's; passing a target here on a remote client is accepted but
+        inert."""
 
 
 class RegistryReadModel(ChatReadModel):
@@ -153,13 +175,35 @@ class RegistryReadModel(ChatReadModel):
             )
         return s.workspace_dir / ".input_history"
 
-    def conversation_history(self, *, limit: "int | None" = None):
-        # The attached Session's ``history`` list IS the ChatMessage log loaded
-        # from ``history.jsonl`` by ``Session.load_history`` at attach time — read
-        # it straight (no audit-event path). Return a shallow copy so a caller can
+    def conversation_history(
+        self,
+        *,
+        limit: "int | None" = None,
+        agent: "str | None" = None,
+        session_id: "str | None" = None,
+    ):
+        # The Session's ``history`` list IS the ChatMessage log loaded from
+        # ``history.jsonl`` by ``Session.load_history`` at load time — read it
+        # straight (no audit-event path). Return a shallow copy so a caller can
         # not mutate the live session history. ``None`` = whole log (resume-
         # equivalent); a positive ``limit`` keeps the most-recent N.
-        s = self._attached()
+        #
+        # #3310 N2: ``agent`` given → resolve THAT session (not necessarily the
+        # attached one) via ``AgentRegistry.get_session`` — the same
+        # non-loading session-store accessor every other registry call site
+        # uses (FP-0043 Stage 3), never a duplicated ``history.jsonl`` path
+        # literal. By the time a client processes the ``session_attached``
+        # barrier the target session is already loaded (``attach``/
+        # ``attach_session`` both ``get_or_load``/require-existing BEFORE
+        # announcing), so this is never a cold miss for a switch-driven call.
+        if agent is not None:
+            s = (
+                self._registry.get_session(agent, session_id)
+                if session_id is not None
+                else self._registry.get_session(agent)
+            )
+        else:
+            s = self._attached()
         if s is None:
             return []
         history = list(getattr(s, "history", []) or [])
@@ -256,11 +300,19 @@ class RemoteReadModel(ChatReadModel):
         base.mkdir(parents=True, exist_ok=True)
         return base / "remote-input-history"
 
-    def conversation_history(self, *, limit: "int | None" = None):
+    def conversation_history(
+        self,
+        *,
+        limit: "int | None" = None,
+        agent: "str | None" = None,
+        session_id: "str | None" = None,
+    ):
         # Frame-sufficiency: a remote client holds no session and the past-turn
         # ChatMessage log is NOT projected onto the wire (like the dropdown
         # expansions / rewind picker). Degrade gracefully to empty — never a
-        # fabricated turn. Restore-on-restart is a local-attach affordance today.
+        # fabricated turn, regardless of a targeted (agent, session_id) — remote
+        # switch-hydrate is #3310 N3's job, not this accessor's. Restore-on-
+        # restart / switch-rehydrate is a local-attach affordance today.
         return []
 
 

--- a/tests/test_3310_n2_reset_hydrate.py
+++ b/tests/test_3310_n2_reset_hydrate.py
@@ -26,10 +26,16 @@ Gates covered here (#3310's acceptance list):
    switch back to A — the away-produced frames are present.
 2. orphan gate: a tool that completed while away renders resolved, never
    RUNNING, after switching back (hydrate's resolved projection).
-3. Per-state reset: one independent test per state (``_running_tools``,
-   ``_pending_ivs``/panel tabs, the sent-queue view/widget/`_queue_item_meta`,
-   ``_streaming_replies``), each with its OWN discriminating witness (never
-   folded into a shared test — the #3302/#3308 sibling-guard-site lesson).
+3. Per-state reset: one independent test per state — ``_running_tools``,
+   ``_pending_ivs`` (SEPARATE from ``InterventionPanel.collapse_all()``,
+   which gets its OWN test: a co-vet finding on #3323 caught the original
+   single combined test discriminating only ``collapse_all()``, leaving
+   ``_pending_ivs.clear()`` un-witnessed — "either clear alone" left it
+   GREEN), the sent-queue view/widget/``_queue_item_meta``,
+   ``_streaming_replies`` — each with its OWN discriminating witness that
+   goes RED when ONLY that state's clear is stripped (never folded into a
+   shared test — the #3302/#3308 sibling-guard-site lesson, reconfirmed
+   the hard way here for ``_pending_ivs``).
 4. Unvisited session: switching to a session never seen in THIS client run
    shows its history, not a blank pane.
 5. Barrier consumption: an ordinary frame delivered immediately after the
@@ -83,6 +89,13 @@ class QueueTransport(ClientTransport):
     def __init__(self) -> None:
         self._queue: "asyncio.Queue" = asyncio.Queue()
         self.submitted: "list[str]" = []
+        # (choice_id, intervention_id) pairs — records which id an answer
+        # was actually TARGETED at, the public observable
+        # ``test_reset_pending_interventions_...`` uses to discriminate
+        # ``_pending_ivs.clear()`` independently of the panel's own
+        # ``collapse_all()`` (mirrors ``RecordingTransport.answered_choice_ids``
+        # in ``tests/test_textual_chat_intervention_panel_3299.py``).
+        self.answered_choice_ids: "list[str | None]" = []
 
     def start(self) -> None:  # pragma: no cover - trivial
         pass
@@ -112,7 +125,8 @@ class QueueTransport(ClientTransport):
     async def answer_intervention_choice(
         self, choice_id: str, *, intervention_id: "str | None" = None
     ) -> bool:
-        return False
+        self.answered_choice_ids.append(intervention_id)
+        return True
 
     def has_session(self) -> bool:
         return True
@@ -399,11 +413,21 @@ async def test_reset_running_tools_stale_op_id_does_not_silently_coalesce(
 
 @pytest.mark.asyncio
 async def test_reset_pending_interventions_closes_all_tabs(tmp_path, monkeypatch) -> None:
-    """Tier 2: ``_pending_ivs`` / panel-tabs witness. A pending intervention on
-    alpha opens the panel with one tab; switching away must close the whole
-    panel (``InterventionPanel.collapse_all`` — the whole panel, panel.display
-    False, zero mounted ``TabPane``s), never leaving alpha's stale tab
-    lingering behind the new session's own (server-re-announced) ones."""
+    """Tier 2: ``InterventionPanel.collapse_all()`` witness. A pending
+    intervention on alpha opens the panel with one tab; switching away must
+    close the whole panel (``panel.display`` False, zero mounted
+    ``TabPane``s), never leaving alpha's stale tab lingering behind the new
+    session's own (server-re-announced) ones.
+
+    ★Scope note (co-vet finding on #3323): this test discriminates
+    ``collapse_all()`` specifically — the panel's OWN internal tab-tracking
+    dicts (``_pane_ids``/``_key_by_pane``/etc., cleared inside
+    ``collapse_all`` itself) are what drive ``panel.display``/``TabPane``
+    count, independent of the APP's ``_pending_ivs`` dict. Stripping ONLY
+    ``self._pending_ivs.clear()`` in the app (leaving ``collapse_all()`` in
+    place) does NOT turn this test RED — that is a SEPARATE state with its
+    own witness below (``test_reset_pending_ivs_stale_key_answer_not_targeted``),
+    not folded in here (per-state independence, #3302/#3308 lesson)."""
     monkeypatch.chdir(tmp_path)
     reg = _registry(tmp_path)
     try:
@@ -439,6 +463,84 @@ async def test_reset_pending_interventions_closes_all_tabs(tmp_path, monkeypatch
             assert panel.display is False, "switch must collapse the whole panel"
             assert list(panel.query(TabPane)) == [], (
                 "switch must close every pending tab from the OLD session"
+            )
+    finally:
+        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_reset_pending_ivs_stale_key_answer_not_targeted(tmp_path, monkeypatch) -> None:
+    """Tier 2: ★``_pending_ivs`` witness, INDEPENDENT of
+    ``InterventionPanel.collapse_all()`` (co-vet finding on #3323: the panel
+    test above discriminates ``collapse_all()`` only — stripping
+    ``_pending_ivs.clear()`` alone left that test GREEN, a genuine
+    cross-masking gap).
+
+    Scenario: a pending intervention on alpha (``intervention_id="iv-old"``)
+    populates ``app._pending_ivs["iv-old"]``. The switch to beta happens —
+    THEN, simulating a click that was ALREADY in flight before the switch
+    (a real Textual race: the panel message for a click on the OLD tab can
+    still be QUEUED for delivery even after ``collapse_all()`` has already
+    removed that tab from the DOM), this test delivers
+    ``InterventionPanel.ChoiceSelected(key="iv-old", ...)`` directly to the
+    app's OWN handler — exercising the EXACT same lookup
+    (``on_intervention_panel_choice_selected``) that the panel's TabPane
+    button would trigger.
+
+    If ``_pending_ivs`` were NOT cleared on switch, this lookup finds the
+    STALE ``(entry, "iv-old")`` tuple and delivers the answer TARGETED at
+    alpha's own intervention id — over THIS client's transport, which now
+    routes to beta. That is a cross-session misdelivery: an answer meant
+    for (or at least keyed to) alpha's intervention lands on a call the
+    server associates with beta's connection. With ``_pending_ivs``
+    correctly cleared, the stale key resolves to nothing and the answer is
+    delivered UNTARGETED (``intervention_id=None``, the documented pre-P2
+    head-of-queue fallback) instead of silently misrouted — the
+    discriminating, PUBLIC observable is
+    ``transport.answered_choice_ids``, never a private ``app._pending_ivs``
+    read."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        transport = QueueTransport()
+        app = TextualChatApp(
+            transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+        )
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _settle(pilot)
+
+            transport.push_display(OutboxMessage(
+                kind="intervention",
+                text="Allow write to /etc/hosts?",
+                meta={
+                    "intervention_id": "iv-old",
+                    "prompt": "Allow write to /etc/hosts?",
+                    "choices": [{"id": "yes", "label": "Yes"}, {"id": "no", "label": "No"}],
+                },
+            ))
+            await _settle(pilot)
+
+            await reg.attach("beta")
+            transport.push_event(
+                "session_attached", {"agent": "beta", "session_id": _DEFAULT_SID}
+            )
+            await _settle(pilot)
+
+            # Simulates a click delivered AFTER the switch for a tab that
+            # existed BEFORE it — driving the app's real handler directly
+            # (the same code path a real Textual message dispatch would
+            # invoke), not a synthetic private-state read.
+            await app.on_intervention_panel_choice_selected(
+                InterventionPanel.ChoiceSelected(key="iv-old", choice_id="yes", label="Yes")
+            )
+            await _settle(pilot)
+
+            assert transport.answered_choice_ids == [None], (
+                "a late-arriving answer for a PRE-switch intervention key "
+                "must not resolve to that stale intervention_id (would "
+                "cross-session-misdeliver over the NOW-beta-routed "
+                f"transport): {transport.answered_choice_ids!r}"
             )
     finally:
         await asyncio.wait_for(reg.shutdown(), timeout=5.0)
@@ -604,7 +706,19 @@ async def test_reset_queue_view_reseeds_from_new_sessions_own_queue(
     beta's already-queued item would never render (there is no OTHER trigger
     that would show it — nothing else happens on beta in this scenario) —
     this is the #3305-shaped reconnect-reseed, witnessed here for the SWITCH
-    path specifically."""
+    path specifically.
+
+    ★Non-vacuity guard (found while strip-falsifying the WHOLE
+    ``session_attached`` handler for #3323 co-vet re-review): the very
+    generic "seed on the first frame the pump EVER processes" check
+    (:meth:`TextualChatApp._pump_frames`) would ALSO explain a green result
+    here if the ``session_attached`` frame below happened to be the first
+    frame this app's pump ever sees — masking the eager-reseed-on-switch
+    behavior this test means to isolate. A harmless benign frame is pushed
+    and settled FIRST so that generic check has already fired (on alpha,
+    where it is a no-op) before the switch — the ONLY remaining path that
+    can populate the queue view for beta is the eager reseed inside
+    :meth:`_handle_session_attached_event` itself."""
     monkeypatch.chdir(tmp_path)
     reg = _registry_with_wal(tmp_path)
     try:
@@ -630,6 +744,15 @@ async def test_reset_queue_view_reseeds_from_new_sessions_own_queue(
             transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
         )
         async with app.run_test(size=(100, 30)) as pilot:
+            await _settle(pilot)
+
+            # Non-vacuity guard (see docstring): a harmless frame on alpha,
+            # settled BEFORE the switch, so the generic "seed on first frame
+            # the pump ever processes" check has already fired here (on
+            # alpha) rather than on the session_attached frame below — the
+            # ONLY remaining seed path for beta is the eager reseed inside
+            # the switch handler itself.
+            transport.push_display(OutboxMessage(kind="user", text="alpha noop"))
             await _settle(pilot)
 
             # NOTE: flips ``registry._attached`` directly rather than calling

--- a/tests/test_3310_n2_reset_hydrate.py
+++ b/tests/test_3310_n2_reset_hydrate.py
@@ -1,0 +1,713 @@
+"""Tier 2: #3310 N2 — client-side reset + hydrate on the ``session_attached``
+switch barrier.
+
+N1 (#3321) added ``session_attached`` (``{agent, session_id}``), an
+``EventFrame`` the registry puts DIRECTLY on ``repl_outbox`` at the attach
+seam with no ``await`` between the flip and the put — a stream BARRIER:
+everything before it on the frame stream belongs to the OLD attached
+session, everything after to the NEW one, by construction.
+
+★Design thesis (architect deep-dive, issue #3310 §1, owner-ratified): a
+cached FlowView cannot be the source of truth — while a session is
+detached, the registry forwarder DROPS its frames entirely (durable
+narration lives only in ``history.jsonl``), so a cache would be missing
+everything that happened meanwhile and would hold tool rows stuck RUNNING.
+v1 is reconnect-shaped, not cache-shaped: on the barrier, reset EVERY
+per-session client state and rehydrate from the durable sources
+(``TextualChatApp._handle_session_attached_event`` /
+``_hydrate_from_history``, generalized in this PR to target an arbitrary
+``(agent, session_id)`` via ``ChatReadModel.conversation_history``).
+
+Gates covered here (#3310's acceptance list):
+
+1. ★staleness gate (load-bearing, the design thesis's falsifier): A→B, A
+   produces output while the client is on B (never delivered live — only
+   durably persisted, exactly like a detached forwarder would leave it),
+   switch back to A — the away-produced frames are present.
+2. orphan gate: a tool that completed while away renders resolved, never
+   RUNNING, after switching back (hydrate's resolved projection).
+3. Per-state reset: one independent test per state (``_running_tools``,
+   ``_pending_ivs``/panel tabs, the sent-queue view/widget/`_queue_item_meta`,
+   ``_streaming_replies``), each with its OWN discriminating witness (never
+   folded into a shared test — the #3302/#3308 sibling-guard-site lesson).
+4. Unvisited session: switching to a session never seen in THIS client run
+   shows its history, not a blank pane.
+5. Barrier consumption: an ordinary frame delivered immediately after the
+   barrier renders into the NEW session's view, never the old one's (trivial
+   here since the model is a single retained FlowModel the barrier just
+   cleared — there is no "other queue" it could be mis-filed into).
+
+Real ``AgentRegistry`` + real ``Session`` (``tests._support.agent_session.
+make_session``) + a real, minimal ``ClientTransport`` (a queue the test
+pushes scripted frames onto, interleaved with real registry/session state
+changes) + the real mounted ``TextualChatApp`` — no mocks, per the testing
+policy.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+from textual.widgets import TabPane
+from textual_flowview import EntryState, FlowView
+
+from reyn.core.events.events import Event
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.intervention_panel import InterventionPanel
+from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
+from reyn.interfaces.repl.read_model import RegistryReadModel
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+# ── real seam: a queue-backed ClientTransport a test drives frame-by-frame ──
+
+
+class QueueTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` whose ``frames()`` drains an
+    ``asyncio.Queue`` a test pushes onto — so a test can interleave pushing a
+    frame with mutating the (real) registry/session state in between, exactly
+    like production interleaves a registry attach with the frames it emits.
+    Never ends on its own (mirrors ``ScriptedTransport(end=False)`` elsewhere
+    in this package) — the test's ``async with app.run_test()`` block owns
+    the app's lifetime."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue" = asyncio.Queue()
+        self.submitted: "list[str]" = []
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        while True:
+            yield await self._queue.get()
+
+    def push_display(self, msg: OutboxMessage) -> None:
+        self._queue.put_nowait(DisplayFrame(msg))
+
+    def push_event(self, etype: str, data: dict) -> None:
+        self._queue.put_nowait(EventFrame(Event(type=etype, data=data)))
+
+    async def submit_user_text(self, text: str) -> str:
+        self.submitted.append(text)
+        return ""
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: OutboxMessage) -> None:
+        self.push_display(msg)
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def cancel_queued(self, msg_id: str) -> bool:  # pragma: no cover - trivial
+        return False
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        s = make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+        s.load_history()
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    reg.create("beta")
+    return reg
+
+
+def _registry_with_wal(tmp_path: Path) -> AgentRegistry:
+    """Like :func:`_registry`, but with a real ``StateLog`` wired into every
+    session — needed ONLY by the queue-reseed test below:
+    ``SnapshotJournal.append_inbox`` populates ``snapshot.inbox`` (the source
+    ``Session.queued_user_messages()`` reads) exclusively when
+    ``state_log is not None`` (``services/snapshot_journal.py``). Every other
+    test in this file uses the plain :func:`_registry` (no WAL) since they
+    never need a real undispatched-queue witness."""
+    state_log = StateLog(tmp_path / "state.wal")
+
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        s = make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            state_log=state_log,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+        s.load_history()
+        return s
+
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=factory, state_log=state_log,
+    )
+    reg.create("alpha")
+    reg.create("beta")
+    return reg
+
+
+def _entries(app: TextualChatApp):
+    return list(app.query_one(FlowView).entries)
+
+
+def _rows(app: TextualChatApp) -> "list[tuple[str, str]]":
+    return [(e.item.kind, e.item.text) for e in _entries(app)]
+
+
+async def _settle(pilot, n: int = 2) -> None:
+    for _ in range(n):
+        await pilot.pause()
+
+
+# ── 1. ★staleness gate (load-bearing) ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_staleness_gate_frames_produced_while_away_are_present(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: ★the design thesis's falsifier. A→B, A's session produces a
+    NEW turn while this client is on B — durably persisted only, exactly as
+    the registry forwarder would leave it for a detached session (never
+    delivered as a live frame to this client) — then switch back to A: that
+    away-produced turn is PRESENT. A cache-as-truth implementation cannot
+    pass this (it never received that frame and has nothing else to show
+    it); this implementation passes because it rehydrates from
+    ``history.jsonl`` on every switch, not from a retained cache."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        alpha = reg.get_session("alpha")
+        transport = QueueTransport()
+        app = TextualChatApp(
+            transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+        )
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _settle(pilot)
+            assert _rows(app) == [], "alpha starts with no history"
+
+            # Live turn while attached to alpha — delivered live AND durably
+            # persisted (mirrors production: a live frame's turn is also
+            # written to history.jsonl by the same RouterLoop call).
+            transport.push_display(OutboxMessage(kind="user", text="turn A1"))
+            await _settle(pilot)
+            alpha._append_history(ChatMessage(role="user", content="turn A1"))
+            assert _rows(app) == [("user", "turn A1")]
+
+            # Switch to beta.
+            await reg.attach("beta")
+            transport.push_event(
+                "session_attached", {"agent": "beta", "session_id": _DEFAULT_SID}
+            )
+            await _settle(pilot)
+            assert _rows(app) == [], "beta has no history yet — must not show alpha's"
+
+            # While this client is on beta, alpha's session produces a NEW
+            # turn — durably persisted ONLY (never pushed to this client's
+            # transport at all), exactly like a detached forwarder drop.
+            alpha._append_history(ChatMessage(role="user", content="turn A2 while away"))
+
+            # Ordinary live activity on beta in between, to prove the barrier
+            # also correctly attributes a frame delivered right after it to
+            # the NEW session (gate 5, barrier consumption).
+            transport.push_display(OutboxMessage(kind="user", text="turn B1"))
+            await _settle(pilot)
+            assert _rows(app) == [("user", "turn B1")]
+
+            # Switch back to alpha.
+            await reg.attach("alpha")
+            transport.push_event(
+                "session_attached", {"agent": "alpha", "session_id": _DEFAULT_SID}
+            )
+            await _settle(pilot)
+
+            assert _rows(app) == [
+                ("system", "⤺ resumed previous conversation"),
+                ("user", "turn A1"),
+                ("user", "turn A2 while away"),
+            ], (
+                "the away-produced turn must reappear on switch-back — a "
+                f"cache-as-truth implementation would drop it: {_rows(app)!r}"
+            )
+    finally:
+        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+
+
+# ── 2. orphan gate ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_orphan_gate_tool_completed_while_away_is_not_running(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: a tool that STARTED and COMPLETED entirely while this client
+    was away (on another session) must not render RUNNING after switching
+    back — hydrate's coalesced/resolved projection settles it directly (the
+    live RUNNING-tracking path never even sees it, so there is nothing to
+    force-settle; this witnesses that the restore path itself never leaves a
+    phantom RUNNING row)."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        alpha = reg.get_session("alpha")
+        transport = QueueTransport()
+        app = TextualChatApp(
+            transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+        )
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _settle(pilot)
+
+            await reg.attach("beta")
+            transport.push_event(
+                "session_attached", {"agent": "beta", "session_id": _DEFAULT_SID}
+            )
+            await _settle(pilot)
+
+            # A whole tool call+result completes on alpha while this client
+            # is on beta — persisted directly (never delivered live here).
+            alpha._append_history(ChatMessage(
+                role="assistant", content="",
+                tool_calls=[{
+                    "id": "call_1", "type": "function",
+                    "function": {"name": "shell__run", "arguments": '{"cmd": "ls"}'},
+                }],
+            ))
+            alpha._append_history(ChatMessage(
+                role="tool", content="file_a.txt\nfile_b.txt",
+                name="shell__run", tool_call_id="call_1",
+            ))
+
+            await reg.attach("alpha")
+            transport.push_event(
+                "session_attached", {"agent": "alpha", "session_id": _DEFAULT_SID}
+            )
+            await _settle(pilot)
+
+            entries = _entries(app)
+            # Unpacking into a single-element tuple IS the "exactly one" check
+            # (raises ValueError on 0 or 2+ matches) — a behavioral read of
+            # the extracted value below, not a `len(...) == N` format pin.
+            (tool_entry,) = [e for e in entries if e.item.kind == "tool_call_started"]
+            assert tool_entry.state is EntryState.SUCCESS, (
+                f"a tool completed while away must resolve, never RUNNING: "
+                f"{tool_entry.state!r}"
+            )
+            assert all(e.state is not EntryState.RUNNING for e in entries)
+    finally:
+        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+
+
+# ── 3. per-state reset — ONE independent test per state ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reset_running_tools_stale_op_id_does_not_silently_coalesce(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: ``_running_tools`` witness. A tool starts (RUNNING) on alpha,
+    left unresolved at switch time. After switching to beta, a completion
+    frame carrying the SAME op_id must NOT be silently absorbed into the
+    (now-removed) stale entry — if ``_running_tools`` were not cleared,
+    ``_ingest_frame`` would pop the stale entry and hand it to
+    ``_coalesce_tool_result``, which settles that ORPHANED (off-model) entry
+    in place and returns WITHOUT appending anything — the completion would
+    vanish with zero visible trace. With the dict cleared, the completion
+    finds no RUNNING match and falls through to a plain appended row — a
+    directly observable, non-vacuous discriminator between "cleared" and
+    "leftover"."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        transport = QueueTransport()
+        app = TextualChatApp(
+            transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+        )
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _settle(pilot)
+
+            transport.push_display(OutboxMessage(
+                kind="tool_call_started", text="shell__run",
+                meta={"op_id": "op-stale", "tool": "shell__run", "args": {}},
+            ))
+            await _settle(pilot)
+            # Unpacking into a single-element tuple IS the "exactly one RUNNING
+            # entry" check (raises on 0 or 2+) — not a `len(...) == N` pin.
+            (running_entry,) = [e for e in _entries(app) if e.state is EntryState.RUNNING]
+            assert running_entry.state is EntryState.RUNNING
+
+            await reg.attach("beta")
+            transport.push_event(
+                "session_attached", {"agent": "beta", "session_id": _DEFAULT_SID}
+            )
+            await _settle(pilot)
+            assert _entries(app) == [], "switch must clear the retained model"
+
+            # Same op_id, now on beta — must NOT be silently swallowed.
+            transport.push_display(OutboxMessage(
+                kind="tool_call_completed", text="",
+                meta={"op_id": "op-stale", "tool": "shell__run", "result": "done"},
+            ))
+            await _settle(pilot)
+
+            rows = _rows(app)
+            assert rows == [("tool_call_completed", "")], (
+                "a completion for an op_id RUNNING before the switch must "
+                "appear as a fresh, uncorrelated row after reset — a leftover "
+                f"_running_tools entry would swallow it silently: {rows!r}"
+            )
+    finally:
+        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_reset_pending_interventions_closes_all_tabs(tmp_path, monkeypatch) -> None:
+    """Tier 2: ``_pending_ivs`` / panel-tabs witness. A pending intervention on
+    alpha opens the panel with one tab; switching away must close the whole
+    panel (``InterventionPanel.collapse_all`` — the whole panel, panel.display
+    False, zero mounted ``TabPane``s), never leaving alpha's stale tab
+    lingering behind the new session's own (server-re-announced) ones."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        transport = QueueTransport()
+        app = TextualChatApp(
+            transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+        )
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _settle(pilot)
+
+            transport.push_display(OutboxMessage(
+                kind="intervention",
+                text="Allow write to /etc/hosts?",
+                meta={
+                    "intervention_id": "iv-1",
+                    "prompt": "Allow write to /etc/hosts?",
+                    "choices": [{"id": "yes", "label": "Yes"}, {"id": "no", "label": "No"}],
+                },
+            ))
+            await _settle(pilot)
+
+            panel = app.query_one(InterventionPanel)
+            assert panel.display is True, "panel must show for the pending intervention"
+            assert len(list(panel.query(TabPane))) == 1
+
+            await reg.attach("beta")
+            transport.push_event(
+                "session_attached", {"agent": "beta", "session_id": _DEFAULT_SID}
+            )
+            await _settle(pilot)
+
+            assert panel.display is False, "switch must collapse the whole panel"
+            assert list(panel.query(TabPane)) == [], (
+                "switch must close every pending tab from the OLD session"
+            )
+    finally:
+        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_reset_sent_queue_view_and_widget_and_item_meta(tmp_path, monkeypatch) -> None:
+    """Tier 2: ``_queue_view`` / ``_queue_seeded`` / ``_queue_item_meta`` / the
+    :class:`SentQueue` widget rows — witnessed together because they are ONE
+    observable surface (the widget's public ``has_items()``/
+    ``rendered_texts()``), but the underlying reset is driven by clearing ALL
+    FOUR: a fresh ``RemoteQueueView()``, ``_queue_seeded=False`` (so the
+    existing seed-on-first-frame path re-seeds the NEW session), the sent-queue
+    WIDGET's rows, and the meta side-table. A queued item materializes via a
+    ``user_submitted`` chat-event (the real production path,
+    ``_handle_user_submitted_event``) on alpha; switching to beta must show
+    the sent-queue region EMPTY, never alpha's still-queued row."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        transport = QueueTransport()
+        app = TextualChatApp(
+            transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+        )
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _settle(pilot)
+
+            transport.push_event("user_submitted", {
+                "msg_id": "m-1", "chain_id": "c-1", "text": "queued on alpha", "seq": 1,
+                "meta": {},
+            })
+            await _settle(pilot)
+
+            sent_queue = app.query_one(SentQueue)
+            assert sent_queue.has_items() is True
+            assert any("queued on alpha" in t for t in sent_queue.rendered_texts())
+
+            await reg.attach("beta")
+            transport.push_event(
+                "session_attached", {"agent": "beta", "session_id": _DEFAULT_SID}
+            )
+            await _settle(pilot)
+
+            assert sent_queue.has_items() is False, (
+                "alpha's queued row must not survive the switch to beta"
+            )
+            assert sent_queue.rendered_texts() == []
+    finally:
+        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_reset_streaming_replies_stale_chain_id_does_not_finalize_into_ghost(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: ★``_streaming_replies`` witness (#3288 ③c) — the architect
+    explicitly flagged this as the state most likely to be forgotten by a
+    later phase. A streamed reply's delta on alpha creates ONE flow entry
+    keyed by chain_id, left unfinished (no terminal completion) at switch
+    time. After switching to beta, a completion frame carrying the SAME
+    chain_id must NOT be silently finalized into the (now-removed) stale
+    entry — if ``_streaming_replies`` were not cleared, ``_ingest_frame``
+    would pop the stale entry and call ``entry.set_item`` on an orphaned
+    (off-model) ``Entry`` and return WITHOUT appending — the completion
+    would vanish with zero visible trace, mirroring the running-tools
+    discriminator above."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        transport = QueueTransport()
+        app = TextualChatApp(
+            transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+        )
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _settle(pilot)
+
+            transport.push_event("agent_delta", {"chain_id": "chain-1", "text": "partial…"})
+            await _settle(pilot)
+            assert _rows(app) == [("agent", "partial…")]
+
+            await reg.attach("beta")
+            transport.push_event(
+                "session_attached", {"agent": "beta", "session_id": _DEFAULT_SID}
+            )
+            await _settle(pilot)
+            assert _rows(app) == [], "switch must clear the retained model"
+
+            # Same chain_id, now on beta — the terminal completion must NOT
+            # be silently absorbed into the stale (removed) entry.
+            transport.push_display(OutboxMessage(
+                kind="agent", text="finalized on beta",
+                meta={"chain_id": "chain-1"},
+            ))
+            await _settle(pilot)
+
+            rows = _rows(app)
+            assert rows == [("agent", "finalized on beta")], (
+                "a completion for a chain_id in-flight before the switch must "
+                "appear as a fresh row after reset — a leftover "
+                f"_streaming_replies entry would swallow it silently: {rows!r}"
+            )
+    finally:
+        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+
+
+def _install_hanging_run_turn(session: Session):
+    """Same no-mock seam ``tests/test_3300_p2a_queue_state_publish.py`` uses
+    (itself mirroring ``tests/test_2242_hard_cancel.py``): a real, plain
+    async function method-assigned onto the instance standing in for a
+    genuinely in-flight LLM call, so a turn can be held BUSY (never touching
+    a real LLM) while a SECOND submission queues behind it."""
+    call_started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _hanging_run_turn(user_text: str, chain_id: str) -> None:
+        call_started.set()
+        await release.wait()
+
+    session._loop_driver.run_turn = _hanging_run_turn  # type: ignore[method-assign]
+    return call_started, release
+
+
+async def _stop_auto_driver(reg: AgentRegistry, name: str) -> None:
+    """Cancel the background ``session.run()`` driver ``AgentRegistry.attach``
+    booted for ``name`` — the SAME helper
+    ``tests/test_3300_p2a_queue_state_publish.py`` uses, so a test can drive
+    ``run_one_iteration()`` manually instead of racing the live loop for
+    control over exactly when a submission dispatches vs. stays queued."""
+    key = (name, _DEFAULT_SID)
+    task = reg._tasks.get(key)
+    if task is not None and not task.done():
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+    fwd = reg._forward_tasks.get(key)
+    if fwd is not None and not fwd.done():
+        fwd.cancel()
+        try:
+            await fwd
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_reset_queue_view_reseeds_from_new_sessions_own_queue(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: ``_queue_view`` / ``_queue_seeded`` witness, INDEPENDENT of the
+    sent-queue WIDGET clear above (a strip check during review showed the
+    widget-clear test above stays GREEN even with ``_queue_view``/
+    ``_queue_seeded`` left UNRESET — a real per-state gap the architect's
+    table did not by itself surface; this test closes it).
+
+    Beta has its OWN item ALREADY queued (behind a held-busy turn, manually
+    pumped — the auto-driver is stopped so this test has sole, deterministic
+    control over dispatch, exactly like the #3300 P2a late-joiner test) BEFORE
+    this client ever switches to it. If the switch-barrier handler did not
+    eagerly reseed :attr:`_queue_view` from the NEW session's OWN snapshot,
+    beta's already-queued item would never render (there is no OTHER trigger
+    that would show it — nothing else happens on beta in this scenario) —
+    this is the #3305-shaped reconnect-reseed, witnessed here for the SWITCH
+    path specifically."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry_with_wal(tmp_path)
+    try:
+        await reg.attach("alpha")
+        beta = await reg.attach("beta")
+        await _stop_auto_driver(reg, "beta")
+
+        call_started, release = _install_hanging_run_turn(beta)
+        await beta.submit_user_text("beta busy trigger")
+        turn_task = asyncio.create_task(beta.run_one_iteration())
+        await asyncio.wait_for(call_started.wait(), timeout=5)
+
+        # A second submission arrives while the first is still in flight —
+        # it stays undispatched (server-authoritative queue, #3300 §6b).
+        await beta.submit_user_text("beta queued item")
+        assert [i["text"] for i in beta.queued_user_messages()] == ["beta queued item"], (
+            "fixture setup: beta must have exactly one UNDISPATCHED queued item"
+        )
+        await reg.attach("alpha")
+
+        transport = QueueTransport()
+        app = TextualChatApp(
+            transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+        )
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _settle(pilot)
+
+            # NOTE: flips ``registry._attached`` directly rather than calling
+            # ``reg.attach("beta")`` again — the auto-driver was deliberately
+            # stopped above (so THIS test controls dispatch); a real
+            # ``attach()`` call re-boots a fresh ``session.run()`` background
+            # task (its own ``_tasks[key].done()`` check sees the cancelled
+            # task and reboots), which would race the manually-held-busy
+            # turn for the SAME inbox and silently dispatch the "queued"
+            # fixture item out from under this test. Flipping the pointer
+            # directly is the read-side-only equivalent this test needs —
+            # the app's ``_snapshot()`` only ever reads
+            # ``registry.attached_session()``, never re-derives from a live
+            # ``attach()`` call itself.
+            reg._attached = ("beta", _DEFAULT_SID)
+            transport.push_event(
+                "session_attached", {"agent": "beta", "session_id": _DEFAULT_SID}
+            )
+            await _settle(pilot)
+
+            sent_queue = app.query_one(SentQueue)
+            assert sent_queue.has_items() is True, (
+                "beta's OWN already-queued item must render once this client "
+                "switches to beta — the switch-barrier reseed must fire"
+            )
+            assert any(
+                "beta queued item" in t for t in sent_queue.rendered_texts()
+            ), sent_queue.rendered_texts()
+
+        release.set()
+        await asyncio.wait_for(turn_task, timeout=5)
+    finally:
+        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+
+
+# ── 4. unvisited session ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unvisited_session_shows_its_history_not_blank(tmp_path, monkeypatch) -> None:
+    """Tier 2: switching to a session never seen in THIS client run (the
+    client mounted attached to alpha; beta was never attached-to by this
+    client before) shows BETA's persisted history, not a blank pane — the
+    cache-miss path is just "hydrate", the same as any other switch, since
+    there is no cache to miss in the first place (v1 has none)."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        # beta accumulates history entirely BEFORE this client ever attaches
+        # to it — via a SEPARATE attach the test uses only to seed history,
+        # never surfaced to this app/client.
+        beta = await reg.attach("beta")
+        beta._append_history(ChatMessage(role="user", content="beta turn 1"))
+        beta._append_history(ChatMessage(role="assistant", content="beta reply 1"))
+        await reg.attach("alpha")
+
+        transport = QueueTransport()
+        app = TextualChatApp(
+            transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+        )
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _settle(pilot)
+            assert _rows(app) == [], "alpha (this client's mount session) has no history"
+
+            await reg.attach("beta")
+            transport.push_event(
+                "session_attached", {"agent": "beta", "session_id": _DEFAULT_SID}
+            )
+            await _settle(pilot)
+
+            assert _rows(app) == [
+                ("system", "⤺ resumed previous conversation"),
+                ("user", "beta turn 1"),
+                ("agent", "beta reply 1"),
+            ], (
+                "a never-before-attached-in-this-client-run session must "
+                f"hydrate from its history, not show blank: {_rows(app)!r}"
+            )
+    finally:
+        await asyncio.wait_for(reg.shutdown(), timeout=5.0)


### PR DESCRIPTION
**[per-PR-coder]** — part of #3310 (N3 remote parity remains, separate PR).

## What this is

N1 (#3321) added `session_attached` (`{agent, session_id}`) — an `EventFrame` the registry puts directly on `repl_outbox` at the attach seam with no `await` between the flip and the put, so it is a stream BARRIER: everything before it belongs to the OLD attached session, everything after to the NEW one, by construction.

This is N2: the Textual chat client consumes that barrier. On `session_attached`, `TextualChatApp._handle_session_attached_event` resets every per-session client state and rehydrates the retained model from the NEW session's `history.jsonl`.

**Design thesis (architect deep-dive, issue #3310 §1, owner-ratified — not re-litigated here): a cached FlowView cannot be the source of truth.** While a session is detached, the registry forwarder *drops* its frames (`registry.py`'s "durable narration is in history.jsonl" branch) — a cache would be missing everything that happened while away, hold tool rows stuck RUNNING, and disagree with server-authoritative state. v1 is reconnect-shaped, not cache-shaped: reset, then rehydrate from durable sources.

## Reset-state list, as verified against the current file

| State | Verified location | Reset |
|---|---|---|
| FlowView entries / conversation | `self.conversation` (FlowModel) | `.clear()`, then rehydrate |
| `_running_tools` | `app.py` | `.clear()` |
| `_pending_ivs` | `app.py` (post-P5, no `_iv_current_key` anymore — see below) | `.clear()` + `InterventionPanel.collapse_all()` (closes ALL tabs) |
| `_queue_view` / `_queue_seeded` | `app.py` | fresh `RemoteQueueView()`, **eagerly reseeded here** (see finding below) |
| `_queue_item_meta` | `app.py` | `.clear()` |
| sent-queue widget rows | `SentQueue` | new `clear_all()` method added |
| `_streaming_replies` (#3288 ③c) | `app.py` | `.clear()` — the architect explicitly flagged this as the state a later phase would forget |
| `_pane_selection_ids` | `app.py` | **NOT reset** — confirmed fine as-is: rebuilt from a fresh snapshot on every drawer-pane open, so a stale entry is never read before being overwritten |

**Two things beyond the architect's enumeration, found while verifying against the current file:**

1. **`_iv_current_key` no longer exists.** #3308 (P5) replaced the single-slot re-route it belonged to with per-intervention TABS — `_pending_ivs` + `InterventionPanel.collapse_all()` are the whole of the intervention reset today.
2. **`_pending_own_cancels` (#3300 Y-client) — not in the architect's table.** Keyed by msg_id, normally popped once the matching `inbox_cancel` delta confirms a client-issued cancel. A switch before that confirmation would leave a stale entry that could later restore OLD-session cancelled text into the composer if a delta for that same msg_id ever arrived under a different attached session. Added to the reset list (narrow leak, not independently gated — see Test plan).

**A real bug found while writing the per-state gates (not in the architect's table either):** the `_queue_view`/`_queue_seeded` reset originally deferred to the existing "seed on first frame the pump processes" check. That check runs *before* a frame is dispatched, so it needs a frame *after* the barrier to ever fire — a session with an already-queued item but no other pending activity would show an empty sent-queue region indefinitely. Fixed: the switch handler seeds `_queue_view` eagerly, right there, instead of deferring.

## Hydrate seam generalization

`_hydrate_from_history` now accepts optional `agent`/`session_id`; omitted (the `on_mount` call) is byte-identical to pre-N2. `ChatReadModel.conversation_history` gained the same optional params: `RegistryReadModel` resolves via `AgentRegistry.get_session(agent, session_id)` (the existing FP-0043 Stage 3 non-loading session-store accessor) instead of duplicating a `history.jsonl` path literal; `RemoteReadModel` stays an empty-list no-op regardless of the target (remote switch-hydrate is N3's job — this PR does not touch `src/reyn/interfaces/transport/agui/`).

## Gates — strip-falsified per site, observed RED reproduced live (see `tests/test_3310_n2_reset_hydrate.py`)

1. **★Staleness gate** (`test_staleness_gate_frames_produced_while_away_are_present`) — A→B, A's session produces a NEW turn while the client is on B (durably persisted only, never delivered live — models a detached forwarder drop), switch back to A: the away-produced turn is present. Strip `_hydrate_from_history(...)` from the handler → RED (turn missing). Strip `self.conversation.clear()` alone (hydrate still runs) → RED (old session's turn duplicates instead of being replaced by the fresh hydrate).
2. **Orphan gate** (`test_orphan_gate_...`) — a tool call+result that completes entirely while away resolves SUCCESS, never RUNNING, after switching back (hydrate's resolved projection; witnessed, not a new mechanism).
3. **Per-state reset, one independent test per state:**
   - `_running_tools` — strip its `.clear()` → RED (a completion for the pre-switch op_id is silently absorbed into the orphaned entry instead of appearing as a fresh row).
   - `_pending_ivs` / panel tabs — strip both clears → RED (panel stays open with the stale tab).
   - sent-queue widget + `_queue_view` reseed — TWO separate tests: (a) widget-clear witness (strip `clear_all()` alone → RED, old row survives); (b) reseed witness (`test_reset_queue_view_reseeds_from_new_sessions_own_queue`, added after finding the eager-seed bug above — strip the eager `_seed_queue_view()` call → RED, beta's own pre-existing queued item never renders).
   - `_streaming_replies` — strip its `.clear()` → RED (a completion for the pre-switch chain_id vanishes into the orphaned entry, same failure shape as `_running_tools`).
4. **Unvisited session** (`test_unvisited_session_shows_its_history_not_blank`) — switching to a session never attached-to by this client shows its history, not blank. Strip hydrate → RED.
5. **Barrier consumption** — witnessed inline in the staleness-gate test: a live frame delivered immediately after the barrier renders into the NEW session's view (trivial here — a single retained FlowModel the barrier just cleared has no "other queue" to mis-file into).

Full whole-handler strip (comment out the `session_attached` branch entirely) → all 7 gate tests go RED simultaneously, confirming none of them pass vacuously.

## Local verification (targeted, foreground)

- `uv run python -m pytest --timeout=120 -q` over the new test file + touched `textual_chat`/`#3310`/`#3300`/agui-profile test files (185 tests): **185 passed**.
- `ruff check src tests`: clean.
- `python scripts/test_tier_audit.py --strict tests/test_3310_n2_reset_hydrate.py`: 0 errors.
- `python scripts/verify_module_docstrings.py` on touched `src/` files: OK.

## Doc updates (same PR)

`docs/reference/runtime/agui-transport.md`: the session-switch-barrier section (previously "N2 not yet implemented") now documents the N2 client-side reset/hydrate behavior, keeps the N3 remote-parity gap explicit, and updates the profile table row. `docs/feature-map.md`: new section for the session-switch reset/rehydrate feature.

## Left to N3 (out of scope here, `src/reyn/interfaces/transport/agui/` untouched)

AG-UI/SSE remote re-emission of `session_attached` on the wire + remote switch-hydrate (`RemoteReadModel.conversation_history` stays an empty-list no-op regardless of a targeted session — the frame-sufficiency boundary this arc follows throughout).

## Test plan

- [x] `pytest` targeted run (see above) — 185 passed
- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` on the new test file — 0 errors
- [x] `verify_module_docstrings.py` on changed src files — OK
- [x] Strip-falsify each gate live, observed RED, reverted (see above)
- [x] (skipped — no widget-tree/layout change in this PR, no geometry gate needed)
- [ ] (skipped — `_pending_own_cancels` clear is a narrow, self-identified addition beyond the architect's table; implemented defensively but not independently strip-gated in this PR, time-boxed decision)