### PR TITLE
fix(llm): gate the /v1/responses bridge on the resolved model's provider — #3288 follow-up

### DIFF
--- a/docs/reference/builtin-models.ja.md
+++ b/docs/reference/builtin-models.ja.md
@@ -133,12 +133,13 @@ answer 品質が落ちる可能性あり。
 
 ### ツールを伴う turn での reasoning（Responses-API bridge）
 
-**tools** を伴い、かつ **OpenAI** の reasoning-capable model に `reasoning_effort`
-が設定された turn は、litellm の Responses-API bridge（`responses/<model>`）を
-通ります。`reasoning_effort + tools` の組み合わせは OpenAI の `/v1/responses`
-でのみ有効で、`/v1/chat/completions` はこの組み合わせを 405 で拒否するためです
-（#1678）。litellm の bridge は現状、model が返す `reasoning` output item を
-map できないため、call が次の error を raise します:
+**tools** を伴い、かつ **OpenAI または Azure** の reasoning-capable model に
+`reasoning_effort` が設定された turn は、litellm の Responses-API bridge
+（`responses/<model>`）を通ります。`reasoning_effort + tools` の組み合わせは
+これらの provider の `/v1/responses` でのみ有効で、`/v1/chat/completions` は
+この組み合わせを 405 で拒否するためです（#1678）。litellm の bridge は現状、
+model が返す `reasoning` output item を map できないため、call が次の error を
+raise します:
 
 ```
 litellm.APIConnectionError: OpenAIException -
@@ -151,12 +152,19 @@ litellm release に存在し、released fix はありません。Reyn は provid
 作りません。
 
 **provider でゲートされる（#3288 follow-up）。** この bridge は Reyn が
-**OpenAI** と解決した model にのみ適用されます（transport/proxy routing では
-なく、解決済み model identity に対する `litellm.get_llm_provider` query —
-`src/reyn/llm/llm.py` の `_requires_responses_bridge` を参照）。Gemini には
-適用されません — Gemini の `reasoning_effort` はネイティブの thinking-budget
-パラメータに map され、`/v1/chat/completions` だけで完結するためです。Gemini の
+**OpenAI または Azure** と解決した model にのみ適用されます（transport/proxy
+routing ではなく、解決済み model identity に対する `litellm.get_llm_provider`
+query — `src/reyn/llm/llm.py` の `_requires_responses_bridge` を参照）。Azure
+が含まれるのは、Azure が reyn の一級 provider であり、OpenAI の reasoning
+model（`azure/o1`、`azure/o3-mini` 等）をそのままホストしているため、同じ
+`/chat/completions` 拒否に当たるからです。Gemini には適用されません —
+Gemini の `reasoning_effort` はネイティブの thinking-budget パラメータに
+map され、`/v1/chat/completions` だけで完結するためです。Gemini の
 tool-turn 上の reasoning はこの bridge を一切通らず、上記 error にも当たりません。
+また、model 名自体に `openai/` segment を含む OpenRouter 経由の model
+（例: `openrouter/openai/gpt-5`）にも適用されません — その call は
+OpenRouter 自身の completions endpoint に着地し、埋め込まれた segment に
+関わらず OpenAI の `/v1/responses` には一切到達しないためです。
 （この gate が入る前は、provider を問わず **すべての** `tools + reasoning_effort`
 組み合わせが bridge を通っており、Gemini のデフォルト model class で token
 streaming が黙って無効化されていました。streaming 側の fix は `_streaming_capable`
@@ -167,24 +175,25 @@ streaming が黙って無効化されていました。streaming 側の fix は 
 1. **tool を伴う** purpose（例: router。その turn は常に tools を持つ）が
    reasoning-capable model を指す。**かつ**
 2. その model に `reasoning_effort` が設定されている。**かつ**
-3. その model が **OpenAI** provider に解決される（`model_class_by_purpose:
-   router: strong` を OpenAI の reasoning model に向ける、またはデフォルトの
-   `model` class をそれに設定）。
+3. その model が **OpenAI または Azure** provider に解決される
+   （`model_class_by_purpose: router: strong` を OpenAI/Azure の reasoning
+   model に向ける、またはデフォルトの `model` class をそれに設定）。
 
 **影響を受けないパス:**
 
 - **デフォルト構成。** `standard`/`light` class（Gemini Flash Lite。#1654 の
   通り `reasoning_effort: low` がデフォルトで設定済み）が影響を受けないのは
   `reasoning_effort` が未設定だからではなく、Gemini が bridge の対象である
-  OpenAI provider ではないためです。デフォルト構成の tool turn は通常通り
+  OpenAI/Azure provider ではないためです。デフォルト構成の tool turn は通常通り
   `/v1/chat/completions` を通ります。
 - **tool なしの chat + reasoning。** reasoning-capable model を tools *なし* で使うと
   `/v1/chat/completions` を通り、reasoning は survive して正常に round-trip します
   （`reasoning_content` / `thinking_blocks` として現れる）。
 
-**回避するには**、tool を伴う turn を担う OpenAI の reasoning-capable model に
-`reasoning_effort` を設定しない — または tool を伴う purpose を OpenAI reasoning
-以外の model に置く。tool なしの chat パスの reasoning は影響を受けません。
+**回避するには**、tool を伴う turn を担う OpenAI/Azure の reasoning-capable
+model に `reasoning_effort` を設定しない — または tool を伴う purpose を
+どちらの provider にも解決されない model に置く。tool なしの chat パスの
+reasoning は影響を受けません。
 
 ## Namespace + override semantics
 

--- a/docs/reference/builtin-models.ja.md
+++ b/docs/reference/builtin-models.ja.md
@@ -133,10 +133,12 @@ answer 品質が落ちる可能性あり。
 
 ### ツールを伴う turn での reasoning（Responses-API bridge）
 
-**tools** を伴い、かつ reasoning-capable model に `reasoning_effort` が設定された
-turn は、litellm の Responses-API bridge（`responses/<model>`）を通ります。litellm
-の bridge は現状、model が返す `reasoning` output item を map できないため、call が
-次の error を raise します:
+**tools** を伴い、かつ **OpenAI** の reasoning-capable model に `reasoning_effort`
+が設定された turn は、litellm の Responses-API bridge（`responses/<model>`）を
+通ります。`reasoning_effort + tools` の組み合わせは OpenAI の `/v1/responses`
+でのみ有効で、`/v1/chat/completions` はこの組み合わせを 405 で拒否するためです
+（#1678）。litellm の bridge は現状、model が返す `reasoning` output item を
+map できないため、call が次の error を raise します:
 
 ```
 litellm.APIConnectionError: OpenAIException -
@@ -148,25 +150,41 @@ item を chat-completions の形に map しないだけです。これは curren
 litellm release に存在し、released fix はありません。Reyn は provider 固有の回避を
 作りません。
 
-**発火する条件 — 狭い opt-in の組み合わせ。** 両方が成立する必要があります:
+**provider でゲートされる（#3288 follow-up）。** この bridge は Reyn が
+**OpenAI** と解決した model にのみ適用されます（transport/proxy routing では
+なく、解決済み model identity に対する `litellm.get_llm_provider` query —
+`src/reyn/llm/llm.py` の `_requires_responses_bridge` を参照）。Gemini には
+適用されません — Gemini の `reasoning_effort` はネイティブの thinking-budget
+パラメータに map され、`/v1/chat/completions` だけで完結するためです。Gemini の
+tool-turn 上の reasoning はこの bridge を一切通らず、上記 error にも当たりません。
+（この gate が入る前は、provider を問わず **すべての** `tools + reasoning_effort`
+組み合わせが bridge を通っており、Gemini のデフォルト model class で token
+streaming が黙って無効化されていました。streaming 側の fix は `_streaming_capable`
+の docstring を参照。）
+
+**発火する条件 — 狭い opt-in の組み合わせ。** すべてが成立する必要があります:
 
 1. **tool を伴う** purpose（例: router。その turn は常に tools を持つ）が
-   **reasoning-capable** model を指す — `model_class_by_purpose: router: strong`、
-   またはデフォルトの `model` class を capable model に設定。**かつ**
-2. その model に `reasoning_effort` が設定されている。
+   reasoning-capable model を指す。**かつ**
+2. その model に `reasoning_effort` が設定されている。**かつ**
+3. その model が **OpenAI** provider に解決される（`model_class_by_purpose:
+   router: strong` を OpenAI の reasoning model に向ける、またはデフォルトの
+   `model` class をそれに設定）。
 
 **影響を受けないパス:**
 
-- **デフォルト構成。** `standard` class（Gemini Flash Lite）は `reasoning_effort`
-  なしで tool turn を捌くので、bridge でなく `/v1/chat/completions` を通り error
-  なし。（Flash Lite は tool turn で reasoning-dormant でもある。）
+- **デフォルト構成。** `standard`/`light` class（Gemini Flash Lite。#1654 の
+  通り `reasoning_effort: low` がデフォルトで設定済み）が影響を受けないのは
+  `reasoning_effort` が未設定だからではなく、Gemini が bridge の対象である
+  OpenAI provider ではないためです。デフォルト構成の tool turn は通常通り
+  `/v1/chat/completions` を通ります。
 - **tool なしの chat + reasoning。** reasoning-capable model を tools *なし* で使うと
   `/v1/chat/completions` を通り、reasoning は survive して正常に round-trip します
   （`reasoning_content` / `thinking_blocks` として現れる）。
 
-**回避するには**、tool を伴う turn を担う reasoning-capable model に
-`reasoning_effort` を設定しない — または tool を伴う purpose を non-reasoning model
-に置く。tool なしの chat パスの reasoning は影響を受けません。
+**回避するには**、tool を伴う turn を担う OpenAI の reasoning-capable model に
+`reasoning_effort` を設定しない — または tool を伴う purpose を OpenAI reasoning
+以外の model に置く。tool なしの chat パスの reasoning は影響を受けません。
 
 ## Namespace + override semantics
 

--- a/docs/reference/builtin-models.md
+++ b/docs/reference/builtin-models.md
@@ -157,12 +157,13 @@ quality on complex tasks.
 
 ### Reasoning on tool-bearing turns (Responses-API bridge)
 
-A turn that carries **tools** *and* has `reasoning_effort` set on an
-**OpenAI** reasoning-capable model is routed through litellm's Responses-API
-bridge (`responses/<model>`), because `reasoning_effort + tools` together are
-only valid on OpenAI's `/v1/responses` endpoint — `/v1/chat/completions`
-rejects the combination with a 405 (#1678). litellm's bridge currently cannot
-map the `reasoning` output item the model returns, so the call raises:
+A turn that carries **tools** *and* has `reasoning_effort` set on a reasoning-
+capable model resolved to the **OpenAI or Azure** provider is routed through
+litellm's Responses-API bridge (`responses/<model>`), because
+`reasoning_effort + tools` together are only valid on the `/v1/responses`
+endpoint on those providers — `/v1/chat/completions` rejects the combination
+with a 405 (#1678). litellm's bridge currently cannot map the `reasoning`
+output item the model returns, so the call raises:
 
 ```
 litellm.APIConnectionError: OpenAIException -
@@ -175,40 +176,48 @@ the current and the latest litellm release, with no released fix; Reyn does not
 ship a provider-specific workaround for it.
 
 **Provider-gated (#3288 follow-up).** The bridge only applies to models Reyn
-resolves as **OpenAI** (via a `litellm.get_llm_provider` query on the resolved
-model identity, never on the transport/proxy routing — see
-`_requires_responses_bridge` in `src/reyn/llm/llm.py`). It does NOT apply to
-Gemini, whose `reasoning_effort` maps to a native "thinking budget" parameter
-handled entirely on `/v1/chat/completions` — Gemini reasoning-on-tool-turns
-never goes through this bridge and never hits the error above. (Earlier
-behavior — before this gate existed — routed EVERY `tools + reasoning_effort`
-combination through the bridge regardless of provider, which silently disabled
-token streaming for Gemini's default model classes; see `_streaming_capable`'s
-docstring for the streaming side of that fix.)
+resolves as **OpenAI or Azure** (via a `litellm.get_llm_provider` query on the
+resolved model identity, never on the transport/proxy routing — see
+`_requires_responses_bridge` in `src/reyn/llm/llm.py`). Azure is included
+because it is a first-class reyn provider that literally hosts OpenAI's
+reasoning models (`azure/o1`, `azure/o3-mini`, …) under the same
+`/chat/completions` rejection. It does NOT apply to Gemini, whose
+`reasoning_effort` maps to a native "thinking budget" parameter handled
+entirely on `/v1/chat/completions` — Gemini reasoning-on-tool-turns never go
+through this bridge and never hit the error above. It also does NOT apply to
+an OpenRouter-routed model whose own model name happens to embed an `openai/`
+segment (e.g. `openrouter/openai/gpt-5`) — that call lands on OpenRouter's own
+completions endpoint, never OpenAI's `/v1/responses`, regardless of the
+embedded segment. (Earlier behavior — before this gate existed — routed EVERY
+`tools + reasoning_effort` combination through the bridge regardless of
+provider, which silently disabled token streaming for Gemini's default model
+classes; see `_streaming_capable`'s docstring for the streaming side of that
+fix.)
 
 **When it bites — a narrow, opt-in combination.** All must hold:
 
 1. a **tool-bearing** purpose (e.g. the router, whose turns always carry tools)
    is pointed at a reasoning-capable model; **and**
 2. `reasoning_effort` is set on that model; **and**
-3. the model resolves to the **OpenAI** provider (`model_class_by_purpose:
-   router: strong` pointed at an OpenAI reasoning model, or the default
-   `model` class set to one).
+3. the model resolves to the **OpenAI or Azure** provider
+   (`model_class_by_purpose: router: strong` pointed at an OpenAI/Azure
+   reasoning model, or the default `model` class set to one).
 
 **Unaffected paths:**
 
 - **The default setup.** The `standard`/`light` classes (Gemini Flash Lite,
   which DOES ship with `reasoning_effort: low` by default — see #1654 above)
-  are unaffected because Gemini is not the OpenAI provider the bridge targets,
-  not because `reasoning_effort` is unset. Tool-bearing turns on the default
-  config go through `/v1/chat/completions` as normal.
+  are unaffected because Gemini is not an OpenAI/Azure provider the bridge
+  targets, not because `reasoning_effort` is unset. Tool-bearing turns on the
+  default config go through `/v1/chat/completions` as normal.
 - **Non-tool chat with reasoning.** A reasoning-capable model *without* tools goes
   through `/v1/chat/completions`; reasoning survives and round-trips normally
   (surfaced as `reasoning_content` / `thinking_blocks`).
 
-**To avoid it**, keep `reasoning_effort` off any OpenAI reasoning-capable model
-that serves tool-bearing turns — or keep tool-bearing purposes on a
-non-OpenAI-reasoning model. Reasoning on the non-tool chat path is unaffected.
+**To avoid it**, keep `reasoning_effort` off any OpenAI/Azure reasoning-capable
+model that serves tool-bearing turns — or keep tool-bearing purposes on a
+model that resolves to neither provider. Reasoning on the non-tool chat path
+is unaffected.
 
 ## Namespace and override semantics
 

--- a/docs/reference/builtin-models.md
+++ b/docs/reference/builtin-models.md
@@ -157,10 +157,12 @@ quality on complex tasks.
 
 ### Reasoning on tool-bearing turns (Responses-API bridge)
 
-A turn that carries **tools** *and* has `reasoning_effort` set on a
-reasoning-capable model is routed through litellm's Responses-API bridge
-(`responses/<model>`). litellm's bridge currently cannot map the `reasoning`
-output item the model returns, so the call raises:
+A turn that carries **tools** *and* has `reasoning_effort` set on an
+**OpenAI** reasoning-capable model is routed through litellm's Responses-API
+bridge (`responses/<model>`), because `reasoning_effort + tools` together are
+only valid on OpenAI's `/v1/responses` endpoint — `/v1/chat/completions`
+rejects the combination with a 405 (#1678). litellm's bridge currently cannot
+map the `reasoning` output item the model returns, so the call raises:
 
 ```
 litellm.APIConnectionError: OpenAIException -
@@ -172,26 +174,41 @@ map the `reasoning` item onto the chat-completions shape. This is present in bot
 the current and the latest litellm release, with no released fix; Reyn does not
 ship a provider-specific workaround for it.
 
-**When it bites — a narrow, opt-in combination.** Both must hold:
+**Provider-gated (#3288 follow-up).** The bridge only applies to models Reyn
+resolves as **OpenAI** (via a `litellm.get_llm_provider` query on the resolved
+model identity, never on the transport/proxy routing — see
+`_requires_responses_bridge` in `src/reyn/llm/llm.py`). It does NOT apply to
+Gemini, whose `reasoning_effort` maps to a native "thinking budget" parameter
+handled entirely on `/v1/chat/completions` — Gemini reasoning-on-tool-turns
+never goes through this bridge and never hits the error above. (Earlier
+behavior — before this gate existed — routed EVERY `tools + reasoning_effort`
+combination through the bridge regardless of provider, which silently disabled
+token streaming for Gemini's default model classes; see `_streaming_capable`'s
+docstring for the streaming side of that fix.)
+
+**When it bites — a narrow, opt-in combination.** All must hold:
 
 1. a **tool-bearing** purpose (e.g. the router, whose turns always carry tools)
-   is pointed at a **reasoning-capable** model — `model_class_by_purpose: router:
-   strong`, or the default `model` class set to a capable model; **and**
-2. `reasoning_effort` is set on that model.
+   is pointed at a reasoning-capable model; **and**
+2. `reasoning_effort` is set on that model; **and**
+3. the model resolves to the **OpenAI** provider (`model_class_by_purpose:
+   router: strong` pointed at an OpenAI reasoning model, or the default
+   `model` class set to one).
 
 **Unaffected paths:**
 
-- **The default setup.** The `standard` class (Gemini Flash Lite) handles
-  tool-bearing turns with no `reasoning_effort`, so they go through
-  `/v1/chat/completions`, not the bridge — no error. (Flash Lite is also
-  reasoning-dormant on tool turns.)
+- **The default setup.** The `standard`/`light` classes (Gemini Flash Lite,
+  which DOES ship with `reasoning_effort: low` by default — see #1654 above)
+  are unaffected because Gemini is not the OpenAI provider the bridge targets,
+  not because `reasoning_effort` is unset. Tool-bearing turns on the default
+  config go through `/v1/chat/completions` as normal.
 - **Non-tool chat with reasoning.** A reasoning-capable model *without* tools goes
   through `/v1/chat/completions`; reasoning survives and round-trips normally
   (surfaced as `reasoning_content` / `thinking_blocks`).
 
-**To avoid it**, keep `reasoning_effort` off any reasoning-capable model that
-serves tool-bearing turns — or keep tool-bearing purposes on a non-reasoning
-model. Reasoning on the non-tool chat path is unaffected.
+**To avoid it**, keep `reasoning_effort` off any OpenAI reasoning-capable model
+that serves tool-bearing turns — or keep tool-bearing purposes on a
+non-OpenAI-reasoning model. Reasoning on the non-tool chat path is unaffected.
 
 ## Namespace and override semantics
 

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1501,6 +1501,52 @@ class ResponsesEndpointRequiredError(Exception):
     so the operator isn't left with a raw 405."""
 
 
+def _requires_responses_bridge(model: str) -> bool:
+    """#3288 follow-up (issue #3288 comment thread, per-PR-coder root-cause):
+    is ``model`` an OpenAI reasoning model that needs the ``/v1/responses``
+    bridge for a ``reasoning_effort + tools`` call?
+
+    The #1678 bridge exists because SOME OpenAI reasoning models reject
+    ``reasoning_effort + tools`` on ``/chat/completions`` and need
+    ``/v1/responses`` instead. It is NOT a universal requirement — e.g.
+    Gemini's ``reasoning_effort`` maps to a native "thinking budget" param
+    (see the #1650 comment above) and does not need (or support well —
+    #1652/②'s reasoning-continuity note) the bridge. Before this fix,
+    ``_routed_to_responses`` had no provider check, so it fired for EVERY
+    ``tools + reasoning_effort`` call, including Gemini's default-config
+    primary reply — silently rewriting ``gemini/...`` to
+    ``responses/gemini/...``, which ``_streaming_capable`` cannot recognize
+    (litellm's model map has no entry for the ``responses/`` marker), so
+    streaming was silently disabled on the default configuration.
+
+    Derives the provider from the resolved MODEL IDENTITY via
+    ``litellm.get_llm_provider``, queried WITHOUT an explicit
+    ``custom_llm_provider`` (``None``) — the SAME transport-independence
+    discipline ``_streaming_capable`` documents: reyn's proxy routing
+    (``proxy_kwargs()``) forces ``custom_llm_provider="openai"`` on the wire
+    for ALL models when an operator proxy is configured, so deriving "is this
+    OpenAI?" from that forced value would make every model look like OpenAI —
+    reproducing the exact bug this function fixes, one layer over. Capability
+    (and provider identity) is a property of the MODEL, not of the transport
+    used to reach it.
+
+    Any lookup failure (unmapped model name, litellm internal error) is
+    caught and treated as "not OpenAI" — conservative in the direction that
+    matters here: it means an unrecognized model is never force-routed
+    through a bridge it may not need, at the cost of a genuinely unmapped
+    OpenAI reasoning model needing an explicit ``openai/responses/...`` model
+    string (already supported — see ``_to_responses_model``'s idempotent
+    explicit-prefix path).
+    """
+    try:
+        import litellm  # noqa: PLC0415
+
+        _, provider, _, _ = litellm.get_llm_provider(model=model, custom_llm_provider=None)
+        return provider == "openai"
+    except Exception:  # noqa: BLE001 — unknown provider → conservative "no bridge"
+        return False
+
+
 def _to_responses_model(model: str) -> str:
     """#1678: rewrite a resolved litellm model string to route through the OpenAI
     Responses API (``/v1/responses``) via the ``responses/`` bridge marker, which
@@ -1725,8 +1771,19 @@ async def recorded_acompletion(
     # parallel recorded_aresponses). An explicit operator prefix is preserved
     # (idempotent). ``_routed_to_responses`` gates the decision-enabling error
     # below so a normal 405 is unaffected.
+    #
+    # #3288 follow-up: this is an OpenAI-specific requirement — gate it on the
+    # resolved model's PROVIDER (``_requires_responses_bridge``), not merely on
+    # the tools+reasoning_effort SHAPE. Without the provider check, this fired
+    # for every reasoning-capable default model class (incl. Gemini, whose
+    # reasoning_effort maps to a native thinking-budget param, not a
+    # /v1/responses requirement), silently rewriting ``gemini/...`` to a
+    # ``responses/`` bridge string that ``_streaming_capable`` cannot
+    # recognize — disabling streaming on the default configuration.
     _routed_to_responses = bool(
-        base_kwargs.get("tools") and base_kwargs.get("reasoning_effort")
+        base_kwargs.get("tools")
+        and base_kwargs.get("reasoning_effort")
+        and _requires_responses_bridge(effective_model)
     )
     if _routed_to_responses:
         effective_model = _to_responses_model(effective_model)
@@ -1904,7 +1961,17 @@ async def recorded_acompletion(
         # (``_streaming_capable``), never a hardcoded provider check.
         # Unknown/uncertain capability → the existing whole-collect call
         # below (conservative fallback, byte-identical to pre-③a behavior).
-        if _streaming_capable(effective_model, has_tools=bool(call_kwargs.get("tools"))):
+        _capable = _streaming_capable(effective_model, has_tools=bool(call_kwargs.get("tools")))
+        # Permanent, one-line-per-call debug signal for the gate DECISION itself
+        # (not just "streamed but the callback never fired" — the #3288 follow-up
+        # gap: the gate silently deciding NOT to stream had no observable trace at
+        # all, which is why the default-config dark-streaming bug needed a live
+        # diagnostic run + code trace to find).
+        logger.debug(
+            "streaming gate: model=%s has_tools=%s capable=%s",
+            effective_model, bool(call_kwargs.get("tools")), _capable,
+        )
+        if _capable:
             return await _stream_and_reconstruct(effective_model, messages, call_kwargs)
         return await litellm.acompletion(model=effective_model, messages=messages, **call_kwargs)
 

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1510,6 +1510,18 @@ def _responses_bridge_providers() -> "frozenset[str]":
     ``.AZURE.value``), not bare string literals — if litellm ever renames a
     provider identity, the enum moves with it instead of silently going
     stale here.
+
+    **This allowlist is PROVISIONAL** (owner direction: minimize
+    provider-dependent code in reyn). litellm's own model info already
+    declares the routing need per-MODEL, not per-provider —
+    ``litellm.get_model_info("o1-pro")["mode"] == "responses"`` — and
+    ``litellm.utils`` exposes a ``supports_reasoning`` capability query
+    alongside the ``supports_native_streaming`` / ``supports_function_calling``
+    ones ``_streaming_capable`` already uses. A follow-up should replace this
+    provider allowlist with that per-model ``mode`` declaration, which would
+    make Azure/OpenRouter case-by-case judgment (and tracking future
+    providers) unnecessary. Until that lands: if an Azure-routed reasoning
+    model 405s unexpectedly, this frozenset is the first place to check.
     """
     import litellm  # noqa: PLC0415
 
@@ -1523,6 +1535,15 @@ def _requires_responses_bridge(model: str) -> bool:
     """#3288 follow-up (issue #3288 comment thread, per-PR-coder root-cause;
     provider-set widened per co-vet finding (b) on PR #3325): does ``model``
     need the ``/v1/responses`` bridge for a ``reasoning_effort + tools`` call?
+
+    **PROVISIONAL — see ``_responses_bridge_providers``'s docstring.** This
+    decision is currently provider-based; a follow-up should switch it to a
+    per-model ``litellm.get_model_info(...)["mode"] == "responses"``
+    declaration instead (litellm already declares this per-model, not merely
+    per-provider), which would need no Azure/OpenRouter case-by-case judgment
+    and no tracking of future providers. Not done in this PR — #3325 fixes a
+    live default-config regression (streaming silently dead) and that fix
+    should not wait on the provider→model-mode replacement.
 
     The #1678 bridge exists because SOME reasoning models reject
     ``reasoning_effort + tools`` on ``/chat/completions`` and need

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1501,12 +1501,30 @@ class ResponsesEndpointRequiredError(Exception):
     so the operator isn't left with a raw 405."""
 
 
-def _requires_responses_bridge(model: str) -> bool:
-    """#3288 follow-up (issue #3288 comment thread, per-PR-coder root-cause):
-    is ``model`` an OpenAI reasoning model that needs the ``/v1/responses``
-    bridge for a ``reasoning_effort + tools`` call?
+def _responses_bridge_providers() -> "frozenset[str]":
+    """The litellm provider identities the #1678 ``/v1/responses`` bridge
+    applies to — see ``_requires_responses_bridge`` for why this is a set,
+    not a single literal.
 
-    The #1678 bridge exists because SOME OpenAI reasoning models reject
+    Enum-referenced (``litellm.LlmProviders.OPENAI.value`` /
+    ``.AZURE.value``), not bare string literals — if litellm ever renames a
+    provider identity, the enum moves with it instead of silently going
+    stale here.
+    """
+    import litellm  # noqa: PLC0415
+
+    return frozenset({
+        litellm.LlmProviders.OPENAI.value,
+        litellm.LlmProviders.AZURE.value,
+    })
+
+
+def _requires_responses_bridge(model: str) -> bool:
+    """#3288 follow-up (issue #3288 comment thread, per-PR-coder root-cause;
+    provider-set widened per co-vet finding (b) on PR #3325): does ``model``
+    need the ``/v1/responses`` bridge for a ``reasoning_effort + tools`` call?
+
+    The #1678 bridge exists because SOME reasoning models reject
     ``reasoning_effort + tools`` on ``/chat/completions`` and need
     ``/v1/responses`` instead. It is NOT a universal requirement — e.g.
     Gemini's ``reasoning_effort`` maps to a native "thinking budget" param
@@ -1518,6 +1536,31 @@ def _requires_responses_bridge(model: str) -> bool:
     ``responses/gemini/...``, which ``_streaming_capable`` cannot recognize
     (litellm's model map has no entry for the ``responses/`` marker), so
     streaming was silently disabled on the default configuration.
+
+    **Provider boundary — why {openai, azure}, and where to look if you hit a
+    405 on an ``azure/o1``-shaped model**: Azure is a first-class reyn
+    provider (``credentials.py``'s ``"azure": "AZURE_API_KEY"``) whose
+    reasoning-model deployments (``azure/o1``, ``azure/o3-mini``, …) are
+    literally OpenAI's reasoning models, hosted by Azure — the SAME
+    ``/chat/completions`` rejection this bridge exists to route around
+    applies there too. Excluding azure would have been a SILENT BEHAVIOR
+    CHANGE for this PR: ``azure/o1`` already resolves through
+    ``_to_responses_model`` (``azure/o1`` → ``azure/responses/o1``), so it was
+    almost certainly bridged before this fix (no provider check existed) —
+    narrowing to ``openai`` alone would un-bridge it and could reintroduce the
+    405 this bridge exists to avoid, for a provider nobody verified doesn't
+    need it. Minimal change = keep Azure's existing (bridged) behavior. If a
+    genuine Azure reasoning-model 405 shows up in the future, this frozenset
+    is the first place to check — either Azure's ``/v1/responses`` support
+    changed, or a model isn't resolving to the ``azure`` provider the way
+    expected (verify with ``litellm.get_llm_provider``, not by inspection).
+
+    **Deliberately excluded: ``openrouter/openai/...``.** ``get_llm_provider``
+    resolves that model string to provider ``"openrouter"``, not
+    ``"openai"`` — correctly: the HTTP call actually lands on OpenRouter's own
+    completions endpoint, not OpenAI's ``/v1/responses``, regardless of the
+    ``openai/`` segment embedded in the OpenRouter model name. Bridging it
+    would target an endpoint OpenRouter doesn't serve.
 
     Derives the provider from the resolved MODEL IDENTITY via
     ``litellm.get_llm_provider``, queried WITHOUT an explicit
@@ -1531,18 +1574,18 @@ def _requires_responses_bridge(model: str) -> bool:
     used to reach it.
 
     Any lookup failure (unmapped model name, litellm internal error) is
-    caught and treated as "not OpenAI" — conservative in the direction that
-    matters here: it means an unrecognized model is never force-routed
-    through a bridge it may not need, at the cost of a genuinely unmapped
-    OpenAI reasoning model needing an explicit ``openai/responses/...`` model
-    string (already supported — see ``_to_responses_model``'s idempotent
-    explicit-prefix path).
+    caught and treated as "does not require the bridge" — conservative in the
+    direction that matters here: it means an unrecognized model is never
+    force-routed through a bridge it may not need, at the cost of a genuinely
+    unmapped reasoning model needing an explicit ``openai/responses/...`` /
+    ``azure/responses/...`` model string (already supported — see
+    ``_to_responses_model``'s idempotent explicit-prefix path).
     """
     try:
         import litellm  # noqa: PLC0415
 
         _, provider, _, _ = litellm.get_llm_provider(model=model, custom_llm_provider=None)
-        return provider == "openai"
+        return provider in _responses_bridge_providers()
     except Exception:  # noqa: BLE001 — unknown provider → conservative "no bridge"
         return False
 
@@ -1772,8 +1815,9 @@ async def recorded_acompletion(
     # (idempotent). ``_routed_to_responses`` gates the decision-enabling error
     # below so a normal 405 is unaffected.
     #
-    # #3288 follow-up: this is an OpenAI-specific requirement — gate it on the
-    # resolved model's PROVIDER (``_requires_responses_bridge``), not merely on
+    # #3288 follow-up: this is a provider-scoped requirement (OpenAI + Azure —
+    # see ``_requires_responses_bridge``'s docstring for the boundary), not a
+    # universal one — gate it on the resolved model's PROVIDER, not merely on
     # the tools+reasoning_effort SHAPE. Without the provider check, this fired
     # for every reasoning-capable default model class (incl. Gemini, whose
     # reasoning_effort maps to a native thinking-budget param, not a

--- a/tests/test_llm_streaming_delta_emission_3288.py
+++ b/tests/test_llm_streaming_delta_emission_3288.py
@@ -251,6 +251,43 @@ def test_silent_zero_delta_stream_logs_once_per_stream(monkeypatch, caplog) -> N
     assert result.usage.prompt_tokens == _USAGE["prompt_tokens"]
 
 
+def test_default_shaped_gemini_call_actually_enters_the_streaming_branch(monkeypatch) -> None:
+    """Tier 3a: #3288 follow-up — the actual goal of the provider-gate fix
+    (`src/reyn/llm/llm.py`'s `_requires_responses_bridge`): a default-shaped
+    call (tools + reasoning_effort attached, Gemini model — exactly what
+    `RouterLoop`'s primary reply sends under reyn.yaml's default model
+    classes) genuinely drives the streaming loop, witnessed via REAL chunk
+    consumption (`chunk_witness`), not merely that `_streaming_capable`
+    returns True in isolation (a terminal-state assertion that would pass
+    even if this call never reached the streaming branch at all — see
+    verification-hazards.md §10). Before the provider gate, this exact call
+    shape got silently rewritten to `responses/gemini-2.5-flash-lite`, which
+    `_streaming_capable` cannot recognize (unmapped in litellm's model map) —
+    reverting `_requires_responses_bridge` out of the `_routed_to_responses`
+    condition reproduces that and this assertion goes RED (chunk_witness stays
+    empty — the whole-collect fallback runs instead)."""
+    chunk_witness: list[int] = []
+    monkeypatch.setattr(litellm, "acompletion", _make_fake_acompletion(chunk_witness))
+
+    deltas: list[str] = []
+    result = asyncio.run(recorded_acompletion(
+        model="gemini/gemini-2.5-flash-lite", messages=[{"role": "user", "content": "hi"}],
+        purpose="main", recorder=None,
+        on_content_delta=deltas.append,
+        # The default-config primary-reply shape: tools attached AND
+        # reasoning_effort set (reyn.yaml's default model classes all carry
+        # reasoning_effort — see builtin_models.py).
+        extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
+    ))
+
+    # Real per-chunk consumption off the async generator — proves the
+    # streaming branch was actually entered and driven, not just that the
+    # capability query returned True.
+    assert chunk_witness == [1, 1, 1]
+    assert deltas == [_CONTENT[: len(_CONTENT) // 2], _CONTENT[len(_CONTENT) // 2 :]]
+    assert result.choices[0].message.content == _CONTENT
+
+
 def test_silent_zero_delta_guard_does_not_fire_when_deltas_do(monkeypatch, caplog) -> None:
     """Tier 1: non-vacuity companion — the SAME guard does NOT fire on a
     normal stream where deltas DO arrive, proving the previous test's log

--- a/tests/test_responses_api_routing_1678.py
+++ b/tests/test_responses_api_routing_1678.py
@@ -240,6 +240,48 @@ def test_openai_reasoning_model_still_routed_proxy_path(monkeypatch) -> None:
     assert captured["model"] == "responses/gpt-5.4"
 
 
+def test_azure_reasoning_model_still_routed(monkeypatch) -> None:
+    """Tier 2: #3288 follow-up REGRESSION gate — co-vet finding (b) on PR
+    #3325: Azure is a first-class reyn provider (`credentials.py`'s
+    `"azure": "AZURE_API_KEY"`) that literally hosts OpenAI's reasoning
+    models, so it hits the SAME `/chat/completions` rejection this bridge
+    exists to route around. `azure/o1` already resolved through
+    `_to_responses_model` before this PR (no provider check existed), so
+    narrowing the gate to `openai` alone would have been a SILENT BEHAVIOR
+    CHANGE for Azure (un-bridging a model nobody verified doesn't need the
+    bridge). Strip `"azure"` out of `_responses_bridge_providers()` and this
+    assertion goes RED (falls back to the unbridged `azure/o1`)."""
+    captured: dict = {}
+    monkeypatch.setattr(litellm, "acompletion", _capturing_acompletion(captured))
+
+    asyncio.run(recorded_acompletion(
+        model="azure/o1", messages=[{"role": "user", "content": "hi"}],
+        purpose="main", recorder=None,
+        extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
+    ))
+    assert captured["model"] == "azure/responses/o1"
+
+
+def test_openrouter_openai_prefixed_model_is_not_routed(monkeypatch) -> None:
+    """Tier 2: #3288 follow-up — documents the deliberate exclusion co-vet
+    finding (b) asked about: an OpenRouter-routed model whose OWN model name
+    happens to embed an `openai/` segment (`openrouter/openai/gpt-5`) is NOT
+    bridged. `litellm.get_llm_provider` resolves this string's PROVIDER as
+    `"openrouter"` (not `"openai"`) — correctly: the HTTP call lands on
+    OpenRouter's own completions endpoint, never OpenAI's `/v1/responses`,
+    regardless of the embedded `openai/` segment naming OpenRouter's upstream
+    model. Bridging it would target an endpoint OpenRouter doesn't serve."""
+    captured: dict = {}
+    monkeypatch.setattr(litellm, "acompletion", _capturing_acompletion(captured))
+
+    asyncio.run(recorded_acompletion(
+        model="openrouter/openai/gpt-5", messages=[{"role": "user", "content": "hi"}],
+        purpose="main", recorder=None,
+        extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
+    ))
+    assert captured["model"] == "openrouter/openai/gpt-5"
+
+
 def test_gemini_405_via_proxy_is_not_wrapped_since_not_routed(monkeypatch) -> None:
     """Tier 2: #3288 follow-up — a Gemini tools+reasoning_effort call that
     405s (e.g. proxy quirk unrelated to /v1/responses) is NOT wrapped in

--- a/tests/test_responses_api_routing_1678.py
+++ b/tests/test_responses_api_routing_1678.py
@@ -8,6 +8,17 @@ parsing unchanged, no parallel chokepoint). When the proxy/endpoint does not ser
 `/v1/responses`, the routed call 405s → reyn raises a decision-enabling error
 (naming BOTH remedies) instead of a raw dead-end; #1676 still captures the raw 405.
 
+#3288 follow-up: the bridge is OpenAI-specific (some OpenAI reasoning models
+reject reasoning_effort+tools on /chat/completions; Gemini's reasoning_effort
+maps to a native thinking-budget param and does not need — or work well with,
+per #1652/② — the bridge). Pre-fix, `_routed_to_responses` had no provider
+check and fired for EVERY tools+reasoning_effort call, including Gemini's
+default-config primary reply, silently rewriting `gemini/...` to a
+`responses/`-prefixed string `_streaming_capable` cannot recognize —
+disabling streaming on the default configuration. The provider-gated tests
+below (`test_gemini_*`, `test_openai_reasoning_model_still_routed_*`) cover
+that fix; see `_requires_responses_bridge` in `src/reyn/llm/llm.py`.
+
 No mocks: real `recorded_acompletion`, a real async fake for `litellm.acompletion`
 (capturing the model / raising a litellm-shaped 405), monkeypatched.
 """
@@ -30,6 +41,7 @@ from reyn.llm.llm import (
 @pytest.fixture(autouse=True)
 def _reset_env(monkeypatch):
     monkeypatch.delenv("OPENAI_API_BASE", raising=False)  # no proxy → model unstripped
+    monkeypatch.delenv("LITELLM_API_BASE", raising=False)  # the var proxy_kwargs() actually reads
     yield
     set_llm_request_event_log(None)
 
@@ -162,3 +174,107 @@ def test_non_routed_405_is_not_wrapped(monkeypatch) -> None:
             purpose="main", recorder=None,
             extra_kwargs={"reasoning_effort": "low"},  # no tools → not routed
         ))
+
+
+# ── #3288 follow-up: the bridge is provider-gated (OpenAI only) ─────────────────
+
+
+def test_gemini_combo_is_not_routed_to_responses(monkeypatch) -> None:
+    """Tier 2: #3288 follow-up — a Gemini tools+reasoning_effort call (the
+    exact default-config primary-reply shape) is NOT routed through the
+    /v1/responses bridge: litellm.acompletion receives the model UNCHANGED.
+    Strip `_requires_responses_bridge` out of the `_routed_to_responses`
+    condition (back to the pre-fix `bool(tools and reasoning_effort)`) and the
+    `responses/` rewrite returns — this assertion goes RED."""
+    captured: dict = {}
+    monkeypatch.setattr(litellm, "acompletion", _capturing_acompletion(captured))
+
+    asyncio.run(recorded_acompletion(
+        model="gemini/gemini-2.5-flash-lite", messages=[{"role": "user", "content": "hi"}],
+        purpose="main", recorder=None,
+        extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
+    ))
+    assert captured["model"] == "gemini/gemini-2.5-flash-lite", (
+        "Gemini must NOT be routed through the OpenAI-specific /v1/responses bridge"
+    )
+
+
+def test_openai_reasoning_model_still_routed_direct_path(monkeypatch) -> None:
+    """Tier 2: #3288 follow-up REGRESSION gate — the direct (non-proxy) path
+    for a genuine OpenAI reasoning model is still bridged after adding the
+    provider gate. This is the risk of the fix: getting the provider check
+    wrong un-bridges a model that genuinely needs /v1/responses, which then
+    405s with no decision-enabling error (see
+    `test_responses_405_raises_decision_enabling_error` above)."""
+    captured: dict = {}
+    monkeypatch.setattr(litellm, "acompletion", _capturing_acompletion(captured))
+
+    asyncio.run(recorded_acompletion(
+        model="openai/gpt-5.4", messages=[{"role": "user", "content": "hi"}],
+        purpose="main", recorder=None,
+        extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
+    ))
+    assert captured["model"] == "openai/responses/gpt-5.4"
+
+
+def test_openai_reasoning_model_still_routed_proxy_path(monkeypatch) -> None:
+    """Tier 2: #3288 follow-up REGRESSION gate — the PROXY path (bare model
+    name post-strip, `custom_llm_provider` forced to "openai" on the wire by
+    `proxy_kwargs()`) is also still bridged. `_to_responses_model` has a
+    different branch for a bare (no-slash) model string than the direct path
+    above, so this is a distinct code path, not a duplicate of the direct-path
+    test. Also proves the provider gate is NOT fooled by (nor dependent on)
+    the proxy's forced `custom_llm_provider` — it derives the provider from
+    the model identity itself (`gpt-5.4` → openai), the same value it would
+    resolve to without a proxy configured at all."""
+    monkeypatch.setenv("LITELLM_API_BASE", "http://proxy.example:4000")
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    captured: dict = {}
+    monkeypatch.setattr(litellm, "acompletion", _capturing_acompletion(captured))
+
+    asyncio.run(recorded_acompletion(
+        model="openai/gpt-5.4", messages=[{"role": "user", "content": "hi"}],
+        purpose="main", recorder=None,
+        extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
+    ))
+    assert captured["model"] == "responses/gpt-5.4"
+
+
+def test_gemini_405_via_proxy_is_not_wrapped_since_not_routed(monkeypatch) -> None:
+    """Tier 2: #3288 follow-up — a Gemini tools+reasoning_effort call that
+    405s (e.g. proxy quirk unrelated to /v1/responses) is NOT wrapped in
+    `ResponsesEndpointRequiredError`, since reyn never routed it through the
+    bridge in the first place (companion to `test_non_routed_405_is_not_wrapped`,
+    scoped to the provider-gate fix)."""
+    async def _raise_405(**_kwargs):
+        raise _FakeProviderError("Method Not Allowed", 405)
+    monkeypatch.setattr(litellm, "acompletion", _raise_405)
+
+    with pytest.raises(_FakeProviderError):
+        asyncio.run(recorded_acompletion(
+            model="gemini/gemini-2.5-flash-lite", messages=[{"role": "user", "content": "hi"}],
+            purpose="main", recorder=None,
+            extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
+        ))
+
+
+def test_openai_reasoning_405_still_raises_decision_enabling_error_after_gate(
+    monkeypatch,
+) -> None:
+    """Tier 2: #3288 follow-up — gate #4: a genuinely-bridged OpenAI call that
+    405s (proxy doesn't serve /v1/responses) still raises the
+    decision-enabling `ResponsesEndpointRequiredError` after the provider gate
+    was added — the 405-wrap path is itself gated on `_routed_to_responses`,
+    so this confirms the provider gate didn't collaterally break it for the
+    provider it must still cover."""
+    async def _raise_405(**_kwargs):
+        raise _FakeProviderError("Method Not Allowed", 405)
+    monkeypatch.setattr(litellm, "acompletion", _raise_405)
+
+    with pytest.raises(ResponsesEndpointRequiredError) as ei:
+        asyncio.run(recorded_acompletion(
+            model="openai/gpt-5.4", messages=[{"role": "user", "content": "hi"}],
+            purpose="main", recorder=None,
+            extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
+        ))
+    assert "/v1/responses" in str(ei.value)


### PR DESCRIPTION
**[per-PR-coder]** — owner-approved fix for the #3288 follow-up diagnosis (root cause posted in the #3288 comment thread).

## Root cause

In `recorded_acompletion` (`src/reyn/llm/llm.py`), `_routed_to_responses = bool(base_kwargs.get("tools") and base_kwargs.get("reasoning_effort"))` had no provider check. reyn's default model classes (`gemini-flash-lite`/`gemini-pro`) carry `reasoning_effort` by default (#1654), and the primary reply always attaches `tools`, so the OpenAI-specific `/v1/responses` bridge (#1678) fired on essentially every default-config turn, rewriting `effective_model` through `_to_responses_model()` — e.g. `gemini-2.5-flash-lite` → `responses/gemini-2.5-flash-lite`. Downstream, `_streaming_capable("responses/gemini-2.5-flash-lite", …)` returns `False` (litellm's model map has no entry for the `responses/` marker), so **token streaming was silently disabled on the default configuration** — the #3288 streaming arc shipped fully tested and inert.

## Fix

Added `_requires_responses_bridge(model)` and threaded it into `_routed_to_responses`:

```python
_routed_to_responses = bool(
    base_kwargs.get("tools")
    and base_kwargs.get("reasoning_effort")
    and _requires_responses_bridge(effective_model)
)
```

**Provider derivation (transport-independent).** `_requires_responses_bridge` queries `litellm.get_llm_provider(model=model, custom_llm_provider=None)` — explicitly `custom_llm_provider=None`, never the value from `proxy_kwargs()`. `proxy_kwargs()` forces `custom_llm_provider="openai"` on the wire for ALL models when an operator proxy is configured; deriving "is this OpenAI?" from that would make every model look like OpenAI and reproduce the same bug one layer over. This mirrors `_streaming_capable`'s own documented precedent (its docstring already calls out this exact trap). `get_llm_provider` is a real litellm capability/identity query, not a string-prefix match — no bespoke prefix matching was needed since litellm already exposes this.

Queried against `effective_model` — the model string as resolved AFTER the proxy prefix-strip but BEFORE the `/v1/responses` bridge mutation, i.e. the actual model identity this call is about to use.

Also added a permanent one-line debug log at the ③a streaming gate (`logger.debug("streaming gate: model=%s has_tools=%s capable=%s", ...)`) — there was previously no observable signal for "the gate ran and decided not to stream", which is why the default-config regression required a live diagnostic run + code trace to find (see the #3288 thread).

## Gates (each strip-falsified, no cross-masking — observed RED confirmed by temporarily reverting the provider condition, running the test, then restoring)

1. **Gemini + reasoning_effort + tools is NOT bridged** (`test_gemini_combo_is_not_routed_to_responses`): `effective_model` stays `gemini/gemini-2.5-flash-lite`. Stripped `_requires_responses_bridge` out of the condition → `responses/` rewrite returns → **observed RED**:
   ```
   assert captured["model"] == "gemini/gemini-2.5-flash-lite"
   AssertionError (captured "responses/gemini-2.5-flash-lite" instead)
   ```
2. **★Regression — OpenAI reasoning models ARE still bridged**, direct path (`test_openai_reasoning_model_still_routed_direct_path`, `openai/gpt-5.4`) and proxy path (`test_openai_reasoning_model_still_routed_proxy_path`, bare `gpt-5.4` + forced `custom_llm_provider=openai` via `LITELLM_API_BASE`) — `_to_responses_model` has distinct branches for each. Stripped the provider check to always-`False` (simulating an overly-broad/wrong gate) → all three OpenAI-side tests (incl. the 405 decision-enabling error test) → **observed RED**:
   ```
   FAILED test_openai_reasoning_model_still_routed_direct_path
   FAILED test_openai_reasoning_model_still_routed_proxy_path
   FAILED test_openai_reasoning_405_still_raises_decision_enabling_error_after_gate
   ```
3. **★The actual goal — streaming now engages on the default configuration** (`test_default_shaped_gemini_call_actually_enters_the_streaming_branch`, `tests/test_llm_streaming_delta_emission_3288.py`): a default-shaped call (Gemini + tools + reasoning_effort) is asserted via the ③b `chunk_witness` real-consumption idiom (real per-chunk consumption off the async generator, not merely `_streaming_capable(...) == True` in isolation — a terminal-state assertion that would pass even if the streaming branch were never reached, per verification-hazards.md §10). Stripped the provider condition → `chunk_witness` stayed empty (whole-collect fallback ran instead) → **observed RED**:
   ```
   assert chunk_witness == [1, 1, 1]
   AssertionError: assert [] == [1, 1, 1]
   ```
4. **The 405 decision-enabling error still fires** for a genuinely-bridged OpenAI call hitting a proxy without `/v1/responses` (`test_openai_reasoning_405_still_raises_decision_enabling_error_after_gate`, plus the pre-existing `test_responses_405_raises_decision_enabling_error`) — covered by the same strip as gate 2 above (this path is gated on `_routed_to_responses`, so a wrong provider gate breaks it too). Added `test_gemini_405_via_proxy_is_not_wrapped_since_not_routed` as the non-vacuity companion (a 405 on a call reyn never routed stays unwrapped).

## Doc drift (same-PR, per CLAUDE.md)

`docs/reference/builtin-models.md` § "Reasoning on tool-bearing turns (Responses-API bridge)" described the bridge as firing for ANY `tools + reasoning_effort` combination and claimed the default Gemini setup was unaffected because it lacked `reasoning_effort` — which was already factually inconsistent with the doc's own #1654 section three paragraphs up (`reasoning_effort: low` IS the Gemini Flash Lite default) and is now also inconsistent with this fix's provider gate. Rewrote the section: the bridge is now explicitly scoped to the OpenAI provider, and the "unaffected paths" explanation is corrected (Gemini is unaffected because it isn't OpenAI, not because `reasoning_effort` is unset). `docs/reference/builtin-models.ja.md` carried the identical stale claim — fixed in the same PR since this PR directly falsifies it (not a blanket en/ja mirror obligation, per CLAUDE.md item 5).

## Non-negotiables run locally (targeted only, foreground)

- `uv run python -m pytest --timeout=120 -q` across all touched files + every test file that exercises `recorded_acompletion`/`_streaming_capable`/`_to_responses_model` (26 files, 126 tests) — all green.
- `ruff check src tests` — all checks passed.
- `python scripts/test_tier_audit.py --strict tests/test_responses_api_routing_1678.py tests/test_llm_streaming_delta_emission_3288.py` — 19/19 OK, 0 Tier-4.
- `python scripts/verify_module_docstrings.py src/reyn/llm/llm.py` — OK.

## Out of scope (per the brief)

Did not change `_streaming_capable` itself, and did not attempt to make streaming work *through* the bridge — whether `stream=True` behaves correctly over `responses/` remains unverified and is explicitly out of scope. No model is left "still bridged but now streaming-capable" by this PR; models that genuinely need the bridge (OpenAI reasoning) simply keep streaming off, exactly as before this PR.

## Test plan

- [x] `uv run python -m pytest --timeout=120 -q tests/test_responses_api_routing_1678.py tests/test_llm_streaming_delta_emission_3288.py` and the broader `recorded_acompletion`-touching set — all green (see above)
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — clean
- [x] `python scripts/verify_module_docstrings.py src/reyn/llm/llm.py` — clean
- [x] (skipped — no UI/manual surface touched by this change; all gates are unit-level against `recorded_acompletion`)