### PR TITLE
fix(tui): un-queued /answer + keyboard route to intervention panel — #3327

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -229,11 +229,35 @@ class TextualChatApp(App):
     EVERY pending intervention has resolved, at which point the whole panel
     collapses (:meth:`_resolve_intervention`). ``Esc``/``Tab`` inside the
     panel (:meth:`on_intervention_panel_dismissed`) return focus to the
-    Composer WITHOUT answering — no intervention's state changes (the #3300
-    sent-queue durably holds any new Composer submit while any stay pending;
-    no black-hole guard is needed here, see the PR body). The Composer itself
-    is now EXCLUSIVELY for new turns — it no longer reads
-    ``pending_intervention_head()`` at all.
+    Composer WITHOUT answering — no intervention's state changes. The
+    Composer itself is EXCLUSIVELY for new turns — it no longer reads
+    ``pending_intervention_head()`` at all — with ONE narrow exception,
+    ``/answer`` (#3327, see :meth:`_submit`).
+
+    **#3327 correction of an earlier, FALSIFIED claim in this docstring**:
+    an older revision asserted that Esc/Tab needed "no black-hole guard…the
+    #3300 sent-queue durably holds any new Composer submit while any stay
+    pending." That is true as far as it goes but misses the actual failure
+    mode: the #3300 sent-queue durably HOLDS a queued submit, but only
+    DISPATCHES it once the blocking turn frees — which for an ``/answer``
+    aimed at THAT SAME pending intervention can never happen (the turn frees
+    only once the intervention resolves, and the intervention resolves only
+    once the queued ``/answer`` dispatches — a chicken-and-egg deadlock, not
+    a "durably held, eventually delivered" queue wait). A keyboard-only user
+    who ``Esc``-dismissed the panel — the escape hatch above, still intended
+    and unchanged — had no way back: ``Tab``/``Shift+Tab`` only cycle
+    Composer↔MenuBar, and the Composer's own ``↓``/``↑`` targeted the menu
+    and sent-queue, never the panel. Two fixes close this, both #3327: (1)
+    :meth:`_submit` now tries ``/answer`` through
+    :meth:`~reyn.interfaces.transport.client_transport.ClientTransport.deliver_pending_answer`
+    — a DIRECT, un-queued delivery — before the queued path, so it can
+    always resolve the intervention it targets regardless of turn state; (2)
+    the Composer's ``↑`` (first line, per :class:`Composer`'s own
+    ``_on_key``) now focuses the pending :class:`InterventionPanel` FIRST,
+    ahead of the sent-queue, whenever one is showing — the SAME idiom that
+    already routes ``↑`` to the sent-queue, extended rather than replaced,
+    and registered in :data:`~reyn.interfaces.inline.textual_chat.chrome.COMPOSER_KEYS`
+    so the Help pane surfaces it.
     """
 
     #: FlowView animation frame rate (Hz) driving the native running-blink gutter.
@@ -856,11 +880,16 @@ class TextualChatApp(App):
         self, event: "InterventionPanel.Dismissed"
     ) -> None:
         """Esc/Tab inside the panel: return focus to the Composer WITHOUT
-        answering — the escape hatch of the focus lifecycle. Every pending
-        intervention stays exactly as it was (the panel stays open); a new
-        Composer submit durably queues on the inbox rather than black-holing
-        (#3300's sent-queue — see the PR body for why #3299 needs no guard of
-        its own here)."""
+        answering — the escape hatch of the focus lifecycle, unchanged by
+        #3327. Every pending intervention stays exactly as it was (the panel
+        stays open); a new Composer submit durably queues on the inbox
+        rather than black-holing (#3300's sent-queue). #3327 fixed the
+        REACHABILITY gap this escape hatch used to leave behind: a
+        keyboard-only user now has a way back to the panel (the Composer's
+        ``↑``, see :class:`Composer`'s ``_on_key``) and ``/answer`` no longer
+        deadlocks behind the sent-queue (see :meth:`_submit`) — so dismissing
+        here is a real, recoverable "focus elsewhere for now", not a
+        one-way trip."""
         self.query_one(Composer).focus()
 
     def _ingest_frame(self, msg: "OutboxMessage") -> None:
@@ -1598,27 +1627,39 @@ class TextualChatApp(App):
         await self._submit(text)
 
     async def _submit(self, text: str) -> None:
-        """Route one submitted line through the transport send seam as an
-        ordinary NEW turn.
+        """Route one submitted line through the transport send seam.
 
         #3299 P1: the Composer is now EXCLUSIVELY for new turns — it no longer
         reads ``pending_intervention_head()`` at all. Answering a pending
-        intervention (closed-set select or free-text) happens ONLY through the
+        intervention (closed-set select or free-text) happens through the
         :class:`~reyn.interfaces.inline.textual_chat.intervention_panel.InterventionPanel`
         (:meth:`on_intervention_panel_choice_selected` /
-        :meth:`on_intervention_panel_text_submitted`), never here. A Composer
-        submit that lands while an intervention is pending is NOT black-holed:
-        the backend turn stays busy awaiting the intervention, so
-        ``submit_user_text`` durably queues the line on the inbox — visible in
-        the sent-queue region (#3300 P2b, this module) and cancelable there
-        (#3300 Y-client, ``↑`` from the composer to focus it, ``Enter`` on a
-        highlighted row to cancel) — rather than losing it. This delegation
-        was verified live (turn-owner-task /
-        inbox-durability trace) by the architect design pass for #3299, so P1
-        needs no hint/block guard of its own. Errors are contained and
-        surfaced as an error frame the pump renders — a silent input drop is
-        the worst failure for a chat box."""
+        :meth:`on_intervention_panel_text_submitted`) — its own, never-queued
+        transport funnel — for anyone who can reach the panel, plus ONE
+        Composer-typed exception: ``/answer`` (#3327). ``/answer`` acts on an
+        EXISTING pending intervention, not a new turn, so it is tried FIRST
+        through :meth:`~reyn.interfaces.transport.client_transport.ClientTransport.deliver_pending_answer`
+        — a direct, un-queued delivery — before falling through to the
+        ordinary new-turn path below. This is load-bearing, not cosmetic:
+        #3327 found that a Composer submit landing while a turn is blocked on
+        an intervention is durably queued (the #3300 sent-queue) but the
+        queue only DRAINS once that SAME turn frees — which requires that
+        SAME intervention to resolve. A queued ``/answer`` therefore chases
+        its own precondition and can never fire; a keyboard-only user who
+        ``Esc``-dismissed the panel (#3299 P1's documented escape hatch, which
+        returns focus WITHOUT answering) had no way back at all before this
+        fix. Every OTHER submission (a fresh turn, or ``/answer`` typed with
+        nothing pending) is UNCHANGED: ``deliver_pending_answer`` returns
+        ``False`` and ``submit_user_text`` durably queues the line on the
+        inbox — visible in the sent-queue region (#3300 P2b, this module) and
+        cancelable there (#3300 Y-client, ``↑`` from the composer to focus
+        it when nothing is pending, ``Enter`` on a highlighted row to
+        cancel) — rather than losing it. Errors are contained and surfaced as
+        an error frame the pump renders — a silent input drop is the worst
+        failure for a chat box."""
         try:
+            if await self._transport.deliver_pending_answer(text):
+                return
             await self._transport.submit_user_text(text)
         except Exception as exc:
             logger.exception("textual chat: submit failed")

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -56,6 +56,7 @@ from textual.widgets import (
     TextArea,
 )
 
+from .intervention_panel import InterventionPanel
 from .sent_queue import SentQueue
 
 if TYPE_CHECKING:
@@ -110,16 +111,28 @@ class Composer(TextArea):
                     menubar.first().focus()
                     return
         if event.key == "up":
-            # ↑ on the composer's FIRST line hands focus UP into the
-            # sent-queue region (#3300 Y-client) when it holds at least one
-            # undispatched item — the mirror image of the ↓ rule above (the
-            # region sits ABOVE the composer: conversation / intervention
-            # panel / sent-queue / input). On any later line, or with an
-            # empty/absent sent-queue, ↑ moves the cursor normally (falls
-            # through to the base TextArea) — never steals focus toward a
-            # region with nothing to act on.
+            # ↑ on the composer's FIRST line hands focus UP into whichever
+            # region above the composer currently has something to act on —
+            # the mirror image of the ↓ rule above (the region sits ABOVE the
+            # composer: conversation / intervention panel / sent-queue /
+            # input). #3327: a pending intervention takes PRIORITY over the
+            # sent-queue (answering it is the more urgent action, and it sits
+            # higher in the stack) — this is also the keyboard route BACK
+            # into the panel after Esc/Tab dismissed it without answering
+            # (InterventionPanel.action_dismiss_panel), which before #3327
+            # had no way back at all. #3300 Y-client's sent-queue-focus rule
+            # is otherwise unchanged: on any later line, or with nothing
+            # pending/queued, ↑ moves the cursor normally (falls through to
+            # the base TextArea) — never steals focus toward a region with
+            # nothing to act on.
             row, _ = self.cursor_location
             if row <= 0:
+                iv_panel = self.app.query(InterventionPanel)
+                if iv_panel and iv_panel.first().has_pending():
+                    event.stop()
+                    event.prevent_default()
+                    iv_panel.first().focus_pending()
+                    return
                 sent_queue = self.app.query(SentQueue)
                 if sent_queue and sent_queue.first().has_items():
                     event.stop()
@@ -183,7 +196,10 @@ COMPOSER_KEYS: "list[tuple[str, str]]" = [
     ("enter", "send"),
     ("shift+enter", "newline"),
     ("↓", "focus menu"),
-    ("↑", "focus sent queue"),
+    # #3327: ↑ now targets whichever of the two regions above the composer
+    # actually has something to act on, pending intervention first — see
+    # ``Composer._on_key``'s "up" branch for the exact priority/fallback.
+    ("↑", "focus pending intervention (else sent queue)"),
 ]
 
 #: The menu row's navigation keys (imperative ``MenuBar._on_key`` overrides).

--- a/src/reyn/interfaces/inline/textual_chat/intervention_panel.py
+++ b/src/reyn/interfaces/inline/textual_chat/intervention_panel.py
@@ -58,7 +58,15 @@ uniform loss of a redundant alias, not a functional regression, since
 ``Esc``/``Tab`` (unchanged from P1/P2): return focus to the Composer WITHOUT
 answering. Declared as widget-level (non-priority) ``BINDINGS`` so Textual's
 ordinary focused-widget-outward resolution finds them on this ancestor before
-``Screen``'s default ``tab``→``focus_next``.
+``Screen``'s default ``tab``→``focus_next``. #3327 gave this escape hatch a
+way BACK: the Composer's own ``↑`` (see
+:class:`~reyn.interfaces.inline.textual_chat.chrome.Composer`'s ``_on_key``)
+focuses this panel (:meth:`focus_pending`) FIRST, ahead of the sent-queue,
+whenever :meth:`has_pending` is true — before #3327, ``Esc``/``Tab`` here was
+a ONE-WAY trip for a keyboard-only user (no binding anywhere retargeted focus
+onto this panel, and the documented ``/answer`` fallback was itself queued
+behind the very intervention it targeted, a structural deadlock — see
+``app.py``'s module docstring and :meth:`~reyn.interfaces.inline.textual_chat.app.TextualChatApp._submit`).
 
 Selecting an option / submitting text posts a message
 (:class:`InterventionPanel.ChoiceSelected` / :class:`InterventionPanel.TextSubmitted`),
@@ -383,6 +391,46 @@ class InterventionPanel(Vertical):
         inputs = list(pane.query(Input))
         if inputs:
             self.call_after_refresh(inputs[0].focus)
+
+    def has_pending(self) -> bool:
+        """Whether at least one tab is still UNANSWERED (#3327) — the
+        Composer's ``↑`` keyboard-reachability route reads this to decide
+        whether ``↑`` should re-focus this panel (ahead of the sent-queue)
+        instead of moving the cursor / falling through to the sent-queue's
+        own ``↑`` handling. Mirrors :attr:`display` (the panel is shown iff
+        something is pending, and :meth:`collapse_all` clears both together)
+        but reads the public tab-tracking surface directly rather than a
+        CSS-facing attribute."""
+        return bool(self._pane_ids)
+
+    def focus_pending(self) -> None:
+        """Re-focus the ACTIVE tab's form — the keyboard route BACK into
+        this panel (#3327) after ``Esc``/``Tab`` returned focus to the
+        Composer (:meth:`action_dismiss_panel`) without answering. Mirrors
+        :meth:`on_tabbed_content_tab_activated`'s own focus logic exactly,
+        since that only fires on an actual tab-activated Textual message —
+        never on a bare "please re-focus what's already active" request like
+        this one. An already-answered active tab (nothing left to focus in
+        it) falls back to the ``Tabs`` bar itself, still inside this panel
+        and Left/Right-navigable to a still-pending sibling tab."""
+        tabs = self.query_one(TabbedContent)
+        active = tabs.active
+        if not active:
+            return
+        try:
+            pane = tabs.get_pane(active)
+        except Exception:
+            return
+        if pane.id in self._answered:
+            tabs.query_one(Tabs).focus()
+            return
+        radios = list(pane.query(RadioSet))
+        if radios:
+            radios[0].focus()
+            return
+        inputs = list(pane.query(Input))
+        if inputs:
+            inputs[0].focus()
 
     def action_dismiss_panel(self) -> None:
         self.post_message(self.Dismissed())

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -136,12 +136,25 @@ class ClientTransport(ABC):
         NOT abstract (mirrors :meth:`cancel_queued`): added after several
         narrow-purpose ``ClientTransport`` stubs already existed across the
         test suite; the default no-op preserves their behavior unchanged.
-        ``InProcessTransport`` overrides it with the real bypass. The AG-UI
-        wire transport does NOT (yet) — it tracks only a SINGLE pending
-        intervention id client-side (see its module docstring) with no
-        server op to resolve an ``/answer`` id-prefix remotely; closing that
-        gap needs a new wire message and is out of #3327's scope (the issue's
-        repro, and this fix, are confined to the in-process path).
+        ``InProcessTransport`` overrides it with the real bypass.
+
+        ``AgUiTransport`` deliberately does NOT override this — not a gap,
+        verified (#3327 co-vet): the REMOTE answer path was never
+        queue-gated to begin with. The plain ``--connect`` client
+        (``stream_client.route_input_line``) already routes a bare (non-``/``)
+        line straight to ``answer_intervention_text`` — un-queued — whenever
+        ``pending_intervention_head()`` is set, no ``/answer`` needed; the
+        AG-UI web surface has its own direct ``TOOL_CALL_RESULT`` POST
+        (``agui/endpoint.py``'s ``_handle_answer`` → ``answer_intervention_by_id``).
+        The #3327 deadlock is a Textual-chat-ONLY defect: #3299 P2
+        deliberately removed the equivalent bare-text-answers-the-head
+        branch from the Composer (the ``pending_intervention_head()`` read
+        this class's own docstring above still mentions) as the
+        no-double-input fix for that arc — leaving the Composer, alone among
+        reyn's clients, with no un-queued answer path until THIS method
+        added one back (scoped to ``/answer``, not bare text, to keep
+        #3300's queue-everything invariant otherwise intact). AG-UI needs no
+        parallel bypass because its answer path was never removed.
         """
         return False
 

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -117,6 +117,34 @@ class ClientTransport(ABC):
     async def cancel_inflight(self) -> None:
         """Cooperatively cancel the in-flight turn (ctrl-c seam)."""
 
+    async def deliver_pending_answer(self, text: str) -> bool:
+        """Attempt DIRECT, un-queued delivery of ``text`` as an ``/answer``
+        command for a pending intervention (#3327). Returns ``True`` iff
+        delivered THIS way — the caller must NOT also call
+        :meth:`submit_user_text` for the same ``text``. Returns ``False``
+        when ``text`` is not an ``/answer`` command, or nothing is pending —
+        the caller then falls through to the ordinary queued
+        :meth:`submit_user_text` path, UNCHANGED (#3300's sent-queue keeps
+        gating every other submission).
+
+        Answering a pending intervention acts on EXISTING state, not a new
+        turn — queuing it behind :meth:`submit_user_text` can deadlock: with
+        a turn blocked awaiting that SAME intervention, the inbox item can
+        only be dequeued once the intervention resolves (chicken-and-egg,
+        #3327's keyboard-only-user repro).
+
+        NOT abstract (mirrors :meth:`cancel_queued`): added after several
+        narrow-purpose ``ClientTransport`` stubs already existed across the
+        test suite; the default no-op preserves their behavior unchanged.
+        ``InProcessTransport`` overrides it with the real bypass. The AG-UI
+        wire transport does NOT (yet) — it tracks only a SINGLE pending
+        intervention id client-side (see its module docstring) with no
+        server op to resolve an ``/answer`` id-prefix remotely; closing that
+        gap needs a new wire message and is out of #3327's scope (the issue's
+        repro, and this fix, are confined to the in-process path).
+        """
+        return False
+
     async def cancel_queued(self, msg_id: str) -> bool:
         """Cancel-by-id an UNDISPATCHED (queued) user message (#3300 P3
         Y-server) — a DIFFERENT intent from :meth:`cancel_inflight` (which

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -149,6 +149,14 @@ class InProcessTransport(ClientTransport):
             return ""
         return await s.submit_user_text(text)
 
+    async def deliver_pending_answer(self, text: str) -> bool:
+        # #3327: real override — see ``Session.maybe_deliver_answer_command``
+        # for the deadlock this un-queued delivery closes.
+        s = self._attached()
+        if s is None:
+            return False
+        return await s.maybe_deliver_answer_command(text)
+
     async def answer_intervention_text(
         self, text: str, *, intervention_id: "str | None" = None
     ) -> bool:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2931,6 +2931,51 @@ class Session:
         # `own_submissions` set).
         return msg_id
 
+    async def maybe_deliver_answer_command(self, text: str) -> bool:
+        """#3327: run an ``/answer`` command IMMEDIATELY, bypassing the inbox,
+        when there is a pending intervention to answer.
+
+        ``/answer`` is not a new turn — it acts on EXISTING pending state — so
+        it must not ride the same inbox queue a fresh turn does. When a turn is
+        blocked awaiting an intervention (the router's ``ask_user``/permission
+        await), that turn is the SOLE consumer of the inbox
+        (:meth:`run_one_iteration` does not call :meth:`_drain_to_wake` again
+        until the current turn settles), so a queued ``/answer`` can only be
+        dequeued once that SAME intervention resolves — a chicken-and-egg
+        deadlock a keyboard-only Textual-chat user could not escape (#3327:
+        ``Esc`` dismisses the intervention panel without answering, per #3299
+        P1's documented escape hatch, and the ``/answer`` fallback then hung
+        forever behind its own precondition).
+
+        This reuses the SAME unqueued, direct-delivery funnel
+        (:meth:`_maybe_handle_slash` → :meth:`_deliver_answer_to` /
+        :meth:`answer_intervention_by_id`) the
+        :class:`~reyn.interfaces.inline.textual_chat.intervention_panel.InterventionPanel`
+        already uses for its own (never-queued) answer delivery — concurrency
+        with an in-flight turn task is therefore already proven safe, not new.
+
+        Returns ``False`` — do nothing — unless ``text`` names the ``answer``
+        slash command AND at least one intervention is currently pending;
+        the caller then falls through to the ordinary ``submit_user_text``
+        queued path, UNCHANGED. This keeps the bypass narrow (#3300's
+        sent-queue keeps gating every OTHER Composer submission, including an
+        ``/answer`` typed while nothing is pending, or an unrelated slash
+        command / new turn typed during a busy turn — the regression risk of
+        widening this bypass beyond ``/answer`` specifically)."""
+        first_line = text.partition("\n")[0]
+        if not first_line.startswith("/"):
+            return False
+        body = first_line[1:].lstrip()
+        if not body:
+            return False
+        cmd = body.split(maxsplit=1)[0]
+        if cmd != "answer":
+            return False
+        if not self._interventions.list_active():
+            return False
+        await self._maybe_handle_slash(text)
+        return True
+
     async def submit_agent_request(
         self, *, from_agent: str, request: str, depth: int, chain_id: str,
         from_sid: "str | None" = None,

--- a/tests/test_3300_y_client_cancel.py
+++ b/tests/test_3300_y_client_cancel.py
@@ -514,8 +514,11 @@ def test_help_pane_lists_composer_up_arrow_and_sentqueue_keys() -> None:
     (``SENTQUEUE_KEYS``), not go undocumented. Pure-function pane formatter —
     no widget mount needed."""
     lines = help_pane_lines()
-    assert any("focus sent queue" in line for line in lines), (
-        "composer's new '↑ -> focus sent queue' binding is missing from "
+    # #3327: ↑ now targets the pending intervention panel FIRST, the
+    # sent-queue as its fallback — the description text was updated to say
+    # so; "sent queue" itself stays a substring of the new text either way.
+    assert any("sent queue" in line for line in lines), (
+        "composer's ↑ -> sent-queue fallback binding is missing from "
         "COMPOSER_KEYS / the Help pane"
     )
     assert any("cancel" in line.lower() for line in lines), (

--- a/tests/test_3327_answer_bypasses_sentqueue.py
+++ b/tests/test_3327_answer_bypasses_sentqueue.py
@@ -286,6 +286,69 @@ async def test_ordinary_submission_still_queues_during_busy_turn(tmp_path, monke
 
 
 @pytest.mark.asyncio
+async def test_unrelated_slash_command_during_pending_intervention_is_not_claimed(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: ★co-vet finding (#3330 review) — GATE 3's narrowness has TWO
+    independent conditions (``cmd == "answer"`` AND something pending), and
+    the FIRST test above only witnessed the second (plain, non-slash text).
+    This is the missing witness for the ``cmd == "answer"`` check itself: an
+    UNRELATED slash command (``/model …``) typed while a turn is blocked on
+    a pending intervention must ALSO fall through to the ordinary queued
+    path — ``deliver_pending_answer`` must not widen to "any slash command
+    is un-queued while something is pending", which would silently erode
+    #3300's "every Composer submission rides the queue" invariant for
+    every OTHER slash command, not just ``/answer``.
+
+    NON-VACUITY (strip-falsify, verified locally): commenting out the
+    ``if cmd != "answer": return False`` guard in
+    ``Session.maybe_deliver_answer_command`` flips this assertion to
+    ``True`` — RED — confirming this test actually exercises that specific
+    line (not just the already-witnessed ``list_active()`` guard)."""
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    out = proj / "out.txt"
+
+    session = _make_session(
+        proj, wal=tmp_path / "state.wal", snap=tmp_path / "snap.json",
+    )
+    run_task = asyncio.create_task(session.run())
+    try:
+        await _start_blocked_write_turn(session, monkeypatch, out=out)
+        transport = _transport_for(session)
+
+        delivered = await transport.deliver_pending_answer("/model gpt-fake")
+        assert delivered is False, (
+            "an UNRELATED slash command (/model) must NOT be claimed by "
+            "deliver_pending_answer while an intervention is pending — the "
+            "bypass must stay narrow to /answer specifically, not widen to "
+            "'any slash command bypasses the queue while something is "
+            "pending'"
+        )
+
+        msg_id = await transport.submit_user_text("/model gpt-fake")
+        assert msg_id, "submit_user_text did not accept the slash command"
+        queued_texts = [
+            item.get("text") for item in session.queued_user_messages()
+        ]
+        assert "/model gpt-fake" in queued_texts, (
+            "the unrelated slash command was not queued — an unintended "
+            "widening of the bypass would let it dispatch early instead"
+        )
+        assert session.interventions.head() is not None, (
+            "an unrelated slash command must never resolve the pending "
+            "intervention"
+        )
+    finally:
+        await session.shutdown()
+        try:
+            await asyncio.wait_for(run_task, timeout=2.0)
+        except asyncio.TimeoutError:
+            run_task.cancel()
+            await asyncio.gather(run_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
 async def test_answer_command_with_nothing_pending_is_not_claimed(tmp_path):
     """Tier 2: GATE 3 (mirror) — ``/answer`` typed with NOTHING pending must
     also fall through to the ordinary queued path (``deliver_pending_answer``

--- a/tests/test_3327_answer_bypasses_sentqueue.py
+++ b/tests/test_3327_answer_bypasses_sentqueue.py
@@ -1,0 +1,314 @@
+"""#3327 — ``/answer`` must dispatch IMMEDIATELY, bypassing the #3300 sent-queue,
+when it targets a pending intervention.
+
+Root cause: the #3300 sent-queue durably HOLDS a queued Composer submit, but
+only DISPATCHES it once the blocking turn frees — and for an ``/answer``
+aimed at the SAME pending intervention, the turn only frees once THAT
+intervention resolves. A queued ``/answer`` therefore chases its own
+precondition and can never fire (chicken-and-egg). Combined with #3299 P1's
+``Esc`` returning focus WITHOUT answering (the intended escape hatch), a
+keyboard-only Textual-chat user who dismissed the panel had no way back at
+all — the deadlock issue #3327 reports.
+
+The fix: ``Session.maybe_deliver_answer_command`` (called from
+``InProcessTransport.deliver_pending_answer``, called from
+``TextualChatApp._submit`` BEFORE ``submit_user_text``) delivers an
+``/answer`` command through the SAME un-queued, direct funnel
+(``_maybe_handle_slash`` → ``_deliver_answer_to``) the
+``InterventionPanel``'s own (never-queued) answer delivery already uses.
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only — a
+real ``Session`` + real ``PermissionResolver`` + the real intervention
+machinery + the real ``InProcessTransport``, driven exactly as
+``TextualChatApp._submit`` drives it. The ONLY faked boundary is the LLM call
+(the established idiom, see ``test_cui_permission_answer_resumes_2690.py``).
+No MagicMock / AsyncMock / patch.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.transport.in_process import InProcessTransport
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session
+from reyn.security.permissions.permissions import PermissionResolver
+from tests._support.agent_session import make_session
+
+_USAGE = TokenUsage(prompt_tokens=5, completion_tokens=3)
+
+
+def _transport_for(session) -> InProcessTransport:
+    """The local ``ClientTransport`` over a single-session registry — the SAME
+    seam ``TextualChatApp._submit`` sends every Composer submission through."""
+    return InProcessTransport(
+        SimpleNamespace(attached_session=lambda: session),
+        intervention_channel=DEFAULT_CHAT_CHANNEL_ID,
+    )
+
+
+def _tool_call_result(name: str, args_json: str) -> LLMToolCallResult:
+    return LLMToolCallResult(
+        content=None,
+        tool_calls=[{
+            "id": "tc_1",
+            "type": "function",
+            "function": {"name": name, "arguments": args_json},
+        }],
+        finish_reason="tool_calls",
+        usage=_USAGE,
+    )
+
+
+def _text_result() -> LLMToolCallResult:
+    return LLMToolCallResult(
+        content="done", tool_calls=[], finish_reason="stop", usage=_USAGE,
+    )
+
+
+def _sequenced_llm_stub(results: "list[LLMToolCallResult]"):
+    """Real async callable mimicking ``call_llm_tools`` — the only faked
+    boundary permitted by policy."""
+    state = {"n": 0}
+
+    async def _stub(**_kwargs) -> LLMToolCallResult:
+        i = state["n"]
+        state["n"] += 1
+        return results[min(i, len(results) - 1)]
+
+    return _stub
+
+
+async def _poll(pred, *, attempts: int = 150, delay: float = 0.02) -> bool:
+    """Bounded poll — a hang exhausts the budget and returns False (RED)."""
+    for _ in range(attempts):
+        if pred():
+            return True
+        await asyncio.sleep(delay)
+    return False
+
+
+def _make_session(project_root: Path, *, wal: Path, snap: Path) -> Session:
+    perm = PermissionResolver({}, project_root=project_root, interactive=True)
+    session = make_session(
+        agent_name="test-agent",
+        permission_resolver=perm,
+        state_log=StateLog(wal),
+        snapshot_path=snap,
+        workspace_base_dir=project_root,
+    )
+    session.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
+    return session
+
+
+async def _start_blocked_write_turn(
+    session: Session, monkeypatch, *, out: Path,
+) -> None:
+    """Drives the router to the out-of-zone write permission prompt and
+    leaves the turn suspended awaiting the answer — the exact precondition
+    #3327's deadlock needs (a turn blocked on the SAME intervention an
+    ``/answer`` would target)."""
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools",
+        _sequenced_llm_stub([
+            _tool_call_result(
+                "file__write",
+                f'{{"path": "{out}", "content": "written ok"}}',
+            ),
+            _text_result(),
+        ]),
+    )
+    await session.submit_user_text("write the file")
+    assert await _poll(lambda: session.interventions.head() is not None), (
+        "the file-write approval prompt never appeared"
+    )
+
+
+@pytest.mark.asyncio
+async def test_answer_command_dispatches_immediately_while_turn_blocked(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: GATE 1 + GATE 2 — an ``/answer <id-prefix> y`` submitted through
+    the SAME seam ``TextualChatApp._submit`` uses
+    (``transport.deliver_pending_answer`` tried FIRST, THEN
+    ``submit_user_text``) resolves the blocked turn's intervention promptly —
+    it is not stuck behind the #3300 sent-queue, which could never drain it
+    (the turn only frees once this SAME intervention resolves).
+
+    RED before the fix: ``deliver_pending_answer`` did not exist (or
+    ``_submit`` never called it) — every ``/answer`` line at this seam went
+    straight to ``submit_user_text`` and sat in the inbox until the poll
+    budget exhausted, since the turn stayed blocked forever. Verified by the
+    companion strip test below AND by the negative control in this same test
+    (the OLD ``submit_user_text``-only path, exercised on a SEPARATE fresh
+    session, is shown to still hang)."""
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    out = proj / "out.txt"
+
+    session = _make_session(
+        proj, wal=tmp_path / "state.wal", snap=tmp_path / "snap.json",
+    )
+    run_task = asyncio.create_task(session.run())
+    try:
+        await _start_blocked_write_turn(session, monkeypatch, out=out)
+        head = session.interventions.head()
+        assert head.kind == "permission.file.write"
+        prefix = head.id[:8]
+
+        transport = _transport_for(session)
+        # THE PRODUCTION CALLSITE under test: TextualChatApp._submit tries
+        # deliver_pending_answer() BEFORE submit_user_text().
+        delivered = await transport.deliver_pending_answer(f"/answer {prefix} y")
+        assert delivered is True, (
+            "deliver_pending_answer did not report the /answer as handled"
+        )
+
+        assert await _poll(lambda: out.exists()), (
+            "the write never completed after /answer — the direct-delivery "
+            "bypass did not actually resolve the blocked intervention "
+            "(#3327 deadlock)"
+        )
+        assert session.interventions.head() is None
+    finally:
+        await session.shutdown()
+        try:
+            await asyncio.wait_for(run_task, timeout=2.0)
+        except asyncio.TimeoutError:
+            run_task.cancel()
+            await asyncio.gather(run_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_strip_falsify_queued_answer_path_deadlocks(tmp_path, monkeypatch):
+    """Tier 2: ★non-vacuity / strip-falsify for gate 1+2 — proves the deadlock
+    this PR fixes is REAL: with ``/answer`` submitted the OLD way (straight
+    to ``submit_user_text``, the sent-queue's normal path, never through
+    ``deliver_pending_answer``), the intervention NEVER resolves within a
+    generous poll budget, because the turn that would dequeue it is the SAME
+    turn blocked awaiting it.
+
+    This demonstrates the OLD seam (``submit_user_text`` alone) still
+    deadlocks on the current tree exactly as before #3327 — the fix only
+    changed WHICH seam ``TextualChatApp._submit`` calls FIRST
+    (``deliver_pending_answer``, proven above), it did not change
+    ``submit_user_text``'s own queueing mechanics. This is the RED the
+    companion positive test above is GREEN against."""
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    out = proj / "out.txt"
+
+    session = _make_session(
+        proj, wal=tmp_path / "state.wal", snap=tmp_path / "snap.json",
+    )
+    run_task = asyncio.create_task(session.run())
+    try:
+        await _start_blocked_write_turn(session, monkeypatch, out=out)
+        head = session.interventions.head()
+        prefix = head.id[:8]
+
+        # The OLD (pre-#3327) seam: straight to submit_user_text, exactly
+        # what a queued Composer submission does — no direct-delivery bypass.
+        await session.submit_user_text(f"/answer {prefix} y")
+
+        resolved = await _poll(lambda: out.exists(), attempts=25, delay=0.02)
+        assert resolved is False, (
+            "the queued-only /answer path resolved the intervention — the "
+            "deadlock this test documents did not reproduce, so the "
+            "companion positive test is not proving what it claims to prove"
+        )
+        assert session.interventions.head() is not None, (
+            "the intervention resolved some other way — the queued /answer "
+            "must remain stuck for this to be a genuine deadlock witness"
+        )
+    finally:
+        await session.shutdown()
+        try:
+            await asyncio.wait_for(run_task, timeout=2.0)
+        except asyncio.TimeoutError:
+            run_task.cancel()
+            await asyncio.gather(run_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_ordinary_submission_still_queues_during_busy_turn(tmp_path, monkeypatch):
+    """Tier 2: GATE 3 — the bypass is narrow. An ORDINARY (non-``/answer``)
+    Composer submission made while a turn is blocked on a pending
+    intervention must still go through ``deliver_pending_answer`` → False →
+    ``submit_user_text`` → the inbox queue, exactly per #3300 — never
+    resolve the intervention, never dispatch early."""
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    out = proj / "out.txt"
+
+    session = _make_session(
+        proj, wal=tmp_path / "state.wal", snap=tmp_path / "snap.json",
+    )
+    run_task = asyncio.create_task(session.run())
+    try:
+        await _start_blocked_write_turn(session, monkeypatch, out=out)
+        transport = _transport_for(session)
+
+        delivered = await transport.deliver_pending_answer("just a normal message")
+        assert delivered is False, (
+            "an ordinary (non-/answer) submission must NOT be claimed by "
+            "deliver_pending_answer — the bypass must stay narrow to /answer"
+        )
+
+        msg_id = await transport.submit_user_text("just a normal message")
+        assert msg_id, "submit_user_text did not accept the ordinary submission"
+
+        # It must sit UNDISPATCHED in the inbox (#3300's sent-queue), not
+        # resolve anything or vanish.
+        queued_texts = [
+            item.get("text") for item in session.queued_user_messages()
+        ]
+        assert "just a normal message" in queued_texts, (
+            "the ordinary submission was not queued — #3300's sent-queue "
+            "contract regressed"
+        )
+        assert session.interventions.head() is not None, (
+            "an ordinary submission must never resolve the pending "
+            "intervention"
+        )
+    finally:
+        await session.shutdown()
+        try:
+            await asyncio.wait_for(run_task, timeout=2.0)
+        except asyncio.TimeoutError:
+            run_task.cancel()
+            await asyncio.gather(run_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_answer_command_with_nothing_pending_is_not_claimed(tmp_path):
+    """Tier 2: GATE 3 (mirror) — ``/answer`` typed with NOTHING pending must
+    also fall through to the ordinary queued path (``deliver_pending_answer``
+    returns False) rather than being silently swallowed."""
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    session = _make_session(
+        proj, wal=tmp_path / "state.wal", snap=tmp_path / "snap.json",
+    )
+    run_task = asyncio.create_task(session.run())
+    try:
+        transport = _transport_for(session)
+        delivered = await transport.deliver_pending_answer("/answer abc123 y")
+        assert delivered is False, (
+            "an /answer with nothing pending must not be claimed by the "
+            "bypass — it should fall through to the ordinary queued path "
+            "(where the slash handler reports its own 'nothing pending' "
+            "error once dispatched)"
+        )
+    finally:
+        await session.shutdown()
+        try:
+            await asyncio.wait_for(run_task, timeout=2.0)
+        except asyncio.TimeoutError:
+            run_task.cancel()
+            await asyncio.gather(run_task, return_exceptions=True)

--- a/tests/test_3327_keyboard_reachability_to_panel.py
+++ b/tests/test_3327_keyboard_reachability_to_panel.py
@@ -1,0 +1,260 @@
+"""#3327 — a keyboard-only user must have a way BACK to the pending
+intervention panel after ``Esc``/``Tab`` dismisses it without answering.
+
+Before this fix: ``Esc``/``Tab`` inside the panel (#3299 P1's documented,
+INTENDED escape hatch) return focus to the Composer, but nothing anywhere
+retargets focus back onto the panel — ``Tab``/``Shift+Tab`` only cycle
+Composer↔MenuBar, and the Composer's own ``↓``/``↑`` targeted the menu and
+sent-queue, never the panel. A keyboard-only user was stuck permanently.
+
+The fix reuses the package's OWN established idiom (``↑`` on the composer's
+first line already reaches upward into the sent-queue when it has items,
+#3300 Y-client) rather than inventing a new key: ``↑`` now checks for a
+pending intervention FIRST — ``InterventionPanel.has_pending()`` — and, if
+one exists, focuses the panel's active tab (``InterventionPanel.focus_pending()``)
+instead of the sent-queue. The new behavior is registered in
+``chrome.py``'s ``COMPOSER_KEYS`` (the Help pane's single source of truth,
+the exact defect class #3314 caught for a previous binding).
+
+Real ``TextualChatApp`` + a real minimal ``ClientTransport`` (mirrors
+``test_textual_chat_intervention_panel_3299.py``'s ``RecordingTransport``) —
+no mocks, per the testing policy.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual.widgets import RadioSet, Static
+
+from reyn.interfaces.inline.textual_chat import Composer, TextualChatApp
+from reyn.interfaces.inline.textual_chat.chrome import COMPOSER_KEYS
+from reyn.interfaces.inline.textual_chat.intervention_panel import InterventionPanel
+from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.runtime.outbox import OutboxMessage
+from reyn.schemas.models import Event
+
+
+class RecordingTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` — replays a fixed frame list,
+    then stays open on a live queue so a test can push more frames (e.g. a
+    ``user_submitted`` sent-queue event), and RECORDS which answer seam each
+    user action reached."""
+
+    def __init__(self, messages: "list[OutboxMessage]") -> None:
+        self._initial = list(messages)
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+        self.submitted: "list[str]" = []
+        self.answered_choice: "list[str]" = []
+        self.answered_text: "list[str]" = []
+
+    async def push_event(self, event: Event) -> None:
+        await self._queue.put(EventFrame(event))
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        for msg in self._initial:
+            yield DisplayFrame(msg)
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str) -> str:
+        self.submitted.append(text)
+        return "m-" + str(len(self.submitted))
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        self.answered_text.append(text)
+        return True
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        self.answered_choice.append(choice_id)
+        return True
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _choice_intervention() -> OutboxMessage:
+    return OutboxMessage(
+        kind="intervention",
+        text="Allow write to /etc/hosts?\n  Yes / No",
+        meta={
+            "intervention_id": "iv-1",
+            "intervention_kind": "confirm",
+            "prompt": "Allow write to /etc/hosts?",
+            "choices": [
+                {"id": "yes", "label": "Yes", "hotkey": "y"},
+                {"id": "no", "label": "No", "hotkey": "n"},
+            ],
+        },
+    )
+
+
+def _user_submitted(*, msg_id: str, chain_id: str, text: str, seq: int) -> Event:
+    return Event(
+        type="user_submitted",
+        data={"text": text, "chain_id": chain_id, "msg_id": msg_id, "seq": seq, "meta": {}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_up_from_composer_reaches_panel_after_esc_dismiss_and_answers() -> None:
+    """Tier 2b: GATE 1 + GATE 5 — the full keyboard-only recovery sequence.
+    ``Esc`` dismisses the panel WITHOUT answering (the escape hatch keeps
+    working, gate 5); ``↑`` from the composer then re-focuses the panel
+    (gate 1's reachability fix); a normal in-panel keystroke (bare ``Enter``
+    on the pre-highlighted first option) answers it.
+
+    NON-VACUITY: focus is checked to be on the Composer (not already on the
+    panel) immediately after Esc, before ``↑`` is pressed — so the final
+    RadioSet focus cannot be a leftover from before the dismiss."""
+    transport = RecordingTransport([_choice_intervention()])
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        panel = app.query_one(InterventionPanel)
+        composer = app.query_one(Composer)
+        radio = panel.query_one(RadioSet)
+        assert radio.has_focus, "panel did not auto-focus on arrival"
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert composer.has_focus, "Esc did not return focus to the Composer"
+        assert panel.display is True, "Esc must not answer/collapse the panel"
+        assert transport.answered_choice == [], "Esc must not deliver an answer"
+
+        # GATE 1: the keyboard route BACK — ↑ from the composer's (empty,
+        # cursor-at-origin) first line.
+        await pilot.press("up")
+        await pilot.pause()
+        assert not composer.has_focus, "↑ did not move focus off the Composer"
+        assert radio.has_focus, (
+            "↑ did not reach the pending intervention panel's RadioSet — "
+            "the #3327 deadlock's reachability gap"
+        )
+
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert transport.answered_choice == ["yes"], (
+            f"the panel, once reached, did not deliver the answer; "
+            f"got {transport.answered_choice}"
+        )
+        assert panel.display is False
+        assert composer.has_focus
+
+
+@pytest.mark.asyncio
+async def test_up_prioritizes_pending_panel_over_nonempty_sent_queue() -> None:
+    """Tier 2b: with BOTH a pending intervention AND a non-empty sent-queue,
+    ``↑`` targets the panel first — answering the intervention is the more
+    urgent action (and unblocks the turn that is itself gating the queued
+    item's own dispatch)."""
+    transport = RecordingTransport([_choice_intervention()])
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await transport.push_event(
+            _user_submitted(msg_id="m1", chain_id="c1", text="queued while busy", seq=1)
+        )
+        await pilot.pause()
+
+        sent_queue = app.query_one(SentQueue)
+        assert sent_queue.has_items(), "test setup: sent-queue must be non-empty"
+
+        composer = app.query_one(Composer)
+        composer.focus()
+        await pilot.pause()
+
+        await pilot.press("up")
+        await pilot.pause()
+
+        panel = app.query_one(InterventionPanel)
+        radio = panel.query_one(RadioSet)
+        assert radio.has_focus, (
+            "↑ focused the sent-queue instead of the higher-priority pending "
+            "intervention panel"
+        )
+        assert not sent_queue.has_focus
+
+
+@pytest.mark.asyncio
+async def test_up_still_reaches_sent_queue_when_nothing_pending() -> None:
+    """Tier 2b: regression guard — with NO pending intervention, ``↑`` keeps
+    its pre-#3327 behavior (focus the non-empty sent-queue) unchanged."""
+    transport = RecordingTransport([])
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(
+            _user_submitted(msg_id="m1", chain_id="c1", text="queued", seq=1)
+        )
+        await pilot.pause()
+
+        composer = app.query_one(Composer)
+        composer.focus()
+        await pilot.pause()
+
+        await pilot.press("up")
+        await pilot.pause()
+
+        sent_queue = app.query_one(SentQueue)
+        assert sent_queue.has_focus, (
+            "↑ did not focus the sent-queue when nothing is pending — "
+            "the pre-#3327 behavior regressed"
+        )
+
+
+@pytest.mark.asyncio
+async def test_help_pane_renders_the_new_up_binding_description() -> None:
+    """Tier 2b: GATE 4 — the new ``↑`` behavior is DISCOVERABLE through the
+    ACTUAL RENDERED Help pane widget (never just the ``COMPOSER_KEYS``
+    constant — the #3314 co-vet finding this exact check pattern guards
+    against: an existence check on the constant would pass even if the pane
+    never rendered it)."""
+    transport = RecordingTransport([])
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+
+        rendered = str(app.query_one("#help", Static).render())
+        assert "focus pending intervention" in rendered, (
+            f"the new ↑ binding description is missing from the RENDERED "
+            f"Help pane; got: {rendered!r}"
+        )
+
+    # Non-vacuity: the constant itself carries the exact text asserted above
+    # (proves the assertion isn't matching on unrelated boilerplate).
+    assert any("focus pending intervention" in desc for _key, desc in COMPOSER_KEYS)


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3327

## Bug

A keyboard-only user who `Esc`-dismisses the intervention panel (#3299 P1's
documented, *intended* escape hatch — focus returns to the Composer WITHOUT
answering) had **no way back**: `Tab`/`Shift+Tab` only cycle Composer↔MenuBar,
the Composer's own `↓`/`↑` targeted the menu and sent-queue (never the
panel), and the documented `/answer` fallback deadlocked itself — a queued
`/answer` only dequeues once the blocking turn frees, and the turn only frees
once *that same intervention* resolves. Only a mouse click could recover.

This is a defect two individually-correct behaviors (#3299 P1's "Esc doesn't
answer" + #3300's "Composer submissions queue") composed into.

## Routing found

`TextualChatApp._submit` → `ClientTransport.submit_user_text` →
`Session.submit_user_text` → **always** `_put_inbox("user", ...)` (the
#3300 inbox/sent-queue), regardless of whether the text is a slash command.
Slash dispatch (`Session._handle_user_message` → `_maybe_handle_slash`) only
runs once that inbox item is *dequeued* — and dequeue only happens once the
CURRENT turn's `run_one_iteration()` returns, which for a turn blocked on an
`ask_user`/permission intervention never happens until that intervention
resolves. Meanwhile, the `InterventionPanel` itself was never queue-gated:
`answer_intervention_choice`/`answer_intervention_text` call
`Session.answer_intervention_by_id` / `answer_oldest_intervention_*` directly,
resolving the pending intervention's future with **no inbox involvement at
all** — the proven-safe direct-delivery funnel this PR reuses for `/answer`.

## Fix (both halves)

1. **Structural — `/answer` no longer queue-gated.** New
   `Session.maybe_deliver_answer_command(text)`: if `text` names the
   `answer` slash command AND at least one intervention is pending, it runs
   `_maybe_handle_slash` immediately (the SAME un-queued funnel the panel
   uses) and returns `True`; otherwise `False` (fall through, unchanged).
   Exposed as `ClientTransport.deliver_pending_answer` (non-abstract default
   `False`, mirroring `cancel_queued`'s precedent so existing transport
   stubs need no change), overridden by `InProcessTransport`.
   `TextualChatApp._submit` tries it FIRST, before `submit_user_text`. The
   AG-UI wire transport intentionally does **not** override it — it tracks
   only a single pending-intervention id client-side with no server op to
   resolve an `/answer` id-prefix remotely; documented as an explicit,
   out-of-scope gap (closing it needs a new wire message).

2. **Reachability — a keyboard route back to the panel.** The Composer's
   existing `↑` idiom (already routes to the sent-queue, #3300 Y-client) now
   checks `InterventionPanel.has_pending()` FIRST and, if true, calls the new
   `InterventionPanel.focus_pending()` instead — reusing the package's own
   established convention rather than inventing a new key, exactly the
   issue's own suggested direction. Registered in `chrome.py`'s
   `COMPOSER_KEYS` (the Help pane's single source of truth — the exact class
   of defect #3314 caught for a previous binding).

## Doc-drift fixed in this PR

`app.py`'s class docstring asserted Esc/Tab needed "no black-hole guard…the
#3300 sent-queue durably holds any new Composer submit while any stay
pending" — true as far as it goes, but it missed that the queue *holds*
without ever *draining* an `/answer` aimed at its own blocking intervention.
Corrected to state what's actually true post-fix, and cross-referenced from
`on_intervention_panel_dismissed`, `_submit`, and the
`InterventionPanel` module docstring's Keymap section.

## Gates (strip-falsified individually, RED confirmed on the broken build)

1. **Deadlock gone** — keyboard-only `Esc` → `↑` → `Enter` answers a pending
   intervention. Stripped the `Composer._on_key` panel-priority check →
   `↑` never moved focus off the Composer → **RED**.
2. **`/answer` dispatches immediately while blocked** — stripped
   `maybe_deliver_answer_command` to always return `False` →
   `deliver_pending_answer` returned `False` instead of `True` → **RED**.
   (Companion `test_strip_falsify_queued_answer_path_deadlocks` also proves
   the OLD `submit_user_text`-only path genuinely still hangs on the current
   tree — non-vacuity for the positive test.)
3. **Ordinary submissions still queue** — widened the bypass to claim ANY
   pending-turn submission (not just `/answer`) → the ordinary-text
   assertion flipped to `True` → **RED**.
4. **New binding in the rendered Help pane** — reverted `COMPOSER_KEYS`'
   description text → `"focus pending intervention"` missing from the
   mounted `#help` `Static`'s actual rendered content → **RED**.
5. **Esc still doesn't answer** — unchanged code path, covered by the
   existing `test_escape_and_tab_from_panel_return_focus_to_composer` plus
   this PR's own combined gate-1 test (Esc assertions run before `↑` is even
   pressed).

## Local verification

- `ruff check src tests` — clean
- `python scripts/test_tier_audit.py --strict <changed test files>` — 22/22 OK, 0 Tier-4
- `python scripts/verify_module_docstrings.py <changed src files>` — OK
- `uv run python -m pytest --timeout=120 -q` on: the 2 new test files, plus
  every #3299/#3300/#3273/#2690/#3308-adjacent textual_chat + AG-UI test
  file touched by this change area — 106 passed (foreground, not backgrounded)
- Rebased onto `origin/main` (past #3323, which also touches `app.py`) —
  clean rebase, re-verified green after.

## Test plan

- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict` on changed test files
- [x] `python scripts/verify_module_docstrings.py` on changed src files
- [x] Targeted `pytest` run (see above) — all green
- [x] Each gate strip-falsified to RED, then restored to GREEN
