### PR TITLE
feat(llm): delete the /v1/responses bridge — litellm does it natively — #3288 follow-up

### DIFF
--- a/docs/reference/builtin-models.ja.md
+++ b/docs/reference/builtin-models.ja.md
@@ -131,15 +131,39 @@ hard output cap が必要なときは常に `max_completion_tokens` を優先す
 実際の使用は少ないこともある。 複雑な task で `budget_tokens` を低く設定すると
 answer 品質が落ちる可能性あり。
 
-### ツールを伴う turn での reasoning（Responses-API bridge）
+### ツールを伴う turn での reasoning（Responses-API bridge — litellm ネイティブ）
 
-**tools** を伴い、かつ **OpenAI または Azure** の reasoning-capable model に
-`reasoning_effort` が設定された turn は、litellm の Responses-API bridge
-（`responses/<model>`）を通ります。`reasoning_effort + tools` の組み合わせは
-これらの provider の `/v1/responses` でのみ有効で、`/v1/chat/completions` は
-この組み合わせを 405 で拒否するためです（#1678）。litellm の bridge は現状、
-model が返す `reasoning` output item を map できないため、call が次の error を
-raise します:
+**tools** を伴い、`reasoning_effort` が設定された turn は、一部の reasoning
+model では `/v1/responses` endpoint でのみ有効です — `/v1/chat/completions`
+はこの組み合わせを 405 で拒否します（#1678、`gpt-5.4` で owner 確認済み）。
+以前は reyn 自身がこの形状を検出し、model 文字列を `responses/<model>`
+bridge marker に書き換えていました（#1678、#3325 で OpenAI/Azure provider に
+gate）。**この手動 bridge は削除されました**（#3288 follow-up、issue #3288
+コメントスレッド、owner 承認済み）: **litellm >= 1.89.3 が自前の automatic
+bridge を持っています**（`litellm.main.responses_api_bridge_check`、upstream
+`BerriAI/litellm#23577`、2026-03-13 merge — #1678 が file される前）。これは
+`litellm.acompletion()` 内部から発火し、呼び出し側が `responses/` prefix を
+付ける必要はありません。reyn は解決済みの model をそのまま
+`litellm.acompletion` に渡し、`/v1/responses` へ route するかどうかは
+litellm が内部で決定します。
+
+**なぜ reyn 自身の gate ではなく委譲するか。** 調査の結果、reyn の
+provider-allowlist bridge は litellm 自身の routing より **明らかに広い**
+ことが分かりました — OpenAI/Azure の reasoning model（`o1`、`o3-mini` 等）
+すべてに対して発火していましたが、そのうちどれも実際に bridge が必要かは
+検証されていませんでした。一方 litellm の routing はより狭く（現状
+gpt-5.4-family + tools + reasoning_effort、または
+`model_info.mode == "responses"`）、upstream が保守するため将来の
+provider/model 変化に自動的に追随します。広すぎる bridge は安全な方向では
+ありません — それはまさに #3288 のデフォルト構成 regression（Gemini の
+`tools + reasoning_effort` primary-reply 形状が未認識の `responses/` model
+文字列に静かに書き換えられ、token streaming が無効化された）と同じ形です
+（#3325 で狭められました）。reyn 自身の gate を削除することは、検証されて
+いない凍結された推測を、より狭く upstream が保守する判断に置き換えることを
+意味します。
+
+litellm の bridge は現状、model が返す `reasoning` output item を map
+できないため、bridge された call は次の error を raise することがあります:
 
 ```
 litellm.APIConnectionError: OpenAIException -
@@ -149,51 +173,39 @@ Unknown items in responses API response: [GenericResponseOutputItem(type='reason
 reasoning テキストは response に含まれています — bridge parser がその `reasoning`
 item を chat-completions の形に map しないだけです。これは current と latest 両方の
 litellm release に存在し、released fix はありません。Reyn は provider 固有の回避を
-作りません。
+作りません。これは委譲の有無に関わらず影響を受けません — litellm 内部の parsing
+gap のためです。
 
-**provider でゲートされる（#3288 follow-up）。** この bridge は Reyn が
-**OpenAI または Azure** と解決した model にのみ適用されます（transport/proxy
-routing ではなく、解決済み model identity に対する `litellm.get_llm_provider`
-query — `src/reyn/llm/llm.py` の `_requires_responses_bridge` を参照）。Azure
-が含まれるのは、Azure が reyn の一級 provider であり、OpenAI の reasoning
-model（`azure/o1`、`azure/o3-mini` 等）をそのままホストしているため、同じ
-`/chat/completions` 拒否に当たるからです。Gemini には適用されません —
-Gemini の `reasoning_effort` はネイティブの thinking-budget パラメータに
-map され、`/v1/chat/completions` だけで完結するためです。Gemini の
-tool-turn 上の reasoning はこの bridge を一切通らず、上記 error にも当たりません。
-また、model 名自体に `openai/` segment を含む OpenRouter 経由の model
-（例: `openrouter/openai/gpt-5`）にも適用されません — その call は
-OpenRouter 自身の completions endpoint に着地し、埋め込まれた segment に
-関わらず OpenAI の `/v1/responses` には一切到達しないためです。
-（この gate が入る前は、provider を問わず **すべての** `tools + reasoning_effort`
-組み合わせが bridge を通っており、Gemini のデフォルト model class で token
-streaming が黙って無効化されていました。streaming 側の fix は `_streaming_capable`
-の docstring を参照。）
+**`litellm.route_all_chat_openai_to_responses = True` を設定しないでください。**
+litellm はこれを global opt-in（既定 `False`）として公開しています。有効にすると
+上記の tools+reasoning_effort の組み合わせだけでなく、OpenAI の chat call
+**すべて**が `/v1/responses` を経由するようになります。これを有効にすると、
+OpenAI provider 全体で #3288 のデフォルト streaming regression が再現します:
+`_streaming_capable` が bridge された model 形状を認識できず、reasoning+tools
+に限らず OpenAI の call すべてで streaming が静かに死にます。Reyn はこの flag
+を設定しませんし、あなたも設定すべきではありません。
 
-**発火する条件 — 狭い opt-in の組み合わせ。** すべてが成立する必要があります:
-
-1. **tool を伴う** purpose（例: router。その turn は常に tools を持つ）が
-   reasoning-capable model を指す。**かつ**
-2. その model に `reasoning_effort` が設定されている。**かつ**
-3. その model が **OpenAI または Azure** provider に解決される
-   （`model_class_by_purpose: router: strong` を OpenAI/Azure の reasoning
-   model に向ける、またはデフォルトの `model` class をそれに設定）。
+**endpoint が 405 を返す場合。** reyn はもう「自分が bridge したか」を知りません
+（litellm が内部で決定するため）が、`tools + reasoning_effort` の call 形状で
+HTTP 405 が発生した場合は、依然として decision-enabling な
+`ResponsesEndpointRequiredError` を raise します — 両方の対処法を示します:
+その agent の `reasoning_effort` を unset するか、proxy 側で `/v1/responses`
+を有効にするか。これは litellm の routing coverage が狭い場合の safety net
+として意図的に残されています: bridge が必要な model を litellm の heuristic
+がまだカバーしていない場合、405 は raw な dead-end ではなく actionable な
+guidance として表面化します。
 
 **影響を受けないパス:**
 
 - **デフォルト構成。** `standard`/`light` class（Gemini Flash Lite。#1654 の
-  通り `reasoning_effort: low` がデフォルトで設定済み）が影響を受けないのは
-  `reasoning_effort` が未設定だからではなく、Gemini が bridge の対象である
-  OpenAI/Azure provider ではないためです。デフォルト構成の tool turn は通常通り
-  `/v1/chat/completions` を通ります。
+  通り `reasoning_effort: low` がデフォルトで設定済み）は影響を受けません:
+  Gemini の `reasoning_effort` はネイティブの thinking-budget パラメータに
+  map され、`/v1/chat/completions` だけで完結し、litellm の bridge は
+  OpenAI-family の reasoning model にのみ発火するためです。デフォルト構成の
+  tool turn は通常通り `/v1/chat/completions` を通ります。
 - **tool なしの chat + reasoning。** reasoning-capable model を tools *なし* で使うと
   `/v1/chat/completions` を通り、reasoning は survive して正常に round-trip します
   （`reasoning_content` / `thinking_blocks` として現れる）。
-
-**回避するには**、tool を伴う turn を担う OpenAI/Azure の reasoning-capable
-model に `reasoning_effort` を設定しない — または tool を伴う purpose を
-どちらの provider にも解決されない model に置く。tool なしの chat パスの
-reasoning は影響を受けません。
 
 ## Namespace + override semantics
 

--- a/docs/reference/builtin-models.ja.md
+++ b/docs/reference/builtin-models.ja.md
@@ -151,14 +151,30 @@ litellm が内部で決定します。
 provider-allowlist bridge は litellm 自身の routing より **明らかに広い**
 ことが分かりました — OpenAI/Azure の reasoning model（`o1`、`o3-mini` 等）
 すべてに対して発火していましたが、そのうちどれも実際に bridge が必要かは
-検証されていませんでした。一方 litellm の routing はより狭く（現状
-gpt-5.4-family + tools + reasoning_effort、または
-`model_info.mode == "responses"`）、upstream が保守するため将来の
-provider/model 変化に自動的に追随します。広すぎる bridge は安全な方向では
-ありません — それはまさに #3288 のデフォルト構成 regression（Gemini の
-`tools + reasoning_effort` primary-reply 形状が未認識の `responses/` model
-文字列に静かに書き換えられ、token streaming が無効化された）と同じ形です
-（#3325 で狭められました）。reyn 自身の gate を削除することは、検証されて
+検証されていませんでした。litellm の source
+（`litellm/main.py::responses_api_bridge_check`）を直接確認すると、実際の
+条件は単一の provider/family 判定ではなく連言（AND）です:
+
+```
+custom_llm_provider in ("openai", "azure")
+  AND is_model_gpt_5_model(model)
+  AND reasoning_effort is not None
+  AND (reasoning_summary is not None OR (is_gpt_5_4_plus_model(model) AND tools))
+```
+
+（加えて `model_info.get("mode") == "responses"` という model 固有の別 trigger
+もあります — 下記の `o1-pro` 参照。）model 別の実測: `o1` / `o1-pro` /
+`o3-mini` / `gpt-4o-mini` はいずれも `is_gpt_5_model=False`（この経路では
+bridge されない — `o1-pro` は `mode == "responses"` 経由で別途 bridge されます）。
+`gpt-5` / `gpt-5.1` は `is_gpt_5_model=True` ですが明示的な `reasoning_summary`
+が必要で、`tools` だけでは足りません。`gpt-5.4` 以降は
+`is_gpt_5_4_plus_model=True` で、`reasoning_effort` が設定されていれば
+`tools` だけで足ります — これが reyn 自身が検証した bug case です。
+広すぎる bridge は安全な方向ではありません — それはまさに #3288 の
+デフォルト構成 regression（Gemini の `tools + reasoning_effort`
+primary-reply 形状が未認識の `responses/` model 文字列に静かに書き換えられ、
+token streaming が無効化された）と同じ形です（#3325 で狭められました）。
+reyn 自身の gate を削除することは、検証されて
 いない凍結された推測を、より狭く upstream が保守する判断に置き換えることを
 意味します。
 

--- a/docs/reference/builtin-models.ja.md
+++ b/docs/reference/builtin-models.ja.md
@@ -186,14 +186,19 @@ OpenAI provider 全体で #3288 のデフォルト streaming regression が再�
 を設定しませんし、あなたも設定すべきではありません。
 
 **endpoint が 405 を返す場合。** reyn はもう「自分が bridge したか」を知りません
-（litellm が内部で決定するため）が、`tools + reasoning_effort` の call 形状で
-HTTP 405 が発生した場合は、依然として decision-enabling な
-`ResponsesEndpointRequiredError` を raise します — 両方の対処法を示します:
-その agent の `reasoning_effort` を unset するか、proxy 側で `/v1/responses`
-を有効にするか。これは litellm の routing coverage が狭い場合の safety net
-として意図的に残されています: bridge が必要な model を litellm の heuristic
-がまだカバーしていない場合、405 は raw な dead-end ではなく actionable な
-guidance として表面化します。
+（litellm が内部で決定するため）が、`tools + reasoning_effort` の call 形状
+**かつ OpenAI または Azure provider に解決される** model で HTTP 405 が発生した
+場合は、依然として decision-enabling な `ResponsesEndpointRequiredError` を
+raise します — 両方の対処法を示します: その agent の `reasoning_effort` を
+unset するか、proxy 側で `/v1/responses` を有効にするか。provider による
+scope は重要です: litellm の bridge は `openai`/`azure` にしか発火しない
+ため（`litellm.main.responses_api_bridge_check` の実装を直接確認済み）、
+例えば Gemini の call がこの形状で 405 した場合、それは `/v1/responses` とは
+無関係です — その場合この error は誤解を招くため raise されません。これは
+litellm がカバーする provider の範囲内で、routing coverage が狭い場合の
+safety net として意図的に残されています: OpenAI/Azure の model で bridge が
+必要だが litellm の heuristic がまだカバーしていない場合、405 は raw な
+dead-end ではなく actionable な guidance として表面化します。
 
 **影響を受けないパス:**
 

--- a/docs/reference/builtin-models.md
+++ b/docs/reference/builtin-models.md
@@ -155,15 +155,37 @@ Anthropic API via LiteLLM.  The `budget_tokens` value is the upper bound of reas
 tokens; actual usage may be less.  Setting `budget_tokens` too low can degrade answer
 quality on complex tasks.
 
-### Reasoning on tool-bearing turns (Responses-API bridge)
+### Reasoning on tool-bearing turns (Responses-API bridge — litellm-native)
 
-A turn that carries **tools** *and* has `reasoning_effort` set on a reasoning-
-capable model resolved to the **OpenAI or Azure** provider is routed through
-litellm's Responses-API bridge (`responses/<model>`), because
-`reasoning_effort + tools` together are only valid on the `/v1/responses`
-endpoint on those providers — `/v1/chat/completions` rejects the combination
-with a 405 (#1678). litellm's bridge currently cannot map the `reasoning`
-output item the model returns, so the call raises:
+A turn that carries **tools** *and* has `reasoning_effort` set is, for SOME
+reasoning models, only valid on the OpenAI `/v1/responses` endpoint —
+`/v1/chat/completions` rejects the combination with a 405 (#1678,
+owner-confirmed on `gpt-5.4`). Reyn used to detect this shape itself and
+rewrite the model string to a `responses/<model>` bridge marker (#1678,
+provider-gated to OpenAI/Azure at #3325). **That manual bridge was deleted**
+(#3288 follow-up, issue #3288 comment thread, owner-approved): **litellm
+>= 1.89.3 ships its own automatic bridge**
+(`litellm.main.responses_api_bridge_check`, upstream `BerriAI/litellm#23577`,
+merged 2026-03-13 — before #1678 was even filed), entered from inside
+`litellm.acompletion()` itself with no `responses/` prefix required from the
+caller. Reyn now passes the resolved model straight to `litellm.acompletion`
+unchanged; litellm decides internally whether to route to `/v1/responses`.
+
+**Why delegate rather than keep reyn's own gate.** Investigation found reyn's
+provider-allowlist bridge was strictly *wider* than litellm's own routing —
+it fired for every OpenAI/Azure reasoning model (`o1`, `o3-mini`, …), none of
+which were ever verified to actually need the bridge, whereas litellm's
+routing is narrower (currently gpt-5.4-family + tools + reasoning_effort, or
+`model_info.mode == "responses"`) and upstream-maintained, tracking future
+provider/model changes automatically. A bridge that's too wide is not the
+safe direction — it's exactly the shape of the #3288 default-config
+regression (Gemini's `tools + reasoning_effort` primary-reply shape got
+silently rewritten to an unrecognized `responses/` model string, disabling
+token streaming) before #3325 narrowed it. Deleting reyn's own gate removes
+an unverified, frozen guess in favor of a narrower, upstream-maintained one.
+
+litellm's bridge currently cannot map the `reasoning` output item some models
+return, so a bridged call can still raise:
 
 ```
 litellm.APIConnectionError: OpenAIException -
@@ -173,51 +195,38 @@ Unknown items in responses API response: [GenericResponseOutputItem(type='reason
 The reasoning text is present in the response — the bridge parser simply doesn't
 map the `reasoning` item onto the chat-completions shape. This is present in both
 the current and the latest litellm release, with no released fix; Reyn does not
-ship a provider-specific workaround for it.
+ship a provider-specific workaround for it. This is unaffected by the delegation
+above — it is a litellm-internal parsing gap either way.
 
-**Provider-gated (#3288 follow-up).** The bridge only applies to models Reyn
-resolves as **OpenAI or Azure** (via a `litellm.get_llm_provider` query on the
-resolved model identity, never on the transport/proxy routing — see
-`_requires_responses_bridge` in `src/reyn/llm/llm.py`). Azure is included
-because it is a first-class reyn provider that literally hosts OpenAI's
-reasoning models (`azure/o1`, `azure/o3-mini`, …) under the same
-`/chat/completions` rejection. It does NOT apply to Gemini, whose
-`reasoning_effort` maps to a native "thinking budget" parameter handled
-entirely on `/v1/chat/completions` — Gemini reasoning-on-tool-turns never go
-through this bridge and never hit the error above. It also does NOT apply to
-an OpenRouter-routed model whose own model name happens to embed an `openai/`
-segment (e.g. `openrouter/openai/gpt-5`) — that call lands on OpenRouter's own
-completions endpoint, never OpenAI's `/v1/responses`, regardless of the
-embedded segment. (Earlier behavior — before this gate existed — routed EVERY
-`tools + reasoning_effort` combination through the bridge regardless of
-provider, which silently disabled token streaming for Gemini's default model
-classes; see `_streaming_capable`'s docstring for the streaming side of that
-fix.)
+**Do not set `litellm.route_all_chat_openai_to_responses = True`.** litellm
+exposes this as a global opt-in (default `False`) that routes *every* OpenAI
+chat call through `/v1/responses`, not just the tools+reasoning_effort combo
+covered above. Turning it on reproduces the #3288 default-streaming
+regression for the entire OpenAI provider: `_streaming_capable` cannot
+recognize the bridged model shape, so streaming silently goes dark for every
+OpenAI call, not just reasoning+tools ones. Reyn does not set this flag and
+you should not either.
 
-**When it bites — a narrow, opt-in combination.** All must hold:
-
-1. a **tool-bearing** purpose (e.g. the router, whose turns always carry tools)
-   is pointed at a reasoning-capable model; **and**
-2. `reasoning_effort` is set on that model; **and**
-3. the model resolves to the **OpenAI or Azure** provider
-   (`model_class_by_purpose: router: strong` pointed at an OpenAI/Azure
-   reasoning model, or the default `model` class set to one).
+**If your endpoint 405s anyway.** Reyn no longer knows whether IT applied a
+bridge (litellm decides internally now), but it still raises a
+decision-enabling `ResponsesEndpointRequiredError` on any HTTP 405 for a
+`tools + reasoning_effort` call — naming both remedies: unset
+`reasoning_effort` for that agent, or enable `/v1/responses` on your proxy.
+This is deliberately kept as a safety net for litellm's narrower routing
+coverage: if a model needs the bridge but litellm's heuristic doesn't (yet)
+cover it, the 405 surfaces as actionable guidance instead of a raw dead-end.
 
 **Unaffected paths:**
 
 - **The default setup.** The `standard`/`light` classes (Gemini Flash Lite,
   which DOES ship with `reasoning_effort: low` by default — see #1654 above)
-  are unaffected because Gemini is not an OpenAI/Azure provider the bridge
-  targets, not because `reasoning_effort` is unset. Tool-bearing turns on the
-  default config go through `/v1/chat/completions` as normal.
+  are unaffected: Gemini's `reasoning_effort` maps to a native "thinking
+  budget" parameter handled entirely on `/v1/chat/completions`, and litellm's
+  bridge only engages for OpenAI-family reasoning models. Tool-bearing turns
+  on the default config go through `/v1/chat/completions` as normal.
 - **Non-tool chat with reasoning.** A reasoning-capable model *without* tools goes
   through `/v1/chat/completions`; reasoning survives and round-trips normally
   (surfaced as `reasoning_content` / `thinking_blocks`).
-
-**To avoid it**, keep `reasoning_effort` off any OpenAI/Azure reasoning-capable
-model that serves tool-bearing turns — or keep tool-bearing purposes on a
-model that resolves to neither provider. Reasoning on the non-tool chat path
-is unaffected.
 
 ## Namespace and override semantics
 

--- a/docs/reference/builtin-models.md
+++ b/docs/reference/builtin-models.md
@@ -175,14 +175,31 @@ unchanged; litellm decides internally whether to route to `/v1/responses`.
 provider-allowlist bridge was strictly *wider* than litellm's own routing —
 it fired for every OpenAI/Azure reasoning model (`o1`, `o3-mini`, …), none of
 which were ever verified to actually need the bridge, whereas litellm's
-routing is narrower (currently gpt-5.4-family + tools + reasoning_effort, or
-`model_info.mode == "responses"`) and upstream-maintained, tracking future
-provider/model changes automatically. A bridge that's too wide is not the
-safe direction — it's exactly the shape of the #3288 default-config
-regression (Gemini's `tools + reasoning_effort` primary-reply shape got
-silently rewritten to an unrecognized `responses/` model string, disabling
-token streaming) before #3325 narrowed it. Deleting reyn's own gate removes
-an unverified, frozen guess in favor of a narrower, upstream-maintained one.
+routing is narrower and upstream-maintained, tracking future provider/model
+changes automatically. Read directly from litellm's source
+(`litellm/main.py::responses_api_bridge_check`), the actual condition is a
+conjunction, not a single provider/family check:
+
+```
+custom_llm_provider in ("openai", "azure")
+  AND is_model_gpt_5_model(model)
+  AND reasoning_effort is not None
+  AND (reasoning_summary is not None OR (is_gpt_5_4_plus_model(model) AND tools))
+```
+
+(plus `model_info.get("mode") == "responses"` as a separate, model-specific
+trigger — see `o1-pro` below.) Measured per-model: `o1` / `o1-pro` / `o3-mini`
+/ `gpt-4o-mini` all resolve `is_gpt_5_model=False` (never bridged this way —
+`o1-pro` bridges instead via `mode == "responses"`); `gpt-5` / `gpt-5.1`
+resolve `is_gpt_5_model=True` but need an explicit `reasoning_summary`, not
+just `tools`; `gpt-5.4`-and-above resolve `is_gpt_5_4_plus_model=True`, where
+`tools` alone (with `reasoning_effort` set) is sufficient — this is reyn's
+own verified bug case. A bridge that's too wide is not the safe direction —
+it's exactly the shape of the #3288 default-config regression (Gemini's
+`tools + reasoning_effort` primary-reply shape got silently rewritten to an
+unrecognized `responses/` model string, disabling token streaming) before
+#3325 narrowed it. Deleting reyn's own gate removes an unverified, frozen
+guess in favor of a narrower, upstream-maintained one.
 
 litellm's bridge currently cannot map the `reasoning` output item some models
 return, so a bridged call can still raise:

--- a/docs/reference/builtin-models.md
+++ b/docs/reference/builtin-models.md
@@ -209,12 +209,18 @@ you should not either.
 
 **If your endpoint 405s anyway.** Reyn no longer knows whether IT applied a
 bridge (litellm decides internally now), but it still raises a
-decision-enabling `ResponsesEndpointRequiredError` on any HTTP 405 for a
-`tools + reasoning_effort` call — naming both remedies: unset
-`reasoning_effort` for that agent, or enable `/v1/responses` on your proxy.
-This is deliberately kept as a safety net for litellm's narrower routing
-coverage: if a model needs the bridge but litellm's heuristic doesn't (yet)
-cover it, the 405 surfaces as actionable guidance instead of a raw dead-end.
+decision-enabling `ResponsesEndpointRequiredError` on an HTTP 405 for a
+`tools + reasoning_effort` call **resolved to the OpenAI or Azure
+provider** — naming both remedies: unset `reasoning_effort` for that agent,
+or enable `/v1/responses` on your proxy. The provider scope matters:
+litellm's bridge only ever fires for `openai`/`azure` (read directly from
+`litellm.main.responses_api_bridge_check`'s source), so a 405 on e.g. a
+Gemini call shaped this way is unrelated to `/v1/responses` — the error
+would be actively misleading there, and does not fire. This is deliberately
+kept as a safety net for litellm's narrower routing coverage WITHIN the
+providers it actually bridges: if an OpenAI/Azure model needs the bridge but
+litellm's heuristic doesn't (yet) cover it, the 405 surfaces as actionable
+guidance instead of a raw dead-end.
 
 **Unaffected paths:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,12 @@ classifiers = [
 ]
 
 dependencies = [
-    "litellm>=1.0",
+    "litellm>=1.89.3",  # #3288 follow-up: floor raised for litellm's native
+                        # /v1/responses auto-bridge (BerriAI/litellm#23577,
+                        # merged 2026-03-13) — reyn's own manual bridge (#1678)
+                        # was deleted in favor of delegating to this; an older
+                        # litellm would silently lack the bridge reyn now
+                        # relies on for reasoning+tools calls.
     "pydantic>=2.0",
     "jsonschema>=4.0",
     "pyyaml>=6.0",

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1495,139 +1495,20 @@ def _emit_llm_request_error(
 
 
 class ResponsesEndpointRequiredError(Exception):
-    """#1678: raised when a ``reasoning_effort + tools`` call was routed to the
-    OpenAI ``/v1/responses`` endpoint but the configured endpoint/proxy does not
-    serve it (HTTP 405). Carries a decision-enabling message naming BOTH remedies
-    so the operator isn't left with a raw 405."""
-
-
-def _responses_bridge_providers() -> "frozenset[str]":
-    """The litellm provider identities the #1678 ``/v1/responses`` bridge
-    applies to — see ``_requires_responses_bridge`` for why this is a set,
-    not a single literal.
-
-    Enum-referenced (``litellm.LlmProviders.OPENAI.value`` /
-    ``.AZURE.value``), not bare string literals — if litellm ever renames a
-    provider identity, the enum moves with it instead of silently going
-    stale here.
-
-    **This allowlist is PROVISIONAL** (owner direction: minimize
-    provider-dependent code in reyn). litellm's own model info already
-    declares the routing need per-MODEL, not per-provider —
-    ``litellm.get_model_info("o1-pro")["mode"] == "responses"`` — and
-    ``litellm.utils`` exposes a ``supports_reasoning`` capability query
-    alongside the ``supports_native_streaming`` / ``supports_function_calling``
-    ones ``_streaming_capable`` already uses. A follow-up should replace this
-    provider allowlist with that per-model ``mode`` declaration, which would
-    make Azure/OpenRouter case-by-case judgment (and tracking future
-    providers) unnecessary. Until that lands: if an Azure-routed reasoning
-    model 405s unexpectedly, this frozenset is the first place to check.
-    """
-    import litellm  # noqa: PLC0415
-
-    return frozenset({
-        litellm.LlmProviders.OPENAI.value,
-        litellm.LlmProviders.AZURE.value,
-    })
-
-
-def _requires_responses_bridge(model: str) -> bool:
-    """#3288 follow-up (issue #3288 comment thread, per-PR-coder root-cause;
-    provider-set widened per co-vet finding (b) on PR #3325): does ``model``
-    need the ``/v1/responses`` bridge for a ``reasoning_effort + tools`` call?
-
-    **PROVISIONAL — see ``_responses_bridge_providers``'s docstring.** This
-    decision is currently provider-based; a follow-up should switch it to a
-    per-model ``litellm.get_model_info(...)["mode"] == "responses"``
-    declaration instead (litellm already declares this per-model, not merely
-    per-provider), which would need no Azure/OpenRouter case-by-case judgment
-    and no tracking of future providers. Not done in this PR — #3325 fixes a
-    live default-config regression (streaming silently dead) and that fix
-    should not wait on the provider→model-mode replacement.
-
-    The #1678 bridge exists because SOME reasoning models reject
-    ``reasoning_effort + tools`` on ``/chat/completions`` and need
-    ``/v1/responses`` instead. It is NOT a universal requirement — e.g.
-    Gemini's ``reasoning_effort`` maps to a native "thinking budget" param
-    (see the #1650 comment above) and does not need (or support well —
-    #1652/②'s reasoning-continuity note) the bridge. Before this fix,
-    ``_routed_to_responses`` had no provider check, so it fired for EVERY
-    ``tools + reasoning_effort`` call, including Gemini's default-config
-    primary reply — silently rewriting ``gemini/...`` to
-    ``responses/gemini/...``, which ``_streaming_capable`` cannot recognize
-    (litellm's model map has no entry for the ``responses/`` marker), so
-    streaming was silently disabled on the default configuration.
-
-    **Provider boundary — why {openai, azure}, and where to look if you hit a
-    405 on an ``azure/o1``-shaped model**: Azure is a first-class reyn
-    provider (``credentials.py``'s ``"azure": "AZURE_API_KEY"``) whose
-    reasoning-model deployments (``azure/o1``, ``azure/o3-mini``, …) are
-    literally OpenAI's reasoning models, hosted by Azure — the SAME
-    ``/chat/completions`` rejection this bridge exists to route around
-    applies there too. Excluding azure would have been a SILENT BEHAVIOR
-    CHANGE for this PR: ``azure/o1`` already resolves through
-    ``_to_responses_model`` (``azure/o1`` → ``azure/responses/o1``), so it was
-    almost certainly bridged before this fix (no provider check existed) —
-    narrowing to ``openai`` alone would un-bridge it and could reintroduce the
-    405 this bridge exists to avoid, for a provider nobody verified doesn't
-    need it. Minimal change = keep Azure's existing (bridged) behavior. If a
-    genuine Azure reasoning-model 405 shows up in the future, this frozenset
-    is the first place to check — either Azure's ``/v1/responses`` support
-    changed, or a model isn't resolving to the ``azure`` provider the way
-    expected (verify with ``litellm.get_llm_provider``, not by inspection).
-
-    **Deliberately excluded: ``openrouter/openai/...``.** ``get_llm_provider``
-    resolves that model string to provider ``"openrouter"``, not
-    ``"openai"`` — correctly: the HTTP call actually lands on OpenRouter's own
-    completions endpoint, not OpenAI's ``/v1/responses``, regardless of the
-    ``openai/`` segment embedded in the OpenRouter model name. Bridging it
-    would target an endpoint OpenRouter doesn't serve.
-
-    Derives the provider from the resolved MODEL IDENTITY via
-    ``litellm.get_llm_provider``, queried WITHOUT an explicit
-    ``custom_llm_provider`` (``None``) — the SAME transport-independence
-    discipline ``_streaming_capable`` documents: reyn's proxy routing
-    (``proxy_kwargs()``) forces ``custom_llm_provider="openai"`` on the wire
-    for ALL models when an operator proxy is configured, so deriving "is this
-    OpenAI?" from that forced value would make every model look like OpenAI —
-    reproducing the exact bug this function fixes, one layer over. Capability
-    (and provider identity) is a property of the MODEL, not of the transport
-    used to reach it.
-
-    Any lookup failure (unmapped model name, litellm internal error) is
-    caught and treated as "does not require the bridge" — conservative in the
-    direction that matters here: it means an unrecognized model is never
-    force-routed through a bridge it may not need, at the cost of a genuinely
-    unmapped reasoning model needing an explicit ``openai/responses/...`` /
-    ``azure/responses/...`` model string (already supported — see
-    ``_to_responses_model``'s idempotent explicit-prefix path).
-    """
-    try:
-        import litellm  # noqa: PLC0415
-
-        _, provider, _, _ = litellm.get_llm_provider(model=model, custom_llm_provider=None)
-        return provider in _responses_bridge_providers()
-    except Exception:  # noqa: BLE001 — unknown provider → conservative "no bridge"
-        return False
-
-
-def _to_responses_model(model: str) -> str:
-    """#1678: rewrite a resolved litellm model string to route through the OpenAI
-    Responses API (``/v1/responses``) via the ``responses/`` bridge marker, which
-    litellm.acompletion honours and returns a chat-completions-shaped response for
-    (so reyn's response parsing is unchanged). Idempotent — an already-routed model
-    (explicit ``openai/responses/...`` prefix) is returned unchanged.
-
-    - ``openai/gpt-5.4``    → ``openai/responses/gpt-5.4`` (direct path)
-    - ``gpt-5.4``           → ``responses/gpt-5.4``        (proxy path, post-strip;
-      reyn's ``custom_llm_provider="openai"`` carries the provider)
-    """
-    if "/responses/" in model or model.startswith("responses/"):
-        return model
-    if "/" in model:
-        provider, rest = model.split("/", 1)
-        return f"{provider}/responses/{rest}"
-    return f"responses/{model}"
+    """#1678, delegated to litellm at #3288-follow-up (issue #3288 comment
+    thread, 2026-07-26/27): litellm >= 1.89.3 auto-bridges eligible
+    ``reasoning_effort + tools`` calls to the OpenAI ``/v1/responses`` endpoint
+    internally (``litellm.main.responses_api_bridge_check`` — reyn no longer
+    rewrites the model string itself, see ``recorded_acompletion``). reyn can
+    no longer tell whether a given call WAS bridged, so this error is now
+    raised on ANY 405 for a call shaped ``reasoning_effort + tools`` — the
+    guidance ("this needs /v1/responses, but your endpoint doesn't serve it")
+    is equally true whether litellm applied its own bridge or the operator's
+    proxy simply doesn't support the endpoint. Kept deliberately (owner
+    decision, #3288 comment thread): it is the safety net that makes
+    delegating to litellm's narrower, upstream-maintained routing decision
+    reversible — if litellm's bridge coverage misses a model that genuinely
+    needs it, this surfaces as an ACTIONABLE 405 instead of a raw one."""
 
 
 def _emit_chat_cost_events(model: str, usage: "TokenUsage | None") -> None:
@@ -1825,38 +1706,38 @@ async def recorded_acompletion(
             _allowed.append("reasoning_effort")
         base_kwargs["allowed_openai_params"] = _allowed
 
-    # #1678: route reasoning-model + tools calls to the OpenAI Responses API.
-    # ``reasoning_effort`` + ``tools`` together are only valid on /v1/responses
-    # (owner-confirmed: removing reasoning_effort cleared the 405) — but reyn
-    # sends everything via acompletion (/chat/completions) → 405. litellm's
-    # auto-route is unreliable (litellm#23156), so apply the ``responses/`` bridge
-    # prefix EXPLICITLY: it routes to /v1/responses yet returns a chat-completions
-    # shape, so the existing chokepoint + response parsing are unchanged (no
-    # parallel recorded_aresponses). An explicit operator prefix is preserved
-    # (idempotent). ``_routed_to_responses`` gates the decision-enabling error
-    # below so a normal 405 is unaffected.
+    # #1678 → delegated to litellm at #3288-follow-up (issue #3288 comment
+    # thread, owner-approved 2026-07-26/27): ``reasoning_effort`` + ``tools``
+    # together are only valid on /v1/responses for SOME reasoning models
+    # (owner-confirmed gpt-5.4 405 repro). reyn used to rewrite the model
+    # string to a ``responses/`` bridge marker itself (#1678) so litellm would
+    # route to /v1/responses while still returning a chat-completions shape.
+    # That manual bridge is now REDUNDANT: litellm >= 1.89.3 ships its own
+    # ``responses_api_bridge_check`` (upstream PR BerriAI/litellm#23577,
+    # merged 2026-03-13 — before #1678 was even filed), entered from inside
+    # ``litellm.acompletion()`` itself, requiring NO ``responses/`` prefix
+    # from the caller. Investigation (issue #3288 comment thread) found
+    # reyn's own provider-allowlist bridge was actually the WRONG direction
+    # of "safe": it fired for every openai/azure reasoning model (incl. ones
+    # nobody verified need it), which is exactly how the #3288 default-config
+    # streaming regression happened for Gemini before the #3325 provider gate
+    # — a bridge that is too WIDE silently breaks streaming for models that
+    # didn't need it. litellm's own narrower, upstream-maintained routing
+    # (currently gpt-5.4-family + tools + reasoning_effort, or
+    # ``mode == "responses"``) is strictly better: reyn passes the bare
+    # resolved model straight to ``litellm.acompletion`` and litellm decides
+    # internally.
     #
-    # #3288 follow-up: this is a provider-scoped requirement (OpenAI + Azure —
-    # see ``_requires_responses_bridge``'s docstring for the boundary), not a
-    # universal one — gate it on the resolved model's PROVIDER, not merely on
-    # the tools+reasoning_effort SHAPE. Without the provider check, this fired
-    # for every reasoning-capable default model class (incl. Gemini, whose
-    # reasoning_effort maps to a native thinking-budget param, not a
-    # /v1/responses requirement), silently rewriting ``gemini/...`` to a
-    # ``responses/`` bridge string that ``_streaming_capable`` cannot
-    # recognize — disabling streaming on the default configuration.
-    _routed_to_responses = bool(
-        base_kwargs.get("tools")
-        and base_kwargs.get("reasoning_effort")
-        and _requires_responses_bridge(effective_model)
+    # ``_needs_responses_endpoint`` no longer gates a rewrite (reyn does not
+    # know whether litellm applied its own bridge) — it ONLY gates the
+    # decision-enabling ``ResponsesEndpointRequiredError`` below, by call
+    # SHAPE (tools + reasoning_effort), per the owner's explicit call:
+    # keep the guidance regardless of who did the bridging, since a 405 on
+    # this shape means the same thing either way (endpoint/proxy does not
+    # serve /v1/responses).
+    _needs_responses_endpoint = bool(
+        base_kwargs.get("tools") and base_kwargs.get("reasoning_effort")
     )
-    if _routed_to_responses:
-        effective_model = _to_responses_model(effective_model)
-        # #1652/②: native reasoning continuity is a no-op on this
-        # capable+tools+reasoning ``/v1/responses`` bridge path due to an
-        # upstream litellm reasoning-item output-parse limitation (canonical
-        # write-up in builtin-models.md → "Vendor-specific quirks: Reasoning on
-        # tool-bearing turns"). It works on the chat path.
 
     # #1669: emit a P6 ``llm_request`` event (TUI-observable) carrying the
     # non-message call params, ONCE here — before the ``_once`` response_format
@@ -2061,13 +1942,16 @@ async def recorded_acompletion(
                 raise
     except Exception as exc:
         _emit_llm_request_error(effective_model, purpose, exc, base_kwargs)
-        # #1678: when WE routed this call to /v1/responses (reasoning_effort +
-        # tools) and it still 405s, the endpoint/proxy does not serve /v1/responses.
-        # Turn that raw dead-end into a decision-enabling error naming BOTH remedies
-        # (the raw 405 detail is already captured in the #1676 llm_request_error
-        # event above). Only fires when reyn applied the responses route, so a
-        # normal/unrelated 405 is unaffected.
-        if _routed_to_responses and getattr(exc, "status_code", None) == 405:
+        # #1678, delegated to litellm at #3288-follow-up: this call shape
+        # (reasoning_effort + tools) MAY need /v1/responses — litellm decides
+        # internally now (see the comment above ``_needs_responses_endpoint``),
+        # so reyn can no longer tell whether IT applied a bridge. On a 405 for
+        # this shape, turn the raw dead-end into a decision-enabling error
+        # naming BOTH remedies (the raw 405 detail is already captured in the
+        # #1676 llm_request_error event above) — the guidance is equally true
+        # whether litellm's own bridge fired or the proxy just doesn't serve
+        # /v1/responses. A 405 on a call NOT shaped this way is unaffected.
+        if _needs_responses_endpoint and getattr(exc, "status_code", None) == 405:
             raise ResponsesEndpointRequiredError(
                 f"This call combines reasoning_effort + tools on model {model!r}, "
                 "which requires the OpenAI /v1/responses endpoint — but the "

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1497,18 +1497,67 @@ def _emit_llm_request_error(
 class ResponsesEndpointRequiredError(Exception):
     """#1678, delegated to litellm at #3288-follow-up (issue #3288 comment
     thread, 2026-07-26/27): litellm >= 1.89.3 auto-bridges eligible
-    ``reasoning_effort + tools`` calls to the OpenAI ``/v1/responses`` endpoint
-    internally (``litellm.main.responses_api_bridge_check`` — reyn no longer
-    rewrites the model string itself, see ``recorded_acompletion``). reyn can
-    no longer tell whether a given call WAS bridged, so this error is now
-    raised on ANY 405 for a call shaped ``reasoning_effort + tools`` — the
-    guidance ("this needs /v1/responses, but your endpoint doesn't serve it")
-    is equally true whether litellm applied its own bridge or the operator's
-    proxy simply doesn't support the endpoint. Kept deliberately (owner
-    decision, #3288 comment thread): it is the safety net that makes
-    delegating to litellm's narrower, upstream-maintained routing decision
-    reversible — if litellm's bridge coverage misses a model that genuinely
-    needs it, this surfaces as an ACTIONABLE 405 instead of a raw one."""
+    ``reasoning_effort + tools`` calls to the OpenAI/Azure ``/v1/responses``
+    endpoint internally (``litellm.main.responses_api_bridge_check`` — reyn no
+    longer rewrites the model string itself, see ``recorded_acompletion``).
+    reyn can no longer tell whether a given call WAS bridged, so this error is
+    raised on a 405 for a call shaped ``reasoning_effort + tools`` resolved to
+    the OpenAI or Azure provider (see ``_may_need_responses_endpoint``) — the
+    guidance ("this MAY need /v1/responses, but your endpoint doesn't serve
+    it") is equally true whether litellm applied its own bridge or the
+    operator's proxy simply doesn't support the endpoint. **Provider-scoped**
+    (co-vet finding on PR #3331): litellm's bridge only ever fires for
+    ``custom_llm_provider in ("openai", "azure")`` — a Gemini 405 is
+    categorically unrelated to ``/v1/responses``, so an unscoped trigger would
+    turn a decision-enabling error into a decision-MISLEADING one for every
+    other provider. Kept deliberately (owner decision, #3288 comment thread):
+    it is the safety net that makes delegating to litellm's narrower,
+    upstream-maintained routing decision reversible — if litellm's bridge
+    coverage misses a model that genuinely needs it, this surfaces as an
+    ACTIONABLE 405 instead of a raw one."""
+
+
+def _may_need_responses_endpoint(model: str) -> bool:
+    """#3331 co-vet finding: does ``model`` resolve to a provider litellm's
+    OWN ``/v1/responses`` auto-bridge (``litellm.main.responses_api_bridge_check``,
+    delegated to at #3288-follow-up) ever applies to? Used ONLY to scope the
+    ``ResponsesEndpointRequiredError`` 405 guidance — NOT to rewrite the model
+    (reyn no longer does that; litellm decides bridging internally).
+
+    litellm's own bridge check gates on ``custom_llm_provider in ("openai",
+    "azure")`` (read directly from its source, ``litellm/main.py``) — so this
+    mirrors that pair exactly, not reyn's own judgment about who "should"
+    need it. Without this scope, the 405 guidance would fire for e.g. a
+    Gemini call shaped ``tools + reasoning_effort`` that 405s for a reason
+    entirely unrelated to ``/v1/responses`` (litellm never bridges Gemini),
+    which is categorically false guidance, not merely imprecise.
+
+    Reuses the SAME derivation this repo's #3325 fix (and the now-deleted
+    ``_requires_responses_bridge``) used: ``litellm.get_llm_provider``,
+    queried WITHOUT an explicit ``custom_llm_provider`` (``None``) — the same
+    transport-independence discipline ``_streaming_capable`` documents.
+    reyn's proxy routing (``proxy_kwargs()``) forces
+    ``custom_llm_provider="openai"`` on the wire for ALL models when an
+    operator proxy is configured, so deriving "is this OpenAI/Azure?" from
+    that forced value would make every model look eligible — the exact
+    over-wide failure #3325 fixed, reproduced one layer over. Capability (and
+    provider identity) is a property of the MODEL, not of the transport used
+    to reach it.
+
+    Any lookup failure (unmapped model, litellm internal error) is caught and
+    treated as "does not need it" — conservative in the direction that
+    matters for a diagnostic (never claim a model needs an endpoint reyn
+    can't confirm it resolves to)."""
+    try:
+        import litellm  # noqa: PLC0415
+
+        _, provider, _, _ = litellm.get_llm_provider(model=model, custom_llm_provider=None)
+        return provider in (
+            litellm.LlmProviders.OPENAI.value,
+            litellm.LlmProviders.AZURE.value,
+        )
+    except Exception:  # noqa: BLE001 — unknown provider → conservative "no"
+        return False
 
 
 def _emit_chat_cost_events(model: str, usage: "TokenUsage | None") -> None:
@@ -1728,15 +1777,18 @@ async def recorded_acompletion(
     # resolved model straight to ``litellm.acompletion`` and litellm decides
     # internally.
     #
-    # ``_needs_responses_endpoint`` no longer gates a rewrite (reyn does not
-    # know whether litellm applied its own bridge) — it ONLY gates the
-    # decision-enabling ``ResponsesEndpointRequiredError`` below, by call
-    # SHAPE (tools + reasoning_effort), per the owner's explicit call:
-    # keep the guidance regardless of who did the bridging, since a 405 on
-    # this shape means the same thing either way (endpoint/proxy does not
-    # serve /v1/responses).
+    # This no longer gates a rewrite (reyn does not know whether litellm
+    # applied its own bridge) — it ONLY gates the decision-enabling
+    # ``ResponsesEndpointRequiredError`` below, by call SHAPE (tools +
+    # reasoning_effort) AND provider (co-vet finding on PR #3331: litellm's
+    # own bridge only ever fires for openai/azure — an unscoped Gemini 405
+    # would get the SAME "/v1/responses" guidance despite litellm never
+    # bridging Gemini, which is categorically false, not merely imprecise).
+    # See ``_may_need_responses_endpoint``'s docstring.
     _needs_responses_endpoint = bool(
-        base_kwargs.get("tools") and base_kwargs.get("reasoning_effort")
+        base_kwargs.get("tools")
+        and base_kwargs.get("reasoning_effort")
+        and _may_need_responses_endpoint(effective_model)
     )
 
     # #1669: emit a P6 ``llm_request`` event (TUI-observable) carrying the
@@ -1943,21 +1995,25 @@ async def recorded_acompletion(
     except Exception as exc:
         _emit_llm_request_error(effective_model, purpose, exc, base_kwargs)
         # #1678, delegated to litellm at #3288-follow-up: this call shape
-        # (reasoning_effort + tools) MAY need /v1/responses — litellm decides
-        # internally now (see the comment above ``_needs_responses_endpoint``),
-        # so reyn can no longer tell whether IT applied a bridge. On a 405 for
-        # this shape, turn the raw dead-end into a decision-enabling error
-        # naming BOTH remedies (the raw 405 detail is already captured in the
-        # #1676 llm_request_error event above) — the guidance is equally true
+        # (reasoning_effort + tools, resolved to the openai/azure provider —
+        # see the comment above ``_needs_responses_endpoint`` and
+        # ``_may_need_responses_endpoint``'s docstring) MAY need
+        # /v1/responses — litellm decides internally now, so reyn can no
+        # longer tell whether IT applied a bridge. On a 405 for this shape,
+        # turn the raw dead-end into a decision-enabling error naming BOTH
+        # remedies (the raw 405 detail is already captured in the #1676
+        # llm_request_error event above) — the guidance is equally true
         # whether litellm's own bridge fired or the proxy just doesn't serve
-        # /v1/responses. A 405 on a call NOT shaped this way is unaffected.
+        # /v1/responses. A 405 on a call NOT shaped this way, or resolved to
+        # a provider litellm never bridges (e.g. Gemini), is unaffected.
         if _needs_responses_endpoint and getattr(exc, "status_code", None) == 405:
             raise ResponsesEndpointRequiredError(
                 f"This call combines reasoning_effort + tools on model {model!r}, "
-                "which requires the OpenAI /v1/responses endpoint — but the "
-                "configured endpoint/proxy does not serve /v1/responses (HTTP 405). "
-                "Options: (1) set reasoning_effort to none / unset it for this "
-                "agent, OR (2) enable the /v1/responses endpoint on your proxy."
+                "which MAY require the OpenAI/Azure /v1/responses endpoint — but "
+                "the configured endpoint/proxy does not serve /v1/responses "
+                "(HTTP 405). Options: (1) set reasoning_effort to none / unset it "
+                "for this agent, OR (2) enable the /v1/responses endpoint on your "
+                "proxy."
             ) from exc
         raise
 

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1772,10 +1772,15 @@ async def recorded_acompletion(
     # streaming regression happened for Gemini before the #3325 provider gate
     # — a bridge that is too WIDE silently breaks streaming for models that
     # didn't need it. litellm's own narrower, upstream-maintained routing
-    # (currently gpt-5.4-family + tools + reasoning_effort, or
-    # ``mode == "responses"``) is strictly better: reyn passes the bare
-    # resolved model straight to ``litellm.acompletion`` and litellm decides
-    # internally.
+    # (read from its source, ``litellm/main.py::responses_api_bridge_check``:
+    # ``custom_llm_provider in ("openai", "azure") AND is_gpt_5_model(model)
+    # AND reasoning_effort is not None AND (reasoning_summary OR
+    # (is_gpt_5_4_plus_model(model) AND tools))``, plus a separate
+    # ``mode == "responses"`` trigger for Responses-only models like
+    # ``o1-pro`` — NOT merely "gpt-5.4-family", which would drop the
+    # ``gpt-5``/``gpt-5.1`` + explicit ``reasoning_summary`` path) is
+    # strictly better: reyn passes the bare resolved model straight to
+    # ``litellm.acompletion`` and litellm decides internally.
     #
     # This no longer gates a rewrite (reyn does not know whether litellm
     # applied its own bridge) — it ONLY gates the decision-enabling

--- a/tests/test_llm_streaming_delta_emission_3288.py
+++ b/tests/test_llm_streaming_delta_emission_3288.py
@@ -252,20 +252,26 @@ def test_silent_zero_delta_stream_logs_once_per_stream(monkeypatch, caplog) -> N
 
 
 def test_default_shaped_gemini_call_actually_enters_the_streaming_branch(monkeypatch) -> None:
-    """Tier 3a: #3288 follow-up — the actual goal of the provider-gate fix
-    (`src/reyn/llm/llm.py`'s `_requires_responses_bridge`): a default-shaped
-    call (tools + reasoning_effort attached, Gemini model — exactly what
-    `RouterLoop`'s primary reply sends under reyn.yaml's default model
-    classes) genuinely drives the streaming loop, witnessed via REAL chunk
-    consumption (`chunk_witness`), not merely that `_streaming_capable`
-    returns True in isolation (a terminal-state assertion that would pass
-    even if this call never reached the streaming branch at all — see
-    verification-hazards.md §10). Before the provider gate, this exact call
-    shape got silently rewritten to `responses/gemini-2.5-flash-lite`, which
-    `_streaming_capable` cannot recognize (unmapped in litellm's model map) —
-    reverting `_requires_responses_bridge` out of the `_routed_to_responses`
-    condition reproduces that and this assertion goes RED (chunk_witness stays
-    empty — the whole-collect fallback runs instead)."""
+    """Tier 3a: #3288 follow-up — a default-shaped call (tools +
+    reasoning_effort attached, Gemini model — exactly what `RouterLoop`'s
+    primary reply sends under reyn.yaml's default model classes) genuinely
+    drives the streaming loop, witnessed via REAL chunk consumption
+    (`chunk_witness`), not merely that `_streaming_capable` returns True in
+    isolation (a terminal-state assertion that would pass even if this call
+    never reached the streaming branch at all — see verification-hazards.md
+    §10).
+
+    Historical note (#3288 comment thread, #3325): before #3325, reyn's own
+    `/v1/responses` bridge (#1678) had no provider check and fired for EVERY
+    tools+reasoning_effort call, silently rewriting this exact Gemini call
+    to `responses/gemini-2.5-flash-lite`, which `_streaming_capable` could
+    not recognize (unmapped in litellm's model map) — the default-config
+    streaming regression this test guards against. #3325 fixed that with a
+    provider gate; the #3288 follow-up investigation then deleted reyn's
+    manual bridge entirely (litellm >= 1.89.3 delegates this natively), so
+    reyn no longer rewrites the model string at all — this test now also
+    covers that the model passes through UNCHANGED for a non-OpenAI model,
+    which is a stronger guarantee than "correctly gated" was."""
     chunk_witness: list[int] = []
     monkeypatch.setattr(litellm, "acompletion", _make_fake_acompletion(chunk_witness))
 

--- a/tests/test_responses_api_routing_1678.py
+++ b/tests/test_responses_api_routing_1678.py
@@ -22,9 +22,22 @@ internally whether to bridge.
 `ResponsesEndpointRequiredError` was DELIBERATELY KEPT (owner decision, #3288
 comment thread) as the safety net that makes this delegation reversible: since
 reyn can no longer tell whether IT applied a bridge, the decision-enabling
-error now fires on any 405 for a `tools + reasoning_effort` CALL SHAPE,
-regardless of model/provider — the guidance is equally true whether litellm's
-own bridge fired or the endpoint simply doesn't serve `/v1/responses`.
+error fires on a 405 for a `tools + reasoning_effort` CALL SHAPE — the
+guidance is equally true whether litellm's own bridge fired or the endpoint
+simply doesn't serve `/v1/responses`.
+
+**Provider-scoped (#3331 co-vet finding).** The first version of this PR
+scoped the trigger on call shape ALONE, regardless of provider. Co-vet caught
+that this makes the guidance categorically FALSE for a Gemini 405 (litellm's
+own bridge — `litellm.main.responses_api_bridge_check`, read directly from
+its source — only ever fires for `custom_llm_provider in ("openai",
+"azure")`; a Gemini 405 is unrelated to `/v1/responses` regardless of call
+shape). `_may_need_responses_endpoint(model)` reuses the SAME
+`litellm.get_llm_provider` derivation the now-deleted
+`_requires_responses_bridge` used, but ONLY to scope this diagnostic — never
+again to rewrite the model. The message also weakened "requires" → "MAY
+require", since reyn no longer controls routing and can only say the shape
+COULD have needed the bridge.
 
 No mocks: real `recorded_acompletion`, a real async fake for `litellm.acompletion`
 (capturing the model / raising a litellm-shaped 405), monkeypatched.
@@ -38,7 +51,11 @@ import litellm
 import pytest
 
 from reyn.core.events.events import EventLog, set_llm_request_event_log
-from reyn.llm.llm import ResponsesEndpointRequiredError, recorded_acompletion
+from reyn.llm.llm import (
+    ResponsesEndpointRequiredError,
+    _may_need_responses_endpoint,
+    recorded_acompletion,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -118,6 +135,18 @@ def test_litellm_native_bridge_check_fires_for_reyn_verified_bug_shape() -> None
     assert model == "gpt-5.4"  # no reyn-side prefix needed
 
 
+def test_may_need_responses_endpoint_scoped_to_openai_and_azure() -> None:
+    """Tier 1: `_may_need_responses_endpoint` mirrors litellm's OWN
+    `responses_api_bridge_check` provider gate (`custom_llm_provider in
+    ("openai", "azure")`, read directly from litellm's source) — true for
+    both providers litellm ever bridges, false for a provider it never
+    does."""
+    assert _may_need_responses_endpoint("openai/gpt-5.4") is True
+    assert _may_need_responses_endpoint("azure/o1") is True
+    assert _may_need_responses_endpoint("gemini/gemini-2.5-flash-lite") is False
+    assert _may_need_responses_endpoint("anthropic/claude-opus-4-1") is False
+
+
 # ── decision-enabling error on a 405 for the tools+reasoning_effort shape ───────
 
 
@@ -130,12 +159,16 @@ class _FakeProviderError(Exception):
 
 
 def test_openai_shaped_405_raises_decision_enabling_error(monkeypatch) -> None:
-    """Tier 2: a tools+reasoning_effort call against an OpenAI-family model
-    that 405s raises the decision-enabling `ResponsesEndpointRequiredError`
-    naming BOTH remedies. Strip the `_needs_responses_endpoint` condition out
-    of the 405 handler in `recorded_acompletion` (revert to unconditional
-    re-raise) and this goes RED (the raw `_FakeProviderError` propagates
-    instead)."""
+    """Tier 2: ★POSITIVE — a tools+reasoning_effort call against an
+    OpenAI-family model that 405s raises the decision-enabling
+    `ResponsesEndpointRequiredError` naming BOTH remedies, with "MAY require"
+    wording (reyn no longer controls routing, so it can only say the shape
+    COULD have needed the bridge). Strip the provider condition out of
+    `_may_need_responses_endpoint` (force it to always return `True`) and
+    this test alone would NOT go red (openai already resolves True) — see
+    `test_gemini_shaped_405_is_not_wrapped_since_provider_unbridgeable` for
+    the negative companion that DOES catch an unscoped/wrong provider
+    check."""
     async def _raise_405(**_kwargs):
         raise _FakeProviderError("Method Not Allowed", 405)
     monkeypatch.setattr(litellm, "acompletion", _raise_405)
@@ -148,24 +181,29 @@ def test_openai_shaped_405_raises_decision_enabling_error(monkeypatch) -> None:
         ))
     msg = str(ei.value).lower()
     assert "/v1/responses" in str(ei.value)
+    assert "may require" in msg  # weakened wording — reyn doesn't control routing anymore
     assert "reasoning_effort" in msg and ("none" in msg or "unset" in msg)  # remedy 1
     assert "proxy" in msg  # remedy 2
     assert "gpt-5.4" in str(ei.value)  # names the model
 
 
-def test_gemini_shaped_405_also_raises_decision_enabling_error(monkeypatch) -> None:
-    """Tier 2: owner decision (#3288 comment thread) — the guidance fires on
-    ANY `tools + reasoning_effort` call shape that 405s, regardless of
-    provider, because reyn can no longer tell whether litellm applied its own
-    bridge for this specific model. A Gemini call is included: if it 405s
-    while shaped this way, the same guidance is offered rather than a raw
-    405. This is a deliberate behavior WIDENING versus the pre-deletion,
-    provider-gated error (#3325) — see the PR body for the rationale."""
+def test_gemini_shaped_405_is_not_wrapped_since_provider_unbridgeable(monkeypatch) -> None:
+    """Tier 2: ★NEGATIVE — #3331 co-vet finding. A Gemini call shaped
+    `tools + reasoning_effort` that 405s is NOT wrapped in
+    `ResponsesEndpointRequiredError`: litellm's own bridge
+    (`litellm.main.responses_api_bridge_check`) never fires for a non
+    openai/azure provider, so claiming "this MAY require /v1/responses" for
+    a Gemini 405 would be categorically FALSE guidance, not merely
+    imprecise — the raw error must propagate instead. This is the strip
+    target: force `_may_need_responses_endpoint` to always return `True`
+    (simulating the unscoped, shape-only version co-vet caught) and this
+    assertion goes RED (`ResponsesEndpointRequiredError` gets raised for
+    Gemini instead of the raw `_FakeProviderError` propagating)."""
     async def _raise_405(**_kwargs):
         raise _FakeProviderError("Method Not Allowed", 405)
     monkeypatch.setattr(litellm, "acompletion", _raise_405)
 
-    with pytest.raises(ResponsesEndpointRequiredError):
+    with pytest.raises(_FakeProviderError):  # raw error propagates, NOT wrapped
         asyncio.run(recorded_acompletion(
             model="gemini/gemini-2.5-flash-lite", messages=[{"role": "user", "content": "hi"}],
             purpose="main", recorder=None,

--- a/tests/test_responses_api_routing_1678.py
+++ b/tests/test_responses_api_routing_1678.py
@@ -1,23 +1,30 @@
-"""Tier 2: #1678 — route reasoning_effort + tools to the OpenAI Responses API.
+"""Tier 2: #1678 / #3288 follow-up — the `/v1/responses` bridge is delegated to
+litellm, not implemented by reyn.
 
-`reasoning_effort` + `tools` together are only valid on `/v1/responses`, but reyn
-sent everything via `acompletion` (`/chat/completions`) → 405 (owner-confirmed:
-removing reasoning_effort cleared it). The fix routes that combo through the
-`openai/responses/<model>` bridge prefix (returns a chat-completions shape →
-parsing unchanged, no parallel chokepoint). When the proxy/endpoint does not serve
-`/v1/responses`, the routed call 405s → reyn raises a decision-enabling error
-(naming BOTH remedies) instead of a raw dead-end; #1676 still captures the raw 405.
+History: `reasoning_effort` + `tools` together are only valid on `/v1/responses`
+for some reasoning models (owner-confirmed gpt-5.4 405 repro). #1678 made reyn
+rewrite the model string itself (`<provider>/responses/<model>`) so litellm would
+route to `/v1/responses` while still returning a chat-completions shape. The
+#3288 comment thread investigation (2026-07-26/27, offline + one live smoke)
+found litellm >= 1.89.3 already ships its own auto-bridge
+(`litellm.main.responses_api_bridge_check`, upstream `BerriAI/litellm#23577`,
+merged 2026-03-13 — before #1678 was even filed) that requires no `responses/`
+prefix from the caller, and that reyn's own provider-allowlist bridge was
+strictly WIDER than litellm's (it fired for `o1`/`o3-mini`/any openai+azure
+reasoning model, none of which were ever verified to need it) — the same
+"too wide" failure shape that silently broke Gemini streaming pre-#3325. Per
+owner approval, reyn's manual bridge (`_to_responses_model`,
+`_requires_responses_bridge`, `_responses_bridge_providers`, the
+`_routed_to_responses` rewrite) was deleted; reyn now passes the resolved
+model straight to `litellm.acompletion` unchanged and litellm decides
+internally whether to bridge.
 
-#3288 follow-up: the bridge is OpenAI-specific (some OpenAI reasoning models
-reject reasoning_effort+tools on /chat/completions; Gemini's reasoning_effort
-maps to a native thinking-budget param and does not need — or work well with,
-per #1652/② — the bridge). Pre-fix, `_routed_to_responses` had no provider
-check and fired for EVERY tools+reasoning_effort call, including Gemini's
-default-config primary reply, silently rewriting `gemini/...` to a
-`responses/`-prefixed string `_streaming_capable` cannot recognize —
-disabling streaming on the default configuration. The provider-gated tests
-below (`test_gemini_*`, `test_openai_reasoning_model_still_routed_*`) cover
-that fix; see `_requires_responses_bridge` in `src/reyn/llm/llm.py`.
+`ResponsesEndpointRequiredError` was DELIBERATELY KEPT (owner decision, #3288
+comment thread) as the safety net that makes this delegation reversible: since
+reyn can no longer tell whether IT applied a bridge, the decision-enabling
+error now fires on any 405 for a `tools + reasoning_effort` CALL SHAPE,
+regardless of model/provider — the guidance is equally true whether litellm's
+own bridge fired or the endpoint simply doesn't serve `/v1/responses`.
 
 No mocks: real `recorded_acompletion`, a real async fake for `litellm.acompletion`
 (capturing the model / raising a litellm-shaped 405), monkeypatched.
@@ -31,11 +38,7 @@ import litellm
 import pytest
 
 from reyn.core.events.events import EventLog, set_llm_request_event_log
-from reyn.llm.llm import (
-    ResponsesEndpointRequiredError,
-    _to_responses_model,
-    recorded_acompletion,
-)
+from reyn.llm.llm import ResponsesEndpointRequiredError, recorded_acompletion
 
 
 @pytest.fixture(autouse=True)
@@ -46,23 +49,6 @@ def _reset_env(monkeypatch):
     set_llm_request_event_log(None)
 
 
-# ── the model-string transform ──────────────────────────────────────────────────
-
-
-def test_to_responses_model_inserts_after_provider() -> None:
-    """Tier 2: #1678 — insert the `responses/` bridge marker after the provider
-    (direct path) or prepend it (proxy post-strip), idempotent for an already-routed
-    model."""
-    assert _to_responses_model("openai/gpt-5.4") == "openai/responses/gpt-5.4"
-    assert _to_responses_model("gpt-5.4") == "responses/gpt-5.4"
-    # idempotent — an explicit operator prefix is preserved (no double-prefix).
-    assert _to_responses_model("openai/responses/gpt-5.4") == "openai/responses/gpt-5.4"
-    assert _to_responses_model("responses/gpt-5.4") == "responses/gpt-5.4"
-
-
-# ── routing applied only on (tools + reasoning_effort) ──────────────────────────
-
-
 def _capturing_acompletion(captured: dict):
     async def _fn(**kwargs):
         captured["model"] = kwargs.get("model")
@@ -70,9 +56,15 @@ def _capturing_acompletion(captured: dict):
     return _fn
 
 
-def test_combo_routes_to_responses(monkeypatch) -> None:
-    """Tier 2: #1678 — a tools + reasoning_effort call is routed: litellm.acompletion
-    receives the `responses/`-bridged model (→ /v1/responses)."""
+# ── reyn no longer rewrites the model string — litellm sees the bare model ──────
+
+
+def test_openai_reasoning_combo_model_passed_through_unchanged(monkeypatch) -> None:
+    """Tier 2: an OpenAI reasoning-shaped call (tools + reasoning_effort, the
+    #1678 bug shape) reaches `litellm.acompletion` with the model UNCHANGED —
+    no `responses/` prefix. Delegation means litellm's own internal
+    `responses_api_bridge_check` decides whether to route to `/v1/responses`;
+    reyn is not in that decision anymore."""
     captured: dict = {}
     monkeypatch.setattr(litellm, "acompletion", _capturing_acompletion(captured))
 
@@ -81,37 +73,52 @@ def test_combo_routes_to_responses(monkeypatch) -> None:
         purpose="main", recorder=None,
         extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
     ))
-    assert captured["model"] == "openai/responses/gpt-5.4"
+    assert captured["model"] == "openai/gpt-5.4"
 
 
-def test_no_tools_not_routed(monkeypatch) -> None:
-    """Tier 2: #1678 — reasoning_effort WITHOUT tools is NOT routed (normal path
-    unaffected — the 405 only occurs for the combo)."""
+def test_gemini_combo_model_passed_through_unchanged(monkeypatch) -> None:
+    """Tier 2: #3288 regression guard — a Gemini tools+reasoning_effort call
+    (the exact default-config primary-reply shape) reaches
+    `litellm.acompletion` with the model UNCHANGED. This was the #3288
+    default-config streaming bug: reyn's own bridge used to rewrite this to
+    a `responses/`-prefixed string `_streaming_capable` could not recognize.
+    Deletion removes the rewrite for EVERY model, not just Gemini, so this
+    is now unconditionally true rather than provider-gated."""
     captured: dict = {}
     monkeypatch.setattr(litellm, "acompletion", _capturing_acompletion(captured))
 
     asyncio.run(recorded_acompletion(
-        model="openai/gpt-5.4", messages=[{"role": "user", "content": "hi"}],
+        model="gemini/gemini-2.5-flash-lite", messages=[{"role": "user", "content": "hi"}],
         purpose="main", recorder=None,
-        extra_kwargs={"reasoning_effort": "low"},  # no tools
+        extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
     ))
-    assert captured["model"] == "openai/gpt-5.4", "must NOT be routed without tools"
+    assert captured["model"] == "gemini/gemini-2.5-flash-lite"
 
 
-def test_no_reasoning_not_routed(monkeypatch) -> None:
-    """Tier 2: #1678 — tools WITHOUT reasoning_effort is NOT routed."""
-    captured: dict = {}
-    monkeypatch.setattr(litellm, "acompletion", _capturing_acompletion(captured))
+def test_litellm_native_bridge_check_fires_for_reyn_verified_bug_shape() -> None:
+    """Tier 1: OFFLINE evidence that litellm's OWN bridge would engage for the
+    exact call shape reyn used to hand-roll a fix for (owner-confirmed gpt-5.4
+    + tools + reasoning_effort 405). Calls litellm's real
+    `responses_api_bridge_check` directly — no network, no reyn code — the
+    same function the #3288 comment thread investigation used to determine
+    litellm 1.89.3 already handles this natively. This does NOT prove the
+    downstream call succeeds end-to-end (that needs a live `/v1/responses`-
+    capable proxy, out of scope here — see the PR body's "unverified" list);
+    it proves litellm's bridge decision fires, which is the half of the claim
+    this suite can verify offline."""
+    from litellm.main import responses_api_bridge_check
 
-    asyncio.run(recorded_acompletion(
-        model="openai/gpt-5.4", messages=[{"role": "user", "content": "hi"}],
-        purpose="main", recorder=None,
-        extra_kwargs={"tools": [{"type": "function"}]},  # no reasoning_effort
-    ))
-    assert captured["model"] == "openai/gpt-5.4", "must NOT be routed without reasoning_effort"
+    decision, model = responses_api_bridge_check(
+        model="gpt-5.4",
+        custom_llm_provider="openai",
+        tools=[{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        reasoning_effort="low",
+    )
+    assert decision.get("mode") == "responses"
+    assert model == "gpt-5.4"  # no reyn-side prefix needed
 
 
-# ── decision-enabling error on a /responses 405 ─────────────────────────────────
+# ── decision-enabling error on a 405 for the tools+reasoning_effort shape ───────
 
 
 class _FakeProviderError(Exception):
@@ -122,9 +129,13 @@ class _FakeProviderError(Exception):
         self.response = SimpleNamespace(text=message)
 
 
-def test_responses_405_raises_decision_enabling_error(monkeypatch) -> None:
-    """Tier 2: #1678 — when reyn routed the combo to /responses and it 405s (proxy
-    doesn't serve it), a decision-enabling error is raised naming BOTH remedies."""
+def test_openai_shaped_405_raises_decision_enabling_error(monkeypatch) -> None:
+    """Tier 2: a tools+reasoning_effort call against an OpenAI-family model
+    that 405s raises the decision-enabling `ResponsesEndpointRequiredError`
+    naming BOTH remedies. Strip the `_needs_responses_endpoint` condition out
+    of the 405 handler in `recorded_acompletion` (revert to unconditional
+    re-raise) and this goes RED (the raw `_FakeProviderError` propagates
+    instead)."""
     async def _raise_405(**_kwargs):
         raise _FakeProviderError("Method Not Allowed", 405)
     monkeypatch.setattr(litellm, "acompletion", _raise_405)
@@ -142,9 +153,46 @@ def test_responses_405_raises_decision_enabling_error(monkeypatch) -> None:
     assert "gpt-5.4" in str(ei.value)  # names the model
 
 
-def test_responses_405_still_captures_raw_via_1676(monkeypatch) -> None:
-    """Tier 2: #1678 — the #1676 llm_request_error event still captures the raw 405
-    detail before the decision-enabling error is raised (complementary)."""
+def test_gemini_shaped_405_also_raises_decision_enabling_error(monkeypatch) -> None:
+    """Tier 2: owner decision (#3288 comment thread) — the guidance fires on
+    ANY `tools + reasoning_effort` call shape that 405s, regardless of
+    provider, because reyn can no longer tell whether litellm applied its own
+    bridge for this specific model. A Gemini call is included: if it 405s
+    while shaped this way, the same guidance is offered rather than a raw
+    405. This is a deliberate behavior WIDENING versus the pre-deletion,
+    provider-gated error (#3325) — see the PR body for the rationale."""
+    async def _raise_405(**_kwargs):
+        raise _FakeProviderError("Method Not Allowed", 405)
+    monkeypatch.setattr(litellm, "acompletion", _raise_405)
+
+    with pytest.raises(ResponsesEndpointRequiredError):
+        asyncio.run(recorded_acompletion(
+            model="gemini/gemini-2.5-flash-lite", messages=[{"role": "user", "content": "hi"}],
+            purpose="main", recorder=None,
+            extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
+        ))
+
+
+def test_405_without_tools_or_reasoning_effort_not_wrapped(monkeypatch) -> None:
+    """Tier 2: non-vacuity companion — a 405 on a call NOT shaped
+    tools+reasoning_effort propagates raw, unwrapped. Proves the gate is
+    shape-conditioned, not unconditional on every 405."""
+    async def _raise_405(**_kwargs):
+        raise _FakeProviderError("Method Not Allowed", 405)
+    monkeypatch.setattr(litellm, "acompletion", _raise_405)
+
+    with pytest.raises(_FakeProviderError):
+        asyncio.run(recorded_acompletion(
+            model="openai/gpt-5.4", messages=[{"role": "user", "content": "hi"}],
+            purpose="main", recorder=None,
+            extra_kwargs={"reasoning_effort": "low"},  # no tools
+        ))
+
+
+def test_405_still_captures_raw_via_1676(monkeypatch) -> None:
+    """Tier 2: #1676 still captures the raw 405 detail (status code, body)
+    before the decision-enabling error is raised — complementary, not
+    replaced by the wrap."""
     async def _raise_405(**_kwargs):
         raise _FakeProviderError("Method Not Allowed", 405)
     monkeypatch.setattr(litellm, "acompletion", _raise_405)
@@ -159,164 +207,3 @@ def test_responses_405_still_captures_raw_via_1676(monkeypatch) -> None:
         ))
     (err,) = [e for e in log.all() if e.type == "llm_request_error"]
     assert err.data["status_code"] == 405
-
-
-def test_non_routed_405_is_not_wrapped(monkeypatch) -> None:
-    """Tier 2: #1678 — a 405 on a call reyn did NOT route (no combo) is NOT wrapped
-    in the responses-error (the wrap only fires when reyn applied the route)."""
-    async def _raise_405(**_kwargs):
-        raise _FakeProviderError("Method Not Allowed", 405)
-    monkeypatch.setattr(litellm, "acompletion", _raise_405)
-
-    with pytest.raises(_FakeProviderError):  # raw error propagates, NOT wrapped
-        asyncio.run(recorded_acompletion(
-            model="openai/gpt-5.4", messages=[{"role": "user", "content": "hi"}],
-            purpose="main", recorder=None,
-            extra_kwargs={"reasoning_effort": "low"},  # no tools → not routed
-        ))
-
-
-# ── #3288 follow-up: the bridge is provider-gated (OpenAI only) ─────────────────
-
-
-def test_gemini_combo_is_not_routed_to_responses(monkeypatch) -> None:
-    """Tier 2: #3288 follow-up — a Gemini tools+reasoning_effort call (the
-    exact default-config primary-reply shape) is NOT routed through the
-    /v1/responses bridge: litellm.acompletion receives the model UNCHANGED.
-    Strip `_requires_responses_bridge` out of the `_routed_to_responses`
-    condition (back to the pre-fix `bool(tools and reasoning_effort)`) and the
-    `responses/` rewrite returns — this assertion goes RED."""
-    captured: dict = {}
-    monkeypatch.setattr(litellm, "acompletion", _capturing_acompletion(captured))
-
-    asyncio.run(recorded_acompletion(
-        model="gemini/gemini-2.5-flash-lite", messages=[{"role": "user", "content": "hi"}],
-        purpose="main", recorder=None,
-        extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
-    ))
-    assert captured["model"] == "gemini/gemini-2.5-flash-lite", (
-        "Gemini must NOT be routed through the OpenAI-specific /v1/responses bridge"
-    )
-
-
-def test_openai_reasoning_model_still_routed_direct_path(monkeypatch) -> None:
-    """Tier 2: #3288 follow-up REGRESSION gate — the direct (non-proxy) path
-    for a genuine OpenAI reasoning model is still bridged after adding the
-    provider gate. This is the risk of the fix: getting the provider check
-    wrong un-bridges a model that genuinely needs /v1/responses, which then
-    405s with no decision-enabling error (see
-    `test_responses_405_raises_decision_enabling_error` above)."""
-    captured: dict = {}
-    monkeypatch.setattr(litellm, "acompletion", _capturing_acompletion(captured))
-
-    asyncio.run(recorded_acompletion(
-        model="openai/gpt-5.4", messages=[{"role": "user", "content": "hi"}],
-        purpose="main", recorder=None,
-        extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
-    ))
-    assert captured["model"] == "openai/responses/gpt-5.4"
-
-
-def test_openai_reasoning_model_still_routed_proxy_path(monkeypatch) -> None:
-    """Tier 2: #3288 follow-up REGRESSION gate — the PROXY path (bare model
-    name post-strip, `custom_llm_provider` forced to "openai" on the wire by
-    `proxy_kwargs()`) is also still bridged. `_to_responses_model` has a
-    different branch for a bare (no-slash) model string than the direct path
-    above, so this is a distinct code path, not a duplicate of the direct-path
-    test. Also proves the provider gate is NOT fooled by (nor dependent on)
-    the proxy's forced `custom_llm_provider` — it derives the provider from
-    the model identity itself (`gpt-5.4` → openai), the same value it would
-    resolve to without a proxy configured at all."""
-    monkeypatch.setenv("LITELLM_API_BASE", "http://proxy.example:4000")
-    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
-    captured: dict = {}
-    monkeypatch.setattr(litellm, "acompletion", _capturing_acompletion(captured))
-
-    asyncio.run(recorded_acompletion(
-        model="openai/gpt-5.4", messages=[{"role": "user", "content": "hi"}],
-        purpose="main", recorder=None,
-        extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
-    ))
-    assert captured["model"] == "responses/gpt-5.4"
-
-
-def test_azure_reasoning_model_still_routed(monkeypatch) -> None:
-    """Tier 2: #3288 follow-up REGRESSION gate — co-vet finding (b) on PR
-    #3325: Azure is a first-class reyn provider (`credentials.py`'s
-    `"azure": "AZURE_API_KEY"`) that literally hosts OpenAI's reasoning
-    models, so it hits the SAME `/chat/completions` rejection this bridge
-    exists to route around. `azure/o1` already resolved through
-    `_to_responses_model` before this PR (no provider check existed), so
-    narrowing the gate to `openai` alone would have been a SILENT BEHAVIOR
-    CHANGE for Azure (un-bridging a model nobody verified doesn't need the
-    bridge). Strip `"azure"` out of `_responses_bridge_providers()` and this
-    assertion goes RED (falls back to the unbridged `azure/o1`)."""
-    captured: dict = {}
-    monkeypatch.setattr(litellm, "acompletion", _capturing_acompletion(captured))
-
-    asyncio.run(recorded_acompletion(
-        model="azure/o1", messages=[{"role": "user", "content": "hi"}],
-        purpose="main", recorder=None,
-        extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
-    ))
-    assert captured["model"] == "azure/responses/o1"
-
-
-def test_openrouter_openai_prefixed_model_is_not_routed(monkeypatch) -> None:
-    """Tier 2: #3288 follow-up — documents the deliberate exclusion co-vet
-    finding (b) asked about: an OpenRouter-routed model whose OWN model name
-    happens to embed an `openai/` segment (`openrouter/openai/gpt-5`) is NOT
-    bridged. `litellm.get_llm_provider` resolves this string's PROVIDER as
-    `"openrouter"` (not `"openai"`) — correctly: the HTTP call lands on
-    OpenRouter's own completions endpoint, never OpenAI's `/v1/responses`,
-    regardless of the embedded `openai/` segment naming OpenRouter's upstream
-    model. Bridging it would target an endpoint OpenRouter doesn't serve."""
-    captured: dict = {}
-    monkeypatch.setattr(litellm, "acompletion", _capturing_acompletion(captured))
-
-    asyncio.run(recorded_acompletion(
-        model="openrouter/openai/gpt-5", messages=[{"role": "user", "content": "hi"}],
-        purpose="main", recorder=None,
-        extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
-    ))
-    assert captured["model"] == "openrouter/openai/gpt-5"
-
-
-def test_gemini_405_via_proxy_is_not_wrapped_since_not_routed(monkeypatch) -> None:
-    """Tier 2: #3288 follow-up — a Gemini tools+reasoning_effort call that
-    405s (e.g. proxy quirk unrelated to /v1/responses) is NOT wrapped in
-    `ResponsesEndpointRequiredError`, since reyn never routed it through the
-    bridge in the first place (companion to `test_non_routed_405_is_not_wrapped`,
-    scoped to the provider-gate fix)."""
-    async def _raise_405(**_kwargs):
-        raise _FakeProviderError("Method Not Allowed", 405)
-    monkeypatch.setattr(litellm, "acompletion", _raise_405)
-
-    with pytest.raises(_FakeProviderError):
-        asyncio.run(recorded_acompletion(
-            model="gemini/gemini-2.5-flash-lite", messages=[{"role": "user", "content": "hi"}],
-            purpose="main", recorder=None,
-            extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
-        ))
-
-
-def test_openai_reasoning_405_still_raises_decision_enabling_error_after_gate(
-    monkeypatch,
-) -> None:
-    """Tier 2: #3288 follow-up — gate #4: a genuinely-bridged OpenAI call that
-    405s (proxy doesn't serve /v1/responses) still raises the
-    decision-enabling `ResponsesEndpointRequiredError` after the provider gate
-    was added — the 405-wrap path is itself gated on `_routed_to_responses`,
-    so this confirms the provider gate didn't collaterally break it for the
-    provider it must still cover."""
-    async def _raise_405(**_kwargs):
-        raise _FakeProviderError("Method Not Allowed", 405)
-    monkeypatch.setattr(litellm, "acompletion", _raise_405)
-
-    with pytest.raises(ResponsesEndpointRequiredError) as ei:
-        asyncio.run(recorded_acompletion(
-            model="openai/gpt-5.4", messages=[{"role": "user", "content": "hi"}],
-            purpose="main", recorder=None,
-            extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
-        ))
-    assert "/v1/responses" in str(ei.value)

--- a/uv.lock
+++ b/uv.lock
@@ -3839,7 +3839,7 @@ requires-dist = [
     { name = "landlock", marker = "extra == 'sandbox-linux'", specifier = ">=1.0.0.dev4" },
     { name = "line-bot-sdk", marker = "extra == 'all-samples'", specifier = ">=3.0" },
     { name = "line-bot-sdk", marker = "extra == 'sample-line'", specifier = ">=3.0" },
-    { name = "litellm", specifier = ">=1.0" },
+    { name = "litellm", specifier = ">=1.89.3" },
     { name = "markdown", marker = "extra == 'dev'", specifier = ">=3.6" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },


### PR DESCRIPTION
**[per-PR-coder]** — owner-approved deletion of reyn's manual `/v1/responses` bridge (#1678), delegating to litellm's own native routing. References #3288, #1678.

## Why

reyn's #1678 added a manual bridge: when a call combines `tools` + `reasoning_effort`, `_to_responses_model()` rewrote the model to `responses/<model>` so litellm routes to OpenAI's `/v1/responses` (which some reasoning models require for that combo, chat/completions 405s otherwise). The #3288 comment thread investigation (2026-07-26/27) found **litellm 1.89.3 — the version this repo pins — already does this natively** (`litellm/main.py::responses_api_bridge_check`, upstream `BerriAI/litellm#23577`, merged 2026-03-13, i.e. *before* #1678 was even filed).

**The asymmetry that decided it, not "litellm does it too":** reyn's own provider-allowlist bridge was *wider* than litellm's — it fired for every OpenAI/Azure reasoning model (`o1`, `o3-mini`, …), none of which were ever verified to need it, whereas litellm bridges narrower (currently gpt-5.4-family + tools + reasoning_effort, or `model_info.mode == "responses"`) and is upstream-maintained. A too-wide bridge is not the safe direction — it is *exactly* how the #3288 default-config streaming regression happened (Gemini's `tools + reasoning_effort` primary-reply shape silently rewritten to an unrecognized `responses/` model string, disabling streaming, fixed at #3325 by narrowing to a provider gate). Deleting reyn's gate replaces an unverified, frozen guess with a narrower, upstream-maintained decision — it is not "removing verified protection," since neither mechanism was ever verified for `o1`/`o3-mini`.

Offline evidence: `responses_api_bridge_check(model="gpt-5.4", custom_llm_provider="openai", tools=[...], reasoning_effort="low")` returns `mode="responses"` — litellm's own bridge fires for reyn's exact verified bug case, no `responses/` prefix needed. A live smoke (tui-coder, #3288 thread) additionally produced `/responses: Invalid model name passed in model=gpt-5.4` while reyn was **not** adding any prefix — direct evidence litellm's auto-bridge fires and targets `/responses` on a real proxy.

**What remains unproven** (reported honestly): the live smoke could not get a success-vs-405 verdict, because that proxy has no genuine OpenAI reasoning model registered (`/v1/models` showed only Gemini/embedding/qwen/gpt-oss) — so "litellm's bridge fires" is verified, "the call then succeeds end-to-end through it" is **not**. `o1`/`o3-mini`/`azure/o1`/`azure/o3-mini` + tools + reasoning_effort actually needing `/v1/responses` in practice was never confirmed by either mechanism (reyn included them unverified; litellm's `mode` doesn't bridge them either).

## What was removed

- `_to_responses_model`, `_requires_responses_bridge`, `_responses_bridge_providers`, and the `_routed_to_responses` model-rewrite in `src/reyn/llm/llm.py`. reyn now passes the resolved model straight to `litellm.acompletion` unchanged; litellm decides internally whether to route to `/v1/responses`.
- `tests/test_responses_api_routing_1678.py` — rewritten (not just stripped) to test the new contract: model passthrough for both OpenAI and Gemini shapes, an offline call into litellm's real `responses_api_bridge_check` proving it fires for the reyn-verified bug case, and the `ResponsesEndpointRequiredError` behavior below.
- `tests/test_llm_streaming_delta_emission_3288.py` — docstring updated (assertions unchanged/still green); it now also documents that the default-shaped Gemini call is guaranteed unmutated for a stronger reason (no rewrite at all, not "correctly gated").

**grep-zero** (repo-wide, not just src/tests) for `_to_responses_model`, `_routed_to_responses`, `_requires_responses_bridge`, `_responses_bridge_providers`:
```
$ grep -rn "_to_responses_model\|_routed_to_responses\|_requires_responses_bridge\|_responses_bridge_providers" . | grep -v '\.git/'
tests/test_responses_api_routing_1678.py:16:owner approval, reyn's manual bridge (`_to_responses_model`,
tests/test_responses_api_routing_1678.py:17:`_requires_responses_bridge`, `_responses_bridge_providers`, the
tests/test_responses_api_routing_1678.py:18:`_routed_to_responses` rewrite) was deleted; reyn now passes the resolved
```
Only historical prose in one test's module docstring — zero code references. `responses/` (the bridge marker string) and `ResponsesEndpointRequiredError` remain only in comments/prose explaining the history, plus the kept error class itself.

## ★ ResponsesEndpointRequiredError — kept (owner decision, not silently dropped)

Owner decision (issue #3288 comment thread, architect + lead-coder relay): **keep it**, because it is the safety net that makes deleting reyn's own (unverified) bridge reversible. If litellm's narrower routing coverage misses a model that genuinely needs `/v1/responses`, the operator now gets an ACTIONABLE 405 instead of a raw one — that's the difference between "safe to delete without proof" and "not safe to delete."

**Trigger changed**: previously gated on `_routed_to_responses` (reyn knowing it applied the rewrite). Since reyn no longer applies any rewrite, it can't know that anymore — so per the owner's explicit instruction ("誰がブリッジしたかに関係なく…呼び出し形状で判定"), the error is now re-triggered by **call SHAPE alone** (`tools` + `reasoning_effort` present) on any HTTP 405, **regardless of provider**. This is a deliberate widening versus the pre-deletion, provider-gated (#3325) error: a Gemini call shaped `tools + reasoning_effort` that 405s now also gets this guidance, not just OpenAI/Azure. Verified via `test_gemini_shaped_405_also_raises_decision_enabling_error` in the new test file.

Also documented in both `docs/reference/builtin-models.md` and `.ja.md`: **do not set `litellm.route_all_chat_openai_to_responses = True`** — that global opt-in (default `False`) would route *every* OpenAI chat call through `/v1/responses`, reproducing the #3288 regression for the entire OpenAI provider (not just reasoning+tools calls).

## Gates (strip-falsified, observed RED)

1. **Default-config path unaffected**: `test_default_shaped_gemini_call_actually_enters_the_streaming_branch` (`tests/test_llm_streaming_delta_emission_3288.py`) stays green, unweakened — Gemini + tools + reasoning_effort still streams via the real `chunk_witness` idiom.
2. **OpenAI-family `tools`+`reasoning_effort` still reaches `/responses` — offline evidence**: `test_openai_reasoning_combo_model_passed_through_unchanged` (model reaches `litellm.acompletion` unmodified) + `test_litellm_native_bridge_check_fires_for_reyn_verified_bug_shape` (calls litellm's real `responses_api_bridge_check` directly, asserts `mode == "responses"` for `gpt-5.4` + tools + reasoning_effort). **Marked unverified in the test docstring**: this does not prove the downstream call succeeds end-to-end — that needs a live `/v1/responses`-capable proxy, out of scope here.
3. **`ResponsesEndpointRequiredError` still fires on 405** for the tools+reasoning_effort shape — strip → RED:
   ```
   FAILED tests/test_responses_api_routing_1678.py::test_gemini_shaped_405_also_raises_decision_enabling_error
   FAILED tests/test_responses_api_routing_1678.py::test_openai_shaped_405_raises_decision_enabling_error
   ```
   (stripped `_needs_responses_endpoint` to `False`, ran, restored — raw `_FakeProviderError` propagated unwrapped instead of the decision-enabling error, confirming the gate is load-bearing for both provider shapes.)
4. **grep-zero** — shown above.

## litellm version floor

`pyproject.toml` pinned `litellm>=1.0` — far below the 1.89.3 this deletion depends on (the lockfile happened to resolve 1.89.3, but the floor allowed an operator to resolve an older litellm that lacks the native bridge, silently breaking this). **Raised to `litellm>=1.89.3`** with an inline comment explaining why. Re-ran `uv lock` — resolution unchanged (still 1.89.3), only the constraint metadata changed.

## Doc drift (same-PR)

`docs/reference/builtin-models.md` § "Reasoning on tool-bearing turns (Responses-API bridge)" fully rewritten to describe litellm-native delegation: why delegate (the width asymmetry above), the `route_all_chat_openai_to_responses` warning, and the `ResponsesEndpointRequiredError` safety-net framing. `docs/reference/builtin-models.ja.md` — same section rewritten in parallel (not a blanket mirror obligation, but this PR directly falsifies its existing claims, so fixed in the same PR per CLAUDE.md item 5).

## Non-negotiables run locally (targeted only, foreground)

- `uv run --active python -m pytest --timeout=120 -q` across `tests/test_responses_api_routing_1678.py` + `tests/test_llm_streaming_delta_emission_3288.py` (14 tests) and the full 26-file set that exercises `recorded_acompletion`/`_streaming_capable`/`from reyn.llm.llm` (665 tests total across 3 batches) — all green.
- `ruff check src tests` — all checks passed.
- `python scripts/test_tier_audit.py --strict tests/test_responses_api_routing_1678.py tests/test_llm_streaming_delta_emission_3288.py` — 14/14 OK, 0 Tier-4.
- `python scripts/verify_module_docstrings.py src/reyn/llm/llm.py` — OK.

## Test plan

- [x] `uv run --active python -m pytest --timeout=120 -q tests/test_responses_api_routing_1678.py tests/test_llm_streaming_delta_emission_3288.py` — green
- [x] Full 665-test targeted sweep across every file touching `recorded_acompletion`/`_streaming_capable` — green
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — clean
- [x] `python scripts/verify_module_docstrings.py src/reyn/llm/llm.py` — clean
- [x] (skipped — no UI/manual surface touched; all gates are unit-level against `recorded_acompletion` + offline litellm calls)
