### PR TITLE
chat.render_mode: plain is genuine --cui equivalence (renderer too) — #3292

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -373,9 +373,9 @@ terminal.
 
 | Value | Behaviour |
 |-------|-----------|
-| `alt-screen` | **Default.** Full-screen Textual (alt-screen driver). Terminal scrollback is auto-saved on enter and restored on exit; the previous conversation is rebuilt from `history.jsonl` on restart. This is the recommended mode — it sidesteps the upstream inline-driver bugs (stale frames stacking on resize, pane collapse) that `inline` still carries. |
-| `inline` | Legacy bounded inline driver — keeps your pre-launch scrollback in place above a bounded region. **Caveat**: this mode still carries upstream Textual inline-driver bugs (on resize old frames stack, and the conversation pane can collapse to ~1 line). Kept as an escape hatch for users who prefer scrollback-in-place; not recommended until those land upstream. |
-| `plain` | Force the plain line-based renderer (no Textual), equivalent to `--cui`. |
+| `alt-screen` | **Default.** Full-screen Textual (alt-screen driver). Terminal scrollback is auto-saved on enter and restored on exit; the previous conversation is rebuilt from `history.jsonl` on restart. This is the recommended mode. |
+| `inline` | Legacy bounded inline driver — keeps your pre-launch scrollback in place above a bounded region. **Caveat**: upstream reports Textual inline-driver bugs here (on resize old frames stack, and the conversation pane can collapse to ~1 line), but reyn's own live-TTY integration did not reproduce the resize-stacking bug across 4+ resizes in a real terminal ([witness](https://github.com/tya5/reyn/pull/3291#issuecomment-5081647531)) — treat this mode as not verified-broken but also not verified-clean. Kept as an escape hatch for users who prefer scrollback-in-place; `alt-screen` remains the recommended default. |
+| `plain` | Force the plain line-based renderer (`ConsoleChatRenderer`, no Textual), genuinely equivalent to `--cui` — same renderer and same input-loop driver, not just the input driver. |
 | `auto` | Resolve to `alt-screen` on a TTY (behaviourally identical to `alt-screen` given the non-TTY→`plain` guard). |
 
 An unrecognised value warns and falls back to `alt-screen`.

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -488,11 +488,16 @@ class ReasoningConfig:
 #   scrollback on enter/exit.
 # - ``inline``: the legacy bounded inline driver, kept as an escape hatch for
 #   users who prefer their pre-launch scrollback preserved in place above the
-#   region. CAVEAT: this mode still carries the upstream Textual inline-driver
-#   bugs #3285/#3286 (resize stacking + pane collapse); it is not the recommended
-#   default and will improve only when those land upstream.
+#   region. CAVEAT: upstream reports the Textual inline-driver bugs #3285
+#   (resize stacking) and #3286 (pane collapse) here, but reyn's own live-TTY
+#   integration did NOT reproduce #3285 across 4+ resizes in a real terminal
+#   (https://github.com/tya5/reyn/pull/3291#issuecomment-5081647531) — treat
+#   this mode as not verified-broken but also not verified-clean; it is still
+#   not the recommended default.
 # - ``plain``: force the plain ConsoleChatRenderer (no Textual), equivalent to
-#   ``--cui``.
+#   ``--cui`` (#3292: the renderer selection in ``chat.py`` forces this too,
+#   not only the input-driver choice ``client_driver.resolve_render_mode``
+#   makes — genuine equivalence, not a hybrid).
 # - ``auto``: resolve to ``alt-screen`` on a real TTY (identical to ``alt-screen``
 #   given the TTY guard, which falls any interactive mode back to ``plain`` off a
 #   TTY); provided as the Codex-style ``auto/always/never`` affordance.
@@ -504,9 +509,11 @@ class ChatConfig:
     """`chat:` — chat-session-specific runtime knobs.
 
     ``render_mode`` (#3273): selects the interactive chat renderer/driver —
-    ``alt-screen`` (default, full-screen), ``inline`` (legacy bounded driver,
-    carries upstream bugs #3285/#3286), ``plain`` (force ConsoleChatRenderer),
-    or ``auto`` (resolve to alt-screen on a TTY). A non-TTY session always falls
+    ``alt-screen`` (default, full-screen), ``inline`` (legacy bounded driver;
+    upstream reports bugs #3285/#3286 there, not reproduced live in reyn's own
+    integration — see the ``CHAT_RENDER_MODES`` comment above), ``plain``
+    (force ``ConsoleChatRenderer``, genuine ``--cui`` equivalence, #3292), or
+    ``auto`` (resolve to alt-screen on a TTY). A non-TTY session always falls
     back to ``plain`` regardless of this value (the interactive Textual drivers
     need a real terminal).
     """

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -240,6 +240,24 @@ def _inline_interactive(*, cui: bool, stdin_isatty: bool, stdout_isatty: bool) -
     return not cui and stdin_isatty and stdout_isatty
 
 
+def _renderer_is_interactive(*, is_interactive: bool, render_mode: str) -> bool:
+    """#3292: fold ``chat.render_mode`` into the renderer-selection predicate.
+
+    ``is_interactive`` (``_inline_interactive``: not ``--cui``, both std streams
+    TTYs) alone used to be the ONLY input to ``make_renderer``, which is why
+    ``chat.render_mode: plain`` on a TTY (without ``--cui``) previously kept the
+    interactive ``InlineChatRenderer`` selected — a hybrid (plain input loop,
+    interactive renderer output) that contradicted both the config's name and
+    its own doc's "equivalent to ``--cui``" claim
+    (https://github.com/tya5/reyn/pull/3291#issuecomment-5081647531). ``plain``
+    now forces the SAME ``ConsoleChatRenderer`` a real ``--cui`` invocation
+    gets — genuine equivalence, not a doc-only claim. Every other
+    ``render_mode`` value (``alt-screen`` / ``inline`` / ``auto``, or an
+    already-defaulted unknown value) leaves ``is_interactive`` untouched.
+    """
+    return is_interactive and render_mode != "plain"
+
+
 def _setup_interactive_logging(project_root: Path) -> None:
     """Route root-logger output to .reyn/logs/reyn.log for the interactive CUI.
 
@@ -595,7 +613,18 @@ def run(args: argparse.Namespace) -> None:
     # human-facing surface. --cui or a non-TTY (pipe / script / run-once) →
     # plain console output. Both drive the same run_repl loop; only the
     # renderer differs. The SAME make_renderer seam picks it on the remote path.
-    renderer = make_renderer(is_interactive)
+    #
+    # #3292: `chat.render_mode: plain` is genuine `--cui` equivalence, not a
+    # hybrid — see `_renderer_is_interactive`. `is_interactive` above stays
+    # cui+tty-only by design — it also gates the pre-config-load log redirect
+    # (#2208), computed before `session_cfg` is loaded, so it deliberately
+    # cannot see `render_mode`.
+    renderer = make_renderer(
+        _renderer_is_interactive(
+            is_interactive=is_interactive,
+            render_mode=session_cfg.config.chat.render_mode,
+        )
+    )
 
     async def _main_chat() -> None:
         # PR21: replay WAL into per-agent snapshots before any new state

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1736,18 +1736,25 @@ async def run_textual_chat(
     (:func:`~reyn.interfaces.repl.client_driver.run_chat_client`) resolves this
     from ``chat.render_mode`` (#3273) — see :func:`resolve_render_mode`.
 
-    Full-screen is the default because two inline-driver bugs made bounded inline
-    unshippable: on resize the old bounded frame is not cleared so stale copies
-    stack (#3285), and the conversation pane collapses to ~1 line regardless of
-    terminal height (#3286). Both are owned by Textual's inline driver, so reyn
-    cannot fix them in inline mode; alt-screen sidesteps the driver entirely and
-    both vanish. The scrollback-preservation rationale that originally motivated
-    inline is now redundant — alt-screen auto-saves/restores terminal scrollback
-    on enter/exit, and Phase 5 restore rebuilds the conversation from
-    ``history.jsonl`` on restart. ``inline=True`` remains selectable as an escape
-    hatch (``chat.render_mode: inline``) for scrollback-preferring users, with
-    the #3285/#3286 caveat. Returns so the driver's caller can tear the transport
-    down + print the cost summary.
+    Full-screen is the default because two inline-driver bugs upstream made
+    bounded inline unshippable: on resize the old bounded frame is not cleared
+    so stale copies stack (#3285), and the conversation pane collapses to ~1
+    line regardless of terminal height (#3286). Both are owned by Textual's
+    inline driver, so reyn cannot fix them in inline mode; alt-screen
+    sidesteps the driver entirely and both vanish there. #3286 is confirmed
+    live-reproduced against reyn's own integration; #3285 is reported upstream
+    but reyn's live-TTY integration did NOT reproduce the resize-stacking
+    across 4+ resizes in a real terminal
+    (https://github.com/tya5/reyn/pull/3291#issuecomment-5081647531) — treat
+    #3285-in-``inline`` as not verified-broken here but also not
+    verified-clean; re-check live before relying on either claim. The
+    scrollback-preservation rationale that originally motivated inline is now
+    redundant — alt-screen auto-saves/restores terminal scrollback on
+    enter/exit, and Phase 5 restore rebuilds the conversation from
+    ``history.jsonl`` on restart. ``inline=True`` remains selectable as an
+    escape hatch (``chat.render_mode: inline``) for scrollback-preferring
+    users; ``alt-screen`` stays the recommended default regardless. Returns so
+    the driver's caller can tear the transport down + print the cost summary.
     """
     app = TextualChatApp(
         transport=transport,

--- a/src/reyn/interfaces/repl/client_driver.py
+++ b/src/reyn/interfaces/repl/client_driver.py
@@ -55,12 +55,25 @@ def resolve_render_mode(mode: str, *, is_tty: bool) -> str:
     The TTY guard is universal: a non-TTY session (piped, CI, sandbox with no
     real terminal, or a host where alt-screen would silently no-op) can never
     enter an interactive Textual driver, so it always resolves to ``"plain"``
-    regardless of the configured mode. On a TTY: ``"plain"`` forces the plain
-    path (config equivalent of ``--cui``); ``"inline"`` selects the legacy
-    bounded inline driver (retains upstream bugs #3285/#3286); ``"auto"`` and
-    ``"alt-screen"`` both resolve to ``"alt-screen"`` (full-screen). An
-    unrecognised mode is treated as the ``alt-screen`` default — config parsing
-    already validates+warns, this is a belt-and-braces fallback.
+    regardless of the configured mode. On a TTY: ``"plain"`` resolves to the
+    plain path here too, but (#3292) that is now the SECOND of two gates —
+    ``chat.py``'s renderer selection already forces ``ConsoleChatRenderer``
+    whenever ``chat.render_mode`` is ``"plain"``, so ``renderer.uses_app_input()``
+    is already ``False`` and this function is never reached with an app-input
+    renderer on a standard ``reyn chat`` invocation; this branch is a
+    defensive fallback for any caller that reaches here with an app-input
+    renderer despite a ``"plain"`` config. The net effect (renderer forced
+    Console + this fallback) is genuine ``--cui`` equivalence, not a hybrid.
+    ``"inline"`` selects the legacy bounded inline driver — upstream reports
+    resize-frame-stacking (#3285) and pane-collapse (#3286) there, but reyn's
+    live-TTY integration did NOT reproduce #3285 across 4+ resizes in a real
+    terminal (tui-coder,
+    https://github.com/tya5/reyn/pull/3291#issuecomment-5081647531); treat
+    ``inline`` as **not verified-broken** here but **also not verified-clean**
+    — re-check live before citing either claim. ``"auto"`` and ``"alt-screen"``
+    both resolve to ``"alt-screen"`` (full-screen). An unrecognised mode is
+    treated as the ``alt-screen`` default — config parsing already
+    validates+warns, this is a belt-and-braces fallback.
     """
     if not is_tty:
         return "plain"
@@ -105,6 +118,14 @@ async def run_chat_client(
     A non-TTY session (``--cui`` / piped / CI / no real terminal) always resolves
     to ``plain`` regardless of mode. This is the SAME selection ``run_repl`` made
     locally — now applied identically to the remote path.
+
+    (#3292, local path only: the local ``reyn chat`` call site already forces
+    ``renderer`` to ``ConsoleChatRenderer`` — ``uses_app_input() is False`` —
+    whenever ``chat.render_mode`` is ``"plain"`` on a TTY, so this function's own
+    ``"plain"`` branch inside :func:`resolve_render_mode` is a defensive
+    fallback there, not the live path. The remote call site does not yet wire
+    ``chat.render_mode`` into its own renderer selection, so this function's
+    ``"plain"`` branch is still load-bearing for a remote invocation.)
 
     ``own_connection_id`` (#3287/#3309 F2): the REMOTE call site's own
     ``connection_id`` (``remote_client.py`` mints it client-side, before any

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -805,9 +805,18 @@ class InlineChatRenderer(ChatRenderer):
         self._waiting_on = _WAITING_ON_THINKING
         self._waiting_on_since = 0.0
         # #2280: same halt-reason surface as ConsoleChatRenderer — this
-        # renderer's own bottom_toolbar (below) is live when ``chat.render_mode``
-        # resolves ``"plain"`` on a TTY without the Textual app taking over
-        # (``client_driver.run_chat_client``).
+        # renderer's own bottom_toolbar (below) was live when ``chat.render_mode``
+        # resolved ``"plain"`` on a TTY without the Textual app taking over
+        # (``client_driver.run_chat_client``'s plain PromptSession loop wires
+        # ``bottom_toolbar=renderer.bottom_toolbar`` — see
+        # ``stream_client.run_input_loop``). #3292: that config value now
+        # selects ``ConsoleChatRenderer`` upstream instead (genuine ``--cui``
+        # equivalence). Since this class's ``uses_app_input()`` is always True
+        # (below), it now ALWAYS takes the Textual-app branch of
+        # ``run_chat_client`` and returns before reaching that loop — so this
+        # ``_halted_reason``/``bottom_toolbar`` machinery is presently dead in
+        # every production call site, kept as the class's own tested contract
+        # (defense-in-depth / future call-site safety net), not a live path.
         self._halted_reason: "str | None" = None
 
     def request_cancel(self) -> None:
@@ -849,20 +858,24 @@ class InlineChatRenderer(ChatRenderer):
             # intervention it was.
             self._set_waiting_on(_WAITING_ON_THINKING)
         elif etype == "user_submitted":
-            # #3300 P1 (C): only reachable when this renderer runs the shared
-            # plain PromptSession loop (``chat.render_mode: plain`` configured
-            # on an interactive TTY) — the default TTY path bypasses this
-            # renderer entirely for ``TextualChatApp`` (client_driver.py),
-            # which has its OWN ``user_submitted`` handler
-            # (``interfaces/inline/textual_chat/app.py``).
+            # #3300 P1 (C): before #3292, reachable when this renderer ran the
+            # shared plain PromptSession loop (``chat.render_mode: plain``
+            # configured on an interactive TTY, no ``--cui``) — the default TTY
+            # path bypasses this renderer entirely for ``TextualChatApp``
+            # (client_driver.py), which has its OWN ``user_submitted`` handler
+            # (``interfaces/inline/textual_chat/app.py``). #3292 made
+            # ``render_mode: plain`` select ``ConsoleChatRenderer`` upstream
+            # instead (genuine ``--cui`` equivalence), so this branch is
+            # presently unreached by any production call site — kept as this
+            # class's own tested contract, not a claim of live reachability.
             self.message(user_submitted_display_message(event))
         elif etype == "intervention_answer_submitted":
             # #3300: the last outbox `kind="user"` broadcast site
             # (InterventionHandler.deliver_answer_to) migrated to this
-            # chat-event — same render/neutralize idiom as user_submitted.
-            # Reachable on the SAME fallback condition noted above (plain
-            # render_mode on a TTY) — the default TTY path has its own
-            # handler (TextualChatApp._handle_intervention_answer_event).
+            # chat-event — same render/neutralize idiom as user_submitted, and
+            # the same #3292 now-unreached status (see the note above) — the
+            # default TTY path has its own handler
+            # (TextualChatApp._handle_intervention_answer_event).
             self.message(intervention_answer_display_message(event))
         elif etype == "session_halted":
             # #2280: the durability-halt observability surface — see

--- a/tests/test_2280_durability_halt_observability.py
+++ b/tests/test_2280_durability_halt_observability.py
@@ -16,12 +16,17 @@ once), and that it reaches every operator-facing surface:
     ``interfaces.inline.textual_chat.chrome.status_line_text`` surface the
     reason; a healthy session's status line carries no such text (negative
     control).
-  - Gate 3 (plain --cui): both LIVE plain-path renderers' ``bottom_toolbar``
-    (``ConsoleChatRenderer`` for ``--cui``; ``InlineChatRenderer`` — the class
-    ``make_inline_renderer()`` actually constructs, NOT the unwired legacy
-    ``RichChatRenderer`` — for ``chat.render_mode: plain`` on a TTY) surface
-    the reason once ``on_chat_event`` sees the event; a fresh renderer (no
-    event yet) shows nothing (negative control).
+  - Gate 3 (plain --cui): ``bottom_toolbar`` on both renderers surfaces the
+    reason once ``on_chat_event`` sees the event; a fresh renderer (no event
+    yet) shows nothing (negative control). ``ConsoleChatRenderer`` is the LIVE
+    ``--cui`` renderer (and, since #3292, also the LIVE renderer for
+    ``chat.render_mode: plain`` on a TTY without ``--cui`` — that config now
+    selects ``ConsoleChatRenderer`` too, not ``InlineChatRenderer``, genuine
+    ``--cui`` equivalence). ``InlineChatRenderer`` — the class
+    ``make_inline_renderer()`` constructs for the default interactive-TTY
+    path, NOT the unwired legacy ``RichChatRenderer`` sibling — is covered
+    here as a direct unit-level pin on its own ``bottom_toolbar`` contract,
+    not a claim that this exact fallback is live-reachable post-#3292.
   - Gate 4 (reachable-for-purpose, TUI app level): a real ``TextualChatApp``
     driven by a real halted registry/session + a transport that forwards the
     `session_halted` event proactively (no DISPLAY frame involved at all,
@@ -242,11 +247,14 @@ def test_console_renderer_bottom_toolbar_surfaces_halt() -> None:
 
 def test_inline_renderer_bottom_toolbar_surfaces_halt() -> None:
     """Tier 1: ``InlineChatRenderer`` — the class ``make_inline_renderer()``
-    actually constructs for the interactive-TTY path (used when
-    ``chat.render_mode: plain`` is configured on a TTY without ``--cui``, the
-    plain PromptSession loop per ``client_driver.run_chat_client``; the
-    legacy ``RichChatRenderer`` sibling class is never constructed by any
-    production call site) shows the same halt banner."""
+    actually constructs for the default interactive-TTY path (the legacy
+    ``RichChatRenderer`` sibling class is never constructed by any production
+    call site) — shows the same halt banner. Pre-#3292, this class was also
+    what ran the plain PromptSession loop when ``chat.render_mode: plain`` was
+    configured on a TTY without ``--cui``; #3292 made that config select
+    ``ConsoleChatRenderer`` instead (genuine ``--cui`` equivalence), so this
+    assertion is now a direct unit-level pin on ``bottom_toolbar``'s own
+    contract, not a claim about that specific fallback's live reachability."""
     renderer = InlineChatRenderer()
     assert renderer.bottom_toolbar() is None, "negative control: healthy renderer shows nothing"
     renderer.on_chat_event(Event(type="session_halted", data={"reason": "durability_failure"}))

--- a/tests/test_chat_render_mode_3273.py
+++ b/tests/test_chat_render_mode_3273.py
@@ -13,8 +13,16 @@ choices"). Two OS invariants are pinned here:
   resolves to ``plain`` regardless of mode (the interactive Textual drivers need a
   real terminal — this is the guard that keeps CI / piped / sandbox paths off the
   alt-screen driver). On a TTY each mode routes to its own path.
+- **renderer selection (#3292)**: :func:`~reyn.interfaces.cli.commands.chat.
+  _renderer_is_interactive` + :func:`~reyn.interfaces.cli.logger_factory.
+  make_renderer` prove ``chat.render_mode: plain`` on a TTY (no ``--cui``) now
+  selects the SAME ``ConsoleChatRenderer`` a real ``--cui`` invocation gets —
+  genuine equivalence, not the pre-#3292 hybrid where only the input driver
+  (this file's other tests) switched while the interactive renderer stayed
+  selected.
 
-Both are pure functions over real config dataclasses — no mocks.
+All are pure functions over real config dataclasses / real renderer instances —
+no mocks.
 """
 from __future__ import annotations
 
@@ -23,7 +31,10 @@ import warnings
 import pytest
 
 from reyn.config.chat import CHAT_RENDER_MODES, ChatConfig, _build_chat_config
+from reyn.interfaces.cli.commands.chat import _renderer_is_interactive
+from reyn.interfaces.cli.logger_factory import make_renderer
 from reyn.interfaces.repl.client_driver import resolve_render_mode
+from reyn.interfaces.repl.renderer import ConsoleChatRenderer, InlineChatRenderer
 
 
 def test_render_mode_default_is_alt_screen() -> None:
@@ -72,3 +83,53 @@ def test_tty_resolution_routes_each_mode() -> None:
     assert resolve_render_mode("plain", is_tty=True) == "plain"
     # Belt-and-braces: an unvalidated/unexpected mode on a TTY → alt-screen default.
     assert resolve_render_mode("something-else", is_tty=True) == "alt-screen"
+
+
+# ── #3292: chat.render_mode: plain is genuine --cui equivalence (renderer too) ──
+
+
+@pytest.mark.parametrize("render_mode", ["alt-screen", "inline", "auto", "bogus"])
+def test_renderer_is_interactive_stays_interactive_for_non_plain_modes(render_mode: str) -> None:
+    """Tier 2: negative control — every render_mode OTHER than "plain" leaves the
+    interactive-TTY renderer selection untouched (proves the "plain" branch below
+    is a targeted carve-out, not a predicate that happens to always return False)."""
+    assert _renderer_is_interactive(is_interactive=True, render_mode=render_mode) is True
+
+
+def test_renderer_is_interactive_plain_forces_non_interactive() -> None:
+    """Tier 2: chat.render_mode: plain on an otherwise-interactive TTY (no --cui)
+    now forces the SAME renderer selection a real --cui invocation gets — genuine
+    equivalence (#3292), not the pre-#3292 hybrid (plain input loop, interactive
+    renderer output)."""
+    assert _renderer_is_interactive(is_interactive=True, render_mode="plain") is False
+
+
+def test_renderer_is_interactive_noop_when_already_noninteractive() -> None:
+    """Tier 2: render_mode is irrelevant once --cui / a non-TTY already selected
+    the non-interactive path — no render_mode value can flip it back on."""
+    for render_mode in (*CHAT_RENDER_MODES, "bogus"):
+        assert _renderer_is_interactive(is_interactive=False, render_mode=render_mode) is False
+
+
+def test_make_renderer_plain_yields_console_renderer_not_inline() -> None:
+    """Tier 2: the concrete-class witness for #3292 — feeding
+    _renderer_is_interactive's plain-mode result into the SAME make_renderer seam
+    chat.py's run() calls yields ConsoleChatRenderer (the real --cui renderer),
+    never InlineChatRenderer. Negative control below pins the interactive branch
+    still yields InlineChatRenderer, so this isn't a seam that always returns
+    ConsoleChatRenderer."""
+    renderer = make_renderer(
+        _renderer_is_interactive(is_interactive=True, render_mode="plain")
+    )
+    assert isinstance(renderer, ConsoleChatRenderer)
+    assert not isinstance(renderer, InlineChatRenderer)
+
+
+def test_make_renderer_default_interactive_still_yields_inline_renderer() -> None:
+    """Tier 2: negative control for the test above — an interactive TTY with the
+    default render_mode still gets the Claude Code-style InlineChatRenderer, so
+    the #3292 carve-out is specific to "plain", not a general regression."""
+    renderer = make_renderer(
+        _renderer_is_interactive(is_interactive=True, render_mode="alt-screen")
+    )
+    assert isinstance(renderer, InlineChatRenderer)

--- a/tests/test_user_submitted_render_3300.py
+++ b/tests/test_user_submitted_render_3300.py
@@ -9,8 +9,14 @@ time — this file proves that per surface:
 - ``ConsoleChatRenderer.on_chat_event`` (the plain / --cui / non-TTY path,
   ALSO the remote/agui path when it resolves non-interactive — same renderer
   selection seam, ``logger_factory.make_renderer``).
-- ``InlineChatRenderer.on_chat_event`` (the ``chat.render_mode: plain``-on-a-
-  TTY fallback — reachable only when the Textual app is bypassed).
+- ``InlineChatRenderer.on_chat_event`` — before #3292 this was the
+  ``chat.render_mode: plain``-on-a-TTY fallback (reachable when the Textual
+  app was bypassed but the interactive renderer stayed selected). #3292 made
+  ``render_mode: plain`` force ``ConsoleChatRenderer`` too (genuine ``--cui``
+  equivalence, not a hybrid), so this branch is no longer reachable through
+  any current production call site's config alone; the coverage below is
+  retained as a direct unit-level pin on ``on_chat_event``'s own contract
+  (defense-in-depth, not a claim of live reachability).
 - ``TextualChatApp._pump_frames`` (the default interactive-TTY surface,
   ``interfaces/inline/textual_chat/app.py``) — #3300 P2b REPLACES the direct-
   to-flow append this file originally pinned with the sent-queue "upward
@@ -236,15 +242,22 @@ def test_console_renderer_neutralizes_at_render(monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Surface: InlineChatRenderer (chat.render_mode=plain-on-a-TTY fallback path)
+# Surface: InlineChatRenderer — pre-#3292 this was the
+# chat.render_mode=plain-on-a-TTY fallback path; #3292 made that config value
+# select ConsoleChatRenderer instead (genuine --cui equivalence), so this
+# on_chat_event contract is no longer reachable via config alone. Coverage
+# kept as a direct unit-level pin, not a live-reachability claim.
 # ---------------------------------------------------------------------------
 
 
 def test_inline_renderer_renders_user_submitted_event(monkeypatch) -> None:
     """Tier 2: InlineChatRenderer.on_chat_event renders the user line from a
-    "user_submitted" event — the ONLY renderer entry point reachable when
-    this class runs the shared plain PromptSession loop instead of the
-    default TextualChatApp (client_driver.py: resolved render_mode="plain")."""
+    "user_submitted" event. Pre-#3292 this was the ONLY renderer entry point
+    reachable when this class ran the shared plain PromptSession loop instead
+    of the default TextualChatApp; #3292 made ``chat.render_mode: plain``
+    select ``ConsoleChatRenderer`` instead, so this is now a direct
+    unit-level contract pin on the method, not a claim of production
+    reachability."""
     out = _capture_stdout(monkeypatch)
     r = InlineChatRenderer()
     event = Event(type="user_submitted", data={"text": "hello inline", "meta": {}})


### PR DESCRIPTION
**[per-PR-coder]** — part of #3292. Implements both items from the issue.

## Item 1 — `render_mode: plain` ≠ `--cui` (decision: option a, genuine equivalence)

`chat.render_mode: plain` on a TTY (no `--cui`) previously kept the
interactive `InlineChatRenderer` selected — `client_driver.resolve_render_mode`
only gated the **input driver** (Textual app vs. plain `PromptSession` loop),
not the **renderer** `chat.py` picks upstream via `make_renderer`/`_inline_interactive`.
So `plain` without `--cui` was a hybrid: plain input loop + the interactive
renderer's own `banner()`/`on_chat_event` output — contradicting both the
config's name and its own doc's "equivalent to `--cui`" claim (witness:
https://github.com/tya5/reyn/pull/3291#issuecomment-5081647531).

Fix: `src/reyn/interfaces/cli/commands/chat.py` adds a small pure predicate
`_renderer_is_interactive(is_interactive, render_mode)` — `is_interactive`
(the existing `--cui`+TTY gate) ANDed with `render_mode != "plain"` — used at
the `make_renderer(...)` call site. `render_mode: plain` on a TTY now selects
`ConsoleChatRenderer`, exactly what `--cui` selects, so `renderer.uses_app_input()`
is `False` and `run_chat_client` never even reaches the Textual-app branch —
same renderer AND same input loop as `--cui`.

`is_interactive` itself (used earlier, pre-config-load, to gate the #2208 log
redirect) is deliberately left untouched — it's computed before `session_cfg`
(and therefore `render_mode`) is available, so it stays `--cui`+TTY-only by
design; only the later renderer-selection call site sees `render_mode`.

### Consumer audit (full-repo grep for `render_mode`, not just src/tests)

`grep -rn "render_mode"` across the whole repo (src, tests, docs) turned up:
- `src/reyn/config/chat.py` — the config field + `CHAT_RENDER_MODES` comment
  block + `ChatConfig` docstring. Updated to describe the new behaviour.
- `src/reyn/interfaces/repl/client_driver.py` — `resolve_render_mode` +
  `run_chat_client` docstrings. Updated: `"plain"`'s branch there is now a
  defensive fallback for the local path (renderer is already forced
  upstream) but is still load-bearing for the **remote** path (`_run_remote`
  in `chat.py` does not wire `chat.render_mode` into its own renderer
  selection at all — pre-existing gap, out of scope here, called out in the
  docstring so it isn't silently assumed fixed).
- `src/reyn/interfaces/repl/renderer.py` — `InlineChatRenderer`'s
  `_halted_reason`/`bottom_toolbar` init comment and its
  `user_submitted`/`intervention_answer_submitted` `on_chat_event` branches
  all had comments claiming reachability "when `chat.render_mode: plain` is
  configured on a TTY". Since `InlineChatRenderer.uses_app_input()` is always
  `True`, and that renderer is now only ever selected when `render_mode !=
  "plain"`, these branches are presently **dead code** in every production
  call site (kept as the class's own tested unit-level contract, not
  removed — that's a larger refactor than this issue asked for). Comments
  corrected to say so explicitly rather than claim a reachability that no
  longer holds.
- `src/reyn/interfaces/inline/textual_chat/app.py` — `run_textual_chat`'s
  docstring references `chat.render_mode` for the `inline=` selection; only
  the #3285 claim needed correcting (see item 2).
- `docs/reference/config/reyn-yaml.md` — the `chat.render_mode` table.
  Updated the `plain` row (now literally true, was previously an
  aspirational/false doc claim) and the `inline` row (item 2).
- `docs/reference/runtime/agui-transport.md` / `.ja.md` — reference
  `chat.render_mode: plain` only in the context of "which loop owns the
  input echo" (`stream_client.py`'s plain `PromptSession` loop). That claim
  was already true before AND after this fix (the input-loop half of
  `render_mode: plain` was never wrong) — no change needed.
- `tests/test_2280_durability_halt_observability.py`,
  `tests/test_user_submitted_render_3300.py` — module/test docstrings
  asserting the pre-fix hybrid was the live path for
  `InlineChatRenderer.bottom_toolbar` / `on_chat_event`. Corrected to note
  the behaviour changed and the coverage is now a unit-level contract pin,
  not a production-reachability claim.
- `_run_remote` (`chat.py`) does not load/pass `chat.render_mode` into its
  own renderer selection at all currently (pre-existing, unrelated gap) —
  left as-is; only the local `run()` path is in scope per the issue.

## Item 2 — `inline` comment/behaviour discrepancy

`client_driver.py`'s `resolve_render_mode` docstring asserted inline
"retains upstream bugs #3285/#3286" as flat fact. tui-coder's real-TTY
witness on #3291 confirmed **#3286** (pane collapse) live, but could **not**
reproduce **#3285** (resize-frame-stacking) in reyn's actual integration
across 4+ resizes (slow and rapid), despite an earlier *standalone*
minimal-Textual repro reproducing it reliably on the same `textual==8.2.8`.

Per the brief, this is NOT rewritten as "the bug is absent" — a
non-reproduction in one environment doesn't prove absence. The comment (and
its mirrors in `config/chat.py`, `renderer.py`... actually
`textual_chat/app.py`, and `docs/reference/config/reyn-yaml.md`) now say:
upstream reports the behaviour; reyn's live-TTY integration did not
reproduce it over 4+ resizes in a real terminal; the mode is therefore
**not known-broken** but **not verified-clean** either — re-check live
before citing either claim in a future decision. Witness cited:
https://github.com/tya5/reyn/pull/3291#issuecomment-5081647531

## Verification

New gate: `tests/test_chat_render_mode_3273.py` —
`test_renderer_is_interactive_plain_forces_non_interactive` +
`test_make_renderer_plain_yields_console_renderer_not_inline` witness that
`render_mode: plain` on a TTY (no `--cui`) now yields `ConsoleChatRenderer`.
Negative controls in the SAME file
(`test_renderer_is_interactive_stays_interactive_for_non_plain_modes`,
`test_make_renderer_default_interactive_still_yields_inline_renderer`,
`test_renderer_is_interactive_noop_when_already_noninteractive`) pin that
every other `render_mode` value, and the already-non-interactive case, are
unaffected.

**Strip-falsify**: reverted `return is_interactive and render_mode != "plain"`
→ `return is_interactive` in `_renderer_is_interactive`. Confirmed the strip
anchor (`render_mode != "plain"`) was unique first (`grep -c` → `1`).
Re-ran the targeted test file: 2 of 10 tests went RED as expected
(`test_renderer_is_interactive_plain_forces_non_interactive`,
`test_make_renderer_plain_yields_console_renderer_not_inline`); the negative
controls stayed green (as they must — they don't depend on the branch being
struck). Restored the fix; all 10 tests green again.

## Test plan

- [x] `ruff check src tests` — all checks passed
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 29
      tests inspected, 0 Tier-4 violations
- [x] Targeted `pytest` (changed-file tests +
      `test_agui_profile_completeness.py` + `test_outbox_vocabulary.py` per
      reviewer instruction, full suite deferred to CI) — 59 passed
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] Strip-falsify with unique-anchor verification (above)
- [x] Full-repo `render_mode` consumer grep (above)
