### PR TITLE
feat(tui): per-turn token split in the right gutter — #3283 ④ remainder

### DIFF
--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -298,17 +298,19 @@ Capability-gated, provider-agnostic token streaming from the LLM call through to
 
 > **Differentiation vs general agents:** streaming is layered onto the SAME single-chokepoint `recorded_acompletion` call, the SAME `OutboxHub`/chat-event fan-out, and the SAME `FlowView` render model every other frame uses — no parallel streaming-only pipeline, no per-provider hardcoding, and no risk of a streamed reply diverging from its non-streamed reconstruction.
 
-#### Textual TUI: state + timing gutters (#3283 ①②④)
+#### Textual TUI: state + timing/cost gutters (#3283 ①②④)
 
 Two fixed-width `FlowView` columns per row: the left keeps entry STATE, the
-right shows per-entry ELAPSED TIME — the only right-gutter content set with
-real per-entry source data (turn cost/tokens are cumulative-only; a state
-chip would duplicate the left gutter).
+right shows per-entry ELAPSED TIME plus the row's TURN's real tokens+cost. A
+state chip, the third candidate, stays dropped — it would duplicate the left
+gutter. Neither right-gutter figure is ever fabricated: a row whose turn the
+runtime cannot price renders `—`, never `0`.
 
 | Feature | Description | Documentation |
 |---------|-------------|---------------|
-| Left gutter — state-coloured glyph (#3273, #3283 ①) | Kind-driven glyph, `EntryState`-driven colour (RUNNING amber / SUCCESS green / ERROR coral / CANCELLED dim); a RUNNING glyph blinks off flowview's native `animation_fps` clock, no app-side timer | [AG-UI transport § Textual TUI gutters](reference/runtime/agui-transport.md#textual-tui-gutters--state-left--elapsed-time-right-3283-124) |
-| Right gutter — per-entry elapsed time (#3283 ④) | A tool-call row shows its LIVE elapsed while RUNNING or its captured FINAL elapsed once SETTLED, via flowview's additive `right_decorator`/`right_gutter_width`; every other entry (user/agent/intervention, and any RESTORED row) shows nothing — no fabricated per-entry cost/token, no duplicated state chip | [AG-UI transport § Textual TUI gutters](reference/runtime/agui-transport.md#textual-tui-gutters--state-left--elapsed-time-right-3283-124) |
+| Left gutter — state-coloured glyph (#3273, #3283 ①) | Kind-driven glyph, `EntryState`-driven colour (RUNNING amber / SUCCESS green / ERROR coral / CANCELLED dim); a RUNNING glyph blinks off flowview's native `animation_fps` clock, no app-side timer | [AG-UI transport § Textual TUI gutters](reference/runtime/agui-transport.md#textual-tui-gutters--state-left--elapsed-timeturn-cost-right-3283-124) |
+| Right gutter — per-entry elapsed time (#3283 ④) | A tool-call row shows its LIVE elapsed while RUNNING or its captured FINAL elapsed once SETTLED, via flowview's additive `right_decorator`/`right_gutter_width`; every other entry (user/agent/intervention, and any RESTORED row) shows nothing — no placeholder, no `"0s"` | [AG-UI transport § Textual TUI gutters](reference/runtime/agui-transport.md#textual-tui-gutters--state-left--elapsed-timeturn-cost-right-3283-124) |
+| Right gutter — per-turn cost/token (#3283 ④) | The agent-reply row that concludes a turn shows that turn's real tokens + USD, read by `chain_id` through `BudgetTracker`'s bounded per-turn buckets (#3339's source-captured attribution) — one figure per turn, never repeated per row and never differenced out of cumulative counters. A row naming a turn with no held figure (no LLM call, evicted bucket, unknown `chain_id`, or a remote client where the buckets are not on the wire) renders `—`, never `0`; a restored conversation shows no figures at all rather than reconstructed ones | [AG-UI transport § Textual TUI gutters](reference/runtime/agui-transport.md#textual-tui-gutters--state-left--elapsed-timeturn-cost-right-3283-124) |
 
 > **Unstarted direction (#3283 ⑤, not yet designed or scoped):** a LIVE dashboard surface outside the conversation pane — `reyn events` live replay, a multi-session monitor, a cost dashboard — built on flowview's `dashboard.py`/`compare.py` example patterns. This would be a Reyn-internal live view over the SAME `reyn events` audit-event log the rest of the OS already emits, not the external, queryable-database/time-series/alerting "observability dashboard" [Care boundary § Concrete examples from the landscape (Observability dashboards)](concepts/architecture/care-boundary.md#concrete-examples-from-the-landscape) deliberately keeps out of scope — that boundary is about NOT shipping BI-style cross-run aggregation infrastructure, not about the TUI never rendering a live in-process view of its own events.
 

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -298,19 +298,19 @@ Capability-gated, provider-agnostic token streaming from the LLM call through to
 
 > **Differentiation vs general agents:** streaming is layered onto the SAME single-chokepoint `recorded_acompletion` call, the SAME `OutboxHub`/chat-event fan-out, and the SAME `FlowView` render model every other frame uses — no parallel streaming-only pipeline, no per-provider hardcoding, and no risk of a streamed reply diverging from its non-streamed reconstruction.
 
-#### Textual TUI: state + timing/cost gutters (#3283 ①②④)
+#### Textual TUI: state + timing/token gutters (#3283 ①②④)
 
 Two fixed-width `FlowView` columns per row: the left keeps entry STATE, the
-right shows per-entry ELAPSED TIME plus the row's TURN's real tokens+cost. A
-state chip, the third candidate, stays dropped — it would duplicate the left
-gutter. Neither right-gutter figure is ever fabricated: a row whose turn the
-runtime cannot price renders `—`, never `0`.
+right shows per-entry ELAPSED TIME plus the row's TURN's real prompt/completion
+token split. A state chip, the third candidate, stays dropped — it would
+duplicate the left gutter. Neither right-gutter figure is ever fabricated: a row
+whose turn the runtime holds no figure for renders `—`, never `0`.
 
 | Feature | Description | Documentation |
 |---------|-------------|---------------|
-| Left gutter — state-coloured glyph (#3273, #3283 ①) | Kind-driven glyph, `EntryState`-driven colour (RUNNING amber / SUCCESS green / ERROR coral / CANCELLED dim); a RUNNING glyph blinks off flowview's native `animation_fps` clock, no app-side timer | [AG-UI transport § Textual TUI gutters](reference/runtime/agui-transport.md#textual-tui-gutters--state-left--elapsed-timeturn-cost-right-3283-124) |
-| Right gutter — per-entry elapsed time (#3283 ④) | A tool-call row shows its LIVE elapsed while RUNNING or its captured FINAL elapsed once SETTLED, via flowview's additive `right_decorator`/`right_gutter_width`; every other entry (user/agent/intervention, and any RESTORED row) shows nothing — no placeholder, no `"0s"` | [AG-UI transport § Textual TUI gutters](reference/runtime/agui-transport.md#textual-tui-gutters--state-left--elapsed-timeturn-cost-right-3283-124) |
-| Right gutter — per-turn cost/token (#3283 ④) | The agent-reply row that concludes a turn shows that turn's real tokens + USD, read by `chain_id` through `BudgetTracker`'s bounded per-turn buckets (#3339's source-captured attribution) — one figure per turn, never repeated per row and never differenced out of cumulative counters. A row naming a turn with no held figure (no LLM call, evicted bucket, unknown `chain_id`, or a remote client where the buckets are not on the wire) renders `—`, never `0`; a restored conversation shows no figures at all rather than reconstructed ones | [AG-UI transport § Textual TUI gutters](reference/runtime/agui-transport.md#textual-tui-gutters--state-left--elapsed-timeturn-cost-right-3283-124) |
+| Left gutter — state-coloured glyph (#3273, #3283 ①) | Kind-driven glyph, `EntryState`-driven colour (RUNNING amber / SUCCESS green / ERROR coral / CANCELLED dim); a RUNNING glyph blinks off flowview's native `animation_fps` clock, no app-side timer | [AG-UI transport § Textual TUI gutters](reference/runtime/agui-transport.md#textual-tui-gutters--state-left--elapsed-timeturn-tokens-right-3283-124) |
+| Right gutter — per-entry elapsed time (#3283 ④) | A tool-call row shows its LIVE elapsed while RUNNING or its captured FINAL elapsed once SETTLED, via flowview's additive `right_decorator`/`right_gutter_width`; every other entry (user/agent/intervention, and any RESTORED row) shows nothing — no placeholder, no `"0s"` | [AG-UI transport § Textual TUI gutters](reference/runtime/agui-transport.md#textual-tui-gutters--state-left--elapsed-timeturn-tokens-right-3283-124) |
+| Right gutter — per-turn token split (#3283 ④) | The agent-reply row that concludes a turn shows that turn's real prompt/completion token split (`↑12k ↓1.8k`), read by `chain_id` through `BudgetTracker`'s bounded per-turn buckets (#3339's source-captured attribution, extended with the split) — one figure per turn, never repeated per row and never differenced out of cumulative counters. A row naming a turn with no held figure (no LLM call, evicted bucket, unknown `chain_id`, or a remote client where the buckets are not on the wire) renders `—`, never `0`, and a turn that really used 0 renders `↑0 ↓0`; a restored conversation shows no figures at all rather than reconstructed ones. The turn's USD cost is returned by the lookup but deliberately not drawn in this column | [AG-UI transport § Textual TUI gutters](reference/runtime/agui-transport.md#textual-tui-gutters--state-left--elapsed-timeturn-tokens-right-3283-124) |
 
 > **Unstarted direction (#3283 ⑤, not yet designed or scoped):** a LIVE dashboard surface outside the conversation pane — `reyn events` live replay, a multi-session monitor, a cost dashboard — built on flowview's `dashboard.py`/`compare.py` example patterns. This would be a Reyn-internal live view over the SAME `reyn events` audit-event log the rest of the OS already emits, not the external, queryable-database/time-series/alerting "observability dashboard" [Care boundary § Concrete examples from the landscape (Observability dashboards)](concepts/architecture/care-boundary.md#concrete-examples-from-the-landscape) deliberately keeps out of scope — that boundary is about NOT shipping BI-style cross-run aggregation infrastructure, not about the TUI never rendering a live in-process view of its own events.
 

--- a/docs/reference/config/budget.md
+++ b/docs/reference/config/budget.md
@@ -239,19 +239,28 @@ cost" is answerable without subtracting running totals from each other.
   record of a past turn's spend is the ledger's per-call `chain_id`, which
   lets any past turn be re-grouped after the fact.
 
-A turn total can be read either **by key** — "what did *this* turn cost", given
-its `chain_id` — or as **"whatever ran last"**, process-wide. The keyed read is
-what a per-row surface uses: the TUI's right gutter prices each agent-reply row
-against the turn that produced it, for rows scrolled arbitrarily far back, so it
-necessarily asks about turns old enough to have been evicted.
+A turn's figures are its **total tokens**, the **prompt / completion split** of
+that total, and its **USD cost**. The split is accumulated at the call alongside
+the total (it is in `TokenUsage`) rather than derived afterwards — the same
+reason the turn key itself is captured there.
 
-When there is no per-turn figure to report the reported tokens and cost are
-**unknown** rather than `0`. A zero would be indistinguishable from a turn that
-genuinely cost nothing, and a renderer that forgot to branch would print it as
-fact. "No figure" covers: before a session's first turn; a turn that made no LLM
-call; a turn evicted from the bounded buckets; a `chain_id` this process never
-saw; and a remote client, where the per-turn buckets are session-local and not
-projected onto the AG-UI wire.
+They can be read either **by key** — "what did *this* turn use", given its
+`chain_id` — or as **"whatever ran last"**, process-wide; both return the same
+shape. The keyed read is what a per-row surface uses: the TUI's right gutter
+labels each agent-reply row with the token split of the turn that produced it
+(`↑prompt ↓completion`), for rows scrolled arbitrarily far back, so it
+necessarily asks about turns old enough to have been evicted. That gutter
+deliberately does not draw the USD figure — a presentation choice at the gutter,
+not a gap in the data; `/cost` and the status line remain the spend surfaces.
+
+When there is no per-turn figure to report, every reported value is **unknown**
+rather than `0`. A zero would be indistinguishable from a turn that genuinely
+used nothing / cost nothing — which is reachable, not hypothetical — and a
+renderer that forgot to branch would print it as fact. "No figure" covers:
+before a session's first turn; a turn that made no LLM call; a turn evicted from
+the bounded buckets; a `chain_id` this process never saw; and a remote client,
+where the per-turn buckets are session-local and not projected onto the AG-UI
+wire.
 
 These figures are not a cap dimension — there is no per-turn limit to
 configure; they are the reporting counterpart to the per-agent / daily /

--- a/docs/reference/config/budget.md
+++ b/docs/reference/config/budget.md
@@ -235,16 +235,23 @@ cost" is answerable without subtracting running totals from each other.
   total. That is by design, not a rounding gap.
 - Turn totals are in-memory, live-session state for the most recent turns
   (bounded, oldest evicted) and are not restored on restart. An evicted turn
-  is **absent**, never reported as a zero total, and the live figure is only
-  ever read for the **latest** turn — which can never be the eviction victim.
-  The durable record of a past turn's spend is the ledger's per-call
-  `chain_id`, which lets any past turn be re-grouped after the fact.
+  is **absent** — reported as **unknown**, never as a zero total. The durable
+  record of a past turn's spend is the ledger's per-call `chain_id`, which
+  lets any past turn be re-grouped after the fact.
 
-When there is no per-turn figure to report — before a session's first turn,
-or when the most recent turn tracked belongs to another session sharing the
-same process-wide tracker — the reported tokens and cost are **unknown**
-rather than `0`. A zero would be indistinguishable from a turn that genuinely
-cost nothing.
+A turn total can be read either **by key** — "what did *this* turn cost", given
+its `chain_id` — or as **"whatever ran last"**, process-wide. The keyed read is
+what a per-row surface uses: the TUI's right gutter prices each agent-reply row
+against the turn that produced it, for rows scrolled arbitrarily far back, so it
+necessarily asks about turns old enough to have been evicted.
+
+When there is no per-turn figure to report the reported tokens and cost are
+**unknown** rather than `0`. A zero would be indistinguishable from a turn that
+genuinely cost nothing, and a renderer that forgot to branch would print it as
+fact. "No figure" covers: before a session's first turn; a turn that made no LLM
+call; a turn evicted from the bounded buckets; a `chain_id` this process never
+saw; and a remote client, where the per-turn buckets are session-local and not
+projected onto the AG-UI wire.
 
 These figures are not a cap dimension — there is no per-turn limit to
 configure; they are the reporting counterpart to the per-agent / daily /

--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -627,7 +627,7 @@ observer via `FlowView.on_flow_clear`. The completion's own final write is NOT
 visibility-gated: the authoritative full text lands whether or not the row is
 on screen.
 
-### Textual TUI gutters — state (left) + elapsed time (right) (#3283 ①②④)
+### Textual TUI gutters — state (left) + elapsed time/turn cost (right) (#3283 ①②④)
 
 The Textual TUI's `FlowView` (`interfaces/inline/textual_chat`) paints TWO
 fixed-width columns per row, both driven by flowview's `FlowDecorator`
@@ -642,23 +642,38 @@ second hand-rolled column:
   (`int(clock() / frame_period)`) that flowview's own
   `FlowView(animation_fps=N)` re-invokes on each animation tick — no
   app-side timer (#3283 ①, native-blink equivalence).
-- **RIGHT gutter — `ReynTimingGutter`** (`gutter.py`, #3283 ④): a per-entry
-  ELAPSED-TIME label (`Ns`/`Nm`/`Nh`), wired via flowview's additive
-  `right_decorator`/`right_gutter_width` params. **Content set — elapsed
-  time only**, decided against what data actually exists (owner-adjudicated
-  on #3283, issue thread): turn cost/tokens are CUMULATIVE-ONLY in
-  `BudgetTracker` (no per-turn/per-entry source — showing one would be a
-  fabricated per-entry number) and a dedicated state chip would duplicate
-  the left gutter's existing `EntryState` encoding. Only a tool-call entry
-  that actually has timing data shows a label — LIVE while RUNNING (read off
-  the same start marker the ② live-spinner body uses), or the FINAL captured
-  duration once SETTLED (stashed at settle time, before the live marker is
-  stripped). Every other entry — user/agent lines, interventions, and ANY
-  RESTORED row — renders an empty right-gutter cell: no placeholder, no
-  `"0s"`. **Restore is live-session-only by decision**: a persisted
-  `ChatMessage` carries no timing field at all, and widening that persisted
-  shape was judged out of proportion to a TUI gutter decoration — a restored
-  tool row's right gutter is always blank, never a reconstructed value.
+- **RIGHT gutter — `ReynRightGutter`** (`gutter.py`, #3283 ④): one column, two
+  label families, wired via flowview's additive
+  `right_decorator`/`right_gutter_width` params. flowview takes a single right
+  decorator, so this class composes two single-purpose halves and joins
+  whatever is non-empty:
+  - **`ReynTimingGutter` — per-entry ELAPSED time** (`Ns`/`Nm`/`Nh`). Only a
+    tool-call entry that actually has timing data shows a label — LIVE while
+    RUNNING (read off the same start marker the ② live-spinner body uses), or
+    the FINAL captured duration once SETTLED (stashed at settle time, before
+    the live marker is stripped).
+  - **`ReynTurnUsageGutter` — the row's turn's real TOKENS + USD COST**
+    (`1.9k $0.03`), anchored to the `kind="agent"` reply row: the row that
+    concludes a turn's visible output, one figure per turn rather than the same
+    total repeated on every row of the turn. Read through a keyed lookup over
+    `BudgetTracker`'s bounded per-turn buckets (`BudgetTracker.turn_usage` via
+    `Session.turn_usage`, reached from the status snapshot's `turn_usage_fn`) —
+    the per-turn attribution #3339 captured at the source. **Never derived by
+    differencing cumulative counters.** A row that NAMES a turn
+    (`meta["chain_id"]`) whose figure the runtime does not hold renders `—`,
+    never `0`: a turn that made no LLM call, a turn EVICTED from the bounded
+    buckets, an unknown chain_id, and a REMOTE client (per-turn buckets are
+    session-local and not projected onto the wire — `turn_usage_fn` is `None`
+    there, the same frame-sufficiency boundary as the past-turn log).
+
+  A dedicated state chip, the umbrella issue's third candidate, stays dropped:
+  it would duplicate the left gutter's existing `EntryState` encoding.
+  A row with no data in either family renders an empty cell — no placeholder,
+  no `"0s"`, no `0`-cost. **Both families are live-session-only by decision**:
+  a persisted `ChatMessage` carries no timing field, `project_restored_frames`
+  does not carry `chain_id` onto a restored frame, and the per-turn buckets are
+  in-memory state a restart does not rehydrate — so a restored row's right
+  gutter is blank, never a reconstructed value.
 
 ### `reyn.intervention.<kind>`
 

--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -627,7 +627,7 @@ observer via `FlowView.on_flow_clear`. The completion's own final write is NOT
 visibility-gated: the authoritative full text lands whether or not the row is
 on screen.
 
-### Textual TUI gutters — state (left) + elapsed time/turn cost (right) (#3283 ①②④)
+### Textual TUI gutters — state (left) + elapsed time/turn tokens (right) (#3283 ①②④)
 
 The Textual TUI's `FlowView` (`interfaces/inline/textual_chat`) paints TWO
 fixed-width columns per row, both driven by flowview's `FlowDecorator`
@@ -652,28 +652,43 @@ second hand-rolled column:
     RUNNING (read off the same start marker the ② live-spinner body uses), or
     the FINAL captured duration once SETTLED (stashed at settle time, before
     the live marker is stripped).
-  - **`ReynTurnUsageGutter` — the row's turn's real TOKENS + USD COST**
-    (`1.9k $0.03`), anchored to the `kind="agent"` reply row: the row that
-    concludes a turn's visible output, one figure per turn rather than the same
-    total repeated on every row of the turn. Read through a keyed lookup over
-    `BudgetTracker`'s bounded per-turn buckets (`BudgetTracker.turn_usage` via
-    `Session.turn_usage`, reached from the status snapshot's `turn_usage_fn`) —
-    the per-turn attribution #3339 captured at the source. **Never derived by
-    differencing cumulative counters.** A row that NAMES a turn
-    (`meta["chain_id"]`) whose figure the runtime does not hold renders `—`,
-    never `0`: a turn that made no LLM call, a turn EVICTED from the bounded
-    buckets, an unknown chain_id, and a REMOTE client (per-turn buckets are
-    session-local and not projected onto the wire — `turn_usage_fn` is `None`
-    there, the same frame-sufficiency boundary as the past-turn log).
+  - **`ReynTurnUsageGutter` — the row's turn's real TOKEN SPLIT**
+    (`↑12k ↓1.8k` — `↑` prompt, `↓` completion), anchored to the `kind="agent"`
+    reply row: the row that concludes a turn's visible output, one figure per
+    turn rather than the same total repeated on every row of the turn. Read
+    through a keyed lookup over `BudgetTracker`'s bounded per-turn buckets
+    (`BudgetTracker.turn_usage` via `Session.turn_usage`, reached from the
+    status snapshot's `turn_usage_fn`) — the per-turn attribution #3339
+    captured at the source, with the prompt/completion split accumulated
+    alongside the total at the call. **Never derived by differencing cumulative
+    counters.** A row that NAMES a turn (`meta["chain_id"]`) whose figure the
+    runtime does not hold renders `—`, never `0`: a turn that made no LLM call,
+    a turn EVICTED from the bounded buckets, an unknown chain_id, and a REMOTE
+    client (per-turn buckets are session-local and not projected onto the wire
+    — `turn_usage_fn` is `None` there, the same frame-sufficiency boundary as
+    the past-turn log). A turn that recorded **0** tokens renders `↑0 ↓0` — a
+    measured fact, kept distinct from `—`.
+
+    The turn's **USD cost is deliberately not drawn here** even though the
+    lookup returns it: tokens answer the question this column exists for, and
+    the narrower column leaves the conversation body room (a real-TTY read at
+    80 columns found a wider gutter left long tables and code cramped).
+    `/cost` and the status line remain the spend surfaces.
 
   A dedicated state chip, the umbrella issue's third candidate, stays dropped:
   it would duplicate the left gutter's existing `EntryState` encoding.
   A row with no data in either family renders an empty cell — no placeholder,
-  no `"0s"`, no `0`-cost. **Both families are live-session-only by decision**:
-  a persisted `ChatMessage` carries no timing field, `project_restored_frames`
-  does not carry `chain_id` onto a restored frame, and the per-turn buckets are
-  in-memory state a restart does not rehydrate — so a restored row's right
-  gutter is blank, never a reconstructed value.
+  no `"0s"`, no `0` tokens. **Both families are live-session-only by
+  decision**: a persisted `ChatMessage` carries no timing field,
+  `project_restored_frames` does not carry `chain_id` onto a restored frame,
+  and the per-turn buckets are in-memory state a restart does not rehydrate —
+  so a restored row's right gutter is blank, never a reconstructed value.
+
+  The column is a fixed width derived in terminal **cells**
+  (`rich.cells.cell_len`, the measure Textual's own compositor applies) from
+  the widest label each family can emit — not from a character count. The two
+  direction markers are East Asian *Ambiguous* width; rich resolves them to one
+  cell, so the derivation and the renderer agree by construction.
 
 ### `reyn.intervention.<kind>`
 

--- a/src/reyn/interfaces/inline/textual_chat/__init__.py
+++ b/src/reyn/interfaces/inline/textual_chat/__init__.py
@@ -55,8 +55,9 @@ boundary and re-exports the public API):
 - :mod:`~reyn.interfaces.inline.textual_chat.presenter` — ``ReynPresenter`` +
   ``_body_and_background`` (body cell construction).
 - :mod:`~reyn.interfaces.inline.textual_chat.gutter` — ``ReynGutter`` (LEFT,
-  state-coloured marker) + ``ReynTimingGutter`` (RIGHT, per-entry elapsed
-  time — Phase ④, #3283) + running-frame constants.
+  state-coloured marker) + ``ReynRightGutter`` (RIGHT, Phase ④ #3283 — a
+  composite of ``ReynTimingGutter``'s per-entry elapsed time and
+  ``ReynTurnUsageGutter``'s per-turn tokens+cost) + running-frame constants.
 - :mod:`~reyn.interfaces.inline.textual_chat.chrome` — ``Composer``,
   ``StatusLine``, ``MenuBar``, ``_MENU_TABS``, and the pure pane formatters
   (``pane_payload`` / ``pane_commands`` / ``status_line_text`` /
@@ -78,7 +79,7 @@ from __future__ import annotations
 
 from .app import TextualChatApp, run_textual_chat
 from .chrome import Composer, MenuBar, StatusLine
-from .gutter import ReynGutter, ReynTimingGutter
+from .gutter import ReynGutter, ReynRightGutter, ReynTimingGutter, ReynTurnUsageGutter
 from .intervention_panel import InterventionPanel
 from .presenter import ReynPresenter, _body_and_background
 
@@ -88,7 +89,9 @@ __all__ = [
     "MenuBar",
     "ReynGutter",
     "ReynPresenter",
+    "ReynRightGutter",
     "ReynTimingGutter",
+    "ReynTurnUsageGutter",
     "StatusLine",
     "TextualChatApp",
     "_body_and_background",

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -65,7 +65,7 @@ from .gutter import (
     _RUNNING_FRAME_PERIOD,
     RIGHT_GUTTER_WIDTH,
     ReynGutter,
-    ReynTimingGutter,
+    ReynRightGutter,
 )
 from .intervention_panel import InterventionPanel
 from .presenter import (
@@ -561,6 +561,20 @@ class TextualChatApp(App):
         # session switch, so a chain_id can never leak past its turn's
         # completion.
         self._streaming_replies: "dict[str, _StreamingReply]" = {}
+        # #3283 ④: the status snapshot's keyed per-turn cost/token lookup
+        # (``turn_usage_fn`` = ``Session.turn_usage``), cached off the snapshot
+        # :meth:`_refresh_live_chrome` already reads once per arriving frame.
+        # The right gutter calls it once PER RENDERED ROW, so it must not build
+        # a snapshot itself; and it must not hold the bound method forever
+        # either (a session SWITCH rebinds it), hence re-cached per frame from
+        # the same read rather than resolved once at mount. ``None`` until the
+        # first frame, and permanently ``None`` on a remote client (per-turn
+        # buckets are session-local, not on the wire) — the gutter renders
+        # ``—`` for a row whose turn it cannot price, never a fabricated 0.
+        self._turn_usage_fn: "Callable[[str], dict | None] | None" = None
+        # One-shot latch so a raising lookup is logged once, not once per
+        # rendered row per repaint (see :meth:`_turn_usage`).
+        self._turn_usage_lookup_failed = False
 
     def compose(self) -> ComposeResult:
         # Held so the frame pump can start/stop the per-entry BODY animation
@@ -572,10 +586,13 @@ class TextualChatApp(App):
             decorator=ReynGutter(frame_period=_RUNNING_FRAME_PERIOD),
             gutter_width=_GUTTER_WIDTH,
             # Phase ④ (#3283): the RIGHT gutter shows per-entry elapsed time
-            # (tool rows only — see ReynTimingGutter's docstring for the
-            # content-set decision). additive flowview params; the LEFT
-            # gutter/state contract above is untouched.
-            right_decorator=ReynTimingGutter(clock=self._clock),
+            # (tool rows) AND the row's turn's real tokens+cost (agent reply
+            # rows, via the keyed per-turn lookup) — see ReynRightGutter and
+            # its two halves for the content-set decisions. additive flowview
+            # params; the LEFT gutter/state contract above is untouched.
+            right_decorator=ReynRightGutter(
+                clock=self._clock, usage_lookup=self._turn_usage
+            ),
             right_gutter_width=RIGHT_GUTTER_WIDTH,
             spacing=1,
             anchor=Anchor.STICKY_BOTTOM,
@@ -627,6 +644,37 @@ class TextualChatApp(App):
             return self._read_model.snapshot(self._config)
         except Exception:
             logger.exception("textual chat: status snapshot read failed")
+            return None
+
+    def _turn_usage(self, chain_id: str) -> "dict | None":
+        """The real tokens+cost of turn ``chain_id``, or ``None`` when there is
+        no figure — the right gutter's per-row lookup (#3283 ④).
+
+        Delegates to the snapshot's ``turn_usage_fn``
+        (:attr:`_turn_usage_fn` = ``Session.turn_usage``, keyed over
+        ``BudgetTracker``'s bounded per-turn buckets). ``None`` covers every
+        no-figure case uniformly — no read model / pre-first-frame, a remote
+        client (per-turn buckets are session-local), a turn that recorded no
+        LLM spend, and a turn EVICTED from the buckets — and the gutter renders
+        ``—`` for all of them. Never a fabricated ``0``, and never a figure
+        derived from cumulative counters.
+
+        A raising lookup is logged ONCE per app run, not once per row per
+        repaint: this runs on the render path, so an unconditional
+        ``logger.exception`` here would drown the log at frame rate for a
+        single persistent fault."""
+        fn = self._turn_usage_fn
+        if fn is None:
+            return None
+        try:
+            return fn(chain_id)
+        except Exception:
+            if not self._turn_usage_lookup_failed:
+                self._turn_usage_lookup_failed = True
+                logger.exception(
+                    "textual chat: per-turn usage lookup failed "
+                    "(right gutter will show '—'; logged once)"
+                )
             return None
 
     def _app_binding_help(self) -> "list[tuple[str, str]]":
@@ -1910,6 +1958,10 @@ class TextualChatApp(App):
         One snapshot read feeds both refreshes, so a frame costs one read
         regardless of whether the drawer is open."""
         snap = self._snapshot()
+        # #3283 ④: re-cache the keyed per-turn lookup off the SAME snapshot read
+        # (see :attr:`_turn_usage_fn`) — the right gutter cannot afford a
+        # snapshot per rendered row.
+        self._turn_usage_fn = (snap or {}).get("turn_usage_fn")
         self._refresh_status(snap)
         try:
             drawer = self.query_one("#drawer", ContentSwitcher)

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -561,7 +561,7 @@ class TextualChatApp(App):
         # session switch, so a chain_id can never leak past its turn's
         # completion.
         self._streaming_replies: "dict[str, _StreamingReply]" = {}
-        # #3283 ④: the status snapshot's keyed per-turn cost/token lookup
+        # #3283 ④: the status snapshot's keyed per-turn token/cost lookup
         # (``turn_usage_fn`` = ``Session.turn_usage``), cached off the snapshot
         # :meth:`_refresh_live_chrome` already reads once per arriving frame.
         # The right gutter calls it once PER RENDERED ROW, so it must not build
@@ -586,10 +586,11 @@ class TextualChatApp(App):
             decorator=ReynGutter(frame_period=_RUNNING_FRAME_PERIOD),
             gutter_width=_GUTTER_WIDTH,
             # Phase ④ (#3283): the RIGHT gutter shows per-entry elapsed time
-            # (tool rows) AND the row's turn's real tokens+cost (agent reply
-            # rows, via the keyed per-turn lookup) — see ReynRightGutter and
-            # its two halves for the content-set decisions. additive flowview
-            # params; the LEFT gutter/state contract above is untouched.
+            # (tool rows) AND the row's turn's real prompt/completion token
+            # split (agent reply rows, via the keyed per-turn lookup) — see
+            # ReynRightGutter and its two halves for the content-set decisions.
+            # additive flowview params; the LEFT gutter/state contract above is
+            # untouched.
             right_decorator=ReynRightGutter(
                 clock=self._clock, usage_lookup=self._turn_usage
             ),
@@ -647,8 +648,10 @@ class TextualChatApp(App):
             return None
 
     def _turn_usage(self, chain_id: str) -> "dict | None":
-        """The real tokens+cost of turn ``chain_id``, or ``None`` when there is
-        no figure — the right gutter's per-row lookup (#3283 ④).
+        """The real per-turn figures for ``chain_id``, or ``None`` when there
+        is no figure — the right gutter's per-row lookup (#3283 ④). The gutter
+        draws the prompt/completion token split; the dict also carries the
+        turn's USD cost for any other caller.
 
         Delegates to the snapshot's ``turn_usage_fn``
         (:attr:`_turn_usage_fn` = ``Session.turn_usage``, keyed over

--- a/src/reyn/interfaces/inline/textual_chat/gutter.py
+++ b/src/reyn/interfaces/inline/textual_chat/gutter.py
@@ -1,5 +1,5 @@
-"""State-coloured LEFT gutter + elapsed-time RIGHT gutter for the Textual chat
-surface's flowview.
+"""State-coloured LEFT gutter + elapsed/turn-cost RIGHT gutter for the Textual
+chat surface's flowview.
 
 :class:`ReynGutter` fills the flowview LEFT gutter column with a kind-driven
 glyph (via :func:`_gutter_glyph_color`) whose COLOUR is driven by the entry's
@@ -11,11 +11,24 @@ the decorator on each animation tick so the glyph advances with wall time — no
 app-held frame counter, no app-side timer. textual-flowview is never modified or
 forked.
 
-:class:`ReynTimingGutter` (Phase ④, #3283) fills the flowview RIGHT gutter
-column (``right_decorator``/``right_gutter_width``, additive flowview params)
-with a per-entry elapsed-time label — see its own docstring for the content-set
-decision (elapsed only; cost/token and a dedicated state chip were both
-evaluated and dropped) and the live-vs-restore split.
+:class:`ReynRightGutter` (Phase ④, #3283) fills the flowview RIGHT gutter column
+(``right_decorator``/``right_gutter_width``, additive flowview params). It is a
+composite of two single-purpose label producers, since flowview takes exactly one
+right decorator:
+
+- :class:`ReynTimingGutter` — per-entry ELAPSED time (live off the clock while a
+  tool row runs, the captured final value once it settles);
+- :class:`ReynTurnUsageGutter` — the row's turn's real TOKENS + USD COST, read
+  through an injected keyed lookup over ``BudgetTracker``'s per-turn buckets
+  (#3339/#3342). Unknown or evicted turns render :data:`TURN_USAGE_UNKNOWN`
+  (``"—"``), never a ``0`` and never a figure derived by differencing cumulative
+  counters.
+
+See each class's docstring for its content-set decision and its live-vs-restore
+posture (neither elapsed nor cost survives a restart — both render honestly
+absent rather than reconstructed). A dedicated state chip, the umbrella issue's
+third right-gutter candidate, stays dropped: the LEFT gutter already encodes
+``EntryState``.
 
 This module is part of the TTY-only ``textual_chat`` package (imported lazily via
 :mod:`reyn.interfaces.repl.client_driver`); its ``textual_flowview`` import never
@@ -195,11 +208,88 @@ def _format_elapsed(seconds: float) -> str:
     return f"{minutes // 60}h"
 
 
-#: FlowView RIGHT-gutter column width (Phase ④, #3283) — wide enough for
-#: :func:`_format_elapsed`'s longest label (3 characters, e.g. ``"99s"``)
-#: plus one column of breathing room. Wired into ``app.py``'s
-#: ``FlowView(right_gutter_width=…)`` config.
-RIGHT_GUTTER_WIDTH = 4
+#: Rendered when the row NAMES a turn (its display frame carries a
+#: ``chain_id``) but the runtime holds NO figure for that turn — it recorded no
+#: LLM spend, or its bucket has been evicted from ``BudgetTracker``'s bounded
+#: per-turn buckets (``TURN_BUCKET_CAP``), or this is a remote client where the
+#: per-turn buckets are not on the wire at all. Explicitly NOT ``"0"`` and
+#: explicitly not an empty cell: both would read as "this turn was free".
+TURN_USAGE_UNKNOWN = "—"
+
+#: The one display-frame kind the per-turn cost/token figure is anchored to —
+#: the agent reply, i.e. the row that CONCLUDES a turn's visible output. See
+#: :class:`ReynTurnUsageGutter` for why the figure is anchored rather than
+#: repeated on every row of the turn.
+TURN_ANCHOR_KIND = "agent"
+
+
+def _format_tokens(tokens: int) -> str:
+    """A compact token count — ``"812"`` / ``"1.9k"`` / ``"120k"`` / ``"1.2M"``
+    — bounded to 4 characters for any turn under a billion tokens, so
+    :data:`RIGHT_GUTTER_WIDTH` can be computed rather than guessed.
+
+    Each band's upper edge is the value that would ROUND into the next band
+    (9_950 → ``"9.9k"``, not ``"10.0k"``), so the 4-character bound holds at the
+    boundaries too rather than only in the middle of each band."""
+    n = max(0, int(tokens))
+    if n < 1_000:
+        return str(n)
+    if n < 9_950:
+        return f"{n / 1_000:.1f}k"
+    if n < 999_500:
+        return f"{round(n / 1_000)}k"
+    if n < 9_950_000:
+        return f"{n / 1_000_000:.1f}M"
+    return f"{round(n / 1_000_000)}M"
+
+
+#: The smallest USD cost :func:`_format_cost` prints as an exact figure.
+#: Anything smaller but still non-zero is rendered with a ``<`` prefix rather
+#: than rounded down to a zero-looking ``"$0.0000"`` — a real spend must never
+#: render as free.
+_COST_FLOOR_USD = 0.0001
+
+
+def _format_cost(cost_usd: float) -> str:
+    """A compact USD label — ``"$0"`` / ``"$0.0004"`` / ``"$1.23"`` / ``"$123"``
+    — bounded to 8 characters (the ``"<$0.0001"`` floor form below).
+
+    A cost of exactly zero prints ``"$0"``: that is a REAL figure (an unpriced
+    model), distinct from :data:`TURN_USAGE_UNKNOWN`, which means "we do not
+    know". A non-zero cost too small to print exactly gets the ``<`` prefix, so
+    real spend never renders as free either."""
+    c = max(0.0, float(cost_usd))
+    if c == 0.0:
+        return "$0"
+    if c < _COST_FLOOR_USD:
+        return f"<${_COST_FLOOR_USD:.4f}"
+    if c < 0.01:
+        return f"${c:.4f}"
+    if c < 100:
+        return f"${c:.2f}"
+    return f"${c:.0f}"
+
+
+#: FlowView RIGHT-gutter column width (Phase ④, #3283) — wired into ``app.py``'s
+#: ``FlowView(right_gutter_width=…)`` config. COMPUTED from the widest label of
+#: each family this column renders, not guessed:
+#:
+#: - elapsed (:func:`_format_elapsed`) — 3 chars (``"99s"``);
+#: - per-turn cost/token (:class:`ReynTurnUsageGutter`) — ``_format_tokens``
+#:   (4, ``"120k"``) + a space + ``_format_cost`` (8, ``"<$0.0001"``) = 13.
+#:
+#: 13 + one column of breathing room = 14. The two families are mutually
+#: exclusive on any one row by construction (elapsed lives on
+#: ``tool_call_started`` rows, the turn figure on :data:`TURN_ANCHOR_KIND`
+#: rows), so the widest cell is 13, not their sum; if that ever stopped
+#: holding, the combined label would simply be clipped by flowview's own
+#: fixed-width gutter — never allowed to steal body columns.
+#:
+#: ★ Bound re-justified against #3337's body-width floor gate at THIS width
+#: (``test_right_gutter_leaves_the_body_at_least_half_the_terminal_width``):
+#: on an 80-column terminal the body keeps ``80 - 2 (left gutter) - 14 = 64``
+#: columns, well clear of the 40-column floor.
+RIGHT_GUTTER_WIDTH = 14
 
 
 class ReynTimingGutter:
@@ -208,15 +298,12 @@ class ReynTimingGutter:
     keeps state, right gutter shows per-entry metadata" split. The LEFT gutter
     (:class:`ReynGutter`) is untouched by this class.
 
-    **Content set — elapsed time only.** The umbrella issue listed turn
-    cost/tokens and a state chip as CANDIDATES; both were evaluated against
-    what data actually exists and dropped (owner-adjudicated on #3283):
+    **This class contributes the ELAPSED half only.** The per-turn cost/token
+    half is :class:`ReynTurnUsageGutter`, and :class:`ReynRightGutter` is the
+    decorator actually wired into ``FlowView(right_decorator=…)`` — it joins
+    both labels into the one shared column. Of the umbrella issue's three
+    right-gutter CANDIDATES, that leaves one still dropped:
 
-    - **Turn cost / tokens**: ``BudgetTracker`` (``reyn.runtime.budget``) is
-      CUMULATIVE ONLY — per-agent / daily / monthly totals. There is no
-      per-turn or per-entry cost/token field anywhere in the runtime.
-      Showing the running total on one arbitrary entry, or a value obtained
-      by dividing it, would be a FABRICATED per-entry number — not shown.
     - **A dedicated state chip**: the left gutter already fully encodes
       :class:`~textual_flowview.EntryState` via glyph + colour (#3273's
       contract); a right-side chip would duplicate that same axis for no
@@ -246,12 +333,132 @@ class ReynTimingGutter:
     def __init__(self, *, clock: "Callable[[], float]" = time.monotonic) -> None:
         self._clock = clock
 
-    def decorate(self, entry: "Entry[OutboxMessage]", width: int, height: int) -> RenderableType:
+    def label(self, entry: "Entry[OutboxMessage]") -> str:
+        """This entry's elapsed-time label, or ``""`` when it has no timing
+        data. The composable half of :meth:`decorate` — :class:`ReynRightGutter`
+        joins this with :meth:`ReynTurnUsageGutter.label`."""
         meta = entry.item.meta or {}
         since = meta.get(_RUNNING_SINCE_KEY)
         if isinstance(since, (int, float)):
-            label = _format_elapsed(self._clock() - since)
-        else:
-            final = meta.get(_ELAPSED_SECS_KEY)
-            label = _format_elapsed(final) if isinstance(final, (int, float)) else ""
-        return Text(label.rjust(width), style=_CC_DIM)
+            return _format_elapsed(self._clock() - since)
+        final = meta.get(_ELAPSED_SECS_KEY)
+        return _format_elapsed(final) if isinstance(final, (int, float)) else ""
+
+    def decorate(self, entry: "Entry[OutboxMessage]", width: int, height: int) -> RenderableType:
+        return Text(self.label(entry).rjust(width), style=_CC_DIM)
+
+
+class ReynTurnUsageGutter:
+    """Fills the flowview RIGHT gutter with a per-entry PER-TURN COST/TOKEN
+    label (Phase ④ remainder, #3283) — the half #3337 had to leave out because
+    the data did not exist yet.
+
+    **The data now exists, and only because it was captured at the source.**
+    #3339/#3342 keyed every LLM call's real tokens+cost by its turn's
+    ``chain_id`` (``BudgetTracker``'s bounded per-turn buckets). This class
+    reads those buckets through an injected ``usage_lookup`` —
+    ``(chain_id) -> {"chain_id", "tokens", "cost_usd"} | None``, in production
+    ``Session.turn_usage`` reached via the status snapshot's ``turn_usage_fn``.
+    Nothing here derives a figure by differencing cumulative counters; that was
+    rejected repeatedly across this arc and there is no code path for it.
+
+    **Anchored to one row per turn, not repeated on every row.** The figure is
+    a TURN total, so it is rendered on the row that concludes the turn's visible
+    output — the :data:`TURN_ANCHOR_KIND` (``"agent"``) reply. Painting the same
+    total onto the turn's user line and each of its tool rows would show one
+    number N times in a column whose every other label (elapsed) IS per-row,
+    which reads as N separate per-row costs. One turn, one figure.
+
+    **Three distinct renders, and they are distinct on purpose:**
+
+    - the anchor row's turn HAS a figure → ``"1.9k $0.03"`` (tokens + USD);
+    - the anchor row NAMES a turn (``meta["chain_id"]``) but the runtime holds
+      no figure for it → :data:`TURN_USAGE_UNKNOWN` (``"—"``). Covers a turn
+      that made no LLM call, a turn EVICTED from the bounded buckets
+      (``TURN_BUCKET_CAP`` — an old row scrolled far back), an unknown
+      chain_id, and a REMOTE client (the buckets are session-local and not on
+      the AG-UI wire). Never ``"0"``, which would read as "this turn was free";
+    - the row names NO turn at all → an EMPTY cell. There is no turn to report
+      on, so there is nothing unknown about it either. This is where every
+      RESTORED row lands: ``restore.project_restored_frames`` re-projects a
+      persisted ``ChatMessage`` and does not carry ``chain_id`` onto the frame,
+      and the per-turn buckets are in-memory live-session state that a restart
+      does not rehydrate — so a restored conversation shows no cost figures
+      rather than reconstructed ones. Same live-vs-restore posture #3337 landed
+      for elapsed.
+
+    ``usage_lookup=None`` (no read model / pre-session / plain fallback) makes
+    every row's lookup unknown, so a row that names a turn still renders ``—``
+    rather than silently nothing."""
+
+    def __init__(
+        self,
+        *,
+        usage_lookup: "Callable[[str], dict | None] | None" = None,
+    ) -> None:
+        self._usage_lookup = usage_lookup
+
+    def label(self, entry: "Entry[OutboxMessage]") -> str:
+        """This entry's per-turn cost/token label: the figure, ``"—"`` when the
+        row names a turn with no known figure, or ``""`` when it names no turn.
+
+        A lookup that raises is treated exactly like "no figure" — this runs on
+        every gutter repaint and must never be able to kill a render."""
+        if entry.item.kind != TURN_ANCHOR_KIND:
+            return ""
+        chain_id = (entry.item.meta or {}).get("chain_id")
+        if not isinstance(chain_id, str) or not chain_id:
+            return ""
+        usage: "dict | None" = None
+        if self._usage_lookup is not None:
+            try:
+                usage = self._usage_lookup(chain_id)
+            except Exception:
+                usage = None
+        if not usage:
+            return TURN_USAGE_UNKNOWN
+        tokens = usage.get("tokens")
+        cost_usd = usage.get("cost_usd")
+        if not isinstance(tokens, (int, float)) or not isinstance(cost_usd, (int, float)):
+            return TURN_USAGE_UNKNOWN
+        return f"{_format_tokens(int(tokens))} {_format_cost(float(cost_usd))}"
+
+    def decorate(self, entry: "Entry[OutboxMessage]", width: int, height: int) -> RenderableType:
+        return Text(self.label(entry).rjust(width), style=_CC_DIM)
+
+
+class ReynRightGutter:
+    """The RIGHT-gutter decorator actually wired into
+    ``FlowView(right_decorator=…)`` — one column, two label families.
+
+    flowview takes a single right decorator, and Phase ④ has two things to say
+    about a row: how long it ran (:class:`ReynTimingGutter`) and what its turn
+    cost (:class:`ReynTurnUsageGutter`). Rather than fold both into one class,
+    each keeps its own ``label`` and this composes them, joining whatever is
+    non-empty with a single space and right-aligning the result. In practice
+    exactly one of the two ever speaks for a given row (elapsed on
+    ``tool_call_started``, the turn figure on :data:`TURN_ANCHOR_KIND`), which
+    is what lets :data:`RIGHT_GUTTER_WIDTH` be the widest single label rather
+    than the sum.
+
+    ``clock`` and ``usage_lookup`` are passed straight through to the two halves
+    (see their docstrings); both are injectable so a test can drive the live
+    elapsed value and the per-turn lookup deterministically with real
+    collaborators."""
+
+    def __init__(
+        self,
+        *,
+        clock: "Callable[[], float]" = time.monotonic,
+        usage_lookup: "Callable[[str], dict | None] | None" = None,
+    ) -> None:
+        self._timing = ReynTimingGutter(clock=clock)
+        self._turn_usage = ReynTurnUsageGutter(usage_lookup=usage_lookup)
+
+    def decorate(self, entry: "Entry[OutboxMessage]", width: int, height: int) -> RenderableType:
+        parts = [
+            label
+            for label in (self._timing.label(entry), self._turn_usage.label(entry))
+            if label
+        ]
+        return Text(" ".join(parts).rjust(width), style=_CC_DIM)

--- a/src/reyn/interfaces/inline/textual_chat/gutter.py
+++ b/src/reyn/interfaces/inline/textual_chat/gutter.py
@@ -1,4 +1,4 @@
-"""State-coloured LEFT gutter + elapsed/turn-cost RIGHT gutter for the Textual
+"""State-coloured LEFT gutter + elapsed/turn-token RIGHT gutter for the Textual
 chat surface's flowview.
 
 :class:`ReynGutter` fills the flowview LEFT gutter column with a kind-driven
@@ -18,14 +18,15 @@ right decorator:
 
 - :class:`ReynTimingGutter` — per-entry ELAPSED time (live off the clock while a
   tool row runs, the captured final value once it settles);
-- :class:`ReynTurnUsageGutter` — the row's turn's real TOKENS + USD COST, read
-  through an injected keyed lookup over ``BudgetTracker``'s per-turn buckets
+- :class:`ReynTurnUsageGutter` — the row's turn's real TOKEN COUNT, read through
+  an injected keyed lookup over ``BudgetTracker``'s per-turn buckets
   (#3339/#3342). Unknown or evicted turns render :data:`TURN_USAGE_UNKNOWN`
-  (``"—"``), never a ``0`` and never a figure derived by differencing cumulative
-  counters.
+  (``"—"``), kept distinct from a real ``0``, and never a figure derived by
+  differencing cumulative counters. The lookup also returns the turn's USD cost;
+  this column deliberately does not display it (owner call — see the class).
 
 See each class's docstring for its content-set decision and its live-vs-restore
-posture (neither elapsed nor cost survives a restart — both render honestly
+posture (neither elapsed nor tokens survive a restart — both render honestly
 absent rather than reconstructed). A dedicated state chip, the umbrella issue's
 third right-gutter candidate, stays dropped: the LEFT gutter already encodes
 ``EntryState``.
@@ -39,6 +40,7 @@ from __future__ import annotations
 import time
 from typing import TYPE_CHECKING, Callable
 
+from rich.cells import cell_len
 from rich.text import Text
 from textual_flowview import EntryState
 
@@ -209,18 +211,54 @@ def _format_elapsed(seconds: float) -> str:
 
 
 #: Rendered when the row NAMES a turn (its display frame carries a
-#: ``chain_id``) but the runtime holds NO figure for that turn — it recorded no
-#: LLM spend, or its bucket has been evicted from ``BudgetTracker``'s bounded
-#: per-turn buckets (``TURN_BUCKET_CAP``), or this is a remote client where the
-#: per-turn buckets are not on the wire at all. Explicitly NOT ``"0"`` and
-#: explicitly not an empty cell: both would read as "this turn was free".
+#: ``chain_id``) but the runtime holds NO token figure for that turn — it
+#: recorded no LLM call, or its bucket has been evicted from
+#: ``BudgetTracker``'s bounded per-turn buckets (``TURN_BUCKET_CAP``), or this
+#: is a remote client where the per-turn buckets are not on the wire at all.
+#: Explicitly NOT ``"0"`` — a turn CAN legitimately record 0 tokens (a provider
+#: that returned no usage), and that is a real figure this must stay distinct
+#: from. Explicitly not an empty cell either, which on a row that names a turn
+#: would read as "this turn used nothing".
 TURN_USAGE_UNKNOWN = "—"
 
-#: The one display-frame kind the per-turn cost/token figure is anchored to —
-#: the agent reply, i.e. the row that CONCLUDES a turn's visible output. See
+#: The one display-frame kind the per-turn token figure is anchored to — the
+#: agent reply, i.e. the row that CONCLUDES a turn's visible output. See
 #: :class:`ReynTurnUsageGutter` for why the figure is anchored rather than
 #: repeated on every row of the turn.
 TURN_ANCHOR_KIND = "agent"
+
+#: Direction markers for the per-turn token split — ``↑`` what the turn SENT
+#: (prompt) and ``↓`` what it generated (completion), e.g. ``"↑12k ↓1.8k"``.
+#:
+#: ★ Both are East Asian **Ambiguous** width (``unicodedata.east_asian_width``
+#: → ``"A"``), so their column count is not universally fixed. MEASURED, not
+#: assumed: ``rich.cells.cell_len`` resolves ambiguous to **1**, and that is
+#: the SAME function Textual's compositor measures this strip with — so the
+#: column arithmetic here and the renderer's agree by construction, and
+#: :data:`RIGHT_GUTTER_WIDTH` derived via :func:`_cell_pad_left` cannot
+#: overflow in process.
+#:
+#: They introduce no NEW class of risk: :data:`TURN_USAGE_UNKNOWN` (``—``,
+#: U+2014) and the LEFT gutter's ``●``/``○``/``◆`` are ambiguous-width too and
+#: have shipped since #3273. The residual — a terminal whose font/locale
+#: renders ambiguous-width as 2 columns — is a property of the terminal, not
+#: observable from inside this process, and applies equally to those existing
+#: glyphs.
+PROMPT_TOKENS_MARKER = "↑"
+COMPLETION_TOKENS_MARKER = "↓"
+
+
+def _cell_pad_left(label: str, width: int) -> str:
+    """Right-align ``label`` in a ``width``-CELL column.
+
+    ``str.rjust`` pads by CHARACTER count; a gutter column is measured in
+    terminal CELLS, and the two differ for any double-width glyph. Padding on
+    :func:`rich.cells.cell_len` — the same measurement Textual's compositor
+    applies to the resulting strip — keeps this cell correct by construction
+    rather than by the coincidence that today's vocabulary happens to be all
+    one-cell. Over-long labels are returned unpadded (flowview's own
+    ``adjust_cell_length`` clips them; they never steal body columns)."""
+    return " " * max(0, width - cell_len(label)) + label
 
 
 def _format_tokens(tokens: int) -> str:
@@ -243,53 +281,30 @@ def _format_tokens(tokens: int) -> str:
     return f"{round(n / 1_000_000)}M"
 
 
-#: The smallest USD cost :func:`_format_cost` prints as an exact figure.
-#: Anything smaller but still non-zero is rendered with a ``<`` prefix rather
-#: than rounded down to a zero-looking ``"$0.0000"`` — a real spend must never
-#: render as free.
-_COST_FLOOR_USD = 0.0001
-
-
-def _format_cost(cost_usd: float) -> str:
-    """A compact USD label — ``"$0"`` / ``"$0.0004"`` / ``"$1.23"`` / ``"$123"``
-    — bounded to 8 characters (the ``"<$0.0001"`` floor form below).
-
-    A cost of exactly zero prints ``"$0"``: that is a REAL figure (an unpriced
-    model), distinct from :data:`TURN_USAGE_UNKNOWN`, which means "we do not
-    know". A non-zero cost too small to print exactly gets the ``<`` prefix, so
-    real spend never renders as free either."""
-    c = max(0.0, float(cost_usd))
-    if c == 0.0:
-        return "$0"
-    if c < _COST_FLOOR_USD:
-        return f"<${_COST_FLOOR_USD:.4f}"
-    if c < 0.01:
-        return f"${c:.4f}"
-    if c < 100:
-        return f"${c:.2f}"
-    return f"${c:.0f}"
-
-
 #: FlowView RIGHT-gutter column width (Phase ④, #3283) — wired into ``app.py``'s
-#: ``FlowView(right_gutter_width=…)`` config. COMPUTED from the widest label of
-#: each family this column renders, not guessed:
+#: ``FlowView(right_gutter_width=…)`` config. COMPUTED in terminal CELLS
+#: (:func:`rich.cells.cell_len`, the renderer's own measure) from the widest
+#: label of each family this column renders, not guessed:
 #:
-#: - elapsed (:func:`_format_elapsed`) — 3 chars (``"99s"``);
-#: - per-turn cost/token (:class:`ReynTurnUsageGutter`) — ``_format_tokens``
-#:   (4, ``"120k"``) + a space + ``_format_cost`` (8, ``"<$0.0001"``) = 13.
+#: - elapsed (:func:`_format_elapsed`) — 3 (``"99s"``);
+#: - per-turn tokens (:class:`ReynTurnUsageGutter`) — the two-figure split
+#:   ``↑<prompt> ↓<completion>``: marker (1) + :func:`_format_tokens` (4) +
+#:   space (1) + marker (1) + :func:`_format_tokens` (4) = **11**
+#:   (e.g. ``"↑120k ↓120k"``). Both markers measure 1 cell — see
+#:   :data:`PROMPT_TOKENS_MARKER` for the ambiguous-width measurement.
 #:
-#: 13 + one column of breathing room = 14. The two families are mutually
-#: exclusive on any one row by construction (elapsed lives on
-#: ``tool_call_started`` rows, the turn figure on :data:`TURN_ANCHOR_KIND`
-#: rows), so the widest cell is 13, not their sum; if that ever stopped
-#: holding, the combined label would simply be clipped by flowview's own
-#: fixed-width gutter — never allowed to steal body columns.
+#: The two families are mutually exclusive on any one row by construction
+#: (elapsed lives on ``tool_call_started`` rows, the token figure on
+#: :data:`TURN_ANCHOR_KIND` rows), so the widest cell is ``max(3, 11) = 11``,
+#: not their sum — 11 + one column of breathing room = 12. If that exclusivity
+#: ever stopped holding, the combined label would simply be clipped by
+#: flowview's own fixed-width gutter — never allowed to steal body columns.
 #:
 #: ★ Bound re-justified against #3337's body-width floor gate at THIS width
 #: (``test_right_gutter_leaves_the_body_at_least_half_the_terminal_width``):
-#: on an 80-column terminal the body keeps ``80 - 2 (left gutter) - 14 = 64``
-#: columns, well clear of the 40-column floor.
-RIGHT_GUTTER_WIDTH = 14
+#: on an 80-column terminal the body keeps ``80 - 2 (left gutter) - 12 = 66``
+#: columns against a 40-column floor.
+RIGHT_GUTTER_WIDTH = 12
 
 
 class ReynTimingGutter:
@@ -298,8 +313,8 @@ class ReynTimingGutter:
     keeps state, right gutter shows per-entry metadata" split. The LEFT gutter
     (:class:`ReynGutter`) is untouched by this class.
 
-    **This class contributes the ELAPSED half only.** The per-turn cost/token
-    half is :class:`ReynTurnUsageGutter`, and :class:`ReynRightGutter` is the
+    **This class contributes the ELAPSED half only.** The per-turn token half
+    is :class:`ReynTurnUsageGutter`, and :class:`ReynRightGutter` is the
     decorator actually wired into ``FlowView(right_decorator=…)`` — it joins
     both labels into the one shared column. Of the umbrella issue's three
     right-gutter CANDIDATES, that leaves one still dropped:
@@ -345,13 +360,13 @@ class ReynTimingGutter:
         return _format_elapsed(final) if isinstance(final, (int, float)) else ""
 
     def decorate(self, entry: "Entry[OutboxMessage]", width: int, height: int) -> RenderableType:
-        return Text(self.label(entry).rjust(width), style=_CC_DIM)
+        return Text(_cell_pad_left(self.label(entry), width), style=_CC_DIM)
 
 
 class ReynTurnUsageGutter:
-    """Fills the flowview RIGHT gutter with a per-entry PER-TURN COST/TOKEN
-    label (Phase ④ remainder, #3283) — the half #3337 had to leave out because
-    the data did not exist yet.
+    """Fills the flowview RIGHT gutter with a per-entry PER-TURN TOKEN COUNT
+    (Phase ④ remainder, #3283) — the half #3337 had to leave out because the
+    data did not exist yet.
 
     **The data now exists, and only because it was captured at the source.**
     #3339/#3342 keyed every LLM call's real tokens+cost by its turn's
@@ -362,28 +377,48 @@ class ReynTurnUsageGutter:
     Nothing here derives a figure by differencing cumulative counters; that was
     rejected repeatedly across this arc and there is no code path for it.
 
+    **Tokens only — the USD cost is deliberately NOT displayed** (owner call).
+    Tokens alone answer the question this column exists for, and dropping the
+    cost figure leaves the conversation body room: a real-TTY read at 80
+    columns found a wider gutter left long tables and code visibly cramped. The
+    lookup still RETURNS ``cost_usd`` and every caller may use it — this is a
+    presentation decision made here, not a narrowing of the data. ``/cost`` and
+    the status line remain the surfaces for spend.
+
+    **Prompt and completion are shown separately**, not as one total:
+    ``↑<prompt> ↓<completion>`` (:data:`PROMPT_TOKENS_MARKER` /
+    :data:`COMPLETION_TOKENS_MARKER`) — what the turn SENT versus what it
+    generated, which a single total cannot express and which move for entirely
+    different reasons (a growing context vs a long reply). The split is carried
+    all the way from ``TokenUsage`` at the call site through
+    ``BudgetTracker``'s per-turn buckets; it is never re-derived here.
+
     **Anchored to one row per turn, not repeated on every row.** The figure is
     a TURN total, so it is rendered on the row that concludes the turn's visible
     output — the :data:`TURN_ANCHOR_KIND` (``"agent"``) reply. Painting the same
     total onto the turn's user line and each of its tool rows would show one
     number N times in a column whose every other label (elapsed) IS per-row,
-    which reads as N separate per-row costs. One turn, one figure.
+    which reads as N separate per-row figures. One turn, one figure.
 
     **Three distinct renders, and they are distinct on purpose:**
 
-    - the anchor row's turn HAS a figure → ``"1.9k $0.03"`` (tokens + USD);
+    - the anchor row's turn HAS a figure → its token split (``"↑12k ↓1.8k"``).
+      Including a REAL zero (``"↑0 ↓0"``): a turn whose calls reported no usage
+      genuinely used 0 tokens, and that is a fact, not an absence;
     - the anchor row NAMES a turn (``meta["chain_id"]``) but the runtime holds
       no figure for it → :data:`TURN_USAGE_UNKNOWN` (``"—"``). Covers a turn
       that made no LLM call, a turn EVICTED from the bounded buckets
       (``TURN_BUCKET_CAP`` — an old row scrolled far back), an unknown
       chain_id, and a REMOTE client (the buckets are session-local and not on
-      the AG-UI wire). Never ``"0"``, which would read as "this turn was free";
+      the AG-UI wire). Never ``"0"`` — that is the real-zero figure above, and
+      collapsing the two would report an unmeasured turn as a measured free
+      one;
     - the row names NO turn at all → an EMPTY cell. There is no turn to report
       on, so there is nothing unknown about it either. This is where every
       RESTORED row lands: ``restore.project_restored_frames`` re-projects a
       persisted ``ChatMessage`` and does not carry ``chain_id`` onto the frame,
       and the per-turn buckets are in-memory live-session state that a restart
-      does not rehydrate — so a restored conversation shows no cost figures
+      does not rehydrate — so a restored conversation shows no token figures
       rather than reconstructed ones. Same live-vs-restore posture #3337 landed
       for elapsed.
 
@@ -399,8 +434,12 @@ class ReynTurnUsageGutter:
         self._usage_lookup = usage_lookup
 
     def label(self, entry: "Entry[OutboxMessage]") -> str:
-        """This entry's per-turn cost/token label: the figure, ``"—"`` when the
-        row names a turn with no known figure, or ``""`` when it names no turn.
+        """This entry's per-turn token label: the count, ``"—"`` when the row
+        names a turn with no known figure, or ``""`` when it names no turn.
+
+        Only ``tokens`` is read off the looked-up dict; ``cost_usd`` is present
+        and valid but not displayed (see the class docstring). A missing or
+        non-numeric ``tokens`` is treated as "no figure" rather than coerced.
 
         A lookup that raises is treated exactly like "no figure" — this runs on
         every gutter repaint and must never be able to kill a render."""
@@ -417,14 +456,19 @@ class ReynTurnUsageGutter:
                 usage = None
         if not usage:
             return TURN_USAGE_UNKNOWN
-        tokens = usage.get("tokens")
-        cost_usd = usage.get("cost_usd")
-        if not isinstance(tokens, (int, float)) or not isinstance(cost_usd, (int, float)):
+        prompt = usage.get("prompt_tokens")
+        completion = usage.get("completion_tokens")
+        if not isinstance(prompt, (int, float)) or not isinstance(
+            completion, (int, float)
+        ):
             return TURN_USAGE_UNKNOWN
-        return f"{_format_tokens(int(tokens))} {_format_cost(float(cost_usd))}"
+        return (
+            f"{PROMPT_TOKENS_MARKER}{_format_tokens(int(prompt))} "
+            f"{COMPLETION_TOKENS_MARKER}{_format_tokens(int(completion))}"
+        )
 
     def decorate(self, entry: "Entry[OutboxMessage]", width: int, height: int) -> RenderableType:
-        return Text(self.label(entry).rjust(width), style=_CC_DIM)
+        return Text(_cell_pad_left(self.label(entry), width), style=_CC_DIM)
 
 
 class ReynRightGutter:
@@ -432,8 +476,8 @@ class ReynRightGutter:
     ``FlowView(right_decorator=…)`` — one column, two label families.
 
     flowview takes a single right decorator, and Phase ④ has two things to say
-    about a row: how long it ran (:class:`ReynTimingGutter`) and what its turn
-    cost (:class:`ReynTurnUsageGutter`). Rather than fold both into one class,
+    about a row: how long it ran (:class:`ReynTimingGutter`) and how many tokens
+    its turn used (:class:`ReynTurnUsageGutter`). Rather than fold both into one class,
     each keeps its own ``label`` and this composes them, joining whatever is
     non-empty with a single space and right-aligning the result. In practice
     exactly one of the two ever speaks for a given row (elapsed on
@@ -461,4 +505,4 @@ class ReynRightGutter:
             for label in (self._timing.label(entry), self._turn_usage.label(entry))
             if label
         ]
-        return Text(" ".join(parts).rjust(width), style=_CC_DIM)
+        return Text(_cell_pad_left(" ".join(parts), width), style=_CC_DIM)

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -242,6 +242,12 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         "ctx_recent_usage": (0, 0),
         "ctx_source": "remote",
         "ctx_compaction_status_fn": None,
+        # #3283 ④: the keyed per-turn cost/token lookup is a SESSION-local read
+        # (the tracker's per-turn buckets are process-local, in-memory, and not
+        # projected onto the AG-UI wire) → None for remote, and the right
+        # gutter renders "—" rather than a fabricated figure. Same
+        # frame-sufficiency boundary as ``conversation_history`` above.
+        "turn_usage_fn": None,
         "cron_jobs": [],
         "mcp_servers": [],
         "hooks": [],

--- a/src/reyn/interfaces/repl/status.py
+++ b/src/reyn/interfaces/repl/status.py
@@ -330,6 +330,15 @@ def _snapshot(registry, config=None):
     # #3339: per-turn token/cost aggregate (see Session.last_turn_usage) — a
     # cheap dict read off the durable tracker, safe on every render frame.
     turn_usage = s.last_turn_usage
+    # #3283 ④: the KEYED per-turn lookup, stored UNCALLED (same shape as
+    # ``ctx_compaction_status_fn`` above, for a different reason). The three
+    # ``turn_*`` scalars below answer "the most recent turn"; a per-ROW surface
+    # (the TUI's right gutter) has to ask about an arbitrary turn's chain_id,
+    # once per rendered row — a snapshot scalar cannot carry that, and building
+    # a whole snapshot per row would be absurd. Handing over the bound method
+    # lets the row surface ask directly, and keeps the never-fabricate contract
+    # in ONE place (``BudgetTracker.turn_usage`` returns None, not 0).
+    turn_usage_fn = s.turn_usage
     return {
         "model": s.model,
         "model_active_class": s.active_model_class(),
@@ -356,8 +365,10 @@ def _snapshot(registry, config=None):
         # cumulative) and `ctx_used` (a single call). A call the OS could not
         # attribute to a turn is counted in no turn's total, so these figures
         # are never a difference of cumulative counters.
-        # All three are None when THERE IS NO FIGURE (before the first turn,
-        # or when the process-shared tracker's latest turn is a different one
+        # All three are None when THERE IS NO FIGURE — before this session's
+        # first turn, or once that turn has been evicted from the tracker's
+        # bounded per-turn buckets (#3283 ④ made this a KEYED read of this
+        # session's own turn, so another session's turn no longer displaces it
         # — see Session.last_turn_usage). Deliberately not 0: a zero would be
         # indistinguishable from a real zero-cost turn and would render as
         # fact, whereas None is loud in both directions (drawn as "None", or
@@ -365,6 +376,10 @@ def _snapshot(registry, config=None):
         "turn_chain_id": turn_usage["chain_id"],
         "turn_tokens": turn_usage["tokens"],
         "turn_cost_usd": turn_usage["cost_usd"],
+        # #3283 ④: keyed per-turn lookup ``(chain_id) -> dict | None``, for a
+        # surface that renders one figure PER ROW rather than one per session.
+        # Deliberately NOT called here (see the assignment above).
+        "turn_usage_fn": turn_usage_fn,
         "ctx_used": ctx_used,
         "ctx_window": ctx_window,
         "ctx_source": ctx_source,

--- a/src/reyn/interfaces/repl/status.py
+++ b/src/reyn/interfaces/repl/status.py
@@ -370,14 +370,18 @@ def _snapshot(registry, config=None):
         # bounded per-turn buckets (#3283 ④ made this a KEYED read of this
         # session's own turn, so another session's turn no longer displaces it
         # — see Session.last_turn_usage). Deliberately not 0: a zero would be
-        # indistinguishable from a real zero-cost turn and would render as
-        # fact, whereas None is loud in both directions (drawn as "None", or
-        # a TypeError on any arithmetic).
+        # indistinguishable from a turn that genuinely used nothing / cost
+        # nothing and would render as fact, whereas None is loud in both
+        # directions (drawn as "None", or a TypeError on any arithmetic).
+        # `last_turn_usage` also carries a prompt/completion split (#3283 ④);
+        # this bar shows the total, and the per-row TUI gutter shows the split
+        # off `turn_usage_fn` below.
         "turn_chain_id": turn_usage["chain_id"],
         "turn_tokens": turn_usage["tokens"],
         "turn_cost_usd": turn_usage["cost_usd"],
         # #3283 ④: keyed per-turn lookup ``(chain_id) -> dict | None``, for a
-        # surface that renders one figure PER ROW rather than one per session.
+        # surface that renders one figure PER ROW rather than one per session
+        # (the TUI right gutter, which draws the prompt/completion split).
         # Deliberately NOT called here (see the assignment above).
         "turn_usage_fn": turn_usage_fn,
         "ctx_used": ctx_used,

--- a/src/reyn/runtime/budget/budget.py
+++ b/src/reyn/runtime/budget/budget.py
@@ -816,7 +816,7 @@ def write_checkpoint(
 #
 # #3283 ④: readers now include a KEYED lookup for OLDER turns
 # (``turn_usage(chain_id)``), not only the latest one — the TUI's right gutter
-# asks "what did the turn this row belongs to cost", for rows scrolled well
+# asks "what did the turn this row belongs to use", for rows scrolled well
 # back. So eviction IS reachable for a real read, and the depth above is what
 # decides when. That is handled by contract rather than by depth: a keyed read
 # of an evicted (or never-recorded) turn returns ``None``, so the caller
@@ -880,7 +880,17 @@ class BudgetTracker:
         # ``_agent_cost_breakdown``): this is live-session display state, and
         # after a restart no turn of this process is in flight. The durable
         # record of a past turn's spend is the ledger's per-call ``chain_id``.
+        #
+        # #3283 ④: kept as a prompt/completion SPLIT as well as a total, so a
+        # reader can distinguish what a turn SENT from what it generated (the
+        # right gutter renders ``↑prompt ↓completion``). The split is recorded
+        # here rather than derived later for the same reason the turn key is:
+        # ``TokenUsage`` carries it at the call, and folding it to a total
+        # first would discard it irrecoverably. The ledger is unaffected — it
+        # persists ``total_tokens`` only, as before.
         self._turn_tokens: OrderedDict[str, int] = OrderedDict()
+        self._turn_prompt_tokens: OrderedDict[str, int] = OrderedDict()
+        self._turn_completion_tokens: OrderedDict[str, int] = OrderedDict()
         self._turn_cost_usd: OrderedDict[str, float] = OrderedDict()
         self._call_window: dict[str, deque[float]] = defaultdict(deque)
         self._warned: set[tuple[str, str]] = set()
@@ -1228,7 +1238,7 @@ class BudgetTracker:
         # #3339: per-turn attribution. Guarded on a real turn key — the None
         # (no turn in scope) path deliberately records nothing here.
         if chain_id is not None:
-            self._record_turn_usage(chain_id, usage.total_tokens, cost_usd)
+            self._record_turn_usage(chain_id, usage, cost_usd)
 
         if agent is not None:
             new_tokens = self._agent_tokens[agent] + usage.total_tokens
@@ -1507,6 +1517,15 @@ class BudgetTracker:
             # the point, not a defect. ``last_turn_chain_id`` names the most
             # recent key (None before any turn recorded spend).
             "turn_tokens": dict(self._turn_tokens),
+            # #3283 ④: the prompt/completion split of the same buckets. Exposed
+            # here as well as via ``turn_usage`` so the BOUND on them is
+            # observable from the public surface — otherwise a companion bucket
+            # that stopped being evicted with its total would grow without
+            # limit and no test could see it (membership is decided by
+            # ``turn_tokens``, so the leak would be invisible through the
+            # lookup).
+            "turn_prompt_tokens": dict(self._turn_prompt_tokens),
+            "turn_completion_tokens": dict(self._turn_completion_tokens),
             "turn_cost_usd": dict(self._turn_cost_usd),
             "last_turn_chain_id": self._last_turn_chain_id,
             "rate_window": {
@@ -1582,7 +1601,9 @@ class BudgetTracker:
         the prompt/completion breakdown is not persisted per ledger record (only ``total_tokens``)."""
         return self._agent_tokens.get(agent, 0)
 
-    def _record_turn_usage(self, chain_id: str, tokens: int, cost_usd: float) -> None:
+    def _record_turn_usage(
+        self, chain_id: str, usage: "TokenUsage", cost_usd: float
+    ) -> None:
         """Accumulate one call's tokens/cost into turn ``chain_id``'s bucket,
         keeping the bucket set bounded (oldest turn evicted past
         ``TURN_BUCKET_CAP``). Insertion order = turn order; a turn already
@@ -1600,16 +1621,32 @@ class BudgetTracker:
         will have been evicted in a long session. That is answered by contract
         — ``None`` for an absent bucket, never a fabricated ``0`` — rather than
         by trying to keep every turn forever."""
-        self._turn_tokens[chain_id] = self._turn_tokens.get(chain_id, 0) + tokens
+        self._turn_tokens[chain_id] = (
+            self._turn_tokens.get(chain_id, 0) + usage.total_tokens
+        )
+        self._turn_prompt_tokens[chain_id] = (
+            self._turn_prompt_tokens.get(chain_id, 0) + usage.prompt_tokens
+        )
+        self._turn_completion_tokens[chain_id] = (
+            self._turn_completion_tokens.get(chain_id, 0) + usage.completion_tokens
+        )
         self._turn_cost_usd[chain_id] = self._turn_cost_usd.get(chain_id, 0.0) + cost_usd
         self._last_turn_chain_id = chain_id
+        # Every companion bucket is evicted with its total, so a chain_id is
+        # either present in ALL of them or in none — which is what lets
+        # ``turn_usage`` decide "known vs unknown" from the total's membership
+        # alone and still return a complete dict.
         while len(self._turn_tokens) > TURN_BUCKET_CAP:
             evicted, _ = self._turn_tokens.popitem(last=False)
+            self._turn_prompt_tokens.pop(evicted, None)
+            self._turn_completion_tokens.pop(evicted, None)
             self._turn_cost_usd.pop(evicted, None)
 
     def latest_turn_usage(self) -> dict | None:
-        """#3339: ``{"chain_id", "tokens", "cost_usd"}`` for the MOST RECENT
-        turn that recorded spend, or ``None`` when no turn has.
+        """#3339: the per-turn figures for the MOST RECENT turn that recorded
+        spend, or ``None`` when no turn has. Same shape as :meth:`turn_usage` —
+        ``{"chain_id", "tokens", "prompt_tokens", "completion_tokens",
+        "cost_usd"}``.
 
         Tokens and cost are summed over every LLM call that turn made
         (tool-loop iterations included), each priced at its own model's rate —
@@ -1623,42 +1660,54 @@ class BudgetTracker:
         chain_id = self._last_turn_chain_id
         if chain_id is None:
             return None
-        return {
-            "chain_id": chain_id,
-            "tokens": self._turn_tokens.get(chain_id, 0),
-            "cost_usd": self._turn_cost_usd.get(chain_id, 0.0),
-        }
+        return self._turn_usage_dict(chain_id)
 
     def turn_usage(self, chain_id: str) -> dict | None:
-        """#3283 ④: ``{"chain_id", "tokens", "cost_usd"}`` for the turn
-        ``chain_id``, or ``None`` when this tracker holds no figure for it.
+        """#3283 ④: ``{"chain_id", "tokens", "prompt_tokens",
+        "completion_tokens", "cost_usd"}`` for the turn ``chain_id``, or
+        ``None`` when this tracker holds no figure for it.
 
-        The KEYED per-turn read. Tokens and cost are summed over every LLM call
-        that turn made (tool-loop iterations included), each priced at its own
-        model's rate — never derived by differencing cumulative counters.
+        The KEYED per-turn read. Tokens (total AND the prompt/completion
+        split) and cost are summed over every LLM call that turn made
+        (tool-loop iterations included), each priced at its own model's rate —
+        never derived by differencing cumulative counters.
 
         ``None`` — never a ``0`` — is the answer for EVERY "no figure" case,
         and there are three, indistinguishable from here and deliberately not
         distinguished: the turn never recorded spend (it made no LLM call, or
         it is not a turn of this process at all), or its bucket has been
         EVICTED (``TURN_BUCKET_CAP``). A ``0`` would be indistinguishable from
-        a turn that genuinely cost nothing, and a renderer that forgot to
-        branch would print it as fact; ``None`` makes that mistake loud (drawn
-        as "None", or a ``TypeError`` the moment anything does arithmetic).
+        a turn that genuinely used nothing / cost nothing — a reachable state,
+        not a hypothetical — and a renderer that forgot to branch would print
+        it as fact; ``None`` makes that mistake loud (drawn as "None", or a
+        ``TypeError`` the moment anything does arithmetic).
 
         This lookup was deliberately absent when the per-turn buckets landed
         (#3339): with no consumer, nothing would have enforced branching on
         "unknown", so the API was narrowed to :meth:`latest_turn_usage` to make
         the ambiguous question unaskable. #3283 ④'s right gutter is that
-        consumer — it renders one turn figure per conversation row, for rows
-        scrolled arbitrarily far back, and renders ``—`` on ``None``. The
+        consumer — it renders one turn's token figure per conversation row,
+        for rows scrolled arbitrarily far back, and renders ``—`` on ``None``.
+        (It does not display ``cost_usd``; that is a presentation choice at the
+        gutter, and this lookup still returns it for every other caller.) The
         durable record of an evicted turn's spend is the ledger's per-call
         ``chain_id``, which lets any past turn be re-grouped after the fact."""
         if chain_id not in self._turn_tokens:
             return None
+        return self._turn_usage_dict(chain_id)
+
+    def _turn_usage_dict(self, chain_id: str) -> dict:
+        """The per-turn figure dict for a chain_id KNOWN to have a bucket.
+
+        One builder for both public readers, so the two can never drift into
+        reporting different shapes for the same turn. ``prompt_tokens`` +
+        ``completion_tokens`` == ``tokens`` (``TokenUsage.total_tokens`` is
+        their sum, accumulated call by call)."""
         return {
             "chain_id": chain_id,
-            "tokens": self._turn_tokens[chain_id],
+            "tokens": self._turn_tokens.get(chain_id, 0),
+            "prompt_tokens": self._turn_prompt_tokens.get(chain_id, 0),
+            "completion_tokens": self._turn_completion_tokens.get(chain_id, 0),
             "cost_usd": self._turn_cost_usd.get(chain_id, 0.0),
         }
 

--- a/src/reyn/runtime/budget/budget.py
+++ b/src/reyn/runtime/budget/budget.py
@@ -809,13 +809,19 @@ def write_checkpoint(
 # ── tracker ─────────────────────────────────────────────────────────────────
 
 # #3339: how many recent turns keep a live per-turn token/cost bucket. The
-# consumer is the status surface ("what did this turn cost"), which reads the
-# most recent turn — the depth exists so a just-finished turn stays readable
-# while later turns run, not so history accumulates unbounded. The tracker is
-# process-shared, so N concurrent sessions share these buckets: the effective
-# per-session depth is CAP/N. Harmless while the only read is the latest turn
-# (never an eviction victim); a future reader of OLDER turns would have to
-# reckon with it.
+# depth exists so a just-finished turn stays readable while later turns run,
+# not so history accumulates unbounded. The tracker is process-shared, so N
+# concurrent sessions share these buckets: the effective per-session depth is
+# CAP/N.
+#
+# #3283 ④: readers now include a KEYED lookup for OLDER turns
+# (``turn_usage(chain_id)``), not only the latest one — the TUI's right gutter
+# asks "what did the turn this row belongs to cost", for rows scrolled well
+# back. So eviction IS reachable for a real read, and the depth above is what
+# decides when. That is handled by contract rather than by depth: a keyed read
+# of an evicted (or never-recorded) turn returns ``None``, so the caller
+# renders "unknown" instead of a fabricated ``0``. The durable record of an
+# evicted turn's spend is the ledger's per-call ``chain_id``.
 TURN_BUCKET_CAP = 64
 
 
@@ -1587,9 +1593,13 @@ class BudgetTracker:
         Insertion order tracks recency only because turns run SEQUENTIALLY
         within a session — a turn that stayed open across more than
         ``TURN_BUCKET_CAP`` later turns would be evicted while still live.
-        That is unreachable while a session runs one turn at a time, and the
-        only reader (``latest_turn_usage``) asks about the turn that just
-        recorded, which is never the eviction victim."""
+        That is unreachable while a session runs one turn at a time.
+
+        Eviction IS observable to a reader, though: ``turn_usage(chain_id)``
+        (#3283 ④) asks about turns arbitrarily far back, so the oldest of them
+        will have been evicted in a long session. That is answered by contract
+        — ``None`` for an absent bucket, never a fabricated ``0`` — rather than
+        by trying to keep every turn forever."""
         self._turn_tokens[chain_id] = self._turn_tokens.get(chain_id, 0) + tokens
         self._turn_cost_usd[chain_id] = self._turn_cost_usd.get(chain_id, 0.0) + cost_usd
         self._last_turn_chain_id = chain_id
@@ -1605,18 +1615,50 @@ class BudgetTracker:
         (tool-loop iterations included), each priced at its own model's rate —
         never derived by differencing cumulative counters.
 
-        Deliberately latest-turn-only, with no ``usage(chain_id)`` sibling. A
-        keyed lookup would have to answer for a turn whose bucket has been
-        evicted (``TURN_BUCKET_CAP``), and the only shapes available there are
-        a fabricated ``0`` or an ``unknown`` sentinel every caller must
-        remember to check. The latest turn can never be the eviction victim,
-        so an API that only asks about it cannot ask the ambiguous question."""
+        Convenience over :meth:`turn_usage` for the caller that does not hold a
+        chain_id — "whatever ran last, process-wide". A caller that DOES know
+        which turn it is asking about should use :meth:`turn_usage` instead:
+        the latest turn process-wide is often not the turn that caller means
+        (one tracker, several sessions)."""
         chain_id = self._last_turn_chain_id
         if chain_id is None:
             return None
         return {
             "chain_id": chain_id,
             "tokens": self._turn_tokens.get(chain_id, 0),
+            "cost_usd": self._turn_cost_usd.get(chain_id, 0.0),
+        }
+
+    def turn_usage(self, chain_id: str) -> dict | None:
+        """#3283 ④: ``{"chain_id", "tokens", "cost_usd"}`` for the turn
+        ``chain_id``, or ``None`` when this tracker holds no figure for it.
+
+        The KEYED per-turn read. Tokens and cost are summed over every LLM call
+        that turn made (tool-loop iterations included), each priced at its own
+        model's rate — never derived by differencing cumulative counters.
+
+        ``None`` — never a ``0`` — is the answer for EVERY "no figure" case,
+        and there are three, indistinguishable from here and deliberately not
+        distinguished: the turn never recorded spend (it made no LLM call, or
+        it is not a turn of this process at all), or its bucket has been
+        EVICTED (``TURN_BUCKET_CAP``). A ``0`` would be indistinguishable from
+        a turn that genuinely cost nothing, and a renderer that forgot to
+        branch would print it as fact; ``None`` makes that mistake loud (drawn
+        as "None", or a ``TypeError`` the moment anything does arithmetic).
+
+        This lookup was deliberately absent when the per-turn buckets landed
+        (#3339): with no consumer, nothing would have enforced branching on
+        "unknown", so the API was narrowed to :meth:`latest_turn_usage` to make
+        the ambiguous question unaskable. #3283 ④'s right gutter is that
+        consumer — it renders one turn figure per conversation row, for rows
+        scrolled arbitrarily far back, and renders ``—`` on ``None``. The
+        durable record of an evicted turn's spend is the ledger's per-call
+        ``chain_id``, which lets any past turn be re-grouped after the fact."""
+        if chain_id not in self._turn_tokens:
+            return None
+        return {
+            "chain_id": chain_id,
+            "tokens": self._turn_tokens[chain_id],
             "cost_usd": self._turn_cost_usd.get(chain_id, 0.0),
         }
 

--- a/src/reyn/runtime/budget/budget.py
+++ b/src/reyn/runtime/budget/budget.py
@@ -824,6 +824,34 @@ def write_checkpoint(
 # evicted turn's spend is the ledger's per-call ``chain_id``.
 TURN_BUCKET_CAP = 64
 
+#: Every per-turn bucket, as ``(attribute name, snapshot key)`` — the SINGLE
+#: declaration of the set, iterated by ``_record_turn_usage``'s eviction loop
+#: and by ``snapshot()`` rather than each re-listing the buckets by hand. Same
+#: shape as ``TextualChatApp._PER_SESSION_DICT_STATE`` (#3310 N2).
+#:
+#: ★ Why a declaration and not four hand-written lines: membership of a turn is
+#: decided by ``_turn_tokens`` ALONE (see :meth:`BudgetTracker.turn_usage`),
+#: which is the right call — one authority, no way for the buckets to disagree
+#: about which turns exist — but it has a second-order consequence. A COMPANION
+#: bucket that stops being evicted grows without limit while every lookup keeps
+#: answering correctly, so no behavioural test can see it: the leak is
+#: invisible precisely BECAUSE the membership decision is clean. Registering a
+#: bucket here is what makes it both bounded and observable
+#: (``snapshot()`` exposes it, and the bound is asserted against that).
+#:
+#: A new bucket MUST be added here. What this tuple does NOT cover:
+#: ``_record_turn_usage``'s accumulation (each bucket sums a different field of
+#: ``TokenUsage``, so there is nothing uniform to drive) and
+#: ``_turn_usage_dict``'s return shape (hand-written on purpose — it is the
+#: documented public contract of ``turn_usage``). Missing either of those is a
+#: visible gap, not a silent leak; missing THIS one is the silent leak.
+_PER_TURN_BUCKETS: "tuple[tuple[str, str], ...]" = (
+    ("_turn_tokens", "turn_tokens"),
+    ("_turn_prompt_tokens", "turn_prompt_tokens"),
+    ("_turn_completion_tokens", "turn_completion_tokens"),
+    ("_turn_cost_usd", "turn_cost_usd"),
+)
+
 
 class BudgetTracker:
     """Process-wide accumulator + hybrid-cap enforcer.
@@ -1516,17 +1544,16 @@ class BudgetTracker:
             # so summing these does not reproduce the session total — that is
             # the point, not a defect. ``last_turn_chain_id`` names the most
             # recent key (None before any turn recorded spend).
-            "turn_tokens": dict(self._turn_tokens),
-            # #3283 ④: the prompt/completion split of the same buckets. Exposed
-            # here as well as via ``turn_usage`` so the BOUND on them is
-            # observable from the public surface — otherwise a companion bucket
-            # that stopped being evicted with its total would grow without
-            # limit and no test could see it (membership is decided by
-            # ``turn_tokens``, so the leak would be invisible through the
-            # lookup).
-            "turn_prompt_tokens": dict(self._turn_prompt_tokens),
-            "turn_completion_tokens": dict(self._turn_completion_tokens),
-            "turn_cost_usd": dict(self._turn_cost_usd),
+            # Every per-turn bucket, projected from the ONE declaration of the
+            # set (:data:`_PER_TURN_BUCKETS`). Exposing them all is what makes
+            # their BOUND observable: a bucket that stopped being evicted would
+            # otherwise grow without limit while every lookup still answered
+            # correctly. Keys: turn_tokens / turn_prompt_tokens /
+            # turn_completion_tokens / turn_cost_usd.
+            **{
+                snap_key: dict(getattr(self, attr_name))
+                for attr_name, snap_key in _PER_TURN_BUCKETS
+            },
             "last_turn_chain_id": self._last_turn_chain_id,
             "rate_window": {
                 m: len([t for t in q if time.monotonic() - t <= 60])
@@ -1632,15 +1659,17 @@ class BudgetTracker:
         )
         self._turn_cost_usd[chain_id] = self._turn_cost_usd.get(chain_id, 0.0) + cost_usd
         self._last_turn_chain_id = chain_id
-        # Every companion bucket is evicted with its total, so a chain_id is
-        # either present in ALL of them or in none — which is what lets
-        # ``turn_usage`` decide "known vs unknown" from the total's membership
-        # alone and still return a complete dict.
+        # EVERY bucket is evicted together, so a chain_id is either present in
+        # ALL of them or in none — which is what lets ``turn_usage`` decide
+        # "known vs unknown" from ``_turn_tokens``'s membership alone and still
+        # return a complete dict. Driven off :data:`_PER_TURN_BUCKETS` rather
+        # than a hand-written list of ``pop`` calls, so a future bucket is
+        # evicted the moment it is registered there — see that constant for why
+        # forgetting one is an INVISIBLE leak rather than a visible bug.
         while len(self._turn_tokens) > TURN_BUCKET_CAP:
             evicted, _ = self._turn_tokens.popitem(last=False)
-            self._turn_prompt_tokens.pop(evicted, None)
-            self._turn_completion_tokens.pop(evicted, None)
-            self._turn_cost_usd.pop(evicted, None)
+            for attr_name, _snap_key in _PER_TURN_BUCKETS:
+                getattr(self, attr_name).pop(evicted, None)
 
     def latest_turn_usage(self) -> dict | None:
         """#3339: the per-turn figures for the MOST RECENT turn that recorded

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1566,27 +1566,39 @@ class Session:
         silently.
 
         "No figure" occurs before this session's first router turn, with no
-        tracker wired (unlimited mode), and when the tracker's latest turn is
-        a DIFFERENT turn than this session's last one — the tracker is
-        process-shared and answers only about the latest turn process-wide
-        (see ``BudgetTracker.latest_turn_usage``). That last case is common,
-        not exotic: several sessions share one tracker, so any turn elsewhere
-        moves "latest" off this session. This session's own last turn is real
-        and its figure IS still held in the tracker's buckets — we CHOSE not
-        to reach for it, because retrieving it means reintroducing the keyed
-        lookup that #3339 deliberately closed (a keyed read has to answer for
-        an evicted turn, and its only available answers are a fabricated 0 or
-        an unknown-sentinel every caller must remember to check). Reporting
-        "unknown" is the cost of keeping that question unaskable."""
+        tracker wired (unlimited mode), and when this session's last turn has
+        been EVICTED from the tracker's bounded per-turn buckets
+        (``TURN_BUCKET_CAP``).
+
+        Read via the KEYED ``BudgetTracker.turn_usage(chain_id)`` (#3283 ④),
+        NOT ``latest_turn_usage()``: the tracker is process-shared, so "the
+        latest turn process-wide" is routinely some OTHER session's turn while
+        this session's own last turn is sitting right there in the buckets.
+        Asking for this session's own key answers the question actually being
+        asked, and cannot return another session's number."""
         _none = {"chain_id": None, "tokens": None, "cost_usd": None}
         chain_id = self._last_turn_chain_id
         tracker = self._budget_tracker
         if chain_id is None or tracker is None:
             return _none
-        latest = tracker.latest_turn_usage()
-        if latest is None or latest["chain_id"] != chain_id:
-            return _none
-        return latest
+        return tracker.turn_usage(chain_id) or _none
+
+    def turn_usage(self, chain_id: str) -> "dict | None":
+        """#3283 ④: tokens + USD cost of the turn ``chain_id`` —
+        ``{"chain_id", "tokens", "cost_usd"}``, or ``None`` when there is no
+        figure for that turn (never recorded, evicted from the tracker's
+        bounded buckets, or no tracker wired at all).
+
+        The KEYED sibling of :attr:`last_turn_usage`, for a caller that already
+        knows which turn it is asking about — the TUI's right gutter, which
+        renders one turn figure per conversation row and shows ``—`` on
+        ``None``. Same never-fabricate contract as the tracker's own
+        ``turn_usage``: no ``0`` stands in for "unknown", and no figure is ever
+        derived by differencing cumulative counters."""
+        tracker = self._budget_tracker
+        if tracker is None:
+            return None
+        return tracker.turn_usage(chain_id)
 
     @property
     def total_cost_breakdown(self):

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1548,7 +1548,8 @@ class Session:
     @property
     def last_turn_usage(self) -> dict:
         """#3339: tokens + USD cost of this session's MOST RECENT turn —
-        ``{"chain_id", "tokens", "cost_usd"}``.
+        ``{"chain_id", "tokens", "prompt_tokens", "completion_tokens",
+        "cost_usd"}`` (the same shape ``BudgetTracker.turn_usage`` returns).
 
         A real per-turn aggregate: the durable tracker summed the actual
         per-call figures of every LLM call made under this turn's chain_id
@@ -1557,13 +1558,18 @@ class Session:
         the cost of a call the OS could not attribute to a turn is in no
         turn's total at all.
 
-        When there is no figure, ALL THREE values are ``None`` — never a
-        placeholder ``0``. A zero is indistinguishable from a real zero-cost
-        turn, and a renderer that forgot to check would print it as fact;
-        ``None`` makes the same mistake loud (drawn as "None", or a
-        ``TypeError`` the moment anything does arithmetic on it). No
-        convention for a consumer to remember, and nothing to get wrong
-        silently.
+        When there is no figure, EVERY value is ``None`` — never a placeholder
+        ``0``. A zero is indistinguishable from a turn that genuinely used
+        nothing / cost nothing, and a renderer that forgot to check would print
+        it as fact; ``None`` makes the same mistake loud (drawn as "None", or a
+        ``TypeError`` the moment anything does arithmetic on it). No convention
+        for a consumer to remember, and nothing to get wrong silently.
+
+        The KEY SET is identical in both cases, so a consumer can read any
+        field without first branching on which case it got — only the VALUES
+        differ. A no-figure dict missing the keys the success dict carries
+        would turn "no figure" into a ``KeyError`` at a different call site
+        than the one that forgot to check.
 
         "No figure" occurs before this session's first router turn, with no
         tracker wired (unlimited mode), and when this session's last turn has
@@ -1576,7 +1582,13 @@ class Session:
         this session's own last turn is sitting right there in the buckets.
         Asking for this session's own key answers the question actually being
         asked, and cannot return another session's number."""
-        _none = {"chain_id": None, "tokens": None, "cost_usd": None}
+        _none = {
+            "chain_id": None,
+            "tokens": None,
+            "prompt_tokens": None,
+            "completion_tokens": None,
+            "cost_usd": None,
+        }
         chain_id = self._last_turn_chain_id
         tracker = self._budget_tracker
         if chain_id is None or tracker is None:
@@ -1585,14 +1597,17 @@ class Session:
 
     def turn_usage(self, chain_id: str) -> "dict | None":
         """#3283 ④: tokens + USD cost of the turn ``chain_id`` —
-        ``{"chain_id", "tokens", "cost_usd"}``, or ``None`` when there is no
-        figure for that turn (never recorded, evicted from the tracker's
-        bounded buckets, or no tracker wired at all).
+        ``{"chain_id", "tokens", "prompt_tokens", "completion_tokens",
+        "cost_usd"}``, or ``None`` when there is no figure for that turn (never
+        recorded, evicted from the tracker's bounded buckets, or no tracker
+        wired at all).
 
         The KEYED sibling of :attr:`last_turn_usage`, for a caller that already
         knows which turn it is asking about — the TUI's right gutter, which
-        renders one turn figure per conversation row and shows ``—`` on
-        ``None``. Same never-fabricate contract as the tracker's own
+        renders one turn's ``↑prompt ↓completion`` split per conversation row
+        and shows ``—`` on ``None``. (It does not display ``cost_usd``; the
+        field is still returned for every other caller.) Same never-fabricate
+        contract as the tracker's own
         ``turn_usage``: no ``0`` stands in for "unknown", and no figure is ever
         derived by differencing cumulative counters."""
         tracker = self._budget_tracker

--- a/tests/test_textual_chat_phase4_turn_cost_gutter_3283.py
+++ b/tests/test_textual_chat_phase4_turn_cost_gutter_3283.py
@@ -91,7 +91,12 @@ from reyn.interfaces.repl.status import _snapshot
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.llm.pricing import TokenUsage
-from reyn.runtime.budget.budget import TURN_BUCKET_CAP, BudgetTracker, CostConfig
+from reyn.runtime.budget.budget import (
+    _PER_TURN_BUCKETS,
+    TURN_BUCKET_CAP,
+    BudgetTracker,
+    CostConfig,
+)
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.profile import AgentProfile
@@ -196,34 +201,52 @@ def test_keyed_turn_usage_sums_a_multi_call_turn_and_isolates_turns() -> None:
 
 
 def test_every_per_turn_bucket_is_bounded_not_only_the_total() -> None:
-    """Tier 2: the prompt/completion buckets #3283 ④ added are evicted WITH
-    their total, so all of them stay bounded by ``TURN_BUCKET_CAP``.
+    """Tier 2: EVERY per-turn bucket is evicted with its total, so all of them
+    stay bounded by ``TURN_BUCKET_CAP``.
 
-    ★ Why this is asserted on ``snapshot()`` rather than inferred from
-    ``turn_usage``: membership is decided by the TOTAL bucket, so a companion
-    bucket that stopped being evicted would keep growing forever while every
-    lookup still answered correctly — an invisible unbounded-memory leak. A
-    strip that removed the companion evictions initially stayed GREEN for
-    exactly that reason; the public snapshot keys are what give the bound a
-    witness. Bounding is a cross-cutting-band obligation, not an optimisation."""
+    ★ Enumerated from :data:`_PER_TURN_BUCKETS` — the same declaration
+    ``_record_turn_usage``'s eviction loop iterates — NOT from a hand-written
+    list of bucket names. A hand-written list reopens the very hole this test
+    exists to close: whoever adds a fifth bucket and forgets both the evict
+    loop and the list reproduces the identical invisible leak, with every
+    behavioural test still green. Sharing one declaration means registering a
+    bucket is what makes it both evicted and checked, in one edit.
+
+    ★ Why the leak is invisible without this: membership of a turn is decided
+    by ``_turn_tokens`` alone, so a companion bucket that stopped being evicted
+    would grow without limit while ``turn_usage`` kept answering correctly. The
+    correct design decision — one authority for membership — is exactly what
+    hides the defect on the memory axis. It is reachable only by stripping.
+
+    ★ Asserted on ``snapshot()`` (public) rather than the private dicts.
+    """
+    assert _PER_TURN_BUCKETS, (
+        "the bucket declaration is empty — this gate would pass by having "
+        "nothing to check"
+    )
     tracker = BudgetTracker(CostConfig())
     for i in range(TURN_BUCKET_CAP + 5):
         _record(tracker, f"turn-{i:03d}", prompt=100 + i, completion=7)
 
     snap = tracker.snapshot()
-    for key in ("turn_tokens", "turn_prompt_tokens", "turn_completion_tokens",
-                "turn_cost_usd"):
-        assert len(snap[key]) == TURN_BUCKET_CAP, (
-            f"{key} grew to {len(snap[key])}, past the {TURN_BUCKET_CAP} cap"
+    seen: "list[set[str]]" = []
+    for _attr_name, snap_key in _PER_TURN_BUCKETS:
+        assert snap_key in snap, (
+            f"{snap_key!r} is declared in _PER_TURN_BUCKETS but the snapshot "
+            "does not expose it — its bound would be unobservable"
         )
+        assert len(snap[snap_key]) == TURN_BUCKET_CAP, (
+            f"{snap_key} grew to {len(snap[snap_key])}, past the "
+            f"{TURN_BUCKET_CAP} cap"
+        )
+        seen.append(set(snap[snap_key]))
+
     # ...and they evict the SAME turns, so a surviving turn is never left with
-    # a total but no split (or the reverse).
-    assert (
-        set(snap["turn_tokens"])
-        == set(snap["turn_prompt_tokens"])
-        == set(snap["turn_completion_tokens"])
-        == set(snap["turn_cost_usd"])
-    ), "the per-turn buckets evicted different turns and are now inconsistent"
+    # a total but no split (or the reverse) — the invariant ``turn_usage``
+    # relies on when it decides membership from the total alone.
+    assert all(keys == seen[0] for keys in seen), (
+        "the per-turn buckets evicted different turns and are now inconsistent"
+    )
 
 
 def test_a_turnless_call_creates_no_lookup_answer() -> None:

--- a/tests/test_textual_chat_phase4_turn_cost_gutter_3283.py
+++ b/tests/test_textual_chat_phase4_turn_cost_gutter_3283.py
@@ -23,9 +23,18 @@ These pin:
 - **the same three outcomes on the RENDERED gutter cell** (Tier 1): the figure,
   ``—``, ``—`` — read off ``decorate()``'s output, and asserted mutually
   distinct in one place so "all three render the same thing" cannot pass.
-- **no non-zero spend ever renders as free** (Tier 1): a sub-hundredth-of-a-cent
-  turn renders a ``<``-prefixed floor, never ``$0`` (which is reserved for a
-  genuinely zero — unpriced-model — turn) and never ``—``.
+- **a real zero stays distinct from unknown** (Tier 1): a turn that recorded
+  0 tokens renders ``↑0 ↓0`` — a measured fact — while a turn with no figure
+  renders ``—``. Collapsing the two would report an unmeasured turn as a
+  measured empty one. (The USD half is no longer displayed at all — owner call;
+  ``turn_usage`` still returns ``cost_usd`` and the lookup is unchanged.)
+- **prompt and completion are separately legible** (Tier 1): the cell carries
+  BOTH figures with their direction markers, so an implementation that showed
+  only a total, or only one side, fails.
+- **the column is sized in terminal CELLS, not characters** (Tier 1): the
+  direction markers are East Asian Ambiguous width, so the width bound is
+  asserted with ``rich.cells.cell_len`` — the renderer's own measure — not
+  ``len()``.
 - **the anchor decision** (Tier 1): the turn figure rides the ``kind="agent"``
   reply row that concludes a turn's visible output, NOT every row of the turn —
   the same total repeated N times in a column whose other label family is
@@ -52,10 +61,12 @@ All collaborators are real: a real :class:`BudgetTracker` (its bound
 from __future__ import annotations
 
 import asyncio
+import unicodedata
 from pathlib import Path
 from typing import AsyncIterator
 
 import pytest
+from rich.cells import cell_len
 from textual_flowview import FlowModel, FlowView
 
 from reyn.core.events.state_log import StateLog
@@ -67,9 +78,12 @@ from reyn.interfaces.inline.textual_chat import (
 )
 from reyn.interfaces.inline.textual_chat._meta_keys import RUNNING_SINCE_KEY
 from reyn.interfaces.inline.textual_chat.gutter import (
+    COMPLETION_TOKENS_MARKER,
+    PROMPT_TOKENS_MARKER,
     RIGHT_GUTTER_WIDTH,
     TURN_ANCHOR_KIND,
     TURN_USAGE_UNKNOWN,
+    _cell_pad_left,
 )
 from reyn.interfaces.inline.textual_chat.restore import project_restored_frames
 from reyn.interfaces.repl.read_model import ChatReadModel, project_remote_snapshot
@@ -141,9 +155,12 @@ def test_keyed_turn_usage_answers_known_evicted_and_unseen_distinctly() -> None:
     assert known["tokens"] == 100 + len(turns) - 1 + 7, (
         "the figure must be the real sum of that turn's own calls"
     )
+    assert known["prompt_tokens"] + known["completion_tokens"] == known["tokens"], (
+        "the split must reconcile with the total it was accumulated alongside"
+    )
     assert known["cost_usd"] > 0.0, (
-        f"{_MODEL} is priced, so a real turn's cost must be non-zero — "
-        "otherwise the cost half of this gate is vacuous"
+        f"{_MODEL} is priced, so the lookup must still carry a real cost — the "
+        "gutter stopped DISPLAYING cost, the lookup did not stop returning it"
     )
 
     assert tracker.turn_usage(evicted) is None, (
@@ -173,6 +190,40 @@ def test_keyed_turn_usage_sums_a_multi_call_turn_and_isolates_turns() -> None:
     assert a["cost_usd"] > b["cost_usd"] or a["tokens"] != b["tokens"], (
         "the two turns must be separately accounted"
     )
+    assert a["prompt_tokens"] == 1234 + 89 and a["completion_tokens"] == 567 + 21, (
+        "prompt and completion must each sum over the turn's own calls"
+    )
+
+
+def test_every_per_turn_bucket_is_bounded_not_only_the_total() -> None:
+    """Tier 2: the prompt/completion buckets #3283 ④ added are evicted WITH
+    their total, so all of them stay bounded by ``TURN_BUCKET_CAP``.
+
+    ★ Why this is asserted on ``snapshot()`` rather than inferred from
+    ``turn_usage``: membership is decided by the TOTAL bucket, so a companion
+    bucket that stopped being evicted would keep growing forever while every
+    lookup still answered correctly — an invisible unbounded-memory leak. A
+    strip that removed the companion evictions initially stayed GREEN for
+    exactly that reason; the public snapshot keys are what give the bound a
+    witness. Bounding is a cross-cutting-band obligation, not an optimisation."""
+    tracker = BudgetTracker(CostConfig())
+    for i in range(TURN_BUCKET_CAP + 5):
+        _record(tracker, f"turn-{i:03d}", prompt=100 + i, completion=7)
+
+    snap = tracker.snapshot()
+    for key in ("turn_tokens", "turn_prompt_tokens", "turn_completion_tokens",
+                "turn_cost_usd"):
+        assert len(snap[key]) == TURN_BUCKET_CAP, (
+            f"{key} grew to {len(snap[key])}, past the {TURN_BUCKET_CAP} cap"
+        )
+    # ...and they evict the SAME turns, so a surviving turn is never left with
+    # a total but no split (or the reverse).
+    assert (
+        set(snap["turn_tokens"])
+        == set(snap["turn_prompt_tokens"])
+        == set(snap["turn_completion_tokens"])
+        == set(snap["turn_cost_usd"])
+    ), "the per-turn buckets evicted different turns and are now inconsistent"
 
 
 def test_a_turnless_call_creates_no_lookup_answer() -> None:
@@ -202,10 +253,10 @@ def test_a_turnless_call_creates_no_lookup_answer() -> None:
 
 def test_gutter_renders_figure_for_known_turn_and_dash_for_unknown_and_evicted() -> None:
     """Tier 1: the three outcomes as the operator sees them, asserted MUTUALLY
-    DISTINCT so "every row renders the same thing" cannot pass. A priced turn
-    shows tokens + USD; an EVICTED turn and an UNSEEN chain_id both show
-    :data:`TURN_USAGE_UNKNOWN` — never ``0``, and never an empty cell (which on
-    a row that names a turn would read as "this turn was free")."""
+    DISTINCT so "every row renders the same thing" cannot pass. A recorded turn
+    shows its prompt/completion split; an EVICTED turn and an UNSEEN chain_id
+    both show :data:`TURN_USAGE_UNKNOWN` — never ``0``, and never an empty cell
+    (which on a row that names a turn would read as "this turn used nothing")."""
     tracker = BudgetTracker(CostConfig())
     turns = [f"turn-{i:03d}" for i in range(TURN_BUCKET_CAP + 2)]
     for i, chain_id in enumerate(turns):
@@ -218,8 +269,15 @@ def test_gutter_renders_figure_for_known_turn_and_dash_for_unknown_and_evicted()
     unseen_label = _label(gutter, _agent_row("turn-never-seen"))
 
     assert known_label not in ("", TURN_USAGE_UNKNOWN), known_label
-    assert "$" in known_label, f"the USD half is missing: {known_label!r}"
-    assert "0" not in known_label.split()[0] or known_label.split()[0] != "0", known_label
+    assert PROMPT_TOKENS_MARKER in known_label, (
+        f"the prompt half is missing: {known_label!r}"
+    )
+    assert COMPLETION_TOKENS_MARKER in known_label, (
+        f"the completion half is missing: {known_label!r}"
+    )
+    assert "$" not in known_label, (
+        f"the USD figure was dropped from this column by decision: {known_label!r}"
+    )
     assert evicted_label == TURN_USAGE_UNKNOWN, evicted_label
     assert unseen_label == TURN_USAGE_UNKNOWN, unseen_label
     assert known_label != evicted_label, (
@@ -258,46 +316,58 @@ def test_remote_snapshot_publishes_no_turn_usage_lookup() -> None:
     assert project_remote_snapshot({"model": "gpt-4o"})["turn_usage_fn"] is None
 
 
-def test_zero_cost_turn_renders_a_real_zero_distinct_from_unknown() -> None:
-    """Tier 1: ``$0`` and ``—`` mean different things and must render
-    differently. A turn recorded against an UNPRICED model genuinely cost
-    nothing — that is a real figure, and it must not be laundered into
-    "unknown"; conversely "unknown" must not be laundered into ``$0``."""
+def test_zero_token_turn_renders_a_real_zero_distinct_from_unknown() -> None:
+    """Tier 1: ``↑0 ↓0`` and ``—`` mean different things and must render
+    differently. A turn whose calls reported no usage genuinely used 0 tokens —
+    that is a measured fact and must not be laundered into "unknown";
+    conversely "unknown" must never be laundered into a zero.
+
+    This is the state that SURVIVED the narrowing. Before the gutter dropped
+    cost, the real-zero-vs-unknown pair was carried by ``$0`` vs ``—``; it now
+    has to be carried by the token figures, and if it were dropped along with
+    the cost column the two meanings would silently merge."""
     tracker = BudgetTracker(CostConfig())
     tracker.record_llm(
-        model="a-model-no-catalog-prices",
+        model=_MODEL,
         agent="alpha",
-        usage=TokenUsage(prompt_tokens=500, completion_tokens=100),
-        chain_id="turn-free",
+        usage=TokenUsage(prompt_tokens=0, completion_tokens=0),
+        chain_id="turn-empty",
     )
-    usage = tracker.turn_usage("turn-free")
-    assert usage is not None and usage["cost_usd"] == 0.0, (
-        "fixture must actually be an unpriced (zero-cost) turn"
+    usage = tracker.turn_usage("turn-empty")
+    assert usage is not None and usage["tokens"] == 0, (
+        "fixture must actually be a recorded turn with a zero token total"
     )
 
     gutter = ReynTurnUsageGutter(usage_lookup=tracker.turn_usage)
-    label = _label(gutter, _agent_row("turn-free"))
+    label = _label(gutter, _agent_row("turn-empty"))
     assert label != TURN_USAGE_UNKNOWN, (
-        f"a genuinely free turn must show its real $0, not 'unknown': {label!r}"
+        f"a measured zero-token turn must show its real 0, not 'unknown': {label!r}"
     )
-    assert "600" in label, f"the token half must still be the real count: {label!r}"
-    assert "$0" in label, label
+    assert label == f"{PROMPT_TOKENS_MARKER}0 {COMPLETION_TOKENS_MARKER}0", label
+    # ...and the unknown leg still renders differently, on the same gutter.
+    assert _label(gutter, _agent_row("turn-absent")) == TURN_USAGE_UNKNOWN
 
 
-def test_a_tiny_but_real_spend_never_renders_as_free() -> None:
-    """Tier 1: the rounding hazard — a turn whose cost is smaller than the
-    smallest exactly-printable figure must NOT render as ``$0`` (free) or as
-    ``—`` (unknown). It renders a ``<``-prefixed floor: real spend, honestly
-    bounded."""
+def test_the_smallest_real_token_counts_render_exactly_not_rounded_away() -> None:
+    """Tier 1: the rounding hazard, retargeted from cost to tokens. A one-token
+    prompt or completion must render as ``1``, never rounded down into a ``0``
+    that would read as "nothing was sent/generated" and never ``—``.
+
+    Structurally safe rather than merely tested: :func:`_format_tokens` prints
+    counts below 1000 exactly (``str(n)``), so there is no band in which a
+    non-zero count can round to zero — this pins that property."""
     gutter = ReynTurnUsageGutter(
-        usage_lookup=lambda cid: {"chain_id": cid, "tokens": 3, "cost_usd": 1e-9}
+        usage_lookup=lambda cid: {
+            "chain_id": cid,
+            "tokens": 2,
+            "prompt_tokens": 1,
+            "completion_tokens": 1,
+            "cost_usd": 0.0,
+        }
     )
     label = _label(gutter, _agent_row("turn-tiny"))
     assert label != TURN_USAGE_UNKNOWN, label
-    assert "$0 " not in label and not label.endswith("$0"), (
-        f"a real non-zero spend rendered as free: {label!r}"
-    )
-    assert "<" in label, f"expected a bounded floor form, got {label!r}"
+    assert label == f"{PROMPT_TOKENS_MARKER}1 {COMPLETION_TOKENS_MARKER}1", label
 
 
 # ── Gate 3: the anchor decision — one figure per turn, not one per row ────────
@@ -315,23 +385,24 @@ def test_a_tiny_but_real_spend_never_renders_as_free() -> None:
         OutboxMessage(kind="reasoning", text="thinking", meta={"chain_id": "turn-A"}),
     ],
 )
-def test_non_anchor_rows_of_a_priced_turn_show_no_cost_figure(
+def test_non_anchor_rows_of_a_recorded_turn_show_no_token_figure(
     item: OutboxMessage,
 ) -> None:
     """Tier 1: the turn figure is ANCHORED to the reply row, so the turn's OTHER
     rows — its user line, its tool calls, its reasoning — render no cost cell
-    even though their frames carry the very same priced ``chain_id``. Repeating
-    one turn total down every row of the turn, in a column whose other label
-    family (elapsed) IS per-row, would read as N separate per-row costs."""
+    even though their frames carry the very same recorded ``chain_id``.
+    Repeating one turn total down every row of the turn, in a column whose
+    other label family (elapsed) IS per-row, would read as N separate per-row
+    figures."""
     tracker = BudgetTracker(CostConfig())
     _record(tracker, "turn-A", prompt=1000, completion=200)
     gutter = ReynTurnUsageGutter(usage_lookup=tracker.turn_usage)
 
     assert tracker.turn_usage("turn-A") is not None, (
-        "fixture must price turn-A, or this negative control is vacuous"
+        "fixture must record turn-A, or this negative control is vacuous"
     )
     assert _label(gutter, item) == "", (
-        f"a non-anchor row of a priced turn must show no cost figure: {item.kind}"
+        f"a non-anchor row of a recorded turn must show no figure: {item.kind}"
     )
     # ...while the anchor row of that SAME turn does — so the empty cells above
     # are the anchoring decision, not a broken lookup.
@@ -407,31 +478,41 @@ def test_the_composite_right_gutter_carries_both_label_families() -> None:
         "the elapsed half must still speak through the composite"
     )
     reply = _label(gutter, _agent_row("turn-A"))
-    assert "$" in reply, f"the turn-cost half is missing: {reply!r}"
+    assert PROMPT_TOKENS_MARKER in reply and COMPLETION_TOKENS_MARKER in reply, (
+        f"the turn-token half is missing: {reply!r}"
+    )
 
 
 def test_every_label_the_column_can_emit_fits_the_configured_width() -> None:
     """Tier 1: :data:`RIGHT_GUTTER_WIDTH` is COMPUTED from the widest label,
     not guessed — so an extreme-but-reachable figure must not overflow the
-    column. Drives the widest shapes of both halves (a huge token count, a
-    huge cost, the sub-floor cost form, a long elapsed) through the real
-    composite."""
-    token_edges = [
+    column. Sweeps every band edge of :func:`_format_tokens` against itself for
+    BOTH halves of the split (the worst case is a large prompt AND a large
+    completion), plus the elapsed family's longest label.
+
+    Measured in terminal CELLS via ``rich.cells.cell_len`` — the same measure
+    Textual's compositor applies — not ``len()``. The direction markers are
+    East Asian Ambiguous width, so a character count would be the wrong
+    question to ask even though the two agree for today's vocabulary."""
+    edges = [
         0, 1, 999, 1_000, 9_949, 9_950, 9_999, 999_499, 999_500,
         9_949_999, 9_950_000, 987_654_321,
     ]
-    cost_edges = [
-        0.0, 1e-9, 0.0001, 0.00999, 0.01, 9.999, 99.994, 99.999, 100.0, 98765.4321,
-    ]
-    for tokens in token_edges:
-        for cost_usd in cost_edges:
-            usage = {"chain_id": "t", "tokens": tokens, "cost_usd": cost_usd}
+    for prompt in edges:
+        for completion in edges:
+            usage = {
+                "chain_id": "t",
+                "tokens": prompt + completion,
+                "prompt_tokens": prompt,
+                "completion_tokens": completion,
+                "cost_usd": 0.0,
+            }
             gutter = ReynRightGutter(usage_lookup=lambda cid, u=usage: u)
             label = _label(gutter, _agent_row("t"))
-            assert len(label) <= RIGHT_GUTTER_WIDTH - 1, (
-                f"{label!r} ({len(label)} cols) leaves no breathing room in "
-                f"RIGHT_GUTTER_WIDTH={RIGHT_GUTTER_WIDTH} "
-                f"(tokens={tokens}, cost_usd={cost_usd})"
+            assert cell_len(label) <= RIGHT_GUTTER_WIDTH - 1, (
+                f"{label!r} ({cell_len(label)} cells) leaves no breathing room "
+                f"in RIGHT_GUTTER_WIDTH={RIGHT_GUTTER_WIDTH} "
+                f"(prompt={prompt}, completion={completion})"
             )
     elapsed = ReynTimingGutter(clock=lambda: 10_000_000.0)
     long_elapsed = _label(
@@ -440,7 +521,82 @@ def test_every_label_the_column_can_emit_fits_the_configured_width() -> None:
             kind="tool_call_started", text="t", meta={RUNNING_SINCE_KEY: 0.0}
         ),
     )
-    assert 0 < len(long_elapsed) <= RIGHT_GUTTER_WIDTH, long_elapsed
+    assert 0 < cell_len(long_elapsed) <= RIGHT_GUTTER_WIDTH, long_elapsed
+
+
+def test_the_direction_markers_measure_one_cell_each() -> None:
+    """Tier 1: ★ the ambiguous-width hazard, pinned rather than assumed.
+    :data:`PROMPT_TOKENS_MARKER` / :data:`COMPLETION_TOKENS_MARKER` are East
+    Asian **Ambiguous** (``east_asian_width == "A"``), so their column count is
+    not universally fixed. The width derivation above is only sound if the
+    renderer measures them as ONE cell — this asserts that against
+    ``rich.cells.cell_len``, the very function Textual's compositor uses, so a
+    rich upgrade that reclassified ambiguous-width to 2 fails HERE with a clear
+    cause rather than as a mysteriously shifted gutter.
+
+    Not a format pin: it pins a LAYOUT invariant the fixed-width column depends
+    on, not the choice of glyph."""
+    for marker in (PROMPT_TOKENS_MARKER, COMPLETION_TOKENS_MARKER):
+        assert unicodedata.east_asian_width(marker) == "A", (
+            f"{marker!r} is no longer ambiguous-width — the note in "
+            "PROMPT_TOKENS_MARKER's docstring needs revisiting"
+        )
+        assert cell_len(marker) == 1, (
+            f"{marker!r} measures {cell_len(marker)} cells; RIGHT_GUTTER_WIDTH "
+            f"={RIGHT_GUTTER_WIDTH} is derived assuming 1"
+        )
+
+
+def test_the_column_pads_by_cells_not_characters() -> None:
+    """Tier 1: :func:`_cell_pad_left` — the gutter's padding function — aligns
+    to a CELL count, which is what a terminal column actually is.
+
+    ★ Driven with a genuinely DOUBLE-WIDTH character. That is not decoration:
+    for the gutter's real vocabulary ``len()`` and ``cell_len()`` agree (every
+    glyph in it measures one cell, ambiguous-width markers included), so an
+    assertion driven only by real labels passes identically for ``str.rjust``
+    and cannot witness the difference — it was vacuous when first written, and
+    a strip to ``rjust`` stayed green. A wide character is the discriminating
+    input: ``rjust`` pads it by character count and overflows the column.
+
+    The production vocabulary cannot currently emit one; this pins the helper's
+    CONTRACT so the column stays correct by construction rather than by the
+    coincidence that today's glyphs happen to be narrow."""
+    wide = "中中"  # U+4E2D, east_asian_width "W" — wider than one cell each
+    assert cell_len(wide) > len(wide), (
+        "fixture must be text whose CELL width exceeds its CHARACTER count — "
+        "otherwise the two padding strategies agree and this cannot witness "
+        "the difference"
+    )
+    padded = _cell_pad_left(wide, 8)
+    assert cell_len(padded) == 8, (
+        f"{padded!r} occupies {cell_len(padded)} cells, not the 8 asked for — "
+        "padding is counting characters, not cells"
+    )
+    assert padded.endswith(wide), "the label itself must survive padding"
+    # An over-long label is returned unpadded rather than negative-padded;
+    # flowview's own adjust_cell_length clips it, it never steals body columns.
+    assert _cell_pad_left(wide, 2) == wide
+
+
+def test_the_rendered_gutter_cell_occupies_exactly_the_column_width() -> None:
+    """Tier 1: through the real composite, a marker-bearing label renders a
+    cell of exactly :data:`RIGHT_GUTTER_WIDTH` cells — the property the
+    fixed-width column depends on, checked on the real render path rather than
+    on the padding helper alone."""
+    gutter = ReynRightGutter(
+        usage_lookup=lambda cid: {
+            "chain_id": cid, "tokens": 13800, "prompt_tokens": 12000,
+            "completion_tokens": 1800, "cost_usd": 0.0,
+        }
+    )
+    padded = gutter.decorate(_entry(_agent_row("t")), RIGHT_GUTTER_WIDTH, 1).plain
+    assert cell_len(padded) == RIGHT_GUTTER_WIDTH, (
+        f"{padded!r} occupies {cell_len(padded)} cells, not {RIGHT_GUTTER_WIDTH}"
+    )
+    assert padded.strip() == (
+        f"{PROMPT_TOKENS_MARKER}12k {COMPLETION_TOKENS_MARKER}1.8k"
+    ), padded
 
 
 # ── Gate 6: the real status snapshot actually publishes the lookup ────────────
@@ -593,16 +749,20 @@ def _rendered_lines(flow: "FlowView[OutboxMessage]") -> "list[str]":
 
 
 @pytest.mark.asyncio
-async def test_mounted_app_prices_a_known_turn_and_dashes_an_unknown_one() -> None:
+async def test_mounted_app_shows_a_known_turns_split_and_dashes_an_unknown_one() -> None:
     """Tier 2b: end-to-end through the REAL mounted app — the real read-model
     seam, the real ``turn_usage_fn`` publication path, the real
-    ``right_decorator`` wiring — a reply row for a PRICED turn ends in its real
-    figure and a reply row for an unknown turn ends in ``—``, read off the
-    COMPOSED row text rather than a ``decorate()`` call. Both rows are in the
-    same render, so a wiring that fell back to one answer for everything fails
-    on the other row."""
+    ``right_decorator`` wiring — a reply row for a RECORDED turn ends in its
+    real prompt/completion split and a reply row for an unknown turn ends in
+    ``—``, read off the COMPOSED row text rather than a ``decorate()`` call.
+    Both rows are in the same render, so a wiring that fell back to one answer
+    for everything fails on the other row.
+
+    BOTH halves of the split are asserted on the rendered line: an
+    implementation that rendered only the total, or only the prompt side, would
+    pass a one-figure check."""
     tracker = BudgetTracker(CostConfig())
-    _record(tracker, "turn-priced", prompt=1500, completion=250)
+    _record(tracker, "turn-recorded", prompt=1500, completion=250)
 
     transport = _QueueTransport()
     app = TextualChatApp(
@@ -612,7 +772,7 @@ async def test_mounted_app_prices_a_known_turn_and_dashes_an_unknown_one() -> No
         await pilot.pause()
         await transport.push(
             OutboxMessage(
-                kind="agent", text="priced reply", meta={"chain_id": "turn-priced"}
+                kind="agent", text="recorded reply", meta={"chain_id": "turn-recorded"}
             )
         )
         await transport.push(
@@ -624,21 +784,22 @@ async def test_mounted_app_prices_a_known_turn_and_dashes_an_unknown_one() -> No
         await pilot.pause()
 
         lines = _rendered_lines(app.query_one(FlowView))
-        priced = [ln for ln in lines if "priced reply" in ln]
+        priced = [ln for ln in lines if "recorded reply" in ln]
         mystery = [ln for ln in lines if "mystery reply" in ln]
         assert priced and mystery, lines
 
-        assert any("$" in ln for ln in priced), (
-            f"the priced turn's row carries no USD figure: {priced!r}"
+        want = f"{PROMPT_TOKENS_MARKER}1.5k {COMPLETION_TOKENS_MARKER}250"
+        assert any(ln.rstrip().endswith(want) for ln in priced), (
+            f"the recorded turn's row does not end in {want!r}: {priced!r}"
         )
         assert not any(ln.rstrip().endswith(TURN_USAGE_UNKNOWN) for ln in priced), (
-            f"a priced turn rendered as unknown: {priced!r}"
+            f"a recorded turn rendered as unknown: {priced!r}"
         )
         assert any(ln.rstrip().endswith(TURN_USAGE_UNKNOWN) for ln in mystery), (
-            f"an unpriced turn did not render {TURN_USAGE_UNKNOWN!r}: {mystery!r}"
+            f"an unrecorded turn did not render {TURN_USAGE_UNKNOWN!r}: {mystery!r}"
         )
-        assert not any("$" in ln for ln in mystery), (
-            f"an unknown turn was given a USD figure: {mystery!r}"
+        assert not any(PROMPT_TOKENS_MARKER in ln for ln in mystery), (
+            f"an unknown turn was given a token figure: {mystery!r}"
         )
 
 

--- a/tests/test_textual_chat_phase4_turn_cost_gutter_3283.py
+++ b/tests/test_textual_chat_phase4_turn_cost_gutter_3283.py
@@ -1,0 +1,687 @@
+"""Phase ④ remainder (#3283): per-turn cost/token in the right gutter.
+
+#3337 landed the right gutter with ELAPSED TIME ONLY, because a per-turn
+cost/token figure did not exist — per-call tokens/cost were folded straight into
+cumulative counters with no turn key, and the only way to "recover" one later
+would have been differencing cumulative counters, i.e. inventing a number.
+#3339/#3342 fixed that at the SOURCE (``BudgetTracker``'s bounded per-turn
+buckets, keyed by the turn's ``chain_id``). This completes ④ by rendering it.
+
+#3339 deliberately CLOSED the keyed lookup: with no consumer, nothing would
+enforce branching on "unknown", so the API was narrowed to
+``latest_turn_usage()`` to make the ambiguous question unaskable. The gutter is
+that consumer, so the lookup is reintroduced WITH the contract — ``None`` for a
+turn the runtime holds no figure for — and the gates below are what enforce the
+branching that #3339 had nothing to enforce.
+
+These pin:
+
+- **the keyed lookup's three outcomes, asserted as DISTINCT** (Tier 2, real
+  ``BudgetTracker``): a recorded turn yields its real summed figures; a turn
+  EVICTED past ``TURN_BUCKET_CAP`` yields ``None``; a ``chain_id`` never seen
+  yields ``None``. Never a ``0`` for either unknown case.
+- **the same three outcomes on the RENDERED gutter cell** (Tier 1): the figure,
+  ``—``, ``—`` — read off ``decorate()``'s output, and asserted mutually
+  distinct in one place so "all three render the same thing" cannot pass.
+- **no non-zero spend ever renders as free** (Tier 1): a sub-hundredth-of-a-cent
+  turn renders a ``<``-prefixed floor, never ``$0`` (which is reserved for a
+  genuinely zero — unpriced-model — turn) and never ``—``.
+- **the anchor decision** (Tier 1): the turn figure rides the ``kind="agent"``
+  reply row that concludes a turn's visible output, NOT every row of the turn —
+  the same total repeated N times in a column whose other label family is
+  per-row would read as N separate per-row costs.
+- **restore renders nothing rather than something reconstructed** (Tier 1, at
+  the SOURCE as well as the gutter): ``project_restored_frames`` does not carry
+  ``chain_id`` onto a restored frame, and the per-turn buckets are in-memory
+  live-session state a restart does not rehydrate — so a restored conversation
+  shows no cost figures at all. Same posture #3337 landed for elapsed.
+- **end-to-end through the mounted app** (Tier 2b): a real ``TextualChatApp``
+  whose read model hands over a REAL ``BudgetTracker``'s bound
+  ``turn_usage`` renders the priced turn's figure and the unknown turn's ``—``
+  on the composed row text, not just in a unit-level ``decorate()`` call.
+- **the #3337 body-width floor still holds at the widened gutter** (Tier 2b):
+  re-asserted here against the SHIPPED :data:`RIGHT_GUTTER_WIDTH` so widening
+  it in future is caught by this file too, not only by #3337's own gate.
+
+All collaborators are real: a real :class:`BudgetTracker` (its bound
+``turn_usage`` IS the production lookup), a real ``FlowModel``/``Entry``, real
+``OutboxMessage``, a real mounted ``TextualChatApp``, and a real
+:class:`~reyn.interfaces.repl.read_model.ChatReadModel` seam implementation
+(the same shape ``RegistryReadModel``/``RemoteReadModel`` have) — no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowModel, FlowView
+
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.inline.textual_chat import (
+    ReynRightGutter,
+    ReynTimingGutter,
+    ReynTurnUsageGutter,
+    TextualChatApp,
+)
+from reyn.interfaces.inline.textual_chat._meta_keys import RUNNING_SINCE_KEY
+from reyn.interfaces.inline.textual_chat.gutter import (
+    RIGHT_GUTTER_WIDTH,
+    TURN_ANCHOR_KIND,
+    TURN_USAGE_UNKNOWN,
+)
+from reyn.interfaces.inline.textual_chat.restore import project_restored_frames
+from reyn.interfaces.repl.read_model import ChatReadModel, project_remote_snapshot
+from reyn.interfaces.repl.status import _snapshot
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.budget.budget import TURN_BUCKET_CAP, BudgetTracker, CostConfig
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from tests._support.agent_session import make_session
+
+_MODEL = "gpt-4o"
+_LEFT_GUTTER_WIDTH = 2
+
+
+def _agent_row(chain_id: "str | None") -> OutboxMessage:
+    """An agent-reply display frame — the turn-figure ANCHOR row. ``chain_id``
+    is the same key ``RouterLoop`` stamps on the real frame's meta."""
+    meta = {"chain_id": chain_id} if chain_id is not None else {}
+    return OutboxMessage(kind=TURN_ANCHOR_KIND, text="done", meta=meta)
+
+
+def _entry(item: OutboxMessage):
+    model: "FlowModel[OutboxMessage]" = FlowModel()
+    return model.append(item)
+
+
+def _label(gutter, item: OutboxMessage) -> str:
+    """The rendered right-gutter cell for ``item``, stripped of alignment
+    padding — read off ``decorate()``, never off a source meta field."""
+    return gutter.decorate(_entry(item), RIGHT_GUTTER_WIDTH, 1).plain.strip()
+
+
+def _record(tracker: BudgetTracker, chain_id: str, prompt: int, completion: int) -> None:
+    tracker.record_llm(
+        model=_MODEL,
+        agent="alpha",
+        usage=TokenUsage(prompt_tokens=prompt, completion_tokens=completion),
+        chain_id=chain_id,
+    )
+
+
+# ── Gate 1: the keyed lookup's three outcomes (Tier 2, real BudgetTracker) ────
+
+
+def test_keyed_turn_usage_answers_known_evicted_and_unseen_distinctly() -> None:
+    """Tier 2: ``BudgetTracker.turn_usage(chain_id)`` — the lookup #3339
+    deliberately closed, reintroduced WITH its contract. Three outcomes, and
+    the point of asserting them together is that they must not collapse into
+    each other: a recorded turn gets its real summed figures, while an EVICTED
+    turn and a NEVER-SEEN chain_id both get ``None`` — never a fabricated 0,
+    which would be indistinguishable from a genuinely free turn."""
+    tracker = BudgetTracker(CostConfig())
+
+    # Fill past the cap so the earliest turns are genuinely evicted, each with a
+    # distinct total so an eviction cannot be masked by equality.
+    turns = [f"turn-{i:03d}" for i in range(TURN_BUCKET_CAP + 2)]
+    for i, chain_id in enumerate(turns):
+        _record(tracker, chain_id, prompt=100 + i, completion=7)
+
+    evicted, kept = turns[0], turns[-1]
+
+    known = tracker.turn_usage(kept)
+    assert known is not None, "a turn still in the buckets must have a figure"
+    assert known["chain_id"] == kept
+    assert known["tokens"] == 100 + len(turns) - 1 + 7, (
+        "the figure must be the real sum of that turn's own calls"
+    )
+    assert known["cost_usd"] > 0.0, (
+        f"{_MODEL} is priced, so a real turn's cost must be non-zero — "
+        "otherwise the cost half of this gate is vacuous"
+    )
+
+    assert tracker.turn_usage(evicted) is None, (
+        "an evicted turn must read as UNKNOWN, never as a 0 total"
+    )
+    assert tracker.turn_usage("turn-never-seen") is None, (
+        "a chain_id this tracker never saw must read as UNKNOWN"
+    )
+    # ...and the three are not the same answer wearing different hats.
+    assert known != tracker.turn_usage(evicted)
+
+
+def test_keyed_turn_usage_sums_a_multi_call_turn_and_isolates_turns() -> None:
+    """Tier 2: a turn's figure is the sum over EVERY LLM call it made (a
+    tool-loop turn makes several), and one turn's spend never leaks into
+    another's — the property that makes a per-row figure meaningful at all."""
+    tracker = BudgetTracker(CostConfig())
+    _record(tracker, "turn-A", prompt=1234, completion=567)
+    _record(tracker, "turn-A", prompt=89, completion=21)
+    _record(tracker, "turn-B", prompt=4321, completion=765)
+
+    a = tracker.turn_usage("turn-A")
+    b = tracker.turn_usage("turn-B")
+    assert a is not None and b is not None
+    assert a["tokens"] == 1234 + 567 + 89 + 21
+    assert b["tokens"] == 4321 + 765
+    assert a["cost_usd"] > b["cost_usd"] or a["tokens"] != b["tokens"], (
+        "the two turns must be separately accounted"
+    )
+
+
+def test_a_turnless_call_creates_no_lookup_answer() -> None:
+    """Tier 2: negative control — a call made outside any turn is still
+    recorded cumulatively, but it neither creates a bucket of its own nor
+    joins another turn's, so no keyed lookup can surface it."""
+    tracker = BudgetTracker(CostConfig())
+    _record(tracker, "turn-A", prompt=100, completion=10)
+    before = tracker.turn_usage("turn-A")
+
+    tracker.record_llm(
+        model=_MODEL,
+        agent="alpha",
+        usage=TokenUsage(prompt_tokens=777, completion_tokens=333),
+    )
+
+    assert tracker.agent_tokens("alpha") == 110 + 1110, (
+        "the turnless call must still be RECORDED, or this control is vacuous"
+    )
+    assert tracker.turn_usage("turn-A") == before, (
+        "a turnless call must not be folded into any turn's figure"
+    )
+
+
+# ── Gate 2: the same three outcomes on the RENDERED cell (Tier 1) ─────────────
+
+
+def test_gutter_renders_figure_for_known_turn_and_dash_for_unknown_and_evicted() -> None:
+    """Tier 1: the three outcomes as the operator sees them, asserted MUTUALLY
+    DISTINCT so "every row renders the same thing" cannot pass. A priced turn
+    shows tokens + USD; an EVICTED turn and an UNSEEN chain_id both show
+    :data:`TURN_USAGE_UNKNOWN` — never ``0``, and never an empty cell (which on
+    a row that names a turn would read as "this turn was free")."""
+    tracker = BudgetTracker(CostConfig())
+    turns = [f"turn-{i:03d}" for i in range(TURN_BUCKET_CAP + 2)]
+    for i, chain_id in enumerate(turns):
+        _record(tracker, chain_id, prompt=1000 + i, completion=200)
+    evicted, kept = turns[0], turns[-1]
+
+    gutter = ReynTurnUsageGutter(usage_lookup=tracker.turn_usage)
+    known_label = _label(gutter, _agent_row(kept))
+    evicted_label = _label(gutter, _agent_row(evicted))
+    unseen_label = _label(gutter, _agent_row("turn-never-seen"))
+
+    assert known_label not in ("", TURN_USAGE_UNKNOWN), known_label
+    assert "$" in known_label, f"the USD half is missing: {known_label!r}"
+    assert "0" not in known_label.split()[0] or known_label.split()[0] != "0", known_label
+    assert evicted_label == TURN_USAGE_UNKNOWN, evicted_label
+    assert unseen_label == TURN_USAGE_UNKNOWN, unseen_label
+    assert known_label != evicted_label, (
+        "a known turn and an evicted one must not render identically"
+    )
+
+
+def test_a_raising_lookup_degrades_to_unknown_rather_than_killing_the_render() -> None:
+    """Tier 1: the error path. ``decorate`` runs on every gutter repaint, so a
+    lookup that raises must not be able to take the whole render down — it
+    degrades to :data:`TURN_USAGE_UNKNOWN`, the same honest answer as any other
+    "no figure" case, and certainly not to a fabricated 0."""
+
+    def _boom(chain_id: str) -> "dict | None":
+        raise RuntimeError("tracker exploded")
+
+    gutter = ReynTurnUsageGutter(usage_lookup=_boom)
+    assert _label(gutter, _agent_row("turn-A")) == TURN_USAGE_UNKNOWN
+
+
+def test_no_lookup_wired_still_renders_unknown_not_a_zero() -> None:
+    """Tier 1: with no lookup available at all (no read model yet, or a REMOTE
+    client — the per-turn buckets are session-local and not on the wire), a row
+    that NAMES a turn still renders ``—``. The failure mode being closed is a
+    silently blank cell, which reads as a free turn."""
+    gutter = ReynTurnUsageGutter(usage_lookup=None)
+    assert _label(gutter, _agent_row("turn-somewhere")) == TURN_USAGE_UNKNOWN
+
+
+def test_remote_snapshot_publishes_no_turn_usage_lookup() -> None:
+    """Tier 1: pins the remote leg at its SOURCE rather than only at the
+    gutter's ``—`` — ``project_remote_snapshot`` hands over ``None`` for the
+    keyed lookup, because per-turn buckets are session-local and are not
+    projected onto the AG-UI wire (the same frame-sufficiency boundary as the
+    past-turn conversation log)."""
+    assert project_remote_snapshot({"model": "gpt-4o"})["turn_usage_fn"] is None
+
+
+def test_zero_cost_turn_renders_a_real_zero_distinct_from_unknown() -> None:
+    """Tier 1: ``$0`` and ``—`` mean different things and must render
+    differently. A turn recorded against an UNPRICED model genuinely cost
+    nothing — that is a real figure, and it must not be laundered into
+    "unknown"; conversely "unknown" must not be laundered into ``$0``."""
+    tracker = BudgetTracker(CostConfig())
+    tracker.record_llm(
+        model="a-model-no-catalog-prices",
+        agent="alpha",
+        usage=TokenUsage(prompt_tokens=500, completion_tokens=100),
+        chain_id="turn-free",
+    )
+    usage = tracker.turn_usage("turn-free")
+    assert usage is not None and usage["cost_usd"] == 0.0, (
+        "fixture must actually be an unpriced (zero-cost) turn"
+    )
+
+    gutter = ReynTurnUsageGutter(usage_lookup=tracker.turn_usage)
+    label = _label(gutter, _agent_row("turn-free"))
+    assert label != TURN_USAGE_UNKNOWN, (
+        f"a genuinely free turn must show its real $0, not 'unknown': {label!r}"
+    )
+    assert "600" in label, f"the token half must still be the real count: {label!r}"
+    assert "$0" in label, label
+
+
+def test_a_tiny_but_real_spend_never_renders_as_free() -> None:
+    """Tier 1: the rounding hazard — a turn whose cost is smaller than the
+    smallest exactly-printable figure must NOT render as ``$0`` (free) or as
+    ``—`` (unknown). It renders a ``<``-prefixed floor: real spend, honestly
+    bounded."""
+    gutter = ReynTurnUsageGutter(
+        usage_lookup=lambda cid: {"chain_id": cid, "tokens": 3, "cost_usd": 1e-9}
+    )
+    label = _label(gutter, _agent_row("turn-tiny"))
+    assert label != TURN_USAGE_UNKNOWN, label
+    assert "$0 " not in label and not label.endswith("$0"), (
+        f"a real non-zero spend rendered as free: {label!r}"
+    )
+    assert "<" in label, f"expected a bounded floor form, got {label!r}"
+
+
+# ── Gate 3: the anchor decision — one figure per turn, not one per row ────────
+
+
+@pytest.mark.parametrize(
+    "item",
+    [
+        OutboxMessage(kind="user", text="hi", meta={"chain_id": "turn-A"}),
+        OutboxMessage(
+            kind="tool_call_started",
+            text="grep",
+            meta={"chain_id": "turn-A", "op_id": "op-1"},
+        ),
+        OutboxMessage(kind="reasoning", text="thinking", meta={"chain_id": "turn-A"}),
+    ],
+)
+def test_non_anchor_rows_of_a_priced_turn_show_no_cost_figure(
+    item: OutboxMessage,
+) -> None:
+    """Tier 1: the turn figure is ANCHORED to the reply row, so the turn's OTHER
+    rows — its user line, its tool calls, its reasoning — render no cost cell
+    even though their frames carry the very same priced ``chain_id``. Repeating
+    one turn total down every row of the turn, in a column whose other label
+    family (elapsed) IS per-row, would read as N separate per-row costs."""
+    tracker = BudgetTracker(CostConfig())
+    _record(tracker, "turn-A", prompt=1000, completion=200)
+    gutter = ReynTurnUsageGutter(usage_lookup=tracker.turn_usage)
+
+    assert tracker.turn_usage("turn-A") is not None, (
+        "fixture must price turn-A, or this negative control is vacuous"
+    )
+    assert _label(gutter, item) == "", (
+        f"a non-anchor row of a priced turn must show no cost figure: {item.kind}"
+    )
+    # ...while the anchor row of that SAME turn does — so the empty cells above
+    # are the anchoring decision, not a broken lookup.
+    assert _label(gutter, _agent_row("turn-A")) != ""
+
+
+def test_a_row_naming_no_turn_renders_an_empty_cell_not_a_dash() -> None:
+    """Tier 1: ``""`` and ``—`` are also different statements. A row that names
+    NO turn has no turn to report on — nothing is *unknown* about it — so it
+    renders an empty cell, exactly as #3337's elapsed negative control does.
+    ``—`` is reserved for "we know which turn, we do not know the figure"."""
+    gutter = ReynTurnUsageGutter(usage_lookup=lambda cid: None)
+    assert _label(gutter, _agent_row(None)) == ""
+    assert _label(gutter, OutboxMessage(kind="agent", text="hi", meta={})) == ""
+
+
+# ── Gate 4: restore — nothing reconstructed, at the source and at the gutter ──
+
+
+def test_restore_projection_never_carries_a_turn_key() -> None:
+    """Tier 1: pins the live-vs-restore split at the SOURCE, not only at the
+    gutter's blank render — ``project_restored_frames`` stamps no ``chain_id``
+    on any projected frame, so a restored conversation cannot even name a turn
+    to price. (The second, independent reason it renders nothing: the per-turn
+    buckets are in-memory live-session state a restart does not rehydrate.)"""
+    log = [
+        ChatMessage(role="user", content="hello"),
+        ChatMessage(role="assistant", content="hi there"),
+    ]
+    frames = project_restored_frames(log)
+    assert frames, "fixture must project at least one frame"
+    for frame in frames:
+        assert "chain_id" not in (frame.meta or {}), (
+            f"a restored {frame.kind} frame named a turn: {frame.meta!r}"
+        )
+
+
+def test_a_restored_reply_row_renders_no_cost_even_with_a_live_tracker() -> None:
+    """Tier 1: the restore leg at the GUTTER, driven with a real tracker that
+    DOES hold figures — a restored reply row still shows nothing, because the
+    projected frame names no turn. Rules out "it looked blank only because the
+    tracker was empty"."""
+    tracker = BudgetTracker(CostConfig())
+    _record(tracker, "turn-A", prompt=1000, completion=200)
+    gutter = ReynTurnUsageGutter(usage_lookup=tracker.turn_usage)
+
+    frames = project_restored_frames([ChatMessage(role="assistant", content="hi")])
+    replies = [f for f in frames if f.kind == TURN_ANCHOR_KIND]
+    assert replies, "fixture must project an agent reply frame"
+    for frame in replies:
+        assert _label(gutter, frame) == ""
+
+
+# ── Gate 5: the composite column carries BOTH label families ─────────────────
+
+
+def test_the_composite_right_gutter_carries_both_label_families() -> None:
+    """Tier 1: :class:`ReynRightGutter` — the decorator actually wired into
+    ``FlowView(right_decorator=…)`` — emits the ELAPSED label on a running tool
+    row and the TURN-COST label on the reply row, through the SAME column. Both
+    halves are load-bearing: a composite that dropped either would fail here
+    while each half's own unit test still passed."""
+    tracker = BudgetTracker(CostConfig())
+    _record(tracker, "turn-A", prompt=1000, completion=200)
+    gutter = ReynRightGutter(clock=lambda: 107.0, usage_lookup=tracker.turn_usage)
+
+    running = OutboxMessage(
+        kind="tool_call_started",
+        text="grep",
+        meta={"op_id": "op-1", "chain_id": "turn-A", RUNNING_SINCE_KEY: 100.0},
+    )
+    assert _label(gutter, running) == "7s", (
+        "the elapsed half must still speak through the composite"
+    )
+    reply = _label(gutter, _agent_row("turn-A"))
+    assert "$" in reply, f"the turn-cost half is missing: {reply!r}"
+
+
+def test_every_label_the_column_can_emit_fits_the_configured_width() -> None:
+    """Tier 1: :data:`RIGHT_GUTTER_WIDTH` is COMPUTED from the widest label,
+    not guessed — so an extreme-but-reachable figure must not overflow the
+    column. Drives the widest shapes of both halves (a huge token count, a
+    huge cost, the sub-floor cost form, a long elapsed) through the real
+    composite."""
+    token_edges = [
+        0, 1, 999, 1_000, 9_949, 9_950, 9_999, 999_499, 999_500,
+        9_949_999, 9_950_000, 987_654_321,
+    ]
+    cost_edges = [
+        0.0, 1e-9, 0.0001, 0.00999, 0.01, 9.999, 99.994, 99.999, 100.0, 98765.4321,
+    ]
+    for tokens in token_edges:
+        for cost_usd in cost_edges:
+            usage = {"chain_id": "t", "tokens": tokens, "cost_usd": cost_usd}
+            gutter = ReynRightGutter(usage_lookup=lambda cid, u=usage: u)
+            label = _label(gutter, _agent_row("t"))
+            assert len(label) <= RIGHT_GUTTER_WIDTH - 1, (
+                f"{label!r} ({len(label)} cols) leaves no breathing room in "
+                f"RIGHT_GUTTER_WIDTH={RIGHT_GUTTER_WIDTH} "
+                f"(tokens={tokens}, cost_usd={cost_usd})"
+            )
+    elapsed = ReynTimingGutter(clock=lambda: 10_000_000.0)
+    long_elapsed = _label(
+        elapsed,
+        OutboxMessage(
+            kind="tool_call_started", text="t", meta={RUNNING_SINCE_KEY: 0.0}
+        ),
+    )
+    assert 0 < len(long_elapsed) <= RIGHT_GUTTER_WIDTH, long_elapsed
+
+
+# ── Gate 6: the real status snapshot actually publishes the lookup ────────────
+
+
+@pytest.mark.asyncio
+async def test_the_real_status_snapshot_publishes_a_working_keyed_lookup(
+    tmp_path,
+) -> None:
+    """Tier 2: the PUBLICATION path, through production code only — a real
+    ``AgentRegistry`` + attached ``Session`` + ``BudgetTracker``, and the real
+    ``interfaces/repl/status.py`` ``_snapshot()``. Its ``turn_usage_fn`` must be
+    a live keyed lookup (``Session.turn_usage`` → ``BudgetTracker.turn_usage``),
+    not merely a present key: the recorded turn's real figures come back and an
+    unseen chain_id comes back ``None``.
+
+    Without this, the app-level gates below would still pass while the snapshot
+    published nothing at all — they supply their own read model."""
+
+    agent = "gutter-cost-3283-agent"
+    tracker = BudgetTracker(CostConfig())
+    state_log = StateLog(tmp_path / "state.wal")
+    registry = AgentRegistry(
+        project_root=tmp_path,
+        session_factory=lambda profile: make_session(
+            agent_name=profile.name,
+            state_log=state_log,
+            snapshot_path=tmp_path / f"{profile.name}_snapshot.json",
+            budget_tracker=tracker,
+        ),
+        state_log=state_log,
+    )
+    AgentProfile.new(agent, role="").save(tmp_path / ".reyn" / "agents" / agent)
+    await registry.attach(agent)
+
+    _record(tracker, "turn-published", prompt=2000, completion=400)
+
+    snap = _snapshot(registry)
+    assert snap is not None, "the real producer returned no snapshot"
+    lookup = snap["turn_usage_fn"]
+    assert lookup is not None, "the real snapshot published no keyed lookup"
+
+    usage = lookup("turn-published")
+    assert usage is not None and usage["tokens"] == 2400, (
+        f"the published lookup is not live: {usage!r}"
+    )
+    assert lookup("turn-never-happened") is None, (
+        "the published lookup must answer UNKNOWN for a turn it has no figure "
+        "for — never a fabricated 0"
+    )
+
+
+# ── Gate 7: end-to-end through the mounted app ────────────────────────────────
+
+
+class _TurnUsageReadModel(ChatReadModel):
+    """A real :class:`ChatReadModel` seam implementation (same shape as
+    ``RegistryReadModel`` / ``RemoteReadModel``) whose snapshot hands over a
+    REAL :class:`BudgetTracker`'s bound ``turn_usage`` — the very callable
+    ``status.py``'s ``_snapshot()`` publishes as ``turn_usage_fn`` in
+    production. Nothing about the lookup is simulated; only the surrounding
+    session/registry is skipped."""
+
+    def __init__(self, tracker: BudgetTracker) -> None:
+        self._tracker = tracker
+
+    def snapshot(self, config=None):
+        return {"turn_usage_fn": self._tracker.turn_usage}
+
+    def intervention_head(self):
+        return None
+
+    def pending_command_ui(self):
+        return None
+
+    def clear_pending_command_ui(self) -> None:
+        return None
+
+    @property
+    def has_command_ui_region(self) -> bool:
+        return True
+
+    @property
+    def history_path(self) -> Path:
+        return Path("/tmp/reyn_3283_p4_cost_history")
+
+    def conversation_history(self, *, limit=None, agent=None, session_id=None):
+        return []
+
+
+class _QueueTransport(ClientTransport):
+    """A real :class:`ClientTransport` fed one frame at a time from a queue, so
+    a test can push frames and inspect the render in between with the stream
+    staying open (the helper shape #3337's gutter tests use)."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[OutboxMessage]" = asyncio.Queue()
+        self.submitted: list[str] = []
+
+    async def push(self, msg: OutboxMessage) -> None:
+        await self._queue.put(msg)
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        while True:
+            yield DisplayFrame(await self._queue.get())
+
+    async def submit_user_text(self, text: str) -> None:
+        self.submitted.append(text)
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _rendered_lines(flow: "FlowView[OutboxMessage]") -> "list[str]":
+    """Every composed row line (left gutter + body + right gutter) of the
+    FlowView's virtual content, via flowview's own selection extraction."""
+    from textual.geometry import Offset
+    from textual.selection import Selection
+
+    height = max(0, flow.virtual_size.height - 1)
+    result = flow.get_selection(
+        Selection(Offset(0, 0), Offset(flow.virtual_size.width, height))
+    )
+    assert result is not None
+    return [ln for ln in result[0].split("\n") if ln.strip()]
+
+
+@pytest.mark.asyncio
+async def test_mounted_app_prices_a_known_turn_and_dashes_an_unknown_one() -> None:
+    """Tier 2b: end-to-end through the REAL mounted app — the real read-model
+    seam, the real ``turn_usage_fn`` publication path, the real
+    ``right_decorator`` wiring — a reply row for a PRICED turn ends in its real
+    figure and a reply row for an unknown turn ends in ``—``, read off the
+    COMPOSED row text rather than a ``decorate()`` call. Both rows are in the
+    same render, so a wiring that fell back to one answer for everything fails
+    on the other row."""
+    tracker = BudgetTracker(CostConfig())
+    _record(tracker, "turn-priced", prompt=1500, completion=250)
+
+    transport = _QueueTransport()
+    app = TextualChatApp(
+        transport=transport, read_model=_TurnUsageReadModel(tracker)
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push(
+            OutboxMessage(
+                kind="agent", text="priced reply", meta={"chain_id": "turn-priced"}
+            )
+        )
+        await transport.push(
+            OutboxMessage(
+                kind="agent", text="mystery reply", meta={"chain_id": "turn-gone"}
+            )
+        )
+        await pilot.pause()
+        await pilot.pause()
+
+        lines = _rendered_lines(app.query_one(FlowView))
+        priced = [ln for ln in lines if "priced reply" in ln]
+        mystery = [ln for ln in lines if "mystery reply" in ln]
+        assert priced and mystery, lines
+
+        assert any("$" in ln for ln in priced), (
+            f"the priced turn's row carries no USD figure: {priced!r}"
+        )
+        assert not any(ln.rstrip().endswith(TURN_USAGE_UNKNOWN) for ln in priced), (
+            f"a priced turn rendered as unknown: {priced!r}"
+        )
+        assert any(ln.rstrip().endswith(TURN_USAGE_UNKNOWN) for ln in mystery), (
+            f"an unpriced turn did not render {TURN_USAGE_UNKNOWN!r}: {mystery!r}"
+        )
+        assert not any("$" in ln for ln in mystery), (
+            f"an unknown turn was given a USD figure: {mystery!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_widened_gutter_still_leaves_the_body_most_of_the_terminal() -> None:
+    """Tier 2b: ★ the #3337 body-width floor, re-asserted against the width
+    this PR ships. Adding the cost/token label widened
+    :data:`RIGHT_GUTTER_WIDTH`, and #3337's gate exists precisely because the
+    file's other gates impose no upper bound on the gutters' share. Measured on
+    the BODY width ``ReynPresenter.present`` actually receives — the only
+    surface that exposes gutter consumption (``FlowView.region.width`` stays
+    the full terminal width regardless).
+
+    Asserted as the ARITHMETIC the width constant claims (screen − left gutter
+    − right gutter), so a future widening that still cleared the half-screen
+    floor but stopped matching the documented computation is also caught."""
+    from reyn.interfaces.inline.textual_chat.presenter import ReynPresenter
+
+    class _WidthRecordingPresenter(ReynPresenter):
+        def __init__(self) -> None:
+            super().__init__()
+            self.widths: "list[int]" = []
+
+        async def present(self, item: "OutboxMessage", width: int):
+            self.widths.append(width)
+            return await super().present(item, width)
+
+    transport = _QueueTransport()
+    presenter = _WidthRecordingPresenter()
+    app = TextualChatApp(transport=transport, presenter=presenter)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await transport.push(OutboxMessage(kind="agent", text="a reply"))
+        await pilot.pause()
+
+        assert presenter.widths, "presenter never received a body width to record"
+        body_width = presenter.widths[-1]
+        screen = app.size.width
+        assert body_width >= screen // 2, (
+            f"the gutters left only {body_width} body columns out of {screen} — "
+            f"RIGHT_GUTTER_WIDTH={RIGHT_GUTTER_WIDTH} breaks the #3337 floor"
+        )
+        assert body_width == screen - _LEFT_GUTTER_WIDTH - RIGHT_GUTTER_WIDTH, (
+            f"body width {body_width} does not match the documented computation "
+            f"{screen} - {_LEFT_GUTTER_WIDTH} - {RIGHT_GUTTER_WIDTH}"
+        )

--- a/tests/test_turn_cost_attribution_3339.py
+++ b/tests/test_turn_cost_attribution_3339.py
@@ -120,6 +120,10 @@ def test_two_turns_aggregate_separately() -> None:
     assert tracker.latest_turn_usage() == {
         "chain_id": "turn-B",
         "tokens": _CALL_B1.total_tokens,
+        # #3283 ④: the prompt/completion split is carried alongside the total
+        # (the right gutter renders the two separately).
+        "prompt_tokens": _CALL_B1.prompt_tokens,
+        "completion_tokens": _CALL_B1.completion_tokens,
         "cost_usd": _cost(_CALL_B1),
     }
     assert "turn-never" not in snap["turn_tokens"]
@@ -172,10 +176,13 @@ def test_turn_buckets_are_bounded_and_keep_the_newest() -> None:
         assert chain_id not in kept, "an evicted turn is absent, never a 0 total"
     # The newest turn survives and still carries its own real figure.
     newest = turns[-1]
+    _newest_usage = TokenUsage(prompt_tokens=10 + len(turns) - 1, completion_tokens=1)
     assert tracker.latest_turn_usage() == {
         "chain_id": newest,
-        "tokens": 10 + len(turns) - 1 + 1,
-        "cost_usd": _cost(TokenUsage(prompt_tokens=10 + len(turns) - 1, completion_tokens=1)),
+        "tokens": _newest_usage.total_tokens,
+        "prompt_tokens": _newest_usage.prompt_tokens,
+        "completion_tokens": _newest_usage.completion_tokens,
+        "cost_usd": _cost(_newest_usage),
     }
     # Cumulative counters are untouched by eviction — bounding the per-turn
     # view must not lose spend from the totals that enforce caps.
@@ -296,7 +303,12 @@ def test_no_turn_figure_is_published_as_unknown_never_zero(tmp_path, monkeypatch
     tracker = BudgetTracker(CostConfig())
     session = make_session(agent_name="test_agent", budget_tracker=tracker)
 
-    unknown = {"chain_id": None, "tokens": None, "cost_usd": None}
+    # Same KEY SET as the success case, all values None — a consumer can read
+    # any field without first branching on which case it got.
+    unknown = {
+        "chain_id": None, "tokens": None, "prompt_tokens": None,
+        "completion_tokens": None, "cost_usd": None,
+    }
     assert session.last_turn_usage == unknown, "no turn run yet ⇒ no figure"
 
     # This session runs a real turn, so it DOES have a figure...

--- a/tests/test_turn_cost_attribution_3339.py
+++ b/tests/test_turn_cost_attribution_3339.py
@@ -16,8 +16,11 @@ The invariants pinned here:
      being recorded in the cumulative counters (so the negative control is not
      vacuously satisfied by "nothing was recorded at all").
   3. The live per-turn buckets stay BOUNDED: the oldest turns are evicted and
-     read as absent (never as a zero total), while the newest — the only one
-     anything reads — survives, and the cumulative counters are untouched.
+     read as absent (never as a zero total), while the newest survives, and the
+     cumulative counters are untouched. (#3283 ④ added a KEYED reader for older
+     turns, so eviction is now observable to a real consumer — answered as
+     "unknown", never as a 0; its own gates live in
+     ``test_textual_chat_phase4_turn_cost_gutter_3283.py``.)
   4. The ledger row carries the turn key, witnessed through the real append
      path; a row written for a turnless call, and a pre-#3339 row, both stay
      valid.
@@ -150,7 +153,7 @@ def test_call_outside_any_turn_contaminates_no_turn_bucket() -> None:
 def test_turn_buckets_are_bounded_and_keep_the_newest() -> None:
     """Tier 2: the per-turn buckets are bounded — a long session evicts the
     OLDEST turns rather than accumulating one bucket per turn forever, and the
-    turn that just recorded (the only one anything reads) is never the victim.
+    turn that just recorded is never the victim.
     An evicted turn is ABSENT, not a zero total."""
     tracker = BudgetTracker(CostConfig())
     turns = [f"turn-{i:03d}" for i in range(TURN_BUCKET_CAP + 3)]
@@ -280,9 +283,14 @@ def test_no_turn_figure_is_published_as_unknown_never_zero(tmp_path, monkeypatch
     tokens/cost are None — never a placeholder 0, which a renderer could not
     tell apart from a turn that genuinely cost nothing.
 
-    Both no-figure cases go through the real mechanism: a session that has not
-    run a turn, and a session whose last turn is no longer the process-shared
-    tracker's latest (the everyday case — one tracker, several sessions)."""
+    The no-figure case goes through the real mechanism: a session that has not
+    run a turn at all.
+
+    #3283 ④ narrowed which cases these are. ``last_turn_usage`` now reads the
+    KEYED ``BudgetTracker.turn_usage(chain_id)`` rather than "the latest turn
+    process-wide", so another session's turn recording spend against the shared
+    tracker no longer hides this session's own figure — asserted below, because
+    that used to be an everyday unknown and is now a known."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(litellm, "acompletion", _scripted_reply(1500, 250))
     tracker = BudgetTracker(CostConfig())
@@ -295,11 +303,32 @@ def test_no_turn_figure_is_published_as_unknown_never_zero(tmp_path, monkeypatch
     asyncio.run(session._handle_user_message("hello", chain_id="turn-mine"))
     assert session.last_turn_usage["tokens"] == 1750
 
-    # ...until some other session's turn records spend against the shared
-    # tracker and becomes the latest. This session's own figure is now
-    # unreachable: it must read as unknown — never 0, and never the other
-    # turn's number.
+    # ...and it KEEPS it when some other session's turn becomes the tracker's
+    # latest: the keyed read asks about this session's own chain_id, so it can
+    # neither lose the figure nor return the other turn's number.
     tracker.record_llm(
         model=_MODEL, agent="beta", usage=_CALL_B1, chain_id="turn-elsewhere",
+    )
+    assert tracker.latest_turn_usage()["chain_id"] == "turn-elsewhere", (
+        "fixture must actually move 'latest' off this session, or the "
+        "assertion below is vacuous"
+    )
+    still_mine = session.last_turn_usage
+    assert still_mine["chain_id"] == "turn-mine"
+    assert still_mine["tokens"] == 1750
+    assert still_mine["cost_usd"] is not None, (
+        "the cost must be a real figure (this fixture's model is unpriced, so "
+        "0.0 is correct) — never the None that means 'no figure'"
+    )
+
+    # The remaining unknown leg, through the real bounding mechanism: once this
+    # session's own turn is EVICTED from the bounded buckets, the figure is gone
+    # and must read as unknown — never as a 0.
+    for i in range(TURN_BUCKET_CAP + 1):
+        tracker.record_llm(
+            model=_MODEL, agent="beta", usage=_CALL_B1, chain_id=f"turn-filler-{i}",
+        )
+    assert tracker.turn_usage("turn-mine") is None, (
+        "fixture must actually evict this session's turn"
     )
     assert session.last_turn_usage == unknown


### PR DESCRIPTION
**[per-PR-coder]** — part of #3283 (Phase ④ remainder). Rebased onto current `main` (③ / #3345 and #3344 landed while this was in flight).

> **Revised twice since first review.** #3347 originally shipped tokens **+ USD cost** at gutter width 14. tui-coder's real-TTY read found 14 columns left long tables and code visibly cramped at 80 columns; the owner then scoped the column to **tokens only**, and then to **prompt and completion shown separately** with `↑`/`↓` markers. What is described below is the current state. Live-during-streaming token growth is deliberately **not** here — it touches #3345's streaming path and is scoped separately.

## What #3337 could not do, and why it can now

#3337 shipped ④'s right gutter with **elapsed time only**. Per-turn token attribution did not exist: per-call figures were folded into cumulative counters with no turn key, and the only way to "recover" one afterwards would have been differencing cumulative counters — inventing a number. #3339/#3342 fixed that at the source. This renders it.

## The keyed lookup, reintroduced *with* its contract

#3339 **deliberately closed** the keyed lookup, because with zero consumers nothing would enforce branching on "unknown". The gutter is that consumer — it asks about turns scrolled arbitrarily far back, so it *must* ask about turns old enough to have been evicted, and renders `—` when the answer is unknown.

- **`BudgetTracker.turn_usage(chain_id) -> dict | None`** — `None`, never `0`.
- **Per-turn buckets now carry the prompt/completion split** alongside the total, accumulated from `TokenUsage` at the call. Never re-derived, never differenced. Both readers (`turn_usage`, `latest_turn_usage`) return one shape through a shared builder so they cannot drift.
- **`Session.turn_usage(chain_id)`**, and `Session.last_turn_usage` now reads its **own** turn by key rather than "the latest turn process-wide" — a shared tracker made another session's turn routinely hide this one's real figure. Its no-figure dict carries the **same key set** as the success dict (all values `None`), so a consumer never has to branch before reading a field.
- **`status.py`** publishes `turn_usage_fn` uncalled; `None` for remote.

**All six prose sites that explained the lookup's absence were re-read and corrected** — `latest_turn_usage`, `Session.last_turn_usage`, `TURN_BUCKET_CAP`'s comment, `_record_turn_usage`, `status.py`'s snapshot comment, `docs/reference/config/budget.md`. Re-read again after the tokens-only narrowing: two had drifted back into saying the gutter asks what a turn "cost", and were fixed.

## What the column shows

`↑<prompt> ↓<completion>` on the `kind="agent"` reply row — the row that concludes a turn. One figure per turn, not the same total repeated down every row of it (that would read as N separate per-row figures in a column whose other family, elapsed, genuinely is per-row).

**Cost is deliberately not drawn here**, but `turn_usage` still returns `cost_usd` — a presentation decision at the gutter, not a narrowing of the data. `/cost` and the status line remain the spend surfaces.

| row | render |
|---|---|
| reply row, turn recorded | `↑12k ↓1.8k` |
| reply row, turn recorded **0** tokens | `↑0 ↓0` — a measured fact |
| reply row, unknown / evicted / remote | `—` |
| row naming no turn at all | *(empty)* |

**Vocabulary re-checked after dropping cost, as instructed.** The real-zero-vs-unknown distinction used to be carried by `$0` vs `—`. Removing the cost column would have silently merged those two meanings; it is now carried by `↑0 ↓0` vs `—`, and asserted.

## Width derivation — 14 → 12

Derived in terminal **cells** (`rich.cells.cell_len`, the measure Textual's own compositor applies), not characters:

```
marker(1) + tokens(4) + space(1) + marker(1) + tokens(4) = 11  →  +1 breathing room = 12
```

`tokens(4)` is `_format_tokens`'s bound (`"120k"`, band edges chosen so nothing rounds into a wider band). Elapsed's widest is 3, and the two families are mutually exclusive per row, so the widest cell is `max(3, 11)`, not the sum.

| screen | body @12 | floor | (was @14) |
|---|---|---|---|
| 80 | **66** | 40 | 64 |
| 100 | 86 | 50 | 84 |
| 120 | 106 | 60 | 104 |
| 24 | 10 | — | 8 |

## Ambiguous-width: measured, not assumed

`↑` U+2191 and `↓` U+2193 are East Asian **Ambiguous** (`east_asian_width == "A"`), so their column count is not universally fixed. Measured:

| glyph | EAW | `rich.cells.cell_len` |
|---|---|---|
| `↑` / `↓` | `A` | **1** |
| `—` (`TURN_USAGE_UNKNOWN`, already shipped) | `A` | 1 |
| `●` `○` `◆` (left gutter, since #3273) | `A` | 1 |
| `中` (control) | `W` | 2 |

Two conclusions. First, **rich's `cell_len` is the same function Textual's compositor measures this strip with**, so the width arithmetic here and the renderer's agree by construction — no in-process overflow is possible. Second, the arrows introduce **no new class of risk**: the em dash this PR already ships as the unknown marker, and the left gutter's `●`/`○`/`◆`, are ambiguous-width too. The residual — a terminal whose font/locale draws ambiguous-width as 2 columns — is a property of the terminal, not observable from inside the process, and applies equally to those existing glyphs. So no ASCII fallback; a gate pins `cell_len == 1` so a rich upgrade that reclassified ambiguous width fails with a clear cause.

**The latent `len()` issue you asked me to name.** `ReynGutter.decorate` (the LEFT gutter) pads with `glyph.ljust(width)` — a character count — and has since #3273. It is correct today only because every glyph in its vocabulary measures one cell; any genuinely wide glyph would mis-pad it. I moved **my** cell onto a `cell_len`-based helper and did not change the left gutter. Worth a follow-up.

## Height parameter — measured (from the two-line-stack design, now superseded)

You asked me to confirm `decorate`'s `height` is post-wrap before committing to a stacked layout. The stack is no longer the design, but the finding stands and is worth recording: **`height` is post-wrap.** flowview's `_compose_line` computes `height = len(body_strips)` from the actual rendered strip list, then passes it to `decorate`. Reconciled against real renders:

| screen | rendered lines | `height` received | reconciles |
|---|---|---|---|
| 40 | 9 | 9 | ✅ |
| 50 | 6 | 6 | ✅ |
| 60 | 5 | 5 | ✅ |
| 80 | 4 | 4 | ✅ |
| 100 | 3 | 3 | ✅ |
| 140 | 2 | 2 | ✅ |

A decorator returning N lines had each land on its own row. One caveat for whoever picks up a multi-line gutter: during the pre-presentation window `height` is the *placeholder's* rendered line count, and the gutter cache is keyed on height so it re-decorates once the real presentation lands.

## Restore — established, not assumed

Two independent reasons, both pinned: `project_restored_frames` carries no `chain_id` onto restored frames (asserted at the source), and `_turn_tokens` / the split buckets are written **only** by `_record_turn_usage` — no `hydrate()`/`load_state()` path touches them. A restored conversation shows no figures — not `0`, not reconstructed. The blank-render test drives a tracker that *does* hold figures, so "blank because empty" is ruled out.

## Strip-falsify — 12 strips, all RED, anchor counts verified first

| # | stripped | count | result |
|---|---|---|---|
| A | `usage_lookup=self._turn_usage` → `None` | 1 | RED — mounted-app e2e |
| B′ | anchor-kind gate neutered | 1 | RED — 4 tests |
| C | `—` → fabricated `"0"` | 2 (both legs together) | RED — 5 tests |
| D | snapshot re-cache deleted | 1 | RED — e2e |
| E | `status.py` stops publishing | 1 | RED — real-snapshot gate |
| F | keyed lookup returns a 0-dict | 1 | RED — 6 tests |
| G | restore stamps `chain_id` | 1 | RED — 2 tests |
| H | width → 39 and → 60 | 1 | RED **both** times, on **both** #3337's floor gate and this PR's — re-confirmed at 12, not carried over |
| I | gutter's `except` removed | 1 | RED |
| J | collapse the split to a total | 1 | RED — 6 tests |
| K | cell-aware pad → `str.rjust` | 1 | RED |
| L | companion buckets not evicted | 1 | RED |

**Two of these were GREEN on the first run, and both were real gaps rather than bad strips.**

- **K** was vacuous: for the gutter's real vocabulary `len()` and `cell_len()` agree, so no production label could tell `rjust` from cell-aware padding. Fixed by driving the helper with a genuinely double-width character — the only discriminating input.
- **L** exposed an actual defect I had introduced: the new split buckets were evicted, but membership is decided by the *total* bucket, so had they stopped being evicted they would have grown without limit while every lookup still answered correctly — an invisible unbounded-memory leak, and a cross-cutting-band (bounding) violation. Fixed by exposing them in `snapshot()` so the bound has a public witness, then asserting it.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` on both changed test files — 30 OK / 0 warnings / 0 errors (one Tier-4 format pin, `len(wide) == 2`, was caught and rewritten as the behavioural `cell_len(wide) > len(wide)`)
- [x] `python scripts/verify_module_docstrings.py` on all 7 changed src files — OK
- [x] Targeted pytest — **2372 passed, 4 skipped** (119s)
- [x] `tests/test_3126_doc_anchor_gate.py` — 250 passed (gutters heading + both inbound `feature-map.md` anchors renamed together, twice)
- [x] Four display states re-checked after the narrowing; the real-zero/unknown pair re-carried on tokens and asserted
- [x] Width derived from the vocabulary in cells; body widths measured at 80/100/120/24
- [x] Ambiguous-width measured for both markers and pinned
- [x] `decorate`'s `height` reconciled against real rendered line counts at 6 widths
- [x] Strip-falsify ×12, all RED — table above
- [x] (skipped — tui-coder's) Real-TTY witness of the narrowed column. The 80-column cramping that prompted this revision was tui-coder's read; re-checking it at 12 is theirs too.
- [ ] Full `pytest` from the repo root — deferred to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
