### PR TITLE
fix(llm): record provider-supplied token counts on streamed calls, not litellm's estimate — part of #3348

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1855,13 +1855,29 @@ async def recorded_acompletion(
         chunks, never emitted per-chunk. ``budget.py`` (the cost band,
         ``record_llm`` at budget.py:1135) is untouched by ③a.
 
-        ``stream_options={"include_usage": True}`` is added ONLY when
-        litellm's own supported-params query confirms the model accepts it
-        (an OpenAI-specific param; Gemini/Anthropic reject it) — again a
-        capability query, not a provider check. Its absence is harmless:
-        ``stream_chunk_builder`` falls back to a token-count estimate for
-        usage, the same graceful degradation litellm's own non-Reyn callers
-        rely on.
+        ★``stream_options={"include_usage": True}`` is set UNCONDITIONALLY
+        (#3348): it is what makes the provider's OWN token counts reach this
+        function at all. Without it litellm's ``CustomStreamWrapper`` never
+        yields the usage-bearing final chunk, ``stream_chunk_builder`` has no
+        provider figure to sum, and it falls back to
+        ``litellm.token_counter`` — a LOCAL ESTIMATE that then flows into
+        ``recorder.record_llm`` / ``/cost`` / budget caps as if it were the
+        provider's number (measured on a live Gemini call: 13 recorded vs 7
+        actual, +86%). Estimated spend is not spend.
+
+        This is deliberately NOT gated on a supported-params query, which is
+        what #3348 removed. The flag is consumed CLIENT-SIDE by the stream
+        wrapper (``CustomStreamWrapper.check_send_stream_usage``), so it works
+        for providers whose wire protocol has no such field; and litellm's
+        param layer skips ``stream_options`` when pruning unsupported params
+        (``litellm/utils.py``: ``if k == "user" or k == "stream_options" or k
+        == "stream": continue``), so passing it can never raise, for any
+        provider, regardless of ``drop_params``. The supported-params list
+        describes what a provider ACCEPTS ON THE WIRE — Gemini and Anthropic
+        do not list it — which is the wrong question for a client-side flag,
+        and gating on it made reyn's token accounting silently provider-
+        dependent (exact on Anthropic, estimated on Gemini). One path, no
+        provider branching.
 
         #3288 ③b: ``on_content_delta`` (the enclosing ``recorded_acompletion``'s
         parameter, closed over here) is invoked ONCE PER CHUNK that carries a
@@ -1879,12 +1895,11 @@ async def recorded_acompletion(
         stream_kwargs.pop("stream", None)
         stream_kwargs.pop("stream_options", None)
         stream_kwargs["stream"] = True
-        try:
-            _supported_params = litellm.get_supported_openai_params(model=model) or []
-        except Exception:  # noqa: BLE001 — params query is best-effort
-            _supported_params = []
-        if "stream_options" in _supported_params:
-            stream_kwargs["stream_options"] = {"include_usage": True}
+        # #3348: unconditional — see the docstring. Gating this on the
+        # provider's supported-params list is what made reyn record a LOCAL
+        # ESTIMATE instead of the provider's own token counts on every
+        # streamed Gemini call.
+        stream_kwargs["stream_options"] = {"include_usage": True}
 
         chunk_stream = await litellm.acompletion(model=model, messages=msgs, **stream_kwargs)
         if not hasattr(chunk_stream, "__aiter__"):

--- a/tests/test_streaming_usage_provider_supplied_3348.py
+++ b/tests/test_streaming_usage_provider_supplied_3348.py
@@ -1,0 +1,205 @@
+"""Tier 2 / Tier 1: #3348 — a streamed call records the PROVIDER's token
+counts, never litellm's local estimate.
+
+``recorded_acompletion``'s streaming loop (#3288 ③a) reconstructs the whole
+response with litellm's ``stream_chunk_builder``. That builder can only report
+provider-supplied usage if the stream actually carried a usage-bearing chunk,
+and litellm's ``CustomStreamWrapper`` only yields one when the call passed
+``stream_options={"include_usage": True}``. Reyn used to gate that flag on
+``litellm.get_supported_openai_params(model=...)`` — a list of what a provider
+accepts ON THE WIRE. Gemini and Anthropic do not list it, so on those models
+the flag was never sent, no usage chunk was ever produced, and
+``stream_chunk_builder`` fell back to ``litellm.token_counter`` — a LOCAL
+ESTIMATE that then flowed into ``record_llm`` → ``/cost`` → budget caps as if
+it were the provider's own number (measured live on Gemini: 13 recorded vs 7
+actual, +86%).
+
+The flag is consumed client-side by the stream wrapper, and litellm's param
+layer never rejects it (see the Tier 1 test below), so #3348 sets it
+unconditionally — one path, no provider branching.
+
+Real instances throughout: a real ``BudgetTracker`` is the recorder (its public
+``agent_tokens`` read is the assertion surface), and ``litellm.acompletion`` is
+replaced with a real scripted async callable — never a ``unittest.mock``
+double — that reproduces the wrapper's client-side contract: it emits the
+usage-bearing final chunk ONLY when ``include_usage`` was requested. A test
+whose fake always emitted usage would pass with or without the fix.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import litellm
+from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices, Usage
+from litellm.utils import get_optional_params
+
+from reyn.llm.llm import call_llm_tools, recorded_acompletion
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+
+# Sentinels chosen so no token-count ESTIMATE of the tiny prompt below could
+# ever coincide with them — a near-miss estimate must not be able to pass this
+# test for the wrong reason.
+_PROVIDER_PROMPT_TOKENS = 7777
+_PROVIDER_COMPLETION_TOKENS = 131
+_CONTENT = "hello world"
+_MESSAGES = [{"role": "user", "content": "hi"}]
+
+# The model the historical gate excluded: litellm's supported-params list for
+# Gemini has no ``stream_options``, so the pre-#3348 code never sent the flag
+# for it. This is the exact shape of the live defect.
+_GATED_MODEL = "gemini/gemini-2.5-flash-lite"
+
+
+def _make_fake_acompletion(seen_kwargs: "list[dict] | None" = None,
+                           chunk_witness: "list[int] | None" = None):
+    """Real, scripted stand-in for ``litellm.acompletion``.
+
+    Reproduces the one behaviour that matters here — litellm's
+    ``CustomStreamWrapper.check_send_stream_usage``: the usage-bearing final
+    chunk is emitted **only** when the caller asked for
+    ``stream_options={"include_usage": True}``. Otherwise the stream ends with
+    a plain finish chunk carrying no usage at all, and the caller's
+    reconstruction has nothing but an estimate to fall back on.
+    """
+
+    async def _fake_acompletion(model: str, messages: list, **kw: Any) -> Any:
+        if seen_kwargs is not None:
+            seen_kwargs.append(dict(kw))
+        if not kw.get("stream"):
+            return litellm.ModelResponse(
+                id="resp-3348", created=1, model=model, object="chat.completion",
+                choices=[{
+                    "index": 0, "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": _CONTENT},
+                }],
+                usage={
+                    "prompt_tokens": _PROVIDER_PROMPT_TOKENS,
+                    "completion_tokens": _PROVIDER_COMPLETION_TOKENS,
+                    "total_tokens": _PROVIDER_PROMPT_TOKENS + _PROVIDER_COMPLETION_TOKENS,
+                },
+            )
+
+        include_usage = bool((kw.get("stream_options") or {}).get("include_usage"))
+
+        def _chunk(delta: Delta, finish_reason: "str | None" = None) -> ModelResponseStream:
+            return ModelResponseStream(
+                id="resp-3348", created=1, model=model, object="chat.completion.chunk",
+                choices=[StreamingChoices(index=0, delta=delta, finish_reason=finish_reason)],
+            )
+
+        async def _gen():
+            pieces = [
+                _chunk(Delta(role="assistant", content=_CONTENT)),
+                _chunk(Delta(), finish_reason="stop"),
+            ]
+            if include_usage:
+                usage_chunk = _chunk(Delta())
+                usage_chunk.usage = Usage(
+                    prompt_tokens=_PROVIDER_PROMPT_TOKENS,
+                    completion_tokens=_PROVIDER_COMPLETION_TOKENS,
+                    total_tokens=_PROVIDER_PROMPT_TOKENS + _PROVIDER_COMPLETION_TOKENS,
+                )
+                pieces.append(usage_chunk)
+            for piece in pieces:
+                if chunk_witness is not None:
+                    chunk_witness.append(1)
+                yield piece
+
+        return _gen()
+
+    return _fake_acompletion
+
+
+def test_gemini_streamed_call_records_the_providers_own_token_counts(monkeypatch) -> None:
+    """Tier 2: cost accounting records provider-supplied usage, not an estimate.
+
+    The model is one litellm's supported-params data excludes ``stream_options``
+    for — the pre-#3348 gate therefore never sent the flag, the scripted
+    provider never emitted a usage chunk, and the recorded figure was
+    ``litellm.token_counter``'s estimate of the prompt. Asserting the RECORDED
+    number (a real ``BudgetTracker``'s public per-agent total, the same counter
+    ``/cost`` and the budget caps read) rather than merely that a flag was
+    passed keeps the witness at the level the defect lived at."""
+    assert "stream_options" not in (
+        litellm.get_supported_openai_params(model=_GATED_MODEL) or []
+    ), (
+        f"{_GATED_MODEL} now lists stream_options in litellm's capability data — "
+        "this test no longer witnesses the gated-provider case it was written for"
+    )
+
+    seen_kwargs: list[dict] = []
+    chunk_witness: list[int] = []
+    monkeypatch.setattr(
+        litellm, "acompletion", _make_fake_acompletion(seen_kwargs, chunk_witness),
+    )
+
+    tracker = BudgetTracker(CostConfig())
+    response = asyncio.run(recorded_acompletion(
+        model=_GATED_MODEL, messages=_MESSAGES, purpose="main",
+        recorder=tracker, agent="alpha",
+    ))
+
+    # The streaming branch was really driven (chunks drained off the async
+    # generator), so this says something about the streaming path and not
+    # about the whole-collect fallback.
+    assert chunk_witness, "no chunk was consumed — the streaming branch never ran"
+    # The provider's figures, exactly — reconstruction summed the usage chunk
+    # instead of estimating.
+    assert response.usage.prompt_tokens == _PROVIDER_PROMPT_TOKENS
+    assert response.usage.completion_tokens == _PROVIDER_COMPLETION_TOKENS
+    # …and those are the figures that landed in the cost counters.
+    assert tracker.agent_tokens("alpha") == (
+        _PROVIDER_PROMPT_TOKENS + _PROVIDER_COMPLETION_TOKENS
+    )
+    # The mechanism: the flag went out on the streaming call itself.
+    (stream_call,) = [k for k in seen_kwargs if k.get("stream")]
+    assert stream_call["stream_options"] == {"include_usage": True}
+
+
+def test_call_llm_tools_records_provider_usage_on_the_router_path(monkeypatch) -> None:
+    """Tier 2: the same guarantee through ``call_llm_tools`` — the entry point
+    ``RouterLoop`` uses for every chat turn, which does its own
+    ``budget.record_llm``. The chokepoint being right is not enough if the
+    caller that actually feeds ``/cost`` in production takes another route."""
+    chunk_witness: list[int] = []
+    monkeypatch.setattr(
+        litellm, "acompletion", _make_fake_acompletion(None, chunk_witness),
+    )
+
+    tracker = BudgetTracker(CostConfig())
+    result = asyncio.run(call_llm_tools(
+        model=_GATED_MODEL, messages=_MESSAGES, tools=[],
+        budget=tracker, budget_agent="alpha",
+    ))
+
+    assert chunk_witness, "no chunk was consumed — the streaming branch never ran"
+    assert result.usage.prompt_tokens == _PROVIDER_PROMPT_TOKENS
+    assert tracker.agent_tokens("alpha") == (
+        _PROVIDER_PROMPT_TOKENS + _PROVIDER_COMPLETION_TOKENS
+    )
+
+
+def test_stream_options_is_never_rejected_by_litellms_param_layer() -> None:
+    """Tier 1: the external contract that makes the unconditional flag safe.
+
+    ``stream_options`` is exempt from litellm's unsupported-param pruning
+    (``litellm/utils.py``: ``if k == "user" or k == "stream_options" or k ==
+    "stream": continue``), so passing it to a provider that does not accept it
+    is DROPPED before the wire, never raised — with or without ``drop_params``.
+    If litellm ever changes that, the unconditional flag becomes a hard error
+    on every Gemini/Anthropic call and this goes RED first."""
+    for model, provider in (
+        ("gemini-2.5-flash-lite", "gemini"),
+        ("claude-sonnet-4-5", "anthropic"),
+    ):
+        for drop in (True, False):
+            params = get_optional_params(
+                model=model, custom_llm_provider=provider,
+                stream=True, stream_options={"include_usage": True},
+                drop_params=drop,
+            )
+            assert params.get("stream") is True
+            assert "stream_options" not in params, (
+                f"{provider} unexpectedly forwards stream_options on the wire"
+            )


### PR DESCRIPTION
**[per-PR-coder]** — part of #3348. Scope changed mid-task by lead-coder after a parallel measurement refuted the issue's premise: no provider supplies token counts *mid-stream* through litellm, so live token growth is out of scope and went back to the owner. What the measurement did surface is a live accounting defect, and that is what this PR fixes. Nothing here touches the display side.

## The defect

`recorded_acompletion`'s streaming loop (`src/reyn/llm/llm.py`) gated `stream_options={"include_usage": True}` on `litellm.get_supported_openai_params(model=...)`. Gemini and Anthropic do not list that param, so on those models:

1. the flag was never sent;
2. litellm's `CustomStreamWrapper` therefore never yielded the usage-bearing final chunk (the flag is what triggers it — `check_send_stream_usage`);
3. `stream_chunk_builder` had no provider figure to sum and fell back to `litellm.token_counter`;
4. that **local estimate** was returned as `response.usage` and recorded by `recorder.record_llm` / `budget.record_llm` — feeding `/cost`, the budget caps, and the per-turn attribution built in #3342.

Live proxy Gemini run (lead-coder's measurement): **`prompt_tokens=13` recorded against a provider truth of `7` (+86%)**. Anthropic is exact via a different route, so the error was silently provider-dependent.

## The fix

Set `stream_options={"include_usage": True}` unconditionally; delete the supported-params query. One path, no provider branching.

The supported-params list answers "does this provider accept this param **on the wire**" — the wrong question for a flag the *client* consumes. Two facts make the unconditional form safe, both read from litellm's source rather than assumed:

- `litellm/utils.py` exempts it from unsupported-param pruning — `if k == "user" or k == "stream_options" or k == "stream": continue` — so it can never raise, for any provider, with or without `drop_params`. Pinned by a Tier 1 test.
- The stream wrapper reads it from the raw kwargs (`main.py:6091`), not from the post-pruning optional params, so it still works for providers whose wire protocol has no such field.

**The other gate is not dead and stays.** `_streaming_capable` (whether to stream *at all*) is a separate decision with a live purpose — o1-pro/gpt-5-pro reject `stream=True`. Strip-falsified: forcing it to `return True` makes `test_on_content_delta_never_fires_on_the_whole_collect_path` RED. Only the `stream_options` capability query was removed, and it has no remaining caller (`get_supported_openai_params` no longer appears in `llm.py`).

## Measurements

Field names on a real chunk, before coding against them (`litellm.acompletion(..., mock_response=..., stream=True, stream_options={"include_usage": True})`, real `ModelResponseStream` objects): usage rides `chunk.usage` as a `litellm.types.utils.Usage` with `prompt_tokens` / `completion_tokens` / `total_tokens` / `prompt_tokens_details` / `completion_tokens_details` — and it appeared on **one** chunk only, the final usage-only one. Content chunks carried `usage=None` throughout, which is the finding that killed the original mid-stream scope.

Capability data (real litellm): `stream_options` listed for `gpt-4o-mini` = True; `gemini/gemini-2.5-flash-lite` = False; `anthropic/claude-sonnet-4-5` = False. That is the gate that was excluding exactly the default-config providers.

`stream_chunk_builder` on identical chunks, differing only in whether a usage chunk is present: **no usage chunk → `prompt_tokens=48, completion_tokens=2` (estimate); with usage chunk → `prompt_tokens=7, completion_tokens=3` (provider)**. Same shape as the live +86%.

Strip-falsify of the fix (anchor `stream_kwargs["stream_options"] = {"include_usage": True}`, `count == 1` verified across `src` + `tests` before stripping): removing the line makes both accounting tests RED with **`assert 8 == 7777`** — i.e. reyn silently recorded `token_counter`'s 8 in place of the provider's 7777. The Tier 1 param-layer test correctly stays green (it pins litellm's contract, not reyn's call).

## Tests

`tests/test_streaming_usage_provider_supplied_3348.py` — real `BudgetTracker` as the recorder, asserted through its public `agent_tokens` read (the same counter `/cost` and the caps read), so the witness sits where the defect lived rather than on "a flag was passed". The scripted `litellm.acompletion` stand-in (a real async callable, no `unittest.mock`) reproduces the wrapper's client-side contract: it emits the usage chunk **only** when `include_usage` was requested. A fake that always emitted usage would pass with or without the fix. Sentinels (`7777` / `131`) are unreachable by any estimate of the two-token prompt, so a near-miss estimate cannot pass for the wrong reason.

1. Tier 2 — a streamed call on `gemini/gemini-2.5-flash-lite` (the model litellm's data excludes the param for) records the provider's figures; guarded by an up-front assertion that the model really is one the old gate excluded, so the test cannot quietly stop witnessing that case.
2. Tier 2 — same guarantee through `call_llm_tools`, the entry point `RouterLoop` uses for every chat turn and which does its own `budget.record_llm`.
3. Tier 1 — litellm's param layer drops `stream_options` rather than rejecting it, for gemini + anthropic, with `drop_params` both ways.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_streaming_usage_provider_supplied_3348.py` — 3/3 OK, 0 warnings, 0 errors
- [x] Targeted pytest: the new file + `test_llm_streaming_delta_emission_3288` / `test_llm_streaming_equivalence_3288` / `test_agent_delta_chat_event_3288` / `test_agui_multi_content_streaming_3288` / `test_cost_chokepoint_1190` / `test_cost_chokepoint_ast_guard_1190` / `test_turn_cost_attribution_3339` / `test_agui_profile_completeness` / `test_outbox_vocabulary` — 57 passed
- [x] Wider sweep `-k "stream or llm or cost or budget or replay"` — 791 passed, 2 skipped
- [x] `python scripts/verify_module_docstrings.py src/reyn/llm/llm.py` — OK
- [x] Strip-falsify both gates (results above)
- [x] (skipped — no local provider credentials in this worktree) Live re-run of the Gemini call to confirm 7 is now recorded; the live before-figure (13 vs 7) is lead-coder's measurement, reproduced here offline against real litellm as the 48-vs-7 estimate/provider split.

## Doc surface

No doc describes the removed gate. `include_usage` / `stream_chunk_builder` / `_streaming_capable` appear in docs only in `docs/reference/builtin-models.md`, in a passage about `route_all_chat_openai_to_responses` and `_streaming_capable` — untouched by this change and still accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
