### PR TITLE
test(llm): pin litellm's no-raise contract for unconditional stream_options — part of #3348

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1868,11 +1868,22 @@ async def recorded_acompletion(
         This is deliberately NOT gated on a supported-params query, which is
         what #3348 removed. The flag is consumed CLIENT-SIDE by the stream
         wrapper (``CustomStreamWrapper.check_send_stream_usage``), so it works
-        for providers whose wire protocol has no such field; and litellm's
-        param layer skips ``stream_options`` when pruning unsupported params
-        (``litellm/utils.py``: ``if k == "user" or k == "stream_options" or k
-        == "stream": continue``), so passing it can never raise, for any
-        provider, regardless of ``drop_params``. The supported-params list
+        for providers whose wire protocol has no such field. Two SEPARATE
+        properties of litellm's param layer make passing it unconditionally
+        safe — neither implies the other, and both are pinned by Tier 1 tests
+        in ``tests/test_streaming_usage_provider_supplied_3348.py``:
+        (1) it does not RAISE for a provider that rejects the param —
+        ``litellm/utils.py`` skips ``stream_options`` when pruning unsupported
+        params (``if k == "user" or k == "stream_options" or k == "stream":
+        continue``), so no ``UnsupportedParamsError`` even under
+        ``drop_params=False``; and (2) it does not LEAK to the wire — the
+        param-mapping layer forwards it only to the OpenAI-compatible
+        providers that genuinely take it (measured across 8 providers ×
+        ``drop_params`` ∈ {False, True}: reaches openai + groq only; dropped
+        for anthropic / gemini / cohere / mistral / bedrock / ollama).
+        Property (1) holds by way of a single ``continue`` line in litellm, so
+        it is structural in THIS litellm version, not for all time — hence the
+        witness. The supported-params list
         describes what a provider ACCEPTS ON THE WIRE — Gemini and Anthropic
         do not list it — which is the wrong question for a client-side flag,
         and gating on it made reyn's token accounting silently provider-

--- a/tests/test_streaming_usage_provider_supplied_3348.py
+++ b/tests/test_streaming_usage_provider_supplied_3348.py
@@ -14,9 +14,11 @@ ESTIMATE that then flowed into ``record_llm`` → ``/cost`` → budget caps as i
 it were the provider's own number (measured live on Gemini: 13 recorded vs 7
 actual, +86%).
 
-The flag is consumed client-side by the stream wrapper, and litellm's param
-layer never rejects it (see the Tier 1 test below), so #3348 sets it
-unconditionally — one path, no provider branching.
+The flag is consumed client-side by the stream wrapper, so #3348 sets it
+unconditionally — one path, no provider branching. Two SEPARATE properties of
+litellm's param layer make that safe, and each gets its own Tier 1 test below
+because neither implies the other: it does not **raise** for a provider that
+rejects the param (layer 1), and it does not **forward** it to one (layer 2).
 
 Real instances throughout: a real ``BudgetTracker`` is the recorder (its public
 ``agent_tokens`` read is the assertion surface), and ``litellm.acompletion`` is
@@ -49,6 +51,26 @@ _MESSAGES = [{"role": "user", "content": "hi"}]
 # Gemini has no ``stream_options``, so the pre-#3348 code never sent the flag
 # for it. This is the exact shape of the live defect.
 _GATED_MODEL = "gemini/gemini-2.5-flash-lite"
+
+# Providers whose supported-params list omits ``stream_options`` — i.e. every
+# provider for which the unconditional flag has to be absorbed by litellm's
+# param layer rather than accepted on the wire. gemini and anthropic lead the
+# list because they are what reyn's default model classes resolve to: a
+# regression in either layer below breaks the default configuration first.
+#
+# bedrock is deliberately NOT here: it LISTS ``stream_options`` as supported
+# and still does not forward it (measured — listed=True, forwarded=False),
+# so it belongs to neither side of this split cleanly. That mismatch is itself
+# the reason the two layers get separate tests: "listed", "does not raise" and
+# "reaches the wire" are three different questions, and a provider can answer
+# them inconsistently.
+_UNSUPPORTING_PROVIDERS = (
+    ("gemini-2.5-flash-lite", "gemini"),
+    ("claude-sonnet-4-5", "anthropic"),
+    ("command-r", "cohere"),
+    ("mistral-large-latest", "mistral"),
+    ("llama3", "ollama"),
+)
 
 
 def _make_fake_acompletion(seen_kwargs: "list[dict] | None" = None,
@@ -180,26 +202,66 @@ def test_call_llm_tools_records_provider_usage_on_the_router_path(monkeypatch) -
     )
 
 
-def test_stream_options_is_never_rejected_by_litellms_param_layer() -> None:
-    """Tier 1: the external contract that makes the unconditional flag safe.
+def test_stream_options_does_not_raise_for_a_provider_that_rejects_it() -> None:
+    """Tier 1: layer 1 of the contract that makes the unconditional flag safe —
+    litellm's param layer does not RAISE on ``stream_options`` for a provider
+    whose supported-params list omits it.
 
-    ``stream_options`` is exempt from litellm's unsupported-param pruning
-    (``litellm/utils.py``: ``if k == "user" or k == "stream_options" or k ==
-    "stream": continue``), so passing it to a provider that does not accept it
-    is DROPPED before the wire, never raised — with or without ``drop_params``.
-    If litellm ever changes that, the unconditional flag becomes a hard error
-    on every Gemini/Anthropic call and this goes RED first."""
-    for model, provider in (
-        ("gemini-2.5-flash-lite", "gemini"),
-        ("claude-sonnet-4-5", "anthropic"),
-    ):
-        for drop in (True, False):
+    ``drop_params=False`` is the strict setting, the one under which an
+    unsupported non-default param normally raises ``UnsupportedParamsError``.
+    ``stream_options`` escapes only because of a single ``continue`` inside
+    ``litellm/utils.py`` (``if k == "user" or k == "stream_options" or k ==
+    "stream": continue``). "Structural" therefore means structural *in this
+    litellm version*: if an upgrade drops that line, every streamed call on
+    exactly the default-config providers becomes a hard error. This is the
+    witness on that layer.
+
+    Distinct from ``…_is_not_forwarded_on_the_wire`` below: not-raising and
+    not-leaking are separate properties of separate layers, and the first does
+    not imply the second."""
+    for model, provider in _UNSUPPORTING_PROVIDERS:
+        assert "stream_options" not in (
+            litellm.get_supported_openai_params(
+                model=model, custom_llm_provider=provider,
+            ) or []
+        ), (
+            f"{provider} now lists stream_options — it no longer exercises the "
+            "unsupported-provider case this test exists for"
+        )
+        for drop in (False, True):
+            # A raise here IS the failure — no assertion needed for layer 1.
             params = get_optional_params(
                 model=model, custom_llm_provider=provider,
                 stream=True, stream_options={"include_usage": True},
                 drop_params=drop,
             )
-            assert params.get("stream") is True
+            assert params.get("stream") is True, (
+                f"{provider} did not even keep stream=True — this call shape is "
+                "not doing what the test assumes"
+            )
+
+
+def test_stream_options_is_not_forwarded_to_a_provider_that_rejects_it() -> None:
+    """Tier 1: layer 2 — the param never reaches the wire for a provider that
+    does not accept it. It is pruned at the param-mapping layer and survives
+    only for the OpenAI-compatible providers that genuinely take it.
+
+    The openai leg is the non-vacuity control: it proves this assertion can
+    observe the param's PRESENCE, so its absence for the others is a real
+    measurement rather than a check that never sees anything."""
+    for model, provider in _UNSUPPORTING_PROVIDERS:
+        for drop in (False, True):
+            params = get_optional_params(
+                model=model, custom_llm_provider=provider,
+                stream=True, stream_options={"include_usage": True},
+                drop_params=drop,
+            )
             assert "stream_options" not in params, (
                 f"{provider} unexpectedly forwards stream_options on the wire"
             )
+
+    openai_params = get_optional_params(
+        model="gpt-4o-mini", custom_llm_provider="openai",
+        stream=True, stream_options={"include_usage": True}, drop_params=False,
+    )
+    assert openai_params["stream_options"] == {"include_usage": True}


### PR DESCRIPTION
**[per-PR-coder]** — part of #3348. Follow-up to #3349 (merged), which landed the fix without this pin. Tests + one docstring correction; no behaviour change.

## Why this test exists

#3349 made `stream_options={"include_usage": True}` unconditional on every streamed call. Nothing stops that param from being handed to a provider that does not accept it — instead, **two separate layers** of litellm absorb it:

- **Layer 1 — it does not raise.** `get_optional_params` normally raises `UnsupportedParamsError` for an unsupported non-default param under `drop_params=False` (litellm's default, and reyn's). `stream_options` escapes solely because of one line in `litellm/utils.py`: `if k == "user" or k == "stream_options" or k == "stream": continue`.
- **Layer 2 — it does not reach the wire.** The param-mapping layer forwards it only to the OpenAI-compatible providers that genuinely take it.

I previously cited the `continue` line and a `{'stream': True}` return as evidence that the flag "can never raise, for any provider" — that establishes layer 1 only, and I framed it as though it covered layer 2 as well. It happens to hold; lead-coder's architect measured layer 2 separately across 8 providers × `drop_params` ∈ {False, True}, 16 combinations, zero raises and zero leakage.

The reason to pin layer 1 specifically: **"structural" here means structural in this litellm version.** It is one `continue` line in a dependency we upgrade. If it goes, the failure is not subtle degradation — it is a hard error on *exactly* `gemini` and `anthropic`, the providers reyn's default model classes resolve to. The bug #3349 fixed was one that broke quietly and survived a long time; this puts a witness on the layer that would break next.

## Strip-falsify

Removed `stream_options` from that exemption line in the installed litellm (`count == 1` verified first) and re-ran. The pin goes RED with exactly the predicted failure:

```
litellm.exceptions.UnsupportedParamsError: gemini does not support parameters:
['stream_options'], for model=gemini-2.5-flash-lite.
```

litellm restored afterwards; the suite is green again (4 passed).

## Also in this PR

**The two layers are not even aligned per-provider — measured.** `bedrock` **lists** `stream_options` in its supported-params (`listed=True`) and the param-mapping layer **still drops it** (`forwarded=False`). "Listed", "does not raise" and "reaches the wire" are three different questions and a provider can answer them inconsistently, which is the concrete reason these are two tests rather than one. Found while assembling the provider list: bedrock failed the "supported-params omits it" precondition, so it is deliberately excluded from `_UNSUPPORTING_PROVIDERS` and the reason is recorded there.

Coverage: `gemini`, `anthropic` (the two that matter), plus `cohere`, `mistral`, `ollama`.

`src/reyn/llm/llm.py` — docstring only: the safety argument now names the two layers separately instead of running them together, records the 8-provider measurement for layer 2, and states that layer 1 is version-scoped with a pointer to its witness.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_streaming_usage_provider_supplied_3348.py` — 4/4 OK, 0 warnings, 0 errors
- [x] Targeted pytest: the file itself — 4 passed
- [x] Wider sweep `-k "stream or llm or cost or budget or replay"` — 792 passed, 2 skipped
- [x] `python scripts/verify_module_docstrings.py src/reyn/llm/llm.py` — OK
- [x] Strip-falsify layer 1 against real litellm (result above); litellm restored and re-verified green
- [x] (skipped — no credentials, and not needed) No live call: both assertions are offline reads of litellm's param layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
