### PR TITLE
fix(tui): left gutter pads by terminal cells, not character count

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/gutter.py
+++ b/src/reyn/interfaces/inline/textual_chat/gutter.py
@@ -142,6 +142,21 @@ def _gutter_glyph_color(msg: "OutboxMessage") -> "tuple[str, str]":
     return glyph, line[1]
 
 
+def _cell_pad_right(label: str, width: int) -> str:
+    """Left-align ``label`` in a ``width``-CELL column — the LEFT gutter's
+    counterpart to :func:`_cell_pad_left` (the RIGHT gutter's helper, #3347).
+
+    ``str.ljust`` pads by CHARACTER count; a gutter column is measured in
+    terminal CELLS, and the two differ for any double-width glyph. Padding on
+    :func:`rich.cells.cell_len` — the same measurement Textual's compositor
+    applies to the resulting strip — keeps this cell correct by construction
+    rather than by the coincidence that today's glyph vocabulary (``·  ⋯ ⎿ ◆
+    ○ ● ✗ ❯``) happens to measure one cell each. Over-long labels are returned
+    unpadded (flowview's own ``adjust_cell_length`` clips them; they never
+    steal body columns)."""
+    return label + " " * max(0, width - cell_len(label))
+
+
 class ReynGutter:
     """Fills the flowview gutter column with a STATE-COLOURED marker (Phase 2).
 
@@ -193,7 +208,7 @@ class ReynGutter:
             color = kind_color
         else:
             color = _STATE_COLOR.get(state, kind_color)
-        return Text(glyph.ljust(width), style=color)
+        return Text(_cell_pad_right(glyph, width), style=color)
 
 
 def _format_elapsed(seconds: float) -> str:

--- a/tests/test_textual_chat_phase2_3273.py
+++ b/tests/test_textual_chat_phase2_3273.py
@@ -43,8 +43,12 @@ from reyn.interfaces.inline.textual_chat import (
     TextualChatApp,
     _body_and_background,
 )
-from reyn.interfaces.inline.textual_chat.gutter import _cell_pad_right
-from reyn.interfaces.repl.renderer import _CC_DONE, _CC_ERR, _CC_WARN
+from reyn.interfaces.inline.textual_chat.gutter import (
+    _RUNNING_FRAMES,
+    _cell_pad_right,
+    _gutter_glyph_color,
+)
+from reyn.interfaces.repl.renderer import _CC_DONE, _CC_ERR, _CC_WARN, _KIND_LINE
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
@@ -426,3 +430,57 @@ def test_left_gutter_pads_by_cells_not_characters() -> None:
     # An over-long label is returned unpadded rather than negative-padded;
     # flowview's own adjust_cell_length clips it, it never steals body columns.
     assert _cell_pad_right(wide, 2) == wide
+
+
+def test_left_gutter_vocabulary_is_all_single_cell() -> None:
+    """Tier 1: every glyph the LEFT gutter can currently EMIT measures exactly
+    one terminal cell (:func:`rich.cells.cell_len`).
+
+    This is a DIFFERENT property from the padding gate above: that one pins
+    ``_cell_pad_right``'s CONTRACT (correct for any width, witnessed with a
+    synthetic wide character the vocabulary cannot produce today).  This one
+    pins the VOCABULARY itself — the reason `glyph.ljust(width)` shipped
+    unnoticed since #3273 is that every glyph in it happens to measure 1 cell
+    (four are East Asian Ambiguous width, which ``cell_len`` resolves to 1).
+    ``_cell_pad_right`` now makes the padding correct regardless, but a
+    single-cell vocabulary is still the realistic, cheap invariant to guard:
+    an emoji marker (most measure 2 cells) added to this vocabulary without
+    widening :data:`RIGHT_GUTTER_WIDTH`-style column accounting elsewhere
+    would be a real, silent regression this test would catch immediately.
+
+    Enumerated from the REAL registry (:data:`_KIND_LINE`, the tool-call and
+    intervention branches of :func:`_gutter_glyph_color`, and
+    :data:`_RUNNING_FRAMES`) rather than a hand-copied literal list, so a
+    future glyph added to any of those sources is automatically covered."""
+    glyphs: "set[str]" = set(_RUNNING_FRAMES)
+    for kind in _KIND_LINE:
+        glyph, _ = _gutter_glyph_color(OutboxMessage(kind=kind, text=""))
+        glyphs.add(glyph)
+    glyph, _ = _gutter_glyph_color(
+        OutboxMessage(kind="tool_call_started", text="grep", meta={"tool": "grep"})
+    )
+    glyphs.add(glyph)
+    glyph, _ = _gutter_glyph_color(
+        OutboxMessage(kind="tool_call_completed", text="", meta={"tool": "grep"})
+    )
+    glyphs.add(glyph)
+    glyph, _ = _gutter_glyph_color(
+        OutboxMessage(kind="tool_call_failed", text="", meta={"tool": "grep"})
+    )
+    glyphs.add(glyph)
+    # intervention: pending (no _answer_label) and resolved (has one) are two
+    # distinct glyph branches (#3324) — both enumerated.
+    glyph, _ = _gutter_glyph_color(OutboxMessage(kind="intervention", text="", meta={}))
+    glyphs.add(glyph)
+    glyph, _ = _gutter_glyph_color(
+        OutboxMessage(kind="intervention", text="", meta={"_answer_label": "yes"})
+    )
+    glyphs.add(glyph)
+
+    assert glyphs, "enumeration produced no glyphs — registry sources changed shape"
+    for glyph in glyphs:
+        assert cell_len(glyph) == 1, (
+            f"{glyph!r} measures {cell_len(glyph)} cells, not 1 — a new "
+            "vocabulary entry (e.g. an emoji marker) needs its column "
+            "accounting revisited, not a silent single-cell assumption"
+        )

--- a/tests/test_textual_chat_phase2_3273.py
+++ b/tests/test_textual_chat_phase2_3273.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import AsyncIterator
 
 import pytest
+from rich.cells import cell_len
 from textual.app import App
 from textual_flowview import EntryState
 
@@ -42,6 +43,7 @@ from reyn.interfaces.inline.textual_chat import (
     TextualChatApp,
     _body_and_background,
 )
+from reyn.interfaces.inline.textual_chat.gutter import _cell_pad_right
 from reyn.interfaces.repl.renderer import _CC_DONE, _CC_ERR, _CC_WARN
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
@@ -387,3 +389,40 @@ def test_failure_rows_carry_coral_background_tint() -> None:
     assert bg_error == _CC_ERR
     _, bg_agent = _body_and_background(OutboxMessage(kind="agent", text="hi"))
     assert bg_agent is None
+
+
+def test_left_gutter_pads_by_cells_not_characters() -> None:
+    """Tier 1: :func:`_cell_pad_right` — the LEFT gutter's padding function,
+    ``ReynGutter.decorate``'s counterpart to the RIGHT gutter's
+    ``_cell_pad_left`` (#3347) — aligns to a CELL count, which is what a
+    terminal column actually is, not a character count.
+
+    ★ Driven with a genuinely DOUBLE-WIDTH character. That is not decoration:
+    for the LEFT gutter's real glyph vocabulary (``· ⋯ ⎿ ◆ ○ ● ✗ ❯``) ``len()``
+    and ``cell_len()`` agree on every glyph — four of them are East Asian
+    Ambiguous width, which ``rich.cells.cell_len`` resolves to 1, the same as
+    ``len()`` — so an assertion driven only by the real vocabulary passes
+    identically for ``str.ljust`` and cannot witness the difference (#3350:
+    this is exactly why the ``ljust`` in place since #3273 was never caught).
+    A wide character is the discriminating input: ``ljust`` pads it by
+    character count and overflows the column.
+
+    The production vocabulary cannot currently emit one; this pins the
+    helper's CONTRACT so the column stays correct by construction rather than
+    by the coincidence that today's glyphs happen to be narrow or
+    ambiguous-resolved-to-1."""
+    wide = "中中"  # U+4E2D, east_asian_width "W" — wider than one cell each
+    assert cell_len(wide) > len(wide), (
+        "fixture must be text whose CELL width exceeds its CHARACTER count — "
+        "otherwise the two padding strategies agree and this cannot witness "
+        "the difference"
+    )
+    padded = _cell_pad_right(wide, 8)
+    assert cell_len(padded) == 8, (
+        f"{padded!r} occupies {cell_len(padded)} cells, not the 8 asked for — "
+        "padding is counting characters, not cells"
+    )
+    assert padded.startswith(wide), "the label itself must survive padding"
+    # An over-long label is returned unpadded rather than negative-padded;
+    # flowview's own adjust_cell_length clips it, it never steals body columns.
+    assert _cell_pad_right(wide, 2) == wide


### PR DESCRIPTION
**[per-PR-coder]** — part of #3350.

`ReynGutter.decorate` (the LEFT gutter, `src/reyn/interfaces/inline/textual_chat/gutter.py`) padded with `glyph.ljust(width)` — a character-count pad — since #3273. Repo-wide grep confirmed it was the only remaining `ljust`/`rjust`/`center` padding site in `src/reyn`.

## Fix

Reuses the pattern #3347 established for the RIGHT gutter: adds `_cell_pad_right` (the left-aligned sibling of `_cell_pad_left`), built on `rich.cells.cell_len` — the same function Textual's compositor measures the strip with — and wires it into `ReynGutter.decorate` in place of `glyph.ljust(width)`. No glyph in the vocabulary changes; this is a padding-mechanism fix only.

Confirmed after the change: `grep -rn '\.ljust(\|\.rjust(\|\.center(' src/reyn/` returns nothing.

## Test

Per the issue's own finding (carried over from #3347's first, vacuous attempt at this same gate): every glyph in the LEFT gutter's real vocabulary (`· ⋯ ⎿ ◆ ○ ● ✗ ❯`) measures 1 cell under both `len()` and `cell_len()` — four are East Asian Ambiguous width, which `cell_len` resolves to 1 — so a gate driven by the real vocabulary would pass identically under `str.ljust` and witness nothing.

`test_left_gutter_pads_by_cells_not_characters` (`tests/test_textual_chat_phase2_3273.py`) instead drives `_cell_pad_right` directly with a genuinely double-width character (`中中`, `east_asian_width == "W"`), asserting the cell-width property (not a pinned string).

**Strip-falsify performed**: reverted `_cell_pad_right`'s body to `label.ljust(width)` (verified anchor `count == 1` first) → test went RED (`'中中      '` measured 10 cells against a width=8 ask, instead of 8). Restored the correct implementation, all tests green again.

**Co-vet follow-up added**: `test_left_gutter_vocabulary_is_all_single_cell`, enumerated from the real registry (`_KIND_LINE`, `_gutter_glyph_color`'s tool-call/intervention branches, `_RUNNING_FRAMES`) rather than a hand-copied literal list — pins that every glyph the LEFT gutter can currently emit is single-cell. Deliberately a separate gate from the padding-contract test above: that one proves the helper is correct for any width (witnessed with a synthetic wide character the vocabulary can't produce today); this one guards the vocabulary itself, so it fails loudly the day an emoji marker (`cell_len` typically 2) is added to the status vocabulary — the realistic future break named in review.

Did not add further character classes (combining/ZWJ/zero-width) to the padding gate itself — confirmed those are behaviourally the same defect class as double-width for `ljust` (a `len()`/`cell_len()` divergence), so the existing `中中` witness already covers what they'd add.

## CI gates (run locally, foreground)

- `ruff check src tests` — pass
- `python scripts/test_tier_audit.py --strict tests/test_textual_chat_phase2_3273.py` — 12/12 OK, 0 Tier-4 violations
- targeted pytest (`test_textual_chat_phase2_3273.py` + the other `textual_chat` gutter-adjacent suites) — 96 passed
- `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/gutter.py` — OK

## Other `len()`-based width arithmetic noticed while in this file

None beyond what #3347 already addressed — `gutter.py` now has zero remaining character-count width arithmetic (`_cell_pad_left` and `_cell_pad_right` are both `cell_len`-based). Did not audit the rest of the TUI beyond this file; out of scope per the issue.

## Test plan

- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict tests/test_textual_chat_phase2_3273.py`
- [x] targeted pytest (gutter-adjacent `textual_chat` suites, 96 passed)
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/gutter.py`
- [x] Manual/visual real-TTY check: **not performed, and not applicable** — with the current glyph vocabulary, the old (`ljust`) and new (`_cell_pad_right`) implementations render byte-identical output, so there is nothing a human eye could observe differing on a real terminal. The property this PR fixes (correctness under a double-width glyph) is not observable at today's vocabulary by construction; it is witnessed instead by the unit-level strip-falsify above, which is the only way to make this defect visible at all.