### PR TITLE
fix(tui): failure rows are painted in their own background colour — part of #3367

### DIFF
--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -642,6 +642,22 @@ second hand-rolled column:
   (`int(clock() / frame_period)`) that flowview's own
   `FlowView(animation_fps=N)` re-invokes on each animation tick — no
   app-side timer (#3283 ①, native-blink equivalence).
+- **ROW TINT — `Presentation.background`** (`presenter.py`): a user row and a
+  FAILURE row (a `tool_call_failed` / `error` frame, or a `tool_call_completed`
+  whose summary is a `✗`) carry a whole-row background that flowview paints
+  edge to edge across gutter + body + padding (`_view._compose_line`). Every
+  tint is a `_CC_*_BG` constant — a faint DARK block (`_CC_USER_BG`,
+  `_CC_ERR_BG`) that the row's normal foreground stays legible against; a
+  saturated `_CC_*` foreground colour is never reused as a background. The two
+  vocabularies are kept disjoint deliberately: foreground and background are
+  chosen on independent code paths, so overlapping them is how they collide.
+  #3367 was exactly that collision — every failure leg paired `style=_CC_ERR`
+  with `background=_CC_ERR`, painting the row's text (and, because the tint
+  spans the gutter column, the gutter's coral `⎿`/`✗` glyph) in its own
+  background colour, so a failed tool call rendered as an unreadable solid
+  band. `tests/test_textual_chat_row_contrast_3367.py` gates the invariant over
+  the (kind, state) cross-product enumerated from `DISPLAY_KINDS` +
+  `EntryState`.
 - **RIGHT gutter — `ReynRightGutter`** (`gutter.py`, #3283 ④): one column, two
   label families, wired via flowview's additive
   `right_decorator`/`right_gutter_width` params. flowview takes a single right

--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -25,6 +25,7 @@ from reyn.interfaces.repl.renderer import (
     _CC_DIM,
     _CC_DONE,
     _CC_ERR,
+    _CC_ERR_BG,
     _CC_TEXT,
     _CC_USER_BG,
     _KIND_LINE,
@@ -177,7 +178,8 @@ def _tool_result_line(msg: "OutboxMessage") -> "tuple[Text, str | None]":
     and failure vocabulary so a coalesced result reads the same as the pre-coalesce
     separate ``tool_call_completed`` / ``tool_call_failed`` row — only the nesting
     (``⎿`` under the call, in one entry) is new. A failure tints the whole row
-    coral (``_CC_ERR``), matching the standalone failure row."""
+    with the dark failure block (:data:`_CC_ERR_BG`) and keeps the coral
+    ``_CC_ERR`` text legible on top of it, matching the standalone failure row."""
     meta = msg.meta or {}
     result_meta = meta.get(_RESULT_META_KEY) or {}
     if meta.get(_RESULT_KIND_KEY) == _ORPHANED_RESULT_KIND:
@@ -192,12 +194,12 @@ def _tool_result_line(msg: "OutboxMessage") -> "tuple[Text, str | None]":
             or result_meta.get("text")
             or ""
         )
-        return Text(f"  ⎿ ✗ {err}", style=_CC_ERR), _CC_ERR
+        return Text(f"  ⎿ ✗ {err}", style=_CC_ERR), _CC_ERR_BG
     summary = summarize_tool_result(meta.get("tool"), result_meta.get("result"))
     failed = summary.startswith("✗")
     return (
         Text(f"  ⎿ {summary}", style=_CC_ERR if failed else _CC_DIM),
-        (_CC_ERR if failed else None),
+        (_CC_ERR_BG if failed else None),
     )
 
 
@@ -228,8 +230,24 @@ def _body_and_background(msg: "OutboxMessage") -> "tuple[RenderableType, str | N
     (flowview paints it edge to edge across gutter + body), matching the plain
     renderer's faint user block without a hand-rolled grid. A FAILURE row
     (``tool_call_failed`` / ``error`` / a ``tool_call_completed`` whose summary
-    is an ``✗`` failure) carries ``background=_CC_ERR`` so the whole row is
-    tinted coral edge to edge — CC's block-tint of a failed tool (Phase 2).
+    is an ``✗`` failure) carries ``background=_CC_ERR_BG`` so the whole row is
+    tinted with the dark failure block edge to edge — CC's block-tint of a failed
+    tool (Phase 2).
+
+    **Foreground and background are picked independently here, so they must
+    never resolve to the same colour** (#3367). Every row tint is a ``_CC_*_BG``
+    constant — a faint dark block — and every text/glyph colour is a ``_CC_*``
+    foreground constant; the two vocabularies do not overlap, which is what makes
+    the no-collision property hold by construction rather than per branch. Before
+    #3367 the five failure legs (two here, two in :func:`_tool_result_line`, plus
+    the ``error`` kind whose ``_KIND_LINE`` body style is already ``_CC_ERR``)
+    each paired ``style=_CC_ERR`` with ``background=_CC_ERR``, painting the text
+    in its own background colour. Because flowview paints the row background
+    across the gutter column too, the left gutter's coral ``✗``/``⎿`` glyph
+    (``ReynGutter``, ``_STATE_COLOR[EntryState.ERROR] == _CC_ERR``) vanished with
+    it — one background choice, every foreground on the row. The gate is
+    ``tests/test_textual_chat_row_contrast_3367.py``, which enumerates the
+    (kind, state) pairings from the producers rather than a hand-written list.
     """
     kind = msg.kind
     meta = msg.meta or {}
@@ -249,17 +267,17 @@ def _body_and_background(msg: "OutboxMessage") -> "tuple[RenderableType, str | N
         summary = summarize_tool_result(meta.get("tool"), meta.get("result"))
         failed = summary.startswith("✗")
         style = _CC_ERR if failed else _CC_DIM
-        return Text(summary, style=style), (_CC_ERR if failed else None)
+        return Text(summary, style=style), (_CC_ERR_BG if failed else None)
     if kind == "tool_call_failed":
         err = meta.get("error_message") or meta.get("error_kind") or msg.text
-        return Text(f"✗ {err}", style=_CC_ERR), _CC_ERR
+        return Text(f"✗ {err}", style=_CC_ERR), _CC_ERR_BG
     line = _KIND_LINE.get(kind)
     body_style = line[2] if line else _CC_TEXT
     body = _body_renderable(kind, msg.text or " ", body_style)
     if kind == "user":
         background = _CC_USER_BG
     elif kind == "error":
-        background = _CC_ERR
+        background = _CC_ERR_BG
     else:
         background = None
     return body, background

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -346,9 +346,24 @@ _CC_ERR = "#f97066"     # red — failure
 _CC_WARN = "#e3b341"    # amber — an intervention that needs the user to act
 _CC_ACCENT = "#d97757"  # terracotta — spinner / accents
 _CC_COOL = "#6cb6ff"    # cool blue — a secondary accent (status-bar agent value)
+# Row-TINT backgrounds. The convention (established by _CC_USER_BG, extended to
+# _CC_ERR_BG by #3367): a row tint is a FAINT DARK block that the row's normal
+# foreground colour stays legible against — never a saturated foreground colour
+# reused as a background. A _CC_*_BG constant is only ever a background, and a
+# _CC_* foreground constant is never used as one; that separation is what keeps
+# "pick a foreground" and "pick a background" from colliding on the same hue.
+#
 # Subtle background block behind the user's own submitted line (CC styles the
 # user input differently from agent output — a faint highlighted block).
 _CC_USER_BG = "#2b2f37"
+# Failure block-tint behind a failed tool call / error row. A desaturated dark
+# coral: it reads unmistakably as "the red row" edge to edge (CC's block-tint of
+# a failed tool) while _CC_ERR text on top of it stays high-contrast. #3367:
+# every failure row previously carried background=_CC_ERR — the SAME value as
+# its own foreground — so the text was painted in its background colour and the
+# row rendered as a solid illegible coral band, exactly when the user most needs
+# to read why something failed.
+_CC_ERR_BG = "#3a1c1a"
 
 # Braille spinner frames for the working indicator (bottom toolbar).
 _SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"

--- a/tests/test_textual_chat_phase2_3273.py
+++ b/tests/test_textual_chat_phase2_3273.py
@@ -17,8 +17,9 @@ clock. These pin the architect-specified Phase-2 gates against that mechanism:
   proving the animation is ADDITIVE, not load-bearing. The positive check pairs
   with the strip so the gate is not vacuous.
 - **state transition** (Tier 2b): a tool-call row goes RUNNING (amber) →
-  SUCCESS (green) / ERROR (coral), and a failed row is tinted ``_CC_ERR``
-  edge-to-edge.
+  SUCCESS (green) / ERROR (coral), and a failed row is tinted ``_CC_ERR_BG``
+  edge-to-edge (#3367: the dark failure block, not the coral foreground colour
+  reused as a background).
 
 All use real instances (a concrete :class:`ScriptedTransport`, a real mounted
 :class:`TextualChatApp`, real :class:`OutboxMessage`, a real list-backed clock
@@ -48,7 +49,13 @@ from reyn.interfaces.inline.textual_chat.gutter import (
     _cell_pad_right,
     _gutter_glyph_color,
 )
-from reyn.interfaces.repl.renderer import _CC_DONE, _CC_ERR, _CC_WARN, _KIND_LINE
+from reyn.interfaces.repl.renderer import (
+    _CC_DONE,
+    _CC_ERR,
+    _CC_ERR_BG,
+    _CC_WARN,
+    _KIND_LINE,
+)
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
@@ -359,7 +366,7 @@ async def test_running_to_error_turns_gutter_coral_and_tints_failure_row() -> No
     """Tier 2b: RUNNING → ERROR — a failed tool call transitions the started
     entry to ERROR (gutter ``_CC_ERR`` coral) AND, under the #3283 ② coalesce,
     the failure is folded into that SAME started entry (no separate row) whose
-    presentation is tinted ``_CC_ERR`` edge-to-edge (CC block-tint). Feeds the
+    presentation is tinted ``_CC_ERR_BG`` edge-to-edge (CC block-tint). Feeds the
     correlated started+failed pair and inspects the coalesced entry's gutter and
     presentation background."""
     transport = ScriptedTransport([_started("op-err"), _failed("op-err")], end=False)
@@ -377,20 +384,24 @@ async def test_running_to_error_turns_gutter_coral_and_tints_failure_row() -> No
         gutter = ReynGutter()
         assert gutter.decorate(started, 2, 1).style == _CC_ERR
 
-        # The coalesced failure entry is tinted coral edge-to-edge.
+        # The coalesced failure entry is tinted edge-to-edge with the dark
+        # failure block — NOT with the coral foreground colour (#3367).
         pres = await ReynPresenter().present(started.item, 80)
-        assert pres.background == _CC_ERR
+        assert pres.background == _CC_ERR_BG
 
 
 def test_failure_rows_carry_coral_background_tint() -> None:
     """Tier 1: the failure-row tint is a pure function of the frame — a
-    ``tool_call_failed`` and an ``error`` frame both carry a ``_CC_ERR``
+    ``tool_call_failed`` and an ``error`` frame both carry a ``_CC_ERR_BG``
     whole-row background, while a non-error row carries none. Pins the
-    ``_body_and_background`` contract directly."""
+    ``_body_and_background`` contract directly. The tint is the dark failure
+    BLOCK, distinct from the coral ``_CC_ERR`` text drawn on top of it — see
+    ``tests/test_textual_chat_row_contrast_3367.py`` for the legibility gate
+    over every (kind, state) pairing."""
     _, bg_failed = _body_and_background(_failed("z"))
-    assert bg_failed == _CC_ERR
+    assert bg_failed == _CC_ERR_BG
     _, bg_error = _body_and_background(OutboxMessage(kind="error", text="boom"))
-    assert bg_error == _CC_ERR
+    assert bg_error == _CC_ERR_BG
     _, bg_agent = _body_and_background(OutboxMessage(kind="agent", text="hi"))
     assert bg_agent is None
 

--- a/tests/test_textual_chat_phase2b_live_tool_3283.py
+++ b/tests/test_textual_chat_phase2b_live_tool_3283.py
@@ -357,9 +357,13 @@ async def test_app_coalesces_a_failure_and_tints_it() -> None:
         assert started.state is EntryState.ERROR
         assert (started.item.meta or {}).get(_RUNNING_SINCE_KEY) is None
         pres = await ReynPresenter().present(started.item, 80)
-        from reyn.interfaces.repl.renderer import _CC_ERR
+        from reyn.interfaces.repl.renderer import _CC_ERR, _CC_ERR_BG
 
-        assert pres.background == _CC_ERR
+        # #3367: the failure tint is the dark failure BLOCK, never the coral
+        # foreground colour reused as a background (that painted the row's text
+        # in its own background and made it illegible).
+        assert pres.background == _CC_ERR_BG
+        assert pres.background != _CC_ERR
         assert "⎿" in _render(pres.renderable)
 
 

--- a/tests/test_textual_chat_row_contrast_3367.py
+++ b/tests/test_textual_chat_row_contrast_3367.py
@@ -1,0 +1,305 @@
+"""Row-legibility gate (#3367): no row paints its ink in its own background.
+
+The owner reported failed tool-call rows rendering as a solid coral band with
+no readable content. Root cause: ``presenter._body_and_background`` picks a
+foreground and a full-row background INDEPENDENTLY, and five failure legs
+picked ``_CC_ERR`` for both — the text was drawn in its own background colour.
+Because flowview paints ``Presentation.background`` across the gutter column
+too (``_view._compose_line``), the left gutter's coral ``⎿``/``✗`` glyph
+(``_STATE_COLOR[EntryState.ERROR]``) disappeared with it: ONE background choice
+silently decides the legibility of EVERY foreground on that row.
+
+So the gate here is over the PAIRINGS, not over the five legs that were named.
+Both foreground producers (``ReynPresenter`` for the body, ``ReynGutter`` for
+the gutter glyph) are driven over a cross-product of scenarios whose axes are
+ENUMERATED FROM THEIR PRODUCERS rather than hand-listed — a hand-written case
+list omits whichever case someone adds next:
+
+- kind ← :data:`reyn.runtime.outbox.DISPLAY_KINDS`, the closed producer
+  vocabulary ``OutboxMessage.__post_init__`` validates against;
+- settle-state ← ``{None} ∪ DISPLAY_KINDS ∪ {ORPHANED_RESULT_KIND}``, the
+  values ``app._coalesce_tool_result`` / ``_sweep_orphaned_running_tools`` /
+  ``restore.project_restored_frames`` can stamp under ``RESULT_KIND_KEY``;
+- entry state ← ``list(EntryState)``, every member of flowview's enum;
+- plus the two payload/meta switches the presenter itself branches on (a
+  result summary that is a ``✗`` failure vs. one that is not;
+  ``RUNNING_SINCE_KEY`` present vs. absent).
+
+Every scenario's rendered segments are inspected for their EFFECTIVE
+(foreground, background) pair and asserted to clear a minimum contrast ratio.
+Contrast, not bare inequality: it strictly implies "not the same colour" (an
+identical pair scores exactly 1.0) while also catching a near-collision that a
+``!=`` check would wave through. The threshold is a floor, not a pin on the
+palette's actual values — no test here asserts a specific hex.
+
+All real instances: real ``OutboxMessage`` / ``FlowModel`` / ``Entry`` /
+``ReynPresenter`` / ``ReynGutter`` / rich ``Console``. No mocks.
+
+Headless can only establish the colour relationship. The visual confirmation
+that a failed tool row now READS in a real terminal is tui-coder's.
+"""
+from __future__ import annotations
+
+import itertools
+
+import pytest
+from rich.color import Color, ColorType
+from rich.console import Console, RenderableType
+from rich.segment import Segment
+from textual_flowview import Entry, EntryState, FlowModel
+
+from reyn.interfaces.inline.textual_chat import ReynGutter, ReynPresenter
+from reyn.interfaces.inline.textual_chat._meta_keys import (
+    ORPHANED_RESULT_KIND,
+    RESULT_KIND_KEY,
+    RESULT_META_KEY,
+    RUNNING_SINCE_KEY,
+)
+from reyn.interfaces.repl.renderer import summarize_tool_result
+from reyn.runtime.outbox import DISPLAY_KINDS, OutboxMessage
+
+#: Minimum acceptable contrast ratio between a row's ink and the surface it is
+#: painted on — a DISTINGUISHABILITY floor, not a WCAG conformance target.
+#:
+#: Deliberately NOT WCAG AA (4.5) or AA-large (3.0): ``_CC_DIM`` is an
+#: intentionally ambient, low-contrast colour, and legislating an accessibility
+#: ratio onto it here would turn this gate into a redesign of the palette rather
+#: than a defence of the #3367 invariant. This floor is set to separate the
+#: failure mode — a foreground painted in its own or a near-identical background
+#: (ratio 1.0 exactly when equal) — from every pairing the palette actually
+#: produces. The gate asserts strict inequality alongside it, so the invariant
+#: named in the issue is pinned literally as well as by proxy. No hex value is
+#: pinned anywhere in this file.
+MIN_CONTRAST = 2.0
+
+#: A tool result that ``summarize_tool_result`` renders as a ``✗`` failure (the
+#: dict-with-``error`` shape). Its failure-ness is ASSERTED in the fixtures
+#: below rather than assumed — the ``✗`` prefix is the switch the presenter's
+#: ``tool_call_completed`` leg branches on.
+_FAILING_RESULT = {"error": "boom"}
+_SUCCEEDING_RESULT = {"op": "read", "content": "one\ntwo\n"}
+
+_WIDTH = 60
+
+
+def _relative_luminance(color: Color) -> float:
+    """WCAG relative luminance of a resolved truecolor triplet."""
+    triplet = color.get_truecolor()
+
+    def _linear(channel: int) -> float:
+        srgb = channel / 255
+        return srgb / 12.92 if srgb <= 0.04045 else ((srgb + 0.055) / 1.055) ** 2.4
+
+    r, g, b = (_linear(c) for c in (triplet.red, triplet.green, triplet.blue))
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def _contrast_ratio(fg: Color, bg: Color) -> float:
+    """WCAG contrast ratio between two colours — 1.0 when they are identical,
+    21.0 for black on white."""
+    lighter, darker = sorted(
+        (_relative_luminance(fg), _relative_luminance(bg)), reverse=True
+    )
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def _is_concrete(color: "Color | None") -> bool:
+    """Whether this is a colour the reyn palette actually CHOSE.
+
+    ``_CC_TEXT`` is the literal string ``"default"`` — the terminal's own
+    foreground, resolved by the emulator and unknowable here. A default colour
+    can never collide with a chosen one by construction (it is not a value this
+    code picks), so it is excluded rather than compared against a guessed RGB.
+    """
+    return color is not None and color.type is not ColorType.DEFAULT
+
+
+def _ink_on_surface(
+    renderable: RenderableType, row_background: "str | None"
+) -> "list[tuple[Color, Color]]":
+    """Every visible (foreground, effective-background) pair in ``renderable``.
+
+    The effective background is the segment's OWN background when it sets one
+    (a ``Text`` styled ``on <colour>``), else the row background flowview paints
+    edge to edge. Whitespace-only segments carry no ink and are skipped.
+    """
+    console = Console(width=_WIDTH, color_system="truecolor", force_terminal=True)
+    row_bg = Color.parse(row_background) if row_background is not None else None
+    pairs: list[tuple[Color, Color]] = []
+    segment: Segment
+    for segment in console.render(renderable, console.options.update_width(_WIDTH)):
+        if not segment.text.strip():
+            continue
+        style = segment.style
+        if style is None:
+            continue
+        background = style.bgcolor if _is_concrete(style.bgcolor) else row_bg
+        if not _is_concrete(style.color) or not _is_concrete(background):
+            continue
+        assert style.color is not None and background is not None  # narrowed above
+        pairs.append((style.color, background))
+    return pairs
+
+
+def _settle_kinds() -> "list[str | None]":
+    """Every value a producer can stamp under ``RESULT_KIND_KEY`` — enumerated
+    from the closed frame vocabulary plus the orphan sentinel, never a
+    hand-picked pair of tool kinds."""
+    return [None, ORPHANED_RESULT_KIND, *sorted(DISPLAY_KINDS)]
+
+
+def _scenarios() -> "list[tuple[str, OutboxMessage]]":
+    """The (kind, state) cross-product of display frames the presenter + gutter
+    can be handed, each as a real :class:`OutboxMessage` with a readable id."""
+    rows: list[tuple[str, OutboxMessage]] = []
+    for kind, settle_kind, result, running, answered in itertools.product(
+        sorted(DISPLAY_KINDS),
+        _settle_kinds(),
+        (_FAILING_RESULT, _SUCCEEDING_RESULT),
+        (False, True),
+        (False, True),
+    ):
+        meta: dict = {
+            "tool": "present",
+            "args": {"blueprint": {"children": []}},
+            "error_message": "bad argument shape",
+            "error_kind": "ValidationError",
+            # A STANDALONE ``tool_call_completed`` row reads its payload from
+            # ``meta["result"]``, while a COALESCED one reads it from
+            # ``meta[RESULT_META_KEY]["result"]``. Both are stamped from the same
+            # ``result`` so the ``✗``-summary leg is reachable on either path —
+            # omitting the top-level key left the standalone leg unexercised, and
+            # its strip stayed GREEN.
+            "result": result,
+        }
+        if settle_kind is not None:
+            meta[RESULT_KIND_KEY] = settle_kind
+            meta[RESULT_META_KEY] = {
+                "result": result,
+                "error_message": "bad argument shape",
+            }
+        if running:
+            meta[RUNNING_SINCE_KEY] = 0.0
+        if answered:
+            meta["_answer_label"] = "yes"
+        label = (
+            f"kind={kind} settled={settle_kind} "
+            f"failed_result={result is _FAILING_RESULT} "
+            f"running={running} answered={answered}"
+        )
+        rows.append((label, OutboxMessage(kind=kind, text="something went wrong", meta=meta)))
+    return rows
+
+
+def _entry(msg: OutboxMessage, state: EntryState) -> "Entry[OutboxMessage]":
+    """A real flowview :class:`Entry` in ``state`` — the gutter decorator's
+    actual argument type, obtained the way production does (from a model)."""
+    model: FlowModel[OutboxMessage] = FlowModel()
+    entry = model.append(msg)
+    entry.set_state(state)
+    return entry
+
+
+def test_scenario_enumeration_is_non_vacuous_and_reaches_the_failure_legs() -> None:
+    """Tier 1: the enumeration the contrast gate iterates is non-empty, is
+    derived from the producers, and actually reaches the legs that regressed.
+
+    Without this, an enumeration that silently collapsed to zero scenarios — or
+    to scenarios that never take a failure branch — would let the contrast gate
+    pass by iterating over nothing. Asserts the axes are populated, that the
+    failing-result fixture really is what ``summarize_tool_result`` calls a
+    failure, and that the three kinds named in #3367 plus the coalesced settle
+    states are present in the cross-product.
+    """
+    scenarios = _scenarios()
+    assert scenarios, "scenario enumeration is empty — the contrast gate would be vacuous"
+    assert DISPLAY_KINDS, "producer kind vocabulary is empty"
+    assert list(EntryState), "flowview EntryState enum is empty"
+
+    # The ``✗`` switch the presenter branches on is real, not assumed.
+    assert summarize_tool_result("present", _FAILING_RESULT).startswith("✗")
+    assert not summarize_tool_result("present", _SUCCEEDING_RESULT).startswith("✗")
+
+    kinds = {msg.kind for _, msg in scenarios}
+    assert {"error", "tool_call_failed", "tool_call_completed", "tool_call_started"} <= kinds
+    settled = {(msg.meta or {}).get(RESULT_KIND_KEY) for _, msg in scenarios}
+    assert {None, ORPHANED_RESULT_KIND, "tool_call_failed", "tool_call_completed"} <= settled
+
+
+@pytest.mark.asyncio
+async def test_row_ink_is_never_painted_in_its_own_background() -> None:
+    """Tier 2b: for every (kind, state) pairing the presenter and gutter can
+    emit, every visible foreground clears :data:`MIN_CONTRAST` against the
+    surface it is painted on.
+
+    Drives the real ``ReynPresenter.present`` (body + row background) and the
+    real ``ReynGutter.decorate`` (glyph, whose colour is ``EntryState``-driven)
+    over the full cross-product, and inspects the rendered segments. The gutter
+    is included because flowview paints the row background across it too, so a
+    background chosen by the presenter governs a foreground chosen by the
+    gutter — the coupling that made ONE bad pairing take out the whole row.
+    """
+    presenter = ReynPresenter(clock=lambda: 0.0)
+    gutter = ReynGutter(frame_period=0.0)
+    checked = 0
+    tinted_kinds: set[str] = set()
+    for label, msg in _scenarios():
+        presentation = await presenter.present(msg, _WIDTH)
+        background = presentation.background
+        if background is not None:
+            tinted_kinds.add(msg.kind)
+        renderables: list[RenderableType] = [presentation.renderable]
+        for state in EntryState:
+            renderables.append(gutter.decorate(_entry(msg, state), 2, 1))
+        for renderable in renderables:
+            for fg, bg in _ink_on_surface(renderable, background):
+                checked += 1
+                assert fg.get_truecolor() != bg.get_truecolor(), (
+                    f"row ink painted in its own background: {label} — "
+                    f"{fg.get_truecolor().hex}"
+                )
+                ratio = _contrast_ratio(fg, bg)
+                assert ratio >= MIN_CONTRAST, (
+                    f"illegible row ink: {label} — foreground {fg.get_truecolor().hex} "
+                    f"on background {bg.get_truecolor().hex} scores {ratio:.2f}, "
+                    f"below the {MIN_CONTRAST} floor"
+                )
+    assert checked > 0, "no (foreground, background) pair was inspected — gate is vacuous"
+    # REACHABILITY, not just non-emptiness: a scenario set that renders plenty of
+    # pairs but never drives a row that actually CARRIES a tint would pass the
+    # count check above while leaving every collision-capable leg unexercised.
+    # This is not hypothetical — the first draft of this file omitted the
+    # top-level ``meta["result"]`` key, so the standalone ``tool_call_completed``
+    # failure leg was never reached and its strip measured GREEN.
+    assert {
+        "error",
+        "tool_call_failed",
+        "tool_call_completed",
+        "tool_call_started",
+        "user",
+    } <= tinted_kinds, f"tinted rows never reached for: {tinted_kinds}"
+
+
+@pytest.mark.asyncio
+async def test_failure_rows_keep_a_distinct_row_tint() -> None:
+    """Tier 2b: the fix keeps the failure block-tint rather than dropping it.
+
+    The illegibility could have been "fixed" by removing the background
+    entirely, trading a legibility defect for the loss of the visual distinction
+    the tint exists to provide. Pins the property instead of the value: a failed
+    tool row and an error row still carry SOME row background, and it is not the
+    same background an ordinary user row carries.
+    """
+    presenter = ReynPresenter(clock=lambda: 0.0)
+    failed = await presenter.present(
+        OutboxMessage(kind="tool_call_failed", text="boom", meta={"error_message": "boom"}),
+        _WIDTH,
+    )
+    errored = await presenter.present(OutboxMessage(kind="error", text="boom"), _WIDTH)
+    user = await presenter.present(OutboxMessage(kind="user", text="hello"), _WIDTH)
+    agent = await presenter.present(OutboxMessage(kind="agent", text="hello"), _WIDTH)
+
+    assert failed.background is not None
+    assert errored.background == failed.background
+    assert user.background is not None and user.background != failed.background
+    assert agent.background is None

--- a/tests/test_textual_chat_row_contrast_3367.py
+++ b/tests/test_textual_chat_row_contrast_3367.py
@@ -70,6 +70,11 @@ from reyn.runtime.outbox import DISPLAY_KINDS, OutboxMessage
 #: produces. The gate asserts strict inequality alongside it, so the invariant
 #: named in the issue is pinned literally as well as by proxy. No hex value is
 #: pinned anywhere in this file.
+#:
+#: Raising this to ``3.0`` is the start condition of **#3371**: the user row
+#: (``_CC_DIM`` on ``_CC_USER_BG``, ratio 2.78) goes RED at that threshold. That
+#: is a palette DESIGN decision, tracked separately — do not raise it here as a
+#: drive-by.
 MIN_CONTRAST = 2.0
 
 #: A tool result that ``summarize_tool_result`` renders as a ``✗`` failure (the


### PR DESCRIPTION
**[per-PR-coder]** — part of #3367.

Failed tool-call / error rows rendered with text colour identical to background colour. Fixed as a **fix-class over the (foreground, background) pairings**, not as the three named lines.

## Verified the trace, and found more than three

The reporter's trace is correct, and incomplete. `_body_and_background` has three colliding legs; **`_tool_result_line` has two more** — and that helper is the *coalesced* tool row, i.e. the path a live failed tool call actually takes (`app._coalesce_tool_result` folds the completion into the started entry, so the standalone `tool_call_failed` row is the uncorrelated fallback). **Five colliding pairings, not three.**

| # | site | pairing before |
|---|---|---|
| 1 | `_tool_result_line`, settled `tool_call_failed` | `style=_CC_ERR`, bg `_CC_ERR` |
| 2 | `_tool_result_line`, `✗` result summary | `style=_CC_ERR`, bg `_CC_ERR` |
| 3 | `_body_and_background`, `tool_call_completed` + `✗` summary | `style=_CC_ERR`, bg `_CC_ERR` |
| 4 | `_body_and_background`, `tool_call_failed` | `style=_CC_ERR`, bg `_CC_ERR` |
| 5 | `_body_and_background`, `kind == "error"` | `_KIND_LINE["error"][2] == _CC_ERR`, bg `_CC_ERR` |

**A sixth foreground was collateral and is not in `presenter.py` at all.** flowview paints `Presentation.background` across the **gutter column** too (`_view._compose_line` → `Strip.apply_style(bgcolor=...)` over `Strip.join([left_gutter, body, right_gutter])`). An error row's `EntryState` is `ERROR`, and `gutter._STATE_COLOR[EntryState.ERROR] == _CC_ERR` — so the gutter's coral `⎿`/`✗` glyph was painted in the same colour too. **One background choice decides the legibility of every foreground on the row**, which is why the gate below covers the gutter and not only the presenter.

## What "fixed" means here

The background stays — the distinction is the point of it, and dropping it would trade a legibility defect for a lesser one. The repo already has a convention for a row tint and it is **not** "reuse a foreground colour": `_CC_USER_BG = "#2b2f37"` is a *faint dark block* that the row's normal foreground reads against. Extended rather than paralleled:

- new `_CC_ERR_BG = "#3a1c1a"` — a desaturated dark coral; still unmistakably "the red row" edge to edge, `_CC_ERR` text on top at a **5.54** contrast ratio;
- the palette comment now states the separation as a rule: **a `_CC_*_BG` constant is only ever a background, a `_CC_*` foreground constant is never used as one.** That disjointness is what makes the no-collision property hold by construction instead of per branch — the actual root fix, since the defect class is "two independent choices can land on the same hue".

Same fix shape reaches the gutter for free: nothing in `gutter.py` changed, and its coral glyph is now legible because the surface underneath it changed.

## The gate — `tests/test_textual_chat_row_contrast_3367.py`

Enumerated **from the producers**, never hand-listed (the `_MENU_TABS` hazard in #3363):

- kind ← `reyn.runtime.outbox.DISPLAY_KINDS` (the closed vocabulary `OutboxMessage.__post_init__` validates against)
- settle-state ← `{None} ∪ DISPLAY_KINDS ∪ {ORPHANED_RESULT_KIND}` (every value a producer can stamp under `RESULT_KIND_KEY`)
- entry state ← `list(EntryState)` (every flowview enum member)
- plus the two switches the presenter itself branches on: a `✗` vs. non-`✗` result summary, `RUNNING_SINCE_KEY` present/absent, `_answer_label` present/absent

→ **2040 scenarios, 2912 (foreground, background) pairs inspected**, driving the real `ReynPresenter.present` **and** the real `ReynGutter.decorate`. All real instances (`OutboxMessage`, `FlowModel`/`Entry`, rich `Console`) — no mocks, no hand-rolled stand-ins.

Each pair is asserted twice: `fg != bg` (the invariant named in the issue, pinned literally) **and** a contrast ratio ≥ `MIN_CONTRAST`. Contrast catches a near-collision that `!=` waves through; identical colours score exactly 1.0, so the floor strictly implies the inequality. **No hex value is asserted anywhere in the test file** — the properties are "differ" and "distinguishable", not "is `#3a1c1a`".

`MIN_CONTRAST = 2.0` is deliberately **not** WCAG AA-large (3.0) — see the "second finding" below for why that is a calibration decision and not a fudge.

**Non-vacuity, two layers.** `assert scenarios` / `assert DISPLAY_KINDS` / `assert list(EntryState)` for emptiness, plus `assert summarize_tool_result(_FAILING_RESULT).startswith("✗")` so the failure switch is verified rather than assumed. And a **reachability** assertion — that `{error, tool_call_failed, tool_call_completed, tool_call_started, user}` each actually produced a tinted row — because a scenario set can render thousands of pairs while never driving a row that carries a tint at all. Not hypothetical: see the strip results.

## Strip-falsify — measured

venv identity checked first (`reyn.__file__` under this worktree's `src`) — the repo-root `.venv` resolved to the parent tree, so an isolated venv was built. Anchor uniqueness `count == 1` verified for all five before stripping.

| strip (restore the colliding pairing) | result |
|---|---|
| 1 `_tool_result_line` settled-failed | **RED** (1 failed) |
| 2 `_tool_result_line` `✗`-summary | **RED** (1 failed) |
| 3 `_body_and_background` `tool_call_completed` | **RED** (1 failed) |
| 4 `_body_and_background` `tool_call_failed` | **RED** (2 failed) |
| 5 `_body_and_background` `error` kind | **RED** (2 failed) |
| all five at once | **RED** |
| palette-level: `_CC_ERR_BG` → `"#f97066"` | **RED** |
| baseline / restored | GREEN (3 passed) |

**Strip 3 measured GREEN on the first run** — a real gate hole, not a passing result. A standalone `tool_call_completed` row reads `meta["result"]`, while a coalesced one reads `meta[RESULT_META_KEY]["result"]`; the first draft stamped only the latter, so that leg was never reached and its restored bug went undetected. Fixed by stamping both, and the reachability assertion above was added specifically so this failure mode fails loudly next time rather than measuring green.

## Second finding — filed as #3371

The gate's worst pairing is **not** an error row: it is the **user row** — `_CC_DIM` `#6b7280` on `_CC_USER_BG` `#2b2f37`, ratio **2.78**, below WCAG AA-large. Pre-existing, not owner-reported, and not a collision — `_CC_DIM` is *deliberately* the ambient/low-importance colour, so holding it to an accessibility ratio here would be redesigning the palette under cover of a bug fix, turning the review question from "is the fix correct" into "is the palette good".

Hence `MIN_CONTRAST = 2.0` in this PR: a **distinguishability floor**, not a WCAG target. It cleanly separates the actual failure mode (ratio 1.0 when equal) from every pairing the palette really produces, without legislating design intent.

Tracked in **#3371**, which carries its own start and acceptance conditions because the gate this PR adds already expresses them: raising `MIN_CONTRAST` to `3.0` makes the 2.78 pair go RED. Not a Test-plan item here — a separate design decision with its own ticket.

## Docs

`docs/reference/runtime/agui-transport.md` § "Textual TUI gutters" gained a **ROW TINT** bullet — no doc previously described the failure-row appearance, and the section that describes what flowview paints per row is where the `_CC_*_BG` invariant belongs. Two test-file docstrings that asserted "tinted `_CC_ERR` edge-to-edge" were falsified by this PR and are corrected in it.

## Test plan

- [x] `ruff check src tests` — All checks passed
- [x] `python scripts/test_tier_audit.py --strict` on the 3 changed/added test files — 27 inspected, 0 Tier-4 errors
- [x] Full `pytest` from the repo root — **9385 passed, 42 skipped** (551s), isolated venv verified against this worktree
- [x] `python scripts/verify_module_docstrings.py` on both changed src files — OK
- [x] Strip-falsify all five pairings + the palette constant — table above
- [ ] **Real-TTY visual confirmation (tui-coder).** Legibility is ultimately visual; headless can only establish the colour relationship. Needs a `reyn chat` run in a real terminal driving a tool-call failure (the reporter's repro: misuse `present`'s argument shape), confirming the failed `⏺ present(...)` header, its `⎿ ✗ ...` line, the standalone error line, and the coral gutter glyph are all readable against the new dark block — and that the row still reads as "the red row" at a glance.
- [x] (moved to #3371 — user-row contrast at 2.78; a palette design decision, not a gate on this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
