### PR TITLE
fix: log unresolved model-class passthrough and yaml parse failures

### DIFF
--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -52,7 +52,20 @@ def _load_yaml(path: Path) -> dict:
         with path.open(encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
         return data if isinstance(data, dict) else {}
-    except Exception:
+    except Exception as exc:
+        # A parse failure here is otherwise indistinguishable from "the file
+        # doesn't exist" — every section the file would have contributed
+        # (models, permissions, ...) silently falls back to built-in/other-tier
+        # defaults with no signal the operator's own file was ever read. Log
+        # so a malformed reyn.yaml/reyn.local.yaml is at least observable
+        # (#3368) — the fallback-to-{} behavior itself is unchanged.
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "failed to parse %s — ignoring this file's config (falling back "
+            "to other config tiers/defaults): %s",
+            path, exc,
+        )
         return {}
 
 

--- a/src/reyn/llm/model_resolver.py
+++ b/src/reyn/llm/model_resolver.py
@@ -294,6 +294,25 @@ class ModelResolver:
         if name in self._resolved:
             return self._resolved[name]
         # Unknown name: passthrough — the name IS the LiteLLM model string.
+        # This is the sanctioned raw-model-string path (e.g. `--model
+        # gemini-2.5-flash-lite` bypassing the class system) — but it is
+        # ALSO what a mistyped or unregistered CLASS name silently falls
+        # into: nothing here can tell the two apart, so a typo or a config
+        # that failed to load its `models:` section (see `_load_yaml`) never
+        # surfaces as an error here — only much later, as a confusing raw
+        # provider-side rejection once litellm itself receives the
+        # unresolved name (#3368). Logged (not raised) so the passthrough
+        # behavior is unchanged, but the case is no longer fully silent.
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "model class %r not found among known classes (%s) — passing it "
+            "through unchanged as a literal LiteLLM model string. If this "
+            "was meant to be a configured class, check reyn.yaml/"
+            "reyn.local.yaml's `models:` section for a typo or a load "
+            "failure.",
+            name, ", ".join(sorted(self._resolved)) or "none",
+        )
         return ModelSpec(model=name, kwargs={})
 
     def class_for_purpose(self, purpose: str) -> str:

--- a/tests/test_config_loader_malformed.py
+++ b/tests/test_config_loader_malformed.py
@@ -78,3 +78,21 @@ def test_fail_loud_sections_still_raise_clear_error(tmp_path) -> None:
     (tmp_path / "reyn.yaml").write_text("tool_use: not-a-dict\n", encoding="utf-8")
     with pytest.raises(ValueError, match="must be a mapping"):
         load_config(tmp_path)
+
+
+def test_yaml_parse_error_logs_warning_and_falls_back(tmp_path, caplog) -> None:
+    """Tier 2: an unparseable reyn.yaml logs a warning naming the file (#3368).
+
+    Found via bug-mining (2026-07-26): `_load_yaml`'s `except Exception:
+    return {}` swallowed parse failures with zero signal, indistinguishable
+    from the file not existing at all — an operator's malformed
+    reyn.yaml/reyn.local.yaml silently lost its entire `models:`/`permissions:`
+    section. Falsification: pre-fix, no log record was emitted here.
+    """
+    import logging
+
+    (tmp_path / "reyn.yaml").write_text("models: [unterminated\n", encoding="utf-8")
+    with caplog.at_level(logging.WARNING, logger="reyn.config.loader"):
+        cfg = load_config(tmp_path)
+    assert dict(cfg.models) == {}
+    assert any("reyn.yaml" in r.message for r in caplog.records)

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -39,6 +39,25 @@ def test_resolve_unknown_name_returns_model_spec_passthrough():
     assert spec.kwargs == {}
 
 
+def test_resolve_unknown_name_logs_warning(caplog):
+    """Tier 2: resolve(unknown) logs a warning naming the unresolved value (#3368).
+
+    Found via bug-mining (2026-07-26): an unregistered/mistyped model CLASS
+    name (e.g. a config load failure dropping `models: {standard: ...}`)
+    falls into the same silent passthrough as a legitimate raw LiteLLM model
+    string — the two are indistinguishable until litellm itself rejects the
+    unresolved name much later. Falsification: pre-fix, no log record was
+    emitted here. Passthrough behavior itself (assertions above) is
+    unchanged by this test — only that it is no longer fully silent.
+    """
+    import logging
+
+    r = ModelResolver({"standard": "openai/model-b"})
+    with caplog.at_level(logging.WARNING, logger="reyn.llm.model_resolver"):
+        r.resolve("stnadard")
+    assert any("stnadard" in rec.message for rec in caplog.records)
+
+
 # ---------------------------------------------------------------------------
 # Backward compat: str form
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[tui-coder]** — part of #3368

## Summary
- `ModelResolver.resolve()`'s unknown-name passthrough (sanctioned for raw `--model` strings) is indistinguishable from a mistyped/unregistered class name — a config-load gap silently reached litellm as a raw string, surfacing only as a confusing provider-side rejection ("You passed model=...") much later. Now logs a warning naming the unresolved value and the currently-known classes; passthrough behavior itself is unchanged.
- `_load_yaml()`'s `except Exception: return {}` silently swallowed any parse error, indistinguishable from the file not existing at all — a malformed `reyn.yaml`/`reyn.local.yaml` could drop its entire `models:`/`permissions:` section with zero signal. Now logs a warning naming the file path and the exception; the `{}` fallback is unchanged.

Root-caused live during ordinary chat use (owner-reported), traced through `router_loop.py` → `call_llm_tools` → `ModelResolver.resolve()`/`_load_yaml()`. This narrow logging fix does not itself resolve the owner's specific unreproduced scenario — it makes the *next* occurrence (theirs or anyone else's) diagnosable via the log instead of fully silent.

## Test plan
- [x] `tests/test_model_resolver.py::test_resolve_unknown_name_logs_warning` — new, asserts the warning names the unresolved value
- [x] `tests/test_config_loader_malformed.py::test_yaml_parse_error_logs_warning_and_falls_back` — new, asserts the warning names the file path and the `{}` fallback is preserved
- [x] `ruff check` on changed files — clean
- [x] `python scripts/test_tier_audit.py --strict` on changed test files — 29/29 OK, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py` on changed src files — OK
- [x] Full `pytest` — 8735 passed; 77 failed / 36 errors all pre-existing and unrelated (env/dependency gaps — `textual_flowview`/`markdown` missing, unrelated `test_auth_gate_middleware.py` failures), confirmed none touch `loader.py`/`model_resolver.py`