### PR TITLE
fix(mcp): anchor the project root before loading config in `mcp serve` — part of #3368

### DIFF
--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -130,13 +130,14 @@ class ReynConfig:
         default="",
         metadata={"desc": "LiteLLM proxy base URL. Set this if you route requests through a local proxy."},
     )
-    # Pre-approved permissions (same structure as phase frontmatter, but value is "allow").
-    # Example: permissions: {exec: allow, file.delete: allow, mcp: {github: allow}}
+    # Pre-declared permissions (same structure as phase frontmatter). Values are
+    # "allow" (pre-approve, skip the interactive prompt) or "deny" (block outright).
+    # Example: permissions: {exec: allow, file.delete: deny, mcp: {github: allow}}
     # (#3226 Phase 3: the `exec` tool's pre-approval key was renamed from `shell`
     # — clean break, no alias; existing reyn.yaml `shell:` keys must be renamed.)
     permissions: dict = field(
         default_factory=dict,
-        metadata={"desc": "Pre-approve specific Control IR ops without interactive prompts."},
+        metadata={"desc": "Pre-declare `allow`/`deny` for specific Control IR ops, skipping the interactive prompt."},
     )
     # MCP server definitions.  Merged across config sources (servers dict is shallow-merged;
     # local overrides project which overrides global).

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -318,26 +318,31 @@ def register(sub) -> None:
     refresh.set_defaults(func=run_refresh)
 
 
-def run_serve(args: argparse.Namespace) -> None:
-    from reyn.config import _find_project_root, load_project_context
-    from reyn.core.events.state_log import StateLog
-    from reyn.llm.llm import run_async
-    from reyn.mcp.server import serve_stdio
-    from reyn.runtime.budget.budget import BudgetTracker
-    from reyn.runtime.factory_config import SessionFactoryConfig
-    from reyn.runtime.presentation_consumer import NullPresentationConsumer
-    from reyn.runtime.profile import AgentProfile
-    from reyn.runtime.registry import AgentRegistry
-    from reyn.runtime.scoped_session_factory import build_scoped_chat_session
-    from reyn.security.permissions.permissions import PermissionResolver
+def _anchor_project_root(args: argparse.Namespace) -> Path:
+    """Resolve `reyn mcp serve`'s project root and anchor the process in it.
 
-    session_cfg = InvocationContext.from_args(args)
-    # #2708 P3.2b: missing-cred pre-check moved onto the single LLM funnel
-    # (``recorded_acompletion``) — no per-surface startup gate. It surfaces as a
-    # typed ``MissingCredentialsError`` through this command's error boundary.
-    model, _ = session_cfg.model_for(args)
-    output_language = session_cfg.output_language_for(args)
-    safety = session_cfg.safety_for(args)
+    MUST run BEFORE the config is loaded (#3368). MCP clients (Claude Desktop,
+    Cursor, …) typically ignore the ``cwd`` field in their server config, so the
+    spawned server process lands in ``/`` — and ``load_config()`` resolves its
+    3-layer cascade from ``Path.cwd()``. Loading the config first therefore read
+    NO ``reyn.yaml`` at all and silently produced the built-in defaults
+    (``models: {}`` + ``model: "standard"``, ``permissions: {}``, default safety
+    / cost / mcp): the unmapped class ``"standard"`` then travelled through
+    ``ModelResolver.resolve``'s sanctioned raw-string passthrough all the way to
+    litellm, which rejected it with ``You passed model=standard`` — the
+    owner-reported symptom, with no ``--model`` flag and no ``/model`` command
+    anywhere in the picture. The ``os.chdir`` below already existed for exactly
+    this reason (relative ``.reyn/...`` paths), but it ran 44 lines AFTER the
+    config load, so it fixed the paths and not the config.
+
+    Extracted as a function so the ordering is structural: the caller cannot
+    obtain a project root without the chdir having happened, and every
+    cwd-derived read after it (config cascade included) sees the project.
+
+    Exits the process with a decision-enabling message when no project root can
+    be determined, or when the resolved root has no ``reyn.yaml``.
+    """
+    from reyn.config import _find_project_root
 
     if args.project:
         project_root = Path(args.project).resolve()
@@ -370,12 +375,39 @@ def run_serve(args: argparse.Namespace) -> None:
     # MCP clients (Claude Desktop, Cursor, …) spawn the server with cwd=`/`,
     # which causes any code that uses relative `.reyn/...` paths to try to
     # write under the filesystem root and crash with a read-only-fs error.
-    # `--project` only fixes the explicit StateLog/budget paths in this
-    # function; deeper code paths (Session, Workspace, AgentRegistry)
-    # also use relative paths internally. Anchor the whole process at the
-    # project root so the same code that works under `reyn chat` works
-    # here unchanged.
+    # `--project` only fixes the explicit StateLog/budget paths in
+    # ``run_serve``; deeper code paths (Session, Workspace, AgentRegistry)
+    # also use relative paths internally — and the config cascade itself
+    # (#3368). Anchor the whole process at the project root so the same code
+    # that works under `reyn chat` works here unchanged.
     os.chdir(project_root)
+    return project_root
+
+
+def run_serve(args: argparse.Namespace) -> None:
+    from reyn.config import load_project_context
+    from reyn.core.events.state_log import StateLog
+    from reyn.llm.llm import run_async
+    from reyn.mcp.server import serve_stdio
+    from reyn.runtime.budget.budget import BudgetTracker
+    from reyn.runtime.factory_config import SessionFactoryConfig
+    from reyn.runtime.presentation_consumer import NullPresentationConsumer
+    from reyn.runtime.profile import AgentProfile
+    from reyn.runtime.registry import AgentRegistry
+    from reyn.runtime.scoped_session_factory import build_scoped_chat_session
+    from reyn.security.permissions.permissions import PermissionResolver
+
+    # #3368: anchor FIRST — the config cascade below is cwd-derived, so it must
+    # not run until the process sits in the project root (see the helper).
+    project_root = _anchor_project_root(args)
+
+    session_cfg = InvocationContext.from_args(args)
+    # #2708 P3.2b: missing-cred pre-check moved onto the single LLM funnel
+    # (``recorded_acompletion``) — no per-surface startup gate. It surfaces as a
+    # typed ``MissingCredentialsError`` through this command's error boundary.
+    model, _ = session_cfg.model_for(args)
+    output_language = session_cfg.output_language_for(args)
+    safety = session_cfg.safety_for(args)
 
     state_log = StateLog(project_root / ".reyn" / "state" / "wal.jsonl")
     budget_tracker = BudgetTracker(session_cfg.config.cost)

--- a/tests/test_3368_mcp_serve_config_anchored_to_project.py
+++ b/tests/test_3368_mcp_serve_config_anchored_to_project.py
@@ -1,0 +1,141 @@
+"""Tier 2: OS invariant — `reyn mcp serve` reads the PROJECT's config, not cwd's.
+
+THE BUG (#3368, owner-reported live as ``You passed model=standard``): MCP
+clients (Claude Desktop, Cursor, …) ignore the ``cwd`` field in their server
+config, so the spawned ``reyn mcp serve --project <root>`` process starts in
+``/``. ``run_serve`` loaded the config FIRST (``InvocationContext.from_args``
+→ ``load_config()``, whose whole 3-layer cascade is derived from
+``Path.cwd()``) and only 44 lines later resolved ``--project`` and
+``os.chdir``'d into it. From ``/`` no ``reyn.yaml`` is reachable, so the
+cascade silently yielded the built-in defaults — ``models: {}`` with
+``model: "standard"``, and ``permissions: {}``. ``"standard"`` is NOT in
+``BUILTIN_MODELS`` (it is a tier every project maps itself), so
+``ModelResolver.resolve`` fell through its sanctioned raw-litellm-string
+passthrough and handed the bare class name to litellm, which rejects it with
+``You passed model=standard`` — no ``--model`` flag and no ``/model``
+command involved. The permission config was dropped by the same ordering.
+
+THE FIX: ``_anchor_project_root`` resolves the root and ``os.chdir``s BEFORE
+the config is loaded, so every cwd-derived read (the config cascade included)
+sees the project. Extracted as a function so the ordering is structural — a
+caller cannot obtain the root without the anchor having run.
+
+The gate below drives the REAL ordering with a REAL project on disk and a
+REAL ``ModelResolver``, from a cwd outside any project. Swapping the two
+calls in ``run_serve`` back (load config, then anchor) turns it red.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from reyn.interfaces.cli.commands.mcp import _anchor_project_root
+from reyn.interfaces.cli.invocation_context import InvocationContext
+
+_PROJECT_YAML = """\
+model: standard
+models:
+  standard: openai/probe-standard-model
+permissions:
+  file.read: allow
+"""
+
+
+def _serve_args(project: Path | None) -> argparse.Namespace:
+    """The argparse Namespace `reyn mcp serve` reads (real attribute set)."""
+    return argparse.Namespace(
+        project=str(project) if project is not None else None,
+        model=None,
+        output_language=None,
+        llm_timeout=None,
+        llm_max_retries=None,
+    )
+
+
+def _make_project(tmp_path: Path) -> Path:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "reyn.yaml").write_text(_PROJECT_YAML, encoding="utf-8")
+    return project
+
+
+def test_serve_resolves_model_class_from_the_project_not_the_spawn_cwd(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: spawned outside any project, `mcp serve --project` still resolves
+    the default model CLASS to the project's litellm string — never the raw
+    class name that litellm rejects with "You passed model=standard" (#3368)."""
+    project = _make_project(tmp_path)
+    elsewhere = tmp_path / "elsewhere"  # no reyn.yaml here or above (tmp_path)
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    args = _serve_args(project)
+    # The production ordering: anchor, THEN load config.
+    assert _anchor_project_root(args) == project.resolve()
+    session_cfg = InvocationContext.from_args(args)
+
+    model_class, resolved = session_cfg.model_for(args)
+    assert model_class == "standard"
+    assert resolved == "openai/probe-standard-model", (
+        "the project's models: mapping must be in effect; a bare class name "
+        "here is the #3368 passthrough that reaches litellm as "
+        f"'You passed model={resolved}'"
+    )
+    assert session_cfg.resolver.is_known_class("standard"), (
+        "'standard' must be a KNOWN class — an unknown one is exactly the "
+        "silent passthrough #3368 is about"
+    )
+
+
+def test_serve_reads_project_permissions_when_spawned_outside_the_project(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: the same ordering carries the project's permission config —
+    the cwd-derived cascade dropped it too, running the MCP surface on
+    fail-closed defaults instead of the operator's config (#3368)."""
+    project = _make_project(tmp_path)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    args = _serve_args(project)
+    _anchor_project_root(args)
+    session_cfg = InvocationContext.from_args(args)
+
+    assert session_cfg.config.permissions.get("file.read") == "allow"
+
+
+def test_run_serve_anchors_before_it_loads_the_config() -> None:
+    """Tier 2: (ordering guard) `run_serve` calls `_anchor_project_root` before
+    `InvocationContext.from_args` — the two behavioral arms above drive the
+    helper directly, so only this arm catches the call sites being swapped
+    back into the #3368 defect."""
+    import ast
+
+    from reyn.interfaces.cli.commands import mcp as mcp_cmd
+
+    tree = ast.parse(Path(mcp_cmd.__file__).read_text(encoding="utf-8"))
+    run_serve = next(
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "run_serve"
+    )
+    anchor_lines = [
+        node.lineno for node in ast.walk(run_serve)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_anchor_project_root"
+    ]
+    config_lines = [
+        node.lineno for node in ast.walk(run_serve)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "from_args"
+    ]
+    assert anchor_lines, "run_serve must anchor the project root (#3368)"
+    assert config_lines, "run_serve must build an InvocationContext"
+    assert max(anchor_lines) < min(config_lines), (
+        "run_serve loads the config before anchoring the project root — the "
+        "cascade is cwd-derived, so an MCP-client spawn (cwd=/) reads NO "
+        "reyn.yaml and falls back to model='standard' + permissions={} (#3368)"
+    )


### PR DESCRIPTION
**[per-PR-coder]** — part of #3368

## Root cause

`reyn mcp serve` loaded the config **before** it resolved `--project` and `os.chdir`'d into it.

`run_serve` called `InvocationContext.from_args(args)` → `load_config()`, whose entire 3-layer cascade is derived from `Path.cwd()`. Forty-four lines later it resolved `--project`, validated `reyn.yaml`, and `os.chdir`'d — fixing relative `.reyn/...` paths but not the config that had already been read.

MCP clients (Claude Desktop, Cursor, Claude Code) ignore the `cwd` field in their server config and spawn the process in `/`. The code's own comments already say so twice. So from `/`, `_find_project_root` found nothing and the cascade returned the built-in defaults:

```
model: "standard"     models: {}     permissions: {}
```

`"standard"` is not in `BUILTIN_MODELS` — it is a tier every project maps for itself. So `ModelResolver.resolve` fell through its sanctioned raw-litellm-string passthrough and handed the bare class name to litellm, which rejects it with **`You passed model=standard`**. No `--model` flag, no `/model` command — matching the owner's report exactly.

The same ordering silently dropped the project's entire `permissions:` declaration — allow entries and deny entries alike — so the MCP surface ran on the shipped defaults instead of the operator's config. The direction of the impact depends on what the operator wrote: an operator who declared allows lost the pre-approval convenience `docs/reference/cli/mcp.md` promises ("Pre-approve run permissions in `reyn.yaml`"); an operator who declared denies lost a restriction they believed was in force. Both are inert on this path — not only the pre-approvals.

## Reproduction (primary evidence)

Wrong-cwd config load, with a real project passed via `--project`:

```
$ cd / && python -c "... InvocationContext.from_args(Namespace(project='<real project>', ...))"
config.models      = {}
config.permissions = {}
model_for          -> ('standard', 'standard')
```

Driving that model through the real `recorded_acompletion` funnel produces both halves of the symptom — the raw log line (litellm's loggers are routed into `.reyn/logs/reyn.log` by `litellm_bootstrap`) and the hard failure:

```
LiteLLM:DEBUG ... You passed model=standard, custom_llm_provider=None.
              Error: litellm.BadRequestError: LLM Provider NOT provided. ... You passed model=standard
reyn.llm.llm  streaming gate: model=standard has_tools=False capable=False
RAISED BadRequestError litellm.BadRequestError: ... You passed model=standard
```

This also explains the architect's `_streaming_capable('gemini-pro') -> False` observation: the gate silently degrades to non-streaming whenever litellm cannot map the name, so an unresolved class disables streaming *before* the call fails.

## Fix

Project-root resolution + `reyn.yaml` validation + `os.chdir` move into `_anchor_project_root`, called first. Extraction makes the ordering **structural** — a caller cannot obtain the root without the anchor having run, so every cwd-derived read after it (the config cascade included) sees the project. No behavior change to the resolution rules themselves.

## Not bundled

Deliberately unconnected to #3349/#3351 (token accounting). Those concern estimated counts on the *streaming* path when `include_usage` is absent; this is a config-ordering defect. Symptoms rhyme, paths differ.

## Scope note

`_install_from_source` (`mcp.py`) has the same shape — it receives a resolved `project_root` but calls `load_config()` cwd-derived for its permission config. Not fixed here: it is an operator-run foreground command invoked from inside the project, so the wrong-cwd precondition does not arise the way it does for a client-spawned server. Flagged rather than silently skipped.

## Docs

No doc change owed. `docs/reference/cli/mcp.md` already asserts "Reads `reyn.yaml` from the project root" and "permissions are checked" — both were false before this PR; the fix makes them true rather than falsifying them.

## Test plan
- [x] `tests/test_3368_mcp_serve_config_anchored_to_project.py` — 3 arms. Two behavioral (real project on disk, real `ModelResolver`, cwd outside any project): the default class resolves to the project's litellm string and is a *known* class; the project's `permissions:` survives. One structural: `run_serve` calls `_anchor_project_root` before `InvocationContext.from_args`.
- [x] **Strip-falsify** — anchor uniqueness checked first (`count == 1` for both call sites). Swapping the two calls in `run_serve` back into the defective order → `test_run_serve_anchors_before_it_loads_the_config` FAILS (`assert 403 < 402`). Restored, green.
- [x] **Behavioral arms witnessed against the defect** — running the defective ordering directly yields `model_for -> ('standard', 'standard')`, `permissions {}`, `is_known_class('standard') False`, violating all three assertions. #3372's new passthrough warning fires on exactly this path, confirming it was built for this defect.
- [x] **Measurement identity verified** — the repo-root `.venv` was found pointing at another worktree, so this branch was measured in an isolated venv, re-asserted after every install (`reyn.__file__` under this worktree's `src`).
- [x] `ruff check src tests` — All checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_3368_...py` — 3/3 OK, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/cli/commands/mcp.py` — OK
- [x] Full `pytest` (foreground, `dev,web,fetch` extras installed) — **9360 passed, 45 skipped, 0 failed**
- [ ] Live MCP-client smoke (spawn `reyn mcp serve --project` from Claude Desktop/Cursor with `cwd=/` and send one message) — not run; no MCP client wired in this worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

