### PR TITLE
docs(ja): fix removed tool_use.chat example, add transport axis + reference section

### DIFF
--- a/docs/concepts/tools-integrations/codeact.ja.md
+++ b/docs/concepts/tools-integrations/codeact.ja.md
@@ -98,17 +98,22 @@ CodeAct は opt-in。 選ぶ価値があるのは:
 
 ## 有効化 (How to enable)
 
-CodeAct は他の scheme 同様 `reyn.yaml` で chat レイヤーに選ぶ。 chat default は
-`enumerate-all` ゆえ CodeAct は opt-in:
+CodeAct は `reyn.yaml` の `tool_use.scheme` x `tool_use.transport` の 2-key
+config で chat レイヤーに選ぶ（FP-0066 P4, #3247）。CodeAct は
+`enumerate-all` presentation を `content_fence` transport 上で表現したもので、
+独立した scheme 名を持たない。 chat レイヤーの default は
+`scheme=enumerate-all` / `transport=tool_calls` ゆえ CodeAct は opt-in:
 
 ```yaml
 # reyn.yaml
 tool_use:
-  chat: codeact     # top-level chat router
+  scheme: enumerate-all
+  transport: content_fence   # top-level chat router
 ```
 
-`chat` レイヤーを `codeact` にできる。
-[`reyn.yaml` § tool_use](../../reference/config/reyn-yaml.md#tool_use-block) 参照。
+旧 `tool_use.chat` key は #3247 で削除済み（clean-break、compat alias 無し）
+— これを書いた `reyn.yaml` は parse 時に失敗する。
+[`reyn.yaml` § tool_use](../../reference/config/reyn-yaml.ja.md#tool_use-block) 参照。
 
 ## security note（セキュリティ注記）
 

--- a/docs/concepts/tools-integrations/tool-use-schemes.ja.md
+++ b/docs/concepts/tools-integrations/tool-use-schemes.ja.md
@@ -40,17 +40,40 @@ agent のツールを LLM にどのように見せるか、そして LLM の呼�
 
 **使いどころ：** **弱い / 低コストモデル**を実行する場合。ツール使用をコードとして表現することが JSON ツール呼び出しを有意に上回るモデルに対して。
 
+CodeAct は `enumerate-all` presentation を **`content_fence` transport**
+上で表現したもの（FP-0066 P4, #3247）— `enumerate-all` と同じ全件フラット
+カタログですが、モデルはネイティブ tool call の代わりにフェンス付きコードとして
+呼び出しを表現します。`tool_use.scheme: enumerate-all` + `tool_use.transport:
+content_fence`（後述）で選択します。独立した `codeact` scheme 名はありません。
+
 ## chat レイヤーの選択
 
-スキームは chat レイヤーに対して選択されます：
+tool-use は 2 つの config key に分解されます: `tool_use.scheme`（**presentation**
+軸 — `category` / `enumerate-all` / `retrieval`）と `tool_use.transport`
+（モデルが選択したアクションをどう表現するか — `tool_calls` / `content_fence`）。
+すべての (scheme, transport) の組み合わせが実装されているわけではなく、
+未登録の組み合わせは config-parse 時に大きく失敗します。
 
 ```yaml
 # reyn.yaml
 tool_use:
-  chat: enumerate-all         # トップレベル chat ルーター（デフォルト）
+  scheme: enumerate-all       # トップレベル chat ルーター（デフォルト）
+  transport: tool_calls       # デフォルト
 ```
 
-chat レイヤーは登録済みの任意のスキームを使えます。完全なキーリファレンス：[`reyn.yaml` § tool_use](../../reference/config/reyn-yaml.md#tool_use-block)。
+CodeAct を選択するには:
+
+```yaml
+# reyn.yaml
+tool_use:
+  scheme: enumerate-all
+  transport: content_fence
+```
+
+旧 `tool_use.chat` の単一 key は #3247 で削除済み（clean-break、compat alias
+無し）— これを書いた `reyn.yaml` は config-load 時に `scheme` / `transport`
+への移行を名指すエラーで失敗します（黙って無視されることはありません）。
+完全なキーリファレンス：[`reyn.yaml` § tool_use](../../reference/config/reyn-yaml.ja.md#tool_use-block)。
 
 ## スワップが安全な理由
 
@@ -65,5 +88,5 @@ chat レイヤーは登録済みの任意のスキームを使えます。完全
 ## 参照
 
 - [Universal Action Catalog](universal-catalog.md) — `universal-category` スキームの内部（step/phase のデフォルト、chat の代替）
-- [`reyn.yaml` § tool_use](../../reference/config/reyn-yaml.md#tool_use-block) — 設定リファレンス
+- [`reyn.yaml` § tool_use](../../reference/config/reyn-yaml.ja.md#tool_use-block) — 設定リファレンス
 - [Permission model](../runtime/permission-model.md) — すべてのスキームがディスパッチするゲート

--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -36,6 +36,7 @@ models:
 | `voice` | マップ | ⚠️ 現在利用不可(consumerなし)。以下参照。 |
 | `events` | マップ | チャットセッションイベントファイルの監査ログローテーションポリシー。以下参照。 |
 | `observability` | マップ | P6 監査イベントの OpenTelemetry (OTLP) エクスポート（オプトイン）。デフォルトは無効。以下参照。 |
+| `tool_use` | マップ | chat レイヤーの tool-use scheme x transport セレクタ（`scheme`、`transport`）。以下参照。 |
 | `mcp` | マップ | MCP サーバー定義。以下参照。 |
 | `python` | マップ | Python preprocessor の追加許可モジュール。以下参照。 |
 | `agent` | マップ | P6 イベント監査証跡と送信 HTTP ヘッダー用のエージェント識別子。以下参照。 |
@@ -276,6 +277,60 @@ safety:
 | `safety.on_limit.auto_extend_times` | int | `1` | abort フォールスルーまでの自動延長回数。`mode: auto_extend` 時のみ使用。 |
 | `safety.on_limit.ask_timeout_seconds` | float（秒） | `0` | `interactive` モードでユーザー返答を待機する時間。`0`（デフォルト） = 無制限待機、正の値 = ウィンドウ経過で partial data として abort。 |
 
+## `tool_use` ブロック {#tool_use-block}
+
+chat レイヤーの tool-use **scheme x transport** セレクタ（FP-0066 P4b, #3247）。
+tool-use は直交する 2 つの軸に分解されます: `scheme` は **presentation** —
+能力が LLM にどう提示・発見されるか（`category` / `enumerate-all` /
+`retrieval`）— であり、`transport` はモデルが選択したアクションをどう
+表現するか（`tool_calls` / `content_fence`）です。解決された
+`(scheme, transport)` の組が、登録済みの `ToolUseScheme`（tool の提示・
+ディスパッチ方法を差し替え可能にする機構）を選択します。
+
+```yaml
+tool_use:
+  scheme: enumerate-all       # デフォルト
+  transport: tool_calls       # デフォルト
+```
+
+| キー | 型 | デフォルト | 説明 |
+|-----|------|---------|-------------|
+| `scheme` | 文字列 | `enumerate-all` | トップレベル chat レイヤーの presentation: `category` / `enumerate-all` / `retrieval`。**デフォルト `enumerate-all`** — アクションをフラットに列挙し LLM が直接呼び出せるようにする（`invoke_action` 名のハルシネーションを防ぎ、非ホットリストの tool-use が ~30%→100% に改善）。少数サーフェス / 多数ツールのカタログには `category` を設定（discover-then-call）。 |
+| `transport` | 文字列 | `tool_calls` | モデルが選択したアクションをどう表現するか: `tool_calls`（ネイティブ tool-calling）または `content_fence`（応答テキスト内のフェンス付きコードとしてアクションを表現 — CodeAct）。 |
+
+すべての `(scheme, transport)` の組み合わせが実装されているわけではありません。現時点で有効な組は:
+
+| `scheme` \ `transport` | `tool_calls` | `content_fence` |
+|---|---|---|
+| `category` | `universal-category` | *(未実装)* |
+| `enumerate-all` | `enumerate-all`（デフォルト） | CodeAct |
+| `retrieval` | `retrieval` | *(未実装)* |
+
+未登録の組み合わせ（例: `scheme: category` + `transport: content_fence`）は、
+黙って default にフォールバックしたり受理されたりせず、**config-parse 時に**
+分かりやすいエラーを送出します。CodeAct は `scheme: enumerate-all` +
+`transport: content_fence` で到達します — `enumerate-all` と同じ全件フラット
+カタログを、ネイティブ tool call の代わりにフェンス付きコードとして表現した
+ものであり、独立した `scheme` 名ではありません。`retrieval` はさらに
+`embedding.enabled: true` を要求します（FP-0066 §7）。
+
+旧来の単一 `tool_use.chat` key は**削除済み**です（clean-break、compat
+alias 無し）。`tool_use.chat` を残したままの `reyn.yaml` は、config-load
+時に `scheme` / `transport` への移行を名指すエラーで**大きく失敗**します
+— 黙って無視されることはありません。旧 `chat: codeact` は `scheme:
+enumerate-all` + `transport: content_fence` に、旧 `chat:
+universal-category` は `scheme: category`（`transport` はデフォルトの
+`tool_calls` のまま）になります — `category` は presentation 軸の名前で、
+登録済みの `universal-category` scheme に解決されます。
+
+scheme は `tools=` payload の構築方法、SP の tool-use 指示、LLM 応答の解釈方法、
+ディスパッチ方法のすべてを所有します — そのため `scheme` / `transport` を
+入れ替えると、OS 側の変更なしに chat レイヤーの tool-use ループ全体が変わります。
+
+各 scheme が何をするか、**どれをいつ選ぶか**（`enumerate-all` / `retrieval` /
+CodeAct vs デフォルト）については
+[Tool-Use Schemes](../../concepts/tools-integrations/tool-use-schemes.ja.md) を参照してください。
+
 ## `web` ブロック
 
 `web_fetch` と MCP パッケージレジストリの SSL 設定。
@@ -358,7 +413,7 @@ sandbox:
 
 ## `action_retrieval` ブロック
 
-ユニバーサルカタログの可視化 + 検索設定。 scheme *選択* は `tool_use` ブロック(EN 版 `reyn-yaml.md#tool_use-block` を参照。ja 版はまだこのブロックの翻訳が無い)に generalize されています — `tool_use.scheme` はデフォルトで `enumerate-all`(この wrapper path ではない)です。 `tool_use.scheme: category` を設定するとこのフラグが設定する wrapper scheme を選択できます(FP-0066 P4b, #3247 — 旧 `tool_use.chat` key は削除され、`scheme` x `transport` の 2-key に分割されました。presentation 軸の名前は `category`、解決先の登録済み scheme 名が `universal-category`)。 chat レイヤーの scheme が `universal-category` に解決される時、 このフラグがその presentation を制御します。 **ユニバーサル wrapper** (`list_actions` / `describe_action` / `invoke_action`) による、 全 skill / agent / MCP / file / memory / RAG カテゴリで統一の browse / describe / invoke を提供します。`universal_wrappers_enabled` は legacy フラグパスの直接呼び出し元に対してデフォルト ON — その呼び出し元について既存の flat `tools=` shape を保持したい operator は `universal_wrappers_enabled: false` でオプトアウト可能。
+ユニバーサルカタログの可視化 + 検索設定。 scheme *選択* は [`tool_use` ブロック](#tool_use-block)（下記参照）に generalize されています — `tool_use.scheme` はデフォルトで `enumerate-all`(この wrapper path ではない)です。 `tool_use.scheme: category` を設定するとこのフラグが設定する wrapper scheme を選択できます(FP-0066 P4b, #3247 — 旧 `tool_use.chat` key は削除され、`scheme` x `transport` の 2-key に分割されました。presentation 軸の名前は `category`、解決先の登録済み scheme 名が `universal-category`)。 chat レイヤーの scheme が `universal-category` に解決される時、 このフラグがその presentation を制御します。 **ユニバーサル wrapper** (`list_actions` / `describe_action` / `invoke_action`) による、 全 skill / agent / MCP / file / memory / RAG カテゴリで統一の browse / describe / invoke を提供します。`universal_wrappers_enabled` は legacy フラグパスの直接呼び出し元に対してデフォルト ON — その呼び出し元について既存の flat `tools=` shape を保持したい operator は `universal_wrappers_enabled: false` でオプトアウト可能。
 
 ```yaml
 action_retrieval:


### PR DESCRIPTION
**[per-PR-coder]** — part of #3375

## What

Fixes the "written and wrong" defects the owner hit, distinct from the
#2967 ja-parity backlog ("not yet written"). Scope is deliberately narrow:
false statements + the reference section they need to point to, not a
general ja translation sweep.

1. **`docs/concepts/tools-integrations/codeact.ja.md`** — the config example
   taught `tool_use.chat: codeact`. That key was removed (clean-break) in
   #3247 / FP-0066 P4b; a `reyn.yaml` carrying it now fails at parse time.
   Replaced with the current `scheme: enumerate-all` + `transport:
   content_fence` form, and added a note naming the removed key so a reader
   who still has the old key understands why their config fails.
2. **`docs/concepts/tools-integrations/tool-use-schemes.ja.md`** — never
   mentioned `transport` at all (only the `scheme`/presentation axis).
   Added the transport axis, the CodeAct = `enumerate-all` + `content_fence`
   equation, the fail-loud-at-parse behavior for unregistered pairs, and
   fixed the "chat layer selection" example to the current 2-key form.
3. **`docs/reference/config/reyn-yaml.ja.md`** — had no `tool_use` section
   at all; the `action_retrieval` section pointed to it with a self-admission
   ("ja 版はまだこのブロックの翻訳が無い"). Added the `tool_use` block
   section (mirroring the English reference: `scheme`/`transport` keys, the
   valid-pairs table, the old-key removal + migration mapping, the
   parse-time-failure behavior), a top-level-key table row, and updated the
   `action_retrieval` section to link to the new local section instead of
   admitting the gap. Also repointed the `tool_use` links in the two concept
   pages above from the English reference doc to this new ja section.

## Sweep result

Grepped the whole repo for `.ja.md` files still showing `tool_use.chat` or
other pre-#3247 single-key examples (`chat: codeact` / `chat:
universal-category` / `chat: enumerate-all` as a `tool_use.chat` value).
Beyond the three files above, no other `.ja.md` file had a stale example —
the two other files that reference `tool_use` (`universal-catalog.ja.md`,
`concepts/architecture/llm-invocation-surfaces.ja.md`) already use the
current `scheme`/`transport` form. One file that mentions bare `tool_use`
(`deep-dives/proposals/0012-async-skill-execution.ja.md`) is unrelated — it
discusses `tool_use`/`tool_calls` message *content blocks*, not the config
key, so it was left untouched.

## Not touched (and why)

- General ja-parity gaps elsewhere in the repo — out of scope per the
  issue's explicit distinction (#2967 backlog, not a per-PR mirror
  obligation). This PR only touches statements that are actively false or
  the reference section needed to correct them.
- `tool-use-schemes.ja.md`'s "参照" section footnote describing
  `universal-category` as "(step/phase のデフォルト、chat の代替)" — this
  reads differently from the English sibling's "(a chat-layer opt-in)" but
  is a pre-existing footnote wording difference, not something #3247
  falsified; left alone to keep this PR scoped to the tool_use.chat /
  transport defects named in the issue.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, no new
      anchor/link errors introduced by this change (pre-existing ja-parity
      anchor gaps in unrelated files are unchanged).
- [x] Verified each cited EN reference line (`docs/reference/config/reyn-yaml.md`
      `## tool_use block`, `docs/concepts/tools-integrations/codeact.md`
      `## How to enable`, `docs/concepts/tools-integrations/tool-use-schemes.md`
      `## Chat-layer selection`) still says what the issue claims before
      porting content.
