### PR TITLE
fix: tool schema must not depend on process history (litellm mutates the payload in place) — part of #3383

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1020,6 +1020,7 @@ def _operation_alias_metadata(
     """
     # Late imports to avoid circular dependency at module load time.
     from reyn.tools import get_default_registry
+    from reyn.tools.types import parameters_for_export
     from reyn.tools.universal_dispatch import (
         KNOWN_STATIC_QUALIFIED_NAMES,
         resolve_describe_action,
@@ -1034,7 +1035,13 @@ def _operation_alias_metadata(
     tool = get_default_registry().lookup(resolved.target_tool_name)
     if tool is None:
         return None
-    return tool.description, dict(tool.parameters)
+    # #3383: ``_build_hot_list_aliases`` drops this value straight into an OpenAI
+    # ``{"type": "function", "function": {"parameters": ...}}`` entry, and
+    # ``build_tools`` appends those entries to the ``tools=`` payload VERBATIM —
+    # a LIVE LLM-payload seam on ordinary turns. Route through the one projection
+    # that owns the deep-copy obligation; a shallow ``dict()`` here let a single
+    # Gemini/Vertex turn rewrite the canonical schema for the rest of the process.
+    return tool.description, parameters_for_export(tool.parameters)
 
 
 def gate_effective_tool_name(name: str, args: "dict | None") -> "str | None":

--- a/src/reyn/tools/hooks.py
+++ b/src/reyn/tools/hooks.py
@@ -41,13 +41,18 @@ _HOOK_POINTS = [
     "turn_start", "turn_end", "session_start", "session_end",
 ]
 # Isolation note (#2898): the schema below embeds ``list(_HOOK_POINTS)`` — a
-# defensive copy — NOT the module list by reference. ``render_for_router`` only
-# shallow-copies ``parameters``, so a by-reference embed would alias the module
-# list into every rendered schema; any later mutation of ``_HOOK_POINTS`` would
-# then silently corrupt every ``hooks_add`` render for the rest of the process
-# (a shared-mutable-state × test-order flake vector). The copy decouples the
-# rendered enum from the module list (same convention as
+# defensive copy — NOT the module list by reference. A by-reference embed would
+# alias the module list into the schema, so any later mutation of
+# ``_HOOK_POINTS`` would corrupt every ``hooks_add`` render for the rest of the
+# process (a shared-mutable-state × test-order flake vector). The copy decouples
+# the rendered enum from the module list (same convention as
 # ``universal_catalog.py``'s ``"enum": list(CATEGORIES)``).
+#
+# #3383 closed the OTHER direction of the same hazard: ``render_for_router``
+# used to only SHALLOW-copy ``parameters``, so a mutation of the rendered
+# payload flowed BACK into the module-level schema. It now deep-copies, which is
+# what makes this list() the only remaining care point here (the module list
+# would still be aliased into the definition itself, upstream of any render).
 
 # Relocated to reyn.tools.descriptions.hooks (Phase 3 tool-description
 # package refactor — byte-identical, no LLM-facing text change).

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -12,6 +12,7 @@ ToolContext.router_state.
 """
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal, Mapping, Protocol
 
@@ -457,7 +458,19 @@ class ToolDefinition:
             "function": {
                 "name": self.name,
                 "description": self.description,
-                "parameters": dict(self.parameters),
+                # deepcopy, NOT dict(): a shallow copy leaves every nested
+                # sub-schema (``properties`` / each ``oneOf`` variant) ALIASED to
+                # the module-level constant this ToolDefinition was built from.
+                # litellm's provider transforms mutate the tools[] payload they
+                # are handed IN PLACE (``_build_vertex_schema`` /
+                # ``add_object_type`` / ``_remove_additional_properties`` —
+                # documented as "the input parameters, modified in place"), so a
+                # single Gemini/Vertex call used to permanently rewrite the
+                # canonical schema for the rest of the process: every later
+                # render — for ANY provider — saw the corrupted shape. That made
+                # the tool schema the LLM receives a function of process history
+                # (#3383).
+                "parameters": deepcopy(dict(self.parameters)),
             },
         }
         if self.schema_enricher is not None and state is not None:

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -338,6 +338,40 @@ class ToolContext:
     agent_name: Any | None = None                    # str | None
 
 
+def parameters_for_export(parameters: Mapping[str, Any]) -> dict[str, Any]:
+    """The ONE way a canonical tool schema is handed outside its definition.
+
+    Every seam that projects a ``ToolDefinition.parameters`` into something a
+    caller keeps — the router ``tools=`` payload, a ``describe_action`` result,
+    a hot-list alias entry — MUST route through here. The obligation this owns
+    is the DEEP copy.
+
+    A shallow ``dict(parameters)`` is wrong, and wrong in a way that is invisible
+    at the call site: it copies only the top level, leaving every nested
+    sub-schema (``properties``, each ``oneOf`` variant, each variant's own
+    property schemas) ALIASED to the module-level constant the ToolDefinition was
+    built from. litellm's provider transforms then rewrite the payload they are
+    handed IN PLACE — ``_build_vertex_schema`` documents itself as returning
+    "the input parameters, modified in place"; within it ``add_object_type``
+    injects ``type: object`` into any node that has none and
+    ``_remove_additional_properties`` deletes ``additionalProperties: false``.
+    So one Gemini/Vertex turn used to permanently rewrite reyn's canonical
+    schema, and every later render — for ANY provider — served the corrupted
+    shape (#3383). The schema the LLM receives must never be a function of
+    process history.
+
+    Centralised deliberately: the four known seams were four copies of the same
+    ``dict(x.parameters)`` expression, so seam five would have been written the
+    same way. Owning the responsibility on the projection, not at each source,
+    is what makes the next seam correct by default. The behavioural gates in
+    ``tests/test_tool_schema_3383_process_history_independence.py`` still assert
+    it PER SEAM — "a helper with the right contract exists" and "every escape
+    point goes through the helper" are different claims, and only the second is
+    the invariant.
+    """
+    return deepcopy(dict(parameters))
+
+
 # ToolHandler: async callable signature.
 # Returns canonical ToolResult; raises on error (dispatcher wraps).
 class ToolHandler(Protocol):
@@ -458,19 +492,10 @@ class ToolDefinition:
             "function": {
                 "name": self.name,
                 "description": self.description,
-                # deepcopy, NOT dict(): a shallow copy leaves every nested
-                # sub-schema (``properties`` / each ``oneOf`` variant) ALIASED to
-                # the module-level constant this ToolDefinition was built from.
-                # litellm's provider transforms mutate the tools[] payload they
-                # are handed IN PLACE (``_build_vertex_schema`` /
-                # ``add_object_type`` / ``_remove_additional_properties`` —
-                # documented as "the input parameters, modified in place"), so a
-                # single Gemini/Vertex call used to permanently rewrite the
-                # canonical schema for the rest of the process: every later
-                # render — for ANY provider — saw the corrupted shape. That made
-                # the tool schema the LLM receives a function of process history
-                # (#3383).
-                "parameters": deepcopy(dict(self.parameters)),
+                # #3383: the ONE projection that owns the deep-copy obligation.
+                # Never inline a shallow ``dict(self.parameters)`` here — see
+                # parameters_for_export.
+                "parameters": parameters_for_export(self.parameters),
             },
         }
         if self.schema_enricher is not None and state is not None:

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -75,6 +75,7 @@ verification 1-9.
 """
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Collection, Final, Mapping
 
 from reyn.tools.descriptions import catalog as _catalog_descriptions
@@ -1082,7 +1083,11 @@ def _describe_one(
 
     return {
         "description": target.description,
-        "input_schema": dict(target.parameters),
+        # deepcopy for the same reason render_for_router does (#3383): a shallow
+        # copy hands the caller every nested sub-schema by reference, so anything
+        # that normalizes this describe_action payload in place would rewrite the
+        # canonical tool definition for the rest of the process.
+        "input_schema": deepcopy(dict(target.parameters)),
     }
 
 

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -75,12 +75,17 @@ verification 1-9.
 """
 from __future__ import annotations
 
-from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Collection, Final, Mapping
 
 from reyn.tools.descriptions import catalog as _catalog_descriptions
 from reyn.tools.descriptions import discovery
-from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
+from reyn.tools.types import (
+    ToolContext,
+    ToolDefinition,
+    ToolGates,
+    ToolResult,
+    parameters_for_export,
+)
 
 # Lazy-imported at function-body level to break the circular dependency
 # with universal_dispatch.py (which imports CATEGORIES + split_qualified_name
@@ -1083,11 +1088,12 @@ def _describe_one(
 
     return {
         "description": target.description,
-        # deepcopy for the same reason render_for_router does (#3383): a shallow
-        # copy hands the caller every nested sub-schema by reference, so anything
-        # that normalizes this describe_action payload in place would rewrite the
-        # canonical tool definition for the rest of the process.
-        "input_schema": deepcopy(dict(target.parameters)),
+        # #3383: a LIVE LLM-payload seam, not just a tool-result one —
+        # ``catalog_entries`` below reuses this ``input_schema`` as an entry's
+        # ``parameters``, and the DEFAULT ``enumerate-all`` scheme concatenates
+        # ``catalog_entries()`` into ``llm_tools_payload`` → ``tools=``. Route
+        # through the one projection that owns the deep-copy obligation.
+        "input_schema": parameters_for_export(target.parameters),
     }
 
 

--- a/tests/test_tool_schema_3383_process_history_independence.py
+++ b/tests/test_tool_schema_3383_process_history_independence.py
@@ -1,0 +1,140 @@
+"""Tier 1: a tool's rendered schema never depends on what ran earlier in the process.
+
+#3383. ``ToolDefinition.render_for_router`` used to return ``dict(self.parameters)``
+— a SHALLOW copy, leaving every nested sub-schema (``properties``, each ``oneOf``
+variant) aliased to the module-level constant the definition was built from.
+litellm's provider transforms rewrite the ``tools[]`` payload they are handed IN
+PLACE (``_build_vertex_schema`` is documented as returning "the input parameters,
+modified in place"; ``add_object_type`` injects ``type: object`` into any node
+without one, ``_remove_additional_properties`` deletes
+``additionalProperties: false``). So ONE Gemini/Vertex call permanently rewrote
+reyn's canonical schema, and every later render — for ANY provider — served the
+corrupted shape: ``plugin_management__install``'s ``source`` variants lost
+``additionalProperties`` and grew ``"type": "object"`` inside their ``kind``
+const, and ``presentation_install_local``'s untyped ``blueprint`` became
+``type: object``. Observed as a schedule-dependent baseline-fixture failure,
+but the defect is in the product: the schema the LLM receives was a function of
+process history.
+
+These tests assert the invariant directly, at each of the three seams where a
+canonical schema leaves its ToolDefinition: the router payload
+(``render_for_router``), the ``build_tools`` payload (``ToolSpec``), and the
+``describe_action`` tool result. Each drives the defect by CONSTRUCTING the
+precondition — mutating the handed-out payload in place, exactly as a provider
+transform does — rather than depending on a provider being reachable or on a
+particular test order.
+
+Enumerated from the live registry, not a hand-picked subset: any future tool
+whose schema has nested structure is covered on the day it is registered.
+"""
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+from typing import Any
+
+from reyn.runtime.router_tools import build_tools
+from reyn.tools import get_default_registry
+from reyn.tools.types import ToolContext
+from reyn.tools.universal_catalog import _handle_describe_action
+
+_SENTINEL_KEY = "__injected_by_a_provider_transform__"
+
+
+def _mutate_in_place(node: Any) -> int:
+    """Rewrite every dict in ``node`` the way a provider transform does.
+
+    Injects a key into each dict and deletes one existing key — the two shapes
+    litellm's Gemini/Vertex path applies (``add_object_type`` /
+    ``_remove_additional_properties``). Returns the number of dicts touched so a
+    caller can reject a vacuous run.
+    """
+    touched = 0
+    if isinstance(node, dict):
+        touched += 1
+        for value in list(node.values()):
+            touched += _mutate_in_place(value)
+        existing = [k for k in node if k != _SENTINEL_KEY]
+        node[_SENTINEL_KEY] = "object"
+        if existing:
+            del node[existing[0]]
+    elif isinstance(node, list):
+        for item in node:
+            touched += _mutate_in_place(item)
+    return touched
+
+
+def test_render_for_router_survives_in_place_mutation_of_a_handed_out_payload() -> None:
+    """Tier 1: mutating a render_for_router() payload cannot alter the next render."""
+    registry = get_default_registry()
+    pristine = {t.name: deepcopy(t.render_for_router()) for t in registry}
+
+    total_touched = 0
+    for tool in registry:
+        payload = tool.render_for_router()
+        total_touched += _mutate_in_place(payload)
+        assert payload != pristine[tool.name], (
+            f"{tool.name}: the mutation helper did not change the payload — "
+            "this run would prove nothing"
+        )
+
+    assert total_touched > len(pristine), (
+        "expected the mutation to reach nested sub-schemas, not just the top "
+        f"level (touched={total_touched}, tools={len(pristine)})"
+    )
+
+    for tool in get_default_registry():
+        assert tool.render_for_router() == pristine[tool.name], (
+            f"{tool.name}: render_for_router() changed after an EARLIER payload "
+            "was mutated in place — the canonical schema escaped by reference, "
+            "so the schema the LLM receives depends on process history (#3383)"
+        )
+
+
+def test_build_tools_survives_in_place_mutation_of_a_handed_out_payload() -> None:
+    """Tier 1: mutating a build_tools() payload cannot alter the next build_tools()."""
+    agents = [{"name": "researcher", "role": "Research agent"}]
+    pristine = deepcopy(build_tools(agents))
+
+    payload = build_tools(agents)
+    touched = _mutate_in_place(payload)
+    assert touched > len(pristine), (
+        f"mutation did not reach nested sub-schemas (touched={touched})"
+    )
+    assert payload != pristine, "the mutation helper did not change the payload"
+
+    assert build_tools(agents) == pristine, (
+        "build_tools() changed after an EARLIER payload was mutated in place — "
+        "a ToolSpec / ToolDefinition schema escaped by reference (#3383)"
+    )
+
+
+def test_describe_action_survives_in_place_mutation_of_its_input_schema() -> None:
+    """Tier 1: mutating describe_action's input_schema cannot alter the definition."""
+    # events=None: describe_action is a pure registry read and emits nothing, so
+    # no event sink is needed (and none is faked).
+    ctx = ToolContext(
+        events=None,
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=None,
+    )
+    action = "plugin_management__install"
+    pristine = deepcopy(asyncio.run(_handle_describe_action({"action_name": action}, ctx)))
+    assert pristine["input_schema"], f"{action}: describe_action returned no input_schema"
+
+    handed_out = asyncio.run(_handle_describe_action({"action_name": action}, ctx))
+    touched = _mutate_in_place(handed_out["input_schema"])
+    assert touched > 1, f"mutation did not reach nested sub-schemas (touched={touched})"
+
+    again = asyncio.run(_handle_describe_action({"action_name": action}, ctx))
+    assert again["input_schema"] == pristine["input_schema"], (
+        "describe_action's input_schema changed after an EARLIER result was "
+        "mutated in place — the canonical schema escaped by reference (#3383)"
+    )
+    assert get_default_registry().lookup(action) is not None
+    assert _SENTINEL_KEY not in str(get_default_registry().lookup(action).parameters), (
+        "the ToolDefinition's own parameters were rewritten by a mutation of a "
+        "describe_action result (#3383)"
+    )

--- a/tests/test_tool_schema_3383_process_history_independence.py
+++ b/tests/test_tool_schema_3383_process_history_independence.py
@@ -16,27 +16,46 @@ const, and ``presentation_install_local``'s untyped ``blueprint`` became
 but the defect is in the product: the schema the LLM receives was a function of
 process history.
 
-These tests assert the invariant directly, at each of the three seams where a
+These tests assert the invariant directly, at each of the FOUR seams where a
 canonical schema leaves its ToolDefinition: the router payload
-(``render_for_router``), the ``build_tools`` payload (``ToolSpec``), and the
-``describe_action`` tool result. Each drives the defect by CONSTRUCTING the
-precondition — mutating the handed-out payload in place, exactly as a provider
-transform does — rather than depending on a provider being reachable or on a
-particular test order.
+(``render_for_router``), the ``build_tools`` payload (``ToolSpec``), the
+``describe_action`` tool result, and the hot-list direct aliases
+(``router_loop._operation_alias_metadata`` → ``_build_hot_list_aliases``, whose
+entries ``build_tools`` appends to ``tools=`` verbatim). Each drives the defect
+by CONSTRUCTING the precondition — mutating the handed-out payload in place,
+exactly as a provider transform does — rather than depending on a provider being
+reachable or on a particular test order.
 
-Enumerated from the live registry, not a hand-picked subset: any future tool
-whose schema has nested structure is covered on the day it is registered.
+★ Coverage has TWO axes, and enumerating the registry only closes one of them.
+The per-seam arms are total in the *tool* axis (registry-enumerated, so a future
+tool is covered the day it is registered) and were **partial in the *seam* axis**
+— the hot-list alias path renders through none of the first three, so a live
+LLM-payload seam sat outside a gate that looked exhaustive. The seam axis is
+closed from both ends here, and the two claims are NOT interchangeable:
+
+  - the four per-seam arms  = the escape points that EXIST route through the
+    projection helper (``parameters_for_export``);
+  - ``test_no_shallow_parameters_copy_outside_the_projection_helper``  = a NEW
+    escape point CANNOT avoid it. Needed because the absence of an arm is
+    silent: a shallow copy is asymptomatic until something mutates it, which is
+    how #3383 survived from a99bcf64 (2026-07-12) to 2026-07-28;
+  - ``test_parameters_for_export_shares_no_mutable_substructure`` = the helper's
+    own contract, independent of any caller.
 """
 from __future__ import annotations
 
+import ast
 import asyncio
 from copy import deepcopy
+from pathlib import Path
 from typing import Any
 
+from reyn.runtime.router_loop import _build_hot_list_aliases
 from reyn.runtime.router_tools import build_tools
 from reyn.tools import get_default_registry
-from reyn.tools.types import ToolContext
+from reyn.tools.types import ToolContext, parameters_for_export
 from reyn.tools.universal_catalog import _handle_describe_action
+from reyn.tools.universal_dispatch import KNOWN_STATIC_QUALIFIED_NAMES
 
 _SENTINEL_KEY = "__injected_by_a_provider_transform__"
 
@@ -62,6 +81,52 @@ def _mutate_in_place(node: Any) -> int:
         for item in node:
             touched += _mutate_in_place(item)
     return touched
+
+
+def _shared_nested_objects(exported: Any, canonical: Any) -> list[str]:
+    """Paths at which ``exported`` still holds the SAME object as ``canonical``."""
+    shared: list[str] = []
+
+    def walk(a: Any, b: Any, path: str) -> None:
+        if isinstance(a, dict) and isinstance(b, dict):
+            if a is b:
+                shared.append(path or "<root>")
+                return
+            for key in a:
+                if key in b:
+                    walk(a[key], b[key], f"{path}.{key}")
+        elif isinstance(a, list) and isinstance(b, list):
+            if a is b:
+                shared.append(path or "<root>")
+                return
+            for i, (x, y) in enumerate(zip(a, b)):
+                walk(x, y, f"{path}[{i}]")
+
+    walk(exported, canonical, "")
+    return shared
+
+
+def test_parameters_for_export_shares_no_mutable_substructure() -> None:
+    """Tier 1: the projection helper's contract — nothing nested stays aliased."""
+    registry = get_default_registry()
+    nested_seen = 0
+    for tool in registry:
+        exported = parameters_for_export(tool.parameters)
+        assert exported == dict(tool.parameters), (
+            f"{tool.name}: parameters_for_export changed the schema's CONTENT; "
+            "it must copy, not normalize"
+        )
+        shared = _shared_nested_objects(exported, tool.parameters)
+        assert not shared, (
+            f"{tool.name}: parameters_for_export left substructure aliased to the "
+            f"canonical schema at {shared!r} — a consumer's in-place edit would "
+            "reach the ToolDefinition (#3383)"
+        )
+        nested_seen += len(dict(tool.parameters).get("properties") or {})
+
+    assert nested_seen > 0, (
+        "no registered tool had nested properties — this arm would prove nothing"
+    )
 
 
 def test_render_for_router_survives_in_place_mutation_of_a_handed_out_payload() -> None:
@@ -133,8 +198,168 @@ def test_describe_action_survives_in_place_mutation_of_its_input_schema() -> Non
         "describe_action's input_schema changed after an EARLIER result was "
         "mutated in place — the canonical schema escaped by reference (#3383)"
     )
-    assert get_default_registry().lookup(action) is not None
-    assert _SENTINEL_KEY not in str(get_default_registry().lookup(action).parameters), (
+    canonical = get_default_registry().lookup(action)
+    assert canonical is not None
+    assert _SENTINEL_KEY not in str(canonical.parameters), (
         "the ToolDefinition's own parameters were rewritten by a mutation of a "
         "describe_action result (#3383)"
+    )
+
+
+def test_hot_list_alias_survives_in_place_mutation_of_its_tools_entry() -> None:
+    """Tier 1: mutating a hot-list alias entry cannot alter the definition.
+
+    The seam arms 1-3 could not see: ``_build_hot_list_aliases`` takes its
+    ``parameters`` from ``_operation_alias_metadata`` — the target
+    ``ToolDefinition.parameters`` — and ``build_tools`` appends the resulting
+    entries to the ``tools=`` payload verbatim, so this reaches litellm on an
+    ordinary turn without passing through ``render_for_router``.
+    """
+    action = "plugin_management__install"
+    assert action in KNOWN_STATIC_QUALIFIED_NAMES, (
+        f"{action} is no longer an alias candidate — pick another operation "
+        "alias with a nested schema, or this arm proves nothing"
+    )
+    canonical = get_default_registry().lookup(action)
+    assert canonical is not None
+    pristine = deepcopy(canonical.parameters)
+
+    entries = _build_hot_list_aliases([action])
+    entry = next(e for e in entries if e["function"]["name"] == action)
+    handed_out = entry["function"]["parameters"]
+    touched = _mutate_in_place(handed_out)
+    assert touched > 1, f"mutation did not reach nested sub-schemas (touched={touched})"
+
+    assert canonical.parameters == pristine, (
+        "the ToolDefinition's parameters changed after a hot-list alias entry "
+        "was mutated in place — the canonical schema escaped by reference into "
+        "the tools= payload (#3383)"
+    )
+    assert _build_hot_list_aliases([action])[0]["function"]["parameters"] == pristine, (
+        "a later hot-list alias build served the corrupted schema (#3383)"
+    )
+
+
+# ── the syntactic half of the seam axis ──────────────────────────────────────
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for ancestor in here.parents:
+        if (ancestor / "pyproject.toml").is_file():
+            return ancestor
+    raise RuntimeError("repo root not found from " + str(here))
+
+
+def _is_shallow_parameters_copy(node: ast.AST) -> bool:
+    """True for a ``dict(<expr>.parameters)`` CALL — the #3383 defect's shape."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "dict"
+        and len(node.args) == 1
+        and isinstance(node.args[0], ast.Attribute)
+        and node.args[0].attr == "parameters"
+    )
+
+
+def _projection_helper_span(types_py: Path) -> tuple[int, int]:
+    """(start, end) line span of ``parameters_for_export`` in tools/types.py."""
+    tree = ast.parse(types_py.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "parameters_for_export":
+            return node.lineno, (node.end_lineno or node.lineno)
+    raise AssertionError(
+        "parameters_for_export not found in tools/types.py — the projection "
+        "chokepoint moved or was renamed (#3383)"
+    )
+
+
+def test_no_shallow_parameters_copy_outside_the_projection_helper() -> None:
+    """Tier 2: no new seam can shallow-copy a schema past the projection helper.
+
+    Walks ``src/reyn`` and REDs on any ``dict(<expr>.parameters)`` call outside
+    ``parameters_for_export`` itself. The per-seam arms above witness that the
+    escape points that EXIST route through the helper; this one is what stops a
+    seam written next month from re-introducing the defect, because the absence
+    of a per-seam arm is silent (a shallow copy is asymptomatic until something
+    mutates it).
+
+    **What this gate does NOT catch — and why it need not, in the same place, so
+    the reason is available exactly when someone is deciding whether the
+    exemption still holds.**
+
+    It matches one syntactic shape, ``dict(<expr>.parameters)``. It will not
+    catch a bare ``<expr>.parameters`` handed out with NO copy at all. One such
+    site exists and is deliberately not flagged: ``runtime/router_tools.py``'s
+    ``ToolSpec.to_openai_dict`` returns ``self.parameters`` uncopied.
+
+    ★ That site's safety is **derived, not intrinsic**. It is safe only because
+    every ``ToolSpec`` construction in ``build_tools`` has the shape
+    ``ToolSpec(parameters=_X_rendered["function"]["parameters"], ...)`` — i.e.
+    ``ToolSpec.parameters`` is always a ``render_for_router()`` product, and
+    therefore already a per-call deep copy produced by ``parameters_for_export``.
+    **If ``render_for_router`` is ever relaxed back toward a shallow copy, that
+    exempt site silently becomes an ungated escape point.** The exemption is
+    contingent on this PR's fix holding; it is not a standing property of
+    ``ToolSpec``.
+
+    Widening the gate to flag bare attribute reads would put a legitimate site in
+    its false-positive set, and a gate that cries wolf gets suppressed — then it
+    protects nothing. The bounded version is honest and survivable, and the
+    ``ToolSpec`` seam is covered behaviourally instead, by
+    ``test_build_tools_survives_in_place_mutation_of_a_handed_out_payload``
+    (which does go RED if ``render_for_router`` regresses — verified by
+    strip-falsify).
+    """
+    root = _repo_root()
+    src = root / "src" / "reyn"
+    types_py = (src / "tools" / "types.py").resolve()
+    start, end = _projection_helper_span(types_py)
+
+    offenders: list[str] = []
+    for py in src.rglob("*.py"):
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not _is_shallow_parameters_copy(node):
+                continue
+            inside_helper = py.resolve() == types_py and start <= node.lineno <= end
+            if not inside_helper:
+                offenders.append(f"{py.relative_to(root)}:{node.lineno}")
+
+    assert not offenders, (
+        "dict(<expr>.parameters) outside parameters_for_export — a SHALLOW copy "
+        "leaves every nested sub-schema aliased to the canonical definition, and "
+        "litellm's provider transforms rewrite the payload they are handed in "
+        "place, so one Gemini/Vertex turn rewrites the schema for the rest of the "
+        "process (#3383). Call reyn.tools.types.parameters_for_export instead. "
+        f"Offending sites: {offenders}"
+    )
+
+
+def test_projection_helper_actually_performs_a_deep_copy() -> None:
+    """Tier 2: positive guard — the allow-listed helper really deep-copies.
+
+    Without this, renaming or gutting ``parameters_for_export`` would leave the
+    AST gate above scanning for offenders against a chokepoint that no longer
+    does anything — asserting-empty and vacuously green. (This arm is why the
+    gate's allow-list is anchored to a function that is checked to still exist:
+    ``_projection_helper_span`` raises rather than returning an empty span.)
+    """
+    root = _repo_root()
+    types_py = (root / "src" / "reyn" / "tools" / "types.py").resolve()
+    start, end = _projection_helper_span(types_py)
+    tree = ast.parse(types_py.read_text(encoding="utf-8"))
+    deep_copies = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "deepcopy"
+        and start <= node.lineno <= end
+    ]
+    assert deep_copies, (
+        "parameters_for_export no longer calls deepcopy — the projection that "
+        "every seam is routed through has stopped owning its one obligation, and "
+        "the AST gate above is now guarding nothing (#3383)"
     )


### PR DESCRIPTION
**[per-PR-coder]** — part of #3383 (stage 1: determination + fix. Stage 2, the golden-file / scaffold policy cleanup of `test_tool_description_relocation.py`, is deliberately NOT in this PR.)

## Determination: it is a **product defect**, not a test artefact

`plugin_management__install`'s rendered schema really does depend on what ran earlier in the process. The baseline test was reporting a genuine defect.

One correction to the symptom as filed: the `oneOf` is **not** lost. Re-reading the CI assertion diff, `oneOf` is present on both sides — the `+`/`-` pairs around it are pytest's key-order rendering. What actually diverges is inside the variants.

## Reproduced deliberately, then reduced to one preceding test

1. Reproduced #3374's red on its branch (`925f87f7`) under `-n auto`, in an **isolated venv** (`import reyn` asserted to resolve into this worktree's `src/` — the repo-root `.venv` editable install points elsewhere, and for an order-dependent effect a wrong-tree import would be indistinguishable from the phenomenon).
2. `-n auto --dist load` schedules **dynamically**, so worker composition varies run to run — that is the "only in some run orders" part. Extracted worker `gw0`'s actual sequence from a verbose run and replayed it **serially in one process**: fails deterministically, 2/2.
3. Delta-debugged that 1401-test prefix down to **one** preceding test:

```
tests/test_fp0001_e2e_ask_user_roundtrip.py::test_async_mode_message_send_returns_task_envelope
tests/tools/test_tool_description_relocation.py::test_full_schema_contract_matches_baseline
```

Those two, in that order, fail in ~3 seconds. Either alone passes.

## Mechanism: the canonical definition is **rewritten at runtime**

Every hand-out site returned `dict(x.parameters)` — a **shallow** copy. Every nested sub-schema (`properties`, each `oneOf` variant, each variant's `kind`) stayed **aliased to the module-level constant** in `plugin_management_verbs.py`.

litellm's provider transforms rewrite the `tools[]` payload they are handed **in place**. `_build_vertex_schema`'s own docstring: *"parameters: dict - the input parameters, modified in place"*. Within it, `add_object_type` injects `type: object` into any node that has none, and `_remove_additional_properties` deletes `additionalProperties: false`.

So one Gemini/Vertex call permanently rewrote reyn's canonical schema, for the rest of the process, for **every** provider.

## The real payload differs — verified against the render paths, not the fixture

Standalone witness (no pytest, no baseline fixture): render, run one real litellm Vertex tool-transform over that payload, then render **fresh** again.

```
tools whose FRESH render changed after ONE transform:
  ['presentation_install_local', 'plugin_management__install']

plugin_management__install.source.oneOf[*].kind
    {"const": "builtin"}  ->  {"const": "builtin", "type": "object"}
plugin_management__install.source.oneOf[*]
    lost  "additionalProperties": false
presentation_install_local.blueprint
    untyped  ->  {"type": "object"}
```

`"type": "object"` on a **string const discriminator** is not a harmless normalization: it is a wrong schema, and a subsequent Anthropic/OpenAI call is served that wrong schema. This is the Tool Contract lens failing on the process-history axis — the typed envelope the LLM is shown was mutable by an unrelated earlier turn.

## ★ There were **four** seams, not three — and how the first gate missed one

The first revision of this PR fixed three sites and gated them by enumerating the registry. Review caught a **fourth**, on the live LLM-payload path:

```
router_loop._operation_alias_metadata  ->  _build_hot_list_aliases
    ->  the OpenAI entry build_tools appends to tools= VERBATIM
```

Witnessed on this branch before the fix, for the very tool #3383 was filed against:

```
in KNOWN_STATIC: True
nested source is SAME OBJECT as canonical: True
canonical corrupted: True        # one _build_vertex_schema call rewrote the ToolDefinition
  oneOf[0].kind now: {'const': 'builtin', 'type': 'object'}
```

**The general lesson, recorded because it is the transferable part:** enumerating the registry proves coverage over **tools**, not over **seams**. The original arms were *total in the tool axis* (a future tool is covered the day it is registered) and *partial in the seam axis* — the hot-list alias path renders through none of them, so a live payload seam sat outside a gate that looked exhaustive.

### The four seams, and their verdicts

| seam | verdict |
|---|---|
| `types.py` `render_for_router` → router `tools=` | routed through the projection helper |
| `universal_catalog._describe_one` → `input_schema` | routed through the helper |
| `router_loop._operation_alias_metadata` → hot-list alias entry | routed through the helper (the fourth seam) |
| `router_tools.py:138` `ToolSpec.to_openai_dict` → `self.parameters` | **no change needed** — see below |

`ToolSpec` is exempt because **every** construction site in `build_tools` has the shape `ToolSpec(parameters=_X_rendered["function"]["parameters"], ...)`, so `ToolSpec.parameters` is always a `render_for_router()` product and therefore already a per-call deep copy. ★ That safety is **derived, not intrinsic**: if `render_for_router` is ever relaxed back toward a shallow copy, this exempt site silently becomes an ungated escape point. That contingency is written into the AST gate's docstring, where the next reader deciding whether the exemption still holds will actually see it.

`render_for_phase` was raised as a possible fifth site. **It does not exist in this tree** — `c662191d` (#3355, the vestigial-phase-surface retirement) deleted it along with `args_schema`. Verified against the remote, not a local tree: `git show origin/main:src/reyn/tools/types.py | grep -c 'render_for_phase\|args_schema'` → `0`, and a full-repo grep finds it only in dated design records. Nothing to route, nothing to exempt.

## Correction: `_describe_one` was on the **default cell's** primary path

The first revision justified this fix as "the `describe_action` tool result; same escape class". That understates it, and the PR body is the record of what was load-bearing, so: `universal_catalog.py:1129` reuses `one.get("input_schema")` as an entry's `parameters` inside `catalog_entries`, and `schemes/enumerate_all.py:81` does `flat_tools = list(ops.base_tools(...)) + catalog` → `llm_tools_payload` → `tools=`. `execution.py:83` makes `enumerate-all` the **default** scheme. So that seam was live on the primary path.

## The fix: one projection, not four patches

`reyn.tools.types.parameters_for_export` is now the **single** place a canonical schema is handed outside its `ToolDefinition`, and it owns the deep-copy obligation. All three real `dict(<x>.parameters)` sites call it. The responsibility sits on the projection rather than on each source, so seam five is correct by default — the same move that made #3379 correct.

Also fixes `hooks.py`'s #2898 isolation note, which asserted the now-false "`render_for_router` only shallow-copies `parameters`".

## The gate: three different claims, all kept

The seam axis is closed from both ends, and these are **not** interchangeable:

1. **Four per-seam behavioural arms** — *the escape points that exist route through the helper*. Each **constructs** the precondition (in-place mutation of the handed-out payload, as a provider transform does) instead of hoping the `-n auto` shuffle cooperates; arms 1–3 are registry-enumerated over the tool axis.
2. **AST gate** (`test_no_shallow_parameters_copy_outside_the_projection_helper`) — *a new escape point cannot avoid the helper*. Needed because the absence of an arm is **silent**: a shallow copy is asymptomatic until something mutates it, which is how #3383 survived from `a99bcf64` (2026-07-12) to today. Follows the existing `test_present_sink_ast_guard_2708.py` idiom, allow-listing by module+function span (never a line number), with a **positive companion** asserting the helper still deep-copies so a rename cannot leave the gate vacuously green.
3. **Helper-contract arm** — the projection shares no mutable substructure, independent of any caller.

Anti-vacuity throughout: each behavioural arm asserts the mutation actually changed the payload *and* actually reached nested sub-schemas before asserting the next render is unchanged.

The positive companion earned its keep during development: it went RED and exposed that my first allow-list matched a shape the helper does not contain (the helper takes a `Name`, not `<expr>.parameters`), so the gate would have been guarding a chokepoint it could not see. Rewritten to assert the real contract (`deepcopy` present in the helper's span).

### Strip-falsify — every site, `count == 1` anchor confirmed before each edit

| stripped to a shallow copy | arms that go RED |
|---|---|
| `render_for_router` | render_for_router, build_tools, describe_action, **AST gate** |
| `_operation_alias_metadata` | hot_list_alias, **AST gate** |
| `_describe_one` | describe_action, **AST gate** |
| `parameters_for_export` itself | render_for_router, build_tools, describe_action, helper-contract, positive-companion |

No strip left the suite green.

## Baseline fixture NOT regenerated

`tests/tools/_pre_migration_tool_schemas_baseline.json` is untouched. It was right and the product was wrong; a seventh regeneration would have recorded the defect as an intended schema change.

## Relation to #3374

With this work cherry-picked onto `925f87f7`, the deterministic 1402-test replay that reproduced the failure is green for `test_full_schema_contract_matches_baseline`. The only remaining reds there are #3374's own four `test_chat_router_i18n` fallback tests, already recorded as #3382.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict <the new test file>` — 7 inspected, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py` on all 4 changed src files — OK
- [x] Full `pytest -n auto` from the repo root — **9396 passed, 45 skipped, 0 failed**
- [x] Deterministic repro (the 2-test pair) RED before / GREEN after
- [x] Fourth-seam witness: `nested source is SAME OBJECT: True → False`, `canonical corrupted: True → False`
- [x] Registry-wide witness: `render_for_router` stable across a real litellm Vertex transform
- [x] Strip-falsify all four sites, anchors `count == 1` verified first (table above)
- [x] Baseline fixture untouched (`git diff` empty); witness/tripwire scratch files kept out of the commit (all live outside the repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
