### PR TITLE
docs(config): drop three dead safety.loop keys from reyn.local.yaml.example

### DIFF
--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -629,16 +629,6 @@
 #     # turn-scoped latch survives a later compaction evicting the tainted
 #     # entry); emits an untrusted_narrowing_engaged audit-event on engage.
 #     intra_turn_untrusted_narrowing: false
-#     # plan() tool call parse-error self-correction (B51 NF-W6-3). 0 = disable.
-#     plan_invalid_retries: 1
-#     # Per-(chain, skill) spawn / token caps (= CostLimitConfig shape):
-#     skill_calls_per_chain:
-#       hard_limit: null
-#       warn_ratio: 0.8
-#       # extension_calls > 0 → exceed follows safety.on_limit.mode (#1877)
-#       extension_calls: 0
-#     skill_tokens_per_chain:
-#       hard_limit: null
 #   timeout:
 #     llm_call_seconds: 60.0
 #     llm_max_retries: 3


### PR DESCRIPTION
**[per-PR-coder]** — closes #3356.

## What

`reyn.local.yaml.example`'s commented `safety.loop:` block advertised three
keys that are not fields of `LoopConfig` (`src/reyn/config/chat.py`):
`plan_invalid_retries`, `skill_calls_per_chain`, `skill_tokens_per_chain`.
An operator who uncommented them got a config that silently did nothing.

Per the issue's instruction, checked git history for each key before
deciding delete-vs-restore — the two verdicts are not symmetric, so each
key needed its own evidence, not a uniform "it's absent, so delete."

## Per-key verdict

**`plan_invalid_retries` — deleted deliberately.**
Introduced by `de362e29` ("plan_invalid self-correction loop", B51 NF-W6-3)
for the `plan()` router tool's parse-error retry. `plan()` itself and
`PlanConfig` were removed wholesale by **#2029**. The follow-up sweep
**#2042** ("docs(config): remove dead plan-mode config refs") explicitly
lists dropping the `safety.loop.plan_invalid_retries` row from
`reyn-yaml.md` / `.ja.md` and from `safety.md`'s yaml example — but that
sweep did not touch `reyn.local.yaml.example`, so the line survived only
in this one file as a miss, not a decision to keep it.

**`skill_calls_per_chain` / `skill_tokens_per_chain` — deleted deliberately.**
This is the pair the issue asked to look at hardest, because
`docs/deep-dives/proposals/0005-safety-as-checkpoint.md` describes a live
`per_chain_skill_calls` limit (site D) wired through `handle_limit_exceeded`
— so I checked for a live enforcement path under a different name before
concluding anything. **#2448** ("refactor(#2439): remove dead budget
per-chain skill-spawn cap subsystem") removed `LoopConfig.skill_calls_per_chain`
/ `skill_tokens_per_chain` by name, with the commit body stating the
rationale explicitly: "the per-chain skill-spawn cap (#1911) ... [had] zero
live callers" once the skill machinery it depended on was deleted (#2434/#2439
skill-engine bulk-delete). The same commit's body confirms `reyn-yaml.md` +
the budget reference docs (EN+JA) were updated in that PR. `handle_limit_exceeded`
(`src/reyn/runtime/limits/limit_handler.py`) is still live — but grepping the
current tree for `per_chain_skill_calls` / `skill_calls_per_chain` /
`skill_tokens_per_chain` finds zero hits outside historical `docs/deep-dives/proposals/`
narrative — no enforcement call site references either name anywhere. The
0005 proposal doc is a dated historical implementation record ("Phase 2
implemented — 2026-05-10"), not a current-mechanism reference doc, so it is
out of scope for a same-PR fix under the doc-staleness rule (which targets
`reyn-yaml.md` / `safety.md` — the current schema references).

**Net: all three are "forgotten to sweep the example file," not "the knob
should exist."** Deleted the ten lines; no restoration needed.

## Doc-drift check (same-PR obligation)

Confirmed `docs/reference/config/reyn-yaml.md`, `docs/concepts/runtime/safety.md`,
and their `.ja.md` counterparts have **no matching rows for any of the three
keys** — #2042 and #2448 already fixed those docs when they made the
removals. No doc changes needed in this PR.

## Test plan

- [x] `grep` for all three key names across `reyn.local.yaml.example` +
      `reyn-yaml.md`/`.ja.md` + `safety.md`/`.ja.md` — zero hits post-change
- [x] `python -m pytest tests/test_reyn_local_example_benchmark_permissions.py tests/test_config_mirror_coverage_1056.py -q` — 7 passed (both exercise `reyn.local.yaml.example`)
- [x] `ruff check src tests` — clean (no Python files changed in this PR)
- [x] No `src/` or test files changed — tier-audit / module-docstring gates N/A
- [x] Full `pytest -q -n auto --timeout=120` from repo root — 9290 passed, 170 failed (pre-existing, unrelated TUI/textual test failures — same set present on `main` with this diff stashed, verified with a sample file)
