### PR TITLE
fix(a2a,mcp): re-source progress fan-outs from live audit-events — #3357

### DIFF
--- a/docs/concepts/multi-agent/a2a.md
+++ b/docs/concepts/multi-agent/a2a.md
@@ -157,15 +157,38 @@ the next `input-required`, until terminal.
 ### SSE streaming
 
 `GET /a2a/tasks/{run_id}/events` returns a `text/event-stream` of the
-task's emitted events. Closes when the task reaches a terminal status.
+task's emitted payloads. Closes when the task reaches a terminal status.
+
+### Progress payloads
+
+While the task runs, both the SSE stream and the webhook (below) carry an
+`status: "in-progress"` payload for each of these audit-events:
+
+| Audit-event | `message` |
+|-------------|-----------|
+| `turn_started` | `turn: <inbox trigger kind>` — e.g. `turn: user` |
+| `llm_called` | `llm: <model>` |
+| `tool_returned` | `tool: <name>` |
+| `tool_failed` | `tool: <name> (failed)` |
+
+```json
+{"run_id": "...", "status": "in-progress", "progress": 3,
+ "event": "tool_returned", "message": "tool: grep", "agent_name": "..."}
+```
+
+`progress` is a monotonic ordinal, not a fraction — the turn's length is not
+known in advance. Only the audit-event kind and the line above are sent; a
+tool's arguments and its result body never leave the process on this channel.
+The same selection and wording reach an MCP client's `notifications/progress`,
+so one parser serves both transports.
 
 ### Push notifications
 
 If `params.webhook_url` is set on the initial `message/send`, Reyn POSTs
 JSON payloads to the URL on each status transition (`running` →
-`input-required` → `running` → `completed`/`failed`/`cancelled`).
-Errors talking to the webhook are logged, not raised — the task
-progresses regardless.
+`input-required` → `running` → `completed`/`failed`/`cancelled`) and on each
+progress payload above. Errors talking to the webhook are logged, not raised —
+the task progresses regardless.
 
 ### Cancellation
 

--- a/docs/concepts/tools-integrations/mcp.md
+++ b/docs/concepts/tools-integrations/mcp.md
@@ -339,6 +339,21 @@ Two tools are registered:
 
 Multi-turn continuity is preserved: each agent's `Session` keeps its `history.jsonl` between calls, so a conversation that starts in Claude Code can be resumed from `reyn chat` — or vice versa.
 
+### Progress notifications
+
+`send_to_agent` blocks for the whole turn, which can be a long time. A client that sets `_meta.progressToken` on the call receives a `notifications/progress` for each of these audit-events as the turn runs:
+
+| Audit-event | Progress message |
+|-------------|------------------|
+| `turn_started` | `turn: <inbox trigger kind>` — e.g. `turn: user` |
+| `llm_called` | `llm: <model>` |
+| `tool_returned` | `tool: <name>` |
+| `tool_failed` | `tool: <name> (failed)` |
+
+`progress` is a monotonic ordinal (1, 2, 3, …) and `total` is always absent — the turn's length is not known in advance, so clients should render a counter or a spinner rather than a percentage. Only the audit-event kind and the line above are sent; a tool's arguments and its result body never leave the process on this channel.
+
+Delivery is best-effort: if the notification cannot be pushed, the turn continues and the final `send_to_agent` reply is unaffected. The server advertises this surface as the experimental `reyn.progress.skill_lifecycle` capability in its `initialize` response, whose `events` field lists exactly the kinds above.
+
 ### What "via MCP" means for your workflows
 
 External clients see agents, not the workflow graph. From the outside, there are only two operations: list agents and send a message. The OS contract still applies on Reyn's side: permissions are checked, events are emitted, and all the normal validation runs. Workflows can be approved non-interactively if `permissions: allow` is set in `reyn.yaml` (the MCP server runs without a human at stdin, so interactive prompts would block indefinitely).

--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -117,6 +117,43 @@ See also: [Concepts: secret handling](../../concepts/runtime/secret-handling.md)
 | `chat_started`, `chat_stopped` | Chat session lifecycle |
 | `turn_cancelled` | A user turn was cancelled mid-router-loop (e.g. `/cancel` or a new submission supersedes the running turn). Payload: `chain_id`. |
 
+## Session and turn lifecycle
+
+The boundary events every trigger passes through, whatever surface submitted it.
+Required fields are declared in `src/reyn/core/events/event_schema.py`.
+
+| Kind | When | Key payload |
+|------|------|-------------|
+| `session_started`, `session_completed` | The session's resource scope opens / closes (alongside `chat_started` / `chat_stopped`). | `agent_name` |
+| `turn_started` | A trigger has been consumed from the inbox and is about to be dispatched. | `kind` — the inbox message kind that triggered this turn (`"user"`, `"agent_response"`, `"task_ready"`, `"hook"`, …), so a subscriber can tell human triggers from automated ones without parsing the payload; `chain_id`; `seq` |
+| `turn_completed` | The router loop reached a terminal condition — router path only. | `chain_id` |
+| `turn_settled` | The turn is done, for EVERY turn kind including slash / intervention short-circuits that return before the router. The reliable clear signal for a working indicator started on `turn_started`. | `kind`; `chain_id` (may be absent for non-user triggers) |
+
+## Tool dispatch
+
+Emitted by `dispatch_tool` (`src/reyn/core/dispatch/dispatcher.py`) around every
+router-dispatched tool call. `tool_returned` and `tool_failed` are mutually
+exclusive per call.
+
+| Kind | When | Key payload |
+|------|------|-------------|
+| `tool_called` | Before invocation, after argument validation. | `caller_kind`, `caller_id`, `tool`, `chain_id`, `args`, `args_hash` |
+| `tool_returned` | The invocation returned. | `caller_kind`, `caller_id`, `tool`, `chain_id`, `args_hash`, `result` |
+| `tool_failed` | The invocation was refused or raised. | same, plus `error_kind` (`permission_denied` \| `exception` \| a validation reason) and `message` |
+
+`args_hash` is a stable SHA-256 prefix over the canonical-JSON arguments — the
+correlation id that pairs a `tool_called` with its outcome across the log.
+
+**Remote fan-out.** `turn_started` / `llm_called` / `tool_returned` / `tool_failed`
+are the kinds the A2A and MCP progress surfaces forward to a remote peer
+(`src/reyn/core/events/progress_lifecycle.py`); see
+[Concepts: A2A § Progress payloads](../../concepts/multi-agent/a2a.md#progress-payloads)
+and [Concepts: MCP § Progress notifications](../../concepts/tools-integrations/mcp.md#progress-notifications).
+Three of the four (`turn_started`, `tool_returned`, `tool_failed`) are also what
+the AG-UI transport maps to `RUN_STARTED` / `TOOL_CALL_END` — see
+[agui-transport.md](agui-transport.md) § "Working-indicator path". Cost events
+(`llm_called`) ride the progress fan-out but not the AG-UI working-indicator set.
+
 ## Task management
 
 Events emitted by the task Control IR ops (`task.py`).

--- a/src/reyn/core/events/progress_lifecycle.py
+++ b/src/reyn/core/events/progress_lifecycle.py
@@ -1,0 +1,71 @@
+"""Which audit-events the A2A + MCP progress fan-outs forward, and how they read.
+
+Two remote protocols expose a best-effort progress stream over a live agent
+turn — A2A (``_A2AProgressBridge``: SSE buffer + webhook POST) and MCP
+(``_MCPProgressBridge``: ``notifications/progress``). Both subscribe to the
+SAME source, the session's chat audit-event log (``Session._chat_events``), and
+both must forward the same selection under the same wording so a peer can apply
+one parser to either transport. This module is that single declaration; the two
+bridges hold no vocabulary of their own.
+
+The selection is a **turn-shaped skeleton**, one line per thing a remote peer
+can act on:
+
+  - ``turn_started``  — a turn boundary on this session (``kind`` names the
+    inbox trigger: ``"user"`` / ``"agent_response"`` / ``"hook"`` / …).
+    Emitted by ``Session.run_one_iteration``.
+  - ``llm_called``    — a provider call went out (``model``). Emitted by
+    ``reyn.llm.llm``'s cost-event pair against the ambient audit-event log.
+  - ``tool_returned`` — a dispatched tool completed (``tool``). Emitted by
+    ``reyn.core.dispatch.dispatcher.dispatch_tool``.
+  - ``tool_failed``   — a dispatched tool completed by failing (``tool``).
+    Same emitter; the two are mutually exclusive per call.
+
+``turn_started`` / ``tool_returned`` / ``tool_failed`` are the same audit-event
+kinds the AG-UI transport maps to ``RUN_STARTED`` / ``TOOL_CALL_END`` (see
+``docs/reference/runtime/agui-transport.md``) — the remote-client-facing
+lifecycle skeleton is deliberately one vocabulary across all three surfaces.
+
+★ Every member MUST have a live emit call-site in ``src/reyn``. The audit-event
+``type`` namespace is open (there is no closed vocabulary and no emit-time
+schema check — ``event_schema.EVENT_AUDIT_REQUIREMENTS`` declares required
+FIELDS for the kinds it covers, not which kinds exist), so a member that no
+producer emits degrades the stream silently: the ordinal counter still
+increments, and a subscribing peer cannot distinguish a degraded stream from a
+quiet run. ``tests/test_progress_lifecycle_fanout_3357.py`` is the liveness
+gate that keeps that from happening again (#3357).
+
+The payload of the forwarded notification carries the event kind plus the
+one-line message built here — never a tool's arguments or result body.
+"""
+from __future__ import annotations
+
+# The audit-event kinds both remote progress fan-outs forward. Read the module
+# docstring before adding a member: it needs a live emitter AND a message arm.
+PROGRESS_LIFECYCLE_EVENTS: "frozenset[str]" = frozenset({
+    "turn_started",
+    "llm_called",
+    "tool_returned",
+    "tool_failed",
+})
+
+
+def format_progress_message(event_type: str, data: dict) -> str:
+    """Render one forwarded audit-event as a peer-readable progress line.
+
+    ``data`` is the audit-event payload. Every arm reads a single identifying
+    field and degrades to ``"?"`` when it is absent, so a payload-shape drift
+    costs a legible label rather than the notification. An unrecognised kind
+    falls through to its own name (the bridges filter to
+    :data:`PROGRESS_LIFECYCLE_EVENTS` before calling, so this is defence in
+    depth, not a routing path).
+    """
+    if event_type == "turn_started":
+        return f"turn: {data.get('kind') or '?'}"
+    if event_type == "llm_called":
+        return f"llm: {data.get('model') or '?'}"
+    if event_type == "tool_returned":
+        return f"tool: {data.get('tool') or '?'}"
+    if event_type == "tool_failed":
+        return f"tool: {data.get('tool') or '?'} (failed)"
+    return event_type

--- a/src/reyn/interfaces/web/routers/a2a.py
+++ b/src/reyn/interfaces/web/routers/a2a.py
@@ -44,6 +44,10 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
+from reyn.core.events.progress_lifecycle import (
+    PROGRESS_LIFECYCLE_EVENTS,
+    format_progress_message,
+)
 from reyn.interfaces.web.a2a_task_view import to_a2a_task
 from reyn.interfaces.web.deps import (
     get_a2a_webhook_registry,
@@ -124,10 +128,10 @@ def _build_agent_card(agent_name: str, role: str, base_url: str) -> dict:
             backed by ``_A2AProgressBridge`` fan-out into
             ``RunEntry.history_events`` (PR #288) +
             ``A2AInterventionBus.deliver`` appending input-required
-            events (= peers see lifecycle + ask_user inline).
-          - ``pushNotifications``: webhook fires on lifecycle events
-            (= phase_started / llm_called / act_executed via PR #286)
-            plus the original ``completed`` / ``failed`` /
+            audit-events (= peers see lifecycle + ask_user inline).
+          - ``pushNotifications``: webhook fires on each forwarded
+            lifecycle audit-event (= ``PROGRESS_LIFECYCLE_EVENTS``, via
+            PR #286) plus the original ``completed`` / ``failed`` /
             ``input-required`` triggers. The two-sink bridge means
             webhook and SSE consumers see identical payloads.
 
@@ -565,7 +569,7 @@ async def _handle_answer_injection(
 
 
 class _A2AProgressBridge:
-    """Forwards selected agent chat-events to A2A peer surfaces.
+    """Forwards selected chat audit-events of one agent to A2A peer surfaces.
 
     Two sinks, one subscriber:
 
@@ -578,13 +582,13 @@ class _A2AProgressBridge:
         #286 with webhook-only bridge; this revision adds the SSE
         sink alongside).
 
-    Mirrors ``mcp_server._MCPProgressBridge`` for the event-scope side:
-    same lifecycle kinds (``phase_started`` / ``llm_called`` /
-    ``act_executed``), same ordinal counter, same message formatting.
-    Different transports. Two instances (= MCP + A2A) is below the
-    rule-of-three threshold so the bridge logic stays per-protocol;
-    a future third instance is the trigger to lift the common
-    ``subscribe / filter / format / dispatch`` shape into a shared base.
+    Mirrors ``mcp.server._MCPProgressBridge`` for the audit-event-scope
+    side: both hold :data:`PROGRESS_LIFECYCLE_EVENTS` and both render with
+    :func:`format_progress_message`, so a peer applies one parser to either
+    transport. Ordinal counter and dispatch shape are per-protocol; two
+    instances (= MCP + A2A) is below the rule-of-three threshold, so a future
+    third instance is the trigger to lift the common ``subscribe / filter /
+    format / dispatch`` shape into a shared base.
 
     Lifecycle: subscribe via ``attach()`` once, ``detach()`` in a
     try/finally so the subscriber doesn't outlive the call. Any sink
@@ -594,11 +598,9 @@ class _A2AProgressBridge:
     ``_handle_async_mode._run``) is the authoritative outcome.
     """
 
-    TRACKED_EVENTS = frozenset({
-        "phase_started",
-        "llm_called",
-        "act_executed",
-    })
+    # The single declaration lives in reyn.core.events.progress_lifecycle so
+    # this bridge and the MCP one cannot drift apart (#3357).
+    TRACKED_EVENTS = PROGRESS_LIFECYCLE_EVENTS
 
     def __init__(
         self,
@@ -658,7 +660,7 @@ class _A2AProgressBridge:
         if event_type not in self.TRACKED_EVENTS:
             return
         data = getattr(event, "data", {}) or {}
-        message = self.format_message(event_type, data)
+        message = format_progress_message(event_type, data)
         self._ordinal += 1
         ordinal = self._ordinal
         try:
@@ -669,20 +671,6 @@ class _A2AProgressBridge:
             # No running loop (= EventLog dispatched outside async context).
             return
         self._tasks.append(task)
-
-    @staticmethod
-    def format_message(event_type: str, data: dict) -> str:
-        if event_type == "phase_started":
-            phase = data.get("phase") or "?"
-            return f"phase: {phase}"
-        if event_type == "llm_called":
-            model = data.get("model") or "?"
-            return f"llm: {model}"
-        if event_type == "act_executed":
-            op_count = data.get("op_count") or 0
-            suffix = "" if op_count == 1 else "s"
-            return f"act: {op_count} op{suffix}"
-        return event_type
 
     async def _send(
         self, ordinal: int, event_type: str, message: str,
@@ -775,9 +763,9 @@ async def _handle_async_mode(
 
     async def _run() -> None:
         # issue #267 Gap 1 + Gap 2: subscribe a progress bridge to the
-        # agent's chat_events for the lifetime of this call. The bridge
-        # fans out run lifecycle events (phase_started / llm_called /
-        # act_executed) to two sinks:
+        # agent's chat audit-event log for the lifetime of this call. The
+        # bridge fans out the lifecycle audit-events named by
+        # PROGRESS_LIFECYCLE_EVENTS to two sinks:
         #   - SSE buffer (always): append to RunEntry.history_events so
         #     GET /a2a/tasks/{run_id}/events replays progression.
         #   - Webhook POST (opt-in): when webhook_url is registered,

--- a/src/reyn/mcp/server.py
+++ b/src/reyn/mcp/server.py
@@ -28,8 +28,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from reyn.core.events.progress_lifecycle import (
+    PROGRESS_LIFECYCLE_EVENTS,
+    format_progress_message,
+)
 from reyn.runtime.agent_locks import get_agent_lock as _get_agent_lock
 
 logger = logging.getLogger(__name__)
@@ -803,8 +807,8 @@ async def _make_mcp_progress_bridge(
       - the request context is unavailable for any reason (= defensive)
 
     The returned bridge has subscribed itself to the agent's chat
-    events; callers MUST call ``bridge.detach()`` in a ``finally`` to
-    avoid the subscriber leaking across calls.
+    audit-event log; callers MUST call ``bridge.detach()`` in a ``finally``
+    to avoid the subscriber leaking across calls.
     """
     try:
         ctx = server.request_context  # type: ignore[attr-defined]
@@ -829,31 +833,26 @@ async def _make_mcp_progress_bridge(
 
 
 class _MCPProgressBridge:
-    """Forwards selected agent chat-events to MCP progress notifications.
+    """Forwards selected chat audit-events of one agent to MCP progress notifications.
 
-    issue #271 M1 (= M1-b lifecycle event scope per owner decision):
-
-      - ``phase_started`` → progress = next ordinal, message = "phase: <name>"
-      - ``llm_called`` → progress = ordinal, message = "llm: <model>"
-      - ``act_executed`` → progress = ordinal, message = "act: <N> op(s)"
+    issue #271 M1 (= M1-b lifecycle scope per owner decision); the forwarded
+    selection and its wording are declared once in
+    :data:`PROGRESS_LIFECYCLE_EVENTS` / :func:`format_progress_message`, shared
+    verbatim with the A2A bridge (#3357).
 
     ``progress`` is monotonic (= ordinal counter) since we don't have a
     meaningful total. The MCP spec accepts ``total=None`` for
     indeterminate progress; clients render as raw value or spinner.
 
-    The subscriber runs synchronously in the EventLog dispatcher; it
+    The subscriber runs synchronously in the audit-event log's dispatcher; it
     schedules the actual ``send_progress_notification`` as an asyncio
-    task so we don't block the event emitter on the MCP transport. Any
+    task so we don't block the emitter on the MCP transport. Any
     transport / cancellation error in the background task is swallowed
     (= progress is best-effort; the main call must never fail because
     notification delivery failed).
     """
 
-    TRACKED_EVENTS = frozenset({
-        "phase_started",
-        "llm_called",
-        "act_executed",
-    })
+    TRACKED_EVENTS = PROGRESS_LIFECYCLE_EVENTS
 
     def __init__(
         self,
@@ -907,7 +906,7 @@ class _MCPProgressBridge:
         if event_type not in self.TRACKED_EVENTS:
             return
         data = getattr(event, "data", {}) or {}
-        message = self._format_message(event_type, data)
+        message = format_progress_message(event_type, data)
         self._ordinal += 1
         ordinal = float(self._ordinal)
         try:
@@ -918,20 +917,6 @@ class _MCPProgressBridge:
             # context picks up the next event.
             return
         self._tasks.append(task)
-
-    @staticmethod
-    def _format_message(event_type: str, data: dict) -> str:
-        if event_type == "phase_started":
-            phase = data.get("phase") or "?"
-            return f"phase: {phase}"
-        if event_type == "llm_called":
-            model = data.get("model") or "?"
-            return f"llm: {model}"
-        if event_type == "act_executed":
-            op_count = data.get("op_count") or 0
-            suffix = "" if op_count == 1 else "s"
-            return f"act: {op_count} op{suffix}"
-        return event_type
 
     async def _send(self, ordinal: float, message: str) -> None:
         send_fn = getattr(self._mcp_session, "send_progress_notification", None)
@@ -952,45 +937,37 @@ class _MCPProgressBridge:
             return
 
 
-async def serve_stdio(
-    registry: "AgentRegistry",
-    *,
-    timeout: float = DEFAULT_SEND_TIMEOUT_SECONDS,
-) -> None:
-    """Run the MCP server speaking JSON-RPC over stdio until EOF / SIGINT.
+def build_init_options(server: Any) -> Any:
+    """Build the MCP ``initialize`` response options this server advertises.
 
-    On exit, the registry is shut down so any in-flight chat sessions
-    drain cleanly (mirrors what ``reyn chat`` does on quit).
+    issue #271 M3: capability advertising. Declares what this server actually
+    emits + handles so MCP clients can negotiate features before issuing
+    ``send_to_agent`` calls. Reality must match the claim (= avoid the #267 Z-b
+    "capability claim vs reality" mismatch pattern by deriving each entry from a
+    concrete production wire):
+
+      - ``NotificationOptions``: tools/prompts/resources lists are STATIC
+        (= ``_list_tools`` returns the same tools every call, no
+        ``notify_*_changed`` call sites in this module).
+      - experimental ``reyn.progress.skill_lifecycle``: ``_MCPProgressBridge``
+        subscribes the agent's chat audit-event log and emits
+        ``notifications/progress`` for each kind in
+        :data:`PROGRESS_LIFECYCLE_EVENTS` during ``send_to_agent``. The
+        advertised ``events`` list is DERIVED from that constant rather than
+        restated, so the declaration cannot drift from the filter (#3357 — it
+        previously named two kinds no producer emitted). The capability KEY is
+        a legacy artifact from the skill-based era, kept as-is because it is a
+        published wire-protocol string clients match on.
+      - experimental ``reyn.cancellation.cooperative``: ``notifications/cancelled``
+        propagation through ``asyncio.CancelledError`` → in-flight agent turn
+        interruption.
+
+    Separated from :func:`serve_stdio` so the advertisement is assertable
+    without standing up a stdio transport.
     """
-    from mcp.server.stdio import stdio_server
-
-    # No extra_tools here: the stdio MCP server hosts no gateway outbound tools
-    # (#1805) — those are reyn-web-scoped (webhook plugins mount in the FastAPI
-    # app + register_tools is collected onto app.state). A stdio CLI has no app,
-    # so there is nothing to host. The SSE path (web/routers/mcp.py) passes
-    # extra_tools; this asymmetry is by design, not an oversight.
-    server = build_server(registry, timeout=timeout)
-    # issue #271 M3: capability advertising. Declare what this server
-    # actually emits + handles so MCP clients can negotiate features
-    # before issuing send_to_agent calls. Reality must match the claim
-    # (= avoid the #267 Z-b "capability claim vs reality" mismatch
-    # pattern by deriving each entry from a concrete production wire):
-    #
-    #   - NotificationOptions: tools/prompts/resources lists are STATIC
-    #     (= ``_list_tools`` returns the same 2 tools every call, no
-    #     notify_list_changed call sites in src/reyn/mcp_server.py).
-    #   - experimental ``reyn.progress.skill_lifecycle``: PR #279 wired
-    #     ``_MCPProgressBridge`` to subscribe chat_events + emit
-    #     ``notifications/progress`` for phase_started / llm_called /
-    #     act_executed during send_to_agent. Name is a legacy artifact
-    #     from the skill-based era; the key is a published wire-protocol
-    #     string so it is kept as-is for client compatibility.
-    #   - experimental ``reyn.cancellation.cooperative``: PR #279 wired
-    #     ``notifications/cancelled`` propagation through
-    #     asyncio.CancelledError → in-flight agent turn interruption.
     from mcp.server import NotificationOptions
 
-    init_options = server.create_initialization_options(
+    return server.create_initialization_options(
         notification_options=NotificationOptions(
             prompts_changed=False,
             resources_changed=False,
@@ -999,11 +976,7 @@ async def serve_stdio(
         experimental_capabilities={
             "reyn.progress.skill_lifecycle": {
                 "version": 1,
-                "events": [
-                    "phase_started",
-                    "llm_called",
-                    "act_executed",
-                ],
+                "events": sorted(PROGRESS_LIFECYCLE_EVENTS),
             },
             "reyn.cancellation.cooperative": {
                 "version": 1,
@@ -1025,6 +998,27 @@ async def serve_stdio(
             },
         },
     )
+
+
+async def serve_stdio(
+    registry: "AgentRegistry",
+    *,
+    timeout: float = DEFAULT_SEND_TIMEOUT_SECONDS,
+) -> None:
+    """Run the MCP server speaking JSON-RPC over stdio until EOF / SIGINT.
+
+    On exit, the registry is shut down so any in-flight chat sessions
+    drain cleanly (mirrors what ``reyn chat`` does on quit).
+    """
+    from mcp.server.stdio import stdio_server
+
+    # No extra_tools here: the stdio MCP server hosts no gateway outbound tools
+    # (#1805) — those are reyn-web-scoped (webhook plugins mount in the FastAPI
+    # app + register_tools is collected onto app.state). A stdio CLI has no app,
+    # so there is nothing to host. The SSE path (web/routers/mcp.py) passes
+    # extra_tools; this asymmetry is by design, not an oversight.
+    server = build_server(registry, timeout=timeout)
+    init_options = build_init_options(server)
     try:
         async with stdio_server() as (read_stream, write_stream):
             await server.run(read_stream, write_stream, init_options)
@@ -1036,6 +1030,7 @@ async def serve_stdio(
 
 
 __all__ = [
+    "build_init_options",
     "build_server",
     "list_agents_impl",
     "send_to_agent_impl",

--- a/tests/test_a2a_sse_producer_267_gap1.py
+++ b/tests/test_a2a_sse_producer_267_gap1.py
@@ -8,8 +8,8 @@ infrastructure.
 
 This PR makes two callers feed ``history_events``:
 
-  1. ``_A2AProgressBridge._send`` — phase_started / llm_called /
-     act_executed events fan out to BOTH the SSE buffer + (optionally)
+  1. ``_A2AProgressBridge._send`` — the ``PROGRESS_LIFECYCLE_EVENTS``
+     audit-event kinds fan out to BOTH the SSE buffer + (optionally)
      the webhook POST. Bridge is now constructed unconditionally in
      ``_handle_async_mode._run`` (= the webhook_url gate moved INTO
      the bridge's per-sink dispatch).
@@ -95,7 +95,7 @@ def test_send_appends_payload_to_history_events() -> None:
         run_registry=registry,
     )
 
-    asyncio.run(bridge._send(3, "phase_started", "phase: planning"))
+    asyncio.run(bridge._send(3, "turn_started", "turn: user"))
 
     refreshed = registry.get(entry.run_id)
     (appended,) = refreshed.history_events
@@ -103,8 +103,8 @@ def test_send_appends_payload_to_history_events() -> None:
         "run_id": entry.run_id,
         "status": "in-progress",
         "progress": 3,
-        "event": "phase_started",
-        "message": "phase: planning",
+        "event": "turn_started",
+        "message": "turn: user",
         "agent_name": "demo",
     }
 
@@ -137,7 +137,7 @@ def test_send_skips_webhook_when_webhook_url_is_none(monkeypatch) -> None:
         run_registry=RunRegistry(),
     )
 
-    asyncio.run(bridge._send(1, "phase_started", "phase: planning"))
+    asyncio.run(bridge._send(1, "turn_started", "turn: user"))
     assert posted == []
 
 
@@ -216,7 +216,7 @@ def test_sse_sink_failure_does_not_block_webhook(monkeypatch) -> None:
         run_registry=_RaisingRegistry(),
     )
 
-    asyncio.run(bridge._send(1, "phase_started", "phase: planning"))
+    asyncio.run(bridge._send(1, "turn_started", "turn: user"))
     # webhook still ran despite SSE failure
     (only,) = posted
 
@@ -248,7 +248,7 @@ def test_webhook_sink_failure_does_not_block_sse(monkeypatch) -> None:
         run_registry=registry,
     )
 
-    asyncio.run(bridge._send(1, "act_executed", "act: 2 ops"))
+    asyncio.run(bridge._send(1, "tool_returned", "tool: grep"))
 
     # SSE append succeeded despite webhook failure
     assert len(registry.get(entry.run_id).history_events) == 1
@@ -338,9 +338,9 @@ def test_sse_endpoint_replays_appended_events_via_history() -> None:
     )
 
     async def _drive() -> None:
-        await bridge._send(1, "phase_started", "phase: planning")
+        await bridge._send(1, "turn_started", "turn: user")
         await bridge._send(2, "llm_called", "llm: m")
-        await bridge._send(3, "act_executed", "act: 2 ops")
+        await bridge._send(3, "tool_returned", "tool: grep")
 
     asyncio.run(_drive())
 
@@ -348,6 +348,6 @@ def test_sse_endpoint_replays_appended_events_via_history() -> None:
     # The endpoint code at line 921 reads `entry.history_events[seen:]`
     # — confirm the slice the endpoint will replay has 3 ordered events.
     assert [e["event"] for e in refreshed.history_events] == [
-        "phase_started", "llm_called", "act_executed",
+        "turn_started", "llm_called", "tool_returned",
     ]
     assert [e["progress"] for e in refreshed.history_events] == [1, 2, 3]

--- a/tests/test_a2a_webhook_progress_267_gap2.py
+++ b/tests/test_a2a_webhook_progress_267_gap2.py
@@ -1,29 +1,31 @@
 """Tier 2: A2A webhook progress trigger expansion (issue #267 Gap 2).
 
-Before this PR, the A2A webhook surface fired only on 3 events:
-``input-required`` (A2AInterventionBus.deliver), ``completed`` /
-``failed`` (_handle_async_mode._run). Mid-call lifecycle (= phase
-transition / LLM call / op batch) was invisible to the peer — peers
-received the initial Task envelope, then silence until terminal.
+Before issue #267 Gap 2, the A2A webhook surface fired only on three
+transitions: ``input-required`` (A2AInterventionBus.deliver),
+``completed`` / ``failed`` (_handle_async_mode._run). Mid-call lifecycle
+was invisible to the peer — peers received the initial Task envelope,
+then silence until terminal.
 
-This PR adds ``_A2AProgressBridge`` (= mirrors ``_MCPProgressBridge``
-shape from PR #279) that subscribes to the agent's ``chat_events``
-for the lifetime of one ``_handle_async_mode`` call and fires
-``status="in-progress"`` webhooks for ``phase_started`` /
-``llm_called`` / ``act_executed``. Two instances (MCP + A2A) is below
-the rule-of-three threshold so the bridge logic is per-protocol; a
-future third instance is the trigger to lift to a shared base.
+``_A2AProgressBridge`` (= mirrors ``_MCPProgressBridge`` shape from PR
+#279) subscribes to the agent's chat audit-event log for the lifetime of
+one ``_handle_async_mode`` call and fires ``status="in-progress"``
+webhooks for the kinds in ``PROGRESS_LIFECYCLE_EVENTS``. Two instances
+(MCP + A2A) is below the rule-of-three threshold so the dispatch logic is
+per-protocol; a future third instance is the trigger to lift to a shared
+base.
 
 Pins:
 
-  1. ``_A2AProgressBridge`` exists with ``TRACKED_EVENTS`` = the 3
-     declared kinds, matching ``_MCPProgressBridge``'s scope (= the
-     contract two bridges share).
+  1. ``_A2AProgressBridge.TRACKED_EVENTS`` IS the shared declaration and
+     matches ``_MCPProgressBridge``'s scope (= the contract two bridges
+     share). The liveness of those kinds is gated separately, in
+     ``tests/test_progress_lifecycle_fanout_3357.py`` — pinning a literal
+     set here is what let two producer-less kinds survive (#3357).
   2. ``attach()`` subscribes to ``session._chat_events``;
      ``detach()`` unsubscribes + cancels in-flight tasks; idempotent.
-  3. Untracked event types are ignored (= ``intervention_routed`` /
-     ``phase_completed`` / etc. don't fire the bridge).
-  4. ``format_message`` produces the expected text for each kind.
+  3. Untracked audit-event kinds are ignored (= ``tool_called`` /
+     ``turn_settled`` / etc. don't fire the bridge).
+  4. The shared formatter produces the expected text for each kind.
   5. ``_send`` POSTs the canonical progress payload to the configured
      webhook_url.
   6. ``ordinal`` is monotonic across multiple events on one bridge.
@@ -92,19 +94,23 @@ def _make_bridge(*, captured_posts: list[tuple[str, dict]], events: EventLog | N
 # ── 1. Tracked event scope matches MCP bridge ─────────────────────────
 
 
-def test_a2a_progress_bridge_tracks_three_lifecycle_events() -> None:
-    """Tier 2: ``_A2AProgressBridge.TRACKED_EVENTS`` matches the MCP
-    bridge's scope exactly (= same 3 lifecycle event kinds). This
-    keeps the per-protocol bridges aligned so a future third-instance
-    abstraction has a stable contract to lift.
+def test_a2a_progress_bridge_shares_the_mcp_bridge_declaration() -> None:
+    """Tier 2: ``_A2AProgressBridge.TRACKED_EVENTS`` matches the MCP bridge's
+    scope exactly, because both ARE the one shared declaration. This keeps the
+    per-protocol bridges aligned so a future third-instance abstraction has a
+    stable contract to lift.
+
+    Deliberately NOT a literal set: pinning the member names here made the two
+    bridges agree with each other while agreeing with no producer, and made the
+    correct removal of a dead kind turn this test RED (#3357). Membership is
+    gated on liveness instead, in ``test_progress_lifecycle_fanout_3357.py``.
     """
+    from reyn.core.events.progress_lifecycle import PROGRESS_LIFECYCLE_EVENTS
     from reyn.interfaces.web.routers.a2a import _A2AProgressBridge
     from reyn.mcp.server import _MCPProgressBridge
 
-    assert _A2AProgressBridge.TRACKED_EVENTS == _MCPProgressBridge.TRACKED_EVENTS
-    assert _A2AProgressBridge.TRACKED_EVENTS == frozenset({
-        "phase_started", "llm_called", "act_executed",
-    })
+    assert _A2AProgressBridge.TRACKED_EVENTS is _MCPProgressBridge.TRACKED_EVENTS
+    assert _A2AProgressBridge.TRACKED_EVENTS is PROGRESS_LIFECYCLE_EVENTS
 
 
 # ── 2. attach / detach lifecycle ──────────────────────────────────────
@@ -152,18 +158,18 @@ def test_detach_is_idempotent() -> None:
 
 
 def test_untracked_event_kinds_are_ignored() -> None:
-    """Tier 2: events outside ``TRACKED_EVENTS`` (= e.g.
-    ``intervention_routed`` / ``phase_completed`` / ``agent_response``)
-    do NOT fire a webhook.
+    """Tier 2: audit-event kinds outside ``TRACKED_EVENTS`` (= e.g. the
+    ``tool_called`` half of the dispatch pair, ``turn_settled``,
+    ``intervention_routed``) do NOT fire a webhook.
     """
     captured: list = []
     bridge, events = _make_bridge(captured_posts=captured)
     bridge.attach()
 
     async def _drive() -> None:
-        events.emit("phase_completed", phase="planning")
+        events.emit("tool_called", tool="grep")
+        events.emit("turn_settled", kind="user")
         events.emit("intervention_routed", route="user_channel")
-        events.emit("agent_response", text="hi")
         # Let any scheduled tasks settle.
         await asyncio.sleep(0)
         await asyncio.sleep(0)
@@ -173,7 +179,7 @@ def test_untracked_event_kinds_are_ignored() -> None:
 
 
 def test_tracked_events_each_fire_one_post() -> None:
-    """Tier 2: each tracked event kind emits exactly one progress
+    """Tier 2: each tracked audit-event kind emits exactly one progress
     webhook with an incremented ordinal.
     """
     captured: list = []
@@ -181,16 +187,16 @@ def test_tracked_events_each_fire_one_post() -> None:
     bridge.attach()
 
     async def _drive() -> None:
-        events.emit("phase_started", phase="planning")
+        events.emit("turn_started", kind="user")
         events.emit("llm_called", model="gemini-2.5-flash-lite")
-        events.emit("act_executed", op_count=3)
+        events.emit("tool_returned", tool="grep")
         await asyncio.sleep(0)
         await asyncio.sleep(0)
 
     asyncio.run(_drive())
 
     assert [e for e, _ in captured] == [
-        "phase_started", "llm_called", "act_executed",
+        "turn_started", "llm_called", "tool_returned",
     ]
     assert [p["ordinal"] for _, p in captured] == [1, 2, 3]
 
@@ -199,30 +205,27 @@ def test_tracked_events_each_fire_one_post() -> None:
 
 
 def test_format_message_for_each_event_kind() -> None:
-    """Tier 2: ``format_message`` outputs the canonical human-readable
-    text per event kind. Matches the MCP bridge's format so peer
-    consumers can apply the same parser to both transports.
+    """Tier 2: the shared formatter outputs the canonical human-readable text
+    per audit-event kind. One function serves both bridges, so peer consumers
+    can apply the same parser to either transport.
     """
-    from reyn.interfaces.web.routers.a2a import _A2AProgressBridge
+    from reyn.core.events.progress_lifecycle import format_progress_message
 
-    assert _A2AProgressBridge.format_message(
-        "phase_started", {"phase": "planning"},
-    ) == "phase: planning"
-    assert _A2AProgressBridge.format_message(
+    assert format_progress_message(
+        "turn_started", {"kind": "user"},
+    ) == "turn: user"
+    assert format_progress_message(
         "llm_called", {"model": "gemini-2.5-flash-lite"},
     ) == "llm: gemini-2.5-flash-lite"
-    # Singular form for 1 op.
-    assert _A2AProgressBridge.format_message(
-        "act_executed", {"op_count": 1},
-    ) == "act: 1 op"
-    # Plural form for N>1.
-    assert _A2AProgressBridge.format_message(
-        "act_executed", {"op_count": 5},
-    ) == "act: 5 ops"
+    assert format_progress_message(
+        "tool_returned", {"tool": "grep"},
+    ) == "tool: grep"
+    # The failure leg stays distinguishable from the success leg.
+    failed = format_progress_message("tool_failed", {"tool": "grep"})
+    assert "grep" in failed
+    assert failed != "tool: grep"
     # Missing fields fall back to "?".
-    assert _A2AProgressBridge.format_message(
-        "phase_started", {},
-    ) == "phase: ?"
+    assert format_progress_message("turn_started", {}) == "turn: ?"
 
 
 # ── 5. Send payload shape ─────────────────────────────────────────────
@@ -258,15 +261,15 @@ def test_send_posts_canonical_progress_payload(monkeypatch) -> None:
         run_registry=_FakeRunRegistry(),
     )
 
-    asyncio.run(bridge._send(7, "phase_started", "phase: planning"))
+    asyncio.run(bridge._send(7, "turn_started", "turn: user"))
     url, payload = posted[0]
     assert url == "https://peer.test/hook"
     assert payload == {
         "run_id": "run-Y",
         "status": "in-progress",
         "progress": 7,
-        "event": "phase_started",
-        "message": "phase: planning",
+        "event": "turn_started",
+        "message": "turn: user",
         "agent_name": "demo",
     }
 
@@ -296,7 +299,7 @@ def test_send_swallows_transport_errors(monkeypatch) -> None:
     )
 
     # No exception raised, no return value used.
-    asyncio.run(bridge._send(1, "phase_started", "phase: planning"))
+    asyncio.run(bridge._send(1, "turn_started", "turn: user"))
 
 
 # ── 6. Post-detach: late events dropped ───────────────────────────────
@@ -319,7 +322,7 @@ def test_late_event_after_detach_is_ignored() -> None:
     bridge._detached = True
 
     async def _drive() -> None:
-        events.emit("phase_started", phase="planning")
+        events.emit("turn_started", kind="user")
         await asyncio.sleep(0)
         await asyncio.sleep(0)
 

--- a/tests/test_channel_state_webhook_wire_269.py
+++ b/tests/test_channel_state_webhook_wire_269.py
@@ -304,7 +304,7 @@ def test_progress_bridge_send_gates_on_is_alive(monkeypatch) -> None:
         run_registry=registry,
     )
 
-    asyncio.run(bridge._send(1, "phase_started", "phase: planning"))
+    asyncio.run(bridge._send(1, "turn_started", "turn: user"))
 
     assert posted == [], (
         "bridge should skip webhook POST when shared ChannelState says dead"
@@ -351,7 +351,7 @@ def test_bus_and_bridge_share_the_same_channel_state(monkeypatch) -> None:
         iv = UserIntervention(kind="ask_user", prompt="?")
         await bus.on_dispatch(iv)
         # Bridge fires 1 failure → state.delivery_failures = 2 (shared)
-        await bridge._send(1, "phase_started", "phase: planning")
+        await bridge._send(1, "turn_started", "turn: user")
         # Bus fires 1 more → state.delivery_failures = 3 = threshold
         iv2 = UserIntervention(kind="ask_user", prompt="?")
         await bus.on_dispatch(iv2)

--- a/tests/test_mcp_capability_advertising_271_m3.py
+++ b/tests/test_mcp_capability_advertising_271_m3.py
@@ -16,8 +16,10 @@ Pins:
      expected ``NotificationOptions`` (tools/prompts/resources NOT
      advertised as list-changed — they are static in production).
   2. ``experimental_capabilities`` declares ``reyn.progress.skill_lifecycle``
-     with the exact event names that ``_MCPProgressBridge`` subscribes
-     to (= phase_started / llm_called / act_executed).
+     with the exact audit-event kinds ``_MCPProgressBridge`` subscribes to
+     — asserted on the built ``InitializationOptions``, in
+     ``tests/test_progress_lifecycle_fanout_3357.py``, since the list is now
+     DERIVED from the shared constant rather than restated in source.
   3. ``experimental_capabilities`` declares
      ``reyn.cancellation.cooperative`` (= matches the PR #279 cancel
      wire).
@@ -27,7 +29,6 @@ Pins:
 from __future__ import annotations
 
 import ast
-import inspect
 from pathlib import Path
 
 import pytest
@@ -38,19 +39,28 @@ pytest.importorskip("mcp", reason="MCP SDK not installed")
 # ── 1. NotificationOptions: lists are static ──────────────────────────
 
 
-def test_serve_stdio_declares_static_tool_list() -> None:
-    """Tier 2: ``serve_mcp_stdio_async`` source carries the explicit
-    ``tools_changed=False`` declaration (= the tool list returned by
-    ``_list_tools`` is static in production). Declaring True without
-    a corresponding ``notify_tools_changed`` call would be the
-    inverse #267 Z-b mismatch.
+def test_serve_stdio_declares_static_tool_list(tmp_path: Path) -> None:
+    """Tier 2: the ``InitializationOptions`` the production pair
+    (``build_server`` + ``build_init_options``) advertises declare the tool
+    list as STATIC (= what ``_list_tools`` returns never changes at runtime).
+    Declaring list-changed without a corresponding ``notify_tools_changed``
+    call would be the inverse #267 Z-b mismatch.
     """
-    from reyn.mcp import server as mcp_server
+    from reyn.core.events.state_log import StateLog
+    from reyn.mcp.server import build_init_options, build_server
+    from reyn.runtime.registry import AgentRegistry
 
-    src = inspect.getsource(mcp_server.serve_stdio)
-    assert "tools_changed=False" in src
-    assert "prompts_changed=False" in src
-    assert "resources_changed=False" in src
+    def _no_session_expected(profile):  # noqa: ANN001, ANN202
+        raise AssertionError("advertising must not construct a Session")
+
+    registry = AgentRegistry(
+        project_root=tmp_path,
+        session_factory=_no_session_expected,
+        state_log=StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl"),
+    )
+    capabilities = build_init_options(build_server(registry)).capabilities
+    assert capabilities.tools is not None
+    assert capabilities.tools.listChanged is False
 
 
 def test_no_notify_changed_calls_in_mcp_server_source() -> None:
@@ -80,37 +90,40 @@ def test_no_notify_changed_calls_in_mcp_server_source() -> None:
 
 def test_experimental_capability_declares_skill_lifecycle_progress() -> None:
     """Tier 2: the experimental capability key
-    ``reyn.progress.skill_lifecycle`` is declared with the exact event
-    names that ``_MCPProgressBridge`` subscribes to (= the contract
-    between declaration and PR #279 wire).
-    """
-    from reyn.mcp import server as mcp_server
+    ``reyn.progress.skill_lifecycle`` is declared on the real
+    ``InitializationOptions`` this server advertises (= the contract between
+    declaration and the PR #279 wire).
 
-    src = inspect.getsource(mcp_server.serve_stdio)
-    assert '"reyn.progress.skill_lifecycle"' in src
-    # The event list shape is part of the contract — clients negotiate
-    # by reading this field.
-    assert '"phase_started"' in src
-    assert '"llm_called"' in src
-    assert '"act_executed"' in src
+    The advertised ``events`` list is NOT re-listed here: it is derived from
+    ``PROGRESS_LIFECYCLE_EVENTS``, and restating it in a test is what froze two
+    producer-less kinds into the wire contract (#3357). The derivation and the
+    liveness of its members are asserted in
+    ``tests/test_progress_lifecycle_fanout_3357.py``.
+    """
+    from mcp.server import Server
+
+    from reyn.mcp.server import build_init_options
+
+    experimental = build_init_options(Server("reyn")).capabilities.experimental
+    assert experimental is not None
+    assert "reyn.progress.skill_lifecycle" in experimental
 
 
 def test_progress_bridge_subscribes_to_declared_event_names() -> None:
-    """Tier 2: the events advertised in the experimental capability
-    MUST match what ``_MCPProgressBridge.__call__`` actually filters
-    on. Pin the mapping so a future bridge edit (= e.g. adding /
-    removing an event kind) is forced to update the declaration.
+    """Tier 2: the kinds advertised in the experimental capability MUST be the
+    kinds ``_MCPProgressBridge`` actually filters on — the same object, so the
+    declaration cannot drift from the wire.
     """
-    from reyn.mcp import server as mcp_server
+    from mcp.server import Server
 
-    bridge_src = inspect.getsource(mcp_server._MCPProgressBridge)
-    for declared_event in ("phase_started", "llm_called", "act_executed"):
-        assert f'"{declared_event}"' in bridge_src, (
-            f"event {declared_event!r} is declared in the "
-            f"experimental capability but _MCPProgressBridge does "
-            f"NOT filter on it (= claim/reality mismatch). Either "
-            f"add the event filter or drop the declaration."
-        )
+    from reyn.mcp.server import _MCPProgressBridge, build_init_options
+
+    experimental = build_init_options(Server("reyn")).capabilities.experimental
+    advertised = experimental["reyn.progress.skill_lifecycle"]["events"]
+    assert advertised == sorted(_MCPProgressBridge.TRACKED_EVENTS), (
+        "the advertised progress kinds and the bridge's filter disagree "
+        "(= #267 Z-b style claim/reality mismatch)."
+    )
 
 
 # ── 3. Experimental: reyn.cancellation.cooperative ───────────────────
@@ -121,10 +134,13 @@ def test_experimental_capability_declares_cooperative_cancellation() -> None:
     ``reyn.cancellation.cooperative`` is declared (= matches PR #279's
     CancelledError propagation wire).
     """
-    from reyn.mcp import server as mcp_server
+    from mcp.server import Server
 
-    src = inspect.getsource(mcp_server.serve_stdio)
-    assert '"reyn.cancellation.cooperative"' in src
+    from reyn.mcp.server import build_init_options
+
+    experimental = build_init_options(Server("reyn")).capabilities.experimental
+    assert experimental is not None
+    assert "reyn.cancellation.cooperative" in experimental
 
 
 def test_cancellation_wire_exists_in_call_tool_handler() -> None:

--- a/tests/test_mcp_iv_support_270_phase_b.py
+++ b/tests/test_mcp_iv_support_270_phase_b.py
@@ -304,17 +304,20 @@ def test_answer_intervention_tool_is_declared() -> None:
 
 
 def test_serve_stdio_declares_iv_input_required_capability() -> None:
-    """Tier 2: ``serve_stdio`` declares ``reyn.iv.input_required`` in
-    the experimental capabilities of the ``initialize`` response (=
+    """Tier 2: the advertised ``initialize`` response declares
+    ``reyn.iv.input_required`` in its experimental capabilities (=
     PR #284's claim/wire calibration pattern: pin both sides of the
     contract so future refactors that drop one without the other
     fail first).
     """
-    from reyn.mcp import server as mcp_server
+    from mcp.server import Server
 
-    src = inspect.getsource(mcp_server.serve_stdio)
-    assert '"reyn.iv.input_required"' in src
-    assert '"answer_tool": "answer_intervention"' in src
+    from reyn.mcp.server import build_init_options
+
+    experimental = build_init_options(Server("reyn")).capabilities.experimental
+    assert experimental is not None
+    iv = experimental["reyn.iv.input_required"]
+    assert iv["answer_tool"] == "answer_intervention"
 
 
 def test_iv_input_required_capability_backed_by_in_source_wire() -> None:

--- a/tests/test_mcp_server_progress_271.py
+++ b/tests/test_mcp_server_progress_271.py
@@ -5,11 +5,12 @@ Pins the server-side outbound notification mechanism that #271 added:
 
   - M1 progress emit: when the MCP client sets ``_meta.progressToken``
     on a ``send_to_agent`` call, the server's ``_call_tool`` handler
-    subscribes a bridge to the agent's chat_events EventLog and
-    forwards M1-b lifecycle events as ``notifications/progress``:
-      * ``phase_started`` → message="phase: <name>"
+    subscribes a bridge to the agent's chat audit-event log and
+    forwards the ``PROGRESS_LIFECYCLE_EVENTS`` kinds as
+    ``notifications/progress``:
+      * ``turn_started`` → message="turn: <inbox trigger kind>"
       * ``llm_called`` → message="llm: <model>"
-      * ``act_executed`` → message="act: <N> op(s)"
+      * ``tool_returned`` / ``tool_failed`` → message="tool: <name>[ (failed)]"
     Each notification carries a monotonic ordinal ``progress`` (=
     no meaningful ``total``, indeterminate) so the client renders
     as a counter or spinner.
@@ -25,11 +26,11 @@ Pins (mostly via the ``_MCPProgressBridge`` unit + the
 ``send_to_agent_impl`` is too heavy for Tier 2 — we verify the
 bridge's contract directly):
 
-  1. Bridge filter: only the 3 tracked event types translate; other
-     events are ignored.
+  1. Bridge filter: only the tracked audit-event kinds translate;
+     other kinds are ignored.
   2. Bridge ordinal: monotonic, starts at 1.
   3. Bridge message format: matches the documented shape for each
-     tracked event type.
+     tracked audit-event kind.
   4. Bridge detach: removes the subscriber so no leak across calls.
   5. Bridge detach is idempotent (= multiple calls safe).
   6. Bridge tolerates send_progress_notification raising (= best-effort).
@@ -107,13 +108,13 @@ def _make_bridge(
 
 
 @pytest.mark.asyncio
-async def test_bridge_forwards_phase_started_as_progress_notification() -> None:
-    """Tier 2: ``phase_started`` event becomes a progress notification
-    with message ``phase: <name>``.
+async def test_bridge_forwards_turn_started_as_progress_notification() -> None:
+    """Tier 2: a ``turn_started`` audit-event becomes a progress notification
+    with message ``turn: <inbox trigger kind>``.
     """
     bridge, event_log, fake_mcp = _make_bridge()
     try:
-        event_log.emit("phase_started", phase="greet")
+        event_log.emit("turn_started", kind="user")
         # Yield to let the spawned task run.
         await asyncio.sleep(0)
         await asyncio.sleep(0)
@@ -122,7 +123,7 @@ async def test_bridge_forwards_phase_started_as_progress_notification() -> None:
         assert call["progress_token"] == "tok-1"
         assert call["progress"] == 1.0
         assert call["total"] is None
-        assert call["message"] == "phase: greet"
+        assert call["message"] == "turn: user"
         assert call["related_request_id"] == "req-1"
     finally:
         bridge.detach()
@@ -142,21 +143,23 @@ async def test_bridge_forwards_llm_called_with_model_message() -> None:
 
 
 @pytest.mark.asyncio
-async def test_bridge_forwards_act_executed_with_op_count() -> None:
-    """Tier 2: ``act_executed`` event becomes ``act: <N> op(s)`` with
-    correct singular / plural.
+async def test_bridge_forwards_tool_dispatch_outcome_with_tool_name() -> None:
+    """Tier 2: the tool-dispatch completion pair becomes ``tool: <name>``, with
+    the failure leg distinguishable from the success leg.
     """
     bridge, event_log, fake_mcp = _make_bridge()
     try:
-        event_log.emit("act_executed", op_count=1)
+        event_log.emit("tool_returned", tool="grep", chain_id="c1")
         await asyncio.sleep(0)
         await asyncio.sleep(0)
-        assert fake_mcp.calls[-1]["message"] == "act: 1 op"
+        assert fake_mcp.calls[-1]["message"] == "tool: grep"
 
-        event_log.emit("act_executed", op_count=3)
+        event_log.emit("tool_failed", tool="grep", error_kind="exception")
         await asyncio.sleep(0)
         await asyncio.sleep(0)
-        assert fake_mcp.calls[-1]["message"] == "act: 3 ops"
+        failed = fake_mcp.calls[-1]["message"]
+        assert "grep" in failed
+        assert failed != "tool: grep"
     finally:
         bridge.detach()
 
@@ -169,9 +172,9 @@ async def test_bridge_ignores_non_tracked_events() -> None:
     """
     bridge, event_log, fake_mcp = _make_bridge()
     try:
-        event_log.emit("llm_response_received", model="x")
-        event_log.emit("phase_completed", phase="greet")
-        event_log.emit("workflow_finished")
+        event_log.emit("llm_response_received", cost_usd=0.1)
+        event_log.emit("turn_settled", kind="user")
+        event_log.emit("tool_called", tool="grep")
         await asyncio.sleep(0)
         await asyncio.sleep(0)
         assert fake_mcp.calls == []
@@ -189,9 +192,9 @@ async def test_bridge_ordinal_increases_monotonically() -> None:
     """
     bridge, event_log, fake_mcp = _make_bridge()
     try:
-        event_log.emit("phase_started", phase="a")
+        event_log.emit("turn_started", kind="user")
         event_log.emit("llm_called", model="m")
-        event_log.emit("act_executed", op_count=2)
+        event_log.emit("tool_returned", tool="grep")
         await asyncio.sleep(0)
         await asyncio.sleep(0)
         progressions = [c["progress"] for c in fake_mcp.calls]
@@ -215,7 +218,7 @@ async def test_bridge_detach_removes_event_subscriber() -> None:
     """
     bridge, event_log, fake_mcp = _make_bridge()
     bridge.detach()
-    event_log.emit("phase_started", phase="greet")
+    event_log.emit("turn_started", kind="user")
     await asyncio.sleep(0)
     await asyncio.sleep(0)
     assert fake_mcp.calls == []
@@ -247,7 +250,7 @@ async def test_bridge_swallows_send_progress_notification_errors() -> None:
     bridge, event_log, fake_mcp = _make_bridge()
     fake_mcp.raise_on_call = RuntimeError("transport gone")
     try:
-        event_log.emit("phase_started", phase="x")
+        event_log.emit("turn_started", kind="user")
         # No exception should propagate to the test.
         await asyncio.sleep(0)
         await asyncio.sleep(0)
@@ -255,11 +258,13 @@ async def test_bridge_swallows_send_progress_notification_errors() -> None:
         # Bridge is still attached + functional for next event (= no
         # poisoning from earlier failure).
         fake_mcp.raise_on_call = None
-        event_log.emit("phase_started", phase="y")
+        event_log.emit("turn_started", kind="agent_response")
         await asyncio.sleep(0)
         await asyncio.sleep(0)
         # The second event was successfully forwarded.
-        success_calls = [c for c in fake_mcp.calls if c["message"] == "phase: y"]
+        success_calls = [
+            c for c in fake_mcp.calls if c["message"] == "turn: agent_response"
+        ]
         assert success_calls, "expected the second event to be forwarded"
     finally:
         bridge.detach()
@@ -325,7 +330,7 @@ async def test_bridge_detach_cancels_inflight_notification_tasks() -> None:
 
     bridge._send = _slow_send  # type: ignore[method-assign]
 
-    event_log.emit("phase_started", phase="x")
+    event_log.emit("turn_started", kind="user")
     # Let the slow send start.
     await asyncio.sleep(0)
     await asyncio.sleep(0)

--- a/tests/test_progress_lifecycle_fanout_3357.py
+++ b/tests/test_progress_lifecycle_fanout_3357.py
@@ -22,8 +22,8 @@ Real instances throughout: a real ``EventLog``, the real bridges, the real
 """
 from __future__ import annotations
 
+import ast
 import asyncio
-import re
 from pathlib import Path
 
 import pytest
@@ -35,36 +35,70 @@ from reyn.core.events.progress_lifecycle import (
 )
 
 _SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
-# The declaration module itself names every kind; scanning it would make the
-# liveness gate self-satisfying.
+# The declaration module names every kind in prose. An AST walk already ignores
+# prose, so this exclusion is belt-and-braces: it also rules out a future
+# illustrative ``emit(...)`` inside the declaration vouching for its own member.
 _DECLARATION = _SRC / "core" / "events" / "progress_lifecycle.py"
 
 
-def _emitter_sources() -> str:
-    """Concatenated ``src/reyn`` python, minus the declaration module."""
-    return "\n".join(
-        p.read_text(encoding="utf-8")
-        for p in sorted(_SRC.rglob("*.py"))
-        if "__pycache__" not in p.parts and p != _DECLARATION
+def _emitted_kind(node: ast.AST) -> str | None:
+    """The kind string of an ``<x>.emit("<kind>", …)`` / ``emit("<kind>", …)`` CALL.
+
+    ``None`` for anything that is not such a call. Only an ``ast.Call`` whose
+    callee is named ``emit`` and whose first positional argument is a string
+    constant counts — which is what makes this an *emitter* census rather than a
+    text census (see the gate's docstring).
+    """
+    if not isinstance(node, ast.Call) or not node.args:
+        return None
+    func = node.func
+    name = (
+        func.attr if isinstance(func, ast.Attribute)
+        else func.id if isinstance(func, ast.Name)
+        else None
     )
+    if name != "emit":
+        return None
+    first = node.args[0]
+    if isinstance(first, ast.Constant) and isinstance(first.value, str):
+        return first.value
+    return None
+
+
+def _kinds_emitted_in_src() -> set[str]:
+    """Every string literal passed as the first positional arg of an ``emit`` call."""
+    emitted: set[str] = set()
+    for py in sorted(_SRC.rglob("*.py")):
+        if "__pycache__" in py.parts or py == _DECLARATION:
+            continue
+        for node in ast.walk(ast.parse(py.read_text(encoding="utf-8"))):
+            kind = _emitted_kind(node)
+            if kind is not None:
+                emitted.add(kind)
+    return emitted
 
 
 # ── 1. The mechanism: every forwarded kind has a live producer ─────────────
 
 
 def test_every_forwarded_kind_has_a_live_emit_call_site() -> None:
-    """Tier 2: each kind in ``PROGRESS_LIFECYCLE_EVENTS`` is emitted by some
-    producer in ``src/reyn`` — matched as an ``emit("<kind>"`` call, not a bare
-    mention, so a docstring or a formatter arm cannot vouch for a dead kind.
+    """Tier 2: each kind in ``PROGRESS_LIFECYCLE_EVENTS`` is emitted by a real
+    producer in ``src/reyn``.
+
+    ★ The census is an **AST walk**, not a text scan, and the distinction is
+    load-bearing rather than stylistic. A ``re.search`` for ``emit("<kind>"``
+    matches that literal wherever it appears — including inside a docstring or a
+    comment. This module, and the modules it guards, discuss these kinds in
+    prose extensively; under a text scan, someone adding a fifth kind who writes
+    the docstring before the emitter would get a green gate over a dead kind,
+    i.e. #3357 recurring through its own guard. Counting only ``ast.Call`` nodes
+    whose callee is ``emit`` and whose first argument is a string constant means
+    *only an actual call* can vouch for a member.
 
     Add a kind no producer emits → RED (that is the #3357 defect reproduced).
     """
-    blob = _emitter_sources()
-    dead = {
-        kind
-        for kind in PROGRESS_LIFECYCLE_EVENTS
-        if not re.search(rf'emit\(\s*"{re.escape(kind)}"', blob)
-    }
+    emitted = _kinds_emitted_in_src()
+    dead = PROGRESS_LIFECYCLE_EVENTS - emitted
     assert not dead, (
         "progress fan-out declares audit-event kinds with no emit call-site in "
         f"src/reyn (nothing produces them; peers see a silently degraded "
@@ -91,7 +125,23 @@ def test_formatter_labels_every_forwarded_kind_distinctly() -> None:
 def test_formatter_reads_the_identifying_field_of_each_kind() -> None:
     """Tier 2: each arm reads the field the real emitter carries — ``kind`` on
     ``turn_started``, ``model`` on ``llm_called``, ``tool`` on the tool-dispatch
-    pair — so the progress line names what happened."""
+    pair — so the progress line names what happened.
+
+    ★ What this arm does NOT cover, written here so the next reader sees it
+    without re-deriving it. Two gaps, both from the expectations being
+    hand-written rather than enumerated from ``PROGRESS_LIFECYCLE_EVENTS``:
+
+      - **A fifth member sits outside this arm silently.** Enumerating is not
+        available: the assertion IS the expected string, so there is nothing to
+        generate it from. The two arms above are the total ones (every member
+        has a live emitter; every member has a distinct message arm) — this one
+        adds "and reads the right field", for the kinds it names.
+      - **``tool_failed`` is asserted more weakly than the other three.** All
+        four kinds ARE exercised below, but its check is substring + inequality
+        rather than an exact string, so a reworded failure suffix stays green
+        here. Deliberate: the exact suffix is presentation, and the property
+        that matters — the failure leg is distinguishable from the success leg —
+        is what is asserted."""
     assert format_progress_message("turn_started", {"kind": "user"}) == "turn: user"
     assert format_progress_message("llm_called", {"model": "sonnet"}) == "llm: sonnet"
     assert format_progress_message("tool_returned", {"tool": "grep"}) == "tool: grep"

--- a/tests/test_progress_lifecycle_fanout_3357.py
+++ b/tests/test_progress_lifecycle_fanout_3357.py
@@ -1,0 +1,185 @@
+"""Tier 2: the A2A + MCP progress fan-outs forward only LIVE audit-event kinds,
+from one shared declaration (#3357).
+
+Both remote progress bridges subscribe to the same source — the session's chat
+audit-event log (``Session._chat_events``) — and forward a selection of kinds as
+progress notifications. Two invariants, asserted separately:
+
+- **The mechanism is honest.** Every kind in ``PROGRESS_LIFECYCLE_EVENTS`` has a
+  live emit call-site in ``src/reyn``. The audit-event ``type`` namespace is
+  OPEN (no closed vocabulary, no emit-time kind check), so a kind nobody emits
+  degrades the stream silently — the ordinal counter keeps incrementing and a
+  subscribing peer cannot tell a degraded stream from a quiet run. That is
+  exactly how ``phase_started`` / ``act_executed`` survived the phase engine's
+  deletion inside two live network protocols.
+- **Production reaches it.** Both bridges hold that constant (not a private
+  copy), render through the shared formatter, and the MCP ``initialize``
+  advertisement derives its ``events`` list from the same constant instead of
+  restating it.
+
+Real instances throughout: a real ``EventLog``, the real bridges, the real
+``build_init_options`` output built from a real ``Server``.
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.events.progress_lifecycle import (
+    PROGRESS_LIFECYCLE_EVENTS,
+    format_progress_message,
+)
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
+# The declaration module itself names every kind; scanning it would make the
+# liveness gate self-satisfying.
+_DECLARATION = _SRC / "core" / "events" / "progress_lifecycle.py"
+
+
+def _emitter_sources() -> str:
+    """Concatenated ``src/reyn`` python, minus the declaration module."""
+    return "\n".join(
+        p.read_text(encoding="utf-8")
+        for p in sorted(_SRC.rglob("*.py"))
+        if "__pycache__" not in p.parts and p != _DECLARATION
+    )
+
+
+# ── 1. The mechanism: every forwarded kind has a live producer ─────────────
+
+
+def test_every_forwarded_kind_has_a_live_emit_call_site() -> None:
+    """Tier 2: each kind in ``PROGRESS_LIFECYCLE_EVENTS`` is emitted by some
+    producer in ``src/reyn`` — matched as an ``emit("<kind>"`` call, not a bare
+    mention, so a docstring or a formatter arm cannot vouch for a dead kind.
+
+    Add a kind no producer emits → RED (that is the #3357 defect reproduced).
+    """
+    blob = _emitter_sources()
+    dead = {
+        kind
+        for kind in PROGRESS_LIFECYCLE_EVENTS
+        if not re.search(rf'emit\(\s*"{re.escape(kind)}"', blob)
+    }
+    assert not dead, (
+        "progress fan-out declares audit-event kinds with no emit call-site in "
+        f"src/reyn (nothing produces them; peers see a silently degraded "
+        f"stream): {sorted(dead)}"
+    )
+
+
+def test_formatter_labels_every_forwarded_kind_distinctly() -> None:
+    """Tier 2: the shared formatter renders a dedicated line per forwarded kind
+    — never the fall-through that just echoes the kind name. A kind added to the
+    constant without a message arm would reach peers as a bare type string."""
+    labels = {
+        kind: format_progress_message(kind, {})
+        for kind in PROGRESS_LIFECYCLE_EVENTS
+    }
+    for kind, label in labels.items():
+        assert label != kind, f"{kind!r} has no message arm in the formatter"
+    rendered = sorted(labels.values())
+    assert rendered == sorted(set(labels.values())), (
+        f"two forwarded kinds render to the same progress line: {labels}"
+    )
+
+
+def test_formatter_reads_the_identifying_field_of_each_kind() -> None:
+    """Tier 2: each arm reads the field the real emitter carries — ``kind`` on
+    ``turn_started``, ``model`` on ``llm_called``, ``tool`` on the tool-dispatch
+    pair — so the progress line names what happened."""
+    assert format_progress_message("turn_started", {"kind": "user"}) == "turn: user"
+    assert format_progress_message("llm_called", {"model": "sonnet"}) == "llm: sonnet"
+    assert format_progress_message("tool_returned", {"tool": "grep"}) == "tool: grep"
+    failed = format_progress_message("tool_failed", {"tool": "grep"})
+    assert "grep" in failed and failed != "tool: grep"
+
+
+# ── 2. Production reaches it: one declaration, both bridges ────────────────
+
+
+def test_both_bridges_forward_the_shared_declaration() -> None:
+    """Tier 2: the A2A and MCP bridges filter on the shared constant itself, so
+    the two protocols cannot drift apart. Give either bridge a private copy →
+    this still passes on equality but RED on identity, which is the point: the
+    copy is what allowed #3357's two dead kinds to sit in both files."""
+    pytest.importorskip("mcp", reason="MCP SDK not installed")
+    from reyn.interfaces.web.routers.a2a import _A2AProgressBridge
+    from reyn.mcp.server import _MCPProgressBridge
+
+    assert _A2AProgressBridge.TRACKED_EVENTS is PROGRESS_LIFECYCLE_EVENTS
+    assert _MCPProgressBridge.TRACKED_EVENTS is PROGRESS_LIFECYCLE_EVENTS
+
+
+def test_mcp_initialize_advertises_the_forwarded_kinds() -> None:
+    """Tier 2: the ``reyn.progress.skill_lifecycle`` experimental capability the
+    MCP ``initialize`` response carries lists exactly the kinds the bridge
+    forwards — derived from the constant, not restated. Hardcode the list back →
+    RED as soon as the forwarded set changes (the claim/reality gate #271 M3
+    asked for, previously a source-text pin that instead FROZE the dead kinds)."""
+    pytest.importorskip("mcp", reason="MCP SDK not installed")
+    from mcp.server import Server
+
+    from reyn.mcp.server import build_init_options
+
+    init_options = build_init_options(Server("reyn"))
+
+    experimental = init_options.capabilities.experimental
+    assert experimental is not None
+    progress = experimental["reyn.progress.skill_lifecycle"]
+    assert progress["events"] == sorted(PROGRESS_LIFECYCLE_EVENTS)
+
+
+# ── 3. End-to-end through a real EventLog ──────────────────────────────────
+
+
+def test_a2a_bridge_forwards_a_live_tool_dispatch_audit_event() -> None:
+    """Tier 2: emitting the audit-event kinds a real turn produces
+    (``turn_started`` then ``tool_returned``) on a real ``EventLog`` reaches the
+    A2A bridge's SSE sink with legible messages and a monotonic ordinal.
+
+    Pins the whole subscribe → filter → format → dispatch path against the kinds
+    production actually emits, which is what the pre-#3357 suite could not do:
+    it only ever emitted kinds no producer wrote."""
+    from reyn.interfaces.web.routers.a2a import _A2AProgressBridge
+    from reyn.interfaces.web.run_registry import RunRegistry
+
+    events = EventLog()
+
+    # ``Session`` is not cheaply constructible; the bridge reads exactly one
+    # attribute off it (the chat audit-event log), and that log is the real
+    # ``EventLog`` production dispatches through.
+    class _SessionWithChatEvents:
+        _chat_events = events
+
+    run_registry = RunRegistry()
+    entry = run_registry.create(agent_name="demo", chain_id="c1")
+    bridge = _A2AProgressBridge(
+        session=_SessionWithChatEvents(),
+        run_id=entry.run_id,
+        webhook_url=None,
+        agent_name="demo",
+        run_registry=run_registry,
+    )
+
+    async def _drive() -> None:
+        bridge.attach()
+        try:
+            events.emit("turn_started", kind="user", chain_id="c1")
+            events.emit("tool_returned", tool="grep", chain_id="c1")
+            events.emit("llm_response_received", cost_usd=0.1)  # not forwarded
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+        finally:
+            bridge.detach()
+
+    asyncio.run(_drive())
+
+    forwarded = run_registry.get(entry.run_id).history_events
+    assert [p["event"] for p in forwarded] == ["turn_started", "tool_returned"]
+    assert [p["message"] for p in forwarded] == ["turn: user", "tool: grep"]
+    assert [p["progress"] for p in forwarded] == [1, 2]


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3357.

## Branch taken: **option 2 — re-source the lifecycle from live audit-events**

The issue asked me to resolve by investigation. A live equivalent exists for both retired meanings, on the *same* `EventLog` the two bridges already subscribe to, so restoring the promised stream beat shrinking it.

### Evidence

**The absence.** `grep -rn 'phase_started|act_executed' src/` → only the two bridge modules (declaration + formatter arm + prose). Zero `emit(` call-sites. Confirmed against a repo-wide scan including docs; every remaining hit is a dogfood journal from the phase-engine era. `src/reyn/core/events/event_schema.py` already carries the #2696 decision record: the phase engine was deleted in #2434 / #2438 and "there is no producer to reconnect to".

**The live equivalents.** The bridges subscribe to `session._chat_events`. Tracing what production emits on *that object*:

| Retired kind | Meaning | Live audit-event on `_chat_events` | Emitter |
|---|---|---|---|
| `phase_started` | a turn / step boundary | `turn_started` (`kind` = inbox trigger) | `Session.run_one_iteration` — `session.py:5494` |
| `act_executed` | an op / tool execution completing | `tool_returned` / `tool_failed` (`tool`) | `dispatch_tool` — `core/dispatch/dispatcher.py` |

Both provably land on the same log: `RouterHostAdapter(… events=self._chat_events …)` (`session.py:3933`) → `RouterLoop`'s `DispatchContext(events=self.host.events)` (`router_loop.py:2956`) → `dispatch_tool`. And the MCP/A2A entry path reaches them: `send_to_agent_impl` drives `MessageBus.request(session, kind="user", …)`, i.e. `run_one_iteration` → router loop, with the bridge attached before the call.

Three independent corroborations that these are *the* remote-client lifecycle vocabulary, not my invention:
- `ChatLifecycleForwarder.on_tool_called` / `on_tool_returned` / `on_tool_failed` already treats this triple as the live tool-execution lifecycle on the same log.
- `docs/reference/runtime/agui-transport.md` maps `turn_started → RUN_STARTED` and `tool_returned` / `tool_failed → TOOL_CALL_END` for the AG-UI wire.
- `event_schema.EVENT_AUDIT_REQUIREMENTS` declares required fields for `turn_started` (`kind`) and the rest of the turn triad.

I did **not** relabel a turn boundary as a "phase" — `phase` is abolished vocabulary and the payload key is gone. The forwarded set is now:

```
turn_started   → "turn: <inbox trigger kind>"
llm_called     → "llm: <model>"      (unchanged)
tool_returned  → "tool: <name>"
tool_failed    → "tool: <name> (failed)"
```

Only the kind and that one line cross the wire — a tool's `args` and `result` never leave the process on this channel.

## ⚠️ Operator-visible: the notification *rate* changes

More kinds is not the breaking part — both A2A and MCP clients ignore unknown kinds by protocol. **The changed frequency is what a receiver will feel.**

Per `send_to_agent` call, progress notifications go from **one per LLM call** to **one per turn + one per LLM call + one per tool call**. The per-tool-call term is new, and it comes off the `dispatch_tool` chokepoint, so it fires far more often than LLM calls do.

No multiplier is stated here on purpose: nobody has measured one, and the ratio depends entirely on the turn. The structural fact — a per-tool-call term now exists where none did before — is the part that is known. **A webhook receiver sized for LLM-call-rate progress will see materially more traffic.**

Related, and **not created by this PR**: the bridges' in-flight task lists (`a2a.py:621` / `server.py:871`) are append-only — `detach()` cancels the unfinished ones but never removes finished entries, and there is no `add_done_callback` in either file. Pre-existing on `main`; this PR raises its rate for the same structural reason. Filed as **#3390** with the prescription (removal callback **plus** a size witness), rather than folded in here.

## The gate gap (★ the part worth more than the cleanup)

**These `TRACKED_EVENTS` were NOT part of the closed vocabulary.** ADR-0039 P6b's `VOCABULARY` (`src/reyn/runtime/outbox.py`) is the closed set of `OutboxMessage.kind` — display/control *frame* kinds (`agent`, `status`, `__end__`, …), gated by `test_outbox_vocabulary.py` / `test_agui_profile_completeness.py`. `TRACKED_EVENTS` names audit-event `type` strings — a **different, open namespace**. Neither gate could ever have seen these. Verified by reading both files, not by assuming.

★ Worth keeping findable: **it is natural to assume audit-event kinds are governed the way outbox frame kinds are, and that assumption is exactly what let two dead kinds sit in a live declaration.** They are not. The audit-event `type` namespace has **no closed vocabulary and no liveness gate** — `event_schema.EVENT_AUDIT_REQUIREMENTS` declares required *fields* for the ~15 kinds it covers, is explicitly "NOT enforced at emit() runtime", and has no reverse dead-entry check. Ironically `test_outbox_vocabulary.py::test_no_dead_vocabulary_entry` is exactly the missing shape — for the other namespace.

**Worse: two tests were actively holding the drift in place.** `test_a2a_webhook_progress_267_gap2.py:97-109` asserted (a) the two bridges agree with each other and (b) the set equals a literal `{"phase_started", "llm_called", "act_executed"}`. Both held perfectly while two of the three had zero producers — the gate proved *mutual agreement*, not *liveness* — and (b) would have gone RED on the correct removal. `test_mcp_capability_advertising_271_m3.py` did the same with `assert '"phase_started"' in src`. Dead code was being protected from being fixed.

**The arm added.** `test_every_forwarded_kind_has_a_live_emit_call_site` enumerates from `PROGRESS_LIFECYCLE_EVENTS` itself (never a hand-written list) and requires a real emit **call**: an `ast.Call` whose callee is named `emit` and whose first positional argument is a string constant.

★ **AST, not regex — and that was a review catch, not my original design.** My first version used `re.search(r'emit\("<kind>"')` over the concatenated text of every `.py` in `src/reyn`, with a docstring claiming "a docstring or a formatter arm cannot vouch for a dead kind". That claim was false: a text scan matches the literal wherever it appears, including inside a comment or docstring — and these modules discuss these kinds in prose extensively. So the guard had **the same defect shape as the thing it guards against**: a promise its implementation did not keep. Rewritten to the AST idiom #3385 landed on `main` today (`test_tool_schema_3383_process_history_independence.py`). Falsified both ways below.

## Changes

- **New** `src/reyn/core/events/progress_lifecycle.py` — `PROGRESS_LIFECYCLE_EVENTS` + `format_progress_message`. The two verbatim-duplicated declarations and the two verbatim-duplicated formatters collapse to one each (the issue asked for this).
- `a2a.py` / `mcp/server.py` — both bridges hold the shared constant and render through the shared formatter. Dead `format_message` arms reading `data["phase"]` / `data["op_count"]` removed.
- `mcp/server.py` — extracted `build_init_options(server)` out of `serve_stdio`, and the `reyn.progress.skill_lifecycle` `events` list is now `sorted(PROGRESS_LIFECYCLE_EVENTS)`. The advertisement cannot drift from the filter, and it becomes assertable without standing up a stdio transport. The capability *key* is kept as-is — it is a published wire string clients match on.
- All three prose docstrings corrected (`a2a.py:129`, `a2a.py:582`, `server.py:984` in the issue's line numbering), plus the `_run` comment and the bridge-factory docstring. "event" is never bare in any of them.

### Docs (same PR)

- `docs/reference/runtime/events.md` — the turn lifecycle (`session_started` / `turn_started` / `turn_completed` / `turn_settled`) and tool dispatch (`tool_called` / `tool_returned` / `tool_failed`) kinds were **entirely absent from the audit-event inventory** despite being live. That absence is part of why nobody noticed the fan-outs were tracking ghosts. Added both, with a note naming the remote fan-out set.
- `docs/concepts/tools-integrations/mcp.md` — new "Progress notifications" section (the MCP server surface had no doc at all for what a `progressToken` gets).
- `docs/concepts/multi-agent/a2a.md` — new "Progress payloads" section; the SSE / push-notification sections previously said only "each status transition".

## Test plan

- [x] `ruff check src tests` — clean.
- [x] `python scripts/test_tier_audit.py --strict` on all 7 changed/new test files — 0 errors, 0 warnings.
- [x] `python -m pytest -q -n auto --timeout=120` from the repo root — **9484 passed, 36 skipped, 0 failed** (255s).

  ★ Reported honestly because the first attempt was not green. An intermediate run came back **7 failed / 9477 passed in 923s** against 358s for a clean run. Its output had been piped through `tail -5`, so only 4 of the 7 names survived; those 4 (`test_litellm_lazy_load` ×2, `test_3028_mcp_stdio_init_timeout`, `test_textual_chat_intervention_panel_3299` — all latency / subprocess / render-timing shaped) pass serially in isolation. Rather than call 3 unknown names "probably flakes", I re-ran the whole suite: counts return to exactly the pre-rewrite green. I also checked that the `-p no:randomly` I added to that re-run is a **no-op** here (`pytest-randomly` is not installed), so the run is not quietly less order-representative than CI.

  ★★ **Cause corrected after direct observation.** I first attributed the 923s run to a `ps aux` poll loop of my own — that was inference, and it was wrong. `ps` afterwards showed **other sessions' pytest processes running on this machine**: a full serial suite (`pytest -q -p no:randomly`, distinct from my `-n auto` invocation) plus a single-test run of `test_textual_chat_intervention_panel_3299.py` — one of the four files that failed in my run. This box has a shared venv and concurrent peers, so wall-clock and timing-sensitive results here are not attributable to one's own session by default. What is unchanged is observed, not inferred: the re-run's **9484 / 36 / 0** matches the pre-rewrite baseline exactly, and the four recovered names pass serially.
- [x] `python scripts/verify_module_docstrings.py` on the 3 changed src files — OK.
- [x] Worktree identity asserted before every measurement: `import reyn` resolves to `.claude/worktrees/agent-a04119c632d8600d9/src/reyn/__init__.py`. The shared venv's editable install points at the main tree, so every run above was made with `PYTHONPATH=<this worktree>/src` and the resolution re-verified.

### Strip-falsify (each new/changed gate; production call-site stripped, anchor uniqueness checked first)

| Strip (anchor `count == 1` verified before editing) | Expected | Observed |
|---|---|---|
| Re-add `phase_started` + `act_executed` to `PROGRESS_LIFECYCLE_EVENTS` (= the #3357 defect reproduced) | liveness arm RED | **RED** — `['act_executed', 'phase_started']`, plus the formatter-arm test RED |
| Same, **plus** a comment in `mcp/server.py` reading `emit("phase_started", ...)` — the prose-vouching case | AST gate still RED | **RED**; and the old regex, run against that same tree, was **GREEN (missed it)** |
| Give `_A2AProgressBridge` a private literal copy of the set | both bridges-share tests RED | **RED** in `test_progress_lifecycle_fanout_3357` and `test_a2a_webhook_progress_267_gap2` |
| Hardcode the MCP advertised `events` back to the old three | advertisement-derivation tests RED | **RED** in both the new file and `test_mcp_capability_advertising_271_m3` |

Row 2 is the falsification of the review finding itself: same defective tree, AST RED, regex GREEN.

A first attempt at strip 3 used `frozenset(PROGRESS_LIFECYCLE_EVENTS)`, which CPython returns as the *same object* — the test stayed green and the strip proved nothing. Re-ran with a genuine literal before trusting the result.

The two assertions are kept separate throughout: **the mechanism is correct** (liveness census; every member has a distinct message arm; the arms read the right field) and **production reaches it** (both bridges hold the constant; the MCP advertisement derives from it; a real `EventLog` → real `RunRegistry` end-to-end fires with the kinds production actually emits).

**What the gates drop, written where the next reader sees it.** `test_formatter_reads_the_identifying_field_of_each_kind` pins expected strings, so it cannot be enumerated from the constant — a fifth member would sit outside it silently, and `tool_failed` is asserted by substring + inequality rather than exact string (deliberate: the exact suffix is presentation; "the failure leg is distinguishable" is the property). Both limits are now stated in the test's own docstring. The two *total* arms are the liveness census and the distinct-message-arm check.

### Also fixed en route

`test_mcp_iv_support_270_phase_b.py` and two tests in `test_mcp_capability_advertising_271_m3.py` asserted capability declarations via `inspect.getsource(serve_stdio)` string matching, which the `build_init_options` extraction broke. Rewritten to assert on the real `InitializationOptions` object instead of source text — the same class of fix as retiring the literal pin. They surfaced only because the full suite was run, not the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
