### PR TITLE
fix(runtime): make the router-cap wrap-up fallback observable + pin both legs

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -6064,6 +6064,22 @@ class Session:
         router_cap fires BEFORE run_loop starts). Falls back to the
         original canned error + hardcoded reply if wrap-up fails or
         produces no text.
+
+        #3382: falling back used to be *silent* — a single
+        ``except Exception: pass`` collapsed "the wrap-up call failed",
+        "no LLM is configured / reachable" and "the LLM returned no text"
+        into one indistinguishable outcome. The reason is now named
+        (``wrap_up_failed: <ExcType>: <msg>`` — which is also how the
+        no-LLM-configured case identifies itself, via the provider's own
+        exception type — or ``wrap_up_empty``) and logged at WARNING
+        before the canned reply is emitted.
+
+        The ``try`` is also narrowed: it no longer wraps the success-path
+        emission, so an outbox/history failure *after* a successful
+        wrap-up surfaces instead of silently producing a second, canned
+        reply. ``BaseException`` (``asyncio.CancelledError`` — see #3377)
+        is deliberately not caught: a cancel must propagate, not be
+        degraded into a user-visible "budget exhausted" message.
         """
         # #1496: emit audit event + attempt LLM wrap-up
         self._chat_events.emit(
@@ -6073,46 +6089,62 @@ class Session:
             cap=exc.cap,
             chain_id=chain_id,
         )
+        from reyn.runtime.router_loop import RouterLoop
+
+        _wrapup_text: str | None = None
+        _reason_unavailable = ""
+        history = self._history_buffer.build_history()
+        messages: list[dict] = [
+            *history,
+            *(
+                [{"role": "user", "content": user_text}]
+                if user_text else []
+            ),
+        ]
+        _temp_loop = RouterLoop(
+            host=self._router_host, chain_id=chain_id, llm_caller=_llm_caller,
+        )
+        _reason = (
+            f"router cap exhausted ({exc.count}/{exc.cap})"
+            f"{'; last reason: ' + exc.last_reason if exc.last_reason else ''}"
+        )
         try:
-            from reyn.runtime.router_loop import RouterLoop
-            history = self._history_buffer.build_history()
-            messages: list[dict] = [
-                *history,
-                *(
-                    [{"role": "user", "content": user_text}]
-                    if user_text else []
-                ),
-            ]
-            _temp_loop = RouterLoop(
-                host=self._router_host, chain_id=chain_id, llm_caller=_llm_caller,
-            )
             _resolved = self._router_host.resolve_model(self.model)
-            _reason = (
-                f"router cap exhausted ({exc.count}/{exc.cap})"
-                f"{'; last reason: ' + exc.last_reason if exc.last_reason else ''}"
-            )
             _wrapup = await _temp_loop._force_close_call_with_retry(
                 messages, resolved_model=_resolved, reason=_reason,
             )
-            if _wrapup.content:
-                await self._put_outbox(OutboxMessage(
-                    kind="agent",
-                    text=_wrapup.content,
-                    meta={
-                        "chain_id": chain_id,
-                        "limit_stopped": True,
-                        "limit_kind": "router_cap",
-                    },
-                ))
-                self._append_history(ChatMessage(
-                    role="assistant",
-                    content=_wrapup.content,
-                    ts=_now_iso(),
-                    meta={"chain_id": chain_id, "source": "router_cap_exhausted_wrap_up"},
-                ))
-                return
-        except Exception:  # noqa: BLE001 — wrap-up failed; degrade to canned reply
-            pass
+        except Exception as _err:  # noqa: BLE001 — named below, then degraded
+            _reason_unavailable = f"wrap_up_failed: {type(_err).__name__}: {_err}"
+        else:
+            _wrapup_text = _wrapup.content or None
+            if _wrapup_text is None:
+                _reason_unavailable = "wrap_up_empty: the LLM returned no text"
+
+        if _wrapup_text is not None:
+            await self._put_outbox(OutboxMessage(
+                kind="agent",
+                text=_wrapup_text,
+                meta={
+                    "chain_id": chain_id,
+                    "limit_stopped": True,
+                    "limit_kind": "router_cap",
+                },
+            ))
+            self._append_history(ChatMessage(
+                role="assistant",
+                content=_wrapup_text,
+                ts=_now_iso(),
+                meta={"chain_id": chain_id, "source": "router_cap_exhausted_wrap_up"},
+            ))
+            return
+
+        logger.warning(
+            "router_cap force-close wrap-up unavailable (%s) — chain_id=%s; "
+            "falling back to the canned retry-exhausted reply, so this turn's "
+            "closing message is generic rather than a summary of what was done.",
+            _reason_unavailable,
+            chain_id,
+        )
 
         # Fallback: original canned error + hardcoded reply
         await self._put_outbox(OutboxMessage(

--- a/tests/_support/router_loop.py
+++ b/tests/_support/router_loop.py
@@ -247,3 +247,22 @@ class ScriptedLLM:
         result = self._script[self.call_count]
         self.call_count += 1
         return result
+
+
+class RaisingLLM:
+    """Real callable replacing call_llm_tools that always raises.
+
+    Same policy standing as :class:`ScriptedLLM` (a real ``__call__``, so
+    signature drift still raises ``TypeError``); this one lets a test pin
+    the *failure* leg of a path that degrades when the LLM is unavailable
+    — without depending on the ambient environment lacking credentials
+    (#3382: four tests were green only because CI has no API key).
+    """
+
+    def __init__(self, error: BaseException | None = None) -> None:
+        self.error = error or RuntimeError("scripted LLM failure")
+        self.call_count: int = 0
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.call_count += 1
+        raise self.error

--- a/tests/test_chat_router_i18n.py
+++ b/tests/test_chat_router_i18n.py
@@ -10,6 +10,17 @@ F11: the system prompt built by router_system_prompt must include an explicit
 Policy: no MagicMock / AsyncMock on collaborators. Real Session and
 build_system_prompt instances. RouterLoop.run() is patched only where strictly
 necessary to avoid network calls (Tier 3 LLM-replay tests are separate).
+
+#3382 — why every F8 test below pins the LLM explicitly: the cap-exhausted
+path first attempts an LLM force-close wrap-up and only falls back to the
+canned ``_ROUTER_RETRY_EXHAUSTED_MSG`` when that wrap-up is unavailable
+(``session.py`` #1496 site C). These tests used to reach the canned leg by
+accident — the ambient environment had no usable model, so the wrap-up
+always raised — which made them green for the wrong reason and green in
+exactly one kind of environment. Each canned-leg test now injects a
+``RaisingLLM``, and ``test_retry_exhausted_wrap_up_success_...`` pins the
+OTHER leg, so a regression in either direction is visible with or without
+credentials.
 """
 from __future__ import annotations
 
@@ -25,6 +36,7 @@ from reyn.runtime.session import (
     Session,
 )
 from tests._support.agent_session import make_session
+from tests._support.router_loop import RaisingLLM, ScriptedLLM
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -74,6 +86,19 @@ def _text_result(text: str) -> LLMToolCallResult:
     )
 
 
+def _pin_llm(monkeypatch, caller) -> None:
+    """Pin the LLM the cap-exhausted wrap-up will reach (#3382).
+
+    ``_handle_user_message`` has no ``_llm_caller`` parameter, so the
+    wrap-up's LLM is pinned at the ``call_llm_tools`` boundary that
+    ``RouterLoop._force_close_call`` falls back to. Replacement is a real
+    callable (policy: Mock vs Fake — ``monkeypatch.setattr`` with a real
+    callable is allowed, and the LLM is the one collaborator a Tier-2c
+    test may fake).
+    """
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", caller)
+
+
 # ---------------------------------------------------------------------------
 # F8 tests — retry-exhausted fallback message language
 # ---------------------------------------------------------------------------
@@ -86,9 +111,13 @@ def test_retry_exhausted_fallback_is_japanese_when_output_language_ja(
 
     The fallback text must come from _ROUTER_RETRY_EXHAUSTED_MSG["ja"],
     not from the hardcoded English string.
+
+    #3382: the wrap-up is pinned unavailable, so the canned leg is
+    reached by construction rather than by the environment lacking a key.
     """
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path, cap=3, output_language="ja")
+    _pin_llm(monkeypatch, RaisingLLM())
 
     # Pre-spend the budget and suppress the reset so the very first
     # _run_router_loop attempt inside _handle_user_message is rejected.
@@ -120,6 +149,7 @@ def test_retry_exhausted_fallback_is_english_when_output_language_en(
     """
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path, cap=3, output_language="en")
+    _pin_llm(monkeypatch, RaisingLLM())  # #3382: canned leg by construction
 
     monkeypatch.setattr(Session, "_reset_router_turn_counter", lambda self: None)
     session.router_invocations_this_turn = 3
@@ -145,6 +175,7 @@ def test_retry_exhausted_fallback_defaults_to_english_for_unsupported_language(
     """
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path, cap=3, output_language="fr")
+    _pin_llm(monkeypatch, RaisingLLM())  # #3382: canned leg by construction
 
     monkeypatch.setattr(Session, "_reset_router_turn_counter", lambda self: None)
     session.router_invocations_this_turn = 3
@@ -344,21 +375,13 @@ def test_retry_exhausted_fallback_is_english_when_output_language_is_none(
     global default for an internal error string when the user has not
     expressed a language preference). Regional languages like ja are
     NOT silently chosen as fallback.
+
+    #3382: uses the designed ``_llm_caller`` seam to pin the wrap-up as
+    unavailable, so the canned leg is reached by construction.
     """
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path, cap=3, output_language=None)
     session.is_attached = True
-
-    delivered: list[dict] = []
-
-    async def fake_put_outbox(msg):
-        delivered.append({
-            "kind": msg.kind,
-            "text": msg.text,
-            "meta": msg.meta,
-        })
-
-    session._put_outbox = fake_put_outbox  # type: ignore[assignment]
 
     from reyn.runtime.errors import RouterCapExceeded
 
@@ -366,16 +389,56 @@ def test_retry_exhausted_fallback_is_english_when_output_language_is_none(
         await session._emit_router_cap_exhausted_user(
             RouterCapExceeded(count=3, cap=3, last_reason="loop"),
             chain_id="chain-test",
+            _llm_caller=RaisingLLM(),
         )
 
     _run(run())
 
     # The agent reply should be the English fallback, not the Japanese one.
-    agent_msgs = [m for m in delivered if m["kind"] == "agent"]
-    assert agent_msgs, f"no agent reply emitted; got: {delivered}"
-    assert agent_msgs[0]["text"] == _ROUTER_RETRY_EXHAUSTED_MSG["en"], (
+    agent_msgs = [m for m in _drain_outbox(session) if m.kind == "agent"]
+    assert agent_msgs, "no agent reply emitted"
+    assert agent_msgs[0].text == _ROUTER_RETRY_EXHAUSTED_MSG["en"], (
         f"Expected English fallback when output_language=None; got: "
-        f"{agent_msgs[0]['text']!r}"
+        f"{agent_msgs[0].text!r}"
     )
     # Specifically NOT the ja message.
-    assert agent_msgs[0]["text"] != _ROUTER_RETRY_EXHAUSTED_MSG["ja"]
+    assert agent_msgs[0].text != _ROUTER_RETRY_EXHAUSTED_MSG["ja"]
+
+
+def test_retry_exhausted_wrap_up_success_replaces_canned_fallback(
+    tmp_path, monkeypatch
+):
+    """Tier 2: when the force-close wrap-up DOES produce text, the user
+    gets that generated summary and NOT the canned i18n fallback (#1496
+    site C's documented specification: the canned message is the fallback,
+    generation is the intent).
+
+    #3382: this is the leg the F8 tests above never had. Without it, the
+    canned-leg assertions stay green in an environment where the wrap-up
+    can never succeed — which is exactly how they came to pin the
+    then-current defect instead of the specification.
+    """
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path, cap=3, output_language="ja")
+    session.is_attached = True
+    _pin_llm(monkeypatch, ScriptedLLM([_text_result("完了した内容の要約です")]))
+
+    monkeypatch.setattr(Session, "_reset_router_turn_counter", lambda self: None)
+    session.router_invocations_this_turn = 3
+    session._router_last_reason = "out_of_scope"
+
+    _run(session._handle_user_message("こんにちは", chain_id="chain-wrapup"))
+
+    msgs = _drain_outbox(session)
+    agent_msgs = [m for m in msgs if m.kind == "agent"]
+    assert agent_msgs, "Expected an agent outbox message"
+    (agent_msg,) = agent_msgs
+    assert agent_msg.text == "完了した内容の要約です", (
+        f"Expected the generated wrap-up; got: {agent_msg.text!r}"
+    )
+    assert agent_msg.text != _ROUTER_RETRY_EXHAUSTED_MSG["ja"]
+    assert (agent_msg.meta or {}).get("limit_stopped") is True
+    # The canned leg emits an error message alongside; it must not fire.
+    assert not [m for m in msgs if m.kind == "error"], (
+        "canned fallback fired despite a successful wrap-up"
+    )

--- a/tests/test_router_cap.py
+++ b/tests/test_router_cap.py
@@ -31,6 +31,7 @@ from reyn.runtime.budget.budget import BudgetTracker, CostConfig
 from reyn.runtime.errors import RouterCapExceeded
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
+from tests._support.router_loop import RaisingLLM
 
 
 def _run(coro):
@@ -98,9 +99,18 @@ def test_handle_user_message_emits_fallback_when_cap_exhausted(
 ):
     """Tier 2: when `_handle_user_message` hits the cap, the user sees a structured
     error + a polite agent fallback on the outbox, the event is emitted,
-    and history records the fallback."""
+    and history records the fallback.
+
+    #3382: the canned fallback is only reached when the force-close
+    wrap-up is unavailable, so the wrap-up's LLM is pinned as raising.
+    Previously this test reached the canned leg only because the ambient
+    environment had no usable model — it was green for the wrong reason.
+    """
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path, cap=3)
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools", RaisingLLM(),
+    )
 
     # Pre-spend so the very first router call in this turn is rejected.
     # Note: `_handle_user_message` resets the counter at its top, then

--- a/tests/test_router_cap_wrapup_observability_3382.py
+++ b/tests/test_router_cap_wrapup_observability_3382.py
@@ -1,0 +1,160 @@
+"""Tier 2: #3382 — degrading to the canned router-cap reply is observable.
+
+The per-turn router cap's user-facing close (``session.py`` #1496 site C)
+tries an LLM force-close wrap-up and falls back to a canned i18n message
+when it cannot produce one. That fallback used to be reached through a
+bare ``except Exception: pass``, so three distinct situations — the
+wrap-up call failed, no LLM is configured/reachable, the LLM returned no
+text — collapsed into one indistinguishable outcome with no record at all.
+
+These tests pin the surviving contract: whenever the canned reply is
+emitted, a WARNING names *which* of those happened; when the wrap-up
+succeeds, nothing is logged. Both legs use the designed ``_llm_caller``
+Tier-2 seam, so neither depends on the environment having credentials.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+import pytest
+
+from reyn.config import LoopConfig, SafetyConfig
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.errors import RouterCapExceeded
+from reyn.runtime.session import _ROUTER_RETRY_EXHAUSTED_MSG, Session
+from tests._support.agent_session import make_session
+from tests._support.router_loop import RaisingLLM, ScriptedLLM, text_result
+
+_USAGE = TokenUsage(prompt_tokens=10, completion_tokens=5)
+
+
+def _make_session(tmp_path: Path) -> Session:
+    safety = SafetyConfig(loop=LoopConfig(max_router_calls_per_turn=3))
+    session = make_session(
+        agent_name="test_cap_agent",
+        budget_tracker=BudgetTracker(CostConfig()),
+        safety=safety,
+    )
+    session.is_attached = True
+    return session
+
+
+def _drain(session: Session) -> list:
+    msgs = []
+    while not session.outbox.empty():
+        msgs.append(session.outbox.get_nowait())
+    return msgs
+
+
+def _warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno >= logging.WARNING
+        and r.name == "reyn.runtime.session"
+    ]
+
+
+def _emit(session: Session, caller) -> None:
+    asyncio.run(session._emit_router_cap_exhausted_user(
+        RouterCapExceeded(count=3, cap=3, last_reason="loop_reason"),
+        chain_id="chain-obs",
+        _llm_caller=caller,
+    ))
+
+
+def test_wrap_up_call_failure_names_the_provider_error(
+    tmp_path, monkeypatch, caplog
+):
+    """Tier 2: when the wrap-up call raises, the warning names it as a
+    call failure AND carries the provider's own exception type + message,
+    which is what distinguishes "no LLM configured/reachable" from any
+    other wrap-up failure. Without that, a misconfigured deployment looks
+    identical to a healthy one that simply hit its cap.
+    """
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    caplog.set_level(logging.WARNING, logger="reyn.runtime.session")
+
+    _emit(session, RaisingLLM(RuntimeError("LLM Provider NOT provided")))
+
+    (warning,) = _warnings(caplog)
+    assert "wrap_up_failed" in warning, warning
+    assert "RuntimeError" in warning, warning
+    assert "LLM Provider NOT provided" in warning, warning
+    assert "chain-obs" in warning, warning
+
+    # ... and the user still gets the canned reply (the degrade is
+    # logged, not turned into an error).
+    agent_msgs = [m for m in _drain(session) if m.kind == "agent"]
+    assert agent_msgs[0].text == _ROUTER_RETRY_EXHAUSTED_MSG["en"]
+
+
+def test_wrap_up_empty_is_named_distinctly_from_a_call_failure(
+    tmp_path, monkeypatch, caplog
+):
+    """Tier 2: an LLM that answers with no text is a different situation
+    from an LLM that could not be called, and the warning must say so —
+    the two used to be the same silent `pass`.
+    """
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    caplog.set_level(logging.WARNING, logger="reyn.runtime.session")
+
+    _emit(session, ScriptedLLM([LLMToolCallResult(
+        content=None, tool_calls=[], finish_reason="stop", usage=_USAGE,
+    )]))
+
+    (warning,) = _warnings(caplog)
+    assert "wrap_up_empty" in warning, warning
+    assert "wrap_up_failed" not in warning, (
+        f"an empty answer must not be reported as a call failure: {warning}"
+    )
+
+
+def test_successful_wrap_up_logs_no_degrade_warning(
+    tmp_path, monkeypatch, caplog
+):
+    """Tier 2: non-vacuity — the warning is tied to the canned fallback,
+    not emitted on every cap-exhausted turn. A warning that always fires
+    carries no information about whether the reply was degraded.
+    """
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    caplog.set_level(logging.WARNING, logger="reyn.runtime.session")
+
+    _emit(session, ScriptedLLM([text_result("wrapped up cleanly")]))
+
+    assert _warnings(caplog) == []
+    agent_msgs = [m for m in _drain(session) if m.kind == "agent"]
+    assert agent_msgs[0].text == "wrapped up cleanly"
+
+
+def test_handle_user_message_reaches_the_degrade_warning(
+    tmp_path, monkeypatch, caplog
+):
+    """Tier 2: production wiring — the warning is reachable from the real
+    entry point (``_handle_user_message`` hitting the cap), not only from
+    a direct call to the emit helper. The mechanism being correct and
+    production reaching it are separate claims; this is the second one.
+    """
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    caplog.set_level(logging.WARNING, logger="reyn.runtime.session")
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools",
+        RaisingLLM(RuntimeError("boom")),
+    )
+    monkeypatch.setattr(Session, "_reset_router_turn_counter", lambda self: None)
+    session.router_invocations_this_turn = 3
+    session._router_last_reason = "out_of_scope"
+
+    asyncio.run(session._handle_user_message("hello", chain_id="chain-wired"))
+
+    (warning,) = _warnings(caplog)
+    assert "wrap_up_failed" in warning, warning
+    assert "chain-wired" in warning, warning


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3382

## What was actually wrong

The router-cap force-close site (`session.py`, #1496 site C) states its own intent in its docstring: *"attempt a force-close wrap-up so the LLM can summarize … Falls back to the original canned error … if wrap-up fails"*. **The code matched that spec. The tests did not** — they asserted the canned string, because at the time they were written `resolve("standard")` made the wrap-up's LLM call always raise. They pinned the defect of the day, not the specification.

I confirmed the mechanism directly on this branch point rather than taking it on report. Instrumenting `_force_close_call_with_retry` and driving the real path:

```
WRAPUP RAISED: BadRequestError litellm.BadRequestError: LLM Provider NOT provided.
  Pass in the LLM provider you are trying to call. You passed model=standard
```

So the canned leg was reached here for exactly the #3368 reason, with no credentials involved — the tests were green for the wrong reason in *this* environment too, not only in CI.

## Tests — both legs, neither environment-dependent

The "CI has no API keys so we can't test this" framing was false: the signature already carried `_llm_caller: Any | None = None  # Tier 2 test seam: scripted-fake injection`. The seam was built and never used.

- **Canned leg** (4 rewritten): each now pins the LLM as unavailable rather than hoping the environment is. `test_retry_exhausted_fallback_is_english_when_output_language_is_none` uses the `_llm_caller` seam directly; the three that drive `_handle_user_message` (which has no seam parameter) pin the real `call_llm_tools` boundary with a real callable — allowed by policy, and the LLM is the one collaborator a Tier-2c test may fake.
- **Success leg** (new — `test_retry_exhausted_wrap_up_success_replaces_canned_fallback`): a scripted LLM produces text, and the assertion is that the user gets *that summary*, `limit_stopped=True`, and **no** canned error. This is the leg the file never had. Asserting one leg only reproduces the original failure — it goes green in whichever environment produces just that leg.
- `tests/test_router_cap.py::test_handle_user_message_emits_fallback_when_cap_exhausted` had the same defect and got the same treatment.
- New `RaisingLLM` in `tests/_support/router_loop.py` alongside the existing `ScriptedLLM` — a real callable, so signature drift still raises `TypeError`.

## Production — the fallback is no longer silent

Three distinct situations collapsed into one `except Exception: pass`: the wrap-up call failed, no LLM is configured/reachable, and the LLM returned no text. They are now named (`wrap_up_failed: <ExcType>: <msg>` — which is also how the no-LLM case identifies itself, via the provider's own exception type — or `wrap_up_empty`) and logged at WARNING with the `chain_id` before the canned reply is emitted.

I did **not** add a separate `model_unresolved` branch. `ModelResolver.resolve()` never raises for an unknown name — it passes through with a warning (`model_resolver.py`) — so that branch would have been unreachable by construction and untestable. The provider's exception type inside `wrap_up_failed` carries that information instead.

The `try` is also **narrowed**: it no longer wraps the success-path emission. Previously an outbox/history failure *after* a successful wrap-up was swallowed and silently produced a second, canned reply. `BaseException` is deliberately still not caught — a `CancelledError` must propagate rather than be degraded into a user-visible "budget exhausted" message (that is #3377, the next PR).

## Verification

- **Strip-falsify, anchor confirmed unique first** (`grep -c` on the message → 1). Stripped the `logger.warning` production call site → **3 of the 4 observability tests RED**. The fourth (`test_successful_wrap_up_logs_no_degrade_warning`) correctly stays green — it asserts the warning does *not* fire, which is the non-vacuity leg.
- **Second falsification**, for the leg a strip cannot reach: forced the success path off (simulating the pre-#3374 world where the wrap-up never yields text) → `test_retry_exhausted_wrap_up_success_replaces_canned_fallback`, `test_successful_wrap_up_logs_no_degrade_warning` and the pre-existing `test_router_cap_force_close_wrap_up_emits_limit_stopped` all go **RED**.
- **Mechanism vs wiring asserted separately**: `test_handle_user_message_reaches_the_degrade_warning` proves production *reaches* the warning from the real entry point, not only that the warning is correct when called directly.
- **Identity checked at measurement time**: the shared `.venv` resolves `reyn` to the **main checkout**, so every run here was made with `PYTHONPATH` pointed at this worktree and `reyn.__file__` verified immediately before measuring.

## Relationship to #3374

These four tests are the only remaining reds on **#3374**, which is parked waiting on them. #3374 did not break them — it removed the upstream defect that was holding them green.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` on all changed test files — 21 inspected, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` — OK
- [x] Full `pytest` from the repo root, read directly: **9483 passed, 36 skipped, 0 failed** (an earlier run showed 169 `textual_chat` failures — that was a stale `textual-flowview 0.3.0.dev0` in the shared venv, not a real red; re-run on the corrected venv is clean, so this is a zero-unrelated-failure baseline rather than a "pre-existing failures" waiver)
- [x] Strip-falsify of the new gate (RED confirmed), plus the second falsification above
- [x] `reyn.__file__` asserted inside this worktree before each measurement

🤖 Generated with [Claude Code](https://claude.com/claude-code)
