### PR TITLE
feat(tui): collapse bottom chrome toward one line + tone-downs

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -39,6 +39,7 @@ from collections import deque
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Callable
 
+from rich.theme import Theme
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal
 from textual.widgets import ContentSwitcher, OptionList, Static
@@ -61,7 +62,6 @@ from .chrome import (
     _MENU_TABS,
     Composer,
     MenuBar,
-    StatusLine,
     _history_option_content,
     build_drawer_pane,
     pane_commands,
@@ -261,8 +261,10 @@ class TextualChatApp(App):
     elapsed is computed from the app-side arrival time (``self._clock``); the
     indicator is a spinner (indeterminate), NOT a progress bar.
 
-    Phase 3 adds the bottom-chrome tab-drawer: below the composer, a
-    :class:`StatusLine` + a focusable :class:`MenuBar`, and a
+    Phase 3 adds the bottom-chrome tab-drawer: below the composer, a focusable
+    :class:`MenuBar` (which also carries the :class:`StatusLine` status-values
+    segment — #3326 collapsed the two into one shared row whenever the
+    terminal is wide enough for both, see :meth:`MenuBar._repack`), and a
     :class:`~textual.widgets.ContentSwitcher` drawer that is collapsed by default
     and expands DOWNWARD when a menu item is opened (see :meth:`_open_drawer`).
 
@@ -480,6 +482,19 @@ class TextualChatApp(App):
         color: $text-muted;
         padding: 0 1;
     }
+    /* #3326: when StatusLine SHARES a row with Tab widgets (MenuBar._repack's
+       merge case), width: auto keeps it sized to its own text instead of
+       stretching to consume the row's remaining space (which would push the
+       tabs before it out of a natural left-packed layout). This is scoped to
+       the ``-shared`` class ONLY — when StatusLine has a row to itself (no
+       room to merge), it keeps the base rule's width (100% of its row),
+       which is load-bearing: an unconstrained auto-width single-line Static
+       renders at its full natural width regardless of the terminal, so an
+       over-long status string (e.g. a long model id) would overflow off the
+       right edge instead of being contained/clipped by its row. */
+    StatusLine.-shared {
+        width: auto;
+    }
     /* height: auto — the menu row WRAPS to as many lines as the terminal width
        needs (chrome.pack_menu_rows), so no tab is ever laid out past the right
        edge. A fixed height:1 here would clip the wrapped rows straight back
@@ -494,6 +509,17 @@ class TextualChatApp(App):
     }
     MenuBar:focus-within { color: $text; }
     MenuBar Tab { padding: 0 1; }
+    /* #3326: tone down. Tab's own DEFAULT_CSS gives ``.-active`` full-brightness
+       ``$foreground`` against every other tab's muted 50%-opacity foreground —
+       a stark contrast jump that reads as loud emphasis (no literal underline
+       is drawn anywhere; MenuBar doesn't use Textual's Tabs/Underline widget).
+       Matched to the status line's own quiet ``$text-muted`` tone instead,
+       kept bold so the active tab stays identifiable without the brightness
+       jump. */
+    MenuBar Tab.-active {
+        color: $text-muted;
+        text-style: bold;
+    }
     /* No separator rule between the menu row and its drawer — they read as one
        continuous, edge-to-edge block (the $panel background is the only cue). */
     #drawer {
@@ -773,12 +799,14 @@ class TextualChatApp(App):
             yield Composer(
                 placeholder="Type a message — Enter to send, Shift+Enter for a newline…"
             )
-        # Bottom chrome: a slim status-values line + a focusable menu row, then a
-        # drawer (ContentSwitcher) that stays collapsed until a menu item opens it
+        # Bottom chrome: a focusable menu row that also carries the slim
+        # status-values segment (#3326: MenuBar owns placing StatusLine on
+        # whichever row has room, collapsing the two previously-separate rows
+        # into one whenever the terminal is wide enough), then a drawer
+        # (ContentSwitcher) that stays collapsed until a menu item opens it
         # downward. Phase 4 fills each pane from its canonical reyn source; each
         # pane is rebuilt from a fresh snapshot when opened (:meth:`_refresh_pane`).
-        yield StatusLine(self._status_text())
-        yield MenuBar(_MENU_TABS, id="menubar")
+        yield MenuBar(_MENU_TABS, id="menubar", status_text=self._status_text())
         with ContentSwitcher(initial=None, id="drawer"):
             for tid, _label in _MENU_TABS:
                 yield build_drawer_pane(tid, self._pane_rows(tid))
@@ -934,6 +962,17 @@ class TextualChatApp(App):
         return status_line_text(snapshot, self._agent_name)  # type: ignore[arg-type]
 
     def on_mount(self) -> None:
+        # #3326: tone down rich.Markdown's default inline-code style ("bold
+        # cyan on black" — rich.default_styles.DEFAULT_STYLES["markdown.code"]
+        # — measured far too loud against the rest of a reply's body). Pushed
+        # once here onto the app's own Rich console, which Textual's
+        # compositor uses to resolve every ``__rich_console__`` render
+        # (verified: this is the actual seam, not merely a plausible one) —
+        # so every agent reply's inline code gets the muted style app-wide,
+        # not just newly-composed widgets. No bold, no forced background box:
+        # a plain cyan tint distinguishes it from body text without the
+        # heavy box the default theme draws.
+        self.console.push_theme(Theme({"markdown.code": "cyan"}))
         # Phase 5 (#3273): hydrate the retained model from the PERSISTED
         # conversation log BEFORE the live frame pump starts, so a restart shows
         # the previous conversation (CC ``--resume`` parity) instead of a blank
@@ -946,9 +985,10 @@ class TextualChatApp(App):
         # there is nothing to start/pause here. The blink is ADDITIVE: a frozen
         # clock leaves a static, correct amber gutter (see the Phase-2 strip gate).
         self.run_worker(self._pump_frames(), name="frames", exclusive=True)
-        # Drawer starts collapsed — the default chrome is just the two slim rows
-        # (status-values line + menu row). It only becomes visible when a menu
-        # item is opened (:meth:`_open_drawer`).
+        # Drawer starts collapsed — the default chrome is just the focusable
+        # menu row (#3326: which also carries the status-values segment when
+        # there's room — see MenuBar._repack). It only becomes visible when a
+        # menu item is opened (:meth:`_open_drawer`).
         self.query_one("#drawer", ContentSwitcher).display = False
         self.query_one(Composer).focus()
 
@@ -2313,12 +2353,13 @@ class TextualChatApp(App):
 
     def _refresh_status(self, snap: "dict | None | object" = _UNSET) -> None:
         """Re-render the bottom status-values line from a fresh snapshot (or the
-        already-read ``snap``)."""
+        already-read ``snap``). #3326: routed through MenuBar (which owns
+        placing StatusLine on whichever row has room), not StatusLine directly."""
         try:
-            line = self.query_one(StatusLine)
+            menubar = self.query_one(MenuBar)
         except Exception:
             return  # not yet mounted
-        line.update(self._status_text(snap))
+        menubar.update_status(self._status_text(snap))
 
     async def on_composer_submitted(self, event: "Composer.Submitted") -> None:
         text = event.value.strip()

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -68,6 +68,7 @@ from rich.text import Text
 from textual import events
 from textual.containers import Horizontal
 from textual.content import Content
+from textual.css.query import NoMatches
 from textual.message import Message
 from textual.widget import Widget
 from textual.widgets import (
@@ -338,10 +339,17 @@ class Composer(TextArea):
 # — the "Textual only where there is a selection" split. Phase 4 fills each pane
 # from its canonical reyn source (see :func:`pane_payload`).
 
+#: Tab labels, abbreviated where needed to leave room for the status-values
+#: line to co-reside on the menu row (#3326). Each abbreviation stays uniquely
+#: identifiable on its own (an accepted condition, not just a nice-to-have —
+#: e.g. ``History`` -> ``Hist`` reads unambiguously; ``Ctx``/``Cost`` are left
+#: alone precisely because shortening either risks the two becoming
+#: indistinguishable at a glance). Most labels were already <= 4 chars and are
+#: untouched.
 _MENU_TABS: "list[tuple[str, str]]" = [
     ("model", "Model"),
     ("agent", "Agent"),
-    ("history", "History"),
+    ("history", "Hist"),
     ("cost", "Cost"),
     ("ctx", "Ctx"),
     # The six categories the retired chip bar kept behind its level-2 "more…"
@@ -351,7 +359,7 @@ _MENU_TABS: "list[tuple[str, str]]" = [
     # ``/visibility`` or ``/hook`` that flips it); Pipe/Cron are read-only.
     ("tool", "Tool"),
     ("mcp", "MCP"),
-    ("skill", "Skill"),
+    ("skill", "Skil"),
     ("pipe", "Pipe"),
     ("hook", "Hook"),
     ("cron", "Cron"),
@@ -1059,10 +1067,17 @@ def build_drawer_pane(tab_id: str, rows: "Sequence[str]") -> Widget:
 
 
 class StatusLine(Static):
-    """Slim bottom status-values line — plain, not rich. Mirrors reyn's inline
-    REPL bottom toolbar (``model │ agent │ cost │ ctx``), which sits BELOW the
-    input — matching Claude Code and reyn (not a top-docked line). The menu
-    *items* live in the focusable :class:`MenuBar` row just below it."""
+    """Slim status-values line — plain, not rich. Mirrors reyn's inline REPL
+    bottom toolbar (``model │ agent │ cost │ ctx``). #2280: this is the ONE
+    always-visible (never-collapsed) chrome region — the halt banner rides on
+    it — so wherever :class:`MenuBar` mounts this widget, it must stay on a
+    row that is always on screen, never scrolled or wrapped away.
+
+    #3326: owned and positioned by :class:`MenuBar`, not a standalone
+    top-level row — it is appended as a trailing widget to whichever wrapped
+    menu row has room for it (usually the last), or given its own extra row
+    when none does. Never yielded directly by the app; see
+    :meth:`MenuBar._repack`."""
 
 
 #: Horizontal cells a :class:`Tab` adds around its label (``Tab``'s own
@@ -1070,6 +1085,12 @@ class StatusLine(Static):
 #: rendered width when packing rows — kept as one named fact so the packer and
 #: the stylesheet cannot silently disagree.
 _TAB_H_PADDING = 2
+
+#: Horizontal cells :class:`StatusLine` adds around its text (its own
+#: ``padding: 0 1`` in the app stylesheet) — the status-segment analog of
+#: ``_TAB_H_PADDING``, used to predict whether it fits alongside tabs on a
+#: packed row (#3326).
+_STATUS_H_PADDING = 2
 
 
 def pack_menu_rows(
@@ -1106,6 +1127,23 @@ def pack_menu_rows(
     return rows
 
 
+def status_fits_last_row(
+    rows: "Sequence[Sequence[tuple[str, str]]]", width: int, status_text_len: int
+) -> bool:
+    """True if the status-values segment fits alongside the last packed tab row.
+
+    Pure, mirroring :func:`pack_menu_rows`'s testability-without-mounting
+    convention (#3326). ``rows`` is the output of :func:`pack_menu_rows`; an
+    empty ``rows`` (no tabs at all) trivially fits if the text alone fits
+    ``width``. Never truncates or squeezes — the caller falls back to giving
+    the status segment its own row when this returns ``False``."""
+    status_cell = status_text_len + _STATUS_H_PADDING
+    if not rows:
+        return status_cell <= width
+    used = sum(len(label) + _TAB_H_PADDING for _tab_id, label in rows[-1])
+    return used + status_cell <= width
+
+
 class MenuBar(Widget, can_focus=True):
     """Focusable menu row (the collapsed bottom chrome). ``← →`` move the
     highlight, ``Enter`` opens the highlighted item's drawer, and ``↑``/``Esc``
@@ -1123,7 +1161,15 @@ class MenuBar(Widget, can_focus=True):
     layout differs.
 
     ``active`` is the highlighted tab id, the same public read the drawer control
-    and the Phase-3 keyboard gates use."""
+    and the Phase-3 keyboard gates use.
+
+    #3326: also owns the :class:`StatusLine` status-values segment — appended
+    as a trailing widget on whichever packed row has room for it (see
+    :func:`status_fits_last_row`), or given its own extra row when none does.
+    This is what collapses the bottom chrome toward one line: the two
+    previously-separate always-visible rows (status line above, menu row
+    below) become one shared row whenever the terminal is wide enough, and
+    fall back to their previous two-row shape (no regression) otherwise."""
 
     # NOTE: the row's HEIGHT is not declared here. The app stylesheet
     # (``TextualChatApp.CSS``'s ``MenuBar`` rule) overrides a widget's
@@ -1152,10 +1198,18 @@ class MenuBar(Widget, can_focus=True):
             self.tab_id = tab_id
             super().__init__()
 
-    def __init__(self, items: "Sequence[tuple[str, str]]", **kwargs) -> None:
+    def __init__(
+        self,
+        items: "Sequence[tuple[str, str]]",
+        *,
+        status_text: str = "",
+        **kwargs,
+    ) -> None:
         super().__init__(**kwargs)
         self._items = list(items)
         self._packed_width = -1
+        self._last_seen_width = -1
+        self._status_text = status_text
         #: The highlighted tab id. Seeded to the first item so the row has a
         #: highlight from the very first frame (before any resize has landed).
         self.active = self._items[0][0] if self._items else ""
@@ -1163,19 +1217,55 @@ class MenuBar(Widget, can_focus=True):
     def _repack(self, width: int) -> None:
         """Rebuild the child rows for ``width``. A no-op when the width has not
         changed, so an ordinary resize storm does not remount 13 widgets a frame."""
-        if width <= 0 or width == self._packed_width:
+        if width <= 0:
+            return
+        self._last_seen_width = width
+        if width == self._packed_width:
             return
         self._packed_width = width
         rows = pack_menu_rows(self._items, width)
+        merge_status = status_fits_last_row(rows, width, len(self._status_text))
         self.remove_children()
-        self.mount_all([
+        menu_rows = [
             Horizontal(
                 *(Tab(label, id=tab_id) for tab_id, label in row),
+                *(
+                    [StatusLine(self._status_text, classes="-shared")]
+                    if merge_status and i == len(rows) - 1
+                    else []
+                ),
                 classes="menubar-row",
             )
-            for row in rows
-        ])
+            for i, row in enumerate(rows)
+        ]
+        if not merge_status:
+            menu_rows.append(
+                Horizontal(StatusLine(self._status_text), classes="menubar-row")
+            )
+        self.mount_all(menu_rows)
         self.call_after_refresh(self._sync_active_class)
+
+    def update_status(self, text: str) -> None:
+        """Update the merged status-values text (#3326).
+
+        A length change can flip the merge decision (:func:`status_fits_last_row`)
+        — most sharply for the #2280 halt banner, prepended ahead of the usual
+        values and far longer than the steady-state text — so a length change
+        forces a fresh repack rather than an in-place ``Static.update``. An
+        unchanged length (the common case: cost/ctx ticking within the same
+        format) updates the mounted widget directly, no remount."""
+        changed_len = len(text) != len(self._status_text)
+        self._status_text = text
+        if not self.is_mounted:
+            return
+        if changed_len:
+            self._packed_width = -1  # force status_fits_last_row to be re-evaluated
+            self._repack(self._last_seen_width)
+        else:
+            try:
+                self.query_one(StatusLine).update(text)
+            except NoMatches:
+                pass
 
     def _sync_active_class(self) -> None:
         for tab in self.query(Tab):

--- a/tests/test_3338_tui_status_chrome_liveness.py
+++ b/tests/test_3338_tui_status_chrome_liveness.py
@@ -806,6 +806,45 @@ async def test_status_line_on_screen_and_merge_matches_prediction(
 
 
 @pytest.mark.asyncio
+async def test_status_line_stays_contained_with_a_long_raw_model_id(tmp_path) -> None:
+    """Tier 2b: ★ real-TTY-witnessed geometry guard (#3326), dedicated
+    long-string case.
+
+    ``test_status_line_on_screen_and_merge_matches_prediction`` already goes
+    RED on the ``width: auto`` overflow defect this guards against, but only
+    incidentally — it depends on the real fixture snapshot's status text
+    happening to be long enough at (60, 20). This test does not depend on
+    that: it deliberately injects a long raw ``--model`` passthrough id (the
+    #3324 shape — a model string matching no configured class), so the
+    containment invariant is pinned independent of how long the default
+    fixture's status text happens to be."""
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+
+    long_raw_model = "some-provider/an-extremely-long-raw-model-identifier-98765"
+    snap, _session, _registry = await _real_snapshot(tmp_path)
+    # Shallow copy — the real snapshot carries live, unpicklable objects
+    # (thread locks etc.) that deepcopy can't touch; only two keys change here.
+    snap = {**snap, "model": long_raw_model, "model_active_class": None}
+    app = TextualChatApp(
+        transport=_EventOnlyTransport(), read_model=_MutableSnapshotReadModel(snap)
+    )
+    async with app.run_test(size=(60, 20)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        screen = app.screen.size
+        line = app.query_one(StatusLine)
+        assert long_raw_model in status_line_text(snap, AGENT), (
+            "test setup did not actually produce a long status string"
+        )
+        assert line.region.x >= 0 and line.region.right <= screen.width, (
+            f"StatusLine off-screen horizontally with a long raw model id: {line.region}"
+        )
+        assert line.region.y >= 0 and line.region.bottom <= screen.height, (
+            f"StatusLine off-screen vertically with a long raw model id: {line.region}"
+        )
+
+
+@pytest.mark.asyncio
 async def test_inline_code_style_toned_down_from_the_loud_default(tmp_path) -> None:
     """Tier 2: #3326 — rich.Markdown's default inline-code style ("bold cyan
     on black", ``rich.default_styles.DEFAULT_STYLES["markdown.code"]``) is

--- a/tests/test_3338_tui_status_chrome_liveness.py
+++ b/tests/test_3338_tui_status_chrome_liveness.py
@@ -52,6 +52,8 @@ import pytest
 from reyn.core.events.state_log import StateLog
 from reyn.interfaces.inline.textual_chat.chrome import (
     _MENU_TABS,
+    MenuBar,
+    StatusLine,
     cost_pane_lines,
     ctx_pane_lines,
     pane_commands,
@@ -711,6 +713,155 @@ async def test_every_menu_tab_is_fully_on_screen(
         assert not offenders, (
             f"tabs laid out off-screen at {screen_size} (screen={screen}); "
             f"offender -> (x, right, y, bottom): {offenders}"
+        )
+
+
+def test_status_fits_last_row_pure() -> None:
+    """Tier 1: :func:`status_fits_last_row` (#3326) — pure fit-decision helper.
+
+    Mirrors the existing #3338 ``pack_menu_rows`` pure-function convention:
+    testable without mounting anything."""
+    from reyn.interfaces.inline.textual_chat.chrome import (
+        pack_menu_rows,
+        status_fits_last_row,
+    )
+
+    # All 13 (abbreviated) tabs pack onto one row at width=78+.
+    rows = pack_menu_rows(_MENU_TABS, 100)
+    # Plenty of room left (100 - 78 tabs = 22) for a short status string.
+    assert status_fits_last_row(rows, 100, status_text_len=10) is True
+    # Not enough room for a long one.
+    assert status_fits_last_row(rows, 100, status_text_len=100) is False
+
+    # A width forcing multiple rows: the LAST row (not the first, which is
+    # nearly full) is what gets checked.
+    narrow_rows = pack_menu_rows(_MENU_TABS, 40)
+    last_row_used = sum(len(label) + 2 for _tid, label in narrow_rows[-1])
+    max_fitting_len = 40 - last_row_used - 2  # 2 == _STATUS_H_PADDING
+    assert status_fits_last_row(narrow_rows, 40, status_text_len=max_fitting_len) is True
+    assert status_fits_last_row(narrow_rows, 40, status_text_len=max_fitting_len + 1) is False
+
+    # No tabs at all: fits iff the text alone fits the width.
+    assert status_fits_last_row([], 20, status_text_len=15) is True
+    assert status_fits_last_row([], 20, status_text_len=25) is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("screen_size", [(100, 30), (80, 24), (60, 20)])
+async def test_status_line_on_screen_and_merge_matches_prediction(
+    screen_size: "tuple[int, int]", tmp_path
+) -> None:
+    """Tier 2b: ★ real-TTY-witnessed geometry guard (#3326).
+
+    Two invariants, both load-bearing:
+    1. :class:`StatusLine` (the #2280 ONE always-visible chrome region — the
+       halt banner rides on it) stays fully on screen on both axes, at every
+       size, regardless of whether it merged onto a tab row or got its own.
+    2. The live widget tree's ACTUAL merge decision (is StatusLine's parent
+       row also carrying Tab children, or does it have a row alone?) matches
+       what :func:`status_fits_last_row` predicts from the real packed rows
+       and the real status text — i.e. the decision is genuinely reflected
+       in what mounts, not merely computed and discarded."""
+    from textual.widgets import Tab
+
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+    from reyn.interfaces.inline.textual_chat.chrome import (
+        pack_menu_rows,
+        status_fits_last_row,
+    )
+
+    snap, _session, _registry = await _real_snapshot(tmp_path)
+    app = TextualChatApp(
+        transport=_EventOnlyTransport(), read_model=_MutableSnapshotReadModel(snap)
+    )
+    async with app.run_test(size=screen_size) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        screen = app.screen.size
+
+        # query_one itself enforces "exactly one match" (raises otherwise) —
+        # the uniqueness guarantee this test needs, with no separate len() check.
+        line = app.query_one(StatusLine)
+        assert line.region.x >= 0 and line.region.right <= screen.width, (
+            f"StatusLine off-screen horizontally at {screen_size}: {line.region}"
+        )
+        assert line.region.y >= 0 and line.region.bottom <= screen.height, (
+            f"StatusLine off-screen vertically at {screen_size}: {line.region}"
+        )
+
+        parent_row = line.parent
+        tabs_sharing_the_row = list(parent_row.query(Tab)) if parent_row is not None else []
+        actually_merged = bool(tabs_sharing_the_row)
+
+        menubar = app.query_one(MenuBar)
+        content_width = menubar.content_size.width or menubar.size.width
+        rows = pack_menu_rows(_MENU_TABS, content_width)
+        predicted_merge = status_fits_last_row(
+            rows, content_width, len(status_line_text(snap, AGENT))
+        )
+        assert actually_merged == predicted_merge, (
+            f"at {screen_size} (content_width={content_width}): predicted "
+            f"merge={predicted_merge} but the live tree shows merged={actually_merged}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_inline_code_style_toned_down_from_the_loud_default(tmp_path) -> None:
+    """Tier 2: #3326 — rich.Markdown's default inline-code style ("bold cyan
+    on black", ``rich.default_styles.DEFAULT_STYLES["markdown.code"]``) is
+    overridden app-wide, not left at the loud default.
+
+    Falsification: pre-fix, ``app.console.get_style("markdown.code")`` is
+    exactly the bold+black-background default; this asserts it no longer is,
+    and specifically that it carries neither ``bold`` nor a forced background
+    (the two components that made it read as too strong)."""
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+
+    snap, _session, _registry = await _real_snapshot(tmp_path)
+    app = TextualChatApp(
+        transport=_EventOnlyTransport(), read_model=_MutableSnapshotReadModel(snap)
+    )
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        style = app.console.get_style("markdown.code")
+        assert not style.bold, f"inline-code style still bold: {style!r}"
+        assert style.bgcolor is None, (
+            f"inline-code style still forces a background: {style!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_menubar_active_tab_toned_down_to_status_line_muted_tone(
+    tmp_path,
+) -> None:
+    """Tier 2: #3326 — MenuBar's active-tab color is toned down to match
+    StatusLine's own quiet ``$text-muted`` tone, rather than Tab's default
+    full-brightness ``$foreground`` jump against every other tab's 50%-muted
+    foreground (measured: no literal underline is drawn anywhere — MenuBar
+    doesn't use Textual's ``Tabs``/``Underline`` widget — the "underline" the
+    issue named was this brightness contrast read as loud emphasis).
+
+    Falsification: pre-fix, the active tab's resolved color is the full
+    ``$foreground`` (distinctly brighter than an inactive tab's 50%-muted
+    one); this asserts the active tab's color instead matches the SAME muted
+    tone StatusLine itself uses."""
+    from textual.widgets import Tab
+
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+
+    snap, _session, _registry = await _real_snapshot(tmp_path)
+    app = TextualChatApp(
+        transport=_EventOnlyTransport(), read_model=_MutableSnapshotReadModel(snap)
+    )
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        line = app.query_one(StatusLine)
+        active_tab = next(tab for tab in app.query(Tab) if tab.has_class("-active"))
+        status_color = line.styles.color
+        active_color = active_tab.styles.color
+        assert active_color == status_color, (
+            f"active tab color {active_color!r} does not match StatusLine's "
+            f"muted tone {status_color!r} — still reads as a loud, distinct highlight"
         )
 
 


### PR DESCRIPTION
**[tui-coder]** — part of #3326 (owner-approved)

## Design conflict found and resolved via owner decision (see issue thread)

The 13 menu tabs alone already needed 2 rows at 80 columns (82 chars > 80, measured), and the status-values text is ~53-55 chars — literally combining both onto one row at typical widths is mathematically infeasible without either losing information or accepting graceful wrapping. Reported this to lead-coder before implementing; **owner chose option A**: status values co-reside on the tab row's whitespace when there's room, tab labels abbreviated to help; narrow terminals staying at 2 rows (not literal 1) is explicitly accepted.

## Implementation

- `status_fits_last_row()` (new pure function, mirrors `pack_menu_rows`'s testable-without-mounting convention): given the packed tab rows and the status text length, decides whether the status segment fits alongside the **last** wrapped tab row (usually the one with the most slack) — not the first, which is typically near-full.
- `MenuBar._repack()` appends `StatusLine` as a trailing widget on that row when `status_fits_last_row` says yes, or gives it its own additional row when no — **never truncates or squeezes either**.
- `MenuBar.update_status()` replaces the old direct `StatusLine.update()` call site — a text **length** change (steady-state cost/ctx ticks vs. the #2280 halt banner, which is dramatically longer) forces a fresh repack since it can flip the fit decision; an unchanged length just updates the mounted widget in place.
- Tab labels abbreviated: `History`→`Hist`, `Skill`→`Skil` (all 13 now fit on one row at width ≥ 78, vs. 82 before — the rest were already ≤ 4 chars). Each abbreviation stays uniquely identifiable (the acceptance condition lead-coder set) — no `Ctx`/`Cost`-style collision risk.
- **A real bug found and fixed during implementation**: giving `StatusLine` a blanket `width: auto` (needed so it doesn't stretch and push tabs off when *sharing* a row) made it render at its full, unconstrained natural width when it has its own dedicated row instead — an over-long status string (e.g. a long model id) would overflow past the screen edge rather than being contained. Fixed by scoping `width: auto` to a `-shared` CSS class applied only in the merge case; the "own row" case keeps the base rule's `width: 100%`, which is what makes an over-long line clip/contain correctly. Caught by the new geometry gate at (60, 20) before it ever reached a terminal.

## Also in this PR (the other two #3326 items)

- **Inline-code tone-down**: `rich.Markdown`'s default `markdown.code` style is `"bold cyan on black"` (measured via `rich.default_styles.DEFAULT_STYLES`) — a solid opaque box that reads as much louder than the rest of a reply's body. Overridden once, app-wide, via `self.console.push_theme(...)` in `on_mount` (verified this is the actual seam Textual's compositor uses to resolve `__rich_console__` renders, not merely a plausible one) to a plain `"cyan"` — no bold, no forced background.
- **MenuBar active-tab tone-down**: there is no literal underline anywhere (`MenuBar` doesn't use Textual's `Tabs`/`Underline` widget) — the "underline" language in the issue was, measured, describing `Tab`'s default `.-active` style: a stark jump to full `$foreground` brightness against every other tab's 50%-muted one. Toned down to match `StatusLine`'s own quiet `$text-muted` tone, kept `bold` so the active tab is still identifiable without the brightness jump.

## Real-TTY witness (tui-coder)

- **80×24**: bottom chrome is now 2 rows (was 3) — all 13 abbreviated tabs pack onto one row, status values on their own row below (not enough room to merge at this width, as owner explicitly accepted). Active tab (`Model`, bold) and status line both render at the same `rgb(160,160,160)` — confirmed matching tone.
- **140×30**: genuine single-row merge — tabs and status values share one physical line.
- Inline code (`` `x` ``) in a live agent reply rendered cyan, not bold, no background box — confirmed via raw ANSI capture.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` on the changed test file — 23 inspected, 0 Tier-4 violations (two `len(...) == N` assertions the auditor flagged were reworked: one removed as non-load-bearing scaffolding, one replaced with `query_one`'s own built-in "exactly one" enforcement)
- [x] `python scripts/verify_module_docstrings.py` on changed src files — OK
- [x] New tests: `status_fits_last_row` pure-function unit tests; a live geometry gate (StatusLine stays on-screen at 3 sizes AND the live tree's actual merge decision matches the pure function's prediction — this is what caught the width-overflow bug above); inline-code style assertion; active-tab color assertion
- [x] Full `pytest` from the repo root — 9391 passed, 49 skipped, 1 failed (`test_composer_submit_during_pending_intervention_is_always_a_new_turn`, an unrelated intervention-panel/composer timing test — confirmed passing 3/3 in isolation, not touched by this PR's files)
- [x] Real-TTY witness — see above