### PR TITLE
fix(runtime): keep the run-loop alive across a turn-scoped cancel, and never end it silently

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5523,24 +5523,54 @@ class Session:
                 try:
                     await self._turn_owner_task
                 except asyncio.CancelledError:
-                    if self._turn_cancel_self_initiated:
-                        # #2242 WAL-invariant 1: CancelledError unwound the
-                        # turn-body task straight out of whatever await it was
-                        # suspended on (mid-generation: the LLM await) — every
-                        # statement AFTER that await (parsing the response,
-                        # appending it to history, any further tool iteration)
-                        # never executes, so the cancelled turn's result is
-                        # never appended. Swallow here (do NOT re-raise) so the
-                        # driver task — and thus the agent — survives to serve
-                        # the next turn; only the per-turn sub-task was cancelled.
-                        _cancelled = True
-                    else:
-                        # Not our own cancel_inflight() call — this driver task
-                        # itself was cancelled from outside (e.g. an anyio scope
-                        # teardown for the MCP/A2A request-handler task pumping
-                        # run_one_iteration directly, FP-0013 §ADR-A). Preserve
-                        # the pre-#2242 behaviour: let it propagate.
+                    # #3377: the question here is WHOSE cancellation this is,
+                    # and the authoritative answer is not a flag — it is
+                    # whether THIS (the driver) task is itself being
+                    # cancelled. ``Task.cancelling() > 0`` is true only when
+                    # ``cancel()`` was called on the current task, which is
+                    # exactly the FP-0013 §ADR-A case (an anyio scope teardown
+                    # cancelling the MCP/A2A request-handler task that pumps
+                    # ``run_one_iteration``). The same discriminator is already
+                    # used by ``reyn.mcp.pool.is_real_control_flow`` and
+                    # ``reyn.core.cancellable.race_cancellable``.
+                    #
+                    # Before #3377 this branched on ``_turn_cancel_self_initiated``
+                    # alone, which conflates two very different things: a
+                    # cancel aimed at THIS task, and a cancel aimed at the
+                    # per-turn SUB-task by anyone who did not go through
+                    # ``cancel_inflight()`` (Ctrl-C plumbed to the turn, a
+                    # timeout, a stop-world operation, whatever is added
+                    # next — #3369 fixed one such source, not the class).
+                    # The second re-raised, which ended the while-loop in
+                    # ``run()``: the inbox kept being PUT to and was never
+                    # CONSUMED again, with no error log, indistinguishable
+                    # from a permanent hang.
+                    _driver = asyncio.current_task()
+                    if _driver is not None and _driver.cancelling() > 0:
+                        # A cancel genuinely directed at this task = a real
+                        # shutdown. It must still stop the loop; structured
+                        # concurrency requires the cancelled task to end.
                         raise
+                    # Only the per-turn sub-task was cancelled. #2242
+                    # WAL-invariant 1 holds either way: CancelledError unwound
+                    # the turn-body task straight out of whatever await it was
+                    # suspended on (mid-generation: the LLM await), so every
+                    # statement after that await never executes and the
+                    # cancelled turn's result is never appended. Swallow (do
+                    # NOT re-raise) so the driver task — and thus the agent —
+                    # survives to serve the next turn.
+                    if not self._turn_cancel_self_initiated:
+                        # #3377: a turn-scoped cancel we did not initiate is
+                        # survivable but NOT expected — record it, so this
+                        # never again presents as an unexplained silent stall.
+                        logger.warning(
+                            "turn sub-task for kind=%s chain_id=%s was cancelled by "
+                            "something other than cancel_inflight(); the turn is "
+                            "abandoned but the run-loop survives to serve the next "
+                            "message.",
+                            kind, payload.get("chain_id"),
+                        )
+                    _cancelled = True
             finally:
                 # #2242 Finding 1: reset the self-initiated flag UNCONDITIONALLY
                 # here (not only on the swallow branch). If cancel_inflight() set
@@ -5714,6 +5744,29 @@ class Session:
         try:
             while await self.run_one_iteration():
                 pass
+        except asyncio.CancelledError:
+            # #3377: the run-loop may legitimately be stopped by a cancel
+            # (a real shutdown), but it must never stop SILENTLY. Without
+            # this, a cancelled loop emitted exactly the same
+            # ``chat_stopped`` / ``session_completed`` pair as a clean
+            # shutdown, so "the agent stopped consuming its inbox" was
+            # indistinguishable from "the agent finished" — while the
+            # inbox kept accepting puts nobody would ever read. Reuses the
+            # #2280 ``session_halted`` surface (already on the transport
+            # forward-allowlist and rendered by both the TUI status line
+            # and the plain-CUI bottom toolbar) rather than inventing a
+            # parallel signal. Guarded on ``_halted_reason is None`` for
+            # the same reason #2280's own emits are: at most one halt
+            # notice per session.
+            if self._halted_reason is None:
+                self._halted_reason = "cancelled"
+                self._chat_events.emit("session_halted", reason=self._halted_reason)
+            logger.warning(
+                "Session.run() for agent '%s' is ending because it was cancelled — "
+                "the run-loop stops here and its inbox will not be consumed again.",
+                self.agent_name,
+            )
+            raise
         finally:
             try:
                 await self._drain_on_shutdown()

--- a/tests/test_3377_run_loop_survives_turn_cancel.py
+++ b/tests/test_3377_run_loop_survives_turn_cancel.py
@@ -1,0 +1,235 @@
+"""Tier 2: #3377 — Session.run() must not die silently on an escaping cancel.
+
+``CancelledError`` is a ``BaseException``, so no ``except Exception`` on the
+path catches it. Before this, a cancel delivered to the per-turn sub-task by
+anyone who did not go through ``cancel_inflight()`` was re-raised out of
+``run_one_iteration`` and ended ``run()``'s while-loop. The resulting failure
+has a distinctive shape and no diagnostic: the inbox keeps being **put** to and
+is never **consumed** again, nothing is waiting because no one is left to wait,
+and no error is logged.
+
+#3369 closed ONE source (``checkout`` cancelling its own turn). This file pins
+the **property** instead, because other routes to that cancel exist (Ctrl-C,
+timeouts, other stop-world operations, whatever is added next):
+
+- a cancel aimed at ONE TURN must not kill the loop, and must leave a record;
+- a cancel aimed at THE SESSION (a real shutdown) must still stop the loop,
+  and must also leave a record.
+
+The witness is deliberately taken at an INTERMEDIATE cross-section — a second
+message is put and must be *consumed* — because a terminal-state assertion
+cannot tell a surviving loop from a dead one that happened to finish its work.
+The cancel is delivered through the real mechanism (``Task.cancel()``, the same
+call ``cancel_inflight`` makes), not by raising ``CancelledError`` inside the
+test, which would prove nothing about a path that never catches it.
+
+Real ``Session`` / ``StateLog`` (no mocks). The only replaced collaborator is
+``RouterLoopDriver.run_turn``, method-assigned as a real async function — the
+same controllable-hang seam ``tests/test_2242_hard_cancel.py`` uses.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+AGENT = "cancel-survival-agent"
+
+
+def _make_session(tmp_path: Path) -> tuple[Session, StateLog]:
+    state_log = StateLog(tmp_path / "state.wal")
+    session = make_session(
+        agent_name=AGENT,
+        state_log=state_log,
+        snapshot_path=tmp_path / "snapshot.json",
+    )
+    return session, state_log
+
+
+def _install_hanging_first_turn(
+    session: Session,
+) -> tuple[asyncio.Event, asyncio.Event, list[str]]:
+    """First turn hangs at a real await point; later turns return at once.
+
+    ``started`` fires as the first turn suspends (where a real turn would be
+    inside its ``litellm.acompletion`` await); ``release`` is the test's gate.
+    ``seen`` records every chain_id the run-loop actually dispatched — the
+    consumed-side witness.
+    """
+    started = asyncio.Event()
+    release = asyncio.Event()
+    seen: list[str] = []
+
+    async def _run_turn(user_text: str, chain_id: str) -> None:
+        seen.append(chain_id)
+        if len(seen) == 1:
+            started.set()
+            await release.wait()
+
+    session._loop_driver.run_turn = _run_turn  # type: ignore[method-assign]
+    return started, release, seen
+
+
+async def _wait_for(predicate, *, attempts: int = 250, delay: float = 0.02) -> None:
+    for _ in range(attempts):
+        if predicate():
+            return
+        await asyncio.sleep(delay)
+
+
+def _warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno >= logging.WARNING and r.name == "reyn.runtime.session"
+    ]
+
+
+async def _stop(session: Session, run_task: asyncio.Task) -> None:
+    await session.shutdown()
+    try:
+        await asyncio.wait_for(run_task, timeout=2.0)
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        run_task.cancel()
+        await asyncio.gather(run_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_turn_scoped_cancel_leaves_the_run_loop_consuming(tmp_path):
+    """Tier 2: #3377 — a cancel delivered to the per-turn sub-task by
+    something other than ``cancel_inflight()`` abandons that turn but must
+    NOT end the run-loop.
+
+    The witness is the signature the bug produces: a message is PUT and then
+    never CONSUMED. Here the second message must be consumed (its turn
+    actually dispatched, the inbox actually drained) — asserting only that
+    the run task is still alive would not distinguish a loop that is
+    consuming from one parked forever on a dead path.
+    """
+    session, state_log = _make_session(tmp_path)
+    started, release, seen = _install_hanging_first_turn(session)
+    run_task = asyncio.create_task(session.run())
+    try:
+        await session._put_inbox("user", {"text": "one", "chain_id": "c-first"})
+        await asyncio.wait_for(started.wait(), timeout=5)
+
+        # The real delivery mechanism, NOT via cancel_inflight(): this is the
+        # shape a Ctrl-C / timeout / stop-world operation produces.
+        session._turn_owner_task.cancel()
+
+        # THE WITNESS: put, and require that it is consumed.
+        await session._put_inbox("user", {"text": "two", "chain_id": "c-second"})
+        await _wait_for(lambda: "c-second" in seen)
+        assert "c-second" in seen, (
+            "the second message was PUT but never CONSUMED — the run-loop died "
+            "on a cancel aimed at a single turn"
+        )
+        assert session.inbox.empty(), "the inbox was not drained"
+        assert not run_task.done(), "run() ended on a turn-scoped cancel"
+    finally:
+        release.set()
+        await _stop(session, run_task)
+        await state_log.aclose()
+
+
+@pytest.mark.asyncio
+async def test_turn_scoped_cancel_of_unknown_origin_is_recorded(tmp_path, caplog):
+    """Tier 2: #3377 — surviving is not enough; a turn killed by a cancel we
+    did not initiate must leave a record naming the turn, so this can never
+    again present as an unexplained stall with nothing in the log.
+    """
+    caplog.set_level(logging.WARNING, logger="reyn.runtime.session")
+    session, state_log = _make_session(tmp_path)
+    started, release, _seen = _install_hanging_first_turn(session)
+    run_task = asyncio.create_task(session.run())
+    try:
+        await session._put_inbox("user", {"text": "one", "chain_id": "c-orphan"})
+        await asyncio.wait_for(started.wait(), timeout=5)
+        session._turn_owner_task.cancel()
+        await _wait_for(lambda: any("c-orphan" in m for m in _warnings(caplog)))
+
+        (warning,) = [m for m in _warnings(caplog) if "c-orphan" in m]
+        assert "cancel_inflight" in warning, warning
+        assert "run-loop survives" in warning, warning
+    finally:
+        release.set()
+        await _stop(session, run_task)
+        await state_log.aclose()
+
+
+@pytest.mark.asyncio
+async def test_self_initiated_cancel_stays_quiet(tmp_path, caplog):
+    """Tier 2: #3377 non-vacuity — ``cancel_inflight()`` is the EXPECTED way
+    to abandon a turn (the user pressed cancel), so it must keep surviving
+    silently. A warning that fires on every cancel would say nothing about
+    whether the cancel had a known origin.
+    """
+    caplog.set_level(logging.WARNING, logger="reyn.runtime.session")
+    session, state_log = _make_session(tmp_path)
+    started, release, seen = _install_hanging_first_turn(session)
+    run_task = asyncio.create_task(session.run())
+    try:
+        await session._put_inbox("user", {"text": "one", "chain_id": "c-user-cancel"})
+        await asyncio.wait_for(started.wait(), timeout=5)
+
+        await session.cancel_inflight()
+
+        await session._put_inbox("user", {"text": "two", "chain_id": "c-after"})
+        await _wait_for(lambda: "c-after" in seen)
+        assert "c-after" in seen, "the loop must survive its own cancel too"
+        assert [m for m in _warnings(caplog) if "c-user-cancel" in m] == [], (
+            "a user-initiated turn cancel must not be reported as unexplained"
+        )
+    finally:
+        release.set()
+        await _stop(session, run_task)
+        await state_log.aclose()
+
+
+@pytest.mark.asyncio
+async def test_cancelling_the_session_still_stops_the_loop_and_records_it(
+    tmp_path, caplog
+):
+    """Tier 2: #3377 — the other half of the design constraint. A cancel
+    genuinely directed at the session (a real shutdown) must still end the
+    loop; making turn-scoped cancels survivable must not make the session
+    un-stoppable.
+
+    And that ending must be legible: ``chat_stopped`` / ``session_completed``
+    fire identically on a clean exit, so on their own they cannot say the
+    loop was cancelled. ``session_halted`` (the #2280 surface both the TUI
+    status line and the plain-CUI toolbar already render) carries that.
+    """
+    caplog.set_level(logging.WARNING, logger="reyn.runtime.session")
+    session, state_log = _make_session(tmp_path)
+    _started, release, seen = _install_hanging_first_turn(session)
+    run_task = asyncio.create_task(session.run())
+    try:
+        # Drive one full turn first, so the cancel below is delivered to a
+        # loop that is demonstrably INSIDE its while — cancelling during
+        # run()'s start-up would exercise a different path.
+        release.set()
+        await session._put_inbox("user", {"text": "one", "chain_id": "c-warmup"})
+        await _wait_for(lambda: "c-warmup" in seen and session.inbox.empty())
+        assert "c-warmup" in seen, "the loop never reached its idle inbox wait"
+        assert session.halted_reason is None
+
+        run_task.cancel()
+        await asyncio.gather(run_task, return_exceptions=True)
+
+        assert run_task.done(), "a cancel aimed at the session must stop the loop"
+        assert session.halted_reason == "cancelled", (
+            f"the loop ended without a halt record; got {session.halted_reason!r}"
+        )
+        halted = [e for e in session._chat_events.all() if e.type == "session_halted"]
+        (halt_event,) = halted
+        assert halt_event.data.get("reason") == "cancelled"
+        assert any("cancelled" in m for m in _warnings(caplog))
+    finally:
+        await state_log.aclose()


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3377

## ⚠️ Read this first: what this PR does NOT claim

**The owner-reported ~5.5-minute freeze is not attributed to this mechanism, and this PR does not close that report.** #3369 never reproduced the freeze itself; that it is *this* mechanism is an inference from a matching signature, not a measurement. Settling it needs a stack capture on the reporter's machine (`-X faulthandler` + `kill -ABRT`).

What this PR fixes is the **property**: the run-loop does not survive a cancellation, and it dies without saying so. That is worth fixing whether or not it is the freeze.

## The property, reproduced

`CancelledError` is a `BaseException`, so nothing on the path catches it. I ran the real `Session.run()` and delivered a cancel to the per-turn sub-task through the real mechanism (`Task.cancel()`), *not* via `cancel_inflight()` — the shape a Ctrl-C, a timeout, or any other stop-world operation produces:

```
run_task done after cancel? True
  exception: CANCELLED
second message consumed? False | inbox empty? False
halted_reason: None
```

That is the reported signature exactly: **put to, never consumed again**, nothing waiting because no one is left to wait, and no error log.

The same probe with `cancel_inflight()` instead:

```
run_task done after cancel? False
second message consumed? True | inbox empty? True
```

So the asymmetry is real: *our own* turn cancel is survivable today, *anyone else's* is fatal. #3369 closed one source of "anyone else"; the class remains.

After the fix, the foreign-cancel probe reads:

```
turn sub-task for kind=user chain_id=c1 was cancelled by something other than
cancel_inflight(); the turn is abandoned but the run-loop survives ...
run_task done after cancel? False
second message consumed? True | inbox empty? True
```

## The fix

**1. A better discriminator.** The `except` branched on `_turn_cancel_self_initiated` alone, which conflates two different things: a cancel aimed at **this** (the driver) task, and a cancel aimed at the per-turn **sub-task** by a third party. Only the first is a real shutdown. The authoritative test is `asyncio.current_task().cancelling() > 0` — true only when `cancel()` was called on the current task — which is already this repo's idiom in `reyn.mcp.pool.is_real_control_flow` and `reyn.core.cancellable.race_cancellable`. I used it inline rather than importing from `reyn.mcp` (runtime → mcp would be a new cross-layer dependency).

This satisfies both halves of the design constraint:

| cancel aimed at | before | after |
|---|---|---|
| the session / driver task (real shutdown, FP-0013 §ADR-A anyio teardown) | propagates | **propagates — unchanged** |
| one turn, via `cancel_inflight()` | swallowed, loop survives | unchanged |
| one turn, by anything else | **propagates → loop dies silently** | turn abandoned, **loop survives**, WARNING logged |

The pre-existing #2242 contract tests (`test_external_cancel_of_driver_task_propagates`, `test_self_initiated_flag_does_not_leak_to_next_turn`) cancel the **driver** task, so they pin the first row — they pass unchanged. The third row was never covered, which is why the gap survived.

**2. No path ends the loop without a record.** `run()` now catches the cancel, records it, and re-raises. It reuses the #2280 `session_halted` chat-event (`reason="cancelled"`) rather than inventing a signal — it is already on the transport forward-allowlist and already rendered by the TUI status line and the plain-CUI bottom toolbar ("⚠ SESSION HALTED — cancelled — agent stopped accepting ops"), and `Session.halted_reason` is a public property.

Worth being precise about the "silent" claim, since I checked: `chat_stopped` / `session_completed` **did** already fire on the cancel path. But they fire identically on a clean shutdown, so they cannot distinguish "the agent finished" from "the agent stopped consuming an inbox that is still being written to". That is the gap `session_halted` closes. Setting `_halted_reason` here does not make the session start rejecting puts — that guard keys off `state_log.durability_failed`, not the reason (verified in `_fail_stop_if_durability_dead`).

## Tests — `tests/test_3377_run_loop_survives_turn_cancel.py`

Real `Session` / `StateLog`; the only replaced collaborator is `RouterLoopDriver.run_turn`, method-assigned as a real async function (the same controllable-hang seam `test_2242_hard_cancel.py` uses).

- The cancel is delivered by **`Task.cancel()`**, the real mechanism — a test that raised `CancelledError` itself would prove nothing about a path that never catches it (issue requirement 3).
- The witness is taken at an **intermediate cross-section**: a second message is put and must be *consumed* (its turn dispatched, the inbox drained). A terminal-state assertion cannot tell a surviving loop from a dead one (issue requirement 2).
- `test_self_initiated_cancel_stays_quiet` is the non-vacuity leg: a user-initiated cancel must keep surviving *silently*, or the new warning would say nothing about origin.
- `test_cancelling_the_session_still_stops_the_loop_and_records_it` pins the other half of the constraint — making turn cancels survivable must not make the session un-stoppable.

**Strip-falsify — both gates, anchors confirmed unique (`grep -c` → 1) before editing:**

| stripped | result |
|---|---|
| the `cancelling()` discriminator (reverted to the flag-only branch) | `test_turn_scoped_cancel_leaves_the_run_loop_consuming`, `test_turn_scoped_cancel_of_unknown_origin_is_recorded` → **RED** |
| the `run()` halt record | `test_cancelling_the_session_still_stops_the_loop_and_records_it` → **RED** |

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_3377_run_loop_survives_turn_cancel.py` — 4 inspected, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` — OK
- [x] Full `pytest` from the repo root, read directly: **9490 passed, 36 skipped, 0 failed**
- [x] `tests/test_2242_hard_cancel.py` passes unchanged (the FP-0013 external-cancel contract is preserved, not weakened)
- [x] Strip-falsify of both new gates — RED confirmed for each
- [x] Live probe of the real `Session.run()` before and after the fix (outputs quoted above)
- [x] `reyn.__file__` asserted inside this worktree immediately before each measurement (the shared `.venv` otherwise resolves to the main checkout)

## Follow-up left open, deliberately

The freeze report itself stays open and unattributed. If it recurs, the diagnostic is a stack capture — and with this PR landed, a run-loop that ends on a cancel now leaves `session_halted` behind, which is the evidence that was missing the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
