### PR TITLE
docs(CLAUDE.md): add PR-workflow rule 6 — arc-closure remainder rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,17 @@ Three rules then keep multi-session work coherent:
    asserts (same reasoning as any other doc-drift fix, not a mirror rule); do
    not invent a "keep en/ja pairs in sync" obligation when scoping a PR. Known
    ja-parity gaps are tracked in #2967 as backlog, not a per-PR gate.
+6. **Arc-closure remainder rule.** When closing an arc, settle every remainder
+   as either **filed** or **explicitly dropped** — **in the closing comment**.
+   Never leave "next arc" as the resting state: that is a third, silent state
+   (a decayed intent, not a decision), evidenced by #2597's natural experiment
+   — one remainder recorded as "server role deferred" survived because it was
+   named in the closing comment; an informally-mentioned "spec gap analysis"
+   remainder existed nowhere (not the issue, not docs, not the proposing
+   session's own memory) and rotted invisibly. A remainder belongs on the
+   surface the merge gate actually reads (an open issue, an unchecked Test
+   plan item) — not on a surface nobody re-checks (a broker message, a memory
+   pin, a comment's prose that never becomes a ticket).
 
 ## Pre-conclusion observation checklist (READ BEFORE WRITING ANY FINDING / 結論)
 


### PR DESCRIPTION
**[docs-maintainer]** — small PR per lead-coder's request, architect-proposed / lead-coder-adopted wording.

## What
Adds rule 6 to CLAUDE.md's PR workflow section: when closing an arc, every remainder must be settled as **filed** or **explicitly dropped**, in the closing comment — "next arc" is a third, silent state (decay, not decision).

Grounded in #2597's natural experiment: one remainder ("server role deferred") was named in the closing comment and survived; an informally-mentioned "spec gap analysis" remainder existed nowhere (not the issue, not docs, not the proposing session's memory) and rotted invisibly.

Kept the required 4 elements per lead-coder's spec: (a) binary choice — filed or dropped (b) settled in the closing comment (c) explicitly names "next arc" as the forbidden third state (d) cites #2597.

Deliberately separate from #3388 (verification-hazards.md) — different axis, as lead-coder noted (that PR is a green-misreading catalog; this is a workflow contract), so keeping them apart preserves the reasoning for the split.

## Test plan
- [x] `ruff check` — clean (doc-only change)
- [x] Matches tone/format of existing rules 1-5 in the same section

🤖 Generated with [Claude Code](https://claude.com/claude-code)