### PR TITLE
fix(tui): surface raw --model passthrough in the Model drawer

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -507,10 +507,22 @@ def _history_option_content(rows: "Sequence[str]") -> list[Content]:
 def _model_pane_entries(
     classes: "Sequence[str]", active: "str | None"
 ) -> "list[tuple[str, str]]":
-    """``(row, slash)`` per operator-configured model class, active class marked."""
-    return [
+    """``(row, slash)`` per operator-configured model class, active class marked.
+
+    #3324: ``active`` can be a raw LiteLLM model string rather than a
+    configured class name — when ``--model <raw-id>`` bypasses the class
+    system entirely (``Session.active_model_class()`` returns ``None`` for a
+    passthrough model, so the caller falls back to the raw model string).
+    That string never equals any class name, so the ``· active`` marker
+    silently appeared nowhere. Prepended here as its own informational row
+    (empty command = inert, the same convention read-only panes use) rather
+    than left unmarked."""
+    entries = [
         (f"{c}  · active" if c == active else c, f"/model {c}") for c in classes
     ]
+    if active is not None and active not in classes:
+        entries.insert(0, (f"(current, not a configured class)  {active}", ""))
+    return entries
 
 
 def model_pane_options(classes: "Sequence[str]", active: "str | None") -> list[str]:

--- a/tests/test_textual_chat_phase4_3273.py
+++ b/tests/test_textual_chat_phase4_3273.py
@@ -87,6 +87,29 @@ def test_model_pane_enumerates_full_class_set_no_subset() -> None:
     assert rows[classes.index("opus")] == "opus  · active", "active class not marked"
 
 
+def test_model_pane_marks_raw_passthrough_model_when_no_class_matches() -> None:
+    """Tier 1: #3324 — when ``--model <raw-id>`` bypasses the class system
+    (``active`` is a raw LiteLLM model string matching no configured class,
+    the shape ``Session.active_model_class() is None`` falls back to), the
+    Model pane surfaces it as its own informational row rather than
+    silently marking nothing.
+
+    Falsification: pre-fix, none of the rendered rows contained the raw
+    model string or any active marker at all."""
+    classes = ["light", "standard", "strong"]
+    raw_model = "gemini-2.5-flash-lite"  # not declared as a class name above
+    rows = model_pane_options(classes, active=raw_model)
+    assert any(raw_model in row for row in rows), (
+        f"raw passthrough model {raw_model!r} does not appear anywhere in the pane: {rows}"
+    )
+    # No configured class is spuriously marked active.
+    assert not any("· active" in row for row in rows), (
+        f"a configured class was marked active for a raw passthrough model: {rows}"
+    )
+    # Every configured class is still present, unmodified.
+    assert {row for row in rows if row in classes} == set(classes)
+
+
 def test_agent_pane_enumerates_full_agent_set_no_subset() -> None:
     """Tier 1: the Agent pane renders EVERY loaded agent (the attached one marked),
     never a curated subset — a fake agent added to the input appears, so a freshly


### PR DESCRIPTION
**[tui-coder]** — part of #3324

## Root cause

`Session.active_model_class()` returns `None` when the current model ID isn't a configured class (a raw `--model <id>` passthrough — a normal, supported invocation). The pane's caller then fell back to `snap.get("model_active_class") or snap.get("model")` (the raw model **string**), which `_model_pane_entries` compares against class **names** via `c == active` — a raw model string never equals a class name, so the `· active` marker silently appeared nowhere in the Model drawer, even though the status line right above correctly showed the model in use.

## Fix

`_model_pane_entries` now prepends the raw model string as its own informational row — `(current, not a configured class)  <raw-id>` — with an empty command (the same "inert row" convention already used for read-only panes), when `active` doesn't match any class in `classes`. No change when `active` genuinely is a configured class name (the common case).

## Real-TTY witness (tui-coder)

`reyn chat --model gemini-2.5-flash-lite` (a raw model string not declared as a class in this project's `reyn.yaml`) → opened the Model drawer → the new row is the first line:

```
(current, not a configured class)  gemini-2.5-flash-lite
claude-haiku
claude-sonnet
...
```

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` on the changed test file — 15 inspected, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py` on the changed src file — OK
- [x] New test: `test_model_pane_marks_raw_passthrough_model_when_no_class_matches`
- [x] Existing `test_model_pane_enumerates_full_class_set_no_subset` (active is a real class) still passes unmodified — confirms no regression to the common case
- [x] Full `pytest` from the repo root — 9170 passed, 4 failed / 12 errors, all `ModuleNotFoundError: No module named 'fastapi'` (this venv's own gap, unrelated to `chrome.py`)
- [x] Real-TTY witness — see above