### PR TITLE
perf(runtime): measured won't-fix for the up-front serialise in build_history — closes #3185

### DIFF
--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -401,6 +401,24 @@ class RouterHistoryBuffer:
         # Serialising once here and reusing the result for both the
         # total-check AND the final return also avoids a double
         # ``_serialise_turn`` call on the surviving subset.
+        #
+        # #3185 (MEASURED, closed won't-fix — do NOT "optimise" this back into
+        # a lazy/partial serialise): serialising every CANDIDATE (not just the
+        # survivors) means an image-bearing turn is base64-materialised even
+        # when it is about to be elided away. Re-measured against the six
+        # largest real ``history.jsonl`` conversations available (up to 2969
+        # turns): whole-``build_history`` CPU is 0.11-4.2 ms, of which
+        # ``_serialise_turn`` over ALL turns is 2-35% (0.005-0.72 ms) — the
+        # rest is ``estimate_tokens_for_any_turn`` + trim, which a serialise
+        # cache cannot remove. A text turn serialises in ~0.24 us because
+        # ``_materialise_path_ref_content`` returns ``str`` content untouched,
+        # so the up-front cost is materially nonzero ONLY for inline images
+        # (synthetic 60 turns / 15x200KB elide: 5.2 ms; 15x1MB: 27 ms). Every
+        # such call precedes or accompanies a provider round-trip that is
+        # orders of magnitude slower and, in exactly the image-heavy case,
+        # uploads that same base64 payload. The saving does not justify a
+        # cross-call cache whose staleness would reintroduce the elide/advisor
+        # divergence PR-B closed.
         wire_turns = [self._serialise_turn(m) for m in turns]
 
         total = sum(


### PR DESCRIPTION
**[per-PR-coder]** — `Closes #3185`.

**Outcome: measured won't-fix.** The issue asked for a re-measurement under realistic conditions *before* any optimisation, and explicitly allowed "the absolute cost is negligible → propose closing" as a success. That is what the numbers say. This PR is **comment-only** — no behaviour change, no cache. PR-B's elide/advisor unification is untouched and byte-identical.

## What was measured

Two harnesses, both run from a venv asserted to resolve `reyn` into this worktree (`.venv-wt`, `uv sync --all-extras --dev`; agents share `lead-coder/.venv`, whose editable install points at the main tree — a wrong tree would have produced plausible wrong numbers rather than an error).

1. **Real conversations** — the six largest `history.jsonl` files on this machine (338–2969 turns, 0.9–1.4 MB), loaded through the production `_migrate_legacy_chat_message` → `ChatMessage` path, real `RouterHistoryBuffer`, real budgets, both no-elide and elide.
2. **Synthetic with images** — real PNG blobs on disk behind a real `MediaStore`, resolved through the real path-ref → base64 path, including a reproduction of the issue's own condition.

### Measurement hygiene (the box was **not** quiet)

The brief asks for an uncontended machine. I could not get one: other agents ran test suites throughout, and 1-min loadavg oscillated between **4.6 and 30.7** over ~40 minutes of waiting (a blocking waiter for loadavg < 2.5 never fired). Rather than report a contended wall-clock median, each figure is reported as **median `time.process_time`** (CPU actually consumed by *this* process — a competing process holding a core does not inflate it) cross-checked against **min-of-N wall clock** (the least-preempted sample).

**Why that is trustworthy here:** across every real-history row, CPU and `wall_min` agree within ~10% even at loadavg 18–30 (e.g. 2969-turn elide: cpu 4.221 ms vs wall_min 3.609 ms). Two statistics with different contamination modes converging is the evidence that neither is measuring the other agents' load. Every number below is CPU time; `wall_min` is shown alongside for `build_history`.

**Harness validation:** the synthetic reproduces the issue's own figure — issue reported 5.85 ms for 60 turns / 15×200KB forced elide, this harness measures **5.21 ms CPU / 4.56 ms wall_min**. Same regime, so the harness is measuring the thing the issue measured.

## Results — real conversations

| conversation | turns | mode | `build_history` cpu | wall_min | `_serialise_turn` over ALL | share |
|---|---:|---|---:|---:|---:|---:|
| architect/emit-hook-event-agent | 30 | elide | 0.247 ms | 0.243 ms | 0.005 ms | 2.0% |
| architect/composer-reachability | 29 | elide | 0.268 ms | 0.258 ms | 0.005 ms | 1.9% |
| tui-coder/alpha | 307 | elide | 0.511 ms | 0.497 ms | 0.053 ms | 10.4% |
| e2e-coder/alpha | 338 | elide | 0.687 ms | 0.631 ms | 0.064 ms | 9.3% |
| tui-coder/worker | 2969 | no-elide | 2.082 ms | 1.864 ms | 0.719 ms | 34.5% |
| tui-coder/worker | 2969 | elide | **4.221 ms** | 3.609 ms | 0.708 ms | 16.8% |

Per-turn: **0.7–9.2 µs/turn**. The rest of `build_history` is `estimate_tokens_for_any_turn` (16–50%) plus trim — **a serialise cache removes none of that**.

## Results — synthetic, with and without images

| scenario | `build_history` cpu | wall_min | serialise ALL | serialise survivors | ratio |
|---|---:|---:|---:|---:|---:|
| text-only, 40 turns, no elide | 0.026 ms | 0.024 ms | 0.007 ms | 0.007 ms | 3.7× |
| text-only, 40 turns, **elide** | 0.046 ms | 0.045 ms | 0.017 ms | 0.002 ms | 23.0× |
| text-only, 120 long turns, **elide** | 0.141 ms | 0.129 ms | 0.021 ms | 0.005 ms | 28.2× |
| 2×200KB screenshots, 40 turns, elide | 0.635 ms | 0.617 ms | 0.623 ms | 0.441 ms | 1.4× |
| **#3185's own case:** 15×200KB, 60 turns, elide | 5.214 ms | 4.564 ms | 5.222 ms | 0.878 ms | 5.9× |
| heavy: 15×1MB, 60 turns, elide | 27.390 ms | 21.598 ms | 21.274 ms | 5.505 ms | 5.0× |

## The ratio-vs-absolute question the issue raised

The issue asked which regime real usage sits in, because "16× on 0.36 ms is a different decision from 16× on 360 ms". **It is the former, and by a wider margin than the issue assumed.**

- The **largest ratio** measured anywhere is **28×** — on text-only elide, where the absolute is **0.141 ms** and the theoretical ceiling of a perfect cache is **0.016 ms**. The ratio is large precisely because the baseline is near zero.
- The **largest absolute** is 27 ms, in a scenario (15 separate 1 MB images in one conversation) whose own provider request carries ~20 MB of base64 — an upload that dwarfs the 16 ms a cache could save.
- On the largest **real** conversation on this machine (2969 turns), the entire achievable saving is **≈0.5 ms** against a provider round-trip measured in seconds.

**Why text turns are so cheap** (this is the load-bearing mechanism, not an incidental): `_materialise_path_ref_content` returns `str` content *unchanged* and returns list content unchanged when no part carries a `path` — so a non-image turn costs one dict construction, ~0.24 µs. The up-front serialise is materially nonzero **only** for inline images.

**How often are there images?** Census over **every** `history.jsonl` under `~/Workspace/reyn_dev` — **21,887 files, 0** containing an image content part (grepped `"type"\s*:\s*"image` — covers both the `image` path-ref and `image_url` inline forms; the legacy `media` key and `base64` were checked separately, and the single `base64` hit was directly inspected and is a *filename* inside a glob tool result, not an image). Total stored media on this machine: one 5-byte test PNG.

*Honest scope limit on that census:* these are dogfood/test-agent conversations in dev worktrees, not end-user production traffic. It does not prove no user ever attaches images — `/image` and screenshot-returning tools are real features. It does establish that the image-bearing regime is not what this repo's own observed conversations look like, and the image-free regime is the one where the measured cost is ~0.02–0.7 ms.

## Why not implement the sketched cache anyway

Beyond the absolute being negligible, the cache is not free of risk against the exact invariant PR-B established:

- The only place a cache can *win* is **across calls** (within one `build_history`, each turn is already serialised exactly once — a within-call cache saves nothing). `Session._active_branch_history` filters `self.history` and returns the same `ChatMessage` objects, so an identity-keyed cross-call cache would in fact hit — feasibility is not the objection.
- The objection is staleness. `ChatMessage` is `@dataclass(init=False)`, **not frozen**. An identity-keyed cache is only correct while no message is mutated after serialisation, which is an invariant nothing currently enforces and no test guards. A stale entry does not fail loudly — it silently feeds the elide decision a wire dict that differs from what the provider will see, which is precisely the divergence PR-B closed.
- Buying ≈0.5 ms on the largest real conversation with a new unenforced whole-history invariant is a bad trade. The issue's own framing agrees: "this repo would rather have [a measured *not worth fixing*] than a speculative optimisation."

## The change in this PR

A comment at the `wire_turns = [...]` line in `build_history` recording the measurement and the reasoning, so the next reader (or reviewer) does not re-file this line as a perf bug once #3185 is closed and less discoverable. No code, no test — a timing assertion here would be exactly the flaky gate the brief rules out.

## Test plan

- [x] `ruff check src tests` — `All checks passed!` (exit 0)
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/services/router_history_buffer.py` — OK (exit 0)
- [x] `pytest` from repo root — **9485 passed, 37 skipped, 10 warnings in 910.85s**, exit 0. Read in full, not tailed-and-inferred.
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — **(skipped — no test files changed; this PR touches one comment block in one src file)**
- [x] Manual: venv identity asserted at measurement time — `import reyn` → `.../worktrees/agent-afa81535d780b32a8/src/reyn/__init__.py`, `sys.executable` → `.../agent-afa81535d780b32a8/.venv-wt/bin/python`. Printed by both harnesses on every run, not audited once up front.
- [x] Manual: harness validated against the issue's own reported figure (5.85 ms reported → 5.21 ms cpu / 4.56 ms wall_min measured, same condition).
- [x] Manual: loadavg captured before and after every run; contention handled by reporting CPU time cross-checked against min-of-N wall, with the agreement between them stated above.
- [x] Manual: no behaviour change — the diff is a comment; `pytest` green includes `tests/test_2957_prb_elide_advisor_token_unification.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
