### PR TITLE
docs(CLAUDE.md): rule 4 gains the 'how to determine final PR' step

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,14 @@ Three rules then keep multi-session work coherent:
    "this PR partially closes #X". For sub-PRs in a multi-PR arc, use `part of
    #X` or `toward #X`. Only the final PR that actually completes the umbrella
    issue should use `Closes #X`.
+   **Determining "final" is not a guess**: before writing `Closes #X` into a
+   brief or PR body, enumerate every PR/issue whose body contains `part of
+   #X` (`gh pr list --state all --search "#X in:body"`) and confirm none are
+   still open. "Probably the last one" is not sufficient — a close closes
+   the umbrella issue's visibility along with it, so a wrong guess hides the
+   remaining work rather than merely failing to finish it (#3368: a `Closes`
+   fired 40 minutes before the arc's actual last PR merged, because the
+   enumeration step was skipped).
    **Reviewer recovery angle:** an unexpected issue auto-close triggered by a
    sub-PR merge is almost always a closing-keyword false positive. Reopen the
    issue and verify the arc is not half-done before assuming completion.


### PR DESCRIPTION
**[docs-maintainer]** — small PR per lead-coder's request, separate from #3388/#3395 (different axis, same reasoning as the split already established).

## What
Rule 4 (closing-keyword caution) said only the final PR in a sub-PR arc should use `Closes #X`, but never said HOW to determine which PR is final. Adds one concrete check: enumerate every open PR/issue with `part of #X` in its body before writing `Closes #X` — don't guess "probably the last one."

Grounded in #3368 (2026-07-28, lead-coder's own dated incident): a `Closes` fired 40 minutes before the arc's actual last PR merged, because the enumeration step was skipped — the same day rule 6 (arc-closure remainder) was written, by the same author. Outcome was retroactively fine (all 4 PRs did land correctly), but "retroactively fine" and "correct at the time it closed" are different claims, and the incident is a clean instance of exactly what rule 6 already warns about.

## Test plan
- [x] `ruff check` — clean (doc-only change)
- [x] Matches tone/format of the existing rule 4 paragraph it extends

🤖 Generated with [Claude Code](https://claude.com/claude-code)