### PR TITLE
fix(tui): keybinding predictability — Tab forward-only, Esc wording fixed

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -403,10 +403,17 @@ COMPOSER_KEYS: "list[tuple[str, str]]" = [
 ]
 
 #: The menu row's navigation keys (imperative ``MenuBar._on_key`` overrides).
+#:
+#: #3365: ``↑`` and ``esc`` used to share one row worded "close" — read as
+#: "closes the drawer, landing on the tab-bar" (one level up), but the ACTUAL
+#: destination (measured, both keys) is the Composer directly, regardless of
+#: navigation depth. Split into two rows with accurate wording instead of one
+#: combined row that invited a "one step back" misreading.
 MENUBAR_KEYS: "list[tuple[str, str]]" = [
     ("← →", "move"),
     ("enter", "open"),
-    ("↑ / esc", "close"),
+    ("↑", "back to composer"),
+    ("esc", "back to composer"),
 ]
 
 #: Keys RESERVED by an approved-but-unimplemented feature — claimed, but bound
@@ -445,10 +452,13 @@ RESERVED_KEYS: "dict[str, str]" = {
 #: ``SentQueue.BINDINGS`` — declarative, but the Help pane still sources them
 #: from HERE, the same single-source-of-truth convention ``MENUBAR_KEYS``
 #: uses, rather than re-deriving prose from the ``Binding`` objects).
+#:
+#: #3365: ``tab`` dropped — its "back to composer" binding was removed
+#: (``Tab`` is forward-only everywhere in the app; ``Esc`` alone owns "back").
 SENTQUEUE_KEYS: "list[tuple[str, str]]" = [
     ("↑ / ↓", "select queued message"),
     ("enter", "cancel selected"),
-    ("esc / tab", "back to composer"),
+    ("esc", "back to composer"),
 ]
 
 

--- a/src/reyn/interfaces/inline/textual_chat/intervention_panel.py
+++ b/src/reyn/interfaces/inline/textual_chat/intervention_panel.py
@@ -55,15 +55,24 @@ this priority binding whenever focus is inside this panel — a deliberate,
 uniform loss of a redundant alias, not a functional regression, since
 ``Up``/``Down`` already do the same thing).
 
-``Esc``/``Tab`` (unchanged from P1/P2): return focus to the Composer WITHOUT
-answering. Declared as widget-level (non-priority) ``BINDINGS`` so Textual's
-ordinary focused-widget-outward resolution finds them on this ancestor before
-``Screen``'s default ``tab``→``focus_next``. #3327 gave this escape hatch a
-way BACK: the Composer's own ``↑`` (see
+``Esc`` (from P1/P2; ``Tab``'s equivalent binding REMOVED, #3365): returns
+focus to the Composer WITHOUT answering. Declared as a widget-level
+(non-priority) ``BINDINGS`` entry so Textual's ordinary focused-widget-outward
+resolution finds it on this ancestor before ``Screen``'s default handling.
+#3365 (architect ruling): ``Tab`` is forward-only everywhere in the app — its
+"back to composer" binding here was redundant with ``Esc``, and having BOTH
+keys mean "back" in some places while ``Tab`` alone means "forward" elsewhere
+(the MenuBar/composer-idle case) was exactly the "same key, opposite meaning"
+inconsistency #3365 was filed to fix. Removing it was gated on
+``test_textual_chat_esc_sufficiency_3365.py`` machine-verifying ``Esc`` alone
+already reaches the Composer from every focus state this panel can hold
+(including its ``Input`` — the specific future-regression risk that gate
+exists to catch). #3327 gave this escape hatch a way BACK: the Composer's own
+``↑`` (see
 :class:`~reyn.interfaces.inline.textual_chat.chrome.Composer`'s ``_on_key``)
 focuses this panel (:meth:`focus_pending`) FIRST, ahead of the sent-queue,
-whenever :meth:`has_pending` is true — before #3327, ``Esc``/``Tab`` here was
-a ONE-WAY trip for a keyboard-only user (no binding anywhere retargeted focus
+whenever :meth:`has_pending` is true — before #3327, ``Esc`` here was a
+ONE-WAY trip for a keyboard-only user (no binding anywhere retargeted focus
 onto this panel, and the documented ``/answer`` fallback was itself queued
 behind the very intervention it targeted, a structural deadlock — see
 ``app.py``'s module docstring and :meth:`~reyn.interfaces.inline.textual_chat.app.TextualChatApp._submit`).
@@ -175,8 +184,13 @@ class InterventionPanel(Vertical):
     #: bindings cannot work here): they switch the active tab even while
     #: focus is inside a pane's ``RadioSet``/``Input``.
     BINDINGS = [
+        # #3365: Tab's own "back to composer" binding was removed — Esc alone
+        # now owns "back" everywhere (architect ruling: Tab is forward-only).
+        # Safe only because test_textual_chat_esc_sufficiency_3365.py
+        # machine-verifies Esc reaches the Composer from every focus state
+        # this panel can hold, INCLUDING its Input — see that file's module
+        # docstring for the #3327-shaped risk this gate specifically guards.
         Binding("escape", "dismiss_panel", "Back to composer", show=False),
-        Binding("tab", "dismiss_panel", "Back to composer", show=False),
         Binding(
             "left", "prev_tab", "Previous intervention", show=False, priority=True
         ),

--- a/src/reyn/interfaces/inline/textual_chat/sent_queue.py
+++ b/src/reyn/interfaces/inline/textual_chat/sent_queue.py
@@ -45,9 +45,14 @@ new one:
 - ``Enter`` cancels the highlighted row — the SAME "Enter acts on the
   highlighted item" idiom those same pickers use (there, Enter *selects*; a
   cancel affordance's "select" action IS "cancel this one").
-- ``Escape``/``Tab`` return focus to the composer — copied VERBATIM from
+- ``Escape`` returns focus to the composer — copied VERBATIM from
   :class:`~reyn.interfaces.inline.textual_chat.intervention_panel.InterventionPanel`'s
-  identical two bindings for the identical purpose.
+  identical binding for the identical purpose. ``Tab``'s equivalent binding
+  was REMOVED (#3365, architect ruling): ``Tab`` is forward-only everywhere
+  in the app, ``Esc`` alone owns "back" — gated on
+  ``test_textual_chat_esc_sufficiency_3365.py`` machine-verifying ``Esc``
+  already reaches the Composer from every focus state this widget (and its
+  siblings) can hold.
 - The composer's own ``↑`` (on its first line) focuses this widget when it
   is non-empty — the mirror image of the composer's existing ``↓``-on-last-
   line-focuses-the-menubar rule (``chrome.py``'s ``Composer._on_key``), so
@@ -107,8 +112,10 @@ class SentQueue(Vertical):
         Binding("up", "select_prev", "Previous queued", show=False),
         Binding("down", "select_next", "Next queued", show=False),
         Binding("enter", "cancel_selected", "Cancel selected", show=False),
+        # #3365: Tab's own "back to composer" binding was removed — Esc alone
+        # owns "back" everywhere now (see the module docstring and
+        # test_textual_chat_esc_sufficiency_3365.py).
         Binding("escape", "focus_composer", "Back to composer", show=False),
-        Binding("tab", "focus_composer", "Back to composer", show=False),
     ]
 
     class Cancelled(Message):

--- a/tests/test_3300_y_client_cancel.py
+++ b/tests/test_3300_y_client_cancel.py
@@ -506,8 +506,9 @@ async def test_sent_queue_does_not_shadow_domnode_is_empty_property() -> None:
 
 def test_help_pane_lists_composer_up_arrow_and_sentqueue_keys() -> None:
     """Tier 2b: the new composer ``↑`` binding and the sent-queue's own keys
-    (↑/↓ move, Enter cancel, Esc/Tab back to composer) must be DISCOVERABLE
-    through the Help pane — ``chrome.py``'s own module docstring states the
+    (↑/↓ move, Enter cancel, Esc back to composer — #3365 dropped Tab from
+    this row, see ``SENTQUEUE_KEYS``) must be DISCOVERABLE through the Help
+    pane — ``chrome.py``'s own module docstring states the
     Help pane sources composer/menu keys from ``COMPOSER_KEYS``/
     ``MENUBAR_KEYS`` "rather than re-hardcoding a second copy"; the new
     sent-queue keys must follow the SAME single-source-of-truth convention

--- a/tests/test_textual_chat_esc_sufficiency_3365.py
+++ b/tests/test_textual_chat_esc_sufficiency_3365.py
@@ -1,0 +1,238 @@
+"""#3365 — Esc-sufficiency gate: Esc returns to the Composer from EVERY focus
+state, before Tab's redundant "back to composer" binding is removed from
+SentQueue/InterventionPanel.
+
+Architect's ruling on #3365 (issue thread): Tab should become forward-only
+(accept/next), with "back" left to Esc alone — but ONLY once Esc's
+sufficiency from every reachable focus state is machine-verified, because a
+future PR could give the InterventionPanel's own ``Input`` widget an
+Esc-clears-text binding, which would swallow the bubble and — if Tab had
+already been removed as a redundant escape hatch — leave the user stuck with
+NO way back (exactly #3327's "the one remaining exit closed" shape). This
+gate is what lets a later PR remove Tab's "back" binding with a real, not
+merely assumed, safety net; and what would immediately catch that future
+Input-vs-Esc regression by going RED.
+
+Five focus states, each independently reachable and each asserted to return
+to the Composer on ``Esc``:
+  1. MenuBar (tab-bar row, not yet opened)
+  2. Drawer content (an OptionList pane)
+  3. SentQueue
+  4. InterventionPanel — closed-set (RadioSet)
+  5. InterventionPanel — free-text (Input) — the specific widget architect
+     flagged as the future risk
+
+Real ``TextualChatApp`` + a real minimal ``ClientTransport`` — no mocks, per
+the testing policy.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual.widgets import Input, OptionList, RadioSet
+
+from reyn.interfaces.inline.textual_chat import Composer, MenuBar, TextualChatApp
+from reyn.interfaces.inline.textual_chat.intervention_panel import InterventionPanel
+from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _Transport(ClientTransport):
+    """A real, minimal :class:`ClientTransport`. ``end=False`` keeps the
+    stream open so the app under test stays mounted for focus inspection."""
+
+    def __init__(self, messages: "list[OutboxMessage]") -> None:
+        self._messages = list(messages)
+        self.submitted: list[str] = []
+        self.answered_choice: list[str] = []
+        self.answered_text: list[str] = []
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        for msg in self._messages:
+            yield DisplayFrame(msg)
+        await asyncio.Event().wait()
+
+    async def submit_user_text(self, text: str) -> None:
+        self.submitted.append(text)
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        self.answered_text.append(text)
+        return True
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        self.answered_choice.append(choice_id)
+        return True
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        self._messages.append(msg)
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _choice_intervention() -> OutboxMessage:
+    return OutboxMessage(
+        kind="intervention",
+        text="Proceed?\n  Yes / No",
+        meta={
+            "intervention_id": "iv-1",
+            "intervention_kind": "confirm",
+            "prompt": "Proceed?",
+            "choices": [
+                {"id": "yes", "label": "Yes", "hotkey": "y"},
+                {"id": "no", "label": "No", "hotkey": "n"},
+            ],
+            "nodes": [
+                {"component": "text", "text": "Proceed?"},
+                {"component": "list", "items": ["Yes", "No"]},
+            ],
+        },
+    )
+
+
+def _free_text_intervention() -> OutboxMessage:
+    return OutboxMessage(
+        kind="intervention",
+        text="What is the target directory?",
+        meta={
+            "intervention_id": "iv-2",
+            "intervention_kind": "ask_user",
+            "prompt": "What is the target directory?",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_esc_from_menubar_returns_to_composer() -> None:
+    """Tier 2b: Esc from the MenuBar tab-bar (drawer not yet opened) -> Composer."""
+    app = TextualChatApp(transport=_Transport([]))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.query_one(Composer).focus()
+        await pilot.pause()
+        await pilot.press("down")
+        await pilot.pause()
+        assert isinstance(app.focused, MenuBar), f"setup: expected MenuBar focused, got {app.focused!r}"
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert isinstance(app.focused, Composer), (
+            f"Esc from MenuBar did not return to Composer: {app.focused!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_esc_from_drawer_content_returns_to_composer() -> None:
+    """Tier 2b: Esc from an OPEN drawer's content (an OptionList) -> Composer,
+    regardless of navigation depth inside it (matches the architect's own
+    measured trace: depth does not change the destination)."""
+    app = TextualChatApp(transport=_Transport([]))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.query_one(Composer).focus()
+        await pilot.pause()
+        await pilot.press("down")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.focused, OptionList), (
+            f"setup: expected an open drawer's OptionList focused, got {app.focused!r}"
+        )
+        # Navigate a few rows deep before Esc — the destination must not depend on depth.
+        await pilot.press("down", "down", "down")
+        await pilot.pause()
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert isinstance(app.focused, Composer), (
+            f"Esc from drawer content did not return to Composer: {app.focused!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_esc_from_sent_queue_returns_to_composer() -> None:
+    """Tier 2b: Esc from a focused, non-empty SentQueue -> Composer."""
+    app = TextualChatApp(transport=_Transport([]))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+
+        # Populate directly via the widget's own public API (mirrors how
+        # #3327's tests exercise SentQueue) — kept minimal/scoped to this gate.
+        sent_queue = app.query_one(SentQueue)
+        sent_queue.show_item(msg_id="m1", text="queued while busy")
+        await pilot.pause()
+        assert sent_queue.has_items(), "test setup: sent-queue must be non-empty"
+
+        sent_queue.focus()
+        await pilot.pause()
+        assert sent_queue.has_focus, "test setup: sent-queue did not take focus"
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.query_one(Composer).has_focus, (
+            f"Esc from SentQueue did not return to Composer: {app.focused!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_esc_from_intervention_panel_choice_returns_to_composer() -> None:
+    """Tier 2b: Esc from a closed-set InterventionPanel (RadioSet) -> Composer."""
+    transport = _Transport([_choice_intervention()])
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        radio = app.query_one(InterventionPanel).query_one(RadioSet)
+        assert radio.has_focus, "test setup: panel did not auto-focus on arrival"
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.query_one(Composer).has_focus, (
+            f"Esc from InterventionPanel (choice) did not return to Composer: {app.focused!r}"
+        )
+        assert transport.answered_choice == [], "Esc must not deliver an answer"
+
+
+@pytest.mark.asyncio
+async def test_esc_from_intervention_panel_input_returns_to_composer() -> None:
+    """Tier 2b: ★ the specific case architect flagged as the future risk —
+    Esc while focus is on the InterventionPanel's free-text ``Input`` (not
+    the RadioSet) still returns to the Composer.
+
+    This is the gate that must go RED the day a future PR gives ``Input`` its
+    own Esc-clears-text binding without also preserving the bubble-to-panel
+    fallback — the #3327 "last exit closed" shape, but for Input specifically."""
+    transport = _Transport([_free_text_intervention()])
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        input_widget = app.query_one(InterventionPanel).query_one(Input)
+        input_widget.focus()
+        await pilot.pause()
+        assert input_widget.has_focus, "test setup: Input did not take focus"
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.query_one(Composer).has_focus, (
+            f"Esc from InterventionPanel's Input did not return to Composer: {app.focused!r}"
+        )
+        assert transport.answered_text == [], "Esc must not deliver an answer"

--- a/tests/test_textual_chat_esc_sufficiency_3365.py
+++ b/tests/test_textual_chat_esc_sufficiency_3365.py
@@ -13,14 +13,22 @@ gate is what lets a later PR remove Tab's "back" binding with a real, not
 merely assumed, safety net; and what would immediately catch that future
 Input-vs-Esc regression by going RED.
 
-Five focus states, each independently reachable and each asserted to return
-to the Composer on ``Esc``:
+Five HAND-ENUMERATED focus states, each independently reachable and each
+asserted to return to the Composer on ``Esc``:
   1. MenuBar (tab-bar row, not yet opened)
   2. Drawer content (an OptionList pane)
   3. SentQueue
   4. InterventionPanel — closed-set (RadioSet)
   5. InterventionPanel — free-text (Input) — the specific widget architect
      flagged as the future risk
+
+This list is NOT derived from an exhaustive enumeration of every focusable
+widget the app can mount (co-vet note, #3365 review) — it is the set of
+regions this issue's own investigation reached. A 6th focusable region added
+later (a new drawer pane type, a new panel) is NOT automatically covered by
+this file; extending the list here is the maintainer's job when one is
+added, the same way a new call site needs its own invariant check elsewhere
+in this codebase.
 
 Real ``TextualChatApp`` + a real minimal ``ClientTransport`` — no mocks, per
 the testing policy.

--- a/tests/test_textual_chat_intervention_panel_3299.py
+++ b/tests/test_textual_chat_intervention_panel_3299.py
@@ -423,10 +423,19 @@ async def test_pending_intervention_flow_entry_has_no_chip_options_rendered() ->
 
 
 @pytest.mark.asyncio
-async def test_escape_and_tab_from_panel_return_focus_to_composer() -> None:
-    """Tier 2b: focus-return — Esc/Tab inside the panel return focus to the
+async def test_escape_from_panel_returns_focus_to_composer_tab_moves_forward() -> None:
+    """Tier 2b: focus-return — Esc inside the panel returns focus to the
     Composer WITHOUT answering; the intervention stays pending (the panel
-    stays open)."""
+    stays open).
+
+    #3365: the panel's own explicit "Tab -> back to composer" binding was
+    REMOVED (architect ruling: Tab is forward-only everywhere in the app,
+    Esc alone owns "back" — gated on
+    test_textual_chat_esc_sufficiency_3365.py). Tab from the panel's RadioSet
+    still happens to land on the Composer below via Textual's default
+    forward focus-cycling (the Composer is simply next in the focus chain
+    here) — asserted as a non-vacuity check that removing the binding didn't
+    strand focus, NOT as evidence of an intentional "back" contract for Tab."""
     transport = RecordingTransport([_choice_intervention()], end=False)
     app = TextualChatApp(transport=transport)
 
@@ -445,13 +454,16 @@ async def test_escape_and_tab_from_panel_return_focus_to_composer() -> None:
         assert transport.answered_choice == []
         assert transport.answered_text == []
 
-        # Re-focus the panel to exercise Tab too.
+        # Re-focus the panel and confirm Tab's default forward-cycling still
+        # lands somewhere sane (not stuck) — not asserting a "back" contract.
         _active_pane(panel).query_one(RadioSet).focus()
         await pilot.pause()
         await pilot.press("tab")
         await pilot.pause()
 
-        assert app.query_one(Composer).has_focus, "Tab did not return focus to the Composer"
+        assert not pane.query_one(RadioSet).has_focus, (
+            "Tab did not move focus forward at all — focus is stuck on the panel"
+        )
         assert panel.display is True
         assert transport.answered_choice == []
 


### PR DESCRIPTION
**[tui-coder]** — part of #3365

Implements the architect's 3-principle ruling from the issue thread (quoted for reference: *"① Esc = どこからでもcomposerへ帰る（既に成立。文言を実態に合わせる）② Tab = 前方向のみ...③ キーの意味は場所で変えない"*).

## Predictability table — before / after

| Key | Context | Before | After |
|---|---|---|---|
| `Tab` | Composer idle | forward → MenuBar | forward → MenuBar (**unchanged**) |
| `Tab` | Completion popup open | accept candidate | accept candidate (**unchanged**, #3354's own basis) |
| `Tab` | SentQueue focused | **back** → Composer (explicit binding) | forward (Textual's default focus-cycle — happens to land on Composer next; **no longer an explicit "back" contract**) |
| `Tab` | InterventionPanel focused | **back** → Composer (explicit binding) | forward (same as above) |
| `Esc` | MenuBar tab-bar | → Composer, Help said "close" | → Composer, Help now says **"back to composer"** (wording fixed, behavior unchanged) |
| `Esc` | Drawer content (OptionList) | → Composer (via app-level fallback), same "close" wording, depth-independent | → Composer, same — now **machine-verified** independent of depth |
| `Esc` | SentQueue | → Composer | → Composer (**unchanged**) |
| `Esc` | InterventionPanel (RadioSet) | → Composer | → Composer (**unchanged**) |
| `Esc` | InterventionPanel (**Input**) | → Composer (bubbles — `Input` claims no `escape` binding) | → Composer (**unchanged, now machine-verified** — see below) |
| `Enter` | Model/Agent/Tool/MCP/Skill/Hook | actionable (dispatches a slash command) | actionable (**unchanged**) |
| `Enter` | Pipe/Cron | rendered as a **plain `Static`** — no selectable row exists at all (not an `OptionList`) | **unchanged** — already satisfies "read-only shows as non-selectable" from #3338, predating this issue |

Net effect: `Tab` no longer means two different, sometimes-opposite things depending on focus (composer-idle "forward" vs. panel/queue "back") — it is forward-only everywhere. `Esc` was already the sole, depth-independent way home; only the Help pane's wording was wrong.

## ① Esc wording (small, no behavior change)

`MENUBAR_KEYS`'s combined row `("↑ / esc", "close")` read as "closes the drawer, landing back on the tab-bar" — but the measured destination for both keys is the Composer directly, at any depth. Split into two rows, both worded `"back to composer"`.

## ② Tab forward-only (gated)

Removed `Binding("tab", "focus_composer"/"dismiss_panel", ...)` from `SentQueue`/`InterventionPanel`. **Gated on landing the safety net first**: `tests/test_textual_chat_esc_sufficiency_3365.py` machine-verifies `Esc` alone reaches the Composer from all 5 reachable focus states, **including the `InterventionPanel`'s free-text `Input`** — the specific future-regression risk the architect flagged (a later PR giving `Input` its own Esc-clears-text binding would swallow the bubble; without a machine gate, removing Tab's redundant binding today would silently reopen a #3327-shaped dead end the day that lands).

**Falsified, not just written**: reintroduced a fake `Input` subclass with a real, action-backed `escape` binding (simulating exactly that future regression) — the gate went RED (`Composer.has_focus` was `False`, focus stuck on the fake Input). Restored, re-ran — GREEN. The gate has teeth.

An existing test (`test_escape_and_tab_from_panel_return_focus_to_composer`) asserted Tab's now-removed binding explicitly; renamed/reworded to `test_escape_from_panel_returns_focus_to_composer_tab_moves_forward` and its Tab assertion loosened to "moved off the panel" (Textual's default focus-cycling happens to land on the Composer next here, which is not an intentional contract to pin).

## ③ Enter consistency — already satisfied, no change needed

Traced `_LIST_PANES`: Pipe/Cron are NOT members, so `build_drawer_pane` renders them as a plain read-only `Static`, not an `OptionList` — there is no selectable/highlightable row for `Enter` to act on at all. This already satisfies "read-only panes show as non-selectable" (landed with #3338, before this #3365 investigation started) — verified, not assumed.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` on all changed/added test files — 43 inspected, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py` on changed src files — OK
- [x] New: `test_textual_chat_esc_sufficiency_3365.py` (5 tests, falsified per above)
- [x] Updated: `test_escape_and_tab_from_panel_return_focus_to_composer` → renamed/reworded (see ②)
- [x] Updated: a stale docstring reference to the old `SENTQUEUE_KEYS` wording in `test_3300_y_client_cancel.py`
- [x] Full `pytest` from the repo root — 9391 passed, 0 failed, 49 skipped
- [x] Real-TTY witness — confirmed Esc from an open drawer (several rows deep) returns to Composer; confirmed Help pane renders without corruption after the MENUBAR_KEYS split