### PR TITLE
refactor(session): one seam for the four MCP listings; non-emission becomes a declared suppression

### DIFF
--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -103,6 +103,18 @@ class RouterHostAdapter:
     # RouterLoopHost Protocol attributes (non-property)
     output_language: str | None
 
+    # 80 flat params is not a Parameter-Object problem — grouping them was
+    # measured as a near-no-op (#3121 took Session 54 -> 45 by adding 4 objects
+    # while leaving 41 flat params in place). Nor is it a Move-Construction one:
+    # only 2 of the 80 are forward-only (stored, never read outside __init__),
+    # so this class genuinely uses 74 of them. What the width tracks instead is
+    # the tools-handler -> host hop: 14 distinct `host.<method>` names are called
+    # from `src/reyn/tools/*.py` (10 of them `mcp_*`), and each needs its own
+    # injected callable here. Collapsing the 10 MCP ones into one facade fails
+    # because the Session methods they reach are 27-48 lines each with their own
+    # ephemeral/pool routing and error contract, not thin delegates (#3409 has
+    # the per-method table). Falsifiable claim: if that hop ever goes away, this
+    # constructor loses ~14 params without anyone touching a Parameter Object.
     def __init__(
         self,
         *,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -6,6 +6,7 @@ rationale (Family decomposition).
 from __future__ import annotations
 
 import asyncio
+import enum
 import json
 import logging
 import re
@@ -928,6 +929,51 @@ def _forward_file_signal_fields(dest: dict, result: dict, *, outcome: str) -> No
             "reyn.core.op_runtime.status_classify (#3193)",
             status, result.get("kind"), result.get("op"),
         )
+
+
+# #3082: closed registry of MCP-listing seam call sites that opt OUT of the
+# default audit emission (``Session._mcp_list_via_gateway``, below). A
+# suppression is a member of ``MCPListingSuppression`` — there is no string
+# opt-out — so every non-emitting call site is enumerated here, next to a
+# reason, and grepping this dict is a complete census of "why doesn't X
+# audit-log".
+#
+# The two reasons below are NOT measurements. There is no record in this
+# repo (issue, PR description, commit) of why ``list_tools`` /
+# ``list_resource_templates`` were built without an emit while
+# ``list_resources`` / ``list_prompts`` were built with one — the #2605 PR
+# that added ``list_resources`` says only "mirrors list_tools ... discovery-
+# only, NOT permission-gated" and separately "emits mcp_resources_listed for
+# observability (list_tools has no analogous event; this ask is explicit
+# per the #2597 (2)a slice spec)" — i.e. a spec asked for the event on the
+# resources path and not on the tools path, with no rationale for the
+# asymmetry recorded anywhere. This registry preserves the existing
+# behavior deliberately (not silently, and not re-affirmed as correct);
+# #3410 is where the asymmetry itself gets settled.
+class MCPListingSuppression(enum.Enum):
+    """Closed set of MCP-listing call sites suppressing the default
+    ``mcp_<noun>_listed`` audit emission. Adding a new suppression means
+    adding a member here with a reason in
+    ``MCP_LISTING_SUPPRESSION_REASONS`` — there is no other way to opt out."""
+
+    LIST_TOOLS = "list_tools"
+    LIST_RESOURCE_TEMPLATES = "list_resource_templates"
+
+
+MCP_LISTING_SUPPRESSION_REASONS: dict[MCPListingSuppression, str] = {
+    MCPListingSuppression.LIST_TOOLS: (
+        "No record exists of why this path does not emit an audit event "
+        "(the #2605 PR that added the emitting siblings only says the "
+        "event was 'explicit per the #2597 (2)a slice spec' for resources/"
+        "prompts, not why tools was left out). Preserved as-is rather than "
+        "re-affirmed as correct; #3410 tracks settling it."
+    ),
+    MCPListingSuppression.LIST_RESOURCE_TEMPLATES: (
+        "Same as LIST_TOOLS: no record of why this path was built without "
+        "an emit. Preserved as-is rather than re-affirmed as correct; "
+        "#3410 tracks settling it."
+    ),
+}
 
 
 class Session:
@@ -7081,24 +7127,31 @@ class Session:
         """Returns the configured MCP server list with descriptions."""
         return self._get_mcp_servers_for_router()
 
-    async def _mcp_list_tools(self, server: str) -> list[dict]:
-        """Query the MCP server for its tools list."""
+    async def _mcp_list_via_gateway(
+        self,
+        server: str,
+        expanded: dict,
+        *,
+        gateway_call: Callable[[Any], Awaitable[list[dict]]],
+        noun: str,
+        suppress: "MCPListingSuppression | None" = None,
+    ) -> list[dict]:
+        """Shared MCP-listing seam (#3082): owns gateway construction, the
+        ``Cancelled``/``MCPFault`` error contract, and the audit-emit
+        decision for all four ``_mcp_list_*`` methods (tools / resources /
+        resource_templates / prompts). Each caller has already resolved its
+        own *server* config into *expanded* and passes a *gateway_call*
+        closure naming which ``MCPGateway`` listing method to invoke; *noun*
+        names the emitted event kind (``mcp_<noun>_listed``) when emission
+        is not suppressed.
+        """
+        # #3082: emitting is the default because erring toward audit coverage is
+        # the recoverable direction — a missed event is invisible after the fact,
+        # a spurious one is not. A call site that does not emit names a member of
+        # ``MCPListingSuppression``; there is no string opt-out, so every
+        # non-emitting listing path is enumerated in one place with its reason.
         from reyn.core.cancellable import Cancelled
-        from reyn.mcp.client import expand_env
         from reyn.mcp.gateway import MCPFault, MCPGateway
-
-        servers = self._mcp_servers_flat()
-        if not servers:
-            return [{"error": "no MCP servers configured"}]
-        server_cfg = servers.get(server)
-        if not server_cfg:
-            return [{"error": f"MCP server {server!r} not configured"}]
-
-        expanded = expand_env(server_cfg)
-        if not isinstance(expanded, dict):
-            return [{"error": f"MCP server {server!r} config must be a dict"}]
-        if "type" not in expanded and expanded.get("url"):
-            expanded = {**expanded, "type": "http"}
 
         # #2421: routed through the MCPGateway seam rather than a raw MCP client — the
         # seam contains the crash path, so a mid-list server death raises MCPFault
@@ -7115,11 +7168,49 @@ class Session:
             else MCPGateway(agent_id=self._agent.agent_id, cancel_event=self._loop_driver.cancel_event)
         )
         try:
-            return await gateway.list_tools(server, expanded)
+            result = await gateway_call(gateway)
         except Cancelled:
             return [{"error": "cancelled"}]
         except MCPFault as exc:
             return [{"error": str(exc)}]
+        if suppress is None:
+            self._chat_events.emit(f"mcp_{noun}_listed", server=server, count=len(result))
+        return result
+
+    def _mcp_resolve_server_config(self, server: str) -> "list[dict] | dict":
+        """Shared config-resolution step for all four ``_mcp_list_*``
+        methods: look up *server* in the flattened MCP server map and
+        ``expand_env`` it. Returns the expanded config dict on success, or a
+        single-error ``[{"error": ...}]`` list (the four methods' existing
+        early-return shape) when the server isn't configured / doesn't
+        resolve to a dict."""
+        servers = self._mcp_servers_flat()
+        if not servers:
+            return [{"error": "no MCP servers configured"}]
+        server_cfg = servers.get(server)
+        if not server_cfg:
+            return [{"error": f"MCP server {server!r} not configured"}]
+
+        from reyn.mcp.client import expand_env
+
+        expanded = expand_env(server_cfg)
+        if not isinstance(expanded, dict):
+            return [{"error": f"MCP server {server!r} config must be a dict"}]
+        if "type" not in expanded and expanded.get("url"):
+            expanded = {**expanded, "type": "http"}
+        return expanded
+
+    async def _mcp_list_tools(self, server: str) -> list[dict]:
+        """Query the MCP server for its tools list."""
+        expanded = self._mcp_resolve_server_config(server)
+        if isinstance(expanded, list):
+            return expanded
+        return await self._mcp_list_via_gateway(
+            server, expanded,
+            gateway_call=lambda gw: gw.list_tools(server, expanded),
+            noun="tools",
+            suppress=MCPListingSuppression.LIST_TOOLS,
+        )
 
     async def _mcp_list_resources(self, server: str) -> list[dict]:
         """Query the MCP server for its resources list.
@@ -7131,41 +7222,14 @@ class Session:
         observability (list_tools has no analogous event; this ask is
         explicit per the #2597 ②a slice spec).
         """
-        from reyn.core.cancellable import Cancelled
-        from reyn.mcp.client import expand_env
-        from reyn.mcp.gateway import MCPFault, MCPGateway
-
-        servers = self._mcp_servers_flat()
-        if not servers:
-            return [{"error": "no MCP servers configured"}]
-        server_cfg = servers.get(server)
-        if not server_cfg:
-            return [{"error": f"MCP server {server!r} not configured"}]
-
-        expanded = expand_env(server_cfg)
-        if not isinstance(expanded, dict):
-            return [{"error": f"MCP server {server!r} config must be a dict"}]
-        if "type" not in expanded and expanded.get("url"):
-            expanded = {**expanded, "type": "http"}
-
-        gateway = (
-            MCPGateway(
-                pool=self._mcp_connection_service, agent_id=self._agent.agent_id,
-                cancel_event=self._loop_driver.cancel_event,
-            )
-            if not self._ephemeral
-            else MCPGateway(agent_id=self._agent.agent_id, cancel_event=self._loop_driver.cancel_event)
+        expanded = self._mcp_resolve_server_config(server)
+        if isinstance(expanded, list):
+            return expanded
+        return await self._mcp_list_via_gateway(
+            server, expanded,
+            gateway_call=lambda gw: gw.list_resources(server, expanded),
+            noun="resources",
         )
-        try:
-            resources = await gateway.list_resources(server, expanded)
-        except Cancelled:
-            return [{"error": "cancelled"}]
-        except MCPFault as exc:
-            return [{"error": str(exc)}]
-        self._chat_events.emit(
-            "mcp_resources_listed", server=server, count=len(resources),
-        )
-        return resources
 
     async def _mcp_list_resource_templates(self, server: str) -> list[dict]:
         """Query the MCP server for its resource templates list.
@@ -7174,37 +7238,15 @@ class Session:
         permission-gated). Empty list is a normal result for a server that
         registers no templates.
         """
-        from reyn.core.cancellable import Cancelled
-        from reyn.mcp.client import expand_env
-        from reyn.mcp.gateway import MCPFault, MCPGateway
-
-        servers = self._mcp_servers_flat()
-        if not servers:
-            return [{"error": "no MCP servers configured"}]
-        server_cfg = servers.get(server)
-        if not server_cfg:
-            return [{"error": f"MCP server {server!r} not configured"}]
-
-        expanded = expand_env(server_cfg)
-        if not isinstance(expanded, dict):
-            return [{"error": f"MCP server {server!r} config must be a dict"}]
-        if "type" not in expanded and expanded.get("url"):
-            expanded = {**expanded, "type": "http"}
-
-        gateway = (
-            MCPGateway(
-                pool=self._mcp_connection_service, agent_id=self._agent.agent_id,
-                cancel_event=self._loop_driver.cancel_event,
-            )
-            if not self._ephemeral
-            else MCPGateway(agent_id=self._agent.agent_id, cancel_event=self._loop_driver.cancel_event)
+        expanded = self._mcp_resolve_server_config(server)
+        if isinstance(expanded, list):
+            return expanded
+        return await self._mcp_list_via_gateway(
+            server, expanded,
+            gateway_call=lambda gw: gw.list_resource_templates(server, expanded),
+            noun="resource_templates",
+            suppress=MCPListingSuppression.LIST_RESOURCE_TEMPLATES,
         )
-        try:
-            return await gateway.list_resource_templates(server, expanded)
-        except Cancelled:
-            return [{"error": "cancelled"}]
-        except MCPFault as exc:
-            return [{"error": str(exc)}]
 
     async def _mcp_read_resource(self, server: str, uri: str) -> dict:
         """Read one MCP resource by URI and return its contents.
@@ -7313,41 +7355,14 @@ class Session:
         session, one-shot pool otherwise). Emits ``mcp_prompts_listed`` for
         observability, same rationale as ``mcp_resources_listed``.
         """
-        from reyn.core.cancellable import Cancelled
-        from reyn.mcp.client import expand_env
-        from reyn.mcp.gateway import MCPFault, MCPGateway
-
-        servers = self._mcp_servers_flat()
-        if not servers:
-            return [{"error": "no MCP servers configured"}]
-        server_cfg = servers.get(server)
-        if not server_cfg:
-            return [{"error": f"MCP server {server!r} not configured"}]
-
-        expanded = expand_env(server_cfg)
-        if not isinstance(expanded, dict):
-            return [{"error": f"MCP server {server!r} config must be a dict"}]
-        if "type" not in expanded and expanded.get("url"):
-            expanded = {**expanded, "type": "http"}
-
-        gateway = (
-            MCPGateway(
-                pool=self._mcp_connection_service, agent_id=self._agent.agent_id,
-                cancel_event=self._loop_driver.cancel_event,
-            )
-            if not self._ephemeral
-            else MCPGateway(agent_id=self._agent.agent_id, cancel_event=self._loop_driver.cancel_event)
+        expanded = self._mcp_resolve_server_config(server)
+        if isinstance(expanded, list):
+            return expanded
+        return await self._mcp_list_via_gateway(
+            server, expanded,
+            gateway_call=lambda gw: gw.list_prompts(server, expanded),
+            noun="prompts",
         )
-        try:
-            prompts = await gateway.list_prompts(server, expanded)
-        except Cancelled:
-            return [{"error": "cancelled"}]
-        except MCPFault as exc:
-            return [{"error": str(exc)}]
-        self._chat_events.emit(
-            "mcp_prompts_listed", server=server, count=len(prompts),
-        )
-        return prompts
 
     async def _mcp_get_prompt(self, server: str, name: str, arguments: "dict | None" = None) -> dict:
         """Fetch one rendered MCP prompt by name and return its messages.


### PR DESCRIPTION
**[e2e-coder]** — owner-directed (#3409 の計測から). 設計は #3082 スレッドで architect firm 済み（案 A）。

## 直している非対称

`_mcp_list_{tools,resources,resource_templates,prompts}` は同じ3つを各自で組み直していました: `MCPGateway` の pooled/bare 選択、`Cancelled`/`MCPFault` のエラー契約、そして — **不揃いに** — audit emit。

| method | emit していたか |
|---|---|
| `_mcp_list_resources` | ✅ `mcp_resources_listed` |
| `_mcp_list_prompts` | ✅ `mcp_prompts_listed` |
| `_mcp_list_tools` | ❌ なし |
| `_mcp_list_resource_templates` | ❌ なし |

★ **そして「なぜ emit しないか」はどこにも記録されていませんでした。** 直している本体はこちらで、emit の有無そのものではありません。

## 形: 既定 emit ＋ 抑制は閉じた型で宣言

`Session._mcp_list_via_gateway` が3つとも所有し、4メソッドは薄い呼び出しになります。**emission が既定**で、emit しない site は閉じた `MCPListingSuppression` enum のメンバーを名指し、理由は `MCP_LISTING_SUPPRESSION_REASONS` に置きます。★**文字列 opt-out は存在しません** — その dict を grep すれば「なぜ X は audit されないのか」の完全な census になります。

**既定を emit にした理由は grain です**（cargo-cult 論ではありません）: `EVENT_AUDIT_REQUIREMENTS` の文言が "Events that must carry these audit fields" ＝ **emit は前提で、制約はそこに付く**。反対向きの第2の規約を足しません。そして記録要求が非対称なのは、**記録する価値の非対称と一致している**からです — *なぜ audit したか* は普通面白くなく、*なぜ しなかったか* だけが面白い。

## ★ 挙動は変わりません（機械的に検証）

- `resources`/`prompts` は suppression を渡さず、**同じ `mcp_resources_listed`/`mcp_prompts_listed` を同じ `server=`/`count=` で emit**
- `tools`/`resource_templates` は suppression を持ち、**引き続き何も emit しません**
- エラー返却は byte-identical（`[{"error": "cancelled"}]` / `[{"error": str(exc)}]`）

検証: `origin/main` と現行で emit される kind 集合を突き合わせ、4呼び出し site の `noun=` / `suppress=` の割り当てを列挙して確認。

## 🔴 抑制理由は「測定」ではありません

**tools-listing が高頻度で audit を汚す、という仮説は妥当ですが未測定**です。私は測れませんでした。∴ **確立した事実として書いていません。**

git 履歴で分かったのは、#2605 PR が **#2597 (2)a slice spec に従って resources 側にイベントを要求した**こと、そして **tools 側で省いた理由はどこにも記録されていない**ことだけです。レジストリは現行挙動を**意図的に保存**します（黙ってでも、正しいと再確認したのでもなく）。**#3410 が非対称そのものを決着させる場所**です。

## 同梱: `RouterHostAdapter` への K-inline 1件

80 flat params が **Parameter-Object 問題でも Move-Construction 問題でもない**ことを記録（forward-only は 80中2 なので後者は当たらない／前者は #3121 が 54→45 のほぼ no-op と実測済み）。幅が追跡しているのは **tools-handler → host の hop** で、反証可能形で書いています: **その hop が消えれば Parameter Object を触らずに約14 params 減る**。#3407 で新設された K-inline 分類の初適用です。

## 検証

- `ruff check src tests` — clean
- anchor gate / #2421 seam completeness / #2813 cancel-event completeness — **320 passed**
- `verify_module_docstrings.py` — OK
- `pytest -k mcp`（CI と同じ extras）— **874 passed / 13 skipped**
- full suite は CI へ

## Test plan

- [x] 挙動保存を機械的に検証（emit kind 集合の前後一致、site ごとの suppress 割り当て）
- [x] 上記 gate をローカルで green
- [ ] full CI green
- [ ] reviewer が確認: 抑制理由が「測定」を騙っていないか、`intentional` 相当の内容ゼロ文言でないか

part of #3082