### PR TITLE
fix(tools): make "no tools= channel" a typed arm, not an empty list — Closes #3421

### DIFF
--- a/docs/concepts/tools-integrations/codeact.ja.md
+++ b/docs/concepts/tools-integrations/codeact.ja.md
@@ -37,7 +37,9 @@ JSON `tools=` payload の代わりに、 CodeAct は **code API** を作る: モ
 呼べる action の reference list を、 system prompt に `tool(...)` signature として
 render する。 permission-eligible な各 action が 1 行 — 名前・引数・短い説明 — で
 並ぶ。 この list は *提示のみ*。 モデルはそれを読んで何が callable かを知る。
-CodeAct では JSON tool payload は空 — モデルに JSON tool-calling は一切提供されない。
+CodeAct には JSON tool channel が **そもそも存在しない** — 「channel はあるが中身が
+空」とは別のことであり、何も advertise されていないのに code API からは全 action が
+呼べる理由でもある。
 
 **何が載るか**: `enumerate-all` scheme が `tool_calls` で advertise するのと同じ
 集合 — base tool（`read_file` / `delegate_to_agent` / `session_spawn` …）と

--- a/docs/concepts/tools-integrations/codeact.md
+++ b/docs/concepts/tools-integrations/codeact.md
@@ -37,10 +37,11 @@ loops, intermediate variables, conditionals — and reaches the outside world
 
 Instead of a JSON `tools=` payload, CodeAct builds a **code API**: a reference
 list of the actions the model may call, rendered into the system prompt as
-`tool(...)` signatures. Each permission-eligible action appears as one line —
+`def name(...)` signatures. Each permission-eligible action appears as one line —
 its name, parameters, and a short description. This list is *presentation only*;
-the model reads it to know what's callable. The JSON tool payload is empty under
-CodeAct — the model is not offered JSON tool-calling at all.
+the model reads it to know what's callable. CodeAct has no JSON tool channel at
+all — that is different from having one with nothing in it, and it is why every
+action stays callable from the code API even though nothing is advertised.
 
 **What is on it:** the same set the `enumerate-all` scheme advertises over
 `tool_calls` — the base tools (`read_file`, `delegate_to_agent`, `session_spawn`,

--- a/src/reyn/runtime/capability_visibility.py
+++ b/src/reyn/runtime/capability_visibility.py
@@ -92,9 +92,11 @@ class _VisibilityProbeOps:
 
     def present(self, available: dict, layer_ctx: dict) -> Any:
         from reyn.runtime.router_tools import build_tools
-        from reyn.tools.scheme import Presentation
+        from reyn.tools.scheme import AdvertisedTools, Presentation
 
-        return Presentation(llm_tools_payload=build_tools(
+        # This probe stands in for the router's own ``present``, which is always a
+        # ``tool_calls`` presentation — the channel exists (#3421).
+        return Presentation(tools_channel=AdvertisedTools(entries=build_tools(
             self._host.list_available_agents(),
             file_permissions=self._host.get_file_permissions(),
             mcp_servers=self._host.get_mcp_servers(),
@@ -103,7 +105,7 @@ class _VisibilityProbeOps:
             search_actions_visible=layer_ctx.get("search_visible", False),
             hot_list_aliases=available.get("hot_list_aliases"),
             compact_visible=layer_ctx.get("ctx_signal_present", False),
-        ))
+        )))
 
     def base_tools(self, available: dict, layer_ctx: dict) -> "list[dict]":
         from reyn.runtime.router_tools import build_tools
@@ -416,7 +418,7 @@ class CapabilityVisibility:
         coroutine-scheduling overhead only, not a hidden I/O wait.
 
         Wrapper-expansion (architect-confirmed granularity) still holds: whatever
-        NAMES a scheme's own ``build_presentation`` puts in ``llm_tools_payload``
+        NAMES a scheme's own ``build_presentation`` puts in ``tools_channel``
         (or ``dispatchable_catalog`` when the scheme decouples it — CodeAct) ARE
         the reachable set, by construction — ``universal-category``'s own
         ``present()`` calls ``build_tools(universal_wrappers_enabled=True)``,
@@ -428,6 +430,7 @@ class CapabilityVisibility:
         """
         from reyn.tools.scheme import (
             DEFAULT_SCHEME_NAME,
+            advertised_entries,
             flat_catalog_entries,
             get_scheme,
         )
@@ -456,11 +459,24 @@ class CapabilityVisibility:
         }
         pres = _run_coro_sync(scheme.build_presentation(available, layer_ctx, ops=ops))
 
-        names = {e["name"] for e in flat_catalog_entries(pres.llm_tools_payload)}
         if pres.dispatchable_catalog is not None:
-            # CodeAct: llm_tools_payload is genuinely [] (no tools= schema); the
-            # actually-reachable set is the code-API's dispatchable catalog.
+            # A scheme that decouples dispatch from advertisement — every
+            # ``content_fence`` cell, whose channel arm is ``NoToolsChannel``, plus
+            # any ``tool_calls`` cell that chooses to. The reachable set is the
+            # dispatchable catalog, not what is advertised.
+            #
+            # #3421: this used to read the advertised payload first and then
+            # overwrite it, with a comment explaining that the CodeAct payload was
+            # "genuinely []". The comment is gone because the type now says it:
+            # a ``NoToolsChannel`` presentation cannot reach the ``else`` branch —
+            # ``Presentation`` refuses to exist with that arm and no
+            # ``dispatchable_catalog``.
             names = {e["name"] for e in flat_catalog_entries(pres.dispatchable_catalog)}
+        else:
+            names = {
+                e["name"]
+                for e in flat_catalog_entries(advertised_entries(pres.tools_channel))
+            }
 
         if self._chat_tool_use_scheme == "universal-category":
             # Wrapper-expansion: the composed payload names the 3-4 wrapper

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1650,7 +1650,15 @@ class RouterLoop:
         _pres = await self._scheme.build_presentation(
             _scheme_available, _scheme_layer_ctx, ops=self,
         )
-        tools = _pres.llm_tools_payload
+        from reyn.tools.scheme import advertised_entries  # noqa: PLC0415
+
+        # #3421: the WIRE view of the scheme's ``tools=`` channel. Both arms
+        # collapse to a list here and that is correct at this boundary — a
+        # transport with no channel (``content_fence``) and a channel with no
+        # eligible tool both send ``tools=[]``. What must NOT collapse is the
+        # dispatch gate, and it does not: a no-channel cell is required to carry
+        # ``dispatchable_catalog``, read below.
+        tools = advertised_entries(_pres.tools_channel)
         # #187 STEP 1c (owner principle): actions are enumerated ONLY by
         # list_actions, and their schemas ONLY by describe_action. The former
         # ARS block (B37/B38) inlined the whole session action catalog into
@@ -2061,6 +2069,7 @@ class RouterLoop:
                 Execute,
                 ExecutionResult,
                 RePresent,
+                advertised_entries,
             )
             # #1666: bound the per-turn tool_call count BEFORE interpret, so all
             # branches + the assistant↔tool-result alignment inherit the cap from a
@@ -2160,7 +2169,8 @@ class RouterLoop:
                     ops=self,
                 )
                 tools = apply_contextual_visibility(
-                    _re_pres.llm_tools_payload, self._contextual_permission,
+                    advertised_entries(_re_pres.tools_channel),
+                    self._contextual_permission,
                 )
                 self._catalog = {t["function"]["name"]: t for t in tools}
                 self._tool_names = frozenset(self._catalog.keys())
@@ -2990,7 +3000,7 @@ class RouterLoop:
         only; the scheme layer owns the tool-use SP (the universal-category
         scheme turns this payload into an ``Exposure`` and lets the ``tool_calls``
         encoder produce both channels)."""
-        from reyn.tools.scheme import Presentation
+        from reyn.tools.scheme import AdvertisedTools, Presentation
 
         univ = layer_ctx["univ_enabled"]
         search_visible = layer_ctx["search_visible"]
@@ -3005,7 +3015,9 @@ class RouterLoop:
             compact_visible=layer_ctx["ctx_signal_present"],
         )
         return Presentation(
-            llm_tools_payload=tools,
+            # The router's own presentation is always a ``tool_calls`` one, so the
+            # channel EXISTS here even when ``build_tools`` returns nothing (#3421).
+            tools_channel=AdvertisedTools(entries=tools),
         )
 
     def base_tools(self, available, layer_ctx) -> list[dict]:

--- a/src/reyn/tools/encoders.py
+++ b/src/reyn/tools/encoders.py
@@ -7,6 +7,11 @@ positional tool-use system-prompt slot-map; ``content_fence`` advertises no
 ``tools=`` at all and renders the descriptors as a Python code-API the model
 calls by identifier.
 
+``encode_tools`` therefore returns a ``ToolsChannel`` (``reyn.tools.scheme``),
+not a list: the two transports disagree about whether the channel EXISTS, which
+is a different question from how many tools are in it, and an empty list could
+only answer the second (#3421).
+
 **One encoder per transport, not one per cell.** A per-cell composer would
 rebuild ``_VALID_SCHEME_TRANSPORT_PAIRS`` implicitly, one decision point per
 cell — the thing the pair table exists to make explicit.
@@ -38,6 +43,7 @@ from reyn.tools.exposure import (
     Exposure,
     FunctionDescriptor,
 )
+from reyn.tools.scheme import AdvertisedTools, NoToolsChannel
 from reyn.tools.transport import Transport
 
 
@@ -157,9 +163,13 @@ class ToolCallsEncoder:
     )
     encodes_sp_slot_overrides = True
 
-    def encode_tools(self, exposure: Exposure) -> "list[dict]":
+    def encode_tools(self, exposure: Exposure) -> AdvertisedTools:
         _assert_encodable(self, exposure)
-        return [d.as_tool_calls_entry() for d in exposure.descriptors]
+        # Always the ``AdvertisedTools`` arm, INCLUDING when the exposure carries
+        # no descriptor: this transport does have a ``tools=`` channel, and an
+        # exposure narrowed down to nothing means the channel is empty — a state
+        # the other arm does not describe (#3421).
+        return AdvertisedTools(entries=[d.as_tool_calls_entry() for d in exposure.descriptors])
 
     def encode_tool_use_sp(self, exposure: Exposure) -> "dict[str, str]":
         _assert_encodable(self, exposure)
@@ -182,11 +192,13 @@ class ContentFenceEncoder:
     encodable_descriptor_kinds = frozenset({DESCRIPTOR_KIND_FUNCTION})
     encodes_sp_slot_overrides = False
 
-    def encode_tools(self, exposure: Exposure) -> "list[dict]":
+    def encode_tools(self, exposure: Exposure) -> NoToolsChannel:
         _assert_encodable(self, exposure)
         # Not "there are no tools" — this transport has no ``tools=`` channel.
-        # The whole tool-use surface is the code-API below.
-        return []
+        # The whole tool-use surface is the code-API below. #3421 moved that
+        # sentence out of this comment and into the return TYPE, so a consumer
+        # can act on it instead of only reading about it here.
+        return NoToolsChannel()
 
     def encode_tool_use_sp(self, exposure: Exposure) -> str:
         _assert_encodable(self, exposure)

--- a/src/reyn/tools/scheme.py
+++ b/src/reyn/tools/scheme.py
@@ -37,20 +37,82 @@ class ToolUseLayer(str, Enum):
     CHAT = "chat"
 
 
+# ── The ``tools=`` channel (#3421) ──────────────────────────────────────────
+#
+# A transport either HAS a ``tools=`` channel or it does not, and that is a
+# different question from how many tools are in it. Expressing the second answer
+# as an empty list made the two indistinguishable: ``[]`` read equally well as
+# "this transport advertises nothing right now" (a real, reachable state — every
+# tool narrowed away by permission) and as "this transport has no such channel at
+# all" (``content_fence``, whose entire surface is the code-API in the system
+# prompt). The distinction was stated in prose at three call sites and in the
+# type at none, so no consumer could act on it.
+#
+# It is a ``{kind: ...}`` discriminated union for the same reason
+# ``exposure.ToolDescriptor`` is: the arm a value is on is a fact the producer
+# knows and the consumer must not re-derive by sniffing the value's shape.
+
+TOOLS_CHANNEL_KIND_ADVERTISED = "advertised"
+TOOLS_CHANNEL_KIND_ABSENT = "absent"
+
+
+@dataclass(frozen=True)
+class AdvertisedTools:
+    """This transport HAS a ``tools=`` channel; ``entries`` is what is in it.
+
+    ``entries == []`` is meaningful on this arm and does not mean the same thing
+    as ``NoToolsChannel``: it says the channel exists and is currently empty (no
+    tool survived exclusion / permission narrowing), which is a state the model
+    can be shown and the operator can be told about."""
+
+    entries: list[dict]
+    kind: str = TOOLS_CHANNEL_KIND_ADVERTISED
+
+
+@dataclass(frozen=True)
+class NoToolsChannel:
+    """This transport has NO ``tools=`` channel — the field does not apply.
+
+    ``content_fence`` is the case: the model expresses a chosen action by writing
+    a fenced snippet against the code-API in ``tool_use_sp``, and nothing is ever
+    advertised through ``tools=``. A cell on this arm therefore cannot use
+    advertisement as its dispatch gate, which is why ``Presentation`` requires it
+    to carry an explicit ``dispatchable_catalog`` (#1618 root-1, now checked)."""
+
+    kind: str = TOOLS_CHANNEL_KIND_ABSENT
+
+
+ToolsChannel = AdvertisedTools | NoToolsChannel
+
+
+def advertised_entries(channel: ToolsChannel) -> "list[dict]":
+    """The entries that reach the provider's ``tools=`` argument — ``[]`` on the
+    absent arm.
+
+    This is the WIRE view, and the collapse is deliberate: an absent channel and
+    an empty one send the same thing, so a consumer whose only job is to hand the
+    payload to the provider (or to name what the model can see) is right to call
+    this. A consumer that must tell the two apart branches on the arm instead —
+    which is now possible, and is the whole point of the union."""
+    if isinstance(channel, AdvertisedTools):
+        return channel.entries
+    return []
+
+
 @dataclass
 class Presentation:
-    """What a scheme shows the LLM: the ``tools=`` payload + the tool-use SP.
+    """What a scheme shows the LLM: the ``tools=`` channel + the tool-use SP.
 
     A scheme builds this by handing an ``Exposure`` (``reyn.tools.exposure`` —
     what is shown, transport-neutrally) to the encoder for its transport
     (``reyn.tools.encoders`` — how that transport writes it down). Both fields
     below are therefore encoder output, and the two channels differ by transport
-    rather than by scheme: ``tool_calls`` fills ``llm_tools_payload`` and a
-    positional slot-map; ``content_fence`` has no ``tools=`` channel at all and
-    puts its whole surface in ``tool_use_sp``.
+    rather than by scheme: ``tool_calls`` fills ``tools_channel`` with
+    ``AdvertisedTools`` and a positional slot-map; ``content_fence`` says
+    ``NoToolsChannel`` and puts its whole surface in ``tool_use_sp``.
     """
 
-    llm_tools_payload: list[dict]
+    tools_channel: ToolsChannel
     # #1593 PR-4: the scheme's current candidate set (hashable ids) — the OS reads
     # this on the RePresent loop to detect convergence (``new = candidates - seen``;
     # empty ⇒ stop). Default empty: schemes that never RePresent (universal /
@@ -58,11 +120,11 @@ class Presentation:
     candidates: tuple = field(default_factory=tuple)
     # #1618 root-1: the scheme's DISPATCHABLE action set — the membership/resolution
     # gate for ANY call (JSON tool_call OR in-code ``tool()``), in the canonical
-    # ``catalog_entries`` shape. Decoupled from ``llm_tools_payload`` (what the LLM
+    # ``catalog_entries`` shape. Decoupled from ``tools_channel`` (what the LLM
     # is ADVERTISED): a scheme can advertise nothing yet dispatch everything (CodeAct
     # writes code, advertises ∅, dispatches the full catalog). Default ``None`` ⇒
-    # dispatchable = advertised (``llm_tools_payload``) — byte-identical for
-    # universal / enumerate-all / retrieval, whose three catalog notions coincide.
+    # dispatchable = advertised — byte-identical for universal / enumerate-all /
+    # retrieval, whose three catalog notions coincide.
     dispatchable_catalog: "list[dict] | None" = None
     # #1618 root-2 / #1627 Stage 0 — positional slot-map for the tool-use SP regions.
     # ``None`` ⇒ the OS builds all three slots via build_universal_tool_use_slots
@@ -77,9 +139,28 @@ class Presentation:
     # the content is scheme-owned. OS retains identity + errors-verbatim + non-tool routing.
     tool_use_sp: "dict[str, str] | str | None" = None
 
+    def __post_init__(self) -> None:
+        # #3421: a cell with no ``tools=`` channel cannot use advertisement as its
+        # dispatch gate — there is nothing advertised to key on — so it MUST name
+        # its dispatchable set explicitly. That was already true of every
+        # ``content_fence`` cell by construction (#1618 root-1: "an empty
+        # advertisement must not become an empty dispatch gate"); it is checkable
+        # only now that "no channel" is a value rather than an empty list. Note
+        # ``dispatchable_catalog=[]`` passes: a cell that genuinely dispatches
+        # nothing says so, which is the same empty-vs-absent discipline one level
+        # down.
+        if isinstance(self.tools_channel, NoToolsChannel) and self.dispatchable_catalog is None:
+            raise ValueError(
+                "a Presentation on the NoToolsChannel arm must carry an explicit "
+                "dispatchable_catalog: with no tools= channel there is no "
+                "advertisement for the dispatch gate to fall back on, so "
+                "dispatchable_catalog=None would silently gate every call against "
+                "an empty set. Pass [] to mean 'dispatches nothing'."
+            )
+
 
 # ── Canonical catalog-shape projections (#1618 root-1) ──────────────────────
-# ``catalog_entries`` (and ``llm_tools_payload``) carry ONE canonical entry shape —
+# ``catalog_entries`` (and an ``AdvertisedTools.entries`` payload) carry ONE canonical
 # the OpenAI-nested ``{"type":"function","function":{"name","description",
 # "parameters"}}``. The OS owns the projections every consumer needs, so no consumer
 # hand-reads a nested dict at a guessed depth (the #1/#3 root: render + the exclude
@@ -314,6 +395,8 @@ DEFAULT_SCHEME_NAME = "enumerate-all"
 
 
 __all__ = [
+    "TOOLS_CHANNEL_KIND_ABSENT", "TOOLS_CHANNEL_KIND_ADVERTISED",
+    "AdvertisedTools", "NoToolsChannel", "ToolsChannel", "advertised_entries",
     "ToolUseLayer", "Presentation", "Execute", "RePresent", "CodeBlock",
     "Interpretation", "ExecutionResult", "ExecContext", "ToolUseScheme", "SchemeOps",
     "register_scheme", "get_scheme", "registered_scheme_names",

--- a/src/reyn/tools/schemes/_category_exposure.py
+++ b/src/reyn/tools/schemes/_category_exposure.py
@@ -75,7 +75,8 @@ def build_category_exposure(
 ) -> Exposure:
     """Build the transport-neutral exposure for one ``category`` cell.
 
-    ``present_entries`` is ``ops.present(...).llm_tools_payload`` — the router's
+    ``present_entries`` is ``advertised_entries(ops.present(...).tools_channel)``
+    — the router's
     universal-category presentation, the already-folded wrapper composition. It
     is passed in already computed because the ``content_fence`` cell needs the
     same untouched list for its dispatchable catalog, and calling ``build_tools``

--- a/src/reyn/tools/schemes/_content_fence_cell.py
+++ b/src/reyn/tools/schemes/_content_fence_cell.py
@@ -118,17 +118,21 @@ class ContentFenceCellScheme:
         """Assemble the cell's ``Presentation`` from its exposure via the
         ``content_fence`` encoder.
 
-        Both channels are encoder output. ``llm_tools_payload`` is the encoder's
-        empty list — NOT "there are no tools" but "this transport has no
-        ``tools=`` channel", which is why the empty list is returned by the
-        encoder rather than written here. ``tool_use_sp`` is the rendered
+        Both channels are encoder output. ``tools_channel`` is the encoder's
+        ``NoToolsChannel`` — NOT "there are no tools" but "this transport has no
+        ``tools=`` channel". Since #3421 that is the value's TYPE rather than a
+        sentence about an empty list, so ``capability_visibility`` and the
+        router read the distinction instead of being told it in a comment.
+        ``dispatchable_catalog`` is mandatory on that arm (``Presentation``
+        checks it): with nothing advertised there is no advertisement for the
+        dispatch gate to fall back on (#1618 root-1). ``tool_use_sp`` is the rendered
         code-API: the SOLE tool-use instruction the model sees, injected at the
         ## Capabilities position with the universal tool-use construction
         dropped (#1618 root-3 ②)."""
         exposure, dispatchable_entries = await self.build_exposure(available, layer_ctx, ops)
         encoder = encoder_for_transport(Transport.CONTENT_FENCE)
         return Presentation(
-            llm_tools_payload=encoder.encode_tools(exposure),
+            tools_channel=encoder.encode_tools(exposure),
             dispatchable_catalog=dispatchable_entries,
             tool_use_sp=encoder.encode_tool_use_sp(exposure),
         )

--- a/src/reyn/tools/schemes/category_content_fence.py
+++ b/src/reyn/tools/schemes/category_content_fence.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 from typing import Any
 
 from reyn.tools.exposure import Exposure
-from reyn.tools.scheme import register_scheme
+from reyn.tools.scheme import advertised_entries, register_scheme
 from reyn.tools.schemes._category_exposure import (
     CONTENT_FENCE_EXPOSURE_DEVIATION,
     build_category_exposure,
@@ -77,7 +77,7 @@ class CategoryContentFenceScheme(ContentFenceCellScheme):
         inside the exposure builder rather than by the OS's post-presentation
         ``tools=`` filter, because this transport has no ``tools=`` payload for
         that filter to act on."""
-        present_entries = list(ops.present(available, layer_ctx).llm_tools_payload)
+        present_entries = advertised_entries(ops.present(available, layer_ctx).tools_channel)
         exposure = build_category_exposure(
             present_entries=present_entries,
             available=available,

--- a/src/reyn/tools/schemes/enumerate_all.py
+++ b/src/reyn/tools/schemes/enumerate_all.py
@@ -80,7 +80,7 @@ class EnumerateAllScheme:
         )
         encoder = encoder_for_transport(Transport.TOOL_CALLS)
         return Presentation(
-            llm_tools_payload=encoder.encode_tools(exposure),
+            tools_channel=encoder.encode_tools(exposure),
             tool_use_sp=encoder.encode_tool_use_sp(exposure),
         )
 

--- a/src/reyn/tools/schemes/retrieval.py
+++ b/src/reyn/tools/schemes/retrieval.py
@@ -113,7 +113,7 @@ class RetrievalScheme:
         answer to "how is this written down" — the seam's whole point."""
         encoder = encoder_for_transport(Transport.TOOL_CALLS)
         return Presentation(
-            llm_tools_payload=encoder.encode_tools(exposure),
+            tools_channel=encoder.encode_tools(exposure),
             tool_use_sp=encoder.encode_tool_use_sp(exposure),
             **presentation_fields,
         )

--- a/src/reyn/tools/schemes/retrieval_content_fence.py
+++ b/src/reyn/tools/schemes/retrieval_content_fence.py
@@ -56,7 +56,7 @@ from __future__ import annotations
 from typing import Any
 
 from reyn.tools.exposure import Exposure, ExposureDeviation, descriptors_from_entries
-from reyn.tools.scheme import register_scheme
+from reyn.tools.scheme import advertised_entries, register_scheme
 from reyn.tools.schemes._content_fence_cell import ContentFenceCellScheme
 from reyn.tools.schemes._retrieval_exposure import retrieval_sp_facts
 from reyn.tools.transport import CONTENT_FENCE_RETRIEVAL_SCHEME_NAME
@@ -187,7 +187,7 @@ class RetrievalContentFenceScheme(ContentFenceCellScheme):
         with ``unknown_tool`` instead of the truthful ``tool_excluded``
         (#1618 root-1)."""
         if layer_ctx.get("search_visible", False):
-            entries = list(ops.present(available, layer_ctx).llm_tools_payload)
+            entries = advertised_entries(ops.present(available, layer_ctx).tools_channel)
             deviation = SEARCH_FIRST_EXPOSURE_DEVIATION
         else:
             entries = list(ops.base_tools(available, layer_ctx)) + await ops.catalog_entries()

--- a/src/reyn/tools/schemes/universal_category.py
+++ b/src/reyn/tools/schemes/universal_category.py
@@ -39,6 +39,7 @@ from reyn.tools.scheme import (
     PlainText,
     Presentation,
     SchemeOps,
+    advertised_entries,
     register_scheme,
 )
 from reyn.tools.schemes._category_exposure import (
@@ -67,14 +68,16 @@ class UniversalCategoryScheme:
         # but universal's body is unchanged — ops.present stays sync and is NOT
         # awaited, so the tools= bytes are byte-identical to PR-1.
         exposure = build_category_exposure(
-            present_entries=ops.present(available, layer_ctx).llm_tools_payload,
+            present_entries=advertised_entries(
+                ops.present(available, layer_ctx).tools_channel
+            ),
             available=available,
             layer_ctx=layer_ctx,
             deviation=TOOL_CALLS_EXPOSURE_DEVIATION,
         )
         encoder = encoder_for_transport(Transport.TOOL_CALLS)
         return Presentation(
-            llm_tools_payload=encoder.encode_tools(exposure),
+            tools_channel=encoder.encode_tools(exposure),
             tool_use_sp=encoder.encode_tool_use_sp(exposure),
         )
 

--- a/src/reyn/tools/transport.py
+++ b/src/reyn/tools/transport.py
@@ -15,8 +15,8 @@ this registry as the live parse-time validation authority for the
 ``tool_use.scheme`` x ``tool_use.transport`` 2-key config (the former
 ``tool_use.chat`` is removed, clean-break). WITHOUT physically splitting
 ``ToolUseScheme`` into two protocols (firm §2 J3 — ``Presentation`` already
-carries the transport freedom via ``llm_tools_payload`` emptiness +
-``tool_use_sp`` + the ``Interpretation`` Execute/CodeBlock branch; transport
+carries the transport freedom via its ``tools_channel`` arm (#3421 — an
+absent ``tools=`` channel is a value, not an empty list) + ``tool_use_sp`` + the ``Interpretation`` Execute/CodeBlock branch; transport
 is expressed as a construction-strategy + interpret-branch SELECTION, not a
 bundle reshuffle).
 
@@ -111,7 +111,7 @@ CONTENT_FENCE_RETRIEVAL_SCHEME_NAME = "retrieval+content_fence"
 # TODAY. The (enumerate-all, content_fence) cell is CodeAct — census-verified
 # as `enumerate-all` presentation (identical full flat catalog via
 # `dispatchable_catalog=entries` / `ops.catalog_entries()`) expressed over the
-# `content_fence` transport (`llm_tools_payload=[]` + `tool_use_sp` rendered
+# `content_fence` transport (`tools_channel=NoToolsChannel()` + `tool_use_sp` rendered
 # code-API + the CodeBlock interpret branch) — see FP-0066 issue #3247, P4
 # firm §1. P4c (#3247) removed the standalone `"codeact"` `_SCHEMES` name
 # (clean-break: codeact is reached ONLY via this (scheme, transport) pair,

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -1091,7 +1091,7 @@ def _describe_one(
         # #3383: a LIVE LLM-payload seam, not just a tool-result one —
         # ``catalog_entries`` below reuses this ``input_schema`` as an entry's
         # ``parameters``, and the DEFAULT ``enumerate-all`` scheme concatenates
-        # ``catalog_entries()`` into ``llm_tools_payload`` → ``tools=``. Route
+        # ``catalog_entries()`` into the advertised ``tools_channel`` → ``tools=``. Route
         # through the one projection that owns the deep-copy obligation.
         "input_schema": parameters_for_export(target.parameters),
     }

--- a/tests/test_3220_capability_visibility_composed_payload.py
+++ b/tests/test_3220_capability_visibility_composed_payload.py
@@ -185,16 +185,16 @@ class _OracleOps:
 
     def present(self, available, layer_ctx):
         from reyn.runtime.router_tools import build_tools
-        from reyn.tools.scheme import Presentation
+        from reyn.tools.scheme import AdvertisedTools, Presentation
 
-        return Presentation(llm_tools_payload=build_tools(
+        return Presentation(tools_channel=AdvertisedTools(entries=build_tools(
             self._host.list_available_agents(),
             file_permissions=self._host.get_file_permissions(),
             mcp_servers=self._host.get_mcp_servers(),
             web_fetch_allowed=self._host.get_web_fetch_allowed(),
             universal_wrappers_enabled=layer_ctx["univ_enabled"],
             search_actions_visible=layer_ctx.get("search_visible", False),
-        ))
+        )))
 
     def base_tools(self, available, layer_ctx):
         from reyn.runtime.router_tools import build_tools
@@ -228,7 +228,7 @@ async def _oracle_payload_names(session: Session, scheme_name: str) -> "tuple[se
     what the scheme actually puts in ``tools=`` (or ``dispatchable_catalog`` for
     CodeAct); ``catalog_names`` = the full ``universal_catalog`` action set (the
     wrapper-expansion target for universal-category)."""
-    from reyn.tools.scheme import flat_catalog_entries, get_scheme
+    from reyn.tools.scheme import advertised_entries, flat_catalog_entries, get_scheme
 
     ops = _OracleOps(session.router_host)
     scheme = get_scheme(scheme_name)
@@ -243,7 +243,7 @@ async def _oracle_payload_names(session: Session, scheme_name: str) -> "tuple[se
         "available_skills": None,
     }
     pres = await scheme.build_presentation(available, layer_ctx, ops=ops)
-    payload_names = {e["name"] for e in flat_catalog_entries(pres.llm_tools_payload)}
+    payload_names = {e["name"] for e in flat_catalog_entries(advertised_entries(pres.tools_channel))}
     if pres.dispatchable_catalog is not None:
         payload_names = {e["name"] for e in flat_catalog_entries(pres.dispatchable_catalog)}
     catalog_names = {e["name"] for e in flat_catalog_entries(await ops.catalog_entries())}

--- a/tests/test_3378_advertise_enforce_agreement.py
+++ b/tests/test_3378_advertise_enforce_agreement.py
@@ -261,7 +261,14 @@ def test_intra_turn_narrowing_re_filters_the_advertised_catalog() -> None:
     finer grain. Round 1's payload (captured below) is the falsifying control: the
     names are there until the narrowing engages.
     """
-    from reyn.tools.scheme import Execute, ExecutionResult, PlainText, Presentation, register_scheme
+    from reyn.tools.scheme import (
+        AdvertisedTools,
+        Execute,
+        ExecutionResult,
+        PlainText,
+        Presentation,
+        register_scheme,
+    )
 
     contextual = _untrusted_contextual()
     target = "multi_agent__delegate"
@@ -275,10 +282,10 @@ def test_intra_turn_narrowing_re_filters_the_advertised_catalog() -> None:
 
         async def build_presentation(self, available, layer_ctx, ops) -> Presentation:
             return Presentation(
-                llm_tools_payload=[
+                tools_channel=AdvertisedTools(entries=[
                     {"type": "function", "function": {"name": n, "description": ""}}
                     for n in ("list_agents", target)
-                ],
+                ]),
             )
 
         def interpret(self, llm_response, *, tool_catalog, ops):
@@ -354,6 +361,7 @@ def test_represent_round_applies_the_advertisement_filter() -> None:
     payload must pass the same filter, or a re-present silently re-offers a denied
     tool the loop's own gate rejects."""
     from reyn.tools.scheme import (
+        AdvertisedTools,
         Execute,
         ExecutionResult,
         PlainText,
@@ -375,16 +383,16 @@ def test_represent_round_applies_the_advertisement_filter() -> None:
         async def build_presentation(self, available, layer_ctx, ops) -> Presentation:
             if not layer_ctx.get("refinement"):
                 return Presentation(
-                    llm_tools_payload=[
+                    tools_channel=AdvertisedTools(entries=[
                         {"type": "function",
                          "function": {"name": "search", "description": ""}},
-                    ],
+                    ]),
                 )
             return Presentation(
-                llm_tools_payload=[
+                tools_channel=AdvertisedTools(entries=[
                     {"type": "function", "function": {"name": n, "description": ""}}
                     for n in ("list_agents", target)
-                ],
+                ]),
                 candidates=("list_agents",),
             )
 

--- a/tests/test_catalog_shape_contract_1618.py
+++ b/tests/test_catalog_shape_contract_1618.py
@@ -1,6 +1,7 @@
 """Tier 2: #1618 root-1 + root-4 — the canonical catalog-shape contract + projections.
 
-`catalog_entries` (and `llm_tools_payload`) carry ONE canonical entry shape — the
+`catalog_entries` (and an advertised `tools_channel` payload) carry ONE canonical
+entry shape — the
 OpenAI-nested `{type, function:{name, description, parameters}}`. The OS provides the
 projections every consumer reads (`flat_catalog_entries` for render + the dispatch
 membership; `dispatch_catalog_map` for the gate), so **no consumer hand-reads a nested

--- a/tests/test_codeact_coexistence_1593.py
+++ b/tests/test_codeact_coexistence_1593.py
@@ -25,6 +25,7 @@ from reyn.runtime.router_loop import RouterLoop
 from reyn.tools.scheme import (
     CodeBlock,
     ExecutionResult,
+    NoToolsChannel,
     PlainText,
     Presentation,
 )
@@ -115,7 +116,13 @@ class _FakeCodeActScheme:
 
     async def build_presentation(self, available, layer_ctx, ops) -> Presentation:
         return Presentation(
-            llm_tools_payload=[],
+            # #3421: a CodeAct cell has NO ``tools=`` channel — not an empty one.
+            # ``dispatchable_catalog`` is mandatory on that arm because there is no
+            # advertisement for the dispatch gate to fall back on; this Fake
+            # dispatches through its own ``execute``, so it names the empty set
+            # rather than leaving the question unanswered.
+            tools_channel=NoToolsChannel(),
+            dispatchable_catalog=[],
             tool_use_sp="code-api",
         )
 

--- a/tests/test_codeact_scheme_1593.py
+++ b/tests/test_codeact_scheme_1593.py
@@ -25,7 +25,13 @@ from types import SimpleNamespace
 import pytest
 
 from reyn.runtime.router_system_prompt import build_system_prompt
-from reyn.tools.scheme import CodeBlock, ExecContext, ExecutionResult, PlainText
+from reyn.tools.scheme import (
+    CodeBlock,
+    ExecContext,
+    ExecutionResult,
+    NoToolsChannel,
+    PlainText,
+)
 from reyn.tools.schemes.codeact import CodeActScheme
 
 
@@ -155,8 +161,9 @@ async def test_build_presentation_renders_code_api_into_tool_use_sp() -> None:
     tool_use_sp (the REPLACE channel); no JSON tools=. Behavior-pinned (action names
     + tool() proxy + prose=terminal contract present), not format-pinned."""
     pres = await CodeActScheme().build_presentation({}, {}, _CatalogOps())
-    # No JSON tools= — CodeAct presents via the SP, model writes a snippet.
-    assert pres.llm_tools_payload == []
+    # No JSON tools= — CodeAct presents via the SP, model writes a snippet. #3421:
+    # the channel is declared ABSENT, which is not the same claim as "empty".
+    assert isinstance(pres.tools_channel, NoToolsChannel)
     # The actions surface in the code-API as DIRECT functions (#1658: def <name>(...),
     # not the tool('name') string-proxy), via the REPLACE channel (tool_use_sp).
     assert "file__read" in pres.tool_use_sp

--- a/tests/test_enumerate_all_scheme_1593.py
+++ b/tests/test_enumerate_all_scheme_1593.py
@@ -24,12 +24,14 @@ if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
 from reyn.tools.scheme import (
+    AdvertisedTools,
     Execute,
     ExecutionResult,
     PlainText,
     Presentation,
     SchemeOps,
     ToolUseScheme,
+    advertised_entries,
 )
 from reyn.tools.schemes.enumerate_all import EnumerateAllScheme
 
@@ -41,7 +43,7 @@ class _FakeOps:
         self.dispatched: list[dict] | None = None
 
     def present(self, available, layer_ctx) -> Presentation:  # universal-only; unused here
-        return Presentation(llm_tools_payload=[{"function": {"name": "WRAPPER"}}])
+        return Presentation(tools_channel=AdvertisedTools(entries=[{"function": {"name": "WRAPPER"}}]))
 
     def base_tools(self, available, layer_ctx) -> list[dict]:
         return [{"function": {"name": "file__read"}}]
@@ -78,7 +80,7 @@ async def test_build_presentation_is_base_plus_catalog_flat() -> None:
     pres = await s.build_presentation(
         {"hot_list_aliases": []}, {"search_visible": False}, _FakeOps(),
     )
-    names = [t["function"]["name"] for t in pres.llm_tools_payload]
+    names = [t["function"]["name"] for t in advertised_entries(pres.tools_channel)]
     assert names == ["file__read", "git__commit", "web__fetch"]   # base then catalog, flat
     assert "WRAPPER" not in names                                   # NOT via ops.present
 
@@ -213,7 +215,7 @@ async def test_enumerate_all_excludes_catalog_mcp_wrapper_3219() -> None:
     pres = await s.build_presentation(
         {"hot_list_aliases": []}, {"search_visible": False}, _RealCatalogOps(),
     )
-    names = [t["function"]["name"] for t in pres.llm_tools_payload]
+    names = [t["function"]["name"] for t in advertised_entries(pres.tools_channel)]
 
     # after: MCP-call action appears in exactly one shape — native, only once.
     assert names.count("call_mcp_tool") == 1

--- a/tests/test_represent_arm_1593.py
+++ b/tests/test_represent_arm_1593.py
@@ -26,6 +26,7 @@ from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.router_loop import _MAX_REPRESENT_ROUNDS, _REPRESENT_ACK
 from reyn.tools.scheme import (
+    AdvertisedTools,
     Execute,
     ExecutionResult,
     PlainText,
@@ -62,7 +63,7 @@ class _FakeRepresentScheme:
     async def build_presentation(self, available, layer_ctx, ops) -> Presentation:
         refinement = layer_ctx.get("refinement")
         if not refinement:
-            return Presentation(llm_tools_payload=[_search_tool()])
+            return Presentation(tools_channel=AdvertisedTools(entries=[_search_tool()]))
         self.represent_calls.append({
             "refinement": refinement, "presented": layer_ctx.get("presented"),
         })
@@ -71,11 +72,11 @@ class _FakeRepresentScheme:
             # but the scheme never drops the search tool (a misbehaving scheme).
             tag = f"action_{len(self.represent_calls)}"
             return Presentation(
-                llm_tools_payload=[_matched_tool(), _search_tool()],
+                tools_channel=AdvertisedTools(entries=[_matched_tool(), _search_tool()]),
                 candidates=(tag,),
             )
         return Presentation(
-            llm_tools_payload=[_matched_tool()],
+            tools_channel=AdvertisedTools(entries=[_matched_tool()]),
             candidates=("matched_action",),
         )
 
@@ -164,7 +165,7 @@ class _TextRepresentScheme:
         self.represented = False
 
     async def build_presentation(self, available, layer_ctx, ops) -> Presentation:
-        return Presentation(llm_tools_payload=[_matched_tool()],
+        return Presentation(tools_channel=AdvertisedTools(entries=[_matched_tool()]),
                             candidates=("matched_action",))
 
     def interpret(self, llm_response, *, tool_catalog, ops):

--- a/tests/test_retrieval_scheme_1593.py
+++ b/tests/test_retrieval_scheme_1593.py
@@ -12,7 +12,13 @@ from __future__ import annotations
 
 import pytest
 
-from reyn.tools.scheme import ExecContext, Execute, ExecutionResult, RePresent
+from reyn.tools.scheme import (
+    ExecContext,
+    Execute,
+    ExecutionResult,
+    RePresent,
+    advertised_entries,
+)
 from reyn.tools.schemes.retrieval import _SEARCH_TOOL_NAME, RetrievalScheme
 
 
@@ -68,7 +74,7 @@ async def test_initial_presentation_shows_search_tool(tmp_path) -> None:
     narrowing-before-call posture."""
     ops = _FakeOps()
     pres = await RetrievalScheme().build_presentation({}, {"search_visible": True}, ops)
-    names = [t["function"]["name"] for t in pres.llm_tools_payload]
+    names = [t["function"]["name"] for t in advertised_entries(pres.tools_channel)]
     assert _SEARCH_TOOL_NAME in names and "respond" in names
     assert ops.calls == []                                # no search yet (no refinement)
 
@@ -98,7 +104,7 @@ async def test_initial_presentation_falls_back_to_catalog_when_search_unavailabl
     ops = _FakeOps(catalog=[_tool("file__write"), _tool("file__read")])
     # search_visible absent (defaults False) — mirrors "no embedding configured".
     pres = await RetrievalScheme().build_presentation({}, {}, ops)
-    names = {t["function"]["name"] for t in pres.llm_tools_payload}
+    names = {t["function"]["name"] for t in advertised_entries(pres.tools_channel)}
     assert _SEARCH_TOOL_NAME not in names                 # search NEVER offered — would be a dead end
     assert {"file__write", "file__read"} <= names          # catalog stays fully reachable instead
     assert "respond" in names                              # base tools still present
@@ -113,7 +119,7 @@ async def test_refined_presentation_runs_search_and_exposes_candidates(tmp_path)
     Presentation.candidates (the OS convergence signal)."""
     ops = _FakeOps(matches=["file__write", "file__read"], catalog=[_tool("file__write"), _tool("file__read"), _tool("web__fetch")])
     pres = await RetrievalScheme().build_presentation({}, {"refinement": {"query": "edit a file"}}, ops)
-    names = {t["function"]["name"] for t in pres.llm_tools_payload}
+    names = {t["function"]["name"] for t in advertised_entries(pres.tools_channel)}
     assert {"file__write", "file__read"} <= names         # matched subset presented
     assert "web__fetch" not in names                      # unmatched NOT presented
     assert _SEARCH_TOOL_NAME in names                     # search stays (non-terminal)
@@ -132,7 +138,7 @@ async def test_convergence_drops_search_tool(tmp_path) -> None:
     pres = await RetrievalScheme().build_presentation(
         {}, {"refinement": {"query": "edit"}, "presented": ("file__write",)}, ops,
     )
-    names = {t["function"]["name"] for t in pres.llm_tools_payload}
+    names = {t["function"]["name"] for t in advertised_entries(pres.tools_channel)}
     assert "file__write" in names
     assert _SEARCH_TOOL_NAME not in names                 # converged → search dropped → must Execute
 
@@ -146,7 +152,7 @@ async def test_new_matches_keep_search_tool(tmp_path) -> None:
     pres = await RetrievalScheme().build_presentation(
         {}, {"refinement": {"query": "read"}, "presented": ("file__write",)}, ops,
     )
-    names = {t["function"]["name"] for t in pres.llm_tools_payload}
+    names = {t["function"]["name"] for t in advertised_entries(pres.tools_channel)}
     assert _SEARCH_TOOL_NAME in names                     # file__read is new → not converged → search stays
 
 

--- a/tests/test_tool_use_category_content_fence_3376.py
+++ b/tests/test_tool_use_category_content_fence_3376.py
@@ -36,7 +36,13 @@ import pytest
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.router_loop import RouterLoop
 from reyn.security.permissions.effective import ContextualPermission
-from reyn.tools.scheme import Presentation, get_scheme
+from reyn.tools.scheme import (
+    AdvertisedTools,
+    NoToolsChannel,
+    Presentation,
+    advertised_entries,
+    get_scheme,
+)
 from reyn.tools.schemes._category_exposure import (
     CONTENT_FENCE_EXPOSURE_DEVIATION,
     TOOL_CALLS_EXPOSURE_DEVIATION,
@@ -98,7 +104,7 @@ class _Ops:
         self._catalog = catalog
 
     def present(self, available, layer_ctx) -> Presentation:
-        return Presentation(llm_tools_payload=list(self._wrappers))
+        return Presentation(tools_channel=AdvertisedTools(entries=list(self._wrappers)))
 
     def base_tools(self, available, layer_ctx) -> "list[dict]":
         return list(self._wrappers)
@@ -225,7 +231,7 @@ async def test_production_folds_against_the_live_catalog() -> None:
         dict(available), dict(layer_ctx), ops=calls_loop,
     )
 
-    advertised = {e["function"]["name"] for e in calls.llm_tools_payload}
+    advertised = {e["function"]["name"] for e in advertised_entries(calls.tools_channel)}
     declared = _declared(fence.tool_use_sp)
     assert declared == advertised, (
         "the two category cells no longer show the same set — the transport "
@@ -269,18 +275,20 @@ def test_the_cell_resolves_to_a_registered_live_scheme() -> None:
 
 @pytest.mark.asyncio
 async def test_the_cell_produces_both_channels_of_a_working_presentation() -> None:
-    """Tier 2: mechanism — the presentation carries an empty ``tools=`` payload,
-    a rendered code-API, and a dispatch catalog.
+    """Tier 2: mechanism — the presentation declares NO ``tools=`` channel, a
+    rendered code-API, and a dispatch catalog.
 
-    ``llm_tools_payload == []`` is this transport's way of saying "I have no
-    ``tools=`` channel" and is the encoder's answer, not a literal in the cell.
-    The third channel is the one that would be easy to forget: with an empty
-    advertisement, a missing ``dispatchable_catalog`` would leave the gate keyed
-    on nothing and every in-code call would come back ``unknown_tool``."""
+    ``tools_channel`` is ``NoToolsChannel`` — this transport's way of saying "the
+    ``tools=`` field does not apply to me", which #3421 moved out of a comment and
+    into the type so it stops reading like "there happen to be zero tools". It is
+    the encoder's answer, not a literal in the cell. The third channel is the one
+    that would be easy to forget: with nothing advertised, a missing
+    ``dispatchable_catalog`` would leave the gate keyed on nothing and every
+    in-code call would come back ``unknown_tool``."""
     pres = await CategoryContentFenceScheme().build_presentation(
         {}, {}, _Ops(wrappers=_WRAPPERS, catalog=_catalog(5)),
     )
-    assert pres.llm_tools_payload == []
+    assert isinstance(pres.tools_channel, NoToolsChannel)
     assert isinstance(pres.tool_use_sp, str) and "def invoke_action(" in pres.tool_use_sp
     assert pres.dispatchable_catalog is not None
     assert {e["function"]["name"] for e in pres.dispatchable_catalog} == {
@@ -416,7 +424,7 @@ def test_the_tool_calls_category_cell_still_runs_the_shared_exposure() -> None:
     re-encoded."""
     ops = _Ops(wrappers=_WRAPPERS, catalog=_catalog(50))
     exposure = build_category_exposure(
-        present_entries=ops.present({}, {}).llm_tools_payload,
+        present_entries=advertised_entries(ops.present({}, {}).tools_channel),
         available={"hot_list_aliases": []},
         layer_ctx={"univ_enabled": True},
         deviation=TOOL_CALLS_EXPOSURE_DEVIATION,
@@ -426,5 +434,5 @@ def test_the_tool_calls_category_cell_still_runs_the_shared_exposure() -> None:
             {"hot_list_aliases": []}, {"univ_enabled": True}, ops,
         )
     )
-    assert pres.llm_tools_payload == [d.as_tool_calls_entry() for d in exposure.descriptors]
-    assert pres.llm_tools_payload == _WRAPPERS
+    assert advertised_entries(pres.tools_channel) == [d.as_tool_calls_entry() for d in exposure.descriptors]
+    assert advertised_entries(pres.tools_channel) == _WRAPPERS

--- a/tests/test_tool_use_exposure_encoder_3376.py
+++ b/tests/test_tool_use_exposure_encoder_3376.py
@@ -43,7 +43,12 @@ from reyn.tools.exposure import (
     descriptor_from_entry,
     descriptors_from_entries,
 )
-from reyn.tools.scheme import Presentation, get_scheme
+from reyn.tools.scheme import (
+    AdvertisedTools,
+    Presentation,
+    advertised_entries,
+    get_scheme,
+)
 from reyn.tools.schemes._enumerate_exposure import (
     CONTENT_FENCE_EXPOSURE_DEVIATION,
     TOOL_CALLS_EXPOSURE_DEVIATION,
@@ -91,7 +96,7 @@ class _Ops:
         # build their exposure from. Its *content* is irrelevant to the arms that
         # use it here (they assert a relation between two derived sets, not the
         # set itself); what matters is that it is one list, composed once.
-        return Presentation(llm_tools_payload=list(self._base) + list(self._catalog))
+        return Presentation(tools_channel=AdvertisedTools(entries=list(self._base) + list(self._catalog)))
 
 
 # ── the pair table: still a capability declaration, still fail-closed ─────────
@@ -203,7 +208,9 @@ def test_a_provider_native_entry_is_carried_verbatim_not_normalised() -> None:
     descriptor = descriptor_from_entry(entry)
     assert descriptor.kind == DESCRIPTOR_KIND_PROVIDER_NATIVE
     assert descriptor.as_tool_calls_entry() == entry
-    assert ToolCallsEncoder().encode_tools(Exposure(descriptors=(descriptor,))) == [entry]
+    assert advertised_entries(
+        ToolCallsEncoder().encode_tools(Exposure(descriptors=(descriptor,)))
+    ) == [entry]
 
 
 @pytest.mark.asyncio
@@ -229,7 +236,7 @@ async def test_production_cells_reach_the_descriptor_classifier() -> None:
         {"hot_list_aliases": []}, {"search_visible": True}, ops,
     )
     descriptors = descriptors_from_entries(base + catalog)
-    assert pres.llm_tools_payload == [d.as_tool_calls_entry() for d in descriptors]
+    assert advertised_entries(pres.tools_channel) == [d.as_tool_calls_entry() for d in descriptors]
     # Vacuity guard: the equality above must have spanned every descriptor shape,
     # otherwise it only proves the seam carries the easy one.
     assert {d.kind for d in descriptors} == {
@@ -361,7 +368,7 @@ async def test_the_production_cells_carry_those_declarations() -> None:
     )
     fence_cell = await CodeActScheme().build_presentation({}, {}, ops)
 
-    advertised = {e["function"]["name"] for e in flat_cell.llm_tools_payload}
+    advertised = {e["function"]["name"] for e in advertised_entries(flat_cell.tools_channel)}
     assert "delegate_to_agent" in advertised
     assert "mcp__call_tool" not in advertised
     assert "def delegate_to_agent(" in fence_cell.tool_use_sp
@@ -458,4 +465,4 @@ def test_presentation_no_longer_carries_the_dead_sp_channel() -> None:
     fields = {f.name for f in dataclasses.fields(Presentation)}
     assert "sp_params" not in fields
     assert "sp_fragment" not in fields
-    assert {"llm_tools_payload", "tool_use_sp"} <= fields
+    assert {"tools_channel", "tool_use_sp"} <= fields

--- a/tests/test_tool_use_retrieval_content_fence_3376.py
+++ b/tests/test_tool_use_retrieval_content_fence_3376.py
@@ -40,7 +40,13 @@ from reyn.core.events.state_log import StateLog
 from reyn.runtime.router_loop import RouterLoop
 from reyn.security.permissions.effective import ContextualPermission
 from reyn.tools.exposure import Exposure, ExposureDeviation
-from reyn.tools.scheme import Presentation, get_scheme
+from reyn.tools.scheme import (
+    AdvertisedTools,
+    NoToolsChannel,
+    Presentation,
+    advertised_entries,
+    get_scheme,
+)
 from reyn.tools.schemes._content_fence_cell import ContentFenceCellScheme
 from reyn.tools.schemes._retrieval_exposure import retrieval_sp_facts
 from reyn.tools.schemes.retrieval import RetrievalScheme
@@ -104,7 +110,7 @@ class _Ops:
         self._catalog = catalog
 
     def present(self, available, layer_ctx) -> Presentation:
-        return Presentation(llm_tools_payload=list(self._wrappers))
+        return Presentation(tools_channel=AdvertisedTools(entries=list(self._wrappers)))
 
     def base_tools(self, available, layer_ctx) -> "list[dict]":
         return list(_BASE)
@@ -292,18 +298,19 @@ async def test_a_withheld_row_does_not_shift_the_identifier_of_a_shown_one() -> 
 
 @pytest.mark.asyncio
 async def test_the_cell_produces_all_three_channels_of_a_presentation() -> None:
-    """Tier 2: mechanism — an empty ``tools=`` payload, a rendered code-API, and a
+    """Tier 2: mechanism — NO ``tools=`` channel, a rendered code-API, and a
     dispatch catalog.
 
-    ``llm_tools_payload == []`` is this transport's way of saying "I have no
-    ``tools=`` channel" and is the encoder's answer, not a literal in the cell.
-    The third channel is the easy one to forget: with an empty advertisement, a
-    missing ``dispatchable_catalog`` would leave the gate keyed on nothing and
-    every in-code call would come back ``unknown_tool``."""
+    ``tools_channel`` is ``NoToolsChannel`` — this transport's way of saying "the
+    ``tools=`` field does not apply to me" (#3421 made that the value's type
+    rather than a comment beside an empty list). It is the encoder's answer, not a
+    literal in the cell. The third channel is the easy one to forget: with nothing
+    advertised, a missing ``dispatchable_catalog`` would leave the gate keyed on
+    nothing and every in-code call would come back ``unknown_tool``."""
     pres = await RetrievalContentFenceScheme().build_presentation(
         {}, dict(_SEARCH_ON), _Ops(wrappers=_WRAPPERS, catalog=_catalog(5)),
     )
-    assert pres.llm_tools_payload == []
+    assert isinstance(pres.tools_channel, NoToolsChannel)
     assert isinstance(pres.tool_use_sp, str) and "def search_actions(" in pres.tool_use_sp
     assert pres.dispatchable_catalog is not None
     assert {e["function"]["name"] for e in pres.dispatchable_catalog} == {

--- a/tests/test_tool_use_scheme_1593.py
+++ b/tests/test_tool_use_scheme_1593.py
@@ -18,11 +18,13 @@ import pytest
 from reyn.config import ToolUseConfig, _build_tool_use_config
 from reyn.tools.scheme import (
     DEFAULT_SCHEME_NAME,
+    AdvertisedTools,
     ExecContext,
     Execute,
     ExecutionResult,
     Presentation,
     ToolUseScheme,
+    advertised_entries,
     get_scheme,
     register_scheme,
     registered_scheme_names,
@@ -40,7 +42,7 @@ class _RecordingOps:
 
     def present(self, available, layer_ctx) -> Presentation:
         self.calls.append("present")
-        return Presentation(llm_tools_payload=[{"t": 1}])
+        return Presentation(tools_channel=AdvertisedTools(entries=[{"t": 1}]))
 
     def resolve(self, llm_response, tool_catalog: dict) -> list[dict]:
         self.calls.append("resolve")
@@ -96,7 +98,7 @@ async def test_universal_build_presentation_delegates() -> None:
     ops = _RecordingOps()
     pres = await UniversalCategoryScheme().build_presentation({}, {}, ops)
     assert "present" in ops.calls
-    assert pres.llm_tools_payload == [{"t": 1}]
+    assert advertised_entries(pres.tools_channel) == [{"t": 1}]
 
 
 def test_universal_interpret_execute_with_tool_calls() -> None:

--- a/tests/test_tools_channel_arms_3421.py
+++ b/tests/test_tools_channel_arms_3421.py
@@ -1,0 +1,138 @@
+"""Tier 2: #3421 — "there are no tools" and "this transport has no ``tools=``
+channel" are distinguishable at the TYPE level.
+
+Before this issue, ``Presentation`` said both with the same value: ``[]``. The
+second meaning was stated in prose at three call sites and in the type at none,
+so no consumer could act on it — ``capability_visibility`` carried a comment
+reading "llm_tools_payload is genuinely [] (no tools= schema)" precisely because
+the value could not say so itself.
+
+The acceptance condition the issue set is the one asserted here: the two are
+distinguishable, **not merely commented apart**. So the arms are compared as
+values (an empty ``AdvertisedTools`` is not a ``NoToolsChannel``) rather than by
+checking that each render happens to look right, and the wire view is asserted to
+collapse them — because that collapse is the reason a single list could pass for
+both, and it stays correct at the provider boundary while ceasing to be the only
+thing a consumer can see.
+
+The registry arm enumerates the live ``(scheme, transport)`` table rather than
+naming cells, so a cell added later cannot escape the agreement.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.tools.encoders import encoder_for_transport
+from reyn.tools.exposure import Exposure, FunctionDescriptor
+from reyn.tools.scheme import (
+    AdvertisedTools,
+    NoToolsChannel,
+    Presentation,
+    advertised_entries,
+)
+from reyn.tools.transport import (
+    Transport,
+    resolve_scheme_for_transport,
+    valid_scheme_transport_pairs,
+)
+
+
+def _descriptor(name: str) -> FunctionDescriptor:
+    return FunctionDescriptor(
+        name=name, description="", parameters={"type": "object", "properties": {}},
+    )
+
+
+def test_an_empty_channel_is_not_an_absent_one() -> None:
+    """Tier 2: the two answers are different VALUES, though they render the same
+    payload on the wire.
+
+    The left-hand side is what ``tool_calls`` produces when every descriptor has
+    been narrowed away — a channel that exists and is empty. The right-hand side
+    is what ``content_fence`` produces always — no channel at all. The equality
+    assertion is the whole issue in one line: before #3421 both were ``[]`` and
+    this comparison could not be written."""
+    narrowed_to_nothing = encoder_for_transport(Transport.TOOL_CALLS).encode_tools(
+        Exposure(descriptors=()),
+    )
+    no_channel = encoder_for_transport(Transport.CONTENT_FENCE).encode_tools(
+        Exposure(descriptors=()),
+    )
+
+    assert narrowed_to_nothing != no_channel
+    assert isinstance(narrowed_to_nothing, AdvertisedTools)
+    assert isinstance(no_channel, NoToolsChannel)
+    # …and the reason a single list could stand in for both: the WIRE view is
+    # identical. That collapse is still correct where the payload is handed to a
+    # provider; what changed is that it is no longer the only view available.
+    assert advertised_entries(narrowed_to_nothing) == advertised_entries(no_channel) == []
+
+
+def test_a_populated_channel_carries_its_entries_through_the_wire_view() -> None:
+    """Tier 2: ``advertised_entries`` is the entries themselves on the populated
+    arm — the union does not cost the ordinary path anything.
+
+    Guards the mirror-image failure of the one above: an accessor that returned
+    ``[]`` for every arm would satisfy that test and silently un-advertise every
+    tool in production."""
+    channel = encoder_for_transport(Transport.TOOL_CALLS).encode_tools(
+        Exposure(descriptors=(_descriptor("file__read"), _descriptor("web__fetch"))),
+    )
+    names = [e["function"]["name"] for e in advertised_entries(channel)]
+    assert names == ["file__read", "web__fetch"]
+
+
+def test_a_presentation_with_no_channel_must_name_its_dispatchable_set() -> None:
+    """Tier 2: #1618 root-1 as a construction-time gate.
+
+    "An empty advertisement must not become an empty dispatch gate" held by
+    convention in every ``content_fence`` cell and was checkable nowhere: with
+    ``[]`` meaning both things, ``dispatchable_catalog=None`` looked like an
+    ordinary tool_calls presentation. On the ``NoToolsChannel`` arm it is a cell
+    that dispatches nothing at all, which no cell wants and which would answer
+    every in-code call with ``unknown_tool``.
+
+    ``[]`` still passes — a cell that genuinely dispatches nothing says so. The
+    refusal is for the cell that never answered the question."""
+    with pytest.raises(ValueError, match="dispatchable_catalog"):
+        Presentation(tools_channel=NoToolsChannel())
+
+    explicitly_empty = Presentation(
+        tools_channel=NoToolsChannel(), dispatchable_catalog=[],
+    )
+    assert explicitly_empty.dispatchable_catalog == []
+
+    # The gate is arm-specific: an advertised channel keys the gate on its own
+    # payload, so ``None`` is the correct answer there and must stay legal.
+    assert Presentation(
+        tools_channel=AdvertisedTools(entries=[]),
+    ).dispatchable_catalog is None
+
+
+@pytest.mark.parametrize(
+    ("scheme_name", "transport"),
+    sorted(valid_scheme_transport_pairs(), key=lambda p: (p[0], p[1].value)),
+)
+def test_every_registered_cell_declares_the_arm_its_transport_implies(
+    scheme_name: str, transport: Transport,
+) -> None:
+    """Tier 2: transport ⇒ arm, over the LIVE registry.
+
+    Enumerated from ``valid_scheme_transport_pairs()`` rather than hand-listed,
+    so a cell registered later is covered without anyone remembering to add it —
+    the same reason the retired #3376 oracle enumerated instead of listing.
+
+    Asserted at the ENCODER, which is where the answer is decided: a cell whose
+    ``build_presentation`` chose the arm itself would be re-deciding a transport
+    property per cell, which is what the one-encoder-per-transport rule exists to
+    prevent."""
+    resolve_scheme_for_transport(scheme_name, transport)  # the cell resolves
+    encoder = encoder_for_transport(transport)
+    channel = encoder.encode_tools(Exposure(descriptors=(_descriptor("x"),)))
+
+    expected = AdvertisedTools if transport is Transport.TOOL_CALLS else NoToolsChannel
+    assert isinstance(channel, expected), (
+        f"the {scheme_name}|{transport.value} cell's encoder produced "
+        f"{type(channel).__name__}; a transport's answer to 'do I have a tools= "
+        "channel' is a property of the transport, not of the cell"
+    )


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3421.

`Presentation.llm_tools_payload` said two different things with the same value. `[]` meant both "this transport advertises nothing right now" (a real, reachable state — every tool narrowed away by permission) and "this transport has no `tools=` channel at all" (`content_fence`, whose whole surface is the code-API in the system prompt). The second meaning lived in prose at three call sites and in the type at none.

## The representation

`tools_channel: ToolsChannel` — a `{kind: ...}` discriminated union in `reyn/tools/scheme.py`, the same shape `exposure.ToolDescriptor` already uses for the descriptor arms (the issue's "check how the provider-native passthrough arm did it and follow that shape"):

| arm | means |
|---|---|
| `AdvertisedTools(entries=[...])` | the channel exists; `entries == []` is meaningful and no longer collides |
| `NoToolsChannel()` | the field does not apply to this transport |

`advertised_entries(channel)` is the **wire view** — `[]` on both arms. That collapse is deliberate and documented: an absent channel and an empty one send the same thing to the provider, so a consumer whose only job is to hand the payload over is right to call it. What changed is that it is no longer the *only* view available.

**The field is renamed, not just retyped.** A type change alone leaves `if pres.llm_tools_payload:` silently flipping to `True` on the new dataclass value — the hazard the issue warns about, where a legible confusion becomes a silent one. With the rename, a stale reader raises `AttributeError` instead. It cost nothing: every src site had to be edited anyway, and the rename rides on the same line.

## Consumer enumeration (AST, not regex)

Enumerated with `ast.walk` over `src/`, `tests/`, `scripts/` for `Attribute(attr=...)`, `keyword(arg=...)`, the `AnnAssign` field declaration, and string literals — plus a second pass for positional `Presentation(...)` construction (none exist) and for direct `encode_tools` callers. **24 attribute reads / 20 keyword writes / 2 other repo-wide; 6 reads + 6 writes in `src/`.** All updated here.

| src read site | did it want to distinguish? | now |
|---|---|---|
| `router_loop.py:1653` (chat presentation) | no | `advertised_entries(...)`, with a comment saying why the collapse is right *at this boundary* and that the dispatch gate is what must not collapse |
| `router_loop.py:2163` (`RePresent` arm) | no | same |
| `capability_visibility.py:459` (census) | **yes** — it carried the comment `# CodeAct: llm_tools_payload is genuinely [] (no tools= schema)` | branch restructured; the comment is deleted because the type states it |
| `schemes/universal_category.py:70` | n/a (always tool_calls) | `advertised_entries(ops.present(...).tools_channel)` |
| `schemes/category_content_fence.py:80` | n/a | same |
| `schemes/retrieval_content_fence.py:190` | n/a | same |

src write sites: the four cells (`enumerate_all`, `retrieval`, `universal_category`, `_content_fence_cell`) pass `encoder.encode_tools(exposure)`, whose *return type* now carries the arm; `RouterLoop.present` and `_VisibilityProbeOps.present` construct `AdvertisedTools` explicitly (both are always `tool_calls` presentations).

## The new type is load-bearing, not decorative

`Presentation.__post_init__` refuses the `NoToolsChannel` arm without an explicit `dispatchable_catalog`. That is #1618 root-1 — *"an empty advertisement must not become an empty dispatch gate"* — turned into a construction-time gate. It held by convention in every `content_fence` cell and was **uncheckable** while `[]` meant both things: `dispatchable_catalog=None` looked like an ordinary tool_calls presentation. `dispatchable_catalog=[]` still passes; a cell that dispatches nothing says so, which is the same empty-vs-absent discipline one level down.

That is also what lets the census drop its explanatory comment: a `NoToolsChannel` presentation **cannot reach** the advertised-set branch, because it cannot exist without a dispatchable catalog.

## Verifying the other cells are unchanged, without the oracle

The #3376 oracle was deleted by #3422, so nothing was protecting the five pre-existing cells. I built my own before/after comparison rather than trusting the suite to happen to notice:

- Recovered the deleted capture harness (`git show ab6c5772^:tests/scaffold/tool_use_oracle_3376.py`) into my scratchpad — **not** reintroduced into the repo. No scaffold, no golden file.
- It drives the **real** object graph the oracle did: a real `Session` → its `RouterHostAdapter` → a real `RouterLoop` (which *is* the `SchemeOps` Protocol implementation) → the registered scheme instance, over cells enumerated from the live `valid_scheme_transport_pairs()`, with the same pinned `available` / `layer_ctx`.
- Captured **7 cells** (6 registered + the `retrieval|tool_calls` `search_visible` variant) on `origin/main` before touching anything, and again after. Compared per-cell, per-field: `advertised_entries`, `dispatchable_catalog`, `tool_use_sp`, `resolved_scheme_name`.

**Result: 7/7 cells, 0 differing fields.** Entry counts unchanged (7 / 60 / 61 / 18 advertised; 0 for all three fence cells). The only thing that moved is the new `channel_kind` the old tree could not report — `absent` for the three `content_fence` cells, `advertised` for the four `tool_calls` ones. The harness's worktree-identity assert fired correctly the first time I ran it misconfigured, so I know what checkout it measured.

## Strip-falsify

Each anchor confirmed unique (`count == 1`) before editing; each strip removed a **production** call site, and each was reverted with a targeted `Edit` (no `git checkout --`, no `git stash`).

| production site stripped | result |
|---|---|
| `Presentation.__post_init__` raise disabled | 1 RED |
| `ContentFenceEncoder.encode_tools` reverted to the pre-fix `AdvertisedTools(entries=[])` | **6 RED** across 3 files, incl. all three `content_fence` cells of the registry-enumerated arm |
| `advertised_entries` collapsed to always-`[]` | 1 RED |

The third is the mirror-image guard, and it is the one worth naming: without it, an accessor that returned `[]` for every arm would satisfy the "empty ≠ absent" test while silently un-advertising every tool in production.

## Tests

`tests/test_tools_channel_arms_3421.py` (Tier 2). The acceptance condition the issue set is asserted as a **value comparison** (`narrowed_to_nothing != no_channel`) rather than as two renders that each happen to look right — that comparison is literally unwritable before this PR. The registry arm is parametrised from `valid_scheme_transport_pairs()`, so a cell added later cannot escape the transport⇒arm agreement, and it asserts at the *encoder*, because a cell choosing its own arm would be re-deciding a transport property per cell (what the one-encoder-per-transport rule exists to prevent).

Three existing tests changed their *claim*, not just their syntax: the two `content_fence` cell tests and `test_codeact_scheme_1593` asserted `llm_tools_payload == []`, and now assert the arm.

## Docs

`docs/concepts/tools-integrations/codeact.md` asserted *"The JSON tool payload is empty under CodeAct"* — the exact framing this PR removes from the code. Nothing on the wire changed, but the sentence taught the reader the ambiguity the type now rules out. Corrected, along with the adjacent stale claim that the code-API renders `tool(...)` signatures (#1658 replaced that with direct `def name(...)`; `encoders.render_code_api` asserts no `tool('` token reaches the prompt at all). The `.ja.md` sibling asserted the same falsified sentence, so that one line is corrected too — its own claim was wrong, not a mirror obligation.

Left alone deliberately: `docs/deep-dives/journal/1593-pr3-codeact-staging-design.md:170` still says `llm_tools_payload`. It is a dated design-review journal recording what #1593 PR-3 *proposed at the time*; editing it would falsify a historical record rather than fix a mechanism description. Flagging it so the reviewer can disagree.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` on all 14 changed/added test files — 113 inspected, 0 errors, 0 warnings
- [x] `pytest` from repo root — **9662 passed, 36 skipped, 0 failed** (12m36s); whole output read, not tailed
- [x] `python scripts/verify_module_docstrings.py` on all 13 changed src files — OK
- [x] Doc gates re-run after the doc commit (`test_3126_doc_anchor_gate` + `test_0060_d5d_doc_ref_registry_gate`, 337 passed) — the suite run predated those edits
- [x] Before/after cell capture: 7/7 cells, 0 differing fields
- [x] Strip-falsify ×3, each observed RED, then restored and re-confirmed green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
