### PR TITLE
fix(tests): scope run_async's litellm client close + TUI single-pause race — #3434

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -546,6 +546,18 @@ async def _close_litellm_async_clients(pre_existing_keys: frozenset = frozenset(
     litellm's close routine can never permanently evict them. Idempotent /
     safe to call when no client was ever created during this call: the diff
     is then empty (no-op).
+
+    Considered and accepted, not overlooked: the hidden window spans an
+    `await` (litellm's close routine), so in principle another task on the
+    SAME event loop could `get_cache`/`set_cache` a preserved key while it's
+    hidden, miss, create a replacement, and then have this function's final
+    `cache_dict.update(preserved)` clobber that replacement with the
+    preserved (older) entry. Accepted for this call site specifically: this
+    window only exists on `run_async`'s own shutdown path, after `await
+    coro` has already returned/raised — by that point nothing on this loop
+    is meant to still be issuing LLM calls that would touch the cache. The
+    alternative (not hiding at all) reintroduces the #3434 defect this
+    function exists to fix, which is the worse failure mode.
     """
     import litellm
 

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -482,11 +482,48 @@ async def shutdown_logging() -> None:
         pass
 
 
-async def _close_litellm_async_clients() -> None:
-    """Close LiteLLM's cached aiohttp-backed async HTTP clients before the
-    event loop closes (issue #2787).
+def _snapshot_litellm_client_cache_keys() -> frozenset:
+    """Return the current key set of litellm's process-wide async-client
+    cache (#3434), for use as the "pre-existing" baseline `run_async` diffs
+    against before closing anything.
 
-    Background:
+    Best-effort: an empty frozenset (rather than raising) if litellm hasn't
+    lazily initialized the cache yet, matching `_close_litellm_async_clients`'s
+    own best-effort posture.
+    """
+    try:
+        import litellm
+
+        cache = getattr(litellm, "in_memory_llm_clients_cache", None)
+        cache_dict = getattr(cache, "cache_dict", None)
+        if cache_dict is None:
+            return frozenset()
+        return frozenset(cache_dict.keys())
+    except Exception:
+        return frozenset()
+
+
+async def _close_litellm_async_clients(pre_existing_keys: frozenset = frozenset()) -> None:
+    """Close LiteLLM's cached aiohttp-backed async HTTP clients before the
+    event loop closes (issue #2787), scoped to clients created during THIS
+    `run_async` call (#3434).
+
+    #3434 root cause: litellm's own `close_litellm_async_clients()` iterates
+    *every* entry in the process-wide `litellm.in_memory_llm_clients_cache`
+    unconditionally — not just entries this call created. The cache is never
+    evicted on close (see `LLMClientCache`'s own docstring: eviction
+    intentionally never closes, because an in-flight request may still hold
+    the client), so a prior test's still-open, still-cached client for e.g.
+    `vertex_ai` gets closed-but-left-cached the moment *any* `run_async` call
+    runs anywhere later in the same worker process — even an LLM-free one.
+    `get_cache` then hands that closed client to the next real call with a
+    matching provider/params key, which fails with "Cannot send a request,
+    as the client has been closed." This is exactly why the failing test
+    varies run to run under `-n auto`: it depends on xdist worker
+    assignment and intra-worker test order, not on any one test's own
+    defect.
+
+    Background (why closing is needed at all — issue #2787):
       LiteLLM's default async transport (`litellm/llms/custom_httpx/
       aiohttp_transport.py`) is a real `aiohttp.ClientSession` cached in
       the process-wide `litellm.in_memory_llm_clients_cache`.
@@ -495,43 +532,42 @@ async def _close_litellm_async_clients() -> None:
       context plus a `ResourceWarning` when a session/connector is
       garbage-collected still open -- this is exactly the "Unhandled
       exception in event loop: / Exception None" noise reported in #2787.
-
-      LiteLLM ships the fix as an explicit opt-in util rather than an
-      automatic close, because its cache intentionally does NOT close
-      evicted/cached clients itself (an in-flight request may still be
-      using one) — see `litellm.caching.llm_caching_handler.
-      LLMClientCache`'s docstring: "For explicit shutdown cleanup, use
-      close_litellm_async_clients()". LiteLLM also self-registers an
-      atexit hook for this (`register_async_client_cleanup`, lazy-loaded
-      on first `litellm.<attr>` access) but that hook recreates a brand
-      new event loop *after* ours has already closed — fragile,
-      especially cross-platform (matches the "recurs on both Mac and
-      Windows" note in #2787). Calling the same util explicitly here,
-      on the still-alive loop, is the deterministic version of that same
-      cleanup, and it is where `shutdown_logging` already lives (same
-      finally, same choke point for `reyn chat` / `--once` / the mcp.py
-      CLI commands that route through `run_async`).
-
-      Must run *after* `shutdown_logging`: `clear_queue()` awaits
-      queued LiteLLM `async_success_handler` coroutines, which may still
-      need the cached async client to complete (e.g. a logging
-      integration's own HTTP call) -- closing the client first could
+      Must run *after* `shutdown_logging`: `clear_queue()` awaits queued
+      LiteLLM `async_success_handler` coroutines, which may still need the
+      cached async client to complete -- closing the client first could
       break that drain.
 
-      Idempotent / safe to call when no client was ever created: the
-      function iterates `litellm.in_memory_llm_clients_cache.cache_dict`
-      (empty cache → no-op) and each handler's own `close()` checks
-      `.closed` before acting, so calling it twice (or on a fully cold
-      cache) never raises or double-closes.
+    Fix: diff the cache's key set against `pre_existing_keys` (captured by
+    `run_async` before awaiting the wrapped coroutine) and temporarily hide
+    the pre-existing entries from litellm's own cache dict while invoking
+    its official close routine — so only clients newly cached during this
+    call get closed, and clients other in-flight callers still own are left
+    alone. Restoring afterwards is unconditional (`finally`) so a raise from
+    litellm's close routine can never permanently evict them. Idempotent /
+    safe to call when no client was ever created during this call: the diff
+    is then empty (no-op).
     """
+    import litellm
+
+    cache = getattr(litellm, "in_memory_llm_clients_cache", None)
+    cache_dict = getattr(cache, "cache_dict", None)
+    if cache_dict is None:
+        return
+
+    preserved = {k: v for k, v in cache_dict.items() if k in pre_existing_keys}
+    for key in preserved:
+        del cache_dict[key]
     try:
-        from litellm.llms.custom_httpx.async_client_cleanup import (
-            close_litellm_async_clients,
-        )
-        await close_litellm_async_clients()
-    except Exception:
-        # Best-effort: never raise from shutdown.
-        pass
+        try:
+            from litellm.llms.custom_httpx.async_client_cleanup import (
+                close_litellm_async_clients,
+            )
+            await close_litellm_async_clients()
+        except Exception:
+            # Best-effort: never raise from shutdown.
+            pass
+    finally:
+        cache_dict.update(preserved)
 
 
 def run_async(coro: Coroutine[object, object, T]) -> T:
@@ -544,6 +580,11 @@ def run_async(coro: Coroutine[object, object, T]) -> T:
     covers all of them from one place. See
     ``reyn.core.events.asyncio_diagnostics`` for why.
     """
+    # #3434: snapshot BEFORE the coroutine runs, so the finally below closes
+    # only litellm async clients this call creates — not every client any
+    # other test/call in this worker process has cached and is still using.
+    pre_existing_keys = _snapshot_litellm_client_cache_keys()
+
     async def _wrapped() -> T:
         from reyn.core.events.asyncio_diagnostics import (
             install_asyncio_exception_handler,
@@ -553,7 +594,7 @@ def run_async(coro: Coroutine[object, object, T]) -> T:
             return await coro
         finally:
             await shutdown_logging()
-            await _close_litellm_async_clients()
+            await _close_litellm_async_clients(pre_existing_keys)
 
     return asyncio.run(_wrapped())
 

--- a/tests/test_3338_tui_status_chrome_liveness.py
+++ b/tests/test_3338_tui_status_chrome_liveness.py
@@ -893,6 +893,14 @@ async def test_menubar_active_tab_toned_down_to_status_line_muted_tone(
         transport=_EventOnlyTransport(), read_model=_MutableSnapshotReadModel(snap)
     )
     async with app.run_test(size=(80, 24)) as pilot:
+        # #3434: Textual applies the initial "-active" CSS class to a Tab
+        # reactively (mount -> compose -> a Message that sets it), which is
+        # not guaranteed to have settled after a single pump of the message
+        # loop under load (observed: passes under a quiet `pytest`, fails
+        # under `-n auto`'s worker-count CPU contention). The neighboring
+        # test in this file (`test_status_line_long_raw_model_id_stays_
+        # onscreen`) already double-pumps for the same reason; match it here.
+        await pilot.pause()
         await pilot.pause()
         line = app.query_one(StatusLine)
         active_tab = next(tab for tab in app.query(Tab) if tab.has_class("-active"))

--- a/tests/test_llm_run_async_client_cache_scope_3434.py
+++ b/tests/test_llm_run_async_client_cache_scope_3434.py
@@ -1,0 +1,58 @@
+"""Tier 2b: `run_async`'s client-close step is scoped to clients created
+during its own call — not litellm's entire process-wide async-client cache
+(#3434).
+"""
+import asyncio
+
+from reyn.llm.llm import run_async
+
+
+def test_run_async_does_not_close_a_client_created_outside_its_own_call() -> None:
+    """Tier 2b: an unrelated, LLM-free `run_async` call must not close a
+    litellm async client another (already-completed) call created and left
+    open.
+
+    Regression guard for #3434: litellm's own `close_litellm_async_clients()`
+    iterates its ENTIRE process-wide client cache, unconditionally — not
+    just entries the calling `run_async` invocation created. `LLMClientCache`
+    never evicts on close (its own docstring: an in-flight request may still
+    hold the client), so under `pytest-xdist` any later LLM-free `run_async`
+    call (e.g. an mcp.py CLI command test) in the same worker process closed
+    every OTHER test's still-open, still-cached litellm client — including
+    ones for providers that test never touched. A real (unmocked) network
+    LLM call running afterward in that worker then failed with "Cannot send
+    a request, as the client has been closed", with the specific failing
+    test varying run to run because it depends on xdist worker assignment
+    and intra-worker test order, not on any one test's own defect.
+
+    Uses litellm's real async-client cache + real aiohttp objects (no
+    mocks — `unittest.mock` is forbidden by testing policy). Asserts on the
+    client session's own public `closed` attribute, not any reyn-private
+    state.
+    """
+    async def _create_client_outside_run_async():
+        # Same call litellm's own vertex_ai/gemini `make_call` makes
+        # internally (`get_async_httpx_client(llm_provider=VERTEX_AI)`,
+        # no params) — the exact cache key a real streaming LLM call hits.
+        from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
+
+        handler = get_async_httpx_client(llm_provider="vertex_ai")
+        return handler.client._transport._get_valid_client_session()
+
+    # Simulates a prior, already-finished test/call that created a real
+    # litellm async client on its OWN event loop (not through `run_async`)
+    # and left it open — exactly what a real (unmocked) LLM call does.
+    session = asyncio.run(_create_client_outside_run_async())
+    assert session.closed is False
+
+    async def _unrelated_llm_free_work() -> str:
+        return "done"
+
+    # Simulates a later, totally unrelated `run_async` call in the same
+    # worker process (e.g. an LLM-free mcp.py CLI command).
+    assert run_async(_unrelated_llm_free_work()) == "done"
+
+    assert session.closed is False, (
+        "run_async closed a litellm async client it did not create — "
+        "this is the #3434 shared-cache poisoning bug"
+    )


### PR DESCRIPTION
**[per-PR-coder]** — Addresses #3434's class (green/red decided by xdist worker assignment), addressing **two independent, directly-reproduced mechanisms** found while investigating.

## Sample refresh (per the issue's own instruction)

#3435 landed today (PR #3442, merged before this branch was cut) and pinned the one test that was hitting real network. Per the issue: *"most recent failure set, not the filing-time one, is the pure sample."* I ran `-n auto` fresh against that state.

| run | scope | result |
|---|---|---|
| A (pre-fix, full collection) | baseline | `test_embed_attempts_observation_3047.py::test_real_retry_populates_attempts_and_op_emits_embed_attempts` FAILED (`attempts == 3`, not 2 — an unlogged empty-message failure on attempt 1) + 9693 passed |
| B (litellm-cache fix only, full collection) | verify culprit-A fix | **9695 passed, 36 skipped — clean** |
| C (litellm-cache fix only, one test deselected → different collection set) | vary sample | `test_3338_tui_status_chrome_liveness.py::test_menubar_active_tab_toned_down_to_status_line_muted_tone` FAILED (`StopIteration`) + 9693 passed — **this is the exact test named in the issue's own run-B and in lead-coder's #3443 sample**, independently reproduced here |
| D (both fixes, full collection) | verify culprit-B fix | **9695 passed, 36 skipped — clean** |

Two clean full runs (B, D) after each respective fix landed; the two dirty runs (A, C) each name a specific failing test, not "flaky in general."

## Culprit A (MEASURED, directly reproduced): `run_async`'s client-close closes clients it didn't create

`reyn.llm.llm.run_async`'s `finally` calls litellm's `close_litellm_async_clients()`, which iterates the **entire process-wide** `litellm.in_memory_llm_clients_cache` unconditionally — not just clients created during that call. `LLMClientCache` never evicts on close (its own docstring: an in-flight request may still hold the client), so *any* later `run_async` call in the same xdist worker — even one that makes zero LLM calls — closes every OTHER test's still-open, still-cached litellm client. `get_cache` then hands that closed-but-cached client to the next real caller with a matching provider key, which fails with `RuntimeError: Cannot send a request, as the client has been closed.` — exactly the traceback the issue quotes, and the mechanism behind run A's `test_embed_attempts_observation_3047` failure (an unlogged, empty-message attempt-1 failure ahead of the stand-in server's real 500 — consistent with a closed-cached-client hit, though I did not capture per-worker test ordering to name run A's exact upstream culprit test; `-q` xdist output doesn't log per-worker order for passing tests).

**What I did verify directly, deterministically, no mocks:**
```python
session = asyncio.run(create_real_vertex_ai_client())   # session.closed == False
run_async(totally_unrelated_llm_free_coroutine())        # e.g. an LLM-free mcp.py CLI call
session.closed                                            # -> True on pre-fix code (RED)
                                                           # -> False on fixed code (GREEN)
```
This is the general mechanism, reproduced with a controlled minimal pair — not tied to one specific historical firing combination. It explains why the *named victim test varies run to run*: any real-network-adjacent test anywhere in a worker after any `run_async` call anywhere earlier in that worker is a candidate victim.

**Fix**: `run_async` now snapshots the client cache's key set *before* running its coroutine, and its close step is scoped to only the keys added during that specific call (pre-existing entries are temporarily hidden from litellm's own cache dict while its official close routine runs, then unconditionally restored). `src/reyn/llm/llm.py`.

**RED before fix**: new test `tests/test_llm_run_async_client_cache_scope_3434.py` — confirmed FAILING against `origin/main`'s `llm.py` (verified via `git show origin/main:... > scratch copy`, never via `git stash`), then GREEN against the fix. The pre-existing `#2787` regression guard (`tests/test_llm_run_async_shutdown_litellm_clients_2787.py`) still passes — the fix only narrows the close's *scope*, it doesn't skip closing clients this call itself created.

## Culprit B (MEASURED, directly reproduced): single-pause race in a TUI test, unrelated to culprit A

`test_menubar_active_tab_toned_down_to_status_line_muted_tone` (`tests/test_3338_tui_status_chrome_liveness.py`) read `app.query(Tab)`'s `"-active"` CSS class after a single `await pilot.pause()`. Textual applies that class reactively (mount → compose → a Message that sets it), and one pump of the message loop isn't guaranteed to have settled under the CPU contention `-n auto`'s worker count introduces. When it hasn't, `next(tab for tab in app.query(Tab) if tab.has_class("-active"))` raises `StopIteration` on the empty generator, which PEP 479 turns into `RuntimeError: coroutine raised StopIteration` inside the Task — exactly the #3443 sample lead-coder reported (`3.12`-only there; I reproduced the identical failure line on `3.11` here, under run C's `-n auto` load, which is consistent with a load-sensitive race rather than a Python-version-specific defect).

This is **not** the same mechanism as culprit A — no `litellm`/`run_async`/network anywhere in this traceback, and it doesn't require a second test to "poison" anything; it's a self-contained timing race in this one test, reproducible alone under sufficient contention (confirmed: run C reproduced it via `-n auto` with only one unrelated test deselected — no #3443-specific diff involved). The neighboring test in the same file already double-pumps for the same reason; this fix matches it (`await pilot.pause()` twice before reading widget state).

**Verification**: 15/15 standalone passes (not meaningfully load-sensitive standalone — the race needs contention to surface) + clean in run D's full `-n auto` pass alongside culprit A's fix.

## What I did NOT establish

- I did not enumerate the exact test-pair that produced run A's `test_embed_attempts_observation_3047` failure specifically (no per-worker ordering log in `-q` mode) — the mechanism is proven generically via a controlled repro, not tied to that one historical instance.
- I have not audited whether other unmarked (non-`@replay`) tests across the suite still make real network calls that remain vulnerable in principle to a *different* provider's cache entry colliding — the fix closes the mechanism regardless of which provider/test pair would have fired, so this shouldn't matter, but I haven't swept the full `@replay`-less test population to confirm none of them still reach real network today.

## Prohibited-list compliance

No timeout loosened, no skip/xfail, no `MagicMock`/`AsyncMock`/`patch`/hand-rolled stand-ins (both new/changed tests use real litellm objects / a real Textual app), no rerun-to-green, no "pin the test to a worker" workaround — both are genuine shared/local-state fixes at the source.

## Test plan

- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict tests/test_llm_run_async_client_cache_scope_3434.py tests/test_3338_tui_status_chrome_liveness.py`
- [x] `pytest` (repo root, `-n auto`, full collection) — run D: 9695 passed, 36 skipped, no failures
- [x] `python scripts/verify_module_docstrings.py src/reyn/llm/llm.py`
- [x] RED→GREEN demonstrated for both fixes (see above)
