### PR TITLE
fix(runtime): remove dead embedding_event_sink seven-hop wire — no producer (#3438)

### DIFF
--- a/docs/reference/runtime/session-construction.md
+++ b/docs/reference/runtime/session-construction.md
@@ -268,14 +268,14 @@ Two other cost-adjacent construction points stay inline:
 
 ## Family 5 — Retrieval
 
-`_build_retrieval_bundle` constructs the embedding block (four attrs:
-`action_embedding_index`/`embedding_provider`/`embedding_model_class`/
-`embedding_event_sink`) plus `action_usage_tracker` — a byte-identical extraction (same
+`_build_retrieval_bundle` constructs the embedding block (three attrs:
+`action_embedding_index`/`embedding_provider`/`embedding_model_class`) plus
+`action_usage_tracker` — a byte-identical extraction (same
 objects, same conditionals, same try/except None-fallbacks, same args as the inline
 sequence it replaced). It stays UNMOVED, invoked at its original position, BEFORE Family 1
 (`_build_audit_event_bundle`) runs — this family has no eager dependency on `chat_events`,
-only the two closures' DEFERRED `self._chat_events` resolution (kept verbatim since this is
-an instance method).
+only the `_on_hot_list_changed` closure's DEFERRED `self._chat_events` resolution (kept
+verbatim since this is an instance method).
 
 `_action_retrieval` (FP-0034 PR-3b-iii) drives whether the universal catalog wrappers
 appear in the router `tools=`. Default constructs an off-flag `ActionRetrievalConfig` so
@@ -306,31 +306,37 @@ surface `search_actions` to the LLM with a `None`/inert index; invoking it
 would raise `AttributeError` inside the handler instead of returning the
 intended empty-result degrade.
 
-### Embedding event sink — deferred self._chat_events capture (FP-0043 C.3/C.4)
+### Embedding event sink — removed (#3438)
 
-FP-0043 Component C.3 wires the embedding provider's lazy model-load
-lifecycle (downloading / loaded / error) into the session's events bus, so
-the TUI can render a sticky status row, a green "done" frame, and a
-retry-hint error row. The sink is called from the embed worker thread;
-`events.emit` is GIL-protected + sync, so this is safe without a
-`call_soon_threadsafe` bridge.
+FP-0043 Component C.3 originally wired the embedding provider's lazy
+model-load lifecycle (downloading / loaded / error) into the session's
+events bus via an `_embedding_event_sink` closure (`f"embedding_{kind}"`),
+threaded through `Session` -> `OpContext` -> the `embed` op -> the provider
+(FP-0057 #2856 Part A) so the TUI could render a sticky status row. #3128
+later removed the in-process embedding-model backend that had a lazy-load
+lifecycle to report on — reyn depends on litellm exclusively for
+embeddings now, and local/offline models are reached (if wanted) via an
+operator-run litellm proxy, which reyn does not manage a download
+lifecycle for (see
+[rag.md § Local and offline embedding models](../../concepts/data-retrieval/rag.md#local-and-offline-embedding-models)).
+That left the sink with no producer: `get_provider` only forwards an
+`event_sink` kwarg to a provider class whose signature accepts it, and the
+sole implementation (`LiteLLMEmbeddingProvider`) never did — so no
+`embedding_*` audit-event kind was ever emitted. #3438 (independent
+re-verification confirmed the zero-producer finding, and found no
+comment/ADR/issue recording an intent to keep the wire for a future
+provider) deleted the sink, `OpContext.embedding_event_sink`, and every hop
+of the threading, along with the `KIND_FAMILY` registry entry it used to
+justify in `event_schema.py`'s `DYNAMIC_KIND_EMIT_SITES`.
 
-**C.4 hotfix (2026-05-27).** The sink closure (`_embedding_event_sink`) MUST
-resolve `self._chat_events` at CALL time, not at construction time — the
-`EventLog` is built later in `__init__` (Family 1, ~line 1560+, which runs
-after Family 5). The original C.3 wiring captured `self.events` instead —
-an attribute that does not exist on `Session` at all (the real attribute is
-`self._chat_events`). That typo raised `AttributeError` the moment the sink
-fired, and the surrounding `except Exception: embedding_provider = None`
-fallback SWALLOWED it silently — disabling `search_actions` for every
-operator who had `embedding_class` set, with no crash, no log line pointing
-at the cause, and no test failure. It shipped and stayed broken until
-someone diagnosed it by hand.
-
-This mirrors the `_on_hot_list_changed` closure pattern in the
-`ActionUsageTracker` setup a few lines below — same deferred-capture shape,
-same swallow-prone `try/except`, same recurrence risk if either closure is
-rewritten to capture eagerly.
+The `_on_hot_list_changed` closure in the `ActionUsageTracker` setup a few
+lines below still uses the same deferred-`self._chat_events`-capture
+pattern the removed sink used to mirror (C.4 hotfix, 2026-05-27: capturing
+`self.events` instead of `self._chat_events` at construction time raised
+`AttributeError` the moment the sink fired, silently swallowed by the
+surrounding `try/except` — see git history for the original incident
+writeup). That recurrence risk is still live for `_on_hot_list_changed`,
+so it is called out here for future edits of that closure.
 
 ## Family 6a — Router-waist (`RouterHostAdapter`)
 

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -593,27 +593,15 @@ DYNAMIC_KIND_EMIT_SITES: tuple[DynamicEmitSite, ...] = (
             "``emit_sink``; censused at that component's own emit sites."
         ),
     ),
-    DynamicEmitSite(
-        module="src/reyn/runtime/session.py",
-        function="_embedding_event_sink",
-        seam="emit",
-        classification="KIND_FAMILY",
-        reason=(
-            "``f\"embedding_{kind}\"`` — a real hole, and currently a hole with "
-            "nothing behind it. The sink is only invoked by an embedding "
-            "provider that accepts an ``event_sink`` kwarg, and no provider in "
-            "the repo does: ``reyn.data.embedding.get_provider`` passes it only "
-            "when the class's signature accepts it, and the sole implementation "
-            "(``LiteLLMEmbeddingProvider``) documents that it does not. So no "
-            "``embedding_*`` kind is emitted today, and none is declared in "
-            "AUDIT_EVENT_KINDS. Wiring a provider that DOES report lifecycle "
-            "means deciding the kind names first — pass them as literals then. "
-            "Tracked in #3438: the threading is either removed, or made real "
-            "with literal kind names. This registry entry should not outlive "
-            "that decision — a permanently-registered hole in a closed "
-            "vocabulary is a contradiction."
-        ),
-    ),
+    # #3438: the ``_embedding_event_sink`` KIND_FAMILY entry that used to live
+    # here (``f"embedding_{kind}"`` in src/reyn/runtime/session.py) was
+    # deleted along with the sink itself and its whole seven-hop wire
+    # (Session -> OpContext -> the `embed` op -> provider). It had no
+    # producer — no embedding provider in the repo ever accepted the
+    # ``event_sink`` kwarg ``get_provider`` conditionally forwarded — and no
+    # comment/ADR/issue recorded an intent to keep it for a future provider,
+    # so the hole is closed by removing the wire rather than by keeping this
+    # registry entry.
     # Two entries for one helper: the recursion inside it, and the call that
     # starts the recursion — different enclosing functions, so different keys.
     DynamicEmitSite(

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -288,19 +288,6 @@ class OpContext:
     # None = a non-turn OpContext (direct/test construction, CLI/preprocessor).
     turn_origin: "str | None" = None
 
-    # FP-0057 #2856 Part A: the TUI model-download status sink for the `embed`
-    # op's provider resolution. Carries ONLY the event_sink CALLABLE
-    # (``(kind, text, meta) -> None``) — NOT a provider instance, so provider
-    # lifecycle/construction stays owned by the embed op handler (which still
-    # does its own redaction-egress
-    # scan before calling it). This is the seam that lets ``ActionEmbeddingIndex``
-    # route tool-use embeds through the shared `embed` op (inheriting the redaction
-    # seam) while preserving the session's TUI download-status rows, instead of
-    # calling `provider.embed()` provider-direct (the pre-#2856 redaction bypass).
-    # None = no TUI-observable download status (tests / non-chat construction) —
-    # the provider falls back to its own no-op default.
-    embedding_event_sink: "Callable[[str, str, dict], None] | None" = None
-
     # #3196: the SAME registered-skill-entry SSoT `:skill` invocation resolves
     # against (Session/RouterHostAdapter's `_available_skills`, built by
     # `reyn.data.skills.registry.build_skill_registry` from config) — threaded

--- a/src/reyn/core/op_runtime/embed.py
+++ b/src/reyn/core/op_runtime/embed.py
@@ -67,7 +67,7 @@ from . import register
 from .context import OpContext
 
 
-def _resolve_provider(event_sink=None):
+def _resolve_provider():
     """Resolve the embedding provider (env override + reyn.yaml embedding config).
 
     Mirrors `op_runtime.semantic_search._resolve_provider` — both call sites
@@ -79,12 +79,6 @@ def _resolve_provider(event_sink=None):
     op-runtime module stays self-contained and independently testable via
     monkeypatching its own module-level `get_provider` name (established
     op_runtime test convention, see `tests/test_op_semantic_search.py`).
-
-    FP-0057 #2856 Part A: ``event_sink`` (from ``ctx.embedding_event_sink``) is
-    forwarded to ``get_provider`` so a session-scoped TUI model-download status
-    sink still fires even though this call resolves a FRESH provider per op call
-    (the caller — e.g. ``ActionEmbeddingIndex`` via the tool-use `embed` op path
-    — no longer holds its own long-lived provider instance).
     """
     name = os.environ.get("REYN_EMBEDDING_PROVIDER", "litellm")
     if name == "litellm":
@@ -93,8 +87,8 @@ def _resolve_provider(event_sink=None):
             cfg = load_config().embedding
         except Exception:
             cfg = None
-        return get_provider(name, config=cfg or {}, event_sink=event_sink)
-    return get_provider(name, config={}, event_sink=event_sink)
+        return get_provider(name, config=cfg or {})
+    return get_provider(name, config={})
 
 
 def _is_embedding_enabled() -> bool:
@@ -188,12 +182,11 @@ async def handle(op: EmbedIROp, ctx: OpContext) -> dict:
          before the egress boundary to an external embedding API.
       2. `provider.embed(scanned_texts, model)` — batches internally; list in,
          list out, vector order preserved. The provider is resolved fresh per
-         call via `_resolve_provider(event_sink=ctx.embedding_event_sink)`
-         (FP-0057 #2856 Part A) — `ctx.embedding_event_sink` forwards the
-         caller's TUI model-download status sink through WITHOUT the caller
-         holding its own provider instance, so a tool-use caller (e.g.
-         `ActionEmbeddingIndex`) routes through this op (inheriting the
-         redaction seam above) while keeping its download-status rows.
+         call via `_resolve_provider()` — every embedding egress (this op,
+         `semantic_search`, `index_update`, and `ActionEmbeddingIndex` via the
+         tool-use `embed` op path) shares this one resolution, inheriting the
+         redaction seam above rather than calling `provider.embed()`
+         provider-direct.
       3. FP-0063 PC: price this call (`estimate_embedding_cost`, its OWN
          model's rate — X6 mixed-model correctness) for the returned metadata,
          and record it into the INDEPENDENT embedding-cost aggregate via
@@ -237,7 +230,7 @@ async def handle(op: EmbedIROp, ctx: OpContext) -> dict:
             model=op.embedding_model,
         )
 
-    provider = _resolve_provider(event_sink=ctx.embedding_event_sink)
+    provider = _resolve_provider()
     try:
         result = await race_cancellable(
             provider.embed(scanned_texts, op.embedding_model),

--- a/src/reyn/data/embedding/__init__.py
+++ b/src/reyn/data/embedding/__init__.py
@@ -24,9 +24,6 @@ Layers (ADR-0033):
 """
 from __future__ import annotations
 
-import inspect
-from typing import Any
-
 from reyn.data.embedding.cost_estimator import CostEstimate, estimate_indexing_cost
 from reyn.data.embedding.litellm_provider import LiteLLMEmbeddingProvider
 from reyn.data.embedding.provider import EmbedBatchResult, EmbeddingProvider
@@ -54,8 +51,6 @@ def register_provider(name: str, impl: type[EmbeddingProvider]) -> None:
 def get_provider(
     name: str = "litellm",
     config: dict | None = None,
-    *,
-    event_sink: "Any | None" = None,
 ) -> EmbeddingProvider:
     """Instantiate and return an EmbeddingProvider by name.
 
@@ -64,11 +59,6 @@ def get_provider(
                 ``LiteLLMEmbeddingProvider``.
         config: Provider configuration dict (e.g. reyn.yaml ``embedding:``
                 section). Empty dict used when None.
-        event_sink: Optional ``(kind, text, meta) -> None`` callable forwarded
-                to backends that accept the kwarg. ``LiteLLMEmbeddingProvider``
-                does not accept it (no lazy-load lifecycle to report on), so
-                it is silently ignored for the default provider — kept on the
-                signature for registered custom providers that do consume it.
 
     Returns:
         An EmbeddingProvider instance.
@@ -77,8 +67,6 @@ def get_provider(
         KeyError: if name is not registered.
     """
     cls = _PROVIDERS[name]
-    if event_sink is not None and "event_sink" in inspect.signature(cls).parameters:
-        return cls(config or {}, event_sink=event_sink)  # type: ignore[call-arg]
     return cls(config or {})  # type: ignore[call-arg]
 
 

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -69,7 +69,6 @@ def build_router_op_context(
     turn_origin: str | None = None,  # proposal 0060 Phase 1 (A7): OS-derived turn provenance → install-op stamping (A9)
     hot_reloader: Any = None,  # #2761 PR-2: this session's HotReloader → immediate mid-turn install apply
     render_template_bounds: Any = None,  # #2679: operator RenderTemplateBounds → the render_template op cap. None → the op's in-handler defaults.
-    embedding_event_sink: Any = None,  # FP-0057 #2856 Part A: TUI model-download status sink for the `embed` op's provider resolution (ActionEmbeddingIndex build/query path). None → no TUI-observable download status.
     budget_gateway: Any = None,  # FP-0063 PC: the calling Session's per-session BudgetGateway → the `embed` op's single embedding-cost recording entry point (fans out to session scope + agent/project scope via the tracker it holds, keyed by agent NAME). Wired by BOTH router op-ctx builders; RouterHostAdapter's is the load-bearing one (the `embed` TOOL resolves that factory).
     available_skills: Any = None,  # #3196: the host's registered SkillEntry list (Session/RouterHostAdapter's `_available_skills`) → the `file` op's skill-load provenance gate (the config-registered-entry class, alongside builtin/plugin). None → that provenance class is simply unavailable (fails closed, not open).
 ) -> Any:
@@ -172,7 +171,6 @@ def build_router_op_context(
         turn_origin=turn_origin,  # proposal 0060 Phase 1 (A7): OS-authoritative provenance source (A9)
         hot_reloader=hot_reloader,  # #2761 PR-2: per-session reloader for immediate mid-turn install apply
         render_template_bounds=render_template_bounds,  # #2679: operator render_template output cap
-        embedding_event_sink=embedding_event_sink,  # FP-0057 #2856 Part A: TUI model-download status sink for the embed op
         budget_gateway=budget_gateway,  # FP-0063 PC: the embed op's embedding-cost recording entry point
         available_skills=available_skills,  # #3196: config-registered-entry provenance class for the file op's skill-load gate
     )

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -191,11 +191,6 @@ class RouterHostAdapter:
         action_embedding_index: Any = None,
         embedding_provider: Any = None,
         embedding_model_class: str | None = None,
-        # FP-0057 #2856 Part A: the session's TUI model-download status sink
-        # CALLABLE (paired with ``embedding_provider`` above), threaded onto
-        # every router OpContext (``ctx.embedding_event_sink``) so the `embed`
-        # op forwards it into the fresh per-call provider it resolves.
-        embedding_event_sink: Any = None,
         # FP-0063 PC: this session's BudgetGateway, threaded onto every router
         # OpContext so the `embed` op can record its INDEPENDENT embedding-cost
         # aggregate (session scope on the gateway itself; agent/project scope
@@ -453,8 +448,6 @@ class RouterHostAdapter:
         self._action_embedding_index = action_embedding_index
         self._embedding_provider = embedding_provider
         self._embedding_model_class = embedding_model_class
-        # FP-0057 #2856 Part A
-        self._embedding_event_sink = embedding_event_sink
         # FP-0063 PC: embedding-cost recording entry point for the `embed` op.
         self._budget_gateway = budget_gateway
         # #2548 PR-A: enabled skill registry snapshot for the ## Skills block.
@@ -2152,10 +2145,6 @@ class RouterHostAdapter:
             # (skill_management__install_* / pipeline ops → build_legacy_op_context →
             # this factory), so it is the load-bearing wiring for PR-2.
             hot_reloader=self.hot_reloader,
-            # FP-0057 #2856 Part A: forward the session's TUI model-download
-            # status sink so the `embed` op preserves it (ActionEmbeddingIndex
-            # build/query now routes through the op instead of provider-direct).
-            embedding_event_sink=self._embedding_event_sink,
             # FP-0063 PC: the live router-dispatched `embed` tool resolves THIS
             # factory, so this is the load-bearing wiring for embedding-cost
             # recording (all three scopes fan out from the gateway).

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -654,8 +654,8 @@ class _HookEventBundle:
 @dataclass(frozen=True)
 class _RetrievalBundle:
     """#3082 Family 5: the retrieval spine — the embedding block
-    (``embedding_provider`` / ``embedding_event_sink`` / ``embedding_model_class``
-    / ``action_embedding_index``, four attrs, one conditional construction
+    (``embedding_provider`` / ``embedding_model_class`` /
+    ``action_embedding_index``, three attrs, one conditional construction
     guarded by ``universal_wrappers_enabled and embedding.enabled`` (FP-0066
     §7) with a
     try/except None-fallback) plus ``action_usage_tracker`` (hot-list
@@ -675,17 +675,31 @@ class _RetrievalBundle:
     the construction sequence that used to run inline in ``Session.__init__``
     at its ORIGINAL position (line ~1152), which is BEFORE Family 1
     (``_build_audit_event_bundle``) runs — so unlike ``hot_reloader``
-    (Family 3) or ``budget`` (Family 4), this family's two closures
-    (``_embedding_event_sink`` / ``_on_hot_list_changed``) do NOT take
-    ``chat_events`` as an eager builder input. They keep resolving
+    (Family 3) or ``budget`` (Family 4), this family's closure
+    (``_on_hot_list_changed``) does NOT take
+    ``chat_events`` as an eager builder input. It keeps resolving
     ``self._chat_events`` at CALL time (the EventLog is constructed later in
-    ``__init__``), exactly as the pre-extraction closures did — eager-izing
+    ``__init__``), exactly as the pre-extraction closure did — eager-izing
     that reference here would raise ``AttributeError`` at construction, since
     ``self._chat_events`` does not exist yet at line ~1152. The builder is an
-    instance method precisely so these closures can keep capturing ``self``."""
+    instance method precisely so this closure can keep capturing ``self``.
+
+    #3438: the fourth attr, ``embedding_event_sink`` (a TUI model-download
+    status sink, FP-0057 #2856 Part A), was removed along with its whole
+    seven-hop wire (Session → OpContext → the `embed` op → provider). It had
+    no producer: ``get_provider`` only forwards an ``event_sink`` kwarg to a
+    provider class whose signature accepts it, and the sole implementation
+    (``LiteLLMEmbeddingProvider``) never did. Its original reason for being —
+    reporting a local in-process embedding model's lazy-load lifecycle
+    (FP-0043 Component C.3) — stopped applying when #3128 removed that
+    in-process backend; local/offline embedding now goes through an
+    operator-run litellm proxy (see
+    docs/concepts/data-retrieval/rag.md#local-and-offline-embedding-models),
+    which reyn does not manage a download lifecycle for. No comment/ADR/issue
+    recorded an intent to keep the wire for a future provider, so this was
+    dead wiring, not a deliberate placeholder."""
 
     embedding_provider: "object | None"
-    embedding_event_sink: "object | None"
     embedding_model_class: "str | None"
     action_embedding_index: "object | None"
     action_usage_tracker: "object | None"
@@ -1107,7 +1121,6 @@ class Session:
         self._action_embedding_index = _retrieval_bundle.action_embedding_index
         self._embedding_provider = _retrieval_bundle.embedding_provider
         self._embedding_model_class = _retrieval_bundle.embedding_model_class
-        self._embedding_event_sink = _retrieval_bundle.embedding_event_sink
         self._action_usage_tracker = _retrieval_bundle.action_usage_tracker
         self._mcp_servers = mcp_servers
         # mcp_connection_service; 4 lambdas deferred-resolve sibling deps at call time (#3082 Family 8c, see session-construction.md#family-8c-mcp-connection-service)
@@ -3546,7 +3559,7 @@ class Session:
         agent_name: str,
     ) -> "_RetrievalBundle":
         """#3082 Family 5: build the retrieval spine — the embedding block
-        (four attrs, one conditional construction guarded by
+        (three attrs, one conditional construction guarded by
         ``universal_wrappers_enabled and embedding.enabled`` (FP-0066 §7,
         clean-break replacement for the retired ``embedding_class`` truthy
         gate) with a try/except
@@ -3572,17 +3585,17 @@ class Session:
         resolvable before this builder's original call site.
 
         ``chat_events`` is deliberately NOT a builder input, unlike Family
-        3's ``hot_reloader`` or Family 4's ``budget``: both closures below
-        (``_embedding_event_sink`` / ``_on_hot_list_changed``) resolve
+        3's ``hot_reloader`` or Family 4's ``budget``: the closure below
+        (``_on_hot_list_changed``) resolves
         ``self._chat_events`` at CALL time, not construction time — the
         EventLog is built later in ``__init__`` (Family 1, ~line 1560+).
         Eager-izing that reference (the Family 3/4 pattern) would raise
         ``AttributeError`` here, since this builder runs BEFORE Family 1.
-        This builder is an instance method precisely so the closures can
+        This builder is an instance method precisely so the closure can
         keep capturing ``self``.
 
-        FP-0034 Phase 2 steps 1 + 5 / FP-0057 #2856 Part A / Issue #192:
-        see the four embedding attrs' and ``action_usage_tracker``'s
+        FP-0034 Phase 2 steps 1 + 5 / Issue #192:
+        see the three embedding attrs' and ``action_usage_tracker``'s
         original inline comments, reproduced verbatim below."""
         # FP-0034 Phase 2 step 1: build the ActionEmbeddingIndex +
         # EmbeddingProvider once per session when the operator has set
@@ -3595,14 +3608,6 @@ class Session:
         action_embedding_index: Any = None
         embedding_provider: Any = None
         embedding_model_class: str | None = None
-        # FP-0057 #2856 Part A: the TUI model-download status sink CALLABLE
-        # (set below, alongside ``embedding_provider``), threaded onto every
-        # router OpContext as ``ctx.embedding_event_sink`` so the `embed` op
-        # (which ``ActionEmbeddingIndex`` now routes through instead of
-        # calling ``provider.embed()`` directly) can forward it into the
-        # FRESH per-call provider it resolves — preserving the download-status
-        # rows without the caller holding a long-lived provider instance.
-        embedding_event_sink: Any = None
         if (
             action_retrieval.universal_wrappers_enabled
             and embedding_config is not None
@@ -3612,32 +3617,7 @@ class Session:
                 from reyn.data.embedding import get_provider as _get_provider
                 from reyn.tools.action_index import ActionEmbeddingIndex
 
-                # Sink closure resolves self._chat_events at CALL time —
-                # eager self.events capture once silently disabled
-                # search_actions for every operator (FP-0043 C.3/C.4 #2856; session-construction.md#embedding-event-sink-deferred-self_chat_events-capture-fp-0043-c3c4).
-                def _embedding_event_sink(
-                    kind: str, text: str, meta: dict,
-                ) -> None:
-                    try:
-                        self._chat_events.emit(
-                            f"embedding_{kind}",
-                            text=text,
-                            **meta,
-                        )
-                    except Exception:
-                        pass
-
-                embedding_provider = _get_provider(
-                    "litellm",
-                    embedding_config,
-                    event_sink=_embedding_event_sink,
-                )
-                # FP-0057 #2856 Part A: keep the sink CALLABLE addressable on
-                # its own so it can be threaded onto router OpContexts
-                # (ctx.embedding_event_sink) independently of
-                # ``embedding_provider`` (which stays for non-tool-use /
-                # legacy callers until they migrate).
-                embedding_event_sink = _embedding_event_sink
+                embedding_provider = _get_provider("litellm", embedding_config)
                 embedding_model_class = embedding_config.default_class
                 # FP-0057 Phase 0: unified onto IndexBackend's cache convention — clean-break, no migration. docs/reference/runtime/reyn-dir-layout.md#canonical-layout
                 action_embedding_index = ActionEmbeddingIndex(
@@ -3651,7 +3631,6 @@ class Session:
                 embedding_provider = None
                 action_embedding_index = None
                 embedding_model_class = None
-                embedding_event_sink = None
         # FP-0034 Phase 2 step 5: ActionUsageTracker for hot list freq+recency.
         # Created when universal_wrappers_enabled=True and hot_list_n > 0.
         # Per-agent compacted table at
@@ -3687,7 +3666,6 @@ class Session:
                 action_usage_tracker = None
         return _RetrievalBundle(
             embedding_provider=embedding_provider,
-            embedding_event_sink=embedding_event_sink,
             embedding_model_class=embedding_model_class,
             action_embedding_index=action_embedding_index,
             action_usage_tracker=action_usage_tracker,
@@ -3833,7 +3811,6 @@ class Session:
             action_embedding_index=self._action_embedding_index,
             embedding_provider=self._embedding_provider,
             embedding_model_class=self._embedding_model_class,
-            embedding_event_sink=self._embedding_event_sink,  # FP-0057 #2856 Part A: forwarded to make_router_op_context
             # FP-0034 Phase 2 step 5: ActionUsageTracker for hot list.
             action_usage_tracker=self._action_usage_tracker,
             uncompacted_tool_call_records_fn=(
@@ -6958,7 +6935,6 @@ class Session:
             turn_origin=self._current_turn_origin,  # proposal 0060 Phase 1 (A7): OS-authoritative provenance source (enumerate ALL op-ctx builders)
             hot_reloader=self._hot_reloader,  # #2761 PR-2: per-session reloader (both router op-ctx builders complete-by-construction)
             render_template_bounds=self._render_template_bounds,  # #2679: operator bounds (both router op-ctx builders complete-by-construction)
-            embedding_event_sink=self._embedding_event_sink,  # FP-0057 #2856 Part A: TUI model-download status sink for the embed op
             budget_gateway=self._budget,  # FP-0063 PC: embedding-cost recording entry point (enumerate ALL op-ctx builders; the load-bearing one for `embed` is RouterHostAdapter's)
             # #3196 co-vet round 2: pass the BASE registered set — deliberately NOT run through
             # the visibility filter (that's RouterHostAdapter's own copy, a UX/menu concern).

--- a/src/reyn/tools/action_index.py
+++ b/src/reyn/tools/action_index.py
@@ -51,15 +51,17 @@ Lifecycle:
 
 FP-0057 #2856 Part A (redaction-bypass close-out): ``build()``/``query()``
 used to call ``provider.embed(...)`` PROVIDER-DIRECT, carrying a session-
-scoped provider whose only reason for living on this class was to also
-carry the TUI's model-download-status ``event_sink`` — a bypass of the
-shared `embed` op's PRE-embed redaction-egress scan (a secret in the tool
-catalog's ``short_description`` would previously leave the process
-unredacted). Both methods now take an ``OpContext`` instead of an
-``EmbeddingProvider`` and route through ``execute_op(EmbedIROp(...), ctx)``;
-the event_sink is preserved via ``ctx.embedding_event_sink`` (a callable,
-not a provider instance) forwarded to the op's own fresh provider
-resolution (see ``core/op_runtime/embed.py``).
+scoped provider — a bypass of the shared `embed` op's PRE-embed
+redaction-egress scan (a secret in the tool catalog's
+``short_description`` would previously leave the process unredacted).
+Both methods now take an ``OpContext`` instead of an ``EmbeddingProvider``
+and route through ``execute_op(EmbedIROp(...), ctx)`` (see
+``core/op_runtime/embed.py``). (#3438 removed the ``ctx.embedding_event_sink``
+TUI model-download-status forwarding this comment used to describe — it had
+no producer; no provider in the repo ever accepted the ``event_sink`` kwarg
+``get_provider`` conditionally forwarded, and the original reason for it —
+a local in-process embedding model's lazy-load lifecycle, FP-0043 C.3 —
+stopped applying once #3128 removed that in-process backend.)
 
 Catalog hash semantics:
   - Hash is over the SORTED tuple of qualified_names.
@@ -352,9 +354,6 @@ class ActionEmbeddingIndex:
         Replaces the pre-#2856 ``provider.embed(...)`` provider-direct call —
         routing through ``execute_op`` inherits the op's PRE-embed redaction-
         egress scan (``embed.py``'s co-vet #3 seam) instead of bypassing it.
-        ``ctx.embedding_event_sink`` (forwarded by the caller) still reaches
-        the op's freshly-resolved provider, so the TUI model-download status
-        rows are unaffected by this routing change.
 
         Raises ``RuntimeError`` on an op-level failure (mirrors the previous
         provider-direct exception-propagation contract — ``build()``'s

--- a/tests/test_op_embed.py
+++ b/tests/test_op_embed.py
@@ -45,14 +45,13 @@ class FakeEmbeddingProvider:
         return 3
 
 
-def _make_ctx(tmp_path: Path, *, embedding_event_sink=None) -> OpContext:
+def _make_ctx(tmp_path: Path) -> OpContext:
     events = EventLog()
     ws = Workspace(events=events)
     return OpContext(
         workspace=ws,
         events=events,
         permission_decl=PermissionDecl(),
-        embedding_event_sink=embedding_event_sink,
     )
 
 
@@ -238,85 +237,6 @@ async def test_embed_no_redaction_event_when_no_secret_present(
     assert result.get("status") != "error", result
     assert fake.received_texts == ["just some ordinary sentence"]
     assert not any(e.type == "embed_secret_redacted" for e in ctx.events.all())
-
-
-# ---------------------------------------------------------------------------
-# Tier 2: FP-0057 #2856 Part A — ctx.embedding_event_sink forwarding seam
-# ---------------------------------------------------------------------------
-#
-# ActionEmbeddingIndex used to call `provider.embed(...)` PROVIDER-DIRECT so
-# it could carry a session-scoped provider's TUI model-download-status
-# event_sink — bypassing this op's PRE-embed redaction-egress seam above.
-# Part A closes that bypass by having ActionEmbeddingIndex route through this
-# op instead; the seam that makes that possible WITHOUT losing the TUI
-# status rows is this op forwarding `ctx.embedding_event_sink` into its own
-# per-call `_resolve_provider(event_sink=...)` — verified here directly
-# (independent of ActionEmbeddingIndex, which has its own coverage in
-# tests/test_action_embedding_index.py).
-
-@pytest.mark.asyncio
-async def test_embed_forwards_ctx_embedding_event_sink_to_provider_resolution(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Tier 2: when ctx carries an embedding_event_sink, the op forwards THAT
-    exact callable into get_provider(event_sink=...) — the seam that keeps
-    the TUI model-download status rows alive for a caller (ActionEmbeddingIndex)
-    that no longer holds its own provider instance."""
-    fake = FakeEmbeddingProvider()
-    received_event_sinks: list[object] = []
-
-    def _spy_get_provider(*_args, event_sink=None, **_kwargs):
-        received_event_sinks.append(event_sink)
-        return fake
-
-    import reyn.core.op_runtime.embed as _embed_mod
-    monkeypatch.setattr(_embed_mod, "get_provider", _spy_get_provider)
-
-    def _tui_sink(kind: str, text: str, meta: dict) -> None:
-        pass
-
-    ctx = _make_ctx(tmp_path, embedding_event_sink=_tui_sink)
-    op = EmbedIROp(kind="embed", texts=["hello"], embedding_model="standard")
-    result = await execute_op(op, ctx)
-
-    assert result.get("status") != "error", result
-    # unpack: exactly one get_provider() call was made for this single embed
-    (forwarded_sink,) = received_event_sinks
-    assert forwarded_sink is _tui_sink, (
-        "ctx.embedding_event_sink must reach get_provider(event_sink=...) "
-        "UNCHANGED (identity), not wrapped/dropped"
-    )
-
-
-@pytest.mark.asyncio
-async def test_embed_forwards_none_when_ctx_embedding_event_sink_stripped(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Tier 2: falsify — stripping ctx.embedding_event_sink (force None — the
-    OpContext default) means get_provider() receives event_sink=None — the
-    RED counterpart of the test above, confirming the forwarding is actually
-    load-bearing (not a no-op wiring that would "pass" either way)."""
-    fake = FakeEmbeddingProvider()
-    received_event_sinks: list[object] = []
-
-    def _spy_get_provider(*_args, event_sink=None, **_kwargs):
-        received_event_sinks.append(event_sink)
-        return fake
-
-    import reyn.core.op_runtime.embed as _embed_mod
-    monkeypatch.setattr(_embed_mod, "get_provider", _spy_get_provider)
-
-    ctx = _make_ctx(tmp_path)  # embedding_event_sink defaults to None
-    assert ctx.embedding_event_sink is None
-    op = EmbedIROp(kind="embed", texts=["hello"], embedding_model="standard")
-    result = await execute_op(op, ctx)
-
-    assert result.get("status") != "error", result
-    (forwarded_sink,) = received_event_sinks
-    assert forwarded_sink is None, (
-        "with no sink on ctx, get_provider() must receive event_sink=None "
-        "(no TUI status forwarded) — the RED case for the test above"
-    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[per-PR-coder]** — fixes #3438.

## Decision: (a) remove the threading

Removed the whole seven-hop wire — `Session._embedding_event_sink` closure →
`_RetrievalBundle.embedding_event_sink` → `RouterHostAdapter`'s
`embedding_event_sink` param/attr → `build_router_op_context`'s
`embedding_event_sink` param → `OpContext.embedding_event_sink` →
`embed.py`'s `_resolve_provider(event_sink=...)` → `get_provider`'s
`event_sink` kwarg (and the `inspect.signature` gate it existed for). Also
removed the `KIND_FAMILY` entry in `event_schema.py`'s
`DYNAMIC_KIND_EMIT_SITES` that registered this as the closed audit-event
kind vocabulary's one blind spot (#3437).

## Independent re-verification of "producer is zero"

Confirmed by AST/signature inspection, not by running anything:

- `src/reyn/data/embedding/__init__.py`'s `_PROVIDERS` registry has exactly
  two entries, both `LiteLLMEmbeddingProvider` — `__init__(self, config:
  "dict[str, Any] | Any | None" = None)`, no `event_sink` parameter.
- Repo-wide grep for `class.*EmbeddingProvider` / `register_provider(` turns
  up only test `Fake*EmbeddingProvider` classes (`tests/test_op_embed.py`,
  `tests/test_op_semantic_search.py`, `tests/test_action_embedding_index.py`,
  etc.) and one production `register_provider("test-custom", _MyProvider)`
  in `tests/test_embedding_provider.py` — none of these classes accept
  `event_sink` either.
- `get_provider`'s own `inspect.signature(cls).parameters` gate is therefore
  never satisfied by any class currently reachable through the registry, in
  or out of tests.

∴ zero `embedding_*` audit-event kinds are emitted today, matching the
issue's MEASURED finding.

## Search for a recorded "keep for later" intent — none found

- The seam's own history (`FP-0057 #2856 Part A`) explains *why* it was
  built: to preserve a TUI model-download status sink (`FP-0043` Component
  C.3, a local in-process embedding model's lazy-load lifecycle) once
  `ActionEmbeddingIndex` was routed through the shared `embed` op instead of
  calling the provider direct.
- That reason stopped applying when **#3128** ("Remove in-process
  sentence-transformers embedding backend — delegate local embedding to
  litellm proxy") removed the in-process backend entirely. Per
  `docs/concepts/data-retrieval/rag.md` § Local and offline embedding
  models, local/offline embedding today goes through an **operator-run
  litellm proxy** — reyn does not manage a download lifecycle for it, so
  there is nothing for this sink to report even in the "local model" case
  the seam was built for.
  - I did not find any comment, ADR, or open issue proposing a future
    provider that *would* consume `event_sink` — i.e. no recorded intent to
    keep this wire for later. Per the issue's own framing, an absent record
    is treated as "forgotten," not "decided," so (a) is the correct call.

## Verification

1. **Zero production callers, independently checked** — see the
   AST/signature re-verification above; every one of the 7 hops was grepped
   end-to-end before deletion (`embedding_event_sink` no longer appears
   anywhere in `src/` or `tests/` except 3 comments recording *why* it was
   removed, left as breadcrumbs for a future reader).
2. **Full suite green after deletion**: `9707 passed, 36 skipped, 44
   warnings in 583.95s` (`uv run pytest -n auto`, matching CI's `-n auto`).
   Two tests that existed specifically to pin the forwarding
   (`test_embed_forwards_ctx_embedding_event_sink_to_provider_resolution` /
   `test_embed_forwards_none_when_ctx_embedding_event_sink_stripped` in
   `tests/test_op_embed.py`) were deleted along with the mechanism they
   tested — their existence confirms the wiring wasn't hypothetical, just
   producer-less.
3. **`DYNAMIC_KIND_EMIT_SITES`'s `KIND_FAMILY` entry removed**, and
   `tests/test_audit_event_kind_vocabulary_3410.py` (part of the full-suite
   run above) stayed green — the #3437 gate does not regress.
4. **Strip-falsify N/A** — this PR *is* the deletion; there is no
   "delete it and see if a test goes RED" step to run beyond the two tests
   removed in (2), which is the expected signal, not a falsification gate.

## Local gates (all green)

- `ruff check src tests`
- `python scripts/test_tier_audit.py --strict tests/test_op_embed.py`
- `uv run pytest -n auto` (full suite, see above)
- `python scripts/verify_module_docstrings.py <8 changed src files>`

`origin/fix/3438-remove-embedding-event-sink-dead-wiring` = `db22b25236925f9558f57778a46d6d51687b05cc`

## Test plan

- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict tests/test_op_embed.py` — 15/15 OK, 0 errors
- [x] `uv run pytest -n auto` (full suite) — 9707 passed, 36 skipped, 0 failed
- [x] `verify_module_docstrings.py` on all 8 changed `src/` files — OK
- [x] Confirmed `DYNAMIC_KIND_EMIT_SITES` no longer declares an
      `embedding_*` `KIND_FAMILY` hole, and #3437's vocabulary-gate test
      stays green
