### PR TITLE
test(events): gate concepts/runtime/events.md's Control IR bucket against AUDIT_EVENT_KINDS

### DIFF
--- a/docs/concepts/runtime/events.md
+++ b/docs/concepts/runtime/events.md
@@ -24,7 +24,16 @@ If the OS is the only mutator (P3) and every mutation emits an audit-event, the 
 A few of the larger buckets:
 
 - **LLM and context** — `llm_called`.
-- **Control IR** — one audit-event per op kind (`sandboxed_exec_started`, `mcp_called`, `web_search_started`, `semantic_search_embed_failed`) plus `permission_denied`. A `file` op like a read instead rides the shared `tool_executed` kind, naming the specific operation in its `op` field rather than as a kind of its own.
+- **Control IR** — one audit-event per op kind, for example:
+  <!-- BEGIN control-ir-bucket-example-kinds -->
+  ```text
+  mcp_called
+  sandboxed_exec_started
+  semantic_search_embed_failed
+  web_search_started
+  ```
+  <!-- END control-ir-bucket-example-kinds -->
+  plus `permission_denied`. A `file` op like a read instead rides the shared `tool_executed` kind, naming the specific operation in its `op` field rather than as a kind of its own.
 - **User interaction** — `user_message_received`, `user_intervention_received`, `chat_started`, `chat_stopped`, `turn_cancelled`.
 - **Agent-to-agent messaging** — `agent_message_sent`, `agent_request_received`, `agent_response_received`, `agent_message_refused`, `chain_timeout`. Each carries `chain_id` so a single user request can be traced across hops.
 

--- a/tests/test_audit_event_kind_vocabulary_3410.py
+++ b/tests/test_audit_event_kind_vocabulary_3410.py
@@ -52,9 +52,13 @@ from reyn.core.events.event_schema import (
 _REPO = Path(__file__).resolve().parents[1]
 _SRC = _REPO / "src" / "reyn"
 _EVENTS_REFERENCE = _REPO / "docs" / "reference" / "runtime" / "events.md"
+_EVENTS_CONCEPT = _REPO / "docs" / "concepts" / "runtime" / "events.md"
 
 _DOC_BEGIN = "<!-- BEGIN audit-event-kinds -->"
 _DOC_END = "<!-- END audit-event-kinds -->"
+
+_CONCEPT_DOC_BEGIN = "<!-- BEGIN control-ir-bucket-example-kinds -->"
+_CONCEPT_DOC_END = "<!-- END control-ir-bucket-example-kinds -->"
 
 
 # ── The census ────────────────────────────────────────────────────────────
@@ -456,6 +460,51 @@ def test_events_reference_enumerates_exactly_the_declared_vocabulary() -> None:
         "AUDIT_EVENT_KINDS — it is what an external consumer enumerates, so a "
         f"stale entry is a handler that never fires. missing={missing} "
         f"extra={extra}"
+    )
+
+
+def _concept_bucket_kinds() -> list[str]:
+    text = _EVENTS_CONCEPT.read_text(encoding="utf-8")
+    start = text.index(_CONCEPT_DOC_BEGIN) + len(_CONCEPT_DOC_BEGIN)
+    end = text.index(_CONCEPT_DOC_END)
+    return re.findall(r"^\s*([a-z0-9_]+)\s*$", text[start:end], flags=re.MULTILINE)
+
+
+def test_concepts_events_control_ir_bucket_cites_only_real_kinds() -> None:
+    """Tier 2: the illustrative Control IR kind list in
+    ``docs/concepts/runtime/events.md`` names only kinds that actually exist.
+
+    Deliberately narrower than the reference-doc gate above: this bucket is a
+    hand-picked EXAMPLE subset, not the closed vocabulary, so the assertion is
+    membership (each cited kind ∈ ``AUDIT_EVENT_KINDS``), not exact equality.
+
+    Why this one bucket gets a delimited, machine-checked block and free doc
+    prose elsewhere does not: a general scan of every doc's backtick-quoted
+    snake_case token against the kind vocabulary was prototyped and rejected
+    (measured, not assumed) — snake_case identifiers for payload fields,
+    config keys, Control IR op kinds, and WAL event kinds are indistinguishable
+    from audit-event kind names by shape alone, so an unscoped scan produces
+    far more false positives than real findings. A structural gate needs a
+    CLOSED target; free prose citing a kind name is not one. This block closes
+    the target by construction (a delimited, single-purpose enumeration) for
+    the one spot that has actually drifted twice in one session (a renamed
+    kind, then a non-kind cited as if it were one) — see the module docstring
+    of ``core/events/event_schema.py`` and #3410's history for both.
+    """
+    cited = _concept_bucket_kinds()
+    assert cited, (
+        "the control-ir-bucket-example-kinds block in "
+        "docs/concepts/runtime/events.md is empty — either the markers moved "
+        "or the block lost its content; a block with nothing in it makes "
+        "this gate vacuously pass"
+    )
+    unknown = sorted(set(cited) - AUDIT_EVENT_KINDS)
+    assert not unknown, (
+        "docs/concepts/runtime/events.md cites kind name(s) not in "
+        f"AUDIT_EVENT_KINDS: {unknown} — either the kind was renamed/removed "
+        "in src/reyn, or the doc named something that was never a kind at "
+        "all (e.g. a Control IR op's own name, or an `op` field value on the "
+        "shared `tool_executed` kind rather than a kind of its own)"
     )
 
 


### PR DESCRIPTION
**[docs-maintainer]** — structural follow-up to the owner's no-bandaids directive (2026-07-29), narrow scope approved by lead-coder/architect after the broader "scan all doc prose" proposal was measured and retracted (see prior broker thread).

## What
This exact bucket line drifted twice in one session (`recall_embed_failed` renamed to `semantic_search_embed_failed`; `read_file` cited as a kind literal when it's actually an `op`-field value on the shared `tool_executed` kind). Per the "close the class, not the instance" mandate:

- Wraps the bucket's example kinds in a delimited `<!-- BEGIN/END control-ir-bucket-example-kinds -->` block, matching `docs/reference/runtime/events.md`'s existing convention.
- Adds `test_concepts_events_control_ir_bucket_cites_only_real_kinds` to `tests/test_audit_event_kind_vocabulary_3410.py`, asserting every cited kind ∈ `AUDIT_EVENT_KINDS` (membership, not exact-match — this is a hand-picked example subset, not the closed vocabulary), plus non-vacuity.

## Why this scope, not broader
3 broader designs were prototyped and measured before this one was chosen:
- Whole-file backtick scan across the 32 docs mentioning "audit-event": 696 distinct tokens, 572 not in the kind set.
- Markdown-table-header ("Kind" column) heuristic: 83 candidates, 27 outsiders — conflated with `control-ir.md`'s Control-IR *op*-kind tables, a different closed vocabulary sharing the same header word.
- Proximity-to-"audit-event" heuristic: 117 candidates, 54 outsiders — conflated with WAL kinds, config keys, and payload field names.

Conclusion: "is this snake_case backtick token an audit-event kind" isn't decidable by shape alone against ≥4 other same-shaped vocabularies — an open target, not safely gateable in general (same test as the doc's own §5: closedness of the target, not "structural vs semantic"). This one delimited block is closed by construction, which is why only it gets the treatment.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_audit_event_kind_vocabulary_3410.py` — 10 inspected, 0 errors
- [x] `pytest tests/test_audit_event_kind_vocabulary_3410.py` — 10 passed
- [x] `python scripts/verify_module_docstrings.py tests/test_audit_event_kind_vocabulary_3410.py` — OK
- [x] `mkdocs build --strict` — exit 0
- [x] Falsified before shipping: inserted a fake kind (`this_kind_does_not_exist`) into the block, confirmed the new test goes RED, reverted, confirmed all 10 tests in the module green again

🤖 Generated with [Claude Code](https://claude.com/claude-code)