### PR TITLE
fix(tests): remove the dead router-cap preset in the intervention no-hang guard test — Closes #3440

### DIFF
--- a/tests/test_intervention_subscriber_guard.py
+++ b/tests/test_intervention_subscriber_guard.py
@@ -18,10 +18,11 @@ Pins:
   5. Session constructs the registry in enforced mode and exposes
      ``register_intervention_listener`` / ``unregister_intervention_listener``
      wrappers.
-  6. End-to-end: a Session that hits a safety limit under
-     ``interactive`` + ``ask_timeout_seconds=0`` with no listener returns
-     immediately (no hang) and lets the caller fall through to its
-     legacy abort path.
+  6. End-to-end: a Session built with ``interactive`` +
+     ``ask_timeout_seconds=0`` + no listener registered runs a normal
+     (under-cap) turn to completion without hanging (see #3440 for why
+     this test does not itself drive the cap-exceeded path — that
+     mechanism is covered directly by pin 2, above).
 
 No mocks. Real registry, real Session.
 """
@@ -242,24 +243,62 @@ def test_chat_session_register_intervention_listener_round_trip() -> None:
     assert session.interventions.has_active_listener() is False
 
 
-# ── 6. End-to-end: limit hit under interactive + timeout=0 + no listener ──
+# ── 6. Session end-to-end: interactive + timeout=0 + no listener, normal turn ──
 
 
 @pytest.mark.replay("fixtures/llm/intervention_guard/safety_limit_no_listener.jsonl")
-def test_safety_limit_under_interactive_no_timeout_no_listener_no_hang(
+def test_interactive_no_timeout_no_listener_normal_turn_no_hang(
     tmp_path: Path, _llm_replay,
 ) -> None:
-    """Tier 2: the exact scenario that motivated issue #254 — a chat
-    session hits a safety limit while running ``mode=interactive`` +
-    ``ask_timeout_seconds=0``, with no UI listener attached. Pre-Phase 1
-    this hung indefinitely awaiting the future. Phase 1: dispatch
-    short-circuits, ``handle_limit_exceeded`` sees an empty answer,
-    treats it as refusal, the caller raises ``RouterCapExceeded``, and
-    ``_handle_user_message`` emits its fallback message and returns.
+    """Tier 2: a Session built with the issue #254 combo — ``mode=interactive``
+    + ``ask_timeout_seconds=0`` + no UI listener registered — runs a normal
+    (under-cap) turn to completion without hanging.
+
+    #3440: this test used to *also* claim to drive the router cap to
+    exhaustion first (via ``session._router_invocations_this_turn = 3``,
+    "pre-spend the router budget so the next call hits the cap") so the turn
+    would exercise ``InterventionRegistry.dispatch``'s no-listener
+    short-circuit end-to-end. That preset was dead on arrival, for two
+    independently fatal reasons (see #3440's investigation for the full
+    measurement):
+
+    1. ``Session`` has no ``_router_invocations_this_turn`` attribute (leading
+       underscore). The real counter lives behind the property
+       ``Session.router_invocations_this_turn`` (no leading underscore,
+       forwarding to ``BudgetGateway``). The old assignment landed on a new,
+       orphaned instance attribute that nothing reads — a #3037-class
+       invented field.
+    2. Even the correctly-named property would not have survived: the very
+       ``_handle_user_message`` call this test drives *unconditionally*
+       resets the per-turn router counter to 0 at its top (see
+       ``Session._reset_router_turn_counter`` / the comment at its call
+       site), before ``RouterLoopDriver._check_cap`` ever runs — and
+       ``_check_cap`` runs exactly once per ``_handle_user_message`` call.
+       So no preset shape driven through a *single* ``_handle_user_message``
+       call can ever observe "cap already exhausted" — that state is only
+       reachable by accumulating real router invocations across in-chain
+       continuations (``_handle_agent_response`` / ``_resolve_pending_chain``,
+       which intentionally do NOT reset) within one chain, which needs a
+       real multi-turn drive this test does not set up (tracked as a
+       follow-up — see #3440).
+
+    Consequently this test never reached the cap-exceeded / dispatch
+    short-circuit path even before this fix — with or without the preset,
+    the turn completes as a plain, un-capped router turn (independently
+    measured: identical real-``litellm.acompletion`` hit count with the
+    preset present vs. removed). That specific mechanism —
+    ``InterventionRegistry.dispatch`` short-circuiting to an empty answer
+    under ``enforce_listener_presence`` with zero listeners — has direct
+    coverage elsewhere in this file
+    (``test_enforced_mode_with_no_listener_short_circuits_with_empty_answer``).
+    What THIS test still legitimately covers: constructing a Session with
+    this exact safety config and driving one real turn through it does not
+    itself hang or misbehave — a regression guard on the wiring, not on the
+    cap-exceeded mechanism.
 
     The test asserts the run completes within a small wall-clock budget
-    — a 5s ceiling is generous; pre-fix the same path waited the entire
-    pytest-timeout window.
+    — a 5s ceiling is generous; pre-fix (#254) the same path waited the
+    entire pytest-timeout window.
 
     #3435: this turn's router call reaches ``litellm.acompletion`` for
     real (``make_session`` gives it no LLM stand-in), so on an unauthenticated
@@ -283,10 +322,6 @@ def test_safety_limit_under_interactive_no_timeout_no_listener_no_hang(
         safety=safety,
     )
     # DELIBERATELY do not register a listener — that is the test condition.
-
-    # Pre-spend the router budget so the next call hits the cap.
-    session._router_invocations_this_turn = 3
-    session._router_last_reason = "out_of_scope"
 
     async def _drive() -> None:
         # Must complete promptly — pre-Phase 1 this awaited forever.


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3440.

## Decision: (b) delete the preset (not (a) fix the name)

I independently re-confirmed both stacked defects the issue reported, then
went further and confirmed a **structural** reason (a)-shaped fixes can't
work here at all, so (b) is the only sound option for this PR.

### Defect 1 (independently re-measured)

`Session` has no `_router_invocations_this_turn` attribute. The real
property is `router_invocations_this_turn` (no leading underscore,
`src/reyn/runtime/session.py:6004-6009`). Direct measurement of
`session.__dict__` right after the test's old assignment:

```
BEFORE  real property: 0   budget internal: 0
AFTER   real property: 0   budget internal: 0   (unchanged!)
orphaned instance attr now present: 3            (landed here instead)
```

(`_router_last_reason`, the *other* preset line, is fine — that property
does exist with the leading underscore, so it was never broken.)

### Defect 2 — why even the correctly-named property can't be made to work

`_handle_user_message` unconditionally calls `_reset_router_turn_counter()`
near its top, **before** `RouterLoopDriver._check_cap` ever runs, and
`_check_cap` runs **exactly once** per `run_turn` call
(`src/reyn/runtime/services/router_loop_driver.py:387`, only call site).
So *any* preset — right name or wrong, direct attribute or the real
`BudgetGateway.check_and_increment_router_cap()` API — is wiped before the
cap check ever sees it, as long as the drive is a single
`_handle_user_message` call. Reaching "cap already exhausted" for real
requires accumulating router invocations across in-chain continuations
(`_handle_agent_response` / `_resolve_pending_chain`, which intentionally
do NOT reset) — a real multi-turn drive, not a single call. That's a
heavier integration test (spawn + continuation + LLMReplay fixtures for
each hop) that the issue itself flagged as needing an owner call on the
driving shape — out of scope for this PR.

### Preset efficacy — measured, not assumed

Instrumented both the old (broken) preset and no preset with a real
`litellm.acompletion` call counter around the *unmodified* production code
(not a strip — this was to characterize current behavior before touching
anything):

```
WITH preset (old code)    -> real acompletion hit count: 5
WITHOUT preset             -> real acompletion hit count: 5
```

Byte-identical either way — confirms the preset was never load-bearing,
independent of #3440's own measurement (which saw hit count 1, likely
before #3435 landed additional turn-plumbing calls; the *comparison*, not
the absolute count, is what matters here).

## What changed

- Removed the two dead preset lines.
- Renamed the test
  `test_safety_limit_under_interactive_no_timeout_no_listener_no_hang` →
  `test_interactive_no_timeout_no_listener_normal_turn_no_hang` and rewrote
  its docstring (and the file's pin-6 summary) to describe what it actually
  measures: a Session built with the issue #254 combo (`mode=interactive` +
  `ask_timeout_seconds=0` + no listener) completes a normal, under-cap turn
  without hanging. It does **not** claim to drive the cap-exceeded /
  dispatch-short-circuit path — that mechanism already has direct coverage
  in the same file via
  `test_enforced_mode_with_no_listener_short_circuits_with_empty_answer`
  (constructs `InterventionRegistry` directly with zero listeners).

This is an honesty fix, not a behavior change: the preset never affected
the outcome, so the test's *measured* behavior is unchanged; only its
*claimed* behavior (docstring) now matches reality.

## Strip-falsify (per repo policy)

Anchor: `await self._loop_driver.run_turn(user_text, chain_id)` in
`src/reyn/runtime/session.py` — confirmed unique (`count == 1`) before
editing. Backed up `session.py` to a scratch copy, replaced the call with
`await asyncio.sleep(3600)` (never resolves within the test's 5s
`asyncio.wait_for`), ran the target test:

```
FAILED tests/test_intervention_subscriber_guard.py::test_interactive_no_timeout_no_listener_normal_turn_no_hang
... TimeoutError
1 failed, 7 deselected, 1 warning in 44.28s
```

RED confirmed — the test genuinely detects a real hang, not a vacuous
pass. Restored `session.py` from the scratch backup (`cp`, not
`git checkout --` / `git stash`); `git status` showed a clean diff on that
file afterward.

## Verification

- `ruff check src tests` — clean.
- `python scripts/test_tier_audit.py --strict tests/test_intervention_subscriber_guard.py`
  — 8/8 OK, 0 warnings, 0 Tier-4 errors.
- `pytest` (repo root, `-n auto`, background + read to the terminal summary
  line, not `wait`): `3 failed, 9706 passed, 36 skipped` — the 3 failures
  (`test_fp0063_arc_witness`, `test_embed_attempts_observation_3047`,
  `test_pipeline_is4_inline`) are unrelated to this change; all 3 pass when
  re-run in isolation (pre-existing xdist/order-dependence flakes, same
  class as #3434).
- `scripts/verify_module_docstrings.py` — not applicable, no `src/` files
  changed.
- Branch pushed: `origin/fix/3440-router-cap-preset-dead` @
  `9671630...` (verified via `git rev-parse origin/fix/3440-router-cap-preset-dead`).

## Test plan

- [x] `pytest tests/test_intervention_subscriber_guard.py` — 8 passed
- [x] Strip-falsify on the production call site — RED confirmed, then
      restored
- [x] Full suite `pytest -n auto` from repo root — green modulo 3
      pre-existing unrelated flakes (verified isolated-pass above)
