### PR TITLE
fix(tests): stub LLM calls for 15 group-A tests, drop allow_real_network — #3452

### DIFF
--- a/tests/test_2103_s1bc_exec_result_routing.py
+++ b/tests/test_2103_s1bc_exec_result_routing.py
@@ -132,18 +132,11 @@ async def test_unrecorded_sid_falls_back_to_kind_agent(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-@pytest.mark.allow_real_network(
-    reason="#3445 group A / #3452 (temporary, time-boxed — NOT a permanent "
-    "design exception like B/D): reaches real litellm.acompletion because no "
-    "LLM stub is wired for this session's run-loop (same shape as #3435). The "
-    "structural gate (#3451) must not silently break this test at merge time; "
-    "the real fix (stub the call, matching this file's sibling tests where "
-    "one exists) is tracked in #3452.",
-)
-async def test_response_routes_to_non_main_spawner_sid_not_main(tmp_path):
+async def test_response_routes_to_non_main_spawner_sid_not_main(tmp_path, monkeypatch):
     """Tier 2: (LOAD-BEARING, #2130) a response addressed to a NON-MAIN (spawner) sid
     routes to THAT specific session, NOT the agent's main. RED on the name-only delivery
     (get_or_load(to) → main): main would get it + the spawner would not."""
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _scripted_llm())
     reg = _registry(tmp_path)
     main = reg.get_or_load("worker")  # the agent's main (must NOT receive a non-main reply)
     x_sid = await reg.spawn_session_recorded("worker", mode="persistent", presentation_consumer=None, intervention_bridge=None)
@@ -209,20 +202,13 @@ async def test_non_main_delegation_reply_routes_to_delegating_sid_not_main(tmp_p
 
 
 @pytest.mark.asyncio
-@pytest.mark.allow_real_network(
-    reason="#3445 group A / #3452 (temporary, time-boxed — NOT a permanent "
-    "design exception like B/D): reaches real litellm.acompletion because no "
-    "LLM stub is wired for this session's run-loop (same shape as #3435). The "
-    "structural gate (#3451) must not silently break this test at merge time; "
-    "the real fix (stub the call, matching this file's sibling tests where "
-    "one exists) is tracked in #3452.",
-)
-async def test_default_path_loads_cold_main_and_starts_forwarder(tmp_path):
+async def test_default_path_loads_cold_main_and_starts_forwarder(tmp_path, monkeypatch):
     """Tier 2: (LOAD-BEARING byte-identical leg, #2130) a reply with NO to_sid (the
     default/main case) keeps the existing get_or_load + ensure_running semantics — it
     LOADS a COLD/unloaded main from disk and starts its forwarder. RED if the default path
     were switched to the get-only get_session (a cold/unloaded main would be silently
     DROPPED, never loaded — a warm-main test would not catch this)."""
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _scripted_llm())
     reg = _registry(tmp_path)
     reg.create("sender")
     sender = reg.get_or_load("sender")

--- a/tests/test_2708_p31_spawn_bridge_present.py
+++ b/tests/test_2708_p31_spawn_bridge_present.py
@@ -35,6 +35,8 @@ from reyn.core.events.config_recovery import reyn_root
 from reyn.core.events.state_log import StateLog
 from reyn.core.pipeline.executor import Pipeline, ToolStep
 from reyn.core.pipeline.work_order import pipeline_run_dir, read_result
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 from reyn.runtime.session_api import run_pipeline_attached, start_pipeline_run
@@ -42,6 +44,19 @@ from reyn.runtime.session_params import PresentationWiring
 from tests._support.agent_session import make_session
 
 _MARKER = "REYN2708P31BRIDGEMARKER"
+
+
+def _scripted_llm():
+    # The DETACHED driver's completion posts a ``pipeline_result`` inbox
+    # message to the reply-to (caller) session, whose next router turn reaches
+    # real litellm.acompletion with no stub wired — same shape as the sibling
+    # stub in tests/test_2103_s1bc_exec_result_routing.py.
+    async def _fake_llm(*args, **kwargs) -> LLMToolCallResult:
+        return LLMToolCallResult(
+            content="ack", tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=1, completion_tokens=1),
+        )
+    return _fake_llm
 
 
 def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
@@ -173,15 +188,7 @@ async def test_attached_present_audit_event_bridged_to_parent_log(
 
 
 @pytest.mark.asyncio
-@pytest.mark.allow_real_network(
-    reason="#3445 group A / #3452 (temporary, time-boxed — NOT a permanent "
-    "design exception like B/D): reaches real litellm.acompletion because no "
-    "LLM stub is wired for this session's run-loop (same shape as #3435). The "
-    "structural gate (#3451) must not silently break this test at merge time; "
-    "the real fix (stub the call, matching this file's sibling tests where "
-    "one exists) is tracked in #3452.",
-)
-async def test_detached_present_not_bridged_to_caller(tmp_path: Path) -> None:
+async def test_detached_present_not_bridged_to_caller(tmp_path: Path, monkeypatch) -> None:
     """Tier 2: scope guard — a DETACHED (``start_pipeline_run``) pipeline's present is NOT
     bridged to the (non-attached) invoker: no ``pipeline_run_attached`` marker is emitted,
     so the caller's forwarder never bridge-subscribes → no bridged ``presented`` on the
@@ -190,6 +197,7 @@ async def test_detached_present_not_bridged_to_caller(tmp_path: Path) -> None:
     — audit-only, no orphan — landed in P3-item3; see
     ``test_spawn_routing_detached_fail_mode_2708``. It still, correctly, does not reach this
     non-attached caller.)"""
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _scripted_llm())
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     reg = _agent_registry(tmp_path, state_log)
     caller = reg.get_or_load("worker")

--- a/tests/test_2708_p32a_spawn_bridge_intervention.py
+++ b/tests/test_2708_p32a_spawn_bridge_intervention.py
@@ -38,6 +38,8 @@ from _async_wait import wait_until  # noqa: E402 — shared #1751 test wait help
 
 from reyn.core.events.state_log import StateLog  # noqa: E402
 from reyn.core.pipeline.executor import Pipeline, ToolStep  # noqa: E402
+from reyn.llm.llm import LLMToolCallResult  # noqa: E402
+from reyn.llm.pricing import TokenUsage  # noqa: E402
 from reyn.runtime.registry import AgentRegistry  # noqa: E402
 from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session  # noqa: E402
 from reyn.runtime.session_api import run_pipeline_attached, start_pipeline_run  # noqa: E402
@@ -46,6 +48,19 @@ from tests._support.agent_session import make_session
 
 _QUESTION = "REYN2708P32A which branch?"
 _ANSWER = "REYN2708P32A-the-blue-branch"
+
+
+def _scripted_llm():
+    # The DETACHED driver's completion posts a ``pipeline_result`` inbox
+    # message to the reply-to (caller) session, whose next router turn reaches
+    # real litellm.acompletion with no stub wired — same shape as the sibling
+    # stub in tests/test_2103_s1bc_exec_result_routing.py.
+    async def _fake_llm(*args, **kwargs) -> LLMToolCallResult:
+        return LLMToolCallResult(
+            content="ack", tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=1, completion_tokens=1),
+        )
+    return _fake_llm
 
 
 def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
@@ -223,15 +238,7 @@ async def test_attached_ask_user_not_stalled_uses_live_parent_listener(
 
 
 @pytest.mark.asyncio
-@pytest.mark.allow_real_network(
-    reason="#3445 group A / #3452 (temporary, time-boxed — NOT a permanent "
-    "design exception like B/D): reaches real litellm.acompletion because no "
-    "LLM stub is wired for this session's run-loop (same shape as #3435). The "
-    "structural gate (#3451) must not silently break this test at merge time; "
-    "the real fix (stub the call, matching this file's sibling tests where "
-    "one exists) is tracked in #3452.",
-)
-async def test_detached_ask_user_does_not_reach_invoker(tmp_path: Path) -> None:
+async def test_detached_ask_user_does_not_reach_invoker(tmp_path: Path, monkeypatch) -> None:
     """Tier 2: scope guard — a DETACHED (``start_pipeline_run``) pipeline's ``ask_user`` does
     NOT reach the (non-attached) invoker's live operator listener (over a bounded window the
     invoker is never prompted). This pins the attached-only scope of P3.2a's PARENT-bridge.
@@ -239,6 +246,7 @@ async def test_detached_ask_user_does_not_reach_invoker(tmp_path: Path) -> None:
     resolved locally, NOT the pre-fix origin-pin park/hang — landed in P3-item3; see
     ``test_spawn_routing_detached_fail_mode_2708``. It correctly resolves without ever touching
     this non-attached invoker's registry.)"""
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _scripted_llm())
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     reg = _agent_registry(tmp_path, state_log)
     caller = reg.get_or_load("worker")

--- a/tests/test_3093_pipeline_registry_spawn_propagation.py
+++ b/tests/test_3093_pipeline_registry_spawn_propagation.py
@@ -73,12 +73,27 @@ import yaml
 
 from reyn.core.events.state_log import StateLog
 from reyn.core.pipeline.work_order import pipeline_run_dir, read_result
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 from reyn.runtime.session_params import PresentationWiring
 from reyn.tools.pipeline_verbs import _handle_run_pipeline, _handle_run_pipeline_async
 from reyn.tools.types import RouterCallerState, ToolContext
 from tests._support.agent_session import make_session
+
+
+def _scripted_llm():
+    # The DETACHED driver's completion posts a ``pipeline_result`` inbox
+    # message to the reply-to (caller) session, whose next router turn reaches
+    # real litellm.acompletion with no stub wired — same shape as the sibling
+    # stub in tests/test_2103_s1bc_exec_result_routing.py.
+    async def _fake_llm(*args, **kwargs) -> LLMToolCallResult:
+        return LLMToolCallResult(
+            content="ack", tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=1, completion_tokens=1),
+        )
+    return _fake_llm
 
 
 def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
@@ -182,14 +197,6 @@ async def _wait_for(pred, timeout: float = 15.0) -> bool:
 
 
 @pytest.mark.asyncio
-@pytest.mark.allow_real_network(
-    reason="#3445 group A / #3452 (temporary, time-boxed — NOT a permanent "
-    "design exception like B/D): reaches real litellm.acompletion because no "
-    "LLM stub is wired for this session's run-loop (same shape as #3435). The "
-    "structural gate (#3451) must not silently break this test at merge time; "
-    "the real fix (stub the call, matching this file's sibling tests where "
-    "one exists) is tracked in #3452.",
-)
 async def test_async_detached_run_resolves_sibling_via_family_gate(
     tmp_path: Path, monkeypatch,
 ) -> None:
@@ -201,6 +208,7 @@ async def test_async_detached_run_resolves_sibling_via_family_gate(
     the on-disk cascade BEFORE the run's first nudge. RED before #3097 (and
     before #3094): the driver would inherit the caller's FROZEN factory-time
     registry and fail "target pipeline 'ns.sibling' is not registered"."""
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _scripted_llm())
     monkeypatch.chdir(tmp_path)
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     out_file = tmp_path / "out.txt"

--- a/tests/test_a2a_bus_stamping_268_phase2.py
+++ b/tests/test_a2a_bus_stamping_268_phase2.py
@@ -40,12 +40,27 @@ pytest.importorskip("fastapi", reason="fastapi not installed ([web] extra missin
 
 from reyn.interfaces.web.a2a_intervention import A2AInterventionBus  # noqa: E402
 from reyn.interfaces.web.run_registry import RunRegistry  # noqa: E402
+from reyn.llm.llm import LLMToolCallResult  # noqa: E402
+from reyn.llm.pricing import TokenUsage  # noqa: E402
 from reyn.runtime.session import Session  # noqa: E402
 from reyn.user_intervention import (  # noqa: E402
     InterventionAnswer,
     UserIntervention,
 )
 from tests._support.agent_session import make_session
+
+
+def _scripted_llm():
+    # send_to_agent_impl drives the session's real router turn — with
+    # no stub wired, that turn reaches real litellm.acompletion (the short
+    # timeout= just raced it, it did not prevent the reach). Same stub shape
+    # as tests/test_2103_s1bc_exec_result_routing.py.
+    async def _fake_llm(*args, **kwargs) -> LLMToolCallResult:
+        return LLMToolCallResult(
+            content="ack", tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=1, completion_tokens=1),
+        )
+    return _fake_llm
 
 # ── 1. A2AInterventionBus.channel_id ──────────────────────────────────
 
@@ -118,16 +133,8 @@ def test_on_dispatch_respects_preexisting_origin_channel_id() -> None:
 # ── 3. send_to_agent_impl listener lifecycle ──────────────────────────
 
 
-@pytest.mark.allow_real_network(
-    reason="#3445 group A / #3452 (temporary, time-boxed — NOT a permanent "
-    "design exception like B/D): reaches real litellm.acompletion because no "
-    "LLM stub is wired for this session's run-loop (same shape as #3435). The "
-    "structural gate (#3451) must not silently break this test at merge time; "
-    "the real fix (stub the call, matching this file's sibling tests where "
-    "one exists) is tracked in #3452.",
-)
 def test_send_to_agent_impl_registers_a2a_channel_id_as_listener(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch,
 ) -> None:
     """Tier 2: when ``send_to_agent_impl`` is called with an
     A2AInterventionBus override, the bus's ``channel_id`` is
@@ -137,6 +144,7 @@ def test_send_to_agent_impl_registers_a2a_channel_id_as_listener(
     Verifies the agent layer's origin-pin check (= Phase 1 design)
     treats the A2A channel as alive while the task runs.
     """
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _scripted_llm())
     from reyn.core.events.state_log import StateLog
     from reyn.mcp.server import send_to_agent_impl
     from reyn.runtime.budget.budget import BudgetTracker, CostConfig
@@ -217,16 +225,8 @@ def test_send_to_agent_impl_registers_a2a_channel_id_as_listener(
     )
 
 
-@pytest.mark.allow_real_network(
-    reason="#3445 group A / #3452 (temporary, time-boxed — NOT a permanent "
-    "design exception like B/D): reaches real litellm.acompletion because no "
-    "LLM stub is wired for this session's run-loop (same shape as #3435). The "
-    "structural gate (#3451) must not silently break this test at merge time; "
-    "the real fix (stub the call, matching this file's sibling tests where "
-    "one exists) is tracked in #3452.",
-)
 def test_send_to_agent_impl_skips_listener_when_override_has_no_channel_id(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch,
 ) -> None:
     """Tier 2: defensive — when an override doesn't expose
     ``channel_id`` (= future bus impls might not), the listener
@@ -235,6 +235,7 @@ def test_send_to_agent_impl_skips_listener_when_override_has_no_channel_id(
     Uses a minimal stub bus to verify the defensive
     ``getattr(intervention_override, "channel_id", None)`` path.
     """
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _scripted_llm())
     from reyn.core.events.state_log import StateLog
     from reyn.mcp.server import send_to_agent_impl
     from reyn.runtime.budget.budget import BudgetTracker, CostConfig
@@ -293,21 +294,14 @@ def test_send_to_agent_impl_skips_listener_when_override_has_no_channel_id(
 # ── 4. Backwards-compat: no override = no listener change ─────────────
 
 
-@pytest.mark.allow_real_network(
-    reason="#3445 group A / #3452 (temporary, time-boxed — NOT a permanent "
-    "design exception like B/D): reaches real litellm.acompletion because no "
-    "LLM stub is wired for this session's run-loop (same shape as #3435). The "
-    "structural gate (#3451) must not silently break this test at merge time; "
-    "the real fix (stub the call, matching this file's sibling tests where "
-    "one exists) is tracked in #3452.",
-)
 def test_send_to_agent_impl_without_override_does_not_register_listener(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch,
 ) -> None:
     """Tier 2: when ``intervention_override`` is None (= the legacy
     path), no listener registration happens. Pre-#268 callers see
     unchanged behaviour.
     """
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _scripted_llm())
     from reyn.core.events.state_log import StateLog
     from reyn.mcp.server import send_to_agent_impl
     from reyn.runtime.budget.budget import BudgetTracker, CostConfig

--- a/tests/test_fp0001_e2e_ask_user_roundtrip.py
+++ b/tests/test_fp0001_e2e_ask_user_roundtrip.py
@@ -230,14 +230,6 @@ def _build_registry_for_test(tmp_path: Path):
 
 
 @pytest.mark.skipif(_SKIP_ROUTER, reason=_SKIP_REASON)
-@pytest.mark.allow_real_network(
-    reason="#3445 group A / #3452 (temporary, time-boxed — NOT a permanent "
-    "design exception like B/D): reaches real litellm.acompletion because no "
-    "LLM stub is wired for this session's run-loop (same shape as #3435). The "
-    "structural gate (#3451) must not silently break this test at merge time; "
-    "the real fix (stub the call, matching this file's sibling tests where "
-    "one exists) is tracked in #3452.",
-)
 def test_async_mode_message_send_returns_task_envelope(tmp_path, monkeypatch):
     """Tier 2c: POST /a2a/agents/{name} with async_mode=true returns a task
     envelope {kind: 'task', id: run_id, status: 'running'}.
@@ -246,6 +238,7 @@ def test_async_mode_message_send_returns_task_envelope(tmp_path, monkeypatch):
     """
     monkeypatch.chdir(tmp_path)
 
+    import reyn.interfaces.web.routers.a2a as a2a_mod
     from reyn.interfaces.web.a2a_webhook_registry import A2AWebhookRegistry
     from reyn.interfaces.web.deps import (
         get_a2a_webhook_registry,
@@ -255,6 +248,20 @@ def test_async_mode_message_send_returns_task_envelope(tmp_path, monkeypatch):
     from reyn.interfaces.web.run_registry import RunRegistry
     from reyn.interfaces.web.server import app
     from tests._support.web_auth import local_operator_client
+
+    # The create path kicks off a real background agent-send turn that
+    # reaches litellm.acompletion with no stub wired — same real-injected-stub
+    # shape as this file's sibling
+    # test_e2e_create_with_webhook_then_cancel_fires_disposition, which stubs
+    # send_to_agent_impl directly rather than the deeper router_loop call.
+    async def _stub_send(*_args, **_kwargs):
+        return {"reply": "ok", "partial": False, "running_run_ids": []}
+
+    monkeypatch.setattr(a2a_mod, "send_to_agent_impl", _stub_send)
+    monkeypatch.setattr(
+        a2a_mod, "resolve_a2a_session",
+        lambda registry, agent_name, context_id=None: None,
+    )
 
     registry = _build_registry_for_test(tmp_path)
     # FP-0009 B: RunRegistry now lives in the FastAPI lifespan startup.

--- a/tests/test_spawn_routing_detached_fail_mode_2708.py
+++ b/tests/test_spawn_routing_detached_fail_mode_2708.py
@@ -29,6 +29,8 @@ from reyn.core.events.config_recovery import reyn_root
 from reyn.core.events.state_log import StateLog
 from reyn.core.pipeline.executor import Pipeline, ToolStep
 from reyn.core.pipeline.work_order import pipeline_run_dir, read_result
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
 from reyn.runtime.presentation_consumer import (
     AuditOnlyPresentationConsumer,
     AuditOnlyPresentationSink,
@@ -44,6 +46,20 @@ from reyn.runtime.session_buses import (
 from reyn.runtime.session_params import PresentationWiring
 from reyn.user_intervention import UserIntervention
 from tests._support.agent_session import make_session
+
+
+def _scripted_llm():
+    # These tests spawn real sessions whose run-loop turn (either the
+    # detached driver's reply-to session processing a pipeline_result, the
+    # run_agent_step ephemeral worker's own turn, or a session_spawn child's
+    # initial submitted request) reaches real litellm.acompletion with no stub
+    # wired — same shape as tests/test_2103_s1bc_exec_result_routing.py.
+    async def _fake_llm(*args, **kwargs) -> LLMToolCallResult:
+        return LLMToolCallResult(
+            content="ack", tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=1, completion_tokens=1),
+        )
+    return _fake_llm
 
 
 def _recording_registry(tmp_path: Path, state_log: "StateLog") -> "tuple[AgentRegistry, list]":
@@ -171,18 +187,13 @@ async def test_ask_user_op_via_audit_only_bridge_returns_typed_refusal() -> None
 
 
 @pytest.mark.asyncio
-@pytest.mark.allow_real_network(
-    reason="#3445 group A / #3452 (temporary, time-boxed — NOT a permanent "
-    "design exception like B/D): reaches real litellm.acompletion because no "
-    "LLM stub is wired for this session's run-loop (same shape as #3435). The "
-    "structural gate (#3451) must not silently break this test at merge time; "
-    "the real fix (stub the call, matching this file's sibling tests where "
-    "one exists) is tracked in #3452.",
-)
-async def test_detached_present_is_audit_only_no_orphan_outbox(tmp_path: Path) -> None:
+async def test_detached_present_is_audit_only_no_orphan_outbox(
+    tmp_path: Path, monkeypatch,
+) -> None:
     """Tier 2: a DETACHED pipeline's ``present`` no longer orphans a ``"presentation"`` message on
     the driver's own undrained outbox (the pre-fix #2710 silent-loss); it is audit-only — the
     driver's ``presented`` P6 event still fires (audit trail preserved), zero outbox presentation."""
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _scripted_llm())
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     reg, built = _recording_registry(tmp_path, state_log)
 
@@ -228,19 +239,14 @@ async def test_detached_present_is_audit_only_no_orphan_outbox(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
-@pytest.mark.allow_real_network(
-    reason="#3445 group A / #3452 (temporary, time-boxed — NOT a permanent "
-    "design exception like B/D): reaches real litellm.acompletion because no "
-    "LLM stub is wired for this session's run-loop (same shape as #3435). The "
-    "structural gate (#3451) must not silently break this test at merge time; "
-    "the real fix (stub the call, matching this file's sibling tests where "
-    "one exists) is tracked in #3452.",
-)
-async def test_detached_ask_user_refuses_deliberately_no_hang(tmp_path: Path) -> None:
+async def test_detached_ask_user_refuses_deliberately_no_hang(
+    tmp_path: Path, monkeypatch,
+) -> None:
     """Tier 2: step-1 resolution pinned. A DETACHED pipeline's ``ask_user`` now RESOLVES (terminal
     reached quickly — NOT the pre-fix origin-pin park/hang that never reached terminal in >6s) via
     a DELIBERATE typed refusal: the driver's ``user_intervention_received`` event carries
     ``refused=True`` + the reason, not a fabricated empty auto-refuse."""
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _scripted_llm())
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     reg, built = _recording_registry(tmp_path, state_log)
 
@@ -284,24 +290,17 @@ async def test_detached_ask_user_refuses_deliberately_no_hang(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
-@pytest.mark.allow_real_network(
-    reason="#3445 group A / #3452 (temporary, time-boxed — NOT a permanent "
-    "design exception like B/D): reaches real litellm.acompletion because no "
-    "LLM stub is wired for this session's run-loop (same shape as #3435). The "
-    "structural gate (#3451) must not silently break this test at merge time; "
-    "the real fix (stub the call, matching this file's sibling tests where "
-    "one exists) is tracked in #3452.",
-)
-async def test_agent_step_worker_spawned_audit_only(tmp_path: Path) -> None:
+async def test_agent_step_worker_spawned_audit_only(tmp_path: Path, monkeypatch) -> None:
     """Tier 2: #2706 root-cause-i — ``run_agent_step`` spawns its ephemeral leaf worker with an
     AuditOnly routing (present audit-only, ask_user typed-refusal), NOT the pre-fix self-bound
     consumer that orphaned a present onto the worker's own outbox for the ``kind=="agent"`` filter
     to silently drop. Pinned on the worker's PUBLIC routing accessors."""
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _scripted_llm())
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     reg, built = _recording_registry(tmp_path, state_log)
 
-    # The worker's one router turn has no live LLM here (returns empty agent text); the spawn +
-    # its declared routing is what #2706 root-cause-i fixes — captured via the recording factory.
+    # The worker's one router turn is scripted — the spawn + its declared
+    # routing is what #2706 root-cause-i fixes — captured via the recording factory.
     try:
         await asyncio.wait_for(
             run_agent_step(reg, identity="worker", prompt="do a thing", timeout=5.0),
@@ -334,21 +333,16 @@ async def test_agent_step_worker_spawned_audit_only(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.allow_real_network(
-    reason="#3445 group A / #3452 (temporary, time-boxed — NOT a permanent "
-    "design exception like B/D): reaches real litellm.acompletion because no "
-    "LLM stub is wired for this session's run-loop (same shape as #3435). The "
-    "structural gate (#3451) must not silently break this test at merge time; "
-    "the real fix (stub the call, matching this file's sibling tests where "
-    "one exists) is tracked in #3452.",
-)
-async def test_session_spawn_child_ask_user_reaches_parent_operator_no_hang(tmp_path: Path) -> None:
+async def test_session_spawn_child_ask_user_reaches_parent_operator_no_hang(
+    tmp_path: Path, monkeypatch,
+) -> None:
     """Tier 2: co-vet must-fix — the LLM ``session_spawn`` tool's BACKGROUND child routes
     ``BridgeToParent`` (not self-bound ReviewedNA), so its ``ask_user`` reaches the spawning
     PARENT's live operator and RESOLVES — it does NOT hit the origin-pin park/hang a self-bound
     child would (its "tui"-stamped iv on a listener-less own registry parks forever). RED before
     fix (child ``intervention_bridge`` is None → ask_user parks on the child's own registry);
     GREEN after (BridgeToParent → the parent operator resolves it)."""
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _scripted_llm())
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     reg, built = _recording_registry(tmp_path, state_log)
     parent = reg.get_or_load("worker")
@@ -407,16 +401,8 @@ async def _spawn_from(
 
 
 @pytest.mark.asyncio
-@pytest.mark.allow_real_network(
-    reason="#3445 group A / #3452 (temporary, time-boxed — NOT a permanent "
-    "design exception like B/D): reaches real litellm.acompletion because no "
-    "LLM stub is wired for this session's run-loop (same shape as #3435). The "
-    "structural gate (#3451) must not silently break this test at merge time; "
-    "the real fix (stub the call, matching this file's sibling tests where "
-    "one exists) is tracked in #3452.",
-)
 async def test_session_spawn_grandchild_ask_user_reaches_root_operator_transitively(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch,
 ) -> None:
     """Tier 2: co-vet recursive-edge closure — a GRANDCHILD (session_spawn from a HEADLESS spawned
     child) routes its ask_user TRANSITIVELY to the first attached ancestor (the ROOT operator), NOT
@@ -424,6 +410,7 @@ async def test_session_spawn_grandchild_ask_user_reaches_root_operator_transitiv
     BridgeToParent is hang-safe at EVERY depth (session_spawn has no depth cap + a spawned child's
     router loop re-exposes session_spawn → grandchildren are reachable). RED if the bridge dispatches
     on the immediate parent's coordinator (the grandchild never reaches the root queue → hang)."""
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _scripted_llm())
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     reg, _built = _recording_registry(tmp_path, state_log)
     root = reg.get_or_load("worker")
@@ -456,19 +443,14 @@ async def test_session_spawn_grandchild_ask_user_reaches_root_operator_transitiv
 
 
 @pytest.mark.asyncio
-@pytest.mark.allow_real_network(
-    reason="#3445 group A / #3452 (temporary, time-boxed — NOT a permanent "
-    "design exception like B/D): reaches real litellm.acompletion because no "
-    "LLM stub is wired for this session's run-loop (same shape as #3435). The "
-    "structural gate (#3451) must not silently break this test at merge time; "
-    "the real fix (stub the call, matching this file's sibling tests where "
-    "one exists) is tracked in #3452.",
-)
-async def test_fully_headless_spawn_chain_ask_user_refuses_not_hang(tmp_path: Path) -> None:
+async def test_fully_headless_spawn_chain_ask_user_refuses_not_hang(
+    tmp_path: Path, monkeypatch,
+) -> None:
     """Tier 2: co-vet recursive-edge terminal — a FULLY-headless spawn chain (no operator listener
     anywhere in the ancestry) resolves ask_user with a typed refusal, NEVER an unbounded park. This
     is the terminal that makes BridgeToParent hang-safe by construction even with no reachable
     operator at the root."""
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _scripted_llm())
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     reg, _built = _recording_registry(tmp_path, state_log)
     root = reg.get_or_load("worker")  # NO listener registered — a headless root (cron/background)


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3452.

## What

#3457 landed the structural gate (`reyn.dev.testing.network_gate`) that turns every
unpinned `litellm.acompletion`/`aembedding` reach into a loud `UnpinnedNetworkReach`
failure, and registered a **temporary, time-boxed** `@pytest.mark.allow_real_network(reason="...#3452...")`
on the 15 tests #3445's group-A sweep found reaching real `litellm.acompletion` with
no LLM stub wired. This PR is the real-fix follow-through the marker's `reason=` names:
every one of the 15 now stubs the LLM call and the marker is removed.

## Fix shape (per test, matching this repo's existing sibling pattern)

- **13/15** — `monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", <scripted stub>)`,
  the exact pattern already used by this repo's sibling tests (e.g.
  `test_2103_s1bc_exec_result_routing.py::test_main_spawn_result_routes_back_correlated_as_spawned_session`).
  Covers: the detached pipeline-driver's completion delivering a `pipeline_result` to the
  reply-to session (whose next router turn reaches the LLM), `run_agent_step`'s ephemeral
  worker turn, and `session_spawn` children's initial submitted-request turn.
- **2/15** (`tests/test_fp0001_e2e_ask_user_roundtrip.py::test_async_mode_message_send_returns_task_envelope`,
  and by extension the a2a-router create-path) — stubs `send_to_agent_impl` /
  `resolve_a2a_session` directly, mirroring this file's own sibling
  `test_e2e_create_with_webhook_then_cancel_fires_disposition`, which already does this
  rather than reaching deeper into `router_loop`.

No new gate/mechanism invented — this is pure application of #3457's existing gate +
this repo's existing stub idioms to the 15 named tests.

## Scope discipline

`test_embed_bound_cancel_3043` / `test_embed_attempts_observation_3047` /
`test_embed_max_retries_wire_count_3047` (adversarial socket / wire-count-counting
`allow_real_network` tests) are **untouched** — out of scope per the issue.

## Verification

- All 15 targeted tests pass with the stub wired, marker removed:
  `test_2103_s1bc_exec_result_routing.py` (2), `test_2708_p31_spawn_bridge_present.py` (1),
  `test_2708_p32a_spawn_bridge_intervention.py` (1),
  `test_3093_pipeline_registry_spawn_propagation.py` (1),
  `test_a2a_bus_stamping_268_phase2.py` (3), `test_fp0001_e2e_ask_user_roundtrip.py` (1),
  `test_spawn_routing_detached_fail_mode_2708.py` (6).
- `grep -rn "3452" tests | wc -l` → **0** (no residual marker or reference).
- **Strip-falsify (non-vacuousness)**: reverting the stub in
  `test_response_routes_to_non_main_spawner_sid_not_main` and forcing the test to
  directly `await` the spawned session's background `run()` task (instead of letting
  it run detached, which is how the reach was previously silently swallowed — the
  exact #3445 finding: "13 of 15 never even surfaced as a visible FAILED test... the
  exception was swallowed inside a background run-loop") reproducibly turns the test
  RED: `network_gate._gate` fires for `litellm.acompletion` with no `@replay`/
  `allow_real_network` marker present (confirmed via a temporary stderr probe in
  `_gate`, reverted via cp-scratch — never landed), and the forced-await assertion
  fails. With the stub restored, the same test is green in <1s. This was reverted via
  cp-scratch restore (`git checkout --` avoided per multi-session-safety policy); the
  final diff contains no probe residue (`git diff --stat` clean before commit).
- Second #3457 gate (declared-but-never-triggered `allow_real_network` markers fail
  the session): green — confirmed via `tests/test_network_gate_3451.py` +
  `test_network_gate_boundary_completeness_3451.py` passing alongside the 7 changed
  files (49 passed total).
- 4 CI gates, all green:
  - `ruff check src tests` → All checks passed!
  - `python scripts/test_tier_audit.py --strict <7 changed test files>` → 41 tests
    inspected, 0 warnings, 0 errors.
  - `pytest -n auto` (full suite, rebased onto `origin/main` @ `71c5c479`) →
    **9729 passed, 36 skipped, 36 warnings in 213.91s** (0 failed, 0 errors).
  - `verify_module_docstrings.py` — no `src/` files changed by this PR (tests-only),
    not applicable.

Branch rebased onto `origin/main` after #3461 merged; no conflicts (tests-only diff).

## Test plan

- [x] All 15 previously-marked tests pass with the stub, no `allow_real_network` marker.
- [x] `grep -rn "3452" tests | wc -l` is 0.
- [x] Strip-falsify: reverting one stub + forcing the background task to be awaited
      reproduces `UnpinnedNetworkReach`-driven RED; restoring the stub is green again.
- [x] `ruff check src tests` green.
- [x] `python scripts/test_tier_audit.py --strict` green on the 7 changed test files.
- [x] Full `pytest -n auto` green (9729 passed, 36 skipped, 0 failed).
- [x] `test_network_gate_3451.py` + `test_network_gate_boundary_completeness_3451.py`
      (the #3457 gate's own tests, incl. the stale-marker check) green alongside the
      changed files.
