### PR TITLE
feat(tools): LLM-reachability gate for router=allow ToolDefinitions — #3464

### DIFF
--- a/src/reyn/tools/llm_reachability.py
+++ b/src/reyn/tools/llm_reachability.py
@@ -1,0 +1,306 @@
+"""LLM-reachability gate — SSoT for which ``router="allow"`` ToolDefinitions
+the LLM can actually reach in the default production configuration, and a
+closed registry of the ones that cannot be reached today, each carrying a
+falsifiable reason (#3464).
+
+## The defect class (5 prior individually-closed instances)
+
+Being registered in the default ``ToolRegistry`` with ``gates.router="allow"``
+does not imply the LLM can ever call the tool — #2032, #3083, #2913, #2875,
+#3215 each independently patched one instance of "registered + dispatchable
+but never appears on the LLM-visible surface." #3464 is the 6th (cron: 5
+tools). This module is the gate that replaces patching instance N+1 forever:
+it derives reachability structurally and requires every unreachable tool to
+be declared, with a reason, rather than silently open.
+
+## Definition of "LLM-reachable" (measured on current ``main``, not assumed)
+
+A ``router="allow"`` ToolDefinition's ``name`` is reachable in the default
+production configuration iff EITHER of two independently-sufficient routes
+can deliver it to the model:
+
+  (a) **Direct advertisement** — ``build_tools()`` can place the name
+      directly in the ``tools=`` payload. Derived structurally: an AST
+      census of every ``<registry>.lookup(...)`` call inside
+      ``router_tools.build_tools``, resolving both string-literal
+      arguments and names that trace back to a string-literal
+      tuple/list assignment (covers the wrapper-name loop, which looks
+      up a loop variable rather than a literal). Structural, not one
+      execution with one args tuple: several of these tools (the D5-D11
+      MCP resource/prompt verbs, ``compact``, ``session_spawn``,
+      ``search_actions``) are only emitted under a *particular*
+      configuration (MCP servers configured / context near budget /
+      embedding enabled) — that is correct conditional gating, not an
+      unreachability defect, and executing ``build_tools([])`` with one
+      fixed arg tuple cannot tell the two apart (confirmed: doing so
+      flags those as "unreachable" too, a false positive this census
+      avoids).
+  (b) **Resolution via ``invoke_action``** — the name is the bare
+      dispatch target of some qualified name in
+      ``universal_dispatch._OPERATION_RULES``. ``invoke_action`` is
+      itself advertised via route (a) whenever the universal wrappers
+      are enabled, which is the shipped default
+      (``ActionRetrievalConfig.universal_wrappers_enabled: bool = True``
+      in ``reyn.config.embedding``) — so resolving through it is a real,
+      always-available route in the default configuration, not a
+      hypothetical one.
+
+**"Any one route suffices" is the deliberate reading** — the issue does
+not require a SPECIFIC path, only that the model can reach the tool
+SOMEHOW. ``hot_list_aliases`` and the MCP ``tool_search_tool`` meta-tool
+are not independent THIRD routes: both are dynamically-selected SUBSETS of
+route (a)/(b)'s pool (hot-list seeds are qualified names drawn from
+``_OPERATION_RULES``; ``tool_search_tool`` wraps the same MCP-server-derived
+dicts route (a) already assembles) — neither can make an otherwise
+structurally-unreachable tool reachable, so neither is modeled as a
+separate route here.
+
+``gates.router="deny"`` tools (e.g. ``ask_user`` — CLI/internal-only by
+design) are out of scope by construction: the census only looks at
+``gates.router == "allow"``.
+
+## Measured result on current ``main``
+
+8 tools, not cron's 5:
+
+  cron_register, cron_unregister, cron_list, cron_enable, cron_disable
+  embed, emit_hook_event, hooks_add
+
+The cron 5 and the other 3 are different in KIND (see
+``UNREACHABLE_TOOL_REASONS`` below) — cron's fate is an open (A)/(B)/(C)
+product decision (#3464); the other 3 are a same-class wiring bug filed as
+a follow-up (#3465) and deliberately NOT fixed here to avoid touching
+``universal_dispatch.py`` / ``router_tools.py`` while PR #3463 (a 444-file
+alias-removal arc) is open against those same files.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+from dataclasses import dataclass
+from typing import Final, Mapping
+
+
+@dataclass(frozen=True)
+class UnreachableToolReason:
+    """One closed-vocabulary classification + a falsifiable one-line reason.
+
+    A classification without a reason (or vice versa) is not accepted —
+    ``test_llm_reachability_gate_3464.py`` requires both non-empty for every
+    declared entry, so a hole cannot be registered as a bare shrug.
+    """
+
+    classification: str
+    reason: str
+
+
+# Closed vocabulary. A PR adding an entry to UNREACHABLE_TOOL_REASONS must
+# pick one of these — not invent ad hoc prose — so the "why" stays
+# machine-checkable as a category, not just human-readable as text.
+UNREACHABLE_CLASSIFICATIONS: Final[frozenset[str]] = frozenset({
+    # Registered, but the LLM-facing surface is intentionally withheld
+    # pending an owner-level product decision about GRANTING the
+    # capability — advertising it would change what the LLM can do, not
+    # merely fix a bug. Carries the specific (A)/(B)/(C)-style decision
+    # the entry is waiting on.
+    "PENDING_CAPABILITY_DECISION",
+    # Registered + fully described as LLM-facing (the tool's own module
+    # docstring already states the intent), but never wired into either
+    # reachability route — a same-class instance of the #3464 defect,
+    # deliberately deferred rather than fixed in the PR that discovered it
+    # (wiring touches the same files a large in-flight rename arc owns).
+    # Must carry a tracking issue link; this classification is a queue
+    # entry, not a resting state.
+    "DEFERRED_WIRING_BUG",
+})
+
+
+_CRON_REASON = (
+    "#3464: 5 cron ToolDefinitions (cron_register/_unregister/_list/_enable/"
+    "_disable) are registered router=allow but reach neither build_tools()'s "
+    "direct-advertisement census nor universal_dispatch._OPERATION_RULES. "
+    "Whether to (A) add a `cron` catalog category (capability grant -- the "
+    "LLM could directly operate cron, an owner decision), (B) keep them "
+    "intentionally CLI/internal-only, or (C) delete the dead surface is an "
+    "open product decision tracked on #3464 itself. This entry records (B) "
+    "as the interim state -- withheld on purpose, not forgotten -- pending "
+    "that decision."
+)
+
+_WIRING_BUG_REASON_TEMPLATE = (
+    "Registered router=allow with a module docstring already asserting "
+    "LLM-facing intent ({intent!r}), but never wired into build_tools() or "
+    "universal_dispatch._OPERATION_RULES -- the same 'registered but the "
+    "routing entry was never added' mechanics as #3083. Filed as #3465 "
+    "rather than fixed in #3464's PR: wiring requires touching "
+    "universal_dispatch.py / router_tools.py, which #3464 was scoped to "
+    "leave alone while PR #3463 (444-file alias-removal arc) is open "
+    "against those same files."
+)
+
+
+UNREACHABLE_TOOL_REASONS: Final[Mapping[str, UnreachableToolReason]] = {
+    "cron_register": UnreachableToolReason("PENDING_CAPABILITY_DECISION", _CRON_REASON),
+    "cron_unregister": UnreachableToolReason("PENDING_CAPABILITY_DECISION", _CRON_REASON),
+    "cron_list": UnreachableToolReason("PENDING_CAPABILITY_DECISION", _CRON_REASON),
+    "cron_enable": UnreachableToolReason("PENDING_CAPABILITY_DECISION", _CRON_REASON),
+    "cron_disable": UnreachableToolReason("PENDING_CAPABILITY_DECISION", _CRON_REASON),
+    "embed": UnreachableToolReason(
+        "DEFERRED_WIRING_BUG",
+        _WIRING_BUG_REASON_TEMPLATE.format(
+            intent="`embed` is the raw, USER-FACING embedding primitive"
+        ),
+    ),
+    "emit_hook_event": UnreachableToolReason(
+        "DEFERRED_WIRING_BUG",
+        _WIRING_BUG_REASON_TEMPLATE.format(
+            intent='Router-only (gates.router="allow")'
+        ),
+    ),
+    "hooks_add": UnreachableToolReason(
+        "DEFERRED_WIRING_BUG",
+        _WIRING_BUG_REASON_TEMPLATE.format(
+            intent="the agent adds a push hook -- the crown-jewel of "
+            "config hot-reload: the agent expands its own hooks"
+        ),
+    ),
+}
+
+
+def _string_constants(node: ast.AST) -> set[str]:
+    return {
+        n.value
+        for n in ast.walk(node)
+        if isinstance(n, ast.Constant) and isinstance(n.value, str)
+    }
+
+
+def compute_direct_advertisable_tool_names(*, source_text: str | None = None) -> frozenset[str]:
+    """Derive route (a): every tool name ``build_tools()`` can place directly
+    in the ``tools=`` payload under SOME valid combination of its parameters.
+
+    Structural (AST) census, not one execution with one args tuple — see the
+    module docstring for why a single ``build_tools([])`` call produces false
+    positives for correctly-conditional tools (MCP resource verbs, ``compact``,
+    ``session_spawn``, ``search_actions``).
+
+    ``source_text`` defaults to the real ``build_tools`` source (via
+    ``inspect.getsource``); tests pass a modified string to strip-falsify
+    without ever touching the file on disk.
+    """
+    if source_text is None:
+        from reyn.runtime.router_tools import build_tools
+
+        source_text = inspect.getsource(build_tools)
+
+    tree = ast.parse(source_text)
+
+    # Pass 1: every ``NAME = <string-literal-only tuple/list/ifexp>``
+    # assignment becomes a lookup-key -> {candidate strings} pool entry.
+    # This is what resolves the wrapper-name loop below (``_wrapper_names``
+    # is assigned an ``A if cond else B`` tuple-of-literals, not a single
+    # literal).
+    string_var_pool: dict[str, set[str]] = {}
+    for node in ast.walk(tree):
+        target: ast.AST | None = None
+        value: ast.AST | None = None
+        if isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+            target, value = node.targets[0], node.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.value is not None:
+            target, value = node.target, node.value
+        if target is None or value is None:
+            continue
+        strs = _string_constants(value)
+        if strs:
+            string_var_pool.setdefault(target.id, set()).update(strs)
+
+    # Pass 2: propagate through ``for X in Y:`` when Y is a known pool name,
+    # so a loop variable (``_wrapper_name``) inherits its iterable's strings
+    # (``_wrapper_names``).
+    for node in ast.walk(tree):
+        if isinstance(node, ast.For) and isinstance(node.target, ast.Name) and isinstance(node.iter, ast.Name):
+            if node.iter.id in string_var_pool:
+                string_var_pool.setdefault(node.target.id, set()).update(string_var_pool[node.iter.id])
+
+    # Pass 3: every ``<obj>.lookup(<arg>)`` call site — resolve a literal
+    # string directly, or a Name via the pool built above.
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "lookup":
+            if not node.args:
+                continue
+            arg = node.args[0]
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                names.add(arg.value)
+            elif isinstance(arg, ast.Name) and arg.id in string_var_pool:
+                names |= string_var_pool[arg.id]
+
+    return frozenset(names)
+
+
+def compute_invoke_action_reachable_tool_names(
+    *, operation_rules: Mapping[str, tuple] | None = None
+) -> frozenset[str]:
+    """Derive route (b): every bare tool name ``invoke_action`` can dispatch
+    to, per ``universal_dispatch._OPERATION_RULES`` (qualified_name -> (bare
+    tool name, arg-transform)).
+
+    ``operation_rules`` defaults to the real table; tests pass a filtered
+    copy to strip-falsify this route independently of route (a).
+    """
+    if operation_rules is None:
+        from reyn.tools.universal_dispatch import _OPERATION_RULES
+
+        operation_rules = _OPERATION_RULES
+    return frozenset(bare_name for bare_name, _handler in operation_rules.values())
+
+
+def compute_llm_reachable_tool_names(
+    *,
+    source_text: str | None = None,
+    operation_rules: Mapping[str, tuple] | None = None,
+) -> frozenset[str]:
+    """Union of route (a) and route (b) — see module docstring."""
+    return compute_direct_advertisable_tool_names(source_text=source_text) | (
+        compute_invoke_action_reachable_tool_names(operation_rules=operation_rules)
+    )
+
+
+def compute_router_allow_tool_names() -> frozenset[str]:
+    """Every ``ToolDefinition`` name in the default registry with
+    ``gates.router == "allow"`` — the census population this gate covers."""
+    from reyn.tools import get_default_registry
+
+    return frozenset(tool.name for tool in get_default_registry() if tool.gates.router == "allow")
+
+
+def compute_unreachable_router_allow_tool_names(
+    *,
+    source_text: str | None = None,
+    operation_rules: Mapping[str, tuple] | None = None,
+    allow_names: frozenset[str] | None = None,
+) -> frozenset[str]:
+    """``router="allow"`` tool names that are NOT reachable by either route.
+
+    ``allow_names`` defaults to the real registry census; tests pass an
+    override to simulate "a new tool got registered router=allow" without
+    mutating the shared default registry.
+    """
+    if allow_names is None:
+        allow_names = compute_router_allow_tool_names()
+    reachable = compute_llm_reachable_tool_names(
+        source_text=source_text, operation_rules=operation_rules
+    )
+    return allow_names - reachable
+
+
+__all__ = [
+    "UnreachableToolReason",
+    "UNREACHABLE_CLASSIFICATIONS",
+    "UNREACHABLE_TOOL_REASONS",
+    "compute_direct_advertisable_tool_names",
+    "compute_invoke_action_reachable_tool_names",
+    "compute_llm_reachable_tool_names",
+    "compute_router_allow_tool_names",
+    "compute_unreachable_router_allow_tool_names",
+]

--- a/tests/test_llm_reachability_gate_3464.py
+++ b/tests/test_llm_reachability_gate_3464.py
@@ -1,0 +1,188 @@
+"""Tier 2: registry <-> LLM-reachability bidirectional gate (#3464).
+
+#2032 / #3083 / #2913 / #2875 / #3215 each individually closed one instance
+of "registered router=allow but the LLM can never actually reach it." #3464
+is the 6th instance (cron: 5 tools) and asks for a gate instead of a 7th
+patch. This suite exercises ``reyn.tools.llm_reachability``:
+
+  1. Every ``router=allow`` tool the gate finds unreachable today is
+     declared in ``UNREACHABLE_TOOL_REASONS`` with a closed-vocabulary
+     classification + non-empty reason (unreachable subseteq declared).
+  2. Every declared entry really is unreachable (declared subseteq
+     unreachable) -- an entry cannot survive after someone fixes the
+     wiring; that would silently hide the fix's own regression coverage.
+  3. Non-vacuity: strip-falsify each route independently and confirm the
+     gate's identity check would go RED for an undeclared tool.
+
+No mocks -- everything here reads the real default ToolRegistry /
+``_OPERATION_RULES`` / ``build_tools`` source, or passes a plain string /
+dict override to the module's own testability seams (``source_text`` /
+``operation_rules`` / ``allow_names``).
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from reyn.tools.llm_reachability import (
+    UNREACHABLE_CLASSIFICATIONS,
+    UNREACHABLE_TOOL_REASONS,
+    compute_direct_advertisable_tool_names,
+    compute_invoke_action_reachable_tool_names,
+    compute_llm_reachable_tool_names,
+    compute_router_allow_tool_names,
+    compute_unreachable_router_allow_tool_names,
+)
+
+
+def _assert_reachability_gate(unreachable: frozenset[str]) -> None:
+    """The gate's own identity check, factored out so both the real-state
+    test and the strip-falsify tests exercise the identical assertion."""
+    declared = frozenset(UNREACHABLE_TOOL_REASONS)
+    undeclared = unreachable - declared
+    assert not undeclared, (
+        f"router=allow tool(s) {sorted(undeclared)} are not reachable via "
+        f"build_tools() direct advertisement NOR invoke_action, and are not "
+        f"declared in UNREACHABLE_TOOL_REASONS -- register them with a "
+        f"reason (see src/reyn/tools/llm_reachability.py), or wire them into "
+        f"reachability if that was an oversight (#3464)."
+    )
+    stale = declared - unreachable
+    assert not stale, (
+        f"UNREACHABLE_TOOL_REASONS entries {sorted(stale)} are declared "
+        f"unreachable but the census now finds them reachable -- remove the "
+        f"stale entry (its wiring fix should ship WITH the removal so the "
+        f"regression stays covered, not silently)."
+    )
+
+
+def test_current_unreachable_set_matches_the_declared_registry() -> None:
+    """Tier 2: registry allow-set minus (build_tools union invoke_action)
+    equals exactly UNREACHABLE_TOOL_REASONS' keys, in both directions."""
+    unreachable = compute_unreachable_router_allow_tool_names()
+    _assert_reachability_gate(unreachable)
+
+
+def test_declared_reasons_use_the_closed_classification_and_are_nonempty() -> None:
+    """Tier 2: no entry may register a hole without a real classification +
+    a reason with actual content (comments.md-style -- must say what the
+    hole IS, not just that it exists)."""
+    assert UNREACHABLE_TOOL_REASONS, "the registry should not be empty while cron is open"
+    for name, entry in UNREACHABLE_TOOL_REASONS.items():
+        assert entry.classification in UNREACHABLE_CLASSIFICATIONS, (
+            f"{name!r} has classification {entry.classification!r}, not one "
+            f"of {sorted(UNREACHABLE_CLASSIFICATIONS)}"
+        )
+        assert isinstance(entry.reason, str) and len(entry.reason.strip()) >= 40, (
+            f"{name!r}'s reason is missing or too short to be a real "
+            f"falsifiable explanation: {entry.reason!r}"
+        )
+
+
+def test_cron_tools_are_declared_pending_capability_decision() -> None:
+    """Tier 2: the 5 cron tools from #3464's own measurement are present
+    and classified as a capability decision, not a wiring bug -- adding
+    them would grant the LLM a new capability (owner call), unlike the
+    other declared entries."""
+    cron_names = {"cron_register", "cron_unregister", "cron_list", "cron_enable", "cron_disable"}
+    assert cron_names <= set(UNREACHABLE_TOOL_REASONS)
+    for name in cron_names:
+        assert UNREACHABLE_TOOL_REASONS[name].classification == "PENDING_CAPABILITY_DECISION"
+
+
+def test_registered_router_allow_tools_all_come_from_the_real_registry() -> None:
+    """Tier 2: sanity check that the census population is nonempty and
+    excludes router=deny tools (e.g. ask_user is CLI/internal-only by
+    design and must never appear in this gate's population)."""
+    allow_names = compute_router_allow_tool_names()
+    assert len(allow_names) > 50, "sanity: the registry should carry dozens of router=allow tools"
+    assert "ask_user" not in allow_names, "ask_user is gates.router=deny and out of scope by construction"
+
+
+# ── Non-vacuity: strip-falsify each route independently ────────────────────
+
+
+def test_strip_direct_advertisement_route_makes_the_gate_fire() -> None:
+    """Tier 2 (non-vacuity): removing a tool ONLY reachable via route (a)
+    (direct build_tools() advertisement, never routed through
+    invoke_action) from the AST census must produce an undeclared
+    unreachable tool -- proving the identity check in
+    ``test_current_unreachable_set_matches_the_declared_registry`` would go
+    RED if this ever happened for real, instead of the assertion being
+    vacuously satisfied.
+
+    ``topology_create`` is confirmed (by inspection of
+    ``universal_dispatch._OPERATION_RULES``) to have no qualified-name
+    entry -- it is direct-route-only, so stripping its lookup call site
+    removes it from BOTH routes' union, unlike stripping e.g. ``web_search``
+    (also reachable via ``web__search`` in _OPERATION_RULES) which would
+    still be reachable through route (b) alone.
+    """
+    from reyn.runtime.router_tools import build_tools
+
+    real_source = inspect.getsource(build_tools)
+    anchor = '_registry.lookup("topology_create")'
+    assert real_source.count(anchor) == 1, (
+        "strip anchor must be unique or this falsifies the wrong call site"
+    )
+    stripped_source = real_source.replace(anchor, '_registry.lookup("__stripped_3464__")')
+
+    invoke_reachable = compute_invoke_action_reachable_tool_names()
+    assert "topology_create" not in invoke_reachable, (
+        "topology_create must be direct-route-only for this strip to be a valid probe"
+    )
+
+    baseline_unreachable = compute_unreachable_router_allow_tool_names()
+    assert "topology_create" not in baseline_unreachable
+
+    stripped_unreachable = compute_unreachable_router_allow_tool_names(source_text=stripped_source)
+    assert "topology_create" in stripped_unreachable
+
+    with pytest.raises(AssertionError):
+        _assert_reachability_gate(stripped_unreachable)
+
+
+def test_strip_invoke_action_route_makes_the_gate_fire() -> None:
+    """Tier 2 (non-vacuity): removing a tool ONLY reachable via route (b)
+    (invoke_action / _OPERATION_RULES, never directly advertised by
+    build_tools()) must equally produce an undeclared unreachable tool --
+    proving route (b) is load-bearing in the gate, not decorative.
+
+    ``search_knowledge`` (``knowledge__search``) is confirmed to have no
+    direct ``_registry.lookup("search_knowledge")`` call site in
+    ``build_tools`` -- it is invoke-route-only.
+    """
+    from reyn.tools.universal_dispatch import _OPERATION_RULES
+
+    direct_reachable = compute_direct_advertisable_tool_names()
+    assert "search_knowledge" not in direct_reachable, (
+        "search_knowledge must be invoke-route-only for this strip to be a valid probe"
+    )
+
+    baseline_unreachable = compute_unreachable_router_allow_tool_names()
+    assert "search_knowledge" not in baseline_unreachable
+
+    stripped_rules = {
+        qualified: target
+        for qualified, target in _OPERATION_RULES.items()
+        if qualified != "knowledge__search"
+    }
+    stripped_unreachable = compute_unreachable_router_allow_tool_names(operation_rules=stripped_rules)
+    assert "search_knowledge" in stripped_unreachable
+
+    with pytest.raises(AssertionError):
+        _assert_reachability_gate(stripped_unreachable)
+
+
+def test_a_hypothetically_newly_registered_tool_with_no_route_fires_the_gate() -> None:
+    """Tier 2 (non-vacuity): simulates the actual #3464 scenario -- a brand
+    new router=allow ToolDefinition name that was never wired anywhere --
+    without registering a real ToolDefinition (which would require a full
+    handler + schema and pollute the shared default registry). Confirms the
+    gate does not silently accept an arbitrary unrecognised name."""
+    allow_names = compute_router_allow_tool_names() | {"totally_new_tool_3464"}
+    unreachable = compute_unreachable_router_allow_tool_names(allow_names=allow_names)
+    assert "totally_new_tool_3464" in unreachable
+    with pytest.raises(AssertionError):
+        _assert_reachability_gate(unreachable)

--- a/tests/test_llm_reachability_gate_3464.py
+++ b/tests/test_llm_reachability_gate_3464.py
@@ -92,11 +92,12 @@ def test_cron_tools_are_declared_pending_capability_decision() -> None:
 
 
 def test_registered_router_allow_tools_all_come_from_the_real_registry() -> None:
-    """Tier 2: sanity check that the census population is nonempty and
-    excludes router=deny tools (e.g. ask_user is CLI/internal-only by
-    design and must never appear in this gate's population)."""
+    """Tier 2: sanity check that the census population carries a known
+    router=allow tool and excludes router=deny tools (e.g. ask_user is
+    CLI/internal-only by design and must never appear in this gate's
+    population)."""
     allow_names = compute_router_allow_tool_names()
-    assert len(allow_names) > 50, "sanity: the registry should carry dozens of router=allow tools"
+    assert "web_search" in allow_names, "sanity: web_search is a stable router=allow tool"
     assert "ask_user" not in allow_names, "ask_user is gates.router=deny and out of scope by construction"
 
 
@@ -104,7 +105,7 @@ def test_registered_router_allow_tools_all_come_from_the_real_registry() -> None
 
 
 def test_strip_direct_advertisement_route_makes_the_gate_fire() -> None:
-    """Tier 2 (non-vacuity): removing a tool ONLY reachable via route (a)
+    """Tier 2: non-vacuity -- removing a tool ONLY reachable via route (a)
     (direct build_tools() advertisement, never routed through
     invoke_action) from the AST census must produce an undeclared
     unreachable tool -- proving the identity check in
@@ -144,7 +145,7 @@ def test_strip_direct_advertisement_route_makes_the_gate_fire() -> None:
 
 
 def test_strip_invoke_action_route_makes_the_gate_fire() -> None:
-    """Tier 2 (non-vacuity): removing a tool ONLY reachable via route (b)
+    """Tier 2: non-vacuity -- removing a tool ONLY reachable via route (b)
     (invoke_action / _OPERATION_RULES, never directly advertised by
     build_tools()) must equally produce an undeclared unreachable tool --
     proving route (b) is load-bearing in the gate, not decorative.
@@ -176,7 +177,7 @@ def test_strip_invoke_action_route_makes_the_gate_fire() -> None:
 
 
 def test_a_hypothetically_newly_registered_tool_with_no_route_fires_the_gate() -> None:
-    """Tier 2 (non-vacuity): simulates the actual #3464 scenario -- a brand
+    """Tier 2: non-vacuity -- simulates the actual #3464 scenario -- a brand
     new router=allow ToolDefinition name that was never wired anywhere --
     without registering a real ToolDefinition (which would require a full
     handler + schema and pollute the shared default registry). Confirms the


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3464.

## The class, not the instance

#2032 / #3083 / #2913 / #2875 / #3215 each individually closed one occurrence of "registered `router=allow` but the LLM can never actually call it." #3464 is the 6th (cron: 5 tools) and explicitly asked for a **gate**, not a 6th instance patch — this PR does not add `cron` to `CATEGORIES`. It adds `src/reyn/tools/llm_reachability.py` (SSoT + census) and `tests/test_llm_reachability_gate_3464.py` (the bidirectional gate, 7 tests).

## Definition of "LLM-reachable" — measured, not assumed

I traced the actual delivery paths rather than deciding the shape up front (the brief explicitly asked me not to guess this). A `router=allow` `ToolDefinition`'s `name` is reachable in the default production configuration iff **either** of two independently-sufficient routes can deliver it:

- **(a) Direct advertisement** — `build_tools()` can place the name in the `tools=` payload. Derived **structurally** (AST census of every `<registry>.lookup(...)` call site inside `router_tools.build_tools`, including the one call whose argument is a loop variable rather than a literal), not by executing `build_tools([])` with one fixed args tuple. That distinction matters: several tools (`compact`, `session_spawn`, `search_actions`, the D5–D11 MCP resource/prompt verbs) are only emitted under a *particular* config (context near budget / embedding enabled / MCP servers configured) — correct conditional gating, not a defect. Executing `build_tools([])` once (as the issue's own reference measurement did, to reproduce the 17/0 baseline) flags all of those as false-positive "unreachable"; the AST census does not.
- **(b) Resolution via `invoke_action`** — the name is the bare dispatch target of some qualified name in `universal_dispatch._OPERATION_RULES`. `invoke_action` is itself delivered via route (a) whenever the universal wrappers are enabled, which is the shipped default (`ActionRetrievalConfig.universal_wrappers_enabled: bool = True`).

**"Any one route suffices"** is the deliberate reading — the issue asks whether the model can reach a tool *somehow*, not through one prescribed path. `hot_list_aliases` and the MCP `tool_search_tool` meta-tool are not independent third routes: both are dynamically-selected subsets of (a)/(b)'s pool (verified: hot-list seeds are `_OPERATION_RULES` qualified names; `tool_search_tool` wraps the same MCP dicts route (a) already assembles) — neither can rescue an otherwise-unreachable tool, so neither is modeled separately.

`gates.router="deny"` tools (`ask_user` — CLI/internal by design) are out of scope by construction: the census only looks at `router="allow"`.

## Gate shape (#3437's template)

- **SSoT**: `UNREACHABLE_TOOL_REASONS: Mapping[str, UnreachableToolReason]` — closed-vocabulary `classification` (`PENDING_CAPABILITY_DECISION` / `DEFERRED_WIRING_BUG`) + non-empty falsifiable `reason` per entry.
- **Bidirectional**: `test_current_unreachable_set_matches_the_declared_registry` asserts `compute_unreachable_router_allow_tool_names() == set(UNREACHABLE_TOOL_REASONS)` in both directions (undeclared-but-unreachable fails; declared-but-now-reachable also fails, so a future wiring fix can't leave a stale exception silently masking its own regression coverage).
- **Derived, not hand-listed**: both the registry census (`get_default_registry()`) and the two reachability routes come from AST/registry introspection, never a second hand-typed name list.
- **Non-vacuity — 3 independent strip-falsify arms, all measured RED** (source-text / dict overrides passed as plain arguments; no file on disk is ever touched, so nothing needed cp-scratch restoration):
  1. Strip `topology_create`'s lookup call site from route (a)'s source text (route-(b)-absence confirmed first) → gate fires.
  2. Strip `knowledge__search` from route (b)'s rules dict (route-(a)-absence confirmed first) → gate fires.
  3. Inject a synthetic `totally_new_tool_3464` into the allow-name census (simulating "a brand new router=allow tool with no wiring at all," i.e. #3464's own scenario) → gate fires.

## Measured result on current `main`: 8 tools, not cron's 5

```
cron_register, cron_unregister, cron_list, cron_enable, cron_disable   (#3464)
embed, emit_hook_event, hooks_add                                       (new finding, this PR)
```

**cron (5)** — classified `PENDING_CAPABILITY_DECISION`. Per the brief: this PR does **not** decide (A) catalog category / (B) intentional-hidden / (C) delete. It registers (B) as the interim, explicit state — withheld on purpose pending the owner's (A) decision — with the reason text naming all three options and pointing at #3464 itself as the place that decision gets made.

**embed / emit_hook_event / hooks_add (3, new)** — classified `DEFERRED_WIRING_BUG`, different in kind from cron: each tool's own module docstring already asserts LLM-facing intent (`embed.py`: "USER-FACING embedding primitive"; `emit_hook_event.py`: "Router-only"; `hooks.py`: "the agent expands its own hooks"). There is no live capability-grant question here — same "registered, routing entry never added" mechanics as #3083. **Deliberately not fixed in this PR**: wiring touches `universal_dispatch.py` / `router_tools.py`, which the brief asked me to leave alone while PR #3463 (444-file alias-removal arc) is open against those same files. Filed as **#3465**, linked from the reason text in `llm_reachability.py`.

## Why not "cron in `CATEGORIES`" (the band-aid)

Per the brief and the issue: adding `cron` to `CATEGORIES` grants the LLM a new capability (direct cron control) — an owner-level product decision, not something a per-PR-coder should decide unilaterally. The gate itself is agnostic to that decision: whichever of (A)/(B)/(C) the owner picks, the fix is "make the declared set and the actual-unreachable set agree again" — remove the cron entries from `UNREACHABLE_TOOL_REASONS` (A/B) or delete the cron tools (C), and the bidirectional test enforces the rest.

## `git diff` footprint

Two new files only — `src/reyn/tools/`/`router_tools.py`/`universal_dispatch.py` are read (via `inspect.getsource` / import), never modified, per the brief's minimize-changes-while-#3463-is-open instruction.

## CI gates (all four, locally)

- `ruff check src tests` — clean
- `python scripts/test_tier_audit.py --strict tests/test_llm_reachability_gate_3464.py` — 7/7 OK, 0 warnings, 0 Tier-4
- `pytest -n auto` from the repo root — see Test plan
- `python scripts/verify_module_docstrings.py src/reyn/tools/llm_reachability.py` — OK

Rebased onto `main` at merge time; `git fetch origin && git rebase origin/main` was a no-op (already current).

## Test plan

- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict tests/test_llm_reachability_gate_3464.py`
- [x] `pytest -n auto` from the repo root (CI parity) — full log tail pasted below
- [x] `python scripts/verify_module_docstrings.py src/reyn/tools/llm_reachability.py`
- [x] `import reyn` asserted to resolve inside this worktree at measurement time
- [x] 3 strip-falsify arms measured RED (see table above), no `git stash` / no file mutation
- [x] Confirmed no other open PR/issue is enumerated as belonging to the #3464 arc before using the closing keyword
- [x] Filed #3465 for the embed/emit_hook_event/hooks_add finding, linked from the code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

