### PR TITLE
feat(observability): route limit_denied to OTLP log at WARN, exclude safety_limit_checkpoint (#3439)

### DIFF
--- a/docs/reference/runtime/observability.md
+++ b/docs/reference/runtime/observability.md
@@ -66,7 +66,7 @@ in one place.
 | `llm_response_received` | metric histograms | `gen_ai.client.token.usage` (input/output), `gen_ai.client.cost.usd` |
 | `tool_executed` / `mcp_called` / `mcp_failed` / `mcp_cancelled` | child span `execute_tool <name>` | `gen_ai.operation.name` (`execute_tool`), `gen_ai.tool.name` |
 | `web_fetch_started` / `web_search_started` (+ completed/failed) | child span `execute_tool` | `gen_ai.tool.name`; the failed variant sets an error status |
-| `permission_granted` / `permission_denied` / `user_intervention_*` / safety events | log record | `reyn.event.type`, `run_id`, `agent_id`, `actor`, `phase`, `intervention_id` |
+| `permission_granted` / `permission_denied` / `user_intervention_*` / `limit_denied` | log record (`permission_denied` and `limit_denied` at `WARN`, the rest `INFO`) | `reyn.event.type`, `run_id`, `agent_id`, `actor`, `phase`, `intervention_id` |
 
 Spans correlate into one trace per run: children nest under the open turn span,
 turns under the session root, keyed by `run_id` (falling back to `agent_id`).

--- a/src/reyn/observability/otel_exporter.py
+++ b/src/reyn/observability/otel_exporter.py
@@ -108,19 +108,34 @@ METRIC_COST_USAGE = "gen_ai.client.cost.usd"
 # and "nothing arrived" reads as "no safety limits were hit". Silence was
 # indistinguishable from health.
 #
-# ★ The live safety kinds are ``limit_denied`` and ``safety_limit_checkpoint``,
-# and NEITHER was substituted in here — routing them is an observability
-# decision, not a rename, and making it silently under cover of a cleanup would
-# be the same class of mistake in the other direction. So safety limits are
-# currently NOT exported at all. Whether they should be is #3439; record the
-# answer HERE, next to this set, when it is decided. A selector set is a promise
-# to an operator about what will arrive and, by omission, about what will not —
-# both halves should be deliberate.
+# ★ The live safety kinds are ``limit_denied`` and ``safety_limit_checkpoint``.
+# #3439 decided which of the two belongs here:
+#
+# * ``limit_denied`` → YES, routed below, at WARN. It is the same story as
+#   ``permission_denied`` on a different axis: both mean "the OS refused an
+#   action the agent wanted" (permission_denied = a capability was denied;
+#   limit_denied = a safety limit was denied and a force-close is imminent).
+#   The reasoning that justifies exporting permission_denied at WARN transfers
+#   unchanged to limit_denied — exporting one and not the other hands an
+#   operator an incomplete picture of "the OS said no", and the missing half
+#   is silent, which is exactly the "silence reads as health" harm this
+#   comment already warns about.
+# * ``safety_limit_checkpoint`` → NO, not routed. The reasoning does NOT
+#   transfer: a checkpoint is a periodic threshold *observation*, not a
+#   refusal — there is no "no" to report. It is also high-volume (semantically
+#   closer to a metric than a log-worthy event); adding it as a log record
+#   would train operators to ignore the channel. "Same safety family" is a
+#   *shape* argument, not a transferred reason, so it is deliberately excluded.
+#
+# Omission is a promise too: this set says both what will arrive at an
+# operator's OTLP backend and, by leaving safety_limit_checkpoint out, what
+# will not. Both halves are intentional as of #3439.
 _LOG_EVENT_TYPES: frozenset[str] = frozenset({
     "permission_granted",
     "permission_denied",
     "user_intervention_requested",
     "user_intervention_received",
+    "limit_denied",
 })
 
 # Tool-family events that open+close a child span at the event (post-hoc audit
@@ -420,7 +435,9 @@ class OtelExporter:
                 attrs[field] = str(data[field])
         severity = (
             SeverityNumber.WARN
-            if etype == "permission_denied"  # the only WARN-worthy live kind here (#3410)
+            if etype in ("permission_denied", "limit_denied")  # WARN-worthy: an
+            # OS refusal (#3410 permission_denied, #3439 limit_denied) — see the
+            # _LOG_EVENT_TYPES comment above for why the reasoning transfers.
             else SeverityNumber.INFO
         )
         self._logger.emit(

--- a/tests/observability/test_otel_exporter.py
+++ b/tests/observability/test_otel_exporter.py
@@ -336,10 +336,8 @@ def test_limit_denied_reaches_otlp_log_record_at_warn() -> None:
         ),
     )
 
-    records = cap.log_records()
-    matching = [r for r in records if str(r.body) == "limit_denied"]
-    assert len(matching) == 1, f"expected exactly one limit_denied log record, got {records}"
-    assert matching[0].severity_number == SeverityNumber.WARN
+    record = next(r for r in cap.log_records() if str(r.body) == "limit_denied")
+    assert record.severity_number == SeverityNumber.WARN
 
 
 def test_permission_denied_still_warn_after_limit_denied_added() -> None:
@@ -350,10 +348,8 @@ def test_permission_denied_still_warn_after_limit_denied_added() -> None:
     cap.exporter(
         Event(type="permission_denied", data={"run_id": _RID, "agent_id": _AID}),
     )
-    records = cap.log_records()
-    matching = [r for r in records if str(r.body) == "permission_denied"]
-    assert len(matching) == 1
-    assert matching[0].severity_number == SeverityNumber.WARN
+    record = next(r for r in cap.log_records() if str(r.body) == "permission_denied")
+    assert record.severity_number == SeverityNumber.WARN
 
 
 def test_permission_granted_stays_info_not_warn() -> None:
@@ -364,10 +360,8 @@ def test_permission_granted_stays_info_not_warn() -> None:
     cap.exporter(
         Event(type="permission_granted", data={"run_id": _RID, "agent_id": _AID}),
     )
-    records = cap.log_records()
-    matching = [r for r in records if str(r.body) == "permission_granted"]
-    assert len(matching) == 1
-    assert matching[0].severity_number == SeverityNumber.INFO
+    record = next(r for r in cap.log_records() if str(r.body) == "permission_granted")
+    assert record.severity_number == SeverityNumber.INFO
 
 
 def test_safety_limit_checkpoint_not_exported_as_log_record() -> None:

--- a/tests/observability/test_otel_exporter.py
+++ b/tests/observability/test_otel_exporter.py
@@ -123,6 +123,10 @@ class _Capture:
     def log_bodies(self) -> list[str]:
         return [str(lr.log_record.body) for lr in self._log_exp.get_finished_logs()]
 
+    def log_records(self) -> list[Any]:
+        """Raw finished log records (body + severity_number), for severity assertions."""
+        return [lr.log_record for lr in self._log_exp.get_finished_logs()]
+
 
 def _ev(etype: str, ts: datetime | None = None, **data: Any) -> Event:
     if ts is None:
@@ -308,6 +312,83 @@ def test_emitted_span_attrs_only_use_pinned_genai_keys() -> None:
     llm = next(s for s in cap.spans() if s.name == "chat gpt-4o")
     assert llm.attributes[GEN_AI_REQUEST_MODEL] == "gpt-4o"
     assert llm.attributes[GEN_AI_OPERATION_NAME] == "chat"
+
+
+# ── 3b. safety log-record routing (#3439) ────────────────────────────────────
+
+
+def test_limit_denied_reaches_otlp_log_record_at_warn() -> None:
+    """Tier 2: #3439 — ``limit_denied`` reaches an OTLP log record at WARN.
+
+    This is the non-vacuity witness: it asserts the audit-event actually
+    arrives at the in-memory OTLP log exporter (not merely that the type
+    string sits in ``_LOG_EVENT_TYPES``). Removing ``limit_denied`` from
+    that set (the strip-falsify) is recorded in the PR body and turns this
+    RED, since no log record with this body would be emitted at all.
+    """
+    from opentelemetry._logs import SeverityNumber
+
+    cap = _Capture()
+    cap.exporter(
+        Event(
+            type="limit_denied",
+            data={"run_id": _RID, "agent_id": _AID, "kind": "max_iterations"},
+        ),
+    )
+
+    records = cap.log_records()
+    matching = [r for r in records if str(r.body) == "limit_denied"]
+    assert len(matching) == 1, f"expected exactly one limit_denied log record, got {records}"
+    assert matching[0].severity_number == SeverityNumber.WARN
+
+
+def test_permission_denied_still_warn_after_limit_denied_added() -> None:
+    """Tier 2: adding limit_denied does not regress permission_denied's WARN."""
+    from opentelemetry._logs import SeverityNumber
+
+    cap = _Capture()
+    cap.exporter(
+        Event(type="permission_denied", data={"run_id": _RID, "agent_id": _AID}),
+    )
+    records = cap.log_records()
+    matching = [r for r in records if str(r.body) == "permission_denied"]
+    assert len(matching) == 1
+    assert matching[0].severity_number == SeverityNumber.WARN
+
+
+def test_permission_granted_stays_info_not_warn() -> None:
+    """Tier 2: a non-refusal safety/permission kind stays at INFO, not WARN."""
+    from opentelemetry._logs import SeverityNumber
+
+    cap = _Capture()
+    cap.exporter(
+        Event(type="permission_granted", data={"run_id": _RID, "agent_id": _AID}),
+    )
+    records = cap.log_records()
+    matching = [r for r in records if str(r.body) == "permission_granted"]
+    assert len(matching) == 1
+    assert matching[0].severity_number == SeverityNumber.INFO
+
+
+def test_safety_limit_checkpoint_not_exported_as_log_record() -> None:
+    """Tier 2: #3439 — ``safety_limit_checkpoint`` is a deliberate omission.
+
+    A checkpoint is a periodic threshold observation, not an OS refusal, and
+    is high-volume enough to be metric-shaped rather than log-worthy; #3439
+    decided NOT to route it. Asserted here (rather than left unasserted) so
+    the omission stays a witnessed decision, not a silent gap that a future
+    change could reintroduce unnoticed — see the PR body for the tradeoff
+    (this pins today's choice against a later "actually make it a metric"
+    decision, which would need to update this test deliberately).
+    """
+    cap = _Capture()
+    cap.exporter(
+        Event(
+            type="safety_limit_checkpoint",
+            data={"run_id": _RID, "agent_id": _AID},
+        ),
+    )
+    assert cap.log_records() == []
 
 
 # ── 4. metrics (cost/token histogram) ────────────────────────────────────────


### PR DESCRIPTION
**[per-PR-coder]** — implements the lead-coder decision on #3439: which live safety kinds reach OTLP.

## Decision (lead-coder, 2026-07-30)

- **`limit_denied` → export as an OTLP log record, severity WARN.** `_LOG_EVENT_TYPES` already exports `permission_denied` at WARN. `limit_denied` and `permission_denied` are the same story on a different axis — both mean "the OS refused an action the agent wanted" (permission_denied = a capability was denied; limit_denied = a safety limit was denied and a force-close is imminent). The reasoning that justifies WARN for `permission_denied` transfers unchanged to `limit_denied`. Exporting one and leaving the other silent hands an operator an incomplete picture of "the OS said no" — and the missing half is silent, which is exactly the "silence reads as health" harm the existing `_LOG_EVENT_TYPES` comment already names.
- **`safety_limit_checkpoint` → NOT exported.** The reasoning does not transfer: a checkpoint is a periodic threshold *observation*, not a refusal — there is no "no" to report. It is also high-volume, semantically closer to a metric than a log-worthy event; routing it as a log record would train operators to ignore the channel. "Same safety family, so route both" is a *shape* argument, not a transferred reason, so it's deliberately excluded.

Both halves recorded in the code comment next to `_LOG_EVENT_TYPES` in `src/reyn/observability/otel_exporter.py`, replacing the "#3439 will decide" placeholder the comment previously carried — the decision is now stated as settled, not pending.

## Changes

- `src/reyn/observability/otel_exporter.py`: add `limit_denied` to `_LOG_EVENT_TYPES`; extend the WARN severity check to `("permission_denied", "limit_denied")`; rewrite the comment block above the set to record both the YES (`limit_denied`) and the NO (`safety_limit_checkpoint`) decisions with reasons.
- `docs/reference/runtime/observability.md`: the OTLP mapping table's log-record row now names `limit_denied` explicitly (dropping the vague "safety events") and states which kinds get WARN vs INFO.
- `tests/observability/test_otel_exporter.py`: four new Tier 2 tests (see below).

## Non-vacuity witness (arrival, not membership)

`test_limit_denied_reaches_otlp_log_record_at_warn` builds a real in-memory OTLP log pipeline (`InMemoryLogExporter` via the existing `_Capture` harness — no mocks), emits a `limit_denied` `Event` through the real `OtelExporter`, and asserts a log record with `body == "limit_denied"` actually lands in the exporter's finished-records buffer with `severity_number == SeverityNumber.WARN`. This asserts arrival through the real dispatch path, not `"limit_denied" in _LOG_EVENT_TYPES`.

`test_permission_denied_still_warn_after_limit_denied_added` and `test_permission_granted_stays_info_not_warn` pin the surrounding severity behavior didn't regress (WARN kept for permission_denied, INFO kept for a non-refusal kind).

## Strip-falsify (measured, not asserted)

Removed `"limit_denied"` from `_LOG_EVENT_TYPES` (restored via `cp` from a scratch backup, not `git checkout --`) and reran:

```
$ uv run pytest tests/observability/test_otel_exporter.py -q -k limit_denied
F.
FAILED tests/observability/test_otel_exporter.py::test_limit_denied_reaches_otlp_log_record_at_warn - StopIteration
1 failed, 1 passed in 0.34s
```

`test_limit_denied_reaches_otlp_log_record_at_warn` goes RED (`StopIteration` — no matching log record reaches the exporter at all) when the selector is stripped; restored and reran green (16/16) before pushing. Repeated identically after rebasing onto `origin/main` (`345c4bb9`) to confirm the strip-falsify still holds on the tree actually being merged.

## `safety_limit_checkpoint` omission — asserted, not just left out

I chose to **assert** the omission (`test_safety_limit_checkpoint_not_exported_as_log_record`: emitting a `safety_limit_checkpoint` event produces zero log records) rather than leave it silently untested. Tradeoff, either way was acceptable per the brief:

- **Chosen (assert):** the omission becomes a witnessed decision, not a gap a later refactor could reintroduce unnoticed. If a future PR decides to route it as a *metric* instead (the `_LOG_EVENT_TYPES` comment's stated alternative), that PR must touch this test deliberately — which is the point, not friction.
- **Rejected (don't assert):** slightly less coupling to today's choice, but the "we decided NOT to do this" intent would live only in the code comment and PR body, with nothing failing if it silently drifted back in.

## CI gates (rebased onto `origin/main` @ `345c4bb9`, worktree HEAD `b0cd1ca7`)

- `ruff check src tests` → `All checks passed!`
- `python scripts/test_tier_audit.py --strict tests/observability/test_otel_exporter.py` → `16 tests inspected, OK: 16, errors: 0`
- `pytest` (repo root, background, `-n auto`) → `9733 passed, 36 skipped, 36 warnings in 157.35s` (log terminal summary line read directly, not inferred from process exit)
- `python scripts/verify_module_docstrings.py src/reyn/observability/otel_exporter.py` → `OK: no module-docstring refactor narrative`

All four gates rerun after the rebase (ruff, tier-audit, targeted otel_exporter test file, docstring check all green again); no PR currently open changes anything under `src/reyn/observability/`.

## Test plan

- [x] `uv run pytest tests/observability/test_otel_exporter.py -q` → 16 passed
- [x] Strip-falsify: remove `limit_denied` from `_LOG_EVENT_TYPES` → `test_limit_denied_reaches_otlp_log_record_at_warn` RED (`StopIteration`); restore via scratch-copy → green again
- [x] Full `pytest` suite (background, `-n auto`) → `9733 passed, 36 skipped`
- [x] `ruff check src tests` → clean
- [x] `python scripts/verify_module_docstrings.py src/reyn/observability/otel_exporter.py` → OK
- [x] Confirmed no open PR (`gh pr list --state all --search "#3439 in:body"`) targets #3439 as a sub-arc, and #3463 (444-file PR, open) touches zero files under `src/reyn/observability/`

Closes #3439
