### PR TITLE
feat(offload): bounded structured_shape summary in offload frontmatter (#2656)

### DIFF
--- a/docs/deep-dives/proposals/0053-tool-result-schema-redesign.md
+++ b/docs/deep-dives/proposals/0053-tool-result-schema-redesign.md
@@ -151,13 +151,17 @@ the same PR. No compat shim.
   <tail>
   ```
 - **structured** — gated by `STRUCTURED_INLINE_MAX_CHARS` (`seam.py:30`, its own file when
-  oversized); the frontmatter then carries the ref + a short preview instead of the data:
+  oversized); the frontmatter then carries the ref + a short preview + a bounded shape
+  summary instead of the data:
   ```
   ---
   structured: offloaded
   structured_ref: <path>       # read back via file__read
   structured_preview: |
     <first ~600 chars>
+  structured_shape:            # #2656 — key names / value types / array length, deterministic,
+    <key>: <type | nested shape>  # depth/breadth/array-sample all bounded (see seam.py) so
+    ...                            # summarizing a huge payload is never itself unbounded work
   ---
   <text>
   ```

--- a/docs/deep-dives/proposals/0054-present-layer.md
+++ b/docs/deep-dives/proposals/0054-present-layer.md
@@ -355,7 +355,8 @@ differentiator is making blindness *auditable*, not forbidding it.)
   The offload output shape is landed and fixed; nothing gates this proposal.
 - **Follow-up (additive, post-arc)**: enrich offload frontmatter with a shape summary
   (key names / types / array lengths) instead of only a head-N-chars preview — improves
-  blind template authoring. To be filed as an issue after the arc lands.
+  blind template authoring. Filed and implemented as #2656 (`structured_shape` in
+  `seam.py`'s `build_offload_body`, additive alongside `structured_preview`).
 
 ## Out of scope (v1)
 

--- a/src/reyn/core/offload/seam.py
+++ b/src/reyn/core/offload/seam.py
@@ -35,7 +35,7 @@ raw for the existing vision follow-up, never embedded in the text body.
 **Structural shape summary (#2656, additive follow-up)**: a head-N-chars ``structured_preview`` is a
 poor summary of *shape* — for a large array-of-objects it shows only (a fragment of) the first element,
 so the LLM cannot reliably read the full top-level key set / value types / array length without a
-``file__read`` round-trip. When a structured attachment is offloaded, the frontmatter ALSO carries
+``read_file`` round-trip. When a structured attachment is offloaded, the frontmatter ALSO carries
 ``structured_shape`` — a deterministically-derived (no extra LLM call) key/type/length descriptor,
 bounded in both depth and breadth (see ``_SHAPE_MAX_DEPTH`` / ``_SHAPE_MAX_KEYS`` /
 ``_SHAPE_MAX_ARRAY_SAMPLE``) so summarizing a huge payload is never itself an unbounded-cost operation.

--- a/src/reyn/core/offload/seam.py
+++ b/src/reyn/core/offload/seam.py
@@ -25,11 +25,23 @@ Two independent offload streams:
 - **text** — capped by ``cap_tool_result_content`` (token budget) at the caller; its preview is plain
   text, not a JSON stub.
 - **structured** — gated here by ``STRUCTURED_INLINE_MAX_CHARS`` (its own ref when oversized); the
-  frontmatter then carries ``structured_ref`` + a short ``structured_preview`` instead of the data.
+  frontmatter then carries ``structured_ref`` + a short ``structured_preview`` + a bounded
+  ``structured_shape`` summary instead of the data.
 
 The format is INDEPENDENT of the store: with no ``save_fn`` the frontmatter still renders (structured
 stays inline, uncapped) — only the size-gated offloading needs a store. Media attachments are returned
 raw for the existing vision follow-up, never embedded in the text body.
+
+**Structural shape summary (#2656, additive follow-up)**: a head-N-chars ``structured_preview`` is a
+poor summary of *shape* — for a large array-of-objects it shows only (a fragment of) the first element,
+so the LLM cannot reliably read the full top-level key set / value types / array length without a
+``file__read`` round-trip. When a structured attachment is offloaded, the frontmatter ALSO carries
+``structured_shape`` — a deterministically-derived (no extra LLM call) key/type/length descriptor,
+bounded in both depth and breadth (see ``_SHAPE_MAX_DEPTH`` / ``_SHAPE_MAX_KEYS`` /
+``_SHAPE_MAX_ARRAY_SAMPLE``) so summarizing a huge payload is never itself an unbounded-cost operation.
+Hitting a bound is recorded IN the summary (``<max_depth:N>`` / ``<truncated>`` / ``<sampled>`` marker
+values) rather than silently dropping data. Purely additive: ``structured`` / ``structured_ref`` /
+``structured_preview`` are unchanged.
 """
 from __future__ import annotations
 
@@ -43,6 +55,72 @@ from reyn.core.offload.canonical import CanonicalToolResult
 STRUCTURED_INLINE_MAX_CHARS: int = 2_000
 _STRUCTURED_PREVIEW_CHARS: int = 600
 
+# Bounds for the ``structured_shape`` summary (#2656): each bound is on the summarizer's OWN descent,
+# never on the input size, so a huge/deeply-nested payload cannot make shape summarization itself
+# unbounded work — it always stops at a small, fixed number of dict levels / object keys / sampled
+# array elements, and records that it stopped (rather than silently truncating without a trace).
+_SHAPE_MAX_DEPTH: int = 4
+_SHAPE_MAX_KEYS: int = 25
+_SHAPE_MAX_ARRAY_SAMPLE: int = 3
+
+
+def summarize_structured_shape(value: Any, *, depth: int = 0) -> Any:
+    """Deterministically derive a compact *shape* descriptor for ``value`` — key names, value types,
+    array lengths, nested up to a small bound — WITHOUT any LLM call and WITHOUT scanning the full
+    payload (bounded depth/breadth/array-sample, #2656).
+
+    - ``dict`` -> ``{key: <nested shape>, ...}`` for up to ``_SHAPE_MAX_KEYS`` keys (in insertion
+      order); beyond that, a ``"<truncated>"`` marker key records how many more keys exist.
+    - ``list`` -> ``{"length": N, "element": <shape>}``; the element shape is derived only from the
+      first ``_SHAPE_MAX_ARRAY_SAMPLE`` elements (never the whole array — this is what keeps a
+      million-element array cheap to summarize). When the sampled elements are all dicts, ``element``
+      is the UNION of their keys (same "columns = union over the first K rows" heuristic the
+      present-layer table renderer uses for the same reason — not a new concept, 0054). A
+      ``"<sampled>"`` marker records that the length exceeds the sample size.
+    - scalars -> a bare type name (``"string"`` / ``"number"`` / ``"boolean"`` / ``"null"``).
+    - beyond ``_SHAPE_MAX_DEPTH`` nested levels -> a ``"<max_depth:N>"`` marker string instead of
+      descending further.
+    """
+    if depth >= _SHAPE_MAX_DEPTH:
+        return f"<max_depth:{_SHAPE_MAX_DEPTH}>"
+    if isinstance(value, dict):
+        keys = list(value.keys())
+        shown_keys = keys[:_SHAPE_MAX_KEYS]
+        shape: dict[str, Any] = {
+            str(k): summarize_structured_shape(value[k], depth=depth + 1) for k in shown_keys
+        }
+        if len(keys) > _SHAPE_MAX_KEYS:
+            shape["<truncated>"] = f"{len(keys) - _SHAPE_MAX_KEYS} more keys"
+        return shape
+    if isinstance(value, list):
+        length = len(value)
+        sample = value[:_SHAPE_MAX_ARRAY_SAMPLE]
+        element_shape: Any = None
+        if sample and all(isinstance(item, dict) for item in sample):
+            union: dict[str, Any] = {}
+            for item in sample:
+                for k, v in item.items():
+                    if k not in union and len(union) < _SHAPE_MAX_KEYS:
+                        union[str(k)] = summarize_structured_shape(v, depth=depth + 1)
+            element_shape = union
+        elif sample:
+            element_shape = summarize_structured_shape(sample[0], depth=depth + 1)
+        result: dict[str, Any] = {"length": length}
+        if element_shape is not None:
+            result["element"] = element_shape
+        if length > _SHAPE_MAX_ARRAY_SAMPLE:
+            result["<sampled>"] = f"first {_SHAPE_MAX_ARRAY_SAMPLE} of {length}"
+        return result
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, (int, float)):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    return type(value).__name__
+
 
 def build_offload_body(
     canonical: CanonicalToolResult,
@@ -53,9 +131,10 @@ def build_offload_body(
     """Return ``(frontmatter, text, media_blocks, content_type)`` for a canonical tool result.
 
     ``frontmatter`` = the signal meta + the structured data (inline when small, or ``structured_ref`` +
-    ``structured_preview`` when large and a ``save_fn`` is available). Empty ``{}`` when there is
-    nothing but plain text. ``text`` = the (uncapped) body the caller then caps + assembles via
-    :func:`render_tool_result`. ``media_blocks`` = the raw media blocks for the vision follow-up.
+    ``structured_preview`` + ``structured_shape`` when large and a ``save_fn`` is available). Empty
+    ``{}`` when there is nothing but plain text. ``text`` = the (uncapped) body the caller then caps
+    + assembles via :func:`render_tool_result`. ``media_blocks`` = the raw media blocks for the vision
+    follow-up.
     ``content_type`` (#2663) = the canonical's RENDERER-only sidecar (``canonical.get("content_type")``)
     — deliberately NEVER folded into ``frontmatter`` (that would leak a transport/renderer signal into
     the LLM-visible ``role: tool`` body); the caller threads it to the ``text`` offload store's
@@ -100,6 +179,7 @@ def build_offload_body(
             frontmatter["structured"] = "offloaded"
             frontmatter["structured_ref"] = stored.get("path", "")
             frontmatter["structured_preview"] = serialized[:_STRUCTURED_PREVIEW_CHARS]
+            frontmatter["structured_shape"] = summarize_structured_shape(combined)
         else:
             frontmatter["structured"] = combined
 

--- a/tests/test_2656_structured_shape_summary.py
+++ b/tests/test_2656_structured_shape_summary.py
@@ -1,0 +1,128 @@
+"""Tier 1: #2656 — offloaded ``structured`` attachments carry a bounded ``structured_shape`` summary
+(key names / value types / array length) in the frontmatter, additive alongside the existing
+``structured_ref`` / ``structured_preview`` (0053 offload seam, `seam.py`'s `build_offload_body`).
+
+A head-N-chars ``structured_preview`` is a poor shape summary for a large array-of-objects (only the
+first element, possibly truncated, is visible). ``structured_shape`` is deterministically derived (no
+extra LLM call) and BOUNDED in depth/breadth/array-sample so summarizing a huge/deep payload is never
+itself an unbounded-cost operation — these tests exercise the real offload seam (no mocks/patches),
+per CLAUDE.md's ban on faking a cheaply-constructible collaborator.
+"""
+from __future__ import annotations
+
+from reyn.core.offload.canonical import to_canonical
+from reyn.core.offload.seam import (
+    _SHAPE_MAX_ARRAY_SAMPLE,
+    _SHAPE_MAX_DEPTH,
+    _SHAPE_MAX_KEYS,
+    build_offload_body,
+    summarize_structured_shape,
+)
+
+
+def _fake_save(value, **_kw) -> dict:
+    """Records what was stored; returns a path-ref block like MediaStore.save_tool_result."""
+    _fake_save.stored.append(value)
+    return {"path": f".reyn/tool-results/{len(_fake_save.stored):04d}.txt", "content_hash": "h"}
+
+
+_fake_save.stored = []
+
+
+def test_offloaded_structured_carries_a_shape_summary_alongside_the_preview():
+    """Tier 1: CORE — a large array-of-objects, offloaded, gets BOTH the existing char-slice preview
+    AND the new ``structured_shape`` — additive, neither field replaces the other."""
+    _fake_save.stored = []
+    rows = [{"id": i, "name": f"row-{i}", "active": i % 2 == 0} for i in range(50)]
+    canonical = to_canonical(
+        {"kind": "mcp", "status": "ok", "server": "s", "tool": "t",
+         "content": "the body text", "structured": {"rows": rows}},
+        source="mcp",
+    )
+    frontmatter, _text, _media, _ct = build_offload_body(canonical, save_fn=_fake_save)
+
+    assert frontmatter.get("structured") == "offloaded"
+    assert frontmatter.get("structured_preview"), "existing preview field is untouched"
+    shape = frontmatter.get("structured_shape")
+    assert shape is not None, "shape summary is present for an offloaded structured attachment"
+    assert shape["rows"]["length"] == 50, "array length is exact, not sampled-approximate"
+    # The element shape is the union of keys across the sampled rows — every top-level key of a
+    # single row is visible from the frontmatter alone, without a file__read round-trip.
+    assert set(shape["rows"]["element"].keys()) == {"id", "name", "active"}
+    assert shape["rows"]["element"]["id"] == "number"
+    assert shape["rows"]["element"]["name"] == "string"
+    assert shape["rows"]["element"]["active"] == "boolean"
+
+
+def test_small_inline_structured_has_no_shape_summary():
+    """Tier 1: a small (non-offloaded) structured attachment stays fully inline — the shape summary is
+    only added for the offloaded path, since the raw data itself already answers "what is the shape"."""
+    _fake_save.stored = []
+    canonical = to_canonical(
+        {"kind": "mcp", "status": "ok", "server": "s", "tool": "t", "content": "hi",
+         "structured": {"n": 1}},
+        source="mcp",
+    )
+    frontmatter, _text, _media, _ct = build_offload_body(canonical, save_fn=_fake_save)
+    assert frontmatter.get("structured") == {"n": 1}
+    assert "structured_shape" not in frontmatter
+
+
+def test_shape_summary_depth_is_bounded_and_records_the_bound():
+    """Tier 1: BOUNDEDNESS — a deeply nested structure (well past ``_SHAPE_MAX_DEPTH``) stops
+    descending and records a ``<max_depth:N>`` marker instead of silently truncating without a trace."""
+    nested: dict = {"leaf": "bottom"}
+    for _ in range(_SHAPE_MAX_DEPTH + 5):
+        nested = {"child": nested}
+    shape = summarize_structured_shape(nested)
+
+    def _depth(d) -> int:
+        n = 0
+        while isinstance(d, dict) and "child" in d:
+            d = d["child"]
+            n += 1
+        return n
+
+    assert _depth(shape) == _SHAPE_MAX_DEPTH, "descent stops exactly at the bound"
+    # Walk to the stopping point and confirm the marker records that the bound was hit.
+    cur = shape
+    for _ in range(_SHAPE_MAX_DEPTH):
+        cur = cur["child"]
+    assert cur == f"<max_depth:{_SHAPE_MAX_DEPTH}>", "hitting the bound is recorded IN the summary"
+
+
+def test_shape_summary_key_breadth_is_bounded_and_records_the_bound():
+    """Tier 1: BOUNDEDNESS — an object with far more keys than ``_SHAPE_MAX_KEYS`` is summarized with
+    only the first N keys shown plus a ``<truncated>`` marker recording how many more exist."""
+    huge = {f"key_{i}": i for i in range(_SHAPE_MAX_KEYS + 37)}
+    shape = summarize_structured_shape(huge)
+    assert "<truncated>" in shape, "the bound-hit is recorded in the summary itself"
+    assert shape["<truncated>"] == "37 more keys"
+    shown = [k for k in shape if k != "<truncated>"]
+    assert len(shown) == _SHAPE_MAX_KEYS, "exactly the bounded number of keys is shown"
+
+
+def test_shape_summary_array_sampling_is_bounded_and_records_the_bound():
+    """Tier 1: BOUNDEDNESS — a huge array's element shape is derived from only the first
+    ``_SHAPE_MAX_ARRAY_SAMPLE`` elements (never a full scan), and the ``<sampled>`` marker records
+    that the length exceeds what was actually inspected. Elements past the sample window are free to
+    differ in shape without inflating the summarizer's work."""
+    n = 200_000
+    array = [{"a": 1} for _ in range(_SHAPE_MAX_ARRAY_SAMPLE)] + [
+        {"totally": "different", "shape": True} for _ in range(n - _SHAPE_MAX_ARRAY_SAMPLE)
+    ]
+    shape = summarize_structured_shape(array)
+    assert shape["length"] == n, "the true length is always cheap to report (len(), not a scan)"
+    assert shape["<sampled>"] == f"first {_SHAPE_MAX_ARRAY_SAMPLE} of {n}"
+    # Only the sampled (uniform) elements' keys appear — proves the summarizer never looked past
+    # the sample window, which is what keeps summarizing a 200k-element array cheap.
+    assert set(shape["element"].keys()) == {"a"}
+
+
+def test_shape_summary_is_total_over_json_scalars():
+    """Tier 1: the summarizer is total over JSON-serializable scalars — every scalar kind that can
+    appear as a structured attachment's leaf value resolves to a bare type name, never raises."""
+    assert summarize_structured_shape(None) == "null"
+    assert summarize_structured_shape(True) == "boolean"
+    assert summarize_structured_shape(3.14) == "number"
+    assert summarize_structured_shape("x") == "string"

--- a/tests/test_2656_structured_shape_summary.py
+++ b/tests/test_2656_structured_shape_summary.py
@@ -47,7 +47,7 @@ def test_offloaded_structured_carries_a_shape_summary_alongside_the_preview():
     assert shape is not None, "shape summary is present for an offloaded structured attachment"
     assert shape["rows"]["length"] == 50, "array length is exact, not sampled-approximate"
     # The element shape is the union of keys across the sampled rows — every top-level key of a
-    # single row is visible from the frontmatter alone, without a file__read round-trip.
+    # single row is visible from the frontmatter alone, without a read_file round-trip.
     assert set(shape["rows"]["element"].keys()) == {"id", "name", "active"}
     assert shape["rows"]["element"]["id"] == "number"
     assert shape["rows"]["element"]["name"] == "string"


### PR DESCRIPTION
**[per-PR-coder]** — Implements #2656: adds a bounded structural shape summary to the offload frontmatter for offloaded `structured` attachments (additive follow-up to the tool-result-schema-redesign arc, `docs/deep-dives/proposals/0053-tool-result-schema-redesign.md`, IMPLEMENTED).

## Problem

When a tool result's `structured` stream is offloaded (`src/reyn/core/offload/seam.py::build_offload_body`), the frontmatter carries `structured: offloaded` + `structured_ref` + `structured_preview` — where the preview is the first ~600 chars of the serialized JSON. For a large array-of-objects this shows only (a fragment of) the first element, so the LLM cannot reliably see the full top-level key set / value types / array length without a `file__read` round-trip.

## Change

Additive: a new `structured_shape` frontmatter field alongside the existing three. It is deterministically derived (no extra LLM call) from the structured value:

- `dict` -> `{key: <nested shape>}` (up to `_SHAPE_MAX_KEYS` keys; beyond that a `<truncated>` marker records how many more exist)
- `list` -> `{"length": N, "element": <shape>}` — element shape derived from only the first `_SHAPE_MAX_ARRAY_SAMPLE` elements (union of keys when they're all dicts — same "columns = union over first K rows" heuristic the present-layer table renderer uses, 0054, not a new concept); a `<sampled>` marker records when the true length exceeds the sample
- scalars -> bare type name (`"string"` / `"number"` / `"boolean"` / `"null"`)
- beyond `_SHAPE_MAX_DEPTH` nested levels -> a `<max_depth:N>` marker instead of descending further

**Bounded by construction**: every bound is on the summarizer's own descent (depth / key count / array sample), never on the input size — a huge or deeply nested payload cannot make shape summarization itself unbounded work, and hitting a bound is recorded IN the summary rather than silently dropped.

`structured` / `structured_ref` / `structured_preview` are completely unchanged — this is purely additive.

## Before / after (LLM-visible frontmatter, real offload seam, 200-row array-of-objects)

**Before** (current `main`, `structured_preview` only — the LLM sees one row and change):

```yaml
---
structured: offloaded
structured_ref: .reyn/tool-results/0001.txt
structured_preview: '{"users": [{"id": 0, "name": "user-0", "email": "user0@example.com",
  "active": true}, {"id": 1, "name": "user-1", "email": "user1@example.com", "active":
  false}, {"id": 2, "name": "user-2", "email": "user2@example.com", "active": false},
  ... (truncated at 600 chars, mid-object) ...
---
listed 200 users
```

**After** (this PR — `structured_preview` unchanged, `structured_shape` added):

```yaml
---
structured: offloaded
structured_ref: .reyn/tool-results/0001.txt
structured_preview: '{"users": [{"id": 0, "name": "user-0", "email": "user0@example.com",
  "active": true}, ... (same 600-char preview, unchanged) ...
structured_shape:
  users:
    length: 200
    element:
      id: number
      name: string
      email: string
      active: boolean
    <sampled>: first 3 of 200
  total: number
---
listed 200 users
```

The LLM can now author a `present` `table`/`keyvalue` binding (or decide whether to `file__read` the ref at all) directly from the frontmatter — it sees the full key set, value types, and true array length, not just whatever survived a 600-char head slice.

## Where

- `src/reyn/core/offload/seam.py` — `summarize_structured_shape()` (new, pure function) + wired into `build_offload_body`'s offload branch only (small inline `structured` stays as-is; the raw data already answers "what is the shape" there)
- `docs/deep-dives/proposals/0053-tool-result-schema-redesign.md` — format diagram updated (doc-drift rule: the mechanism this doc describes changed, so the doc changes in the same PR)
- `docs/deep-dives/proposals/0054-present-layer.md` — its own "follow-up" note now points at this PR/issue instead of "to be filed"
- `tests/test_2656_structured_shape_summary.py` — new (Tier 1), exercises the REAL offload seam (`to_canonical` + `build_offload_body`, no mocks/patches)

## Replay-fixture impact

Checked: no `tests/` fixture (JSON/JSONL/YAML) contains the literal strings `structured_preview` / `structured_ref` / `structured: offloaded`, so no `LLMReplay` fixture needed re-recording — this field is additive to a frontmatter shape no fixture pins byte-for-byte.

## Strip-falsify

Removed the `frontmatter["structured_shape"] = summarize_structured_shape(combined)` wiring line in `build_offload_body`, ran `tests/test_2656_structured_shape_summary.py`: `test_offloaded_structured_carries_a_shape_summary_alongside_the_preview` went RED (`AssertionError: shape summary is present for an offloaded structured attachment`), the other 5 (unit tests on `summarize_structured_shape` itself) stayed green as expected since they call the function directly. Restored via `cp` from a scratch copy (not `git checkout --`); re-ran — all 6 green again.

## 4 gates (this worktree, commit `6f359102`, later rebased onto `356ab3ad` — no conflicts, offload/ untouched by open PR #3463)

- `ruff check src tests` — All checks passed!
- `python scripts/test_tier_audit.py --strict tests/test_2656_structured_shape_summary.py` — 6/6 OK, 0 warnings, 0 errors
- `pytest` (full suite, background, `-n auto`): **9740 passed, 36 skipped, 6 failed** — the 6 failures (`test_fp0063_p3_rag_pipelines.py`, `test_plugin_install.py`, `test_textual_chat_intervention_panel_3299.py` ×3, `test_embed_attempts_observation_3047.py`) are in files this PR does not touch; re-ran each in isolation (no `-n auto`) and all passed — pre-existing parallel-worker flakiness, not a regression from this change.
- `python scripts/verify_module_docstrings.py src/reyn/core/offload/seam.py` — OK, no refactor narrative

## Test plan

- [x] `ruff check src tests` green
- [x] `test_tier_audit.py --strict` green on the new test file
- [x] Full `pytest` green modulo 6 pre-existing-flaky failures verified unrelated + reproduced green in isolation
- [x] `verify_module_docstrings.py` green
- [x] Strip-falsify: RED without the wiring, GREEN restored
- [x] **Owner confirmation of the LLM-visible frontmatter addition** (the before/after example above) — this is the owner gate per dispatch brief, left unchecked intentionally — **APPROVED by owner 2026-07-30**: 「3468 OK」

Closes #2656

