### PR TITLE
feat(runtime): bind hot-list sink to chat_events by identity, guard single-assignment (#3408)

### DIFF
--- a/docs/reference/runtime/session-construction.md
+++ b/docs/reference/runtime/session-construction.md
@@ -272,10 +272,26 @@ Two other cost-adjacent construction points stay inline:
 `action_embedding_index`/`embedding_provider`/`embedding_model_class`) plus
 `action_usage_tracker` — a byte-identical extraction (same
 objects, same conditionals, same try/except None-fallbacks, same args as the inline
-sequence it replaced). It stays UNMOVED, invoked at its original position, BEFORE Family 1
-(`_build_audit_event_bundle`) runs — this family has no eager dependency on `chat_events`,
-only the `_on_hot_list_changed` closure's DEFERRED `self._chat_events` resolution (kept
-verbatim since this is an instance method).
+sequence it replaced), MODULO one reordering (#3408): the call site MOVED from its
+original position (BEFORE Family 1 / `_build_audit_event_bundle`) to run right AFTER
+Family 1 instead. #3408 measured that nothing between the two positions reads or writes
+this family's own attrs (`_action_embedding_index`/`_embedding_provider`/
+`_embedding_model_class`/`_action_usage_tracker`), so the move is safe.
+
+Before #3408, this family had no eager dependency on `chat_events` — only the
+`_on_hot_list_changed` closure's DEFERRED `self._chat_events` NAME resolution, because the
+EventLog did not exist yet at the builder's old (pre-Family-1) call site. #3408 closed that
+deferral instead of keeping it: the builder now takes `chat_events` as an eager arg and the
+closure binds it by IDENTITY (the `_audit_bundle.chat_events` object, passed through), not
+by re-resolving `self._chat_events` on every call. This closes the #2856 accident's CLASS —
+a name reference silently resolving to a DIFFERENT EventLog than the one live when it was
+written — not just the one instance: an identity reference can't retarget.
+
+The rationale (git-grep evidence: `_chat_events =` is a single assignment repo-wide, in
+`Session.__init__` only) is machine-checked, not just asserted in the docstring —
+`tests/test_chat_events_single_assignment_3408.py`'s AST arm fails the day a restore/attach
+path adds a second assignment site, naming the offending file:line and saying "route this
+through the builder arg instead."
 
 `_action_retrieval` (FP-0034 PR-3b-iii) drives whether the universal catalog wrappers
 appear in the router `tools=`. Default constructs an off-flag `ActionRetrievalConfig` so

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -670,19 +670,20 @@ class _RetrievalBundle:
     (dropped) and ``subscription_writer`` is WAL-derived task-subscription
     state, not retrieval (excluded, reassigned to a later family).
 
-    Pure output→input value object, with one inversion from Families 3/4:
-    :meth:`Session._build_retrieval_bundle` is a byte-identical extraction of
-    the construction sequence that used to run inline in ``Session.__init__``
-    at its ORIGINAL position (line ~1152), which is BEFORE Family 1
-    (``_build_audit_event_bundle``) runs — so unlike ``hot_reloader``
-    (Family 3) or ``budget`` (Family 4), this family's closure
-    (``_on_hot_list_changed``) does NOT take
-    ``chat_events`` as an eager builder input. It keeps resolving
-    ``self._chat_events`` at CALL time (the EventLog is constructed later in
-    ``__init__``), exactly as the pre-extraction closure did — eager-izing
-    that reference here would raise ``AttributeError`` at construction, since
-    ``self._chat_events`` does not exist yet at line ~1152. The builder is an
-    instance method precisely so this closure can keep capturing ``self``.
+    Pure output→input value object. #3408 moved the call site from its
+    original pre-Family-1 position to run right AFTER Family 1
+    (``_build_audit_event_bundle``), so this family's closure
+    (``_on_hot_list_changed``) now takes ``chat_events`` as an eager builder
+    input — like ``hot_reloader`` (Family 3) and ``budget`` (Family 4) — and
+    binds it by IDENTITY instead of resolving ``self._chat_events`` by NAME
+    at call time. Before #3408, the builder ran BEFORE Family 1 (so
+    ``self._chat_events`` did not exist yet at its old call site) and the
+    closure deferred the name lookup to call time to avoid an
+    ``AttributeError``; #3408 measured that nothing between the old and new
+    call sites reads or writes this family's own attrs, moved the call site
+    instead, and closed the deferral. See
+    :meth:`Session._build_retrieval_bundle`'s docstring for the full
+    identity-vs-name rationale and the AST guard that keeps it true.
 
     #3438: the fourth attr, ``embedding_event_sink`` (a TUI model-download
     status sink, FP-0057 #2856 Part A), was removed along with its whole
@@ -1114,14 +1115,6 @@ class Session:
         self._last_reply_to: Any = None
         # Outbox interceptor for external transport (e.g. Slack via MCP); None skips interception (FP-0041 #489 PR-D2)
         self._outbox_interceptor: Any = None
-        # Embedding block + action_usage_tracker, byte-identical extraction, unmoved (#3082 Family 5, see session-construction.md#family-5-retrieval)
-        _retrieval_bundle = self._build_retrieval_bundle(
-            self._action_retrieval, embedding_config, self.agent_name,
-        )
-        self._action_embedding_index = _retrieval_bundle.action_embedding_index
-        self._embedding_provider = _retrieval_bundle.embedding_provider
-        self._embedding_model_class = _retrieval_bundle.embedding_model_class
-        self._action_usage_tracker = _retrieval_bundle.action_usage_tracker
         self._mcp_servers = mcp_servers
         # mcp_connection_service; 4 lambdas deferred-resolve sibling deps at call time (#3082 Family 8c, see session-construction.md#family-8c-mcp-connection-service)
         self._mcp_connection_service = self._build_mcp_connection_service()
@@ -1278,6 +1271,24 @@ class Session:
         self._event_store = _audit_bundle.event_store
         self._chat_events = _audit_bundle.chat_events
         self._otel_exporter = _audit_bundle.otel_exporter
+        # Embedding block + action_usage_tracker (#3082 Family 5). MOVED here,
+        # right after Family 1, so the hot-list sink can bind chat_events by
+        # IDENTITY (the _audit_bundle.chat_events OBJECT, passed as a builder
+        # arg) instead of by NAME (a `self._chat_events` lookup deferred to
+        # CALL time). #3408: the name-lookup form is the #2856 accident's
+        # class -- a name reference can resolve to a DIFFERENT EventLog than
+        # the one that was live at bind time (the #2856 bug bound `self.events`
+        # by name and silently picked up the wrong log); an identity-bound
+        # reference cannot, because it never re-resolves the name. Safe to
+        # move here because Family 5 has no eager dependency on anything
+        # Family 3/6a/etc. build later (see session-construction.md#family-5-retrieval).
+        _retrieval_bundle = self._build_retrieval_bundle(
+            self._action_retrieval, embedding_config, self.agent_name, self._chat_events,
+        )
+        self._action_embedding_index = _retrieval_bundle.action_embedding_index
+        self._embedding_provider = _retrieval_bundle.embedding_provider
+        self._embedding_model_class = _retrieval_bundle.embedding_model_class
+        self._action_usage_tracker = _retrieval_bundle.action_usage_tracker
         # hook_bus -> hook_dispatcher -> fs_watcher -> composer_registry -> composed_consumer -> hot_reloader; runs right after Family 1 since hot_reloader reads chat_events eagerly (#3082 Family 3, see session-construction.md#family-3-hook-event-reactivity)
         _hook_bundle = self._build_hook_event_bundle(
             _boot_in_set,
@@ -3557,6 +3568,7 @@ class Session:
         action_retrieval: "ActionRetrievalConfig",
         embedding_config: "EmbeddingConfig | None",
         agent_name: str,
+        chat_events: "EventLog",
     ) -> "_RetrievalBundle":
         """#3082 Family 5: build the retrieval spine — the embedding block
         (three attrs, one conditional construction guarded by
@@ -3574,25 +3586,40 @@ class Session:
         retrieval) are excluded per this same spec's DAG corrections.
 
         Byte-identical extraction of the construction sequence that used to
-        run inline in ``__init__`` at its ORIGINAL position (line ~1152,
-        BEFORE Family 1 / ``_build_audit_event_bundle`` runs) — same
-        objects, same order, same conditionals, same try/except
-        None-fallbacks, same args. ``action_retrieval`` / ``embedding_config``
-        / ``agent_name`` are the ``self._action_retrieval`` value / the
+        run inline in ``__init__``, MODULO one reordering (#3408): the
+        call site moved from its ORIGINAL position (line ~1152, BEFORE
+        Family 1 / ``_build_audit_event_bundle`` ran) to run right AFTER
+        Family 1 instead. ``action_retrieval`` / ``embedding_config`` /
+        ``agent_name`` are the ``self._action_retrieval`` value / the
         ``embedding_config`` __init__ parameter / the LOCAL ``agent_name``
         __init__ parameter (NOT ``self.agent_name``, mirroring the original
-        inline reference at the ``action_usage_tracker`` persist path) — all
-        resolvable before this builder's original call site.
+        inline reference at the ``action_usage_tracker`` persist path) —
+        all resolvable at the new call site exactly as they were at the old
+        one, since nothing between the two positions reads or writes them.
 
-        ``chat_events`` is deliberately NOT a builder input, unlike Family
-        3's ``hot_reloader`` or Family 4's ``budget``: the closure below
-        (``_on_hot_list_changed``) resolves
-        ``self._chat_events`` at CALL time, not construction time — the
-        EventLog is built later in ``__init__`` (Family 1, ~line 1560+).
-        Eager-izing that reference (the Family 3/4 pattern) would raise
-        ``AttributeError`` here, since this builder runs BEFORE Family 1.
-        This builder is an instance method precisely so the closure can
-        keep capturing ``self``.
+        ``chat_events`` IS a builder input (#3408), unlike its pre-#3408
+        shape where it was deliberately excluded so the closure below
+        (``_on_hot_list_changed``) could defer ``self._chat_events``
+        resolution to CALL time — the EventLog did not exist yet at the
+        builder's old (pre-Family-1) call site, so an eager reference there
+        would have raised ``AttributeError``. #3408 moved the call site
+        instead of keeping the deferral: ``git grep '_chat_events ='`` across
+        ``src`` finds exactly ONE assignment, ``Session.__init__``'s single
+        ``self._chat_events = _audit_bundle.chat_events`` — no restore/attach
+        path re-binds it — so a NAME lookup deferred to call time and an
+        IDENTITY reference captured once at construction resolve to the same
+        object today. The identity form is preferred structurally: a name
+        lookup re-resolves ``self._chat_events`` on every call, so a future
+        rebinding of that name (however unlikely) would retarget every
+        deferred closure that names it silently — the #2856 accident's
+        class (a name reference resolved to a DIFFERENT EventLog than the
+        one live when the reference was written). An identity reference
+        captured once cannot retarget: it either keeps pointing at the
+        EventLog it was given, or (if that assumption ever breaks) the
+        AST single-assignment guard in
+        ``tests/test_chat_events_single_assignment_3408.py`` goes RED first,
+        naming the new call site and saying "route this through the builder
+        arg, not a rediscovered eager ``self._chat_events``."
 
         FP-0034 Phase 2 steps 1 + 5 / Issue #192:
         see the three embedding attrs' and ``action_usage_tracker``'s
@@ -3644,13 +3671,15 @@ class Session:
         ):
             try:
                 from reyn.tools.action_usage_tracker import ActionUsageTracker
-                # Issue #192: wire a callback that emits ``hot_list_updated``
-                # on every reorder of the compacted ranking. Lambda defers
-                # ``self._chat_events`` resolution to call time (it's
-                # constructed below at the EventLog init).
+                # Issue #192 / #3408: wire a callback that emits
+                # ``hot_list_updated`` on every reorder of the compacted
+                # ranking. Binds the ``chat_events`` builder ARG by IDENTITY
+                # (not a ``self._chat_events`` name lookup) — see this
+                # method's docstring for why identity binding is safe today
+                # and what keeps it safe (the AST single-assignment guard).
                 def _on_hot_list_changed(ranking: list[dict]) -> None:
                     try:
-                        self._chat_events.emit(
+                        chat_events.emit(
                             "hot_list_updated", ranking=ranking,
                         )
                     except Exception:

--- a/tests/test_chat_events_single_assignment_3408.py
+++ b/tests/test_chat_events_single_assignment_3408.py
@@ -88,10 +88,9 @@ def test_self_chat_events_assigned_exactly_once_src_wide() -> None:
         "(self._chat_events, resolved at call time) instead of the identity-"
         "bound builder arg — see that method's docstring."
     )
-    [(only_file, only_lines)] = offenders.items()
+    [(only_file, _only_lines)] = offenders.items()
     assert only_file == "src/reyn/runtime/session.py", (
         "the sole self._chat_events assignment moved out of "
         f"runtime/session.py to {only_file} — Session.__init__ is the "
         "expected owner (Family 1 / _build_audit_event_bundle)"
     )
-    assert len(only_lines) == 1

--- a/tests/test_chat_events_single_assignment_3408.py
+++ b/tests/test_chat_events_single_assignment_3408.py
@@ -1,0 +1,97 @@
+"""Tier 2: OS invariant — #3408 ``self._chat_events`` single-assignment AST guard.
+
+#2856's accident was NOT "a stale value from a re-assignment" — it was a
+NAME reference (``self.events``) that resolved to a DIFFERENT audit-event log
+than the one live when the reference was written, silently disabling
+``search_actions`` for every operator (FP-0043 C.3/C.4). #3408 measured that
+``self._chat_events`` is written exactly ONCE repo-wide (``git grep
+'_chat_events =' -- src`` -> ``session.py:1279`` only, inside
+``Session.__init__``) and used that fact to replace a deferred NAME lookup
+(``Session._build_retrieval_bundle``'s ``_on_hot_list_changed`` closure
+resolving ``self._chat_events`` at call time) with an IDENTITY binding (the
+``chat_events`` object passed as a builder arg, captured once).
+
+Identity binding is only safe *because* the write is single — if a future
+restore/attach path re-assigns ``self._chat_events`` after construction, an
+identity-bound closure built from the FIRST value would keep pointing at a
+stale/replaced EventLog while every NAME-based reader would see the new one.
+This guard makes that precondition a CHECKED invariant instead of a comment:
+the day a second ``self._chat_events = ...`` assignment site appears anywhere
+in ``src/reyn``, this test goes RED, naming the new file:line and saying
+"route the identity-bound closures back through a live NAME lookup instead."
+
+AST-based (not regex): a regex on ``_chat_events =`` would also match dict
+keys, docstring prose, and comments — none of which are assignments. Only an
+``ast.Assign``/``ast.AugAssign`` target of ``self._chat_events`` counts.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for ancestor in here.parents:
+        if (ancestor / "pyproject.toml").is_file():
+            return ancestor
+    raise RuntimeError("repo root not found from " + str(here))
+
+
+def _is_self_chat_events_target(node: ast.expr) -> bool:
+    """True for a ``self._chat_events`` attribute-assignment TARGET."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "_chat_events"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "self"
+    )
+
+
+def _find_assignment_sites(py: Path) -> list[int]:
+    tree = ast.parse(py.read_text(encoding="utf-8"))
+    sites: list[int] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if _is_self_chat_events_target(target):
+                    sites.append(node.lineno)
+        elif isinstance(node, ast.AugAssign) and _is_self_chat_events_target(node.target):
+            sites.append(node.lineno)
+    return sites
+
+
+def test_self_chat_events_assigned_exactly_once_src_wide() -> None:
+    """Tier 2: ``self._chat_events = ...`` has exactly ONE assignment site in
+    ``src/reyn`` — the precondition #3408's identity-bound
+    ``_on_hot_list_changed`` closure (``Session._build_retrieval_bundle``)
+    relies on. A second site means a restore/attach path can now re-target
+    the log after construction, which an identity-bound closure would miss —
+    this must go RED before that lands, not be discovered later as a silent
+    stale-sink bug."""
+    root = _repo_root()
+    src = root / "src" / "reyn"
+
+    offenders: dict[str, list[int]] = {}
+    for py in src.rglob("*.py"):
+        sites = _find_assignment_sites(py)
+        if sites:
+            offenders[str(py.relative_to(root))] = sites
+
+    total = sum(len(v) for v in offenders.values())
+    assert total == 1, (
+        "self._chat_events assignment count changed from the single-write "
+        "invariant #3408's identity binding depends on (expected exactly 1, "
+        f"found {total}): {offenders}. If this is a deliberate new "
+        "restore/attach re-assignment path, Session._build_retrieval_bundle's "
+        "_on_hot_list_changed closure must go back to a live NAME lookup "
+        "(self._chat_events, resolved at call time) instead of the identity-"
+        "bound builder arg — see that method's docstring."
+    )
+    [(only_file, only_lines)] = offenders.items()
+    assert only_file == "src/reyn/runtime/session.py", (
+        "the sole self._chat_events assignment moved out of "
+        f"runtime/session.py to {only_file} — Session.__init__ is the "
+        "expected owner (Family 1 / _build_audit_event_bundle)"
+    )
+    assert len(only_lines) == 1

--- a/tests/test_retrieval_sink_identity_3408.py
+++ b/tests/test_retrieval_sink_identity_3408.py
@@ -1,0 +1,69 @@
+"""Tier 2: OS invariant — #3408 identity-bound hot-list sink E2E.
+
+#3408 replaced ``Session._build_retrieval_bundle``'s ``_on_hot_list_changed``
+closure's NAME lookup (``self._chat_events``, resolved at call time) with an
+IDENTITY binding (the ``chat_events`` builder arg, captured once). This is
+the E2E identity witness the architect's firm required: through a REAL
+``Session`` (never a mock/stub of ``ActionUsageTracker`` or ``EventLog``),
+recording a real action usage -> ``merge_compacted`` reordering the compacted
+ranking -> the sink firing -> ``session._chat_events.emit("hot_list_updated",
+...)`` -> a real subscriber attached to ``session._chat_events`` AFTER
+construction receiving that event.
+
+The point this proves: the sink the retrieval builder wired at construction
+time and the ``EventLog`` a caller reaches via ``session._chat_events`` after
+construction are THE SAME OBJECT. A name-resolution bug (#2856's class) would
+silently emit onto some OTHER EventLog no subscriber here is watching, and
+this test would see the outbox stay empty instead.
+"""
+from __future__ import annotations
+
+import time
+
+from reyn.config.embedding import ActionRetrievalConfig
+from reyn.core.events.events import Event
+from tests._support.agent_session import make_session
+
+
+class _EventSink:
+    """A real (non-mock) chat-event subscriber — a plain callback collector
+    (mirrors tests/test_agent_delta_chat_event_3288.py's ``_EventSink``)."""
+
+    def __init__(self) -> None:
+        self.events: list[Event] = []
+
+    def __call__(self, event: Event) -> None:
+        self.events.append(event)
+
+
+def test_hot_list_sink_reaches_the_sessions_own_chat_events() -> None:
+    """Tier 2: a real ActionUsageTracker ranking change reaches a subscriber
+    attached to session._chat_events — proving the sink the retrieval
+    builder wired IS the session's live EventLog, bound by identity rather
+    than rediscovered by name."""
+    session = make_session(
+        agent_name="test_agent_3408",
+        action_retrieval_config=ActionRetrievalConfig(hot_list_n=5),
+    )
+    tracker = session._action_usage_tracker
+    assert tracker is not None, (
+        "hot_list_n=5 must construct a real ActionUsageTracker — if this is "
+        "None, _build_retrieval_bundle's conditional changed shape"
+    )
+
+    sink = _EventSink()
+    session._chat_events.add_subscriber(sink)
+
+    # A real qualified-name usage record, reordering the compacted ranking
+    # from empty -> one entry (order always changes on the first record),
+    # which fires ActionUsageTracker's on_ranking_changed callback for real.
+    tracker.merge_compacted([("file__read", time.time())])
+
+    hot_list_events = [e for e in sink.events if e.type == "hot_list_updated"]
+    assert len(hot_list_events) == 1, (
+        "the identity-bound hot-list sink did not reach session._chat_events' "
+        "own subscriber — either the closure is emitting onto a DIFFERENT "
+        "EventLog than the one session._chat_events exposes (the #2856 "
+        f"failure class), or the ranking-changed path didn't fire. Captured: {sink.events}"
+    )
+    assert hot_list_events[0].data.get("ranking") == tracker.full_ranking()

--- a/tests/test_retrieval_sink_identity_3408.py
+++ b/tests/test_retrieval_sink_identity_3408.py
@@ -54,10 +54,13 @@ def test_hot_list_sink_reaches_the_sessions_own_chat_events() -> None:
     sink = _EventSink()
     session._chat_events.add_subscriber(sink)
 
-    # A real qualified-name usage record, reordering the compacted ranking
-    # from empty -> one entry (order always changes on the first record),
-    # which fires ActionUsageTracker's on_ranking_changed callback for real.
-    tracker.merge_compacted([("file__read", time.time())])
+    # A synthetic-but-validly-shaped (<category>__<entry>, category in
+    # CATEGORIES) usage record -- deliberately NOT a real production action
+    # name, so this fixture never reads as "here is a currently-valid
+    # action" -- reordering the compacted ranking from empty -> one entry
+    # (order always changes on the first record), which fires
+    # ActionUsageTracker's on_ranking_changed callback for real.
+    tracker.merge_compacted([("file__test_hot_list_entry", time.time())])
 
     hot_list_events = [e for e in sink.events if e.type == "hot_list_updated"]
     assert hot_list_events, (

--- a/tests/test_retrieval_sink_identity_3408.py
+++ b/tests/test_retrieval_sink_identity_3408.py
@@ -60,10 +60,10 @@ def test_hot_list_sink_reaches_the_sessions_own_chat_events() -> None:
     tracker.merge_compacted([("file__read", time.time())])
 
     hot_list_events = [e for e in sink.events if e.type == "hot_list_updated"]
-    assert len(hot_list_events) == 1, (
+    assert hot_list_events, (
         "the identity-bound hot-list sink did not reach session._chat_events' "
         "own subscriber — either the closure is emitting onto a DIFFERENT "
         "EventLog than the one session._chat_events exposes (the #2856 "
         f"failure class), or the ranking-changed path didn't fire. Captured: {sink.events}"
     )
-    assert hot_list_events[0].data.get("ranking") == tracker.full_ranking()
+    assert hot_list_events[-1].data.get("ranking") == tracker.full_ranking()


### PR DESCRIPTION
**[per-PR-coder]** — Implements #3408 (post-firm content: identity binding + single-assignment guard; the original issue-body option (b) was rejected in the comment thread and is NOT implemented here).

## What

Two structural closures of the #2856 accident's *class* (a chat-event sink resolved by NAME silently landing on a DIFFERENT `EventLog` than the one live when it was written):

1. **Identity binding**: `Session._build_retrieval_bundle`'s `_on_hot_list_changed` closure (the hot-list `search_actions` freq+recency sink) now binds `chat_events` by IDENTITY — the actual `_audit_bundle.chat_events` object, passed as a builder arg — instead of resolving `self._chat_events` by NAME at call time. This required moving the builder's call site in `Session.__init__` to run right AFTER Family 1 (`_build_audit_event_bundle`) instead of before it (measured: nothing between the two positions reads/writes this family's own attrs, so the move is byte-identical modulo position).
2. **Single-assignment as a checked invariant**: added an AST arm (`tests/test_chat_events_single_assignment_3408.py`) asserting `self._chat_events = ...` has exactly ONE assignment site repo-wide (`src/reyn/runtime/session.py`, inside `Session.__init__`). This is the precondition the identity binding depends on — if a future restore/attach path ever re-assigns `self._chat_events`, this test goes RED, naming the new site and saying "route the identity-bound closure back through a live name lookup."

Both `_build_retrieval_bundle`'s and `_RetrievalBundle`'s docstrings, plus `docs/reference/runtime/session-construction.md`'s Family 5 section, were rewritten in the same PR (the prior text asserted the old pre-#3408 ordering/rationale as current, which this PR falsifies).

## Why (from the issue thread)

The issue's original body proposed option (b) — a Composition-Root-supplied lazy `EventLog` provider. The architect's firm (issue comments) measured that both of (b)'s motivating premises don't hold: `_chat_events` is written exactly once repo-wide (no re-assignment to defend against), and `_build_audit_event_bundle` isn't a pure factory (5 `self.*` reads), so a Composition Root can't hold the `EventLog` either. (b) was explicitly rejected (regla 6 — dropped with reasons recorded, not deferred). The issue's content was replaced with the two items above, which lead-coder then dispatched.

## Scope discipline (per dispatch brief)

Only `src/reyn/runtime/session.py`, `docs/reference/runtime/session-construction.md`, and the two new test files are touched. No changes to `router_loop.py` / `router_tools.py` (PR #3463, open, touches those files heavily).

## Witnesses

- **Identity witness (E2E, real construction)**: `tests/test_retrieval_sink_identity_3408.py` builds a real `Session` (via `make_session`, `hot_list_n=5`), attaches a real (non-mock) subscriber to `session._chat_events` AFTER construction, fires a real `ActionUsageTracker.merge_compacted(...)` call, and asserts the subscriber receives the resulting `hot_list_updated` event — proving the sink the retrieval builder wired at construction and the `EventLog` `session._chat_events` exposes afterward are the SAME object.
- **Strip-falsify**: temporarily rebound the closure to a freshly-constructed `EventLog()` instead of the `chat_events` builder arg — the identity witness went RED (`assert 0 == 1`, captured events `[]`) exactly as expected, confirming the test actually exercises the identity binding rather than passing vacuously. Restored from a scratch backup (not `git checkout --`) before committing.
- **AST single-assignment arm**: `tests/test_chat_events_single_assignment_3408.py` — passes today (1 assignment, `session.py`); manually verified it fails (and names the offending site) when a second `self._chat_events = ...` is added anywhere in `src/reyn` during development of this PR.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_chat_events_single_assignment_3408.py tests/test_retrieval_sink_identity_3408.py` — 2/2 OK (fixed two Tier-4 `len(...) == N` format pins flagged on the first pass)
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` — OK
- [x] `pytest` (full suite, repo root, `-n auto --timeout=120`) — see report
- [x] Identity E2E witness passes; strip-falsify reproduces RED
- [x] `git fetch origin && git rebase origin/main` immediately before opening this PR; full suite re-run post-rebase

Closes #3408
