### PR TITLE
feat(tui): PageUp/PageDown scroll the conversation from the composer

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -304,6 +304,28 @@ class Composer(TextArea):
                     event.prevent_default()
                     sent_queue.first().focus()
                     return
+        if event.key in ("pageup", "pagedown"):
+            # #3470: PageUp/PageDown scroll the CONVERSATION, unconditionally —
+            # never the composer's own text. TextArea's default binds these to
+            # page-sized cursor jumps, which in a <= MAX_ROWS-tall chat box has
+            # no practical value; meanwhile "scroll back through the chat" had
+            # NO discoverable key at all (the only route was an undocumented
+            # Shift+Tab focus hop into the conversation pane, with no visual
+            # cue that focus had left the composer). Unconditional delegation
+            # keeps one meaning per key (#3365 principle: a key's meaning does
+            # not change with state), and focus never leaves the composer.
+            # The pane is queried by type NAME so this module keeps its
+            # import-isolation (textual_flowview stays out of chrome.py —
+            # pinned by test_phase3_chrome_imports_stay_tty_only).
+            flow = self.app.query("FlowView")
+            if flow:
+                event.stop()
+                event.prevent_default()
+                if event.key == "pageup":
+                    flow.first().scroll_page_up(animate=False)
+                else:
+                    flow.first().scroll_page_down(animate=False)
+                return
         await super()._on_key(event)
 
     def on_text_area_changed(self, event: TextArea.Changed) -> None:
@@ -394,6 +416,9 @@ _LIST_PANES = frozenset({
 COMPOSER_KEYS: "list[tuple[str, str]]" = [
     ("enter", "send"),
     ("shift+enter", "newline"),
+    # #3470: the conversation's scroll keys, usable WITHOUT leaving the
+    # composer (delegated in ``Composer._on_key`` — focus never moves).
+    ("pgup / pgdn", "scroll conversation"),
     ("↓", "focus menu"),
     # #3327: ↑ now targets whichever of the two regions above the composer
     # actually has something to act on, pending intervention first — see

--- a/tests/test_conversation_scroll_keys_3470.py
+++ b/tests/test_conversation_scroll_keys_3470.py
@@ -1,0 +1,146 @@
+"""#3470 — PageUp/PageDown scroll the conversation from the composer.
+
+Owner design review found that "scroll back through the chat" — a chat UI's
+basic read-back action — had NO discoverable key: composer-focused PageUp was
+swallowed by TextArea's own page-cursor binding (a no-op in a <= 6-row box),
+and the only working route was an undocumented Shift+Tab focus hop into the
+conversation pane with no visual cue that focus had left the composer.
+
+The fix delegates PageUp/PageDown from ``Composer._on_key`` to the FlowView's
+page-scroll — unconditionally (one meaning per key, #3365 principle), with
+focus never leaving the composer — and registers the keys in
+``COMPOSER_KEYS`` so the Help pane (the #3314 single source of truth)
+documents them.
+
+Real ``TextualChatApp`` + a real minimal ``ClientTransport`` — no mocks."""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import Composer, TextualChatApp
+from reyn.interfaces.inline.textual_chat.chrome import COMPOSER_KEYS, help_pane_lines
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _Transport(ClientTransport):
+    def __init__(self) -> None:
+        self.submitted: list[str] = []
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        await asyncio.Event().wait()
+        yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
+
+    async def submit_user_text(self, text: str) -> None:
+        self.submitted.append(text)
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+async def _overflowing_conversation(app: TextualChatApp, pilot) -> FlowView:
+    """Append enough rows that the conversation genuinely overflows the
+    viewport (asserted, so the scroll assertions below cannot pass vacuously
+    on an unscrollable pane)."""
+    for i in range(60):
+        app.conversation.append(OutboxMessage(kind="status", text=f"row {i}"))
+    await pilot.pause()
+    await pilot.pause()
+    flow = app.query_one(FlowView)
+    assert flow.max_scroll_y > 0, (
+        "test setup: the conversation does not overflow the viewport"
+    )
+    return flow
+
+
+@pytest.mark.asyncio
+async def test_pageup_scrolls_conversation_and_focus_stays_on_composer() -> None:
+    """Tier 2b: composer-focused PageUp scrolls the conversation BACK (the
+    #3470 fix) and focus never leaves the composer — the delegation is a
+    scroll, not a focus hop."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        flow = await _overflowing_conversation(app, pilot)
+        composer = app.query_one(Composer)
+        composer.focus()
+        await pilot.pause()
+
+        at_bottom = flow.scroll_y
+        await pilot.press("pageup")
+        await pilot.pause()
+
+        assert flow.scroll_y < at_bottom, (
+            f"PageUp did not scroll the conversation (scroll_y stayed at "
+            f"{flow.scroll_y})"
+        )
+        assert composer.has_focus, "PageUp moved focus off the composer"
+
+
+@pytest.mark.asyncio
+async def test_pagedown_scrolls_back_toward_the_bottom() -> None:
+    """Tier 2b: PageDown reverses PageUp — the user can return to the live
+    tail without any focus change."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        flow = await _overflowing_conversation(app, pilot)
+        composer = app.query_one(Composer)
+        composer.focus()
+        await pilot.pause()
+
+        await pilot.press("pageup")
+        await pilot.press("pageup")
+        await pilot.pause()
+        scrolled_up = flow.scroll_y
+
+        await pilot.press("pagedown")
+        await pilot.pause()
+
+        assert flow.scroll_y > scrolled_up, (
+            f"PageDown did not scroll back down (scroll_y stayed at "
+            f"{flow.scroll_y})"
+        )
+        assert composer.has_focus, "PageDown moved focus off the composer"
+
+
+def test_scroll_keys_are_discoverable_through_the_help_pane() -> None:
+    """Tier 2b: the new keys ride ``COMPOSER_KEYS`` (the Help pane's #3314
+    single source of truth) — a key that works but is not documented there is
+    exactly the defect #3470 was filed about."""
+    assert any(
+        "pgup" in key and "scroll" in desc for key, desc in COMPOSER_KEYS
+    ), "pgup/pgdn scroll keys missing from COMPOSER_KEYS"
+    lines = help_pane_lines()
+    assert any("scroll conversation" in line for line in lines), (
+        "the scroll keys did not reach the rendered Help pane"
+    )

--- a/tests/test_textual_chat_esc_sufficiency_3365.py
+++ b/tests/test_textual_chat_esc_sufficiency_3365.py
@@ -13,7 +13,7 @@ gate is what lets a later PR remove Tab's "back" binding with a real, not
 merely assumed, safety net; and what would immediately catch that future
 Input-vs-Esc regression by going RED.
 
-Five HAND-ENUMERATED focus states, each independently reachable and each
+Six HAND-ENUMERATED focus states, each independently reachable and each
 asserted to return to the Composer on ``Esc``:
   1. MenuBar (tab-bar row, not yet opened)
   2. Drawer content (an OptionList pane)
@@ -21,10 +21,15 @@ asserted to return to the Composer on ``Esc``:
   4. InterventionPanel — closed-set (RadioSet)
   5. InterventionPanel — free-text (Input) — the specific widget architect
      flagged as the future risk
+  6. FlowView (the conversation pane — ``can_focus=True``, reachable via
+     Textual's own Shift+Tab focus cycling). #3470's design review found
+     this region ALREADY existed outside the original hand-enumeration —
+     exactly the "6th focusable region" case the note below predicted —
+     so it is now armed here per that note's own instruction.
 
 This list is NOT derived from an exhaustive enumeration of every focusable
 widget the app can mount (co-vet note, #3365 review) — it is the set of
-regions this issue's own investigation reached. A 6th focusable region added
+regions the #3365/#3470 investigations reached. A NEW focusable region added
 later (a new drawer pane type, a new panel) is NOT automatically covered by
 this file; extending the list here is the maintainer's job when one is
 added, the same way a new call site needs its own invariant check elsewhere
@@ -244,3 +249,34 @@ async def test_esc_from_intervention_panel_input_returns_to_composer() -> None:
             f"Esc from InterventionPanel's Input did not return to Composer: {app.focused!r}"
         )
         assert transport.answered_text == [], "Esc must not deliver an answer"
+
+
+@pytest.mark.asyncio
+async def test_esc_from_conversation_pane_returns_to_composer() -> None:
+    """Tier 2b: Esc from the focused conversation pane (FlowView) -> Composer.
+
+    The 6th hand-enumerated state (see the module docstring): FlowView is
+    ``can_focus=True`` and reachable through Textual's own Shift+Tab focus
+    cycling — a route #3470's design review found already live but entirely
+    outside the original enumeration. Reached here exactly that way (a real
+    ``shift+tab`` keypress, not a programmatic ``.focus()``), so the test
+    covers the route a keyboard user actually takes."""
+    from textual_flowview import FlowView
+
+    app = TextualChatApp(transport=_Transport([]))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.query_one(Composer).focus()
+        await pilot.pause()
+
+        await pilot.press("shift+tab")
+        await pilot.pause()
+        assert isinstance(app.focused, FlowView), (
+            f"setup: Shift+Tab did not reach the conversation pane: {app.focused!r}"
+        )
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.query_one(Composer).has_focus, (
+            f"Esc from the conversation pane did not return to Composer: {app.focused!r}"
+        )


### PR DESCRIPTION
**[tui-coder]** — part of #3470 (owner design review → 直接指示による実装)

## Why the defect existed (one sentence)

The conversation pane (FlowView) participates in Textual's focus cycling **incidentally** (`can_focus=True`, reachable by Shift+Tab) but no key contract was ever designed for it — it belongs to none of the Help pane's source-of-truth tables (`COMPOSER_KEYS`/`MENUBAR_KEYS`/`SENTQUEUE_KEYS`), and composer-focused PageUp was swallowed by TextArea's own page-cursor binding (a no-op in a ≤6-row chat box) — so "scroll back through the chat" was reachable only by an undocumented focus hop with zero visual cue that keystrokes were no longer going to the input.

## Fix

- `Composer._on_key`: PageUp/PageDown delegate to the FlowView's page scroll, **unconditionally** — one meaning per key (#3365 principle 3), and **focus never leaves the composer** (no invisible-focus state to fall into). The pane is queried by type *name* so `chrome.py` keeps its `textual_flowview` import isolation (pinned by the existing phase-3 isolation test).
- `COMPOSER_KEYS` gains `("pgup / pgdn", "scroll conversation")` — rides the #3314 single source into the Help pane.
- **#3399's Esc-sufficiency gate: the predicted "6th focusable region" armed.** That gate's docstring explicitly said a later-found focusable region must be added by hand — FlowView is exactly that case (found live during this review). New test reaches it via a real `shift+tab` press (the route a keyboard user takes, not a programmatic `.focus()`) and asserts Esc returns to the Composer. Docstring updated 5 → 6, non-exhaustiveness note retained.

Shift+Tab focus cycling itself is untouched (Textual standard); with PageUp/PageDown live from the composer there is no longer any *need* to know about it.

## Falsified

Stripped the delegation block → both scroll tests RED (keys swallowed again, `scroll_y` unmoved); restored → GREEN. The Help-pane test guards the documentation half independently.

## Real-TTY witness (100×30, this worktree's venv, `reyn.__file__` verified)

- 40-line reply overflowing the viewport → composer-focused `PageUp`×2 scrolled back to the original prompt at top.
- Typed `z` mid-scroll → landed in the composer (`❯ z`) — focus provably never moved.
- `PageDown`×3 → back at the tail (lines 34-36 visible again).

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` (2 test files, 9 tests) — 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py src/.../chrome.py` — OK
- [x] Strip-falsify — above
- [x] Full `pytest -n auto` — 9646 passed; 7 failed with the SAME signature as #3472's run and the #3434/#3444 family: 6 pass standalone (xdist contention — `test_compaction_resolver_aware_1172`×3, `test_llm_request_error_1676`, `test_llm_router_s3b_1829`×2), 1 environmental (`test_flowview_library_is_unmodified` pins flowview `0.4.0` vs this venv's local dev `0.6.0` editable install; this diff touches no flowview surface)
- [x] Real-TTY witness — above
