### PR TITLE
fix(runtime): emit routing_decided at the dispatch chokepoint, not the invoke_action surface — #3455

### DIFF
--- a/docs/reference/runtime/events.ja.md
+++ b/docs/reference/runtime/events.ja.md
@@ -97,9 +97,9 @@ SSoT は `src/reyn/core/events/event_schema.py` の `AUDIT_EVENT_KINDS` で、�
 
 | 種類 | トリガー | 主要なペイロード |
 |------|---------|-------------|
-| `routing_decided` | router の単一ディスパッチ関門（`RouterLoop._dispatch_resolved`）で、カタログアクションがディスパッチされるたびに発行されます — `invoke_action` ラッパー経由、bare な hot-list-alias 呼び出し、ARS-salvage された直接呼び出し、あるいは（#3455）universal wrapper が無効な場合のフラット/デフォルトの bare-name ディスパッチパスのいずれでも。 | `action_name: str`; `source: str` — `"invoke_action"` \| `"hot_list_alias"` \| `"ars_direct"`; `outcome: str` — `"success"` \| `"error"`; `chain_id: str` — クロスコール相関用リクエストチェーン識別子。 |
+| `routing_decided` | router の単一ディスパッチ関門（`RouterLoop._dispatch_resolved`）で、カタログアクションがディスパッチされるたびに発行されます — `invoke_action` ラッパー経由、bare な hot-list-alias 呼び出し、ARS-salvage された直接呼び出し、あるいは（#3455）reyn.yaml で `action_retrieval.universal_wrappers_enabled: false` を設定した場合のフラットな bare-name ディスパッチパスのいずれでも。 | `action_name: str`; `source: str` — `"invoke_action"` \| `"hot_list_alias"` \| `"ars_direct"`; `outcome: str` — `"success"` \| `"error"`; `chain_id: str` — クロスコール相関用リクエストチェーン識別子。 |
 
-**注記:** モデルがどの入口を使ったかによらず、カタログアクションのルーティングを監査できます（#3455: 以前は `invoke_action` ラッパー経由にのみ紐づいており、デフォルトのフラット bare-name 構成ではこのイベントが一度も発行されませんでした）。`chain_id` を使って、アクションのダウンストリームイベントとのクロスコリレーションが行えます。
+**注記:** モデルがどの入口を使ったかによらず、カタログアクションのルーティングを監査できます（#3455: 以前は `invoke_action` ラッパー経由にのみ紐づいており、`universal_wrappers_enabled: false` の opt-out 構成ではこのイベントが一度も発行されませんでした）。`chain_id` を使って、アクションのダウンストリームイベントとのクロスコリレーションが行えます。
 
 ## ユーザーインタラクション
 

--- a/docs/reference/runtime/events.ja.md
+++ b/docs/reference/runtime/events.ja.md
@@ -97,9 +97,9 @@ SSoT は `src/reyn/core/events/event_schema.py` の `AUDIT_EVENT_KINDS` で、�
 
 | 種類 | トリガー | 主要なペイロード |
 |------|---------|-------------|
-| `routing_decided` | アクションラッパー（`list_actions` / `search_actions` / `describe_action` / `invoke_action`）がリクエストをルーティングするとき、ユニバーサルアクションカタログのディスパッチパスから発行されます。 | `action_name: str`; `source: str` — `"catalog"` \| `"hot_alias"` \| `"direct"`; `outcome: str` — `"dispatched"` \| `"deflected"` \| `"error"`; `chain_id: str` — クロスコール相関用リクエストチェーン識別子。 |
+| `routing_decided` | router の単一ディスパッチ関門（`RouterLoop._dispatch_resolved`）で、カタログアクションがディスパッチされるたびに発行されます — `invoke_action` ラッパー経由、bare な hot-list-alias 呼び出し、ARS-salvage された直接呼び出し、あるいは（#3455）universal wrapper が無効な場合のフラット/デフォルトの bare-name ディスパッチパスのいずれでも。 | `action_name: str`; `source: str` — `"invoke_action"` \| `"hot_list_alias"` \| `"ars_direct"`; `outcome: str` — `"success"` \| `"error"`; `chain_id: str` — クロスコール相関用リクエストチェーン識別子。 |
 
-**注記:** ラッパーオンリーのルーティングパスの監査が可能です。`chain_id` を使って、アクションのダウンストリームイベントとのクロスコリレーションが行えます。
+**注記:** モデルがどの入口を使ったかによらず、カタログアクションのルーティングを監査できます（#3455: 以前は `invoke_action` ラッパー経由にのみ紐づいており、デフォルトのフラット bare-name 構成ではこのイベントが一度も発行されませんでした）。`chain_id` を使って、アクションのダウンストリームイベントとのクロスコリレーションが行えます。
 
 ## ユーザーインタラクション
 

--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -340,9 +340,9 @@ See also: [Concepts: secret handling](../../concepts/runtime/secret-handling.md)
 
 | Kind | Trigger | Key payload |
 |------|---------|-------------|
-| `routing_decided` | Emitted at the router's single dispatch chokepoint (`RouterLoop._dispatch_resolved`) whenever a catalog action is dispatched — via the `invoke_action` wrapper, a bare hot-list-alias tool call, an ARS-salvaged direct call, or (#3455) the flat/default bare-name dispatch path used when universal wrappers are off. | `action_name: str`; `source: str` — `"invoke_action"` \| `"hot_list_alias"` \| `"ars_direct"`; `outcome: str` — `"success"` \| `"error"`; `chain_id: str` — request chain identifier for cross-call correlation. |
+| `routing_decided` | Emitted at the router's single dispatch chokepoint (`RouterLoop._dispatch_resolved`) whenever a catalog action is dispatched — via the `invoke_action` wrapper, a bare hot-list-alias tool call, an ARS-salvaged direct call, or (#3455) the flat bare-name dispatch path used when `action_retrieval.universal_wrappers_enabled: false` is set in reyn.yaml. | `action_name: str`; `source: str` — `"invoke_action"` \| `"hot_list_alias"` \| `"ars_direct"`; `outcome: str` — `"success"` \| `"error"`; `chain_id: str` — request chain identifier for cross-call correlation. |
 
-**Notes:** enables auditing catalog-action routing regardless of which entry surface the model used (#3455: previously gated on the `invoke_action` wrapper surface, so the default flat bare-name configuration never emitted this event at all). Cross-correlate with `chain_id` across the action's downstream events.
+**Notes:** enables auditing catalog-action routing regardless of which entry surface the model used (#3455: previously gated on the `invoke_action` wrapper surface, so the `universal_wrappers_enabled: false` opt-out configuration never emitted this event at all). Cross-correlate with `chain_id` across the action's downstream events.
 
 ## User interaction
 

--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -340,9 +340,9 @@ See also: [Concepts: secret handling](../../concepts/runtime/secret-handling.md)
 
 | Kind | Trigger | Key payload |
 |------|---------|-------------|
-| `routing_decided` | Emitted by the universal action catalog dispatch path when an action wrapper (`list_actions` / `search_actions` / `describe_action` / `invoke_action`) routes a request. | `action_name: str`; `source: str` — `"catalog"` \| `"hot_alias"` \| `"direct"`; `outcome: str` — `"dispatched"` \| `"deflected"` \| `"error"`; `chain_id: str` — request chain identifier for cross-call correlation. |
+| `routing_decided` | Emitted at the router's single dispatch chokepoint (`RouterLoop._dispatch_resolved`) whenever a catalog action is dispatched — via the `invoke_action` wrapper, a bare hot-list-alias tool call, an ARS-salvaged direct call, or (#3455) the flat/default bare-name dispatch path used when universal wrappers are off. | `action_name: str`; `source: str` — `"invoke_action"` \| `"hot_list_alias"` \| `"ars_direct"`; `outcome: str` — `"success"` \| `"error"`; `chain_id: str` — request chain identifier for cross-call correlation. |
 
-**Notes:** enables auditing the wrapper-only routing path. Cross-correlate with `chain_id` across the action's downstream events.
+**Notes:** enables auditing catalog-action routing regardless of which entry surface the model used (#3455: previously gated on the `invoke_action` wrapper surface, so the default flat bare-name configuration never emitted this event at all). Cross-correlate with `chain_id` across the action's downstream events.
 
 ## User interaction
 

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -131,8 +131,10 @@ EVENT_AUDIT_REQUIREMENTS: dict[str, frozenset[str]] = {
     # entry surface (invoke_action wrapper / bare hot-list alias / ARS-
     # salvaged direct call / flat bare-name dispatch when universal wrappers
     # are off). Previously emitted from a run_loop-local block gated on
-    # `if _univ_enabled:`, which meant the default (wrappers-off) config
-    # never emitted it at all even though catalog routing was happening.
+    # `if _univ_enabled:`, which meant the opt-out config (an operator
+    # setting `action_retrieval.universal_wrappers_enabled: false` in
+    # reyn.yaml) never emitted it at all even though catalog routing was
+    # happening.
     # action_name: the resolved action_name (e.g. "agent.peer__alice")
     # source: how the routing happened
     #   ("invoke_action" | "hot_list_alias" | "ars_direct")

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -126,9 +126,16 @@ EVENT_AUDIT_REQUIREMENTS: dict[str, frozenset[str]] = {
     # direction" applies and the fix was to add the missing emitters. The
     # difference is reachability, not observability.
     # FP-0034 Phase 3: Universal catalog routing decision (Self-improvement Loop)
-    # Emitted by RouterLoop when invoke_action or a hot list alias is executed.
+    # #3455: emitted by RouterLoop._dispatch_resolved — the single dispatch
+    # chokepoint every catalog action call funnels through, regardless of
+    # entry surface (invoke_action wrapper / bare hot-list alias / ARS-
+    # salvaged direct call / flat bare-name dispatch when universal wrappers
+    # are off). Previously emitted from a run_loop-local block gated on
+    # `if _univ_enabled:`, which meant the default (wrappers-off) config
+    # never emitted it at all even though catalog routing was happening.
     # action_name: the resolved action_name (e.g. "agent.peer__alice")
-    # source: how the routing happened ("invoke_action" | "hot_list_alias")
+    # source: how the routing happened
+    #   ("invoke_action" | "hot_list_alias" | "ars_direct")
     # outcome: "success" | "error" based on the tool result status
     # chain_id: for cross-agent tracing (P6)
     "routing_decided": frozenset({"action_name", "source", "outcome", "chain_id"}),

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1764,11 +1764,17 @@ class RouterLoop:
         self._catalog = {t["function"]["name"]: t for t in tools}
         self._tool_names = frozenset(self._catalog.keys())
         # B28-Q2 Case A: per-turn counters for chat_turn_completed_inline.
-        # _routing_decided_fired: set to True the first time routing_decided
-        #   is emitted in this turn (= invoke_action or hot_list_alias path).
+        # #3455: routing_decided is now emitted from ``_dispatch_resolved`` —
+        # the single chokepoint every catalog dispatch funnels through
+        # (invoke_action wrapper, bare hot-list alias, ARS-salvaged direct
+        # call, AND the flat/default bare-name dispatch that runs when
+        # universal wrappers are OFF, which the prior ``_univ_enabled``-gated
+        # emit never covered). An instance attribute (not a run_loop-local)
+        # because the emit site moved to a method called from multiple
+        # places; reset here so it reads "did routing happen THIS turn".
         # _tool_calls_attempted: count of tool_call rounds where the LLM
         #   invoked at least one tool (including non-catalog tools).
-        _routing_decided_fired: bool = False
+        self._routing_decided_this_turn: bool = False
         _tool_calls_attempted: int = 0
         # B42-NF-W6-1: empty-stop retry counter. The empty-stop handler
         # consults this before injecting a continuation prompt + looping,
@@ -2242,78 +2248,18 @@ class RouterLoop:
                     )
                     return self._total_usage
 
-                # FP-0034 Phase 3: routing_decided P6 event for catalog dispatch audit.
-                # Emitted independently of tracker (tracker=None is valid when
-                # hot_list_n=0, but P6 audit must fire whenever catalog routing
-                # actually happened). Guard: only when universal wrappers are on,
-                # which is the only condition under which catalog routing occurs.
-                if _univ_enabled:
-                    for tc, r in zip(tool_calls, tool_results):
-                        _rd_name = tc.get("function", {}).get("name", "")
-                        if _rd_name == "invoke_action":
-                            _rd_args = tc.get("function", {}).get("arguments", {})
-                            if isinstance(_rd_args, str):
-                                try:
-                                    import json as _json_rd
-                                    _rd_args = _json_rd.loads(_rd_args)
-                                except Exception:  # noqa: BLE001
-                                    _rd_args = {}
-                            _rd_action = (
-                                _rd_args.get("action_name", "")
-                                if isinstance(_rd_args, dict) else ""
-                            )
-                            _rd_source = "invoke_action"
-                        elif _rd_name in _KNOWN_ACTION_NAMES:
-                            # Issue #241: distinguish "real hot-list alias the
-                            # LLM correctly used" (= name actually surfaced in
-                            # tools[]) from "ARS-only direct call the salvage
-                            # path covers" (= name appeared only in the
-                            # invoke_action.description ARS block, salvaged
-                            # by PR #240). Pre-#241, both cases were tagged
-                            # ``"hot_list_alias"`` regardless, muddying the
-                            # audit chain for downstream readers (B42 W5-S6).
-                            #
-                            # #3429: the test was ``"__" in _rd_name`` — a
-                            # direct call by an action's QUALIFIED spelling, the
-                            # only way to name an action directly back then.
-                            # With one name per action the equivalent test is
-                            # membership in the action set. This does NOT touch
-                            # the ``_univ_enabled`` guard above, whose own
-                            # coverage hole is #3455.
-                            _rd_action = _rd_name
-                            if _rd_name in self._catalog:
-                                _rd_source = "hot_list_alias"
-                            else:
-                                _rd_source = "ars_direct"
-                        else:
-                            continue  # non-catalog tool — skip
-                        if not _rd_action:
-                            continue
-                        # #3450: derive from the SAME source as the LLM-visible
-                        # envelope — dispatch_tool's own outer ``status`` field.
-                        # Before #3450, dispatch_tool wrapped a handler's own
-                        # (non-raising) error return as
-                        # ``{"status": "ok", "data": {...error...}}``, so this
-                        # outer-``status`` check silently recorded "success"
-                        # for a failed catalog dispatch (the #3429 arc's
-                        # measurement that broadened this issue's scope).
-                        # dispatch_tool now promotes any handler-declared
-                        # error to this SAME outer ``status`` before ``r``
-                        # is ever built, so checking it here is both simpler
-                        # and correct: ``r["status"]`` is trustworthy for
-                        # every catalog dispatch outcome, not just
-                        # dispatch_tool's own pre-dispatch synthetic errors.
-                        _rd_outcome = "error" if (
-                            isinstance(r, dict) and r.get("status") == "error"
-                        ) else "success"
-                        host.events.emit(
-                            "routing_decided",
-                            action_name=_rd_action,
-                            source=_rd_source,
-                            outcome=_rd_outcome,
-                            chain_id=self.chain_id,
-                        )
-                        _routing_decided_fired = True  # B28-Q2: track for inline exclusivity
+                # #3455: routing_decided is no longer emitted here. It used to
+                # live in this loop, gated on ``if _univ_enabled:`` — which
+                # meant the DEFAULT configuration (universal wrappers off,
+                # flat bare-name tools=) never emitted it at all, even though
+                # catalog routing was happening on every dispatched call. The
+                # emit is now inside ``_dispatch_resolved`` (the #3429-census
+                # chokepoint every dispatch funnels through — invoke_action,
+                # bare hot-list alias, ARS-salvaged direct call, and the flat
+                # bare-name path alike), so coverage is structural rather than
+                # a property of which entry surface the model happened to
+                # use. ``self._routing_decided_this_turn`` (set there) is the
+                # B28-Q2 inline-exclusivity flag consumed below.
                 # #1608: the active scheme builds the appendable message sequence
                 # (assistant tool-call turn + per-result {role:tool, tool_call_id}
                 # messages + media follow-ups) AND persists each to history; the OS
@@ -2414,7 +2360,7 @@ class RouterLoop:
             # B28-Q2 Case A: emit chat_turn_completed_inline when no catalog
             # dispatch happened in this turn (= routing_decided never fired).
             # Mutually exclusive with routing_decided per turn (P6 audit).
-            if _univ_enabled and not _routing_decided_fired:
+            if _univ_enabled and not self._routing_decided_this_turn:
                 host.events.emit(
                     "chat_turn_completed_inline",
                     chain_id=self.chain_id,
@@ -2837,26 +2783,46 @@ class RouterLoop:
         and dispatch via the wrapper path so the user-visible behavior
         matches what the LLM intended.
         """
-        name, args = self._resolve_tool_call(tc)
+        name, args, raw_name = self._resolve_tool_call(tc)
 
         excluded = self._excluded_result(name, args)
         if excluded is not None:
+            # #3455: a pre-dispatch exclude IS a routing decision (the
+            # decision was "deny") — it never reaches ``_dispatch_resolved``,
+            # so its own emit call there would silently drop this outcome.
+            # Matches the pre-#3455 behavior (the old run_loop-local emit
+            # iterated ALL tool_results, excluded ones included).
+            self._emit_routing_decided(name, args, excluded, raw_name=raw_name)
             return excluded
-        return await self._dispatch_resolved(name, args)
+        return await self._dispatch_resolved(name, args, raw_name=raw_name)
 
-    def _resolve_tool_call(self, tc: dict) -> "tuple[str, dict]":
-        """#1593: name + args + #229 salvage → the effective ``(name, args)``.
+    def _resolve_tool_call(self, tc: dict) -> "tuple[str, dict, str]":
+        """#1593: name + args + #229 salvage → the effective ``(name, args)``,
+        plus (#3455) the ``raw_name`` the model actually called BEFORE any
+        salvage rewrite.
 
         **Resolution only** (no dispatch), so the scheme's ``interpret`` runs it and
         the OS exclude-gates the result BEFORE ``execute`` — preserving the #1406/#187
-        pre-dispatch order across the scheme split (byte-identical)."""
+        pre-dispatch order across the scheme split (byte-identical).
+
+        #3455: ``raw_name`` is threaded through to ``_dispatch_resolved`` so
+        ``routing_decided``'s ``source`` classification keeps reading "which
+        surface did the MODEL use" (invoke_action / a bare name) rather than
+        "what name did dispatch end up running" — the #229 salvage rewrites
+        an un-advertised bare call's EFFECTIVE name/args to ``invoke_action``
+        internally, but that rewrite is an OS routing mechanic, not a change
+        in what the model did. Losing this distinction would silently
+        reclassify every existing ``"ars_direct"``-labeled call as
+        ``"invoke_action"`` the moment the emit moved to the resolved
+        chokepoint — the #241 discriminator would break value, not shape."""
         from reyn.tools.universal_catalog import strip_provider_tool_namespace  # noqa: PLC0415
 
         # #1989: a weak model (Gemini) may echo its function-calling namespace
         # onto the call name (``default_api.invoke_action`` /
         # ``default_api.web_search``). Strip it FIRST so the catalog membership +
         # the salvage below see the plain name. Safe: reyn names are dot-free.
-        name = strip_provider_tool_namespace(tc["function"]["name"])
+        raw_name = strip_provider_tool_namespace(tc["function"]["name"])
+        name = raw_name
         try:
             args = json.loads(tc["function"]["arguments"])
         except (json.JSONDecodeError, KeyError):
@@ -2864,7 +2830,7 @@ class RouterLoop:
 
         if name not in self._catalog:
             name, args = self._maybe_salvage_action_direct_call(name, args)
-        return name, args
+        return name, args, raw_name
 
     def _excluded_result(self, name: str, args: dict) -> "dict | None":
         """#1406/#187: the **pre-dispatch** exclude gate. Returns the
@@ -2912,7 +2878,9 @@ class RouterLoop:
                 }
         return None
 
-    async def _dispatch_resolved(self, name: str, args: dict) -> dict:
+    async def _dispatch_resolved(
+        self, name: str, args: dict, *, raw_name: "str | None" = None,
+    ) -> dict:
         """#1593: dispatch a resolved, exclude-cleared tool call via the OS substrate
         (DispatchContext / ``dispatch_tool`` — P5). The pure-OS dispatch
         half of the former ``_execute_tool``; the scheme's ``execute`` orchestrates
@@ -2924,7 +2892,17 @@ class RouterLoop:
         ``self._catalog`` (universal / enumerate / retrieval, where dispatchable =
         advertised — byte-identical). CodeAct advertises ∅ but dispatches the full
         catalog, so its gate must key on the dispatchable set, not the empty mirror
-        (the #7 "not in catalog" root)."""
+        (the #7 "not in catalog" root).
+
+        #3455: ``raw_name`` (optional) is the name the MODEL literally called,
+        before the #229 salvage rewrite — see ``_resolve_tool_call``. This is
+        the single chokepoint EVERY dispatch funnels through (native
+        Execute-round calls via ``resolve()``/``dispatch()``, the direct
+        ``_execute_tool`` test seam, and the CodeAct in-snippet ``tool()``
+        call via ``_run_codeblock_round``'s ``_os_gate`` — the latter has no
+        separate "raw" surface, so it omits ``raw_name`` and
+        ``_emit_routing_decided`` falls back to ``name``), which is what
+        makes it the right place for ``routing_decided`` (#3455)."""
         catalog = (
             self._dispatch_catalog
             if self._dispatch_catalog is not None
@@ -2951,7 +2929,74 @@ class RouterLoop:
         # source takes the deepest); a direct call has only this outer tag = the named tool.
         if isinstance(result, dict):
             result.setdefault("_canonical_source", name)
+        self._emit_routing_decided(name, args, result, raw_name=raw_name)
         return result
+
+    def _emit_routing_decided(
+        self, name: str, args: dict, result: Any, *, raw_name: "str | None" = None,
+    ) -> None:
+        """#3455: emit ``routing_decided`` at the chokepoint EVERY catalog
+        dispatch funnels through (``_dispatch_resolved`` — the #3429 census
+        finding that ``dispatch_tool`` is called from exactly this one
+        call site plus the CodeAct ``tool()`` unwrap, both of which route
+        here). Structural fix, not a widened gate: this replaces the prior
+        ``run_loop``-local emit that lived inside ``if _univ_enabled:`` —
+        a guard keyed on which ENTRY SURFACE the model used (the
+        ``invoke_action`` wrapper), not on whether routing actually
+        happened. The default configuration
+        (``universal_wrappers_enabled=False`` → flat bare-name ``tools=``)
+        never advertises ``invoke_action`` at all, so that guard silently
+        zeroed out ``routing_decided`` for the default path even though
+        every one of its tool calls dispatches a catalog action right here.
+
+        ``surface`` (``raw_name`` if given, else ``name``) is what the model
+        actually called, BEFORE the #229 salvage rewrite. This matters
+        because the salvage rewrites an un-advertised bare call's EFFECTIVE
+        ``(name, args)`` to ``invoke_action`` internally — a routing
+        mechanic, not something the model did — so classifying off the
+        POST-salvage ``name`` would relabel every existing
+        ``"ars_direct"`` call as ``"invoke_action"``, silently changing the
+        #241 discriminator's meaning the moment the emit moved here.
+
+        Source classification (unchanged from the relocated logic):
+          - ``"invoke_action"``: the model called the universal wrapper;
+            the real action name is nested in ``args["action_name"]``.
+          - ``"hot_list_alias"``: a bare catalog-action name that was
+            actually advertised in ``tools=`` (#241).
+          - ``"ars_direct"``: a bare catalog-action name NOT advertised —
+            reached only via the #229/#3429 salvage.
+          - anything else (e.g. ``delegate_to_agent``, an async peer tool):
+            not a catalog action — no routing decision to record.
+        """
+        surface = raw_name if raw_name is not None else name
+        if surface == "invoke_action":
+            action_name = (
+                args.get("action_name", "") if isinstance(args, dict) else ""
+            )
+            source = "invoke_action"
+        elif surface in _KNOWN_ACTION_NAMES:
+            action_name = surface
+            source = "hot_list_alias" if surface in self._catalog else "ars_direct"
+        else:
+            return  # non-catalog tool — no routing decision to record
+        if not action_name:
+            return
+        # #3450: derive from the SAME source as the LLM-visible envelope —
+        # dispatch_tool's own outer ``status`` field, which now promotes any
+        # handler-declared error before ``result`` is ever built (see
+        # dispatcher.py), so this check is trustworthy for every catalog
+        # dispatch outcome.
+        outcome = "error" if (
+            isinstance(result, dict) and result.get("status") == "error"
+        ) else "success"
+        self.host.events.emit(
+            "routing_decided",
+            action_name=action_name,
+            source=source,
+            outcome=outcome,
+            chain_id=self.chain_id,
+        )
+        self._routing_decided_this_turn = True
 
     # ── #1593 SchemeOps adapter ─────────────────────────────────────────────
     # The router IS the ``SchemeOps`` a *delegating* scheme calls. PR-1's
@@ -3101,8 +3146,8 @@ class RouterLoop:
         deduped = self._dedupe_tool_calls_round(llm_response.tool_calls)
         actions: list[dict] = []
         for tc in deduped:
-            name, args = self._resolve_tool_call(tc)
-            actions.append({"tc": tc, "name": name, "args": args})
+            name, args, raw_name = self._resolve_tool_call(tc)
+            actions.append({"tc": tc, "name": name, "args": args, "raw_name": raw_name})
         return actions
 
     async def dispatch(self, actions: list[dict]) -> list[dict]:
@@ -3123,7 +3168,9 @@ class RouterLoop:
         parallel latency for genuinely-independent calls."""
         results: list[dict] = []
         for a in actions:
-            results.append(await self._dispatch_resolved(a["name"], a["args"]))
+            results.append(await self._dispatch_resolved(
+                a["name"], a["args"], raw_name=a.get("raw_name"),
+            ))
         # FP-0050/#1822 S2: tag untrusted-source results by the EFFECTIVE resolved
         # name (``a["name"]``). feedback() iterates the raw tool_calls whose name
         # may be the ``invoke_action`` wrapper, so classifying there would miss
@@ -3457,6 +3504,14 @@ class RouterLoop:
         for i, a in enumerate(actions):
             ex = self._excluded_result(a["name"], a["args"])
             if ex is not None:
+                # #3455: the exclude gate IS a routing decision (outcome
+                # "error") — this action never reaches ``dispatch()`` /
+                # ``_dispatch_resolved``, so its emit call there would never
+                # see it. Mirrors the pre-#3455 behavior (the old run_loop
+                # emit iterated every tool_result, excluded ones included).
+                self._emit_routing_decided(
+                    a["name"], a["args"], ex, raw_name=a.get("raw_name"),
+                )
                 results[i] = ex
             else:
                 to_dispatch.append((i, a))
@@ -3488,6 +3543,12 @@ class RouterLoop:
         async def _os_gate(name: str, args: dict) -> dict:
             excluded = self._excluded_result(name, args)
             if excluded is not None:
+                # #3455: CodeAct's in-snippet ``tool()`` calls previously had
+                # NO routing_decided coverage at all (the old emit only ever
+                # iterated the Execute arm's tool_calls/tool_results). Now
+                # covered symmetrically with the exclude branches above:
+                # the exclude gate is itself a routing decision.
+                self._emit_routing_decided(name, args, excluded)
                 return excluded
             return await self._dispatch_resolved(name, args)
 

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -2250,9 +2250,11 @@ class RouterLoop:
 
                 # #3455: routing_decided is no longer emitted here. It used to
                 # live in this loop, gated on ``if _univ_enabled:`` — which
-                # meant the DEFAULT configuration (universal wrappers off,
-                # flat bare-name tools=) never emitted it at all, even though
-                # catalog routing was happening on every dispatched call. The
+                # meant the opt-out configuration (an operator setting
+                # ``action_retrieval.universal_wrappers_enabled: false`` in
+                # reyn.yaml → flat bare-name ``tools=``, the pre-PR-3b-iv
+                # shape) never emitted it at all, even though catalog routing
+                # was happening on every dispatched call. The
                 # emit is now inside ``_dispatch_resolved`` (the #3429-census
                 # chokepoint every dispatch funnels through — invoke_action,
                 # bare hot-list alias, ARS-salvaged direct call, and the flat
@@ -2943,11 +2945,12 @@ class RouterLoop:
         ``run_loop``-local emit that lived inside ``if _univ_enabled:`` —
         a guard keyed on which ENTRY SURFACE the model used (the
         ``invoke_action`` wrapper), not on whether routing actually
-        happened. The default configuration
-        (``universal_wrappers_enabled=False`` → flat bare-name ``tools=``)
+        happened. The opt-out configuration (an operator setting
+        ``action_retrieval.universal_wrappers_enabled: false`` in
+        reyn.yaml → flat bare-name ``tools=``, the pre-PR-3b-iv shape)
         never advertises ``invoke_action`` at all, so that guard silently
-        zeroed out ``routing_decided`` for the default path even though
-        every one of its tool calls dispatches a catalog action right here.
+        zeroed out ``routing_decided`` for that path even though every one
+        of its tool calls dispatches a catalog action right here.
 
         ``surface`` (``raw_name`` if given, else ``name``) is what the model
         actually called, BEFORE the #229 salvage rewrite. This matters

--- a/tests/test_provider_tool_namespace_strip_1989.py
+++ b/tests/test_provider_tool_namespace_strip_1989.py
@@ -85,9 +85,10 @@ def test_resolve_strips_namespace_so_bare_name_hits_catalog():
     """Tier 2: ``default_api.invoke_action`` as a call NAME → stripped → hits the
     catalog directly (RED pre-#1989 = unknown_tool)."""
     shim = _ResolveShim(catalog={"invoke_action": object()})
-    name, args = shim._resolve_tool_call(_tc("default_api.invoke_action", '{"x": 1}'))
+    name, args, raw_name = shim._resolve_tool_call(_tc("default_api.invoke_action", '{"x": 1}'))
     assert name == "invoke_action"
     assert args == {"x": 1}
+    assert raw_name == "invoke_action"
 
 
 def test_resolve_strips_namespace_then_salvages_action_call_name():
@@ -100,13 +101,14 @@ def test_resolve_strips_namespace_then_salvages_action_call_name():
     carries ``web_search``, so the ``invoke_action`` route this catalog DOES
     advertise is the right target."""
     shim = _ResolveShim(catalog={"invoke_action": object()})
-    name, args = shim._resolve_tool_call(_tc("default_api.web_search", '{"query": "q"}'))
+    name, args, raw_name = shim._resolve_tool_call(_tc("default_api.web_search", '{"query": "q"}'))
     assert name == "invoke_action"
     assert args == {"action_name": "web_search", "args": {"query": "q"}}
+    assert raw_name == "web_search"
 
 
 def test_resolve_bare_name_is_unchanged():
     """Tier 2: a normal bare call name is unaffected (no-op strip)."""
     shim = _ResolveShim(catalog={"invoke_action": object()})
-    name, _ = shim._resolve_tool_call(_tc("invoke_action"))
+    name, _, _ = shim._resolve_tool_call(_tc("invoke_action"))
     assert name == "invoke_action"

--- a/tests/test_router_loop_routing_decided.py
+++ b/tests/test_router_loop_routing_decided.py
@@ -530,3 +530,97 @@ def test_invoke_action_description_has_no_ars_block(monkeypatch: pytest.MonkeyPa
     # The ARS block's headers (public surface the LLM saw) must be absent.
     assert "ACTION ARG SCHEMAS" not in desc
     assert "canonical keys for all session-visible actions" not in desc
+
+
+# ---------------------------------------------------------------------------
+# #3455: coverage-hole fix — routing_decided emitted at the dispatch
+# chokepoint (_dispatch_resolved) regardless of which entry surface the
+# model used, INCLUDING the flat/default bare-name dispatch shape that the
+# prior ``if _univ_enabled:``-gated emit never covered.
+# ---------------------------------------------------------------------------
+
+
+def test_routing_decided_emitted_for_bare_direct_call_when_universal_wrappers_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Tier 2: #3455 — bare-name direct catalog dispatch emits routing_decided
+    even with ``universal_wrappers_enabled=False`` (the DEFAULT reyn.yaml
+    shape: flat bare-name ``tools=``, no ``invoke_action`` wrapper at all).
+
+    This is the actual coverage hole #3455 reports. Before the fix, the
+    emit lived in ``run_loop`` inside ``if _univ_enabled:`` — with wrappers
+    off that whole block was skipped unconditionally, so EVERY catalog
+    dispatch through the flat/default tool shape produced NO
+    ``routing_decided`` event, even though ``dispatch_tool`` ran the exact
+    same real catalog dispatch it always does. The fix relocates the emit
+    into ``_dispatch_resolved`` — the single chokepoint every dispatch
+    (wrapped or bare) funnels through — so coverage no longer depends on
+    which entry surface the model used, or on the ``_univ_enabled`` flag.
+
+    Strip-falsify: commenting out the ``self._emit_routing_decided(...)``
+    call in ``RouterLoop._dispatch_resolved`` turns this RED (0 events)
+    while every other routing_decided test that uses
+    ``universal_wrappers_enabled=True`` stays unaffected — proving this
+    test is the one pinned on the new (previously-uncovered) path.
+    """
+    host = _FakeRouterHost(universal_wrappers_enabled=False)
+    _run_with_llm_sequence(
+        host,
+        [
+            _tool_result([{"name": "list_agents", "args": {"path": "."}}]),
+            _text_result("done"),
+        ],
+        monkeypatch,
+    )
+
+    events = _routing_decided_events(host)
+    (ev,) = events
+    assert ev["action_name"] == "list_agents"
+    assert ev["outcome"] == "success"
+    assert ev["chain_id"] == "chain-test"
+
+
+def test_routing_decided_both_entry_surfaces_no_double_emit(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Tier 2: #3455 intermediate-cut witness — a bare direct call AND an
+    ``invoke_action``-wrapped call in the SAME round both drive
+    ``routing_decided`` through the real dispatch chokepoint, with the
+    correct per-call outcome, and with NO double-emit (2 dispatched tool
+    calls → exactly 2 routing_decided events, not 4 and not 0).
+
+    ``universal_wrappers_enabled=True`` here so both entry surfaces are
+    simultaneously available to the (simulated) model in one round —
+    the flat/default (wrappers-off) coverage is pinned separately above.
+    """
+    host = _FakeRouterHost(universal_wrappers_enabled=True)
+    _run_with_llm_sequence(
+        host,
+        [
+            _tool_result([
+                {"name": "list_agents", "args": {"path": "."}},
+                {
+                    "name": "invoke_action",
+                    "args": {"action_name": "skill_list", "args": {}},
+                },
+            ]),
+            _text_result("done"),
+        ],
+        monkeypatch,
+    )
+
+    events = _routing_decided_events(host)
+    # Behavioral (not a size pin): the MULTISET of action_names emitted must
+    # be exactly one "list_agents" + one "skill_list" — no double-emit (a
+    # dup would surface as a repeated name in this sorted list) and no
+    # missing emit (a drop would surface as a missing name).
+    assert sorted(e["action_name"] for e in events) == ["list_agents", "skill_list"]
+    by_action = {e["action_name"]: e for e in events}
+    # No tracker on this host → list_agents is not advertised as a hot-list
+    # row (same "no tracker" baseline as the existing ars_direct tests
+    # above), so the bare direct call classifies as "ars_direct" — the
+    # #229/#3429 salvage path, not "hot_list_alias".
+    assert by_action["list_agents"]["source"] == "ars_direct"
+    assert by_action["list_agents"]["outcome"] == "success"
+    assert by_action["skill_list"]["source"] == "invoke_action"
+    assert by_action["skill_list"]["outcome"] == "success"

--- a/tests/test_router_loop_routing_decided.py
+++ b/tests/test_router_loop_routing_decided.py
@@ -544,13 +544,15 @@ def test_routing_decided_emitted_for_bare_direct_call_when_universal_wrappers_di
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Tier 2: #3455 — bare-name direct catalog dispatch emits routing_decided
-    even with ``universal_wrappers_enabled=False`` (the DEFAULT reyn.yaml
-    shape: flat bare-name ``tools=``, no ``invoke_action`` wrapper at all).
+    even with ``universal_wrappers_enabled=False`` (the opt-out shape an
+    operator gets from ``action_retrieval.universal_wrappers_enabled: false``
+    in reyn.yaml: flat bare-name ``tools=``, no ``invoke_action`` wrapper at
+    all — the production default, since PR-3b-iv, is actually ``True``).
 
     This is the actual coverage hole #3455 reports. Before the fix, the
     emit lived in ``run_loop`` inside ``if _univ_enabled:`` — with wrappers
     off that whole block was skipped unconditionally, so EVERY catalog
-    dispatch through the flat/default tool shape produced NO
+    dispatch through the flat bare-name tool shape produced NO
     ``routing_decided`` event, even though ``dispatch_tool`` ran the exact
     same real catalog dispatch it always does. The fix relocates the emit
     into ``_dispatch_resolved`` — the single chokepoint every dispatch

--- a/tests/test_serial_tool_dispatch_2344.py
+++ b/tests/test_serial_tool_dispatch_2344.py
@@ -39,7 +39,9 @@ class _OrderedDispatchLoop(RouterLoop):
         self.shared: dict = {"written": False}
         self.trace: list[str] = []
 
-    async def _dispatch_resolved(self, name: str, args: dict) -> dict:
+    async def _dispatch_resolved(
+        self, name: str, args: dict, *, raw_name: "str | None" = None,
+    ) -> dict:
         if name == "write":
             await asyncio.sleep(0)  # yield: under gather the reader runs here, before the write lands
             self.shared["written"] = True
@@ -113,7 +115,9 @@ class _RealEventDispatchLoop(RouterLoop):
         self.shared: dict = {"written": False}
         self.event_log = EventLog()
 
-    async def _dispatch_resolved(self, name: str, args: dict) -> dict:
+    async def _dispatch_resolved(
+        self, name: str, args: dict, *, raw_name: "str | None" = None,
+    ) -> dict:
         async def _invoker(a: dict):
             if name == "write":
                 await asyncio.sleep(0)  # the real await-invoker yield point


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3455

## What

`routing_decided` used to be emitted from a `run_loop`-local block gated on
`if _univ_enabled:`. That guard is a proxy for "did the model use the
`invoke_action` wrapper", not "did routing actually happen" — so any
session with `action_retrieval.universal_wrappers_enabled: false` in
reyn.yaml (the pre-PR-3b-iv shape, still a supported opt-out — the
production **default** has been `true` since PR-3b-iv) never emitted
`routing_decided` at all, even though catalog dispatch ran on every call.

This PR moves the emit to `RouterLoop._dispatch_resolved` — the #3429-census
chokepoint every dispatch funnels through (confirmed: only 3 call sites in
`router_loop.py` call `dispatch_tool`, all via this one method) — plus the
`_excluded_result` pre-dispatch-deny branches (an exclude IS a routing
decision: "this call is rejected", same as before). Source classification
(`invoke_action` / `hot_list_alias` / `ars_direct`) is unchanged in **value**:
the name the model literally called (pre `#229`-salvage) is threaded through
as `raw_name` from `_resolve_tool_call` → `resolve()`/`dispatch()` →
`_dispatch_resolved`, so the salvage rewrite (which internally turns an
un-advertised bare call into an `invoke_action` call) does not silently
relabel existing `"ars_direct"` calls as `"invoke_action"`.

`data` shape is unchanged (`action_name` / `source` / `outcome` / `chain_id`,
same field names, same value vocabulary) — no consumer break, no vocabulary
change, so the `#3437` CI-checked kind gate is untouched.

## Newly-firing classes (the coverage widening this PR causes)

1. **Bare-name direct catalog dispatch under
   `universal_wrappers_enabled: false`** (the actual coverage hole #3455
   reports). Every catalog action call in that configuration previously
   produced zero `routing_decided` events; now it fires with the correct
   `outcome`.
2. **CodeAct in-snippet `tool()` calls** (`_run_codeblock_round`'s
   `_os_gate`) — this scheme arm was NEVER part of the old emit's scope at
   all (the old code only ever zipped over the Execute arm's
   `tool_calls`/`tool_results`). Both the dispatched branch and the
   pre-dispatch exclude-deny branch now emit.

No change to: the Execute-round native tool-call path when
`universal_wrappers_enabled: true` (already covered, values unchanged),
the `#3437` kind vocabulary, or the `#3450` outcome-derivation contract.

## Witness

`tests/test_router_loop_routing_decided.py`:
- `test_routing_decided_emitted_for_bare_direct_call_when_universal_wrappers_disabled`
  — real `RouterLoop.run()` turn, `universal_wrappers_enabled=False`, bare
  direct call → asserts `routing_decided` fires with the correct
  `action_name`/`outcome`/`chain_id`. **RED before the fix** (0 events).
- `test_routing_decided_both_entry_surfaces_no_double_emit` — intermediate-cut
  witness: ONE round with a bare direct call AND an `invoke_action`-wrapped
  call, `universal_wrappers_enabled=True`. Asserts both real paths emit with
  the correct per-call `source`/`outcome`, via a multiset assertion on
  `action_name` (not a bare `len(...) == N` size pin, per the tier-audit
  Tier-4 rule) — proves no double-emit (a dup would show as a repeated name)
  and no drop (a missing name).
- All 6 pre-existing tests in the file still pass unchanged in behavior
  (source/outcome semantics preserved via `raw_name` threading).

**Strip-falsify** (cp-scratch backup/restore, no `git stash`): commenting out
`self._emit_routing_decided(...)` in `_dispatch_resolved` turns 6 tests RED
(0 events). Commenting out the `_run_execute_round` exclude-branch emit
turns `test_routing_decided_outcome_error_on_tool_error` (a pre-existing
test pinning the pre-dispatch-deny → `outcome="error"` path) RED. Both
verified, then restored — confirmed clean (`git diff` empty before final
commit).

## Consumer sweep

- `docs/reference/runtime/events.md` / `.ja.md` — `routing_decided` row
  updated: "when it fires" description + corrected `source`/`outcome` value
  lists (they were already stale relative to code — `"catalog"|"hot_alias"|
  "direct"` / `"dispatched"|"deflected"|"error"` never matched the real
  `"invoke_action"|"hot_list_alias"|"ars_direct"` / `"success"|"error"`
  values; fixed in the same PR since I was already touching this row's
  "when" description).
- `src/reyn/core/events/event_schema.py` — `AUDIT_EVENT_KINDS` comment
  updated (no vocabulary/field change, no `#3437` gate impact).
- Existing tests with `RouterLoop` subclass overrides of `_dispatch_resolved`
  (`test_serial_tool_dispatch_2344.py`) and callers of
  `_resolve_tool_call`/`.resolve()` (`test_provider_tool_namespace_strip_1989.py`)
  updated for the new `raw_name` parameter/3-tuple return — swept, not left
  broken.

## Test plan

- [x] `ruff check src tests` (changed files) — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 0 errors (fixed one Tier-4 `len(...) == N` flag by switching to a multiset value assertion)
- [x] `pytest` (full suite, `-n auto`, from repo root) — 9653 passed, 36 skipped, 0 failed
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] Manual: strip-falsify both new emit call sites, confirmed RED, restored (see Witness section)
- [x] `uv run python -c "import reyn; print(reyn.__file__)"` resolves to this worktree
