### PR TITLE
fold(mcp): fold Path A listing methods onto RouterHostAdapter, drop 5 constructor callbacks — #3447

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -509,52 +509,27 @@ The OS resolves the server's transport, dispatches via `MCPClient.get_prompt` (g
 
 **Prompts have no subscribe concept.** Unlike resources (`mcp_subscribe_resource`/`mcp_unsubscribe_resource`), MCP's `prompts` capability has no server-push notification for a specific prompt's content changing — only the coarser `notifications/prompts/list_changed` (bridged to an EventLog event by `reyn.mcp.message_handler.ReynMCPMessageHandler.on_prompt_list_changed`, independent of this op kind). There is no `mcp_subscribe_prompt` to build.
 
-## Two dispatch paths reach MCP capability, and why they stay separate (#3409)
+## MCP dispatch: discovery lives on the adapter, content/action ops go through `execute_op` (#3409/#3411/#3447)
 
 Tool handlers in `src/reyn/tools/*.py` reach MCP capability by two different routes:
 
-- **Path A** — a handler calls `host.<named method>` (a callback injected into `RouterHostAdapter`). The four discovery methods above — `list_mcp_tools`, `list_mcp_resources`, `list_mcp_resource_templates`, `list_mcp_prompts` — route straight through `MCPGateway` from `RouterHostAdapter`, bypassing `execute_op` entirely.
-- **Path B** — a handler calls `execute_op(TypedIROp, ctx)` directly. The five content/action op kinds documented above — `mcp` (call_tool), `mcp_read_resource`, `mcp_subscribe_resource`, `mcp_unsubscribe_resource`, `mcp_get_prompt` — all go through this path already.
+- **Discovery** (`list_mcp_servers`, `list_mcp_tools`, `list_mcp_resources`, `list_mcp_resource_templates`, `list_mcp_prompts`) — a handler calls `host.mcp_list_*(...)`, where `host` is `RouterHostAdapter` and these are the adapter's OWN methods (#3447 folded them off `Session`, which used to inject each as a constructor-callback — see history below). They route straight through `MCPGateway`, bypassing `execute_op` entirely — these five are declared "no permission gate, no op-kind" in `schemas/models.py` itself (the same file `OP_KIND_MODEL_MAP` lives in): discovering *what's available* is not gated, only reading/calling content is (see "Discovery is NOT gated" above and at `mcp_read_resource`).
+- **Content/action** — a handler calls `execute_op(TypedIROp, ctx)` directly. The five op kinds documented above — `mcp` (call_tool), `mcp_read_resource`, `mcp_subscribe_resource`, `mcp_unsubscribe_resource`, `mcp_get_prompt` — all go through this path.
 
-Typed op kinds for the Path-A methods already exist in `OP_KIND_MODEL_MAP` (see the op-kind table at the top of this doc), and `tools/mcp.py`'s own docstring names `execute_op` as the eventual destination for MCP dispatch. So today's route to the four list methods takes three hops that do not pass through the abstraction (`ToolDefinition.handler` -> `host.list_mcp_*` -> the injected `RouterHostAdapter` callback -> `Session._mcp_list_*`) before reaching the same op layer the other five methods reach directly.
+### The error contract: raise at the gateway seam, catch at the tool-handler boundary
 
-### The measurement
+Both routes now share the same exception discipline: `Cancelled`/`MCPFault` propagate as exceptions out of the `MCPGateway` call and are **not** caught inside `RouterHostAdapter`. The catch happens at the tool-handler boundary in `src/reyn/tools/mcp.py`:
 
-Per-method correspondence table (#3409, AST-verified — not re-derived here, see the issue for the full audit trail):
+- The 5 content/action op kinds never catch at all — an uncaught exception reaches `dispatch_tool`, which promotes it to the outer envelope (`{status: "error", error: {kind, message}}`, #3450/#3478).
+- The 5 discovery methods route every gateway call through `_call_mcp_list` (`tools/mcp.py`), a shared try/except that reproduces the exact `{"error": "cancelled"}` / `{"error": str(exc)}` shape the caller received when the catch lived inside `Session._mcp_list_via_gateway` (pre-#3447). A separate failure mode — an unresolved server config (roster empty / server not configured / config not a dict) — is NOT an exception at all; `RouterHostAdapter._mcp_resolve_server_config` returns it as the same `[{"error": ...}]` sentinel shape as an early return, and `_mcp_list_error` (also `tools/mcp.py`) detects it identically whether it came from config resolution or from `_call_mcp_list`'s catch.
 
-| method | routes via | permission gate | audit emit | error format | `_ephemeral`/pool routing |
-|---|---|---|---|---|---|
-| `_mcp_list_servers` | neither (returns the static configured-server roster) | — | — | — | — |
-| `_mcp_list_tools` | `MCPGateway` direct | none | `mcp_tools_listed` | `{"error": ...}` dict, 5 call sites | Y |
-| `_mcp_list_resources` | `MCPGateway` direct | none | `mcp_resources_listed` | same 5 sites | Y |
-| `_mcp_list_resource_templates` | `MCPGateway` direct | none | `mcp_resource_templates_listed` | same 5 sites | Y |
-| `_mcp_list_prompts` | `MCPGateway` direct | none | `mcp_prompts_listed` | same 5 sites | Y |
-| `_mcp_call_tool` | `execute_op(MCPIROp)` | `PermissionDecl(mcp=[server])` | — (op layer's own concern) | none — raises into the op layer | Y (+ pool context manager) |
-| `_mcp_read_resource` | `execute_op` | same | — | none | Y (+ pool context manager) |
-| `_mcp_subscribe_resource` | `execute_op` | same | — | none | Y |
-| `_mcp_unsubscribe_resource` | `execute_op` | same | — | none | Y |
-| `_mcp_get_prompt` | `execute_op` | same | — | none | Y (+ pool context manager) |
+Architect firm (#3411, 2026-07-29): moving the catch upward is behavior-preserving, not a contract change — no context-manager / audit-emit / pool-teardown step sits between the raise site (inside `MCPGateway`) and either catch position (the old in-`Session` one or the new in-`tools/mcp.py` one).
 
-The four listing methods now share one seam, `Session._mcp_list_via_gateway` — the "error format" and "audit emit" columns above are its behavior, not four independent implementations.
+**Out of scope, by explicit negative acceptance criterion (#3447):** the call-family op kinds (`mcp`, `mcp_read_resource`, `mcp_get_prompt`) were ALREADY unified on the throw contract before this fold and get NO new catch — adding one would change their LLM-visible failure shape (today: `dispatch_tool`'s `Error (kind): message` envelope; a handler-level catch would instead surface as an ok-shaped `{"error": ...}` dict, a real behavior change). "Symmetric with discovery" is not a reason to add one; see #3447 (architect self-correction) for the full reasoning against a shared call-family catch helper.
 
-Two of the five columns are **not** blockers, despite looking like gaps:
+### History: why this used to be two structurally different paths (#3409)
 
-- **Missing permission gate** — by design. `list_tools`/`list_resources`/`list_resource_templates`/`list_prompts` are declared "no permission gate, no op-kind" in `schemas/models.py` itself (the same file `OP_KIND_MODEL_MAP` lives in): discovering *what's available* is not gated, only reading/calling content is (see "Discovery is NOT gated" above and at `mcp_read_resource`).
-- **Audit-emit split** — resolved in #3410: all four listing methods emit (`mcp_tools_listed` / `mcp_resources_listed` / `mcp_resource_templates_listed` / `mcp_prompts_listed`), and the `MCPListingSuppression` registry that declared the earlier asymmetry is gone. The asymmetry had no recorded rationale — that registry said so in its own comment — and closing the audit-event kind vocabulary made it a public-interface question rather than an internal one: two of four sibling discovery calls being invisible to an external consumer is not something a consumer can reason about. Each call site now passes its kind as a string literal, so the vocabulary gate can read it.
-
-### The actual blocker: the error contract, not permission
-
-Path A's four listing methods return `[{"error": ...}]` at five call sites inside `_mcp_list_via_gateway`: no MCP servers configured, the named server not configured, its config not a dict, a `Cancelled` cancellation folded to `{"error": "cancelled"}`, and an `MCPFault` folded to `{"error": str(exc)}`. That list-wrapped dict is the op layer's internal representation — unchanged by #3441. What reaches the tool handler's caller changed: all five `_handle_list_mcp_*` handlers now route through the shared `_mcp_list_error` helper (`tools/mcp.py`, #3441), which detects the sentinel and returns a bare `{"error": ...}` dict instead of the list. That dict is still the value the tool handler returns to the LLM — it is caller-visible, and **LLM-visible**: a model reading `{"error": "cancelled"}` is reading response text, not observing a raised exception. The normalization changes the wire shape (list of one vs. a bare dict), not this section's underlying point — Path A still returns error text as a dict, Path B still raises.
-
-Path B's five `execute_op`-routed methods have none of that. `Cancelled`, `MCPFault`, and everything else propagate as exceptions into the op layer; there is no `{"error": ...}` dict anywhere on that path.
-
-Folding the four listing methods into `execute_op` is therefore not a structural move by itself — it requires first deciding what the *unified* error contract is: the op layer starts returning `list_*`-shaped error dicts, the listing call sites start accepting exceptions, or `execute_op` grows a dual contract. Any of those changes what the LLM receives on a listing failure, which is a **behaviour change**, not a refactor — and behaviour changes are not folded into structural changes (a regression on either axis then has no attribution). That decision is tracked separately as **#3411** and is deliberately out of scope here.
-
-🔴 **This document is accurate only while #3411 is open.** Once #3411 settles which error contract Path A and Path B share, the one blocking asymmetry in the table above closes and folding the four listing methods into `execute_op` becomes a plain structural move — subject to the usual `OP_KIND_MODEL_MAP` <-> `control-ir.md` same-PR sync rule, since the typed op kinds already exist. Re-derive the table above before acting on it once #3411 closes; do not assume the reasoning here still applies unchanged.
-
-### `RouterHostAdapter`'s parameter count is a shadow of this split, not a Parameter-Object problem
-
-This is why `RouterHostAdapter.__init__` carries 10 `mcp_*` callback parameters (out of its ~80 total) instead of one facade: each of the ten methods above needs its own injected callable because none of them is a thin delegate — the table's "error format" and "`_ephemeral`/pool routing" columns are real logic living on the `Session` side of each callback, not a 2-4 line pass-through. Grouping the 80 parameters into a Parameter Object was already measured as a near-no-op on #3121 (54 -> 45 params, 41 left flat) — the width tracks the tools-handler -> host hop counted in this section, not a missing grouping. The falsifiable form of this claim is recorded as a K-inline directly on `RouterHostAdapter.__init__` in `src/reyn/runtime/services/router_host_adapter.py`.
+Before #3447, discovery routed through `Session` callbacks injected into `RouterHostAdapter.__init__` (`mcp_list_servers=self._mcp_list_servers`, etc. — five separate constructor parameters), which is why `RouterHostAdapter.__init__` carried 10 `mcp_*` callback parameters instead of one facade or zero. The five discovery methods shared one seam, `Session._mcp_list_via_gateway`, which — unlike the content/action ops — caught `Cancelled`/`MCPFault` itself and returned `[{"error": ...}]` rather than raising (#3409's "the actual blocker: the error contract, not permission" finding). #3411 settled the error-contract question (raise, matching the content/action ops) once #3443 gave the discovery handlers a shared catch point (`_mcp_list_error`) to normalize the raised exception back into the same wire shape. #3447 did the resulting structural move: the five discovery methods became `RouterHostAdapter`'s own methods (no more `Session`-side implementation, no more constructor callback for these five — the adapter already duplicated the two inputs they needed, `_mcp_servers_flat`/`_get_mcp_servers_for_router`), and the exception catch moved from `Session._mcp_list_via_gateway` to `tools/mcp.py`'s `_call_mcp_list`.
 
 ## `mcp_install`
 

--- a/docs/reference/runtime/session-construction.md
+++ b/docs/reference/runtime/session-construction.md
@@ -472,13 +472,20 @@ Construction is unconditional and cheap — an empty dict until the first
 `get()`.
 
 **Ephemeral routing.** Only the non-ephemeral MCP call sites
-(`_mcp_call_tool` / `_mcp_list_tools`) route through this held-open service.
-An ephemeral session (`self._ephemeral`, set post-construction by the
-registry once spawn mode is known) keeps using the per-call `MCPClientPool`
-instead, so a sub-second-lived spawned session never holds a server
-connection open needlessly. The service is closed at session teardown via
-`aclose_mcp_connections` (`registry.remove_session` / `archive_agent`'s
-main-session path).
+(`Session._mcp_call_tool` and, on `RouterHostAdapter`,
+`mcp_list_servers`/`mcp_list_tools`/`mcp_list_resources`/
+`mcp_list_resource_templates`/`mcp_list_prompts` — #3447 folded the five
+listing methods off `Session` onto the adapter itself, threading this same
+`self._mcp_connection_service` instance through as a raw constructor
+argument) route through this held-open service. An ephemeral session
+(`self._ephemeral`, set post-construction by the registry once spawn mode
+is known — read via a LIVE `ephemeral_fn` callable on the adapter side, not
+a snapshot, for the same reason `session_id`/`ephemeral` are read through
+live providers elsewhere in this doc) keeps using the per-call
+`MCPClientPool` instead, so a sub-second-lived spawned session never holds
+a server connection open needlessly. The service is closed at session
+teardown via `aclose_mcp_connections` (`registry.remove_session` /
+`archive_agent`'s main-session path).
 
 **Deferred lambdas.** Three of the six constructor arguments are lambdas
 that defer resolution to CALL time, because none of the attributes they

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -449,10 +449,11 @@ KIND_EMIT_SEAMS: dict[str, str | None] = {
     # cased here, so it stays visible.
     "_emit": None,
     "_audit": None,
-    # ``Session._mcp_list_via_gateway(..., event_kind=...)`` — the shared MCP
-    # listing seam. The kind rides a keyword and every call site passes a
-    # literal (#3410); before that it was assembled as ``f"mcp_{noun}_listed"``,
-    # which no census could read.
+    # ``RouterHostAdapter._mcp_list_via_gateway(..., event_kind=...)`` — the
+    # shared MCP listing seam (#3447: folded off Session, same function name).
+    # The kind rides a keyword and every call site passes a literal (#3410);
+    # before that it was assembled as ``f"mcp_{noun}_listed"``, which no
+    # census could read.
     "_mcp_list_via_gateway": "event_kind",
 }
 
@@ -571,14 +572,15 @@ DYNAMIC_KIND_EMIT_SITES: tuple[DynamicEmitSite, ...] = (
         ),
     ),
     DynamicEmitSite(
-        module="src/reyn/runtime/session.py",
+        module="src/reyn/runtime/services/router_host_adapter.py",
         function="_mcp_list_via_gateway",
         seam="emit",
         classification="FORWARDER",
         reason=(
-            "The shared MCP listing seam. Registered with ``event_kind`` as its "
-            "kind keyword; all four ``_mcp_list_*`` call sites pass a literal "
-            "(#3410)."
+            "The shared MCP listing seam (#3447: folded off Session onto "
+            "RouterHostAdapter, byte-identical function name/seam). "
+            "Registered with ``event_kind`` as its kind keyword; all four "
+            "gateway-backed ``mcp_list_*`` call sites pass a literal (#3410)."
         ),
     ),
     DynamicEmitSite(

--- a/src/reyn/core/op_runtime/mcp_get_prompt.py
+++ b/src/reyn/core/op_runtime/mcp_get_prompt.py
@@ -12,9 +12,10 @@ completed-or-failed follow-up — mirrors ``mcp_resource_read``/
 
 Discovery (``list_prompts``) is deliberately NOT an op kind here — it mirrors
 ``list_resources``/``list_tools``, which bypass the permission gate + op-kind
-machinery entirely (see ``session.py::_mcp_list_prompts``). Only the
-content-returning get is gated, matching the tools/resources surface's own
-split between ungated `list_*` and gated `call_tool`/`read_resource`.
+machinery entirely (see ``RouterHostAdapter.mcp_list_prompts``, #3447 —
+folded off Session, still no op-kind of its own). Only the content-returning
+get is gated, matching the tools/resources surface's own split between
+ungated `list_*` and gated `call_tool`/`read_resource`.
 
 Prompts have no subscribe concept — out of scope entirely, unlike resources.
 """

--- a/src/reyn/core/op_runtime/mcp_install.py
+++ b/src/reyn/core/op_runtime/mcp_install.py
@@ -188,14 +188,14 @@ async def probe_mcp_server(
     raises, and because the config write is strictly AFTER this probe, nothing gets
     committed. **Transport-uniform**: stdio and remote (http/sse) share this one path —
     ``MCPClient.__aexit__`` owns the transport-appropriate teardown, so the probe never
-    branches on transport (mirrors ``Session._mcp_list_tools``)."""
+    branches on transport (mirrors ``RouterHostAdapter.mcp_list_tools``, #3447)."""
     from reyn.mcp.client import expand_env  # noqa: PLC0415
     from reyn.mcp.gateway import MCPFault, MCPGateway  # noqa: PLC0415
 
     expanded = expand_env(server_entry)
     if not isinstance(expanded, dict):
         return f"server config must be a dict, got {type(expanded).__name__}"
-    # A url-only remote entry defaults to http (mirrors _mcp_list_tools).
+    # A url-only remote entry defaults to http (mirrors mcp_list_tools).
     if "type" not in expanded and expanded.get("url"):
         expanded = {**expanded, "type": "http"}
     gateway = MCPGateway(agent_id=agent_id, cancel_event=cancel_event)

--- a/src/reyn/core/op_runtime/mcp_read_resource.py
+++ b/src/reyn/core/op_runtime/mcp_read_resource.py
@@ -12,9 +12,10 @@ follow-up — mirrors ``mcp_called``/``mcp_completed``/``mcp_failed``).
 Discovery (``list_resources``/``list_resource_templates``) is deliberately
 NOT an op kind here — it mirrors ``list_tools``, which bypasses the
 permission gate + op-kind machinery entirely (see
-``session.py::_mcp_list_resources``). Only the content-returning read is
-gated, matching the tools surface's own split between ungated `list_tools`
-and gated `call_tool`.
+``RouterHostAdapter.mcp_list_resources``, #3447 — folded off Session, still
+no op-kind of its own). Only the content-returning read is gated, matching
+the tools surface's own split between ungated `list_tools` and gated
+`call_tool`.
 
 Subscribe / resources/updated / on_resource_updated (slice ②b) are OUT OF
 SCOPE here.

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -67,27 +67,37 @@ class RouterHostAdapter:
         Async callback ``(path: str) -> dict``.
     file_regenerate_index:
         Async callback ``(*, path, output_path, entry_template, header) -> dict``.
-    mcp_list_servers:
-        Async callback ``() -> list[dict]``.
-    mcp_list_tools:
-        Async callback ``(server: str) -> list[dict]``.
     mcp_call_tool:
         Async callback ``(server: str, tool: str, args: dict) -> dict``.
-    mcp_list_resources:
-        Async callback ``(server: str) -> list[dict]`` (#2597 slice ②a).
-    mcp_list_resource_templates:
-        Async callback ``(server: str) -> list[dict]`` (#2597 slice ②a).
     mcp_read_resource:
         Async callback ``(server: str, uri: str) -> dict`` (#2597 slice ②a).
     mcp_subscribe_resource:
         Async callback ``(server: str, uri: str) -> dict`` (#2597 slice ②b).
     mcp_unsubscribe_resource:
         Async callback ``(server: str, uri: str) -> dict`` (#2597 slice ②b).
-    mcp_list_prompts:
-        Async callback ``(server: str) -> list[dict]`` (#2597 slice ②c).
     mcp_get_prompt:
         Async callback ``(server: str, name: str, arguments: dict | None) -> dict``
         (#2597 slice ②c).
+    mcp_connection_service:
+        The session-owned ``MCPConnectionService`` (or ``None``) — #3447: the
+        adapter's OWN ``mcp_list_servers``/``mcp_list_tools``/``mcp_list_resources``/
+        ``mcp_list_resource_templates``/``mcp_list_prompts`` methods build their
+        ``MCPGateway`` directly (no session callback for the 5 listing methods —
+        they never needed permission-gated ``execute_op`` state, only the same
+        server-config inputs the adapter already duplicates via
+        ``_mcp_servers_flat``/``_get_mcp_servers_for_router``).
+    mcp_agent_id:
+        The session's ``agent_id`` (#3447) — distinct from ``agent_name`` above;
+        threaded raw (identity is immutable for the session lifetime) as the
+        listing methods' gateway pool key (its ``agent_id=`` constructor kwarg;
+        wording kept away from a literal "Gateway(" per the #2813 scanner note
+        below).
+    ephemeral_fn:
+        Zero-arg callable returning the LIVE ``Session._ephemeral`` flag (#3447) —
+        a callable, not a snapshot bool, because ``_ephemeral`` is reassigned
+        post-construction by the registry / pipeline executor (spawn-time flip),
+        mirroring ``live_session_id_fn``'s same staleness hazard. ``None`` (test
+        construction) behaves as never-ephemeral.
     send_to_agent:
         Async callback ``(*, to, request, depth, chain_id) -> None``.
     put_outbox:
@@ -143,24 +153,26 @@ class RouterHostAdapter:
         file_delete: Callable[..., Awaitable[dict]],
         file_regenerate_index: Callable[..., Awaitable[dict]],
         # MCP op callbacks
-        mcp_list_servers: Callable[..., Awaitable[list]],
-        mcp_list_tools: Callable[..., Awaitable[list]],
         mcp_call_tool: Callable[..., Awaitable[dict]],
-        # #2597 slice ②a: resources consumption (list/read/templates) — defaults to
+        # #2597 slice ②a: resources consumption (read/templates) — defaults to
         # None so pre-existing hand-built adapters (tests, other call sites that
         # construct RouterHostAdapter without resources support) stay valid; the
         # mcp_verbs handlers getattr-guard before calling.
-        mcp_list_resources: "Callable[..., Awaitable[list]] | None" = None,
-        mcp_list_resource_templates: "Callable[..., Awaitable[list]] | None" = None,
         mcp_read_resource: "Callable[..., Awaitable[dict]] | None" = None,
         # #2597 slice ②b: resource subscriptions — same None-default /
         # getattr-guard pattern as the ②a resources callbacks above.
         mcp_subscribe_resource: "Callable[..., Awaitable[dict]] | None" = None,
         mcp_unsubscribe_resource: "Callable[..., Awaitable[dict]] | None" = None,
-        # #2597 slice ②c: prompts consumption — same None-default / getattr-guard
-        # pattern as the ②a resources callbacks above. No subscribe analogue.
-        mcp_list_prompts: "Callable[..., Awaitable[list]] | None" = None,
+        # #2597 slice ②c: prompt fetch — same None-default / getattr-guard
+        # pattern as the ②a resources callbacks above.
         mcp_get_prompt: "Callable[..., Awaitable[dict]] | None" = None,
+        # #3447: the 5 mcp_list_* callbacks (servers/tools/resources/
+        # resource_templates/prompts) were folded onto the adapter itself —
+        # see the class docstring's mcp_connection_service/mcp_agent_id/
+        # ephemeral_fn entries. These 3 raw inputs replace them.
+        mcp_connection_service: Any = None,
+        mcp_agent_id: str | None = None,
+        ephemeral_fn: "Callable[[], bool] | None" = None,
         # Action callbacks
         send_to_agent: Callable[..., Awaitable[None]],
         put_outbox: Callable[..., Awaitable[None]],
@@ -423,16 +435,16 @@ class RouterHostAdapter:
         self._file_delete_cb = file_delete
         self._file_regenerate_index_cb = file_regenerate_index
         # MCP callbacks
-        self._mcp_list_servers_cb = mcp_list_servers
-        self._mcp_list_tools_cb = mcp_list_tools
         self._mcp_call_tool_cb = mcp_call_tool
-        self._mcp_list_resources_cb = mcp_list_resources
-        self._mcp_list_resource_templates_cb = mcp_list_resource_templates
         self._mcp_read_resource_cb = mcp_read_resource
         self._mcp_subscribe_resource_cb = mcp_subscribe_resource
         self._mcp_unsubscribe_resource_cb = mcp_unsubscribe_resource
-        self._mcp_list_prompts_cb = mcp_list_prompts
         self._mcp_get_prompt_cb = mcp_get_prompt
+        # #3447: raw inputs for the 5 mcp_list_* methods this adapter now
+        # implements directly (folded off Session — see class docstring).
+        self._mcp_connection_service = mcp_connection_service
+        self._mcp_agent_id = mcp_agent_id
+        self._ephemeral_fn = ephemeral_fn
         # Action callbacks
         self._send_to_agent_cb = send_to_agent
         self._put_outbox_cb = put_outbox
@@ -1567,27 +1579,134 @@ class RouterHostAdapter:
 
     # --- MCP ops ---
 
+    # #3447: the five discovery-only listing methods used to be thin
+    # ``self._mcp_list_*_cb(...)`` delegates onto Session (which held the
+    # gateway-construction / error-catch logic in ``_mcp_list_via_gateway`` /
+    # ``_mcp_resolve_server_config``). They are now the adapter's own
+    # implementation — this is where Path A's fold-into-execute_op lands:
+    # the gateway call RAISES ``Cancelled``/``MCPFault`` instead of catching
+    # them here; the catch moved to ``tools/mcp.py``'s ``_handle_list_mcp_*``
+    # handlers (the existing ``_mcp_list_error`` sentinel-check position).
+    # Architect firm (#3411, 2026-07-29): no context-manager / audit-emit /
+    # pool-teardown step sits between the raise site (inside the gateway
+    # call, below) and either catch position, so moving the catch upward is
+    # behavior-preserving, not a contract change.
+
+    def _mcp_resolve_server_config(self, server: str) -> "list[dict] | dict":
+        """Shared config-resolution step for all five ``mcp_list_*`` methods:
+        look up *server* in the flattened MCP server map and ``expand_env``
+        it. Returns the expanded config dict on success, or a single-error
+        ``[{"error": ...}]`` list (the methods' existing early-return shape,
+        NOT an exception — this is validation, not a gateway-call failure)
+        when the server isn't configured / doesn't resolve to a dict."""
+        servers = self._mcp_servers_flat()
+        if not servers:
+            return [{"error": "no MCP servers configured"}]
+        server_cfg = servers.get(server)
+        if not server_cfg:
+            return [{"error": f"MCP server {server!r} not configured"}]
+
+        from reyn.mcp.client import expand_env
+
+        expanded = expand_env(server_cfg)
+        if not isinstance(expanded, dict):
+            return [{"error": f"MCP server {server!r} config must be a dict"}]
+        if "type" not in expanded and expanded.get("url"):
+            expanded = {**expanded, "type": "http"}
+        return expanded
+
+    async def _mcp_list_via_gateway(
+        self,
+        server: str,
+        expanded: dict,
+        *,
+        gateway_call: "Callable[[Any], Awaitable[list[dict]]]",
+        event_kind: str,
+    ) -> list[dict]:
+        """Shared MCP-listing seam (#3082, folded here #3447): owns gateway
+        construction and the audit emit for all four gateway-backed
+        ``mcp_list_*`` methods (tools / resources / resource_templates /
+        prompts — ``mcp_list_servers`` never reaches this, it has no gateway
+        call). Each caller has already resolved its own *server* config into
+        *expanded* and passes a *gateway_call* closure naming which
+        ``MCPGateway`` listing method to invoke, plus *event_kind* — the
+        audit-event kind this listing emits.
+
+        ``Cancelled``/``MCPFault`` are NOT caught here (#3447) — they
+        propagate to the caller (``tools/mcp.py``'s ``_handle_list_mcp_*``),
+        matching the call-family (``mcp``/``mcp_read_resource``/etc.)
+        exception contract.
+
+        ``event_kind`` is passed as a string LITERAL by every call site and is
+        never assembled here (#3410): a kind the vocabulary gate cannot read
+        as a constant is a kind it cannot check against the closed
+        vocabulary.
+        """
+        from reyn.mcp.gateway import MCPGateway
+
+        ephemeral = self._ephemeral_fn() if self._ephemeral_fn is not None else False
+        # #2421: routed through the MCPGateway seam rather than a raw MCP client — the
+        # seam contains the crash path, so a mid-list server death raises MCPFault
+        # instead of an uncontained BaseExceptionGroup. #2597 S2a: pool only when
+        # non-ephemeral — pooling a sub-second-lived session is pure churn.
+        # (Wording note: keep the class name away from a following "(" — the #2813
+        # completeness scanner reads `MCPGateway\s*\(` as a construction site.)
+        gateway = (
+            MCPGateway(
+                pool=self._mcp_connection_service, agent_id=self._mcp_agent_id,
+                cancel_event=self._cancel_event,
+            )
+            if not ephemeral
+            else MCPGateway(agent_id=self._mcp_agent_id, cancel_event=self._cancel_event)
+        )
+        result = await gateway_call(gateway)
+        self._events.emit(event_kind, server=server, count=len(result))
+        return result
+
     async def mcp_list_servers(self) -> list[dict]:
-        return await self._mcp_list_servers_cb()
+        """Returns the configured MCP server list with descriptions."""
+        return self._get_mcp_servers_for_router()
 
     async def mcp_list_tools(self, server: str) -> list[dict]:
-        return await self._mcp_list_tools_cb(server)
+        """Query the MCP server for its tools list. Discovery-only, NOT
+        permission-gated (no op-kind). Emits ``mcp_tools_listed``."""
+        expanded = self._mcp_resolve_server_config(server)
+        if isinstance(expanded, list):
+            return expanded
+        return await self._mcp_list_via_gateway(
+            server, expanded,
+            gateway_call=lambda gw: gw.list_tools(server, expanded),
+            event_kind="mcp_tools_listed",
+        )
 
     async def mcp_call_tool(self, server: str, tool: str, args: dict) -> dict:
         return await self._mcp_call_tool_cb(server, tool, args)
 
-    # #2597 slice ②a: resources consumption. getattr-guarded callback (None when
-    # not wired) rather than a hard AttributeError — mirrors how mcp_verbs' host
-    # duck-type callers already tolerate missing methods elsewhere.
+    # #2597 slice ②a: resources consumption.
     async def mcp_list_resources(self, server: str) -> list[dict]:
-        if self._mcp_list_resources_cb is None:
-            return [{"error": "mcp resources listing is not wired on this host"}]
-        return await self._mcp_list_resources_cb(server)
+        """Mirrors ``mcp_list_tools`` exactly — discovery-only, NOT
+        permission-gated. Emits ``mcp_resources_listed``."""
+        expanded = self._mcp_resolve_server_config(server)
+        if isinstance(expanded, list):
+            return expanded
+        return await self._mcp_list_via_gateway(
+            server, expanded,
+            gateway_call=lambda gw: gw.list_resources(server, expanded),
+            event_kind="mcp_resources_listed",
+        )
 
     async def mcp_list_resource_templates(self, server: str) -> list[dict]:
-        if self._mcp_list_resource_templates_cb is None:
-            return [{"error": "mcp resource templates listing is not wired on this host"}]
-        return await self._mcp_list_resource_templates_cb(server)
+        """Mirrors ``mcp_list_resources`` (discovery-only, not
+        permission-gated). Empty list is a normal result for a server that
+        registers no templates. Emits ``mcp_resource_templates_listed``."""
+        expanded = self._mcp_resolve_server_config(server)
+        if isinstance(expanded, list):
+            return expanded
+        return await self._mcp_list_via_gateway(
+            server, expanded,
+            gateway_call=lambda gw: gw.list_resource_templates(server, expanded),
+            event_kind="mcp_resource_templates_listed",
+        )
 
     async def mcp_read_resource(self, server: str, uri: str) -> dict:
         if self._mcp_read_resource_cb is None:
@@ -1606,12 +1725,19 @@ class RouterHostAdapter:
             return {"status": "error", "error": "mcp resource unsubscribe is not wired on this host"}
         return await self._mcp_unsubscribe_resource_cb(server, uri)
 
-    # #2597 slice ②c: prompts consumption. Same getattr-guarded-callback
-    # pattern as the ②a resources methods above. No subscribe analogue.
+    # #2597 slice ②c: prompts consumption.
     async def mcp_list_prompts(self, server: str) -> list[dict]:
-        if self._mcp_list_prompts_cb is None:
-            return [{"error": "mcp prompts listing is not wired on this host"}]
-        return await self._mcp_list_prompts_cb(server)
+        """Mirrors ``mcp_list_resources`` exactly (prompts are addressed by
+        name, not URI, but the discovery shape is otherwise identical).
+        Emits ``mcp_prompts_listed``."""
+        expanded = self._mcp_resolve_server_config(server)
+        if isinstance(expanded, list):
+            return expanded
+        return await self._mcp_list_via_gateway(
+            server, expanded,
+            gateway_call=lambda gw: gw.list_prompts(server, expanded),
+            event_kind="mcp_prompts_listed",
+        )
 
     async def mcp_get_prompt(self, server: str, name: str, arguments: dict | None = None) -> dict:
         if self._mcp_get_prompt_cb is None:
@@ -1773,7 +1899,7 @@ class RouterHostAdapter:
             # unwinds correctly.
             try:
                 async with asyncio.timeout(per_server_timeout):
-                    tools = await self._mcp_list_tools_cb(server_name)
+                    tools = await self.mcp_list_tools(server_name)
             except (TimeoutError, asyncio.TimeoutError):
                 return server_name, []
             except Exception:  # noqa: BLE001 — adapter must never raise

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -3818,19 +3818,27 @@ class Session:
             file_write=self._file_write,
             file_delete=self._file_delete,
             file_regenerate_index=self._file_regenerate_index,
-            mcp_list_servers=self._mcp_list_servers,
-            mcp_list_tools=self._mcp_list_tools,
             mcp_call_tool=self._mcp_call_tool,
-            # #2597 slice ②a: resources consumption (list/read/templates).
-            mcp_list_resources=self._mcp_list_resources,
-            mcp_list_resource_templates=self._mcp_list_resource_templates,
+            # #2597 slice ②a: resources consumption (read/templates).
             mcp_read_resource=self._mcp_read_resource,
             # #2597 slice ②b: resource subscriptions.
             mcp_subscribe_resource=self._mcp_subscribe_resource,
             mcp_unsubscribe_resource=self._mcp_unsubscribe_resource,
-            # #2597 slice ②c: prompts consumption (list/get).
-            mcp_list_prompts=self._mcp_list_prompts,
+            # #2597 slice ②c: prompt fetch (get).
             mcp_get_prompt=self._mcp_get_prompt,
+            # #3447: the 5 mcp_list_* callbacks (servers/tools/resources/
+            # resource_templates/prompts) were folded onto the adapter itself
+            # (RouterHostAdapter.mcp_list_*) — it already duplicated
+            # _mcp_servers_flat/_get_mcp_servers_for_router, so only the raw
+            # gateway-identity inputs need threading through, not a callback
+            # per listing method. ``ephemeral_fn`` is a LIVE read (not a
+            # snapshot bool) because ``self._ephemeral`` is reassigned
+            # post-construction by the registry / pipeline_executor_driver
+            # (spawn-time ephemeral flip) — see the ``_spawn_tracker``
+            # construction note above for the same hazard on session_id.
+            mcp_connection_service=self._mcp_connection_service,
+            mcp_agent_id=self._agent.agent_id,
+            ephemeral_fn=lambda: self._ephemeral,
             send_to_agent=self._send_to_agent,
             put_outbox=self._put_outbox,
             append_history=self._append_history,
@@ -7075,132 +7083,26 @@ class Session:
             return out
         return {"error": result.get("error", "regenerate_index failed")}
 
-    async def _mcp_list_servers(self) -> list[dict]:
-        """Returns the configured MCP server list with descriptions."""
-        return self._get_mcp_servers_for_router()
-
-    async def _mcp_list_via_gateway(
-        self,
-        server: str,
-        expanded: dict,
-        *,
-        gateway_call: Callable[[Any], Awaitable[list[dict]]],
-        event_kind: str,
-    ) -> list[dict]:
-        """Shared MCP-listing seam (#3082): owns gateway construction, the
-        ``Cancelled``/``MCPFault`` error contract, and the audit emit for all
-        four ``_mcp_list_*`` methods (tools / resources / resource_templates /
-        prompts). Each caller has already resolved its own *server* config into
-        *expanded* and passes a *gateway_call* closure naming which
-        ``MCPGateway`` listing method to invoke, plus *event_kind* — the
-        audit-event kind this listing emits.
-
-        ``event_kind`` is passed as a string LITERAL by every call site and is
-        never assembled here (#3410 — see the module-level note above
-        ``Session``): a kind the vocabulary gate cannot read as a constant is a
-        kind it cannot check against the closed vocabulary.
-        """
-        # All four listing paths emit — see the #3410 note above the class.
-        from reyn.core.cancellable import Cancelled
-        from reyn.mcp.gateway import MCPFault, MCPGateway
-
-        # #2421: routed through the MCPGateway seam rather than a raw MCP client — the
-        # seam contains the crash path, so a mid-list server death raises MCPFault
-        # instead of an uncontained BaseExceptionGroup. #2597 S2a: pool only when
-        # non-ephemeral — pooling a sub-second-lived session is pure churn.
-        # (Wording note: keep the class name away from a following "(" — the #2813
-        # completeness scanner reads `MCPGateway\s*\(` as a construction site.)
-        gateway = (
-            MCPGateway(
-                pool=self._mcp_connection_service, agent_id=self._agent.agent_id,
-                cancel_event=self._loop_driver.cancel_event,
-            )
-            if not self._ephemeral
-            else MCPGateway(agent_id=self._agent.agent_id, cancel_event=self._loop_driver.cancel_event)
-        )
-        try:
-            result = await gateway_call(gateway)
-        except Cancelled:
-            return [{"error": "cancelled"}]
-        except MCPFault as exc:
-            return [{"error": str(exc)}]
-        self._chat_events.emit(event_kind, server=server, count=len(result))
-        return result
-
-    def _mcp_resolve_server_config(self, server: str) -> "list[dict] | dict":
-        """Shared config-resolution step for all four ``_mcp_list_*``
-        methods: look up *server* in the flattened MCP server map and
-        ``expand_env`` it. Returns the expanded config dict on success, or a
-        single-error ``[{"error": ...}]`` list (the four methods' existing
-        early-return shape) when the server isn't configured / doesn't
-        resolve to a dict."""
-        servers = self._mcp_servers_flat()
-        if not servers:
-            return [{"error": "no MCP servers configured"}]
-        server_cfg = servers.get(server)
-        if not server_cfg:
-            return [{"error": f"MCP server {server!r} not configured"}]
-
-        from reyn.mcp.client import expand_env
-
-        expanded = expand_env(server_cfg)
-        if not isinstance(expanded, dict):
-            return [{"error": f"MCP server {server!r} config must be a dict"}]
-        if "type" not in expanded and expanded.get("url"):
-            expanded = {**expanded, "type": "http"}
-        return expanded
-
-    async def _mcp_list_tools(self, server: str) -> list[dict]:
-        """Query the MCP server for its tools list.
-
-        Discovery-only, NOT permission-gated (no op-kind), routed through the
-        shared ``_mcp_list_via_gateway`` seam. Emits ``mcp_tools_listed``
-        (#3410 — all four listing paths emit; see the note above ``Session``).
-        """
-        expanded = self._mcp_resolve_server_config(server)
-        if isinstance(expanded, list):
-            return expanded
-        return await self._mcp_list_via_gateway(
-            server, expanded,
-            gateway_call=lambda gw: gw.list_tools(server, expanded),
-            event_kind="mcp_tools_listed",
-        )
-
-    async def _mcp_list_resources(self, server: str) -> list[dict]:
-        """Query the MCP server for its resources list.
-
-        #2597 slice ②a: mirrors ``_mcp_list_tools`` exactly — discovery-only,
-        NOT permission-gated (no op-kind), routed through the same
-        ``MCPGateway`` seam (held connection service on a non-ephemeral
-        session, one-shot pool otherwise). Emits ``mcp_resources_listed`` for
-        observability (#3410 — all four listing paths emit; see the note
-        above ``Session``).
-        """
-        expanded = self._mcp_resolve_server_config(server)
-        if isinstance(expanded, list):
-            return expanded
-        return await self._mcp_list_via_gateway(
-            server, expanded,
-            gateway_call=lambda gw: gw.list_resources(server, expanded),
-            event_kind="mcp_resources_listed",
-        )
-
-    async def _mcp_list_resource_templates(self, server: str) -> list[dict]:
-        """Query the MCP server for its resource templates list.
-
-        #2597 slice ②a: mirrors ``_mcp_list_resources`` (discovery-only, not
-        permission-gated). Empty list is a normal result for a server that
-        registers no templates. Emits ``mcp_resource_templates_listed``
-        (#3410 — all four listing paths emit; see the note above ``Session``).
-        """
-        expanded = self._mcp_resolve_server_config(server)
-        if isinstance(expanded, list):
-            return expanded
-        return await self._mcp_list_via_gateway(
-            server, expanded,
-            gateway_call=lambda gw: gw.list_resource_templates(server, expanded),
-            event_kind="mcp_resource_templates_listed",
-        )
+    # #3447: the five discovery-only mcp_list_* methods (servers / tools /
+    # resources / resource_templates / prompts) FOLDED onto RouterHostAdapter —
+    # see ``RouterHostAdapter._mcp_list_via_gateway`` /
+    # ``RouterHostAdapter._mcp_resolve_server_config`` /
+    # ``RouterHostAdapter.mcp_list_*``. Unlike the call-family methods below
+    # (read/subscribe/unsubscribe/get_prompt/call_tool), the listing methods
+    # never touched permission-gated ``execute_op`` state Session alone
+    # holds — the adapter already duplicated the two inputs they needed
+    # (``_mcp_servers_flat`` / ``_get_mcp_servers_for_router``), so moving the
+    # gateway-calling logic there too let the corresponding 5 constructor
+    # callbacks (``mcp_list_servers`` / ``mcp_list_tools`` /
+    # ``mcp_list_resources`` / ``mcp_list_resource_templates`` /
+    # ``mcp_list_prompts``) drop from ``RouterHostAdapter.__init__`` entirely
+    # (#3409's "17 callbacks" constructor-width finding). The op layer now
+    # RAISES ``Cancelled``/``MCPFault`` instead of catching them locally; the
+    # catch moved to ``tools/mcp.py``'s ``_handle_list_mcp_*`` handlers, at
+    # the same position the ``_mcp_list_error`` sentinel-check already sat —
+    # architect firm (#3411, 2026-07-29): no context-manager / audit-emit /
+    # pool-teardown sits between the raise site and either catch position, so
+    # this is behavior-preserving, not a contract change.
 
     async def _mcp_read_resource(self, server: str, uri: str) -> dict:
         """Read one MCP resource by URI and return its contents.
@@ -7300,23 +7202,8 @@ class Session:
         ctx.mcp_connection_service = self._mcp_connection_service
         return await execute_op(op, ctx)
 
-    async def _mcp_list_prompts(self, server: str) -> list[dict]:
-        """Query the MCP server for its prompts list.
-
-        #2597 slice ②c: mirrors ``_mcp_list_resources`` exactly — discovery-only,
-        NOT permission-gated (no op-kind), routed through the same
-        ``MCPGateway`` seam (held connection service on a non-ephemeral
-        session, one-shot pool otherwise). Emits ``mcp_prompts_listed`` for
-        observability, same rationale as ``mcp_resources_listed``.
-        """
-        expanded = self._mcp_resolve_server_config(server)
-        if isinstance(expanded, list):
-            return expanded
-        return await self._mcp_list_via_gateway(
-            server, expanded,
-            gateway_call=lambda gw: gw.list_prompts(server, expanded),
-            event_kind="mcp_prompts_listed",
-        )
+    # #3447: _mcp_list_prompts folded onto RouterHostAdapter.mcp_list_prompts —
+    # see the note above ``_mcp_read_resource``.
 
     async def _mcp_get_prompt(self, server: str, name: str, arguments: "dict | None" = None) -> dict:
         """Fetch one rendered MCP prompt by name and return its messages.

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -833,7 +833,8 @@ OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     "mcp":         MCPIROp,
     # #2597 slice ②a: resources consumption — read is permission-gated (external
     # content); list/list-templates stay op-kind-free, mirroring list_tools (see
-    # op_runtime/mcp_read_resource.py + session.py's _mcp_list_resources).
+    # op_runtime/mcp_read_resource.py + RouterHostAdapter.mcp_list_resources,
+    # #3447 — folded off Session, still no op-kind of its own).
     "mcp_read_resource": MCPReadResourceIROp,
     # #2597 slice ②b: resource subscriptions — subscribe/unsubscribe are
     # permission-gated the same way read is (stateful action against the
@@ -843,7 +844,8 @@ OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     "mcp_unsubscribe_resource": MCPUnsubscribeResourceIROp,
     # #2597 slice ②c: prompts consumption — get is permission-gated (external
     # content); list stays op-kind-free, mirroring list_tools/list_resources (see
-    # op_runtime/mcp_get_prompt.py + session.py's _mcp_list_prompts).
+    # op_runtime/mcp_get_prompt.py + RouterHostAdapter.mcp_list_prompts, #3447 —
+    # folded off Session, still no op-kind of its own).
     "mcp_get_prompt": MCPGetPromptIROp,
     "ask_user":    AskUserIROp,
     # FP-0054 PR-A: present bulk data + a declarative view to the user surface

--- a/src/reyn/tools/mcp.py
+++ b/src/reyn/tools/mcp.py
@@ -59,7 +59,7 @@ is handled by the caller per ADR-0026 M3 wave pattern.
 from __future__ import annotations
 
 import copy
-from typing import TYPE_CHECKING, Any, Final, Mapping
+from typing import TYPE_CHECKING, Any, Awaitable, Final, Mapping
 
 from reyn.tools.descriptions import mcp as _mcp_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
@@ -268,17 +268,51 @@ def _mcp_list_error(result: "list | None") -> "str | None":
     """Detect the shared MCP-listing failure sentinel and return its message,
     or None when *result* is a normal listing.
 
-    All five ``list_mcp_*`` discovery paths (servers / tools / resources /
-    resource_templates / prompts) can fail without raising: a Cancelled /
-    MCPFault error, or an unresolved server config, comes back as a single-
-    element ``[{"error": "..."}]`` list rather than an exception (see
-    ``Session._mcp_list_via_gateway`` / ``_mcp_resolve_server_config``).
-    Surface MCP-layer errors so the LLM can diagnose the failure instead of
-    seeing an empty (or one-entry, error-shaped) list with no explanation.
+    An unresolved server config (roster empty / server not configured /
+    config not a dict) comes back as a single-element ``[{"error": "..."}]``
+    list rather than an exception (see
+    ``RouterHostAdapter._mcp_resolve_server_config``) — that is validation,
+    not a gateway-call failure, so it stays an early-return sentinel rather
+    than a raise. Surface MCP-layer errors so the LLM can diagnose the
+    failure instead of seeing an empty (or one-entry, error-shaped) list
+    with no explanation.
+
+    #3447: the *gateway-call* failure (``Cancelled``/``MCPFault``) used to
+    ALSO reach this sentinel shape, caught inside
+    ``Session._mcp_list_via_gateway``. That catch moved to each
+    ``_handle_list_mcp_*`` call site below (folded into
+    ``RouterHostAdapter``'s own listing methods, which now let the two
+    exceptions propagate) — see ``_call_mcp_list`` just below.
     """
     if result and isinstance(result[0], Mapping) and "error" in result[0]:
         return result[0]["error"]
     return None
+
+
+async def _call_mcp_list(host_call: "Awaitable[list]") -> "list | dict":
+    """Shared catch point (#3447) for the four gateway-backed
+    ``mcp_list_*`` host methods (tools / resources / resource_templates /
+    prompts — ``mcp_list_servers`` never raises, it has no gateway call).
+
+    ``RouterHostAdapter.mcp_list_*`` now let ``Cancelled``/``MCPFault``
+    propagate (folded off ``Session._mcp_list_via_gateway``'s former
+    in-place catch — architect firm, #3411: no context-manager / audit-emit
+    / pool-teardown step sits between the raise site and either catch
+    position, so moving the catch here is behavior-preserving). Catching
+    here reproduces the exact byte-identical ``{"error": "cancelled"}`` /
+    ``{"error": str(exc)}`` shape the caller previously received as a
+    return value, so every ``_handle_list_mcp_*`` handler below stays
+    unchanged past this point.
+    """
+    from reyn.core.cancellable import Cancelled
+    from reyn.mcp.gateway import MCPFault
+
+    try:
+        return await host_call
+    except Cancelled:
+        return [{"error": "cancelled"}]
+    except MCPFault as exc:
+        return [{"error": str(exc)}]
 
 
 async def _handle_list_mcp_servers(
@@ -326,7 +360,7 @@ async def _handle_list_mcp_tools(
     """
     host = _require_host(ctx)
     server = str(args["server"])
-    result = await host.mcp_list_tools(server)
+    result = await _call_mcp_list(host.mcp_list_tools(server))
     error = _mcp_list_error(result)
     if error is not None:
         # An error envelope, returned as-is: no key the caller could mistake
@@ -360,7 +394,7 @@ async def _handle_list_mcp_resources(
     """
     host = _require_host(ctx)
     server = str(args["server"])
-    result = await host.mcp_list_resources(server)
+    result = await _call_mcp_list(host.mcp_list_resources(server))
     error = _mcp_list_error(result)
     if error is not None:
         return {"error": error}
@@ -375,7 +409,7 @@ async def _handle_list_mcp_resource_templates(
     templates registered), not an error."""
     host = _require_host(ctx)
     server = str(args["server"])
-    result = await host.mcp_list_resource_templates(server)
+    result = await _call_mcp_list(host.mcp_list_resource_templates(server))
     error = _mcp_list_error(result)
     if error is not None:
         return {"error": error}
@@ -437,7 +471,7 @@ async def _handle_list_mcp_prompts(
     """
     host = _require_host(ctx)
     server = str(args["server"])
-    result = await host.mcp_list_prompts(server)
+    result = await _call_mcp_list(host.mcp_list_prompts(server))
     error = _mcp_list_error(result)
     if error is not None:
         return {"error": error}

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -29,14 +29,6 @@ async def null_file_regen(*, path, output_path, entry_template, header) -> dict:
     return {"path": path, "output_path": output_path, "entries": 0}
 
 
-async def null_mcp_list_servers() -> list:
-    return []
-
-
-async def null_mcp_list_tools(server: str) -> list:
-    return []
-
-
 async def null_mcp_call_tool(server: str, tool: str, args: dict) -> dict:
     return {}
 
@@ -138,8 +130,6 @@ def make_adapter(
         file_write=null_file_write,
         file_delete=null_file_delete,
         file_regenerate_index=null_file_regen,
-        mcp_list_servers=null_mcp_list_servers,
-        mcp_list_tools=null_mcp_list_tools,
         mcp_call_tool=null_mcp_call_tool,
         send_to_agent=null_send_to_agent,
         put_outbox=null_put_outbox,

--- a/tests/test_2597_s2b_mcp_notifications_bridge.py
+++ b/tests/test_2597_s2b_mcp_notifications_bridge.py
@@ -44,10 +44,6 @@ async def _null_file_regen(*, path, output_path, entry_template, header) -> dict
     return {"path": path, "output_path": output_path, "entries": 0}
 
 
-async def _null_mcp_list_servers() -> list:
-    return []
-
-
 async def _null_send_to_agent(*, to, request, depth, chain_id) -> None:
     pass
 
@@ -81,7 +77,7 @@ def _make_adapter(*, tmp_path: Path, events: EventLog) -> RouterHostAdapter:
         file_delete=_null_file_delete,
         file_regenerate_index=_null_file_regen,
     )
-    return RouterHostAdapter(
+    adapter = RouterHostAdapter(
         agent_name="test-agent",
         agent_role="test",
         output_language="en",
@@ -99,8 +95,6 @@ def _make_adapter(*, tmp_path: Path, events: EventLog) -> RouterHostAdapter:
         file_write=_null_file_write,
         file_delete=_null_file_delete,
         file_regenerate_index=_null_file_regen,
-        mcp_list_servers=_null_mcp_list_servers,
-        mcp_list_tools=_probe,
         mcp_call_tool=_null_mcp_call_tool,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
@@ -109,6 +103,10 @@ def _make_adapter(*, tmp_path: Path, events: EventLog) -> RouterHostAdapter:
         agent_replies_tracker=lambda: None,
         state_dir=tmp_path / "state",
     )
+    # #3447: mcp_list_tools is now a real RouterHostAdapter method — see the
+    # same-shaped note in test_mcp_lazy_tools_cache.py's _make_adapter_with_mcp.
+    adapter.mcp_list_tools = _probe
+    return adapter
 
 
 # ── (a) real server-pushed tools/list_changed -> event + cache invalidation ────────

--- a/tests/test_3441_list_mcp_servers_error_surface.py
+++ b/tests/test_3441_list_mcp_servers_error_surface.py
@@ -114,6 +114,20 @@ class _ToolsHost:
         return self._result
 
 
+class _RaisingToolsHost:
+    """#3447: RouterHostAdapter.mcp_list_tools now RAISES Cancelled/MCPFault
+    instead of catching them and returning ``[{"error": ...}]`` — this Fake
+    host reproduces that raise contract so the test below exercises the
+    ACTUAL catch point (``_call_mcp_list`` in tools/mcp.py), not just the
+    ``_mcp_list_error`` sentinel-detection helper (already covered above)."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    async def mcp_list_tools(self, server: str):
+        raise self._exc
+
+
 class _ResourcesHost:
     def __init__(self, result):
         self._result = result
@@ -183,6 +197,34 @@ def test_list_mcp_tools_normal_result_still_rewrites_names():
     result = _run(_handle_list_mcp_tools({"server": "web-search"}, _tool_ctx(host)))
 
     assert [t["name"] for t in result["mcp_tools"]] == ["web-search__search"]
+
+
+def test_list_mcp_tools_cancelled_raise_still_surfaces_as_error_dict():
+    """Tier 2: #3447 behavior-preservation witness — RouterHostAdapter.mcp_list_tools
+    now RAISES Cancelled instead of returning ``[{"error": "cancelled"}]``
+    (the op-layer-throws fold). The LLM-visible shape must be UNCHANGED: this
+    exercises the real catch point, ``_call_mcp_list`` (tools/mcp.py), and
+    pins that it still produces the same ``{"error": "cancelled"}`` dict the
+    pre-fold in-Session catch used to."""
+    from reyn.core.cancellable import Cancelled
+
+    host = _RaisingToolsHost(Cancelled())
+    result = _run(_handle_list_mcp_tools({"server": "web-search"}, _tool_ctx(host)))
+
+    assert result == {"error": "cancelled"}
+
+
+def test_list_mcp_tools_mcpfault_raise_still_surfaces_as_error_dict():
+    """Tier 2: #3447 behavior-preservation witness — same as the Cancelled
+    case above but for MCPFault, the gateway's own fault-containment
+    exception. Pins ``{"error": str(exc)}``, byte-identical to the pre-fold
+    in-Session catch's return value."""
+    from reyn.mcp.gateway import MCPFault
+
+    host = _RaisingToolsHost(MCPFault("connection refused"))
+    result = _run(_handle_list_mcp_tools({"server": "web-search"}, _tool_ctx(host)))
+
+    assert result == {"error": "connection refused"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_3441_list_mcp_servers_error_surface.py
+++ b/tests/test_3441_list_mcp_servers_error_surface.py
@@ -1,14 +1,16 @@
 """Tier 2: #3441 — list_mcp_servers error surface + shared error-detection helper.
 
 Bug (tools/mcp.py): unlike its 4 siblings, ``_handle_list_mcp_servers`` handed the
-LLM ``{"servers": [{"error": "cancelled"}]}`` verbatim on a Session-layer failure
-(Cancelled/MCPFault/unresolved-config — see ``Session._mcp_list_via_gateway`` /
-``_mcp_resolve_server_config``, both of which return the sentinel
-``[{"error": "..."}]`` rather than raising) — a failure disguised as a one-entry
-successful server listing. The other four ``list_mcp_*`` handlers already detected
-this sentinel, but via TWO different implementations (``_handle_list_mcp_tools``
-checked every entry `t` in its name-rewrite loop; the other three checked only
-``result[0]`` with an ``isinstance(..., Mapping)`` guard).
+LLM ``{"servers": [{"error": "cancelled"}]}`` verbatim on an adapter-layer failure
+(unresolved-config — see ``RouterHostAdapter._mcp_resolve_server_config``, which
+returns the sentinel ``[{"error": "..."}]`` rather than raising; #3447 additionally
+moved the Cancelled/MCPFault catch for a gateway-call failure up to
+``_call_mcp_list`` in this same module, reproducing the identical sentinel one
+layer up) — a failure disguised as a one-entry successful server listing. The
+other four ``list_mcp_*`` handlers already detected this sentinel, but via TWO
+different implementations (``_handle_list_mcp_tools`` checked every entry `t` in
+its name-rewrite loop; the other three checked only ``result[0]`` with an
+``isinstance(..., Mapping)`` guard).
 
 Fix: add the missing arm to ``_handle_list_mcp_servers`` AND consolidate all five
 call sites onto one shared helper, ``_mcp_list_error(result)`` — chosen to follow

--- a/tests/test_action_retrieval_wiring.py
+++ b/tests/test_action_retrieval_wiring.py
@@ -69,8 +69,6 @@ def _make_adapter(
         file_write=_noop_callable,
         file_delete=_noop_callable,
         file_regenerate_index=_noop_callable,
-        mcp_list_servers=_noop_callable,
-        mcp_list_tools=_noop_callable,
         mcp_call_tool=_noop_callable,
         send_to_agent=_noop_callable,
         put_outbox=_noop_callable,

--- a/tests/test_agui_reasoning_map_p6a.py
+++ b/tests/test_agui_reasoning_map_p6a.py
@@ -141,7 +141,7 @@ def _mk_host(reasoning_config, *, outbox: list, history: list) -> RouterHostAdap
         agent_workspace_dir=workspace,
         file_read=_noop, file_write=_noop, file_delete=_noop,
         file_regenerate_index=_noop,
-        mcp_list_servers=_noop, mcp_list_tools=_noop, mcp_call_tool=_noop,
+        mcp_call_tool=_noop,
         send_to_agent=_noop,
         put_outbox=lambda msg: outbox.append(msg) or _noop(),
         append_history=lambda msg: history.append(msg),

--- a/tests/test_chat_router_modelspec_kwargs_1654.py
+++ b/tests/test_chat_router_modelspec_kwargs_1654.py
@@ -46,7 +46,7 @@ def _mk_host_with_kwargs():
         journal=None, agent_registry=None,
         agent_workspace_dir=workspace,
         file_read=_noop, file_write=_noop, file_delete=_noop,
-        file_regenerate_index=_noop, mcp_list_servers=_noop, mcp_list_tools=_noop,
+        file_regenerate_index=_noop,
         mcp_call_tool=_noop, send_to_agent=_noop,
         put_outbox=_noop, append_history=_noop,
         delegation_tracker=lambda: [], agent_replies_tracker=lambda: [],

--- a/tests/test_mcp_cache_warm_start.py
+++ b/tests/test_mcp_cache_warm_start.py
@@ -48,10 +48,6 @@ async def _null_file_regen(*, path, output_path, entry_template, header) -> dict
     return {"path": path, "output_path": output_path, "entries": 0}
 
 
-async def _null_mcp_list_servers() -> list:
-    return []
-
-
 async def _null_mcp_call_tool(server: str, tool: str, args: dict) -> dict:
     return {}
 
@@ -111,7 +107,7 @@ def _make_adapter(
         file_delete=_null_file_delete,
         file_regenerate_index=_null_file_regen,
     )
-    return RouterHostAdapter(
+    adapter = RouterHostAdapter(
         agent_name="test-agent",
         agent_role="test",
         output_language="en",
@@ -129,8 +125,6 @@ def _make_adapter(
         file_write=_null_file_write,
         file_delete=_null_file_delete,
         file_regenerate_index=_null_file_regen,
-        mcp_list_servers=_null_mcp_list_servers,
-        mcp_list_tools=probe,
         mcp_call_tool=_null_mcp_call_tool,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
@@ -139,6 +133,10 @@ def _make_adapter(
         agent_replies_tracker=lambda: None,
         state_dir=state_dir,
     )
+    # #3447: mcp_list_tools is now a real RouterHostAdapter method — see the
+    # same-shaped note in test_mcp_lazy_tools_cache.py's _make_adapter_with_mcp.
+    adapter.mcp_list_tools = probe
+    return adapter
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_lazy_tools_cache.py
+++ b/tests/test_mcp_lazy_tools_cache.py
@@ -42,10 +42,6 @@ async def _null_file_regen(*, path, output_path, entry_template, header) -> dict
     return {"path": path, "output_path": output_path, "entries": 0}
 
 
-async def _null_mcp_list_servers() -> list:
-    return []
-
-
 async def _null_mcp_call_tool(server: str, tool: str, args: dict) -> dict:
     return {}
 
@@ -85,7 +81,7 @@ def _make_adapter_with_mcp(
     # FP-0037 S1: pass an empty per-test state_dir so the warm-start path
     # never reads a stale on-disk cache from the project root (.reyn/state/).
     # Each test gets a fresh isolated directory → live probe always runs.
-    return RouterHostAdapter(
+    adapter = RouterHostAdapter(
         agent_name="test-agent",
         agent_role="test",
         output_language="en",
@@ -103,8 +99,6 @@ def _make_adapter_with_mcp(
         file_write=_null_file_write,
         file_delete=_null_file_delete,
         file_regenerate_index=_null_file_regen,
-        mcp_list_servers=_null_mcp_list_servers,
-        mcp_list_tools=mcp_list_tools_cb,
         mcp_call_tool=_null_mcp_call_tool,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
@@ -113,6 +107,15 @@ def _make_adapter_with_mcp(
         agent_replies_tracker=lambda: None,
         state_dir=tmp_path / "state",
     )
+    # #3447: mcp_list_tools is now a real RouterHostAdapter method (folded off
+    # Session's former callback-injected _mcp_list_tools). This test suite's
+    # subject is ensure_mcp_tools_cached()'s OWN caching/parallel/timeout
+    # logic, not the gateway underneath mcp_list_tools — so the probe is
+    # wired the same way any other test double overrides one method on a
+    # real, cheaply-constructed instance: an instance-attribute assignment
+    # shadowing the bound method (real callable, not a mock/patch).
+    adapter.mcp_list_tools = mcp_list_tools_cb
+    return adapter
 
 
 # ── 1. No-server case ──────────────────────────────────────────────────────

--- a/tests/test_mcp_list_tools_finally_close.py
+++ b/tests/test_mcp_list_tools_finally_close.py
@@ -1,16 +1,19 @@
-"""Tier 2: _mcp_list_tools (EPHEMERAL session) closes the MCP client on EVERY exit path + surfaces
+"""Tier 2: mcp_list_tools (EPHEMERAL session) closes the MCP client on EVERY exit path + surfaces
 errors (list crash).
 
-``Session._mcp_list_tools`` routes an EPHEMERAL session's calls through the one-shot ``MCPGateway``
-seam (→ ``MCPClientPool`` → ``MCPClient``, #2421); #2597 S2a's held-open ``MCPConnectionService``
+``RouterHostAdapter.mcp_list_tools`` (#3447: folded off ``Session._mcp_list_tools``, same seam,
+same name, new home) routes an EPHEMERAL session's calls through the one-shot ``MCPGateway`` seam
+(→ ``MCPClientPool`` → ``MCPClient``, #2421); #2597 S2a's held-open ``MCPConnectionService``
 is the NON-ephemeral (persistent/main session) default instead — see
 ``test_2597_s2a_mcp_connection_service.py`` for that path's connection-reuse contract. The one-shot
 pool opens + closes the client in the SAME task on success, error, AND cancellation, and the
-gateway contains any fault into an ``MCPFault`` → the list method returns an ``[{"error": …}]``
-result instead of leaking the SDK's anyio cancel-scope cross-task (the owner-facing
-``list_mcp_tools`` crash). This pins the close-on-error guarantee + same-task affinity + error
-surfacing through the real Session's ephemeral path, with the fake patched where the POOL
-constructs it. No subprocess.
+gateway contains any fault into an ``MCPFault``. #3447 moved the ``Cancelled``/``MCPFault`` CATCH
+off this seam and onto ``tools/mcp.py``'s ``_handle_list_mcp_tools`` (via ``_call_mcp_list``) — so
+``RouterHostAdapter.mcp_list_tools`` itself now RAISES ``MCPFault`` on the error path instead of
+returning an ``[{"error": …}]`` result (architect firm #3411: behavior-preserving at the LLM-visible
+boundary, since the tool handler still reproduces that exact shape one layer up). This test pins the
+close-on-error guarantee + same-task affinity at the ADAPTER seam, with the fake patched where the
+POOL constructs it. No subprocess.
 """
 from __future__ import annotations
 
@@ -21,6 +24,7 @@ import pytest
 
 import reyn.mcp.pool as pool_mod
 from reyn.core.events.state_log import StateLog
+from reyn.mcp.gateway import MCPFault
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
@@ -47,10 +51,12 @@ async def _session(tmp_path) -> Session:
     reg.get_or_load("alice")
     sid = await reg.spawn_session_recorded("alice", presentation_consumer=None, intervention_bridge=None)
     sess = reg.get_session("alice", sid)
-    # #2597 S2a: only an EPHEMERAL session still routes _mcp_list_tools through the
+    # #2597 S2a: only an EPHEMERAL session still routes mcp_list_tools through the
     # one-shot MCPClientPool this test exercises — a persistent session now holds its
     # connection open via MCPConnectionService instead (see
-    # test_2597_s2a_mcp_connection_service.py).
+    # test_2597_s2a_mcp_connection_service.py). #3447: the adapter's ephemeral_fn
+    # reads this LIVE, so flipping it post-construction (as the registry does for a
+    # real spawned session) is still observed correctly.
     sess._ephemeral = True
     return sess
 
@@ -93,7 +99,12 @@ def _install_fake(monkeypatch, sess, *, raises: bool) -> None:
     _FakeMCPClient._next_raises = raises
     monkeypatch.setattr(pool_mod, "MCPClient", _FakeMCPClient)  # where the pool constructs it
     # Supply one configured server so the method reaches the client lifecycle.
-    monkeypatch.setattr(sess, "_mcp_servers_flat", lambda: {"srv": {"command": "fake"}})
+    # #3447: server-config resolution now lives on RouterHostAdapter itself
+    # (its own _mcp_servers_flat, not Session's — the adapter builds the
+    # gateway directly, no more session callback in between).
+    monkeypatch.setattr(
+        sess._router_host, "_mcp_servers_flat", lambda: {"srv": {"command": "fake"}},
+    )
 
 
 @pytest.mark.asyncio
@@ -104,10 +115,12 @@ async def test_list_tools_error_path_still_closes_same_task(tmp_path, monkeypatc
     sess = await _session(tmp_path)
     _install_fake(monkeypatch, sess, raises=True)
 
-    result = await sess._mcp_list_tools("srv")
-
-    assert any("boom from list_tools" in (e.get("error") or "") for e in result), \
-        "the fault is surfaced as an error result (gateway describe_fault), not raised"
+    with pytest.raises(MCPFault) as excinfo:
+        await sess._router_host.mcp_list_tools("srv")
+    assert "boom from list_tools" in str(excinfo.value), (
+        "the fault propagates as MCPFault (#3447: the catch moved to tools/mcp.py's "
+        "_handle_list_mcp_tools, not raised here)"
+    )
     client = _FakeMCPClient.instances[-1]
     assert client.closed is True, "client MUST be closed on the error path (pool __aexit__)"
     assert client.close_task is client.list_task, (
@@ -121,7 +134,7 @@ async def test_list_tools_success_path_closes_and_returns(tmp_path, monkeypatch)
     sess = await _session(tmp_path)
     _install_fake(monkeypatch, sess, raises=False)
 
-    result = await sess._mcp_list_tools("srv")
+    result = await sess._router_host.mcp_list_tools("srv")
 
     assert result == [{"name": "some_tool"}]
     client = _FakeMCPClient.instances[-1]

--- a/tests/test_mcp_yaml_mtime_watch.py
+++ b/tests/test_mcp_yaml_mtime_watch.py
@@ -48,10 +48,6 @@ async def _null_file_regen(*, path, output_path, entry_template, header) -> dict
     return {"path": path, "output_path": output_path, "entries": 0}
 
 
-async def _null_mcp_list_servers() -> list:
-    return []
-
-
 async def _null_mcp_call_tool(server: str, tool: str, args: dict) -> dict:
     return {}
 
@@ -139,8 +135,6 @@ def _make_adapter(
         file_write=_null_file_write,
         file_delete=_null_file_delete,
         file_regenerate_index=_null_file_regen,
-        mcp_list_servers=_null_mcp_list_servers,
-        mcp_list_tools=probe,
         mcp_call_tool=_null_mcp_call_tool,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
@@ -561,8 +555,6 @@ async def test_session_handle_user_message_calls_yaml_watch_before_reload(
         file_write=_null_file_write,
         file_delete=_null_file_delete,
         file_regenerate_index=_null_file_regen,
-        mcp_list_servers=_null_mcp_list_servers,
-        mcp_list_tools=probe,
         mcp_call_tool=_null_mcp_call_tool,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,

--- a/tests/test_pipeline_driver_resource_caller_state_2567.py
+++ b/tests/test_pipeline_driver_resource_caller_state_2567.py
@@ -238,14 +238,19 @@ async def test_driver_dispatch_reaches_real_host_mcp_roster(tmp_path: Path) -> N
 def test_pipeline_executor_driver_cancel_event_is_none_not_attributeerror(
     tmp_path: Path,
 ) -> None:
-    """Tier 2: #2813 co-vet catch — Session._mcp_list_tools (and its 3 siblings)
-    read ``self._loop_driver.cancel_event`` unconditionally to thread a Ctrl-C
-    race into MCPGateway. ``PipelineExecutorDriver`` (the OTHER ExecutionDriver
-    implementor, used by driver-sessions born from run_pipeline_async) has no
-    interactive-turn cancel_event concept — before this fix it had no
-    ``cancel_event`` attribute AT ALL, so a driver-session calling any MCP
-    discovery method would AttributeError instead of returning a normal
-    error-list result. Real PipelineExecutorDriver, no mocks."""
+    """Tier 2: #2813 co-vet catch — the 5 gateway-backed ``mcp_list_*``
+    listing methods (#3447: folded onto ``RouterHostAdapter``, formerly
+    ``Session._mcp_list_tools`` and its 3 siblings) unconditionally source a
+    cancel_event to thread a Ctrl-C race into MCPGateway — via
+    ``RouterHostAdapter._cancel_event``, itself wired from
+    ``ExecutionDriver.cancel_event`` (``_set_cancel_event``, called from
+    ``RouterLoopDriver.__init__``). ``PipelineExecutorDriver`` (the OTHER
+    ExecutionDriver implementor, used by driver-sessions born from
+    run_pipeline_async) has no interactive-turn cancel_event concept —
+    before the #2813 fix it had no ``cancel_event`` attribute AT ALL, so a
+    driver-session calling any MCP discovery method would AttributeError
+    instead of returning a normal error-list result. Real
+    PipelineExecutorDriver, no mocks."""
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     reg = _worker_registry(tmp_path, state_log)
     work_order = PipelineWorkOrder(

--- a/tests/test_reasoning_integration_1652.py
+++ b/tests/test_reasoning_integration_1652.py
@@ -51,7 +51,7 @@ def _mk_host(reasoning_config, *, outbox: list, history: list, section: str = ""
         agent_workspace_dir=workspace,
         file_read=_noop, file_write=_noop, file_delete=_noop,
         file_regenerate_index=_noop,
-        mcp_list_servers=_noop, mcp_list_tools=_noop, mcp_call_tool=_noop,
+        mcp_call_tool=_noop,
         send_to_agent=_noop,
         put_outbox=lambda msg: outbox.append(msg) or _noop(),
         append_history=lambda msg: history.append(msg),

--- a/tests/test_router_host_adapter_invariants.py
+++ b/tests/test_router_host_adapter_invariants.py
@@ -63,12 +63,6 @@ from tests._support.router_host_adapter import (
     null_mcp_call_tool as _null_mcp_call_tool,
 )
 from tests._support.router_host_adapter import (
-    null_mcp_list_servers as _null_mcp_list_servers,
-)
-from tests._support.router_host_adapter import (
-    null_mcp_list_tools as _null_mcp_list_tools,
-)
-from tests._support.router_host_adapter import (
     null_put_outbox as _null_put_outbox,
 )
 from tests._support.router_host_adapter import (
@@ -182,8 +176,6 @@ def test_delegation_tracker_appended_on_send_to_agent(tmp_path):
         file_write=_null_file_write,
         file_delete=_null_file_delete,
         file_regenerate_index=_null_file_regen,
-        mcp_list_servers=_null_mcp_list_servers,
-        mcp_list_tools=_null_mcp_list_tools,
         mcp_call_tool=_null_mcp_call_tool,
         send_to_agent=fake_send,
         put_outbox=_null_put_outbox,
@@ -254,8 +246,6 @@ def test_adapter_exposes_permission_resolver_property(tmp_path):
         file_write=_null_file_write,
         file_delete=_null_file_delete,
         file_regenerate_index=_null_file_regen,
-        mcp_list_servers=_null_mcp_list_servers,
-        mcp_list_tools=_null_mcp_list_tools,
         mcp_call_tool=_null_mcp_call_tool,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
@@ -313,8 +303,6 @@ def test_make_router_op_context_wires_intervention_bus(tmp_path):
         file_write=_null_file_write,
         file_delete=_null_file_delete,
         file_regenerate_index=_null_file_regen,
-        mcp_list_servers=_null_mcp_list_servers,
-        mcp_list_tools=_null_mcp_list_tools,
         mcp_call_tool=_null_mcp_call_tool,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
@@ -371,8 +359,6 @@ def test_make_router_op_context_no_factory_leaves_bus_none(tmp_path):
         file_write=_null_file_write,
         file_delete=_null_file_delete,
         file_regenerate_index=_null_file_regen,
-        mcp_list_servers=_null_mcp_list_servers,
-        mcp_list_tools=_null_mcp_list_tools,
         mcp_call_tool=_null_mcp_call_tool,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,

--- a/tests/test_session_refresh_mcp_servers.py
+++ b/tests/test_session_refresh_mcp_servers.py
@@ -326,8 +326,11 @@ async def test_refresh_does_not_raise_on_adapter_failure(
     """
     state_dir = _state_dir(tmp_path)
     # No pre-written disk cache — forces live-probe path (ensure_mcp_tools_cached).
-    # The real mcp_list_tools callback is the session's _mcp_list_tools,
-    # which on error/non-existent server returns [] (= adapter defensive behaviour).
+    # mcp_list_tools is RouterHostAdapter's own method (#3447: folded off
+    # Session's former _mcp_list_tools callback) — ensure_mcp_tools_cached's
+    # _probe_one wraps it in a blanket except-Exception, so on error/
+    # non-existent server the per-server entry is still cached as []
+    # (= adapter defensive behaviour, unchanged by the fold).
 
     old_cwd = os.getcwd()
     os.chdir(tmp_path)


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3447.

## What (per the corrected firm — #3447's own thread, 2026-07-30 self-correction)

Path A's 5 discovery-only MCP listing methods (`mcp_list_servers` /
`mcp_list_tools` / `mcp_list_resources` / `mcp_list_resource_templates` /
`mcp_list_prompts`) folded off `Session` (where they lived as
constructor-injected callbacks into `RouterHostAdapter`) onto
`RouterHostAdapter` itself, which now implements them directly. The
gateway-calling seam (`_mcp_list_via_gateway` / `_mcp_resolve_server_config`,
moved verbatim) no longer catches `Cancelled`/`MCPFault` — it raises. The
catch moved to `tools/mcp.py`'s `_handle_list_mcp_*` handlers via a new
shared `_call_mcp_list` helper, reproducing the exact `{"error": ...}` shape
the caller received before.

**Negative acceptance criterion (explicit, architect's 2026-07-30
self-correction): the call family (`_handle_call_mcp_tool` /
`_handle_read_mcp_resource` / `_handle_get_mcp_prompt` /
`_handle_subscribe_mcp_resource` / `_handle_unsubscribe_mcp_resource`) gets
ZERO diff.** ✅ **Confirmed — `git diff a7859fd0 -- src/reyn/tools/mcp.py`
touches only the `Awaitable` import, `_mcp_list_error`/`_call_mcp_list`, and
the 4 gateway-backed `_handle_list_mcp_*` bodies; none of the 5 call-family
handler functions appear in the diff at all.** These were already unified on
the throw contract before this PR and adding a shared catch would change
their LLM-visible failure shape (today: `dispatch_tool`'s
`Error (kind): message` envelope) — the architect's own self-correction
retracted that earlier processing.

## Constructor shrink (the arc's visible outcome, #3409)

`RouterHostAdapter.__init__` drops the 5 `mcp_list_*` callback parameters
entirely (not just stops receiving them — the parameters no longer exist).
In their place, 3 raw inputs the adapter's own listing methods need:
`mcp_connection_service` (the session-owned pooled connection service, a
plain object reference — never reassigned after `Session.__init__`),
`mcp_agent_id` (the session's `agent_id`, immutable for the session
lifetime), and `ephemeral_fn` (a zero-arg **live** callable reading
`Session._ephemeral` — not a snapshot bool, because `_ephemeral` is
reassigned post-construction by the registry / pipeline executor at
spawn-time, the same staleness hazard `session_id`/`ephemeral` providers
document elsewhere in `session.py`). Net: -5 callback params, +3 raw/live
inputs.

All call sites of the 5 removed callback kwargs were swept (`tests/`
+ `src/`) — including 4 test files that used `mcp_list_tools=<probe>` as a
dependency-injection seam for `ensure_mcp_tools_cached`'s own
caching/parallel/timeout tests; these now assign the probe as an instance
attribute post-construction (`adapter.mcp_list_tools = probe`, shadowing the
real bound method — a real callable override, not a mock).

## Docs synced same-PR

`docs/reference/runtime/control-ir.md`'s "Two dispatch paths" section
carried its own self-invalidation flag ("accurate only while #3411 is
open") — rewritten to describe the post-fold state (adapter-owned
discovery, shared raise/catch discipline, history section explaining why
it used to be two structurally different paths). `event_schema.py`'s
`DYNAMIC_KIND_EMIT_SITES` entry for `_mcp_list_via_gateway` updated to the
new module path (function name unchanged). `session-construction.md`'s
ephemeral-routing note and a few op_runtime docstrings updated to name the
new location.

## Witness (list family, both faces — measured, not assumed)

- **Success path**: unchanged — `test_list_mcp_tools_normal_result_still_rewrites_names`
  (pre-existing #3441 test) still passes byte-identically.
- **Failure path** (new, added this PR — `tests/test_3441_list_mcp_servers_error_surface.py`):
  `test_list_mcp_tools_cancelled_raise_still_surfaces_as_error_dict` and
  `test_list_mcp_tools_mcpfault_raise_still_surfaces_as_error_dict` construct
  a Fake host whose `mcp_list_tools` RAISES `Cancelled`/`MCPFault` (the new
  contract) and assert `_handle_list_mcp_tools` still returns
  `{"error": "cancelled"}` / `{"error": "connection refused"}` — byte-identical
  to the pre-fold in-`Session` catch's return value.
- **Ephemeral-session close-on-error** (`tests/test_mcp_list_tools_finally_close.py`,
  relocated from `Session._mcp_list_tools` to `RouterHostAdapter.mcp_list_tools`):
  still pins same-task `MCPClientPool` close on every exit path; updated to
  assert the RAISE (`pytest.raises(MCPFault)`) instead of a returned error-list,
  since the catch moved one layer up.

## Strip-falsify

Reverted `_handle_list_mcp_tools` to call `host.mcp_list_tools(server)`
directly (bypassing the new `_call_mcp_list` catch) → the 2 new
Cancelled/MCPFault witness tests went RED (uncaught exception propagates out
of the test instead of being caught into `{"error": ...}`), the other 14
tests in that file stayed GREEN (they don't exercise a raising host).
Restored via the scratchpad backup (not `git stash`, which is repo-shared)
→ all 16 GREEN again.

## Environment / 4 gates

- `uv sync --all-extras --dev`; `uv run python -c "import reyn"` resolves to
  this worktree's `src/reyn/__init__.py`.
- `ruff check src tests` — clean.
- `python scripts/test_tier_audit.py --strict <changed test files>` — 91
  inspected, 0 Tier-4 violations, 0 warnings.
- `pytest -n auto` (full suite, from repo root) — run TWICE (once pre-rebase,
  once post-rebase onto #3480 which landed mid-task and touched
  `router_loop.py`/`event_schema.py`): **9655 passed, 36 skipped, 0 failed**
  on the final (post-rebase) run. Rebase was clean (no conflicts) — #3480's
  changes are in `router_loop.py`'s `routing_decided` emission point, which
  reads the tool-dispatch outer envelope (`dispatch_tool`'s status field,
  already fixed generically by #3478) and is orthogonal to this PR's
  op-layer/adapter-internal changes; confirmed by re-running
  `test_router_loop_routing_decided.py` alongside this PR's own touched
  tests post-rebase (46 passed).
- `python scripts/verify_module_docstrings.py <changed src files>` — clean.

## Test plan

- [x] `ruff check src tests` clean
- [x] `test_tier_audit.py --strict` on all changed/added test files — 0 Tier-4
- [x] Full `pytest -n auto` suite green (9655 passed, 36 skipped, 0 failed),
      run post-rebase onto `origin/main` (includes #3480)
- [x] `verify_module_docstrings.py` clean on changed src files
- [x] Call-family diff-zero confirmed via `git diff a7859fd0 -- src/reyn/tools/mcp.py`
- [x] List-family success + failure LLM-visible shape witness added and green
- [x] Strip-falsify: reverting the `_call_mcp_list` fold turns the new
      witness tests RED; restoring returns them GREEN
- [x] `docs/reference/runtime/control-ir.md` + related docstrings re-derived,
      not left describing the pre-fold mechanism
