### PR TITLE
feat(tui): empty-state welcome hint + one-reflow history hydration

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -51,7 +51,11 @@ from textual_flowview import (
 )
 
 from reyn.interfaces.repl._copy_sentinel import COPY_BUFFER_MAX, handle_copy_sentinel
-from reyn.interfaces.repl.renderer import chat_markdown_theme, summarize_tool_result
+from reyn.interfaces.repl.renderer import (
+    _CC_DIM,
+    chat_markdown_theme,
+    summarize_tool_result,
+)
 from reyn.interfaces.transport.agui.state import RemoteQueueView
 from reyn.interfaces.transport.frames import FrameTag
 
@@ -172,6 +176,26 @@ def _configured_gutter_visibility(config) -> "tuple[bool, bool]":
         return (bool(gutters.left), bool(gutters.right))
     except AttributeError:
         return (defaults.left, defaults.right)
+
+
+def empty_state_hint() -> "object":
+    """The conversation pane's empty-state hint (#3476 ②, flowview 0.6.0
+    ``empty=``): shown across the viewport while the model has no entries — a
+    fresh session previously opened onto a blank void above the composer
+    (owner design review). Ambient by design: dim, no colour (the palette
+    reserves colour for state), horizontally centered here, vertically placed
+    by the FlowView's ``empty_align``. The keys it names are the composer's
+    own (``COMPOSER_KEYS``' send / completion rows) phrased for a first
+    glance; the Help tab stays the exhaustive source. flowview clears it the
+    moment the first entry lands, so there is no app-side show/hide to drift.
+    """
+    from rich.text import Text
+
+    hint = Text(justify="center")
+    hint.append("reyn\n\n", style=f"bold {_CC_DIM}")
+    hint.append("Type a message to start\n", style=_CC_DIM)
+    hint.append("/ commands · : skills · Help tab for keys", style=_CC_DIM)
+    return hint
 
 
 #: Sentinel for :meth:`TextualChatApp._pane_rows`'s optional ``snap`` argument —
@@ -752,6 +776,13 @@ class TextualChatApp(App):
             # Native running-blink: FlowView owns the animation clock and
             # re-invokes the time-based ReynGutter each tick (no app-side timer).
             animation_fps=self.ANIMATION_FPS,
+            # #3476 ②: a fresh session previously opened onto a blank void
+            # above the composer (owner design review). flowview 0.6.0's
+            # empty state shows this hint across the viewport while the model
+            # has no entries and clears itself the moment the first entry
+            # lands — no app-side show/hide wiring to drift.
+            empty=empty_state_hint(),
+            empty_align="middle",
         )
         # #3352: apply the configured START state. flowview has no constructor
         # parameter for gutter visibility (both flags initialise True), so the
@@ -1046,14 +1077,18 @@ class TextualChatApp(App):
         except Exception:
             logger.exception("textual chat: history projection failed")
             return
-        for msg in frames:
-            try:
-                entry = self.conversation.append(msg)
-            except Exception:
-                logger.exception(
-                    "textual chat: restore append failed for kind=%r", msg.kind
-                )
-                continue
+        # #3476 ②: batch append — ``extend`` reflows the view ONCE for the
+        # whole restored history instead of once per entry (flowview 0.6.0;
+        # the per-entry ``set_state`` calls below redraw only the gutter, no
+        # reflow). Handle creation cannot fail per-item (presentation runs at
+        # paint, not append), so the one try/except covers what the old
+        # per-item guard did.
+        try:
+            entries = self.conversation.extend(frames)
+        except Exception:
+            logger.exception("textual chat: restore batch append failed")
+            return
+        for msg, entry in zip(frames, entries):
             # Resolved, never RUNNING — mirror the completion handler's terminal
             # transition for a settled tool result (SUCCESS unless the summary
             # marks a failure); non-tool rows keep DEFAULT.

--- a/tests/test_empty_state_hint_3476.py
+++ b/tests/test_empty_state_hint_3476.py
@@ -1,0 +1,100 @@
+"""#3476 ② — the conversation pane's empty-state hint.
+
+A fresh session previously opened onto a blank void above the composer
+(owner design review). flowview 0.6.0's ``empty=`` shows a hint across the
+viewport while the model has no entries and clears it the moment the first
+entry lands. These tests read the PAINTED surface (``FlowView.render_line``,
+the same rows a terminal receives) rather than a private attribute, so they
+pin what a user sees, not what was configured.
+
+Real ``TextualChatApp`` + a real minimal ``ClientTransport`` — no mocks."""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _Transport(ClientTransport):
+    def __init__(self) -> None:
+        self.submitted: list[str] = []
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        await asyncio.Event().wait()
+        yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
+
+    async def submit_user_text(self, text: str) -> None:
+        self.submitted.append(text)
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _painted_text(flow: FlowView) -> str:
+    """Every visible row of the conversation pane, as painted."""
+    return "\n".join(
+        "".join(segment.text for segment in flow.render_line(y))
+        for y in range(flow.size.height)
+    )
+
+
+@pytest.mark.asyncio
+async def test_fresh_session_paints_the_welcome_hint() -> None:
+    """Tier 2b: a fresh session (no history, nothing pumped) paints the hint
+    where the blank void used to be — read from the rendered rows."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        painted = _painted_text(app.query_one(FlowView))
+        assert "Type a message to start" in painted, (
+            f"the empty-state hint is not painted; pane shows: {painted!r}"
+        )
+        assert "Help tab for keys" in painted
+
+
+@pytest.mark.asyncio
+async def test_hint_clears_when_the_first_entry_lands() -> None:
+    """Tier 2b: the hint is the EMPTY state, not a banner — the first real
+    entry replaces it (flowview owns the transition; this pins that reyn's
+    wiring lets it happen rather than pinning the hint over content)."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        app.conversation.append(OutboxMessage(kind="status", text="first row"))
+        await pilot.pause()
+        painted = _painted_text(app.query_one(FlowView))
+        assert "Type a message to start" not in painted, (
+            "the empty-state hint is still painted after content arrived"
+        )
+        assert "first row" in painted


### PR DESCRIPTION
**[tui-coder]** — part of #3476(owner 全面採用方針の②)

## 1. 空状態ウェルカムヒント(flowview 0.6.0 `empty=`)

新規セッションはこれまで composer の上が真っ黒な空白でした(owner デザインレビュー指摘)。flowview の empty state で、エントリ0件の間だけ viewport 中央に dim のヒントを描画:

```
                        reyn

               Type a message to start
      / commands · : skills · Help tab for keys
```

- **設計**: 全て dim(パレットの「色は状態を示す」規則に従い無彩色)、水平センター+`empty_align="middle"`。記載キーは composer 自身のもの(`COMPOSER_KEYS` の send/completion 行)を初見向けに言い換え、網羅は Help タブに委譲
- **消滅は flowview 所有**: 初回エントリ到達で自動的に消える — app 側に show/hide 配線なし(drift する状態を持たない)
- **テストは描画面を読む**(`FlowView.render_line` = 端末が受け取る行)— 設定値でなく「ユーザーに見えるもの」を pin。falsify 済み: `empty=` を外すと RED(空白が戻る)
- 2本目のテストが「ヒントは banner ではなく empty state」を pin(初回エントリで消えることを assert)

## 2. hydration の一括 reflow 化(`FlowModel.extend`)

`_hydrate_from_history` は復元履歴を **1件ずつ append(毎回 reflow)** していた箇所を `extend()` 一括(reflow 1回)に。後続の per-entry `set_state` はガター再描画のみで reflow なし。復元の正しさは既存 phase-5 スイート(17件)でparity確認。旧ループの per-item try/except は「handle 生成は per-item で失敗し得ない(presentation は paint 時)」ため単一 try/except に集約(コメントに理由記載)。

## 実TTY witness(100×30、venv 同一性確認済)

- 新規セッション起動 → ヒントが中央に dim 描画(スクリーン行11-14)
- 初回メッセージ送信 → ヒント消滅(grep 0件)、返信描画正常

## Test plan

- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict`(新テストファイル)— 0 Tier-4
- [x] `verify_module_docstrings.py` — OK
- [x] falsify: `empty=` strip で RED → 復元 GREEN
- [x] phase-5 restore パリティ 17/17 + full `pytest -n auto` 9558 passed(6 fails は反復既知の contention set: `llm_router_s3b`×2+`compaction_resolver_aware`×3 ほか — 単独 12/12 green、本 diff の面に接触なし)
- [x] 実TTY witness — 上記
