### PR TITLE
feat(runtime): bundle RouterHostAdapter's op-context/mcp-gateway params — #3482 N+1 gate

### DIFF
--- a/docs/reference/runtime/session-construction.md
+++ b/docs/reference/runtime/session-construction.md
@@ -364,6 +364,27 @@ same construction order, same ~40 args, including 3 DEFERRED per-turn lambdas �
 over `self` and resolved at call time, not eager-ized). It stays UNMOVED, invoked at its
 original position — every dependency is already set on `self` by this point.
 
+**#3482 param bundling**: `RouterHostAdapter.__init__` groups two real
+consumer-set clusters (measured by AST, not by name prefix) into frozen,
+default-free dataclasses built just before the constructor call: the
+16-field `RouterOpContextInputs` (every field's sole reader is
+`RouterHostAdapter.make_router_op_context` — includes `turn_origin_fn` from
+the paragraph above, plus `allowed_mcp`/`budget_gateway`/`compact_now`/
+`contextual_permission`/`hook_bus`/`hook_dispatcher`/`hot_reloader`/
+`multimodal_config`/`presentation_renderer_factory`/`render_template_bounds`/
+`sandbox_backend_instance`/`sandbox_policy`/`workspace_base_dir`/
+`workspace_state_dir`/`base_available_skills_fn`) and the 3-field
+`McpGatewayInputs` (`mcp_connection_service`/`mcp_agent_id`/`ephemeral_fn` —
+#3447's Path A fold, sole reader `_mcp_list_via_gateway`). Session still
+builds each field with the exact same expression as before (same object,
+same order, same call-time semantics — `turn_origin_fn`/`ephemeral_fn` are
+still live per-turn lambdas, not eager-ized); only the wire shape changed,
+from ~19 flat kwargs to 2 bundle kwargs. The remaining ~58 params stay bare
+scalars, each with a reason recorded in
+`ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS` (`router_host_adapter.py`) — bundle
+coverage is deliberately not 100% (forcing it would be a name-prefix
+grouping pressure, not a consumer-set one).
+
 ### Chat turn_budget engine — None on small context, never raise (#1092 PR-F1)
 
 `_build_router_waist` builds the chat axis's `turn_budget` engine off the

--- a/src/reyn/runtime/services/__init__.py
+++ b/src/reyn/runtime/services/__init__.py
@@ -11,7 +11,11 @@ from reyn.runtime.services.intervention_registry import InterventionRegistry
 from reyn.runtime.services.memory_service import MemoryService
 from reyn.runtime.services.recovery import build_recovery, default_snapshot_path
 from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
-from reyn.runtime.services.router_host_adapter import RouterHostAdapter
+from reyn.runtime.services.router_host_adapter import (
+    McpGatewayInputs,
+    RouterHostAdapter,
+    RouterOpContextInputs,
+)
 from reyn.runtime.services.router_loop_driver import RouterLoopDriver
 from reyn.runtime.services.snapshot_journal import SnapshotJournal
 from reyn.services.compaction.engine import (
@@ -32,9 +36,11 @@ __all__ = [
     "InterventionCoordinator",
     "InterventionHandler",
     "InterventionRegistry",
+    "McpGatewayInputs",
     "MemoryService",
     "RouterHistoryBuffer",
     "RouterHostAdapter",
+    "RouterOpContextInputs",
     "RouterLoopDriver",
     "ChainTimeoutGlue",
     "SnapshotJournal",

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
@@ -18,6 +19,60 @@ from reyn.core.events.events import EventLog
 logger = logging.getLogger(__name__)
 
 _DEFAULT_STATE_DIR = Path(".reyn") / "state"
+
+
+@dataclass(frozen=True)
+class RouterOpContextInputs:
+    """#3482: the 16 ``RouterHostAdapter.__init__`` params whose ONLY reader
+    is :meth:`RouterHostAdapter.make_router_op_context` (measured by AST on
+    ``origin/main`` at 890e22d2 — class-internal ``self._<field>`` usage
+    sites, no external ``host.<attr>`` reader for any of these 16). The
+    adapter is a pure RELAY for this cluster: it never inspects or branches
+    on any of these fields itself, it only carries them from Session's
+    construction call to the single call site inside
+    ``make_router_op_context`` (``src/reyn/runtime/services/router_host_adapter.py``).
+
+    Pure value object, no default field values (a default would let a
+    caller's silent omission absorb a wiring change unnoticed — the
+    byte-identical-refactor invariant #3082 established for this bundle
+    family) and no construction logic (assembling these 16 values stays the
+    CALLER's job, same as before this bundle existed).
+    """
+
+    allowed_mcp: "list[str] | None"
+    base_available_skills_fn: "Callable[[], Any] | None"
+    budget_gateway: Any
+    compact_now: Any
+    contextual_permission: Any
+    hook_bus: Any
+    hook_dispatcher: Any
+    hot_reloader: Any
+    multimodal_config: Any
+    presentation_renderer_factory: "Callable[[], Any] | None"
+    render_template_bounds: Any
+    sandbox_backend_instance: Any
+    sandbox_policy: "dict | None"
+    turn_origin_fn: "Callable[[], str | None] | None"
+    workspace_base_dir: "Path | None"
+    workspace_state_dir: "Path | None"
+
+
+@dataclass(frozen=True)
+class McpGatewayInputs:
+    """#3482: the 3 raw gateway-identity inputs (#3447) whose ONLY reader is
+    :meth:`RouterHostAdapter._mcp_list_via_gateway` (measured on current
+    main, 890e22d2 — all three read exclusively inside that one method's
+    ``MCPGateway(...)`` construction). A real clustering by consumer set,
+    not a name-prefix grouping: the three arrived together in #3447 (the
+    Path A fold) and are carried together to the same one construction
+    site.
+
+    Pure value object — no defaults, no construction logic (see
+    :class:`RouterOpContextInputs`'s docstring for the rationale)."""
+
+    mcp_connection_service: Any
+    mcp_agent_id: "str | None"
+    ephemeral_fn: "Callable[[], bool] | None"
 
 
 class RouterHostAdapter:
@@ -36,8 +91,10 @@ class RouterHostAdapter:
     output_language:
         BCP-47 code or None. Stored as a plain attribute (not property) per
         the RouterLoopHost Protocol.
-    allowed_mcp:
-        Optional allowlist for MCP server scope (forwarded to PermissionDecl).
+    op_context_inputs:
+        :class:`RouterOpContextInputs` — the 16 fields whose only reader is
+        ``make_router_op_context`` (#3482), bundled because the adapter is a
+        pure relay for this cluster (see the class's docstring).
     permission_resolver:
         PermissionResolver instance (or None) for config-derived gates.
     mcp_servers:
@@ -78,26 +135,31 @@ class RouterHostAdapter:
     mcp_get_prompt:
         Async callback ``(server: str, name: str, arguments: dict | None) -> dict``
         (#2597 slice ②c).
-    mcp_connection_service:
-        The session-owned ``MCPConnectionService`` (or ``None``) — #3447: the
-        adapter's OWN ``mcp_list_servers``/``mcp_list_tools``/``mcp_list_resources``/
-        ``mcp_list_resource_templates``/``mcp_list_prompts`` methods build their
-        ``MCPGateway`` directly (no session callback for the 5 listing methods —
-        they never needed permission-gated ``execute_op`` state, only the same
-        server-config inputs the adapter already duplicates via
-        ``_mcp_servers_flat``/``_get_mcp_servers_for_router``).
-    mcp_agent_id:
-        The session's ``agent_id`` (#3447) — distinct from ``agent_name`` above;
-        threaded raw (identity is immutable for the session lifetime) as the
-        listing methods' gateway pool key (its ``agent_id=`` constructor kwarg;
-        wording kept away from a literal "Gateway(" per the #2813 scanner note
-        below).
-    ephemeral_fn:
-        Zero-arg callable returning the LIVE ``Session._ephemeral`` flag (#3447) —
-        a callable, not a snapshot bool, because ``_ephemeral`` is reassigned
-        post-construction by the registry / pipeline executor (spawn-time flip),
-        mirroring ``live_session_id_fn``'s same staleness hazard. ``None`` (test
-        construction) behaves as never-ephemeral.
+    mcp_gateway_inputs:
+        :class:`McpGatewayInputs` — the 3 raw gateway-identity inputs (#3447:
+        ``mcp_connection_service`` / ``mcp_agent_id`` / ``ephemeral_fn``)
+        whose only reader is ``_mcp_list_via_gateway`` (#3482 bundle — a real
+        consumer-set cluster, all three arrived together in #3447's Path A
+        fold and are carried together to the same one construction site):
+
+        - ``mcp_connection_service``: the session-owned ``MCPConnectionService``
+          (or ``None``) — the adapter's OWN ``mcp_list_servers``/``mcp_list_tools``/
+          ``mcp_list_resources``/``mcp_list_resource_templates``/``mcp_list_prompts``
+          methods build their ``MCPGateway`` directly (no session callback for the
+          5 listing methods — they never needed permission-gated ``execute_op``
+          state, only the same server-config inputs the adapter already
+          duplicates via ``_mcp_servers_flat``/``_get_mcp_servers_for_router``).
+        - ``mcp_agent_id``: the session's ``agent_id`` — distinct from
+          ``agent_name`` above; threaded raw (identity is immutable for the
+          session lifetime) as the listing methods' gateway pool key (its
+          ``agent_id=`` constructor kwarg; wording kept away from a literal
+          "Gateway(" per the #2813 scanner note below).
+        - ``ephemeral_fn``: zero-arg callable returning the LIVE
+          ``Session._ephemeral`` flag — a callable, not a snapshot bool,
+          because ``_ephemeral`` is reassigned post-construction by the
+          registry / pipeline executor (spawn-time flip), mirroring
+          ``live_session_id_fn``'s same staleness hazard. ``None`` (test
+          construction) behaves as never-ephemeral.
     send_to_agent:
         Async callback ``(*, to, request, depth, chain_id) -> None``.
     put_outbox:
@@ -113,25 +175,29 @@ class RouterHostAdapter:
     # RouterLoopHost Protocol attributes (non-property)
     output_language: str | None
 
-    # 80 flat params is not a Parameter-Object problem — grouping them was
-    # measured as a near-no-op (#3121 took Session 54 -> 45 by adding 4 objects
-    # while leaving 41 flat params in place). Nor is it a Move-Construction one:
-    # only 2 of the 80 are forward-only (stored, never read outside __init__),
-    # so this class genuinely uses 74 of them. What the width tracks instead is
-    # the tools-handler -> host hop: 14 distinct `host.<method>` names are called
-    # from `src/reyn/tools/*.py` (10 of them `mcp_*`), and each needs its own
-    # injected callable here. Collapsing the 10 MCP ones into one facade fails
-    # because the Session methods they reach are 27-48 lines each with their own
-    # ephemeral/pool routing and error contract, not thin delegates (#3409 has
-    # the per-method table). Falsifiable claim: if that hop ever goes away, this
-    # constructor loses ~14 params without anyone touching a Parameter Object.
+    # 77 flat params is not a Parameter-Object problem in general — grouping
+    # them was measured as a near-no-op (#3121 took Session 54 -> 45 by adding
+    # 4 objects while leaving 41 flat params in place): a param-object split
+    # only pays for itself where a REAL consumer-set cluster exists, and #3482
+    # measured exactly two: the 16-param op-context cluster and the 3-param
+    # mcp-gateway cluster below (``op_context_inputs`` / ``mcp_gateway_inputs``).
+    # The remaining ~58 stay flat scalars — collapsing e.g. the 5 mcp_call/
+    # get_prompt/read_resource/subscribe/unsubscribe callbacks into one facade
+    # fails because the Session methods they reach are 27-48 lines each with
+    # their own ephemeral/pool routing and error contract, not thin delegates
+    # (#3409 has the per-method table); each is a single-consumer wiring lane
+    # with no shared-consumer partner, not a hidden cluster. See
+    # ``ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS`` (module level, below the
+    # class) for the per-lane reasons, and
+    # ``tests/test_router_host_adapter_param_gate_3482.py`` for the AST gate
+    # that keeps every param in one of {bundle type, exception registry}.
     def __init__(
         self,
         *,
         agent_name: str,
         agent_role: str,
         output_language: str | None,
-        allowed_mcp: list[str] | None = None,
+        op_context_inputs: RouterOpContextInputs,
         permission_resolver: Any,               # PermissionResolver | None
         mcp_servers: dict | None,
         project_context: str,
@@ -145,7 +211,6 @@ class RouterHostAdapter:
         presentation_registry: Any = None,      # PresentationRegistry | None — FP-0054 PR-C
         record_spawned_task: "Callable[[str, str], None] | None" = None,  # #2103 S1bc-exec
         live_session_id_fn: "Callable[[], str | None] | None" = None,     # #2103 S1bc-exec
-        turn_origin_fn: "Callable[[], str | None] | None" = None,  # proposal 0060 Phase 1 (A7)
         agent_workspace_dir: Path,
         # File op callbacks
         file_read: Callable[..., Awaitable[dict]],
@@ -168,11 +233,9 @@ class RouterHostAdapter:
         mcp_get_prompt: "Callable[..., Awaitable[dict]] | None" = None,
         # #3447: the 5 mcp_list_* callbacks (servers/tools/resources/
         # resource_templates/prompts) were folded onto the adapter itself —
-        # see the class docstring's mcp_connection_service/mcp_agent_id/
-        # ephemeral_fn entries. These 3 raw inputs replace them.
-        mcp_connection_service: Any = None,
-        mcp_agent_id: str | None = None,
-        ephemeral_fn: "Callable[[], bool] | None" = None,
+        # see the class docstring's mcp_gateway_inputs entry. These 3 raw
+        # inputs (bundled #3482) replace them.
+        mcp_gateway_inputs: McpGatewayInputs,
         # Action callbacks
         send_to_agent: Callable[..., Awaitable[None]],
         put_outbox: Callable[..., Awaitable[None]],
@@ -192,8 +255,6 @@ class RouterHostAdapter:
         # ``emit_hook_event`` builds the LLM's own ``llm:<session_id>:*``
         # namespace (never an op field the LLM could forge).
         session_id: str | None = None,
-        hook_dispatcher: Any = None,  # #1800 slice 5c: the Session's HookDispatcher
-        hook_bus: Any = None,  # Hook-Event Redesign Phase 5 part 2: the Session's HookBus → emit_hook_event
         # FP-0034 Phase 2 step 1: ActionEmbeddingIndex + EmbeddingProvider
         # for search_actions.  When all three are set (= operator set
         # ``embedding.enabled: true`` (FP-0066 §7) AND Session built a
@@ -212,34 +273,18 @@ class RouterHostAdapter:
         # tools/types.py) — i.e. the live interactive path. Without it the
         # user-facing embed is billed but recorded nowhere ($0.00), the exact
         # bug FP-0063 closes.
-        budget_gateway: Any = None,
         # FP-0034 Phase 2: sandbox backend name for exec D14 visibility
         # gate. Passed from ``session._sandbox_config.backend`` so the
         # universal catalog ``_enumerate_category("exec")`` can decide
         # whether to expose ``exec``. Default None hides
         # the exec category (= noop / no sandbox configured).
         sandbox_backend: str | None = None,
-        sandbox_policy: dict | None = None,
         # #187: the FS EnvironmentBackend INSTANCE (docker for in-container repos)
-        # + the container repo root + host-side state dir, for the router OpContext
-        # Workspace. Distinct from ``sandbox_backend`` (a STRING for the exec D14
-        # gate). Without these the LIVE file-op dispatch built a host-cwd Workspace
-        # (the #187 wrong-FS defect: file ops on the reyn repo, not /testbed).
+        # for the router OpContext Workspace. Distinct from ``sandbox_backend``
+        # (a STRING for the exec D14 gate). Without this the LIVE file-op
+        # dispatch built a host-cwd Workspace (the #187 wrong-FS defect: file
+        # ops on the reyn repo, not /testbed).
         environment_backend: Any = None,
-        workspace_base_dir: Path | None = None,
-        workspace_state_dir: Path | None = None,
-        # #187 exec-seam (10th defect): the SandboxBackend INSTANCE for exec
-        # EXECUTION (docker for in-container repos). Distinct from the
-        # ``sandbox_backend`` STRING above (which only drives the D14 exec
-        # visibility gate): the op handler (op_runtime/sandboxed_exec) reads
-        # ``ctx.sandbox_backend`` (the instance) and falls back to the host
-        # seatbelt backend when it is None. Without threading this, the LIVE
-        # router's exec ran on the host (``No such file or directory:
-        # '/testbed'``), so the agent's verify loop always failed. Parallel to
-        # ``environment_backend`` for FS (#1411) — the legacy
-        # ``Session._make_router_op_context`` already passes it; the live
-        # adapter omitted it (the same live-vs-legacy seam gap as #1410/#1411).
-        sandbox_backend_instance: Any = None,
         # FP-0034 Phase 2 step 5: ActionUsageTracker for hot list freq+recency.
         # Session passes the session-scoped tracker; None when wrappers are
         # off or hot_list_n == 0.
@@ -282,7 +327,7 @@ class RouterHostAdapter:
         # concern; it must never gate a trust decision. None (test
         # construction) falls back to `self._available_skills` at call
         # time, preserving prior behavior for callers that don't wire it.
-        base_available_skills_fn: "Callable[[], Any] | None" = None,
+        # (``base_available_skills_fn`` moved into ``op_context_inputs`` #3482.)
         # B25-S5-1: when True, RouterLoop awaits the action embedding index
         # build synchronously on the first turn before computing the D14
         # search_actions visibility gate. Off by default (= lazy bg build).
@@ -296,12 +341,7 @@ class RouterHostAdapter:
         # config-deny path still raises, interactive prompt path raises
         # the documented RuntimeError telling the caller a bus is needed).
         intervention_bus_factory: Callable[[], Any] | None = None,
-        # FP-0054 PR-B: callable that yields a PresentationRenderer for router-initiated
-        # `present` ops. Session passes a factory wrapping
-        # ``OutboxPresentationRenderer(session)``; None (tests / headless) keeps
-        # ``OpContext.presentation_renderer=None`` — the `present` op's PR-A null-surface
-        # behavior (ack + audit event still fire; no UI is reached).
-        presentation_renderer_factory: Callable[[], Any] | None = None,
+        # (``presentation_renderer_factory`` moved into ``op_context_inputs`` #3482.)
         # #2175: the safety.on_limit checkpoint + the shared per-run extension dict —
         # injected from Session (mirror the inter_agent_messaging injection) so the spawn SEAM can
         # route a spawn-limit exceed through the same mode-driven on_limit framework as
@@ -309,16 +349,8 @@ class RouterHostAdapter:
         # unattended (reject), the C3 hard-deny posture.
         handle_chat_limit_checkpoint: "Callable[..., Any] | None" = None,
         safety_extensions: "dict[str, float] | None" = None,
-        # Issue #364 multi-modal cluster: media-size gate config (reyn.yaml
-        # ``multimodal:`` section). Threaded into the OpContext built by
-        # ``make_router_op_context`` so router-initiated web_fetch /
-        # read_file / mcp ops consult the cap + on_oversize policy.
-        # ``None`` = no cap.
-        multimodal_config: Any = None,
-        # #2679: operator RenderTemplateBounds threaded onto the router OpContext so
-        # a router/pipeline render_template op honours the operator's output cap.
-        # None → the op's in-handler defaults (256_000 chars / 5.0s).
-        render_template_bounds: Any = None,
+        # (``multimodal_config`` / ``render_template_bounds`` moved into
+        # ``op_context_inputs`` #3482.)
         # #1652: ReasoningConfig (continuity/display/recent_turns) + the session
         # callback that renders the bounded prior-reasoning text section (reads
         # history + applies the continuity gate). None → reasoning disabled.
@@ -339,11 +371,7 @@ class RouterHostAdapter:
         # build_offload_body's structured inline-size gate. Default False = offload
         # off unless the operator opts in via ``offload.enabled: true``.
         offload_enabled: bool = False,
-        # #272/#1128 compact op: awaitable () -> {freed_tokens, free_window_after}
-        # wired by Session to its force_compact_now wrapper, so the LLM-
-        # emittable `compact` control_ir op can voluntarily compact history.
-        # ``None`` = no compaction context (compact op returns a clear error).
-        compact_now: Any = None,
+        # (``compact_now`` moved into ``op_context_inputs`` #3482.)
         # #272/#1128 context-size signal: callable () -> {free_window,
         # effective_trigger} (exact tokens) for the OS-injected SP header.
         # ``None`` = no signal rendered (e.g. test stubs).
@@ -373,23 +401,23 @@ class RouterHostAdapter:
         # FP-0050 / #1822: content-threat scan + fence config. None (test hosts)
         # → defaults (disabled-safe via the methods' guards).
         threat_scan: Any = None,
-        contextual_permission: Any = None,  # #1827 S3: per-session capability narrowing → control-IR OpContext
-        hot_reloader: Any = None,  # #2073 S3: this session's HotReloader → tool ctx
+        # (``contextual_permission`` / ``hot_reloader`` moved into
+        # ``op_context_inputs`` #3482 — ``hot_reloader`` is ALSO exposed as
+        # the public ``self.hot_reloader`` attribute below, unchanged.)
     ) -> None:
+        self._op_ctx = op_context_inputs
+        self._mcp_gateway = mcp_gateway_inputs
         self._threat_scan = threat_scan
-        self._contextual_permission = contextual_permission
         # #2073 S3: exposed (public) so RouterLoop threads it onto the tool ctx, so a
         # self-reload tool reloads THIS session (per-session, not a process global).
-        self.hot_reloader = hot_reloader
+        # (source: op_context_inputs.hot_reloader — #3482 bundle)
+        self.hot_reloader = self._op_ctx.hot_reloader
         self._session_id = session_id  # #1953 dynamic-wire: emit_hook_event's session-namespace key
-        self._hook_dispatcher = hook_dispatcher  # #1800 slice 5c
-        self._hook_bus = hook_bus  # Hook-Event Redesign Phase 5 part 2: emit_hook_event's publish target
         self._turn_budget_engine = turn_budget_engine
         self._turn_cancel_fn = turn_cancel_fn  # #1468
         self._agent_name = agent_name
         self._agent_role = agent_role
         self.output_language = output_language
-        self._allowed_mcp = allowed_mcp
         self._perm = permission_resolver
         self._mcp_servers = mcp_servers
         # Lazy per-session cache for MCP tools — populated by
@@ -427,7 +455,6 @@ class RouterHostAdapter:
         self._presentation_registry = presentation_registry
         self._record_spawned_task = record_spawned_task   # #2103 S1bc-exec
         self._live_session_id_fn = live_session_id_fn      # #2103 S1bc-exec
-        self._turn_origin_fn = turn_origin_fn      # proposal 0060 Phase 1 (A7)
         self._workspace_dir = Path(agent_workspace_dir)
         # File callbacks
         self._file_read_cb = file_read
@@ -440,11 +467,9 @@ class RouterHostAdapter:
         self._mcp_subscribe_resource_cb = mcp_subscribe_resource
         self._mcp_unsubscribe_resource_cb = mcp_unsubscribe_resource
         self._mcp_get_prompt_cb = mcp_get_prompt
-        # #3447: raw inputs for the 5 mcp_list_* methods this adapter now
-        # implements directly (folded off Session — see class docstring).
-        self._mcp_connection_service = mcp_connection_service
-        self._mcp_agent_id = mcp_agent_id
-        self._ephemeral_fn = ephemeral_fn
+        # #3447/#3482: raw inputs for the 5 mcp_list_* methods this adapter
+        # implements directly (folded off Session — see class docstring),
+        # bundled into mcp_gateway_inputs (single reader: _mcp_list_via_gateway).
         # Action callbacks
         self._send_to_agent_cb = send_to_agent
         self._put_outbox_cb = put_outbox
@@ -460,25 +485,16 @@ class RouterHostAdapter:
         self._action_embedding_index = action_embedding_index
         self._embedding_provider = embedding_provider
         self._embedding_model_class = embedding_model_class
-        # FP-0063 PC: embedding-cost recording entry point for the `embed` op.
-        self._budget_gateway = budget_gateway
+        # (``budget_gateway`` / ``base_available_skills_fn`` / ``sandbox_backend_instance`` /
+        # ``workspace_base_dir`` / ``workspace_state_dir`` / ``sandbox_policy`` /
+        # ``presentation_renderer_factory`` / ``multimodal_config`` / ``render_template_bounds`` /
+        # ``compact_now`` all live on ``self._op_ctx`` — #3482 RouterOpContextInputs bundle;
+        # ``make_router_op_context`` reads them there directly, its sole consumer role.)
         # #2548 PR-A: enabled skill registry snapshot for the ## Skills block.
         self._available_skills = available_skills
-        # #3196 co-vet round 2: live base-set callback (see the constructor
-        # param's docstring) — the source `make_router_op_context` uses for
-        # `OpContext.available_skills`, deliberately NOT `self._available_skills`
-        # above once visibility filtering starts mutating it.
-        self._base_available_skills_fn = base_available_skills_fn
         # FP-0034 Phase 2
         self._sandbox_backend = sandbox_backend
-        self._sandbox_backend_instance = sandbox_backend_instance
         self._environment_backend = environment_backend
-        self._workspace_base_dir = workspace_base_dir
-        self._workspace_state_dir = workspace_state_dir
-        # #1339 / sandbox-model completion: the operator's reyn.yaml
-        # sandbox.policy (dict | None) used to resolve the concrete agent-level
-        # policy onto the router OpContext (None → the default policy).
-        self._sandbox_policy = sandbox_policy
         # FP-0034 Phase 2 step 5
         self._action_usage_tracker = action_usage_tracker
         self._uncompacted_tool_call_records_fn = uncompacted_tool_call_records_fn
@@ -489,21 +505,11 @@ class RouterHostAdapter:
         # interactive (Layer 4) approval flow without crashing on
         # ``intervention_bus is None`` defensive guards.
         self._intervention_bus_factory = intervention_bus_factory
-        # FP-0054 PR-B: presentation-renderer factory used by make_router_op_context to
-        # populate ``ctx.presentation_renderer`` so a router-initiated `present` op
-        # reaches the live UI surface instead of PR-A's null surface.
-        self._presentation_renderer_factory = presentation_renderer_factory
         # #2175: spawn-limit on_limit checkpoint + the shared extension dict.
         self._handle_chat_limit_checkpoint = handle_chat_limit_checkpoint
         self._safety_extensions: "dict[str, float]" = (
             safety_extensions if safety_extensions is not None else {}
         )
-        # Issue #364: store the gate config so make_router_op_context can
-        # thread it into the OpContext for router-initiated binary ops.
-        self._multimodal_config = multimodal_config
-        # #2679: store the operator render_template output bounds for the same
-        # make_router_op_context threading.
-        self._render_template_bounds = render_template_bounds
         # #1652: reasoning capture/continuity/display config + the section renderer.
         self._reasoning_config = reasoning_config
         self._reasoning_continuity_section_fn = reasoning_continuity_section_fn
@@ -515,8 +521,6 @@ class RouterHostAdapter:
         self._media_followup_budget = media_followup_budget
         # tool-result-schema-redesign §5: structured-offload gate flag.
         self._offload_enabled = offload_enabled
-        # #272/#1128 compact op: voluntary-compaction callable (or None).
-        self._compact_now = compact_now
         # #1470: per-turn cancel event set by RouterLoopDriver._set_cancel_event.
         # None until RouterLoopDriver registers itself at construction time.
         self._cancel_event: asyncio.Event | None = None
@@ -1644,7 +1648,11 @@ class RouterHostAdapter:
         """
         from reyn.mcp.gateway import MCPGateway
 
-        ephemeral = self._ephemeral_fn() if self._ephemeral_fn is not None else False
+        # #3482: mcp_gateway_inputs bundle — mcp_connection_service/mcp_agent_id/
+        # ephemeral_fn are read ONLY here (this method), the real cluster #3447 formed.
+        ephemeral_fn = self._mcp_gateway.ephemeral_fn
+        ephemeral = ephemeral_fn() if ephemeral_fn is not None else False
+        mcp_agent_id = self._mcp_gateway.mcp_agent_id
         # #2421: routed through the MCPGateway seam rather than a raw MCP client — the
         # seam contains the crash path, so a mid-list server death raises MCPFault
         # instead of an uncontained BaseExceptionGroup. #2597 S2a: pool only when
@@ -1653,11 +1661,11 @@ class RouterHostAdapter:
         # completeness scanner reads `MCPGateway\s*\(` as a construction site.)
         gateway = (
             MCPGateway(
-                pool=self._mcp_connection_service, agent_id=self._mcp_agent_id,
+                pool=self._mcp_gateway.mcp_connection_service, agent_id=mcp_agent_id,
                 cancel_event=self._cancel_event,
             )
             if not ephemeral
-            else MCPGateway(agent_id=self._mcp_agent_id, cancel_event=self._cancel_event)
+            else MCPGateway(agent_id=mcp_agent_id, cancel_event=self._cancel_event)
         )
         result = await gateway_call(gateway)
         self._events.emit(event_kind, server=server, count=len(result))
@@ -2192,6 +2200,11 @@ class RouterHostAdapter:
         """
         from reyn.runtime.router_op_context import build_router_op_context
 
+        # #3482: op_ctx is the RouterOpContextInputs bundle — this method is the
+        # SOLE reader of all 16 of its fields (the measured cluster the bundle
+        # was formed from). Local alias only for readability below.
+        op_ctx = self._op_ctx
+
         # #1412: single-sourced via build_router_op_context (shared with
         # Session). RouterHostAdapter wires intervention_bus inline (via the
         # factory) + media/multimodal/compact (the registry-dispatch path serves
@@ -2203,8 +2216,8 @@ class RouterHostAdapter:
             else None
         )
         presentation_renderer = (
-            self._presentation_renderer_factory()
-            if self._presentation_renderer_factory is not None
+            op_ctx.presentation_renderer_factory()
+            if op_ctx.presentation_renderer_factory is not None
             else None
         )
         return build_router_op_context(
@@ -2213,47 +2226,47 @@ class RouterHostAdapter:
             file_permissions=self._get_file_permissions_for_router(),
             mcp_servers=self._get_mcp_servers_for_router(),
             mcp_servers_flat=self._mcp_servers_flat(),
-            allowed_mcp=self._allowed_mcp,
-            workspace_base_dir=self._workspace_base_dir,
-            workspace_state_dir=self._workspace_state_dir,
+            allowed_mcp=op_ctx.allowed_mcp,
+            workspace_base_dir=op_ctx.workspace_base_dir,
+            workspace_state_dir=op_ctx.workspace_state_dir,
             environment_backend=self._environment_backend,
-            sandbox_backend=self._sandbox_backend_instance,
-            sandbox_policy=self._sandbox_policy,
+            sandbox_backend=op_ctx.sandbox_backend_instance,
+            sandbox_policy=op_ctx.sandbox_policy,
             agent_id=None,
             intervention_bus=bus,
             presentation_renderer=presentation_renderer,
             # FP-0054 PR-C: the adapter's CURRENT registry snapshot (hot-reload swaps it).
             presentation_registry=self._presentation_registry,
-            multimodal_config=self._multimodal_config,
-            render_template_bounds=self._render_template_bounds,  # #2679: operator render_template output cap
+            multimodal_config=op_ctx.multimodal_config,
+            render_template_bounds=op_ctx.render_template_bounds,  # #2679: operator render_template output cap
             media_store=self._media_store,
-            compact_now=self._compact_now,
+            compact_now=op_ctx.compact_now,
             cancel_event=self._cancel_event,
             threat_scan=self._threat_scan,
-            contextual_permission=self._contextual_permission,  # #1827 S3
+            contextual_permission=op_ctx.contextual_permission,  # #1827 S3
             # #1953 dynamic-wire: the REAL chat-session id, threaded so
             # emit_hook_event builds the LLM's own session-scoped namespace.
             session_id=self._session_id,
-            hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c
-            hook_bus=self._hook_bus,  # Hook-Event Redesign Phase 5 part 2: emit_hook_event's publish target
+            hook_dispatcher=op_ctx.hook_dispatcher,  # #1800 slice 5c
+            hook_bus=op_ctx.hook_bus,  # Hook-Event Redesign Phase 5 part 2: emit_hook_event's publish target
             # proposal 0060 Phase 1 (A7): a live callback read (varies per turn, so
             # a fixed init value would be stale — cf. live_session_id_fn).
             # This is the router-dispatched install path (skill_install_*
             # / pipeline / presentation_install_local → this factory), so it
             # is the load-bearing wiring for A9's per-handler provenance stamp.
             turn_origin=(
-                self._turn_origin_fn() if self._turn_origin_fn else None
+                op_ctx.turn_origin_fn() if op_ctx.turn_origin_fn else None
             ),
             # #2761 PR-2: the per-session HotReloader so an install op (skill/pipeline)
             # can apply a pure-addition reload IMMEDIATELY (mid-turn) → the new entry is
             # resolvable this turn. This is the router-dispatched install path
             # (skill_install_* / pipeline ops → build_legacy_op_context →
             # this factory), so it is the load-bearing wiring for PR-2.
-            hot_reloader=self.hot_reloader,
+            hot_reloader=op_ctx.hot_reloader,
             # FP-0063 PC: the live router-dispatched `embed` tool resolves THIS
             # factory, so this is the load-bearing wiring for embedding-cost
             # recording (all three scopes fan out from the gateway).
-            budget_gateway=self._budget_gateway,
+            budget_gateway=op_ctx.budget_gateway,
             # #3196 co-vet round 2: the BASE registered-skill set, NOT
             # `self._available_skills` (that field is the per-session
             # VISIBILITY-FILTERED view, mutated in place by
@@ -2263,8 +2276,8 @@ class RouterHostAdapter:
             # all") and must not depend on whether the operator hid the
             # skill from the menu — visibility must never gate trust.
             available_skills=(
-                self._base_available_skills_fn()
-                if self._base_available_skills_fn is not None
+                op_ctx.base_available_skills_fn()
+                if op_ctx.base_available_skills_fn is not None
                 else self._available_skills
             ),
         )
@@ -2286,3 +2299,114 @@ class RouterHostAdapter:
         if self._intervention_bus_factory is None:
             return None
         return self._intervention_bus_factory()
+
+
+# ---------------------------------------------------------------------------
+# #3482 N+1 gate registries — every RouterHostAdapter.__init__ param must
+# have an annotation naming one of ROUTER_HOST_ADAPTER_BUNDLE_TYPES, or be a
+# key in ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS with a REASON (why it stays a
+# bare scalar). tests/test_router_host_adapter_param_gate_3482.py asserts
+# this by AST over the real signature — a bare `foo_fn: Callable` param
+# added tomorrow with no bundle annotation and no registry entry goes RED.
+#
+# The reasons below classify by CONSUMER SET (the #3482 firm's discriminator
+# — never by name prefix): most are single-consumer wiring lanes (one
+# Session collaborator → one dedicated adapter method/property), which is
+# NOT itself a defect — #3121 measured that grouping single-consumer params
+# by name-prefix alone is a near-no-op. A handful are multi-consumer (read
+# by 2+ adapter methods) but the reader SET differs per param, so they don't
+# form a cluster either. Six (the mcp call-family callbacks + mcp_servers)
+# get the specific, non-speculative reason the architect required: DECIDED
+# to stay bare, not "scheduled for a future fold" (writing a resolution date
+# for un-scheduled work is exactly the schedule/resolution conflation the
+# architect's firm forbids — see the #3482 issue thread).
+# ---------------------------------------------------------------------------
+
+ROUTER_HOST_ADAPTER_BUNDLE_TYPES: "tuple[str, ...]" = (
+    "RouterOpContextInputs",
+    "McpGatewayInputs",
+)
+
+_MCP_CALL_FAMILY_REASON = (
+    "Single-consumer forwarding lane (its own dedicated adapter method "
+    "reaches Session's callback) — one of 5 call-family callbacks +  "
+    "mcp_servers measured (#3482, current main 890e22d2) to each resolve "
+    "to its OWN transfer method, a different consumer set per param, not a "
+    "shared cluster. The call family is already unified on a throw contract "
+    "(#3447 correction). DECIDED: remains bare — there is no scheduled fold "
+    "and no same-consumer partner to bundle with; not a stated \"future "
+    "resolution\" (see the #3482 issue thread's schedule/resolution note)."
+)
+
+ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS: "dict[str, str]" = {
+    # --- identity ---
+    "agent_name": "Identity attribute; own accessor (agent_name/chat_id properties), no bundle partner.",
+    "agent_role": "Identity attribute; own accessor (agent_role property), no bundle partner.",
+    "output_language": "RouterLoopHost Protocol non-property attribute; read externally via host.output_language (router_loop), no adapter-internal cluster partner.",
+    "agent_workspace_dir": "Single-consumer (get_memory_index's workspace path); no bundle partner.",
+    # --- config / collaborators with their own dedicated accessor ---
+    "permission_resolver": "Multi-consumer (permission_resolver property + get_file_permissions + make_router_op_context's file-permission resolution); no single shared-consumer cluster to fold into.",
+    "mcp_servers": _MCP_CALL_FAMILY_REASON,
+    "project_context": "Single-consumer (get_project_context); no bundle partner.",
+    "events": "Multi-consumer EventLog (events property + emit() at multiple call sites across the class); no cluster partner.",
+    "resolver": "Single-consumer (resolve_model/resolve_model_spec); ModelResolver, no bundle partner.",
+    "memory": "Single-consumer (memory_path/memory_dir via MemoryService); no bundle partner.",
+    "journal": "Forward-only (stored, never read within this class or externally) — legacy SnapshotJournal handle; no current consumer, no bundle partner.",
+    "state_log": "Single-consumer (state_log property, WAL head for config generation emit); no bundle partner.",
+    "agent_registry": "Multi-consumer AgentRegistry (list_available_agents / spawn_session / get_agent_registry / session-nesting-depth checks); no single-partner cluster.",
+    "pipeline_registry": "Single-consumer (get_pipeline_registry, IS-5 run_pipeline lookup source); no bundle partner.",
+    "presentation_registry": "Multi-consumer (get_presentation_registry property + make_router_op_context); reader set differs from the 16-param op-context cluster (get_presentation_registry has no partner there), no clean fold.",
+    "record_spawned_task": "Single-consumer (#2103 S1bc-exec spawn_session path); no bundle partner.",
+    "live_session_id_fn": "Single-consumer (live_session_id property); no bundle partner.",
+    # --- file op callback family (own consumer per callback) ---
+    "file_read": "Single-consumer forwarding callback (its own adapter method); file-op family, no shared-consumer partner.",
+    "file_write": "Single-consumer forwarding callback (its own adapter method); file-op family, no shared-consumer partner.",
+    "file_delete": "Single-consumer forwarding callback (its own adapter method); file-op family, no shared-consumer partner.",
+    "file_regenerate_index": "Single-consumer forwarding callback (its own adapter method); file-op family, no shared-consumer partner.",
+    # --- mcp call family (DECIDED bare, see _MCP_CALL_FAMILY_REASON) ---
+    "mcp_call_tool": _MCP_CALL_FAMILY_REASON,
+    "mcp_read_resource": _MCP_CALL_FAMILY_REASON,
+    "mcp_subscribe_resource": _MCP_CALL_FAMILY_REASON,
+    "mcp_unsubscribe_resource": _MCP_CALL_FAMILY_REASON,
+    "mcp_get_prompt": _MCP_CALL_FAMILY_REASON,
+    # --- action callbacks / trackers (own consumer each) ---
+    "send_to_agent": "Single-consumer action callback (send_to_agent method, plus delegation_tracker fan-out); no shared-consumer partner outside its own method.",
+    "put_outbox": "Single-consumer action callback; no bundle partner.",
+    "append_history": "Single-consumer action callback; no bundle partner.",
+    "delegation_tracker": "Single-consumer tracker getter (send_to_agent's post-dispatch record); no bundle partner.",
+    "agent_replies_tracker": "Single-consumer tracker getter; no bundle partner.",
+    # --- FP-0034 universal catalog / retrieval accessors (each own getter) ---
+    "universal_wrappers_enabled": "Single-consumer (get_universal_wrappers_enabled); no bundle partner.",
+    "action_embedding_index": "Single-consumer (get_action_embedding_index); RouterLoop reads it directly via host.get_action_embedding_index(), not through make_router_op_context — not a member of the op-context cluster.",
+    "embedding_provider": "Single-consumer (get_embedding_provider); same reasoning as action_embedding_index.",
+    "embedding_model_class": "Single-consumer (get_embedding_model_class); same reasoning as action_embedding_index.",
+    "action_usage_tracker": "Single-consumer (get_action_usage_tracker); no bundle partner.",
+    "uncompacted_tool_call_records_fn": "Single-consumer (get_uncompacted_tool_call_records); no bundle partner.",
+    "action_retrieval_config": "Single-consumer (get_action_retrieval_config); no bundle partner.",
+    "available_skills": "Multi-consumer (get_available_skills property + make_router_op_context's fallback-when-no-base-fn branch); reader set differs from the op-context cluster's base_available_skills_fn, no clean fold.",
+    "eager_embedding_build": "Single-consumer (get_eager_embedding_build); no bundle partner.",
+    # --- sandbox / environment (D14 string vs FS-op instance are distinct axes) ---
+    "sandbox_backend": "Single-consumer (get_sandbox_backend, the D14 exec-visibility STRING); distinct axis from sandbox_backend_instance (op-context bundle), no partner.",
+    "environment_backend": "Multi-consumer (get_cwd / get_environment_info / make_router_op_context); reader set spans 3 methods, wider than the op-context cluster, no clean fold.",
+    # --- session-scoped safety / limits ---
+    "session_id": "Multi-consumer (live_session_id property fallback + make_router_op_context); reader set differs from the op-context cluster (live_session_id has no partner there), no clean fold.",
+    "intervention_bus_factory": "Multi-consumer (make_router_op_context + make_intervention_bus); reader set differs from the op-context cluster's own presentation_renderer_factory (make_intervention_bus has no partner there), no clean fold.",
+    "handle_chat_limit_checkpoint": "Single-consumer (_spawn_limit_checkpoint call sites within spawn_session/spawn_agent); no bundle partner.",
+    "safety_extensions": "Single-consumer (read/mutated by the same spawn-limit checkpoint call sites); no bundle partner.",
+    # --- reasoning / media / offload (own accessor pair) ---
+    "reasoning_config": "Single-consumer reasoning display/continuity accessor pair (its own dedicated methods); not read via make_router_op_context, not a member of the op-context cluster.",
+    "reasoning_continuity_section_fn": "Single-consumer (paired with reasoning_config, same dedicated accessor methods); no bundle partner.",
+    "media_store": "Multi-consumer (media_store property + make_router_op_context); reader set differs from the op-context cluster, no clean fold.",
+    "cap_tool_result": "Single-consumer (cap_tool_result method); no bundle partner.",
+    "media_followup_budget": "Single-consumer (media_followup_budget method); no bundle partner.",
+    "offload_enabled": "Single-consumer (offload_enabled property); no bundle partner.",
+    "context_window_status": "Single-consumer (context_window_status property); no bundle partner.",
+    # --- FP-0037 mcp tools cache paths ---
+    "state_dir": "Single-consumer (mcp tools cache file path resolution, _state_dir); no bundle partner.",
+    "project_root": "Single-consumer (yaml scope tier watch, _project_root); no bundle partner.",
+    # --- turn budget / cancel ---
+    "turn_budget_engine": "Multi-consumer (wrap_up_output_reserve property + set_turn_budget_engine); reader set differs from the op-context cluster, no clean fold.",
+    "turn_cancel_fn": "Single-consumer (_is_turn_cancel_requested); no bundle partner.",
+    # --- content-threat scan (widest-shared scalar in the class) ---
+    "threat_scan": "Multi-consumer (scan_tool_result / fence_tool_result / scan_for_block / get_project_context / make_router_op_context — 5 methods); the widest-shared scalar in the class, no single cluster to fold into.",
+}

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -62,10 +62,11 @@ class McpGatewayInputs:
     """#3482: the 3 raw gateway-identity inputs (#3447) whose ONLY reader is
     :meth:`RouterHostAdapter._mcp_list_via_gateway` (measured on current
     main, 890e22d2 — all three read exclusively inside that one method's
-    ``MCPGateway(...)`` construction). A real clustering by consumer set,
-    not a name-prefix grouping: the three arrived together in #3447 (the
-    Path A fold) and are carried together to the same one construction
-    site.
+    gateway construction call. (Wording note: keep the class name away from
+    a following "(" here — the #2813 completeness scanner reads that pattern
+    as a live construction site.) A real clustering by consumer set, not a
+    name-prefix grouping: the three arrived together in #3447 (the Path A
+    fold) and are carried together to the same one construction site.
 
     Pure value object — no defaults, no construction logic (see
     :class:`RouterOpContextInputs`'s docstring for the rationale)."""

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -73,8 +73,10 @@ from reyn.runtime.services import (
     InterventionCoordinator,
     InterventionHandler,
     InterventionRegistry,
+    McpGatewayInputs,
     MemoryService,
     RouterHostAdapter,
+    RouterOpContextInputs,
     SnapshotJournal,
 )
 from reyn.runtime.services.chain_manager import _PendingChain
@@ -3759,6 +3761,46 @@ class Session:
             use_chars4=getattr(self._compaction, "use_chars4_estimate", False),
         )
 
+        # #3482: the 16-param op-context cluster (measured: sole reader is
+        # RouterHostAdapter.make_router_op_context) bundled into one frozen,
+        # default-free dataclass — pure output→input value object, same
+        # values/order as the flat kwargs this replaces (byte-identical).
+        _op_context_inputs = RouterOpContextInputs(
+            allowed_mcp=self._allowed_mcp,
+            base_available_skills_fn=lambda: self._available_skills,
+            budget_gateway=self._budget,
+            compact_now=self._compact_now_for_op,
+            contextual_permission=contextual_permission,  # #1827 S3 → control-IR OpContext (raw initial value, see docstring)
+            hook_bus=self._hook_bus,  # Hook-Event Redesign Phase 5 part 2: emit_hook_event's publish target
+            hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c (router path)
+            hot_reloader=self._hot_reloader,  # #2073 S3 → per-session reload route (tool ctx)
+            multimodal_config=self._multimodal_config,
+            # FP-0054 PR-B / #2708 P1: give the router OpContext a real PresentationRenderer
+            # so a `present` op reaches the surface's sink instead of PR-A's null surface.
+            # Built per make_router_op_context() call. The sink is obtained from the
+            # surface's declared PresentationConsumer (orphan-impossible:
+            # OutboxPresentationRenderer is constructible ONLY inside
+            # OutboxPresentationConsumer.sink) — bound to THIS Session via sink(self).
+            presentation_renderer_factory=lambda: self._presentation_consumer.sink(self),
+            render_template_bounds=self._render_template_bounds,
+            sandbox_backend_instance=self._sandbox_backend,
+            sandbox_policy=(
+                self._sandbox_config.policy if self._sandbox_config is not None
+                else None
+            ),
+            turn_origin_fn=lambda: self._current_turn_origin,
+            workspace_base_dir=self._workspace_base_dir,
+            workspace_state_dir=self._workspace_state_dir,
+        )
+        # #3482/#3447: the 3-param mcp-gateway cluster (sole reader:
+        # RouterHostAdapter._mcp_list_via_gateway) — a real consumer-set
+        # cluster, all three arrived together in #3447's Path A fold.
+        _mcp_gateway_inputs = McpGatewayInputs(
+            mcp_connection_service=self._mcp_connection_service,
+            mcp_agent_id=self._agent.agent_id,
+            ephemeral_fn=lambda: self._ephemeral,
+        )
+
         router_host = RouterHostAdapter(
             # #2175: the safety.on_limit checkpoint + the shared per-run extension dict —
             # so the spawn SEAM (agent_spawn / topology_create) routes spawn-limit exceeds
@@ -3769,23 +3811,12 @@ class Session:
             turn_budget_engine=_chat_turn_budget_engine,
             # FP-0050 / #1822 S2: content-threat scan + fence config.
             threat_scan=self._safety.threat_scan,
-            contextual_permission=contextual_permission,  # #1827 S3 → control-IR OpContext (raw initial value, see docstring)
-            hot_reloader=self._hot_reloader,  # #2073 S3 → per-session reload route (tool ctx)
-            # FP-0063 PC: the router-dispatched `embed` TOOL builds its OpContext from
-            # THIS host (RouterCallerState.op_context_factory = host.make_router_op_context),
-            # so this is the live interactive path's embedding-cost wiring. The gateway is
-            # the single recording entry point (session scope on itself; agent/project via
-            # the shared tracker it holds). Session's own _make_router_op_context serves
-            # file/MCP ops, which no embed op reaches.
-            budget_gateway=self._budget,
+            op_context_inputs=_op_context_inputs,  # #3482
             state_log=self._state_log,  # #2259 PR-1 → config generation emit from config ops
             session_id=self._session_id,
-            hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c (router path)
-            hook_bus=self._hook_bus,  # Hook-Event Redesign Phase 5 part 2: emit_hook_event's publish target
             agent_name=self.agent_name,
             agent_role=self._agent_role,
             output_language=self.output_language,
-            allowed_mcp=self._allowed_mcp,
             permission_resolver=self._perm,
             mcp_servers=self._mcp_servers,
             project_context=self._project_context,
@@ -3810,9 +3841,6 @@ class Session:
             # spawn guard.
             record_spawned_task=self.record_spawned_task,
             live_session_id_fn=lambda: self._session_id,
-            # proposal 0060 Phase 1 (A7): a live callback (not a fixed init
-            # value) because turn_origin varies per turn.
-            turn_origin_fn=lambda: self._current_turn_origin,
             agent_workspace_dir=self.workspace_dir,
             file_read=self._file_read,
             file_write=self._file_write,
@@ -3826,19 +3854,13 @@ class Session:
             mcp_unsubscribe_resource=self._mcp_unsubscribe_resource,
             # #2597 slice ②c: prompt fetch (get).
             mcp_get_prompt=self._mcp_get_prompt,
-            # #3447: the 5 mcp_list_* callbacks (servers/tools/resources/
+            # #3447/#3482: the 5 mcp_list_* callbacks (servers/tools/resources/
             # resource_templates/prompts) were folded onto the adapter itself
             # (RouterHostAdapter.mcp_list_*) — it already duplicated
             # _mcp_servers_flat/_get_mcp_servers_for_router, so only the raw
-            # gateway-identity inputs need threading through, not a callback
-            # per listing method. ``ephemeral_fn`` is a LIVE read (not a
-            # snapshot bool) because ``self._ephemeral`` is reassigned
-            # post-construction by the registry / pipeline_executor_driver
-            # (spawn-time ephemeral flip) — see the ``_spawn_tracker``
-            # construction note above for the same hazard on session_id.
-            mcp_connection_service=self._mcp_connection_service,
-            mcp_agent_id=self._agent.agent_id,
-            ephemeral_fn=lambda: self._ephemeral,
+            # gateway-identity inputs need threading through (mcp_gateway_inputs
+            # bundle, built above), not a callback per listing method.
+            mcp_gateway_inputs=_mcp_gateway_inputs,
             send_to_agent=self._send_to_agent,
             put_outbox=self._put_outbox,
             append_history=self._append_history,
@@ -3855,41 +3877,18 @@ class Session:
             ),
             action_retrieval_config=self._action_retrieval,
             available_skills=self._available_skills,  # #2548 PR-A
-            # #3196: read the BASE skill set here, not RouterHostAdapter's
-            # UX-filtered copy — swapping silently weakens the file-op
-            # skill-provenance trust gate (session-construction.md#base_available_skills_fn-reads-the-base-set-not-the-ux-filtered-copy-3196).
-            base_available_skills_fn=lambda: self._available_skills,
             # Read the injected sandbox_backend INSTANCE's .name, not the
             # config string — a mismatch silently HIDES a working exec
             # capability from discovery (#1417/FP-0034; session-construction.md#sandbox_backend-gate-reads-the-injected-instance-not-the-config-string-1417-fp-0034).
             sandbox_backend=_exec_gate_backend_name(
                 self._sandbox_backend, self._sandbox_config
             ),
-            # #187: the FS env-backend instance + container repo root + host-side
-            # state dir for the LIVE router OpContext Workspace (the registry
-            # file-dispatch factory). Same source as the chat OpContext (#1410).
+            # #187: the FS env-backend instance for the LIVE router OpContext
+            # Workspace (the registry file-dispatch factory). Same source as
+            # the chat OpContext (#1410). (workspace_base_dir/workspace_state_dir/
+            # sandbox_backend_instance/sandbox_policy/multimodal_config/
+            # render_template_bounds now live in op_context_inputs, #3482.)
             environment_backend=self._environment_backend,
-            workspace_base_dir=self._workspace_base_dir,
-            workspace_state_dir=self._workspace_state_dir,
-            # #187 exec-seam (10th defect): the exec backend INSTANCE so the LIVE
-            # router's sandboxed_exec runs in the container repo, not the host
-            # seatbelt fallback. Same instance the legacy _make_router_op_context
-            # passes (4824); chat.py injects the SAME docker backend at both FS +
-            # exec seams (#1289 single-shared-sandbox). Distinct from the D14
-            # STRING above.
-            sandbox_backend_instance=self._sandbox_backend,
-            # #1339 / sandbox-model completion: thread the operator sandbox
-            # policy so make_router_op_context resolves a concrete agent-level
-            # policy onto the router OpContext (closes the chat-factory wiring gap).
-            sandbox_policy=(
-                self._sandbox_config.policy if self._sandbox_config is not None
-                else None
-            ),
-            # Issue #364 multi-modal cluster: media-size gate config.
-            multimodal_config=self._multimodal_config,
-            # FP-0055 / #2679: operator render_template output bounds → the router
-            # OpContext (the render_template op reads ctx.render_template_bounds).
-            render_template_bounds=self._render_template_bounds,
             # #1652: reasoning config (display/continuity/recent_turns gates) +
             # the bounded prior-reasoning section renderer (reads this session's
             # history). The host exposes reasoning_display_enabled() /
@@ -3910,9 +3909,7 @@ class Session:
             # inline-size gate (STRUCTURED_INLINE_MAX_CHARS). Static per-session config,
             # not a callable (unlike the two budgets above, which read live engine state).
             offload_enabled=self._offload_config.enabled,
-            # #272/#1128 compact op: voluntary-compaction callback so the LLM-
-            # emittable `compact` control_ir op can compact chat history.
-            compact_now=self._compact_now_for_op,
+            # (``compact_now`` now lives in op_context_inputs, #3482.)
             # #272/#1128 context-size signal: live exact-token budget so the
             # router SP can show the LLM the free window (header).
             context_window_status=self.context_window_status,
@@ -3923,13 +3920,7 @@ class Session:
             # parent's operator; root/detached -> self-bound), single-sourced via
             # _make_router_intervention_bus. docs/concepts/runtime/intervention-delivery.md#the-single-construction-seam
             intervention_bus_factory=self._make_router_intervention_bus,
-            # FP-0054 PR-B / #2708 P1: give the router OpContext a real PresentationRenderer
-            # so a `present` op reaches the surface's sink instead of PR-A's null surface.
-            # Built per make_router_op_context() call, mirroring the intervention_bus_factory
-            # above. The sink is obtained from the surface's declared PresentationConsumer
-            # (orphan-impossible: OutboxPresentationRenderer is constructible ONLY inside
-            # OutboxPresentationConsumer.sink) — bound to THIS Session via sink(self).
-            presentation_renderer_factory=lambda: self._presentation_consumer.sink(self),
+            # (``presentation_renderer_factory`` now lives in op_context_inputs, #3482.)
             # FP-0037 S2: yaml mtime watch needs the project root to resolve
             # the 3 yaml scope tier paths. None falls back to user-global only.
             project_root=getattr(self._registry, "_project_root", None),

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -10,7 +10,12 @@ from pathlib import Path
 
 from reyn.core.events.events import EventLog
 from reyn.llm.model_resolver import ModelResolver
-from reyn.runtime.services import MemoryService, RouterHostAdapter
+from reyn.runtime.services import (
+    McpGatewayInputs,
+    MemoryService,
+    RouterHostAdapter,
+    RouterOpContextInputs,
+)
 
 
 async def null_file_read(path: str) -> dict:
@@ -109,11 +114,35 @@ def make_adapter(
     _delegations = delegation_list
     _replies = agent_replies_list
 
+    op_context_inputs = RouterOpContextInputs(
+        allowed_mcp=None,
+        base_available_skills_fn=None,
+        budget_gateway=None,
+        compact_now=None,
+        contextual_permission=None,
+        hook_bus=None,
+        hook_dispatcher=None,
+        hot_reloader=None,
+        multimodal_config=None,
+        presentation_renderer_factory=None,
+        render_template_bounds=None,
+        sandbox_backend_instance=None,
+        sandbox_policy=None,
+        turn_origin_fn=turn_origin_fn,
+        workspace_base_dir=workspace_base_dir,
+        workspace_state_dir=None,
+    )
+    mcp_gateway_inputs = McpGatewayInputs(
+        mcp_connection_service=None,
+        mcp_agent_id=None,
+        ephemeral_fn=None,
+    )
+
     return RouterHostAdapter(
         agent_name=agent_name,
         agent_role="test role",
         output_language="en",
-        allowed_mcp=None,
+        op_context_inputs=op_context_inputs,
         permission_resolver=None,
         mcp_servers=None,
         project_context="",
@@ -131,6 +160,7 @@ def make_adapter(
         file_delete=null_file_delete,
         file_regenerate_index=null_file_regen,
         mcp_call_tool=null_mcp_call_tool,
+        mcp_gateway_inputs=mcp_gateway_inputs,
         send_to_agent=null_send_to_agent,
         put_outbox=null_put_outbox,
         append_history=null_append_history,
@@ -139,6 +169,4 @@ def make_adapter(
         turn_budget_engine=turn_budget_engine,
         environment_backend=environment_backend,
         session_id=session_id,
-        turn_origin_fn=turn_origin_fn,
-        workspace_base_dir=workspace_base_dir,
     )

--- a/tests/test_2597_s2b_mcp_notifications_bridge.py
+++ b/tests/test_2597_s2b_mcp_notifications_bridge.py
@@ -20,7 +20,38 @@ from reyn.core.events.events import EventLog
 from reyn.llm.model_resolver import ModelResolver
 from reyn.mcp.connection_service import MCPConnectionService
 from reyn.mcp.message_handler import ReynMCPMessageHandler
-from reyn.runtime.services import MemoryService, RouterHostAdapter
+from reyn.runtime.services import (
+    McpGatewayInputs,
+    MemoryService,
+    RouterHostAdapter,
+    RouterOpContextInputs,
+)
+
+# #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
+# bundled into two frozen, default-free dataclasses. These module-level
+# constants are the "all fields unset" instances this file's tests reuse.
+_EMPTY_OP_CTX = RouterOpContextInputs(
+    allowed_mcp=None,
+    base_available_skills_fn=None,
+    budget_gateway=None,
+    compact_now=None,
+    contextual_permission=None,
+    hook_bus=None,
+    hook_dispatcher=None,
+    hot_reloader=None,
+    multimodal_config=None,
+    presentation_renderer_factory=None,
+    render_template_bounds=None,
+    sandbox_backend_instance=None,
+    sandbox_policy=None,
+    turn_origin_fn=None,
+    workspace_base_dir=None,
+    workspace_state_dir=None,
+)
+_EMPTY_MCP_GATEWAY = McpGatewayInputs(
+    mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
+)
+
 
 _SUPPORT_DIR = Path(__file__).parent / "_support"
 _ECHO_SERVER = _SUPPORT_DIR / "mcp_fastmcp_echo_server.py"
@@ -81,7 +112,7 @@ def _make_adapter(*, tmp_path: Path, events: EventLog) -> RouterHostAdapter:
         agent_name="test-agent",
         agent_role="test",
         output_language="en",
-        allowed_mcp=None,
+        op_context_inputs=_EMPTY_OP_CTX,
         permission_resolver=None,
         mcp_servers={"srv": {}},
         project_context="",
@@ -96,6 +127,7 @@ def _make_adapter(*, tmp_path: Path, events: EventLog) -> RouterHostAdapter:
         file_delete=_null_file_delete,
         file_regenerate_index=_null_file_regen,
         mcp_call_tool=_null_mcp_call_tool,
+        mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
         append_history=_null_append_history,

--- a/tests/test_action_retrieval_wiring.py
+++ b/tests/test_action_retrieval_wiring.py
@@ -24,7 +24,36 @@ import pytest
 
 from reyn.config import ActionRetrievalConfig, ReynConfig, load_config
 from reyn.runtime.router_tools import build_tools
-from reyn.runtime.services.router_host_adapter import RouterHostAdapter
+from reyn.runtime.services.router_host_adapter import (
+    McpGatewayInputs,
+    RouterHostAdapter,
+    RouterOpContextInputs,
+)
+
+# #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
+# bundled into two frozen, default-free dataclasses. These module-level
+# constants are the "all fields unset" instances this file's tests reuse.
+_EMPTY_OP_CTX = RouterOpContextInputs(
+    allowed_mcp=None,
+    base_available_skills_fn=None,
+    budget_gateway=None,
+    compact_now=None,
+    contextual_permission=None,
+    hook_bus=None,
+    hook_dispatcher=None,
+    hot_reloader=None,
+    multimodal_config=None,
+    presentation_renderer_factory=None,
+    render_template_bounds=None,
+    sandbox_backend_instance=None,
+    sandbox_policy=None,
+    turn_origin_fn=None,
+    workspace_base_dir=None,
+    workspace_state_dir=None,
+)
+_EMPTY_MCP_GATEWAY = McpGatewayInputs(
+    mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
+)
 
 
 def _noop_callable(*_args: Any, **_kwargs: Any) -> None:
@@ -55,7 +84,7 @@ def _make_adapter(
         agent_name="test_agent",
         agent_role="test",
         output_language=None,
-        allowed_mcp=None,
+        op_context_inputs=_EMPTY_OP_CTX,
         permission_resolver=None,
         mcp_servers=None,
         project_context="",
@@ -70,6 +99,7 @@ def _make_adapter(
         file_delete=_noop_callable,
         file_regenerate_index=_noop_callable,
         mcp_call_tool=_noop_callable,
+        mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
         send_to_agent=_noop_callable,
         put_outbox=_noop_callable,
         append_history=_noop_callable,

--- a/tests/test_agui_reasoning_map_p6a.py
+++ b/tests/test_agui_reasoning_map_p6a.py
@@ -56,7 +56,38 @@ from reyn.interfaces.transport.agui.protocol import (
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.llm.model_resolver import ModelResolver
 from reyn.runtime.outbox import OutboxMessage
-from reyn.runtime.services import MemoryService, RouterHostAdapter
+from reyn.runtime.services import (
+    McpGatewayInputs,
+    MemoryService,
+    RouterHostAdapter,
+    RouterOpContextInputs,
+)
+
+# #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
+# bundled into two frozen, default-free dataclasses. These module-level
+# constants are the "all fields unset" instances this file's tests reuse.
+_EMPTY_OP_CTX = RouterOpContextInputs(
+    allowed_mcp=None,
+    base_available_skills_fn=None,
+    budget_gateway=None,
+    compact_now=None,
+    contextual_permission=None,
+    hook_bus=None,
+    hook_dispatcher=None,
+    hot_reloader=None,
+    multimodal_config=None,
+    presentation_renderer_factory=None,
+    render_template_bounds=None,
+    sandbox_backend_instance=None,
+    sandbox_policy=None,
+    turn_origin_fn=None,
+    workspace_base_dir=None,
+    workspace_state_dir=None,
+)
+_EMPTY_MCP_GATEWAY = McpGatewayInputs(
+    mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
+)
+
 
 _REASONING_TEXT = "step 1: 17*23 = 391; therefore the answer is 391."
 
@@ -129,7 +160,7 @@ def _mk_host(reasoning_config, *, outbox: list, history: list) -> RouterHostAdap
     workspace = Path(".reyn") / "agents" / "t"
     return RouterHostAdapter(
         agent_name="t", agent_role="r", output_language="en",
-        allowed_mcp=None, permission_resolver=None,
+        op_context_inputs=_EMPTY_OP_CTX, permission_resolver=None,
         mcp_servers=None, project_context="", events=events,
         resolver=ModelResolver({}),
         memory=MemoryService(
@@ -142,6 +173,7 @@ def _mk_host(reasoning_config, *, outbox: list, history: list) -> RouterHostAdap
         file_read=_noop, file_write=_noop, file_delete=_noop,
         file_regenerate_index=_noop,
         mcp_call_tool=_noop,
+        mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
         send_to_agent=_noop,
         put_outbox=lambda msg: outbox.append(msg) or _noop(),
         append_history=lambda msg: history.append(msg),

--- a/tests/test_chat_router_modelspec_kwargs_1654.py
+++ b/tests/test_chat_router_modelspec_kwargs_1654.py
@@ -19,7 +19,38 @@ from typing import Any
 
 from reyn.core.events.events import EventLog
 from reyn.llm.model_resolver import ModelResolver, ModelSpec
-from reyn.runtime.services import MemoryService, RouterHostAdapter
+from reyn.runtime.services import (
+    McpGatewayInputs,
+    MemoryService,
+    RouterHostAdapter,
+    RouterOpContextInputs,
+)
+
+# #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
+# bundled into two frozen, default-free dataclasses. These module-level
+# constants are the "all fields unset" instances this file's tests reuse.
+_EMPTY_OP_CTX = RouterOpContextInputs(
+    allowed_mcp=None,
+    base_available_skills_fn=None,
+    budget_gateway=None,
+    compact_now=None,
+    contextual_permission=None,
+    hook_bus=None,
+    hook_dispatcher=None,
+    hot_reloader=None,
+    multimodal_config=None,
+    presentation_renderer_factory=None,
+    render_template_bounds=None,
+    sandbox_backend_instance=None,
+    sandbox_policy=None,
+    turn_origin_fn=None,
+    workspace_base_dir=None,
+    workspace_state_dir=None,
+)
+_EMPTY_MCP_GATEWAY = McpGatewayInputs(
+    mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
+)
+
 
 _EFFORT = "high"     # non-default reasoning_effort
 _TEMP = 0.37         # non-default temperature
@@ -39,7 +70,7 @@ def _mk_host_with_kwargs():
     })
     return RouterHostAdapter(
         agent_name="t", agent_role="r", output_language="en",
-        allowed_mcp=None, permission_resolver=None,
+        op_context_inputs=_EMPTY_OP_CTX, permission_resolver=None,
         mcp_servers=None, project_context="", events=events, resolver=resolver,
         memory=MemoryService(agent_workspace_dir=workspace, events=events,
             file_write=_noop, file_read=_noop, file_delete=_noop, file_regenerate_index=_noop),
@@ -47,7 +78,7 @@ def _mk_host_with_kwargs():
         agent_workspace_dir=workspace,
         file_read=_noop, file_write=_noop, file_delete=_noop,
         file_regenerate_index=_noop,
-        mcp_call_tool=_noop, send_to_agent=_noop,
+        mcp_call_tool=_noop, mcp_gateway_inputs=_EMPTY_MCP_GATEWAY, send_to_agent=_noop,
         put_outbox=_noop, append_history=_noop,
         delegation_tracker=lambda: [], agent_replies_tracker=lambda: [],
         turn_budget_engine=None, environment_backend=None,

--- a/tests/test_mcp_cache_warm_start.py
+++ b/tests/test_mcp_cache_warm_start.py
@@ -24,7 +24,38 @@ import pytest
 
 from reyn.core.events.events import EventLog
 from reyn.llm.model_resolver import ModelResolver
-from reyn.runtime.services import MemoryService, RouterHostAdapter
+from reyn.runtime.services import (
+    McpGatewayInputs,
+    MemoryService,
+    RouterHostAdapter,
+    RouterOpContextInputs,
+)
+
+# #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
+# bundled into two frozen, default-free dataclasses. These module-level
+# constants are the "all fields unset" instances this file's tests reuse.
+_EMPTY_OP_CTX = RouterOpContextInputs(
+    allowed_mcp=None,
+    base_available_skills_fn=None,
+    budget_gateway=None,
+    compact_now=None,
+    contextual_permission=None,
+    hook_bus=None,
+    hook_dispatcher=None,
+    hot_reloader=None,
+    multimodal_config=None,
+    presentation_renderer_factory=None,
+    render_template_bounds=None,
+    sandbox_backend_instance=None,
+    sandbox_policy=None,
+    turn_origin_fn=None,
+    workspace_base_dir=None,
+    workspace_state_dir=None,
+)
+_EMPTY_MCP_GATEWAY = McpGatewayInputs(
+    mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
+)
+
 from reyn.runtime.services.mcp_cache_file import cache_file_path, write_cache
 
 # ---------------------------------------------------------------------------
@@ -111,7 +142,7 @@ def _make_adapter(
         agent_name="test-agent",
         agent_role="test",
         output_language="en",
-        allowed_mcp=None,
+        op_context_inputs=_EMPTY_OP_CTX,
         permission_resolver=None,
         mcp_servers=mcp_servers,
         project_context="",
@@ -126,6 +157,7 @@ def _make_adapter(
         file_delete=_null_file_delete,
         file_regenerate_index=_null_file_regen,
         mcp_call_tool=_null_mcp_call_tool,
+        mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
         append_history=_null_append_history,

--- a/tests/test_mcp_lazy_tools_cache.py
+++ b/tests/test_mcp_lazy_tools_cache.py
@@ -23,7 +23,38 @@ import pytest
 
 from reyn.core.events.events import EventLog
 from reyn.llm.model_resolver import ModelResolver
-from reyn.runtime.services import MemoryService, RouterHostAdapter
+from reyn.runtime.services import (
+    McpGatewayInputs,
+    MemoryService,
+    RouterHostAdapter,
+    RouterOpContextInputs,
+)
+
+# #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
+# bundled into two frozen, default-free dataclasses. These module-level
+# constants are the "all fields unset" instances this file's tests reuse.
+_EMPTY_OP_CTX = RouterOpContextInputs(
+    allowed_mcp=None,
+    base_available_skills_fn=None,
+    budget_gateway=None,
+    compact_now=None,
+    contextual_permission=None,
+    hook_bus=None,
+    hook_dispatcher=None,
+    hot_reloader=None,
+    multimodal_config=None,
+    presentation_renderer_factory=None,
+    render_template_bounds=None,
+    sandbox_backend_instance=None,
+    sandbox_policy=None,
+    turn_origin_fn=None,
+    workspace_base_dir=None,
+    workspace_state_dir=None,
+)
+_EMPTY_MCP_GATEWAY = McpGatewayInputs(
+    mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
+)
+
 
 
 async def _null_file_read(path: str) -> dict:
@@ -85,7 +116,7 @@ def _make_adapter_with_mcp(
         agent_name="test-agent",
         agent_role="test",
         output_language="en",
-        allowed_mcp=None,
+        op_context_inputs=_EMPTY_OP_CTX,
         permission_resolver=None,
         mcp_servers=mcp_servers,
         project_context="",
@@ -100,6 +131,7 @@ def _make_adapter_with_mcp(
         file_delete=_null_file_delete,
         file_regenerate_index=_null_file_regen,
         mcp_call_tool=_null_mcp_call_tool,
+        mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
         append_history=_null_append_history,

--- a/tests/test_mcp_yaml_mtime_watch.py
+++ b/tests/test_mcp_yaml_mtime_watch.py
@@ -24,7 +24,38 @@ import pytest
 
 from reyn.core.events.events import EventLog
 from reyn.llm.model_resolver import ModelResolver
-from reyn.runtime.services import MemoryService, RouterHostAdapter
+from reyn.runtime.services import (
+    McpGatewayInputs,
+    MemoryService,
+    RouterHostAdapter,
+    RouterOpContextInputs,
+)
+
+# #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
+# bundled into two frozen, default-free dataclasses. These module-level
+# constants are the "all fields unset" instances this file's tests reuse.
+_EMPTY_OP_CTX = RouterOpContextInputs(
+    allowed_mcp=None,
+    base_available_skills_fn=None,
+    budget_gateway=None,
+    compact_now=None,
+    contextual_permission=None,
+    hook_bus=None,
+    hook_dispatcher=None,
+    hot_reloader=None,
+    multimodal_config=None,
+    presentation_renderer_factory=None,
+    render_template_bounds=None,
+    sandbox_backend_instance=None,
+    sandbox_policy=None,
+    turn_origin_fn=None,
+    workspace_base_dir=None,
+    workspace_state_dir=None,
+)
+_EMPTY_MCP_GATEWAY = McpGatewayInputs(
+    mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
+)
+
 from reyn.runtime.services.mcp_cache_file import cache_file_path, read_cache, write_cache
 
 # ---------------------------------------------------------------------------
@@ -121,7 +152,7 @@ def _make_adapter(
         agent_name="test-agent",
         agent_role="test",
         output_language="en",
-        allowed_mcp=None,
+        op_context_inputs=_EMPTY_OP_CTX,
         permission_resolver=None,
         mcp_servers=mcp_servers,
         project_context="",
@@ -136,6 +167,7 @@ def _make_adapter(
         file_delete=_null_file_delete,
         file_regenerate_index=_null_file_regen,
         mcp_call_tool=_null_mcp_call_tool,
+        mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
         append_history=_null_append_history,
@@ -541,7 +573,7 @@ async def test_session_handle_user_message_calls_yaml_watch_before_reload(
         agent_name="order-test",
         agent_role="test",
         output_language="en",
-        allowed_mcp=None,
+        op_context_inputs=_EMPTY_OP_CTX,
         permission_resolver=None,
         mcp_servers=None,
         project_context="",
@@ -556,6 +588,7 @@ async def test_session_handle_user_message_calls_yaml_watch_before_reload(
         file_delete=_null_file_delete,
         file_regenerate_index=_null_file_regen,
         mcp_call_tool=_null_mcp_call_tool,
+        mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
         append_history=_null_append_history,

--- a/tests/test_reasoning_integration_1652.py
+++ b/tests/test_reasoning_integration_1652.py
@@ -23,7 +23,38 @@ from reyn.core.events.events import EventLog
 from reyn.core.events.state_log import StateLog
 from reyn.llm.model_resolver import ModelResolver
 from reyn.runtime.chat_message import ChatMessage
-from reyn.runtime.services import MemoryService, RouterHostAdapter
+from reyn.runtime.services import (
+    McpGatewayInputs,
+    MemoryService,
+    RouterHostAdapter,
+    RouterOpContextInputs,
+)
+
+# #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
+# bundled into two frozen, default-free dataclasses. These module-level
+# constants are the "all fields unset" instances this file's tests reuse.
+_EMPTY_OP_CTX = RouterOpContextInputs(
+    allowed_mcp=None,
+    base_available_skills_fn=None,
+    budget_gateway=None,
+    compact_now=None,
+    contextual_permission=None,
+    hook_bus=None,
+    hook_dispatcher=None,
+    hot_reloader=None,
+    multimodal_config=None,
+    presentation_renderer_factory=None,
+    render_template_bounds=None,
+    sandbox_backend_instance=None,
+    sandbox_policy=None,
+    turn_origin_fn=None,
+    workspace_base_dir=None,
+    workspace_state_dir=None,
+)
+_EMPTY_MCP_GATEWAY = McpGatewayInputs(
+    mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
+)
+
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 
@@ -39,7 +70,7 @@ def _mk_host(reasoning_config, *, outbox: list, history: list, section: str = ""
     workspace = Path(".reyn") / "agents" / "t"
     return RouterHostAdapter(
         agent_name="t", agent_role="r", output_language="en",
-        allowed_mcp=None, permission_resolver=None,
+        op_context_inputs=_EMPTY_OP_CTX, permission_resolver=None,
         mcp_servers=None, project_context="", events=events,
         resolver=ModelResolver({}),
         memory=MemoryService(
@@ -52,6 +83,7 @@ def _mk_host(reasoning_config, *, outbox: list, history: list, section: str = ""
         file_read=_noop, file_write=_noop, file_delete=_noop,
         file_regenerate_index=_noop,
         mcp_call_tool=_noop,
+        mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
         send_to_agent=_noop,
         put_outbox=lambda msg: outbox.append(msg) or _noop(),
         append_history=lambda msg: history.append(msg),

--- a/tests/test_router_host_adapter_invariants.py
+++ b/tests/test_router_host_adapter_invariants.py
@@ -14,11 +14,43 @@ import pytest
 from reyn.core.events.events import EventLog
 from reyn.llm.model_resolver import ModelResolver
 from reyn.runtime.router_loop import RouterLoopHost
-from reyn.runtime.services import MemoryService, RouterHostAdapter
+from reyn.runtime.services import (
+    McpGatewayInputs,
+    MemoryService,
+    RouterHostAdapter,
+    RouterOpContextInputs,
+)
 
 # ---------------------------------------------------------------------------
 # Minimal stubs and helpers
 # ---------------------------------------------------------------------------
+
+# #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
+# bundled into two frozen, default-free dataclasses. These module-level
+# constants are the "all fields unset" instances the tests below reuse —
+# the bundle classes themselves stay default-free (see RouterOpContextInputs
+# / McpGatewayInputs docstrings), the defaulting lives here in caller code.
+_EMPTY_OP_CTX = RouterOpContextInputs(
+    allowed_mcp=None,
+    base_available_skills_fn=None,
+    budget_gateway=None,
+    compact_now=None,
+    contextual_permission=None,
+    hook_bus=None,
+    hook_dispatcher=None,
+    hot_reloader=None,
+    multimodal_config=None,
+    presentation_renderer_factory=None,
+    render_template_bounds=None,
+    sandbox_backend_instance=None,
+    sandbox_policy=None,
+    turn_origin_fn=None,
+    workspace_base_dir=None,
+    workspace_state_dir=None,
+)
+_EMPTY_MCP_GATEWAY = McpGatewayInputs(
+    mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
+)
 
 class _FakeEventStore:
     """Minimal event store that discards events."""
@@ -155,7 +187,7 @@ def test_delegation_tracker_appended_on_send_to_agent(tmp_path):
         agent_name="alpha",
         agent_role="role",
         output_language=None,
-        allowed_mcp=None,
+        op_context_inputs=_EMPTY_OP_CTX,
         permission_resolver=None,
         mcp_servers=None,
         project_context="",
@@ -177,6 +209,7 @@ def test_delegation_tracker_appended_on_send_to_agent(tmp_path):
         file_delete=_null_file_delete,
         file_regenerate_index=_null_file_regen,
         mcp_call_tool=_null_mcp_call_tool,
+        mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
         send_to_agent=fake_send,
         put_outbox=_null_put_outbox,
         append_history=_null_append_history,
@@ -232,7 +265,7 @@ def test_adapter_exposes_permission_resolver_property(tmp_path):
         agent_name="alpha2",
         agent_role="role",
         output_language=None,
-        allowed_mcp=None,
+        op_context_inputs=_EMPTY_OP_CTX,
         permission_resolver=sentinel,
         mcp_servers=None,
         project_context="",
@@ -247,6 +280,7 @@ def test_adapter_exposes_permission_resolver_property(tmp_path):
         file_delete=_null_file_delete,
         file_regenerate_index=_null_file_regen,
         mcp_call_tool=_null_mcp_call_tool,
+        mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
         append_history=_null_append_history,
@@ -289,7 +323,7 @@ def test_make_router_op_context_wires_intervention_bus(tmp_path):
         agent_name="bus-test",
         agent_role="role",
         output_language=None,
-        allowed_mcp=None,
+        op_context_inputs=_EMPTY_OP_CTX,
         permission_resolver=None,
         mcp_servers=None,
         project_context="",
@@ -304,6 +338,7 @@ def test_make_router_op_context_wires_intervention_bus(tmp_path):
         file_delete=_null_file_delete,
         file_regenerate_index=_null_file_regen,
         mcp_call_tool=_null_mcp_call_tool,
+        mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
         append_history=_null_append_history,
@@ -345,7 +380,7 @@ def test_make_router_op_context_no_factory_leaves_bus_none(tmp_path):
         agent_name="nobus-test",
         agent_role="role",
         output_language=None,
-        allowed_mcp=None,
+        op_context_inputs=_EMPTY_OP_CTX,
         permission_resolver=None,
         mcp_servers=None,
         project_context="",
@@ -360,6 +395,7 @@ def test_make_router_op_context_no_factory_leaves_bus_none(tmp_path):
         file_delete=_null_file_delete,
         file_regenerate_index=_null_file_regen,
         mcp_call_tool=_null_mcp_call_tool,
+        mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
         send_to_agent=_null_send_to_agent,
         put_outbox=_null_put_outbox,
         append_history=_null_append_history,

--- a/tests/test_router_host_adapter_param_gate_3482.py
+++ b/tests/test_router_host_adapter_param_gate_3482.py
@@ -1,0 +1,143 @@
+"""Tier 2: OS invariant — every RouterHostAdapter.__init__ param's annotation
+is either a registered bundle type or a reasoned scalar exception (#3482,
+mirroring #3451/#3437's AST-derived SSoT + bidirectional-gate shape).
+
+The #3482 firm (issue thread, architect's re-grounded comment on current
+main 890e22d2) measured two real consumer-set clusters in RouterHostAdapter's
+77 constructor params — the 16-field op-context cluster
+(``RouterOpContextInputs``, sole reader ``make_router_op_context``) and the
+3-field mcp-gateway cluster (``McpGatewayInputs``, sole reader
+``_mcp_list_via_gateway``) — and explicitly REJECTED forcing 100% bundle
+coverage ("consumer 集合が一致するものだけを束ねる... 強制収容は接頭辞
+（形）に逃げる圧力になります"). The remaining ~58 params stay bare scalars,
+each with a reason recorded in ``ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS``.
+
+This is NOT a param-count pin (Tier-4): the gate never compares against a
+fixed N. It asserts a STRUCTURE — every param falls into one of exactly two
+buckets, both enumerable and both non-empty — so a new bare param added
+tomorrow with neither a bundle annotation nor a registry entry goes RED at
+the exact moment it's added, not silently.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from reyn.runtime.services.router_host_adapter import (
+    ROUTER_HOST_ADAPTER_BUNDLE_TYPES,
+    ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS,
+    RouterHostAdapter,
+)
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for ancestor in here.parents:
+        if (ancestor / "pyproject.toml").is_file():
+            return ancestor
+    raise RuntimeError("repo root not found from " + str(here))
+
+
+def _init_params() -> list[tuple[str, "str | None"]]:
+    """AST-derive {param_name: annotation_source} for RouterHostAdapter.__init__
+    from the REAL file on disk — never a hand-maintained list (the #3437/#3451
+    lesson: a hand-written enumeration silently drifts from the signature)."""
+    root = _repo_root()
+    path = root / "src" / "reyn" / "runtime" / "services" / "router_host_adapter.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "RouterHostAdapter":
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == "__init__":
+                    args = item.args
+                    out = []
+                    for a in (*args.posonlyargs, *args.args, *args.kwonlyargs):
+                        if a.arg == "self":
+                            continue
+                        ann = ast.unparse(a.annotation) if a.annotation else None
+                        out.append((a.arg, ann))
+                    return out
+    raise RuntimeError("RouterHostAdapter.__init__ not found via AST")
+
+
+def test_bundle_type_and_exception_registries_are_non_empty() -> None:
+    """Tier 2: vacuity guard — an empty registry on either side would make
+    the completeness assertion below pass trivially (#3437's vacuity lesson:
+    a gate that can be satisfied by declaring nothing is not a gate)."""
+    assert ROUTER_HOST_ADAPTER_BUNDLE_TYPES, (
+        "ROUTER_HOST_ADAPTER_BUNDLE_TYPES is empty — the gate would vacuously "
+        "pass by finding no bundle-typed params to recognize."
+    )
+    assert ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS, (
+        "ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS is empty — the gate would "
+        "vacuously pass by finding no exceptions either."
+    )
+    for name, reason in ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS.items():
+        assert reason and reason.strip(), (
+            f"scalar exception {name!r} has an empty reason — a registry "
+            "entry with no reason is a bare param wearing a disguise."
+        )
+
+
+def test_every_init_param_is_bundled_or_reasoned() -> None:
+    """Tier 2: every RouterHostAdapter.__init__ param (AST-derived from the
+    real file, not hand-listed) has an annotation naming a registered bundle
+    type, OR is a key in the scalar exception registry with a reason.
+
+    RED the moment a new bare param (e.g. ``foo_fn: Callable``) is added
+    without either — the exact N+1 gate the #3482 firm required, without
+    pinning a param count (Tier-4)."""
+    params = _init_params()
+    assert params, "AST found zero __init__ params — parser drifted from the real signature."
+
+    undeclared: list[tuple[str, "str | None"]] = []
+    for name, ann in params:
+        ann_str = ann or ""
+        if any(bundle_name in ann_str for bundle_name in ROUTER_HOST_ADAPTER_BUNDLE_TYPES):
+            continue
+        if name in ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS:
+            continue
+        undeclared.append((name, ann))
+
+    assert not undeclared, (
+        "RouterHostAdapter.__init__ has params with neither a registered bundle "
+        "annotation nor a scalar-exception registry entry — a bare param slipped "
+        "in uncovered:\n"
+        + "\n".join(f"  {n}: {a}" for n, a in undeclared)
+        + "\nEither fold it into an existing/new bundle (if it shares a consumer "
+        "with one), or add it to ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS with a "
+        "reason (current-form, not a scheduled future fold)."
+    )
+
+
+def test_scalar_exception_keys_match_real_bare_params_exactly() -> None:
+    """Tier 2: real ⊆ declared AND declared ⊆ real — the registry names
+    exactly the params that are actually bare scalars right now, no more, no
+    less. Catches BOTH a stale entry (param renamed/removed/bundled but the
+    registry key survives) and a param quietly re-annotated to a bundle type
+    while a same-named registry entry lingers unnoticed."""
+    params = _init_params()
+    bare_now = {
+        name
+        for name, ann in params
+        if not any(bundle_name in (ann or "") for bundle_name in ROUTER_HOST_ADAPTER_BUNDLE_TYPES)
+    }
+    registered = set(ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS)
+
+    stale = registered - bare_now
+    assert not stale, (
+        f"ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS has stale entries no longer "
+        f"matching a bare __init__ param: {sorted(stale)}"
+    )
+    missing = bare_now - registered
+    assert not missing, (
+        f"These bare __init__ params have no scalar-exception registry entry: "
+        f"{sorted(missing)}"
+    )
+
+
+def test_router_host_adapter_is_the_real_class_under_gate() -> None:
+    """Tier 2: sanity — RouterHostAdapter imports cleanly and is the class
+    the AST walk above is describing (import-identity check, not a private-
+    state assertion)."""
+    assert RouterHostAdapter.__name__ == "RouterHostAdapter"


### PR DESCRIPTION
**[per-PR-coder]** — implements #3482 per the architect's re-grounded firm (current main, 890e22d2 at measurement time).

## What this does

`RouterHostAdapter.__init__` had 77 flat params. Per the architect's AST-measured firm (issue thread), two REAL consumer-set clusters exist:

1. **`RouterOpContextInputs`** (16 fields) — every field's sole reader is `RouterHostAdapter.make_router_op_context`; the adapter is a pure relay for this cluster (Session → make_router_op_context, nothing else touches these 16 in between). Fields: `allowed_mcp`, `base_available_skills_fn`, `budget_gateway`, `compact_now`, `contextual_permission`, `hook_bus`, `hook_dispatcher`, `hot_reloader`, `multimodal_config`, `presentation_renderer_factory`, `render_template_bounds`, `sandbox_backend_instance`, `sandbox_policy`, `turn_origin_fn`, `workspace_base_dir`, `workspace_state_dir`.
2. **`McpGatewayInputs`** (3 fields) — `mcp_connection_service` / `mcp_agent_id` / `ephemeral_fn`, all three read only inside `_mcp_list_via_gateway` (#3447's Path A fold; a real cluster, not a name-prefix grouping).

Both are frozen `@dataclass`es with **no default field values** (a default would let a caller's silent omission absorb a wiring change, breaking the byte-identical-refactor invariant #3082 established) and **no construction logic** (pure data — building the 16/3 values stays the caller's job, unchanged from before).

The remaining ~58 params stay bare scalars — bundle coverage is **deliberately not 100%** (the architect: forcing full coverage is a name-prefix/shape pressure, not a consumer-set one). Each bare param is registered in `ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS` (`router_host_adapter.py`) with a reason. Six of them (the 5 mcp call-family callbacks + `mcp_servers`) get the specific "DECIDED to stay bare, no scheduled fold" wording the architect required — never a stated future resolution for unscheduled work.

## N+1 gate (`tests/test_router_host_adapter_param_gate_3482.py`)

AST-derives every `__init__` param from the real source file (never hand-listed) and asserts each one's annotation names a registered bundle type OR is a key in the scalar-exception registry. No count is pinned (Tier-4 avoided). Bidirectional check also catches stale registry entries.

**RED verified**: injected a bare `strip_witness_foo_fn: Callable[[], Any] | None = None` param — both completeness assertions failed listing exactly that name. Restored via `cp` from a scratch backup (no `git stash`).

## Callsite sweep

- `src/reyn/runtime/session.py` — builds both bundles just before `RouterHostAdapter(...)`, same field expressions as before (byte-identical: same objects, same lambdas, same order).
- `src/reyn/runtime/services/__init__.py` — re-exports `RouterOpContextInputs` / `McpGatewayInputs`.
- `tests/_support/router_host_adapter.py` (shared DI-seam builder) + 9 test files that constructed `RouterHostAdapter` directly (mirrors #3481's DI-seam sweep) — all updated to build the two bundles (all-`None` where the old flat kwargs were omitted, since the bundle has no default to silently absorb that).
- `docs/reference/runtime/session-construction.md` — Family 6a section updated with the #3482 bundling note (doc-stays-synced rule).

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 71 tests inspected, 0 Tier-4 violations
- [x] `pytest` (full suite, `-n auto`, background) — see result in PR comment
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] N+1 gate RED-verified with bare strip-witness param, then restored
- [x] 16-param / 3-param cluster re-measured on current branch — matches architect's list exactly (allowed_mcp, base_available_skills_fn, budget_gateway, compact_now, contextual_permission, hook_bus, hook_dispatcher, hot_reloader, multimodal_config, presentation_renderer_factory, render_template_bounds, sandbox_backend_instance, sandbox_policy, turn_origin_fn, workspace_base_dir, workspace_state_dir / mcp_connection_service, mcp_agent_id, ephemeral_fn)

Closes #3482
