### PR TITLE
feat(tui): lazy history paging on ReachedTop + /copy ring eviction fix (part of #3476)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -198,6 +198,41 @@ def empty_state_hint() -> "object":
     return hint
 
 
+#: #3476 ④: restored-history page size, in display frames. Hydration appends
+#: only the newest page; older frames page in via
+#: :meth:`TextualChatApp.on_flow_view_reached_top` as the user scrolls up.
+#: 200 frames ≈ a full page-in stays well under one frame budget at the
+#: measured ~1µs/entry handle cost, while covering far more than one viewport
+#: (so a single page-in absorbs several screens of scrolling before the next).
+_HYDRATE_PAGE_FRAMES = 200
+
+
+def _apply_restored_state(msg: "OutboxMessage", entry: "Entry[OutboxMessage]") -> None:
+    """The restored-frame state transition, shared by initial hydration and
+    the #3476 ④ lazy page-in — resolved, never RUNNING: mirror the completion
+    handler's terminal transition for a settled tool result (SUCCESS unless
+    the summary marks a failure); non-tool rows keep DEFAULT."""
+    meta = msg.meta or {}
+    if msg.kind == "tool_call_started" and _RESULT_KIND_KEY in meta:
+        result_meta = meta.get(_RESULT_META_KEY) or {}
+        if meta[_RESULT_KIND_KEY] == "tool_call_failed":
+            entry.set_state(EntryState.ERROR)
+        else:
+            summary = summarize_tool_result(
+                meta.get("tool"), result_meta.get("result")
+            )
+            entry.set_state(
+                EntryState.ERROR if summary.startswith("✗") else EntryState.SUCCESS
+            )
+    elif msg.kind == "tool_call_completed":
+        summary = summarize_tool_result(meta.get("tool"), meta.get("result"))
+        entry.set_state(
+            EntryState.ERROR if summary.startswith("✗") else EntryState.SUCCESS
+        )
+    elif msg.kind == "tool_call_failed":
+        entry.set_state(EntryState.ERROR)
+
+
 #: Sentinel for :meth:`TextualChatApp._pane_rows`'s optional ``snap`` argument —
 #: distinguishes "no snapshot passed, read a fresh one" from an explicit ``None``
 #: snapshot (pre-session), which must NOT trigger a second read.
@@ -751,6 +786,13 @@ class TextualChatApp(App):
         # dict, so it is reset explicitly on a session switch rather than by
         # :attr:`_PER_SESSION_DICT_STATE`'s uniform ``.clear()`` loop.
         self._recent_replies: "deque[str]" = deque(maxlen=COPY_BUFFER_MAX)
+        # #3476 ④: restored frames older than the hydrated tail page, oldest
+        # first — consumed from the end, one page per ReachedTop, by
+        # :meth:`on_flow_view_reached_top`. Reset by every
+        # :meth:`_hydrate_from_history` call (initial mount AND session
+        # switch), so a switch can never page in the previous session's
+        # leftovers.
+        self._older_frames: "list[OutboxMessage]" = []
 
     def compose(self) -> ComposeResult:
         # Held so the frame pump can start/stop the per-entry BODY animation
@@ -783,6 +825,10 @@ class TextualChatApp(App):
             # lands — no app-side show/hide wiring to drift.
             empty=empty_state_hint(),
             empty_align="middle",
+            # #3476 ④: fire ReachedTop while the top edge is still a few rows
+            # away, so the next history page is in place by the time the user
+            # actually arrives at it.
+            reach_threshold=3,
         )
         # #3352: apply the configured START state. flowview has no constructor
         # parameter for gutter visibility (both flags initialise True), so the
@@ -1077,52 +1123,64 @@ class TextualChatApp(App):
         except Exception:
             logger.exception("textual chat: history projection failed")
             return
+        # #3476 ④: LAZY page split — only the newest ``_HYDRATE_PAGE_FRAMES``
+        # are appended now; the older prefix is held aside and prepended a
+        # page at a time by :meth:`on_flow_view_reached_top` as the user
+        # scrolls toward it (flowview keeps the scroll position across a
+        # prepend). Measured (#3476 issue comment): the view-side win is
+        # small at realistic history sizes — this is deliberate owner-chosen
+        # forward infrastructure, and the split costs one slice.
+        self._older_frames = frames[:-_HYDRATE_PAGE_FRAMES]
+        tail = frames[-_HYDRATE_PAGE_FRAMES:]
         # #3476 ②: batch append — ``extend`` reflows the view ONCE for the
-        # whole restored history instead of once per entry (flowview 0.6.0;
-        # the per-entry ``set_state`` calls below redraw only the gutter, no
+        # whole appended page instead of once per entry (flowview 0.6.0;
+        # the per-entry ``set_state`` calls redraw only the gutter, no
         # reflow). Handle creation cannot fail per-item (presentation runs at
         # paint, not append), so the one try/except covers what the old
         # per-item guard did.
         try:
-            entries = self.conversation.extend(frames)
+            entries = self.conversation.extend(tail)
         except Exception:
             logger.exception("textual chat: restore batch append failed")
             return
-        for msg, entry in zip(frames, entries):
-            # Resolved, never RUNNING — mirror the completion handler's terminal
-            # transition for a settled tool result (SUCCESS unless the summary
-            # marks a failure); non-tool rows keep DEFAULT.
-            meta = msg.meta or {}
-            if msg.kind == "tool_call_started" and _RESULT_KIND_KEY in meta:
-                result_meta = meta.get(_RESULT_META_KEY) or {}
-                if meta[_RESULT_KIND_KEY] == "tool_call_failed":
-                    entry.set_state(EntryState.ERROR)
-                else:
-                    summary = summarize_tool_result(
-                        meta.get("tool"), result_meta.get("result")
-                    )
-                    entry.set_state(
-                        EntryState.ERROR
-                        if summary.startswith("✗")
-                        else EntryState.SUCCESS
-                    )
-            elif msg.kind == "tool_call_completed":
-                summary = summarize_tool_result(meta.get("tool"), meta.get("result"))
-                entry.set_state(
-                    EntryState.ERROR if summary.startswith("✗") else EntryState.SUCCESS
-                )
-            elif msg.kind == "tool_call_failed":
-                entry.set_state(EntryState.ERROR)
-        # #3362: seed the ``/copy`` ring from the SAME restored frames, so a
-        # reply visible in the pane after a restart / session switch is one
-        # ``/copy`` can reach. ``frames`` is oldest-first (as rendered), the ring
-        # is newest-first, hence the reversal; the ring's own ``maxlen`` bounds
-        # it, so a long history cannot grow this past ``COPY_BUFFER_MAX``. The
-        # caller clears the ring alongside ``conversation.clear()``, exactly as
-        # it does for the model this loop re-appends to.
-        for msg in reversed(frames):
+        for msg, entry in zip(tail, entries):
+            _apply_restored_state(msg, entry)
+        # #3362: seed the ``/copy`` ring from ALL restored frames — including
+        # the not-yet-paged-in older prefix (#3476 ④): what ``/copy`` can
+        # reach is the restored HISTORY, not the currently materialised page.
+        # #3486: ``appendleft`` in natural (oldest-first) order — the SAME
+        # direction the live pump uses — so index 0 is the newest reply AND
+        # ``maxlen`` evicts from the OLDEST side. The previous
+        # ``reversed(frames)`` + ``append`` expressed newest-first correctly
+        # only while the reply count stayed ≤ ``COPY_BUFFER_MAX``: past it,
+        # ``append`` evicts from the LEFT — the newest side — silently
+        # inverting the "1 = newest" contract for any restored history with
+        # more than ``COPY_BUFFER_MAX`` replies. The caller clears the ring
+        # alongside ``conversation.clear()``, exactly as it does for the
+        # model this loop re-appends to.
+        for msg in frames:
             if msg.kind == "agent":
-                self._recent_replies.append(msg.text)
+                self._recent_replies.appendleft(msg.text)
+
+    def on_flow_view_reached_top(self, event: "FlowView.ReachedTop") -> None:
+        """#3476 ④: page the next-older slice of the restored history in when
+        the user scrolls near the top. ``insert_many(0, …)`` reflows once and
+        flowview keeps the scroll position (the row being read stays put), so
+        the page lands invisibly above. Fires once per approach and re-arms on
+        retreat (flowview's edge-trigger contract); with nothing left to page
+        in this is a no-op. Live frames are unaffected — they append at the
+        bottom through the frame pump, never through this path."""
+        if not self._older_frames:
+            return
+        page = self._older_frames[-_HYDRATE_PAGE_FRAMES:]
+        try:
+            entries = self.conversation.insert_many(0, page)
+        except Exception:
+            logger.exception("textual chat: lazy history page-in failed")
+            return
+        self._older_frames = self._older_frames[:-_HYDRATE_PAGE_FRAMES]
+        for msg, entry in zip(page, entries):
+            _apply_restored_state(msg, entry)
 
     def _open_drawer(self, tab_id: "str | None") -> None:
         """Expand/collapse the downward drawer. ``None`` (or the ``"__close__"``

--- a/tests/test_lazy_history_paging_3476.py
+++ b/tests/test_lazy_history_paging_3476.py
@@ -1,0 +1,295 @@
+"""#3476 ④ — lazy history paging: hydrate the newest page, page older frames
+in on ReachedTop.
+
+Hydration appends only the newest ``_HYDRATE_PAGE_FRAMES`` restored frames;
+the older prefix pages in a slice at a time as the user scrolls toward the
+top (``FlowView.ReachedTop`` → ``insert_many(0, …)``, scroll position kept by
+flowview). Owner-chosen forward infrastructure — the view-side cost of full
+hydration was measured small (#3476 issue comment), so what these tests pin
+is CORRECTNESS of the paging, not a performance claim:
+
+- the initially materialised page is exactly the newest slice of the real
+  projection, in order (expected values come from running the REAL
+  ``project_restored_frames`` on the same log, never hand-arithmetic);
+- a real scroll to the top pages the previous slice in — contiguous, in
+  order — repeatedly until the full history is materialised, after which
+  further top-scrolls are no-ops;
+- a restored tool frame paged in lazily still gets its terminal entry state
+  (the shared ``_apply_restored_state`` runs on the page-in path too);
+- ``/copy`` after a long restore honors the 1=newest contract (#3486: the
+  hydrate seeding used to invert the ring's eviction direction past
+  ``COPY_BUFFER_MAX``) — witnessed through the real copy path, not the ring.
+
+Real ``TextualChatApp`` + the same concrete ``ChatReadModel`` seam shape the
+phase-5 restore suite drives — no mocks."""
+from __future__ import annotations
+
+import asyncio
+import os
+import stat
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import EntryState, FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.app import _HYDRATE_PAGE_FRAMES
+from reyn.interfaces.inline.textual_chat.restore import project_restored_frames
+from reyn.interfaces.repl.read_model import ChatReadModel
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _Transport(ClientTransport):
+    def __init__(self) -> None:
+        self.submitted: list[str] = []
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        await asyncio.Event().wait()
+        yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
+
+    async def submit_user_text(self, text: str) -> None:
+        self.submitted.append(text)
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+class _HistoryReadModel(ChatReadModel):
+    """A real :class:`ChatReadModel` seam impl (the phase-5 suite's shape):
+    ``conversation_history`` serves a synthetic persisted log, so the REAL
+    hydrate + projector run end to end."""
+
+    def __init__(self, messages: "list[ChatMessage]") -> None:
+        self._messages = messages
+
+    def snapshot(self, config=None):
+        return None
+
+    def intervention_head(self):
+        return None
+
+    def pending_command_ui(self):
+        return None
+
+    def clear_pending_command_ui(self) -> None:
+        return None
+
+    def has_command_ui_region(self) -> bool:
+        return True
+
+    def history_path(self) -> Path:
+        return Path("/tmp/reyn_lazy_paging_input_history")
+
+    def conversation_history(self, *, limit=None):
+        return self._messages[-limit:] if limit is not None else list(self._messages)
+
+
+def _turns(n_turns: int) -> "list[ChatMessage]":
+    return [
+        m
+        for i in range(n_turns)
+        for m in (
+            ChatMessage(role="user", content=f"question {i}"),
+            ChatMessage(role="assistant", content=f"answer {i}"),
+        )
+    ]
+
+
+def _expected_texts(log: "list[ChatMessage]") -> "list[str]":
+    """What the FULL materialised pane should hold — derived from the real
+    projector, never hand-arithmetic (the projection adds e.g. the resume
+    divider; recomputing its shape here would just duplicate it wrongly)."""
+    return [frame.text for frame in project_restored_frames(log)]
+
+
+def _texts(app: TextualChatApp) -> "list[str]":
+    return [entry.item.text for entry in app.conversation]
+
+
+@pytest.mark.asyncio
+async def test_hydration_materialises_exactly_the_newest_page() -> None:
+    """Tier 2b: with a history longer than one page, the pane opens holding
+    exactly the newest ``_HYDRATE_PAGE_FRAMES`` frames — the contiguous TAIL
+    of the real projection."""
+    log = _turns(_HYDRATE_PAGE_FRAMES)  # 2 frames/turn + divider -> ~2 pages
+    app = TextualChatApp(transport=_Transport(), read_model=_HistoryReadModel(log))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        expected_full = _expected_texts(log)
+        assert len(expected_full) > _HYDRATE_PAGE_FRAMES, (
+            "test setup: the history does not exceed one page"
+        )
+        assert _texts(app) == expected_full[-_HYDRATE_PAGE_FRAMES:], (
+            "the materialised page is not the projection's newest slice"
+        )
+
+
+@pytest.mark.asyncio
+async def test_scrolling_to_the_top_pages_older_history_in_until_exhausted() -> None:
+    """Tier 2b: ReachedTop (driven by a REAL scroll to the top, not a
+    hand-posted message) prepends the previous page — and repeating the
+    scroll materialises the FULL projection, in order, after which further
+    top-scrolls are no-ops."""
+    log = _turns(_HYDRATE_PAGE_FRAMES + 10)
+    app = TextualChatApp(transport=_Transport(), read_model=_HistoryReadModel(log))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        flow = app.query_one(FlowView)
+        expected_full = _expected_texts(log)
+        assert len(_texts(app)) < len(expected_full), (
+            "test setup: nothing left to page in"
+        )
+
+        for _ in range(6):  # more rounds than pages — proves the no-op tail
+            flow.scroll_to_top()
+            await pilot.pause()
+            await pilot.pause()
+            if len(_texts(app)) == len(expected_full):
+                break
+            # Leave the edge so flowview re-arms the trigger for the next round.
+            flow.scroll_to_bottom()
+            await pilot.pause()
+
+        assert _texts(app) == expected_full, (
+            "the fully paged-in pane does not equal the projection "
+            f"({len(_texts(app))} of {len(expected_full)} frames)"
+        )
+
+        flow.scroll_to_top()
+        await pilot.pause()
+        assert len(_texts(app)) == len(expected_full), (
+            "exhausted paging was not a no-op"
+        )
+
+
+@pytest.mark.asyncio
+async def test_lazily_paged_tool_frame_gets_its_terminal_state() -> None:
+    """Tier 2b: a coalesced tool frame living in the OLDER (lazily paged)
+    slice arrives with a TERMINAL entry state, not DEFAULT — the shared
+    ``_apply_restored_state`` runs on the page-in path, not only on the
+    initial hydrate."""
+    log: "list[ChatMessage]" = [
+        ChatMessage(role="user", content="old question"),
+        ChatMessage(
+            role="assistant",
+            content="",
+            tool_calls=[{
+                "id": "call_old",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": '{"path": "a.py"}'},
+            }],
+        ),
+        ChatMessage(
+            role="tool", content="Read 1 line", name="read_file",
+            tool_call_id="call_old",
+        ),
+    ]
+    log += _turns(_HYDRATE_PAGE_FRAMES // 2)  # tail keeps the tool frame unpaged
+    app = TextualChatApp(transport=_Transport(), read_model=_HistoryReadModel(log))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        assert not any(
+            e.item.kind == "tool_call_started" for e in app.conversation
+        ), "test setup: the tool frame is already materialised"
+
+        flow = app.query_one(FlowView)
+        flow.scroll_to_top()
+        await pilot.pause()
+        await pilot.pause()
+
+        tool_entries = [
+            e for e in app.conversation if e.item.kind == "tool_call_started"
+        ]
+        assert tool_entries, "the tool frame never paged in"
+        assert tool_entries[0].state is not EntryState.DEFAULT, (
+            "the paged-in tool frame kept DEFAULT state — _apply_restored_state "
+            "did not run on the page-in path"
+        )
+
+
+class _SentinelTransport(_Transport):
+    """Emits one ``__copy_last_reply__`` display frame after mount, then stays
+    open — the real public route into the copy path (no ring internals read)."""
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        yield DisplayFrame(OutboxMessage(kind="__copy_last_reply__", text=""))
+        await asyncio.Event().wait()
+
+
+@pytest.fixture()
+def clipboard(tmp_path, monkeypatch):
+    """A REAL ``pbcopy`` on ``PATH`` recording its stdin (the #3362 witness
+    shape: environment arrangement, not a mock — ``copy_to_clipboard`` really
+    spawns it). Atomic write (temp + rename) so a poller never reads a
+    half-written sink."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    sink = tmp_path / "clipboard.txt"
+    script = bindir / "pbcopy"
+    script.write_text(
+        "#!/bin/sh\n/bin/cat > " + str(sink) + ".part\n"
+        "/bin/mv " + str(sink) + ".part " + str(sink) + "\n"
+    )
+    script.chmod(script.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setenv("PATH", str(bindir) + os.pathsep + os.environ["PATH"])
+
+    def read():
+        return sink.read_text() if sink.exists() else None
+
+    return read
+
+
+@pytest.mark.asyncio
+async def test_copy_after_a_long_restore_reaches_the_newest_reply(clipboard) -> None:
+    """Tier 2b: #3486 — after restoring a history with MORE replies than
+    ``COPY_BUFFER_MAX``, ``/copy`` (1 = newest) copies the NEWEST reply.
+
+    Witnessed through the real public path (the ``__copy_last_reply__``
+    sentinel + a real ``pbcopy`` stand-in), never the ring's internals.
+    Falsification: pre-#3486, the hydrate seeding's ``reversed`` + ``append``
+    made ``deque(maxlen)`` evict from the NEWEST side once the reply count
+    crossed the cap, so this copied the (cap+1)-th-newest reply instead —
+    every earlier fixture stayed under the cap and never crossed the
+    inversion boundary."""
+    n_turns = _HYDRATE_PAGE_FRAMES  # replies ≫ COPY_BUFFER_MAX
+    log = _turns(n_turns)
+    app = TextualChatApp(
+        transport=_SentinelTransport(), read_model=_HistoryReadModel(log)
+    )
+    async with app.run_test(size=(80, 24)) as pilot:
+        for _ in range(60):
+            await pilot.pause()
+            if clipboard() is not None:
+                break
+        assert clipboard() == f"answer {n_turns - 1}", (
+            f"/copy after a long restore copied {clipboard()!r}, not the newest "
+            "reply — the ring's eviction direction inverted the 1=newest contract"
+        )


### PR DESCRIPTION
**[tui-coder]** — #3476 ④ lazy history paging (part of #3476)。Closes #3486。

## What

- **Hydrate は最新 `_HYDRATE_PAGE_FRAMES` (200) frame のみ materialise**。古い prefix は `self._older_frames` に保持し、`FlowView.ReachedTop`(`reach_threshold=3`、edge から離れると re-arm)で 1 ページずつ `insert_many(0, …)` — flowview 0.6.0 の scroll-position-preserving prepend で、読んでいる行は動かない。
- 復元 tool frame の terminal-state 遷移を `_apply_restored_state` に共通化し、hydrate 経路と page-in 経路の両方で実行。
- **隣接修正 #3486**: hydrate の /copy ring seeding が `reversed(frames)` + `append` で、復元 reply 数が `COPY_BUFFER_MAX`(20) を超えると `deque(maxlen)` の evict が newest 側に反転し「/copy 1 = newest」契約が壊れていた(live pump は `appendleft` で正しい)。natural order + `appendleft` に統一。

## 測定済みの前提(正直な注記)

view 側の全 hydrate コストは実測で小さい([事前実測 + descope 推奨](https://github.com/tya5/reyn/issues/3476#issuecomment-5126119536): 40k frames extend ≈ 41ms、height は lazy 推定)。owner はこれを踏まえ **「予定通り実装する」** を選択([決定記録](https://github.com/tya5/reyn/issues/3476#issuecomment-5126521787))。本 PR は **forward infrastructure** であり、性能改善 claim はしない — テストが pin するのは paging の**正しさ**のみ。

## Tests (`tests/test_lazy_history_paging_3476.py`, Tier 2b ×4)

期待値はすべて実 `project_restored_frames` から導出(hand-arithmetic なし)。

1. hydration が projection の newest slice を正確に materialise する
2. 実 `scroll_to_top()` で ReachedTop 駆動の page-in が全履歴を順序どおり materialise し、以後は no-op
3. lazily paged された tool frame が terminal state を得る(page-in 経路でも `_apply_restored_state` が走る)
4. **#3486 回帰**: cap 超え(200 replies > 20)の復元後、実 copy 経路(`__copy_last_reply__` sentinel + PATH 上の実 `pbcopy` stand-in)で newest reply がコピーされる — ring 内部は読まない

**Falsify**: fix を pre-fix コード(`reversed`+`append`)に戻すと test 4 が RED(`answer 19` を copy)、fix で GREEN — 両方向確認済み。旧 test 4(「ring は未 page-in の reply に届く」)は private-state アクセスかつ**バグによってのみ green だった**主張のため削除。

## Gates

- [x] `ruff check src tests` clean
- [x] `test_tier_audit.py --strict` — 4/4 OK(private-state flag 解消)
- [x] `verify_module_docstrings.py` OK
- [x] full `pytest -n auto` (local; 結果は PR コメントで報告)

## Test plan (Manual / Visual)

- [x] 実端末 witness (tmux 150×45): 120 turn (240 msg) の捏造 `history.jsonl` を持つ workspace で TUI 起動 → 復元は newest page のみ(bottom = turn 119)→ PageUp 連打で resume divider + question 0 まで実スクロール page-in → `/copy 1` が実 pbcopy 経由で `witness answer 119`(newest)→ PageDown で末尾復帰、表示無傷

🤖 Generated with [Claude Code](https://claude.com/claude-code)
