### PR TITLE
feat(tui): ctrl+f in-conversation search bar (part of #3476)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -89,6 +89,7 @@ from .presenter import (
 )
 from .restore import project_restored_frames
 from .rewind_picker import RewindPicker
+from .search_bar import SearchBar
 from .sent_queue import SentQueue
 
 if TYPE_CHECKING:
@@ -510,6 +511,12 @@ class TextualChatApp(App):
         # reservation that IS still live.
         ("ctrl+g", "toggle_left_gutter", "Show/hide left gutter (state)"),
         ("ctrl+t", "toggle_right_gutter", "Show/hide right gutter (elapsed/tokens)"),
+        # #3476 ⑤: in-conversation search (owner-decided entry point). ctrl+f
+        # re-verified free against the same enumeration the ctrl+g/ctrl+t
+        # comment above records: TextArea binds no ctrl+f (its ``chrome.py
+        # _EDIT_KEYS`` listing only flags a completion recompute, it consumes
+        # nothing), and ``chrome.RESERVED_KEYS`` reserves ctrl+r/f2 only.
+        ("ctrl+f", "open_search", "Search conversation"),
     ]
 
     CSS = """
@@ -517,6 +524,22 @@ class TextualChatApp(App):
     FlowView {
         height: 1fr;
         scrollbar-size-vertical: 0;
+    }
+    /* #3476 ⑤: the current search hit (and any click-selected entry —
+       flowview applies the same class to both). flowview ships NO colour of
+       its own for this ("unstyled by default", its component-class contract),
+       so without this rule a selection is invisible. ``reverse`` — the
+       terminal-native current-hit affordance (less/vim) — rather than a
+       background wash: flowview merges a row's ``Presentation.background``
+       into every segment BEFORE applying this component style, and
+       ``apply_style`` lets segment-explicit attributes win, so a background
+       here would vanish on exactly the rows that carry a full-row backdrop
+       (user lines, failure rows). ``reverse`` is an attribute no presenter
+       segment sets, so it survives the merge on every row kind. (Upstream
+       structural gap noted on #3476: selected/cursor component styles should
+       apply with override semantics — ⑥'s keyboard cursor hits the same.) */
+    FlowView > .flowview--selected {
+        text-style: reverse;
     }
     #inputrow {
         height: auto;
@@ -829,6 +852,12 @@ class TextualChatApp(App):
             # away, so the next history page is in place by the time the user
             # actually arrives at it.
             reach_threshold=3,
+            # #3476 ⑤: the search bar marks the current hit through flowview's
+            # entry selection (``select()`` is a documented no-op without
+            # this). Also enables flowview's native click-to-select — a
+            # clicked entry gets the same ``flowview--selected`` highlight,
+            # which reads as a deliberate affordance, not a search leak.
+            selectable=True,
         )
         # #3352: apply the configured START state. flowview has no constructor
         # parameter for gutter visibility (both flags initialise True), so the
@@ -871,6 +900,12 @@ class TextualChatApp(App):
         # (``display=False`` — see ``CompletionPopup.on_mount``).
         self._completion = CompletionPopup(id="completion")
         yield self._completion
+        # #3476 ⑤: the ctrl+f search bar — the last chrome region before the
+        # composer (collapsed by default; the completion popup above it can
+        # never be open at the same time, since completion follows COMPOSER
+        # typing and the search bar owns focus while visible).
+        self._search_bar = SearchBar(id="search-bar")
+        yield self._search_bar
         with Horizontal(id="inputrow"):
             yield Static("❯", id="inputgutter")
             yield Composer(
@@ -1181,6 +1216,97 @@ class TextualChatApp(App):
         self._older_frames = self._older_frames[:-_HYDRATE_PAGE_FRAMES]
         for msg, entry in zip(page, entries):
             _apply_restored_state(msg, entry)
+
+    # ── #3476 ⑤: in-conversation search ────────────────────────────────────
+
+    def _materialise_all_older(self) -> None:
+        """Materialise the ENTIRE lazily-held older prefix (#3476 ④) in one
+        ``insert_many`` (one reflow). Search must see the full restored
+        history — a hit that exists in history but not in the materialised
+        page would read as "no match", a lie — and the measured full-hydrate
+        cost is negligible (#3476 issue comment), so search-open simply pays
+        it all at once rather than teaching search a second, virtual domain."""
+        if not self._older_frames:
+            return
+        rest = self._older_frames
+        try:
+            entries = self.conversation.insert_many(0, rest)
+        except Exception:
+            logger.exception("textual chat: search-open history materialise failed")
+            return
+        self._older_frames = []
+        for msg, entry in zip(rest, entries):
+            _apply_restored_state(msg, entry)
+
+    def action_open_search(self) -> None:
+        """ctrl+f: open (or refocus) the search bar. Reopening keeps the
+        previous query (the browser convention), so re-sync its match state."""
+        self._materialise_all_older()
+        self._search_bar.open()
+        if self._search_bar.query:
+            self._search_sync(self._search_bar.query, jump=True)
+
+    @staticmethod
+    def _search_predicate(query: str):
+        """Case-insensitive substring over the MODEL text (``entry.item.text``)
+        — what the frame says, independent of presentation. ``entry_text()``
+        (the rendered body) is deliberately NOT used: it returns ``""`` for
+        entries that have never been painted, which would silently exclude
+        every never-scrolled-to row from the search domain."""
+        q = query.lower()
+        return lambda entry: q in (entry.item.text or "").lower()
+
+    def _search_sync(self, query: str, *, jump: bool) -> None:
+        """Recompute the match set for ``query`` and sync count + selection.
+        ``jump=True`` selects the NEWEST match (a bottom-anchored conversation
+        searches backward from now) and centers it; ``jump=False`` only
+        re-anchors the count around the current selection."""
+        flow = self._flow
+        if not query:
+            flow.clear_selection()
+            self._search_bar.set_count(0, 0)
+            return
+        hits = flow.find(self._search_predicate(query))
+        if not hits:
+            flow.clear_selection()
+            self._search_bar.set_count(0, 0)
+            return
+        current = flow.selected
+        if jump or current not in hits:
+            current = hits[-1]
+            flow.select(current)
+            flow.scroll_to_entry(current, align="center", animate=True)
+        self._search_bar.set_count(hits.index(current) + 1, len(hits))
+
+    def on_search_bar_query_changed(self, event: "SearchBar.QueryChanged") -> None:
+        # Incremental: every keystroke recomputes and jumps to the newest
+        # match, browser-style.
+        self._search_sync(event.query, jump=True)
+
+    def on_search_bar_navigate(self, event: "SearchBar.Navigate") -> None:
+        query = self._search_bar.query
+        if not query:
+            return
+        flow = self._flow
+        pred = self._search_predicate(query)
+        # Recompute lazily AT the navigation (not on every live append): the
+        # find_next/find_previous walk runs over the live model, so matches
+        # that arrived since the last keystroke are found without any
+        # append-time bookkeeping.
+        step = flow.find_previous if event.older else flow.find_next
+        target = step(pred)  # from the current selection, wrapping
+        if target is None:
+            self._search_bar.set_count(0, 0)
+            return
+        flow.select(target)
+        flow.scroll_to_entry(target, align="center", animate=True)
+        hits = flow.find(pred)
+        self._search_bar.set_count(hits.index(target) + 1, len(hits))
+
+    def on_search_bar_dismissed(self, event: "SearchBar.Dismissed") -> None:
+        self._search_bar.hide()
+        self._flow.clear_selection()
+        self.query_one(Composer).focus()
 
     def _open_drawer(self, tab_id: "str | None") -> None:
         """Expand/collapse the downward drawer. ``None`` (or the ``"__close__"``

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -498,6 +498,18 @@ SENTQUEUE_KEYS: "list[tuple[str, str]]" = [
     ("esc", "back to composer"),
 ]
 
+#: The search bar's keys while it is open (#3476 ⑤,
+#: ``search_bar.SearchBar`` — imperative ``on_key`` + the Input's own Enter,
+#: sourced from HERE for the Help pane per the same single-source-of-truth
+#: convention as the sibling ledgers above). The bar itself opens from the
+#: app's declarative ``ctrl+f`` binding, which the Help pane already lists
+#: via ``app_bindings``.
+SEARCHBAR_KEYS: "list[tuple[str, str]]" = [
+    ("enter / ↑", "search: older match"),
+    ("shift+enter / ↓", "search: newer match"),
+    ("esc", "close search, back to composer"),
+]
+
 
 def pane_is_list(tab_id: str) -> bool:
     """Whether ``tab_id``'s drawer pane is an interactive :class:`OptionList`
@@ -1033,6 +1045,7 @@ def help_pane_lines(
     composer_keys: "Sequence[tuple[str, str]]" = tuple(COMPOSER_KEYS),
     menubar_keys: "Sequence[tuple[str, str]]" = tuple(MENUBAR_KEYS),
     sentqueue_keys: "Sequence[tuple[str, str]]" = tuple(SENTQUEUE_KEYS),
+    searchbar_keys: "Sequence[tuple[str, str]]" = tuple(SEARCHBAR_KEYS),
 ) -> list[str]:
     """The Help readout — the app's declarative ``BINDINGS`` (passed as
     ``(key, description)`` pairs) plus the imperative composer/menu navigation
@@ -1045,6 +1058,7 @@ def help_pane_lines(
     lines += [f"  {key}  {desc}" for key, desc in composer_keys]
     lines += [f"  {key}  {desc}" for key, desc in menubar_keys]
     lines += [f"  {key}  {desc}" for key, desc in sentqueue_keys]
+    lines += [f"  {key}  {desc}" for key, desc in searchbar_keys]
     lines += [f"  {key}  {desc}" for key, desc in app_bindings]
     return lines
 

--- a/src/reyn/interfaces/inline/textual_chat/search_bar.py
+++ b/src/reyn/interfaces/inline/textual_chat/search_bar.py
@@ -1,0 +1,138 @@
+"""``SearchBar`` — the ctrl+f in-conversation search bar (#3476 ⑤).
+
+A one-line bar docked directly above the input row (region order:
+conversation / intervention panel / rewind picker / sent-queue / completion
+popup / **search bar** / input — the last chrome region before the composer).
+Collapsed by default (``display=False`` in :meth:`on_mount`), shown by the
+app's ``ctrl+f`` binding.
+
+This widget is PURE CHROME, the same split every sibling region uses (see
+:class:`~reyn.interfaces.inline.textual_chat.sent_queue.SentQueue`): it owns
+the query :class:`~textual.widgets.Input`, the ``n/M`` match-count label, and
+the key surface, and POSTS messages — the app owns the actual search state
+(match computation over the flow model, selection, scrolling), because only
+the app holds the :class:`~textual_flowview.FlowView` and the lazily-held
+older-history prefix (#3476 ④) a correct search must see.
+
+Key surface (owner-decided: Enter = next / Shift+Enter = previous):
+
+- ``Enter`` → :class:`Navigate` toward OLDER matches — the search scans a
+  bottom-anchored conversation, so "next result" walks backward in time,
+  the same direction iTerm2/less searches walk (``↓`` steps back toward
+  newer as the mirror). ``Enter`` arrives as the Input's own ``Submitted``
+  message; the rest arrive through :meth:`on_key` (an :class:`Input` binds
+  none of them, so they bubble here from the focused Input).
+- ``Shift+Enter`` → :class:`Navigate` toward NEWER matches. Requires an
+  extended-keys terminal (the same caveat as the composer's own
+  Shift+Enter-for-newline), which is why ``↑``/``↓`` mirror the two
+  directions as a fallback — a one-line Input has no other use for them.
+  The arrows map SPATIALLY (``↑`` = older, the direction the viewport
+  moves; ``↓`` = newer), not by the next/prev labels — so the arrow you
+  press and the way the conversation scrolls always agree.
+- ``Escape`` → :class:`Dismissed`; the app hides the bar, clears the
+  selection, and returns focus to the composer (the package-wide "``Esc``
+  alone owns back-to-composer" rule, #3365).
+"""
+from __future__ import annotations
+
+from textual.containers import Horizontal
+from textual.message import Message
+from textual.widgets import Input, Static
+
+
+class SearchBar(Horizontal):
+    """The ctrl+f search bar: query input + ``n/M`` match count."""
+
+    DEFAULT_CSS = """
+    SearchBar {
+        display: none;
+        height: 1;
+        background: $panel;
+        padding: 0 1;
+    }
+    SearchBar Input {
+        width: 1fr;
+        background: $panel;
+    }
+    SearchBar #search-count {
+        width: auto;
+        height: 1;
+        color: $text-muted;
+        padding: 0 0 0 1;
+    }
+    """
+
+    class QueryChanged(Message):
+        """The query text changed — the app recomputes matches incrementally."""
+
+        def __init__(self, query: str) -> None:
+            self.query = query
+            super().__init__()
+
+    class Navigate(Message):
+        """Step to the adjacent match. ``older=True`` walks backward in time
+        (model order ``find_previous``), ``False`` forward toward newer."""
+
+        def __init__(self, *, older: bool) -> None:
+            self.older = older
+            super().__init__()
+
+    class Dismissed(Message):
+        """The user closed the bar (Escape)."""
+
+    def compose(self):
+        # ``compact=True`` is Textual's own one-line Input mode (border
+        # stripped with !important, height 1) — hand-CSS overrides lose to
+        # the ``Input:focus`` border rule and paint half-block border rows
+        # (measured), so use the first-class knob instead.
+        yield Input(placeholder="Search conversation…", id="search-input", compact=True)
+        yield Static("", id="search-count")
+
+    def on_mount(self) -> None:
+        self.display = False
+
+    # ── the app-facing surface ──────────────────────────────────────────────
+
+    def open(self) -> None:
+        """Show the bar and focus the query input. The previous query is KEPT
+        (reopening resumes the last search, the browser ctrl+f convention);
+        the app re-syncs the count/selection on open."""
+        self.display = True
+        self.query_one("#search-input", Input).focus()
+
+    def hide(self) -> None:
+        self.display = False
+
+    @property
+    def query(self) -> str:
+        return self.query_one("#search-input", Input).value
+
+    def set_count(self, current: int, total: int) -> None:
+        """``current`` is the 1-based model-order position of the selected
+        match (0 = none selected); ``total`` the match count."""
+        label = f"{current}/{total}" if total else ("0/0" if self.query else "")
+        self.query_one("#search-count", Static).update(label)
+
+    # ── key surface ─────────────────────────────────────────────────────────
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        event.stop()
+        self.post_message(self.QueryChanged(event.value))
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        # Enter — the Input consumes the key itself and posts Submitted.
+        event.stop()
+        self.post_message(self.Navigate(older=True))
+
+    def on_key(self, event) -> None:
+        # Everything Enter is not: an Input binds none of these, so they
+        # bubble here from the focused query box.
+        if event.key in ("shift+enter", "down"):
+            event.stop()
+            self.post_message(self.Navigate(older=False))
+        elif event.key == "up":
+            event.stop()
+            self.post_message(self.Navigate(older=True))
+        elif event.key == "escape":
+            event.stop()
+            self.post_message(self.Dismissed())

--- a/tests/test_search_bar_3476.py
+++ b/tests/test_search_bar_3476.py
@@ -1,0 +1,253 @@
+"""#3476 ⑤ — the ctrl+f in-conversation search bar.
+
+What these pin (all through the public surface — pressed keys, the painted
+count label via ``Static.render()``, ``FlowView.selected``/``display`` —
+never widget internals):
+
+- ``ctrl+f`` from the composer opens the bar and focuses its query input;
+- typing searches incrementally: the NEWEST match is selected (a
+  bottom-anchored conversation searches backward from now) and the ``n/M``
+  count reflects the match set;
+- ``Enter``/``↑`` walk toward older matches, ``↓`` back toward newer, both
+  wrapping — positions verified against model order;
+- a match living ONLY in the lazily-held older prefix (#3476 ④) is found:
+  opening search materialises the full restored history first;
+- ``Escape`` closes the bar, clears the selection, and returns focus to the
+  composer (#3365's "Esc alone owns back").
+
+Real ``TextualChatApp`` + real minimal ``ClientTransport`` — no mocks."""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+from textual.widgets import Input, Static
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.app import _HYDRATE_PAGE_FRAMES
+from reyn.interfaces.inline.textual_chat.chrome import Composer
+from reyn.interfaces.inline.textual_chat.restore import project_restored_frames
+from reyn.interfaces.inline.textual_chat.search_bar import SearchBar
+from reyn.interfaces.repl.read_model import ChatReadModel
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _Transport(ClientTransport):
+    def __init__(self) -> None:
+        self.submitted: list[str] = []
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        await asyncio.Event().wait()
+        yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
+
+    async def submit_user_text(self, text: str) -> None:
+        self.submitted.append(text)
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+class _HistoryReadModel(ChatReadModel):
+    """A real :class:`ChatReadModel` seam impl (the phase-5 suite's shape)."""
+
+    def __init__(self, messages: "list[ChatMessage]") -> None:
+        self._messages = messages
+
+    def snapshot(self, config=None):
+        return None
+
+    def intervention_head(self):
+        return None
+
+    def pending_command_ui(self):
+        return None
+
+    def clear_pending_command_ui(self) -> None:
+        return None
+
+    def has_command_ui_region(self) -> bool:
+        return True
+
+    def history_path(self) -> Path:
+        return Path("/tmp/reyn_search_bar_input_history")
+
+    def conversation_history(self, *, limit=None):
+        return self._messages[-limit:] if limit is not None else list(self._messages)
+
+
+def _count_text(app: TextualChatApp) -> str:
+    """The painted match-count label, via the widget's public render."""
+    return str(app.query_one("#search-count", Static).render())
+
+
+def _selected_text(app: TextualChatApp) -> "str | None":
+    from textual_flowview import FlowView
+
+    entry = app.query_one(FlowView).selected
+    return None if entry is None else entry.item.text
+
+
+async def _type(pilot, text: str) -> None:
+    for ch in text:
+        await pilot.press(ch)
+    await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_ctrl_f_opens_the_bar_and_focuses_the_query_input() -> None:
+    """Tier 2b: ctrl+f pressed while the composer holds focus (the app's
+    resting state) opens the search bar and moves focus into its input."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        bar = app.query_one(SearchBar)
+        assert not bar.display, "test setup: the bar is already open"
+        await pilot.press("ctrl+f")
+        await pilot.pause()
+        assert bar.display, "ctrl+f did not open the search bar"
+        assert isinstance(app.focused, Input), (
+            f"focus is on {app.focused!r}, not the search input"
+        )
+
+
+@pytest.mark.asyncio
+async def test_incremental_search_selects_the_newest_match_with_count() -> None:
+    """Tier 2b: typing in the bar searches incrementally — the newest matching
+    entry is selected and the count label shows its model-order position."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        for text in ("alpha one", "nothing here", "alpha two", "tail"):
+            app.conversation.append(OutboxMessage(kind="agent", text=text))
+        await pilot.pause()
+        await pilot.press("ctrl+f")
+        await _type(pilot, "alpha")
+        assert _selected_text(app) == "alpha two", (
+            "incremental search did not select the newest match"
+        )
+        assert _count_text(app) == "2/2"
+
+
+@pytest.mark.asyncio
+async def test_enter_walks_older_arrows_map_spatially_and_wrap() -> None:
+    """Tier 2b: Enter/↑ step toward OLDER matches, ↓ back toward newer, and
+    the walk wraps at either end — verified by which entry is selected."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        for text in ("match old", "filler", "match mid", "filler", "match new"):
+            app.conversation.append(OutboxMessage(kind="agent", text=text))
+        await pilot.pause()
+        await pilot.press("ctrl+f")
+        await _type(pilot, "match")
+        assert _selected_text(app) == "match new"
+        assert _count_text(app) == "3/3"
+
+        await pilot.press("enter")
+        await pilot.pause()
+        assert _selected_text(app) == "match mid", "Enter did not step older"
+        assert _count_text(app) == "2/3"
+
+        await pilot.press("up")
+        await pilot.pause()
+        assert _selected_text(app) == "match old", "↑ did not step older"
+        assert _count_text(app) == "1/3"
+
+        await pilot.press("enter")
+        await pilot.pause()
+        assert _selected_text(app) == "match new", (
+            "the older-walk did not wrap past the oldest match"
+        )
+
+        await pilot.press("down")
+        await pilot.pause()
+        assert _selected_text(app) == "match old", (
+            "↓ (newer) did not wrap past the newest match"
+        )
+
+
+@pytest.mark.asyncio
+async def test_search_finds_a_match_only_present_in_the_unpaged_prefix() -> None:
+    """Tier 2b: #3476 ④/⑤ junction — a match that lives ONLY in the
+    lazily-held older prefix is found, because opening search materialises
+    the full restored history first."""
+    log = [
+        ChatMessage(role="user", content="needle-in-the-prefix"),
+        ChatMessage(role="assistant", content="old reply"),
+    ]
+    for i in range(_HYDRATE_PAGE_FRAMES // 2):
+        log.append(ChatMessage(role="user", content=f"question {i}"))
+        log.append(ChatMessage(role="assistant", content=f"answer {i}"))
+    app = TextualChatApp(transport=_Transport(), read_model=_HistoryReadModel(log))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        assert not any(
+            "needle-in-the-prefix" in (e.item.text or "") for e in app.conversation
+        ), "test setup: the needle is already materialised"
+
+        await pilot.press("ctrl+f")
+        await _type(pilot, "needle")
+        assert len(list(app.conversation)) == len(project_restored_frames(log)), (
+            "search-open did not materialise the full restored history"
+        )
+        selected = _selected_text(app)
+        assert selected is not None and "needle-in-the-prefix" in selected, (
+            f"the prefix-only match was not found (selected: {selected!r})"
+        )
+        assert _count_text(app) == "1/1"
+
+
+@pytest.mark.asyncio
+async def test_escape_closes_clears_selection_and_refocuses_composer() -> None:
+    """Tier 2b: Escape dismisses the bar (#3365 'Esc alone owns back') —
+    the bar hides, the search selection is cleared, focus returns to the
+    composer."""
+    from textual_flowview import FlowView
+
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.conversation.append(OutboxMessage(kind="agent", text="alpha"))
+        await pilot.pause()
+        await pilot.press("ctrl+f")
+        await _type(pilot, "alpha")
+        assert _selected_text(app) == "alpha", "test setup: no active search hit"
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert not app.query_one(SearchBar).display, "Escape did not hide the bar"
+        assert app.query_one(FlowView).selected is None, (
+            "the search selection survived dismissal"
+        )
+        assert isinstance(app.focused, Composer), (
+            f"focus is on {app.focused!r}, not back on the composer"
+        )


### PR DESCRIPTION
**[tui-coder]** — #3476 ⑤ ctrl+f 検索バー(part of #3476)。

## What

- **`SearchBar`**(composer 直上、chrome の最後の region): `ctrl+f` で開く(owner 決定の入口。設計コメント: https://github.com/tya5/reyn/issues/3476#issuecomment-5126609787)。
- **incremental substring search** — model text(`entry.item.text`)対象、newest match を選択し `scroll_to_entry(align="center", animate=True)`。
- **Enter / ↑ = older、Shift+Enter / ↓ = newer**(owner 決定)。矢印は「見た目の移動方向」に合わせて割当(↑=older は viewport が上へ動く方向と一致)。`FlowView.find_next`/`find_previous`(model order、wrap=True)。
- **Escape** = バー閉じる + selection クリア + composer へ focus 復帰(#3365 の Esc-owns-back 規律)。
- **④ との合流**: 検索を開いた瞬間に `_older_frames` を**全量 materialise**(`insert_many` 1 回)。復元履歴にあるのに未 page-in というだけで「該当なし」に見えるのは UX 上の嘘になるため。

## 実装上の発見(upstream 構造的ギャップ、issue に記録済み)

flowview の `flowview--selected` component style は行の `Presentation.background`(ユーザ行・失敗行の全幅背景)と **merge** され、`Strip.apply_style` はセグメント側の明示属性を優先するため、**background による selected スタイルはユーザ行/失敗行で消える**。`text-style: reverse` はどのセグメントも明示しない属性なので全行種で生き残る — この方式を採用。⑥(keyboard cursor)も同じ構造に当たる見込みとして #3476 に注記済み。

## キー衝突チェック

`ctrl+f` — TextArea の BINDINGS に無し(`chrome.py _EDIT_KEYS` の `"ctrl+f"` はキーを消費しないフラグのみ)、`chrome.RESERVED_KEYS` は ctrl+r/f2 のみ予約。Help pane に `SEARCHBAR_KEYS` を追加(`chrome.help_pane_lines`、既存の単一情報源規律を踏襲)。

## Tests (`tests/test_search_bar_3476.py`, Tier 2b ×5)

実 `TextualChatApp` + 実 transport、キー押下・`Static.render()`・`FlowView.selected`/`display` などの公開面のみ assert:

1. ctrl+f でバー表示+query input へ focus
2. incremental search で newest match 選択+count
3. Enter/↑=older、Shift+Enter相当/↓=newer、両端で wrap
4. **④/⑤合流**: 未 page-in prefix にしか無い match が検索開始時の全量 materialise で見つかる
5. Escape でバー非表示+selection クリア+composer 復帰

## Gates

- [x] `ruff check src tests` clean
- [x] `test_tier_audit.py --strict` — 5/5 OK
- [x] `verify_module_docstrings.py` OK
- [x] full `pytest -n auto`(結果は PR コメントで報告)

## Test plan (Manual / Visual)

- [x] 実端末 witness(tmux 150×45、240 msg 復元 workspace): ctrl+f → query 入力 → count 表示(`1/1`/`N/M`)を目視 → 複数 match で newest 選択+中央スクロールを確認 → Enter で older(count 減)、↑ も older(同じ hit へ)、↓ で newer → 未 page-in の `witness question 0` を検索し全量 page-in の上で hit → 実際の `reverse` ハイライトを画面キャプチャの raw ANSI(`\x1b[7m`)で確認(ユーザ行/エージェント行の両方で生存、背景色 wash 版は消えることも実機で確認しコード修正)→ Escape でバー消滅+ハイライト 0 件を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
