### PR TITLE
feat(tui): keyboard cursor over the conversation pane (closes #3476)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -39,6 +39,7 @@ from collections import deque
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Callable
 
+from textual import events
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal
 from textual.widgets import ContentSwitcher, OptionList, Static
@@ -50,6 +51,7 @@ from textual_flowview import (
     FlowView,
 )
 
+from reyn.interfaces.repl._clipboard import copy_to_clipboard_async
 from reyn.interfaces.repl._copy_sentinel import COPY_BUFFER_MAX, handle_copy_sentinel
 from reyn.interfaces.repl.renderer import (
     _CC_DIM,
@@ -541,6 +543,18 @@ class TextualChatApp(App):
     FlowView > .flowview--selected {
         text-style: reverse;
     }
+    /* #3476 ⑥: the keyboard cursor — the same background-merge structural gap
+       ⑤ found (see the ``flowview--selected`` rule above) applies identically
+       here (same ``Strip.apply_style`` code path), so ``reverse`` again rather
+       than a background wash. When a search hit and the cursor land on the
+       SAME entry, flowview applies ``flowview--selected`` then
+       ``flowview--cursor`` in that order (flowview's own component-application
+       order, unchanged here) — ``reverse`` on ``reverse`` is idempotent, so the
+       row simply reads as one reversed row either way, never a doubled
+       effect. */
+    FlowView > .flowview--cursor {
+        text-style: reverse;
+    }
     #inputrow {
         height: auto;
         max-height: 8;
@@ -858,6 +872,16 @@ class TextualChatApp(App):
             # clicked entry gets the same ``flowview--selected`` highlight,
             # which reads as a deliberate affordance, not a search leak.
             selectable=True,
+            # #3476 ⑥: the keyboard cursor (the visual affordance #3470
+            # deferred to this PR). Reached the SAME way #3470 already
+            # established — Shift+Tab focus-cycling into FlowView, Esc back
+            # out (#3399 gate) — never a new focus path. flowview owns
+            # ↑/↓/PageUp/PageDown/Home/End moving the cursor once FlowView
+            # has focus; while it doesn't, those keys are unaffected (the
+            # composer's own PageUp/PageDown delegation, #3470, calls
+            # actions on ``self._flow`` directly and never depends on this
+            # flag).
+            cursor=True,
         )
         # #3352: apply the configured START state. flowview has no constructor
         # parameter for gutter visibility (both flags initialise True), so the
@@ -1307,6 +1331,51 @@ class TextualChatApp(App):
         self._search_bar.hide()
         self._flow.clear_selection()
         self.query_one(Composer).focus()
+
+    # ── #3476 ⑥: the keyboard cursor's own actions ─────────────────────────
+
+    def on_descendant_focus(self, event: "events.DescendantFocus") -> None:
+        """Arm the keyboard cursor the moment FlowView gains focus (Shift+Tab
+        landing on it, #3470), rather than leaving it invisible until the
+        first arrow press: flowview's own :meth:`~textual_flowview.FlowView.move_cursor`
+        starts from ``cursor=None`` and only lands on an entry once a
+        direction key moves it — a real but easy-to-miss affordance gap for
+        a feature whose whole point is a visible position indicator.
+        ``cursor_last`` (not ``cursor_first``) so arrival highlights the
+        newest entry, matching where a resumed/live conversation's attention
+        already is."""
+        if event.widget is self._flow and self._flow.cursor is None:
+            self._flow.cursor_last()
+
+    async def on_flow_view_activated(self, event: "FlowView.Activated") -> None:
+        """Enter/Space on the cursor entry: copy ITS text directly.
+
+        A direct, ring-free path — ``/copy N`` addresses one of the last
+        ``COPY_BUFFER_MAX`` AGENT replies by ordinal; the cursor instead
+        points at one exact, arbitrary entry (any kind), so there is no
+        ordinal to resolve and no reason to go through the ring."""
+        from reyn.runtime.outbox import OutboxMessage
+
+        ok, status = await copy_to_clipboard_async(event.entry.item.text)
+        self._ingest_frame(
+            OutboxMessage(kind="status", text=status if not ok else "copied to clipboard")
+        )
+
+    async def on_key(self, event) -> None:
+        # #3476 ⑥: 'r' while the cursor has focus is a keyboard shortcut for
+        # typing bare ``/rewind`` + Enter — routed through the exact same
+        # ``_submit`` seam an ordinary submission uses, so the picker
+        # (#3362's RewindPicker) and rewind's destructive-action path are
+        # completely unchanged. NOT a per-entry jump: the conversation pane's
+        # ChatMessage.seq and the WAL seq ``list_rewind_points`` addresses are
+        # different sequence spaces with no correlation wired anywhere in the
+        # codebase today, so a specific cursor entry cannot be mapped onto a
+        # specific rewind point without new plumbing outside this PR's scope
+        # (recorded on #3476, owner-confirmed: a fast /rewind entry point is
+        # the intended integration, not a targeted jump).
+        if event.key == "r" and self.focused is self._flow:
+            event.stop()
+            await self._submit("/rewind")
 
     def _open_drawer(self, tab_id: "str | None") -> None:
         """Expand/collapse the downward drawer. ``None`` (or the ``"__close__"``

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -510,6 +510,17 @@ SEARCHBAR_KEYS: "list[tuple[str, str]]" = [
     ("esc", "close search, back to composer"),
 ]
 
+#: The conversation pane's keyboard cursor (#3476 ⑥, reached the SAME way as
+#: ``SENTQUEUE_KEYS`` — Shift+Tab focus-cycling, ``app.py``'s ``cursor=True``).
+#: ↑/↓/PageUp/PageDown/Home/End are flowview's OWN built-in cursor bindings
+#: (not re-declared here — this ledger only lists what reyn adds on top).
+CONVERSATION_CURSOR_KEYS: "list[tuple[str, str]]" = [
+    ("↑ / ↓ / PgUp / PgDn / Home / End", "move cursor"),
+    ("enter / space", "copy entry to clipboard"),
+    ("r", "open /rewind"),
+    ("esc", "back to composer"),
+]
+
 
 def pane_is_list(tab_id: str) -> bool:
     """Whether ``tab_id``'s drawer pane is an interactive :class:`OptionList`
@@ -1046,6 +1057,7 @@ def help_pane_lines(
     menubar_keys: "Sequence[tuple[str, str]]" = tuple(MENUBAR_KEYS),
     sentqueue_keys: "Sequence[tuple[str, str]]" = tuple(SENTQUEUE_KEYS),
     searchbar_keys: "Sequence[tuple[str, str]]" = tuple(SEARCHBAR_KEYS),
+    cursor_keys: "Sequence[tuple[str, str]]" = tuple(CONVERSATION_CURSOR_KEYS),
 ) -> list[str]:
     """The Help readout — the app's declarative ``BINDINGS`` (passed as
     ``(key, description)`` pairs) plus the imperative composer/menu navigation
@@ -1059,6 +1071,7 @@ def help_pane_lines(
     lines += [f"  {key}  {desc}" for key, desc in menubar_keys]
     lines += [f"  {key}  {desc}" for key, desc in sentqueue_keys]
     lines += [f"  {key}  {desc}" for key, desc in searchbar_keys]
+    lines += [f"  {key}  {desc}" for key, desc in cursor_keys]
     lines += [f"  {key}  {desc}" for key, desc in app_bindings]
     return lines
 

--- a/tests/test_conversation_cursor_3476.py
+++ b/tests/test_conversation_cursor_3476.py
@@ -1,0 +1,208 @@
+"""#3476 ⑥ — the conversation pane's keyboard cursor (``cursor=True``).
+
+The visual affordance #3470 deferred to this PR: FlowView is reachable via
+Shift+Tab (established there), and this PR gives that focus state a keyboard
+cursor — ↑/↓/PageUp/PageDown/Home/End move it (flowview's own built-in
+bindings, not re-tested here), Enter/Space copies the cursor entry directly
+to the clipboard, and ``r`` opens ``/rewind`` through the ordinary submit
+seam. What these tests pin (real ``TextualChatApp`` + a real minimal
+``ClientTransport``, public surface only — pressed keys, ``FlowView.cursor``,
+a real ``pbcopy`` stand-in, the transport's own submitted-text log):
+
+- Shift+Tab reaches the conversation pane with the cursor on the LAST entry
+  (``cursor_last`` is flowview's own mount-time default once ``cursor=True``);
+- Enter/Space copies the CURSOR entry's own text — any kind, not just an
+  agent reply, and NOT through the ``/copy`` ring;
+- ``r`` submits bare ``/rewind`` through the app's normal submit seam (the
+  SAME path an ordinary composer-typed ``/rewind`` would take) — never a
+  per-entry targeted jump (there is no chat-seq/WAL-seq correlation to make
+  one; #3476 issue comment).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import stat
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.chrome import Composer
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _Transport(ClientTransport):
+    def __init__(self) -> None:
+        self.submitted: list[str] = []
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        await asyncio.Event().wait()
+        yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
+
+    async def submit_user_text(self, text: str) -> None:
+        self.submitted.append(text)
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def deliver_pending_answer(self, text: str) -> bool:
+        return False
+
+
+@pytest.fixture()
+def clipboard(tmp_path, monkeypatch):
+    """A REAL ``pbcopy`` on ``PATH`` recording its stdin — the #3362/#3476⑤
+    witness shape (environment arrangement, not a mock)."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    sink = tmp_path / "clipboard.txt"
+    script = bindir / "pbcopy"
+    script.write_text(
+        "#!/bin/sh\n/bin/cat > " + str(sink) + ".part\n"
+        "/bin/mv " + str(sink) + ".part " + str(sink) + "\n"
+    )
+    script.chmod(script.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setenv("PATH", str(bindir) + os.pathsep + os.environ["PATH"])
+
+    def read():
+        return sink.read_text() if sink.exists() else None
+
+    return read
+
+
+async def _focus_flow(pilot, app) -> "FlowView":
+    app.query_one(Composer).focus()
+    await pilot.pause()
+    await pilot.press("shift+tab")
+    await pilot.pause()
+    flow = app.query_one(FlowView)
+    assert app.focused is flow, f"setup: Shift+Tab did not focus FlowView: {app.focused!r}"
+    return flow
+
+
+@pytest.mark.asyncio
+async def test_shift_tab_arms_the_cursor_on_the_last_entry() -> None:
+    """Tier 2b: reaching FlowView via Shift+Tab starts the cursor on the
+    newest (last) entry — flowview's own ``cursor=True`` mount default."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        for text in ("one", "two", "three"):
+            app.conversation.append(OutboxMessage(kind="agent", text=text))
+        await pilot.pause()
+        flow = await _focus_flow(pilot, app)
+        assert flow.cursor is not None and flow.cursor.item.text == "three", (
+            f"cursor did not start on the newest entry: {flow.cursor!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_enter_copies_the_cursor_entry_directly(clipboard) -> None:
+    """Tier 2b: Enter (Activated) copies the CURSOR entry's own text — a
+    TOOL-kind entry here, proving this bypasses the agent-only /copy ring
+    entirely (the ring cannot address a tool row at all)."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.conversation.append(OutboxMessage(kind="agent", text="an agent reply"))
+        app.conversation.append(OutboxMessage(kind="tool_call_completed", text="tool output XYZ"))
+        await pilot.pause()
+        flow = await _focus_flow(pilot, app)
+        assert flow.cursor.item.text == "tool output XYZ", (
+            "setup: cursor is not on the tool entry"
+        )
+
+        await pilot.press("enter")
+        for _ in range(30):
+            await pilot.pause()
+            if clipboard() is not None:
+                break
+        assert clipboard() == "tool output XYZ", (
+            f"Enter did not copy the cursor entry's own text (got {clipboard()!r})"
+        )
+
+
+@pytest.mark.asyncio
+async def test_space_also_activates_the_cursor_entry(clipboard) -> None:
+    """Tier 2b: Space is flowview's other built-in activate key — same effect
+    as Enter, verified independently rather than assumed from Enter's test."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.conversation.append(OutboxMessage(kind="agent", text="reply text"))
+        await pilot.pause()
+        await _focus_flow(pilot, app)
+
+        await pilot.press("space")
+        for _ in range(30):
+            await pilot.pause()
+            if clipboard() is not None:
+                break
+        assert clipboard() == "reply text"
+
+
+@pytest.mark.asyncio
+async def test_r_opens_rewind_through_the_ordinary_submit_seam() -> None:
+    """Tier 2b: 'r' with the cursor focused submits bare '/rewind' through
+    the SAME seam an ordinary composer submission uses — not a targeted
+    per-entry jump (there is no seq correlation to make one)."""
+    transport = _Transport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.conversation.append(OutboxMessage(kind="agent", text="reply"))
+        await pilot.pause()
+        await _focus_flow(pilot, app)
+
+        await pilot.press("r")
+        await pilot.pause()
+        assert transport.submitted == ["/rewind"], (
+            f"'r' did not submit bare /rewind through the normal seam: "
+            f"{transport.submitted!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_r_is_a_plain_character_everywhere_else() -> None:
+    """Tier 2b: 'r' typed in the COMPOSER (the resting focus state) is an
+    ordinary character, never intercepted — the shortcut is gated on the
+    cursor actually having focus."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        composer = app.query_one(Composer)
+        composer.focus()
+        await pilot.pause()
+        await pilot.press("r")
+        await pilot.pause()
+        assert composer.text == "r", (
+            f"'r' was intercepted while the composer had focus: {composer.text!r}"
+        )

--- a/tests/test_textual_chat_esc_sufficiency_3365.py
+++ b/tests/test_textual_chat_esc_sufficiency_3365.py
@@ -13,7 +13,7 @@ gate is what lets a later PR remove Tab's "back" binding with a real, not
 merely assumed, safety net; and what would immediately catch that future
 Input-vs-Esc regression by going RED.
 
-Six HAND-ENUMERATED focus states, each independently reachable and each
+Seven HAND-ENUMERATED focus states, each independently reachable and each
 asserted to return to the Composer on ``Esc``:
   1. MenuBar (tab-bar row, not yet opened)
   2. Drawer content (an OptionList pane)
@@ -26,6 +26,10 @@ asserted to return to the Composer on ``Esc``:
      this region ALREADY existed outside the original hand-enumeration —
      exactly the "6th focusable region" case the note below predicted —
      so it is now armed here per that note's own instruction.
+  7. SearchBar's query ``Input`` (#3476 ⑤ — reached via ``ctrl+f``, not
+     Shift+Tab cycling). Added on the SAME "maintainer's job" instruction
+     the note below states — #3488 introduced this region without arming
+     it here; closed by this PR.
 
 This list is NOT derived from an exhaustive enumeration of every focusable
 widget the app can mount (co-vet note, #3365 review) — it is the set of
@@ -279,4 +283,37 @@ async def test_esc_from_conversation_pane_returns_to_composer() -> None:
         await pilot.pause()
         assert app.query_one(Composer).has_focus, (
             f"Esc from the conversation pane did not return to Composer: {app.focused!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_esc_from_search_bar_returns_to_composer() -> None:
+    """Tier 2b: Esc from the search bar's query Input -> Composer.
+
+    The 7th hand-enumerated state (see the module docstring): SearchBar is
+    reached via ``ctrl+f`` (#3476 ⑤), not Shift+Tab cycling — a different
+    reachability path than every other state in this file, so it is armed
+    here as its own case rather than assumed to be covered by the FlowView
+    case above."""
+    from reyn.interfaces.inline.textual_chat.search_bar import SearchBar
+
+    app = TextualChatApp(transport=_Transport([]))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.query_one(Composer).focus()
+        await pilot.pause()
+
+        await pilot.press("ctrl+f")
+        await pilot.pause()
+        assert isinstance(app.focused, Input), (
+            f"setup: ctrl+f did not focus the search input: {app.focused!r}"
+        )
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.query_one(Composer).has_focus, (
+            f"Esc from the search bar did not return to Composer: {app.focused!r}"
+        )
+        assert not app.query_one(SearchBar).display, (
+            "Esc from the search bar left it open"
         )


### PR DESCRIPTION
**[tui-coder]** — #3476 ⑥ キーボードカーソル。**#3476 を close します**(①〜⑥ 全項目完了)。

Closes #3476

## What

- `FlowView` に flowview 0.6.0 の `cursor=True` を有効化 — #3470 が保留した「FlowView フォーカスの視覚表示」を埋める最後の面。
- 到達手段は #3470 確立済みの経路のまま(Shift+Tab、Esc で復帰、#3399 gate 保護)。↑/↓/PageUp/PageDown/Home/End は flowview 組み込み。
- **`DescendantFocus` で FlowView フォーカス直後にカーソルを newest entry へ arm** — flowview 自身の `move_cursor` は `cursor=None` から始まり最初の矢印キーで初めて着地する仕様のため、そのままだと「フォーカスしても何も見えない」affordance gap になる。矢印を押す前から見える状態にした。
- **Enter/Space(`Activated`)= カーソル上のエントリを直接クリップボードへコピー** — kind 不問・ring 不使用(`/copy` の `COPY_BUFFER_MAX` ring は agent reply の序数指定専用だが、カーソルは任意の 1 エントリを直接指すため解決すべき序数が無い)。
- **`r` = 裸 `/rewind` を通常 submit seam(`app._submit`)経由で送信** — 既存 `RewindPicker`(#3362)への高速入口。**特定エントリへの直接ジャンプではない**(下記参照)。

## rewind 統合のスコープ(owner 確認済み)

`ChatMessage.seq`(会話ログ)と `AgentRegistry.list_rewind_points` が返す WAL seq は別の seq 空間で、両者を結ぶ相関はコードベースに現存しません。特定カーソルエントリ→特定チェックポイントへの直接ジャンプはこの相関の新規配線が必要で ⑥ のスコープを超えるため、**`r` は「裸 `/rewind` を打つのと同じことをするショートカット」として実装**(owner 判断記録: https://github.com/tya5/reyn/issues/3476#issuecomment-5126939172)。

## ⑤ で見つけた構造ギャップの検証(予測の当否報告)

⑤ の PR で「`flowview--selected` の背景色スタイルが `Presentation.background` 持ち行(user/failure 行)で消える」構造ギャップを発見し、「⑥ の cursor でも同じ機構に当たる見込み」という**予測つきで**issue に記録していました。

**予測は的中しました。** `flowview--cursor` も同じ `Style.apply_style` の merge セマンティクスを通るため、同じく `text-style: reverse` を採用。実端末で user 行・agent 行の両方で reverse(`\x1b[7m`)が生存することを確認。同一エントリに selected と cursor が重なるケースは flowview 自身の適用順(selected → cursor)により cursor 側が事実上優先、reverse の重ね掛けは冪等なので二重効果にはなりません。

## 副次修正: #3365 Esc-sufficiency gate の backfill

#3488(⑤)が SearchBar という新しい focusable region を導入した際、同 gate ファイルの docstring が明記する「新 region 追加時は maintainer がここを拡張する」ルールを私自身が見落としていました。今回気づいたので追加(6→7 states、全 green)。

## Tests

- `tests/test_conversation_cursor_3476.py`(Tier 2b ×5): Shift+Tab で newest entry に cursor arm / Enter でカーソルエントリ(tool kind、ring 対象外)を直接コピー / Space も同様に動作 / `r` が実 submit seam で bare `/rewind` を送る / composer フォーカス中は `r` が通常文字として通る(ショートカットが cursor focus 限定であることを確認)
- `tests/test_textual_chat_esc_sufficiency_3365.py`: SearchBar state 追加(7/7 green)

## Gates

- [x] `ruff check src tests` clean
- [x] `test_tier_audit.py --strict` — 12/12 OK
- [x] `verify_module_docstrings.py` OK
- [x] full `pytest -n auto`: **9582 passed, 49 skipped, 0 failed**(結果は PR コメントで報告)

## Test plan (Manual / Visual)

- [x] 実端末 witness(tmux 150×45、240 msg 復元 workspace): Shift+Tab(raw `ESC [ Z`)で FlowView フォーカス → newest entry(agent 行)が reverse で自動 arm 済みを確認(矢印キー不要)→ ↑ で older(user 行)へ移動、reverse 生存確認 → Enter でそのユーザ発言を直接コピー(実クリップボードで確認、"copied to clipboard" ステータス表示)→ `r` で `/rewind` 送信、RewindPicker が checkpoint 一覧(`seq 6 · ... · turn`)を表示 → Esc でキャンセル、composer 復帰 → composer で `r` を打鍵し通常文字として入力されることを確認(ショートカットが漏れ出していない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
