### PR TITLE
fix(tui): mark the addressed row with a gutter rail, not reverse video (closes #3490)

### DIFF
--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -654,6 +654,26 @@ second hand-rolled column:
   (`int(clock() / frame_period)`) that flowview's own
   `FlowView(animation_fps=N)` re-invokes on each animation tick — no
   app-side timer (#3283 ①, native-blink equivalence).
+  This column additionally carries the **ADDRESSED-ROW RAIL** (#3490): when an
+  entry is the keyboard cursor's row (#3476 ⑥) or the current `ctrl+f` search
+  hit (#3476 ⑤), a thin `▎` bar in `_CC_COOL` is drawn in the gutter's
+  trailing cell, down the body's whole post-wrap `height`, so one entry reads
+  as one marked block. The state glyph keeps its own `EntryState` colour —
+  being addressed is a POSITION, not an outcome, so the mark must not repaint
+  the state vocabulary. The app supplies `ReynGutter(is_marked=…)`, which reads
+  `FlowView.cursor`/`.selected` live on every gutter repaint, and re-derives
+  the two affected rows' gutters via `FlowView.refresh_gutter` on each
+  `Highlighted`/`Selected` (the gutter cache is keyed on a decor revision that
+  a cursor move does not bump, so without that invalidation the rail would
+  strand on the row it was first painted on). **Why the rail is gutter CONTENT
+  and not a `flowview--selected`/`--cursor` component style**: flowview applies
+  a component style as `Segment.apply_style(segments, style)` ==
+  `style + segment.style` — a BASE *beneath* each segment's own attributes,
+  with no `post_style` — so a background there is swallowed on exactly the rows
+  carrying the ROW TINT described next. `text-style: reverse` does survive that
+  merge (it is what #3476 ⑤/⑥ originally shipped) but inverts fg/bg into a
+  near-white block over the palette, so surviving the merge is necessary and
+  not sufficient.
 - **ROW TINT — `Presentation.background`** (`presenter.py`): a user row and a
   FAILURE row (a `tool_call_failed` / `error` frame, or a `tool_call_completed`
   whose summary is a `✗`) carry a whole-row background that flowview paints

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -527,34 +527,18 @@ class TextualChatApp(App):
         height: 1fr;
         scrollbar-size-vertical: 0;
     }
-    /* #3476 ⑤: the current search hit (and any click-selected entry —
-       flowview applies the same class to both). flowview ships NO colour of
-       its own for this ("unstyled by default", its component-class contract),
-       so without this rule a selection is invisible. ``reverse`` — the
-       terminal-native current-hit affordance (less/vim) — rather than a
-       background wash: flowview merges a row's ``Presentation.background``
-       into every segment BEFORE applying this component style, and
-       ``apply_style`` lets segment-explicit attributes win, so a background
-       here would vanish on exactly the rows that carry a full-row backdrop
-       (user lines, failure rows). ``reverse`` is an attribute no presenter
-       segment sets, so it survives the merge on every row kind. (Upstream
-       structural gap noted on #3476: selected/cursor component styles should
-       apply with override semantics — ⑥'s keyboard cursor hits the same.) */
-    FlowView > .flowview--selected {
-        text-style: reverse;
-    }
-    /* #3476 ⑥: the keyboard cursor — the same background-merge structural gap
-       ⑤ found (see the ``flowview--selected`` rule above) applies identically
-       here (same ``Strip.apply_style`` code path), so ``reverse`` again rather
-       than a background wash. When a search hit and the cursor land on the
-       SAME entry, flowview applies ``flowview--selected`` then
-       ``flowview--cursor`` in that order (flowview's own component-application
-       order, unchanged here) — ``reverse`` on ``reverse`` is idempotent, so the
-       row simply reads as one reversed row either way, never a doubled
-       effect. */
-    FlowView > .flowview--cursor {
-        text-style: reverse;
-    }
+    /* #3490: NO ``flowview--selected`` / ``--cursor`` component style. Both
+       are deliberately left unstyled (flowview's own default) and the
+       addressed row is marked in the GUTTER instead — see ReynGutter's
+       ``is_marked``. A component style cannot do this job: flowview applies it
+       via ``Strip.apply_style``, i.e. ``style + segment.style``, so it is only
+       ever a BASE under each segment's own attributes and a background here
+       vanishes on the rows that carry a full-row ``Presentation.background``
+       (the user's own line, failure rows). ``text-style: reverse`` DOES
+       survive that merge — it is what #3476 ⑤/⑥ shipped — but inverting
+       fg/bg paints a near-white block over the palette (owner review: "白背景
+       になって気持ち悪い / 洗練されてたデザインを壊してる"), so surviving the
+       merge is necessary and not sufficient: the mark has to be CONTENT. */
     #inputrow {
         height: auto;
         max-height: 8;
@@ -830,6 +814,12 @@ class TextualChatApp(App):
         # switch), so a switch can never page in the previous session's
         # leftovers.
         self._older_frames: "list[OutboxMessage]" = []
+        # #3490: the entries the addressed-row rail is currently painted on.
+        # flowview's Highlighted/Selected report only the entry MOVED TO, so the
+        # one moved AWAY from is tracked here — it needs its gutter re-derived
+        # too, otherwise the rail is left behind on it.
+        self._marked_cursor: "Entry[OutboxMessage] | None" = None
+        self._marked_selected: "Entry[OutboxMessage] | None" = None
 
     def compose(self) -> ComposeResult:
         # Held so the frame pump can start/stop the per-entry BODY animation
@@ -838,7 +828,13 @@ class TextualChatApp(App):
         self._flow: "FlowView[OutboxMessage]" = FlowView(
             model=self.conversation,
             presenter=self._presenter,
-            decorator=ReynGutter(frame_period=_RUNNING_FRAME_PERIOD),
+            decorator=ReynGutter(
+                frame_period=_RUNNING_FRAME_PERIOD,
+                # #3490: the addressed-row rail. Read live off the view each
+                # repaint (not pushed in on every move) so the gutter can never
+                # hold a stale copy of which entry is current.
+                is_marked=self._is_addressed_entry,
+            ),
             gutter_width=_GUTTER_WIDTH,
             # Phase ④ (#3283): the RIGHT gutter shows per-entry elapsed time
             # (tool rows) AND the row's turn's real prompt/completion token
@@ -1269,6 +1265,10 @@ class TextualChatApp(App):
         self._search_bar.open()
         if self._search_bar.query:
             self._search_sync(self._search_bar.query, jump=True)
+            # #3490: re-opening onto the SAME hit selects an already-selected
+            # entry, which flowview treats as a no-op (no ``Selected``), so the
+            # focus-gated rail would not come back on its own.
+            self._remark_entry(self._flow.selected)
 
     @staticmethod
     def _search_predicate(query: str):
@@ -1332,6 +1332,68 @@ class TextualChatApp(App):
         self._flow.clear_selection()
         self.query_one(Composer).focus()
 
+    # ── #3490: the addressed-row rail ──────────────────────────────────────
+
+    def _is_addressed_entry(self, entry: "Entry[OutboxMessage]") -> bool:
+        """Whether ``entry`` is the row the user is currently addressing — the
+        keyboard cursor's position (#3476 ⑥) or the live search hit (⑤).
+
+        Both answer "this is the row you are on", so they share ONE rail rather
+        than competing marks; when they coincide the row is marked once. Read by
+        :class:`ReynGutter` on every gutter repaint, so it is always the view's
+        own live state — ``_flow`` may not exist yet during ``compose``, hence
+        the guard.
+
+        Each leg is gated on its own surface actually being ACTIVE, not merely
+        on the position being remembered: the cursor's rail shows only while
+        FlowView holds focus, the hit's only while the search bar is open. The
+        positions themselves persist (leaving and re-entering the pane resumes
+        where you were — see :meth:`on_descendant_focus`), but a rail on a pane
+        nobody is addressing is permanent chrome rather than an affordance, and
+        this whole issue (#3490) is about the mark not intruding on the
+        conversation's own design when it has nothing to say."""
+        flow = getattr(self, "_flow", None)
+        if flow is None:
+            return False
+        if entry is flow.cursor and flow.has_focus:
+            return True
+        bar = getattr(self, "_search_bar", None)
+        return entry is flow.selected and bar is not None and bar.display
+
+    def _remark_entry(self, entry: "Entry[OutboxMessage] | None") -> None:
+        """Re-derive ``entry``'s gutter on the next paint.
+
+        The gutter cache is keyed on the entry's own decor revision, which a
+        cursor/selection MOVE does not bump (flowview repaints the body but has
+        no reason to think the gutter changed) — so the rail would otherwise
+        stay on the row it was first painted on. ``refresh_gutter`` is
+        flowview's public invalidation hook for exactly this."""
+        if entry is not None:
+            try:
+                self._flow.refresh_gutter(entry)
+            except Exception:
+                logger.exception("textual chat: gutter refresh failed")
+
+    def on_descendant_blur(self, event: "events.DescendantBlur") -> None:
+        """#3490: hide the cursor's rail when the pane loses focus (Esc back to
+        the composer, a Tab step onward). The cursor POSITION is kept — only
+        the mark goes, because nothing is being addressed any more."""
+        if event.widget is getattr(self, "_flow", None):
+            self._remark_entry(self._flow.cursor)
+
+    def on_flow_view_highlighted(self, event: "FlowView.Highlighted") -> None:
+        """#3490: move the rail with the keyboard cursor — repaint the row it
+        left as well as the one it arrived on."""
+        previous, self._marked_cursor = self._marked_cursor, event.entry
+        self._remark_entry(previous)
+        self._remark_entry(event.entry)
+
+    def on_flow_view_selected(self, event: "FlowView.Selected") -> None:
+        """#3490: the search hit's rail, same two-row repaint as the cursor."""
+        previous, self._marked_selected = self._marked_selected, event.entry
+        self._remark_entry(previous)
+        self._remark_entry(event.entry)
+
     # ── #3476 ⑥: the keyboard cursor's own actions ─────────────────────────
 
     def on_descendant_focus(self, event: "events.DescendantFocus") -> None:
@@ -1344,8 +1406,16 @@ class TextualChatApp(App):
         ``cursor_last`` (not ``cursor_first``) so arrival highlights the
         newest entry, matching where a resumed/live conversation's attention
         already is."""
-        if event.widget is self._flow and self._flow.cursor is None:
+        if event.widget is not self._flow:
+            return
+        if self._flow.cursor is None:
             self._flow.cursor_last()
+        else:
+            # #3490: the position was remembered from a previous visit, so no
+            # cursor MOVE happens and no ``Highlighted`` fires — but the rail is
+            # focus-gated, so the row still needs its gutter re-derived to
+            # bring the rail back.
+            self._remark_entry(self._flow.cursor)
 
     async def on_flow_view_activated(self, event: "FlowView.Activated") -> None:
         """Enter/Space on the cursor entry: copy ITS text directly.

--- a/src/reyn/interfaces/inline/textual_chat/gutter.py
+++ b/src/reyn/interfaces/inline/textual_chat/gutter.py
@@ -45,6 +45,7 @@ from rich.text import Text
 from textual_flowview import EntryState
 
 from reyn.interfaces.repl.renderer import (
+    _CC_COOL,
     _CC_DIM,
     _CC_DONE,
     _CC_ERR,
@@ -93,6 +94,18 @@ _RUNNING_FRAMES = ("●", "○")
 #: ``FlowView(animation_fps=1/_RUNNING_FRAME_PERIOD)`` so the decorator is
 #: re-invoked at least once per frame. ``<= 0`` freezes the blink (static frame 0).
 _RUNNING_FRAME_PERIOD = 0.5
+
+#: The ADDRESSED-entry rail (#3490): a thin left-edge bar marking the keyboard
+#: cursor's row / the current search hit. One cell wide, drawn in the gutter's
+#: trailing cell so it costs no body column and doubles as the gutter/body
+#: separator on the marked row.
+_MARK_RAIL = "▎"
+
+#: The rail's colour — ``_CC_COOL`` (the palette's secondary accent) rather than
+#: any ``_STATE_COLOR`` member or ``_CC_ACCENT``: being addressed is a POSITION,
+#: not an outcome and not "running", so it must not collide with the state
+#: vocabulary the glyph beside it already speaks.
+_MARK_COLOR = _CC_COOL
 
 
 def _gutter_glyph_color(msg: "OutboxMessage") -> "tuple[str, str]":
@@ -179,16 +192,31 @@ class ReynGutter:
     ``clock`` is injectable (default :func:`time.monotonic`) so a test can drive
     the frame deterministically; ``frame_period <= 0`` freezes the blink to a
     static frame 0 (the animation is additive — a frozen clock leaves a correct,
-    non-animated amber gutter)."""
+    non-animated amber gutter).
+
+    ``is_marked`` (#3490) reports whether an entry is the ADDRESSED one — the
+    keyboard cursor's position or the current search hit. A marked entry gets
+    :data:`_MARK_RAIL` drawn down its whole height in the gutter's trailing
+    cell, which is why the mark lives HERE rather than in a
+    ``flowview--selected``/``--cursor`` component style: a component style is
+    applied as a *base* under each segment's own attributes
+    (``Segment.apply_style`` = ``style + segment.style``; flowview passes no
+    ``post_style``), so a background there is swallowed on exactly the rows that
+    carry a full-row ``Presentation.background`` — the user's own line and any
+    failure row. The gutter is CONTENT, so it renders identically on every row
+    kind. Defaults to "nothing is marked", leaving the Phase-2 gutter
+    byte-identical for every caller that does not pass it."""
 
     def __init__(
         self,
         *,
         frame_period: float = _RUNNING_FRAME_PERIOD,
         clock: "Callable[[], float]" = time.monotonic,
+        is_marked: "Callable[[Entry[OutboxMessage]], bool] | None" = None,
     ) -> None:
         self._frame_period = frame_period
         self._clock = clock
+        self._is_marked = is_marked
 
     def _running_frame(self) -> str:
         """The current ``_RUNNING_FRAMES`` glyph, selected from the clock. A
@@ -208,7 +236,20 @@ class ReynGutter:
             color = kind_color
         else:
             color = _STATE_COLOR.get(state, kind_color)
-        return Text(_cell_pad_right(glyph, width), style=color)
+        if self._is_marked is None or not self._is_marked(entry):
+            return Text(_cell_pad_right(glyph, width), style=color)
+        # #3490: the addressed entry — a thin rail down the gutter's trailing
+        # cell, spanning the body's full post-wrap ``height`` so a multi-row
+        # reply reads as ONE marked block. The state glyph keeps its own
+        # EntryState colour (the mark is a POSITION, not a state, so it must
+        # not repaint the state vocabulary).
+        rail = Text()
+        for row in range(max(1, height)):
+            if row:
+                rail.append("\n")
+            rail.append(_cell_pad_right(glyph if row == 0 else "", width - 1), style=color)
+            rail.append(_MARK_RAIL, style=_MARK_COLOR)
+        return rail
 
 
 def _format_elapsed(seconds: float) -> str:

--- a/tests/test_addressed_row_rail_3490.py
+++ b/tests/test_addressed_row_rail_3490.py
@@ -1,0 +1,307 @@
+"""#3490 — the addressed row is marked by a GUTTER RAIL, not a style overlay.
+
+#3476 ⑤/⑥ marked the search hit / keyboard cursor with
+``text-style: reverse`` on flowview's ``--selected``/``--cursor`` component
+classes. That survived flowview's style merge but inverted fg/bg into a
+near-white block over the palette (owner review: it broke the design). The
+mark is now CONTENT — a thin rail in the left gutter's trailing cell — which
+is what makes it work uniformly:
+
+flowview applies a component style as ``Segment.apply_style(segments, style)``
+== ``style + segment.style``, i.e. as a BASE beneath each segment's own
+attributes, and passes no ``post_style``. So a component *background* is
+swallowed on every row whose presentation carries a full-row
+``Presentation.background`` — the user's own line and any failure row. These
+tests therefore assert the rail on BOTH a plain agent row and a backdropped
+user row, and assert the absence of reverse video, because "it survives the
+merge" and "it looks right" are two different requirements and only the
+second one failed last time.
+
+Read off the PAINTED surface (``FlowView.render_line`` — the same strips a
+terminal receives) with a real ``TextualChatApp`` + a real minimal
+``ClientTransport``: no mocks, no private view state.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.chrome import Composer
+from reyn.interfaces.inline.textual_chat.gutter import _MARK_RAIL
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _Transport(ClientTransport):
+    def __init__(self) -> None:
+        self.submitted: list[str] = []
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        await asyncio.Event().wait()
+        yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
+
+    async def submit_user_text(self, text: str) -> None:
+        self.submitted.append(text)
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def deliver_pending_answer(self, text: str) -> bool:
+        return False
+
+
+def _painted_rows(flow: FlowView) -> "list[str]":
+    """Every visible row of the pane, as painted (gutter included)."""
+    return [
+        "".join(segment.text for segment in flow.render_line(y))
+        for y in range(flow.size.height)
+    ]
+
+
+def _railed_rows(flow: FlowView) -> "list[str]":
+    return [row for row in _painted_rows(flow) if _MARK_RAIL in row]
+
+
+def _reversed_rows(flow: FlowView) -> "list[str]":
+    """Rows painted with reverse video — the regression this issue is about."""
+    out = []
+    for y in range(flow.size.height):
+        strip = flow.render_line(y)
+        if any(seg.style is not None and seg.style.reverse for seg in strip):
+            out.append("".join(seg.text for seg in strip))
+    return out
+
+
+async def _focus_flow(pilot, app) -> "FlowView":
+    app.query_one(Composer).focus()
+    await pilot.pause()
+    await pilot.press("shift+tab")
+    await pilot.pause()
+    flow = app.query_one(FlowView)
+    assert app.focused is flow, f"setup: Shift+Tab did not focus FlowView: {app.focused!r}"
+    return flow
+
+
+@pytest.mark.asyncio
+async def test_the_cursor_row_is_railed_and_nothing_is_reverse_video() -> None:
+    """Tier 2b: the keyboard cursor's row paints a rail — and NO row paints
+    reverse video (the near-white inversion #3476 ⑥ shipped)."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        for text in ("older reply", "newest reply"):
+            app.conversation.append(OutboxMessage(kind="agent", text=text))
+        await pilot.pause()
+        flow = await _focus_flow(pilot, app)
+
+        railed = _railed_rows(flow)
+        assert any("newest reply" in row for row in railed), (
+            f"the cursor row is not railed: {railed!r}"
+        )
+        assert not any("older reply" in row for row in railed), (
+            f"a row the cursor is not on is railed: {railed!r}"
+        )
+        assert _reversed_rows(flow) == [], (
+            f"reverse video is painted again: {_reversed_rows(flow)!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_backdropped_user_row_is_railed_too() -> None:
+    """Tier 2b: the rail shows on the USER's own row — the row kind whose
+    full-row ``Presentation.background`` swallows any component-style
+    background, and the reason the mark cannot be a style overlay."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.conversation.append(OutboxMessage(kind="agent", text="a reply"))
+        app.conversation.append(OutboxMessage(kind="user", text="my own question"))
+        await pilot.pause()
+        flow = await _focus_flow(pilot, app)
+
+        railed = _railed_rows(flow)
+        assert any("my own question" in row for row in railed), (
+            f"the user row is not railed: {railed!r}"
+        )
+        assert not any("a reply" in row for row in railed), (
+            f"the rail leaked onto the agent row: {railed!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_rail_moves_with_the_cursor_leaving_no_trail() -> None:
+    """Tier 2b: moving the cursor repaints the row it LEFT as well as the one
+    it arrived on — the gutter cache is keyed on a decor revision a cursor
+    move does not bump, so a missing invalidation would strand the rail."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        for text in ("first", "second", "third"):
+            app.conversation.append(OutboxMessage(kind="agent", text=text))
+        await pilot.pause()
+        flow = await _focus_flow(pilot, app)
+        assert any("third" in row for row in _railed_rows(flow)), (
+            "setup: the rail did not start on the last row"
+        )
+
+        await pilot.press("up")
+        await pilot.pause()
+        railed = _railed_rows(flow)
+        assert any("second" in row for row in railed), (
+            f"the rail did not follow the cursor: {railed!r}"
+        )
+        assert not any("third" in row for row in railed), (
+            f"the rail was left behind on the row the cursor left: {railed!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_rail_spans_a_multi_row_entrys_full_height() -> None:
+    """Tier 2b: a wrapped, multi-row body is marked down its WHOLE height, so
+    one entry reads as one marked block rather than a mark on its first line."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(60, 30)) as pilot:
+        await pilot.pause()
+        long_text = " ".join(f"word{i}" for i in range(60))  # wraps at width 60
+        app.conversation.append(OutboxMessage(kind="agent", text=long_text))
+        await pilot.pause()
+        flow = await _focus_flow(pilot, app)
+
+        railed = _railed_rows(flow)
+        # ``word0`` is on the body's FIRST painted row, ``word59`` on its LAST:
+        # both railed == the mark spans the whole entry, not only its head.
+        assert any("word0 " in row for row in railed), (
+            f"the entry's first row is not railed: {railed!r}"
+        )
+        assert any("word59" in row for row in railed), (
+            f"the entry's last row is not railed — the rail stopped short: {railed!r}"
+        )
+        assert _reversed_rows(flow) == []
+
+
+@pytest.mark.asyncio
+async def test_an_unaddressed_pane_paints_no_rail() -> None:
+    """Tier 2b: with focus on the composer and no search running, nothing is
+    addressed — the pane paints no rail at all (the mark is an affordance for
+    an active position, not permanent chrome)."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.conversation.append(OutboxMessage(kind="agent", text="a reply"))
+        await pilot.pause()
+        flow = app.query_one(FlowView)
+        assert _railed_rows(flow) == [], f"an unaddressed pane is railed: {_railed_rows(flow)!r}"
+
+
+@pytest.mark.asyncio
+async def test_leaving_the_pane_hides_the_rail_but_keeps_the_position() -> None:
+    """Tier 2b: Esc back to the composer removes the rail — nothing is being
+    addressed, and a rail on an unfocused pane is permanent chrome rather than
+    an affordance. Re-entering the pane brings it back on the SAME row, so the
+    position is remembered even though the mark is not painted meanwhile."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        for text in ("first", "second"):
+            app.conversation.append(OutboxMessage(kind="agent", text=text))
+        await pilot.pause()
+        flow = await _focus_flow(pilot, app)
+        await pilot.press("up")
+        await pilot.pause()
+        assert any("first" in row for row in _railed_rows(flow)), (
+            "setup: the cursor was not moved onto the older row"
+        )
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.query_one(Composer).has_focus, "setup: Esc did not reach the composer"
+        assert _railed_rows(flow) == [], (
+            f"the rail survived leaving the pane: {_railed_rows(flow)!r}"
+        )
+
+        await pilot.press("shift+tab")
+        await pilot.pause()
+        assert any("first" in row for row in _railed_rows(flow)), (
+            f"re-entering did not restore the rail on the remembered row: "
+            f"{_railed_rows(flow)!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_closing_search_removes_the_hits_rail() -> None:
+    """Tier 2b: Esc out of the search bar takes the hit's rail with it — the
+    search-hit leg is gated on the bar being open, mirroring the cursor leg's
+    focus gate."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.conversation.append(OutboxMessage(kind="agent", text="alpha match"))
+        await pilot.pause()
+        await pilot.press("ctrl+f")
+        for ch in "alpha":
+            await pilot.press(ch)
+        await pilot.pause()
+        flow = app.query_one(FlowView)
+        assert _railed_rows(flow), "setup: the search hit was not railed"
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert _railed_rows(flow) == [], (
+            f"the hit's rail survived closing the search bar: {_railed_rows(flow)!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_search_hit_is_railed() -> None:
+    """Tier 2b: the ⑤ search hit shares the SAME rail as the cursor — both mean
+    "the row you are addressing", so they are one vocabulary, not two."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        for text in ("alpha match", "unrelated"):
+            app.conversation.append(OutboxMessage(kind="agent", text=text))
+        await pilot.pause()
+
+        await pilot.press("ctrl+f")
+        for ch in "alpha":
+            await pilot.press(ch)
+        await pilot.pause()
+
+        flow = app.query_one(FlowView)
+        railed = _railed_rows(flow)
+        assert any("alpha match" in row for row in railed), (
+            f"the search hit is not railed: {railed!r}"
+        )
+        assert not any("unrelated" in row for row in railed), (
+            f"a non-matching row is railed: {railed!r}"
+        )
+        assert _reversed_rows(flow) == []


### PR DESCRIPTION
**[tui-coder]** — owner 実機レビュー指摘の修正。

Closes #3490

## 症状

#3476 ⑤/⑥ が `flowview--selected` / `--cursor` に `text-style: reverse` を当てていたため、fg `#e0e0e0` / bg `#121212` が反転して**ほぼ白の帯**が行を横断していました(owner: 「なんか白背景になって気持ち悪い / 洗練されてたデザインを壊してる」)。tmux raw capture で `\x1b[7m` を確認。

**私の判断ミスの構造**: ⑤ で「背景色ベースの component style はユーザ行・失敗行で消える」ことを発見し、merge を生き残る `reverse` を選びました。しかし**「merge を生き残る」と「見た目が良い」は別要件**で、⑤/⑥ の実機 witness では前者だけを検証していました(`\x1b[7m` の生存を確認して満足し、それが美的にどう見えるかを見ていなかった)。

## 修正: マークを style overlay から**内容**へ

- `flowview--selected` / `--cursor` の component style を撤去(flowview 既定の unstyled に戻す)。
- `ReynGutter` が**左ガター末尾セルに細いレール `▎`(`_CC_COOL`)** を描画。body の post-wrap `height` 全域に伸ばすので、複数行エントリは**1つのマークされたブロック**として読めます。
- **body 列を消費しません**(マーク行ではガターの pad セルがレールになるだけなので、本文の桁位置は不動 — カーソル移動で文字がガタつかない)。
- state グリフの色は不変。**被アドレスは *位置* であって *状態* ではない**ので、state 語彙(RUNNING amber / SUCCESS green / ERROR coral)を塗り替えません。

**なぜ内容でなければならないか**: flowview は component style を `Segment.apply_style(segments, style)` == `style + segment.style` で当て、`post_style` を渡しません。つまり常に segment 自身の属性の**下地**になるため、`Presentation.background` を持つ行(ユーザ行・失敗行)では背景指定が消えます。ガターは内容なので全行種で同一に描かれます。

## フォーカス連動(実装中の追加発見、#3490 コメントに記録)

レール投入直後の実機確認で、Esc でペインを離れた後もレールが残ることに気づきました。位置は保持したいが、誰もアドレスしていないペインの青いレールは affordance ではなく**恒久 chrome** で、指摘された視覚ノイズと同性質です。よって各脚をそれぞれの surface が ACTIVE な間のみ表示に:

- カーソルの脚 → FlowView がフォーカス保持中のみ
- 検索ヒットの脚 → 検索バーが開いている間のみ

位置は保持されるため Shift+Tab で戻ると同じ行に復帰。フォーカス変化では cursor MOVE が無く `Highlighted` が飛ばないため、`DescendantFocus` / `DescendantBlur` と検索再オープン時に該当行のガターを明示的に再導出しています(ガターキャッシュは cursor 移動・フォーカス変化のどちらでも bump されない decor revision キー)。

## Tests (`tests/test_addressed_row_rail_3490.py`, Tier 2b ×8)

`FlowView.render_line` の**描画済みストリップ**(端末が受け取るものと同一)を読み、reverse 属性の不在も直接 assert:

1. カーソル行にレール / 他行には無し / **reverse がどこにも無い**
2. **背景を持つユーザ行**にもレール(style overlay では届かない行種)
3. カーソル移動でレール追従・**元の行に残留しない**
4. 折り返した複数行 body の**先頭行と最終行の両方**にレール(全高スパン)
5. 非アドレス時はレール無し
6. 検索ヒットにも同一レール
7. **離脱でレール消滅 + 再入場で記憶した同じ行に復帰**
8. **検索を閉じるとヒットのレールも消える**

**Falsify**: reverse 版に戻すと 5/6(拡張前)が RED、修正で 8/8 GREEN — 両方向確認済み。

## Docs

`docs/reference/runtime/agui-transport.md` の LEFT gutter 節を同 PR で更新(CLAUDE.md ハード規則)。レールの語彙・フォーカス連動・キャッシュ無効化と、**なぜ component style ではなく内容なのか**(直後の ROW TINT 節が説明する merge セマンティクスと接続)を追記。

## Gates

- [x] `ruff check src tests` clean
- [x] `test_tier_audit.py --strict` — 8/8 OK(行数 assert の Tier-4 指摘を受け、「どの行にレールが有り/無いか」の挙動 assert に書き換え済み)
- [x] `verify_module_docstrings.py` OK
- [x] full `pytest -n auto`(結果は PR コメントで報告)

## Test plan (Manual / Visual)

- [x] 実端末 witness(tmux 150×45、240 msg 復元 workspace): Shift+Tab でレール出現 → ↑ でレール追従(残留なし) → **ユーザ行(背景持ち)でもレール描画**を raw ANSI で確認 → 15 行の長い返信で**全高スパン**(レール 15 / reverse 0) → Esc でレール消滅 → Shift+Tab で**同じ行に復帰** → ctrl+f 検索ヒットにレール → Esc でヒットのレールも消滅 → 全操作を通して `\x1b[7m` 出現ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)
