### PR TITLE
docs(tests): record the rich memo bug and when the workaround can go

### DIFF
--- a/tests/test_markdown_palette_gate_3469.py
+++ b/tests/test_markdown_palette_gate_3469.py
@@ -106,6 +106,38 @@ def _memo_cleared_theme() -> "object":
     gate measure what a real single-colour-system terminal process sees. A
     REAL terminal process is unaffected by the upstream bug: it has one
     colour system, so the memo is always computed for the system it serves.
+
+    **Upstream status — deliberately NOT reported (owner decision).** This is a
+    bug in rich, not in reyn and not in litellm: ``Style._make_ansi_codes``
+    caches the rendered SGR in ``self._ansi`` and never keys that cache by
+    ``color_system``. It is recorded here rather than filed upstream, so this
+    docstring is the only place the mechanism lives — keep it accurate.
+
+    **When can this helper go away?** Run this against the installed rich; it
+    is the whole decision, and it needs no reyn code::
+
+        from io import StringIO
+        from rich.console import Console
+        from rich.style import Style
+
+        s = Style.parse("#6b7280")
+        Console(file=StringIO(), force_terminal=True,
+                color_system="standard").print("x", style=s)
+        out = StringIO()
+        Console(file=out, force_terminal=True,
+                color_system="truecolor").print("x", style=s)
+        print(repr(out.getvalue()))
+
+    On rich 15.0.0 this prints ``'\x1b[90mx\x1b[0m\n'`` — the truecolor
+    console re-emitting the *standard* console's memoized escape, i.e. the bug
+    is present and this helper is still load-bearing. Once it prints an
+    ``\x1b[38;2;107;114;128m`` sequence instead, rich keys the memo per colour
+    system, and then: this function collapses to a plain
+    ``chat_markdown_theme()`` call, and
+    :func:`test_gate_measures_the_theme_not_another_consoles_downgrade_memo`
+    (which only guards against the poisoning, and passes either way) loses its
+    reason to exist. Do not delete either one on a version bump alone — run the
+    snippet, because the fix could land in any release.
     """
     theme = chat_markdown_theme()
     for style in theme.styles.values():  # type: ignore[attr-defined]


### PR DESCRIPTION
**[tui-coder]** — owner 決定「rich への上流報告は出さない、代わりに自分のコードに注記する」への対応(lead-coder 経由で受領)。

## 背景

#3472 で CI 限定 red の根本原因として rich の上流バグを特定しました(`Style._make_ansi_codes` が SGR を `self._ansi` にメモ化するが **`color_system` でキーしていない** + `Style.parse` が `lru_cache` でプロセス全体にインスタンスを共有 → 低色数コンソールの描画が共有メモを汚染し、truecolor コンソールがそれを再送出)。決定的な回帰テストに変換して #3472 で着地済みです。

**owner 判断: 上流には出さない。代わりに機構を自分のコード/ドキュメントに残す。** よってこの docstring が**唯一の記録**になります。

## 追記した3点

1. **これは rich のバグである**こと(reyn でも litellm でもない)と、正確な上流の場所(`Style._make_ansi_codes`、rich 15.0.0)
2. **上流に出さないのは意図的な判断**であること(見落としではない)
3. ★ **「まだ必要か」を判定する手順** — lead-coder の指示「将来 rich を上げたときに、まだ必要かが読める形」への対応

## 判定手順を実行可能な snippet にした理由

**既存のどちらのテストもこの問いに答えられません。** `test_gate_measures_the_theme_not_another_consoles_downgrade_memo` は「メモ汚染が漏れないこと」を守る**防御**で、`_memo_cleared_theme` が効いている限り**上流が直っていても直っていなくても緑**です。つまり **suite が緑であることは「回避策がまだ必要」の証拠になりません**。

そこで reyn のコードを一切使わない6行の probe を置き、**両方の期待出力**を明記しました:

- rich 15.0.0 → `'\x1b[90mx\x1b[0m\n'`(truecolor コンソールが standard コンソールのメモを再送出 = **バグあり、回避策は load-bearing**)
- 直った場合 → `\x1b[38;2;107;114;128m` が出る = `_memo_cleared_theme` は素の `chat_markdown_theme()` に縮小でき、poison test も存在理由を失う

**この snippet は書く前に実際に走らせて検証しました**(未検証の手順を「判定基準」として残すのは意味がないため)。

**バージョン pin にはしていません** — 修正はどのリリースに入るか分からないので、「バージョン比較を信じるな、probe を走らせろ」と書いてあります。

## Gates

- [x] `ruff check` clean
- [x] `test_tier_audit.py --strict` — 4/4 OK、**bounded-life warning 0**(検出器をテストとして追加せず docstring の手順にしたので、腐るテストを増やしていません)
- [x] `pytest tests/test_markdown_palette_gate_3469.py` — 4 passed
- [ ] full `pytest` — docstring のみの変更のため未実行(実行可能コードに差分なし。CI で確認されます)

## Test plan

- [x] Manual: 判定 snippet を installed rich に対して実行し、bug-present 側の出力(`90`)を確認
- [x] Manual: 既存4テストが緑のままであることを確認(docstring 変更なので当然だが、貼り付けミスの検出として)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
