### PR TITLE
fix(mcp): guarantee tools-cache priming ahead of every turn kind's first LLM call — #3475

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5647,21 +5647,19 @@ class Session:
         # budget without resetting.
         self._reset_router_turn_counter()
 
-        # FP-0037 S2: yaml-triggered MCP tools cache refresh, run BEFORE the
-        # S1 disk-reload step — see docs/reference/cli/mcp.md#refresh-quick-reference
-        await self._router_host.maybe_refresh_mcp_tools_from_yaml()
-
-        # FP-0037 S1: pick up an operator-run `reyn mcp refresh` from disk —
-        # see docs/reference/cli/mcp.md#refresh-quick-reference
-        self._router_host.maybe_reload_mcp_tools_cache_from_disk()
-
-        # FP-0037 issue #160: lazy MCP tool discovery cache. First user
-        # turn probes every configured MCP server's tool list once;
-        # subsequent turns no-op. Zero startup latency; first-turn cost
-        # is bounded by per_server_timeout (default 5s, parallel).
-        # When no MCP servers are configured this is a near-free no-op.
-        await self._router_host.ensure_mcp_tools_cached()
-
+        # #3475: the FP-0037 MCP-tools-cache priming chain (yaml refresh / disk
+        # reload / lazy probe) used to live HERE — the "user" turn kind only.
+        # `_handle_hook_message` and `InterAgentMessaging.handle_agent_request`
+        # call `_run_router_loop` directly and never ran this chain, so a
+        # session whose FIRST turn arrives as `hook` or `agent_request` (e.g. a
+        # freshly `spawn_ephemeral_session`-ed worker driven by an inbound
+        # `agent_request`) built its first `tools=` payload against an
+        # unprimed (`None`) cache — no `mcp_tool_name` enum, silently, for the
+        # rest of that session's life (the populated-guard is one-shot). The
+        # chain now lives in `_run_router_loop` itself instead — see that
+        # method's docstring for why it is the one seam every turn kind
+        # funnels through — so the ordering guarantee is structural (every
+        # first LLM call goes through this priming, not just the common case).
         try:
             await self._run_router_loop(text, chain_id)
         except StructuredOutputError:
@@ -7472,8 +7470,23 @@ class Session:
         unattributed instead of charged to the latest turn; see
         ``reyn.core.turn_scope`` for the enumeration of those paths (the
         ``/compact`` slash short-circuit and the dev/dogfood surfaces).
+
+        #3475: this is ALSO where the FP-0037 MCP-tools-cache priming chain
+        (yaml refresh / disk reload / lazy probe) runs, for the same reason —
+        it is the one place every turn kind funnels through BEFORE the first
+        LLM call of the turn. Previously only ``_handle_user_message`` ran this
+        chain, so a turn arriving as ``hook`` or ``agent_request`` (a freshly
+        spawned worker's first inbound message, e.g.) built its `tools=`
+        payload against a never-primed cache — no `mcp_tool_name` enum on
+        `call_mcp_tool`/`describe_mcp_tool`, silently, for that session's
+        entire life (`ensure_mcp_tools_cached`'s populated-guard is one-shot).
+        Running the chain here instead makes the ordering guarantee structural
+        rather than kind-dependent.
         """
         self._last_turn_chain_id = chain_id
+        await self._router_host.maybe_refresh_mcp_tools_from_yaml()
+        self._router_host.maybe_reload_mcp_tools_cache_from_disk()
+        await self._router_host.ensure_mcp_tools_cached()
         with active_turn(chain_id):
             await self._loop_driver.run_turn(user_text, chain_id)
         # #1800 slice 5a: emit HERE (after `run_turn()` returns), not inside RouterLoop — the

--- a/tests/test_3475_mcp_probe_priming_all_turn_kinds.py
+++ b/tests/test_3475_mcp_probe_priming_all_turn_kinds.py
@@ -1,0 +1,157 @@
+"""Tier 2: #3475 — the MCP-tools-cache priming chain must run before the
+FIRST LLM call of a turn regardless of the turn's `kind`, not just `user`.
+
+Background (#3429 arc / #3463 review / #3475 investigation): the FP-0037
+lazy MCP-tools-cache priming chain (`maybe_refresh_mcp_tools_from_yaml` →
+`maybe_reload_mcp_tools_cache_from_disk` → `ensure_mcp_tools_cached`) used to
+run ONLY inside `Session._handle_user_message` — the `kind="user"` turn
+handler. `Session._handle_hook_message` (`kind="hook"`) and
+`InterAgentMessaging.handle_agent_request` (`kind="agent_request"`, the path
+a freshly `spawn_ephemeral_session`-ed worker's first inbound message takes)
+both call `Session._run_router_loop` directly and never ran the chain. A
+session whose FIRST turn arrives as one of those two kinds therefore built
+its first `tools=` payload (and thus `call_mcp_tool`/`describe_mcp_tool`'s
+`mcp_tool_name` enum) against a never-primed (`None`) cache — permanently for
+that session's life, since `ensure_mcp_tools_cached`'s populated-guard is
+one-shot (`if self._mcp_tools_cache is not None: return`).
+
+This is the production-side question #3475 asks to settle: is the priming
+chain await-ordered ahead of the first LLM call, or does it merely "usually
+run in time"? Answer for `hook`/`agent_request`-first sessions: neither —
+it never ran at all. The fix moves the chain from `_handle_user_message`
+into `Session._run_router_loop` itself — the one seam every turn kind
+(user / hook / agent_request / pipeline_result) funnels through before its
+first LLM call (see that method's own docstring) — making the guarantee
+structural instead of kind-dependent.
+
+Verified here via the SAME real-callable seam
+`tests/test_2242_hard_cancel.py` uses to isolate the mechanism under test
+from RouterLoop's own internals: `Session._loop_driver.run_turn` is replaced
+with a plain async function (method-assigned onto the instance — not a
+mock) that captures `session.router_host.mcp_tools_cache_snapshot` (public
+property) the INSTANT it is invoked. Because the real `_run_router_loop`
+awaits the priming chain immediately before calling `run_turn`, the captured
+snapshot proves whether priming already ran by then.
+
+No unittest.mock/AsyncMock/MagicMock/patch. Private-state access: NONE —
+the only session internals read are the public `router_host` property and
+its public `mcp_tools_cache_snapshot`.
+
+strip-falsify: reverting the `_run_router_loop`/`_handle_user_message` change
+(the chain moved back to only firing for kind="user") turns
+`test_agent_request_first_turn_primes_mcp_cache_before_first_llm_call` and
+`test_hook_first_turn_primes_mcp_cache_before_first_llm_call` RED — the
+captured snapshot is `None` because priming never ran for those kinds.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.services.mcp_cache_file import cache_file_path, write_cache
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+_SERVER = "reyn_markitdown"
+_TOOLS = [{"name": "convert_to_markdown", "description": "convert a uri to markdown"}]
+
+
+def _make_session(tmp_path: Path) -> Session:
+    """A session with one configured MCP server, warm-startable from disk so
+    `ensure_mcp_tools_cached()` never needs a real subprocess probe (mirrors
+    `tests/test_session_refresh_mcp_servers.py`'s own technique)."""
+    write_cache(cache_file_path(tmp_path / ".reyn" / "state"), {_SERVER: _TOOLS})
+    return make_session(
+        agent_name="fp3475-agent",
+        mcp_servers={_SERVER: {"description": "markitdown"}},
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snapshot.json",
+    )
+
+
+def _install_snapshot_capturing_run_turn(session: Session) -> dict:
+    """Replace `_loop_driver.run_turn` with a real, plain async function
+    (instance method-assignment, not a mock) that snapshots the MCP tools
+    cache the instant it is invoked, then ends the turn immediately (no LLM
+    call, no tool loop) — the test only cares about ordering, not the turn's
+    outcome."""
+    box: dict = {"snapshot": "UNSET"}
+
+    async def _capturing_run_turn(user_text: str, chain_id: str) -> None:
+        box["snapshot"] = session.router_host.mcp_tools_cache_snapshot
+
+    session._loop_driver.run_turn = _capturing_run_turn
+    return box
+
+
+@pytest.mark.asyncio
+async def test_agent_request_first_turn_primes_mcp_cache_before_first_llm_call(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: a session's FIRST turn arriving as `kind="agent_request"`
+    (the `spawn_ephemeral_session` + inbound-request shape a worker session
+    sees) has the MCP tools cache populated before `run_turn` — its first
+    LLM call — is invoked."""
+    old_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        session = _make_session(tmp_path)
+        box = _install_snapshot_capturing_run_turn(session)
+
+        assert session.router_host.mcp_tools_cache_snapshot is None, (
+            "cache must be unprimed before the first turn runs"
+        )
+
+        await session.submit_agent_request(
+            from_agent="peer", request="hello", depth=1, chain_id="chain-1",
+        )
+        await session.run_one_iteration()
+
+        assert box["snapshot"] != "UNSET", "run_turn was never invoked"
+        assert box["snapshot"] is not None, (
+            "MCP tools cache must be primed before the first LLM call of an "
+            "agent_request-kind first turn — it was never populated"
+        )
+        assert _SERVER in box["snapshot"], (
+            f"expected {_SERVER!r} in the primed cache, got {box['snapshot']!r}"
+        )
+    finally:
+        os.chdir(old_cwd)
+
+
+@pytest.mark.asyncio
+async def test_hook_first_turn_primes_mcp_cache_before_first_llm_call(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: a session's FIRST turn arriving as `kind="hook"` (an E
+    self-continuation push) also has the MCP tools cache populated before
+    `run_turn` is invoked."""
+    old_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        session = _make_session(tmp_path)
+        box = _install_snapshot_capturing_run_turn(session)
+
+        assert session.router_host.mcp_tools_cache_snapshot is None, (
+            "cache must be unprimed before the first turn runs"
+        )
+
+        await session.inbox.put((
+            "hook",
+            {"name": "session_start", "text": "wake up", "chain_id": "chain-2"},
+        ))
+        await session.run_one_iteration()
+
+        assert box["snapshot"] != "UNSET", "run_turn was never invoked"
+        assert box["snapshot"] is not None, (
+            "MCP tools cache must be primed before the first LLM call of a "
+            "hook-kind first turn — it was never populated"
+        )
+        assert _SERVER in box["snapshot"], (
+            f"expected {_SERVER!r} in the primed cache, got {box['snapshot']!r}"
+        )
+    finally:
+        os.chdir(old_cwd)


### PR DESCRIPTION
**[per-PR-coder]** — part of #3475 (投入承認 2026-07-30).

## Why

#3475 asked whether production's MCP-tools-cache priming chain
(`maybe_refresh_mcp_tools_from_yaml` → `maybe_reload_mcp_tools_cache_from_disk`
→ `ensure_mcp_tools_cached`) is await-ordered ahead of a session's first LLM
call, or merely "usually in time". Investigation found it depends on the
turn's `kind`:

- `kind="user"` (`Session._handle_user_message`): the chain was already
  correctly awaited before `_run_router_loop`.
- `kind="hook"` (`Session._handle_hook_message`) and `kind="agent_request"`
  (`InterAgentMessaging.handle_agent_request` — the shape a freshly
  `spawn_ephemeral_session`-ed worker's first inbound message takes) called
  `_run_router_loop` directly and **never ran the chain at all**.

A session whose first turn arrives as `hook` or `agent_request` therefore
built its first `tools=` payload — and thus `call_mcp_tool`/
`describe_mcp_tool`'s `mcp_tool_name` enum — against a never-primed (`None`)
cache, permanently for that session's life (`ensure_mcp_tools_cached`'s
populated-guard is one-shot). This is the argument-choice variant of the
#3464/#3465 "capability not advertised" class.

(Separately, and NOT addressed by this PR: even on the `kind="user"` path,
`ensure_mcp_tools_cached`'s fixed `per_server_timeout=5.0` can lose to a slow
MCP-server subprocess spawn under co-located CPU load, permanently caching
that server as empty — likely the proximate cause of the fp0063 3/16 flap
this arc originally observed. That is a separate, pre-existing, deliberately
documented timeout/no-retry tradeoff; changing it is a distinct design
decision left to a follow-up, not band-aided here. See the #3475 comment
for the full writeup.)

## What changed

Moved the 3-step priming chain from `Session._handle_user_message` into
`Session._run_router_loop` itself — the one seam every turn kind (`user` /
`hook` / `agent_request` / `pipeline_result`) funnels through before its
first LLM call, per that method's own docstring. The ordering guarantee is
now structural instead of kind-dependent.

## Witness

`tests/test_3475_mcp_probe_priming_all_turn_kinds.py` (Tier 2, 2 tests):
`Session._loop_driver.run_turn` is replaced with a real callable
(method-assignment, not a mock — the same seam `test_2242_hard_cancel.py`
uses) that captures `session.router_host.mcp_tools_cache_snapshot` (public
property) the instant it is invoked. A disk warm-start cache avoids needing
a real MCP subprocess. Each test drives a session's FIRST turn as
`agent_request` / `hook` and asserts the cache was already primed by the
time `run_turn` runs.

strip-falsify (cp-scratch, no `git stash`): reverting to the pre-fix code
(chain only in `_handle_user_message`) turns both tests RED (captured
snapshot is `None`). Restoring the fix turns them GREEN again.

## 4 gates

- `ruff check src tests` → all checks passed
- `python scripts/test_tier_audit.py --strict tests/test_3475_mcp_probe_priming_all_turn_kinds.py` → 2 inspected, 0 errors, 0 warnings
- `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` → OK
- `pytest -q -n auto` (full suite, rebased onto `origin/main`) → `9688 passed, 36 skipped, 1 failed in 866.27s`. The 1 failure
  (`tests/test_plugin_install.py::test_registered_command_pointing_at_missing_venv_fails_fast_no_fetch`)
  is unrelated to this PR's files (`mcp_install.py`'s venv-probe test, not
  `session.py`/`router_host_adapter.py`), passes 1/1 in isolation, and is a
  co-located-load flake of the same general class this issue is about (a
  different site/mechanism).

## Environment

- Dedicated worktree (`agent-a85aa43a1d4808cc0`), no shared-tree edits.
- Rebased cleanly onto `origin/main` (`e29b6762e`) before pushing.
- `import reyn` resolves to this checkout's `src/reyn/__init__.py` (verified).

## Test plan

- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict tests/test_3475_mcp_probe_priming_all_turn_kinds.py`
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py`
- [x] `pytest -q -n auto` (full suite; 1 unrelated flake, isolation-confirmed, documented above)
- [x] strip-falsify (cp-scratch revert → RED, restore → GREEN)
