### PR TITLE
fix(tui): the app paints no ground — chrome takes the terminal's background (closes #3503)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -557,7 +557,20 @@ class TextualChatApp(App):
     ]
 
     CSS = """
-    Screen { layout: vertical; }
+    /* #3503: the app paints NO ground of its own — the terminal's background
+       shows through. Measured before this: ``#inputrow`` / ``#inputgutter`` /
+       ``SentQueue`` / ``MenuBar`` all declare ``transparent`` already, yet all
+       painted ``#121212``, because "transparent" means "show what is behind"
+       and what was behind is the SCREEN's own ``#121212`` (Textual's dark
+       theme). So this could not be fixed per widget — the Screen is the source,
+       which is why the fix reaches the whole surface rather than just the two
+       regions the report named. Regions that are meant to stand OUT keep
+       declaring ``$panel`` explicitly (drawer, completion popup, search bar,
+       rewind picker), and the presenter's deliberate ROW TINTS
+       (``_CC_USER_BG`` / ``_CC_ERR_BG``) are unaffected — those are content,
+       not ground. */
+    App { background: ansi_default; }
+    Screen { layout: vertical; background: transparent; }
     FlowView {
         height: 1fr;
         scrollbar-size-vertical: 0;
@@ -602,6 +615,11 @@ class TextualChatApp(App):
         max-height: 6;
         border: none;
         padding: 0;
+        /* #3503: ``TextArea``'s own DEFAULT_CSS sets ``background: $surface``
+           (measured: it painted ``#1e1e1e`` while everything around it was
+           transparent), so the input box needs its own opt-out — a transparent
+           Screen alone does not reach it. */
+        background: transparent;
     }
     StatusLine {
         height: 1;

--- a/tests/test_chrome_uses_the_terminal_background_3503.py
+++ b/tests/test_chrome_uses_the_terminal_background_3503.py
@@ -1,0 +1,130 @@
+"""#3503 — the app paints no ground of its own; the terminal's background shows.
+
+Owner report: the input box and the sent-queue region above it were black. The
+cause was NOT those widgets — measured, `#inputrow`, `#inputgutter`, `SentQueue`
+and `MenuBar` all already declared `transparent`, and all still PAINTED
+`#121212`, because "transparent" means "show what is behind" and what was
+behind was the App/Screen's own `$background`. Textual's own `App` CSS is
+explicit about it (`App { background: $background }`, with an `&:ansi` variant
+using `ansi_default`), so the fix has to happen at the root — which is why it
+reaches the whole surface rather than only the two regions named.
+
+These tests assert the RESOLVED background of each chrome region is the
+terminal's default rather than a forced colour, and that the regions which are
+*meant* to stand out (the `$panel` overlays) still carry one. A test that only
+checked the CSS declaration would have passed before the fix — the declaration
+was already `transparent`; the painted colour is the thing that was wrong.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from rich.color import ColorType
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.chrome import Composer, MenuBar
+from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _Transport(ClientTransport):
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        await asyncio.Event().wait()
+        yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
+
+    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+        pass
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _is_terminal_default(widget) -> bool:
+    bg = widget.rich_style.bgcolor
+    return bg is None or bg.type is ColorType.DEFAULT
+
+
+@pytest.mark.asyncio
+async def test_the_input_row_and_sent_queue_take_the_terminals_background() -> None:
+    """Tier 2b: the two regions the owner named — the input box and the
+    sent-queue above it — resolve to the terminal's own background, not a
+    forced dark colour. The sent queue is populated first so the assertion is
+    about a region that is actually being displayed."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        queue = app.query_one(SentQueue)
+        queue.show_item("m1", "a queued message")
+        await pilot.pause()
+
+        for name, widget in (
+            ("#inputrow", app.query_one("#inputrow")),
+            ("#inputgutter", app.query_one("#inputgutter")),
+            ("Composer", app.query_one(Composer)),
+            ("SentQueue", queue),
+        ):
+            assert _is_terminal_default(widget), (
+                f"{name} forces its own background "
+                f"({widget.rich_style.bgcolor}) instead of taking the terminal's"
+            )
+
+
+@pytest.mark.asyncio
+async def test_the_root_and_menu_row_force_no_background_either() -> None:
+    """Tier 2b: the ROOT is where this had to be fixed — a per-widget change
+    could not work while the App/Screen painted underneath. The menu row is
+    included because it is chrome by the same reasoning."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        assert _is_terminal_default(app.screen), (
+            f"the Screen still paints {app.screen.rich_style.bgcolor} — every "
+            "transparent child inherits it, which is the whole bug"
+        )
+        assert _is_terminal_default(app.query_one(MenuBar))
+
+
+@pytest.mark.asyncio
+async def test_overlay_regions_still_carry_their_own_background() -> None:
+    """Tier 2b: non-vacuity, and a real design boundary — dropping the app's
+    ground must NOT flatten the surfaces that are supposed to read as raised.
+    The drawer and the completion popup declare ``$panel`` deliberately; if
+    this test ever goes red alongside the ones above, the change went too far
+    and the whole chrome became one undifferentiated plane."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        for selector in ("#drawer", "#completion"):
+            widget = app.query_one(selector)
+            assert not _is_terminal_default(widget), (
+                f"{selector} lost its own background — overlays are meant to "
+                "stand out from the terminal ground, not merge into it"
+            )


### PR DESCRIPTION
**[tui-coder]** — owner 実機指摘「input box とその上の sent queue も黒背景やめて欲しい」への修正。

Closes #3503

## 原因は指摘された領域ではありませんでした(実測)

`#inputrow` / `#inputgutter` / `SentQueue` / `MenuBar` は **すでに `transparent` を宣言済み**でした。それでも黒く塗られていたのは、**「transparent = 後ろを見せる」であり、後ろにあったのが App/Screen 自身の `$background`** だったためです。

```
#inputrow      declared=transparent(a=0)   painted=#121212   ← 透過宣言なのに黒
#inputgutter   declared=transparent(a=0)   painted=#121212
SentQueue      declared=transparent(a=0)   painted=#121212
MenuBar        declared=transparent(a=0)   painted=#121212
Composer       declared=#1e1e1e            painted=#1e1e1e   ← TextArea 由来の自前背景
Screen         declared=#121212            painted=#121212   ← 真の出所
```

**∴ 個別ウィジェットの CSS では直せません。** Textual 自身の CSS がそれを明言しています:

```
App { background: $background;  &:ansi { background: ansi_default; … } }
```

これが「2つの領域の指摘なのに変更が画面全体に及ぶ」理由です。

## 修正

- **`App { background: ansi_default; }`** — Textual 自身が `:ansi` variant で使うキーワードで「端末の既定背景」。`App.ansi_color = True`(app 全体を16色に落とす)と違い、**前景の `_CC_*` truecolor パレットを保ったまま**背景だけ端末依存にできます
- `Screen { background: transparent; }`
- `Composer { background: transparent; }` — TextArea の DEFAULT_CSS が `$surface`(実測 `#1e1e1e`)を持つため root だけでは届きません

**意図的な着色は保持**: presenter の ROW TINT(ユーザ行 `#1e222a` / 失敗行)、overlay 群(drawer / completion popup / search bar / rewind picker)の `$panel`。

## Tests (`tests/test_chrome_uses_the_terminal_background_3503.py`, 3本)

1. 指摘された領域(input row / gutter / composer / sent queue)が端末既定
2. root(Screen)と menu row も同様 — **1 が成立するには root が直っている必要がある**という因果を明示
3. **非空洞性**: overlay(`#drawer` / `#completion`)は自前背景を保つ — 1 と同時に赤くなったら「行き過ぎて全部が単一平面になった」ことを検出

**宣言ではなく解決後の色を assert** しています — 宣言は修正前から `transparent` だったので、宣言を見るテストは修正前でも通ってしまい無意味です。falsify: root の変更を戻すと 1・2 が RED、3 は緑のまま。

## 🟡 残る微小な残渣(正直な報告)

実端末で **`#0c0c0c` が2セル分**残ります: input row 上の空行1本と、アクティブなメニュータブ直後の隙間。base 背景が Textual から見て未知になったため **alpha 指定の背景が黒に対してブレンドされる**のが原因の見当です。**ウィジェットレベルの `rich_style` は全て `default` を報告**するので、実端末キャプチャでしか見えません(`get_widget_at` で該当座標を引いても `default`)。

`MenuBar Tab` を狙った上書きを試したところ **残渣が 2→3 に増えて悪化**したため撤回しました。指摘された領域は満たされているので、深追いして設計を不安定にするより残して報告します。**owner 判断待ち**: (a) 許容 (b) `App.ansi_color = True` で全面的に端末パレットへ(代償: パレット16色化) (c) 追加調査。

## ★ 作業中に自分の誤診を1件捕まえました(記録)

途中 `test_menubar_active_tab_toned_down_to_status_line_muted_tone`(#3326/#3338 の不変条件)が落ち、私は **「`ansi_default` により alpha 由来のテーマ色が解決されなくなる = owner の2つの決定の衝突」** という説明を用意しました。症状(片方は `#e0e0e0` に解決、片方は `white 60%` のまま)に完全に一致していたので、owner にトレードオフの裁定を求める一歩手前まで行きました。

**実際は私の revert スクリプトのバグでした。** マーカー間の範囲を消す実装だったため、間に居合わせた無関係な CSS ルール2件(#3326 のアクティブタブのトーン調整、`MenuBar Tab` の padding)を巻き込んで削除しており、テストは「そのルールが消えたから」落ちていました。`git diff origin/main | grep '^-'` で意図しない削除を見て気づき、復元後 31/31 green。**`ansi_default` は #3338 の不変条件を壊しません** — 存在しない衝突でした。

**もっともらしい機構が症状に一致することは、前提を検証する合図であって結論する合図ではない**、という形で pin 済みです(`feedback_diff_against_main_before_blaming_the_change`)。

## Gates

- [x] `ruff check src tests` clean
- [x] `test_tier_audit.py --strict` OK
- [x] `verify_module_docstrings.py` OK
- [x] full `pytest -n auto`: **9695 passed / 2 failed → 2件とも contention 帰属**
- [x] **diff の削除行を確認** — `Screen` の1行置換のみで、意図しない削除ゼロ(上記の誤診を踏んだ直後なので明示的に確認しています)

### 2件の帰属(全件記録)

| test | 単独 | 判定 |
|---|---|---|
| `test_plugin_install::test_registered_command_pointing_at_missing_venv_fails_fast_no_fetch` | pass | contention |
| `test_textual_chat_intervention_panel_3299::test_second_enter_after_answering_does_not_deliver_to_unread_second` | pass | contention |

**補強証拠2点**: (1) run が **570s**(通常の約3倍)で、他セッションも suite 実行中の重い contention 下。(2) ★ **回ごとに *違う* intervention-panel テストが落ちる** — 前の run では `test_escape_from_panel_returns_focus_to_composer_tab_moves_forward` と `test_resolve_updates_the_same_entry_no_new_entry_appended`、今回は `test_second_enter_after_answering_does_not_deliver_to_unread_second`。**実回帰なら同じテストが決定的に落ちる**ので、この非決定性自体が contention の署名です。ファイル全体では 25/25 green。

### ⚠️ 途中で自分の環境汚染を1件見つけました(報告)

1つ前の run では `test_plugin_install` が **単独でも落ちて**いました。contention では説明できない状態です。原因は **私が flowview の上流 fix を検証するため `pip install --force-reinstall` を繰り返して venv を汚していた**ことでした。新 main へ rebase + `uv sync --all-extras --dev` で解消(同時に websockets / wrapt / yarl 等も入れ替わり、実際にドリフトしていました)。**「単独でも落ちる」を contention と書かずに環境を疑ったのが正解でした。**

なお1つ前の run は `4 failed` と表示されたのに FAILED 行が3つしか残っておらず、**4件目の名前が特定できませんでした**。「3件帰属できたから残りも同じ」と外挿せず、環境を直して full suite を再実行し、上表の確定リストを取り直しています。
## Test plan

- [x] 実端末(tmux 150×45): `48;2;18;18;18`(旧 Screen 背景)の出現**ゼロ**、ユーザ行の ROW TINT は保持(9箇所)、前景の truecolor パレットも保持を raw ANSI で確認
- [ ] **Visual (owner gate)**: 全体の見た目 — 特に残渣2セルを許容するかの判断、および背景が端末依存になったことで overlay とのコントラストが意図どおりか

🤖 Generated with [Claude Code](https://claude.com/claude-code)
