### PR TITLE
docs(tui): fix stale flowview API citation (move_cursor -> move_highlight)

### DIFF
--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -936,12 +936,13 @@ directly and does not depend on the cursor at all.
 | `r` | Open `/rewind` |
 | `Esc` | Back to the composer |
 
-Arriving at the pane arms the cursor on the **newest** entry rather than
-leaving it invisible until the first arrow press: flowview's `move_cursor`
-starts from "no cursor" and only lands on an entry once a direction key moves
-it, which is a real gap for a feature whose whole point is a visible position
-indicator. A remembered position is kept across visits — leaving and
-re-entering resumes where you were.
+Arriving at the pane arms the highlight on the **newest** entry rather than
+leaving it invisible until the first arrow press: flowview's `move_highlight`
+starts from `highlighted=None` and only lands on an entry once a direction key
+moves it (`Textual`'s own, unrelated `TextArea.move_cursor` is a same-named
+different API and not this one), which is a real gap for a feature whose whole
+point is a visible position indicator. A remembered position is kept across
+visits — leaving and re-entering resumes where you were.
 
 **Copy** (`FlowView.Activated`) is a direct, ring-free path: `/copy N`
 addresses one of the last `COPY_BUFFER_MAX` **agent replies** by ordinal,


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary
`docs/reference/runtime/agui-transport.md`'s "Textual TUI keyboard cursor" section cited flowview's `move_cursor` for the arm-on-focus-gain mechanism. No such method exists in flowview — confirmed via `.venv/lib/python3.12/site-packages/textual_flowview/_view.py:727`, the real method is `move_highlight`. `move_cursor` is Textual's own unrelated `TextArea` API (`composer.move_cursor`, `app.py:2655`), which is exactly the same-name collision #3506's commit message warns about for the rest of the 0.7.0 highlight-rename sweep — this one sentence predates #3506 (from #3492) and was missed by it.

## Verification
- `move_highlight` confirmed to exist in the installed flowview 0.8.0 package; `move_cursor` does not.
- `mkdocs build --strict` — exit 0, no new warnings on this file.
- `ruff check` — clean.

## Test plan
- [x] `ruff check docs/reference/runtime/agui-transport.md` — clean
- [x] `mkdocs build --strict --config-file .mkdocs/mkdocs.yml` — exit 0