### PR TITLE
test(tui): close the copy-mode motion gate across every surface; exit by real key

### DIFF
--- a/tests/test_copy_mode_3507.py
+++ b/tests/test_copy_mode_3507.py
@@ -140,22 +140,105 @@ async def test_copy_mode_leaves_the_addressed_row_rail_alone() -> None:
         )
 
 
-@pytest.mark.asyncio
-async def test_reyn_declares_no_copy_mode_motion_bindings() -> None:
-    """Tier 2: reyn adds NO motion binding of its own — the keymap inside copy
-    mode is flowview's (owner direction). A binding added here later would
-    silently shadow an upstream key and drift from it, so the absence is the
-    thing worth asserting; ``c`` (entry) is reyn's one and only addition."""
-    keys = {
-        (b[0] if isinstance(b, tuple) else b.key) for b in TextualChatApp.BINDINGS
-    }
+def _binding_surfaces() -> "dict[str, list[str]]":
+    """Every class in the package that declares ``BINDINGS``, and the keys it
+    claims — DERIVED from the source tree, not hand-listed.
+
+    A hand-written list would reproduce, one level up, the very defect this
+    gate exists to catch: the previous version read one of the four surfaces
+    while claiming to cover reyn's keymap, and "there are only four today" is
+    exactly as weak as "only the app declares bindings today". The derivation
+    walks the AST for ``BINDINGS`` assigned in a ``ClassDef`` body, so a new
+    surface is covered the day it is written.
+
+    Keys are read in all THREE shapes Textual accepts in a BINDINGS list: a
+    bare string, a tuple whose first element is the key, and ``Binding(key,
+    ...)``. Missing a shape would make a real binding invisible here, which in
+    a gate that asserts an ABSENCE is indistinguishable from compliance.
+
+    Deliberately NOT ``Widget.__subclasses__()``: that only sees classes some
+    import has already executed, so a surface nobody imported would silently
+    read as "no violations" — the worst direction for this particular check.
+    """
+    import ast
+    import pathlib
+
+    package = pathlib.Path(__file__).resolve().parents[1] / (
+        "src/reyn/interfaces/inline/textual_chat"
+    )
+    surfaces: dict[str, list[str]] = {}
+    for path in sorted(package.glob("*.py")):
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            for stmt in node.body:
+                if isinstance(stmt, ast.Assign):
+                    targets = stmt.targets
+                elif isinstance(stmt, ast.AnnAssign):
+                    targets = [stmt.target]
+                else:
+                    continue
+                if not any(
+                    isinstance(t, ast.Name) and t.id == "BINDINGS" for t in targets
+                ):
+                    continue
+                keys: list[str] = []
+                for element in getattr(stmt.value, "elts", []):
+                    if isinstance(element, ast.Constant) and isinstance(
+                        element.value, str
+                    ):
+                        keys.append(element.value)
+                    elif isinstance(element, ast.Tuple) and element.elts:
+                        first = element.elts[0]
+                        if isinstance(first, ast.Constant) and isinstance(
+                            first.value, str
+                        ):
+                            keys.append(first.value)
+                    elif isinstance(element, ast.Call) and element.args:
+                        first = element.args[0]
+                        if isinstance(first, ast.Constant) and isinstance(
+                            first.value, str
+                        ):
+                            keys.append(first.value)
+                surfaces[node.name] = keys
+    return surfaces
+
+
+def test_no_reyn_surface_declares_a_copy_mode_motion_key() -> None:
+    """Tier 2: NO reyn binding surface claims a copy-mode motion key — the
+    keymap inside copy mode is flowview's (owner direction).
+
+    The surfaces are DERIVED from the tree (see :func:`_binding_surfaces`), so
+    this covers a binding surface added tomorrow. An earlier version read only
+    ``TextualChatApp.BINDINGS`` and claimed to cover reyn's keymap; the fix for
+    that must not be a hand-written list of the four that exist today, which
+    would be the same defect one level up.
+
+    ``c`` (entry into copy mode) is reyn's one and only addition."""
+    surfaces = _binding_surfaces()
+
+    # Non-vacuity: a derivation that found nothing would pass this gate while
+    # checking nothing at all.
+    assert surfaces, "no BINDINGS surface was derived — the walk is broken"
+    assert "TextualChatApp" in surfaces, (
+        f"the app's own bindings were not derived; found {sorted(surfaces)}"
+    )
+
     motions = {"h", "j", "k", "l", "w", "b", "e", "0", "$", "^", "g", "v", "V", "y",
                "n", "N", "*", "[", "]", "z"}
-    assert not (keys & motions), (
-        f"reyn declared copy-mode motion keys of its own: {sorted(keys & motions)} — "
-        "the motions belong to flowview's defaults"
+    offenders = {
+        name: sorted(set(keys) & motions)
+        for name, keys in surfaces.items()
+        if set(keys) & motions
+    }
+    assert not offenders, (
+        f"reyn surfaces declared copy-mode motion keys: {offenders} — the "
+        "motions belong to flowview's defaults and a reyn binding would shadow "
+        "them"
     )
-    assert "c" in keys, "the copy-mode entry key is missing from the app bindings"
+    assert "c" in surfaces["TextualChatApp"], (
+        "the copy-mode entry key is missing from the app bindings"
+    )
 
 
 @pytest.mark.asyncio
@@ -229,10 +312,25 @@ async def test_the_chrome_sees_both_copy_mode_edges() -> None:
             f"entering copy mode told the user nothing; pane holds: {texts!r}"
         )
 
-        flow.exit_copy_mode()
+        # Exit with the REAL key, not the public method: ``Esc`` means something
+        # in reyn too (leave the pane, close the drawer), so which side wins is
+        # itself worth pinning — a method call would pass even if the key never
+        # reached flowview.
+        await pilot.press("escape")
         await pilot.pause()
-        assert not flow.copy_mode, "setup: copy mode did not exit"
+        assert not flow.copy_mode, "a real Esc did not leave copy mode"
         texts = [e.item.text for e in app.conversation]
         assert any("copy mode off" in t for t in texts), (
             f"the exit edge was not observed; pane holds: {texts!r}"
+        )
+        assert app.focused is flow, (
+            "the first Esc left the PANE as well as copy mode — leaving a mode "
+            "and leaving the pane are two steps, not one"
+        )
+
+        # ...and the SECOND Esc is reyn's own: back to the composer.
+        await pilot.press("escape")
+        await pilot.pause()
+        assert isinstance(app.focused, Composer), (
+            f"the second Esc did not return to the composer: {app.focused!r}"
         )


### PR DESCRIPTION
**[tui-coder]** — #3506 レビューで挙がった残渣2件。**マージ阻害ではない**とのことでしたので、3段スタックが解けた今まとめて出します。

part of #3507

## ① motion gate を全 `BINDINGS` 面へ

「reyn は copy mode の motion キーを1つも宣言していない」という gate が、**4つある binding 宣言面のうち `TextualChatApp.BINDINGS` の1面しか見ていません**でした。

実測では兄弟3面は navigation キーのみ(`SentQueue`: up/down/enter/escape、`InterventionPanel`: escape/left/right、`RewindPicker`: escape)なので**今日は真**ですが、**誰かが兄弟面に printable キーを足した瞬間に嘘になります**。4面すべてを検査し、違反した面の名前を出す形にしました。

★ **falsify を2つの異なる兄弟面で実施**: `SentQueue` に `j`、`RewindPicker` に `y` を足すとそれぞれ RED。**閉じたのは instance ではなく class** です。

## ② `Esc` を実キーに + 段階の pin

exit テストが `exit_copy_mode()` を直接呼んでおり、**キーが flowview に届いたかを検証できていません**でした。`Esc` は reyn 側にも意味がある(ペインを出る / drawer を閉じる)ので、まさに「どちらが勝つか」が問題になるキーです。

実キーで駆動したところ、**メソッド呼び出しでは原理的に出ない挙動**が見えました:

- **1回目の `Esc`** — copy mode を抜け、**フォーカスはペインに残る**
- **2回目の `Esc`** — composer へ戻る

**モードを出ることとペインを出ることは2段階**でした。両方を pin しています — 片側の binding priority が変われば静かに1段階に潰れる面なので。

## Gates

- [x] `ruff check src tests` clean
- [x] `test_tier_audit.py --strict` OK
- [x] full `pytest -n auto`: **9708 passed / 37 skipped / 0 failed**(帰属すべき失敗ゼロ)

## 触っていないもの(明示)

- ★ **`test_a_forced_concrete_background_is_still_detected_as_non_default`**(#3510 が入れた theme 非依存の positive control)は**無傷**です。同ファイルは触っていません
- ★ **`$panel` の扱い**は owner 判断待ちなので、具体色を先回りで置いていません

## Test plan

- [x] falsify: 兄弟2面それぞれで motion キー追加 → RED、除去 → GREEN
- [x] `Esc` の2段階挙動を実キーで測定し、その通りに pin
- [x] main 追随後に **flowview のバージョンを直接読んで** 0.8.0 を確認(`uv sync` が何も入れ替えなかったことを最新の証拠として使わない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
