### PR TITLE
fix(runtime): derive RouterHostAdapter's bundling predicate from measurement — #3482

### DIFF
--- a/docs/reference/runtime/session-construction.md
+++ b/docs/reference/runtime/session-construction.md
@@ -359,31 +359,45 @@ so it is called out here for future edits of that closure.
 `_build_router_waist` aggregates ~40 already-constructed Session sub-components (Families
 1-5's outputs + params/early attrs set earlier in `__init__`) into `RouterHostAdapter`, the
 single object most later families read through — a byte-identical extraction (same object,
-same construction order, same ~40 args, including 3 DEFERRED per-turn lambdas —
-`live_session_id_fn`/`current_task_id_fn`/`turn_origin_fn` — kept verbatim, still closing
-over `self` and resolved at call time, not eager-ized). It stays UNMOVED, invoked at its
-original position — every dependency is already set on `self` by this point.
+same construction order, same values, including 2 DEFERRED per-turn lambdas —
+`live_session_id_inputs.live_session_id_fn`/`op_context_inputs.turn_origin_fn` — kept
+verbatim, still closing over `self` and resolved at call time, not eager-ized). It stays
+UNMOVED, invoked at its original position — every dependency is already set on `self` by
+this point.
 
-**#3482 param bundling**: `RouterHostAdapter.__init__` groups two real
-consumer-set clusters (measured by AST, not by name prefix) into frozen,
-default-free dataclasses built just before the constructor call: the
-16-field `RouterOpContextInputs` (every field's sole reader is
-`RouterHostAdapter.make_router_op_context` — includes `turn_origin_fn` from
-the paragraph above, plus `allowed_mcp`/`budget_gateway`/`compact_now`/
-`contextual_permission`/`hook_bus`/`hook_dispatcher`/`hot_reloader`/
-`multimodal_config`/`presentation_renderer_factory`/`render_template_bounds`/
-`sandbox_backend_instance`/`sandbox_policy`/`workspace_base_dir`/
-`workspace_state_dir`/`base_available_skills_fn`) and the 3-field
-`McpGatewayInputs` (`mcp_connection_service`/`mcp_agent_id`/`ephemeral_fn` —
-#3447's Path A fold, sole reader `_mcp_list_via_gateway`). Session still
-builds each field with the exact same expression as before (same object,
-same order, same call-time semantics — `turn_origin_fn`/`ephemeral_fn` are
-still live per-turn lambdas, not eager-ized); only the wire shape changed,
-from ~19 flat kwargs to 2 bundle kwargs. The remaining ~58 params stay bare
-scalars, each with a reason recorded in
-`ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS` (`router_host_adapter.py`) — bundle
-coverage is deliberately not 100% (forcing it would be a name-prefix
-grouping pressure, not a consumer-set one).
+**#3482 param bundling**: `RouterHostAdapter.__init__` groups every real
+consumer-set cluster (measured by AST, not by name prefix) into frozen,
+default-free dataclasses built just before the constructor call — five of
+them, each named after the sole consumer the measurement found:
+
+| bundle | fields | sole consumer |
+| --- | --- | --- |
+| `RouterOpContextInputs` | 16: `allowed_mcp`/`base_available_skills_fn`/`budget_gateway`/`compact_now`/`contextual_permission`/`hook_bus`/`hook_dispatcher`/`hot_reloader`/`multimodal_config`/`presentation_renderer_factory`/`render_template_bounds`/`sandbox_backend_instance`/`sandbox_policy`/`turn_origin_fn`/`workspace_base_dir`/`workspace_state_dir` | `make_router_op_context` |
+| `McpGatewayInputs` | `mcp_connection_service`/`mcp_agent_id`/`ephemeral_fn` (#3447's Path A fold) | `_mcp_list_via_gateway` |
+| `SendToAgentInputs` | `send_to_agent`/`delegation_tracker` | the `send_to_agent` method |
+| `PutOutboxInputs` | `put_outbox`/`agent_replies_tracker` | the `put_outbox` method |
+| `LiveSessionIdInputs` | `session_id`/`live_session_id_fn` | the `live_session_id` property |
+
+Session still builds each field with the exact same expression as before
+(same object, same order, same call-time semantics — `turn_origin_fn` /
+`ephemeral_fn` / `live_session_id_fn` and the two tracker lambdas are still
+live per-turn callables, not eager-ized); only the wire shape changed.
+
+The remaining bare params are bare because **no other param travels to the
+same set of destinations** — and that is not recorded anywhere as prose. It is
+COMPUTED, by `scripts/measure_router_host_adapter_consumers.py` (exact
+consumer-set equality; a member that reads an already-bundled attribute is a
+landed bundle's hub and is not counted twice), and enforced by
+`tests/test_router_host_adapter_param_gate_3482.py`, which goes RED when a
+bare param acquires an exact-match partner, when a param loses its last
+measurable consumer without being shelved in
+`ROUTER_HOST_ADAPTER_CONSUMER_UNMEASURED`, or when a written claim in either
+registry contradicts the measurement. Bundle coverage is deliberately not
+100% — forcing it would be name-prefix grouping pressure, not a consumer-set
+one. The earlier `ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS` registry of 58
+per-param prose reasons is gone: 6 of its "no shared-consumer partner" claims
+were measurably false (they are the three bundles at the bottom of the table
+above), because that gate only ever checked a reason was non-empty.
 
 ### Chat turn_budget engine — None on small context, never raise (#1092 PR-F1)
 

--- a/docs/reference/runtime/session-construction.md
+++ b/docs/reference/runtime/session-construction.md
@@ -394,10 +394,10 @@ measurable consumer without being shelved in
 `ROUTER_HOST_ADAPTER_CONSUMER_UNMEASURED`, or when a written claim in either
 registry contradicts the measurement. Bundle coverage is deliberately not
 100% — forcing it would be name-prefix grouping pressure, not a consumer-set
-one. The earlier `ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS` registry of 58
-per-param prose reasons is gone: 6 of its "no shared-consumer partner" claims
-were measurably false (they are the three bundles at the bottom of the table
-above), because that gate only ever checked a reason was non-empty.
+one. Do not re-record the predicate as a per-param prose reason: a gate can
+only check that prose is non-empty, never that it is true — when this was
+tried, six such reasons were false, and they are the three bundles at the
+bottom of the table above.
 
 ### Chat turn_budget engine — None on small context, never raise (#1092 PR-F1)
 

--- a/scripts/measure_router_host_adapter_consumers.py
+++ b/scripts/measure_router_host_adapter_consumers.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Measure, per ``RouterHostAdapter.__init__`` param, WHERE its value is read.
+
+The output is the SSoT for one predicate: *does this constructor param share
+an exact consumer set with another param* (= is it half of a real bundle)?
+``tests/test_router_host_adapter_param_gate_3482.py`` imports this module and
+DERIVES that predicate instead of trusting prose — the #3482 defect was a
+registry of 58 hand-written "no shared-consumer partner" reasons whose truth
+nothing checked, and 6 of which were measurably false.
+
+Altitude (the part that got #3482 wrong the first time)
+-------------------------------------------------------
+Measuring "who reads this param" *inside* the adapter answers the wrong
+question: the adapter is a RELAY, so nearly every param resolves to its own
+same-named forwarding method by construction, and one gets N singletons for N
+params no matter how the wiring is actually shaped. A param's consumer is
+therefore the DESTINATION its value is carried to, measured as:
+
+  consumers(p) = { "adapter.<m>" for each adapter member m reading p's stored
+                   attribute }
+               ∪ { "<module>::<func>" for each site OUTSIDE the adapter that
+                   reads p's stored attribute, or reads/calls one of those
+                   members, off a host/adapter-named expression }
+
+Both halves matter. Without the adapter members, ``append_history`` (carried
+to two members) looks identical to ``put_outbox`` (carried to one). Without
+the external sites, params with no in-class reader (``journal``,
+``output_language``) look dead.
+
+Discriminator: EXACT SET EQUALITY, never overlap
+------------------------------------------------
+Overlap is not usable: on the measured tree 80 param pairs overlap, and
+overlap is not transitive (A∩B≠∅ ∧ B∩C≠∅ with A∩C=∅), so it cannot define a
+bundle boundary — its transitive closure melts into one 28-param blob. Exact
+equality is what "carried together to the same place" means.
+
+Already-bundled consumers are not counted twice
+-----------------------------------------------
+A member that reads fields off an ALREADY-bundled attribute (e.g.
+``make_router_op_context`` reading ``self._op_ctx.<field>``) is a consumer
+whose cluster has already been landed as a bundle. Left in, such a hub
+manufactures equality between params that in fact travel to different
+dedicated accessors (6 params on the measured tree). It is excluded from the
+consumer set — the param itself is NOT excluded, only that one destination,
+per the #3482 firm's "exclude the hub by role, not by threshold; ``run`` /
+``run_loop`` are not hubs" rule. The hub set is DERIVED from the bundle-typed
+attributes, so a newly landed bundle updates it with no edit here.
+
+stdlib-only (``ast``/``pathlib``), no ``reyn`` import: both registries and the
+signature are AST-derived from the file on disk, so a hand-maintained list can
+never drift from what is measured.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+ADAPTER_RELPATH = Path("src") / "reyn" / "runtime" / "services" / "router_host_adapter.py"
+ADAPTER_CLASS = "RouterHostAdapter"
+SCAN_ROOT_RELPATH = Path("src") / "reyn"
+
+# An attribute access is treated as an external read of the adapter's surface
+# when its base expression names a host/adapter — `host.x`, `self._router_host.x`,
+# `router_host.x`, `adapter.x`. Deliberately conservative: a false NEGATIVE here
+# shows up as "consumer unmeasured" (a shelf entry a human must justify), while a
+# broader match would invent consumers and manufacture clusters.
+_HOST_BASE_SUFFIXES = ("host", "adapter")
+
+
+@dataclass(frozen=True)
+class ParamMeasurement:
+    """One ``__init__`` param and the destinations its value reaches."""
+
+    name: str
+    annotation: str | None
+    bundle_type: str | None
+    stored_attrs: tuple[str, ...]
+    adapter_members: tuple[str, ...]
+    external_sites: tuple[str, ...]
+
+    @property
+    def is_bundled(self) -> bool:
+        return self.bundle_type is not None
+
+    @property
+    def consumers(self) -> frozenset[str]:
+        return frozenset(
+            [f"adapter.{m}" for m in self.adapter_members] + list(self.external_sites)
+        )
+
+
+@dataclass(frozen=True)
+class Measurement:
+    """The whole signature, measured."""
+
+    params: tuple[ParamMeasurement, ...]
+    bundle_types: tuple[str, ...]
+    bundled_consumers: tuple[str, ...]
+    unmeasured_registry: dict[str, str]
+    blocked_registry: dict[str, str]
+
+    def by_name(self) -> dict[str, ParamMeasurement]:
+        return {p.name: p for p in self.params}
+
+    @property
+    def bare_params(self) -> tuple[ParamMeasurement, ...]:
+        return tuple(p for p in self.params if not p.is_bundled)
+
+    def partners_of(self, name: str) -> tuple[str, ...]:
+        """Bare params whose consumer set is EXACTLY equal to ``name``'s.
+
+        Empty for a param with no measurable consumer — "no partner" and "not
+        measurable" are different shelves and must not be conflated.
+        """
+        mine = self.by_name()[name].consumers
+        if not mine:
+            return ()
+        return tuple(
+            sorted(p.name for p in self.bare_params if p.name != name and p.consumers == mine)
+        )
+
+    def exact_match_clusters(self) -> tuple[tuple[str, ...], ...]:
+        groups: dict[frozenset[str], list[str]] = defaultdict(list)
+        for p in self.bare_params:
+            if p.consumers:
+                groups[p.consumers].append(p.name)
+        return tuple(
+            sorted(
+                (tuple(sorted(names)) for names in groups.values() if len(names) > 1),
+                key=lambda names: (-len(names), names),
+            )
+        )
+
+    def unmeasured_params(self) -> tuple[str, ...]:
+        return tuple(sorted(p.name for p in self.bare_params if not p.consumers))
+
+
+def _init_node(tree: ast.Module) -> ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == ADAPTER_CLASS:
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == "__init__":
+                    return item
+    raise RuntimeError(f"{ADAPTER_CLASS}.__init__ not found by AST")
+
+
+def _class_node(tree: ast.Module) -> ast.ClassDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == ADAPTER_CLASS:
+            return node
+    raise RuntimeError(f"class {ADAPTER_CLASS} not found by AST")
+
+
+def _module_level_dict(tree: ast.Module, name: str) -> dict[str, str]:
+    """Read a module-level ``name: ... = {"k": "v"}`` literal by AST."""
+    for node in tree.body:
+        targets = list(getattr(node, "targets", []))
+        target = getattr(node, "target", None)
+        if target is not None:
+            targets.append(target)
+        if not any(isinstance(t, ast.Name) and t.id == name for t in targets):
+            continue
+        value = getattr(node, "value", None)
+        if not isinstance(value, ast.Dict):
+            raise RuntimeError(f"{name} is not a dict literal — AST derivation broke")
+        out: dict[str, str] = {}
+        for k, v in zip(value.keys, value.values):
+            if not isinstance(k, ast.Constant):
+                raise RuntimeError(f"{name} has a non-literal key — AST derivation broke")
+            try:
+                out[str(k.value)] = str(ast.literal_eval(v))
+            except ValueError:
+                # A shared reason constant referenced by Name: keep the source
+                # text so a claim check still has something to read.
+                out[str(k.value)] = ast.unparse(v)
+        return out
+    return {}
+
+
+def _module_level_str_tuple(tree: ast.Module, name: str) -> tuple[str, ...]:
+    for node in tree.body:
+        targets = list(getattr(node, "targets", []))
+        target = getattr(node, "target", None)
+        if target is not None:
+            targets.append(target)
+        if not any(isinstance(t, ast.Name) and t.id == name for t in targets):
+            continue
+        value = getattr(node, "value", None)
+        if not isinstance(value, (ast.Tuple, ast.List)):
+            raise RuntimeError(f"{name} is not a tuple/list literal — AST derivation broke")
+        return tuple(str(ast.literal_eval(e)) for e in value.elts)
+    return ()
+
+
+def _stored_attrs(init: ast.FunctionDef, param_names: set[str]) -> dict[str, set[str]]:
+    """param -> the ``self.<attr>`` names its value is stored on.
+
+    Any ``Name`` appearing in the assigned expression counts, so wrapped forms
+    (``Path(state_dir) if state_dir is not None else _DEFAULT``) are covered.
+    """
+    out: dict[str, set[str]] = defaultdict(set)
+    for node in ast.walk(init):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)) or node.value is None:
+            continue
+        targets = list(node.targets) if isinstance(node, ast.Assign) else [node.target]
+        names = {n.id for n in ast.walk(node.value) if isinstance(n, ast.Name)}
+        for t in targets:
+            if isinstance(t, ast.Attribute) and isinstance(t.value, ast.Name) and t.value.id == "self":
+                for p in names & param_names:
+                    out[p].add(t.attr)
+    return out
+
+
+def _member_attr_reads(cls: ast.ClassDef) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    """(attr -> members reading it, member -> attrs it reads), ``__init__`` aside."""
+    attr_readers: dict[str, set[str]] = defaultdict(set)
+    member_attrs: dict[str, set[str]] = defaultdict(set)
+    for item in cls.body:
+        if not isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) or item.name == "__init__":
+            continue
+        for node in ast.walk(item):
+            if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+                if node.value.id == "self":
+                    attr_readers[node.attr].add(item.name)
+                    member_attrs[item.name].add(node.attr)
+    return attr_readers, member_attrs
+
+
+def _bundled_consumers(attr_readers: dict[str, set[str]], bundle_attrs: set[str]) -> set[str]:
+    """Members that read an already-bundled attribute (the hubs).
+
+    Touching ``self._op_ctx`` at all makes ``make_router_op_context`` a bundled
+    consumer: its cluster is already landed, so counting it again would
+    manufacture equality between bare params that in fact travel to different
+    dedicated accessors. Keyed on the ATTRIBUTE, not on ``self._op_ctx.<field>``
+    subscripting, because a member is free to alias first
+    (``op_ctx = self._op_ctx``) — which the real code does.
+    """
+    hubs: set[str] = set()
+    for attr in bundle_attrs:
+        hubs |= attr_readers.get(attr, set())
+    return hubs
+
+
+def _external_reads(repo_root: Path, adapter_path: Path) -> dict[str, set[str]]:
+    """name -> {"<relpath>::<func>"} for reads off a host/adapter-named base."""
+    out: dict[str, set[str]] = defaultdict(set)
+    scan_root = repo_root / SCAN_ROOT_RELPATH
+    for path in sorted(scan_root.rglob("*.py")):
+        if path.resolve() == adapter_path.resolve():
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        rel = path.relative_to(scan_root).as_posix()
+        stack: list[str] = []
+
+        class _V(ast.NodeVisitor):
+            def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+                stack.append(node.name)
+                self.generic_visit(node)
+                stack.pop()
+
+            def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802
+                stack.append(node.name)
+                self.generic_visit(node)
+                stack.pop()
+
+            def visit_Attribute(self, node: ast.Attribute) -> None:  # noqa: N802
+                base = ast.unparse(node.value)
+                if any(base.endswith(suffix) for suffix in _HOST_BASE_SUFFIXES):
+                    out[node.attr].add(f"{rel}::{stack[-1] if stack else '<module>'}")
+                self.generic_visit(node)
+
+        _V().visit(tree)
+    return out
+
+
+def measure(repo_root: Path) -> Measurement:
+    """AST-measure every ``__init__`` param's consumer set (see module docstring)."""
+    adapter_path = repo_root / ADAPTER_RELPATH
+    tree = ast.parse(adapter_path.read_text(encoding="utf-8"))
+    cls = _class_node(tree)
+    init = _init_node(tree)
+
+    bundle_types = _module_level_str_tuple(tree, "ROUTER_HOST_ADAPTER_BUNDLE_TYPES")
+    unmeasured_registry = _module_level_dict(tree, "ROUTER_HOST_ADAPTER_CONSUMER_UNMEASURED")
+    blocked_registry = _module_level_dict(tree, "ROUTER_HOST_ADAPTER_BUNDLE_BLOCKED")
+
+    annotations: dict[str, str | None] = {}
+    args = init.args
+    for a in (*args.posonlyargs, *args.args, *args.kwonlyargs):
+        if a.arg == "self":
+            continue
+        annotations[a.arg] = ast.unparse(a.annotation) if a.annotation else None
+
+    def bundle_of(annotation: str | None) -> str | None:
+        for name in bundle_types:
+            if name in (annotation or ""):
+                return name
+        return None
+
+    stored = _stored_attrs(init, set(annotations))
+    attr_readers, _member_attrs = _member_attr_reads(cls)
+    bundle_attrs = {
+        attr
+        for name, annotation in annotations.items()
+        if bundle_of(annotation)
+        for attr in stored.get(name, set())
+    }
+    hubs = _bundled_consumers(attr_readers, bundle_attrs)
+    external = _external_reads(repo_root, adapter_path)
+
+    params: list[ParamMeasurement] = []
+    for name, annotation in annotations.items():
+        attrs = stored.get(name, set())
+        members = {m for a in attrs for m in attr_readers.get(a, set())} - hubs
+        sites: set[str] = set()
+        for a in attrs:
+            sites |= external.get(a, set())
+        for m in members:
+            sites |= external.get(m, set())
+        params.append(
+            ParamMeasurement(
+                name=name,
+                annotation=annotation,
+                bundle_type=bundle_of(annotation),
+                stored_attrs=tuple(sorted(attrs)),
+                adapter_members=tuple(sorted(members)),
+                external_sites=tuple(sorted(sites)),
+            )
+        )
+
+    return Measurement(
+        params=tuple(params),
+        bundle_types=bundle_types,
+        bundled_consumers=tuple(sorted(hubs)),
+        unmeasured_registry=unmeasured_registry,
+        blocked_registry=blocked_registry,
+    )
+
+
+def repo_root_from(start: Path) -> Path:
+    for ancestor in [start, *start.parents]:
+        if (ancestor / "pyproject.toml").is_file():
+            return ancestor
+    raise RuntimeError(f"repo root not found from {start}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo-root", type=Path, default=None)
+    ap.add_argument("--detail", action="store_true", help="print every param's destinations")
+    ns = ap.parse_args(argv)
+    root = ns.repo_root or repo_root_from(Path(__file__).resolve())
+    m = measure(root)
+
+    bundled = [p for p in m.params if p.is_bundled]
+    print(f"repo root:            {root}")
+    print(f"__init__ params:      {len(m.params)}  (bundled {len(bundled)} / bare {len(m.bare_params)})")
+    print(f"bundle types:         {list(m.bundle_types)}")
+    print(f"bundled consumers excluded from clustering: {list(m.bundled_consumers)}")
+
+    clusters = m.exact_match_clusters()
+    print(f"\nexact-match clusters: {len(clusters)} "
+          f"/ {sum(len(c) for c in clusters)} bare params")
+    for names in clusters:
+        print(f"  {list(names)}")
+        print(f"      consumers: {sorted(m.by_name()[names[0]].consumers)}")
+
+    unmeasured = m.unmeasured_params()
+    print(f"\nno measurable consumer ({len(unmeasured)}):")
+    for name in unmeasured:
+        print(f"  {name}: shelf reason = {m.unmeasured_registry.get(name, '<<MISSING>>')!r}")
+
+    if ns.detail:
+        print("\nper-param destinations:")
+        for p in sorted(m.params, key=lambda p: p.name):
+            tag = f"[{p.bundle_type}]" if p.is_bundled else ""
+            print(f"  {p.name}{tag}: attrs={list(p.stored_attrs)} "
+                  f"members={list(p.adapter_members)} external={list(p.external_sites)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/reyn/runtime/services/__init__.py
+++ b/src/reyn/runtime/services/__init__.py
@@ -12,9 +12,12 @@ from reyn.runtime.services.memory_service import MemoryService
 from reyn.runtime.services.recovery import build_recovery, default_snapshot_path
 from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
 from reyn.runtime.services.router_host_adapter import (
+    LiveSessionIdInputs,
     McpGatewayInputs,
+    PutOutboxInputs,
     RouterHostAdapter,
     RouterOpContextInputs,
+    SendToAgentInputs,
 )
 from reyn.runtime.services.router_loop_driver import RouterLoopDriver
 from reyn.runtime.services.snapshot_journal import SnapshotJournal

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -76,6 +76,55 @@ class McpGatewayInputs:
     ephemeral_fn: "Callable[[], bool] | None"
 
 
+@dataclass(frozen=True)
+class SendToAgentInputs:
+    """#3482: the two params whose consumer set is EXACTLY
+    ``{adapter.send_to_agent, router_loop::_send_to_agent_bound}`` — the peer
+    dispatch callback and the tracker its result is appended to. One dedicated
+    method reads both and nothing else does, so they travel together.
+
+    Pure value object — no defaults, no construction logic (see
+    :class:`RouterOpContextInputs`'s docstring for the rationale)."""
+
+    send_to_agent: "Callable[..., Awaitable[None]]"
+    delegation_tracker: "Callable[[], list[dict] | None]"
+
+
+@dataclass(frozen=True)
+class PutOutboxInputs:
+    """#3482: the two params whose consumer set is EXACTLY
+    ``{adapter.put_outbox, router_loop::run_loop}`` — the raw outbox put and
+    the reply tracker the same method appends the emitted text to.
+
+    ``append_history`` deliberately stays OUT: it is read by
+    ``append_history_entry`` as well, so its consumer set is strictly larger
+    and bundling it here would be a name/locality grouping, not a measured
+    one. Pure value object — no defaults, no construction logic."""
+
+    put_outbox: "Callable[..., Awaitable[None]]"
+    agent_replies_tracker: "Callable[[], list[str] | None]"
+
+
+@dataclass(frozen=True)
+class LiveSessionIdInputs:
+    """#3482: the two params whose consumer set is EXACTLY
+    ``{adapter.live_session_id}`` — the construction-time sid and the live
+    callback that supersedes it. The property picks between them, which is why
+    neither is meaningful without the other.
+
+    ``session_id`` is ALSO read by ``make_router_op_context``, but that member
+    is an already-bundled consumer (``RouterOpContextInputs``); counting a
+    landed bundle's hub a second time manufactures equality between params
+    that in fact travel to different dedicated accessors, so it is excluded
+    from consumer sets (#3482 firm: exclude the hub by ROLE, not by a
+    param-count threshold — ``run``/``run_loop`` are turn paths, not hubs).
+
+    Pure value object — no defaults, no construction logic."""
+
+    session_id: "str | None"
+    live_session_id_fn: "Callable[[], str | None] | None"
+
+
 class RouterHostAdapter:
     """Concrete RouterLoopHost implementation extracted from Session.
 
@@ -161,37 +210,45 @@ class RouterHostAdapter:
           registry / pipeline executor (spawn-time flip), mirroring
           ``live_session_id_fn``'s same staleness hazard. ``None`` (test
           construction) behaves as never-ephemeral.
-    send_to_agent:
-        Async callback ``(*, to, request, depth, chain_id) -> None``.
-    put_outbox:
-        Async callback ``(OutboxMessage) -> None`` — the raw outbox put.
+    send_to_agent_inputs:
+        :class:`SendToAgentInputs` — the peer-dispatch callback ``(*, to,
+        request, depth, chain_id) -> None`` plus the ``list[dict] | None``
+        delegation tracker it records into (#3482 bundle: exact consumer-set
+        match on ``send_to_agent``).
+    put_outbox_inputs:
+        :class:`PutOutboxInputs` — the raw ``(OutboxMessage) -> None`` put plus
+        the ``list[str] | None`` agent-replies tracker (#3482 bundle: exact
+        consumer-set match on ``put_outbox``).
+    live_session_id_inputs:
+        :class:`LiveSessionIdInputs` — the construction-time ``session_id`` and
+        the live ``() -> str | None`` callback that supersedes it (#3482
+        bundle: exact consumer-set match on the ``live_session_id`` property).
     append_history:
         Sync callback ``(ChatMessage) -> None``.
-    delegation_tracker:
-        Zero-arg callable returning the current ``list[dict] | None``.
-    agent_replies_tracker:
-        Zero-arg callable returning the current ``list[str] | None``.
     """
 
     # RouterLoopHost Protocol attributes (non-property)
     output_language: str | None
 
-    # 77 flat params is not a Parameter-Object problem in general — grouping
-    # them was measured as a near-no-op (#3121 took Session 54 -> 45 by adding
-    # 4 objects while leaving 41 flat params in place): a param-object split
-    # only pays for itself where a REAL consumer-set cluster exists, and #3482
-    # measured exactly two: the 16-param op-context cluster and the 3-param
-    # mcp-gateway cluster below (``op_context_inputs`` / ``mcp_gateway_inputs``).
-    # The remaining ~58 stay flat scalars — collapsing e.g. the 5 mcp_call/
-    # get_prompt/read_resource/subscribe/unsubscribe callbacks into one facade
-    # fails because the Session methods they reach are 27-48 lines each with
-    # their own ephemeral/pool routing and error contract, not thin delegates
-    # (#3409 has the per-method table); each is a single-consumer wiring lane
-    # with no shared-consumer partner, not a hidden cluster. See
-    # ``ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS`` (module level, below the
-    # class) for the per-lane reasons, and
-    # ``tests/test_router_host_adapter_param_gate_3482.py`` for the AST gate
-    # that keeps every param in one of {bundle type, exception registry}.
+    # A long flat kwarg list is not a Parameter-Object problem in general —
+    # grouping by shape was measured as a near-no-op (#3121 took Session 54 ->
+    # 45 by adding 4 objects while leaving 41 flat params in place): a
+    # param-object split only pays for itself where a REAL consumer-set cluster
+    # exists. #3482 bundles every cluster the measurement finds and nothing
+    # else; the bare params that remain are bare because no OTHER param is
+    # carried to exactly the same destinations.
+    #
+    # That last sentence is NOT recorded here as prose, because prose rots
+    # unchecked: the first #3482 pass wrote 58 per-param "no shared-consumer
+    # partner" reasons into a registry whose gate only verified the reasons
+    # were non-empty, and 6 of them were measurably false. The predicate is
+    # computable, so it is COMPUTED —
+    # ``scripts/measure_router_host_adapter_consumers.py`` measures each param's
+    # consumer set and ``tests/test_router_host_adapter_param_gate_3482.py``
+    # fails the moment a bare param acquires an exact-match partner (it must
+    # become a bundle) or a written claim contradicts the measurement. Only the
+    # residue a measurement CANNOT settle is written down, in
+    # ``ROUTER_HOST_ADAPTER_CONSUMER_UNMEASURED`` / ``_BUNDLE_BLOCKED`` below.
     def __init__(
         self,
         *,
@@ -211,7 +268,6 @@ class RouterHostAdapter:
         pipeline_registry: Any = None,          # PipelineRegistry | None — IS-5
         presentation_registry: Any = None,      # PresentationRegistry | None — FP-0054 PR-C
         record_spawned_task: "Callable[[str, str], None] | None" = None,  # #2103 S1bc-exec
-        live_session_id_fn: "Callable[[], str | None] | None" = None,     # #2103 S1bc-exec
         agent_workspace_dir: Path,
         # File op callbacks
         file_read: Callable[..., Awaitable[dict]],
@@ -237,13 +293,19 @@ class RouterHostAdapter:
         # see the class docstring's mcp_gateway_inputs entry. These 3 raw
         # inputs (bundled #3482) replace them.
         mcp_gateway_inputs: McpGatewayInputs,
-        # Action callbacks
-        send_to_agent: Callable[..., Awaitable[None]],
-        put_outbox: Callable[..., Awaitable[None]],
+        # Action callbacks — each bundle below is one measured consumer-set
+        # cluster (#3482); ``append_history`` stays bare because its consumer
+        # set is strictly larger than ``put_outbox``'s (append_history_entry
+        # reads it too).
+        send_to_agent_inputs: SendToAgentInputs,
+        put_outbox_inputs: PutOutboxInputs,
         append_history: Callable,
-        # Tracker getters (return mutable list or None)
-        delegation_tracker: Callable[[], "list[dict] | None"],
-        agent_replies_tracker: Callable[[], "list[str] | None"],
+        # #1953 dynamic-wire + #2103 S1bc-exec: the chat session identity
+        # (``emit_hook_event`` builds the LLM's own ``llm:<session_id>:*``
+        # namespace from it — never an op field the LLM could forge) and the
+        # live callback that supersedes it for a spawned session. Bundled
+        # #3482: the ``live_session_id`` property is the exact consumer of both.
+        live_session_id_inputs: LiveSessionIdInputs,
         # FP-0034 PR-3b-iii/iv: universal catalog wrapper visibility
         # (= reyn.yaml action_retrieval.universal_wrappers_enabled).
         # Session passes True by default since PR-3b-iv flipped the
@@ -252,10 +314,6 @@ class RouterHostAdapter:
         # adapters by hand) preserve the prior tools= shape and don't
         # accidentally activate wrappers without intent.
         universal_wrappers_enabled: bool = False,
-        # #1953 dynamic-wire: the chat session identity, threaded so
-        # ``emit_hook_event`` builds the LLM's own ``llm:<session_id>:*``
-        # namespace (never an op field the LLM could forge).
-        session_id: str | None = None,
         # FP-0034 Phase 2 step 1: ActionEmbeddingIndex + EmbeddingProvider
         # for search_actions.  When all three are set (= operator set
         # ``embedding.enabled: true`` (FP-0066 §7) AND Session built a
@@ -408,12 +466,14 @@ class RouterHostAdapter:
     ) -> None:
         self._op_ctx = op_context_inputs
         self._mcp_gateway = mcp_gateway_inputs
+        self._send_to_agent_in = send_to_agent_inputs
+        self._put_outbox_in = put_outbox_inputs
+        self._live_sid_in = live_session_id_inputs
         self._threat_scan = threat_scan
         # #2073 S3: exposed (public) so RouterLoop threads it onto the tool ctx, so a
         # self-reload tool reloads THIS session (per-session, not a process global).
         # (source: op_context_inputs.hot_reloader — #3482 bundle)
         self.hot_reloader = self._op_ctx.hot_reloader
-        self._session_id = session_id  # #1953 dynamic-wire: emit_hook_event's session-namespace key
         self._turn_budget_engine = turn_budget_engine
         self._turn_cancel_fn = turn_cancel_fn  # #1468
         self._agent_name = agent_name
@@ -455,7 +515,6 @@ class RouterHostAdapter:
         # the Session's copy) so a newly-registered template is visible next turn.
         self._presentation_registry = presentation_registry
         self._record_spawned_task = record_spawned_task   # #2103 S1bc-exec
-        self._live_session_id_fn = live_session_id_fn      # #2103 S1bc-exec
         self._workspace_dir = Path(agent_workspace_dir)
         # File callbacks
         self._file_read_cb = file_read
@@ -471,13 +530,10 @@ class RouterHostAdapter:
         # #3447/#3482: raw inputs for the 5 mcp_list_* methods this adapter
         # implements directly (folded off Session — see class docstring),
         # bundled into mcp_gateway_inputs (single reader: _mcp_list_via_gateway).
-        # Action callbacks
-        self._send_to_agent_cb = send_to_agent
-        self._put_outbox_cb = put_outbox
+        # Action callbacks — the dispatch/outbox pairs live on their #3482
+        # bundles (``self._send_to_agent_in`` / ``self._put_outbox_in``); the
+        # ``send_to_agent`` / ``put_outbox`` methods read them there.
         self._append_history_cb = append_history
-        # Tracker getters
-        self._delegation_tracker = delegation_tracker
-        self._agent_replies_tracker = agent_replies_tracker
         # FP-0034 PR-3b-iii
         self._universal_wrappers_enabled = universal_wrappers_enabled
         # B25-S5-1
@@ -679,7 +735,8 @@ class RouterHostAdapter:
         post-construction, so the live fn wins when wired). IS-2 reads this as
         the ``run_pipeline_async`` reply address; the ``spawn_session``
         result-routing path reads the same expression."""
-        return self._live_session_id_fn() if self._live_session_id_fn else self._session_id
+        live_fn = self._live_sid_in.live_session_id_fn
+        return live_fn() if live_fn else self._live_sid_in.session_id
 
     @property
     def events(self) -> Any:
@@ -1076,11 +1133,11 @@ class RouterHostAdapter:
     async def send_to_agent(self, *, to: str, request: str, depth: int,
                             chain_id: str) -> None:
         """Dispatch to peer and record delegation for pending-chain registration."""
-        await self._send_to_agent_cb(
+        await self._send_to_agent_in.send_to_agent(
             to=to, request=request, depth=depth, chain_id=chain_id,
         )
         # Track delegations so callers can register _PendingChain after the loop.
-        tracker = self._delegation_tracker()
+        tracker = self._send_to_agent_in.delegation_tracker()
         if tracker is not None:
             tracker.append({"to": to, "request": request})
 
@@ -1463,7 +1520,7 @@ class RouterHostAdapter:
             from reyn.runtime.reasoning_continuity import reasoning_text
             _reasoning_display = reasoning_text(_reasoning)
             if _reasoning_display:
-                await self._put_outbox_cb(OutboxMessage(
+                await self._put_outbox_in.put_outbox(OutboxMessage(
                     kind="reasoning",
                     text=_reasoning_display,
                     meta={"chain_id": meta.get("chain_id"), "reasoning": _reasoning},
@@ -1472,7 +1529,9 @@ class RouterHostAdapter:
             {k: v for k, v in meta.items() if k != "reasoning"}
             if "reasoning" in meta else meta
         )
-        await self._put_outbox_cb(OutboxMessage(kind=kind, text=text, meta=_outbox_meta))
+        await self._put_outbox_in.put_outbox(
+            OutboxMessage(kind=kind, text=text, meta=_outbox_meta)
+        )
         # Persist agent (conversational) replies to history so the context
         # window stays coherent across turns.
         #
@@ -1504,7 +1563,7 @@ class RouterHostAdapter:
             ))
             # Capture for agent-to-agent paths that need to forward the
             # reply upstream via _send_agent_response.
-            replies = self._agent_replies_tracker()
+            replies = self._put_outbox_in.agent_replies_tracker()
             if replies is not None:
                 replies.append(text)
 
@@ -2247,7 +2306,7 @@ class RouterHostAdapter:
             contextual_permission=op_ctx.contextual_permission,  # #1827 S3
             # #1953 dynamic-wire: the REAL chat-session id, threaded so
             # emit_hook_event builds the LLM's own session-scoped namespace.
-            session_id=self._session_id,
+            session_id=self._live_sid_in.session_id,
             hook_dispatcher=op_ctx.hook_dispatcher,  # #1800 slice 5c
             hook_bus=op_ctx.hook_bus,  # Hook-Event Redesign Phase 5 part 2: emit_hook_event's publish target
             # proposal 0060 Phase 1 (A7): a live callback read (varies per turn, so
@@ -2303,111 +2362,61 @@ class RouterHostAdapter:
 
 
 # ---------------------------------------------------------------------------
-# #3482 N+1 gate registries — every RouterHostAdapter.__init__ param must
-# have an annotation naming one of ROUTER_HOST_ADAPTER_BUNDLE_TYPES, or be a
-# key in ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS with a REASON (why it stays a
-# bare scalar). tests/test_router_host_adapter_param_gate_3482.py asserts
-# this by AST over the real signature — a bare `foo_fn: Callable` param
-# added tomorrow with no bundle annotation and no registry entry goes RED.
+# #3482 N+1 gate — the registries below hold ONLY what a measurement cannot
+# settle.
 #
-# The reasons below classify by CONSUMER SET (the #3482 firm's discriminator
-# — never by name prefix): most are single-consumer wiring lanes (one
-# Session collaborator → one dedicated adapter method/property), which is
-# NOT itself a defect — #3121 measured that grouping single-consumer params
-# by name-prefix alone is a near-no-op. A handful are multi-consumer (read
-# by 2+ adapter methods) but the reader SET differs per param, so they don't
-# form a cluster either. Six (the mcp call-family callbacks + mcp_servers)
-# get the specific, non-speculative reason the architect required: DECIDED
-# to stay bare, not "scheduled for a future fold" (writing a resolution date
-# for un-scheduled work is exactly the schedule/resolution conflation the
-# architect's firm forbids — see the #3482 issue thread).
+# The question "may this param stay a bare scalar?" has a computable answer:
+# is any OTHER param carried to exactly the same set of destinations? So it is
+# COMPUTED, by scripts/measure_router_host_adapter_consumers.py, and enforced
+# by tests/test_router_host_adapter_param_gate_3482.py:
+#
+#   * bare param that acquires an exact-match partner  -> RED (bundle them)
+#   * bare param with no measurable consumer           -> RED unless shelved
+#                                                         below with a reason
+#   * a shelved reason contradicted by measurement     -> RED
+#
+# The first #3482 pass instead wrote 58 per-param prose reasons, most asserting
+# "no shared-consumer partner", behind a gate that only checked the reasons
+# were non-empty. Six were measurably false (delegation_tracker/send_to_agent,
+# put_outbox/agent_replies_tracker, session_id/live_session_id_fn — each pair
+# an exact consumer-set match, now the three bundles above). A declaration's
+# EXISTENCE was standing in as the witness for its TRUTH; deriving the
+# predicate is the fix, and deleting the prose is part of the fix, because
+# prose that restates a computable fact can only rot.
 # ---------------------------------------------------------------------------
 
 ROUTER_HOST_ADAPTER_BUNDLE_TYPES: "tuple[str, ...]" = (
     "RouterOpContextInputs",
     "McpGatewayInputs",
+    "SendToAgentInputs",
+    "PutOutboxInputs",
+    "LiveSessionIdInputs",
 )
 
-_MCP_CALL_FAMILY_REASON = (
-    "Single-consumer forwarding lane (its own dedicated adapter method "
-    "reaches Session's callback) — one of 5 call-family callbacks +  "
-    "mcp_servers measured (#3482, current main 890e22d2) to each resolve "
-    "to its OWN transfer method, a different consumer set per param, not a "
-    "shared cluster. The call family is already unified on a throw contract "
-    "(#3447 correction). DECIDED: remains bare — there is no scheduled fold "
-    "and no same-consumer partner to bundle with; not a stated \"future "
-    "resolution\" (see the #3482 issue thread's schedule/resolution note)."
-)
-
-ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS: "dict[str, str]" = {
-    # --- identity ---
-    "agent_name": "Identity attribute; own accessor (agent_name/chat_id properties), no bundle partner.",
-    "agent_role": "Identity attribute; own accessor (agent_role property), no bundle partner.",
-    "output_language": "RouterLoopHost Protocol non-property attribute; read externally via host.output_language (router_loop), no adapter-internal cluster partner.",
-    "agent_workspace_dir": "Single-consumer (get_memory_index's workspace path); no bundle partner.",
-    # --- config / collaborators with their own dedicated accessor ---
-    "permission_resolver": "Multi-consumer (permission_resolver property + get_file_permissions + make_router_op_context's file-permission resolution); no single shared-consumer cluster to fold into.",
-    "mcp_servers": _MCP_CALL_FAMILY_REASON,
-    "project_context": "Single-consumer (get_project_context); no bundle partner.",
-    "events": "Multi-consumer EventLog (events property + emit() at multiple call sites across the class); no cluster partner.",
-    "resolver": "Single-consumer (resolve_model/resolve_model_spec); ModelResolver, no bundle partner.",
-    "memory": "Single-consumer (memory_path/memory_dir via MemoryService); no bundle partner.",
-    "journal": "Forward-only (stored, never read within this class or externally) — legacy SnapshotJournal handle; no current consumer, no bundle partner.",
-    "state_log": "Single-consumer (state_log property, WAL head for config generation emit); no bundle partner.",
-    "agent_registry": "Multi-consumer AgentRegistry (list_available_agents / spawn_session / get_agent_registry / session-nesting-depth checks); no single-partner cluster.",
-    "pipeline_registry": "Single-consumer (get_pipeline_registry, IS-5 run_pipeline lookup source); no bundle partner.",
-    "presentation_registry": "Multi-consumer (get_presentation_registry property + make_router_op_context); reader set differs from the 16-param op-context cluster (get_presentation_registry has no partner there), no clean fold.",
-    "record_spawned_task": "Single-consumer (#2103 S1bc-exec spawn_session path); no bundle partner.",
-    "live_session_id_fn": "Single-consumer (live_session_id property); no bundle partner.",
-    # --- file op callback family (own consumer per callback) ---
-    "file_read": "Single-consumer forwarding callback (its own adapter method); file-op family, no shared-consumer partner.",
-    "file_write": "Single-consumer forwarding callback (its own adapter method); file-op family, no shared-consumer partner.",
-    "file_delete": "Single-consumer forwarding callback (its own adapter method); file-op family, no shared-consumer partner.",
-    "file_regenerate_index": "Single-consumer forwarding callback (its own adapter method); file-op family, no shared-consumer partner.",
-    # --- mcp call family (DECIDED bare, see _MCP_CALL_FAMILY_REASON) ---
-    "mcp_call_tool": _MCP_CALL_FAMILY_REASON,
-    "mcp_read_resource": _MCP_CALL_FAMILY_REASON,
-    "mcp_subscribe_resource": _MCP_CALL_FAMILY_REASON,
-    "mcp_unsubscribe_resource": _MCP_CALL_FAMILY_REASON,
-    "mcp_get_prompt": _MCP_CALL_FAMILY_REASON,
-    # --- action callbacks / trackers (own consumer each) ---
-    "send_to_agent": "Single-consumer action callback (send_to_agent method, plus delegation_tracker fan-out); no shared-consumer partner outside its own method.",
-    "put_outbox": "Single-consumer action callback; no bundle partner.",
-    "append_history": "Single-consumer action callback; no bundle partner.",
-    "delegation_tracker": "Single-consumer tracker getter (send_to_agent's post-dispatch record); no bundle partner.",
-    "agent_replies_tracker": "Single-consumer tracker getter; no bundle partner.",
-    # --- FP-0034 universal catalog / retrieval accessors (each own getter) ---
-    "universal_wrappers_enabled": "Single-consumer (get_universal_wrappers_enabled); no bundle partner.",
-    "action_embedding_index": "Single-consumer (get_action_embedding_index); RouterLoop reads it directly via host.get_action_embedding_index(), not through make_router_op_context — not a member of the op-context cluster.",
-    "embedding_provider": "Single-consumer (get_embedding_provider); same reasoning as action_embedding_index.",
-    "embedding_model_class": "Single-consumer (get_embedding_model_class); same reasoning as action_embedding_index.",
-    "action_usage_tracker": "Single-consumer (get_action_usage_tracker); no bundle partner.",
-    "uncompacted_tool_call_records_fn": "Single-consumer (get_uncompacted_tool_call_records); no bundle partner.",
-    "action_retrieval_config": "Single-consumer (get_action_retrieval_config); no bundle partner.",
-    "available_skills": "Multi-consumer (get_available_skills property + make_router_op_context's fallback-when-no-base-fn branch); reader set differs from the op-context cluster's base_available_skills_fn, no clean fold.",
-    "eager_embedding_build": "Single-consumer (get_eager_embedding_build); no bundle partner.",
-    # --- sandbox / environment (D14 string vs FS-op instance are distinct axes) ---
-    "sandbox_backend": "Single-consumer (get_sandbox_backend, the D14 exec-visibility STRING); distinct axis from sandbox_backend_instance (op-context bundle), no partner.",
-    "environment_backend": "Multi-consumer (get_cwd / get_environment_info / make_router_op_context); reader set spans 3 methods, wider than the op-context cluster, no clean fold.",
-    # --- session-scoped safety / limits ---
-    "session_id": "Multi-consumer (live_session_id property fallback + make_router_op_context); reader set differs from the op-context cluster (live_session_id has no partner there), no clean fold.",
-    "intervention_bus_factory": "Multi-consumer (make_router_op_context + make_intervention_bus); reader set differs from the op-context cluster's own presentation_renderer_factory (make_intervention_bus has no partner there), no clean fold.",
-    "handle_chat_limit_checkpoint": "Single-consumer (_spawn_limit_checkpoint call sites within spawn_session/spawn_agent); no bundle partner.",
-    "safety_extensions": "Single-consumer (read/mutated by the same spawn-limit checkpoint call sites); no bundle partner.",
-    # --- reasoning / media / offload (own accessor pair) ---
-    "reasoning_config": "Single-consumer reasoning display/continuity accessor pair (its own dedicated methods); not read via make_router_op_context, not a member of the op-context cluster.",
-    "reasoning_continuity_section_fn": "Single-consumer (paired with reasoning_config, same dedicated accessor methods); no bundle partner.",
-    "media_store": "Multi-consumer (media_store property + make_router_op_context); reader set differs from the op-context cluster, no clean fold.",
-    "cap_tool_result": "Single-consumer (cap_tool_result method); no bundle partner.",
-    "media_followup_budget": "Single-consumer (media_followup_budget method); no bundle partner.",
-    "offload_enabled": "Single-consumer (offload_enabled property); no bundle partner.",
-    "context_window_status": "Single-consumer (context_window_status property); no bundle partner.",
-    # --- FP-0037 mcp tools cache paths ---
-    "state_dir": "Single-consumer (mcp tools cache file path resolution, _state_dir); no bundle partner.",
-    "project_root": "Single-consumer (yaml scope tier watch, _project_root); no bundle partner.",
-    # --- turn budget / cancel ---
-    "turn_budget_engine": "Multi-consumer (wrap_up_output_reserve property + set_turn_budget_engine); reader set differs from the op-context cluster, no clean fold.",
-    "turn_cancel_fn": "Single-consumer (_is_turn_cancel_requested); no bundle partner.",
-    # --- content-threat scan (widest-shared scalar in the class) ---
-    "threat_scan": "Multi-consumer (scan_tool_result / fence_tool_result / scan_for_block / get_project_context / make_router_op_context — 5 methods); the widest-shared scalar in the class, no single cluster to fold into.",
+# Bare params for which the static measurement finds NO consumer at all.
+# "Not measurable" is NOT "has no partner": a dynamic ``getattr(host, ...)``
+# read, a test-only surface, or a hole in the scan all look identical from
+# here, so the value of an entry is the part a scan CANNOT supply — what is
+# actually known about the param. The gate checks this registry against the
+# measurement in BOTH directions (a param that gains a consumer must leave,
+# and a param that loses its last consumer must be added).
+ROUTER_HOST_ADAPTER_CONSUMER_UNMEASURED: "dict[str, str]" = {
+    "journal": (
+        "Stored on self._journal and read nowhere the scan can see: no adapter "
+        "member reads it, and no host-surface read of `journal`/`_journal` "
+        "exists anywhere under src/reyn. Session wires a real SnapshotJournal "
+        "and nothing records whether the handle is kept deliberately (a "
+        "reserved surface) or was simply left behind, and code cannot "
+        "distinguish 'forgotten' from 'decided' — so it is shelved as "
+        "unmeasured rather than declared partnerless. Removing the param is a "
+        "Session-construction decision, not a #3482 measurement one."
+    ),
 }
+
+# Bare params that DO have an exact-match partner but must not be bundled, for
+# a reason no measurement can produce. Empty on purpose: every cluster the
+# measurement currently finds is bundled. An entry here is a claim the gate
+# checks — if the named param has no measured partner, the exception marker is
+# dead and goes RED (#3457's "drop the exception that never fires" arm, which
+# applies here precisely because a reason is a CLAIM, not a value).
+ROUTER_HOST_ADAPTER_BUNDLE_BLOCKED: "dict[str, str]" = {}

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -73,10 +73,13 @@ from reyn.runtime.services import (
     InterventionCoordinator,
     InterventionHandler,
     InterventionRegistry,
+    LiveSessionIdInputs,
     McpGatewayInputs,
     MemoryService,
+    PutOutboxInputs,
     RouterHostAdapter,
     RouterOpContextInputs,
+    SendToAgentInputs,
     SnapshotJournal,
 )
 from reyn.runtime.services.chain_manager import _PendingChain
@@ -3739,8 +3742,10 @@ class Session:
         constructible; the sole production caller, ``__init__``, always passes
         the real constructor value.
 
-        ★ Two args are DEFERRED lambdas, NOT eager values —
-        ``live_session_id_fn`` / ``turn_origin_fn``
+        ★ Two of the values threaded in are DEFERRED lambdas, NOT eager values
+        — ``live_session_id_inputs.live_session_id_fn`` /
+        ``op_context_inputs.turn_origin_fn`` (both #3482 bundle fields; being
+        inside a frozen dataclass changes nothing about when they resolve)
         keep resolving ``self._session_id`` / ``self._current_turn_origin``
         at CALL time, not here: ``_current_turn_origin`` already carries a
         pre-turn DEFAULT at construction (``"auto_improvement"``, set at
@@ -3751,13 +3756,13 @@ class Session:
         is deferred because a spawned session's live session id can change
         AFTER this constructor runs (the cached ``self._session_id`` read
         here is stale for that case — see the inline comment above
-        ``record_spawned_task`` below). Eager-izing any of the three would
-        freeze a per-turn value at
-        construction time — the Family 3/5 deferred/eager pitfall repeated
-        here for a third and heavier family. ``record_spawned_task`` (a bound
-        method) and the two tracker lambdas ``delegation_tracker`` /
-        ``agent_replies_tracker`` are likewise kept verbatim, still closing
-        over ``self``.
+        ``record_spawned_task`` below). Eager-izing either would freeze a
+        per-turn value at construction time — the Family 3/5 deferred/eager
+        pitfall repeated here for a third and heavier family.
+        ``record_spawned_task`` (a bound method) and the two tracker lambdas
+        (``send_to_agent_inputs.delegation_tracker`` /
+        ``put_outbox_inputs.agent_replies_tracker``) are likewise kept
+        verbatim, still closing over ``self``.
 
         PR-refactor-session-1 wave 3 PR3: RouterHostAdapter — concrete
         RouterLoopHost implementation extracted from Session. Constructed
@@ -3811,6 +3816,24 @@ class Session:
             mcp_agent_id=self._agent.agent_id,
             ephemeral_fn=lambda: self._ephemeral,
         )
+        # #3482: three more measured consumer-set clusters (sole readers:
+        # RouterHostAdapter.send_to_agent / .put_outbox / .live_session_id).
+        # Same values, same call-time semantics as the flat kwargs they
+        # replace — the trackers stay lambdas over the live Session fields and
+        # live_session_id_fn stays a deferred read (the constructor's cached
+        # session_id is stale for a spawned session).
+        _send_to_agent_inputs = SendToAgentInputs(
+            send_to_agent=self._send_to_agent,
+            delegation_tracker=lambda: self._router_loop_delegations,
+        )
+        _put_outbox_inputs = PutOutboxInputs(
+            put_outbox=self._put_outbox,
+            agent_replies_tracker=lambda: self._router_loop_agent_replies,
+        )
+        _live_session_id_inputs = LiveSessionIdInputs(
+            session_id=self._session_id,
+            live_session_id_fn=lambda: self._session_id,
+        )
 
         router_host = RouterHostAdapter(
             # #2175: the safety.on_limit checkpoint + the shared per-run extension dict —
@@ -3824,7 +3847,7 @@ class Session:
             threat_scan=self._safety.threat_scan,
             op_context_inputs=_op_context_inputs,  # #3482
             state_log=self._state_log,  # #2259 PR-1 → config generation emit from config ops
-            session_id=self._session_id,
+            live_session_id_inputs=_live_session_id_inputs,  # #3482
             agent_name=self.agent_name,
             agent_role=self._agent_role,
             output_language=self.output_language,
@@ -3851,7 +3874,6 @@ class Session:
             # is stale for spawned sessions, stamped post-construction) for the non-main
             # spawn guard.
             record_spawned_task=self.record_spawned_task,
-            live_session_id_fn=lambda: self._session_id,
             agent_workspace_dir=self.workspace_dir,
             file_read=self._file_read,
             file_write=self._file_write,
@@ -3872,11 +3894,9 @@ class Session:
             # gateway-identity inputs need threading through (mcp_gateway_inputs
             # bundle, built above), not a callback per listing method.
             mcp_gateway_inputs=_mcp_gateway_inputs,
-            send_to_agent=self._send_to_agent,
-            put_outbox=self._put_outbox,
+            send_to_agent_inputs=_send_to_agent_inputs,  # #3482
+            put_outbox_inputs=_put_outbox_inputs,  # #3482
             append_history=self._append_history,
-            delegation_tracker=lambda: self._router_loop_delegations,
-            agent_replies_tracker=lambda: self._router_loop_agent_replies,
             universal_wrappers_enabled=self._action_retrieval.universal_wrappers_enabled,
             action_embedding_index=self._action_embedding_index,
             embedding_provider=self._embedding_provider,

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -11,10 +11,13 @@ from pathlib import Path
 from reyn.core.events.events import EventLog
 from reyn.llm.model_resolver import ModelResolver
 from reyn.runtime.services import (
+    LiveSessionIdInputs,
     McpGatewayInputs,
     MemoryService,
+    PutOutboxInputs,
     RouterHostAdapter,
     RouterOpContextInputs,
+    SendToAgentInputs,
 )
 
 
@@ -137,6 +140,18 @@ def make_adapter(
         mcp_agent_id=None,
         ephemeral_fn=None,
     )
+    send_to_agent_inputs = SendToAgentInputs(
+        send_to_agent=null_send_to_agent,
+        delegation_tracker=lambda: _delegations,
+    )
+    put_outbox_inputs = PutOutboxInputs(
+        put_outbox=null_put_outbox,
+        agent_replies_tracker=lambda: _replies,
+    )
+    live_session_id_inputs = LiveSessionIdInputs(
+        session_id=session_id,
+        live_session_id_fn=None,
+    )
 
     return RouterHostAdapter(
         agent_name=agent_name,
@@ -161,12 +176,10 @@ def make_adapter(
         file_regenerate_index=null_file_regen,
         mcp_call_tool=null_mcp_call_tool,
         mcp_gateway_inputs=mcp_gateway_inputs,
-        send_to_agent=null_send_to_agent,
-        put_outbox=null_put_outbox,
+        send_to_agent_inputs=send_to_agent_inputs,
+        put_outbox_inputs=put_outbox_inputs,
         append_history=null_append_history,
-        delegation_tracker=lambda: _delegations,
-        agent_replies_tracker=lambda: _replies,
+        live_session_id_inputs=live_session_id_inputs,
         turn_budget_engine=turn_budget_engine,
         environment_backend=environment_backend,
-        session_id=session_id,
     )

--- a/tests/test_2597_s2b_mcp_notifications_bridge.py
+++ b/tests/test_2597_s2b_mcp_notifications_bridge.py
@@ -21,10 +21,13 @@ from reyn.llm.model_resolver import ModelResolver
 from reyn.mcp.connection_service import MCPConnectionService
 from reyn.mcp.message_handler import ReynMCPMessageHandler
 from reyn.runtime.services import (
+    LiveSessionIdInputs,
     McpGatewayInputs,
     MemoryService,
+    PutOutboxInputs,
     RouterHostAdapter,
     RouterOpContextInputs,
+    SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
@@ -128,11 +131,16 @@ def _make_adapter(*, tmp_path: Path, events: EventLog) -> RouterHostAdapter:
         file_regenerate_index=_null_file_regen,
         mcp_call_tool=_null_mcp_call_tool,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent=_null_send_to_agent,
-        put_outbox=_null_put_outbox,
+        send_to_agent_inputs=SendToAgentInputs(
+            send_to_agent=_null_send_to_agent, delegation_tracker=lambda: None,
+        ),
+        put_outbox_inputs=PutOutboxInputs(
+            put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
+        ),
         append_history=_null_append_history,
-        delegation_tracker=lambda: None,
-        agent_replies_tracker=lambda: None,
+        live_session_id_inputs=LiveSessionIdInputs(
+            session_id=None, live_session_id_fn=None,
+        ),
         state_dir=tmp_path / "state",
     )
     # #3447: mcp_list_tools is now a real RouterHostAdapter method — see the

--- a/tests/test_action_retrieval_wiring.py
+++ b/tests/test_action_retrieval_wiring.py
@@ -25,9 +25,12 @@ import pytest
 from reyn.config import ActionRetrievalConfig, ReynConfig, load_config
 from reyn.runtime.router_tools import build_tools
 from reyn.runtime.services.router_host_adapter import (
+    LiveSessionIdInputs,
     McpGatewayInputs,
+    PutOutboxInputs,
     RouterHostAdapter,
     RouterOpContextInputs,
+    SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
@@ -100,11 +103,16 @@ def _make_adapter(
         file_regenerate_index=_noop_callable,
         mcp_call_tool=_noop_callable,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent=_noop_callable,
-        put_outbox=_noop_callable,
+        send_to_agent_inputs=SendToAgentInputs(
+            send_to_agent=_noop_callable, delegation_tracker=lambda: None,
+        ),
+        put_outbox_inputs=PutOutboxInputs(
+            put_outbox=_noop_callable, agent_replies_tracker=lambda: None,
+        ),
         append_history=_noop_callable,
-        delegation_tracker=lambda: None,
-        agent_replies_tracker=lambda: None,
+        live_session_id_inputs=LiveSessionIdInputs(
+            session_id=None, live_session_id_fn=None,
+        ),
         universal_wrappers_enabled=universal_wrappers_enabled,
     )
 

--- a/tests/test_agui_reasoning_map_p6a.py
+++ b/tests/test_agui_reasoning_map_p6a.py
@@ -57,10 +57,13 @@ from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.llm.model_resolver import ModelResolver
 from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.services import (
+    LiveSessionIdInputs,
     McpGatewayInputs,
     MemoryService,
+    PutOutboxInputs,
     RouterHostAdapter,
     RouterOpContextInputs,
+    SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
@@ -174,11 +177,18 @@ def _mk_host(reasoning_config, *, outbox: list, history: list) -> RouterHostAdap
         file_regenerate_index=_noop,
         mcp_call_tool=_noop,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent=_noop,
-        put_outbox=lambda msg: outbox.append(msg) or _noop(),
+        send_to_agent_inputs=SendToAgentInputs(
+            send_to_agent=_noop, delegation_tracker=lambda: [],
+        ),
+        put_outbox_inputs=PutOutboxInputs(
+            put_outbox=lambda msg: outbox.append(msg) or _noop(),
+            agent_replies_tracker=lambda: [],
+        ),
         append_history=lambda msg: history.append(msg),
-        delegation_tracker=lambda: [],
-        agent_replies_tracker=lambda: [], turn_budget_engine=None,
+        live_session_id_inputs=LiveSessionIdInputs(
+            session_id=None, live_session_id_fn=None,
+        ),
+        turn_budget_engine=None,
         environment_backend=None,
         reasoning_config=reasoning_config,
         reasoning_continuity_section_fn=lambda: "",

--- a/tests/test_chat_router_modelspec_kwargs_1654.py
+++ b/tests/test_chat_router_modelspec_kwargs_1654.py
@@ -20,10 +20,13 @@ from typing import Any
 from reyn.core.events.events import EventLog
 from reyn.llm.model_resolver import ModelResolver, ModelSpec
 from reyn.runtime.services import (
+    LiveSessionIdInputs,
     McpGatewayInputs,
     MemoryService,
+    PutOutboxInputs,
     RouterHostAdapter,
     RouterOpContextInputs,
+    SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
@@ -78,9 +81,17 @@ def _mk_host_with_kwargs():
         agent_workspace_dir=workspace,
         file_read=_noop, file_write=_noop, file_delete=_noop,
         file_regenerate_index=_noop,
-        mcp_call_tool=_noop, mcp_gateway_inputs=_EMPTY_MCP_GATEWAY, send_to_agent=_noop,
-        put_outbox=_noop, append_history=_noop,
-        delegation_tracker=lambda: [], agent_replies_tracker=lambda: [],
+        mcp_call_tool=_noop, mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
+        send_to_agent_inputs=SendToAgentInputs(
+            send_to_agent=_noop, delegation_tracker=lambda: [],
+        ),
+        put_outbox_inputs=PutOutboxInputs(
+            put_outbox=_noop, agent_replies_tracker=lambda: [],
+        ),
+        append_history=_noop,
+        live_session_id_inputs=LiveSessionIdInputs(
+            session_id=None, live_session_id_fn=None,
+        ),
         turn_budget_engine=None, environment_backend=None,
     )
 

--- a/tests/test_mcp_cache_warm_start.py
+++ b/tests/test_mcp_cache_warm_start.py
@@ -25,10 +25,13 @@ import pytest
 from reyn.core.events.events import EventLog
 from reyn.llm.model_resolver import ModelResolver
 from reyn.runtime.services import (
+    LiveSessionIdInputs,
     McpGatewayInputs,
     MemoryService,
+    PutOutboxInputs,
     RouterHostAdapter,
     RouterOpContextInputs,
+    SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
@@ -158,11 +161,16 @@ def _make_adapter(
         file_regenerate_index=_null_file_regen,
         mcp_call_tool=_null_mcp_call_tool,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent=_null_send_to_agent,
-        put_outbox=_null_put_outbox,
+        send_to_agent_inputs=SendToAgentInputs(
+            send_to_agent=_null_send_to_agent, delegation_tracker=lambda: None,
+        ),
+        put_outbox_inputs=PutOutboxInputs(
+            put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
+        ),
         append_history=_null_append_history,
-        delegation_tracker=lambda: None,
-        agent_replies_tracker=lambda: None,
+        live_session_id_inputs=LiveSessionIdInputs(
+            session_id=None, live_session_id_fn=None,
+        ),
         state_dir=state_dir,
     )
     # #3447: mcp_list_tools is now a real RouterHostAdapter method — see the

--- a/tests/test_mcp_lazy_tools_cache.py
+++ b/tests/test_mcp_lazy_tools_cache.py
@@ -24,10 +24,13 @@ import pytest
 from reyn.core.events.events import EventLog
 from reyn.llm.model_resolver import ModelResolver
 from reyn.runtime.services import (
+    LiveSessionIdInputs,
     McpGatewayInputs,
     MemoryService,
+    PutOutboxInputs,
     RouterHostAdapter,
     RouterOpContextInputs,
+    SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
@@ -132,11 +135,16 @@ def _make_adapter_with_mcp(
         file_regenerate_index=_null_file_regen,
         mcp_call_tool=_null_mcp_call_tool,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent=_null_send_to_agent,
-        put_outbox=_null_put_outbox,
+        send_to_agent_inputs=SendToAgentInputs(
+            send_to_agent=_null_send_to_agent, delegation_tracker=lambda: None,
+        ),
+        put_outbox_inputs=PutOutboxInputs(
+            put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
+        ),
         append_history=_null_append_history,
-        delegation_tracker=lambda: None,
-        agent_replies_tracker=lambda: None,
+        live_session_id_inputs=LiveSessionIdInputs(
+            session_id=None, live_session_id_fn=None,
+        ),
         state_dir=tmp_path / "state",
     )
     # #3447: mcp_list_tools is now a real RouterHostAdapter method (folded off

--- a/tests/test_mcp_yaml_mtime_watch.py
+++ b/tests/test_mcp_yaml_mtime_watch.py
@@ -25,10 +25,13 @@ import pytest
 from reyn.core.events.events import EventLog
 from reyn.llm.model_resolver import ModelResolver
 from reyn.runtime.services import (
+    LiveSessionIdInputs,
     McpGatewayInputs,
     MemoryService,
+    PutOutboxInputs,
     RouterHostAdapter,
     RouterOpContextInputs,
+    SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
@@ -168,11 +171,16 @@ def _make_adapter(
         file_regenerate_index=_null_file_regen,
         mcp_call_tool=_null_mcp_call_tool,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent=_null_send_to_agent,
-        put_outbox=_null_put_outbox,
+        send_to_agent_inputs=SendToAgentInputs(
+            send_to_agent=_null_send_to_agent, delegation_tracker=lambda: None,
+        ),
+        put_outbox_inputs=PutOutboxInputs(
+            put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
+        ),
         append_history=_null_append_history,
-        delegation_tracker=lambda: None,
-        agent_replies_tracker=lambda: None,
+        live_session_id_inputs=LiveSessionIdInputs(
+            session_id=None, live_session_id_fn=None,
+        ),
         state_dir=state_dir,
         project_root=project_root,
     )
@@ -589,11 +597,16 @@ async def test_session_handle_user_message_calls_yaml_watch_before_reload(
         file_regenerate_index=_null_file_regen,
         mcp_call_tool=_null_mcp_call_tool,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent=_null_send_to_agent,
-        put_outbox=_null_put_outbox,
+        send_to_agent_inputs=SendToAgentInputs(
+            send_to_agent=_null_send_to_agent, delegation_tracker=lambda: None,
+        ),
+        put_outbox_inputs=PutOutboxInputs(
+            put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
+        ),
         append_history=_null_append_history,
-        delegation_tracker=lambda: None,
-        agent_replies_tracker=lambda: None,
+        live_session_id_inputs=LiveSessionIdInputs(
+            session_id=None, live_session_id_fn=None,
+        ),
         state_dir=state_dir,
         project_root=None,
     )

--- a/tests/test_reasoning_integration_1652.py
+++ b/tests/test_reasoning_integration_1652.py
@@ -24,10 +24,13 @@ from reyn.core.events.state_log import StateLog
 from reyn.llm.model_resolver import ModelResolver
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.services import (
+    LiveSessionIdInputs,
     McpGatewayInputs,
     MemoryService,
+    PutOutboxInputs,
     RouterHostAdapter,
     RouterOpContextInputs,
+    SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
@@ -84,11 +87,18 @@ def _mk_host(reasoning_config, *, outbox: list, history: list, section: str = ""
         file_regenerate_index=_noop,
         mcp_call_tool=_noop,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent=_noop,
-        put_outbox=lambda msg: outbox.append(msg) or _noop(),
+        send_to_agent_inputs=SendToAgentInputs(
+            send_to_agent=_noop, delegation_tracker=lambda: [],
+        ),
+        put_outbox_inputs=PutOutboxInputs(
+            put_outbox=lambda msg: outbox.append(msg) or _noop(),
+            agent_replies_tracker=lambda: [],
+        ),
         append_history=lambda msg: history.append(msg),
-        delegation_tracker=lambda: [],
-        agent_replies_tracker=lambda: [], turn_budget_engine=None,
+        live_session_id_inputs=LiveSessionIdInputs(
+            session_id=None, live_session_id_fn=None,
+        ),
+        turn_budget_engine=None,
         environment_backend=None,
         reasoning_config=reasoning_config,
         reasoning_continuity_section_fn=lambda: section,

--- a/tests/test_router_host_adapter_invariants.py
+++ b/tests/test_router_host_adapter_invariants.py
@@ -15,10 +15,13 @@ from reyn.core.events.events import EventLog
 from reyn.llm.model_resolver import ModelResolver
 from reyn.runtime.router_loop import RouterLoopHost
 from reyn.runtime.services import (
+    LiveSessionIdInputs,
     McpGatewayInputs,
     MemoryService,
+    PutOutboxInputs,
     RouterHostAdapter,
     RouterOpContextInputs,
+    SendToAgentInputs,
 )
 
 # ---------------------------------------------------------------------------
@@ -210,11 +213,16 @@ def test_delegation_tracker_appended_on_send_to_agent(tmp_path):
         file_regenerate_index=_null_file_regen,
         mcp_call_tool=_null_mcp_call_tool,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent=fake_send,
-        put_outbox=_null_put_outbox,
+        send_to_agent_inputs=SendToAgentInputs(
+            send_to_agent=fake_send, delegation_tracker=lambda: tracker,
+        ),
+        put_outbox_inputs=PutOutboxInputs(
+            put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
+        ),
         append_history=_null_append_history,
-        delegation_tracker=lambda: tracker,
-        agent_replies_tracker=lambda: None,
+        live_session_id_inputs=LiveSessionIdInputs(
+            session_id=None, live_session_id_fn=None,
+        ),
     )
 
     asyncio.run(adapter.send_to_agent(
@@ -281,11 +289,16 @@ def test_adapter_exposes_permission_resolver_property(tmp_path):
         file_regenerate_index=_null_file_regen,
         mcp_call_tool=_null_mcp_call_tool,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent=_null_send_to_agent,
-        put_outbox=_null_put_outbox,
+        send_to_agent_inputs=SendToAgentInputs(
+            send_to_agent=_null_send_to_agent, delegation_tracker=lambda: None,
+        ),
+        put_outbox_inputs=PutOutboxInputs(
+            put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
+        ),
         append_history=_null_append_history,
-        delegation_tracker=lambda: None,
-        agent_replies_tracker=lambda: None,
+        live_session_id_inputs=LiveSessionIdInputs(
+            session_id=None, live_session_id_fn=None,
+        ),
     )
 
     assert adapter.permission_resolver is sentinel, (
@@ -339,11 +352,16 @@ def test_make_router_op_context_wires_intervention_bus(tmp_path):
         file_regenerate_index=_null_file_regen,
         mcp_call_tool=_null_mcp_call_tool,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent=_null_send_to_agent,
-        put_outbox=_null_put_outbox,
+        send_to_agent_inputs=SendToAgentInputs(
+            send_to_agent=_null_send_to_agent, delegation_tracker=lambda: None,
+        ),
+        put_outbox_inputs=PutOutboxInputs(
+            put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
+        ),
         append_history=_null_append_history,
-        delegation_tracker=lambda: None,
-        agent_replies_tracker=lambda: None,
+        live_session_id_inputs=LiveSessionIdInputs(
+            session_id=None, live_session_id_fn=None,
+        ),
         intervention_bus_factory=lambda: sentinel_bus,
     )
 
@@ -396,11 +414,16 @@ def test_make_router_op_context_no_factory_leaves_bus_none(tmp_path):
         file_regenerate_index=_null_file_regen,
         mcp_call_tool=_null_mcp_call_tool,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent=_null_send_to_agent,
-        put_outbox=_null_put_outbox,
+        send_to_agent_inputs=SendToAgentInputs(
+            send_to_agent=_null_send_to_agent, delegation_tracker=lambda: None,
+        ),
+        put_outbox_inputs=PutOutboxInputs(
+            put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
+        ),
         append_history=_null_append_history,
-        delegation_tracker=lambda: None,
-        agent_replies_tracker=lambda: None,
+        live_session_id_inputs=LiveSessionIdInputs(
+            session_id=None, live_session_id_fn=None,
+        ),
     )
 
     op_ctx = adapter.make_router_op_context()

--- a/tests/test_router_host_adapter_param_gate_3482.py
+++ b/tests/test_router_host_adapter_param_gate_3482.py
@@ -1,32 +1,47 @@
-"""Tier 2: OS invariant — every RouterHostAdapter.__init__ param's annotation
-is either a registered bundle type or a reasoned scalar exception (#3482,
-mirroring #3451/#3437's AST-derived SSoT + bidirectional-gate shape).
+"""Tier 2: OS invariant — a bare ``RouterHostAdapter.__init__`` param is bare
+only because MEASUREMENT says no other param travels to the same destinations
+(#3482), never because a hand-written reason says so.
 
-The #3482 firm (issue thread, architect's re-grounded comment on current
-main 890e22d2) measured two real consumer-set clusters in RouterHostAdapter's
-77 constructor params — the 16-field op-context cluster
-(``RouterOpContextInputs``, sole reader ``make_router_op_context``) and the
-3-field mcp-gateway cluster (``McpGatewayInputs``, sole reader
-``_mcp_list_via_gateway``) — and explicitly REJECTED forcing 100% bundle
-coverage ("consumer 集合が一致するものだけを束ねる... 強制収容は接頭辞
-（形）に逃げる圧力になります"). The remaining ~58 params stay bare scalars,
-each with a reason recorded in ``ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS``.
+The first #3482 pass shipped a registry of 58 per-param prose reasons, most
+asserting "no shared-consumer partner", behind a gate that checked only that a
+reason was non-empty. Six were measurably false — the declaration's EXISTENCE
+was standing in as the witness for its TRUTH. So this gate derives the
+predicate from ``scripts/measure_router_host_adapter_consumers.py`` (exact
+consumer-set equality, already-bundled hubs not counted twice) and the module
+keeps prose ONLY for the residue a measurement cannot settle:
 
-This is NOT a param-count pin (Tier-4): the gate never compares against a
-fixed N. It asserts a STRUCTURE — every param falls into one of exactly two
-buckets, both enumerable and both non-empty — so a new bare param added
-tomorrow with neither a bundle annotation nor a registry entry goes RED at
-the exact moment it's added, not silently.
+* a bare param that acquires an exact-match partner   -> RED (bundle them)
+* a bare param with no measurable consumer            -> RED unless shelved in
+                                                         ``..._CONSUMER_UNMEASURED``
+* a shelved / blocked claim the measurement refutes    -> RED
+
+No param count is pinned (that would be a Tier-4 format pin): every arm
+asserts a STRUCTURE, so the gate fires the moment a new param is wired, not at
+the next time someone edits a number.
 """
 from __future__ import annotations
 
-import ast
+import functools
+import importlib.util
+import sys
 from pathlib import Path
 
 from reyn.runtime.services.router_host_adapter import (
+    ROUTER_HOST_ADAPTER_BUNDLE_BLOCKED,
     ROUTER_HOST_ADAPTER_BUNDLE_TYPES,
-    ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS,
+    ROUTER_HOST_ADAPTER_CONSUMER_UNMEASURED,
     RouterHostAdapter,
+)
+
+# Phrases that assert a DERIVED predicate. The gate computes this predicate, so
+# a registry reason repeating it is either redundant or (the #3482 defect) false
+# — either way it is checked against the measurement, never trusted.
+_NO_PARTNER_CLAIM_PHRASES = (
+    "no shared-consumer partner",
+    "no bundle partner",
+    "no same-consumer partner",
+    "no partner",
+    "no cluster partner",
 )
 
 
@@ -38,106 +53,191 @@ def _repo_root() -> Path:
     raise RuntimeError("repo root not found from " + str(here))
 
 
-def _init_params() -> list[tuple[str, "str | None"]]:
-    """AST-derive {param_name: annotation_source} for RouterHostAdapter.__init__
-    from the REAL file on disk — never a hand-maintained list (the #3437/#3451
-    lesson: a hand-written enumeration silently drifts from the signature)."""
-    root = _repo_root()
-    path = root / "src" / "reyn" / "runtime" / "services" / "router_host_adapter.py"
-    tree = ast.parse(path.read_text(encoding="utf-8"))
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ClassDef) and node.name == "RouterHostAdapter":
-            for item in node.body:
-                if isinstance(item, ast.FunctionDef) and item.name == "__init__":
-                    args = item.args
-                    out = []
-                    for a in (*args.posonlyargs, *args.args, *args.kwonlyargs):
-                        if a.arg == "self":
-                            continue
-                        ann = ast.unparse(a.annotation) if a.annotation else None
-                        out.append((a.arg, ann))
-                    return out
-    raise RuntimeError("RouterHostAdapter.__init__ not found via AST")
+def _load_measurement_module():
+    """Import scripts/measure_router_host_adapter_consumers.py.
+
+    scripts/ has no ``__init__.py`` — same loader idiom as
+    tests/test_check_pr_closing_intent.py uses for its sibling script.
+    """
+    path = _repo_root() / "scripts" / "measure_router_host_adapter_consumers.py"
+    assert path.is_file(), f"measurement script missing: {path}"
+    spec = importlib.util.spec_from_file_location("_rha_consumer_measure", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
-def test_bundle_type_and_exception_registries_are_non_empty() -> None:
-    """Tier 2: vacuity guard — an empty registry on either side would make
-    the completeness assertion below pass trivially (#3437's vacuity lesson:
-    a gate that can be satisfied by declaring nothing is not a gate)."""
-    assert ROUTER_HOST_ADAPTER_BUNDLE_TYPES, (
-        "ROUTER_HOST_ADAPTER_BUNDLE_TYPES is empty — the gate would vacuously "
-        "pass by finding no bundle-typed params to recognize."
+@functools.lru_cache(maxsize=1)
+def _measure():
+    """Measure once per session — every arm reads the same snapshot, and the
+    scan parses all of src/reyn (seconds, not milliseconds)."""
+    return _load_measurement_module().measure(_repo_root())
+
+
+def test_measurement_is_not_vacuous() -> None:
+    """Tier 2: vacuity guard — every other arm here is only as strong as the
+    measurement it derives from, and a silently empty measurement (parser
+    drifted off the signature, external scan matched nothing) would make all
+    of them pass by finding nothing to complain about."""
+    m = _measure()
+
+    assert m.params, "AST found zero __init__ params — the parser drifted off the signature."
+    assert m.bundle_types, (
+        "ROUTER_HOST_ADAPTER_BUNDLE_TYPES is empty — no annotation could be "
+        "recognized as a bundle, so every param would look bare."
     )
-    assert ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS, (
-        "ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS is empty — the gate would "
-        "vacuously pass by finding no exceptions either."
+    assert [p for p in m.params if p.is_bundled], (
+        "no param resolved to a bundle type — the annotation/bundle-name match broke."
     )
-    for name, reason in ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS.items():
+    assert m.bundled_consumers, (
+        "no already-bundled consumer was derived — the hub-exclusion rule went "
+        "dead, which silently re-admits the equality a landed bundle already absorbed."
+    )
+    assert [p for p in m.params if p.external_sites], (
+        "the external host-surface scan found no reader anywhere under src/reyn — "
+        "with it dead every param looks 'consumer unmeasured' and the shelf "
+        "swallows the whole signature."
+    )
+    assert [p for p in m.params if p.adapter_members], (
+        "no param resolved to an adapter member — the in-class reader scan went dead, "
+        "which erases the destination level that distinguishes append_history from put_outbox."
+    )
+
+
+def test_no_bare_param_has_an_unbundled_exact_match_partner() -> None:
+    """Tier 2: the derived N+1 arm. Two params carried to exactly the same set
+    of destinations are one bundle; if they are still bare, this fails and
+    names the pair. A param wired tomorrow into an existing lane's consumer
+    goes RED at the moment it is wired — no registry edit can silence it."""
+    m = _measure()
+    offenders = {
+        cluster: sorted(m.by_name()[cluster[0]].consumers)
+        for cluster in m.exact_match_clusters()
+        if not all(name in ROUTER_HOST_ADAPTER_BUNDLE_BLOCKED for name in cluster)
+    }
+    assert not offenders, (
+        "These bare RouterHostAdapter.__init__ params share an EXACT consumer set "
+        "and must be one bundle (a frozen dataclass, no defaults, no construction "
+        "logic) — or, if bundling is impossible for a reason no measurement can "
+        "produce, be registered in ROUTER_HOST_ADAPTER_BUNDLE_BLOCKED:\n"
+        + "\n".join(f"  {list(c)}\n      consumers: {cons}" for c, cons in offenders.items())
+    )
+
+
+def test_params_with_no_measurable_consumer_are_shelved_with_a_reason() -> None:
+    """Tier 2: "not measurable" is a different shelf from "has no partner", and
+    the gate keeps them from merging — in both directions, so a param that
+    gains a consumer must leave the shelf and one that loses its last consumer
+    must join it. The reason is the part a scan cannot supply."""
+    m = _measure()
+    measured_unmeasurable = set(m.unmeasured_params())
+    shelved = set(ROUTER_HOST_ADAPTER_CONSUMER_UNMEASURED)
+
+    unshelved = measured_unmeasurable - shelved
+    assert not unshelved, (
+        "These bare params have NO measurable consumer and no shelf entry: "
+        f"{sorted(unshelved)}. Add each to ROUTER_HOST_ADAPTER_CONSUMER_UNMEASURED "
+        "with what IS known (dynamic read / external surface / dead wiring under "
+        "review) — do not claim 'no partner', which is a different and stronger claim."
+    )
+    stale = shelved - measured_unmeasurable
+    assert not stale, (
+        "These params are shelved as having no measurable consumer, but the "
+        f"measurement finds one: {sorted(stale)}. The shelf entry is now false — "
+        "delete it (and bundle the param if it acquired an exact-match partner)."
+    )
+    for name, reason in ROUTER_HOST_ADAPTER_CONSUMER_UNMEASURED.items():
         assert reason and reason.strip(), (
-            f"scalar exception {name!r} has an empty reason — a registry "
-            "entry with no reason is a bare param wearing a disguise."
+            f"shelf entry {name!r} has an empty reason — an entry with no reason "
+            "is a bare param wearing a disguise, the exact #3482 defect."
         )
 
 
-def test_every_init_param_is_bundled_or_reasoned() -> None:
-    """Tier 2: every RouterHostAdapter.__init__ param (AST-derived from the
-    real file, not hand-listed) has an annotation naming a registered bundle
-    type, OR is a key in the scalar exception registry with a reason.
+def test_written_claims_agree_with_the_measurement() -> None:
+    """Tier 2: a claim contradicted by measurement goes RED (#3482 firm ④B).
 
-    RED the moment a new bare param (e.g. ``foo_fn: Callable``) is added
-    without either — the exact N+1 gate the #3482 firm required, without
-    pinning a param count (Tier-4)."""
-    params = _init_params()
-    assert params, "AST found zero __init__ params — parser drifted from the real signature."
+    Two shapes: a ``BUNDLE_BLOCKED`` entry for a param the measurement gives no
+    partner (the exception marker never fires — it is stale or was never true),
+    and any reason text asserting the derived "no partner" predicate about a
+    param that measurably HAS a partner."""
+    m = _measure()
+    by_name = m.by_name()
 
-    undeclared: list[tuple[str, "str | None"]] = []
-    for name, ann in params:
-        ann_str = ann or ""
-        if any(bundle_name in ann_str for bundle_name in ROUTER_HOST_ADAPTER_BUNDLE_TYPES):
-            continue
-        if name in ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS:
-            continue
-        undeclared.append((name, ann))
-
-    assert not undeclared, (
-        "RouterHostAdapter.__init__ has params with neither a registered bundle "
-        "annotation nor a scalar-exception registry entry — a bare param slipped "
-        "in uncovered:\n"
-        + "\n".join(f"  {n}: {a}" for n, a in undeclared)
-        + "\nEither fold it into an existing/new bundle (if it shares a consumer "
-        "with one), or add it to ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS with a "
-        "reason (current-form, not a scheduled future fold)."
+    unknown = set(ROUTER_HOST_ADAPTER_BUNDLE_BLOCKED) | set(ROUTER_HOST_ADAPTER_CONSUMER_UNMEASURED)
+    unknown -= set(by_name)
+    assert not unknown, (
+        f"registry entries name params that do not exist in __init__: {sorted(unknown)}"
     )
 
-
-def test_scalar_exception_keys_match_real_bare_params_exactly() -> None:
-    """Tier 2: real ⊆ declared AND declared ⊆ real — the registry names
-    exactly the params that are actually bare scalars right now, no more, no
-    less. Catches BOTH a stale entry (param renamed/removed/bundled but the
-    registry key survives) and a param quietly re-annotated to a bundle type
-    while a same-named registry entry lingers unnoticed."""
-    params = _init_params()
-    bare_now = {
-        name
-        for name, ann in params
-        if not any(bundle_name in (ann or "") for bundle_name in ROUTER_HOST_ADAPTER_BUNDLE_TYPES)
+    dead_markers = {
+        name: reason
+        for name, reason in ROUTER_HOST_ADAPTER_BUNDLE_BLOCKED.items()
+        if not m.partners_of(name)
     }
-    registered = set(ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS)
+    assert not dead_markers, (
+        "ROUTER_HOST_ADAPTER_BUNDLE_BLOCKED claims these params have an "
+        "exact-match partner that cannot be bundled, but the measurement finds "
+        f"no partner for them: {sorted(dead_markers)}. The claim is false (or has "
+        "gone stale) — delete the entry rather than leave a marker that never fires."
+    )
 
-    stale = registered - bare_now
-    assert not stale, (
-        f"ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS has stale entries no longer "
-        f"matching a bare __init__ param: {sorted(stale)}"
+    contradicted = {}
+    for registry in (ROUTER_HOST_ADAPTER_CONSUMER_UNMEASURED, ROUTER_HOST_ADAPTER_BUNDLE_BLOCKED):
+        for name, reason in registry.items():
+            lowered = reason.lower()
+            if not any(phrase in lowered for phrase in _NO_PARTNER_CLAIM_PHRASES):
+                continue
+            partners = m.partners_of(name)
+            if partners:
+                contradicted[name] = partners
+    assert not contradicted, (
+        "These registry reasons assert that the param has no shared-consumer "
+        "partner, and the measurement exhibits one — the #3482 defect exactly: "
+        + "; ".join(f"{n} shares its consumer set with {list(p)}" for n, p in contradicted.items())
+        + ". The predicate is derived by this gate; do not restate it in prose."
     )
-    missing = bare_now - registered
-    assert not missing, (
-        f"These bare __init__ params have no scalar-exception registry entry: "
-        f"{sorted(missing)}"
-    )
+
+
+def test_every_bundle_type_is_a_real_default_free_dataclass() -> None:
+    """Tier 2: the bundle registry names real frozen dataclasses with NO field
+    defaults. A default would let a caller's silent omission absorb a wiring
+    change, which is what the byte-identical-refactor invariant forbids."""
+    import dataclasses
+
+    import reyn.runtime.services.router_host_adapter as mod
+
+    for type_name in ROUTER_HOST_ADAPTER_BUNDLE_TYPES:
+        bundle = getattr(mod, type_name, None)
+        assert bundle is not None and dataclasses.is_dataclass(bundle), (
+            f"{type_name} is in ROUTER_HOST_ADAPTER_BUNDLE_TYPES but is not a "
+            "dataclass in router_host_adapter.py"
+        )
+        fields = dataclasses.fields(bundle)
+        assert fields, f"{type_name} has no fields — an empty bundle carries nothing"
+        defaulted = [
+            f.name
+            for f in fields
+            if f.default is not dataclasses.MISSING
+            or f.default_factory is not dataclasses.MISSING  # type: ignore[misc]
+        ]
+        assert not defaulted, (
+            f"{type_name} fields have defaults ({defaulted}) — every field must be "
+            "explicit at the call site so an omitted wire cannot pass silently."
+        )
 
 
 def test_router_host_adapter_is_the_real_class_under_gate() -> None:
-    """Tier 2: sanity — RouterHostAdapter imports cleanly and is the class
-    the AST walk above is describing (import-identity check, not a private-
-    state assertion)."""
-    assert RouterHostAdapter.__name__ == "RouterHostAdapter"
+    """Tier 2: sanity — the measured file is the module the gate imports from,
+    so a green result above is about the class actually in use."""
+    m = _measure()
+    measured = {p.name for p in m.params}
+    live = set(RouterHostAdapter.__init__.__code__.co_varnames[
+        1 : RouterHostAdapter.__init__.__code__.co_argcount
+        + RouterHostAdapter.__init__.__code__.co_kwonlyargcount
+    ])
+    assert measured == live, (
+        "the AST measurement and the imported class disagree about the param set "
+        f"— only-in-AST {sorted(measured - live)}, only-in-class {sorted(live - measured)}"
+    )


### PR DESCRIPTION
**[per-PR-coder]** — #3482 second phase. `Closes #3482` (enumerated `gh pr list --state all --search "3482 in:body"`: only #3484, merged; no open sibling declaring non-closing intent for #3482).

## The defect

#3484 landed 58 per-param prose reasons in `ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS`, most asserting `no shared-consumer partner`, behind a gate whose only condition was that a reason is **non-empty**. So the gate could never notice that a reason was **false** — the declaration's *existence* was standing in as the witness for its *truth*. Six of them were false.

The fix is not new wording. `has a shared-consumer partner` is a **computable predicate**, so this PR computes it and deletes the prose that restated it.

## 1. My measurement

New reproducible script: **`scripts/measure_router_host_adapter_consumers.py`** (stdlib-only, no `reyn` import; both the signature and the registries are AST-derived from the file on disk, so no hand-maintained list can drift).

Discriminator, exactly as the firm fixed it:

- **exact consumer-set equality only** (overlap rejected: 80 pairs, non-transitive, no definable bundle boundary);
- consumer set = `{adapter.<member> reading the param's stored attr}` ∪ `{external <module>::<func> reading that attr or one of those members off a host/adapter-named base}` — **both** halves, scanned over all of `src/reyn`;
- an **already-bundled consumer** (a member reading a bundle attribute) is not counted twice. That set is *derived* from the bundle-typed attrs, not hardcoded — a future bundle updates it for free. `run` / `run_loop` are **not** excluded.

**Result on `main` = e4105f5c (before this PR's changes): 3 exact-match clusters / 6 params.**

| cluster | consumer set |
| --- | --- |
| `delegation_tracker` + `send_to_agent` | `adapter.send_to_agent`, `router_loop::_send_to_agent_bound` |
| `agent_replies_tracker` + `put_outbox` | `adapter.put_outbox`, `router_loop::run_loop` |
| `live_session_id_fn` + `session_id` | `adapter.live_session_id` |

**All six had a registry reason asserting no partner** (`no bundle partner` ×3, `no shared-consumer partner outside its own method`, `no clean fold` ×1, `no bundle partner` for `live_session_id_fn`). 6/6 false — I inspected each of the six reason strings directly, not a sample.

### Difference from the architect's numbers (4 groups / 9 params) — and why I did not tune

Identical on three of their four groups (the two above plus `['live_session_id_fn','session_id']`, which their hub-exclusion arm also predicted). The one I do **not** reproduce is `['agent_role','output_language','project_context']`.

That group appears only if consumer sets are measured from **external sites alone**, dropping the adapter-member level. Measured that way the three do share `{router_loop::run}` — but the same relaxation also merges `append_history` into the `put_outbox` cluster, which is **wrong**: `append_history` is additionally read by `append_history_entry`, so it is not carried to the same places. Keeping the member level splits `agent_role` (its own `agent_role` property), `project_context` (`get_project_context`) and `output_language` (no in-class reader) into three different destinations. I kept the more discriminating measurement and report 3/6 rather than tuning to 4/9.

## 2. What landed

Three new frozen, default-free, logic-free bundles named after their measured sole consumer — `SendToAgentInputs`, `PutOutboxInputs`, `LiveSessionIdInputs` (five bundles total with #3484's two). Session builds each with the same expressions as before: the trackers and `live_session_id_fn` are still lambdas resolved at call time, not eager-ized.

**Fixpoint checked**: after bundling, the measurement finds **0 exact-match clusters** among the remaining 52 bare params (bundling adds hub exclusions, which could in principle reveal new clusters — it does not here).

## 3. The gate, rebuilt as derivation (firm ④)

`ROUTER_HOST_ADAPTER_SCALAR_EXCEPTIONS` (58 prose entries) is **deleted**. Two registries remain, holding only what a measurement cannot settle:

- `ROUTER_HOST_ADAPTER_CONSUMER_UNMEASURED` — the "not measurable" shelf, kept strictly separate from "no partner";
- `ROUTER_HOST_ADAPTER_BUNDLE_BLOCKED` — empty; an entry is a *claim* the gate checks.

Arms in `tests/test_router_host_adapter_param_gate_3482.py`: bare param with an exact-match partner → RED; param with no measurable consumer not on the shelf (and shelf entry whose param *has* a consumer) → RED; a `BUNDLE_BLOCKED` marker for a param with no measured partner → RED; a reason asserting the derived no-partner predicate about a param that has one → RED. Plus a bundle-shape arm (real dataclass, no field defaults) and a vacuity guard. **No count is pinned.**

Deliverable 4 (drop `file-op family` from the four `file_*` reasons — shape talk, which the firm forbids) is subsumed: those reasons no longer exist. Worth recording: under the firm's **exact-match** discriminator those four claims were *not* false — `_remember` / `_forget` / `_read_memory_body` are three different consumer sets. They were only falsified under the pairwise-overlap criterion the architect rejected.

## 4. RED evidence (strip-falsify — cp-scratch restore, never `git checkout --`; each anchor `count == 1` before editing)

| strip | expected arm | observed |
| --- | --- | --- |
| A. unbundle `send_to_agent`/`delegation_tracker` back to bare params | cluster arm | **RED** — `test_no_bare_param_has_an_unbundled_exact_match_partner`: `['delegation_tracker','send_to_agent'] consumers: ['adapter.send_to_agent','runtime/router_loop.py::_send_to_agent_bound']`. Other 5 green. |
| **B. A + register both in `BUNDLE_BLOCKED` with the sentence `...no shared-consumer partner.`** | **claim arm (firm ④B)** | **RED** — `test_written_claims_agree_with_the_measurement`: *"send_to_agent shares its consumer set with ['delegation_tracker']; delegation_tracker shares its consumer set with ['send_to_agent']"*. The cluster arm is *satisfied* here (they are registered) — **the only thing making it red is the false sentence.** This is the #3482 defect reproduced and caught. |
| C. `BUNDLE_BLOCKED["threat_scan"]` (a param with no partner) | dead-marker arm | **RED** — *"claims these params have an exact-match partner ... measurement finds no partner: ['threat_scan']"* |
| D. shelve `state_log` as consumer-unmeasured (it has one) | shelf arm | **RED** — *"shelved as having no measurable consumer, but the measurement finds one: ['state_log']"* |
| E. disable the external-site scan (`_HOST_BASE_SUFFIXES`) | vacuity guard | **RED** — the guard fires before the shelf can swallow the signature |

## 5. The "unmeasurable" shelf — 1 entry

**`journal`** — stored on `self._journal`; no adapter member reads it and there is no `host.journal` / `host._journal` read anywhere under `src/reyn`. Recorded as *unmeasured*, not *partnerless*: dynamic reads and dead wiring look identical to a static scan, and code cannot distinguish "forgotten" from "decided".

**Remainder (not silently deferred):** `journal` looks like dead wiring, but deleting a required constructor param that Session deliberately wires is a Session-construction decision, not a measurement one, and no comment records intent. Not filed as an issue by me — flagging it here for the closing comment; say the word and I file it, or drop it explicitly.

*(Note: the architect's firm asserted `router_loop` reads `host._journal`. On e4105f5c it does not — grep finds no such read. The `self._journal` hits in `session.py`/`registry.py` are Session's own attribute, not the adapter's.)*

## 6. Four CI gates (run locally, separately)

| gate | result |
| --- | --- |
| `ruff check src tests scripts` | **PASS** — All checks passed |
| `scripts/test_tier_audit.py --strict` (10 changed test files) | **PASS** — 69 inspected, 0 warnings, 0 Tier-4 errors |
| `pytest -q -n auto --timeout=120` (repo root) | **PASS** — 9726 passed, 36 skipped (192 s, rebased onto current main 11470662) |
| `scripts/verify_module_docstrings.py` (3 changed src files) | **PASS** |

Honest note on the pytest gate: the **first** full run reported 4 failures — `test_fp0063_arc_witness`, `test_audit_event_kind_vocabulary_3410`, `test_config_package_reexport_1682`, `test_plugin_install`. All four pass in isolation, and **three subsequent full runs with CI's exact flags were green** (9700/9700, then 9726/9726 after rebasing onto current main). That run also took 503 s vs 259 s (cold caches under load), and none of the four is in a subsystem this diff touches. Reported rather than hidden.

## Docs

`docs/reference/runtime/session-construction.md` Family 6a rewritten: the five bundles as a table, the derived gate replacing the prose registry, and the deferred-lambda sentence corrected (it claimed 3 lambdas including `current_task_id_fn`, a param that no longer exists anywhere in `src/`).

## Test plan

- [x] `pytest -q -n auto --timeout=120` from repo root — 9700 passed
- [x] `ruff check src tests scripts`
- [x] `python scripts/test_tier_audit.py --strict` on all changed test files
- [x] `python scripts/verify_module_docstrings.py` on all changed src files
- [x] Manual: `python scripts/measure_router_host_adapter_consumers.py --detail` before and after — 3 clusters/6 params → 0 clusters
- [x] Manual: five strip-falsify arms above, each RED on the intended arm, restored by `cp` and re-verified green

Closes #3482

