### PR TITLE
fix(test): rebind the live-sid bundle, not the removed private wire — follow-up to #3515

### DIFF
--- a/tests/test_2103_s1bc_exec_result_routing.py
+++ b/tests/test_2103_s1bc_exec_result_routing.py
@@ -27,6 +27,7 @@ from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.services import LiveSessionIdInputs
 from reyn.runtime.session import Session
 from reyn.runtime.session_params import PresentationWiring
 from tests._support.agent_session import make_session
@@ -165,7 +166,9 @@ async def test_non_main_spawn_is_now_allowed_guard_lifted(tmp_path):
     reg = _registry(tmp_path)
     main = reg.get_or_load("worker")
     host = main._router_host
-    host._live_session_id_fn = lambda: "abc12345"  # a non-main sid
+    host._live_sid_in = LiveSessionIdInputs(  # a non-main sid
+        session_id=host._live_sid_in.session_id, live_session_id_fn=lambda: "abc12345",
+    )
     result = await host.spawn_session(
         request="nested", mode="persistent", narrowing=None, chain_id="c3",
     )

--- a/tests/test_spawn_routing_detached_fail_mode_2708.py
+++ b/tests/test_spawn_routing_detached_fail_mode_2708.py
@@ -36,6 +36,7 @@ from reyn.runtime.presentation_consumer import (
     AuditOnlyPresentationSink,
 )
 from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.services import LiveSessionIdInputs
 from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session
 from reyn.runtime.session_api import run_agent_step, start_pipeline_run
 from reyn.runtime.session_buses import (
@@ -349,7 +350,9 @@ async def test_session_spawn_child_ask_user_reaches_parent_operator_no_hang(
     # A live operator attached to the PARENT (the "tui" listener a mounted CUI registers).
     parent.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
     host = parent._router_host
-    host._live_session_id_fn = lambda: "main"  # from_sid = the parent's real sid (resolvable)
+    host._live_sid_in = LiveSessionIdInputs(  # from_sid = the parent's real sid (resolvable)
+        session_id=host._live_sid_in.session_id, live_session_id_fn=lambda: "main",
+    )
 
     result = await host.spawn_session(
         request="help me", mode="persistent", narrowing=None, chain_id="c1",
@@ -393,7 +396,9 @@ async def _spawn_from(
     """Spawn a child session from ``spawner`` via the LLM session_spawn adapter path (so the child
     gets the adapter's BridgeToParent routing), returning ``(child_session, child_sid)``."""
     host = spawner._router_host
-    host._live_session_id_fn = lambda: spawner_sid
+    host._live_sid_in = LiveSessionIdInputs(
+        session_id=host._live_sid_in.session_id, live_session_id_fn=lambda: spawner_sid,
+    )
     r = await host.spawn_session(request="x", mode="persistent", narrowing=None, chain_id="c")
     child = reg.get_session("worker", r["sid"])
     assert child is not None


### PR DESCRIPTION
**[per-PR-coder]** — follow-up to #3515 (already merged). Not a new feature: **a green-but-wrong condition #3515 left behind, found by the private-attr sweep I ran after the merge race.**

## What was wrong

Three test sites steer a real `RouterHostAdapter`'s live sid by assigning the private wire directly:

```python
host._live_session_id_fn = lambda: "main"        # test_spawn_routing_detached_fail_mode_2708.py x2
host._live_session_id_fn = lambda: "abc12345"    # test_2103_s1bc_exec_result_routing.py
```

#3515 moved that wire into the `LiveSessionIdInputs` bundle, so `live_session_id` now reads `self._live_sid_in.live_session_id_fn`. The assignments above became **inert** — they set a dead attribute — and **all three tests still passed.** That is the shape to distrust: the override silently stopped taking effect, and green said nothing. `test_2103`'s stated premise ("a non-main sid") was no longer being established at all.

The constructor sweep in #3515 could not have caught this: these sites never call the constructor.

## The fix

Rebind the bundle instead. Like-for-like — the sites already reached for a private wire; this does not introduce a new one, and no production API is added for a test's benefit.

```python
host._live_sid_in = LiveSessionIdInputs(
    session_id=host._live_sid_in.session_id, live_session_id_fn=lambda: "abc12345",
)
```

## Liveness witnessed, not inferred from green

```
make_adapter(session_id="base-sid") -> live_session_id == "base-sid"
after rebinding the bundle          -> live_session_id == "override-sid"
```

i.e. the override now produces a value the dead mechanism could not.

## Gates

| gate | result |
| --- | --- |
| `pytest` (the two files) | **PASS** — 18 passed |
| `pytest -q -n auto --timeout=120` (repo root, pre-rebase tree) | **PASS** — 9726 passed, 36 skipped |
| `ruff check tests` | **PASS** |
| `test_tier_audit.py --strict` (both files) | **PASS** — 18 inspected, 0 Tier-4 |
| `verify_module_docstrings.py` | n/a — no `src/` file changed |

## Test plan

- [x] Both files pass with the override actually live
- [x] Full suite green on the same content before rebasing onto merged main
- [x] `ruff` + tier audit on the changed files
- [x] Manual: printed `live_session_id` before/after the rebind (above)

Follow-up to #3482 / #3515 — deliberately no closing keyword; #3482 is already closed by #3515.
