### PR TITLE
feat(mcp): surface silent probe degradation + config-ise per_server_timeout — #3475

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -439,6 +439,7 @@ safety:
     llm_call_seconds: 60       # per-call HTTP timeout (--llm-timeout)
     llm_max_retries: 3         # transient-error retries per call (--llm-max-retries)
     chain_seconds: 60          # wait for delegate reply before upstream error
+    mcp_probe_seconds: 5       # per-server MCP tools-list probe timeout (#3475)
   on_limit:
     mode: interactive          # interactive | unattended | auto_extend
     auto_extend_times: 1       # (auto_extend mode) number of auto-extensions
@@ -474,6 +475,7 @@ safety:
 | `safety.timeout.llm_call_seconds` | float (s) | `60` | `--llm-timeout` | Per-call HTTP timeout passed to LiteLLM. |
 | `safety.timeout.llm_max_retries` | int | `3` | `--llm-max-retries` | Transient-error retries per LLM call (LiteLLM exponential backoff). |
 | `safety.timeout.chain_seconds` | float (s) | `60` | — | How long a multi-agent chain waits for a delegate reply before synthesising an error. `0` = disabled. |
+| `safety.timeout.mcp_probe_seconds` | float (s) | `5` | — | Per-server timeout for the MCP tools-list probe (`ensure_mcp_tools_cached` / `reyn mcp refresh`, #3475). A server slower than this is cached as an EMPTY tool list for the session (no retry); an `mcp_tool_probe_degraded` audit-event names the server and reason (`timeout` / `exception`). Raise under co-located CPU load. |
 
 ### `safety.on_limit` fields
 

--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -137,6 +137,7 @@ mcp_resources_listed
 mcp_server_installed
 mcp_server_removed
 mcp_tool_list_changed
+mcp_tool_probe_degraded
 mcp_tools_listed
 memory_deleted
 memory_saved

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -633,6 +633,10 @@
 #     llm_call_seconds: 60.0
 #     llm_max_retries: 3
 #     chain_seconds: 60.0           # ≤0 = disable delegate-reply wait
+#     mcp_probe_seconds: 5.0        # #3475: per-server MCP tools-list probe timeout;
+#                                   # a server slower than this is cached EMPTY for the
+#                                   # session (an mcp_tool_probe_degraded audit-event
+#                                   # names why) — raise under co-located CPU load
 #   on_limit:
 #     mode: interactive             # interactive | unattended | auto_extend
 #     auto_extend_times: 1          # used when mode = auto_extend

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -80,11 +80,24 @@ class TimeoutConfig:
             How long a multi-agent pending chain waits for a delegate
             reply before the runtime synthesises an upstream error.
             ``0`` (or any non-positive value) disables.
+        mcp_probe_seconds:
+            #3475: per-server timeout for the MCP tools-list probe
+            (`RouterHostAdapter.ensure_mcp_tools_cached` / the CLI's
+            `reyn mcp refresh`). A server slower than this is cached as
+            an EMPTY tool list for the rest of the session (no retry —
+            see `ensure_mcp_tools_cached`'s own docstring) and an
+            `mcp_tool_probe_degraded` audit-event is emitted naming which
+            server and why. THE default (``5.0``) — the two call sites
+            derive their own defaults from this field rather than
+            repeating the literal, so raising this one number is the only
+            operator action needed to widen the budget under co-located
+            CPU load; it does not itself change the default.
     """
 
     llm_call_seconds: float = 60.0
     llm_max_retries: int = 3
     chain_seconds: float = 60.0
+    mcp_probe_seconds: float = 5.0
 
 
 ON_LIMIT_MODES = ("interactive", "unattended", "auto_extend")
@@ -759,6 +772,9 @@ def _build_safety_config(raw: object) -> SafetyConfig:
         )),
         chain_seconds=float(timeout_raw.get(
             "chain_seconds", timeout_defaults.chain_seconds,
+        )),
+        mcp_probe_seconds=float(timeout_raw.get(
+            "mcp_probe_seconds", timeout_defaults.mcp_probe_seconds,
         )),
     )
     on_limit_defaults = OnLimitConfig()

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -308,6 +308,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "mcp_server_installed",
     "mcp_server_removed",
     "mcp_tool_list_changed",
+    "mcp_tool_probe_degraded",
     "mcp_tools_listed",
     "memory_deleted",
     "memory_saved",

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -18,8 +18,17 @@ import os
 import sys
 from pathlib import Path
 
+from reyn.config.chat import TimeoutConfig
+
 from ..common_args import add_common_args
 from ..invocation_context import InvocationContext
+
+# #3475: THE default for the MCP tools-list per-server probe timeout lives on
+# ``TimeoutConfig.mcp_probe_seconds`` (config-definition side, #3461's
+# ``FileScopes`` precedent) — this module reads it rather than repeating the
+# literal, so this CLI and ``RouterHostAdapter.ensure_mcp_tools_cached`` derive
+# their own defaults from the SAME source instead of two independent ``5.0``s.
+_DEFAULT_MCP_PROBE_SECONDS = TimeoutConfig().mcp_probe_seconds
 
 # ---------------------------------------------------------------------------
 # Scope tier helpers
@@ -1171,7 +1180,7 @@ def run_clear_secret(args: argparse.Namespace) -> None:
 
 
 async def _probe_server_tools(
-    server_name: str, cfg: dict, *, per_server_timeout: float = 5.0,
+    server_name: str, cfg: dict, *, per_server_timeout: float = _DEFAULT_MCP_PROBE_SECONDS,
 ) -> tuple[str, list[dict]]:
     """Probe a single MCP server's tool list with a per-server timeout.
 
@@ -1208,7 +1217,8 @@ def run_refresh(args: argparse.Namespace) -> None:
 
     Reads the MCP server config from the 3-scope yaml cascade (user-global
     / project / project-local), probes every server's tool list in parallel
-    with a per-server 5-second timeout, and writes the result atomically to
+    with a per-server timeout (``safety.timeout.mcp_probe_seconds``, default
+    5s — #3475), and writes the result atomically to
     ``.reyn/state/mcp_tools_cache.json``.  Per-server failures print a
     warning and write an empty list for that server (= same broken-server
     behavior as the session-side lazy probe).
@@ -1218,13 +1228,18 @@ def run_refresh(args: argparse.Namespace) -> None:
     """
     import asyncio
 
-    from reyn.config import _find_project_root
+    from reyn.config import load_config
     from reyn.runtime.services.mcp_cache_file import cache_file_path, write_cache
 
     if args.project:
         project_root: Path | None = Path(args.project).resolve()
     else:
         project_root = _get_project_root()
+
+    # #3475: same source of truth the session-side probe reads
+    # (`Session._safety.timeout.mcp_probe_seconds`) — one config value drives
+    # both the CLI's and the runtime's per-server probe timeout.
+    per_server_timeout = load_config(project_root).safety.timeout.mcp_probe_seconds
 
     entries = _all_servers_with_scope(project_root)
 
@@ -1245,7 +1260,7 @@ def run_refresh(args: argparse.Namespace) -> None:
 
     async def _probe_all() -> dict[str, list[dict]]:
         tasks = [
-            _probe_server_tools(name, cfg)
+            _probe_server_tools(name, cfg, per_server_timeout=per_server_timeout)
             for name, cfg in servers_flat.items()
         ]
         results = await asyncio.gather(*tasks)

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -14,11 +14,20 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
+from reyn.config.chat import TimeoutConfig
 from reyn.core.events.events import EventLog
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_STATE_DIR = Path(".reyn") / "state"
+
+# #3475: THE default for the MCP tools-list per-server probe timeout lives on
+# ``TimeoutConfig.mcp_probe_seconds`` (the config definition side, per #3461's
+# ``FileScopes`` precedent) — this module reads it rather than repeating the
+# literal, so it and ``interfaces/cli/commands/mcp.py``'s ``_probe_server_tools``
+# derive their own defaults from the SAME source instead of two independently
+# hardcoded ``5.0`` literals drifting apart.
+_DEFAULT_MCP_PROBE_SECONDS = TimeoutConfig().mcp_probe_seconds
 
 
 @dataclass(frozen=True)
@@ -1901,7 +1910,7 @@ class RouterHostAdapter:
         return result
 
     async def ensure_mcp_tools_cached(
-        self, *, per_server_timeout: float = 5.0,
+        self, *, per_server_timeout: float = _DEFAULT_MCP_PROBE_SECONDS,
     ) -> None:
         """Probe every configured MCP server's tool list and cache the
         results for the session lifetime.
@@ -1921,7 +1930,16 @@ class RouterHostAdapter:
         so a single slow / unreachable server does not block the others.
         Per-server timeout caps each probe; on timeout or exception the
         server is cached as an empty list (= still cached, so we don't
-        re-probe a known-broken server every turn).
+        re-probe a known-broken server every turn). #3475: that degradation
+        used to be silent — a server dropping out under co-located load left
+        no trace anywhere the operator could see. Each such case now emits an
+        `mcp_tool_probe_degraded` audit-event naming the server and the
+        reason (`timeout` / `exception`), so "this server is unreachable" is
+        an observation instead of an inference from a missing tool the model
+        never mentions. `per_server_timeout` (default `TimeoutConfig.
+        mcp_probe_seconds`, #3475) is operator-tunable via `safety.timeout.
+        mcp_probe_seconds` in reyn.yaml — the knob this audit-event tells the
+        operator to reach for.
 
         The result feeds `_get_mcp_servers_for_router` which is consumed
         by `_enumerate_category("mcp.tool")` (= list_actions visibility)
@@ -1969,8 +1987,25 @@ class RouterHostAdapter:
                 async with asyncio.timeout(per_server_timeout):
                     tools = await self.mcp_list_tools(server_name)
             except (TimeoutError, asyncio.TimeoutError):
+                # #3475: this server is cached as EMPTY for the rest of the
+                # session (no retry, by design — see the method docstring).
+                # Surface that decision — silence made the earlier #3475
+                # investigation depend on a fixture byte-diff to notice it.
+                self._events.emit(
+                    "mcp_tool_probe_degraded",
+                    server=server_name,
+                    reason="timeout",
+                    per_server_timeout=per_server_timeout,
+                )
                 return server_name, []
-            except Exception:  # noqa: BLE001 — adapter must never raise
+            except Exception as exc:  # noqa: BLE001 — adapter must never raise
+                self._events.emit(
+                    "mcp_tool_probe_degraded",
+                    server=server_name,
+                    reason="exception",
+                    per_server_timeout=per_server_timeout,
+                    detail=repr(exc),
+                )
                 return server_name, []
             # _mcp_list_tools may return [{"error": "..."}] on failure;
             # treat as empty so the cache shape stays uniform.

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -3217,7 +3217,9 @@ class Session:
         try:
             await self._router_host.maybe_refresh_mcp_tools_from_yaml()
             self._router_host.maybe_reload_mcp_tools_cache_from_disk()
-            await self._router_host.ensure_mcp_tools_cached()
+            await self._router_host.ensure_mcp_tools_cached(
+                per_server_timeout=self._safety.timeout.mcp_probe_seconds,
+            )
         except Exception as exc:  # noqa: BLE001
             logger.warning("refresh_mcp_servers: turn-boundary chain raised: %r", exc)
             snapshot_after = self._router_host.mcp_tools_cache_snapshot or {}
@@ -7517,7 +7519,9 @@ class Session:
         self._last_turn_chain_id = chain_id
         await self._router_host.maybe_refresh_mcp_tools_from_yaml()
         self._router_host.maybe_reload_mcp_tools_cache_from_disk()
-        await self._router_host.ensure_mcp_tools_cached()
+        await self._router_host.ensure_mcp_tools_cached(
+            per_server_timeout=self._safety.timeout.mcp_probe_seconds,
+        )
         with active_turn(chain_id):
             await self._loop_driver.run_turn(user_text, chain_id)
         # #1800 slice 5a: emit HERE (after `run_turn()` returns), not inside RouterLoop — the

--- a/tests/test_3475_probe_degradation_visibility_and_timeout_config.py
+++ b/tests/test_3475_probe_degradation_visibility_and_timeout_config.py
@@ -1,0 +1,311 @@
+"""Tier 2/1: #3475 (remaining half) — probe-degradation visibility + `per_server_timeout`
+config-isation.
+
+The turn-kind priming gap (#3475's first half) landed in PR #3499. This file covers the
+owner-decided remainder (see the issue's final two comments): `ensure_mcp_tools_cached`'s
+`_probe_one` used to cache a timed-out/broken MCP server as an empty tool list for the
+session's entire life and say NOTHING about it — an operator could only notice via a
+fixture byte-diff, as #3475's own investigation did. The owner's decision was BOTH of:
+
+  C — surface the degradation as an `mcp_tool_probe_degraded` audit-event naming the
+      server and the reason (`timeout` / `exception`).
+  config-isation — the two independently-hardcoded `per_server_timeout: float = 5.0`
+      defaults (`router_host_adapter.py`'s `ensure_mcp_tools_cached` and
+      `interfaces/cli/commands/mcp.py`'s `_probe_server_tools`) now derive from ONE
+      source: `TimeoutConfig.mcp_probe_seconds` (`safety.timeout.mcp_probe_seconds` in
+      reyn.yaml), default unchanged at 5.0.
+
+Because C alone tells the operator "you're losing" but not how to fix it, and the config
+knob alone lets them fix a problem they cannot notice, the owner required both in one PR
+(see the issue's last two comments — "C対応必須だし、5.0 ハードコードは修正必要").
+
+No unittest.mock/AsyncMock/MagicMock/patch anywhere in this file. The Session-level tests
+use the SAME real-callable-override technique `tests/test_mcp_lazy_tools_cache.py` and
+`tests/test_3475_mcp_probe_priming_all_turn_kinds.py` already use (instance-attribute
+assignment of a plain async function onto `router_host.mcp_list_tools`) — not a mock.
+
+The single most important property asserted here is NOT "the mechanism ran" — it is what
+the operator/LLM actually receives: the literal audit-event payload
+(`event.type`, `event.data["server"]`, `event.data["reason"]`) an operator reading
+`.reyn/events` (or `router_host.events.all()`, its in-memory mirror) would see, and the
+literal wall-clock behaviour change (timeout fires or doesn't) a non-default config value
+produces. #3512's strip-D arm went GREEN because every witness there was "a function was
+called", never "the string a consumer reads" — this file assigns the audit-event's own
+field values, not a call count, and it drives a NON-default config value end to end
+(a probe that would only time out under the CONFIGURED value, not under the still-live
+5.0 default) so a dead wiring shows up as a wrong RESULT, not merely an uncalled path.
+
+strip-falsify (recorded here, executed manually before landing):
+  - Visibility: revert the two `self._events.emit("mcp_tool_probe_degraded", ...)` calls
+    in `_probe_one` back to a bare `return server_name, []` → RED (no event of that type).
+  - Config wiring: revert `Session._handle_user_message` / `Session._run_router_loop` to
+    call `ensure_mcp_tools_cached()` with no `per_server_timeout=` kwarg → RED (the 0.05s
+    configured value never reaches the probe, the 5.0s default absorbs the 0.2s sleep, the
+    server is NOT cached empty, and `test_session_threads_configured_probe_timeout...`
+    fails on the "cached empty" assertion).
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+
+from reyn.config import SafetyConfig, TimeoutConfig
+from reyn.core.events.event_schema import AUDIT_EVENT_KINDS
+from reyn.core.events.state_log import StateLog
+from tests._support.agent_session import make_session
+
+_REPO = Path(__file__).resolve().parents[1]
+_ROUTER_HOST_ADAPTER = _REPO / "src" / "reyn" / "runtime" / "services" / "router_host_adapter.py"
+_MCP_CLI = _REPO / "src" / "reyn" / "interfaces" / "cli" / "commands" / "mcp.py"
+_CHAT_CONFIG = _REPO / "src" / "reyn" / "config" / "chat.py"
+
+
+# ── 1. Config contract — `safety.timeout.mcp_probe_seconds` parses (Tier 1) ────────────
+
+
+def test_mcp_probe_seconds_default_and_nondefault_parse():
+    """Tier 1: `TimeoutConfig.mcp_probe_seconds` defaults to 5.0 (unchanged — this is a
+    knob, not a default-raise) and `_build_safety_config` round-trips a non-default
+    operator value from the `safety.timeout:` yaml section."""
+    from reyn.config.chat import _build_safety_config
+
+    assert TimeoutConfig().mcp_probe_seconds == 5.0
+    assert SafetyConfig().timeout.mcp_probe_seconds == 5.0
+
+    built_default = _build_safety_config({})
+    assert built_default.timeout.mcp_probe_seconds == 5.0
+
+    built = _build_safety_config({"timeout": {"mcp_probe_seconds": 12.5}})
+    assert built.timeout.mcp_probe_seconds == 12.5, (
+        "a non-default safety.timeout.mcp_probe_seconds must round-trip through "
+        "_build_safety_config — testing with 5.0 itself would stay green even if "
+        "the key were never read"
+    )
+
+
+# ── 2. `mcp_tool_probe_degraded` is a declared audit-event kind (Tier 1) ───────────────
+
+
+def test_mcp_tool_probe_degraded_is_a_declared_kind():
+    """Tier 1: the new audit-event kind is in the closed vocabulary (#3410) —
+    tests/test_audit_event_kind_vocabulary_3410.py additionally checks the doc mirror
+    and that every declared kind has a real emit site."""
+    assert "mcp_tool_probe_degraded" in AUDIT_EVENT_KINDS
+
+
+# ── 3. Session-level: non-default config value actually bounds the probe,          ────
+#        AND the degradation is visible on the real EventLog (Tier 2)              ────
+
+
+def _make_probe_session(tmp_path: Path, *, mcp_probe_seconds: float, probe_cb):
+    server = "flaky_server"
+    session = make_session(
+        agent_name="fp3475-probe-agent",
+        mcp_servers={server: {"description": "flaky"}},
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snapshot.json",
+        safety=SafetyConfig(timeout=TimeoutConfig(mcp_probe_seconds=mcp_probe_seconds)),
+    )
+    # Real-callable override (same technique as test_mcp_lazy_tools_cache.py /
+    # test_3475_mcp_probe_priming_all_turn_kinds.py) — not a mock.
+    session.router_host.mcp_list_tools = probe_cb
+    return session, server
+
+
+async def _drive_first_turn(session) -> None:
+    """Route one turn through the real turn-kind seam (`_run_router_loop`) without
+    invoking an actual LLM call — mirrors test_3475_mcp_probe_priming_all_turn_kinds.py's
+    `_install_snapshot_capturing_run_turn`, since this file's subject is the priming
+    chain's ARGUMENTS (per_server_timeout) and its side effects (audit-events), not
+    RouterLoop's own internals."""
+    async def _noop_run_turn(user_text: str, chain_id: str) -> None:
+        return None
+
+    session._loop_driver.run_turn = _noop_run_turn
+    await session.submit_agent_request(
+        from_agent="peer", request="hello", depth=1, chain_id="chain-3475",
+    )
+    await session.run_one_iteration()
+
+
+@pytest.mark.asyncio
+async def test_session_threads_configured_probe_timeout_into_the_real_probe(tmp_path: Path):
+    """Tier 2: (LOAD-BEARING) `safety.timeout.mcp_probe_seconds` set to a NON-default,
+    short value (0.05s) must reach `ensure_mcp_tools_cached`'s `per_server_timeout` —
+    the round-trip is witnessed by a probe that sleeps 0.2s: that sleep exceeds the
+    CONFIGURED 0.05s but not the unchanged 5.0s default, so a wired path times out
+    (server cached empty) and a dead path (still passing the 5.0s default) would NOT —
+    the test fails on a wrong RESULT, not merely on an uncalled function, if the wiring
+    from Session._safety.timeout.mcp_probe_seconds regresses."""
+    old_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        async def _slow_probe(server_name: str) -> list[dict]:
+            await asyncio.sleep(0.2)
+            return [{"name": "should_not_appear", "description": ""}]
+
+        session, server = _make_probe_session(
+            tmp_path, mcp_probe_seconds=0.05, probe_cb=_slow_probe,
+        )
+        await _drive_first_turn(session)
+
+        snapshot = session.router_host.mcp_tools_cache_snapshot
+        assert snapshot is not None, "priming must have run for the first turn"
+        assert snapshot[server] == [], (
+            "expected the configured 0.05s per_server_timeout to time out the "
+            "0.2s-sleeping probe; a non-empty result means the 0.05s value never "
+            "reached ensure_mcp_tools_cached and the unwired 5.0s default absorbed "
+            "the sleep instead"
+        )
+    finally:
+        os.chdir(old_cwd)
+
+
+@pytest.mark.asyncio
+async def test_probe_timeout_emits_visible_degradation_event(tmp_path: Path):
+    """Tier 2: (LOAD-BEARING) a probe that times out under the configured budget emits
+    `mcp_tool_probe_degraded` on the session's real EventLog, naming the server and
+    `reason="timeout"` — the literal payload an operator reading `.reyn/events` sees,
+    not merely evidence that some emit call happened."""
+    old_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        async def _slow_probe(server_name: str) -> list[dict]:
+            await asyncio.sleep(0.2)
+            return [{"name": "x", "description": ""}]
+
+        session, server = _make_probe_session(
+            tmp_path, mcp_probe_seconds=0.05, probe_cb=_slow_probe,
+        )
+        await _drive_first_turn(session)
+
+        degradations = [
+            e for e in session.router_host.events.all()
+            if e.type == "mcp_tool_probe_degraded"
+        ]
+        assert len(degradations) >= 1, (
+            "no mcp_tool_probe_degraded event was emitted — the probe timeout is "
+            "silent again"
+        )
+        event = degradations[0]
+        assert event.data["server"] == server
+        assert event.data["reason"] == "timeout"
+        assert event.data["per_server_timeout"] == 0.05, (
+            "the event should name the ACTUAL timeout budget in force, not a "
+            "hardcoded literal"
+        )
+    finally:
+        os.chdir(old_cwd)
+
+
+@pytest.mark.asyncio
+async def test_probe_exception_emits_visible_degradation_event(tmp_path: Path):
+    """Tier 2: a probe that raises (broken server, not merely slow) also emits
+    `mcp_tool_probe_degraded`, with `reason="exception"` and a `detail` naming the
+    error — independent of the configured timeout value (default budget here)."""
+    old_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        async def _broken_probe(server_name: str) -> list[dict]:
+            raise RuntimeError("connection refused")
+
+        session, server = _make_probe_session(
+            tmp_path, mcp_probe_seconds=TimeoutConfig().mcp_probe_seconds,
+            probe_cb=_broken_probe,
+        )
+        await _drive_first_turn(session)
+
+        degradations = [
+            e for e in session.router_host.events.all()
+            if e.type == "mcp_tool_probe_degraded"
+        ]
+        assert len(degradations) >= 1
+        event = degradations[0]
+        assert event.data["server"] == server
+        assert event.data["reason"] == "exception"
+        assert "connection refused" in event.data.get("detail", ""), (
+            f"expected the underlying error in `detail`, got {event.data!r}"
+        )
+    finally:
+        os.chdir(old_cwd)
+
+
+# ── 4. AST completeness — exactly ONE literal 5.0 default, the other two derive ────
+#        from it (Tier 2) ──────────────────────────────────────────────────────────
+
+
+def _kwonly_default_node(tree: ast.Module, func_name: str, param_name: str) -> ast.expr | None:
+    """Return the AST default expression for `param_name` (a kwonly arg) of the
+    (sole) function/async-function named `func_name` in `tree`."""
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
+            names = [a.arg for a in node.args.kwonlyargs]
+            defaults = node.args.kw_defaults
+            for name, default in zip(names, defaults):
+                if name == param_name:
+                    return default
+    return None
+
+
+def _is_float_literal_5(node: ast.expr | None, value: float = 5.0) -> bool:
+    return (
+        isinstance(node, ast.Constant)
+        and isinstance(node.value, (int, float))
+        and float(node.value) == value
+    )
+
+
+def _dataclass_field_default(tree: ast.Module, class_name: str, field_name: str) -> ast.expr | None:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for stmt in node.body:
+                if (
+                    isinstance(stmt, ast.AnnAssign)
+                    and isinstance(stmt.target, ast.Name)
+                    and stmt.target.id == field_name
+                    and stmt.value is not None
+                ):
+                    return stmt.value
+    return None
+
+
+def test_per_server_timeout_derives_from_a_single_5_0_source():
+    """Tier 2: (LOAD-BEARING, AST — not regex, since a regex for `5.0` catches
+    docstring/comment mentions of the number as false positives) exactly ONE literal
+    `5.0` default exists across the three sites this feature touches:
+    `TimeoutConfig.mcp_probe_seconds` (the config definition — #3461's `FileScopes`
+    precedent: the default lives on the schema, not hidden in a resolver's
+    `__init__`). `RouterHostAdapter.ensure_mcp_tools_cached`'s `per_server_timeout`
+    and `interfaces/cli/commands/mcp.py`'s `_probe_server_tools`'s `per_server_timeout`
+    must NOT independently repeat the literal — both derive their default from the
+    `TimeoutConfig` field so raising the one number is the only edit needed."""
+    chat_tree = ast.parse(_CHAT_CONFIG.read_text(encoding="utf-8"))
+    adapter_tree = ast.parse(_ROUTER_HOST_ADAPTER.read_text(encoding="utf-8"))
+    cli_tree = ast.parse(_MCP_CLI.read_text(encoding="utf-8"))
+
+    config_default = _dataclass_field_default(chat_tree, "TimeoutConfig", "mcp_probe_seconds")
+    assert config_default is not None, "TimeoutConfig.mcp_probe_seconds field not found"
+    assert _is_float_literal_5(config_default), (
+        "the canonical default must live on TimeoutConfig.mcp_probe_seconds as the "
+        "literal 5.0 — found something else"
+    )
+
+    adapter_default = _kwonly_default_node(
+        adapter_tree, "ensure_mcp_tools_cached", "per_server_timeout",
+    )
+    assert adapter_default is not None, "ensure_mcp_tools_cached.per_server_timeout not found"
+    assert not _is_float_literal_5(adapter_default), (
+        "ensure_mcp_tools_cached's per_server_timeout default must NOT independently "
+        "hardcode 5.0 — it must derive from TimeoutConfig.mcp_probe_seconds instead"
+    )
+
+    cli_default = _kwonly_default_node(cli_tree, "_probe_server_tools", "per_server_timeout")
+    assert cli_default is not None, "_probe_server_tools.per_server_timeout not found"
+    assert not _is_float_literal_5(cli_default), (
+        "_probe_server_tools's per_server_timeout default must NOT independently "
+        "hardcode 5.0 — it must derive from TimeoutConfig.mcp_probe_seconds instead"
+    )

--- a/tests/test_mcp_refresh_cli.py
+++ b/tests/test_mcp_refresh_cli.py
@@ -223,3 +223,50 @@ def test_refresh_uses_atomic_write(tmp_path: Path, monkeypatch) -> None:
         ".tmp sibling file must not linger after a successful write"
     )
     assert cache_path.exists(), "cache file must exist after successful write"
+
+
+# ---------------------------------------------------------------------------
+# 6. #3475: `safety.timeout.mcp_probe_seconds` threads into `_probe_server_tools`
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_uses_configured_mcp_probe_seconds(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: (LOAD-BEARING) `run_refresh` reads `safety.timeout.mcp_probe_seconds`
+    via the REAL config loader (`reyn.config.load_config`, not stubbed) and threads
+    the actual configured value into `_probe_server_tools`'s `per_server_timeout`
+    kwarg — the CLI side of #3475's "one source for both hardcoded 5.0 sites"
+    requirement (the runtime side is `Session._safety.timeout.mcp_probe_seconds`,
+    covered in tests/test_3475_probe_degradation_visibility_and_timeout_config.py).
+    Uses 9.5 (NOT the unchanged 5.0 default) — testing with the default value would
+    stay green even if this wiring were dead."""
+    import reyn.interfaces.cli.commands.mcp as mcp_cmd
+
+    project_root = tmp_path / "proj_timeout"
+    project_root.mkdir()
+    (project_root / "reyn.yaml").write_text(
+        "safety:\n  timeout:\n    mcp_probe_seconds: 9.5\n",
+        encoding="utf-8",
+    )
+
+    recorded: list[float] = []
+
+    async def _recording_probe(server_name, cfg, *, per_server_timeout=5.0):
+        recorded.append(per_server_timeout)
+        return server_name, []
+
+    monkeypatch.setattr(mcp_cmd, "_probe_server_tools", _recording_probe)
+    monkeypatch.setattr(
+        mcp_cmd,
+        "_all_servers_with_scope",
+        lambda root: [("s", "project", {"type": "stdio"})],
+    )
+    monkeypatch.setattr(mcp_cmd, "_get_project_root", lambda: project_root)
+
+    import argparse
+    ns = argparse.Namespace(project=None, func=mcp_cmd.run_refresh)
+    mcp_cmd.run_refresh(ns)
+
+    assert recorded == [9.5], (
+        "expected _probe_server_tools to be called with the configured "
+        f"per_server_timeout=9.5, got {recorded!r}"
+    )


### PR DESCRIPTION
**[per-PR-coder]** — remaining half of #3475 (turn-kind priming landed in #3499). Owner decision (issue's last two comments): C (surface the degradation) is required, AND the hardcoded `per_server_timeout=5.0` must become an operator-adjustable config, default unchanged. Both are in this PR — visibility alone tells the operator "you're losing" but not how to fix it; a knob alone lets them fix a problem they cannot notice.

Closes #3475 — the remaining half (the turn-kind-priming half landed as #3499, merged).


## What changed

**C — surface the degradation.** `ensure_mcp_tools_cached`'s `_probe_one` (`src/reyn/runtime/services/router_host_adapter.py`) used to do `except (TimeoutError, ...): return server_name, []` / `except Exception: return server_name, []` — caching a broken/slow MCP server as an empty tool list for the session's entire life, silently. Each branch now also emits an `mcp_tool_probe_degraded` audit-event naming the server, the reason (`timeout` / `exception`), the timeout budget in force, and (for exceptions) the error detail.

**Config-isation.** `per_server_timeout` was hardcoded `5.0` independently in two places:
- `router_host_adapter.py`'s `ensure_mcp_tools_cached`
- `interfaces/cli/commands/mcp.py`'s `_probe_server_tools`

Both now default from `TimeoutConfig.mcp_probe_seconds` (new field, default unchanged at `5.0`), configurable as `safety.timeout.mcp_probe_seconds` in reyn.yaml. `Session`'s two `ensure_mcp_tools_cached()` call sites now pass `per_server_timeout=self._safety.timeout.mcp_probe_seconds`; the CLI's `run_refresh` now calls `load_config(project_root).safety.timeout.mcp_probe_seconds` and threads it into `_probe_server_tools`.

**Why `safety.timeout.mcp_probe_seconds` and not a new top-level key**: `safety.timeout` is the existing "wall-clock bounds" namespace (`llm_call_seconds`, `chain_seconds`) — this is the same kind of limit (a probe taking too long), and it keeps the setting under the block operators already look in rather than introducing a second config surface for a similar concept. The yaml key is `mcp_probe_seconds`, not the implementation-internal `per_server_timeout` — the config surface names the concept from the operator's side (probing MCP servers), not the parameter name a specific function happens to use internally.

## 1. Before/after — what the operator/LLM actually receives

Before: a server timing out or throwing during probe left **zero trace** anywhere — `#3475`'s own investigation only discovered this class of bug via a fixture byte-diff.

After, reading `router_host.events.all()` (the in-memory mirror of what lands in `.reyn/events`) after a probe degrades:
```
Event(type="mcp_tool_probe_degraded", data={
    "server": "flaky_server",
    "reason": "timeout",
    "per_server_timeout": 0.05,
})
```
or, for a probe that raised:
```
Event(type="mcp_tool_probe_degraded", data={
    "server": "flaky_server",
    "reason": "exception",
    "per_server_timeout": 5.0,
    "detail": "RuntimeError('connection refused')",
})
```
`mcp_tool_probe_degraded` is declared in the closed audit-event vocabulary (`AUDIT_EVENT_KINDS`, `src/reyn/core/events/event_schema.py`) and documented in `docs/reference/runtime/events.md`; `tests/test_audit_event_kind_vocabulary_3410.py` (10 tests) passes, confirming the declaration/producer/doc triad.

**NarrowingOrigin / attribute_deny (#3512) — measured, not adopted**: I checked whether the degradation could ride #3512's `NarrowingOrigin(label, cause, lifts_when)` + `attribute_deny()` surface instead of/in addition to a fresh audit-event. It doesn't fit: that mechanism narrates *permission narrowing* — a capability the agent's envelope authorized getting excluded by a `CapabilityProfile`/`ContextualPermission` composition (`src/reyn/security/permissions/effective.py`, `src/reyn/runtime/capability_visibility.py`). The probe-degradation case has no permission decision anywhere in it — the tool's enum entry never existed because the probe that would populate it failed; there is nothing being denied for a `NarrowingOrigin` to attribute. A dedicated audit-event is the right surface (mirrors `#3467`'s `limit_denied` shape, and `mcp_install_probe_failed` is the nearest existing sibling kind — different call site, same "a probe failed" shape).

## 2. Non-default config round-trip (the dead-wiring-proof witness)

`tests/test_3475_probe_degradation_visibility_and_timeout_config.py::test_session_threads_configured_probe_timeout_into_the_real_probe` sets `safety.timeout.mcp_probe_seconds=0.05` (NOT the unchanged `5.0` default) and drives a real `Session` turn against a probe that sleeps `0.2s`. `0.2s` exceeds the configured `0.05s` but not the still-live `5.0s` default, so the test asserts the server is cached **empty** (timed out) — a dead wiring (still passing the `5.0` default) would leave the tool present instead, failing on a wrong *result*, not merely an uncalled path.

`tests/test_mcp_refresh_cli.py::test_refresh_uses_configured_mcp_probe_seconds` does the CLI-side equivalent: writes `safety.timeout.mcp_probe_seconds: 9.5` into a real `reyn.yaml`, runs `run_refresh` through the real config loader, and asserts `_probe_server_tools` was actually called with `per_server_timeout=9.5`.

## 3. AST confirmation — one source for both `5.0` sites

`tests/test_3475_probe_degradation_visibility_and_timeout_config.py::test_per_server_timeout_derives_from_a_single_5_0_source` parses (not regex — a regex for `5.0` would false-positive on docstrings/comments) `config/chat.py`, `router_host_adapter.py`, `interfaces/cli/commands/mcp.py` and asserts:
- `TimeoutConfig.mcp_probe_seconds`'s dataclass-field default **is** the literal `5.0` (the one canonical source).
- `ensure_mcp_tools_cached`'s and `_probe_server_tools`'s `per_server_timeout` kwonly defaults are **NOT** independently-hardcoded `5.0` literals (both are `_DEFAULT_MCP_PROBE_SECONDS = TimeoutConfig().mcp_probe_seconds` module constants instead).

## 4. Strip-falsify RED evidence (executed manually, restored before push)

| Strip | Result |
|---|---|
| Revert both `_probe_one` emit calls to bare `return server_name, []` | `test_probe_timeout_emits_visible_degradation_event` and `test_probe_exception_emits_visible_degradation_event` → **RED** (`0 >= 1` — no event) |
| Revert `Session`'s two call sites to `ensure_mcp_tools_cached()` (no `per_server_timeout=` kwarg) | `test_session_threads_configured_probe_timeout_into_the_real_probe` → **RED** (server not cached empty — the 5.0s default absorbed the 0.2s sleep); `test_probe_timeout_emits_visible_degradation_event` → **RED** too (same reason, no timeout fires) |
| Revert `run_refresh`'s `_probe_all` to call `_probe_server_tools(name, cfg)` (drop `per_server_timeout=`) | `test_refresh_uses_configured_mcp_probe_seconds` → **RED** (`[5.0] != [9.5]`) |
| Revert `ensure_mcp_tools_cached`'s default back to a literal `5.0` | `test_per_server_timeout_derives_from_a_single_5_0_source` → **RED** |

All four reverts restored cleanly afterward (`git diff` empty against the committed tree post-restore).

## 5. Four gates (separately, rebased onto current `origin/main` / `d8ab05c32`)

- `ruff check src tests` → **All checks passed**
- `python scripts/test_tier_audit.py --strict tests/test_3475_probe_degradation_visibility_and_timeout_config.py tests/test_mcp_refresh_cli.py` → **12 inspected, 0 errors, 0 warnings**
- `python scripts/verify_module_docstrings.py <the 5 changed src files>` → **OK**
- `pytest -q -n auto` (repo root) → **9733 passed, 36 skipped, 0 failed in 202.39s**

**On the full-suite number**: an earlier run (same rebased tree, before I added the `reyn.local.yaml.example` / `docs/reference/config/reyn-yaml.md` mirror entries) reported `5 failed, 9728 passed in 991s`, run concurrently with other active sessions. Two of the five (`test_config_mirror_coverage_1056.py`'s two tests) were a real defect in my own diff — a new `ReynConfig` field must be mirrored in the example/reference doc-completeness gate — fixed in this PR (now green). The other three (`test_2761_pr3_mcp_immediate_probe.py`, `test_fp0063_arc_witness.py`, `test_3310_n2_reset_hydrate.py`) do not touch `mcp_servers`/`ensure_mcp_tools_cached`/`per_server_timeout` in any assertion-relevant way (checked by grep — neither `test_2761...` nor `test_3310...` configures MCP servers at all, so my `Session` diff is inert on their code path), and both pass standalone. The clean rerun above collected the **same 9733 tests** (9728 + 5 = 9733, exact match — nothing vanished) at **202s vs 991s** (~5x less wall-clock contention, run solo) with **0 failures** — the same-collection-count + no-contention + all-green combination is evidence against a test-side defect in those three, stronger than a solo pass alone would be (a solo pass is also consistent with "only reproduces under contention"; a full-suite all-green at the same collected count is not consistent with a deterministic defect in those three).

## Closing-keyword sibling check

`gh pr list --state all --search "3475 in:body" --json number,title,state,url` → three hits: #3499 (MERGED, the turn-kind-priming half), and two unrelated PRs whose bodies happen to contain the substring `3475` incidentally (#3478, #3477 — neither mentions issue #3475 as their subject). No open PR declares non-closing intent for #3475.

## Test plan

- [x] `pytest tests/test_3475_probe_degradation_visibility_and_timeout_config.py tests/test_mcp_refresh_cli.py tests/test_mcp_lazy_tools_cache.py tests/test_3475_mcp_probe_priming_all_turn_kinds.py tests/test_config_mirror_coverage_1056.py tests/test_audit_event_kind_vocabulary_3410.py` — all green
- [x] Full `pytest -q -n auto` — 9733 passed, 36 skipped, 0 failed
- [x] All 4 CI gates green locally (see §5)
- [x] Strip-falsify RED confirmed for both deliverables + the AST gate, then restored

