### PR TITLE
test(fp0063): make the arc witness's machine-global base dir single-occupant — #3473

### DIFF
--- a/tests/test_fp0063_arc_witness.py
+++ b/tests/test_fp0063_arc_witness.py
@@ -518,6 +518,54 @@ async def _drive_one_turn(registry, prompt: str, timeout: float) -> str:
 # ---------------------------------------------------------------------------
 
 
+#: The arc's base dir. FIXED and hardcoded (NOT ``tmp_path``) on purpose: its
+#: STRING form is baked into the committed LLMReplay fixture -- both into the
+#: hashed key and into the replayed tool-call ARGUMENTS the runtime actually
+#: acts on (turn 2's ``run_pipeline`` input paths come back OUT of the fixture),
+#: so a per-run unique dir would need the fixture re-recorded on every run. See
+#: the test's own docstring for the two-part portability rationale.
+_ARC_BASE_DIR = Path("/tmp/reyn_fp0063_arc_witness_dir")  # noqa: S108 -- see above
+_ARC_LOCK_PATH = Path("/tmp/reyn_fp0063_arc_witness_dir.lock")  # noqa: S108
+
+
+@pytest.fixture
+def arc_base_dir():
+    """#3473: hand the test its base dir under a cross-process EXCLUSIVE lock.
+
+    ``_ARC_BASE_DIR`` is machine-global and the test wipes it on entry, so two
+    concurrent instances of THIS test -- a co-located suite in another worktree,
+    two CI jobs sharing a runner, a standalone run beside a full ``-n auto``
+    suite -- were not merely racing, they were deleting each other's live tree
+    (including the process CWD the test chdir's into). Measured on #3473: the
+    reported symptom, ``FileNotFoundError: '.reyn/agents/operator/state/
+    sessions/<sid>/history.jsonl'`` (a RELATIVE path -- the CWD anchor itself
+    was gone), reproduced only in the arm whose co-located load suite ALSO ran
+    this file, and never in the arm that excluded it; two bare concurrent runs
+    reproduce it in seconds as ``FileExistsError`` on the ``mkdir`` below.
+
+    The lock is mutual EXCLUSION, not a wait-and-hope: a second instance cannot
+    enter the directory at all until the first has left it, so interleaving is
+    structurally impossible rather than unlikely. (A sleep/retry here would only
+    have made "usually makes it in time" into "makes it in time more often" --
+    the shape #3473 explicitly rules out.) ``flock`` is advisory but every
+    participant is this same fixture, which is what makes advisory sufficient.
+    """
+    import fcntl
+    import shutil
+
+    fd = os.open(_ARC_LOCK_PATH, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        # Wiped + recreated so each run starts clean -- safe to do destructively
+        # ONLY because the lock above guarantees no peer is inside it right now.
+        shutil.rmtree(_ARC_BASE_DIR, ignore_errors=True)
+        _ARC_BASE_DIR.mkdir(parents=True)
+        yield _ARC_BASE_DIR
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
 def _install_key_normalizer(monkeypatch: pytest.MonkeyPatch, base_dir: Path) -> None:
     """Make ``LLMReplay.key`` base-dir-INDEPENDENT for this run.
 
@@ -568,7 +616,7 @@ def _install_key_normalizer(monkeypatch: pytest.MonkeyPatch, base_dir: Path) -> 
 
 @pytest.mark.asyncio
 async def test_llm_driven_install_ingest_query_arc_reaches_the_ingested_chunk(
-    monkeypatch: pytest.MonkeyPatch, out_of_process_reyn: str,
+    monkeypatch: pytest.MonkeyPatch, out_of_process_reyn: str, arc_base_dir: Path,
 ) -> None:
     """Tier 3a: an LLM (replayed via LLMReplay at the real litellm.acompletion
     boundary) drives install_plugin -> run_pipeline(rag_ingest.ingest)
@@ -615,20 +663,15 @@ async def test_llm_driven_install_ingest_query_arc_reaches_the_ingested_chunk(
          forms to a sentinel before the hash.
 
     Together the committed key contains no machine- or OS-specific absolute path
-    at all. (A hardcoded ``/tmp`` subdir carries a tiny collision risk under
-    parallel runners, mitigated by the wipe-and-recreate below + the unique
-    dirname; this single test uses it and runs once.)"""
+    at all. The price is that ``_ARC_BASE_DIR`` is a MACHINE-GLOBAL, fixed path
+    that this test wipes on entry -- so it is a shared mutable resource, and the
+    ``arc_base_dir`` fixture's exclusive lock (see its docstring, #3473) is what
+    makes concurrent occupancy structurally impossible rather than merely
+    unlikely."""
     import reyn.core.op_runtime.embed as embed_mod
     from reyn.runtime.services.router_host_adapter import RouterHostAdapter
 
-    # A FIXED, hardcoded /tmp base -- byte-identical STRING on macOS and Linux
-    # (unlike ``tempfile.gettempdir()``, whose value is OS-specific and was the
-    # first cut's CI-RED cause). Wiped + recreated so each run starts clean.
-    tmp_path = Path("/tmp/reyn_fp0063_arc_witness_dir")  # noqa: S108 -- see docstring
-    import shutil
-
-    shutil.rmtree(tmp_path, ignore_errors=True)
-    tmp_path.mkdir(parents=True)
+    tmp_path = arc_base_dir
 
     _install_key_normalizer(monkeypatch, tmp_path)
 


### PR DESCRIPTION
**[per-PR-coder]** — part of #3473. Stage-1 judgment + the fix for the face this PR closes.

## Stage-1 answer: **(a)** — the ordering guarantee already exists; the failure has another cause

> *Does production need an ordering guarantee between the writer that creates `.../sessions/<sid>/history.jsonl` and the reader that reaches `session.py`'s read path?*

**It already has one, and it is structural.** Call paths traced:

- **Creator**: `AgentRegistry.spawn_session` (`src/reyn/runtime/registry.py:2718-2722`) re-keys `session.history_path` to `<state>/sessions/<enc(sid)>/history.jsonl` and calls `history_path.parent.mkdir(parents=True, exist_ok=True)` **synchronously**, before the session is inserted into `self._sessions` and before any turn can be submitted. Every programmatic spawn funnels through it (`spawn_session_recorded` → `spawn_ephemeral_session` / `_spawn_pipeline_driver_session`).
- **Writer**: `Session._append_history` (`session.py:2619`) — `history_path.open("a")`, no mkdir (the comment at registry.py:2719 states the invariant).
- **Reader**: `Session.load_history` (`session.py:2997`) is already `exists()`-guarded, and `registry.py:905/927` are `is_file()`-guarded. **No reader can raise this.**

`open("a")` raises `FileNotFoundError` only when the **parent directory is missing**. So the reported error is not a read at all — it is a **write-after-delete**.

## What actually deleted it — measured, not inferred

The reported path is **relative**: `.reyn/agents/operator/state/sessions/<sid>/history.jsonl`. My reproduction shows the whole chain gone, up to and including the CWD anchor:

```
FileNotFoundError: [Errno 2] No such file or directory: '.reyn/agents/operator'
FileNotFoundError: [Errno 2] No such file or directory: '.reyn/agents'
FileNotFoundError: [Errno 2] No such file or directory: '.reyn'
```

Cause: the test pins a **machine-global** base dir and wipes it on entry —

```python
tmp_path = Path("/tmp/reyn_fp0063_arc_witness_dir")
shutil.rmtree(tmp_path, ignore_errors=True); tmp_path.mkdir(parents=True)
...
monkeypatch.chdir(project_root)   # project_root is inside that dir
```

so a second instance of **this same test** deletes the first one's live tree, CWD included. (The docstring's own claim — "a tiny collision risk under parallel runners, **mitigated by the wipe-and-recreate below**" — had it backwards: the wipe *is* the damage.)

### Attribution measurement (two arms, same load level, load avg 14-25)

| arm | co-located `-n auto` suite | arc-test result | faces observed |
|---|---|---|---|
| A | full suite **including** this file | **4/10 failed** | `FileNotFoundError` on `.reyn/...` **AND** `MissingFixture` |
| B | full suite **excluding** this file (`--ignore`) | **3/9 failed** | `MissingFixture` **only — 0 occurrences of the `.reyn` face** |

Run 6 of arm A reproduces the issue's symptom verbatim:
`FileNotFoundError: '.reyn/agents/operator/state/sessions/98daddc9/history.jsonl'`, raised from `_append_history`.

**Bare 2-process RED witness** (quiet machine, no other load): `FileExistsError: [Errno 17] File exists: '/tmp/reyn_fp0063_arc_witness_dir'` in 4.8s. This is also the root cause of tui-coder's "6-parallel → 17/18 failed with `FileExistsError: agent 'operator' already exists`" — the same shared tree, one level deeper.

## The fix

An `arc_base_dir` fixture holding a **cross-process exclusive `flock`** for the test's duration. This is mutual exclusion, not a wait-and-hope: a peer cannot be inside the directory at all, so interleaving is **structurally impossible** rather than unlikely. No sleep, no retry, no timeout bump — the shape #3473 rules out would only have turned "usually makes it in time" into "makes it in time more often".

The falsified docstring paragraph is rewritten in the same change (doc-drift rule).

### Strip-falsify

| | 2 concurrent instances | 6 concurrent instances |
|---|---|---|
| **before** (= guard stripped) | `FileExistsError`, 1 of 2 dead in 4.8s | tui-coder: 17/18 failed |
| **after** | 2/2 pass (2 trials, 4/4) | **6/6 pass**, serialized (6/12/17/22/27/32s) |

## ⚠️ A SECOND face remains open — filed separately, NOT fixed here

`MissingFixture: No fixture entry for model='gemini/gemini-2.5-flash-lite'` is a **different defect with a different cause**, and it is the one that survives arm B. Root cause established with primary evidence:

I dumped the exact `LLMReplay.key` inputs from a GREEN run and from a RED run. **The only difference in the entire payload** is that the `call_mcp_tool` / `describe_mcp_tool` tool schemas lose their enum:

```diff
       "mcp_tool_name": {
-       "enum": ["reyn_markitdown.convert_to_markdown"],
```

That enum comes from `RouterHostAdapter.ensure_mcp_tools_cached`, whose per-server probe has a 5s deadline (`safety.timeout.mcp_probe_seconds`); a server slower than that is cached as **empty for the session's lifetime, with no retry** (#3475 made it emit `mcp_tool_probe_degraded`). Under co-located load the markitdown stub server exceeds it → the enum vanishes → the `tools=` payload differs → the fixture key misses.

**Deterministic RED**: passing `safety=SafetyConfig(timeout=TimeoutConfig(mcp_probe_seconds=0.001))` into this test's session factory reproduces the identical `MissingFixture` on a quiet machine in 2.06s.

**Cheap natural reproducer**: `pytest tests/test_fp0063_arc_witness.py tests/test_fp0063_p3_rag_pipelines.py tests/test_fp0063_p4_builtin_rag_skill.py -n auto` → **2/2 failed** on an otherwise idle machine (p3's real MCP servers supply the contention).

I did **not** fix it here: the fix needs a design decision (pin the catalog by pre-writing the warm-start cache / assert-on-`mcp_tool_probe_degraded` / widen the deadline), and a deadline widening is exactly the shape #3473 prohibits. Filed as a separate issue.

*Note for whoever picks it up*: this test's `Session`s are built without `safety=`, so `Session.__init__`'s `safety or SafetyConfig()` means the project `reyn.yaml`'s `safety:` block is **inert here** — my first attempt at this witness set it in the yaml and got a false GREEN.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_fp0063_arc_witness.py` — OK 1, errors 0
- [x] full `pytest -n auto` from repo root — **9732 passed, 37 skipped**
- [x] `verify_module_docstrings.py` — n/a (no `src/` files changed)
- [x] Manual: 2-process and 6-process concurrent runs of this test, before (RED) and after (GREEN) — table above
