### PR TITLE
fix(tui): composer placeholder を dim にする（ansi-dark で Textual 自身の規則が無効化されるため）

### DIFF
--- a/docs/deep-dives/research/tui-light-terminal-audit.md
+++ b/docs/deep-dives/research/tui-light-terminal-audit.md
@@ -6,6 +6,20 @@ status: draft
 
 # TUI light-terminal compatibility audit
 
+!!! warning "Superseded — this is a 2026-05-17 snapshot, not current behaviour"
+
+    The chat TUI no longer paints its own dark ground. It now runs Textual's
+    `ansi-dark` theme, so `$background`/`$surface`/`$panel` resolve to the
+    `ansi_default` marker (or `transparent`) and the host terminal's own
+    colours show through *by design* — the opposite of the "the host
+    terminal's pixels do not bleed through" finding below. The
+    recommendation to defer was also overtaken: the change shipped.
+
+    Read on for the survey of where colour was hard-coded and why a light
+    terminal was survivable at the time; do not read it as a description of
+    what the TUI does today. Current behaviour lives in the CSS in
+    `src/reyn/interfaces/inline/textual_chat/` and its `on_mount` commentary.
+
 ## TL;DR
 
 The premise "Reyn TUI is unreadable on a light terminal because its text uses

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -635,6 +635,18 @@ class TextualChatApp(App):
            Screen alone does not reach it. */
         background: transparent;
     }
+    /* The placeholder must read as an invitation, not as typed text. Textual's
+       own rule is ``color: $text 40%``, which under ``ansi-dark`` resolves
+       ``$text`` to the ansi_default MARKER — and alpha compositing DROPS the
+       marker, so the 40% never applies and it painted at the terminal's full
+       default foreground (measured: ``Color('default')``, no dim). ``dim``
+       is used instead of a muted colour because it leaves the HUE to the
+       terminal, which is what a themed default is for; ``$text-muted`` hits
+       the identical trap, and a concrete grey would pin a colour the user's
+       theme is entitled to choose. */
+    Composer > .text-area--placeholder {
+        text-style: dim;
+    }
     StatusLine {
         height: 1;
         color: $text-muted;

--- a/tests/test_placeholder_dim_3522.py
+++ b/tests/test_placeholder_dim_3522.py
@@ -1,0 +1,139 @@
+"""#3522 — the composer placeholder reads as an invitation, not as typed text.
+
+Textual's own rule is ``.text-area--placeholder { color: $text 40%; }``. Under
+the ``ansi-dark`` theme adopted in #3505 that is INERT: ``$text`` resolves to the
+``ansi_default`` marker and alpha compositing drops the marker, so the 40% never
+applies and the placeholder painted at the terminal's full default foreground.
+
+Asserted on the PAINTED segment rather than on the CSS declaration, because the
+declaration is exactly what was already there and already not working. Two
+properties are pinned, not one: that the placeholder IS dimmed, and that typed
+text is NOT — a rule reaching further than the placeholder would make the user's
+own input look provisional, and only the second assertion can see that.
+
+The colour is deliberately left as the terminal's default (``dim`` rather than a
+muted colour): the owner's standing direction is that the terminal's own theme
+wins over any concrete shade reyn could pick.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.chrome import Composer
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _Transport(ClientTransport):
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        await asyncio.Event().wait()
+        yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
+
+    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+        pass
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def deliver_pending_answer(self, text: str) -> bool:
+        return False
+
+
+def _body_segment(composer: Composer):
+    """The placeholder/text run of the composer's first row.
+
+    NOT ``segments[0]``: the first non-blank segment is the CURSOR CELL, which
+    carries its own colour and is unaffected by the placeholder's component
+    style. Reading it makes even a ``color: red`` positive control look inert —
+    the mistake this helper exists to keep out of the assertions.
+    """
+    segments = [s for s in composer.render_line(0) if s.text.strip()]
+    assert len(segments) > 1, (
+        f"expected a cursor cell followed by a text run, got {segments!r}"
+    )
+    return segments[1]
+
+
+@pytest.mark.asyncio
+async def test_the_placeholder_is_dimmed() -> None:
+    """Tier 2b: the empty composer's prompt paints dimmed, so an untouched
+    input is legible as untouched."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(90, 20)) as pilot:
+        await pilot.pause()
+        composer = app.query_one(Composer)
+        assert composer.text == "", "setup: the composer was not empty"
+
+        assert _body_segment(composer).style.dim, (
+            "the placeholder painted at full brightness — Textual's own "
+            "`color: $text 40%` is inert under ansi-dark"
+        )
+
+
+@pytest.mark.asyncio
+async def test_typed_text_is_not_dimmed() -> None:
+    """Tier 2b: the dimming stops at the placeholder.
+
+    The invariant, not the addition: a rule that reached the composer's real
+    content would make everything the user types look provisional, and the
+    dimmed-placeholder assertion alone cannot tell the two cases apart.
+    """
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(90, 20)) as pilot:
+        await pilot.pause()
+        composer = app.query_one(Composer)
+        composer.text = "a real message"
+        await pilot.pause()
+
+        assert not _body_segment(composer).style.dim, (
+            "the user's own typed text was dimmed along with the placeholder"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_placeholder_keeps_the_terminal_foreground_colour() -> None:
+    """Tier 2b: dimming does not pin a colour.
+
+    A muted grey would dim it too, but it would also override whatever
+    foreground the user's terminal theme chose — the standing direction is that
+    the terminal's theme wins. ``dim`` is the only measured option that darkens
+    while leaving the hue to the terminal.
+    """
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(90, 20)) as pilot:
+        await pilot.pause()
+        colour = _body_segment(app.query_one(Composer)).style.color
+
+        assert colour is not None and colour.is_default, (
+            f"the placeholder pinned a concrete foreground colour ({colour!r}) "
+            "instead of deferring to the terminal's own theme"
+        )


### PR DESCRIPTION
**[tui-coder]** — owner 依頼①「type a message は暗くして欲しい」(lead-coder 経由)への対応。依頼②「`ansi-dark` 全体の見た目レビュー」の成果物は **#3523** に分けています(理由は下記)。

Closes #3522

## 症状と実測した原因

placeholder が入力済みテキストと同じ明るさで出ていました。

Textual の `TextArea` 自身の既定は `.text-area--placeholder { color: $text 40%; }` です。ところが #3505 で採用した `ansi-dark` では `$text` = `ansi_default`(端末デフォルトを表す**マーカー**)で、**アルファ合成はマーカーを落とす**ため 40% が一切効きません。実測した painted segment:

```
baseline (Textual 既定 $text 40%)   color=Color("default")   dim=None   ← 全輝度
```

これは #3505 の `on_mount` コメントが「`$text-muted` 等が同一値へ潰れる」として既知の trade-off に挙げていた面の、具体的な1件です。

## ★ 測定を1回間違えたので記録します

最初、`color: red` の **positive control すら効かない**と読み、「セレクタが当たっていない」と結論しかけました。誤りでした — **`Composer.render_line(0)` の最初の非空白セグメントは placeholder ではなくカーソルセル**(`color(15)`)で、placeholder 本体は2番目です。私はずっとカーソルを測っていました。

全セグメントをダンプして初めて `red` が2番目に届いているのが見え、そこから候補の比較が成立しました。**同じ罠を次に踏まないよう、テストの `_body_segment()` ヘルパの docstring にこの理由を残しています。**

## 候補の比較(実測、3件とも実行)

| 候補 | painted color | dim |
|---|---|---|
| `color: $text-muted` | `Color("default")` | None |
| **`text-style: dim`** | **`Color("default")`** | **True** |
| `color: ansi_bright_black` | `color(8)` | None |

`$text-muted` は**同一の罠**で無効。`ansi_bright_black` は効きますが**具体色を固定**するため、owner の既定方針(「基本背景と文字の装飾は変更しない方が良い」「ターミナルのテーマ参照できるならそっち優先」)に反します。

∴ **`text-style: dim`** — 色を端末に委ねたまま暗くする唯一の選択肢。これは `MenuBar` の `Tab` が ansi-dark 下で active/inactive を保てている手段(`bold`/`dim`)と同じで、**発明ではなく既存パターンの踏襲**です。

## 実端末 witness (tmux 150×45)

```
'\x1b[39m❯ \x1b[2mType a message — Enter to send, Shift+Enter for a newline…\x1b[0m'
                  ^^^^^^ SGR 2 (dim)、38;2; の truecolor 前景は無し
```

入力後:

```
'\x1b[39m❯ hello world'      ← SGR 2 が消えている
```

## 依頼②(`ansi-dark` レビュー)を別 issue にした理由

マウント済みウィジェットの `styles.color` を**全件走査**した結果、`$text-muted` を使う**7箇所すべて**が `$text` と同一値に潰れていました(`#inputgutter` / `StatusLine` / `SentQueue` / `#search-count` / `#rewind-picker-title` / `MenuBar` / `InterventionPanel` 補助行)。つまり chrome 全体で「控えめ」表現が失われています。

しかし owner は `ansi-dark` 全体を見て「見た目いい感じ」と評価済みで、`$panel`/`$surface` の transparent 化も accept 済みです。**7箇所を一括で暗くするのは owner がまだ見ていない広範な見た目変更**なので、本 PR には入れず **#3523** に調査結果として起票し、判断を仰いでいます。

## doc drift を1件修正

`docs/deep-dives/research/tui-light-terminal-audit.md` が、**#3505 が falsify した現状を今も主張**していました — 「テーマは `dark=True` で構成」「`$surface = #1E1E1E`」「**端末のピクセルは透けない**」。最後のものは、今のアプリが**意図的にやっていることの正反対**です。

#3504/#3505 は doc を一切伴わずに merge されており、これは「新機能に対応する doc の不在は stale チェックでは検出できない」型の穴です(stale チェックは既存記述の矛盾を探すので、**書かれていないもの**は見えません)。

2026-05-17 時点の研究スナップショットとしての価値は残るので、削除ではなく**現状主張を止める banner** を付けています。

## Tests (`tests/test_placeholder_dim_3522.py`, 3本)

CSS 宣言ではなく**描画されたセグメント**で検証します — 宣言は「既にそこにあって、既に効いていなかった」ものだからです。

1. placeholder が **dim で塗られる**
2. **入力済みテキストは dim にならない**(不変条件 — placeholder より広く効く規則は、ユーザ自身の入力を暫定的に見せてしまう。1だけでは区別できません)
3. placeholder が**具体色を固定していない**(端末テーマ優先の方針をテストに固定)

### Falsify(3本とも別々の反例で非空洞を確認)

| 反例 | RED になるテスト |
|---|---|
| 規則を除去 | 1 |
| `Composer { text-style: dim }` へ拡大(over-reach) | 2 |
| `color: ansi_bright_black` へ変更(色固定) | 1, 3 |

## Gates

- [x] `ruff check src tests` clean
- [x] `test_tier_audit.py --strict` OK (3 tests, Tier 4 違反 0)
- [x] `verify_module_docstrings.py` OK
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` 成功
- [x] full `pytest -n auto`: **9734 passed, 37 skipped, 1 failed → 帰属済み(本変更起因ゼロ)**

### 1件の帰属

`test_fp0063_arc_witness::…reaches_the_ingested_chunk` — **単独では pass**(実行確認済み)。**#3473 / #3519** で追跡中の既知 flake で、`/tmp/reyn_fp0063_arc_witness_dir` という**マシン全体で共有される固定パス**を使うため、他セッションが同時に suite を回すと衝突します。本変更の範囲(TUI の CSS 1規則 + テスト + doc banner)とは無関係です。

## Test plan

- [x] 実端末(tmux 150×45): placeholder が SGR 2 で暗く出ること、truecolor 前景を固定していないこと、**入力すると dim が消える**ことを raw エスケープで確認
- [ ] **Visual (owner gate)**: 暗さの程度が意図どおりか。`dim` は端末側の実装に委ねるため、**端末によっては効き方が変わります**(SGR 2 を無視する emulator も存在します)。owner の端末での見え方をご確認ください

🤖 Generated with [Claude Code](https://claude.com/claude-code)
