### PR TITLE
docs(verification-hazards): §3 gets a third zero — the search instrument was broken

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -68,9 +68,25 @@ anywhere to be found — absence isn't a string you can search for. #3037's
 invented `permission_resolver` field required an AST diff against
 `RouterCallerState.__dataclass_fields__`, not a grep, to surface at all.
 
+A third way zero can lie even when the thing WOULD leave a trace: the search
+tool itself silently fails to find it. A hardcoded-color census reported
+"only 2 violations," compounding two independent defects: it searched for
+the CSS `property: #hex` shape only, never the Python color constants that
+were the real majority of the usage; and a follow-up attempt to grep for
+those constants directly ALSO returned zero, because `git grep -E` is POSIX
+ERE, which does not understand `\s` — so even a known hit
+(`_CC_DIM = "#6b7280"`) went unfound. The true count was 8 constants across
+66 call sites, one of them (`_CC_DIM`) a live candidate for a real
+"gutter text invisible" bug an owner had already reported (#3525, 2026-07-31).
+Neither zero was distinguishable from a real zero without recognizing the
+query itself was narrow, then broken.
+
 **Apply**: before trusting a "zero hits" result, ask whether the thing you're
 checking for would leave a positive trace if present, or only an absence —
-only the first kind makes zero a real answer.
+only the first kind makes zero a real answer. Then calibrate the instrument
+itself: run the same query against one KNOWN hit before trusting a null
+result on the rest, and prefer `-P`/PCRE or a portable class like
+`[[:space:]]` over ERE metacharacters that vary by grep flavor.
 
 ## 4. Census vs. structure — extrapolation dies on use, not on review
 


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary
Adds a third paragraph to §3 ("Two zeros: one settles it, one says nothing") for a distinct case: the thing being searched for WOULD leave a trace, but the search instrument itself silently failed.

Instance, verified directly against the issue comment (#3525) rather than taken verbatim from the broker report — the original draft conflated two independent, compounding defects into one, so I split them out:
1. The census searched for the CSS `property: #hex` shape only, never the Python color constants that were the real majority of the usage.
2. A follow-up grep for those Python constants directly ALSO returned zero, because `git grep -E` is POSIX ERE and doesn't understand `\s` — missing even a known hit (`_CC_DIM = "#6b7280"`).

True count: 8 color constants across 66 call sites (not "2 violations" as first reported), one of them a live candidate for a real "gutter text invisible" bug an owner had already reported. Content and detection technique (calibrate against a known hit before trusting a null; prefer `-P`/PCRE or `[[:space:]]` over ERE metacharacters) from lead-coder, who caught and corrected their own report.

## Test plan
- [x] `ruff check` — clean
- [x] `mkdocs build --strict` — exit 0, no new warnings