### PR TITLE
fix(tui): 右ガターのラベルの色を端末に委ねる（固定 #6b7280 が透過背景で読めなかった）

### DIFF
--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -776,6 +776,18 @@ second hand-rolled column:
   and the per-turn buckets are in-memory state a restart does not rehydrate —
   so a restored row's right gutter is blank, never a reconstructed value.
 
+  Both labels are painted with `_CC_AMBIENT` (`"dim"`, i.e. SGR 2) rather than
+  a colour, so the TERMINAL's theme decides their shade (#3536). They had used
+  the fixed mid-grey `_CC_DIM` (`#6b7280`), which on a transparent terminal
+  background left them unreadable — its contrast is whatever shows through.
+  This applies HERE and not to `_CC_DIM` generally: a terminal-chosen
+  foreground is only safe over a terminal-chosen background, and these labels
+  ride solely on rows the presenter does not tint (`agent`,
+  `tool_call_started`). On a tinted row (`_CC_USER_BG` / `_CC_ERR_BG`, fixed
+  dark hex) the same substitution would be dark-on-dark for a light-terminal
+  user, and the row-contrast gate would stop measuring the pairing entirely —
+  it only inspects segments whose foreground is concrete.
+
   The column is a fixed width derived in terminal **cells**
   (`rich.cells.cell_len`, the measure Textual's own compositor applies) from
   the widest label each family can emit — not from a character count. The two

--- a/src/reyn/interfaces/inline/textual_chat/gutter.py
+++ b/src/reyn/interfaces/inline/textual_chat/gutter.py
@@ -45,6 +45,7 @@ from rich.text import Text
 from textual_flowview import EntryState
 
 from reyn.interfaces.repl.renderer import (
+    _CC_AMBIENT,
     _CC_DIM,
     _CC_DONE,
     _CC_ERR,
@@ -450,7 +451,7 @@ class ReynTimingGutter:
         return _format_elapsed(final) if isinstance(final, (int, float)) else ""
 
     def decorate(self, entry: "Entry[OutboxMessage]", width: int, height: int) -> RenderableType:
-        return Text(_cell_pad_left(self.label(entry), width), style=_CC_DIM)
+        return Text(_cell_pad_left(self.label(entry), width), style=_CC_AMBIENT)
 
 
 class ReynTurnUsageGutter:
@@ -558,7 +559,7 @@ class ReynTurnUsageGutter:
         )
 
     def decorate(self, entry: "Entry[OutboxMessage]", width: int, height: int) -> RenderableType:
-        return Text(_cell_pad_left(self.label(entry), width), style=_CC_DIM)
+        return Text(_cell_pad_left(self.label(entry), width), style=_CC_AMBIENT)
 
 
 class ReynRightGutter:
@@ -614,7 +615,7 @@ class ReynRightGutter:
         ]
         label = " ".join(parts)
         if self._is_marked is None or not self._is_marked(entry):
-            return Text(_cell_pad_left(label, width), style=_CC_DIM)
+            return Text(_cell_pad_left(label, width), style=_CC_AMBIENT)
         # The addressed entry: the rail in this gutter's LEADING cell, spanning
         # the body's full post-wrap ``height`` so a multi-row reply reads as ONE
         # marked block. The labels keep their own dim styling — being addressed
@@ -625,5 +626,5 @@ class ReynRightGutter:
             if row:
                 rail.append("\n")
             rail.append(_MARK_RAIL, style=_MARK_COLOR)
-            rail.append(_cell_pad_left(label if row == 0 else "", width - 1), style=_CC_DIM)
+            rail.append(_cell_pad_left(label if row == 0 else "", width - 1), style=_CC_AMBIENT)
         return rail

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -341,7 +341,31 @@ class RichChatRenderer(ChatRenderer):
 # to signal STATE — error (red), needs-action (amber), done (green), ambient/low
 # (dim) — so a coloured glyph always means "something to notice".
 _CC_TEXT = "default"    # terminal default fg — normal text + markers (no forced colour)
-_CC_DIM = "#6b7280"     # low-importance / ambient
+_CC_DIM = "#6b7280"     # low-importance / ambient, as a COLOUR (see _CC_AMBIENT)
+# The same "low-importance" role expressed as an ATTRIBUTE rather than a colour
+# (#3536). ``dim`` emits SGR 2 and forces no colour, so the terminal's own theme
+# decides the shade — the owner's standing direction (#3525) and the only form
+# that survives a TRANSPARENT terminal background, which is what made the right
+# gutter's labels unreadable: a fixed mid-grey has whatever contrast the user's
+# desktop happens to give it.
+#
+# ★ This does NOT replace _CC_DIM, and the split is forced by measurement, not
+# taste. _CC_DIM is still required wherever a real COLOUR is:
+#
+# - ``prompt_toolkit`` rejects an attribute outright — ``fg:dim`` raises
+#   ``ValueError: Wrong color format 'dim'`` (measured), so the repl status bar
+#   needs a colour value.
+# - On a row that carries a TINT (``_CC_USER_BG`` / ``_CC_ERR_BG``, both fixed
+#   dark hex), terminal-default ink would be dark-on-dark on a LIGHT terminal,
+#   and #3367's contrast gate cannot even see the pairing: it skips any segment
+#   whose foreground is not concrete. Making a foreground terminal-relative
+#   while its background stays a fixed hex trades a measurable guarantee for an
+#   unmeasurable one.
+#
+# So this is used where the row carries NO tint — measured: ``agent`` and
+# ``tool_call_started`` rows have ``background=None``, and those are exactly the
+# rows the right gutter's token / elapsed labels ride on.
+_CC_AMBIENT = "dim"
 _CC_DONE = "#7ee787"    # green — completion
 _CC_ERR = "#f97066"     # red — failure
 _CC_WARN = "#e3b341"    # amber — an intervention that needs the user to act

--- a/tests/test_right_gutter_label_visible_3536.py
+++ b/tests/test_right_gutter_label_visible_3536.py
@@ -1,0 +1,158 @@
+"""#3536 — the right gutter's labels let the TERMINAL pick their colour.
+
+Owner report: the elapsed / token labels are unreadable. The text was being
+drawn; it was painted in a fixed truecolor mid-grey (`_CC_DIM = "#6b7280"`),
+which has whatever contrast the user's background happens to give it — and on a
+transparent terminal background, that is not a decision reyn is in a position to
+make.
+
+The fix is scoped, and the scope is the interesting part. `_CC_DIM` cannot
+simply become an attribute everywhere: `prompt_toolkit` rejects `fg:dim`
+outright, and on a row carrying a fixed dark TINT a terminal-default foreground
+would be dark-on-dark for a light-terminal user — a pairing #3367's contrast
+gate cannot even see, because it skips segments whose foreground is not
+concrete. So the ambient attribute is used only where no tint is in play.
+
+The last test here pins that premise rather than the fix: if an agent or tool
+row ever starts carrying a tint, these labels would become exactly the
+unmeasurable pairing described above, and no assertion about the label itself
+would notice.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from rich.console import Console
+from rich.text import Text
+
+from reyn.interfaces.inline.textual_chat.presenter import ReynPresenter
+from reyn.interfaces.repl.renderer import _CC_AMBIENT, _CC_DIM
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _Transport(ClientTransport):
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        await asyncio.Event().wait()
+        yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
+
+    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+        pass
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def deliver_pending_answer(self, text: str) -> bool:
+        return False
+
+
+def _render(style: str) -> str:
+    """What a label styled ``style`` actually puts on the wire."""
+    buffer = Console(file=None, width=24, force_terminal=True, color_system="truecolor")
+    with buffer.capture() as captured:
+        buffer.print(Text("↑12k ↓2k", style=style), end="")
+    return captured.get()
+
+
+def test_the_ambient_label_style_forces_no_colour() -> None:
+    """Tier 1: the ambient style emits an ATTRIBUTE, never a colour.
+
+    Asserted on the emitted escape rather than on the constant's spelling: what
+    makes the label legible on someone else's background is that no `38;2;`
+    truecolor foreground reaches the wire, and only the rendered output can say
+    that.
+    """
+    emitted = _render(_CC_AMBIENT)
+
+    assert "38;2;" not in emitted, (
+        f"the ambient label pinned a truecolor foreground: {emitted!r}"
+    )
+    assert "\x1b[2m" in emitted, (
+        f"the ambient label is not dimmed, so it reads as ordinary text: {emitted!r}"
+    )
+
+
+def test_the_dim_colour_constant_stays_a_colour() -> None:
+    """Tier 1: `_CC_DIM` is NOT converted along with it.
+
+    Two callers structurally require a colour value — `prompt_toolkit`
+    (`fg:dim` raises `ValueError: Wrong color format`) and any foreground that
+    lands on a fixed dark row tint, which needs to remain measurable by #3367's
+    contrast gate. A well-meaning sweep that "finishes the job" would break both.
+    """
+    assert _CC_DIM.startswith("#"), (
+        f"_CC_DIM stopped being a colour ({_CC_DIM!r}) — prompt_toolkit's "
+        "`fg:` and the tinted-row contrast gate both require one"
+    )
+    assert "38;2;" in _render(_CC_DIM), (
+        "_CC_DIM no longer emits a concrete foreground, so the contrast gate "
+        "silently stops inspecting the pairings it exists to measure"
+    )
+
+
+def test_prompt_toolkit_rejects_the_ambient_style_as_a_colour() -> None:
+    """Tier 1: the reason for the split, as an executable fact.
+
+    This is the constraint that makes the two-constant split necessary rather
+    than stylistic — recorded as a test so it does not have to be rediscovered
+    by whoever next proposes collapsing them.
+    """
+    from prompt_toolkit.styles import Style
+
+    Style.from_dict({"ok": f"fg:{_CC_DIM}"})  # the colour form is accepted
+
+    with pytest.raises(ValueError):
+        Style.from_dict({"bad": f"fg:{_CC_AMBIENT}"})
+
+
+@pytest.mark.asyncio
+async def test_the_rows_carrying_these_labels_have_no_tint() -> None:
+    """Tier 2b: the PREMISE that makes a terminal-coloured label safe here.
+
+    A terminal-default foreground is only safe over a terminal-default
+    background. The right gutter's labels ride on agent rows (token split) and
+    started-tool rows (elapsed) — neither of which the presenter tints. If that
+    ever changes, these labels become fixed-dark-under-unknown-ink and #3367's
+    gate cannot see the pairing, so the failure has to be caught here.
+    """
+    presenter = ReynPresenter(clock=lambda: 0.0)
+
+    for message in (
+        OutboxMessage(kind="agent", text="a reply"),
+        OutboxMessage(
+            kind="tool_call_started", text="read_file", meta={"tool": "read_file"}
+        ),
+    ):
+        presentation = await presenter.present(message, 80)
+        assert presentation.background is None, (
+            f"a {message.kind!r} row now carries the tint "
+            f"{presentation.background!r} — the right gutter's label sits on it "
+            "with a terminal-chosen colour, which no contrast gate can measure"
+        )


### PR DESCRIPTION
**[tui-coder]** — owner 報告(telegram, lead-coder 経由)「右がたーのもじれつがみえないよ。レール対応前から見えない」。

Closes #3536

## 実測（推論ではありません）

実端末(tmux 150×45、実 LLM 経由)で token ラベルの行:

```
\x1b[38;2;107;114;128m     ↑12k ↓2
```

★ **文字列は描かれています。** 問題は色で、`_CC_DIM = "#6b7280"` という**固定 truecolor の中間灰**です。**透過背景の端末では、コントラストは背後に何が透けるかで決まります** — reyn が決められる事柄ではありません(#3525)。owner の「レール対応前から見えない」とも整合します。

## 修正

`_CC_AMBIENT = "dim"`(同じ「低重要度」の役割を**色ではなく SGR 属性**で表現)を追加し、右ガターのラベル描画4箇所をそこへ向けました。

**実端末 witness**: 同じ行が **`\x1b[2m`** になり、`38;2;` は消えています。

## 🔴 `_CC_DIM` を一括置換しない理由 — 「広いから」ではなく「不正だから」

`_CC_DIM` は51箇所で使われていますが、**単純置換は2箇所で壊れます。両方とも実測です:**

**① prompt_toolkit が属性を拒否**

```
Style.from_dict({"x": "fg:dim"})
  → ValueError: Wrong color format 'dim'
```
repl のステータスバーは色値が必要です。**この制約はテストに固定しました** — 次に「統一しよう」と考える人が再発見しなくて済むように。

**② tint を背負う行では、測れる保証を測れない保証に置き換えることになる**

`_CC_USER_BG` / `_CC_ERR_BG` はどちらも**固定の暗い hex** です。前景だけ端末デフォルトにすると、**明るい端末のユーザには暗×暗**になります。さらに #3367 のコントラストゲートは**前景が具体色でないセグメントをスキップする**実装なので、その組み合わせは**測定対象から静かに消えます**。

## ★ 「ここでは安全」という前提自体をテストで固定しています

端末が選ぶ前景が安全なのは、**背景も端末が選んでいる時だけ**です。右ガターのラベルが乗るのは、presenter が tint を付けない行だけでした(実測):

| 行 | row tint | 右ガターのラベル |
|---|---|---|
| `user` | `#1e222a` | 無し |
| **`agent`** | **無し** | **token** |
| **`tool_call_started`** | **無し** | **elapsed** |
| `tool_call_failed` / `error` | `#3a1c1a` | 無し |

∴ 4本目のテストは**ラベルではなく前提**を pin しています — `agent` / `tool_call_started` に将来 tint が付いたら、ラベルは「不明な色 × 固定の暗い背景」になり、**ラベル自身を見る assertion では誰も気づけません**。

## 修正後も `#6b7280` が残る場所（実測・意図的）

実端末 capture で残っていたのは**ユーザ行の本文だけ**でした。あそこは固定の暗い tint を背負っており、#3367 がその組み合わせを **3.30** で測っています。∴ **残るべくして残っています。**

## Tests (`tests/test_right_gutter_label_visible_3536.py`, 4本)

1. ambient は**色を出さない**(定数の綴りでなく**出力エスケープ**で判定 — 他人の背景で読めるかを決めるのは wire に何が乗るかなので)
2. `_CC_DIM` は**色のまま**(善意の一括掃除への防波堤)
3. **prompt_toolkit が属性を拒否する事実**を実行可能な形で記録
4. **ラベルが乗る行に tint が無い**(この修正が安全である前提)

### Falsify（両方向）

| 反例 | RED |
|---|---|
| ambient を固定灰へ戻す(**直さない**方向) | 1, 3 |
| `_CC_DIM` も属性へ掃く(**直しすぎる**方向) | 2, 3 |

## Gates

- [x] `ruff check src tests` clean
- [x] `test_tier_audit.py --strict` OK
- [x] `verify_module_docstrings.py` OK
- [x] `mkdocs build --strict` 成功
- [x] full `pytest -n auto`: **9759 passed, 37 skipped, 0 failed**(帰属すべき失敗ゼロ)

★ **既存の色関連ゲートも個別に確認済み**: `test_textual_chat_row_contrast_3367` / `test_markdown_palette_gate_3469` / `test_textual_chat_phase2_3273` / `test_textual_chat_intervention_panel_3299` — いずれも緑。

## doc

`agui-transport.md` の右ガター節に、**この置換が「ここでは」成立し `_CC_DIM` 一般には成立しない理由**を追記しました(色の話は既存記述がゼロだったので、stale ではなく空白を埋める形です)。

## 🔎 #3525 の census について

lead-coder から「hex 違反は2行のみ」という自身の報告の訂正がありました。私の側の実測も一致します — **色定数は8件、TUI 全体で66箇所**。本 PR はそのうち**右ガターのラベル4箇所**だけを扱っています。**残りは #3525 / #3523 の範囲**で、②の理由から**前景だけ先に端末依存化するのは危険**です — tint 定数とセットで扱う必要があります。

## Test plan

- [x] 実端末(tmux 150×45、実 LLM): 修正前 `\x1b[38;2;107;114;128m` → 修正後 `\x1b[2m`、`38;2;` 消失を raw エスケープで確認
- [ ] **Visual (owner gate)**: ★ **owner の端末(透過背景)で実際に読めるようになったか。** `dim` は端末側の実装に委ねるため、**SGR 2 を無視する emulator では変化しません** — その場合は ANSI 16色(`bright_black` 等)が次の候補ですが、**Textual が名前付き色を truecolor へダウンコンバートする**既知の実測があるため、そちらは別途の検討が要ります

🤖 Generated with [Claude Code](https://claude.com/claude-code)
