### PR TITLE
fix(tui): fold an intervention answer into the entry that asked it (#3540)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1886,7 +1886,14 @@ class TextualChatApp(App):
         The SAME entry is updated in place (churn-zero, #3299 P2 §4) to a
         ``✓ answered: <label>`` record
         (:meth:`ReynPresenter._present_intervention_pending` reads the
-        ``_answer_label`` meta key). The entry's :class:`EntryState` goes to
+        ``_answer_label`` meta key). #3540: this is the LOCAL-panel half of the
+        settle — the answer's own broadcast comes back as an
+        ``intervention_answer_submitted`` event and stamps the SAME key on the
+        SAME entry (:meth:`_handle_intervention_answer_event`), which is what
+        settles an answer this panel never saw (`/answer`, an A2A peer, AG-UI
+        HITL). Both writes are idempotent in render terms, so the local path
+        keeps its immediate feedback without producing a second entry. The
+        entry's :class:`EntryState` goes to
         ``DEFAULT`` — not ``SUCCESS``/``ERROR`` (an intervention answer is
         neither an outcome to celebrate nor a failure, the #3296
         don't-fabricate-a-classification lesson) and not ``RUNNING`` (would

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2511,28 +2511,83 @@ class TextualChatApp(App):
             text = _neutralized_label(str(item.get("text", "")))
             self._ingest_frame(OutboxMessage(kind="user", text=text, meta=meta))
 
-    def _handle_intervention_answer_event(self, event) -> None:
-        """Render an ``intervention_answer_submitted`` chat-event as a flow
-        entry (#3300 — the last outbox `kind="user"` broadcast site,
-        ``InterventionHandler.deliver_answer_to``, migrated to a chat-event).
+    def _announced_intervention_entry(self, iv_id: str) -> "Entry[OutboxMessage] | None":
+        """The flow entry ``InterventionHandler.announce`` produced for
+        intervention ``iv_id``, or ``None`` when this surface never saw the
+        announce (#3540).
 
-        Unlike ``user_submitted`` (which stages in the sent-queue region
-        first, :meth:`_handle_user_submitted_event`), an intervention answer
-        has no queue/dispatch lifecycle to stage through — it renders
-        straight to the flow, same as before this event-ify (when it arrived
-        as a DISPLAY frame). The payload carries RAW text; this is the
-        surface's OWN neutralize-at-render-boundary call (the SAME
-        ``_neutralized_label`` seam :meth:`_handle_turn_started_event` uses
-        for the analogous ``user_submitted`` promotion), so a control/ESC
-        byte in an answer (free-text or an LLM-derived choice label) cannot
-        reach this TTY.
+        The correlation surface is the ENTRY's own ``meta["intervention_id"]``
+        (put there by the handler's ``_iv_meta``), NOT :attr:`_pending_ivs`:
+        :meth:`_resolve_intervention` POPS the pending map the moment the TUI
+        panel delivers an answer, which is BEFORE the resulting
+        ``intervention_answer_submitted`` event comes back round the transport
+        — a lookup keyed on the pending map would miss exactly the common
+        case. The entry itself is never popped, so it is a stable key at any
+        point in the answer's lifecycle."""
+        for entry in self.conversation:
+            item = entry.item
+            if item.kind != "intervention":
+                continue
+            if (item.meta or {}).get("intervention_id") == iv_id:
+                return entry
+        return None
+
+    def _handle_intervention_answer_event(self, event) -> None:
+        """Fold an ``intervention_answer_submitted`` chat-event into the flow
+        entry that ASKED the question (#3300 — the last outbox `kind="user"`
+        broadcast site, ``InterventionHandler.deliver_answer_to``, migrated to
+        a chat-event; #3540 — the fold).
+
+        #3540: the answer belongs to a question that ALREADY has a flow entry
+        (``announce``'s ``kind="intervention"`` row), so appending it as its own
+        ``kind="user"`` row left an answered intervention rendering as TWO
+        entries live where the SAME session reloaded rendered ONE (``restore.py``'s
+        ratified self-contained Q→A shape, #3299 P4). This reads the
+        ``intervention_id`` the event has always carried, finds that entry, and
+        settles it IN PLACE by stamping ``_answer_label`` — the same churn-zero
+        write :meth:`_resolve_intervention` makes for the local-panel path, and
+        the same meta key the restore projection writes, so live and restore
+        now produce the SAME entry sequence for the same answered intervention.
+
+        The branch is on ENTRY PRESENCE, never on delivery route: `/answer`, an
+        A2A peer and the AG-UI HITL path all deliver through the one
+        ``deliver_answer_to`` funnel and all of them saw the announce, so one
+        entry-keyed lookup covers every funnel uniformly (a TUI-local
+        suppression would have lost the answers that never touch the panel).
+
+        FALLBACK — no matching entry: append the bare answer exactly as
+        before. That leg is what a thin client which ATTACHED AFTER the
+        announce sees, and a bare answer line is the correct render there:
+        it has no question row to fold into. It is also the leg the payload's
+        RAW text is neutralized on (:func:`_neutralized_label`, the SAME seam
+        :meth:`_handle_turn_started_event` uses for ``user_submitted``). The
+        fold leg stamps the RAW label instead — deliberately, because
+        ``ReynPresenter._present_intervention_pending`` neutralizes
+        ``_answer_label`` at ITS render call site (the ONE boundary the
+        restored path already relies on), so pre-stripping here would make
+        live and restore differ in the stored bytes for no gain.
+
+        Note the ANSWERER's attribution meta (``actor``/``auth_user_id``) is
+        not merged onto the folded entry: that entry's ``actor`` is the ASKING
+        run's, and history's own answered record keeps no answerer identity
+        either — so merging would both overwrite a live field and put live
+        ahead of what restore can ever reproduce. The fallback leg carries the
+        attribution meta unchanged, as it always did.
         """
         from reyn.runtime.outbox import OutboxMessage  # noqa: PLC0415
 
         data = event.data or {}
-        text = _neutralized_label(str(data.get("text", "")))
+        raw_text = str(data.get("text", ""))
+        iv_id = data.get("intervention_id")
+        entry = self._announced_intervention_entry(iv_id) if iv_id else None
+        if entry is not None:
+            meta = entry.item.meta or {}
+            entry.set_item(replace(entry.item, meta={**meta, "_answer_label": raw_text}))
+            return
         meta = dict(data.get("meta") or {})
-        self._ingest_frame(OutboxMessage(kind="user", text=text, meta=meta))
+        self._ingest_frame(
+            OutboxMessage(kind="user", text=_neutralized_label(raw_text), meta=meta)
+        )
 
     def _handle_session_halted_event(self, event) -> None:
         """#2280: the durability-halt observability surface. ``session_halted``
@@ -2872,10 +2927,16 @@ class TextualChatApp(App):
         once, on the first frame (:meth:`_seed_queue_view`). A single frame's
         failure must not kill the pump, so ingest is guarded.
 
-        #3300 (event-ify the intervention-answer echo): ``intervention_answer_submitted``
-        (:meth:`_handle_intervention_answer_event`) renders straight to the
-        flow, unlike ``user_submitted`` — an intervention answer was never a
-        queued inbox item, so there is no sent-queue stage to promote through.
+        #3300 (event-ify the intervention-answer echo) / #3540 (the fold):
+        ``intervention_answer_submitted``
+        (:meth:`_handle_intervention_answer_event`) never stages in the
+        sent-queue the way ``user_submitted`` does — an intervention answer was
+        never a queued inbox item, so there is no promotion step. It does not
+        append a row of its own either: it SETTLES the ``kind="intervention"``
+        entry its ``intervention_id`` identifies, in place, so an answered
+        intervention is ONE Q→A entry (the shape ``restore.py`` already
+        projects). Only an answer with no matching entry — a client attached
+        after the announce — still appends a bare ``kind="user"`` row.
 
         #3310 N2: ``session_attached`` (:meth:`_handle_session_attached_event`)
         is the switch-reset BARRIER — everything on this stream before it

--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -397,12 +397,14 @@ class ReynPresenter:
         site — the SAME leaf-neutralization discipline ``_intervention_head``
         already applies to ``prompt``/``detail`` (#2770) — because a matched
         CLOSED-SET choice's label is model-supplied / untrusted the same way
-        the prompt is; a live choice answer arrives here ALREADY neutralized
-        (``InterventionPanel`` neutralizes labels at tab-build time) so this
-        is idempotent for it, but a RESTORED answer arrives RAW (persisted
-        RAW by design — neutralize only at display boundaries, never at
-        write time), making this the ONE real neutralization boundary for the
-        restore path's answer text."""
+        the prompt is; a RESTORED answer arrives RAW (persisted RAW by design
+        — neutralize only at display boundaries, never at write time), and
+        since #3540 a LIVE answer does too (``TextualChatApp.
+        _handle_intervention_answer_event`` folds the event's RAW text onto
+        this same key, so live and restore store the same bytes). This is
+        therefore the ONE real neutralization boundary for an answer label on
+        both paths — the panel's own tab-build neutralization covers the
+        widget, not this row."""
         meta = item.meta or {}
         head = _intervention_head(item)
         head_h = self._measure(head, width)

--- a/src/reyn/interfaces/transport/frames.py
+++ b/src/reyn/interfaces/transport/frames.py
@@ -82,10 +82,17 @@ _TURN_AND_ANSWER_EVENTS = frozenset(
         # chat-event, following the ``user_submitted`` precedent exactly.
         # Carries RAW text (the answer's display text: the raw answer, or the
         # matched choice's label) + ``intervention_id`` + attribution ``meta``;
-        # each surface's event→display handler neutralizes at render time (see
+        # each surface neutralizes at ITS render boundary (see
         # ``reyn.interfaces.repl.renderer.intervention_answer_display_message``
         # / ``reyn.interfaces.inline.textual_chat.app.
-        # TextualChatApp._handle_intervention_answer_event``).
+        # TextualChatApp._handle_intervention_answer_event``). #3540: the
+        # Textual surface FOLDS the answer into the ``kind="intervention"``
+        # entry ``intervention_id`` identifies rather than appending a row of
+        # its own, so for that (now normal) leg the render boundary is
+        # ``ReynPresenter._present_intervention_pending``'s ``_answer_label``
+        # neutralization — the SAME one the restored Q→A entry passes through;
+        # the handler's own ``_neutralized_label`` call still covers the
+        # no-matching-entry fallback.
         "intervention_answer_submitted",
         # #3300 P3 (Y-server): cancel-by-id for an UNDISPATCHED (queued) user
         # message — the server-authoritative removal signal (never a

--- a/tests/test_3300_intervention_answer_eventify.py
+++ b/tests/test_3300_intervention_answer_eventify.py
@@ -21,6 +21,14 @@ SURFACE-SIDE consumers the producer-side tests cannot reach:
    retired outbox broadcast provided must not regress), and must neutralize
    raw ESC/OSC at ITS OWN render boundary (the surface never trusted the
    producer to have already stripped it — #3300's RAW-on-the-wire model).
+   ★ #3540 NARROWED WHAT THESE COVER: the handler now FOLDS an answer into
+   the ``kind="intervention"`` entry its ``intervention_id`` identifies, and
+   appends a row of its own only when no such entry exists. Every TUI test
+   here pushes an answer event into an app that never saw the announce, so
+   they are the FALLBACK leg's witnesses — which is exactly the leg whose
+   ADR-0039 reachability + own-boundary neutralization they were written for.
+   The fold leg (and the live-vs-restore entry-sequence gate) lives in
+   ``tests/test_3540_intervention_answer_fold.py``.
 2. ``ConsoleChatRenderer`` / ``InlineChatRenderer`` (the plain/--cui and
    plain-render-mode-fallback surfaces, ``on_chat_event`` ->
    ``intervention_answer_display_message``) — same neutralize-at-boundary
@@ -118,9 +126,11 @@ def _flow_user_entries(app: TextualChatApp):
 
 @pytest.mark.asyncio
 async def test_intervention_answer_event_appends_flow_entry_directly() -> None:
-    """Tier 2b: an "intervention_answer_submitted" event renders straight to
-    the flow (no sent-queue staging — an intervention answer was never a
-    queued inbox item, unlike "user_submitted").
+    """Tier 2b: an "intervention_answer_submitted" event with NO announced
+    question entry on this surface renders straight to the flow (no
+    sent-queue staging — an intervention answer was never a queued inbox
+    item, unlike "user_submitted"). #3540: this is the fallback leg, the one
+    a client attached after the announce takes.
 
     Strip-falsify: removing the ``elif etype ==
     "intervention_answer_submitted"`` branch in ``_pump_frames`` (or the

--- a/tests/test_3540_intervention_answer_fold.py
+++ b/tests/test_3540_intervention_answer_fold.py
@@ -1,0 +1,390 @@
+"""#3540: an answered intervention is ONE flow entry live, exactly as it is on
+restore.
+
+Owner-observed on a real TTY: answering an intervention left TWO entries — the
+intervention row (``✓ answered: <label>``) plus a separate ``kind="user"`` row
+carrying the same answer text — while the SAME session reloaded rendered ONE
+self-contained Q→A entry (``restore.py``'s #3299 P4 shape). Two writers acted on
+one answer and neither knew about the other: ``_resolve_intervention`` settled
+the entry in place, and ``_handle_intervention_answer_event`` appended the
+broadcast echo as its own row.
+
+The fix reads the ``intervention_id`` the ``intervention_answer_submitted``
+event has ALWAYS carried (``InterventionHandler.deliver_answer_to``) and folds
+the answer into the flow entry ``announce`` already produced. The wire is
+unchanged.
+
+★ WHERE THE GATE IS AIMED. The property is **not** "the live code looks like the
+restore code" — that is a proxy. It is **"live and restore produce the same
+entry sequence for the same answered intervention"**, which is precisely what
+the owner's report falsified, and which stays falsifiable if EITHER side drifts.
+``test_live_and_restore_produce_the_same_entry_sequence`` drives BOTH sides off
+ONE real ``InterventionHandler`` round trip (its announce frame + its emitted
+event feed the live app; its history append feeds the restore projection), so
+neither side is a hand-shaped fixture that could agree with the other by
+construction.
+
+The branch under test is on ENTRY PRESENCE, never on delivery route, so the
+FALLBACK leg (an answer whose question this surface never saw — a thin client
+attached after the announce) is a real, reachable leg and gets its own witness:
+``test_answer_with_no_announced_entry_still_appends_a_bare_row`` asserts a row
+that a dead fallback simply cannot produce, alongside an untouched unrelated
+pending entry proving the lookup did not match indiscriminately.
+
+Real instances throughout — a real ``TextualChatApp`` on a real minimal
+``ClientTransport``, a real ``InterventionHandler`` / ``InterventionRegistry`` /
+``SnapshotJournal`` / ``EventLog``, a real ``ReynPresenter``. No mocks, per the
+testing policy.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+from rich.console import Console
+from textual_flowview import FlowView
+
+from reyn.core.events.events import EventLog
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.presenter import ReynPresenter
+from reyn.interfaces.inline.textual_chat.restore import project_restored_frames
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.services.intervention_handler import InterventionHandler
+from reyn.runtime.services.intervention_registry import InterventionRegistry
+from reyn.runtime.services.snapshot_journal import SnapshotJournal
+from reyn.schemas.models import Event
+from reyn.user_intervention import InterventionChoice, UserIntervention
+
+_RAW_ESC_OSC = "\x1b[31mRED\x1b]0;pwn\x07"
+
+
+class QueueTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` fed one frame at a time —
+    display frames AND event frames, so one test can drive the announce and
+    the answer through the SAME stream the app really reads."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+
+    async def push_display(self, msg: OutboxMessage) -> None:
+        await self._queue.put(DisplayFrame(msg))
+
+    async def push_event(self, event: Event) -> None:
+        await self._queue.put(EventFrame(event))
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+        pass
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:  # pragma: no cover - no test drives the panel seam
+        return True
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:  # pragma: no cover - no test drives the panel seam
+        return True
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: OutboxMessage) -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _announce_frame(*, iv_id: str, prompt: str) -> OutboxMessage:
+    """An announce frame shaped as ``InterventionHandler._iv_meta`` builds it."""
+    return OutboxMessage(
+        kind="intervention",
+        text=prompt,
+        meta={
+            "intervention_id": iv_id,
+            "intervention_kind": "confirm",
+            "prompt": prompt,
+            "choices": [
+                {"id": "yes", "label": "Yes", "hotkey": "y"},
+                {"id": "no", "label": "No", "hotkey": "n"},
+            ],
+        },
+    )
+
+
+def _answer_event(*, iv_id: str, text: str, meta: "dict | None" = None) -> Event:
+    return Event(
+        type="intervention_answer_submitted",
+        data={"intervention_id": iv_id, "text": text, "meta": meta or {}},
+    )
+
+
+def _flow_items(app: TextualChatApp) -> "list[OutboxMessage]":
+    return [e.item for e in app.query_one(FlowView).entries]
+
+
+def _render(msg: OutboxMessage) -> str:
+    """Render an intervention entry through the SAME presenter path a live and
+    a restored entry both take."""
+    presentation = ReynPresenter()._present_intervention_pending(msg, 80)
+    # ``force_terminal=False``: styling escapes are the CONSOLE's, not the
+    # entry's — leaving them in would both make the ESC assertions below
+    # ambiguous and make the live/restore comparison depend on whether a
+    # Textual app happened to be mounted when the render ran.
+    console = Console(width=80, no_color=True, force_terminal=False)
+    with console.capture() as cap:
+        console.print(presentation.renderable)
+    return cap.get()
+
+
+def _signature(msg: OutboxMessage) -> "tuple[str, str]":
+    """The comparable shape of one entry: its kind plus what it actually
+    renders as. Compared LIVE-vs-RESTORE only — never against a literal, so
+    this pins no formatting of its own."""
+    if msg.kind == "intervention":
+        return (msg.kind, _render(msg))
+    return (msg.kind, msg.text)
+
+
+# ── The symptom: pending → answered stays ONE entry ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_answered_intervention_is_one_entry_pending_and_after() -> None:
+    """Tier 2: an announce followed by its answer leaves exactly ONE flow
+    entry, settled in place — the owner's 2→1 report, asserted at BOTH
+    sections of the lifecycle.
+
+    The WHILE-PENDING assertions are load-bearing: a build that delivered
+    nothing at all would also end with "no second entry", so the pending
+    section pins that the question really is on screen and unanswered before
+    the answer arrives, and the answered section pins that the SAME entry (not
+    a replacement) then carries the answer."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_announce_frame(iv_id="iv-1", prompt="Delete branch?"))
+        await pilot.pause()
+
+        # ── while pending ──
+        pending = _flow_items(app)
+        assert [m.kind for m in pending] == ["intervention"], (
+            f"expected one pending intervention entry, got {[m.kind for m in pending]}"
+        )
+        assert (pending[0].meta or {}).get("_answer_label") is None, (
+            "the entry must still be UNANSWERED before the answer event arrives"
+        )
+        assert "Delete branch?" in _render(pending[0])
+
+        await transport.push_event(_answer_event(iv_id="iv-1", text="Yes"))
+        await pilot.pause()
+
+        # ── after answering ──
+        answered = _flow_items(app)
+        assert [m.kind for m in answered] == ["intervention"], (
+            "answering must settle the SAME entry, never append a second row; "
+            f"got {[m.kind for m in answered]}"
+        )
+        assert (answered[0].meta or {}).get("_answer_label") == "Yes"
+        rendered = _render(answered[0])
+        assert "Delete branch?" in rendered and "Yes" in rendered, (
+            f"the settled entry must carry BOTH question and answer: {rendered!r}"
+        )
+
+
+# ── The gate: live and restore agree on the entry sequence ───────────────────
+
+
+def _build_handler(
+    tmp_path: Path,
+) -> "tuple[InterventionHandler, InterventionRegistry, list, list, list]":
+    """A real, fully-wired handler whose THREE outputs are all captured:
+    the announce outbox frames, the emitted chat-events, and the history
+    appends — the producer both sides of the gate are driven from."""
+    state_log = StateLog(tmp_path / "state.wal")
+    outbox: "list[OutboxMessage]" = []
+    events: "list[Event]" = []
+    history: "list[dict]" = []
+    event_log = EventLog(subscribers=[events.append])
+    journal = SnapshotJournal(
+        agent_name="test_agent", snapshot_path=tmp_path / "snap.json", state_log=state_log,
+    )
+
+    async def _put_outbox(msg: OutboxMessage) -> None:
+        outbox.append(msg)
+
+    def _append_history(role: str, text: str, ts: str, meta: dict) -> None:
+        history.append({"role": role, "text": text, "meta": meta})
+
+    handler_ref: "list[InterventionHandler]" = []
+
+    async def _on_announce(iv: UserIntervention) -> None:
+        if handler_ref:
+            await handler_ref[0].announce(iv)
+
+    registry = InterventionRegistry(on_announce=_on_announce)
+    handler = InterventionHandler(
+        intervention_registry=registry, journal=journal, event_log=event_log,
+        put_outbox=_put_outbox, append_history=_append_history,
+    )
+    handler_ref.append(handler)
+    return handler, registry, outbox, events, history
+
+
+@pytest.mark.asyncio
+async def test_live_and_restore_produce_the_same_entry_sequence(tmp_path: Path) -> None:
+    """Tier 2: ★ the gate. For ONE real answered intervention, the LIVE entry
+    sequence and the RESTORED entry sequence are the same — same kinds, same
+    rendered content, same length.
+
+    Both sides come from the SAME real ``InterventionHandler`` round trip: its
+    ``announce`` outbox frame and its ``intervention_answer_submitted`` event
+    drive the live app; the history record it appended drives
+    ``project_restored_frames``. That is what makes disagreement (the owner's
+    report: two entries live, one restored) detectable from EITHER side —
+    implementation sameness is not asserted anywhere, because it is a proxy
+    for this, not the property itself."""
+    from _async_wait import wait_until  # noqa: PLC0415 — shared #1751 test helper
+
+    handler, registry, outbox, events, history = _build_handler(tmp_path)
+    iv = UserIntervention(
+        kind="ask_user",
+        prompt="Delete the branch?",
+        run_id="run-1",
+        choices=[
+            InterventionChoice(id="yes", label="Yes", hotkey="y"),
+            InterventionChoice(id="no", label="No", hotkey="n"),
+        ],
+    )
+    dispatch_task = asyncio.ensure_future(handler.dispatch(iv))
+    await wait_until(lambda: bool(registry.list_active()))
+    assert await handler.deliver_answer_to(iv, "", choice_id_override="yes") is True
+    await asyncio.gather(dispatch_task, return_exceptions=True)
+
+    announces = [m for m in outbox if m.kind == "intervention"]
+    answer_events = [e for e in events if e.type == "intervention_answer_submitted"]
+    assert [m.kind for m in announces] == ["intervention"], (
+        f"producer must announce exactly once; outbox={[m.kind for m in outbox]}"
+    )
+    assert [e.type for e in answer_events] == ["intervention_answer_submitted"], (
+        f"producer must broadcast exactly one answer; events={[e.type for e in events]}"
+    )
+
+    # ── live side ──
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(announces[0])
+        await pilot.pause()
+        await transport.push_event(answer_events[0])
+        await pilot.pause()
+        live = [_signature(m) for m in _flow_items(app)]
+
+    # ── restore side ──
+    restored_msgs = [
+        ChatMessage(role=h["role"], content=h["text"], meta=h["meta"]) for h in history
+    ]
+    restored = [
+        _signature(f)
+        for f in project_restored_frames(restored_msgs)
+        if f.kind != "system"
+    ]
+
+    assert live == restored, (
+        "live and restore must render the same entry sequence for the same "
+        f"answered intervention; live={live!r} restored={restored!r}"
+    )
+    # Non-vacuity: both sides must actually SHOW the answered Q→A — two empty
+    # sequences would otherwise compare equal.
+    assert [kind for kind, _ in live] == ["intervention"], (
+        f"expected exactly the answered Q→A entry on both sides, got {live!r}"
+    )
+    assert "Delete the branch?" in live[0][1] and "Yes" in live[0][1]
+
+
+# ── The fallback leg — reached, and asserted on a value a dead leg can't make ─
+
+
+@pytest.mark.asyncio
+async def test_answer_with_no_announced_entry_still_appends_a_bare_row() -> None:
+    """Tier 2: ★ fallback witness. An answer whose intervention this surface
+    never announced (a thin client attached AFTER the announce) still renders
+    — as the bare ``kind="user"`` row it always did, because there is no
+    question entry to fold into.
+
+    A fallback nobody reaches stays green while dead, so this asserts a value
+    the dead leg cannot produce: the ``kind="user"`` row itself, which exists
+    ONLY if the append actually ran. The unrelated pending intervention in the
+    same flow is asserted UNTOUCHED, which is what distinguishes "the lookup
+    found nothing and fell back" from "the lookup matched anything at hand"."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_announce_frame(iv_id="iv-seen", prompt="Unrelated?"))
+        await pilot.pause()
+        await transport.push_event(
+            _answer_event(iv_id="iv-never-announced", text="Osaka", meta={"actor": "bob"})
+        )
+        await pilot.pause()
+
+        items = _flow_items(app)
+        assert [m.kind for m in items] == ["intervention", "user"], (
+            "an uncorrelated answer must still reach the flow as its own row; "
+            f"got {[m.kind for m in items]}"
+        )
+        assert items[1].text == "Osaka"
+        assert (items[1].meta or {}).get("actor") == "bob", (
+            "the fallback leg keeps the answer's attribution meta (ADR-0039)"
+        )
+        assert (items[0].meta or {}).get("_answer_label") is None, (
+            "the unrelated pending intervention must NOT have been settled"
+        )
+
+
+@pytest.mark.asyncio
+async def test_folded_answer_label_is_neutralized_at_the_presenter_boundary() -> None:
+    """Tier 2: the folded answer keeps the wire's RAW bytes (the same thing a
+    persisted answer keeps, which is what lets live and restore compare equal)
+    and is stripped at the ONE shared display boundary —
+    ``ReynPresenter._present_intervention_pending`` — so an ESC/OSC payload in
+    a model-supplied choice label cannot reach the TTY."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_announce_frame(iv_id="iv-1", prompt="Which?"))
+        await pilot.pause()
+        await transport.push_event(_answer_event(iv_id="iv-1", text=_RAW_ESC_OSC))
+        await pilot.pause()
+
+        (item,) = _flow_items(app)
+        rendered = _render(item)
+        assert "\x1b" not in rendered and "\x07" not in rendered, (
+            f"raw ESC/BEL leaked into the settled answer line: {rendered!r}"
+        )
+        assert "RED" in rendered


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3540.

Implements the **architect firm** (and the lead's correction), not the issue body's root-cause paragraph: **the consumer reads the correlation key that is already on the wire and folds in place into the flow entry that already exists. The wire does not change.**

## What changed

`TextualChatApp._handle_intervention_answer_event` now reads the `intervention_id` that `InterventionHandler.deliver_answer_to` has always put on `intervention_answer_submitted`, looks up the `kind="intervention"` flow entry `announce` produced, and stamps `_answer_label` on it in place — the same churn-zero write `_resolve_intervention` makes and the same meta key `restore.py` writes. No second `kind="user"` row.

- **Branch on ENTRY PRESENCE, not delivery route** — `/answer`, an A2A peer and AG-UI HITL all deliver through the one funnel and all saw the announce, so one entry-keyed lookup covers every funnel. No TUI-vs-peer special case.
- **Fallback preserved** — no matching entry (a thin client attached *after* the announce) still appends the bare answer row, with its attribution meta, exactly as before.
- **Correlation is on the flow entry's `meta`, never `_pending_ivs`** — `_resolve_intervention` pops the pending map before the event arrives; the entry is never popped, so it is stable at any point in the answer's lifecycle. (New helper `_announced_intervention_entry`, whose docstring records why.)
- **The prompt stays off the answer event** — the untrusted bytes keep travelling one path, so neutralization keeps one obligation. The fold stamps the wire's RAW label; `ReynPresenter._present_intervention_pending` neutralizes it at the one shared display boundary the restored entry already passes through, so live and restore store the same bytes.
- **`external_source` untouched** — it is stamped on the *history* record (`deliver_answer_to`), never on the event meta; the wire is unchanged, so the taint marker is unaffected.

## Where the gate is aimed

Not "the live implementation matches the restore implementation" — that is a proxy. The gate asserts **live and restore produce the same entry sequence for the same answered intervention**, driven from **one real `InterventionHandler` round trip**: its announce frame + its emitted event feed a real mounted `TextualChatApp`; its history append feeds `project_restored_frames`. Neither side is a hand-shaped fixture that could agree by construction, and drift on *either* side falsifies it.

`test_answered_intervention_is_one_entry_pending_and_after` asserts the entry count and shape **while pending** and **after answering**, so a build that delivers nothing at all cannot pass on "no second entry".

## Files

- `src/reyn/interfaces/inline/textual_chat/app.py` — the fold + `_announced_intervention_entry`; `_resolve_intervention` and `_pump_frames` docstrings re-stated (they described the old "renders straight to the flow" behaviour).
- `src/reyn/interfaces/inline/textual_chat/presenter.py` — `_present_intervention_pending`'s docstring claimed a live answer "arrives here ALREADY neutralized". Falsified by this PR: a live answer now arrives RAW, like a restored one. Fixed in the same PR per the CLAUDE.md doc rule.
- `src/reyn/interfaces/transport/frames.py` — the event-vocabulary comment named `_handle_intervention_answer_event` as the Textual surface's render boundary; for the (now normal) fold leg that boundary is the presenter.
- `tests/test_3540_intervention_answer_fold.py` — new.
- `tests/test_3300_intervention_answer_eventify.py` — docstrings only: its TUI tests all push an answer into an app that never saw the announce, i.e. they are now the fallback leg's witnesses. Said so explicitly rather than leaving a stale "renders straight to the flow" claim.

## Measured: 2 to 1 on a real TTY

Real `TextualChatApp` on a real pty under tmux (100x30), driven through the real transport seam — `answer_intervention_choice` emits the real `intervention_answer_submitted` event back down the frame stream, as the server does. `Enter` selects `Yes` in the panel (the owner's exact path).

**Before** (this PR's fold call site stripped, everything else identical):

```
◆ Delete the branch?
    ✓ answered: Yes

❯ Yes
```

**After**:

```
◆ Delete the branch?
    ✓ answered: Yes
```

The same 2 to 1 was measured for the event-only path (no local panel resolve — the `/answer` / peer shape): before = the pending intervention row **plus** `❯ Yes`; after = one `◆ Delete the branch? / ✓ answered: Yes`.

## Fallback-leg witness (a fallback nobody reaches stays green while dead)

`test_answer_with_no_announced_entry_still_appends_a_bare_row` pushes an answer for `iv-never-announced` into a flow that holds an *unrelated* pending intervention, and asserts:
- the `kind="user"` row exists with its text and its `actor` attribution — a value the dead leg cannot produce, since it exists only if the append actually ran;
- the unrelated pending entry is **still unanswered** — which is what separates "the lookup found nothing and fell back" from "the lookup matched whatever was at hand".

**Strip-falsify (both legs, anchors confirmed unique — `count == 1` before editing):**

| production call site stripped | result |
|---|---|
| the fold lookup (`entry = self._announced_intervention_entry(...)` replaced by `None`) | RED x3, and the failure message *is* the defect: `got ['intervention', 'user']` |
| the fallback append (`_ingest_frame(OutboxMessage(kind="user", ...))`) | RED x4 — my fallback witness **and** the three existing #3300 TUI tests |

Neither strip stayed green.

## Test plan

- [x] `ruff check src tests` — All checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_3540_intervention_answer_fold.py tests/test_3300_intervention_answer_eventify.py` — 11 inspected, 0 errors (two `len(...) == N` format pins rewritten as list-equality assertions)
- [x] `python scripts/verify_module_docstrings.py` on the three changed src files — OK
- [x] `pytest -n auto` (full suite) — **9778 passed, 36 skipped** in 2m24s
- [x] Manual/Visual: real-TTY 2-to-1 reproduction under tmux, local-panel path AND event-only path, before/after — pasted above
- [x] Strip-falsify both legs, anchors verified unique — table above
- [x] Env identity asserted before and during the run: `uv sync --all-extras --dev`, `uv run python -c "import reyn"` resolves inside this worktree's `.venv` (never `--active`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
