### PR TITLE
fix(docs): correct 5 docstrings claiming a mechanism that is not there + gate the LLM-callable claim — #3548

### DIFF
--- a/src/reyn/core/op_runtime/index_drop.py
+++ b/src/reyn/core/op_runtime/index_drop.py
@@ -2,10 +2,18 @@
 
 Destructive op: drops the SQLite backend + removes the SourceManifest entry.
 
-Permission gate: mirrors require_mcp_install pattern (ADR-0029).
-  - Caller must declare `permissions.index_drop: true`.
-  - Config may hard-allow or hard-deny (permissions.index_drop: allow/deny).
-  - Interactive prompt or REYN_INDEX_DROP_AUTO_APPROVE=1 CI escape hatch.
+Permission gate (#571 permission-collapse arc, Phase 5): the uniform
+file-write axis, NOT a bool axis of its own.
+  - Caller must declare `file.write` over `.reyn/config/index/sources.yaml`
+    (the manifest) and the source's own index dir.
+  - A sandbox `write_paths` cap is threaded in and constrains it; the delete
+    self-gates again at the real write site inside the backend, so a
+    resolver-less caller is gated too (#2856 Part B).
+  - The bool-axis `permissions.index_drop` decl, its ask-prompt, and the
+    `REYN_INDEX_DROP_AUTO_APPROVE=1` escape hatch this docstring used to
+    describe are GONE — `require_index_drop` no longer exists on
+    `PermissionResolver`. Per-source granularity is not preserved (see the
+    inline note on the gate below).
 
 P6 event: emits `index_dropped` after completion (audit trail).
 """
@@ -37,8 +45,8 @@ async def handle(
             "index_drop: op_runtime context has no workspace. Index ops "
             "require a workspace to locate the SQLite backend; pass an "
             "OpContext with a populated `workspace` field. This typically "
-            "indicates the calling tool (e.g. drop_source) was invoked from "
-            "a router-side path without a workspace."
+            "indicates the caller was dispatched from a path that carries "
+            "no workspace."
         )
 
     workspace_root = ctx.workspace.base_dir

--- a/src/reyn/core/op_runtime/index_query.py
+++ b/src/reyn/core/op_runtime/index_query.py
@@ -66,8 +66,8 @@ async def handle(
             "index_query: op_runtime context has no workspace. Index ops "
             "require a workspace to locate the SQLite backend; pass an "
             "OpContext with a populated `workspace` field. This typically "
-            "indicates the calling tool (e.g. semantic_search, drop_source) was "
-            "invoked from a router-side path without a workspace."
+            "indicates the caller (e.g. the semantic_search macro op) was "
+            "dispatched from a path that carries no workspace."
         )
 
     workspace_root = ctx.workspace.base_dir

--- a/src/reyn/core/op_runtime/index_update.py
+++ b/src/reyn/core/op_runtime/index_update.py
@@ -104,9 +104,11 @@ async def handle(op: IndexUpdateIROp, ctx: OpContext) -> dict:
     # Permission gate — own-write (not destructive), same shape as
     # index_query's read gate / index_drop's write gate: declares
     # file.write authority over this source's own index + the sources.yaml
-    # manifest, so a sandbox write_paths cap constrains it. Default-ALLOW
-    # posture (no ask-gate) comes from the ToolGates on the `index_update`
-    # ToolDefinition, not from this call.
+    # manifest, so a sandbox write_paths cap constrains it. The default-ALLOW
+    # posture (no ask-gate) is the file.write gate's own outcome — it used to
+    # be attributed to the ToolGates on an `index_update` ToolDefinition, but
+    # that tool was retired by FP-0066 P1b (#3257), so this call site plus the
+    # backend's own write-site self-gate are the WHOLE gate now.
     if ctx.permission_resolver is not None:
         # Derive the DB path via the SAME `cache_dir_for_source` helper
         # `SqliteIndexBackend._db_path` uses for the actual write, so the gate

--- a/src/reyn/core/op_runtime/mcp_drop_server.py
+++ b/src/reyn/core/op_runtime/mcp_drop_server.py
@@ -7,8 +7,10 @@ matching secret env keys from ~/.reyn/secrets.env.
 Handler logic (one-shot, no sub-phases):
   1. Resolve scope — explicit (op.scope) or auto-detect by walking
      local → project → user tiers for the first match.
-  2. Gate via PermissionResolver.require_mcp_drop_server (mirrors
-     require_mcp_install but uses a distinct decl field).
+  2. Gate via PermissionResolver.require_file_write over the scope's config
+     file (mirrors mcp_install). The bool-axis ``require_mcp_drop_server``
+     this line used to name was removed by the #571 permission-collapse arc
+     (Phase 5) and no longer exists on ``PermissionResolver``.
   3. Capture the server's env block so we know which secret keys to
      clean up (= `${KEY}` references inside the entry).
   4. Remove the entry from yaml, prune empty `mcp.servers` / `mcp`
@@ -24,7 +26,7 @@ Scope → file mapping mirrors mcp_install:
 
 This is a P5 exception: reyn.yaml lives outside the workspace, so the
 OS handler writes it directly (same pattern as mcp_install). The
-action is gated behind require_mcp_drop_server (FP-0034 §D23) and
+action is gated behind the uniform file-write axis (see step 2) and
 recorded via event (P6), preserving the audit trail.
 """
 from __future__ import annotations
@@ -162,7 +164,8 @@ async def handle(
 
     Raises:
         ValueError: when ``op.server`` is empty.
-        PermissionError: when require_mcp_drop_server gate denies the op.
+        PermissionError: when the file-write gate on the scope's config file
+            denies the op.
         FileNotFoundError-equivalent: when ``op.server`` is not present in
             any scope (returned as a ``{status: "not_found"}`` dict, not
             an exception — the LLM should be able to retry or move on).

--- a/src/reyn/core/op_runtime/mcp_install.py
+++ b/src/reyn/core/op_runtime/mcp_install.py
@@ -3,7 +3,12 @@
 Handler logic (one-shot, no sub-phases):
   1. Fetch server.json via RegistryClient
   2. Check runtime command availability (npx / uvx / docker / dnx)
-  3. Gate via PermissionResolver.require_mcp_install (ADR-0029)
+  3. Gate via PermissionResolver.require_file_write (the config file it
+     mutates) + require_http_get (the registry host it fetched from). The
+     bool-axis ``require_mcp_install`` this line used to name was removed by
+     the #571 permission-collapse arc (Phase 5) and no longer exists on
+     ``PermissionResolver``; per-server granularity is enforced at call time
+     by the ``permissions.mcp`` gate instead.
   4. Prompt for secret env vars via intervention_bus; persist with secrets.store
   5. Reload (#2761 PR-3): a PURE ADDITION on a live per-session reloader takes the
      IMMEDIATE mid-turn path — PROBE the server (spawn/connect + list_tools) FIRST,
@@ -21,8 +26,8 @@ Scope → file mapping:
 
 This is a P5 exception: reyn.yaml lives outside the workspace, so the OS
 handler writes it directly (same pattern as `reyn config set`). The action
-is gated behind require_mcp_install permission (ADR-0029) and recorded via
-event (P6), which preserves the audit trail.
+is gated behind the uniform file-write + http-get permission axes (see step
+3) and recorded via event (P6), which preserves the audit trail.
 """
 from __future__ import annotations
 

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -721,7 +721,11 @@ class SemanticSearchIROp(BaseModel):
     enumeration anyway).
 
     Handler dispatches sub-ops via the OS dispatch path (= iterate op
-    precedent). LLM-callable via ToolDefinition `semantic_search`.
+    precedent). NOT LLM-callable: there is no `semantic_search`
+    ToolDefinition — the agent-facing layer-1 RAG tool of that name was
+    RETIRED by FP-0066 P1b (#3257) as a pre-audience-split relic. This op
+    is the OS-internal substrate that tool used to ride, reached only
+    through the op_runtime dispatch path.
     """
     kind: Literal["semantic_search"]
     query: str
@@ -734,8 +738,16 @@ class SemanticSearchIROp(BaseModel):
 class IndexDropIROp(BaseModel):
     """Remove an indexed source entirely (ADR-0033 §2.1).
 
-    `permissions.index_drop: ask` default (= ADR-0029 mirror, destructive op
-    consent gate). LLM-callable via ToolDefinition `drop_source`.
+    Permission gate: the caller must hold `file.write` over the source
+    manifest (`.reyn/config/index/sources.yaml`) plus the source's own index
+    dir, and the destructive delete self-gates at the real write site inside
+    the backend. The bool-axis `permissions.index_drop` / `require_index_drop`
+    ask-prompt this docstring used to describe was removed by the #571
+    permission-collapse arc (Phase 5) — see `op_runtime/index_drop.py`.
+
+    NOT LLM-callable: there is no `drop_source` ToolDefinition — the
+    agent-facing layer-1 RAG tool of that name was RETIRED by FP-0066 P1b
+    (#3257). This op is the OS-internal substrate it used to ride.
     """
     kind: Literal["index_drop"]
     source: str
@@ -774,10 +786,18 @@ class IndexUpdateIROp(BaseModel):
     source (an existing source's `embedding_model` field is authoritative
     over a caller-supplied override — a source is one embedding space).
 
-    `permissions.index_drop`-style ask-gate does NOT apply here (index_update
-    is additive/own-write, not destructive) — default-ALLOW, mirroring
-    `embed`/`index_query`.
-    LLM-callable via ToolDefinition `index_update`.
+    Permission gate: additive/own-write (not destructive), so it declares
+    `file.write` over this source's own index + the sources.yaml manifest and
+    nothing more — same shape as `index_query`'s read gate and `index_drop`'s
+    write gate, and constrained by a sandbox `write_paths` cap. There is no
+    ask-prompt on either this op or `index_drop` (the bool-axis
+    `require_index_drop` was removed by the #571 permission-collapse arc,
+    Phase 5), and the default-ALLOW posture no longer comes from a
+    ToolDefinition's `ToolGates` — see the next paragraph.
+
+    NOT LLM-callable: there is no `index_update` ToolDefinition — the
+    agent-facing layer-1 RAG tool of that name was RETIRED by FP-0066 P1b
+    (#3257). This op is the OS-internal substrate it used to ride.
     """
     kind: Literal["index_update"]
     source: str

--- a/src/reyn/tools/descriptions/__init__.py
+++ b/src/reyn/tools/descriptions/__init__.py
@@ -25,10 +25,13 @@ the ``mcp`` module precedent from Phase 2 (mixed ``category`` values,
 grouped by feature).
 
 ``ALL`` aggregates every bucket's descriptions into one
-``dict[str, ToolDescription]`` keyed by a package-unique entry name (NOT
-always the bare tool name — e.g. ``semantic_search_hide_legacy`` shares
-``tool_name="semantic_search"`` with the ``semantic_search`` entry, since it
-is an alternate, currently-unwired description variant for that same tool).
+``dict[str, ToolDescription]`` keyed by a package-unique entry name. The key
+is ALLOWED to differ from the record's ``tool_name`` — that is what makes two
+description variants for one tool expressible. Read the key as an entry id,
+never as a tool name. (The example this docstring used to give, a
+``semantic_search`` / ``semantic_search_hide_legacy`` pair, was retired along
+with the agent-facing RAG tools in FP-0066 P1b (#3257) — the shape is still
+supported, the illustration was not replaced.)
 """
 from __future__ import annotations
 

--- a/src/reyn/tools/mcp_drop.py
+++ b/src/reyn/tools/mcp_drop.py
@@ -16,8 +16,8 @@ FP-0034 §D23, this op lives in the universal catalog under
 
 The handler delegates to op_runtime.mcp_drop_server.handle, which:
   1. Resolves scope (= explicit or auto-detect)
-  2. Gates via require_mcp_drop_server (FP-0034 §D23 — distinct from
-     mcp_install permission)
+  2. Gates via require_file_write on the scope's config file (the bool-axis
+     ``require_mcp_drop_server`` was removed by the #571 arc, Phase 5)
   3. Removes the YAML entry
   4. Optionally cleans secrets
   5. Emits mcp_server_removed P6 event

--- a/src/reyn/tools/mcp_install.py
+++ b/src/reyn/tools/mcp_install.py
@@ -10,7 +10,9 @@ bare-name path (a pipeline ``tool: mcp_install`` step resolves through
 The handler delegates to op_runtime.mcp_install.handle, which performs:
   1. Registry fetch (RegistryClient.get_server)
   2. runtimeHint existence check
-  3. Permission gate (PermissionResolver.require_mcp_install / ADR-0029)
+  3. Permission gate (PermissionResolver.require_file_write on the config
+     file + require_http_get on the registry host — the bool-axis
+     ``require_mcp_install`` was removed by the #571 arc, Phase 5)
   4. Secret env vars prompt + secrets.store persistence
   5. reyn.yaml / reyn.local.yaml write (scope-dependent)
   6. mcp_server_installed event emit (P6)

--- a/tests/test_llm_callable_claim_resolves_3548.py
+++ b/tests/test_llm_callable_claim_resolves_3548.py
@@ -1,0 +1,130 @@
+"""Tier 2: a docstring's ``LLM-callable via ToolDefinition X`` claim must name a
+tool the default registry actually resolves (#3548).
+
+The claim is a reachability statement about the LLM's surface — "the model can
+call this" — and a reader (human or agent) has no other cheap way to check it.
+#3548's three instances (``semantic_search`` / ``drop_source`` /
+``index_update``) survived FP-0066 P1b (#3257), which retired the very
+``ToolDefinition``s they named; the ops kept working as OS-internal substrate,
+so nothing failed and nothing noticed. This module is the gate that would have
+turned that PR red.
+
+**Why this pair is gateable at all** — and the pair CLAUDE.md warns is NOT:
+``control-ir.md`` ↔ ``OP_KIND_MODEL_MAP`` is explicitly on the author, not on
+CI. The difference is that "is this name in the registry?" has a single,
+total, in-process answer: ``get_default_registry()`` builds by executing a
+straight-line sequence of ``registry.register(...)`` calls with no config,
+env, or plugin conditional in it, so absence from it is absence, full stop —
+there is no "registered only when X is configured" reading that would make a
+true claim look false here. If that ever stops being true (a conditional
+registration lands), this gate starts producing false positives and the
+honest fix is to teach it the condition or delete it, not to weaken the
+claim's wording.
+
+Scope note: the gate can only see the ONE prose form. A docstring that says
+"the LLM calls this as ``foo``" is invisible to it. It is a drift-arrester for
+the established phrasing, not a proof that every reachability claim in ``src``
+is true — and the self-test below keeps it from silently becoming neither.
+
+Real instances throughout: the real source tree, the real registry.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+from reyn.tools import get_default_registry
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
+
+# ``(?<!NOT )`` keeps a NEGATED claim ("NOT LLM-callable ...") from being read as
+# an assertion — the correction #3548 lands uses exactly that wording, so without
+# the guard the fix would fail its own gate.
+_CLAIM = re.compile(r"(?<!NOT )LLM-callable via ToolDefinition\s+`{1,2}([A-Za-z_][A-Za-z0-9_]*)`{1,2}")
+
+
+def _claims_in_source(source: str, label: str) -> list[tuple[str, str]]:
+    """Every ``(tool_name, where)`` claim in ``source``'s docstrings.
+
+    AST, not a raw-text regex: a regex over the whole file matches inside string
+    literals and comments too, which is how #3548's own sweep produced false
+    positives before it was redone in-process.
+    """
+    found: list[tuple[str, str]] = []
+    tree = ast.parse(source, label)
+    for node in ast.walk(tree):
+        if not isinstance(
+            node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+        ):
+            continue
+        doc = ast.get_docstring(node, clean=False)
+        if not doc:
+            continue
+        # Docstrings wrap; the claim can straddle a newline.
+        flat = " ".join(doc.split())
+        for match in _CLAIM.finditer(flat):
+            where = f"{label}::{getattr(node, 'name', '<module>')}"
+            found.append((match.group(1), where))
+    return found
+
+
+def _claims_in_tree() -> list[tuple[str, str]]:
+    found: list[tuple[str, str]] = []
+    for path in sorted(_SRC.rglob("*.py")):
+        found.extend(
+            _claims_in_source(path.read_text(encoding="utf-8"), str(path.relative_to(_SRC.parent.parent)))
+        )
+    return found
+
+
+def test_extractor_finds_a_claim_and_ignores_a_negated_one() -> None:
+    """Tier 2: the instrument works — a zero from the sweep below is a finding,
+    not a broken regex. Both legs matter: it must SEE the positive form (else
+    the gate is vacuous) and must NOT see the negated form (else the #3548
+    correction, which says "NOT LLM-callable", fails the gate it ships with).
+    """
+    module = '''
+"""Header.
+
+LLM-callable via ToolDefinition ``definitely_not_a_real_tool``.
+"""
+
+
+class A:
+    """Body text.
+
+    NOT LLM-callable: there is no ``also_not_real`` ToolDefinition — retired.
+    LLM-callable via ToolDefinition `another_fake_tool`.
+    """
+'''
+    names = {name for name, _ in _claims_in_source(module, "<synthetic>")}
+    assert "definitely_not_a_real_tool" in names
+    assert "another_fake_tool" in names
+    assert "also_not_real" not in names
+
+
+def test_synthetic_claim_would_go_red() -> None:
+    """Tier 2: the gate has teeth — a claim naming an unregistered tool is
+    detectable as unresolved by the SAME lookup the sweep uses.
+    """
+    registered = set(get_default_registry().names())
+    assert "definitely_not_a_real_tool" not in registered
+
+
+def test_every_llm_callable_claim_resolves_in_the_default_registry() -> None:
+    """Tier 2: the invariant — each claim names a tool the registry resolves."""
+    claims = _claims_in_tree()
+    assert claims, (
+        "no 'LLM-callable via ToolDefinition X' claim found anywhere in src/ — "
+        "either the phrasing was abandoned (retire this gate) or the sweep is "
+        "broken (fix it); a silent zero here makes the gate vacuous."
+    )
+    registry = get_default_registry()
+    unresolved = [(name, where) for name, where in claims if registry.lookup(name) is None]
+    assert not unresolved, (
+        "docstring claims 'LLM-callable via ToolDefinition X' for a tool the "
+        f"default registry does not resolve: {unresolved}. Either the tool was "
+        "retired (correct the docstring — say what the op IS reachable through) "
+        "or the registration was dropped (restore it)."
+    )

--- a/tests/test_op_runtime_index_workspace_guard.py
+++ b/tests/test_op_runtime_index_workspace_guard.py
@@ -7,18 +7,19 @@ Pinned invariant:
 - Each of the 3 index op handlers checks ``ctx.workspace is None`` BEFORE
   attempting ``ctx.workspace.base_dir`` access.
 - On None, the handler raises ``ValueError`` with an actionable error
-  message that names (a) the op kind, (b) the cause (= router-side path
-  with no workspace), (c) the fix path (= pass an OpContext with
+  message that names (a) the op kind, (b) the cause (= dispatched from a
+  path carrying no workspace), (c) the fix path (= pass an OpContext with
   workspace).
 - The opaque ``AttributeError: 'NoneType' object has no attribute
   'base_dir'`` is no longer surfaced to control_ir_failed events.
 
 Motivation: B48 W2-S7 (= chained_find_then_index) showed 4 consecutive
 ``control_ir_failed`` events with the opaque AttributeError. The
-``ctx.workspace`` was None because the calling tool (e.g. recall)
-propagated a workspace-less ToolContext through. The opaque error
-prevented the LLM and operators from understanding the actual cause.
-This guard makes the failure mode actionable.
+``ctx.workspace`` was None because the caller propagated a workspace-less
+context through (at the time, the agent-facing RAG tools that FP-0066 P1b
+later retired). The opaque error prevented the LLM and operators from
+understanding the actual cause. This guard makes the failure mode
+actionable.
 
 testing.ja.md compliance:
 - No mocks. Real ``handle()`` called against a real OpContext with
@@ -87,7 +88,8 @@ def test_index_query_raises_clear_value_error_when_workspace_none():
     assert "workspace" in msg.lower()
     # actionable hint: should mention OpContext + how to fix
     assert "OpContext" in msg
-    assert "router-side" in msg.lower()
+    # …and name the cause, not just the symptom (the dispatching path had none)
+    assert "dispatched" in msg.lower()
 
 
 def test_index_query_fallback_path_bypasses_workspace_check():


### PR DESCRIPTION
**[per-PR-coder]** — part of #3548.

## Verdicts — all three are ⓑ (the claim is stale), and I measured that before treating them alike

| claim | verdict | evidence |
|---|---|---|
| `semantic_search` | **ⓑ stale** | `0c22a1c05` — *"feat(FP-0066 P1b): retire layer-1 agent-facing RAG tools (semantic_search/index_update/drop_source/list_rag_sources)"* (#3257). The `ToolDefinition` was deleted; `router_tools.py:623` and `tools/__init__.py:148` both carry the retirement note. |
| `drop_source` | **ⓑ stale** | same commit. Zero `name=`/register hit in `src/` (lead-coder's finding, re-confirmed). |
| `index_update` | **ⓑ stale** | same commit; `tools/descriptions/io.py:14` records the `ToolDescription` records going with it. |

**Not ⓐ (conditional).** `get_default_registry()` (`src/reyn/tools/__init__.py:140`) is a straight-line sequence of `registry.register(...)` calls — **no `if`, no config read, no env read, no plugin hook** in the body. So "absent from the default registry" cannot mean "registered when something is configured". **Not ⓒ**: `ToolRegistry()` is constructed in exactly one place in `src/`.

Measurement was in-process AST + `registry.lookup`, not a regex over the file — the two known-true claims (`load_skill`, `embed`) came back `True` in the same sweep, so the zero for the other three is an observation and not a broken instrument.

## What the fix corrects beyond the three lines

Re-reading each touched docstring in full (CLAUDE.md's doc rule: read the section, not the keyword) found two more false claims *inside the same paragraphs*:

- `IndexDropIROp`: "`permissions.index_drop: ask` default (destructive op consent gate)" — the bool axis, its ask-prompt and `require_index_drop` were removed by the **#571 permission-collapse arc, Phase 5**. `require_index_drop` is not a `PermissionResolver` method. The live gate is `require_file_write` + the backend's own write-site self-gate (#2856 Part B).
- `IndexUpdateIROp`: attributes its default-ALLOW posture to "the ToolGates on the `index_update` ToolDefinition" — which is the very thing FP-0066 P1b deleted. Same wrong attribution in an inline comment at `op_runtime/index_update.py:108`.

## The extra claims from the brief — one same-class, one NOT

**Same class, folded in — `require_mcp_install` / `require_mcp_drop_server`.** Verified by introspection: `[m for m in dir(PermissionResolver) if m.startswith("require_")]` → `require_file_read, require_file_write, require_http_get, require_mcp, require_media_load, require_plugin_git_run_code_trust, require_secret_write, require_tool, require_web_fetch`. **Neither method exists.** 8 docstring lines across `op_runtime/mcp_install.py`, `op_runtime/mcp_drop_server.py`, `tools/mcp_install.py`, `tools/mcp_drop.py`, `op_runtime/index_drop.py` assert gating through them. The two *inline comments* at `mcp_install.py:413` / `mcp_drop_server.py:216` already say the axis was removed (#571 Phase 5) — the module docstrings above them contradicted the code directly below. Corrected to name the real gate (`require_file_write` + `require_http_get`).

**NOT the same class — `require_tool` at `capability-profile.md:130`. Reported, not touched.** The doc says one shared builder `contextual_deny_message` produces the deny text for the router-loop tool gate, `require_tool`, and `require_mcp`. **That claim is true at the code level**: `permissions.py:1466` `require_tool` does call `contextual_deny_message` (`permissions.py:~1500`). What is true is the *other* fact from #3546 — `require_tool` has **zero `src/` callers** (only tests). That is a *dead gate*, not a docstring asserting a mechanism that is not there, so widening this diff to it would be treating two different defects as one. Left for a separate decision.

## Also found, deliberately NOT in this diff

`docs/concepts/agent-engineering/retrieval-engineering.md`, `docs/concepts/data-retrieval/operational-intelligence.md` (+ `.ja` siblings) and `docs/concepts/data-retrieval/rag.ja.md:159` describe `semantic_search` as *"a typed Control IR op the LLM calls directly"* / *"a built-in tool the LLM itself calls during an ordinary `reyn chat` session"*, and `index_update()` as a safe-mode entry point (retired by FP-0066 **P1c**). That is the same falsehood at the concept-doc layer, but it is a multi-document narrative rewrite about what reyn's retrieval story *is* — it needs a decision about the post-audience-split story, not a per-line correction. Filing recommended; I did not widen into it.

## Gate: recommended AND built — `tests/test_llm_callable_claim_resolves_3548.py`

The brief asked me to say so if conditional registration would make such a gate produce false positives. **It would not, and I measured why**: the registry builder has no conditional in it, so absence is total. The gate AST-sweeps `src/**/*.py` docstrings for `LLM-callable via ToolDefinition X` and asserts each `X` resolves via `get_default_registry().lookup()`.

Honest about its limits, in the module docstring: it sees **one prose form only** — a docstring phrased *"the LLM calls this as `foo`"* is invisible to it. It is a drift-arrester for the established phrasing, not a proof about every reachability claim in `src/`. Two supporting tests keep it from becoming vacuous: the extractor must find the positive form (and must *not* match the negated `NOT LLM-callable` form this PR introduces), and the unresolved-lookup leg is exercised directly.

**RED witness on real pre-fix content** (not a synthetic): running the sweep against `git show main:src/reyn/schemas/models.py` yields
`UNRESOLVED: [('semantic_search', …), ('drop_source', …), ('index_update', …)]` while `load_skill`/`embed` resolve.

Note on precedent: CLAUDE.md is explicit that `control-ir.md` ↔ `OP_KIND_MODEL_MAP` is on the author, not CI. The difference here is that the checked side is *in-process and total* — a registry membership question, not a prose-vs-map comparison.

## Test plan

- [x] `ruff check src tests` — All checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_llm_callable_claim_resolves_3548.py tests/test_op_runtime_index_workspace_guard.py` — 7 inspected, 0 errors
- [x] `pytest -n auto` (full suite, repo root) — **9801 passed, 36 skipped**
- [x] `python scripts/verify_module_docstrings.py <9 changed src files>` — OK
- [x] Falsify: gate goes RED against pre-fix `models.py` (3 unresolved) — output above
- [x] Falsify: the correction's own `NOT LLM-callable` wording does not trip the gate (covered by `test_extractor_finds_a_claim_and_ignores_a_negated_one`)
- [x] `tests/test_op_runtime_index_workspace_guard.py` updated in the same PR — it pinned the old error string that named the retired `semantic_search`/`drop_source` tools as the cause; assertion + docstring now pin the corrected cause.
