### PR TITLE
fix(permissions): agent-step worker inherits + composes the invoker's per-session narrowing — #3553

### DIFF
--- a/docs/reference/runtime/pipeline-dsl.md
+++ b/docs/reference/runtime/pipeline-dsl.md
@@ -409,8 +409,9 @@ an R1 expression — see below.
 
 An LLM-driven leaf step: `prompt` (a template string) is interpolated against
 the current context and run as one turn in an ephemeral session,
-capability-narrowed to `capabilities` (or the invoker's own profile if
-omitted) under `identity` (or the invoker's own identity if omitted).
+capability-narrowed to `capabilities` **composed with** the invoker's own
+per-session narrowing — never instead of it — under `identity` (or the
+invoker's own identity if omitted).
 
 ```yaml
 - agent: {prompt: "Summarize: {ctx.doc}", capabilities: {tools: [read_file]}, schema: Summary, output: summary}
@@ -420,7 +421,7 @@ omitted) under `identity` (or the invoker's own identity if omitted).
 |-----|----------|---------|
 | `prompt` | yes | A template string — `{ctx.dotted.path}` / `{pipe}` references are interpolated (values only, no operators — this is string interpolation, not an R1 expression). |
 | `identity` | no | The agent identity to run under. Defaults to the run's invoker. A **registered** pipeline may name any identity; an **inline, agent-generated** pipeline may only name the invoker's own identity — naming another agent's identity is rejected by the static-analysis gate as a capability escalation (see [Ad-hoc inline launch](#ad-hoc-inline-launch)). |
-| `capabilities` | no | `{tools: [NAME*]}` — narrows the ephemeral session's tool surface. Restrict-only: a pipeline step can never exceed the invoker's own envelope. |
+| `capabilities` | no | `{tools: [NAME*]}` — narrows the ephemeral session's tool surface. Restrict-only: a pipeline step can never exceed the invoker's own envelope. The two narrowings are composed most-restrictive-wins — denies union, allow-lists intersect, and an omitted allow-list means "no restriction from this side", so omitting `capabilities` leaves the invoker's own allow-list in force rather than clearing it. |
 | `schema` | no | Same `verify: schema` semantics as `tool`, applied to the parsed JSON reply. |
 | `output` | no | Named store to write the result to. |
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1661,6 +1661,20 @@ class Session:
         return self._agent.agent_id
 
     @property
+    def session_id(self) -> str:
+        """This session's LIVE sid — the second half of the ``(agent, sid)`` key
+        every per-session workspace surface is keyed by (``config.yaml`` narrowing,
+        snapshot, state dir).
+
+        A live read, not the construction-time value: ``spawn_session_recorded``
+        re-keys a spawned session AFTER constructing it (``session._session_id =
+        new_sid``), so anything caching the constructor's ``session_id`` argument is
+        stale for exactly the sessions that were spawned programmatically. #3553
+        added it because ``run_agent_step`` holds its invoker as a whole ``Session``
+        and needs that key to look the invoker's own narrowing back up."""
+        return self._session_id
+
+    @property
     def model(self) -> str:
         return self._model_override if self._model_override is not None else self._agent.model
 

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -170,7 +170,9 @@ async def spawn_ephemeral_session(
     )
 
 
-def _build_agent_step_narrowing(capabilities: "list[str] | None") -> dict:
+def _build_agent_step_narrowing(
+    capabilities: "list[str] | None", parent_narrowing: "dict | None" = None,
+) -> "dict | None":
     """The per-session narrowing an ``agent`` step spawns under.
 
     ``tool_deny`` always includes ``_DELEGATION_DENY_TOOLS`` — a v1
@@ -179,12 +181,35 @@ def _build_agent_step_narrowing(capabilities: "list[str] | None") -> dict:
     (``profile_permits``: ``in_allow and tool not in tool_deny``), so even a
     ``capabilities`` list that names a delegation tool is denied at the live
     gate. ``tool_allow`` is set only when the caller passes an explicit
-    ``capabilities`` list — omitting it (``None``) leaves the agent's normal
-    envelope untouched (restrict-only narrowing, never a re-grant)."""
+    ``capabilities`` list.
+
+    ``parent_narrowing`` (#3553) is the INVOKER's own sid-keyed #2103-S1a mapping
+    (``AgentRegistry.per_session_narrowing``), composed in through
+    ``capability_profile.compose_narrowing_mappings`` (deny ∪, allow ∩, absent
+    allow = ⊤). ⚠️ This docstring used to say that omitting ``capabilities``
+    "leaves the agent's normal envelope untouched (restrict-only narrowing, never
+    a re-grant)". That was true only against the AGENT's own declaration, which is
+    name-keyed and therefore re-derived on the worker for free — and false against
+    the INVOKER, which is what a reader checks it for: the worker is born under a
+    FRESH sid, so before #3553 the invoker's sid-keyed narrowing resolved to
+    nothing on it and the two keys built here were the child's WHOLE envelope. An
+    invoker narrowed to ``tool_allow: [A]`` therefore handed a ``capabilities``-less
+    agent step a worker with no allow-list at all — a widening, not a restriction,
+    and measured (``tests/test_3553_agent_step_worker_narrowing_inheritance.py``) as
+    a denied tool's real side effect happening inside an agent step. The
+    composition, not this function's own two keys, is what makes the claim true now,
+    and only for the layers ``per_session_narrowing`` carries — see
+    ``run_agent_step``'s call site for which layers those are.
+
+    Returns ``None`` when there is nothing to impose at all, which cannot happen
+    today (``_DELEGATION_DENY_TOOLS`` is non-empty) but keeps the return type the
+    same as the composition's."""
+    from reyn.security.permissions.capability_profile import compose_narrowing_mappings
+
     narrowing: dict[str, Any] = {"tool_deny": list(_DELEGATION_DENY_TOOLS)}
     if capabilities is not None:
         narrowing["tool_allow"] = list(capabilities)
-    return narrowing
+    return compose_narrowing_mappings(parent_narrowing, narrowing)
 
 
 async def run_agent_step(
@@ -266,7 +291,27 @@ async def run_agent_step(
             "(no registry to validate against)."
         )
 
-    narrowing = _build_agent_step_narrowing(capabilities)
+    # #3553: the leaf worker is a NEW permission envelope, born under a FRESH sid, so
+    # the invoker's sid-keyed #2103-S1a narrowing does not reach it by identity the way
+    # the name-keyed layers do (the agent's own ``permissions`` declaration, its topology
+    # ``capability_profile`` bindings, the #2081 ``_delegate`` floor — all re-derived from
+    # the agent NAME by ``resolved_profile_for``). It has to be read back off the invoker
+    # and composed with this step's own narrowing, or a ``capabilities``-less agent step
+    # hands the worker a strictly WIDER envelope than the session that asked for it. This
+    # is the same seam #3546/#3554 closed one level up, for the pipeline driver-session
+    # that is typically the ``invoker_session`` here; the two layers the sibling site
+    # deliberately does NOT carry are unchanged (the #2285 in-memory ``/visibility``
+    # toggle and the #1827-S4b ephemeral untrusted-context narrowing, which
+    # ``Session._ephemeral_contextual_for_turn`` re-derives per turn from the session's
+    # OWN history and so is not an inheritable value at all).
+    parent_narrowing = (
+        registry.per_session_narrowing(
+            invoker_session.agent_name, invoker_session.session_id,
+        )
+        if invoker_session is not None
+        else None
+    )
+    narrowing = _build_agent_step_narrowing(capabilities, parent_narrowing)
     # #2769 (refines #2706/#2710 P3-item3): an agent-step's user-reaching capabilities route to the
     # pipeline INVOKER when one is threaded in (``BridgeToParent(invoker_session)`` — the driver
     # session), so ``ask_user`` / permission / ``safety.limit`` / elicitation AND ``present`` reach

--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -193,6 +193,77 @@ def compose_resolved(
     )
 
 
+#: The narrowing-MAPPING keys :func:`load_capability_profile` reads as an
+#: ALLOW-shaped axis — a value stays reachable only if EVERY term lists it, and an
+#: ABSENT key is ⊤ (no restriction on that axis), never the empty set. ``categories``
+#: belongs here and not with the denies: it is the KEEP-VISIBLE set, so intersecting
+#: it is what ``compose_resolved`` expresses as "union the excluded categories".
+_NARROWING_ALLOW_KEYS: "tuple[str, ...]" = ("tool_allow", "mcp_allow", "categories")
+
+#: The narrowing-MAPPING keys read as a DENY-shaped axis — any term's deny wins, so
+#: they compose by union. An absent key is the empty set.
+_NARROWING_DENY_KEYS: "tuple[str, ...]" = ("tool_deny", "mcp_deny")
+
+
+def compose_narrowing_mappings(
+    parent: "dict | None", child: "dict | None",
+) -> "dict | None":
+    """Compose two RAW narrowing MAPPINGS, most-restrictive-wins (#3553).
+
+    The mapping-level sibling of :func:`compose_resolved`, and derived from the same
+    two rules rather than from a fresh judgement: **union of denials, intersection
+    of allows**, applied uniformly to every axis. It exists because the sid-keyed
+    #2103-S1a layer is carried between sessions as the raw ``config.yaml`` mapping
+    (``AgentRegistry.per_session_narrowing`` → ``spawn_session_recorded(narrowing=)``),
+    so a spawner that ALSO imposes a narrowing of its own has to combine the two
+    BEFORE the child's file is written — there is no later seam where the child could
+    still see its parent's mapping.
+
+    The three cases are each uniquely determined, so composing is not a policy choice:
+
+    - parent-only key — the child does not constrain that axis, so the parent's value
+      stands (allow: ``parent ∩ ⊤ = parent``; deny: ``parent ∪ ∅ = parent``).
+    - child-only key — symmetrically the child's value stands. ⚠️ This is the case an
+      absent ALLOW key must NOT be read as the empty set: reading it as ∅ would make a
+      childless axis deny everything, and reading the PARENT's absence as ∅ would make
+      the composition unable to widen back — both are wrong for the same reason.
+    - both — deny keys union, allow keys intersect.
+
+    A key in neither table is one :func:`load_capability_profile` does not read, so it
+    cannot change either session's live envelope whichever value survives; the child's
+    is taken. That "cannot change" holds only while the two tables cover every axis
+    field of :class:`CapabilityProfile`, which is why a test pins exactly that — a new
+    axis added to the loader without being added here would start being silently
+    dropped from an inherited narrowing.
+
+    ``None`` / empty on either side returns the other unchanged (nothing to inherit,
+    or nothing to impose), so the inert case stays byte-identical.
+    """
+    if not parent:
+        return dict(child) if child else None
+    if not child:
+        return dict(parent)
+    out: dict = dict(parent)
+    for key, value in child.items():
+        if key in _NARROWING_DENY_KEYS:
+            base = _as_tuple(parent.get(key)) or ()
+            extra = _as_tuple(value) or ()
+            seen = set(base)
+            out[key] = list(base) + [v for v in extra if v not in seen]
+        elif key in _NARROWING_ALLOW_KEYS:
+            theirs = _as_tuple(value)
+            mine = _as_tuple(parent[key]) if key in parent else None
+            if mine is None or theirs is None:
+                # ⊤ on one side ⇒ the other side verbatim.
+                out[key] = list(theirs if mine is None else mine)
+            else:
+                keep = set(mine)
+                out[key] = [v for v in theirs if v in keep]
+        else:
+            out[key] = value
+    return out
+
+
 # ── #1827 S4: context-auto untrusted-source narrowing ───────────────────────
 #
 # Defense-in-depth with the #1862 content-fence: while untrusted external content

--- a/src/reyn/tools/pipeline_verbs.py
+++ b/src/reyn/tools/pipeline_verbs.py
@@ -48,7 +48,14 @@ all statically decidable over the parsed ``Pipeline`` + its ``SchemaRegistry``:
      declaration, its topology ``capability_profile`` bindings, and the #2081
      ``_delegate`` floor all resolve from the agent NAME, so a same-identity
      child re-derives them unchanged. An ``agent`` step additionally narrows
-     RESTRICT-ONLY (``_build_agent_step_narrowing``).
+     RESTRICT-ONLY (``_build_agent_step_narrowing``) — which #3553 had to make
+     true rather than merely restate: that function used to build the worker's
+     WHOLE narrowing from the step's own ``capabilities`` plus the delegation
+     deny, so a step declaring no ``capabilities`` handed its worker no allow
+     restriction at all, losing the invoker's SID-keyed one for the same reason
+     the driver-session did. It now composes the invoker's mapping in
+     (``capability_profile.compose_narrowing_mappings``: denies union, allows
+     intersect, an absent allow key is ⊤).
      ⚠️ This check used to claim the whole envelope followed from identity ("⊆
      by construction, no runtime re-check needed"). It does not: the #2103-S1a
      per-session narrowing is keyed by SID, not by identity, so a fresh

--- a/tests/test_3546_pipeline_driver_narrowing_inheritance.py
+++ b/tests/test_3546_pipeline_driver_narrowing_inheritance.py
@@ -1,6 +1,6 @@
 """Tier 2: OS invariant — a pipeline driver-session is born with the invoker's
-per-session capability narrowing, and every ``spawn_session_recorded`` call site
-declares one.
+per-session capability narrowing, and every spawn call site declares one — and
+(#3553) declares which of its spawner's envelope layers that narrowing composes.
 
 #3546. ``AgentRegistry.spawn_session_recorded`` is the single seam at which a new
 permission envelope is BORN. Two of its three call sites pass ``narrowing=``
@@ -15,6 +15,20 @@ places that might have re-checked: call seams are unbounded (a new dispatch path
 can be added at any time), whereas the sites where an envelope is born are
 bounded and AST-enumerable. That is what ``test_every_spawn_site_passes_narrowing``
 pins.
+
+#3553 widened that gate twice, because passing SOME ``narrowing=`` value turned out
+to be satisfiable by a value that is not a function of the parent at all — which is
+what the ``agent`` step's own spawn was doing one level down, green here the whole
+time. The enumeration now also covers ``spawn_ephemeral_session`` (the forwarder,
+so the site that DECIDES the agent-step value is inside the gate rather than one
+hop outside it), and every enumerated site must declare in ``_SITE_PARENT_LAYERS``
+which layers of its spawner's envelope its value composes, plus the behavioural
+test that measures the claim. ⚠️ That declaration is an INTENT record: a site whose
+prose and code disagree stays green. It is the index of the per-site behavioural
+tests, not a substitute for them — see ``_SiteDeclaration``. Enumerating the sites
+also surfaced a THIRD member of this fix-class (the ``session_spawn`` tool's spawn
+passes its LLM's requested narrowing, never its spawner's), declared as such and
+filed as #3556 rather than fixed on a guess.
 
 Scope of what this fix carries (the layers a session's live capability envelope
 is composed from — enumerated, not assumed):
@@ -57,6 +71,7 @@ alone.
 from __future__ import annotations
 
 import ast
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -269,18 +284,115 @@ async def test_pipeline_driver_session_inherits_invoker_narrowing(
 
 # ── the completeness gate: every place an envelope is BORN ────────────────────
 
-#: ``(module path relative to src/, enclosing function name)`` for a
-#: ``spawn_session_recorded`` call site that legitimately must NOT pass
-#: ``narrowing=``, with the reason. Empty today: all production call sites pass
-#: it. A new site either passes ``narrowing=`` or is registered here with a
-#: reason a reviewer can weigh — the #3484 ``*_UNMEASURED`` idiom.
+#: ``(module path relative to src/, enclosing function name)`` for a spawn call
+#: site that legitimately must NOT pass ``narrowing=``, with the reason. Empty
+#: today: all production call sites pass it. A new site either passes
+#: ``narrowing=`` or is registered here with a reason a reviewer can weigh — the
+#: #3484 ``*_UNMEASURED`` idiom.
 _NARROWING_EXEMPT_SITES: "dict[tuple[str, str], str]" = {}
 
-_SPAWN_SEAM = "spawn_session_recorded"
+#: The seams at which a child session's permission envelope is decided: the
+#: recorded spawn primitive, plus the one wrapper that forwards a caller's value
+#: into it. Both are enumerated because a site that only calls the WRAPPER
+#: (``run_agent_step``) still decides the value, and counting the primitive alone
+#: would leave that decision outside the gate — which is how #3553 stayed invisible
+#: to the #3546 version of this gate for as long as it did.
+_SPAWN_SEAMS: "tuple[str, ...]" = ("spawn_session_recorded", "spawn_ephemeral_session")
+
+
+@dataclass(frozen=True)
+class _SiteDeclaration:
+    """What a spawn site claims about the value it passes as ``narrowing=``.
+
+    ⚠️ **This is an INTENT record, not a behaviour record.** Nothing here reads the
+    site's implementation; a site whose ``parent_layers`` prose and whose code
+    disagree stays green in this file forever. That is the exact limit the #3554
+    version of this gate had in a different spelling — it pinned that a site passes
+    SOME value, which #3553 satisfied while passing a value that was not a function
+    of the parent at all. Widening the pin from "passes a value" to "declares which
+    parent layers the value composes" moves the failure from silent to *stated*; it
+    does not make it detected.
+
+    ``measured_by`` is what closes that: the behavioural half. It names the tests
+    that drive the site for real and observe a denied capability's side effect NOT
+    happening, so the registry doubles as an index of those tests and a site with an
+    empty index is visibly unmeasured rather than invisibly so.
+    """
+
+    #: Which layers of the SPAWNER's envelope the value passed here composes.
+    parent_layers: str
+    #: ``"tests/<file>.py::<test function>"`` for each behavioural measurement of
+    #: this site. Empty only when ``unmeasured_reason`` says why.
+    measured_by: "tuple[str, ...]" = ()
+    #: Why this site has no behavioural measurement, when it has none.
+    unmeasured_reason: str = ""
+
+
+_S3546 = "tests/test_3546_pipeline_driver_narrowing_inheritance.py"
+_S3553 = "tests/test_3553_agent_step_worker_narrowing_inheritance.py"
+
+#: Every spawn site in ``src/``, with the parent layers its ``narrowing=`` value
+#: composes and the behavioural test that measures that claim. A site missing from
+#: this table fails ``test_every_spawn_site_declares_its_parent_layers`` — the
+#: completeness half. See ``_SiteDeclaration`` for why that half is not sufficient.
+_SITE_PARENT_LAYERS: "dict[tuple[str, str], _SiteDeclaration]" = {
+    ("reyn/runtime/session_api.py", "_spawn_pipeline_driver_session"): _SiteDeclaration(
+        parent_layers=(
+            "the invoker's #2103-S1a sid-keyed narrowing, VERBATIM "
+            "(registry.per_session_narrowing) — this site imposes nothing of its own, "
+            "so there is nothing to compose it with. The name-keyed layers (the "
+            "agent's permissions declaration, topology capability_profile bindings, "
+            "the #2081 _delegate floor) ride along for free because the driver shares "
+            "the invoker's identity; the #2285 /visibility toggle and the #1827-S4b "
+            "ephemeral untrusted-context narrowing are deliberately not carried — see "
+            "this module's docstring, layers 3 and 4."
+        ),
+        measured_by=(f"{_S3546}::test_narrowed_invoker_pipeline_tool_step",),
+    ),
+    ("reyn/runtime/session_api.py", "run_agent_step"): _SiteDeclaration(
+        parent_layers=(
+            "the invoker's #2103-S1a sid-keyed narrowing COMPOSED with this agent "
+            "step's own narrowing (the structural delegation deny + the step's "
+            "capabilities allow-list), via capability_profile."
+            "compose_narrowing_mappings: deny keys union, allow keys intersect, an "
+            "absent allow key is ⊤. Same name-keyed / not-carried layers as the "
+            "pipeline driver site above (#3553)."
+        ),
+        measured_by=(
+            f"{_S3553}::test_worker_without_capabilities_inherits_invoker_allow_list",
+            f"{_S3553}::test_worker_with_capabilities_inherits_invoker_deny_list",
+        ),
+    ),
+    ("reyn/runtime/session_api.py", "spawn_ephemeral_session"): _SiteDeclaration(
+        parent_layers=(
+            "NONE of its own — a thin forwarder that hands its caller's ``narrowing`` "
+            "straight to the primitive. The deciding site is whoever calls IT, which "
+            "is why this gate enumerates that seam too."
+        ),
+        unmeasured_reason=(
+            "there is no value of its own to measure; its callers are declared and "
+            "measured individually."
+        ),
+    ),
+    ("reyn/runtime/services/router_host_adapter.py", "spawn_session"): _SiteDeclaration(
+        parent_layers=(
+            "🔴 NONE — the value is the ``session_spawn`` tool argument, i.e. whatever "
+            "the spawning session's LLM asked for. The spawner's OWN #2103-S1a "
+            "sid-keyed narrowing is not a term, so this is the third site of the "
+            "#3546 / #3553 fix-class and it is still open: #3556."
+        ),
+        unmeasured_reason=(
+            "#3556 — reachability is unmeasured (code-trace only), and whether this "
+            "seam is even supposed to be restrict-only against its spawner has not "
+            "been confirmed against the design prose. Filed rather than fixed in "
+            "#3553 so the fix is not a guess."
+        ),
+    ),
+}
 
 
 def _spawn_call_sites() -> "list[tuple[str, str, int]]":
-    """Every ``spawn_session_recorded`` CALL in ``src/`` as
+    """Every CALL of a ``_SPAWN_SEAMS`` function in ``src/`` as
     ``(relative module path, enclosing function, keywords-present marker)``.
 
     An AST walk, not a regex: the same keyword inside a docstring or a comment is
@@ -304,7 +416,7 @@ def _spawn_call_sites() -> "list[tuple[str, str, int]]":
             name = func.attr if isinstance(func, ast.Attribute) else (
                 func.id if isinstance(func, ast.Name) else None
             )
-            if name != _SPAWN_SEAM:
+            if name not in _SPAWN_SEAMS:
                 continue
             has_narrowing = any(kw.arg == "narrowing" for kw in node.keywords) or any(
                 kw.arg is None for kw in node.keywords  # **kwargs forwarding
@@ -318,21 +430,23 @@ def _spawn_call_sites() -> "list[tuple[str, str, int]]":
 
 
 def test_spawn_seam_call_sites_are_findable() -> None:
-    """Tier 2: instrument check — the AST walk finds the seam's known call sites.
+    """Tier 2: instrument check — the AST walk finds the seams' known call sites.
 
     A completeness gate that silently found NOTHING would pass for the wrong
-    reason, so the gate's own search is witnessed against two sites it must see:
-    the pipeline driver spawn and the ``session_spawn`` tool's spawn.
+    reason, so the gate's own search is witnessed against three sites it must see:
+    the pipeline driver spawn, the ``session_spawn`` tool's spawn, and (#3553) the
+    agent-step spawn, which reaches the primitive only through the wrapper.
     """
     sites = _spawn_call_sites()
     functions = {(mod, fn) for mod, fn, _ in sites}
     assert ("reyn/runtime/session_api.py", "_spawn_pipeline_driver_session") in functions
+    assert ("reyn/runtime/session_api.py", "run_agent_step") in functions
     assert any(mod == "reyn/runtime/services/router_host_adapter.py" for mod, _ in functions)
 
 
 def test_every_spawn_site_passes_narrowing() -> None:
-    """Tier 2: every place a new permission envelope is BORN
-    (``spawn_session_recorded``) declares the narrowing the child inherits.
+    """Tier 2: every place a new permission envelope is BORN declares the narrowing
+    the child inherits.
 
     Counted at the place that should inherit, not at the places that might have
     re-checked — the latter set is unbounded, this one is enumerable. A site that
@@ -344,8 +458,63 @@ def test_every_spawn_site_passes_narrowing() -> None:
         if not has and (mod, fn) not in _NARROWING_EXEMPT_SITES
     ]
     assert not missing, (
-        "spawn_session_recorded call site(s) do not pass narrowing=, so the "
-        "spawned session's permission envelope is born wider than its spawner's: "
+        "spawn call site(s) do not pass narrowing=, so the spawned session's "
+        "permission envelope is born wider than its spawner's: "
         f"{missing!r}. Pass narrowing=, or register the site in "
         "_NARROWING_EXEMPT_SITES with the reason it must not."
     )
+
+
+def test_every_spawn_site_declares_its_parent_layers() -> None:
+    """Tier 2: (#3553) every spawn site declares WHICH of its spawner's envelope
+    layers the value it passes composes.
+
+    The #3546 gate above pins that a site passes SOME ``narrowing=`` value, which is
+    satisfiable by a value that is not a function of the parent at all — exactly what
+    ``run_agent_step`` did. This half makes the composition a stated property of each
+    site. ⚠️ Stated, not verified: see ``_SiteDeclaration``.
+    """
+    undeclared = [
+        (mod, fn) for mod, fn, _ in _spawn_call_sites()
+        if (mod, fn) not in _SITE_PARENT_LAYERS
+    ]
+    assert not undeclared, (
+        "spawn call site(s) do not declare which layers of the spawner's permission "
+        f"envelope their narrowing= value composes: {undeclared!r}. Add an entry to "
+        "_SITE_PARENT_LAYERS naming the layers AND the behavioural test that measures "
+        "them (or the reason there is none)."
+    )
+
+
+def test_every_declared_site_names_a_behavioural_test_or_a_reason() -> None:
+    """Tier 2: (#3553) the declaration registry doubles as an INDEX OF TESTS — each
+    site names either the behavioural test(s) that measure its composition or the
+    reason it has none, and each named test exists.
+
+    This is the join between the gate's two halves. The completeness half records
+    intent and cannot fail on a wrong implementation; the semantic half is per-site
+    behavioural and cannot enumerate. Requiring every declared site to point at a
+    real test is what stops the intent record from being the only thing a new site
+    ever gets — a stale name (a renamed or deleted test) fails here rather than
+    quietly leaving the site unmeasured.
+    """
+    tests_root = Path(__file__).resolve().parent
+    for (mod, fn), decl in sorted(_SITE_PARENT_LAYERS.items()):
+        assert decl.parent_layers.strip(), f"{mod}::{fn} declares no parent layers"
+        assert decl.measured_by or decl.unmeasured_reason.strip(), (
+            f"{mod}::{fn} names neither a behavioural test nor a reason it has none"
+        )
+        for ref in decl.measured_by:
+            path_part, _, test_name = ref.partition("::")
+            path = tests_root.parent / path_part
+            assert path.is_file(), f"{mod}::{fn} names a missing test file: {ref}"
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            defined = {
+                node.name for node in ast.walk(tree)
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            }
+            assert test_name in defined, (
+                f"{mod}::{fn} names a behavioural test that does not exist: {ref}. "
+                "A renamed or deleted measurement must not leave the site silently "
+                "declared-but-unmeasured."
+            )

--- a/tests/test_3553_agent_step_worker_narrowing_inheritance.py
+++ b/tests/test_3553_agent_step_worker_narrowing_inheritance.py
@@ -1,0 +1,340 @@
+"""Tier 2: OS invariant — an ``agent`` step's leaf worker is born inside its
+INVOKER's per-session capability envelope, not merely inside the step's own
+``capabilities`` declaration.
+
+#3553, the sibling of #3546 one level down. ``run_agent_step`` spawned the worker
+with ``_build_agent_step_narrowing(capabilities)``, which composed only the
+structural delegation deny plus the caller's ``capabilities`` list — the invoker's
+own sid-keyed #2103-S1a narrowing was never a term. The worker gets a FRESH sid, so
+that layer resolves to nothing on it: the same axis #3546 restored at the pipeline
+driver spawn was dropped again at the driver's own children.
+
+The composition is derived, not chosen (``capability_profile.
+compose_narrowing_mappings``): **deny keys union, allow keys intersect, an ABSENT
+allow key is ⊤**. The two acceptance legs below are the two rules, one each, and
+they are separable on purpose — with only one of them measured you cannot tell
+which rule did the work, and half a composition still widens the child:
+
+  * ``test_worker_without_capabilities_inherits_invoker_allow_list`` — the invoker
+    narrows with ``tool_allow`` ONLY and the step declares NO ``capabilities``.
+    Before the fix the worker's narrowing had no ``tool_allow`` key at all, i.e. no
+    allow restriction: the invoker's allow-list was lost WHOLE. This is the leg that
+    fails if an absent allow key is read as anything other than "the other side
+    verbatim".
+  * ``test_worker_with_capabilities_inherits_invoker_deny_list`` — the invoker
+    narrows with ``tool_deny`` ONLY and the step explicitly declares
+    ``capabilities=["write_file"]``, i.e. asks for exactly what its invoker was
+    refused. This is the leg that fails if the denies do not union.
+
+Both witness a REAL side effect — the file ``write_file`` puts on disk — rather than
+a status string: a denial that only changed a return value would not prove the
+capability was prevented. ``write_file`` is the production tool, reached through a
+real ``RouterLoop`` turn on the real worker session; the only faked collaborator is
+the LLM completion itself, injected through ``RouterLoopDriver``'s designed
+``_loop_observer`` seam. An earlier draft of these tests registered a bespoke
+side-effecting tool instead and passed against the UNFIXED code, because a tool that
+is not in the universal catalog is never advertised and so never dispatches — the
+tests were measuring nothing. ``test_the_witness_tool_actually_runs_when_permitted``
+is the instrument check that keeps that failure detectable.
+
+The completeness half of the gate lives in
+``tests/test_3546_pipeline_driver_narrowing_inheritance.py``, extended by #3553 to
+record, per spawn site, WHICH parent layers it composes and which test measures
+that. That half records INTENT: a site whose declaration and implementation disagree
+stays green there. These two legs are what actually measures this site, and neither
+half substitutes for the other.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.model_resolver import ModelResolver
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.runtime.session_api import _build_agent_step_narrowing, run_agent_step
+from reyn.runtime.session_params import PresentationWiring
+from reyn.runtime.spawn_routing import AuditOnlyNoSurface
+from reyn.security.permissions.capability_profile import compose_narrowing_mappings
+from tests._support.agent_session import make_session
+from tests._support.permissions import make_resolver
+
+#: The capability under test: a real, catalog-listed, side-effecting tool whose
+#: effect is observable on disk without reading any return value.
+_WITNESS_TOOL = "write_file"
+#: A second real tool, used as the invoker's ``tool_allow`` content in leg 1 so the
+#: allow-list is non-empty and demonstrably does NOT contain ``_WITNESS_TOOL``.
+_OTHER_TOOL = "read_file"
+_OUT_NAME = "p3553_out.txt"
+
+
+class _WritesOnceLLM:
+    """A real ``_llm_caller``-shaped callable (the RouterLoop Tier-2 test seam): the
+    first turn asks for ``write_file``, every later turn answers in plain text so the
+    loop terminates whether or not the call was allowed.
+
+    Not a ``MagicMock``: a drift in the ``call_llm_tools`` keyword contract raises
+    ``TypeError`` here exactly as it would in production. The LLM's content is
+    incidental — what is under test is whether the OS lets the requested capability
+    reach its handler.
+    """
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.calls += 1
+        if self.calls == 1:
+            return LLMToolCallResult(
+                content=None,
+                tool_calls=[{
+                    "id": "c1", "type": "function",
+                    "function": {
+                        "name": _WITNESS_TOOL,
+                        "arguments": '{"path": "%s", "content": "step-ran"}' % _OUT_NAME,
+                    },
+                }],
+                finish_reason="tool_calls",
+                usage=TokenUsage(prompt_tokens=1, completion_tokens=1),
+            )
+        return LLMToolCallResult(
+            content="done", tool_calls=[], finish_reason="stop", usage=TokenUsage(),
+        )
+
+
+def _registry(tmp_path: Path, scripted: "_WritesOnceLLM") -> AgentRegistry:
+    """Real ``AgentRegistry`` + real ``Session`` factory + real ``RouterLoop`` +
+    real ``PermissionResolver`` (with ``file.write`` approved, so a denial observed
+    below is the capability narrowing and not the write gate)."""
+    if not (tmp_path / "reyn.yaml").exists():
+        (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    holder: dict = {}
+    resolver = ModelResolver({"standard": "gemini/gemini-2.5-flash-lite"})
+    perms = make_resolver(tmp_path, config={"file.write": "allow"})
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
+        s = make_session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            permission_resolver=perms, workspace_base_dir=tmp_path,
+            presentation_wiring=PresentationWiring(
+                presentation_consumer=presentation_consumer,
+                intervention_bridge=intervention_bridge,
+            ),
+            resolver=resolver,
+        )
+        s._loop_driver._loop_observer = (
+            lambda loop: setattr(loop, "_llm_caller", scripted)
+        )
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    if not reg.exists("worker"):
+        reg.create("worker")
+    return reg
+
+
+async def _narrowed_invoker(reg: AgentRegistry, narrowing: "dict | None") -> Session:
+    """Spawn a REAL session under ``narrowing`` through the production spawn seam
+    (``spawn_session_recorded`` — the same call the ``session_spawn`` tool makes), so
+    the invoker's sid-keyed ``config.yaml`` is written by production code."""
+    routing = AuditOnlyNoSurface()
+    sid = await reg.spawn_session_recorded(
+        "worker", mode="persistent", narrowing=narrowing,
+        presentation_consumer=routing.presentation_consumer,
+        intervention_bridge=routing.intervention_bridge,
+    )
+    session = reg.get_session("worker", sid)
+    assert session is not None
+    return session
+
+
+def _written(tmp_path: Path) -> "list[str]":
+    """Every on-disk copy of the witness file, wherever the worker's workspace
+    resolved it — the side effect itself, not a status string."""
+    return sorted(str(p) for p in tmp_path.rglob(_OUT_NAME))
+
+
+# ── instrument check ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_the_witness_tool_actually_runs_when_permitted(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: instrument check — with the invoker narrowed on an UNRELATED tool, the
+    agent-step worker's ``write_file`` call really does reach its handler and put a
+    file on disk.
+
+    Without this, both acceptance legs below would pass for the wrong reason if the
+    tool call stopped being dispatchable at all (which is exactly what happened to an
+    earlier draft using a non-catalog tool). The legs assert an absence; this asserts
+    the presence they are the absence of.
+    """
+    monkeypatch.chdir(tmp_path)
+    scripted = _WritesOnceLLM()
+    reg = _registry(tmp_path, scripted)
+
+    invoker = await _narrowed_invoker(reg, {"tool_deny": ["some_unrelated_tool"]})
+    await run_agent_step(
+        reg, identity="worker", prompt="write the file", invoker_session=invoker,
+    )
+
+    assert _written(tmp_path), (
+        "the agent-step worker's write_file never executed even with nothing "
+        "narrowing it — the two acceptance legs below would be vacuous"
+    )
+
+
+# ── leg 1: the ⊤ rule (invoker allow-list, step declares no capabilities) ──────
+
+
+@pytest.mark.asyncio
+async def test_worker_without_capabilities_inherits_invoker_allow_list(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: an ``agent`` step that declares NO ``capabilities`` still cannot run a
+    tool its invoker's ``tool_allow`` excludes.
+
+    This is the widening the composition's ⊤ rule closes: the step imposes no allow
+    restriction of its own, so the worker's allow-list must be the invoker's
+    (``parent ∩ ⊤ = parent``) rather than absent. Before the fix it was absent, and
+    the tool's real side effect happened.
+    """
+    monkeypatch.chdir(tmp_path)
+    scripted = _WritesOnceLLM()
+    reg = _registry(tmp_path, scripted)
+
+    invoker = await _narrowed_invoker(reg, {"tool_allow": [_OTHER_TOOL]})
+    result = await run_agent_step(
+        reg, identity="worker", prompt="write the file", invoker_session=invoker,
+    )
+
+    assert not _written(tmp_path), (
+        "a tool OUTSIDE the invoker's tool_allow executed its real side effect "
+        f"inside an agent step that declared no capabilities (reply: {result!r})"
+    )
+
+
+# ── leg 2: the union rule (invoker deny-list, step asks for the denied tool) ───
+
+
+@pytest.mark.asyncio
+async def test_worker_with_capabilities_inherits_invoker_deny_list(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: an ``agent`` step cannot re-grant a tool its invoker denied by naming
+    it in ``capabilities``.
+
+    The step's ``capabilities`` is an allow-list, so on its own it would make the tool
+    the worker's ONLY reachable capability. The invoker's ``tool_deny`` has to union
+    in for the answer to stay a denial. Before the fix it did not, and the tool's real
+    side effect happened.
+    """
+    monkeypatch.chdir(tmp_path)
+    scripted = _WritesOnceLLM()
+    reg = _registry(tmp_path, scripted)
+
+    invoker = await _narrowed_invoker(reg, {"tool_deny": [_WITNESS_TOOL]})
+    result = await run_agent_step(
+        reg, identity="worker", prompt="write the file",
+        capabilities=[_WITNESS_TOOL], invoker_session=invoker,
+    )
+
+    assert not _written(tmp_path), (
+        "a tool the invoker's per-session narrowing DENIED executed its real side "
+        f"effect inside an agent step that named it in capabilities (reply: {result!r})"
+    )
+
+
+# ── the composition rules, as a unit (the two legs' shared derivation) ────────
+
+
+def test_compose_absent_allow_is_top_not_empty() -> None:
+    """Tier 2: an ABSENT allow key means ⊤ (no restriction on that axis), so the other
+    side's allow-list survives composition verbatim — in BOTH directions.
+
+    Reading absence as the empty set instead would make a child that declares no
+    capabilities unable to reach anything (parent-absent case), or silently drop the
+    parent's allow-list (child-absent case — the #3553 defect itself).
+    """
+    child_only = compose_narrowing_mappings(
+        {"tool_deny": ["d"]}, {"tool_allow": ["a"], "tool_deny": ["e"]},
+    )
+    assert set(child_only["tool_allow"]) == {"a"}
+
+    parent_only = compose_narrowing_mappings(
+        {"tool_allow": ["a", "b"]}, {"tool_deny": ["e"]},
+    )
+    assert set(parent_only["tool_allow"]) == {"a", "b"}
+
+
+def test_compose_denies_union_and_allows_intersect() -> None:
+    """Tier 2: the two restrict-only rules, on the axis where both sides constrain —
+    ``*_deny`` unions (deny-always-wins) and ``*_allow`` intersects (a value stays
+    reachable only if EVERY term allows it)."""
+    composed = compose_narrowing_mappings(
+        {"tool_allow": ["a", "b"], "tool_deny": ["x"]},
+        {"tool_allow": ["b", "c"], "tool_deny": ["y"]},
+    )
+    assert set(composed["tool_allow"]) == {"b"}
+    assert set(composed["tool_deny"]) == {"x", "y"}
+
+
+def test_compose_carries_axes_the_child_does_not_constrain() -> None:
+    """Tier 2: the MCP and category axes are composed by the same two rules, so a
+    parent narrowing that uses them is not silently dropped just because an ``agent``
+    step only ever speaks the TOOL axis."""
+    composed = compose_narrowing_mappings(
+        {"mcp_allow": ["github"], "mcp_deny": ["evil"], "categories": ["io"]},
+        {"tool_deny": ["delegate_to_agent"]},
+    )
+    assert set(composed["mcp_allow"]) == {"github"}
+    assert set(composed["mcp_deny"]) == {"evil"}
+    assert set(composed["categories"]) == {"io"}
+    assert set(composed["tool_deny"]) == {"delegate_to_agent"}
+
+
+def test_compose_key_tables_cover_every_profile_axis() -> None:
+    """Tier 2: the two composition tables cover every axis
+    ``load_capability_profile`` actually reads.
+
+    ``compose_narrowing_mappings`` may only claim that an unlisted key cannot change a
+    session's envelope while that is true. A new axis added to ``CapabilityProfile``
+    without being added to a table would fall through to the "inert" branch and start
+    being silently dropped from inherited narrowings.
+    """
+    from dataclasses import fields
+
+    from reyn.security.permissions.capability_profile import (
+        _NARROWING_ALLOW_KEYS,
+        _NARROWING_DENY_KEYS,
+        CapabilityProfile,
+    )
+
+    axes = {f.name for f in fields(CapabilityProfile)} - {"name", "description"}
+    tabled = set(_NARROWING_ALLOW_KEYS) | set(_NARROWING_DENY_KEYS)
+    assert axes == tabled, (
+        "a CapabilityProfile axis is not classified as allow-shaped or deny-shaped in "
+        "capability_profile's composition tables, so an inherited narrowing would "
+        f"drop it: {axes ^ tabled!r}"
+    )
+
+
+def test_agent_step_narrowing_without_an_invoker_is_unchanged() -> None:
+    """Tier 2: with nothing to inherit (a headless ``reyn pipe`` run — no
+    ``invoker_session``), the narrowing an ``agent`` step builds is exactly the
+    structural delegation deny plus any declared ``capabilities``, so the inert path
+    is byte-identical to pre-#3553."""
+    assert _build_agent_step_narrowing(None, None) == _build_agent_step_narrowing(None)
+    plain = _build_agent_step_narrowing([_OTHER_TOOL], None)
+    assert plain is not None
+    assert set(plain["tool_allow"]) == {_OTHER_TOOL}
+    assert "delegate_to_agent" in plain["tool_deny"]


### PR DESCRIPTION
**[per-PR-coder]** — 実装完了。**★ 到達性は両脚とも MEASURED（RED-before / GREEN-after を脚ごとに分離して実測）** です。**★ 4 番目の曖昧な合成ケースは出ませんでした**が、**★ 同じ fix-class の 3 番目の *サイト* が gate の拡張で立ち上がったので #3556 に起票**しました（本 PR では直していません）。

Closes #3553

## ★ 受け入れテスト — 2 脚、別々に RED-before / GREEN-after

**★ 先に計器が壊れていたことを報告します。** 最初の版は #3554 と同じく **bespoke な副作用ツールを登録**して worker に呼ばせる形でした。**strip を打ったのに GREEN のままで**、ブリーフの「GREEN な strip は穴」に従って調べたところ — **★ universal catalog に載っていないツールは LLM に advertise されず、router turn では *一度も dispatch されません***。∴ **両脚とも「何も測っていない」状態で緑でした。**

→ **witness を実在の production ツール `write_file`** に置き換え（`file.write` は real `PermissionResolver` で approve 済み＝観測される拒否が narrowing のものであって write gate のものでないことを保証）、**instrument check（`test_the_witness_tool_actually_runs_when_permitted`）を先に立てて**、**「絞られていなければツールは実際にディスクに書く」を毎回確認**してから 2 脚の *不在* を assert しています。

| strip | 脚1（`capabilities` 未指定・親は `tool_allow` のみ） | 脚2（`capabilities=[write_file]`・親は `tool_deny` のみ） | instrument |
|---|---|---|---|
| **STRIP-A**（合成そのものを無効化＝修正前の挙動） | 🔴 **RED** | 🔴 **RED** | ✅ GREEN |
| **STRIP-B**（deny の *和* だけを無効化） | ✅ GREEN | 🔴 **RED** | ✅ GREEN |
| **STRIP-C**（allow の *⊤ 扱い* だけを無効化） | 🔴 **RED** | ✅ GREEN | ✅ GREEN |
| **修正あり** | ✅ **GREEN** | ✅ **GREEN** | ✅ GREEN |

★ **B と C が互いに背反に赤くなることが、「和と積のどちらが効いたか分からない」を実測で閉じた部分**です。片方だけの実装では必ずどちらかの脚が赤で残ります。

**witness は実副作用**です — `write_file` がディスクに置くファイルの *不在*（`tmp_path.rglob(...)`）で、戻り値や status 文字列ではありません。

## ★ 合成 — firm どおり、判断は発生しませんでした

**★ 再発明していません。** 意味論は **既存の `capability_profile.compose_resolved`（"union of denials, intersection of allows"）そのもの**で、本 PR はその **mapping レベルの兄弟** `compose_narrowing_mappings` を同じファイルの隣に置いただけです（合成対象が `ResolvedProfile` ではなく config.yaml へ再永続化される生 dict なので、型が違うだけで規則は同一）。

- `*_deny` → **和**
- `*_allow` → **積、不在 = ⊤**
- 親のみ / 子のみ / 両方 の 3 ケースすべて一意

★ **4 番目の曖昧なケースは出ませんでした。** 出かけた候補は 2 つあり、どちらも同じ規則で一意に決まったので停止していません:

1. **`categories` 軸** — `compose_resolved` が `excluded_categories` の *和* として表現しているものは、KEEP-VISIBLE 集合 `categories` の *積* と同値。∴ allow 側のテーブルに入るだけで、新しい判断ではありません。
2. **`mcp_allow` / `mcp_deny`** — 子（agent step）は TOOL 軸しか喋らないので常に「親のみ」ケース。同じ規則。

⚠️ **その代わり、テーブルが `CapabilityProfile` の全軸を覆っているかを CI で pin しました**（`test_compose_key_tables_cover_every_profile_axis`）。**「テーブルに無い key は loader が読まないので無害」は、テーブルが全軸を覆っている間しか真でない**ので、新しい軸が loader に増えたら赤くなります。

## 🔴 偽の docstring — 実測に直しました

`_build_agent_step_narrowing` の *"restrict-only narrowing, never a re-grant"*:

★ **AGENT の宣言に対しては真、INVOKER に対しては偽**でした（そして読者が確認するのは後者）。**新しい未検証の主張に差し替えてはいません** — 直した文は **「本 PR の 2 脚が測ったこと」だけ**を述べ、**「どの層について真か」を `per_session_narrowing` が運ぶ層に限定**しています。

## ★ gate — 2 段。**片方が他方を代替しないことをコードに書きました**

**★ 拡張は 2 回です**（1 回ではありません）:

1. **列挙面の拡張** — `spawn_session_recorded` に加えて **`spawn_ephemeral_session`（forwarder）も列挙**。★ **これが無いと #3553 の *値を決めているサイト*（`run_agent_step`）は gate の 1 ホップ外**で、実際 #3554 の gate はそれで緑のままでした。
2. **宣言面の拡張** — 各サイトが `_SITE_PARENT_LAYERS` に **「親のどの層を合成したか」＋「それを測る behavioural test」** を宣言。

⚠️ ★ **1 番目の段の限界を `_SiteDeclaration` の docstring に明記しました**（PR 本文だけでなく、ブリーフの要求どおりコードに）:

> *This is an INTENT record, not a behaviour record. Nothing here reads the site's implementation; a site whose ``parent_layers`` prose and whose code disagree stays green in this file forever.*

★ **`measured_by` が registry を *テストの索引* にしている部分**で、`test_every_declared_site_names_a_behavioural_test_or_a_reason` が **各サイトが実在するテストを指していること**を AST で検証します（**リネーム/削除で「宣言済みだが未計測」に静かに落ちるのを防ぐ**）。**測定が無いサイトは `unmeasured_reason` で *見える* 未計測**になります。

**gate の strip-falsify**（両方とも anchor の `count == 1` を編集前に確認）:

| strip | 結果 |
|---|---|
| **STRIP-D**（`run_agent_step` の宣言エントリを外す） | 🔴 `test_every_spawn_site_declares_its_parent_layers` RED |
| **STRIP-E**（`measured_by` のテスト名を実在しない名前へ） | 🔴 `test_every_declared_site_names_a_behavioural_test_or_a_reason` RED |

## 🔴 ★ gate の拡張が炙り出した 3 番目のサイト → #3556（**直していません**）

**サイトを列挙して「どの親の層を合成したか」を書かせた結果**、`router_host_adapter.spawn_session`（= `session_spawn` ツール）が **「親の層は 1 つも合成していない — 値は LLM が要求した narrowing そのもの」** としか書けませんでした。

★ **#3546 → #3553 → 本件 で同一軸（#2103-S1a sid-keyed 層）の 3 件目**です。**#3554 の gate はこれを緑にしていました**（軸が「`narrowing=` を渡しているか」だったため）。

**畳まなかった理由**（ブリーフのスコープ外というだけではありません）: ★ **この seam の `narrowing` は「親が子に *課す*」引数**で、**「親が意図的に広げた子を作る」ユースケースが設計上あるのかを prose で確認していません**。⚪ **到達性も code-trace のみで未実測**です。∴ **推測で直さず #3556 に起票**し、**registry には *明示的に未計測* として登録**してあります（＝ gate が穴を隠すのではなく表示している状態）。

## 変更点

| ファイル | 内容 |
|---|---|
| `security/permissions/capability_profile.py` | `compose_narrowing_mappings` + 軸テーブル 2 本（`compose_resolved` の隣、同じ規則の mapping 版） |
| `runtime/session.py` | `Session.session_id` public property（live 読み。spawn が構築 *後* に re-key するので、コンストラクタ引数のキャッシュは spawn されたセッションでは必ず stale） |
| `runtime/session_api.py` | `run_agent_step` が invoker の narrowing を読んで合成 / `_build_agent_step_narrowing` の偽 docstring 修正 |
| `docs/reference/runtime/pipeline-dsl.md` | `agent` step の `capabilities` は invoker の narrowing と **合成** される（*の代わり* ではない）＋合成規則。★ **この 2 行は修正 *前* から「invoker's own profile if omitted」「can never exceed the invoker's own envelope」と書いており、実装がそれを満たしていませんでした** — doc が先に正しかった側の drift です |
| `tests/test_3553_...py` | 2 脚 + instrument check + 合成規則のユニット + 軸テーブル網羅 gate |
| `tests/test_3546_...py` | gate を 2 方向に拡張（列挙面 + 宣言面）、module docstring を実態に更新 |

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` 変更した 2 テストファイル — **14/14 OK, errors 0**
- [x] `pytest -n auto`（フルスイート。permission + spawn は横断的なので部分実行にしていません） — **9808 passed, 36 skipped, exit 0**
- [x] `python scripts/verify_module_docstrings.py` 変更した 3 src ファイル — OK
- [x] 受け入れ 2 脚の RED-before / GREEN-after を **脚ごとに分離**して実測（STRIP-A/B/C、上表）
- [x] gate 2 半分の strip-falsify（STRIP-D/E、anchor の `count == 1` を編集前に確認）
- [x] 計器の健全性 — bespoke ツール版が「両脚 GREEN のまま strip に耐える」偽陽性だったことを検出し、`write_file` へ差し替えて instrument check をテストとして常設
- [x] `Closes` の前に `3553 in:body` を全列挙 — 該当は #3554（MERGED）のみ、open な part-of 参照（#3553 を非クローズ意図で挙げる PR）は無し

🤖 Generated with [Claude Code](https://claude.com/claude-code)

