### PR TITLE
fix(permissions): AgentRegistry.spawn_session enters the spawn-seam gate on reachability, and crash recovery stops reviving sessions un-narrowed — #3561

### DIFF
--- a/src/reyn/interfaces/slash/__init__.py
+++ b/src/reyn/interfaces/slash/__init__.py
@@ -104,7 +104,9 @@ REGISTRY: SlashRegistry = SlashRegistry()
 def suggest_for_unknown(cmd: str, *, names: list[str] | None = None) -> list[str]:
     """Return up to ~3 closest-match suggestions for a typo'd slash command.
 
-    Used by :meth:`Session._dispatch_slash` to build the inline error
+    Used by :meth:`Session._maybe_handle_slash` — the OS's one slash
+    dispatch method (``runtime/session.py``; the ``Session._dispatch_slash``
+    this line used to name has never existed) — to build the inline error
     body when ``/<cmd>`` doesn't resolve. The suggestion list is
     intentionally tight: prefix-matches (= commands whose name starts with
     the typed token) come first, then fuzzy similarity matches

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2729,6 +2729,37 @@ class AgentRegistry:
         # freshness for the CURRENT conversation is already supplied separately by the
         # live overlay (this session's uncompacted calls layered on each turn). So it is
         # correctly shared across the agent's sessions, not per-conversation state.
+        # #3561: re-resolve + inject the sid-keyed #2103-S1a narrowing, for the same
+        # reason #2126 does it in spawn_session_recorded and at the same point in the
+        # sequence — right after the per-session state dir is finalized, before the
+        # caller starts a run-loop. The factory resolved this session's envelope with
+        # sid=None (no sid exists yet at construction), so the live session's
+        # _contextual_permission — the SINGLE source the RouterLoop's advertisement
+        # filter and its _excluded_result call-time gate both read — ignores this sid's
+        # config.yaml until something re-resolves WITH the sid.
+        #
+        # spawn_session_recorded did that for itself and only for itself, which left
+        # every caller that reaches this primitive DIRECTLY outside the narrowing:
+        # restore_all and _rewake_pipeline_runs re-create a crashed session under its
+        # ORIGINAL sid, whose config.yaml is still on disk, and the re-woken session ran
+        # unnarrowed. Measured, not inferred: against a live positive control (an
+        # un-narrowed session whose write_file DOES land), the re-woken session's denied
+        # write_file landed too — while capability_visibility_state() still showed the
+        # tool denied, because THAT surface re-resolves with the sid on every read and
+        # the enforcement path does not. Two surfaces, one of them decorative; the gap is
+        # invisible from the operator's status bar.
+        # See tests/test_3561_spawn_session_seam_reachability.py.
+        #
+        # Injecting here rather than at each recovery site closes the class at the one
+        # place every path shares: this is where the sid becomes known, so it is where
+        # the sid-keyed layer becomes resolvable. Inert for a sid with no config.yaml
+        # (resolved_profile_for then returns the name-keyed layers the factory already
+        # applied). spawn_session_recorded keeps its own re-inject — it WRITES the config
+        # after this returns, so its value does not exist yet at this point.
+        inject = getattr(session, "apply_per_session_narrowing", None)
+        if callable(inject):
+            contextual, excluded = self.resolved_profile_for(name, sid=new_sid)
+            inject(contextual, excluded)
         # #2285 step2: now that the per-session state dir is finalized (snapshot re-key above),
         # restore any persisted visibility/hook toggles for this (name, sid) — the loaded override
         # composes atop the authoritative envelope, so visible ⊆ authorized survives across restart.

--- a/tests/test_3546_pipeline_driver_narrowing_inheritance.py
+++ b/tests/test_3546_pipeline_driver_narrowing_inheritance.py
@@ -53,6 +53,14 @@ observes it reach ``/session new`` — ``Session._handle_user_message`` short-ci
 all — and spawn. The pre-measurement guess ("slash is operator-initiated, so it is out of
 scope") is false.
 
+★ Enumerating the primitive immediately paid for itself: measuring the CRASH-RECOVERY
+sites (``restore_all`` / ``_rewake_pipeline_runs``), which reach ``spawn_session``
+directly and had never been counted, found that a re-woken session was reborn OUTSIDE
+its own persisted per-session narrowing — resolvable on the operator's status bar,
+un-enforced in the RouterLoop. #3561 fixes that in ``spawn_session`` itself. That is the
+concrete answer to "does a seam with no inheritance channel matter": it did, and the
+shape check would never have asked.
+
 Every enumerated site is accounted for today — a state this file records but does not
 enforce, since a NEW site may register an ``unmeasured_reason`` and stay green here.
 ``/session new``'s missing inheritance is a real, declared gap (#3562), not a
@@ -579,22 +587,32 @@ _SITE_PARENT_LAYERS: "dict[tuple[str, str], _SiteDeclaration]" = {
             "behavioural shape this file measures elsewhere (a denied capability's side "
             "effect not happening) has no subject here: with no spawner session there "
             "is no narrowing whose loss could be observed. #3561 recorded this rather "
-            "than inventing a measurement whose green would mean nothing."
+            "than inventing a measurement whose green would mean nothing. What this "
+            "site DOES now get from the primitive — the sid's own persisted narrowing, "
+            "applied at construction — is measured at the recovery sites below, which "
+            "exercise the same injection in the primitive."
         ),
     ),
     ("reyn/runtime/registry.py", "restore_all"): _SiteDeclaration(
         parent_layers=(
-            "NOT an inheritance from a spawner at all — a RE-ATTACHMENT to the child's "
-            "own durable layer. Crash recovery re-creates a session that already "
-            "existed, under the SAME sid, and the #2103-S1a narrowing lives in "
+            "NOT an inheritance from a spawner — a RE-ATTACHMENT to the child's own "
+            "durable layer. Crash recovery re-creates a session that already existed, "
+            "under the SAME sid, and the #2103-S1a narrowing lives in "
             "``<state>/sessions/<enc(sid)>/config.yaml``, keyed by that sid. The "
-            "primitive's per-session path re-key is what restores the resolution path; "
-            "there is no value to pass. The name-keyed layers ride along as everywhere "
-            "else. That this actually survives — rather than the re-woken session being "
-            "reborn wide — is the measurement named below, not an assumption."
+            "name-keyed layers ride along as everywhere else. "
+            "★ This site is why the gate had to widen: enumerating it is what got the "
+            "claim MEASURED, and it was false. The layer was resolvable but not "
+            "ENFORCED — the factory resolves an envelope with ``sid=None``, so the live "
+            "``_contextual_permission`` the RouterLoop reads never saw the file, and a "
+            "re-woken narrowed session executed a denied tool for real. #3561 moved the "
+            "``#2126`` re-resolve-and-inject into ``spawn_session`` itself, where the "
+            "sid becomes known, closing it for every direct caller of the primitive at "
+            "once. What the site inherits is now a property of the primitive, which is "
+            "the reason the primitive belongs on this list at all."
         ),
         measured_by=(
-            f"{_S3561}::test_recovery_recreated_session_keeps_its_persisted_narrowing",
+            f"{_S3561}::test_recovery_recreated_session_is_still_inside_its_persisted_narrowing",
+            f"{_S3561}::test_the_witness_tool_runs_when_nothing_narrows_it",
         ),
     ),
     ("reyn/runtime/registry.py", "_rewake_pipeline_runs"): _SiteDeclaration(
@@ -603,12 +621,14 @@ _SITE_PARENT_LAYERS: "dict[tuple[str, str], _SiteDeclaration]" = {
             "crash-recovery re-creation, re-entering under the work order's "
             "``driver_sid``, so the driver-session's own persisted narrowing (written "
             "when ``_spawn_pipeline_driver_session`` first spawned it through "
-            "``spawn_session_recorded``) is resolved from disk by sid rather than "
-            "passed. Measured by the same behavioural leg, which drives the shared "
-            "``spawn_session``-under-an-existing-sid path both arms use."
+            "``spawn_session_recorded``) is resolved from disk by sid and, since #3561, "
+            "injected into the live envelope by the primitive both arms share. Measured "
+            "by the same behavioural pair, which drives that shared "
+            "``spawn_session``-under-an-existing-sid path."
         ),
         measured_by=(
-            f"{_S3561}::test_recovery_recreated_session_keeps_its_persisted_narrowing",
+            f"{_S3561}::test_recovery_recreated_session_is_still_inside_its_persisted_narrowing",
+            f"{_S3561}::test_the_witness_tool_runs_when_nothing_narrows_it",
         ),
     ),
     ("reyn/interfaces/slash/session.py", "session_cmd"): _SiteDeclaration(

--- a/tests/test_3546_pipeline_driver_narrowing_inheritance.py
+++ b/tests/test_3546_pipeline_driver_narrowing_inheritance.py
@@ -30,9 +30,34 @@ also surfaced a THIRD member of this fix-class (the ``session_spawn`` tool's spa
 passed its LLM's requested narrowing, never its spawner's), declared as such and
 filed as #3556 rather than fixed on a guess; #3556 then composed the spawner's layer
 in and replaced that site's ``unmeasured_reason`` with the two behavioural legs in
-``tests/test_3556_session_spawn_narrowing_inheritance.py``. Every enumerated site is
-measured today — a state this file records but does not enforce, since a NEW site may
-register an ``unmeasured_reason`` and stay green here.
+``tests/test_3556_session_spawn_narrowing_inheritance.py``.
+
+#3561 widened it a third time, on the axis the first two widenings had in common. Both
+earlier gates decided membership by SHAPE — #3554's by whether a site spelled
+``narrowing=`` (which #3556 satisfied while passing a value that was no function of its
+parent), and the enumeration itself by whether a callee's NAME was on a list. Neither
+question is the one that matters. ``AgentRegistry.spawn_session`` — the sync primitive
+that ``spawn_session_recorded`` itself calls, and that four other sites call directly —
+was outside the gate because it takes no ``narrowing`` argument at all, i.e. it failed
+the shape check in the opposite direction. "It cannot inherit" is not "it need not
+inherit": an API with no inheritance channel is an unmet requirement. The criterion is
+REACHABILITY — can a narrowed subject cause this to run — and it is now listed, with the
+walk resolving calls by RECEIVER so ``spawn_session`` the registry primitive is not
+conflated with the two other functions of that name (see ``_Seam``).
+
+Reachability is measured, not assumed:
+``tests/test_3561_spawn_session_seam_reachability.py`` drives an agent step whose prompt
+is a previous agent step's MODEL OUTPUT, on a session narrowed to one capability, and
+observes it reach ``/session new`` — ``Session._handle_user_message`` short-circuits to
+``_maybe_handle_slash`` before the router turn, so the reaching turn makes no LLM call at
+all — and spawn. The pre-measurement guess ("slash is operator-initiated, so it is out of
+scope") is false.
+
+Every enumerated site is accounted for today — a state this file records but does not
+enforce, since a NEW site may register an ``unmeasured_reason`` and stay green here.
+``/session new``'s missing inheritance is a real, declared gap (#3562), not a
+measurement gap: its declaration says so, and its measurement asserts the reachability
+only, so closing #3562 does not turn it red.
 
 Scope of what this fix carries (the layers a session's live capability envelope
 is composed from — enumerated, not assumed):
@@ -75,6 +100,7 @@ alone.
 from __future__ import annotations
 
 import ast
+import inspect
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -84,6 +110,7 @@ import yaml
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
+from reyn.runtime.session_api import spawn_ephemeral_session
 from reyn.runtime.session_params import PresentationWiring
 from reyn.runtime.spawn_routing import AuditOnlyNoSurface
 from reyn.tools.pipeline_verbs import _handle_run_pipeline
@@ -289,19 +316,115 @@ async def test_pipeline_driver_session_inherits_invoker_narrowing(
 # ── the completeness gate: every place an envelope is BORN ────────────────────
 
 #: ``(module path relative to src/, enclosing function name)`` for a spawn call
-#: site that legitimately must NOT pass ``narrowing=``, with the reason. Empty
-#: today: all production call sites pass it. A new site either passes
-#: ``narrowing=`` or is registered here with a reason a reviewer can weigh — the
-#: #3484 ``*_UNMEASURED`` idiom.
-_NARROWING_EXEMPT_SITES: "dict[tuple[str, str], str]" = {}
+#: site that does NOT pass ``narrowing=``, with the reason. A new site either
+#: passes ``narrowing=`` or is registered here with a reason a reviewer can weigh
+#: — the #3484 ``*_UNMEASURED`` idiom.
+#:
+#: #3561 filled it, for one reason only: every entry calls
+#: ``AgentRegistry.spawn_session``, whose signature HAS no ``narrowing`` parameter.
+#: That is deliberately recorded as an unmet requirement, not as a merit-based
+#: exemption — "the API cannot take one" would be a shape argument, and this arc has
+#: been slipped past on the shape axis twice already. What each site's child envelope
+#: is actually decided by is stated in ``_SITE_PARENT_LAYERS``, individually.
+#: ``test_narrowing_exempt_sites_have_no_narrowing_channel`` reads the LIVE signature,
+#: so the day a ``narrowing`` channel is added to the primitive, every entry here goes
+#: RED and has to be revisited rather than quietly outliving its reason.
+_UNMET_NO_NARROWING_CHANNEL = (
+    "calls AgentRegistry.spawn_session, which has no narrowing parameter (#3561): an "
+    "UNMET REQUIREMENT recorded so the gate counts the site, not an exemption on the "
+    "merits. See this site's _SITE_PARENT_LAYERS entry for what decides its child's "
+    "envelope instead."
+)
+_NARROWING_EXEMPT_SITES: "dict[tuple[str, str], str]" = {
+    ("reyn/runtime/registry.py", "spawn_session_recorded"): _UNMET_NO_NARROWING_CHANNEL,
+    ("reyn/runtime/registry.py", "resolve_session"): _UNMET_NO_NARROWING_CHANNEL,
+    ("reyn/runtime/registry.py", "restore_all"): _UNMET_NO_NARROWING_CHANNEL,
+    ("reyn/runtime/registry.py", "_rewake_pipeline_runs"): _UNMET_NO_NARROWING_CHANNEL,
+    ("reyn/interfaces/slash/session.py", "session_cmd"): _UNMET_NO_NARROWING_CHANNEL,
+}
+
+@dataclass(frozen=True)
+class _Seam:
+    """A function at which a child session's permission envelope is decided,
+    named by its DEFINITION SITE rather than by its name (#3561).
+
+    The #3553 version of this gate matched call sites by NAME alone, which is
+    sound only while a name has exactly one definition in ``src/``. It does not
+    for ``spawn_session``: ``AgentRegistry.spawn_session`` (the primitive),
+    ``RouterHostAdapter.spawn_session`` (the ``session_spawn`` tool's adapter) and
+    ``RouterLoop``'s host-protocol call all spell the same six characters, and a
+    name match conflates them — it reports the ``router_loop.py`` host call as a
+    site of the registry primitive, which it is not.
+
+    ``receivers`` is how a call is RESOLVED: the key is
+    ``(calling module, ast.unparse(receiver expression))`` — ``""`` for a bare-name
+    call — and the value says whether that call is THIS seam. An unlisted receiver
+    is an error, not a guess: the instrument refuses to attribute a call it cannot
+    resolve, so a new call site with an unfamiliar receiver REDs
+    ``test_spawn_seam_receivers_are_all_resolvable`` instead of being silently
+    counted or silently skipped.
+
+    ``receivers=None`` declares the name unambiguous — pinned, not assumed, by
+    ``test_unambiguous_seam_names_have_exactly_one_definition``, which REDs the
+    moment a second ``def`` of that name appears anywhere in ``src/``.
+    """
+
+    #: The attribute / function name as it appears at a call site.
+    name: str
+    #: The real function object — imported, not named by string, so a rename
+    #: raises at collection time and ``inspect.signature`` reads the live
+    #: parameter list (``test_narrowing_exempt_sites_have_no_narrowing_channel``).
+    func: object
+    #: Module (relative to ``src/``) the seam is defined in.
+    module: str
+    #: ``(calling module, receiver expr) -> is-this-seam``. ``None`` ⇒ the name
+    #: has exactly one definition in ``src/`` and every call of it resolves here.
+    receivers: "dict[tuple[str, str], bool] | None" = None
+
 
 #: The seams at which a child session's permission envelope is decided: the
-#: recorded spawn primitive, plus the one wrapper that forwards a caller's value
-#: into it. Both are enumerated because a site that only calls the WRAPPER
-#: (``run_agent_step``) still decides the value, and counting the primitive alone
-#: would leave that decision outside the gate — which is how #3553 stayed invisible
-#: to the #3546 version of this gate for as long as it did.
-_SPAWN_SEAMS: "tuple[str, ...]" = ("spawn_session_recorded", "spawn_ephemeral_session")
+#: recorded spawn primitive, the one wrapper that forwards a caller's value into
+#: it, and (#3561) the SYNC primitive under both. The wrapper is enumerated
+#: because a site that only calls it (``run_agent_step``) still decides the value,
+#: and counting the primitive alone would leave that decision outside the gate —
+#: which is how #3553 stayed invisible to the #3546 version of this gate for as
+#: long as it did.
+#:
+#: ``AgentRegistry.spawn_session`` joined the list in #3561 on a REACHABILITY
+#: criterion, not a shape one. It takes no ``narrowing`` argument, and "it cannot
+#: take one, so it is out of scope" is the same shape argument that let #3556
+#: through this gate inverted: #3556 passed BECAUSE it spelled ``narrowing=``,
+#: while passing a value that was not a function of its parent. A seam with no
+#: inheritance channel is an UNMET REQUIREMENT, not an exemption — so it is listed,
+#: and each of its sites states what actually decides its child's envelope.
+_SPAWN_SEAMS: "tuple[_Seam, ...]" = (
+    _Seam(
+        name="spawn_session_recorded",
+        func=AgentRegistry.spawn_session_recorded,
+        module="reyn/runtime/registry.py",
+    ),
+    _Seam(
+        name="spawn_ephemeral_session",
+        func=spawn_ephemeral_session,
+        module="reyn/runtime/session_api.py",
+    ),
+    _Seam(
+        name="spawn_session",
+        func=AgentRegistry.spawn_session,
+        module="reyn/runtime/registry.py",
+        receivers={
+            # ``self`` inside registry.py IS the AgentRegistry.
+            ("reyn/runtime/registry.py", "self"): True,
+            # ``reg = session._registry`` — the AgentRegistry the REPL session holds.
+            ("reyn/interfaces/slash/session.py", "reg"): True,
+            # ``self.host`` is a RouterLoopHost (RouterHostAdapter in production):
+            # a DIFFERENT ``spawn_session``, taking chain_id/mode/request. Its own
+            # enclosing function ``router_host_adapter.spawn_session`` is already an
+            # enumerated site of the ``spawn_session_recorded`` seam, one hop down.
+            ("reyn/runtime/router_loop.py", "self.host"): False,
+        },
+    ),
+)
 
 
 @dataclass(frozen=True)
@@ -321,20 +444,39 @@ class _SiteDeclaration:
     that drive the site for real and observe a denied capability's side effect NOT
     happening, so the registry doubles as an index of those tests and a site with an
     empty index is visibly unmeasured rather than invisibly so.
+
+    #3561 split the "no measurement" case in two, because the two were not the same
+    thing wearing one field. A FORWARDER has no value of its own to measure and its
+    callers do — that is a claim about the call graph, so it is now
+    ``measured_via_callers``, a typed list the AST checks against the call graph it
+    actually finds (``test_forwarder_exemptions_name_their_real_callers``). The old
+    spelling was the prose "there is no value of its own to measure; a thin
+    forwarder…" — a JUDGEMENT, which stays green whether or not it is still true, and
+    in particular stays green when a second caller appears that nobody measured.
+    ``unmeasured_reason`` keeps only the genuinely-unmeasured case.
     """
 
     #: Which layers of the SPAWNER's envelope the value passed here composes.
     parent_layers: str
     #: ``"tests/<file>.py::<test function>"`` for each behavioural measurement of
-    #: this site. Empty only when ``unmeasured_reason`` says why.
+    #: this site. Empty only when ``measured_via_callers`` or ``unmeasured_reason``
+    #: says why.
     measured_by: "tuple[str, ...]" = ()
-    #: Why this site has no behavioural measurement, when it has none.
+    #: (#3561) For a FORWARDER — a site that decides no value of its own — every
+    #: site that calls it, each of which must itself be enumerated and must resolve
+    #: (transitively, through its own forwarders) to a non-empty ``measured_by``.
+    #: Checked against the call graph the AST walk finds, so the exemption cannot
+    #: outlive its justification: a new, unmeasured caller REDs the gate.
+    measured_via_callers: "tuple[tuple[str, str], ...]" = ()
+    #: Why this site has no behavioural measurement, when it has none and is not a
+    #: forwarder either.
     unmeasured_reason: str = ""
 
 
 _S3546 = "tests/test_3546_pipeline_driver_narrowing_inheritance.py"
 _S3553 = "tests/test_3553_agent_step_worker_narrowing_inheritance.py"
 _S3556 = "tests/test_3556_session_spawn_narrowing_inheritance.py"
+_S3561 = "tests/test_3561_spawn_session_seam_reachability.py"
 
 #: Every spawn site in ``src/``, with the parent layers its ``narrowing=`` value
 #: composes and the behavioural test that measures that claim. A site missing from
@@ -374,10 +516,11 @@ _SITE_PARENT_LAYERS: "dict[tuple[str, str], _SiteDeclaration]" = {
             "straight to the primitive. The deciding site is whoever calls IT, which "
             "is why this gate enumerates that seam too."
         ),
-        unmeasured_reason=(
-            "there is no value of its own to measure; its callers are declared and "
-            "measured individually."
-        ),
+        # #3561: was the prose "there is no value of its own to measure; a thin
+        # forwarder…" — a judgement no test could check, and one that would have
+        # stayed green if a SECOND, unmeasured caller had appeared. The claim is now
+        # the call graph itself.
+        measured_via_callers=(("reyn/runtime/session_api.py", "run_agent_step"),),
     ),
     ("reyn/runtime/services/router_host_adapter.py", "spawn_session"): _SiteDeclaration(
         parent_layers=(
@@ -396,20 +539,148 @@ _SITE_PARENT_LAYERS: "dict[tuple[str, str], _SiteDeclaration]" = {
             f"{_S3556}::test_spawner_allow_list_survives_an_llm_requested_narrowing",
         ),
     ),
+    # ── #3561: the sites of the SYNC primitive ``AgentRegistry.spawn_session`` ──
+    # None of these can pass ``narrowing=`` — the primitive has no such parameter.
+    # That is recorded in ``_NARROWING_EXEMPT_SITES`` as an unmet requirement rather
+    # than an exemption on the merits, and each entry below says what DOES decide the
+    # child's envelope, because "it cannot inherit" is not the same claim as "it has
+    # nothing to inherit".
+    ("reyn/runtime/registry.py", "spawn_session_recorded"): _SiteDeclaration(
+        parent_layers=(
+            "NONE of its own — this is the recorded seam itself, calling the sync "
+            "primitive and then writing its OWN ``narrowing`` argument to the child's "
+            "sid-keyed ``config.yaml`` (the #2103-S1a layer) a few statements later. "
+            "The value is therefore decided by whoever calls IT, which is why all "
+            "three of those callers are enumerated sites in their own right."
+        ),
+        measured_via_callers=(
+            ("reyn/runtime/session_api.py", "spawn_ephemeral_session"),
+            ("reyn/runtime/session_api.py", "_spawn_pipeline_driver_session"),
+            ("reyn/runtime/services/router_host_adapter.py", "spawn_session"),
+        ),
+    ),
+    ("reyn/runtime/registry.py", "resolve_session"): _SiteDeclaration(
+        parent_layers=(
+            "NONE, and there is no spawner SESSION here to take them from: this is the "
+            "inbound-transport get-or-spawn for a ``<transport>:<native_id>`` "
+            "conversation key (a2a / mcp / cron / webhook / web), entered from a "
+            "transport frame. The child gets the agent's NAME-keyed layers only (the "
+            "agent's permissions declaration, topology capability_profile bindings, the "
+            "#2081 _delegate floor), identical to every other session of that agent. "
+            "⚠ Not a closed question: ``Session._cross_session_hook_put`` reaches this "
+            "with a hook-config ``target_session_id`` of the form ``transport:native``, "
+            "so a SESSION can be upstream of it after all — but the session it reaches "
+            "through is one of its OWN agent's, whose name-keyed envelope it already "
+            "shares, so there is no per-session layer to carry across. A cross-AGENT "
+            "variant would change that answer; there is none today."
+        ),
+        unmeasured_reason=(
+            "the claim is about the ABSENCE of a per-session layer to inherit, and the "
+            "behavioural shape this file measures elsewhere (a denied capability's side "
+            "effect not happening) has no subject here: with no spawner session there "
+            "is no narrowing whose loss could be observed. #3561 recorded this rather "
+            "than inventing a measurement whose green would mean nothing."
+        ),
+    ),
+    ("reyn/runtime/registry.py", "restore_all"): _SiteDeclaration(
+        parent_layers=(
+            "NOT an inheritance from a spawner at all — a RE-ATTACHMENT to the child's "
+            "own durable layer. Crash recovery re-creates a session that already "
+            "existed, under the SAME sid, and the #2103-S1a narrowing lives in "
+            "``<state>/sessions/<enc(sid)>/config.yaml``, keyed by that sid. The "
+            "primitive's per-session path re-key is what restores the resolution path; "
+            "there is no value to pass. The name-keyed layers ride along as everywhere "
+            "else. That this actually survives — rather than the re-woken session being "
+            "reborn wide — is the measurement named below, not an assumption."
+        ),
+        measured_by=(
+            f"{_S3561}::test_recovery_recreated_session_keeps_its_persisted_narrowing",
+        ),
+    ),
+    ("reyn/runtime/registry.py", "_rewake_pipeline_runs"): _SiteDeclaration(
+        parent_layers=(
+            "Same as ``restore_all`` above — the pipeline-driver arm of the same "
+            "crash-recovery re-creation, re-entering under the work order's "
+            "``driver_sid``, so the driver-session's own persisted narrowing (written "
+            "when ``_spawn_pipeline_driver_session`` first spawned it through "
+            "``spawn_session_recorded``) is resolved from disk by sid rather than "
+            "passed. Measured by the same behavioural leg, which drives the shared "
+            "``spawn_session``-under-an-existing-sid path both arms use."
+        ),
+        measured_by=(
+            f"{_S3561}::test_recovery_recreated_session_keeps_its_persisted_narrowing",
+        ),
+    ),
+    ("reyn/interfaces/slash/session.py", "session_cmd"): _SiteDeclaration(
+        parent_layers=(
+            "NONE — and unlike the two recovery sites, this one has something it could "
+            "inherit and does not. ``/session new`` opens a session under the ATTACHED "
+            "agent with no ``config.yaml`` of its own and nothing carried from the "
+            "invoking session, so the child's #2103-S1a layer is empty however narrow "
+            "its invoker is. This is the arc's open gap, filed as #3562; it is declared "
+            "HERE rather than left off the list, because a site the gate does not "
+            "enumerate is a site the gate does not count. "
+            "#3561 measured that it is REACHABLE FROM MODEL OUTPUT, which is the fact "
+            "that decides it is in scope: an agent step whose prompt is a previous "
+            "agent step's model output, run on a session narrowed to a single "
+            "capability, reaches this site and spawns — no operator in the path, no LLM "
+            "call on the reaching turn (``Session._handle_user_message`` short-circuits "
+            "to ``_maybe_handle_slash`` before the router runs). The measurement below "
+            "asserts the REACHABILITY only, never that the child is un-narrowed, so it "
+            "stays green when #3562 closes the gap."
+        ),
+        measured_by=(
+            f"{_S3561}::test_model_output_reaches_slash_dispatch_and_spawns_a_session",
+        ),
+    ),
 }
 
 
-def _spawn_call_sites() -> "list[tuple[str, str, int]]":
-    """Every CALL of a ``_SPAWN_SEAMS`` function in ``src/`` as
-    ``(relative module path, enclosing function, keywords-present marker)``.
+_SRC = Path(__file__).resolve().parents[1] / "src"
+
+
+@dataclass(frozen=True)
+class _CallSite:
+    """One resolved call of one seam."""
+
+    module: str          # relative to ``src/``
+    function: str        # enclosing function ("<module>" at module level)
+    seam: str            # the resolved seam's ``name``
+    has_narrowing: bool  # an explicit ``narrowing=`` kwarg, or ``**kwargs`` forwarding
+
+    @property
+    def key(self) -> "tuple[str, str]":
+        return (self.module, self.function)
+
+
+#: Every ``(calling module, receiver expr)`` this run saw for a seam that needs
+#: resolution but that ``_Seam.receivers`` does not answer. Populated by
+#: :func:`_spawn_call_sites` and asserted empty by
+#: ``test_spawn_seam_receivers_are_all_resolvable`` — an unresolvable receiver must
+#: not be silently counted (a false site) OR silently skipped (a missed site).
+_UNRESOLVED_RECEIVERS: "set[tuple[str, str, str]]" = set()
+
+
+def _spawn_call_sites() -> "list[_CallSite]":
+    """Every CALL of a ``_SPAWN_SEAMS`` seam in ``src/``, RESOLVED to a definition.
 
     An AST walk, not a regex: the same keyword inside a docstring or a comment is
     prose, and matching it textually has already produced false positives on this
     codebase. ``ast`` sees only real ``Call`` nodes.
+
+    #3561: the walk resolves each call by RECEIVER, not by name. Matching
+    ``spawn_session`` by name alone attributes ``router_loop.py``'s
+    ``self.host.spawn_session(chain_id=…, mode=…, request=…)`` to
+    ``AgentRegistry.spawn_session``, which is a different function taking different
+    arguments — a false site that would then need a false declaration. A receiver
+    the seam's table does not answer is recorded in ``_UNRESOLVED_RECEIVERS`` and
+    fails its own test; the walk never guesses in either direction.
     """
-    src = Path(__file__).resolve().parents[1] / "src"
-    sites: "list[tuple[str, str, int]]" = []
-    for py in sorted(src.rglob("*.py")):
+    _UNRESOLVED_RECEIVERS.clear()
+    by_name: "dict[str, _Seam]" = {s.name: s for s in _SPAWN_SEAMS}
+    sites: "list[_CallSite]" = []
+    for py in sorted(_SRC.rglob("*.py")):
+        rel = str(py.relative_to(_SRC))
         tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
         # Enclosing-function attribution: walk defs, then their nested calls.
         enclosing: "dict[int, str]" = {}
@@ -421,35 +692,142 @@ def _spawn_call_sites() -> "list[tuple[str, str, int]]":
             if not isinstance(node, ast.Call):
                 continue
             func = node.func
-            name = func.attr if isinstance(func, ast.Attribute) else (
-                func.id if isinstance(func, ast.Name) else None
-            )
-            if name not in _SPAWN_SEAMS:
+            if isinstance(func, ast.Attribute):
+                name, receiver = func.attr, ast.unparse(func.value)
+            elif isinstance(func, ast.Name):
+                name, receiver = func.id, ""
+            else:
                 continue
+            seam = by_name.get(name)
+            if seam is None:
+                continue
+            if seam.receivers is not None:
+                resolved = seam.receivers.get((rel, receiver))
+                if resolved is None:
+                    _UNRESOLVED_RECEIVERS.add((rel, receiver, name))
+                    continue
+                if not resolved:
+                    continue  # a different function that shares the name
             has_narrowing = any(kw.arg == "narrowing" for kw in node.keywords) or any(
                 kw.arg is None for kw in node.keywords  # **kwargs forwarding
             )
-            sites.append((
-                str(py.relative_to(src)),
-                enclosing.get(id(node), "<module>"),
-                int(has_narrowing),
+            sites.append(_CallSite(
+                module=rel,
+                function=enclosing.get(id(node), "<module>"),
+                seam=seam.name,
+                has_narrowing=has_narrowing,
             ))
     return sites
+
+
+def _definition_sites(name: str) -> "set[str]":
+    """Every module in ``src/`` that defines a function or method called ``name``
+    — the ground truth an unambiguous-name claim is checked against."""
+    found: "set[str]" = set()
+    for py in sorted(_SRC.rglob("*.py")):
+        tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+                found.add(str(py.relative_to(_SRC)))
+    return found
 
 
 def test_spawn_seam_call_sites_are_findable() -> None:
     """Tier 2: instrument check — the AST walk finds the seams' known call sites.
 
     A completeness gate that silently found NOTHING would pass for the wrong
-    reason, so the gate's own search is witnessed against three sites it must see:
-    the pipeline driver spawn, the ``session_spawn`` tool's spawn, and (#3553) the
-    agent-step spawn, which reaches the primitive only through the wrapper.
+    reason, so the gate's own search is witnessed against four sites it must see:
+    the pipeline driver spawn, the ``session_spawn`` tool's spawn, (#3553) the
+    agent-step spawn, which reaches the recorded primitive only through the wrapper,
+    and (#3561) ``/session new``, which reaches the SYNC primitive and no wrapper at
+    all. The fourth is the one the pre-#3561 name-matching walk could not see,
+    because ``spawn_session`` was not on the list to match.
     """
     sites = _spawn_call_sites()
-    functions = {(mod, fn) for mod, fn, _ in sites}
+    functions = {s.key for s in sites}
     assert ("reyn/runtime/session_api.py", "_spawn_pipeline_driver_session") in functions
     assert ("reyn/runtime/session_api.py", "run_agent_step") in functions
     assert any(mod == "reyn/runtime/services/router_host_adapter.py" for mod, _ in functions)
+    assert ("reyn/interfaces/slash/session.py", "session_cmd") in functions
+
+
+def test_spawn_seam_resolution_separates_same_named_functions() -> None:
+    """Tier 2: (#3561) the walk resolves ``spawn_session`` by RECEIVER, so it does
+    not conflate three unrelated functions that share the name.
+
+    The known-present positive and the known-present negative are asserted together,
+    because either alone is satisfiable by a broken instrument: a walk that matched
+    nothing would pass a negative-only check, and a walk that matched everything by
+    name would pass a positive-only one.
+
+      positive — ``interfaces/slash/session.py``'s ``reg.spawn_session(...)`` IS
+                 ``AgentRegistry.spawn_session``;
+      negative — ``runtime/router_loop.py``'s ``self.host.spawn_session(...)`` is
+                 ``RouterHostAdapter.spawn_session`` (``chain_id`` / ``mode`` /
+                 ``request``), and the registry's envelope-birth accounting must not
+                 claim it. Its own enclosing function is separately enumerated as a
+                 site of ``spawn_session_recorded``, one hop down.
+    """
+    resolved = {(s.module, s.function, s.seam) for s in _spawn_call_sites()}
+    assert (
+        "reyn/interfaces/slash/session.py", "session_cmd", "spawn_session",
+    ) in resolved
+    assert not any(
+        mod == "reyn/runtime/router_loop.py" and seam == "spawn_session"
+        for mod, _fn, seam in resolved
+    ), (
+        "the walk attributed router_loop.py's host-protocol spawn_session call to "
+        "AgentRegistry.spawn_session — a name match, not a resolution"
+    )
+    # …and the hop down IS counted, so the negative above is a re-attribution, not
+    # a hole.
+    assert (
+        "reyn/runtime/services/router_host_adapter.py", "spawn_session",
+        "spawn_session_recorded",
+    ) in resolved
+
+
+def test_spawn_seam_receivers_are_all_resolvable() -> None:
+    """Tier 2: (#3561) every call of an ambiguous seam name has a receiver the seam's
+    resolution table answers.
+
+    The walk refuses to guess: an unlisted receiver is neither counted (a phantom
+    site with a phantom declaration) nor skipped (a real site the gate stops
+    counting, which is the failure mode #3561 exists to close). It lands here
+    instead, so a new call site through an unfamiliar receiver forces a human to
+    resolve it once and record the answer.
+    """
+    _spawn_call_sites()
+    assert not _UNRESOLVED_RECEIVERS, (
+        "call(s) of a spawn-seam name whose receiver the seam's `receivers` table "
+        f"does not resolve: {sorted(_UNRESOLVED_RECEIVERS)!r}. Resolve each to its "
+        "DEFINITION and add it as True (this seam) or False (a different function "
+        "of the same name)."
+    )
+
+
+def test_unambiguous_seam_names_have_exactly_one_definition() -> None:
+    """Tier 2: (#3561) a seam declared unambiguous (``receivers=None``) really has
+    one definition in ``src/``, and every seam's declared module really defines it.
+
+    Name matching is sound only under that premise, and the premise is exactly the
+    kind of thing that silently stops being true — someone adds a second
+    ``spawn_ephemeral_session`` on another class and the walk starts attributing its
+    calls to this one. Asserting the definition SET (not its size) means the failure
+    names the intruder.
+    """
+    for seam in _SPAWN_SEAMS:
+        defs = _definition_sites(seam.name)
+        assert seam.module in defs, (
+            f"seam {seam.name!r} is declared as defined in {seam.module!r}, but no "
+            f"such definition was found there (found: {sorted(defs)!r})"
+        )
+        if seam.receivers is None:
+            assert defs == {seam.module}, (
+                f"seam {seam.name!r} is declared unambiguous, but {sorted(defs)!r} "
+                "define that name — resolution by name alone now conflates them. "
+                "Give the seam a `receivers` table."
+            )
 
 
 def test_every_spawn_site_passes_narrowing() -> None:
@@ -458,12 +836,12 @@ def test_every_spawn_site_passes_narrowing() -> None:
 
     Counted at the place that should inherit, not at the places that might have
     re-checked — the latter set is unbounded, this one is enumerable. A site that
-    legitimately must not pass ``narrowing=`` registers its reason in
-    ``_NARROWING_EXEMPT_SITES`` instead of being silently absent.
+    does not pass ``narrowing=`` registers its reason in ``_NARROWING_EXEMPT_SITES``
+    instead of being silently absent.
     """
     missing = [
-        (mod, fn) for mod, fn, has in _spawn_call_sites()
-        if not has and (mod, fn) not in _NARROWING_EXEMPT_SITES
+        s.key for s in _spawn_call_sites()
+        if not s.has_narrowing and s.key not in _NARROWING_EXEMPT_SITES
     ]
     assert not missing, (
         "spawn call site(s) do not pass narrowing=, so the spawned session's "
@@ -471,6 +849,35 @@ def test_every_spawn_site_passes_narrowing() -> None:
         f"{missing!r}. Pass narrowing=, or register the site in "
         "_NARROWING_EXEMPT_SITES with the reason it must not."
     )
+
+
+def test_narrowing_exempt_sites_have_no_narrowing_channel() -> None:
+    """Tier 2: (#3561) every exempt site's exemption rests on a fact about the LIVE
+    seam signature, not on prose — the seam it calls really has no ``narrowing``
+    parameter.
+
+    Every entry in ``_NARROWING_EXEMPT_SITES`` today says the same thing: the site
+    calls ``AgentRegistry.spawn_session``, which has no channel to pass a narrowing
+    through. That is recorded as an unmet requirement, and this test is what makes it
+    expire: add the channel and every exemption goes RED, forcing each site to either
+    use it or re-argue. It also fails if an exempt entry is stale (naming a site the
+    walk no longer finds), so the registry cannot accumulate dead permissions.
+    """
+    seam_by_name = {s.name: s for s in _SPAWN_SEAMS}
+    sites = _spawn_call_sites()
+    for key in sorted(_NARROWING_EXEMPT_SITES):
+        seams_here = {s.seam for s in sites if s.key == key and not s.has_narrowing}
+        assert seams_here, (
+            f"_NARROWING_EXEMPT_SITES lists {key!r}, but the walk finds no "
+            "narrowing-less spawn call there — a stale exemption"
+        )
+        for seam_name in sorted(seams_here):
+            params = inspect.signature(seam_by_name[seam_name].func).parameters
+            assert "narrowing" not in params, (
+                f"{key!r} is exempted from passing narrowing=, but the seam it calls "
+                f"({seam_name}) DOES take a narrowing parameter — the exemption's "
+                "stated reason is no longer true. Pass it, or re-argue the exemption."
+            )
 
 
 def test_every_spawn_site_declares_its_parent_layers() -> None:
@@ -483,8 +890,7 @@ def test_every_spawn_site_declares_its_parent_layers() -> None:
     site. ⚠️ Stated, not verified: see ``_SiteDeclaration``.
     """
     undeclared = [
-        (mod, fn) for mod, fn, _ in _spawn_call_sites()
-        if (mod, fn) not in _SITE_PARENT_LAYERS
+        s.key for s in _spawn_call_sites() if s.key not in _SITE_PARENT_LAYERS
     ]
     assert not undeclared, (
         "spawn call site(s) do not declare which layers of the spawner's permission "
@@ -509,8 +915,13 @@ def test_every_declared_site_names_a_behavioural_test_or_a_reason() -> None:
     tests_root = Path(__file__).resolve().parent
     for (mod, fn), decl in sorted(_SITE_PARENT_LAYERS.items()):
         assert decl.parent_layers.strip(), f"{mod}::{fn} declares no parent layers"
-        assert decl.measured_by or decl.unmeasured_reason.strip(), (
-            f"{mod}::{fn} names neither a behavioural test nor a reason it has none"
+        assert (
+            decl.measured_by
+            or decl.measured_via_callers
+            or decl.unmeasured_reason.strip()
+        ), (
+            f"{mod}::{fn} names neither a behavioural test, nor the callers that "
+            "carry the measurement for it, nor a reason it has none"
         )
         for ref in decl.measured_by:
             path_part, _, test_name = ref.partition("::")
@@ -526,3 +937,85 @@ def test_every_declared_site_names_a_behavioural_test_or_a_reason() -> None:
                 "A renamed or deleted measurement must not leave the site silently "
                 "declared-but-unmeasured."
             )
+
+
+def test_forwarder_exemptions_name_their_real_callers() -> None:
+    """Tier 2: (#3561) a forwarder's exemption is a claim about the CALL GRAPH, and
+    the call graph is what checks it.
+
+    ``spawn_ephemeral_session``'s exemption used to read "there is no value of its
+    own to measure; a thin forwarder…" — a judgement, true or false in the reader's
+    head and green either way. In particular it stayed green under the one change
+    that would falsify it: a SECOND caller, deciding a second value nobody measured.
+    The claim is now "these are its callers", and this test compares that list to the
+    callers the AST actually finds, in both directions:
+
+      - a declared caller the walk does not find ⇒ the list is stale;
+      - a found caller the list omits ⇒ a new deciding site slipped in behind the
+        exemption, which is exactly the case the prose could not catch.
+
+    A declared caller must also be an enumerated site itself, so the exemption cannot
+    hand the measurement to somewhere the gate never looks.
+    """
+    sites = _spawn_call_sites()
+    for key, decl in sorted(_SITE_PARENT_LAYERS.items()):
+        if not decl.measured_via_callers:
+            continue
+        seam_name = key[1]  # a forwarder's own def name is the seam its callers call
+        assert seam_name in {s.name for s in _SPAWN_SEAMS}, (
+            f"{key!r} declares measured_via_callers, but {seam_name!r} is not an "
+            "enumerated seam — its callers are not something this walk can find"
+        )
+        actual = {s.key for s in sites if s.seam == seam_name}
+        declared = set(decl.measured_via_callers)
+        assert declared == actual, (
+            f"{key[0]}::{key[1]} claims its measurement is carried by "
+            f"{sorted(declared)!r}, but the call graph says its callers are "
+            f"{sorted(actual)!r}. A forwarder exemption must not outlive the caller "
+            "set that justified it."
+        )
+        for caller in sorted(declared):
+            assert caller in _SITE_PARENT_LAYERS, (
+                f"{key[0]}::{key[1]} defers its measurement to {caller!r}, which is "
+                "not itself a declared site — the deferral would leave the value "
+                "decided outside the gate"
+            )
+
+
+def test_forwarder_deferral_terminates_in_a_real_measurement() -> None:
+    """Tier 2: (#3561) following every ``measured_via_callers`` deferral reaches a
+    site with a non-empty ``measured_by`` — the exemption chain has a bottom.
+
+    Two forwarders now defer to each other's callers
+    (``spawn_session_recorded`` → ``spawn_ephemeral_session`` → ``run_agent_step``),
+    and a deferral graph that closed into a cycle, or that ended on an
+    ``unmeasured_reason``, would let a site be "measured" by nothing at all while
+    every individual link looked accounted for. Walking the closure is what makes
+    "its callers are measured individually" a checkable sentence rather than a
+    plausible one.
+    """
+    for key, decl in sorted(_SITE_PARENT_LAYERS.items()):
+        if not decl.measured_via_callers:
+            continue
+        seen: "set[tuple[str, str]]" = set()
+        frontier = list(decl.measured_via_callers)
+        leaves: "list[tuple[str, str]]" = []
+        while frontier:
+            cur = frontier.pop()
+            if cur in seen:
+                continue
+            seen.add(cur)
+            sub = _SITE_PARENT_LAYERS[cur]
+            if sub.measured_via_callers:
+                frontier.extend(sub.measured_via_callers)
+            else:
+                leaves.append(cur)
+        assert leaves, (
+            f"{key[0]}::{key[1]}'s deferral closes into a cycle and never reaches a "
+            "site that measures anything"
+        )
+        unmeasured = [leaf for leaf in leaves if not _SITE_PARENT_LAYERS[leaf].measured_by]
+        assert not unmeasured, (
+            f"{key[0]}::{key[1]} defers its measurement, transitively, to site(s) "
+            f"that measure nothing: {sorted(unmeasured)!r}"
+        )

--- a/tests/test_3561_spawn_session_seam_reachability.py
+++ b/tests/test_3561_spawn_session_seam_reachability.py
@@ -1,0 +1,318 @@
+"""Tier 2: OS invariant — the two behavioural claims that put
+``AgentRegistry.spawn_session`` inside the #3546/#3553/#3556 spawn-seam gate.
+
+#3561. That primitive was outside the gate because it takes no ``narrowing``
+argument, and the question asked about it was "is a primitive that cannot take a
+narrowing in scope?" — a SHAPE question. It is the same question #3554's gate asked
+in the opposite direction: #3554 counted a site as compliant BECAUSE it spelled
+``narrowing=``, which #3556 satisfied while passing a value that was no function of
+its parent at all. "Cannot inherit" is not "need not inherit": an API with no
+inheritance channel is an unmet requirement, not an exemption. The criterion is
+REACHABILITY — can a narrowed subject cause this to run.
+
+★ **Reachability was measured before the site was classified, not after.** The
+standing assumption was that ``AgentRegistry.spawn_session``'s one non-registry call
+site, the ``/session new`` slash command, is operator-initiated and therefore out of
+scope. The path that had actually been established was only that the OPERATOR input
+face reaches it — never that no other face does.
+``test_model_output_reaches_slash_dispatch_and_spawns_a_session`` is the falsification:
+it drives the real ``run_agent_step`` with a prompt that is a previous agent step's
+MODEL OUTPUT, on a session narrowed to a single capability, and observes a session
+being born. The assumption is false.
+
+Why the reaching turn is not a model turn: ``Session._handle_user_message`` tests
+``text.startswith("/")`` and hands the line to ``_maybe_handle_slash`` BEFORE the
+router turn, so the worker never calls its LLM on that turn at all — which the test
+asserts, because "the scripted LLM was not consulted" is what distinguishes a slash
+short-circuit from a model that happened to decide to spawn. Slash dispatch has
+exactly two production callers (``_handle_user_message`` and
+``maybe_deliver_answer_command``), so the surface reached here is small and
+enumerable; what is NOT bounded is the set of ways text arrives at
+``_handle_user_message``, and the agent-step prompt is one of them.
+
+What this file deliberately does NOT assert: that the session ``/session new`` opens
+is un-narrowed. It is (the invoking session's #2103-S1a layer is not carried, which is
+#3562), but pinning that would make the fix red. The measurement is the reachability,
+which stays true either way.
+
+The second claim is a different site of the same primitive and the opposite verdict.
+Crash recovery (``restore_all`` / ``_rewake_pipeline_runs``) re-creates a session
+through ``spawn_session`` with no narrowing argument either, and that one is NOT a
+gap: the session is re-created under its ORIGINAL sid, and the #2103-S1a layer is
+keyed by sid on disk. ``test_recovery_recreated_session_keeps_its_persisted_narrowing``
+measures that it really survives — the ``#2126`` comment inside
+``spawn_session_recorded`` documents that construction-time resolution runs with
+``sid=None`` and therefore ignores ``config.yaml``, which is exactly the shape a
+re-woken session could have been reborn wide through, so the survival is a result and
+not a deduction. Its negative control, ``test_recovery_without_a_persisted_narrowing_
+restores_an_unnarrowed_session``, removes the persisted file and shows the same
+assertion going the other way — without it, a permanently-denied tool would satisfy
+the positive leg for a reason having nothing to do with recovery.
+
+The completeness half of the gate — which sites exist, how they are resolved, and
+what each declares — lives in
+``tests/test_3546_pipeline_driver_narrowing_inheritance.py``; this module is what its
+``measured_by`` entries for the ``spawn_session`` sites point at.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import _interpolate_prompt
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.model_resolver import ModelResolver
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.runtime.session_api import run_agent_step
+from reyn.runtime.session_params import PresentationWiring
+from reyn.runtime.spawn_routing import AuditOnlyNoSurface
+from tests._support.agent_session import make_session
+
+#: The line the scripted LLM emits. It is a real, registered slash command whose
+#: handler calls ``AgentRegistry.spawn_session`` — see ``interfaces/slash/session.py``.
+_MODEL_OUTPUT = "/session new"
+
+#: The tool the recovery legs narrow away. A production, catalog-listed tool, so the
+#: envelope read below is about a capability that really exists.
+_DENIED_TOOL = "write_file"
+
+
+class _ScriptedReply:
+    """A real ``_llm_caller``-shaped callable answering with one fixed plain-text
+    turn — the Tier-2c LLM stand-in this arc's sibling files already use (see
+    ``tests/test_pipeline_r5_run_agent_step.py``), NOT a ``MagicMock``: a signature
+    drift in the ``call_llm_tools`` contract raises ``TypeError`` here exactly as it
+    would in production.
+
+    ``calls`` is load-bearing, not diagnostic: the reachability leg reads it to show
+    that the turn which reached slash dispatch consulted no model at all.
+    """
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.calls = 0
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.calls += 1
+        return LLMToolCallResult(
+            content=self.content, tool_calls=[], finish_reason="stop", usage=TokenUsage(),
+        )
+
+
+def _registry(
+    tmp_path: Path, scripted: "_ScriptedReply | None" = None, *, agents: "tuple[str, ...]" = ("worker",),
+) -> AgentRegistry:
+    """Real ``AgentRegistry`` + real ``Session`` factory — the harness shape
+    ``tests/test_pipeline_r5_run_agent_step.py`` uses, including the ``holder``
+    deferred-registry-ref so the factory can pass ``registry=`` for ephemeral
+    auto-vanish, and its real-litellm-name resolver so a spawned session's
+    model-support pre-check has a name to resolve."""
+    if not (tmp_path / "reyn.yaml").exists():
+        (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    holder: dict = {}
+    resolver = ModelResolver({"standard": "gemini/gemini-2.5-flash-lite"})
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
+        s = make_session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            presentation_wiring=PresentationWiring(
+                presentation_consumer=presentation_consumer,
+                intervention_bridge=intervention_bridge,
+            ),
+            resolver=resolver,
+        )
+        if scripted is not None:
+            s._loop_driver._loop_observer = (
+                lambda loop: setattr(loop, "_llm_caller", scripted)
+            )
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    for name in agents:
+        if not reg.exists(name):
+            reg.create(name)
+    return reg
+
+
+def _envelope_denials(session: Session) -> "list[str]":
+    """The tool names this session's live capability ENVELOPE denies, read off the
+    public status-bar read model (``capability_visibility_state``) rather than any
+    private attribute — the same surface the operator's own status bar renders."""
+    state = session.capability_visibility_state()
+    return [
+        entry["name"] for entry in state.get("denied_by_envelope", ())
+        if entry.get("kind") == "tool"
+    ]
+
+
+# ── the reachability falsification ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_model_output_reaches_slash_dispatch_and_spawns_a_session(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: MODEL OUTPUT reaches slash dispatch, and through it
+    ``AgentRegistry.spawn_session`` — the measurement that decides
+    ``interfaces/slash/session.py::session_cmd`` is a spawn seam in scope.
+
+    Two agent steps, both real ``run_agent_step`` calls on real sessions:
+
+      1. the first returns the model's text — here a slash command;
+      2. the production template splice (``executor._interpolate_prompt``, the exact
+         function an ``agent`` step's ``prompt`` goes through) puts that text in the
+         second step's prompt;
+      3. the second step's worker — narrowed to a single capability, so it is a
+         NARROWED subject — reaches ``/session new`` and a session is born under the
+         attached agent.
+
+    No operator submits anything at any point. ``scripted.calls`` staying at 1 across
+    step 2 is what shows the reaching turn short-circuited at
+    ``_maybe_handle_slash`` instead of running a router turn: without it, a spawn
+    could be explained by the worker's own model deciding to spawn, which is a
+    different (already-gated, #3556) path.
+    """
+    monkeypatch.chdir(tmp_path)
+    scripted = _ScriptedReply(_MODEL_OUTPUT)
+    reg = _registry(tmp_path, scripted, agents=("worker", "operator"))
+
+    # 1. a model emits a slash command as its ordinary reply text.
+    model_output = await run_agent_step(reg, identity="worker", prompt="go")
+    assert model_output == _MODEL_OUTPUT
+    assert scripted.calls == 1
+
+    # 2. the production splice puts it in the next step's prompt, verbatim.
+    next_prompt = _interpolate_prompt("{pipe}", {"ctx": {}, "pipe": model_output})
+    assert next_prompt == _MODEL_OUTPUT
+
+    # An operator is attached, which is the ordinary REPL state — ``/session new``
+    # acts on the ATTACHED agent, so this is whose session count moves.
+    reg.get_or_load("operator")
+    await reg.attach_session("operator", "main")
+    before = set(reg.session_ids("operator"))
+
+    # 3. a narrowed worker runs that prompt.
+    await run_agent_step(
+        reg, identity="worker", prompt=next_prompt, capabilities=[_DENIED_TOOL],
+    )
+
+    born = set(reg.session_ids("operator")) - before
+    assert born, (
+        "model output did not reach slash dispatch — no session was born under the "
+        "attached agent. If this is now correct, the reachability claim in "
+        "tests/test_3546_pipeline_driver_narrowing_inheritance.py's declaration for "
+        "interfaces/slash/session.py::session_cmd is stale and must be re-argued."
+    )
+    assert scripted.calls == 1, (
+        "the reaching turn consulted the LLM, so the spawn is not evidence of the "
+        "slash short-circuit — _handle_user_message is expected to hand a '/'-prefixed "
+        f"line to _maybe_handle_slash before any router turn (llm calls: {scripted.calls})"
+    )
+
+
+# ── the recovery site: the sid-keyed layer really is re-attached ─────────────
+
+
+async def _spawn_narrowed_and_persist(reg: AgentRegistry, tmp_path: Path) -> str:
+    """Spawn a narrowed session through the recorded seam and wait for its
+    per-session snapshot to land on disk — ``restore_all`` discovers spawned
+    sessions BY that file, so a test that raced it would measure nothing at all."""
+    routing = AuditOnlyNoSurface()
+    sid = await reg.spawn_session_recorded(
+        "worker", mode="persistent", narrowing={"tool_deny": [_DENIED_TOOL]},
+        presentation_consumer=routing.presentation_consumer,
+        intervention_bridge=routing.intervention_bridge,
+    )
+    session = reg.get_session("worker", sid)
+    assert session is not None
+    # Non-empty restored state is restore_all's own precondition for re-creating a
+    # session (step 5 skips a snapshot with nothing stranded in it).
+    await session._put_inbox("user", {"text": "stranded", "chain_id": "c3561"})
+    await session.await_quiescent()
+    snapshot = (
+        tmp_path / ".reyn" / "agents" / "worker" / "state" / "sessions" / sid / "snapshot.json"
+    )
+    for _ in range(100):
+        if snapshot.is_file():
+            break
+        await asyncio.sleep(0.05)
+    assert snapshot.is_file(), "the spawned session's snapshot never reached disk"
+    return sid
+
+
+@pytest.mark.asyncio
+async def test_recovery_recreated_session_keeps_its_persisted_narrowing(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: a session re-created by crash recovery through the SYNC
+    ``spawn_session`` primitive is still inside the narrowing it was spawned with.
+
+    ``restore_all`` (and its ``_rewake_pipeline_runs`` sibling) pass no ``narrowing``
+    — there is no argument to pass — and re-enter under the ORIGINAL sid, which is
+    what the #2103-S1a layer is keyed by. That the layer is therefore re-attached
+    rather than lost is not deducible from the call: ``spawn_session_recorded``'s own
+    ``#2126`` note records that construction-time resolution runs with ``sid=None``
+    and ignores ``config.yaml``, which is why it re-injects explicitly and why a
+    recovery path that does not could have been reborn wide.
+
+    A fresh registry over the same tree is the restart: same project root, same WAL,
+    nothing carried in memory.
+    """
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    sid = await _spawn_narrowed_and_persist(reg, tmp_path)
+    assert _DENIED_TOOL in _envelope_denials(reg.get_session("worker", sid)), (
+        "precondition: the freshly spawned session is not narrowed, so the recovery "
+        "assertion below would be vacuous"
+    )
+
+    restarted = _registry(tmp_path)
+    await restarted.restore_all()
+
+    recovered = restarted.get_session("worker", sid)
+    assert recovered is not None, "crash recovery did not re-create the spawned session"
+    assert _DENIED_TOOL in _envelope_denials(recovered), (
+        "a session re-created by crash recovery was reborn OUTSIDE the per-session "
+        "narrowing it was spawned with — the sid-keyed #2103-S1a layer did not "
+        f"survive the restart (envelope denials: {_envelope_denials(recovered)!r})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_recovery_without_a_persisted_narrowing_restores_an_unnarrowed_session(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: the negative control for the leg above — with the persisted narrowing
+    removed, the same recovery path restores a session that does NOT deny the tool.
+
+    Without this, the positive leg is satisfiable by a tool that is denied for some
+    unrelated, permanent reason (a category default, a floor), which would make it
+    green whether or not recovery carries anything. Deleting the one file the claim
+    is about is the smallest change that separates the two explanations.
+    """
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    sid = await _spawn_narrowed_and_persist(reg, tmp_path)
+
+    config = tmp_path / ".reyn" / "agents" / "worker" / "state" / "sessions" / sid / "config.yaml"
+    assert config.is_file(), "the recorded spawn seam did not persist a narrowing to read"
+    config.unlink()
+
+    restarted = _registry(tmp_path)
+    await restarted.restore_all()
+
+    recovered = restarted.get_session("worker", sid)
+    assert recovered is not None, "crash recovery did not re-create the spawned session"
+    assert _DENIED_TOOL not in _envelope_denials(recovered), (
+        "the tool is denied even with no persisted narrowing, so the positive leg's "
+        "green says nothing about recovery carrying the narrowing"
+    )

--- a/tests/test_3561_spawn_session_seam_reachability.py
+++ b/tests/test_3561_spawn_session_seam_reachability.py
@@ -35,19 +35,27 @@ is un-narrowed. It is (the invoking session's #2103-S1a layer is not carried, wh
 #3562), but pinning that would make the fix red. The measurement is the reachability,
 which stays true either way.
 
-The second claim is a different site of the same primitive and the opposite verdict.
+★ **The second claim is a defect this enumeration found, and the fix that closes it.**
 Crash recovery (``restore_all`` / ``_rewake_pipeline_runs``) re-creates a session
-through ``spawn_session`` with no narrowing argument either, and that one is NOT a
-gap: the session is re-created under its ORIGINAL sid, and the #2103-S1a layer is
-keyed by sid on disk. ``test_recovery_recreated_session_keeps_its_persisted_narrowing``
-measures that it really survives — the ``#2126`` comment inside
-``spawn_session_recorded`` documents that construction-time resolution runs with
-``sid=None`` and therefore ignores ``config.yaml``, which is exactly the shape a
-re-woken session could have been reborn wide through, so the survival is a result and
-not a deduction. Its negative control, ``test_recovery_without_a_persisted_narrowing_
-restores_an_unnarrowed_session``, removes the persisted file and shows the same
-assertion going the other way — without it, a permanently-denied tool would satisfy
-the positive leg for a reason having nothing to do with recovery.
+through the SYNC ``spawn_session`` with no narrowing argument either — and until #3561
+it was reborn WIDE. The session is re-created under its ORIGINAL sid and its
+#2103-S1a ``config.yaml`` is still on disk, but the live session's
+``_contextual_permission`` — the single source the RouterLoop's advertisement filter
+and its ``_excluded_result`` call-time gate both read — was resolved by the factory
+with ``sid=None`` and so never saw that file. ``spawn_session_recorded`` re-resolved
+and re-injected WITH the sid (its ``#2126`` note says why); nothing on the direct path
+to the primitive did. #3561 moved that injection into ``spawn_session`` itself, where
+the sid becomes known, which closes it for every direct caller at once.
+
+★ **The measurement that found it is also a lesson about which surface to read.** The
+first attempt asserted on ``capability_visibility_state()`` — the operator's status
+bar — and was GREEN on the broken code, because that surface re-resolves with the sid
+on every read while the enforcement path does not. Two surfaces, one decorative. What
+found the defect was ``write_file``'s real file landing on disk, next to a POSITIVE
+CONTROL (``test_the_witness_tool_runs_when_nothing_narrows_it``) proving the witness
+was alive at all: an earlier run of these legs had every arm "denied", including the
+un-narrowed one, because the write gate — not the narrowing — was refusing everything.
+The control is permanent for that reason.
 
 The completeness half of the gate — which sites exist, how they are resolved, and
 what each declares — lives in
@@ -73,6 +81,7 @@ from reyn.runtime.session_api import run_agent_step
 from reyn.runtime.session_params import PresentationWiring
 from reyn.runtime.spawn_routing import AuditOnlyNoSurface
 from tests._support.agent_session import make_session
+from tests._support.permissions import make_resolver
 
 #: The line the scripted LLM emits. It is a real, registered slash command whose
 #: handler calls ``AgentRegistry.spawn_session`` — see ``interfaces/slash/session.py``.
@@ -118,11 +127,17 @@ def _registry(
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     holder: dict = {}
     resolver = ModelResolver({"standard": "gemini/gemini-2.5-flash-lite"})
+    # ``file.write`` approved at the PERMISSION layer, so a write that does not happen
+    # below is the capability narrowing refusing it and not the write gate — the
+    # confusion that made an earlier version of the recovery legs read "denied"
+    # everywhere, including the un-narrowed control.
+    perms = make_resolver(tmp_path, config={"file.write": "allow"})
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         s = make_session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
+            permission_resolver=perms, workspace_base_dir=tmp_path,
             presentation_wiring=PresentationWiring(
                 presentation_consumer=presentation_consumer,
                 intervention_bridge=intervention_bridge,
@@ -142,16 +157,6 @@ def _registry(
             reg.create(name)
     return reg
 
-
-def _envelope_denials(session: Session) -> "list[str]":
-    """The tool names this session's live capability ENVELOPE denies, read off the
-    public status-bar read model (``capability_visibility_state``) rather than any
-    private attribute — the same surface the operator's own status bar renders."""
-    state = session.capability_visibility_state()
-    return [
-        entry["name"] for entry in state.get("denied_by_envelope", ())
-        if entry.get("kind") == "tool"
-    ]
 
 
 # ── the reachability falsification ──────────────────────────────────────────
@@ -219,29 +224,89 @@ async def test_model_output_reaches_slash_dispatch_and_spawns_a_session(
     )
 
 
-# ── the recovery site: the sid-keyed layer really is re-attached ─────────────
 
 
-async def _spawn_narrowed_and_persist(reg: AgentRegistry, tmp_path: Path) -> str:
-    """Spawn a narrowed session through the recorded seam and wait for its
-    per-session snapshot to land on disk — ``restore_all`` discovers spawned
-    sessions BY that file, so a test that raced it would measure nothing at all."""
+# ── the recovery site: the sid-keyed layer must survive re-creation ──────────
+
+#: The file the witness tool writes. Relative, so it lands wherever the session's
+#: workspace resolves it and ``rglob`` finds it either way.
+_OUT_NAME = "p3561_out.txt"
+
+
+class _WritesOnceLLM:
+    """A real ``_llm_caller``-shaped callable: the FIRST turn asks for
+    ``_DENIED_TOOL``, every later turn answers in plain text so the loop terminates
+    whether or not the call was allowed. Not a ``MagicMock`` — a drift in the
+    ``call_llm_tools`` keyword contract raises ``TypeError`` here as in production.
+
+    ``turns`` is load-bearing: an absence on disk observed because the session never
+    took a turn is indistinguishable from one observed because the capability was
+    denied, so every leg asserts the turn happened before reading the filesystem.
+    """
+
+    def __init__(self) -> None:
+        self.turns = 0
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.turns += 1
+        if self.turns == 1:
+            return LLMToolCallResult(
+                content=None,
+                tool_calls=[{
+                    "id": "c3561", "type": "function",
+                    "function": {
+                        "name": _DENIED_TOOL,
+                        "arguments": '{"path": "%s", "content": "ran"}' % _OUT_NAME,
+                    },
+                }],
+                finish_reason="tool_calls",
+                usage=TokenUsage(prompt_tokens=1, completion_tokens=1),
+            )
+        return LLMToolCallResult(
+            content="done", tool_calls=[], finish_reason="stop", usage=TokenUsage(),
+        )
+
+
+def _written(tmp_path: Path) -> "list[str]":
+    """Every on-disk copy of the witness file — the side effect itself, never a
+    status string."""
+    return sorted(str(p) for p in tmp_path.rglob(_OUT_NAME))
+
+
+async def _drive_one_turn(session: Session) -> None:
+    """Run ONE real turn on ``session`` through the production run+collect primitive
+    (``MessageBus.request``), the same way ``run_agent_step`` drives a worker."""
+    from reyn.runtime.message_bus import MessageBus
+    from reyn.runtime.transport import SystemRef
+
+    await MessageBus().request(
+        session, kind="user", payload={"text": "write it", "chain_id": "c3561t"},
+        reply_to=SystemRef(), timeout=30,
+    )
+
+
+async def _spawn_and_persist(
+    reg: AgentRegistry, tmp_path: Path, narrowing: "dict | None",
+) -> str:
+    """Spawn a session through the recorded seam and wait for its per-session
+    snapshot to land on disk — ``restore_all`` discovers spawned sessions BY that
+    file, so a test that raced it would restore nothing and measure nothing."""
     routing = AuditOnlyNoSurface()
     sid = await reg.spawn_session_recorded(
-        "worker", mode="persistent", narrowing={"tool_deny": [_DENIED_TOOL]},
+        "worker", mode="persistent", narrowing=narrowing,
         presentation_consumer=routing.presentation_consumer,
         intervention_bridge=routing.intervention_bridge,
     )
     session = reg.get_session("worker", sid)
     assert session is not None
     # Non-empty restored state is restore_all's own precondition for re-creating a
-    # session (step 5 skips a snapshot with nothing stranded in it).
-    await session._put_inbox("user", {"text": "stranded", "chain_id": "c3561"})
+    # session (its step 5 skips a snapshot with nothing stranded in it).
+    await session._put_inbox("user", {"text": "stranded", "chain_id": "c3561s"})
     await session.await_quiescent()
     snapshot = (
         tmp_path / ".reyn" / "agents" / "worker" / "state" / "sessions" / sid / "snapshot.json"
     )
-    for _ in range(100):
+    for _ in range(200):
         if snapshot.is_file():
             break
         await asyncio.sleep(0.05)
@@ -250,69 +315,77 @@ async def _spawn_narrowed_and_persist(reg: AgentRegistry, tmp_path: Path) -> str
 
 
 @pytest.mark.asyncio
-async def test_recovery_recreated_session_keeps_its_persisted_narrowing(
+async def test_the_witness_tool_runs_when_nothing_narrows_it(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: the POSITIVE CONTROL for the leg below — with no narrowing anywhere,
+    the recovery-recreated session's ``write_file`` really does reach its handler and
+    put a file on disk.
+
+    This is not ceremony. The first version of these legs reported "denied" on every
+    arm INCLUDING this one, because ``file.write`` was refused by the permission
+    resolver rather than by any narrowing — an absence that proved nothing while
+    looking exactly like proof. A leg that observes a side effect NOT happening is
+    only readable next to one that observes it happening.
+    """
+    monkeypatch.chdir(tmp_path)
+    scripted = _WritesOnceLLM()
+    reg = _registry(tmp_path, scripted)
+    sid = await _spawn_and_persist(reg, tmp_path, narrowing=None)
+
+    restarted = _registry(tmp_path, scripted)
+    await restarted.restore_all()
+    recovered = restarted.get_session("worker", sid)
+    assert recovered is not None, "crash recovery did not re-create the spawned session"
+
+    await _drive_one_turn(recovered)
+
+    assert scripted.turns >= 2, (
+        f"the recovered session never finished a turn (turns={scripted.turns}) — the "
+        "leg below would then be asserting an absence caused by nothing running"
+    )
+    assert _written(tmp_path), (
+        "the witness tool did not execute even with nothing narrowing it, so an "
+        "absence observed in the narrowed leg would say nothing about the narrowing"
+    )
+
+
+@pytest.mark.asyncio
+async def test_recovery_recreated_session_is_still_inside_its_persisted_narrowing(
     tmp_path: Path, monkeypatch,
 ) -> None:
     """Tier 2: a session re-created by crash recovery through the SYNC
-    ``spawn_session`` primitive is still inside the narrowing it was spawned with.
+    ``spawn_session`` primitive cannot execute a capability its persisted per-session
+    narrowing denies.
 
-    ``restore_all`` (and its ``_rewake_pipeline_runs`` sibling) pass no ``narrowing``
-    — there is no argument to pass — and re-enter under the ORIGINAL sid, which is
-    what the #2103-S1a layer is keyed by. That the layer is therefore re-attached
-    rather than lost is not deducible from the call: ``spawn_session_recorded``'s own
-    ``#2126`` note records that construction-time resolution runs with ``sid=None``
-    and ignores ``config.yaml``, which is why it re-injects explicitly and why a
-    recovery path that does not could have been reborn wide.
+    ``restore_all`` passes no ``narrowing`` — there is no argument to pass — and
+    re-enters under the ORIGINAL sid, which is what the #2103-S1a layer is keyed by.
+    Before #3561 that layer was resolvable but not ENFORCED: the factory resolves an
+    envelope with ``sid=None``, so the live ``_contextual_permission`` the RouterLoop
+    reads never saw the sid's ``config.yaml``, and the re-woken session wrote the file.
+    The assertion is the file's absence, next to
+    ``test_the_witness_tool_runs_when_nothing_narrows_it``'s presence.
 
     A fresh registry over the same tree is the restart: same project root, same WAL,
     nothing carried in memory.
     """
     monkeypatch.chdir(tmp_path)
-    reg = _registry(tmp_path)
-    sid = await _spawn_narrowed_and_persist(reg, tmp_path)
-    assert _DENIED_TOOL in _envelope_denials(reg.get_session("worker", sid)), (
-        "precondition: the freshly spawned session is not narrowed, so the recovery "
-        "assertion below would be vacuous"
-    )
+    scripted = _WritesOnceLLM()
+    reg = _registry(tmp_path, scripted)
+    sid = await _spawn_and_persist(reg, tmp_path, narrowing={"tool_deny": [_DENIED_TOOL]})
 
-    restarted = _registry(tmp_path)
+    restarted = _registry(tmp_path, scripted)
     await restarted.restore_all()
-
     recovered = restarted.get_session("worker", sid)
     assert recovered is not None, "crash recovery did not re-create the spawned session"
-    assert _DENIED_TOOL in _envelope_denials(recovered), (
-        "a session re-created by crash recovery was reborn OUTSIDE the per-session "
-        "narrowing it was spawned with — the sid-keyed #2103-S1a layer did not "
-        f"survive the restart (envelope denials: {_envelope_denials(recovered)!r})"
+
+    await _drive_one_turn(recovered)
+
+    assert scripted.turns >= 1, (
+        "the recovered session never took a turn, so the absence below is vacuous"
     )
-
-
-@pytest.mark.asyncio
-async def test_recovery_without_a_persisted_narrowing_restores_an_unnarrowed_session(
-    tmp_path: Path, monkeypatch,
-) -> None:
-    """Tier 2: the negative control for the leg above — with the persisted narrowing
-    removed, the same recovery path restores a session that does NOT deny the tool.
-
-    Without this, the positive leg is satisfiable by a tool that is denied for some
-    unrelated, permanent reason (a category default, a floor), which would make it
-    green whether or not recovery carries anything. Deleting the one file the claim
-    is about is the smallest change that separates the two explanations.
-    """
-    monkeypatch.chdir(tmp_path)
-    reg = _registry(tmp_path)
-    sid = await _spawn_narrowed_and_persist(reg, tmp_path)
-
-    config = tmp_path / ".reyn" / "agents" / "worker" / "state" / "sessions" / sid / "config.yaml"
-    assert config.is_file(), "the recorded spawn seam did not persist a narrowing to read"
-    config.unlink()
-
-    restarted = _registry(tmp_path)
-    await restarted.restore_all()
-
-    recovered = restarted.get_session("worker", sid)
-    assert recovered is not None, "crash recovery did not re-create the spawned session"
-    assert _DENIED_TOOL not in _envelope_denials(recovered), (
-        "the tool is denied even with no persisted narrowing, so the positive leg's "
-        "green says nothing about recovery carrying the narrowing"
+    assert not _written(tmp_path), (
+        "a session re-created by crash recovery executed a tool its own persisted "
+        "per-session narrowing denies — the sid-keyed #2103-S1a layer was resolvable "
+        f"but not enforced after the restart (written: {_written(tmp_path)!r})"
     )

--- a/tests/test_3561_spawn_session_seam_reachability.py
+++ b/tests/test_3561_spawn_session_seam_reachability.py
@@ -65,6 +65,7 @@ what each declares — lives in
 from __future__ import annotations
 
 import asyncio
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -228,9 +229,21 @@ async def test_model_output_reaches_slash_dispatch_and_spawns_a_session(
 
 # ── the recovery site: the sid-keyed layer must survive re-creation ──────────
 
-#: The file the witness tool writes. Relative, so it lands wherever the session's
-#: workspace resolves it and ``rglob`` finds it either way.
-_OUT_NAME = "p3561_out.txt"
+def _out_name() -> str:
+    """A witness filename unique to ONE test run.
+
+    Not decoration. The witness is searched for across the whole per-worker tmp tree,
+    not just this test's ``tmp_path``, because a session's workspace does not
+    necessarily resolve where the test's cwd points — and an earlier version of these
+    legs went green on BROKEN code for exactly that reason: run after a sibling test in
+    the same process, the denied write landed under the sibling's directory, so
+    ``tmp_path.rglob`` found nothing and the absence read as a denial. Unique name plus
+    wide search means a write that happens ANYWHERE is attributed to the run that
+    caused it, and the leg fails as it should. (Run alone, the same test failed — which
+    is how the discrepancy surfaced. A gate that only fires in a cold process is not a
+    gate.)
+    """
+    return f"p3561_out_{uuid.uuid4().hex}.txt"
 
 
 class _WritesOnceLLM:
@@ -244,7 +257,8 @@ class _WritesOnceLLM:
     denied, so every leg asserts the turn happened before reading the filesystem.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, out_name: str) -> None:
+        self.out_name = out_name
         self.turns = 0
 
     async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
@@ -256,7 +270,7 @@ class _WritesOnceLLM:
                     "id": "c3561", "type": "function",
                     "function": {
                         "name": _DENIED_TOOL,
-                        "arguments": '{"path": "%s", "content": "ran"}' % _OUT_NAME,
+                        "arguments": '{"path": "%s", "content": "ran"}' % self.out_name,
                     },
                 }],
                 finish_reason="tool_calls",
@@ -267,10 +281,11 @@ class _WritesOnceLLM:
         )
 
 
-def _written(tmp_path: Path) -> "list[str]":
-    """Every on-disk copy of the witness file — the side effect itself, never a
-    status string."""
-    return sorted(str(p) for p in tmp_path.rglob(_OUT_NAME))
+def _written(tmp_path: Path, out_name: str) -> "list[str]":
+    """Every on-disk copy of the witness file — the side effect itself, never a status
+    string — searched from the per-worker tmp ROOT, not from this test's own directory.
+    See :func:`_out_name` for why the wider search is the point."""
+    return sorted(str(p) for p in tmp_path.parent.rglob(out_name))
 
 
 async def _drive_one_turn(session: Session) -> None:
@@ -329,7 +344,8 @@ async def test_the_witness_tool_runs_when_nothing_narrows_it(
     only readable next to one that observes it happening.
     """
     monkeypatch.chdir(tmp_path)
-    scripted = _WritesOnceLLM()
+    out_name = _out_name()
+    scripted = _WritesOnceLLM(out_name)
     reg = _registry(tmp_path, scripted)
     sid = await _spawn_and_persist(reg, tmp_path, narrowing=None)
 
@@ -344,7 +360,7 @@ async def test_the_witness_tool_runs_when_nothing_narrows_it(
         f"the recovered session never finished a turn (turns={scripted.turns}) — the "
         "leg below would then be asserting an absence caused by nothing running"
     )
-    assert _written(tmp_path), (
+    assert _written(tmp_path, out_name), (
         "the witness tool did not execute even with nothing narrowing it, so an "
         "absence observed in the narrowed leg would say nothing about the narrowing"
     )
@@ -370,7 +386,8 @@ async def test_recovery_recreated_session_is_still_inside_its_persisted_narrowin
     nothing carried in memory.
     """
     monkeypatch.chdir(tmp_path)
-    scripted = _WritesOnceLLM()
+    out_name = _out_name()
+    scripted = _WritesOnceLLM(out_name)
     reg = _registry(tmp_path, scripted)
     sid = await _spawn_and_persist(reg, tmp_path, narrowing={"tool_deny": [_DENIED_TOOL]})
 
@@ -384,8 +401,8 @@ async def test_recovery_recreated_session_is_still_inside_its_persisted_narrowin
     assert scripted.turns >= 1, (
         "the recovered session never took a turn, so the absence below is vacuous"
     )
-    assert not _written(tmp_path), (
+    assert not _written(tmp_path, out_name), (
         "a session re-created by crash recovery executed a tool its own persisted "
         "per-session narrowing denies — the sid-keyed #2103-S1a layer was resolvable "
-        f"but not enforced after the restart (written: {_written(tmp_path)!r})"
+        f"but not enforced after the restart (written: {_written(tmp_path, out_name)!r})"
     )


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3561.

## Phase 1 — the measurement, run before the classification

**Question: does a path exist by which MODEL OUTPUT reaches slash dispatch?**

**Result: MEASURED — yes.** `tests/test_3561_spawn_session_seam_reachability.py::test_model_output_reaches_slash_dispatch_and_spawns_a_session` drives it end to end with real objects:

1. a real `run_agent_step` returns `/session new` as its ordinary model output;
2. the production splice `executor._interpolate_prompt` puts that text in the next agent step's prompt;
3. that worker — narrowed via `capabilities=["write_file"]`, i.e. a genuinely narrowed subject — reaches `/session new` and a session is born under the attached agent.

No operator anywhere in the path. `Session._handle_user_message` tests `text.startswith("/")` and hands the line to `_maybe_handle_slash` **before** the router turn, so the reaching turn makes **no LLM call at all** — the test asserts the scripted LLM's call count did not move, which is what separates a slash short-circuit from a model that merely decided to spawn. **"It is operator-initiated, so it is out of scope" is false.**

### What I could NOT rule out

The positive settles the classification, so I did not need an exhaustive negative — and I did not get one. Honest inventory of the other faces:

- **Ruled out by enumeration + reading**, not by execution: `_maybe_handle_slash` has exactly **two** production callers in `src/` (`_handle_user_message`, `maybe_deliver_answer_command`); `agent_request` / `agent_response` (A2A) and `hook` inbox kinds route to their own handlers and reach neither. `pipeline_result` reaches `_handle_user_message` but `PipelineExecutorDriver._format_result_text` prefixes every message with `[pipeline] `, so it cannot start with `/`.
- **Not ruled out**: whether AG-UI / web / `gateway.api` / MCP `_put_inbox("user", …)` payloads ever carry model-authored text. All four funnel into the same `_handle_user_message`, and the MCP one in particular is driven by a client that is itself usually an LLM host. I did not trace every external client, so I can only say the funnel is open, not that it is used.
- **`present`**: I found no path from a `present` op's output back into an inbox, but I did not enumerate exhaustively enough to call that a negative result.
- **Intervention answers**: `maybe_deliver_answer_command` gates on `cmd == "answer"` plus a pending intervention, so it cannot reach `/session`. It is still an operator-transport face; I did not chase it further.

## Phase 2 — `AgentRegistry.spawn_session` is now in `SPAWN_SEAMS`

Classified on **reachability**, not shape. It takes no `narrowing` argument, and judging it out of scope for that reason is #3554's error inverted — that gate passed #3556 *because* it spelled `narrowing=` while passing a value that was no function of its parent. An API with no inheritance channel is an unmet requirement, so it is listed, and every one of its five sites is declared and exempted **as unmet** (`_UNMET_NO_NARROWING_CHANNEL`), never on the merits. `test_narrowing_exempt_sites_have_no_narrowing_channel` reads the **live** signature, so adding a channel REDs every exemption instead of letting it outlive its reason.

### ★ Enumerating it immediately found a real defect

The two crash-recovery sites (`restore_all`, `_rewake_pipeline_runs`) reach the primitive directly and had never been counted. Measuring them: **a re-woken session was reborn OUTSIDE its own persisted per-session narrowing.** The factory resolves an envelope with `sid=None`, so the live `_contextual_permission` — the single source the RouterLoop's advertisement filter and its `_excluded_result` call-time gate both read — never saw the sid's `config.yaml`. `spawn_session_recorded` re-injected for itself (its `#2126` note says why); nothing on the direct path did. A narrowed session that crashed and re-woke executed a denied `write_file` for real.

Fixed at the primitive (`registry.spawn_session`), where the sid becomes known, closing it for every direct caller at once rather than site by site.

**★ Two lessons worth recording, both of which nearly cost the finding:**

- My first witness read `capability_visibility_state()` — the operator's status bar — and was **GREEN on the broken code**, because that surface re-resolves with the sid on every read while the enforcement path does not. Two surfaces, one decorative. Only the real side effect found it.
- The first side-effect run showed "denied" on **every** arm including an un-narrowed one, because the permission resolver was refusing `file.write` outright. `test_the_witness_tool_runs_when_nothing_narrows_it` is a permanent positive control for exactly that.

### Instrument

Enumeration is by **resolved symbol**, not name. Three functions in `src/` are called `spawn_session`; a name match attributes `router_loop.py`'s `self.host.spawn_session(chain_id=…, mode=…, request=…)` to the registry primitive, which it is not. `_Seam.receivers` maps `(calling module, receiver expr) → is-this-seam`, an unlisted receiver is an **error** rather than a guess (`test_spawn_seam_receivers_are_all_resolvable`), and a seam declared name-unambiguous has that premise pinned against the definition set (`test_unambiguous_seam_names_have_exactly_one_definition`). Resolved call sites of `AgentRegistry.spawn_session`: **five** (`spawn_session_recorded`, `resolve_session`, `restore_all`, `_rewake_pipeline_runs`, `slash/session.py::session_cmd`) — the sixth name match is the different function.

## Phase 3 — the forwarder exemption is now a countable claim

`spawn_ephemeral_session`'s reason was *"there is no value of its own to measure; a thin forwarder…"* — a judgement, green whether or not still true, and in particular green if a **second, unmeasured caller** appeared. It is now a typed `measured_via_callers` list, and two tests check it:

- `test_forwarder_exemptions_name_their_real_callers` compares the declared callers to the AST call graph **in both directions**, so a stale list and a new unmeasured caller both fail;
- `test_forwarder_deferral_terminates_in_a_real_measurement` walks the deferral closure, so a cycle or a chain ending on an `unmeasured_reason` fails rather than looking accounted for at every link.

## Phase 4 — the dangling docstring reference

`slash/__init__.py:107` named `Session._dispatch_slash`. Verified absent from `src/` (the docstring was the only hit); corrected to `Session._maybe_handle_slash`, with the dead name noted so the correction does not read as arbitrary.

## Strip-falsify

Every gate stripped, anchor uniqueness checked first (one candidate anchor had `count == 2` and was rejected):

| strip | result |
|---|---|
| remove the `/`-prefix short-circuit in `_handle_user_message` | RED (reachability) |
| remove `spawn_session` from `_SPAWN_SEAMS` | RED ×3 |
| revert the walk to name-only matching | RED ×2 |
| add a `narrowing` param to `AgentRegistry.spawn_session` | RED (exemption expiry) |
| add a 2nd caller / 2nd definition / unresolvable receiver in `src/` | RED ×4 |
| remove the `spawn_session` narrowing injection | RED (recovery), control stays GREEN |

★ **One strip changed a test, not just the code.** The recovery leg passed serially and failed alone — the denied write was landing outside the test's own `tmp_path`, so a narrow `rglob` read "nothing written" as "denied". A gate that only fires in a cold process is not a gate; the witness now uses a unique filename and searches the per-worker tmp root, and fails in both orders.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` on both changed test files — 15/15 OK, 0 warnings, 0 errors
- [x] `python scripts/verify_module_docstrings.py` on both changed src files — OK
- [x] `pytest -n auto` full suite — **9825 passed, 36 skipped, 0 failed**
- [x] Strip-falsify table above, each strip reverted and re-verified GREEN
- [x] Recovery leg verified RED-on-strip both serially and under `-n auto`, and isolated

## Remainders

- **Filed**: #3562 — `/session new` carries none of its invoker's narrowing. Declared in `_SITE_PARENT_LAYERS` with the reachability measurement attached; the measurement asserts reachability only, never that the child is un-narrowed, so closing #3562 does not turn it red. Not fixed here because the route through `spawn_session_recorded` changes rewind-tracking and has a visible UX consequence — that wants an explicit decision.
- **Explicitly dropped**: no exhaustive negative proof that no *other* face reaches slash dispatch. The positive settles the scope question this arc needed; the open funnel is recorded above rather than left implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
