### PR TITLE
fix(scripts): rekey_fixtures must not report a dead patch as 'all fixtures up to date' — #3568

### DIFF
--- a/scripts/rekey_fixtures.py
+++ b/scripts/rekey_fixtures.py
@@ -8,29 +8,123 @@ Usage:
     python scripts/rekey_fixtures.py [--test-pattern GLOB] [--dry-run]
 
 Options:
-    --test-pattern  pytest nodeids/glob (default: tests/test_replay_skill_router.py)
+    --test-pattern  pytest nodeids/glob (default: tests — the whole suite; pass a
+                    narrower pattern when you know which tests replay)
     --dry-run       print what would change; do not write files
+
+Exit codes:
+    0  the scan ran and either found nothing to do or did it
+    1  the scan ran but could not be trusted — see below
+    2  usage error (argparse)
+
+#3568: this tool patches a PRIVATE method of another module, so it is exposed to
+signature drift, and its failure mode was to report the drift as good news. The
+pre-#3473 patch took ``(self, key, model, messages)``; ``_replay`` had since
+grown ``observed`` and ``request``, so every patched call raised ``TypeError``,
+no ``MISSING_KEY`` line was ever printed, and the tool announced "No missing keys
+found — all fixtures up to date." That is "the instrument is dead" reported in
+the affirmative. Two mechanisms close it, and the FIRST is the one that matters:
+
+1. **Compatibility is verified before the scan** (:func:`verify_replay_signature`
+   against ``REQUIRED_REPLAY_PARAMS``) — in the SUBPROCESS, so it inspects the
+   very ``reyn`` the scan measures (the #2103 wrong-import-target hazard), and
+   pytest is never started when it fails. The patch body itself forwards
+   ``*args``/``**kwargs`` and binds by name, but a forgiving signature ALONE
+   would only fail differently and silently: a renamed or reordered parameter
+   still passes ``*args`` and then reads the wrong value. The name-and-order
+   check is the mechanism; the forwarding is the convenience.
+2. **"0 missing keys" and "the patch never fired" are different states, and only
+   the first is success.** The patcher reports its call count; a scan that never
+   invoked ``_replay`` (bad pattern, collection error, a fixture wired some other
+   way) is reported as an error with a non-zero exit, never as "up to date".
 """
 from __future__ import annotations
 
 import argparse
+import inspect
 import json
 import os
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-DEFAULT_PATTERN = "tests/test_replay_skill_router.py"
+DEFAULT_PATTERN = "tests"
+
+# The exact parameter list (names AND order) of ``LLMReplay._replay`` that the
+# patcher below is written against. It binds the call by NAME, so a rename or a
+# reorder is as fatal as an added parameter — hence the whole tuple is compared,
+# not its length. Update this in the same change that changes ``_replay``.
+REQUIRED_REPLAY_PARAMS = ("self", "key", "model", "messages", "observed", "request")
+
+# Emitted by the patcher subprocess; parsed by the parent.
+MARKER_MISSING = "MISSING_KEY="
+MARKER_PATCH_ERROR = "REKEY_PATCH_ERROR="
+MARKER_CALLS = "REKEY_REPLAY_CALLS="
+# Subprocess exit code for "the patch is incompatible, pytest was never started".
+EXIT_PATCH_INCOMPATIBLE = 97
+
+
+def verify_replay_signature(replay_cls: Any) -> str | None:
+    """Return ``None`` when ``replay_cls._replay`` matches
+    :data:`REQUIRED_REPLAY_PARAMS`, else a human-readable description of the
+    incompatibility.
+
+    This is the drift gate. It is deliberately a pure function over a class so
+    the same comparison can be made from the patcher subprocess (against the
+    ``reyn`` actually under test) and from a test (against the real
+    ``LLMReplay``)."""
+    actual = tuple(inspect.signature(replay_cls._replay).parameters)
+    if actual == REQUIRED_REPLAY_PARAMS:
+        return None
+    return _describe_incompatibility(list(REQUIRED_REPLAY_PARAMS), list(actual))
+
+
+def _describe_incompatibility(expected: list[str], actual: list[str]) -> str:
+    missing = [p for p in expected if p not in actual]
+    added = [p for p in actual if p not in expected]
+    detail = []
+    if missing:
+        detail.append(f"parameters the patch reads but _replay no longer has: {missing}")
+    if added:
+        detail.append(f"parameters _replay grew that the patch does not read: {added}")
+    if not detail:
+        detail.append("same parameter names in a DIFFERENT order")
+    return (
+        "LLMReplay._replay signature is incompatible with this script's patch.\n"
+        f"  expected: {expected}\n"
+        f"  actual:   {actual}\n"
+        "  " + "\n  ".join(detail) + "\n"
+        "Nothing was scanned. Update REQUIRED_REPLAY_PARAMS and the patcher in "
+        "scripts/rekey_fixtures.py to match, then re-run."
+    )
+
+
+@dataclass
+class ScanResult:
+    """What one patched-pytest subprocess actually observed.
+
+    ``replay_calls is None`` means the patcher never got to report — it is NOT
+    the same as ``0``, and neither is the same as "no missing keys"."""
+
+    missing: list[dict] = field(default_factory=list)
+    replay_calls: int | None = None
+    patch_error: str | None = None
+    returncode: int = 0
+    output: str = ""
 
 
 # ── Step 1: capture new keys by temporarily patching LLMReplay._replay ────────
 
 
-def _capture_new_keys(test_pattern: str) -> list[dict]:
+def _capture_new_keys(test_pattern: str) -> ScanResult:
     """Re-run pytest with LLMReplay._replay patched to emit the missing key.
 
-    Each MissingFixture raises after printing:  MISSING_KEY=<hash>|<fixture>|<preview>
-    We capture stdout/stderr and parse those lines.
+    Each MissingFixture raises after printing a ``MISSING_KEY=<json>`` line. We
+    capture stdout/stderr and parse those lines, plus the patcher's own
+    self-report (``REKEY_PATCH_ERROR=`` / ``REKEY_REPLAY_CALLS=``) that says
+    whether the instrument was alive at all.
     """
     import subprocess
     import textwrap
@@ -39,31 +133,76 @@ def _capture_new_keys(test_pattern: str) -> list[dict]:
     # Simpler: pass a conftest plugin via --co ... actually the cleanest is
     # a small wrapper script that installs the patch before importing pytest.
 
-    patcher_code = textwrap.dedent("""\
+    patcher_code = textwrap.dedent(f"""\
+        import atexit
+        import inspect
         import json
         import sys
-        from pathlib import Path
-        from reyn.dev.testing.replay import LLMReplay, MissingFixture
+        from reyn.dev.testing.replay import LLMReplay
+
+        REQUIRED = {tuple(REQUIRED_REPLAY_PARAMS)!r}
 
         _orig_replay = LLMReplay._replay
+        _sig = inspect.signature(_orig_replay)
+        _actual = tuple(_sig.parameters)
+        if _actual != REQUIRED:
+            # Refuse to run. A patch that cannot bind produces zero MISSING_KEY
+            # lines, which is indistinguishable from "everything is fine" once
+            # pytest's own failure output is discarded by --tb=no (#3568).
+            print(
+                {MARKER_PATCH_ERROR!r} + json.dumps({{"actual": list(_actual)}}),
+                flush=True,
+            )
+            sys.exit({EXIT_PATCH_INCOMPATIBLE})
 
-        def _patched_replay(self, key, model, messages):
+        _calls = [0]
+
+        def _patched_replay(self, *args, **kwargs):
+            # Forward-compatible call shape, but read the arguments BY NAME via
+            # the real signature — positional forwarding alone would happily
+            # hand a renamed/reordered parameter to the wrong reader.
+            _calls[0] += 1
+            bound = _sig.bind(self, *args, **kwargs)
+            bound.apply_defaults()
+            arg = bound.arguments
+            key = arg["key"]
+            messages = arg["messages"]
             if key not in self._records:
                 preview = self._prompt_preview(messages)
+                # #3473: carry the live environment imprint and the per-component
+                # fingerprint of THIS request, so the rekeyed entry has the same
+                # shape a real record-mode entry has. Without them a replayed
+                # entry is "precondition unverifiable" on any machine whose
+                # environment is non-empty, and a future miss cannot be attributed.
+                try:
+                    from reyn.dev.testing.replay_key_diff import fingerprint
+                    request = arg["request"]
+                    components = fingerprint(
+                        request.model, request.messages, request.tools,
+                        request.tool_choice,
+                    )
+                except Exception:
+                    components = None
+                observed = arg["observed"]
                 # Emit a machine-readable JSON line BEFORE raising. JSON keeps it
                 # single-line + delimiter-safe: a preview or path may contain
                 # newlines or '|' (the old f-string |-split form truncated those).
                 print(
-                    "MISSING_KEY=" + json.dumps({
+                    {MARKER_MISSING!r} + json.dumps({{
                         "new_key": key,
                         "fixture_path": str(self.fixture_path),
                         "prompt_preview": preview[:200],
-                    }),
+                        "preconditions": observed if isinstance(observed, dict) else None,
+                        "key_components": components,
+                    }}),
                     flush=True,
                 )
-            return _orig_replay(self, key, model, messages)
+            return _orig_replay(*bound.args, **bound.kwargs)
 
         LLMReplay._replay = _patched_replay
+        atexit.register(
+            lambda: print({MARKER_CALLS!r} + str(_calls[0]), flush=True)
+        )
 
         import pytest
         sys.exit(pytest.main(sys.argv[1:]))
@@ -98,21 +237,87 @@ def _capture_new_keys(test_pattern: str) -> list[dict]:
         result = subprocess.run(
             cmd, capture_output=True, text=True, cwd=str(REPO_ROOT), env=env,
         )
-        return _parse_missing_keys(result.stdout + result.stderr)
+        output = result.stdout + result.stderr
+        return ScanResult(
+            missing=_parse_missing_keys(output),
+            replay_calls=parse_replay_calls(output),
+            patch_error=parse_patch_error(output),
+            returncode=result.returncode,
+            output=output,
+        )
     finally:
         patcher_path.unlink(missing_ok=True)
+
+
+def parse_patch_error(output: str) -> str | None:
+    """Return the rendered incompatibility report if the patcher refused to run."""
+    for line in output.splitlines():
+        idx = line.find(MARKER_PATCH_ERROR)
+        if idx < 0:
+            continue
+        try:
+            rec = json.loads(line[idx + len(MARKER_PATCH_ERROR):])
+        except json.JSONDecodeError:
+            continue
+        return _describe_incompatibility(
+            list(REQUIRED_REPLAY_PARAMS), list(rec.get("actual", [])),
+        )
+    return None
+
+
+def parse_replay_calls(output: str) -> int | None:
+    """Return how many times the patched ``_replay`` ran, or ``None`` if the
+    patcher never reported (it did not reach exit — the scan measured nothing)."""
+    found: int | None = None
+    for line in output.splitlines():
+        idx = line.find(MARKER_CALLS)
+        if idx < 0:
+            continue
+        try:
+            found = int(line[idx + len(MARKER_CALLS):].strip())
+        except ValueError:
+            continue
+    return found
+
+
+def diagnose_scan(result: ScanResult) -> str | None:
+    """Return ``None`` when the scan can be believed, else why it cannot.
+
+    #3568: this is the separation between "0 anomalies" and "0 observations".
+    Only the former may be reported as success."""
+    if result.patch_error:
+        return result.patch_error
+    if result.replay_calls is None:
+        return (
+            "The patcher never reported its call count — it did not reach exit, "
+            "so the scan measured nothing.\n"
+            f"pytest subprocess exit code: {result.returncode}\n"
+            "This is NOT 'all fixtures up to date'. Re-run the pattern under "
+            "pytest directly to see what failed."
+        )
+    if result.replay_calls == 0:
+        return (
+            "The patch never fired: LLMReplay._replay was called 0 times by this "
+            "pattern.\n"
+            f"pytest subprocess exit code: {result.returncode}\n"
+            "This is NOT 'all fixtures up to date' — nothing was observed. Check "
+            "that --test-pattern selects tests that actually replay."
+        )
+    return None
 
 
 def _parse_missing_keys(output: str) -> list[dict]:
     """Parse ``MISSING_KEY=<json>`` lines from the patcher subprocess output.
 
     Each line is ``MISSING_KEY=`` followed by a JSON object
-    ``{new_key, fixture_path, prompt_preview}``. JSON-encoding makes the line
-    newline-/delimiter-safe (a preview or path may contain ``|`` or a newline —
-    the old ``|``-split + raw f-string form truncated the preview at the first
-    newline, #2024 bug 1). The marker is matched anywhere in the line (pytest may
-    prefix it), and results are deduped by ``(new_key, fixture_path)``."""
-    marker = "MISSING_KEY="
+    ``{new_key, fixture_path, prompt_preview, preconditions, key_components}``
+    (the last two added by #3568 so the written entry can have a record-mode
+    shape). JSON-encoding makes the line newline-/delimiter-safe (a preview or
+    path may contain ``|`` or a newline — the old ``|``-split + raw f-string form
+    truncated the preview at the first newline, #2024 bug 1). The marker is
+    matched anywhere in the line (pytest may prefix it), and results are deduped
+    by ``(new_key, fixture_path)``."""
+    marker = MARKER_MISSING
     captured: list[dict] = []
     seen: set[tuple[str, str]] = set()
     for line in output.splitlines():
@@ -131,10 +336,17 @@ def _parse_missing_keys(output: str) -> list[dict]:
         if dedup in seen:
             continue
         seen.add(dedup)
+        preconditions = rec.get("preconditions")
+        components = rec.get("key_components")
         captured.append({
             "new_key": new_key,
             "fixture_path": Path(fixture_path),
             "prompt_preview": rec.get("prompt_preview", ""),
+            # #3568/#3473: absent on a line from an older patcher — kept as None
+            # so the writer can fall back rather than write an empty imprint,
+            # which means something else (see LLMReplay._check_preconditions).
+            "preconditions": preconditions if isinstance(preconditions, dict) else None,
+            "key_components": components if isinstance(components, dict) else None,
         })
     return captured
 
@@ -162,6 +374,8 @@ def _rekey_fixture(
     new_key: str,
     prompt_preview: str,
     dry_run: bool,
+    preconditions: dict | None = None,
+    key_components: dict | None = None,
 ) -> bool:
     """Append a new entry for ``new_key`` reusing the response of the EXISTING
     entry whose ``prompt_preview`` matches.
@@ -177,6 +391,17 @@ def _rekey_fixture(
     response (#2024 bug 2). On an ambiguous match (several entries share a
     preview) the most-recent match is reused (tie-break); on NO match the rekey
     is skipped with a warning — never write an unjustified response.
+
+    #3568/#3473: the written entry must have the same SHAPE a record-mode entry
+    has, not just a key and a response. ``preconditions`` (the live environment
+    imprint observed on the missing call) and ``key_components`` (that call's
+    per-component fingerprint) come from the patcher; ``kind`` follows the
+    source entry. Omitting ``preconditions`` makes the entry "precondition
+    unverifiable" on any machine whose environment is non-empty, and omitting
+    ``key_components`` leaves a future miss with no attribution. The fingerprint
+    is NOT copied from the source entry when the patcher did not supply one — a
+    stale fingerprint would attribute the next miss to the wrong component,
+    which is worse than having none.
 
     Returns True if a rekey was performed (or would be in dry-run).
     """
@@ -202,12 +427,18 @@ def _rekey_fixture(
         return False
     source = matches[-1]
 
-    new_entry = {
+    new_entry: dict[str, Any] = {
         "key": new_key,
+        "kind": source.get("kind", "completion"),
         "model": source.get("model", ""),
         "prompt_preview": prompt_preview or source.get("prompt_preview", ""),
-        "response": source["response"],
     }
+    imprint = preconditions if preconditions is not None else source.get("preconditions")
+    if isinstance(imprint, dict):
+        new_entry["preconditions"] = imprint
+    if isinstance(key_components, dict):
+        new_entry["key_components"] = key_components
+    new_entry["response"] = source["response"]
 
     if dry_run:
         print(
@@ -241,10 +472,20 @@ def main() -> int:
     args = parser.parse_args()
 
     print(f"Scanning: {args.test_pattern}")
-    missing = _capture_new_keys(args.test_pattern)
+    result = _capture_new_keys(args.test_pattern)
 
+    # #3568: believe the scan only after it has said it observed something.
+    problem = diagnose_scan(result)
+    if problem is not None:
+        print(f"[ERROR] {problem}", file=sys.stderr)
+        return 1
+
+    missing = result.missing
     if not missing:
-        print("No missing keys found — all fixtures up to date.")
+        print(
+            "No missing keys found — all fixtures up to date "
+            f"({result.replay_calls} replay call(s) observed)."
+        )
         return 0
 
     print(f"Found {len(missing)} missing key(s):")
@@ -256,6 +497,8 @@ def main() -> int:
             new_key=item["new_key"],
             prompt_preview=item["prompt_preview"],
             dry_run=args.dry_run,
+            preconditions=item.get("preconditions"),
+            key_components=item.get("key_components"),
         )
         if ok:
             changed += 1

--- a/tests/test_rekey_fixtures_tool.py
+++ b/tests/test_rekey_fixtures_tool.py
@@ -225,3 +225,149 @@ def test_parse_missing_keys_dedups(tmp_path):
     output = f"MISSING_KEY={rec}\nMISSING_KEY={rec}\n"
     parsed = rk._parse_missing_keys(output)
     assert [r["new_key"] for r in parsed] == ["k1"]  # deduped to the one request
+
+
+# ── #3568: the patch must not drift away from what it patches ─────────────────
+
+
+def test_patch_signature_matches_real_llm_replay():
+    """Tier 2: #3568 — the script's declared patch signature matches the REAL
+    LLMReplay._replay. When _replay's parameters are renamed, reordered, or
+    added to, the patch can no longer bind and the tool observes NOTHING; the
+    pre-#3473 4-parameter patch made every patched call raise TypeError while
+    the tool printed 'all fixtures up to date'. This assertion is the drift
+    gate: it fails on the signature change, not months later on a false
+    all-clear."""
+    from reyn.dev.testing.replay import LLMReplay
+
+    problem = rk.verify_replay_signature(LLMReplay)
+
+    assert problem is None, problem
+
+
+def test_incompatibility_report_names_the_parameters_that_moved():
+    """Tier 2: #3568 — the refusal message names WHICH parameters differ, so the
+    maintainer can fix the patch instead of guessing. Reproduces the historical
+    drift: the pre-#3473 patch list vs the real signature of today."""
+    import inspect
+
+    from reyn.dev.testing.replay import LLMReplay
+
+    stale = ["self", "key", "model", "messages"]          # the pre-#3473 patch
+    actual = list(inspect.signature(LLMReplay._replay).parameters)
+
+    report = rk._describe_incompatibility(stale, actual)
+
+    assert "observed" in report and "request" in report
+    assert "Nothing was scanned" in report
+
+
+def test_zero_replay_calls_is_reported_as_a_problem_not_as_up_to_date():
+    """Tier 2: #3568 — '0 missing keys' and 'the patch never fired' are different
+    states and only the first is success. A scan that observed nothing must be
+    diagnosed as unusable even though its missing-key list is empty."""
+    observed_nothing = rk.ScanResult(missing=[], replay_calls=0, returncode=0)
+    observed_something = rk.ScanResult(missing=[], replay_calls=3, returncode=0)
+
+    problem = rk.diagnose_scan(observed_nothing)
+
+    assert problem is not None
+    assert "never fired" in problem
+    assert "NOT 'all fixtures up to date'" in problem
+    # the same empty missing-list, but with observations behind it, IS success
+    assert rk.diagnose_scan(observed_something) is None
+
+
+def test_missing_patcher_report_is_reported_as_a_problem():
+    """Tier 2: #3568 — ``replay_calls is None`` (the patcher never reported at
+    all, e.g. it died before exit) is a third state, distinct from 0 calls and
+    from a clean scan, and is likewise not success."""
+    never_reported = rk.ScanResult(missing=[], replay_calls=None, returncode=1)
+
+    problem = rk.diagnose_scan(never_reported)
+
+    assert problem is not None
+    assert "measured nothing" in problem
+
+
+def test_patch_error_line_becomes_the_diagnosis():
+    """Tier 2: #3568 — when the patcher subprocess refuses to run, the parent
+    reports the incompatibility rather than the empty missing-key list."""
+    line = rk.MARKER_PATCH_ERROR + json.dumps({"actual": ["self", "k", "m"]})
+    calls_line = rk.MARKER_CALLS + "0"
+    output = f"{line}\n{calls_line}\n"
+
+    result = rk.ScanResult(
+        missing=rk._parse_missing_keys(output),
+        replay_calls=rk.parse_replay_calls(output),
+        patch_error=rk.parse_patch_error(output),
+        returncode=rk.EXIT_PATCH_INCOMPATIBLE,
+        output=output,
+    )
+    problem = rk.diagnose_scan(result)
+
+    assert problem is not None
+    assert "signature is incompatible" in problem
+
+
+def test_call_count_is_read_from_the_patchers_self_report():
+    """Tier 2: #3568 — the call count is read from the patcher's own line;
+    output without that line yields None (never reported), not 0 (reported
+    zero)."""
+    assert rk.parse_replay_calls(f"noise\n{rk.MARKER_CALLS}7\nmore noise\n") == 7
+    assert rk.parse_replay_calls("no patcher line here\n") is None
+
+
+def test_rekeyed_entry_carries_preconditions_and_key_components(tmp_path):
+    """Tier 2: #3568/#3473 — the appended entry has the SHAPE a record-mode entry
+    has. Without ``preconditions`` the entry is 'precondition unverifiable' on
+    any machine whose environment is non-empty; without ``key_components`` a
+    later miss cannot be attributed to a component."""
+    fixture = tmp_path / "fixture.jsonl"
+    _write_fixture(fixture, [{
+        "key": "old_key",
+        "kind": "completion",
+        "model": "gemini-2.5-flash-lite",
+        "prompt_preview": "hi",
+        "response": {"choices": []},
+    }])
+
+    rk._rekey_fixture(
+        fixture_path=fixture,
+        new_key="new_key",
+        prompt_preview="hi",
+        dry_run=False,
+        preconditions={"mcp_catalog": {"servers": [], "tools": []}},
+        key_components={"model": "abc", "tool_choice": "none"},
+    )
+
+    written = _read_fixture(fixture)[-1]
+    assert written["key"] == "new_key"
+    assert written["kind"] == "completion"
+    assert written["preconditions"] == {"mcp_catalog": {"servers": [], "tools": []}}
+    assert written["key_components"] == {"model": "abc", "tool_choice": "none"}
+
+
+def test_rekeyed_entry_omits_stale_key_components_when_none_captured(tmp_path):
+    """Tier 2: #3568 — a fingerprint is NOT copied from the source entry. It
+    describes the OLD request; carried forward it would attribute the next miss
+    to the wrong component, which is worse than having no attribution. The
+    environment imprint, which is not request-specific, IS carried forward."""
+    fixture = tmp_path / "fixture.jsonl"
+    _write_fixture(fixture, [{
+        "key": "old_key",
+        "kind": "completion",
+        "model": "gemini-2.5-flash-lite",
+        "prompt_preview": "hi",
+        "preconditions": {"mcp_catalog": {"servers": [], "tools": []}},
+        "key_components": {"model": "stale-fingerprint"},
+        "response": {"choices": []},
+    }])
+
+    rk._rekey_fixture(
+        fixture_path=fixture, new_key="new_key", prompt_preview="hi", dry_run=False,
+    )
+
+    written = _read_fixture(fixture)[-1]
+    assert "key_components" not in written
+    assert written["preconditions"] == {"mcp_catalog": {"servers": [], "tools": []}}


### PR DESCRIPTION
**[per-PR-coder]** — Fixes #3568.

## The defect, reproduced

【MEASURED】 The patch signature vs the real one:

```
real LLMReplay._replay params : ['self', 'key', 'model', 'messages', 'observed', 'request']
scripts/rekey_fixtures.py:50  : def _patched_replay(self, key, model, messages)
```

Every patched call raised `TypeError` — measured directly by running the old patcher body:

```
E  TypeError: _patched_replay() takes 4 positional arguments but 6 were given   (x5, one per replay test)
src/reyn/dev/testing/replay.py:403: TypeError
```

**The false all-clear is reproduced.** Condition: `tests/fixtures/llm/llm_tools/text_only.jsonl`'s
completion key mutated so it genuinely does not match (`pytest tests/test_llm_tools.py` →
`MissingFixture`, 1 failed / 4 passed — a real, staleness-shaped miss).

```
$ python scripts/rekey_fixtures.py --test-pattern tests/test_llm_tools.py --dry-run   # OLD
Scanning: tests/test_llm_tools.py
No missing keys found — all fixtures up to date.
EXIT=0
```

A maintainer checking fixture freshness gets a green, affirmative all-clear while the
instrument is dead and the fixture is stale.

## What changed

**1. Compatibility is verified BEFORE the scan, and refusal is an error.**
`REQUIRED_REPLAY_PARAMS` declares the exact parameter list (names AND order) the patch is
written against; the patcher compares it to `inspect.signature(LLMReplay._replay)` **in the
subprocess** — so it inspects the same `reyn` the scan measures (the #2103
wrong-import-target hazard) — and never starts pytest on a mismatch.

```
$ python scripts/rekey_fixtures.py --test-pattern tests/test_llm_tools.py --dry-run   # NEW, drift simulated
[ERROR] LLMReplay._replay signature is incompatible with this script's patch.
  expected: ['self', 'key', 'model', 'messages']
  actual:   ['self', 'key', 'model', 'messages', 'observed', 'request']
  parameters _replay grew that the patch does not read: ['observed', 'request']
Nothing was scanned. Update REQUIRED_REPLAY_PARAMS and the patcher in scripts/rekey_fixtures.py to match, then re-run.
EXIT=1
```

**2. "0 missing keys" and "the patch never fired" are now different states.** The patcher
self-reports its `_replay` call count; `diagnose_scan()` treats `0 calls` (and "never
reported at all") as an unusable scan with exit 1:

```
$ python scripts/rekey_fixtures.py --test-pattern tests/test_rekey_fixtures_tool.py --dry-run
[ERROR] The patch never fired: LLMReplay._replay was called 0 times by this pattern.
pytest subprocess exit code: 0
This is NOT 'all fixtures up to date' — nothing was observed. ...
EXIT=1
```

A healthy scan now says so out loud: `No missing keys found — all fixtures up to date (N replay call(s) observed).`

**3. The patch body is signature-agnostic *in addition to* the check** — `*args`/`**kwargs`
forwarding with `Signature.bind`, reading arguments **by name**. This is convenience, not
the mechanism: a renamed or reordered parameter still passes `*args` and would then be read
into the wrong slot. The name-and-order check is what stops that.

**4. Detection restored** — same corrupted-fixture condition as above, NEW script:

```
Scanning: tests/test_llm_tools.py
Found 2 missing key(s):
  fixture: text_only.jsonl, key: a45afc2cb2e15b9d...
  [REKEY] text_only.jsonl: +a45afc2cb2e15b9d... (matched deadbeefb2e15b9d...)
  fixture: text_only.jsonl, key: 559b815119aaab1d...
  [WARN] no prompt_preview match for 559b815119aaab1d... — skip
Rekeyed 1 entry/entries.
$ pytest tests/test_llm_tools.py -q   ->  9 passed
```

(The second key is the deliberate miss in `test_llm_tools_drift_detection`; the existing
preview-match guard correctly refuses to invent a response for it.)

## The written-entry shape — the unverified report was TRUE

【MEASURED】 field names per line of `text_only.jsonl` after a rekey, old writer vs new:

```
old (and the pre-existing legacy entry):  ['key', 'model', 'prompt_preview', 'response']
new:                                      ['key', 'kind', 'model', 'prompt_preview',
                                           'preconditions', 'key_components', 'response']
```

A record-mode entry (`LLMReplay._record`) writes `kind` / `preconditions` /
`key_components`; the rekey writer omitted all three. Consequences, from the code that reads
them: an entry with no `preconditions` is rejected by `_check_preconditions` as *"Fixture
precondition unverifiable"* on any machine whose environment is non-empty (this is latent on
this host — the local MCP catalog is empty, so the branch `recorded is None` +
`actual == absent_value()` continues rather than raising; I did not construct a non-empty
catalog to fire it), and an entry with no `key_components` makes a later miss report
*"Key-component attribution unavailable"* — which is literally what the reproduction's
`MissingFixture` printed.

The patcher now supplies both from the live call. A `key_components` fingerprint is **not**
copied from the source entry when the patcher supplied none: it describes the OLD request
and would attribute the next miss to the wrong component, which is worse than no
attribution. The environment imprint, not being request-specific, is carried forward.

## One more silent all-clear path, closed as a side effect

`DEFAULT_PATTERN` was `tests/test_replay_skill_router.py` — **a file that does not exist**.
Bare `python scripts/rekey_fixtures.py` therefore ran pytest with exit code 4 and printed
"all fixtures up to date". It is now `tests`, and the 0-calls gate makes any bad pattern
loud (`pytest subprocess exit code: 4` in the error).

## Tests

`tests/test_rekey_fixtures_tool.py` already existed and is the established pattern for
testing this script (`sys.path`-insert `scripts/`, call the functions directly) — followed
it rather than inventing a location. 7 tests added, all Tier 2, no fakes: the drift gate
asserts against the **real** `LLMReplay`.

**Strip-falsify** (anchor uniqueness confirmed `count == 1` before each edit):

| strip | reverted guard | result |
|---|---|---|
| 1 | `REQUIRED_REPLAY_PARAMS` -> the pre-#3473 4-tuple | RED — `test_patch_signature_matches_real_llm_replay` |
| 2 | `if result.replay_calls == 0:` -> `if False:` | RED — `test_zero_replay_calls_is_reported_as_a_problem_not_as_up_to_date` |
| 3 | entry writer -> copy source `key_components`, drop `preconditions` | RED — both entry-shape tests |

## Test plan

- [x] Manual: old script on a genuine miss -> "all fixtures up to date", exit 0 (false all-clear reproduced)
- [x] Manual: new script, simulated drift -> incompatibility error naming `observed`/`request`, exit 1
- [x] Manual: new script, pattern with no replay tests -> "patch never fired", exit 1
- [x] Manual: new script on the genuine miss -> 2 keys found, 1 rekeyed, `pytest tests/test_llm_tools.py` -> 9 passed
- [x] Manual: rekeyed entry field names compared against `LLMReplay._record`'s entry shape
- [x] `ruff check src tests scripts/rekey_fixtures.py` -> All checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_rekey_fixtures_tool.py` -> 16 inspected, 0 errors
- [x] `pytest` (full suite, from repo root, on the exact committed tree) -> 9836 passed, 36 skipped
- [x] (skipped — `verify_module_docstrings.py`: no `src/` file changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
