### PR TITLE
chore(deps): bump textual-flowview pin to v0.9.0 (O(1) differential reflow)

### DIFF
--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -1005,6 +1005,14 @@ it. `FlowView.row_count` / `row_text(y)` / `entry_at_row(y)` are the row-level
 primitives copy mode is built on, available to any consumer that needs to map
 content rows back to entries.
 
+A selection — whether from copy mode's `y` or a mouse drag — covers the **body
+columns only** (flowview 0.9.0): the gutters are decoration, like a scrollbar,
+so a yank carries the message text and never a state glyph, an elapsed label,
+or a token figure. `row_text(y)` is body-only for the same reason. Reading a
+*gutter* off `get_selection` therefore reports an empty gutter for a perfectly
+painted one — the surface that answers "is the gutter on screen?" is
+`render_line(y)`, Textual's own paint surface.
+
 ### `reyn.intervention.<kind>`
 
 An **open namespace** carried differently from the two above: it is the `toolName`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,12 +66,19 @@ dependencies = [
     # LAZILY on the TTY path only, so the plain / --cui / non-TTY / CI paths never
     # touch textual or flowview and stay green even if flowview fails to resolve.
     "textual>=0.80",
-    # v0.6.0 (e64b278). 0.5.0: animated jumps, body_width/effective gutter
+    # v0.9.0 (1440fc8). 0.5.0: animated jumps, body_width/effective gutter
     # widths. 0.6.0: empty state, scroll_to_entry(align=), opt-in keyboard
     # cursor, ReachedTop/ReachedBottom infinite scroll, insert_many/extend.
-    # All additive; defaults unchanged (cursor=False, empty=None,
-    # animate=False) — #3476 adoption arc.
-    "textual-flowview @ git+https://github.com/tya5/textual-flowview.git@11ac8dc97b2a1b3a87271ec6f3ba1e586a2267f8",
+    # 0.9.0: O(1) differential reflow (Viewport.invalidate_height_of dirties
+    # only the prefix-sum offsets from the changed entry onward) — internal,
+    # so reyn's existing set_item path gets it with no call-site change; plus
+    # Entry.patch_rows / Presentation(strips=) (NOT wired here — deferred
+    # pending #3539) and body-only text selection (the gutter is decoration,
+    # so a yank no longer carries gutter glyphs). All additive; defaults
+    # unchanged (cursor=False, empty=None, animate=False) — #3476 adoption arc.
+    # The SHA is the *commit*, not the tag object: v0.9.0 is a LIGHTWEIGHT tag
+    # (no `^{}` peel in `git ls-remote`), unlike the annotated v0.7.0/v0.8.0.
+    "textual-flowview @ git+https://github.com/tya5/textual-flowview.git@1440fc8b273a23326e50b532b646bf3b26f31be4",
     "numpy>=1.24",           # RAG index backend cosine similarity (ADR-0033)
     "croniter>=2.0",         # cron expression parsing for FP-0009 Component B
     "charset-normalizer>=3.0",  # #1452 read_file encoding detection (MIT, pure-python)

--- a/tests/test_textual_chat_phase2_3273.py
+++ b/tests/test_textual_chat_phase2_3273.py
@@ -190,7 +190,7 @@ def test_flowview_library_is_unmodified_blink_lives_in_reyn() -> None:
     # #3476: pinned to the version pyproject's git SHA resolves to — the pin
     # here is what detects a locally-forked/vendored flowview masquerading as
     # the release (a mismatch means the installed copy is not the pinned one).
-    assert textual_flowview.__version__ == "0.8.0"
+    assert textual_flowview.__version__ == "0.9.0"
     # The native animation primitive reyn now drives the blink through: FlowView
     # accepts an ``animation_fps`` and owns its own animation tick.
     import inspect

--- a/tests/test_textual_chat_phase4_right_gutter_3283.py
+++ b/tests/test_textual_chat_phase4_right_gutter_3283.py
@@ -198,6 +198,19 @@ def _full_selection(flow: "FlowView[OutboxMessage]") -> Selection:
     return Selection(Offset(0, 0), Offset(flow.virtual_size.width, height))
 
 
+def _painted_lines(flow: "FlowView[OutboxMessage]") -> "list[str]":
+    """Every non-blank PAINTED row of the FlowView, gutters included, read off
+    ``Widget.render_line`` — Textual's public paint surface.
+
+    This is the surface that answers "is the right gutter on screen?".
+    ``get_selection`` deliberately is NOT: from textual-flowview 0.9.0 the
+    selection is confined to the BODY columns (the gutter is decoration, like a
+    scrollbar, so a yank never carries gutter glyphs), so reading a gutter label
+    out of a selection reports an empty gutter for a perfectly painted one."""
+    lines = [flow.render_line(y).text.rstrip() for y in range(flow.size.height)]
+    return [ln for ln in lines if ln.strip()]
+
+
 def _entry_by_kind(app: TextualChatApp, kind: str):
     return [e for e in app.query_one(FlowView).entries if e.item.kind == kind]
 
@@ -407,10 +420,15 @@ async def test_app_stashes_final_elapsed_for_an_orphaned_tool_too() -> None:
 async def test_right_gutter_wired_end_to_end_settled_tool_vs_plain_row() -> None:
     """Tier 2b: through the REAL mounted FlowView (real ``right_decorator`` /
     ``right_gutter_width`` wiring), a SETTLED tool row's composed line ends in
-    the elapsed label and a plain agent row's composed line does not — reads
-    ``FlowView.get_selection`` (flowview's own selection-extraction, which
-    composes left gutter + body + right gutter), asserting on the RENDERED
-    row text rather than the source meta field."""
+    the elapsed label and a plain agent row's composed line does not — read off
+    ``FlowView.render_line`` (Textual's public paint surface, which composes
+    left gutter + body + right gutter), asserting on the RENDERED row text
+    rather than the source meta field.
+
+    Also pins the complement, since the two are easy to confuse: the same label
+    is ABSENT from ``get_selection``. Since textual-flowview 0.9.0 a selection
+    is confined to the body columns, so a yank carries the message text and no
+    gutter glyphs — that is the contract, not a missing gutter."""
     now = [500.0]
     transport = QueueTransport()
     app = TextualChatApp(transport=transport, clock=lambda: now[0])
@@ -425,10 +443,7 @@ async def test_right_gutter_wired_end_to_end_settled_tool_vs_plain_row() -> None
         await pilot.pause()
 
         flow = app.query_one(FlowView)
-        result = flow.get_selection(_full_selection(flow))
-        assert result is not None
-        text, _sep = result
-        lines = [ln for ln in text.split("\n") if ln.strip()]
+        lines = _painted_lines(flow)
 
         # The settled tool row's own line carries its captured elapsed label
         # at the RIGHT-hand end (the right gutter) — positive content check.
@@ -442,6 +457,14 @@ async def test_right_gutter_wired_end_to_end_settled_tool_vs_plain_row() -> None
         agent_lines = [ln for ln in lines if "hello there" in ln]
         assert agent_lines, f"no rendered row found for the agent row: {lines!r}"
         assert not any(re.search(r"\d+[smh]$", ln) for ln in agent_lines), agent_lines
+
+        # Complement: a SELECTION over the same rows yields the body text and
+        # no gutter glyph — flowview 0.9.0 confines selection to the body.
+        result = flow.get_selection(_full_selection(flow))
+        assert result is not None
+        selected, _sep = result
+        assert "grep" in selected, selected
+        assert not re.search(r"\d+[smh]\s*$", selected, re.MULTILINE), selected
 
 
 # ── Gate 3: left gutter unchanged (#3273 state contract) ──────────────────────
@@ -636,9 +659,7 @@ async def test_narrow_terminal_keeps_gutters_fixed_and_squashes_the_body() -> No
         # RUNNING tool row's elapsed label is still readable in the composed
         # row text even at this extreme width (flowview's own body-width
         # floor absorbs the squeeze instead of hiding the gutter).
-        result = flow.get_selection(_full_selection(flow))
-        assert result is not None
-        text, _sep = result
-        assert re.search(r"\d+[smh]\s*$", text, re.MULTILINE), (
-            f"elapsed label not found in narrow-terminal render:\n{text!r}"
+        painted = "\n".join(_painted_lines(flow))
+        assert re.search(r"\d+[smh]\s*$", painted, re.MULTILINE), (
+            f"elapsed label not found in narrow-terminal render:\n{painted!r}"
         )

--- a/tests/test_textual_chat_phase4_turn_cost_gutter_3283.py
+++ b/tests/test_textual_chat_phase4_turn_cost_gutter_3283.py
@@ -759,16 +759,14 @@ class _QueueTransport(ClientTransport):
 
 def _rendered_lines(flow: "FlowView[OutboxMessage]") -> "list[str]":
     """Every composed row line (left gutter + body + right gutter) of the
-    FlowView's virtual content, via flowview's own selection extraction."""
-    from textual.geometry import Offset
-    from textual.selection import Selection
+    FlowView, read off ``Widget.render_line`` — Textual's public paint surface.
 
-    height = max(0, flow.virtual_size.height - 1)
-    result = flow.get_selection(
-        Selection(Offset(0, 0), Offset(flow.virtual_size.width, height))
-    )
-    assert result is not None
-    return [ln for ln in result[0].split("\n") if ln.strip()]
+    NOT ``get_selection``: since textual-flowview 0.9.0 a selection is confined
+    to the BODY columns (the gutter is decoration, like a scrollbar, so a yank
+    never carries gutter glyphs), so selection text reports an empty gutter for
+    a perfectly painted one."""
+    lines = [flow.render_line(y).text.rstrip() for y in range(flow.size.height)]
+    return [ln for ln in lines if ln.strip()]
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -3866,7 +3866,7 @@ requires-dist = [
     { name = "sqlite-vec", marker = "extra == 'builtin-rag'", specifier = ">=0.1.9" },
     { name = "starlette", marker = "extra == 'web'", specifier = ">=1.0,<1.3" },
     { name = "textual", specifier = ">=0.80" },
-    { name = "textual-flowview", git = "https://github.com/tya5/textual-flowview.git?rev=11ac8dc97b2a1b3a87271ec6f3ba1e586a2267f8" },
+    { name = "textual-flowview", git = "https://github.com/tya5/textual-flowview.git?rev=1440fc8b273a23326e50b532b646bf3b26f31be4" },
     { name = "trafilatura", marker = "extra == 'fetch'", specifier = ">=1.8" },
     { name = "twine", marker = "extra == 'release'", specifier = ">=5.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = ">=0.27" },
@@ -4077,8 +4077,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "python_full_version < '3.13' or python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "jeepney", marker = "python_full_version < '3.13' or python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -4233,8 +4233,8 @@ wheels = [
 
 [[package]]
 name = "textual-flowview"
-version = "0.8.0"
-source = { git = "https://github.com/tya5/textual-flowview.git?rev=11ac8dc97b2a1b3a87271ec6f3ba1e586a2267f8#11ac8dc97b2a1b3a87271ec6f3ba1e586a2267f8" }
+version = "0.9.0"
+source = { git = "https://github.com/tya5/textual-flowview.git?rev=1440fc8b273a23326e50b532b646bf3b26f31be4#1440fc8b273a23326e50b532b646bf3b26f31be4" }
 dependencies = [
     { name = "textual" },
 ]


### PR DESCRIPTION
**[per-PR-coder]** — Bump the `textual-flowview` git pin from v0.8.0 to **v0.9.0**, on the owner's instruction ("v0.9.0 は取り込んでね。flowview 自体の改善が含まれてるからね").

**Version bump only.** `Entry.patch_rows` / `Presentation(strips=)` — v0.9.0's new incremental-streaming API — are deliberately **NOT wired**; that decision is deferred pending a separate measurement (#3539). Nothing under `src/` changes.

## The pin

```
old : ...@11ac8dc97b2a1b3a87271ec6f3ba1e586a2267f8   (v0.8.0)
new : ...@1440fc8b273a23326e50b532b646bf3b26f31be4   (v0.9.0)
```

⚠️ **v0.9.0 is a LIGHTWEIGHT tag** — unlike the annotated v0.7.0/v0.8.0 it has no `^{}` peel line in `git ls-remote`, so `refs/tags/v0.9.0` points straight at the commit. Verified two ways, because pinning a *tag object* SHA would not resolve:

- `git ls-remote` shows `v0.8.0` + `v0.8.0^{}` but only a bare `v0.9.0`.
- `git cat-file -t 1440fc8…` → `commit` (vs `0046fa88…` → `tag` for the v0.8.0 ref).

A note recording the lightweight-tag shape is now in `pyproject.toml` beside the pin, and the adjacent comment block — which still said "v0.6.0 (e64b278)" while the pin had already moved to v0.8.0 — is corrected.

**Installed version read directly** from the worktree-local venv (not inferred from the lockfile):

```
module  : .../.venv/lib/python3.11/site-packages/textual_flowview/__init__.py
__version__               : 0.9.0
importlib.metadata.version: 0.9.0
```

## Behaviour change found — reported, not papered over

v0.9.0's headline change (**O(1) differential reflow**) is internal and needs no call-site change. But v0.9.0 also carries an upstream **fix** that reyn's tests did see:

> Text selection is confined to the **body** columns — the gutter is decoration, not selectable text (like a scrollbar).

So `FlowView.get_selection` / `row_text(y)` no longer return gutter glyphs. Three reyn tests used `get_selection` as a *proxy* for "the composed row, gutters included", and that proxy is now body-only by design.

**This is not a reyn regression — the gutter still paints.** Verified on `render_line`, Textual's public paint surface, through the real mounted app:

```
y= 0 '● recorded reply       …        ↑1.5k ↓250'
y= 2 '● mystery reply        …                 —'
--- get_selection() (body-only in 0.9.0) ---
'recorded reply\n\nmystery reply'
```

The three tests are therefore moved to the surface that actually answers their question (`render_line`, via a `_painted_lines` / `_rendered_lines` helper whose docstring records why `get_selection` is the wrong surface). One of them additionally gains the **complement** as a positive pin of the new contract: the same elapsed label is present on the paint surface and absent from the selection, so a yank carries message text and no gutter glyphs. The `agui-transport.md` copy-mode section — which documents `row_text(y)` and the yank — gains the sentence it now needs.

The fourth failure was the deliberate `__version__ == "0.8.0"` pin in `test_textual_chat_phase2_3273.py` (the anti-vendoring check), updated to `0.9.0`.

Nothing else in reyn's flowview surface moved: reyn implements no `ModelListener` (the new `on_flow_patch` member is internal to the library), and `Presentation`'s new `strips=` field has a default, so reyn's existing `Presentation(height=…, renderable=…)` calls are unaffected.

## Measured: is the reflow win observable at reyn's entry counts?

**Largely no — and that is fine; the bump is owner-requested regardless.**

reyn hydrates `_HYDRATE_PAGE_FRAMES = 200` frames and pages in 200 more per scroll-up, so a realistic conversation pane holds **N ≈ 200**, reaching perhaps 400–1000 after several page-ups. Nowhere near the N=5000 the upstream figure is quoted at.

A/B of the exact term that changed (`Viewport._prefix` rebuild — both legs run the same installed 0.9.0 code and differ only in which invalidation `_refresh_layout` issues, `invalidate_heights()` vs `invalidate_height_of(last)`), 2000 iterations, ms per reflow:

| N | v0.8.0 leg (full) | v0.9.0 leg (tail) |
|---|---|---|
| 200 (realistic) | 0.07 – 0.16 | ~0.001 |
| 600 | ~0.50 | ~0.001 |
| 1000 | 0.94 – 1.48 | ~0.001 |
| 5000 | 4.0 – 8.0 | ~0.001 |
| 20000 | 9.7 – 26.1 | ~0.001 |

Ranges are across three runs on a shared machine; the tail leg is flat and the full leg is noisy but clearly linear. **At reyn's realistic N≈200 the saving is roughly 0.1 ms per reflow** — under ~1% of a 16.7 ms frame budget, i.e. not something an operator can perceive. It becomes real only well beyond the entry counts reyn currently reaches, so treat this as **forward headroom**, not a performance fix. The reasons to take v0.9.0 are the owner's instruction and the body-only-selection fix, which *is* user-visible.

The microbenchmark measures the offset-rebuild term in isolation, not a whole frame; it does not claim an end-to-end frame-time delta.

## Test plan

- [x] `uv sync --all-extras --dev`; installed `textual_flowview.__version__` read directly = `0.9.0`
- [x] `git ls-remote` + `git cat-file -t` confirm v0.9.0 is a lightweight tag and the pinned SHA is a commit
- [x] `uv lock --check` (separate CI gate) — passes
- [x] `ruff check src tests` — passes
- [x] `python scripts/test_tier_audit.py --strict` on the three changed test files — 0 errors, 0 warnings
- [x] `pytest -n auto` (full suite — a dep bump under the TUI is cross-cutting)
- [x] `scripts/verify_module_docstrings.py` — (skipped — no `src/` file changed in this PR)
- [x] Reflow A/B measured at N = 50…20000; realistic-N result stated above
- [ ] **Visual, real TTY — for tui-coder:** stream a reply in a real terminal and confirm the conversation pane looks right (no reflow jitter, gutters intact), then drag-select and yank across a row and confirm the copied text carries the message body and **no** gutter glyphs. **I have no TTY and cannot judge appearance — deliberately left unchecked for tui-coder.**

## Coordination

Touches `pyproject.toml` / `uv.lock` / three test files / one doc. **No `src/` changes**, so this should not collide with the concurrent #3570 (streaming coalesce) work on `textual_chat/app.py`; whichever lands second rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
