### PR TITLE
fix(transport): unconditional suspension point per frame in the drain loop — #3570 (1/2)

### DIFF
--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -28,6 +28,7 @@ footgun where a client kills the server).
 """
 from __future__ import annotations
 
+import asyncio
 from typing import AsyncIterator, Awaitable, Callable
 
 from reyn.interfaces.transport.agui.protocol import (
@@ -134,6 +135,14 @@ class AgUiTransport(ClientTransport):
             if line == "":
                 if block:
                     for frame in self._consume_block(block):
+                        # #3570, same property as ``InProcessTransport.frames``:
+                        # one SSE block decodes to MANY frames (a MESSAGES_SNAPSHOT
+                        # reconnect alone carries the whole backlog) and this inner
+                        # loop has no await of its own, while ``aiter_lines`` over a
+                        # buffered read returns without suspending either. Without
+                        # this line whether the loop breathes is a function of how
+                        # much the server packed into one block.
+                        await asyncio.sleep(0)
                         yield frame
                         if (
                             isinstance(frame, DisplayFrame)
@@ -146,6 +155,7 @@ class AgUiTransport(ClientTransport):
         # Flush a trailing block with no terminal blank line.
         if block:
             for frame in self._consume_block(block):
+                await asyncio.sleep(0)  # #3570, same reason as the loop above
                 yield frame
 
     # -- send side ----------------------------------------------------------

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -41,6 +41,7 @@ from reyn.interfaces.transport.agui.protocol import (
 )
 from reyn.interfaces.transport.agui.state import RemoteStatusView, reguard_nodes
 from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.drain import suspend_between_frames
 from reyn.interfaces.transport.frames import DisplayFrame, Frame
 
 
@@ -142,7 +143,7 @@ class AgUiTransport(ClientTransport):
                         # buffered read returns without suspending either. Without
                         # this line whether the loop breathes is a function of how
                         # much the server packed into one block.
-                        await asyncio.sleep(0)
+                        await suspend_between_frames()
                         yield frame
                         if (
                             isinstance(frame, DisplayFrame)
@@ -155,7 +156,7 @@ class AgUiTransport(ClientTransport):
         # Flush a trailing block with no terminal blank line.
         if block:
             for frame in self._consume_block(block):
-                await asyncio.sleep(0)  # #3570, same reason as the loop above
+                await suspend_between_frames()  # #3570, same reason as above
                 yield frame
 
     # -- send side ----------------------------------------------------------

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -365,6 +365,14 @@ class _SessionFrameSource:
     async def frames(self):
         while True:
             frame = await self._q.get()
+            # #3570, the server-side instance of the same shape as
+            # ``InProcessTransport.frames``: ``_q`` is fed by SYNCHRONOUS
+            # ``put_nowait`` callers (the chat-event subscriber, the forwarder),
+            # so a burst leaves it non-empty and ``get()`` stops suspending —
+            # the emitter would then encode + serialize the whole burst without
+            # the server's event loop running anything else (other connections'
+            # writes, the fail-close driver's timers).
+            await asyncio.sleep(0)
             yield frame
             if isinstance(frame, DisplayFrame) and frame.message.kind == "__end__":
                 return

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -52,6 +52,7 @@ from reyn.interfaces.transport.agui.surface import (
     monotonic,
     surface_registry,
 )
+from reyn.interfaces.transport.drain import suspend_between_frames
 from reyn.interfaces.transport.frames import (
     DisplayFrame,
     EventFrame,
@@ -372,7 +373,7 @@ class _SessionFrameSource:
             # the emitter would then encode + serialize the whole burst without
             # the server's event loop running anything else (other connections'
             # writes, the fail-close driver's timers).
-            await asyncio.sleep(0)
+            await suspend_between_frames()
             yield frame
             if isinstance(frame, DisplayFrame) and frame.message.kind == "__end__":
                 return

--- a/src/reyn/interfaces/transport/drain.py
+++ b/src/reyn/interfaces/transport/drain.py
@@ -1,0 +1,39 @@
+"""The suspension point every frame drain passes through, once per frame (#3570).
+
+A frame drain reads like it suspends per frame and does not: ``asyncio.Queue.get()``
+returns WITHOUT suspending while the queue is non-empty, and ``async for`` over a
+buffered source (an SSE line iterator, a decoded block) awaits coroutines that
+return immediately. Awaiting something that does not suspend is not a scheduling
+point, so a producer that delivers several frames at once has the consumer drain
+to exhaustion with the event loop never running anything else — no animation, no
+keystroke, no timer, for as long as the burst lasts.
+
+:func:`suspend_between_frames` is that missing point, and it lives here rather
+than being spelled ``await asyncio.sleep(0)`` at each site for one reason: it
+gives the property a NAME that a gate can enumerate. ``tests/
+test_stream_drain_yield_3570.py`` walks every ``frames()`` drain in this package
+and requires each ``yield`` to be paired with a call to this function, so a
+FOURTH transport cannot reintroduce the defect by simply not knowing about it.
+Three sites fixed by hand is a fact about today; the pairing is a rule about
+tomorrow.
+"""
+from __future__ import annotations
+
+import asyncio
+
+
+async def suspend_between_frames() -> None:
+    """Return control to the event loop, unconditionally, exactly once.
+
+    Called once per frame by every drain in this package — never conditionally
+    ("only when the queue is non-empty" is the timing-dependent shape this
+    exists to remove) and never per batch: the queues involved are unbounded,
+    so a "suspend every N frames" rule would leave the interval between
+    suspensions proportional to something the producer chooses. At one frame it
+    is a single frame's processing, which is the smallest a non-preemptible
+    consumer can offer.
+    """
+    await asyncio.sleep(0)
+
+
+__all__ = ["suspend_between_frames"]

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -127,6 +127,26 @@ class InProcessTransport(ClientTransport):
     async def frames(self) -> "AsyncIterator[Frame]":
         while True:
             frame = await self._frames.get()
+            # #3570: an UNCONDITIONAL yield point, once per frame. ``Queue.get()``
+            # returns WITHOUT suspending whenever the queue is non-empty, so the
+            # ``await`` above is not a scheduling point at all in the regime that
+            # matters: a producer that enqueues several frames between two visits
+            # of this task (a provider whose SSE reads carry many deltas — measured
+            # occupancy 5..1000 in #3570) makes the consumer drain to exhaustion
+            # with ZERO returns to the event loop, so nothing else — animations,
+            # input, timers — runs for the whole burst. Whether the loop breathes
+            # must not be a function of queue occupancy (a timing property); this
+            # line makes it a function of the loop's structure.
+            #
+            # ★The suspension is per FRAME, not per batch of frames. ``_frames``
+            # is an UNBOUNDED ``asyncio.Queue``, so any "suspend every N frames"
+            # rule would leave the interval between suspensions proportional to
+            # something the producer chooses; at N=1 the interval is one frame's
+            # processing, which is the smallest a non-preemptible consumer can
+            # offer and needs no time-based escape hatch to bound it. It also
+            # leaves the terminal check below exactly where it was — no batch
+            # can ever straddle ``__end__``.
+            await asyncio.sleep(0)
             yield frame
             if frame.tag is FrameTag.DISPLAY and frame.message.kind == "__end__":
                 return

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -34,6 +34,7 @@ import logging
 from typing import TYPE_CHECKING, AsyncIterator
 
 from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.drain import suspend_between_frames
 from reyn.interfaces.transport.frames import (
     DisplayFrame,
     EventFrame,
@@ -146,7 +147,7 @@ class InProcessTransport(ClientTransport):
             # offer and needs no time-based escape hatch to bound it. It also
             # leaves the terminal check below exactly where it was — no batch
             # can ever straddle ``__end__``.
-            await asyncio.sleep(0)
+            await suspend_between_frames()
             yield frame
             if frame.tag is FrameTag.DISPLAY and frame.message.kind == "__end__":
                 return

--- a/tests/test_stream_drain_yield_3570.py
+++ b/tests/test_stream_drain_yield_3570.py
@@ -1,0 +1,230 @@
+"""#3570 (1/2) — input arriving DURING a stream must be handled in bounded time.
+
+``InProcessTransport.frames`` awaits ``asyncio.Queue.get()`` once per frame,
+which reads like a suspension point per frame but is not one: ``get()`` returns
+WITHOUT suspending whenever the queue is non-empty. A provider that delivers
+several deltas per socket read — litellm's stream wrapper yields every chunk a
+single read carried, and awaiting a coroutine that does not suspend is not a
+scheduling point — therefore leaves the consumer draining to exhaustion with
+ZERO returns to the event loop. Nothing else runs for the whole burst: not the
+animation, not a keystroke, not a timer. That is the owner's report ("the UI is
+frozen for the whole stream and comes back the instant it ends").
+
+**The contract this file gates**: input injected while a stream is arriving is
+handled within a BOUNDED number of frames — bounded by construction (one
+suspension per frame) rather than by how full the queue happens to be, which is
+a timing property.
+
+The bound is expressed in FRAMES, never in wall-clock: a millisecond deadline
+would be a load-sensitive gate that fails only under ``-n auto`` concurrency,
+which is the class #3473 just closed. The delta the app is ingesting is the
+logical tick.
+
+Real ``AgentRegistry`` + real ``Session`` + real ``InProcessTransport`` + real
+``TextualChatApp``; the deltas ride the production chat-event emit
+(``host.events.emit("agent_delta", ...)``, the call ``RouterLoop
+._emit_agent_delta`` makes) and the tool frames ride ``repl_outbox`` (the
+display path the registry forwarder feeds). No mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from textual.message import Message
+
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame, FrameTag
+from reyn.interfaces.transport.in_process import InProcessTransport
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID
+from tests._support.agent_session import make_session
+
+#: One delta's worth of text. Small, like a real token chunk.
+_CHUNK = "lorem ipsum "
+
+
+class _InputProbe(Message):
+    """A message posted onto the app's own queue — the SAME ``App`` message pump
+    a keystroke is delivered on, so handling it means the app got the processor
+    back, not that some surface merely looked alive (a spinner animates happily
+    on stale state, which is why "it looked smooth" is never the witness here)."""
+
+
+class _InputProbeApp(TextualChatApp):
+    """The REAL app with two observations added: which delta the pump is on, and
+    at which delta a probe posted mid-backlog is handled.
+
+    A subclass recording around ``super()`` calls, never a stand-in — the idiom
+    ``tests/test_transport_bit_identical.py``'s ``_RecordingInlineRenderer``
+    uses. Both readings are counted in FRAMES (the logical tick), which is what
+    keeps the gate off wall-clock and therefore stable under load.
+    """
+
+    inject_after_deltas = 20
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.deltas_ingested = 0
+        self.probe_injected_at: "int | None" = None
+        self.probe_handled_at: "int | None" = None
+
+    def _handle_agent_delta_event(self, event) -> None:
+        self.deltas_ingested += 1
+        if (
+            self.probe_injected_at is None
+            and self.deltas_ingested >= self.inject_after_deltas
+        ):
+            self.probe_injected_at = self.deltas_ingested
+            self.post_message(_InputProbe())
+        super()._handle_agent_delta_event(event)
+
+    def on__input_probe(self, message: _InputProbe) -> None:
+        if self.probe_handled_at is None:
+            self.probe_handled_at = self.deltas_ingested
+
+
+def _tool_started(op_id: str) -> OutboxMessage:
+    return OutboxMessage(
+        kind="tool_call_started",
+        text="grep",
+        meta={"tool": "grep", "op_id": op_id, "args": {}},
+    )
+
+
+def _tool_completed(op_id: str) -> OutboxMessage:
+    return OutboxMessage(
+        kind="tool_call_completed",
+        text="grep",
+        meta={"tool": "grep", "op_id": op_id, "result": "ok"},
+    )
+
+
+async def _build(tmp_path: Path, app_cls=TextualChatApp):
+    """Real registry + session + transport + app, wired as ``reyn chat`` wires
+    them (``repl.py``: build the transport over the registry, ``start`` it, hand
+    it to the app)."""
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    holder: dict = {}
+
+    def factory(profile, *, presentation_consumer=None, intervention_bridge=None):
+        return make_session(
+            agent_name=profile.name,
+            state_log=state_log,
+            registry=holder.get("reg"),
+            snapshot_path=tmp_path / "snapshot.json",
+            workspace_base_dir=tmp_path / "ws",
+            workspace_state_dir=tmp_path / "state",
+        )
+
+    registry = AgentRegistry(
+        project_root=tmp_path, session_factory=factory, state_log=state_log
+    )
+    holder["reg"] = registry
+    if not registry.exists("default"):
+        registry.create("default")
+    await registry.attach("default")
+    transport = InProcessTransport(
+        registry, intervention_channel=DEFAULT_CHAT_CHANNEL_ID
+    )
+    transport.start()
+    return registry, transport, app_cls(transport=transport)
+
+
+async def _until(pred, *, attempts: int = 400, delay: float = 0.01) -> bool:
+    """Bounded poll — a hang exhausts the budget and returns False (RED). This is
+    the test's own patience, not the property under test (which is counted in
+    frames)."""
+    for _ in range(attempts):
+        if pred():
+            return True
+        await asyncio.sleep(delay)
+    return False
+
+
+@pytest.mark.asyncio
+async def test_input_arriving_during_a_stream_is_handled_within_a_few_frames(
+    tmp_path,
+) -> None:
+    """Tier 2: ★★the contract — input injected WHILE a backlog of stream frames
+    is being drained is handled within a bounded number of frames, not after the
+    whole backlog.
+
+    The backlog is MIXED — two chain_ids interleaved, with tool frames landing
+    between them on the SAME ordered queue — because a clean single-chain run is
+    the easy case and would not catch a suspension point that another frame kind
+    can defeat.
+
+    Strip-falsify (recorded in the PR body): removing the ``await
+    asyncio.sleep(0)`` from ``InProcessTransport.frames`` pushes the probe's
+    handling to the END of the backlog — the frozen UI, reproduced.
+    """
+    per_chain = 150
+    arrivals = per_chain * 2
+    registry, transport, app = await _build(tmp_path, app_cls=_InputProbeApp)
+    session = registry.attached_session()
+    try:
+        async with app.run_test(size=(100, 50)) as pilot:
+            await pilot.pause()
+            for i in range(per_chain):
+                for chain in ("chain-a", "chain-b"):
+                    session.router_host.events.emit(
+                        "agent_delta", text=_CHUNK, chain_id=chain
+                    )
+                if i % 25 == 0:
+                    registry.repl_outbox.put_nowait(_tool_started(f"op-{i}"))
+                    registry.repl_outbox.put_nowait(_tool_completed(f"op-{i}"))
+
+            assert await _until(
+                lambda: app.deltas_ingested >= arrivals
+            ), "the mixed backlog never drained"
+            assert app.probe_handled_at is not None, (
+                "the injected input was never handled at all"
+            )
+            waited = app.probe_handled_at - app.probe_injected_at
+            assert waited < 0, (
+                f"input injected at frame {app.probe_injected_at} was only handled "
+                f"{waited} frames later, out of a {arrivals}-frame backlog — the "
+                "drain loop holds the processor for the whole stream"
+            )
+    finally:
+        await registry.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_the_stream_still_terminates_at_the_end_frame(tmp_path) -> None:
+    """Tier 1: the added suspension point does not change WHEN the frame stream
+    ends: ``__end__`` is delivered, and nothing queued behind it is.
+
+    The suspension is one yield per frame — there is no batching, so there is no
+    "``__end__`` arrived mid-batch" case to decide. This gate pins that: the
+    terminal check still runs on the SAME frame it always did, immediately after
+    that frame is yielded, whether or not more frames are already queued behind
+    it (they are here — the queue is pre-filled past the end, which is exactly
+    the non-empty regime that made ``get()`` stop suspending in the first place).
+    """
+    registry, transport, _app = await _build(tmp_path)
+    session = registry.attached_session()
+    try:
+        session.router_host.events.emit("agent_delta", text="a", chain_id="c")
+        registry.repl_outbox.put_nowait(OutboxMessage(kind="__end__", text=""))
+        registry.repl_outbox.put_nowait(OutboxMessage(kind="status", text="after"))
+        await asyncio.sleep(0)  # let the outbox pump re-tag onto the frame stream
+
+        seen = []
+        async for frame in transport.frames():
+            seen.append(frame)
+
+        kinds = [
+            f.message.kind if f.tag is FrameTag.DISPLAY else "<event>" for f in seen
+        ]
+        assert "__end__" in kinds, f"the terminal frame was never delivered: {kinds}"
+        assert kinds[-1] == "__end__", (
+            f"frames were delivered after the terminal frame: {kinds}"
+        )
+        assert isinstance(seen[0], (DisplayFrame, EventFrame))
+    finally:
+        await registry.shutdown()

--- a/tests/test_stream_drain_yield_3570.py
+++ b/tests/test_stream_drain_yield_3570.py
@@ -28,14 +28,19 @@ display path the registry forwarder feeds). No mocks.
 """
 from __future__ import annotations
 
+import ast
 import asyncio
 from pathlib import Path
 
 import pytest
 from textual.message import Message
 
+import reyn.interfaces.transport as transport_pkg
 from reyn.core.events.state_log import StateLog
 from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.endpoint import _SessionFrameSource
+from reyn.interfaces.transport.agui.protocol import encode_frame, to_sse
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame, FrameTag
 from reyn.interfaces.transport.in_process import InProcessTransport
 from reyn.runtime.outbox import OutboxMessage
@@ -234,3 +239,178 @@ async def test_the_stream_still_terminates_at_the_end_frame(tmp_path) -> None:
         assert isinstance(seen[0], (DisplayFrame, EventFrame))
     finally:
         await registry.shutdown()
+
+
+async def _suspension_gaps_while_draining(frames, *, count: int) -> "list[int]":
+    """Drain ``count`` frames while a co-running task counts its own turns, and
+    return the counter's advance BETWEEN consecutive frames.
+
+    A gap of 0 means the loop never came back between those two frames — the
+    starvation this issue is about. Sampling happens INSIDE the drain, so no
+    ``sleep`` in a test body can inflate the reading (a co-task left spinning
+    across a polling wait would report health the drain never had)."""
+    counter = [0]
+    stop = asyncio.Event()
+
+    async def co_task() -> None:
+        while not stop.is_set():
+            counter[0] += 1
+            await asyncio.sleep(0)
+
+    runner = asyncio.create_task(co_task())
+    samples: "list[int]" = []
+    try:
+        async for _frame in frames:
+            samples.append(counter[0])
+            if len(samples) >= count:
+                break
+    finally:
+        stop.set()
+        await runner
+    return [b - a for a, b in zip(samples, samples[1:])]
+
+
+@pytest.mark.asyncio
+async def test_the_agui_client_drain_suspends_between_frames_of_one_read(
+    tmp_path,
+) -> None:
+    """Tier 2: ★the SECOND ``ClientTransport`` — ``AgUiTransport`` — returns to
+    the loop between frames of a buffered SSE read, not only between reads.
+
+    Its starvation has a different source from ``InProcessTransport``'s: no
+    queue is involved. ``async for raw in self._sse_lines`` awaits a line
+    iterator that, over an already-buffered read, produces every line without
+    suspending, and one decoded block can carry MANY frames through an inner
+    ``for`` loop with no await of its own (a MESSAGES_SNAPSHOT reconnect
+    carries the whole backlog that way). Enumerating the three implementations
+    and patching each was the easy half; this is the half that says the patch
+    is load-bearing HERE and not just in the site that happened to have a test.
+
+    Real wire bytes (the production ``encode_frame`` + ``to_sse``) through the
+    real ``AgUiTransport``.
+
+    Strip-falsify (PR body): dropping the suspension from
+    ``AgUiTransport.frames`` makes every gap 0 — the whole SSE buffer is
+    decoded and delivered without the loop running anything else."""
+    count = 60
+    sse = "".join(
+        to_sse(encode_frame(DisplayFrame(OutboxMessage(kind="agent", text=f"r{i}"))))
+        for i in range(count)
+    )
+
+    async def _lines():
+        for line in sse.split("\n"):
+            yield line
+
+    async def _noop_send(_payload):
+        return None
+
+    transport = AgUiTransport(_lines(), _noop_send)
+    gaps = await _suspension_gaps_while_draining(transport.frames(), count=count)
+
+    starved = [g for g in gaps if g == 0]
+    assert gaps, "test setup: no frames were decoded from the SSE buffer"
+    assert len(starved) < len(gaps) // 10, (
+        f"{len(starved)} of {len(gaps)} consecutive frames were delivered with "
+        "the event loop running nothing in between — the AG-UI client drain "
+        "starves the loop for a whole buffered read"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_server_frame_source_suspends_between_frames_of_a_burst(
+    tmp_path,
+) -> None:
+    """Tier 2: ★the THIRD site — the AG-UI endpoint's per-connection frame
+    source — returns to the loop between frames too.
+
+    Not a ``ClientTransport`` (it is the server's own fan-out), but the same
+    ``asyncio.Queue`` + synchronous ``put_nowait`` shape, and its consumer
+    encodes and serializes every frame onto a socket. Starving there holds the
+    SERVER's loop: other connections' writes and the fail-close driver's timers
+    stop for the burst, which is a strictly wider blast radius than one TUI.
+
+    Real ``Session`` + real ``_SessionFrameSource``; the burst is emitted
+    through the production chat-event channel, so the queue fills exactly the
+    way a streamed reply fills it.
+
+    Strip-falsify (PR body): dropping the suspension makes every gap 0."""
+    count = 60
+    registry, _transport, _app = await _build(tmp_path)
+    session = registry.attached_session()
+    source = _SessionFrameSource(session, registry=registry, agent_name="default")
+    source.start()
+    try:
+        for i in range(count + 5):
+            session.router_host.events.emit(
+                "agent_delta", text=f"d{i}", chain_id="chain"
+            )
+        gaps = await _suspension_gaps_while_draining(source.frames(), count=count)
+
+        starved = [g for g in gaps if g == 0]
+        assert gaps, "test setup: the burst never reached the source's queue"
+        assert len(starved) < len(gaps) // 10, (
+            f"{len(starved)} of {len(gaps)} consecutive frames were delivered "
+            "with the event loop running nothing in between — the server-side "
+            "drain starves the server's loop for the whole burst"
+        )
+    finally:
+        source.close()
+        await registry.shutdown()
+
+
+def test_every_frame_drain_in_the_transport_package_pairs_yields_with_a_suspension() -> None:
+    """Tier 2: ★the CLASS gate — every ``frames()`` drain in the transport
+    package pairs each ``yield`` with a call to
+    :func:`~reyn.interfaces.transport.drain.suspend_between_frames`.
+
+    Three sites fixed by hand is a fact about today; a FOURTH transport is
+    where the defect gets reimported, by an author who never read this issue.
+    The enumeration is over the PACKAGE's source (every ``async def frames``
+    under ``reyn/interfaces/transport``), not over ``ClientTransport``
+    subclasses, because the server-side source is one of the three sites and is
+    not a subclass — a subclass-only enumeration would have declared complete
+    coverage while missing it.
+
+    ★What this gate can and cannot see: it is a pairing count (a suspension per
+    ``yield``), not a path analysis — it catches "a yield was added without a
+    suspension point", which is the reimport shape, and it cannot prove a
+    suspension is reached on every branch. The behavioural gates above are what
+    say the suspension actually fires; this one says a new site cannot quietly
+    skip having one.
+
+    Non-vacuous: the scan must find the three known drains by name, so a
+    broken scanner reports its own breakage instead of passing empty."""
+    package = Path(transport_pkg.__file__).parent
+    found: "dict[str, tuple[int, int]]" = {}
+    for path in sorted(package.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.AsyncFunctionDef) or node.name != "frames":
+                continue
+            yields = sum(1 for n in ast.walk(node) if isinstance(n, ast.Yield))
+            suspensions = sum(
+                1
+                for n in ast.walk(node)
+                if isinstance(n, ast.Await)
+                and isinstance(n.value, ast.Call)
+                and getattr(n.value.func, "id", getattr(n.value.func, "attr", None))
+                == "suspend_between_frames"
+            )
+            found[f"{path.relative_to(package)}::{node.name}"] = (yields, suspensions)
+
+    known = {"in_process.py::frames", "agui/client.py::frames", "agui/endpoint.py::frames"}
+    assert known <= set(found), (
+        f"the drain scan did not see {sorted(known - set(found))} — it found "
+        f"{sorted(found)}. The scanner is broken (a moved/renamed drain, a parse "
+        "failure), so its silence about the rest means nothing"
+    )
+    unpaired = {
+        site: counts for site, counts in found.items() if counts[1] < counts[0]
+    }
+    assert not unpaired, (
+        f"frame drain(s) yielding without a paired suspension point: {unpaired} "
+        "(site -> (yields, suspensions)). A drain that yields more often than it "
+        "suspends can hand a burst to its consumer with the event loop never "
+        "running in between — see reyn.interfaces.transport.drain"
+    )

--- a/tests/test_stream_drain_yield_3570.py
+++ b/tests/test_stream_drain_yield_3570.py
@@ -134,10 +134,16 @@ async def _build(tmp_path: Path, app_cls=TextualChatApp):
     return registry, transport, app_cls(transport=transport)
 
 
-async def _until(pred, *, attempts: int = 400, delay: float = 0.01) -> bool:
+async def _until(pred, *, attempts: int = 3000, delay: float = 0.01) -> bool:
     """Bounded poll — a hang exhausts the budget and returns False (RED). This is
     the test's own patience, not the property under test (which is counted in
-    frames)."""
+    frames).
+
+    Generous on purpose: under ``-n auto`` the machine may be running ten other
+    workers, and how long a 300-frame backlog takes to drain there is not what
+    this file is measuring. The PROPERTY is counted in frames; this is only the
+    patience that keeps a genuine hang from hanging the suite.
+    """
     for _ in range(attempts):
         if pred():
             return True
@@ -185,7 +191,7 @@ async def test_input_arriving_during_a_stream_is_handled_within_a_few_frames(
                 "the injected input was never handled at all"
             )
             waited = app.probe_handled_at - app.probe_injected_at
-            assert waited < 0, (
+            assert waited < arrivals // 10, (
                 f"input injected at frame {app.probe_injected_at} was only handled "
                 f"{waited} frames later, out of a {arrivals}-frame backlog — the "
                 "drain loop holds the processor for the whole stream"


### PR DESCRIPTION
**[per-PR-coder]** — toward #3570 (1 of 2: the unconditional suspension point; the repaint budget is the sibling PR).

> ⚠️ **Do not merge this one alone.** Measured on the shipped base (textual-flowview **v0.9.0**, `__version__` read directly): this change *by itself* is a 5x throughput regression on a streamed reply, because the suspension it adds converts flowview's accidental "coalesce by starvation" into a real per-delta present. The sibling PR (repaint budget) removes that, and the pair measures better than main on every axis. Numbers below. I was asked to split and land this first; the measurement says the split is safe to *review* separately but not to *merge* separately, so I am reporting rather than deciding.

## The defect

`frames()` awaits `asyncio.Queue.get()` once per frame, which *reads* like a suspension point per frame and is not one: **`get()` returns without suspending whenever the queue is non-empty.** A provider that delivers several deltas per socket read (litellm's stream wrapper yields every chunk a single read carried, and awaiting a coroutine that does not suspend is not a scheduling point) therefore leaves the consumer draining to exhaustion with **zero** returns to the event loop. Nothing else runs for the whole burst — not the animation, not a keystroke, not a timer. That is the owner's report: *"stream中uiかたまってるよ。アニメも止まる"*, recovering the instant the stream ends.

Whether the UI breathed was a function of **queue occupancy** — a timing property — not of the loop's structure.

## The contract this PR closes

> **Input injected while a stream is arriving is handled within a bounded number of frames.**

Bounded **by construction**: one suspension per frame, so the interval between suspensions is one frame's processing, never a function of how much the producer packed into the queue.

**Why N=1 and no time-based arm.** `_frames` is an unbounded `asyncio.Queue`, so any "suspend every N frames" rule leaves the interval proportional to something the producer chooses; at N=1 the interval is a single frame's processing, which is the smallest a non-preemptible consumer can offer — a wall-clock arm could not improve on it and would be dead code. It also leaves the terminal `__end__` check exactly where it was: no batch can straddle the end frame (gated below).

## Measured on the real path, on flowview v0.9.0

Real `AgentRegistry` + real `Session` + real `InProcessTransport` + real `TextualChatApp`. Mixed backlog: two chain_ids interleaved with tool frames on the same ordered queue, 300 frames. A probe posted onto the app's own message pump — the same pump a keystroke rides — at frame 20:

| | injected at frame | handled N frames later |
|---|---|---|
| main | 20 of 300 | **280** (i.e. after the entire backlog) |
| this PR | 20 of 300 | **0** |

### The cost, and why the pair must land together

Same harness, 2000 deltas / 60 KB reply, a 60fps animation task as the co-runner:

| | main | **this PR alone** | this PR + the repaint budget |
|---|---|---|---|
| paced (~1000 deltas/s) wall-clock | 3.17 s | **16.11 s** | 3.29 s |
| paced `present()` calls | 90 | **1908** | 72 |
| paced animation ticks / expected | 106 / 190 | 394 / 966 | 118 / 198 |
| fully buffered burst wall-clock | 0.07 s | **15.28 s** | 0.25 s |
| burst `present()` calls | 3 | **1773** | 2 |
| burst animation ticks / expected | **1 / 4** | 371 / 917 | **13 / 15** |
| input probe (frames) | 280 | 0 | 0 |

Reading: on main the burst case is "fast" only because the loop never runs — 2000 `set_item`s collapse into 3 presents and 1 animation frame, which is the frozen UI. Giving the loop back its turns makes those presents *real* (1773 of them, ~7 ms each), so the reply falls seconds behind the stream. The repaint budget in the sibling PR is what makes the number of presents follow the paint rate instead of the arrival rate; with it, the pair is better than main on wall-clock **and** on animation survival **and** on input latency.

★ The premise was checked before fixing: queue occupancy is **not** 0-1. It is 1 when the producer awaits between every delta, equal to the batch size when one read carries several (5, 20, ...), and the whole reply when the response arrives buffered (2000).

★ `patch_rows` / `Presentation(strips=)` / differential-reflow wiring is **not** done here, and is not proposed: as of 2026-08-01 it is **permission-gated on the owner** (standing instruction, recorded on #3539) — not deferred, not "when convenient", and not unlocked by a measurement. Verified by diff rather than by assertion: `git diff origin/main..` over this branch matches none of `patch_rows` / `Presentation(` / `strips=`. What the numbers above DO include is v0.9.0's internal reflow work reaching the existing `set_item` path on its own, which is why they were all re-taken on it.

## `frames()` implementations — enumerated from the `ClientTransport` ABC, verdict each

| implementation | same defect? | action |
|---|---|---|
| `transport/in_process.py::InProcessTransport.frames` | **yes** — `asyncio.Queue` drain fed by synchronous `put_nowait` callers | fixed |
| `transport/agui/client.py::AgUiTransport.frames` | **yes**, from a different source — one SSE block decodes to *many* frames through an inner `for` loop with no await of its own, and `aiter_lines` over a buffered read does not suspend either | fixed |
| `transport/agui/endpoint.py` surface `frames` (server side, not a `ClientTransport`) | **yes** — same `asyncio.Queue` + `put_nowait` shape; its consumer encodes and serializes each frame, so a burst holds the *server's* loop (other connections, the fail-close driver's timers) | fixed |
| the ~40 `frames()` in `tests/` | n/a — test transports, each with its own await shape | untouched |

## Test plan

- [x] ⚠️ **MERGE GATE — this PR must be merged together with #3575, never alone.** Measured: alone it is a 5x throughput regression on a streamed reply (table above). Do not tick this box by reasoning about it; tick it when both are being merged in the same operation.  — ✅ lead-coder が #3574 → #3575 を連続 merge（下のコメント参照）
- [x] `tests/test_stream_drain_yield_3570.py` — the contract, real path, mixed backlog. The bound is counted in **frames**, never wall-clock (a millisecond deadline is the load-sensitive gate class #3473 just closed); the only wall-clock in the file is the poll's patience against a genuine hang.
- [x] **A witness per site, not per enumeration** (co-vet ①). The three-site enumeration was complete but only `in_process` had a gate — stripping either AG-UI suspension left the suite green, i.e. those two fixes were unwitnessed. Both now have a behavioural gate that drains the REAL implementation and samples a co-running task's progress *inside* the drain:
  - `AgUiTransport` — real wire bytes (`encode_frame` + `to_sse`) through the real transport; strip -> **59 of 59** consecutive frames delivered with the loop running nothing in between (RED).
  - the endpoint's `_SessionFrameSource` — real `Session`, burst emitted through the production chat-event channel; strip -> **59 of 59** (RED).
- [x] **strip-falsify** (`in_process`): removing its suspension -> `input injected at frame 20 was only handled 280 frames later` (RED). Restored -> 0 (GREEN). Re-run on v0.9.0.
- [x] **Class gate, not three hand-fixes** (co-vet ②). The suspension point is now one named helper (`reyn/interfaces/transport/drain.py::suspend_between_frames`) that all three sites call, and an AST gate walks every `async def frames` under `reyn/interfaces/transport` requiring each `yield` to be paired with a call to it — so a FOURTH transport cannot reimport the defect by not knowing about the issue. Non-vacuity: the scan must see the three known drains **by name** (not by count), or it reports its own breakage. Honest limit, stated in the test: it is a pairing count, not a path analysis — it catches "a yield added without a suspension point"; the behavioural gates above are what say the suspension fires.
- [x] Termination gate: `__end__` is still delivered and nothing queued behind it is, with the queue pre-filled past the end — the very non-empty regime that made `get()` stop suspending.
- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict tests/test_stream_drain_yield_3570.py`
- [x] `python scripts/verify_module_docstrings.py` on the three changed src files
- [x] `pytest` full suite from the repo root
- [x] Final measurements re-taken on the tree with textual-flowview **v0.9.0** (#3571 merged; `textual_flowview.__version__` read directly, not inferred from the lockfile)

