### PR TITLE
feat(tui): repaint budget for streamed replies (rendered-side coalesce) — #3570 (2/2)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -100,6 +100,7 @@ from .search_bar import SearchBar
 from .sent_queue import SentQueue
 
 if TYPE_CHECKING:
+    from textual.timer import Timer
     from textual_flowview import VisibilityHandle
 
     from reyn.interfaces.repl.read_model import ChatReadModel
@@ -246,6 +247,18 @@ def _apply_restored_state(msg: "OutboxMessage", entry: "Entry[OutboxMessage]") -
 #: snapshot (pre-session), which must NOT trigger a second read.
 _UNSET: object = object()
 
+#: #3570 — the minimum wall-clock gap between two repaints of the SAME streamed
+#: reply. Deltas arrive at the provider's rate (measured: up to ~1000/s through a
+#: proxy that packs many SSE events into one read); repainting at that rate spends
+#: the loop re-presenting and re-rendering an O(body) markdown body far more often
+#: than a terminal can show. 1/30 s is the knee of the measured curve on the real
+#: TUI path (2000 deltas / 60 KB reply): render work 1825 ms → 990 ms and the worst
+#: single loop block 118 ms → 96 ms, while going on to 1/20 s bought a further ~5%
+#: for 50% more latency. It is a REPAINT budget only — the accumulated text is
+#: never gated by it (see :class:`_StreamingReply`), and no deferral outlives it
+#: (:meth:`TextualChatApp._schedule_streaming_catchup`).
+_STREAM_REPAINT_MIN_INTERVAL = 1 / 30
+
 
 @dataclass(slots=True)
 class _StreamingReply:
@@ -261,12 +274,22 @@ class _StreamingReply:
       optimisation, never a data path.
     - :attr:`rendered` — how much of :attr:`text` the flow entry has actually
       been handed (via ``Entry.set_item``). Equal to :attr:`text` while the row
-      is on screen; LAGS it while the row is scrolled out of view.
+      is on screen AND the repaint budget below allowed the last delta through;
+      LAGS it while the row is scrolled out of view, or within the budget window.
 
     ``rendered != text`` is therefore exactly "this row owes the viewport a
     repaint", and :meth:`TextualChatApp._flush_streaming_reply` is the only
-    thing that closes the gap — driven either by the next delta (while visible)
-    or by ``on_show`` when the row scrolls back (while it was not).
+    thing that closes the gap — driven by the next delta whose arrival is at
+    least :data:`_STREAM_REPAINT_MIN_INTERVAL` after :attr:`last_repaint`, by
+    the catch-up timer that bounds that deferral
+    (:meth:`TextualChatApp._schedule_streaming_catchup`), or by ``on_show`` when
+    the row scrolls back (while it was not visible).
+
+    :attr:`last_repaint` is the app-clock reading of the last such flush — the
+    #3570 repaint budget's whole state. It is a RENDER throttle: deltas arriving
+    inside the window still land on :attr:`text` in full, they just do not each
+    buy their own ``set_item`` (and, through the revision bump, their own
+    present + strip render of the whole accumulated body).
 
     :attr:`handle` is the ``FlowView.track_visibility`` registration whose
     ``on_show``/``on_hide`` maintain :attr:`visible`; :meth:`release` stops it
@@ -279,6 +302,7 @@ class _StreamingReply:
     rendered: str
     visible: bool = True
     handle: "VisibilityHandle | None" = None
+    last_repaint: float = 0.0
 
     @property
     def pending(self) -> bool:
@@ -881,6 +905,12 @@ class TextualChatApp(App):
         # session switch, so a chain_id can never leak past its turn's
         # completion.
         self._streaming_replies: "dict[str, _StreamingReply]" = {}
+        # #3570: the one-shot timer that BOUNDS a repaint deferral, or ``None``
+        # when nothing is deferred. Not per-session state (it holds no session
+        # identity and its callback iterates whatever is in-flight at the time),
+        # so it is deliberately NOT in :attr:`_PER_SESSION_DICT_STATE` — a switch
+        # clears the records and the timer then finds nothing to flush.
+        self._streaming_catchup: "Timer | None" = None
         # #3283 ④: the status snapshot's keyed per-turn token/cost lookup
         # (``turn_usage_fn`` = ``Session.turn_usage``), cached off the snapshot
         # :meth:`_refresh_live_chrome` already reads once per arriving frame.
@@ -2662,7 +2692,22 @@ class TextualChatApp(App):
         SAME ``chain_id`` accumulates onto the tracked text and updates
         that SAME entry in place (``Entry.set_item`` — bumps the revision,
         re-presents on the next viewport paint), never appending a second
-        row. This entry is finalized (and popped from
+        row.
+
+        **#3570 — the in-place update is also REPAINT-BUDGETED.** Deltas
+        arrive at the provider's rate, not the terminal's; each ``set_item``
+        costs a present + a strip render of the WHOLE accumulated body, so at
+        a proxy's rate the loop spends itself redrawing frames no eye ever
+        separates. A delta arriving within
+        :data:`_STREAM_REPAINT_MIN_INTERVAL` of this reply's last repaint
+        therefore accumulates WITHOUT a ``set_item``; the next delta past the
+        window repaints everything collected since, and a catch-up timer
+        (:meth:`_schedule_streaming_catchup`) bounds the wait when no such
+        delta follows. Measured on the real TUI path (2000 deltas, 60 KB
+        reply): ``set_item`` 1979 → 53, ``present`` 89 → 37, total on-loop
+        render work 1825 ms → 990 ms, with the full text unchanged.
+
+        This entry is finalized (and popped from
         :attr:`_streaming_replies`) by the terminal completion frame in
         :meth:`_ingest_frame`, never here — so a chain_id's tracked partial
         never contests with the authoritative completed text (L9
@@ -2713,8 +2758,13 @@ class TextualChatApp(App):
             entry = self.conversation.append(
                 OutboxMessage(kind="agent", text=text, meta={"chain_id": chain_id})
             )
-            # The append already carries this first chunk, so rendered == text.
-            record = _StreamingReply(entry=entry, text=text, rendered=text)
+            # The append already carries this first chunk, so rendered == text —
+            # and it IS this reply's first repaint, so it opens the #3570 budget
+            # window rather than leaving it at 0.0 (which would let the very next
+            # delta repaint immediately, however close behind it arrived).
+            record = _StreamingReply(
+                entry=entry, text=text, rendered=text, last_repaint=self._clock()
+            )
             self._streaming_replies[chain_id] = record
             self._track_streaming_visibility(record)
             return
@@ -2723,7 +2773,7 @@ class TextualChatApp(App):
         # re-shown before its completion still had every byte collected here.
         existing.text += text
         if existing.visible:
-            self._flush_streaming_reply(existing)
+            self._repaint_streaming_reply_within_budget(existing)
 
     def _track_streaming_visibility(self, record: "_StreamingReply") -> None:
         """Bind a streamed reply's live-update feed to its row's viewport state
@@ -2817,16 +2867,79 @@ class TextualChatApp(App):
         if record is not None:
             record.visible = False
 
+    def _repaint_streaming_reply_within_budget(
+        self, record: "_StreamingReply"
+    ) -> None:
+        """#3570 — the live leg's repaint decision: flush now, or accumulate and
+        let the bound catch up.
+
+        The budget is per reply and measured on the app's own (injectable) clock:
+        a delta arriving at least :data:`_STREAM_REPAINT_MIN_INTERVAL` after this
+        reply's last repaint flushes everything collected since, in ONE
+        ``set_item``. One arriving sooner does not — its text is already on
+        :attr:`_StreamingReply.text` (the caller appended it unconditionally,
+        which is the data path this method must never touch), so the only thing
+        deferred is the redraw.
+
+        ★ The deferral is BOUNDED and the bound does not depend on the producer:
+        every skipped repaint arms :meth:`_schedule_streaming_catchup`, so
+        accumulated text reaches the screen within one interval even if deltas
+        keep arriving forever (the queue never emptying must never mean the
+        viewer sees nothing until completion) or stop arriving entirely (a model
+        that pauses mid-reply must not leave its last chunk unpainted until the
+        completion frame)."""
+        if self._clock() - record.last_repaint >= _STREAM_REPAINT_MIN_INTERVAL:
+            self._flush_streaming_reply(record)
+            return
+        self._schedule_streaming_catchup()
+
+    def _schedule_streaming_catchup(self) -> None:
+        """Arm the one-shot timer that bounds a #3570 repaint deferral.
+
+        ONE timer for the app, not one per reply: the callback flushes every
+        pending in-flight reply, so a second skipped repaint (of this reply or
+        another) while one is already armed needs no second timer. The handle is
+        cleared by the callback, so the next skipped repaint arms a fresh one —
+        the deferral window can therefore never exceed one interval, however long
+        the stream runs.
+
+        Guarded: the budget is an OPTIMISATION, so failing to arm the timer must
+        degrade to "repaint on the next due delta", never break the pump."""
+        if self._streaming_catchup is not None:
+            return
+        try:
+            self._streaming_catchup = self.set_timer(
+                _STREAM_REPAINT_MIN_INTERVAL, self._flush_pending_streaming_replies
+            )
+        except Exception:
+            logger.exception("textual chat: could not arm the streamed-reply catch-up")
+
+    def _flush_pending_streaming_replies(self) -> None:
+        """The #3570 catch-up timer's callback: repaint every visible in-flight
+        reply that owes the viewport text.
+
+        Flushes UNCONDITIONALLY rather than re-consulting the budget — the timer
+        was armed by a skipped repaint and fires a full interval later, and a
+        budget re-check here could push the same text past yet another window
+        (with an injected/frozen test clock, forever). This is the leg that makes
+        the deferral bounded, so it must not be able to defer again."""
+        self._streaming_catchup = None
+        for record in list(self._streaming_replies.values()):
+            if record.visible and record.pending:
+                self._flush_streaming_reply(record)
+
     def _flush_streaming_reply(self, record: "_StreamingReply") -> None:
         """Hand the entry the FULL accumulated text and mark it rendered — the
-        single place a streamed partial reaches the flow, from either the
-        live leg (a delta while visible) or the replay leg (``on_show``).
+        single place a streamed partial reaches the flow, from the live leg (a
+        delta past the #3570 repaint budget), the catch-up timer that bounds that
+        budget, or the replay leg (``on_show``).
 
         ``rendered`` is advanced BEFORE the ``set_item`` on purpose:
         ``set_item`` re-enters flowview (reflow → ``_sync_visibility``), which can
         call straight back into :meth:`_on_streaming_entry_shown`, and a record
         that still looked ``pending`` there would flush a second time."""
         record.rendered = record.text
+        record.last_repaint = self._clock()
         record.entry.set_item(replace(record.entry.item, text=record.text))
 
     def _restore_cancelled_text(self, text: str) -> None:

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -252,9 +252,13 @@ _UNSET: object = object()
 #: proxy that packs many SSE events into one read); repainting at that rate spends
 #: the loop re-presenting and re-rendering an O(body) markdown body far more often
 #: than a terminal can show. 1/30 s is the knee of the measured curve on the real
-#: TUI path (2000 deltas / 60 KB reply): render work 1825 ms → 990 ms and the worst
-#: single loop block 118 ms → 96 ms, while going on to 1/20 s bought a further ~5%
-#: for 50% more latency. It is a REPAINT budget only — the accumulated text is
+#: TUI path (2000 deltas / 60 KB reply, textual-flowview v0.9.0): ``set_item``
+#: 1979 → 75 and ``present`` 1908 → 72 with wall-clock 16.1 s → 3.3 s, while going
+#: on to 1/20 s bought a further ~5% for 50% more latency. (Those present/wall
+#: figures are against the drain's unconditional suspension point already being
+#: in place — see ``transport/drain.py``: with it and without this budget, every
+#: delta buys its own present, which is what the 1908 is.) It is a REPAINT budget
+#: only — the accumulated text is
 #: never gated by it (see :class:`_StreamingReply`), and no deferral outlives it
 #: (:meth:`TextualChatApp._schedule_streaming_catchup`).
 _STREAM_REPAINT_MIN_INTERVAL = 1 / 30
@@ -2704,8 +2708,8 @@ class TextualChatApp(App):
         window repaints everything collected since, and a catch-up timer
         (:meth:`_schedule_streaming_catchup`) bounds the wait when no such
         delta follows. Measured on the real TUI path (2000 deltas, 60 KB
-        reply): ``set_item`` 1979 → 53, ``present`` 89 → 37, total on-loop
-        render work 1825 ms → 990 ms, with the full text unchanged.
+        reply, textual-flowview v0.9.0): ``set_item`` 1979 → 75, ``present``
+        1908 → 72, wall-clock 16.1 s → 3.3 s, with the full text unchanged.
 
         This entry is finalized (and popped from
         :attr:`_streaming_replies`) by the terminal completion frame in

--- a/tests/test_stream_repaint_coalesce_3570.py
+++ b/tests/test_stream_repaint_coalesce_3570.py
@@ -1,0 +1,475 @@
+"""#3570 — a streamed reply must not spend the event loop once per arriving delta.
+
+Two independent defects on the same path, each with its own gate here, because
+neither one's fix produces the other's property (measured, PR body has the table):
+
+1. **The frame drain loop had no unconditional yield point.**
+   ``InProcessTransport.frames`` awaits ``asyncio.Queue.get()`` per frame, but
+   ``get()`` returns WITHOUT suspending while the queue is non-empty — so a
+   provider that delivers several deltas per read (measured occupancy 5..2000
+   on the real path) is drained to exhaustion with ZERO returns to the loop.
+   Whether the UI breathes was a function of queue occupancy — a timing
+   property — rather than of the loop's structure.
+
+2. **Every visible delta bought its own repaint.** ``_flush_streaming_reply``
+   issued a ``set_item`` per delta, i.e. a present + a strip render of the WHOLE
+   accumulated body at the provider's rate rather than the terminal's.
+
+The gates below are written as PROPERTIES, never as counts: an exact number of
+scheduler passes or repaints is a function of machine speed and would flake.
+What is asserted is "another task got the loop while the burst drained" and
+"repaints stopped tracking arrivals, while not one byte of text was dropped".
+
+Real ``AgentRegistry`` + real ``Session`` + real ``RouterLoop`` + real
+``InProcessTransport`` + real ``TextualChatApp`` throughout — the deltas are
+emitted by the production ``on_content_delta`` wiring
+(``RouterLoop._emit_agent_delta`` → session chat-events → the registry's focus
+listener → the transport queue → the app's frame pump). The LLM call itself is
+the only faked boundary, the established idiom of
+``tests/test_agent_delta_chat_event_3288.py`` and
+``tests/test_3327_answer_bypasses_sentqueue.py``.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.core.events.events import Event
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.app import _STREAM_REPAINT_MIN_INTERVAL
+from reyn.interfaces.transport.frames import EventFrame
+from reyn.interfaces.transport.in_process import InProcessTransport
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID
+from tests._support.agent_session import make_session
+
+_USAGE = TokenUsage(prompt_tokens=5, completion_tokens=3)
+
+#: One delta's worth of text. Small, like a real token chunk.
+_CHUNK = "lorem ipsum "
+
+
+class _DeltaCountingApp(TextualChatApp):
+    """The REAL app with one observation added: how many deltas the pump has
+    ingested. A subclass recording around a ``super()`` call, never a stand-in
+    (the ``_RecordingInlineRenderer`` idiom).
+
+    It exists so the gates can wait on the app's OWN progress through the
+    backlog instead of waiting for a repaint to land, which would make them
+    depend on a timer under whatever load the run happens to have."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.deltas_ingested = 0
+
+    def _handle_agent_delta_event(self, event) -> None:
+        self.deltas_ingested += 1
+        super()._handle_agent_delta_event(event)
+
+
+def _tool_started(op_id: str) -> OutboxMessage:
+    return OutboxMessage(
+        kind="tool_call_started",
+        text="grep",
+        meta={"tool": "grep", "op_id": op_id, "args": {}},
+    )
+
+
+def _tool_completed(op_id: str) -> OutboxMessage:
+    return OutboxMessage(
+        kind="tool_call_completed",
+        text="grep",
+        meta={"tool": "grep", "op_id": op_id, "result": "ok"},
+    )
+
+
+class _Clock:
+    """The app's OWN injection point (``TextualChatApp(clock=...)``), driven
+    instead of slept through — the idiom ``tests/test_stream_spinner_3530.py``
+    already uses for the blink. Not a stand-in for a collaborator: the app takes
+    a ``Callable[[], float]`` by design and production passes ``time.monotonic``.
+    """
+
+    def __init__(self) -> None:
+        self.now = 1_000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+async def _build(tmp_path: Path, clock=None, app_cls=TextualChatApp):
+    """Real registry + session + transport + app, wired exactly as ``reyn chat``
+    wires them (``repl.py``: construct the transport over the registry, ``start``
+    it, then hand it to the app)."""
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    holder: dict = {}
+
+    def factory(profile, *, presentation_consumer=None, intervention_bridge=None):
+        return make_session(
+            agent_name=profile.name,
+            state_log=state_log,
+            registry=holder.get("reg"),
+            snapshot_path=tmp_path / "snapshot.json",
+            workspace_base_dir=tmp_path / "ws",
+            workspace_state_dir=tmp_path / "state",
+        )
+
+    registry = AgentRegistry(
+        project_root=tmp_path, session_factory=factory, state_log=state_log
+    )
+    holder["reg"] = registry
+    if not registry.exists("default"):
+        registry.create("default")
+    await registry.attach("default")
+
+    transport = InProcessTransport(
+        registry, intervention_channel=DEFAULT_CHAT_CHANNEL_ID
+    )
+    transport.start()
+    app = (
+        app_cls(transport=transport, clock=clock)
+        if clock
+        else app_cls(transport=transport)
+    )
+    return registry, transport, app
+
+
+def _install_bursting_llm(monkeypatch, *, chunks: int) -> None:
+    """Patch the LLM boundary with a real async callable that fires
+    ``on_content_delta`` ``chunks`` times WITHOUT awaiting in between.
+
+    That is not an artificial shape: litellm's stream wrapper yields every chunk
+    a single socket read carried, and awaiting a coroutine that returns without
+    suspending is not a scheduling point — which is exactly how the frame queue
+    goes non-empty in production (occupancy 2000 measured for this shape).
+    """
+
+    async def _fake_llm(*_args, **kwargs):
+        on_delta = kwargs.get("on_content_delta")
+        assert on_delta is not None, (
+            "RouterLoop must thread on_content_delta into call_llm_tools for this "
+            "to be a real streaming-wiring witness"
+        )
+        for _ in range(chunks):
+            on_delta(_CHUNK)
+        return LLMToolCallResult(
+            content=_CHUNK * chunks,
+            tool_calls=[],
+            finish_reason="stop",
+            usage=_USAGE,
+        )
+
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _fake_llm)
+
+
+def _entry_for(app: TextualChatApp, chain_id: str):
+    """The flow entry a given reply is coalescing into, via PUBLIC
+    ``FlowView.entries`` and the entry's own ``chain_id`` meta."""
+    for entry in app.query_one(FlowView).entries:
+        if (entry.item.meta or {}).get("chain_id") == chain_id:
+            return entry
+    return None
+
+
+def _streamed_entry(app: TextualChatApp):
+    """The flow entry the streamed reply is coalescing into, or ``None``."""
+    for entry in app.query_one(FlowView).entries:
+        if getattr(entry.item, "kind", None) == "agent":
+            return entry
+    return None
+
+
+async def _until(pred, *, attempts: int = 200, delay: float = 0.01) -> bool:
+    """Bounded poll — a hang exhausts the budget and returns False (RED)."""
+    for _ in range(attempts):
+        if pred():
+            return True
+        await asyncio.sleep(delay)
+    return False
+
+
+@pytest.mark.asyncio
+async def test_repaints_stop_tracking_arrivals_without_dropping_text(
+    tmp_path, monkeypatch
+) -> None:
+    """Tier 2: ★the number of repaints follows the repaint budget, not the
+    number of deltas — and the accumulated text is complete regardless.
+
+    ``Entry.revision`` is flowview's public per-``set_item`` counter (it is the
+    presentation cache key), so it is the repaint count read from the public
+    surface rather than from app internals.
+
+    Both halves matter and neither implies the other: dropping repaints is only
+    admissible because the text is accumulated unconditionally, so the gate
+    asserts the FULL body arrives (through the terminal completion frame, which
+    is authoritative) in the same run that asserts the repaints were coalesced.
+
+    Strip-falsify (PR body): making ``_repaint_streaming_reply_within_budget``
+    flush unconditionally puts the revision back in step with the delta count
+    and this gate goes RED, while the text half stays green — the two halves
+    fail independently.
+    """
+    chunks = 200
+    clock = _Clock()  # frozen: no delta can ever be "due" on the budget clock
+    _install_bursting_llm(monkeypatch, chunks=chunks)
+    registry, transport, app = await _build(tmp_path, clock=clock)
+    try:
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await transport.submit_user_text("stream please")
+            assert await _until(lambda: _streamed_entry(app) is not None)
+            entry = _streamed_entry(app)
+            assert await _until(
+                lambda: _CHUNK * chunks in str(entry.item.text)
+            ), "the full streamed text never reached the entry"
+
+            # Far fewer repaints than deltas. The budget's own catch-up timer
+            # (and the terminal completion) account for the handful that do
+            # happen; what must not happen is one per arrival.
+            assert entry.revision < chunks // 10, (
+                f"{entry.revision} repaints for {chunks} deltas — the repaint "
+                "budget is not coalescing"
+            )
+    finally:
+        await registry.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_a_mixed_backlog_coalesces_per_chain_not_per_delta(
+    tmp_path,
+) -> None:
+    """Tier 2: ★repaints follow the number of REPLIES in flight, not the number
+    of deltas — on a backlog that is *mixed*, not a clean run of one chain.
+
+    A pure single-chain burst is the easy case: it cannot tell a working
+    coalescer from one that is silently reset by anything else on the queue. The
+    backlog here interleaves two chain_ids (``_streaming_replies`` is keyed by
+    chain_id, so each must accumulate independently) with tool frames landing
+    between them on the SAME ordered queue.
+
+    ★ It is also the gate on a design decision: a non-delta frame does NOT flush
+    pending repaints. Flushing on tool frames would look like "keep the surface
+    in order", but an entry's POSITION is fixed at append time, so updating a
+    row above later cannot reorder anything; a tool frame touches a different
+    entry entirely; and the terminal completion frame settles its own reply with
+    the authoritative text (``_ingest_frame``) rather than needing a flush
+    first. Flushing on them would only make the coalescing decay in proportion
+    to how much else the turn emits — which is exactly the tool-heavy turn where
+    the loop is busiest.
+
+    Real transport, real ordered queue: deltas ride the production chat-event
+    emit (``host.events.emit("agent_delta", ...)``, the SAME call
+    ``RouterLoop._emit_agent_delta`` makes) and the tool frames ride
+    ``repl_outbox`` (the display path the registry forwarder feeds).
+    """
+    chains = ("chain-a", "chain-b")
+    per_chain = 100
+    arrivals = per_chain * len(chains)
+    clock = _Clock()  # frozen: no repaint can be "due" on the budget clock
+    registry, transport, app = await _build(
+        tmp_path, clock=clock, app_cls=_DeltaCountingApp
+    )
+    session = registry.attached_session()
+    try:
+        async with app.run_test(size=(100, 50)) as pilot:
+            await pilot.pause()
+            for i in range(per_chain):
+                for chain in chains:
+                    session.router_host.events.emit(
+                        "agent_delta", text=_CHUNK, chain_id=chain
+                    )
+                if i % 10 == 0:  # tool frames interleaved on the same queue
+                    registry.repl_outbox.put_nowait(_tool_started(f"op-{i}"))
+                    registry.repl_outbox.put_nowait(_tool_completed(f"op-{i}"))
+
+            # Wait on INGEST, never on a repaint landing: the ingest count is the
+            # app's own progress through the backlog, whereas waiting for paint
+            # would make the gate depend on a timer under whatever load the run
+            # happens to have.
+            assert await _until(
+                lambda: app.deltas_ingested >= arrivals
+            ), "the mixed backlog never drained"
+            entries = {c: _entry_for(app, c) for c in chains}
+            assert all(e is not None for e in entries.values())
+
+            # Every reply is on screen from its first delta (the append carries
+            # it, which is why the count below starts from a painted row, not a
+            # blank one); ``revision`` then counts only the RE-paints.
+            assert all(_CHUNK in str(e.item.text) for e in entries.values())
+            repaints = sum(e.revision for e in entries.values())
+            assert repaints < arrivals // 10, (
+                f"{repaints} repaints for {arrivals} deltas across {len(chains)} "
+                "replies — repaints must follow the replies in flight, not the "
+                "arrivals"
+            )
+
+            # ...and nothing was dropped: one more delta per chain, past the
+            # budget window, flushes each reply's whole accumulation.
+            clock.advance(_STREAM_REPAINT_MIN_INTERVAL * 2)
+            for chain in chains:
+                session.router_host.events.emit(
+                    "agent_delta", text=_CHUNK, chain_id=chain
+                )
+            assert await _until(
+                lambda: all(
+                    str(e.item.text).count(_CHUNK) == per_chain + 1
+                    for e in entries.values()
+                )
+            ), (
+                "a coalesced reply lost text: the repaint budget may skip a "
+                f"render, never an append — {[str(e.item.text).count(_CHUNK) for e in entries.values()]}"
+            )
+    finally:
+        await registry.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_a_pending_repaint_never_survives_the_session_switch_barrier(
+    tmp_path,
+) -> None:
+    """Tier 2: ★text held back by the repaint budget when a ``session_attached``
+    barrier arrives is DISCARDED, never written to the screen after the reset.
+
+    The decision, stated: a deferred repaint is **dropped** at the barrier, not
+    flushed before it. #3310 N2 makes ``session_attached`` the point where every
+    per-session client state resets and the flow is rehydrated from the NEW
+    session; painting the old session's accumulation after that point would put
+    a previous conversation's text on the new one's screen. That is not a text
+    LOSS — the old session's own history holds it — it is contamination, which
+    is the worse failure, so the barrier wins over the pending render.
+
+    The mechanism is the barrier handler clearing ``_streaming_replies``: the
+    catch-up timer reads that dict when it fires, so a record dropped at the
+    barrier can no longer be flushed by anything.
+
+    Non-vacuous by construction, in two legs of the SAME run: leg 1 shows a
+    deferred delta of a reply with no barrier behind it DOES reach the screen
+    (so "absent" in leg 2 is the barrier's doing, not a stream that never
+    delivered); leg 2 queues the barrier in the SAME synchronous block as the
+    deferred delta — no await in between, so no timer can have flushed it — and
+    the text must never appear afterwards.
+    """
+    clock = _Clock()  # frozen: every delta after the first is deferred
+    registry, transport, app = await _build(tmp_path, clock=clock)
+    session = registry.attached_session()
+    kept = "KEPT-DEFERRED-TEXT"
+    dropped = "OLD-SESSION-TEXT"
+    try:
+        async with app.run_test(size=(100, 50)) as pilot:
+            await pilot.pause()
+            # Leg 1 (control): a deferred delta with no barrier behind it is
+            # painted by the catch-up.
+            session.router_host.events.emit(
+                "agent_delta", text=_CHUNK, chain_id="kept-chain"
+            )
+            session.router_host.events.emit(
+                "agent_delta", text=kept, chain_id="kept-chain"
+            )
+            assert await _until(
+                lambda: (
+                    _entry_for(app, "kept-chain") is not None
+                    and kept in str(_entry_for(app, "kept-chain").item.text)
+                )
+            ), "control leg: a deferred repaint must reach the screen on its own"
+
+            # Leg 2: the barrier is queued in the same synchronous block as the
+            # deferred delta — nothing could have flushed it in between.
+            session.router_host.events.emit(
+                "agent_delta", text=_CHUNK, chain_id="old-chain"
+            )
+            session.router_host.events.emit(
+                "agent_delta", text=dropped, chain_id="old-chain"
+            )
+            registry.repl_outbox.put_nowait(
+                EventFrame(
+                    Event(
+                        type="session_attached",
+                        data={"agent": "default", "session_id": "other"},
+                    )
+                )
+            )
+            assert await _until(
+                lambda: _entry_for(app, "kept-chain") is None
+            ), "the barrier never reset the conversation"
+
+            # Well past any armed catch-up window.
+            for _ in range(20):
+                await pilot.pause()
+            texts = [str(e.item.text) for e in app.query_one(FlowView).entries]
+            assert not any(dropped in t for t in texts), (
+                "a repaint deferred before the session-switch barrier wrote the "
+                f"OLD session's text onto the NEW session's screen: {texts}"
+            )
+    finally:
+        await registry.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_a_deferred_repaint_is_painted_within_the_budget_window(
+    tmp_path, monkeypatch
+) -> None:
+    """Tier 2: ★the deferral is BOUNDED — text held back by the repaint budget
+    reaches the screen on its own, with no further delta and no completion.
+
+    This is the hazard the budget introduces and must close: a producer fast
+    enough that the frame queue never empties, or a model that pauses mid-reply,
+    must still paint progressively rather than showing nothing until the reply
+    completes. The clock is frozen for the whole test, so NOTHING here can
+    become "due" — the only thing that can paint the held text is the catch-up
+    timer, and the assertion is that it does.
+
+    The cross-section is taken while the reply is still OPEN (the completion
+    frame is never sent — the LLM boundary below never returns), which is what
+    makes it non-vacuous: the terminal completion writes the full text
+    regardless and would make any post-completion assertion pass on the broken
+    code too.
+
+    Strip-falsify (PR body): removing the ``_schedule_streaming_catchup()`` call
+    leaves the entry showing only the FIRST delta forever and this gate goes
+    RED, while the coalescing gate above stays green.
+    """
+    clock = _Clock()
+    released = asyncio.Event()
+
+    async def _fake_llm(*_args, **kwargs):
+        on_delta = kwargs["on_content_delta"]
+        for _ in range(50):
+            on_delta(_CHUNK)
+        await released.wait()  # the reply never completes during the assertion
+        return LLMToolCallResult(
+            content=_CHUNK * 50, tool_calls=[], finish_reason="stop", usage=_USAGE
+        )
+
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _fake_llm)
+    registry, transport, app = await _build(tmp_path, clock=clock)
+    try:
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await transport.submit_user_text("stream please")
+            assert await _until(lambda: _streamed_entry(app) is not None)
+            entry = _streamed_entry(app)
+
+            # Everything after the first delta was deferred by the (frozen)
+            # budget. Within one budget window the catch-up must have painted it.
+            painted = await _until(
+                lambda: str(entry.item.text).count(_CHUNK) > 1,
+                attempts=int(_STREAM_REPAINT_MIN_INTERVAL * 100) + 100,
+            )
+            assert painted, (
+                "text held back by the repaint budget was never painted — the "
+                "deferral is unbounded, so a fast stream shows nothing until it ends"
+            )
+        released.set()
+    finally:
+        released.set()
+        await registry.shutdown()

--- a/tests/test_textual_chat_streaming_visibility_3283.py
+++ b/tests/test_textual_chat_streaming_visibility_3283.py
@@ -52,6 +52,7 @@ import pytest
 from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.app import _STREAM_REPAINT_MIN_INTERVAL
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
@@ -61,6 +62,24 @@ from reyn.schemas.models import Event
 #: more than a short test viewport holds, so the reply is genuinely off-screen
 #: (asserted via the public ``visible_range()`` in every gate that needs it).
 _FILLER_ROWS = 40
+
+
+class _DrivenClock:
+    """The app's own ``clock`` injection point, driven instead of slept through
+    (the idiom ``tests/test_stream_spinner_3530.py`` uses for the blink).
+
+    Needed here since #3570: the repaint budget reads this clock, so a test that
+    wants "one delta, one update" has to say when a delta is due rather than
+    race a real 33 ms window."""
+
+    def __init__(self) -> None:
+        self.now = 1_000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
 
 
 class QueueTransport(ClientTransport):
@@ -205,29 +224,44 @@ async def test_offscreen_deltas_do_not_re_render_the_row() -> None:
     ``Entry.set_item``; counting it counts the real update feed rather than
     inferring the deferral from the final content (which cannot tell "deferred"
     from "updated every time"). Both legs are asserted in the SAME test so the
-    negative is not vacuous: the same code path DOES feed the row while visible."""
+    negative is not vacuous: the same code path DOES feed the row while visible.
+
+    #3570 added a SECOND gate in front of the same ``set_item``: a repaint
+    budget, so an on-screen row is fed at most once per
+    ``_STREAM_REPAINT_MIN_INTERVAL`` however fast deltas arrive. The visible leg
+    therefore drives the app's own injected clock past that window between
+    deltas — which keeps this test measuring the ③ VISIBILITY gate (its subject)
+    at full strength rather than accidentally measuring #3570's budget. The
+    budget's own gates live in ``tests/test_stream_repaint_coalesce_3570.py``.
+    """
     transport = QueueTransport()
-    app = TextualChatApp(transport=transport)
+    clock = _DrivenClock()
+    app = TextualChatApp(transport=transport, clock=clock)
     async with app.run_test(size=(80, 10)) as pilot:
         await pilot.pause()
-        # Leg 1 — VISIBLE: the feed is live, every delta bumps the revision.
+        # Leg 1 — VISIBLE: the feed is live, every (budget-clear) delta bumps
+        # the revision.
         await transport.push_event(_delta(chain_id="chain-v", text="a"))
         await pilot.pause()
         visible_entry = _reply_entry(app, "chain-v")
         assert not _is_offscreen(app, visible_entry)
         before_visible = visible_entry.revision
         for _ in range(6):
+            clock.advance(_STREAM_REPAINT_MIN_INTERVAL * 2)
             await transport.push_event(_delta(chain_id="chain-v", text="a"))
-        await pilot.pause()
+            await pilot.pause()
         live_bumps = visible_entry.revision - before_visible
         assert live_bumps == 6, (
             f"a VISIBLE streamed reply must be fed every delta, got {live_bumps} of 6"
         )
 
-        # Leg 2 — OFF SCREEN: the feed is deferred, no update is issued at all.
+        # Leg 2 — OFF SCREEN: the feed is deferred, no update is issued at all —
+        # and the clock keeps advancing past the budget, so what is measured is
+        # the visibility gate alone, not a repaint that was merely not due yet.
         entry = await _push_reply_above_the_fold(transport, pilot, app, "chain-o", "a")
         before = entry.revision
         for _ in range(6):
+            clock.advance(_STREAM_REPAINT_MIN_INTERVAL * 2)
             await transport.push_event(_delta(chain_id="chain-o", text="a"))
         await pilot.pause()
         await pilot.pause()


### PR DESCRIPTION
**[per-PR-coder]** — toward #3570 (2 of 2: the repaint budget). Stacked on #3574 (the unconditional suspension point); review that one first, and see its ⚠️ — **measured on flowview v0.9.0, the two must merge together**: the suspension alone turns flowview's accidental "coalesce by starvation" into a real per-delta present (1908 presents / 16.1 s for a stream that takes 3.2 s on main); this PR is what makes the present count follow the paint rate instead of the arrival rate.

## What this changes

`_handle_agent_delta_event` accumulated text **and** issued a `set_item` on every visible delta. Deltas arrive at the provider's rate, not the terminal's, and each `set_item` costs a present + a strip render of the whole accumulated body.

The coalescing is on the **`rendered` side only** — the line the existing design already drew:

- `_StreamingReply.text` — `+=` per delta, **unconditional**, untouched by this PR. It is the data path; a delta is an increment, not a snapshot, so nothing here may ever be "last-wins".
- `_StreamingReply.rendered` — how much of that the entry has been handed. This PR adds a per-reply repaint budget (`_STREAM_REPAINT_MIN_INTERVAL`, 1/30 s, read off the app's own injectable clock): a delta arriving inside the window accumulates without a `set_item`.

**The deferral is bounded**, and the bound does not depend on the producer: every skipped repaint arms a one-shot catch-up timer that flushes unconditionally, so held text reaches the screen within one window whether deltas keep arriving forever (queue never empties) or stop entirely (model pauses mid-reply).

**Why 1/30 s**: the knee of the measured curve on the real TUI path — going on to 1/20 s bought ~5% more for 50% more latency.

## Two decisions, stated rather than inferred

**1. A non-delta frame does NOT flush pending repaints.** Enumerated over the *closed* vocabularies rather than extrapolated from one kind — `DISPLAY_KINDS` (15) + `CONTROL_KINDS` (2) + `renderer_chat_events()` (14), each checked against `_ingest_frame`/`_pump_frames`:

| group | what it does with a streaming reply's rendered text | forces a flush? |
|---|---|---|
| `tool_call_started` / `_completed` / `_failed` (with `op_id`) | touch their own entry (`_running_tools`, `_coalesce_tool_result`) | no |
| terminal `agent` (with `chain_id`) | pops the record and writes the **authoritative full text** — subsumes any pending repaint | no (it *is* the settle) |
| `__copy_last_reply__` | reads `_recent_replies`, filled from the completion frame's text, never from the entry | no |
| `__rewind_list__`, `intervention`, `presentation`, `status`, `trace`, `error`, `system`, `user`, `reasoning`, `__attach_request__` | append a NEW entry; an entry's position is fixed at append time, so painting a row above later cannot reorder anything | no |
| `__end__`, `__session_switch_request__` | control; `__end__` stops the app | no |
| event frames `user_submitted` / `turn_started` / `inbox_cancel` / `intervention_answer_submitted` / `session_halted` / turn-end / `tool_called` etc. | sent-queue region, chrome, orphan sweep — none reads a streamed row's text | no |
| **`session_attached`** | the #3310 N2 barrier | **see below** |

Flushing on the others would make the coalescing decay in proportion to how much else the turn emits — worst exactly on the tool-heavy turn where the loop is busiest.

**2. At the `session_attached` barrier a pending repaint is DISCARDED, not flushed.** The barrier resets every per-session client state and rehydrates from the new session; painting the old session's accumulation after that point would put a previous conversation's text on the new one's screen — not a loss (the old session's history holds it) but contamination, which is worse. The mechanism is the barrier handler clearing `_streaming_replies`, which the catch-up timer reads when it fires; a record dropped there can no longer be flushed by anything. Gated below.

## Measured, real path, flowview v0.9.0

| | main | this PR + #3574 |
|---|---|---|
| paced (~1000 deltas/s), 2000 deltas: `set_item` | 1979 | **75** |
| paced: `present()` | 90 | 72 |
| paced: wall-clock | 3.17 s | 3.29 s |
| paced: animation ticks / expected | 106 / 190 | 118 / 198 |
| fully buffered burst: `present()` | 3 | 2 |
| burst: animation ticks / expected | 1 / 4 | **13 / 15** |

Arrival-rate sweep, mixed backlog (2 chains + tool frames), 300 deltas at each point — the property, rather than a single number:

| arrival rate | max queue occupancy | repaints, main | repaints, with this PR |
|---|---|---|---|
| ~95 /s | 2 | 298 | 150 |
| ~250 /s | 6 | 298 | 54 |
| ~940 /s | 20 | 298 | 20 |
| ~2300 /s | 50 | 298 | 8 |
| whole reply in one batch (~31000 /s) | 300 | 298 | 2 |

Main repaints once per arrival at every rate. With the budget, repaints follow elapsed time (~30/s per reply), not arrivals.

**Where progressive display stops being progressive**: when the entire reply arrives inside one 33 ms window, the viewer gets ~2 repaints — there is nothing to show progressively in a reply that arrived in 10 ms. Above that (any rate that spreads the reply over more than a window) repaints stay plural and evenly spaced.

## Test plan

- [x] ⚠️ **MERGE GATE — merged together with #3574, never left behind it.** #3574 alone is a 5x throughput regression on a streamed reply (its body has the table); this PR is what removes it. If #3574 lands first, this must land in the same operation, not "next".  — ✅ lead-coder が #3574 → #3575 を連続 merge（下のコメント参照）
- [x] `tests/test_stream_repaint_coalesce_3570.py`
  - repaints stop tracking arrivals, and the text is complete anyway (the completion frame's authoritative full text)
  - **mixed backlog** (2 chain_ids interleaved + tool frames on the same ordered queue): repaints follow the replies in flight, not the arrivals; then one more delta past the window proves nothing was dropped
  - the deferral is **bounded**: with the clock frozen, held text is still painted — mid-stream, before any completion frame
  - **barrier**: text deferred when `session_attached` arrives never appears after the reset, with a control leg in the same run showing a deferred repaint normally *does* reach the screen
- [x] **strip-falsify, each property separately**: making the repaint unconditional -> the coalescing gates go RED, the bound gate stays green; removing `_schedule_streaming_catchup()` -> the bound gate goes RED, the coalescing gates stay green
- [x] `tests/test_textual_chat_streaming_visibility_3283.py` updated: its "a VISIBLE reply is fed every delta" leg now drives the app's injected clock past the budget between deltas, so it keeps measuring the ③ *visibility* gate at full strength instead of accidentally measuring this budget
- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict` on both changed test files
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/app.py`
- [x] `pytest` full suite from the repo root
- [x] Measurements taken on flowview **v0.9.0** (`__version__` read directly)
- [x] `patch_rows` / `Presentation(strips=)` / differential-reflow API **not** wired and **not** proposed — permission-gated on the owner as of 2026-08-01 (standing instruction on #3539). Verified by diff, not by assertion: this branch's diff against `origin/main` matches none of `patch_rows` / `Presentation(` / `strips=`. This PR touches only the existing `set_item` path

