### PR TITLE
test(conftest): reset rich's process-global Style SGR memo between tests — #3572

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -283,6 +283,70 @@ def _isolate_budget_limit_context():
     from reyn.llm.llm import _llm_call_limit_context_var
     _llm_call_limit_context_var.set(None)
 
+
+@pytest.fixture(autouse=True)
+def _isolate_rich_style_ansi_memo():
+    """Reset rich's process-global rendered-SGR memo after every test (#3572).
+
+    ``Style._make_ansi_codes`` caches a Style's rendered escape in
+    ``self._ansi`` and never keys that cache by ``color_system`` (measured on
+    rich 15.0.0 — a bug in rich, deliberately NOT reported upstream, see
+    ``tests/test_markdown_palette_gate_3469.py``'s ``_memo_cleared_theme`` for
+    the owner decision and the runnable "is it still there?" snippet). Because
+    ``Style.parse`` is ``lru_cache``d and ``rich.default_styles.DEFAULT_STYLES``
+    is a module global, those Style instances are shared by every test in the
+    pytest process: whichever console renders a given style string FIRST bakes
+    its colour system into the shared instance, and every later console —
+    whatever colour system IT asked for — re-emits that escape verbatim.
+
+    What makes this bite in CI and not on a developer's machine is the colour
+    system reyn's own renderers get. ``RichChatRenderer`` / ``InlineChatRenderer``
+    construct ``Console(force_terminal=True, ...)`` with colour detection left to
+    rich, which is correct for production. Under CI's environment (no ``TERM``,
+    no ``COLORTERM``) that detects **standard**, so any of the ~15 test files
+    that drive those renderers memoizes ``_CC_DIM`` (``#6b7280``) as
+    bright-black ``'90'``; a later test that explicitly asks for truecolor then
+    measures ``'\\x1b[90m…'`` and goes red (measured: #3571 / #3575, byte-identical
+    to a local repro with ``TERM``/``COLORTERM`` unset, running
+    ``test_agui_sr5_bit_identical_p4.py`` before
+    ``test_right_gutter_label_visible_3536.py``). It flaps rather than failing
+    every run because ``--dist load`` decides per run which worker gets which
+    pair. Locally, ``TERM=xterm-256color`` detects eight-bit and both sides of
+    the pair agree often enough to hide it.
+
+    Guarding each READER (as #3472 did for the palette gate alone) closes one
+    hole and leaves the class open — the next test that renders ``#6b7280`` on a
+    truecolor console inherits the bug, which is exactly how #3536's gutter test
+    became the second victim. Resetting here instead is leaker-agnostic: every
+    test starts from an unmemoized rich, so no test can observe another's colour
+    system. ``_ansi`` is a rich-private field and there is no public reset
+    (``copy()`` and ``+ Style()`` both preserve or alias it), so the two globals
+    are restored directly — if a rich upgrade renames either, this fixture
+    raises here rather than silently stopping.
+
+    Same shape as ``_isolate_budget_limit_context`` above, for the same reason.
+    """
+    yield
+    from rich.default_styles import DEFAULT_STYLES
+    from rich.style import Style
+
+    # Every ``lru_cache``d member of ``Style`` — enumerated rather than named
+    # (``parse``, ``_add``, ``normalize``, ``clear_meta_and_links``, … on rich
+    # 15.0.0) because ``Style.__add__`` delegates to a CACHED ``_add``, so the
+    # combined style a Console actually renders is itself process-global and
+    # carries its own ``_ansi``. Clearing only ``parse`` measurably leaves the
+    # red in place (verified while landing this: the poisoned instance the
+    # renderer used was the cached ``_add`` result, not the parsed one).
+    cleared = [
+        member for member in (getattr(Style, name, None) for name in dir(Style))
+        if hasattr(member, "cache_clear")
+    ]
+    assert cleared, "rich.style.Style exposes no cached member — reset is now a no-op"
+    for member in cleared:
+        member.cache_clear()
+    for style in DEFAULT_STYLES.values():
+        style._ansi = None
+
 # ── Marker registration ────────────────────────────────────────────────────────
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -293,9 +293,11 @@ def _isolate_rich_style_ansi_memo():
     rich 15.0.0 — a bug in rich, deliberately NOT reported upstream, see
     ``tests/test_markdown_palette_gate_3469.py``'s ``_memo_cleared_theme`` for
     the owner decision and the runnable "is it still there?" snippet). Because
-    ``Style.parse`` is ``lru_cache``d and ``rich.default_styles.DEFAULT_STYLES``
-    is a module global, those Style instances are shared by every test in the
-    pytest process: whichever console renders a given style string FIRST bakes
+    ``Style.parse`` AND ``Style._add`` (which ``Style.__add__`` delegates to,
+    i.e. the combined style a Console actually renders) are ``lru_cache``d, and
+    ``rich.default_styles.DEFAULT_STYLES`` is a module global, those Style
+    instances are shared by every test in the pytest process: whichever console
+    renders a given style string FIRST bakes
     its colour system into the shared instance, and every later console —
     whatever colour system IT asked for — re-emits that escape verbatim.
 
@@ -303,8 +305,8 @@ def _isolate_rich_style_ansi_memo():
     system reyn's own renderers get. ``RichChatRenderer`` / ``InlineChatRenderer``
     construct ``Console(force_terminal=True, ...)`` with colour detection left to
     rich, which is correct for production. Under CI's environment (no ``TERM``,
-    no ``COLORTERM``) that detects **standard**, so any of the ~15 test files
-    that drive those renderers memoizes ``_CC_DIM`` (``#6b7280``) as
+    no ``COLORTERM``) that detects **standard**, so any test that drives one of
+    those two renderers memoizes ``_CC_DIM`` (``#6b7280``) as
     bright-black ``'90'``; a later test that explicitly asks for truecolor then
     measures ``'\\x1b[90m…'`` and goes red (measured: #3571 / #3575, byte-identical
     to a local repro with ``TERM``/``COLORTERM`` unset, running
@@ -320,9 +322,9 @@ def _isolate_rich_style_ansi_memo():
     became the second victim. Resetting here instead is leaker-agnostic: every
     test starts from an unmemoized rich, so no test can observe another's colour
     system. ``_ansi`` is a rich-private field and there is no public reset
-    (``copy()`` and ``+ Style()`` both preserve or alias it), so the two globals
-    are restored directly — if a rich upgrade renames either, this fixture
-    raises here rather than silently stopping.
+    (``copy()`` and ``+ Style()`` both preserve or alias it), so rich's caches
+    and defaults are restored directly — and a rich upgrade that removes them
+    makes this fixture raise here rather than silently become a no-op.
 
     Same shape as ``_isolate_budget_limit_context`` above, for the same reason.
     """

--- a/tests/test_markdown_palette_gate_3469.py
+++ b/tests/test_markdown_palette_gate_3469.py
@@ -94,13 +94,21 @@ def _memo_cleared_theme() -> "object":
     rich (measured on 15.0.0, ``style.py`` ``_make_ansi_codes``) memoizes a
     Style's rendered escape on FIRST render without keying it by the
     console's ``color_system`` — and ``Style.parse`` is ``lru_cache``d
-    process-wide, so the instances in this theme are shared with every other
-    test in the same pytest process. Any earlier test that rendered the same
-    style string on a lower-colour console bakes the DOWNGRADED escape into
-    the shared instance (``#6b7280`` → bright_black ``'90'``), and this
-    gate's truecolor console then re-emits it — a false leak that flaps with
-    xdist test ordering (the #3472 CI-only red; reproduced deterministically
-    in ``test_gate_measures_the_theme_not_another_consoles_downgrade_memo``).
+    process-wide, so the instances in this theme are shared with everything
+    else rendered in the same pytest process. Whatever renders a style string
+    on a lower-colour console FIRST bakes the DOWNGRADED escape into the shared
+    instance (``#6b7280`` → bright_black ``'90'``), and this gate's truecolor
+    console then re-emits it — a false leak (the #3472 CI-only red; reproduced
+    deterministically in
+    ``test_gate_measures_the_theme_not_another_consoles_downgrade_memo``).
+
+    ACROSS tests that leak is closed centrally as of #3572: the autouse
+    ``_isolate_rich_style_ansi_memo`` fixture in ``tests/conftest.py`` resets
+    rich's memo after every test, so no test can inherit another's colour
+    system (which is what made #3536's gutter test red on CI). This helper is
+    still load-bearing for the poisoning that happens WITHIN a single test —
+    which is exactly what the sibling test below performs deliberately.
+
     Clearing the memo (a rich-private field, acknowledged — no public reset
     exists: ``copy()`` and ``+ Style()`` both preserve or alias it) makes the
     gate measure what a real single-colour-system terminal process sees. A


### PR DESCRIPTION
**[per-PR-coder]** — Fixes #3572. The order-dependent CI red behind #3571 / #3575.

## The correction that matters: the named poisoner is not the poisoner

#3572 identifies `test_markdown_palette_gate_3469.py::test_gate_measures_the_theme_not_another_consoles_downgrade_memo` as the test that poisons rich's process-global `Style` memo and never restores it. **Measured: it does restore.** It poisons, then calls `_render_ansi(themed=True)` → `_memo_cleared_theme()`, which clears `_ansi` on exactly the same `Style.parse`-shared instances and re-renders them truecolor. Running it immediately before the victim is **green**, with `TERM`/`COLORTERM` unset (CI's environment) and with them set:

```
$ unset TERM COLORTERM
$ pytest tests/test_markdown_palette_gate_3469.py::test_gate_measures_the_theme_not_another_consoles_downgrade_memo \
         tests/test_right_gutter_label_visible_3536.py::test_the_dim_colour_constant_stays_a_colour
2 passed
```

The real poisoners are ordinary tests, and the mechanism has a **second** un-keyed cache, not just `_ansi`:

- `RichChatRenderer` / `InlineChatRenderer` (`repl/renderer.py:268`, `:895`) build `Console(force_terminal=True, ...)` and leave colour detection to rich — correct for production.
- Under CI (`TERM` and `COLORTERM` unset) rich's `_detect_color_system()` returns **standard**. Measured:

```
detected color_system: standard
memo after production-shaped console: '90'
truecolor console emits: '\x1b[90my\x1b[0m'
```

- So any test that drives one of those two renderers memoizes `_CC_DIM` (`#6b7280`) as bright-black `'90'`, and a later test that explicitly asks for truecolor re-emits it.

Locally this hides because `TERM=xterm-256color` detects eight-bit, and `--dist load` decides per run which worker gets which pair — hence "1 in 5", not a flake.

## The fix

A new autouse fixture `_isolate_rich_style_ansi_memo` in `tests/conftest.py` resets rich's memo after every test — leaker-agnostic, so it closes the class rather than the hole. Same shape (and same rationale) as the existing `_isolate_budget_limit_context` fixture directly above it. Guarding readers one at a time is what left #3536's gutter test exposed hours after it landed.

**Clearing `Style.parse` alone is not enough, and that was measured, not assumed.** `Style.__add__` delegates to `Style._add`, which is *also* `lru_cache`d — the instance a `Console` actually renders is the cached combined style, carrying its own `_ansi`. With only `Style.parse.cache_clear()` the repro below stayed RED; a `Style.render` spy showed the rendering instance was a different object, id different from the parse-cache entry, already holding `'90'`. The fixture therefore enumerates every `lru_cache`d member of `Style` (rather than naming them, so a rich upgrade that adds one is covered), asserts the enumeration is non-empty, and resets `_ansi` on `rich.default_styles.DEFAULT_STYLES`.

Neither test was weakened. `_memo_cleared_theme()` stays — it is still load-bearing for the poisoning the palette gate performs *within* a single test — and its docstring is corrected in this PR to stop claiming the cross-test leak is still open (doc-drift rule).

## Witness

**RED before** — in-process ordering, CI-like env, byte-identical to the CI failure:

```
$ unset TERM COLORTERM
$ pytest tests/test_agui_sr5_bit_identical_p4.py \
         tests/test_right_gutter_label_visible_3536.py::test_the_dim_colour_constant_stays_a_colour
E   assert '38;2;' in '\x1b[90m↑12k ↓2k\x1b[0m'
E    +  where '\x1b[90m↑12k ↓2k\x1b[0m' = _render('#6b7280')
1 failed, 1 passed
```

**GREEN after** — same command, same order: `2 passed`.

**Strip-falsify** — anchor confirmed unique (`grep -c 'def _isolate_rich_style_ansi_memo():'` = 1), body replaced with `yield; return`: the ordering above goes **RED again** (`1 failed, 1 passed`); restored, GREEN again, `git diff --stat` clean after the restore.

No reproduction-rate claim is made from CI runs — CI ordering is not controlled; the in-process ordering above is the witness.

## Sweep: is the poisoner the only one?

Producers enumerated from `grep -rn "Console(" src/reyn/`:

| site | colour system | poisoner? |
| --- | --- | --- |
| `repl/renderer.py:268` (`RichChatRenderer`) | auto -> **standard** under CI | **yes** |
| `repl/renderer.py:895` (`InlineChatRenderer`) | auto -> **standard** under CI | **yes** |
| `repl/renderer.py:221` | `color_system=None` | no — `Style.render` returns early |
| `textual_chat/presenter.py:365`, `repl/present_renderer.py:165` | `Console()`, not a terminal under pytest | no |

Test-side: `grep -rn "color_system" tests/` finds exactly one non-truecolor, non-`None` console — the deliberate poisoner in `test_markdown_palette_gate_3469.py`, which self-restores as shown above. `grep -rn "force_terminal" tests/ | grep -v color_system` finds no test console left on auto detection.

So: the poisoner named in the issue is not one; the actual poisoners are the two production renderers reached by any of the test files that drive them (`grep -rln "RichChatRenderer\|InlineChatRenderer" tests/` -> 15 files). Measured directly under CI-like env, without this fix, `test_agui_sr5_bit_identical_p4.py`, `test_user_submitted_render_3300.py` and `test_inline_pr3a_app.py` each leave the memo at `'90'` at teardown.

## Test plan

- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict tests/conftest.py tests/test_markdown_palette_gate_3469.py`
- [x] `pytest -n auto` from the repo root, with `TERM`/`COLORTERM` unset (the axis that was never run locally)
- [x] `verify_module_docstrings.py` — n/a, no `src/` change
- [x] Manual: RED-before / GREEN-after / strip-falsify, all three transcribed above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
