### PR TITLE
fix(security): /session new inherits its invoker's per-session narrowing — part of #3562

### DIFF
--- a/docs/concepts/multi-agent/sessions.md
+++ b/docs/concepts/multi-agent/sessions.md
@@ -53,6 +53,16 @@ outbox, the current task, and transient run state. Identity-scoped things — me
 permissions, workspace scope, peer addressing — live on the Agent and are shared by
 all of that Agent's Sessions; conversation-scoped things stay isolated per Session.
 
+One capability layer is nonetheless *session*-scoped: a session can be **narrowed**
+below its agent's envelope (restrict-only — a narrowing can never grant what the
+identity does not already have). That layer is inherited on spawn: a session opened
+from a narrowed session — by `/session new`, by a pipeline, by an agent step, or by
+the `session_spawn` tool — is born inside the opener's narrowing, composed
+most-restrictive-wins (denials union, allow-lists intersect). So an operator whose own
+session is narrowed gets a narrowed new session, and `/session new` names what it
+inherited in its reply. The alternative — a fresh session silently starting wide — is
+the one an operator cannot notice.
+
 Persistence and recovery key on the **Session**:
 
 - **Per-session persistence** — each Session's state is snapshotted independently,

--- a/src/reyn/interfaces/slash/session.py
+++ b/src/reyn/interfaces/slash/session.py
@@ -6,7 +6,11 @@ structural substrate (N Sessions per Agent, keyed by session-id) landed in
 Stage 3; this is the REPL wiring.
 
   /session new          → open a new session under the attached agent (shared
-                          identity); prints the new session-id.
+                          identity); prints the new session-id. #3562: the new
+                          session is born INSIDE the invoking session's own
+                          per-session capability narrowing (#2103-S1a), composed
+                          the same way the three sibling spawn sites compose
+                          theirs, and the reply names what it inherited.
   /session switch <sid> → focus another session of the attached agent. Routed
                           through the registry forwarder (like ``/attach``) so
                           the focus flip + display re-wire are sequenced, not
@@ -24,11 +28,57 @@ from typing import TYPE_CHECKING
 from reyn.interfaces.slash import reply, reply_error, slash
 from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.spawn_routing import ReviewedNA
+from reyn.security.permissions.capability_profile import compose_narrowing_mappings
 
 if TYPE_CHECKING:
     from reyn.runtime.session import Session
 
 _USAGE = "usage: /session new | /session switch <sid> | /session list"
+
+#: How many denied capability names the inherited-restriction line spells out before
+#: it stops and just counts the rest — the line is an orientation aid in a REPL reply,
+#: not the full census (``/visibility`` renders that).
+_NAMED_DENIALS = 5
+
+
+def _inherited_restriction_lines(reg, name: str, sid: str) -> "list[str]":
+    """The operator-facing explanation of what a just-spawned session inherited.
+
+    #3562 (architect's in-PR requirement): with ``allow ∩`` composed uniformly, a
+    ``/session new`` reached from a NARROWED invoker can open a session with few or
+    even zero usable capabilities. That is the safe direction, but silent — the
+    operator sees a new session id and no reason for anything that later refuses. This
+    reads the child's own ``capability_visibility_state()`` (the existing #2285/#3378
+    read model — no new mechanism) and says so at spawn time.
+
+    ⚠️ Explanation, NOT enforcement, and deliberately not the witness that inheritance
+    works: ``capability_visibility_state`` re-resolves with the sid on every read, and
+    was GREEN on the broken code #3561 fixed, where the same envelope was resolvable
+    but not enforced. What proves the inheritance is a denied tool's side effect not
+    happening (``tests/test_3562_slash_session_new_narrowing_inheritance.py``); this
+    surface has its own separate test, for its own separate claim.
+
+    Empty when the child session is not retrievable (nothing truthful to say)."""
+    child = reg.get_session(name, sid)
+    if child is None:
+        return []
+    state = child.capability_visibility_state()
+    denied = sorted(row["name"] for row in state["denied_by_envelope"])
+    tools_left = sum(1 for row in state["authorized"] if row["kind"] == "tool")
+    lines: "list[str]" = []
+    if denied:
+        shown = ", ".join(denied[:_NAMED_DENIALS])
+        more = len(denied) - _NAMED_DENIALS
+        lines.append(
+            f"  ↳ inherited this session's capability narrowing — {len(denied)} "
+            f"denied in the new session: {shown}" + (f", +{more} more" if more > 0 else "")
+        )
+    if not tools_left:
+        lines.append(
+            "  ↳ no tools remain available in it; open the session from a session "
+            "that is not narrowed, or lift the narrowing, if that was not intended"
+        )
+    return lines
 
 
 @slash(
@@ -53,6 +103,35 @@ async def session_cmd(session: "Session", args: str) -> None:
     rest = parts[1].strip() if len(parts) > 1 else ""
 
     if sub == "new":
+        # #3562: the child is born under the ATTACHED agent, and the layer that decides
+        # its capability envelope is keyed by (agent, sid) — so the INVOKING session's
+        # #2103-S1a narrowing has to be carried explicitly or the child is born wider
+        # than whoever asked for it. The name-keyed layers (the agent's permissions
+        # declaration, topology capability_profile bindings, the #2081 _delegate floor)
+        # ride along for free; the #2285 /visibility toggle and the #1827-S4b ephemeral
+        # untrusted-context narrowing are deliberately not carried, same as the three
+        # sibling spawn sites (see test_3546's module docstring, layers 3 and 4).
+        #
+        # ★ WHY, since the answer changed under this code: an OWNER POLICY decision —
+        # if an operator has switched a capability off for their session and then opens
+        # a new one from it, that capability stays off. Operator intent persists across
+        # the spawn. The gap was originally argued as a containment one (#3561 had
+        # measured that model output reached this site, so an un-narrowed child was an
+        # escape); #3595 step 1 ruled that reachability a defect and closed it, which
+        # retires the containment argument WITHOUT touching this one — the policy claim
+        # never depended on who could reach the command.
+        #
+        # The composition rule is the siblings' rule applied UNIFORMLY (deny ∪, allow ∩,
+        # an absent allow = ⊤) — this site imposes nothing of its own, so the child term
+        # is None and the invoker's mapping stands. There is deliberately NO branch for
+        # the case where the invoking session's agent differs from the attached one:
+        # ``name`` is ``reg.attached_name``, so on the operator path the caller IS the
+        # attach target and the identities coincide. A branch would be a lenient special
+        # case for exactly the caller a uniform restrict-only rule exists to bound.
+        parent_narrowing = reg.per_session_narrowing(
+            session.agent_name, session.session_id,
+        )
+        inherited = compose_narrowing_mappings(parent_narrowing, None)
         try:
             # #2708 P3-item3: /session new opens a real attachable conversation session — the user
             # /session switches to focus + drain it; self-binding to the factory default is reviewed-NA.
@@ -61,11 +140,15 @@ async def session_cmd(session: "Session", args: str) -> None:
                 name,
                 presentation_consumer=_routing.presentation_consumer,
                 intervention_bridge=_routing.intervention_bridge,
+                narrowing=inherited,
             )
         except ValueError as exc:  # dup id (spawn_session guards)
             await reply_error(session, str(exc))
             return
-        await reply(session, f"opened session {sid!r} — /session switch {sid} to focus it")
+        lines = [f"opened session {sid!r} — /session switch {sid} to focus it"]
+        if inherited:
+            lines.extend(_inherited_restriction_lines(reg, name, sid))
+        await reply(session, "\n".join(lines))
         return
 
     if sub == "switch":

--- a/src/reyn/interfaces/slash/session.py
+++ b/src/reyn/interfaces/slash/session.py
@@ -69,9 +69,17 @@ def _inherited_restriction_lines(reg, name: str, sid: str) -> "list[str]":
     if denied:
         shown = ", ".join(denied[:_NAMED_DENIALS])
         more = len(denied) - _NAMED_DENIALS
+        # Says two separate true things rather than one convenient one: the child
+        # inherited this session's narrowing (a fact about what was passed), and its
+        # envelope denies these capabilities (a fact read off the child). It does NOT
+        # claim every denial listed is DUE to the inheritance — ``denied_by_envelope``
+        # also carries the agent's own name-keyed layers, which the child would have had
+        # either way, and attributing those to the operator's narrowing would be a
+        # confident wrong answer to "why is this denied?".
         lines.append(
-            f"  ↳ inherited this session's capability narrowing — {len(denied)} "
-            f"denied in the new session: {shown}" + (f", +{more} more" if more > 0 else "")
+            f"  ↳ inherited this session's capability narrowing; the new session's "
+            f"envelope denies {len(denied)}: {shown}"
+            + (f", +{more} more" if more > 0 else "")
         )
     if not tools_left:
         lines.append(

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2639,13 +2639,61 @@ class AgentRegistry:
             attach_anchor(anchors)
         return session
 
+    def _persist_session_narrowing(self, name: str, sid: str, narrowing: dict) -> None:
+        """Write ``narrowing`` to ``(name, sid)``'s own ``config.yaml`` — the #2103-S1a
+        per-session capability layer, workspace-backed (P5).
+
+        The single WRITER of that file, so the two spawn entry points cannot drift from
+        each other or from its reader (``_load_per_session_capability_profile`` /
+        ``per_session_narrowing``, both keyed through ``_session_state_dir``). The
+        synthetic ``name`` key is what ``per_session_narrowing`` strips back off, so the
+        parent→child round-trip is exact.
+
+        Writing the file is not by itself enforcement: the live session's
+        ``_contextual_permission`` was resolved by the factory with ``sid=None`` and has
+        never seen this file. Each of the two callers re-resolves WITH the sid and
+        injects — ``spawn_session`` immediately after calling this, and
+        ``spawn_session_recorded`` after its own ``refresh_config_projections()`` (the
+        ordering there is measured, not stylistic; see the note at its ``spawn_session``
+        call). A caller that writes without injecting has persisted a narrowing nothing
+        enforces, which is the #2126 failure mode."""
+        import yaml
+        cfg_path = self._session_state_dir(name, sid) / "config.yaml"
+        cfg_path.parent.mkdir(parents=True, exist_ok=True)
+        cfg_path.write_text(
+            yaml.safe_dump({"name": f"_session_{sid}", **narrowing}),
+            encoding="utf-8",
+        )
+
     def spawn_session(
         self, name: str, sid: "str | None" = None,
         *, presentation_consumer: "object | None",
         intervention_bridge: "object | None",
+        narrowing: "dict | None" = None,
     ) -> str:
         """FP-0043 Stage 3: open a NEW conversation Session under an existing
         Agent, SHARING the agent's identity object. Returns the new session-id.
+
+        #3562: ``narrowing`` is the #2103-S1a per-session capability mapping the child
+        is BORN under — persisted to its own ``config.yaml`` and injected into the live
+        session before this returns, so the first turn already gates against it.
+        ``None`` (every recovery caller, and any caller with nothing to impose) is
+        byte-identical to the pre-#3562 behaviour: no file is written and the sid's own
+        persisted layer, if it has one, is what the injection below applies.
+
+        ★ Why the channel is HERE and not "route the remaining caller through
+        ``spawn_session_recorded``" — a decision, not an omission. ``/session new``
+        (``interfaces/slash/session.py``) was the one reachable caller with something to
+        inherit and no way to pass it (#3561 recorded that as an UNMET REQUIREMENT
+        rather than an exemption). Sending it through the recorded seam instead would
+        have carried three unrelated changes with it: a ``session_spawned`` WAL record
+        making an operator-opened session rewind-tracked and re-materialisable (which
+        operator-created sessions are not today, so a rewind past the command would
+        start DROPPING the operator's session), a spawn-time
+        ``refresh_config_projections()``, and async-ness. #3562 changes exactly one
+        observable thing — the child's envelope — so the channel belongs on the
+        primitive every direct caller already shares. It is also where #3561 put the
+        injection, for the same reason: this is where the sid becomes known.
 
         #2708 P3-item3: ``presentation_consumer`` + ``intervention_bridge`` are REQUIRED,
         no-default kwargs (the spawn-axis completeness gate) — every caller must declare an
@@ -2754,8 +2802,22 @@ class AgentRegistry:
         # place every path shares: this is where the sid becomes known, so it is where
         # the sid-keyed layer becomes resolvable. Inert for a sid with no config.yaml
         # (resolved_profile_for then returns the name-keyed layers the factory already
-        # applied). spawn_session_recorded keeps its own re-inject — it WRITES the config
-        # after this returns, so its value does not exist yet at this point.
+        # applied).
+        #
+        # #3562: a caller-supplied ``narrowing`` is persisted FIRST, so the single
+        # re-resolve below covers both the sid's already-persisted layer (recovery) and
+        # the value this spawn imposes (inheritance) — one write, one injection, no
+        # second seam where the two could disagree.
+        #
+        # ⚠️ The injection is only durable for a caller that does not then run
+        # ``refresh_config_projections()``: that refresh's
+        # ``reapply_visibility_override`` re-resolves from base and SETs, and on a
+        # session with no registry back-reference there is no base to re-resolve, so it
+        # sets ALLOW-ALL and discards this. That is why ``spawn_session_recorded``
+        # deliberately does NOT pass ``narrowing`` here and re-injects after its own
+        # refresh instead — measured, see the note at its ``spawn_session`` call.
+        if narrowing:
+            self._persist_session_narrowing(name, new_sid, narrowing)
         inject = getattr(session, "apply_per_session_narrowing", None)
         if callable(inject):
             contextual, excluded = self.resolved_profile_for(name, sid=new_sid)
@@ -2778,7 +2840,10 @@ class AgentRegistry:
         """#2103 S1bc: the action-layer SESSION-SPAWN seam — spawn a fresh-context
         session under ``name`` (sync ``spawn_session``) + persist the spawner's
         per-session capability narrowing (workspace-backed P5 config.yaml, the #2103
-        S1a layer) + emit ``session_spawned`` so rewind tracks/drops/re-materialises
+        S1a layer — written through the primitive's ``_persist_session_narrowing``, the
+        single writer, but from HERE and not through the primitive's ``narrowing``
+        channel: see the note at the ``spawn_session`` call for the measurement that
+        pins the ordering) + emit ``session_spawned`` so rewind tracks/drops/re-materialises
         it. Mirrors ``create_agent`` (the agent CREATE seam): the mechanism stays sync;
         the event marks the LLM action. ``session_spawned`` is config-complete
         (mode + narrowing) for symmetric re-materialise. Returns the new sid.
@@ -2793,6 +2858,19 @@ class AgentRegistry:
         parent surface, ask_user reaches the parent's live operator), ``AuditOnlyNoSurface``
         (detached/headless — present audit-only, ask_user a typed refusal), or ``ReviewedNA``
         (``None``/``None`` self-bound, reviewed sites only). No silent default (#2708 P3-item3)."""
+        # #3562: this seam does NOT hand ``narrowing`` down the primitive's new channel,
+        # and the reason is measured rather than stylistic. Its own write + re-inject
+        # (below) must stay AFTER ``refresh_config_projections()``: that refresh fires
+        # ``reapply_visibility_override``, which re-resolves the envelope from base and
+        # SETs it — and when the session has no registry back-reference there IS no base
+        # to re-resolve, so it sets an ALLOW-ALL envelope and silently discards anything
+        # injected before it. Passing the narrowing down was tried and falsified by
+        # tests/test_2103_s1bc_session_spawn_tool.py::
+        # test_spawn_session_recorded_enforces_narrowing_on_live_session and
+        # tests/test_pipeline_a2_spawn_ephemeral_session.py::
+        # test_spawn_ephemeral_session_narrowing_applied — both went RED with an empty
+        # ``tool_deny`` on the live session. The primitive's channel is for callers that
+        # do not run that refresh (``/session new``, #3562).
         sid = self.spawn_session(
             name,
             presentation_consumer=presentation_consumer,
@@ -2852,13 +2930,11 @@ class AgentRegistry:
                 # its one turn asking a question no one can answer.
                 spawned_session._non_interactive = True
         if narrowing:
-            import yaml
-            cfg_path = self._session_state_dir(name, sid) / "config.yaml"
-            cfg_path.parent.mkdir(parents=True, exist_ok=True)
-            cfg_path.write_text(
-                yaml.safe_dump({"name": f"_session_{sid}", **narrowing}),
-                encoding="utf-8",
-            )
+            # #3562: the file write itself is the primitive's ``_persist_session_narrowing``
+            # — one writer for both spawn entry points, so the two cannot drift from each
+            # other or from the reader. Only the CALL SITE stays here; see the note above
+            # this method's ``spawn_session`` call for the measurement that keeps it here.
+            self._persist_session_narrowing(name, sid, narrowing)
             # #2126: ENFORCE the narrowing just written. The per-session capability
             # layer (#1827 / #2103-S1a) only resolves WITH a sid, and every
             # construction-time factory caller resolves sid=None — so the live spawned

--- a/tests/test_3546_pipeline_driver_narrowing_inheritance.py
+++ b/tests/test_3546_pipeline_driver_narrowing_inheritance.py
@@ -38,20 +38,29 @@ earlier gates decided membership by SHAPE — #3554's by whether a site spelled
 parent), and the enumeration itself by whether a callee's NAME was on a list. Neither
 question is the one that matters. ``AgentRegistry.spawn_session`` — the sync primitive
 that ``spawn_session_recorded`` itself calls, and that four other sites call directly —
-was outside the gate because it takes no ``narrowing`` argument at all, i.e. it failed
-the shape check in the opposite direction. "It cannot inherit" is not "it need not
+was outside the gate because it took no ``narrowing`` argument at all (it does since
+#3562), i.e. it failed the shape check in the opposite direction. "It cannot inherit"
+is not "it need not
 inherit": an API with no inheritance channel is an unmet requirement. The criterion is
 REACHABILITY — can a narrowed subject cause this to run — and it is now listed, with the
 walk resolving calls by RECEIVER so ``spawn_session`` the registry primitive is not
 conflated with the two other functions of that name (see ``_Seam``).
 
 Reachability is measured, not assumed:
-``tests/test_3561_spawn_session_seam_reachability.py`` drives an agent step whose prompt
-is a previous agent step's MODEL OUTPUT, on a session narrowed to one capability, and
-observes it reach ``/session new`` — ``Session._handle_user_message`` short-circuits to
-``_maybe_handle_slash`` before the router turn, so the reaching turn makes no LLM call at
-all — and spawn. The pre-measurement guess ("slash is operator-initiated, so it is out of
-scope") is false.
+``tests/test_3561_spawn_session_seam_reachability.py`` drove an agent step whose prompt
+was a previous agent step's MODEL OUTPUT, on a session narrowed to one capability, and
+observed it reach ``/session new`` and spawn — ``Session._handle_user_message``
+short-circuited to ``_maybe_handle_slash`` before the router turn, so the reaching turn
+made no LLM call at all. The pre-measurement guess ("slash is operator-initiated, so it
+is out of scope") was false.
+
+★ #3595 step 1 then made it TRUE, by ruling that path a defect: the agent-step prompt
+rides its own inbox kind instead of claiming ``kind="user"``, so it never enters the
+``startswith('/')`` dispatch, and that file's leg is the same measurement INVERTED (the
+absence of the spawn, plus an operator control proving the command still runs). The
+enumeration criterion is unchanged and so is this site's membership — this list counts
+every place a child envelope is BORN, not every place a model can reach. What #3595
+retires is the severity argument, not the entry (#3596 / #3562-#3586).
 
 ★ Enumerating the primitive immediately paid for itself: measuring the CRASH-RECOVERY
 sites (``restore_all`` / ``_rewake_pipeline_runs``), which reach ``spawn_session``
@@ -63,9 +72,26 @@ shape check would never have asked.
 
 Every enumerated site is accounted for today — a state this file records but does not
 enforce, since a NEW site may register an ``unmeasured_reason`` and stay green here.
-``/session new``'s missing inheritance is a real, declared gap (#3562), not a
-measurement gap: its declaration says so, and its measurement asserts the reachability
-only, so closing #3562 does not turn it red.
+
+★ #3562 closed the one declared GAP and, in doing so, expired the exemption every
+``spawn_session`` site rested on. ``/session new`` composes its invoker's #2103-S1a
+layer in (uniformly — see its declaration for why there is no cross-identity branch),
+which required the primitive to grow the ``narrowing`` channel #3561 had recorded as an
+UNMET REQUIREMENT. ``test_no_exemption_claims_a_channel_that_exists`` is what made that
+expiry mechanical rather than remembered: the four sites that still pass nothing are
+re-argued on the merits — no spawner to inherit from (``resolve_session``); a value
+would OVERWRITE the recovering session's own durable layer, since the primitive
+persists what it is given (the recovery pair); and, for ``spawn_session_recorded``, the
+injection has to happen at a LATER point than the primitive offers. ★ That last one is
+measured, not judged: routing its ``narrowing`` through the new channel REDs two
+existing behavioural tests, because ``refresh_config_projections()`` runs in between and
+its ``reapply_visibility_override`` re-resolves-from-base-and-SETs — with no registry
+back-reference there is no base, so it lands on ALLOW-ALL and discards the injection.
+"The channel exists, therefore use it" would have been a shape argument in the third
+direction. The ``_S3561`` legs assert reachability only, never anything about what the
+child inherits, so they are orthogonal to #3562's and stay green through it — verified
+by running them (both the pre-#3595 leg and, after the rebase, its #3596 inverse plus
+the operator control), not assumed.
 
 Scope of what this fix carries (the layers a session's live capability envelope
 is composed from — enumerated, not assumed):
@@ -328,28 +354,67 @@ async def test_pipeline_driver_session_inherits_invoker_narrowing(
 #: passes ``narrowing=`` or is registered here with a reason a reviewer can weigh
 #: — the #3484 ``*_UNMEASURED`` idiom.
 #:
-#: #3561 filled it, for one reason only: every entry calls
-#: ``AgentRegistry.spawn_session``, whose signature HAS no ``narrowing`` parameter.
-#: That is deliberately recorded as an unmet requirement, not as a merit-based
+#: #3561 filled it, for one reason only: every entry called
+#: ``AgentRegistry.spawn_session``, whose signature had no ``narrowing`` parameter.
+#: That was deliberately recorded as an unmet requirement, not as a merit-based
 #: exemption — "the API cannot take one" would be a shape argument, and this arc has
-#: been slipped past on the shape axis twice already. What each site's child envelope
-#: is actually decided by is stated in ``_SITE_PARENT_LAYERS``, individually.
-#: ``test_narrowing_exempt_sites_have_no_narrowing_channel`` reads the LIVE signature,
-#: so the day a ``narrowing`` channel is added to the primitive, every entry here goes
-#: RED and has to be revisited rather than quietly outliving its reason.
+#: been slipped past on the shape axis twice already.
+#:
+#: ★ #3562 MET that requirement: the primitive now takes ``narrowing``, and the
+#: exemption that rested on its absence expired exactly as
+#: ``test_narrowing_exempt_sites_have_no_narrowing_channel`` was built to make it. One
+#: entry left the table by USING the channel (``/session new`` composes its invoker's
+#: layer in). The four that remain are re-argued ON THE MERITS below, individually —
+#: two shapes: there is no SPAWNER whose narrowing could be inherited (and passing one
+#: would not be a no-op but an overwrite of the child's own durable layer), or — for
+#: the recorded seam — the enforcement must happen at a LATER point than the primitive
+#: offers, which was measured, not assumed.
+_EXEMPT_NO_SPAWNER_SESSION = (
+    "no spawner SESSION exists at this seam (#3562): it is the inbound-transport "
+    "get-or-spawn for a `<transport>:<native_id>` conversation key, entered from a "
+    "transport frame, so there is no per-session layer to carry across. The child "
+    "re-derives the agent's NAME-keyed layers itself. See this site's "
+    "_SITE_PARENT_LAYERS entry."
+)
+_EXEMPT_RECOVERY_REENTRY = (
+    "crash recovery RE-ENTERS an existing sid rather than spawning a child (#3562): "
+    "that session's own #2103-S1a config.yaml is already on disk and is resolved + "
+    "injected by the primitive itself (#3561). There is no spawner here, and passing a "
+    "narrowing would not be a no-op — the primitive PERSISTS what it is given, so any "
+    "value would overwrite the recovering session's own durable layer. See this site's "
+    "_SITE_PARENT_LAYERS entry."
+)
+_EXEMPT_RECORDED_SEAM_INJECTS_LATER = (
+    "the recorded seam writes + injects its OWN ``narrowing`` a few statements after "
+    "the spawn, and that ordering is MEASURED (#3562): it must happen AFTER its "
+    "``refresh_config_projections()``, whose ``reapply_visibility_override`` "
+    "re-resolves the envelope from base and SETs it — on a session with no registry "
+    "back-reference there is no base, so it sets ALLOW-ALL and discards anything "
+    "injected earlier. Handing the value down the primitive's channel was tried and "
+    "REDded tests/test_2103_s1bc_session_spawn_tool.py::"
+    "test_spawn_session_recorded_enforces_narrowing_on_live_session and "
+    "tests/test_pipeline_a2_spawn_ephemeral_session.py::"
+    "test_spawn_ephemeral_session_narrowing_applied, both with an empty live tool_deny."
+)
+_NARROWING_EXEMPT_SITES: "dict[tuple[str, str], str]" = {
+    ("reyn/runtime/registry.py", "spawn_session_recorded"): (
+        _EXEMPT_RECORDED_SEAM_INJECTS_LATER
+    ),
+    ("reyn/runtime/registry.py", "resolve_session"): _EXEMPT_NO_SPAWNER_SESSION,
+    ("reyn/runtime/registry.py", "restore_all"): _EXEMPT_RECOVERY_REENTRY,
+    ("reyn/runtime/registry.py", "_rewake_pipeline_runs"): _EXEMPT_RECOVERY_REENTRY,
+}
+
+#: The exemption text #3561 used while the primitive had no ``narrowing`` parameter.
+#: Kept as a named constant with no users so
+#: ``test_no_exemption_claims_a_channel_that_exists`` can check that nothing re-adopts
+#: it — the claim it makes is now false, and a false reason is worse than none.
 _UNMET_NO_NARROWING_CHANNEL = (
     "calls AgentRegistry.spawn_session, which has no narrowing parameter (#3561): an "
     "UNMET REQUIREMENT recorded so the gate counts the site, not an exemption on the "
     "merits. See this site's _SITE_PARENT_LAYERS entry for what decides its child's "
     "envelope instead."
 )
-_NARROWING_EXEMPT_SITES: "dict[tuple[str, str], str]" = {
-    ("reyn/runtime/registry.py", "spawn_session_recorded"): _UNMET_NO_NARROWING_CHANNEL,
-    ("reyn/runtime/registry.py", "resolve_session"): _UNMET_NO_NARROWING_CHANNEL,
-    ("reyn/runtime/registry.py", "restore_all"): _UNMET_NO_NARROWING_CHANNEL,
-    ("reyn/runtime/registry.py", "_rewake_pipeline_runs"): _UNMET_NO_NARROWING_CHANNEL,
-    ("reyn/interfaces/slash/session.py", "session_cmd"): _UNMET_NO_NARROWING_CHANNEL,
-}
 
 @dataclass(frozen=True)
 class _Seam:
@@ -381,7 +446,7 @@ class _Seam:
     name: str
     #: The real function object — imported, not named by string, so a rename
     #: raises at collection time and ``inspect.signature`` reads the live
-    #: parameter list (``test_narrowing_exempt_sites_have_no_narrowing_channel``).
+    #: parameter list (``test_no_exemption_claims_a_channel_that_exists``).
     func: object
     #: Module (relative to ``src/``) the seam is defined in.
     module: str
@@ -399,12 +464,13 @@ class _Seam:
 #: long as it did.
 #:
 #: ``AgentRegistry.spawn_session`` joined the list in #3561 on a REACHABILITY
-#: criterion, not a shape one. It takes no ``narrowing`` argument, and "it cannot
+#: criterion, not a shape one. It took no ``narrowing`` argument then, and "it cannot
 #: take one, so it is out of scope" is the same shape argument that let #3556
 #: through this gate inverted: #3556 passed BECAUSE it spelled ``narrowing=``,
 #: while passing a value that was not a function of its parent. A seam with no
-#: inheritance channel is an UNMET REQUIREMENT, not an exemption — so it is listed,
-#: and each of its sites states what actually decides its child's envelope.
+#: inheritance channel is an UNMET REQUIREMENT, not an exemption — so it was listed,
+#: each of its sites stating what actually decides its child's envelope, and #3562
+#: then MET the requirement by adding the channel to the primitive.
 _SPAWN_SEAMS: "tuple[_Seam, ...]" = (
     _Seam(
         name="spawn_session_recorded",
@@ -485,6 +551,7 @@ _S3546 = "tests/test_3546_pipeline_driver_narrowing_inheritance.py"
 _S3553 = "tests/test_3553_agent_step_worker_narrowing_inheritance.py"
 _S3556 = "tests/test_3556_session_spawn_narrowing_inheritance.py"
 _S3561 = "tests/test_3561_spawn_session_seam_reachability.py"
+_S3562 = "tests/test_3562_slash_session_new_narrowing_inheritance.py"
 
 #: Every spawn site in ``src/``, with the parent layers its ``narrowing=`` value
 #: composes and the behavioural test that measures that claim. A site missing from
@@ -548,16 +615,21 @@ _SITE_PARENT_LAYERS: "dict[tuple[str, str], _SiteDeclaration]" = {
         ),
     ),
     # ── #3561: the sites of the SYNC primitive ``AgentRegistry.spawn_session`` ──
-    # None of these can pass ``narrowing=`` — the primitive has no such parameter.
-    # That is recorded in ``_NARROWING_EXEMPT_SITES`` as an unmet requirement rather
-    # than an exemption on the merits, and each entry below says what DOES decide the
-    # child's envelope, because "it cannot inherit" is not the same claim as "it has
-    # nothing to inherit".
+    # #3561 listed these while the primitive had no ``narrowing`` parameter at all,
+    # recording that in ``_NARROWING_EXEMPT_SITES`` as an unmet requirement rather than
+    # an exemption on the merits — because "it cannot inherit" is not the same claim as
+    # "it has nothing to inherit". #3562 met the requirement: the primitive takes the
+    # argument, this seam and ``/session new`` pass one, and the three that still do not
+    # are exempt on the second claim, stated per site below.
     ("reyn/runtime/registry.py", "spawn_session_recorded"): _SiteDeclaration(
         parent_layers=(
             "NONE of its own — this is the recorded seam itself, calling the sync "
             "primitive and then writing its OWN ``narrowing`` argument to the child's "
-            "sid-keyed ``config.yaml`` (the #2103-S1a layer) a few statements later. "
+            "sid-keyed ``config.yaml`` (the #2103-S1a layer) a few statements later, "
+            "through the primitive's ``_persist_session_narrowing`` (#3562 made that "
+            "the single writer) and re-injecting it into the live session. It does NOT "
+            "hand the value down the primitive's own ``narrowing`` channel, and that is "
+            "measured rather than stylistic — see its _NARROWING_EXEMPT_SITES reason. "
             "The value is therefore decided by whoever calls IT, which is why all "
             "three of those callers are enumerated sites in their own right."
         ),
@@ -580,7 +652,9 @@ _SITE_PARENT_LAYERS: "dict[tuple[str, str], _SiteDeclaration]" = {
             "so a SESSION can be upstream of it after all — but the session it reaches "
             "through is one of its OWN agent's, whose name-keyed envelope it already "
             "shares, so there is no per-session layer to carry across. A cross-AGENT "
-            "variant would change that answer; there is none today."
+            "variant would change that answer; there is none today. #3562: the "
+            "primitive now HAS a ``narrowing`` channel, and this site still passes "
+            "nothing — not for want of a channel but for want of a spawner."
         ),
         unmeasured_reason=(
             "the claim is about the ABSENCE of a per-session layer to inherit, and the "
@@ -608,7 +682,11 @@ _SITE_PARENT_LAYERS: "dict[tuple[str, str], _SiteDeclaration]" = {
             "``#2126`` re-resolve-and-inject into ``spawn_session`` itself, where the "
             "sid becomes known, closing it for every direct caller of the primitive at "
             "once. What the site inherits is now a property of the primitive, which is "
-            "the reason the primitive belongs on this list at all."
+            "the reason the primitive belongs on this list at all. "
+            "#3562: the primitive now also has a ``narrowing`` channel, and this site "
+            "deliberately passes nothing through it — the primitive PERSISTS what it is "
+            "given, so a value here would overwrite the recovering session's own "
+            "durable layer with a spawner's, and there is no spawner in a re-wake."
         ),
         measured_by=(
             f"{_S3561}::test_recovery_recreated_session_is_still_inside_its_persisted_narrowing",
@@ -633,14 +711,30 @@ _SITE_PARENT_LAYERS: "dict[tuple[str, str], _SiteDeclaration]" = {
     ),
     ("reyn/interfaces/slash/session.py", "session_cmd"): _SiteDeclaration(
         parent_layers=(
-            "NONE — and unlike the two recovery sites, this one has something it could "
-            "inherit and does not. ``/session new`` opens a session under the ATTACHED "
-            "agent with no ``config.yaml`` of its own and nothing carried from the "
-            "invoking session, so the child's #2103-S1a layer is empty however narrow "
-            "its invoker is. This is the arc's open gap, filed as #3562; it is declared "
-            "HERE rather than left off the list, because a site the gate does not "
+            "the INVOKING session's #2103-S1a sid-keyed narrowing "
+            "(``registry.per_session_narrowing`` for the caller's own (agent, sid)), "
+            "composed through ``capability_profile.compose_narrowing_mappings`` with a "
+            "``None`` child term — this site imposes nothing of its own, so deny ∪ / "
+            "allow ∩ / absent-allow-⊤ leaves the invoker's mapping standing (#3562). "
+            "Same name-keyed / not-carried layers as the three sites above. Until #3562 "
+            "this site carried NOTHING: the child's #2103-S1a layer was empty however "
+            "narrow its invoker was, which is why it was declared here as the arc's "
+            "open gap rather than left off the list — a site the gate does not "
             "enumerate is a site the gate does not count. "
-            "#3561 measured that it was REACHABLE FROM MODEL OUTPUT, which is what "
+            "★ The composition is applied UNIFORMLY, with no branch for the case where "
+            "the invoking session's agent differs from the ATTACHED agent the child is "
+            "born under. ``name`` is ``reg.attached_name``, so on the operator path — "
+            "the only face that reaches this site, see below — the caller IS the attach "
+            "target and the identities coincide, so there is no live cross-identity "
+            "case to branch on; a branch would be a lenient special case for exactly "
+            "the caller a uniform restrict-only rule exists to bound. (The original "
+            "#3562 argument for uniformity was sharper — the identities differed ONLY "
+            "on the model-output path, making 'the identity differs' the same event as "
+            "'the escape is happening'. #3595 step 1 retired that argument by closing "
+            "the path; it did not change the decision, and #3562/#3586 stands on an "
+            "owner policy decision instead: a session opened from a narrowed one should "
+            "stay narrowed.) "
+            "#3561 measured that this site was REACHABLE FROM MODEL OUTPUT, which is what "
             "first decided it was in scope: an agent step whose prompt was a previous "
             "agent step's model output, run on a session narrowed to a single "
             "capability, reached this site and spawned — no operator in the path, no "
@@ -658,13 +752,19 @@ _SITE_PARENT_LAYERS: "dict[tuple[str, str], _SiteDeclaration]" = {
             "by #3562/#3586 on an owner policy decision (a session opened from a "
             "narrowed one should stay narrowed), which stands on its own and never "
             "stood on this reachability. "
-            "The measurement below still asserts REACHABILITY only — now its absence, "
-            "paired with an operator control proving the command itself still runs — "
-            "never anything about what the child inherits."
+            "★ Two different claims are measured below, and they are not "
+            "interchangeable. The ``_S3561`` pair is about WHO can reach the site — now "
+            "the ABSENCE of the model-output path, paired with an operator control "
+            "proving the command itself still runs — and asserts nothing about what the "
+            "child inherits. The ``_S3562`` pair is about what the child inherits when "
+            "an operator does reach it, witnessed on the side-effect side (a denied "
+            "tool's file does not appear) next to its own un-narrowed control."
         ),
         measured_by=(
             f"{_S3561}::test_model_output_cannot_reach_slash_dispatch_and_spawns_nothing",
             f"{_S3561}::test_an_operator_submitted_slash_command_still_spawns_a_session",
+            f"{_S3562}::test_a_session_opened_by_slash_session_new_cannot_run_a_tool_its_invoker_is_denied",
+            f"{_S3562}::test_the_witness_tool_runs_when_the_invoker_is_not_narrowed",
         ),
     ),
 }
@@ -885,32 +985,43 @@ def test_every_spawn_site_passes_narrowing() -> None:
     )
 
 
-def test_narrowing_exempt_sites_have_no_narrowing_channel() -> None:
-    """Tier 2: (#3561) every exempt site's exemption rests on a fact about the LIVE
-    seam signature, not on prose — the seam it calls really has no ``narrowing``
-    parameter.
+def test_no_exemption_claims_a_channel_that_exists() -> None:
+    """Tier 2: (#3561, expired and re-grounded by #3562) no exemption rests on the
+    claim that the seam it calls cannot take a ``narrowing`` — checked against the LIVE
+    signature, so the claim cannot outlive the fact.
 
-    Every entry in ``_NARROWING_EXEMPT_SITES`` today says the same thing: the site
-    calls ``AgentRegistry.spawn_session``, which has no channel to pass a narrowing
-    through. That is recorded as an unmet requirement, and this test is what makes it
-    expire: add the channel and every exemption goes RED, forcing each site to either
-    use it or re-argue. It also fails if an exempt entry is stale (naming a site the
-    walk no longer finds), so the registry cannot accumulate dead permissions.
+    #3561 exempted five sites on exactly that claim, correctly at the time: the sync
+    primitive had no such parameter. #3562 added it, which is what this test was built
+    to force — two of the five now USE the channel and the other three are re-argued on
+    their own merits. What survives here is the mechanical half of that: if a seam takes
+    ``narrowing`` and a site is nonetheless exempt, the exemption must not be justified
+    by the seam's shape. It also fails on a stale entry (naming a site the walk no
+    longer finds), so the registry cannot accumulate dead permissions.
+
+    ⚠️ This test cannot check that a merit-based reason is TRUE — no test can read
+    prose. What makes a remaining exemption weigh-able is its ``_SITE_PARENT_LAYERS``
+    entry (required by ``test_every_spawn_site_declares_its_parent_layers``) plus the
+    behavioural measurement that entry names.
     """
     seam_by_name = {s.name: s for s in _SPAWN_SEAMS}
     sites = _spawn_call_sites()
     for key in sorted(_NARROWING_EXEMPT_SITES):
+        reason = _NARROWING_EXEMPT_SITES[key]
         seams_here = {s.seam for s in sites if s.key == key and not s.has_narrowing}
         assert seams_here, (
             f"_NARROWING_EXEMPT_SITES lists {key!r}, but the walk finds no "
             "narrowing-less spawn call there — a stale exemption"
         )
+        assert reason.strip(), f"{key!r} is exempt with no stated reason"
         for seam_name in sorted(seams_here):
             params = inspect.signature(seam_by_name[seam_name].func).parameters
-            assert "narrowing" not in params, (
-                f"{key!r} is exempted from passing narrowing=, but the seam it calls "
-                f"({seam_name}) DOES take a narrowing parameter — the exemption's "
-                "stated reason is no longer true. Pass it, or re-argue the exemption."
+            if "narrowing" not in params:
+                continue
+            assert reason != _UNMET_NO_NARROWING_CHANNEL, (
+                f"{key!r} is exempted from passing narrowing= on the grounds that "
+                f"{seam_name} has no such parameter, but it DOES — the exemption's "
+                "stated reason is false. Pass it, or re-argue the exemption on its "
+                "merits."
             )
 
 

--- a/tests/test_3562_slash_session_new_narrowing_inheritance.py
+++ b/tests/test_3562_slash_session_new_narrowing_inheritance.py
@@ -1,0 +1,382 @@
+"""Tier 2: OS invariant — a session opened by ``/session new`` is born INSIDE the
+invoking session's per-session capability narrowing.
+
+#3562, the gap #3561 declared and did not close. ``interfaces/slash/session.py::
+session_cmd`` calls ``AgentRegistry.spawn_session`` — the sync primitive, which until
+this change had no ``narrowing`` channel at all — and carried nothing from its caller,
+so the child's #2103-S1a layer was empty however narrow its invoker was.
+
+★ **Why this file exists is an OWNER POLICY decision, not a containment argument, and
+the difference is load-bearing enough to state before the tests.** The gap was first
+argued as a security one: #3561 had measured that ``/session new`` was reachable from
+MODEL OUTPUT (an agent step's prompt arrived as ``kind="user"``, so a ``/``-prefixed
+line short-circuited to ``_maybe_handle_slash`` before any router turn), which made an
+un-narrowed child an escape. ★ #3595 step 1 ruled that reachability a DEFECT and closed
+it: the agent-step prompt now rides its own inbox kind, and
+``tests/test_3561_spawn_session_seam_reachability.py`` measures its absence
+(``test_model_output_cannot_reach_slash_dispatch_and_spawns_nothing``) next to an
+operator control. So the escape argument is retired, and this file does not rest on it.
+
+What remains, and what these tests measure, is the owner's ruling on the plain
+question — if an operator has switched ``write_file`` off for their session and then
+opens a new one from it, should ``write_file`` work there? — answered no. A session
+opened from a narrowed session stays narrowed. That claim is about operator intent
+persisting across a spawn, and it is unaffected by who can reach the command.
+
+The composition is the three sibling sites' rule
+(``capability_profile.compose_narrowing_mappings``: deny ∪, allow ∩, an absent allow
+key = ⊤), restrict-only in every direction, applied UNIFORMLY — no branch for the case
+where the invoking session's agent differs from the ATTACHED agent the child is born
+under. ``name = reg.attached_name``, so on the operator path the caller IS the attach
+target and the identities coincide; there is no live cross-identity case to branch on,
+and a branch would be a lenient special case for exactly the caller a uniform
+restrict-only rule exists to bound.
+
+★ **What is the witness, and what is not.** The two behavioural legs below assert on
+``write_file``'s REAL side effect — a file on disk — next to a positive control that
+observes the same tool running when nothing narrows it. They deliberately do NOT read
+``capability_visibility_state()``: that surface re-resolves with the sid on every read
+and was GREEN on the broken code #3561 fixed, where the envelope was resolvable but not
+enforced. The reply line this PR adds is rendered FROM that same surface, so it is an
+explanation for the operator, not evidence that anything is enforced — it gets its own
+test (``test_the_reply_names_what_the_new_session_inherited``) for its own, separate
+claim.
+
+The user-visible consequence is real and intended (owner-approved): an operator whose
+own session is narrowed now gets a narrowed new session. The asymmetry behind it is
+recoverability — an over-narrow child announces itself (something is refused, and the
+operator can re-open from an unnarrowed session), whereas the over-wide child the old
+code produced announced nothing at all.
+
+The completeness half of this gate — which spawn sites exist and what each declares —
+lives in ``tests/test_3546_pipeline_driver_narrowing_inheritance.py``; this module is
+what its declaration for ``interfaces/slash/session.py::session_cmd`` now points at.
+"""
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.model_resolver import ModelResolver
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.message_bus import MessageBus
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.runtime.session_params import PresentationWiring
+from reyn.runtime.spawn_routing import AuditOnlyNoSurface
+from reyn.runtime.transport import SystemRef
+from tests._support.agent_session import make_session
+from tests._support.permissions import make_resolver
+
+#: The capability the invoking session is narrowed away from. A production,
+#: catalog-listed tool whose execution leaves an observable trace on disk.
+_DENIED_TOOL = "write_file"
+
+#: The agent whose session invokes ``/session new``.
+_INVOKER_AGENT = "worker"
+
+#: The ATTACHED agent — the one ``/session new`` opens the child under. Different from
+#: the invoker on purpose: it is the cross-identity shape, the one the composition must
+#: NOT branch on, and driving it here means the uniform rule is exercised rather than
+#: assumed from the same-identity case that an operator's own keystroke produces.
+_ATTACHED_AGENT = "operator"
+
+
+def _out_name() -> str:
+    """A witness filename unique to ONE test run.
+
+    Searched for across the whole per-worker tmp tree rather than this test's own
+    ``tmp_path`` — a session's workspace does not necessarily resolve where the test's
+    cwd points, and #3561 recorded an earlier version of a sibling leg going green on
+    BROKEN code for exactly that reason (the denied write landed under a sibling test's
+    directory, so a narrow search found nothing and the absence read as a denial).
+    """
+    return f"p3562_out_{uuid.uuid4().hex}.txt"
+
+
+class _WritesOnceLLM:
+    """A real ``_llm_caller``-shaped callable: the FIRST turn asks for ``_DENIED_TOOL``,
+    every later turn answers in plain text so the loop terminates whether or not the
+    call was allowed. Not a ``MagicMock`` — a drift in the ``call_llm_tools`` keyword
+    contract raises ``TypeError`` here exactly as it would in production.
+
+    ``turns`` is load-bearing: an absence on disk observed because the session never
+    took a turn is indistinguishable from one observed because the capability was
+    denied, so every leg asserts the turn happened before reading the filesystem.
+    """
+
+    def __init__(self, out_name: str) -> None:
+        self.out_name = out_name
+        self.turns = 0
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.turns += 1
+        if self.turns == 1:
+            return LLMToolCallResult(
+                content=None,
+                tool_calls=[{
+                    "id": "c3562", "type": "function",
+                    "function": {
+                        "name": _DENIED_TOOL,
+                        "arguments": '{"path": "%s", "content": "ran"}' % self.out_name,
+                    },
+                }],
+                finish_reason="tool_calls",
+                usage=TokenUsage(prompt_tokens=1, completion_tokens=1),
+            )
+        return LLMToolCallResult(
+            content="done", tool_calls=[], finish_reason="stop", usage=TokenUsage(),
+        )
+
+
+def _written(tmp_path: Path, out_name: str) -> "list[str]":
+    """Every on-disk copy of the witness file — the side effect itself, never a status
+    string — searched from the per-worker tmp ROOT. See :func:`_out_name`."""
+    return sorted(str(p) for p in tmp_path.parent.rglob(out_name))
+
+
+def _registry(tmp_path: Path, scripted: "_WritesOnceLLM") -> AgentRegistry:
+    """Real ``AgentRegistry`` + real ``Session`` factory — the harness shape
+    ``tests/test_3561_spawn_session_seam_reachability.py`` uses, including the
+    ``holder`` deferred-registry-ref (so a spawned session gets ``registry=``) and a
+    real-litellm-name resolver (so a spawned session's model-support pre-check has a
+    name to resolve).
+
+    ``file.write`` is approved at the PERMISSION layer, so a write that does not happen
+    is the capability narrowing refusing it and not the write gate — the confusion that
+    made an earlier version of #3561's legs read "denied" everywhere, including the
+    un-narrowed control.
+    """
+    if not (tmp_path / "reyn.yaml").exists():
+        (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    holder: dict = {}
+    resolver = ModelResolver({"standard": "gemini/gemini-2.5-flash-lite"})
+    perms = make_resolver(tmp_path, config={"file.write": "allow"})
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
+        s = make_session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            permission_resolver=perms, workspace_base_dir=tmp_path,
+            presentation_wiring=PresentationWiring(
+                presentation_consumer=presentation_consumer,
+                intervention_bridge=intervention_bridge,
+            ),
+            resolver=resolver,
+        )
+        s._loop_driver._loop_observer = (
+            lambda loop: setattr(loop, "_llm_caller", scripted)
+        )
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    for name in (_INVOKER_AGENT, _ATTACHED_AGENT):
+        if not reg.exists(name):
+            reg.create(name)
+    return reg
+
+
+async def _drive(session: Session, text: str) -> "list[OutboxMessage]":
+    """Run ONE real turn on ``session`` through the production run+collect primitive
+    (``MessageBus.request``). Returns the turn's outbox messages, which is where a slash
+    reply lands.
+
+    ★ ``kind="user"`` is a deliberate claim, not a convenience. Since #3595 step 1 that
+    kind means specifically "an operator typed this at a client", and it is the only one
+    whose text ``Session._handle_user_message`` interprets as a command surface before
+    handing it to the shared turn body (``_handle_inbox_text``). Simulating an operator
+    keystroke is exactly what these legs need — the ONLY face that reaches ``/session
+    new`` today — so this is the right side of that split. A producer that is not an
+    operator would have to call the lower half directly and could not run the command at
+    all, which is ``tests/test_3561_spawn_session_seam_reachability.py``'s subject."""
+    return await MessageBus().request(
+        session, kind="user", payload={"text": text, "chain_id": "c3562t"},
+        reply_to=SystemRef(), timeout=30,
+    )
+
+
+async def _invoker(
+    reg: AgentRegistry, narrowing: "dict | None",
+) -> Session:
+    """The session that will type ``/session new`` — spawned under ``_INVOKER_AGENT``
+    with (or without) a per-session narrowing of its own, through the recorded seam that
+    is the production writer of that layer."""
+    routing = AuditOnlyNoSurface()
+    sid = await reg.spawn_session_recorded(
+        _INVOKER_AGENT, mode="persistent", narrowing=narrowing,
+        presentation_consumer=routing.presentation_consumer,
+        intervention_bridge=routing.intervention_bridge,
+    )
+    session = reg.get_session(_INVOKER_AGENT, sid)
+    assert session is not None
+    return session
+
+
+async def _open_child(reg: AgentRegistry, invoker: Session) -> "tuple[str, list[OutboxMessage]]":
+    """Drive ``/session new`` on ``invoker`` and return the sid of the session that was
+    born under the ATTACHED agent, plus the turn's outbox messages.
+
+    Fails loudly if no session appeared: every leg below is about the child's envelope,
+    and a leg that measured a child which does not exist would be vacuous.
+    """
+    reg.get_or_load(_ATTACHED_AGENT)  # attach_session focuses, it never builds
+    await reg.attach_session(_ATTACHED_AGENT, "main")
+    before = set(reg.session_ids(_ATTACHED_AGENT))
+    replies = await _drive(invoker, "/session new")
+    born = set(reg.session_ids(_ATTACHED_AGENT)) - before
+    assert len(born) == 1, (
+        f"/session new did not open exactly one session under {_ATTACHED_AGENT!r} "
+        f"(new: {sorted(born)!r}) — the leg would then be measuring nothing"
+    )
+    return born.pop(), replies
+
+
+@pytest.mark.asyncio
+async def test_the_witness_tool_runs_when_the_invoker_is_not_narrowed(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: the POSITIVE CONTROL — a session opened by ``/session new`` from an
+    UN-narrowed invoker really does reach ``write_file``'s handler and put a file on
+    disk.
+
+    Not ceremony. #3561 recorded a version of these legs reporting "denied" on every arm
+    including the control, because ``file.write`` was refused by the permission resolver
+    rather than by any narrowing — an absence that proved nothing while looking exactly
+    like proof. The leg below observes a side effect NOT happening; it is only readable
+    next to one that observes it happening.
+    """
+    monkeypatch.chdir(tmp_path)
+    out_name = _out_name()
+    scripted = _WritesOnceLLM(out_name)
+    reg = _registry(tmp_path, scripted)
+
+    invoker = await _invoker(reg, narrowing=None)
+    child_sid, _ = await _open_child(reg, invoker)
+    child = reg.get_session(_ATTACHED_AGENT, child_sid)
+    assert child is not None
+
+    await _drive(child, "write it")
+
+    assert scripted.turns >= 2, (
+        f"the child session never finished a turn (turns={scripted.turns}) — the leg "
+        "below would then be asserting an absence caused by nothing running"
+    )
+    assert _written(tmp_path, out_name), (
+        "the witness tool did not execute even with nothing narrowing it, so an absence "
+        "observed in the narrowed leg would say nothing about the narrowing"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_session_opened_by_slash_session_new_cannot_run_a_tool_its_invoker_is_denied(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: a session opened by ``/session new`` from a NARROWED invoker cannot
+    execute a capability that invoker is denied.
+
+    The invoker is a session of one agent and the child is born under a DIFFERENT
+    (attached) agent — the cross-identity shape — and the narrowing is carried anyway.
+    That is the uniform rule being exercised rather than assumed: the same-identity case
+    an operator's own keystroke produces would pass under a lenient special case too, so
+    the leg that distinguishes them is this one.
+
+    The assertion is the file's ABSENCE, next to
+    ``test_the_witness_tool_runs_when_the_invoker_is_not_narrowed``'s presence. Before
+    #3562 the same setup wrote the file: the child's #2103-S1a layer was empty, so the
+    RouterLoop's advertisement filter and its ``_excluded_result`` call-time gate had
+    nothing to read.
+    """
+    monkeypatch.chdir(tmp_path)
+    out_name = _out_name()
+    scripted = _WritesOnceLLM(out_name)
+    reg = _registry(tmp_path, scripted)
+
+    invoker = await _invoker(reg, narrowing={"tool_deny": [_DENIED_TOOL]})
+    child_sid, _ = await _open_child(reg, invoker)
+    child = reg.get_session(_ATTACHED_AGENT, child_sid)
+    assert child is not None
+
+    await _drive(child, "write it")
+
+    assert scripted.turns >= 1, (
+        "the child session never took a turn, so the absence below is vacuous"
+    )
+    assert not _written(tmp_path, out_name), (
+        "a session opened by /session new executed a tool the session that opened it is "
+        "denied — the invoker's per-session narrowing was not carried into the child's "
+        f"envelope (written: {_written(tmp_path, out_name)!r})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_reply_names_what_the_new_session_inherited(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: the ``/session new`` reply tells the operator which capabilities the new
+    session inherited a denial of.
+
+    A SEPARATE claim from the two legs above, deliberately: with ``allow ∩`` composed
+    uniformly, a child can be born with few or no usable capabilities, which is safe but
+    opaque — an operator would otherwise see a new session id and no reason for anything
+    that later refuses. The line is rendered from the child's own
+    ``capability_visibility_state()`` (the existing #2285/#3378 read model, no new
+    mechanism).
+
+    ⚠️ This is the EXPLANATION's test, not the enforcement's. That surface re-resolves
+    with the sid on every read and was green on the broken code #3561 fixed; the
+    inheritance itself is measured by the denied tool's side effect not happening,
+    above. The assertions here are on the presence of the denied capability's NAME and
+    of the invoking session's sid — never on layout, wording or ordering.
+    """
+    monkeypatch.chdir(tmp_path)
+    scripted = _WritesOnceLLM(_out_name())
+    reg = _registry(tmp_path, scripted)
+
+    invoker = await _invoker(reg, narrowing={"tool_deny": [_DENIED_TOOL]})
+    child_sid, replies = await _open_child(reg, invoker)
+
+    text = "\n".join(m.text for m in replies if m.text)
+    assert child_sid in text, "the reply does not name the session it opened"
+    assert _DENIED_TOOL in text, (
+        "the reply does not name the capability the new session inherited a denial of, "
+        f"so the operator has no stated reason for a later refusal (reply: {text!r})"
+    )
+    assert "inherit" in text.lower(), (
+        f"the reply does not say the restriction was INHERITED, which is the one thing "
+        f"that tells the operator where it came from (reply: {text!r})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_unnarrowed_invoker_reply_stays_free_of_inheritance_noise(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: with nothing to inherit, the ``/session new`` reply says nothing about
+    inheritance.
+
+    The negative half of the leg above, and the one that makes it non-vacuous: a reply
+    that always carried the line would satisfy the positive assertion while saying
+    nothing about the child. It also pins the inert case — an operator who is not
+    narrowed sees exactly what they saw before #3562.
+    """
+    monkeypatch.chdir(tmp_path)
+    scripted = _WritesOnceLLM(_out_name())
+    reg = _registry(tmp_path, scripted)
+
+    invoker = await _invoker(reg, narrowing=None)
+    child_sid, replies = await _open_child(reg, invoker)
+
+    text = "\n".join(m.text for m in replies if m.text)
+    assert child_sid in text, "the reply does not name the session it opened"
+    assert "inherit" not in text.lower(), (
+        f"the reply claims an inherited restriction where the invoker has none — the "
+        f"positive leg would then be satisfied by a constant string (reply: {text!r})"
+    )

--- a/tests/test_slash_budget_session_reload_cmds.py
+++ b/tests/test_slash_budget_session_reload_cmds.py
@@ -17,6 +17,12 @@ from reyn.runtime.outbox import OutboxMessage
 
 
 class _FakeSession:
+    #: (#3562) ``/session new`` looks the INVOKING session's own (agent, sid) up to find
+    #: the per-session narrowing the child inherits, so the stand-in carries the two
+    #: identity fields the real ``Session`` exposes.
+    agent_name = "alpha"
+    session_id = "main"
+
     def __init__(
         self,
         *,
@@ -83,8 +89,18 @@ class _FakeRegistry:
         self._spawn_raises = spawn_raises
         self._get_session_result = get_session_result
 
+    def per_session_narrowing(self, name: str, sid: "str | None" = None) -> "dict | None":
+        """#3562: no per-session capability layer on this stand-in's sessions, so the
+        handler's inheritance branch is inert and these tests keep measuring the
+        dispatch paths they were written for. ★ The inheritance is measured against real
+        instances — by a denied tool's real side effect — in
+        ``tests/test_3562_slash_session_new_narrowing_inheritance.py``, never here: a
+        stand-in that answers None can only exercise the empty case."""
+        return None
+
     def spawn_session(
         self, name: str, *, presentation_consumer=None, intervention_bridge=None,
+        narrowing: "dict | None" = None,
     ) -> str:
         if self._spawn_raises is not None:
             raise self._spawn_raises

--- a/tests/test_slash_session_1726.py
+++ b/tests/test_slash_session_1726.py
@@ -19,7 +19,16 @@ from reyn.runtime.outbox import OutboxMessage
 
 
 class _StubRegistry:
-    """Stub of the registry surface the /session handler reads/calls."""
+    """Stub of the registry surface the /session handler reads/calls.
+
+    #3562: ``per_session_narrowing`` answers None (this stub's sessions carry no
+    per-session capability layer), so the handler's inheritance branch is inert here and
+    these tests keep measuring what they were written for — the command flow and its
+    replies. ★ The inheritance itself is NOT measured against this stub and must not be:
+    a stand-in that answers None can only ever exercise the empty case. It is measured
+    against real instances, by a denied tool's real side effect, in
+    ``tests/test_3562_slash_session_new_narrowing_inheritance.py``.
+    """
 
     def __init__(self, *, attached_name="default", sids=("main",), focused="main"):
         self._attached_name = attached_name
@@ -31,7 +40,13 @@ class _StubRegistry:
     def attached_name(self):
         return self._attached_name
 
-    def spawn_session(self, name, *, presentation_consumer=None, intervention_bridge=None):
+    def per_session_narrowing(self, name, sid=None):
+        return None
+
+    def spawn_session(
+        self, name, *, presentation_consumer=None, intervention_bridge=None,
+        narrowing=None,
+    ):
         sid = f"s{len(self._sids)}"
         self._sids.append(sid)
         self.spawned.append(name)
@@ -45,6 +60,11 @@ class _StubRegistry:
 
 
 class _FakeSession:
+    #: (#3562) The handler looks its OWN (agent, sid) up to find what to inherit, so the
+    #: stand-in carries the two identity fields the real ``Session`` exposes.
+    agent_name = "default"
+    session_id = "main"
+
     def __init__(self, registry):
         self._registry = registry
         # reply()/reply_error() and the switch sentinel all route through


### PR DESCRIPTION
**[per-PR-coder]** — part of #3562.

## 🔴 This PR is NOT an escape fix — read it as an owner policy decision

★ **The rationale has been replaced since this PR was opened, and the original one is retired.** It first stood on containment: #3561 had measured that `/session new` was reachable from MODEL OUTPUT, which made an un-narrowed child an escape. **#3595 ruled that reachability a defect and closed it on `main` (#3596 / #3597)** — an agent-step prompt no longer claims `kind="user"`, so it never enters the slash dispatch at all. ★ **Do not read this PR as blocking an escape; that hole is already shut, elsewhere.**

What this PR stands on is the owner's ruling on the plain question — *if an operator switches `write_file` off for their session and then runs `/session new`, should `write_file` work in the new session?* — **"使えるべきじゃないね"**. Operator intent persists across the spawn. That claim never depended on who could reach the command, which is why closing the reachability changed nothing here. The rationale is now stated in `slash/session.py` at the call site, in the #3562 test module's docstring, and in the `_SITE_PARENT_LAYERS` declaration — not only in this body.

## ✅ User-visible behaviour change — owner-approved

**An operator whose own session is narrowed now gets a narrowed new session.** The trade, stated as a trade: inheriting can produce a session that is *too narrow*, which the operator notices immediately (something is refused) and can recover from (re-open from an unnarrowed session, or lift the narrowing). Not inheriting produces a session that is *too wide*, which nobody notices and no surface reports after the fact — including the case where the operator never knew they were narrowed (#1827 taint-derived narrowing is not operator-set).

**There is no second behaviour change.** No session-lifecycle change of any kind: nothing gained or lost a `session_spawned` record, nothing became (or stopped being) rewind-tracked or re-materialisable, and `spawn_session_recorded`'s own sequence is unchanged (see *Measured, not assumed* below — I tried to simplify it and the tests said no).

## The defect

`interfaces/slash/session.py::session_cmd` called `AgentRegistry.spawn_session` carrying nothing from its invoker, so the child's #2103-S1a per-session layer was empty however narrow its invoker was — and stayed empty for an operator who had just narrowed themselves. (#3561 first surfaced the site by measuring a model-output path to it; that path is gone as of #3596, and the empty-layer defect is unchanged by its removal.)

## The lifecycle decision — (a), written into the code

The issue asked for a deliberate choice between (a) adding a `narrowing` channel to `spawn_session` and (b) routing `/session new` through `spawn_session_recorded`. **This PR takes (a)**, and `spawn_session`'s docstring carries the reason so a later reader can tell a decision from an omission:

(b) would have carried three unrelated changes along with the fix — a `session_spawned` WAL record making an operator-opened session rewind-tracked and re-materialisable (so a rewind past the command would start **dropping the operator's session**, a lifecycle change nobody asked for), a spawn-time `refresh_config_projections()`, and async-ness. (a) changes exactly one observable thing: the child's envelope. The channel also belongs on the primitive on the merits — it is where the sid becomes known, which is why #3561 put the *injection* there, and it is the seam all five direct callers share.

Both entry points now write the file through **one writer** (`_persist_session_narrowing`), so they cannot drift from each other or from its reader.

## ★ Measured, not assumed — the one place my reasoning was wrong

I first had `spawn_session_recorded` hand its `narrowing` down the new channel too (one writer, one injection point), reasoning that its later re-inject was redundant because `refresh_config_projections()` re-resolves the envelope from base *with the sid* and would therefore read the file. **The full suite falsified that**: `test_spawn_session_recorded_enforces_narrowing_on_live_session` and `test_spawn_ephemeral_session_narrowing_applied` went RED with an empty live `tool_deny`.

The cause, traced rather than guessed: `reapply_visibility_override` re-resolves from base and **SETs**. On a session with **no registry back-reference** there is no base to re-resolve, so it sets an ALLOW-ALL envelope and silently discards anything injected before it. The old ordering (inject *after* the refresh) was load-bearing, not incidental.

So `spawn_session_recorded` keeps its own write + inject after the refresh, and that ordering is now pinned by a comment naming both tests. Its `_NARROWING_EXEMPT_SITES` entry states the measurement.

🔎 **Latent hazard found on the way, not fixed here** (flagging for lead to decide whether to file): "re-resolve from base, then SET" *widens to allow-all when the base is unavailable* — a fail-open in a security-core path. Today it is contained (production sessions carry the registry ref; the two paths that inject without a later refresh are recovery and `/session new`), which is why I did not widen this PR's scope into #2285/#3097 territory on my own judgement.

## Composition — uniform, no cross-identity branch

`capability_profile.compose_narrowing_mappings(parent, None)` (deny ∪ / allow ∩ / absent allow = ⊤), the three sibling sites' rule. No branch for the cross-identity case: `name = reg.attached_name`, so on the operator path — the only face that reaches this site now — the caller *is* the attach target and the identities coincide, leaving no live cross-identity case to branch on. A branch would be a lenient special case for exactly the caller a uniform restrict-only rule exists to bound.

⚠️ Architect's original argument for uniformity was sharper and is now retired with the reachability it rested on ("the identities differ only when model output reaches the site, so *the identity differs* is the same event as *the escape is happening*"). **The decision is unchanged; only its support is.** The test still drives the cross-identity shape (invoker under one agent, child under the attached one), so the uniform rule is exercised rather than assumed — a lenient special case would pass the same-identity leg.

## The inherited-restriction line

`/session new`'s reply names what the child inherited (denied capability names, plus a second line when no tools remain), rendered from the child's existing `capability_visibility_state()` — no new mechanism.

🔴 **It is not the witness.** That surface re-resolves with the sid on every read and was GREEN on the broken code #3561 fixed. The inheritance is witnessed on the side-effect side (a denied tool's file does not appear); the display has its own separate test for its own separate claim, plus a negative twin asserting an unnarrowed invoker's reply carries no inheritance line — otherwise a constant string would satisfy the positive leg.

## Strip-falsify (both halves; anchors confirmed unique with `grep -c` → 1 first)

| strip | result |
|---|---|
| baseline | `tests/test_3562_*.py` **4 passed** |
| remove `narrowing=inherited` at the slash call site | **2 failed, 2 passed** — RED: the enforcement witness + the display test; GREEN: both controls, correctly (they assert the *un*narrowed case) |
| restore | **4 passed** |
| remove `self._persist_session_narrowing(...)` in the primitive | **2 failed, 15 passed** across #3562 + #3556 + #3553 — the same two legs RED; the sibling seams stay green, correctly, because `spawn_session_recorded` writes its own (that is exactly the split the ordering finding above forced) |
| restore | **4 passed**; **76 passed** across the whole affected set |

## Gate bookkeeping

- `tests/test_3546_*.py`'s `_SITE_PARENT_LAYERS` entry for `("reyn/interfaces/slash/session.py", "session_cmd")` — the declaration of this gap — is replaced by what the site now composes, pointing at the new behavioural legs.
- ★ Adding the channel expired **all five** `_NARROWING_EXEMPT_SITES` entries, not just the slash one — `test_narrowing_exempt_sites_have_no_narrowing_channel` reads the live signature and was built to do exactly that. **This is the piece the issue body does not mention**; it is most of the test-side diff. One site left the table by *using* the channel; the remaining four are re-argued on the merits: `resolve_session` has no spawner to inherit from; the recovery pair would not pass a no-op but an **overwrite** of the recovering session's own durable layer (the primitive persists what it is given); `spawn_session_recorded` must inject later than the primitive offers (measured — above). The test is re-grounded as `test_no_exemption_claims_a_channel_that_exists`.
- #3561's reachability legs stay green — **verified by running them**, both before the rebase (the original `test_model_output_reaches_slash_dispatch_and_spawns_a_session`) and after it (#3596's inverse `test_model_output_cannot_reach_slash_dispatch_and_spawns_nothing` plus its operator control `test_an_operator_submitted_slash_command_still_spawns_a_session`). They measure WHO reaches the site; this PR measures what the child inherits — orthogonal axes, and the site declaration now says so explicitly so a later reader cannot mistake one pair for the other's evidence.
- Two pre-existing files drive `/session new` through hand-rolled stand-ins (`test_slash_session_1726.py`, `test_slash_budget_session_reload_cmds.py`) and broke loudly on the new reads, which is the correct failure. They are extended to mirror the real surface (`per_session_narrowing` → None, the two identity fields), with a docstring in each saying the inheritance is measured against **real instances** in `tests/test_3562_*.py` and must not be read off a stand-in that can only ever exercise the empty case.

## Recovery-feature gate

Not triggered on the merits, and this is a judgement rather than an omission: the reconstruction source for this layer is the sid's `config.yaml` under the per-session state dir, not a WAL-event — and #3564 already added the truncate-falsify pair for exactly that claim (`test_persisted_narrowing_survives_a_wal_truncation_past_its_spawn_record` + its un-narrowed twin), which this PR runs green unchanged. This PR does not add a new reconstruction source.

## Rebase onto #3596 / #3597 — what conflicted and how it was resolved

**One conflict, in `tests/test_3546_*.py`** — the `session_cmd` site declaration, which both sides had rewritten. ★ **No source conflict at all**: this PR touches `slash/session.py` and `registry.py`; #3596 split `session.py`, which this PR never edits.

The resolution is a **union of two claims, not a pick of one side**. `main`'s side said *who can reach the site* (the model-output path is closed; the site stays enumerated because this gate counts where an envelope is BORN, not where a model can reach). My side said *what the site now composes*. Both are true and neither implies the other, so the entry states both and its `measured_by` names all four legs — `_S3561`'s inverted pair **and** `_S3562`'s inheritance pair — with a sentence saying which pair measures which claim, so a later reader cannot take one as the other's evidence.

★ **Checked specifically for the hazard you named** — whether the resolution moved anything across the `_handle_user_message` / `_handle_inbox_text` split. It did not, and not by inspection alone: this PR's tests drive the invoker with `kind="user"`, the operator entry *above* the split (the only kind whose text is still slash-interpreted), and they spawn — measured, green. The harness docstring now states that the kind claim is deliberate and which side of the split it is on, so a future edit that moves it will read as a change rather than a detail.

**Prose that rested on the retired argument was rewritten, not left standing** — in `slash/session.py`'s call-site comment, this PR's test module docstring, its cross-identity test docstring, and the site declaration. ⚪ One drive-by: `test_3546_*.py`'s module docstring still asserted "model output … observes it reach `/session new` … the guess is false" in the present tense, which #3596 falsified and did not update. Fixed here because my resolution sits three lines below it and had to re-argue the same claim — leaving the two adjacent and contradicting would be exactly the drift the doc rule targets.

## Test plan

- [x] `ruff check src tests` — All checks passed
- [x] `python scripts/test_tier_audit.py --strict` on the four changed/added test files — 40 inspected, 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/registry.py src/reyn/interfaces/slash/session.py` — OK
- [x] `pytest` from the repo root, foreground, terminal line read myself (result in the Verification section below)
- [x] Strip-falsify both halves: RED confirmed, restored, GREEN confirmed (table above)
- [x] Anchor uniqueness confirmed (`grep -c` → 1) before each strip
- [x] `scripts/check_pr_closing_intent.py`'s own `_CLOSING_RE` run over this body and every commit message — 0 closing declarations, 1 `part of` declaration for #3562

## Verification

| gate | result |
|---|---|
| `ruff check src tests` | All checks passed! |
| `python scripts/test_tier_audit.py --strict` (4 files) | 40 inspected · OK 40 · warnings 0 · errors 0 · exit 0 |
| `python scripts/verify_module_docstrings.py` (2 src files) | OK |
| `pytest` (repo root, foreground, **post-rebase**, exit 0) | **9867 passed, 36 skipped, 0 failed** in 739s (12:19) |

★ Identity of what was measured, since a suite number is only worth its subject: the run was launched **after** `git rebase --continue` and `git status` was **clean** at its start and at its end, so the tree it measured is exactly the two commits on this branch. Neither known intermittent fired — `test_textual_chat_gutter_toggle_3352.py:333` (#3590) and `test_fp0066_p3b_repo_knowledge_ingest.py:198` (#3594) both passed, so nothing here is attributed to them.

★ Both witness sets green together, run as one invocation (`22 passed`): this PR's inheritance pair + display pair, and #3596's `test_model_output_cannot_reach_slash_dispatch_and_spawns_nothing` + `test_an_operator_submitted_slash_command_still_spawns_a_session`, plus the #3546 gate.

## Docs

`docs/concepts/multi-agent/sessions.md` described permissions as identity-scoped and shared across an Agent's sessions, with no mention of the session-scoped narrowing layer this PR makes visibly inheritable. A paragraph now states the layer, the inheritance, and the reason. (No `.ja.md` obligation invoked — the ja sibling asserts nothing this PR falsifies.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
