### PR TITLE
fix(runtime): an agent step's prompt stops claiming the "user" inbox kind — part of #3595

### DIFF
--- a/docs/concepts/tools-integrations/skills.md
+++ b/docs/concepts/tools-integrations/skills.md
@@ -157,7 +157,7 @@ so `:skill` does not add a `require_file_read` gate around the read.
 Implementation: `reyn.interfaces.skill_invoke` (the parser / substitution /
 collision-lookup helpers, pure functions) and
 `Session._maybe_handle_skill_invoke` (the dispatch point in
-`_handle_user_message`, mirroring `_maybe_handle_slash`'s shape).
+`_handle_inbox_text`, mirroring `_maybe_handle_slash`'s shape).
 
 **Audit trail.** The `:` invoke path emits its own `skill_invoke_body_loaded`
 audit-event for each loaded skill body (name, path), scoped separately from
@@ -166,13 +166,15 @@ the ordinary `file.read`/`load_skill` op's `skill_body_loaded` event (see
 replay distinguish "the model read this skill on its own" from "the operator
 explicitly invoked it via `:name`".
 
-### Call-site mechanics (`_handle_user_message`)
+### Call-site mechanics (`_handle_inbox_text`)
 
-`Session._maybe_handle_skill_invoke` returns a `(consumed, text)` tri-state read by
-`_handle_user_message` right after the `/`-slash short-circuit:
+`Session._maybe_handle_skill_invoke` returns a `(consumed, text)` tri-state read at
+the top of `_handle_inbox_text` — the turn body `_handle_user_message` enters right
+after the `/`-slash short-circuit (#3595 step 1 split the two apart, so `/` is now
+an OPERATOR-entry-only step while `:` stays on the shared body):
 
 - `consumed is True` — the invocation was fully handled here (e.g. `:list`, an
-  unknown-name error, a `skill_invoke_collision` warning); `_handle_user_message`
+  unknown-name error, a `skill_invoke_collision` warning); `_handle_inbox_text`
   returns immediately, no router turn happens.
 - `consumed is False` — either `text` wasn't `:`-shaped after all, or it was and
   resolved successfully; `text` is REPLACED with the composed skill body(ies) +

--- a/docs/reference/runtime/pipeline-dsl.md
+++ b/docs/reference/runtime/pipeline-dsl.md
@@ -432,7 +432,12 @@ Every `agent` step, wherever it is reached (top-level or fanned out inside a
 #### Agent-step exception surfacing (#187 / #2732)
 
 An `agent` step's leaf session (`spawn_ephemeral_session`, always
-`mode="ephemeral"`) drives its router loop inside `Session._handle_user_message`.
+`mode="ephemeral"`) drives its router loop inside `Session._handle_inbox_text`.
+(#3595 step 1: the prompt rides the inbox as `AGENT_STEP_INBOX_KIND`
+(`"agent_step"`), not `"user"`, and `_run_turn_body` routes that kind straight to
+this shared turn body — so a prompt that happens to start with `/` is content the
+model reads, never a slash command the OS executes. `_handle_user_message` is now
+the OPERATOR entry alone: slash dispatch, then this same body.)
 Two hardening passes changed how a mid-work failure there reaches the pipeline
 executor:
 
@@ -449,7 +454,8 @@ AND emits a `router_loop_terminated_by_exception` audit event (`chain_id`,
 
 **#2732 — the classified-summary path silently produced a successful-looking
 empty answer for agent steps.** The catch-all `except Exception` in
-`_handle_user_message` is intentionally broad (any LLM-call or router-loop
+`_handle_inbox_text` (in `_handle_user_message` until #3595 split the body out)
+is intentionally broad (any LLM-call or router-loop
 exception, not only credential errors) — that breadth predates #2732. What
 #2732 fixed is what happens *after* classification for an ephemeral session:
 `spawn_ephemeral_session` hardcodes `mode="ephemeral"`, and `run_agent_step`'s

--- a/src/reyn/interfaces/skill_invoke.py
+++ b/src/reyn/interfaces/skill_invoke.py
@@ -117,7 +117,7 @@ def parse_skill_invocation(text: str) -> "ParsedSkillInvocation | None":
     """Parse a leading ``:name [:name2 ...] [trailing text]`` stack.
 
     Returns ``None`` when *text* does not start with a ``:name``-shaped
-    token at all — the caller (``Session._handle_user_message``) then falls
+    token at all — the caller (``Session._handle_inbox_text``) then falls
     through to ordinary message handling untouched, so a message that merely
     starts with a literal colon in prose (rare, but not impossible) is never
     misrouted into an "unknown skill" error. Once at least one valid

--- a/src/reyn/interfaces/slash/image.py
+++ b/src/reyn/interfaces/slash/image.py
@@ -210,7 +210,7 @@ async def image_cmd(session: object, args: str) -> None:
         "mime_type": mime,
         "content_hash": content_hash,
     }
-    # Queue is drained by Session._handle_user_message on the next
+    # Queue is drained by Session._handle_inbox_text on the next
     # user turn (= attached to that ChatMessage.media).
     queue: list[dict] = getattr(session, "_pending_user_images", None)
     if queue is None:

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1690,7 +1690,7 @@ class RouterLoop:
                 )(),
                 non_interactive=self._non_interactive,
             )
-        # Session._handle_user_message appends the user turn to history
+        # Session._handle_inbox_text appends the user turn to history
         # BEFORE invoking _run_router_loop, so by the time we get here the
         # caller's `history` argument already ends with this turn's user
         # message. Appending it again as a trailing user message creates a

--- a/src/reyn/runtime/services/budget_gateway.py
+++ b/src/reyn/runtime/services/budget_gateway.py
@@ -215,7 +215,7 @@ class BudgetGateway:
     def reset_router_turn_counter(self) -> None:
         """Reset the per-turn router invocation counter and last reason.
 
-        Called at the top of each fresh turn (``_handle_user_message``,
+        Called at the top of each fresh turn (``_handle_inbox_text``,
         ``_handle_agent_request``). Re-entrant in-chain paths intentionally
         do NOT reset — their invocations count against the same budget.
         """

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5433,6 +5433,20 @@ class Session:
             # launch returned immediately, so this is a fresh turn, routed
             # exactly like a task wake).
             await self._handle_pipeline_result(payload)
+        elif kind == "agent_step":  # AGENT_STEP_INBOX_KIND value (#3595 step 1)
+            # A pipeline ``agent`` step's prompt: text a MODEL will read as this
+            # ephemeral worker's one turn, never an operator's typed line. It used
+            # to arrive as ``kind="user"`` (``session_api.run_agent_step``), which
+            # is what put model-authored text through ``_handle_user_message``'s
+            # ``startswith("/")`` slash dispatch — every registered slash command
+            # executable from model output. Its own kind routes it to the turn
+            # body directly: the short-circuit is not skipped by a flag, it is
+            # not on this path at all (#3595 / owner: "inbox につまれたものは
+            # スラッシュコマンドとして解釈されない").
+            await self._handle_inbox_text(
+                payload.get("text", ""),
+                chain_id=payload.get("chain_id") or _new_chain_id(),
+            )
         elif kind == "hook":  # HOOK_INBOX_KIND value (#1800 slice 5b)
             # E (wake=true) lifecycle-hook push delivered as a turn trigger:
             # a system-role [hook:name] message + one router turn (self-
@@ -5452,7 +5466,8 @@ class Session:
         — the OS-authoritative provenance classification of this turn, threaded into
         ``OpContext.turn_origin`` at both ctx-build sites. Only an explicit
         ``kind == "user"`` turn grants ``"user_directed"``; EVERY other kind —
-        hook, pipeline_result, sub-agent ``agent_request``/``agent_response``, or
+        hook, pipeline_result, ``agent_step`` (#3595), sub-agent
+        ``agent_request``/``agent_response``, or
         any future kind this method does not yet know about — resolves to the
         strictER ``"auto_improvement"``. This is an if/else fail-safe, not a
         lookup table: there is no path by which an unmapped kind can silently
@@ -5460,7 +5475,11 @@ class Session:
         autonomous turn bypass the Phase-4 auto-improvement gate). Sub-agent
         turns are deliberately `"auto_improvement"` (lead-adjudicated, Addendum
         B A7): a human directed the PARENT task, not necessarily this install
-        action."""
+        action. #3595 made a pipeline agent step's prompt turn carry its own
+        kind instead of impersonating ``"user"``, so it now lands on that same
+        stricter side — by the rule above, not by a new branch, and matching the
+        sub-agent reasoning verbatim (the human directed the pipeline, not this
+        step's install)."""
         self._current_turn_origin = "user_directed" if kind == "user" else "auto_improvement"
 
     async def _handle_pipeline_result(self, payload: dict) -> None:
@@ -5619,12 +5638,52 @@ class Session:
         # task — see docs/concepts/data-retrieval/chat-compaction.md#compaction-paths
 
     async def _handle_user_message(self, text: str, *, chain_id: str) -> None:
+        """An OPERATOR-authored line: interpret it, then run the turn.
+
+        #3595 step 1 split this in two. Everything above the
+        ``_handle_inbox_text`` call interprets text *as an operator command
+        surface* — the slash dispatch. Everything below it is the turn itself,
+        which every text-bearing inbox kind needs. Only text whose kind claims
+        an operator typed it may enter here; a non-operator producer calls
+        ``_handle_inbox_text`` directly, so it cannot execute a slash command
+        by writing one (owner ruling: "inbox につまれたものはスラッシュコマンド
+        として解釈されない。されるんだとするとそれが不具合").
+
+        Sibling entry: ``_handle_pipeline_result`` still calls THIS method, so a
+        pipeline's OS-framed result text is still slash-interpreted. Its framing
+        (``[pipeline] run …``) means no such text can currently start with
+        ``/``, but that is a property of the formatter, not a gate — recorded as
+        a finding on #3595, deliberately not changed here (it would also change
+        that path's ``:skill`` and pending-intervention-answer behaviour, which
+        is a different rollback shape).
+        """
         # Slash commands (`/list`, `/tasks kill <id>`, `/answer <id> <text>`)
         # take precedence over both the active-intervention router and a
         # fresh router turn.
         if text.startswith("/"):
             if await self._maybe_handle_slash(text):
                 return
+        await self._handle_inbox_text(text, chain_id=chain_id)
+
+    async def _handle_inbox_text(self, text: str, *, chain_id: str) -> None:
+        """Run ONE turn on ``text`` — the shared body under every text-bearing
+        inbox kind, with the SLASH dispatch above it rather than in it
+        (#3595 step 1).
+
+        Extracted from ``_handle_user_message``, which now calls it after that
+        dispatch, unchanged for operators. ``kind="agent_step"`` reaches it
+        directly: an agent step's prompt is model-readable CONTENT, so it gets a
+        turn and never an OS-executed command.
+
+        The split point is the slash block and nothing else, so this body still
+        carries the ``:skill`` invocation and the pending-intervention answer
+        route exactly as the agent-step path met them before — both remain
+        reachable from an agent step's prompt. Neither dispatches a registered
+        command (a `:` invocation composes skill text and falls THROUGH into the
+        turn below; an intervention answer is a typed reply to a question this
+        session itself asked), which is why closing the slash leg alone is the
+        step-1 scope; #3595 records them as findings for the later steps.
+        """
         # #3100: operator-explicit `:skill [:skill2 ...] [trailing]` skill
         # invocation — a namespace separate from `/` (Axis 4: syntactic
         # closed-type distinction, not a runtime precedence lookup). Unlike
@@ -5981,7 +6040,7 @@ class Session:
 
     def _reset_router_turn_counter(self) -> None:
         """Reset the per-turn router invocation counter. Called at the top
-        of each fresh turn (`_handle_user_message`, `_handle_agent_request`).
+        of each fresh turn (`_handle_inbox_text`, `_handle_agent_request`).
         Re-entrant in-chain paths (`_handle_agent_response` continuation,
         `_resolve_pending_chain`) intentionally do NOT reset — their
         invocations count against the same budget."""

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -28,8 +28,10 @@ existing primitives — it adds no new session/LLM machinery of its own:
      would make it return early on a pending chain the spawned session is
      still awaiting a reply for.
   2. ``MessageBus.request`` (``runtime/message_bus.py``) — the existing
-     synchronous run+collect: put a ``user`` message on the spawned
-     session's inbox, pump ``run_one_iteration`` on the caller's own task
+     synchronous run+collect: put an ``AGENT_STEP_INBOX_KIND`` message (the
+     prompt is a model's reading material, never an operator's typed line, so
+     it does not claim the ``user`` kind that slash dispatch acts on) on the
+     spawned session's inbox, pump ``run_one_iteration`` on the caller's own task
      until quiescent, and return every ``OutboxMessage`` emitted during the
      turn. The ephemeral session self-vanishes via
      ``_maybe_schedule_ephemeral_vanish`` once the turn leaves it quiescent
@@ -109,6 +111,23 @@ from reyn.runtime.transport import SystemRef
 if TYPE_CHECKING:
     from reyn.core.pipeline.schema import SchemaRegistry
     from reyn.runtime.registry import AgentRegistry
+
+#: The inbox kind an ``agent`` pipeline step's prompt rides (#3595 step 1).
+#:
+#: A member of the SAME discriminated union ``Session._run_turn_body`` already
+#: dispatches on (``user`` / ``agent_request`` / ``agent_response`` /
+#: ``pipeline_result`` / ``hook``) — this is not a new mechanism, it is the
+#: agent-step path no longer claiming a kind that is not true of it. ``"user"``
+#: means "a human typed this at a client", and ``Session._handle_user_message``
+#: acts on that claim by handing a ``/``-prefixed line to slash dispatch. An
+#: agent step's prompt is a MODEL's text, so under the old ``kind="user"`` every
+#: registered slash command was executable from model output; under its own kind
+#: the prompt reaches the turn body directly and none of them are.
+#:
+#: Declared here, at the producer, the way ``hooks.dispatcher.HOOK_INBOX_KIND``
+#: is; ``session.py``'s dispatch spells the literal with a comment naming this
+#: constant, the same as it does for ``hook``.
+AGENT_STEP_INBOX_KIND = "agent_step"
 
 # Tool names an ``agent`` pipeline step must never reach — a leaf worker (R6
 # session-hierarchy constraint 4: "E_i are spawn-tree LEAVES"). Two distinct
@@ -230,8 +249,15 @@ async def run_agent_step(
     The future Pipeline executor's ``agent`` step primitive (R5): spawn a
     leaf-worker session under ``identity`` (capability-narrowed to
     ``capabilities`` plus a structural delegation deny, see
-    ``_build_agent_step_narrowing``), feed it ``prompt`` as a single ``user``
-    turn via ``MessageBus.request``, and return its collected reply.
+    ``_build_agent_step_narrowing``), feed it ``prompt`` as a single
+    ``AGENT_STEP_INBOX_KIND`` turn via ``MessageBus.request``, and return its
+    collected reply.
+
+    #3595 step 1: that kind used to be ``"user"``, i.e. the prompt claimed a
+    human had typed it at a client, which is what made every registered slash
+    command executable from a model's output (``Session._handle_user_message``
+    hands a ``/``-prefixed line to slash dispatch before any router turn). See
+    ``AGENT_STEP_INBOX_KIND``.
 
     With ``schema`` unset, returns the joined ``kind="agent"`` reply text
     verbatim. With ``schema`` set (a name registered in ``schema_registry``):
@@ -374,7 +400,7 @@ async def run_agent_step(
     bus = MessageBus()
     replies = await bus.request(
         session,
-        kind="user",
+        kind=AGENT_STEP_INBOX_KIND,
         payload={"text": prompt, "chain_id": chain_id or uuid.uuid4().hex},
         reply_to=SystemRef(),
         timeout=timeout if timeout is not None else _DEFAULT_AGENT_STEP_TIMEOUT_S,

--- a/tests/test_3546_pipeline_driver_narrowing_inheritance.py
+++ b/tests/test_3546_pipeline_driver_narrowing_inheritance.py
@@ -640,17 +640,31 @@ _SITE_PARENT_LAYERS: "dict[tuple[str, str], _SiteDeclaration]" = {
             "its invoker is. This is the arc's open gap, filed as #3562; it is declared "
             "HERE rather than left off the list, because a site the gate does not "
             "enumerate is a site the gate does not count. "
-            "#3561 measured that it is REACHABLE FROM MODEL OUTPUT, which is the fact "
-            "that decides it is in scope: an agent step whose prompt is a previous "
+            "#3561 measured that it was REACHABLE FROM MODEL OUTPUT, which is what "
+            "first decided it was in scope: an agent step whose prompt was a previous "
             "agent step's model output, run on a session narrowed to a single "
-            "capability, reaches this site and spawns — no operator in the path, no LLM "
-            "call on the reaching turn (``Session._handle_user_message`` short-circuits "
-            "to ``_maybe_handle_slash`` before the router runs). The measurement below "
-            "asserts the REACHABILITY only, never that the child is un-narrowed, so it "
-            "stays green when #3562 closes the gap."
+            "capability, reached this site and spawned — no operator in the path, no "
+            "LLM call on the reaching turn. ★ #3595 step 1 made that FALSE and the "
+            "measurement below is now its inverse: the agent-step prompt rides its own "
+            "inbox kind (``session_api.AGENT_STEP_INBOX_KIND``) instead of claiming "
+            "``kind='user'``, so it never enters ``Session._handle_user_message``'s "
+            "``startswith('/')`` dispatch and no registered slash command is reachable "
+            "from model output at all. "
+            "★ The site STAYS enumerated, and the reason has changed rather than "
+            "expired: this list counts every place a child envelope is BORN, not every "
+            "place a model can reach — a site whose only caller is an operator is still "
+            "a site whose child inherits nothing. What #3595 retires is the SEVERITY "
+            "argument, not the entry. The narrowing gap itself was settled separately "
+            "by #3562/#3586 on an owner policy decision (a session opened from a "
+            "narrowed one should stay narrowed), which stands on its own and never "
+            "stood on this reachability. "
+            "The measurement below still asserts REACHABILITY only — now its absence, "
+            "paired with an operator control proving the command itself still runs — "
+            "never anything about what the child inherits."
         ),
         measured_by=(
-            f"{_S3561}::test_model_output_reaches_slash_dispatch_and_spawns_a_session",
+            f"{_S3561}::test_model_output_cannot_reach_slash_dispatch_and_spawns_nothing",
+            f"{_S3561}::test_an_operator_submitted_slash_command_still_spawns_a_session",
         ),
     ),
 }

--- a/tests/test_3561_spawn_session_seam_reachability.py
+++ b/tests/test_3561_spawn_session_seam_reachability.py
@@ -14,26 +14,39 @@ REACHABILITY — can a narrowed subject cause this to run.
 standing assumption was that ``AgentRegistry.spawn_session``'s one non-registry call
 site, the ``/session new`` slash command, is operator-initiated and therefore out of
 scope. The path that had actually been established was only that the OPERATOR input
-face reaches it — never that no other face does.
-``test_model_output_reaches_slash_dispatch_and_spawns_a_session`` is the falsification:
-it drives the real ``run_agent_step`` with a prompt that is a previous agent step's
-MODEL OUTPUT, on a session narrowed to a single capability, and observes a session
-being born. The assumption is false.
+face reaches it — never that no other face does. The original
+``test_model_output_reaches_slash_dispatch_and_spawns_a_session`` was the
+falsification: it drove the real ``run_agent_step`` with a prompt that is a previous
+agent step's MODEL OUTPUT, on a session narrowed to a single capability, and observed
+a session being born. The assumption was false.
 
-Why the reaching turn is not a model turn: ``Session._handle_user_message`` tests
-``text.startswith("/")`` and hands the line to ``_maybe_handle_slash`` BEFORE the
-router turn, so the worker never calls its LLM on that turn at all — which the test
-asserts, because "the scripted LLM was not consulted" is what distinguishes a slash
-short-circuit from a model that happened to decide to spawn. Slash dispatch has
-exactly two production callers (``_handle_user_message`` and
-``maybe_deliver_answer_command``), so the surface reached here is small and
-enumerable; what is NOT bounded is the set of ways text arrives at
-``_handle_user_message``, and the agent-step prompt is one of them.
+★ **#3595 step 1 made it true, and this file's leg is the same measurement inverted.**
+The reason model output reached slash dispatch was a KIND that was not true of it:
+``run_agent_step`` fed its prompt as ``kind="user"``, i.e. as a line a human had typed
+at a client, and ``Session._handle_user_message`` acts on that claim by handing a
+``/``-prefixed line to ``_maybe_handle_slash`` before any router turn. The prompt now
+rides its own union member (``session_api.AGENT_STEP_INBOX_KIND``), which
+``_run_turn_body`` routes straight to the shared turn body — the slash dispatch is not
+skipped by a flag, it is not on that path at all. The leg below asserts the ABSENCE of
+the spawn, and asserts the scripted LLM WAS consulted on the reaching turn: the text
+is now content a model reads, which is the positive half that keeps the absence from
+being explained by "the worker never ran". ★ The original assertion message asked for
+exactly this re-argument if the reachability claim ever became false; the guard is
+kept alive inverted rather than deleted, because what has to stay measured is that no
+non-operator face reaches an OS-executed command — a claim that only an executable
+witness can hold. The paired operator leg
+(``test_an_operator_submitted_slash_command_still_spawns_a_session``) is its control:
+the same command, submitted the way every client submits one, still executes, so
+"nothing spawns any more" cannot pass for the fix.
 
-What this file deliberately does NOT assert: that the session ``/session new`` opens
-is un-narrowed. It is (the invoking session's #2103-S1a layer is not carried, which is
-#3562), but pinning that would make the fix red. The measurement is the reachability,
-which stays true either way.
+Slash dispatch has exactly two production callers (``_handle_user_message`` and
+``maybe_deliver_answer_command``), so the surface is small and enumerable; what is NOT
+bounded is the set of ways text arrives at ``_handle_user_message`` — which is why the
+fix was to bound the KIND that may enter it rather than to enumerate the commands.
+
+What this file deliberately does NOT assert: anything about the narrowing of the
+session ``/session new`` opens (#3562's subject). The measurement is WHO can reach the
+site, which is a separate axis from what the child inherits when they do.
 
 ★ **The second claim is a defect this enumeration found, and the fix that closes it.**
 Crash recovery (``restore_all`` / ``_rewake_pipeline_runs``) re-creates a session
@@ -174,32 +187,36 @@ def _registry(
 
 
 
-# ── the reachability falsification ──────────────────────────────────────────
+# ── the reachability measurement, inverted by #3595 step 1 ──────────────────
 
 
 @pytest.mark.asyncio
-async def test_model_output_reaches_slash_dispatch_and_spawns_a_session(
+async def test_model_output_cannot_reach_slash_dispatch_and_spawns_nothing(
     tmp_path: Path, monkeypatch,
 ) -> None:
-    """Tier 2: MODEL OUTPUT reaches slash dispatch, and through it
-    ``AgentRegistry.spawn_session`` — the measurement that decides
-    ``interfaces/slash/session.py::session_cmd`` is a spawn seam in scope.
+    """Tier 2: MODEL OUTPUT does not reach slash dispatch, so it cannot reach
+    ``AgentRegistry.spawn_session`` through ``interfaces/slash/session.py::session_cmd``.
 
-    Two agent steps, both real ``run_agent_step`` calls on real sessions:
+    The #3561 falsification, run unchanged and asserted the other way round (#3595
+    step 1). Two agent steps, both real ``run_agent_step`` calls on real sessions:
 
-      1. the first returns the model's text — here a slash command;
+      1. the first returns the model's text — here a real, registered slash command;
       2. the production template splice (``executor._interpolate_prompt``, the exact
          function an ``agent`` step's ``prompt`` goes through) puts that text in the
          second step's prompt;
-      3. the second step's worker — narrowed to a single capability, so it is a
-         NARROWED subject — reaches ``/session new`` and a session is born under the
-         attached agent.
+      3. the second step's worker runs that prompt and NO session is born.
 
-    No operator submits anything at any point. ``scripted.calls`` staying at 1 across
-    step 2 is what shows the reaching turn short-circuited at
-    ``_maybe_handle_slash`` instead of running a router turn: without it, a spawn
-    could be explained by the worker's own model deciding to spawn, which is a
-    different (already-gated, #3556) path.
+    The second assertion is what makes the absence readable. ``scripted.calls``
+    reaching 2 means the reaching turn went to the model — the slash-shaped line was
+    delivered as CONTENT for a router turn. Without it, "no session was born" would
+    have a second explanation (the worker never ran at all), which is the shape an
+    absence-only leg cannot tell apart. The two together say: the line arrived, and it
+    arrived as text rather than as a command.
+
+    The invariant is not about ``/session new``. It is that a non-operator inbox kind
+    cannot execute ANY of the registered slash commands, because the kind that carries
+    it never enters the dispatch — ``/session new`` is simply the command whose side
+    effect is observable from outside the session.
     """
     monkeypatch.chdir(tmp_path)
     scripted = _ScriptedReply(_MODEL_OUTPUT)
@@ -215,7 +232,7 @@ async def test_model_output_reaches_slash_dispatch_and_spawns_a_session(
     assert next_prompt == _MODEL_OUTPUT
 
     # An operator is attached, which is the ordinary REPL state — ``/session new``
-    # acts on the ATTACHED agent, so this is whose session count moves.
+    # acts on the ATTACHED agent, so this is whose session count would move.
     reg.get_or_load("operator")
     await reg.attach_session("operator", "main")
     before = set(reg.session_ids("operator"))
@@ -226,16 +243,59 @@ async def test_model_output_reaches_slash_dispatch_and_spawns_a_session(
     )
 
     born = set(reg.session_ids("operator")) - before
-    assert born, (
-        "model output did not reach slash dispatch — no session was born under the "
-        "attached agent. If this is now correct, the reachability claim in "
-        "tests/test_3546_pipeline_driver_narrowing_inheritance.py's declaration for "
-        "interfaces/slash/session.py::session_cmd is stale and must be re-argued."
+    assert not born, (
+        "model output reached slash dispatch and spawned a session under the attached "
+        f"agent ({sorted(born)!r}) — the agent-step prompt is being interpreted as an "
+        "operator command line again, which puts all 25 registered slash commands back "
+        "within reach of model output (#3595 step 1: the prompt must ride "
+        "session_api.AGENT_STEP_INBOX_KIND, never kind='user')"
     )
-    assert scripted.calls == 1, (
-        "the reaching turn consulted the LLM, so the spawn is not evidence of the "
-        "slash short-circuit — _handle_user_message is expected to hand a '/'-prefixed "
-        f"line to _maybe_handle_slash before any router turn (llm calls: {scripted.calls})"
+    assert scripted.calls == 2, (
+        "the reaching turn never consulted the LLM, so the absence above is not "
+        "evidence that the prompt was delivered as content — the worker may not have "
+        f"taken a turn at all (llm calls: {scripted.calls})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_operator_submitted_slash_command_still_spawns_a_session(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: the CONTROL for the leg above — an operator-submitted ``/session new``
+    still executes, so slash dispatch is closed to model output and not to everyone.
+
+    Same registry, same command, same observable (a session born under the attached
+    agent); the only difference is the door the text comes through
+    (``Session.submit_user_text`` — the one public entry every client's composer ends
+    at, CUI and TUI alike). Without this leg, deleting slash dispatch outright would
+    also pass the absence above, and #3595 step 1 explicitly must not change what an
+    operator typing ``/model foo`` gets.
+
+    ``scripted.calls`` staying at 0 is the other half: the operator's line
+    short-circuited at ``_maybe_handle_slash`` before any router turn, which is what
+    distinguishes an executed command from a model that decided to spawn.
+    """
+    monkeypatch.chdir(tmp_path)
+    scripted = _ScriptedReply("nothing to say")
+    reg = _registry(tmp_path, scripted, agents=("operator",))
+
+    operator = reg.get_or_load("operator")
+    await reg.attach_session("operator", "main")
+    before = set(reg.session_ids("operator"))
+
+    await operator.submit_user_text(_MODEL_OUTPUT)
+    await operator.run_one_iteration()
+    await operator.await_quiescent()
+
+    born = set(reg.session_ids("operator")) - before
+    assert born, (
+        "an operator's own '/session new' no longer opens a session — #3595 step 1 "
+        "closed slash dispatch to a kind that is not the operator's, and must leave "
+        "the operator's own path untouched"
+    )
+    assert scripted.calls == 0, (
+        "the operator's slash line reached the model instead of the slash handler, so "
+        f"the spawn above is not evidence the command ran (llm calls: {scripted.calls})"
     )
 
 


### PR DESCRIPTION
**[per-PR-coder]** — step 1 of the #3595 arc, part of #3595. An `agent` step's prompt no longer claims the `"user"` inbox kind, so **model output can no longer execute any of the 25 registered slash commands**.

## The defect

`run_agent_step` fed its prompt as `kind="user"` — the claim "a human typed this at a client". `Session._handle_user_message` acts on that claim by handing a `/`-prefixed line to `_maybe_handle_slash` **before** any router turn. A pipeline `agent` step's prompt is ordinarily a previous step's model output, spliced in verbatim by `executor._interpolate_prompt` — so the prompt and an operator's typing were mechanically indistinguishable.

## The fix

The typed discriminated union `_run_turn_body` dispatches on already existed (`user` / `agent_request` / `agent_response` / `pipeline_result` / `hook`). The defect was that this path lied about its member. The prompt now rides `session_api.AGENT_STEP_INBOX_KIND` (`"agent_step"`), a new member of that same union, which `_run_turn_body` routes straight to the shared turn body.

★ The slash dispatch is **not skipped by a flag — it is not on that path at all**. `_handle_user_message` keeps it and is now the operator entry alone; its body below the slash block is extracted as `_handle_inbox_text` (the shared turn body). **The split point is the slash block and nothing else**, so `:skill` invocation and the pending-intervention answer route are untouched on every path.

★ **Observable behaviour for CUI and TUI is unchanged.** An operator typing `/model foo` still works exactly as today — there is a test leg for precisely that (below).

### What this shuts: all 25 commands, structurally

Enumerated from the live registry (`REGISTRY.names()`, not from a doc): `agent agents answer attach budget clear-history compact concept copy cost exit help hook image list memory model pending plugin quit reload reset rewind session visibility`.

It does not enumerate them — the branch that dispatches them is never entered — so a 26th command is out of reach the day it is registered.

### One consequence worth naming

`_stamp_execution_context` maps every non-`"user"` kind to the stricter `"auto_improvement"` turn origin. An agent-step turn therefore now stamps installs `provenance=auto_improvement` instead of `user_directed`. That happens **by the existing fail-safe rule, not a new branch**, and it matches 0060's own sub-agent reasoning verbatim ("a human directed the PARENT task, not necessarily this install action"). It is stricter, never wider.

## Strip-falsify (numbers, both directions)

Anchor uniqueness checked first: `grep -c 'kind=AGENT_STEP_INBOX_KIND,' src/reyn/runtime/session_api.py` → **1**.

| state | `tests/test_3561_spawn_session_seam_reachability.py` |
|---|---|
| fix applied | **6 passed** |
| kind reverted to `"user"` (fix stripped) | **1 failed, 5 passed** — the failure is `test_model_output_cannot_reach_slash_dispatch_and_spawns_nothing` |
| fix restored | **6 passed** |

★ The operator control passed in **all three** states, which is what makes it a control rather than a second copy of the same measurement.

## Re-arguing the #3561 test — it was built to shout here, and it did

`test_model_output_reaches_slash_dispatch_and_spawns_a_session` asserted model output **does** reach slash dispatch, and its own assertion message said: *"If this is now correct, the reachability claim in tests/test_3546_…'s declaration for interfaces/slash/session.py::session_cmd is stale and must be re-argued."*

**What the claim was for.** `_SITE_PARENT_LAYERS` enumerates every place a child session's permission envelope is BORN. `session_cmd` (`/session new`) got onto that list because #3561 measured that a *narrowed subject* could reach it — reachability, not shape, was the criterion.

**Is the declaration stale?** Its severity argument is; its entry is not. The list counts sites where a child is born, not sites a model can reach — a site whose only caller is an operator still births a child that inherits nothing. So the entry stays, with the reason rewritten: the reachability sentence now records that #3595 step 1 made it false, and that the narrowing gap itself was settled by #3562 / PR #3586 on the owner's policy decision, which stood on its own and never stood on this escape.

**What the test asserts instead.** The same measurement, inverted, kept alive rather than deleted:

- `test_model_output_cannot_reach_slash_dispatch_and_spawns_nothing` — the identical two-agent-step setup, asserting **no session is born**, *and* that `scripted.calls == 2`. The second half is load-bearing: it says the reaching turn **did** consult the model, so the absence cannot be explained by "the worker never ran".
- `test_an_operator_submitted_slash_command_still_spawns_a_session` — the control. Same command, same observable, through `Session.submit_user_text` (the one public entry every client's composer ends at), asserting a session **is** born and `scripted.calls == 0`. Without it, deleting slash dispatch outright would also pass the leg above.

`tests/test_3546_pipeline_driver_narrowing_inheritance.py` is updated in this PR: the `session_cmd` declaration's prose, and its `measured_by` now naming both legs.

## Census: every caller that feeds text into a session's inbox

Enumerated from the `_put_inbox` call sites (the single chokepoint) and their producers, then read individually — not trusted from a grep count.

| producer | kind | truthful? |
|---|---|---|
| `session.submit_user_text` → `_put_inbox("user", …)`; funnelled into by `transport/in_process.py:171`, `agui/endpoint.py:614`, `repl/stream_client.py:186`, `textual_chat/app.py:3272` | `user` | ✅ a human typed it at a client |
| `session_api.run_agent_step` | `agent_step` | ✅ **fixed here** (was `user`) |
| `session.submit_agent_request` / `submit_agent_response` | `agent_request` / `agent_response` | ✅ |
| `session.submit_pipeline_result` | `pipeline_result` | ✅ kind is truthful — but see finding 2 |
| `hooks/dispatcher.py:394`, `session._cross_session_hook_put` | `hook` | ✅ |
| 🟡 `registry.py:1254` (`_rewake_pipeline_runs` resume nudge) | `user` | ❌ a crash-recovery nudge, not a human. Text is `""` so it cannot reach slash |
| 🟡 `session_api.py:643` (`start_pipeline_run`) and `session_api.py:794` (`run_pipeline_attached`) | `user` | ❌ same shape, text `""` |
| 🔴 `gateway/api.py:120` `push_to_agent(kind="user")` — the public webhook API; callers `sample_slack/webhook.py:184`, `sample_line/webhook.py:136` | `user` | ❌ **an EXTERNAL user's chat message reaches slash dispatch.** Attacker-controlled, non-empty text |
| 🟡 `interfaces/web/server.py:82` (cron fire) | `user` | ❌ an unattended timer, not a human. Text is operator-authored job config |
| 🟡 `mcp/server.py:241` (`send_to_agent`) | `user` | ❌ an MCP client — frequently another LLM. Non-empty text |

★ **Not fixed here, per the brief — reported for the arc's later steps.** In severity order:

1. **`push_to_agent` and MCP `send_to_agent`** are the two remaining non-empty-text paths where a non-operator's string reaches slash dispatch. A Slack message reading `/reset` executes today. These two are what matter for steps 2/3.
2. **`_handle_pipeline_result` still calls `_handle_user_message`**, so a pipeline's result text is still slash-interpreted. It cannot fire today only because `_format_result_text` prefixes `[pipeline] run …` — a property of the formatter, not a gate. Deliberately not changed here: routing it to `_handle_inbox_text` would also change its `:skill` and pending-intervention-answer behaviour, a different rollback shape.
3. **The three `""`-text nudges** (`registry.py:1254`, `session_api.py:643` / `:794`) claim `user` for a machine wake. Harmless today by text emptiness, but they are exactly the "the next injector copies the current idiom" hazard the architect named.
4. **Pre-existing doc drift, untouched**: `router_host_adapter.py:1969` says the MCP probe is "Called by `Session._handle_user_message`". That moved to `_run_router_loop` in #3475; it was already false before this PR.

## Corrections to the brief / issue, measured

- The brief listed `session_api.py:617`; on current `origin/main` that site is at **`session_api.py:643`**, and there is a **fourth** sibling the brief did not name: **`session_api.py:794`** (`run_pipeline_attached`'s nudge, also `kind="user"`). Line numbers had all shifted (`_handle_user_message` is at `session.py:5621`, not `:5613`) — everything re-anchored by content.
- Four of the brief's listed callers (`in_process`, `agui/endpoint`, `stream_client`, `textual_chat/app`) are **not** inbox producers themselves — they funnel into `submit_user_text`, which is the producer. The distinct producers are the 9 `_put_inbox` call sites.
- The issue body's table of `_handle_user_message`'s two callers is accurate, and finding 2 above is the half of it this PR deliberately leaves open.

## Docs updated in the same PR (the mechanism changed, so the doc changed)

- `docs/reference/runtime/pipeline-dsl.md` — the agent-step exception-surfacing section named `_handle_user_message` as where the leaf session drives its router loop, in two places.
- `docs/concepts/tools-integrations/skills.md` — the `:`-invoke call-site mechanics section, same reason.
- In-code residues naming the moved body: `session.py`, `budget_gateway.py`, `router_loop.py`, `skill_invoke.py`, `slash/image.py`.

## Test plan

- [x] `ruff check src tests` — All checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_3546_pipeline_driver_narrowing_inheritance.py tests/test_3561_spawn_session_seam_reachability.py` — 18 inspected, 0 errors, 0 warnings
- [x] `python -m pytest -q -n auto --timeout=120` from the repo root, foreground, summary line read directly — **9859 passed, 36 skipped** in 216 s. Neither known intermittent (#3590, #3594) fired.
- [x] `python scripts/verify_module_docstrings.py` on all 6 changed `src/` files — OK
- [x] Strip-falsify with a uniqueness-checked anchor, both directions — numbers in the table above
- [x] The 25-command list enumerated from the live registry, not from a doc
- [x] Measured-code identity confirmed at measurement time: the imported `reyn.runtime.session_api` resolves inside this agent's own worktree, and the worktree was re-checked immediately before measuring, committing and pushing
- [x] Closing-intent: `scripts/check_pr_closing_intent.py`'s own `_CLOSING_RE` run over the commit message → no matches; `_NONCLOSING_RE` → `3595`. Rule-4 enumeration is not applicable: this is step 1 of several and declares no closing keyword anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
