### PR TITLE
fix(runtime): webhook / MCP / cron stop claiming the "user" inbox kind — part of #3595

### DIFF
--- a/docs/concepts/multi-agent/a2a.md
+++ b/docs/concepts/multi-agent/a2a.md
@@ -166,7 +166,7 @@ While the task runs, both the SSE stream and the webhook (below) carry an
 
 | Audit-event | `message` |
 |-------------|-----------|
-| `turn_started` | `turn: <inbox trigger kind>` — e.g. `turn: user` |
+| `turn_started` | `turn: <inbox trigger kind>` — `turn: external_message` for an A2A delegation (#3595 step 1b: a peer's message is not the operator's typing, so it does not claim the `user` kind) |
 | `llm_called` | `llm: <model>` |
 | `tool_returned` | `tool: <name>` |
 | `tool_failed` | `tool: <name> (failed)` |

--- a/docs/concepts/tools-integrations/mcp.md
+++ b/docs/concepts/tools-integrations/mcp.md
@@ -343,9 +343,19 @@ Two tools are registered:
 | Tool | Signature | What it does |
 |------|-----------|--------------|
 | `list_agents` | `()` | Returns a JSON array of `{name, role}` objects — one entry per agent declared in `reyn.yaml`. |
-| `send_to_agent` | `(agent_name, message)` | Submits one user-style message to the named agent and blocks (up to `--timeout` seconds) for the final reply text. Returns `{reply, partial, agent}`. If `partial=true`, the agent is still working; call again to receive more. |
+| `send_to_agent` | `(agent_name, message)` | Submits one message to the named agent as a conversational turn and blocks (up to `--timeout` seconds) for the final reply text. Returns `{reply, partial, agent}`. If `partial=true`, the agent is still working; call again to receive more. |
 
 Multi-turn continuity is preserved: each agent's `Session` keeps its `history.jsonl` between calls, so a conversation that starts in Claude Code can be resumed from `reyn chat` — or vice versa.
+
+#### `message` is content the model reads, never an operator command
+
+A `send_to_agent` message rides the `external_message` inbox kind: the OS's record that a counterparty outside this process wrote it, which is what it is. It is **not** the `user` kind, which means "a human typed this at a first-party client" and is the only kind Reyn interprets as an operator command line.
+
+The visible consequence: **Reyn's slash commands are not available over MCP.** A message reading `/reset`, `/model`, `/visibility` or any other registered command is read by the LLM as text; nothing is executed.
+
+This is a **decision, not an omission** (#3595 step 1b, owner ruling 2026-08-01: 「現時点では slash に公開不要」 — "no need to expose slash at present"). Until that arc, `send_to_agent` claimed the `user` kind, so any MCP client could run any registered slash command — including `reset`, `rewind` and `plugin` — by sending one as its message. If Reyn ever does expose slash to a peer, the route is a shared client-side slash layer, not a transport re-inspecting the message for a leading `/`.
+
+The same holds for the A2A router, which shares this implementation, and for chat-gateway plugins — see [the gateway authoring guide](../../gateway/authoring-guide.md#slash-commands-are-not-exposed-to-gateways).
 
 ### Progress notifications
 

--- a/docs/concepts/tools-integrations/mcp.md
+++ b/docs/concepts/tools-integrations/mcp.md
@@ -353,7 +353,7 @@ Multi-turn continuity is preserved: each agent's `Session` keeps its `history.js
 
 | Audit-event | Progress message |
 |-------------|------------------|
-| `turn_started` | `turn: <inbox trigger kind>` — e.g. `turn: user` |
+| `turn_started` | `turn: <inbox trigger kind>` — `turn: external_message` for a `send_to_agent` call (#3595 step 1b: an MCP peer's message is not the operator's typing, so it does not claim the `user` kind) |
 | `llm_called` | `llm: <model>` |
 | `tool_returned` | `tool: <name>` |
 | `tool_failed` | `tool: <name> (failed)` |

--- a/docs/gateway/authoring-guide.md
+++ b/docs/gateway/authoring-guide.md
@@ -127,9 +127,12 @@ Reyn versions; this API stays stable.
 ### Helpers
 
   push_to_agent(*, target_agent, text, sender, reply_to=None,
-                kind="user", extra_meta=None, registry=None)
+                extra_meta=None, registry=None)
     Deliver a message to a Reyn agent's inbox. Default for webhook
-    gateways.
+    gateways. The inbox kind is fixed at
+    ``EXTERNAL_MESSAGE_INBOX_KIND`` and is deliberately NOT a
+    parameter — see "Slash commands are not exposed to gateways"
+    below.
 
   list_agents(*, registry=None) -> list[str]
     All agent names known to the project (= sorted disk view).
@@ -172,6 +175,30 @@ await push_to_agent(
 **Do NOT call internal session methods directly.** ``Session.
 _put_inbox`` etc. are private API and may change between Reyn
 versions; ``reyn.gateway.api`` is the contract that stays stable.
+
+### Slash commands are not exposed to gateways
+
+A message pushed through `push_to_agent` is **content the model
+reads**, never a Reyn operator command. A gateway user sending
+`/reset`, `/visibility`, `/plugin` or any other registered slash
+command gets it read by the LLM as text; nothing is executed.
+
+This is a **decision, not an omission** (#3595 step 1b, owner ruling
+2026-08-01: 「現時点では slash に公開不要」 — "no need to expose slash
+at present"). Until this arc, a gateway push claimed the `"user"`
+inbox kind — the claim that a human typed the line at a first-party
+client — and `Session._handle_user_message` acts on that claim by
+handing a `/`-prefixed line to slash dispatch before any router
+turn. Anyone able to post to a webhook could therefore run any
+registered slash command. Gateway pushes now ride
+`EXTERNAL_MESSAGE_INBOX_KIND`, which `Session._run_turn_body` routes
+straight to the shared turn body: the dispatch is not skipped by a
+flag, it is not on the path at all.
+
+If Reyn ever does expose slash to a gateway, the route is the
+ratified one — a **shared client-side slash layer** the gateway
+drives — not `startswith("/")` re-introduced at a transport, and not
+an allow-list of "safe" commands.
 
 Reyn's session dispatch automatically:
 - Surfaces ``sender`` as a state_change history entry (= PR-A

--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -362,7 +362,7 @@ Required fields are declared in `src/reyn/core/events/event_schema.py`.
 | Kind | When | Key payload |
 |------|------|-------------|
 | `session_started`, `session_completed` | The session's resource scope opens / closes (alongside `chat_started` / `chat_stopped`). | `agent_name` |
-| `turn_started` | A trigger has been consumed from the inbox and is about to be dispatched. | `kind` — the inbox message kind that triggered this turn (`"user"`, `"agent_response"`, `"task_ready"`, `"hook"`, …), so a subscriber can tell human triggers from automated ones without parsing the payload; `chain_id`; `seq` |
+| `turn_started` | A trigger has been consumed from the inbox and is about to be dispatched. | `kind` — the inbox message kind that triggered this turn (`"user"`, `"agent_response"`, `"task_ready"`, `"hook"`, `"agent_step"`, `"external_message"`, `"cron"`, …), so a subscriber can tell human triggers from automated ones without parsing the payload. #3595 made that reading TRUE rather than approximate: a pipeline agent step's prompt (step 1), and a webhook / MCP / A2A / cron push (step 1b), used to arrive claiming `"user"`; each now carries its own member, so `kind == "user"` means an operator typed the line at a first-party client and nothing else does. `chain_id`; `seq` |
 | `turn_completed` | The router loop reached a terminal condition — router path only. | `chain_id` |
 | `turn_settled` | The turn is done, for EVERY turn kind including slash / intervention short-circuits that return before the router. The reliable clear signal for a working indicator started on `turn_started`. | `kind`; `chain_id` (may be absent for non-user triggers) |
 

--- a/src/reyn/gateway/api.py
+++ b/src/reyn/gateway/api.py
@@ -4,7 +4,7 @@ Plugins (= webhook handlers under ``reyn.gateway.*`` or external pip
 packages registered via the ``reyn.webhooks`` entry-point group)
 SHOULD use the helpers in this module to interact with Reyn agents,
 NOT call internal ``Session`` methods (= ``_put_inbox``,
-``_handle_user_message``) directly.
+``_handle_inbox_text``) directly.
 
 The contract here is intended to stay stable across Reyn minor
 versions; internal session APIs may change without notice.
@@ -18,11 +18,19 @@ versions; internal session APIs may change without notice.
 
 - The signature is **kwarg-only** so future additions don't shift
   positional arguments.
-- ``kind`` defaults to ``"user"`` (= the typical webhook plugin case
-  where an external message becomes a user-shaped turn). Future
-  unification with A2A / MCP message paths may use other kind
-  values; the parameter is exposed today so the contract can extend
-  without API break.
+- The inbox kind is **not a parameter** (#3595 step 1b). Every push
+  through this module rides
+  ``runtime.transport.EXTERNAL_MESSAGE_INBOX_KIND``. Until #3595 step
+  1b it defaulted to ``"user"`` and was caller-overridable "so the
+  contract can extend without API break" — but ``"user"`` is the ONE
+  kind ``Session._handle_user_message`` acts on by handing a
+  ``/``-prefixed line to slash dispatch, so that parameter was the
+  gate: a plugin could claim to be the operator and thereby make an
+  external chat message execute any registered slash command. A
+  discriminator that decides a trust class is not something its own
+  subject may choose. Nothing in-tree ever passed it; the A2A /  MCP
+  paths it was reserved for do not go through this module at all
+  (they drive ``mcp.server.send_to_agent_impl``).
 - ``extra_meta`` is a passthrough hook for future per-path metadata
   (= e.g. A2A's ``chain_id``, MCP's ``request_id``). Webhook plugins
   typically omit it; A2A/MCP convergence work is tracked separately.
@@ -33,7 +41,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from reyn.runtime.transport import TransportRef
+from reyn.runtime.transport import EXTERNAL_MESSAGE_INBOX_KIND, TransportRef
 
 
 async def push_to_agent(
@@ -42,7 +50,6 @@ async def push_to_agent(
     text: str,
     sender: str,
     reply_to: TransportRef | None = None,
-    kind: str = "user",
     extra_meta: dict | None = None,
     registry: Any | None = None,
 ) -> None:
@@ -52,6 +59,14 @@ async def push_to_agent(
     plugins. Use it instead of touching ``Session._put_inbox``
     directly. Internal session APIs may change between Reyn versions;
     this function won't.
+
+    The message rides ``EXTERNAL_MESSAGE_INBOX_KIND`` — the truthful
+    claim for text this module carries: a counterparty outside this
+    process wrote it, never the operator at a first-party client. That
+    is what keeps a Slack/LINE message reading ``/reset`` from
+    executing the command (#3595 step 1b; the kind is fixed here and
+    not a parameter — see this module's docstring for why it stopped
+    being one).
 
     Parameters
     ----------
@@ -73,12 +88,6 @@ async def push_to_agent(
         via MCP). When set, Reyn's outbox interceptor (= PR-D2)
         forwards replies through ``route_to_mcp``. When ``None``,
         replies follow the default surface (= TUI / detached).
-    kind:
-        Inbox dispatch kind. ``"user"`` for normal external user
-        messages (= webhook plugin default). Other values are
-        Reyn-internal (= ``"agent_request"`` / ``"agent_response"``
-        for A2A; reserved for future unification work). Plugin
-        authors should not need to override this in current Reyn.
     extra_meta:
         Per-path metadata for future unification (= A2A chain_id,
         MCP request_id, etc.). Webhook plugins typically omit it;
@@ -117,7 +126,7 @@ async def push_to_agent(
         envelope["reply_to"] = reply_to
     if extra_meta:
         envelope["meta"] = dict(extra_meta)
-    await session._put_inbox(kind, envelope)
+    await session._put_inbox(EXTERNAL_MESSAGE_INBOX_KIND, envelope)
 
 
 # ── agent discovery ────────────────────────────────────────────────────

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -50,6 +50,13 @@ async def _run_once(agent_registry, agent_name, *, instream=None, send=None) -> 
     result = await send(
         agent_registry, agent_name=agent_name, message=message,
         timeout=_ONCE_SEND_TIMEOUT,
+        # #3595 step 1b: send_to_agent_impl defaults to the EXTERNAL kind (its
+        # MCP / A2A producers are outside-the-process peers). `reyn run-once` is
+        # NOT that — it is the operator, piping their own line at a first-party
+        # CLI, so it says so. Dropping this makes `echo "/model x" | reyn
+        # run-once` stop executing the command, which is an operator-visible
+        # behaviour change this arc explicitly must not make.
+        inbox_kind="user",
     )
     return result if isinstance(result, dict) else {"reply": result or ""}
 

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -636,12 +636,19 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
         reply_parts: list[str] = []
 
         try:
+            # #3595 step 1b: send_to_agent_impl defaults to the EXTERNAL kind
+            # (its MCP / A2A producers are peers outside this process). A
+            # dogfood scenario is the opposite: a human-authored line replayed
+            # AS the operator's own typing, and the whole point of the
+            # instrument is to exercise the path an operator's line takes. Any
+            # other kind would measure a path no operator uses.
             if scenario.is_multi_turn:
                 for prompt in scenario.prompts:
                     result = await send_to_agent_impl(
                         registry,
                         agent_name=agent_name,
                         message=prompt,
+                        inbox_kind="user",
                     )
                     if result.get("reply"):
                         reply_parts.append(result["reply"])
@@ -651,6 +658,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                     registry,
                     agent_name=agent_name,
                     message=message,
+                    inbox_kind="user",
                 )
                 if result.get("reply"):
                     reply_parts.append(result["reply"])

--- a/src/reyn/interfaces/web/server.py
+++ b/src/reyn/interfaces/web/server.py
@@ -55,11 +55,20 @@ def _make_cron_runner():
         history of prior runs ("what changed since last run"). The run-loop is
         booted WITHOUT a forwarder (``ensure_session_running``) since cron is
         unattended (output handling = S4b-3b notify layer); the envelope is
-        dispatched as ``kind="user"`` so the LLM processes the text as a turn, with
-        ``sender="cron:<name>"`` driving the PR-A attribution state_change.
+        dispatched as ``CRON_INBOX_KIND`` so the LLM processes the text as a turn,
+        with ``sender="cron:<name>"`` driving the PR-A attribution state_change.
+
+        #3595 step 1b: that kind was ``"user"`` until this arc, which meant a job
+        message beginning with ``/`` was executed as an operator slash command in
+        this unattended session instead of being read by the model. Cron is not a
+        human at a client, so it stopped saying it was one.
         """
         from reyn.interfaces.web.deps import _get_registry
-        from reyn.runtime.cron.routing import dispatch_cron_fired, resolve_cron_session
+        from reyn.runtime.cron.routing import (
+            CRON_INBOX_KIND,
+            dispatch_cron_fired,
+            resolve_cron_session,
+        )
         registry = _get_registry()
         try:
             session = resolve_cron_session(registry, to, native_id)
@@ -79,7 +88,7 @@ def _make_cron_runner():
         if notify:
             from reyn.runtime.transport import ExternalRef
             payload["reply_to"] = ExternalRef(transport=notify, destination={})
-        await session._put_inbox("user", payload)
+        await session._put_inbox(CRON_INBOX_KIND, payload)
         return "ok"
 
     async def _failure_notifier(job, reason: str) -> None:

--- a/src/reyn/mcp/server.py
+++ b/src/reyn/mcp/server.py
@@ -35,6 +35,7 @@ from reyn.core.events.progress_lifecycle import (
     format_progress_message,
 )
 from reyn.runtime.agent_locks import get_agent_lock as _get_agent_lock
+from reyn.runtime.transport import EXTERNAL_MESSAGE_INBOX_KIND
 
 logger = logging.getLogger(__name__)
 
@@ -186,6 +187,10 @@ async def send_to_agent_impl(
     timeout: float = DEFAULT_SEND_TIMEOUT_SECONDS,
     intervention_override: "RequestBus | None" = None,
     sid: "str | None" = None,
+    # EXTERNAL_MESSAGE_INBOX_KIND is imported at module level, not with this
+    # module's usual lazy-import idiom, because a default argument is evaluated
+    # at def time. reyn.runtime.transport imports nothing but dataclasses.
+    inbox_kind: str = EXTERNAL_MESSAGE_INBOX_KIND,
 ) -> dict:
     """Backing implementation of the ``send_to_agent`` tool.
 
@@ -202,6 +207,23 @@ async def send_to_agent_impl(
     FP-0013: uses ``MessageBus.request`` to pump ``session.run_one_iteration``
     from this task, eliminating the inline ``_handle_user_message`` bypass.
     The inbox is now the single intake channel for every transport surface.
+
+    ``inbox_kind`` (#3595 step 1b) is the union member ``message`` rides onto
+    the inbox, and it exists because THIS function has four producers with two
+    different answers to "who wrote this text":
+
+    - the MCP ``send_to_agent`` tool and the A2A JSON-RPC router — a
+      counterparty outside this process, frequently another LLM. They take the
+      default, ``EXTERNAL_MESSAGE_INBOX_KIND``.
+    - ``reyn run-once`` (whole stdin as one message) and the dogfood scenario
+      runner — an operator at a first-party client, and a harness standing in
+      for one. Both pass ``inbox_kind="user"`` explicitly.
+
+    The default is the NON-operator one on purpose: a new caller that says
+    nothing gets the kind that cannot execute a slash command, the same
+    fail-safe direction ``Session._stamp_execution_context`` uses for turn
+    origin. Under the old unconditional ``kind="user"`` an MCP client could run
+    any registered slash command by sending ``/reset`` as its message.
     """
     if not registry.exists(agent_name):
         raise ValueError(
@@ -240,7 +262,7 @@ async def send_to_agent_impl(
         try:
             replies = await bus.request(
                 session,
-                kind="user",
+                kind=inbox_kind,
                 payload={"text": message, "chain_id": chain_id},
                 reply_to=McpRef(request_id=req_id),
                 timeout=timeout,

--- a/src/reyn/runtime/cron/routing.py
+++ b/src/reyn/runtime/cron/routing.py
@@ -26,6 +26,30 @@ from reyn.hooks.ingress import CronIngressAdapter
 
 CRON_TRANSPORT = "cron"
 
+#: The inbox kind a fired message-based cron job's text rides (#3595 step 1b).
+#:
+#: Declared here (the cron subsystem's runtime module, imported by the web
+#: server's thin ``_inbox_pusher`` glue) the way
+#: ``hooks.dispatcher.HOOK_INBOX_KIND`` is declared in the hook dispatcher.
+#:
+#: It used to be ``"user"``, the claim ``Session._handle_user_message`` acts on
+#: by handing a ``/``-prefixed line to slash dispatch — so a job whose message
+#: began with ``/`` executed an operator command in an UNATTENDED session with
+#: no client to show the result to.
+#:
+#: **Why cron does not share** ``EXTERNAL_MESSAGE_INBOX_KIND`` **with the
+#: webhook / MCP producers.** The kind's job is to say who authored the text for
+#: the purpose of deciding whether the OS may act on its form, and cron answers
+#: differently from those two: a cron message is OPERATOR-authored, in
+#: ``.reyn/`` job config, under the same file-permission trust as the rest of
+#: the workspace — not a counterparty's chat line. That is a distinction a trust
+#: decision (e.g. #3501's untrusted-content narrowing) would branch on, and no
+#: envelope field can carry it: ``sender`` (``"cron:<job>"`` vs ``"slack:U456"``)
+#: is a free-form attribution string the pushing plugin supplies, and a
+#: discriminator a trust decision reads must not come from the side being
+#: classified.
+CRON_INBOX_KIND = "cron"
+
 # Hook-Event Redesign Phase 2 (proposal 0059 §6.4): the Cron Adapter is
 # stateless (no bound queue/session — it resolves its target Session fresh
 # at fire time), so one module-level instance is shared by every call.

--- a/src/reyn/runtime/message_bus.py
+++ b/src/reyn/runtime/message_bus.py
@@ -47,12 +47,22 @@ class MessageBus:
         ref = McpRef(request_id=_new_request_id())
         replies = await bus.request(
             session,
-            kind="user",
+            kind=EXTERNAL_MESSAGE_INBOX_KIND,
             payload={"text": message, "chain_id": chain_id},
             reply_to=ref,
             timeout=60.0,
         )
         reply_text = "\\n\\n".join(r.text for r in replies)
+
+    The example pairs ``McpRef`` with ``EXTERNAL_MESSAGE_INBOX_KIND`` because
+    that is what an MCP request IS — it showed ``kind="user"`` until #3595 step
+    1b, which is the pairing that arc removed (``"user"`` claims a human typed
+    the line at a first-party client, and ``Session._handle_user_message`` acts
+    on that claim by handing a ``/``-prefixed line to slash dispatch). ★ A
+    usage example is a template: the next author of an injection path copies
+    it, so an example that names a kind untruthfully reproduces the defect
+    rather than merely describing it. Pick the kind that is true of YOUR
+    producer — see ``kind`` below.
 
     The bus puts the message on ``session.inbox`` tagged with ``reply_to``,
     then pumps ``run_one_iteration()`` until the session is quiescent *for
@@ -87,7 +97,21 @@ class MessageBus:
         agent:
             The Session to drive.
         kind:
-            Inbox message kind (e.g. ``"user"``).
+            Inbox message kind — the member of the union
+            ``Session._run_turn_body`` dispatches on, naming WHO authored
+            ``payload["text"]``. It is a claim about origin, not a routing
+            hint: ``"user"`` means a human typed this at a first-party client,
+            and is the ONLY kind whose text Reyn interprets as an operator
+            command line. Every other producer says what it is —
+            ``transport.EXTERNAL_MESSAGE_INBOX_KIND`` (a webhook / MCP / A2A
+            peer), ``session_api.AGENT_STEP_INBOX_KIND`` (a pipeline agent
+            step's prompt), ``cron.routing.CRON_INBOX_KIND``,
+            ``hooks.dispatcher.HOOK_INBOX_KIND``, ``"agent_request"`` /
+            ``"agent_response"`` / ``"pipeline_result"``. ★ Naming ``"user"``
+            when a human did not type it is what made every registered slash
+            command executable from model output and from a Slack message
+            (#3595); this parameter is a free-form ``str`` today, so nothing
+            but the caller's honesty enforces it.
         payload:
             Inbox message payload dict.  The bus stamps ``reply_to`` into a
             ``_bus_reply_to`` key so handlers can propagate it to outbox

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -4844,6 +4844,13 @@ class Session:
         ``pipeline_result`` inbox items are internal wake triggers, never
         rendered as a queued user message).
 
+        #3595 step 1b narrowed what reaches this filter rather than changing the
+        filter: text pushed by an external transport (``external_message``) or a
+        cron fire (``cron``) used to claim ``kind="user"`` and therefore appeared
+        here. It no longer does, and that is the same sentence as before — the
+        sent-queue renders what THIS operator submitted from a client, and a
+        Slack peer's message was never that.
+
         Each item: ``{"msg_id": str, "chain_id": str | None, "text": str | None,
         "meta": dict}`` — ``msg_id``/``chain_id`` are the correlation ids a
         client matches against the ``user_submitted`` (enqueue) /
@@ -5447,6 +5454,36 @@ class Session:
                 payload.get("text", ""),
                 chain_id=payload.get("chain_id") or _new_chain_id(),
             )
+        elif kind == "external_message":  # EXTERNAL_MESSAGE_INBOX_KIND (#3595 step 1b)
+            # Text that arrived over an EXTERNAL transport: a chat webhook
+            # (``gateway.api.push_to_agent`` — Slack / LINE / any ``reyn.webhooks``
+            # plugin) or an out-of-process request handler
+            # (``mcp.server.send_to_agent_impl``, reached by the MCP
+            # ``send_to_agent`` tool and the A2A JSON-RPC router). Both used to
+            # arrive as ``kind="user"``, which is the claim
+            # ``_handle_user_message`` acts on by handing a ``/``-prefixed line to
+            # slash dispatch — so a Slack message reading ``/reset`` executed the
+            # command, and anyone able to post to the webhook could run any of the
+            # registered slash commands. Its own kind routes it to the turn body
+            # directly: the short-circuit is not skipped by a flag, it is not on
+            # this path at all (#3595 / owner: "inbox につまれたものはスラッシュ
+            # コマンドとして解釈されない").
+            await self._handle_inbox_text(
+                payload.get("text", ""),
+                chain_id=payload.get("chain_id") or _new_chain_id(),
+            )
+        elif kind == "cron":  # CRON_INBOX_KIND value (#3595 step 1b)
+            # A fired message-based cron job's text. Operator-authored (job
+            # config), but authored as the AGENT'S PROMPT and delivered to an
+            # unattended session with no client attached — not a line typed at a
+            # composer, so it does not claim to be one. Same routing as
+            # ``external_message`` above, a separate union member because the two
+            # answer "who wrote this" differently; see
+            # ``runtime.cron.routing.CRON_INBOX_KIND``.
+            await self._handle_inbox_text(
+                payload.get("text", ""),
+                chain_id=payload.get("chain_id") or _new_chain_id(),
+            )
         elif kind == "hook":  # HOOK_INBOX_KIND value (#1800 slice 5b)
             # E (wake=true) lifecycle-hook push delivered as a turn trigger:
             # a system-role [hook:name] message + one router turn (self-
@@ -5466,7 +5503,8 @@ class Session:
         — the OS-authoritative provenance classification of this turn, threaded into
         ``OpContext.turn_origin`` at both ctx-build sites. Only an explicit
         ``kind == "user"`` turn grants ``"user_directed"``; EVERY other kind —
-        hook, pipeline_result, ``agent_step`` (#3595), sub-agent
+        hook, pipeline_result, ``agent_step`` (#3595), ``external_message`` /
+        ``cron`` (#3595 step 1b), sub-agent
         ``agent_request``/``agent_response``, or
         any future kind this method does not yet know about — resolves to the
         strictER ``"auto_improvement"``. This is an if/else fail-safe, not a
@@ -5648,6 +5686,14 @@ class Session:
         ``_handle_inbox_text`` directly, so it cannot execute a slash command
         by writing one (owner ruling: "inbox につまれたものはスラッシュコマンド
         として解釈されない。されるんだとするとそれが不具合").
+
+        #3595 step 1b moved the last three text-bearing producers off ``"user"``
+        onto that direct route: a chat webhook and an MCP / A2A peer
+        (``transport.EXTERNAL_MESSAGE_INBOX_KIND``) and a cron fire
+        (``cron.routing.CRON_INBOX_KIND``). Slash is deliberately not exposed to
+        any of them (owner, 2026-08-01: 「現時点では slash に公開不要」) — if it
+        ever is, it goes through a shared CLIENT-side slash layer, never through
+        a transport re-testing ``startswith("/")``.
 
         Sibling entry: ``_handle_pipeline_result`` still calls THIS method, so a
         pipeline's OS-framed result text is still slash-interpreted. Its framing

--- a/src/reyn/runtime/transport.py
+++ b/src/reyn/runtime/transport.py
@@ -97,12 +97,54 @@ class ExternalRef:
 
 
 # ---------------------------------------------------------------------------
+# Inbox kind for text arriving over an external transport
+# ---------------------------------------------------------------------------
+
+#: The inbox kind every message that arrived over an EXTERNAL transport rides
+#: (#3595 step 1b): a chat webhook (``gateway.api.push_to_agent`` — Slack /
+#: LINE / any ``reyn.webhooks`` plugin) and an out-of-process request handler
+#: (``mcp.server.send_to_agent_impl``, reached by the MCP ``send_to_agent``
+#: tool and by the A2A JSON-RPC router).
+#:
+#: A member of the SAME discriminated union ``Session._run_turn_body`` already
+#: dispatches on (``user`` / ``agent_request`` / ``agent_response`` /
+#: ``pipeline_result`` / ``agent_step`` / ``hook``). ``"user"`` means "a human
+#: typed this at a first-party client", and ``Session._handle_user_message``
+#: acts on that claim by handing a ``/``-prefixed line to slash dispatch before
+#: any router turn. None of the producers above is that human, so under the old
+#: ``kind="user"`` a Slack message reading ``/reset`` executed the command; under
+#: this kind the text reaches the turn body directly and no registered slash
+#: command is reachable from it at all.
+#:
+#: **Why ONE kind for two transports.** What the kind has to answer is who
+#: authored the text, for the purpose of deciding whether the OS may act on its
+#: FORM — and a webhook peer and an MCP/A2A peer answer it identically: a
+#: counterparty outside this process, never the operator. Every in-tree consumer
+#: of the kind (turn dispatch, ``_stamp_execution_context``, the hook-driven-turn
+#: valve, ``queued_user_messages``) branches identically on the two. A consumer
+#: that needs the transport ITSELF already has a strictly better source on the
+#: envelope — ``sender`` (``"slack:U456"``) or ``reply_to`` (``McpRef`` /
+#: ``ExternalRef``) — which names the individual peer, not just its transport.
+#: A distinction no consumer branches on, and that a richer field already
+#: carries, is a label rather than a union member.
+#:
+#: Declared HERE rather than at one of the two producers, because neither
+#: produces it alone; this module is already the shared vocabulary both import
+#: for the same class of thing (``ExternalRef`` / ``McpRef``). Contrast
+#: ``hooks.dispatcher.HOOK_INBOX_KIND`` and
+#: ``runtime.session_api.AGENT_STEP_INBOX_KIND``, which each have exactly one
+#: producer and live in it.
+EXTERNAL_MESSAGE_INBOX_KIND = "external_message"
+
+
+# ---------------------------------------------------------------------------
 # Union alias
 # ---------------------------------------------------------------------------
 
 TransportRef = TuiRef | McpRef | A2aRef | AgentRef | SystemRef | ExternalRef
 
 __all__ = [
+    "EXTERNAL_MESSAGE_INBOX_KIND",
     "TransportRef",
     "TuiRef",
     "McpRef",

--- a/tests/gateway/sample_line/test_webhook.py
+++ b/tests/gateway/sample_line/test_webhook.py
@@ -25,6 +25,8 @@ import json
 
 import pytest
 
+from reyn.runtime.transport import EXTERNAL_MESSAGE_INBOX_KIND
+
 linebot = pytest.importorskip("linebot.v3")
 
 
@@ -174,7 +176,9 @@ def test_user_text_message_dispatches_to_agent(_line_client):
     pushed = _line_client.pushed
     assert pushed, "expected at least one push call to the agent"
     kind, payload = pushed[0]
-    assert kind == "user"
+    # #3595 step 1b: a gateway push rides the EXTERNAL kind, never "user" —
+    # the kind whose text Session._handle_user_message hands to slash dispatch.
+    assert kind == EXTERNAL_MESSAGE_INBOX_KIND
     assert payload["text"] == "hello LINE bot"
     assert payload["sender"] == "line:user:U456"
 

--- a/tests/gateway/sample_slack/test_webhook.py
+++ b/tests/gateway/sample_slack/test_webhook.py
@@ -34,6 +34,8 @@ import time
 
 import pytest
 
+from reyn.runtime.transport import EXTERNAL_MESSAGE_INBOX_KIND
+
 # Skip the SDK-dependent tests when slack-bolt isn't installed (= when
 # reyn is installed without the ``sample_slack`` extra).
 slack_bolt = pytest.importorskip("slack_bolt")
@@ -185,7 +187,9 @@ def test_app_mention_dispatches_to_agent_inbox(_slack_client):
     pushed = _slack_client.pushed
     assert pushed, "expected at least one push call to the agent"
     kind, payload = pushed[0]
-    assert kind == "user"
+    # #3595 step 1b: a gateway push rides the EXTERNAL kind, never "user" —
+    # the kind whose text Session._handle_user_message hands to slash dispatch.
+    assert kind == EXTERNAL_MESSAGE_INBOX_KIND
     assert payload["text"] == "<@U_BOT> hello"
     assert payload["sender"] == "slack:U456"
 

--- a/tests/gateway/test_api.py
+++ b/tests/gateway/test_api.py
@@ -3,7 +3,7 @@
 Pins the stable contract that webhook plugins consume:
 
   push_to_agent(target_agent, text, sender, reply_to=None,
-                kind="user", extra_meta=None, registry=None)
+                extra_meta=None, registry=None)
 
 Internal ``Session._put_inbox`` is deliberately private; the
 helper is the documented path. Tests cover:
@@ -12,8 +12,12 @@ helper is the documented path. Tests cover:
      and pushes the right envelope shape.
   2. Optional ``reply_to`` propagates when set, absent when None.
   3. Optional ``extra_meta`` becomes the envelope's ``meta``.
-  4. Non-default ``kind`` is forwarded to ``_put_inbox`` (= future
-     A2A/MCP unify path).
+  4. The inbox kind is FIXED at ``EXTERNAL_MESSAGE_INBOX_KIND`` and
+     is not caller-selectable (#3595 step 1b — it used to default to
+     ``"user"`` and be overridable, which is what let a webhook
+     message execute an operator slash command; the reachability
+     consequence is measured in
+     ``tests/test_3595_step1b_external_producer_slash_reachability.py``).
   5. Custom ``registry`` override is honored (= tests stub out the
      process singleton).
   6. ``FileNotFoundError`` from registry propagates (= caller
@@ -28,7 +32,7 @@ from __future__ import annotations
 import pytest
 
 from reyn.gateway.api import push_to_agent
-from reyn.runtime.transport import ExternalRef
+from reyn.runtime.transport import EXTERNAL_MESSAGE_INBOX_KIND, ExternalRef
 
 # ── stub registry / session ───────────────────────────────────────────
 
@@ -75,7 +79,7 @@ class _StubRegistry:
 @pytest.mark.asyncio
 async def test_push_to_agent_minimal_call():
     """Tier 2: a minimal call (= target_agent + text + sender) lands
-    a ``kind="user"`` envelope with no reply_to / meta.
+    an ``EXTERNAL_MESSAGE_INBOX_KIND`` envelope with no reply_to / meta.
     """
     reg = _StubRegistry()
     await push_to_agent(
@@ -85,7 +89,9 @@ async def test_push_to_agent_minimal_call():
         registry=reg,
     )
     sess = await reg.ensure_running("news")
-    assert sess.pushed == [("user", {"text": "hello", "sender": "slack:U1"})]
+    assert sess.pushed == [
+        (EXTERNAL_MESSAGE_INBOX_KIND, {"text": "hello", "sender": "slack:U1"}),
+    ]
 
 
 @pytest.mark.asyncio
@@ -104,7 +110,7 @@ async def test_push_to_agent_with_reply_to():
     )
     sess = await reg.ensure_running("news")
     kind, payload = sess.pushed[0]
-    assert kind == "user"
+    assert kind == EXTERNAL_MESSAGE_INBOX_KIND
     assert payload["reply_to"] is ref
 
 
@@ -145,22 +151,32 @@ async def test_push_to_agent_extra_meta_propagates():
 
 
 @pytest.mark.asyncio
-async def test_push_to_agent_kind_override():
-    """Tier 2: non-default ``kind`` is forwarded to ``_put_inbox``.
-    Reserved for future A2A / MCP unification; webhook plugins use
-    the default ``"user"``.
+async def test_push_to_agent_kind_is_not_caller_selectable():
+    """Tier 2: the caller cannot choose the inbox kind (#3595 step 1b).
+
+    This replaces a leg that pinned the opposite — a ``kind=`` kwarg forwarded
+    verbatim to ``_put_inbox``, "reserved for future A2A / MCP unification".
+    The reservation was never taken up (the A2A and MCP paths drive
+    ``mcp.server.send_to_agent_impl``, not this module) and the parameter was
+    the gate: ``"user"`` is the one kind whose text
+    ``Session._handle_user_message`` hands to slash dispatch, so a plugin that
+    passed it made an external chat message able to execute any registered
+    slash command. A discriminator that decides a trust class is not something
+    the classified side may choose.
+
+    Pinned as the TypeError a plugin still passing ``kind=`` now gets — loud at
+    the call site, rather than silently ignored, which would leave the plugin
+    author believing a kind they chose is in effect.
     """
     reg = _StubRegistry()
-    await push_to_agent(
-        target_agent="news",
-        text="please respond",
-        sender="a2a:peer",
-        kind="agent_request",
-        registry=reg,
-    )
-    sess = await reg.ensure_running("news")
-    kind, _ = sess.pushed[0]
-    assert kind == "agent_request"
+    with pytest.raises(TypeError):
+        await push_to_agent(
+            target_agent="news",
+            text="please respond",
+            sender="a2a:peer",
+            kind="agent_request",
+            registry=reg,
+        )
 
 
 @pytest.mark.asyncio
@@ -215,7 +231,7 @@ async def test_push_to_agent_full_envelope_shape():
     )
     sess = await reg.ensure_running("news")
     kind, payload = sess.pushed[0]
-    assert kind == "user"
+    assert kind == EXTERNAL_MESSAGE_INBOX_KIND
     assert payload == {
         "text": "hi",
         "sender": "line:user:U1",

--- a/tests/test_2608_h5_cron_webhook_hooks.py
+++ b/tests/test_2608_h5_cron_webhook_hooks.py
@@ -28,7 +28,11 @@ import pytest
 
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.cron import CronJob
-from reyn.runtime.cron.routing import dispatch_cron_fired, resolve_cron_session
+from reyn.runtime.cron.routing import (
+    CRON_INBOX_KIND,
+    dispatch_cron_fired,
+    resolve_cron_session,
+)
 from reyn.runtime.cron.runners import build_default_runner
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
@@ -132,9 +136,12 @@ async def test_real_cron_fire_dispatches_cron_fired_hook_into_session_inbox(tmp_
     _seed(tmp_path, "news_agent")
 
     async def _inbox_pusher(to: str, envelope: dict, native_id: str) -> str:
+        # Mirrors the production pusher in reyn.interfaces.web.server, kind
+        # included: #3595 step 1b moved cron off "user", and a local stand-in
+        # keeping the old one stops standing in for the producer.
         session = resolve_cron_session(reg, to, native_id)
         dispatch_cron_fired(session, native_id, to)
-        await session._put_inbox("user", envelope)
+        await session._put_inbox(CRON_INBOX_KIND, envelope)
         return "ok"
 
     runner = build_default_runner(inbox_pusher=_inbox_pusher)
@@ -168,9 +175,12 @@ async def test_cron_matcher_filters_by_job_name_exact(tmp_path):
     _seed(tmp_path, "news_agent")
 
     async def _inbox_pusher(to: str, envelope: dict, native_id: str) -> str:
+        # Mirrors the production pusher in reyn.interfaces.web.server, kind
+        # included: #3595 step 1b moved cron off "user", and a local stand-in
+        # keeping the old one stops standing in for the producer.
         session = resolve_cron_session(reg, to, native_id)
         dispatch_cron_fired(session, native_id, to)
-        await session._put_inbox("user", envelope)
+        await session._put_inbox(CRON_INBOX_KIND, envelope)
         return "ok"
 
     runner = build_default_runner(inbox_pusher=_inbox_pusher)
@@ -196,9 +206,12 @@ async def test_cron_empty_registry_leaves_ingress_delivery_unaffected(tmp_path):
     _seed(tmp_path, "news_agent")
 
     async def _inbox_pusher(to: str, envelope: dict, native_id: str) -> str:
+        # Mirrors the production pusher in reyn.interfaces.web.server, kind
+        # included: #3595 step 1b moved cron off "user", and a local stand-in
+        # keeping the old one stops standing in for the producer.
         session = resolve_cron_session(reg, to, native_id)
         dispatch_cron_fired(session, native_id, to)
-        await session._put_inbox("user", envelope)
+        await session._put_inbox(CRON_INBOX_KIND, envelope)
         return "ok"
 
     runner = build_default_runner(inbox_pusher=_inbox_pusher)
@@ -211,7 +224,8 @@ async def test_cron_empty_registry_leaves_ingress_delivery_unaffected(tmp_path):
     items = _drain(session)
     (only_item,) = items  # exactly one item — unpack asserts the count
     kind, payload = only_item
-    assert kind == "user"
+    # #3595 step 1b: a cron fire rides CRON_INBOX_KIND, never "user".
+    assert kind == CRON_INBOX_KIND
     assert payload["text"] == "hi"  # no hook message — pure no-op
 
 
@@ -299,7 +313,9 @@ async def test_webhook_empty_registry_leaves_ingress_delivery_unaffected(tmp_pat
     items = _drain(session)
     (only_item,) = items  # exactly one item — unpack asserts the count
     kind, payload = only_item
-    assert kind == "user"
+    # #3595 step 1b: a webhook push rides the EXTERNAL kind, never "user".
+    from reyn.runtime.transport import EXTERNAL_MESSAGE_INBOX_KIND
+    assert kind == EXTERNAL_MESSAGE_INBOX_KIND
     assert payload["text"] == "hi"  # no hook message — pure no-op
 
 

--- a/tests/test_3595_step1b_external_producer_slash_reachability.py
+++ b/tests/test_3595_step1b_external_producer_slash_reachability.py
@@ -1,0 +1,316 @@
+"""Tier 2: no non-operator inbox producer can execute a registered slash command.
+
+#3595 step 1 closed the pipeline ``agent`` step's prompt (``AGENT_STEP_INBOX_KIND``);
+``tests/test_3561_spawn_session_seam_reachability.py`` holds that leg. Step 1b closes
+the three producers that were left claiming ``kind="user"`` with NON-EMPTY text:
+
+  * ``reyn.gateway.api.push_to_agent`` — the stable public webhook API every chat
+    gateway plugin routes through (Slack / LINE samples ship in-tree). Its text is
+    written by whoever can post to the webhook.
+  * ``reyn.mcp.server.send_to_agent_impl`` — reached by the MCP ``send_to_agent``
+    tool and by the A2A JSON-RPC router. Its text is written by a peer process,
+    frequently another LLM.
+  * the ``reyn web`` cron runner's inbox push — an unattended timer firing an
+    operator-authored job message into a session with no client attached.
+
+``"user"`` is the claim ``Session._handle_user_message`` acts on by handing a
+``/``-prefixed line to ``_maybe_handle_slash`` BEFORE any router turn, so under that
+kind a Slack message reading ``/reset`` executed the command. Each producer now
+rides its own member of the union ``_run_turn_body`` already dispatches on
+(``runtime.transport.EXTERNAL_MESSAGE_INBOX_KIND`` for the first two,
+``runtime.cron.routing.CRON_INBOX_KIND`` for the third), which routes straight to
+the shared turn body: the dispatch is not skipped by a flag, it is not on those
+paths at all.
+
+**What each leg asserts, and why both halves are needed.** The observable is a real
+side effect outside the session — ``/session new`` opens a conversation session under
+the attached agent, so ``AgentRegistry.session_ids`` moves if and only if the command
+ran. Each leg asserts (a) that it did NOT move, and (b) that the scripted LLM WAS
+consulted. (b) is load-bearing: without it, "no session was born" has a second
+explanation — the turn never ran at all — which is exactly what an absence-only leg
+cannot tell apart. Together they say the line arrived, and arrived as text.
+
+``test_an_operator_submitted_slash_command_still_spawns_a_session`` is the control
+for all three, on the same harness: the same command through
+``Session.submit_user_text`` (the one public entry every client's composer ends at)
+still executes. Without it, deleting slash dispatch outright — or a harness that
+silently runs no turns — would pass every absence leg above.
+
+**The product decision this file records.** Slash is deliberately NOT exposed to
+these transports (owner ruling, 2026-08-01: 「現時点では slash に公開不要」 — "no
+need to expose slash at present"). A reader finding this behaviour later is looking
+at a decision, not at a feature that was dropped by accident. If it is ever revisited,
+the ratified route is a shared client-side slash layer — never ``startswith("/")``
+returning to a transport.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.gateway.api import push_to_agent
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.model_resolver import ModelResolver
+from reyn.llm.pricing import TokenUsage
+from reyn.mcp.server import send_to_agent_impl
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.runtime.session_params import PresentationWiring
+from tests._support.agent_session import make_session
+from tests._support.permissions import make_resolver
+
+#: A real, registered slash command whose handler calls
+#: ``AgentRegistry.spawn_session`` (``interfaces/slash/session.py::session_cmd``) —
+#: the one command whose side effect is observable from OUTSIDE the session that
+#: runs it, which is what lets every leg here assert on a real side effect rather
+#: than on the inbox kind string. The invariant is not about ``/session new``: it is
+#: that a non-operator kind reaches NO registered command, because the branch that
+#: dispatches them is never entered.
+_SLASH_LINE = "/session new"
+
+#: How long a leg waits for a producer that hands its turn to a booted run-loop
+#: (webhook / cron) rather than pumping it inline. The wait ends as soon as EITHER
+#: outcome is visible, so a regression is fast, not a timeout.
+_SETTLE_TIMEOUT_S = 10.0
+
+
+class _ScriptedReply:
+    """A real ``_llm_caller``-shaped callable answering with one fixed plain-text
+    turn — the Tier-2c LLM stand-in this arc's sibling files already use (see
+    ``tests/test_3561_spawn_session_seam_reachability.py``), NOT a ``MagicMock``:
+    a signature drift in the ``call_llm_tools`` contract raises ``TypeError`` here
+    exactly as it would in production.
+
+    ``calls`` is load-bearing rather than diagnostic — every leg reads it to show
+    the turn under test really consulted a model.
+    """
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.calls = 0
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.calls += 1
+        return LLMToolCallResult(
+            content=self.content, tool_calls=[], finish_reason="stop", usage=TokenUsage(),
+        )
+
+
+def _registry(
+    tmp_path: Path, scripted: _ScriptedReply, *, agents: "tuple[str, ...]" = ("worker", "operator"),
+) -> AgentRegistry:
+    """Real ``AgentRegistry`` + real ``Session`` factory — the harness shape
+    ``tests/test_3561_spawn_session_seam_reachability.py`` uses, including the
+    ``holder`` deferred-registry-ref so the factory can pass ``registry=``, and its
+    real-litellm-name resolver so a spawned session's model-support pre-check has a
+    name to resolve."""
+    if not (tmp_path / "reyn.yaml").exists():
+        (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    holder: dict = {}
+    resolver = ModelResolver({"standard": "gemini/gemini-2.5-flash-lite"})
+    perms = make_resolver(tmp_path, config={"file.write": "allow"})
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
+        s = make_session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            permission_resolver=perms, workspace_base_dir=tmp_path,
+            presentation_wiring=PresentationWiring(
+                presentation_consumer=presentation_consumer,
+                intervention_bridge=intervention_bridge,
+            ),
+            resolver=resolver,
+        )
+        s._loop_driver._loop_observer = (
+            lambda loop: setattr(loop, "_llm_caller", scripted)
+        )
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    for name in agents:
+        if not reg.exists(name):
+            reg.create(name)
+    return reg
+
+
+async def _attach_operator(reg: AgentRegistry) -> "set[str]":
+    """Attach an operator agent — the ordinary REPL state, and whose session set
+    ``/session new`` acts on (``session_cmd`` reads ``registry.attached_name``).
+    Returns the baseline session-id set to diff against."""
+    reg.get_or_load("operator")
+    await reg.attach_session("operator", "main")
+    return set(reg.session_ids("operator"))
+
+
+async def _settle(reg: AgentRegistry, scripted: _ScriptedReply, before: "set[str]") -> None:
+    """Wait for a run-loop-driven producer's turn to become observable, then let
+    every in-flight task finish. Exits as soon as EITHER outcome is visible (a
+    session was born, or the model was consulted), so the failing direction is
+    reported quickly instead of after the full timeout."""
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + _SETTLE_TIMEOUT_S
+    while loop.time() < deadline:
+        if scripted.calls > 0 or set(reg.session_ids("operator")) - before:
+            break
+        await asyncio.sleep(0.01)
+    for sid in list(reg.session_ids("worker")):
+        session = reg.get_session("worker", sid)
+        if session is not None:
+            await session.await_quiescent()
+
+
+def _assert_no_command_ran(reg: AgentRegistry, before: "set[str]", producer: str) -> None:
+    born = set(reg.session_ids("operator")) - before
+    assert not born, (
+        f"a slash command delivered by {producer} EXECUTED — a session was born under "
+        f"the attached agent ({sorted(born)!r}). That producer is claiming an inbox "
+        "kind whose text Session._handle_user_message hands to slash dispatch, which "
+        "puts every registered slash command within reach of whoever writes that text "
+        "(#3595 step 1b)"
+    )
+
+
+def _assert_the_turn_ran(scripted: _ScriptedReply, producer: str) -> None:
+    assert scripted.calls > 0, (
+        f"the turn {producer} delivered never consulted the LLM, so the absence above "
+        "is not evidence the text was delivered as content — nothing may have run at "
+        f"all (llm calls: {scripted.calls})"
+    )
+
+
+# ── the three producers step 1b closes ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_webhook_delivered_slash_command_is_read_not_executed(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: a chat webhook's message cannot execute a registered slash command.
+
+    Drives the real stable public API (``gateway.api.push_to_agent``) the in-tree
+    Slack and LINE samples call, with the text an external party controls. Before
+    #3595 step 1b this pushed ``kind="user"`` and the command ran: anyone able to
+    post to the webhook could reach ``/reset``, ``/visibility``, ``/plugin``,
+    ``/rewind`` and the rest.
+    """
+    monkeypatch.chdir(tmp_path)
+    scripted = _ScriptedReply("nothing to say")
+    reg = _registry(tmp_path, scripted)
+    before = await _attach_operator(reg)
+
+    await push_to_agent(
+        target_agent="worker",
+        text=_SLASH_LINE,
+        sender="slack:U456",
+        registry=reg,
+    )
+    await _settle(reg, scripted, before)
+
+    _assert_no_command_ran(reg, before, "gateway.api.push_to_agent")
+    _assert_the_turn_ran(scripted, "gateway.api.push_to_agent")
+
+
+@pytest.mark.asyncio
+async def test_an_mcp_delivered_slash_command_is_read_not_executed(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: an MCP / A2A peer's message cannot execute a registered slash command.
+
+    Drives the real ``send_to_agent_impl`` — the backing implementation of the MCP
+    ``send_to_agent`` tool and of the A2A JSON-RPC router — taking its DEFAULT
+    ``inbox_kind``, which is the point: a caller that says nothing about who wrote
+    the text gets the kind that cannot execute a command.
+    """
+    monkeypatch.chdir(tmp_path)
+    scripted = _ScriptedReply("nothing to say")
+    reg = _registry(tmp_path, scripted)
+    before = await _attach_operator(reg)
+
+    await send_to_agent_impl(reg, agent_name="worker", message=_SLASH_LINE, timeout=30.0)
+
+    _assert_no_command_ran(reg, before, "mcp.server.send_to_agent_impl")
+    _assert_the_turn_ran(scripted, "mcp.server.send_to_agent_impl")
+
+
+@pytest.mark.asyncio
+async def test_a_cron_fire_slash_message_is_read_not_executed(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: a fired cron job's message cannot execute a registered slash command.
+
+    Drives the production runner ``reyn web`` installs (``_make_cron_runner``), with
+    a real ``CronJob``. The job's text is operator-authored, but authored as the
+    AGENT'S PROMPT and delivered to an unattended session — so before #3595 step 1b
+    a job message beginning with ``/`` ran an operator command with no client
+    present to have asked for it or to see the result.
+    """
+    monkeypatch.chdir(tmp_path)
+    scripted = _ScriptedReply("nothing to say")
+    reg = _registry(tmp_path, scripted)
+    before = await _attach_operator(reg)
+
+    from reyn.interfaces.web import deps as web_deps
+    from reyn.interfaces.web.server import _make_cron_runner
+    from reyn.runtime.cron import CronJob
+
+    monkeypatch.setattr(web_deps, "_get_registry", lambda: reg)
+    runner = _make_cron_runner()
+    outcome = await runner(
+        CronJob(name="nightly", schedule="0 9 * * *", to="worker", message=_SLASH_LINE),
+    )
+    assert outcome == "ok", (
+        "the cron fire did not dispatch at all, so neither assertion below measures "
+        f"anything about slash reachability (runner returned {outcome!r})"
+    )
+    await _settle(reg, scripted, before)
+
+    _assert_no_command_ran(reg, before, "the reyn web cron runner")
+    _assert_the_turn_ran(scripted, "the reyn web cron runner")
+
+
+# ── the control ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_an_operator_submitted_slash_command_still_spawns_a_session(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: the CONTROL for the three legs above — slash dispatch is closed to
+    non-operator producers and not to everyone.
+
+    Same harness, same command, same observable; the only difference is the door the
+    text comes through — ``Session.submit_user_text``, the one public entry every
+    client's composer ends at, CUI and TUI alike. Without this leg, a harness that
+    ran no turns, or a change that deleted slash dispatch outright, would pass all
+    three absences.
+
+    ``scripted.calls`` staying at 0 is the other half: the operator's line
+    short-circuited at ``_maybe_handle_slash`` before any router turn, which is what
+    tells an executed command apart from a model that decided to spawn.
+    """
+    monkeypatch.chdir(tmp_path)
+    scripted = _ScriptedReply("nothing to say")
+    reg = _registry(tmp_path, scripted)
+    before = await _attach_operator(reg)
+
+    operator = reg.get_or_load("operator")
+    await operator.submit_user_text(_SLASH_LINE)
+    await operator.run_one_iteration()
+    await operator.await_quiescent()
+
+    born = set(reg.session_ids("operator")) - before
+    assert born, (
+        "an operator's own '/session new' no longer opens a session — #3595 step 1b "
+        "closed slash dispatch to kinds that are not the operator's, and must leave "
+        "the operator's own path untouched"
+    )
+    assert scripted.calls == 0, (
+        "the operator's slash line reached the model instead of the slash handler, so "
+        f"the spawn above is not evidence the command ran (llm calls: {scripted.calls})"
+    )

--- a/tests/test_chat_cli_flags.py
+++ b/tests/test_chat_cli_flags.py
@@ -152,8 +152,16 @@ def _run_chat_once(tmp_path, monkeypatch, *, no_restore: bool):
     args = top.parse_args(argv)
     args.once = True  # drive the fast one-shot branch, same as `run-once`
 
+    # Signature mirrors send_to_agent_impl, ``inbox_kind`` included (#3595 step
+    # 1b): `reyn run-once` passes it explicitly, and a double that swallows the
+    # kwarg would stop witnessing that the operator path still claims "user".
     async def _fake_send(registry, *, agent_name, message, timeout=0,
-                          intervention_override=None, sid=None) -> dict:
+                          intervention_override=None, sid=None,
+                          inbox_kind="user") -> dict:
+        assert inbox_kind == "user", (
+            "`reyn run-once` is the operator's own line at a first-party CLI; it "
+            f"must not ride a non-operator inbox kind (got {inbox_kind!r})"
+        )
         return {"reply": "ok", "limit_stopped": False}
 
     monkeypatch.setattr("reyn.mcp.server.send_to_agent_impl", _fake_send)

--- a/tests/test_teardown_completeness_2783.py
+++ b/tests/test_teardown_completeness_2783.py
@@ -139,8 +139,16 @@ def test_reyn_run_once_cli_reaches_registry_shutdown(tmp_path, monkeypatch):
     run_once.register(sub)
     args = top.parse_args(["run-once"])
 
+    # Signature mirrors send_to_agent_impl, ``inbox_kind`` included (#3595 step
+    # 1b): `reyn run-once` passes it explicitly, and a double that swallows the
+    # kwarg would stop witnessing that the operator path still claims "user".
     async def _fake_send(registry, *, agent_name, message, timeout=0,
-                          intervention_override=None, sid=None) -> dict:
+                          intervention_override=None, sid=None,
+                          inbox_kind="user") -> dict:
+        assert inbox_kind == "user", (
+            "`reyn run-once` is the operator's own line at a first-party CLI; it "
+            f"must not ride a non-operator inbox kind (got {inbox_kind!r})"
+        )
         return {"reply": "ok", "limit_stopped": False}
 
     monkeypatch.setattr("reyn.mcp.server.send_to_agent_impl", _fake_send)

--- a/tests/test_transport_ref.py
+++ b/tests/test_transport_ref.py
@@ -458,7 +458,11 @@ async def test_a2a_endpoint_uses_message_bus(tmp_path, monkeypatch):
         inbox_consumed.append(kind)
         return await original_put_inbox(self, kind, payload)
 
-    async def _fake_handle_user_message(self, text, *, chain_id):
+    # #3595 step 1b: the seam is _handle_inbox_text, the shared turn body every
+    # text-bearing inbox kind reaches (_handle_user_message is the OPERATOR entry
+    # above it and calls straight into this). Patching the body keeps this test on
+    # the code both the old kind="user" route and the new external kind end at.
+    async def _fake_handle_inbox_text(self, text, *, chain_id):
         from reyn.runtime.chat_message import ChatMessage
         self._append_history(ChatMessage(
             role="user", content=text, ts="2026-05-14T00:00:00",
@@ -471,7 +475,7 @@ async def test_a2a_endpoint_uses_message_bus(tmp_path, monkeypatch):
         ))
 
     monkeypatch.setattr(Session, "_put_inbox", _tracking_put_inbox)
-    monkeypatch.setattr(Session, "_handle_user_message", _fake_handle_user_message)
+    monkeypatch.setattr(Session, "_handle_inbox_text", _fake_handle_inbox_text)
 
     result = await send_to_agent_impl(
         registry,
@@ -481,9 +485,12 @@ async def test_a2a_endpoint_uses_message_bus(tmp_path, monkeypatch):
     )
 
     # The inbox was used (= MessageBus path, not inline bypass).
-    assert "user" in inbox_consumed, (
+    from reyn.runtime.transport import EXTERNAL_MESSAGE_INBOX_KIND
+    assert EXTERNAL_MESSAGE_INBOX_KIND in inbox_consumed, (
         "send_to_agent_impl must use the inbox (MessageBus path); "
-        "direct _handle_user_message bypass detected."
+        "direct turn-body bypass detected. (#3595 step 1b: the kind it puts is "
+        "EXTERNAL_MESSAGE_INBOX_KIND, not 'user' — an MCP / A2A peer is not the "
+        "operator, and 'user' is the kind whose text reaches slash dispatch.)"
     )
     assert result["agent"] == "default"
     assert "bus_reply:test_bus_msg" in result["reply"]


### PR DESCRIPTION
**[per-PR-coder]** — step 1b of the #3595 arc, part of #3595. The three inbox producers that #3596 left claiming `"user"` with non-empty text stop claiming it, so **a chat webhook, an MCP/A2A peer and a cron fire can no longer execute any registered slash command**.

## What an external party could do before, and what they can do after

**Before.** Anyone able to POST to a configured Slack / LINE / generic webhook could send `/reset`, `/visibility`, `/plugin`, `/rewind`, `/clear-history`, `/model`, `/quit` — any of the 25 registered commands — and Reyn executed it. The message went in as `kind="user"`, i.e. as the claim *a human typed this at a first-party client*, and `Session._handle_user_message` acts on that claim by handing a `/`-prefixed line to `_maybe_handle_slash` **before any router turn**. The same was true of an MCP client's `send_to_agent` call and of an A2A delegation, and of a cron job whose message began with `/` (executed in an unattended session with no client present).

**After.** The same text reaches the model as content and is answered as an ordinary turn. No command runs. The three legs in the new test file each assert this on a real side effect — `/session new`'s spawn, observable from outside the session — not on a kind string.

## The product decision this PR records — not a dropped feature

> **owner (2026-08-01): 「現時点では slash に公開不要」** — no need to expose slash at present.

★ So this is the **final shape**, not a stopgap: there is no follow-up that builds a slash path for Slack / LINE / MCP. Recorded here, in `docs/gateway/authoring-guide.md` (a new "Slash commands are not exposed to gateways" section), and in `Session._handle_user_message`'s docstring — because **code cannot tell "forgotten" from "decided"**, and a later reader finding that Slack slash "doesn't work" would otherwise reasonably try to restore it. The ruling is also recorded on #3595 itself.

If it is ever revisited: the route is the ratified one — a **shared client-side slash layer** the transport drives — never `startswith("/")` returning to a transport, and never an allow-list of "safe" commands.

## The kinds, and the one-vs-two argument

Two new members of the union `_run_turn_body` already dispatches on (`user` / `agent_request` / `agent_response` / `pipeline_result` / `agent_step` / `hook`):

| kind | constant | producers |
|---|---|---|
| `external_message` | `runtime.transport.EXTERNAL_MESSAGE_INBOX_KIND` | `gateway.api.push_to_agent` (webhook) **and** `mcp.server.send_to_agent_impl` (MCP tool + A2A router) |
| `cron` | `runtime.cron.routing.CRON_INBOX_KIND` | the `reyn web` cron runner's inbox push |

**Why webhook and MCP share one.** The question the kind exists to answer is *who authored this text, for the purpose of deciding whether the OS may act on its FORM* — and a webhook peer and an MCP/A2A peer answer it identically: a counterparty outside this process, never the operator. I enumerated the in-tree consumers of the kind and each branches the same way on the two: turn dispatch (`_run_turn_body`), provenance (`_stamp_execution_context`), the hook-driven-turn valve (`run_one_iteration`), and the sent-queue projection (`queued_user_messages`). A consumer that needs the transport *itself* already has a strictly better source **on the envelope** — `sender` (`"slack:U456"`) or `reply_to` (`ExternalRef` / `McpRef`) — which names the individual peer, not merely its transport. ★ A distinction no consumer branches on, and that a richer field already carries at higher resolution, is a label, not a union member.

**Why cron does NOT share it.** Cron answers that same question differently: its text is **operator-authored**, in `.reyn/` job config, under the same file-permission trust as the workspace — not a counterparty's chat line. That is a distinction a trust decision (e.g. #3501's untrusted-content narrowing) would branch on. ★ And no envelope field can carry it: `sender` (`"cron:<job>"` vs `"slack:U456"`) is a **free-form attribution string the pushing plugin supplies**, and a discriminator a trust decision reads must not come from the side being classified. That last point is also why `push_to_agent`'s `kind` parameter is removed — see below.

`EXTERNAL_MESSAGE_INBOX_KIND` is declared in `runtime/transport.py` rather than at "the producer", because it has two producers and neither owns it; that module is already the shared vocabulary both import for the same class of thing (`ExternalRef` / `McpRef`). `CRON_INBOX_KIND` lives in `runtime/cron/routing.py`, mirroring `hooks.dispatcher.HOOK_INBOX_KIND` exactly (one subsystem, one producer).

## Two judgement calls beyond the literal brief — flagging both

**1. `push_to_agent`'s `kind` kwarg is removed** (it defaulted to `"user"` and was caller-overridable "so the contract can extend without API break"). Changing only the default leaves the defect one kwarg away from returning: a plugin could still pass `kind="user"` and make its external message execute commands. ★ A parameter that lets the caller choose whether it is the operator is not a parameter — it is the gate. Nothing in-tree ever passed it, and the A2A / MCP unification it was reserved for does not go through this module at all (those drive `send_to_agent_impl`). `tests/gateway/test_api.py::test_push_to_agent_kind_override` is replaced by `test_push_to_agent_kind_is_not_caller_selectable`, pinning the `TypeError` a plugin still passing it now gets — loud at the call site rather than silently ignored.

**2. `send_to_agent_impl` gains an `inbox_kind` parameter, and cron is in scope.** See the census below for why cron is a fourth producer with non-empty text, and the next section for why `send_to_agent_impl` needed a parameter rather than a blanket change.

## 🔴 The brief's biggest miss: `send_to_agent_impl` is not only MCP

The brief describes `mcp/server.py:241` as "an MCP server call". It has **four** producers:

| call site | who wrote the text | `inbox_kind` |
|---|---|---|
| `mcp/server.py` `send_to_agent` tool | an MCP peer, frequently another LLM | default (`external_message`) |
| `interfaces/web/routers/a2a.py` ×2 | an A2A peer | default (`external_message`) |
| `interfaces/cli/commands/chat.py::_run_once` | **the operator**, piping stdin at `reyn run-once` | explicit `"user"` |
| `interfaces/cli/commands/dogfood.py` ×2 | a human-authored scenario replayed **as** operator typing | explicit `"user"` |

A blanket change would have made `echo "/model x" | reyn run-once` stop executing the command — an operator-visible behaviour change this arc explicitly must not make — and would have made the dogfood instrument measure a path no operator uses. ★ **The default is the NON-operator kind on purpose**: a new caller that says nothing gets the kind that cannot execute a command, the same fail-safe direction `_stamp_execution_context` uses for turn origin.

## Census: every producer that puts text on an inbox

Enumerated by me from the `_put_inbox` call sites plus the two indirection layers that reach them (`Session.submit_user_text`, `MessageBus.request`), then each producer read individually — not taken from the brief or from #3596.

| producer | kind after this PR | truthful? |
|---|---|---|
| `session.submit_user_text` → `_put_inbox("user", …)` (funnelled into by `transport/in_process.py`, `agui/endpoint.py`, `repl/stream_client.py`, `textual_chat/app.py`) | `user` | ✅ a human typed it at a client |
| `session_api.run_agent_step` | `agent_step` | ✅ #3596 |
| `session.submit_agent_request` / `submit_agent_response` | `agent_request` / `agent_response` | ✅ |
| `session.submit_pipeline_result` | `pipeline_result` | ✅ kind truthful — but see finding 1 |
| `hooks/dispatcher.py:394` | `hook` | ✅ |
| `session._cross_session_hook_put` (session.py:4779) | caller-supplied; sole caller is the hook dispatcher | ✅ |
| 🟢 `gateway/api.py` `push_to_agent` (callers `sample_slack/webhook.py`, `sample_line/webhook.py`) | **`external_message`** | ✅ **fixed here** (was `user`) |
| 🟢 `mcp/server.py` `send_to_agent_impl` (MCP tool + A2A router legs) | **`external_message`** | ✅ **fixed here** (was `user` for all four producers) |
| 🟢 `interfaces/web/server.py` cron `_inbox_pusher` | **`cron`** | ✅ **fixed here** (was `user`) — ★ the fourth non-empty-text producer |
| 🟡 `registry.py:1254` (`_rewake_pipeline_runs` resume nudge) | `user` | ❌ a crash-recovery nudge, not a human. Text is `""` — see finding 2 |
| 🟡 `session_api.py:643` (`start_pipeline_run`) and `session_api.py:794` (`run_pipeline_attached`) | `user` | ❌ same shape, text `""` — finding 2 |

★ **No fifth non-empty-text producer exists.** Every remaining `"user"` claim is one of the three `""`-text nudges.

## Out of scope — confirmed still true, deliberately left

1. **`_handle_pipeline_result` still calls `_handle_user_message`** — confirmed at `session.py:5527`. A pipeline's result text is still slash-interpreted; it cannot fire only because `_format_result_text` prefixes `[pipeline] run …`, a property of the formatter, not a gate.
2. **The three `""`-text machine nudges** (`registry.py:1254`, `session_api.py:643`, `session_api.py:794`) still claim `user`. Empty text cannot start with `/`, so no exposure — the kind is still untruthful.
3. **`router_host_adapter.py:1969`** still says the MCP probe is "Called by `Session._handle_user_message`" — confirmed still false since #3475, still untouched.

## Consequences worth naming (all stricter, none wider)

- **Turn origin.** `_stamp_execution_context` maps every non-`"user"` kind to the stricter `"auto_improvement"`. A webhook / MCP / cron turn now stamps installs `provenance=auto_improvement` instead of `user_directed` — **by the existing fail-safe rule, not a new branch**. Correct on its face: a Slack peer did not direct an install.
- **Hook-driven-turn valve.** `run_one_iteration` resets the counter only on `kind == "user"`. These turns no longer reset it, so the valve fires marginally sooner. Same direction and same mechanism as #3596's `agent_step`.
- **Sent-queue projection.** `queued_user_messages()` filters `kind == "user"`, so an MCP message queued on the agent's `main` session no longer appears in an attached client's sent-queue view. That reads as the docstring already did — the sent-queue renders what *this operator* submitted from a client, and a peer's message was never that. Docstring updated in place.

## Strip-falsify — three producers, three legs, each anchor uniqueness-checked first

`grep -cF` → **1** for every anchor before stripping (`await session._put_inbox(EXTERNAL_MESSAGE_INBOX_KIND, envelope)`; `inbox_kind: str = EXTERNAL_MESSAGE_INBOX_KIND,`; `await session._put_inbox(CRON_INBOX_KIND, payload)`).

| state | result on `tests/test_3595_step1b_external_producer_slash_reachability.py` |
|---|---|
| fix applied | **4 passed** |
| webhook kind reverted to `"user"` | **1 failed, 3 passed** — `test_a_webhook_delivered_slash_command_is_read_not_executed` |
| restored | **4 passed** |
| MCP default reverted to `"user"` | **1 failed, 3 passed** — `test_an_mcp_delivered_slash_command_is_read_not_executed` |
| restored | **4 passed** |
| cron kind reverted to `"user"` | **1 failed, 3 passed** — `test_a_cron_fire_slash_message_is_read_not_executed` |
| restored | **4 passed** |

★ **Three different legs, one per producer** — no leg is standing in for another. ★ The operator control passed in **all seven** states, which is what makes it a control rather than a second copy of the same measurement.

## Tests

New: `tests/test_3595_step1b_external_producer_slash_reachability.py` — three absence legs + one control, on a real `AgentRegistry` with real `Session`s (harness shape borrowed from `test_3561_…`; the LLM stand-in is a real callable, not a mock). Each absence leg asserts **both** that no session was born **and** that the scripted LLM *was* consulted — the positive half, so "nothing happened at all" cannot explain the absence. The cron leg additionally asserts the runner returned `"ok"`, so a dispatch that never happened cannot pass as a command that never ran.

Updated, each because the PR falsified what it pinned (not to make it pass):
- `tests/gateway/test_api.py` — envelope-kind pins; the `kind=` override leg replaced by its inverse.
- `tests/gateway/sample_slack/test_webhook.py`, `tests/gateway/sample_line/test_webhook.py` — kind assertions.
- `tests/test_2608_h5_cron_webhook_hooks.py` — kind assertions **and** its three local `_inbox_pusher` doubles, which mirror the production pusher; a stand-in that keeps the old kind stops standing in for the producer.
- `tests/test_transport_ref.py::test_a2a_endpoint_uses_message_bus` — moved its seam from `_handle_user_message` to `_handle_inbox_text` (the shared body both the old and new routes end at) and updated the kind it looks for.
- `tests/test_chat_cli_flags.py`, `tests/test_teardown_completeness_2783.py` — the `_run_once` `send` doubles now mirror `send_to_agent_impl`'s signature including `inbox_kind`, and **assert it is `"user"`**, so the operator leg keeps a witness rather than merely tolerating the kwarg.

## Docs updated in the same PR (the mechanism changed, so the doc changed)

- `docs/gateway/authoring-guide.md` — the `push_to_agent` signature, and the new "Slash commands are not exposed to gateways" section carrying the owner ruling.
- `docs/reference/runtime/events.md` — `turn_started`'s `kind` enumeration; #3595 is what makes "tell human triggers from automated ones" true rather than approximate.
- `docs/concepts/tools-integrations/mcp.md`, `docs/concepts/multi-agent/a2a.md` — both stated the progress line reads `turn: user`; it now reads `turn: external_message`.
- In-code: `Session._handle_user_message` / `_stamp_execution_context` / `queued_user_messages`, `gateway/api.py`, `mcp/server.py`, `web/server.py`, `cron/routing.py`.

## ★ Corrections to the brief, measured

1. **`src/reyn/interfaces/gateway/api.py` does not exist.** The file is `src/reyn/gateway/api.py` (no `interfaces/`). Everything re-anchored by content.
2. **`send_to_agent_impl` has four producers, not one** — the brief called it "an MCP server call". Two of them (`reyn run-once`, dogfood) are operator surfaces; a blanket change would have silently altered them. This is why the change is a parameter with a fail-safe default rather than a one-line edit.
3. **The fourth producer is cron, and the brief's own framing hid it.** The brief said "two producers still claim `kind="user"` untruthfully with non-empty text" and listed cron only under #3596's 🟡 findings — but cron's text *is* non-empty (it is the job's `message`). Included, per the brief's own fourth-producer clause.
4. Line numbers: `push_to_agent`'s push is at `gateway/api.py:129` (brief said 120); `send_to_agent_impl`'s `bus.request` kind is at `mcp/server.py:263` (brief said 241). Nothing was applied by line number.
5. Not an error, just unstated: **removing `push_to_agent`'s `kind` parameter** is a judgement call past the literal scope. Flagged above rather than buried; happy to revert that one hunk if a reviewer wants the API kwarg preserved.

## Test plan

- [x] `ruff check src tests` — All checks passed
- [x] `python scripts/test_tier_audit.py --strict` on all 8 new/changed test files — 78 tests inspected, 0 errors, 0 warnings
- [x] `python -m pytest -q -n auto --timeout=120` from the repo root, foreground, summary line read directly — **9863 passed, 36 skipped** in 231 s. Neither known intermittent (#3590, #3594) fired.
- [x] `python scripts/verify_module_docstrings.py` on all 8 changed `src/` files — OK
- [x] Strip-falsify, three producers separately, each anchor `grep -cF`-confirmed unique first — numbers in the table above; three distinct legs failed
- [x] Measured-code identity confirmed at measurement time: an in-pytest probe printed `reyn.__file__` inside this agent's own worktree and read `EXTERNAL_MESSAGE_INBOX_KIND` from it. ⚠️ Worth knowing: a bare `python -c "import reyn"` from this worktree resolves the **shared checkout** (the borrowed venv's editable path) — pytest is correct because `pythonpath = ["src"]` is rootdir-relative. The worktree was re-checked with `pwd` + `git worktree list` immediately before measuring, committing and pushing.
- [x] `_put_inbox` census enumerated from the call sites myself, including the two indirection layers, and each producer read individually
- [x] Closing-intent: this PR declares `part of #3595` and no closing keyword anywhere. Rule-4 enumeration is not applicable — this is step 1b of a multi-step arc and the arc is not complete (step 2, moving the handler argument to `ClientTransport`, and step 3, deleting both session-side entry points, are still open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
