### PR TITLE
docs(verification-hazards): add §14 — declaration of completion ≠ witness of completion

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -404,6 +404,31 @@ And before a gate is allowed to pin a literal collection's exact contents,
 confirm that pinning it won't fight the next correct change to that
 collection.
 
+## 14. A declaration of completion is not a witness of completion
+
+A lead reported an arc's items "①②④⑤ complete" after merging a PR. Item ①
+explicitly included a rewrite of the LLM-facing tool-description prose for a
+retired mechanism. A later PR's author, editing a nearby paragraph, checked
+`gh pr view <N> --json files` for the merged PR before citing it as
+precedent — and that file was not in its file set. The retired mechanism's
+sales pitch (`"returns a structured preview... and a path_ref to the full
+body saved under .reyn/tool-results/"`) had shipped to the model, unchanged,
+for the entire duration between the two PRs: "①complete" was true only for
+the item's *code* half, not its doc half, and the declaration didn't
+distinguish the two.
+
+This is the completion-declaration form of the same root as §1's "Observed-
+target identity unverified" — not "which object did I measure," but "which
+object did the PERSON REPORTING COMPLETION measure before declaring it."
+Reporting "arc done" is itself a claim, and the claim's own referent (the
+actual file set of the PR being cited) was never checked before it propagated
+into a second person's mental model of what was already fixed.
+
+**Apply**: before citing a prior PR as having landed item X, run
+`gh pr view <N> --json files` and confirm X's own named file is actually in
+that set — a declaration of completion is not a witness of completion, and
+checking costs one command.
+
 ## See also
 
 - [Testing policy](testing.md) — Tier model, Mock vs Fake, decision flow.


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary
Adds §14 to `verification-hazards.md`, per lead-coder's request (they offered "existing coverage is fine" as a welcome answer too, but I judged this genuinely distinct).

Instance: a lead reported an arc item complete after merging a PR that included a doc-prose rewrite for a retired mechanism. A later PR's author, before citing the merged PR as precedent, ran `gh pr view <N> --json files` and found the specific file wasn't in that PR's file set — the retired mechanism's LLM-facing sales pitch had shipped unchanged for the entire gap between the two PRs.

Checked against existing content before adding: closest is §1's "Observed-target identity unverified," but that face is about which object a *measurement* touches; this is about which object a *completion claim* touches before it propagates into someone else's mental model of what's already fixed — a distinct axis with its own one-command detection method (`gh pr view <N> --json files`).

## Checked, not changed
`docs/guide/for-users/popular-mcp-servers.md`'s "MCP server's remaining advantage is `start_index` pagination" claim is still true, per lead-coder — only the *reason* changed (was: reyn has it but unreachable; now: reyn doesn't have it at all). Not drift, correctly left untouched.

## Test plan
- [x] `ruff check` — clean
- [x] `mkdocs build --strict` — exit 0, no new warnings