### PR TITLE
docs(3557): fix stale semantic_search claim found in #3557-close sweep

### DIFF
--- a/docs/concepts/agent-engineering/index.ja.md
+++ b/docs/concepts/agent-engineering/index.ja.md
@@ -47,7 +47,7 @@ LLM がどのように世界に作用するか: すべての副作用は typed �
 
 ### 3. [Retrieval Engineering](retrieval-engineering.md)
 
-適切なコンテキストを適切なタイミングで、決定論的に(`semantic_search` + preprocessor ステップ)agent に渡すこと — プロンプトに無条件に詰め込むのではありません。これは憲章が明示する 2 つの honest thin area の 1 つです。
+適切なコンテキストを適切なタイミングで、決定論的に(tool/mcp/pipeline カタログに対する`search_actions`、agent向けドキュメント検索のための FP-0063 user-RAG plugin のバンドル済みパイプライン — in-core `IndexBackend` substrate 自体には agent-callable な入口はありません)agent に渡すこと — プロンプトに無条件に詰め込むのではありません。これは憲章が明示する 2 つの honest thin area の 1 つです。
 
 ### 4. [Reliability Engineering](reliability-engineering.md)
 

--- a/docs/concepts/agent-engineering/index.md
+++ b/docs/concepts/agent-engineering/index.md
@@ -47,7 +47,7 @@ How the LLM acts on the world: every side effect rides a typed, validated envelo
 
 ### 3. [Retrieval Engineering](retrieval-engineering.md)
 
-Getting the right context into the agent at the right time, deterministically (`semantic_search` + the preprocessor step), not stuffed unconditionally into the prompt. This is one of the constitution's two declared honest thin areas.
+Getting the right context into the agent at the right time, deterministically (`search_actions` over the tool/mcp/pipeline catalog; the FP-0063 user-RAG plugin's bundled pipelines for agent-facing document search — the in-core `IndexBackend` substrate has no agent-callable entry point of its own), not stuffed unconditionally into the prompt. This is one of the constitution's two declared honest thin areas.
 
 ### 4. [Reliability Engineering](reliability-engineering.md)
 


### PR DESCRIPTION
**[docs-maintainer]** — part of #3557

## Summary
Requested sweep before closing #3557: confirming no live doc still describes the retired layer-1 RAG tools as LLM-callable. Found one: `docs/concepts/agent-engineering/index.md`'s Retrieval Engineering blurb (+ `.ja.md` mirror) still said "semantic_search + the preprocessor step" is the current context-delivery mechanism — same stale claim already fixed in `retrieval-engineering.md` and `CLAUDE.md`, missed here because the surrounding wording differs enough that a keyword-only pass would skip it.

Checked and confirmed clean: `universal-catalog.md`, `tool-naming.md` (both already correctly framed as retired), `enable-semantic-search.md` (about the live, distinct `search_actions` catalog-search feature — only mentions `semantic_search` once, factually, as an internal embedding consumer), `control-ir.md` (has the accurate retirement note at lines 566-591, elsewhere in the same doc — a discoverability nit, not a false claim).

## Test plan
- [x] `ruff check` — clean
- [x] `mkdocs build --strict` — exit 0, no new warnings