### PR TITLE
docs(verification-hazards): §14 gets a sibling instance — search the decision record too

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -424,10 +424,28 @@ Reporting "arc done" is itself a claim, and the claim's own referent (the
 actual file set of the PR being cited) was never checked before it propagated
 into a second person's mental model of what was already fixed.
 
+A sibling instance, same day: an owner asked why four constructor params
+weren't grouped together. A lead re-derived the grouping criterion from the
+code, doubted it under owner questioning, and re-measured to back up the
+doubt — a full four-step chain, all of it already sitting in PR #3515,
+merged two days earlier, including the exact rejected alternative and the
+measured reason it was rejected (a looser criterion looked cleaner but
+silently mis-grouped an unrelated param). The habit of grepping for an existing
+mechanism before writing a new one had been applied to CODE but not to the
+DECISION RECORD — the PR body, issue comments, and design firms that already
+settled the question. `gh pr view <N> --json body` would have closed it in
+one command.
+
 **Apply**: before citing a prior PR as having landed item X, run
 `gh pr view <N> --json files` and confirm X's own named file is actually in
 that set — a declaration of completion is not a witness of completion, and
-checking costs one command.
+checking costs one command. Before re-deriving *why* a design is the way it
+is — especially when a criterion starts to look wrong under questioning —
+search the decision record (`gh pr list --search "#<issue> in:body"`,
+`gh pr view <N> --json body`, `gh issue view <N> --comments`) for the PR or
+issue that already settled it, including any rejected alternative and the
+reason it was rejected; re-deriving from code alone re-litigates a decision
+someone already made and recorded.
 
 ## See also
 


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary
Adds a sibling instance to §14 ("A declaration of completion is not a witness of completion"), per lead-coder's request — they framed it as a tentative suggestion, not a decision, and offered "no addition needed" as a welcome answer too.

Instance: an owner asked why 4 constructor params weren't grouped together. A lead re-derived the grouping criterion from the code, doubted it under owner questioning, and re-measured to back the doubt — a full 4-step chain, all of it already sitting in PR #3515 (merged two days earlier), including the exact rejected alternative and the measured reason it was rejected. The existing-mechanism-grep discipline had been applied to CODE but not to the DECISION RECORD (PR bodies, issue comments, design firms that already settled the question).

Kept as a §14 addition rather than a new top-level section: same root (a prior record already answered this, unchecked before redoing the work) as the completion-declaration face, just a different action (search decision history before re-deriving, vs. verify a file set before citing).

## Fixed during drafting
My first draft cited a memory-pin name (`existing-mechanism-grep-before-new-fix`) as if it were a repo artifact — not valid in a doc other readers can access. Reworded to plain prose and cited the real PR (#3515) instead.

## Test plan
- [x] `ruff check` — clean
- [x] `mkdocs build --strict` — exit 0, no new warnings