### PR TITLE
docs(verification-hazards): add §15 — existence is not the same as being called

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -447,6 +447,41 @@ issue that already settled it, including any rejected alternative and the
 reason it was rejected; re-deriving from code alone re-litigates a decision
 someone already made and recorded.
 
+## 15. A declared field, a complete implementation, and a passing test all look alive — regardless of whether anything calls them
+
+`MemoryService.remember` / `.forget` / `.read_body` were fully implemented,
+docstringed, and one of them had a Tier-2 test that explicitly asserted it
+was exercised by "a live consumer." Their actual production caller count was
+**zero** — three near-duplicate router-loop privates did the real work,
+reimplementing the same rules (a threat-scan reject, frontmatter
+construction, index ingest) independently. `RouterCallerState.memory_service`
+existed as a declared field for the same reason: wired by nobody, because the
+wiring had gone to three separate `*_fn` callables instead (#3608).
+
+Worse inside the same defect: a security check with a HAND-MIRRORED test
+double has a test path that never touches the real thing. Two call sites
+copied `scan_for_block`'s scan-then-emit sequence by hand into fake host
+objects (`_BlockHost`) rather than driving the real method — so the test
+suite could go green forever even if the real `scan_for_block` diverged from
+its copies, because nothing ever asserted the copies matched.
+
+A field, an implementation, and a test all being present is necessary for
+"this is live" but nowhere near sufficient — none of the three states whether
+anything on the production path actually calls it. This is a different axis
+from §1 (which object a measurement touches) and §14 (whether a completion
+claim's own referent was checked): here the artifact itself is completely
+real and correctly built, and the gap is that its EXISTENCE was mistaken for
+its USE.
+
+**Apply**: when a mechanism looks fully built — field declared, method
+implemented with a docstring, test passing — count its production callers
+before trusting that it does anything. Existence of the field, the
+implementation, or the test does not count toward that number. Also check
+whether a test that exercises "the same behavior" does so through the REAL
+call path or a hand-mirrored copy of it — a copy that never diverges from
+the real thing under test is not proof they stayed in sync, only that no one
+has yet made them diverge.
+
 ## See also
 
 - [Testing policy](testing.md) — Tier model, Mock vs Fake, decision flow.


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary
Adds §15 to `verification-hazards.md`, per lead-coder's request — they explicitly asked me to judge fit against §1 and §14 before adding, since it's plausibly close to both.

Instance (verified against PR #3608): `MemoryService.remember`/`.forget`/`.read_body` were fully implemented, docstringed, and one had a Tier-2 test asserting it was exercised by "a live consumer" — production caller count was zero, three near-duplicate router-loop privates did the real work independently. `RouterCallerState.memory_service` existed as a declared field wired by nobody. Worse in the same PR: a security check (`scan_for_block`) had two hand-mirrored test doubles copying its scan-then-emit sequence by hand rather than driving the real method — a test path that could never diverge from the real thing under test because it never touched it.

Checked against §1 and §14 before adding: distinct from both. §1 is about which object a measurement touches (venv, worktree, line numbers); §14 is about whether a completion claim's own referent was checked (a PR's file set). Here the artifact is completely real and correctly built — the gap is that its existence (field/impl/test all present) was mistaken for its use (production callers).

## Test plan
- [x] `ruff check` — clean
- [x] `mkdocs build --strict` — exit 0, no new warnings