### PR TITLE
refactor(runtime): one supplier for the chat-router OpContext, not two argument lists — closes #3607

### DIFF
--- a/docs/reference/runtime/session-construction.md
+++ b/docs/reference/runtime/session-construction.md
@@ -359,29 +359,38 @@ so it is called out here for future edits of that closure.
 `_build_router_waist` aggregates ~40 already-constructed Session sub-components (Families
 1-5's outputs + params/early attrs set earlier in `__init__`) into `RouterHostAdapter`, the
 single object most later families read through — a byte-identical extraction (same object,
-same construction order, same values, including 2 DEFERRED per-turn lambdas —
-`live_session_id_inputs.live_session_id_fn`/`op_context_inputs.turn_origin_fn` — kept
-verbatim, still closing over `self` and resolved at call time, not eager-ized). It stays
-UNMOVED, invoked at its original position — every dependency is already set on `self` by
-this point.
+same construction order, same values, including the DEFERRED per-turn callables —
+`live_session_id_inputs.live_session_id_fn` and every `*_fn` field of the op-context
+supplier — kept verbatim, still closing over `self` and resolved at call time, not
+eager-ized). It stays UNMOVED, invoked at its original position — every dependency is
+already set on `self` by this point.
+
+**#3607 op-context supplier**: `_build_router_waist` also builds
+`self._router_op_context_source` (a `RouterOpContextSource`, see
+`runtime/router_op_context.py`) and hands the SAME object to the adapter as
+`op_context_source`. It is the only caller of `build_router_op_context`, so
+`Session._make_router_op_context` and `RouterHostAdapter.make_router_op_context`
+are both one-line delegations to `.build()` and cannot hand out different
+capabilities. It replaced a 16-field `RouterOpContextInputs` bundle that was a
+COPY of the Session attributes the Session's own builder read directly — two
+argument lists for one object, which had diverged on twelve fields.
 
 **#3482 param bundling**: `RouterHostAdapter.__init__` groups every real
 consumer-set cluster (measured by AST, not by name prefix) into frozen,
-default-free dataclasses built just before the constructor call — five of
+default-free dataclasses built just before the constructor call — four of
 them, each named after the sole consumer the measurement found:
 
 | bundle | fields | sole consumer |
 | --- | --- | --- |
-| `RouterOpContextInputs` | 16: `allowed_mcp`/`base_available_skills_fn`/`budget_gateway`/`compact_now`/`contextual_permission`/`hook_bus`/`hook_dispatcher`/`hot_reloader`/`multimodal_config`/`presentation_renderer_factory`/`render_template_bounds`/`sandbox_backend_instance`/`sandbox_policy`/`turn_origin_fn`/`workspace_base_dir`/`workspace_state_dir` | `make_router_op_context` |
 | `McpGatewayInputs` | `mcp_connection_service`/`mcp_agent_id`/`ephemeral_fn` (#3447's Path A fold) | `_mcp_list_via_gateway` |
 | `SendToAgentInputs` | `send_to_agent`/`delegation_tracker` | the `send_to_agent` method |
 | `PutOutboxInputs` | `put_outbox`/`agent_replies_tracker` | the `put_outbox` method |
 | `LiveSessionIdInputs` | `session_id`/`live_session_id_fn` | the `live_session_id` property |
 
 Session still builds each field with the exact same expression as before
-(same object, same order, same call-time semantics — `turn_origin_fn` /
-`ephemeral_fn` / `live_session_id_fn` and the two tracker lambdas are still
-live per-turn callables, not eager-ized); only the wire shape changed.
+(same object, same order, same call-time semantics — `ephemeral_fn` /
+`live_session_id_fn` and the two tracker lambdas are still live per-turn
+callables, not eager-ized); only the wire shape changed.
 
 **#3607 — ask the layering question BEFORE the bundling one.** Four params
 (`file_read` / `file_write` / `file_delete` / `file_regenerate_index`) left the
@@ -637,23 +646,23 @@ from the catalog the LLM sees, indistinguishable from an operator who
 deliberately disabled exec. No injected instance → falls back to the config
 string (auto / host-default behaviour unchanged).
 
-### base_available_skills_fn reads the BASE set, not the UX-filtered copy (#3196)
+### available_skills_fn reads the BASE set, not the UX-filtered copy (#3196)
 
 `RouterHostAdapter` receives two related-but-distinct skill sets:
 
 - `available_skills=self._available_skills` — the base registered-skill set
   (#2548 PR-A).
-- `base_available_skills_fn=lambda: self._available_skills` — a LIVE read of
-  that SAME `Session._available_skills` field, threaded in separately.
+- `available_skills_fn=lambda: self._available_skills` on the op-context
+  supplier — a LIVE read of that SAME `Session._available_skills` field.
 
-The reason for the second, seemingly-redundant parameter: `RouterHostAdapter`
+The reason for the second, seemingly-redundant source: `RouterHostAdapter`
 holds its OWN `_available_skills` attribute, which `reapply_skill_visibility`
 mutates into a UX-filtered COPY (skills the user toggled off via the status
-bar disappear from it, `#2285`). `make_router_op_context` uses
-`base_available_skills_fn` for the `file` op's skill-load provenance gate — a
+bar disappear from it, `#2285`). The router OpContext uses
+`available_skills_fn` for the `file` op's skill-load provenance gate — a
 TRUST decision, not a UI-visibility decision.
 
-If a future edit swaps `base_available_skills_fn` to close over
+If a future edit swaps `available_skills_fn` to close over
 `RouterHostAdapter`'s own (filtered) `_available_skills` instead of
 `Session._available_skills`, the provenance gate would start following the
 UX visibility toggle: a skill a user merely HID from their own view (but is
@@ -711,14 +720,14 @@ trust decision on a specific skill, discovered later if at all.
   R-D12 follow-up.
 - `_current_task_id` (#1953 §16, recursive-request) — the `task_id` this session is
   currently EXECUTING as a task-as-request, set per-turn from an execute-wake's meta
-  (`run_one_iteration`). Read by the router op-ctx builders so `task.create` derives
+  (`run_one_iteration`). Read by the router op-context supplier so `task.create` derives
   ownership (`requester=<this task>`). `None` = not executing an assigned task (a user /
   hook / recovery turn). Slice B extends the lifetime to a persistent assignment spanning
   continuation + recovery turns.
 - `_current_turn_origin` (proposal 0060 Phase 1 Layer A, A7) — the OS-authoritative
   provenance classification of the turn currently being processed, mirroring
   `_current_task_id` exactly (same seam, same threading). Set per-turn in
-  `_stamp_execution_context`; read by the router op-ctx builders so install-op handlers
+  `_stamp_execution_context`; read per build by the router op-context supplier so install-op handlers
   (skill/pipeline/present, A9) stamp `entry["provenance"]` from a single OS-set source the
   LLM cannot spoof. Initialized to the STRICTER value (fail-safe: never default to
   `"user_directed"` before the first turn is classified).

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -131,9 +131,9 @@ class OpContext:
     # it had 0 writers across all OpContext constructions, so its "Threaded by
     # the OpContext builders" comment was false the whole time.)
     #
-    # Threaded by ``build_router_op_context`` (both router op-ctx builders).
-    # The load-bearing one for `embed` is RouterHostAdapter's — that is the
-    # factory the router-dispatched embed TOOL resolves. None (direct/test
+    # Threaded by ``build_router_op_context``, whose single caller is the
+    # session's ``RouterOpContextSource`` — so it reaches the router-dispatched
+    # `embed` TOOL's factory by construction. None (direct/test
     # construction) = the call is priced into the returned metadata but not
     # recorded into any aggregate.
     budget_gateway: object | None = None

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -1,28 +1,31 @@
-"""#1412: single-source the chat-router OpContext construction.
+"""The chat-router OpContext: one supplier, one construction.
 
-Two hosts built the ``actor="chat_router"`` OpContext with ~95% identical
-code: ``Session._make_router_op_context`` (session.py) and
-``RouterHostAdapter.make_router_op_context`` (services/router_host_adapter.py).
-They drifted — #1410/#1411 threaded ``base_dir`` to one and lagged the other
-(the #187 wrong-FS class). This factory is the single source for the common
-construction (PermissionDecl with the #571 axes, the canonical ``.reyn/`` write
-paths + session-approval, the Workspace FS root, the OpContext).
+``build_router_op_context`` assembles the ``actor="chat_router"`` OpContext
+(PermissionDecl with the #571 axes, the canonical ``.reyn/`` write paths +
+session-approval, the Workspace FS root, the OpContext itself) and
+:class:`RouterOpContextSource` is its **only** caller: one object per Session
+owns the materials and answers "give me an op-context" for every chat-router
+surface.
 
-**Behavior-preserving** (#1412 lead decision): the fields that legitimately
-differ per host — ``agent_id`` / ``intervention_bus`` / ``multimodal_config`` /
-``media_store`` / ``compact_now`` / ``run_id`` — are caller-supplied params, so
-each host passes its CURRENT values (incl. ``None`` where it doesn't wire one).
-The divergence the single-sourcing makes explicit (e.g. RouterHostAdapter never
-wires ``agent_id``) is surfaced for a follow-up classification, NOT folded here
-(same "root-fix surfaces a latent gap" pattern as #1402 -> #1431).
+Why a supplier rather than a set of materials each host carries: the two
+surfaces that need this OpContext — ``Session`` (its own ``_file_op`` / MCP
+callbacks) and ``RouterHostAdapter`` (``op_context_factory``, the registry
+dispatch path) — used to *each* call the factory, one from its own attributes
+and one from a 16-field bundle of copies of those same attributes. Two call
+sites assembling the same object is a drift surface, and it had already
+drifted on twelve fields: ``agent_id``, ``presentation_renderer``,
+``intervention_bus``, ``presentation_registry``, ``multimodal_config``,
+``compact_now``, ``cancel_event``, ``threat_scan`` and ``session_id`` reached
+one path and not the other, and ``allowed_mcp`` / ``contextual_permission`` /
+``sandbox_policy`` were read LIVE on one path and frozen at construction on the
+other. So which capabilities an op got depended on which door it came through,
+and for three of them, on how long the session had been running.
 
-Which-ops trace (#1412): Session's impl serves file ops (``_file_op``) +
-MCP ops (which wire ``intervention_bus`` POST-HOC on the returned ctx), so its
-``intervention_bus=None`` at construction is a wiring-style difference, not a
-missing capability; media/multimodal/compact ops go via the registry /
-RouterHostAdapter path. The lone capability-gap candidate is RouterHostAdapter's
-unset ``agent_id`` (registry-dispatched memory ops lose agent-scope) — a
-follow-up to classify drift-vs-intentional.
+Per-turn values are held as zero-arg **suppliers**, not snapshots: a value
+captured when the Session is constructed (``turn_origin``,
+``contextual_permission``, the live session id, the sandbox policy, the
+hot-reloaded presentation registry / skill set) is right on the first turn and
+wrong on every turn after it.
 """
 from __future__ import annotations
 
@@ -51,10 +54,10 @@ def build_router_op_context(
     environment_backend: Any,  # FS seam backend instance (#1200 PR-F1)
     sandbox_backend: Any,  # exec seam backend instance (#1200 PR-F2)
     sandbox_policy: Any,  # raw policy → resolve_sandbox_policy here (#1339)
-    # ── per-host fields (caller-supplied; behavior-preserving) ─────────────
-    agent_id: str | None,  # FP-0016 memory scope (RouterHostAdapter: None — gap candidate)
-    intervention_bus: Any = None,  # Session wires post-hoc; RouterHostAdapter inline
-    presentation_renderer: Any,  # #2708 P1: REQUIRED (no default) — every OpContext builder must EXPLICITLY decide the present sink (a PresentationRenderer or None for the file/MCP-op path that no present op reaches). Silent-omission drift removed. RouterHostAdapter wires the surface consumer's sink (factory); Session._make_router_op_context passes None.
+    # ── fields the single supplier resolves per call ───────────────────────
+    agent_id: str | None,  # FP-0016 identity → the MCP client's X-Reyn-Agent-Id header
+    intervention_bus: Any = None,  # the surface that answers a router op's intervention
+    presentation_renderer: Any,  # #2708 P1: REQUIRED (no default) — the present sink must be an EXPLICIT decision (a PresentationRenderer or None), never a silent omission.
     presentation_registry: Any = None,  # FP-0054 PR-C: operator named-template registry (hot-reloadable)
     multimodal_config: Any = None,  # #364
     media_store: Any = None,  # #383
@@ -69,14 +72,14 @@ def build_router_op_context(
     turn_origin: str | None = None,  # proposal 0060 Phase 1 (A7): OS-derived turn provenance → install-op stamping (A9)
     hot_reloader: Any = None,  # #2761 PR-2: this session's HotReloader → immediate mid-turn install apply
     render_template_bounds: Any = None,  # #2679: operator RenderTemplateBounds → the render_template op cap. None → the op's in-handler defaults.
-    budget_gateway: Any = None,  # FP-0063 PC: the calling Session's per-session BudgetGateway → the `embed` op's single embedding-cost recording entry point (fans out to session scope + agent/project scope via the tracker it holds, keyed by agent NAME). Wired by BOTH router op-ctx builders; RouterHostAdapter's is the load-bearing one (the `embed` TOOL resolves that factory).
-    available_skills: Any = None,  # #3196: the host's registered SkillEntry list (Session/RouterHostAdapter's `_available_skills`) → the `file` op's skill-load provenance gate (the config-registered-entry class, alongside builtin/plugin). None → that provenance class is simply unavailable (fails closed, not open).
+    budget_gateway: Any = None,  # FP-0063 PC: the calling Session's per-session BudgetGateway → the `embed` op's single embedding-cost recording entry point (fans out to session scope + agent/project scope via the tracker it holds, keyed by agent NAME).
+    available_skills: Any = None,  # #3196: the host's registered SkillEntry list → the `file` op's skill-load provenance gate (the config-registered-entry class, alongside builtin/plugin). None → that provenance class is simply unavailable (fails closed, not open).
 ) -> Any:
-    """Build the chat-router OpContext (the single source for both hosts).
+    """Build the chat-router OpContext.
 
-    The PermissionDecl + canonical-path approval + Workspace + OpContext are
-    identical across hosts; per-host fields are passed explicitly. See module
-    docstring for the drift-class + behavior-preserving rationale."""
+    Assembly only: every value arrives resolved. The one caller is
+    :meth:`RouterOpContextSource.build`, which owns the materials and decides
+    when each is read — see the module docstring."""
     from reyn.core.op_runtime.context import OpContext
     from reyn.data.workspace.workspace import Workspace
     from reyn.security.permissions.permissions import PermissionDecl
@@ -98,10 +101,10 @@ def build_router_op_context(
     # has NO such runtime prompt — the allowlist IS the whole gate, so it must
     # read the OPERATOR'S actual reyn.yaml declaration, never a wildcard
     # default. Read straight off `permission_resolver._config` (the raw
-    # `config.permissions` dict), the SAME idiom both hosts already use for
-    # `file.read`/`file.write` (`_get_file_permissions_for_router`) — centralized
-    # here instead of duplicated in Session AND RouterHostAdapter since this is
-    # the one place both already funnel through.
+    # `config.permissions` dict), the SAME idiom the supplier already uses for
+    # `file.read`/`file.write` (`_get_file_permissions_for_router`) — read here,
+    # in the one place every chat-router OpContext funnels through, rather than
+    # at each surface that asks for one.
     _raw_perm_config = getattr(permission_resolver, "_config", None) or {}
     env_expand = (
         PermissionDecl._parse_secret_key_list(_raw_perm_config.get("env.expand"))
@@ -174,3 +177,162 @@ def build_router_op_context(
         budget_gateway=budget_gateway,  # FP-0063 PC: the embed op's embedding-cost recording entry point
         available_skills=available_skills,  # #3196: config-registered-entry provenance class for the file op's skill-load gate
     )
+
+
+class RouterOpContextSource:
+    """The one supplier of chat-router OpContexts for a Session.
+
+    Owns every material :func:`build_router_op_context` needs and is that
+    function's ONLY caller, so "which capabilities does a chat-router op get"
+    has one answer instead of one per surface. ``Session`` keeps a single
+    instance and hands the SAME object to ``RouterHostAdapter``; both
+    ``Session._make_router_op_context`` and
+    ``RouterHostAdapter.make_router_op_context`` are one-line delegations to
+    :meth:`build`, which is what makes the two entry points equivalent by
+    construction rather than by review.
+
+    **Suppliers, not snapshots.** Fields named ``*_fn`` are read at
+    :meth:`build` time. Each of them is a value that changes AFTER this object
+    is constructed — the per-turn provenance (``turn_origin``), a spawned
+    session's real id, the operator's capability narrowing (built after the
+    router waist, so it does not even exist yet at construction), the resolved
+    sandbox policy, and the two hot-reloadable registries. A plain value in any
+    of those slots is correct on the first turn and silently stale on every
+    turn after it. A ``None`` supplier means "this Session wires no such
+    value" and yields ``None`` (``mcp_servers_flat`` yields ``{}`` — its
+    consumer indexes it).
+
+    No parameter has a default: a caller that silently omits one would absorb a
+    wiring change unnoticed, which is the failure mode #3482's default-free
+    bundles were introduced to prevent.
+
+    ``cancel_event`` is the one slot filled after construction — ``RouterLoop``
+    creates the per-turn ``asyncio.Event`` and registers it via
+    :meth:`set_cancel_event` (through ``RouterHostAdapter._set_cancel_event``),
+    so it lives here rather than being copied into every holder that needs it.
+    """
+
+    def __init__(
+        self,
+        *,
+        events: Any,
+        permission_resolver: Any,
+        file_permissions_fn: Any,
+        mcp_servers_fn: Any,
+        mcp_servers_flat_fn: Any,
+        allowed_mcp_fn: Any,
+        workspace_base_dir: Any,
+        workspace_state_dir: Any,
+        environment_backend: Any,
+        sandbox_backend: Any,
+        sandbox_policy_fn: Any,
+        agent_id: Any,
+        intervention_bus_factory: Any,
+        presentation_renderer_factory: Any,
+        presentation_registry_fn: Any,
+        multimodal_config: Any,
+        media_store_fn: Any,
+        compact_now: Any,
+        threat_scan: Any,
+        contextual_permission_fn: Any,
+        session_id_fn: Any,
+        hook_dispatcher: Any,
+        hook_bus: Any,
+        turn_origin_fn: Any,
+        hot_reloader: Any,
+        render_template_bounds: Any,
+        budget_gateway: Any,
+        available_skills_fn: Any,
+    ) -> None:
+        self._events = events
+        self._permission_resolver = permission_resolver
+        self._file_permissions_fn = file_permissions_fn
+        self._mcp_servers_fn = mcp_servers_fn
+        self._mcp_servers_flat_fn = mcp_servers_flat_fn
+        self._allowed_mcp_fn = allowed_mcp_fn
+        self._workspace_base_dir = workspace_base_dir
+        self._workspace_state_dir = workspace_state_dir
+        self._environment_backend = environment_backend
+        self._sandbox_backend = sandbox_backend
+        self._sandbox_policy_fn = sandbox_policy_fn
+        self._agent_id = agent_id
+        self._intervention_bus_factory = intervention_bus_factory
+        self._presentation_renderer_factory = presentation_renderer_factory
+        self._presentation_registry_fn = presentation_registry_fn
+        self._multimodal_config = multimodal_config
+        self._media_store_fn = media_store_fn
+        self._compact_now = compact_now
+        self._threat_scan = threat_scan
+        self._contextual_permission_fn = contextual_permission_fn
+        self._session_id_fn = session_id_fn
+        self._hook_dispatcher = hook_dispatcher
+        self._hook_bus = hook_bus
+        self._turn_origin_fn = turn_origin_fn
+        self._hot_reloader = hot_reloader
+        self._render_template_bounds = render_template_bounds
+        self._budget_gateway = budget_gateway
+        self._available_skills_fn = available_skills_fn
+        self._cancel_event: Any = None
+
+    @property
+    def hot_reloader(self) -> Any:
+        """#2073 S3 / #2761 PR-2: this session's HotReloader.
+
+        Public because it has a SECOND consumer besides the OpContext —
+        ``RouterLoop`` threads it onto the tool ctx so a self-reload tool
+        reloads THIS session rather than a process global. Read from here so
+        the two consumers share one holder."""
+        return self._hot_reloader
+
+    @property
+    def cancel_event(self) -> Any:
+        """The per-turn cancel event, or None outside a turn.
+
+        Public because the MCP-listing seam needs the same event the OpContext
+        carries; a second copy on the adapter is exactly the duplication this
+        class exists to remove."""
+        return self._cancel_event
+
+    def set_cancel_event(self, event: Any) -> None:
+        """#1470: register the turn's cancel event so a sandboxed op can
+        observe cancellation mid-subprocess."""
+        self._cancel_event = event
+
+    @staticmethod
+    def _resolve(supplier: Any, absent: Any = None) -> Any:
+        """Call *supplier*, or yield *absent* when this Session wires none."""
+        return supplier() if supplier is not None else absent
+
+    def build(self) -> Any:
+        """Build a chat-router OpContext with this Session's CURRENT state."""
+        return build_router_op_context(
+            events=self._events,
+            permission_resolver=self._permission_resolver,
+            file_permissions=self._resolve(self._file_permissions_fn),
+            mcp_servers=self._resolve(self._mcp_servers_fn),
+            mcp_servers_flat=self._resolve(self._mcp_servers_flat_fn, {}),
+            allowed_mcp=self._resolve(self._allowed_mcp_fn),
+            workspace_base_dir=self._workspace_base_dir,
+            workspace_state_dir=self._workspace_state_dir,
+            environment_backend=self._environment_backend,
+            sandbox_backend=self._sandbox_backend,
+            sandbox_policy=self._resolve(self._sandbox_policy_fn),
+            agent_id=self._agent_id,
+            intervention_bus=self._resolve(self._intervention_bus_factory),
+            presentation_renderer=self._resolve(self._presentation_renderer_factory),
+            presentation_registry=self._resolve(self._presentation_registry_fn),
+            multimodal_config=self._multimodal_config,
+            media_store=self._resolve(self._media_store_fn),
+            compact_now=self._compact_now,
+            cancel_event=self._cancel_event,
+            threat_scan=self._threat_scan,
+            contextual_permission=self._resolve(self._contextual_permission_fn),
+            session_id=self._resolve(self._session_id_fn),
+            hook_dispatcher=self._hook_dispatcher,
+            hook_bus=self._hook_bus,
+            turn_origin=self._resolve(self._turn_origin_fn),
+            hot_reloader=self._hot_reloader,
+            render_template_bounds=self._render_template_bounds,
+            budget_gateway=self._budget_gateway,
+            available_skills=self._resolve(self._available_skills_fn),
+        )

--- a/src/reyn/runtime/services/__init__.py
+++ b/src/reyn/runtime/services/__init__.py
@@ -16,7 +16,6 @@ from reyn.runtime.services.router_host_adapter import (
     McpGatewayInputs,
     PutOutboxInputs,
     RouterHostAdapter,
-    RouterOpContextInputs,
     SendToAgentInputs,
 )
 from reyn.runtime.services.router_loop_driver import RouterLoopDriver
@@ -44,7 +43,6 @@ __all__ = [
     "MemoryService",
     "RouterHistoryBuffer",
     "RouterHostAdapter",
-    "RouterOpContextInputs",
     "RouterLoopDriver",
     "ChainTimeoutGlue",
     "SnapshotJournal",

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -12,7 +12,7 @@ import asyncio
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from reyn.config.chat import TimeoutConfig
 from reyn.core.events.events import EventLog
@@ -23,6 +23,9 @@ from reyn.runtime.services.mcp_cache_file import (
     answered_only,
 )
 from reyn.security.permissions.capability_profile import compose_narrowing_mappings
+
+if TYPE_CHECKING:
+    from reyn.runtime.router_op_context import RouterOpContextSource
 
 logger = logging.getLogger(__name__)
 
@@ -38,42 +41,6 @@ _DEFAULT_MCP_PROBE_SECONDS = TimeoutConfig().mcp_probe_seconds
 
 
 @dataclass(frozen=True)
-class RouterOpContextInputs:
-    """#3482: the 16 ``RouterHostAdapter.__init__`` params whose ONLY reader
-    is :meth:`RouterHostAdapter.make_router_op_context` (measured by AST on
-    ``origin/main`` at 890e22d2 — class-internal ``self._<field>`` usage
-    sites, no external ``host.<attr>`` reader for any of these 16). The
-    adapter is a pure RELAY for this cluster: it never inspects or branches
-    on any of these fields itself, it only carries them from Session's
-    construction call to the single call site inside
-    ``make_router_op_context`` (``src/reyn/runtime/services/router_host_adapter.py``).
-
-    Pure value object, no default field values (a default would let a
-    caller's silent omission absorb a wiring change unnoticed — the
-    byte-identical-refactor invariant #3082 established for this bundle
-    family) and no construction logic (assembling these 16 values stays the
-    CALLER's job, same as before this bundle existed).
-    """
-
-    allowed_mcp: "list[str] | None"
-    base_available_skills_fn: "Callable[[], Any] | None"
-    budget_gateway: Any
-    compact_now: Any
-    contextual_permission: Any
-    hook_bus: Any
-    hook_dispatcher: Any
-    hot_reloader: Any
-    multimodal_config: Any
-    presentation_renderer_factory: "Callable[[], Any] | None"
-    render_template_bounds: Any
-    sandbox_backend_instance: Any
-    sandbox_policy: "dict | None"
-    turn_origin_fn: "Callable[[], str | None] | None"
-    workspace_base_dir: "Path | None"
-    workspace_state_dir: "Path | None"
-
-
-@dataclass(frozen=True)
 class McpGatewayInputs:
     """#3482: the 3 raw gateway-identity inputs (#3447) whose ONLY reader is
     :meth:`RouterHostAdapter._mcp_list_via_gateway` (measured on current
@@ -84,8 +51,11 @@ class McpGatewayInputs:
     name-prefix grouping: the three arrived together in #3447 (the Path A
     fold) and are carried together to the same one construction site.
 
-    Pure value object — no defaults, no construction logic (see
-    :class:`RouterOpContextInputs`'s docstring for the rationale)."""
+    Pure value object, no default field values (a default would let a caller's
+    silent omission absorb a wiring change unnoticed — the byte-identical
+    -refactor invariant #3082 established for this bundle family) and no
+    construction logic (assembling the values stays the CALLER's job, same as
+    before the bundle existed). The rationale applies to every bundle below."""
 
     mcp_connection_service: Any
     mcp_agent_id: "str | None"
@@ -100,7 +70,7 @@ class SendToAgentInputs:
     method reads both and nothing else does, so they travel together.
 
     Pure value object — no defaults, no construction logic (see
-    :class:`RouterOpContextInputs`'s docstring for the rationale)."""
+    :class:`McpGatewayInputs`'s docstring for the rationale)."""
 
     send_to_agent: "Callable[..., Awaitable[None]]"
     delegation_tracker: "Callable[[], list[dict] | None]"
@@ -128,12 +98,11 @@ class LiveSessionIdInputs:
     callback that supersedes it. The property picks between them, which is why
     neither is meaningful without the other.
 
-    ``session_id`` is ALSO read by ``make_router_op_context``, but that member
-    is an already-bundled consumer (``RouterOpContextInputs``); counting a
-    landed bundle's hub a second time manufactures equality between params
-    that in fact travel to different dedicated accessors, so it is excluded
-    from consumer sets (#3482 firm: exclude the hub by ROLE, not by a
-    param-count threshold — ``run``/``run_loop`` are turn paths, not hubs).
+    #3607: ``session_id`` used to have a second reader —
+    ``make_router_op_context`` threaded the CONSTRUCTION-TIME value into every
+    OpContext while this property preferred the live callback, so a spawned
+    session's ops carried the stale id. The op-context supplier now reads the
+    live callback, and this pair's consumer set is the one accessor again.
 
     Pure value object — no defaults, no construction logic."""
 
@@ -157,10 +126,12 @@ class RouterHostAdapter:
     output_language:
         BCP-47 code or None. Stored as a plain attribute (not property) per
         the RouterLoopHost Protocol.
-    op_context_inputs:
-        :class:`RouterOpContextInputs` — the 16 fields whose only reader is
-        ``make_router_op_context`` (#3482), bundled because the adapter is a
-        pure relay for this cluster (see the class's docstring).
+    op_context_source:
+        The session's :class:`~reyn.runtime.router_op_context.RouterOpContextSource`
+        — the op-context capability itself, shared with ``Session`` rather than
+        copied. #3607: the adapter used to receive 16 separate materials and
+        assemble its own OpContext from them; a supplier is the finished thing,
+        so there is nothing left to assemble differently from the other caller.
     permission_resolver:
         PermissionResolver instance (or None) for config-derived gates.
     mcp_servers:
@@ -271,7 +242,7 @@ class RouterHostAdapter:
         agent_name: str,
         agent_role: str,
         output_language: str | None,
-        op_context_inputs: RouterOpContextInputs,
+        op_context_source: "RouterOpContextSource",
         permission_resolver: Any,               # PermissionResolver | None
         mcp_servers: dict | None,
         project_context: str,
@@ -379,25 +350,12 @@ class RouterHostAdapter:
         # by ``CapabilityVisibility.reapply_skill_visibility`` to the
         # per-session VISIBILITY-FILTERED view (a UX menu concern — which
         # skills the operator chose to hide from `## Skills` / `skill_list`).
-        # It is therefore the wrong source for a TRUST decision. See
-        # ``base_available_skills_fn`` below, which is what
-        # ``make_router_op_context`` uses for the `file` op's skill-load
-        # provenance gate instead.
+        # It is therefore the wrong source for a TRUST decision — the `file`
+        # op's skill-load provenance gate reads the BASE set through the
+        # op-context supplier's ``available_skills_fn`` instead (#3196 co-vet
+        # round 2), so hiding a skill from the menu cannot change whether it
+        # is trusted.
         available_skills: Any = None,
-        # #3196 co-vet round 2: a LIVE callback returning the BASE
-        # registered-skill set (config `skills.entries`, before the
-        # per-session visibility filter above is ever applied) — Session
-        # wires ``lambda: self._available_skills`` (its own base field,
-        # never mutated by visibility toggling). `make_router_op_context`
-        # threads THIS (not the mutable `self._available_skills` field
-        # above) into `OpContext.available_skills`, so the `file` op's
-        # skill-load provenance gate answers the SAME "is this a
-        # config-registered skill" question regardless of whether the
-        # operator has hidden it from the menu — visibility is a UX
-        # concern; it must never gate a trust decision. None (test
-        # construction) falls back to `self._available_skills` at call
-        # time, preserving prior behavior for callers that don't wire it.
-        # (``base_available_skills_fn`` moved into ``op_context_inputs`` #3482.)
         # B25-S5-1: when True, RouterLoop awaits the action embedding index
         # build synchronously on the first turn before computing the D14
         # search_actions visibility gate. Off by default (= lazy bg build).
@@ -411,7 +369,6 @@ class RouterHostAdapter:
         # config-deny path still raises, interactive prompt path raises
         # the documented RuntimeError telling the caller a bus is needed).
         intervention_bus_factory: Callable[[], Any] | None = None,
-        # (``presentation_renderer_factory`` moved into ``op_context_inputs`` #3482.)
         # #2175: the safety.on_limit checkpoint + the shared per-run extension dict —
         # injected from Session (mirror the inter_agent_messaging injection) so the spawn SEAM can
         # route a spawn-limit exceed through the same mode-driven on_limit framework as
@@ -419,8 +376,6 @@ class RouterHostAdapter:
         # unattended (reject), the C3 hard-deny posture.
         handle_chat_limit_checkpoint: "Callable[..., Any] | None" = None,
         safety_extensions: "dict[str, float] | None" = None,
-        # (``multimodal_config`` / ``render_template_bounds`` moved into
-        # ``op_context_inputs`` #3482.)
         # #1652: ReasoningConfig (continuity/display/recent_turns) + the session
         # callback that renders the bounded prior-reasoning text section (reads
         # history + applies the continuity gate). None → reasoning disabled.
@@ -443,7 +398,6 @@ class RouterHostAdapter:
         offload_enabled: bool = False,
         offload_structured_inline_max_chars: int | None = None,
         offload_structured_preview_chars: int | None = None,
-        # (``compact_now`` moved into ``op_context_inputs`` #3482.)
         # #272/#1128 context-size signal: callable () -> {free_window,
         # effective_trigger} (exact tokens) for the OS-injected SP header.
         # ``None`` = no signal rendered (e.g. test stubs).
@@ -473,20 +427,13 @@ class RouterHostAdapter:
         # FP-0050 / #1822: content-threat scan + fence config. None (test hosts)
         # → defaults (disabled-safe via the methods' guards).
         threat_scan: Any = None,
-        # (``contextual_permission`` / ``hot_reloader`` moved into
-        # ``op_context_inputs`` #3482 — ``hot_reloader`` is ALSO exposed as
-        # the public ``self.hot_reloader`` attribute below, unchanged.)
     ) -> None:
-        self._op_ctx = op_context_inputs
+        self._op_ctx_source = op_context_source
         self._mcp_gateway = mcp_gateway_inputs
         self._send_to_agent_in = send_to_agent_inputs
         self._put_outbox_in = put_outbox_inputs
         self._live_sid_in = live_session_id_inputs
         self._threat_scan = threat_scan
-        # #2073 S3: exposed (public) so RouterLoop threads it onto the tool ctx, so a
-        # self-reload tool reloads THIS session (per-session, not a process global).
-        # (source: op_context_inputs.hot_reloader — #3482 bundle)
-        self.hot_reloader = self._op_ctx.hot_reloader
         self._turn_budget_engine = turn_budget_engine
         self._turn_cancel_fn = turn_cancel_fn  # #1468
         self._agent_name = agent_name
@@ -557,11 +504,9 @@ class RouterHostAdapter:
         self._action_embedding_index = action_embedding_index
         self._embedding_provider = embedding_provider
         self._embedding_model_class = embedding_model_class
-        # (``budget_gateway`` / ``base_available_skills_fn`` / ``sandbox_backend_instance`` /
-        # ``workspace_base_dir`` / ``workspace_state_dir`` / ``sandbox_policy`` /
-        # ``presentation_renderer_factory`` / ``multimodal_config`` / ``render_template_bounds`` /
-        # ``compact_now`` all live on ``self._op_ctx`` — #3482 RouterOpContextInputs bundle;
-        # ``make_router_op_context`` reads them there directly, its sole consumer role.)
+        # (#3607: every material the chat-router OpContext is built from lives
+        # on ``self._op_ctx_source`` — the Session's ONE supplier, shared not
+        # copied. Nothing on this adapter mirrors it.)
         # #2548 PR-A: enabled skill registry snapshot for the ## Skills block.
         self._available_skills = available_skills
         # FP-0034 Phase 2
@@ -595,9 +540,6 @@ class RouterHostAdapter:
         self._offload_enabled = offload_enabled
         self._offload_structured_inline_max_chars = offload_structured_inline_max_chars
         self._offload_structured_preview_chars = offload_structured_preview_chars
-        # #1470: per-turn cancel event set by RouterLoopDriver._set_cancel_event.
-        # None until RouterLoopDriver registers itself at construction time.
-        self._cancel_event: asyncio.Event | None = None
         # #272/#1128 context-size signal: live budget provider (or None).
         self._context_window_status = context_window_status
 
@@ -1711,10 +1653,12 @@ class RouterHostAdapter:
         gateway = (
             MCPGateway(
                 pool=self._mcp_gateway.mcp_connection_service, agent_id=mcp_agent_id,
-                cancel_event=self._cancel_event,
+                cancel_event=self._op_ctx_source.cancel_event,
             )
             if not ephemeral
-            else MCPGateway(agent_id=mcp_agent_id, cancel_event=self._cancel_event)
+            else MCPGateway(
+                agent_id=mcp_agent_id, cancel_event=self._op_ctx_source.cancel_event,
+            )
         )
         result = await gateway_call(gateway)
         self._events.emit(event_kind, server=server, count=len(result))
@@ -2305,111 +2249,40 @@ class RouterHostAdapter:
                 )
         return merged
 
+    @property
+    def hot_reloader(self) -> Any:
+        """#2073 S3: this session's HotReloader, so a self-reload tool reloads
+        THIS session and not a process global. RouterLoop reads it off the host
+        (``getattr(host, "hot_reloader", None)``) and threads it onto the tool
+        ctx. Delegates to the op-context supplier, which is the one holder."""
+        return self._op_ctx_source.hot_reloader
+
     def make_router_op_context(self) -> Any:
-        """Build an OpContext for router-initiated file / MCP / web ops.
+        """Ask the session's op-context supplier for a chat-router OpContext.
 
-        Public method (ADR-0026 Phase 3.5): the unified registry handlers
-        in ``src/reyn/tools/`` delegate to op_runtime via this factory so
-        the OpContext carries the operator-declared PermissionDecl and the
-        Workspace with ``actor="chat_router"``. Without this, handlers
-        would synthesize a ``PermissionDecl()`` empty default and op_runtime
-        permission gates would deny operations.
+        Public method (ADR-0026 Phase 3.5): the unified registry handlers in
+        ``src/reyn/tools/`` reach op_runtime through this factory (bound as
+        ``RouterCallerState.op_context_factory``), so the OpContext carries the
+        operator-declared PermissionDecl and the Workspace with
+        ``actor="chat_router"``. Without it, handlers would synthesize an empty
+        ``PermissionDecl()`` and op_runtime's permission gates would deny.
 
-        Uses the injected events log and permission resolver. The actor
-        ``"chat_router"`` is used for permission key lookups. PermissionDecl
-        is populated from the agent's effective permissions so that op_runtime
-        layer permission checks actually gate access.
+        #3607: the adapter used to assemble the OpContext itself from 16
+        injected materials, while ``Session`` assembled a DIFFERENT one (twelve
+        fields apart) from the same values held as its own attributes. This is
+        now the same supplier the Session uses, so the two cannot diverge.
         """
-        from reyn.runtime.router_op_context import build_router_op_context
-
-        # #3482: op_ctx is the RouterOpContextInputs bundle — this method is the
-        # SOLE reader of all 16 of its fields (the measured cluster the bundle
-        # was formed from). Local alias only for readability below.
-        op_ctx = self._op_ctx
-
-        # #1412: single-sourced via build_router_op_context (shared with
-        # Session). RouterHostAdapter wires intervention_bus inline (via the
-        # factory) + media/multimodal/compact (the registry-dispatch path serves
-        # web/media ops). agent_id is unset here (registry-dispatch lacks one) —
-        # a #1412 follow-up gap candidate, preserved behaviorally.
-        bus = (
-            self._intervention_bus_factory()
-            if self._intervention_bus_factory is not None
-            else None
-        )
-        presentation_renderer = (
-            op_ctx.presentation_renderer_factory()
-            if op_ctx.presentation_renderer_factory is not None
-            else None
-        )
-        return build_router_op_context(
-            events=self._events,
-            permission_resolver=self._perm,
-            file_permissions=self._get_file_permissions_for_router(),
-            mcp_servers=self._get_mcp_servers_for_router(),
-            mcp_servers_flat=self._mcp_servers_flat(),
-            allowed_mcp=op_ctx.allowed_mcp,
-            workspace_base_dir=op_ctx.workspace_base_dir,
-            workspace_state_dir=op_ctx.workspace_state_dir,
-            environment_backend=self._environment_backend,
-            sandbox_backend=op_ctx.sandbox_backend_instance,
-            sandbox_policy=op_ctx.sandbox_policy,
-            agent_id=None,
-            intervention_bus=bus,
-            presentation_renderer=presentation_renderer,
-            # FP-0054 PR-C: the adapter's CURRENT registry snapshot (hot-reload swaps it).
-            presentation_registry=self._presentation_registry,
-            multimodal_config=op_ctx.multimodal_config,
-            render_template_bounds=op_ctx.render_template_bounds,  # #2679: operator render_template output cap
-            media_store=self._media_store,
-            compact_now=op_ctx.compact_now,
-            cancel_event=self._cancel_event,
-            threat_scan=self._threat_scan,
-            contextual_permission=op_ctx.contextual_permission,  # #1827 S3
-            # #1953 dynamic-wire: the REAL chat-session id, threaded so
-            # emit_hook_event builds the LLM's own session-scoped namespace.
-            session_id=self._live_sid_in.session_id,
-            hook_dispatcher=op_ctx.hook_dispatcher,  # #1800 slice 5c
-            hook_bus=op_ctx.hook_bus,  # Hook-Event Redesign Phase 5 part 2: emit_hook_event's publish target
-            # proposal 0060 Phase 1 (A7): a live callback read (varies per turn, so
-            # a fixed init value would be stale — cf. live_session_id_fn).
-            # This is the router-dispatched install path (skill_install_*
-            # / pipeline / presentation_install_local → this factory), so it
-            # is the load-bearing wiring for A9's per-handler provenance stamp.
-            turn_origin=(
-                op_ctx.turn_origin_fn() if op_ctx.turn_origin_fn else None
-            ),
-            # #2761 PR-2: the per-session HotReloader so an install op (skill/pipeline)
-            # can apply a pure-addition reload IMMEDIATELY (mid-turn) → the new entry is
-            # resolvable this turn. This is the router-dispatched install path
-            # (skill_install_* / pipeline ops → build_legacy_op_context →
-            # this factory), so it is the load-bearing wiring for PR-2.
-            hot_reloader=op_ctx.hot_reloader,
-            # FP-0063 PC: the live router-dispatched `embed` tool resolves THIS
-            # factory, so this is the load-bearing wiring for embedding-cost
-            # recording (all three scopes fan out from the gateway).
-            budget_gateway=op_ctx.budget_gateway,
-            # #3196 co-vet round 2: the BASE registered-skill set, NOT
-            # `self._available_skills` (that field is the per-session
-            # VISIBILITY-FILTERED view, mutated in place by
-            # `CapabilityVisibility.reapply_skill_visibility` — a UX menu
-            # concern). The `file` op's skill-load provenance gate is a
-            # TRUST decision ("is this a config-registered skill body at
-            # all") and must not depend on whether the operator hid the
-            # skill from the menu — visibility must never gate trust.
-            available_skills=(
-                op_ctx.base_available_skills_fn()
-                if op_ctx.base_available_skills_fn is not None
-                else self._available_skills
-            ),
-        )
+        return self._op_ctx_source.build()
 
     def _set_cancel_event(self, event: asyncio.Event) -> None:
         """#1470: called by RouterLoopDriver at construction to register the
-        per-turn cancel event. make_router_op_context threads it into OpContext
-        so sandboxed_exec backends can observe cancel_inflight() mid-subprocess.
+        per-turn cancel event, which the op-context supplier threads into every
+        OpContext it builds so sandboxed_exec backends can observe
+        cancel_inflight() mid-subprocess. Registered on the SUPPLIER, not
+        copied here: ``_mcp_list_via_gateway`` needs the same event, and two
+        holders of one value is the drift shape #3607 removed.
         """
-        self._cancel_event = event
+        self._op_ctx_source.set_cancel_event(event)
 
     def make_intervention_bus(self) -> "Any | None":
         """Return the current intervention bus for safety-limit checkpoints.
@@ -2448,7 +2321,6 @@ class RouterHostAdapter:
 # ---------------------------------------------------------------------------
 
 ROUTER_HOST_ADAPTER_BUNDLE_TYPES: "tuple[str, ...]" = (
-    "RouterOpContextInputs",
     "McpGatewayInputs",
     "SendToAgentInputs",
     "PutOutboxInputs",

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -69,6 +69,7 @@ from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.outbox_hub import OutboxHub
 from reyn.runtime.pending_op_view import PendingOpView
 from reyn.runtime.presentation_consumer import OutboxPresentationConsumer
+from reyn.runtime.router_op_context import RouterOpContextSource
 from reyn.runtime.services import (
     BudgetGateway,
     ChainManager,
@@ -82,7 +83,6 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    RouterOpContextInputs,
     SendToAgentInputs,
     SnapshotJournal,
 )
@@ -3757,34 +3757,34 @@ class Session:
         reads every OTHER dependency as ``self._X`` / ``self.X`` directly,
         exactly as the inline construction did. ``contextual_permission`` is
         the one EXPLICIT param (#3121 step3 Extract Class): it is the RAW
-        constructor-supplied initial value (RouterHostAdapter freezes its own
-        copy at construction, same as the pre-extraction code — later toggles
-        via ``CapabilityVisibility`` do not retroactively update it, matching
-        byte-identical pre-#3121 behavior), threaded explicitly because
+        constructor-supplied initial value, threaded explicitly because
         ``CapabilityVisibility`` (which owns the LIVE composed value everywhere
         else) needs ``router_host`` — THIS call's output — so it cannot exist
-        yet when this builder runs. Defaults to ``None`` (= no narrowing) so a
+        yet when this builder runs. It is the FALLBACK the op-context
+        supplier's ``contextual_permission_fn`` uses until
+        ``CapabilityVisibility`` exists, after which the supplier reads the
+        live composed value (#3607 — the adapter used to freeze this raw value
+        for the whole session, so an operator's later narrowing never reached a
+        registry-dispatched op). Defaults to ``None`` (= no narrowing) so a
         bare ``_build_router_waist()`` (e.g. a builder-contract test) stays
         constructible; the sole production caller, ``__init__``, always passes
         the real constructor value.
 
-        ★ Two of the values threaded in are DEFERRED lambdas, NOT eager values
-        — ``live_session_id_inputs.live_session_id_fn`` /
-        ``op_context_inputs.turn_origin_fn`` (both #3482 bundle fields; being
-        inside a frozen dataclass changes nothing about when they resolve)
-        keep resolving ``self._session_id`` / ``self._current_turn_origin``
-        at CALL time, not here: ``_current_turn_origin`` already carries a
-        pre-turn DEFAULT at construction (``"auto_improvement"``, set at
-        :1083 — BEFORE this builder runs), but it is then REASSIGNED per turn
-        inside ``run_one_iteration`` (far after ``__init__`` returns) — an
-        eager-captured value here would freeze the pre-turn default forever,
-        never seeing a real turn's origin; ``live_session_id_fn``
-        is deferred because a spawned session's live session id can change
-        AFTER this constructor runs (the cached ``self._session_id`` read
-        here is stale for that case — see the inline comment above
-        ``record_spawned_task`` below). Eager-izing either would freeze a
-        per-turn value at construction time — the Family 3/5 deferred/eager
-        pitfall repeated here for a third and heavier family.
+        ★ Several of the values threaded in are DEFERRED, NOT eager — the
+        ``*_fn`` fields of ``RouterOpContextSource`` (#3607) and
+        ``live_session_id_inputs.live_session_id_fn`` (#3482) keep resolving
+        ``self._<attr>`` at CALL time, not here. ``_current_turn_origin``
+        already carries a pre-turn DEFAULT at construction
+        (``"auto_improvement"``, set at :1083 — BEFORE this builder runs), but
+        it is then REASSIGNED per turn inside ``run_one_iteration`` (far after
+        ``__init__`` returns) — an eager-captured value here would freeze the
+        pre-turn default forever, never seeing a real turn's origin;
+        ``live_session_id_fn`` is deferred because a spawned session's live
+        session id can change AFTER this constructor runs (the cached
+        ``self._session_id`` read here is stale for that case — see the inline
+        comment above ``record_spawned_task`` below). Eager-izing any of them
+        would freeze a per-turn value at construction time — the Family 3/5
+        deferred/eager pitfall repeated here for a third and heavier family.
         ``record_spawned_task`` (a bound method) and the two tracker lambdas
         (``send_to_agent_inputs.delegation_tracker`` /
         ``put_outbox_inputs.agent_replies_tracker``) are likewise kept
@@ -3805,36 +3805,82 @@ class Session:
             max_inline_bytes=self._offload_config.max_inline_bytes,
         )
 
-        # #3482: the 16-param op-context cluster (measured: sole reader is
-        # RouterHostAdapter.make_router_op_context) bundled into one frozen,
-        # default-free dataclass — pure output→input value object, same
-        # values/order as the flat kwargs this replaces (byte-identical).
-        _op_context_inputs = RouterOpContextInputs(
-            allowed_mcp=self._allowed_mcp,
-            base_available_skills_fn=lambda: self._available_skills,
-            budget_gateway=self._budget,
-            compact_now=self._compact_now_for_op,
-            contextual_permission=contextual_permission,  # #1827 S3 → control-IR OpContext (raw initial value, see docstring)
-            hook_bus=self._hook_bus,  # Hook-Event Redesign Phase 5 part 2: emit_hook_event's publish target
-            hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c (router path)
-            hot_reloader=self._hot_reloader,  # #2073 S3 → per-session reload route (tool ctx)
-            multimodal_config=self._multimodal_config,
-            # FP-0054 PR-B / #2708 P1: give the router OpContext a real PresentationRenderer
-            # so a `present` op reaches the surface's sink instead of PR-A's null surface.
-            # Built per make_router_op_context() call. The sink is obtained from the
-            # surface's declared PresentationConsumer (orphan-impossible:
-            # OutboxPresentationRenderer is constructible ONLY inside
-            # OutboxPresentationConsumer.sink) — bound to THIS Session via sink(self).
-            presentation_renderer_factory=lambda: self._presentation_consumer.sink(self),
-            render_template_bounds=self._render_template_bounds,
-            sandbox_backend_instance=self._sandbox_backend,
-            sandbox_policy=(
+        # #3607: the ONE chat-router op-context supplier for this Session.
+        # Both entry points that hand an OpContext to a chat-router op —
+        # ``Session._make_router_op_context`` (the _file_op / MCP callbacks)
+        # and ``RouterHostAdapter.make_router_op_context`` (the registry
+        # dispatch's ``op_context_factory``) — are one-line delegations to
+        # ``.build()`` on THIS object, so they cannot hand out different
+        # capabilities. Before, each assembled its own, and twelve fields had
+        # already diverged. Every ``*_fn`` here is read at build time: see the
+        # class docstring for why a snapshot of any of them is right on turn 1
+        # and wrong afterwards.
+        self._router_op_context_source = RouterOpContextSource(
+            events=self._chat_events,
+            permission_resolver=self._perm,
+            file_permissions_fn=self._get_file_permissions_for_router,
+            mcp_servers_fn=self._get_mcp_servers_for_router,
+            mcp_servers_flat_fn=self._mcp_servers_flat,
+            # #1827: live — ``_reapply_per_agent_capability`` REPLACES the
+            # allowlist mid-session, and a narrowing that only reached one of
+            # the two op-context doors is not a narrowing.
+            allowed_mcp_fn=lambda: self._allowed_mcp,
+            workspace_base_dir=self._workspace_base_dir,
+            workspace_state_dir=self._workspace_state_dir,
+            environment_backend=self._environment_backend,
+            sandbox_backend=self._sandbox_backend,
+            # #1339: live — ``_sandbox_config`` is the resolved operator policy
+            # and a reload can replace it.
+            sandbox_policy_fn=lambda: (
                 self._sandbox_config.policy if self._sandbox_config is not None
                 else None
             ),
+            # FP-0016: this agent's identity → the MCP client's X-Reyn-Agent-Id.
+            agent_id=self._agent.agent_id,
+            # FP-0022 fix (#53) / #3049: bridge-aware — resolved per call so an
+            # attached pipeline driver's op reaches the ORIGINATOR's operator.
+            intervention_bus_factory=self._make_router_intervention_bus,
+            # FP-0054 PR-B / #2708 P1: a real PresentationRenderer so a `present`
+            # op reaches the surface's sink instead of PR-A's null surface. The
+            # sink comes from the surface's declared PresentationConsumer
+            # (orphan-impossible: OutboxPresentationRenderer is constructible
+            # ONLY inside OutboxPresentationConsumer.sink) — bound to THIS
+            # Session via sink(self).
+            presentation_renderer_factory=lambda: self._presentation_consumer.sink(self),
+            # FP-0054 PR-C: live — ``_reapply_presentations`` swaps the registry
+            # so a newly-registered template is visible on the next op.
+            presentation_registry_fn=lambda: self._presentation_registry,
+            multimodal_config=self._multimodal_config,
+            media_store_fn=lambda: self._media_store,  # #383/#2409
+            compact_now=self._compact_now_for_op,  # #272/#1128
+            threat_scan=self._safety.threat_scan,  # FP-0050/#1822
+            # #1827 S3: live — ``CapabilityVisibility`` owns the composed value
+            # but needs ``router_host``, i.e. THIS builder's output, so it does
+            # not exist yet. Until it does, the constructor's raw value is the
+            # narrowing in force (byte-identical to the pre-#3607 adapter,
+            # which froze that value forever).
+            contextual_permission_fn=lambda: (
+                self._capability_visibility.contextual_permission
+                if getattr(self, "_capability_visibility", None) is not None
+                else contextual_permission
+            ),
+            # #1953: live — a spawned session's real id is assigned after this
+            # constructor runs, and ops must namespace under the real one.
+            session_id_fn=lambda: self._session_id,
+            hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c
+            hook_bus=self._hook_bus,  # Hook-Event Redesign Phase 5 part 2
+            # proposal 0060 Phase 1 (A7): live — ``_current_turn_origin`` carries
+            # a pre-turn default here and is REASSIGNED per turn in
+            # ``run_one_iteration``; an eager read would freeze the default.
             turn_origin_fn=lambda: self._current_turn_origin,
-            workspace_base_dir=self._workspace_base_dir,
-            workspace_state_dir=self._workspace_state_dir,
+            hot_reloader=self._hot_reloader,  # #2073 S3 / #2761 PR-2
+            render_template_bounds=self._render_template_bounds,  # #2679
+            budget_gateway=self._budget,  # FP-0063 PC
+            # #3196 co-vet round 2: the BASE registered set, deliberately NOT the
+            # visibility-filtered view — the `file` op's skill-load provenance
+            # gate is a TRUST decision and must not depend on whether the
+            # operator hid the skill from the menu.
+            available_skills_fn=lambda: self._available_skills,
         )
         # #3482/#3447: the 3-param mcp-gateway cluster (sole reader:
         # RouterHostAdapter._mcp_list_via_gateway) — a real consumer-set
@@ -3873,7 +3919,7 @@ class Session:
             turn_budget_engine=_chat_turn_budget_engine,
             # FP-0050 / #1822 S2: content-threat scan + fence config.
             threat_scan=self._safety.threat_scan,
-            op_context_inputs=_op_context_inputs,  # #3482
+            op_context_source=self._router_op_context_source,  # #3607
             state_log=self._state_log,  # #2259 PR-1 → config generation emit from config ops
             live_session_id_inputs=_live_session_id_inputs,  # #3482
             agent_name=self.agent_name,
@@ -3940,9 +3986,9 @@ class Session:
             ),
             # #187: the FS env-backend instance for the LIVE router OpContext
             # Workspace (the registry file-dispatch factory). Same source as
-            # the chat OpContext (#1410). (workspace_base_dir/workspace_state_dir/
-            # sandbox_backend_instance/sandbox_policy/multimodal_config/
-            # render_template_bounds now live in op_context_inputs, #3482.)
+            # the chat OpContext (#1410) — which now reads it off the shared
+            # op-context supplier; the adapter keeps its own reference because
+            # its container-repo helpers read it directly.
             environment_backend=self._environment_backend,
             # #1652: reasoning config (display/continuity/recent_turns gates) +
             # the bounded prior-reasoning section renderer (reads this session's
@@ -3968,7 +4014,6 @@ class Session:
             # threaded beside the flag through the same static-config seam.
             offload_structured_inline_max_chars=self._offload_config.structured_inline_max_chars,
             offload_structured_preview_chars=self._offload_config.structured_preview_chars,
-            # (``compact_now`` now lives in op_context_inputs, #3482.)
             # #272/#1128 context-size signal: live exact-token budget so the
             # router SP can show the LLM the free window (header).
             context_window_status=self.context_window_status,
@@ -3979,7 +4024,6 @@ class Session:
             # parent's operator; root/detached -> self-bound), single-sourced via
             # _make_router_intervention_bus. docs/concepts/runtime/intervention-delivery.md#the-single-construction-seam
             intervention_bus_factory=self._make_router_intervention_bus,
-            # (``presentation_renderer_factory`` now lives in op_context_inputs, #3482.)
             # FP-0037 S2: yaml mtime watch needs the project root to resolve
             # the 3 yaml scope tier paths. None falls back to user-global only.
             project_root=getattr(self._registry, "_project_root", None),
@@ -4751,8 +4795,13 @@ class Session:
             return False  # single-agent / no profile → nothing per-agent to reapply
         if prof.allowed_mcp == self._allowed_mcp:
             return False
+        # #3607: ONE holder. The router OpContext's ``allowed_mcp`` is read off
+        # this attribute at build time, so assigning it IS reapplying the gate.
+        # There used to be a second assignment here, onto the adapter — dead
+        # since #3482 moved the adapter's ``allowed_mcp`` into a FROZEN bundle:
+        # it created an attribute nothing read, so the narrowing reached the
+        # Session door and silently not the registry-dispatch one.
         self._allowed_mcp = prof.allowed_mcp
-        self._router_host._allowed_mcp = prof.allowed_mcp          # MCP gate (decl source)
         return True
 
     async def _reapply_new_agent(self, in_set: dict) -> bool:
@@ -7102,9 +7151,11 @@ class Session:
         return False, composed
 
     # ── RouterLoop helper methods (Wave 3 F1, kept for session callbacks) ──────────
-    # _make_router_op_context + 3 helpers remain on Session because the
-    # session's internal MCP/file callbacks (_mcp_list_tools, _mcp_call_tool,
-    # _file_op) use them. The adapter has its own private copies.
+    # These 3 resolvers remain on Session because the session's internal
+    # MCP/file callbacks (_mcp_list_tools, _mcp_call_tool, _file_op) use them,
+    # and because the op-context supplier reads them as bound methods (so the
+    # roster it advertises follows a mid-session mcp_install). The adapter has
+    # its own copies for the surfaces it serves directly.
 
     def _get_file_permissions_for_router(self) -> dict | None:
         """Return file permissions in the form {read: [paths], write: [paths]}
@@ -7154,65 +7205,16 @@ class Session:
         return result
 
     def _make_router_op_context(self) -> "OpContext":
-        """Build a minimal OpContext for router-initiated file/MCP ops.
+        """Ask this session's op-context supplier for a chat-router OpContext.
 
-        Uses the session's events log and permission resolver. The actor
-        "chat_router" is used for permission key lookups — it matches what the
-        PermissionResolver uses to gate paths. All .reyn/ paths are in the
-        default write zone so memory ops pass without additional approval.
-
-        PermissionDecl is populated from the agent's effective permissions
-        (file_read / file_write from config, mcp from configured servers) so
-        that op_runtime layer permission checks actually gate access rather than
-        silently allowing everything through an empty decl.
+        The internal MCP / file callbacks below (``_file_op``,
+        ``_mcp_call_tool`` and siblings) reach op_runtime through here. #3607:
+        this used to assemble its own OpContext — the same object
+        ``RouterHostAdapter.make_router_op_context`` assembled separately, and
+        the two had diverged on twelve fields, so an op's capabilities depended
+        on which door it came through. Both are now one call on one supplier.
         """
-        from reyn.runtime.router_op_context import build_router_op_context
-
-        # #1412: single-sourced via build_router_op_context (shared with
-        # RouterHostAdapter). Session wires intervention_bus POST-HOC on the
-        # returned ctx (the MCP-op caller), so it is None at construction here;
-        # media/multimodal/compact ops go via the registry / RouterHostAdapter
-        # path (None here) — behavior-preserving.
-        return build_router_op_context(
-            events=self._chat_events,
-            permission_resolver=self._perm,
-            file_permissions=self._get_file_permissions_for_router(),
-            mcp_servers=self._get_mcp_servers_for_router(),
-            mcp_servers_flat=self._mcp_servers_flat(),
-            allowed_mcp=self._allowed_mcp,
-            workspace_base_dir=self._workspace_base_dir,
-            workspace_state_dir=self._workspace_state_dir,
-            environment_backend=self._environment_backend,
-            sandbox_backend=self._sandbox_backend,
-            sandbox_policy=(
-                self._sandbox_config.policy
-                if getattr(self, "_sandbox_config", None) is not None
-                else None
-            ),
-            agent_id=self._agent.agent_id,
-            # #2708 P1: this builder serves file/MCP ops (_file_op / MCP), which no
-            # `present` op reaches — so the present sink is EXPLICITLY None (the required
-            # kwarg forces the decision, no silent omission). The visible present path is
-            # RouterHostAdapter.make_router_op_context, which wires the surface consumer's sink.
-            presentation_renderer=None,
-            # #2409: forward the media store (the public twin RouterHostAdapter.make_router_op_context
-            # already does — session.py:1826). Without it the chat-router MCP path got media_store=None
-            # → MCP ImageContent couldn't be saved as a path-ref → a large image was inlined as
-            # base64 to the LLM instead of a small path-ref (the clean-payload/offload gate needs the
-            # image out of the inline body).
-            media_store=self._media_store,
-            contextual_permission=self._capability_visibility.contextual_permission,  # #1827 S3 → control-IR OpContext
-            hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c: complete-by-construction (both router callers)
-            hook_bus=self._hook_bus,  # Hook-Event Redesign Phase 5 part 2: emit_hook_event's publish target (both router op-ctx builders complete-by-construction)
-            turn_origin=self._current_turn_origin,  # proposal 0060 Phase 1 (A7): OS-authoritative provenance source (enumerate ALL op-ctx builders)
-            hot_reloader=self._hot_reloader,  # #2761 PR-2: per-session reloader (both router op-ctx builders complete-by-construction)
-            render_template_bounds=self._render_template_bounds,  # #2679: operator bounds (both router op-ctx builders complete-by-construction)
-            budget_gateway=self._budget,  # FP-0063 PC: embedding-cost recording entry point (enumerate ALL op-ctx builders; the load-bearing one for `embed` is RouterHostAdapter's)
-            # #3196 co-vet round 2: pass the BASE registered set — deliberately NOT run through
-            # the visibility filter (that's RouterHostAdapter's own copy, a UX/menu concern).
-            # Filtering here would conflate a trust/provenance decision with a display decision.
-            available_skills=self._available_skills,
-        )
+        return self._router_op_context_source.build()
 
     def _make_router_intervention_bus(self):
         """The chat-router intervention bus for a router-initiated op, resolved

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -10,15 +10,61 @@ from pathlib import Path
 
 from reyn.core.events.events import EventLog
 from reyn.llm.model_resolver import ModelResolver
+from reyn.runtime.router_op_context import RouterOpContextSource
 from reyn.runtime.services import (
     LiveSessionIdInputs,
     McpGatewayInputs,
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    RouterOpContextInputs,
     SendToAgentInputs,
 )
+
+# Every RouterOpContextSource field, all inert. Deliberately spelled out
+# rather than defaulted on the class: the class stays default-free (a silent
+# omission there would absorb a wiring change unnoticed), so adding a field to
+# it makes make_op_context_source raise TypeError here — one loud edit instead
+# of a quiet None in every test.
+_INERT_OP_CONTEXT_SOURCE_FIELDS: dict = {
+    "events": None,
+    "permission_resolver": None,
+    "file_permissions_fn": None,
+    "mcp_servers_fn": None,
+    "mcp_servers_flat_fn": None,
+    "allowed_mcp_fn": None,
+    "workspace_base_dir": None,
+    "workspace_state_dir": None,
+    "environment_backend": None,
+    "sandbox_backend": None,
+    "sandbox_policy_fn": None,
+    "agent_id": None,
+    "intervention_bus_factory": None,
+    "presentation_renderer_factory": None,
+    "presentation_registry_fn": None,
+    "multimodal_config": None,
+    "media_store_fn": None,
+    "compact_now": None,
+    "threat_scan": None,
+    "contextual_permission_fn": None,
+    "session_id_fn": None,
+    "hook_dispatcher": None,
+    "hook_bus": None,
+    "turn_origin_fn": None,
+    "hot_reloader": None,
+    "render_template_bounds": None,
+    "budget_gateway": None,
+    "available_skills_fn": None,
+}
+
+
+def make_op_context_source(**overrides: object) -> RouterOpContextSource:
+    """A REAL RouterOpContextSource with everything inert but *overrides*.
+
+    The real class, not a stand-in: it is a plain object with no I/O, so a test
+    that needs one builds one."""
+    unknown = set(overrides) - set(_INERT_OP_CONTEXT_SOURCE_FIELDS)
+    assert not unknown, f"not RouterOpContextSource fields: {sorted(unknown)}"
+    return RouterOpContextSource(**{**_INERT_OP_CONTEXT_SOURCE_FIELDS, **overrides})
 
 
 async def null_file_read(path: str) -> dict:
@@ -71,6 +117,7 @@ def make_adapter(
     on_limit: object = None,  # #2175: OnLimitConfig for the spawn-limit checkpoint (None → no checkpoint = unattended reject)
     safety_extensions: "dict | None" = None,  # #2175: shared per-run extension dict
     intervention_answer: "str | None" = None,  # #2175: interactive-mode bus answer (choice_id, e.g. "yes")
+    intervention_bus_factory: "object | None" = None,  # FP-0022 (#53): op-ctx intervention bus
 ) -> RouterHostAdapter:
     """Construct a minimal RouterHostAdapter with real collaborators."""
     if events is None:
@@ -117,23 +164,13 @@ def make_adapter(
     _delegations = delegation_list
     _replies = agent_replies_list
 
-    op_context_inputs = RouterOpContextInputs(
-        allowed_mcp=None,
-        base_available_skills_fn=None,
-        budget_gateway=None,
-        compact_now=None,
-        contextual_permission=None,
-        hook_bus=None,
-        hook_dispatcher=None,
-        hot_reloader=None,
-        multimodal_config=None,
-        presentation_renderer_factory=None,
-        render_template_bounds=None,
-        sandbox_backend_instance=None,
-        sandbox_policy=None,
+    op_context_source = make_op_context_source(
+        events=events,
+        environment_backend=environment_backend,
         turn_origin_fn=turn_origin_fn,
         workspace_base_dir=workspace_base_dir,
-        workspace_state_dir=None,
+        session_id_fn=(lambda: session_id) if session_id is not None else None,
+        intervention_bus_factory=intervention_bus_factory,
     )
     mcp_gateway_inputs = McpGatewayInputs(
         mcp_connection_service=None,
@@ -157,7 +194,7 @@ def make_adapter(
         agent_name=agent_name,
         agent_role="test role",
         output_language="en",
-        op_context_inputs=op_context_inputs,
+        op_context_source=op_context_source,
         permission_resolver=None,
         mcp_servers=None,
         project_context="",

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -117,7 +117,6 @@ def make_adapter(
     on_limit: object = None,  # #2175: OnLimitConfig for the spawn-limit checkpoint (None → no checkpoint = unattended reject)
     safety_extensions: "dict | None" = None,  # #2175: shared per-run extension dict
     intervention_answer: "str | None" = None,  # #2175: interactive-mode bus answer (choice_id, e.g. "yes")
-    intervention_bus_factory: "object | None" = None,  # FP-0022 (#53): op-ctx intervention bus
 ) -> RouterHostAdapter:
     """Construct a minimal RouterHostAdapter with real collaborators."""
     if events is None:
@@ -170,7 +169,6 @@ def make_adapter(
         turn_origin_fn=turn_origin_fn,
         workspace_base_dir=workspace_base_dir,
         session_id_fn=(lambda: session_id) if session_id is not None else None,
-        intervention_bus_factory=intervention_bus_factory,
     )
     mcp_gateway_inputs = McpGatewayInputs(
         mcp_connection_service=None,

--- a/tests/test_2597_s2b_mcp_notifications_bridge.py
+++ b/tests/test_2597_s2b_mcp_notifications_bridge.py
@@ -26,31 +26,15 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    RouterOpContextInputs,
     SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
 # bundled into two frozen, default-free dataclasses. These module-level
 # constants are the "all fields unset" instances this file's tests reuse.
-_EMPTY_OP_CTX = RouterOpContextInputs(
-    allowed_mcp=None,
-    base_available_skills_fn=None,
-    budget_gateway=None,
-    compact_now=None,
-    contextual_permission=None,
-    hook_bus=None,
-    hook_dispatcher=None,
-    hot_reloader=None,
-    multimodal_config=None,
-    presentation_renderer_factory=None,
-    render_template_bounds=None,
-    sandbox_backend_instance=None,
-    sandbox_policy=None,
-    turn_origin_fn=None,
-    workspace_base_dir=None,
-    workspace_state_dir=None,
-)
+from tests._support.router_host_adapter import make_op_context_source  # noqa: E402
+
+_EMPTY_OP_CTX = make_op_context_source()
 _EMPTY_MCP_GATEWAY = McpGatewayInputs(
     mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
 )
@@ -115,7 +99,7 @@ def _make_adapter(*, tmp_path: Path, events: EventLog) -> RouterHostAdapter:
         agent_name="test-agent",
         agent_role="test",
         output_language="en",
-        op_context_inputs=_EMPTY_OP_CTX,
+        op_context_source=_EMPTY_OP_CTX,
         permission_resolver=None,
         mcp_servers={"srv": {}},
         project_context="",

--- a/tests/test_3520_unknown_probe_is_not_an_answer.py
+++ b/tests/test_3520_unknown_probe_is_not_an_answer.py
@@ -47,7 +47,6 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    RouterOpContextInputs,
     SendToAgentInputs,
 )
 from reyn.runtime.services.mcp_cache_file import cache_file_path, read_cache
@@ -57,24 +56,9 @@ _TOOL = "convert_to_markdown"
 _TOOLS = [{"name": _TOOL, "description": "convert a uri to markdown"}]
 _AGENTS = [{"name": "researcher", "role": "Research agent", "cluster": "default"}]
 
-_EMPTY_OP_CTX = RouterOpContextInputs(
-    allowed_mcp=None,
-    base_available_skills_fn=None,
-    budget_gateway=None,
-    compact_now=None,
-    contextual_permission=None,
-    hook_bus=None,
-    hook_dispatcher=None,
-    hot_reloader=None,
-    multimodal_config=None,
-    presentation_renderer_factory=None,
-    render_template_bounds=None,
-    sandbox_backend_instance=None,
-    sandbox_policy=None,
-    turn_origin_fn=None,
-    workspace_base_dir=None,
-    workspace_state_dir=None,
-)
+from tests._support.router_host_adapter import make_op_context_source  # noqa: E402
+
+_EMPTY_OP_CTX = make_op_context_source()
 _EMPTY_MCP_GATEWAY = McpGatewayInputs(
     mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
 )
@@ -152,7 +136,7 @@ def _make_adapter(*, tmp_path: Path, state_dir: Path, probe) -> RouterHostAdapte
         agent_name="test-agent",
         agent_role="test",
         output_language="en",
-        op_context_inputs=_EMPTY_OP_CTX,
+        op_context_source=_EMPTY_OP_CTX,
         permission_resolver=None,
         mcp_servers={_SERVER: {"description": "markitdown"}},
         project_context="",

--- a/tests/test_action_retrieval_wiring.py
+++ b/tests/test_action_retrieval_wiring.py
@@ -29,31 +29,15 @@ from reyn.runtime.services.router_host_adapter import (
     McpGatewayInputs,
     PutOutboxInputs,
     RouterHostAdapter,
-    RouterOpContextInputs,
     SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
 # bundled into two frozen, default-free dataclasses. These module-level
 # constants are the "all fields unset" instances this file's tests reuse.
-_EMPTY_OP_CTX = RouterOpContextInputs(
-    allowed_mcp=None,
-    base_available_skills_fn=None,
-    budget_gateway=None,
-    compact_now=None,
-    contextual_permission=None,
-    hook_bus=None,
-    hook_dispatcher=None,
-    hot_reloader=None,
-    multimodal_config=None,
-    presentation_renderer_factory=None,
-    render_template_bounds=None,
-    sandbox_backend_instance=None,
-    sandbox_policy=None,
-    turn_origin_fn=None,
-    workspace_base_dir=None,
-    workspace_state_dir=None,
-)
+from tests._support.router_host_adapter import make_op_context_source  # noqa: E402
+
+_EMPTY_OP_CTX = make_op_context_source()
 _EMPTY_MCP_GATEWAY = McpGatewayInputs(
     mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
 )
@@ -87,7 +71,7 @@ def _make_adapter(
         agent_name="test_agent",
         agent_role="test",
         output_language=None,
-        op_context_inputs=_EMPTY_OP_CTX,
+        op_context_source=_EMPTY_OP_CTX,
         permission_resolver=None,
         mcp_servers=None,
         project_context="",

--- a/tests/test_agui_reasoning_map_p6a.py
+++ b/tests/test_agui_reasoning_map_p6a.py
@@ -62,31 +62,15 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    RouterOpContextInputs,
     SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
 # bundled into two frozen, default-free dataclasses. These module-level
 # constants are the "all fields unset" instances this file's tests reuse.
-_EMPTY_OP_CTX = RouterOpContextInputs(
-    allowed_mcp=None,
-    base_available_skills_fn=None,
-    budget_gateway=None,
-    compact_now=None,
-    contextual_permission=None,
-    hook_bus=None,
-    hook_dispatcher=None,
-    hot_reloader=None,
-    multimodal_config=None,
-    presentation_renderer_factory=None,
-    render_template_bounds=None,
-    sandbox_backend_instance=None,
-    sandbox_policy=None,
-    turn_origin_fn=None,
-    workspace_base_dir=None,
-    workspace_state_dir=None,
-)
+from tests._support.router_host_adapter import make_op_context_source  # noqa: E402
+
+_EMPTY_OP_CTX = make_op_context_source()
 _EMPTY_MCP_GATEWAY = McpGatewayInputs(
     mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
 )
@@ -163,7 +147,7 @@ def _mk_host(reasoning_config, *, outbox: list, history: list) -> RouterHostAdap
     workspace = Path(".reyn") / "agents" / "t"
     return RouterHostAdapter(
         agent_name="t", agent_role="r", output_language="en",
-        op_context_inputs=_EMPTY_OP_CTX, permission_resolver=None,
+        op_context_source=_EMPTY_OP_CTX, permission_resolver=None,
         mcp_servers=None, project_context="", events=events,
         resolver=ModelResolver({}),
         memory=MemoryService(

--- a/tests/test_chat_router_modelspec_kwargs_1654.py
+++ b/tests/test_chat_router_modelspec_kwargs_1654.py
@@ -25,31 +25,15 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    RouterOpContextInputs,
     SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
 # bundled into two frozen, default-free dataclasses. These module-level
 # constants are the "all fields unset" instances this file's tests reuse.
-_EMPTY_OP_CTX = RouterOpContextInputs(
-    allowed_mcp=None,
-    base_available_skills_fn=None,
-    budget_gateway=None,
-    compact_now=None,
-    contextual_permission=None,
-    hook_bus=None,
-    hook_dispatcher=None,
-    hot_reloader=None,
-    multimodal_config=None,
-    presentation_renderer_factory=None,
-    render_template_bounds=None,
-    sandbox_backend_instance=None,
-    sandbox_policy=None,
-    turn_origin_fn=None,
-    workspace_base_dir=None,
-    workspace_state_dir=None,
-)
+from tests._support.router_host_adapter import make_op_context_source  # noqa: E402
+
+_EMPTY_OP_CTX = make_op_context_source()
 _EMPTY_MCP_GATEWAY = McpGatewayInputs(
     mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
 )
@@ -73,7 +57,7 @@ def _mk_host_with_kwargs():
     })
     return RouterHostAdapter(
         agent_name="t", agent_role="r", output_language="en",
-        op_context_inputs=_EMPTY_OP_CTX, permission_resolver=None,
+        op_context_source=_EMPTY_OP_CTX, permission_resolver=None,
         mcp_servers=None, project_context="", events=events, resolver=resolver,
         memory=MemoryService(agent_workspace_dir=workspace, events=events,
             file_write=_noop, file_read=_noop, file_delete=_noop, file_regenerate_index=_noop),

--- a/tests/test_mcp_cache_warm_start.py
+++ b/tests/test_mcp_cache_warm_start.py
@@ -30,31 +30,15 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    RouterOpContextInputs,
     SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
 # bundled into two frozen, default-free dataclasses. These module-level
 # constants are the "all fields unset" instances this file's tests reuse.
-_EMPTY_OP_CTX = RouterOpContextInputs(
-    allowed_mcp=None,
-    base_available_skills_fn=None,
-    budget_gateway=None,
-    compact_now=None,
-    contextual_permission=None,
-    hook_bus=None,
-    hook_dispatcher=None,
-    hot_reloader=None,
-    multimodal_config=None,
-    presentation_renderer_factory=None,
-    render_template_bounds=None,
-    sandbox_backend_instance=None,
-    sandbox_policy=None,
-    turn_origin_fn=None,
-    workspace_base_dir=None,
-    workspace_state_dir=None,
-)
+from tests._support.router_host_adapter import make_op_context_source  # noqa: E402
+
+_EMPTY_OP_CTX = make_op_context_source()
 _EMPTY_MCP_GATEWAY = McpGatewayInputs(
     mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
 )
@@ -149,7 +133,7 @@ def _make_adapter(
         agent_name="test-agent",
         agent_role="test",
         output_language="en",
-        op_context_inputs=_EMPTY_OP_CTX,
+        op_context_source=_EMPTY_OP_CTX,
         permission_resolver=None,
         mcp_servers=mcp_servers,
         project_context="",

--- a/tests/test_mcp_lazy_tools_cache.py
+++ b/tests/test_mcp_lazy_tools_cache.py
@@ -31,31 +31,15 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    RouterOpContextInputs,
     SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
 # bundled into two frozen, default-free dataclasses. These module-level
 # constants are the "all fields unset" instances this file's tests reuse.
-_EMPTY_OP_CTX = RouterOpContextInputs(
-    allowed_mcp=None,
-    base_available_skills_fn=None,
-    budget_gateway=None,
-    compact_now=None,
-    contextual_permission=None,
-    hook_bus=None,
-    hook_dispatcher=None,
-    hot_reloader=None,
-    multimodal_config=None,
-    presentation_renderer_factory=None,
-    render_template_bounds=None,
-    sandbox_backend_instance=None,
-    sandbox_policy=None,
-    turn_origin_fn=None,
-    workspace_base_dir=None,
-    workspace_state_dir=None,
-)
+from tests._support.router_host_adapter import make_op_context_source  # noqa: E402
+
+_EMPTY_OP_CTX = make_op_context_source()
 _EMPTY_MCP_GATEWAY = McpGatewayInputs(
     mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
 )
@@ -121,7 +105,7 @@ def _make_adapter_with_mcp(
         agent_name="test-agent",
         agent_role="test",
         output_language="en",
-        op_context_inputs=_EMPTY_OP_CTX,
+        op_context_source=_EMPTY_OP_CTX,
         permission_resolver=None,
         mcp_servers=mcp_servers,
         project_context="",

--- a/tests/test_mcp_yaml_mtime_watch.py
+++ b/tests/test_mcp_yaml_mtime_watch.py
@@ -30,31 +30,15 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    RouterOpContextInputs,
     SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
 # bundled into two frozen, default-free dataclasses. These module-level
 # constants are the "all fields unset" instances this file's tests reuse.
-_EMPTY_OP_CTX = RouterOpContextInputs(
-    allowed_mcp=None,
-    base_available_skills_fn=None,
-    budget_gateway=None,
-    compact_now=None,
-    contextual_permission=None,
-    hook_bus=None,
-    hook_dispatcher=None,
-    hot_reloader=None,
-    multimodal_config=None,
-    presentation_renderer_factory=None,
-    render_template_bounds=None,
-    sandbox_backend_instance=None,
-    sandbox_policy=None,
-    turn_origin_fn=None,
-    workspace_base_dir=None,
-    workspace_state_dir=None,
-)
+from tests._support.router_host_adapter import make_op_context_source  # noqa: E402
+
+_EMPTY_OP_CTX = make_op_context_source()
 _EMPTY_MCP_GATEWAY = McpGatewayInputs(
     mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
 )
@@ -161,7 +145,7 @@ def _make_adapter(
         agent_name="test-agent",
         agent_role="test",
         output_language="en",
-        op_context_inputs=_EMPTY_OP_CTX,
+        op_context_source=_EMPTY_OP_CTX,
         permission_resolver=None,
         mcp_servers=mcp_servers,
         project_context="",
@@ -591,7 +575,7 @@ async def test_session_handle_user_message_calls_yaml_watch_before_reload(
         agent_name="order-test",
         agent_role="test",
         output_language="en",
-        op_context_inputs=_EMPTY_OP_CTX,
+        op_context_source=_EMPTY_OP_CTX,
         permission_resolver=None,
         mcp_servers=None,
         project_context="",

--- a/tests/test_reasoning_integration_1652.py
+++ b/tests/test_reasoning_integration_1652.py
@@ -29,31 +29,15 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    RouterOpContextInputs,
     SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
 # bundled into two frozen, default-free dataclasses. These module-level
 # constants are the "all fields unset" instances this file's tests reuse.
-_EMPTY_OP_CTX = RouterOpContextInputs(
-    allowed_mcp=None,
-    base_available_skills_fn=None,
-    budget_gateway=None,
-    compact_now=None,
-    contextual_permission=None,
-    hook_bus=None,
-    hook_dispatcher=None,
-    hot_reloader=None,
-    multimodal_config=None,
-    presentation_renderer_factory=None,
-    render_template_bounds=None,
-    sandbox_backend_instance=None,
-    sandbox_policy=None,
-    turn_origin_fn=None,
-    workspace_base_dir=None,
-    workspace_state_dir=None,
-)
+from tests._support.router_host_adapter import make_op_context_source  # noqa: E402
+
+_EMPTY_OP_CTX = make_op_context_source()
 _EMPTY_MCP_GATEWAY = McpGatewayInputs(
     mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
 )
@@ -73,7 +57,7 @@ def _mk_host(reasoning_config, *, outbox: list, history: list, section: str = ""
     workspace = Path(".reyn") / "agents" / "t"
     return RouterHostAdapter(
         agent_name="t", agent_role="r", output_language="en",
-        op_context_inputs=_EMPTY_OP_CTX, permission_resolver=None,
+        op_context_source=_EMPTY_OP_CTX, permission_resolver=None,
         mcp_servers=None, project_context="", events=events,
         resolver=ModelResolver({}),
         memory=MemoryService(

--- a/tests/test_router_host_adapter_invariants.py
+++ b/tests/test_router_host_adapter_invariants.py
@@ -20,37 +20,19 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    RouterOpContextInputs,
     SendToAgentInputs,
 )
 
 # ---------------------------------------------------------------------------
 # Minimal stubs and helpers
 # ---------------------------------------------------------------------------
+# #3607/#3482: the adapter takes the session's op-context SUPPLIER plus the
+# mcp-gateway bundle. These module-level constants are the inert instances the
+# tests below reuse — the real classes, kept default-free, with the defaulting
+# in caller code (see McpGatewayInputs / RouterOpContextSource docstrings).
+from tests._support.router_host_adapter import make_op_context_source  # noqa: E402
 
-# #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
-# bundled into two frozen, default-free dataclasses. These module-level
-# constants are the "all fields unset" instances the tests below reuse —
-# the bundle classes themselves stay default-free (see RouterOpContextInputs
-# / McpGatewayInputs docstrings), the defaulting lives here in caller code.
-_EMPTY_OP_CTX = RouterOpContextInputs(
-    allowed_mcp=None,
-    base_available_skills_fn=None,
-    budget_gateway=None,
-    compact_now=None,
-    contextual_permission=None,
-    hook_bus=None,
-    hook_dispatcher=None,
-    hot_reloader=None,
-    multimodal_config=None,
-    presentation_renderer_factory=None,
-    render_template_bounds=None,
-    sandbox_backend_instance=None,
-    sandbox_policy=None,
-    turn_origin_fn=None,
-    workspace_base_dir=None,
-    workspace_state_dir=None,
-)
+_EMPTY_OP_CTX = make_op_context_source()
 _EMPTY_MCP_GATEWAY = McpGatewayInputs(
     mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
 )
@@ -204,7 +186,7 @@ def test_delegation_tracker_appended_on_send_to_agent(tmp_path):
         agent_name="alpha",
         agent_role="role",
         output_language=None,
-        op_context_inputs=_EMPTY_OP_CTX,
+        op_context_source=_EMPTY_OP_CTX,
         permission_resolver=None,
         mcp_servers=None,
         project_context="",
@@ -283,7 +265,7 @@ def test_adapter_exposes_permission_resolver_property(tmp_path):
         agent_name="alpha2",
         agent_role="role",
         output_language=None,
-        op_context_inputs=_EMPTY_OP_CTX,
+        op_context_source=_EMPTY_OP_CTX,
         permission_resolver=sentinel,
         mcp_servers=None,
         project_context="",
@@ -342,7 +324,9 @@ def test_make_router_op_context_wires_intervention_bus(tmp_path):
         agent_name="bus-test",
         agent_role="role",
         output_language=None,
-        op_context_inputs=_EMPTY_OP_CTX,
+        op_context_source=make_op_context_source(
+            intervention_bus_factory=lambda: sentinel_bus,
+        ),
         permission_resolver=None,
         mcp_servers=None,
         project_context="",
@@ -400,7 +384,7 @@ def test_make_router_op_context_no_factory_leaves_bus_none(tmp_path):
         agent_name="nobus-test",
         agent_role="role",
         output_language=None,
-        op_context_inputs=_EMPTY_OP_CTX,
+        op_context_source=_EMPTY_OP_CTX,
         permission_resolver=None,
         mcp_servers=None,
         project_context="",

--- a/tests/test_router_op_context_single_source_1412.py
+++ b/tests/test_router_op_context_single_source_1412.py
@@ -1,11 +1,12 @@
-"""Tier 2: #1412 — the chat-router OpContext is built from a single source.
+"""Tier 2: #1412/#3607 — the chat-router OpContext has ONE construction site.
 
 ``Session._make_router_op_context`` and
 ``RouterHostAdapter.make_router_op_context`` built the
 ``actor="chat_router"`` OpContext with ~95% identical code and drifted
 (#1410/#1411 threaded base_dir to one, lagged the other — the #187 wrong-FS
-class). The fix routes both through ``build_router_op_context``
-(reyn/runtime/router_op_context.py).
+class). #1412 routed both through ``build_router_op_context``; #3607 removed
+the second CALL of it, because sharing an assembly function still leaves two
+argument lists to diverge — and twelve fields had.
 
 Pinned invariants (src-wide AST, the #1402 sole-construction pattern):
 
@@ -13,8 +14,10 @@ Pinned invariants (src-wide AST, the #1402 sole-construction pattern):
   ``router_op_context.py`` anywhere in ``src/reyn``. A second chat-router
   OpContext construction re-opens the drift class → this fails, naming
   file:line (incl. hidden sites).
-- Both hosts delegate to ``build_router_op_context`` (positive guard — the
-  chokepoint is used, not bypassed).
+- ``build_router_op_context`` is CALLED exactly once in all of ``src/reyn``,
+  and that one call is inside ``router_op_context.py`` itself (the supplier's
+  ``build``). A surface that re-assembles its own argument list — the #1412
+  drift class one level up — fails this, naming the file.
 
 Cf. [[feedback_multi_callsite_wiring_audit]] / #1402 src-wide invariant.
 """
@@ -49,15 +52,20 @@ def _chat_router_opcontext_sites() -> list[str]:
     return sites
 
 
-def _calls_named(rel: str, name: str) -> int:
-    tree = ast.parse((_SRC / rel).read_text(encoding="utf-8"))
-    return sum(
-        1
-        for n in ast.walk(tree)
-        if isinstance(n, ast.Call)
-        and isinstance(n.func, ast.Name)
-        and n.func.id == name
-    )
+def _call_sites_of(name: str) -> list[str]:
+    """Every ``name(...)`` call site under src/reyn, as ``rel:lineno``."""
+    sites: list[str] = []
+    for py in sorted(_SRC.rglob("*.py")):
+        rel = str(py.relative_to(_SRC))
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for n in ast.walk(tree):
+            if (
+                isinstance(n, ast.Call)
+                and isinstance(n.func, ast.Name)
+                and n.func.id == name
+            ):
+                sites.append(f"{rel}:{n.lineno}")
+    return sites
 
 
 def test_chat_router_opcontext_built_only_in_factory() -> None:
@@ -75,10 +83,26 @@ def test_chat_router_opcontext_built_only_in_factory() -> None:
     )
 
 
-def test_both_hosts_delegate_to_build_router_op_context() -> None:
-    """Tier 2: #1412 — Session and RouterHostAdapter both call
-    build_router_op_context (positive guard: the chokepoint is used)."""
-    for rel in ("runtime/session.py", "runtime/services/router_host_adapter.py"):
-        assert _calls_named(rel, "build_router_op_context") >= 1, (
-            f"{rel} must delegate to build_router_op_context (#1412 single-source)"
-        )
+def test_build_router_op_context_has_exactly_one_call_site() -> None:
+    """Tier 2: #3607 — the chokepoint is used AND used once.
+
+    The positive half (a call exists) keeps the factory from being bypassed;
+    the singular half is what #1412 could not assert, and is the whole point of
+    #3607: two surfaces calling one assembly function still write two argument
+    lists, and those had diverged on twelve fields. Falsifiable in both
+    directions — delete the call and this names the absence; add a second
+    anywhere under src/reyn and this names the file:line."""
+    sites = _call_sites_of("build_router_op_context")
+    assert sites, (
+        "build_router_op_context is called nowhere — the chokepoint is bypassed"
+    )
+    outside = [s for s in sites if not s.startswith(_FACTORY_REL + ":")]
+    assert not outside, (
+        "build_router_op_context called outside "
+        f"{_FACTORY_REL} — a second caller writes a second argument list, which "
+        f"is the #1412 drift class: {outside}"
+    )
+    assert not sites[1:], (
+        "build_router_op_context has more than one call site "
+        f"(RouterOpContextSource.build is the only one): {sites}"
+    )

--- a/tests/test_router_op_context_source_3607.py
+++ b/tests/test_router_op_context_source_3607.py
@@ -1,0 +1,198 @@
+"""Tier 2: #3607 — the two chat-router op-context doors hand out the same thing.
+
+A chat-router op can reach op_runtime through either of two entry points:
+
+* ``Session._make_router_op_context`` — the session's own ``_file_op`` /
+  ``_mcp_call_tool`` callbacks, and
+* ``RouterHostAdapter.make_router_op_context`` — bound as
+  ``RouterCallerState.op_context_factory``, i.e. the registry dispatch every
+  LLM-emitted tool call goes through.
+
+They used to assemble an OpContext each, from the same materials held twice
+(``Session``'s attributes, and a 16-field copy of them injected into the
+adapter). Which capabilities an op got therefore depended on which door it came
+through, and twelve fields had already diverged. Both are now one call on one
+``RouterOpContextSource``.
+
+What is asserted here is the DEFECT, not the refactor: "the adapter takes one
+parameter now" would be true of any parameter object. These arms compare what
+the two doors PRODUCE, and check that a value which changes after the Session
+is constructed is seen through both — a snapshot taken at construction time is
+right on the first turn and wrong on every turn after it, which is the failure
+mode a one-shot equality check cannot see.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import fields, is_dataclass
+from pathlib import Path
+
+from reyn.core.op_runtime.context import OpContext
+from tests._support.agent_session import make_session
+
+
+def _fingerprint(value: object) -> object:
+    """A comparable summary of an OpContext field.
+
+    Identity is the wrong comparison for several fields: the intervention bus
+    and the presentation renderer are BUILT per call, so two calls of the same
+    door already return different objects. So: values compare by value,
+    dataclasses recurse (a permission decl differing in one axis must show),
+    and anything else compares by type — enough to catch "one door wires a
+    renderer and the other wires None", which is the class of divergence #3607
+    removed."""
+    if value is None or isinstance(value, (str, int, float, bool, Path)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_fingerprint(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _fingerprint(v) for k, v in sorted(value.items(), key=lambda kv: str(kv[0]))}
+    if is_dataclass(value) and not isinstance(value, type):
+        return (
+            type(value).__name__,
+            {f.name: _fingerprint(getattr(value, f.name)) for f in fields(value)},
+        )
+    return type(value).__name__
+
+
+def _shape(ctx: OpContext) -> dict:
+    """Fingerprint EVERY declared OpContext field.
+
+    Derived from the dataclass, not from a hand-listed set, so a field added to
+    OpContext tomorrow is compared across both doors without editing this
+    test — the way the twelve divergences accumulated was that nobody
+    re-enumerated."""
+    return {f.name: _fingerprint(getattr(ctx, f.name)) for f in fields(ctx)}
+
+
+def _both_doors(session) -> tuple[dict, dict]:
+    return (
+        _shape(session._make_router_op_context()),
+        _shape(session._router_host.make_router_op_context()),
+    )
+
+
+def _differing(a: dict, b: dict) -> list[str]:
+    return sorted(k for k in a if a[k] != b[k])
+
+
+def test_the_two_doors_build_the_same_op_context(tmp_path) -> None:
+    """Tier 2: #3607 — every OpContext field is equal across both entry points.
+
+    Before this landed, `agent_id`, `session_id`, `presentation_renderer`,
+    `intervention_bus`, `presentation_registry`, `multimodal_config`,
+    `compact_now`, `cancel_event` and `threat_scan` each reached one door and
+    not the other, and `allowed_mcp` / `contextual_permission` /
+    `sandbox_policy` were live on one door and frozen on the other."""
+    session = make_session(agent_name="doors", workspace_state_dir=tmp_path)
+
+    session_door, adapter_door = _both_doors(session)
+
+    assert not _differing(session_door, adapter_door), (
+        "the two chat-router op-context doors produced different OpContexts on "
+        f"these fields: {_differing(session_door, adapter_door)} — an op's "
+        "capabilities must not depend on which door it came through (#3607)"
+    )
+
+
+def test_the_comparison_can_tell_two_op_contexts_apart(tmp_path) -> None:
+    """Tier 2: #3607 vacuity guard — the field comparison discriminates.
+
+    The equality arm above is only as strong as `_fingerprint`. If it collapsed
+    everything to a type name it would report agreement between two genuinely
+    different contexts. Here the same door is asked twice across a real change,
+    and the difference must show."""
+    session = make_session(agent_name="discriminate", workspace_state_dir=tmp_path)
+
+    before = _shape(session._make_router_op_context())
+    session._allowed_mcp = ["only-this-server"]
+    after = _shape(session._make_router_op_context())
+
+    assert "permission_decl" in _differing(before, after), (
+        "changing the MCP allowlist did not change the fingerprint — the "
+        "comparison used by the equality arm cannot see field differences"
+    )
+
+
+def test_a_mid_session_mcp_narrowing_reaches_both_doors(tmp_path, monkeypatch) -> None:
+    """Tier 2: #3607 — the per-agent MCP narrowing is not snapshotted.
+
+    ``_reapply_per_agent_capability`` (the #2073 hot-reload seam) replaces the
+    allowlist mid-session. Driven through that real seam with a real
+    ``profile.yaml``: both doors must advertise the narrowed list afterwards.
+    This is the stale-snapshot arm — a value captured when the Session was
+    built passes a one-shot equality check and fails here."""
+    project = tmp_path / "proj"
+    agent_dir = project / ".reyn" / "agents" / "narrowed"
+    agent_dir.mkdir(parents=True)
+    # ``_hot_reload_project_root`` falls back to cwd when no registry root is
+    # wired — that is the root the real seam re-reads profile.yaml from.
+    monkeypatch.chdir(project)
+    session = make_session(
+        agent_name="narrowed",
+        workspace_base_dir=project,
+        workspace_state_dir=tmp_path / "state",
+    )
+
+    before_session, before_adapter = _both_doors(session)
+    assert before_session["permission_decl"] == before_adapter["permission_decl"]
+
+    (agent_dir / "profile.yaml").write_text("allowed_mcp:\n  - only-this-server\n")
+    changed = asyncio.run(session._reapply_per_agent_capability({}))
+    assert changed, "the hot-reload seam did not apply the profile's allowed_mcp"
+
+    for door_name, ctx in (
+        ("Session._make_router_op_context", session._make_router_op_context()),
+        ("RouterHostAdapter.make_router_op_context",
+         session._router_host.make_router_op_context()),
+    ):
+        assert ctx.permission_decl.allowed_mcp == ["only-this-server"], (
+            f"{door_name} still advertises the pre-narrowing MCP allowlist "
+            f"({ctx.permission_decl.allowed_mcp}) — a narrowing that reaches "
+            "only one door is not a narrowing (#3607)"
+        )
+
+
+def test_the_turn_origin_of_the_current_turn_reaches_both_doors(tmp_path) -> None:
+    """Tier 2: #3607 — turn provenance is read per build, not per session.
+
+    ``_stamp_execution_context`` (proposal 0060 A7) reclassifies the turn on
+    every turn, long after the Session is constructed. Both doors must report
+    the CURRENT classification; the install-op provenance stamp (A9) is what
+    reads it."""
+    from reyn.runtime.turn_origin import TurnOrigin
+
+    session = make_session(agent_name="origin", workspace_state_dir=tmp_path)
+
+    session._stamp_execution_context(TurnOrigin.CLIENT_INPUT, {})
+    for door in (session._make_router_op_context,
+                 session._router_host.make_router_op_context):
+        assert door().turn_origin == "user_directed"
+
+    session._stamp_execution_context("pipeline_step", {})
+    for door in (session._make_router_op_context,
+                 session._router_host.make_router_op_context):
+        assert door().turn_origin == "auto_improvement", (
+            "a door still reports the previous turn's provenance — the value "
+            "was snapshotted instead of supplied (#3607)"
+        )
+
+
+def test_the_agent_identity_reaches_the_registry_dispatch_door(tmp_path) -> None:
+    """Tier 2: #3607 — the registry-dispatch door carries the agent identity.
+
+    ``agent_id`` is the FP-0016 identity the MCP client sends as
+    ``X-Reyn-Agent-Id``. It was ``None`` on this door and the real value on the
+    Session door — #1412 flagged the asymmetry as a gap candidate and preserved
+    it behaviorally, and the adapter had the value all along (it passes the
+    same one to its own ``mcp_list_*`` gateway). Drift, not a decision: the two
+    doors now agree."""
+    session = make_session(agent_name="identity", workspace_state_dir=tmp_path)
+
+    adapter_ctx = session._router_host.make_router_op_context()
+    session_ctx = session._make_router_op_context()
+    assert adapter_ctx.agent_id, (
+        "the registry-dispatch door builds an OpContext with no agent identity "
+        "— MCP calls made through it would send no X-Reyn-Agent-Id (#3607)"
+    )
+    assert adapter_ctx.agent_id == session_ctx.agent_id


### PR DESCRIPTION
**[per-PR-coder]** — the `op_context_inputs` half of #3607.

Enumerated `part of #3607`: only #3608, merged. This completes the issue, so it carries the closing keyword at the bottom.

## The defect, measured — and it is bigger than the brief said

`RouterHostAdapter` was handed 16 materials and **assembled its own chat-router OpContext** from them; `Session._make_router_op_context` assembled a **second** one from the same values held as its own attributes. Two argument lists for one object.

★ **The brief (and architect's firm) said the adapter "adds nothing to the 16" and is a pure relay. That is true of the 16 and false of the method.** `make_router_op_context` also read `_events`, `_perm`, `_environment_backend`, `_media_store`, `_threat_scan`, `_presentation_registry`, `_available_skills`, `_cancel_event`, `_intervention_bus_factory`, `_live_sid_in.session_id` and three of its own resolver helpers — thirteen more materials the Session-side builder did **not** all pass. So "hand the adapter `Session._make_router_op_context`" would have silently dropped them. The supplier has to own the **union**, which is what landed.

**Twelve fields had diverged** (each verified by reading both call sites on `625f9b3b`):

| field | Session door | adapter door |
| --- | --- | --- |
| `agent_id` | the real agent id | **`None`** |
| `presentation_renderer` | `None` | the surface's sink |
| `intervention_bus` | `None` (wired post-hoc) | built inline |
| `presentation_registry` / `multimodal_config` / `compact_now` / `cancel_event` / `threat_scan` | absent (defaults) | wired |
| `session_id` | absent | the **construction-time** sid, not the live one |
| `allowed_mcp` | live read | **frozen at construction** |
| `contextual_permission` | live read | **frozen at construction** |
| `sandbox_policy` | live read | **frozen at construction** |

## What landed

`RouterOpContextSource` (`src/reyn/runtime/router_op_context.py`) — one per Session, built in `_build_router_waist`, handed to the adapter as `op_context_source`, and kept by Session as `self._router_op_context_source`. `Session._make_router_op_context` and `RouterHostAdapter.make_router_op_context` are both `return <source>.build()`. `build_router_op_context` now has **exactly one call site**, inside the supplier.

**Liveness is the design, not a detail.** These fields are zero-arg suppliers resolved at `build()` time: `file_permissions_fn` / `mcp_servers_fn` / `mcp_servers_flat_fn` (bound Session methods, so a mid-session `mcp_install` roster re-read is visible), `sandbox_policy_fn`, `intervention_bus_factory` (bridge-aware per call, #3049), `presentation_renderer_factory`, `presentation_registry_fn`, `contextual_permission_fn`, `session_id_fn`, `turn_origin_fn`, `available_skills_fn`, `allowed_mcp_fn`, `media_store_fn`. `cancel_event` is the one post-construction slot: `RouterLoopDriver` → `adapter._set_cancel_event` → `source.set_cancel_event`, and `_mcp_list_via_gateway` reads it off the supplier rather than keeping a second copy. `hot_reloader` likewise became a property delegating to the supplier — it has a second consumer (`RouterLoop` threads it onto the tool ctx), so it needed a holder, not a copy.

`contextual_permission_fn` falls back to the constructor's raw value until `CapabilityVisibility` exists — that object needs `router_host`, i.e. this builder's output, so it cannot exist when the supplier is built. That fallback is the pre-#3607 adapter behaviour; everything after it is the live composed value.

## ★ The `agent_id` asymmetry: **drift, not a decision** — and one more like it

#1412 recorded it as *"agent_id is unset here (registry-dispatch lacks one) — a follow-up gap candidate, preserved behaviorally"*. **"Registry-dispatch lacks one" is false**: the adapter is handed the same id as `McpGatewayInputs.mcp_agent_id` and already passes it to its own `mcp_list_*` gateway. It had the value and did not thread it. `OpContext.agent_id`'s only consumers are five `MCPGateway(...)` constructions → `MCPClient` → the `X-Reyn-Agent-Id` header (FP-0016 Component E). So the effect of closing it is that MCP calls dispatched through the registry now carry the same identity header the Session-side MCP path and `mcp_list_tools` already sent. Closed, not encoded in the equivalence test — and the reasoning is in `RouterOpContextSource`'s docstring and `build_router_op_context`'s `agent_id` comment where a reader finds it.

★ **A second, unrecorded one found while measuring:** `_reapply_per_agent_capability` wrote `self._router_host._allowed_mcp = prof.allowed_mcp` with the comment `# MCP gate (decl source)`. **Nothing has read `_allowed_mcp` on the adapter since #3482** moved it into a frozen bundle — the write created an attribute with no reader, so the per-agent MCP narrowing reached the Session door and silently not the registry-dispatch one. `grep -rn "_allowed_mcp" src/` before this PR: 5 hits, none of them a read of the adapter's. The dead write is deleted and the narrowing now reaches both doors by construction; `test_a_mid_session_mcp_narrowing_reaches_both_doors` is the witness.

## The witness — the defect, not the refactor

`tests/test_router_op_context_source_3607.py` (5 arms). "The adapter has one param now" would be true of any Parameter Object, so nothing asserts that:

- **`test_the_two_doors_build_the_same_op_context`** — fingerprints **every** field of `OpContext`, enumerated from `dataclasses.fields`, not a hand-listed set (a field added tomorrow is compared without editing the test; not re-enumerating is exactly how twelve divergences accumulated). Values compare by value, dataclasses recurse, everything else by type — because `intervention_bus` / `presentation_renderer` are *built per call*, so identity is the wrong comparison even between two calls of the same door.
- **`test_the_comparison_can_tell_two_op_contexts_apart`** — vacuity guard: the equality arm is only as strong as the fingerprint, so a real change must show through it.
- **`test_a_mid_session_mcp_narrowing_reaches_both_doors`** — the stale-snapshot arm, driven through the real `_reapply_per_agent_capability` hot-reload seam with a real `profile.yaml`.
- **`test_the_turn_origin_of_the_current_turn_reaches_both_doors`** — drives the real `_stamp_execution_context` twice and requires the *second* classification.
- **`test_the_agent_identity_reaches_the_registry_dispatch_door`** — the drift above.

`test_router_op_context_single_source_1412.py`'s positive guard is replaced by the strictly stronger one #1412 could not state: `build_router_op_context` has **one** call site, and it is in the factory module. Real objects throughout (`make_session`); no mocks; `tests/_support/router_host_adapter.py` grows `make_op_context_source(**overrides)`, which builds the **real** class with every field spelled out — so adding a field raises `TypeError` there instead of defaulting quietly in ten test files.

## Strip-falsify (cp-backup restore, never `git checkout --`; every anchor `grep -c`-confirmed before editing)

| # | strip | anchor count | result |
| --- | --- | --- | --- |
| A | `allowed_mcp_fn=lambda: self._allowed_mcp` → a construction-time snapshot | **1** | **RED x2** — `test_a_mid_session_mcp_narrowing_reaches_both_doors`, `test_the_comparison_can_tell_two_op_contexts_apart`. Restored → 5 passed |
| B | `turn_origin_fn=lambda: self._current_turn_origin` → snapshot | **1** | **RED x1** — `test_the_turn_origin_of_the_current_turn_reaches_both_doors`. Restored → 5 passed |
| C | `agent_id=self._agent.agent_id` → `None` (re-open the #1412 gap) | **1** (the 2-line anchor with its comment; the bare expression appears 3x in the file) | **RED x1** — `test_the_agent_identity_reaches_the_registry_dispatch_door`. ★ The equality arm stayed **GREEN** — both doors are `None` — which is precisely why the identity arm exists and why "the two agree" is not sufficient on its own. Restored → 5 passed |
| D | give `Session._make_router_op_context` its own `build_router_op_context(...)` call again, pre-#3607 shape | **1** | **RED x3** — `test_the_two_doors_build_the_same_op_context`, `test_the_turn_origin_...`, and `test_build_router_op_context_has_exactly_one_call_site`. Restored → 7 passed |

No `STRIP` residue in `src/` or `tests/` (grep: 1 pre-existing prose hit in `llm/llm.py`, plus unrelated `STRIPE_KEY` / `GUARD_STRIPPED` matches).

## Behaviour deltas — all named

Unifying two divergent builders forces one value to win per field. In every case the **more**-wired / **more**-live door won, so each delta grants a capability that was already granted through the other door:

1. **Registry-dispatched MCP calls now send `X-Reyn-Agent-Id`** (the `agent_id` drift above). The only consumer of `OpContext.agent_id`.
2. **The per-agent MCP narrowing now reaches the registry-dispatch door** (the dead write above). Security-relevant in the *narrowing* direction.
3. **`contextual_permission` and `sandbox_policy` are live on the registry-dispatch door.** Both were frozen at construction there; an operator narrowing or a policy reload now applies from the next op instead of never.
4. **`session_id` on the registry-dispatch door is the live id**, not the construction-time one — the value `live_session_id` already preferred for every other consumer (a spawned session's id changes after `__init__`).
5. **Session's `_file_op` / MCP path gains** `presentation_renderer`, `intervention_bus` (at construction; its post-hoc assignment still wins where it happens), `presentation_registry`, `multimodal_config`, `compact_now`, `cancel_event`, `threat_scan`, `session_id`. Inert on that path today — no `present` / `compact` / media op reaches it — but it is now the same OpContext, so a future op that does reach it is not silently uncapabilitied.
6. **The `mcp_servers` list the PermissionDecl derives names from comes from Session's resolver**, which omits the adapter's `tools` key. Only `[s["name"] for s in servers]` is read, so the declared MCP names are unchanged; naming it because the value's shape changed.

⚠️ Nothing here changes an LLM-visible tool result. Two are security-direction changes (2 and 3 both grant *less*); I would ask for an explicit ruling on **1** if you would rather the identity header stay off the registry path — it is the one delta that sends something new outward.

## Doc drift fixed here

- `docs/reference/runtime/session-construction.md` — Family 6a: the `RouterOpContextInputs` row is gone (five bundles → four), the supplier is described, the "2 DEFERRED per-turn lambdas" sentence is corrected, and the #3196 section's `base_available_skills_fn` (a name that no longer exists anywhere) is renamed to `available_skills_fn`, heading included. Also the two `_current_task_id` / `_current_turn_origin` entries that said "read by the router op-ctx builders" (plural).
- `src/reyn/core/op_runtime/context.py` — the `budget_gateway` comment asserted "(both router op-ctx builders)" and named RouterHostAdapter's as the load-bearing one; there is one builder now.
- `src/reyn/runtime/router_op_context.py` — module docstring rewritten (it described the two-host situation as current), plus the `agent_id` param comment that still called the adapter's `None` a "gap candidate".
- Checked and **deliberately not edited**: `docs/deep-dives/decisions/0026`, `0036`, `docs/deep-dives/proposals/0045` / `0050` / `0060`, `llm-invocation-surfaces.md` + `.ja.md`, `control-ir.md` — each names `make_router_op_context` or `build_router_op_context` as a thing that exists and is reached, which is still true. `docs/deep-dives/journal/**` is historical record.

## Measurement

`scripts/measure_router_host_adapter_consumers.py`: **55 params before and after**, **0 exact-match clusters** both sides, shelf unchanged (`journal`). ★ **The brief's "params 16 → 1" was already true on `main`** — #3482 bundled them into one param. What this PR removes is 16 **fields**, one **construction site**, and one dead dual-write; the param count is unchanged by construction.

## ⚠️ File overlap with open PR #3606

One file overlaps: `src/reyn/runtime/session.py`. **Measured, not assumed** — #3606's hunks are at 3070, 5407–5695, 6801–6840, 7603; mine are the import block (~72), `_build_router_waist` (3760–4030), `_reapply_per_agent_capability` (~4798) and `_make_router_op_context` (7154–7217). Disjoint. The nearest contact is #3606's `_handle_pipeline_result` change, whose hunk header names `_stamp_execution_context` as context only — that method (which my turn-origin test drives) is untouched by it. Flagged for whoever merges second; nothing was silently resolved.

## Test plan

- [x] `pytest -q -n auto --timeout=120` from the repo root, foreground — **9897 passed, 36 skipped**. Both known intermittents (#3590 `test_textual_chat_gutter_toggle_3352.py`, #3594 `test_fp0066_p3b_repo_knowledge_ingest.py`) passed.
- [x] `ruff check src tests` — All checks passed
- [x] `python scripts/test_tier_audit.py --strict` on all 14 changed/added test files — 77 inspected, 0 warnings, 0 Tier-4 errors (one was caught and fixed: an assert calling `session._make_router_op_context()` inline read as a private-state assertion)
- [x] `python scripts/verify_module_docstrings.py` on all 5 changed src files — OK
- [x] Manual: `scripts/measure_router_host_adapter_consumers.py` — 55 params / 0 clusters, shelf unchanged
- [x] Manual: the four strip-falsify arms above, each RED on the named arm, restored by `cp` and re-verified green
- [x] Manual: `pytest tests/test_3126_doc_anchor_gate.py` after renaming the `base_available_skills_fn` heading — 317 passed
- [x] Manual: enumerated the closing scope — the only other PR whose body declares it is part of #3607 is #3608, merged, so this one completes the arc

Closes #3607
