### PR TITLE
fix(runtime): preserve the live capability envelope when no base can be read — part of #3593 (stage ①)

### DIFF
--- a/src/reyn/runtime/capability_visibility.py
+++ b/src/reyn/runtime/capability_visibility.py
@@ -293,6 +293,28 @@ class CapabilityVisibility:
         — toggle-ON discards from the override so the capability is restored *up to the envelope*,
         never re-granted beyond it (an envelope-denied capability stays denied). The per-turn
         RouterLoop reads these fields at construction, so the change is live next turn.
+
+        #3593 ① — NO BASE ⇒ NO WRITE. The SET above is correct only when a base was actually
+        OBTAINED. Without an envelope source there is nothing to re-resolve, and composing the
+        override against a default ``ContextualPermission()`` (which allows everything) and SETting
+        THAT paints over live fields that were correct until that moment — the topology
+        ``capability_profile`` bindings, the #2081 ``_delegate`` floor and the #2103-S1a
+        per-session narrowing all replaced by "allow-all minus whatever the operator toggled".
+        A missing INPUT was triggering a WRITE, and the write went outward.
+
+        The live fields already hold the correct values (resolved at construction from a real
+        base), so the existing state is the authority and any state derived from a base that
+        could not be read is fabricated. This method therefore has no standing to overwrite it
+        and returns without writing — that is a judgement about authority, not the "it is safe,
+        so do nothing" a *no-op* would name. It is not fail-closed either: fail-closed would be
+        another write, of a value nobody resolved.
+
+        Cost of preserving, stated rather than buried: on such a session an override change made
+        since the last successful resolve does not reach the live gate (it is still recorded in
+        ``visibility_override`` / persisted / rendered in ``hidden_by_session``). Applying it
+        anyway would require an envelope to compose against, and inventing one is the defect.
+        The condition is surfaced (WARNING) rather than passed over in silence — see
+        ``_surface_unreadable_envelope_source``.
         """
         from typing import cast
 
@@ -310,13 +332,15 @@ class CapabilityVisibility:
         # resolved_profile_for is documented to return (ContextualPermission | None, ...);
         # its declared type is the wider `object | None`, so cast to the concrete type the
         # downstream compose_resolved requires (registry.py:3509 guarantees it).
-        base_ctx: "ContextualPermission | None" = None
-        base_excl: "frozenset[str]" = frozenset()
-        if self._registry is not None and hasattr(self._registry, "resolved_profile_for"):
-            raw_ctx, base_excl = self._registry.resolved_profile_for(
-                self._agent_name, sid=self._session_id_provider(),
-            )
-            base_ctx = cast("ContextualPermission | None", raw_ctx)
+        if self._registry is None or not hasattr(self._registry, "resolved_profile_for"):
+            # #3593 ①: preserve — see the docstring. No base was obtained, so nothing below
+            # may run: everything below composes a NEW envelope and SETs it over the live one.
+            self._surface_unreadable_envelope_source()
+            return
+        raw_ctx, base_excl = self._registry.resolved_profile_for(
+            self._agent_name, sid=self._session_id_provider(),
+        )
+        base_ctx: "ContextualPermission | None" = cast("ContextualPermission | None", raw_ctx)
 
         ov = self._visibility_override
         keep_categories: "tuple[str, ...] | None" = None
@@ -343,6 +367,48 @@ class CapabilityVisibility:
         self._contextual_permission = final_ctx
         self._excluded_categories = final_excl
 
+    def _surface_unreadable_envelope_source(self) -> None:
+        """#3593 ①: say out loud that the envelope base could not be read.
+
+        Preserving is the safe direction, which is exactly why it must not be silent: the
+        session keeps whatever gate it already had, so nothing downstream misbehaves, and the
+        wiring defect that produced a security-core object with no envelope source leaves no
+        other trace. A widening bug announces nothing on its own (#3593's framing); a
+        *silently* preserved one announces nothing either.
+
+        WARNING log, not a P6 audit-event kind, and the reason is not convenience:
+
+        - ``.reyn/events`` is the replayable record of what happened to the WORKSPACE, and its
+          ``type`` namespace is a closed vocabulary with consumers outside reyn (see
+          ``AUDIT_EVENT_KINDS``). "A collaborator this object needed was absent" is a fact
+          about how reyn was WIRED at construction, not an action taken on the workspace, and
+          it reconstructs nothing on replay.
+        - This class holds four deps by design (envelope source, router host, two live
+          getters) and no event sink. Injecting one — through ``Session`` and every
+          construction site — to carry a single wiring diagnostic is a larger coupling change
+          than the defect being fixed, and would have to be threaded through the very
+          bootstrap window (the one measured no-back-reference caller) where it is least
+          likely to be available.
+        - Sibling precedent in this same class: ``persist_visibility_override`` reports its
+          best-effort failure the same way.
+
+        Stage ② (#3593) is meant to make this branch unreachable by construction — fix the
+        one bootstrap-ordering caller, then require the envelope source non-optionally. Until
+        then this warning is what would tell an operator the window widened.
+        """
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "#3593: capability envelope NOT re-resolved for agent %r (sid %r) — no envelope "
+            "source to read the base from. The live envelope is PRESERVED, not widened; any "
+            "visibility-override change since the last successful resolve is recorded and "
+            "persisted but is NOT reflected in the live gate. A session on the security-core "
+            "path is expected to carry the registry back-reference: reaching this means a "
+            "construction site built one without it.",
+            self._agent_name,
+            self._session_id_provider(),
+        )
+
     def reapply_skill_visibility(self) -> None:
         """#2548 PR-B: recompute the live skill list from the base registered set minus the session override.
 
@@ -365,6 +431,11 @@ class CapabilityVisibility:
         for visibility: ``reapply_visibility_override`` re-resolves from base, which still denies
         it). Session-scoped (this sid only); live next turn; persists across restart (step2,
         ``toggle_store_dir`` is the caller's per-session state dir).
+
+        "Live next turn" holds for a session that HAS an envelope source. On one that does not,
+        ``reapply_visibility_override`` preserves the live envelope rather than recomposing it
+        (#3593 ①, see its docstring) — the toggle is still recorded, persisted and reported in
+        ``hidden_by_session``, but it does not reach the live gate, and the attempt is logged.
 
         For ``kind="skill"``: restrict-only within the registered set — disabling a skill name not
         in the registered set is silently ignored (no error; the override is a no-op). Enabling a

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2809,13 +2809,19 @@ class AgentRegistry:
         # the value this spawn imposes (inheritance) — one write, one injection, no
         # second seam where the two could disagree.
         #
-        # ⚠️ The injection is only durable for a caller that does not then run
+        # ⚠️ This injection USED to be non-durable for a caller that then ran
         # ``refresh_config_projections()``: that refresh's
         # ``reapply_visibility_override`` re-resolves from base and SETs, and on a
-        # session with no registry back-reference there is no base to re-resolve, so it
-        # sets ALLOW-ALL and discards this. That is why ``spawn_session_recorded``
-        # deliberately does NOT pass ``narrowing`` here and re-injects after its own
-        # refresh instead — measured, see the note at its ``spawn_session`` call.
+        # session with no registry back-reference there was no base to re-resolve, so it
+        # set ALLOW-ALL and discarded this. #3593 ① removed the discard at its source —
+        # with no base obtained, that method now PRESERVES the live envelope (it has no
+        # standing to overwrite it) instead of writing a fabricated one, and says so.
+        # ``spawn_session_recorded`` still does NOT pass ``narrowing`` here and re-injects
+        # after its own refresh; #3593 ① did not re-litigate that ordering (measured
+        # there: with the preserve fix in place, routing the value down this channel no
+        # longer REDs the two tests that pinned the ordering — deciding whether to move it
+        # is a separate change with its own review). See the note at its
+        # ``spawn_session`` call.
         if narrowing:
             self._persist_session_narrowing(name, new_sid, narrowing)
         inject = getattr(session, "apply_per_session_narrowing", None)
@@ -2858,19 +2864,29 @@ class AgentRegistry:
         parent surface, ask_user reaches the parent's live operator), ``AuditOnlyNoSurface``
         (detached/headless — present audit-only, ask_user a typed refusal), or ``ReviewedNA``
         (``None``/``None`` self-bound, reviewed sites only). No silent default (#2708 P3-item3)."""
-        # #3562: this seam does NOT hand ``narrowing`` down the primitive's new channel,
-        # and the reason is measured rather than stylistic. Its own write + re-inject
-        # (below) must stay AFTER ``refresh_config_projections()``: that refresh fires
+        # #3562: this seam does NOT hand ``narrowing`` down the primitive's new channel.
+        # The original reason was measured: its own write + re-inject (below) had to stay
+        # AFTER ``refresh_config_projections()``, because that refresh fires
         # ``reapply_visibility_override``, which re-resolves the envelope from base and
-        # SETs it — and when the session has no registry back-reference there IS no base
-        # to re-resolve, so it sets an ALLOW-ALL envelope and silently discards anything
+        # SETs it — and when the session had no registry back-reference there was no base
+        # to re-resolve, so it set an ALLOW-ALL envelope and silently discarded anything
         # injected before it. Passing the narrowing down was tried and falsified by
         # tests/test_2103_s1bc_session_spawn_tool.py::
         # test_spawn_session_recorded_enforces_narrowing_on_live_session and
         # tests/test_pipeline_a2_spawn_ephemeral_session.py::
         # test_spawn_ephemeral_session_narrowing_applied — both went RED with an empty
-        # ``tool_deny`` on the live session. The primitive's channel is for callers that
-        # do not run that refresh (``/session new``, #3562).
+        # ``tool_deny`` on the live session.
+        #
+        # ⚠️ #3593 ① removed that discard: with no base obtained,
+        # ``reapply_visibility_override`` now preserves the live envelope instead of
+        # overwriting it with a fabricated one. Re-measured under the fix — routing the
+        # value down the primitive's channel keeps both of those tests GREEN — so the
+        # ordering below is no longer FORCED by the refresh. It is left exactly as it is
+        # here: #3593 ① is scoped to the fail-open write, and moving a spawn seam's
+        # narrowing injection is a behavioural change that deserves its own PR and its
+        # own review. Read this as "no longer forced, deliberately not moved", not as
+        # "still impossible". The primitive's channel is for callers that do not run that
+        # refresh (``/session new``, #3562).
         sid = self.spawn_session(
             name,
             presentation_consumer=presentation_consumer,

--- a/tests/test_3546_pipeline_driver_narrowing_inheritance.py
+++ b/tests/test_3546_pipeline_driver_narrowing_inheritance.py
@@ -82,13 +82,18 @@ expiry mechanical rather than remembered: the four sites that still pass nothing
 re-argued on the merits — no spawner to inherit from (``resolve_session``); a value
 would OVERWRITE the recovering session's own durable layer, since the primitive
 persists what it is given (the recovery pair); and, for ``spawn_session_recorded``, the
-injection has to happen at a LATER point than the primitive offers. ★ That last one is
-measured, not judged: routing its ``narrowing`` through the new channel REDs two
+injection happens at a LATER point than the primitive offers. ★ That last one was
+measured, not judged: routing its ``narrowing`` through the new channel REDded two
 existing behavioural tests, because ``refresh_config_projections()`` runs in between and
 its ``reapply_visibility_override`` re-resolves-from-base-and-SETs — with no registry
-back-reference there is no base, so it lands on ALLOW-ALL and discards the injection.
+back-reference there was no base, so it landed on ALLOW-ALL and discarded the injection.
 "The channel exists, therefore use it" would have been a shape argument in the third
-direction. The ``_S3561`` legs assert reachability only, never anything about what the
+direction. ★ #3593 ① removed that discard (no base obtained ⇒ the live envelope is
+PRESERVED, never overwritten with a fabricated one), and re-measured: under the fix both
+of those tests stay GREEN with the value routed down the channel. The site keeps its
+current ordering — #3593 ① is scoped to the fail-open write and deliberately does not
+move a spawn seam's injection point — so the exemption below now rests on "not moved,
+pending its own PR", not on "the refresh would eat it". The ``_S3561`` legs assert reachability only, never anything about what the
 child inherits, so they are orthogonal to #3562's and stay green through it — verified
 by running them (both the pre-#3595 leg and, after the rebase, its #3596 inverse plus
 the operator control), not assumed.
@@ -386,15 +391,20 @@ _EXEMPT_RECOVERY_REENTRY = (
 )
 _EXEMPT_RECORDED_SEAM_INJECTS_LATER = (
     "the recorded seam writes + injects its OWN ``narrowing`` a few statements after "
-    "the spawn, and that ordering is MEASURED (#3562): it must happen AFTER its "
+    "the spawn. That ordering was MEASURED (#3562): it had to happen AFTER its "
     "``refresh_config_projections()``, whose ``reapply_visibility_override`` "
     "re-resolves the envelope from base and SETs it — on a session with no registry "
-    "back-reference there is no base, so it sets ALLOW-ALL and discards anything "
+    "back-reference there was no base, so it set ALLOW-ALL and discarded anything "
     "injected earlier. Handing the value down the primitive's channel was tried and "
     "REDded tests/test_2103_s1bc_session_spawn_tool.py::"
     "test_spawn_session_recorded_enforces_narrowing_on_live_session and "
     "tests/test_pipeline_a2_spawn_ephemeral_session.py::"
-    "test_spawn_ephemeral_session_narrowing_applied, both with an empty live tool_deny."
+    "test_spawn_ephemeral_session_narrowing_applied, both with an empty live tool_deny. "
+    "#3593 (1) removed that discard — no base obtained now PRESERVES the live envelope "
+    "instead of overwriting it — and re-measured: both tests stay GREEN with the value "
+    "routed down the channel. The site is unchanged because #3593 (1) is scoped to the "
+    "fail-open write, not because the refresh would still eat it; moving the injection "
+    "is a behavioural change owed its own PR."
 )
 _NARROWING_EXEMPT_SITES: "dict[tuple[str, str], str]" = {
     ("reyn/runtime/registry.py", "spawn_session_recorded"): (

--- a/tests/test_3593_preserve_envelope_when_base_unreadable.py
+++ b/tests/test_3593_preserve_envelope_when_base_unreadable.py
@@ -1,0 +1,189 @@
+"""Tier 2: #3593 ① — a session's live capability envelope is PRESERVED, never
+overwritten, when ``reapply_visibility_override`` cannot read a base.
+
+``CapabilityVisibility.reapply_visibility_override`` re-resolves the WHOLE agent
+envelope from base and SETs both live fields (SET, not union — that is what lets a
+``/visibility`` toggle-ON restore a capability *up to* the envelope without
+re-widening past it). The SET is correct only when a base was actually obtained:
+without an envelope source it used to compose the override against a default
+``ContextualPermission()`` (allows everything) and SET that, replacing the topology
+bindings, the #2081 delegate floor and the #2103-S1a per-session narrowing with
+"allow-all minus whatever the operator toggled". A missing input triggered a write,
+and the write went outward.
+
+The reach path exercised here is the measured one from the issue: the restart path
+(``AgentRegistry.spawn_session`` with an existing sid) injects the sid-keyed
+narrowing and then calls ``load_persisted_toggles()``, which calls
+``reapply_visibility_override`` for any sid with a persisted ``visibility.yaml``.
+No ``refresh_config_projections()`` is involved.
+
+Real ``AgentRegistry`` + real ``Session`` throughout; the two arms differ in exactly
+one input — whether the session factory hands the session its registry
+back-reference. Each arm asserts VALUES on its own (which tool names the live gate
+denies), never "the two arms agree": both arms sharing one defect would agree.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.security.permissions.effective import CapabilityAxis, ContextualLayer
+from tests._support.agent_session import make_session
+
+NARROWED_TOOL = "write_file"   # denied by the sid's persisted config.yaml (the envelope)
+TOGGLED_TOOL = "read_file"     # hidden by the sid's persisted visibility.yaml (the override)
+
+
+def _make_registry(tmp_path: Path, *, with_back_reference: bool) -> AgentRegistry:
+    """A real registry whose sessions carry (or do not carry) the registry
+    back-reference — the single variable between the two arms. ``registry=None`` is
+    the shape production's ``build_scoped_chat_session`` produces when its caller
+    passes no registry (``interfaces/cli/commands/dogfood.py``'s bootstrap window)."""
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile: AgentProfile) -> Session:
+        return make_session(
+            agent_name=profile.name,
+            state_log=state_log,
+            registry=holder.get("reg") if with_back_reference else None,
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    if not (tmp_path / ".reyn" / "agents" / "alice").exists():
+        AgentProfile.new("alice", role="").save(tmp_path / ".reyn" / "agents" / "alice")
+    return reg
+
+
+def _denies_tool(session: Session, name: str) -> bool:
+    """What the LIVE gate does — the single field the RouterLoop's advertisement filter
+    and its call-time gate both read."""
+    return not ContextualLayer(session.contextual_permission).allows(CapabilityAxis.TOOL, name)
+
+
+def _persist_narrowing_and_toggle(tmp_path: Path) -> str:
+    """Produce the on-disk precondition the issue measured: one sid with BOTH a
+    ``config.yaml`` narrowing (the envelope layer) and a ``visibility.yaml`` toggle
+    (the override layer). Written by a normal, fully-wired session — so the state the
+    restart arms read back is real persisted state, not a hand-built fixture."""
+    reg = _make_registry(tmp_path, with_back_reference=True)
+    reg.get_or_load("alice")
+    sid = reg.spawn_session(
+        "alice",
+        narrowing={"tool_deny": [NARROWED_TOOL]},
+        presentation_consumer=None,
+        intervention_bridge=None,
+    )
+    reg.get_session("alice", sid).set_capability_visible("tool", TOGGLED_TOOL, False)
+    return sid
+
+
+def _restart(tmp_path: Path, sid: str, *, with_back_reference: bool) -> Session:
+    """The restart path (``restore_all`` re-enters an existing sid): a fresh registry
+    re-creates (alice, sid), which re-injects the sid's persisted narrowing and then
+    fires ``load_persisted_toggles()`` -> ``reapply_visibility_override``."""
+    reg = _make_registry(tmp_path, with_back_reference=with_back_reference)
+    reg.get_or_load("alice")
+    reg.spawn_session("alice", sid=sid, presentation_consumer=None, intervention_bridge=None)
+    return reg.get_session("alice", sid)
+
+
+def test_envelope_narrowing_survives_a_reapply_with_no_base(tmp_path, monkeypatch) -> None:
+    """Tier 2: with NO envelope source, the re-resolve preserves the live envelope —
+    the sid's persisted ``tool_deny`` is still enforced by the live gate after
+    ``reapply_visibility_override`` ran. RED before #3593 ①: the re-resolve composed
+    the override against an allow-everything default and SET it, so the injected
+    narrowing was silently replaced and the tool became allowed."""
+    monkeypatch.chdir(tmp_path)
+    sid = _persist_narrowing_and_toggle(tmp_path)
+
+    session = _restart(tmp_path, sid, with_back_reference=False)
+
+    assert _denies_tool(session, NARROWED_TOOL), (
+        f"the sid's persisted envelope narrowing must still deny {NARROWED_TOOL!r} after a "
+        "re-resolve that could not read a base — with no base there is no standing to "
+        "overwrite the live envelope"
+    )
+    # The named cost of preserving (#3593 ①), asserted rather than left implicit: the
+    # override cannot be composed without an envelope to compose it against, so the
+    # toggle is recorded and persisted but does not reach the live gate on such a
+    # session. Applying it would require inventing the envelope, which is the defect.
+    assert not _denies_tool(session, TOGGLED_TOOL), (
+        "with no base the override is NOT applied to the live gate (preserve, not partially "
+        "recompose) — it stays visible in the override/persisted state instead"
+    )
+    assert {"kind": "tool", "name": TOGGLED_TOOL} in (
+        session.capability_visibility_state()["hidden_by_session"]
+    ), "the toggle itself is still recorded and reported, only not applied to the live gate"
+
+
+def test_reapply_with_a_base_still_composes_envelope_and_override(tmp_path, monkeypatch) -> None:
+    """Tier 2: the preserve branch does not swallow the normal path — with an envelope
+    source, the same restart resolves the base AND composes the override, so the live
+    gate denies both the envelope-narrowed tool and the session-hidden one. Values are
+    named here directly; this arm never compares itself against the no-base arm."""
+    monkeypatch.chdir(tmp_path)
+    sid = _persist_narrowing_and_toggle(tmp_path)
+
+    session = _restart(tmp_path, sid, with_back_reference=True)
+
+    assert _denies_tool(session, NARROWED_TOOL), (
+        f"the envelope's persisted narrowing must deny {NARROWED_TOOL!r}"
+    )
+    assert _denies_tool(session, TOGGLED_TOOL), (
+        f"the session's persisted /visibility override must deny {TOGGLED_TOOL!r}"
+    )
+
+
+def test_the_preserve_branch_is_reached_on_the_restart_path(
+    tmp_path, monkeypatch, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 2: the preserve branch is REACHED through the production restart path, and
+    says so. A branch nothing reaches is dead, and a preserved envelope is
+    indistinguishable from a correctly re-resolved one by looking at the envelope alone
+    — the WARNING is the only thing that distinguishes them, which is why preserving is
+    not allowed to be silent. RED if the branch stops being reached, or if it is reached
+    silently."""
+    monkeypatch.chdir(tmp_path)
+    sid = _persist_narrowing_and_toggle(tmp_path)
+
+    with caplog.at_level(logging.WARNING, logger="reyn.runtime.capability_visibility"):
+        _restart(tmp_path, sid, with_back_reference=False)
+
+    unreadable = [
+        r for r in caplog.records
+        if r.levelno >= logging.WARNING and "#3593" in r.getMessage()
+    ]
+    assert unreadable, (
+        "reaching the preserve branch must surface: no WARNING naming #3593 was emitted "
+        "while re-applying the visibility override on a session with no envelope source"
+    )
+    message = unreadable[0].getMessage()
+    assert "alice" in message, "the warning must name the agent whose envelope was not re-resolved"
+    assert sid in message, "the warning must name the session it happened on"
+
+
+def test_a_wired_session_does_not_reach_the_preserve_branch(
+    tmp_path, monkeypatch, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 2: the branch is reached ONLY when the base is genuinely unavailable — the
+    same restart with an envelope source emits no such warning. Without this, a warning
+    fired unconditionally would satisfy the reachability witness above while telling an
+    operator nothing."""
+    monkeypatch.chdir(tmp_path)
+    sid = _persist_narrowing_and_toggle(tmp_path)
+
+    with caplog.at_level(logging.WARNING, logger="reyn.runtime.capability_visibility"):
+        _restart(tmp_path, sid, with_back_reference=True)
+
+    assert not [
+        r for r in caplog.records
+        if r.levelno >= logging.WARNING and "#3593" in r.getMessage()
+    ], "a session that CAN read its base must not report an unreadable envelope source"


### PR DESCRIPTION
**[per-PR-coder]** — stage ① of #3593. `part of #3593` — stage ② (fix the dogfood bootstrap ordering, then tighten `_EnvelopeSource | None` to non-Optional) is a separate PR and is deliberately not started here.

## The defect, framed as architect framed it

Not "what should a missing base be read as" — **the defect is that we WRITE when we could not read.**

`CapabilityVisibility.reapply_visibility_override` re-resolves the whole agent envelope from base and **SETs** `_contextual_permission` / `_excluded_categories`. SET (not union) is deliberate and correct and is unchanged here — it is what lets a toggle-ON restore a capability *up to* the envelope without re-widening past it. But SET is correct **only when a base was obtained**. With no envelope source, `base_ctx` stayed `None`, a default `ContextualPermission()` (allows everything) was composed with the override alone, and the result was SET — replacing the topology `capability_profile` bindings, the #2081 `_delegate` floor and the #2103-S1a per-session narrowing with "allow-all minus whatever the operator toggled".

The correct values are already in the live fields (resolved at construction from a real base). So the fix is neither fail-closed nor raise: **preserve — do not write.** The code says this in those words; it explicitly does not call it a "no-op", because that reads as "it is safe, so do nothing" rather than "it has no standing to overwrite".

## Where the preserve branch sits, and how its reachability is witnessed

`src/reyn/runtime/capability_visibility.py` — an early `return` at the top of `reapply_visibility_override`, before anything that composes a new envelope. It calls `_surface_unreadable_envelope_source()` on the way out.

`test_the_preserve_branch_is_reached_on_the_restart_path` witnesses that the branch is REACHED through a production path (§15): a real `AgentRegistry.spawn_session(sid=...)` restart — which injects the sid's persisted narrowing and then calls `load_persisted_toggles()` → `reapply_visibility_override` — on a session built without the registry back-reference. `test_a_wired_session_does_not_reach_the_preserve_branch` is the negative control, so the witness cannot be satisfied by a warning that fires unconditionally.

## How the missing base surfaces, and why that channel

WARNING on `reyn.runtime.capability_visibility`, naming the agent and the sid. Preserving is the safe direction, which is exactly why it must not be silent — a preserved envelope is indistinguishable from a correctly re-resolved one by looking at the envelope alone.

A P6 audit-event kind was considered and rejected, argued in `_surface_unreadable_envelope_source`'s docstring: `.reyn/events` is the replayable record of what happened to the **workspace** and its `type` namespace is a closed vocabulary with consumers outside reyn; "a collaborator this object needed was absent at construction" is a fact about how reyn was **wired**, not an action on the workspace, and it reconstructs nothing on replay. This class also holds four deps by design and no event sink — threading one in (through `Session` and every construction site) to carry a wiring diagnostic is a larger coupling change than the defect, and would have to reach the very bootstrap window where it is least likely to exist. Sibling precedent in the same class: `persist_visibility_override` reports its best-effort failure the same way.

## ⚠️ Behaviour delta, named rather than buried

On a session with **no** envelope source, a `/visibility` toggle no longer reaches the live gate. It is still recorded in `visibility_override`, still persisted to `visibility.yaml`, and still reported in `hidden_by_session` — but the live `contextual_permission` is left alone, because applying the override requires an envelope to compose it against and inventing one is the defect. This is asserted directly in `test_envelope_narrowing_survives_a_reapply_with_no_base` so it is a stated contract, not a side effect. On a wired session (every unconditional production caller) nothing changes.

## Docs / comments this PR falsifies — fixed here

Three prose sites asserted "with no registry back-reference there is no base, so it sets ALLOW-ALL and discards this", which this PR makes false:

- `src/reyn/runtime/registry.py` — the `spawn_session` injection note and the `spawn_session_recorded` ordering note.
- `tests/test_3546_pipeline_driver_narrowing_inheritance.py` — the module docstring and `_EXEMPT_RECORDED_SEAM_INJECTS_LATER`.

**Re-measured, not assumed**: with this fix in place, routing `spawn_session_recorded`'s `narrowing` down the primitive's channel keeps `tests/test_2103_s1bc_session_spawn_tool.py::test_spawn_session_recorded_enforces_narrowing_on_live_session` and `tests/test_pipeline_a2_spawn_ephemeral_session.py::test_spawn_ephemeral_session_narrowing_applied` GREEN (2 passed) — the ordering is no longer forced by the refresh. The site is left exactly as it was (that would be a behavioural change owed its own PR); the comments now read "no longer forced, deliberately not moved" instead of "still impossible".

No new audit-event kind, so no `AUDIT_EVENT_KINDS` / `events.md` three-part change is due.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_3593_preserve_envelope_when_base_unreadable.py tests/test_3546_pipeline_driver_narrowing_inheritance.py` — 16 inspected, 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/capability_visibility.py src/reyn/runtime/registry.py` — OK
- [x] `pytest` from the repo root, foreground, summary read myself: **9913 passed, 36 skipped** in 703s. Neither known intermittent (#3590, #3594) fired.
- [x] Measured-code identity checked at measurement time: a probe inside a pytest run prints `reyn.__file__` = this worktree's `src/reyn/__init__.py` (a bare `python -c "import reyn"` here resolves the SHARED checkout — only the pytest-path measurement is valid).
- [x] Strip-falsify ①, restore the overwrite (anchor `if self._registry is None or not hasattr(...)`, `grep -c` = 1): **2 RED** — the value arm `test_envelope_narrowing_survives_a_reapply_with_no_base` and the reachability witness; the with-base arm and the negative control stayed green (correctly — they do not depend on the branch).
- [x] Strip-falsify ②, remove only the surfacing (anchor `            self._surface_unreadable_envelope_source()\n`, `grep -c` = 1): **1 RED** — the reachability witness only; the value arms stayed green, confirming the two mechanisms are falsified independently.
- [x] Both strips restored; full-suite run above is post-restore.
- [x] §16 applied: no arm asserts "with-registry and without-registry agree". Each arm names its own values (`write_file` denied by the envelope layer; `read_file` denied by the override only on the wired arm) — both arms could be broken identically and the equality would still hold.
- [x] Testing policy re-read before writing tests; no fakes (real `AgentRegistry` + real `Session` throughout, persisted state written by a real session), no private-state assertions, no format/order pins.
- [x] Behaviour delta named in the body above and asserted in a test.

## Sweep: "absent" vs "unknown" — run, on a bounded slice, reported as my own measurement

Architect handed over the axis (only `X | None` holding **the result of a look-up**; declaration-derived `None` is legitimate and out of scope) without running the census. I ran it over one slice I could enumerate exactly — every consumer of `resolved_profile_for`, the look-up in question (11 sites in `src/`):

| site | verdict |
|---|---|
| `runtime/capability_visibility.py` `reapply_visibility_override` | **instance — fixed here** |
| `runtime/capability_visibility.py` `capability_visibility_state` | **instance, not fixed** — same `registry is None → ContextualLayer(None) → allows all`, but on the READ model: it would report everything as `authorized`. No write, so out of stage ①'s scope; it becomes unreachable when stage ② tightens the type. Flagging rather than fixing, since changing the read model has renderer blast radius. |
| `interfaces/cli/commands/dogfood.py:511` | **instance** — `_reg.resolved_profile_for(...) if _reg else (None, frozenset())`: the look-up was not performed and the result is read as "no narrowing", at construction. This is the same bootstrap window stage ② is meant to remove. |
| `registry_bootstrap.py:175`, `web/deps.py:307`, `cli/chat.py:497`, `cli/mcp.py:447` | not instances — the look-up is always performed; `None` means "no narrowing declared". |
| `registry.py:2829`, `:2965` | not instances — same, on the registry itself. |
| `registry.py:3688` (⊆-parent conjunct) | **the correct handling of this exact axis, already in the repo** — absent/stale parent ⇒ fail-closed delegate floor; present-but-unrestricted parent ⇒ `None` skipped. It distinguishes the two cases explicitly in a comment. Worth citing as the in-repo positive example. |

Not claimed: a repo-wide census of the axis. This is one look-up's consumer set, enumerated by grep and read individually.
