### PR TITLE
docs(contributing): grep-scope census hazard in verification-hazards.md

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -508,6 +508,53 @@ stop at the equality assertion. Add at least one assertion that names an
 actual expected value for a load-bearing field, reached through only ONE of
 the paths, independent of whatever the other path currently produces.
 
+## 17. Scope, not just pattern — a grep's directory/file-set decides the census as much as its regex does
+
+Distinguish this from §3/§4 (a pattern too narrow in TOKEN SPELLING — a CSS
+`#hex` shape missing a Python `_CC_DIM = "#6b7280"` constant, or POSIX ERE not
+understanding `\s`): here the regex can be exactly right and the census still
+undercounts, because the search never looked in the file, or the package,
+the defect actually lives in. The searcher reports what matched honestly;
+the files never searched produce no signal at all, so a partial SCOPE reads
+exactly like a total one — to the searcher and to the reader, alike.
+
+Two same-day instances (2026-08-02):
+
+- A filed defect asserted "no processing restores the cursor position after
+  paint (grep 0 hits)." The restore call existed the whole time, in
+  `app.py`: `Control.move_to(*cursor_position)` at the end of every frame.
+  The fix PR's own retrospective names the actual miss: "`_compositor.py`
+  だけを見たための誤りで、復帰は `app.py` 側にありました" ("the mistake was
+  from looking at only `_compositor.py`; the restore lives on the `app.py`
+  side"). The filed issue's root cause ("doesn't restore") was wrong; the
+  real defect was "restores to a STALE value" — a different fix entirely
+  (#3621 → #3622).
+- A `$text-muted` census ran a grep scoped to reyn's own chat interface
+  directory, found 6 sites, and reported that as the affected set. The
+  coder's own correction: "私は `grep '\$text-muted'
+  src/reyn/interfaces/inline/textual_chat/*.py` で列挙しました。∴ 答えられ
+  るのは『reyn が `\$text-muted` と書いた場所』だけです" — the grep's scope
+  was reyn's own source tree, and the same collapsed-to-`$text`-value defect
+  class also lives in Textual's own `DEFAULT_CSS` (`_text_area.py`,
+  `_input.py`, `_option_list.py`) — a directory the census never entered
+  because it isn't reyn's code, and one of those sites was already the
+  confirmed cause of a distinct, previously-fixed bug in the same class
+  (#3523).
+
+### The detection technique
+
+Neither closure came from a better regex. Instance 1 was caught by
+searching OUTSIDE the file set the original diagnosis had named. Instance 2
+was caught by asking "does this defect class exist somewhere I didn't
+look, for a reason unrelated to how it's spelled" — the dependency's own
+source tree, not `reyn`'s — rather than widening the pattern.
+
+**Apply**: state scope alongside the count — "N, over `<files/dirs
+searched>`" — an unscoped N reads as total. Before trusting a 0 or a small
+N, name every location the defect COULD live (adjacent files in the same
+subsystem, a dependency's own source, a sibling directory) and confirm each
+was actually searched, not just the one that felt likely.
+
 ## See also
 
 - [Testing policy](testing.md) — Tier model, Mock vs Fake, decision flow.


### PR DESCRIPTION
**[per-PR-coder]** — Adds one new section (§17) to `docs/deep-dives/contributing/verification-hazards.md`: a grep's directory/file-set silently decides the census, as distinct from token-spelling narrowness (already covered by §3 "Two zeros" and §4 "Census vs. structure").

## What this is, and what it isn't

Checked first whether this duplicated existing material. §3 and §4 already document a *pattern-form* failure (a CSS `#hex` shape missing a Python `_CC_DIM = "#6b7280"` constant; POSIX ERE not understanding `\s`) — that's token spelling, not scope. The new §17 is a different axis: the regex can be exactly right and the census still undercounts because the search never entered the file, or the package, the defect lives in.

## Instances verified (2 of the 3 offered — the third didn't fit this axis)

1. **#3621 → #3622** (IME cursor anchor). The filed issue claimed "no processing restores the cursor position after paint (grep 0 hits)." The restore call existed the whole time in `app.py` (`Control.move_to(*cursor_position)`, end of every frame). PR #3622's own retrospective: `_compositor.py` だけを見たための誤りで、復帰は `app.py` 側にありました. The wrong root cause ("doesn't restore") led to the wrong fix direction; the real defect was "restores to a stale value."
2. **#3523** (`$text-muted` census). A grep scoped to `src/reyn/interfaces/inline/textual_chat/*.py` found 6 sites and was reported as the affected set. The coder's own correction: the grep could only ever answer "where did reyn write `$text-muted`" — the same collapsed-to-`$text` defect also lives in Textual's own `DEFAULT_CSS` (`_text_area.py`, `_input.py`, `_option_list.py`), a directory the census never entered because it isn't reyn's code.

**#3525 did not make the cut for this axis.** I verified it against the issue and its comment thread: the first correction on #3525 ("2 hex violations" → "8 color constants across 66 sites") is the *exact* incident already quoted verbatim in this doc's existing §3 (a form/token-spelling miss: CSS-hex pattern vs. Python string constants, plus a broken POSIX-ERE regex) — reusing it as a new instance would have duplicated existing content. #3525 also had a *second*, later correction (2 hex lines → 3 slot-name violations in Textual's `theme.py`), but that one is also a pattern-FORM failure (hex spelling vs. symbolic slot name), not a directory/file-SCOPE failure — so it belongs under the existing token-spelling axis too, not this new section. I used #3621/#3622 and #3523 instead, both of which are genuinely about which files/directories were searched.

## Gates

- `ruff check src tests` — green
- `mkdocs build --strict -f .mkdocs/mkdocs.ja.yml` equivalent (`.mkdocs/mkdocs.yml`) — green, `Documentation built in 7.96 seconds`, no new warnings touching the changed file (pre-existing en/ja anchor-mirror INFO lines only, unrelated to this change)
- `pytest` — not run locally per lead-coder's follow-up correction (docs-only change; CI runs it and is authoritative here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)