### PR TITLE
docs: make the models mapping form and its two traps reachable from the example config

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -130,6 +130,8 @@ models:
 | `extra_body` | no | Provider-specific payload (e.g. `thinking` for reasoning models). |
 | `reasoning_effort` | no | Reasoning budget for the model: `minimal` / `low` / `medium` / `high` / `disable` / `none`. **Validated at load** (see below). |
 | `extends` | no | Inherit from a named class and deep-merge overrides (see below). |
+| `api_base` | no | Per-class endpoint override — a routing field, not forwarded as a litellm kwarg. |
+| `provider` | no | Per-class litellm `custom_llm_provider` — a routing field, not forwarded as a litellm kwarg. |
 | *(any other field)* | no | Silently passed through to litellm (passthrough policy). |
 
 > **Cost limit**: use `max_completion_tokens`, not `max_tokens`.  `max_tokens` is a legacy

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -52,10 +52,40 @@
 # resolves against the built-in catalog or ``reyn.yaml`` ``models:``; a
 # string containing "/" is passed through to LiteLLM as-is.
 # -----------------------------------------------------------------------------
+# An entry may also be a MAPPING. ``model`` is the only required key; every
+# other key except ``extends`` / ``api_base`` / ``provider`` is forwarded to
+# ``litellm.acompletion`` unchanged and unvalidated (a typo therefore surfaces
+# as a litellm failure, not a reyn config error). Full field table:
+# docs/reference/config/reyn-yaml.md § `models` block.
+#
+# The passthrough is also the escape hatch for when litellm does not RECOGNISE
+# a model (``my-new-model`` below). Litellm fetches its model catalog over the
+# network at import and falls back to the copy bundled in the package when that
+# fetch fails; a model too new to appear in the bundled copy is then treated as
+# unknown, and litellm rejects parameters it would otherwise allow:
+#
+#   litellm.UnsupportedParamsError: openai does not support parameters:
+#   ['tool_choice'], for model=<your-model>
+#
+# Because this depends on whether that fetch succeeded, the same config can work
+# on one run and fail on the next. Naming the parameters carries them through
+# the check either way. Prefer that over litellm's other suggestion,
+# ``drop_params: true`` — that one DISCARDS the rejected parameter rather than
+# passing it, silently changing behaviour (dropping ``tool_choice`` changes how
+# the model calls tools).
+# -----------------------------------------------------------------------------
 # models:
 #   light:    openai/gpt-4o-mini
 #   standard: claude-sonnet            # built-in catalog reference
-#   strong:   anthropic/claude-3-7-sonnet
+#
+#   strong:                            # mapping form
+#     model: anthropic/claude-3-7-sonnet
+#     temperature: 0.0
+#     max_completion_tokens: 16000     # preferred over max_tokens
+#
+#   my-new-model:
+#     model: some-model-too-new-for-litellm
+#     allowed_openai_params: ["tool_choice"]
 
 
 # -----------------------------------------------------------------------------

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -73,6 +73,17 @@
 # ``drop_params: true`` — that one DISCARDS the rejected parameter rather than
 # passing it, silently changing behaviour (dropping ``tool_choice`` changes how
 # the model calls tools).
+#
+# Do NOT set ``stream`` here. Reyn owns that decision — it asks litellm whether
+# the model can stream and then either streams and reconstructs the reply, or
+# collects it whole. A ``stream: true`` in the entry is forwarded into the
+# collect-whole branch, so litellm hands back a stream object that reyn reads as
+# a finished reply and finds empty:
+#
+#   EmptyLLMResponseError: LLM returned a 200 response with empty choices
+#   (model=...); provider response: <...CustomStreamWrapper object...>
+#
+# The key does not enable streaming — it only produces that error.
 # -----------------------------------------------------------------------------
 # models:
 #   light:    openai/gpt-4o-mini


### PR DESCRIPTION
**[tui-coder]** — Owner ran into two failures in a row configuring a model too new for litellm, and asked that the working config be reachable from `reyn.local.yaml.example` — the example only showed the string form of a `models:` entry, so there was no path from it to the mapping form, and therefore none to the litellm passthrough.

## What the example now covers

1. **The mapping form itself**, with a pointer to the field table in `docs/reference/config/reyn-yaml.md`.
2. **`allowed_openai_params` as the escape hatch for an unrecognised model.** litellm fetches its model catalog over the network at import and falls back to the copy bundled in the package when that fetch fails. A model too new for the bundled copy is then unknown, and litellm rejects parameters it would otherwise allow — so the same config works on one run and fails on the next.
3. **`stream` must not be set.** Reyn owns that decision; its collect-whole branch forwards `**call_kwargs` verbatim, so an operator `stream: true` reaches litellm and the returned stream object is read as a finished reply.

Also adds `api_base` / `provider` rows to `reyn-yaml.md`'s field table — the example now names them as the exceptions to the passthrough, and a reader following that pointer would not have found them.

## Evidence

Both traps are observed, not theorised.

- **Trap 2** reproduced by forcing the fallback catalog (`LITELLM_LOCAL_MODEL_COST_MAP=True`), which raises the same `UnsupportedParamsError` the example quotes; with `allowed_openai_params` named, the same call validates. The bundled catalog contains 0 entries for the model in question, the remote one does.
- **Trap 3** came from a live run: `EmptyLLMResponseError ... provider response: <...CustomStreamWrapper object...>`, with `_streaming_capable` returning `False` for both call shapes (so the collect-whole branch is the one taken). Removing `stream` fixed the run — owner confirmed the reply and tool visibility came back.

Trap 3 is also a reyn defect: an operator `stream` key is neither rejected nor ignored, it silently breaks an unrelated-looking path. Filed separately; this PR only closes the documentation gap.

## Test plan

- [x] `ruff check src tests` — clean
- [x] The three suites that read `reyn.local.yaml.example` (`test_config_mirror_coverage_1056`, `test_reyn_local_example_benchmark_permissions`, `test_offload_unify_3580`) — 17 passed
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — built
- [x] Manual: stripped the comment markers from the new example block, parsed it as YAML and fed each entry to `ModelSpec.from_config` — all four resolve, and `allowed_openai_params` lands in `kwargs` (which `llm.py:2432` forwards to litellm). Verifies the example is usable as written, not just readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)