### PR TITLE
docs: repair four dead links in root markdown and gate the class

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ There is no `black` dependency — `ruff format` covers formatting.
 
 Reyn's OS is governed by eight invariants. Violations break the runtime and
 will not be merged. The full rationale is in
-[`docs/concepts/principles.md`](docs/concepts/principles.md). The
+[`docs/concepts/architecture/charter.md`](docs/concepts/architecture/charter.md). The
 hard rules:
 
 - **P1** Phase declares only `input_schema` and instructions. It must not

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Most agent frameworks optimize for reach. Reyn optimizes for the **integrity of 
 
 The trade-off is explicit: **predictability and auditability over maximum autonomy.** If you want the densest integration ecosystem and maximum LLM latitude, a connectivity-first agent or a workflow framework will feel less restrictive.
 
-> These guarantees are formalized as the OS's eight design principles — see [principles](docs/concepts/architecture/principles.md).
+> These guarantees are formalized as the OS's eight engineering lenses — see [charter](docs/concepts/architecture/charter.md).
 
 ---
 
@@ -156,7 +156,7 @@ flowchart LR
 - **Reached two ways** — *humans drive a session directly* (TUI / browser Web UI → `submit_user_text`), while *systems and schedules inject into an agent's inbox*: external connection (MCP server · A2A server · gateway webhooks like Slack / LINE) and internal trigger (`cron`). An *in-turn hook* layer can intercept a running turn (proposed). The HTTP surfaces — A2A, MCP-over-SSE, gateway webhooks, and the browser Web UI — are all served by the one `reyn web` (FastAPI) gateway. See [interaction layers](docs/concepts/architecture/interaction-layers.md).
 - **Related** — an `AgentRegistry` holds many *Agents* (each an identity), each with many parallel *Sessions*; agents delegate to peers under a *topology* (network / team / pipeline), hop-capped and `chain_id`-traced. See [multi-agent](docs/concepts/multi-agent/multi-agent.md) · [sessions](docs/concepts/multi-agent/sessions.md).
 
-Details: [architecture](docs/concepts/architecture/architecture.md) · [principles](docs/concepts/architecture/principles.md).
+Details: [architecture](docs/concepts/architecture/) · [charter](docs/concepts/architecture/charter.md).
 
 ---
 
@@ -197,10 +197,10 @@ Reyn connects too (MCP + A2A) and runs open-ended tasks, but optimizes for **int
 | Section | What's covered |
 |---|---|
 | [Getting started](docs/guide/getting-started/) | Install, chat mode, evals |
-| [For users](docs/guide/for-users/) | Day-to-day usage: permissions, sandbox, cost caps, scheduling, memory |
-| [For automation authors](docs/guide/for-skill-authors/) | Phases, composition, MCP, validation, operations |
+| [For users](docs/guide/for-users/) | Day-to-day usage: permissions, sandbox, cost caps, memory, MCP servers, writing a pipeline |
+| [For Reyn developers](docs/guide/for-reyn-developers/) | Adding an op kind, replay tests, principles in the code |
 | [Reference](docs/reference/) | CLI, config (`reyn.yaml`), Control IR, events |
-| [Concepts](docs/concepts/) | Architecture, principles, the act-sense-react loop |
+| [Concepts](docs/concepts/) | Architecture, the charter, the act-sense-react loop |
 | [Feature inventory](docs/feature-map.md) | Every implemented feature, grouped by subsystem |
 
 ```bash

--- a/tests/test_root_markdown_relative_links.py
+++ b/tests/test_root_markdown_relative_links.py
@@ -1,0 +1,77 @@
+"""Tier 1: contract — every relative link in a repo-ROOT markdown file points
+at a path that exists.
+
+The root ``README.md`` is not in ``.mkdocs/mkdocs.yml``'s nav, so
+``mkdocs build --strict`` — the gate that catches this class everywhere under
+``docs/`` — never renders it and never resolves its links. Nothing else did
+either: ``test_3126_doc_anchor_gate.py`` validates the ``#anchor`` half of a
+reference (does the heading slug exist), not the path half (does the file
+exist), and its scopes are ``src/reyn/`` comments and ``docs/`` internals.
+
+The uncovered gap was not hypothetical. Three README links were dead when this
+gate was written, the oldest for over a month:
+
+- ``docs/guide/for-skill-authors/`` — removed by #2493
+- ``docs/concepts/architecture/architecture.md`` — removed by #2447
+- ``docs/concepts/architecture/principles.md`` — removed by #2447
+
+Each was deleted by a purge PR that had no reason to look at the README, and
+no gate spanned the two. They surfaced only when an LLM read the README during
+a live session, followed the dead directory link, and built a plausible file
+path underneath it — so the failure reached a user as "the document does not
+exist" rather than as a broken link anyone had clicked.
+
+Scope is deliberately the root and only the root: everything under ``docs/``
+already has the mkdocs gate, and duplicating it here would mean two gates
+disagreeing about excluded paths.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# ``[text](target)`` — skip absolute URLs, mail links, and pure ``#anchor``
+# references (the latter are test_3126's scope, not this gate's).
+_LINK_RE = re.compile(r"\]\((?!https?://|mailto:|#)([^)\s]+)")
+
+
+def _root_markdown_files() -> "list[Path]":
+    """Enumerated from the live filesystem, never a curated list — a markdown
+    file added to the root is covered the moment it lands."""
+    return sorted(p for p in _REPO_ROOT.glob("*.md") if p.is_file())
+
+
+def test_root_markdown_files_are_actually_present() -> None:
+    """Tier 1: the gate has something to check.
+
+    A glob that silently matched nothing would make every assertion below
+    vacuously true — the shape this repo keeps finding in coverage gates.
+    """
+    names = {p.name for p in _root_markdown_files()}
+
+    assert "README.md" in names, (
+        f"README.md not found at the repo root; the gate is looking in the "
+        f"wrong place (found: {sorted(names)})"
+    )
+
+
+def test_every_relative_link_in_root_markdown_resolves() -> None:
+    """Tier 1: no root markdown file links to a path that does not exist."""
+    dead: "list[str]" = []
+
+    for md in _root_markdown_files():
+        text = md.read_text(encoding="utf-8")
+        for match in _LINK_RE.finditer(text):
+            target = match.group(1).split("#", 1)[0]
+            if not target:
+                continue  # was a bare "#anchor" with a trailing fragment
+            resolved = (md.parent / target).resolve()
+            if not resolved.exists():
+                line = text.count("\n", 0, match.start()) + 1
+                dead.append(f"{md.name}:{line} -> {target}")
+
+    assert not dead, "root markdown links pointing at paths that do not exist:\n" + "\n".join(
+        f"  {d}" for d in dead
+    )


### PR DESCRIPTION
**[tui-coder]** — Owner reported that reyn told them a `present` document could not be found. Tracing the session produced a defect that had been live for over a month.

## What happened

The model was asked about `present`, read `README.md`, and followed:

```
| [For automation authors](docs/guide/for-skill-authors/) | ... |
```

That directory was removed by #2493. The model then built a plausible reference path underneath it and read it, which failed:

```
reyn_repo: path 'docs/guide/for-skill-authors/references/output-present-and-self-review.md'
does not exist in the Reyn repository.
```

The document it wanted does exist — `src/reyn/builtin/skills/reyn-cheat-sheet/references/output-present-and-self-review.md`, readable via `reyn_repo_read`. Only the prefix was wrong, and the README supplied it.

## The four dead links

| File | Target | Removed by |
|---|---|---|
| `README.md` | `docs/guide/for-skill-authors/` | #2493 |
| `README.md` | `docs/concepts/architecture/architecture.md` | #2447 |
| `README.md` | `docs/concepts/architecture/principles.md` | #2447 |
| `CONTRIBUTING.md` | `docs/concepts/principles.md` | #2447 |

The architecture links now point at `charter.md`, which is where the eight lenses live. The "For automation authors" row is dropped rather than repointed: that content was purged, not moved, and the surviving material sits in `for-users/` (`write-a-pipeline.md`, `popular-mcp-servers.md`) — which the neighbouring row now names.

## Why no gate caught it

`mkdocs build --strict` resolves links for pages in its nav; the root README is not one of them. `test_3126_doc_anchor_gate.py` covers the `#anchor` half of a reference — does the heading slug exist — not the path half, and its scopes are `src/reyn/` comments and `docs/` internals. Nothing spanned "a purge PR deletes a page the README links to".

This adds that gate over root markdown, enumerated from the filesystem so a new root file is covered the moment it lands. It found the `CONTRIBUTING.md` one, which the manual sweep had not looked for.

## Not fixed here

`CONTRIBUTING.md`'s "Architectural rules (P1-P8)" section is left as-is. The constitution supersedes P1-P8 with the eight lenses plus the cross-cutting band (P5/P6/P7 survive demoted), so that section needs a content pass by someone who can say which of the eight hard rules still hold. Repairing its link while leaving the list unexamined is the honest stopping point; guessing at the list would be a different change wearing this one's clothes.

Separately: the agent history that fed this session still contains an absolute path to a skill directory renamed by #3588, and is replayed into context every turn. Filed as its own issue — a rename PR has no way to see that it poisoned every past conversation.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_root_markdown_relative_links.py` — 2 OK, 0 warnings, 0 errors
- [x] `python scripts/verify_module_docstrings.py tests/test_root_markdown_relative_links.py` — OK
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — built
- [x] New gate passes on the repaired tree (2 passed)
- [x] Positive control: appended `[probe](docs/definitely-not-here.md)` to README, gate fails naming `README.md:238 -> docs/definitely-not-here.md`; reverted, gate passes. Verifies it detects rather than merely passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)