### PR TITLE
fix(config): reject stream/stream_options on models: entries at load (#3627)

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -126,11 +126,38 @@ models:
 | `extra_body` | いいえ | プロバイダー固有のペイロード（例：推論モデルの `thinking`）。 |
 | `reasoning_effort` | いいえ | モデルの推論バジェット: `minimal` / `low` / `medium` / `high` / `disable` / `none`。**ロード時にバリデーション**（下記参照）。 |
 | `extends` | いいえ | 名前付きクラスから継承し、オーバーライドを deep merge（下記参照）。 |
+| `stream` / `stream_options` | いいえ | **設定不可。** ストリーミングするかどうかは reyn 自身が決めます（呼び出しごとの litellm capability query）。どちらのキーもモデル定義に書くと**ロード時に reject**されます（下記参照）。 |
 | *（その他のフィールド）* | いいえ | litellm にそのまま渡されます（パススルーポリシー）。 |
 
 > **コスト制限**: `max_tokens` ではなく `max_completion_tokens` を使用してください。`max_tokens` は多くのプロバイダーが無視するレガシーのソフトヒントです。`max_completion_tokens` は API レベルで強制されます（OpenAI o1+ および Anthropic モデル）。
 
-**フィールドポリシー**: `model` のみ必須です。ほとんどのフィールドはバリデーションなしで `litellm.acompletion` に直接渡されます（未知のフィールドも silent に転送されます — future-proof）。タイポは reyn エラーではなく silent な litellm 失敗を引き起こします。唯一の例外は `reasoning_effort` で、ロード時にバリデーションされます（下記）。
+**フィールドポリシー**: `model` のみ必須です。ほとんどのフィールドはバリデーションなしで `litellm.acompletion` に直接渡されます（未知のフィールドも silent に転送されます — future-proof）。タイポは reyn エラーではなく silent な litellm 失敗を引き起こします。ロード時にバリデーションされる例外は2つ: `reasoning_effort`（下記）と `stream` / `stream_options`（下記） — 後者は値チェックではなく**完全に reject**されます。
+
+### `stream` / `stream_options`（設定不可）
+
+ストリーミングするかどうかは reyn が決めます — 単一の completion 経路
+（`recorded_acompletion`）内で行われる、呼び出しごとの litellm capability
+query です。モデル定義側で `stream` あるいは `stream_options` を宣言しても
+ストリーミングは有効になりません（capability query が依然として決定します）
+— そのキーが kwargs のパススルーに乗って、query が選んだどちらかの分岐に
+届くだけです。非ストリーミング分岐では、これによって litellm がストリーム
+オブジェクトを返し、reyn がそれを完了した返答として読んでしまい、
+以下のように表面化していました:
+
+```
+EmptyLLMResponseError: LLM returned a 200 response with empty choices
+(model=...); provider response: <litellm...CustomStreamWrapper object...>
+```
+
+両キーとも litellm に届く前に**コンフィグロード時に reject**されます
+（`ValueError`、fail-fast）:
+
+```yaml
+models:
+  strong:
+    model: openai/gpt-5
+    stream: true   # ロード時に ValueError — このキーを削除してください
+```
 
 ### `reasoning_effort`（モデルごとの推論バジェット）
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -132,13 +132,39 @@ models:
 | `extends` | no | Inherit from a named class and deep-merge overrides (see below). |
 | `api_base` | no | Per-class endpoint override — a routing field, not forwarded as a litellm kwarg. |
 | `provider` | no | Per-class litellm `custom_llm_provider` — a routing field, not forwarded as a litellm kwarg. |
+| `stream` / `stream_options` | no | **Not settable.** Reyn owns the streaming decision itself (a per-call litellm capability query); either key on a model def is **rejected at load** — see below. |
 | *(any other field)* | no | Silently passed through to litellm (passthrough policy). |
 
 > **Cost limit**: use `max_completion_tokens`, not `max_tokens`.  `max_tokens` is a legacy
 > soft hint that many providers ignore; it has no enforcement power on OpenAI o1+ or
 > Anthropic models.  `max_completion_tokens` is enforced at the API level.
 
-**Field policy**: `model` is the only required field. Most other fields are passed directly to `litellm.acompletion` without validation — unknown fields are silently forwarded (future-proof); typos cause silent litellm failures, not reyn errors. The one exception is `reasoning_effort`, which is validated at load (below).
+**Field policy**: `model` is the only required field. Most other fields are passed directly to `litellm.acompletion` without validation — unknown fields are silently forwarded (future-proof); typos cause silent litellm failures, not reyn errors. Two exceptions are validated at load instead: `reasoning_effort` (below) and `stream` / `stream_options` (below), the latter **rejected outright** rather than merely value-checked.
+
+### `stream` / `stream_options` (not settable)
+
+Reyn decides whether a call streams — a per-call litellm capability query made
+inside the single completion funnel (`recorded_acompletion`), never a model-def
+setting. Declaring `stream` or `stream_options` on a model definition does
+**not** turn streaming on (the capability query still decides that); it only
+lets the key ride the kwargs passthrough into whichever branch the query
+picks. On the non-streaming branch this made litellm hand back a stream
+object that reyn read as a finished reply, surfacing as:
+
+```
+EmptyLLMResponseError: LLM returned a 200 response with empty choices
+(model=...); provider response: <litellm...CustomStreamWrapper object...>
+```
+
+Both keys are **rejected at config load** (`ValueError`, fail-fast) rather
+than reaching litellm:
+
+```yaml
+models:
+  strong:
+    model: openai/gpt-5
+    stream: true   # ValueError at load — remove this key
+```
 
 ### `reasoning_effort` (per-model reasoning budget)
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -74,16 +74,19 @@
 # passing it, silently changing behaviour (dropping ``tool_choice`` changes how
 # the model calls tools).
 #
-# Do NOT set ``stream`` here. Reyn owns that decision — it asks litellm whether
-# the model can stream and then either streams and reconstructs the reply, or
-# collects it whole. A ``stream: true`` in the entry is forwarded into the
-# collect-whole branch, so litellm hands back a stream object that reyn reads as
-# a finished reply and finds empty:
+# Do NOT set ``stream`` (or ``stream_options``) here. Reyn owns that decision —
+# it asks litellm whether the model can stream and then either streams and
+# reconstructs the reply, or collects it whole. Setting the key does NOT enable
+# streaming (the gate still decides that); it only reaches the wrong branch and
+# breaks it. This is rejected at config-load (#3627), so the entry fails fast
+# with a message naming the reason, rather than reaching litellm and surfacing
+# as an empty-response error mid-run:
 #
 #   EmptyLLMResponseError: LLM returned a 200 response with empty choices
 #   (model=...); provider response: <...CustomStreamWrapper object...>
 #
-# The key does not enable streaming — it only produces that error.
+# (a stream object read as a finished reply — the shape the load-time reject
+# now prevents rather than merely documents against).
 # -----------------------------------------------------------------------------
 # models:
 #   light:    openai/gpt-4o-mini

--- a/src/reyn/llm/model_resolver.py
+++ b/src/reyn/llm/model_resolver.py
@@ -76,6 +76,39 @@ class ModelSpec:
         # Placed here (not in from_config) so BOTH the plain-dict path and the
         # extends-merge path (which build ModelSpec directly) are covered
         # by-construction — single validation site, no parallel drift.
+        # #3627: reject an operator-declared ``stream`` (or ``stream_options``)
+        # at config-load. Reyn — not the operator — decides whether a call
+        # streams: `llm.py`'s single completion funnel makes that call
+        # per-request via a litellm capability query
+        # (`_streaming_capable`, inside `recorded_acompletion`) and
+        # deliberately sets no `stream` key of its own at the call site the
+        # operator's kwargs ride into. A `stream: true` here does NOT turn
+        # streaming on (the gate still decides that) — it rides
+        # `spec.kwargs` straight through to `litellm.acompletion` on
+        # whichever branch the gate picks. On the collect-whole branch
+        # (gate says no) that returns a `CustomStreamWrapper` instead of a
+        # completed response, which the branch then reads as one, surfacing
+        # as `EmptyLLMResponseError: LLM returned a 200 response with empty
+        # choices ...; provider response: <CustomStreamWrapper object ...>`
+        # — an error that names neither `stream` nor the config. Reject at
+        # load, before that shape can ever form.
+        if "stream" in self.kwargs or "stream_options" in self.kwargs:
+            _bad = [k for k in ("stream", "stream_options") if k in self.kwargs]
+            raise ValueError(
+                f"models {'/'.join(_bad)} must not be set (model={self.model!r}); "
+                "reyn decides whether a call streams for itself (a per-call "
+                "litellm capability query inside recorded_acompletion) — an "
+                "operator-set 'stream' does not turn streaming on, it only "
+                "rides through to litellm.acompletion on whichever branch "
+                "the gate picks. On the non-streaming branch this makes "
+                "litellm return a stream object that reyn then reads as a "
+                "finished reply, surfacing as "
+                "'EmptyLLMResponseError ... provider response: "
+                "<CustomStreamWrapper ...>'. Remove it from this model's "
+                "config; reyn will stream when it decides the model/call "
+                "shape supports it."
+            )
+
         effort = self.kwargs.get("reasoning_effort")
         if effort is None:
             return

--- a/tests/test_stream_key_rejected_at_config_load_3627.py
+++ b/tests/test_stream_key_rejected_at_config_load_3627.py
@@ -1,0 +1,108 @@
+"""#3627: an operator-declared ``stream`` (or ``stream_options``) on a
+``models:`` entry must fail at config-load, not ride the ``spec.kwargs``
+passthrough into ``litellm.acompletion``.
+
+Reyn owns the streaming decision (``llm.py``'s single completion funnel makes
+it per-call via a litellm capability query inside ``recorded_acompletion``);
+a settable ``stream`` key on a model def is INERT as an enable (the gate
+still decides) and ACTIVE as a break — on the collect-whole branch it makes
+litellm return a ``CustomStreamWrapper`` that the branch reads as a finished
+response, surfacing as ``EmptyLLMResponseError ... provider response:
+<CustomStreamWrapper object ...>`` (an error naming neither ``stream`` nor
+the config).
+
+Reachability note (owner decision, #3627 comment thread): ``ModelSpec.__post_init__``
+is the SINGLE construction-time validation site — every producer of a
+``ModelSpec`` with non-empty ``kwargs`` routes through it (``from_config``,
+the ``extends``-merge path, and every direct ``ModelSpec(...)`` call site in
+``llm.py`` / ``router_loop.py``, all of which pass either ``kwargs={}`` or a
+reyn-internal hardcoded dict that never contains ``stream``). Once this
+rejection lands, there is no remaining path that gets a ``stream`` key into
+``spec.kwargs`` reaching ``llm.py``'s collect-whole branch — so a SEPARATE
+strip immediately before ``**call_kwargs`` there would be a declared,
+implemented, tested branch that is never called (verification-hazards.md
+§15). This PR does not add that strip; see the PR body for the full
+enumeration.
+
+Tier: config-parse + load-time validation (fail-fast) = Tier 1 (the
+ModelSpec config contract, same class as #1650's reasoning_effort tests).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.llm.model_resolver import ModelResolver, ModelSpec
+
+# ── Tier 1: load-time rejection (fail-fast) ─────────────────────────────────
+
+
+def test_stream_key_rejected_at_construction():
+    """Tier 1: #3627 — ``stream`` on a model def fails at ModelSpec
+    construction (config-load), not mid-call inside litellm."""
+    with pytest.raises(ValueError, match="stream") as excinfo:
+        ModelSpec(model="openai/gpt-5.6-luna", kwargs={"stream": True})
+    msg = str(excinfo.value)
+    # Decision-enabling: names WHO decides (reyn, not the operator) and WHAT
+    # to do (remove it) — not just "invalid key".
+    assert "reyn decides" in msg
+    assert "model=" in msg and "gpt-5.6-luna" in msg
+
+
+def test_stream_options_key_also_rejected():
+    """Tier 1: #3627 — ``stream_options`` (the sibling litellm streaming
+    control) is rejected the same way as ``stream``."""
+    with pytest.raises(ValueError, match="stream_options"):
+        ModelSpec(model="openai/gpt-5.6-luna", kwargs={"stream_options": {"include_usage": True}})
+
+
+def test_stream_rejection_message_explains_the_failure_mode():
+    """Tier 1: #3627 — the message describes what goes wrong when the key is
+    set (a stream object read as a finished reply), matching the legibility
+    standard of the existing reasoning_effort deny messages in this file,
+    not a bare "invalid key"."""
+    with pytest.raises(ValueError) as excinfo:
+        ModelSpec(model="openai/gpt-5.6-luna", kwargs={"stream": True})
+    msg = str(excinfo.value)
+    assert "CustomStreamWrapper" in msg
+
+
+def test_stream_key_rejected_at_resolver_startup():
+    """Tier 1: #3627 — the fail-fast also fires through ModelResolver
+    startup (the path a real reyn.local.yaml `models:` entry takes),
+    naming the offending model."""
+    with pytest.raises(ValueError, match="gpt-5.6-luna"):
+        ModelResolver(
+            {"gpt-5.6-luna": {"model": "gpt-5.6-luna", "stream": True}}
+        )
+
+
+def test_stream_key_rejected_through_reyn_config_models_layer():
+    """Tier 1: #3627 — the rejection fires through ``ReynConfig.models`` ->
+    ``ModelResolver`` (the actual reyn.local.yaml `models:` load path), not
+    just via a hand-constructed ModelSpec/mapping."""
+    from reyn.config import ReynConfig
+
+    cfg = ReynConfig(models={
+        "gpt-5.6-luna": {"model": "gpt-5.6-luna", "stream": True},
+    })
+    with pytest.raises(ValueError, match="reyn decides"):
+        ModelResolver(cfg.models)
+
+
+def test_stream_key_rejected_through_extends_merge_path():
+    """Tier 1: #3627 — a `stream` introduced via an `extends` merge (the
+    OTHER ModelSpec producer besides `from_config`) is rejected too — single
+    validation site (`__post_init__`) covers both producers by construction."""
+    with pytest.raises(ValueError, match="reyn decides"):
+        ModelResolver({
+            "base": {"model": "openai/gpt-4o"},
+            "child": {"extends": "base", "stream": True},
+        })
+
+
+def test_no_stream_key_is_unaffected():
+    """Tier 1: #3627 — a model def without `stream`/`stream_options` is
+    unchanged (the validation is a no-op; the passthrough policy for other
+    kwargs, e.g. temperature, is intact)."""
+    spec = ModelSpec(model="openai/gpt-4o", kwargs={"temperature": 0.2})
+    assert spec.kwargs == {"temperature": 0.2}


### PR DESCRIPTION
**[per-PR-coder]** — Implements #3627 (owner decision: lead-coder's recommended ①+②, with ② conditional on reachability).

## The defect

`reyn.local.yaml`:
```yaml
models:
  gpt-5.6-luna:
    model: gpt-5.6-luna
    stream: true
```
rode `spec.kwargs` into the collect-whole branch of `llm.py`'s single completion funnel, so `litellm.acompletion` returned a `CustomStreamWrapper` that got read as a finished reply, surfacing as `EmptyLLMResponseError ... provider response: <CustomStreamWrapper object ...>` — an error naming neither `stream` nor the config.

## ① Reject at config load (implemented)

`ModelSpec.__post_init__` (`src/reyn/llm/model_resolver.py`) now rejects `stream` / `stream_options` on any `models:` entry with a `ValueError`. This is the single construction-time validation site already used for `reasoning_effort` (#1650) — it covers both `ModelSpec.from_config` (plain dict form) and the `extends`-merge path by construction, no parallel validation site.

**Rejection message** (decision-enabling, matching the shape of the existing `reasoning_effort` deny messages in the same file):
> `models stream must not be set (model='gpt-5.6-luna'); reyn decides whether a call streams for itself (a per-call litellm capability query inside recorded_acompletion) — an operator-set 'stream' does not turn streaming on, it only rides through to litellm.acompletion on whichever branch the gate picks. On the non-streaming branch this makes litellm return a stream object that reyn then reads as a finished reply, surfacing as 'EmptyLLMResponseError ... provider response: <CustomStreamWrapper ...>'. Remove it from this model's config; reyn will stream when it decides the model/call shape supports it.`

It says: who decides (reyn, not the operator), what to do (remove the key), and what breaks when it's set (the stream-object-read-as-reply failure mode) — not just "invalid key".

## ② Strip at the branch — reachability enumeration, NOT added

Before writing ②, enumerated every path that can put a key into `spec.kwargs`:

1. **Config load** (`reyn.yaml` / `reyn.local.yaml` `models:` → `ModelResolver.__init__` → `_resolve_entry` → `ModelSpec.from_config` **or** the `extends`-deep-merge branch) — both go through `ModelSpec.__post_init__`. Closed by ①.
2. **`BUILTIN_MODELS`** (reyn's own built-in catalog, `builtin_models.py`) — same `_resolve_entry`/`from_config` path, same `__post_init__`. Reyn's own entries never set `stream`; also closed by ①.
3. **Direct `ModelSpec(...)` construction in production code** — grepped every call site:
   - `model_resolver.py` (`from_config`, `resolve()` passthrough, `_resolve_entry`) — `kwargs={}` or the `extends`-merged dict, all validated.
   - `llm.py:2328` — `ModelSpec(model=model, kwargs={})`.
   - `router_loop.py:1700`, `:1843` — `kwargs={}`.
   - `router_loop.py:2674` — `kwargs={"max_tokens": int(_reserve)}` (reyn-internal, hardcoded, never operator-controlled, never `stream`).

   Every one of these is either empty or a reyn-internal hardcoded dict, and **all of them construct via `ModelSpec(...)`, which always runs `__post_init__`.**
4. **`dataclasses.replace`** — grepped; the only use in the runtime is on an unrelated dataclass (`resource_state` in `router_loop.py:3943`), not `ModelSpec`. `dataclasses.replace` on `ModelSpec` would re-run `__post_init__` anyway (it calls `__init__`), so even a hypothetical future use is still covered.

**Conclusion: no live path remains that reaches `llm.py`'s `spec_kwargs = dict(spec.kwargs)` (line 2355) / `**spec_kwargs` (line 2432) with a `stream` key, once ① is in place.** A strip immediately before `**call_kwargs` there would be a declared, implemented, tested branch that is never called on any production path — exactly the hazard `docs/deep-dives/contributing/verification-hazards.md` §15 describes (a field/implementation/test can all be "alive" while having zero production callers). **② is not added.** If a future PR adds a NEW `ModelSpec` producer that bypasses `__post_init__` (e.g. `object.__setattr__` on the frozen dataclass, or a raw dict handed straight to `litellm.acompletion` outside `ModelSpec`), that PR should re-open this question against its own new path — not retrofit a currently-dead strip.

## RED-on-break (self-falsification)

Reverted the `__post_init__` check (`git stash`) and re-ran the new test file:
```
6 failed, 1 passed in 0.55s
```
6/7 tests go RED (the 7th, `test_no_stream_key_is_unaffected`, is the no-op regression check and correctly stays green either way). Re-applied the fix (`git stash pop`) — all 7 pass again.

## Tests

`tests/test_stream_key_rejected_at_config_load_3627.py` (Tier 1, mirrors `test_reasoning_effort_config_1650.py`'s shape):
- construction-time rejection + message assertions (`"reyn decides"`, `"CustomStreamWrapper"`, offending model name) — real values asserted, not just "it raised"
- `stream_options` rejected the same way
- rejection through `ModelResolver` startup (the real `models:`-mapping load path)
- rejection through `ReynConfig.models` → `ModelResolver` (the actual `reyn.local.yaml` load path, not a hand-built mapping)
- rejection through the `extends`-merge producer (the OTHER `ModelSpec` producer besides `from_config`)
- no-op regression: a model def without `stream` is unaffected

No mocks — real `ModelSpec` / `ModelResolver` / `ReynConfig` instances throughout.

## Docs

- `reyn.local.yaml.example`: updated the existing `stream` comment (landed doc-only in #3626) — it now says the key is rejected at load, not merely discouraged, and rewords the failure-mode description accordingly.
- `docs/reference/config/reyn-yaml.md`: added a `stream` / `stream_options` row to the `models:` field table, updated the "Field policy" line (previously claimed unconditional passthrough for "any other field", now names the two load-validated exceptions), and added a `### stream / stream_options (not settable)` subsection mirroring the `reasoning_effort` subsection's shape.
- `docs/reference/config/reyn-yaml.ja.md`: same three edits in Japanese — its field table and field-policy line made the same now-false "any other field passes through silently" claim, so it needed the same fix (not a mirror obligation, fixing its own falsified claim per CLAUDE.md's doc-drift rule).

## Before-push gates (run in this worktree, foreground)

- `ruff check src/reyn/llm/model_resolver.py tests/test_stream_key_rejected_at_config_load_3627.py reyn.local.yaml.example` → clean
- `python scripts/test_tier_audit.py --strict tests/test_stream_key_rejected_at_config_load_3627.py` → 7/7 OK, 0 warnings, 0 errors
- `python scripts/verify_module_docstrings.py src/reyn/llm/model_resolver.py` → OK
- `python -m pytest tests/test_stream_key_rejected_at_config_load_3627.py tests/test_model_resolver.py tests/test_model_resolver_extends.py tests/test_reasoning_effort_config_1650.py -q` → 82 passed (targeted; full `pytest` left to CI per instructions)

## Test plan

- [x] A `models:` entry with `stream: true` fails at config load with a message naming who decides + what breaks (asserted, not just "it raised")
- [x] Broke the fix and confirmed RED (6/7 new tests fail on revert)
- [x] ② evaluated for reachability; not added — enumeration + reasoning above
- [x] ruff / tier-audit / docstring gates green locally

Closes #3627
