### PR TITLE
fix(runtime): stop double-persisting tool-turn text to history.jsonl

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -490,7 +490,15 @@ class RouterLoopCore(Protocol):
 
     def resolve_model(self, name: str) -> str: ...
     def make_router_op_context(self) -> Any: ...
-    async def put_outbox(self, *, kind: str, text: str, meta: dict) -> None: ...
+    # #3633: ``persist`` makes the kind=="agent" → history-append coupling an
+    # EXPLICIT per-call-site choice instead of an implicit blanket rule the
+    # host applies unconditionally. Defaults True (= the pre-#3633 behavior,
+    # unchanged for every existing caller); a call site whose text is already
+    # persisted by another path (e.g. router_loop's tool-turn display bubble,
+    # duplicated by ``feedback()``'s ``append_history_entry``) passes False.
+    async def put_outbox(
+        self, *, kind: str, text: str, meta: dict, persist: bool = True,
+    ) -> None: ...
 
 
 @runtime_checkable
@@ -630,8 +638,11 @@ class RouterLoopHost(RouterLoopCore, Protocol):
     async def spawn_session(self, *, request: str, mode: str,
                             narrowing: "dict | None", chain_id: str) -> dict: ...
 
-    async def put_outbox(self, *, kind: str, text: str,
-                         meta: dict) -> None: ...
+    # #3633: see RouterLoopCore.put_outbox above — ``persist`` is the same
+    # explicit per-call-site opt-out, inherited here (Protocol overlap).
+    async def put_outbox(
+        self, *, kind: str, text: str, meta: dict, persist: bool = True,
+    ) -> None: ...
 
     # E-full PR-E (issue #383): persist a single ChatMessage entry
     # without routing through the outbox (= no TUI display side-effect).
@@ -2106,16 +2117,30 @@ class RouterLoop:
                 # #1642: surface the assistant's TEXT content that accompanies tool_calls.
                 # The terminal text-reply path (below, ~line 2638) only fires for a
                 # no-tool_calls turn, so on a tool-turn the explanatory text was dropped
-                # from the conversation (it is still persisted to history). Emit it as an
-                # ``agent`` bubble BEFORE _run_execute_round so the text renders ahead of
-                # the tool rows (lifecycle_forwarder queues tool_call_started during the
-                # round). Skip empty (no empty bubble); no double-emit — the terminal path
-                # is no-tool_calls-only, and history persistence is unchanged.
+                # from the conversation. Emit it as an ``agent`` bubble BEFORE
+                # _run_execute_round so the text renders ahead of the tool rows
+                # (lifecycle_forwarder queues tool_call_started during the round). Skip
+                # empty (no empty bubble).
+                #
+                # #3633: this call is DISPLAY-ONLY — ``persist=False``. The prior
+                # comment here ("no double-emit ... history persistence is unchanged")
+                # was wrong: it only ruled out collision with the *different*
+                # no-tool_calls terminal path further down this file and missed that
+                # ``self._scheme.feedback()`` (called a few lines below, via
+                # ``format_feedback`` → ``append_history_entry``) independently
+                # persists this SAME text moments later as the canonical
+                # ``source="router_tool_turn"`` record — the one that also carries
+                # ``tool_calls``, so it is the complete turn. Without ``persist=False``
+                # RouterHostAdapter's unconditional ``kind=="agent"`` → append-to-
+                # history side effect wrote the identical string to history.jsonl
+                # twice (measured: 24/283 adjacent-duplicate assistant records in a
+                # real session, #3633).
                 _tool_turn_text = result.content or ""
                 if _tool_turn_text.strip():
                     await self.host.put_outbox(
                         kind="agent",
                         text=_tool_turn_text,
+                        persist=False,
                         # #1652: supply this turn's reasoning (host gates display/
                         # continuity + emits the discrete kind="reasoning" signal).
                         meta={

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -1470,7 +1470,9 @@ class RouterHostAdapter:
             name=name,
         ))
 
-    async def put_outbox(self, *, kind: str, text: str, meta: dict) -> None:
+    async def put_outbox(
+        self, *, kind: str, text: str, meta: dict, persist: bool = True,
+    ) -> None:
         from reyn.runtime.chat_message import ChatMessage, _now_iso
         from reyn.runtime.outbox import OutboxMessage
         # #1652: centralised reasoning handling for agent replies. The router
@@ -1519,7 +1521,18 @@ class RouterHostAdapter:
         # the canned text in history maintains alternation; the
         # cascading-attractor mitigation needs to live elsewhere
         # (= context build / classifier-side, tracked as follow-up).
-        if kind == "agent" and text:
+        #
+        # #3633: ``persist`` (default True) makes this append an EXPLICIT
+        # per-call-site choice rather than an implicit blanket rule. A caller
+        # whose text is already persisted through a different path (e.g.
+        # router_loop's tool-turn display bubble — the SAME text is persisted
+        # a few lines later as the canonical record by
+        # ``append_history_entry`` in ``RouterLoop.feedback()``, complete
+        # with ``tool_calls``) passes ``persist=False`` so the display-only
+        # outbox emit does not ALSO write to history.jsonl. Do not add a new
+        # unconditional persist path here without checking whether the text
+        # is already recorded elsewhere.
+        if kind == "agent" and text and persist:
             # Issue #383: chat history now uses ``role="assistant"`` +
             # ``content=`` (= wire shape mirror); the OutboxMessage above
             # keeps ``kind="agent"`` since that's the TUI-facing

--- a/tests/_support/router_loop.py
+++ b/tests/_support/router_loop.py
@@ -60,6 +60,13 @@ class FakeRouterHost:
 
         # Track calls
         self.outbox: list[dict] = []
+        # #3633: mirrors RouterHostAdapter's kind=="agent" → history-append
+        # side effect (gated by ``persist``, default True) so a router_loop
+        # test can assert on the actual persisted-history population, not
+        # just the outbox. ``append_history_entry`` mirrors the OTHER
+        # persist path (``RouterLoop.feedback()`` → ``append_history_entry``)
+        # so both producers of a #3633-shaped duplicate are exercised.
+        self.history: list[dict] = []
         self.skill_calls: list[dict] = []
         self.agent_sends: list[dict] = []
         self.spawn_calls: list[dict] = []
@@ -154,8 +161,34 @@ class FakeRouterHost:
                                   "narrowing": narrowing, "chain_id": chain_id})
         return {"status": "ok", "kind": "session_spawned", "mode": mode}
 
-    async def put_outbox(self, *, kind: str, text: str, meta: dict) -> None:
+    async def put_outbox(
+        self, *, kind: str, text: str, meta: dict, persist: bool = True,
+    ) -> None:
         self.outbox.append({"kind": kind, "text": text, "meta": meta})
+        # #3633: mirror RouterHostAdapter.put_outbox's persist side effect.
+        if kind == "agent" and text and persist:
+            self.history.append({
+                "role": "assistant", "content": text, "meta": meta,
+                "tool_calls": None,
+            })
+
+    def append_history_entry(
+        self,
+        *,
+        role: str,
+        content: Any,
+        meta: dict | None = None,
+        tool_calls: "list[dict] | None" = None,
+        tool_call_id: "str | None" = None,
+        name: "str | None" = None,
+    ) -> None:
+        """#3633: mirrors RouterHostAdapter.append_history_entry (issue #383)
+        — the no-outbox-side-effect persist path ``RouterLoop.feedback()``
+        uses for the canonical tool-call turn record."""
+        self.history.append({
+            "role": role, "content": content, "meta": meta or {},
+            "tool_calls": tool_calls,
+        })
 
     # --- File callbacks (the memory capability's, not the host's) ---
     #

--- a/tests/test_3633_history_double_append.py
+++ b/tests/test_3633_history_double_append.py
@@ -1,0 +1,222 @@
+"""Tier 3a / Tier 2: #3633 — a tool-turn's assistant TEXT must persist to
+history exactly once, not twice.
+
+Root cause: ``RouterLoop``'s Execute arm emits the tool-turn's accompanying
+text via ``host.put_outbox(kind="agent", text=..., source="router_tool_turn_text")``
+so it renders ahead of the tool-call rows (#1642). ``RouterHostAdapter.put_outbox``
+has a side effect: any ``kind=="agent"`` non-empty text is unconditionally
+appended to persistent history. A few lines later, ``RouterLoop.feedback()``
+(via the active scheme's ``format_feedback``) independently persists the SAME
+text as the canonical ``source="router_tool_turn"`` record (complete with
+``tool_calls``) through ``append_history_entry`` — a call path that does
+NOT go through the outbox and so was never gated by the first append. Net
+effect (measured in a real session, issue #3633): the identical assistant
+text landed in ``history.jsonl`` twice, 24/283 records in the sampled
+session.
+
+The fix threads an explicit ``persist: bool = True`` kwarg through
+``put_outbox`` (Protocol + ``RouterHostAdapter`` impl) and sets
+``persist=False`` at the ``router_tool_turn_text`` call site — the coupling
+between ``kind=="agent"`` and the history-append side effect is now an
+explicit per-call-site choice rather than an implicit blanket rule.
+
+Tier 3a test drives the real ``RouterLoop`` via the ``call_llm_tools``
+scripted-injection seam + ``FakeRouterHost`` (a real Fake — no mocks — now
+mirroring BOTH of RouterHostAdapter's persist paths: the ``put_outbox``
+side effect, gated by ``persist``, and ``append_history_entry``). Tier 2
+test drives the real ``RouterHostAdapter`` directly (no Fake) to pin the
+``persist=False`` contract at its source.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from tests._support.router_loop import (
+    FakeRouterHost,
+    make_loop,
+    text_result,
+)
+from tests._support.router_loop import (
+    ScriptedLLM as _ScriptedLLM,
+)
+
+_USAGE = TokenUsage(prompt_tokens=10, completion_tokens=5)
+
+
+def _text_and_tool(content: str) -> LLMToolCallResult:
+    return LLMToolCallResult(
+        content=content,
+        tool_calls=[
+            {
+                "id": "t1",
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "arguments": json.dumps({"path": "notes.txt"}),
+                },
+            }
+        ],
+        finish_reason="tool_calls",
+        usage=_USAGE,
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_turn_text_persists_to_history_exactly_once(monkeypatch):
+    """Tier 3a: a turn with content + tool_calls persists ``content`` to
+    history ONE time (the canonical ``router_tool_turn`` record with
+    ``tool_calls``), not twice (#3633 — pre-fix it was also persisted via
+    the display-only ``router_tool_turn_text`` outbox emit)."""
+    host = FakeRouterHost()
+    host._files["notes.txt"] = "file body"
+    loop = make_loop(host)
+    script = [
+        _text_and_tool("Let me run your skill first."),  # Execute turn
+        text_result("All done."),                        # terminal turn
+    ]
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _ScriptedLLM(script))
+    await loop.run("run my skill", [])
+
+    adjacent_dupes = _count_adjacent_exact_duplicates(host.history)
+    assert adjacent_dupes == 0, (
+        f"expected 0 adjacent exact-duplicate history entries, got "
+        f"{adjacent_dupes}: {host.history}"
+    )
+
+    matches = [
+        e for e in host.history
+        if e["role"] == "assistant" and e["content"] == "Let me run your skill first."
+    ]
+    # Tuple-unpack: raises ValueError if there isn't EXACTLY one match — a
+    # behavioural assertion (the surviving record's shape), not a length pin.
+    (surviving,) = matches
+    # The surviving record is the canonical one — it carries tool_calls.
+    assert surviving["tool_calls"], "surviving record must be the complete turn"
+
+    # The display bubble still renders (outbox unaffected by persist=False).
+    agent_outbox_texts = [m["text"] for m in host.outbox if m["kind"] == "agent"]
+    assert "Let me run your skill first." in agent_outbox_texts
+
+
+@pytest.mark.asyncio
+async def test_no_tool_calls_terminal_reply_still_persists(monkeypatch):
+    """Tier 3a: regression guard for the OTHER path #3633's wrong comment was
+    actually reasoning about — a plain no-tool_calls text reply (the common
+    case) must still persist to history exactly once. ``persist=False`` is
+    scoped to the tool-turn-with-text call site only."""
+    host = FakeRouterHost()
+    loop = make_loop(host)
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools", _ScriptedLLM([text_result("just text")])
+    )
+    await loop.run("hi", [])
+
+    matches = [e for e in host.history if e["content"] == "just text"]
+    (surviving,) = matches  # exactly one — ValueError otherwise
+    assert surviving["role"] == "assistant"
+
+
+def _count_adjacent_exact_duplicates(history: list[dict]) -> int:
+    """Count adjacent pairs with identical (role, content) — the shape
+    measured in #3633 (24/283 in the owner's real history.jsonl)."""
+    count = 0
+    for prev, cur in zip(history, history[1:]):
+        if prev["role"] == cur["role"] and prev["content"] == cur["content"]:
+            count += 1
+    return count
+
+
+# ── RouterHostAdapter.put_outbox persist=False contract ─────────────────
+
+
+def test_adapter_put_outbox_persist_false_skips_history_append(tmp_path):
+    """Tier 2: RouterHostAdapter.put_outbox with ``persist=False`` emits the
+    outbox message but does NOT append to history — the fix's load-bearing
+    contract, pinned directly against the real adapter (no Fake)."""
+    from reyn.core.events.events import EventLog
+    from reyn.llm.model_resolver import ModelResolver
+    from reyn.runtime.services import (
+        LiveSessionIdInputs,
+        McpGatewayInputs,
+        MemoryService,
+        PutOutboxInputs,
+        RouterHostAdapter,
+        SendToAgentInputs,
+    )
+    from tests._support.router_host_adapter import (
+        make_op_context_source,
+        null_file_delete,
+        null_file_read,
+        null_file_regen,
+        null_file_write,
+        null_mcp_call_tool,
+        null_send_to_agent,
+    )
+
+    outbox: list[dict] = []
+    history: list = []
+
+    async def _put_outbox(msg) -> None:
+        outbox.append({"kind": msg.kind, "text": msg.text})
+
+    def _append_history(msg) -> None:
+        history.append(msg)
+
+    events = EventLog(subscribers=[])
+    workspace = tmp_path / "agents" / "alpha"
+    adapter = RouterHostAdapter(
+        agent_name="alpha",
+        agent_role="role",
+        output_language=None,
+        op_context_source=make_op_context_source(events=events),
+        permission_resolver=None,
+        mcp_servers=None,
+        project_context="",
+        events=events,
+        resolver=ModelResolver({}),
+        memory=MemoryService(
+            agent_workspace_dir=workspace,
+            events=events,
+            file_write=null_file_write,
+            file_read=null_file_read,
+            file_delete=null_file_delete,
+            file_regenerate_index=null_file_regen,
+        ),
+        journal=None,
+        agent_registry=None,
+        agent_workspace_dir=workspace,
+        mcp_call_tool=null_mcp_call_tool,
+        mcp_gateway_inputs=McpGatewayInputs(
+            mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
+        ),
+        send_to_agent_inputs=SendToAgentInputs(
+            send_to_agent=null_send_to_agent, delegation_tracker=lambda: None,
+        ),
+        put_outbox_inputs=PutOutboxInputs(
+            put_outbox=_put_outbox, agent_replies_tracker=lambda: None,
+        ),
+        append_history=_append_history,
+        live_session_id_inputs=LiveSessionIdInputs(
+            session_id=None, live_session_id_fn=None,
+        ),
+    )
+
+    asyncio.run(adapter.put_outbox(
+        kind="agent", text="display only", meta={"chain_id": "c1"}, persist=False,
+    ))
+    assert [m["text"] for m in outbox] == ["display only"]
+    assert history == [], "persist=False must not append to history"
+
+    asyncio.run(adapter.put_outbox(
+        kind="agent", text="final reply", meta={"chain_id": "c1"},
+    ))
+    assert [m["text"] for m in outbox] == ["display only", "final reply"]
+    # Tuple-unpack: default persist=True must append EXACTLY the new entry —
+    # not zero (regression) and not a second copy of "display only".
+    (only_entry,) = history
+    assert only_entry.content == "final reply"

--- a/tests/test_chat_turn_completed_inline.py
+++ b/tests/test_chat_turn_completed_inline.py
@@ -152,7 +152,9 @@ class _FakeRouterHost:
     def resolve_model(self, name: str) -> str:
         return "fake-model"
 
-    async def put_outbox(self, *, kind: str, text: str, meta: dict) -> None:
+    async def put_outbox(
+        self, *, kind: str, text: str, meta: dict, persist: bool = True,
+    ) -> None:
         self.outbox.append({"kind": kind, "text": text, "meta": meta})
 
     async def reyn_repo_list(self, *, path: str) -> dict:

--- a/tests/test_codeact_coexistence_1593.py
+++ b/tests/test_codeact_coexistence_1593.py
@@ -97,7 +97,9 @@ class _FakeHost:
     def resolve_model(self, name: str) -> str:
         return "fake-model"
 
-    async def put_outbox(self, *, kind: str, text: str, meta: dict) -> None:
+    async def put_outbox(
+        self, *, kind: str, text: str, meta: dict, persist: bool = True,
+    ) -> None:
         self.outbox.append({"kind": kind, "text": text, "meta": meta})
 
     def append_history_entry(self, *, role: str, content: str, meta: dict, **kw) -> None:

--- a/tests/test_router_empty_response.py
+++ b/tests/test_router_empty_response.py
@@ -111,7 +111,9 @@ class FakeRouterHost:
     async def send_to_agent(self, *, to: str, request: str, depth: int, chain_id: str) -> None:
         pass
 
-    async def put_outbox(self, *, kind: str, text: str, meta: dict) -> None:
+    async def put_outbox(
+        self, *, kind: str, text: str, meta: dict, persist: bool = True,
+    ) -> None:
         self.outbox.append({"kind": kind, "text": text, "meta": meta})
 
     async def file_read(self, path: str) -> str:

--- a/tests/test_router_loop_non_interactive_live_1443.py
+++ b/tests/test_router_loop_non_interactive_live_1443.py
@@ -106,7 +106,9 @@ class _FakeRouterHost:
     def resolve_model(self, name: str) -> str:
         return "fake-model"
 
-    async def put_outbox(self, *, kind: str, text: str, meta: dict) -> None:
+    async def put_outbox(
+        self, *, kind: str, text: str, meta: dict, persist: bool = True,
+    ) -> None:
         self.outbox.append({"kind": kind, "text": text, "meta": meta})
 
 

--- a/tests/test_router_loop_routing_decided.py
+++ b/tests/test_router_loop_routing_decided.py
@@ -155,7 +155,9 @@ class _FakeRouterHost:
     def resolve_model(self, name: str) -> str:
         return "fake-model"
 
-    async def put_outbox(self, *, kind: str, text: str, meta: dict) -> None:
+    async def put_outbox(
+        self, *, kind: str, text: str, meta: dict, persist: bool = True,
+    ) -> None:
         self.outbox.append({"kind": kind, "text": text, "meta": meta})
 
     async def reyn_repo_list(self, *, path: str) -> dict:

--- a/tests/test_router_loop_tool_turn_persistence.py
+++ b/tests/test_router_loop_tool_turn_persistence.py
@@ -135,11 +135,16 @@ def test_router_loop_call_site_uses_getattr_guard_for_legacy_hosts(monkeypatch):
     test fakes pre-dating PR-E), the router_loop call site silently
     no-ops instead of crashing — keeps the protocol additive.
     """
-    # The defensive-guard pattern itself is unit-tested by the
-    # broader test_router_loop_*.py suite which uses FakeRouterHost
-    # lacking the new method. Here we pin the contract textually:
-    # the router_loop source uses ``getattr(host, "append_history_entry", None)``
-    # so any host without the method is silently bypassed.
+    # #3633: FakeRouterHost now implements ``append_history_entry`` (it
+    # mirrors RouterHostAdapter's persist side effects so a router_loop test
+    # can assert on the persisted-history population — see
+    # tests/_support/router_loop.py), so the runtime guard is no longer
+    # exercised by "a host lacking the method" in this suite. It still
+    # matters for any narrower RouterLoopCore-only host (see the Protocol
+    # split docstring in router_loop.py), so we keep pinning the contract
+    # textually here: the router_loop source uses
+    # ``getattr(host, "append_history_entry", None)`` so any host without
+    # the method is silently bypassed.
     import inspect
 
     from reyn.runtime import router_loop

--- a/tests/test_session_cost_accumulation.py
+++ b/tests/test_session_cost_accumulation.py
@@ -112,7 +112,7 @@ class _FakeHost:
     async def send_to_agent(self, *, to, request, depth, chain_id) -> None:
         pass
 
-    async def put_outbox(self, *, kind, text, meta) -> None:
+    async def put_outbox(self, *, kind, text, meta, persist: bool = True) -> None:
         self.outbox.append({"kind": kind, "text": text, "meta": meta})
 
     async def file_read(self, path: str) -> str:


### PR DESCRIPTION
**[per-PR-coder]** — implements #3633.

## Root cause (confirmed)

`RouterHostAdapter.put_outbox` (`src/reyn/runtime/services/router_host_adapter.py:1473`) has a side effect: any `kind=="agent"` non-empty text is **unconditionally** appended to persistent history. `RouterLoop`'s Execute arm emits the tool-turn's accompanying text through this exact call (`src/reyn/runtime/router_loop.py:2140`, `source="router_tool_turn_text"`) purely so it renders ahead of the tool-call rows — it relied on the side effect for persistence. A few lines later, `RouterLoop.feedback()` (via the active scheme's `format_feedback`) **independently** persists the SAME text again as the canonical `source="router_tool_turn"` record (complete with `tool_calls`, via `append_history_entry` — a call path the outbox side effect never accounted for). Net effect: the identical assistant text landed in `history.jsonl` twice — **measured 24/283 adjacent-duplicate assistant records** in the owner's real session, all `router_tool_turn_text` → `router_tool_turn`.

The pre-existing comment at `router_loop.py:2112-2113` ("no double-emit — the terminal path is no-tool_calls-only, and history persistence is unchanged") was wrong: it only ruled out collision with the *different* no-tool_calls terminal-reply path further down the file, and missed `feedback()`'s independent append entirely. **Fixed in this PR** (comment rewritten with the correct reasoning + the #3633 pointer).

## Enumeration (per the issue's condition)

**1. Every `host.put_outbox(kind="agent")` caller in `router_loop.py`, and whether history persistence is intended:**

| call site (line) | `source` | persist intended? | decision |
|---|---|---|---|
| 2140 | `router_tool_turn_text` | **NO** — duplicated by `feedback()`'s `router_tool_turn` a few lines later | `persist=False` (the fix) |
| 2234 | `agent_spawn_ack` | yes — unique text, no other append | unchanged (`persist=True` default) |
| 2344 | `router_empty_response` | yes — unique | unchanged |
| 2376 | (structured-answer final reply) | yes — unique, no tool_calls | unchanged |
| 2382 | (plain terminal reply, no tool_calls) | yes — unique; this is the path the old wrong comment was actually about | unchanged |
| 2464 | (limit-denied wrap-up) | yes — unique | unchanged |

(`self.host` here is exclusively `RouterHostAdapter` in production — it's the sole implementor of the `RouterLoopHost` Protocol; `session.py`'s own `_put_outbox` is a different, lower-level primitive RouterHostAdapter delegates to for the raw outbox message, with no history-append side effect of its own — so callers outside `router_loop.py` are a different mechanism, not in scope here.)

**2. Whether the other two duplicate populations lead-coder measured share this cause:**

```
24  role=assistant  router_tool_turn_text -> router_tool_turn   ← THIS issue, fixed here
 2  role=user       (no meta.source)                             ← investigated, NOT this cause
 1  role=system     config_watcher -> config_watcher (same wal_seq, 68ms apart)  ← investigated, NOT this cause
```

Investigated via static read (see **#3636**, filed with the full investigation): population 1's candidate call sites (`session.py:5832` plain-submit vs `intervention_handler.py:325` HITL-answer) are mutually exclusive via an explicit early-return (`session.py:5790`) — not a structural double-append like #3633's. Population 2's `wal_seq` match doesn't prove a double-emit (`wal_seq` is a WAL-position snapshot, not a unique event id — `session.py:2637-2638`), and the `config_reloaded` emit sites are XOR-gated / reentrant-guarded (`hot_reload.py:236,304,359`). Neither shares a call site, flag, or adapter with `put_outbox`/`feedback()`. **Filed as #3636** rather than left unrecorded, since both root causes need runtime tracing (not resolvable from static reading alone) and are out of this PR's scope.

**3. (a) vs (b):** chose **(b)** — removed the implicit side effect by threading an explicit `persist: bool = True` kwarg through `put_outbox` (Protocol in `router_loop.py` + `RouterHostAdapter` impl), defaulting to the pre-fix behavior everywhere, with `persist=False` set explicitly at the one call site that needs it. This makes the `kind=="agent"` → history-append coupling a **per-call-site, visible choice** rather than an implicit blanket rule — closing the class (any future display-only `put_outbox(kind="agent")` call site must now explicitly opt out, instead of silently inheriting an unconditional persist) rather than patching this one instance.

## What I am NOT claiming

This PR does **not** claim "the repetition is fixed." There is a separate, measured observation (repetition *inside* a single `agent_delta`) that history duplication cannot explain and that this fix cannot address. The only claim here is: **adjacent duplicate records in `history.jsonl` are gone** for the measured shape.

## Verification

- **Post-fix duplicate count**: `tests/test_3633_history_double_append.py::test_tool_turn_text_persists_to_history_exactly_once` drives the real `RouterLoop` through a text+tool_calls turn via `FakeRouterHost` (now mirroring BOTH of `RouterHostAdapter`'s persist paths — the `put_outbox` side effect gated by `persist`, and `append_history_entry`) and asserts **0** adjacent exact-duplicate history entries (helper `_count_adjacent_exact_duplicates`), plus that the tool-turn text appears exactly once (tuple-unpack, not a `len()` pin) and the surviving record carries `tool_calls` (i.e. it's the canonical one).
- **RED-on-break, measured**: reverted `persist=False` → `persist=True` at the call site and re-ran the test — it failed with `expected 0 adjacent exact-duplicate history entries, got 1`, reproducing the exact `router_tool_turn_text` → `router_tool_turn` adjacent pair from the issue. Reverted back to green before pushing.
- **No-tool_calls terminal-reply regression guard**: `test_no_tool_calls_terminal_reply_still_persists` pins that the ordinary final-text-reply path (the one the OLD wrong comment was actually reasoning about) still persists exactly once — `persist=False` is scoped to the tool-turn-with-text site only.
- **`RouterHostAdapter.put_outbox` contract, pinned directly (no Fake)**: `test_adapter_put_outbox_persist_false_skips_history_append` constructs a real `RouterHostAdapter` and asserts `persist=False` emits the outbox message but skips the history-append callback, while default `persist=True` still appends (no regression).
- **Consumer sweep**: every test-double `put_outbox` implementation across `tests/` (6 files besides `tests/_support/router_loop.py`) updated to accept the new `persist` kwarg (all keep the pre-fix default behavior — the router now passes `persist=False` for exactly one call site, and none of these test doubles model history persistence themselves except `FakeRouterHost`, which now does).
- All four CI gates run locally and green: `ruff check src tests`; `python scripts/test_tier_audit.py --strict <changed test files>`; `python scripts/verify_module_docstrings.py src/reyn/runtime/router_loop.py src/reyn/runtime/services/router_host_adapter.py`; targeted `pytest` runs on every changed/related test file (126 passed, 0 failed — the one pre-existing failure in `test_textual_chat_streaming_visibility_3283.py` reproduces identically on `origin/main` with my changes stashed, confirmed unrelated — a Textual `FlowView` library-upgrade issue).
- No tool schema or router tool-roster change in this PR (only a `put_outbox` kwarg + history-append gating), so replay fixtures are not affected — not exercised as part of this fix.

## Doc drift

No normative doc (control-ir.md, events.md, etc.) describes this mechanism — only journal/dogfood entries reference the surrounding behavior informally. The one stale in-repo comment (`router_loop.py:2112-2113`) is fixed in this PR, and a second comment in `tests/test_router_loop_tool_turn_persistence.py` (which claimed the broader test suite exercises `router_loop`'s `append_history_entry` getattr-guard via "FakeRouterHost lacking the new method") is also corrected, since `FakeRouterHost` now implements `append_history_entry` as part of this fix's Fake-fidelity improvement.

## Follow-up filed

**#3636** — the `role=user` (2 adjacent dupes) and `role=system`/`config_watcher` (1 pair, same `wal_seq`) populations, confirmed structurally separate from this bug, with the investigation record (candidate call/emit sites, what was ruled out, what still needs runtime tracing).

## Test plan

- [x] `ruff check src tests` — green
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — green (0 Tier-4 violations)
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — green
- [x] Targeted `pytest` on all changed/related test files — 126 passed
- [x] Post-fix adjacent-duplicate count measured as 0 (not a claim)
- [x] Break-the-fix RED measurement done and reported above
- [x] Two other duplicate populations investigated; confirmed separate mechanism; filed as #3636
- [x] `part of` enumeration: no other open PR references #3633 (`gh pr list --search "3633 in:body"` empty at branch-off and again before opening this PR)

Closes #3633