### PR TITLE
fix: separate streaming capability from the enable decision, and let a model class set it

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -132,39 +132,61 @@ models:
 | `extends` | no | Inherit from a named class and deep-merge overrides (see below). |
 | `api_base` | no | Per-class endpoint override — a routing field, not forwarded as a litellm kwarg. |
 | `provider` | no | Per-class litellm `custom_llm_provider` — a routing field, not forwarded as a litellm kwarg. |
-| `stream` / `stream_options` | no | **Not settable.** Reyn owns the streaming decision itself (a per-call litellm capability query); either key on a model def is **rejected at load** — see below. |
+| `stream` | no | Whether calls for this class stream. A **reyn** field, not forwarded to litellm; overrides the capability query in both directions. Omit to let reyn decide — see below. |
+| `stream_options` | no | **Not settable.** No reyn meaning, and it breaks the collect-whole branch — **rejected at load**. |
 | *(any other field)* | no | Silently passed through to litellm (passthrough policy). |
 
 > **Cost limit**: use `max_completion_tokens`, not `max_tokens`.  `max_tokens` is a legacy
 > soft hint that many providers ignore; it has no enforcement power on OpenAI o1+ or
 > Anthropic models.  `max_completion_tokens` is enforced at the API level.
 
-**Field policy**: `model` is the only required field. Most other fields are passed directly to `litellm.acompletion` without validation — unknown fields are silently forwarded (future-proof); typos cause silent litellm failures, not reyn errors. Two exceptions are validated at load instead: `reasoning_effort` (below) and `stream` / `stream_options` (below), the latter **rejected outright** rather than merely value-checked.
+**Field policy**: `model` is the only required field. Most other fields are passed directly to `litellm.acompletion` without validation — unknown fields are silently forwarded (future-proof); typos cause silent litellm failures, not reyn errors. Three exceptions are handled at load instead: `reasoning_effort` (below), `stream` (consumed by reyn, type-checked), and `stream_options` (**rejected outright**).
 
-### `stream` / `stream_options` (not settable)
+### `stream` — whether this class's calls stream
 
-Reyn decides whether a call streams — a per-call litellm capability query made
-inside the single completion funnel (`recorded_acompletion`), never a model-def
-setting. Declaring `stream` or `stream_options` on a model definition does
-**not** turn streaming on (the capability query still decides that); it only
-lets the key ride the kwargs passthrough into whichever branch the query
-picks. On the non-streaming branch this made litellm hand back a stream
-object that reyn read as a finished reply, surfacing as:
+Reyn decides this per call, from a litellm capability query inside the single
+completion funnel (`recorded_acompletion`). `stream:` is the operator's answer,
+and it **wins over the query in both directions**:
+
+```yaml
+models:
+  my-new-model:
+    model: some-model-too-new-for-litellm
+    stream: true      # stream, whatever the catalog says
+  picky-endpoint:
+    model: openai/gpt-5
+    stream: false     # never stream, even though the catalog allows it
+```
+
+Omit the field to leave the decision to reyn. That is the right default; set it
+when you know something the catalog does not.
+
+You often will. Reyn pins litellm's model table to the snapshot bundled with the
+installed package (`LITELLM_LOCAL_MODEL_COST_MAP`, set in `reyn/__init__.py` to
+silence a startup network fetch), so a model newer than that snapshot is absent
+from it — permanently, not intermittently. An absent row is not a statement that
+the model cannot stream, and reyn no longer reads it as one; but where the
+catalog is actively wrong, this field is how you say so.
+
+This is a **reyn** field: it is consumed by the streaming decision and never
+forwarded to `litellm.acompletion`. That distinction is load-bearing — as an
+ordinary passthrough kwarg it reached the collect-whole branch and made litellm
+return a stream object that reyn read as a finished reply, surfacing as an error
+naming neither `stream` nor the config:
 
 ```
 EmptyLLMResponseError: LLM returned a 200 response with empty choices
 (model=...); provider response: <litellm...CustomStreamWrapper object...>
 ```
 
-Both keys are **rejected at config load** (`ValueError`, fail-fast) rather
-than reaching litellm:
+A non-boolean value is rejected at load. Unlike the forwarded fields, a typo
+here would otherwise never reach anything that could complain about it.
 
-```yaml
-models:
-  strong:
-    model: openai/gpt-5
-    stream: true   # ValueError at load — remove this key
-```
+### `stream_options` (not settable)
+
+Rejected at config load (`ValueError`, fail-fast). It has no reyn meaning, and
+riding the kwargs passthrough it produces the same broken shape described
+above.
 
 ### `reasoning_effort` (per-model reasoning budget)
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -74,19 +74,25 @@
 # passing it, silently changing behaviour (dropping ``tool_choice`` changes how
 # the model calls tools).
 #
-# Do NOT set ``stream`` (or ``stream_options``) here. Reyn owns that decision —
-# it asks litellm whether the model can stream and then either streams and
-# reconstructs the reply, or collects it whole. Setting the key does NOT enable
-# streaming (the gate still decides that); it only reaches the wrong branch and
-# breaks it. This is rejected at config-load (#3627), so the entry fails fast
-# with a message naming the reason, rather than reaching litellm and surfacing
-# as an empty-response error mid-run:
+# ``stream`` is the exception to the passthrough: it is a REYN field, consumed
+# by the streaming decision and never forwarded to litellm. Reyn normally
+# decides per call by asking litellm whether the model can stream; ``stream:``
+# is your answer and it wins in both directions — ``true`` streams whatever the
+# catalog says, ``false`` never streams. Omit it to leave the decision to reyn.
+#
+# You will need it more often than that sounds. Reyn pins litellm's model table
+# to the snapshot bundled with the installed package (to avoid a startup network
+# fetch), so a model newer than that snapshot is simply absent from it. Absence
+# is not a statement that the model cannot stream — reyn no longer treats it as
+# one — but where the table is actively wrong, this is how you say so.
+#
+# ``stream_options`` is still rejected at load: it has no reyn meaning, and as a
+# passthrough kwarg it reaches the collect-whole branch and makes litellm return
+# a stream object that reyn reads as a finished reply, surfacing as an error
+# naming neither the key nor the config:
 #
 #   EmptyLLMResponseError: LLM returned a 200 response with empty choices
 #   (model=...); provider response: <...CustomStreamWrapper object...>
-#
-# (a stream object read as a finished reply — the shape the load-time reject
-# now prevents rather than merely documents against).
 # -----------------------------------------------------------------------------
 # models:
 #   light:    openai/gpt-4o-mini
@@ -100,6 +106,7 @@
 #   my-new-model:
 #     model: some-model-too-new-for-litellm
 #     allowed_openai_params: ["tool_choice"]
+#     stream: true                     # reyn field — the catalog has no row to read
 
 
 # -----------------------------------------------------------------------------

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1663,7 +1663,7 @@ def _may_need_responses_endpoint(model: str) -> bool:
     Reuses the SAME derivation this repo's #3325 fix (and the now-deleted
     ``_requires_responses_bridge``) used: ``litellm.get_llm_provider``,
     queried WITHOUT an explicit ``custom_llm_provider`` (``None``) — the same
-    transport-independence discipline ``_streaming_capable`` documents.
+    transport-independence discipline ``_streaming_capability`` documents.
     reyn's proxy routing (``proxy_kwargs()``) forces
     ``custom_llm_provider="openai"`` on the wire for ALL models when an
     operator proxy is configured, so deriving "is this OpenAI/Azure?" from
@@ -1744,8 +1744,10 @@ def _emit_chat_cost_events(
 # ---------------------------------------------------------------------------
 
 
-def _streaming_capable(model: str, has_tools: bool) -> bool:
-    """Capability-gated streaming decision (#3288 ③a) — a litellm inline
+def _streaming_capability(model: str, has_tools: bool) -> "bool | None":
+    """What the CATALOG says this model can do — not whether a call streams.
+
+    A litellm inline
     capability query, mirroring the existing ``litellm.supports_response_schema``
     precedent (``router_loop.py``'s structured-output precheck). NEVER a
     hardcoded provider/model-name check (owner design principle) — this is
@@ -1773,13 +1775,43 @@ def _streaming_capable(model: str, has_tools: bool) -> bool:
     "no capability" for the very providers this feature targets. Capability
     is a property of the MODEL, not of the transport used to reach it.
 
-    Any lookup failure (unmapped model name, litellm internal error) is
-    caught and treated as "unknown" — returns False (whole-collect
-    fallback). Conservative by construction, never an optimistic guess.
+    **A model absent from litellm's catalog is UNKNOWN, not incapable.**
+    ``supports_native_streaming`` collapses those two into one ``False``: for a
+    model it finds, an unset ``supports_native_streaming`` field defaults to
+    ``True``, but a model it cannot find at all falls into its ``except`` and
+    returns ``False``. Reading that ``False`` as "cannot stream" makes catalog
+    membership decide a capability, and the two have no relation — one is a
+    property of the model, the other of how current the shipped table is.
+
+    Reyn makes that especially load-bearing: ``reyn/__init__.py`` sets
+    ``LITELLM_LOCAL_MODEL_COST_MAP`` by default to silence litellm's startup
+    network fetch, so the catalog is the copy BUNDLED with the installed
+    litellm. A model newer than that snapshot is therefore permanently absent,
+    not intermittently — every model too new for the pinned table would have
+    streamed only if the operator opted back into the remote fetch.
+
+    Asking for a whole response is not the safe direction either. A provider
+    that only ever streams (measured on a Codex-backed endpoint: SSE arrives
+    even when ``stream`` is not requested) must then have its stream folded
+    into one response by litellm's bridge — a translation nobody asked for,
+    and where the reply was observed to be lost entirely. "Conservative" has to
+    mean "do not assert what we did not measure", and an absent catalog row
+    measures nothing.
+
+    Returns ``None`` for "the catalog does not say" — a THIRD answer, not a
+    ``False``. Capability is what the model can do; whether a given call
+    streams is a policy question that reads this and decides. They were one
+    function, so an absent catalog row silently became a policy outcome;
+    :func:`_streaming_enabled` is where the decision lives now, and it is the
+    only thing call sites ask.
     """
     try:
         import litellm  # noqa: PLC0415
         from litellm.utils import supports_native_streaming  # noqa: PLC0415
+        try:
+            litellm.get_model_info(model=model, custom_llm_provider=None)
+        except Exception:  # noqa: BLE001 — absent from the catalog, nothing more
+            return None
         if not supports_native_streaming(model=model, custom_llm_provider=None):
             return False
         if has_tools and not litellm.supports_function_calling(
@@ -1787,8 +1819,48 @@ def _streaming_capable(model: str, has_tools: bool) -> bool:
         ):
             return False
         return True
-    except Exception:  # noqa: BLE001 — unknown capability → conservative fallback
-        return False
+    except Exception:  # noqa: BLE001 — could not ask; still not a "cannot"
+        return None
+
+
+def _streaming_enabled(
+    model: str, has_tools: bool, override: "bool | None" = None,
+) -> bool:
+    """Whether THIS call streams — the policy decision (#3288 ③a).
+
+    Reads :func:`_streaming_capability` and resolves its three answers:
+
+    - ``False`` — the catalog states the model cannot stream natively (the
+      reasoning-only endpoints that reject ``stream=True`` outright). Honoured:
+      it is a real statement about the model.
+    - ``True`` — stream.
+    - ``None`` — the catalog does not say. Stream.
+
+    ``None`` resolving to "stream" is the part that carries a reason. Absence
+    from the catalog is a fact about the shipped table, not about the model,
+    and reyn pins that table: ``reyn/__init__.py`` sets
+    ``LITELLM_LOCAL_MODEL_COST_MAP`` by default to silence litellm's startup
+    network fetch, so a model newer than the installed snapshot is absent on
+    every run, permanently.
+
+    Nor is "collect the whole response" the cautious direction. A provider that
+    only ever streams (measured on a Codex-backed endpoint: SSE arrives with no
+    ``stream`` in the request) then needs its stream folded into one response by
+    litellm's bridge — a translation nobody asked for, and where the reply was
+    observed to be dropped entirely. Declining to stream asserts just as much as
+    streaming does; it only looks safer.
+
+    ``override`` is the operator's answer, from a model class's ``stream:``
+    field, and it WINS over the catalog in both directions. An operator can
+    know something the shipped table does not — that is the ordinary case for
+    a model too new for it, and refusing their answer would leave them arguing
+    with a snapshot they cannot edit. A wrong override costs one provider
+    error; deferring to a stale table cost a silently dropped reply.
+    """
+    if override is not None:
+        return override
+    capability = _streaming_capability(model, has_tools)
+    return capability is not False
 
 
 async def recorded_acompletion(
@@ -1804,6 +1876,7 @@ async def recorded_acompletion(
     emit_cost_events: bool = False,  # #1683: chat path opts in (kernel emits via LLMCallRecorder)
     routing: dict | None = None,  # #309: per-class api_base/provider; None → global proxy_kwargs()
     on_content_delta: "Callable[[str], None] | None" = None,  # #3288 ③b: opt-in per-chunk content-delta callback (see _stream_and_reconstruct)
+    stream_override: "bool | None" = None,  # a model class's ``stream:`` — operator policy, NOT a litellm kwarg
 ) -> object:
     """Single cost-observability chokepoint for ALL ``litellm.acompletion`` calls (#1190).
 
@@ -1823,7 +1896,7 @@ async def recorded_acompletion(
     ``on_content_delta`` (#3288 ③b): an OPT-IN, per-call callback invoked
     SYNCHRONOUSLY with each non-empty content-delta string as ``_stream_and_reconstruct``
     (③a) drains the chunk stream — never invoked on the whole-collect (non-streaming)
-    path, so it is capability-gated by construction (see ``_streaming_capable``: no
+    path, so it is capability-gated by construction (see ``_streaming_enabled``: no
     capability ⇒ no streaming ⇒ this callback never fires). ``None`` (every caller
     except ``RouterLoop``'s primary reply call) is byte-identical to today. A raising
     callback is caught and logged — a broken display-event emit must never break the
@@ -2158,11 +2231,16 @@ async def recorded_acompletion(
         # #3288 ③a: capability-gated streaming loop, INSIDE the single #1190
         # funnel (the two ``litellm.acompletion`` call sites remain exactly
         # this one and the Router branch above — no second completion
-        # call-site was added). The decision is a litellm capability query
-        # (``_streaming_capable``), never a hardcoded provider check.
-        # Unknown/uncertain capability → the existing whole-collect call
-        # below (conservative fallback, byte-identical to pre-③a behavior).
-        _capable = _streaming_capable(effective_model, has_tools=bool(call_kwargs.get("tools")))
+        # call-site was added). The decision is ``_streaming_enabled`` — a
+        # policy over a litellm capability query, never a hardcoded provider
+        # check. A capability the catalog does not state is NOT read as
+        # "cannot": see ``_streaming_enabled`` for why whole-collect is not
+        # the cautious direction it looks like.
+        _capable = _streaming_enabled(
+            effective_model,
+            has_tools=bool(call_kwargs.get("tools")),
+            override=stream_override,
+        )
         # Permanent, one-line-per-call debug signal for the gate DECISION itself
         # (not just "streamed but the callback never fired" — the #3288 follow-up
         # gap: the gate silently deciding NOT to stream had no observable trace at
@@ -2304,7 +2382,7 @@ async def call_llm_tools(
       - thinking disabled (Gemini #17949 multi-turn parallel + thinking bug)
 
     Streaming (#3288 ③a) is decided per-call by ``recorded_acompletion`` via
-    a litellm capability query (see ``_streaming_capable``) — NOT forced off
+    a capability-informed policy (see ``_streaming_enabled``) — NOT forced off
     here. The historical Gemini streaming+tools bug (litellm#21041) is
     absorbed by that capability check, not by this function.
 
@@ -2479,6 +2557,7 @@ async def call_llm_tools(
             routing=_routing,  # #309 per-class api_base/provider (else global wins)
             response_format=response_format,  # 0062: None for every op-loop tool call
             on_content_delta=on_content_delta,  # #3288 ③b: forwarded straight through
+            stream_override=spec.stream,  # operator policy from the model class
         )
 
     # #2210 HIGH layer: when the per-call HTTP timeout + the Router/Reyn retries are ALL

--- a/src/reyn/llm/model_resolver.py
+++ b/src/reyn/llm/model_resolver.py
@@ -65,6 +65,13 @@ class ModelSpec:
     # for a direct provider). Both default None → inherit the global api_base.
     api_base: str | None = None
     provider: str | None = None  # litellm custom_llm_provider
+    # Whether calls for this class stream. A REYN field consumed by
+    # ``_streaming_enabled`` — never forwarded to litellm, which is the whole
+    # point: passed through as an ordinary kwarg it reaches the collect-whole
+    # branch and makes litellm return a stream object that reyn then reads as a
+    # finished reply (#3627). ``None`` = no operator opinion, decide from the
+    # catalog.
+    stream: bool | None = None
 
     def __post_init__(self) -> None:
         # #1650: validate the operator-declared ``reasoning_effort`` at
@@ -76,11 +83,17 @@ class ModelSpec:
         # Placed here (not in from_config) so BOTH the plain-dict path and the
         # extends-merge path (which build ModelSpec directly) are covered
         # by-construction — single validation site, no parallel drift.
-        # #3627: reject an operator-declared ``stream`` (or ``stream_options``)
-        # at config-load. Reyn — not the operator — decides whether a call
-        # streams: `llm.py`'s single completion funnel makes that call
+        # #3627, revised by #3639: ``stream`` on a model class is now a REYN
+        # field (see ``ModelSpec.stream``), consumed by ``_streaming_enabled``
+        # as the operator's answer — an operator who configured the endpoint
+        # can know what litellm's pinned snapshot does not. It never reaches
+        # ``kwargs``, so the passthrough this guard was written for has no path
+        # left; the guard stays as a construction-time backstop for anything
+        # that puts one there directly, and for ``stream_options``, which has
+        # no reyn meaning and breaks the same way. The original reasoning,
+        # still accurate for a kwargs-borne key: `llm.py`'s single completion funnel makes that call
         # per-request via a litellm capability query
-        # (`_streaming_capable`, inside `recorded_acompletion`) and
+        # (`_streaming_enabled`, inside `recorded_acompletion`) and
         # deliberately sets no `stream` key of its own at the call site the
         # operator's kwargs ride into. A `stream: true` here does NOT turn
         # streaming on (the gate still decides that) — it rides
@@ -187,11 +200,19 @@ class ModelSpec:
                 raise ValueError(
                     f"ModelSpec 'provider' must be a string, got {type(provider).__name__}"
                 )
+            stream = value.get("stream")
+            if stream is not None and not isinstance(stream, bool):
+                raise ValueError(
+                    f"ModelSpec 'stream' must be a boolean, got {type(stream).__name__}"
+                )
             kwargs = {
                 k: v for k, v in value.items()
-                if k not in ("model", "extends", "api_base", "provider")
+                if k not in ("model", "extends", "api_base", "provider", "stream")
             }
-            return cls(model=model, kwargs=kwargs, api_base=api_base, provider=provider)
+            return cls(
+                model=model, kwargs=kwargs, api_base=api_base,
+                provider=provider, stream=stream,
+            )
         raise ValueError(
             f"ModelSpec.from_config expects str or dict, got {type(value).__name__}"
         )

--- a/tests/test_llm_streaming_capability_driver_3288.py
+++ b/tests/test_llm_streaming_capability_driver_3288.py
@@ -1,12 +1,13 @@
 """Tier 1: Contract — #3288 ③a capability-is-driver gate.
 
-The streaming decision (``reyn.llm.llm._streaming_capable``) must be driven
+The streaming decision (``reyn.llm.llm._streaming_enabled``, over
+``_streaming_capability``) must be driven
 by a litellm inline capability query, NEVER a hardcoded provider/model-name
 check (owner design principle — no "Gemini doesn't stream" string literal).
 
 Two independent proofs:
 
-1. Structural: ``_streaming_capable``'s source contains no provider-name
+1. Structural: ``_streaming_capability``'s source contains no provider-name
    string literal (gemini/openai/anthropic/vertex/...) — a hardcoded branch
    would show up as a literal compared against ``model``.
 2. Behavioral strip: neuter the underlying litellm capability query (a real
@@ -23,7 +24,7 @@ import re
 import litellm
 import litellm.utils as litellm_utils
 
-from reyn.llm.llm import _streaming_capable
+from reyn.llm.llm import _streaming_capability, _streaming_enabled
 
 _PROVIDER_NAME_HINTS = (
     "gemini", "vertex", "openai", "anthropic", "claude", "bedrock", "azure",
@@ -31,15 +32,15 @@ _PROVIDER_NAME_HINTS = (
 
 
 def test_no_hardcoded_provider_name_in_capability_check() -> None:
-    """Tier 1: strip — ``_streaming_capable``'s source names no provider."""
-    src = inspect.getsource(_streaming_capable)
+    """Tier 1: strip — ``_streaming_capability``'s source names no provider."""
+    src = inspect.getsource(_streaming_capability)
     # Strip the docstring (prose may legitimately discuss "Gemini" as
     # historical context) — only the executable body must be hardcode-free.
     body = re.sub(r'""".*?"""', "", src, flags=re.DOTALL)
     lowered = body.lower()
     offenders = [name for name in _PROVIDER_NAME_HINTS if name in lowered]
     assert not offenders, (
-        f"_streaming_capable's executable body names provider(s) {offenders} — "
+        f"_streaming_capability's executable body names provider(s) {offenders} — "
         "the streaming decision must come from a litellm capability query, "
         "never a hardcoded provider/model-name check."
     )
@@ -53,13 +54,13 @@ def test_capability_query_drives_the_decision(monkeypatch) -> None:
     decides)."""
     # gpt-4o-mini genuinely supports native streaming per litellm's own data
     # — confirm the baseline is True before neutering.
-    assert _streaming_capable("gpt-4o-mini", has_tools=False) is True
+    assert _streaming_enabled("gpt-4o-mini", has_tools=False) is True
 
     def _always_false(model: str, custom_llm_provider=None) -> bool:  # noqa: ANN001
         return False
 
     monkeypatch.setattr(litellm_utils, "supports_native_streaming", _always_false)
-    assert _streaming_capable("gpt-4o-mini", has_tools=False) is False, (
+    assert _streaming_enabled("gpt-4o-mini", has_tools=False) is False, (
         "neutering the capability query to False must flip the decision to "
         "False — if it stays True, something other than the query is driving "
         "the branch (a hardcode)."
@@ -70,27 +71,51 @@ def test_capability_query_gates_tools_axis_too(monkeypatch) -> None:
     """Tier 1: the tools-present axis (supports_function_calling) is ALSO
     query-driven, not skipped/hardcoded. Neuter it to False and confirm a
     tools-bearing call is denied even though plain streaming is allowed."""
-    assert _streaming_capable("gpt-4o-mini", has_tools=True) is True
+    assert _streaming_enabled("gpt-4o-mini", has_tools=True) is True
 
     def _no_function_calling(model: str, custom_llm_provider=None) -> bool:  # noqa: ANN001
         return False
 
     monkeypatch.setattr(litellm, "supports_function_calling", _no_function_calling)
-    assert _streaming_capable("gpt-4o-mini", has_tools=True) is False
+    assert _streaming_enabled("gpt-4o-mini", has_tools=True) is False
     # Plain-text (no tools) is unaffected — the function-calling axis is only
     # consulted when tools are actually attached.
-    assert _streaming_capable("gpt-4o-mini", has_tools=False) is True
+    assert _streaming_enabled("gpt-4o-mini", has_tools=False) is True
 
 
-def test_unknown_model_is_conservative_fallback() -> None:
-    """Tier 1: an unmapped/unknown model → False (whole-collect fallback),
-    never an optimistic guess."""
-    assert _streaming_capable("totally-unknown-model-xyz-3288", has_tools=False) is False
-    assert _streaming_capable("totally-unknown-model-xyz-3288", has_tools=True) is False
+def test_an_unknown_model_reports_no_capability_rather_than_none() -> None:
+    """Tier 1: absent from the catalog is its OWN answer.
+
+    This assertion is inverted from what it pinned before, deliberately. It
+    read "an unmapped model → False (whole-collect fallback), never an
+    optimistic guess", which made catalog membership decide a capability —
+    two unrelated facts, one about the shipped table's age and one about the
+    model. ``supports_native_streaming`` conflates them (a model it cannot
+    find falls into its ``except`` and returns ``False``, while a model it
+    finds with the field unset defaults to ``True``), and reading that
+    ``False`` as "cannot" is what reyn was doing.
+
+    Reyn pins the table — ``reyn/__init__.py`` sets
+    ``LITELLM_LOCAL_MODEL_COST_MAP`` by default — so this was permanent for
+    any model newer than the installed snapshot, not occasional.
+    """
+    assert _streaming_capability("totally-unknown-model-xyz-3288", has_tools=False) is None
+    assert _streaming_capability("totally-unknown-model-xyz-3288", has_tools=True) is None
+
+
+def test_an_unknown_model_streams() -> None:
+    """Tier 1: the policy resolves "the catalog does not say" to streaming.
+
+    Separate from the assertion above because they are different claims: one
+    is what the catalog reports, the other is what reyn does about it. Fusing
+    them is the defect this pair exists to keep apart.
+    """
+    assert _streaming_enabled("totally-unknown-model-xyz-3288", has_tools=False) is True
+    assert _streaming_enabled("totally-unknown-model-xyz-3288", has_tools=True) is True
 
 
 def test_reasoning_only_endpoint_denied_streaming() -> None:
     """Tier 1: a real, non-hardcoded litellm capability fact — o1-pro's
     model-info map entry says supports_native_streaming=False (litellm's own
     data, not reyn's) — must deny streaming."""
-    assert _streaming_capable("o1-pro", has_tools=False) is False
+    assert _streaming_enabled("o1-pro", has_tools=False) is False

--- a/tests/test_llm_streaming_delta_emission_3288.py
+++ b/tests/test_llm_streaming_delta_emission_3288.py
@@ -256,7 +256,7 @@ def test_default_shaped_gemini_call_actually_enters_the_streaming_branch(monkeyp
     reasoning_effort attached, Gemini model — exactly what `RouterLoop`'s
     primary reply sends under reyn.yaml's default model classes) genuinely
     drives the streaming loop, witnessed via REAL chunk consumption
-    (`chunk_witness`), not merely that `_streaming_capable` returns True in
+    (`chunk_witness`), not merely that `_streaming_enabled` returns True in
     isolation (a terminal-state assertion that would pass even if this call
     never reached the streaming branch at all — see verification-hazards.md
     §10).
@@ -264,7 +264,7 @@ def test_default_shaped_gemini_call_actually_enters_the_streaming_branch(monkeyp
     Historical note (#3288 comment thread, #3325): before #3325, reyn's own
     `/v1/responses` bridge (#1678) had no provider check and fired for EVERY
     tools+reasoning_effort call, silently rewriting this exact Gemini call
-    to `responses/gemini-2.5-flash-lite`, which `_streaming_capable` could
+    to `responses/gemini-2.5-flash-lite`, which `_streaming_capability` could
     not recognize (unmapped in litellm's model map) — the default-config
     streaming regression this test guards against. #3325 fixed that with a
     provider gate; the #3288 follow-up investigation then deleted reyn's

--- a/tests/test_llm_tools.py
+++ b/tests/test_llm_tools.py
@@ -57,7 +57,7 @@ async def test_stream_is_capability_gated_not_forced_false(monkeypatch):
     """Tier 1: framework contract (#3288 ③a) — ``call_llm_tools`` no longer
     forces ``stream=False`` unconditionally (the pre-③a Gemini #21041
     workaround). The decision is now made INSIDE ``recorded_acompletion`` via
-    a litellm capability query (``_streaming_capable``): a genuinely
+    a capability-informed policy (``_streaming_enabled``): a genuinely
     streaming+function-calling-capable model (real litellm capability data,
     not a reyn hardcode) is called with ``stream=True``.
 

--- a/tests/test_model_class_stream_policy_3639.py
+++ b/tests/test_model_class_stream_policy_3639.py
@@ -1,0 +1,77 @@
+"""Tier 2: a model class can state whether its calls stream, and reyn obeys it.
+
+Whether a call streams was decided solely by litellm's catalog. That catalog is
+a snapshot pinned by ``reyn/__init__.py`` (``LITELLM_LOCAL_MODEL_COST_MAP``), so
+for any model newer than the installed litellm it says nothing — and reyn read
+"says nothing" as "cannot stream". The operator, who chose the model and knows
+the endpoint, had no way to say otherwise.
+
+``stream:`` on a model class is that way. It is a REYN field, consumed by
+``_streaming_enabled``, and deliberately NOT forwarded to litellm: passed
+through as an ordinary kwarg it lands in the collect-whole branch and makes
+litellm hand back a stream object that reyn reads as a finished reply (#3627).
+Keeping it out of ``kwargs`` is what makes that impossible rather than merely
+discouraged, so it is asserted here.
+"""
+from __future__ import annotations
+
+from reyn.llm.llm import _streaming_capability, _streaming_enabled
+from reyn.llm.model_resolver import ModelSpec
+
+_UNKNOWN = "totally-unknown-model-xyz-3639"
+_KNOWN_NON_STREAMING = "o1-pro"
+
+
+def test_stream_is_a_reyn_field_not_a_litellm_kwarg() -> None:
+    """Tier 2: ``stream`` reaches the spec and never the passthrough kwargs.
+
+    The sibling keys are checked in the same call so a change that started
+    forwarding everything verbatim would fail here rather than at a provider.
+    """
+    spec = ModelSpec.from_config(
+        {"model": "some-model", "stream": True, "temperature": 0.0}
+    )
+
+    assert spec.stream is True
+    assert spec.kwargs == {"temperature": 0.0}
+
+
+def test_an_absent_stream_field_leaves_the_decision_to_the_catalog() -> None:
+    """Tier 2: no operator opinion is distinct from an operator saying False."""
+    spec = ModelSpec.from_config({"model": "some-model"})
+
+    assert spec.stream is None
+    assert _streaming_enabled(_UNKNOWN, has_tools=False, override=spec.stream) is True
+
+
+def test_the_operator_can_turn_streaming_off_for_a_model_the_catalog_allows() -> None:
+    """Tier 2: the override wins downward."""
+    assert _streaming_capability("gpt-4o", has_tools=False) is True
+
+    assert _streaming_enabled("gpt-4o", has_tools=False, override=False) is False
+
+
+def test_the_operator_can_turn_streaming_on_for_a_model_the_catalog_denies() -> None:
+    """Tier 2: the override wins upward too — the direction that matters.
+
+    Downward-only would still leave an operator arguing with a snapshot they
+    cannot edit, which is the situation that produced the defect: a model too
+    new for the pinned table, with a working endpoint the operator had already
+    configured.
+    """
+    assert _streaming_capability(_KNOWN_NON_STREAMING, has_tools=False) is False
+
+    assert _streaming_enabled(_KNOWN_NON_STREAMING, has_tools=False, override=True) is True
+
+
+def test_a_non_boolean_stream_is_rejected_at_load() -> None:
+    """Tier 2: a typo fails where the operator can see it.
+
+    Most model-class fields are forwarded to litellm unvalidated, so a typo
+    surfaces as a provider error. This one is consumed by reyn, so nothing
+    downstream would complain — ``"true"`` would simply be truthy forever.
+    """
+    import pytest
+
+    with pytest.raises(ValueError, match="stream"):
+        ModelSpec.from_config({"model": "some-model", "stream": "true"})

--- a/tests/test_responses_api_routing_1678.py
+++ b/tests/test_responses_api_routing_1678.py
@@ -98,7 +98,7 @@ def test_gemini_combo_model_passed_through_unchanged(monkeypatch) -> None:
     (the exact default-config primary-reply shape) reaches
     `litellm.acompletion` with the model UNCHANGED. This was the #3288
     default-config streaming bug: reyn's own bridge used to rewrite this to
-    a `responses/`-prefixed string `_streaming_capable` could not recognize.
+    a `responses/`-prefixed string `_streaming_capability` could not recognize.
     Deletion removes the rewrite for EVERY model, not just Gemini, so this
     is now unconditionally true rather than provider-gated."""
     captured: dict = {}

--- a/tests/test_stream_key_rejected_at_config_load_3627.py
+++ b/tests/test_stream_key_rejected_at_config_load_3627.py
@@ -66,27 +66,45 @@ def test_stream_rejection_message_explains_the_failure_mode():
     assert "CustomStreamWrapper" in msg
 
 
-def test_stream_key_rejected_at_resolver_startup():
-    """Tier 1: #3627 — the fail-fast also fires through ModelResolver
-    startup (the path a real reyn.local.yaml `models:` entry takes),
-    naming the offending model."""
-    with pytest.raises(ValueError, match="gpt-5.6-luna"):
-        ModelResolver(
-            {"gpt-5.6-luna": {"model": "gpt-5.6-luna", "stream": True}}
-        )
+def test_a_model_class_stream_field_is_accepted_and_consumed():
+    """Tier 1: an operator-declared ``stream:`` loads, and does NOT reach kwargs.
+
+    This assertion is inverted from what #3627 pinned, by owner decision: an
+    operator who configured the endpoint can know things litellm's pinned
+    snapshot does not, so they get to state the answer. What #3627 was
+    protecting against — the key riding ``spec.kwargs`` into
+    ``litellm.acompletion`` — is closed more firmly than by rejecting it:
+    ``stream`` is a consumed ModelSpec field now, so there is no longer a
+    kwargs path for it to take. The construction-time rejection above still
+    stands for anything that puts one there directly.
+    """
+    resolver = ModelResolver(
+        {"gpt-5.6-luna": {"model": "gpt-5.6-luna", "stream": True}}
+    )
+    spec = resolver.resolve("gpt-5.6-luna")
+
+    assert spec.stream is True
+    assert "stream" not in spec.kwargs
 
 
-def test_stream_key_rejected_through_reyn_config_models_layer():
-    """Tier 1: #3627 — the rejection fires through ``ReynConfig.models`` ->
-    ``ModelResolver`` (the actual reyn.local.yaml `models:` load path), not
-    just via a hand-constructed ModelSpec/mapping."""
+def test_the_stream_field_survives_the_reyn_config_models_layer():
+    """Tier 1: it arrives through the real ``reyn.local.yaml`` load path.
+
+    Asserted through ``ReynConfig.models`` -> ``ModelResolver`` rather than a
+    hand-built mapping, because an operator writes YAML — a field that parsed
+    in isolation but was dropped by the config layer would look identical from
+    a unit test and do nothing in a real run.
+    """
     from reyn.config import ReynConfig
 
     cfg = ReynConfig(models={
         "gpt-5.6-luna": {"model": "gpt-5.6-luna", "stream": True},
     })
-    with pytest.raises(ValueError, match="reyn decides"):
-        ModelResolver(cfg.models)
+
+    spec = ModelResolver(cfg.models).resolve("gpt-5.6-luna")
+
+    assert spec.stream is True
+    assert "stream" not in spec.kwargs
 
 
 def test_stream_key_rejected_through_extends_merge_path():


### PR DESCRIPTION
**[tui-coder]** — From an owner live failure: talking to a model too new for litellm's bundled table failed with the reply **dropped entirely**. Revises #3627.

## The chain, and where it starts

```
litellm catalog has no row for the model
  -> supports_native_streaming returns False        (its except branch)
  -> reyn reads that as "cannot stream"             ★ starts here
  -> reyn requests a whole response
  -> but the provider streams regardless (measured: SSE with no `stream` in the request)
  -> litellm must fold that stream into one response
  -> its bridge returns the terminal frame's empty `output` -> reply lost
```

litellm's bridge defect and the upstream's spec violation are both real, but **reyn never had to enter that path.**

## Catalog membership was deciding a capability

`supports_native_streaming`'s `False` has two meanings: the catalog knows the model and says no, or it has never heard of it. A model it *finds* with the field unset defaults to **True** — so absence is treated more harshly than an explicit blank. Those are unrelated facts: one is a property of the model, the other of how current the shipped table is.

Reyn makes it permanent rather than occasional: `reyn/__init__.py` sets `LITELLM_LOCAL_MODEL_COST_MAP` by default to silence a startup network fetch, so the table is the snapshot bundled with the installed litellm and a newer model is absent **on every run**.

And "collect the whole response" is not the cautious direction it looks like — declining to stream asserts just as much as streaming does, and here it asserted wrongly at the cost of the entire reply.

## Two changes, because the first exposed they were one thing

**1. Capability and enablement are separate.** `_streaming_capability` answers `True` / `False` / `None` — `None` being "the catalog does not say". `_streaming_enabled` is the policy over it. Fused, an absent catalog row silently became a policy outcome, and there was nowhere for an operator answer to attach.

**2. A model class's `stream:` is that answer**, and it wins in both directions:

```yaml
models:
  my-new-model:
    model: some-model-too-new-for-litellm
    stream: true       # stream, whatever the catalog says
```

An operator who configured the endpoint can know what a pinned snapshot does not; refusing them leaves them arguing with a table they cannot edit. A wrong override costs one provider error — deferring to a stale table cost a silently dropped reply.

## Relation to #3627

#3627 rejected `stream` at load, correctly for what it was then: an inert-as-enable, active-as-break passthrough. What it guarded against is now closed **more firmly than by rejecting it** — `stream` is a consumed `ModelSpec` field, so no kwargs path exists for it to take. The construction-time guard stays as a backstop for anything that puts one in `kwargs` directly, and `stream_options` is still rejected outright: no reyn meaning, breaks the same way.

Two of #3627's assertions are inverted here, deliberately and by owner decision. Both rewritten in place with the reasoning, not deleted.

## Evidence

Measured against the owner's live endpoint, same model, same proxy:

| call | result |
|---|---|
| non-streaming | `Unknown items in responses API response: []` |
| **streaming** | **content arrives — `'2'`** |

The route is the only difference. Gate behaviour after the change:

| model | capability | enabled |
|---|---|---|
| `gpt-5.6-luna` (absent) | `None` | **True** (was False) |
| `gpt-4o` | `True` | True (unchanged) |
| `o1-pro`, `gpt-5-pro` | `False` | False (unchanged — a real statement is still honoured) |

## Test plan

- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` on all three touched test files — 0 warnings, 0 errors
- [x] `verify_module_docstrings.py` on the changed src + test files — OK
- [x] `mkdocs build --strict` — 0 errors
- [x] `pytest -k "stream or model_resolver or llm_tools or config_mirror or local_example"` — 209 passed
- [x] Falsification: reverting the gate turns the unknown-model assertions red while the known-model ones stay green
- [x] Manual: the example config's `models:` block stripped of comment markers, parsed, and fed to `ModelSpec.from_config` — `stream` lands on the spec, never in `kwargs`
- [ ] (skipped — needs the merge) End-to-end `reyn chat` against `gpt-5.6-luna`. The probes above cover the parts, not the whole — in particular a **tools-bearing** streaming call, which the router loop always makes, is not among them. The owner is verifying on their side after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)