### PR TITLE
refactor(tui): name every colour in one file, and gate it

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -53,6 +53,7 @@ from textual_flowview import (
     FlowView,
 )
 
+from reyn.interfaces.inline.textual_chat import palette
 from reyn.interfaces.repl._clipboard import (
     copy_to_clipboard,
     copy_to_clipboard_async,
@@ -651,7 +652,7 @@ class TextualChatApp(App):
         ("c", "copy_mode", "Copy mode (vim-style text cursor)"),
     ]
 
-    CSS = """
+    CSS = palette.css("""
     /* #3503: the app paints NO ground of its own — the terminal's background
        shows through. Measured before this: ``#inputrow`` / ``#inputgutter`` /
        ``SentQueue`` / ``MenuBar`` all declare ``transparent`` already, yet all
@@ -664,7 +665,7 @@ class TextualChatApp(App):
        rewind picker), and the presenter's deliberate ROW TINTS
        (``_CC_USER_BG`` / ``_CC_ERR_BG``) are unaffected — those are content,
        not ground. */
-    App { background: ansi_default; }
+    App { background: @app-background@; }
     Screen { layout: vertical; background: transparent; }
     FlowView {
         height: 1fr;
@@ -700,13 +701,13 @@ class TextualChatApp(App):
         height: auto;
         max-height: 8;
         margin-top: 1;
-        border-top: solid #3d434f;
-        border-bottom: solid #3d434f;
+        border-top: solid @rule@;
+        border-bottom: solid @rule@;
     }
     #inputgutter {
         width: 2;
         height: auto;
-        color: $text-muted;
+        color: @quiet@;
     }
     Composer {
         height: 3;
@@ -733,7 +734,7 @@ class TextualChatApp(App):
     }
     StatusLine {
         height: 1;
-        color: $text-muted;
+        color: @quiet@;
         padding: 0 1;
     }
     /* #3326: when StatusLine SHARES a row with Tab widgets (MenuBar._repack's
@@ -791,7 +792,7 @@ class TextualChatApp(App):
        kept bold so the active tab stays identifiable without the brightness
        jump. */
     MenuBar Tab.-active {
-        color: $text-muted;
+        color: @quiet@;
         text-style: bold;
     }
     /* No separator rule between the menu row and its drawer — they read as one
@@ -799,7 +800,7 @@ class TextualChatApp(App):
     #drawer {
         height: auto;
         max-height: 12;
-        background: $panel;
+        background: @surface@;
         padding: 0;
     }
     /* OptionList ships an all-round default border — strip it so the drawer
@@ -807,12 +808,12 @@ class TextualChatApp(App):
     #drawer OptionList {
         height: auto;
         max-height: 12;
-        background: $panel;
+        background: @surface@;
         border: none;
         padding: 0;
     }
     #drawer Static { height: auto; padding: 1 0; }
-    """
+    """)
 
     #: Per-entry BODY animation rate (Hz) for the live RUNNING-tool indicator
     #: (Phase ②). Drives ``FlowView.animate_entry`` so the spinner + elapsed body
@@ -1385,7 +1386,7 @@ class TextualChatApp(App):
         # marker-carrying values and the marker survives — measured: no
         # ``48;2;`` truecolor background escape codes anywhere in a real
         # terminal capture after this switch, versus 2 residue regions
-        # before. A LOCALIZED per-selector ``background: ansi_default;``
+        # before. A LOCALIZED per-selector ``background: @app-background@;``
         # override (mirroring how #3504 fixed ``App``) was tried first and
         # does NOT work: the literal ``ansi_default`` value fails to
         # propagate when declared on anything other than ``App`` itself

--- a/src/reyn/interfaces/inline/textual_chat/completion.py
+++ b/src/reyn/interfaces/inline/textual_chat/completion.py
@@ -132,6 +132,8 @@ from typing import TYPE_CHECKING
 
 from textual.widgets import OptionList
 
+from reyn.interfaces.inline.textual_chat import palette
+
 from .presenter import _neutralized_label, option_content_rows
 
 if TYPE_CHECKING:
@@ -549,16 +551,16 @@ class CompletionPopup(OptionList, can_focus=False):
     :meth:`sync` and reads :attr:`owns_keys` before claiming a navigation key.
     """
 
-    DEFAULT_CSS = """
+    DEFAULT_CSS = palette.css("""
     CompletionPopup {
         display: none;
         height: auto;
         max-height: 10;
-        background: $panel;
+        background: @surface@;
         border: none;
         padding: 0;
     }
-    """
+    """)
 
     def on_mount(self) -> None:
         self.display = False

--- a/src/reyn/interfaces/inline/textual_chat/intervention_panel.py
+++ b/src/reyn/interfaces/inline/textual_chat/intervention_panel.py
@@ -108,6 +108,8 @@ from textual.widgets import (
     Tabs,
 )
 
+from reyn.interfaces.inline.textual_chat import palette
+
 from .presenter import _neutralized_label
 
 if TYPE_CHECKING:
@@ -154,10 +156,10 @@ class InterventionPanel(Vertical):
     #: widget state. Only ``TabbedContent`` itself (which DOES default to
     #: ``height: auto`` — ``TabbedContent.DEFAULT_CSS`` — so overriding it is
     #: a no-op override, kept for documentation clarity) needs a rule here.
-    DEFAULT_CSS = """
+    DEFAULT_CSS = palette.css("""
     InterventionPanel {
         height: auto;
-        border: round $warning;
+        border: round @attention@;
         padding: 0 1;
         margin-top: 1;
     }
@@ -166,17 +168,17 @@ class InterventionPanel(Vertical):
     }
     InterventionPanel .iv-pane-title {
         text-style: bold;
-        color: $warning;
+        color: @attention@;
     }
     InterventionPanel .iv-pane-detail {
-        color: $text-muted;
+        color: @quiet@;
     }
     InterventionPanel RadioSet {
         border: none;
         height: auto;
         padding: 0;
     }
-    """
+    """)
 
     #: ``Esc``/``Tab`` stay ordinary (non-priority) bindings — the escape
     #: hatch, unchanged from P1/P2. ``Left``/``Right`` are PRIORITY bindings

--- a/src/reyn/interfaces/inline/textual_chat/palette.py
+++ b/src/reyn/interfaces/inline/textual_chat/palette.py
@@ -1,0 +1,93 @@
+"""The single place the inline CUI names a colour.
+
+Every colour and emphasis decision the TUI makes is a token here, and every
+widget's ``DEFAULT_CSS`` interpolates one rather than writing a value. Checking
+what the interface paints is then reading this file, not sweeping for whatever
+syntax a value happened to take.
+
+That distinction is not theoretical. A census that grepped for ``$var NN%``
+missed ``solid #3d434f`` — the hex sits behind a border keyword, so the pattern
+never matched it — and a second census over ``$text-muted`` missed
+``background: $accent 30%``, which is what an operator then reported as an
+unreadable green block. Both were found only by enumerating the VALUES instead
+of matching an expectation about their shape. Enumerating them is what this
+module makes unnecessary: ``test_tui_colour_tokens.py`` fails if any colour is
+written outside it.
+
+**Terminal-owned meanings stay with the terminal.** Where the terminal already
+has a meaning — its default foreground and background — the token names that
+rather than pinning a value the user's theme is entitled to choose. Emphasis is
+carried by SGR attributes (``dim``, ``bold``) for the same reason: under the
+``ansi-*`` themes ``$text`` and ``$text-muted`` both resolve to the
+``ansi_default`` marker, and alpha compositing DROPS that marker — so
+``$text 40%`` and ``$accent 30%`` do not fade anything, they either do nothing
+or paint a solid colour. An attribute leaves the hue to the terminal and
+survives the merge.
+"""
+from __future__ import annotations
+
+#: Every colour the inline CUI names, as ``@token@`` -> value. Widgets write
+#: the marker and pass their sheet through :func:`css`; nothing else in
+#: ``interfaces/`` may write a value.
+#:
+#: The marker syntax is deliberate. Textual CSS already uses ``$`` for its own
+#: variables and ``{}`` for selectors, so neither an f-string nor ``%``
+#: formatting can carry a template through untouched — and a token published as
+#: an app-level CSS variable would make every widget depend on being mounted
+#: inside the reyn app, which is not true of the tests that mount them alone.
+#: ``@name@`` collides with nothing and resolves at class-definition time.
+TOKENS: "dict[str, str]" = {
+    #: Raised surfaces: drawer, completion popup, search bar, rewind picker,
+    #: status line. The one place the CUI departs from the terminal's ground,
+    #: so a panel reads as a distinct layer rather than as more conversation.
+    "@surface@": "$panel",
+    #: De-emphasised text — hints, placeholders, secondary labels.
+    "@quiet@": "$text-muted",
+    #: Something is waiting on the operator (the intervention panel's border
+    #: and its prompt). The only semantic colour the CUI claims; anything else
+    #: that must stand out uses an attribute instead.
+    "@attention@": "$warning",
+    #: The app's ground. ``ansi_default`` is the marker meaning "whatever the
+    #: terminal's background is" — not a colour, deliberately.
+    "@app-background@": "ansi_default",
+    #: Hairline rules around the input row. A concrete value because it must
+    #: read as a divider against BOTH terminal grounds; a theme variable would
+    #: follow the theme and vanish into one of them.
+    "@rule@": "#3d434f",
+    #: The selected row in a list the operator navigates (the sent-queue).
+    #: ``bold`` rather than a background: a filled block is what
+    #: ``$accent 30%`` produced once alpha was dropped — a solid ANSI-green bar
+    #: under default-coloured text — and a full-row inversion was rejected on
+    #: the conversation for the same reason (#3490: the mark has to be
+    #: CONTENT). Widgets pair this with a marker in the row text.
+    "@selected-style@": "bold",
+}
+
+#: The marker a selected row carries in its own text, so selection survives
+#: without a colour at all. Not a CSS value — it is content.
+SELECTED_MARKER = "\u25b8"
+
+
+def css(sheet: str) -> str:
+    """Resolve ``@token@`` markers in a widget stylesheet.
+
+    Raises on an unknown marker rather than leaving it in place: Textual would
+    reject the whole sheet for the unparseable value, and one blank interface
+    is a poor way to learn about a typo.
+    """
+    import re as _re
+
+    unknown = {
+        m for m in _re.findall(r"@[a-z-]+@", sheet) if m not in TOKENS
+    }
+    if unknown:
+        raise ValueError(
+            f"unknown palette token(s) {sorted(unknown)} — declare them in "
+            f"palette.TOKENS or fix the spelling"
+        )
+    for marker, value in TOKENS.items():
+        sheet = sheet.replace(marker, value)
+    return sheet
+
+
+__all__ = ["SELECTED_MARKER", "TOKENS", "css"]

--- a/src/reyn/interfaces/inline/textual_chat/rewind_picker.py
+++ b/src/reyn/interfaces/inline/textual_chat/rewind_picker.py
@@ -37,6 +37,8 @@ from textual.content import Content
 from textual.message import Message
 from textual.widgets import OptionList, Static
 
+from reyn.interfaces.inline.textual_chat import palette
+
 #: Max characters of a point's ``ts`` shown in a row — the WAL timestamp is a
 #: free-form string read straight off the WAL entry, so it is truncated rather
 #: than allowed to push ``kind`` off a narrow terminal.
@@ -70,26 +72,26 @@ def rewind_row_text(point: "dict") -> str:
 class RewindPicker(Vertical):
     """The collapsed-by-default ``/rewind`` checkpoint region."""
 
-    DEFAULT_CSS = """
+    DEFAULT_CSS = palette.css("""
     RewindPicker {
         height: auto;
         max-height: 12;
-        background: $panel;
+        background: @surface@;
         padding: 0;
     }
     RewindPicker OptionList {
         height: auto;
         max-height: 10;
-        background: $panel;
+        background: @surface@;
         border: none;
         padding: 0;
     }
     RewindPicker #rewind-picker-title {
         height: auto;
-        color: $text-muted;
+        color: @quiet@;
         padding: 0 1;
     }
-    """
+    """)
 
     BINDINGS = [("escape", "dismiss", "Cancel rewind")]
 

--- a/src/reyn/interfaces/inline/textual_chat/search_bar.py
+++ b/src/reyn/interfaces/inline/textual_chat/search_bar.py
@@ -39,28 +39,30 @@ from textual.containers import Horizontal
 from textual.message import Message
 from textual.widgets import Input, Static
 
+from reyn.interfaces.inline.textual_chat import palette
+
 
 class SearchBar(Horizontal):
     """The ctrl+f search bar: query input + ``n/M`` match count."""
 
-    DEFAULT_CSS = """
+    DEFAULT_CSS = palette.css("""
     SearchBar {
         display: none;
         height: 1;
-        background: $panel;
+        background: @surface@;
         padding: 0 1;
     }
     SearchBar Input {
         width: 1fr;
-        background: $panel;
+        background: @surface@;
     }
     SearchBar #search-count {
         width: auto;
         height: 1;
-        color: $text-muted;
+        color: @quiet@;
         padding: 0 0 0 1;
     }
-    """
+    """)
 
     class QueryChanged(Message):
         """The query text changed — the app recomputes matches incrementally."""

--- a/src/reyn/interfaces/inline/textual_chat/sent_queue.py
+++ b/src/reyn/interfaces/inline/textual_chat/sent_queue.py
@@ -84,6 +84,8 @@ from textual.content import Content
 from textual.message import Message
 from textual.widgets import Static
 
+from reyn.interfaces.inline.textual_chat import palette
+
 from .presenter import _neutralized_label
 
 
@@ -94,19 +96,22 @@ class SentQueue(Vertical):
 
     can_focus = True
 
-    DEFAULT_CSS = """
+    DEFAULT_CSS = palette.css("""
     SentQueue {
         height: auto;
         max-height: 6;
-        color: $text-muted;
+        color: @quiet@;
         padding: 0 1;
     }
     SentQueue Static { height: auto; }
-    SentQueue Static.-selected {
-        background: $accent 30%;
-        color: $text;
-    }
-    """
+    /* Selection is an ATTRIBUTE plus a marker in the row's own text, never a
+       filled background. ``background: $accent 30%`` was the previous rule and
+       under the ansi themes the alpha is DROPPED, so it painted a solid ANSI
+       green bar with default-coloured text on top — reported as unreadable.
+       #3490 settled the same question on the conversation: surviving the style
+       merge is necessary and not sufficient, the mark has to be CONTENT. */
+    SentQueue Static.-selected { text-style: @selected-style@; }
+    """)
 
     BINDINGS = [
         Binding("up", "select_prev", "Previous queued", show=False),
@@ -131,6 +136,7 @@ class SentQueue(Vertical):
     def on_mount(self) -> None:
         self.display = False
         self._rows: "dict[str, Static]" = {}
+        self._labels: "dict[str, str]" = {}
         self._selected_index = 0
 
     def show_item(self, msg_id: str, text: str) -> None:
@@ -143,7 +149,8 @@ class SentQueue(Vertical):
         if msg_id in self._rows:
             self.remove_item(msg_id)
         label = _neutralized_label(text)
-        row = Static(Content(f"⧗ {label}"))
+        self._labels[msg_id] = label
+        row = Static(Content(f"  ⧗ {label}"))
         self._rows[msg_id] = row
         self.mount(row)
         self.display = True
@@ -154,6 +161,7 @@ class SentQueue(Vertical):
         """Remove a queued item's row (the PROMOTE exit or the ``inbox_cancel``
         REMOVE exit, #3300 Y-client). No-op for an unknown ``msg_id``.
         Collapses the region back to hidden once the last item is gone."""
+        self._labels.pop(msg_id, None)
         row = self._rows.pop(msg_id, None)
         if row is not None:
             row.remove()
@@ -208,9 +216,19 @@ class SentQueue(Vertical):
         self._selected_index = max(0, min(self._selected_index, last))
 
     def _apply_highlight(self) -> None:
+        """Mark the selected row, in its TEXT as well as its style.
+
+        The marker is what makes selection legible where a background cannot
+        go (see the CSS above); the two-space indent on unselected rows keeps
+        the queue text aligned so the marker reads as a pointer rather than as
+        the rows shifting."""
         order = list(self._rows.keys())
         for i, msg_id in enumerate(order):
-            self._rows[msg_id].set_class(i == self._selected_index, "-selected")
+            selected = i == self._selected_index
+            row = self._rows[msg_id]
+            row.set_class(selected, "-selected")
+            lead = f"{palette.SELECTED_MARKER} " if selected else "  "
+            row.update(Content(f"{lead}⧗ {self._labels[msg_id]}"))
 
     def action_select_prev(self) -> None:
         if self._selected_index > 0:

--- a/tests/test_3300_p2b_sentqueue_render.py
+++ b/tests/test_3300_p2b_sentqueue_render.py
@@ -318,7 +318,13 @@ async def test_sent_queue_updates_live_as_deltas_arrive() -> None:
         await pilot.pause()
 
         sent_queue = app.query_one(SentQueue)
-        assert {"alpha", "beta"} <= {t.split(" ", 1)[-1] for t in sent_queue.rendered_texts()}
+        # Split on the queued glyph, not the first space: a row now carries a
+        # selection marker ahead of it (selection is CONTENT, not a background
+        # — see SentQueue.DEFAULT_CSS), so the leading token count varies with
+        # which row is highlighted.
+        assert {"alpha", "beta"} <= {
+            t.split("⧗ ", 1)[-1] for t in sent_queue.rendered_texts()
+        }
 
         await transport.push_event(_turn_started(chain_id="c1", seq=3))
         await pilot.pause()

--- a/tests/test_tui_colour_tokens.py
+++ b/tests/test_tui_colour_tokens.py
@@ -1,0 +1,133 @@
+"""Tier 1: contract — the inline CUI names colours in exactly one file.
+
+Two censuses of the TUI's colours each missed something, and the second miss
+reached an operator as an unreadable green block. The first grepped for
+``$var NN%`` and did not see ``solid #3d434f`` — the hex sits behind a border
+keyword, so the pattern never matched it. The second grepped for
+``$text-muted`` and did not see ``background: $accent 30%``. Both were found
+only by enumerating the VALUES rather than matching an expected shape.
+
+Enumerating is what this gate removes the need for. Every colour lives in
+``palette.py`` and every widget writes a ``$reyn-*`` token, so "what does this
+interface paint" is one file, and a value written anywhere else fails here
+rather than waiting for someone to grep for the right syntax.
+
+Scope is reyn's own stylesheets under ``interfaces/``. Textual's own
+``DEFAULT_CSS`` is out of scope — reyn does not own it, and #3525 tracks the
+places it collides with the ansi themes.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from reyn.interfaces.inline.textual_chat import palette
+
+_INTERFACES = Path(__file__).resolve().parent.parent / "src" / "reyn" / "interfaces"
+
+#: A colour-bearing CSS declaration: the property names that take one, and the
+#: value up to the semicolon. ``border``/``outline`` are included because their
+#: value carries a colour behind a style keyword — the shape the first census
+#: missed.
+_DECLARATION = re.compile(
+    r"\b(background|color|tint|border|outline)([a-z-]*): *([^;\n]+);"
+)
+
+#: Values that name no colour, so a rule using one is not a colour decision.
+_COLOURLESS = frozenset({"none", "transparent", "auto", "initial", "hidden"})
+
+
+def _stylesheet_lines() -> "list[tuple[Path, int, str]]":
+    """Every line of reyn-owned source under ``interfaces/``, with its origin.
+
+    Enumerated from the filesystem rather than a list of known widgets, so a
+    new widget is covered the moment it lands.
+    """
+    out: "list[tuple[Path, int, str]]" = []
+    for path in sorted(_INTERFACES.rglob("*.py")) + sorted(_INTERFACES.rglob("*.tcss")):
+        if path.name == "palette.py":
+            continue  # the one file allowed to hold values
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            out.append((path, number, line))
+    return out
+
+
+def _colour_values() -> "list[str]":
+    """Every colour value declared outside ``palette.py``, as ``path:line -> value``."""
+    offenders: "list[str]" = []
+    for path, number, line in _stylesheet_lines():
+        stripped = line.strip()
+        # Skip prose: comment lines, and doc/rationale text that quotes CSS.
+        if stripped.startswith(("#", "*", "/*")) or "``" in line:
+            continue
+        for match in _DECLARATION.finditer(line):
+            value = match.group(3).strip()
+            tokens = [t for t in value.split() if t not in _COLOURLESS]
+            for token in tokens:
+                if token.startswith("@") and token.endswith("@"):
+                    continue  # a palette marker — the point of the exercise
+                if token in _COLOURLESS or token in {"solid", "round", "dashed", "tall", "wide", "heavy", "outer", "inner", "thick"}:
+                    continue
+                if re.fullmatch(r"\d+", token):
+                    continue  # a width, not a colour
+                offenders.append(f"{path.relative_to(_INTERFACES)}:{number} -> {token}")
+    return offenders
+
+
+def test_the_gate_is_looking_at_real_stylesheets() -> None:
+    """Tier 1: setup — the enumeration finds the widgets it is meant to check.
+
+    A glob that matched nothing would make the assertion below vacuously true,
+    which is the exact shape the two failed censuses had.
+    """
+    lines = _stylesheet_lines()
+
+    assert any("sent_queue.py" in str(p) for p, _, _ in lines)
+    assert any("@quiet@" in line or "@surface@" in line for _, _, line in lines), (
+        "no widget references a palette token — the tokens are not in use"
+    )
+
+
+def test_no_colour_is_named_outside_the_palette() -> None:
+    """Tier 1: every colour value in reyn's own CSS is a ``$reyn-*`` token."""
+    offenders = _colour_values()
+
+    assert not offenders, (
+        "colour values declared outside palette.py — add a token there and "
+        "reference it instead:\n" + "\n".join(f"  {o}" for o in offenders)
+    )
+
+
+def test_every_marker_a_widget_uses_is_declared() -> None:
+    """Tier 1: no widget references a token the palette does not define.
+
+    An undeclared marker survives into the stylesheet as an unparseable value,
+    and Textual rejects the WHOLE sheet for one bad value — so a typo here is a
+    blank interface, not a wrong colour. ``palette.css`` raises on it instead;
+    this asserts the widgets are clean today.
+    """
+    used: "set[str]" = set()
+    for path, _, line in _stylesheet_lines():
+        if path.suffix != ".py":
+            continue
+        used |= set(re.findall(r"@[a-z-]+@", line))
+
+    undeclared = used - set(palette.TOKENS)
+
+    assert not undeclared, f"markers used but not declared: {sorted(undeclared)}"
+
+
+def test_an_unknown_marker_is_rejected_rather_than_left_in_place() -> None:
+    """Tier 1: ``palette.css`` fails loudly on a token it does not know."""
+    import pytest
+
+    with pytest.raises(ValueError, match="unknown palette token"):
+        palette.css("Foo { color: @not-a-real-token@; }")
+
+
+def test_resolution_leaves_no_marker_behind() -> None:
+    """Tier 1: a resolved sheet carries values, not markers."""
+    resolved = palette.css("Foo { background: @surface@; color: @quiet@; }")
+
+    assert "@" not in resolved
+    assert palette.TOKENS["@surface@"] in resolved


### PR DESCRIPTION
**[tui-coder]** — Owner directive, after a colour defect they reported turned out to be one my own census had missed: *「むしろ網羅的に確認できるよう色情報を局所化せよ。バラつかせるな」*.

## Why localising, rather than another sweep

Two censuses of the inline CUI's colours each missed something.

| census | grepped for | missed | why |
|---|---|---|---|
| #3523 | `$text-muted` | `background: $accent 30%` | wrong variable |
| follow-up | `$var NN%` | `solid #3d434f` | the hex sits **behind a border keyword**, so the pattern never matched |

The second miss is the one the operator saw: the sent-queue's selected row rendered as a solid ANSI-green bar with default-coloured text on top. Both were found only by enumerating the **values** rather than matching an expected shape — and there is no reason to think a third pattern would have been the last one.

## What this does

`palette.py` holds every value. Widgets write an `@token@` marker and pass their sheet through `palette.css()`. A gate enumerates every colour-bearing declaration under `interfaces/` and fails on any value named outside the palette.

Verified it detects rather than merely passes, against **both** shapes the censuses missed:

```
$accent 30%      -> inline/textual_chat/search_bar.py:50 -> $accent
solid #ff00ff    -> inline/textual_chat/search_bar.py:50 -> #ff00ff
```

File, line and value, so the failure needs no interpretation.

## Why markers, and not the two more obvious approaches

Both were tried first and are recorded because they look correct until they are not:

- **f-string / `%` interpolation** — Textual CSS uses `{}` for selectors and `$` for its own variables, so neither can carry a template through intact. The f-string attempt failed on `display: none;` inside a selector block.
- **App-level CSS variables** (`get_css_variables`) — idiomatic, and wrong here twice: Textual does **not** resolve a variable that points at another variable (`$reyn-quiet` → `$text-muted` reaches the parser verbatim and fails the whole sheet), and publishing tokens at the app level makes every widget depend on being mounted inside the reyn app. That broke six tests that mount widgets alone — a real fragility, not a test artifact.

`@name@` collides with nothing, resolves at class-definition time, and `palette.css()` raises on an unknown marker rather than leaving it to become an unparseable value — Textual rejects the entire sheet for one of those, so a typo is a blank interface, not a wrong colour.

## The reported defect, fixed with a token rather than around it

Selection is now an attribute plus a marker in the row's own text. Measured under `ansi-dark`, same widget:

| | before | after |
|---|---|---|
| selected row | `default on color(2)` — solid green fill | `bold default on default`, text `▸ ⧗ …` |
| unselected | `default on default` | `default on default`, text `  ⧗ …` |

This follows #3490's finding on the conversation — surviving the style merge is necessary and not sufficient, **the mark has to be CONTENT** — and it is also why the alpha was inert: under the ansi themes compositing DROPS the ansi marker, so `$accent 30%` never faded anything.

Everything else keeps its current value. This localises **where** colours are decided; it does not relitigate **what** they are. `$text-muted` still resolves to `$text-muted` — #3525 tracks that separately.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict tests/test_tui_colour_tokens.py` — 0 errors
- [x] `verify_module_docstrings.py` on the new module + gate — OK
- [x] `pytest -k "textual or tui or sent_queue or intervention or completion or rewind or search_bar or chrome"` — **727 passed**
- [x] Falsification of the gate against both previously-missed shapes (above)
- [x] Rendered measurement of the sent-queue rows before/after under `ansi-dark` (above)
- [ ] (skipped — needs a TTY) Visual confirmation in a real terminal that the selected queue row reads clearly. The rendered-segment measurement covers what reaches the terminal; how it *looks* is the operator's call, and the owner is running this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)