### PR TITLE
feat(tui): fold a pipeline run into one row with live progress

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/_meta_keys.py
+++ b/src/reyn/interfaces/inline/textual_chat/_meta_keys.py
@@ -80,8 +80,15 @@ RUNNING_SINCE_KEY = "_running_since"
 #: value. This is a decision (owner-adjudicated on #3283), not an oversight.
 ELAPSED_SECS_KEY = "_elapsed_secs"
 
+#: Marks a row as one pipeline RUN'S progress rather than a one-off status
+#: line, and carries the run id. Set app-side when a step frame is folded in
+#: (``_coalesce_pipeline_step``); the presenter reads it to render the run's
+#: state instead of the latest frame's text.
+PIPELINE_RUN_KEY = "_pipeline_run_id"
+
 __all__ = [
     "ELAPSED_SECS_KEY",
+    "PIPELINE_RUN_KEY",
     "ORPHANED_RESULT_KIND",
     "RESULT_KIND_KEY",
     "EXPANDED_KEY",

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -69,6 +69,7 @@ from reyn.interfaces.transport.frames import FrameTag
 from ._meta_keys import ELAPSED_SECS_KEY as _ELAPSED_SECS_KEY
 from ._meta_keys import EXPANDED_KEY as _EXPANDED_KEY
 from ._meta_keys import ORPHANED_RESULT_KIND as _ORPHANED_RESULT_KIND
+from ._meta_keys import PIPELINE_RUN_KEY as _PIPELINE_RUN_KEY
 from .chrome import (
     _MENU_TABS,
     Composer,
@@ -883,6 +884,9 @@ class TextualChatApp(App):
         # deterministic args_hash, meta["op_id"]) so a later completion/failure
         # frame transitions the SAME entry RUNNING → SUCCESS/ERROR (CC parity).
         self._running_tools: "dict[object, Entry[OutboxMessage]]" = {}
+        #: One row per pipeline RUN, keyed by ``run_id`` — every step frame for
+        #: that run folds into it (:meth:`_coalesce_pipeline_step`).
+        self._pipeline_runs: "dict[str, Entry[OutboxMessage]]" = {}
         # ALL pending interventions' flow entries (#3299 P2 — was single-slot
         # in P1, overwritten by a second concurrent pending intervention, an
         # architect self-review finding: ``outstanding_interventions`` is a
@@ -2223,6 +2227,15 @@ class TextualChatApp(App):
         plain-fallback turn sequence."""
         kind = msg.kind
         meta = msg.meta or {}
+        # A pipeline's step frames fold into ONE row, keyed by the run. A
+        # 15-step run emits 30 of them (a started/completed pair per step), and
+        # appended individually they bury the conversation they are progress
+        # FOR. ``lifecycle_forwarder`` already sends them as transient
+        # ``status`` with the ``run_id`` in meta — the key was there, nothing
+        # consumed it.
+        if kind == "status" and meta.get("source") == "pipeline":
+            if self._coalesce_pipeline_step(msg):
+                return
         op_id = meta.get("op_id")
         if kind in ("tool_call_completed", "tool_call_failed") and op_id is not None:
             started = self._running_tools.pop(op_id, None)
@@ -2304,6 +2317,15 @@ class TextualChatApp(App):
             logger.exception("textual chat: could not stop running-tool animation")
         started_meta = started.item.meta or {}
         result_meta = result_msg.meta or {}
+        if started_meta.get("tool") == "run_pipeline":
+            # Settle every open run: the step frames cannot say which of them
+            # was the last, and an attached ``run_pipeline`` call owns exactly
+            # one run — the same assumption ``lifecycle_forwarder`` unsubscribes
+            # on. Any row still open here belongs to a run that has ended.
+            for run_id in list(self._pipeline_runs):
+                self._settle_pipeline_run(
+                    run_id, failed=result_msg.kind == "tool_call_failed"
+                )
         merged = {k: v for k, v in started_meta.items() if k != _RUNNING_SINCE_KEY}
         merged[_RESULT_KIND_KEY] = result_msg.kind
         merged[_RESULT_META_KEY] = result_meta
@@ -2326,6 +2348,59 @@ class TextualChatApp(App):
             started.set_state(
                 EntryState.ERROR if summary.startswith("✗") else EntryState.SUCCESS
             )
+
+    def _coalesce_pipeline_step(self, msg: "OutboxMessage") -> bool:
+        """Fold one pipeline step frame into that run's single row.
+
+        Returns ``True`` when the frame was absorbed, ``False`` to let the
+        caller append it as an ordinary entry — a frame with no ``run_id`` has
+        no row to belong to, and dropping it would lose progress rather than
+        tidy it.
+
+        The row shows the run's own state (``rag_ingest.ingest  ▸ 7/15
+        transform``) rather than the latest line'"'"'s text, so a reader sees where
+        the run IS, not what it most recently said. Progress is read from the
+        frame'"'"'s own numbers; the forwarder already puts them in the text, but
+        parsing a display string back into numbers is the kind of coupling that
+        breaks silently the first time the wording changes.
+        """
+        meta = msg.meta or {}
+        run_id = meta.get("run_id")
+        if not run_id:
+            return False
+        entry = self._pipeline_runs.get(run_id)
+        item = replace(msg, meta={**meta, _PIPELINE_RUN_KEY: run_id})
+        if entry is None:
+            entry = self._flow.append(item)
+            self._pipeline_runs[run_id] = entry
+            try:
+                self._flow.start_entry_animation(entry)
+            except Exception:
+                logger.exception("textual chat: could not start pipeline animation")
+            return True
+        try:
+            entry.set_item(item)
+        except Exception:
+            logger.exception("textual chat: could not update pipeline row")
+        return True
+
+    def _settle_pipeline_run(self, run_id: str, *, failed: bool) -> None:
+        """Stop a run'"'"'s row animating and give it a terminal state.
+
+        Driven by the ``run_pipeline`` tool call completing — the same signal
+        ``lifecycle_forwarder`` unsubscribes on — because the step frames
+        themselves cannot say "and that was the last one": the final
+        ``pipeline_step_completed`` is indistinguishable from any other until
+        the tool returns.
+        """
+        entry = self._pipeline_runs.pop(run_id, None)
+        if entry is None:
+            return
+        try:
+            self._flow.stop_entry_animation(entry)
+        except Exception:
+            logger.exception("textual chat: could not stop pipeline animation")
+        entry.set_state(EntryState.ERROR if failed else EntryState.SUCCESS)
 
     def _sweep_orphaned_running_tools(self) -> None:
         """Force-settle any tool row still RUNNING at a TURN BOUNDARY (#72).

--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -38,6 +38,7 @@ from reyn.interfaces.repl.renderer import (
 
 from ._meta_keys import EXPANDED_KEY as _EXPANDED_KEY
 from ._meta_keys import ORPHANED_RESULT_KIND as _ORPHANED_RESULT_KIND
+from ._meta_keys import PIPELINE_RUN_KEY as _PIPELINE_RUN_KEY
 from ._meta_keys import RESULT_KIND_KEY as _RESULT_KIND_KEY
 from ._meta_keys import RESULT_META_KEY as _RESULT_META_KEY
 from ._meta_keys import RUNNING_SINCE_KEY as _RUNNING_SINCE_KEY
@@ -156,6 +157,43 @@ def _intervention_head(msg: "OutboxMessage") -> RenderableType:
     if detail:
         parts.append(Text(_neutralized_label(str(detail)), style=_CC_DIM))
     return parts[0] if len(parts) == 1 else Group(*parts)
+
+
+#: Width of a pipeline row's progress bar, in cells. Small on purpose: the row
+#: shares a line with the pipeline's name and step, and a bar that dominates it
+#: would say less than the numbers beside it already do.
+_PIPELINE_BAR_CELLS = 12
+
+
+def _pipeline_row(meta: dict) -> "Text":
+    """One pipeline RUN's row: name, a bar, and where the run is.
+
+    Built from the numbers in ``meta`` rather than from the frame's text. The
+    forwarder composes a sentence too, and parsing that back would couple this
+    to its wording — the numbers are what the row is actually about.
+
+    A run whose ``total_steps`` is unknown gets the step count with no bar,
+    rather than a bar over a guessed denominator: a progress bar that is not
+    measuring anything is worse than none.
+    """
+    name = str(meta.get("pipeline_name") or "pipeline")
+    kind = str(meta.get("step_kind") or "?")
+    index = meta.get("step_index")
+    total = meta.get("total_steps")
+    done = (index or 0) + (1 if meta.get("step_event") == "pipeline_step_completed" else 0)
+
+    out = Text()
+    out.append(name, style="bold")
+    if isinstance(total, int) and total > 0:
+        filled = max(0, min(_PIPELINE_BAR_CELLS, round(done / total * _PIPELINE_BAR_CELLS)))
+        out.append("  ")
+        out.append("━" * filled)
+        out.append("─" * (_PIPELINE_BAR_CELLS - filled), style=_CC_DIM)
+        out.append(f"  {done}/{total}")
+    else:
+        out.append(f"  step {done}")
+    out.append(f"  {kind}", style=_CC_DIM)
+    return out
 
 
 def _tool_head(msg: "OutboxMessage") -> Text:
@@ -315,6 +353,8 @@ def _body_and_background(msg: "OutboxMessage") -> "tuple[RenderableType, str | N
     if kind == "presentation":
         from reyn.interfaces.repl.present_renderer import render_presentation_nodes
         return render_presentation_nodes(meta.get("nodes", [])), None
+    if meta.get(_PIPELINE_RUN_KEY) is not None:
+        return _pipeline_row(meta), None
     # kind == "intervention" is intercepted earlier, in ``ReynPresenter.present``
     # (the pending/resolved placeholder — #3299 P1), so it never reaches here.
     if kind == "tool_call_started":

--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -165,35 +165,57 @@ def _intervention_head(msg: "OutboxMessage") -> RenderableType:
 _PIPELINE_BAR_CELLS = 12
 
 
-def _pipeline_row(meta: dict) -> "Text":
+def _pipeline_row(meta: dict) -> "RenderableType":
     """One pipeline RUN's row: name, a bar, and where the run is.
+
+    The bar is ``rich.progress_bar.ProgressBar`` — Rich's own, not a hand-rolled
+    ``"\u2501" * n``. A reimplementation looks equivalent at a glance and is
+    not: the real one renders a HALF-cell tip (``\u2578``), so the bar advances
+    at twice the resolution its width suggests — most of what makes a 12-cell
+    bar worth drawing at all.
 
     Built from the numbers in ``meta`` rather than from the frame's text. The
     forwarder composes a sentence too, and parsing that back would couple this
     to its wording — the numbers are what the row is actually about.
 
     A run whose ``total_steps`` is unknown gets the step count with no bar,
-    rather than a bar over a guessed denominator: a progress bar that is not
-    measuring anything is worse than none.
+    rather than a bar over a guessed denominator: a bar that is not measuring
+    anything is worse than none.
     """
+    from rich.progress_bar import ProgressBar
+    from rich.table import Table
+
     name = str(meta.get("pipeline_name") or "pipeline")
     kind = str(meta.get("step_kind") or "?")
     index = meta.get("step_index")
     total = meta.get("total_steps")
-    done = (index or 0) + (1 if meta.get("step_event") == "pipeline_step_completed" else 0)
+    done = (index or 0) + (
+        1 if meta.get("step_event") == "pipeline_step_completed" else 0
+    )
 
-    out = Text()
-    out.append(name, style="bold")
-    if isinstance(total, int) and total > 0:
-        filled = max(0, min(_PIPELINE_BAR_CELLS, round(done / total * _PIPELINE_BAR_CELLS)))
-        out.append("  ")
-        out.append("━" * filled)
-        out.append("─" * (_PIPELINE_BAR_CELLS - filled), style=_CC_DIM)
-        out.append(f"  {done}/{total}")
-    else:
-        out.append(f"  step {done}")
-    out.append(f"  {kind}", style=_CC_DIM)
-    return out
+    if not (isinstance(total, int) and total > 0):
+        return Text.assemble((name, "bold"), (f"  step {done}  ", ""), (kind, _CC_DIM))
+
+    row = Table.grid(padding=(0, 1))
+    for _ in range(4):
+        row.add_column()
+    row.add_row(
+        Text(name, style="bold"),
+        # Styles defer to the terminal rather than taking Rich's default
+        # magenta/green: a themed default is the user's to choose, and the bar
+        # is not one of the two places this CUI claims a colour of its own.
+        ProgressBar(
+            total=total,
+            completed=done,
+            width=_PIPELINE_BAR_CELLS,
+            style=_CC_DIM,
+            complete_style="",
+            finished_style="",
+        ),
+        Text(f"{done}/{total}"),
+        Text(kind, style=_CC_DIM),
+    )
+    return row
 
 
 def _tool_head(msg: "OutboxMessage") -> Text:

--- a/src/reyn/runtime/lifecycle_forwarder.py
+++ b/src/reyn/runtime/lifecycle_forwarder.py
@@ -387,7 +387,18 @@ class ChatLifecycleForwarder:
             marker, suffix = "✓", " done"
         progress = f"{n}/{total_steps}" if total_steps else str(n)
         text = f"[{marker} {pipeline_name}: step {progress} ({step_kind}){suffix}]"
-        meta = {"source": "pipeline", "run_id": data.get("run_id")}
+        # The numbers travel in meta, not only inside ``text``: a display that
+        # wants a progress bar should read them, never parse them back out of a
+        # sentence whose wording is free to change.
+        meta = {
+            "source": "pipeline",
+            "run_id": data.get("run_id"),
+            "pipeline_name": pipeline_name,
+            "step_index": step_index,
+            "total_steps": total_steps,
+            "step_kind": step_kind,
+            "step_event": event_type,
+        }
         try:
             self.outbox.put_nowait(OutboxMessage(kind="status", text=text, meta=meta))
         except asyncio.QueueFull:

--- a/tests/test_pipeline_single_flow_entry_3641.py
+++ b/tests/test_pipeline_single_flow_entry_3641.py
@@ -11,8 +11,24 @@ reports the run's state rather than the latest frame's sentence.
 """
 from __future__ import annotations
 
+from rich.console import Console
+
 from reyn.interfaces.inline.textual_chat._meta_keys import PIPELINE_RUN_KEY
 from reyn.interfaces.inline.textual_chat.presenter import _pipeline_row
+
+
+def _plain(meta: dict) -> str:
+    """The row as it reaches a terminal.
+
+    Rendered through a real Console rather than read off a ``Text`` object: the
+    bar is a Rich renderable (``ProgressBar``), so its cells only exist once
+    something renders it — asserting on anything earlier would be asserting on
+    the recipe, not the meal.
+    """
+    console = Console(width=80, force_terminal=False)
+    with console.capture() as capture:
+        console.print(_pipeline_row(meta))
+    return capture.get()
 
 
 def _step_meta(index: int, *, total: "int | None" = 15, completed: bool = False) -> dict:
@@ -30,7 +46,7 @@ def _step_meta(index: int, *, total: "int | None" = 15, completed: bool = False)
 
 def test_the_row_names_the_run_and_where_it_is() -> None:
     """Tier 2: the pipeline, the count, and the step kind all reach the row."""
-    row = _pipeline_row(_step_meta(6, completed=True)).plain
+    row = _plain(_step_meta(6, completed=True))
 
     assert "rag_ingest.ingest" in row
     assert "7/15" in row
@@ -41,15 +57,15 @@ def test_the_bar_tracks_progress() -> None:
     """Tier 2: the bar is a function of the numbers, not decoration.
 
     Compared across three points rather than pinned at one, so the assertion
-    describes the relationship and survives a change to the bar's width.
+    describes the relationship and survives a change to the bar's width — or to
+    Rich's own glyphs, which is not reyn's to pin.
     """
-    start = _pipeline_row(_step_meta(0)).plain
-    middle = _pipeline_row(_step_meta(6, completed=True)).plain
-    end = _pipeline_row(_step_meta(14, completed=True)).plain
+    start = _plain(_step_meta(0))
+    middle = _plain(_step_meta(6, completed=True))
+    end = _plain(_step_meta(14, completed=True))
 
     assert start.count("━") == 0
     assert 0 < middle.count("━") < end.count("━")
-    assert end.count("─") == 0
 
 
 def test_an_unknown_total_gets_no_bar() -> None:
@@ -59,9 +75,9 @@ def test_an_unknown_total_gets_no_bar() -> None:
     ahead of time; drawing a bar anyway would show a position on a scale that
     does not exist.
     """
-    row = _pipeline_row(_step_meta(3, total=None)).plain
+    row = _plain(_step_meta(3, total=None))
 
-    assert "━" not in row and "─" not in row
+    assert "━" not in row
     assert "step 4" in row or "step 3" in row
 
 
@@ -72,6 +88,6 @@ def test_the_row_does_not_read_the_frame_text() -> None:
     the display to its wording. Passing meta with no text at all is the direct
     statement that the text is not an input.
     """
-    row = _pipeline_row(_step_meta(2)).plain
+    row = _plain(_step_meta(2))
 
     assert "rag_ingest.ingest" in row  # rendered without any msg.text existing

--- a/tests/test_pipeline_single_flow_entry_3641.py
+++ b/tests/test_pipeline_single_flow_entry_3641.py
@@ -1,0 +1,77 @@
+"""Tier 2: a pipeline run occupies ONE row, and that row shows its progress.
+
+A 15-step run emits a ``pipeline_step_started``/``pipeline_step_completed``
+pair per step — 30 frames — and each was appended as its own flow entry, so the
+conversation the run belongs to scrolled away behind its own progress.
+
+The frames were already the right shape for folding: ``lifecycle_forwarder``
+sends them as transient ``status`` carrying the ``run_id``. Nothing consumed
+the key. These pin both halves of the fix — one row per run, and a row that
+reports the run's state rather than the latest frame's sentence.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.inline.textual_chat._meta_keys import PIPELINE_RUN_KEY
+from reyn.interfaces.inline.textual_chat.presenter import _pipeline_row
+
+
+def _step_meta(index: int, *, total: "int | None" = 15, completed: bool = False) -> dict:
+    return {
+        PIPELINE_RUN_KEY: "run-1",
+        "pipeline_name": "rag_ingest.ingest",
+        "step_index": index,
+        "total_steps": total,
+        "step_kind": "transform",
+        "step_event": (
+            "pipeline_step_completed" if completed else "pipeline_step_started"
+        ),
+    }
+
+
+def test_the_row_names_the_run_and_where_it_is() -> None:
+    """Tier 2: the pipeline, the count, and the step kind all reach the row."""
+    row = _pipeline_row(_step_meta(6, completed=True)).plain
+
+    assert "rag_ingest.ingest" in row
+    assert "7/15" in row
+    assert "transform" in row
+
+
+def test_the_bar_tracks_progress() -> None:
+    """Tier 2: the bar is a function of the numbers, not decoration.
+
+    Compared across three points rather than pinned at one, so the assertion
+    describes the relationship and survives a change to the bar's width.
+    """
+    start = _pipeline_row(_step_meta(0)).plain
+    middle = _pipeline_row(_step_meta(6, completed=True)).plain
+    end = _pipeline_row(_step_meta(14, completed=True)).plain
+
+    assert start.count("━") == 0
+    assert 0 < middle.count("━") < end.count("━")
+    assert end.count("─") == 0
+
+
+def test_an_unknown_total_gets_no_bar() -> None:
+    """Tier 2: a bar over a guessed denominator is worse than none.
+
+    ``total_steps`` is absent for any producer that does not know its length
+    ahead of time; drawing a bar anyway would show a position on a scale that
+    does not exist.
+    """
+    row = _pipeline_row(_step_meta(3, total=None)).plain
+
+    assert "━" not in row and "─" not in row
+    assert "step 4" in row or "step 3" in row
+
+
+def test_the_row_does_not_read_the_frame_text() -> None:
+    """Tier 2: rendering is driven by meta alone.
+
+    The forwarder also composes a sentence, and reading that back would couple
+    the display to its wording. Passing meta with no text at all is the direct
+    statement that the text is not an input.
+    """
+    row = _pipeline_row(_step_meta(2)).plain
+
+    assert "rag_ingest.ingest" in row  # rendered without any msg.text existing


### PR DESCRIPTION
**[tui-coder]** — Owner report after a `rag_ingest` run: *「pipeline 実行したら関連するステップが個別に flow entry になってる。これ単一 flow entry にしてリッチな進捗表示にできない？」*

## What was happening

Traced through the owner's live logs. The pipeline runs in a **spawned driver session**, and its events land on that session's own EventLog:

```
.reyn/events/agents/default/sessions/4bae93a3/chat/2026-08/…
  pipeline_step_started    x15
  pipeline_step_completed  x15     run_id / step_index / total_steps: 15 / step_kind
```

`lifecycle_forwarder` bridges them to the parent as transient `status` frames — deliberately, its own comment says a many-step pipeline "would spam permanent `system` markers otherwise" — and it puts the **`run_id` in meta**.

The key was there. Nothing consumed it: `_ingest_frame` appends anything it does not specially coalesce, so 30 frames became 30 entries and the conversation they were progress *for* scrolled away behind them.

## What this does

They coalesce by `run_id`, using the idiom tool results already use:

- one row per run, updated in place
- animated while it runs
- terminal state when the `run_pipeline` call completes

Settling is driven by that tool call rather than by the frames themselves, because the final `pipeline_step_completed` is indistinguishable from any other until the tool returns — the same signal `lifecycle_forwarder` unsubscribes on.

```
rag_ingest.ingest  ────────────  0/15  transform
rag_ingest.ingest  ━━━━━━──────  7/15  transform
rag_ingest.ingest  ━━━━━━━━━━━━  15/15  transform
rag_ingest.ingest  step 4  transform          <- total unknown: count, no bar
```

## Rendered from meta, not from the sentence

The forwarder composes a display string AND now carries the numbers it already had (`pipeline_name` / `step_index` / `total_steps` / `step_kind`) in meta. The row reads those.

Parsing the numbers back out of the forwarder's text would have worked today and broken silently the first time its wording changed — the row and the sentence would be two renderings of one fact, one of them derived from the other's prose.

A run with no known total gets its step count and **no bar**: a bar over a guessed denominator shows a position on a scale that does not exist.

## Evidence

End to end through the coalescing path, 15 steps:

```
投入フレーム数: 30
★ 生成された flow entry 数: 1
最終行の meta: {step_index: 14, total_steps: 15, step_event: pipeline_step_completed}
```

## Test plan

- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` on the new test file — 0 errors
- [x] `verify_module_docstrings.py` on all four changed files — OK
- [x] `pytest -k "textual or tui or flow or pipeline"` — **900 passed**
- [x] End-to-end fold measured: 30 frames → 1 entry, final state retained (above)
- [x] The bar is asserted as a RELATION across three points rather than pinned at one, so it survives a change to the bar width
- [ ] (skipped — needs a TTY and a real pipeline) Visual confirmation that the row reads well while a run is in flight. The owner is running this build and reported the original defect; the rendered text is measured above, but how it looks mid-run is their call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)