### PR TITLE
docs: make embedding's one switch findable, and stop claiming it needs no edits

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -1690,7 +1690,11 @@ presentations:
 
 ## `embedding` block
 
-RAG embedding model classes and batch settings. Built-in defaults cover the OpenAI path — no `reyn.yaml` changes are required for a fresh install with `OPENAI_API_KEY`.
+RAG embedding model classes and batch settings.
+
+`enabled` is the one switch and it is **off by default** — nothing else in this
+block turns embedding on. Once it is on, the built-in defaults cover the OpenAI
+path, so a fresh install with `OPENAI_API_KEY` needs no further changes.
 
 > **Non-OpenAI embeddings behind a LiteLLM proxy.** If your embedding
 > class routes through a LiteLLM proxy to a non-OpenAI provider (e.g. an

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -641,9 +641,22 @@
 
 
 # -----------------------------------------------------------------------------
-# embedding: RAG embedding settings. Built-in defaults
-# cover the common OpenAI path so users can start indexing after
-# ``pip install reyn`` + ``OPENAI_API_KEY`` with no edits required.
+# embedding: RAG embedding settings.
+#
+# ``enabled`` is the ONE switch, and it is OFF by default. Nothing else in this
+# block turns embedding on — the rest only chooses how it behaves once it is.
+# Until you set it, the embedding-backed semantic-discovery layer stays dark:
+# ``search_actions``, knowledge retrieval, and the FP-0063 plugin's
+# ``rag_ingest`` embed step. Plain ``list_*`` discovery and the load / read /
+# invoke verbs are unaffected either way.
+#
+#   embedding:
+#     enabled: true
+#
+# Off by default because embedding needs a provider and costs money per call —
+# a predictable-safe default, not an oversight. With it on, the built-in
+# classes cover the common OpenAI path, so ``pip install reyn`` +
+# ``OPENAI_API_KEY`` needs no further edits.
 #
 # Built-in classes:
 #   light, standard → openai/text-embedding-3-small
@@ -656,6 +669,7 @@
 # ``search_actions`` visibility gate falls back to hidden gracefully).
 # -----------------------------------------------------------------------------
 # embedding:
+#   enabled: true                 # ← the switch; everything below is inert without it
 #   default_class: standard
 #   classes:
 #     light:    openai/text-embedding-3-small


### PR DESCRIPTION
**[tui-coder]** — Owner report: *「embedding true の方法が reyn.local.yaml.example みてもわからんかった」*. They are right, and the example is worse than merely incomplete.

## The omission

`EmbeddingConfig.enabled` is the **single opt-in switch** for the whole embedding-backed semantic-discovery layer (`config/embedding.py:55`) and defaults to `False`. The example's `embedding:` block lists **eight fields** — `default_class`, `classes`, `batch_size`, `max_concurrent_batches`, `max_retries`, `retry_backoff`, `tokenizer`, `cost_warn_threshold` — and not that one.

Every field it shows is inert until `enabled` is set. An operator reading top to bottom sees a fully-specified block and no way in.

## The part that actively misleads

Both the example and the reference section opened with:

> Built-in defaults cover the OpenAI path — no `reyn.yaml` changes are required for a fresh install with `OPENAI_API_KEY`.

With `enabled` defaulting to `False`, that is **false as written**. Set the key, change nothing else, and `search_actions`, knowledge retrieval, and the FP-0063 plugin's `rag_ingest` embed step all stay dark — while the operator has been told they are configured. That is the shape of the defect, not the missing line.

## What changed

- `enabled` leads the example's block, with its default stated, what it gates named, and **why** it is off (a provider and a per-call cost — a deliberate default, which is why this says so rather than changing it).
- Both "no edits required" claims are scoped to *after* it is on, where they are true.
- The reference **field table already documented `enabled` correctly** — only its section opener carried the claim. Fixed there, table untouched.

Nothing about the default changes.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `mkdocs build --strict` — 0 errors
- [x] `pytest -k "config_mirror or local_example or embedding"` — 187 passed (includes the config-mirror gate that checks the example against the dataclass)
- [x] Verified against the source rather than the docs: `EmbeddingConfig().enabled` is `False`, and `config/embedding.py:55-74` is what the new wording paraphrases

## Note

Same file, same class of defect as #3626, where I wrote that a litellm catalog miss was intermittent — reyn pins the local map, so it is permanent. Both were prose in this example asserting something nobody had checked. Worth a gate eventually; not proposing one here without a way to check a claim mechanically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)