### PR TITLE
fix(testing): LLMReplay regenerate-in-place replaces, not appends; stacking CI gate (#3634)

### DIFF
--- a/docs/deep-dives/contributing/testing.ja.md
+++ b/docs/deep-dives/contributing/testing.ja.md
@@ -387,12 +387,20 @@ python -m pytest tests/test_replay_my_area.py -v
 # フィクスチャが tests/fixtures/llm/my_area/my_scenario.jsonl に書き込まれます
 ```
 
-**意図的なプロンプトのドリフト後**: フィクスチャを削除して再記録します:
+**意図的なプロンプトのドリフト後**: `REYN_LLM_RECORD=1` で再記録します —
+事前の削除はもう不要です（#3634 で `LLMReplay.flush()` が「追記」でなく
+「再記録/置き換え済みエントリを置換」するようになったため、その場での
+再生成が schema 世代を積み重ねることはなくなりました）:
 
 ```bash
-rm tests/fixtures/llm/my_area/my_scenario.jsonl
 REYN_LLM_RECORD=1 python -m pytest tests/test_replay_my_area.py -v
 ```
+
+事前削除（`rm tests/fixtures/llm/my_area/my_scenario.jsonl`）も引き続き
+動作しますが、それは好みの問題であり正しさの要件ではありません — 詳細は
+`write-replay-tests.md` の Step 4 と `LLMReplay.flush` 自身の docstring、
+積層したフィクスチャが再度混入した場合に検出する CI ゲートである
+`tests/test_replay_fixture_no_stacking_3634.py` を参照してください。
 
 ### ドリフト検出 — 各エリアで必須
 

--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -525,12 +525,21 @@ python -m pytest tests/test_replay_my_area.py -v
 # Fixture written to tests/fixtures/llm/my_area/my_scenario.jsonl
 ```
 
-**After intentional prompt drift**: delete the fixture and re-record:
+**After intentional prompt drift**: re-record with `REYN_LLM_RECORD=1` —
+deleting first is no longer required (#3634 made `LLMReplay.flush()` replace
+a re-recorded/superseded entry instead of appending alongside it, so
+regenerating in place cannot stack schema generations any more):
 
 ```bash
-rm tests/fixtures/llm/my_area/my_scenario.jsonl
 REYN_LLM_RECORD=1 python -m pytest tests/test_replay_my_area.py -v
 ```
+
+Deleting first (`rm tests/fixtures/llm/my_area/my_scenario.jsonl`) still
+works if you prefer an explicit "starting from nothing," but it is a
+preference, not a correctness requirement — see `write-replay-tests.md`
+Step 4 and ``reyn.dev.testing.replay.LLMReplay.flush``'s own docstring for
+the mechanism, and `tests/test_replay_fixture_no_stacking_3634.py` for the
+CI gate that would catch it if a stacked fixture landed anyway.
 
 ### Drift detection — required for each area
 

--- a/docs/guide/for-reyn-developers/write-replay-tests.md
+++ b/docs/guide/for-reyn-developers/write-replay-tests.md
@@ -255,14 +255,24 @@ changes and replay mode raises `MissingFixture`. This is expected and correct.
 An intentional change to the MCP catalog instead raises `PreconditionMismatch`;
 re-recording is the same fix, and it also refreshes the captured snapshot.
 
-Re-record by deleting the fixture and running with `REYN_LLM_RECORD=1`:
+Re-record with `REYN_LLM_RECORD=1` — **no manual delete required (#3634)**:
 
 ```bash
-rm tests/fixtures/llm/my_area/text_only.jsonl
 REYN_LLM_RECORD=1 python -m pytest tests/test_replay_my_area.py -v
 ```
 
-Or delete and let conftest auto-detect the missing file:
+`LLMReplay.flush()` replaces, not appends: an entry this run re-recorded
+(same call, unchanged) or superseded (same call, changed tool schema) is
+dropped from the on-disk copy before the fresh one is written, and any OTHER
+entry — e.g. one recorded by a sibling test that shares this same fixture
+file — is left untouched. Before #3634, `flush()` only ever appended, so
+regenerating in place after a schema change (even a `description`-only edit)
+left the OLD entry on disk alongside the new one: the fixture then matched
+BOTH the old and the new schema and stayed green regardless of which one the
+code implements — worse than a stale fixture, which at least goes RED. Delete
+the fixture first if you prefer an explicit "starting from nothing" (conftest
+auto-detects the missing file and switches to record mode), but it is no
+longer required for correctness:
 
 ```bash
 rm tests/fixtures/llm/my_area/text_only.jsonl
@@ -272,6 +282,8 @@ python -m pytest tests/test_replay_my_area.py -v
 
 Commit the new fixture alongside the change. Reviewers can diff the
 `prompt_preview` field in the JSONL to see what changed.
+`tests/test_replay_fixture_no_stacking_3634.py` is a CI gate that fails if any
+committed fixture ever holds the same logical call under more than one key.
 
 > **Warning — `-k` filtered runs exclude replay tests.** If your local test run uses
 > `-k some_keyword` that does not match replay test names, replay tests are silently

--- a/docs/reference/testing/replay.md
+++ b/docs/reference/testing/replay.md
@@ -43,9 +43,11 @@ Restores the original `litellm.acompletion` / `litellm.aembedding`. Safe to call
 
 ### `flush()`
 
-Writes pending record-mode entries to `fixture_path`. Appends to the existing file; creates the file and parent directories if they do not exist. No-op in replay mode.
+Writes pending record-mode entries to `fixture_path`; creates the file and parent directories if they do not exist. No-op in replay mode.
 
-In **record** mode it additionally asks each precondition to *capture* the live environment and writes one `"environment"` line per captured snapshot (#3473) — at the end of recording, when whatever populates that environment has had the whole run to do so. A replay-mode `flush()` captures nothing: appending this machine's environment to a committed fixture is the opposite of the guarantee.
+**Replaces, not appends (#3634).** Regenerating a fixture in place — re-running a `mode="record"` test against unchanged code, no manual delete required — no longer stacks: an on-disk entry is dropped, not kept alongside the fresh one, when it shares this session's exact key (an unchanged call re-recorded verbatim) or shares the same `reyn.dev.testing.replay_stacking.group_signature` (model + `tool_choice` + per-message digests — i.e. everything the key hashes over EXCEPT `tools`) as a call this session just recorded — that second case is an EARLIER schema generation of a call this run superseded. Every other on-disk entry — e.g. one recorded by a sibling test that shares this same fixture file — is preserved untouched, so re-recording one test in a multi-test fixture file does not erase its siblings. Before #3634, `flush()` unconditionally appended, so regenerating in place after a tool schema change (including a description-only edit) left the OLD entry on disk alongside the new one and the fixture matched both schema generations — green either way, measuring neither; `tests/test_replay_fixture_no_stacking_3634.py` is the CI gate against that class recurring.
+
+In **record** mode it additionally asks each precondition to *capture* the live environment and writes one `"environment"` line per captured snapshot (#3473) — at the end of recording, when whatever populates that environment has had the whole run to do so. A replay-mode `flush()` captures nothing: writing this machine's environment into a committed fixture is the opposite of the guarantee.
 
 ### Context manager
 

--- a/src/reyn/dev/testing/replay.py
+++ b/src/reyn/dev/testing/replay.py
@@ -73,6 +73,19 @@ Set ``REYN_LLM_RECORD=1`` before running pytest to call the real LLM/embedding
 provider and write fixtures. If a fixture file is absent, record mode is
 activated automatically (first-run fixture generation).
 
+#3634: regenerating in place REPLACES a call's stale entry, not appends
+alongside it. Before #3634, :meth:`flush` only ever appended, so re-recording
+a call whose TOOL SCHEMA changed (including a description-only edit — the
+schema hash covers the whole tool payload) produced a new key while the old
+entry stayed on disk; the fixture then matched both the old and the new
+schema and never went RED again, regardless of which one the code actually
+implements. See ``reyn.dev.testing.replay_stacking`` for the grouping rule
+that lets :meth:`flush` tell "this session re-recorded that exact call under
+a new key" (drop the old one) from "a different call recorded by a sibling
+test sharing this same fixture file" (keep it) — and
+``tests/test_replay_fixture_no_stacking_3634.py`` for the CI gate that fails
+if any committed fixture holds a stacked group anyway.
+
 Sensitive data note
 -------------------
 ``prompt_preview`` is capped at 200 characters and is purely informational.
@@ -94,6 +107,7 @@ from reyn.dev.testing.replay_preconditions import (
     ReplayRequest,
     default_preconditions,
 )
+from reyn.dev.testing.replay_stacking import group_signature
 
 if TYPE_CHECKING:
     pass
@@ -303,8 +317,37 @@ class LLMReplay:
     def flush(self) -> None:
         """Write pending record-mode entries to the fixture file.
 
-        Appends new entries; existing entries are not rewritten.  The
-        fixture directory is created automatically.
+        #3634: REPLACES, not appends. A naive append made regenerating a
+        fixture in place — the documented procedure — stack schema
+        generations: re-recording a call whose tool schema changed produced
+        a NEW key while the OLD entry (recorded against the old schema)
+        stayed on disk, so the fixture then matched both generations and
+        stopped measuring anything (a stale fixture goes RED and gets
+        noticed; a stacked one stays GREEN). The fix drops two kinds of
+        on-disk entry before writing:
+
+        1. Any entry whose ``key`` matches a key THIS session (re-)recorded —
+           an unchanged call re-recorded verbatim would otherwise leave a
+           byte-identical duplicate line every time (harmless to a replay
+           lookup, which collapses same-key entries into one dict slot, but
+           still fixture bloat / git-diff noise for no reason).
+        2. Any completion entry whose :func:`replay_stacking.group_signature`
+           (model + tool_choice + per-message digests, i.e. everything the
+           key hashes over EXCEPT ``tools`` — the one component a schema
+           change is expected to move) matches an entry this session
+           recorded — that is an EARLIER generation of a call this run
+           superseded, the #3634 stacking case proper.
+
+        Every other on-disk entry (a genuinely different call, e.g. one
+        recorded by a SIBLING test sharing this same fixture file —
+        ``llm_tools/text_only.jsonl`` is read by four separate tests) is
+        preserved untouched: this is a surgical replace of only what this
+        session (re-)recorded, not a wholesale truncate, so cross-test
+        accumulation into one shared fixture file still works. An on-disk
+        entry predating #3473 carries no ``key_components`` fingerprint and
+        so cannot be grouped by rule 2 — it is preserved unconditionally
+        unless rule 1 (exact key match) applies, degrading to the old
+        append-only safety rather than silently deleting un-groupable data.
 
         #3473: in RECORD mode each precondition is asked to :meth:`capture` the
         live environment here — at the END of recording, when whatever
@@ -312,7 +355,9 @@ class LLMReplay:
         recorded run to do so. The snapshots are written as ``"environment"``
         lines and are what a later replay injects. A replay-mode flush
         captures nothing: it would append this machine's environment to a
-        committed fixture, which is the opposite of the guarantee.
+        committed fixture, which is the opposite of the guarantee. (In
+        practice a replay-mode flush is always a no-op: only record-mode
+        calls ever populate ``self._pending``.)
         """
         captured = [
             {"kind": "environment", "name": precondition.name, "value": snapshot}
@@ -324,8 +369,56 @@ class LLMReplay:
         if not self._pending and not captured:
             return
         self.fixture_path.parent.mkdir(parents=True, exist_ok=True)
-        with self.fixture_path.open("a", encoding="utf-8") as fh:
-            for entry in [*captured, *self._pending]:
+
+        if self.mode != "record":
+            # Unreachable in practice (see docstring) — kept as the safe
+            # append fallback rather than silently rewriting a fixture no
+            # replay-mode caller asked to change.
+            with self.fixture_path.open("a", encoding="utf-8") as fh:
+                for entry in [*captured, *self._pending]:
+                    fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+            self._pending.clear()
+            return
+
+        session_groups = {
+            group_signature(entry["key_components"])
+            for entry in self._pending
+            if entry.get("kind", "completion") == "completion"
+            and isinstance(entry.get("key_components"), dict)
+        }
+        # Every key this session (re-)recorded, completion AND embedding
+        # alike -- an on-disk entry sharing one of these keys is about to be
+        # rewritten verbatim by the fresh pending copy, so keeping the old
+        # line too would be a byte-identical duplicate (harmless to replay,
+        # since a dict lookup collapses it, but still a fixture that grows a
+        # line every time an UNCHANGED call is re-recorded).
+        session_keys = {entry["key"] for entry in self._pending}
+
+        kept_existing: list[dict[str, Any]] = []
+        if self.fixture_path.exists():
+            for raw_line in self.fixture_path.read_text(encoding="utf-8").splitlines():
+                raw_line = raw_line.strip()
+                if not raw_line:
+                    continue
+                try:
+                    entry = json.loads(raw_line)
+                except Exception:
+                    # Corrupt line — same silent-skip policy as `_load`.
+                    continue
+                key = entry.get("key")
+                if key in session_keys:
+                    continue  # this session re-recorded this exact call — drop the old copy
+                if entry.get("kind", "completion") == "completion":
+                    components = entry.get("key_components")
+                    if (
+                        isinstance(components, dict)
+                        and group_signature(components) in session_groups
+                    ):
+                        continue  # stale earlier-generation duplicate — drop
+                kept_existing.append(entry)
+
+        with self.fixture_path.open("w", encoding="utf-8") as fh:
+            for entry in [*kept_existing, *captured, *self._pending]:
                 fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
         self._pending.clear()
 

--- a/src/reyn/dev/testing/replay_stacking.py
+++ b/src/reyn/dev/testing/replay_stacking.py
@@ -1,0 +1,103 @@
+"""Stacked-fixture detection (#3634).
+
+A committed ``LLMReplay`` fixture "stacks" when the SAME logical call — the
+same conversation-so-far, i.e. the same ``model`` + ``tool_choice`` + per-
+message digest sequence — is recorded under more than one ``key``. This
+happens when a tool's schema (its JSON schema, INCLUDING its ``description``
+string — #3634 measured that a description-only edit already moves the key)
+changes and the fixture is regenerated **in place**: :meth:`LLMReplay.flush`
+used to only ever append, so the OLD entry (recorded against the old schema)
+stayed on disk right alongside the NEW one, and the fixture then matched
+BOTH schema generations — green regardless of which one the code actually
+implements, which is worse than a stale fixture (a stale one goes RED and
+gets noticed).
+
+:func:`group_signature` is the grouping key two entries share when they are
+the same logical call under different generations: everything the SHA-256
+key hashes over EXCEPT ``tools`` — the one component a schema change is
+*expected* to move, so grouping on it would hide the exact thing this module
+exists to catch. It reads the per-component fingerprint (`key_components`,
+#3473's ``replay_key_diff.fingerprint``) each entry recorded since #3473
+carries. A pre-#3473 entry carries no fingerprint and cannot be grouped
+precisely — see :func:`stacked_groups`'s docstring for how that gap is
+handled (skipped, not guessed).
+
+Two consumers share this one grouping rule rather than each re-deriving it:
+:meth:`LLMReplay.flush` (record mode: drop an old entry from the SAME group
+a session just re-recorded, so regenerating in place replaces instead of
+appending — see ``reyn.dev.testing.replay``'s module docstring "Record
+mode") and ``tests/test_replay_fixture_no_stacking_3634.py`` (the CI gate:
+every committed fixture must hold zero multi-key groups).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def group_signature(key_components: dict[str, Any]) -> tuple[Any, ...]:
+    """Return the (model, tool_choice, message-digest-sequence) signature.
+
+    Two entries with the same signature are the SAME logical call — deliberately
+    excluding ``tools``, the one component a schema change is expected to move.
+    """
+    return (
+        key_components.get("model"),
+        key_components.get("tool_choice"),
+        tuple(key_components.get("messages") or []),
+    )
+
+
+def iter_completion_entries(fixture_path: Path) -> list[dict[str, Any]]:
+    """Return every ``kind: completion`` entry in *fixture_path* (or legacy
+    entries with no ``kind`` field, which default to ``"completion"`` — see
+    ``LLMReplay._load``). Corrupt lines are skipped, mirroring ``_load``'s own
+    silent-skip policy for a test-artifact file."""
+    if not fixture_path.exists():
+        return []
+    entries = []
+    for raw_line in fixture_path.read_text(encoding="utf-8").splitlines():
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+        try:
+            entry = json.loads(raw_line)
+        except Exception:
+            continue
+        if entry.get("kind", "completion") == "completion":
+            entries.append(entry)
+    return entries
+
+
+def stacked_groups(fixture_path: Path) -> dict[tuple[Any, ...], list[str]]:
+    """Return ``{group_signature: [keys]}`` for every group holding MORE THAN
+    ONE distinct key among this fixture's completion entries.
+
+    Only entries carrying a #3473 ``key_components`` fingerprint can be
+    grouped precisely (the fingerprint is what lets two entries be recognised
+    as the same call minus ``tools``) — an entry recorded before #3473 has no
+    fingerprint and is silently excluded from grouping, not treated as its
+    own singleton group. This means a pre-#3473 fixture that is ALSO stacked
+    reports zero groups here, not a false "clean" verdict grounded in
+    evidence — the caller (the CI gate, the sweep) must say "unmeasurable",
+    never "measured clean", for such a file.
+    """
+    groups: dict[tuple[Any, ...], list[str]] = {}
+    for entry in iter_completion_entries(fixture_path):
+        components = entry.get("key_components")
+        if not isinstance(components, dict):
+            continue
+        sig = group_signature(components)
+        groups.setdefault(sig, []).append(entry.get("key"))
+    return {sig: keys for sig, keys in groups.items() if len(set(keys)) > 1}
+
+
+def has_fingerprinted_entries(fixture_path: Path) -> bool:
+    """True if at least one completion entry carries a #3473 fingerprint —
+    i.e. this fixture is precisely checkable by :func:`stacked_groups` at
+    all. Lets a caller distinguish "measured clean" from "unmeasurable"."""
+    return any(
+        isinstance(entry.get("key_components"), dict)
+        for entry in iter_completion_entries(fixture_path)
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,13 @@ Usage in tests::
 Environment variables
 ---------------------
 ``REYN_LLM_RECORD=1``
-    Force record mode — call the real LLM and overwrite / extend the fixture.
+    Force record mode — call the real LLM and re-record the fixture.
     Requires a live LLM backend (see ``project_local_env.md`` in memory).
+    #3634: this REPLACES each re-recorded call's stale entry rather than
+    appending a duplicate alongside it (``LLMReplay.flush``'s own docstring
+    has the mechanism) — a fixture shared by several tests keeps every
+    OTHER test's entries untouched, so re-running one test under
+    ``REYN_LLM_RECORD=1`` does not erase its siblings' recordings.
 
 Record mode is also activated automatically when a fixture file is missing
 (first-run bootstrap).

--- a/tests/test_fp0063_arc_witness.py
+++ b/tests/test_fp0063_arc_witness.py
@@ -69,19 +69,30 @@ description). Same switch, same verification — the NEW fixtures against the OL
 schema raise ``MissingFixture`` attributing the drift to ``present: schema
 differs (08b2323ddf3a -> 4ab741e16061)``.
 
-**Delete the fixture files before regenerating.** ``REYN_FP0063_ARC_WITNESS_GENERATE=1``
-records into whatever is already there, so regenerating in place APPENDS: the
-old keys survive alongside the new ones and the fixture then matches BOTH the
-old and the new schema — green either way, witnessing neither. Measured here:
+**Historical hazard, fixed by #3634 — regenerating in place used to APPEND.**
+``REYN_FP0063_ARC_WITNESS_GENERATE=1`` used to record into whatever was already
+there, and ``LLMReplay.flush`` only ever appended: the old keys survived
+alongside the new ones and the fixture then matched BOTH the old and the new
+schema — green either way, witnessing neither. Measured at the time (#3630):
 regenerating in place took ``turn1`` from 6 keys to 8 with all 6 old ones intact,
-and the result passed against the pre-change ``present`` schema. Deleting first
-produced 2 keys, and that fixture fails against the old schema as it should.
+and the result passed against the pre-change ``present`` schema; deleting the
+file first produced 2 keys, and that fixture failed against the old schema as
+it should. The same measurement showed the committed fixture had ALREADY been
+accumulating this way: ``turn1`` carried the SAME two logical calls three times
+over with six distinct keys, i.e. three schema generations layered by earlier
+in-place regenerations, any of which would have satisfied a run.
 
-The same measurement says the committed fixture had been accumulating: ``turn1``
-carried the SAME two logical calls three times over with six DISTINCT keys, i.e.
-three schema generations layered by the earlier in-place regenerations, any of
-which would have satisfied a run. The counts this re-key leaves (``turn1`` 2
-keys, ``turn2`` 3) are the arc's actual call count, not a reduction in coverage.
+#3634 made this class of accumulation impossible instead of merely
+work-around-able: ``LLMReplay.flush`` now REPLACES an on-disk entry with the
+freshly-recorded one when a completion this session just recorded shares its
+``reyn.dev.testing.replay_stacking.group_signature`` (model + tool_choice +
+per-message digests — i.e. everything the key hashes over except ``tools``,
+the one component a schema change is expected to move), so regenerating THIS
+file in place with ``REYN_FP0063_ARC_WITNESS_GENERATE=1`` (no manual delete
+required) now leaves exactly the arc's actual call count (``turn1`` 2 keys,
+``turn2`` 3), not a reduction in coverage — and
+``tests/test_replay_fixture_no_stacking_3634.py`` is the CI gate that fails if
+any committed fixture (this one or any other) holds a stacked group anyway.
 
 Why the fixture responses are AUTHORED, not live-recorded (disclosed, not
 silently passed off as a live LLM transcript -- same disclosure norm as this

--- a/tests/test_replay_fixture_no_stacking_3634.py
+++ b/tests/test_replay_fixture_no_stacking_3634.py
@@ -1,0 +1,75 @@
+"""Tier 1: every committed LLM replay fixture holds zero stacked-generation
+groups (#3634).
+
+A fixture "stacks" when the SAME logical call — same ``model`` + ``tool_choice``
++ per-message digest sequence, i.e. everything ``LLMReplay.key`` hashes over
+EXCEPT ``tools`` — is recorded under more than one key. This happens when a
+tool's schema changes (a JSON-schema field, or ONLY its ``description`` string
+— #3634 measured that a description-only edit already moves the key) and the
+fixture is regenerated in place: before #3634, ``LLMReplay.flush`` only ever
+appended, so the OLD entry (recorded against the old schema) survived
+alongside the NEW one and the fixture then matched BOTH schema generations —
+green regardless of which one the code actually implements. That is worse
+than a stale fixture: a stale fixture goes RED and gets noticed; a stacked
+one stays GREEN and measures nothing, and ordinary CI has no way to tell.
+
+This gate is the structural backstop #3634 asks for: even though #3634 also
+fixed ``LLMReplay.flush`` to replace instead of append (so a clean
+regeneration cannot stack going forward), this test is what would catch a
+FUTURE regression in that mechanism, or a stacked fixture landing by some
+other path (a hand-edited fixture, a merge conflict resolved by picking both
+sides), without requiring a human to notice.
+
+Coverage caveat (measured, not assumed): grouping requires each entry's
+#3473 ``key_components`` fingerprint. An entry recorded before #3473 carries
+none and cannot be grouped precisely — ``replay_stacking.stacked_groups``
+silently excludes it rather than guessing, so a pre-#3473 fixture that
+happens to ALSO be stacked would report zero groups here. As of #3634, 32 of
+the 34 committed fixture files under ``tests/fixtures/llm`` predate #3473 and
+are therefore UNMEASURABLE by this gate (not "measured clean") — every
+fixture recorded or re-recorded from here on carries the fingerprint, so this
+gap only affects fixtures nobody has touched since #3473 landed and it
+shrinks every time one of those is legitimately re-recorded.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.dev.testing.replay_stacking import has_fingerprinted_entries, stacked_groups
+
+_FIXTURES_ROOT = Path(__file__).parent / "fixtures" / "llm"
+_FIXTURE_FILES = sorted(_FIXTURES_ROOT.rglob("*.jsonl"))
+
+
+@pytest.mark.parametrize(
+    "fixture_path",
+    _FIXTURE_FILES,
+    ids=[str(p.relative_to(_FIXTURES_ROOT)) for p in _FIXTURE_FILES],
+)
+def test_fixture_holds_no_stacked_generations(fixture_path: Path) -> None:
+    """Tier 1: a committed fixture never carries the same logical call under
+    more than one key.
+
+    Only checkable for fixtures carrying at least one #3473 ``key_components``
+    fingerprint — see module docstring. A fixture with none is skipped (not
+    passed): a skip here means "cannot tell", a pass means "checked, clean",
+    and conflating the two would let a genuinely unmeasurable, possibly-stacked
+    legacy fixture read as verified.
+    """
+    if not has_fingerprinted_entries(fixture_path):
+        pytest.skip(
+            f"{fixture_path.name} predates #3473 (no key_components "
+            "fingerprint on any entry) — stacking cannot be precisely "
+            "detected for this file. See module docstring."
+        )
+    stacked = stacked_groups(fixture_path)
+    assert not stacked, (
+        f"{fixture_path} holds {len(stacked)} logical call(s) recorded under "
+        f"more than one key (stale tool-schema generations stacked instead of "
+        f"replaced — #3634): "
+        + "; ".join(f"{len(set(keys))} distinct keys for one call" for keys in stacked.values())
+        + ". Re-record with the fixture-owning test (delete-first is no "
+        "longer required — #3634 made LLMReplay.flush replace in place)."
+    )


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3634.

## The defect (measured on #3632, this PR's basis)

`LLMReplay.flush()` only ever **appended** in record mode. Regenerating a
fixture in place (the documented `REYN_FP0063_ARC_WITNESS_GENERATE=1` /
`REYN_LLM_RECORD=1` procedure) after ANY tool schema change — including a
`description`-only edit, since the whole tool payload is part of the hashed
key — left the OLD entry on disk right alongside the NEW one. The fixture
then matched **both** schema generations: green either way, regardless of
which one the code actually implements. A stale fixture goes RED and gets
noticed; a stacked one stays GREEN and measures nothing, and ordinary CI
cannot tell the difference.

## Part 3 first — the sweep (sized the rest)

Enumerated all 34 committed files under `tests/fixtures/llm/**/*.jsonl` and
grouped completion entries by `(model, tool_choice, per-message-digest
sequence)` — everything the SHA-256 key hashes over **except** `tools`, the
one component a schema change is expected to move (`replay_stacking.
group_signature`). A group holding more than one distinct `key` is a stacked
call.

- **Precisely measurable**: only 2 of 34 files (`fp0063_arc_witness/turn1_install.jsonl`,
  `turn2_ingest_query.jsonl`) carry the #3473 `key_components` fingerprint this
  grouping needs. **Both are clean — 0 stacked groups** (already fixed by
  #3630's proper delete-first re-key; this PR's own gate now enforces it stays
  that way).
- **Unmeasurable**: the other 32 files predate #3473 and carry no
  fingerprint, so precise stacking detection is impossible from the fixture
  alone (this is stated as a coverage gap in the gate's own docstring, not
  papered over as "checked, clean").
- **Adjacent discovery, NOT the same defect**: while confirming which test
  reads each file, 26 of those 32 turned out to be referenced by **zero**
  current test (grepped the literal fixture path AND each directory's
  basename, repo-wide). These fixtures can't even be reached by a test run —
  filed separately as **#3645** (arc-closure-remainder rule: filed, not left
  as an implicit "someone will notice"). #3634's own scope is the
  stacking-while-green defect, not a fixture graveyard cleanup, so I did not
  delete or "fix" those 26 files here.

## Part 1 — regenerate replaces, not appends

`LLMReplay.flush()` (`src/reyn/dev/testing/replay.py`) now drops an on-disk
completion entry before writing when:

1. its `key` matches a key this SESSION just (re-)recorded (an unchanged call
   re-recorded verbatim would otherwise leave a byte-identical duplicate
   line), or
2. its `group_signature` matches an entry this session recorded but its `key`
   differs — an EARLIER schema generation of a call this run superseded
   (the #3634 case proper).

Every other on-disk entry — e.g. one recorded by a SIBLING test sharing the
same fixture file (`llm_tools/text_only.jsonl` is read by 4 separate tests)
— is preserved untouched: this is a surgical replace of only what this
session touched, not a wholesale truncate, so cross-test accumulation into
one shared fixture file still works. A pre-#3473 entry with no
`key_components` fingerprint can't be grouped by rule 2 and is preserved
unless rule 1 (exact key) applies — degrades to the old append-only safety,
never silent deletion of un-groupable data.

**Verified, not just "worked"**: a standalone record/re-record script (see
Test plan) confirms —
- Re-recording the SAME call after a tool-schema change: **1 line before,
  1 line after** (previously: stacks to 2+).
- Re-recording the SAME call unchanged: still 1 line (no duplicate).
- Two SEPARATE record sessions writing to ONE shared fixture file (the
  `llm_tools/text_only.jsonl` pattern), then re-recording only the first:
  the SECOND session's entry survives untouched (2 lines before, 2 after,
  not 3 or 1).

## Part 2 — the CI gate

`tests/test_replay_fixture_no_stacking_3634.py`: parametrized over every
`tests/fixtures/llm/**/*.jsonl` file. Skips (not passes) a file with zero
`key_components`-fingerprinted entries — "cannot tell" is reported
distinctly from "checked, clean." Fails if any group holds more than one
distinct key.

**RED/GREEN demonstrated against the real gate** (not just the underlying
function): copied `turn1_install.jsonl` to a throwaway
`fp0063_arc_witness/_demo_stacked_3634.jsonl`, duplicated its first
completion entry under a fake key (same `group_signature`, different `key`)
— `pytest tests/test_replay_fixture_no_stacking_3634.py::...[_demo_stacked_3634.jsonl]`
→ **FAILED**, reporting the exact stacked group. Removed the duplicate line →
**PASSED**. Demo file deleted before commit (not part of the diff).

## Docs updated in this PR (all described the now-fixed procedure)

- `docs/reference/testing/replay.md` — `flush()` section
- `docs/guide/for-reyn-developers/write-replay-tests.md` — Step 4
- `docs/deep-dives/contributing/testing.md` — "Recording fixtures"
- `docs/deep-dives/contributing/testing.ja.md` — same section (not a
  blanket mirror obligation; fixed because this PR falsifies its own
  "delete first" claim, per CLAUDE.md rule 5)
- `tests/test_fp0063_arc_witness.py`'s own module docstring — reframed the
  #3630 "delete first" note as history, pointing at the #3634 mechanism
  that makes it no longer necessary
- `tests/conftest.py` — `REYN_LLM_RECORD=1` docstring

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_replay_fixture_no_stacking_3634.py tests/test_fp0063_arc_witness.py tests/conftest.py` — 2 tests inspected, 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py src/reyn/dev/testing/replay.py src/reyn/dev/testing/replay_stacking.py` — OK
- [x] `pytest tests/test_replay_fixture_no_stacking_3634.py` — 2 passed, 32 skipped
- [x] `pytest tests/test_fp0063_arc_witness.py` — 1 passed, no fixture drift on disk
- [x] `pytest tests/test_3473_replay_environment_precondition.py` — 11 passed (flush() change doesn't regress precondition capture/injection)
- [x] `pytest tests/test_llm_tools.py tests/test_config_write_jit_bus_3086.py tests/test_2761_pr2_hotreload_immediate_apply.py tests/test_intervention_subscriber_guard.py tests/test_0060_phase1_layer_a.py` — 52 passed, no fixture drift (the shared/marker-based `@pytest.mark.replay` path exercised end to end)
- [x] Gate RED/GREEN demonstrated against the real test file (see above)
- [x] flush()-replace behavior verified with a standalone record/re-record script for: schema-changed re-record, unchanged re-record, and sibling-test-shared-file re-record (see above)
- [x] Full local `pytest` — intentionally NOT run per CLAUDE.md; CI is authoritative for that gate
- [x] Follow-up filed: #3645 (26/34 orphaned fixture files, a distinct problem from stacking, discovered during the sweep)

Part of the #3634 arc closure: only this PR references #3634; verified with
`gh pr list --state all --search "3634 in:body"` before opening (empty).