### PR TITLE
fix(tests): replace wall-clock bounds with deterministic completion signals — #3590 #3594

### DIFF
--- a/tests/test_fp0066_p3b_repo_knowledge_ingest.py
+++ b/tests/test_fp0066_p3b_repo_knowledge_ingest.py
@@ -135,6 +135,36 @@ def _patch_repo_root(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
     monkeypatch.setattr(_rr_mod, "resolve_reyn_root", lambda: root)
 
 
+async def _await_scheduled_source_build(
+    coordinator: IndexCoordinator, manifest: Any, source_id: str,
+) -> None:
+    """Deterministically wait for a background-scheduled build to reach its
+    final manifest state — no wall-clock sleep, no elapsed-time threshold
+    (#3594).
+
+    ``ensure_built(await_completion=False)`` (what
+    ``sync_repo_ingest_background`` calls) schedules ``asyncio.create_task``
+    and returns before the task has had a single event-loop tick to run —
+    the manifest entry does not exist yet, so ``search_await`` (the public
+    completion-await surface) would see "no entry" and take its no-op
+    branch, never actually awaiting anything. The bounded loop below gives
+    the scheduled task event-loop ticks (``asyncio.sleep(0)`` — a
+    cooperative yield, not a timed wait) until the manifest entry exists
+    (``_run_build``'s first line is ``await self._set_state(source_id,
+    "building")``, so the entry appears as soon as the task gets to run at
+    all); ``search_await`` then hands off to the coordinator's own
+    ``_bg_tasks`` await, which is the actual completion signal. The loop
+    bound (2000 ticks) is a safety net against a genuinely broken scheduler,
+    not a timing budget — if the entry never appears, ``search_await`` still
+    no-ops and the caller's own state assertion goes red for the real
+    reason (state never reached "clean"), rather than this helper hanging."""
+    for _ in range(2000):
+        if await manifest.get(source_id) is not None:
+            break
+        await asyncio.sleep(0)
+    await coordinator.search_await(source_id)
+
+
 # ── 1. static/background, non-blocking ──────────────────────────────────
 
 
@@ -163,36 +193,31 @@ def test_sync_repo_ingest_background_does_not_block_the_triggering_call(
     op_ctx = _make_op_ctx(ws_root)
     events = EventLog()
 
-    import time
-
-    async def _trigger_then_wait() -> tuple[float, Any, Any]:
-        start = time.monotonic()
-        await sync_repo_ingest_background(coordinator, op_ctx, events=events)
-        elapsed = time.monotonic() - start
-        # Let the background tasks actually run to completion — comfortably
-        # longer than the provider's artificial delay. This is a direct
-        # ``asyncio.sleep`` rather than ``search_await`` deliberately: right
-        # after ``ensure_built(await_completion=False)`` schedules a task,
-        # the task has not had a single event-loop tick to run yet, so the
-        # manifest entry does not exist — ``search_await`` treats a missing
-        # entry as "nothing to await" (its no-op branch) and would return
-        # immediately without ever giving the task a chance to run. A real
-        # caller never hits this race (it calls ``search_await`` on a LATER
-        # turn, after many intervening event-loop iterations); this test
-        # sidesteps it the same way by giving the loop real time to run the
-        # scheduled tasks before reading final state.
-        await asyncio.sleep(provider.delay + 0.2)
+    async def _trigger_then_wait() -> tuple[list[tuple[str, ...]], Any, Any]:
         manifest = get_source_manifest(ws_root)
-        return elapsed, await manifest.get(KNOWLEDGE_REPO_DOC_SOURCE_ID), await manifest.get(
-            KNOWLEDGE_REPO_SRC_SOURCE_ID,
+        await sync_repo_ingest_background(coordinator, op_ctx, events=events)
+        # The caller must not have blocked on the embed work. If it had,
+        # ``provider.embed`` would already have been called by the time this
+        # await returns — checked directly on the provider's own call log,
+        # never on an elapsed-time threshold (#3594: a wall-clock bound here
+        # produced false failures under CI load, since "scheduled but not
+        # yet run" and "genuinely slow to schedule" look identical to a
+        # timer but NOT to this call-log check).
+        calls_right_after_trigger = list(provider.calls)
+        await _await_scheduled_source_build(coordinator, manifest, KNOWLEDGE_REPO_DOC_SOURCE_ID)
+        await _await_scheduled_source_build(coordinator, manifest, KNOWLEDGE_REPO_SRC_SOURCE_ID)
+        return (
+            calls_right_after_trigger,
+            await manifest.get(KNOWLEDGE_REPO_DOC_SOURCE_ID),
+            await manifest.get(KNOWLEDGE_REPO_SRC_SOURCE_ID),
         )
 
-    elapsed, doc_entry, src_entry = _run(_trigger_then_wait())
+    calls_right_after_trigger, doc_entry, src_entry = _run(_trigger_then_wait())
 
-    assert elapsed < 0.15, (
-        f"sync_repo_ingest_background took {elapsed:.3f}s to return with a "
-        "0.3s provider delay — it must have blocked on the embed work "
-        "instead of only scheduling a background task (§8)"
+    assert calls_right_after_trigger == [], (
+        f"sync_repo_ingest_background's own await already reached the embed "
+        f"provider ({calls_right_after_trigger!r}) — it must have blocked "
+        "on the embed work instead of only scheduling a background task (§8)"
     )
     assert doc_entry is not None and doc_entry.state == "clean"
     assert src_entry is not None and src_entry.state == "clean"

--- a/tests/test_textual_chat_gutter_toggle_3352.py
+++ b/tests/test_textual_chat_gutter_toggle_3352.py
@@ -85,6 +85,33 @@ def _config(*, left: bool = True, right: bool = True) -> ReynConfig:
     return ReynConfig(chat=ChatConfig(gutters=GutterConfig(left=left, right=right)))
 
 
+async def _drain_presenter_workers(app: TextualChatApp) -> None:
+    """Deterministically wait for FlowView's in-flight ``present()`` workers
+    to finish, rather than assuming ``pilot.pause()`` was enough (#3590).
+
+    ``pilot.pause()`` decides "idle" by comparing wall-clock time against
+    process CPU time (``textual._wait.wait_for_idle``) — a wall-clock proxy,
+    not a completion signal. Under CI contention it can return control to the
+    test before a scheduled ``run_worker`` task (FlowView's
+    ``flowview-present-{entry.id}`` group, started synchronously by
+    ``_present_entry`` but executed on the event loop later) has actually
+    run, so a stale-width present lands AFTER the snapshot point instead of
+    before it. ``App.workers`` is Textual's own public completion signal for
+    exactly this; filtered to the presenter's own worker group (NOT
+    ``wait_for_complete()`` unfiltered, which would hang forever on the
+    app's own infinite ``frames`` pump worker —
+    ``TextualChatApp`` starts it with ``run_worker(self._pump_frames(),
+    name="frames", exclusive=True)`` and it never completes for the life
+    of the app)."""
+    presenting = [w for w in app.workers if w.group.startswith("flowview-present-")]
+    if presenting:
+        # ``wait_for_complete(workers)`` falls back to waiting on EVERY
+        # worker in the manager when ``workers`` is falsy (its own
+        # ``workers or self``) — an empty list must short-circuit here, or
+        # this would hang forever on the app's infinite ``frames`` worker.
+        await app.workers.wait_for_complete(presenting)
+
+
 def _offenders(
     app: TextualChatApp, *, bounds: "tuple[int, int] | None" = None
 ) -> "dict[str, tuple[int, int, int, int]]":
@@ -314,7 +341,16 @@ async def test_the_body_is_actually_re_presented_at_the_recovered_width() -> Non
     merely reporting a larger number while the rendered rows stay laid out for
     the old width. Read off the real collaboration seam
     (:class:`_WidthRecordingPresenter`, a real ``ReynPresenter`` subclass that
-    records what FlowView hands ``present()``)."""
+    records what FlowView hands ``present()``).
+
+    The snapshot point (``seen_before``) and the read point (``after``) both
+    sit past :func:`_drain_presenter_workers`, not merely past a second
+    ``pilot.pause()`` — #3590: two unrelated PRs each showed a stray
+    pre-toggle width (``{66, 78}`` instead of ``{78}``) landing in the
+    "after" window under CI contention. The stray width was the FIRST
+    present (triggered by the ``op-reflow`` push) completing AFTER the
+    snapshot instead of before it, because ``pilot.pause()``'s cpu-idle
+    heuristic is a wall-clock proxy, not a worker-completion signal."""
     transport = QueueTransport()
     presenter = _WidthRecordingPresenter()
     app = TextualChatApp(transport=transport, presenter=presenter)
@@ -322,12 +358,14 @@ async def test_the_body_is_actually_re_presented_at_the_recovered_width() -> Non
         await pilot.pause()
         await transport.push(_started("op-reflow"))
         await pilot.pause()
+        await _drain_presenter_workers(app)
         flow = app._flow
         seen_before = len(presenter.widths)
         recovered = flow.body_width + RIGHT_GUTTER_WIDTH
 
         await pilot.press(RIGHT_KEY)
         await pilot.pause()
+        await _drain_presenter_workers(app)
         after = presenter.widths[seen_before:]
         assert after, "hiding the gutter re-presented nothing — the body never reflowed"
         assert set(after) == {recovered}, (


### PR DESCRIPTION
**[per-PR-coder]** — fixes the two wall-clock-bounded tests from #3590 and #3594.

## #3590 — gutter reflow test (`test_the_body_is_actually_re_presented_at_the_recovered_width`)

**Verdict: (A) test-side timing dependency, not a real defect** — confirmed by reading the mechanism, not by re-running until green.

**Mechanism**: the test assumes one more `pilot.pause()` after pushing the triggering frame is enough for FlowView's `flowview-present-{entry.id}` background worker (started via `run_worker`) to have converged before it snapshots `presenter.widths`. `pilot.pause()` decides "idle" via `textual._wait.wait_for_idle` — comparing wall-clock elapsed time against process CPU time, a heuristic proxy, not a completion signal. Under CI contention it can return control to the test before the scheduled worker has had its turn, so the FIRST present (triggered by the initial message push, at the pre-toggle width) lands in the "after" window instead of before it — exactly the observed `{66, 78}` instead of `{78}`.

**Reproduction, measured**:
- Forced maximal race (skip the intervening `pilot.pause()` entirely, so the initial present is provably not yet scheduled when the snapshot is taken): **old test body — 5/5 reproduces `{66, 78}`** (deterministic once the race is forced open — this is what confirms the mechanism, not a probabilistic re-run).
- Same forced-race harness with the fix (`pilot.pause()` + drain on `App.workers.wait_for_complete()`, filtered to the `flowview-present-` group): **0/30**.
- Natural regime (in-process, asyncio-level synthetic competitor task): **0/30 both before and after** — I was not able to reproduce a nonzero *natural* rate in this environment (an in-process asyncio busy-task is a weaker perturbation than real OS-level CI contention); the forced-race harness is the stronger, mechanism-level evidence, stated here plainly rather than papered over with an inflated rate.
- Through `pytest`, 30/30 pass both before and after (consistent with #3581's own finding that `pytest`'s overhead widens the window and hides the race).

**Fix**: added `_drain_presenter_workers(app)`, which waits on `App.workers.wait_for_complete()` filtered to the `flowview-present-` group — Textual's own public worker-completion signal — instead of a second `pilot.pause()`. (Unfiltered `wait_for_complete()` would hang forever on the app's own infinite `frames`-pump worker; caught this in review before it shipped.) Applied at both the snapshot point and the read point.

**RED-on-break**: stripping the real `action_toggle_right_gutter` to a no-op (the file's own established strip pattern) still fails the fixed test — `"hiding the gutter re-presented nothing — the body never reflowed"` — confirming the drain-based fix did not make the gate vacuous.

Swept the file for the same shape: `test_width_recovery_gate_is_load_bearing_against_a_dead_action` also reads `presenter.widths` after a push+pause, but its assertion is a *subset* check (`<= {before}`) that a stray leaked pre-toggle width cannot falsify (it equals `before` either way), so it is not exposed to this race and was left alone.

## #3594 — repo-knowledge ingest test (`test_sync_repo_ingest_background_does_not_block_the_triggering_call`)

Two independent wall-clock bounds, per the issue's own read of the mechanism:

1. **`elapsed < 0.15`** approximated "the caller did not block on the embed provider". Replaced with a direct check: `provider.calls == []` immediately after the trigger call returns. This is what "did not block" actually means, with no dependency on machine speed at all.
2. **`state == "clean"` after a fixed `asyncio.sleep(provider.delay + 0.2)`** assumed the background build would finish inside that window. Replaced with `_await_scheduled_source_build`: a bounded tick-poll (`asyncio.sleep(0)`, not a timed wait) until the manifest entry exists, then `IndexCoordinator.search_await` — the module's own public completion-await surface, which awaits the actual in-flight `_bg_tasks` entry. The tick-poll exists only to bridge search_await's documented "no entry yet = nothing to await" no-op window; it has no timing budget, and if the entry never appears the caller's own state assertion still goes red for the real reason.

**Reproduction, measured** (GIL-hogging competitor thread in-process, real OS-level CPU contention — the same class of interference #3594 attributes to CI load):
- `state == "clean"` bound: **old (fixed sleep) — 15/15 fails** under a 0.6s hog (exceeding the 0.5s sleep window) vs **new (search_await) — 0/15** under the identical hog.
- `elapsed < 0.15` bound: did not reproduce under this harness (0/20 with and without the hog) — `sync_repo_ingest_background` itself does very little internal awaiting before returning, so GIL contention delays *when* it runs but not *how much work* it does once scheduled. The actually-observed CI failure (`'building' == 'clean'`) matches the second bound, not this one; fixed both since both are wall-clock-dependent regardless.
- Through `pytest`, 30/30 pass both before and after.

**RED-on-break**, both parts:
- (A) forcing `IndexCoordinator.ensure_built` to always block (`await_completion=True`) → `calls_right_after_trigger` is non-empty → assertion fails with the real provider call log printed.
- (B) forcing the embed provider to always raise → the source never reaches `clean` → `doc_entry.state == "clean"` fails (real AssertionError, not a hang).

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_textual_chat_gutter_toggle_3352.py tests/test_fp0066_p3b_repo_knowledge_ingest.py` — 18/18 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py` on both files — OK (no src/ changes in this PR)
- [x] Both files run 30/30 through pytest, no flakes observed in this environment
- [x] Reproduction rates measured and stated honestly, including where I could NOT reproduce a natural (non-forced) rate
- [x] RED-on-break proof provided for both fixed assertions in both files
- [x] No mock/AsyncMock/patch/hand-rolled stand-in introduced; no private-state assertions added (the drain/poll helpers observe public `App.workers` / `manifest.get()` / `search_await`, never assert on them)
- [x] Did not run the full local `pytest` (CI is authoritative per policy) — ran only the two affected files plus targeted repro harnesses

Closes #3590
Closes #3594