### PR TITLE
fix(plugins): stop baking skill-dir/plugin-root tokens into history (#3629)

### DIFF
--- a/docs/concepts/tools-integrations/skills.md
+++ b/docs/concepts/tools-integrations/skills.md
@@ -293,6 +293,32 @@ baked, and doing so is a no-op once P2 starts baking them (a baked body has
 no `${...}` left to match). `${REYN_PROJECT_DIR}` and `${env:VAR_NAME}` are
 genuinely dynamic and are always resolved fresh, never baked.
 
+**#3629 — "stable location" describes the copy-time bake, not what a load
+persists to history.** The load-time-expanded VALUE (the string
+`load_skill` returns) still goes into `.reyn/agents/<id>/history.jsonl` as
+the tool result — and history is immutable. A rename or move of the
+plugin/skill directory after that point (#3588's shipped-skill rename above
+was one instance) used to leave the OLD absolute path baked into an old
+history entry forever, replayed to the model every later turn with no way
+to tell it apart from a live one. Since #3629, what gets **persisted**
+differs from what the model reads that turn: `${REYN_SKILL_DIR}`/
+`${REYN_PLUGIN_ROOT}` (+ their `${CLAUDE_*}` aliases) are left LITERAL in
+the persisted entry (`reyn.plugins.skill_load.load_skill_body`'s
+`persisted` return value; the resolved values ride along as
+audit-completeness metadata, `token_map`, never as a re-expansion source),
+and a wire-serialise pass re-resolves them FRESH against the current
+filesystem every time that entry is replayed
+(`reyn.plugins.skill_load.refresh_location_tokens`, wired into
+`RouterHistoryBuffer._serialise_turn`) — the same "resolved fresh each
+call, never baked into a durable copy" discipline `${REYN_PROJECT_DIR}`
+already had, extended to the two tokens that were missing it.
+`${REYN_PROJECT_DIR}`/`${env:VAR_NAME}` needed no change; they were already
+safe by this measure. Already-persisted (pre-#3629) history is neither
+rewritten nor annotated — the fix is forward-only; see
+[Not-found suggestions surface the current structure](#not-found-suggestions-surface-the-current-structure)
+below for what happens when the model tries to act on one of those old,
+now-dead paths.
+
 Reuses `reyn.plugins.tokens` (`PluginTokenContext` / `expand_reyn_tokens`) —
 the same expansion primitive an mcp server's spawn config and a pipeline's
 `ctx` params use (ADR §3.4's "uniform across capabilities" split) — rather
@@ -398,6 +424,25 @@ last check enforces a one-level-deep invariant: L1 (menu) -> L2 (router,
 leaf — a link from inside a reference to yet another file would be
 unreachable anyway (only `SKILL.md` gets token expansion), so an
 L3-to-L3 link is always a bug, not a valid deeper level.
+
+## Not-found suggestions surface the current structure
+
+#3629: already-persisted history is never rewritten (see the "stable
+location" note above), so a renamed/moved skill directory leaves old
+history entries pointing at a path that no longer exists — history
+outliving the filesystem is accepted as a permanent, forward-only-fixed
+cost. What changed instead is the surface where that stale reference
+actually causes harm: when the model tries to read a path whose PARENT
+directory is itself gone (not just empty — see the distinction below),
+`file.read`'s `not_found` result's `suggestions` list (`_nearby_files`,
+`src/reyn/core/op_runtime/file.py`) includes the nearest EXISTING ancestor
+directory instead of an empty list, so the model can discover the current
+structure on the spot rather than guessing a replacement path from a dead
+one. This is deliberately general (renames, moves, plugin reinstalls all
+produce the same "parent is gone" shape) — it distinguishes "no parent" (a
+renamed/moved directory — this fallback fires) from "no neighbours" (an
+existing-but-empty directory — the suggestions list legitimately stays
+`[]`, unchanged from before #3629).
 
 ## Hot-reload
 

--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -718,14 +718,34 @@ Handler lifecycle (`op_runtime/load_skill.py`):
    `${REYN_PROJECT_DIR}`/`${CLAUDE_*}` aliases unconditionally, and
    `${env:VAR}` only when `VAR` is declared on `ctx.permission_decl.
    env_expand` (#3198, deny-by-default) — an undeclared or unset name's
-   token is left unexpanded, never blanked.
+   token is left unexpanded, never blanked. **#3629**: this is the fully-
+   expanded string returned as `content` (what the model reads THIS
+   turn, unchanged); `load_skill_body` ALSO returns a second, persist-safe
+   variant with `${REYN_SKILL_DIR}`/`${REYN_PLUGIN_ROOT}` (+ `${CLAUDE_*}`
+   aliases) left LITERAL, plus the location-token map, surfaced as this
+   op result's `content_history`/`token_map`/`skill_source_path` fields —
+   see step 8 below for why.
 7. **Self-bounding**: an oversized body is truncated to the resolver's
    inline cap (`control_ir_inline_cap`) rather than blowing the context;
    `status: "truncated"` + a `note` on that path.
+8. **#3629 — persist-safe history, not the expanded value**: `content` is
+   what the current turn's LLM call sees; `content_history` (present only
+   alongside a set provenance) is what `router_loop.py`'s tool-result
+   assembly persists to `history.jsonl` instead — history is immutable, so
+   baking an absolute path into it froze a value that a later rename/move
+   (#3588 was one instance) could turn stale forever, with no way for the
+   model to tell a stale absolute path from a live one. A wire-serialise
+   pass (`RouterHistoryBuffer._serialise_turn` →
+   `reyn.plugins.skill_load.refresh_location_tokens`) re-resolves the
+   literal tokens fresh, against the CURRENT filesystem, every time a
+   persisted entry is replayed — `token_map` is audit-completeness
+   metadata only (never a re-expansion source).
 
 Result fields: `status` (`"ok"` / `"truncated"` / `"not_found"` / `"error"`),
 `path`, `content`, plus `total_chars`/`_truncated`/`note` on a truncated
-result and `encoding` when a non-UTF-8 codec was used.
+result, `encoding` when a non-UTF-8 codec was used, and (#3629)
+`content_history`/`token_map`/`skill_source_path` when a provenance class
+matched (step 6).
 
 Events emitted: `tool_executed` (`op="load_skill"`) always; `skill_body_loaded`
 (`provenance`, `env_tokens_expanded`/`env_names_expanded`,

--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -88,6 +88,23 @@ class CanonicalToolResult(TypedDict, total=False):
     meta: dict
     content_type: "str | None"
 
+    # #3629 — an OPTIONAL persist-only alternate to ``text``. When present, the
+    # router-loop tool-result assembly persists THIS to ``history.jsonl``
+    # instead of the (possibly-capped, rendered) ``text`` — never both, never
+    # neither: absent means "persist the same thing as this turn shows",
+    # exactly every OTHER mapper's existing behavior (byte-identical, zero
+    # change). ``load_skill_to_canonical`` is the one mapper that sets it, so
+    # a skill body's location tokens (``${REYN_SKILL_DIR}``/
+    # ``${REYN_PLUGIN_ROOT}``) can be persisted literal (never baked to an
+    # absolute value) while ``text`` still shows the model the fully-resolved
+    # path THIS turn. ``history_meta`` rides alongside it — NEVER copied into
+    # the visible ``meta``/frontmatter (that would put it in front of the
+    # model); the router loop stashes it directly on the persisted
+    # ``ChatMessage.meta`` instead (never sent over the wire, see
+    # ``chat_message.py``'s meta-key docstrings).
+    history_text: str
+    history_meta: dict
+
 
 # A canonical mapper: an invoked producer's raw result dict → the canonical shape.
 CanonicalMapper = Callable[[dict], CanonicalToolResult]
@@ -745,14 +762,36 @@ def load_skill_to_canonical(result: dict) -> CanonicalToolResult:
 
     SUCCESS shape only — FP-0056 v2 piece #1 routes any error (``status``
     error/not_found, which carries an ``error`` field) through the shared
-    ``error_to_canonical`` seam before this mapper runs."""
+    ``error_to_canonical`` seam before this mapper runs.
+
+    #3629: when ``load_skill``'s op result carries ``content_history`` (only
+    when a provenance class matched, ``reyn.core.op_runtime.load_skill``'s
+    own gate), this mapper ALSO sets ``history_text``/``history_meta`` — the
+    persist-safe body (location tokens left literal) + the token map/source
+    path a later wire-serialise re-resolves fresh from
+    (``router_history_buffer.py`` /
+    ``reyn.plugins.skill_load.refresh_location_tokens``). ``text`` stays the
+    fully-expanded body regardless — the model reads exactly what it always
+    did THIS turn; only what gets PERSISTED differs."""
     meta: dict[str, Any] = {}
     for key in ("path", "status", "truncated", "total_chars"):
         value = result.get(key)
         if value is not None:
             meta[key] = value
     text = _explicit_empty(result.get("content", "") or "", "(empty skill body)", meta)
-    return CanonicalToolResult(text=text, attachments=[], source_ref=None, meta=meta)
+    canonical: CanonicalToolResult = {
+        "text": text, "attachments": [], "source_ref": None, "meta": meta,
+    }
+    content_history = result.get("content_history")
+    if content_history is not None:
+        canonical["history_text"] = _explicit_empty(
+            content_history, "(empty skill body)", {},
+        )
+        canonical["history_meta"] = {
+            "token_map": result.get("token_map") or {},
+            "skill_source_path": result.get("skill_source_path"),
+        }
+    return canonical
 
 
 def reyn_repo_to_canonical(result: dict) -> CanonicalToolResult:

--- a/src/reyn/core/op_runtime/file.py
+++ b/src/reyn/core/op_runtime/file.py
@@ -142,14 +142,58 @@ async def _read_image_file(op: FileIROp, ctx: OpContext, *, mime_type: str) -> d
     }
 
 
+def _nearest_existing_ancestor(ws, start: str) -> "str | None":
+    """Walk *start*'s parents (project-relative) until one exists as a
+    directory, or return ``None`` if none does — including the workspace
+    root itself in the walk (``Path(...).parents`` always ends at ``"."``).
+
+    #3629: the decision-enabling half of the not-found suggestion fix. A
+    renamed/moved/reinstalled directory means ``path``'s own parent is gone
+    too, not just its siblings — the caller (:func:`_nearby_files`) uses
+    this to distinguish that case ("no parent" — an ancestor is the only
+    thing left to point at) from "no neighbours" (parent exists but is
+    empty, where an empty suggestion list is already the correct, honest
+    answer). Never raises: a denied/erroring ``stat_path`` at any level is
+    treated as "does not exist" and the walk continues upward.
+    """
+    for ancestor in Path(start).parents:
+        candidate = str(ancestor)
+        try:
+            stat = ws.stat_path(candidate)
+        except (PermissionError, OSError):
+            continue
+        if stat is not None and stat.get("is_dir"):
+            return candidate
+    return None
+
+
 def _nearby_files(ws, path: str, *, max_results: int = _NOT_FOUND_SUGGESTIONS_LIMIT) -> list[str]:
     """List sibling files under the parent of *path*, for use as not_found suggestions.
 
-    Returns project-relative paths from ``Workspace.glob_files``. Empty list
-    when the parent dir doesn't exist, permission is denied, or the glob
-    yields nothing — never raises.
+    Returns project-relative paths from ``Workspace.glob_files`` when the
+    parent directory exists (possibly empty — "no neighbours" legitimately
+    yields ``[]``).
+
+    #3629: when the parent directory itself does NOT exist — a rename, a
+    move, or a plugin reinstall to a different location, exactly the case
+    that leaves an absolute path baked into history pointing at nothing —
+    that is "no parent", not "no neighbours", and an empty list gives the
+    model nothing to recover with (it cannot tell "this directory is simply
+    empty" from "this whole path is gone"). In that case, return the
+    nearest EXISTING ancestor (see :func:`_nearest_existing_ancestor`) as a
+    single suggestion, so the model can discover the current structure
+    on the spot instead of guessing a replacement path. Permission denials
+    and OS errors at any point still degrade to ``[]``, never raise.
     """
     parent = str(Path(path).parent) if str(Path(path).parent) not in ("", ".") else "."
+    if parent != ".":
+        try:
+            parent_stat = ws.stat_path(parent)
+        except (PermissionError, OSError):
+            parent_stat = None
+        if parent_stat is None or not parent_stat.get("is_dir"):
+            ancestor = _nearest_existing_ancestor(ws, parent)
+            return [f"{ancestor}/"] if ancestor is not None else []
     pattern = f"{parent}/*" if parent != "." else "*"
     try:
         return ws.glob_files(pattern, max_results=max_results)

--- a/src/reyn/core/op_runtime/load_skill.py
+++ b/src/reyn/core/op_runtime/load_skill.py
@@ -44,6 +44,20 @@ provenance classes still succeeds with plain, unexpanded content — no
 ``skill_body_loaded`` event fires (fails CLOSED: no expansion, never open).
 This mirrors the pre-extraction ``file.read`` fallback exactly (an
 unregistered ``SKILL.md``-shaped path was never a hard error there either).
+
+**#3629 — the result carries a second, persist-safe content variant when a
+provenance class matched.** ``content`` stays the fully-expanded body (what
+the model reads THIS turn, unchanged from before #3629). ``content_history``
+/ ``token_map`` / ``skill_source_path`` (present only when ``content_history
+is not None``, i.e. a provenance class matched) are what
+``load_skill_to_canonical`` threads onto the persisted history entry
+instead — the location tokens (``${REYN_SKILL_DIR}``/``${REYN_PLUGIN_ROOT}``)
+are left literal in ``content_history`` rather than baked to an absolute
+value, so a later rename/move (#3588 was one instance) can never freeze a
+now-dead path into ``.reyn/agents/<id>/history.jsonl``, which is immutable
+by design. See ``reyn.plugins.skill_load.load_skill_body``'s docstring for
+the full mechanism and ``refresh_location_tokens`` for how a persisted entry
+re-resolves fresh on replay.
 """
 from __future__ import annotations
 
@@ -172,21 +186,33 @@ async def handle(op: LoadSkillIROp, ctx: OpContext) -> dict:
     if provenance is None and _config_registered_skill_body_provenance(ctx, resolved_path):
         provenance = "config_entry"
 
+    # #3629: set only when `load_skill_body` actually ran (below) — the
+    # persist-safe (location tokens left literal) body + the token map the
+    # caller (`router_loop.py`'s tool-result assembly) stashes on the
+    # persisted history entry's `meta`, plus the identity `content_history`
+    # can be re-resolved against on replay. `None` here (unregistered path,
+    # the `else` branch below) means "nothing to persist differently" — the
+    # ordinary `content` is used for both current-turn and history, exactly
+    # as before #3629.
+    content_history: "str | None" = None
+    location_token_map: "dict[str, str] | None" = None
     if provenance is not None:
-        content, env_names_expanded, env_names_denied = load_skill_body(
-            content,
-            skill_path=resolved_path,
-            project_dir=ctx.workspace.base_dir,
-            # SKILL.md is the one open standard (agentskills.io) multiple
-            # hosts share, so every skill-load IS the ingestion boundary
-            # ADR 0064 §3.6 scopes the `${CLAUDE_*}` alias to — there is no
-            # narrower "this one is Claude-authored" signal to gate on.
-            alias_claude=True,
-            # #3198: the allowlist gate on WHAT a body that already cleared
-            # the #3196 provenance gate may read from os.environ.
-            # ctx.permission_decl is a required (non-Optional) OpContext
-            # field — always present.
-            permission_decl=ctx.permission_decl,
+        content, content_history, location_token_map, env_names_expanded, env_names_denied = (
+            load_skill_body(
+                content,
+                skill_path=resolved_path,
+                project_dir=ctx.workspace.base_dir,
+                # SKILL.md is the one open standard (agentskills.io) multiple
+                # hosts share, so every skill-load IS the ingestion boundary
+                # ADR 0064 §3.6 scopes the `${CLAUDE_*}` alias to — there is
+                # no narrower "this one is Claude-authored" signal to gate on.
+                alias_claude=True,
+                # #3198: the allowlist gate on WHAT a body that already
+                # cleared the #3196 provenance gate may read from os.environ.
+                # ctx.permission_decl is a required (non-Optional) OpContext
+                # field — always present.
+                permission_decl=ctx.permission_decl,
+            )
         )
         # NEVER include the expanded/denied VALUES here — an audit-event is
         # not a second secret-storage location (#3196 firm design, extended
@@ -219,6 +245,18 @@ async def handle(op: LoadSkillIROp, ctx: OpContext) -> dict:
             model_str = None
     cap = control_ir_inline_cap(model_str, events=ctx.events, phase=ctx.actor)
 
+    # #3629: `content_history`/`token_map` (set above, only when
+    # `load_skill_body` ran) ride along in the SAME field shape regardless of
+    # the truncated/ok branch below — `load_skill_to_canonical` reads them
+    # off the raw result dict, never off `content` itself.
+    history_fields: dict = {}
+    if content_history is not None:
+        history_fields["content_history"] = (
+            content_history[:cap] if len(content_history) > cap else content_history
+        )
+        history_fields["token_map"] = location_token_map
+        history_fields["skill_source_path"] = op.path
+
     if len(content) > cap:
         truncated_content = content[:cap]
         ctx.events.emit(
@@ -238,6 +276,7 @@ async def handle(op: LoadSkillIROp, ctx: OpContext) -> dict:
                 f"{op.path!r}."
             ),
             **enc_field,
+            **history_fields,
         }
 
     ctx.events.emit("tool_executed", op="load_skill", path=op.path)
@@ -247,6 +286,7 @@ async def handle(op: LoadSkillIROp, ctx: OpContext) -> dict:
         "status": "ok",
         "content": content,
         **enc_field,
+        **history_fields,
     }
 
 

--- a/src/reyn/interfaces/skill_invoke.py
+++ b/src/reyn/interfaces/skill_invoke.py
@@ -305,19 +305,26 @@ def resolve_skill_body(
             p = p / "SKILL.md"
         content = p.read_text(encoding="utf-8")
 
-    # #3196/#3198: `load_skill_body` now returns
-    # `(body, env_names_expanded, env_names_denied)` so `file.handle`'s
-    # audit-event can report names+counts without ever logging a value. The
-    # `:` invoke path's own trust boundary is the already-registered `entry`
-    # this body resolved from (never an arbitrary path) — its own
-    # `skill_invoke_body_loaded` audit-event (session.py) does not need
-    # either list, so both are discarded here.
-    body, _env_names_expanded, _env_names_denied = load_skill_body(
-        content,
-        skill_path=path,
-        project_dir=project_dir,
-        alias_claude=True,
-        permission_decl=permission_decl,
+    # #3196/#3198/#3629: `load_skill_body` now returns `(body,
+    # persisted_body, location_token_map, env_names_expanded,
+    # env_names_denied)` — `persisted_body`/`location_token_map` exist so
+    # the `load_skill` OP's history persistence can leave location tokens
+    # literal (#3629); this `:` invoke path returns `body` (the plain,
+    # fully-expanded text, unchanged from before #3629) straight to its
+    # caller, which is NOT the `load_skill` op's history-persistence path —
+    # out of scope here, same as the env name lists this comment already
+    # discarded. The `:` invoke path's own trust boundary is the
+    # already-registered `entry` this body resolved from (never an
+    # arbitrary path); its own `skill_invoke_body_loaded` audit-event
+    # (session.py) does not need any of the three discarded values.
+    body, _persisted_body, _location_token_map, _env_names_expanded, _env_names_denied = (
+        load_skill_body(
+            content,
+            skill_path=path,
+            project_dir=project_dir,
+            alias_claude=True,
+            permission_decl=permission_decl,
+        )
     )
     return body
 

--- a/src/reyn/plugins/skill_load.py
+++ b/src/reyn/plugins/skill_load.py
@@ -108,7 +108,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from reyn.plugins.manifest import manifest_path_for
-from reyn.plugins.tokens import PluginTokenContext, expand_reyn_tokens
+from reyn.plugins.tokens import (
+    LOCATION_TOKEN_NAMES,
+    PluginTokenContext,
+    expand_with_map,
+    resolve_token_map,
+)
 
 if TYPE_CHECKING:
     from reyn.security.permissions.permissions import PermissionDecl
@@ -219,7 +224,7 @@ def load_skill_body(
     project_dir: Path,
     alias_claude: bool = False,
     permission_decl: "PermissionDecl | None" = None,
-) -> "tuple[str, list[str], list[str]]":
+) -> "tuple[str, str, dict[str, str], list[str], list[str]]":
     """Expand invocation-time ``${REYN_*}``/``${CLAUDE_*}``/``${env:...}``
     tokens in a decoded SKILL.md body (§3.5's "skill-load verb").
 
@@ -227,11 +232,36 @@ def load_skill_body(
     caller — ``file.handle`` — has already run the decode ladder; this
     function does no I/O of its own and never re-reads the file).
 
-    Returns ``(expanded_body, env_names_expanded, env_names_denied)`` — the
-    caller returns *expanded_body* verbatim as the read op's `content`;
-    the two name lists (#3198, superseding #3196's bare int count) are for
-    the caller's audit-event ONLY (names + counts via ``len()``, NEVER the
-    values) — never for display to the model.
+    Returns ``(expanded_body, persisted_body, location_token_map,
+    env_names_expanded, env_names_denied)``:
+
+    - *expanded_body* — EVERY recognised token substituted (unchanged shape
+      from before #3629). The caller returns this verbatim as the read op's
+      current-turn `content` — what the model reads THIS turn is exactly as
+      correct as it always was; nothing about immediate usability changes.
+    - *persisted_body* — ``REYN_PROJECT_DIR``/``CLAUDE_PROJECT_DIR``
+      substituted (measured safe: never baked into a durable copy, #3629
+      architect ruling), but ``REYN_SKILL_DIR``/``REYN_PLUGIN_ROOT`` (+
+      their ``CLAUDE_*`` aliases, :data:`~reyn.plugins.tokens.
+      LOCATION_TOKEN_NAMES`) left LITERAL. This is what the caller
+      persists to ``history.jsonl`` instead of *expanded_body* — a rename
+      or move after this turn can never freeze a now-dead absolute path
+      into the durable record, because the record never held one.
+    - *location_token_map* — the SAME token → value mapping that would have
+      baked the location tokens into *expanded_body*, for the caller to
+      stash on the persisted entry's ``meta`` (audit-completeness: since
+      LLM-payload trace dumping is opt-in (``REYN_LLM_TRACE_DUMP``), history
+      is the only ALWAYS-ON record of what a given turn actually resolved
+      to). This map is NOT a re-expansion source on replay —
+      :func:`refresh_location_tokens` re-derives fresh values from the
+      CURRENT filesystem every time, never from this frozen snapshot; see
+      that function's docstring.
+    - *env_names_expanded* / *env_names_denied* — as before (#3198,
+      superseding #3196's bare int count): names + counts via ``len()``
+      ONLY, for the caller's audit-event, never the values, never for
+      display to the model. Reported against *expanded_body* — the
+      current-turn text actually shown to the model — since that is the
+      one substitution round whose count matters for the audit event.
 
     ``alias_claude`` should be ``True`` only when *skill_path* is known to be
     a Claude-authored SKILL.md (ADR §3.6's ingestion-boundary rule, mirroring
@@ -242,9 +272,8 @@ def load_skill_body(
     ``None`` (the default) is treated as an EMPTY ``PermissionDecl``, i.e.
     NOTHING is allowlisted, so a caller that forgets to thread a real decl
     fails CLOSED (no env expansion at all), never open. Location tokens
-    (``${REYN_*}``/``${CLAUDE_*}``, via ``expand_reyn_tokens`` above) are
-    UNAFFECTED by this gate — they carry no credential, only positional
-    metadata (ADR §3.4).
+    (``${REYN_*}``/``${CLAUDE_*}``) are UNAFFECTED by this gate — they carry
+    no credential, only positional metadata (ADR §3.4).
     """
     skill_dir = Path(skill_path).resolve().parent
     token_ctx = PluginTokenContext(
@@ -252,8 +281,89 @@ def load_skill_body(
         project_dir=project_dir,
         skill_dir=skill_dir,
     )
-    expanded = expand_reyn_tokens(content, token_ctx, alias_claude=alias_claude)
-    return _expand_env_tokens(expanded, permission_decl)
+    full_map = resolve_token_map(token_ctx, alias_claude=alias_claude)
+    location_map = {k: v for k, v in full_map.items() if k in LOCATION_TOKEN_NAMES}
+    non_location_map = {k: v for k, v in full_map.items() if k not in LOCATION_TOKEN_NAMES}
+
+    persisted = expand_with_map(content, non_location_map)
+    expanded = expand_with_map(persisted, location_map)
+
+    expanded, env_expanded, env_denied = _expand_env_tokens(expanded, permission_decl)
+    # Same substitution, applied to the persist-safe variant too — ``${env:...}``
+    # expansion is orthogonal to the location-token split (a different regex,
+    # #3198's own security gate, no interaction either way) and must not
+    # differ between what the model reads this turn and what gets persisted.
+    persisted, _persisted_env_expanded, _persisted_env_denied = _expand_env_tokens(
+        persisted, permission_decl,
+    )
+    return expanded, persisted, location_map, env_expanded, env_denied
+
+
+def refresh_location_tokens(
+    content: str, *, skill_source_path: str, project_dir: Path, alias_claude: bool = False,
+) -> str:
+    """Re-expand ``${REYN_SKILL_DIR}``/``${REYN_PLUGIN_ROOT}`` (+ ``CLAUDE_*``
+    aliases) in a PERSISTED skill-body history entry, against the CURRENT
+    filesystem, at wire-serialise time (#3629).
+
+    This is the "dynamic param" half of the location-token fix — the
+    ``REYN_PROJECT_DIR`` discipline (ADR §3.4: "only has a value at
+    invocation... expanded fresh each call, never baked into a durable
+    copy") extended to the two tokens ``load_skill_body`` now leaves literal
+    in what it persists. *skill_source_path* is the IDENTITY the original
+    ``load_skill`` call resolved against (``op.path`` — typically
+    project-relative, exactly as the model gave it), never the frozen
+    absolute VALUE from that turn's ``location_token_map`` — an identity can
+    be re-resolved fresh; a frozen value can only be repeated.
+
+    Fresh resolution runs the EXACT SAME two calls the original load did
+    (:func:`resolve_plugin_root` off ``Path(skill_source_path).parent``) —
+    no separate mechanism, no drift risk between write-time and replay-time
+    resolution.
+
+    Three outcomes, by design, no other:
+
+    - *skill_source_path* still resolves to a real file (nothing moved, OR
+      the same relative structure exists in THIS run's checkout even
+      though a PRIOR run's checkout was different — the "two working
+      copies" / "different machine" case #3629 names explicitly) →
+      substituted with the CURRENT value. Self-heals completely.
+    - *skill_source_path* no longer resolves to anything (the file itself
+      was renamed/deleted — #3629's actual reported case, #3588's skill
+      rename) → the token is left LITERAL, unexpanded. This is NOT a
+      partial fix masquerading as success: an unexpanded ``${REYN_SKILL_DIR}``
+      is unambiguously a placeholder to the model, never mistaken for a
+      live path the way a frozen absolute string was (the exact defect
+      #3629 reports) — the class of failure changes from "silently wrong"
+      to "visibly unresolved", which is the improvement this function
+      claims, no more.
+    - *content* has no location token left to match (a non-skill turn, or
+      one that never had one) → returned unchanged, cheap no-op.
+
+    Never touches already-poisoned pre-#3629 history — those entries were
+    persisted with the token ALREADY baked into ``content`` as a plain
+    string; there is no token left for this function to find, by
+    construction (#3629 architect ruling: existing poisoned rows are
+    intentionally never rewritten or annotated).
+    """
+    candidate = Path(skill_source_path)
+    if not candidate.is_absolute():
+        candidate = project_dir / candidate
+    try:
+        exists = candidate.is_file()
+    except OSError:
+        exists = False
+    if not exists:
+        return content
+    skill_dir = candidate.resolve().parent
+    token_ctx = PluginTokenContext(
+        plugin_root=resolve_plugin_root(skill_dir),
+        project_dir=project_dir,
+        skill_dir=skill_dir,
+    )
+    full_map = resolve_token_map(token_ctx, alias_claude=alias_claude)
+    location_map = {k: v for k, v in full_map.items() if k in LOCATION_TOKEN_NAMES}
+    return expand_with_map(content, location_map)
 
 
 __all__ = [
@@ -261,4 +371,5 @@ __all__ = [
     "is_skill_body_path",
     "resolve_plugin_root",
     "load_skill_body",
+    "refresh_location_tokens",
 ]

--- a/src/reyn/plugins/tokens.py
+++ b/src/reyn/plugins/tokens.py
@@ -30,6 +30,26 @@ expansion mechanism itself (no asymmetry between capability types, §3.4).
 Any ``${...}`` token this module does not recognise (an env var for
 ``expand_env``, a pipeline ``ctx`` param, an unset field) is left untouched
 — the two expansion layers compose by each ignoring what the other owns.
+
+**#3629 — "stable location" only describes the copy-time bake, not
+persistence.** ``REYN_SKILL_DIR``/``REYN_PLUGIN_ROOT`` being "resolved once
+at copy time" says nothing about what happens to a VALUE this module
+expands into a skill body at LOAD time (``skill_load.py``, invocation-time,
+same as the dynamic params) once that expanded string is persisted to
+``.reyn/agents/<id>/history.jsonl`` — history is immutable, so a rename or
+move after that point leaves the OLD absolute path baked into an old
+history entry forever, replayed to the model on every later turn with no
+way to tell it apart from a live path. This module's mechanism (expand a
+literal token into a value) is unaffected either way; the fix (#3629) lives
+one layer up, in ``skill_load.py``/the history-persistence boundary: the
+location tokens (``REYN_SKILL_DIR``/``REYN_PLUGIN_ROOT``, plus their
+``CLAUDE_*`` aliases — see :data:`LOCATION_TOKEN_NAMES`) are kept literal
+in what gets PERSISTED and re-expanded fresh, against the current
+filesystem, every time a persisted turn is re-serialised for the wire
+(``router_history_buffer.py``'s :func:`~reyn.plugins.skill_load.
+refresh_location_tokens`) — the same "expanded fresh each call, never
+baked into a durable copy" discipline this module already documents for
+``REYN_PROJECT_DIR``, extended to the two tokens that were missing it.
 """
 from __future__ import annotations
 
@@ -52,6 +72,18 @@ CLAUDE_ALIAS_MAP: dict[str, str] = {
     "CLAUDE_SKILL_DIR": "REYN_SKILL_DIR",
     "CLAUDE_PROJECT_DIR": "REYN_PROJECT_DIR",
 }
+
+# #3629: the token NAMES (canonical + CLAUDE_* alias spellings) that must
+# never be baked into what gets PERSISTED to history — see the module
+# docstring's "stable location only describes the copy-time bake" note.
+# ``REYN_PROJECT_DIR``/``CLAUDE_PROJECT_DIR`` are deliberately absent: the
+# architect's #3629 measurement found PROJECT_DIR already safe (never
+# baked into a durable copy, resolved fresh from the live workspace on
+# every call) — only the two location tokens share SKILL_DIR's defect.
+LOCATION_TOKEN_NAMES: frozenset[str] = frozenset({
+    "REYN_SKILL_DIR", "REYN_PLUGIN_ROOT",
+    "CLAUDE_SKILL_DIR", "CLAUDE_PLUGIN_ROOT",
+})
 
 
 @dataclass(frozen=True)
@@ -137,3 +169,30 @@ def _expand(obj: Any, token_map: dict[str, str]) -> Any:
     if isinstance(obj, list):
         return [_expand(v, token_map) for v in obj]
     return obj
+
+
+def resolve_token_map(ctx: PluginTokenContext, *, alias_claude: bool = False) -> dict[str, str]:
+    """Public wrapper over the token-name → value map :func:`expand_reyn_tokens`
+    substitutes from (#3629).
+
+    Callers that need to expand a SUBSET of the recognised tokens (e.g.
+    ``skill_load.py`` expanding ``REYN_PROJECT_DIR`` immediately while
+    leaving the location tokens literal for persistence — see
+    :data:`LOCATION_TOKEN_NAMES`) build their own partial map by filtering
+    this one, then call :func:`expand_with_map` — never re-derive the
+    value computation independently (``PluginTokenContext.tokens()`` +
+    the ``CLAUDE_*`` alias rule stay the single source).
+    """
+    return _resolve_token_map(ctx, alias_claude=alias_claude)
+
+
+def expand_with_map(obj: Any, token_map: dict[str, str]) -> Any:
+    """Public wrapper over the same recursive substitution
+    :func:`expand_reyn_tokens` uses internally, taking an already-resolved
+    ``token_map`` directly (#3629) — for a caller that wants to expand only
+    a SUBSET of the tokens :func:`resolve_token_map` would return (see that
+    function's docstring). A token name absent from *token_map* is left
+    untouched, exactly like an unrecognised token — the caller controls
+    "subset" purely by which keys it omits, not by a second code path.
+    """
+    return _expand(obj, token_map)

--- a/src/reyn/runtime/chat_message.py
+++ b/src/reyn/runtime/chat_message.py
@@ -77,6 +77,32 @@ INTERVENTION_DETAIL_META_KEY = "intervention_detail"
 #: answered" for a closed-set intervention; this key always carries it.
 INTERVENTION_ANSWER_META_KEY = "intervention_answer"
 
+# #3629: stamped on a ``role="tool"`` ``load_skill`` result's persisted entry
+# ONLY (``router_loop.py``'s tool-result assembly, mirroring the
+# ``TOOL_STATUS_META_KEY`` pattern above — the ONE place that already knows
+# a mapper set ``history_text``/``history_meta``, canonical.py's
+# ``load_skill_to_canonical``). ``content`` for such an entry keeps
+# ``${REYN_SKILL_DIR}``/``${REYN_PLUGIN_ROOT}`` (+ ``CLAUDE_*`` aliases)
+# LITERAL rather than baked to an absolute value that a later rename/move
+# would freeze forever (history is immutable) — these two keys are what a
+# wire-serialise pass (``router_history_buffer.py``'s ``_serialise_turn`` →
+# ``reyn.plugins.skill_load.refresh_location_tokens``) needs to re-resolve
+# the tokens FRESH, against the CURRENT filesystem, every time the entry is
+# replayed.
+#
+# ``TOKEN_MAP_META_KEY`` is audit-completeness ONLY (#3629 architect
+# ruling: LLM-payload trace dumping is opt-in via ``REYN_LLM_TRACE_DUMP``,
+# so history is the only ALWAYS-ON record of what a turn's tokens actually
+# resolved to at the time) — a wire-serialise pass MUST NOT read substitution
+# VALUES from it; it re-derives fresh values from ``SKILL_SOURCE_PATH_META_KEY``
+# every time (a frozen value can only repeat what was already stale; only a
+# re-resolvable identity can self-heal — see ``refresh_location_tokens``'s
+# docstring). Like every other ``meta`` key, this NEVER reaches the LLM
+# (``RouterHistoryBuffer._serialise_turn`` builds the wire dict from
+# ``role``/``content``/``tool_calls``/``tool_call_id``/``name`` only).
+TOKEN_MAP_META_KEY = "token_map"
+SKILL_SOURCE_PATH_META_KEY = "skill_source_path"
+
 
 @dataclass(init=False)
 class ChatMessage:

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3240,6 +3240,8 @@ class RouterLoop:
         )
         from reyn.core.offload.seam import build_offload_body, render_tool_result
         from reyn.runtime.chat_message import (
+            SKILL_SOURCE_PATH_META_KEY,
+            TOKEN_MAP_META_KEY,
             TOOL_ERROR_KIND_META_KEY,
             TOOL_ERROR_MESSAGE_META_KEY,
             TOOL_STATUS_ERROR,
@@ -3297,6 +3299,14 @@ class RouterLoop:
             scan_target: str
             _tool_error_kind: "str | None" = None
             _tool_error_message: "str | None" = None
+            # #3629: an ALTERNATE persisted-content string + its meta, set ONLY
+            # when the canonical mapper (`load_skill_to_canonical`) supplied
+            # ``history_text``/``history_meta`` — every other mapper leaves this
+            # ``None``, so persistence is byte-identical to ``content_str`` for
+            # them, unchanged. See ``CanonicalToolResult.history_text``'s
+            # docstring (canonical.py) for why this exists.
+            _persist_content_str: "str | None" = None
+            _history_meta_extra: dict = {}
             # Unwrap dispatch-envelope layers ({status, data} with nothing else) until the op
             # result (the dict carrying ``kind``) is reached. One layer for op_runtime ops
             # (bare {kind:…} wrapped once by dispatch_tool); two for tool-registry handlers whose
@@ -3395,8 +3405,21 @@ class RouterLoop:
                         # recover it from the stored ref's file extension.
                         text = _cap(text, content_type=content_type)
                     content_str = render_tool_result(frontmatter, text)
+                    # #3629: `load_skill_to_canonical` is the one mapper that sets
+                    # `history_text` — the SAME frontmatter, un-capped (a skill body is
+                    # already read-bounded upstream by `load_skill`'s own
+                    # `control_ir_inline_cap`, so a second offload-store cap pass here
+                    # would risk a second, independent offload ref for content that
+                    # never needs one in practice). `history_meta` carries no LLM-visible
+                    # text — it becomes ChatMessage.meta keys only, never frontmatter.
+                    _history_text = canonical.get("history_text")
+                    if _history_text is not None:
+                        _persist_content_str = render_tool_result(frontmatter, _history_text)
+                        _history_meta_extra = dict(canonical.get("history_meta") or {})
             if post_text:
                 content_str = f"{content_str}\n\n---\n{post_text}"
+                if _persist_content_str is not None:
+                    _persist_content_str = f"{_persist_content_str}\n\n---\n{post_text}"
             # FP-0050/#1822 S2: scan-all on the FULL content BEFORE cap truncates
             # (so injection can't hide past the size cap). Detection completeness.
             _scan = getattr(host, "scan_tool_result", None)
@@ -3408,6 +3431,8 @@ class RouterLoop:
                 _fence = getattr(host, "fence_tool_result", None)
                 if _fence is not None:
                     content_str = _fence(content_str)
+                    if _persist_content_str is not None:
+                        _persist_content_str = _fence(_persist_content_str)
             out.append({
                 "role": "tool",
                 "tool_call_id": tc["id"],
@@ -3436,10 +3461,21 @@ class RouterLoop:
                 _tool_meta[TOOL_ERROR_MESSAGE_META_KEY] = _tool_error_message
                 if _tool_error_kind is not None:
                     _tool_meta[TOOL_ERROR_KIND_META_KEY] = _tool_error_kind
+            # #3629: persist the location-tokens-literal variant + its token
+            # map/source-path (never the wire ``content_str`` shown above) when
+            # the canonical mapper supplied one — see ``_persist_content_str``'s
+            # comment above and ``CanonicalToolResult.history_text``'s docstring.
+            if "token_map" in _history_meta_extra:
+                _tool_meta[TOKEN_MAP_META_KEY] = _history_meta_extra["token_map"]
+            if "skill_source_path" in _history_meta_extra:
+                _tool_meta[SKILL_SOURCE_PATH_META_KEY] = _history_meta_extra["skill_source_path"]
             if _append_entry is not None:
                 _append_entry(
                     role="tool",
-                    content=content_str,
+                    content=(
+                        _persist_content_str if _persist_content_str is not None
+                        else content_str
+                    ),
                     meta=_tool_meta,
                     tool_call_id=tc["id"],
                     name=tc.get("function", {}).get("name"),

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -132,6 +132,48 @@ def _materialise_path_ref_content(
     return materialised
 
 
+def _refresh_skill_location_tokens(
+    content: "str | list[dict]", meta: Any, project_dir_fn: "Callable[[], Any] | None",
+) -> "str | list[dict]":
+    """#3629: re-expand ``${REYN_SKILL_DIR}``/``${REYN_PLUGIN_ROOT}`` (+
+    ``CLAUDE_*`` aliases) in a persisted ``load_skill`` tool-result entry,
+    against the CURRENT filesystem, every time this turn's history is
+    serialised for the wire — the "dynamic param" discipline
+    (``reyn.plugins.tokens``'s ``REYN_PROJECT_DIR`` classification)
+    extended to the two location tokens that used to get baked to an
+    absolute value once and persisted forever.
+
+    No-op (content returned unchanged) unless ALL of:
+    ``content`` is a ``str`` (a tool message never uses the multimodal
+    list-of-parts shape — mirrors :func:`_materialise_path_ref_content`'s
+    own type gate), ``meta`` carries ``SKILL_SOURCE_PATH_META_KEY`` (set
+    only by ``router_loop.py``'s tool-result assembly when
+    ``load_skill_to_canonical`` supplied ``history_text``/``history_meta``
+    — see ``chat_message.py``'s key docstrings), and *project_dir_fn* is
+    not ``None`` (a legacy/test double with no workspace access degrades to
+    "never refresh", same fail-closed idiom ``_materialise_path_ref_content``
+    uses for a ``None`` ``media_store``).
+
+    Pre-#3629 history has no ``SKILL_SOURCE_PATH_META_KEY`` at all — this
+    function never touches it, matching the architect's ruling that
+    already-poisoned entries are neither rewritten nor annotated.
+    """
+    if not isinstance(content, str) or not isinstance(meta, dict) or project_dir_fn is None:
+        return content
+    from reyn.runtime.chat_message import SKILL_SOURCE_PATH_META_KEY
+    skill_source_path = meta.get(SKILL_SOURCE_PATH_META_KEY)
+    if not skill_source_path:
+        return content
+    project_dir = project_dir_fn()
+    if project_dir is None:
+        return content
+    from reyn.plugins.skill_load import refresh_location_tokens
+    return refresh_location_tokens(
+        content, skill_source_path=skill_source_path, project_dir=project_dir,
+        alias_claude=True,
+    )
+
+
 def resolve_effective_trigger_and_budgets(
     compaction_controller: Any, model: str, events: Any,
 ) -> "tuple[int, int, int]":
@@ -178,6 +220,7 @@ class RouterHistoryBuffer:
         action_retrieval: Any,            # ActionRetrievalConfig — .universal_wrappers_enabled
         non_interactive: bool,
         reasoning: Any = None,            # ReasoningConfig — .continuity / .recent_turns (#1652/②)
+        project_dir_fn: "Callable[[], Any] | None" = None,  # #3629: zero-arg → CURRENT workspace base_dir
     ) -> None:
         self._history_fn = history_fn
         self._compaction = compaction
@@ -192,6 +235,12 @@ class RouterHistoryBuffer:
         # (native re-attach) instead of a router-SP text section. ReasoningConfig
         # gates it (.continuity) and bounds it (.recent_turns). None → off.
         self._reasoning = reasoning
+        # #3629: live, not cached — the same "resolve at the moment it's needed"
+        # discipline as ``_model`` above (a rewind/checkout/reinstall between
+        # turns must be reflected, never the construction-time workspace).
+        # ``None`` (a legacy/test double with no workspace access) degrades to
+        # "never refresh location tokens" — _serialise_turn's own None-check.
+        self._project_dir_fn = project_dir_fn
 
     @property
     def _model(self) -> str:
@@ -248,6 +297,12 @@ class RouterHistoryBuffer:
         # _migrate_legacy_chat_message) → normalise on read.
         role = "assistant" if m.role == "agent" else m.role
         content = _materialise_path_ref_content(m.content, self._media_store)
+        # #3629: fresh, every serialise — re-resolve any location token a
+        # persisted `load_skill` entry left literal, against the CURRENT
+        # filesystem (see _refresh_skill_location_tokens's docstring).
+        content = _refresh_skill_location_tokens(
+            content, getattr(m, "meta", None), self._project_dir_fn,
+        )
         msg: dict = {"role": role, "content": content}
         if m.tool_calls is not None:
             msg["tool_calls"] = m.tool_calls

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -4074,6 +4074,14 @@ class Session:
             action_retrieval=self._action_retrieval,
             non_interactive=self._non_interactive,
             reasoning=self._reasoning,  # #1652/② native reasoning re-attach + bound
+            # #3629: live workspace root, resolved at wire-serialise time — a
+            # callable (never the resolved value) so a rewind/checkout swap
+            # between turns is reflected. Mirrors ``Workspace.__init__``'s own
+            # ``base_dir or Path.cwd()`` default (``self._workspace_base_dir``
+            # is the agent-level override, ``None`` when unset — the SAME
+            # value ``ctx.workspace.base_dir`` resolves to for the ops this
+            # buffer's history entries came from).
+            project_dir_fn=lambda: self._workspace_base_dir or Path.cwd(),
         )
 
         compaction_controller = CompactionController(

--- a/tests/plugins/test_skill_load.py
+++ b/tests/plugins/test_skill_load.py
@@ -111,7 +111,7 @@ def test_load_skill_body_expands_reyn_tokens_to_distinct_real_paths(tmp_path):
         "project=${REYN_PROJECT_DIR}"
     )
 
-    expanded, env_expanded, env_denied = load_skill_body(
+    expanded, _persisted, _loc_map, env_expanded, env_denied = load_skill_body(
         content, skill_path=skill_path, project_dir=project_dir,
     )
 
@@ -136,7 +136,7 @@ def test_load_skill_body_claude_alias_matches_reyn_token_value(tmp_path):
     project_dir.mkdir()
 
     content = "${CLAUDE_SKILL_DIR}|${REYN_SKILL_DIR}"
-    expanded, _env_expanded, _env_denied = load_skill_body(
+    expanded, _persisted, _loc_map, _env_expanded, _env_denied = load_skill_body(
         content, skill_path=skill_path, project_dir=project_dir, alias_claude=True,
     )
 
@@ -153,7 +153,7 @@ def test_load_skill_body_claude_alias_off_leaves_token_untouched(tmp_path):
     project_dir = tmp_path / "some-project"
     project_dir.mkdir()
 
-    expanded, _env_expanded, _env_denied = load_skill_body(
+    expanded, _persisted, _loc_map, _env_expanded, _env_denied = load_skill_body(
         "${CLAUDE_SKILL_DIR}", skill_path=skill_path, project_dir=project_dir,
         alias_claude=False,
     )
@@ -173,7 +173,7 @@ def test_load_skill_body_expands_env_token_when_allowlisted(tmp_path, monkeypatc
     project_dir = tmp_path / "some-project"
     project_dir.mkdir()
 
-    expanded, env_expanded, env_denied = load_skill_body(
+    expanded, _persisted, _loc_map, env_expanded, env_denied = load_skill_body(
         "value=${env:REYN_SKILL_LOAD_TEST_TOKEN}",
         skill_path=skill_path, project_dir=project_dir,
         permission_decl=PermissionDecl(env_expand=["REYN_SKILL_LOAD_TEST_TOKEN"]),
@@ -196,7 +196,7 @@ def test_load_skill_body_env_token_denied_by_default_empty_allowlist(tmp_path, m
     project_dir = tmp_path / "some-project"
     project_dir.mkdir()
 
-    expanded, env_expanded, env_denied = load_skill_body(
+    expanded, _persisted, _loc_map, env_expanded, env_denied = load_skill_body(
         "value=${env:REYN_SKILL_LOAD_TEST_TOKEN}",
         skill_path=skill_path, project_dir=project_dir,
         # permission_decl omitted entirely -- the default-deny path.
@@ -221,7 +221,7 @@ def test_load_skill_body_env_token_denied_by_default_multiple_names(tmp_path, mo
     project_dir = tmp_path / "some-project"
     project_dir.mkdir()
 
-    expanded, env_expanded, _env_denied = load_skill_body(
+    expanded, _persisted, _loc_map, env_expanded, _env_denied = load_skill_body(
         f"value=${{env:{var_name}}}", skill_path=skill_path, project_dir=project_dir,
     )
 
@@ -244,7 +244,7 @@ def test_load_skill_body_env_allowlist_is_selective(tmp_path, monkeypatch):
     project_dir = tmp_path / "some-project"
     project_dir.mkdir()
 
-    expanded, env_expanded, env_denied = load_skill_body(
+    expanded, _persisted, _loc_map, env_expanded, env_denied = load_skill_body(
         "a=${env:REYN_SKILL_LOAD_ALLOWED_VAR} b=${env:REYN_SKILL_LOAD_DENIED_VAR}",
         skill_path=skill_path, project_dir=project_dir,
         permission_decl=PermissionDecl(env_expand=["REYN_SKILL_LOAD_ALLOWED_VAR"]),
@@ -266,7 +266,7 @@ def test_load_skill_body_env_allowlist_wildcard_expands_any_name(tmp_path, monke
     project_dir = tmp_path / "some-project"
     project_dir.mkdir()
 
-    expanded, env_expanded, env_denied = load_skill_body(
+    expanded, _persisted, _loc_map, env_expanded, env_denied = load_skill_body(
         "v=${env:REYN_SKILL_LOAD_WILDCARD_VAR}",
         skill_path=skill_path, project_dir=project_dir,
         permission_decl=PermissionDecl(env_expand=["*"]),
@@ -288,7 +288,7 @@ def test_load_skill_body_unset_allowlisted_env_token_left_untouched(tmp_path, mo
     project_dir = tmp_path / "some-project"
     project_dir.mkdir()
 
-    expanded, env_expanded, env_denied = load_skill_body(
+    expanded, _persisted, _loc_map, env_expanded, env_denied = load_skill_body(
         "${env:REYN_SKILL_LOAD_TEST_UNSET_TOKEN}",
         skill_path=skill_path, project_dir=project_dir,
         permission_decl=PermissionDecl(env_expand=["REYN_SKILL_LOAD_TEST_UNSET_TOKEN"]),
@@ -312,7 +312,7 @@ def test_load_skill_body_bare_var_not_expanded_even_when_set(tmp_path, monkeypat
     project_dir = tmp_path / "some-project"
     project_dir.mkdir()
 
-    expanded, env_expanded, env_denied = load_skill_body(
+    expanded, _persisted, _loc_map, env_expanded, env_denied = load_skill_body(
         "example: ${SOME_VAR}", skill_path=skill_path, project_dir=project_dir,
         permission_decl=PermissionDecl(env_expand=["*"]),
     )

--- a/tests/test_3629_skill_dir_history_dynamic_token.py
+++ b/tests/test_3629_skill_dir_history_dynamic_token.py
@@ -1,0 +1,363 @@
+"""Tier 1 / Tier 2: #3629 — a skill body's location tokens
+(``${REYN_SKILL_DIR}``/``${REYN_PLUGIN_ROOT}``) are no longer baked to an
+absolute value in what gets PERSISTED to ``history.jsonl``; a wire-serialise
+pass re-resolves them fresh, against the CURRENT filesystem, every time.
+
+The reported defect (issue #3629): a skill directory rename (#3588,
+underscore -> hyphen) left an ALREADY-EXPANDED absolute path baked into a
+persisted tool-result entry; history is immutable, so every later turn
+replayed a path to a directory that no longer existed, and the model had no
+way to tell a stale absolute path from a live one.
+
+Covered here, bottom-up:
+
+  1. ``load_skill_body`` (pure function, ``reyn.plugins.skill_load``) —
+     the persisted variant leaves location tokens literal; the token map
+     is metadata only.
+  2. ``refresh_location_tokens`` — the "dynamic param" half. THE
+     directory-moved witness: change the directory BETWEEN write and
+     read, assert the RESOLVED PATH FOLLOWS (self-heal); a genuine
+     rename/delete leaves the token literal (never a stale value).
+  3. ``load_skill`` op (``reyn.core.op_runtime.load_skill``) — the result
+     dict carries ``content_history``/``token_map``/``skill_source_path``
+     alongside the unchanged, fully-expanded ``content``.
+  4. ``load_skill_to_canonical`` — threads them onto
+     ``CanonicalToolResult.history_text``/``history_meta``.
+  5. ``RouterLoop.feedback`` — persists the LITERAL-token variant (not the
+     wire ``content_str``) via ``append_history_entry``, with
+     ``token_map``/``skill_source_path`` on the persisted ``ChatMessage``'s
+     meta — the model still reads the fully-resolved path THIS turn (the
+     ``out`` wire dict is unaffected).
+  6. ``RouterHistoryBuffer._serialise_turn`` — a REAL ``ChatMessage`` built
+     the way step 5 persists one, replayed through a REAL
+     ``RouterHistoryBuffer.build_history()`` after the directory moves —
+     the wire dict content follows the CURRENT filesystem, by value.
+
+No mocks — real ``Workspace``/``OpContext``/``ChatMessage``/``RouterLoop``/
+``RouterHistoryBuffer`` throughout (``FakeRouterHost`` is the project's
+established Fake, not a mock).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+from reyn.config.chat import CompactionConfig
+from reyn.core.events.events import EventLog
+from reyn.core.offload.canonical import load_skill_to_canonical
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.load_skill import handle as load_skill_handle
+from reyn.data.skills.registry import SkillEntry
+from reyn.data.workspace.workspace import Workspace
+from reyn.plugins.skill_load import load_skill_body, refresh_location_tokens
+from reyn.runtime.chat_message import (
+    SKILL_SOURCE_PATH_META_KEY,
+    TOKEN_MAP_META_KEY,
+    ChatMessage,
+)
+from reyn.runtime.router_loop import RouterLoop
+from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
+from reyn.schemas.models import LoadSkillIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.tools.scheme import ExecutionResult
+from tests._support.router_loop import FakeRouterHost
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── 1. load_skill_body: persisted variant keeps location tokens literal ─────
+
+def test_load_skill_body_persisted_variant_leaves_location_tokens_literal(tmp_path):
+    """Tier 1: the CURRENT-turn ``expanded`` body is fully resolved (unchanged
+    from before #3629); the PERSISTED body keeps ``${REYN_SKILL_DIR}``/
+    ``${REYN_PLUGIN_ROOT}`` literal while ``${REYN_PROJECT_DIR}`` (measured
+    safe) is still expanded. The location token map records the SAME values
+    that were baked into ``expanded`` — audit-completeness only."""
+    skill_dir = tmp_path / "skills" / "my-skill"
+    skill_dir.mkdir(parents=True)
+    skill_path = skill_dir / "SKILL.md"
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    body = "skill=${REYN_SKILL_DIR} project=${REYN_PROJECT_DIR}"
+
+    expanded, persisted, loc_map, _env_exp, _env_den = load_skill_body(
+        body, skill_path=skill_path, project_dir=project_dir,
+    )
+
+    assert f"skill={skill_dir.resolve()}" in expanded
+    assert f"project={project_dir.resolve()}" in expanded
+    assert "${REYN_SKILL_DIR}" in persisted, "location token must stay literal in the persisted form"
+    assert f"project={project_dir.resolve()}" in persisted, "PROJECT_DIR stays expanded (measured safe)"
+    assert loc_map["REYN_SKILL_DIR"] == str(skill_dir.resolve())
+    assert "REYN_PROJECT_DIR" not in loc_map, "the map is LOCATION tokens only"
+
+
+# ── 2. refresh_location_tokens: the directory-moved witness ─────────────────
+
+def test_refresh_location_tokens_self_heals_when_directory_moves(tmp_path):
+    """Tier 1: THE directory-moved witness (#3629 brief) — the skill
+    directory is renamed BETWEEN persisting the literal-token body and
+    replaying it; re-resolution against the SAME (project-relative)
+    ``skill_source_path`` follows the CURRENT filesystem and produces the
+    NEW directory's absolute path, asserted BY VALUE."""
+    old_dir = tmp_path / "skills" / "old-name"
+    old_dir.mkdir(parents=True)
+    skill_path = old_dir / "SKILL.md"
+    skill_path.write_text("x", encoding="utf-8")
+    persisted = "See ${REYN_SKILL_DIR}/reference.md"
+    source_path = str(skill_path.relative_to(tmp_path))
+
+    # Nothing moved yet: fresh resolution reproduces the SAME dir.
+    before = refresh_location_tokens(
+        persisted, skill_source_path=source_path, project_dir=tmp_path,
+    )
+    assert str(old_dir.resolve()) in before
+
+    # The directory moves (a checkout swap / relocation — #3629 names this
+    # explicitly, distinct from a rename that changes the LAST path
+    # component the model itself referenced).
+    new_root = tmp_path / "moved-checkout"
+    new_root.mkdir()
+    new_dir = new_root / "skills" / "old-name"
+    new_dir.parent.mkdir(parents=True)
+    old_dir.rename(new_dir)
+
+    after = refresh_location_tokens(
+        persisted, skill_source_path="skills/old-name/SKILL.md", project_dir=new_root,
+    )
+    assert str(new_dir.resolve()) in after, "must follow the CURRENT filesystem, not the write-time value"
+    assert str(old_dir) not in after
+    assert "${REYN_SKILL_DIR}" not in after
+
+
+def test_refresh_location_tokens_leaves_token_literal_when_path_is_gone(tmp_path):
+    """Tier 1: the reported case — the skill's OWN directory is renamed
+    (#3588's underscore->hyphen), so the ORIGINAL ``skill_source_path`` no
+    longer resolves to anything. The token is left LITERAL rather than
+    substituted with a stale value — unambiguously a placeholder to the
+    model, never mistaken for a live path (the exact #3629 defect)."""
+    old_dir = tmp_path / "skills" / "reyn_cheat_sheet"
+    old_dir.mkdir(parents=True)
+    (old_dir / "SKILL.md").write_text("x", encoding="utf-8")
+    persisted = "See ${REYN_SKILL_DIR}/reference.md"
+    source_path = "skills/reyn_cheat_sheet/SKILL.md"
+
+    old_dir.rename(tmp_path / "skills" / "reyn-cheat-sheet")
+
+    after = refresh_location_tokens(persisted, skill_source_path=source_path, project_dir=tmp_path)
+
+    assert after == persisted, "unresolvable identity -> literal token, never a guessed/stale value"
+    assert "${REYN_SKILL_DIR}" in after
+
+
+# ── 3. the load_skill op result carries the persist-safe fields ─────────────
+
+def _make_ctx(project_root, available_skills):
+    events = EventLog()
+    ws = Workspace(events=events, base_dir=project_root)
+    resolver = PermissionResolver(config_permissions={}, project_root=project_root, interactive=False)
+    return OpContext(
+        workspace=ws, events=events, permission_decl=PermissionDecl(),
+        permission_resolver=resolver, actor="test_3629", available_skills=available_skills,
+    )
+
+
+def _config_registered(tmp_path, body: str):
+    project_root = tmp_path / "proj"
+    skill_dir = project_root / "skills" / "greeter"
+    skill_dir.mkdir(parents=True)
+    skill_path = skill_dir / "SKILL.md"
+    skill_path.write_text(body, encoding="utf-8")
+    rel_path = str(skill_path.relative_to(project_root))
+    entry = SkillEntry(name="greeter", description="d", path=rel_path)
+    ctx = _make_ctx(project_root, [entry])
+    return ctx, rel_path, skill_dir
+
+
+def test_load_skill_op_result_carries_content_history_and_token_map(tmp_path):
+    """Tier 2: a config-registered skill load's result dict has ``content``
+    fully expanded (unchanged) AND ``content_history``/``token_map``/
+    ``skill_source_path`` for the persist path — never present for the
+    unregistered path (#3196 fails-closed, unaffected by #3629)."""
+    ctx, rel_path, skill_dir = _config_registered(tmp_path, "loc=${REYN_SKILL_DIR}")
+
+    result = _run(load_skill_handle(LoadSkillIROp(kind="load_skill", path=rel_path), ctx))
+
+    assert result["status"] == "ok"
+    assert f"loc={skill_dir.resolve()}" in result["content"]
+    assert "${REYN_SKILL_DIR}" in result["content_history"]
+    assert result["token_map"]["REYN_SKILL_DIR"] == str(skill_dir.resolve())
+    assert result["skill_source_path"] == rel_path
+
+
+# ── 4. canonical mapper threads history_text/history_meta ────────────────────
+
+def test_load_skill_to_canonical_sets_history_text_only_when_present():
+    """Tier 1: ``history_text``/``history_meta`` appear ONLY when the op
+    result carries ``content_history`` (a provenance-classified load) — a
+    plain (unregistered-path) result's canonical form is unaffected,
+    byte-identical to before #3629."""
+    with_history = load_skill_to_canonical({
+        "path": "s/SKILL.md", "status": "ok", "content": "expanded body",
+        "content_history": "${REYN_SKILL_DIR} body",
+        "token_map": {"REYN_SKILL_DIR": "/abs/path"},
+        "skill_source_path": "s/SKILL.md",
+    })
+    assert with_history["history_text"] == "${REYN_SKILL_DIR} body"
+    assert with_history["history_meta"] == {
+        "token_map": {"REYN_SKILL_DIR": "/abs/path"}, "skill_source_path": "s/SKILL.md",
+    }
+
+    without_history = load_skill_to_canonical({
+        "path": "s/SKILL.md", "status": "ok", "content": "raw body",
+    })
+    assert "history_text" not in without_history
+    assert "history_meta" not in without_history
+
+
+# ── 5. RouterLoop.feedback persists the literal-token variant ───────────────
+
+def test_router_loop_feedback_persists_literal_token_variant_with_meta(tmp_path):
+    """Tier 2: ``RouterLoop.feedback`` persists the ``history_text`` variant
+    (location tokens literal) via ``append_history_entry`` — NOT the fully
+    resolved wire content — and stamps ``token_map``/``skill_source_path``
+    onto the persisted entry's meta. The wire dict returned by ``feedback``
+    (what the model reads THIS turn) still shows the fully-resolved path."""
+    ctx, rel_path, skill_dir = _config_registered(tmp_path, "loc=${REYN_SKILL_DIR}")
+    op_result = _run(load_skill_handle(LoadSkillIROp(kind="load_skill", path=rel_path), ctx))
+    assert op_result["status"] == "ok"
+    # Tag exactly as the real dispatch chokepoint would (FP-0056 PR-F1).
+    tagged_result = {**op_result, "_canonical_source": "load_skill"}
+
+    host = FakeRouterHost()
+    loop = RouterLoop(host=host, chain_id="chain-3629", max_iterations=5)
+
+    wire = loop.feedback(ExecutionResult(
+        tool_results=[tagged_result],
+        tool_calls=[{
+            "id": "tc1", "type": "function",
+            "function": {"name": "load_skill", "arguments": json.dumps({"path": rel_path})},
+        }],
+        assistant_content="",
+    ))
+
+    tool_wire = next(m for m in wire if m.get("role") == "tool")
+    assert f"loc={skill_dir.resolve()}" in tool_wire["content"], (
+        "the CURRENT turn's wire content is unaffected -- still fully resolved"
+    )
+
+    persisted_tool_entries = [e for e in host.history if e["role"] == "tool"]
+    assert persisted_tool_entries, "expected the load_skill result to persist a tool entry"
+    entry = persisted_tool_entries[0]
+    assert "${REYN_SKILL_DIR}" in entry["content"], (
+        "the PERSISTED entry must keep the location token literal, not the "
+        "absolute value the model read this turn"
+    )
+    assert entry["meta"][TOKEN_MAP_META_KEY]["REYN_SKILL_DIR"] == str(skill_dir.resolve())
+    assert entry["meta"][SKILL_SOURCE_PATH_META_KEY] == rel_path
+
+
+# ── 6. RouterHistoryBuffer._serialise_turn re-resolves fresh, by value ───────
+
+def _buffer(history: list, project_dir):
+    return RouterHistoryBuffer(
+        history_fn=lambda: history,
+        compaction=CompactionConfig(),
+        compaction_controller=None,
+        model_fn=lambda: "openai/gpt-4o",
+        events=None,
+        media_store=None,
+        router_host=None,
+        action_retrieval=None,
+        non_interactive=False,
+        project_dir_fn=lambda: project_dir,
+    )
+
+
+def test_serialise_turn_refreshes_location_token_after_checkout_moves(tmp_path):
+    """Tier 2: THE directory-moved witness over the real
+    ``RouterHistoryBuffer`` (#3629 names this explicitly: "the owner runs
+    reyn from two working copies") — the SAME persisted ``ChatMessage``
+    (shaped exactly as step 5 above persists one) is replayed via a REAL
+    ``build_history()`` from a DIFFERENT checkout root than it was written
+    under; the wire content follows the CURRENT filesystem root, asserted
+    by value, not merely "changed"."""
+    source_path = "skills/my-skill/SKILL.md"
+
+    checkout_a = tmp_path / "checkout-a"
+    (checkout_a / "skills" / "my-skill").mkdir(parents=True)
+    (checkout_a / "skills" / "my-skill" / "SKILL.md").write_text("x", encoding="utf-8")
+
+    checkout_b = tmp_path / "checkout-b"
+    (checkout_b / "skills" / "my-skill").mkdir(parents=True)
+    (checkout_b / "skills" / "my-skill" / "SKILL.md").write_text("x", encoding="utf-8")
+
+    msg = ChatMessage(
+        role="tool",
+        content="See ${REYN_SKILL_DIR}/reference.md",
+        meta={
+            TOKEN_MAP_META_KEY: {"REYN_SKILL_DIR": "/some/stale/write-time/value"},
+            SKILL_SOURCE_PATH_META_KEY: source_path,
+        },
+        tool_call_id="tc1", name="load_skill",
+    )
+
+    wire_a = _buffer([msg], checkout_a).build_history()
+    tool_msg_a = next(m for m in wire_a if m.get("role") == "tool")
+    assert str((checkout_a / "skills" / "my-skill").resolve()) in tool_msg_a["content"]
+    assert "/some/stale/write-time/value" not in tool_msg_a["content"], (
+        "must NEVER re-expand from the frozen meta value -- only fresh resolution"
+    )
+
+    # Same persisted entry, replayed from the OTHER checkout (a rewind /
+    # process restart pointed at a different working copy).
+    wire_b = _buffer([msg], checkout_b).build_history()
+    tool_msg_b = next(m for m in wire_b if m.get("role") == "tool")
+    assert str((checkout_b / "skills" / "my-skill").resolve()) in tool_msg_b["content"], (
+        "replaying the SAME persisted entry from a DIFFERENT checkout root "
+        "must follow the CURRENT filesystem, not repeat checkout-a's value"
+    )
+    assert str(checkout_a) not in tool_msg_b["content"]
+
+
+def test_serialise_turn_leaves_token_literal_when_source_path_gone(tmp_path):
+    """Tier 2: when the persisted entry's ``skill_source_path`` no longer
+    resolves at all (deleted, or the model's own path reference renamed
+    away — #3629's actual reported shape), the wire content keeps the
+    literal token rather than showing any absolute path — legible
+    unresolved, never a guess."""
+    msg = ChatMessage(
+        role="tool",
+        content="See ${REYN_SKILL_DIR}/reference.md",
+        meta={
+            TOKEN_MAP_META_KEY: {"REYN_SKILL_DIR": "/some/stale/write-time/value"},
+            SKILL_SOURCE_PATH_META_KEY: "skills/reyn_cheat_sheet/SKILL.md",  # never existed here
+        },
+        tool_call_id="tc1", name="load_skill",
+    )
+    buf = _buffer([msg], tmp_path)
+
+    wire = buf.build_history()
+
+    tool_msg = next(m for m in wire if m.get("role") == "tool")
+    assert "${REYN_SKILL_DIR}" in tool_msg["content"]
+    assert "/some/stale/write-time/value" not in tool_msg["content"]
+
+
+def test_serialise_turn_is_noop_for_pre_3629_history(tmp_path):
+    """Tier 2: an entry with no ``SKILL_SOURCE_PATH_META_KEY`` at all (every
+    pre-#3629 persisted row, and every non-skill tool message) is untouched
+    by the refresh pass -- the architect's ruling that already-poisoned
+    history is neither rewritten nor annotated."""
+    msg = ChatMessage(
+        role="tool", content="an ordinary tool result, no location tokens here",
+        meta={"chain_id": "abc"}, tool_call_id="tc1", name="read_file",
+    )
+    buf = _buffer([msg], tmp_path)
+
+    wire = buf.build_history()
+
+    tool_msg = next(m for m in wire if m.get("role") == "tool")
+    assert tool_msg["content"] == "an ordinary tool result, no location tokens here"

--- a/tests/test_op_runtime_file_not_found_suggestions.py
+++ b/tests/test_op_runtime_file_not_found_suggestions.py
@@ -155,15 +155,63 @@ def test_edit_existing_file_unchanged(tmp_path, monkeypatch):
 # ── parent-dir edge cases ──────────────────────────────────────────────────────
 
 
-def test_read_not_found_in_nested_missing_dir(tmp_path, monkeypatch):
-    """Tier 2: missing parent dir → suggestions empty, no crash."""
+def test_read_not_found_in_nested_missing_dir_suggests_nearest_ancestor(tmp_path, monkeypatch):
+    """Tier 2: (#3629) a missing PARENT dir — not just missing siblings — now
+    returns the nearest EXISTING ancestor as a suggestion, asserted by VALUE
+    (the workspace root itself, since nothing under it exists here), rather
+    than the pre-#3629 empty list. This is "no parent", the case a rename,
+    move, or plugin reinstall produces — see ``_nearest_existing_ancestor``'s
+    docstring (file.py) for why it must be distinguished from "no
+    neighbours" (test_read_not_found_in_nested_existing_but_empty_dir,
+    below), which legitimately still returns ``[]``."""
     monkeypatch.chdir(tmp_path)
     ctx = _make_ctx(tmp_path)
 
     result = _run(handle(_read("nonexistent_dir/file.md"), ctx))
 
     assert result["status"] == "not_found"
+    assert result["suggestions"] == ["./"]
+
+
+def test_read_not_found_in_nested_existing_but_empty_dir(tmp_path, monkeypatch):
+    """Tier 2: (#3629) an EXISTING but empty parent dir is "no neighbours",
+    not "no parent" — the suggestions list stays legitimately empty rather
+    than falling back to an ancestor (that fallback exists to recover a
+    missing STRUCTURE, not to pad a genuinely-empty directory)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "empty_dir").mkdir()
+    ctx = _make_ctx(tmp_path)
+
+    result = _run(handle(_read("empty_dir/file.md"), ctx))
+
+    assert result["status"] == "not_found"
     assert result["suggestions"] == []
+
+
+def test_read_not_found_under_renamed_skill_dir_suggests_current_ancestor(tmp_path, monkeypatch):
+    """Tier 2: (#3629 strip-falsify) the reported scenario, reproduced
+    directly — a skill directory is renamed (mirroring #3588's
+    underscore-to-hyphen shipped-skill rename) and a later read against the
+    OLD (now-vanished) path is asked for suggestions.
+
+    Asserted by VALUE: the suggestion names the CURRENT ancestor
+    (``skills/``, which still exists and now contains the renamed dir) —
+    not merely "suggestions is non-empty". Before the #3629 fix this
+    returned ``[]`` (RED — see this module's git history / the PR that
+    introduced this test for the pre-fix measurement)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "skills" / "reyn_cheat_sheet").mkdir(parents=True)
+    (tmp_path / "skills" / "reyn_cheat_sheet" / "SKILL.md").write_text("body", encoding="utf-8")
+    # The rename #3588 performed: reyn_cheat_sheet -> reyn-cheat-sheet.
+    (tmp_path / "skills" / "reyn_cheat_sheet").rename(tmp_path / "skills" / "reyn-cheat-sheet")
+    ctx = _make_ctx(tmp_path)
+
+    # A read against the OLD, now-dead path (as an old history entry would
+    # still name it — history is immutable, #3629's whole premise).
+    result = _run(handle(_read("skills/reyn_cheat_sheet/reference.md"), ctx))
+
+    assert result["status"] == "not_found"
+    assert result["suggestions"] == ["skills/"]
 
 
 def test_read_not_found_in_nested_existing_dir(tmp_path, monkeypatch):


### PR DESCRIPTION
**[per-PR-coder]** — Implements #3629 per architect's firm design (issuecomment-5156137923, ruling issuecomment-5158323812).

## What changed

1. **PLUGIN_ROOT handled alongside SKILL_DIR.** Architect measured both belong to the same "stable location" class in `plugins/tokens.py`'s docstring and share the same latent defect (`LOCATION_TOKEN_NAMES` in `tokens.py` now names both + their `CLAUDE_*` aliases). `REYN_PROJECT_DIR` was measured already-safe and is untouched.

2. **①+metadata, not ①+③.** `load_skill_body` (`plugins/skill_load.py`) now returns a persist-safe variant alongside the current-turn one:
   - `content` — fully expanded (unchanged; what the model reads THIS turn).
   - `persisted` — `${REYN_SKILL_DIR}`/`${REYN_PLUGIN_ROOT}` (+ `CLAUDE_*` aliases) left LITERAL; `${REYN_PROJECT_DIR}` still expanded.
   - `location_token_map` — the write-time values, threaded onto `ChatMessage.meta` (`token_map`/`skill_source_path`, `chat_message.py`) as **audit-completeness only** (LLM-payload trace dumping is opt-in via `REYN_LLM_TRACE_DUMP`; history is the only always-on record). Never a re-expansion source.

   Wiring: `load_skill` op → `content_history`/`token_map`/`skill_source_path` fields → `load_skill_to_canonical` (`CanonicalToolResult.history_text`/`history_meta`, new optional TypedDict fields) → `RouterLoop.feedback()` persists `history_text` via `append_history_entry` instead of the wire `content_str` (which stays fully resolved — the model's current-turn read is unaffected).

3. **Already-poisoned history is untouched** (ruling: permanent cost + depends on the model reading an annotation correctly). `refresh_location_tokens` (new, `skill_load.py`) is wired into `RouterHistoryBuffer._serialise_turn` and re-resolves the literal tokens FRESH, against the current filesystem, every time a **newly-persisted** entry is replayed — using the identity (`skill_source_path`, i.e. the original `op.path`), never the frozen `token_map` value. Self-heals when the same relative structure still resolves (a relocated checkout/plugin-root — "two working copies" from the issue body); leaves the token legibly unexpanded (never a stale absolute value) when the identity is genuinely gone (an actual rename, #3588's shape).

4. **`file.py`'s not-found `suggestions`** (`_nearby_files`) now include the nearest EXISTING ancestor when the path's own PARENT directory is gone (not just empty) — decision-enabling at the point the harm lands, for old poisoned history alike. Distinguishes "no parent" (ancestor fallback fires) from "no neighbours" (stays `[]`, unchanged).

## Verification

- **By-value assertions** throughout (§16): `_nearby_files` asserts the literal ancestor path (`["skills/"]`), not "non-empty"; `refresh_location_tokens`/`RouterHistoryBuffer` tests assert the actual resolved absolute path.
- **Directory-moved witness**: `test_serialise_turn_refreshes_location_token_after_checkout_moves` builds the SAME persisted `ChatMessage` and replays it via a real `RouterHistoryBuffer.build_history()` from two different checkout roots — asserts the wire content follows the CURRENT root each time, never repeats the other checkout's value.
- **RED-on-break, both fixes**:
  - `file.py`: reverting `_nearby_files`/`_nearest_existing_ancestor` → 2 of the new not-found tests fail (`assert [] == ['skills/']` / `['./']`), 9 unaffected.
  - Token mechanism: reverting the full change set → `ImportError: cannot import name 'refresh_location_tokens'` (collection-level RED across the new test module).
- Existing test suites for `load_skill`, `skill_load`, `canonical`, `router_loop`, `router_history_buffer`, `file` not-found suggestions, `skill_invoke` all still pass (fixed 11 pre-existing 3-tuple unpacks in `tests/plugins/test_skill_load.py` + one caller in `interfaces/skill_invoke.py` for the new 5-tuple return; updated one test in `test_op_runtime_file_not_found_suggestions.py` whose docstring asserted the OLD "missing parent → suggestions empty" behavior this PR intentionally changes).
- No tool schema/description changed (only internal op-result fields) — no LLM replay fixture re-recording needed; confirmed the tests referencing `load_skill` by name still pass unmodified.
- Docs: `docs/concepts/tools-integrations/skills.md`'s "stable location" section (which this PR falsifies) updated with the #3629 mechanism + a new "Not-found suggestions surface the current structure" section; `docs/reference/runtime/control-ir.md`'s `load_skill` op section updated with the new result fields. `docs/deep-dives/proposals/0064-plugin-model.md` is an ADR (left untouched per ADR immutability).

## Gates run locally (foreground)
- `ruff check src tests` — clean.
- `scripts/test_tier_audit.py --strict` on the 3 changed/added test files — 33/33 OK, 0 Tier-4 violations.
- `scripts/verify_module_docstrings.py` on all changed src files — OK.
- Full local `pytest` NOT run (per policy — CI is authoritative); ran the targeted suites above plus a `-k` sweep across skill/router_loop/router_history/canonical/chat_message/tokens/not_found/3629/3247 (733 passed, 3 pre-existing unrelated failures confirmed present on main too — a flaky textual-focus widget test in `test_3354_composer_completion.py`, unrelated to this change, 19 failures pre-existing vs 3 post-existing in the same run — not caused by this diff).

## Test plan
- [x] `ruff check src tests`
- [x] `scripts/test_tier_audit.py --strict` on changed test files
- [x] `scripts/verify_module_docstrings.py` on changed src files
- [x] Targeted pytest runs (listed above) green
- [x] RED-on-break confirmed for both fixes
- [x] Directory-moved witness (by value) confirmed
- [x] No tool schema/description change → no fixture re-recording needed (verified)

part of #3629 — recommend closing #3629 once merged (this PR covers all three parts of the firm design + the file.py decision-enabling companion; no further sub-PRs are planned by this session).