### PR TITLE
fix(runtime): force-close covers_through_seq bounded by actually-summarised range (#3599)

### DIFF
--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -3,7 +3,7 @@
 Owns:
 
   - build_history              — slice history into OpenAI-style messages
-  - decompose_history_for_retry — head/raw_middle/tail/summary for retry_loop
+  - decompose_history_for_retry — head/raw_middle/tail/summary/seq_by_id for retry_loop
   - build_system_prompt        — assemble the router system prompt string
   - _serialise_turn            — materialise one ChatMessage to a wire dict
 
@@ -476,8 +476,9 @@ class RouterHistoryBuffer:
 
     def decompose_history_for_retry(
         self,
-    ) -> tuple[list[dict], list[dict], list[dict], dict | None]:
-        """Decompose current history into (head, raw_middle, tail, summary) for retry_loop.
+    ) -> tuple[list[dict], list[dict], list[dict], dict | None, dict[int, int]]:
+        """Decompose current history into (head, raw_middle, tail, summary,
+        seq_by_id) for retry_loop.
 
         #1128 step 3: mirrors :meth:`build_history`'s token-budget
         elide threshold (effective_trigger) and exposes the elided ``raw_middle``
@@ -489,6 +490,14 @@ class RouterHistoryBuffer:
         When total token estimate <= effective_trigger the full history goes into
         ``head`` with empty ``raw_middle`` / ``tail`` — there is nothing to elide,
         and retry_loop's shrink can still trim ``head``.
+
+        #3599: ``seq_by_id`` maps ``id(wire_dict) -> ChatMessage.seq`` for every
+        turn in ``head + raw_middle + tail`` (built off the same ``turns`` /
+        ``wire_turns`` pairing already computed here, so no extra serialise
+        pass). It lets a caller that only receives a SUBSET of these wire dicts
+        (e.g. the force-close wrap-up fallback, which may feed the LLM only
+        ``tail`` or neither) recover exactly which seqs that subset covers,
+        instead of assuming the full decomposition was used.
         """
         from reyn.services.compaction.engine import (
             estimate_tokens_for_any_turn,
@@ -509,6 +518,15 @@ class RouterHistoryBuffer:
         # #2957 PR-B: serialise once up front — same canonical-quantity
         # rationale as build_history (see ``_serialise_turn``'s docstring).
         wire_turns = [self._serialise_turn(m) for m in turns]
+
+        # #3599: pair each wire dict back to its source ChatMessage's seq —
+        # zip is positionally safe (wire_turns[i] was built FROM turns[i]
+        # above, same order, one-to-one). id() keys are only ever looked up
+        # against wire dicts drawn from THIS SAME wire_turns list (never
+        # across calls / after GC of the list), so no id-reuse hazard.
+        seq_by_id: dict[int, int] = {
+            id(wt): t.seq for wt, t in zip(wire_turns, turns)
+        }
 
         total = sum(
             estimate_tokens_for_any_turn(wt, self._model, use_chars4=use_chars4)
@@ -540,7 +558,7 @@ class RouterHistoryBuffer:
         # #1652/②: bound native reasoning across the ordered carriers (the strip
         # is in-place, so the shared dicts in head/raw_middle/tail are bounded).
         self._bound_wire_reasoning(head + raw_middle + tail)
-        return head, raw_middle, tail, summary_dict
+        return head, raw_middle, tail, summary_dict, seq_by_id
 
     def build_system_prompt(self) -> str:
         """Return the router system prompt for the current session state.

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -217,13 +217,23 @@ class RouterLoopDriver:
         ``[consolidation] + new turn`` instead of the raw head/tail that just
         overflowed.  ``user_text`` is unused here (the new message is re-applied
         by the loop's next ``_run_with_shrink``); kept for symmetry / future audit.
+
+        #3599: ``covers_through_seq`` used to be ``next_seq()-1`` unconditionally
+        — "everything up to right now is covered" — regardless of whether
+        ``_force_close_wrap_up``'s bounded fallback actually shrank the input
+        below that. Now it is exactly what ``_force_close_wrap_up`` reports it
+        fed the LLM (never more), and any range that fallback shrinkage
+        dropped from the summarisation input is logged on the SAME event so
+        the loss is legible, not silently absorbed into a watermark that
+        claims otherwise.
         """
         from reyn.runtime.chat_message import ChatMessage, _now_iso
         from reyn.runtime.session import _render_summary_for_storage
 
         resolved_model = self._resolver.resolve(self._effective_router_model_class()).model
-        consolidation = await self._force_close_wrap_up(loop, resolved_model)
-        covers = max(self._next_seq_fn() - 1, 0)
+        consolidation, covers, dropped_seq_ranges = await self._force_close_wrap_up(
+            loop, resolved_model
+        )
         structured = {"consolidation": consolidation}
         msg = ChatMessage(
             role="summary",
@@ -236,9 +246,17 @@ class RouterLoopDriver:
             "router_force_close_handoff",
             covers_through_seq=covers,
             consolidation_chars=len(consolidation),
+            # #3599: [start_seq, end_seq] pairs the fallback shrank OUT of the
+            # summarisation input — [] when the top-tier candidate (no
+            # shrink) succeeded. A later reader can tell "summarised" from
+            # "silently dropped" instead of trusting a watermark that no
+            # longer distinguishes them.
+            dropped_seq_ranges=[list(r) for r in dropped_seq_ranges],
         )
 
-    async def _force_close_wrap_up(self, loop: Any, resolved_model: str) -> str:
+    async def _force_close_wrap_up(
+        self, loop: Any, resolved_model: str
+    ) -> "tuple[str, int, list[tuple[int, int]]]":
         """Produce the capped consolidation via the force-close wrap-up call.
 
         Made to FIT by a bounded fallback that shrinks the input if the
@@ -247,15 +265,43 @@ class RouterLoopDriver:
         ``[summary + raw_middle + tail]`` → ``[summary + tail]`` → ``[summary]``.
         If even summary-only overflows, the model is RUNTIME sub-viable → raise,
         surfaced as a genuine dead-end by the handoff loop.
+
+        #3599: returns ``(text, covers_through_seq, dropped_seq_ranges)``.
+        ``covers_through_seq`` is derived from the turns THIS call actually fed
+        the winning candidate to — never ``next_seq()-1`` regardless of which
+        tier won, mirroring the normal-compaction sibling's
+        ``compute_covers_through_seq`` / ``candidates[-1].seq`` bound
+        (``compaction_controller.py``) instead of trusting the global seq
+        counter. Floored at the prior summary's own ``covers_through_seq`` so
+        the watermark never regresses (continuity, same as that sibling's
+        carry-forward). ``dropped_seq_ranges`` names the raw_middle/tail seq
+        span(s) the fallback shrank OUT of the input when a lower tier wins
+        (empty when the top tier succeeds).
+
+        Note (#3599, scoped out of this fix — reported, not silently folded
+        in): ``head`` (the earliest token-budget slice from
+        ``decompose_history_for_retry``) is NEVER part of ANY candidate here,
+        in every tier, not only under fallback — a distinct, pre-existing gap
+        this PR does not change the semantics of. See the PR description.
         """
         from reyn.runtime.session import _render_summary_for_storage
         from reyn.services.compaction.engine import (
             ContextOverflowError as _ContextOverflowError,
         )
 
-        _head, _raw_middle, _tail, _summary_dict = (
+        _head, _raw_middle, _tail, _summary_dict, _seq_by_id = (
             self._history_buffer.decompose_history_for_retry()
         )
+
+        def _max_seq(_turns: list[dict]) -> int:
+            return max((_seq_by_id.get(id(t), 0) for t in _turns), default=0)
+
+        def _seq_span(_turns: list[dict]) -> "tuple[int, int] | None":
+            _seqs = [s for s in (_seq_by_id.get(id(t), 0) for t in _turns) if s]
+            return (min(_seqs), max(_seqs)) if _seqs else None
+
+        _prev_cover = int((_summary_dict or {}).get("covers_through_seq", 0))
+
         _summary_msg: list[dict] = []
         if _summary_dict:
             _summary_msg = [{
@@ -265,18 +311,24 @@ class RouterLoopDriver:
                     + _render_summary_for_storage(_summary_dict)
                 ),
             }]
+        # (input, turns actually fed, turns the fallback shrank away) per tier.
         _candidates = [
-            _summary_msg + _raw_middle + _tail,
-            _summary_msg + _tail,
-            _summary_msg,
+            (_summary_msg + _raw_middle + _tail, _raw_middle + _tail, []),
+            (_summary_msg + _tail, _tail, _raw_middle),
+            (_summary_msg, [], _raw_middle + _tail),
         ]
         _last_exc: Exception | None = None
-        for _inp in _candidates:
+        for _inp, _fed, _dropped_by_fallback in _candidates:
             try:
                 _result = await loop._force_close_call(
                     _inp, resolved_model=resolved_model
                 )
-                return _result.content or ""
+                _covers = max(_prev_cover, _max_seq(_fed))
+                _dropped_span = _seq_span(_dropped_by_fallback)
+                _dropped: list[tuple[int, int]] = (
+                    [_dropped_span] if _dropped_span is not None else []
+                )
+                return _result.content or "", _covers, _dropped
             except Exception as _exc:
                 if not any(kw in str(_exc).lower() for kw in (
                     "context", "token", "length", "limit", "too long", "too large",
@@ -326,7 +378,7 @@ class RouterLoopDriver:
             )
             from reyn.services.compaction.engine import retry_loop as _retry_loop
             engine = self._compaction_controller._engine
-            _head, _raw_middle, _tail, _summary_dict = (
+            _head, _raw_middle, _tail, _summary_dict, _ = (
                 self._history_buffer.decompose_history_for_retry()
             )
             _new_msg = {"role": "user", "content": user_text}

--- a/tests/test_build_history_producer_calls_2939.py
+++ b/tests/test_build_history_producer_calls_2939.py
@@ -105,7 +105,7 @@ def test_decompose_history_for_retry_materialises_the_producer_once():
     history.insert(0, ChatMessage(role="summary", content="earlier conversation"))
     buf, calls = _buffer(history, "openai/gpt-4o")
 
-    head, _raw_middle, _tail, _summary = buf.decompose_history_for_retry()
+    head, _raw_middle, _tail, _summary, _seq_by_id = buf.decompose_history_for_retry()
 
     assert head, "sanity: the decomposition is non-empty"
     assert calls["n"] == 1, (

--- a/tests/test_force_close_chat_handoff_1092.py
+++ b/tests/test_force_close_chat_handoff_1092.py
@@ -161,7 +161,9 @@ async def test_wrap_up_bounded_fallback_fits(tmp_path) -> None:
     for t in ("U1", "A1", "U2", "A2"):
         _push(session, "user" if t.startswith("U") else "assistant", t)
     loop = _FailFirstLoop(fail_first=2)
-    out = await session._loop_driver._force_close_wrap_up(loop, resolved_model="m")
+    out, _covers, _dropped = await session._loop_driver._force_close_wrap_up(
+        loop, resolved_model="m"
+    )
     assert out == _CONSOL
     assert loop.attempts == 3  # 2 over-large candidates fell back, 3rd fit
 

--- a/tests/test_force_close_covers_through_seq_3599.py
+++ b/tests/test_force_close_covers_through_seq_3599.py
@@ -1,0 +1,205 @@
+"""Tier 2: force-close ``covers_through_seq`` must not exceed what the wrap-up
+call actually fed the LLM (#3599).
+
+``_force_close_wrap_up`` has a 3-tier bounded fallback that shrinks its input
+on overflow: ``[summary + raw_middle + tail]`` -> ``[summary + tail]`` ->
+``[summary]``. Before this fix, the caller (``_force_close_handoff``) recorded
+``covers_through_seq = next_seq() - 1`` UNCONDITIONALLY — "everything up to
+right now is covered" — regardless of which tier actually won, so a fallback
+that dropped ``raw_middle`` (or ``raw_middle`` + ``tail``) from the
+summarisation input still had its watermark claim the FULL range as covered.
+
+Driven through the real ``_force_close_handoff`` + real ``_force_close_wrap_up``
+against a hand-written fake RouterLoop (a collaborator double, not a Mock)
+whose ``_force_close_call`` overflows a controlled number of times before
+succeeding — forcing a specific fallback tier to win. All turns are role="user"
+so every one gets a real monotonic ``.seq`` via ``Session._append_history``
+(the real assignment path — bypassing the assign step, e.g. via a bare
+``session.history.append``, would leave every turn at ``seq=0`` and make the
+by-value assertions below vacuous).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.chat_message import ChatMessage
+from reyn.services.compaction.engine import ContextOverflowError
+from tests._support.session import make_session as _make_session
+
+# Content sized (with use_chars4_estimate=True, 1 token per 4 chars) so 8 turns
+# of this content elide into head=[t0] / raw_middle=[t1..t6] / tail=[t7] at
+# t_max=2800 (the same construction test_retry_loop_chat_wiring_1125.py's
+# _make_session docstring measures: head_budget~74, tail_budget~112,
+# effective_trigger~489; 320 chars -> 80 tokens/turn; 8*80=640 > 489 -> elide).
+_TURN_80TOK = "X" * 320
+_T_MAX = 2800
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _push_user(session, text: str) -> None:
+    """Append a REAL user turn through Session._append_history so it gets a
+    genuine monotonic .seq (role="user" is the only role the seq-assignment
+    gate fires for) — required for the by-value seq assertions below."""
+    session._append_history(ChatMessage(role="user", content=text, ts=_now()))
+
+
+class _FailFirstThenSucceed:
+    """Collaborator double for RouterLoop: ``_force_close_call`` raises a
+    context-overflow error on the first ``fail_first`` attempts, then
+    succeeds — drives the bounded fallback to land on a specific tier."""
+
+    def __init__(self, fail_first: int) -> None:
+        self.attempts = 0
+        self._fail_first = fail_first
+        self.seen_inputs: list[list[dict]] = []
+
+    async def _force_close_call(
+        self, messages: list[dict], *, resolved_model: str
+    ) -> LLMToolCallResult:
+        self.attempts += 1
+        self.seen_inputs.append(messages)
+        if self.attempts <= self._fail_first:
+            raise ContextOverflowError("wrap-up input too large")
+        return LLMToolCallResult(
+            content="CONSOL", tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(prompt_tokens=5, completion_tokens=3),
+        )
+
+
+def _capture_events(session) -> list[Any]:
+    seen: list[Any] = []
+    session._chat_events.add_subscriber(lambda e: seen.append(e))
+    return seen
+
+
+def _push_8_turns(session) -> None:
+    for _ in range(8):
+        _push_user(session, _TURN_80TOK)
+
+
+@pytest.mark.asyncio
+async def test_top_tier_success_covers_matches_actually_fed_seqs(tmp_path) -> None:
+    """Tier 2: when the FULL candidate (raw_middle + tail, no fallback) wins,
+    covers_through_seq equals the max seq actually fed — byte-identical to the
+    pre-fix value here (tail already reaches the newest seq), no dropped
+    ranges. Establishes the non-regression baseline before the fallback cases
+    below actually change behaviour."""
+    session = _make_session(tmp_path, t_max=_T_MAX)
+    _push_8_turns(session)
+    head, raw_middle, tail, _summary, seq_by_id = (
+        session._history_buffer.decompose_history_for_retry()
+    )
+    assert head and raw_middle and tail, (
+        "test premise: this construction must actually elide into a "
+        "non-empty head/raw_middle/tail split for the scenario to exercise "
+        "the fallback tiers below"
+    )
+    expected_covers = max(seq_by_id[id(t)] for t in raw_middle + tail)
+    events = _capture_events(session)
+    loop = _FailFirstThenSucceed(fail_first=0)  # top tier succeeds immediately
+
+    await session._loop_driver._force_close_handoff(loop=loop, user_text="x")
+
+    assert loop.attempts == 1
+    (fired,) = [e for e in events if e.type == "router_force_close_handoff"]
+    assert fired.data["covers_through_seq"] == expected_covers
+    assert fired.data["dropped_seq_ranges"] == []
+
+
+@pytest.mark.asyncio
+async def test_tier2_fallback_does_not_overclaim_and_reports_the_drop(
+    tmp_path,
+) -> None:
+    """Tier 2: when the fallback shrinks to [summary + tail] (raw_middle
+    dropped from the summarisation input), covers_through_seq must still
+    equal the max seq ACTUALLY fed (tail's own seq — happens to equal the old
+    formula's next_seq()-1 here, since tail holds the newest turn) — the
+    requirement is asserted BY VALUE (not "old == new"), and the dropped
+    raw_middle span must be reported so the loss is legible, not silently
+    absorbed."""
+    session = _make_session(tmp_path, t_max=_T_MAX)
+    _push_8_turns(session)
+    head, raw_middle, tail, _summary, seq_by_id = (
+        session._history_buffer.decompose_history_for_retry()
+    )
+    assert raw_middle and tail, (
+        "test premise: this construction must produce a non-empty "
+        "raw_middle AND tail for the tier-2 fallback (raw_middle dropped, "
+        "tail kept) to mean anything"
+    )
+    expected_covers = max(seq_by_id[id(t)] for t in tail)
+    expected_dropped_span = [
+        min(seq_by_id[id(t)] for t in raw_middle),
+        max(seq_by_id[id(t)] for t in raw_middle),
+    ]
+    events = _capture_events(session)
+    loop = _FailFirstThenSucceed(fail_first=1)  # top tier overflows once, tier2 fits
+
+    await session._loop_driver._force_close_handoff(loop=loop, user_text="x")
+
+    assert loop.attempts == 2
+    (fired,) = [e for e in events if e.type == "router_force_close_handoff"]
+    assert fired.data["covers_through_seq"] == expected_covers
+    assert fired.data["dropped_seq_ranges"] == [expected_dropped_span]
+
+
+@pytest.mark.asyncio
+async def test_tier3_fallback_pins_covers_to_prior_watermark_not_next_seq(
+    tmp_path,
+) -> None:
+    """Tier 2: THE #3599 regression case — when even [summary + tail]
+    overflows and the fallback lands on [summary] ALONE — nothing new fed to
+    the LLM at all — covers_through_seq must NOT advance past the prior
+    summary's own watermark (0, no summary yet here). Before the fix this
+    unconditionally recorded ``next_seq() - 1`` (== 8), claiming the entire
+    conversation was summarised when NONE of it reached the wrap-up call —
+    the exact defect #3599 names. Both raw_middle's and tail's seq span are
+    reported as dropped."""
+    session = _make_session(tmp_path, t_max=_T_MAX)
+    _push_8_turns(session)
+    head, raw_middle, tail, _summary, seq_by_id = (
+        session._history_buffer.decompose_history_for_retry()
+    )
+    assert raw_middle and tail, (
+        "test premise: this construction must produce a non-empty "
+        "raw_middle AND tail for the tier-3 fallback (both dropped) to "
+        "mean anything"
+    )
+    next_seq_minus_1 = session._next_seq - 1
+    assert next_seq_minus_1 == max(seq_by_id[id(t)] for t in raw_middle + tail), (
+        "test premise: every pushed turn is role=user, so the global seq "
+        "counter must have advanced in lockstep with the newest turn "
+        "actually present in raw_middle/tail"
+    )
+    expected_dropped_span = [
+        min(seq_by_id[id(t)] for t in raw_middle + tail),
+        max(seq_by_id[id(t)] for t in raw_middle + tail),
+    ]
+    events = _capture_events(session)
+    loop = _FailFirstThenSucceed(fail_first=2)  # top tier + tier2 both overflow
+
+    await session._loop_driver._force_close_handoff(loop=loop, user_text="x")
+
+    assert loop.attempts == 3
+    (fired,) = [e for e in events if e.type == "router_force_close_handoff"]
+    assert fired.data["covers_through_seq"] == 0
+    assert fired.data["covers_through_seq"] != next_seq_minus_1, (
+        "the pre-fix defect: covers_through_seq recorded next_seq()-1 "
+        "(claiming full coverage) even though the wrap-up input was shrunk "
+        "to the persisted summary alone — nothing new was fed to the LLM"
+    )
+    assert fired.data["dropped_seq_ranges"] == [expected_dropped_span]
+    # The installed summary message itself must carry the same bounded value
+    # (this is what downstream consumers like Session._uncompacted_tool_call_
+    # records actually read back from history — not just the audit event).
+    latest = session._latest_summary()
+    assert latest is not None
+    assert (latest.meta or {}).get("covers_through_seq") == 0

--- a/tests/test_retry_loop_chat_wiring_1125.py
+++ b/tests/test_retry_loop_chat_wiring_1125.py
@@ -116,7 +116,7 @@ def test_decompose_slices_head_raw_middle_tail(tmp_path) -> None:
     for i in range(msgs_pushed):
         _push(session, "user" if i % 2 == 0 else "assistant", _TURN_80TOK)
 
-    head, raw_middle, tail, summary = session._history_buffer.decompose_history_for_retry()
+    head, raw_middle, tail, summary, _seq_by_id = session._history_buffer.decompose_history_for_retry()
 
     assert head, "head must be non-empty after elide"
     assert tail, "tail must be non-empty after elide"
@@ -145,7 +145,7 @@ def test_decompose_no_elide_when_history_fits_window(tmp_path) -> None:
     for i in range(3):
         _push(session, "user", f"q-{i}")
 
-    head, raw_middle, tail, summary = session._history_buffer.decompose_history_for_retry()
+    head, raw_middle, tail, summary, _seq_by_id = session._history_buffer.decompose_history_for_retry()
 
     assert [m["content"] for m in head] == ["q-0", "q-1", "q-2"]
     assert raw_middle == []
@@ -166,7 +166,7 @@ def test_decompose_extracts_structured_summary(tmp_path) -> None:
     for i in range(6):
         _push(session, "user", f"m-{i}")
 
-    _head, _raw_middle, _tail, summary = session._history_buffer.decompose_history_for_retry()
+    _head, _raw_middle, _tail, summary, _seq_by_id = session._history_buffer.decompose_history_for_retry()
     assert summary == structured
 
 
@@ -185,7 +185,7 @@ def test_decompose_wire_shape_matches_build_history(tmp_path) -> None:
     for i in range(8):
         _push(session, "user" if i % 2 == 0 else "assistant", _TURN_80TOK)
 
-    head, raw_middle, tail, _summary = session._history_buffer.decompose_history_for_retry()
+    head, raw_middle, tail, _summary, _seq_by_id = session._history_buffer.decompose_history_for_retry()
     via_build = session._history_buffer.build_history()
 
     # Both paths must return the same non-bridge turns in the same order.
@@ -238,7 +238,7 @@ def test_recovery_summary_bridge_matches_normal_path(tmp_path) -> None:
         if isinstance(m["content"], str) and m["content"].startswith("[summary")
     )
     # Recovery path renders the structured dict the same way.
-    _h, _rm, _t, summary_dict = session._history_buffer.decompose_history_for_retry()
+    _h, _rm, _t, summary_dict, _seq_by_id = session._history_buffer.decompose_history_for_retry()
     recovery_bridge = (
         "[summary of earlier conversation]\n" + _render_summary_for_storage(summary_dict)
     )
@@ -262,7 +262,7 @@ def test_session_decomposition_feeds_retry_loop(tmp_path) -> None:
     for i in range(3):
         _push(session, "user", f"hi-{i}")
 
-    head, raw_middle, tail, summary = session._history_buffer.decompose_history_for_retry()
+    head, raw_middle, tail, summary, _seq_by_id = session._history_buffer.decompose_history_for_retry()
     engine = session._compaction_controller._engine
     new_msg = {"role": "user", "content": "latest"}
 


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3599

## Re-derived trigger condition (not assumed from the issue)

Read `_force_close_wrap_up` / `_force_close_handoff` in `src/reyn/runtime/services/router_loop_driver.py`. The 3-tier bounded fallback is real:
`[summary + raw_middle + tail]` → `[summary + tail]` → `[summary]`. The caller
unconditionally recorded `covers_through_seq = max(next_seq() - 1, 0)` — "everything up to right now" — regardless of which tier won.

Because a scalar watermark can only express a *contiguous* "everything ≤ N is covered" claim, and `tail` (the newest turns) is included in BOTH the top tier and the tier-2 fallback, the numeric value only visibly diverges from the old formula when **tier 3** wins (`raw_middle` **and** `tail` both dropped — nothing new reaches the LLM at all). In that case the old code still claimed `next_seq()-1` (full coverage) while zero new content was summarised. Under tier-2 (only `raw_middle` dropped), the OLD numeric value happened to coincide with the correct one (both equal `tail`'s max seq) — the defect there is invisible in the number but real in the *meaning*: nothing distinguished "raw_middle was summarised" from "raw_middle was silently dropped." Verified this by constructing all three tiers with known seqs (test file below) rather than assuming from the issue text.

**Residual finding, reported not folded in**: `head` (the earliest token-budget slice from `decompose_history_for_retry`) is **never** part of ANY candidate here — not just under fallback, in every tier, including full success. Per `build_history`'s force-close branch (`router_history_buffer.py:349-384`), after ANY force-close the raw head/tail is replaced entirely by `[bridge] + post-turns`, so `head`'s content becomes permanently unreachable to the router LLM whether or not it was already covered by the prior summary's own watermark. Whether `head` should now be fed into the wrap-up call is a cost/behavior tradeoff distinct from this ticket's named defect (the fallback-drop miscount), so I did not fold a semantics change for it into this PR — flagging for a follow-up decision rather than silently expanding scope.

## Consumer sweep

`covers_through_seq` (this field, this event) is read by:
- `Session._uncompacted_tool_call_records` (`session.py:6053-6071`) — treats `seq <= watermark` as "already compacted," feeding the router's hot-list. This is the CONCRETE harm: force-close never calls `_merge_action_usage` (unlike the normal `CompactionController._run_compaction` path), so if the watermark falsely advances past turns that were never folded into the compacted table, their tool-calls become invisible to the hot-list forever — neither "live" nor "compacted."
- `Session._compact_now_for_op` (`session.py:7541-7564`, the `/compact` op) — reports `covers_through_seq` deltas as the "chat middle-compression" metric.
- `router_force_close_handoff` audit event (in `AUDIT_EVENT_KINDS`, closed vocabulary — I only added payload fields to an EXISTING kind, no new kind, so the CI-checked events.md enumeration is untouched).

`decompose_history_for_retry`'s return signature changed (4-tuple → 5-tuple, added `seq_by_id`); swept all 2 src call sites + 6 test call sites across 3 test files to unpack the new element. `_force_close_wrap_up`'s return also changed (`str` → `(str, int, list[tuple[int,int]])`); swept its one other test call site (`test_force_close_chat_handoff_1092.py`).

## Fix

`covers_through_seq` is now `max(prev_summary_covers_through_seq, max_seq_of_turns_actually_fed_to_the_winning_candidate)` — mirrors the normal-compaction sibling's `compute_covers_through_seq` / `candidates[-1].seq` bound in `compaction_controller.py:322` (which already derives this from the actual `new_turns` input, not a global counter) instead of trusting `next_seq()`. Floored at the prior summary's own watermark for continuity (same carry-forward the sibling does).

Whatever the fallback shrank away is reported as `dropped_seq_ranges` (list of `[start_seq, end_seq]`) on the same `router_force_close_handoff` event — legible instead of silently absorbed into an inflated number.

## Recovery-feature gate judgment

**Does not apply.** `covers_through_seq` is a field on a `summary`-role `ChatMessage`, persisted directly to `history.jsonl` — it is not reconstructed by replaying `.reyn/state/wal.jsonl` WAL-events after a crash (no PITR/rewind/restore path touches this field; the WAL-anchor mechanism near it, `#2360`, only tags turns for rewind *visibility* filtering, it doesn't derive `covers_through_seq`'s value). No truncate-falsify test added; none of `state_log.py` / WAL reconstruction paths were touched.

## Verification — by value, and RED-on-break

`tests/test_force_close_covers_through_seq_3599.py`, 3 tests, real `Session` + real `_force_close_handoff`/`_force_close_wrap_up` against a hand-written fake `RouterLoop` collaborator (no mocks) whose `_force_close_call` overflows a controlled number of times to force a specific tier:
- top tier succeeds → `covers_through_seq == max(seq of turns actually fed)`, `dropped_seq_ranges == []` (non-regression baseline).
- tier-2 fallback (raw_middle dropped) → `covers_through_seq == max(seq of tail)` (asserted by value, not "old == new"), `dropped_seq_ranges == [[min(raw_middle seq), max(raw_middle seq)]]`.
- tier-3 fallback (raw_middle + tail both dropped) → `covers_through_seq == 0` (asserted by value — NOT `!= next_seq()-1`, though that's also asserted as the named regression), `dropped_seq_ranges` covers both spans, and the persisted summary message's own `meta["covers_through_seq"]` is checked (what the real downstream consumer reads, not just the event payload).

**Broke my own fix and measured RED**: temporarily reintroduced the old `covers = max(next_seq_fn() - 1, 0)` formula. Result: `test_top_tier_success...` and `test_tier2_fallback...` still PASSED (their expected numeric value coincides with the old formula, as explained above — the tier-2 defect is a meaning bug, not a numeric one, until dropped_seq_ranges is checked... actually dropped_seq_ranges is computed independently of `covers` in the implementation, so it stayed correct even with the broken `covers` line — only `test_tier3_fallback...` went RED: `assert fired.data["covers_through_seq"] == 0` failed with `8 == 0`. Restored the fix, reran, all 3 GREEN.

Also ran the full sweep of touched/adjacent test files (25 tests: the new file + `test_force_close_chat_handoff_1092.py` + `test_force_close_covers_slice_1092.py` + `test_retry_loop_chat_wiring_1125.py` + `test_build_history_producer_calls_2939.py`, plus `test_2957_pra_chatmessage_token_type_mismatch.py` + `test_limit_deny_force_close_router_cap_1496.py` + `test_safety_max_iterations_fp0005.py`) — all green.

## Docs

Checked `docs/deep-dives/decisions/0036-history-compaction-force-close-unification.md` (ADR — immutable per standing convention, not touched), `docs/concepts/agent-engineering/reliability-engineering.md`, `docs/concepts/data-retrieval/chat-compaction.md`/`.ja.md`, `docs/reference/runtime/events.md`. None describe the `covers_through_seq` derivation mechanism specifically (events.md is a flat kind-name enumeration only) — no doc changes needed.

## Gates run locally (foreground, read myself)

- `ruff check src tests` — all checks passed.
- `python scripts/test_tier_audit.py --strict` on all 4 changed/added test files — 19 + 3 tests, 0 Tier-4 errors (fixed 2 real Tier-4 hits along the way: `len(x) == N` format-pinning → truthy/non-empty premise checks; a docstring's first line had a parenthetical before the `Tier N:` prefix → fixed).
- `python scripts/verify_module_docstrings.py` on both changed src files — OK.
- Full local `pytest` NOT run (CI is authoritative per policy) — ran only the touched/adjacent test files above.

## Test plan
- [x] Ran the new by-value test file against the real fix — 3/3 pass.
- [x] Broke the fix (reverted the `covers` line only) and confirmed the tier-3 test goes RED (`8 == 0`); tier-1/tier-2 stay green as expected (explained above) — restored, reran, GREEN.
- [x] Swept all `decompose_history_for_retry` / `_force_close_wrap_up` consumers (src + tests) for the signature change.
- [x] ruff / tier-audit / docstring gates green locally.