### PR TITLE
fix(runtime): dogfood session factory always hands a real registry — part of #3593 (stage ②)

### DIFF
--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -504,12 +504,18 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
         _reg_cell: list = []
 
         def _session_factory(profile: AgentProfile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
-            # #1827 S3: resolve the agent's topology capability_profile. The registry
-            # cell may be empty during bootstrap → (None, ∅) = byte-identical.
-            _reg = _reg_cell[0] if _reg_cell else None
-            _ctx_perm, _profile_excluded = (
-                _reg.resolved_profile_for(profile.name) if _reg else (None, frozenset())
-            )
+            # #3593 ②: this closure is only ever invoked as ``self._factory(...)`` from
+            # ``AgentRegistry._construct_session`` (registry.py), which requires an
+            # already-returned ``AgentRegistry`` instance to call — and that instance is
+            # exactly ``_reg_cell[0]``, appended immediately below, BEFORE ``reg`` is
+            # returned to this function's caller. So by the time this factory ever runs,
+            # ``_reg_cell`` is always populated; the previous `if _reg_cell else None`
+            # guard defended a window that cannot occur (nothing calls this factory
+            # directly — verified: `_session_factory` has no other reference than the
+            # `session_factory=` kwarg below). Read directly rather than re-deriving a
+            # bootstrap case that does not exist.
+            _reg = _reg_cell[0]
+            _ctx_perm, _profile_excluded = _reg.resolved_profile_for(profile.name)
             s = build_scoped_chat_session(
                 # #2708 P1: the dogfood eval harness is headless with no outbox/present
                 # drain at all — a reviewed NA surface. Null is byte-identical (present
@@ -532,7 +538,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 agent_role=profile.role,
                 compaction_config=config.chat.compaction,
                 reasoning_config=config.chat.reasoning,  # #1652
-                registry=_reg_cell[0] if _reg_cell else None,
+                registry=_reg,  # #3593 ②: always the real registry — see the note above
                 allowed_mcp=profile.allowed_mcp,
                 events_config=config.events,
                 state_log=None,  # no WAL for dogfood dispatch

--- a/tests/test_3593_stage2_dogfood_registry_ordering.py
+++ b/tests/test_3593_stage2_dogfood_registry_ordering.py
@@ -1,0 +1,111 @@
+"""Tier 2: #3593 (2) - dogfood's session factory hands CapabilityVisibility a
+REAL registry back-reference at construction, through the real dogfood
+bootstrap path (``_build_live_runner``), not by reading the code.
+
+Background: ``interfaces/cli/commands/dogfood.py``'s per-scenario session
+factory used to read ``_reg_cell[0] if _reg_cell else None`` with a comment
+claiming "the registry cell may be empty during bootstrap". That comment was
+never actually true: the factory closure is captured as ``session_factory=``
+on ``AgentRegistry.__init__`` and is only ever INVOKED later, lazily, from
+``AgentRegistry._construct_session`` (``self._factory(profile, ...)``) - which
+requires an already-returned ``AgentRegistry`` instance to call. ``_make_registry``
+appends that instance into ``_reg_cell`` immediately after constructing it,
+BEFORE returning it to its own caller - so by the time anything could call
+the factory, the cell is always populated. The conditional defended a window
+that call-order already forecloses; #3593 (2) removes the dead defensive
+code and this file witnesses the invariant it removed, through the real path,
+rather than a re-implementation of it.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import reyn.runtime.capability_visibility as capability_visibility_mod
+from reyn.dev.dogfood.scenarios import Scenario
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from tests._support.agent_session import make_session
+
+
+def _text_result(text: str) -> LLMToolCallResult:
+    return LLMToolCallResult(
+        content=text,
+        tool_calls=[],
+        finish_reason="stop",
+        usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+    )
+
+
+def _spy_on_capability_visibility_registry(monkeypatch) -> "list[object]":
+    """Wrap the REAL ``CapabilityVisibility.__init__`` to record the ``registry``
+    it is constructed with, then delegate to the real implementation unchanged
+    (a spy, not a fake collaborator — the constructed object and its behaviour
+    are the genuine ones; only the call is observed)."""
+    captured: "list[object]" = []
+    original_init = capability_visibility_mod.CapabilityVisibility.__init__
+
+    def _spy_init(self, *, registry, **kwargs):
+        captured.append(registry)
+        original_init(self, registry=registry, **kwargs)
+
+    monkeypatch.setattr(
+        capability_visibility_mod.CapabilityVisibility, "__init__", _spy_init,
+    )
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_dogfood_bootstrap_hands_capability_visibility_a_real_registry(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: driving a real dogfood scenario through ``_build_live_runner`` (the
+    production entry point ``interfaces/cli/commands/dogfood.py::run_run`` uses)
+    constructs ``CapabilityVisibility`` with a non-None registry that has
+    ``resolved_profile_for`` — witnessed at the actual construction call, not
+    inferred from reading ``_session_factory``'s source."""
+    monkeypatch.chdir(tmp_path)
+    captured = _spy_on_capability_visibility_registry(monkeypatch)
+
+    from reyn.interfaces.cli.commands.dogfood import _build_live_runner
+
+    runner_fn = _build_live_runner("default")
+
+    async def fake_llm(**kw):
+        return _text_result("ack")
+
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", fake_llm)
+    result = await runner_fn(Scenario(id="s1", input="hello"))
+
+    assert result.scenario_id == "s1"
+    assert captured, (
+        "CapabilityVisibility was never constructed during the scenario run — "
+        "the witness observed nothing"
+    )
+    assert all(reg is not None for reg in captured), (
+        "dogfood's bootstrap constructed at least one CapabilityVisibility with "
+        "registry=None — the ordering is NOT fixed"
+    )
+    assert all(hasattr(reg, "resolved_profile_for") for reg in captured), (
+        "the registry dogfood hands CapabilityVisibility must expose "
+        "resolved_profile_for (the _EnvelopeSource contract)"
+    )
+
+
+def test_the_spy_would_have_caught_a_missing_registry(monkeypatch, tmp_path: Path) -> None:
+    """Tier 2: negative control for the witness above — the same spy, pointed at a
+    session deliberately constructed with NO registry back-reference, DOES capture
+    None. Without this, a spy that captures nothing meaningful (e.g. a stale
+    reference, or a wrapper that never actually runs) would pass the positive
+    test vacuously."""
+    monkeypatch.chdir(tmp_path)
+    captured = _spy_on_capability_visibility_registry(monkeypatch)
+
+    make_session(agent_name="registry-less", registry=None)
+
+    assert captured == [None], (
+        "the spy must observe the exact registry a Session hands "
+        "CapabilityVisibility, including a None one — otherwise it cannot be "
+        "trusted to have witnessed the real dogfood path above"
+    )


### PR DESCRIPTION
**[per-PR-coder]** — part of #3593 (stage ②). Does **not** complete issue 3593 — see "What I did not do" below; the type-tightening / preserve-branch deletion this stage was briefed to do remains blocked on a real finding, not a convenience deferral.

## What this PR does

Removes the dead `_reg_cell[0] if _reg_cell else None` fallback in `interfaces/cli/commands/dogfood.py`'s per-scenario session factory (the one production `Session(registry=None)` site architect's population measurement named). The removed comment claimed "the registry cell may be empty during bootstrap" — that was never actually true, and this PR proves it rather than re-asserting it: `_session_factory` is captured as `session_factory=` on `AgentRegistry.__init__` and is only ever invoked later, lazily, from `AgentRegistry._construct_session`, which requires an already-constructed `AgentRegistry` to call — and `_make_registry` appends that instance into `_reg_cell` immediately after construction, before returning it. So the closure can never run before the cell is populated; the `else None` branch was structurally dead even before this PR.

## Ordering witness — through a real dogfood bootstrap, not by reading the code

`tests/test_3593_stage2_dogfood_registry_ordering.py::test_dogfood_bootstrap_hands_capability_visibility_a_real_registry` drives the REAL `interfaces/cli/commands/dogfood.py::_build_live_runner` (the function `run_run` uses) through a full scenario, with a spy wrapped around the real `CapabilityVisibility.__init__` (records the `registry` kwarg, then delegates to the unmodified constructor — not a mock, the constructed object is genuine) and asserts every observed `registry` is non-None and exposes `resolved_profile_for`.

`test_the_spy_would_have_caught_a_missing_registry` is the sensitivity control: the same spy, pointed at a session built with `registry=None` directly, captures `None` — proving the spy isn't vacuously passing.

**Strip-falsify, and an honest surprise**: I reverted this PR's dogfood.py diff and reran the positive witness — it stayed **GREEN**. This is expected, not a gap in the test: since the cell was always populated by call-order (never actually reachable via the old code either), there is no behavioral difference to falsify here. This PR is a dead-code / stale-comment removal at the dogfood site, not a behavior change — I'm stating that plainly rather than manufacturing a RED that doesn't exist.

## What I did not do, and why — the premise didn't hold when measured

The brief's instruction was: close the dogfood ordering, then tighten `CapabilityVisibility.__init__`'s `registry: _EnvelopeSource | None` to non-Optional, then delete the stage ① preserve branch (`reapply_visibility_override`'s early-return) and its 2 reachability tests, since they'd become unconstructible.

**They do not become unconstructible — measured, not assumed.** Two independent facts, verified by execution:

1. **`Session.__init__`'s own `registry: AgentRegistry | None = None` default is untouched by fixing dogfood**, and it is not merely a hypothetical: `tests/test_2103_s1bc_session_spawn_tool.py` and `tests/test_pipeline_a2_spawn_ephemeral_session.py` build sessions via factories that never pass `registry=` at all, then call `AgentRegistry.spawn_session_recorded`, which **unconditionally** calls `spawned_session.refresh_config_projections()` (`registry.py:2930`) — which fires `_reapply_visibility_override_seam` → `reapply_visibility_override()` on a session whose `self._registry is None`. This is not dogfood's bootstrap-window artifact; it is two independent test factories that never wired a registry, for reasons unrelated to capability-visibility (they're testing spawn-narrowing enforcement, which is registry-independent — `apply_per_session_narrowing` never touches `self._registry`).
2. **I found more of the same shape** (also unconditional `registry=`-less factories reaching a live seam dispatch that fires the visibility seam): `test_2073_s3_hooks_write_op.py`, `test_2761_pr2_hotreload_immediate_apply.py` (5 call sites) via direct `session._hot_reloader.apply_pending()` calls.
3. **I temporarily removed the `reapply_visibility_override` guard** (`if self._registry is None or not hasattr(...): ... return`) and reran all of the above plus `test_3097`/`test_3546`/`test_3561`/`test_3562`/the three `test_visibility_*_2285` files/`test_2088`/`test_2581_pipeline_hotreload`/`test_mcp_install_local_hot_reload`/`test_2761_pr3`/`test_3220`/`test_3378`/`test_3380`/`test_3338` (150 tests total across these). **Result: 0 new failures** (the 13 `test_3338` failures are the pre-existing unrelated `_CursorFlowView` textual issue #3650 already documented — confirmed identical with the guard present). This is because `HotReloader`'s seam dispatch wraps every seam call in `except Exception` and logs a warning (`hot_reload.py`, "a seam never breaks the spawn/turn/loop") — so the resulting `AttributeError: 'NoneType' object has no attribute 'resolved_profile_for'` is silently swallowed, and since it fires before any field assignment, the net effect is accidentally identical to "preserve" — just via exception-before-mutation instead of a designed check, and with the structured `#3593` WARNING replaced by a generic swallowed-exception one.

**The conclusion this forces**: making the preserve branch unconstructible requires more than fixing dogfood's ordering — it requires `Session.__init__`'s own `registry` parameter to stop accepting `None`, because any caller (test or otherwise) can construct a registry-less `Session` directly and reach `reapply_visibility_override` through it (via `set_capability_visible`, `load_persisted_toggles`, or any hot-reload seam dispatch). That is a repo-wide, ~300-call-site signature change (every `make_session(...)` in the test suite that doesn't pass `registry=`), not a dogfood-scoped one, and squarely outside what architect's own population measurement addressed (which was scoped to *production* `Session(registry=None)` call sites — that population is now provably closed by this PR; the *test-suite* population was never in scope of that measurement and remains open).

Per the brief's own instruction — **"If you find the branch is still reachable after your ordering fix, then the ordering is not actually fixed — say so rather than tightening the type on top of it."** — I am saying so. I did not touch `capability_visibility.py`'s type, guard, or `_surface_unreadable_envelope_source`, and I did not delete `tests/test_3593_preserve_envelope_when_base_unreadable.py`'s reachability tests — they still witness a genuinely reachable path (their own independent harness, unaffected by the dogfood fix either way).

## #3650 (`envelope_unknown` / `unknown`) interaction

Since I did not tighten the type or touch the read-side guard, `capability_visibility_state`'s `envelope_unknown`/`unknown` mechanism is unaffected by this PR and keeps exactly the live source it had before (the same registry-less-Session population above also reaches it — e.g. via a direct `capability_visibility_state()` call on such a session). No new dead-code instance was created here.

## Recommendation for whoever picks up the actual type-tightening

The real stage ② (type-tightening + branch deletion) needs, first: either (a) a census + fix of every test factory that constructs a registry-less `Session` and then reaches a hot-reload seam dispatch (the shape I found 4+ instances of, not exhaustively enumerated here — I stopped at a representative, falsifying sample per the effort this PR could responsibly spend), or (b) accept that `Session.__init__`'s `registry` param itself must become required, and do the ~300-site test-signature sweep that implies. Neither is a dogfood-scoped fix, and either should be its own reviewed PR, not folded into "tighten one type annotation."

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_3593_stage2_dogfood_registry_ordering.py` — 2 inspected, 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/cli/commands/dogfood.py` — OK
- [x] New test file green (2/2); `test_fp0036_live_runner.py` (adjacent dogfood coverage) still green (6/6)
- [x] Strip-falsify: reverted the dogfood.py diff, reran the positive witness — GREEN (documented above as the expected, non-behavioral-change result)
- [x] Sensitivity control for the spy: `test_the_spy_would_have_caught_a_missing_registry` — captures `None` when pointed at a genuinely registry-less session
- [x] Broader collateral check: temporarily removed the `reapply_visibility_override` guard and ran 150 tests across the visibility/spawn/hot-reload family — 0 new failures (see "What I did not do" §3) — restored before commit
- [x] Testing policy re-read; no mock/AsyncMock/patch/hand-rolled fakes (the "spy" wraps and delegates to the real `CapabilityVisibility.__init__`, never replacing its behavior); no private-state assertions; no format/order pins
- [ ] (skipped — no visual/TTY surface touched; not independently re-verifiable from this environment)

Enumerated per CLAUDE.md rule 4 before writing "part of": `gh pr list --state all --search "3593 in:body"` shows #3614 (stage ①, merged) as the only other `part of #3593` PR; this is the second. Neither completes the issue, so `Closes #3593` is not used.



<!-- closing-check: discussing #3593 -->
