### PR TITLE
docs: fix stale auto-record-on-missing-fixture claim missed by #3663

### DIFF
--- a/docs/guide/for-reyn-developers/write-replay-tests.md
+++ b/docs/guide/for-reyn-developers/write-replay-tests.md
@@ -270,14 +270,17 @@ regenerating in place after a schema change (even a `description`-only edit)
 left the OLD entry on disk alongside the new one: the fixture then matched
 BOTH the old and the new schema and stayed green regardless of which one the
 code implements — worse than a stale fixture, which at least goes RED. Delete
-the fixture first if you prefer an explicit "starting from nothing" (conftest
-auto-detects the missing file and switches to record mode), but it is no
-longer required for correctness:
+the fixture first if you prefer an explicit "starting from nothing," but
+**#3662 removed the missing-file-implies-record-mode fallback**: a deleted
+fixture now makes the test fail LOUD at fixture setup (before
+`LLMReplay.install()` runs) with the exact `REYN_LLM_RECORD=1` command to
+re-run, rather than silently switching modes on your behalf — you still need
+`REYN_LLM_RECORD=1` explicitly, delete or no delete:
 
 ```bash
 rm tests/fixtures/llm/my_area/text_only.jsonl
-python -m pytest tests/test_replay_my_area.py -v
-# conftest sees file missing → switches to record mode automatically
+REYN_LLM_RECORD=1 python -m pytest tests/test_replay_my_area.py -v
+# without REYN_LLM_RECORD=1 this now fails loud instead of auto-recording
 ```
 
 Commit the new fixture alongside the change. Reviewers can diff the


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary
Sweep requested alongside #3663 (which fixed the same "missing fixture auto-switches to record mode" claim in 4 places: `replay.py`/`conftest.py` docstrings, `replay.md`'s mode table, `network_gate.py`'s module docstring). Found a 5th live instance: `docs/guide/for-reyn-developers/write-replay-tests.md` still told readers deleting a fixture makes conftest "auto-detect the missing file and switch to record mode" — #3662 removed that fallback; a missing fixture now fails loud at fixture setup with the exact `REYN_LLM_RECORD=1` command to re-run.

Checked and confirmed unrelated: a `MissingFixture` example a few lines down is about drift within an EXISTING fixture file (a different key not found), not the whole-file-missing case #3662 changed — left untouched.

No JA mirror exists for this file. Historical `deep-dives/journal`/`decisions` mentions of "no fixture re-recording" are about a different topic (re-recording not required after a fix) and are historical narrative regardless.

## Test plan
- [x] `ruff check` — clean
- [x] `mkdocs build --strict` — exit 0, no new warnings (existing "excluded from built site" INFO only)