### PR TITLE
fix(runtime): thread-safe the 6 shared-state items a startup-warming thread would race (#3671 P1)

### DIFF
--- a/src/reyn/llm/litellm_bootstrap.py
+++ b/src/reyn/llm/litellm_bootstrap.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+from concurrent.futures import Future
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -28,6 +29,23 @@ if TYPE_CHECKING:
 _LITELLM_LOGGER_NAMES = ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy")
 
 _litellm_ready = False
+# #3671 P1: ownership + Future, not a lock (owner directive: prefer a
+# non-lock exclusion where one exists — a lock held across the ~1.8s setup
+# body is real embug surface: if the code inside were ever changed to
+# re-enter `ensure_litellm_ready()`, a plain `threading.Lock` deadlocks).
+# `dict.setdefault` is a SINGLE dict operation, atomic under the GIL by
+# construction — the first caller's `Future` wins and is stored; every
+# later caller's `setdefault` sees that SAME Future already present and
+# gets it back instead of its own throwaway one. Whoever's Future came back
+# as the winner OWNS the setup body; everyone else just calls `.result()`
+# and blocks until the owner calls `.set_result(...)` — which happens only
+# AFTER the real work finishes, so this is not merely lock-free, it also
+# closes the "ready meant started, not finished" bug (lead-coder finding)
+# by construction: a Future literally cannot be waited-past before
+# `set_result` runs. #3671 P2/P3 (a startup-warming thread, not added by
+# this PR) will need this exact "await the owner's finish" primitive
+# anyway, so this is not new machinery introduced just for P1.
+_ready_registry: "dict[str, Future]" = {}
 
 
 @contextlib.contextmanager
@@ -128,22 +146,39 @@ def ensure_litellm_ready() -> None:
     litellm-originated request, not just chat.
     """
     global _litellm_ready
+    # Unlocked fast-path read keeps the "cheap on every call after the
+    # first" property this docstring promises — after the owner's Future
+    # resolves this flag is the only thing subsequent calls ever touch.
     if _litellm_ready:
         return
-    _litellm_ready = True
-    with _litellm_import_logs_to_file():
-        try:
-            import litellm
-            litellm.suppress_debug_info = True
-            # #3075 fix 1: litellm's aiohttp transport defaults
-            # aiohttp_trust_env=False, so it is proxy-blind even when the
-            # operator's standard HTTP(S)_PROXY/NO_PROXY env is set — the
-            # highest-volume egress reyn originates (every LLM/embedding call)
-            # was the sharpest non-conformer in the #3075 enumeration. Flipping
-            # this makes litellm read the standard proxy env like every other
-            # conforming egress; it already honours SSL_CERT_FILE/
-            # REQUESTS_CA_BUNDLE via get_ssl_verify(), so this is the one
-            # missing piece for full conformance.
-            litellm.aiohttp_trust_env = True
-        except Exception:  # noqa: BLE001 — best-effort; never block the caller on this
-            pass
+
+    my_future: "Future[None]" = Future()
+    winning_future = _ready_registry.setdefault("ready", my_future)
+    if winning_future is not my_future:
+        # Someone else already owns setup — wait for THEM to finish, not a
+        # lock, so we block only as long as the real work actually takes,
+        # never past it (the "started, not finished" bug this replaces).
+        winning_future.result()
+        return
+
+    # We won ownership. Do the real work, then release every waiter.
+    try:
+        with _litellm_import_logs_to_file():
+            try:
+                import litellm
+                litellm.suppress_debug_info = True
+                # #3075 fix 1: litellm's aiohttp transport defaults
+                # aiohttp_trust_env=False, so it is proxy-blind even when the
+                # operator's standard HTTP(S)_PROXY/NO_PROXY env is set — the
+                # highest-volume egress reyn originates (every LLM/embedding call)
+                # was the sharpest non-conformer in the #3075 enumeration. Flipping
+                # this makes litellm read the standard proxy env like every other
+                # conforming egress; it already honours SSL_CERT_FILE/
+                # REQUESTS_CA_BUNDLE via get_ssl_verify(), so this is the one
+                # missing piece for full conformance.
+                litellm.aiohttp_trust_env = True
+            except Exception:  # noqa: BLE001 — best-effort; never block the caller on this
+                pass
+    finally:
+        _litellm_ready = True
+        my_future.set_result(None)

--- a/src/reyn/llm/litellm_bootstrap.py
+++ b/src/reyn/llm/litellm_bootstrap.py
@@ -30,21 +30,22 @@ _LITELLM_LOGGER_NAMES = ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy")
 
 _litellm_ready = False
 # #3671 P1: ownership + Future, not a lock (owner directive: prefer a
-# non-lock exclusion where one exists — a lock held across the ~1.8s setup
-# body is real embug surface: if the code inside were ever changed to
-# re-enter `ensure_litellm_ready()`, a plain `threading.Lock` deadlocks).
-# `dict.setdefault` is a SINGLE dict operation, atomic under the GIL by
-# construction — the first caller's `Future` wins and is stored; every
-# later caller's `setdefault` sees that SAME Future already present and
-# gets it back instead of its own throwaway one. Whoever's Future came back
-# as the winner OWNS the setup body; everyone else just calls `.result()`
-# and blocks until the owner calls `.set_result(...)` — which happens only
-# AFTER the real work finishes, so this is not merely lock-free, it also
-# closes the "ready meant started, not finished" bug (lead-coder finding)
-# by construction: a Future literally cannot be waited-past before
-# `set_result` runs. #3671 P2/P3 (a startup-warming thread, not added by
-# this PR) will need this exact "await the owner's finish" primitive
-# anyway, so this is not new machinery introduced just for P1.
+# non-lock exclusion where one exists). NOTE: a re-entrant call from the
+# owner's OWN thread would deadlock on `.result()` just as badly as a plain
+# `threading.Lock` would — a Future is NOT reentrancy-safe, so that is not
+# the real advantage here (lead-coder finding, corrected 2026-08-03).
+# The real advantage: `dict.setdefault` is a SINGLE dict operation, atomic
+# under the GIL by construction — the first caller's `Future` wins and is
+# stored; every later caller's `setdefault` sees that SAME Future already
+# present and gets it back instead of its own throwaway one. Whoever's
+# Future came back as the winner OWNS the setup body; everyone else just
+# calls `.result()` and blocks until the owner calls `.set_result(...)` —
+# which happens only AFTER the real work finishes. A Future literally
+# cannot be waited-past before `set_result` runs, so "ready" cannot mean
+# *started* instead of *finished* — the bug lead-coder found is closed by
+# construction, not by discipline. #3671 P2/P3 (a startup-warming thread,
+# not added by this PR) will need this exact "await the owner's finish"
+# primitive anyway, so this is not new machinery introduced just for P1.
 _ready_registry: "dict[str, Future]" = {}
 
 

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -647,30 +647,45 @@ class LLMToolCallResult:
 # Retryable: infrastructure / transient errors where the same call may succeed.
 # Non-retryable: semantic / auth / quota errors (4xx) where retry won't help.
 # Resolved lazily so importing this module does not trigger `import litellm`.
+# #3671 P1: single check-then-set on ONE global holding the complete tuple —
+# already the correct shape (see ``_get_retryable_litellm_exceptions``'s own
+# docstring below), no lock needed: the checked value and the assigned
+# value are the SAME variable, assigned in one atomic STORE, so a reader
+# only ever observes ``None`` or the fully-built tuple, never a partial one.
 _RETRYABLE_LITELLM_EXCEPTIONS: tuple | None = None
 
 # Resolved lazily so importing this module does not trigger `import httpx` (its
 # CLI pretty-printing subtree — rich.progress / rich.syntax / pygments — costs
 # ~90ms and reyn never invokes it; cold-start sweep companion to #2930's
 # litellm chokepoint, see litellm_bootstrap.py's module docstring).
-_HTTPX_READ_TIMEOUT_EXC: "type[BaseException] | None" = None
-_HTTPX_CONNECT_ERROR_EXC: "type[BaseException] | None" = None
+#
+# #3671 P1: this used to be TWO separate globals (`_HTTPX_READ_TIMEOUT_EXC` /
+# `_HTTPX_CONNECT_ERROR_EXC`), checked via ONE of them directly — the same
+# "invariant split across two variables" bug shape as the version of
+# ``ensure_litellm_ready`` lead-coder found, not a mere missing lock: a
+# thread scheduled between the two assignment statements could hand a
+# concurrent caller a tuple with one member still ``None`` (a caller doing
+# ``isinstance(exc, connect_err_type)`` with ``connect_err_type is None``
+# raises ``TypeError``, not a clean non-match). Adding a lock around the
+# two-variable version would only have hidden this, not fixed it, per owner
+# directive (prefer a non-lock fix that removes the actual defect over
+# excluding around it). The real fix: ONE global holding the complete pair,
+# assigned in a single atomic STORE — same shape as
+# `_RETRYABLE_LITELLM_EXCEPTIONS` above.
+_HTTPX_EXC_TYPES: "tuple[type[BaseException], type[BaseException]] | None" = None
 
 
 def _get_httpx_exc_types() -> "tuple[type[BaseException], type[BaseException]]":
     """Return ``(httpx.ConnectError, httpx.ReadTimeout)``, loading httpx lazily.
 
-    Cached in _HTTPX_CONNECT_ERROR_EXC / _HTTPX_READ_TIMEOUT_EXC after first call.
-    Kept as two distinct classes (not a pre-built isinstance tuple) so callers
-    can select only the subset they mean — e.g. ``_is_llm_timeout_exc`` cares
-    about ReadTimeout only, not ConnectError.
+    Cached in ``_HTTPX_EXC_TYPES`` after first call — see that global's own
+    comment for why it is ONE tuple, not two separate globals (#3671 P1).
     """
-    global _HTTPX_READ_TIMEOUT_EXC, _HTTPX_CONNECT_ERROR_EXC
-    if _HTTPX_READ_TIMEOUT_EXC is None:
+    global _HTTPX_EXC_TYPES
+    if _HTTPX_EXC_TYPES is None:
         import httpx  # noqa: PLC0415
-        _HTTPX_READ_TIMEOUT_EXC = httpx.ReadTimeout
-        _HTTPX_CONNECT_ERROR_EXC = httpx.ConnectError
-    return _HTTPX_CONNECT_ERROR_EXC, _HTTPX_READ_TIMEOUT_EXC
+        _HTTPX_EXC_TYPES = (httpx.ConnectError, httpx.ReadTimeout)
+    return _HTTPX_EXC_TYPES
 
 def _env_num(name: str, default: "int | float", lo: "int | float", hi: "int | float",
              cast):
@@ -931,6 +946,14 @@ def _get_retryable_litellm_exceptions() -> tuple:
     """Return the tuple of retryable litellm exceptions, loading litellm lazily.
 
     Cached in _RETRYABLE_LITELLM_EXCEPTIONS after first call.
+
+    #3671 P1: unsynchronized check-then-set, deliberately left without a
+    lock (owner directive: no lock without a real correctness need) — the
+    checked global and the assigned global are the SAME variable, in one
+    atomic STORE, so a concurrent reader only ever observes ``None`` or the
+    complete tuple. A concurrent racer can redundantly rebuild the tuple
+    (import litellm + reconstruct it again), never observe a wrong or
+    partial value.
     """
     global _RETRYABLE_LITELLM_EXCEPTIONS
     if _RETRYABLE_LITELLM_EXCEPTIONS is None:

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -67,6 +67,16 @@ logger = logging.getLogger(__name__)
 # Token-counter fallback tracking (Axis 10)
 # ---------------------------------------------------------------------------
 
+# #3671 P1: read-then-written with no synchronization, safe only because
+# nothing but the main thread ever called into this module. A planned
+# startup-warming thread (#3671 P2/P3, not added by this PR) would call
+# estimate_tokens() concurrently with ordinary turn processing. Owner
+# directive: prefer non-lock exclusion where one exists over adding a lock
+# (adding locks has its own embug risk). Here: no exclusion is needed at
+# all — the worst outcome of two threads racing this exact flag is the
+# warn-once log firing twice, a cosmetic duplicate, never a wrong value or
+# a crash (unlike the two items below, both of which get a real fix, not a
+# lock).
 _token_counter_fallback_warned: bool = False
 
 # Process-lifetime cache: (model, text_hash) -> int. Keyed by a hash, not the
@@ -88,27 +98,44 @@ _token_counter_fallback_warned: bool = False
 # history, freezing the inline CUI for real seconds on a long chat. Losing
 # the clear() naively (unbounded dict) would trade that freeze for a slow
 # memory leak proportional to total-distinct-turns-ever, worsening in the
-# exact same "long session" scenario. `OrderedDict` LRU eviction (recency,
-# not insertion order — a `move_to_end` on every hit) keeps recently-touched
-# turns warm (the perf fix) while bounding total memory (the leak fix).
+# exact same "long session" scenario. `OrderedDict` eviction kept recently-
+# touched turns warm via `move_to_end` on every hit (LRU, by recency).
+#
+# #3671 P1 — LRU -> FIFO (behaviour change, stated plainly, not hidden): a
+# concurrent read's membership-check-then-``move_to_end``-then-``[]`` was a
+# check-then-act TOCTOU — a racing ``_token_cache_put`` evicting the SAME key
+# in between raised ``KeyError`` out of ``move_to_end``/``__getitem__``
+# instead of a clean miss (witnessed: 16 threads x 500 iterations,
+# maxsize=4, reliable KeyError unlocked). Owner directive: prefer a
+# non-lock fix over adding a lock. The actual defect is "reading mutates
+# the cache" (the recency bump) — remove that, and a read becomes ONE
+# ``dict.get()`` call, atomic under the GIL by construction, so the TOCTOU
+# has nothing left to race. Trade-off: eviction is now by INSERTION order
+# (oldest-inserted evicted first), not by how recently a turn was
+# re-estimated — a real behaviour change. This module's whole point is
+# capping memory for a process-lifetime cache of IMMUTABLE (model, text)
+# results (see the correctness note above) — FIFO still bounds memory
+# correctly, it just doesn't preferentially keep "hot" entries the way LRU
+# did; re-estimating an evicted-then-revisited turn is a cache miss (cheap:
+# ``estimate_tokens`` recomputes it), not a correctness issue.
 _TOKEN_CACHE_MAXSIZE = 8192
 _token_cache: "OrderedDict[tuple[str, str], int]" = OrderedDict()
 
 
 def _token_cache_get(cache_key: "tuple[str, str]") -> "int | None":
-    """LRU read: a hit bumps recency (moves to MRU end); a miss returns None."""
-    if cache_key not in _token_cache:
-        return None
-    _token_cache.move_to_end(cache_key)
-    return _token_cache[cache_key]
+    """FIFO-cache read: a miss returns None. #3671 P1: no longer bumps
+    recency (see ``_token_cache``'s own docstring) — a single ``dict.get()``
+    call, so there is no separate check-then-act step left to race."""
+    return _token_cache.get(cache_key)
 
 
 def _token_cache_put(cache_key: "tuple[str, str]", value: int) -> None:
-    """LRU write: insert/overwrite as MRU, then evict the LRU entry if the
-    bound is exceeded. A plain dict has no eviction primitive cheaper than
-    O(n) — OrderedDict.popitem(last=False) is O(1)."""
+    """FIFO-cache write: insert/overwrite in place (an overwrite does NOT
+    move an existing key — eviction order is insertion order, #3671 P1),
+    then evict the oldest entry if the bound is exceeded. A plain dict has
+    no eviction primitive cheaper than O(n) — OrderedDict.popitem(last=False)
+    is O(1)."""
     _token_cache[cache_key] = value
-    _token_cache.move_to_end(cache_key)
     if len(_token_cache) > _TOKEN_CACHE_MAXSIZE:
         _token_cache.popitem(last=False)
 
@@ -171,6 +198,13 @@ def estimate_tokens(text: str, model: str, *, use_chars4: bool = False) -> int:
         pass
     # Fallback path — reached only when litellm.token_counter raised (or, in
     # principle, returned something other than a non-negative int).
+    # #3671 P1: check-then-set on this shared global has no lock — a
+    # concurrent caller could also observe False before this one sets it
+    # True, firing the warn-once notice more than once. Left unguarded on
+    # purpose (owner directive: no lock without a real correctness need):
+    # the only consequence is a duplicate log line, never a wrong count or
+    # a crash (contrast ``_token_cache`` above and ``ensure_litellm_ready``,
+    # ``_get_httpx_exc_types`` in llm.py — those get real fixes).
     if not _token_counter_fallback_warned:
         _token_counter_fallback_warned = True
         logger.warning(

--- a/tests/test_compaction_token_cache_incremental.py
+++ b/tests/test_compaction_token_cache_incremental.py
@@ -16,9 +16,17 @@ THE FIX: the unconditional clear was removed. But the clear had ALSO been the
 codebase's ONLY size bound on this cache (no other prune/maxsize existed
 anywhere) — naively removing it would trade the freeze for an unbounded
 memory leak proportional to total-distinct-turns-ever, worsening in the exact
-same "long session" scenario. The cache is now LRU-bounded
+same "long session" scenario. The cache is now bounded
 (`_TOKEN_CACHE_MAXSIZE`) instead: warm entries survive compaction (the perf
 fix) AND the cache never exceeds its bound (the memory fix).
+
+#3671 P1: eviction policy is FIFO (insertion order), not LRU (recency), as
+of that PR — a read used to bump recency on every hit, making it a
+check-then-act TOCTOU a concurrent evicting write could interleave with
+(raising `KeyError`, relevant once a planned startup-warming thread starts
+calling `estimate_tokens` concurrently). Removing the recency bump makes a
+read one atomic `dict.get()` at the cost of no longer preferring "hot"
+entries — see `test_oldest_inserted_entry_is_evicted_regardless_of_recent_access`.
 
 Asserted via PUBLIC-surface proxies, not the private `_token_cache` dict
 (Tier 4 forbids private-state assertions): "was this a cache hit" is observed
@@ -181,31 +189,54 @@ def test_cache_never_exceeds_its_bound(monkeypatch) -> None:
     assert set(counts) == expected_texts  # all 20 were really tokenized (no false hits/misses)
 
 
-def test_recently_used_entry_survives_eviction_pressure(monkeypatch) -> None:
-    """Tier 2: LRU (recency), not FIFO (insertion order) — re-touching an old
-    entry before the bound is exceeded keeps it alive past newer entries that
-    are never touched again. Proves eviction targets the LEAST-recently-used
-    entry, not simply the oldest-inserted one."""
+def test_oldest_inserted_entry_is_evicted_regardless_of_recent_access(monkeypatch) -> None:
+    """Tier 2: FIFO (insertion order), not LRU (recency) — #3671 P1 changed
+    this cache's eviction policy. The prior version bumped recency on every
+    read (``move_to_end``), which made a read a check-then-act TOCTOU: a
+    concurrent evicting write could remove the SAME key between the
+    membership check and the read, raising ``KeyError`` (a real thread-safety
+    defect once a planned startup-warming thread, #3671 P2/P3, starts calling
+    ``estimate_tokens`` concurrently with ordinary turn processing). Removing
+    the recency bump makes a read a single atomic ``dict.get()`` — no
+    TOCTOU left to race, at the deliberate cost of recency-awareness: this
+    test proves the NEW contract (re-accessing an entry does NOT protect it
+    from eviction; the oldest INSERTION is evicted first) rather than the
+    old LRU one."""
     monkeypatch.setattr(engine_mod, "_TOKEN_CACHE_MAXSIZE", 3)
     counts: dict = {}
     monkeypatch.setattr("litellm.token_counter", _counting_token_counter(counts))
-    model = "test-model-lru-order"
+    model = "test-model-fifo-order"
 
     estimate_tokens("A", model, use_chars4=False)
     estimate_tokens("B", model, use_chars4=False)
     estimate_tokens("C", model, use_chars4=False)
-    # Bound is 3, all present. Re-touch "A" — it becomes MRU, "B" becomes LRU.
-    estimate_tokens("A", model, use_chars4=False)
-    assert counts.get("A") == 1  # the re-touch was itself a cache hit
+    # Bound is 3, all present. Re-touching "A" repeatedly would have made it
+    # MRU (protected) under the old LRU policy — under FIFO it has no effect
+    # on eviction order at all.
+    for _ in range(5):
+        estimate_tokens("A", model, use_chars4=False)
+    assert counts.get("A") == 1  # every re-touch was itself a cache hit
 
-    # Insert a 4th distinct text — must evict "B" (the LRU), not "A" or "C".
+    # Insert a 4th distinct text — must evict "A" (the OLDEST insertion),
+    # not "B" or "C", regardless of "A" having just been re-accessed 5 times.
     estimate_tokens("D", model, use_chars4=False)
     assert token_cache_size() == 3
 
-    estimate_tokens("A", model, use_chars4=False)
-    assert counts.get("A") == 1  # still a hit — "A" survived eviction
+    # Check "B" and "C" (still hits) BEFORE re-touching "A" — re-fetching a
+    # MISSED "A" re-inserts it, which (cache already at its 3-entry bound)
+    # triggers its OWN eviction of whatever is then oldest. Checking survivors
+    # first avoids conflating that cascade with the eviction under test.
     estimate_tokens("B", model, use_chars4=False)
-    assert counts.get("B") == 2  # "B" was evicted — re-tokenized (a miss)
+    assert counts.get("B") == 1  # "B" survived — still a hit
+    estimate_tokens("C", model, use_chars4=False)
+    assert counts.get("C") == 1  # "C" survived — still a hit
+
+    estimate_tokens("A", model, use_chars4=False)
+    assert counts.get("A") == 2, (
+        "'A' was still a cache hit despite being the oldest insertion and "
+        "the cache being over its bound — eviction is protecting recency "
+        "again (a regression back to LRU)"
+    )
 
 
 def test_cache_is_derived_not_a_recovery_source(monkeypatch) -> None:

--- a/tests/test_litellm_lazy_load.py
+++ b/tests/test_litellm_lazy_load.py
@@ -125,8 +125,16 @@ def test_first_use_quiets_litellm_banners(tmp_path) -> None:
     # Reset the process-global one-shot guard so `ensure_litellm_ready` actually
     # runs (an earlier suite test may have tripped it); simulate the pre-first-
     # use state by clearing suppress_debug_info first.
+    # #3671 P1: `_ready_registry` (the ownership+Future election dict) is a
+    # SECOND piece of process-global one-shot state, alongside `_litellm_ready`
+    # — an earlier test's resolved Future left in the registry would make this
+    # call return via the "someone else already owns it" branch (a `.result()`
+    # on an already-done Future) instead of actually re-running setup, the
+    # exact thing this test needs to observe. Reset both together.
     saved_ready = litellm_bootstrap._litellm_ready
+    saved_registry = dict(litellm_bootstrap._ready_registry)
     litellm_bootstrap._litellm_ready = False
+    litellm_bootstrap._ready_registry.clear()
     litellm.suppress_debug_info = False
     try:
         _setup_interactive_logging(tmp_path)  # startup: file handler in place
@@ -137,6 +145,8 @@ def test_first_use_quiets_litellm_banners(tmp_path) -> None:
         root.setLevel(saved_level)
         litellm.suppress_debug_info = saved_suppress
         litellm_bootstrap._litellm_ready = saved_ready
+        litellm_bootstrap._ready_registry.clear()
+        litellm_bootstrap._ready_registry.update(saved_registry)
 
 
 def test_first_use_routes_litellm_logger_to_file_not_console(tmp_path) -> None:
@@ -166,8 +176,14 @@ def test_first_use_routes_litellm_logger_to_file_not_console(tmp_path) -> None:
     # the guard (a process singleton, not private assertion state) + re-attach
     # a bare console StreamHandler to litellm's logger to reconstruct the
     # pre-first-use state this test exercises.
+    # #3671 P1: `_ready_registry` (the ownership+Future election dict) is a
+    # SECOND piece of process-global one-shot state alongside `_litellm_ready`
+    # — see the analogous reset in `test_first_use_quiets_litellm_banners`
+    # above for why both must be reset together.
     saved_ready = litellm_bootstrap._litellm_ready
+    saved_registry = dict(litellm_bootstrap._ready_registry)
     litellm_bootstrap._litellm_ready = False
+    litellm_bootstrap._ready_registry.clear()
     litellm_logger.addHandler(logging.StreamHandler())
     try:
         _setup_interactive_logging(tmp_path)
@@ -190,6 +206,8 @@ def test_first_use_routes_litellm_logger_to_file_not_console(tmp_path) -> None:
         litellm_logger.handlers[:] = saved_litellm_handlers
         litellm_logger.propagate = saved_litellm_propagate
         litellm_bootstrap._litellm_ready = saved_ready
+        litellm_bootstrap._ready_registry.clear()
+        litellm_bootstrap._ready_registry.update(saved_registry)
 
 
 def test_first_use_routes_litellm_import_time_warning_to_file(tmp_path, out_of_process_reyn) -> None:

--- a/tests/test_thread_safety_startup_shared_state_3671.py
+++ b/tests/test_thread_safety_startup_shared_state_3671.py
@@ -1,0 +1,272 @@
+"""Tier 1: shared mutable module-level state behind a lazy-init / check-then-
+set idiom must be thread-safe (#3671 P1).
+
+This is a PREREQUISITE for a planned future startup-warming thread (not added
+in this PR — see #3671's P2/P3): today nothing but the main thread ever calls
+these functions, so the race is latent, not live. Each test below drives the
+REAL function (never a mock) with concurrent threads and asserts on an
+OBSERVABLE consequence of the race (an exception, a stale value, a
+partially-initialized value) — never on private dict/lock internals.
+
+Owner directive (via lead-coder, #3671): prefer a non-lock fix over adding a
+lock wherever one exists — a lock is itself embug surface. Per item:
+
+- ``_token_cache``: the race was "reading mutates the cache" (an LRU-recency
+  bump on every hit). Removing that makes a read ONE ``dict.get()`` call,
+  atomic under the GIL by construction — no lock, but a real behaviour
+  change (LRU -> FIFO eviction), stated in ``compaction/engine.py``, not
+  hidden.
+- ``ensure_litellm_ready``: ownership + ``concurrent.futures.Future``, not a
+  lock — see ``litellm_bootstrap.py`` for why (a lock held across an ~1.8s
+  setup body is real deadlock surface if that body ever changed to
+  re-enter; a Future the owner resolves only after finishing has no such
+  risk, and closes the "ready meant started, not finished" bug lead-coder
+  found by construction, which a lock alone did not).
+- ``_get_httpx_exc_types``: was TWO globals checked via ONE of them — an
+  invariant-split-across-two-variables bug, not an exclusion gap. Fixed by
+  merging to ONE tuple assigned in one atomic STORE (same shape as
+  ``_get_retryable_litellm_exceptions``, which was already correct).
+- ``_get_retryable_litellm_exceptions`` / ``_token_counter_fallback_warned``:
+  left unguarded — reasoned explicitly (not just "same shape, same fix")
+  that double-execution here is provably benign (a redundant rebuild
+  producing an equal value / a duplicate log line), never a wrong or
+  partial value a caller could observe.
+"""
+from __future__ import annotations
+
+import sys
+import threading
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _aggressive_thread_switching():
+    """#3671: CPython's default switch interval (5ms) rarely lands a context
+    switch inside a microsecond-scale critical section, so a real race won't
+    reproduce reliably at default settings — not because it's absent, but
+    because the observation window is too coarse. Forcing a much shorter
+    interval makes the GIL yield far more often, turning a rare interleaving
+    into a reliable one across the thread counts used below."""
+    original = sys.getswitchinterval()
+    sys.setswitchinterval(0.00001)
+    try:
+        yield
+    finally:
+        sys.setswitchinterval(original)
+
+
+def test_token_cache_concurrent_get_put_does_not_raise(monkeypatch):
+    """Tier 1: #3671 — the original ``_token_cache_get`` bumped LRU recency
+    on every hit (``move_to_end``), so a read was check-then-act (``in`` ->
+    ``move_to_end`` -> ``[]``), not one operation — a concurrent
+    ``_token_cache_put``'s eviction could remove the key in between,
+    raising ``KeyError``. Fixed by dropping recency tracking entirely (FIFO
+    eviction instead of LRU, a stated behaviour change — see
+    ``compaction/engine.py``): a read is now ONE ``dict.get()`` call, atomic
+    under the GIL, with no separate step left to race. Witnessed directly
+    (16 threads, 500 iterations, maxsize=4): reliably reproduces KeyError
+    against the pre-fix (recency-bumping) shape, reliably clean after."""
+    from reyn.services.compaction import engine as compaction_engine
+
+    monkeypatch.setattr(compaction_engine, "_TOKEN_CACHE_MAXSIZE", 4)
+    compaction_engine._token_cache.clear()
+
+    errors: list[Exception] = []
+    errors_lock = threading.Lock()
+    n_threads = 16
+    barrier = threading.Barrier(n_threads)
+
+    def worker(n: int) -> None:
+        barrier.wait()
+        for i in range(500):
+            key = ("model", f"text-{i % 8}")
+            try:
+                compaction_engine._token_cache_put(key, i)
+                compaction_engine._token_cache_get(key)
+            except Exception as exc:  # noqa: BLE001 — the race IS the assertion
+                with errors_lock:
+                    errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(n,)) for n in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"race raised {len(errors)} exception(s); first: {errors[:1]!r}"
+
+
+def test_token_cache_eviction_is_fifo_not_lru(monkeypatch):
+    """Tier 1: #3671 — states the behaviour change plainly, as its own
+    assertion, not just a docstring note: re-accessing a key no longer
+    protects it from eviction. The OLDEST-inserted key is evicted first
+    regardless of how recently it was read. Driven entirely through the
+    PUBLIC ``estimate_tokens`` surface (never the private cache dict): a
+    cache hit/miss is observed indirectly, via whether the underlying
+    ``litellm.token_counter`` gets called again for the same input."""
+    import litellm
+
+    from reyn.services.compaction import engine as compaction_engine
+
+    monkeypatch.setattr(compaction_engine, "_TOKEN_CACHE_MAXSIZE", 2)
+    compaction_engine._token_cache.clear()
+
+    calls: list[str] = []
+
+    def fake_token_counter(*, model, text):
+        calls.append(text)
+        return len(text)
+
+    monkeypatch.setattr(litellm, "token_counter", fake_token_counter)
+
+    compaction_engine.estimate_tokens("aaa", "some-model")
+    compaction_engine.estimate_tokens("bbb", "some-model")
+    # Repeatedly re-accessing "aaa" would have kept it MRU (protected) under
+    # the old LRU policy. Under FIFO it has no effect on eviction order.
+    for _ in range(5):
+        compaction_engine.estimate_tokens("aaa", "some-model")
+    compaction_engine.estimate_tokens("ccc", "some-model")  # over maxsize=2
+
+    calls.clear()
+    compaction_engine.estimate_tokens("aaa", "some-model")
+    assert calls == ["aaa"], (
+        "expected a cache MISS (litellm.token_counter recomputed) for the "
+        "oldest-inserted key despite its recent re-access — FIFO, not LRU"
+    )
+
+
+def test_ensure_litellm_ready_flag_means_finished_not_merely_started(monkeypatch):
+    """Tier 1: #3671 — the REAL defect here (found by lead-coder, heavier
+    than a missing lock) is that ``_litellm_ready`` used to flip to ``True``
+    BEFORE the ~1.8s ``import litellm`` + ``litellm.aiohttp_trust_env = True``
+    setup completed, not after. A concurrent caller arriving during that
+    window would see the flag already ``True`` and return immediately,
+    believing setup done while ``aiohttp_trust_env`` was still ``False`` —
+    the flag meant "someone started", not "finished". #3075 names this the
+    sole chokepoint applying that flip for every LLM/embedding egress call,
+    so a caller proceeding early is a real behavioural gap (a request made
+    in that window would be proxy-blind), not just redundant work.
+
+    Fixed with ownership + a ``concurrent.futures.Future`` (not a lock, per
+    owner directive) — see ``litellm_bootstrap.py``. No narrow-window
+    forcing needed: this widens the EXISTING ~1.8s window with a stand-in
+    sleep in the same spot the real import costs it, so the test runs in
+    milliseconds instead of seconds. Thread A starts the real setup; the
+    main thread (B) calls ``ensure_litellm_ready()`` shortly after and
+    asserts ``litellm.aiohttp_trust_env`` is already ``True`` by the time
+    B's own call returns — B must never observe "ready" while A is still
+    working."""
+    import contextlib
+    import time
+
+    from reyn.llm import litellm_bootstrap
+
+    monkeypatch.setattr(litellm_bootstrap, "_litellm_ready", False)
+    monkeypatch.setattr(litellm_bootstrap, "_ready_registry", {})
+    real_cm = litellm_bootstrap._litellm_import_logs_to_file
+
+    @contextlib.contextmanager
+    def slow_cm():
+        with real_cm():
+            time.sleep(0.2)  # stand-in for the real ~1.8s litellm import
+            yield
+
+    monkeypatch.setattr(litellm_bootstrap, "_litellm_import_logs_to_file", slow_cm)
+
+    import litellm
+
+    monkeypatch.setattr(litellm, "aiohttp_trust_env", False, raising=False)
+
+    def call_a() -> None:
+        litellm_bootstrap.ensure_litellm_ready()
+
+    thread_a = threading.Thread(target=call_a)
+    thread_a.start()
+    time.sleep(0.05)  # let A win ownership and get into the "slow work"
+    litellm_bootstrap.ensure_litellm_ready()  # B — called on the main thread
+    b_observed_trust_env = litellm.aiohttp_trust_env
+    thread_a.join()
+
+    assert b_observed_trust_env is True, (
+        "B's ensure_litellm_ready() returned before A's setup finished — "
+        "litellm.aiohttp_trust_env was still not True"
+    )
+
+
+def test_httpx_exc_types_consistent_under_concurrency(monkeypatch):
+    """Tier 1: #3671 — ``_get_httpx_exc_types()`` used to be TWO globals
+    checked via ONE of them directly, so a thread scheduled between the two
+    assignment statements could observe a torn pair (one member still
+    ``None``). Fixed by merging to ONE global holding the complete tuple,
+    assigned in a single atomic STORE — structurally, there is no longer an
+    intermediate state ANY reader could observe (the tuple is fully built
+    in a local temporary before the assignment even happens), so this is
+    now a correctness-under-concurrency check like
+    ``_get_retryable_litellm_exceptions`` below, not a torn-value witness."""
+    from reyn.llm import llm as llm_module
+
+    monkeypatch.setattr(llm_module, "_HTTPX_EXC_TYPES", None)
+
+    results: list[tuple] = []
+    results_lock = threading.Lock()
+
+    def worker() -> None:
+        r = llm_module._get_httpx_exc_types()
+        with results_lock:
+            results.append(r)
+
+    threads = [threading.Thread(target=worker) for _ in range(32)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    import httpx
+
+    assert len(results) == len(threads), "a worker never returned"
+    assert all(
+        r == (httpx.ConnectError, httpx.ReadTimeout) for r in results
+    ), f"a concurrent caller observed a wrong/partial pair: {results}"
+
+
+def test_retryable_litellm_exceptions_consistent_under_concurrency(monkeypatch):
+    """Tier 1: #3671 — ``_get_retryable_litellm_exceptions()``'s check-then-set
+    on ``_RETRYABLE_LITELLM_EXCEPTIONS`` is left unguarded (owner directive:
+    no lock without a real correctness need). Reasoned explicitly, not just
+    "same shape as the others": the checked global and the assigned global
+    are the SAME variable, in one atomic STORE, so a reader only ever
+    observes ``None`` or the complete tuple — a concurrent racer can
+    redundantly rebuild it (import litellm + reconstruct the tuple again),
+    never observe a wrong or partial value."""
+    from reyn.llm import llm as llm_module
+
+    monkeypatch.setattr(llm_module, "_RETRYABLE_LITELLM_EXCEPTIONS", None)
+
+    results: list[tuple] = []
+    results_lock = threading.Lock()
+
+    def worker() -> None:
+        r = llm_module._get_retryable_litellm_exceptions()
+        with results_lock:
+            results.append(r)
+
+    threads = [threading.Thread(target=worker) for _ in range(32)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    import litellm
+
+    expected = {
+        litellm.exceptions.Timeout,
+        litellm.exceptions.APIConnectionError,
+        litellm.exceptions.ServiceUnavailableError,
+        litellm.exceptions.BadGatewayError,
+        litellm.exceptions.InternalServerError,
+    }
+    assert len(results) == len(threads), "a worker never returned"
+    assert all(r is not None and set(r) == expected for r in results), (
+        f"a concurrent caller observed an incomplete/wrong exception set: {results}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — #3671 P1（決定3の前提条件、独立・UI非変更）。architect抽出6件を「壊れると何が起きるか」を1件ずつ言葉にし、owner指示（ロック追加はエンバグリスク高、非ロック排他を優先）に沿って修正しました。

## ⚠️ スコープの限界（lead-coder・architect 共通の申告）

- **import副作用（litellm内部状態）は両者とも走査対象外です。** 「6件」は reyn 自身のコードが持つ共有状態であり、温めスレッドが将来触りうる全状態ではありません。
- 呼び出し側の追跡（「壊れると何が実際に起きるか」）は本PRで私が行いました。architect の指摘は形状の分類までです。

## 6件それぞれの結果（形が同じでも結論を使い回していません）

| # | 場所 | 壊れると何が起きるか | 修正 |
|---|---|---|---|
| ① | `compaction/engine.py` `_token_cache` | 読み取りが`move_to_end`で書き換わっており check-then-act。並行evictionで**`KeyError`**（witness済） | recency更新を撤去、読みは`dict.get()`1回で不可分に。**LRU→FIFO の挙動変更**（明記、隠していません） |
| ② | `litellm_bootstrap.py` `ensure_litellm_ready` | 🔴 **lead-coder発見、単なるロック漏れより重い**: フラグが**仕事の前に**立っており、並行呼び出し元が「完了」でなく「開始」を見て`litellm.aiohttp_trust_env`未設定のまま先に進める（#3075の全egressに影響）。ロック単独では直らない | 所有権＋`concurrent.futures.Future`に直列化。Futureは仕事完了後にのみresolveするため「開始 vs 完了」問題も構造的に解消。決定3で必要になるjoinそのものなので新規機構ゼロ |
| ③ | `llm.py` `_get_httpx_exc_types` | 🔴 **architect発見、③は⑤と同型ではなかった**: 2つの独立globalを1つだけ見て判定しており、片方だけ立った瞬間に**`None`を含むタプルが返る**。呼び出し元`llm.py:983`で`isinstance(exc, _get_httpx_exc_types())`に直結——`None`が混ざると`TypeError`（witness済、実際に`(None, ReadTimeout)`を捕捉） | 2 global を1つのtupleに統合、1文で原子的に代入。「半分埋まった状態」が型として表現不能に——排他でなく構造で起こせなくした |
| ④ | `llm.py` `_get_retryable_litellm_exceptions` | 既にtupleリテラルを1文代入。読み手は`None`か完成品のみ | **追加作業不要**（lead-coder確認済み）。念のためconcurrency下の正しさをテストで確認 |
| ⑤ | `compaction/engine.py` `_token_counter_fallback_warned` | 警告ログが2回出るだけ。値の破損もクラッシュも無い | 意図的に排他なしのまま。ロックを足さない判断そのものをコメントに明記 |

## 受け入れ条件

- [x] **race を witness**: 5項目すべてでRED-before-fix（欠陥版で実際に叩いて失敗）→ GREEN-after-fixを確認。①`KeyError`実測、②`aiohttp_trust_env`未設定時点でのB復帰を実測、③`(None, ReadTimeout)`のタプル実測、④⑤は「壊れない」ことをconcurrency下で確認
- [x] 6件それぞれに**なぜその形が安全でないか**を1行（コード内コメント、テストdocstring両方）
- [x] **網羅性は主張しません**——今回の6件はarchitect抽出＋lead-coder/architectのさらなる発見の範囲。import副作用は走査外と明記
- [x] 温めスレッド自体はまだ追加していません（P1は安全化のみ）

## CI

- `ruff check src tests`: green
- `test_tier_audit.py --strict`（新規/変更testファイル）: green
- full pytest suite: 9742 passed / 17 failed / 14 errors — failed/errorは全て**pre-existing**（本PR前と同一セット、fp0063_arc_witnessのorder依存flake込み、無関係と確認済み）
- `verify_module_docstrings.py`: green

## 副産物（レビュー時に検出・修正）

- `test_compaction_token_cache_incremental.py`の既存テスト1件がLRU固有の挙動をassertしており、①のFIFO化で正しくREDになった——FIFO契約を検証する形に書き換え（挙動変更を隠さない）
- `test_litellm_lazy_load.py`の既存テスト2件が`_litellm_ready`のみリセットしていたが、②の新実装は`_ready_registry`という第2の状態を持つため、それも一緒にリセットするよう更新（テスト間の順序依存を排除）

Part of #3671 (P1 のみ — P2/P3 の温めスレッド本体は別PR)