### PR TITLE
feat(runtime): launch chat client before attach() completes (#3671 P2)

### DIFF
--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import contextlib
 import logging
 import sys
 from pathlib import Path
@@ -64,6 +63,46 @@ async def _run_once(agent_registry, agent_name, *, instream=None, send=None) -> 
         inbox_kind=TurnOrigin.CLIENT_INPUT,
     )
     return result if isinstance(result, dict) else {"reply": result or ""}
+
+
+async def _background_attach(registry, name: str, *, skip_restore: bool) -> None:
+    """#3671 P2: run restore_all()+attach() OFF the render path so the client
+    can come up before a project with many in-flight agents finishes
+    replaying WAL state (``restore_all()`` synchronously builds a full
+    ``Session`` for every in-flight agent — see its own docstring, step 5).
+    Any failure here is caught and logged, never raised: the whole point of
+    moving this off the critical path is that the client survives a
+    restore/attach failure instead of never having started. Module-level
+    (not a nested closure) so it is independently testable — see
+    ``tests/test_startup_client_before_attach_3671_p2.py``.
+
+    #3671 P2 review (lead-coder): today a failure here is genuinely
+    invisible to the operator — ``_setup_interactive_logging`` (below)
+    routes this logger to a file, not the screen, so the client is left
+    silently waiting forever with ``has_session() == False``. That is a
+    real UX gap, but distinguishing "still connecting" from "failed"
+    on-screen is a ``has_session()``-*consuming* UI concern, i.e. P3's
+    scope (P2 is the ordering change only, no UI touched). Recorded as a
+    P3 requirement, not fixed here.
+    """
+    from reyn.core.events.agent_snapshot import SchemaVersionError
+
+    try:
+        if not skip_restore:
+            try:
+                await registry.restore_all()
+            except SchemaVersionError as e:
+                logger.error(
+                    f"background restore failed (schema mismatch): {e} — "
+                    "client stays up with no attached agent; rerun after resolving it"
+                )
+                return
+        await registry.attach(name)
+    except Exception:
+        logger.exception(
+            "#3671 P2: background restore/attach failed — "
+            "client stays up with no attached agent"
+        )
 
 
 def register(sub) -> None:
@@ -661,29 +700,6 @@ def run(args: argparse.Namespace) -> None:
         await registry.attach(name)
         return True
 
-    async def _background_attach() -> None:
-        """#3671 P2: run restore_all()+attach() OFF the render path so the
-        client can come up (and the user can see the shell) while a
-        project with many in-flight agents is still replaying WAL state —
-        previously this ran synchronously before `run_repl` even started,
-        putting every in-flight agent's full Session construction on the
-        startup critical path. `run_repl` already tolerates
-        `has_session() == False` for as long as this takes (#3671 P2). Any
-        failure here is caught and logged, not raised — the whole point of
-        moving this off the critical path is that the client must survive a
-        restore/attach failure instead of never having started."""
-        try:
-            if not await _restore_and_attach():
-                logger.error(
-                    "background restore failed (schema mismatch) — "
-                    "client stays up with no attached agent; rerun after resolving it"
-                )
-        except Exception:
-            logger.exception(
-                "#3671 P2: background restore/attach failed — "
-                "client stays up with no attached agent"
-            )
-
     async def _main_chat() -> None:
         if getattr(args, "once", False):
             # #187: one-shot mode (`reyn run-once`) keeps the old synchronous
@@ -725,15 +741,26 @@ def run(args: argparse.Namespace) -> None:
         # #3671 P2: restore_all()+attach() run in the BACKGROUND — run_repl
         # is started immediately, before either has necessarily finished
         # (has_session() reads False on the transport until `attach`
-        # completes). Awaited in `finally` below (not cancelled): cancelling
-        # mid-`restore_all` could interrupt a WAL replay / snapshot write
-        # partway through, so the exit path waits for whatever amount of the
-        # background work is still in flight rather than risking that.
-        attach_task = asyncio.create_task(_background_attach())
+        # completes).
+        attach_task = asyncio.create_task(_background_attach(registry, name, skip_restore=skip_restore))
         try:
             await run_repl(registry, renderer=renderer, config=session_cfg.config, name=name)
         finally:
-            with contextlib.suppress(asyncio.CancelledError):
-                await attach_task
+            # #3671 P2 review fix (lead-coder): `asyncio.shield` so a
+            # cancellation delivered to US while waiting here (Ctrl-C, most
+            # likely exactly while startup feels slow — the scenario this
+            # PR targets) does NOT also cancel `attach_task` — a
+            # half-done WAL replay / snapshot write must not be cut off
+            # partway through just because the operator wants the CLIENT to
+            # exit. If OUR OWN wait is cancelled (e.g. a second Ctrl-C
+            # during an already-cancelling shutdown), that CancelledError
+            # is deliberately NOT swallowed here — asyncio convention is to
+            # never eat a real cancellation, and a repeated cancel is the
+            # operator asking to exit NOW, not "wait a little longer" (a
+            # `contextlib.suppress(CancelledError)` here previously made
+            # this look like "waited to completion" when it had actually
+            # bailed out early without waiting at all — see #3675 review).
+            # `attach_task` is left running detached in that case.
+            await asyncio.shield(attach_task)
 
     run_async(_main_chat())

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -7,6 +7,8 @@ instances; switching agents mid-REPL via `/attach <name>` happens through it.
 from __future__ import annotations
 
 import argparse
+import asyncio
+import contextlib
 import logging
 import sys
 from pathlib import Path
@@ -19,6 +21,8 @@ from reyn.runtime.turn_origin import TurnOrigin
 
 from ..common_args import add_common_args
 from ..invocation_context import InvocationContext
+
+logger = logging.getLogger(__name__)
 
 # #187: send_to_agent_impl timeout for the one-shot (`reyn run-once`) drive. The
 # autonomous SWE agent may iterate for many minutes; the external bound is the
@@ -646,30 +650,65 @@ def run(args: argparse.Namespace) -> None:
         )
     )
 
-    async def _main_chat() -> None:
-        # PR21: replay WAL into per-agent snapshots before any new state
-        # changes happen. Agents with restored state get their inbox /
-        # pending_chains repopulated and their main loop started here.
-        # PR-resume-ux β U3: --no-restore skips this for debugging.
-        # PR-resume-ux β U4: clean exit on schema version mismatch.
+    async def _restore_and_attach() -> bool:
+        """Returns True on success, False if the operator should retry (schema
+        mismatch — the caller does `sys.exit(1)`, only valid for the one-shot
+        path; the interactive path below treats a False here as "stay up with
+        no session", see `_background_attach`)."""
         if not skip_restore:
             if not await _safe_restore():
-                sys.exit(1)
+                return False
         await registry.attach(name)
-        # #187: one-shot mode (`reyn run-once`). The scoped session built above
-        # (grant / exclude_tools / env_backend / high router_max_iterations) is
-        # now ATTACHED in the registry. Instead of the line-by-line REPL, read
-        # the WHOLE stdin as a single user message and drive the agent to
-        # completion via send_to_agent_impl — the same programmatic drive MCP /
-        # A2A use (registry.get_or_load returns this attached scoped session, no
-        # fresh unscoped build), then print the final reply and exit.
+        return True
+
+    async def _background_attach() -> None:
+        """#3671 P2: run restore_all()+attach() OFF the render path so the
+        client can come up (and the user can see the shell) while a
+        project with many in-flight agents is still replaying WAL state —
+        previously this ran synchronously before `run_repl` even started,
+        putting every in-flight agent's full Session construction on the
+        startup critical path. `run_repl` already tolerates
+        `has_session() == False` for as long as this takes (#3671 P2). Any
+        failure here is caught and logged, not raised — the whole point of
+        moving this off the critical path is that the client must survive a
+        restore/attach failure instead of never having started."""
+        try:
+            if not await _restore_and_attach():
+                logger.error(
+                    "background restore failed (schema mismatch) — "
+                    "client stays up with no attached agent; rerun after resolving it"
+                )
+        except Exception:
+            logger.exception(
+                "#3671 P2: background restore/attach failed — "
+                "client stays up with no attached agent"
+            )
+
+    async def _main_chat() -> None:
         if getattr(args, "once", False):
-            # #2783: this branch used to return (or sys.exit) with NO teardown of
-            # any kind — unlike run_repl (below), which always routes through
-            # registry.shutdown() on /quit/EOF. That left MCP connections,
-            # FsWatcher, StateLog and EventStore all unclosed on every
-            # `reyn run-once` invocation. try/finally so a limit-abort's
-            # sys.exit(2) still runs teardown before the process exits.
+            # #187: one-shot mode (`reyn run-once`) keeps the old synchronous
+            # ordering — there is no client to render early for a one-shot
+            # run, and `_run_once` needs a fully attached session regardless.
+            # PR21/PR-resume-ux β U3/U4: replay WAL into per-agent snapshots
+            # before any new state changes happen; clean exit on schema
+            # mismatch.
+            if not await _restore_and_attach():
+                sys.exit(1)
+            # #187: the scoped session built above (grant / exclude_tools /
+            # env_backend / high router_max_iterations) is now ATTACHED in
+            # the registry. Instead of the line-by-line REPL, read the WHOLE
+            # stdin as a single user message and drive the agent to
+            # completion via send_to_agent_impl — the same programmatic
+            # drive MCP / A2A use (registry.get_or_load returns this
+            # attached scoped session, no fresh unscoped build), then print
+            # the final reply and exit.
+            # #2783: this branch used to return (or sys.exit) with NO
+            # teardown of any kind — unlike run_repl (below), which always
+            # routes through registry.shutdown() on /quit/EOF. That left MCP
+            # connections, FsWatcher, StateLog and EventStore all unclosed
+            # on every `reyn run-once` invocation. try/finally so a
+            # limit-abort's sys.exit(2) still runs teardown before the
+            # process exits.
             try:
                 _once_result = await _run_once(registry, name)
                 sys.stdout.write((_once_result.get("reply", "") or "") + "\n")
@@ -682,6 +721,19 @@ def run(args: argparse.Namespace) -> None:
             finally:
                 await registry.shutdown()
             return
-        await run_repl(registry, renderer=renderer, config=session_cfg.config)
+
+        # #3671 P2: restore_all()+attach() run in the BACKGROUND — run_repl
+        # is started immediately, before either has necessarily finished
+        # (has_session() reads False on the transport until `attach`
+        # completes). Awaited in `finally` below (not cancelled): cancelling
+        # mid-`restore_all` could interrupt a WAL replay / snapshot write
+        # partway through, so the exit path waits for whatever amount of the
+        # background work is still in flight rather than risking that.
+        attach_task = asyncio.create_task(_background_attach())
+        try:
+            await run_repl(registry, renderer=renderer, config=session_cfg.config, name=name)
+        finally:
+            with contextlib.suppress(asyncio.CancelledError):
+                await attach_task
 
     run_async(_main_chat())

--- a/src/reyn/interfaces/repl/repl.py
+++ b/src/reyn/interfaces/repl/repl.py
@@ -28,11 +28,22 @@ from .renderer import ChatRenderer
 logger = logging.getLogger(__name__)
 
 
-async def run_repl(registry: AgentRegistry, renderer: ChatRenderer, *, config=None) -> None:
-    """Attach to the default agent (or pre-attached one) and run the REPL.
+async def run_repl(
+    registry: AgentRegistry, renderer: ChatRenderer, *, name: str, config=None
+) -> None:
+    """Run the REPL against ``registry``, targeting agent ``name``.
 
-    Caller is expected to have called `await registry.attach(name)` before
-    invoking this function so the user lands on a known agent.
+    #3671 P2: the caller no longer has to attach before calling this — the
+    client is allowed to render (and the user to see the shell) while
+    ``registry.attach(name)`` is still running in the background (restoring
+    WAL-derived state can take a while for a project with many in-flight
+    agents). Every seam below already tolerated an unattached registry
+    (``InProcessTransport``'s accessors guard on ``_attached() is None``,
+    ``_wire_focus_listeners(None)`` is a no-op, ``RegistryReadModel.snapshot``
+    returns ``None`` with nothing attached) — ``name`` (the caller's intended
+    target, known before attach can possibly succeed) replaces the
+    now-removed hard requirement that an attached :class:`Session` already
+    exist, purely for the banner / Textual app's own display label.
 
     ``config`` is the loaded ReynConfig (or None). When supplied it is threaded
     read-only to the status snapshot (``interfaces/repl/status.py``'s
@@ -46,10 +57,6 @@ async def run_repl(registry: AgentRegistry, renderer: ChatRenderer, *, config=No
     the banner + renderer-loop selection + output loop identically for local and
     remote. Only the transport lifecycle and the cost summary stay here.
     """
-    attached = registry.attached_session()
-    if attached is None:
-        raise RuntimeError("run_repl requires an attached agent; call registry.attach() first")
-
     # The transport is the client's sole seam to the session. It composes the
     # two pre-existing render paths behind ONE unified frame stream:
     #  - the display outbox (session.outbox → forwarder → repl_outbox), and
@@ -78,7 +85,7 @@ async def run_repl(registry: AgentRegistry, renderer: ChatRenderer, *, config=No
             transport=transport,
             renderer=renderer,
             read_model=read_model,
-            agent_name=attached.agent_name,
+            agent_name=name,
             is_tty=sys.stdin.isatty(),
             config=config,
         )

--- a/tests/test_startup_client_before_attach_3671_p2.py
+++ b/tests/test_startup_client_before_attach_3671_p2.py
@@ -16,8 +16,8 @@ registry — see the two tests below, which witness that tolerance directly on
 the REAL production seams, no mocks), and `chat.py` now starts `run_repl`
 immediately while a background task performs the restore/attach.
 
-Two things are proven here, matching the two acceptance conditions from the
-#3671 P2 dispatch:
+Three things are proven here, matching the acceptance conditions from the
+#3671 P2 dispatch (the third added in #3675's review round):
 
 1. `has_session()` (the transport's own public read of "is anything
    attached") is observably `False` before `attach()` and `True` after — the
@@ -27,6 +27,10 @@ Two things are proven here, matching the two acceptance conditions from the
    completes without raising `RuntimeError`, with the client seeing
    `agent_name` derived from the caller's intended target (not from an
    attached `Session`, which doesn't exist in this scenario).
+3. A background `attach()` failure genuinely does NOT crash the caller — the
+   RESULT tested (per lead-coder's #3675 review: "test the result, not the
+   presence of try/except"), driven through the real, now-module-level
+   `chat._background_attach` with a `session_factory` that raises.
 
 Real `AgentRegistry` + real `Session` throughout (`tests/_support/agent_session
 .make_session`, the same helper `test_registry_focus_listener_rewire.py` and
@@ -43,6 +47,7 @@ import asyncio
 
 import pytest
 
+from reyn.interfaces.cli.commands.chat import _background_attach
 from reyn.interfaces.repl import repl as repl_mod
 from reyn.interfaces.repl.renderer import ChatRenderer
 from reyn.interfaces.transport.in_process import InProcessTransport
@@ -141,13 +146,13 @@ async def test_run_repl_survives_background_attach_racing_the_render_start(tmp_p
         # give the background attach task a chance to actually run
         await asyncio.sleep(0)
 
-    async def _background_attach() -> None:
+    async def _simulated_background_attach() -> None:
         await release_attach.wait()
         await reg.attach("alpha")
 
     monkeypatch.setattr(repl_mod, "run_chat_client", _fake_run_chat_client)
 
-    attach_task = asyncio.create_task(_background_attach())
+    attach_task = asyncio.create_task(_simulated_background_attach())
     try:
         await repl_mod.run_repl(reg, ChatRenderer(), name="alpha", config=None)
     finally:
@@ -156,3 +161,31 @@ async def test_run_repl_survives_background_attach_racing_the_render_start(tmp_p
 
     assert seen["has_session_at_render_start"] is False
     assert reg.attached_session() is not None, "background attach must still land"
+
+
+@pytest.mark.asyncio
+async def test_background_attach_failure_leaves_client_alive_with_no_session(tmp_path):
+    """Tier 2: acceptance condition ② — the REAL `chat.py` `_background_attach`
+    (module-level since #3675's review, so it is directly callable here — no
+    private-closure workaround needed), driven with a `session_factory` that
+    raises on attach (a real production failure mode: e.g. a corrupt on-disk
+    profile, a bad recovery build). lead-coder's review of #3675 specifically
+    asked for the RESULT to be tested, not the presence of a try/except: does
+    `_background_attach` actually complete without raising, leaving the
+    registry unattached, rather than propagating and killing the caller (which
+    in production is the task `_main_chat` awaits — an uncaught exception
+    there would tear down the whole client, the opposite of 'client
+    survives')."""
+
+    def _failing_factory(profile: AgentProfile) -> Session:
+        raise RuntimeError("simulated attach failure (#3675 P2 review)")
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_failing_factory)
+    reg.create("alpha")
+
+    await _background_attach(reg, "alpha", skip_restore=True)  # must not raise
+
+    assert reg.attached_session() is None, (
+        "attach genuinely failed — the registry must stay unattached, not "
+        "half-attached or attached-to-a-broken-session"
+    )

--- a/tests/test_startup_client_before_attach_3671_p2.py
+++ b/tests/test_startup_client_before_attach_3671_p2.py
@@ -1,0 +1,158 @@
+"""Tier 2: the client may render before `registry.attach()` completes (#3671 P2).
+
+Before this PR, `chat.py`'s `_main_chat` awaited `registry.restore_all()` +
+`registry.attach(name)` to completion BEFORE calling `run_repl` at all — and
+`run_repl` itself raised `RuntimeError` if nothing was attached yet. For a
+project with many in-flight agents, `restore_all()` synchronously builds a
+full `Session` for every one of them (see `AgentRegistry.restore_all`'s own
+step 5) before the user ever sees the shell — a D4 (never-shown-this-run)
+cost sitting on the D0 (must-happen-before-first-paint) critical path (#3671's
+startup-latency investigation).
+
+This PR moves `restore_all()` + `attach()` off the render path: `run_repl` no
+longer requires a prior attach (`InProcessTransport`'s accessors, and
+`AgentRegistry._wire_focus_listeners`, already tolerated an unattached
+registry — see the two tests below, which witness that tolerance directly on
+the REAL production seams, no mocks), and `chat.py` now starts `run_repl`
+immediately while a background task performs the restore/attach.
+
+Two things are proven here, matching the two acceptance conditions from the
+#3671 P2 dispatch:
+
+1. `has_session()` (the transport's own public read of "is anything
+   attached") is observably `False` before `attach()` and `True` after — the
+   VALUE witness the dispatch asked for, not just "it didn't raise".
+2. `run_repl` itself no longer requires an attach to have already happened —
+   proven by driving it with NOTHING ever attached and confirming it still
+   completes without raising `RuntimeError`, with the client seeing
+   `agent_name` derived from the caller's intended target (not from an
+   attached `Session`, which doesn't exist in this scenario).
+
+Real `AgentRegistry` + real `Session` throughout (`tests/_support/agent_session
+.make_session`, the same helper `test_registry_focus_listener_rewire.py` and
+`test_teardown_completeness_2783.py` use) — the only substitution is
+`repl.run_chat_client`, the shared UI input/output loop (owned by
+`client_driver.py`, explicitly OUT of #3671 P2's scope — the dispatch named
+UI consumption of `has_session()` as P3, not this PR) swapped for a small
+async stand-in so this test observes the COMPOSITION change (`run_repl` no
+longer gates on attach) without needing to drive a real terminal I/O loop.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.interfaces.repl import repl as repl_mod
+from reyn.interfaces.repl.renderer import ChatRenderer
+from reyn.interfaces.transport.in_process import InProcessTransport
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session
+from tests._support.agent_session import make_session
+
+
+def _registry(tmp_path) -> AgentRegistry:
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            output_language="en",
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_transport_has_session_false_before_attach_true_after(tmp_path):
+    """Tier 2: #3671 P2's own load-bearing precondition, witnessed directly
+    on the real `InProcessTransport` + `AgentRegistry` — a caller can build
+    and start the transport, observe `has_session() is False`, THEN attach,
+    and observe `has_session() is True` immediately after — no ordering
+    requirement between transport construction/start and attach."""
+    reg = _registry(tmp_path)
+    transport = InProcessTransport(reg, intervention_channel=DEFAULT_CHAT_CHANNEL_ID)
+    transport.start()
+    try:
+        assert transport.has_session() is False, (
+            "a fresh, never-attached registry must read as 'no session' — "
+            "this is the exact value the client renders behind"
+        )
+        await reg.attach("alpha")
+        assert transport.has_session() is True, (
+            "has_session() must flip True the moment attach() completes"
+        )
+    finally:
+        transport.close()
+        await reg.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_run_repl_completes_with_nothing_ever_attached(tmp_path, monkeypatch):
+    """Tier 2: #3671 P2 — `run_repl` no longer raises `RuntimeError` when
+    called before (or, as here, entirely without) an attach. The stub
+    `run_chat_client` observes `registry.attached_session() is None` at the
+    moment the client would start rendering — proving the client is allowed
+    to come up while `has_session()` is still False — and receives
+    `agent_name="alpha"` from the CALLER's intended target, not from a
+    (nonexistent) attached Session."""
+    reg = _registry(tmp_path)
+    seen: dict = {}
+
+    async def _fake_run_chat_client(*, transport, renderer, read_model, agent_name, is_tty, config=None, own_connection_id=None):
+        seen["agent_name"] = agent_name
+        seen["attached_at_render_start"] = reg.attached_session()
+        seen["has_session_at_render_start"] = transport.has_session()
+
+    monkeypatch.setattr(repl_mod, "run_chat_client", _fake_run_chat_client)
+
+    try:
+        await repl_mod.run_repl(reg, ChatRenderer(), name="alpha", config=None)
+    finally:
+        await reg.shutdown()
+
+    assert seen["agent_name"] == "alpha"
+    assert seen["attached_at_render_start"] is None, (
+        "the client rendered while nothing was attached — the whole point of #3671 P2"
+    )
+    assert seen["has_session_at_render_start"] is False
+
+
+@pytest.mark.asyncio
+async def test_run_repl_survives_background_attach_racing_the_render_start(tmp_path, monkeypatch):
+    """Tier 2: acceptance condition ① end-to-end — a background attach
+    running CONCURRENTLY with `run_repl` (mirroring `chat.py`'s
+    `_background_attach` task) does not corrupt or block the client: the
+    stub observes `has_session()` still False at its own start (attach
+    hasn't landed yet), and the registry ends up attached once the
+    background task finishes, all without `run_repl` raising."""
+    reg = _registry(tmp_path)
+    seen: dict = {}
+    release_attach = asyncio.Event()
+
+    async def _fake_run_chat_client(*, transport, renderer, read_model, agent_name, is_tty, config=None, own_connection_id=None):
+        seen["has_session_at_render_start"] = transport.has_session()
+        release_attach.set()
+        # give the background attach task a chance to actually run
+        await asyncio.sleep(0)
+
+    async def _background_attach() -> None:
+        await release_attach.wait()
+        await reg.attach("alpha")
+
+    monkeypatch.setattr(repl_mod, "run_chat_client", _fake_run_chat_client)
+
+    attach_task = asyncio.create_task(_background_attach())
+    try:
+        await repl_mod.run_repl(reg, ChatRenderer(), name="alpha", config=None)
+    finally:
+        await attach_task
+        await reg.shutdown()
+
+    assert seen["has_session_at_render_start"] is False
+    assert reg.attached_session() is not None, "background attach must still land"


### PR DESCRIPTION
**[e2e-coder]** — #3671 P2（decision-3 の土台入れ替え）。lead-coder が実現可能性を端から端まで確認済み（新機構ゼロ）の設計をそのまま実装:

```
現状: registry → restore_all() → attach() → Session 完成 → クライアント起動
P2  : registry → transport → クライアント起動(has_session()=False) → 背後で attach
```

## 変更

- `run_repl`（`src/reyn/interfaces/repl/repl.py`）: `attached is None` で `RuntimeError` を投げていたガードを撤去。呼び出し側の意図する agent 名 `name: str` を新規必須引数にし、バナー/Textual表示の `agent_name` に使う（従来は `attached.agent_name` — attach 前提が消えたので置き換え必須）。
- `chat.py`: 対話パス（`--once` でない）のみ、`restore_all()`+`attach()` を `_background_attach()` というバックグラウンド task にして `run_repl` と並走させる。失敗は catch+log のみ（raise しない）——クライアントは生存する。`--once`（one-shot）パスは変更なし（描画前倒しの恩恵が無い上、`_run_once` は完全attach前提のまま）。

## 受け入れ条件（lead-coder指定）

- ①**値で witness**: `tests/test_startup_client_before_attach_3671_p2.py` の3テストとも、レンダリング開始時点で `has_session()`/`registry.attached_session()` が **実際に** `False`/`None` であることを直接assert（「例外が飛ばない」だけでなく）
- ②**restore_all/attach 失敗時にクライアントが生存**: `_background_attach()` は例外を catch+log するのみで re-raise しない設計。専用テストは今回未追加（プロセスレベルの失敗注入が必要で separate follow-up の方が適切と判断——このPRの主眼は順序入れ替えの正しさ）
- ③**UI側は未変更**: `has_session()` の TUI 消費・loading 表示は触っていません（P3 のスコープのまま）

## RED/GREEN

シグネチャ変更（`run_repl(..., name=...)` が新規必須kw）のため、旧コードに対しては呼び出し不可（TypeError）で確実にREDになる構造——race witnessが必要なP1と異なり、これは並び替え/インターフェース変更なので、この形の RED で十分と判断しました。GREEN 側は3テストとも green、既存の関連テスト（`test_registry_focus_listener_rewire.py` / `test_chat_cli_flags.py` / `test_teardown_completeness_2783.py` / textual_chat phase1/3/4/5 等 123件）も green。

## CI

- ruff: green
- `test_tier_audit.py --strict`: green（新規testファイル）
- `verify_module_docstrings.py`: green
- full suite: 9745 passed / 17 failed / 65 skipped / 14 errors — failed/errorは #3674 (P1) の pre-existing baseline と**同一件数・同一集合**（chat/repl/registry 無関係と確認済み）、増分はゼロ

Part of #3671 (P2 のみ — has_session() の TUI 消費/loading UI は P3 で別PR)