### PR TITLE
feat(runtime): TUI consumes has_session()/attach_failed(), gates submit (#3671 P3)

### DIFF
--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -76,14 +76,12 @@ async def _background_attach(registry, name: str, *, skip_restore: bool) -> None
     (not a nested closure) so it is independently testable — see
     ``tests/test_startup_client_before_attach_3671_p2.py``.
 
-    #3671 P2 review (lead-coder): today a failure here is genuinely
-    invisible to the operator — ``_setup_interactive_logging`` (below)
-    routes this logger to a file, not the screen, so the client is left
-    silently waiting forever with ``has_session() == False``. That is a
-    real UX gap, but distinguishing "still connecting" from "failed"
-    on-screen is a ``has_session()``-*consuming* UI concern, i.e. P3's
-    scope (P2 is the ordering change only, no UI touched). Recorded as a
-    P3 requirement, not fixed here.
+    #3671 P3: this now ALSO calls ``registry.record_background_attach_error``
+    on every failure path (in addition to logging), so a client reading
+    ``ClientTransport.attach_failed()`` can distinguish "still connecting"
+    from "gave up" on screen — closing the P2-review-recorded UX gap
+    (``_setup_interactive_logging`` routes this logger to a file, not the
+    screen, so the log line alone was never operator-visible).
     """
     from reyn.core.events.agent_snapshot import SchemaVersionError
 
@@ -92,17 +90,20 @@ async def _background_attach(registry, name: str, *, skip_restore: bool) -> None
             try:
                 await registry.restore_all()
             except SchemaVersionError as e:
+                msg = f"background restore failed (schema mismatch): {e}"
                 logger.error(
-                    f"background restore failed (schema mismatch): {e} — "
-                    "client stays up with no attached agent; rerun after resolving it"
+                    f"{msg} — client stays up with no attached agent; "
+                    "rerun after resolving it"
                 )
+                registry.record_background_attach_error(msg)
                 return
         await registry.attach(name)
-    except Exception:
+    except Exception as e:
         logger.exception(
             "#3671 P2: background restore/attach failed — "
             "client stays up with no attached agent"
         )
+        registry.record_background_attach_error(f"{type(e).__name__}: {e}")
 
 
 def register(sub) -> None:

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1367,13 +1367,29 @@ class TextualChatApp(App):
             app_bindings=self._app_binding_help(),
         )
 
+    def _attach_state(self) -> "str | None":
+        """#3671 P3 (B0, shared by the header AND the composer submit-gate —
+        see ``on_composer_submitted``): the tri-state
+        ``"connecting" | "failed" | None`` (``None`` = attached) read off the
+        SAME ``transport.has_session()`` / ``transport.attach_failed()`` seam
+        both consumers use, so the two never disagree about whether a session
+        is up. Owner ruling: "not yet" and "this is the answer" must never
+        render the same — ``None`` here is the ONLY state that lets a
+        consumer show a real value; both non-``None`` states must degrade to
+        an explicit placeholder, never a stale or fabricated one."""
+        if self._transport.has_session():
+            return None
+        return "failed" if self._transport.attach_failed() else "connecting"
+
     def _status_text(self, snap: "dict | None | object" = _UNSET) -> str:
         """The status-values line (``model │ agent │ cost │ ctx``), from the live
         status snapshot (F5b: running cost + context percent are visible even with
         the drawer closed). Falls back to the threaded ``agent_name`` pre-session.
         Pass ``snap`` to reuse an already-read snapshot (one read per frame)."""
         snapshot = self._snapshot() if snap is _UNSET else snap
-        return status_line_text(snapshot, self._agent_name)  # type: ignore[arg-type]
+        return status_line_text(
+            snapshot, self._agent_name, attach_state=self._attach_state()
+        )  # type: ignore[arg-type]
 
     def on_mount(self) -> None:
         # #3505: #3504 made ``App``'s own background ``ansi_default`` (the
@@ -3530,14 +3546,42 @@ class TextualChatApp(App):
 
     async def on_composer_submitted(self, event: "Composer.Submitted") -> None:
         text = event.value.strip()
-        self.query_one(Composer).clear_and_reset()
         if not text:
+            self.query_one(Composer).clear_and_reset()
             return
         if text in {"/quit", "/exit"}:
+            self.query_one(Composer).clear_and_reset()
             await self._transport.shutdown()
             self.exit()
             return
+        # #3671 P3 (decision 4B): block ORDINARY submission until attach()
+        # completes. Deliberately does NOT clear the composer — the typed
+        # text must survive, unlike the two branches above — and does NOT
+        # touch `submit_user_text` / the #3300 sent-queue at all: there is no
+        # session yet to queue against, so this is a genuinely separate path,
+        # not a variant of the queue-cancel "restore text" mechanic. Reuses
+        # the SAME `has_session()`/`attach_failed()` pair the header (B0,
+        # `_attach_state`) reads, so the two surfaces can never disagree.
+        if not self._transport.has_session():
+            self._notify_blocked_on_attach()
+            return
+        self.query_one(Composer).clear_and_reset()
         await self._submit(text)
+
+    def _notify_blocked_on_attach(self) -> None:
+        """#3671 P3: tell the operator WHY their Enter did nothing, matching
+        the header's connecting/failed distinction (owner ruling: a genuine
+        failure must never be papered over as an indefinite "still loading")
+        rather than silently dropping the keystroke."""
+        if self._transport.attach_failed():
+            text = "attach failed (see log) — your message was kept; retry once resolved"
+        else:
+            text = "still connecting — your message will send once ready"
+        from reyn.runtime.outbox import OutboxMessage  # noqa: PLC0415
+        try:
+            self._transport.put_display(OutboxMessage(kind="status", text=text))
+        except Exception:
+            pass
 
     async def _submit(self, text: str) -> None:
         """Route one submitted line through the transport send seam.

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -1152,21 +1152,39 @@ def pane_payload(
     return help_pane_lines(app_bindings)
 
 
-def status_line_text(snap: "dict | None", agent_name: str) -> str:
+def status_line_text(
+    snap: "dict | None", agent_name: str, *, attach_state: "str | None" = None
+) -> str:
     """The slim ``model │ agent │ cost │ ctx`` status-values line, from the live
     status snapshot (F5b: the running cost + context percent are visible here even
-    when the drawer is closed). Falls back to the threaded ``agent_name`` and
-    ``—``/``$0.0000``/``—`` when no snapshot is available yet (pre-session).
+    when the drawer is closed).
 
-    #2280: when ``snap["halted_reason"]`` is set (the session fail-stopped on a
-    persistent durability failure — ``Session.halted_reason``), a ``HALTED``
-    banner segment is PREPENDED ahead of the usual values — this line is the
-    ONE always-visible (never-collapsed) chrome region, so it is the surface an
-    idle operator (not currently submitting anything) will proactively see the
-    halt on, rather than only learning it from the next op's raised
-    ``DurabilityHaltError``. Purely observability — the halt itself is already
-    enforced synchronously elsewhere (``_fail_stop_if_durability_dead`` /
-    ``run_one_iteration``); this never gates or delays anything."""
+    ``attach_state`` (#3671 P3): ``"connecting"`` / ``"failed"`` / ``None``
+    (attached — the ordinary case). Owner ruling: "not yet attached" and
+    "this is the answer" must never render as the same thing, so a non-``None``
+    ``attach_state`` short-circuits BEFORE any ``model``/``cost``/``ctx`` field
+    is read — there is no attached session behind those numbers yet, so this
+    never risks rendering a placeholder (``$0.0000`` / ``—``) that could be
+    misread as a real, confirmed value. ``"connecting"`` and ``"failed"``
+    render VISIBLY DIFFERENT text (not merely different in a way only a log
+    reader would notice) — a permanently-``"connecting"``-looking client on a
+    genuine failure is exactly what the owner ruling forbids.
+    """
+    if attach_state == "connecting":
+        return f"⏳ connecting… │ agent {agent_name}"
+    if attach_state == "failed":
+        return f"✗ attach failed (see log) │ agent {agent_name}"
+
+    # #2280: when ``snap["halted_reason"]`` is set (the session fail-stopped on
+    # a persistent durability failure — ``Session.halted_reason``), a
+    # ``HALTED`` banner segment is PREPENDED ahead of the usual values — this
+    # line is the ONE always-visible (never-collapsed) chrome region, so it is
+    # the surface an idle operator (not currently submitting anything) will
+    # proactively see the halt on, rather than only learning it from the next
+    # op's raised ``DurabilityHaltError``. Purely observability — the halt
+    # itself is already enforced synchronously elsewhere
+    # (``_fail_stop_if_durability_dead`` / ``run_one_iteration``); this never
+    # gates or delays anything.
     snap = snap or {}
     model = snap.get("model_active_class") or snap.get("model") or "—"
     agent = snap.get("attached_name") or agent_name

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -1169,11 +1169,23 @@ def status_line_text(
     render VISIBLY DIFFERENT text (not merely different in a way only a log
     reader would notice) — a permanently-``"connecting"``-looking client on a
     genuine failure is exactly what the owner ruling forbids.
+
+    #3671 P3 review (lead-coder): deliberately plain text, no decorative
+    glyph — ``⏳`` measures East-Asian-Width ``W`` (2 terminal cells) while
+    every other character on this ONE always-visible, ``│``-delimited row is
+    ``N``/``Na`` (1 cell); glyph width also varies by terminal/font, and this
+    line has zero such glyphs today, so it would be the first. A 1-cell
+    misjudgement on the narrowest-terminal case (owner's own environment)
+    breaks the whole row, not just this segment. Visual decoration is
+    explicitly a separate, still-open owner decision (#3642) — this PR lands
+    the MECHANISM only; a glyph can be added later without touching the
+    mechanism, but a broken row on a still-forming feature would cast doubt
+    on the mechanism itself.
     """
     if attach_state == "connecting":
-        return f"⏳ connecting… │ agent {agent_name}"
+        return f"connecting… │ agent {agent_name}"
     if attach_state == "failed":
-        return f"✗ attach failed (see log) │ agent {agent_name}"
+        return f"attach failed (see log) │ agent {agent_name}"
 
     # #2280: when ``snap["halted_reason"]`` is set (the session fail-stopped on
     # a persistent durability failure — ``Session.halted_reason``), a

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -113,6 +113,25 @@ class ClientTransport(ABC):
     def has_session(self) -> bool:
         """Whether a session is currently attached (client input guard)."""
 
+    def attach_failed(self) -> bool:
+        """#3671 P3: whether the attach this transport is waiting on is KNOWN
+        to have given up — vs. still in flight, or never attempted (both of
+        which read ``False`` here, same as ``has_session()`` does for them).
+        A client with ``has_session() is False`` uses this to distinguish
+        "still connecting" from "gave up" (owner ruling: a client must never
+        paint a genuine failure as an indefinite loading state).
+
+        NOT abstract (mirrors :meth:`cancel_queued` / :meth:`run_slash_command`
+        above): several narrow-purpose ``ClientTransport`` stubs across the
+        test suite pre-date this method, and only `InProcessTransport` (#3671
+        P2's own background-attach path) has anything meaningful to report —
+        a remote (``AgUiTransport``) attach either already succeeded by the
+        time ``--connect`` returns or the connection attempt itself raised,
+        so there is no separate "connecting in the background" phase to fail
+        remotely; the default ``False`` (paired with its own ``has_session()``)
+        is correct there, not a placeholder."""
+        return False
+
     @abstractmethod
     def pending_intervention_head(self) -> "object | None":
         """The oldest pending intervention handle, or None — client routing input."""

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -160,6 +160,12 @@ class InProcessTransport(ClientTransport):
     def has_session(self) -> bool:
         return self._attached() is not None
 
+    def attach_failed(self) -> bool:
+        # #3671 P3: delegates to the registry's own recorded state (set by
+        # `chat.py._background_attach` on failure, cleared at the top of
+        # every `attach()` call) — the transport holds no separate copy.
+        return bool(self._registry.attach_failed())
+
     def pending_intervention_head(self) -> "object | None":
         s = self._attached()
         return s.interventions.head() if s is not None else None

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -289,6 +289,14 @@ class AgentRegistry:
         # Single queue the REPL drains; registry routes each attached agent's
         # outbox into here.
         self.repl_outbox: asyncio.Queue = asyncio.Queue()
+        # #3671 P3: the ONE place a caller doing a BACKGROUND attach (P2's
+        # `chat.py._background_attach`, running off the render path) can
+        # record that its attach ultimately failed, so a client reading
+        # `has_session() is False` can distinguish "still connecting" from
+        # "gave up" (see `ClientTransport.attach_failed`). `None` = no
+        # recorded failure. Cleared at the top of `attach()` so a fresh
+        # attach attempt is never shadowed by a stale prior failure.
+        self._background_attach_error: str | None = None
         # Ensure default exists so `reyn chat` (no name) works out of the box.
         if not (self._dir / DEFAULT_AGENT_NAME / PROFILE_FILENAME).is_file():
             AgentProfile.new(DEFAULT_AGENT_NAME, role="").save(
@@ -3097,6 +3105,13 @@ class AgentRegistry:
         """Switch the attached agent to `name`. Loads + starts session.run()
         and the outbox forwarder for the new agent if not already running.
         Old agent stays in `self._tasks` (background)."""
+        # #3671 P3: a fresh attach attempt (or its `get_or_load` below, which
+        # can itself raise) is never shadowed by a PRIOR background attempt's
+        # recorded failure — clear it up front rather than only on success,
+        # so a caller retrying after `record_background_attach_error` sees a
+        # clean "connecting" state again immediately, not "failed" until
+        # this attempt ALSO finishes.
+        self._background_attach_error = None
         new_session = self.get_or_load(name)
         sid = _DEFAULT_SID  # FP-0043 S3: attach(name) focuses the default session
         key = (name, sid)
@@ -3261,6 +3276,23 @@ class AgentRegistry:
         if self._attached is None:
             return None
         return self._peek_session(self._attached[0], self._attached[1])
+
+    def record_background_attach_error(self, error: str) -> None:
+        """#3671 P3: called by a caller doing a BACKGROUND attach (P2's
+        `chat.py._background_attach`) when it gives up, so `attach_failed()`
+        below can tell a client apart "still connecting" from "gave up" —
+        both look identical from `has_session()` alone (`False` either way).
+        A caller that never does a background attach never calls this; a
+        transport reading `attach_failed()` before ANY attach was even
+        attempted correctly still sees `False` (== "connecting")."""
+        self._background_attach_error = error
+
+    def attach_failed(self) -> bool:
+        """#3671 P3: whether the most recent attach attempt is KNOWN to have
+        given up (vs. still in flight, or having never started) — see
+        `record_background_attach_error`. Cleared at the top of every
+        `attach()` call, so a retry is never shadowed by a stale failure."""
+        return self._background_attach_error is not None
 
     def running_tasks(self) -> list[asyncio.Task]:
         """All non-completed tasks (session.run + forwarders) for shutdown drain."""

--- a/tests/test_textual_chat_attach_state_3671_p3.py
+++ b/tests/test_textual_chat_attach_state_3671_p3.py
@@ -1,0 +1,371 @@
+"""Tier 2: the Textual chat TUI consumes `has_session()`/`attach_failed()` to
+distinguish "not yet attached" from a real value, and blocks submission until
+attached (#3671 P3).
+
+Before this PR, `interfaces/inline/` had ZERO references to `has_session()` —
+the header rendered `model — │ agent <name> │ cost $0.0000 │ ctx —` whether
+nothing was attached yet OR the attach had genuinely failed, indistinguishable
+from each other and from a real (if unlikely) `$0.0000` cost. The composer
+was worse: `on_composer_submitted` cleared the typed text UNCONDITIONALLY
+before checking anything, so a message typed while `has_session()` was still
+`False` (#3671 P2's own new window) was silently discarded — the opposite of
+decision 4B ("keep text in the box").
+
+B0 (owner ruling: one shared mechanism before B1/B2, so the header and the
+composer can never disagree) is `TextualChatApp._attach_state()` — a tri-state
+`"connecting" | "failed" | None` read off the SAME
+`transport.has_session()` / `transport.attach_failed()` pair both consumers
+now use:
+
+- B1 (header): `status_line_text(snap, agent_name, attach_state=...)`
+  (`interfaces/inline/textual_chat/chrome.py`) short-circuits BEFORE reading
+  any `model`/`cost`/`ctx` field when `attach_state` is not `None` — a
+  "connecting" or "failed" render can never be confused with a real value,
+  by construction (there is no code path that reaches the placeholder
+  `"—"`/`"$0.0000"` strings from a non-`None` attach_state).
+- B2 (connecting vs failed): the two render VISIBLY DIFFERENT text, sourced
+  from `AgentRegistry.attach_failed()` (new — `chat.py._background_attach`,
+  #3671 P2, now calls `registry.record_background_attach_error(...)` on every
+  failure path, not just logs it to a file the operator never sees).
+- Decision 4B (composer): `on_composer_submitted` gates ordinary submission
+  on `has_session()`, preserving the typed text and never touching
+  `submit_user_text` / the #3300 sent-queue (there is no session to queue
+  against yet) — `/quit`/`/exit` remain unblocked (an operator waiting on a
+  slow attach must still be able to exit).
+
+Real `AgentRegistry` (for the pure-registry tests) + a real, minimal
+`ClientTransport` implementation (mirroring `ScriptedTransport` in
+`test_textual_chat_phase4_3273.py`) + the real `TextualChatApp`/pilot — no
+mocks, per the testing policy.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.interfaces.inline.textual_chat.chrome import Composer, status_line_text
+from reyn.interfaces.repl.read_model import ChatReadModel
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+# ---------------------------------------------------------------------------
+# B1/B2 — status_line_text's own tri-state, pure-function level
+# ---------------------------------------------------------------------------
+
+
+def test_status_line_connecting_never_shows_a_model_or_cost_value():
+    """Tier 2: B1 — a "connecting" state never reads model/cost/ctx off
+    `snap`, even when `snap` is fully populated (a real attach could be about
+    to overwrite it) — the two must never blend into a half-real line."""
+    fully_populated_snap = {
+        "model_active_class": "opus", "cost_agent": 1.2345, "attached_name": "alpha",
+    }
+    text = status_line_text(fully_populated_snap, "alpha", attach_state="connecting")
+    assert "opus" not in text
+    assert "1.2345" not in text
+    assert "connecting" in text.lower()
+
+
+def test_status_line_failed_is_visibly_different_from_connecting():
+    """Tier 2: B2 — "connecting" and "failed" must not render identically;
+    an operator glancing at the header must be able to tell them apart
+    without reading a log file (owner ruling)."""
+    connecting = status_line_text(None, "alpha", attach_state="connecting")
+    failed = status_line_text(None, "alpha", attach_state="failed")
+    assert connecting != failed
+    assert "fail" in failed.lower()
+
+
+def test_status_line_attached_state_unaffected():
+    """Tier 2: `attach_state=None` (attached) is byte-identical to the
+    pre-#3671-P3 behavior — no regression for the ordinary, already-attached
+    case."""
+    snap = {"model_active_class": "opus", "cost_agent": 0.5, "attached_name": "alpha"}
+    assert status_line_text(snap, "alpha", attach_state=None) == status_line_text(snap, "alpha")
+
+
+# ---------------------------------------------------------------------------
+# B0's registry-side half — AgentRegistry.attach_failed()
+# ---------------------------------------------------------------------------
+
+
+def _registry(tmp_path, *, factory=None) -> AgentRegistry:
+    if factory is None:
+        def factory(profile: AgentProfile) -> Session:
+            agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+            agent_dir.mkdir(parents=True, exist_ok=True)
+            return make_session(
+                agent_name=profile.name, agent_role=profile.role,
+                output_language="en", snapshot_path=agent_dir / "state" / "snapshot.json",
+            )
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    return reg
+
+
+def test_registry_attach_failed_false_before_any_recorded_failure(tmp_path):
+    """Tier 2: a fresh registry (no attach attempted yet, or one in flight)
+    reads `attach_failed() is False` — this is the "connecting" case, not
+    "failed"."""
+    reg = _registry(tmp_path)
+    assert reg.attach_failed() is False
+
+
+def test_registry_attach_failed_true_after_recorded_failure(tmp_path):
+    """Tier 2: `record_background_attach_error` (called by
+    `chat.py._background_attach` on every failure path) flips
+    `attach_failed()` True — the exact seam `InProcessTransport.attach_failed`
+    delegates to."""
+    reg = _registry(tmp_path)
+    reg.record_background_attach_error("boom")
+    assert reg.attach_failed() is True
+
+
+@pytest.mark.asyncio
+async def test_registry_attach_failed_cleared_by_a_fresh_attach_attempt(tmp_path):
+    """Tier 2: a NEW `attach()` call clears a stale prior failure up front —
+    a retry must read as "connecting" again immediately, not "failed" until
+    the retry also finishes (or fails again)."""
+    reg = _registry(tmp_path)
+    reg.record_background_attach_error("boom")
+    assert reg.attach_failed() is True
+    await reg.attach("alpha")
+    assert reg.attach_failed() is False
+
+
+# ---------------------------------------------------------------------------
+# Decision 4B — composer blocks submission, preserves text, no #3300 touch
+# ---------------------------------------------------------------------------
+
+
+class _AttachStateTransport(ClientTransport):
+    """A real, minimal `ClientTransport` (mirrors `ScriptedTransport` in
+    `test_textual_chat_phase4_3273.py`) whose `has_session()`/
+    `attach_failed()` are test-controlled, so the composer's gating can be
+    driven through both states without a real registry/attach cycle."""
+
+    def __init__(self) -> None:
+        self._session = False
+        self._failed = False
+        self.submitted: list[str] = []
+        self.displayed: list[OutboxMessage] = []
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        for msg in self.displayed:
+            yield DisplayFrame(msg)
+        import asyncio
+        await asyncio.Event().wait()
+
+    async def submit_user_text(self, text: str) -> str:
+        self.submitted.append(text)
+        return "msg-1"
+
+    async def answer_intervention_text(self, text: str, *, intervention_id=None) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str, *, intervention_id=None) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return self._session
+
+    def attach_failed(self) -> bool:
+        return self._failed
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        self.displayed.append(msg)
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+class _NoneReadModel(ChatReadModel):
+    """Mirrors what `RegistryReadModel.snapshot()` genuinely returns
+    pre-attach — `None` (see `status._snapshot`)."""
+
+    def snapshot(self, config=None):
+        return None
+
+    def intervention_head(self):
+        return None
+
+    def pending_command_ui(self):
+        return None
+
+    def clear_pending_command_ui(self) -> None:
+        return None
+
+    @property
+    def has_command_ui_region(self) -> bool:
+        return True
+
+    @property
+    def history_path(self) -> Path:
+        return Path("/tmp/reyn_p3_attach_state_history")
+
+    def conversation_history(self, *, limit=None):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_submit_blocked_while_unattached_preserves_typed_text():
+    """Tier 2: decision 4B's core witness — typing while `has_session()` is
+    `False` and pressing Enter must NOT clear the composer and must NOT call
+    `submit_user_text` (the #3300 queue is never touched: nothing was ever
+    submitted to it)."""
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+
+    transport = _AttachStateTransport()
+    app = TextualChatApp(transport=transport, read_model=_NoneReadModel())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        composer = app.query_one(Composer)
+        composer.text = "hello, are you there"
+        await pilot.pause()
+        await app.on_composer_submitted(Composer.Submitted("hello, are you there"))
+        await pilot.pause()
+
+        assert transport.submitted == [], "must not reach the #3300 queue while unattached"
+        assert composer.text == "hello, are you there", (
+            "typed text must survive a blocked submission (decision 4B)"
+        )
+        assert any("connecting" in m.text.lower() for m in transport.displayed), (
+            "operator must be told WHY nothing happened"
+        )
+
+
+@pytest.mark.asyncio
+async def test_submit_blocked_message_distinguishes_failed_from_connecting():
+    """Tier 2: the SAME block, but with `attach_failed()` True — the notice
+    text must say "failed", not "connecting" (B0 sourced from the same pair
+    the header reads, so the two surfaces agree)."""
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+
+    transport = _AttachStateTransport()
+    transport._failed = True
+    app = TextualChatApp(transport=transport, read_model=_NoneReadModel())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        composer = app.query_one(Composer)
+        composer.text = "still there?"
+        await pilot.pause()
+        await app.on_composer_submitted(Composer.Submitted("still there?"))
+        await pilot.pause()
+
+        assert transport.submitted == []
+        assert composer.text == "still there?"
+        assert any("fail" in m.text.lower() for m in transport.displayed)
+
+
+@pytest.mark.asyncio
+async def test_submit_proceeds_normally_once_attached():
+    """Tier 2: once `has_session()` flips True (attach completed), an
+    ordinary submission clears the composer and reaches
+    `submit_user_text` exactly as before #3671 P3 — no regression to the
+    attached-path behavior."""
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+
+    transport = _AttachStateTransport()
+    transport._session = True
+    app = TextualChatApp(transport=transport, read_model=_NoneReadModel())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        composer = app.query_one(Composer)
+        composer.text = "go ahead"
+        await pilot.pause()
+        await app.on_composer_submitted(Composer.Submitted("go ahead"))
+        await pilot.pause()
+
+        assert transport.submitted == ["go ahead"]
+        assert composer.text == ""
+
+
+@pytest.mark.asyncio
+async def test_quit_still_works_while_unattached():
+    """Tier 2: an operator waiting on a slow/failed attach must still be able
+    to exit — `/quit` is NOT gated behind `has_session()`."""
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+
+    transport = _AttachStateTransport()
+    app = TextualChatApp(transport=transport, read_model=_NoneReadModel())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        composer = app.query_one(Composer)
+        await app.on_composer_submitted(Composer.Submitted("/quit"))
+        await pilot.pause()
+        assert not app.is_running
+
+
+# ---------------------------------------------------------------------------
+# Header end-to-end: the MOUNTED StatusLine widget reflects attach state
+# ---------------------------------------------------------------------------
+#
+# Three separate app instances (one per state) rather than mutating one
+# live — the header's live refresh is driven off frame arrival
+# (`_refresh_live_chrome`, called from the frame-pump loop), and asserting
+# through that would mean either reaching into `_status_text()` directly
+# (a private-state assertion the tier policy forbids) or fabricating a fake
+# live frame stream; a fresh app per state is simpler and stays entirely on
+# the PUBLIC `StatusLine` widget surface, which is what actually renders to
+# the operator.
+
+
+@pytest.mark.asyncio
+async def test_header_shows_connecting_state_at_mount():
+    """Tier 2: B0/B1 — a never-attached transport renders the "connecting"
+    header on the real, MOUNTED `StatusLine` widget."""
+    from reyn.interfaces.inline.textual_chat import StatusLine, TextualChatApp
+
+    transport = _AttachStateTransport()
+    app = TextualChatApp(transport=transport, read_model=_NoneReadModel())
+    async with app.run_test(size=(100, 30)):
+        status = str(app.query_one(StatusLine).render())
+        assert "connecting" in status.lower()
+
+
+@pytest.mark.asyncio
+async def test_header_shows_failed_state_at_mount():
+    """Tier 2: B0/B2 — an `attach_failed()` transport renders the "failed"
+    header, visibly different from "connecting", on the mounted widget."""
+    from reyn.interfaces.inline.textual_chat import StatusLine, TextualChatApp
+
+    transport = _AttachStateTransport()
+    transport._failed = True
+    app = TextualChatApp(transport=transport, read_model=_NoneReadModel())
+    async with app.run_test(size=(100, 30)):
+        status = str(app.query_one(StatusLine).render())
+        assert "fail" in status.lower()
+
+
+@pytest.mark.asyncio
+async def test_header_shows_ordinary_state_once_attached():
+    """Tier 2: B0 — an attached transport shows neither placeholder text,
+    no regression for the ordinary case."""
+    from reyn.interfaces.inline.textual_chat import StatusLine, TextualChatApp
+
+    transport = _AttachStateTransport()
+    transport._session = True
+    app = TextualChatApp(transport=transport, read_model=_NoneReadModel())
+    async with app.run_test(size=(100, 30)):
+        status = str(app.query_one(StatusLine).render())
+        assert "connecting" not in status.lower()
+        assert "fail" not in status.lower()


### PR DESCRIPTION
**[e2e-coder]** — #3671 P3。lead-coord指定の4条件（TUI消費・loading表示・connecting/failed区別・decision4B）を実装。**見た目の可否は owner ゲート**のため、以下に文字で正確に書きます（朝の判定用・現在mainに入っている最終形）。

## 見え方（テキストで正確に・装飾グリフなし）

**ヘッダ（既存 `model │ agent │ cost │ ctx` の1行、常時表示領域）:**

| 状態 | 表示 |
|---|---|
| 通常時（既存・無変更） | `model opus │ agent default │ cost $0.1234 │ ctx 42%` |
| **connecting**（attach前・新規） | `connecting… │ agent default` |
| **failed**（attach失敗・新規） | `attach failed (see log) │ agent default` |

（レビューで `⏳` は削除しました — lead-coder実測: East-Asian-Width `W`(2セル)で、このstatus lineの他文字は全て1セル。owner環境=git-bash/mintty on Windowsが最も幅がぶれる組み合わせで、1セルずれると`│`区切りの行全体が崩れるため。装飾自体は#3642で保留中の別論点——今回は装飾なしの機構のみです。）

model/cost/ctx の各フィールドは connecting/failed 時は**一切読まれません**（`status_line_text`がattach_stateで早期return——プレースホルダの `—`/`$0.0000` が「本物の値」と誤読される余地を構造的に排除）。HALTEDバナー（既存）とは意味的に排他（未attach時はhalted_reasonがそもそも存在しない）。

**コンポーザ（入力欄）— decision 4B:**
- 未attach時にEnter → **入力欄はクリアされません**（文字は残る）
- `submit_user_text` は呼ばれません（#3300 sent-queueには一切触れません——queueへ到達する前でblock）
- 1行の通知が会話ペインに `kind="status"` で流れます: `still connecting — your message will send once ready`（failed時は `attach failed (see log) — your message was kept; retry once resolved`）
- `/quit` `/exit` は未attach時も**ブロックされません**（遅い/失敗したattachを待つ操作者は必ず抜けられる——lead-coderのレビューで「良い判断」と確認済み）

## B0（owner裁定: B1/B2の前に共通機構1つ）

`TextualChatApp._attach_state()` — `transport.has_session()` / `transport.attach_failed()` の同じペアから tri-state (`"connecting" | "failed" | None`) を導出し、ヘッダ・コンポーザ両方がこの**同じ1関数**を読みます（片方だけ更新して食い違う余地なし）。

## 実装

- `ClientTransport.attach_failed()` — 新規、非abstract（default `False`。`cancel_queued`と同パターン——既存の narrow-purpose stub 群を壊さない）
- `InProcessTransport.attach_failed()` — `AgentRegistry.attach_failed()` に委譲
- `AgentRegistry`: `_background_attach_error` フィールド + `record_background_attach_error()` / `attach_failed()`。**`attach()` の先頭でクリア**——再attach試行が古い失敗に隠れない
- `chat.py._background_attach`（#3671 P2）: 失敗パス全てで `registry.record_background_attach_error(...)` を追加呼び出し（ログだけでなく状態にも残す）
- `chrome.status_line_text(snap, agent_name, *, attach_state=None)`: `attach_state` 非Noneで早期return、装飾グリフなし
- `app.py`: `_attach_state()`（B0）、`_status_text()` が使用、`on_composer_submitted` が decision4B のガードを追加

## スコープ外（明示）

- **見た目の最終可否・装飾グリフの要否**: owner ゲート（#3642 と同じ保留線）— この PR は装飾なしの機構のみ
- **#3300 sent-queue**: 一切未変更（未attach時はqueueへ到達する前でblockするため、触る理由がない——Cの足場化を避ける狙い通り）
- リモート（`AgUiTransport`）の `attach_failed()`: default `False` のまま（remote には「backgroundでattach中」という独立フェーズが無いため——コメントに理由明記）

## テスト（13本、新規ファイル `tests/test_textual_chat_attach_state_3671_p3.py`）

- `status_line_text` tri-state の pure-function 検証（connecting時にmodel/cost値が一切現れないこと含む）
- `AgentRegistry.attach_failed()` の記録/クリア
- decision4B: block時に入力欄温存+queue未到達+通知表示、attach後は通常動作、`/quit`は常に通る
- ヘッダの3状態（mount時点、real `StatusLine` widget の `.render()` で public surface のみ検証）

RED-before-fix: 9本を stash で確認（2本は「無変更ケース」なので元々green——正しい）。GREEN後、既存 textual_chat phase1-5 / registry / transport 関連224件も green。グリフ削除後も13本green（文字列アサーションはグリフに依存しない設計）。

## CI

- ruff: green
- `test_tier_audit.py --strict`: green（private-state assertion を1件検出・`StatusLine.render()`経由のpublic surfaceに書き直し済み）
- `verify_module_docstrings.py`: green
- full suite: 9759 passed / 17 failed / 65 skipped / 14 errors — failed/errorは #3674/#3675 と**同一集合**（increment ゼロ、chat/repl/registry/inline 無関係と確認済み）

Part of #3671 (P3 — has_session()/attach_failed() consumption + submit gate)