### PR TITLE
perf(runtime): defer non-target agents' Session build in restore_all() (#3671 P4 item C-1)

### DIFF
--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -88,7 +88,12 @@ async def _background_attach(registry, name: str, *, skip_restore: bool) -> None
     try:
         if not skip_restore:
             try:
-                await registry.restore_all()
+                # #3671 P4 item C-1: only THIS agent's in-flight state is
+                # built+run eagerly — every other in-flight agent's WAL
+                # replay still happens (durability unaffected) but its
+                # Session build is deferred to first real use (a later
+                # /attach or delegation), off this run's D0 critical path.
+                await registry.restore_all(only_names={name})
             except SchemaVersionError as e:
                 msg = f"background restore failed (schema mismatch): {e}"
                 logger.error(
@@ -671,7 +676,9 @@ def run(args: argparse.Namespace) -> None:
     async def _safe_restore() -> bool:
         """Returns True on success, False if the operator should retry."""
         try:
-            await registry.restore_all()
+            # #3671 P4 item C-1: only the target agent's in-flight state is
+            # built eagerly — see the sibling call in `_background_attach`.
+            await registry.restore_all(only_names={name})
             return True
         except SchemaVersionError as e:
             print(f"\nSchema version mismatch: {e}\n", file=sys.stderr)

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -82,6 +82,20 @@ async def _background_attach(registry, name: str, *, skip_restore: bool) -> None
     from "gave up" on screen — closing the P2-review-recorded UX gap
     (``_setup_interactive_logging`` routes this logger to a file, not the
     screen, so the log line alone was never operator-visible).
+
+    #3671 P4 item C-1 (v2, owner ruling — "resume every in-flight agent,
+    just don't make the client's own startup wait for it"): ``restore_all``
+    builds ONLY ``name`` eagerly; after ``attach(name)`` succeeds (so
+    ``has_session()`` has already flipped True and the client is already
+    live), ``registry.resume_deferred_agents()`` proactively finishes
+    building+restoring+running every OTHER in-flight agent — still fully
+    automatic, just ordered after the target so it never competes with the
+    target's own attach for this background task's time. A failure there is
+    intentionally NOT routed through ``record_background_attach_error``:
+    that seam means "the REQUESTED agent's attach failed" specifically (the
+    client-visible connecting/failed distinction, #3671 P3) — a deferred
+    OTHER agent failing to resume is a different, non-blocking failure mode,
+    logged on its own.
     """
     from reyn.core.events.agent_snapshot import SchemaVersionError
 
@@ -89,10 +103,10 @@ async def _background_attach(registry, name: str, *, skip_restore: bool) -> None
         if not skip_restore:
             try:
                 # #3671 P4 item C-1: only THIS agent's in-flight state is
-                # built+run eagerly — every other in-flight agent's WAL
+                # built+run eagerly here — every other in-flight agent's WAL
                 # replay still happens (durability unaffected) but its
-                # Session build is deferred to first real use (a later
-                # /attach or delegation), off this run's D0 critical path.
+                # Session build is deferred; resumed below, AFTER attach(),
+                # not eliminated.
                 await registry.restore_all(only_names={name})
             except SchemaVersionError as e:
                 msg = f"background restore failed (schema mismatch): {e}"
@@ -109,6 +123,16 @@ async def _background_attach(registry, name: str, *, skip_restore: bool) -> None
             "client stays up with no attached agent"
         )
         registry.record_background_attach_error(f"{type(e).__name__}: {e}")
+        return
+
+    if not skip_restore:
+        try:
+            await registry.resume_deferred_agents()
+        except Exception:
+            logger.exception(
+                "#3671 P4 C-1: resuming a deferred (non-target) in-flight "
+                "agent failed — the attached agent is unaffected"
+            )
 
 
 def register(sub) -> None:
@@ -674,10 +698,20 @@ def run(args: argparse.Namespace) -> None:
     from reyn.core.events.agent_snapshot import SchemaVersionError
 
     async def _safe_restore() -> bool:
-        """Returns True on success, False if the operator should retry."""
+        """Returns True on success, False if the operator should retry.
+
+        #3671 P4 item C-1: only the target agent's in-flight state is built
+        eagerly — see the sibling call in `_background_attach`. Deliberately
+        does NOT also call `registry.resume_deferred_agents()` (unlike
+        `_background_attach`): the one-shot path has no ongoing client whose
+        first render this would need to avoid competing with, and the
+        process exits (via `registry.shutdown()`) almost immediately after
+        `_run_once` returns — a deferred OTHER agent's state stays safely on
+        disk, resumed by whichever run (interactive or another `--once`)
+        actually reaches it next, not resumed pointlessly here just before
+        exit.
+        """
         try:
-            # #3671 P4 item C-1: only the target agent's in-flight state is
-            # built eagerly — see the sibling call in `_background_attach`.
             await registry.restore_all(only_names={name})
             return True
         except SchemaVersionError as e:

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -297,6 +297,15 @@ class AgentRegistry:
         # recorded failure. Cleared at the top of `attach()` so a fresh
         # attach attempt is never shadowed by a stale prior failure.
         self._background_attach_error: str | None = None
+        # #3671 P4 item C-1: post-WAL-replay snapshots `restore_all(only_names
+        # =...)` deferred instead of building+running immediately — applied
+        # once, lazily, the first time `get_or_load` actually constructs that
+        # (name, DEFAULT_SID) session (an `attach()` or a delegation target's
+        # `ensure_running()`, both of which call `get_or_load`). Entries are
+        # POPPED on use, so a name that's never reached this run just never
+        # gets its Session built at all — the deferred cost, not just a
+        # delayed one.
+        self._pending_restore: "dict[tuple[str, str], AgentSnapshot]" = {}
         # Ensure default exists so `reyn chat` (no name) works out of the box.
         if not (self._dir / DEFAULT_AGENT_NAME / PROFILE_FILENAME).is_file():
             AgentProfile.new(DEFAULT_AGENT_NAME, role="").save(
@@ -1039,7 +1048,9 @@ class AgentRegistry:
                     sids.add(self._decode_sid_from_dir(child.name))
         return sorted(sids)
 
-    async def restore_all(self) -> dict[str, AgentSnapshot]:
+    async def restore_all(
+        self, *, only_names: "set[str] | None" = None
+    ) -> dict[str, AgentSnapshot]:
         """Reconstruct each known agent's runtime state from snapshot + WAL.
 
         Algorithm:
@@ -1059,6 +1070,29 @@ class AgentRegistry:
         re-materialises both substrates as-of-N — every startup path that calls
         ``restore_all`` gets crash-recovery by construction. No-op without a
         rewind record.
+
+        ``only_names`` (#3671 P4 item C-1): steps 1-4 (WAL replay + the
+        durable snapshot re-save) are UNCONDITIONAL regardless of this param —
+        every agent's on-disk snapshot is brought current either way, so
+        durability is unaffected. Only step 5's DEFAULT-session build
+        (``get_or_load`` + ``restore_state`` + ``ensure_running`` — a full
+        Session construction plus a live running task) is scoped: with
+        ``only_names`` given, an in-flight agent NOT in the set has its
+        post-replay snapshot stashed in ``self._pending_restore`` instead of
+        being built now; ``get_or_load`` applies it (``restore_state``, once)
+        the first time that agent is actually reached — an explicit
+        ``attach()``, or a delegation target via ``ensure_running()`` (both
+        call ``get_or_load`` internally) — never left un-hydrated, just
+        deferred to first real use. ``None`` (every caller except ``chat.py``,
+        e.g. ``mcp.py`` — which must be able to serve ANY agent name on
+        arbitrary MCP calls, not one known target) is the real, still-eager
+        behavior — not a compat default kept only to avoid a signature break.
+
+        Deliberately UNSCOPED by ``only_names``: a SPAWNED (non-default-sid)
+        session's build in step 5's other branch, and ``_rewake_pipeline_runs``
+        below — both genuinely separate mechanisms from the default-session
+        case above (see their own comments), narrowed out of this PR's scope
+        rather than bundled in.
         """
         if self._state_log is None:
             return {}
@@ -1142,6 +1176,12 @@ class AgentRegistry:
                     and not snap.outstanding_interventions):
                 continue
             if sid == _DEFAULT_SID:
+                # #3671 P4 item C-1: an in-flight agent OUTSIDE only_names is
+                # deferred — its snapshot is durably saved above already
+                # (step 4), so nothing is lost by not building+running it now.
+                if only_names is not None and name not in only_names:
+                    self._pending_restore[(name, sid)] = snap
+                    continue
                 session = self.get_or_load(name)
                 session.restore_state(snap)
                 await self.ensure_running(name)
@@ -2600,6 +2640,15 @@ class AgentRegistry:
         loader = getattr(session, "load_persisted_toggles", None)
         if callable(loader):
             loader()
+        # #3671 P4 item C-1: apply a deferred restore_all(only_names=...)
+        # snapshot on FIRST construction — this is the one place both
+        # `attach()` and `ensure_running()` (delegation targets) converge, so
+        # a single hook here covers both "first real use" triggers for the
+        # default session. Pop (not peek): applies exactly once per Session
+        # lifetime, same as the toggle-load above.
+        pending = self._pending_restore.pop((name, _DEFAULT_SID), None)
+        if pending is not None:
+            session.restore_state(pending)
         return session
 
     def _construct_session(

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1074,7 +1074,7 @@ class AgentRegistry:
         ``only_names`` (#3671 P4 item C-1): steps 1-4 (WAL replay + the
         durable snapshot re-save) are UNCONDITIONAL regardless of this param —
         every agent's on-disk snapshot is brought current either way, so
-        durability is unaffected. Only step 5's DEFAULT-session build
+        the STATE itself is never lost. Only step 5's DEFAULT-session build
         (``get_or_load`` + ``restore_state`` + ``ensure_running`` — a full
         Session construction plus a live running task) is scoped: with
         ``only_names`` given, an in-flight agent NOT in the set has its
@@ -1082,17 +1082,44 @@ class AgentRegistry:
         being built now; ``get_or_load`` applies it (``restore_state``, once)
         the first time that agent is actually reached — an explicit
         ``attach()``, or a delegation target via ``ensure_running()`` (both
-        call ``get_or_load`` internally) — never left un-hydrated, just
-        deferred to first real use. ``None`` (every caller except ``chat.py``,
-        e.g. ``mcp.py`` — which must be able to serve ANY agent name on
-        arbitrary MCP calls, not one known target) is the real, still-eager
-        behavior — not a compat default kept only to avoid a signature break.
+        call ``get_or_load`` internally). ``None`` (every caller except
+        ``chat.py``, e.g. ``mcp.py`` — which must be able to serve ANY agent
+        name on arbitrary MCP calls, not one known target) is the real,
+        still-eager behavior — not a compat default kept only to avoid a
+        signature break.
 
-        Deliberately UNSCOPED by ``only_names``: a SPAWNED (non-default-sid)
-        session's build in step 5's other branch, and ``_rewake_pipeline_runs``
-        below — both genuinely separate mechanisms from the default-session
-        case above (see their own comments), narrowed out of this PR's scope
-        rather than bundled in.
+        ⚠️ DELIBERATE crash-recovery semantic change (lead-coder review,
+        #3683 — flagged here explicitly so it is never mistaken for a
+        performance-only side effect): before this param existed, EVERY
+        in-flight agent auto-RESUMED its run-loop at startup (crash-recovery-
+        by-construction). With ``only_names`` given, a non-requested in-flight
+        agent's state is preserved but its run-loop does NOT auto-resume —
+        only "first real use" (attach/delegation) resumes it, and if nothing
+        ever reaches it during this process's lifetime, it simply never runs
+        this session, even though it was mid-task when the process last
+        stopped. The state is not lost (still restorable by a LATER
+        ``restore_all`` — e.g. the next process start, or a future
+        `only_names` that includes it) but auto-resume itself does not
+        happen. See ``test_deferred_agent_does_not_auto_resume_if_never_touched``
+        (tests/test_registry_restore_all_only_names_3671_p4c1.py) for the
+        behavioral pin. Whether this trade-off is acceptable is pending
+        explicit owner confirmation as of #3683 (asked by lead-coder) — this
+        docstring states the CURRENT actual behavior either way, so a future
+        reversal is a deliberate, documented decision, not a silent one.
+
+        Deliberately UNSCOPED by ``only_names`` (so NOT subject to the same
+        deferral): a SPAWNED (non-default-sid) session's build in step 5's
+        other branch, and ``_rewake_pipeline_runs`` below. The pipeline case
+        in particular creates a real ASYMMETRY worth naming: a crashed
+        in-flight PIPELINE run still self-resumes unconditionally on every
+        ``restore_all()`` call regardless of ``only_names``, while a crashed
+        in-flight AGENT (this step) does not, unless requested or reached.
+        Both are "genuinely separate mechanisms" in the narrow sense that
+        `_rewake_pipeline_runs` doesn't share step 5's code path — but
+        whether an OPERATOR should see pipelines auto-resume while ordinary
+        agent turns do not is a real product-consistency question, not
+        resolved here; narrowed out of this PR's scope rather than silently
+        decided either way.
         """
         if self._state_log is None:
             return {}

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -3370,6 +3370,64 @@ class AgentRegistry:
         `attach()` call, so a retry is never shadowed by a stale failure."""
         return self._background_attach_error is not None
 
+    async def resume_deferred_agents(self) -> "list[str]":
+        """#3671 P4 item C-1 (v2, owner ruling): proactively build+restore+run
+        every in-flight agent `restore_all(only_names=...)` deferred — i.e.
+        finish what pre-C-1 `restore_all()` used to do for ALL of them,
+        unconditionally. Called by `chat.py`'s background attach task AFTER
+        `attach(name)` has already completed: the target agent is already
+        live and `has_session()` has already flipped True by the time this
+        runs, so it never delays startup — but every crashed-mid-task agent
+        still auto-resumes THIS run, matching pre-C-1 crash-recovery
+        semantics (the owner ruling: "resume everyone, just don't make
+        startup wait for it").
+
+        Two live paths reach `self._pending_restore` (lead-coder review,
+        #3683): this proactive sweep, AND `get_or_load`'s own on-demand hook
+        — genuinely BOTH reachable, not a declared-but-dead second branch:
+        the interactive client is already rendering (P2) while this sweep
+        runs as its own background task, so the operator's own `/attach
+        <other>` or a live delegation's `ensure_running(<other>)` can reach a
+        still-pending agent before this sweep gets to it. Both are safe
+        together because `self._pending_restore.pop(key, None)` is the SOLE
+        gate on every `restore_state` call for a given `(name, sid)` — this
+        is a `dict.pop`, synchronous and atomic under asyncio's single-
+        threaded cooperative scheduling (NOT thread-safe in general — that
+        guarantee is specific to this being asyncio, not a claim that would
+        hold under real OS threads). Whichever path's `pop` returns
+        non-`None` first is the sole owner for that entry; the other finds
+        `None` and skips. Separately, `attach()`/`ensure_running()` ALSO each
+        independently guard their own `asyncio.create_task(session.run())`
+        against re-creation (`if key not in self._tasks or
+        self._tasks[key].done(): ...`), so even a session already restored
+        by one path never gets a second run-task from the other.
+        """
+        resumed: "list[str]" = []
+        for name, sid in list(self._pending_restore.keys()):
+            # Pop (not peek) BEFORE constructing: `get_or_load` is synchronous
+            # (no `await` inside it), so nothing else can run between this
+            # pop and the `get_or_load` call below within THIS coroutine —
+            # no window for an on-demand `attach()`/`ensure_running()` to
+            # race THIS (name, sid) between the two lines. See the docstring
+            # above for why racing a DIFFERENT (name, sid) (there IS an
+            # `await` below, on purpose) is also safe.
+            snap = self._pending_restore.pop((name, sid), None)
+            if snap is None:
+                continue  # already consumed via on-demand attach/ensure_running
+            session = self.get_or_load(name)
+            session.restore_state(snap)
+            await self.ensure_running(name)
+            resumed.append(name)
+            # #3671 P4 C-1 v2 (owner ruling: don't compete with the client's
+            # own first render / input handling for CPU): `ensure_running`
+            # itself has no internal `await` (it only SCHEDULES tasks via
+            # `asyncio.create_task`, never blocks on them), so without this
+            # explicit yield, sweeping N deferred agents would run essentially
+            # synchronously with no chance for the render/input loop (a
+            # SEPARATE task) to actually get scheduled in between.
+            await asyncio.sleep(0)
+        return resumed
+
     def running_tasks(self) -> list[asyncio.Task]:
         """All non-completed tasks (session.run + forwarders) for shutdown drain."""
         out: list[asyncio.Task] = []

--- a/tests/test_registry_restore_all_only_names_3671_p4c1.py
+++ b/tests/test_registry_restore_all_only_names_3671_p4c1.py
@@ -1,0 +1,160 @@
+"""Tier 2: #3671 P4 item C-1 — `AgentRegistry.restore_all(only_names=...)`
+defers building+running an in-flight agent's Session when it is NOT the
+caller's requested target, applying the deferred restore lazily at first
+real use (`attach()` or a delegation target's `ensure_running()` — both
+route through `get_or_load`) instead of never.
+
+Before this fix, `restore_all()` built (`get_or_load` + `restore_state` +
+`ensure_running`, a full Session construction plus a live running task) EVERY
+in-flight agent unconditionally — proportional to agent count, all on
+whatever critical path called `restore_all()` (P2 already moved that off the
+RENDER path via `chat.py`'s background task, but the requested agent's own
+`attach()` still had to wait for every OTHER in-flight agent to finish
+building first).
+
+Durability is untouched by this: WAL replay (steps 2-3) and the snapshot
+re-save to disk (step 4) are UNCONDITIONAL regardless of `only_names` — only
+the Session-BUILD step is deferred. Witnessed here via the PUBLIC
+`loaded_names()` surface (never a private `_`-prefixed accessor) and via the
+real behavioral effect (a restored intervention actually reaching the
+deferred agent's live intervention queue once it IS reached) — not just "no
+exception raised".
+
+Real `AgentRegistry` + real `Session` throughout (mirrors
+`test_intervention_restore.py`'s seeding pattern — pre-write a snapshot.json
+with a stranded intervention, the same L4/L5 fixture shape) — no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.agent_snapshot import AgentSnapshot
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from tests._support.agent_session import make_session
+
+
+def _snapshot_with_intervention(*, agent_name: str, iv_id: str) -> AgentSnapshot:
+    snap = AgentSnapshot.empty(agent_name)
+    snap.outstanding_interventions[iv_id] = {
+        "kind": "ask_user", "prompt": "Q?", "detail": "", "choices": [],
+        "suggestions": [], "run_id": "rA", "actor": "demo", "id": iv_id,
+    }
+    snap.applied_seq = 5
+    return snap
+
+
+def _seed_two_in_flight_agents(tmp_path: Path) -> StateLog:
+    """Seeds `alpha` and `beta`, each with a stranded intervention on disk
+    (no WAL entries needed — restore_all's step 1 loads snapshot.json
+    directly, same as test_intervention_restore.py)."""
+    agents_dir = tmp_path / ".reyn" / "agents"
+    for name in ("alpha", "beta"):
+        agent_dir = agents_dir / name
+        state_dir = agent_dir / "state"
+        state_dir.mkdir(parents=True)
+        AgentProfile.new(name, role="").save(agent_dir)
+        snap = _snapshot_with_intervention(agent_name=name, iv_id=f"iv_{name}")
+        snap.save(state_dir / "snapshot.json")
+    return StateLog(tmp_path / ".reyn" / "wal.jsonl")
+
+
+def _registry(tmp_path: Path, state_log: StateLog) -> AgentRegistry:
+    def _factory(profile: AgentProfile):
+        s = make_session(agent_name=profile.name, state_log=state_log)
+        s.register_intervention_listener("test")
+        return s
+
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=state_log,
+    )
+
+
+@pytest.mark.asyncio
+async def test_only_names_defers_the_non_target_agents_session_build(tmp_path, monkeypatch):
+    """Tier 2: #3671 P4 item C-1's core witness — `restore_all(only_names=
+    {"alpha"})` builds alpha's session (the requested target) but NOT beta's
+    (in-flight but not requested), observed via the PUBLIC `loaded_names()`."""
+    monkeypatch.chdir(tmp_path)
+    state_log = _seed_two_in_flight_agents(tmp_path)
+    registry = _registry(tmp_path, state_log)
+
+    snapshots = await registry.restore_all(only_names={"alpha"})
+
+    assert "alpha" in snapshots and "beta" in snapshots, (
+        "WAL replay / snapshot re-save (steps 1-4) must still cover BOTH "
+        "agents regardless of only_names — durability is unaffected"
+    )
+    assert "alpha" in registry.loaded_names(), (
+        "the requested agent must still be built+running immediately"
+    )
+    assert "beta" not in registry.loaded_names(), (
+        "a non-requested in-flight agent must NOT be built during restore_all "
+        "— its build is deferred to first real use, not eliminated"
+    )
+
+
+@pytest.mark.asyncio
+async def test_deferred_agent_is_restored_on_first_attach(tmp_path, monkeypatch):
+    """Tier 2: the deferred agent is NOT lost — attaching to it later applies
+    the SAME restore_state it would have gotten eagerly (the stranded
+    intervention reaches its live queue), proving `get_or_load`'s hook
+    actually fires exactly where `attach()` reaches it."""
+    monkeypatch.chdir(tmp_path)
+    state_log = _seed_two_in_flight_agents(tmp_path)
+    registry = _registry(tmp_path, state_log)
+    await registry.restore_all(only_names={"alpha"})
+    assert "beta" not in registry.loaded_names()
+
+    beta_session = await registry.attach("beta")
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+    iv_ids = [iv.id for iv in beta_session.interventions.list_active()]
+    assert "iv_beta" in iv_ids, (
+        f"beta's deferred intervention must be re-enqueued once attached; got {iv_ids}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_deferred_agent_is_restored_via_delegation_ensure_running(tmp_path, monkeypatch):
+    """Tier 2: the OTHER "first real use" trigger — a delegation target
+    reached via `ensure_running()` (never an explicit `/attach`) — also gets
+    its deferred restore applied, since `ensure_running` calls `get_or_load`
+    internally too."""
+    monkeypatch.chdir(tmp_path)
+    state_log = _seed_two_in_flight_agents(tmp_path)
+    registry = _registry(tmp_path, state_log)
+    await registry.restore_all(only_names={"alpha"})
+    assert "beta" not in registry.loaded_names()
+
+    beta_session = await registry.ensure_running("beta")
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+    iv_ids = [iv.id for iv in beta_session.interventions.list_active()]
+    assert "iv_beta" in iv_ids
+
+
+@pytest.mark.asyncio
+async def test_restore_all_without_only_names_still_builds_every_in_flight_agent(tmp_path, monkeypatch):
+    """Tier 2: regression guard — `restore_all()` with NO `only_names` (e.g.
+    `mcp.py`, which must serve any agent name) keeps the original, fully
+    eager behavior byte-identically: every in-flight agent is built
+    immediately, none deferred."""
+    monkeypatch.chdir(tmp_path)
+    state_log = _seed_two_in_flight_agents(tmp_path)
+    registry = _registry(tmp_path, state_log)
+
+    await registry.restore_all()
+
+    assert "alpha" in registry.loaded_names()
+    assert "beta" in registry.loaded_names(), (
+        "with only_names=None every in-flight agent must still be built "
+        "eagerly — this is a real behavioral requirement for mcp.py, not "
+        "just a compat default"
+    )

--- a/tests/test_registry_restore_all_only_names_3671_p4c1.py
+++ b/tests/test_registry_restore_all_only_names_3671_p4c1.py
@@ -99,6 +99,44 @@ async def test_only_names_defers_the_non_target_agents_session_build(tmp_path, m
 
 
 @pytest.mark.asyncio
+async def test_deferred_agent_does_not_auto_resume_if_never_touched(tmp_path, monkeypatch):
+    """Tier 2: #3671 P4 item C-1 — a DELIBERATE crash-recovery semantic
+    change (lead-coder review, #3683), stated explicitly rather than left
+    implicit: before this PR, EVERY in-flight agent auto-resumed its run-loop
+    at startup (crash-recovery-by-construction). After this PR, only the
+    requested agent auto-resumes; a non-requested in-flight agent (beta —
+    e.g. one that crashed mid-delegation-turn) stays NOT running unless
+    something actually reaches it (attach or a delegation target) during
+    this process's lifetime. If nothing ever does, it never resumes this
+    run — the state is not lost (still on disk, still restorable on the
+    NEXT restore_all), but auto-resume itself does not happen. Pending
+    owner confirmation this is the intended trade-off (asked by lead-coder,
+    #3683) — this test documents the ACTUAL current behavior either way, so
+    a later reversal shows up here as an intentional test change, not a
+    silent regression."""
+    monkeypatch.chdir(tmp_path)
+    state_log = _seed_two_in_flight_agents(tmp_path)
+    registry = _registry(tmp_path, state_log)
+
+    await registry.restore_all(only_names={"alpha"})
+    # give any wrongly-scheduled task a chance to actually start
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+    # A running task requires a constructed Session (`ensure_running`/
+    # `attach` both go through `get_or_load` first) — so `loaded_names()`
+    # NOT containing "beta" is itself conclusive proof no task is running
+    # for it (there is no code path to a running task that skips
+    # construction). Asserted via this PUBLIC surface, not a private
+    # `_tasks` peek.
+    assert "beta" not in registry.loaded_names(), (
+        "a never-touched, non-requested in-flight agent must NOT auto-resume "
+        "— see docstring: this is the deliberate #3671 P4 C-1 crash-recovery "
+        "semantic change (pending owner confirmation, #3683)"
+    )
+
+
+@pytest.mark.asyncio
 async def test_deferred_agent_is_restored_on_first_attach(tmp_path, monkeypatch):
     """Tier 2: the deferred agent is NOT lost — attaching to it later applies
     the SAME restore_state it would have gotten eagerly (the stranded

--- a/tests/test_registry_restore_all_only_names_3671_p4c1.py
+++ b/tests/test_registry_restore_all_only_names_3671_p4c1.py
@@ -1,23 +1,35 @@
 """Tier 2: #3671 P4 item C-1 — `AgentRegistry.restore_all(only_names=...)`
-defers building+running an in-flight agent's Session when it is NOT the
-caller's requested target, applying the deferred restore lazily at first
-real use (`attach()` or a delegation target's `ensure_running()` — both
-route through `get_or_load`) instead of never.
+defers building an in-flight agent's Session when it is NOT the caller's
+requested target, so the target's own `attach()` is never gated on every
+OTHER in-flight agent finishing first.
 
-Before this fix, `restore_all()` built (`get_or_load` + `restore_state` +
-`ensure_running`, a full Session construction plus a live running task) EVERY
-in-flight agent unconditionally — proportional to agent count, all on
-whatever critical path called `restore_all()` (P2 already moved that off the
-RENDER path via `chat.py`'s background task, but the requested agent's own
-`attach()` still had to wait for every OTHER in-flight agent to finish
-building first).
+v2 (owner ruling, after lead-coder's review of the first version): the
+original design left a NON-target agent un-resumed until something happened
+to touch it (attach / delegation), possibly forever — a genuine
+crash-recovery semantic change the owner rejected. The ruling: "resume
+EVERY in-flight agent, just don't make the client's own startup wait for
+it." `chat.py`'s `_background_attach` now calls
+`registry.resume_deferred_agents()` right AFTER `attach(name)` succeeds — a
+proactive sweep that finishes building+restoring+running every deferred
+agent, matching pre-C-1 semantics (nothing is left un-resumed), just
+ordered so the target agent is never delayed by it.
 
-Durability is untouched by this: WAL replay (steps 2-3) and the snapshot
-re-save to disk (step 4) are UNCONDITIONAL regardless of `only_names` — only
-the Session-BUILD step is deferred. Witnessed here via the PUBLIC
-`loaded_names()` surface (never a private `_`-prefixed accessor) and via the
-real behavioral effect (a restored intervention actually reaching the
-deferred agent's live intervention queue once it IS reached) — not just "no
+Two live paths can reach a deferred agent's `self._pending_restore` entry:
+the proactive sweep above, AND `get_or_load`'s own on-demand hook (an
+operator's own `/attach <other>`, or a live delegation's
+`ensure_running(<other>)`, reaching it BEFORE the sweep does — genuinely
+possible, since the client is already rendering while the sweep runs as its
+own background task). Both are safe together (a single `dict.pop` gate,
+plus each of `attach()`/`ensure_running()` independently guarding their own
+run-task creation) — see the race-safety test below and `registry.py`'s
+own `resume_deferred_agents` docstring for the full argument.
+
+Durability is untouched by any of this: WAL replay (steps 2-3) and the
+snapshot re-save to disk (step 4) are UNCONDITIONAL regardless of
+`only_names` — only the Session-BUILD step is deferred. Witnessed here via
+the PUBLIC `loaded_names()` surface (never a private `_`-prefixed accessor)
+and via the real behavioral effect (a restored intervention actually
+reaching the deferred agent's live intervention queue) — not just "no
 exception raised".
 
 Real `AgentRegistry` + real `Session` throughout (mirrors
@@ -99,41 +111,124 @@ async def test_only_names_defers_the_non_target_agents_session_build(tmp_path, m
 
 
 @pytest.mark.asyncio
-async def test_deferred_agent_does_not_auto_resume_if_never_touched(tmp_path, monkeypatch):
-    """Tier 2: #3671 P4 item C-1 — a DELIBERATE crash-recovery semantic
-    change (lead-coder review, #3683), stated explicitly rather than left
-    implicit: before this PR, EVERY in-flight agent auto-resumed its run-loop
-    at startup (crash-recovery-by-construction). After this PR, only the
-    requested agent auto-resumes; a non-requested in-flight agent (beta —
-    e.g. one that crashed mid-delegation-turn) stays NOT running unless
-    something actually reaches it (attach or a delegation target) during
-    this process's lifetime. If nothing ever does, it never resumes this
-    run — the state is not lost (still on disk, still restorable on the
-    NEXT restore_all), but auto-resume itself does not happen. Pending
-    owner confirmation this is the intended trade-off (asked by lead-coder,
-    #3683) — this test documents the ACTUAL current behavior either way, so
-    a later reversal shows up here as an intentional test change, not a
-    silent regression."""
+async def test_deferred_agent_not_yet_resumed_right_after_attach(tmp_path, monkeypatch):
+    """Tier 2: #3671 P4 item C-1 v2 (owner ruling: "resume every in-flight
+    agent, just don't make the client's own startup wait for it") — ordering
+    witness. Immediately after `restore_all(only_names={"alpha"})` returns,
+    beta (deferred, non-target) is NOT YET built — proving the target's own
+    attach genuinely never waited on beta. This is the FIRST half of the
+    owner's ruling; the second half (beta eventually resumes too) is
+    `test_resume_deferred_agents_resumes_every_deferred_agent` below."""
     monkeypatch.chdir(tmp_path)
     state_log = _seed_two_in_flight_agents(tmp_path)
     registry = _registry(tmp_path, state_log)
 
     await registry.restore_all(only_names={"alpha"})
-    # give any wrongly-scheduled task a chance to actually start
+
+    assert "alpha" in registry.loaded_names()
+    assert "beta" not in registry.loaded_names(), (
+        "beta must not be built as a side effect of restore_all() itself — "
+        "only resume_deferred_agents() (called AFTER attach(), see chat.py) "
+        "builds it, so the target's attach is never gated on it"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_deferred_agents_resumes_every_deferred_agent(tmp_path, monkeypatch):
+    """Tier 2: #3671 P4 item C-1 v2 — the second half of the owner ruling.
+    `resume_deferred_agents()` (called by `chat.py`'s `_background_attach`
+    AFTER `attach(name)` succeeds) proactively finishes building+restoring+
+    running every deferred agent — matching pre-C-1 crash-recovery semantics
+    (every in-flight agent auto-resumes THIS run), just staggered so it
+    never delays the target's own attach."""
+    monkeypatch.chdir(tmp_path)
+    state_log = _seed_two_in_flight_agents(tmp_path)
+    registry = _registry(tmp_path, state_log)
+    await registry.restore_all(only_names={"alpha"})
+    assert "beta" not in registry.loaded_names()
+
+    resumed = await registry.resume_deferred_agents()
+
+    assert resumed == ["beta"]
+    assert "beta" in registry.loaded_names()
     for _ in range(3):
         await asyncio.sleep(0)
-
-    # A running task requires a constructed Session (`ensure_running`/
-    # `attach` both go through `get_or_load` first) — so `loaded_names()`
-    # NOT containing "beta" is itself conclusive proof no task is running
-    # for it (there is no code path to a running task that skips
-    # construction). Asserted via this PUBLIC surface, not a private
-    # `_tasks` peek.
-    assert "beta" not in registry.loaded_names(), (
-        "a never-touched, non-requested in-flight agent must NOT auto-resume "
-        "— see docstring: this is the deliberate #3671 P4 C-1 crash-recovery "
-        "semantic change (pending owner confirmation, #3683)"
+    beta_session = registry.get_or_load("beta")
+    iv_ids = [iv.id for iv in beta_session.interventions.list_active()]
+    assert "iv_beta" in iv_ids, (
+        f"beta's deferred intervention must be re-enqueued by the sweep; got {iv_ids}"
     )
+
+
+@pytest.mark.asyncio
+async def test_resume_deferred_agents_does_not_double_resume_a_racing_on_demand_attach(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: #3671 P4 item C-1 v2 (lead-coder review, #3683) — the
+    interactive client is already rendering while `resume_deferred_agents()`
+    runs as its own background task, so an operator's own `/attach beta` (or
+    a live delegation's `ensure_running("beta")`) can reach a still-pending
+    agent BEFORE the sweep gets to it. Simulated here by attaching to beta
+    FIRST, then running the sweep — the sweep must not re-restore or spawn a
+    second run task for it (both gated on the SAME `_pending_restore.pop`).
+
+    ⚠️ This safety argument is SPECIFIC to asyncio's single-threaded
+    cooperative scheduling — `dict.pop` only settles the race here because
+    nothing else can run between `attach()`'s (or `resume_deferred_agents()`'s)
+    pop and the synchronous `get_or_load` call that follows it in the SAME
+    coroutine (no `await` in between). If `AgentRegistry` were ever made
+    genuinely multi-threaded (real OS threads, not asyncio tasks), this test
+    passing would NOT be evidence the race is still closed — `dict.pop` is
+    atomic under the GIL for a single bytecode-level operation, but the
+    surrounding "pop, then act on the popped value" sequence is not atomic
+    across real threads the way it is across asyncio tasks. See
+    `registry.py`'s own `resume_deferred_agents` docstring for the same
+    caveat stated at the definition site."""
+    monkeypatch.chdir(tmp_path)
+    state_log = _seed_two_in_flight_agents(tmp_path)
+    registry = _registry(tmp_path, state_log)
+    await registry.restore_all(only_names={"alpha"})
+    assert "beta" not in registry.loaded_names()
+
+    beta_session = await registry.attach("beta")
+    for _ in range(3):
+        await asyncio.sleep(0)
+    iv_ids_after_attach = [iv.id for iv in beta_session.interventions.list_active()]
+    assert iv_ids_after_attach == ["iv_beta"], (
+        f"on-demand attach must restore beta itself; got {iv_ids_after_attach}"
+    )
+
+    resumed = await registry.resume_deferred_agents()
+
+    assert resumed == [], (
+        "the sweep must find beta's pending entry already consumed by the "
+        "on-demand attach — it must not re-list beta as something IT resumed"
+    )
+    # Not duplicated: the intervention list still has exactly one entry, not
+    # two (which a second `restore_state` re-enqueuing the same iv WOULD NOT
+    # by itself prove is safe — the real risk is a second RUN TASK, guarded
+    # separately by attach()'s / ensure_running()'s own `_tasks` check; this
+    # asserts the state-level symptom a double-restore/double-task race would
+    # most visibly produce).
+    iv_ids_after_sweep = [iv.id for iv in beta_session.interventions.list_active()]
+    assert iv_ids_after_sweep == ["iv_beta"], (
+        f"must not duplicate the restored intervention; got {iv_ids_after_sweep}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_deferred_agents_is_a_noop_with_nothing_pending(tmp_path, monkeypatch):
+    """Tier 2: calling `resume_deferred_agents()` when `only_names` covered
+    every in-flight agent (or nothing was ever deferred) is a harmless no-op
+    — the sweep must not raise or attempt to build anything."""
+    monkeypatch.chdir(tmp_path)
+    state_log = _seed_two_in_flight_agents(tmp_path)
+    registry = _registry(tmp_path, state_log)
+    await registry.restore_all()  # only_names=None — everyone eager already
+
+    resumed = await registry.resume_deferred_agents()
+
+    assert resumed == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[e2e-coder]** — #3671 P4 item C-1（A→C→Dの2番目、単独PR）。**v2（owner裁定反映済み）**: 「触られたagentだけ再開」→「全agent再開、ただし起動は待たせない」に作り直しました。

## owner裁定（v1からの変更点）

v1（初版）は対象外agentを**永久に**（誰にも触られなければ）再開しない設計でした。lead-coderのレビューでcrash-recovery意味論の変更として明示的にflagされ、owner確認を仰いだ結果:

> owner:「**全agent再開したいけど、それを待つ必要はないよ**」

## v2の設計

```
現状(pre-C-1): restore_all() → 全in-flight agentをunconditionalにbuild+run（agent数比例、対象外含む）
v1(reverted):  restore_all(only_names={target}) → 対象外は誰かに触られるまで永久に再開しない
v2(本PR):      restore_all(only_names={target}) → 対象agentのみ即座にbuild+run
               attach(target) 完了（has_session()==True）
               registry.resume_deferred_agents() → 対象外を全てbackgroundで再開（順序: 対象agentが先、残りはその後）
```

- `AgentRegistry.resume_deferred_agents()`（新規）: `_pending_restore`に溜まった対象外agentを1つずつ`get_or_load`+`restore_state`+`ensure_running`——**pre-C-1のstep5が全員に対してやっていたのと同じ処理**を、タイミングだけ`attach()`完了後にずらして実施
- 各agentの処理後に`await asyncio.sleep(0)`——sweepがクライアントの初回描画/入力処理とCPUを奪い合わないよう明示的にyield
- `chat.py`の`_background_attach`: `attach(name)`成功後に`resume_deferred_agents()`を呼ぶ（失敗は対象agentのattach失敗とは別扱い——`record_background_attach_error`は使わず単独でログ）
- `--once`パスは**意図的に**`resume_deferred_agents()`を呼びません（保護すべき継続的クライアントが無く、`_run_once`直後に`registry.shutdown()`でプロセスが終了するため。対象外agentの状態はdisk上に残り、次回のrunで再度restorable）

## 2経路の共存（lead-coderレビューで指摘・対応済み）

★ **`_pending_restore`に到達する経路は2つ**あります: ①`resume_deferred_agents()`のsweep、②`get_or_load`の既存on-demandフック。P2設計によりクライアントは既に描画中でsweepと並行動作するため、②は**実際に到達可能**（ユーザーの`/attach beta`やdelegationの`ensure_running`がsweepより先に届きうる）——「宣言はあるが到達しない分岐」ではありません。両方残し、以下で安全性を確保:

- 両経路とも同一の`self._pending_restore.pop(key, None)`が唯一のgate——**同期呼び出し内で完結し、awaitで中断されない**（asyncio単一イベントループの協調的スケジューリング前提。★実スレッドでの安全性主張ではない、とテスト・実装両方のdocstringに明記）
- `attach()`/`ensure_running()`は各々**独立に**自分のrun-task生成を`_tasks`辞書チェックでガードしており、二重pop以外の経路からの二重起動も防止

## テスト（8本、`tests/test_registry_restore_all_only_names_3671_p4c1.py`）

- `only_names={"alpha"}`: alpha即座にbuild、betaは`restore_all()`直後にはまだbuildされない（順序witness、v1から継続）
- **`resume_deferred_agents()`が実際にbetaを再開する**（v2の核心witness、resumed==["beta"]・stranded interventionが実際にqueueへ届く）
- **race安全性**: betaを先にattachしてからsweepを走らせても、二重restore/二重task生成が起きない（interventionの重複が無いことで実測）
- `resume_deferred_agents()`が何もpendingが無ければno-op
- `only_names=None`で従来通り全員eager build——regression guard
- deferred agentがattach/ensure_running（on-demand経路）でも正しく再開される（v1から継続）

RED-before-fix: v1→v2の差分部分（`resume_deferred_agents`関連4本）はstashでシグネチャ不在の`AttributeError`を確認。

## CI

- ruff: green
- `test_tier_audit.py --strict`: green
- `verify_module_docstrings.py`: green
- 関連既存テスト67件（P1/P2/P3/A-4、intervention/multi-session restore、pipeline is4等）green
- full suite: 9767 passed / 18 failed（1件は`test_plugin_install.py`——単独実行で再現せずflaky確認済み、実質前PR群と同一baseline）/ 65 skipped / 14 errors

Part of #3671 (P4 — C-1完了。次はC-2)