### PR TITLE
fix(#3671): report startup timing even when the operator interrupts

### DIFF
--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -446,6 +446,25 @@ def _report_startup_timing() -> None:
 
 
 def run(args: argparse.Namespace) -> None:
+    """Entry point — wraps the whole startup so the timing report always lands.
+
+    #3671: the report exists for someone whose startup takes minutes, and what
+    that person does is press Ctrl-C. Measured: the interrupt arrives wherever
+    the startup happens to be. A first attempt guarded only the final
+    ``run_async`` call, and a Ctrl-C during registry construction — several
+    steps earlier — still printed nothing. Whatever stage is slow IS the stage
+    the interrupt lands in, so the guard has to cover all of them.
+
+    ``finally`` rather than ``except KeyboardInterrupt``: a startup that dies on
+    an exception is also one someone wants the numbers for.
+    """
+    try:
+        _run(args)
+    finally:
+        _report_startup_timing()
+
+
+def _run(args: argparse.Namespace) -> None:
     # ADR-0039 P3: `--connect <url>` short-circuits to the remote thin client
     # before any local session machinery is built (the remote server owns the
     # session; this process is pure I/O).
@@ -817,4 +836,3 @@ def run(args: argparse.Namespace) -> None:
             await asyncio.shield(attach_task)
 
     run_async(_main_chat())
-    _report_startup_timing()

--- a/tests/test_startup_timing_3671.py
+++ b/tests/test_startup_timing_3671.py
@@ -167,3 +167,61 @@ def test_a_startup_that_never_reached_a_frame_still_reports(monkeypatch) -> None
     monkeypatch.setattr(startup_timing, "_FIRST_FRAME_AT", None)
 
     assert startup_timing.process_elapsed_seconds() > 0
+
+
+def test_the_report_survives_an_interrupt(monkeypatch, capsys) -> None:
+    """Tier 2: Ctrl-C during startup still prints the breakdown.
+
+    This is the case the whole feature exists for. Someone whose startup takes
+    minutes presses Ctrl-C, and an unguarded report would withhold the numbers
+    from exactly that person, in exactly that situation — the "a tool is
+    unreachable at the moment it was built for" shape this repo keeps finding.
+
+    Measured while fixing it: guarding only the final `run_async` call was not
+    enough. An interrupt during registry construction, several steps earlier,
+    still printed nothing — whatever stage is slow IS the stage the interrupt
+    lands in. Hence the guard wraps the whole of `run`.
+    """
+    import argparse
+
+    from reyn.interfaces.cli.commands import chat as chat_cmd
+
+    monkeypatch.setenv("REYN_STARTUP_TIMING", "1")
+
+    def _interrupted(_args: argparse.Namespace) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(chat_cmd, "_run", _interrupted)
+
+    try:
+        chat_cmd.run(argparse.Namespace())
+    except KeyboardInterrupt:
+        pass
+
+    assert "startup timing" in capsys.readouterr().out
+
+
+def test_the_report_survives_an_exception(monkeypatch, capsys) -> None:
+    """Tier 2: a startup that dies still reports.
+
+    `finally` rather than `except KeyboardInterrupt`, because a crash is also a
+    startup someone wants the numbers for — and it is the case where "how far
+    did it get" is hardest to reconstruct afterwards.
+    """
+    import argparse
+
+    from reyn.interfaces.cli.commands import chat as chat_cmd
+
+    monkeypatch.setenv("REYN_STARTUP_TIMING", "1")
+
+    def _boom(_args: argparse.Namespace) -> None:
+        raise RuntimeError("startup blew up")
+
+    monkeypatch.setattr(chat_cmd, "_run", _boom)
+
+    try:
+        chat_cmd.run(argparse.Namespace())
+    except RuntimeError:
+        pass
+
+    assert "startup timing" in capsys.readouterr().out


### PR DESCRIPTION
**[tui-coder]** — Fixes the defect lead-coder found by **running main**, not by reading the PR. Thank you for that — the numbers in my PR body were from a `/quit` exit, which is not what the person this is for will do.

## The defect

```python
run_async(_main_chat())
_report_startup_timing()      # ← no guard
```

The report exists for someone whose startup takes **minutes**. What that person does is press **Ctrl-C** — and the interrupt skips straight past the call. ★ **The tool withheld its numbers from exactly the person it was built for, in exactly the situation it was built for.**

Same shape as everything else tracked today: a mechanism that exists and is unreachable at the moment it is for.

## Guarding `run_async` alone was not enough — measured, not assumed

My first fix wrapped only that call. I then made startup artificially slow and interrupted it **during registry construction**, several steps earlier:

```
^CTraceback (most recent call last):
  ...
  File "chat.py", line 587, in run
KeyboardInterrupt
```

**No report.** The interrupt never reached the guard, because the slow part was upstream of it.

★ **Whatever stage is slow IS the stage the interrupt lands in.** On the reporter's machine the slow stage is unknown — that is the entire point of the feature — so the guard has to cover all of them. `run()` is now a wrapper whose `finally` always reports; the body moved to `_run()`.

## Verified in a real terminal

Startup slowed artificially, Ctrl-C mid-way, before the TUI ever appeared:

```
^Cstartup timing (REYN_STARTUP_TIMING=1)
  import         0.00s    0.0%
  config         0.00s    0.1%
  registry       0.00s    0.0%
  ...
  unaccounted    5.36s   99.9%
  TOTAL          5.37s
```

The 99.9% is the injected delay, correctly attributed to no declared stage.

## `finally`, not `except KeyboardInterrupt`

A startup that dies on an exception is also one someone wants the numbers for — and it is the case where *"how far did it get"* is hardest to reconstruct afterwards. Both paths are tested.

## On your correction

You told the owner "the table appears after startup" when it is **after exit**. Worth noting the asymmetry that creates: with this fix, `/quit` and Ctrl-C both produce it, so the instruction can simply be *"exit however you like"*. The workaround you gave them is no longer needed.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` — 0 errors
- [x] `verify_module_docstrings.py` — OK
- [x] `pytest tests/test_startup_timing_3671.py` — **12 passed** (2 new: interrupt, exception)
- [x] **Real terminal, real interrupt mid-startup** — output above
- [x] Falsification: removing the `finally` turns both new tests red, the other 10 stay green

🤖 Generated with [Claude Code](https://claude.com/claude-code)