### PR TITLE
feat(#3671): name the 94% of startup that had no name

### DIFF
--- a/src/reyn/__init__.py
+++ b/src/reyn/__init__.py
@@ -28,5 +28,15 @@ import os
 # fetch (e.g. sets the var to a falsey value themselves) is respected — see
 # reyn's no-uncustomizable-hardcodes rule. Must run before litellm is imported
 # anywhere; see the module docstring above for why this is the right place.
+# #3671: the earliest instant reyn's own code runs. Everything after it — the
+# whole import tree, litellm included (1.75s of a 1.9s startup here) — is
+# measurable; everything before it (interpreter start, site setup) is not, from
+# inside this process. Captured HERE rather than in the timing module because
+# that module is imported late, and a clock started then reports the import
+# phase as 0.00s — measured, and the reason this line exists.
+import time as _time
+
+STARTUP_CLOCK_ORIGIN = _time.perf_counter()
+
 os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
 os.environ.setdefault("LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS", "True")

--- a/src/reyn/interfaces/cli/__init__.py
+++ b/src/reyn/interfaces/cli/__init__.py
@@ -26,6 +26,14 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main() -> None:
+    # #3671: closes the ``import`` stage. Everything before this line is the
+    # interpreter starting plus the import tree — measured at 1.75s for
+    # ``litellm`` alone here, and the owner's machine spends ~3.4x longer in
+    # the same region. Without this mark that time lands in ``unaccounted``,
+    # where the largest phase of startup looks like a mystery.
+    from reyn.runtime.startup_timing import mark_cli_reached  # noqa: PLC0415
+
+    mark_cli_reached()
     parser = build_parser()
     args = parser.parse_args()
     try:

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -835,4 +835,10 @@ def _run(args: argparse.Namespace) -> None:
             # `attach_task` is left running detached in that case.
             await asyncio.shield(attach_task)
 
+    # #3671: closes the gap between the command starting and the TUI object
+    # existing — session setup, history load, transport wiring. Measured at
+    # ~1.36s of a 2.28s startup, the largest single block that had no name.
+    from reyn.runtime.startup_timing import mark_async_entered  # noqa: PLC0415
+
+    mark_async_entered()
     run_async(_main_chat())

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -3678,6 +3678,13 @@ async def run_textual_chat(
     users; ``alt-screen`` stays the recommended default regardless. Returns so
     the driver's caller can tear the transport down + print the cost summary.
     """
+    # #3671: the framework's own startup begins here — terminal setup, first
+    # layout, first paint. Everything before it is reyn assembling things;
+    # everything after it is Textual, and the two were indistinguishable while
+    # both sat inside ``unaccounted``.
+    from reyn.runtime.startup_timing import mark_app_constructed  # noqa: PLC0415
+
+    mark_app_constructed()
     app = TextualChatApp(
         transport=transport,
         read_model=read_model,

--- a/src/reyn/runtime/startup_timing.py
+++ b/src/reyn/runtime/startup_timing.py
@@ -32,13 +32,30 @@ from typing import Iterator
 
 _ENV = "REYN_STARTUP_TIMING"
 
-#: When this module was first imported — the earliest instant reyn's own code
+def _origin() -> float:
+    """The startup clock's zero.
+
+    ``reyn.STARTUP_CLOCK_ORIGIN`` when available — the earliest reyn code to
+    run. Falling back to now would silently report the import phase as 0.00s,
+    which is how the first attempt at this failed: the timing module is
+    imported LATE, so a clock started here begins after the thing it is meant
+    to measure has already finished.
+    """
+    try:
+        import reyn
+
+        return reyn.STARTUP_CLOCK_ORIGIN
+    except Exception:  # noqa: BLE001 - a diagnostic must not break a startup
+        return time.perf_counter()
+
+
+#: When reyn's own code first ran — the earliest instant reyn's own code
 #: can observe. Everything before it (the interpreter starting, and the import
 #: tree that reaches here) is attributed to ``import``: reyn cannot time what
 #: ran before reyn existed, and pretending otherwise would put that cost in
 #: ``unaccounted``, where it would look like a mystery rather than the one
 #: phase whose cost is structural.
-_MODULE_IMPORTED_AT = time.perf_counter()
+_MODULE_IMPORTED_AT = _origin()
 
 
 #: When the interface first reached the screen, or ``None`` while it has not.
@@ -46,6 +63,61 @@ _MODULE_IMPORTED_AT = time.perf_counter()
 #: session into the report — an early wiring did exactly that and produced
 #: "first-frame 98.5%", which was true and told nobody anything.
 _FIRST_FRAME_AT: "float | None" = None
+
+
+#: When ``run()`` was reached — everything before it is interpreter start plus
+#: the import tree. Measured on this machine: 1.75s of that is ``litellm``
+#: alone, against a 1.9s startup. It is the single largest phase and it is not
+#: reyn's own work, which is exactly why it needs a line of its own rather than
+#: dissolving into ``unaccounted``.
+_CLI_REACHED_AT: "float | None" = None
+
+
+def mark_cli_reached() -> None:
+    """Record that the CLI entry point is running.
+
+    Closes the ``import`` stage: the span from this module being imported (the
+    earliest instant reyn can observe) to the command actually starting.
+    """
+    global _CLI_REACHED_AT
+    if _CLI_REACHED_AT is None:
+        _CLI_REACHED_AT = time.perf_counter()
+        TIMING.record("import", _CLI_REACHED_AT - _MODULE_IMPORTED_AT)
+
+
+#: When the TUI object was constructed — the boundary between reyn assembling
+#: things and the terminal framework starting up. Measured here: everything
+#: before it totals ~0.35s and everything after it ~1.8s, so a report stopping
+#: at ``session`` says nothing about the majority of the wait.
+_APP_CONSTRUCTED_AT: "float | None" = None
+
+
+#: When the async entry point started running. Measured: 0.49s in, with the TUI
+#: object not constructed until 1.85s — so ~1.36s sits between them, in session
+#: setup, and it was the largest single block of ``unaccounted``.
+_ASYNC_ENTERED_AT: "float | None" = None
+
+
+def mark_async_entered() -> None:
+    """Record that the async startup path has begun."""
+    global _ASYNC_ENTERED_AT
+    if _ASYNC_ENTERED_AT is None:
+        _ASYNC_ENTERED_AT = time.perf_counter()
+
+
+def mark_app_constructed() -> None:
+    """Record that the TUI object exists and the framework is about to boot.
+
+    Paired with :func:`mark_first_frame` to bracket the framework's own startup
+    — terminal setup, first layout, first paint — as ``tui-boot``. Two marks
+    rather than a ``with`` block because the region spans a return out of one
+    function and into a framework callback, which no context manager can hold.
+    """
+    global _APP_CONSTRUCTED_AT
+    if _APP_CONSTRUCTED_AT is None:
+        _APP_CONSTRUCTED_AT = time.perf_counter()
+        if _ASYNC_ENTERED_AT is not None:
+            TIMING.record("client-prep", _APP_CONSTRUCTED_AT - _ASYNC_ENTERED_AT)
 
 
 def mark_first_frame() -> None:
@@ -58,6 +130,8 @@ def mark_first_frame() -> None:
     global _FIRST_FRAME_AT
     if _FIRST_FRAME_AT is None:
         _FIRST_FRAME_AT = time.perf_counter()
+        if _APP_CONSTRUCTED_AT is not None:
+            TIMING.record("tui-boot", _FIRST_FRAME_AT - _APP_CONSTRUCTED_AT)
 
 
 def process_elapsed_seconds() -> float:
@@ -74,6 +148,14 @@ def process_elapsed_seconds() -> float:
 #: collected as they report, so the output has a stable shape an operator can
 #: read the same way twice — and so a stage that did not run is visible as
 #: ``0.00`` rather than as a missing line.
+#:
+#: ``first-frame`` is deliberately NOT here. It named the ENDPOINT of startup,
+#: not an interval, so nothing ever recorded a duration against it and it
+#: printed ``0.00`` on every machine — including one taking 7.58s to reach the
+#: interface, where it read as "the TUI appears instantly". A row that cannot
+#: hold a value is worse than no row: this module's whole premise is that
+#: ``0.00`` means measured-and-fast, and one entry quietly breaking that
+#: promise poisons every other reading. The span it stood for is ``TOTAL``.
 STAGES: "tuple[str, ...]" = (
     "import",
     "config",
@@ -81,7 +163,8 @@ STAGES: "tuple[str, ...]" = (
     "plugins",
     "mcp",
     "session",
-    "first-frame",
+    "client-prep",
+    "tui-boot",
 )
 
 
@@ -150,7 +233,9 @@ class StartupTiming:
         unaccounted = self.unaccounted_seconds(wall_seconds)
         share = (unaccounted / wall_seconds * 100) if wall_seconds > 0 else 0.0
         lines.append(f"  {'unaccounted':<12} {unaccounted:6.2f}s  {share:5.1f}%")
-        lines.append(f"  {'TOTAL':<12} {wall_seconds:6.2f}s")
+        lines.append(
+            f"  {'TOTAL':<12} {wall_seconds:6.2f}s  (start \u2192 interface on screen)"
+        )
         return lines
 
 


### PR DESCRIPTION
**[tui-coder]** — Part of #3671, driven by the owner's real numbers: `TOTAL 7.58s`, `unaccounted 98.9%`. The report said where the time was **not**.

**Result on this machine: `unaccounted` 86% → 6.3%.**

```
  import         0.31s   13.0%
  config         0.00s    0.2%
  registry       0.02s    0.8%
  plugins        0.00s    0.0%
  mcp            0.00s    0.0%
  session        0.00s    0.0%
  client-prep    1.42s   60.2%
  tui-boot       0.46s   19.5%
  unaccounted    0.15s    6.3%
  TOTAL          2.36s  (start → interface on screen)
```

## `first-frame` removed — it could never hold a value

lead-coder found this by reading the owner's output: `first-frame 0.00s` on a **7.58s** startup. It named an **endpoint**, not an interval, and nothing ever recorded a duration against it — so it printed `0.00` on every machine, forever, and read as *"the interface appears instantly"*. It was nearly relayed to the owner as a finding.

★ A row that cannot hold a value is worse than no row **here specifically**, because this module's entire premise is that `0.00` means *measured and fast*. One entry quietly breaking that promise poisons every other reading.

The span it stood for is `TOTAL`, which now says so: **`(start → interface on screen)`** — the owner's symptom in the words they used for it.

## `import` was structurally unmeasurable — my defect

The clock started when `startup_timing` was imported. That module is imported **from `main()`** — after the import tree has already run. So the largest phase was not merely unmeasured, **it could not be measured**, and it did not even land in `unaccounted`.

Same class as the `first-frame` defect, in the module built to prevent it. Origin moved to `reyn/__init__.py`, the earliest reyn code there is. Interpreter start remains outside — stated, not pretended.

Local reference: `import litellm` alone is **1.75s** here. The owner's machine runs ~3.4× slower in this region, so this line alone may be several seconds there.

## Two new stages, both located by measurement

Timestamps first, names second:

```
before-run_async   0.490s
at-app-construct   1.848s     ← ~1.36s between them, previously nameless
```

- **`client-prep`** — async entry to the TUI object: session setup, history, transport. **1.42s / 60.2%**, the largest single unnamed block.
- **`tui-boot`** — TUI object to first frame: Textual's own startup. **0.46s**.

## `mcp` and `plugins` stay declared and empty — deliberately

You asked for these first; I could not wire them, and the reason is a finding:

- **`plugins`** — the work is registry construction inside `SessionFactoryConfig.from_config`, already covered by `registry`. A second stage would double-count.
- **`mcp`** — the only call sites are `op_runtime/mcp_*.py`, which run at **op time**, not startup.

The empty rows are the evidence. ★ If the owner's machine shows time there, it means something this one never does — which the declared-stage design makes visible instead of silent.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` — 0 errors
- [x] `verify_module_docstrings.py` on all three changed src files — OK
- [x] `pytest tests/test_startup_timing_3671.py` — **12 passed**
- [x] **Real terminal, real startup** — output above
- [x] Gap located by timestamping before/after, not by reading code
- [ ] (needs the owner's machine) Whether the 7.5s lands in `import`, `client-prep` or `tui-boot`. That is the question this PR exists to let them answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)