### PR TITLE
fix(#3523): let the search count and the rewind heading recede

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/palette.py
+++ b/src/reyn/interfaces/inline/textual_chat/palette.py
@@ -54,6 +54,13 @@ TOKENS: "dict[str, str]" = {
     #: read as a divider against BOTH terminal grounds; a theme variable would
     #: follow the theme and vanish into one of them.
     "@rule@": "#3d434f",
+    #: Text that should recede: a count the interface produced, a heading that
+    #: labels a region. An SGR ATTRIBUTE, not a colour — under the ansi themes
+    #: ``$text-muted`` resolves to the same ``ansi_default`` marker as ordinary
+    #: text, so it recedes by exactly nothing (measured on #3522/#3528). ``dim``
+    #: leaves the hue to the terminal, which is the operator's to choose, and
+    #: actually changes what is drawn.
+    "@recede@": "dim",
     #: The selected row in a list the operator navigates (the sent-queue).
     #: ``bold`` rather than a background: a filled block is what
     #: ``$accent 30%`` produced once alpha was dropped — a solid ANSI-green bar

--- a/src/reyn/interfaces/inline/textual_chat/rewind_picker.py
+++ b/src/reyn/interfaces/inline/textual_chat/rewind_picker.py
@@ -86,7 +86,12 @@ class RewindPicker(Vertical):
         border: none;
         padding: 0;
     }
+    /* #3523 ②: a heading should look like a heading — it labels the rows
+       below it rather than competing with them. `dim` leaves the hue to the
+       terminal (the owner's rule: adopt the meaning the terminal already has)
+       instead of pinning a colour. */
     RewindPicker #rewind-picker-title {
+        text-style: @recede@;
         height: auto;
         color: @quiet@;
         padding: 0 1;

--- a/src/reyn/interfaces/inline/textual_chat/search_bar.py
+++ b/src/reyn/interfaces/inline/textual_chat/search_bar.py
@@ -59,7 +59,11 @@ class SearchBar(Horizontal):
     SearchBar #search-count {
         width: auto;
         height: 1;
-        color: @quiet@;
+        /* #3523 ①: the count is the interface answering, not what the operator
+           typed — `alpha 1/1` should not read as two equal halves. `dim` rather
+           than a muted colour because under the ansi themes `$text-muted` is
+           the same marker as ordinary text and receded by nothing. */
+        text-style: @recede@;
         padding: 0 0 0 1;
     }
     """)

--- a/tests/test_recede_dim_3523.py
+++ b/tests/test_recede_dim_3523.py
@@ -1,0 +1,79 @@
+"""Tier 2: two pieces of interface text recede, without pinning a colour.
+
+#3523, owner-adjudicated: the search bar's match count (`alpha 1/1`) reads as
+two equal halves, so what the operator typed and what the interface answered
+look alike; and `/rewind`'s heading competes with the rows it labels.
+
+Both already asked for `$text-muted`, which under the `ansi-*` themes resolves
+to the same `ansi_default` marker as ordinary text — measured on #3522/#3528.
+They receded by nothing. `dim` is an SGR attribute: it changes what is drawn
+and leaves the hue to the terminal, which is the owner's standing rule — adopt
+the meaning the terminal already has rather than inventing one.
+
+The assertions read the RESOLVED style rather than the stylesheet text, because
+"the rule is present" and "the rule does anything" are the two things #3522
+showed can differ.
+"""
+from __future__ import annotations
+
+import pytest
+from textual.app import App, ComposeResult
+
+from reyn.interfaces.inline.textual_chat.palette import TOKENS
+from reyn.interfaces.inline.textual_chat.rewind_picker import RewindPicker
+from reyn.interfaces.inline.textual_chat.search_bar import SearchBar
+
+
+class _Probe(App):
+    def compose(self) -> ComposeResult:
+        yield SearchBar()
+        yield RewindPicker()
+
+
+def test_the_recede_token_is_an_attribute_not_a_colour() -> None:
+    """Tier 2: the token pins no hue.
+
+    A colour here would be the defect these two changes exist to avoid — under
+    a themed terminal it either does nothing or overrides a choice that is the
+    operator's to make.
+    """
+    assert TOKENS["@recede@"] == "dim"
+
+
+@pytest.mark.asyncio
+async def test_the_match_count_recedes_under_the_ansi_theme() -> None:
+    """Tier 2: `1/1` is dimmed where `$text-muted` did nothing.
+
+    Asserted under `ansi-dark` specifically: that is the theme where the old
+    rule was inert, so a test under any other theme would pass without
+    witnessing the fix.
+    """
+    app = _Probe()
+    async with app.run_test() as pilot:
+        app.theme = "ansi-dark"
+        await pilot.pause()
+
+        assert "dim" in str(app.query_one("#search-count").styles.text_style)
+
+
+@pytest.mark.asyncio
+async def test_the_rewind_heading_recedes_and_keeps_the_terminal_colours() -> None:
+    """Tier 2: the heading dims, and no foreground or background is pinned.
+
+    Checked on the rendered segment rather than on the style object — what
+    reaches the terminal is the thing the owner sees, and a rule can resolve
+    correctly while something downstream paints over it.
+    """
+    app = _Probe()
+    async with app.run_test(size=(80, 20)) as pilot:
+        app.theme = "ansi-dark"
+        app.query_one(RewindPicker).display = True
+        await pilot.pause()
+
+        segment = next(iter(app.query_one("#rewind-picker-title").render_line(0)))
+        style = str(segment.style)
+
+        assert "dim" in style
+        assert "default on default" in style, (
+            f"the heading pinned a colour instead of dimming: {style}"
+        )


### PR DESCRIPTION
**[tui-coder]** — Owner-adjudicated (「直して。」). The two sites narrowed by the operation-words test; the other four stay as they are.

## What you will see

**① Search bar** — the count is the interface answering, not what you typed:

```
before   ❯ alpha                    1/1        ← both at full strength
after    ❯ alpha                    1/1        ← the count dimmed
```

**② `/rewind`** — the heading labels the rows instead of competing with them:

```
before   rewind to a checkpoint (Enter to check out · Esc to cancel)
         12  2026-08-04 10:22  turn boundary
         11  2026-08-04 10:19  turn boundary

after    rewind to a checkpoint (Enter to check out · Esc to cancel)   ← dimmed
         12  2026-08-04 10:22  turn boundary
         11  2026-08-04 10:19  turn boundary
```

In both cases only the **brightness** changes. The hue stays whatever your terminal chose.

## Why this is a fix and not a preference

Both sites **already asked** to be quiet — they set `color: $text-muted`. Under the `ansi-*` themes that resolves to the same `ansi_default` marker as ordinary text, so they receded by **nothing**. Same trap #3522 and #3528 measured.

The rules were present and inert. `dim` is an SGR attribute: it changes what is drawn, and it leaves the hue to the terminal — your rule, *adopt the meaning the terminal already has*.

## Measured, not asserted

Rendered segment under `ansi-dark`:

```
dim default on default
```

Dimmed, with **no foreground or background pinned**. Falsified by reverting to `color: @quiet@` — the count assertion goes red, which is the whole point: the old rule could not be told from no rule at all.

The token lives in `palette.py` as `@recede@`, so this decision sits in the one file the colour gate checks (#3640).

## Not touched

- The other four #3523 sites — something else already carries the distinction; colour would duplicate it.
- **The sent queue.** My reason for leaving it alone was that sent items sit inside a dim block. ★ **If #3525 decides to drop that block, this premise fails and the queue needs revisiting.** Flagging it here so the dependency is not lost between two issues.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` — 0 errors
- [x] `verify_module_docstrings.py` — OK
- [x] `pytest` on the colour-token gate + search/rewind suites — **171 passed**
- [x] Resolved style asserted under `ansi-dark` specifically — the theme where the old rule was inert, so the test witnesses the fix rather than passing incidentally
- [x] Falsification: reverting to `color: @quiet@` turns the count assertion red
- [ ] (owner gate) Whether it now reads right on your terminal — the rendering is measured, the look is yours to judge

🤖 Generated with [Claude Code](https://claude.com/claude-code)