### PR TITLE
fix(#3542): ask for plain blue on the selection band, not bright blue

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -668,6 +668,20 @@ class TextualChatApp(App):
        not ground. */
     App { background: @app-background@; }
     Screen { layout: vertical; background: transparent; }
+    /* #3542: the drag-selection band. Textual's ansi-dark defaults to
+       `ansi_bright_blue`, which the operator found too loud against the
+       conversation. Dropping to `ansi_blue` asks the terminal for a different
+       one of its sixteen slots — reyn is not overriding the user's colours
+       here and never was, it only picks which frame to request. Declared as an
+       explicit background/foreground PAIR rather than `text-style: reverse`:
+       Textual COMPOSES the selection style onto each cell, so reverse would
+       let every coloured run (tool rows, amber intervention headings, dim
+       chrome) become its own background and the band would fragment — which
+       is a different complaint than "too loud". */
+    Screen > .screen--selection {
+        background: @selection-bg@;
+        color: @selection-fg@;
+    }
     FlowView {
         height: 1fr;
         scrollbar-size-vertical: 0;

--- a/src/reyn/interfaces/inline/textual_chat/palette.py
+++ b/src/reyn/interfaces/inline/textual_chat/palette.py
@@ -61,6 +61,16 @@ TOKENS: "dict[str, str]" = {
     #: the conversation for the same reason (#3490: the mark has to be
     #: CONTENT). Widgets pair this with a marker in the row text.
     "@selected-style@": "bold",
+    #: The drag-selection band. ``ansi_blue`` rather than Textual's default
+    #: ``ansi_bright_blue``: the operator found the bright frame too loud
+    #: against the conversation (#3542). Both are ANSI FRAMES, not colours —
+    #: what blue looks like is the terminal theme's decision and stays that
+    #: way; this only chooses which of the sixteen slots to ask for.
+    "@selection-bg@": "ansi_blue",
+    #: The text inside that band. Unchanged from Textual's default, and named
+    #: here so the pair is legible in one place: a background chosen without
+    #: its foreground beside it is how contrast regressions happen.
+    "@selection-fg@": "ansi_black",
 }
 
 #: The marker a selected row carries in its own text, so selection survives

--- a/tests/test_selection_not_bright_3542.py
+++ b/tests/test_selection_not_bright_3542.py
@@ -1,0 +1,91 @@
+"""Tier 2: the drag-selection band asks for plain blue, not bright blue.
+
+#3542, owner-adjudicated: the selection read as too loud against the
+conversation. Textual's `ansi-dark` defaults `screen-selection-background` to
+`ansi_bright_blue` (slot 12); reyn now asks for `ansi_blue` (slot 4).
+
+Both are ANSI FRAMES, not colours. What blue actually looks like is the
+terminal theme's decision, and it stays that way — reyn was never overriding
+the operator's palette here, it only chooses which of the sixteen slots to
+request. That distinction is what these tests pin: the assertions are on the
+`ansi` slot number, not on RGB, because an RGB assertion would pass while
+quietly meaning reyn had started dictating the colour.
+
+`text-style: reverse` was considered and rejected. Textual COMPOSES the
+selection style onto each cell, so reverse would let every coloured run — tool
+rows, amber intervention headings, dim chrome — become its own background, and
+the band would fragment. That answers a complaint nobody made; the complaint
+was loudness, not uniformity.
+"""
+from __future__ import annotations
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+from reyn.interfaces.inline.textual_chat import palette
+
+#: ANSI slot numbers, named so the assertions below read as intent rather than
+#: as magic numbers. 4 is blue; 12 is its bright counterpart.
+_ANSI_BLUE = 4
+_ANSI_BRIGHT_BLUE = 12
+_ANSI_BLACK = 0
+
+
+class _Probe(App):
+    CSS = palette.css(
+        """
+Screen > .screen--selection {
+    background: @selection-bg@;
+    color: @selection-fg@;
+}
+"""
+    )
+
+    def compose(self) -> ComposeResult:
+        yield Static("x")
+
+
+def test_the_tokens_name_ansi_frames_not_colours() -> None:
+    """Tier 2: the palette asks for slots, so the terminal keeps deciding.
+
+    A hex value here would look equivalent and would take the choice away from
+    the operator's theme — the thing this change is careful NOT to do.
+    """
+    assert palette.TOKENS["@selection-bg@"] == "ansi_blue"
+    assert palette.TOKENS["@selection-fg@"] == "ansi_black"
+
+
+@pytest.mark.asyncio
+async def test_the_selection_resolves_to_plain_blue_under_ansi_dark() -> None:
+    """Tier 2: the band lands on slot 4, not Textual's default slot 12.
+
+    Asserted on the resolved component style rather than on the stylesheet
+    text: a rule can be present and lose to something later in the cascade,
+    which is the failure mode this repo keeps finding.
+    """
+    app = _Probe()
+    async with app.run_test(size=(40, 10)) as pilot:
+        app.theme = "ansi-dark"
+        await pilot.pause()
+
+        styles = app.screen.get_component_styles("screen--selection")
+
+        assert styles.background.ansi == _ANSI_BLUE
+        assert styles.background.ansi != _ANSI_BRIGHT_BLUE
+
+
+@pytest.mark.asyncio
+async def test_the_text_inside_the_band_is_unchanged() -> None:
+    """Tier 2: only the background moved.
+
+    Pinned because changing a background without its foreground is how a
+    readable pair turns into an unreadable one — and the fix for "too loud"
+    must not become "now I cannot read it".
+    """
+    app = _Probe()
+    async with app.run_test(size=(40, 10)) as pilot:
+        app.theme = "ansi-dark"
+        await pilot.pause()
+
+        assert app.screen.get_component_styles("screen--selection").color.ansi == _ANSI_BLACK


### PR DESCRIPTION
**[tui-coder]** — Owner-adjudicated (「a で進めて」). Selection background `ansi_bright_blue` → `ansi_blue`; foreground unchanged.

## What you will see

Drag-select across the conversation:

```
before   ████ the selected text ████     ← bright blue band (ANSI slot 12)
after    ▓▓▓▓ the selected text ▓▓▓▓     ← plain blue band  (ANSI slot 4)
```

Same shape, same black text inside, **one step down in loudness**. Whether that blue is navy, slate or something else is still your terminal theme's call — the change only picks which of the sixteen slots reyn asks for.

## reyn was never overriding your colours

Worth stating plainly, because the earlier framing had it backwards. `ansi-dark` ships:

```
screen-selection-background: ansi_bright_blue
screen-selection-foreground: ansi_black
```

Those are **ANSI frames**, not hex. reyn chooses the slot; the terminal decides what it looks like. That is why the tests assert `styles.background.ansi == 4` rather than an RGB triple — ★ **an RGB assertion would pass while quietly meaning reyn had started dictating the colour.**

## Why not `text-style: reverse`

Textual **composes** the selection style onto each cell. With reverse, every coloured run — tool rows, amber intervention headings, dim chrome — would become its own background, and the band would fragment across the selection.

★ That answers a complaint nobody made. The report was **too loud**, not *too uniform*; the current explicit pair is what keeps the band even, and it should stay.

## Measured

Resolved component style under `ansi-dark`:

```
background  Color(0, 0, 128, ansi=4)      ← was ansi=12
foreground  Color(0, 0, 0, ansi=0)        ← unchanged
```

Falsified by restoring `ansi_bright_blue`: two of the three tests go red.

## Notes

- Tokens live in `palette.py`, so this sits in the one file the colour gate checks — **with the foreground named beside the background**, because a background changed without its pair is how a readable combination turns unreadable.
- ★ **#3525 should be closable after this.** Its premise was that reyn overrides the terminal and would need `OSC 17;?` to ask what the real selection colour is. It does not override, so there is nothing to ask.
- #3523's four deferred sites are unaffected — the dim block those depend on is untouched here.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` — 0 errors
- [x] `verify_module_docstrings.py` — OK
- [x] `pytest` selection + colour-token gate — 8 passed
- [x] Resolved style measured under `ansi-dark` (above), asserted on the ANSI slot rather than RGB
- [x] Falsification: restoring bright blue turns two tests red
- [ ] (owner gate) Whether it now sits right against the conversation — the slot is measured, the look is yours

🤖 Generated with [Claude Code](https://claude.com/claude-code)