### PR TITLE
fix(#3688): stop the sent queue from silently clipping what was just sent

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2812,6 +2812,20 @@ class TextualChatApp(App):
         if applied and msg_id:
             self._queue_item_meta[msg_id] = dict(data.get("meta") or {})
             self._sent_queue.show_item(msg_id, text)
+        elif not applied:
+            # #3688: the rejecting branch used to be pure absence — no row, no
+            # log, no trace of any kind. "The server dropped it", "the gate
+            # superseded it" and "it has not arrived yet" then look identical
+            # to the operator AND to anyone investigating, which is what made
+            # the owner's report expensive to attribute. The gate rejecting a
+            # stale delta is legitimate and stays silent to the operator; it
+            # stops being invisible to the LOG, which is the surface an
+            # investigation reads.
+            logger.debug(
+                "textual chat: sent-queue gate rejected user_submitted "
+                "msg_id=%s seq=%s (already reflected by a prior snapshot/delta)",
+                msg_id, seq,
+            )
 
     def _handle_turn_started_event(self, event) -> None:
         """PROMOTE exit (#3300 P2b, sent-queue exit contract §6a): a

--- a/src/reyn/interfaces/inline/textual_chat/sent_queue.py
+++ b/src/reyn/interfaces/inline/textual_chat/sent_queue.py
@@ -100,6 +100,18 @@ class SentQueue(Vertical):
     SentQueue {
         height: auto;
         max-height: 6;
+        /* #3688: the cap keeps a long queue from eating the conversation, but
+           WITHOUT this the overflow was CLIPPED — a 7th row was mounted, in the
+           model, ``display=True``, and simply not on screen. Measured before
+           the fix: 9 queued items rendered 6, and the six were the OLDEST, so
+           the row that vanished was always the one the operator had just
+           submitted ("I sent it and it never appeared", owner report). Silent
+           truncation of a region whose whole job is "what you sent is still
+           waiting" is the one thing it must not do. Scrolling keeps every item
+           reachable — including by the up/down/Enter cancel bindings below,
+           which a "show only the newest 6" rule would have cut off from the
+           older items it is most likely to be aimed at. */
+        overflow-y: auto;
         color: @quiet@;
         padding: 0 1;
     }
@@ -156,6 +168,15 @@ class SentQueue(Vertical):
         self.display = True
         self._clamp_selection()
         self._apply_highlight()
+        # #3688: a new row appends at the BOTTOM, i.e. past the cap once the
+        # queue is deeper than the visible window — so without this the item
+        # the operator just submitted is precisely the one they cannot see.
+        # Only when the region is not being navigated: while it holds focus the
+        # selected row owns the viewport (``_apply_highlight`` scrolls to it),
+        # and yanking the view to the bottom mid-navigation would move the
+        # cancel target out from under them.
+        if not self.has_focus:
+            self._bring_into_view(row)
 
     def remove_item(self, msg_id: str) -> None:
         """Remove a queued item's row (the PROMOTE exit or the ``inbox_cancel``
@@ -211,6 +232,22 @@ class SentQueue(Vertical):
             return None
         return order[max(0, min(self._selected_index, len(order) - 1))]
 
+    def _bring_into_view(self, row: Static) -> None:
+        """Scroll ``row`` into the visible window, best-effort.
+
+        Deferred to after the next refresh because a row scrolled to on the
+        same beat it was mounted has no laid-out region yet, so the scroll
+        would target nothing. Guarded because this is a display convenience on
+        a region whose job is to keep showing what is queued — a scroll fault
+        must never take the queue's own rendering down with it."""
+        def _scroll() -> None:
+            try:
+                self.scroll_to_widget(row, animate=False)
+            except Exception:  # noqa: BLE001 — display convenience, never load-bearing
+                pass
+
+        self.call_after_refresh(_scroll)
+
     def _clamp_selection(self) -> None:
         last = max(len(self._rows) - 1, 0)
         self._selected_index = max(0, min(self._selected_index, last))
@@ -229,6 +266,13 @@ class SentQueue(Vertical):
             row.set_class(selected, "-selected")
             lead = f"{palette.SELECTED_MARKER} " if selected else "  "
             row.update(Content(f"{lead}⧗ {self._labels[msg_id]}"))
+            # #3688: with the region scrollable (see the CSS cap above), the
+            # selected row can sit outside the visible six — arrowing onto a row
+            # that stays off screen is the same silent-clip defect wearing a
+            # different hat, since Enter then cancels something the operator
+            # cannot see.
+            if selected:
+                self._bring_into_view(row)
 
     def action_select_prev(self) -> None:
         if self._selected_index > 0:

--- a/tests/test_sent_queue_overflow_visible_3688.py
+++ b/tests/test_sent_queue_overflow_visible_3688.py
@@ -1,0 +1,199 @@
+"""#3688 — a queued item deeper than the sent-queue's height cap stays reachable.
+
+The owner's report was "I sent a message while a reply was streaming and it
+never appeared in the sent queue". Measurement located it here, not in the
+delta path it looked like: the server emitted ``user_submitted`` 0.1 ms after
+the submit, with a ``seq`` that the client's own ``RemoteQueueView`` gate
+ACCEPTS — so the item was in the client's model and its row was mounted with
+``display=True``. ``SentQueue`` capped its height at 6 rows with no
+``overflow-y``, so row 7 onward was simply clipped off the bottom of the
+screen. The six that survived were the OLDEST, which is why the row that
+disappeared was always the one just submitted.
+
+What these gates pin is the BEHAVIOUR ("an item past the cap is still
+reachable on screen"), never the mechanism (no assertion on scroll offsets,
+on the cap being 6, or on which rows happen to be visible at rest) — the cap
+is a layout choice that may change; "nothing is silently hidden" is the
+contract.
+
+Real ``TextualChatApp`` + a real minimal ``ClientTransport`` (the
+``test_3300_p2b_sentqueue_render.py`` helper shape) — no ``unittest.mock``.
+Visibility is read off what the compositor actually put on screen, because the
+whole defect was invisible to every widget-level accessor: ``display`` was
+True, ``rendered_texts()`` listed the row, and the model held the item.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import EventFrame
+from reyn.runtime.outbox import OutboxMessage
+from reyn.schemas.models import Event
+
+
+class QueueTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` fed one frame at a time from a
+    queue (the ``test_3300_p2b_sentqueue_render.py`` helper shape)."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+
+    async def push_event(self, event: Event) -> None:
+        await self._queue.put(EventFrame(event))
+
+    def start(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str) -> None:
+        pass
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        pass
+
+    async def cancel_inflight(self) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+
+
+def _screen_text(app: TextualChatApp) -> str:
+    """Everything the compositor actually painted — the only surface that can
+    tell a clipped row from a drawn one."""
+    return "\n".join(
+        "".join(segment.text for segment in strip)
+        for strip in app.screen._compositor.render_strips()
+    )
+
+
+def _label(index: int) -> str:
+    return f"QUEUED-{index:02d}"
+
+
+async def _queue_n(transport: QueueTransport, pilot, count: int) -> None:
+    for i in range(1, count + 1):
+        await transport.push_event(
+            Event(
+                type="user_submitted",
+                data={
+                    "text": _label(i),
+                    "chain_id": f"c{i}",
+                    "msg_id": f"m{i}",
+                    "seq": i,
+                    "meta": {},
+                },
+            )
+        )
+    for _ in range(6):
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_newest_queued_item_is_on_screen_past_the_height_cap() -> None:
+    """Tier 2: the item submitted LAST is visible on screen even when the queue
+    is deeper than the region's height cap.
+
+    The owner-facing contract: what you just sent is what you most need to see.
+    Before the fix this failed with nine rows in the model and the six OLDEST
+    on screen.
+    """
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _queue_n(transport, pilot, 9)
+
+        sent_queue = app.query_one(SentQueue)
+        assert sent_queue.has_items()
+        newest = _label(9)
+        assert newest in _screen_text(app), (
+            "the most recently queued item is not on screen — a submission that "
+            "is in the model, mounted and display=True but clipped is "
+            "indistinguishable, to the operator, from one the server dropped"
+        )
+
+
+@pytest.mark.asyncio
+async def test_every_queued_item_is_reachable_by_navigating() -> None:
+    """Tier 2: an item outside the visible window can be brought on screen by
+    the region's own up/down selection.
+
+    Enter cancels the selected item, so a selection that lands on a row nobody
+    can see aims a destructive action at an invisible target. Navigating from
+    the newest back to the oldest must surface each one.
+    """
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _queue_n(transport, pilot, 9)
+
+        sent_queue = app.query_one(SentQueue)
+        sent_queue.focus()
+        await pilot.pause()
+
+        # Walk the whole queue; every row must become visible at some point.
+        seen: "set[str]" = set()
+        for _ in range(len(sent_queue.rendered_texts())):
+            await pilot.pause()
+            painted = _screen_text(app)
+            seen.update(_label(i) for i in range(1, 10) if _label(i) in painted)
+            sent_queue.action_select_next()
+        for _ in range(len(sent_queue.rendered_texts())):
+            await pilot.pause()
+            painted = _screen_text(app)
+            seen.update(_label(i) for i in range(1, 10) if _label(i) in painted)
+            sent_queue.action_select_prev()
+        await pilot.pause()
+        seen.update(_label(i) for i in range(1, 10) if _label(i) in _screen_text(app))
+
+        unreachable = sorted({_label(i) for i in range(1, 10)} - seen)
+        assert not unreachable, (
+            "queued items never became visible while navigating the region, so "
+            f"Enter could cancel a row the operator cannot see: {unreachable}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_queue_within_the_cap_still_shows_every_item() -> None:
+    """Tier 2: the fix does not disturb the ordinary case — a queue that fits
+    shows all of its items, unchanged.
+
+    Guards the direction the scroll change could plausibly break: making the
+    region scrollable must not cost the small-queue rendering that already
+    worked.
+    """
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _queue_n(transport, pilot, 3)
+
+        painted = _screen_text(app)
+        missing = [_label(i) for i in range(1, 4) if _label(i) not in painted]
+        assert not missing, f"a queue inside the cap lost rows: {missing}"


### PR DESCRIPTION
**[tui-coder]** — part of #3688

Owner report: 「stream 出力中に次のメッセージ送ったのに sent queue に出てこないね」

## What it actually was

The hypothesis on the issue was the seq gate — that a mid-stream `user_submitted`
loses to the running turn's `turn_started` on the shared counter. **Measured, and
falsified.** On a real `Session` running a real turn:

```
turn_active at submit: True
submit_user_text returned after 0.1 ms   (970 ms before the turn ended)
user_submitted seq=3   (after that turn's turn_started seq=2)
the real RemoteQueueView gate: applied=True → would render ['SECOND MESSAGE']
```

The server is healthy and the gate accepts it. Per the issue's own decision rule,
that puts the defect on the opposite side — the draw.

`SentQueue` capped its height at 6 rows with **no `overflow-y`**, so the overflow
was clipped rather than scrolled. Measured on screen (compositor output, not a
widget accessor):

```
n= 6: model rows=6  ON SCREEN=6  invisible=0
n= 7: model rows=7  ON SCREEN=6  invisible=1
n= 9: model rows=9  ON SCREEN=6  invisible=3   ← visible: the OLDEST six
```

The six that survive are the oldest, so **the row that disappears is always the
one just submitted**. Every widget-level accessor said it was fine — `display`
True, `rendered_texts()` listing the row, the model holding the item — which is
why it read as a dropped delta.

⚠️ **Honest limit**: whether the owner had ≥7 items queued at that moment is
**not verified**. A single queued item stayed visible in every arm tested,
including 80×8 with 200 streamed deltas. So this is a confirmed defect and the
only failure mode I could reproduce, not a proven account of that one instance.
It does line up with the earlier 「sent queue がずっと deque されない」 report
(#3638, closed unreproduced) — a queue already holding stale items is exactly the
precondition.

## What changed

- The cap stays (a long queue must not eat the conversation); the overflow
  **scrolls** instead of being clipped.
- A new row scrolls into view — unless the region is being navigated, where the
  **selected** row owns the viewport instead. `Enter` cancels the selection, so a
  selection nobody can see aims a destructive action at an invisible target.
- The gate's rejecting branch was pure absence — no row, no log, nothing. "the
  server dropped it" / "the gate superseded it" / "it has not arrived yet" were
  indistinguishable to the operator *and* to anyone investigating. It now leaves a
  debug record; a legitimate stale-delta rejection still says nothing to the
  operator.

## How it looks

With 3 queued (unchanged from before):

```
 ▸ ⧗ QUEUED-01
   ⧗ QUEUED-02
   ⧗ QUEUED-03
```

With 9 queued — the newest are on screen, a scrollbar marks that there is more
above (`show_vertical_scrollbar: True`), and the region is still 6 rows tall and
the same width:

```
   ⧗ QUEUED-04
   ⧗ QUEUED-05
   ⧗ QUEUED-06
   ⧗ QUEUED-07
   ⧗ QUEUED-08
   ⧗ QUEUED-09
```

## Test plan

- [x] `tests/test_sent_queue_overflow_visible_3688.py` — 3 gates: the newest item
      is on screen past the cap; every item becomes visible while navigating; a
      queue inside the cap is unchanged.
- [x] **Falsify**: removing `overflow-y: auto` turns the first two RED
      (`invisible: QUEUED-07/08/09`) and leaves the within-cap gate GREEN — so the
      gates are load-bearing and the control is correctly insensitive.
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` on the new file — 3 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py` on both changed src files — OK
- [x] Sent-queue + colour-token suites (59 tests) — green
- [x] Full `pytest` — CI is green on both 3.11 and 3.12. Locally 9975 passed and
      10 failed; the 10 are **byte-identical to what `origin/main` produces on the
      same machine** (`comm` of the two sorted FAILED lists is empty in both
      directions), and CI passes them on main and here alike, so they are an
      artifact of my local environment (textual 8.2.6), not of this change.
- [ ] Visual confirmation by the owner (the "how it looks" section above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
