### PR TITLE
fix(#3695): stop recording an unpriced LLM call as one that cost nothing

### DIFF
--- a/src/reyn/runtime/budget/budget.py
+++ b/src/reyn/runtime/budget/budget.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import time
 from collections import OrderedDict, defaultdict, deque
@@ -39,6 +40,37 @@ from reyn.llm.pricing import (
     estimate_embedding_cost,
     merge_usage_sources,
 )
+
+logger = logging.getLogger(__name__)
+
+#: Models already reported as unpriced (#3695). Once per model per process:
+#: the condition holds for every call to that model, so a per-call warning
+#: would be a flood, and a flood is read as noise and filtered out — which is
+#: indistinguishable from never having warned at all.
+_UNPRICED_MODELS_WARNED: set[str] = set()
+
+
+def _warn_unpriced_model_once(model: str) -> None:
+    """Say once, per model, that its calls are being counted as costing $0.
+
+    The counter (``BudgetTracker.agent_unpriced_calls``) records the fact for
+    a reader that asks; this is the surface for the reader who does not know
+    to ask. The embedding path's equivalent counter has existed for some time
+    and NOTHING under ``interfaces/`` reads it, so a counter alone would
+    reproduce the same silence one level over.
+    """
+    if model in _UNPRICED_MODELS_WARNED:
+        return
+    _UNPRICED_MODELS_WARNED.add(model)
+    logger.warning(
+        "no price is known for model %r — its calls are recorded with tokens "
+        "but $0.00, so the reported cost is a LOWER BOUND, not the amount "
+        "spent. reyn reads litellm's bundled cost map "
+        "(LITELLM_LOCAL_MODEL_COST_MAP), so a model newer than that snapshot "
+        "stays unpriced.",
+        model,
+    )
+
 
 # ── exceptions ──────────────────────────────────────────────────────────────
 
@@ -886,6 +918,29 @@ class BudgetTracker:
         self._config = config
         self._agent_tokens: dict[str, int] = defaultdict(int)
         self._agent_cost_usd: dict[str, float] = defaultdict(float)
+        # #3695: how many of this agent's calls had NO price, so a reader can
+        # tell "$0.00 because these calls were free" from "$0.00 because we do
+        # not know what they cost". ``estimate_cost`` returns None for an
+        # unpriced model precisely so the two stay distinguishable
+        # (``pricing.py``: "unknown != free"), and ``record_llm`` then folded
+        # that None into 0.0 — every call adding exactly nothing to a total
+        # that still presented itself as the amount spent. Reported live by
+        # the owner: a model absent from litellm's cost map (which reyn pins
+        # to the bundled snapshot, so a NEW model is unpriced permanently)
+        # left the cost figure frozen at its last hydrated value all day.
+        #
+        # This is the mechanism the embedding path already applies
+        # (``EmbeddingCost.unpriced_calls``, "visible, not a silent $0.00") —
+        # applied here, not invented.
+        #
+        # In-memory only, resetting on restart, for the SAME scope reason
+        # ``_agent_cost_breakdown`` below records: persisting it means
+        # extending the on-disk ledger schema and triggers the CLAUDE.md
+        # recovery-feature gate. The consequence is stated rather than hidden:
+        # after a restart the hydrated total carries no unpriced marker, so
+        # this makes the live session honest and leaves the durable total's
+        # own blindness untouched.
+        self._agent_unpriced_calls: dict[str, int] = defaultdict(int)
         # Cost-panel breakdown (#cost-panel-breakdown): per-agent CostBreakdown
         # (prompt/cache-read/cache-creation/completion + savings), accumulated
         # per call in ``record_llm`` alongside ``_agent_cost_usd``. NOT ledger-
@@ -1293,8 +1348,15 @@ class BudgetTracker:
         self._call_window[model].append(time.monotonic())
 
         warn_dims: list[str] = []
-        cost_usd, _ = estimate_cost(model, usage)
-        cost_usd = cost_usd or 0.0
+        priced_cost_usd, _ = estimate_cost(model, usage)
+        # #3695: keep "unknown" distinguishable from "free" before the fold to
+        # 0.0 below. The fold itself is kept — an unpriced call must still be
+        # counted in tokens, in the ledger and against the period counters —
+        # but the fact that it was unpriced now survives it.
+        unpriced = priced_cost_usd is None
+        cost_usd = priced_cost_usd or 0.0
+        if unpriced and usage.total_tokens:
+            _warn_unpriced_model_once(model)
 
         # #1190 stage (iii): per-purpose attribution for the /budget breakdown.
         if purpose is not None:
@@ -1311,6 +1373,8 @@ class BudgetTracker:
             self._agent_tokens[agent] = new_tokens
             new_cost = self._agent_cost_usd[agent] + cost_usd
             self._agent_cost_usd[agent] = new_cost
+            if unpriced:
+                self._agent_unpriced_calls[agent] += 1
 
             # Cost-panel breakdown accumulation (session/agent/project scope
             # rows). ``estimate_cost_breakdown`` returns None for an unpriced/
@@ -1665,6 +1729,19 @@ class BudgetTracker:
         ``registry.agent_cost_usd`` (#cost-restart), the inline status bar. One counter per agent
         (summed across all its sessions in ``record_llm``), so it never N×-counts multiple sessions."""
         return self._agent_cost_usd.get(agent, 0.0)
+
+    def agent_unpriced_calls(self, agent: str) -> int:
+        """How many of ``agent``'s recorded LLM calls had no known price (#3695).
+
+        Non-zero means ``agent_cost_usd`` is a LOWER BOUND, not the amount
+        spent: those calls contributed 0. A reader that shows the cost without
+        consulting this is stating a total it cannot know — which is what the
+        owner saw as a figure that never moved.
+
+        In-memory for this process only (see ``__init__``), so it describes
+        the calls THIS run recorded, not the hydrated durable total.
+        """
+        return self._agent_unpriced_calls.get(agent, 0)
 
     def agent_tokens(self, agent: str) -> int:
         """All-time cumulative TOTAL tokens for ``agent`` (durable, ledger-hydrated). Total only —

--- a/tests/test_unpriced_llm_cost_visible_3695.py
+++ b/tests/test_unpriced_llm_cost_visible_3695.py
@@ -1,0 +1,152 @@
+"""#3695 — an unpriced model's calls stay distinguishable from free ones.
+
+The owner reported the status bar's cost figure never moving: it showed an old
+hydrated value all day and never grew. Measured cause, in ``record_llm``:
+
+    estimate_cost("gpt-5.6-luna", usage) -> (None, None)     # unpriced
+    estimate_cost("gpt-4o",       usage) -> (0.0075, {...})  # priced
+
+``cost_usd = cost_usd or 0.0`` folded that None to zero, so every call added
+exactly nothing to a total that still presented itself as the amount spent.
+Two lines further down the SAME function skips the cache breakdown for an
+unpriced model rather than treating unknown as free — the same fact handled
+two ways within one function. ``pricing.py`` states the rule outright
+("unknown != free"), and the embedding path already applies the mechanism
+(``EmbeddingCost.unpriced_calls``, "visible, not a silent $0.00"). The LLM
+path did not.
+
+Every gate here pairs the unpriced case with a PRICED CONTROL. Without one,
+"the cost did not grow" passes for a harness that never reached the
+accumulation at all — which is exactly how the first attempt at measuring
+this went (a stub above ``record_llm`` made both models look frozen).
+"""
+from __future__ import annotations
+
+import logging
+
+from reyn.llm.pricing import TokenUsage, estimate_cost
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+
+_PRICED = "gpt-4o"
+_UNPRICED = "reyn-test-model-with-no-price"
+_USAGE = TokenUsage(prompt_tokens=1000, completion_tokens=500)
+
+
+def _tracker() -> BudgetTracker:
+    return BudgetTracker(CostConfig())
+
+
+def test_the_two_models_this_module_relies_on_really_are_priced_and_not() -> None:
+    """Tier 2: the premise every other gate here rests on, asserted directly.
+
+    If the "unpriced" model ever gained a price, or the priced one lost its
+    entry, the rest of this module would keep passing while testing nothing.
+    """
+    assert estimate_cost(_PRICED, _USAGE)[0] is not None
+    assert estimate_cost(_UNPRICED, _USAGE)[0] is None
+
+
+def test_an_unpriced_call_is_counted_while_a_priced_one_is_not() -> None:
+    """Tier 2: the unpriced counter tracks exactly the calls with no price."""
+    priced, unpriced = _tracker(), _tracker()
+
+    for _ in range(3):
+        priced.record_llm(model=_PRICED, agent="a", usage=_USAGE)
+        unpriced.record_llm(model=_UNPRICED, agent="a", usage=_USAGE)
+
+    assert unpriced.agent_unpriced_calls("a") == 3
+    assert priced.agent_unpriced_calls("a") == 0, (
+        "a priced call must not be reported as one whose cost is unknown"
+    )
+
+
+def test_the_unpriced_total_is_a_lower_bound_the_reader_can_detect() -> None:
+    """Tier 2: the owner's symptom, and the signal that now distinguishes it.
+
+    Cost frozen at zero while tokens climb is INDISTINGUISHABLE from a genuinely
+    free model until something says the price was unknown. Both halves are
+    asserted: the frozen cost (the symptom, still true — this change does not
+    invent a price) and the counter (the part that makes it legible).
+    """
+    tracker = _tracker()
+
+    for _ in range(3):
+        tracker.record_llm(model=_UNPRICED, agent="a", usage=_USAGE)
+
+    assert tracker.agent_tokens("a") > 0, "tokens are independent of pricing"
+    assert tracker.agent_cost_usd("a") == 0.0
+    assert tracker.agent_unpriced_calls("a") > 0, (
+        "cost 0.00 with no unpriced signal reads as 'these calls were free'"
+    )
+
+
+def test_a_priced_agent_reports_a_cost_that_grows() -> None:
+    """Tier 2: the control — the same harness, on a priced model, accumulates.
+
+    This is what makes the assertions above non-vacuous: if the harness never
+    reached the accumulation, this test fails rather than the others quietly
+    passing.
+    """
+    tracker = _tracker()
+
+    tracker.record_llm(model=_PRICED, agent="a", usage=_USAGE)
+    after_one = tracker.agent_cost_usd("a")
+    tracker.record_llm(model=_PRICED, agent="a", usage=_USAGE)
+
+    assert after_one > 0.0
+    assert tracker.agent_cost_usd("a") > after_one
+
+
+def test_mixing_priced_and_unpriced_keeps_both_facts() -> None:
+    """Tier 2: a real cost AND a count of what is missing from it.
+
+    The realistic case is an agent that used a priced model and then switched.
+    Reporting only one of the two would either hide the spend or hide the gap.
+    """
+    tracker = _tracker()
+
+    tracker.record_llm(model=_PRICED, agent="a", usage=_USAGE)
+    tracker.record_llm(model=_UNPRICED, agent="a", usage=_USAGE)
+
+    assert tracker.agent_cost_usd("a") > 0.0
+    assert tracker.agent_unpriced_calls("a") == 1
+
+
+def test_agents_do_not_share_an_unpriced_count() -> None:
+    """Tier 2: the counter is per agent, like the cost it qualifies.
+
+    A count filed under the wrong key would attach the caveat to an agent whose
+    figure is complete, and drop it from the one whose figure is not.
+    """
+    tracker = _tracker()
+
+    tracker.record_llm(model=_UNPRICED, agent="a", usage=_USAGE)
+    tracker.record_llm(model=_PRICED, agent="b", usage=_USAGE)
+
+    assert tracker.agent_unpriced_calls("a") == 1
+    assert tracker.agent_unpriced_calls("b") == 0
+
+
+def test_an_unpriced_model_is_reported_where_a_reader_who_did_not_ask_sees_it(
+    caplog,
+) -> None:
+    """Tier 2: the warning fires for an unpriced model, and not for a priced one.
+
+    The counter serves a reader that knows to ask. The embedding path's
+    equivalent counter is read by nothing under ``interfaces/``, so a counter
+    alone would repeat that silence.
+    """
+    import reyn.runtime.budget.budget as budget_mod
+
+    budget_mod._UNPRICED_MODELS_WARNED.discard(_UNPRICED)
+    with caplog.at_level(logging.WARNING, logger=budget_mod.__name__):
+        _tracker().record_llm(model=_UNPRICED, agent="a", usage=_USAGE)
+        unpriced_text = caplog.text
+        caplog.clear()
+        _tracker().record_llm(model=_PRICED, agent="a", usage=_USAGE)
+        priced_text = caplog.text
+
+    assert _UNPRICED in unpriced_text
+    assert _PRICED not in priced_text, (
+        "a priced model must not be reported as having an unknown price"
+    )


### PR DESCRIPTION
**[tui-coder]** — part of #3695

Owner report: 「status bar の cost が全然更新されなかった」「初期値は古い値が出てて…今日は全然ふえなかった」

## What it is

The hypothesis on the issue was the display side, or the tracker instance the
chip reads differing from the one that records. Measured, it is neither.

```
estimate_cost("gpt-5.6-luna", usage) -> (None, None)     # unpriced
estimate_cost("gpt-4o",       usage) -> (0.0075, {...})  # priced
```

`record_llm` did `cost_usd = cost_usd or 0.0`, folding that `None` to zero — so
every call added exactly nothing to a total that still presented itself as the
amount spent. Reproduced with a **priced control**, three calls each:

```
gpt-4o                  cost=0.022500  tokens=4500   cost grew: True
<model with no price>   cost=0.000000  tokens=4500   cost grew: False, tokens: True
```

Cost frozen while tokens climb — the owner's symptom exactly. This confirms it
without waiting on their machine, per the discriminating prediction (tokens and
ctx% are independent of pricing, so they keep moving).

It is **structural, not intermittent**: reyn pins `LITELLM_LOCAL_MODEL_COST_MAP`
(`reyn/__init__.py:31`), so the bundled snapshot is the whole catalogue and any
model newer than it is unpriced permanently. The owner will hit this again on
the next new model.

## Why this is an omission, not a new rule

- `pricing.py:274` already states it: *"An unpriced model means cost UNKNOWN →
  return (None, None), not 0.0. (unknown ≠ free)"*
- The **embedding path already applies the mechanism** —
  `EmbeddingCost.unpriced_calls`, commented *"visible, not a silent $0.00"*.
- Two lines below the fold, the **same function** skips the cache breakdown for
  an unpriced model rather than booking it as free.

Only the per-agent total treated unknown as zero.

## What changed (recording side only)

- Per-agent `unpriced_calls` + a public `agent_unpriced_calls()` accessor. A
  non-zero count means `agent_cost_usd` is a **lower bound**, not the spend.
- A warning naming the model once per process. The embedding counter has existed
  for a while and **nothing under `interfaces/` reads it** (`grep unpriced
  src/reyn/interfaces` is empty), so a counter on its own would reproduce the
  same silence one level over. Say the word and I will drop it.
- The fold to `0.0` **stays** — an unpriced call must still count toward tokens,
  the ledger and the period counters. What changes is that the fact it was
  unpriced now survives the fold.

## Scope, stated rather than hidden

- ⚠️ The counter is **in-memory and resets on restart** — the same choice
  `_agent_cost_breakdown` records for itself (persisting it means extending the
  on-disk ledger schema and triggers the CLAUDE.md recovery-feature gate). So
  this makes the live session honest and **leaves the hydrated durable total's
  own blindness untouched**. The ledger writes `cost_usd: 0.0` for these calls
  and cannot distinguish them either.
- The **display side is deliberately not here** — it is an owner-gated decision
  (`cost $0.1234+?` is under discussion). Splitting them means the recording side
  is not wasted whichever display form is chosen.

## Test plan

- [x] `tests/test_unpriced_llm_cost_visible_3695.py` — 7 gates. Every one pairs
      the unpriced case with a **priced control**, and one gate asserts the
      premise itself (that the two models really are priced and unpriced), so
      this module cannot quietly go vacuous if a price is added later.
- [x] **Falsify**: removing the counter and the warning turns 5 of the 7 RED;
      the premise and control gates stay GREEN.
- [x] ⚠️ **Why the controls are there**: my first attempt at measuring this
      stubbed `call_llm_tools`, which sits **above** `record_llm` — so both
      models looked frozen and the "unpriced" reading would have been vacuous.
      The priced control is what caught it.
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 0 errors
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] Budget-adjacent suites (checkpoint / registry multi-session / embed cost
      wiring) — 30 passed
- [x] Full `pytest` — 9982 passed, 10 failed; the 10 are **byte-identical to what
      `origin/main` produces on this machine** (`comm` of the sorted FAILED lists
      is empty in both directions) and CI is green on main, so they are a local
      environment artifact (textual 8.2.6), not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
