### PR TITLE
refactor(runtime): promote 3 session.py private pure functions to session_pure.py (#3679 stage 1)

### DIFF
--- a/scripts/s7_driver.py
+++ b/scripts/s7_driver.py
@@ -180,13 +180,13 @@ import os
 os.chdir('{WORKSPACE}')
 from pathlib import Path
 from reyn.runtime.router_system_prompt import build_system_prompt
-from reyn.runtime.session import _merge_memory_indexes
+from reyn.runtime.session_pure import merge_memory_indexes
 
 async def main():
     # Build memory index the same way ChatSession does
     shared_path = Path('.reyn/memory/MEMORY.md')
     agent_path = Path('.reyn/agents/{AGENT_NAME}/memory/MEMORY.md')
-    memory_index = _merge_memory_indexes(
+    memory_index = merge_memory_indexes(
         shared_path=shared_path,
         agent_path=agent_path,
         agent_name='{AGENT_NAME}',

--- a/src/reyn/interfaces/web/routers/a2a.py
+++ b/src/reyn/interfaces/web/routers/a2a.py
@@ -61,6 +61,7 @@ from reyn.runtime.a2a_routing import (
     resolve_a2a_session,
 )
 from reyn.runtime.agent_locks import get_agent_lock
+from reyn.runtime.session_pure import new_chain_id
 
 logger = logging.getLogger(__name__)
 
@@ -764,9 +765,8 @@ async def _handle_async_mode(
     ``_create_a2a_task`` shim.
     """
     from reyn.interfaces.web.a2a_intervention import A2AInterventionBus  # noqa: PLC0415
-    from reyn.runtime.session import _new_chain_id  # noqa: PLC0415
 
-    chain_id = _new_chain_id()
+    chain_id = new_chain_id()
     entry = run_registry.create(
         agent_name=agent_name,
         chain_id=chain_id,

--- a/src/reyn/mcp/server.py
+++ b/src/reyn/mcp/server.py
@@ -35,6 +35,7 @@ from reyn.core.events.progress_lifecycle import (
     format_progress_message,
 )
 from reyn.runtime.agent_locks import get_agent_lock as _get_agent_lock
+from reyn.runtime.session_pure import new_chain_id
 from reyn.runtime.turn_origin import TurnOrigin
 
 logger = logging.getLogger(__name__)
@@ -238,10 +239,9 @@ async def send_to_agent_impl(
     session = await _get_session(registry, agent_name, sid=sid)
 
     from reyn.runtime.message_bus import MessageBus  # noqa: PLC0415 — lazy import
-    from reyn.runtime.session import _new_chain_id  # noqa: PLC0415 — lazy import
     from reyn.runtime.transport import McpRef  # noqa: PLC0415 — lazy import
 
-    chain_id = _new_chain_id()
+    chain_id = new_chain_id()
     req_id = f"mcp-{chain_id}"
 
     # Serialize concurrent calls to the same agent — the lock keeps

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -22,6 +22,7 @@ from reyn.runtime.services.mcp_cache_file import (
     ToolsUnknown,
     answered_only,
 )
+from reyn.runtime.session_pure import merge_memory_indexes
 from reyn.security.permissions.capability_profile import compose_narrowing_mappings
 
 if TYPE_CHECKING:
@@ -725,8 +726,7 @@ class RouterHostAdapter:
 
     def get_memory_index(self) -> dict:
         """Return merged shared + agent memory index."""
-        from reyn.runtime.session import _merge_memory_indexes
-        return _merge_memory_indexes(
+        return merge_memory_indexes(
             shared_path=Path(".reyn") / "memory" / "MEMORY.md",
             agent_path=self._workspace_dir / "memory" / "MEMORY.md",
             agent_name=self._agent_name,

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, Callable
 
+from reyn.runtime.session_pure import render_summary_for_storage
+
 if TYPE_CHECKING:
     pass
 
@@ -228,7 +230,6 @@ class RouterLoopDriver:
         claims otherwise.
         """
         from reyn.runtime.chat_message import ChatMessage, _now_iso
-        from reyn.runtime.session import _render_summary_for_storage
 
         resolved_model = self._resolver.resolve(self._effective_router_model_class()).model
         consolidation, covers, dropped_seq_ranges = await self._force_close_wrap_up(
@@ -237,7 +238,7 @@ class RouterLoopDriver:
         structured = {"consolidation": consolidation}
         msg = ChatMessage(
             role="summary",
-            content=_render_summary_for_storage(structured),
+            content=render_summary_for_storage(structured),
             ts=_now_iso(),
             meta={"structured": structured, "covers_through_seq": covers},
         )
@@ -294,7 +295,6 @@ class RouterLoopDriver:
         above), so the interval is empty BY CONSTRUCTION, not by a special
         case.
         """
-        from reyn.runtime.session import _render_summary_for_storage
         from reyn.services.compaction.engine import (
             ContextOverflowError as _ContextOverflowError,
         )
@@ -318,7 +318,7 @@ class RouterLoopDriver:
                 "role": "assistant",
                 "content": (
                     "[summary of earlier conversation]\n"
-                    + _render_summary_for_storage(_summary_dict)
+                    + render_summary_for_storage(_summary_dict)
                 ),
             }]
         # (input, turns actually fed, turns the fallback shrank away) per tier.
@@ -378,7 +378,6 @@ class RouterLoopDriver:
         it ONLY when it actually gives up (cap reached / sub-viable model), so a
         recoverable handoff is not mislogged as a dead-end.
         """
-        from reyn.runtime.session import _render_summary_for_storage
         from reyn.runtime.usage_shim import _RouterUsageShim
         from reyn.services.compaction.engine import (
             ContextOverflowError as _ContextOverflowError,
@@ -410,7 +409,7 @@ class RouterLoopDriver:
             async def _router_main_call(*, SP, head, summary, tail, new_msg):
                 _msgs = list(head)
                 if summary:
-                    _summary_text = _render_summary_for_storage(summary)
+                    _summary_text = render_summary_for_storage(summary)
                     _msgs.append({
                         "role": "assistant",
                         "content": (

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -100,6 +100,11 @@ from reyn.runtime.session_params import (
     PresentationWiring,
     ReactivityConfig,
 )
+from reyn.runtime.session_pure import (
+    merge_memory_indexes,
+    new_chain_id,
+    render_summary_for_storage,
+)
 from reyn.runtime.spawn_tracker import SpawnTracker
 from reyn.runtime.turn_origin import TurnOrigin
 from reyn.security.permissions.permissions import PermissionResolver
@@ -450,13 +455,6 @@ def _run_meta(run_id: str | None, actor: str | None) -> dict:
     }
 
 
-def _new_chain_id() -> str:
-    """Mint a fresh chain_id for a top-level user request. Each user submission
-    starts a new chain; agent_request / agent_response payloads forward the
-    chain_id they received without minting new ones."""
-    return uuid.uuid4().hex
-
-
 def _user_frame_meta(attribution: "dict | None") -> dict:
     """Build ``meta`` for a ``kind="user"`` outbox frame (ADR-0039 multi-client
     input-broadcast fix).
@@ -489,61 +487,6 @@ def _format_hook_attribution(name: str, text: str) -> str:
     consumer (C — wake=false ride-along) and ``_handle_hook_message`` (E —
     wake=true trigger) so the two paths can never drift."""
     return f"[hook:{name}] {text}"
-
-
-def _read_memory_index(path: Path) -> str:
-    """Return MEMORY.md contents at `path` or empty string if absent."""
-    try:
-        return path.read_text(encoding="utf-8") if path.is_file() else ""
-    except OSError:
-        return ""
-
-
-def _merge_memory_indexes(
-    *, shared_path: Path, agent_path: Path, agent_name: str,
-) -> dict:
-    """Combine the shared and agent-scoped MEMORY.md files into a single
-    `data.memory_index` payload (PR15).
-
-    The router phase used to read `.reyn/memory/MEMORY.md` via a preprocessor
-    `file/read` step; that step is removed because the agent-scoped path
-    `.reyn/agents/<name>/memory/MEMORY.md` is dynamic and a static phase
-    YAML cannot interpolate it. Session synthesizes the merged view
-    here and stuffs it directly into the artifact.
-
-    The two layers are kept separate in the output markdown — `(shared)` and
-    `(agent: <name>)` — so the LLM can decide which slug path to use when
-    writing new memory entries.
-    """
-    shared = _read_memory_index(shared_path).strip()
-    agent  = _read_memory_index(agent_path).strip()
-
-    if not shared and not agent:
-        return {"status": "not_found", "content": ""}
-
-    parts: list[str] = []
-    if shared:
-        parts.append(f"# Memory Index (shared)\n\n{_strip_index_header(shared)}")
-    else:
-        parts.append("# Memory Index (shared)\n\n(empty)")
-    parts.append(
-        f"# Memory Index (agent: {agent_name})\n\n"
-        f"{_strip_index_header(agent) if agent else '(empty)'}"
-    )
-    return {"status": "ok", "content": "\n\n".join(parts).strip() + "\n"}
-
-
-def _strip_index_header(content: str) -> str:
-    """Drop a leading `# Memory Index` heading (with optional trailing blank
-    lines) from a stored MEMORY.md so we don't render two headings when
-    merging. Anything else is returned verbatim."""
-    lines = content.splitlines()
-    if lines and lines[0].lstrip().startswith("# Memory Index"):
-        i = 1
-        while i < len(lines) and not lines[i].strip():
-            i += 1
-        lines = lines[i:]
-    return "\n".join(lines).strip()
 
 
 # NOTE: `_PendingChain` lives in `reyn.runtime.services.chain_manager` (PR-refactor-session-1
@@ -601,33 +544,6 @@ def _iv_meta(iv: "UserIntervention") -> dict:
 # by the by-construction floor.
 _MAX_FORCE_CLOSE_HANDOFFS = 1
 
-
-
-def _render_summary_for_storage(structured: dict) -> str:
-    """Render a chat_summary structured dict to a quick-display text blob.
-
-    Stored in ChatMessage.text so REPL traces and audit dumps don't need
-    to re-render the structured form. The slicer prefers the structured
-    form for LLM consumption — this is for human consumption only.
-    """
-    parts: list[str] = []
-    # #1092 PR-F2a: a force-close handoff consolidation carries its (free-text)
-    # body in the dedicated ``consolidation`` field — render it verbatim and
-    # first (it IS the conversation's carried-forward essence). Absent on normal
-    # compaction summaries → no output change for them (byte-identical).
-    consolidation = (structured.get("consolidation") or "").strip()
-    if consolidation:
-        parts.append(consolidation)
-    topic = (structured.get("topic_arc") or "").strip()
-    if topic:
-        parts.append(f"[topic] {topic}")
-    for key in ("decisions", "pending", "session_user_facts", "artifacts_referenced"):
-        items = structured.get(key) or []
-        if not items:
-            continue
-        parts.append(f"[{key}]")
-        parts.extend(f"  - {item}" for item in items)
-    return "\n".join(parts)
 
 
 class DurabilityHaltError(RuntimeError):
@@ -3075,7 +2991,7 @@ class Session:
         # PR14: every top-level user submission starts a fresh chain_id that
         # propagates through any agent_request / agent_response generated in
         # response. Logged in history meta + events.jsonl for cross-agent trace.
-        chain_id = _new_chain_id()
+        chain_id = new_chain_id()
         # #3300 P2b: meta computed once, stored additively on the inbox payload too
         # (not just emitted on the event below) — a late-joiner seeding from
         # STATE_SNAPSHOT/queued_user_messages() needs it too. See agui-transport.md.
@@ -3142,7 +3058,7 @@ class Session:
         must dedup can key on ``run_id``."""
         await self._put_inbox(TurnOrigin.PIPELINE_RESULT, {
             "run_id": run_id, "pipeline_name": pipeline_name, "status": status,
-            "text": text, "chain_id": chain_id or _new_chain_id(),
+            "text": text, "chain_id": chain_id or new_chain_id(),
             "sender": "pipeline:os",
         })
 
@@ -4111,7 +4027,7 @@ class Session:
                 ts=_now_iso(),
                 meta={"structured": structured, "covers_through_seq": covers},
             ),
-            render_summary=_render_summary_for_storage,
+            render_summary=render_summary_for_storage,
             # Feed compacted candidates' tool calls into the per-agent
             # action_usage table so the hot-list survives summarisation.
             merge_action_usage=merge_action_usage,
@@ -5502,7 +5418,7 @@ class Session:
             # as a forwarder.
             await self._handle_inbox_text(
                 payload.get("text", ""),
-                chain_id=payload.get("chain_id") or _new_chain_id(),
+                chain_id=payload.get("chain_id") or new_chain_id(),
             )
         elif kind == TurnOrigin.AGENT_REQUEST:
             await self._handle_agent_request(payload)
@@ -5529,7 +5445,7 @@ class Session:
             # turn-origin stamp below reads.
             await self._handle_inbox_text(
                 payload.get("text", ""),
-                chain_id=payload.get("chain_id") or _new_chain_id(),
+                chain_id=payload.get("chain_id") or new_chain_id(),
             )
         elif kind == TurnOrigin.EXTERNAL_MESSAGE:
             # Text that arrived over an EXTERNAL transport: a chat webhook
@@ -5551,7 +5467,7 @@ class Session:
             # layer, never re-testing ``startswith("/")`` at a transport.
             await self._handle_inbox_text(
                 payload.get("text", ""),
-                chain_id=payload.get("chain_id") or _new_chain_id(),
+                chain_id=payload.get("chain_id") or new_chain_id(),
             )
         elif kind == TurnOrigin.CRON:
             # A fired message-based cron job's text. Operator-authored (job
@@ -5563,7 +5479,7 @@ class Session:
             # ``TurnOrigin.CRON``.
             await self._handle_inbox_text(
                 payload.get("text", ""),
-                chain_id=payload.get("chain_id") or _new_chain_id(),
+                chain_id=payload.get("chain_id") or new_chain_id(),
             )
         elif kind == TurnOrigin.HOOK:
             # E (wake=true) lifecycle-hook push delivered as a turn trigger:
@@ -5587,7 +5503,7 @@ class Session:
             # entirely, so every text-bearing member now takes this same call.
             await self._handle_inbox_text(
                 payload.get("text", ""),
-                chain_id=payload.get("chain_id") or _new_chain_id(),
+                chain_id=payload.get("chain_id") or new_chain_id(),
             )
 
     def _maybe_schedule_ephemeral_vanish(self) -> None:
@@ -5633,7 +5549,7 @@ class Session:
         longer load-bearing."""
         await self._handle_inbox_text(
             payload.get("text", ""),
-            chain_id=payload.get("chain_id") or _new_chain_id(),
+            chain_id=payload.get("chain_id") or new_chain_id(),
         )
 
     async def _handle_hook_message(self, payload: dict) -> None:
@@ -5645,7 +5561,7 @@ class Session:
         single router turn runs."""
         name = payload.get("name", "hook")
         text = payload.get("text", "")
-        chain_id = payload.get("chain_id") or _new_chain_id()
+        chain_id = payload.get("chain_id") or new_chain_id()
         self._append_history(ChatMessage(
             role="system",
             content=_format_hook_attribution(name, text),

--- a/src/reyn/runtime/session_pure.py
+++ b/src/reyn/runtime/session_pure.py
@@ -1,0 +1,102 @@
+"""Pure, module-level chat-session helpers: chain-id minting, chat-summary
+rendering, and shared+agent memory-index merging.
+
+Each function here takes no ``self`` and has a light dependency footprint
+(stdlib only) — safe for any caller (including ``reyn.runtime.session``
+itself, and `reyn.runtime.services` modules that `session.py` in turn
+imports) to import at its own module top level with no risk of a circular
+import back into `session.py`.
+"""
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+
+def new_chain_id() -> str:
+    """Mint a fresh chain_id for a top-level user request. Each user submission
+    starts a new chain; agent_request / agent_response payloads forward the
+    chain_id they received without minting new ones."""
+    return uuid.uuid4().hex
+
+
+def _read_memory_index(path: Path) -> str:
+    """Return MEMORY.md contents at `path` or empty string if absent."""
+    try:
+        return path.read_text(encoding="utf-8") if path.is_file() else ""
+    except OSError:
+        return ""
+
+
+def _strip_index_header(content: str) -> str:
+    """Drop a leading `# Memory Index` heading (with optional trailing blank
+    lines) from a stored MEMORY.md so we don't render two headings when
+    merging. Anything else is returned verbatim."""
+    lines = content.splitlines()
+    if lines and lines[0].lstrip().startswith("# Memory Index"):
+        i = 1
+        while i < len(lines) and not lines[i].strip():
+            i += 1
+        lines = lines[i:]
+    return "\n".join(lines).strip()
+
+
+def merge_memory_indexes(
+    *, shared_path: Path, agent_path: Path, agent_name: str,
+) -> dict:
+    """Combine the shared and agent-scoped MEMORY.md files into a single
+    `data.memory_index` payload (PR15).
+
+    The router phase used to read `.reyn/memory/MEMORY.md` via a preprocessor
+    `file/read` step; that step is removed because the agent-scoped path
+    `.reyn/agents/<name>/memory/MEMORY.md` is dynamic and a static phase
+    YAML cannot interpolate it. Session synthesizes the merged view
+    here and stuffs it directly into the artifact.
+
+    The two layers are kept separate in the output markdown — `(shared)` and
+    `(agent: <name>)` — so the LLM can decide which slug path to use when
+    writing new memory entries.
+    """
+    shared = _read_memory_index(shared_path).strip()
+    agent = _read_memory_index(agent_path).strip()
+
+    if not shared and not agent:
+        return {"status": "not_found", "content": ""}
+
+    parts: list[str] = []
+    if shared:
+        parts.append(f"# Memory Index (shared)\n\n{_strip_index_header(shared)}")
+    else:
+        parts.append("# Memory Index (shared)\n\n(empty)")
+    parts.append(
+        f"# Memory Index (agent: {agent_name})\n\n"
+        f"{_strip_index_header(agent) if agent else '(empty)'}"
+    )
+    return {"status": "ok", "content": "\n\n".join(parts).strip() + "\n"}
+
+
+def render_summary_for_storage(structured: dict) -> str:
+    """Render a chat_summary structured dict to a quick-display text blob.
+
+    Stored in ChatMessage.text so REPL traces and audit dumps don't need
+    to re-render the structured form. The slicer prefers the structured
+    form for LLM consumption — this is for human consumption only.
+    """
+    parts: list[str] = []
+    # #1092 PR-F2a: a force-close handoff consolidation carries its (free-text)
+    # body in the dedicated ``consolidation`` field — render it verbatim and
+    # first (it IS the conversation's carried-forward essence). Absent on normal
+    # compaction summaries → no output change for them (byte-identical).
+    consolidation = (structured.get("consolidation") or "").strip()
+    if consolidation:
+        parts.append(consolidation)
+    topic = (structured.get("topic_arc") or "").strip()
+    if topic:
+        parts.append(f"[topic] {topic}")
+    for key in ("decisions", "pending", "session_user_facts", "artifacts_referenced"):
+        items = structured.get(key) or []
+        if not items:
+            continue
+        parts.append(f"[{key}]")
+        parts.extend(f"  - {item}" for item in items)
+    return "\n".join(parts)

--- a/tests/test_force_close_covers_slice_1092.py
+++ b/tests/test_force_close_covers_slice_1092.py
@@ -18,10 +18,8 @@ No mocks: a real Session with a synthetic T_max.
 from __future__ import annotations
 
 from reyn.runtime.services.router_history_buffer import _is_force_close_consolidation
-from reyn.runtime.session import (
-    ChatMessage,
-    _render_summary_for_storage,
-)
+from reyn.runtime.session import ChatMessage
+from reyn.runtime.session_pure import render_summary_for_storage
 from tests._support.session import make_session as _make_session
 from tests._support.session import now as _now
 from tests._support.session import push as _push
@@ -31,7 +29,7 @@ def _append_force_close_summary(session, consolidation: str) -> ChatMessage:
     """Append a force-close consolidation summary (the F2b install shape)."""
     msg = ChatMessage(
         role="summary",
-        content=_render_summary_for_storage({"consolidation": consolidation}),
+        content=render_summary_for_storage({"consolidation": consolidation}),
         ts=_now(),
         meta={"structured": {"consolidation": consolidation}, "covers_through_seq": 0},
     )
@@ -117,11 +115,11 @@ def test_is_force_close_consolidation_detection() -> None:
 def test_render_consolidation_field_verbatim_and_normal_unchanged() -> None:
     """Tier 2: the renderer surfaces the consolidation verbatim; a normal
     structured dict (no consolidation) renders exactly as before (byte-identical)."""
-    assert "MY-CONSOLIDATION" in _render_summary_for_storage(
+    assert "MY-CONSOLIDATION" in render_summary_for_storage(
         {"consolidation": "MY-CONSOLIDATION"}
     )
     # normal summary: unchanged output (no `consolidation` → no new lines).
-    assert _render_summary_for_storage({"topic_arc": "T"}) == "[topic] T"
-    assert _render_summary_for_storage(
+    assert render_summary_for_storage({"topic_arc": "T"}) == "[topic] T"
+    assert render_summary_for_storage(
         {"decisions": ["d1"]}
     ) == "[decisions]\n  - d1"

--- a/tests/test_retry_loop_chat_wiring_1125.py
+++ b/tests/test_retry_loop_chat_wiring_1125.py
@@ -205,11 +205,11 @@ def test_recovery_summary_bridge_matches_normal_path(tmp_path) -> None:
     normal router path's bridge.
 
     The recovery prompt rebuilt by ``_router_main_call`` renders the structured
-    summary via ``_render_summary_for_storage`` — the same renderer that produced
+    summary via ``render_summary_for_storage`` — the same renderer that produced
     the persisted ``summary.content`` the normal path uses for its bridge.
     So the summary bridge is byte-identical across both paths.
     """
-    from reyn.runtime.session import _render_summary_for_storage
+    from reyn.runtime.session_pure import render_summary_for_storage
 
     session = _make_session(tmp_path, t_max=2800)
     structured = {
@@ -219,7 +219,7 @@ def test_recovery_summary_bridge_matches_normal_path(tmp_path) -> None:
         "session_user_facts": [],
         "artifacts_referenced": [],
     }
-    rendered = _render_summary_for_storage(structured)
+    rendered = render_summary_for_storage(structured)
     session.history.append(ChatMessage(
         role="summary",
         content=rendered,
@@ -240,7 +240,7 @@ def test_recovery_summary_bridge_matches_normal_path(tmp_path) -> None:
     # Recovery path renders the structured dict the same way.
     _h, _rm, _t, summary_dict, _seq_by_id = session._history_buffer.decompose_history_for_retry()
     recovery_bridge = (
-        "[summary of earlier conversation]\n" + _render_summary_for_storage(summary_dict)
+        "[summary of earlier conversation]\n" + render_summary_for_storage(summary_dict)
     )
     assert recovery_bridge == normal_bridge
 

--- a/tests/test_session_pure_extraction_3679_s1.py
+++ b/tests/test_session_pure_extraction_3679_s1.py
@@ -1,0 +1,122 @@
+"""Tier 2: #3679 stage 1 — `new_chain_id` / `render_summary_for_storage` /
+`merge_memory_indexes` promoted from `reyn.runtime.session`'s private
+(`_`-prefixed) names to a new, dependency-light public module,
+`reyn.runtime.session_pure`.
+
+Zero behavior change — every existing test that exercised these functions
+through `session.py` still passes UNMODIFIED except for the import line
+itself switching to the new module (the tier's own acceptance condition:
+"only the rename differs" — see `tests/test_force_close_covers_slice_1092.py`
+and `tests/test_retry_loop_chat_wiring_1125.py`, both updated in this same
+PR to import from the new module, no other diff).
+
+Three things pinned here, matching the stage-1 acceptance conditions
+(architect-specified):
+
+1. "Pure" is a CHECK, not an assertion in prose — each promoted function's
+   signature is inspected to confirm it takes no `self`/`cls` (genuinely a
+   module-level function, not a method masquerading as one).
+2. No backward-compat alias: `reyn.runtime.session` no longer HAS the old
+   private names at all (not even as a re-export) — all 15+ call sites
+   across the repo were moved to the new module in this same PR, so nothing
+   should still need one.
+3. The new module is importable at module top-level WITHOUT first importing
+   `reyn.runtime.session` — proving it is genuinely independent (this is
+   what makes the lazy-import discipline the two real circular-import call
+   sites (`router_host_adapter.py`, `router_loop_driver.py`) used to need
+   actually unnecessary now, not just inconvenient).
+"""
+from __future__ import annotations
+
+import inspect
+import subprocess
+import sys
+from pathlib import Path
+
+from reyn.runtime.session_pure import (
+    merge_memory_indexes,
+    new_chain_id,
+    render_summary_for_storage,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_new_chain_id_is_a_pure_function_no_self():
+    """Tier 2: acceptance condition ① — a genuine module-level function, not
+    a method: no `self`/`cls` in its signature."""
+    params = inspect.signature(new_chain_id).parameters
+    assert "self" not in params and "cls" not in params
+
+
+def test_render_summary_for_storage_is_a_pure_function_no_self():
+    """Tier 2: acceptance condition ①."""
+    params = inspect.signature(render_summary_for_storage).parameters
+    assert "self" not in params and "cls" not in params
+
+
+def test_merge_memory_indexes_is_a_pure_function_no_self():
+    """Tier 2: acceptance condition ①."""
+    params = inspect.signature(merge_memory_indexes).parameters
+    assert "self" not in params and "cls" not in params
+
+
+def test_session_module_no_longer_has_the_old_private_names():
+    """Tier 2: acceptance condition ② — no backward-compat alias left in
+    `session.py`. All 15+ call sites moved to the new module's public name
+    in this same PR; if any were missed, THAT call site breaks loudly
+    (ImportError/AttributeError) rather than this test silently permitting
+    a straggler to keep using the old name."""
+    import reyn.runtime.session as session_mod
+
+    assert not hasattr(session_mod, "_new_chain_id")
+    assert not hasattr(session_mod, "_render_summary_for_storage")
+    assert not hasattr(session_mod, "_merge_memory_indexes")
+
+
+def test_session_pure_importable_without_first_importing_session():
+    """Tier 2: acceptance condition ③ — `reyn.runtime.session_pure` is
+    importable standalone, in a FRESH subprocess, without
+    `reyn.runtime.session` (or anything that imports it) already loaded
+    first. This is the direct proof the lazy-import discipline the two real
+    circular-import call sites used to need is genuinely gone: if
+    `session_pure` still depended on anything that imports `session.py`
+    back, importing it FIRST (before `session.py` has a chance to partially
+    initialize) would raise the same
+    "cannot import name ... from partially initialized module" this stage
+    is fixing."""
+    proc = subprocess.run(
+        [sys.executable, "-c", "import reyn.runtime.session_pure; print('OK')"],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
+    assert "OK" in proc.stdout
+
+
+def test_router_host_adapter_and_router_loop_driver_import_it_at_top_level():
+    """Tier 2: the two real circular-import call sites (`router_host_adapter
+    .py`, `router_loop_driver.py` — the ONLY two where a reproduced
+    `ImportError` justified the original lazy-import) now import
+    `session_pure` at their OWN module top, not lazily inside a function —
+    the concrete "lazy import no longer needed" proof for the sites that
+    actually needed it (`mcp/server.py`/`a2a.py`'s lazy imports were a local
+    convention, not cycle-avoidance — see `session_pure`'s own module
+    docstring)."""
+    import ast
+
+    for rel in (
+        "src/reyn/runtime/services/router_host_adapter.py",
+        "src/reyn/runtime/services/router_loop_driver.py",
+    ):
+        tree = ast.parse((_REPO_ROOT / rel).read_text(encoding="utf-8"))
+        top_level_modules = {
+            node.module
+            for node in ast.iter_child_nodes(tree)
+            if isinstance(node, ast.ImportFrom)
+        }
+        assert "reyn.runtime.session_pure" in top_level_modules, (
+            f"{rel} must import session_pure at module top level, not lazily"
+        )


### PR DESCRIPTION
**[e2e-coder]** — #3679 段階1。`_new_chain_id` / `_render_summary_for_storage` / `_merge_memory_indexes`（+その内部ヘルパー2つ）を`session.py`から新規モジュール`reyn.runtime.session_pure`へ昇格。**挙動変更ゼロ**。

## 件数の訂正（着手前にlead-coderと突き合わせ済み）

lead-coderの初期見積り（外部利用: `_new_chain_id` 7箇所 / `_render_summary_for_storage` 6箇所）は誤りで、**実測で訂正**しました（lead-coder確認済み・「貴殿の実測が正しく、私の数字が誤り」）:

| 関数 | 外部呼び出し | 内部(session.py自身) | 備考 |
|---|---|---|---|
| `_new_chain_id` | 2箇所（mcp/server.py, a2a.py） | 9箇所 | 内部呼び出しをlead-coder当初カウントに含めていたのが誤りの原因 |
| `_render_summary_for_storage` | 3ファイル9呼び出し行（router_loop_driver.py×3, test_force_close×4, test_retry_loop×2） | 1箇所 | うち6箇所はテストコード——「既存テスト無改変」ではなくテスト側もimport行のみ改名 |
| `_merge_memory_indexes` | 2箇所 | 0箇所 | うち1つ(`scripts/s7_driver.py`)は**subprocess起動script文字列の中**——静的検査に映らず、リネームすると実行時に壊れる箇所。手当て済み |

## 循環importの実態（lead-coderの説明も一部誤りだったため実測で訂正）

- **実際に循環importを再現できたのは`router_host_adapter.py`/`router_loop_driver.py`のみ**（`session.py`のtop-level importが`reyn.runtime.services`経由でこの2ファイルのtop-levelに戻る実循環。eager top-level importで`ImportError: cannot import name ... from partially initialized module`を実際に再現）
- `mcp/server.py`/`a2a.py`のlazy importは**循環回避ではありませんでした**——静的・動的検査どちらでも循環を再現できず、同関数内で他のruntimeモジュールもlazy importする既存の局所的な慣習に過ぎなかったと判明。本文には「循環回避のため」と書きません（lead-coder指摘通り）

## 実装

- 新規 `src/reyn/runtime/session_pure.py`: `new_chain_id()` / `render_summary_for_storage()` / `merge_memory_indexes()`（+ private helper `_read_memory_index`/`_strip_index_header`）。依存はstdlibのみ(`uuid`, `pathlib.Path`)——`session.py`自身の import を一切持たないため、どこからimportしても循環しません
- `session.py`: 5関数の定義を削除、top-level importに置き換え。内部呼び出し10箇所（`_new_chain_id`×9, `_render_summary_for_storage`×1）を新名へ更新
- 外部呼び出し元6ファイル全て新名へ移行、**旧名の後方互換aliasは一切残していません**（owner方針: 後方互換=技術負債）
  - `mcp/server.py`・`a2a.py`: lazy importをtop-levelへ格上げ（循環が無いと確認済みのため）
  - `router_host_adapter.py`・`router_loop_driver.py`: 実循環があった箇所——`session_pure`は依存最小のためこちらもtop-level importへ格上げ可能と確認済み
  - `scripts/s7_driver.py`: subprocess起動script文字列内の参照も書き換え済み
  - テスト2ファイル: import行のみ変更、他の差分なし

## 別件Issue切り出し

調査中に発見: `src/reyn/runtime/services/inter_agent_messaging.py`に**独立した別実装**の`_new_chain_id`（importでなく別コード、出力形式も微妙に異なる）が存在。段階1で公開名を与えた直後に「公開名と別実装が併存」する状態になるため、#3700として切り出し済み（段階1本体はスコープ外のまま）。

## テスト（6本、新規ファイル `tests/test_session_pure_extraction_3679_s1.py`）

- 受け入れ条件①: 3関数それぞれ`inspect.signature`で`self`/`cls`を取らないことを検査（「主張でなく検査」——architect指定）
- 受け入れ条件②: `session.py`に旧private名が一切残っていないことを`hasattr`で確認
- 受け入れ条件③: `session_pure`が`session.py`を先にimportせずとも単独importできることをfresh subprocessで確認
- 追加: 実循環があった2ファイルが実際にtop-level importへ切り替わったことをAST検査で確認

## CI

- ruff: green
- `test_tier_audit.py --strict`: green
- `verify_module_docstrings.py`: green（新規モジュールのdocstringから“抽出元”ナラティブを除去——ポリシー指摘を受け修正）
- full suite: 9795 passed / 17 failed / 65 skipped / 14 errors — failed/errorは前PR群と**同一集合**（増分ゼロ）

Part of #3679 (段階1のみ。段階2はarchitect実測により却下済み、段階3は#3671の土台完了後)