### PR TITLE
fix(#3699): make a drawer readout taller than the drawer reachable

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -372,6 +372,46 @@ class _CursorFlowView(FlowView["OutboxMessage"]):
             self.post_message(KeyCommitted(self, entry))
 
 
+class ScrollableDrawer(ContentSwitcher):
+    """The bottom drawer, with keys that can reach a readout taller than it.
+
+    ``ContentSwitcher`` scrolls when its stylesheet says so (see the
+    ``#drawer`` rule) but binds no key to do it, so a Help pane of 30 lines in
+    a 12-row drawer was reachable by mouse wheel and by nothing else (#3699 —
+    measured: 11 of 30 lines on screen, and the 19 missing were the keyboard
+    shortcuts the pane exists to list).
+
+    PgUp/PgDn rather than ↑/↓: ``↑`` already means "back to composer" while
+    the drawer is open (``chrome.MENUBAR_KEYS``), and rebinding it would trade
+    one unreachable thing for another. PgUp/PgDn are unbound in this context
+    and already read as "page through content" elsewhere in this app. The
+    Help pane lists them from that same ledger, so the pane that was cut off
+    now also says how to see the rest.
+
+    A pane that fits is unaffected: with nothing to scroll, these keys move
+    nothing rather than being conditionally absent.
+    """
+
+    BINDINGS = [
+        Binding("pagedown", "scroll_pane_down", "Scroll this pane", show=False),
+        Binding("pageup", "scroll_pane_up", "Scroll this pane", show=False),
+        Binding("home", "scroll_pane_home", "Top of this pane", show=False),
+        Binding("end", "scroll_pane_end", "Bottom of this pane", show=False),
+    ]
+
+    def action_scroll_pane_down(self) -> None:
+        self.scroll_page_down(animate=False)
+
+    def action_scroll_pane_up(self) -> None:
+        self.scroll_page_up(animate=False)
+
+    def action_scroll_pane_home(self) -> None:
+        self.scroll_home(animate=False)
+
+    def action_scroll_pane_end(self) -> None:
+        self.scroll_end(animate=False)
+
+
 class TextualChatApp(App):
     """The TTY conversation pane: a FlowView of the live conversation + a
     Composer, both fed/served by one :class:`ClientTransport`.
@@ -801,6 +841,18 @@ class TextualChatApp(App):
     #drawer {
         height: auto;
         max-height: 12;
+        /* #3699: the readout panes (Help/Cost/Ctx) are routinely taller than
+           this cap — Help alone is 30 non-blank lines — and without this the
+           remainder was CLIPPED: no scrollbar, no indication, nothing any key
+           could reach. Measured before the fix: 11 of Help's 30 lines on
+           screen, and the 19 missing ones were the keyboard shortcuts, i.e.
+           the reason the pane is opened at all.
+           The overflow belongs HERE rather than on the pane: a ``Static`` is
+           not a scroll container, so capping the Static instead truncates its
+           virtual size to the cap (measured: virtual height 12 for 30 lines of
+           content) and there is then nothing left to scroll to. The list panes
+           were never affected — ``OptionList`` scrolls itself. */
+        overflow-y: auto;
         background: @surface@;
         padding: 0;
     }
@@ -813,6 +865,10 @@ class TextualChatApp(App):
         border: none;
         padding: 0;
     }
+    /* #3699: deliberately NO max-height here — the pane must be allowed to be
+       its full content height so the scroll container above has something to
+       scroll to. Capping the Static instead clamps its virtual size and the
+       content past the cap stops existing rather than moving off screen. */
     #drawer Static { height: auto; padding: 1 0; }
     """)
 
@@ -1211,7 +1267,7 @@ class TextualChatApp(App):
         # downward. Phase 4 fills each pane from its canonical reyn source; each
         # pane is rebuilt from a fresh snapshot when opened (:meth:`_refresh_pane`).
         yield MenuBar(_MENU_TABS, id="menubar", status_text=self._status_text())
-        with ContentSwitcher(initial=None, id="drawer"):
+        with ScrollableDrawer(initial=None, id="drawer"):
             for tid, _label in _MENU_TABS:
                 yield build_drawer_pane(tid, self._pane_rows(tid))
 
@@ -1873,6 +1929,15 @@ class TextualChatApp(App):
         child = drawer.query_one(f"#{tab_id}")
         if isinstance(child, OptionList):
             child.focus()
+        else:
+            # #3699: a readout pane taller than the drawer's cap scrolls — but
+            # the scrolling is the DRAWER's (a Static is not a scroll
+            # container), so the drawer is what has to hold focus for a key to
+            # move it. Without this the content past the fold stays unreachable
+            # and merely gains a scrollbar nothing can drive, which is the same
+            # defect wearing an affordance.
+            drawer.can_focus = True
+            drawer.focus()
 
     def _refresh_pane(self, tab_id: str, snap: "dict | None | object" = _UNSET) -> None:
         """Re-derive ``tab_id``'s pane content from the current canonical sources

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -449,6 +449,13 @@ COMPOSER_KEYS: "list[tuple[str, str]]" = [
 MENUBAR_KEYS: "list[tuple[str, str]]" = [
     ("← →", "move"),
     ("enter", "open"),
+    # #3699: a readout pane taller than the drawer's cap scrolls, and until
+    # this row existed the Help pane did not say how — the pane whose content
+    # was cut off was also the pane that would have told you how to see the
+    # rest. PgUp/PgDn rather than ↑/↓ because ↑ already means "back to
+    # composer" here (the row below), and this app already uses PgUp/PgDn for
+    # "page through content" on the conversation.
+    ("PgUp / PgDn", "scroll this pane"),
     ("↑", "back to composer"),
     ("esc", "back to composer"),
 ]
@@ -1230,6 +1237,10 @@ def build_drawer_pane(tab_id: str, rows: "Sequence[str]") -> Widget:
             else rows
         )
         return OptionList(*options, id=tab_id)
+    # #3699 keeps this a plain ``Static``: the scrolling for an over-tall
+    # readout is done by the drawer around it (see the ``#drawer`` rule in the
+    # app stylesheet for why it cannot be done here), so this branch stays the
+    # simple "render these rows" it has always been.
     return Static(Text("\n".join(rows)), id=tab_id)
 
 

--- a/tests/test_drawer_readout_reachable_3699.py
+++ b/tests/test_drawer_readout_reachable_3699.py
@@ -1,0 +1,225 @@
+"""#3699 — a drawer readout taller than the drawer stays reachable.
+
+The Help pane is 30 non-blank lines; the drawer caps at 12. Measured before
+this change, on a 100x30 terminal: 11 lines on screen and 19 not — and the 19
+were the keyboard shortcuts, i.e. the entire reason the pane is opened. No
+scrollbar, no indication, and no key that moved it.
+
+Same class as #3688's sent queue: a height cap without an overflow rule does
+not shorten a region, it deletes the part past the cap. The sweep that found
+this one also cleared the siblings — ``OptionList``-backed panes (History /
+Model / Agent / the rewind picker / the completion popup) scroll themselves,
+so the readouts (Help / Cost / Ctx) were the remaining case.
+
+Two things have to hold, and only together: the content must be scrollable AND
+a key must be able to scroll it. A scrollbar the keyboard cannot drive leaves
+the content just as unreachable, with an affordance drawn next to it — so the
+central gate here presses keys and asks what became visible, rather than
+asserting a style or a scroll offset.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual.widgets import ContentSwitcher, OptionList
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.chrome import (
+    MENUBAR_KEYS,
+    Composer,
+    help_pane_lines,
+)
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import EventFrame
+from reyn.runtime.outbox import OutboxMessage
+from reyn.schemas.models import Event
+
+
+class QueueTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` (the shared test idiom)."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+
+    async def push_event(self, event: Event) -> None:
+        await self._queue.put(EventFrame(event))
+
+    def start(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str) -> None:
+        pass
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        pass
+
+    async def cancel_inflight(self) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+
+
+def _painted(app: TextualChatApp) -> str:
+    """What the compositor actually put on screen — the only surface that
+    distinguishes a clipped line from a drawn one."""
+    return "\n".join(
+        "".join(segment.text for segment in strip)
+        for strip in app.screen._compositor.render_strips()
+    )
+
+
+def _help_lines(app: TextualChatApp) -> "list[str]":
+    return [line for line in help_pane_lines(app._app_binding_help()) if line.strip()]
+
+
+def _visible(app: TextualChatApp, lines: "list[str]") -> "set[str]":
+    painted = _painted(app)
+    return {line for line in lines if line.strip()[:38] in painted}
+
+
+@pytest.mark.asyncio
+async def test_the_help_pane_is_taller_than_the_drawer_so_this_module_is_not_vacuous() -> None:
+    """Tier 2: the premise — Help really does overflow the drawer.
+
+    If Help ever became short enough to fit, every gate below would pass while
+    testing nothing. This fails first and says so.
+    """
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._open_drawer("help")
+        for _ in range(4):
+            await pilot.pause()
+
+        lines = _help_lines(app)
+        assert len(_visible(app, lines)) < len(lines), (
+            "the Help pane now fits in the drawer, so the reachability gates "
+            "below no longer exercise the overflow they were written for"
+        )
+
+
+@pytest.mark.asyncio
+async def test_every_help_line_can_be_reached_from_the_keyboard() -> None:
+    """Tier 2: paging through the drawer surfaces every line of the readout.
+
+    The owner-facing contract: what the pane says must be readable, all of it,
+    without a mouse. Before this change PgDn moved nothing and 19 of 30 lines
+    could not be brought on screen by any key.
+    """
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._open_drawer("help")
+        for _ in range(4):
+            await pilot.pause()
+
+        lines = _help_lines(app)
+        seen = _visible(app, lines)
+        for _ in range(8):
+            await pilot.press("pagedown")
+            await pilot.pause()
+            seen |= _visible(app, lines)
+
+        unreachable = [line for line in lines if line not in seen]
+        assert not unreachable, (
+            "lines of the Help pane never became visible while paging through "
+            f"it, so nothing in the UI can show them: {unreachable}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_opening_a_readout_puts_focus_where_the_scroll_keys_land() -> None:
+    """Tier 2: the drawer holds focus for a readout pane.
+
+    Scrollable-but-unfocused is the failure mode this half exists to stop: the
+    content would be one keypress away from visible and that keypress would go
+    somewhere else.
+    """
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._open_drawer("help")
+        for _ in range(4):
+            await pilot.pause()
+
+        assert app.focused is app.query_one("#drawer", ContentSwitcher)
+
+
+@pytest.mark.asyncio
+async def test_a_picker_pane_still_focuses_its_list() -> None:
+    """Tier 2: the list panes keep the focus they already had.
+
+    ``↑``/``↓`` drive the selection in a picker; taking that focus away to give
+    it to the drawer would break the pickers to fix the readouts.
+    """
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._open_drawer("model")
+        for _ in range(4):
+            await pilot.pause()
+
+        assert isinstance(app.focused, OptionList)
+
+
+@pytest.mark.asyncio
+async def test_escape_still_returns_to_the_composer_from_a_readout() -> None:
+    """Tier 2: the existing keyboard contract survives the new focus target.
+
+    ``Esc`` means "back to composer" everywhere in this app. Moving focus onto
+    the drawer must not create a place Esc does not work from.
+    """
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._open_drawer("help")
+        for _ in range(4):
+            await pilot.pause()
+
+        await pilot.press("escape")
+        for _ in range(4):
+            await pilot.pause()
+
+        assert isinstance(app.focused, Composer), (
+            f"Esc from the Help pane landed on {type(app.focused).__name__}"
+        )
+
+
+def test_the_help_text_says_how_to_scroll_itself() -> None:
+    """Tier 2: the scroll keys appear in the pane whose content is cut off.
+
+    The pane that needed scrolling was also the pane that would have said how —
+    so a fix that scrolls without documenting it leaves the discovery problem
+    exactly where it was.
+    """
+    keys = {key for key, _label in MENUBAR_KEYS}
+    assert any("PgDn" in key or "pagedown" in key.lower() for key in keys), (
+        f"the drawer's key ledger does not mention paging: {sorted(keys)}"
+    )


### PR DESCRIPTION
**[tui-coder]** — Closes #3699

## What it is

The Help pane is 30 non-blank lines; the drawer caps at 12. Measured on a
100×30 terminal before this change:

```
help pane: 30 non-blank lines / ON SCREEN: 11 / INVISIBLE: 19
missing tail: ctrl+g, ctrl+t, ctrl+f, ctrl+c, c (copy mode)
```

The 19 that vanished were the keyboard shortcuts — the entire reason the pane
is opened. No scrollbar, no indication, and no key that moved it.

## Swept, not patched

This is the same class as #3688's sent queue: a height cap with no overflow
rule does not shorten a region, it deletes the part past the cap. Since #3688
fixed one instance, I swept the siblings rather than leave them for the next
report:

| Region | cap | state |
| --- | --- | --- |
| `SentQueue` | 6 | fixed in #3689 |
| **`#drawer` readout (Help / Cost / Ctx)** | 12 | **this PR** |
| `#drawer OptionList`, `RewindPicker`, `CompletionPopup` | 12/10 | `OptionList` scrolls itself — unaffected |
| `#inputrow` / `Composer` | 8/6 | input surfaces, not readouts |

`build_drawer_pane` returns a plain `Static` for **every** readout, so Cost and
Ctx shared the defect. Fixing Help alone would have left them.

## Two halves, and only together

- **The overflow goes on the DRAWER, not the pane.** A `Static` is not a scroll
  container, so capping the Static instead clamps its virtual size — measured, a
  30-line Static under `max-height: 12` reports **virtual height 12**, and the
  content past the cap stops existing rather than moving off screen.
- **The drawer takes focus for a readout**, so a key can move it. Scrollable but
  unfocused leaves the content just as unreachable with an affordance drawn next
  to it — the "visible but unreachable" shape #3688 avoided for the selected row,
  and the acceptance condition raised on this issue.

Both halves are falsified independently: removing **either** turns the
reachability gate red.

## Keys

`PgUp`/`PgDn`, not `↑`/`↓`: `↑` already means "back to composer" while the
drawer is open (`MENUBAR_KEYS`), and rebinding it would trade one unreachable
thing for another. PgUp/PgDn are unbound in this context and already read as
"page through content" elsewhere in this app.

They are listed in `MENUBAR_KEYS`, so **the pane that was cut off now also says
how to see the rest** — a fix that scrolls without documenting it leaves the
discovery problem where it was.

## How it looks

Opening Help now focuses the drawer and shows a scrollbar; `PgDn` pages through
to the end, `Esc` still returns to the composer, and a picker pane still focuses
its `OptionList` so `↑`/`↓` drive the selection as before. A pane that fits is
unchanged — with nothing to scroll, the keys move nothing.

## Test plan

- [x] `tests/test_drawer_readout_reachable_3699.py` — 6 gates: every Help line is
      reachable **by keypress** (not by asserting a style or a scroll offset);
      the drawer holds focus for a readout; a picker still focuses its list; Esc
      still returns to the composer; the help text lists the scroll keys; and a
      premise gate that fails first if Help ever becomes short enough to fit.
- [x] **Falsify, both halves separately**: removing `overflow-y` → reachability
      gate RED; removing the focus call → reachability **and** focus gates RED.
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 0 errors
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] Drawer/keyboard-adjacent suites (esc-sufficiency, keyboard reachability,
      completion, chrome liveness, phase4, queue cancel) — 116 passed, 1 failure
      that is in the known-on-main set below
- [x] Full `pytest` — 9992 passed, 10 failed; the 10 are **byte-identical to what
      `origin/main` produces on this machine** (`comm` of the sorted FAILED lists
      empty in both directions) and CI is green on main, so they are a local
      environment artifact (textual 8.2.6), not this change.
- [ ] Visual confirmation by the owner

⚪ Noticed while writing this: one of those 10, `test_esc_from_search_bar_returns_to_composer`,
asserts `isinstance(app.focused, Input)` and `Composer` is not an `Input` subclass
locally — my own first version of the Esc gate here failed the same way and the
assertion, not the behaviour, was wrong. CI passes it, so the two environments
disagree about that type. Filing separately rather than touching it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
