### PR TITLE
fix(3697): repair 8/9 broken journal cross-links, widen anchor gate coverage

### DIFF
--- a/docs/deep-dives/journal/dogfood/2026-05-04-batch-1-practice/findings/F05-delegate-double-inbox-put.md
+++ b/docs/deep-dives/journal/dogfood/2026-05-04-batch-1-practice/findings/F05-delegate-double-inbox-put.md
@@ -11,7 +11,7 @@
 | Found | 2026-05-04 |
 
 > Context: F5 は scenario 2 で発生した「16 秒の悲劇」 cascade の口火を
-> 切った bug。 全体の流れは [findings.md の F5-F8 連鎖事故 section](../findings.md#f5-f8-multi-agent-delegate-完全失敗の四重奏-16-秒の悲劇)
+> 切った bug。 全体の流れは [findings.md の F5-F8 連鎖事故 section](../findings.md#round-2--f5-f8-16-秒の悲劇-multi-agent-delegate-連鎖事故)
 > を参照。
 
 ---

--- a/docs/deep-dives/journal/dogfood/2026-05-17-g31-three-component-decomposition.md
+++ b/docs/deep-dives/journal/dogfood/2026-05-17-g31-three-component-decomposition.md
@@ -4,7 +4,7 @@
 |---|---|
 | Date | 2026-05-17 |
 | Session | e2e-coder |
-| Triggering | giveup-tracker [G31](./giveup-tracker.md#g31) follow-up — "is there a non-overfit structural fix?" |
+| Triggering | giveup-tracker [G31](./giveup-tracker.md#g31-capability-question-content-leakage--weak-gemini-25-flash-lite-で-何ができる-系質問への-reply-が-router-meta-tool--qualified-name-を本文-echo) follow-up — "is there a non-overfit structural fix?" |
 | Models | gemini-2.5-flash-lite (weak default), gemini-2.5-flash (strong, cost-gated permission granted for this session) |
 | Method | trace-driven `--patch` replay, [`scripts/llm_replay.py`](../../../scripts/llm_replay.py), N=10 per cell, classification by regex heuristics |
 | Total cost | ~430 weak calls + ~40 strong calls |
@@ -225,8 +225,8 @@ The full batch scripts used here (`/tmp/sp_*.py`) are throwaway — recreate fro
 
 ## Related
 
-- giveup-tracker [G31](./giveup-tracker.md#g31) — original entry, framing pre-decomposition
-- giveup-tracker [G12](./giveup-tracker.md#g12) — adjacent affordance-bias family
+- giveup-tracker [G31](./giveup-tracker.md#g31-capability-question-content-leakage--weak-gemini-25-flash-lite-で-何ができる-系質問への-reply-が-router-meta-tool--qualified-name-を本文-echo) — original entry, framing pre-decomposition
+- giveup-tracker [G12](./giveup-tracker.md#g12-attractor-variant-family--weak-llm-の-must-rule-確率的不honor) — adjacent affordance-bias family
 - FP-0034 issue #36 — universal catalog architecture (= the layer where descriptions live)
 - PR #110 — README weak-model warning + giveup-tracker G31 entry
 - PR #117 / #119 / `a1a5093a` — D2-min / D2-full / cherry-pick (= hot-list alias schema cleanse; surface-related but independent fix)

--- a/docs/deep-dives/journal/dogfood/README.md
+++ b/docs/deep-dives/journal/dogfood/README.md
@@ -67,7 +67,7 @@ shadow しても見えないものを見るための iterative loop。
   `permissions: file.read / python.pure / python.trusted: allow` を追加することで
   project-wide pre-approval を付与しつつ、 committed `reyn.yaml` と interactive
   TTY ユーザへの影響を ゼロに保つのが標準 pattern。 詳細は
-  [permission-model.md](../../en/concepts/runtime/permission-model.md#reynlocalyaml-for-operator-local-pre-approval) 参照
+  [permission-model.md](../../../concepts/runtime/permission-model.md#reynlocalyaml-for-operator-local-pre-approval) 参照
 - **resolved-indirectly classification (batch 10 で形式化)**: fix の cascade
   effect で別 bug が同時消失する pattern。 「reproduce or refute first」 で
   確認後に「不要 fix 投資を回避」 として明示記録、 prediction 設計に「次 layer

--- a/docs/deep-dives/journal/insights/2026-05-07-category-only-catalog-landing.md
+++ b/docs/deep-dives/journal/insights/2026-05-07-category-only-catalog-landing.md
@@ -261,8 +261,8 @@ attractor 系 LLM 挙動問題は **下 layer から疑う**。 SP は最終手�
 - [industry tool discovery patterns survey](2026-05-07-industry-tool-discovery-survey.md)
 
 ### 関連 giveup-tracker entries
-- [G12: attractor variant family (Pattern E section)](../dogfood/giveup-tracker.md#g12)
-- [G23: intent-axis section is load-bearing routing scaffold](../dogfood/giveup-tracker.md#g23)
+- [G12: attractor variant family (Pattern E section)](../dogfood/giveup-tracker.md#g12-attractor-variant-family--weak-llm-の-must-rule-確率的不honor)
+- [G23: intent-axis section is load-bearing routing scaffold](../dogfood/giveup-tracker.md#g23-intent-axis-section-is-load-bearing-routing-scaffold--category-only-retry-succeeded)
 
 ### Commits
 - `dc8296f` Wave A trial (= reverted)

--- a/docs/deep-dives/journal/insights/2026-05-07-industry-tool-discovery-survey.md
+++ b/docs/deep-dives/journal/insights/2026-05-07-industry-tool-discovery-survey.md
@@ -262,7 +262,7 @@ Reyn の `intent-axis section + per-category list_*` family は (a) 派の
 
 ### 関連 Reyn doc
 
-- [G23: intent-axis section is load-bearing routing scaffold](../dogfood/giveup-tracker.md#g23) (= 同 session の Wave A revert evidence)
+- [G23: intent-axis section is load-bearing routing scaffold](../dogfood/giveup-tracker.md#g23-intent-axis-section-is-load-bearing-routing-scaffold--category-only-retry-succeeded) (= 同 session の Wave A revert evidence)
 - [envelope-layer attractor fix + mutation isolation methodology](2026-05-07-envelope-layer-attractor-fix.md) (= 同 session の sibling insight)
 - [Reyn vision project memory](../../../memory/project_reyn_vision.md) (= P3 + predictability over autonomy framing)
 - [agent-framework-trends.md](../../research/landscape/agent-framework-trends.md) (= この survey を参照する Researcher ロール成果物)

--- a/tests/test_3126_doc_anchor_gate.py
+++ b/tests/test_3126_doc_anchor_gate.py
@@ -296,7 +296,7 @@ def _resolve_cross_file_target(doc_path: Path, target_path: str) -> Path | None:
 # cross-link each other constantly, and building this arm's first version
 # found 9 such links, 8 already dangling (#3697) — flagged rather than
 # silently repaired, since fixing them read at the time as touching a
-# historical corpus's own content. Owner ruling (#3697): repairing a link
+# historical corpus's own content. lead-coder ruling (#3697): repairing a link
 # is NOT rewriting what a record claims — the claim, conclusion, and any
 # measured value are untouched; only the citation's spelling changes to
 # reach the same real section. All 8 repaired on that basis, and this arm

--- a/tests/test_3126_doc_anchor_gate.py
+++ b/tests/test_3126_doc_anchor_gate.py
@@ -290,18 +290,22 @@ def _resolve_cross_file_target(doc_path: Path, target_path: str) -> Path | None:
 # citations' `_github_slugify` predictions matched the live page's actual
 # `href="#..."` fragment exactly, including the em-dash double-hyphen case).
 #
-# Deliberately scoped to a PUBLISHED citing doc only, excluding excluded-
-# doc-to-excluded-doc links (the `docs/deep-dives/journal/**` historical
-# dogfood/insight write-ups cross-link each other constantly — 9 such
-# links found while building this arm, several already dangling). Those
-# are a separate, much larger, unowned corpus: append-only historical
-# journal entries were never held to "citation stays live" rigor, and
-# sweeping them into a newly-red gate on this PR would be a scope decision
-# for whoever owns that corpus, not a side effect of closing #3672.
+# Originally scoped to a PUBLISHED citing doc only (#3672's landing PR,
+# #3696), deliberately excluding excluded-doc-to-excluded-doc links: the
+# `docs/deep-dives/journal/**` historical dogfood/insight write-ups
+# cross-link each other constantly, and building this arm's first version
+# found 9 such links, 8 already dangling (#3697) — flagged rather than
+# silently repaired, since fixing them read at the time as touching a
+# historical corpus's own content. Owner ruling (#3697): repairing a link
+# is NOT rewriting what a record claims — the claim, conclusion, and any
+# measured value are untouched; only the citation's spelling changes to
+# reach the same real section. All 8 repaired on that basis, and this arm
+# widened to cover excluded-source links too, so the 8/9 density doesn't
+# silently return the day the next citation goes stale — a one-time
+# repair with no gate is the exact "covers what existed when it ran, not
+# what exists now" shape #3718 named the same day.
 _CROSS_FILE_EXCLUDED_LINKS: list[tuple[Path, int, Path, str]] = []
 for _doc, _lineno, _target_path, _anchor in _CROSS_FILE_LINKS_ALL:
-    if _is_excluded(_doc.relative_to(_DOCS).as_posix(), _EXCLUDE_PREFIXES):
-        continue
     _target_rel = _resolve_cross_file_target(_doc, _target_path)
     if _target_rel is not None and _is_excluded(
         _target_rel.as_posix(), _EXCLUDE_PREFIXES


### PR DESCRIPTION
**[docs-maintainer]** — Closes #3697, per lead-coder's ruling (https://github.com/tya5/reyn/issues/3697#issuecomment-5198894845): link repair is not a content rewrite — a record's claims/conclusions/measured values are untouched by fixing a citation's spelling to reach the same real section.

## What changed (link-only, zero content changes)

- **7 dangling-anchor fixes**: `giveup-tracker.md#g31`/`#g12`/`#g23` (3/2/2 occurrences) repointed to their real, much-longer GitHub-rendered slugs — the headings (`G12:`/`G23:`/`G31:`) exist, the citer just guessed a short slug that was never real. Verified each is the SAME section before repointing (never silently repointed to a different one, per the ruling).
- **1 mis-titled citation**: `findings.md`'s F5-F8 section was cited under wording (`完全失敗の四重奏`) that never appears anywhere in that file's own git history — a hand-typed guess from the start (the #3039/#3124 hazard class, this time on the citing file's own intended target). Repointed to the real heading's real slug.
- **1 broken path**: `journal/dogfood/README.md:70` cited `../../en/concepts/runtime/permission-model.md` — a directory (`docs/deep-dives/en/`) that doesn't exist at all. Fixed to the real relative path. This target was never actually excluded — it only *looked* excluded because the bogus path happened to resolve under a `deep-dives/` prefix by coincidence. It's a real published page, so it's now naturally covered by `check_doc_anchors.py` going forward.

Verified via `git diff` that only the link target changed on each touched line — no prose, claim, or measured value moved.

## Gate widened, not just repaired

`test_3126_doc_anchor_gate.py`'s scope-3 arm (added in #3696 for the #3672 gap) was deliberately restricted to published-citing-doc → excluded-target. Widened here to cover excluded-source → excluded-target too: 8/9 broken is a density that reverts to the same state without a gate holding it — the exact "a one-time audit only covers what existed when it ran" shape #3718 named the same day.

Falsified before shipping: renamed a real heading, confirmed both citations into it fail with the expected message, reverted.

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean
- [x] `python scripts/check_doc_anchors.py` — 0 dangling anchors
- [x] `pytest tests/test_3126_doc_anchor_gate.py` — 329/329 pass (up from 321 — 8 more cases now gated)
- [x] `ruff check` / `test_tier_audit.py --strict` — clean
- [x] Falsified the widened scope (renamed a real heading, confirmed RED, reverted, confirmed GREEN)