### PR TITLE
fix(runtime): add project-root resolution to reyn memory CLI (#3716)

### DIFF
--- a/src/reyn/data/memory/memory_paths.py
+++ b/src/reyn/data/memory/memory_paths.py
@@ -12,12 +12,19 @@ from __future__ import annotations
 from pathlib import Path
 
 
-def memory_dir(agent: str | None = None) -> Path:
+def memory_dir(agent: str | None = None, root: Path | None = None) -> Path:
     """Memory directory for the given layer.
 
     `agent=None` (default) → shared layer.
     `agent="<name>"`       → that agent's scoped layer.
+
+    ``root`` (#3716): the caller's already-resolved project root
+    (``.reyn``-inclusive — same convention as
+    ``reyn.runtime.services.recovery.default_snapshot_path``'s ``root``
+    param, #3705). ``None`` (every caller that has no root to supply) falls
+    back to ``Path.cwd() / ".reyn"`` — the exact previous behavior.
     """
+    base = root if root is not None else Path.cwd() / ".reyn"
     if agent is None:
-        return Path(".reyn") / "memory"
-    return Path(".reyn") / "agents" / agent / "memory"
+        return base / "memory"
+    return base / "agents" / agent / "memory"

--- a/src/reyn/interfaces/cli/commands/memory.py
+++ b/src/reyn/interfaces/cli/commands/memory.py
@@ -85,6 +85,17 @@ def register(sub) -> None:
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 
+def _project_reyn_root() -> Path:
+    """#3716: the SAME project-root resolution `reyn chat` already uses
+    (`_find_project_root(Path.cwd()) or Path.cwd()`, then `/ ".reyn"` —
+    matching `env_backend.py`'s `workspace_state_dir` convention, #3705) —
+    `reyn memory` had no project-root resolution anywhere in its own call
+    chain before this, so every write silently followed the ambient cwd
+    with no way for a caller to override it."""
+    from reyn.config import _find_project_root
+    return (_find_project_root(Path.cwd()) or Path.cwd()) / ".reyn"
+
+
 def _layer_dir(args: argparse.Namespace) -> Path:
     """Resolve the memory directory for the layer the user picked.
 
@@ -92,10 +103,11 @@ def _layer_dir(args: argparse.Namespace) -> Path:
     Validates that the agent profile exists when `--agent` is given so we
     don't silently scan an empty directory.
     """
+    root = _project_reyn_root()
     agent = getattr(args, "agent", None)
     if agent is None:
-        return memory_dir()
-    profile_path = Path(".reyn") / "agents" / agent / "profile.yaml"
+        return memory_dir(root=root)
+    profile_path = root / "agents" / agent / "profile.yaml"
     if not profile_path.is_file():
         print(
             f"Error: agent {agent!r} not found "
@@ -104,7 +116,7 @@ def _layer_dir(args: argparse.Namespace) -> Path:
             file=sys.stderr,
         )
         sys.exit(1)
-    return memory_dir(agent)
+    return memory_dir(agent, root=root)
 
 
 def _layer_label(args: argparse.Namespace) -> str:

--- a/tests/test_memory_cli_project_root_3716.py
+++ b/tests/test_memory_cli_project_root_3716.py
@@ -1,0 +1,70 @@
+"""#3716 — `reyn memory` CLI project-root resolution.
+
+Deferred from #3705's Session-write-path fix: `reyn memory` had NO
+project-root resolution anywhere in its own call chain — `memory_dir()`
+(`data/memory/memory_paths.py`) took no root argument at all, so every
+write/read silently followed the ambient process cwd with no way for a
+caller to override it (unlike `default_snapshot_path`, whose `root=` param
+#3705 added — a value the caller could supply but the callee ignored;
+`reyn memory` had no value to supply in the first place).
+
+`memory_dir()` gains a `root=` param (same convention as
+`default_snapshot_path`), and `interfaces/cli/commands/memory.py` gains its
+own project-root resolution (`_project_reyn_root`, mirroring `reyn chat`'s
+`_find_project_root(Path.cwd()) or Path.cwd()`), threaded through
+`_layer_dir` — the CLI's single seam every subcommand already goes through.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from reyn.data.memory.memory_paths import memory_dir
+from reyn.interfaces.cli.commands.memory import _layer_dir, _project_reyn_root
+
+
+def test_memory_dir_respects_an_explicit_root():
+    """Tier 2: #3716 — `memory_dir(root=...)` is anchored on the given root,
+    not the ambient cwd."""
+    root = Path("/some/project/.reyn")
+    assert memory_dir(agent=None, root=root) == root / "memory"
+    assert memory_dir(agent="alpha", root=root) == root / "agents" / "alpha" / "memory"
+
+
+def test_memory_dir_falls_back_to_cwd_when_root_is_none(tmp_path, monkeypatch):
+    """Tier 2: regression guard — `root=None` (the default) is byte-identical
+    to the pre-#3716 behavior."""
+    monkeypatch.chdir(tmp_path)
+    assert memory_dir(agent=None) == tmp_path / ".reyn" / "memory"
+
+
+def test_project_reyn_root_walks_up_to_the_real_project_root(tmp_path, monkeypatch):
+    """Tier 2: #3716 — `_project_reyn_root()` finds the SAME project root
+    `reyn chat` would, walking UP from a subdirectory the operator happens
+    to be standing in — not just the immediate cwd. This is what makes
+    `reyn memory list` (run from a project subdirectory, the normal way any
+    reyn CLI command is invoked) resolve to the project's real `.reyn/`,
+    not fabricate one under the subdirectory."""
+    project_root = tmp_path / "my-project"
+    (project_root / "src" / "deep" / "subdir").mkdir(parents=True)
+    (project_root / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    monkeypatch.chdir(project_root / "src" / "deep" / "subdir")
+
+    assert _project_reyn_root() == project_root / ".reyn"
+
+
+def test_layer_dir_uses_the_project_root_not_raw_cwd(tmp_path, monkeypatch):
+    """Tier 2: #3716 core witness — `_layer_dir(args)` (every `reyn memory`
+    subcommand's single directory-resolution seam) resolves under the
+    PROJECT root, not wherever the process happens to be standing when
+    invoked from a subdirectory."""
+    project_root = tmp_path / "my-project"
+    subdir = project_root / "some" / "nested" / "cwd"
+    subdir.mkdir(parents=True)
+    (project_root / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    monkeypatch.chdir(subdir)
+
+    args = argparse.Namespace(agent=None)
+    assert _layer_dir(args) == project_root / ".reyn" / "memory"
+    # NOT resolved against the subdirectory the process happened to start in.
+    assert _layer_dir(args) != subdir / ".reyn" / "memory"

--- a/tests/test_memory_invariants.py
+++ b/tests/test_memory_invariants.py
@@ -420,9 +420,14 @@ def test_memory_dir_shared_path():
     Protects: callers that build paths to the shared layer must get a stable,
     predictable path. If this path drifts, skills and the CLI disagree on
     where shared memory lives.
+
+    #3716: `memory_dir()`'s no-``root`` fallback is now an explicit
+    ``Path.cwd() / ".reyn"`` (was a bare relative literal) — same location
+    on disk, but a relative and an absolute ``Path`` are never ``==``, so
+    this compares against the resolved absolute form.
     """
     result = memory_dir(agent=None)
-    assert result == Path(".reyn") / "memory"
+    assert result == Path.cwd() / ".reyn" / "memory"
 
 
 def test_memory_dir_agent_path():
@@ -430,9 +435,12 @@ def test_memory_dir_agent_path():
 
     Protects: the agent-scoped path contract. Skills that write to their own
     scope and callers that read from it must agree on the path structure.
+
+    #3716: see `test_memory_dir_shared_path` — same relative-vs-absolute
+    ``Path`` note.
     """
     result = memory_dir(agent="my_agent")
-    assert result == Path(".reyn") / "agents" / "my_agent" / "memory"
+    assert result == Path.cwd() / ".reyn" / "agents" / "my_agent" / "memory"
 
 
 # ── render_body ────────────────────────────────────────────────────────────────

--- a/tests/test_workspace_root_not_cwd_3705.py
+++ b/tests/test_workspace_root_not_cwd_3705.py
@@ -178,6 +178,16 @@ def _cwd_relative_reyn_sites(py_file: Path) -> "list[int]":
 #   agent.py, recovery.py, session.py (`_reyn_state_root`),
 #   router_host_adapter.py, replay_preconditions.py (explicitly documented
 #   as intentionally mirroring router_host_adapter's own convention).
+#   #3716: `data/memory/memory_paths.py`'s `memory_dir(root=None)` fallback
+#   joins this group too — `reyn memory` now HAS project-root plumbing
+#   (`interfaces/cli/commands/memory.py`'s `_project_reyn_root`), so this
+#   ONE site (a single `base = root if root is not None else Path.cwd() /
+#   ".reyn"` shared by both the "shared" and "agent" branches) is the
+#   intentional `root=None` default, not an unaddressed gap
+#   (lead-coder review, #3722: the gate counts sites, it does not read
+#   REASONS — a stable count at an already-allowlisted path can silently go
+#   stale in what it's claiming, which is exactly what happened here when
+#   #3716 landed without also updating this comment).
 # - Genuine top-level CLI entry points, where "operate on whatever project
 #   the operator is standing in" IS the intended behavior (the same way
 #   `git status` reads the cwd) — not Session-owned, not reachable via
@@ -187,16 +197,21 @@ def _cwd_relative_reyn_sites(py_file: Path) -> "list[int]":
 #   interfaces/cli/commands/{agent,dogfood,events,mcp,web}.py,
 #   interfaces/web/server.py (the `reyn web` server's own persist paths),
 #   dev/dogfood/runner.py.
-# - Deferred (filed separately, NOT fixed here): `data/memory/memory_paths.py`
-#   and `interfaces/cli/commands/memory.py` — genuinely need NEW project-root
-#   plumbing (`reyn memory` has none today), not a value silently ignored;
-#   same "file it, don't force it" judgment as #3671 P4's A-3/C-2/D-2.
+# - Deferred (filed separately, NOT fixed here): `interfaces/slash/memory.py`
+#   (#3721) — the `/memory` chat command calls `list_entries()`/`find_one()`
+#   with no arguments, falling into the same `memory_dir()` cwd-relative
+#   default, but this file has ZERO `Path(".reyn")`/`Path.cwd() / ".reyn"`
+#   literals of its OWN (the defect lives entirely in the CALLEE it doesn't
+#   override), so it does not appear as its own allowlist entry — #3721 is
+#   tracked there, not here, because this gate only sees literal cwd-anchor
+#   EXPRESSIONS, not "a caller that omitted an available override".
 _ALLOWED_SITES: "dict[str, int]" = {
     "src/reyn/runtime/agent.py": 1,
     "src/reyn/runtime/services/recovery.py": 1,
     "src/reyn/runtime/session.py": 1,
     "src/reyn/runtime/services/router_host_adapter.py": 1,
     "src/reyn/dev/testing/replay_preconditions.py": 1,
+    "src/reyn/data/memory/memory_paths.py": 1,  # Session-owned fallback (root=None), see comment above
     "src/reyn/interfaces/cli/commands/agent.py": 3,
     "src/reyn/interfaces/cli/commands/dogfood.py": 1,
     "src/reyn/interfaces/cli/commands/events.py": 1,
@@ -204,8 +219,6 @@ _ALLOWED_SITES: "dict[str, int]" = {
     "src/reyn/interfaces/cli/commands/web.py": 1,
     "src/reyn/interfaces/web/server.py": 2,
     "src/reyn/dev/dogfood/runner.py": 1,
-    "src/reyn/data/memory/memory_paths.py": 2,  # deferred, see comment above
-    "src/reyn/interfaces/cli/commands/memory.py": 1,  # deferred, see comment above
 }
 
 


### PR DESCRIPTION
**[e2e-coder]** — #3716。#3705から切り出された「reyn memory CLIにはproject-root解決がそもそも存在しない」問題への対応。

## 実装

- `data/memory/memory_paths.py`の`memory_dir()`に`root=`引数追加（`default_snapshot_path`と同じ規約、#3705）
- `interfaces/cli/commands/memory.py`に新規`_project_reyn_root()`——`reyn chat`が既に使っている`_find_project_root(Path.cwd()) or Path.cwd()`の歩行をそのまま再利用
- 全サブコマンドが通る唯一の窓口`_layer_dir()`に`root`を通す——プロジェクトのサブディレクトリから`reyn memory`を実行しても（通常のCLI利用パターン）実プロジェクトルートを解決するようになりました（従来は起動時cwd直下に新規`.reyn/`を作ってしまう挙動）

## 別件発見（#3721へ切り出し・本PR未対応）

実装中に`interfaces/slash/memory.py`（`/memory`チャットスラッシュコマンド、**実セッション中に到達可能**）も引数無しで`list_entries()`/`find_one()`を呼んでおり同じcwd依存だと判明。こちらは`ctx.session`読み取りが必要ですが、`#3595 S4`移行の**ratchet gate**（`test_3595_s4_slash_handler_seam.py`——session直接アクセスは縮小方向のみ許可）と衝突するため、単純に直すとその移行方針に逆行します。設計判断を要するため#3721へ分離しました。

## テスト（4本新規 + 既存2本更新）

新規 `tests/test_memory_cli_project_root_3716.py`:
- `memory_dir(root=...)`が明示的rootを尊重
- `root=None`でcwd fallback不変（regression guard）
- `_project_reyn_root()`がサブディレクトリから実プロジェクトルートまで正しく歩行
- `_layer_dir(args)`がproject rootを使う（raw cwdでない）——core witness

既存 `tests/test_memory_invariants.py`の2件を更新——`memory_dir()`のno-root fallbackが相対リテラルから絶対`Path.cwd()/".reyn"`表現に変わったための比較調整（実際の書き込み先は不変、Pathオブジェクトの絶対/相対表現の差のみ、#3705の同型修正と同じ理由）

RED-before-fix: `_project_reyn_root`不在によるImportErrorで確認。

## CI

- ruff: green
- `test_tier_audit.py --strict`: green
- `verify_module_docstrings.py`: green
- 関連テスト37件green
- full suite: 9797 passed / 10 failed / 70 skipped / 14 errors — failed/errorは既存baselineと**同一集合**（増分ゼロ）

## 作業環境について

owner実行環境（`../user`）への書き込み事故を受け、本PRの全作業は隔離されたscratch worktree（独自venv）で実施しました。`../user`は一切使用していません。

Part of #3705（`reyn memory` CLI分。`/memory`スラッシュコマンド分は#3721へ）