### PR TITLE
feat(#3680): keep a readable conversation on a short terminal

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -83,6 +83,7 @@ from .chrome import (
     pane_payload,
     status_line_text,
 )
+from .compact import compact_caps
 from .completion import CompletionPopup, CompletionState, compute_completion
 from .gutter import (
     _RUNNING_FRAME_PERIOD,
@@ -1999,6 +2000,7 @@ class TextualChatApp(App):
         if tab_id is None or tab_id == "__close__":
             drawer.display = False
             drawer.current = None
+            self._apply_compact_layout()
             self.query_one(Composer).focus()
             return
         drawer.current = tab_id
@@ -2007,6 +2009,7 @@ class TextualChatApp(App):
         # (a snapshot read once at compose time would be stale by first open).
         self._refresh_pane(tab_id)
         drawer.display = True
+        self._apply_compact_layout()
         child = drawer.query_one(f"#{tab_id}")
         if isinstance(child, OptionList):
             child.focus()
@@ -2074,6 +2077,48 @@ class TextualChatApp(App):
         if 0 <= event.option_index < len(cmds) and cmds[event.option_index]:
             await self._submit(cmds[event.option_index])
         self._open_drawer(None)
+
+    def _apply_compact_layout(self) -> None:
+        """Re-decide how much room the transient regions may take (#3680).
+
+        Called whenever the answer can change: a resize, or a region opening or
+        closing. The decision itself is :func:`compact_caps` — a pure function
+        of the height and what is open — so the policy can be read and tested
+        without a terminal, and this stays the wiring only.
+
+        Every region it shrinks still holds everything it had: the drawer, the
+        picker and the completion popup scroll (#3688/#3699), and the queue
+        keeps every item behind its count. Nothing here drops content to make
+        room, which is the line #3688 established.
+        """
+        try:
+            queue = self.query_one(SentQueue)
+            drawer = self.query_one("#drawer", ContentSwitcher)
+        except Exception:
+            return  # before compose, or after teardown: nothing to decide
+        caps = compact_caps(
+            self.size.height,
+            drawer_open=bool(drawer.display),
+            rewind_open=bool(self._rewind_picker.display),
+            completion_open=bool(self._completion.display),
+            queue_items=len(queue.rendered_texts()) if queue.has_items() else 0,
+            turn_active=self._activity.state is not None,
+            intervention_open=bool(self._iv_panel.display),
+        )
+        if drawer.display and not caps["drawer"]:
+            # Priority 7: there is no height at which this fits and leaves a
+            # readable conversation, so it closes rather than becoming a
+            # sliver that has taken the conversation with it.
+            self._open_drawer(None)
+            return
+        drawer.styles.max_height = caps["drawer"] or None
+        self._rewind_picker.styles.max_height = caps["rewind"] or None
+        self._completion.styles.max_height = caps["completion"] or None
+        queue.set_summarised(queue.has_items() and not caps["queue"])
+
+    def on_resize(self, event) -> None:
+        """A resize changes the whole answer, so re-decide (#3680)."""
+        self._apply_compact_layout()
 
     async def action_cancel_turn(self) -> None:
         """ctrl+c: cooperatively interrupt the in-flight turn (#3498).
@@ -2969,6 +3014,7 @@ class TextualChatApp(App):
         if applied and msg_id:
             self._queue_item_meta[msg_id] = dict(data.get("meta") or {})
             self._sent_queue.show_item(msg_id, text)
+            self._apply_compact_layout()
         elif not applied:
             # #3688: the rejecting branch used to be pure absence — no row, no
             # log, no trace of any kind. "The server dropped it", "the gate
@@ -3696,6 +3742,17 @@ class TextualChatApp(App):
                 # loop) and guarded so a snapshot read failure never kills the pump.
                 try:
                     self._refresh_live_chrome()
+                    # #3680: the inputs to the layout decision (a turn
+                    # starting, an item queued) arrive on these same frames,
+                    # so re-deciding here is what keeps the answer from being
+                    # computed against state that has not landed yet — the
+                    # first version decided at open-time only and was a frame
+                    # behind, which measured as one row too many for the
+                    # drawer.
+                    try:
+                        self._apply_compact_layout()
+                    except Exception:
+                        logger.exception("textual chat: compact layout failed")
                 except Exception:
                     logger.exception("textual chat: live chrome refresh failed")
         finally:

--- a/src/reyn/interfaces/inline/textual_chat/compact.py
+++ b/src/reyn/interfaces/inline/textual_chat/compact.py
@@ -1,0 +1,118 @@
+"""How much room the transient regions may take on a short terminal (#3680).
+
+The zone above the composer stacks: an intervention panel, the ``/rewind``
+picker, the live-turn row, the sent queue, the completion popup, the search
+bar — each with its own cap, and none of them aware of the others. Measured at
+80x20 with three messages queued, a turn running and the Help drawer open, the
+conversation was left **one row**. Every region was within its own limit.
+
+So the caps have to be decided together, against the height actually
+available, rather than one at a time. This module is that decision, as a pure
+function of the terminal height and which regions want space — pure so the
+policy can be reasoned about and tested without mounting anything, and so the
+same numbers can be asserted directly rather than inferred from a screenshot.
+
+The order regions give way in is the issue's, and it is an order of
+consequence, not of size:
+
+1. the composer keeps its three rows — losing the line you are typing is worse
+   than losing anything else;
+2. the conversation keeps :data:`FLOW_MIN` — below that it stops being a
+   conversation and becomes a viewport;
+3. a pending intervention stays visible and operable — it is a question
+   somebody is waiting on;
+4. the completion popup, the rewind picker and the drawer shrink, in that
+   order, because each still holds every item it had: they scroll (#3688,
+   #3699), so a smaller box hides nothing;
+5. the sent queue collapses to a count only as a last resort, and never drops
+   an item — the queue is durable state, and #3688 is the record of what
+   happens when a region silently stops showing part of it.
+"""
+from __future__ import annotations
+
+#: Rows the conversation must keep. Eight is the acceptance figure from #3680:
+#: enough for a short exchange to remain readable as an exchange rather than a
+#: peephole onto the newest line.
+FLOW_MIN = 8
+
+#: Rows the composer must keep (its content line plus its two rules).
+COMPOSER_MIN = 3
+
+#: What each region asks for when nothing is squeezing it — the caps that were
+#: already in the stylesheets before this policy existed.
+DRAWER_MAX = 12
+REWIND_MAX = 12
+COMPLETION_MAX = 10
+QUEUE_MAX = 6
+
+
+def compact_caps(
+    screen_height: int,
+    *,
+    drawer_open: bool = False,
+    rewind_open: bool = False,
+    completion_open: bool = False,
+    queue_items: int = 0,
+    turn_active: bool = False,
+    intervention_open: bool = False,
+) -> "dict[str, int]":
+    """Height caps for the transient regions, given the room there is.
+
+    Returns a cap per region name. ``queue`` of ``0`` means the queue should
+    render as its one-line ``Queued: N`` summary instead of a row per item —
+    still every item, still cancellable, just not spending a row each.
+
+    Only regions that are actually open take part: a closed drawer is not
+    competing for anything, so a terminal that is short but uncluttered is
+    left alone.
+    """
+    fixed = COMPOSER_MIN + _CHROME_ROWS
+    if turn_active:
+        fixed += 1  # the live-turn row
+    if intervention_open:
+        fixed += _INTERVENTION_ROWS
+
+    spare = screen_height - fixed - FLOW_MIN
+    caps = {
+        "drawer": DRAWER_MAX if drawer_open else 0,
+        "rewind": REWIND_MAX if rewind_open else 0,
+        "completion": COMPLETION_MAX if completion_open else 0,
+        "queue": min(queue_items, QUEUE_MAX) if queue_items else 0,
+    }
+
+    # Give way in reverse order of consequence: the completion popup first (it
+    # is mid-keystroke and scrolls), then the picker, then the drawer, and the
+    # queue's own rows only once the others are at their floor.
+    for name, floor in (("completion", 3), ("rewind", 3), ("drawer", 3)):
+        if spare >= sum(caps.values()):
+            break
+        excess = sum(caps.values()) - spare
+        if caps[name] > floor:
+            caps[name] = max(floor, caps[name] - excess)
+
+    if sum(caps.values()) > spare and caps["queue"]:
+        # Last: the queue becomes a count. It keeps every item — this is the
+        # one region whose contents are durable state a person is waiting on,
+        # so it may lose its rows but never an entry (#3688).
+        caps["queue"] = 0
+
+    # Last resort, and the issue's own priority 7: a region that cannot be made
+    # small enough to leave a readable conversation is CLOSED rather than left
+    # as a sliver. A two-row drawer is not a smaller drawer, it is an unusable
+    # one that has also taken the conversation with it — and closing is
+    # reversible by the same keystroke that opened it, on a terminal where
+    # reopening at a workable height is a resize away.
+    for name in ("completion", "rewind", "drawer"):
+        if sum(caps.values()) > spare and caps[name]:
+            caps[name] = 0
+
+    return caps
+
+
+#: Rows the always-present chrome occupies: the menu row and the status row it
+#: packs onto, plus the rule above the input.
+_CHROME_ROWS = 3
+
+#: Rows a pending intervention keeps — its prompt and one answer line. It is
+#: never squeezed below this: it is a question somebody is waiting on.
+_INTERVENTION_ROWS = 4

--- a/src/reyn/interfaces/inline/textual_chat/sent_queue.py
+++ b/src/reyn/interfaces/inline/textual_chat/sent_queue.py
@@ -150,6 +150,15 @@ class SentQueue(Vertical):
         self._rows: "dict[str, Static]" = {}
         self._labels: "dict[str, str]" = {}
         self._selected_index = 0
+        #: #3680: when the terminal is too short to give the queue a row per
+        #: item, it renders as one ``Queued: N`` line instead. Every item is
+        #: still HERE — the rows are what is given up, never an entry, because
+        #: this region's contents are durable state somebody is waiting on.
+        self._summarised = False
+        # The one-line stand-in, mounted once and hidden until it is needed.
+        self._summary = Static("", id="sent-queue-summary")
+        self.mount(self._summary)
+        self._summary.display = False
 
     def show_item(self, msg_id: str, text: str) -> None:
         """Materialize a queued item (``user_submitted``): neutralize the
@@ -207,7 +216,15 @@ class SentQueue(Vertical):
     def rendered_texts(self) -> "list[str]":
         """The currently-queued rows' rendered text, oldest first — the
         public read a caller (a test, or a future consumer) uses to inspect
-        displayed content without reaching into private widget state."""
+        displayed content without reaching into private widget state.
+
+        #3680: while the region is summarised it returns the summary — what is
+        ON SCREEN, not what would be there at full height. A reader of this
+        surface asking "what does the queue show" must not be told about rows
+        the operator cannot see; the item COUNT is still ``len(queue())`` on
+        the model, which is where "what is queued" belongs."""
+        if self._summarised:
+            return [str(self._summary.content)] if self._rows else []
         return [str(row.content) for row in self._rows.values()]
 
     def has_items(self) -> bool:
@@ -252,6 +269,23 @@ class SentQueue(Vertical):
         last = max(len(self._rows) - 1, 0)
         self._selected_index = max(0, min(self._selected_index, last))
 
+    def set_summarised(self, summarised: bool) -> None:
+        """Render as one ``Queued: N`` line (``True``) or a row per item.
+
+        The queue keeps every item either way, so this is reversible the
+        moment the room comes back."""
+        if self._summarised == summarised:
+            return
+        self._summarised = summarised
+        for row in self._rows.values():
+            row.display = not summarised
+        self._apply_highlight()
+
+    @property
+    def summarised(self) -> bool:
+        """Whether the queue is currently showing a count instead of rows."""
+        return self._summarised
+
     def _apply_highlight(self) -> None:
         """Mark the selected row, in its TEXT as well as its style.
 
@@ -260,6 +294,14 @@ class SentQueue(Vertical):
         the queue text aligned so the marker reads as a pointer rather than as
         the rows shifting."""
         order = list(self._rows.keys())
+        if self._summarised:
+            # One line, and it names the count rather than implying the rows
+            # were dropped. Selection is untouched underneath: restoring the
+            # rows restores exactly what was selected.
+            self._summary.update(Content(f"  Queued: {len(order)}"))
+            self._summary.display = bool(order)
+            return
+        self._summary.display = False
         for i, msg_id in enumerate(order):
             selected = i == self._selected_index
             row = self._rows[msg_id]

--- a/tests/test_compact_layout_3680.py
+++ b/tests/test_compact_layout_3680.py
@@ -1,0 +1,256 @@
+"""#3680 — a short terminal keeps a readable conversation.
+
+Every region above the composer had its own height cap and none knew about the
+others. Measured before this change, at 80x20 with three messages queued, a
+turn running and the Help drawer open, the conversation was left **one row** —
+and every region was inside its own limit. The caps were individually correct
+and collectively wrong.
+
+Two halves, gated separately because they fail differently:
+
+- :func:`compact_caps` is a pure function of the height and what is open, so
+  the policy itself can be asserted directly rather than inferred from a
+  rendered screen. A policy bug shows up here as a number.
+- the wiring is gated on a real app, because a correct policy computed from
+  stale inputs is still wrong on screen — measured: the first version decided
+  only when a region opened, which was a frame before the turn state landed,
+  and gave the drawer one row too many.
+
+What the policy may NOT do is drop content to make room. Everything it shrinks
+still holds every item it had: the drawer, the picker and the completion popup
+scroll (#3688, #3699), and the queue keeps every entry behind its count. That
+line is gated too — #3688 is the record of what a region silently showing less
+than it holds costs.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.compact import (
+    COMPOSER_MIN,
+    FLOW_MIN,
+    compact_caps,
+)
+from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.runtime.outbox import OutboxMessage
+from reyn.schemas.models import Event
+
+
+class QueueTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` (the shared test idiom)."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+
+    async def push_event(self, event: Event) -> None:
+        await self._queue.put(EventFrame(event))
+
+    async def push_display(self, msg: OutboxMessage) -> None:
+        await self._queue.put(DisplayFrame(msg))
+
+    def start(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str) -> None:
+        pass
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        pass
+
+    async def cancel_inflight(self) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+
+
+# ── the policy, without a terminal ───────────────────────────────────────────
+
+
+def test_a_roomy_terminal_is_left_alone() -> None:
+    """Tier 1: nothing is squeezed when nothing needs to be.
+
+    A policy that shrank regions on a tall terminal would be paying the cost
+    everywhere to fix the case that only happens somewhere.
+    """
+    caps = compact_caps(40, drawer_open=True, queue_items=3, turn_active=True)
+
+    assert caps["drawer"] == 12, "a tall terminal has no reason to shrink the drawer"
+    assert caps["queue"] == 3, "and no reason to collapse the queue"
+
+
+def test_the_queue_keeps_its_rows_until_everything_else_has_given_way() -> None:
+    """Tier 1: the queue collapses last.
+
+    It is the one region holding durable state somebody is waiting on, so it
+    gives up its rows only once the scrollable regions are at their floor.
+    """
+    caps = compact_caps(24, drawer_open=True, queue_items=3, turn_active=True)
+
+    assert caps["queue"], "the queue collapsed while the drawer still had room"
+    assert caps["drawer"] < 12, "the drawer did not give way first"
+
+
+def test_a_region_that_cannot_fit_is_closed_rather_than_slivered() -> None:
+    """Tier 1: below a usable height the drawer closes.
+
+    A two-row drawer is not a smaller drawer — it is an unusable one that has
+    also taken the conversation with it.
+    """
+    caps = compact_caps(16, drawer_open=True, queue_items=3, turn_active=True)
+
+    assert caps["drawer"] == 0
+
+
+def test_the_policy_never_asks_for_more_than_there_is() -> None:
+    """Tier 1: across every height, the caps leave the two minimums intact.
+
+    Swept rather than spot-checked: the failure this exists to stop was a
+    combination nobody had tried, so asserting one combination would repeat
+    the mistake.
+    """
+    for height in range(12, 41):
+        for drawer in (False, True):
+            for queued in (0, 3, 6):
+                caps = compact_caps(
+                    height,
+                    drawer_open=drawer,
+                    queue_items=queued,
+                    turn_active=True,
+                )
+                asked = sum(caps.values())
+                room = height - COMPOSER_MIN - FLOW_MIN
+                assert asked <= room, (
+                    f"at height {height} (drawer={drawer}, queued={queued}) the "
+                    f"policy asked for {asked} rows with only {room} to give"
+                )
+
+
+# ── the wiring, on a real app ────────────────────────────────────────────────
+
+
+async def _crowded(app, transport, pilot, *, drawer: bool = True):
+    """Three queued, a turn running, and the Help drawer open — the owner's
+    worst case and the one measured at one row of conversation."""
+    for i in range(3):
+        await transport.push_event(
+            Event(
+                type="user_submitted",
+                data={
+                    "text": f"queued {i}",
+                    "chain_id": f"c{i}",
+                    "msg_id": f"m{i}",
+                    "seq": i + 1,
+                    "meta": {},
+                },
+            )
+        )
+    await transport.push_event(
+        Event(type="turn_started", data={"kind": "user", "chain_id": "cX", "seq": 99})
+    )
+    if drawer:
+        app._open_drawer("help")
+    for _ in range(8):
+        await pilot.pause()
+
+
+@pytest.mark.parametrize("height", [24, 20, 16])
+@pytest.mark.asyncio
+async def test_the_conversation_keeps_its_minimum_on_a_short_terminal(height) -> None:
+    """Tier 2b: the acceptance condition, on the real app at three heights.
+
+    80x24 is the figure #3680 names; the shorter two are where the same stack
+    was worst (measured before: one row at 80x20, one at 80x16).
+    """
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(80, height)) as pilot:
+        await pilot.pause()
+        await _crowded(app, transport, pilot)
+
+        flow = app.query_one(FlowView).size.height
+        assert flow >= FLOW_MIN, (
+            f"at 80x{height} the conversation was left {flow} rows with every "
+            "region inside its own cap — the caps were individually correct "
+            "and collectively wrong"
+        )
+
+
+@pytest.mark.asyncio
+async def test_collapsing_the_queue_loses_no_item() -> None:
+    """Tier 2b: the summary is a rendering, not a truncation.
+
+    #3688 is the record of what a region silently showing less than it holds
+    costs. The queue may stop spending a row per item; it may not stop having
+    them.
+    """
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(80, 16)) as pilot:
+        await pilot.pause()
+        await _crowded(app, transport, pilot)
+
+        queue = app.query_one(SentQueue)
+        assert queue.summarised, "the queue did not collapse where it had to"
+        assert queue.has_items(), "the queue reported itself empty once collapsed"
+        assert "3" in " ".join(queue.rendered_texts()), (
+            f"the summary does not say how many are waiting: {queue.rendered_texts()}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_room_returning_restores_the_rows() -> None:
+    """Tier 2b: the policy is reversible.
+
+    Everything it does is a rendering decision, so closing the thing that was
+    competing has to put the queue's rows back — otherwise a moment of
+    crowding would cost the operator their view for the rest of the session.
+    """
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(80, 16)) as pilot:
+        await pilot.pause()
+        await _crowded(app, transport, pilot)
+        queue = app.query_one(SentQueue)
+        assert queue.summarised
+
+        # Closing the drawer is not enough at THIS height — the stack still
+        # does not fit — which is itself the point: the collapse tracks the
+        # room, not a latch that once set stays set. The policy says so for a
+        # taller terminal, and the widget round-trips when told.
+        assert compact_caps(34, queue_items=3, turn_active=True)["queue"] == 3, (
+            "the policy would not restore the rows even given the room"
+        )
+
+        queue.set_summarised(False)
+        await pilot.pause()
+        assert not queue.summarised
+        assert len(queue.rendered_texts()) == 3, (
+            f"the rows did not come back: {queue.rendered_texts()}"
+        )


### PR DESCRIPTION
**[tui-coder]** — Closes #3680

## The problem, measured

Every region above the composer had its own height cap and **none knew about the
others**. At 80×20 with three messages queued, a turn running and the Help
drawer open, the conversation was left **one row** — and every region was inside
its own limit. The caps were individually correct and collectively wrong.

```
condition                 flow before -> after
(80,24) q3+turn+help            2  ->  8
(80,20) q3+turn+help            1  ->  9
(80,16) q3+turn                 6  ->  8
(80,16) q3+turn+help            1  ->  8
```

## The decision, in one place

`compact.py` is a **pure function** of the terminal height and what is open. Pure
so the policy can be read and asserted as numbers rather than inferred from a
rendered screen — and so **a policy bug and a wiring bug fail in different
places**.

Regions give way in the issue's order, which is an order of **consequence, not
of size**:

1. the composer keeps its three rows
2. the conversation keeps eight
3. a pending intervention stays visible and operable
4. the completion popup, the picker and the drawer shrink
5. the queue collapses to `Queued: N`
6. a region that still cannot fit **closes** rather than becoming a sliver

## Nothing here drops content to make room

- the regions that shrink all **scroll** (#3688, #3699), so a smaller box hides
  nothing;
- the queue keeps **every item** behind its count — it may lose its rows, never
  an entry;
- a drawer with no usable height closes, because a two-row drawer is not a
  smaller drawer, it is an unusable one that has also taken the conversation.

#3688 is the record of what a region silently showing less than it holds costs,
so that line is gated rather than asserted in prose.

`SentQueue.rendered_texts()` returns the summary while collapsed — the public
read reports **what is on screen**, not what would be there at full height.

## Two of my own mistakes, both invisible to the tools

- **the policy method was never inserted.** I anchored the edit on a name that
  exists only on another branch, so the *call sites* landed and the method did
  not. `ruff` passes on a call to a method that does not exist; only running it
  showed the `AttributeError`.
- **the first wiring was a frame stale.** It decided only when a region opened —
  which is before the turn state lands — and measured as one row too many for
  the drawer. It now re-decides on the frames that carry those inputs.

## Test plan

- [x] `tests/test_compact_layout_3680.py` — 9 gates. The policy is swept across
      heights 12–40 × drawer × queue depth rather than spot-checked, because the
      failure this exists to stop **was a combination nobody had tried**.
- [x] The acceptance condition on a real app at 80×24, 80×20 and 80×16.
- [x] The collapsed queue keeps every item and says how many.
- [x] Existing suites — 106 passed (queue render, #3688 overflow, #3699 drawer,
      #3693 activity row, completion, status chrome): every prior contract intact.
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 0 errors
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] Full `pytest` — **10063 passed, 11 failed**. The 11 are byte-identical to
      what `origin/main` produces on this machine (`comm` of the sorted FAILED
      lists is empty in both directions), so nothing here is new.
- [ ] Owner confirmation on their own machine — after merge.

⚠️ **On the "same as main" claim**: those 11 also fail on `origin/main` in this
environment. That comparison detects anything **this branch** breaks — the
environment applies equally to both sides — but it does not license calling them
"environmental". Since writing that, two have been pinned down and one has not:

- `test_plain_path_survives_flowview_absence` — the subprocess reads the
  *installed* reyn rather than the worktree. Independently named by #3725's
  `verify_env_identity.py` as `tree-identity/inherited`, so this is confirmed
  rather than inferred.
- my `textual-flowview` was an editable install from a local clone rather than
  the pinned commit (`flowview-pin/local-copy`). Same commit, but not the same
  provenance — reinstalled from the pin, and the checker is clean on that
  finding now.
- `ctrl+f did not open the search bar` remains **unexplained**, and I am
  recording it as unexplained rather than folding it into the two above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
