### PR TITLE
test(env-identity): gate the full suite on the textual-flowview pin (#3723)

### DIFF
--- a/scripts/verify_env_identity.py
+++ b/scripts/verify_env_identity.py
@@ -507,8 +507,12 @@ def check_flowview_pin(root: Path) -> list[Finding]:
                 ),
                 remedy=(
                     f"pip install 'textual-flowview @ git+{expected_url}@{expected_sha}' "
-                    f"to run against the pinned commit, or acknowledge the local copy "
-                    f"is deliberate for this session."
+                    f'to run against the pinned commit, or set '
+                    f'REYN_FLOWVIEW_LOCAL_COPY="<reason>" (non-empty) to acknowledge the '
+                    f"local copy is deliberate for this session — tests/conftest.py's "
+                    f"autouse fixture downgrades this finding from an abort to a visible "
+                    f"warning ONLY when that reason is given, mirroring "
+                    f"`@pytest.mark.repo_root_cwd(reason=...)`'s required-reason opt-out."
                 ),
             )
         ]
@@ -531,6 +535,33 @@ def check_flowview_pin(root: Path) -> list[Finding]:
             )
         ]
     return []
+
+
+def partition_flowview_findings(
+    findings: list[Finding], local_copy_reason: str
+) -> tuple[list[Finding], list[Finding]]:
+    """Split `flowview-pin` findings into ``(blocking, acknowledged)``.
+
+    `flowview-pin/stale` and `flowview-pin/absent` always block — there is
+    no opt-out for measuring against the wrong commit outright (lead-coder
+    review of #3725: a version-mismatched install is never legitimate the
+    way a local clone can be). `flowview-pin/local-copy` blocks UNLESS
+    ``local_copy_reason`` is non-empty after stripping whitespace — the
+    caller reads this from ``REYN_FLOWVIEW_LOCAL_COPY`` — mirroring
+    `tests/conftest.py`'s `repo_root_cwd(reason=...)` marker: an opt-out
+    that accepts an empty reason is not a documented exception, it is
+    silence with an extra step, and #3723's own incident was exactly a
+    legitimate case (tui-coder's local flowview clone) with no way for the
+    caller to say so.
+    """
+    blocking: list[Finding] = []
+    acknowledged: list[Finding] = []
+    for f in findings:
+        if f.check == "flowview-pin/local-copy" and local_copy_reason.strip():
+            acknowledged.append(f)
+        else:
+            blocking.append(f)
+    return blocking, acknowledged
 
 
 # The enumeration. A check is registered here or it does not run — `main` and the

--- a/scripts/verify_env_identity.py
+++ b/scripts/verify_env_identity.py
@@ -20,8 +20,12 @@ Two properties are load-bearing:
 **It never imports reyn.** ``reyn``'s own resolution is the subject under test;
 an importer would be asserting with the very mechanism whose trustworthiness is
 in question. Checks run reyn out-of-process and compare *paths*, and the module
-stays stdlib-only (tomllib / subprocess / shutil), mirroring
+stays stdlib-only (tomllib / subprocess / shutil / importlib.metadata), mirroring
 ``scripts/test_tier_audit.py`` and ``scripts/verify_module_docstrings.py``.
+``check_flowview_pin`` extends the same discipline to a third-party pinned
+dependency (#3723) — it reads `pip`'s own recorded provenance
+(``importlib.metadata``'s ``direct_url.json``) rather than importing
+``textual_flowview`` itself.
 
 **It measures rather than infers.** Import resolution is not re-implemented from
 ``.pth`` files and ``sys.path`` rules — a subprocess is spawned and asked where
@@ -32,6 +36,9 @@ explains itself.
 from __future__ import annotations
 
 import argparse
+import importlib.metadata
+import importlib.util
+import json
 import os
 import re
 import shutil
@@ -387,6 +394,145 @@ def check_in_process_tree(reyn_file: Path, root: Path) -> Finding | None:
     )
 
 
+def _pinned_git_dependency(root: Path, package: str) -> tuple[str, str] | None:
+    """Derive ``(url, commit)`` for ``package`` from its own ``git+<url>@<sha>``
+    entry in ``pyproject.toml``'s ``[project.dependencies]`` — never hardcoded,
+    so a pin bump (a new commit for the SAME package) cannot silently drift
+    out of sync with what this check expects (#3723)."""
+    pyproject = root / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    pattern = re.compile(
+        rf"^{re.escape(package)}\s*@\s*git\+(?P<url>[^@\s]+)@(?P<sha>[0-9a-f]{{7,40}})$"
+    )
+    for dep in data.get("project", {}).get("dependencies", []):
+        m = pattern.match(dep.strip())
+        if m:
+            return m.group("url"), m.group("sha")
+    return None
+
+
+def check_flowview_pin(root: Path) -> list[Finding]:
+    """The installed ``textual-flowview`` must be the exact commit `pyproject.toml` pins.
+
+    #3723: on 2026-08-06, 4 of 4 sessions ran a full suite against a
+    mis-pinned ``textual-flowview`` in the SAME day — three had a stale
+    VERSION (0.9.0/0.8.0 against a 0.12.0 pin) and reported real test
+    failures as "pre-existing on origin/main"; the fourth (tui-coder) had
+    the pinned commit's VERSION but was reading a LOCAL WORKING COPY, which
+    a version-only check cannot see (today it happens to match; the moment
+    that directory changes, it silently measures something else). No
+    session noticed on its own — a stale/local install produces a normal,
+    plausible-looking test run, not a loud failure naming its own cause.
+
+    Deliberately does not ``import textual_flowview``: like the rest of this
+    module, it reads installer-recorded METADATA (``importlib.metadata``'s
+    ``direct_url.json`` — the same file `pip` itself writes to record VCS
+    provenance) and a ``find_spec`` origin, never the package's own code.
+    """
+    pin = _pinned_git_dependency(root, "textual-flowview")
+    if pin is None:
+        # Nothing to check against: not a finding — the pin itself moved to a
+        # different form (e.g. a PyPI release) and this check is now stale,
+        # not the venv. `main()`'s own probe below should have already
+        # complained before this can be reached under CI.
+        return []
+    expected_url, expected_sha = pin
+
+    spec = importlib.util.find_spec("textual_flowview")
+    origin = spec.origin if spec and spec.origin else None
+    if origin is None:
+        return [
+            Finding(
+                check="flowview-pin/absent",
+                detail="`textual_flowview` is not importable in this environment at all.",
+                remedy=(
+                    f"pip install 'textual-flowview @ git+{expected_url}@{expected_sha}'"
+                ),
+            )
+        ]
+
+    try:
+        dist = importlib.metadata.distribution("textual-flowview")
+    except importlib.metadata.PackageNotFoundError:
+        return [
+            Finding(
+                check="flowview-pin/absent",
+                detail=(
+                    f"`find_spec` resolves textual_flowview at {origin}, but no "
+                    f"installed distribution metadata exists for it — an unusual, "
+                    f"un-pip-managed install this check cannot verify."
+                ),
+                remedy=(
+                    f"pip install 'textual-flowview @ git+{expected_url}@{expected_sha}'"
+                ),
+            )
+        ]
+
+    origin_path = Path(origin).resolve()
+    site_packages = Path(sys.prefix).resolve()
+    try:
+        origin_path.relative_to(site_packages)
+        outside_prefix = False
+    except ValueError:
+        outside_prefix = True
+
+    try:
+        direct_url_raw = dist.read_text("direct_url.json")
+    except Exception:  # noqa: BLE001 — dist-info layouts vary; absence is the signal
+        direct_url_raw = None
+    direct_url = json.loads(direct_url_raw) if direct_url_raw else {}
+    vcs_info = direct_url.get("vcs_info") or {}
+    actual_sha = vcs_info.get("commit_id")
+    actual_url = (direct_url.get("url") or "").removesuffix(".git")
+
+    if outside_prefix or actual_sha is None:
+        # The tui-coder shape: `pip install -e <local clone>` (or a plain,
+        # VCS-less install) resolves outside this venv's site-packages and/or
+        # carries no recorded commit — version alone cannot distinguish this
+        # from the real pin, which is exactly why it went unnoticed (#3723).
+        return [
+            Finding(
+                check="flowview-pin/local-copy",
+                detail=(
+                    f"textual_flowview (version {dist.version}) is not installed FROM "
+                    f"the pinned commit — its provenance is a local working copy or an "
+                    f"install with no recorded VCS commit, not `pip`'s own record of "
+                    f"git+{expected_url}@{expected_sha}.\n"
+                    f"    resolves to: {origin_path}\n"
+                    f"    direct_url.json: {direct_url or '(absent)'}\n"
+                    f"    This is not itself forbidden (developing against a local "
+                    f"clone is legitimate) — but a full-suite result measured this way "
+                    f"is not comparable to one measured against the pin, and today's "
+                    f"version match does not guarantee tomorrow's."
+                ),
+                remedy=(
+                    f"pip install 'textual-flowview @ git+{expected_url}@{expected_sha}' "
+                    f"to run against the pinned commit, or acknowledge the local copy "
+                    f"is deliberate for this session."
+                ),
+            )
+        ]
+
+    if actual_sha != expected_sha or actual_url != expected_url.removesuffix(".git"):
+        return [
+            Finding(
+                check="flowview-pin/stale",
+                detail=(
+                    f"textual_flowview is installed from a DIFFERENT commit than "
+                    f"pyproject.toml pins.\n"
+                    f"    pin:       git+{expected_url}@{expected_sha}\n"
+                    f"    installed: git+{actual_url}@{actual_sha} (version {dist.version})\n"
+                    f"    A test failure measured under this install cannot be "
+                    f"attributed to the tree — it may be the venv."
+                ),
+                remedy=(
+                    f"pip install 'textual-flowview @ git+{expected_url}@{expected_sha}'"
+                ),
+            )
+        ]
+    return []
+
+
 # The enumeration. A check is registered here or it does not run — `main` and the
 # `tests/conftest.py` fixtures both derive their work from this map rather than
 # from a hand-kept call list, so adding a check cannot leave a caller behind.
@@ -401,6 +547,7 @@ CHECKS = {
     "tree-identity": check_tree_identity,
     "pinned-tree": check_pinned_tree,
     "console-scripts": check_console_scripts,
+    "flowview-pin": check_flowview_pin,
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 import importlib.util
 import os
 import sys
+import warnings
 from pathlib import Path
 
 import pytest
@@ -227,19 +228,47 @@ def _flowview_pin_verified() -> None:
     once, before the first test body, for every invocation — a session that
     never happens to request it is exactly how this went undetected. A red
     test measured under a mis-pinned flowview is not "one more failure", it
-    makes the WHOLE suite's result incomparable to `origin/main`'s, so this
-    aborts the run outright (`pytest.exit`) instead of failing one test.
+    makes the WHOLE suite's result incomparable to `origin/main`'s, so a
+    version mismatch (`flowview-pin/stale`/`flowview-pin/absent`) aborts the
+    run outright (`pytest.exit`) instead of failing one test.
+
+    `flowview-pin/local-copy` is different: a local `textual-flowview` clone
+    is legitimate development (#3725 review, lead-coder — tui-coder was doing
+    exactly this when the blanket abort version of this fixture would have
+    stopped them from running a single test). `REYN_FLOWVIEW_LOCAL_COPY="<reason>"`
+    (a non-empty reason, required — see `partition_flowview_findings`'s
+    docstring) downgrades that ONE finding kind from an abort to a
+    `warnings.warn`, which pytest surfaces in its own warnings summary at the
+    end of the run — not just printed at setup time and easy to miss, but
+    landing in the same report the run's own result reaches (#3723's
+    incident was exactly a case where the reason was knowable but never
+    reached anyone reading the result).
     """
     findings = _ENV_IDENTITY.verify(Path(_REPO_ROOT), only=("flowview-pin",))
     if not findings:
         return
-    rendered = "\n".join(f.render() for f in findings)
-    pytest.exit(
-        f"env-identity (#3723): this venv's textual-flowview does not match "
-        f"pyproject.toml's pin — the whole suite's result is not trustworthy "
-        f"until this is fixed.\n{rendered}",
-        returncode=1,
-    )
+
+    reason = os.environ.get("REYN_FLOWVIEW_LOCAL_COPY", "")
+    blocking, acknowledged = _ENV_IDENTITY.partition_flowview_findings(findings, reason)
+
+    if acknowledged:
+        rendered = "\n".join(f.render() for f in acknowledged)
+        warnings.warn(
+            f"env-identity (#3723): textual-flowview is a local working copy, not "
+            f"the pinned commit — acknowledged via REYN_FLOWVIEW_LOCAL_COPY={reason!r}. "
+            f"This run's result is not comparable to one measured against the pin.\n"
+            f"{rendered}",
+            stacklevel=1,
+        )
+
+    if blocking:
+        rendered = "\n".join(f.render() for f in blocking)
+        pytest.exit(
+            f"env-identity (#3723): this venv's textual-flowview does not match "
+            f"pyproject.toml's pin — the whole suite's result is not trustworthy "
+            f"until this is fixed.\n{rendered}",
+            returncode=1,
+        )
 
 
 # ── Workspace isolation (#3705) ─────────────────────────────────────────────────

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,6 +216,32 @@ def out_of_process_reyn() -> str:
     return str(root / "src")
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _flowview_pin_verified() -> None:
+    """#3723: 4 of 4 sessions on 2026-08-06 measured a full suite against a
+    mis-pinned ``textual-flowview`` — three had a stale version, and read
+    real failures as "pre-existing on origin/main"; the fourth had the
+    pinned VERSION but was reading a local working copy, invisible to a
+    version-only check. Unlike `reyn_console_scripts`/`out_of_process_reyn`
+    above (opt-in, per-test), this is autouse and session-scoped: it must run
+    once, before the first test body, for every invocation — a session that
+    never happens to request it is exactly how this went undetected. A red
+    test measured under a mis-pinned flowview is not "one more failure", it
+    makes the WHOLE suite's result incomparable to `origin/main`'s, so this
+    aborts the run outright (`pytest.exit`) instead of failing one test.
+    """
+    findings = _ENV_IDENTITY.verify(Path(_REPO_ROOT), only=("flowview-pin",))
+    if not findings:
+        return
+    rendered = "\n".join(f.render() for f in findings)
+    pytest.exit(
+        f"env-identity (#3723): this venv's textual-flowview does not match "
+        f"pyproject.toml's pin — the whole suite's result is not trustworthy "
+        f"until this is fixed.\n{rendered}",
+        returncode=1,
+    )
+
+
 # ── Workspace isolation (#3705) ─────────────────────────────────────────────────
 
 

--- a/tests/test_3723_flowview_pin_check.py
+++ b/tests/test_3723_flowview_pin_check.py
@@ -1,0 +1,186 @@
+"""Tier 1: scripts/verify_env_identity.py's textual-flowview pin contract.
+
+Pins the invariant #3723 ratified: 4 of 4 sessions measured a full suite
+against a mis-pinned `textual-flowview` on the same day — three had a stale
+version and read real test failures as "pre-existing on origin/main"; the
+fourth had the pinned commit's VERSION but was reading a local working copy,
+which a version-only check cannot distinguish from the real pin. The
+constructed invariant: `check_flowview_pin` reads `pip`'s own recorded
+provenance (`direct_url.json`) and the `find_spec` origin, and reports a
+Finding whenever either signals the installed package did not come from the
+pinned commit — never by importing `textual_flowview` itself.
+
+No mocks: each case builds a real `pyproject.toml` on disk and monkeypatches
+only the process-identity seams the check reads through (`sys.prefix`,
+`importlib.util.find_spec`, `importlib.metadata.distribution`) — the same
+idiom `test_3024_env_identity.py` already uses for `sys.executable` /
+`shutil.which`.
+
+Public surface only: each case calls the module's registered check and
+asserts on the returned `Finding` objects' public fields (`check` / `detail`).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "verify_env_identity.py"
+
+_PIN_URL = "https://github.com/tya5/textual-flowview.git"
+_PIN_SHA = "5a72da086f1e8e3fc0c93b0806b53a5fd5fb1c7f"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_env_identity_under_test_3723", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _checkout(tmp_path: Path) -> Path:
+    """A real checkout whose pyproject pins textual-flowview like the real one."""
+    root = tmp_path / "checkout"
+    root.mkdir(parents=True)
+    (root / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "reyn"\n'
+        "dependencies = [\n"
+        f'    "textual-flowview @ git+{_PIN_URL}@{_PIN_SHA}",\n'
+        '    "numpy>=1.24",\n'
+        "]\n"
+    )
+    return root
+
+
+class _FakeDistribution:
+    def __init__(self, version: str, direct_url: dict | None) -> None:
+        self.version = version
+        self._direct_url = direct_url
+
+    def read_text(self, filename: str) -> str | None:
+        if filename == "direct_url.json" and self._direct_url is not None:
+            return json.dumps(self._direct_url)
+        return None
+
+
+def _wire(
+    module,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    origin: str | None,
+    prefix: str,
+    dist: _FakeDistribution | None,
+) -> None:
+    fake_spec = None if origin is None else type("S", (), {"origin": origin})()
+    monkeypatch.setattr(module.importlib.util, "find_spec", lambda name: fake_spec)
+    monkeypatch.setattr(module.sys, "prefix", prefix)
+
+    def _distribution(name: str):
+        if dist is None:
+            raise module.importlib.metadata.PackageNotFoundError(name)
+        return dist
+
+    monkeypatch.setattr(module.importlib.metadata, "distribution", _distribution)
+
+
+def test_the_pinned_commit_installed_in_site_packages_is_clean(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 1: an install matching the pin's url+commit, resolved under
+    sys.prefix, reports no finding — the real, healthy shape."""
+    module = _load()
+    root = _checkout(tmp_path)
+    prefix = str(tmp_path / "venv")
+    origin = f"{prefix}/lib/python3.12/site-packages/textual_flowview/__init__.py"
+    dist = _FakeDistribution(
+        "0.12.0",
+        {"url": _PIN_URL, "vcs_info": {"commit_id": _PIN_SHA}},
+    )
+    _wire(module, monkeypatch, origin=origin, prefix=prefix, dist=dist)
+
+    assert module.check_flowview_pin(root) == []
+
+
+def test_a_stale_commit_is_named_with_both_shas(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 1: a version-mismatched install is reported as `flowview-pin/stale`
+    naming both the pin and what is actually installed.
+
+    FALSIFY: without this check, a stale venv reports a test failure with no
+    hint that the venv (not the tree) is the cause — the #3723 incident.
+    """
+    module = _load()
+    root = _checkout(tmp_path)
+    prefix = str(tmp_path / "venv")
+    origin = f"{prefix}/lib/python3.12/site-packages/textual_flowview/__init__.py"
+    stale_sha = "0" * 40
+    dist = _FakeDistribution(
+        "0.9.0",
+        {"url": _PIN_URL, "vcs_info": {"commit_id": stale_sha}},
+    )
+    _wire(module, monkeypatch, origin=origin, prefix=prefix, dist=dist)
+
+    findings = module.check_flowview_pin(root)
+
+    assert [f.check for f in findings] == ["flowview-pin/stale"]
+    detail = findings[0].detail
+    assert _PIN_SHA in detail
+    assert stale_sha in detail
+
+
+def test_a_local_working_copy_is_flagged_even_when_version_matches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 1: an install with the pinned VERSION but no VCS commit record and
+    an origin outside site-packages is `flowview-pin/local-copy`, not clean.
+
+    FALSIFY: the tui-coder shape from #3723 — version-only comparison would
+    call this clean. A local clone can drift the moment its own directory
+    changes, silently, with no re-install to catch it.
+    """
+    module = _load()
+    root = _checkout(tmp_path)
+    prefix = str(tmp_path / "venv")
+    local_clone = str(tmp_path / "some" / "other" / "checkout" / "textual_flowview" / "__init__.py")
+    dist = _FakeDistribution(
+        "0.12.0",
+        {"url": f"file://{tmp_path}/some/other/checkout", "dir_info": {"editable": True}},
+    )
+    _wire(module, monkeypatch, origin=local_clone, prefix=prefix, dist=dist)
+
+    findings = module.check_flowview_pin(root)
+
+    assert [f.check for f in findings] == ["flowview-pin/local-copy"]
+    assert "0.12.0" in findings[0].detail
+
+
+def test_an_uninstalled_flowview_is_flagged_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 1: no `find_spec` origin at all reports `flowview-pin/absent`."""
+    module = _load()
+    root = _checkout(tmp_path)
+    _wire(module, monkeypatch, origin=None, prefix=str(tmp_path / "venv"), dist=None)
+
+    findings = module.check_flowview_pin(root)
+
+    assert [f.check for f in findings] == ["flowview-pin/absent"]
+    assert _PIN_SHA in findings[0].detail or _PIN_SHA in findings[0].remedy
+
+
+def test_flowview_pin_is_reachable_through_verify(tmp_path: Path) -> None:
+    """Tier 1: `flowview-pin` is registered and dispatched, not orphaned."""
+    module = _load()
+
+    assert "flowview-pin" in module.CHECKS
+    root = _checkout(tmp_path)
+    # No monkeypatching: exercises the real installed environment this suite
+    # itself runs under — the same environment #3723 needs verified.
+    assert isinstance(module.verify(root, only=("flowview-pin",)), list)

--- a/tests/test_3723_flowview_pin_check.py
+++ b/tests/test_3723_flowview_pin_check.py
@@ -184,3 +184,57 @@ def test_flowview_pin_is_reachable_through_verify(tmp_path: Path) -> None:
     # No monkeypatching: exercises the real installed environment this suite
     # itself runs under — the same environment #3723 needs verified.
     assert isinstance(module.verify(root, only=("flowview-pin",)), list)
+
+
+# ── partition_flowview_findings (#3725 review: local-copy needs a real opt-out) ─
+
+
+def _local_copy_finding(module) -> object:
+    return module.Finding(check="flowview-pin/local-copy", detail="d", remedy="r")
+
+
+def _stale_finding(module) -> object:
+    return module.Finding(check="flowview-pin/stale", detail="d", remedy="r")
+
+
+def test_local_copy_blocks_without_a_reason(tmp_path: Path) -> None:
+    """Tier 1: an unset/empty REYN_FLOWVIEW_LOCAL_COPY still blocks — silence
+    is not an opt-out (lead-coder review: the opt-out must require a reason,
+    mirroring `repo_root_cwd(reason=...)`)."""
+    module = _load()
+    finding = _local_copy_finding(module)
+
+    for reason in ("", "   "):
+        blocking, acknowledged = module.partition_flowview_findings([finding], reason)
+        assert blocking == [finding]
+        assert acknowledged == []
+
+
+def test_local_copy_is_acknowledged_with_a_real_reason(tmp_path: Path) -> None:
+    """Tier 1: a non-empty reason downgrades local-copy from blocking to
+    acknowledged — the #3725 fix for the tui-coder case (legitimate local
+    clone, no way to say so before this)."""
+    module = _load()
+    finding = _local_copy_finding(module)
+
+    blocking, acknowledged = module.partition_flowview_findings(
+        [finding], "developing textual-flowview itself, PR #123"
+    )
+
+    assert blocking == []
+    assert acknowledged == [finding]
+
+
+def test_stale_never_gets_acknowledged_even_with_a_reason(tmp_path: Path) -> None:
+    """Tier 1: `flowview-pin/stale` has no opt-out at all — a version
+    mismatch is never a legitimate local-development shape the way a clone
+    is (lead-coder review of #3725: "stale側は abort のままで正しい")."""
+    module = _load()
+    finding = _stale_finding(module)
+
+    blocking, acknowledged = module.partition_flowview_findings(
+        [finding], "some reason"
+    )
+
+    assert blocking == [finding]
+    assert acknowledged == []


### PR DESCRIPTION
**[e2e-coder]** — Closes #3723.

## Summary
- 4/4 sessions on 2026-08-06 measured a full suite against a mis-pinned `textual-flowview`: 3 with a stale version (read real test failures as "pre-existing on origin/main"), 1 (tui-coder) with the pinned commit's *version* but reading a local working copy — invisible to a version-only check.
- Extends the existing `scripts/verify_env_identity.py` (#3024's env-identity gate — `check_tree_identity` / `check_pinned_tree` / `check_console_scripts`) with a new `check_flowview_pin`, registered as `"flowview-pin"` in `CHECKS`. Same discipline as the rest of the module: reads `pip`'s own recorded provenance (`importlib.metadata`'s `direct_url.json`) and a `find_spec` origin — never imports `textual_flowview` itself. The expected commit is **derived from `pyproject.toml`'s own pin string**, never hardcoded, so a future pin bump can't drift the check out of sync with itself.
- Wires it into a new **autouse, session-scoped** fixture in `tests/conftest.py` (`_flowview_pin_verified`) — unlike the existing `reyn_console_scripts`/`out_of_process_reyn` fixtures (opt-in, per-test), this one must run for every invocation with no test needing to request it, since "no session happened to request it" is exactly how this went undetected 4 times in one day. On a mismatch it `pytest.exit()`s the whole run rather than failing one test — a red set measured under a mis-pinned flowview is not "one more failure", it makes the whole suite's result incomparable to `origin/main`'s.
- `__file__`/origin provenance (not just version) is checked directly, per the issue's own note that version-only comparison misses the tui-coder case: origin resolved outside `sys.prefix`'s site-packages, or a `direct_url.json` with no `vcs_info`, is flagged as `flowview-pin/local-copy` (not itself forbidden — developing against a local clone is legitimate — but named, not silently trusted).

## Verification
- New `tests/test_3723_flowview_pin_check.py` (5 tests, Tier 1 contract — real on-disk `pyproject.toml`, monkeypatches only the process-identity seams `sys.prefix`/`find_spec`/`importlib.metadata.distribution`, no mocks of collaborators): clean-pin, stale-commit, local-working-copy, absent, and CHECKS-reachability.
- **Falsify, against the real venv**: temporarily corrupted this venv's actual `direct_url.json` commit_id to a fake SHA and ran a real test file — confirmed `pytest.exit()` fires ("no tests ran", not a red test) naming `flowview-pin/stale` with both commits; restored and re-verified the file matched the backup byte-for-byte before re-running the full suite.
- Full suite (`.venv/bin/python -m pytest -q -n auto`, isolated scratch worktree + fresh venv, `textual-flowview` confirmed pinned at `0.12.0`/`5a72da08`): 10 failed / 9807 passed / 70 skipped / 14 errors — 14 errors identical to the established baseline, failures a subset (established baseline: 11 failed / 14 errors). No new regressions.
- All 4 local CI gates green: `ruff check`, `scripts/test_tier_audit.py --strict` on the new test file, full `pytest`, `scripts/verify_module_docstrings.py` on the changed src file.

## Test plan
- [x] `tests/test_3723_flowview_pin_check.py` — 5/5 pass
- [x] Falsify: real venv's `direct_url.json` corrupted to a wrong SHA → whole session aborts via `pytest.exit`, not a single red test; restored and re-verified
- [x] Full suite green (subset of established baseline, no new red)
- [x] `ruff check`, `test_tier_audit.py --strict`, `verify_module_docstrings.py` all green