### PR TITLE
fix(config): unblock mypy syntax errors (#3726)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -362,3 +362,15 @@ ignore = [
 python_version = "3.11"
 strict = false
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# numpy 2.x's bundled __init__.pyi uses PEP 695 `type X = ...` (3.12+-only
+# syntax) internally; mypy applies the declared `python_version` restriction
+# to third-party stubs too, not just first-party code, so parsing it under
+# our `python_version = "3.11"` (matching `requires-python`, #3726) raises a
+# real SyntaxError in numpy's OWN stub — nothing to do with our code.
+# `follow_imports = "skip"` treats numpy as untyped (Any) instead of parsing
+# its stub, which is the standard workaround for this exact upstream tension.
+module = ["numpy", "numpy.*"]
+follow_imports = "skip"
+follow_imports_for_stubs = true

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -144,7 +144,7 @@ class ReynConfig:
     #
     # Per-server schema (raw dict; no dataclass — kept flexible so new MCP SDK
     # transport options can be added without OS changes per P7):
-    #   type:    "stdio" | "http" | "sse"   (required; transport selector)
+    #   `type`:  "stdio" | "http" | "sse"   (required; transport selector)
     #   command, args, env, cwd             (stdio transport)
     #   url, headers, timeout               (http / streamable-http transport)
     #
@@ -159,7 +159,7 @@ class ReynConfig:
     #   mcp:
     #     servers:
     #       github:
-    #         type: http
+    #         `type`: http
     #         url: https://api.githubcopilot.com/mcp/
     #         headers:
     #           Authorization: "Bearer ${GITHUB_TOKEN}"


### PR DESCRIPTION
**[e2e-coder]** — part of #3726 (not closing — CI-wiring decision remains open).

## Summary

#3726: mypy is configured in `pyproject.toml` but has never run in CI. Running it hit a fatal syntax error at `config/root.py:147` that `ast.parse` alone does not reproduce, and architect deliberately left the cause unidentified rather than guess. This PR identifies both blockers with a minimal, isolated repro for each — not inference — fixes them, and reports the resulting real baseline.

### Blocker 1 — `config/root.py:147`, root-caused
mypy always parses source with `ast.parse(src, type_comments=True)` to support legacy PEP 484 comment-style annotations. CPython's own parser treats **any** comment starting with `# type:` (after stripping `#` + whitespace) as a type expression to attempt-parse — not just ones attached to an assignment. `root.py:147`/`162` are prose doc-comments describing the MCP server dict schema, and happen to start with "type:", so mypy tries to parse `"stdio" | "http" | "sse"   (required; transport selector)` as a type — invalid syntax.

Isolated repro (no mypy, no project code):
```python
>>> import ast
>>> ast.parse('x = 1\n#   type:    "stdio" | "http" | "sse"   (required; transport selector)\ny = 2\n', type_comments=True)
SyntaxError: invalid syntax
```
None of the issue's own three hypotheses (mypy version / Python-syntax-version target / plugin config) were the cause. Fixed by wrapping `` `type` `` in backticks in both comments — breaks the literal `# type:` prefix match, no change in meaning.

### Blocker 2 — found immediately behind blocker 1
numpy 2.5.1's bundled `__init__.pyi` uses PEP 695 `type X = ...` (3.12+-only syntax). mypy applies the project's `python_version = "3.11"` setting (matching `requires-python`) to third-party stubs too, not just first-party code, so parsing numpy's stub under that restriction raises a real `SyntaxError` in numpy's own file:
```python
>>> ast.parse(numpy_stub_source, feature_version=(3, 11))
SyntaxError: Type statement is only supported in Python 3.12 and greater
>>> ast.parse(numpy_stub_source)  # default (3.12) parse
# succeeds
```
`follow_imports = "skip"` alone did **not** unblock this — mypy still parses a module's stub for syntax before consulting `follow_imports`. Adding `follow_imports_for_stubs = true` (scoped to `numpy`/`numpy.*` via `[[tool.mypy.overrides]]`) did.

## Measured baseline (acceptance criterion #2)

With both blockers cleared, `mypy src/reyn` reports **602 errors in 139 files (569 source files checked)**.

⚠️ A caveat worth flagging before anyone treats 602 as "602 real bugs": **76 of the 602 (12.6%)** are `Module "reyn.config" has no attribute ...` — a known false-positive class. `src/reyn/config/__init__.py`'s `_reexport()` mechanically copies every submodule name into the package namespace via `getattr` in a loop (deliberate, #1682, guarded by `test_config_package_reexport_1682.py`), which is invisible to mypy's static analysis. The remaining ~526 are a mix of real `attr-defined`/`arg-type`/`assignment` findings not yet triaged.

## Not done in this PR
Whether/how to wire mypy into CI (as a blocking gate now, incrementally, or deferred with the 602-count as a tracked debt) is a design decision for #3726, not this PR — this PR's scope is strictly "unblock the measurement so #3726 can decide with real numbers instead of a syntax error." #3726 stays open.

## Verification
- Both repros confirmed in isolation (`ast.parse`, no mypy) before touching config.
- `ruff check`, `tomllib.load`, `ast.parse` on both changed files — clean.
- Full config test suite (13 files, 93 tests incl. the `#1682` re-export guard) — all pass, no regression (comment-only + scoped mypy-config change).

## Test plan
- [x] Isolated `ast.parse` repro for both blockers, confirmed before/after
- [x] `mypy src/reyn/config/root.py` — no longer errors on syntax
- [x] `mypy src/reyn` — runs to completion, 602 errors / 139 files (real measurement, not a guess)
- [x] `ruff check`, `tomllib`/`ast` sanity on changed files
- [x] Full config test suite green (93 tests)