### PR TITLE
feat(ci): wire mypy in as a ratchet, not a report (#3726)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,34 @@ jobs:
       - name: Run ruff
         run: ruff check .
 
+  mypy-ratchet:
+    name: mypy (ratchet)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dev dependencies
+        run: pip install -e ".[dev]"
+
+      # #3726: mypy is configured (pyproject.toml [tool.mypy]) but was never
+      # run in CI — a declared check with no execution. scripts/mypy_ratchet.py
+      # only fails on a (file, error-code) pair NOT already in the committed
+      # baseline (scripts/mypy_ratchet_baseline.json); see that script's module
+      # docstring for why this is a ratchet (same skeleton as
+      # tests/test_3595_s4_slash_handler_seam.py's residue gate) rather than a
+      # blocking full-adoption gate or a report-only job nobody's decision
+      # depends on.
+      - name: Run mypy ratchet
+        run: python scripts/mypy_ratchet.py
+
   docs:
     name: docs build (strict)
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,10 +87,14 @@ Key constraints (full rationale in the doc):
 This repo is touched by multiple Claude sessions (lead-coder, e2e-coder,
 per-PR coders) authenticating as the same `gh` user.
 
-**Before you open a PR, run all four CI gates locally** — `ruff check src
+**Before you open a PR, run all five CI gates locally** — `ruff check src
 tests`, `python scripts/test_tier_audit.py --strict <changed test files>`,
-`pytest` (from the repo root), and
-`python scripts/verify_module_docstrings.py <changed src files>` are *separate*
+`pytest` (from the repo root), `python scripts/verify_module_docstrings.py
+<changed src files>`, and `python scripts/mypy_ratchet.py` (#3726 — a
+*ratchet*, not full mypy adoption: it only fails on a `(file, error-code)`
+pair not already in `scripts/mypy_ratchet_baseline.json`; a genuinely new
+mypy finding in a file you touched will fail this even though `mypy` itself
+isn't in this repo's mental model of "the linter") are *separate*
 CI jobs. A green `pytest` alone is **not** a green CI run (`pytest-green ≠
 CI-green`): ruff `I001` import-sort and a Tier-4 format pin (`len(...) == N`)
 both fail CI while `pytest` passes. Details + the Tier-4 → behavioral-assertion

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -358,6 +358,13 @@ ignore = [
     "F841",
 ]
 
+# #3726: wired into CI as a ratchet (.github/workflows/test.yml's "mypy
+# (ratchet)" job), not a blocking full-adoption gate — the tree currently
+# carries 603 findings (212 unique (file, error-code) pairs), too many to
+# close before adopting. scripts/mypy_ratchet.py fails CI only on a pair NOT
+# already in the committed scripts/mypy_ratchet_baseline.json; see that
+# script's module docstring for the full rationale (same skeleton as
+# tests/test_3595_s4_slash_handler_seam.py's residue ratchet).
 [tool.mypy]
 python_version = "3.11"
 strict = false

--- a/scripts/mypy_ratchet.py
+++ b/scripts/mypy_ratchet.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""A mypy finding is a ratchet, not a report — new ones fail CI, old ones don't need closing first.
+
+#3726: mypy has been configured in ``pyproject.toml`` since before this script
+existed, and no CI job ever ran it — a declared check with no execution, the
+same shape #3024 (env-identity) and #3595 S4 (the slash residue gate) each hit
+independently. Two of the day's real defects (`compact_caps` never wired,
+`fv.cursor` reading an attribute 0.12.0 dropped) were exactly the class mypy
+exists to catch and neither showed up until someone ran it by hand.
+
+The straightforward fix — wire mypy into CI as a blocking gate — does not
+work today: a real measurement against the current tree returns 603 errors.
+Requiring that backlog closed before adoption defers adoption indefinitely
+(every day it stays unadopted is another day a `compact_caps`-shaped defect
+can land unnoticed), and a **report-only** job does not close the gap either
+— it would just be a second instance of "configured, running, changing
+nobody's decision," a report nobody reads is not meaningfully different from
+a check nobody runs.
+
+So this is a **ratchet**, the same skeleton as
+``tests/test_3595_s4_slash_handler_seam.py``'s ``_SESSION_RESIDUE``: a
+committed BASELINE of every ``(file, error-code)`` pair the tree currently
+carries. A pair not in the baseline is new — CI fails, immediately, the same
+day the defect lands. A pair that WAS in the baseline and is gone because
+someone fixed it just silently stops appearing; nothing has to be edited to
+let a fix "count." The baseline can only ever be read down over time by
+actual fixes — regenerating it wholesale to make a new failure disappear is
+the one way to defeat the ratchet, and is exactly the file-count-preserving
+excuse #3123's own review vocabulary calls out.
+
+Deliberately keyed on ``(file, error-code)``, not the bare per-file error
+COUNT: a count-only baseline lets "fix one, introduce a different one" pass
+silently (the fixed count and the new count can net to the same total). Keyed
+this way, a genuinely NEW finding in an already-baselined file for a
+DIFFERENT code is still visible — only the exact ``(file, code)`` pairs
+already declared are grandfathered.
+
+The 76 ``reyn.config`` re-export false positives (#1682's ``_reexport()``,
+invisible to mypy's static analysis, documented in #3726's own triage) stay
+IN the baseline rather than being carved out via a per-module mypy
+``ignore_errors`` override — an exclude-config is itself a new declaration to
+maintain, and the point of this script is to draw one line (the baseline)
+before adding more.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_BASELINE_PATH = _ROOT / "scripts" / "mypy_ratchet_baseline.json"
+_TARGET = "src/reyn"
+
+# Matches mypy's normal-mode error line:
+#   src/reyn/foo/bar.py:123: error: <message>  [error-code]
+# Deliberately excludes `note:` lines (mypy emits explanatory notes attached
+# to some errors, e.g. "note: Error code ... not covered by ...") and the
+# trailing "Found N errors in M files" summary line — neither carries a
+# `[code]` a future run can be diffed against.
+_ERROR_LINE = re.compile(r"^(?P<file>[^:]+\.py):\d+: error: .*\[(?P<code>[a-z][a-z0-9-]*)\]\s*$")
+
+
+def run_mypy(root: Path = _ROOT, target: str = _TARGET) -> str:
+    """Run mypy against ``target`` and return its combined stdout+stderr.
+
+    Never raises on a non-zero exit — mypy exits 1 whenever it reports any
+    error, which is the expected, common case this script exists to handle,
+    not a failure of the subprocess call itself.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-m", "mypy", target],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    return proc.stdout + proc.stderr
+
+
+def parse_mypy_output(text: str) -> "set[tuple[str, str]]":
+    """Extract the ``{(file, error-code)}`` set mypy's output reports.
+
+    Multiple error lines in the same file for the same code (mypy repeats a
+    `[attr-defined]` finding once per occurrence) collapse to one pair — the
+    ratchet is keyed on "does this file still carry this CLASS of finding",
+    not on exact line counts (a line shifting because of an unrelated edit
+    above it must never itself flip the gate red)."""
+    pairs: set[tuple[str, str]] = set()
+    for line in text.splitlines():
+        m = _ERROR_LINE.match(line)
+        if m:
+            pairs.add((m.group("file"), m.group("code")))
+    return pairs
+
+
+def load_baseline(path: Path = _BASELINE_PATH) -> "set[tuple[str, str]]":
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return {(entry["file"], entry["code"]) for entry in data}
+
+
+def write_baseline(pairs: "set[tuple[str, str]]", path: Path = _BASELINE_PATH) -> None:
+    data = [{"file": f, "code": c} for f, c in sorted(pairs)]
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def new_findings(
+    measured: "set[tuple[str, str]]", baseline: "set[tuple[str, str]]"
+) -> "set[tuple[str, str]]":
+    """The ratchet check itself: any measured pair the baseline does not
+    already declare is new — a pair leaving the measured set (a fix) is not
+    reported here at all, by design (see module docstring)."""
+    return measured - baseline
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--write-baseline",
+        action="store_true",
+        help=(
+            "regenerate the baseline from a fresh mypy run instead of checking "
+            "against it. Use ONLY after actually fixing/triaging findings — "
+            "regenerating to silence a new failure defeats the ratchet (see "
+            "module docstring)."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    output = run_mypy()
+    measured = parse_mypy_output(output)
+
+    if args.write_baseline:
+        write_baseline(measured)
+        print(f"Wrote {len(measured)} (file, code) pairs to {_BASELINE_PATH}")
+        return 0
+
+    baseline = load_baseline()
+    new = new_findings(measured, baseline)
+    if not new:
+        print(f"mypy ratchet OK: {len(measured)} findings, all baselined ({len(baseline)} declared).")
+        return 0
+
+    print(
+        f"mypy ratchet FAILED: {len(new)} new (file, error-code) pair(s) not in "
+        f"the baseline ({_BASELINE_PATH.relative_to(_ROOT)}):\n",
+        file=sys.stderr,
+    )
+    for file, code in sorted(new):
+        print(f"  {file}  [{code}]", file=sys.stderr)
+    print(
+        "\nEither fix the new finding(s), or if this is a deliberate, understood "
+        "addition, add the (file, code) pair to the baseline explicitly — do "
+        "NOT regenerate the whole baseline with --write-baseline to silence this.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mypy_ratchet_baseline.json
+++ b/scripts/mypy_ratchet_baseline.json
@@ -1,0 +1,850 @@
+[
+  {
+    "file": "src/reyn/_ssrf_guard.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/_ssrf_pin.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/_ssrf_pin.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/config/chat.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/config/config_schema.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/config/config_schema.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/config/infra.py",
+    "code": "name-defined"
+  },
+  {
+    "file": "src/reyn/config/root.py",
+    "code": "name-defined"
+  },
+  {
+    "file": "src/reyn/core/events/agent_snapshot.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/core/events/agent_snapshot.py",
+    "code": "call-overload"
+  },
+  {
+    "file": "src/reyn/core/events/event_store.py",
+    "code": "misc"
+  },
+  {
+    "file": "src/reyn/core/events/state_log.py",
+    "code": "name-defined"
+  },
+  {
+    "file": "src/reyn/core/kernel/codeact_runner.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/core/offload/canonical.py",
+    "code": "literal-required"
+  },
+  {
+    "file": "src/reyn/core/offload/canonical.py",
+    "code": "operator"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/context.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/embed.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/emit_hook_event.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/file.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/file.py",
+    "code": "no-redef"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/index_update.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/mcp_install.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/mcp_install.py",
+    "code": "union-attr"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/pipeline_install.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/pipeline_install.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/pipeline_install.py",
+    "code": "operator"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/plugin_install.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/plugin_install.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/plugin_install.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/plugin_install.py",
+    "code": "list-item"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/plugin_install.py",
+    "code": "union-attr"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/sandboxed_exec.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/semantic_search.py",
+    "code": "return-value"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/skill_install.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/core/pipeline/analyzer.py",
+    "code": "dict-item"
+  },
+  {
+    "file": "src/reyn/core/pipeline/executor.py",
+    "code": "union-attr"
+  },
+  {
+    "file": "src/reyn/core/pipeline/expr.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/core/pipeline/parser.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/core/pipeline/parser.py",
+    "code": "operator"
+  },
+  {
+    "file": "src/reyn/core/pipeline/parser.py",
+    "code": "return-value"
+  },
+  {
+    "file": "src/reyn/core/pipeline/parser.py",
+    "code": "union-attr"
+  },
+  {
+    "file": "src/reyn/core/pipeline/serde.py",
+    "code": "dict-item"
+  },
+  {
+    "file": "src/reyn/core/registry/client.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/core/registry/source_resolver.py",
+    "code": "var-annotated"
+  },
+  {
+    "file": "src/reyn/data/embedding/litellm_provider.py",
+    "code": "no-redef"
+  },
+  {
+    "file": "src/reyn/data/index/knowledge_ingest.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/data/index/source_manifest.py",
+    "code": "call-overload"
+  },
+  {
+    "file": "src/reyn/data/pipelines/registry.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/data/pipelines/registry.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/data/pipelines/registry.py",
+    "code": "misc"
+  },
+  {
+    "file": "src/reyn/data/pipelines/registry.py",
+    "code": "type-var"
+  },
+  {
+    "file": "src/reyn/dev/dogfood/interpretation.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/dev/dogfood/publish.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/dev/dogfood/replay.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/dev/dogfood/runner.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/dev/dogfood/verifiers/reply.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/dev/testing/replay_stacking.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/hooks/composer.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/hooks/dispatcher.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/hooks/render.py",
+    "code": "return-value"
+  },
+  {
+    "file": "src/reyn/hooks/shell_runner.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/hooks/shell_runner.py",
+    "code": "index"
+  },
+  {
+    "file": "src/reyn/hooks/shell_runner.py",
+    "code": "return-value"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/audit.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/audit.py",
+    "code": "union-attr"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/auth.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/chat.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/config.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/cron.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/dogfood.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/dogfood.py",
+    "code": "name-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/embeddings.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/mcp.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/mcp.py",
+    "code": "call-arg"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/mcp.py",
+    "code": "union-attr"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/memory.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/permissions.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/pipe.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/pipe.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/plugin.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/plugin.py",
+    "code": "return-value"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/support_bundle.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/web.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/env_backend.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/invocation_context.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/inline/textual_chat/app.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/interfaces/inline/textual_chat/app.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/inline/textual_chat/app.py",
+    "code": "name-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/inline/textual_chat/app.py",
+    "code": "return-value"
+  },
+  {
+    "file": "src/reyn/interfaces/inline/textual_chat/app.py",
+    "code": "union-attr"
+  },
+  {
+    "file": "src/reyn/interfaces/inline/textual_chat/intervention_panel.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/interfaces/inline/textual_chat/search_bar.py",
+    "code": "override"
+  },
+  {
+    "file": "src/reyn/interfaces/repl/renderer.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/interfaces/repl/renderer.py",
+    "code": "union-attr"
+  },
+  {
+    "file": "src/reyn/interfaces/repl/repl.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/interfaces/repl/stream_client.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/repl/stream_client.py",
+    "code": "misc"
+  },
+  {
+    "file": "src/reyn/interfaces/skill_invoke.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/interfaces/slash/agents.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/slash/dispatch.py",
+    "code": "valid-type"
+  },
+  {
+    "file": "src/reyn/interfaces/slash/image.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/interfaces/slash/memory.py",
+    "code": "call-arg"
+  },
+  {
+    "file": "src/reyn/interfaces/slash/plugin.py",
+    "code": "return-value"
+  },
+  {
+    "file": "src/reyn/interfaces/transport/agui/client.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/transport/agui/client.py",
+    "code": "valid-type"
+  },
+  {
+    "file": "src/reyn/interfaces/transport/agui/emitter.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/transport/agui/emitter.py",
+    "code": "valid-type"
+  },
+  {
+    "file": "src/reyn/interfaces/transport/agui/endpoint.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/transport/agui/endpoint.py",
+    "code": "valid-type"
+  },
+  {
+    "file": "src/reyn/interfaces/transport/agui/protocol.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/interfaces/transport/agui/protocol.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/transport/agui/protocol.py",
+    "code": "dict-item"
+  },
+  {
+    "file": "src/reyn/interfaces/transport/agui/protocol.py",
+    "code": "valid-type"
+  },
+  {
+    "file": "src/reyn/interfaces/transport/client_transport.py",
+    "code": "valid-type"
+  },
+  {
+    "file": "src/reyn/interfaces/transport/in_process.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/transport/in_process.py",
+    "code": "valid-type"
+  },
+  {
+    "file": "src/reyn/interfaces/transport/session_bound.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/transport/session_bound.py",
+    "code": "valid-type"
+  },
+  {
+    "file": "src/reyn/interfaces/web/auth/core.py",
+    "code": "union-attr"
+  },
+  {
+    "file": "src/reyn/interfaces/web/deps.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/interfaces/web/deps.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/web/deps.py",
+    "code": "name-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/web/routers/a2a.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/interfaces/web/routers/a2a.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/interfaces/web/routers/a2a.py",
+    "code": "return-value"
+  },
+  {
+    "file": "src/reyn/interfaces/web/run_registry.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/interfaces/web/server.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/llm/llm.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/llm/llm.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/llm/pricing.py",
+    "code": "call-overload"
+  },
+  {
+    "file": "src/reyn/llm/wire_format.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/mcp/client.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/mcp/message_handler.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/mcp/registry.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/mcp/server.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/mcp/server.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/mcp/server.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/prompt/router_frame.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/prompt/router_frame.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/prompt/router_frame.py",
+    "code": "union-attr"
+  },
+  {
+    "file": "src/reyn/runtime/budget/budget.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/runtime/budget/budget.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/runtime/budget/budget.py",
+    "code": "call-overload"
+  },
+  {
+    "file": "src/reyn/runtime/budget/budget.py",
+    "code": "index"
+  },
+  {
+    "file": "src/reyn/runtime/budget/budget.py",
+    "code": "operator"
+  },
+  {
+    "file": "src/reyn/runtime/capability_visibility.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/runtime/capability_visibility.py",
+    "code": "union-attr"
+  },
+  {
+    "file": "src/reyn/runtime/capability_visibility.py",
+    "code": "var-annotated"
+  },
+  {
+    "file": "src/reyn/runtime/chat_message.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/runtime/cron/runners.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/runtime/external_routing.py",
+    "code": "call-arg"
+  },
+  {
+    "file": "src/reyn/runtime/hot_reload.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/runtime/lifecycle_forwarder.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/runtime/limits/limit_handler.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/runtime/model_cost_warn.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/runtime/model_cost_warn.py",
+    "code": "misc"
+  },
+  {
+    "file": "src/reyn/runtime/registry.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/runtime/registry.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/runtime/registry.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/runtime/registry.py",
+    "code": "union-attr"
+  },
+  {
+    "file": "src/reyn/runtime/registry_bootstrap.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/runtime/router_loop.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/runtime/router_loop.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/runtime/router_loop.py",
+    "code": "name-defined"
+  },
+  {
+    "file": "src/reyn/runtime/router_op_context.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/runtime/services/compaction_controller.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/runtime/services/compaction_controller.py",
+    "code": "union-attr"
+  },
+  {
+    "file": "src/reyn/runtime/services/inter_agent_messaging.py",
+    "code": "call-arg"
+  },
+  {
+    "file": "src/reyn/runtime/services/intervention_handler.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/runtime/services/pipeline_executor_driver.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/runtime/services/router_host_adapter.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/runtime/session.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/runtime/session.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/runtime/session.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/runtime/session.py",
+    "code": "name-defined"
+  },
+  {
+    "file": "src/reyn/runtime/session.py",
+    "code": "union-attr"
+  },
+  {
+    "file": "src/reyn/runtime/session.py",
+    "code": "var-annotated"
+  },
+  {
+    "file": "src/reyn/runtime/session_api.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/runtime/session_api.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/security/permissions/capability_profile.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/security/permissions/capability_profile.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/security/permissions/effective.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/security/permissions/file_scope.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/security/permissions/permissions.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/security/permissions/permissions.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/security/sandbox/__init__.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/security/sandbox/_subprocess_io.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/security/sandbox/_subprocess_io.py",
+    "code": "index"
+  },
+  {
+    "file": "src/reyn/security/sandbox/_subprocess_io.py",
+    "code": "union-attr"
+  },
+  {
+    "file": "src/reyn/security/sandbox/backends/landlock.py",
+    "code": "union-attr"
+  },
+  {
+    "file": "src/reyn/security/sandbox/backends/seatbelt.py",
+    "code": "union-attr"
+  },
+  {
+    "file": "src/reyn/security/sandbox/noop_backend.py",
+    "code": "union-attr"
+  },
+  {
+    "file": "src/reyn/services/compaction/engine.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/tools/agent_spawn.py",
+    "code": "misc"
+  },
+  {
+    "file": "src/reyn/tools/ask_user.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/tools/cron.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/tools/exec.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/tools/hooks.py",
+    "code": "union-attr"
+  },
+  {
+    "file": "src/reyn/tools/llm_reachability.py",
+    "code": "attr-defined"
+  },
+  {
+    "file": "src/reyn/tools/mcp.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/tools/mcp_install.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/tools/memory.py",
+    "code": "return-value"
+  },
+  {
+    "file": "src/reyn/tools/pipeline_verbs.py",
+    "code": "misc"
+  },
+  {
+    "file": "src/reyn/tools/plugin_management_verbs.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/tools/scheme.py",
+    "code": "union-attr"
+  },
+  {
+    "file": "src/reyn/tools/schemes/category_content_fence.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/tools/schemes/codeact.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/tools/schemes/retrieval_content_fence.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/tools/skill_verbs.py",
+    "code": "arg-type"
+  },
+  {
+    "file": "src/reyn/tools/topology_create.py",
+    "code": "misc"
+  },
+  {
+    "file": "src/reyn/tools/types.py",
+    "code": "assignment"
+  },
+  {
+    "file": "src/reyn/user_intervention.py",
+    "code": "arg-type"
+  }
+]

--- a/tests/test_3726_mypy_ratchet.py
+++ b/tests/test_3726_mypy_ratchet.py
@@ -1,0 +1,144 @@
+"""Tier 1: scripts/mypy_ratchet.py's parse/diff contract.
+
+Same skeleton as `tests/test_3595_s4_slash_handler_seam.py`'s `_SESSION_RESIDUE`
+ratchet — a committed baseline set only ever shrinks; a measured entry not in
+it is new and must be surfaced, an entry that silently disappears from the
+measured set (a fix) is not itself reported. Here the measured set is
+`(file, mypy-error-code)` pairs rather than private-member accesses, and the
+"walk" is running mypy itself rather than an AST pass, but the ratchet logic
+(`new_findings`) is the same shape: `measured - baseline`, nothing more.
+
+Public surface only: `parse_mypy_output` / `new_findings` / `load_baseline` /
+`write_baseline` are called directly against real strings/files (no mocks —
+there is nothing to fake here, the whole point is these are pure functions
+over text/sets).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "mypy_ratchet.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_mypy_ratchet_under_test", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ── parse_mypy_output ───────────────────────────────────────────────────────
+
+
+def test_parses_error_lines_into_file_code_pairs() -> None:
+    """Tier 1: an ordinary mypy error line becomes one (file, code) pair."""
+    module = _load()
+    text = (
+        'src/reyn/foo.py:12: error: Name "X" is not defined  [name-defined]\n'
+        'src/reyn/bar.py:34: error: Argument 1 has incompatible type  [arg-type]\n'
+    )
+    assert module.parse_mypy_output(text) == {
+        ("src/reyn/foo.py", "name-defined"),
+        ("src/reyn/bar.py", "arg-type"),
+    }
+
+
+def test_repeated_lines_in_the_same_file_and_code_collapse_to_one_pair() -> None:
+    """Tier 1: the ratchet is keyed on (file, code), not exact line/occurrence
+    count — a line shifting from an unrelated edit above it must never flip
+    the gate by itself."""
+    module = _load()
+    text = (
+        'src/reyn/foo.py:12: error: msg one  [attr-defined]\n'
+        'src/reyn/foo.py:99: error: msg two  [attr-defined]\n'
+    )
+    assert module.parse_mypy_output(text) == {("src/reyn/foo.py", "attr-defined")}
+
+
+def test_note_lines_and_the_summary_line_are_not_parsed_as_findings() -> None:
+    """Tier 1: FALSIFY — a `note:` line or the trailing `Found N errors...`
+    summary carry no `[code]` a future run can diff against; parsing them
+    would corrupt the baseline with entries that can never be matched again."""
+    module = _load()
+    text = (
+        'src/reyn/foo.py:12: error: msg  [assignment]\n'
+        'src/reyn/foo.py:12: note: Error code "arg-type" not covered by "type: ignore[assignment]" comment\n'
+        "Found 1 error in 1 file (checked 5 source files)\n"
+    )
+    assert module.parse_mypy_output(text) == {("src/reyn/foo.py", "assignment")}
+
+
+# ── new_findings (the ratchet itself) ───────────────────────────────────────
+
+
+def test_a_measured_pair_absent_from_baseline_is_new() -> None:
+    """Tier 1: FALSIFY — a pair the baseline never declared must surface as new."""
+    module = _load()
+    measured = {("src/reyn/foo.py", "attr-defined"), ("src/reyn/bar.py", "arg-type")}
+    baseline = {("src/reyn/foo.py", "attr-defined")}
+    assert module.new_findings(measured, baseline) == {("src/reyn/bar.py", "arg-type")}
+
+
+def test_a_baselined_pair_that_disappears_from_measured_is_not_reported() -> None:
+    """Tier 1: a fix (a baselined pair no longer measured) never appears in
+    `new_findings` — nothing has to be edited to let a fix 'count', per the
+    module's own design (mirrors #3595's ratchet: only growth is gated)."""
+    module = _load()
+    measured: set[tuple[str, str]] = set()
+    baseline = {("src/reyn/foo.py", "attr-defined")}
+    assert module.new_findings(measured, baseline) == set()
+
+
+def test_measured_set_equal_to_baseline_is_clean() -> None:
+    """Tier 1: nothing new against an identical measured/baseline set."""
+    module = _load()
+    pairs = {("src/reyn/foo.py", "attr-defined"), ("src/reyn/bar.py", "arg-type")}
+    assert module.new_findings(pairs, pairs) == set()
+
+
+# ── load_baseline / write_baseline round-trip ───────────────────────────────
+
+
+def test_write_then_load_baseline_round_trips(tmp_path: Path) -> None:
+    """Tier 1: what write_baseline puts on disk, load_baseline reads back
+    unchanged — the maintenance path (`--write-baseline`) round-trips."""
+    module = _load()
+    path = tmp_path / "baseline.json"
+    pairs = {("src/reyn/foo.py", "attr-defined"), ("src/reyn/bar.py", "arg-type")}
+
+    module.write_baseline(pairs, path)
+    loaded = module.load_baseline(path)
+
+    assert loaded == pairs
+
+
+def test_written_baseline_is_sorted_for_stable_diffs(tmp_path: Path) -> None:
+    """Tier 1: sorted output keeps the committed file's diffs reviewable —
+    an unsorted dump would make every regeneration a full-file reorder."""
+    module = _load()
+    path = tmp_path / "baseline.json"
+    pairs = {("src/reyn/zzz.py", "attr-defined"), ("src/reyn/aaa.py", "arg-type")}
+
+    module.write_baseline(pairs, path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+
+    files = [entry["file"] for entry in data]
+    assert files == sorted(files)
+
+
+# ── the real repo, end to end ────────────────────────────────────────────────
+
+
+def test_the_committed_baseline_is_reachable_through_the_registered_target() -> None:
+    """Tier 1: `load_baseline()`'s own default (no path argument, the same
+    default `main()` uses) resolves to the real committed baseline — a path
+    typo here would silently no-op the CI job (0 findings, 0 baseline,
+    trivially "clean") rather than raising."""
+    module = _load()
+    baseline = module.load_baseline()
+    assert len(baseline) > 0


### PR DESCRIPTION
**[e2e-coder]** — Closes #3726.

## Summary

Per lead-coder's explicit ruling on this issue (report-only rejected: "a report nobody's decision depends on is just a second instance of the issue's own starting problem — configured, running, changing nothing"). This wires mypy into CI as a **ratchet**, the same skeleton as `tests/test_3595_s4_slash_handler_seam.py`'s `_SESSION_RESIDUE` gate:

- `scripts/mypy_ratchet_baseline.json` — the current tree's real measurement: **212 unique `(file, error-code)` pairs** (from 603 raw error lines).
- `scripts/mypy_ratchet.py` — runs `mypy src/reyn`, parses `(file, code)` pairs out of the output, fails (exit 1, names every offender) iff any measured pair is NOT already in the baseline. A pair leaving the measured set (a fix) needs no edit anywhere — it just silently stops appearing.
- New CI job `mypy (ratchet)` in `.github/workflows/test.yml` (5th job, alongside `test`/`lint`/`docs`/`audit`).
- `pyproject.toml`'s `[tool.mypy]` section gets a comment pointing at this (why it's a ratchet, not full adoption, per the earlier "leaving config declared-but-unrun is the bug this issue names" framing).
- `CLAUDE.md`'s "run all four CI gates locally" updated to five, in the same PR per the doc-sync hard rule.

## Design conditions (lead-coder's explicit ruling, all satisfied)
- **Keyed on `(file, error-code)`, not a bare count** — a count-only baseline lets "fix one, introduce a different one" pass silently. Verified: `new_findings()` is a pure set-difference over pairs, unit-tested directly.
- **Falsify**: injected a genuine new `[assignment]` error into `src/reyn/tools/scheme.py`, confirmed the gate goes RED naming exactly that `(file, code)` pair, reverted (byte-identical restore verified via `diff`), confirmed green again.
- **References `#3595` S4 as the same skeleton** — in `mypy_ratchet.py`'s module docstring and the new test file's docstring.
- **The 76 `reyn.config` re-export false positives stay IN the baseline** — not carved out via a mypy `ignore_errors`/override, since an exclude-config is itself a new declaration to maintain (drawing one line — the baseline — before adding more).

## Verification
- `tests/test_3726_mypy_ratchet.py` (9 tests, Tier 1 contract, no mocks — pure functions over real strings/files): parsing (ordinary lines, repeated-line collapse, note-line/summary-line exclusion), the ratchet diff itself (new/absent/identical), baseline round-trip + sort-stability, and reachability of the real committed baseline through the public `load_baseline()` default.
- Falsify against the real tree (see above).
- Full local suite: `ruff check`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `scripts/mypy_ratchet.py` itself, and the full `pytest` run (9832 passed / 10 failed / 14 errors — a strict subset of the established main baseline, no new regressions) all green.
- `.github/workflows/test.yml` YAML-parsed and confirmed the new job registers.

## Test plan
- [x] `tests/test_3726_mypy_ratchet.py` — 9/9 pass
- [x] Falsify: real new mypy error injected → RED naming the exact pair; reverted, byte-identical restore confirmed, green again
- [x] `scripts/mypy_ratchet.py` clean against its own committed baseline (212/212)
- [x] Full suite green (strict subset of established baseline)
- [x] `ruff check`, `test_tier_audit.py --strict`, `verify_module_docstrings.py` all green
- [x] CLAUDE.md / pyproject.toml doc-sync done in this PR