### PR TITLE
ci(#3670): wrap every job's real work with a self-imposed timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,21 @@ jobs:
         # any specific test executed. -rs makes "what didn't run, and why"
         # permanently legible in the CI log instead of requiring a rerun with
         # extra flags to find out after the fact.
-        run: python -m pytest -q -n auto --timeout=120 -rs
+        #
+        # `timeout 12m` (#3670): a GitHub Actions job/step hitting its own
+        # `timeout-minutes` reports conclusion `cancelled`, which every
+        # monitoring query built around `conclusion == "failure"` (the
+        # obvious, common form) silently treats as "not red" — #3670 found
+        # main's audit job cancelled on 4 of 5 consecutive pushes with NO
+        # monitoring trigger ever firing, because "cancelled" isn't
+        # "failure". Self-timing out via the coreutils `timeout` command
+        # BEFORE the platform's own job-level kill fires converts a would-be
+        # `cancelled` into an ordinary nonzero-exit step `failure` — legible
+        # to every `conclusion == "failure"` query without changing what
+        # they query for. `12m` (job budget 15m) leaves ~3m headroom for
+        # checkout/setup/pip-install (which run before this step and also
+        # count against the job's 15m) plus post-job cleanup.
+        run: timeout 12m python -m pytest -q -n auto --timeout=120 -rs
 
   lint:
     name: ruff
@@ -74,8 +88,10 @@ jobs:
       - name: Install dev dependencies
         run: pip install -e ".[dev]"
 
+      # `timeout 4m` (#3670): see the "Run tests" step above for why —
+      # converts a would-be `cancelled` job-timeout into a legible `failure`.
       - name: Run ruff
-        run: ruff check .
+        run: timeout 4m ruff check .
 
   mypy-ratchet:
     name: mypy (ratchet)
@@ -102,8 +118,11 @@ jobs:
       # tests/test_3595_s4_slash_handler_seam.py's residue gate) rather than a
       # blocking full-adoption gate or a report-only job nobody's decision
       # depends on.
+      #
+      # `timeout 8m` (#3670): see the "Run tests" job's comment for why —
+      # converts a would-be `cancelled` job-timeout into a legible `failure`.
       - name: Run mypy ratchet
-        run: python scripts/mypy_ratchet.py
+        run: timeout 8m python scripts/mypy_ratchet.py
 
   docs:
     name: docs build (strict)
@@ -126,8 +145,11 @@ jobs:
       # and missing nav targets fail at PR time, not post-merge on the Pages
       # deploy — which was previously the only place --strict ran (a broken
       # link could pass PR review and then turn the main Pages job red).
+      #
+      # `timeout 6m` (#3670): see the "Run tests" job's comment for why —
+      # converts a would-be `cancelled` job-timeout into a legible `failure`.
       - name: Build docs (strict)
-        run: mkdocs build --strict -f .mkdocs/mkdocs.yml
+        run: timeout 6m mkdocs build --strict -f .mkdocs/mkdocs.yml
 
       # --strict catches a dangling *file* reference but never checks
       # whether `#anchor` actually exists on the target page — that's this
@@ -135,8 +157,12 @@ jobs:
       # second build, no new dependency). See scripts/check_doc_anchors.py
       # for the incident this closes (#3557/#3592: 42/42 line-number
       # citations in charter.md had drifted, silently).
+      #
+      # `timeout 2m` (#3670): same reasoning as the step above. The two
+      # step budgets (6m + 2m) plus checkout/setup/pip-install leave margin
+      # under the job's 10m total.
       - name: Check doc anchors
-        run: python scripts/check_doc_anchors.py
+        run: timeout 2m python scripts/check_doc_anchors.py
 
   audit:
     name: test-tier audit
@@ -161,6 +187,17 @@ jobs:
       # scripts/test_tier_audit.py is stdlib-only (argparse / ast / re
       # / json / pathlib). No pip install needed — keeps the job fast
       # and decoupled from src/ install state.
+      #
+      # `timeout 10m` (#3670): converts a would-be `cancelled` job-timeout
+      # into a legible `failure` — see the "Run tests" job's comment for
+      # the full rationale. This specific job is what #3670 actually
+      # measured cancelling (4 of 5 consecutive main pushes, always at the
+      # 15-minute signature); #3670's own fix (a real algorithmic hotspot
+      # in test_tier_audit.py, see that PR) already took a full-tree run
+      # from ~122s to ~5s locally, so this budget should never realistically
+      # bind again — the wrapper stays as defense in depth against a FUTURE
+      # slowdown being invisible the same way, not because this one is
+      # still expected to be tight.
       - name: Run test-tier audit
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -179,17 +216,19 @@ jobs:
             echo "Auditing changed test files:"
             echo "$CHANGED"
             # shellcheck disable=SC2086
-            python scripts/test_tier_audit.py --strict $CHANGED
+            timeout 10m python scripts/test_tier_audit.py --strict $CHANGED
           else
             # push to main (or any non-PR trigger): full audit over the
             # entire test suite — invariant safety net, unchanged.
-            python scripts/test_tier_audit.py --strict tests/
+            timeout 10m python scripts/test_tier_audit.py --strict tests/
           fi
 
       # scripts/verify_module_docstrings.py is stdlib-only. PR events: scoped
       # to changed src files (fast). main push: full-tree run — the
       # regress-proof invariant net, now that the tree is clean (#1802). Blocks
       # moved-module refactor-narrative docstrings (the C-series discipline).
+      #
+      # `timeout 3m` (#3670): same reasoning as the step above.
       - name: Run module-docstring narrative check
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -203,8 +242,8 @@ jobs:
             echo "Checking changed src files:"
             echo "$CHANGED"
             # shellcheck disable=SC2086
-            python scripts/verify_module_docstrings.py $CHANGED
+            timeout 3m python scripts/verify_module_docstrings.py $CHANGED
           else
             # push to main (or any non-PR trigger): full-tree gate.
-            python scripts/verify_module_docstrings.py src/reyn
+            timeout 3m python scripts/verify_module_docstrings.py src/reyn
           fi


### PR DESCRIPTION
**[e2e-coder]** — part of #3670 (the remaining, highest-priority item: making a timeout look like a failure, not a shrug).

## Choice recorded (per lead-coder's "your call, just write down which" instruction)

Chose to implement the CI-side fix. Detection-side (backlog-watcher querying for `cancelled`, not just `failure`) is already handled per lead-coder — this is the other half.

## Why

A GitHub Actions job/step hitting its own `timeout-minutes` reports conclusion `cancelled`. Every monitoring query built around the obvious, common form (`conclusion == "failure"`) silently treats that as "not red". main's `audit` job was cancelled on 4 of 5 consecutive pushes today with **no monitoring trigger ever firing**, entirely because `cancelled` isn't `failure`.

## Fix

Wraps each job's actual long-running command(s) with the coreutils `timeout` command, set a few minutes under the job's own `timeout-minutes` (leaving headroom for checkout/setup/pip-install, which run first and also count against the same budget, plus post-job cleanup). `timeout` firing before the platform's own job-level kill converts a would-be `cancelled` into an ordinary nonzero-exit step `failure` (exit 124) — legible to every existing `conclusion == "failure"` query without anyone having to change what they query for.

Sanity-checked locally (not assumed):
```
timeout 1 sleep 5        → exit 124  (fires on expiry)
timeout 5 python3 -c "print('ok')"      → exit 0    (passes through normal success)
timeout 5 python3 -c "import sys; sys.exit(1)"  → exit 1  (passes through normal failure unchanged)
```

Applied **uniformly across all 6 jobs** (`test` ×2 matrix legs, `lint`, `mypy-ratchet`, `docs` ×2 steps, `audit` ×2 steps) rather than only the one job #3670 happened to catch cancelling — the underlying platform behavior applies to every job equally, and #3670's own post-mortem is explicitly that this class went unnoticed because detection assumed "the job that already bit us" rather than "the mechanism, wherever it next fires."

Does **not** lower any `timeout-minutes` value or otherwise change job semantics — purely adds a tighter self-imposed cutoff inside the existing budget. `audit`'s own budget (10m self-timeout, out of a 15m job) should never realistically bind again post-#3733's fix, but stays as defense in depth against a future slowdown being invisible the same way.

## Verification
- `.github/workflows/test.yml` YAML-parsed, job/step structure confirmed intact.
- `timeout`'s exit-code passthrough behavior sanity-checked locally (above).
- No Python touched by this PR — ran the unaffected gates (`ruff check .`, `mypy` ratchet) as a safety net anyway; both green.

## Test plan
- [x] YAML valid, all 6 jobs' steps intact
- [x] `timeout` exit-code behavior verified locally (124 on expiry, passthrough otherwise)
- [x] `ruff check .`, mypy ratchet green (no Python changed, sanity-checked anyway)