### PR TITLE
instrument(#3671): split client-prep into 4 named sub-stages

### DIFF
--- a/src/reyn/interfaces/repl/client_driver.py
+++ b/src/reyn/interfaces/repl/client_driver.py
@@ -144,7 +144,21 @@ async def run_chat_client(
             _configured_render_mode(config), is_tty=is_tty,
         )
         if resolved != "plain":
-            from reyn.interfaces.inline.textual_chat import run_textual_chat  # noqa: PLC0415
+            from reyn.runtime.startup_timing import (  # noqa: PLC0415
+                mark_tui_import_done,
+                stage,
+            )
+
+            # #3671 client-prep breakdown (architect's design, P3): this is
+            # the FIRST touch of textual/textual_flowview on this path — the
+            # import is lazy so that cost is paid here, not in the `import`
+            # stage (which closes at `mark_cli_reached`, before this module
+            # is even imported). Prime suspect for the 19.46s `client-prep`
+            # owner measured: owner's own `import 4.60s` is reyn's import
+            # tree only, and does not include this.
+            with stage("client-prep:tui-import"):
+                from reyn.interfaces.inline.textual_chat import run_textual_chat  # noqa: PLC0415
+            mark_tui_import_done()
             await run_textual_chat(
                 transport=transport,
                 read_model=read_model,

--- a/src/reyn/interfaces/repl/repl.py
+++ b/src/reyn/interfaces/repl/repl.py
@@ -71,14 +71,18 @@ async def run_repl(
     # session across `/attach` (re-wired by the registry), so neither the
     # working indicator nor the intervention channel strands on the old session.
     from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID
-    transport = InProcessTransport(
-        registry, intervention_channel=DEFAULT_CHAT_CHANNEL_ID
-    )
-    transport.start()
+    from reyn.runtime.startup_timing import stage  # noqa: PLC0415
+
+    with stage("client-prep:transport"):
+        transport = InProcessTransport(
+            registry, intervention_channel=DEFAULT_CHAT_CHANNEL_ID
+        )
+        transport.start()
 
     # The LOCAL read-model reads status/region/tasks off the attached session —
     # byte-identical to the pre-P3 inline reads.
-    read_model = RegistryReadModel(registry)
+    with stage("client-prep:read-model"):
+        read_model = RegistryReadModel(registry)
 
     try:
         await run_chat_client(

--- a/src/reyn/runtime/startup_timing.py
+++ b/src/reyn/runtime/startup_timing.py
@@ -105,6 +105,33 @@ def mark_async_entered() -> None:
         _ASYNC_ENTERED_AT = time.perf_counter()
 
 
+#: When the lazily-imported ``run_textual_chat`` module finished importing
+#: (``textual``/``textual_flowview`` and everything they pull in — NOT
+#: covered by the ``import`` stage above, which closes at ``mark_cli_reached``
+#: and therefore only ever measures reyn's OWN import tree; this import is
+#: lazy specifically so the flowview/textual cost is paid only on the path
+#: that needs it, which means that cost falls INSIDE this span instead).
+#: #3671 client-prep breakdown (architect's design): the boundary between
+#: "reyn resolved which renderer to use" and "the TUI framework's own object
+#: graph is being built" — P3/P4 below.
+_TUI_IMPORT_DONE_AT: "float | None" = None
+
+
+def mark_tui_import_done() -> None:
+    """Record that the lazy ``textual_chat``/``textual``/``textual_flowview``
+    import (``client_driver.py``'s ``from reyn.interfaces.inline.textual_chat
+    import run_textual_chat``) has finished.
+
+    Paired with :func:`mark_app_constructed` to bracket ``client-prep:app-
+    construct`` (P4) — the same "call is being made and returns are one
+    ``await`` deeper than a ``with`` block can hold" shape as
+    ``mark_app_constructed``/``mark_first_frame``.
+    """
+    global _TUI_IMPORT_DONE_AT
+    if _TUI_IMPORT_DONE_AT is None:
+        _TUI_IMPORT_DONE_AT = time.perf_counter()
+
+
 def mark_app_constructed() -> None:
     """Record that the TUI object exists and the framework is about to boot.
 
@@ -112,12 +139,28 @@ def mark_app_constructed() -> None:
     — terminal setup, first layout, first paint — as ``tui-boot``. Two marks
     rather than a ``with`` block because the region spans a return out of one
     function and into a framework callback, which no context manager can hold.
+
+    Also closes ``client-prep:app-construct`` (P4, paired with
+    :func:`mark_tui_import_done`) — #3671's original single ``client-prep``
+    lump (``mark_app_constructed`` minus ``mark_async_entered``) is replaced
+    by 4 named sub-stages at the seams architect's design identified
+    (``client-prep:transport`` / ``:read-model`` in ``repl.py``,
+    ``:tui-import`` around the lazy import, ``:app-construct`` here) rather
+    than kept alongside them — recording both would double-count the same
+    wall time under two names and corrupt ``unaccounted_seconds``'s
+    wall-vs-sum arithmetic. Any residual gap between the 4 sub-stages
+    (control-flow between them that no ``stage()``/mark pair covers) now
+    shows as ``unaccounted`` instead of being folded into the old lump —
+    the module's own stated philosophy: a report that silently absorbs the
+    unmeasured into the measured cannot tell the reader which is which.
     """
     global _APP_CONSTRUCTED_AT
     if _APP_CONSTRUCTED_AT is None:
         _APP_CONSTRUCTED_AT = time.perf_counter()
-        if _ASYNC_ENTERED_AT is not None:
-            TIMING.record("client-prep", _APP_CONSTRUCTED_AT - _ASYNC_ENTERED_AT)
+        if _TUI_IMPORT_DONE_AT is not None:
+            TIMING.record(
+                "client-prep:app-construct", _APP_CONSTRUCTED_AT - _TUI_IMPORT_DONE_AT
+            )
 
 
 def mark_first_frame() -> None:
@@ -163,7 +206,10 @@ STAGES: "tuple[str, ...]" = (
     "plugins",
     "mcp",
     "session",
-    "client-prep",
+    "client-prep:transport",
+    "client-prep:read-model",
+    "client-prep:tui-import",
+    "client-prep:app-construct",
     "tui-boot",
 )
 

--- a/tests/test_startup_timing_3671.py
+++ b/tests/test_startup_timing_3671.py
@@ -201,6 +201,91 @@ def test_the_report_survives_an_interrupt(monkeypatch, capsys) -> None:
     assert "startup timing" in capsys.readouterr().out
 
 
+def test_client_prep_is_four_named_sub_stages_not_one_lump(monkeypatch) -> None:
+    """Tier 2: #3671 (architect's design) — the single `client-prep` lump is
+    replaced by 4 named sub-stages at the seams already in the code (transport
+    construction, read-model construction, the lazy textual/flowview import,
+    and app construction), so a slow startup can say WHICH of the four, not
+    just that the client was slow to get ready."""
+    assert "client-prep" not in STAGES
+    for name in (
+        "client-prep:transport",
+        "client-prep:read-model",
+        "client-prep:tui-import",
+        "client-prep:app-construct",
+    ):
+        assert name in STAGES
+
+
+def test_tui_import_done_then_app_constructed_records_app_construct_stage(
+    monkeypatch,
+) -> None:
+    """Tier 2: P4 — the span between the lazy textual_chat import finishing
+    and the TUI object existing is recorded as `client-prep:app-construct`,
+    the same paired-mark shape `mark_app_constructed`/`mark_first_frame`
+    already use for a region a `with` block cannot hold (it crosses an
+    `await` into a different module)."""
+    import time
+
+    from reyn.runtime import startup_timing
+
+    monkeypatch.setattr(startup_timing, "_TUI_IMPORT_DONE_AT", None)
+    monkeypatch.setattr(startup_timing, "_APP_CONSTRUCTED_AT", None)
+    before = startup_timing.TIMING.total_seconds
+
+    startup_timing.mark_tui_import_done()
+    time.sleep(0.02)
+    startup_timing.mark_app_constructed()
+
+    after = startup_timing.TIMING.total_seconds
+    assert after - before >= 0.02
+
+
+def test_app_constructed_without_a_prior_tui_import_mark_records_nothing(
+    monkeypatch,
+) -> None:
+    """Tier 2: FALSIFY — if `mark_tui_import_done` was never called (e.g. a
+    future non-textual renderer reaches `mark_app_constructed` some other
+    way), no `client-prep:app-construct` time is recorded rather than
+    computing a bogus span against a stale/absent mark. Mirrors the existing
+    `if _ASYNC_ENTERED_AT is not None` guard shape."""
+    from reyn.runtime import startup_timing
+
+    monkeypatch.setattr(startup_timing, "_TUI_IMPORT_DONE_AT", None)
+    monkeypatch.setattr(startup_timing, "_APP_CONSTRUCTED_AT", None)
+    before = startup_timing.TIMING.total_seconds
+
+    startup_timing.mark_app_constructed()
+
+    assert startup_timing.TIMING.total_seconds == before
+
+
+def test_a_second_tui_import_mark_does_not_move_the_span(monkeypatch) -> None:
+    """Tier 2: idempotent, mirroring `mark_first_frame`'s own "only the first
+    call counts" contract — a re-import (should never happen, but the mark
+    is defensive the same way the others are) must not shrink P4 by resetting
+    the start point. Witnessed through the PUBLIC recorded duration (not the
+    private timestamp): if the second mark moved the start forward, the
+    recorded span would only cover the second sleep, not both.
+    """
+    import time
+
+    from reyn.runtime import startup_timing
+
+    monkeypatch.setattr(startup_timing, "_TUI_IMPORT_DONE_AT", None)
+    monkeypatch.setattr(startup_timing, "_APP_CONSTRUCTED_AT", None)
+    before = startup_timing.TIMING.total_seconds
+
+    startup_timing.mark_tui_import_done()
+    time.sleep(0.02)
+    startup_timing.mark_tui_import_done()  # no-op: only the first call counts
+    time.sleep(0.02)
+    startup_timing.mark_app_constructed()
+
+    after = startup_timing.TIMING.total_seconds
+    assert after - before >= 0.04
+
+
 def test_the_report_survives_an_exception(monkeypatch, capsys) -> None:
     """Tier 2: a startup that dies still reports.
 


### PR DESCRIPTION
**[e2e-coder]** — part of #3671 (architect's design, instrumentation only — no prescription this round, per lead-coder's explicit instruction).

## Context

Owner's real-machine remeasurement: `TOTAL 31.68s / import 4.60s / client-prep 19.46s (61.4%) / tui-boot 5.05s / unaccounted 2.20s`. The instrument works (`unaccounted` dropped from 98.9% at filing to 6.9%), but `client-prep` itself is still one lump covering four different things.

## What this adds

4 marks at existing seams (architect's design — no new mechanism):
- `client-prep:transport` — `repl.py`: `InProcessTransport` construction + `start()`
- `client-prep:read-model` — `repl.py`: `RegistryReadModel` construction
- `client-prep:tui-import` — `client_driver.py`: the lazy `from reyn.interfaces.inline.textual_chat import run_textual_chat` — the first touch of `textual`/`textual_flowview` on this path. **Not covered by the existing `import` stage**, which closes at `mark_cli_reached()` before this module is even imported — so this cost was invisible to owner's own `import 4.60s` figure, exactly as architect flagged.
- `client-prep:app-construct` — `client_driver.py` → `app.py`: new paired `mark_tui_import_done()`/`mark_app_constructed()`, the same shape `mark_app_constructed()`/`mark_first_frame()` already use for a span a `with` block can't hold (crosses an `await` into another module).

The old single `client-prep` record is **replaced**, not kept alongside the 4 new ones — recording both would double-count the same wall time under two names and corrupt `unaccounted_seconds()`'s wall-vs-sum arithmetic. Any residual gap between the 4 sub-stages that no `stage()`/mark pair covers now shows as `unaccounted` instead of being silently absorbed into the old lump.

## What this does NOT do

Architect's own ranking (P3, the lazy import, as prime suspect) is explicitly stated as a **guess, not a measurement**. This PR does not act on it — no "front-load the import" or "background it" prescription. That's the next step, once the 4 marks say which one actually dominates on a real machine.

## Verification

- 5 new unit tests (paired-mark idempotency, the guard-when-absent case, span computation) — all pass.
- **Real, live confirmation, not just unit tests**: launched an actual `reyn chat` under a pseudo-terminal with `REYN_STARTUP_TIMING=1` — it genuinely rendered on screen (the real banner + composer, visible in the captured ANSI output), was interrupted, and printed a report showing all 4 new stages, including a nonzero `client-prep:tui-import` (0.14s) — confirming the mechanism fires end-to-end in a real startup, not just in isolated unit tests.
- Full local suite (all extras installed): **10171 passed, 43 skipped, 0 failed, 0 errors.**
- `ruff check`, `test_tier_audit.py --strict`, mypy ratchet, `verify_module_docstrings.py` — all green.

## Test plan
- [x] 5 new unit tests for the paired-mark mechanics, all pass
- [x] Live pty run of real `reyn chat` — TUI actually rendered, interrupted, report showed all 4 stages including a real nonzero `tui-import` reading
- [x] Full suite green, no regressions
- [x] `ruff check`, `test_tier_audit.py --strict`, mypy ratchet, `verify_module_docstrings.py` all green
- [x] No prescription made — dominant term not yet determined on a real machine