### PR TITLE
ci(#3670): retighten the audit job's self-imposed timeout using real CI numbers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -188,16 +188,19 @@ jobs:
       # / json / pathlib). No pip install needed — keeps the job fast
       # and decoupled from src/ install state.
       #
-      # `timeout 10m` (#3670): converts a would-be `cancelled` job-timeout
-      # into a legible `failure` — see the "Run tests" job's comment for
-      # the full rationale. This specific job is what #3670 actually
-      # measured cancelling (4 of 5 consecutive main pushes, always at the
-      # 15-minute signature); #3670's own fix (a real algorithmic hotspot
-      # in test_tier_audit.py, see that PR) already took a full-tree run
-      # from ~122s to ~5s locally, so this budget should never realistically
-      # bind again — the wrapper stays as defense in depth against a FUTURE
-      # slowdown being invisible the same way, not because this one is
-      # still expected to be tight.
+      # `timeout 3m` (#3670, retightened): converts a would-be `cancelled`
+      # job-timeout into a legible `failure` — see the "Run tests" job's
+      # comment for the full rationale. This specific job is what #3670
+      # actually measured cancelling (4 of 5 consecutive main pushes,
+      # always at the 15-minute signature); #3670's own fix (a real
+      # algorithmic hotspot in test_tier_audit.py) took the full-tree run
+      # from 915s to a MEASURED 21s in real CI (this step's own share: ~7s
+      # of that, per a real run's per-step timestamps). Landed initially at
+      # a generous `10m` before that fix was confirmed in CI; a budget that
+      # loose says nothing when this step gets slow again — the exact
+      # defect #3670 exists to close — so it's retightened now that real
+      # numbers exist. `3m` is a ~25x margin over the measured ~7s, not a
+      # guess.
       - name: Run test-tier audit
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -216,11 +219,11 @@ jobs:
             echo "Auditing changed test files:"
             echo "$CHANGED"
             # shellcheck disable=SC2086
-            timeout 10m python scripts/test_tier_audit.py --strict $CHANGED
+            timeout 3m python scripts/test_tier_audit.py --strict $CHANGED
           else
             # push to main (or any non-PR trigger): full audit over the
             # entire test suite — invariant safety net, unchanged.
-            timeout 10m python scripts/test_tier_audit.py --strict tests/
+            timeout 3m python scripts/test_tier_audit.py --strict tests/
           fi
 
       # scripts/verify_module_docstrings.py is stdlib-only. PR events: scoped
@@ -228,7 +231,9 @@ jobs:
       # regress-proof invariant net, now that the tree is clean (#1802). Blocks
       # moved-module refactor-narrative docstrings (the C-series discipline).
       #
-      # `timeout 3m` (#3670): same reasoning as the step above.
+      # `timeout 1m` (#3670, retightened): same reasoning as the step
+      # above — measured real share of this specific step: ~2.3s, so `1m`
+      # is a ~25x margin, matching the audit step's own retightened ratio.
       - name: Run module-docstring narrative check
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -242,8 +247,8 @@ jobs:
             echo "Checking changed src files:"
             echo "$CHANGED"
             # shellcheck disable=SC2086
-            timeout 3m python scripts/verify_module_docstrings.py $CHANGED
+            timeout 1m python scripts/verify_module_docstrings.py $CHANGED
           else
             # push to main (or any non-PR trigger): full-tree gate.
-            timeout 3m python scripts/verify_module_docstrings.py src/reyn
+            timeout 1m python scripts/verify_module_docstrings.py src/reyn
           fi


### PR DESCRIPTION
**[e2e-coder]** — follow-up requested when #3734 landed ("入ったら timeout 10m の妥当性を再測してください").

## Real numbers, not a guess

Two consecutive main CI runs post-#3733/#3734, per-step timestamps from the actual logs:
- Whole `audit` job: ~21-22s (was 915s pre-#3733).
- `Run test-tier audit` step alone: ~7s.
- `Run module-docstring narrative check` step alone: ~2.3s.

## The fix

The self-imposed `timeout` wrapper #3734 introduced was set generously (`10m`/`3m`) before #3733's fix was confirmed in real CI — reasonable at the time, but exactly the shape lead-coder flagged: a budget that stays loose after the real number is known says nothing the next time this step gets slow again, which is the defect #3670 exists to close.

Retightened to `timeout 3m` (audit) / `timeout 1m` (docstring) — a ~25x margin over the measured real numbers on both, generous enough to absorb CI variance and larger diffs without false positives, tight enough to actually flag a future regression long before it approaches anywhere near the old 900s crisis.

The job-level `timeout-minutes: 15` (GitHub's own outer backstop) is untouched — only the inner self-imposed wrapper is retightened.

## Verification
- YAML valid, job/step structure intact.
- Based on real timestamps from 2 actual main CI runs (`gh run view --json jobs`), not estimated.

## Test plan
- [x] YAML valid
- [x] Budget values derived from real, measured CI timestamps (2 runs), not guessed