### PR TITLE
test: wait for the submit to arrive, not for one pass of the event loop

### DIFF
--- a/tests/test_textual_chat_intervention_panel_3299.py
+++ b/tests/test_textual_chat_intervention_panel_3299.py
@@ -270,6 +270,21 @@ def _pane_ids_in_order(panel: InterventionPanel) -> "list[str]":
     return [pane.id for pane in panel.query(TabPane) if pane.id is not None]
 
 
+async def _settle_until(pilot, until) -> None:
+    """Pump until ``until()`` is true, or until the budget runs out.
+
+    The budget is generous and is only SPENT when the condition is genuinely
+    slow, so a healthy run costs one pass. Modelled on
+    ``tests/test_textual_chat_copy_rewind_3362.py``'s ``_settle``, and on
+    #3651's rule: wait for a signal, never for a wall-clock guess.
+    """
+    for _ in range(150):
+        await pilot.pause()
+        if until():
+            return
+        await asyncio.sleep(0.01)
+
+
 @pytest.mark.asyncio
 async def test_choice_intervention_panel_selection_delivers_correct_choice_id() -> None:
     """Tier 2b: F1 permission-band reachability — a closed-set intervention
@@ -362,7 +377,14 @@ async def test_composer_submit_during_pending_intervention_is_always_a_new_turn(
         await pilot.pause()
         await pilot.press("y", "e", "s")
         await pilot.press("enter")
-        await pilot.pause()
+        # #3720: wait for the submit to ARRIVE, not for one turn of the loop.
+        # A bare ``pause()`` asserts that the send completes within a single
+        # pass of the event loop, which is a property of the machine rather
+        # than of the code — it went red once on CI's 3.11 runner and green on
+        # a rerun of the same commit. The predicate never weakens the
+        # assertion: if the submit never lands, the assert below still fails,
+        # just after waiting rather than before.
+        await _settle_until(pilot, lambda: transport.submitted)
 
     assert transport.submitted == ["yes"]
     assert transport.answered_choice == []


### PR DESCRIPTION
**[e2e-coder]** — main is red (pytest 3.12), fixing urgently.

## Problem

`main` red: `test_composer_submit_during_pending_intervention_is_always_a_new_turn` — `assert [] == ['yes']`. Asserts `transport.submitted` immediately after a bare `pilot.pause()`, which only guarantees the send completes within a single pass of the event loop — a property of the machine's own timing, not of the code under test. Red once on 3.11 (previous occurrence), red once (differently) on 3.12 (this occurrence), green on rerun both times — **timing-dependent, not version-dependent**.

## Fix

Cherry-picked (this file, this diff **only** — 23 lines) from PR #3720's `tests/test_textual_chat_intervention_panel_3299.py`. That PR stays open and intentionally RED for an unrelated, real tail-away defect (#3712) — this unrelated fix shouldn't be held hostage to it. **Not marking this as fixing/closing #3712** — that stays a separate, real, open issue.

Adds `_settle_until(pilot, until)`: pumps (`pilot.pause()` + a short sleep) up to 150 times or until the condition holds — modelled on `test_textual_chat_copy_rewind_3362.py`'s own `_settle` and #3651's rule (wait for a signal, never a wall-clock guess). Never weakens the assertion — if the submit genuinely never lands, the assert below still fails, just after waiting rather than before.

## Verification
- Target test passes **5/5** locally.
- **Falsified `_settle_until`'s own pumping behavior directly** (not just "it went green"): injected an artificial 0.5s delay into the fake transport's `submit_user_text`, confirmed the test still passes (it waits the delay out rather than asserting on a stale empty list) — reverted after.
- Full file: 24/24 tier-audit clean, 25/25 pytest pass.
- `ruff check`, mypy ratchet — green.

## Test plan
- [x] Target test passes 5/5 locally
- [x] Falsify: artificial 0.5s delay injected into the transport, `_settle_until` waits it out correctly, reverted
- [x] Full file (25 tests) passes; tier-audit (24 test functions) clean
- [x] `ruff check`, mypy ratchet green
- [x] No closing keyword — #3712 (the tail-away defect PR #3720 is blocked on) stays open