### PR TITLE
test(#3570): remove real-timer dependency from the mixed-backlog coalesce assertion

### DIFF
--- a/tests/test_stream_repaint_coalesce_3570.py
+++ b/tests/test_stream_repaint_coalesce_3570.py
@@ -246,7 +246,7 @@ async def test_repaints_stop_tracking_arrivals_without_dropping_text(
 
 @pytest.mark.asyncio
 async def test_a_mixed_backlog_coalesces_per_chain_not_per_delta(
-    tmp_path,
+    tmp_path, monkeypatch,
 ) -> None:
     """Tier 2: ★repaints follow the number of REPLIES in flight, not the number
     of deltas — on a backlog that is *mixed*, not a clean run of one chain.
@@ -271,6 +271,29 @@ async def test_a_mixed_backlog_coalesces_per_chain_not_per_delta(
     emit (``host.events.emit("agent_delta", ...)``, the SAME call
     ``RouterLoop._emit_agent_delta`` makes) and the tool frames ride
     ``repl_outbox`` (the display path the registry forwarder feeds).
+
+    ★ #3746 fix: ``_schedule_streaming_catchup`` is neutralized here. With
+    ``clock`` frozen, ``_repaint_streaming_reply_within_budget``'s own
+    comparison (``self._clock() - record.last_repaint``) never crosses the
+    budget, so the DIRECT flush path never fires during this loop — every
+    repaint the old assertion measured came exclusively from the catch-up
+    TIMER, which is armed via Textual's real ``set_timer`` (real wall-clock,
+    NOT the injected clock — confirmed by reading ``message_pump.py``). The
+    "frozen: no repaint can be due" comment above was true for the budget
+    check but not for this second path, so the repaint count this test
+    measured was actually "how many real 33ms windows elapsed while
+    processing 200 arrivals on this machine, under this load" — environment-
+    and load-dependent by construction, not a stable per-arrival ratio.
+    Measured directly: 2-4 repaints across 15 local runs (Python 3.12), a
+    CI run hit exactly 20 (the `arrivals // 10` threshold this test used to
+    assert against) once. The catch-up timer's own real-time behavior is
+    already dedicated-tested by
+    ``test_a_deferred_repaint_is_painted_within_the_budget_window`` above,
+    so this test does not need to also exercise it — disabling it here
+    makes THIS test's own claim (chain interleaving + tool frames do not
+    defeat per-chain coalescing) assert on the fully deterministic path
+    instead of racing a real timer against however long a real backlog
+    drain happens to take.
     """
     chains = ("chain-a", "chain-b")
     per_chain = 100
@@ -279,6 +302,13 @@ async def test_a_mixed_backlog_coalesces_per_chain_not_per_delta(
     registry, transport, app = await _build(
         tmp_path, clock=clock, app_cls=_DeltaCountingApp
     )
+    # #3746: see the docstring above — the catch-up timer is real-wall-clock
+    # driven regardless of the frozen `clock`, so it is the ONLY source of
+    # non-determinism left once the budget check itself never fires. A no-op
+    # here is safe per the method's own contract ("the budget is an
+    # OPTIMISATION... failing to arm the timer must degrade... never break
+    # the pump") and covered in isolation by the sibling test above.
+    monkeypatch.setattr(app, "_schedule_streaming_catchup", lambda: None)
     session = registry.attached_session()
     try:
         async with app.run_test(size=(100, 50)) as pilot:
@@ -304,13 +334,18 @@ async def test_a_mixed_backlog_coalesces_per_chain_not_per_delta(
 
             # Every reply is on screen from its first delta (the append carries
             # it, which is why the count below starts from a painted row, not a
-            # blank one); ``revision`` then counts only the RE-paints.
+            # blank one); ``revision`` then counts only the RE-paints. With the
+            # catch-up timer neutralized and the budget clock frozen, NO repaint
+            # can happen during this loop at all — asserting exactly 0 is the
+            # deterministic, environment-independent form of the same claim the
+            # old approximate `< arrivals // 10` threshold was reaching for.
             assert all(_CHUNK in str(e.item.text) for e in entries.values())
             repaints = sum(e.revision for e in entries.values())
-            assert repaints < arrivals // 10, (
+            assert repaints == 0, (
                 f"{repaints} repaints for {arrivals} deltas across {len(chains)} "
-                "replies — repaints must follow the replies in flight, not the "
-                "arrivals"
+                "replies with the catch-up timer disabled and the budget clock "
+                "frozen — no repaint should be possible at all; the direct "
+                "budget-check path fired when it should not have"
             )
 
             # ...and nothing was dropped: one more delta per chain, past the


### PR DESCRIPTION
**[e2e-coder]** — 🔴 main-red fix, top priority per lead-coder. Fixes `tests/test_stream_repaint_coalesce_3570.py::test_a_mixed_backlog_coalesces_per_chain_not_per_delta` (CI: pytest 3.12 job, `20 < 20` off-by-exactly-one).

## Attribution confirmed: not #3744

#3744 only added a new test file — zero production changes — so it cannot have altered coalescing behavior. Trigger, not cause (same shape as #3735).

## Root cause: NOT a boundary-tight but honest "<10" contract — the assertion was measuring real wall-clock timer noise

Measured, not guessed, per the ask:

- The test freezes `clock` (`_Clock`, injected via `TextualChatApp(clock=...)`) so `_repaint_streaming_reply_within_budget`'s own comparison (`self._clock() - record.last_repaint >= _STREAM_REPAINT_MIN_INTERVAL`) never crosses the budget during the loop — confirmed by reading `app.py`. The DIRECT flush path therefore never fires.
- Every repaint the old assertion counted came exclusively from the catch-up timer (`_schedule_streaming_catchup`), which arms via Textual's own `MessagePump.set_timer` — confirmed by reading `textual/message_pump.py`: this uses the REAL event loop (`call_later`), not the injected `clock`. The "frozen: no repaint can be 'due'" comment at the top of the test was true for the budget-check path only, not for this one.
- **This means the measured repaint count is "how many real 33ms windows elapsed while processing 200 arrivals on this machine, under this load"** — environment- and load-dependent by construction, not a stable per-arrival ratio. There is no documented "N arrivals per repaint" contract anywhere in the design comments; the actual invariant is time-based ("within one interval"), not count-based.
- Confirmed empirically: 2-4 repaints across 15 local runs (Python 3.12, same version as the failing CI job) with wall-clock durations varying 1.1s-5.19s between otherwise-identical runs — direct evidence the count tracks real elapsed time, not delta volume. CI hit exactly 20 once, consistent with a slower/loaded CI runner producing more real timer firings during the same logical work.

## Fix

Not a threshold tweak (`<` → `<=` would just move the flaky boundary by one, not remove the flakiness). `_schedule_streaming_catchup` is neutralized (`monkeypatch.setattr(app, "_schedule_streaming_catchup", lambda: None)`) for this specific test, making the assertion assert on the fully deterministic path: with the timer disabled and the clock frozen, **no repaint can happen at all**, so the assertion tightens from an approximate `< arrivals // 10` to an exact `== 0`. The catch-up timer's own real-time behavior is already dedicated-tested in isolation by the sibling `test_a_deferred_repaint_is_painted_within_the_budget_window` in the same file, so this test doesn't lose coverage by not also exercising it — its own claim (chain interleaving + tool frames don't defeat per-chain coalescing) was never about the timer.

## Verification

- [x] 10 consecutive local runs post-fix — stable at `repaints == 0` every time (vs. 2-4 pre-fix, confirming the fix eliminates the timing dependency entirely, not just narrows it)
- [x] Falsify: forced `_repaint_streaming_reply_within_budget` to flush unconditionally (the real defect this test exists to catch) → 198/200 repaints, RED for the right reason → reverted, `git diff --stat` on `app.py` empty
- [x] `ruff check src tests` — clean
- [x] `scripts/test_tier_audit.py --strict` on the changed file — 4/4 OK, 0 Tier-4 violations
- [x] `scripts/mypy_ratchet.py` — OK, 211 findings all baselined (no new)
- [x] Full test file (`test_stream_repaint_coalesce_3570.py`) — 4/4 passed
- [x] full-repo `pytest` — running, will report before merge (opening now given main-red urgency; test-file-only change, no production code touched)

## Test plan

- [x] Root cause measured (real-timer dependency), not assumed
- [x] Falsify confirms the fixed assertion is load-bearing against the real defect class
- [x] No production code changed — the coalescer's own behavior is unaffected, only the test's timing dependency is removed

part of #3570
