### PR TITLE
docs: sync testing.md's CI-gate count with CLAUDE.md (four → five, mypy ratchet)

### DIFF
--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -719,10 +719,10 @@ REYN_LLM_RECORD=1 python -m pytest tests/ -v
 
 ---
 
-## Before you push — the four CI gates
+## Before you push — the five CI gates
 
 A green `pytest` run is **not** a green CI run. `.github/workflows/test.yml` runs
-four *separate* gates; run all four locally on your diff before calling a PR
+five *separate* gates; run all five locally on your diff before calling a PR
 ready:
 
 1. **pytest** — from the repo root (not a subset path) so collection matches CI:
@@ -751,10 +751,18 @@ ready:
    ```bash
    python scripts/verify_module_docstrings.py <changed_src_files>
    ```
+5. **mypy ratchet** — `scripts/mypy_ratchet.py` (#3726). A *ratchet*, not full
+   mypy adoption: it only fails on a `(file, error-code)` pair not already
+   declared in `scripts/mypy_ratchet_baseline.json` — a genuinely new mypy
+   finding in a file you touched fails this even though `mypy` itself isn't
+   in this repo's mental model of "the linter":
+   ```bash
+   python scripts/mypy_ratchet.py
+   ```
 
 A green `pytest` alone has shipped PRs that CI then bounced on ruff (`I001`) or
 the tier audit (a `len(...) == 1` format pin). Report scope honestly: say
-"pytest passed" if that is all you ran — "suite passed" implies all four gates.
+"pytest passed" if that is all you ran — "suite passed" implies all five gates.
 
 ---
 


### PR DESCRIPTION
**[docs-maintainer]** — Doc-drift sweep across today's ~31 merged PRs. Only 1 of 8 checked areas was real, actionable drift; the rest were already synced, test-only (no doc claim to falsify), or PRs still CI-pending with nothing to check yet.

## The drift

`CLAUDE.md:96` already says "run all five CI gates locally" and describes the mypy ratchet (#3729's own PR body synced it). `docs/deep-dives/contributing/testing.md`'s "## Before you push" section — the doc CLAUDE.md itself points readers to — was never updated: heading, opening sentence, and closing line all still said "four", and the numbered list had no mypy entry.

## Areas checked, no action needed

- `present`'s ack shape (#3740) — verified the PR's own doc-sync claim against actual current doc content (control-ir.md, present.md ×2, .ja.md ×2): all 4 correctly reflect the new `coerced`/`rows` shape.
- CUI echo-split (#3744/#3745) — test-only PRs, no `src/`/`docs/` changes.
- chain_id unification (#3747) — still OPEN/CI-pending, nothing merged to check.
- workspace-root explicitness (#3730) — fixed `/memory` CLI's cwd-relative default; no doc ever described the old behavior, so nothing is now false (a pre-existing gap, not new drift).
- mypy ratchet docstring (#3739) — docstring-only, no doc claims touched.
- CI timeout (#3734/#3736) — no doc states the specific timeout values these changed.
- verification-hazards.md §18 discoverability — no other doc references it by section number; nothing needs updating.
- testing.md's own § Time (#3749) — still OPEN/CI-pending, nothing to check yet.

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean
- [x] `python scripts/check_doc_anchors.py` — 0 dangling anchors
- [x] `pytest tests/test_3126_doc_anchor_gate.py` — 332/332 pass