### PR TITLE
test(#3570,#3693): remove real-timer dependencies caught by the #3748 attempts=1 experiment

### DIFF
--- a/tests/test_activity_row_3693.py
+++ b/tests/test_activity_row_3693.py
@@ -98,6 +98,23 @@ async def _settle(pilot, times: int = 4) -> None:
         await pilot.pause()
 
 
+async def _until(pred, *, attempts: int = 300, delay: float = 0.02) -> bool:
+    """Bounded poll (#3746-shaped fix, applied here too, see
+    ``test_the_clock_advances_without_any_delta_arriving``) — a hang exhausts
+    the budget and returns False (RED), never hangs the suite. 300 * 0.02 = 6s
+    ceiling, comfortably above ``ActivityRow.TICK_SECONDS`` (1.0s) even under
+    real CI load, while still genuinely requiring the row's own
+    ``set_interval`` timer to have fired at least once — this polls for the
+    OBSERVABLE effect of that firing, it never calls ``tick()`` directly
+    (which would pass even if ``on_mount``'s ``set_interval`` call were
+    silently removed, the exact regression this test exists to catch)."""
+    for _ in range(attempts):
+        if pred():
+            return True
+        await asyncio.sleep(delay)
+    return False
+
+
 # ── the row's own text: what it may and may not claim ────────────────────────
 
 
@@ -339,9 +356,20 @@ async def test_the_clock_advances_without_any_delta_arriving() -> None:
 
     Deliberately driven with NO frames at all. A gate that pushed deltas would
     go green on the side-effect path this exists to replace.
-    """
-    import asyncio as _asyncio
 
+    ★ #3746-shaped fix: a fixed ``asyncio.sleep(TICK_SECONDS * 1.4)`` waits on
+    the row's real ``set_interval`` timer (``activity_row.py``, real
+    wall-clock, NOT the injected ``clock`` above — same mechanism #3746 found
+    in ``app.py``'s streaming catch-up timer) with a FIXED margin, which a
+    loaded CI runner can exceed. Unlike #3746's coalesce test, this one CANNOT
+    simply disable the real timer — the timer firing on its own schedule IS
+    the property under test (the docstring's own point: a gate driven by
+    calling ``tick()`` directly would go green on the exact side-effect path
+    this test exists to replace). Fixed by polling for the OBSERVABLE effect
+    (the render text actually changing) with a generous bounded ceiling
+    instead of a single fixed sleep — still requires the real timer to have
+    fired, just tolerant of how long that takes under load.
+    """
     ticks: "list[float]" = [1000.0]
     transport = QueueTransport()
     app = TextualChatApp(transport=transport, clock=lambda: ticks[0])
@@ -354,11 +382,9 @@ async def test_the_clock_advances_without_any_delta_arriving() -> None:
 
         # Time passes; nothing arrives.
         ticks[0] += 75.0
-        await _asyncio.sleep(ActivityRow.TICK_SECONDS * 1.4)
-        await _settle(pilot)
-
-        after = str(row.render())
-        assert after != before, (
+        assert await _until(lambda: str(row.render()) != before), (
             f"the elapsed time did not move while the turn ran: {before!r}"
         )
+
+        after = str(row.render())
         assert "01:15" in after, f"the clock is not tracking the real gap: {after!r}"

--- a/tests/test_activity_row_3693.py
+++ b/tests/test_activity_row_3693.py
@@ -98,21 +98,26 @@ async def _settle(pilot, times: int = 4) -> None:
         await pilot.pause()
 
 
-async def _until(pred, *, attempts: int = 300, delay: float = 0.02) -> bool:
-    """Bounded poll (#3746-shaped fix, applied here too, see
-    ``test_the_clock_advances_without_any_delta_arriving``) — a hang exhausts
-    the budget and returns False (RED), never hangs the suite. 300 * 0.02 = 6s
-    ceiling, comfortably above ``ActivityRow.TICK_SECONDS`` (1.0s) even under
-    real CI load, while still genuinely requiring the row's own
-    ``set_interval`` timer to have fired at least once — this polls for the
-    OBSERVABLE effect of that firing, it never calls ``tick()`` directly
-    (which would pass even if ``on_mount``'s ``set_interval`` call were
-    silently removed, the exact regression this test exists to catch)."""
-    for _ in range(attempts):
-        if pred():
-            return True
-        await asyncio.sleep(delay)
-    return False
+async def _until(pred) -> None:
+    """Wait for ``pred()`` to become true — UNBOUNDED, no per-test time
+    budget (owner policy 2026-08-06,
+    ``feedback_tests_carry_no_time_limits_decompose_instead``: a test carries
+    no time limit of its own, marker or in-body; a slower environment must
+    only make this slower, never fail it — an ``attempts=N`` cap is a
+    disguised linear sleep, since past N it bets pass/fail on elapsed time
+    the same way a bare ``sleep(N)`` would). If this hangs, CI's
+    ``--timeout=120`` is the blast-radius kill-switch, not a contract this
+    test is written against — a hang there means "decompose this test or fix
+    the hang," never "the ceiling should have been bigger."
+
+    Used here (see ``test_the_clock_advances_without_any_delta_arriving``)
+    to poll for the OBSERVABLE effect of the row's own real ``set_interval``
+    timer firing — this still genuinely requires that real timer to have
+    fired at least once; it never calls ``tick()`` directly (which would
+    pass even if ``on_mount``'s ``set_interval`` call were silently removed,
+    the exact regression this test exists to catch)."""
+    while not pred():
+        await asyncio.sleep(0.01)
 
 
 # ── the row's own text: what it may and may not claim ────────────────────────
@@ -380,11 +385,12 @@ async def test_the_clock_advances_without_any_delta_arriving() -> None:
         row = app.query_one(ActivityRow)
         before = str(row.render())
 
-        # Time passes; nothing arrives.
+        # Time passes; nothing arrives. Unbounded wait (see `_until`): if the
+        # elapsed time never moves, this hangs rather than failing with a
+        # message — CI's own kill-switch is what surfaces that, not a local
+        # budget pretending to know how long is "too long."
         ticks[0] += 75.0
-        assert await _until(lambda: str(row.render()) != before), (
-            f"the elapsed time did not move while the turn ran: {before!r}"
-        )
+        await _until(lambda: str(row.render()) != before)
 
         after = str(row.render())
         assert "01:15" in after, f"the clock is not tracking the real gap: {after!r}"

--- a/tests/test_stream_repaint_coalesce_3570.py
+++ b/tests/test_stream_repaint_coalesce_3570.py
@@ -218,11 +218,32 @@ async def test_repaints_stop_tracking_arrivals_without_dropping_text(
     flush unconditionally puts the revision back in step with the delta count
     and this gate goes RED, while the text half stays green — the two halves
     fail independently.
+
+    ★ #3748 experiment fix: same real-timer dependency #3746 found in this
+    file's mixed-backlog sibling. With ``clock`` frozen, the budget-check
+    path never fires, so every repaint the old ``< chunks // 10`` threshold
+    measured came from the catch-up timer's real ``set_timer`` (real
+    wall-clock, not the injected clock) — caught live by the #3748
+    ``attempts=1`` experiment (21 repaints on one run, one over the old
+    threshold of 20). Neutralized here too, for the same reason: the
+    catch-up timer's own real-time behavior is already dedicated-tested by
+    ``test_a_deferred_repaint_is_painted_within_the_budget_window``. Unlike
+    the mixed-backlog sibling, the expected count with it disabled is
+    exactly 1, not 0 — the terminal completion frame's own
+    ``entry.set_item`` (below, in ``_ingest_frame``) is a real, unconditional
+    repaint independent of the catch-up timer, and this test's OWN scenario
+    runs to completion (unlike the mixed-backlog test, which asserts
+    mid-stream, before any completion frame arrives).
     """
     chunks = 200
     clock = _Clock()  # frozen: no delta can ever be "due" on the budget clock
     _install_bursting_llm(monkeypatch, chunks=chunks)
     registry, transport, app = await _build(tmp_path, clock=clock)
+    # #3748: see the docstring above — neutralize the real-wall-clock catch-up
+    # timer so the measured revision count is fully deterministic. Safe per
+    # the method's own contract (an optimisation only) and covered in
+    # isolation by the sibling test named above.
+    monkeypatch.setattr(app, "_schedule_streaming_catchup", lambda: None)
     try:
         async with app.run_test(size=(100, 30)) as pilot:
             await pilot.pause()
@@ -233,11 +254,12 @@ async def test_repaints_stop_tracking_arrivals_without_dropping_text(
                 lambda: _CHUNK * chunks in str(entry.item.text)
             ), "the full streamed text never reached the entry"
 
-            # Far fewer repaints than deltas. The budget's own catch-up timer
-            # (and the terminal completion) account for the handful that do
-            # happen; what must not happen is one per arrival.
-            assert entry.revision < chunks // 10, (
-                f"{entry.revision} repaints for {chunks} deltas — the repaint "
+            # With the catch-up timer disabled and the budget clock frozen, the
+            # ONLY possible repaint is the terminal completion frame's own
+            # unconditional `entry.set_item` — exactly 1, deterministically.
+            assert entry.revision == 1, (
+                f"{entry.revision} repaints for {chunks} deltas — expected "
+                "exactly 1 (the terminal completion write); the repaint "
                 "budget is not coalescing"
             )
     finally:


### PR DESCRIPTION
**[e2e-coder]** — Two same-class fixes, bundled since both are direct #3746/#3748 follow-ups.

## 1. `test_repaints_stop_tracking_arrivals_without_dropping_text` (#3570 sibling)

Caught LIVE by the #3748 `attempts=1` experiment: this test, in the same file as #3746, has the identical bug — frozen clock means every measured repaint comes from the real catch-up timer (`set_timer`, real wall-clock), not the injected clock. One experiment run hit 21 repaints against the old `< chunks // 10` (20) threshold. Same fix as #3746: neutralize the catch-up timer (already dedicated-tested by a sibling in the same file) and tighten to an exact, deterministic count — here `== 1` (not `== 0` like #3746's test), because this test's own scenario runs to completion, and the terminal completion frame's `entry.set_item` is a real, unconditional repaint independent of the catch-up timer.

Verified: 10/10 stable locally, falsify confirmed load-bearing (200/200 repaints when `_repaint_streaming_reply_within_budget` is forced to flush unconditionally, reverted clean).

## 2. `ActivityRow`'s real-timer test (#3693), per the new owner policy

`test_the_clock_advances_without_any_delta_arriving` waited on `ActivityRow`'s real `set_interval` timer with a fixed `asyncio.sleep(TICK_SECONDS * 1.4)` margin — same class as #3746, but this test genuinely NEEDS the real timer to fire on its own schedule (that's the property under test, unlike #3746's purely-optimizational catch-up timer, so it can't simply be disabled).

Per the owner's now-merged testing policy (`feedback_tests_carry_no_time_limits_decompose_instead`, testing.md § Time): no test carries a time budget, marker or in-body — a bounded poll's `attempts=N` is a disguised linear sleep past N. Replaced the fixed sleep with an UNBOUNDED `while not pred(): await asyncio.sleep(0.01)`, relying only on CI's `--timeout=120` as the blast-radius kill-switch, never a per-test contract. Falsify re-verified under the new form: breaking the `set_interval` wiring now correctly HANGS (bash-level `timeout 15` → exit 124) rather than asserting a message — the prescribed witness shape under the new policy.

(Note: this test's fix predates my seeing the policy pin — I had already converged independently on a bounded-poll form, then redesigned to unbounded once I saw the pin land. Recorded on the issue thread as the independent-convergence witness lead-coder flagged.)

## Test plan

- [x] `ruff check src tests` — clean
- [x] `scripts/test_tier_audit.py --strict` on both changed files — 15/15 OK, 0 Tier-4 violations
- [x] `scripts/mypy_ratchet.py` — OK, 211 findings all baselined (no new)
- [x] Both files' full test suites — 15/15 passed
- [x] 10 consecutive runs of the repaint fix — stable; 8 consecutive runs of the activity_row fix — stable
- [x] Falsify both, manually verified RED/hang for the right reason, reverted clean
- [x] full-repo `pytest` — running (nohup+disown, avoiding the Bash-tool 600s ceiling that killed 3 earlier background attempts), will report before merge

No production code changed in either fix.

part of #3570, part of #3693, part of #3748
