### PR TITLE
test(#3748): unbound the 10-file identical _wait_for helper, no time budgets

### DIFF
--- a/tests/test_2597_p1_reconnect_resync_read.py
+++ b/tests/test_2597_p1_reconnect_resync_read.py
@@ -39,11 +39,13 @@ def _stdio_cfg(script: Path) -> dict:
 
 
 async def _wait_for(predicate, *, delay: float = 0.02) -> None:
-    """Poll ``predicate()`` -- UNBOUNDED (owner policy 2026-08-06,
-    feedback_tests_carry_no_time_limits_decompose_instead): no per-test time
-    budget, marker or in-body. A slower environment only makes this slower,
+    """Delivery is asynchronous, not synchronous with the triggering call.
+    Unbounded per the owner's testing policy
+    (docs/deep-dives/contributing/testing.md, ## Time): no test carries a time
+    budget, marker or in-body -- a slower environment only makes this slower,
     never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
-    contract this waits against."""
+    contract.
+    """
     while not predicate():
         await asyncio.sleep(delay)
 

--- a/tests/test_2597_p1_reconnect_resync_read.py
+++ b/tests/test_2597_p1_reconnect_resync_read.py
@@ -38,13 +38,13 @@ def _stdio_cfg(script: Path) -> dict:
     return {"type": "stdio", "command": sys.executable, "args": [str(script)]}
 
 
-async def _wait_for(predicate, *, attempts: int = 100, delay: float = 0.02) -> None:
-    """Poll ``predicate()`` until True or give up — mirrors
-    test_2597_s2b_resource_subscriptions.py's pattern (async delivery, not
-    synchronous with the triggering call)."""
-    for _ in range(attempts):
-        if predicate():
-            return
+async def _wait_for(predicate, *, delay: float = 0.02) -> None:
+    """Poll ``predicate()`` -- UNBOUNDED (owner policy 2026-08-06,
+    feedback_tests_carry_no_time_limits_decompose_instead): no per-test time
+    budget, marker or in-body. A slower environment only makes this slower,
+    never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
+    contract this waits against."""
+    while not predicate():
         await asyncio.sleep(delay)
 
 

--- a/tests/test_2597_s2b_resource_subscriptions.py
+++ b/tests/test_2597_s2b_resource_subscriptions.py
@@ -60,13 +60,13 @@ def _run(coro):
     return asyncio.run(coro)
 
 
-async def _wait_for(predicate, *, attempts: int = 100, delay: float = 0.02) -> None:
-    """Poll ``predicate()`` until True or give up — the notification arrives
-    asynchronously on FastMCP/the SDK's receive loop, not synchronously with the
-    triggering call (mirrors test_2597_s2b_mcp_notifications_bridge.py's pattern)."""
-    for _ in range(attempts):
-        if predicate():
-            return
+async def _wait_for(predicate, *, delay: float = 0.02) -> None:
+    """Poll ``predicate()`` -- UNBOUNDED (owner policy 2026-08-06,
+    feedback_tests_carry_no_time_limits_decompose_instead): no per-test time
+    budget, marker or in-body. A slower environment only makes this slower,
+    never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
+    contract this waits against."""
+    while not predicate():
         await asyncio.sleep(delay)
 
 

--- a/tests/test_2597_s2b_resource_subscriptions.py
+++ b/tests/test_2597_s2b_resource_subscriptions.py
@@ -61,11 +61,13 @@ def _run(coro):
 
 
 async def _wait_for(predicate, *, delay: float = 0.02) -> None:
-    """Poll ``predicate()`` -- UNBOUNDED (owner policy 2026-08-06,
-    feedback_tests_carry_no_time_limits_decompose_instead): no per-test time
-    budget, marker or in-body. A slower environment only makes this slower,
-    never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
-    contract this waits against."""
+    """The notification arrives asynchronously on FastMCP/the SDK's receive loop,
+    not synchronously with the triggering call. Unbounded per the owner's
+    testing policy (docs/deep-dives/contributing/testing.md, ## Time): no test
+    carries a time budget, marker or in-body -- a slower environment only makes
+    this slower, never fail it; CI's --timeout=120 is the blast-radius
+    kill-switch, not a contract.
+    """
     while not predicate():
         await asyncio.sleep(delay)
 

--- a/tests/test_2608_h1_mcp_resource_updated_hook.py
+++ b/tests/test_2608_h1_mcp_resource_updated_hook.py
@@ -40,11 +40,13 @@ def _stdio_cfg(script: Path) -> dict:
 
 
 async def _wait_for(predicate, *, delay: float = 0.02) -> None:
-    """Poll ``predicate()`` -- UNBOUNDED (owner policy 2026-08-06,
-    feedback_tests_carry_no_time_limits_decompose_instead): no per-test time
-    budget, marker or in-body. A slower environment only makes this slower,
-    never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
-    contract this waits against."""
+    """The push notification arrives asynchronously on the MCP receive-loop task,
+    not synchronously with the triggering call. Unbounded per the owner's
+    testing policy (docs/deep-dives/contributing/testing.md, ## Time): no test
+    carries a time budget, marker or in-body -- a slower environment only makes
+    this slower, never fail it; CI's --timeout=120 is the blast-radius
+    kill-switch, not a contract.
+    """
     while not predicate():
         await asyncio.sleep(delay)
 

--- a/tests/test_2608_h1_mcp_resource_updated_hook.py
+++ b/tests/test_2608_h1_mcp_resource_updated_hook.py
@@ -39,13 +39,13 @@ def _stdio_cfg(script: Path) -> dict:
     return {"type": "stdio", "command": sys.executable, "args": [str(script)]}
 
 
-async def _wait_for(predicate, *, attempts: int = 100, delay: float = 0.02) -> None:
-    """Poll ``predicate()`` until True or give up — the push notification arrives
-    asynchronously on the MCP receive-loop task, not synchronously with the
-    triggering call (mirrors test_2597_s2b_resource_subscriptions.py's pattern)."""
-    for _ in range(attempts):
-        if predicate():
-            return
+async def _wait_for(predicate, *, delay: float = 0.02) -> None:
+    """Poll ``predicate()`` -- UNBOUNDED (owner policy 2026-08-06,
+    feedback_tests_carry_no_time_limits_decompose_instead): no per-test time
+    budget, marker or in-body. A slower environment only makes this slower,
+    never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
+    contract this waits against."""
+    while not predicate():
         await asyncio.sleep(delay)
 
 

--- a/tests/test_2608_h4_fs_watcher.py
+++ b/tests/test_2608_h4_fs_watcher.py
@@ -62,13 +62,13 @@ class _Recorder:
         self.calls.append((point, dict(template_vars)))
 
 
-async def _wait_for(predicate, *, attempts: int = 200, delay: float = 0.02) -> None:
-    """Poll ``predicate()`` until True or give up — fs events arrive
-    asynchronously off a separate OS thread, not synchronously with the
-    triggering file write."""
-    for _ in range(attempts):
-        if predicate():
-            return
+async def _wait_for(predicate, *, delay: float = 0.02) -> None:
+    """Poll ``predicate()`` -- UNBOUNDED (owner policy 2026-08-06,
+    feedback_tests_carry_no_time_limits_decompose_instead): no per-test time
+    budget, marker or in-body. A slower environment only makes this slower,
+    never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
+    contract this waits against."""
+    while not predicate():
         await asyncio.sleep(delay)
 
 

--- a/tests/test_2608_h4_fs_watcher.py
+++ b/tests/test_2608_h4_fs_watcher.py
@@ -63,11 +63,13 @@ class _Recorder:
 
 
 async def _wait_for(predicate, *, delay: float = 0.02) -> None:
-    """Poll ``predicate()`` -- UNBOUNDED (owner policy 2026-08-06,
-    feedback_tests_carry_no_time_limits_decompose_instead): no per-test time
-    budget, marker or in-body. A slower environment only makes this slower,
+    """fs events arrive asynchronously off a separate OS thread, not synchronously
+    with the triggering file write. Unbounded per the owner's testing policy
+    (docs/deep-dives/contributing/testing.md, ## Time): no test carries a time
+    budget, marker or in-body -- a slower environment only makes this slower,
     never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
-    contract this waits against."""
+    contract.
+    """
     while not predicate():
         await asyncio.sleep(delay)
 
@@ -202,7 +204,7 @@ async def test_symlinked_watch_path_reports_events_under_the_configured_prefix(t
         # A generous budget, then an EXPLICIT non-empty assertion so a genuine
         # "never fired" fails loudly (with the diagnostic below) instead of an
         # opaque IndexError on ``calls[0]``.
-        await _wait_for(lambda: len(trigger.calls) >= 1, attempts=500, delay=0.02)
+        await _wait_for(lambda: len(trigger.calls) >= 1, delay=0.02)
         assert trigger.calls, (
             f"no file_changed hook fired within the wait budget for a write under "
             f"a symlinked watch path (configured={configured_path!r}, "

--- a/tests/test_2608_h5_cron_webhook_hooks.py
+++ b/tests/test_2608_h5_cron_webhook_hooks.py
@@ -66,11 +66,13 @@ def _seed(tmp_path: Path, name: str) -> None:
 
 
 async def _wait_for(predicate, *, delay: float = 0.02) -> None:
-    """Poll ``predicate()`` -- UNBOUNDED (owner policy 2026-08-06,
-    feedback_tests_carry_no_time_limits_decompose_instead): no per-test time
-    budget, marker or in-body. A slower environment only makes this slower,
-    never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
-    contract this waits against."""
+    """The hook fires on a background task (``fire_and_forget``), not
+    synchronously with the triggering call. Unbounded per the owner's testing
+    policy (docs/deep-dives/contributing/testing.md, ## Time): no test carries
+    a time budget, marker or in-body -- a slower environment only makes this
+    slower, never fail it; CI's --timeout=120 is the blast-radius kill-switch,
+    not a contract.
+    """
     while not predicate():
         await asyncio.sleep(delay)
 

--- a/tests/test_2608_h5_cron_webhook_hooks.py
+++ b/tests/test_2608_h5_cron_webhook_hooks.py
@@ -65,13 +65,13 @@ def _seed(tmp_path: Path, name: str) -> None:
     AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
 
 
-async def _wait_for(predicate, *, attempts: int = 100, delay: float = 0.02) -> None:
-    """Poll ``predicate()`` until True or give up — the hook fires on a
-    background task (``fire_and_forget``), not synchronously with the
-    triggering call (mirrors H1/H4's own polling helper)."""
-    for _ in range(attempts):
-        if predicate():
-            return
+async def _wait_for(predicate, *, delay: float = 0.02) -> None:
+    """Poll ``predicate()`` -- UNBOUNDED (owner policy 2026-08-06,
+    feedback_tests_carry_no_time_limits_decompose_instead): no per-test time
+    budget, marker or in-body. A slower environment only makes this slower,
+    never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
+    contract this waits against."""
+    while not predicate():
         await asyncio.sleep(delay)
 
 

--- a/tests/test_2608_run_loop_pickup.py
+++ b/tests/test_2608_run_loop_pickup.py
@@ -66,11 +66,13 @@ def _make_llm_stub_fn(result: LLMToolCallResult):  # type: ignore[no-untyped-def
 
 
 async def _wait_for(predicate, *, delay: float = 0.02) -> None:
-    """Poll ``predicate()`` -- UNBOUNDED (owner policy 2026-08-06,
-    feedback_tests_carry_no_time_limits_decompose_instead): no per-test time
-    budget, marker or in-body. A slower environment only makes this slower,
+    """The hook fire and the run-loop's pickup of it both happen asynchronously
+    off separate tasks. Unbounded per the owner's testing policy
+    (docs/deep-dives/contributing/testing.md, ## Time): no test carries a time
+    budget, marker or in-body -- a slower environment only makes this slower,
     never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
-    contract this waits against."""
+    contract.
+    """
     while not predicate():
         await asyncio.sleep(delay)
 

--- a/tests/test_2608_run_loop_pickup.py
+++ b/tests/test_2608_run_loop_pickup.py
@@ -65,12 +65,13 @@ def _make_llm_stub_fn(result: LLMToolCallResult):  # type: ignore[no-untyped-def
     return _stub
 
 
-async def _wait_for(predicate, *, attempts: int = 200, delay: float = 0.02) -> None:
-    """Poll ``predicate()`` until True or give up — the hook fire and the
-    run-loop's pickup of it both happen asynchronously off separate tasks."""
-    for _ in range(attempts):
-        if predicate():
-            return
+async def _wait_for(predicate, *, delay: float = 0.02) -> None:
+    """Poll ``predicate()`` -- UNBOUNDED (owner policy 2026-08-06,
+    feedback_tests_carry_no_time_limits_decompose_instead): no per-test time
+    budget, marker or in-body. A slower environment only makes this slower,
+    never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
+    contract this waits against."""
+    while not predicate():
         await asyncio.sleep(delay)
 
 

--- a/tests/test_2620_bound_webhook_fire_and_forget.py
+++ b/tests/test_2620_bound_webhook_fire_and_forget.py
@@ -40,10 +40,13 @@ def _make_session(tmp_path: Path) -> Session:
     return make_session(agent_name="bound_test_agent", state_log=state_log, reactivity=ReactivityConfig(hooks_config=hooks_config))
 
 
-async def _wait_for(predicate, *, attempts: int = 100, delay: float = 0.02) -> None:
-    for _ in range(attempts):
-        if predicate():
-            return
+async def _wait_for(predicate, *, delay: float = 0.02) -> None:
+    """Poll ``predicate()`` -- UNBOUNDED (owner policy 2026-08-06,
+    feedback_tests_carry_no_time_limits_decompose_instead): no per-test time
+    budget, marker or in-body. A slower environment only makes this slower,
+    never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
+    contract this waits against."""
+    while not predicate():
         await asyncio.sleep(delay)
 
 

--- a/tests/test_2620_bound_webhook_fire_and_forget.py
+++ b/tests/test_2620_bound_webhook_fire_and_forget.py
@@ -41,11 +41,12 @@ def _make_session(tmp_path: Path) -> Session:
 
 
 async def _wait_for(predicate, *, delay: float = 0.02) -> None:
-    """Poll ``predicate()`` -- UNBOUNDED (owner policy 2026-08-06,
-    feedback_tests_carry_no_time_limits_decompose_instead): no per-test time
-    budget, marker or in-body. A slower environment only makes this slower,
+    """Unbounded per the owner's testing policy
+    (docs/deep-dives/contributing/testing.md, ## Time): no test carries a time
+    budget, marker or in-body -- a slower environment only makes this slower,
     never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
-    contract this waits against."""
+    contract.
+    """
     while not predicate():
         await asyncio.sleep(delay)
 

--- a/tests/test_3377_run_loop_survives_turn_cancel.py
+++ b/tests/test_3377_run_loop_survives_turn_cancel.py
@@ -76,10 +76,13 @@ def _install_hanging_first_turn(
     return started, release, seen
 
 
-async def _wait_for(predicate, *, attempts: int = 250, delay: float = 0.02) -> None:
-    for _ in range(attempts):
-        if predicate():
-            return
+async def _wait_for(predicate, *, delay: float = 0.02) -> None:
+    """Poll ``predicate()`` -- UNBOUNDED (owner policy 2026-08-06,
+    feedback_tests_carry_no_time_limits_decompose_instead): no per-test time
+    budget, marker or in-body. A slower environment only makes this slower,
+    never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
+    contract this waits against."""
+    while not predicate():
         await asyncio.sleep(delay)
 
 

--- a/tests/test_3377_run_loop_survives_turn_cancel.py
+++ b/tests/test_3377_run_loop_survives_turn_cancel.py
@@ -77,11 +77,12 @@ def _install_hanging_first_turn(
 
 
 async def _wait_for(predicate, *, delay: float = 0.02) -> None:
-    """Poll ``predicate()`` -- UNBOUNDED (owner policy 2026-08-06,
-    feedback_tests_carry_no_time_limits_decompose_instead): no per-test time
-    budget, marker or in-body. A slower environment only makes this slower,
+    """Unbounded per the owner's testing policy
+    (docs/deep-dives/contributing/testing.md, ## Time): no test carries a time
+    budget, marker or in-body -- a slower environment only makes this slower,
     never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
-    contract this waits against."""
+    contract.
+    """
     while not predicate():
         await asyncio.sleep(delay)
 

--- a/tests/test_hook_event_ingress_adapter_0059_phase2.py
+++ b/tests/test_hook_event_ingress_adapter_0059_phase2.py
@@ -58,11 +58,12 @@ from tests._support.agent_session import make_session
 
 
 async def _wait_for(predicate, *, delay: float = 0.02) -> None:
-    """Poll ``predicate()`` -- UNBOUNDED (owner policy 2026-08-06,
-    feedback_tests_carry_no_time_limits_decompose_instead): no per-test time
-    budget, marker or in-body. A slower environment only makes this slower,
+    """Unbounded per the owner's testing policy
+    (docs/deep-dives/contributing/testing.md, ## Time): no test carries a time
+    budget, marker or in-body -- a slower environment only makes this slower,
     never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
-    contract this waits against."""
+    contract.
+    """
     while not predicate():
         await asyncio.sleep(delay)
 

--- a/tests/test_hook_event_ingress_adapter_0059_phase2.py
+++ b/tests/test_hook_event_ingress_adapter_0059_phase2.py
@@ -57,10 +57,13 @@ from reyn.runtime.session_params import ReactivityConfig
 from tests._support.agent_session import make_session
 
 
-async def _wait_for(predicate, *, attempts: int = 100, delay: float = 0.02) -> None:
-    for _ in range(attempts):
-        if predicate():
-            return
+async def _wait_for(predicate, *, delay: float = 0.02) -> None:
+    """Poll ``predicate()`` -- UNBOUNDED (owner policy 2026-08-06,
+    feedback_tests_carry_no_time_limits_decompose_instead): no per-test time
+    budget, marker or in-body. A slower environment only makes this slower,
+    never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
+    contract this waits against."""
+    while not predicate():
         await asyncio.sleep(delay)
 
 

--- a/tests/test_hook_event_schema_registry_sync_0059.py
+++ b/tests/test_hook_event_schema_registry_sync_0059.py
@@ -97,10 +97,13 @@ async def _noop(*args, **kwargs):
     return None
 
 
-async def _wait_for(predicate, *, attempts: int = 200, delay: float = 0.02) -> None:
-    for _ in range(attempts):
-        if predicate():
-            return
+async def _wait_for(predicate, *, delay: float = 0.02) -> None:
+    """Poll ``predicate()`` -- UNBOUNDED (owner policy 2026-08-06,
+    feedback_tests_carry_no_time_limits_decompose_instead): no per-test time
+    budget, marker or in-body. A slower environment only makes this slower,
+    never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
+    contract this waits against."""
+    while not predicate():
         await asyncio.sleep(delay)
 
 

--- a/tests/test_hook_event_schema_registry_sync_0059.py
+++ b/tests/test_hook_event_schema_registry_sync_0059.py
@@ -98,11 +98,12 @@ async def _noop(*args, **kwargs):
 
 
 async def _wait_for(predicate, *, delay: float = 0.02) -> None:
-    """Poll ``predicate()`` -- UNBOUNDED (owner policy 2026-08-06,
-    feedback_tests_carry_no_time_limits_decompose_instead): no per-test time
-    budget, marker or in-body. A slower environment only makes this slower,
+    """Unbounded per the owner's testing policy
+    (docs/deep-dives/contributing/testing.md, ## Time): no test carries a time
+    budget, marker or in-body -- a slower environment only makes this slower,
     never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
-    contract this waits against."""
+    contract.
+    """
     while not predicate():
         await asyncio.sleep(delay)
 


### PR DESCRIPTION
**[e2e-coder]** — First slice of the #3748 unbounded-wait migration, per lead-coder's explicit split: mechanical batch separate from the judgment-requiring rest, so the two aren't reviewed as one undifferentiated diff.

## Scope: 10 files sharing one byte-identical `_wait_for` helper

```python
async def _wait_for(predicate, *, attempts: int = N, delay: float = 0.02) -> None:
    for _ in range(attempts):
        if predicate():
            return
        await asyncio.sleep(delay)
```

Discriminator (not a count — per lead-coder, counts drift by definition across sessions): each of these has a genuine predicate **inside** the loop, and the function returns `None` unconditionally (even past `attempts`) — no caller anywhere checks the return value (`grep -c "assert await _wait_for\|= await _wait_for"` → 0 across all 10 files), so removing the bound changes nothing about control flow at any call site.

Converted to:

```python
async def _wait_for(predicate, *, delay: float = 0.02) -> None:
    while not predicate():
        await asyncio.sleep(delay)
```

Per the owner's now-merged testing policy (`docs/deep-dives/contributing/testing.md` § Time): no test carries a time budget, marker or in-body; a slower environment only makes this slower, never fail it; CI's `--timeout=120` is the blast-radius kill-switch, not a contract.

## Fixup commit (`e9c2d61f`) — addressed all 3 change-request items

1. **Broken doc reference fixed** — the original docstring pointed at `feedback_tests_carry_no_time_limits_decompose_instead`, a memory slug that never resolves in the repo, not a real path. Now points at `docs/deep-dives/contributing/testing.md` § Time. The same broken reference had landed one commit earlier in #3752 (already merged) — fixed there too, in a small standalone follow-up: #3754.
2. **Producer "why async" rationale restored** alongside the new policy note, not replaced by it (fs events on a separate OS thread, MCP receive-loop task, `fire_and_forget` background task, etc., per file).
3. **A real bug found via self-report, not by lead-coder's review**: `test_2608_h4_fs_watcher.py:205` called `_wait_for(..., attempts=500)` — a `TypeError` against the new signature. My original "66 passed, 1 skipped" report never actually exercised this: the whole file was silently SKIPPED locally, because the `fs-watch` extra wasn't installed in my venv — a skip is indistinguishable from a pass in an aggregate count. Installed the extra, reran naming all 10 files explicitly with `-v`: **80 collected, 80 passed, 0 skipped** this time — genuinely verified, not just attempted. Also swept the whole tree for the same override shape (`git grep` for `attempts=`/`n=` against every `_wait_for`/`_until`/`_poll` call site) — one more site found, in `test_3327_answer_bypasses_sentqueue.py`, **not part of this PR** (different class: a "prove nothing happened" negative wait, `assert resolved is False`, that cannot go unbounded the same way — flagged for the judgment-requiring follow-up PR).

## Verification

- [x] All 10 files, named explicitly with `-v` (not a package-wide run that could hide a skip) — **80 collected, 80 passed, 0 skipped**
- [x] Falsify, once per FORM (not per site, since the 10 are byte-identical) — forced the predicate permanently false in one representative file → hung, `timeout 10` → exit 124 → reverted, `git diff --stat` on that file matches the batch conversion exactly
- [x] `ruff check src tests` — clean
- [x] `scripts/test_tier_audit.py --strict` on all 10 files — 80/80 OK, 0 Tier-4 violations
- [x] `scripts/mypy_ratchet.py` — OK, 211 findings all baselined (no new)
- [x] full-repo `pytest` (pre-fixup commit) — 10104 passed, 49 skipped, 0 failures
- [x] full-repo `pytest` (post-fixup commit, `e9c2d61f`) — 10118 passed, 48 skipped, 0 failures

No production code changed. Judgment-requiring conversions (blind-pump sites with a recoverable predicate, bool-returning helpers whose callers assert on the return, real-timer sites needing #3746-style treatment, and the "negative wait" class found above) follow in a separate PR once this one lands, per the split.

part of #3748

