### PR TITLE
docs(#3752): fix a broken doc reference in an already-merged docstring

### DIFF
--- a/tests/test_activity_row_3693.py
+++ b/tests/test_activity_row_3693.py
@@ -100,15 +100,14 @@ async def _settle(pilot, times: int = 4) -> None:
 
 async def _until(pred) -> None:
     """Wait for ``pred()`` to become true — UNBOUNDED, no per-test time
-    budget (owner policy 2026-08-06,
-    ``feedback_tests_carry_no_time_limits_decompose_instead``: a test carries
-    no time limit of its own, marker or in-body; a slower environment must
-    only make this slower, never fail it — an ``attempts=N`` cap is a
-    disguised linear sleep, since past N it bets pass/fail on elapsed time
-    the same way a bare ``sleep(N)`` would). If this hangs, CI's
-    ``--timeout=120`` is the blast-radius kill-switch, not a contract this
-    test is written against — a hang there means "decompose this test or fix
-    the hang," never "the ceiling should have been bigger."
+    budget (owner's testing policy, docs/deep-dives/contributing/testing.md
+    § Time: a test carries no time limit of its own, marker or in-body; a
+    slower environment must only make this slower, never fail it — an
+    ``attempts=N`` cap is a disguised linear sleep, since past N it bets
+    pass/fail on elapsed time the same way a bare ``sleep(N)`` would). If
+    this hangs, CI's ``--timeout=120`` is the blast-radius kill-switch, not
+    a contract this test is written against — a hang there means "decompose
+    this test or fix the hang," never "the ceiling should have been bigger."
 
     Used here (see ``test_the_clock_advances_without_any_delta_arriving``)
     to poll for the OBSERVABLE effect of the row's own real ``set_interval``


### PR DESCRIPTION
**[e2e-coder]** — Follow-up from lead-coder's review of #3753: the same broken doc reference (a memory slug, `feedback_tests_carry_no_time_limits_decompose_instead`, treated as if it were a repo path) landed in #3752 (already merged) one commit earlier than #3753. Fixed to point at the real merged doc: `docs/deep-dives/contributing/testing.md` § Time.

No behavior change — docstring only.

## Test plan

- [x] `ruff check` — clean
- [x] `scripts/test_tier_audit.py --strict` — 11/11 OK
- [x] `scripts/mypy_ratchet.py` — OK, no new findings
- [x] `pytest tests/test_activity_row_3693.py` — 11/11 passed
- [x] (skipped — 実行可能バイトが 0 の docstring 単独差分。tier-audit 11/11・対象ファイル 11/11・ruff・mypy-ratchet で覆われている。lead-coder 承認) full-repo `pytest`

part of #3748
