### PR TITLE
test(#3748): unbound judgment-batch predicate-waits (3 files)

### DIFF
--- a/tests/test_1800_c_staging.py
+++ b/tests/test_1800_c_staging.py
@@ -399,9 +399,10 @@ async def test_c_staging_durable_during_drain_wait(tmp_path) -> None:
     # below. Poll the STRONGER condition the test actually asserts — the on-disk snapshot
     # holding the entry — which implies the WAL is already durable too (the wait-for-condition
     # discipline #1751 adopted when fsync moved off-loop).
-    for _ in range(400):
-        if AgentSnapshot.load(session.agent_name, session._snapshot_path).next_turn_context:
-            break
+    # #3748: unbounded (owner policy) -- the asserts below check exact COUNT
+    # and CONTENT, a stronger claim than this loop's mere truthiness check,
+    # so they are not restating the loop condition and stay.
+    while not AgentSnapshot.load(session.agent_name, session._snapshot_path).next_turn_context:
         await asyncio.sleep(0.005)
 
     # While _drain_to_wake is still blocking (no trigger sent), verify

--- a/tests/test_2597_s2b_mcp_notifications_bridge.py
+++ b/tests/test_2597_s2b_mcp_notifications_bridge.py
@@ -163,17 +163,16 @@ async def test_tool_list_changed_notification_emits_event_and_invalidates_cache(
         # give the event loop a beat to run the receive loop's callback.
         import asyncio
 
-        for _ in range(50):
-            if adapter.mcp_tools_cache_snapshot is None:
-                break
+        # #3748: unbounded (owner policy) -- wait for on_tool_list_changed to
+        # invalidate the lazy MCP tools cache. No terminating assert: the loop
+        # condition IS that check, so an assert restating it can never fire; a
+        # hang here surfaces via the kill stack showing this exact `while`.
+        while adapter.mcp_tools_cache_snapshot is not None:
             await asyncio.sleep(0.02)
 
         matching = [e for e in events.all() if e.type == "mcp_tool_list_changed"]
         (only_event,) = matching  # exactly one — the single real notification sent
         assert only_event.data.get("server") == "srv"
-        assert adapter.mcp_tools_cache_snapshot is None, (
-            "on_tool_list_changed must invalidate the lazy MCP tools cache"
-        )
     finally:
         await service.aclose()
 

--- a/tests/test_2839_a2a_run_registry_truncate_falsify.py
+++ b/tests/test_2839_a2a_run_registry_truncate_falsify.py
@@ -112,13 +112,12 @@ async def test_pending_intervention_a2a_run_survives_restart_and_wal_truncation(
 
     iv = UserIntervention(kind="ask_user", prompt="What is your name?", run_id=run_id)
     dispatch_task = asyncio.ensure_future(session.handle_intervention(iv))
-    # Let dispatch proceed to the point of recording + awaiting the future.
-    for _ in range(3):
+    # #3748: unbounded (owner policy) -- wait for dispatch to reach the point
+    # of recording + awaiting the future (sanity: it must be genuinely
+    # dispatched before we can prove it survives truncation). No terminating
+    # assert: the loop condition IS that check.
+    while session.interventions.get(iv.id) is None:
         await asyncio.sleep(0)
-    assert session.interventions.get(iv.id) is not None, (
-        "sanity: the intervention must be genuinely dispatched (in the active "
-        "queue) before we can prove it survives truncation"
-    )
 
     # The A2A bus mirrors input-required onto the RunEntry (real object, same
     # method production wiring calls — issue #1981/#292 side-effect contract).
@@ -160,18 +159,18 @@ async def test_pending_intervention_a2a_run_survives_restart_and_wal_truncation(
     session2, state_log2 = _make_session(wal, snapshot_path)
     reconstructed = _reconstruct_snapshot(AGENT, snapshot_path, state_log2)
     session2.restore_state(reconstructed)
-    for _ in range(3):
-        await asyncio.sleep(0)  # let the restored intervention task settle
+    # #3748: unbounded (owner policy) -- wait for the restored intervention
+    # task to register the intervention: it must survive WAL truncation
+    # below its own source event (snapshot-backed via AgentSnapshot, not
+    # WAL-derived). No terminating assert: the loop condition IS that check.
+    while session2.interventions.get(iv.id) is None:
+        await asyncio.sleep(0)
 
     # RunRegistry is a standalone atomic-JSON snapshot (#2839 Phase 1 firm) —
     # a fresh instance reloads it independent of the WAL entirely.
     run_registry2 = RunRegistry(persist_path=run_registry_path)
 
     # ── Phase 3: resume — both halves survived, and compose correctly ──────
-    assert session2.interventions.get(iv.id) is not None, (
-        "the outstanding intervention must survive WAL truncation below its "
-        "own source event (snapshot-backed via AgentSnapshot, not WAL-derived)"
-    )
     restored_entry = run_registry2.get(run_id)
     assert restored_entry is not None
     assert restored_entry.status == RunStatus.INPUT_REQUIRED, (
@@ -200,7 +199,13 @@ async def test_pending_intervention_a2a_run_survives_restart_and_wal_truncation(
         "→ router-coherent round trip survives restart + WAL truncation"
     )
 
-    # Cleanup: let the restored dispatch task resolve.
+    # #3748: NOT converted -- confirmed by falsify-in-reverse (a genuine
+    # hang, not a slow pass) that dispatch_task does not resolve on its own
+    # here even after the intervention above was answered: cancellation is
+    # this cleanup's actual terminal action, not a fallback for a slow
+    # condition. No predicate can be honestly written for "settle, then
+    # cancel regardless" -- left as a bounded grace pump pending the
+    # decomposition pass (own PR, per lead-coder's split).
     for _ in range(5):
         await asyncio.sleep(0)
     if not dispatch_task.done():

--- a/tests/test_2839_a2a_run_registry_truncate_falsify.py
+++ b/tests/test_2839_a2a_run_registry_truncate_falsify.py
@@ -117,7 +117,7 @@ async def test_pending_intervention_a2a_run_survives_restart_and_wal_truncation(
     # dispatched before we can prove it survives truncation). No terminating
     # assert: the loop condition IS that check.
     while session.interventions.get(iv.id) is None:
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.01)
 
     # The A2A bus mirrors input-required onto the RunEntry (real object, same
     # method production wiring calls — issue #1981/#292 side-effect contract).
@@ -164,7 +164,7 @@ async def test_pending_intervention_a2a_run_survives_restart_and_wal_truncation(
     # below its own source event (snapshot-backed via AgentSnapshot, not
     # WAL-derived). No terminating assert: the loop condition IS that check.
     while session2.interventions.get(iv.id) is None:
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.01)
 
     # RunRegistry is a standalone atomic-JSON snapshot (#2839 Phase 1 firm) —
     # a fresh instance reloads it independent of the WAL entirely.
@@ -199,13 +199,12 @@ async def test_pending_intervention_a2a_run_survives_restart_and_wal_truncation(
         "→ router-coherent round trip survives restart + WAL truncation"
     )
 
-    # #3748: NOT converted -- confirmed by falsify-in-reverse (a genuine
+    # Out of #3748's scope: this loop's iteration count is not standing in
+    # for a pass/fail condition -- settle or force-cancel, either way the
+    # cleanup proceeds the same. Confirmed by falsify-in-reverse (a genuine
     # hang, not a slow pass) that dispatch_task does not resolve on its own
-    # here even after the intervention above was answered: cancellation is
-    # this cleanup's actual terminal action, not a fallback for a slow
-    # condition. No predicate can be honestly written for "settle, then
-    # cancel regardless" -- left as a bounded grace pump pending the
-    # decomposition pass (own PR, per lead-coder's split).
+    # after being answered, so cancellation is a real branch of this
+    # cleanup, not a timeout standing in for a predicate. Left as-is.
     for _ in range(5):
         await asyncio.sleep(0)
     if not dispatch_task.done():


### PR DESCRIPTION
**[e2e-coder]** — part of #3748 (judgment-requiring batch, per-file triage).

## Summary
- `test_2839_a2a_run_registry_truncate_falsify.py`: 2 of 3 waits converted to unbounded (Inertness rule from #3755 applied — no trailing assert). The 3rd (cleanup wait for `dispatch_task.done()`) is explicitly **left unconverted**: falsify-in-reverse showed a genuine hang, not a slow pass — `dispatch_task` does not resolve on its own after being answered, so cancellation is the cleanup's real terminal action. Left as the original bounded grace-pump, flagged for a separate decomposition pass.
- `test_1800_c_staging.py`: loop condition converted to unbounded; the two asserts immediately after check exact count/content (stronger claim than the loop's truthiness check), so they stay — not an Inertness case.
- `test_2597_s2b_mcp_notifications_bridge.py`: loop converted to unbounded; trailing assert restated the loop's exact break condition (Inertness) — removed, rationale already captured in the existing comment above the loop.

## Test plan
- [x] `pytest tests/test_2839_a2a_run_registry_truncate_falsify.py tests/test_1800_c_staging.py tests/test_2597_s2b_mcp_notifications_bridge.py -v` — all pass (test_2839 was hanging pre-fix on the 3rd site)
- [x] `ruff check` on all 3 files — clean
- [x] `python scripts/test_tier_audit.py --strict` on all 3 files — 0 errors, 0 warnings
- [x] (skipped — full-suite run not needed; single-file/no-shared-helper changes)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>