### PR TITLE
test(#3748): unbound shared _until helper in test_stream_repaint_coalesce_3570

### DIFF
--- a/tests/test_stream_repaint_coalesce_3570.py
+++ b/tests/test_stream_repaint_coalesce_3570.py
@@ -189,13 +189,12 @@ def _streamed_entry(app: TextualChatApp):
     return None
 
 
-async def _until(pred, *, attempts: int = 200, delay: float = 0.01) -> bool:
-    """Bounded poll — a hang exhausts the budget and returns False (RED)."""
-    for _ in range(attempts):
-        if pred():
-            return True
+async def _until(pred, *, delay: float = 0.01) -> None:
+    """Poll for ``pred`` (owner policy, #3748 -- unbounded). A hang surfaces
+    via CI's own kill (the kill stack shows this exact loop), not a
+    test-local budget racing it."""
+    while not pred():
         await asyncio.sleep(delay)
-    return False
 
 
 @pytest.mark.asyncio
@@ -248,11 +247,9 @@ async def test_repaints_stop_tracking_arrivals_without_dropping_text(
         async with app.run_test(size=(100, 30)) as pilot:
             await pilot.pause()
             await transport.submit_user_text("stream please")
-            assert await _until(lambda: _streamed_entry(app) is not None)
+            await _until(lambda: _streamed_entry(app) is not None)
             entry = _streamed_entry(app)
-            assert await _until(
-                lambda: _CHUNK * chunks in str(entry.item.text)
-            ), "the full streamed text never reached the entry"
+            await _until(lambda: _CHUNK * chunks in str(entry.item.text))
 
             # With the catch-up timer disabled and the budget clock frozen, the
             # ONLY possible repaint is the terminal completion frame's own
@@ -348,9 +345,7 @@ async def test_a_mixed_backlog_coalesces_per_chain_not_per_delta(
             # app's own progress through the backlog, whereas waiting for paint
             # would make the gate depend on a timer under whatever load the run
             # happens to have.
-            assert await _until(
-                lambda: app.deltas_ingested >= arrivals
-            ), "the mixed backlog never drained"
+            await _until(lambda: app.deltas_ingested >= arrivals)
             entries = {c: _entry_for(app, c) for c in chains}
             assert all(e is not None for e in entries.values())
 
@@ -377,14 +372,11 @@ async def test_a_mixed_backlog_coalesces_per_chain_not_per_delta(
                 session.router_host.events.emit(
                     "agent_delta", text=_CHUNK, chain_id=chain
                 )
-            assert await _until(
+            await _until(
                 lambda: all(
                     str(e.item.text).count(_CHUNK) == per_chain + 1
                     for e in entries.values()
                 )
-            ), (
-                "a coalesced reply lost text: the repaint budget may skip a "
-                f"render, never an append — {[str(e.item.text).count(_CHUNK) for e in entries.values()]}"
             )
     finally:
         await registry.shutdown()
@@ -432,12 +424,12 @@ async def test_a_pending_repaint_never_survives_the_session_switch_barrier(
             session.router_host.events.emit(
                 "agent_delta", text=kept, chain_id="kept-chain"
             )
-            assert await _until(
+            await _until(
                 lambda: (
                     _entry_for(app, "kept-chain") is not None
                     and kept in str(_entry_for(app, "kept-chain").item.text)
                 )
-            ), "control leg: a deferred repaint must reach the screen on its own"
+            )
 
             # Leg 2: the barrier is queued in the same synchronous block as the
             # deferred delta — nothing could have flushed it in between.
@@ -455,9 +447,7 @@ async def test_a_pending_repaint_never_survives_the_session_switch_barrier(
                     )
                 )
             )
-            assert await _until(
-                lambda: _entry_for(app, "kept-chain") is None
-            ), "the barrier never reset the conversation"
+            await _until(lambda: _entry_for(app, "kept-chain") is None)
 
             # Well past any armed catch-up window.
             for _ in range(20):
@@ -513,19 +503,15 @@ async def test_a_deferred_repaint_is_painted_within_the_budget_window(
         async with app.run_test(size=(100, 30)) as pilot:
             await pilot.pause()
             await transport.submit_user_text("stream please")
-            assert await _until(lambda: _streamed_entry(app) is not None)
+            await _until(lambda: _streamed_entry(app) is not None)
             entry = _streamed_entry(app)
 
             # Everything after the first delta was deferred by the (frozen)
-            # budget. Within one budget window the catch-up must have painted it.
-            painted = await _until(
-                lambda: str(entry.item.text).count(_CHUNK) > 1,
-                attempts=int(_STREAM_REPAINT_MIN_INTERVAL * 100) + 100,
-            )
-            assert painted, (
-                "text held back by the repaint budget was never painted — the "
-                "deferral is unbounded, so a fast stream shows nothing until it ends"
-            )
+            # budget. The catch-up timer's own real interval is the actual
+            # bound (dedicated-tested by the interval constant itself); this
+            # waits on the real event it produces, unbounded (#3748 owner
+            # policy) rather than re-implementing a second timeout around it.
+            await _until(lambda: str(entry.item.text).count(_CHUNK) > 1)
         released.set()
     finally:
         released.set()

--- a/tests/test_stream_repaint_coalesce_3570.py
+++ b/tests/test_stream_repaint_coalesce_3570.py
@@ -366,7 +366,12 @@ async def test_a_mixed_backlog_coalesces_per_chain_not_per_delta(
             )
 
             # ...and nothing was dropped: one more delta per chain, past the
-            # budget window, flushes each reply's whole accumulation.
+            # budget window, flushes each reply's whole accumulation. The
+            # repaint budget may skip a render, never an append — a hang
+            # below means the opposite happened (a coalesced reply lost
+            # text); the per-entry counts that used to print on failure no
+            # longer do (#3748: a hang surfaces via CI's kill, not a
+            # message).
             clock.advance(_STREAM_REPAINT_MIN_INTERVAL * 2)
             for chain in chains:
                 session.router_host.events.emit(
@@ -424,6 +429,9 @@ async def test_a_pending_repaint_never_survives_the_session_switch_barrier(
             session.router_host.events.emit(
                 "agent_delta", text=kept, chain_id="kept-chain"
             )
+            # control leg: a deferred repaint must reach the screen on its
+            # own (no barrier follows it here) — leg 2 below is the barrier
+            # case this is the baseline for.
             await _until(
                 lambda: (
                     _entry_for(app, "kept-chain") is not None


### PR DESCRIPTION
**[e2e-coder]** — part of #3748 (judgment-requiring batch, per-file triage). Fresh branch off main (not stacked on #3756/#3757).

## Summary
`test_stream_repaint_coalesce_3570.py`'s shared `_until(pred, attempts=200) -> bool` helper, used at 8 call sites, converted to an unbounded `while not pred(): await asyncio.sleep(delay)`. Each site's trailing `assert await _until(...), "..."` restated the loop condition (Inertness, per #3755) and was removed.

One site deserved extra care: `test_a_deferred_repaint_is_painted_within_the_budget_window`'s docstring frames the claim as "the deferral is BOUNDED", and the call used a custom `attempts=int(_STREAM_REPAINT_MIN_INTERVAL * 100) + 100` override. On inspection this override is generous slack for `-n auto` scheduling load, not the actual bound-enforcement — the real bound is the catch-up timer's own fixed interval (`_STREAM_REPAINT_MIN_INTERVAL`), already dedicated-tested elsewhere. The poll here only detects that the real timer already fired; converting it to unbounded doesn't weaken what the test proves.

Falsified the most novel shape in this file — a negative wait (waiting for a flow entry to become `None` after a session-switch barrier resets it) — by forcing the predicate to `lambda: False` and confirming a genuine timeout-kill hang (not a vacuous pass), then reverting.

## Test plan
- [x] `pytest tests/test_stream_repaint_coalesce_3570.py -v` — 4 passed (independently, on a fresh worktree off origin/main with its own venv)
- [x] Falsify: forced negative-wait predicate to `lambda: False` → confirmed genuine hang (timeout-kill, exit 124), reverted
- [x] `ruff check tests/test_stream_repaint_coalesce_3570.py` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_stream_repaint_coalesce_3570.py` — 0 errors, 0 warnings
- [x] (skipped — full-suite run not needed; single-file change, no shared cross-file helper touched)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---

**[lead-coder] change request（マージ前）**

- [x] 消した assert のうち、条件の言い換えでない 2 件の散文をコメントとして復元（`the repaint budget may skip a render, never an append` ／ `control leg: a deferred repaint must reach the screen on its own`）
- [x] 実件数を吐いていた f-string 診断が失われる箇所に、「失敗はハングとして出る・件数は出ない」旨を一行



⚪ **上の各項は lead-coder が `c7e0bf30` に対して実測で確認済み**（差分・ブランチ・該当ファイルを直接読んで一致を確認、確認内容は本 PR のコメントに記載）。★ **印を付けたのは lead-coder です** — 指摘したのが lead-coder で、確認したのも lead-coder のため。
