### PR TITLE
test(#3748): unbound _await_scheduled_source_build in test_fp0066_p3b

### DIFF
--- a/tests/test_fp0066_p3b_repo_knowledge_ingest.py
+++ b/tests/test_fp0066_p3b_repo_knowledge_ingest.py
@@ -154,15 +154,22 @@ async def _await_scheduled_source_build(
     all); ``search_await`` then hands off to the coordinator's own
     ``_bg_tasks`` await, which is the actual completion signal.
 
-    #3748: unbounded (owner policy) -- was a 2000-tick safety net against a
-    genuinely broken scheduler. No terminating assert: the loop condition
-    IS that check, so a hang here (CI's own kill-switch) is now the honest
-    failure record, in place of the no-op-then-red-for-the-real-reason
-    fallback the bound used to route through. ``sleep(0.01)`` not
-    ``sleep(0)``: unbounded + a pure scheduler yield hot-spins one core for
-    the life of a genuine hang, starving ``-n auto`` siblings for the whole
-    CI kill window; a real delay costs nothing once the predicate is
-    already true (normally within one tick)."""
+    #3748: unbounded (owner policy) -- in scope despite being labeled "a
+    safety net, not a timing budget", because a broken scheduler's failure
+    DOES land on pass/fail: the old bound fell through to search_await's
+    no-op branch, which let a caller's own ``assert state == "clean"`` go
+    red -- but that red MISIDENTIFIES the cause (the scheduler never ran,
+    not "the build never reached clean"). A hang's kill stack instead
+    shows this exact ``while await manifest.get(...) is None``, naming the
+    real cause directly -- strictly more precise than the red it replaces,
+    not merely equally safe. (Contrast #3756 site 3, correctly left out of
+    scope: there, timing out vs. not changes nothing -- pass/fail reaches
+    the same way either branch goes.)
+
+    ``sleep(0.01)`` not ``sleep(0)``: unbounded + a pure scheduler yield
+    hot-spins one core for the life of a genuine hang, starving ``-n auto``
+    siblings for the whole CI kill window; a real delay costs nothing once
+    the predicate is already true (normally within one tick)."""
     while await manifest.get(source_id) is None:
         await asyncio.sleep(0.01)
     await coordinator.search_await(source_id)

--- a/tests/test_fp0066_p3b_repo_knowledge_ingest.py
+++ b/tests/test_fp0066_p3b_repo_knowledge_ingest.py
@@ -147,21 +147,24 @@ async def _await_scheduled_source_build(
     and returns before the task has had a single event-loop tick to run —
     the manifest entry does not exist yet, so ``search_await`` (the public
     completion-await surface) would see "no entry" and take its no-op
-    branch, never actually awaiting anything. The bounded loop below gives
-    the scheduled task event-loop ticks (``asyncio.sleep(0)`` — a
-    cooperative yield, not a timed wait) until the manifest entry exists
+    branch, never actually awaiting anything. The loop below gives the
+    scheduled task event-loop ticks until the manifest entry exists
     (``_run_build``'s first line is ``await self._set_state(source_id,
     "building")``, so the entry appears as soon as the task gets to run at
     all); ``search_await`` then hands off to the coordinator's own
-    ``_bg_tasks`` await, which is the actual completion signal. The loop
-    bound (2000 ticks) is a safety net against a genuinely broken scheduler,
-    not a timing budget — if the entry never appears, ``search_await`` still
-    no-ops and the caller's own state assertion goes red for the real
-    reason (state never reached "clean"), rather than this helper hanging."""
-    for _ in range(2000):
-        if await manifest.get(source_id) is not None:
-            break
-        await asyncio.sleep(0)
+    ``_bg_tasks`` await, which is the actual completion signal.
+
+    #3748: unbounded (owner policy) -- was a 2000-tick safety net against a
+    genuinely broken scheduler. No terminating assert: the loop condition
+    IS that check, so a hang here (CI's own kill-switch) is now the honest
+    failure record, in place of the no-op-then-red-for-the-real-reason
+    fallback the bound used to route through. ``sleep(0.01)`` not
+    ``sleep(0)``: unbounded + a pure scheduler yield hot-spins one core for
+    the life of a genuine hang, starving ``-n auto`` siblings for the whole
+    CI kill window; a real delay costs nothing once the predicate is
+    already true (normally within one tick)."""
+    while await manifest.get(source_id) is None:
+        await asyncio.sleep(0.01)
     await coordinator.search_await(source_id)
 
 


### PR DESCRIPTION
**[e2e-coder]** — part of #3748 (judgment-requiring batch, per-file triage). Fresh branch off main.

## Summary
`_await_scheduled_source_build`'s 2000-tick bound was already documented in its own docstring as "a safety net against a genuinely broken scheduler, not a timing budget" — exactly the case the owner's testing policy targets. A real predicate exists (`await manifest.get(source_id) is not None`), so the bound was redundant with CI's own `--timeout=120` and, on a genuine break, routed the failure through a soft no-op fallback (`search_await` no-ops on a missing entry, letting a downstream assertion fail "for the real reason") rather than surfacing honestly as a hang. Converted to unbounded per policy.

`sleep(0.01)` not `sleep(0)`: the loop normally resolves within one tick, but per lead-coder's #3756 review finding, unbounded + a pure scheduler yield would hot-spin one core for the life of a genuine hang, starving `-n auto` siblings for the whole CI kill window. A real delay costs nothing once the predicate is already true.

## Test plan
- [x] `pytest tests/test_fp0066_p3b_repo_knowledge_ingest.py -v` — 6 passed (independently, fresh worktree off origin/main, own venv)
- [x] Falsify: forced the predicate to always-false → confirmed genuine timeout-kill hang (exit 124), reverted
- [x] `ruff check tests/test_fp0066_p3b_repo_knowledge_ingest.py` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_fp0066_p3b_repo_knowledge_ingest.py` — 0 errors, 0 warnings
- [x] (skipped — full-suite run not needed; single-file change, no shared cross-file helper touched)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>