### PR TITLE
test(#3748): unbound the teardown-wait loops in test_reyn_web_proc

### DIFF
--- a/tests/test_reyn_web_proc.py
+++ b/tests/test_reyn_web_proc.py
@@ -36,12 +36,11 @@ def test_context_manager_kills_process_on_exit(tmp_path):
     with m.managed_reyn_web([sys.executable, "-c", "import time; time.sleep(120)"]) as proc:
         assert proc.poll() is None, "process should be alive inside the context"
         pid = proc.pid
-    # give teardown a moment
-    for _ in range(50):
-        if not _alive(pid):
-            break
+    # #3748: unbounded (owner policy) -- wait for teardown to kill the
+    # process. No terminating assert: the loop condition IS that check, so
+    # a hang here surfaces via the kill stack showing this exact loop.
+    while _alive(pid):
         time.sleep(0.1)
-    assert not _alive(pid), "process must be dead after context exit"
 
 
 def test_group_kill_reaps_child_processes(tmp_path):
@@ -64,18 +63,19 @@ def test_group_kill_reaps_child_processes(tmp_path):
     )
     with m.managed_reyn_web([sys.executable, "-c", code]) as proc:
         parent_pid = proc.pid
-        # wait for the grandchild pid to be recorded
-        for _ in range(50):
-            if pidfile.exists() and pidfile.read_text().strip():
-                break
+        # #3748: unbounded (owner policy) -- wait for the grandchild pid to
+        # be recorded, needed before the context exits so teardown can
+        # reap it too.
+        while not (pidfile.exists() and pidfile.read_text().strip()):
             time.sleep(0.1)
     child_pid = int(pidfile.read_text().strip())
-    for _ in range(50):
-        if not _alive(parent_pid) and not _alive(child_pid):
-            break
+    # #3748: unbounded (owner policy) -- wait for teardown's group-kill to
+    # reap both the managed server AND the child it forked (own-session
+    # group, per the module docstring above). No terminating asserts: the
+    # loop condition already proves both, so a hang here surfaces via the
+    # kill stack showing this exact loop.
+    while _alive(parent_pid) or _alive(child_pid):
         time.sleep(0.1)
-    assert not _alive(parent_pid), "managed server must be dead"
-    assert not _alive(child_pid), "forked child must also be reaped (group kill)"
 
 
 def test_selftest_entrypoint_passes():

--- a/tests/test_reyn_web_proc.py
+++ b/tests/test_reyn_web_proc.py
@@ -69,12 +69,16 @@ def test_group_kill_reaps_child_processes(tmp_path):
         while not (pidfile.exists() and pidfile.read_text().strip()):
             time.sleep(0.1)
     child_pid = int(pidfile.read_text().strip())
-    # #3748: unbounded (owner policy) -- wait for teardown's group-kill to
-    # reap both the managed server AND the child it forked (own-session
-    # group, per the module docstring above). No terminating asserts: the
-    # loop condition already proves both, so a hang here surfaces via the
-    # kill stack showing this exact loop.
-    while _alive(parent_pid) or _alive(child_pid):
+    # #3748: unbounded (owner policy) -- two SEPARATE waits, not one
+    # compound OR: a compound loop's kill stack can't tell "the server
+    # didn't die" from "group kill didn't reap the forked child" -- and
+    # the latter, not the former, is this test's actual reason to exist
+    # (own-session group + killpg reaping the WHOLE group, not just the
+    # direct child). Splitting costs nothing: if both are already dead,
+    # neither loop spins.
+    while _alive(parent_pid):
+        time.sleep(0.1)
+    while _alive(child_pid):
         time.sleep(0.1)
 
 


### PR DESCRIPTION
**[e2e-coder]** — part of #3748 (judgment-requiring batch, per-file triage). Fresh branch off main.

## Summary
3 bounded (`for _ in range(50): ...; time.sleep(0.1)`) loops in `test_reyn_web_proc.py` (a synchronous, real-subprocess process-group teardown test), each existing to avoid a race against the assertion(s) that follow. In scope per the pass/fail-landing discriminator from lead-coder's #3759 review: checking too early would be a false-negative RED on a correctly-working teardown — a genuine flakiness risk, not a case (like #3756 site 3) where the outcome is identical regardless of how the bound resolves.

Converted all 3 sites to unbounded `while`; the trailing asserts they gated (`assert not _alive(pid)`, etc.) became Inertness-dead once the loop condition already proves them, and were removed — folding any "why" into a loop comment where it added something the existing docstrings didn't already say.

## Test plan
- [x] `pytest tests/test_reyn_web_proc.py -v` — 3 passed (independently, fresh worktree off origin/main, own venv)
- [x] Falsify: forced the first site's `_alive` predicate to always-true → confirmed genuine timeout-kill hang (exit 124), reverted
- [x] `ruff check tests/test_reyn_web_proc.py` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_reyn_web_proc.py` — 0 errors, 0 warnings
- [x] (skipped — full-suite run not needed; single-file change, no shared cross-file helper touched)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---

**[lead-coder] change request（マージ前）**

- [x] `while _alive(parent_pid) or _alive(child_pid)` を 2 本の無界待ちに分ける。合成すると「group kill が子を刈らなかった」と「サーバが死ななかった」がハング 1 症状に潰れ、このテストの存在理由（前者）が見えなくなる



⚪ **上の各項は lead-coder が `875eecf0` に対して実測で確認済み**（差分・ブランチ・該当ファイルを直接読んで一致を確認、確認内容は本 PR のコメントに記載）。★ **印を付けたのは lead-coder です** — 指摘したのが lead-coder で、確認したのも lead-coder のため。
