### PR TITLE
test(#3748): unbound background-readiness polls in test_index_coordinator_3247

### DIFF
--- a/tests/test_index_coordinator_3247_p2a.py
+++ b/tests/test_index_coordinator_3247_p2a.py
@@ -170,12 +170,11 @@ def test_ensure_built_background_schedules_a_task_and_completes(monkeypatch: pyt
         assert outcome.background is True
         assert outcome.triggered is True
         # Poll the PUBLIC readiness gate for the scheduled background task
-        # to complete (bounded — no private-state introspection).
-        for _ in range(200):
-            if await coord.is_ready("repo_doc"):
-                break
+        # to complete (no private-state introspection). #3748: unbounded
+        # (owner policy) -- no terminating assert: the loop condition IS
+        # that check.
+        while not await coord.is_ready("repo_doc"):
             await asyncio.sleep(0.01)
-        assert await coord.is_ready("repo_doc") is True
 
     _run(_scenario())
 

--- a/tests/test_index_coordinator_3247_p2b.py
+++ b/tests/test_index_coordinator_3247_p2b.py
@@ -281,13 +281,12 @@ def test_non_eager_schedules_background(tmp_path: Path, monkeypatch: pytest.Monk
         assert idx.is_ready() is False
         coordinator = loop._get_index_coordinator()
         # Poll the PUBLIC readiness gate for the scheduled background task
-        # to complete (bounded — no private-state introspection, mirrors
-        # test_index_coordinator_3247_p2a.py's equivalent poll).
-        for _ in range(200):
-            if idx.is_ready():
-                break
+        # to complete (no private-state introspection, mirrors
+        # test_index_coordinator_3247_p2a.py's equivalent poll). #3748:
+        # unbounded (owner policy) -- no terminating assert for idx itself:
+        # the loop condition IS that check.
+        while not idx.is_ready():
             await asyncio.sleep(0.01)
-        assert idx.is_ready() is True
         assert await coordinator.is_ready("actions") is True
 
     _run(_scenario())


### PR DESCRIPTION
**[e2e-coder]** — part of #3748 (judgment-requiring batch, per-file triage). Fresh branch off main.

## Summary
Two identical-shape sites (`test_index_coordinator_3247_p2a.py`, `test_index_coordinator_3247_p2b.py`), each polling a PUBLIC readiness gate for a scheduled background build task to complete. Both were docstring-labeled "bounded — no private-state introspection" (not "safety net"-framed), and both feed a real subsequent assertion, so both are squarely in scope per the pass/fail-landing discriminator. Converted to unbounded; the p2a site's trailing assert was Inertness-dead and removed; the p2b site's second assert (checking a DIFFERENT thing — the coordinator's readiness, not `idx`'s) was kept.

## Test plan
- [x] `pytest tests/test_index_coordinator_3247_p2a.py tests/test_index_coordinator_3247_p2b.py -v` — 25 passed (independently, fresh worktree off origin/main, own venv)
- [x] Falsify: not re-run — identical `while not await coord.is_ready(...)` / `while not idx.is_ready()` form already falsified 4x this batch (test_2839, test_fp0066, test_reyn_web_proc, test_intervention_restore)
- [x] `ruff check` on both files — clean
- [x] `python scripts/test_tier_audit.py --strict` on both files — 0 errors, 0 warnings
- [x] (skipped — full-suite run not needed; two-file change, no shared cross-file helper touched)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>