### PR TITLE
test(#3748): unbound the shared _settle_until helper in test_textual_chat_intervention_panel_3299

### DIFF
--- a/tests/test_textual_chat_intervention_panel_3299.py
+++ b/tests/test_textual_chat_intervention_panel_3299.py
@@ -271,17 +271,15 @@ def _pane_ids_in_order(panel: InterventionPanel) -> "list[str]":
 
 
 async def _settle_until(pilot, until) -> None:
-    """Pump until ``until()`` is true, or until the budget runs out.
+    """Pump until ``until()`` is true (#3748: unbounded, owner policy).
 
-    The budget is generous and is only SPENT when the condition is genuinely
-    slow, so a healthy run costs one pass. Modelled on
-    ``tests/test_textual_chat_copy_rewind_3362.py``'s ``_settle``, and on
-    #3651's rule: wait for a signal, never for a wall-clock guess.
-    """
-    for _ in range(150):
+    Modelled on ``tests/test_textual_chat_copy_rewind_3362.py``'s
+    ``_settle``, and on #3651's rule: wait for a signal, never for a
+    wall-clock guess. A hang here surfaces via CI's own kill-switch,
+    naming this exact loop -- callers' own assertions still fail for the
+    real reason if the wait ever resolves on a false signal."""
+    while not until():
         await pilot.pause()
-        if until():
-            return
         await asyncio.sleep(0.01)
 
 

--- a/tests/test_textual_chat_intervention_panel_3299.py
+++ b/tests/test_textual_chat_intervention_panel_3299.py
@@ -277,9 +277,16 @@ async def _settle_until(pilot, until) -> None:
     ``_settle``, and on #3651's rule: wait for a signal, never for a
     wall-clock guess. A hang here surfaces via CI's own kill-switch,
     naming this exact loop -- callers' own assertions still fail for the
-    real reason if the wait ever resolves on a false signal."""
-    while not until():
+    real reason if the wait ever resolves on a false signal.
+
+    ``pilot.pause()`` runs BEFORE every check, unconditionally -- it is
+    not just a delay, it is the pump that flushes pending UI messages, so
+    an already-true predicate must still get one pass before returning
+    (lead-coder review: checking first would silently skip that flush)."""
+    while True:
         await pilot.pause()
+        if until():
+            return
         await asyncio.sleep(0.01)
 
 


### PR DESCRIPTION
**[e2e-coder]** — part of #3748 (judgment-requiring batch, per-file triage). Fresh branch off main.

## Summary
`_settle_until`'s own docstring already argued the 150-iteration bound was patience, not a correctness bet ("the budget is generous and is only SPENT when the condition is genuinely slow, so a healthy run costs one pass"), and its single call site's own comment confirms the downstream assertion still fails for the real reason if the wait ever resolves on a false signal ("the predicate never weakens the assertion... just after waiting rather than before"). In scope per the pass/fail-landing discriminator from lead-coder's #3759/#3760 review.

Converted to unbounded; folded the "why" into the helper's docstring. No change needed at the call site (it carried no message to lose).

## Test plan
- [x] `pytest tests/test_textual_chat_intervention_panel_3299.py -v` — 25 passed (independently, fresh worktree off origin/main, own venv)
- [x] Falsify: forced the predicate to `lambda: False` → confirmed genuine timeout-kill hang (exit 124), reverted
- [x] `ruff check tests/test_textual_chat_intervention_panel_3299.py` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_textual_chat_intervention_panel_3299.py` — 0 errors, 0 warnings
- [x] (skipped — full-suite run not needed; single-file change, no shared cross-file helper touched)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---

**[lead-coder] change request（マージ前）**

- [x] `pilot.pause()` を判定の前に戻す（`while True: await pilot.pause(); if until(): return; await asyncio.sleep(0.01)`）。`pause()` は待ちの手段であると同時に保留メッセージを流す作用で、順序を変えると「述語は真だが UI 未反映」で抜ける。無界化の目的は保たれ代償ゼロ
- [x] アーク全体で、待ち以外の作用を持つ呼び出し（`pilot.pause()` / `_settle(...)` 等）がループ本体の先頭にあった site を他にも確認し、件数を報告（0 件なら「0 件」と明記）



⚪ **上の各項は lead-coder が `2b8e929f` に対して実測で確認済み**（差分・ブランチ・該当ファイルを直接読んで一致を確認、確認内容は本 PR のコメントに記載）。★ **印を付けたのは lead-coder です** — 指摘したのが lead-coder で、確認したのも lead-coder のため。
