### PR TITLE
test(#3748): unbound _poll in test_cui_permission_answer_resumes_2690

### DIFF
--- a/tests/test_cui_permission_answer_resumes_2690.py
+++ b/tests/test_cui_permission_answer_resumes_2690.py
@@ -31,9 +31,10 @@ is the LLM call (``reyn.runtime.router_loop.call_llm_tools``), replaced with a
 real async stub — the established idiom for driving ``session.run()`` end-to-end
 without a live model. No MagicMock / AsyncMock / patch.
 
-Both scenarios are bounded: a hang trips the poll budget and the assertion
-fails (RED); the fix resolves the future so the op completes well within the
-budget (GREEN).
+Both scenarios poll unboundedly for the resolving condition (#3748: owner
+policy) — the fix's real future-resolve makes each poll return promptly
+(GREEN); a real regression here hangs, surfacing via CI's own kill-switch
+naming the exact stuck poll rather than an approximated timeout (RED).
 """
 from __future__ import annotations
 
@@ -96,13 +97,13 @@ def _sequenced_llm_stub(results: list[LLMToolCallResult]):
     return _stub
 
 
-async def _poll(pred, *, attempts: int = 150, delay: float = 0.02) -> bool:
-    """Bounded poll — a hang exhausts the budget and returns False (RED)."""
-    for _ in range(attempts):
-        if pred():
-            return True
+async def _poll(pred, *, delay: float = 0.02) -> None:
+    """Poll for ``pred`` (#3748: unbounded, owner policy). A hang surfaces
+    via CI's own kill, naming this exact loop -- callers' own assertions
+    still fail for the real reason if the wait ever resolves on a false
+    signal."""
+    while not pred():
         await asyncio.sleep(delay)
-    return False
 
 
 def _make_session(project_root: Path, *, wal: Path, snap: Path) -> Session:
@@ -137,7 +138,7 @@ async def test_cui_write_approval_answer_resumes_blocked_turn(tmp_path, monkeypa
     pending file-write permission so the blocked router turn resumes — the write
     completes and ``permission_granted`` (kind=file.write) is emitted. RED before
     the fix (the inbox-routed answer never reaches the suspended future → the
-    write never lands → the bounded poll times out)."""
+    write never lands → the poll hangs)."""
     proj = tmp_path / "proj"
     proj.mkdir()
     out = proj / "out.txt"  # under project root but OUTSIDE the .reyn/ write zone
@@ -161,9 +162,7 @@ async def test_cui_write_approval_answer_resumes_blocked_turn(tmp_path, monkeypa
         await session.submit_user_text("write the file")
         # The router turn reaches the out-of-zone write gate and dispatches the
         # approval prompt — the turn is now suspended awaiting the answer.
-        assert await _poll(lambda: session.interventions.head() is not None), (
-            "the file-write approval prompt never appeared"
-        )
+        await _poll(lambda: session.interventions.head() is not None)
         head = session.interventions.head()
         assert head.kind == "permission.file.write"
         assert {c.hotkey for c in head.choices} == {"y", "j", "r", "N"}
@@ -173,17 +172,16 @@ async def test_cui_write_approval_answer_resumes_blocked_turn(tmp_path, monkeypa
         # submit_user_text → inbox → never dequeued (deadlock).
         await route_input_line(_transport_for(session), "y", None)
 
-        assert await _poll(lambda: out.exists()), (
-            "write never completed after answering y — the blocked turn did "
-            "not resume (#2690 hang)"
-        )
+        # #2690: on the buggy tree this hangs (the blocked turn never
+        # resumes) rather than the file failing to appear -- a hang here IS
+        # the regression, surfacing via the kill stack the same way it did
+        # before this test existed.
+        await _poll(lambda: out.exists())
         assert out.read_text() == "written ok"
         # The intervention future resolved: nothing pending, and the
         # permission_granted event the reporter found MISSING is now emitted.
         assert session.interventions.head() is None
-        assert await _poll(lambda: str(out) in _granted_paths(session)), (
-            "no permission_granted event was emitted for the write path"
-        )
+        await _poll(lambda: str(out) in _granted_paths(session))
     finally:
         await session.shutdown()
         try:
@@ -218,17 +216,12 @@ async def test_cui_read_approval_answer_resumes_identically(tmp_path, monkeypatc
     run_task = asyncio.create_task(session.run())
     try:
         await session.submit_user_text("read the outside file")
-        assert await _poll(lambda: session.interventions.head() is not None), (
-            "the file-read approval prompt never appeared"
-        )
+        await _poll(lambda: session.interventions.head() is not None)
         assert session.interventions.head().kind == "permission.file.read"
 
         await route_input_line(_transport_for(session), "y", None)
 
-        assert await _poll(lambda: str(outside) in _granted_paths(session)), (
-            "read never completed after answering y — the blocked turn did "
-            "not resume"
-        )
+        await _poll(lambda: str(outside) in _granted_paths(session))
         assert session.interventions.head() is None
     finally:
         await session.shutdown()

--- a/tests/test_cui_permission_answer_resumes_2690.py
+++ b/tests/test_cui_permission_answer_resumes_2690.py
@@ -97,12 +97,22 @@ def _sequenced_llm_stub(results: list[LLMToolCallResult]):
     return _stub
 
 
-async def _poll(pred, *, delay: float = 0.02) -> None:
+async def _poll(pred, *, task: "asyncio.Task | None" = None, delay: float = 0.02) -> None:
     """Poll for ``pred`` (#3748: unbounded, owner policy). A hang surfaces
     via CI's own kill, naming this exact loop -- callers' own assertions
     still fail for the real reason if the wait ever resolves on a false
-    signal."""
+    signal.
+
+    ``task``, when given, is the producer this predicate is waiting on
+    (``session.run()``'s task): if it dies before the predicate goes true,
+    that exception IS the real failure -- re-raising it beats an unbounded
+    loop hanging on a producer that will never satisfy the predicate again,
+    which would hide the exception behind a kill stack pointing only at
+    this loop (owner policy bans betting on elapsed time, not on ignoring
+    a dead producer)."""
     while not pred():
+        if task is not None and task.done():
+            task.result()
         await asyncio.sleep(delay)
 
 
@@ -162,7 +172,7 @@ async def test_cui_write_approval_answer_resumes_blocked_turn(tmp_path, monkeypa
         await session.submit_user_text("write the file")
         # The router turn reaches the out-of-zone write gate and dispatches the
         # approval prompt — the turn is now suspended awaiting the answer.
-        await _poll(lambda: session.interventions.head() is not None)
+        await _poll(lambda: session.interventions.head() is not None, task=run_task)
         head = session.interventions.head()
         assert head.kind == "permission.file.write"
         assert {c.hotkey for c in head.choices} == {"y", "j", "r", "N"}
@@ -176,12 +186,12 @@ async def test_cui_write_approval_answer_resumes_blocked_turn(tmp_path, monkeypa
         # resumes) rather than the file failing to appear -- a hang here IS
         # the regression, surfacing via the kill stack the same way it did
         # before this test existed.
-        await _poll(lambda: out.exists())
+        await _poll(lambda: out.exists(), task=run_task)
         assert out.read_text() == "written ok"
         # The intervention future resolved: nothing pending, and the
         # permission_granted event the reporter found MISSING is now emitted.
         assert session.interventions.head() is None
-        await _poll(lambda: str(out) in _granted_paths(session))
+        await _poll(lambda: str(out) in _granted_paths(session), task=run_task)
     finally:
         await session.shutdown()
         try:
@@ -216,12 +226,12 @@ async def test_cui_read_approval_answer_resumes_identically(tmp_path, monkeypatc
     run_task = asyncio.create_task(session.run())
     try:
         await session.submit_user_text("read the outside file")
-        await _poll(lambda: session.interventions.head() is not None)
+        await _poll(lambda: session.interventions.head() is not None, task=run_task)
         assert session.interventions.head().kind == "permission.file.read"
 
         await route_input_line(_transport_for(session), "y", None)
 
-        await _poll(lambda: str(outside) in _granted_paths(session))
+        await _poll(lambda: str(outside) in _granted_paths(session), task=run_task)
         assert session.interventions.head() is None
     finally:
         await session.shutdown()


### PR DESCRIPTION
**[e2e-coder]** — part of #3748 (judgment-requiring batch, per-file triage). Fresh branch off main.

## Summary
5 call sites of a shared `_poll(pred, attempts=150) -> bool` helper, all in scope: each gates a real downstream assertion, no fixed-tick budget substituting for a real condition. Converted to unbounded; 4 of 5 Inertness-dead wrapper asserts removed (pure predicate restatement); the 5th kept the `#2690` issue-history tag as a standalone comment — a domain fact per lead-coder's #3758 finding (on the buggy tree this specific wait hangs rather than the write file failing to appear, which IS the regression this test exists to catch).

Fixed 3 stale doc claims in the same PR (CLAUDE.md doc-drift-in-same-PR rule): the module docstring and one test docstring both asserted "the bounded poll times out" / "budget" framing that no longer describes the converted code.

## Test plan
- [x] `pytest tests/test_cui_permission_answer_resumes_2690.py -v` — 2 passed (independently, fresh worktree off origin/main, own venv)
- [x] Falsify: forced one site's predicate to `lambda: False` → confirmed genuine timeout-kill hang (exit 124), reverted
- [x] `ruff check tests/test_cui_permission_answer_resumes_2690.py` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_cui_permission_answer_resumes_2690.py` — 0 errors, 0 warnings
- [x] (skipped — full-suite run not needed; single-file change, no shared cross-file helper touched)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---

**[lead-coder] change request（マージ前）**

- [x] `_poll` に生産者の生存確認を入れる（`if task.done(): task.result()` — 時間の上限ではなく「待っている相手が死んでいないか」の確認）。`session.run()` が例外死すると現状は 120 秒ハングし、kill スタックが `_poll` を指して真の例外を隠す
- [x] #3748 で変換した待ちのうち、テストが handle を持つ背景タスクが生産者のものを列挙し、まとめて直す issue を 1 本立ててリンク（「次のアークで」は不可）



⚪ **上の各項は lead-coder が `87a9852f` に対して実測で確認済み**（差分・ブランチ・該当ファイルを直接読んで一致を確認、確認内容は本 PR のコメントに記載）。★ **印を付けたのは lead-coder です** — 指摘したのが lead-coder で、確認したのも lead-coder のため。
