### PR TITLE
test(#3748): unbound the fixed-tick restore wait in test_2259_pr3_recovery_semantics_falsify

### DIFF
--- a/tests/test_2259_pr3_recovery_semantics_falsify.py
+++ b/tests/test_2259_pr3_recovery_semantics_falsify.py
@@ -147,13 +147,18 @@ async def _restore_ivids(tmp_path: Path, wal: Path) -> list[str]:
     reg, state_log = _make_registry(tmp_path, wal)
     snapshots = await reg.restore_all()
     main = reg.get_session("alpha")
-    if main is not None:
+    snap = snapshots.get("alpha")
+    if main is not None and snap is not None:
         # #3748: unbounded (owner policy) -- restore_state schedules the
         # re-enqueue as background tasks; wait for them to register every id
         # the just-reconstructed durable snapshot expects (the SAME source
-        # restore_state itself reads), not a fixed tick count.
-        expected = set(snapshots["alpha"].outstanding_interventions)
-        while set(_active_iv_ids(main)) != expected:
+        # restore_state itself reads), not a fixed tick count. Weak wait
+        # (count only) -- a strong `!=` comparison here would make a
+        # restoration bug that produces the WRONG ids hang forever instead
+        # of surfacing as a caller-side set-mismatch assertion, defeating
+        # this helper's whole purpose (lead-coder review, #3762's pattern).
+        expected_count = len(snap.outstanding_interventions)
+        while len(_active_iv_ids(main)) < expected_count:
             await asyncio.sleep(0.01)
     ids = [] if main is None else _active_iv_ids(main)
     if main is not None:

--- a/tests/test_2259_pr3_recovery_semantics_falsify.py
+++ b/tests/test_2259_pr3_recovery_semantics_falsify.py
@@ -145,10 +145,16 @@ async def _restore_ivids(tmp_path: Path, wal: Path) -> list[str]:
     main session's active intervention ids. Flushes the save-back so the durable snapshot is
     consistent for any subsequent restart."""
     reg, state_log = _make_registry(tmp_path, wal)
-    await reg.restore_all()
-    for _ in range(3):  # let restore_state's re-enqueue tasks register the interventions
-        await asyncio.sleep(0)
+    snapshots = await reg.restore_all()
     main = reg.get_session("alpha")
+    if main is not None:
+        # #3748: unbounded (owner policy) -- restore_state schedules the
+        # re-enqueue as background tasks; wait for them to register every id
+        # the just-reconstructed durable snapshot expects (the SAME source
+        # restore_state itself reads), not a fixed tick count.
+        expected = set(snapshots["alpha"].outstanding_interventions)
+        while set(_active_iv_ids(main)) != expected:
+            await asyncio.sleep(0.01)
     ids = [] if main is None else _active_iv_ids(main)
     if main is not None:
         await main.journal.flush()  # drain restore_all's async snapshot save-back


### PR DESCRIPTION
**[e2e-coder]** — part of #3748 (judgment-requiring batch, per-file triage). Fresh branch off main. This is the last file in the current triage pass.

## Summary
`_restore_ivids`'s fixed 3-tick wait (before checking which interventions restored) converts to a real predicate: `restore_all`'s own return value already gives the reconstructed durable snapshot, whose `outstanding_interventions` is the EXACT source `Session.restore_state`'s background re-enqueue tasks read — poll for the session's active intervention ids to reach that same set, rather than hoping 3 ticks was enough. In scope per the pass/fail-landing discriminator (the caller's own comparison assertions read this result).

Note: this helper's re-enqueue tasks are internal to `Session.restore_state` and not exposed as a handle the test holds, so the producer-death check from #3764/#3765 doesn't apply here the same way — no task handle exists to check.

## Test plan
- [x] `pytest tests/test_2259_pr3_recovery_semantics_falsify.py -v` — 4 passed (independently, fresh worktree off origin/main, own venv)
- [x] Falsify: forced the predicate to always-blocking (`while True`) → confirmed genuine timeout-kill hang (exit 124), reverted
- [x] `ruff check tests/test_2259_pr3_recovery_semantics_falsify.py` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_2259_pr3_recovery_semantics_falsify.py` — 0 errors, 0 warnings
- [x] (skipped — full-suite run not needed; single-file change, no shared cross-file helper touched)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---

**[lead-coder] change request（マージ前）**

- [x] 待ちを `!= expected` から `len(...) < len(expected)` へ。`_falsify` テストなので、誤った id が入った場合も `!=` は永久に一致せず、「復元が壊れた」が不透明なハングになる（呼び出し側の集合比較が一度も走らない）
- [x] `snapshots["alpha"]` を `.get("alpha")` に。`main is not None` はセッション登録簿の話で、`restore_all` の戻り値に鍵がある保証ではない



⚪ **上の各項は lead-coder が `97ead65e` に対して実測で確認済み**（差分・ブランチ・該当ファイルを直接読んで一致を確認、確認内容は本 PR のコメントに記載）。★ **印を付けたのは lead-coder です** — 指摘したのが lead-coder で、確認したのも lead-coder のため。
