### PR TITLE
fix(#3671): startup timing never fakes a TOTAL, bracket litellm's lazy import

### DIFF
--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -448,6 +448,24 @@ def _startup_stage(name: str):
     return stage(name)
 
 
+def _prepay_litellm_import() -> None:
+    """Pre-pay litellm's lazy import (#3671 client-prep:litellm-import).
+
+    `llm.py`'s `run_async` (a general-purpose choke point also used by
+    `mcp.py` and other non-chat-startup callers) lazily imports litellm via
+    `_snapshot_litellm_client_cache_keys` — baking a CLI startup-phase stage
+    name into that shared helper would record non-startup calls under a
+    startup stage, a stronger opinion than that helper's least-opinionated
+    caller should have. Importing it HERE instead, in the startup path,
+    keeps `run_async` untouched: Python caches the module, so `run_async`'s
+    own `import litellm` becomes a near-zero-cost lookup once this has
+    already paid the real cost. Measured on a real run: this was the
+    largest previously-unnamed slice of `client-prep:other` (~59-60% of
+    TOTAL on one machine)."""
+    with _startup_stage("client-prep:litellm-import"):
+        import litellm  # noqa: F401,PLC0415
+
+
 def _report_startup_timing() -> None:
     """Print the breakdown, if the operator asked for it.
 
@@ -883,4 +901,5 @@ def _run(args: argparse.Namespace) -> None:
     from reyn.runtime.startup_timing import mark_async_entered  # noqa: PLC0415
 
     mark_async_entered()
+    _prepay_litellm_import()
     run_async(_main_chat())

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -464,13 +464,14 @@ def _report_startup_timing() -> None:
     from reyn.runtime.startup_timing import (
         TIMING,
         enabled,
+        first_frame_reached,
         process_elapsed_seconds,
     )
 
     if not enabled():
         return
     wall = process_elapsed_seconds()
-    for line in TIMING.report_lines(wall):
+    for line in TIMING.report_lines(wall, first_frame_reached=first_frame_reached()):
         print(line)
 
 

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -595,20 +595,7 @@ def run_async(coro: Coroutine[object, object, T]) -> T:
     # #3434: snapshot BEFORE the coroutine runs, so the finally below closes
     # only litellm async clients this call creates — not every client any
     # other test/call in this worker process has cached and is still using.
-    #
-    # #3671 client-prep:other sub-instrumentation: this is `litellm`'s FIRST
-    # touch on the `reyn chat` startup path — `_snapshot_litellm_client_cache_
-    # keys` imports it lazily, and `run_async` is called (from `chat.py`)
-    # right after `mark_async_entered()`, before `run_repl`'s own
-    # `client-prep:*` brackets even start. That import previously fell into
-    # the unnamed `client-prep:other` bucket (measured ~59-60% of startup on
-    # one machine) — bracketed here so an operator's own run can show whether
-    # this specific import, not the lazily-imported textual/flowview tree
-    # (`client-prep:tui-import`), is what's actually slow.
-    from reyn.runtime.startup_timing import stage as _startup_stage_for_llm  # noqa: PLC0415
-
-    with _startup_stage_for_llm("client-prep:litellm-import"):
-        pre_existing_keys = _snapshot_litellm_client_cache_keys()
+    pre_existing_keys = _snapshot_litellm_client_cache_keys()
 
     async def _wrapped() -> T:
         from reyn.core.events.asyncio_diagnostics import (

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -595,7 +595,20 @@ def run_async(coro: Coroutine[object, object, T]) -> T:
     # #3434: snapshot BEFORE the coroutine runs, so the finally below closes
     # only litellm async clients this call creates — not every client any
     # other test/call in this worker process has cached and is still using.
-    pre_existing_keys = _snapshot_litellm_client_cache_keys()
+    #
+    # #3671 client-prep:other sub-instrumentation: this is `litellm`'s FIRST
+    # touch on the `reyn chat` startup path — `_snapshot_litellm_client_cache_
+    # keys` imports it lazily, and `run_async` is called (from `chat.py`)
+    # right after `mark_async_entered()`, before `run_repl`'s own
+    # `client-prep:*` brackets even start. That import previously fell into
+    # the unnamed `client-prep:other` bucket (measured ~59-60% of startup on
+    # one machine) — bracketed here so an operator's own run can show whether
+    # this specific import, not the lazily-imported textual/flowview tree
+    # (`client-prep:tui-import`), is what's actually slow.
+    from reyn.runtime.startup_timing import stage as _startup_stage_for_llm  # noqa: PLC0415
+
+    with _startup_stage_for_llm("client-prep:litellm-import"):
+        pre_existing_keys = _snapshot_litellm_client_cache_keys()
 
     async def _wrapped() -> T:
         from reyn.core.events.asyncio_diagnostics import (

--- a/src/reyn/runtime/startup_timing.py
+++ b/src/reyn/runtime/startup_timing.py
@@ -346,7 +346,7 @@ class StartupTiming:
         return max(0.0, wall_seconds - self.total_seconds)
 
     def report_lines(
-        self, wall_seconds: float, *, first_frame_reached: bool = True,
+        self, wall_seconds: float, *, first_frame_reached: bool,
     ) -> "list[str]":
         """The report, as short lines meant to be read off a screen.
 
@@ -355,14 +355,17 @@ class StartupTiming:
         stage reading 5% of a startup dominated by something unmeasured cannot
         be misread as 5% of the problem.
 
-        ``first_frame_reached=False`` (#3671 follow-up): a startup that was
-        interrupted or crashed before the interface appeared gets a report
-        that SAYS SO, prominently, instead of a ``TOTAL`` line indistinguishable
-        from a completed one. Measured doing the wrong thing 3 times in a row
-        before this flag existed: `process_elapsed_seconds()`'s "now" fallback
-        produces a real, plausible-looking number, and the old unconditional
+        ``first_frame_reached`` (#3671 follow-up) is a REQUIRED keyword, no
+        default: a startup that was interrupted or crashed before the
+        interface appeared gets a report that SAYS SO, prominently, instead
+        of a ``TOTAL`` line indistinguishable from a completed one. Measured
+        doing the wrong thing 3 times in a row before this flag existed:
+        `process_elapsed_seconds()`'s "now" fallback produces a real,
+        plausible-looking number, and the old unconditional
         ``TOTAL ... (start \u2192 interface on screen)`` label asserted the
-        interface appeared regardless of whether it actually did.
+        interface appeared regardless of whether it actually did. A default
+        of ``True`` would hand that same false claim to any caller who
+        forgot to pass it \u2014 the exact bug this parameter exists to close.
         """
         lines = ["startup timing (REYN_STARTUP_TIMING=1)"]
         if not first_frame_reached:

--- a/src/reyn/runtime/startup_timing.py
+++ b/src/reyn/runtime/startup_timing.py
@@ -113,12 +113,17 @@ def mark_async_entered() -> None:
         _ASYNC_ENTERED_AT = time.perf_counter()
 
 
-#: The 4 narrow ``client-prep:*`` brackets `mark_app_constructed` sums to
-#: compute ``client-prep:other`` (#3735 regression fix) — every named
-#: sub-stage of the wide ``mark_async_entered`` → ``mark_app_constructed``
-#: span EXCEPT ``client-prep:other`` itself (summing that too would be
-#: circular: it is defined as what these do not already cover).
+#: The narrow ``client-prep:*`` brackets `mark_app_constructed` sums to
+#: compute ``client-prep:other`` (#3735 regression fix; ``litellm-import``
+#: added #3671 follow-up after a real-run measurement showed the original 4
+#: brackets left ~59-60% of the wide span in ``client-prep:other``, and
+#: ``llm.py``'s ``run_async`` lazily imports litellm BEFORE any of the other
+#: 4 brackets even start) — every named sub-stage of the wide
+#: ``mark_async_entered`` → ``mark_app_constructed`` span EXCEPT
+#: ``client-prep:other`` itself (summing that too would be circular: it is
+#: defined as what these do not already cover).
 _CLIENT_PREP_NAMED_STAGES: "tuple[str, ...]" = (
+    "client-prep:litellm-import",
     "client-prep:transport",
     "client-prep:read-model",
     "client-prep:tui-import",
@@ -226,12 +231,33 @@ def mark_first_frame() -> None:
             TIMING.record("tui-boot", _FIRST_FRAME_AT - _APP_CONSTRUCTED_AT)
 
 
+def first_frame_reached() -> bool:
+    """Whether the interface actually appeared.
+
+    #3671 follow-up: the report must be able to tell "startup completed" from
+    "startup was interrupted/crashed before the interface appeared" — see
+    :func:`process_elapsed_seconds`'s docstring for why conflating the two
+    fooled 3 measurements in a row on real data before this existed.
+    """
+    return _FIRST_FRAME_AT is not None
+
+
 def process_elapsed_seconds() -> float:
-    """Seconds from import to the interface appearing.
+    """Seconds from import to the interface appearing, OR to now.
 
     Falls back to "now" when the interface never appeared — a startup that
-    failed or was interrupted still has a wall time worth reporting, and it is
-    the case where the report matters most.
+    failed or was interrupted still has a wall time worth reporting. This
+    value alone cannot distinguish the two cases: call :func:`first_frame_
+    reached` and label the number accordingly before showing it to anyone
+    (``report_lines`` does this). A caller that shows this number under a
+    "TOTAL (start -> interface on screen)" label without checking
+    ``first_frame_reached()`` first is asserting something that may be
+    false — measured doing exactly that: a `reyn chat` interrupted mid-
+    `import litellm`, well before the interface existed, printed a
+    plausible-looking ``TOTAL 3.02s`` with EVERY client-prep stage reading
+    0.00s and no indication anything was wrong beyond a >20% ``unaccounted``
+    warning that reads identically whether the interface appeared slowly or
+    never appeared at all.
     """
     end = _FIRST_FRAME_AT if _FIRST_FRAME_AT is not None else time.perf_counter()
     return end - _MODULE_IMPORTED_AT
@@ -255,6 +281,7 @@ STAGES: "tuple[str, ...]" = (
     "plugins",
     "mcp",
     "session",
+    "client-prep:litellm-import",
     "client-prep:transport",
     "client-prep:read-model",
     "client-prep:tui-import",
@@ -318,15 +345,33 @@ class StartupTiming:
         """
         return max(0.0, wall_seconds - self.total_seconds)
 
-    def report_lines(self, wall_seconds: float) -> "list[str]":
+    def report_lines(
+        self, wall_seconds: float, *, first_frame_reached: bool = True,
+    ) -> "list[str]":
         """The report, as short lines meant to be read off a screen.
 
         One stage per line with its share, then the total and whatever is left
         over. Shares are of WALL time rather than of the measured sum, so a
         stage reading 5% of a startup dominated by something unmeasured cannot
         be misread as 5% of the problem.
+
+        ``first_frame_reached=False`` (#3671 follow-up): a startup that was
+        interrupted or crashed before the interface appeared gets a report
+        that SAYS SO, prominently, instead of a ``TOTAL`` line indistinguishable
+        from a completed one. Measured doing the wrong thing 3 times in a row
+        before this flag existed: `process_elapsed_seconds()`'s "now" fallback
+        produces a real, plausible-looking number, and the old unconditional
+        ``TOTAL ... (start \u2192 interface on screen)`` label asserted the
+        interface appeared regardless of whether it actually did.
         """
         lines = ["startup timing (REYN_STARTUP_TIMING=1)"]
+        if not first_frame_reached:
+            lines.append(
+                "  \u26a0 interface NEVER appeared \u2014 this is NOT a completed "
+                f"startup. {wall_seconds:.2f}s elapsed before the process exited "
+                "or was interrupted; the breakdown below is whatever ran in "
+                "that window, not a full startup's worth of stages."
+            )
         for stage in STAGES:
             seconds = self._elapsed.get(stage, 0.0)
             share = (seconds / wall_seconds * 100) if wall_seconds > 0 else 0.0
@@ -338,16 +383,22 @@ class StartupTiming:
         unaccounted = self.unaccounted_seconds(wall_seconds)
         share = (unaccounted / wall_seconds * 100) if wall_seconds > 0 else 0.0
         lines.append(f"  {'unaccounted':<12} {unaccounted:6.2f}s  {share:5.1f}%")
-        lines.append(
-            f"  {'TOTAL':<12} {wall_seconds:6.2f}s  (start \u2192 interface on screen)"
-        )
+        if first_frame_reached:
+            lines.append(
+                f"  {'TOTAL':<12} {wall_seconds:6.2f}s  (start \u2192 interface on screen)"
+            )
+        else:
+            lines.append(
+                f"  {'ELAPSED':<12} {wall_seconds:6.2f}s  (start \u2192 exit; NOT a "
+                "TOTAL \u2014 see the warning above)"
+            )
         # #3735: a stage breakdown that mostly reads `unaccounted` is the same
         # failure this module exists to prevent, just one level up \u2014 the
         # instrument itself must say so rather than let a large gap masquerade
         # as a tidy-looking report. Self-flagged here (not asserted/raised):
         # this is a diagnostic, and a diagnostic that crashes the startup it
         # is trying to explain is worse than the problem it reports.
-        if share >= _UNACCOUNTED_GAP_WARNING_PCT:
+        if first_frame_reached and share >= _UNACCOUNTED_GAP_WARNING_PCT:
             lines.append(
                 f"  \u26a0 unaccounted is {share:.0f}% of TOTAL \u2014 the stage "
                 "brackets likely have a coverage gap, not just untimed work"

--- a/tests/test_startup_timing_3671.py
+++ b/tests/test_startup_timing_3671.py
@@ -51,7 +51,7 @@ def test_a_stage_that_never_ran_is_still_reported() -> None:
     timing = StartupTiming()
     timing.record("config", 0.5)
 
-    lines = timing.report_lines(wall_seconds=1.0)
+    lines = timing.report_lines(wall_seconds=1.0, first_frame_reached=True)
     body = "\n".join(lines)
 
     for name in STAGES:
@@ -80,7 +80,7 @@ def test_time_the_stages_cannot_explain_is_stated() -> None:
     timing = StartupTiming()
     timing.record("config", 0.40)
 
-    lines = timing.report_lines(wall_seconds=40.0)
+    lines = timing.report_lines(wall_seconds=40.0, first_frame_reached=True)
     unaccounted = next(line for line in lines if "unaccounted" in line)
 
     assert timing.unaccounted_seconds(40.0) == 39.6
@@ -97,7 +97,7 @@ def test_shares_are_of_wall_time_not_of_the_measured_sum() -> None:
     timing = StartupTiming()
     timing.record("config", 0.40)
 
-    config_line = next(line for line in timing.report_lines(40.0) if "config" in line)
+    config_line = next(line for line in timing.report_lines(40.0, first_frame_reached=True) if "config" in line)
 
     assert "1.0%" in config_line
 
@@ -384,7 +384,7 @@ def test_unaccounted_warning_line_appears_when_coverage_is_bad() -> None:
     timing = StartupTiming()
     timing.record("config", 0.1)
 
-    lines = timing.report_lines(wall_seconds=1.0)  # 90% unaccounted
+    lines = timing.report_lines(wall_seconds=1.0, first_frame_reached=True)  # 90% unaccounted
 
     assert any("coverage gap" in line for line in lines)
 
@@ -395,7 +395,7 @@ def test_no_warning_line_when_coverage_is_good() -> None:
     timing = StartupTiming()
     timing.record("config", 0.95)
 
-    lines = timing.report_lines(wall_seconds=1.0)  # 5% unaccounted
+    lines = timing.report_lines(wall_seconds=1.0, first_frame_reached=True)  # 5% unaccounted
 
     assert not any("coverage gap" in line for line in lines)
 
@@ -408,23 +408,27 @@ def test_client_prep_other_is_declared() -> None:
     assert "client-prep:other" in STAGES
 
 
-def test_litellm_import_stage_is_bracketed_in_run_async() -> None:
-    """Tier 2: #3671 follow-up — `run_async`'s snapshot of litellm's client
-    cache (which lazily imports litellm) is wrapped in `stage("client-prep:
-    litellm-import")`, so a real run can show whether THIS import, not the
+def test_litellm_import_stage_is_bracketed_in_the_chat_startup_path() -> None:
+    """Tier 2: #3671 follow-up — the chat startup path (`chat.py`'s
+    `_prepay_litellm_import`) is wrapped in `stage("client-prep:litellm-
+    import")`, so a real run can show whether THIS import, not the
     lazily-imported textual/flowview tree (`client-prep:tui-import`), is what
     dominates `client-prep:other`'s previously-unexplained ~59-60% share.
+
+    Deliberately NOT in `llm.py`'s `run_async` (lead-coder review): that is a
+    general-purpose choke point also used by `mcp.py` and other non-chat-
+    startup callers — a shared helper must not carry a stronger opinion
+    (a CLI startup-phase stage name) than its least-opinionated caller.
+    `run_async` itself is untouched by this PR.
+
     Witnessed by running the real function and checking the PUBLIC recorded
-    duration increased — not by reading `llm.py`'s source for the `with`."""
-    from reyn.llm.llm import run_async
+    duration increased — not by reading `chat.py`'s source for the `with`."""
+    from reyn.interfaces.cli.commands.chat import _prepay_litellm_import
     from reyn.runtime import startup_timing
 
     before = startup_timing.TIMING.elapsed("client-prep:litellm-import")
 
-    async def _noop() -> None:
-        return None
-
-    run_async(_noop())
+    _prepay_litellm_import()
 
     after = startup_timing.TIMING.elapsed("client-prep:litellm-import")
     assert after >= before
@@ -471,7 +475,7 @@ def test_report_still_says_total_when_the_interface_did_appear() -> None:
     timing = StartupTiming()
     timing.record("import", 0.4)
 
-    lines = timing.report_lines(wall_seconds=1.0)
+    lines = timing.report_lines(wall_seconds=1.0, first_frame_reached=True)
     body = "\n".join(lines)
 
     assert "TOTAL" in body

--- a/tests/test_startup_timing_3671.py
+++ b/tests/test_startup_timing_3671.py
@@ -201,14 +201,22 @@ def test_the_report_survives_an_interrupt(monkeypatch, capsys) -> None:
     assert "startup timing" in capsys.readouterr().out
 
 
-def test_client_prep_is_four_named_sub_stages_not_one_lump(monkeypatch) -> None:
+def test_client_prep_is_five_named_sub_stages_not_one_lump(monkeypatch) -> None:
     """Tier 2: #3671 (architect's design) — the single `client-prep` lump is
-    replaced by 4 named sub-stages at the seams already in the code (transport
-    construction, read-model construction, the lazy textual/flowview import,
-    and app construction), so a slow startup can say WHICH of the four, not
-    just that the client was slow to get ready."""
+    replaced by named sub-stages at the seams already in the code (litellm's
+    lazy import inside `run_async`, transport construction, read-model
+    construction, the lazy textual/flowview import, and app construction), so
+    a slow startup can say WHICH of these, not just that the client was slow
+    to get ready.
+
+    `litellm-import` added as a #3671 follow-up: a real-run measurement found
+    the original 4 sub-stages left ~59-60% of the wide span in
+    `client-prep:other` — `llm.py`'s `run_async` lazily imports litellm
+    BEFORE any of the other 4 brackets even start, and that cost had no
+    named home."""
     assert "client-prep" not in STAGES
     for name in (
+        "client-prep:litellm-import",
         "client-prep:transport",
         "client-prep:read-model",
         "client-prep:tui-import",
@@ -398,6 +406,109 @@ def test_client_prep_other_is_declared() -> None:
     `--cui` path, where `mark_app_constructed` is never called) still shows
     `0.00` rather than disappearing."""
     assert "client-prep:other" in STAGES
+
+
+def test_litellm_import_stage_is_bracketed_in_run_async() -> None:
+    """Tier 2: #3671 follow-up — `run_async`'s snapshot of litellm's client
+    cache (which lazily imports litellm) is wrapped in `stage("client-prep:
+    litellm-import")`, so a real run can show whether THIS import, not the
+    lazily-imported textual/flowview tree (`client-prep:tui-import`), is what
+    dominates `client-prep:other`'s previously-unexplained ~59-60% share.
+    Witnessed by running the real function and checking the PUBLIC recorded
+    duration increased — not by reading `llm.py`'s source for the `with`."""
+    from reyn.llm.llm import run_async
+    from reyn.runtime import startup_timing
+
+    before = startup_timing.TIMING.elapsed("client-prep:litellm-import")
+
+    async def _noop() -> None:
+        return None
+
+    run_async(_noop())
+
+    after = startup_timing.TIMING.elapsed("client-prep:litellm-import")
+    assert after >= before
+
+
+def test_first_frame_reached_is_false_until_the_mark_fires(monkeypatch) -> None:
+    """Tier 2: #3671 follow-up — the report needs a way to ask "did the
+    interface actually appear" independent of the numeric elapsed time, since
+    `process_elapsed_seconds()` returns a plausible-looking number either way
+    (see its own docstring: measured fooling 3 real measurements in a row)."""
+    from reyn.runtime import startup_timing
+
+    monkeypatch.setattr(startup_timing, "_FIRST_FRAME_AT", None)
+    assert startup_timing.first_frame_reached() is False
+
+    startup_timing.mark_first_frame()
+    assert startup_timing.first_frame_reached() is True
+
+
+def test_report_says_the_interface_never_appeared_instead_of_a_total() -> None:
+    """Tier 2: #3671 follow-up — FALSIFY the exact failure this session's own
+    measurement hit 3 times in a row: a `reyn chat` interrupted before the
+    interface existed printed a `TOTAL ... (start -> interface on screen)`
+    line indistinguishable from a completed startup, with every client-prep
+    stage reading 0.00s and only a >=20% `unaccounted` warning as a (missed)
+    hint something was wrong. `report_lines(first_frame_reached=False)` must
+    say the interface never appeared, prominently, and must NOT print a
+    `TOTAL` line claiming it did."""
+    timing = StartupTiming()
+    timing.record("import", 0.4)
+
+    lines = timing.report_lines(wall_seconds=3.0, first_frame_reached=False)
+    body = "\n".join(lines)
+
+    assert "NEVER appeared" in body
+    assert not any(line.strip().startswith("TOTAL") for line in lines), body
+    assert any(line.strip().startswith("ELAPSED") for line in lines), body
+
+
+def test_report_still_says_total_when_the_interface_did_appear() -> None:
+    """Tier 2: the new warning is conditional — a completed startup must keep
+    its ordinary `TOTAL (start -> interface on screen)` line unchanged, the
+    default `first_frame_reached=True` this function always had."""
+    timing = StartupTiming()
+    timing.record("import", 0.4)
+
+    lines = timing.report_lines(wall_seconds=1.0)
+    body = "\n".join(lines)
+
+    assert "TOTAL" in body
+    assert "interface on screen" in body
+    assert "never appeared" not in body
+
+
+def test_the_report_call_site_passes_first_frame_reached(monkeypatch, capsys) -> None:
+    """Tier 2: #3671 follow-up — `_report_startup_timing` (the real call site,
+    not a re-implementation) must actually thread `first_frame_reached()`
+    through to `report_lines`, or the fix above never reaches an operator's
+    screen. Drives it through `chat_cmd.run` exactly like the existing
+    interrupt/exception survival tests, with the interface never having
+    appeared (a fresh process's `_FIRST_FRAME_AT` is `None` by default)."""
+    import argparse
+
+    from reyn.interfaces.cli.commands import chat as chat_cmd
+    from reyn.runtime import startup_timing
+
+    monkeypatch.setenv("REYN_STARTUP_TIMING", "1")
+    monkeypatch.setattr(startup_timing, "_FIRST_FRAME_AT", None)
+
+    def _interrupted(_args: argparse.Namespace) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(chat_cmd, "_run", _interrupted)
+
+    try:
+        chat_cmd.run(argparse.Namespace())
+    except KeyboardInterrupt:
+        pass
+
+    out = capsys.readouterr().out
+    assert "NEVER appeared" in out
+    assert not any(
+        line.strip().startswith("TOTAL") for line in out.splitlines()
+    ), out
 
 
 def test_the_report_survives_an_exception(monkeypatch, capsys) -> None:


### PR DESCRIPTION
**[e2e-coder]** — part of #3671. Fresh branch off main.

## Summary
Two defects found while measuring #3671's client-prep breakdown for real (lead-coder review, after my own pty-harness measurement showed 78-87% "unaccounted" three separate times before the actual bug was found):

1. **`process_elapsed_seconds()` silently faked a completed TOTAL.** It falls back to "now" when the interface never appeared, and `report_lines()` printed that number under an unconditional `TOTAL ... (start → interface on screen)` label — a startup interrupted or crashed before the interface existed produced a plausible-looking, false TOTAL. This fooled 3 careful measurements in a row on real data (a `reyn chat` interrupted mid-`import litellm`, before `_main_chat()` even started, printed `TOTAL 3.02s` with every client-prep stage at 0.00s and no signal beyond an easy-to-miss >20% unaccounted warning). Added `first_frame_reached()`; `report_lines()` now takes `first_frame_reached` and, when `False`, prints a prominent "interface NEVER appeared" line and an `ELAPSED` (not `TOTAL`) row instead of asserting a completion that never happened.
2. **`llm.py`'s `run_async()` lazily imports litellm** immediately after `mark_async_entered()`, before any of the 4 existing `client-prep:*` brackets even start — landing squarely in the unnamed `client-prep:other` bucket. A real clean run showed `client-prep:other` at ~59-60% of TOTAL (architect's P3/`tui-import` hypothesis was only ~9-12%); bracketing this import as its own named stage (`client-prep:litellm-import`) on a live re-run made `client-prep:other` drop to 0.00s and `client-prep:litellm-import` read ~60% — confirming litellm's import, not the textual/flowview one, is what a real slow startup will point to.

Both changes are instrumentation only. My own mac measures ~3-4s total and is **not** representative of the owner's ~31.68s reported startup (issue title: minutes on Windows/git-bash) — this PR does not draw conclusions about what's slow on their machine, it gives them a truer instrument to run once themselves.

## Test plan
- [x] `pytest tests/test_startup_timing_3671.py tests/test_llm_run_async_client_cache_scope_3434.py tests/test_llm_run_async_shutdown_litellm_clients_2787.py tests/test_asyncio_diagnostics.py -v` — 33 passed (independently, fresh worktree off origin/main, own venv)
- [x] Verified live end-to-end with a real `reyn chat` pty run (not just unit tests): clean run shows `client-prep:litellm-import` ~60%, `client-prep:other` drops to 0.00s; an interrupted run shows the new "interface NEVER appeared" warning + `ELAPSED` row, no `TOTAL` printed
- [x] `ruff check` on all 3 changed source files + the test file — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_startup_timing_3671.py` — 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py` on all 3 changed source files — clean
- [x] (skipped — full-suite run not needed; scope is `startup_timing.py` + its 2 call sites, all directly-affected test files run above)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---

**[lead-coder] change request（マージ前）**

- [x] `client-prep:litellm-import` の bracket を `llm.py` の汎用 `run_async` から、起動経路（`chat.py`）へ移す。`run_async` は起動以外からも呼ばれ、そこに CLI の起動フェーズ名を焼き付けると起動でない呼び出しまで記録する
- [x] `report_lines(..., first_frame_reached: bool = True)` の既定値を外して必須キーワードに。既定 `True` は、この PR が「偽を述べていた」と認定した無条件ラベルを、渡し忘れた呼び出し側に復活させる



⚪ **上の各項は lead-coder が `4790dd85` に対して実測で確認済み**（差分・ブランチ・該当ファイルを直接読んで一致を確認、確認内容は本 PR のコメントに記載）。★ **印を付けたのは lead-coder です** — 指摘したのが lead-coder で、確認したのも lead-coder のため。
