### PR TITLE
fix(#3681): _find_project_root single-owner cache, not optional-kwarg threading

### DIFF
--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -319,6 +319,10 @@ def _merge(base: dict, override: dict, *, tier_label: str | None = None) -> dict
     return result
 
 
+# maxsize=None (unbounded): keys are distinct resolved cwd-like starting
+# paths a single process is asked about, naturally a handful at most
+# (production callers all resolve from `Path.cwd()`) — not a value with
+# unbounded cardinality over a process's lifetime.
 @lru_cache(maxsize=None)
 def _find_project_root_uncached(resolved_start: Path) -> Path | None:
     """The actual filesystem walk — never call directly, see `_find_project_root`.

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import socket
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Literal
 
@@ -318,9 +319,15 @@ def _merge(base: dict, override: dict, *, tier_label: str | None = None) -> dict
     return result
 
 
-def _find_project_root(start: Path) -> Path | None:
-    """Walk up from start until finding reyn.yaml, or return None."""
-    current = start.resolve()
+@lru_cache(maxsize=None)
+def _find_project_root_uncached(resolved_start: Path) -> Path | None:
+    """The actual filesystem walk — never call directly, see `_find_project_root`.
+
+    ``resolved_start`` must already be resolved (the caller does this once,
+    so this cached function's key is the real, canonical path — an
+    unresolved and a resolved path pointing at the same directory must hit
+    the same cache entry, not two)."""
+    current = resolved_start
     while True:
         if (current / "reyn.yaml").exists():
             return current
@@ -328,6 +335,31 @@ def _find_project_root(start: Path) -> Path | None:
         if parent == current:
             return None
         current = parent
+
+
+def _find_project_root(start: Path) -> Path | None:
+    """Walk up from start until finding reyn.yaml, or return None.
+
+    #3681 (#3671 P4 item A-3): single-owner cache keyed on the resolved
+    ``start`` path, so a process that calls this N times for the same
+    starting directory (`reyn chat` alone did it 3x: interactive-logging
+    setup, `load_config()`, `build_environment_backend()`) walks the
+    filesystem once, not N times, WITHOUT any caller needing to thread a
+    pre-computed value through — the fix an optional `project_root=` kwarg
+    (rejected, #3678 review) could not give: a caller that forgets to pass
+    it silently reverts to walking again, undetectably.
+
+    A real `reyn` process runs this walk against a project directory whose
+    ancestor `reyn.yaml` presence does not change mid-run, so this is safe
+    in production. It is NOT safe across a whole pytest session sharing one
+    interpreter, where many tests write a fresh `reyn.yaml` under a
+    `tmp_path` after this may have already cached a miss for that exact
+    path — `tests/conftest.py`'s `_clear_find_project_root_cache` autouse
+    fixture clears the cache before every test so each test's own writes
+    are observed. Call :func:`_find_project_root_uncached`'s own
+    ``cache_clear()`` directly if a test needs to invalidate mid-test
+    (querying the same path, writing `reyn.yaml`, then querying again)."""
+    return _find_project_root_uncached(start.resolve())
 
 
 def _warn_legacy_dot_reyn_config(path: Path) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -480,6 +480,31 @@ def _isolate_rich_style_ansi_memo():
     for style in DEFAULT_STYLES.values():
         style._ansi = None
 
+
+@pytest.fixture(autouse=True)
+def _clear_find_project_root_cache() -> None:
+    """Reset `_find_project_root`'s process-global cache after every test (#3681).
+
+    `_find_project_root` (`reyn.config.loader`) is now `lru_cache`d, keyed on
+    the resolved starting path, so a single `reyn` process walks the
+    filesystem once per distinct starting directory instead of once per
+    caller (#3671 P4 item A-3: `reyn chat` alone called it 3x for the same
+    cwd — interactive-logging setup, `load_config()`,
+    `build_environment_backend()`). Safe in production (a process's own
+    `reyn.yaml` ancestry does not change mid-run); NOT safe across a whole
+    pytest session sharing one interpreter, where a `tmp_path`-based test
+    could in principle collide with a stale cached miss from an earlier
+    test's walk over the same absolute path (unlikely in practice — pytest's
+    `tmp_path` is unique per test — but not something to leave to chance
+    given how cheaply it is closed). Same shape as
+    `_isolate_rich_style_ansi_memo` above, for the same reason: a process-
+    global cache leaking across tests is bugs waiting for the wrong pair of
+    tests to run adjacently, not a bug already reproduced.
+    """
+    yield
+    from reyn.config.loader import _find_project_root_uncached
+    _find_project_root_uncached.cache_clear()
+
 # ── Marker registration ────────────────────────────────────────────────────────
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,7 @@ import os
 import sys
 import warnings
 from pathlib import Path
+from typing import Iterator
 
 import pytest
 
@@ -482,27 +483,47 @@ def _isolate_rich_style_ansi_memo():
 
 
 @pytest.fixture(autouse=True)
-def _clear_find_project_root_cache() -> None:
-    """Reset `_find_project_root`'s process-global cache after every test (#3681).
+def _clear_find_project_root_cache() -> Iterator[None]:
+    """Reset `_find_project_root`'s process-global cache before AND after
+    every test (#3681).
 
     `_find_project_root` (`reyn.config.loader`) is now `lru_cache`d, keyed on
     the resolved starting path, so a single `reyn` process walks the
     filesystem once per distinct starting directory instead of once per
     caller (#3671 P4 item A-3: `reyn chat` alone called it 3x for the same
     cwd — interactive-logging setup, `load_config()`,
-    `build_environment_backend()`). Safe in production (a process's own
-    `reyn.yaml` ancestry does not change mid-run); NOT safe across a whole
-    pytest session sharing one interpreter, where a `tmp_path`-based test
-    could in principle collide with a stale cached miss from an earlier
-    test's walk over the same absolute path (unlikely in practice — pytest's
-    `tmp_path` is unique per test — but not something to leave to chance
-    given how cheaply it is closed). Same shape as
+    `build_environment_backend()`).
+
+    Cleared on BOTH sides, not just after: a fixture that only clears in its
+    teardown leaves every worker's FIRST test running against whatever the
+    cache picked up during collection-time / session-scoped fixture setup —
+    the one point an after-only clear cannot reach, since nothing ran this
+    fixture's teardown yet.
+
+    Safe in production TODAY: a `reyn` process's own `reyn.yaml` ancestry
+    does not change mid-run — verified by checking every command that WRITES
+    `reyn.yaml` — only `reyn init` (`interfaces/cli/commands/init.py`) —
+    prints and exits immediately after, never querying `_find_project_root`
+    again in the same process (verified by grep: no other command writes
+    `reyn.yaml`, and `init.py` itself never calls `_find_project_root` or
+    `load_config`).
+    This is an observation about the CURRENT command set, not an invariant:
+    a future command that writes `reyn.yaml` and then CONTINUES running
+    (unlike `init`'s write-then-exit) would need its own explicit
+    `_find_project_root_uncached.cache_clear()` call at that write site.
+
+    NOT safe across a whole pytest session sharing one interpreter, where a
+    `tmp_path`-based test could in principle collide with a stale cached
+    miss from an earlier test's walk over the same absolute path (unlikely
+    in practice — pytest's `tmp_path` is unique per test — but not something
+    to leave to chance given how cheaply it is closed). Same shape as
     `_isolate_rich_style_ansi_memo` above, for the same reason: a process-
     global cache leaking across tests is bugs waiting for the wrong pair of
     tests to run adjacently, not a bug already reproduced.
     """
-    yield
     from reyn.config.loader import _find_project_root_uncached
+    _find_project_root_uncached.cache_clear()
+    yield
     _find_project_root_uncached.cache_clear()
 
 # ── Marker registration ────────────────────────────────────────────────────────

--- a/tests/test_config_loader_pure_helpers.py
+++ b/tests/test_config_loader_pure_helpers.py
@@ -130,3 +130,59 @@ def test_find_project_root_no_reyn_yaml_returns_none(tmp_path: Path) -> None:
     sub = tmp_path / "nested"
     sub.mkdir()
     assert _find_project_root(sub) is None
+
+
+def test_find_project_root_second_call_does_not_walk_again(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: #3681 — a second call for the SAME resolved start path does not
+    re-walk the filesystem (single-owner cache, #3671 P4 item A-3: `reyn
+    chat` alone called this 3x per invocation for the same cwd before this).
+    Witnessed through the PUBLIC filesystem side effect (`Path.exists` call
+    count), not by reading the private `lru_cache` state directly."""
+    (tmp_path / "reyn.yaml").write_text("", encoding="utf-8")
+    sub = tmp_path / "a" / "b"
+    sub.mkdir(parents=True)
+
+    calls = {"n": 0}
+    real_exists = Path.exists
+
+    def _counting_exists(self: Path) -> bool:
+        calls["n"] += 1
+        return real_exists(self)
+
+    monkeypatch.setattr(Path, "exists", _counting_exists)
+
+    first = _find_project_root(sub)
+    after_first = calls["n"]
+    assert after_first > 0, "the first call must have touched the filesystem"
+
+    second = _find_project_root(sub)
+
+    assert second == first == tmp_path
+    assert calls["n"] == after_first, (
+        "the second call for the same start path re-walked the filesystem "
+        f"({calls['n'] - after_first} more Path.exists() calls) instead of "
+        "using the cached result"
+    )
+
+
+def test_find_project_root_cache_clear_makes_a_later_reyn_yaml_visible(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #3681 FALSIFY — the cache is not permanently stuck on a stale
+    miss. A test (or any caller) that creates `reyn.yaml` AFTER an earlier
+    query for the same path can still observe it, by explicitly clearing
+    `_find_project_root_uncached`'s cache — the same seam the `tests/
+    conftest.py` autouse fixture calls after every test."""
+    from reyn.config.loader import _find_project_root_uncached
+
+    sub = tmp_path / "nested"
+    sub.mkdir()
+
+    assert _find_project_root(sub) is None
+
+    (tmp_path / "reyn.yaml").write_text("", encoding="utf-8")
+    _find_project_root_uncached.cache_clear()
+
+    assert _find_project_root(sub) == tmp_path


### PR DESCRIPTION
**[e2e-coder]** — part of #3671 P4 item A-3. Fresh branch off main.

## Summary
Confirmed 3 independent redundant filesystem walks per `reyn chat` invocation: `chat.py`'s own `project_root` computation, `InvocationContext.from_args()` → `load_config()` → `_find_project_root()`, and `build_environment_backend()` → `env_backend.py`'s own call — all against the same cwd.

Per #3681's explicit rejection of an optional `project_root=` kwarg (a caller that forgets to pass it silently reverts to walking again, undetectably — exactly the pattern owner's clean-end-state ruling forbids, and the same discriminator as #3768's `first_frame_reached` default issue): `_find_project_root` itself now owns a single-owner cache, keyed on the resolved start path, via a private `lru_cache`d `_find_project_root_uncached`. No caller coordination is required or possible to skip — a second call for the same start path cannot walk the filesystem again by construction. Witnessed through the public `Path.exists()` call-count side effect, not private cache state.

**Test-safety** (the issue's own explicit concern before starting): a process-wide cache is unsafe across a whole pytest session sharing one interpreter unless cleared between tests. Added an autouse `_clear_find_project_root_cache` fixture in `tests/conftest.py` (same shape as the existing `_isolate_rich_style_ansi_memo` fixture for the same class of problem) — clears **before and after** every test (an after-only clear misses each worker's first test, which runs against whatever collection-time/session-scoped setup left behind). Independently audited (via a dedicated research agent) all 9 test files the issue flagged as similar-pattern candidates for the harder within-a-single-test staleness risk (query path X, write `reyn.yaml`, query X again expecting a different result) — none found in any of them.

**Production-safety claim, with its falsifier stated**: verified (by reading `init.py` in full and grepping every other `reyn.yaml`-mentioning command file) that `reyn init` is the only command that writes `reyn.yaml`, and it prints and exits immediately after — never re-querying `_find_project_root` in the same process. Documented explicitly in the fixture's docstring that this is an observation about the current command set, not an invariant: a future command that writes `reyn.yaml` and then continues running would need its own `cache_clear()` call at that write site.

## Test plan
- [x] `pytest tests/test_config_loader_pure_helpers.py` (the direct test file) + all 9 flagged files — 129 passed, 1 skipped, 0 failures (independently, fresh worktree off origin/main, own venv)
- [x] Broader sweep (`-k "config or chat or env_backend or project_root or mcp"`) — 1066 passed, 2 skipped, 0 failures
- [x] Independent audit (research agent) of all 9 flagged files for within-test staleness — none found; verdict: SAFE
- [x] Live-verified with a real `reyn chat` pty run (not just unit tests) — clean start, clean exit
- [x] `ruff check` on all changed files — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_config_loader_pure_helpers.py` — 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py` on the changed source file — clean
- [x] Full local suite (`pytest` from repo root, against the final fixup commit `665a17022`) — **10107 passed, 48 skipped, 0 failures** (704.30s)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>