### PR TITLE
fix(#3593): CapabilityVisibility.registry is genuinely Optional, not a non-Optional lie

### DIFF
--- a/src/reyn/runtime/capability_visibility.py
+++ b/src/reyn/runtime/capability_visibility.py
@@ -200,7 +200,7 @@ class CapabilityVisibility:
     def __init__(
         self,
         *,
-        registry: "_EnvelopeSource",
+        registry: "_EnvelopeSource | None",
         router_host: "_RouterHost",
         session_id_provider: "Callable[[], str | None]",
         agent_name: "str",
@@ -333,15 +333,17 @@ class CapabilityVisibility:
         # its declared type is the wider `object | None`, so cast to the concrete type the
         # downstream compose_resolved requires (registry.py:3509 guarantees it).
         #
-        # #3593 ② review: `registry`'s type is `_EnvelopeSource` (non-Optional) now that
-        # every production caller of build_scoped_chat_session passes a real one — but a
-        # type annotation is a static-checking signal, not a runtime guarantee (Python does
-        # not enforce it), and this `is None` check stays regardless. If it were removed,
-        # the failure direction on a genuinely unreadable base is not a crash — it composes
-        # the override against an allow-everything default and SETs it, so a persisted
-        # `tool_deny` narrowing is silently replaced and the tool becomes ALLOWED. That is a
-        # permission WIDENING, the opposite of fail-closed, which is why the type alone
-        # (a compile-time-only signal) is not sufficient here.
+        # #3593 review: `registry` is genuinely `_EnvelopeSource | None` — Session's own
+        # `registry` field is `AgentRegistry | None` (a caller without a back-reference is
+        # a real, legitimate state, not a wiring bug to paper over with a non-Optional lie)
+        # — so `is None` is a fully-typed discriminator, not a runtime-only guess about a
+        # static signal. `not hasattr(..., "resolved_profile_for")` stays alongside it as a
+        # SEPARATE, purely defensive check: Python does not enforce the Protocol at
+        # runtime, so a non-conforming object could theoretically reach here despite the
+        # type. Either arm means the same thing (no base to read), which is why they share
+        # one branch: composing the override against an allow-everything default and
+        # SETting it would silently replace a persisted `tool_deny` narrowing with ALLOWED
+        # — a permission WIDENING, the opposite of fail-closed.
         if self._registry is None or not hasattr(self._registry, "resolved_profile_for"):
             # #3593 ①: preserve — see the docstring. No base was obtained, so nothing below
             # may run: everything below composes a NEW envelope and SETs it over the live one.
@@ -402,9 +404,13 @@ class CapabilityVisibility:
         - Sibling precedent in this same class: ``persist_visibility_override`` reports its
           best-effort failure the same way.
 
-        Stage ② (#3593) is meant to make this branch unreachable by construction — fix the
-        one bootstrap-ordering caller, then require the envelope source non-optionally. Until
-        then this warning is what would tell an operator the window widened.
+        Stage ② (#3593) fixed the one measured bootstrap-ordering caller that reached here
+        unnecessarily (dogfood's registry cell). This branch stays reachable by DESIGN,
+        though: ``registry`` is genuinely ``AgentRegistry | None`` — a session legitimately
+        exists without a back-reference in some construction paths — so "no envelope
+        source" is not itself a defect to engineer away, only a state that must never widen
+        permissions. This warning is what tells an operator it happened, on any path that
+        reaches it.
         """
         import logging
 


### PR DESCRIPTION
**[e2e-coder]** — closes #3593. Fresh branch off main.

## Summary
This resolves the last recorded remainder on #3593: the `[arg-type]` finding at `session.py:1359` (`Argument "registry" to "CapabilityVisibility" has incompatible type "Any | None"; expected "_EnvelopeSource"`), grandfathered invisible by the mypy ratchet's `(file, code)` grain (documented in #3739), left open as a `part of #3593` remainder rather than filed separately.

Measured before implementing (lead-coder's explicit correction to my first plan, which over-applied their own earlier "typed union, not form-sniff" guidance): is "no usable base" one state or two-plus? Read the full guard in `reapply_visibility_override` — `registry is None or not hasattr(..., "resolved_profile_for")` — both arms produce the identical outcome (preserve + warn, same code path, same message), and no test exercises the `hasattr` arm as a distinct scenario. One state, not two: `X | None` is already a fully-typed discriminator, so a sentinel class + `isinstance` would just re-say what `| None` already says, and would split "no base" into two spellings (public Optional, internal sentinel) that drift apart over time.

`Session`'s own `registry` field is genuinely `AgentRegistry | None` — a session legitimately exists without a back-reference in some construction paths, confirmed by `session.py:1358`'s direct passthrough (`registry=self._registry`, no `None`-branch beforehand). So `CapabilityVisibility`'s own `registry: "_EnvelopeSource"` (non-Optional) was the actual lie, not Session's Optional field. Corrected to `_EnvelopeSource | None`, matching what every caller actually passes. `is None` was always the real discriminator at runtime; it is now also the typed one. No sentinel, no `isinstance`, no new abstraction — a 1-line type correction plus updating 2 comments that had asserted the type would eventually become non-Optional (it will not; the state is legitimate, not a wiring defect to engineer away).

## Enumeration (closing-keyword safety, CLAUDE.md rule 4)
Every PR referencing #3593: #3614 (stage ①, MERGED), #3650 (the #3615 read-model twin, MERGED), #3655 (stage ②, MERGED), #3738 (the earlier type-tightening attempt this supersedes, MERGED), #3739 (mypy ratchet docs, MERGED). All merged; this PR completes the only remaining recorded remainder. No other open PR or issue references #3593.

## Test plan
- [x] `pytest` on all 4 `#3593`/`#3615`/pipeline-driver-narrowing related test files — 20 passed, 0 failures
- [x] Broader sweep (`-k "capability_visibility or visibility_override or 2285"`) — 26 passed, 8 skipped, 0 failures
- [x] `mypy` diff (git-stash comparison): the specific `registry` arg-type error is present before this fix, gone after — confirmed directly, not inferred from the ratchet's coarse-grained pass/fail
- [x] `python scripts/mypy_ratchet.py` — 211/212, unchanged (baseline is presence-only; `session.py`'s `arg-type` entry stays declared regardless, masked by other unrelated findings in the same file) — baseline file untouched
- [x] `ruff check src/reyn/runtime/capability_visibility.py` — clean
- [x] (skipped — full-suite run not needed; single-file, type-annotation-only change with no behavioral difference, all directly-affected + broader-sweep tests green)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>