### PR TITLE
fix(#3765): check producer task health at the 2 known instances

### DIFF
--- a/tests/test_1800_c_staging.py
+++ b/tests/test_1800_c_staging.py
@@ -402,7 +402,13 @@ async def test_c_staging_durable_during_drain_wait(tmp_path) -> None:
     # #3748: unbounded (owner policy) -- the asserts below check exact COUNT
     # and CONTENT, a stronger claim than this loop's mere truthiness check,
     # so they are not restating the loop condition and stay.
+    # #3765: check the producer's health, not just elapsed time -- if
+    # drain_task dies (an exception) before staging, that exception IS the
+    # real failure; re-raising it beats hanging on a producer that will
+    # never satisfy the predicate again (mirrors #3764's fix).
     while not AgentSnapshot.load(session.agent_name, session._snapshot_path).next_turn_context:
+        if drain_task.done():
+            drain_task.result()
         await asyncio.sleep(0.005)
 
     # While _drain_to_wake is still blocking (no trigger sent), verify

--- a/tests/test_2839_a2a_run_registry_truncate_falsify.py
+++ b/tests/test_2839_a2a_run_registry_truncate_falsify.py
@@ -116,7 +116,13 @@ async def test_pending_intervention_a2a_run_survives_restart_and_wal_truncation(
     # of recording + awaiting the future (sanity: it must be genuinely
     # dispatched before we can prove it survives truncation). No terminating
     # assert: the loop condition IS that check.
+    # #3765: check dispatch_task's health, not just elapsed time -- if it
+    # dies (an exception) before recording, that exception IS the real
+    # failure; re-raising it beats hanging on a producer that will never
+    # satisfy the predicate again (mirrors #3764's fix).
     while session.interventions.get(iv.id) is None:
+        if dispatch_task.done():
+            dispatch_task.result()
         await asyncio.sleep(0.01)
 
     # The A2A bus mirrors input-required onto the RunEntry (real object, same


### PR DESCRIPTION
**[e2e-coder]** — closes #3765. Fresh branch off main.

## Summary
Applies #3764's established pattern (`if task.done(): task.result()` — task health, not a time bound) to the 2 instances #3765 named, both found by scanning #3748-touched files for `asyncio.create_task`/`ensure_future` held alongside an unbounded wait that never checked the task.

- `tests/test_1800_c_staging.py`: `drain_task = asyncio.create_task(session._drain_to_wake())`, unchecked by the wait for the staged `next_turn_context` entry.
- `tests/test_2839_a2a_run_registry_truncate_falsify.py`: `dispatch_task = asyncio.ensure_future(session.handle_intervention(iv))`, unchecked by the wait for the intervention to register. The file's *second* wait (on `session2`'s restore-triggered re-enqueue) has no producer task handle available — `restore_state`'s re-enqueue runs as an internal task inside `Session`, never exposed to the caller — so it's unchanged, the same limitation already noted for `test_2259` in #3748.

**Scope, stated explicitly per #3765's own framing**: this is the sweep the issue itself scoped to (files #3748 already touched), not a full-repo sweep — other instances may exist outside that set.

## Test plan
- [x] `pytest tests/test_1800_c_staging.py tests/test_2839_a2a_run_registry_truncate_falsify.py -v` — 7 passed (independently, fresh worktree off origin/main, own venv)
- [x] Falsified both sites: forced each producer coroutine to raise immediately instead of doing its real work, confirmed the test fails FAST (~1.7s) with the real exception surfaced (not a hang), reverted before commit
- [x] `ruff check` on both files — clean
- [x] `python scripts/test_tier_audit.py --strict` on both files — 0 errors, 0 warnings
- [x] (skipped — full-suite run not needed; 2-file change, no shared cross-file helper touched)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>