### PR TITLE
fix(#3671): defer litellm's cold import past startup for LLM-free sessions

### DIFF
--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -448,22 +448,18 @@ def _startup_stage(name: str):
     return stage(name)
 
 
-def _prepay_litellm_import() -> None:
-    """Pre-pay litellm's lazy import (#3671 client-prep:litellm-import).
-
-    `llm.py`'s `run_async` (a general-purpose choke point also used by
-    `mcp.py` and other non-chat-startup callers) lazily imports litellm via
-    `_snapshot_litellm_client_cache_keys` — baking a CLI startup-phase stage
-    name into that shared helper would record non-startup calls under a
-    startup stage, a stronger opinion than that helper's least-opinionated
-    caller should have. Importing it HERE instead, in the startup path,
-    keeps `run_async` untouched: Python caches the module, so `run_async`'s
-    own `import litellm` becomes a near-zero-cost lookup once this has
-    already paid the real cost. Measured on a real run: this was the
-    largest previously-unnamed slice of `client-prep:other` (~59-60% of
-    TOTAL on one machine)."""
-    with _startup_stage("client-prep:litellm-import"):
-        import litellm  # noqa: F401,PLC0415
+#: #3671 P5: `_prepay_litellm_import` (removed) existed ONLY because
+#: `run_async` used to force `import litellm` unconditionally at its own
+#: top (via a since-removed eager cache-key snapshot) — prepaying here, in
+#: a NAMED startup stage, was how that already-unavoidable cost got
+#: measured separately from the unnamed `client-prep:other` bucket rather
+#: than actually removed. Once `run_async`/`litellm_bootstrap` stopped
+#: forcing that import for an LLM-free session (`reyn.llm.litellm_bootstrap`
+#: module docstring), prepaying it here would have UNDONE that fix by
+#: re-introducing the exact unconditional import this file's own function
+#: used to exist to merely relabel. `"litellm" not in sys.modules` after an
+#: LLM-free session is the property that removal (not relabelling) makes
+#: possible — see `test_run_async_never_imports_litellm_without_an_llm_call`.
 
 
 def _report_startup_timing() -> None:
@@ -901,5 +897,4 @@ def _run(args: argparse.Namespace) -> None:
     from reyn.runtime.startup_timing import mark_async_entered  # noqa: PLC0415
 
     mark_async_entered()
-    _prepay_litellm_import()
     run_async(_main_chat())

--- a/src/reyn/llm/litellm_bootstrap.py
+++ b/src/reyn/llm/litellm_bootstrap.py
@@ -74,6 +74,19 @@ _ready_registry: "dict[str, Future]" = {}
 # `run_async` is the only intended re-entry point, but nothing stops a
 # concurrent asyncio task within one call from racing another into
 # `ensure_litellm_ready` first.
+#
+# A SINGLE module-global generation counter (not one scoped per-call some
+# other way) is safe only because `run_async` (`llm.py`) is `asyncio.run`
+# underneath: `asyncio.run` raises if called while a loop is already
+# running on the same thread, so two `run_async` calls cannot be nested or
+# concurrent on one thread — not by convention, by asyncio's own
+# construction. `run_async`'s only callers are the CLI's own outermost
+# entry points (`chat.py`, `mcp.py`), one `asyncio.run(_wrapped())` per
+# process lifetime of a call. If `run_async` is ever invoked from more
+# than one OS thread concurrently, this assumption is the first thing that
+# breaks — a second thread's `reset_client_cache_baseline` would advance
+# the SAME generation counter the first thread's in-flight call is still
+# reading, invalidating its baseline mid-call.
 _baseline_generation = 0
 _baseline_registry: "dict[int, Future]" = {}
 

--- a/src/reyn/llm/litellm_bootstrap.py
+++ b/src/reyn/llm/litellm_bootstrap.py
@@ -15,6 +15,19 @@ first-import work. Callers that need the ``litellm`` module still do their own
 ``import litellm`` afterward (cheap — Python caches the module), but calling
 ``ensure_litellm_ready()`` first guarantees the log-routing patch is active
 for whichever call site happens to import litellm first in a given process.
+
+#3671: this module also owns the #3434 client-cache "pre-existing keys"
+baseline (:func:`reset_client_cache_baseline`/:func:`client_cache_baseline`)
+— NOT because it is about logging, but because ``ensure_litellm_ready`` is
+already the one place every REAL litellm use passes through, which is
+exactly where the baseline must be captured for a session that never calls
+the LLM to never import litellm at all. ``llm.py``'s ``run_async`` used to
+call ``import litellm`` unconditionally at its own top (via a now-removed
+eager snapshot helper) purely to compute this baseline — costing every
+session litellm's own ~1.5-5s cold-import before the UI could even mount,
+whether or not that session ever used the LLM. Moving the capture here
+means it only happens on the SAME call path that was going to pay the
+import cost anyway.
 """
 from __future__ import annotations
 
@@ -47,6 +60,22 @@ _litellm_ready = False
 # not added by this PR) will need this exact "await the owner's finish"
 # primitive anyway, so this is not new machinery introduced just for P1.
 _ready_registry: "dict[str, Future]" = {}
+
+# #3671: the litellm async-client cache's key set as it stood at the START
+# of the CURRENT `run_async` call (#3434's "pre-existing" baseline) — a
+# DIFFERENT lifetime than `_litellm_ready` above. `_litellm_ready` is
+# process-wide, set once ever; this is per-`run_async`-CALL, reset at each
+# call's start by `reset_client_cache_baseline` and captured lazily by
+# whichever real litellm use (`ensure_litellm_ready`) happens first WITHIN
+# that call — regardless of whether litellm's own process-wide first-import
+# setup already ran for an earlier call. Same ownership shape as
+# `_ready_registry` above (a Future per "generation", `setdefault`-raced)
+# rather than a lock, and for the same reason: the loop-owning caller in
+# `run_async` is the only intended re-entry point, but nothing stops a
+# concurrent asyncio task within one call from racing another into
+# `ensure_litellm_ready` first.
+_baseline_generation = 0
+_baseline_registry: "dict[int, Future]" = {}
 
 
 @contextlib.contextmanager
@@ -150,36 +179,101 @@ def ensure_litellm_ready() -> None:
     # Unlocked fast-path read keeps the "cheap on every call after the
     # first" property this docstring promises — after the owner's Future
     # resolves this flag is the only thing subsequent calls ever touch.
-    if _litellm_ready:
-        return
-
-    my_future: "Future[None]" = Future()
-    winning_future = _ready_registry.setdefault("ready", my_future)
-    if winning_future is not my_future:
-        # Someone else already owns setup — wait for THEM to finish, not a
-        # lock, so we block only as long as the real work actually takes,
-        # never past it (the "started, not finished" bug this replaces).
-        winning_future.result()
-        return
-
-    # We won ownership. Do the real work, then release every waiter.
-    try:
-        with _litellm_import_logs_to_file():
+    # NOTE: still falls through to `_capture_client_cache_baseline` below —
+    # the process-wide-once setup and the per-`run_async`-call baseline
+    # (#3671/#3434) are different lifetimes, so this early return must not
+    # skip the second one.
+    if not _litellm_ready:
+        my_future: "Future[None]" = Future()
+        winning_future = _ready_registry.setdefault("ready", my_future)
+        if winning_future is not my_future:
+            # Someone else already owns setup — wait for THEM to finish, not
+            # a lock, so we block only as long as the real work actually
+            # takes, never past it (the "started, not finished" bug this
+            # replaces).
+            winning_future.result()
+        else:
+            # We won ownership. Do the real work, then release every waiter.
             try:
-                import litellm
-                litellm.suppress_debug_info = True
-                # #3075 fix 1: litellm's aiohttp transport defaults
-                # aiohttp_trust_env=False, so it is proxy-blind even when the
-                # operator's standard HTTP(S)_PROXY/NO_PROXY env is set — the
-                # highest-volume egress reyn originates (every LLM/embedding call)
-                # was the sharpest non-conformer in the #3075 enumeration. Flipping
-                # this makes litellm read the standard proxy env like every other
-                # conforming egress; it already honours SSL_CERT_FILE/
-                # REQUESTS_CA_BUNDLE via get_ssl_verify(), so this is the one
-                # missing piece for full conformance.
-                litellm.aiohttp_trust_env = True
-            except Exception:  # noqa: BLE001 — best-effort; never block the caller on this
-                pass
-    finally:
-        _litellm_ready = True
-        my_future.set_result(None)
+                with _litellm_import_logs_to_file():
+                    try:
+                        import litellm
+                        litellm.suppress_debug_info = True
+                        # #3075 fix 1: litellm's aiohttp transport defaults
+                        # aiohttp_trust_env=False, so it is proxy-blind even when the
+                        # operator's standard HTTP(S)_PROXY/NO_PROXY env is set — the
+                        # highest-volume egress reyn originates (every LLM/embedding call)
+                        # was the sharpest non-conformer in the #3075 enumeration. Flipping
+                        # this makes litellm read the standard proxy env like every other
+                        # conforming egress; it already honours SSL_CERT_FILE/
+                        # REQUESTS_CA_BUNDLE via get_ssl_verify(), so this is the one
+                        # missing piece for full conformance.
+                        litellm.aiohttp_trust_env = True
+                    except Exception:  # noqa: BLE001 — best-effort; never block the caller on this
+                        pass
+            finally:
+                _litellm_ready = True
+                my_future.set_result(None)
+
+    _capture_client_cache_baseline()
+
+
+def reset_client_cache_baseline() -> None:
+    """Arm a FRESH per-call baseline capture (#3434's "pre-existing" key
+    set) for the `run_async` invocation about to start.
+
+    Call this at `run_async`'s own entry — it touches only plain module
+    globals, never imports litellm, so it costs nothing for a session that
+    never calls the LLM (the #3671 property: `"litellm" not in sys.modules`
+    must still hold after this runs). The NEXT real litellm use within the
+    call (`ensure_litellm_ready`, from `recorded_acompletion` or the
+    embedding provider) captures the actual baseline lazily; if no such use
+    ever happens, no baseline is ever captured and
+    :func:`client_cache_baseline` stays `None` for the whole call.
+    """
+    global _baseline_generation
+    _baseline_generation += 1
+
+
+def client_cache_baseline() -> "frozenset | None":
+    """This `run_async` call's pre-existing litellm client-cache key set
+    (#3434), or `None` if the call never touched litellm at all.
+
+    `None` and `frozenset()` mean DIFFERENT things to the caller
+    (`_close_litellm_async_clients`): `None` means "nothing was ever
+    imported this call, there is nothing of ours to close, do not even
+    import litellm to check" — treating it as an empty baseline instead
+    would tell the close step "everything currently cached is new, close
+    all of it", which is the #3434 bug (closing another call's still-open
+    client) reintroduced one layer up.
+    """
+    future = _baseline_registry.get(_baseline_generation)
+    if future is None or not future.done():
+        return None
+    return future.result()
+
+
+def _capture_client_cache_baseline() -> None:
+    """Lazily capture :func:`client_cache_baseline`'s value for the CURRENT
+    generation (see :func:`reset_client_cache_baseline`), once, the first
+    time this is reached within a given `run_async` call — regardless of
+    whether litellm's own process-wide first-import setup (above) ran just
+    now or ran for an earlier call. Same ownership shape as
+    ``ensure_litellm_ready``'s Future/registry, scoped per-generation
+    instead of process-wide, for the same reentrancy-safety reason: nothing
+    stops two concurrent asyncio tasks within one call from both reaching
+    ``ensure_litellm_ready`` before either has captured the baseline."""
+    generation = _baseline_generation
+    my_future: "Future[frozenset]" = Future()
+    winning_future = _baseline_registry.setdefault(generation, my_future)
+    if winning_future is not my_future:
+        return  # someone else already owns (or has finished) this capture
+    try:
+        import litellm
+
+        cache = getattr(litellm, "in_memory_llm_clients_cache", None)
+        cache_dict = getattr(cache, "cache_dict", None)
+        baseline = frozenset(cache_dict.keys()) if cache_dict else frozenset()
+    except Exception:  # noqa: BLE001 — best-effort, matches the module's posture elsewhere
+        baseline = frozenset()
+    winning_future.set_result(baseline)

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -473,6 +473,15 @@ async def shutdown_logging() -> None:
       If LiteLLM ever guarantees clean drain in `asyncio.run` shutdown
       without caller intervention, this function and `run_async` become
       thin wrappers and can be removed.
+
+    #3671: guarded by ``litellm_bootstrap.client_cache_baseline() is not
+    None`` at the call site in ``run_async`` — the queue this drains can
+    only have entries if ``acompletion()`` ran at least once this call
+    (this docstring's own "enqueues ... after every acompletion()"), so a
+    session that never touched the LLM has NOTHING to drain, and the
+    unconditional ``from litellm... import`` below would otherwise force
+    litellm's cold import (#3671's whole cost) just to confirm an empty
+    queue.
     """
     try:
         from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
@@ -482,28 +491,7 @@ async def shutdown_logging() -> None:
         pass
 
 
-def _snapshot_litellm_client_cache_keys() -> frozenset:
-    """Return the current key set of litellm's process-wide async-client
-    cache (#3434), for use as the "pre-existing" baseline `run_async` diffs
-    against before closing anything.
-
-    Best-effort: an empty frozenset (rather than raising) if litellm hasn't
-    lazily initialized the cache yet, matching `_close_litellm_async_clients`'s
-    own best-effort posture.
-    """
-    try:
-        import litellm
-
-        cache = getattr(litellm, "in_memory_llm_clients_cache", None)
-        cache_dict = getattr(cache, "cache_dict", None)
-        if cache_dict is None:
-            return frozenset()
-        return frozenset(cache_dict.keys())
-    except Exception:
-        return frozenset()
-
-
-async def _close_litellm_async_clients(pre_existing_keys: frozenset = frozenset()) -> None:
+async def _close_litellm_async_clients(pre_existing_keys: frozenset) -> None:
     """Close LiteLLM's cached aiohttp-backed async HTTP clients before the
     event loop closes (issue #2787), scoped to clients created during THIS
     `run_async` call (#3434).
@@ -537,15 +525,28 @@ async def _close_litellm_async_clients(pre_existing_keys: frozenset = frozenset(
       cached async client to complete -- closing the client first could
       break that drain.
 
-    Fix: diff the cache's key set against `pre_existing_keys` (captured by
-    `run_async` before awaiting the wrapped coroutine) and temporarily hide
-    the pre-existing entries from litellm's own cache dict while invoking
-    its official close routine — so only clients newly cached during this
-    call get closed, and clients other in-flight callers still own are left
-    alone. Restoring afterwards is unconditional (`finally`) so a raise from
-    litellm's close routine can never permanently evict them. Idempotent /
-    safe to call when no client was ever created during this call: the diff
-    is then empty (no-op).
+    Fix: diff the cache's key set against `pre_existing_keys` (#3671:
+    `litellm_bootstrap.client_cache_baseline()`, captured lazily by the
+    first real litellm use *within this call*, not necessarily by
+    `run_async` itself — see that function's own docstring for why) and
+    temporarily hide the pre-existing entries from litellm's own cache dict
+    while invoking its official close routine — so only clients newly
+    cached during this call get closed, and clients other in-flight
+    callers still own are left alone. Restoring afterwards is unconditional
+    (`finally`) so a raise from litellm's close routine can never
+    permanently evict them.
+
+    #3671: NOT called at all (not "called with an empty pre_existing_keys")
+    when the call never touched litellm — `run_async` checks
+    `client_cache_baseline() is not None` before calling this, so a
+    session that never used the LLM never pays this function's own `import
+    litellm` either. Calling it with `pre_existing_keys=frozenset()` for
+    that case (the previous behaviour) would look idempotent but is NOT:
+    `cache_dict` may be non-empty from OTHER calls in the same worker
+    process, and an empty baseline would make the diff below treat every
+    one of THEIR entries as "new to this call" and close them — the #3434
+    bug, reintroduced by the very frozenset() default that looked like a
+    safe idempotent no-op.
 
     Considered and accepted, not overlooked: the hidden window spans an
     `await` (litellm's close routine), so in principle another task on the
@@ -591,11 +592,27 @@ def run_async(coro: Coroutine[object, object, T]) -> T:
     unhandled-exception capture here (rather than at each call site)
     covers all of them from one place. See
     ``reyn.core.events.asyncio_diagnostics`` for why.
+
+    #3671: does NOT import litellm itself, and never did directly — but
+    used to force it as a side effect via `litellm_bootstrap`'s
+    predecessor of `client_cache_baseline` being captured EAGERLY here,
+    before `coro` (the whole session) had run at all. A session that
+    never calls the LLM (the common case for "just show the TUI") was
+    paying litellm's own multi-second cold import before the UI could
+    mount, for a baseline `_close_litellm_async_clients` would only ever
+    need if the LLM WAS called. `reset_client_cache_baseline` below only
+    arms lazy capture — the ACTUAL import now happens on whichever call
+    reaches it first, inside the session's own real LLM use
+    (`recorded_acompletion`/the embedding provider), if it happens at
+    all. `"litellm" not in sys.modules` after a session that never used
+    it is the gate this exists to keep true —
+    `test_run_async_never_imports_litellm_without_an_llm_call` pins it.
     """
-    # #3434: snapshot BEFORE the coroutine runs, so the finally below closes
-    # only litellm async clients this call creates — not every client any
-    # other test/call in this worker process has cached and is still using.
-    pre_existing_keys = _snapshot_litellm_client_cache_keys()
+    from reyn.llm.litellm_bootstrap import client_cache_baseline, reset_client_cache_baseline
+
+    # #3434 (scope) / #3671 (cost): arm a FRESH per-call baseline without
+    # importing litellm — see `reset_client_cache_baseline`'s own docstring.
+    reset_client_cache_baseline()
 
     async def _wrapped() -> T:
         from reyn.core.events.asyncio_diagnostics import (
@@ -605,8 +622,34 @@ def run_async(coro: Coroutine[object, object, T]) -> T:
         try:
             return await coro
         finally:
-            await shutdown_logging()
-            await _close_litellm_async_clients(pre_existing_keys)
+            # #3671: two INDEPENDENT gates, deliberately not one.
+            #
+            # `shutdown_logging` gates on `"litellm" in sys.modules` — the
+            # general "was litellm touched AT ALL this call" signal, true
+            # for `recorded_acompletion`/the embedding provider AND for any
+            # other lazy litellm call site in this codebase (there are
+            # several — cost/pricing/budget lookups, `router_loop.py`, the
+            # replay harness) that does not happen to route through
+            # `ensure_litellm_ready`. Draining litellm's logging-worker
+            # queue is safe and idempotent regardless of WHICH path
+            # imported litellm, so the broader signal is correct here.
+            #
+            # `_close_litellm_async_clients` gates on `client_cache_baseline()
+            # is not None` — a NARROWER, TRUSTED-baseline-only signal.
+            # Closing clients needs to know what pre-existed THIS call
+            # (#3434); a call that imported litellm through some OTHER path
+            # never captured that baseline, and guessing `frozenset()` would
+            # misread "unknown" as "nothing pre-existed" and close every
+            # OTHER call's still-open client — the #3434 bug, reintroduced.
+            # Skipping is the safe direction: at worst a client that path
+            # created is not closed until GC (#2787's pre-existing risk
+            # class, not a new one), never another call's client closed
+            # early.
+            if "litellm" in sys.modules:
+                await shutdown_logging()
+            pre_existing_keys = client_cache_baseline()
+            if pre_existing_keys is not None:
+                await _close_litellm_async_clients(pre_existing_keys)
 
     return asyncio.run(_wrapped())
 

--- a/src/reyn/runtime/startup_timing.py
+++ b/src/reyn/runtime/startup_timing.py
@@ -114,16 +114,22 @@ def mark_async_entered() -> None:
 
 
 #: The narrow ``client-prep:*`` brackets `mark_app_constructed` sums to
-#: compute ``client-prep:other`` (#3735 regression fix; ``litellm-import``
-#: added #3671 follow-up after a real-run measurement showed the original 4
-#: brackets left ~59-60% of the wide span in ``client-prep:other``, and
-#: ``llm.py``'s ``run_async`` lazily imports litellm BEFORE any of the other
-#: 4 brackets even start) — every named sub-stage of the wide
-#: ``mark_async_entered`` → ``mark_app_constructed`` span EXCEPT
-#: ``client-prep:other`` itself (summing that too would be circular: it is
-#: defined as what these do not already cover).
+#: compute ``client-prep:other`` (#3735 regression fix) — every named
+#: sub-stage of the wide ``mark_async_entered`` → ``mark_app_constructed``
+#: span EXCEPT ``client-prep:other`` itself (summing that too would be
+#: circular: it is defined as what these do not already cover).
+#:
+#: ``litellm-import`` briefly lived here (#3671 follow-up, after a real-run
+#: measurement showed the original 4 brackets left ~59-60% of the wide span
+#: in ``client-prep:other``, traced to ``llm.py``'s ``run_async`` forcing
+#: ``import litellm`` before any of the other 4 brackets even started) — and
+#: was REMOVED, not renamed, once that forced import itself was removed
+#: (``reyn.llm.litellm_bootstrap`` module docstring): a session that never
+#: calls the LLM no longer imports litellm at all during startup, so there
+#: is no longer a client-prep cost of that name to bracket. The time it used
+#: to measure moved out of ``client-prep:other`` entirely rather than into
+#: this tuple.
 _CLIENT_PREP_NAMED_STAGES: "tuple[str, ...]" = (
-    "client-prep:litellm-import",
     "client-prep:transport",
     "client-prep:read-model",
     "client-prep:tui-import",
@@ -274,6 +280,14 @@ def process_elapsed_seconds() -> float:
 #: hold a value is worse than no row: this module's whole premise is that
 #: ``0.00`` means measured-and-fast, and one entry quietly breaking that
 #: promise poisons every other reading. The span it stood for is ``TOTAL``.
+#: #3671: ``client-prep:litellm-import`` — REMOVED, not left to report
+#: ``0.00`` (this module's own stated line above: "``0.00`` means
+#: measured-and-fast", not "this stage no longer exists"; a permanently-dead
+#: row would break that promise the same way a never-fired ``first-frame``
+#: did). Removed once the forced startup-time ``import litellm`` it measured
+#: was itself removed (``reyn.llm.litellm_bootstrap`` module docstring) — a
+#: session that never calls the LLM no longer has a litellm-import cost
+#: anywhere in this bracket to name.
 STAGES: "tuple[str, ...]" = (
     "import",
     "config",
@@ -281,7 +295,6 @@ STAGES: "tuple[str, ...]" = (
     "plugins",
     "mcp",
     "session",
-    "client-prep:litellm-import",
     "client-prep:transport",
     "client-prep:read-model",
     "client-prep:tui-import",

--- a/tests/test_litellm_lazy_load.py
+++ b/tests/test_litellm_lazy_load.py
@@ -330,3 +330,132 @@ def test_measured_startup_latency_delta_from_deferring_litellm(out_of_process_re
         f"a bare litellm import ({litellm_s:.3f}s) — litellm may be back on "
         f"the startup path"
     )
+
+
+# ── #3671: structural guard for the ensure_litellm_ready-first assumption ────
+#
+# run_async's #3434 close-scoping now depends on ensure_litellm_ready()
+# having run before ANY litellm async client is created THIS call (see
+# reyn.llm.llm.run_async's own docstring). That was verified against today's
+# call sites by NAME (grepping for get_async_httpx_client/acompletion/
+# aembedding) — a name-shaped search, the exact blind-spot class this
+# session hit three times already: a 5th call site creating a client under a
+# DIFFERENT name would be invisible to a name grep and would silently make
+# the assumption false, breaking in the direction that does not turn CI red
+# (close silently skips). These three gates turn "verified once by grep"
+# into "enforced by construction" the same way #1190's AST guard already
+# does for litellm.acompletion specifically — walking every file's AST
+# rather than matching an expected name shape.
+#
+# RESIDUAL RISK, deliberately accepted rather than closed (lead-coder
+# review): these gates still enumerate litellm's client-creating APIs BY
+# NAME (acompletion / aembedding / get_async_httpx_client) — routing every
+# lazy litellm call site through ensure_litellm_ready() unconditionally
+# (closing this for good) would also force it onto sites that only ever
+# touch STATIC data (model_budget.py / model_cost_rate.py / pricing.py /
+# core/registry/client.py / core/op_runtime/web.py — cost maps, token
+# counting, ssl verify — none create an async client), which risks pulling
+# the import back toward startup for paths that never needed it, the exact
+# #3671 regression this arc closes. If litellm ever grows a NEW
+# client-creating API under a different name, THESE GATES WILL NOT CATCH
+# IT — add it here alongside the three above.
+
+import ast
+
+
+def _repo_src_root() -> "Path":
+    here = Path(__file__).resolve()
+    for ancestor in here.parents:
+        if (ancestor / "pyproject.toml").is_file():
+            return ancestor / "src" / "reyn"
+    raise RuntimeError("repo root not found from " + str(here))
+
+
+def _call_span(py: "Path", func_name: str) -> "tuple[int, int] | None":
+    """The (start, end) line span of the first ``def``/``async def`` named
+    ``func_name`` in ``py``, or ``None`` if not found."""
+    tree = ast.parse(py.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
+            return node.lineno, (node.end_lineno or node.lineno)
+    return None
+
+
+def test_litellm_aembedding_only_inside_the_bounded_helper() -> None:
+    """Tier 2: OS invariant — ``litellm.aembedding`` may be called ONLY
+    inside ``LiteLLMEmbeddingProvider._aembedding_bounded``
+    (``reyn.data.embedding.litellm_provider``), the one place that already
+    calls ``ensure_litellm_ready()`` (via its caller, ``embed_batch``)
+    before reaching it. A new embedding call site elsewhere would create a
+    litellm async client without that guarantee, silently breaking
+    run_async's #3434 close-scoping baseline in the direction that never
+    turns CI red on its own (the close step just skips)."""
+    src = _repo_src_root()
+    provider_py = (src / "data" / "embedding" / "litellm_provider.py").resolve()
+    span = _call_span(provider_py, "_aembedding_bounded")
+    assert span is not None, "_aembedding_bounded not found — chokepoint moved?"
+    start, end = span
+
+    offenders: "list[str]" = []
+    for py in src.rglob("*.py"):
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "aembedding"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "litellm"
+            ):
+                continue
+            inside = py.resolve() == provider_py and start <= node.lineno <= end
+            if not inside:
+                offenders.append(f"{py.relative_to(src.parent.parent)}:{node.lineno}")
+
+    assert not offenders, (
+        "litellm.aembedding called outside _aembedding_bounded (bypasses "
+        "the ensure_litellm_ready-first guarantee run_async's #3434 "
+        f"close-scoping depends on). Offending sites: {offenders}"
+    )
+
+
+def test_no_production_call_site_creates_a_litellm_client_below_acompletion_aembedding() -> None:
+    """Tier 2: OS invariant — nothing in ``src/reyn/`` calls litellm's
+    lower-level async-client constructors directly (``get_async_httpx_client``
+    and siblings), which would create a real cached client WITHOUT going
+    through ``litellm.acompletion``/``aembedding`` — and therefore without
+    the ``ensure_litellm_ready()`` guarantee those two chokepoints carry
+    (the #1190 AST guard for ``acompletion``; the sibling gate above for
+    ``aembedding``). Today this is true because nothing needs to reach that
+    low-level; this test is what makes a FUTURE such site fail here instead
+    of silently widening the #3434 close-scoping gap.
+
+    Scoped to ``get_async_httpx_client`` by name deliberately paired with a
+    Tier-1 comment, not a Tier-2 enforcement claim: litellm exposes more
+    than one low-level constructor family, and this guard does not claim to
+    enumerate all of them — it closes the ONE bypass this arc's own
+    investigation found and used in test setup (see
+    ``test_llm_run_async_shutdown_litellm_clients_2787.py``), so a
+    regression on THAT specific bypass is caught."""
+    src = _repo_src_root()
+
+    offenders: "list[str]" = []
+    for py in src.rglob("*.py"):
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module and "get_async_httpx_client" in [
+                a.name for a in node.names
+            ]:
+                offenders.append(f"{py.relative_to(src.parent.parent)}:{node.lineno}")
+            elif (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "get_async_httpx_client"
+            ):
+                offenders.append(f"{py.relative_to(src.parent.parent)}:{node.lineno}")
+
+    assert not offenders, (
+        "get_async_httpx_client used outside a test — this creates a "
+        "litellm async client WITHOUT the ensure_litellm_ready-first "
+        f"guarantee. Offending sites: {offenders}"
+    )

--- a/tests/test_llm_run_async_client_cache_scope_3434.py
+++ b/tests/test_llm_run_async_client_cache_scope_3434.py
@@ -3,6 +3,10 @@ during its own call — not litellm's entire process-wide async-client cache
 (#3434).
 """
 import asyncio
+import os
+import subprocess
+import sys
+import textwrap
 
 from reyn.llm.llm import run_async
 
@@ -56,3 +60,50 @@ def test_run_async_does_not_close_a_client_created_outside_its_own_call() -> Non
         "run_async closed a litellm async client it did not create — "
         "this is the #3434 shared-cache poisoning bug"
     )
+
+
+def test_run_async_never_imports_litellm_without_an_llm_call(out_of_process_reyn) -> None:
+    """Tier 2b: #3671 — the required gate. `run_async` given an LLM-free
+    coroutine must leave `"litellm" not in sys.modules` after it returns.
+
+    This is the ONE witness that actually pins the startup-latency win: the
+    other tests in this file (and #3434's own regression guard above) stay
+    green whether litellm is imported eagerly or lazily — they test SCOPING
+    of the close step, not WHETHER an import happened at all. Someone could
+    silently reinstate an eager `import litellm` at `run_async`'s own top
+    (the exact #3671 defect this arc fixed) and every other test would stay
+    green; only this one would turn red that day.
+
+    Subprocess, not in-process (same reasoning as `test_litellm_lazy_load
+    .py`'s own tests): almost every OTHER test in this suite imports litellm
+    somewhere, so `sys.modules` is contaminated by test order in-process —
+    only a fresh interpreter answers "did THIS call import it" honestly.
+    """
+    script = """
+        import sys
+        from reyn.llm.llm import run_async
+
+        assert "litellm" not in sys.modules, (
+            "litellm was already imported before run_async even ran — "
+            "broken test setup, not what this test means to check"
+        )
+
+        async def _llm_free() -> str:
+            return "done"
+
+        assert run_async(_llm_free()) == "done"
+        assert "litellm" not in sys.modules, sorted(
+            m for m in sys.modules if "litellm" in m
+        )
+        print("OK")
+        """
+    env = {**os.environ, "PYTHONPATH": out_of_process_reyn}
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout

--- a/tests/test_llm_run_async_shutdown_litellm_clients_2787.py
+++ b/tests/test_llm_run_async_shutdown_litellm_clients_2787.py
@@ -20,6 +20,21 @@ def test_run_async_closes_cached_litellm_async_client() -> None:
     surfacing as "Unhandled exception in event loop: Exception None").
     """
     async def _create_litellm_async_client():
+        # #3671: `ensure_litellm_ready()` first — the real call shape every
+        # actual litellm egress site uses (`recorded_acompletion`/the
+        # embedding provider, per that function's own docstring), and the
+        # hook `run_async`'s #3434 close-scoping baseline is captured
+        # through. A bare `import litellm` here (this test's shape before
+        # #3671) bypasses that hook — a client materialises, but the
+        # close step never learns litellm was touched THIS call and skips
+        # closing anything, which is correct #3671 behaviour for a call
+        # that genuinely never went through litellm's real entry points,
+        # but wrong for what this test means to exercise (a real client
+        # this call created SHOULD get closed).
+        from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+
+        ensure_litellm_ready()
+
         # Exercises litellm's real cache + real aiohttp-backed transport —
         # the same call shape `litellm.acompletion(...)` makes internally
         # for the aiohttp-transport providers (issue #2787's leak class).

--- a/tests/test_startup_timing_3671.py
+++ b/tests/test_startup_timing_3671.py
@@ -201,22 +201,23 @@ def test_the_report_survives_an_interrupt(monkeypatch, capsys) -> None:
     assert "startup timing" in capsys.readouterr().out
 
 
-def test_client_prep_is_five_named_sub_stages_not_one_lump(monkeypatch) -> None:
+def test_client_prep_is_four_named_sub_stages_not_one_lump(monkeypatch) -> None:
     """Tier 2: #3671 (architect's design) — the single `client-prep` lump is
-    replaced by named sub-stages at the seams already in the code (litellm's
-    lazy import inside `run_async`, transport construction, read-model
-    construction, the lazy textual/flowview import, and app construction), so
-    a slow startup can say WHICH of these, not just that the client was slow
-    to get ready.
+    replaced by named sub-stages at the seams already in the code (transport
+    construction, read-model construction, the lazy textual/flowview import,
+    and app construction), so a slow startup can say WHICH of these, not
+    just that the client was slow to get ready.
 
-    `litellm-import` added as a #3671 follow-up: a real-run measurement found
-    the original 4 sub-stages left ~59-60% of the wide span in
-    `client-prep:other` — `llm.py`'s `run_async` lazily imports litellm
-    BEFORE any of the other 4 brackets even start, and that cost had no
-    named home."""
+    `litellm-import` briefly existed as a 5th sub-stage (#3671 follow-up)
+    bracketing a startup-time `import litellm` that `run_async` used to
+    force unconditionally — REMOVED, not merely un-asserted here, once that
+    forced import itself was removed (`reyn.llm.litellm_bootstrap` module
+    docstring): a session that never calls the LLM no longer pays a
+    litellm-import cost during startup at all, so there is nothing left for
+    a 5th bracket to name."""
     assert "client-prep" not in STAGES
+    assert "client-prep:litellm-import" not in STAGES
     for name in (
-        "client-prep:litellm-import",
         "client-prep:transport",
         "client-prep:read-model",
         "client-prep:tui-import",
@@ -408,30 +409,14 @@ def test_client_prep_other_is_declared() -> None:
     assert "client-prep:other" in STAGES
 
 
-def test_litellm_import_stage_is_bracketed_in_the_chat_startup_path() -> None:
-    """Tier 2: #3671 follow-up — the chat startup path (`chat.py`'s
-    `_prepay_litellm_import`) is wrapped in `stage("client-prep:litellm-
-    import")`, so a real run can show whether THIS import, not the
-    lazily-imported textual/flowview tree (`client-prep:tui-import`), is what
-    dominates `client-prep:other`'s previously-unexplained ~59-60% share.
-
-    Deliberately NOT in `llm.py`'s `run_async` (lead-coder review): that is a
-    general-purpose choke point also used by `mcp.py` and other non-chat-
-    startup callers — a shared helper must not carry a stronger opinion
-    (a CLI startup-phase stage name) than its least-opinionated caller.
-    `run_async` itself is untouched by this PR.
-
-    Witnessed by running the real function and checking the PUBLIC recorded
-    duration increased — not by reading `chat.py`'s source for the `with`."""
-    from reyn.interfaces.cli.commands.chat import _prepay_litellm_import
-    from reyn.runtime import startup_timing
-
-    before = startup_timing.TIMING.elapsed("client-prep:litellm-import")
-
-    _prepay_litellm_import()
-
-    after = startup_timing.TIMING.elapsed("client-prep:litellm-import")
-    assert after >= before
+# #3671 P5: test_litellm_import_stage_is_bracketed_in_the_chat_startup_path
+# retired (clean break, CLAUDE.md testing.md § extracted-refactor test
+# lifecycle). It pinned `chat.py`'s `_prepay_litellm_import` bracketing a
+# startup-time `import litellm` that has since been removed entirely, not
+# relabelled — `run_async`/`litellm_bootstrap` no longer force that import
+# for an LLM-free session, so there is no bracket left to witness. See
+# `test_run_async_never_imports_litellm_without_an_llm_call`
+# (test_llm_run_async_client_cache_scope_3434.py) for what replaced it.
 
 
 def test_first_frame_reached_is_false_until_the_mark_fires(monkeypatch) -> None:


### PR DESCRIPTION
**[e2e-coder]** — traced per lead-coder's request, implementation followed after go-ahead. No specific latency number promised (measured on this machine, not the owner's — "how many of the 5.6s disappear needs a real run to know").

## Root cause
`run_async` (llm.py) called `_snapshot_litellm_client_cache_keys()` unconditionally at its own top — forcing litellm's own multi-second cold import (`-X importtime` confirmed: pure Python module-tree loading across every provider litellm supports, not network cost) before the wrapped coroutine (the whole session) had run at all, even for a session that never calls the LLM. This contradicted `llm.py`'s own established lazy-import discipline everywhere else in the same file.

## Why naive removal is unsafe
`import litellm` has a measured side effect: it populates ~4 default async-client cache entries immediately (confirmed empirically). So "not yet imported" ≠ "cache is empty" — an empty/wrong baseline at shutdown would misread every OTHER call's still-cached client as "new to this call" and close it, reintroducing #3434 (already regression-tested against the LLM-free multi-call-per-process scenario).

## Fix
Extends the **existing** single chokepoint (`litellm_bootstrap.ensure_litellm_ready`, #3671 P1's established single-owner pattern) with a per-`run_async`-call baseline (`reset_client_cache_baseline`/`client_cache_baseline`) — a different lifetime than that function's process-wide-once import setup, same Future/registry ownership shape for the same reentrancy-safety reason. `run_async`'s own entry only arms lazy capture (no import). The first REAL litellm use within the call (`recorded_acompletion` or the embedding provider — both already call `ensure_litellm_ready` first) captures the actual baseline. A session that never touches the LLM never captures one; shutdown then skips **both** steps independently:
- the client-close step, gated on `client_cache_baseline() is not None` (a trusted-baseline-only signal — guessing `frozenset()` would reintroduce #3434)
- the logging-drain step, gated on the broader `"litellm" in sys.modules` (several OTHER lazy litellm call sites exist that don't touch the async-client cache but could still enqueue log work)

## Also removed, not just relabelled
- `chat.py`'s `_prepay_litellm_import` (added under #3768 specifically to *relabel* the cost `run_async` used to force unconditionally, for measurement). Removing prepay alone, without removing the eager-import root cause, would have just moved the same cost to the same place inside `run_async` — not eliminated it (flagged explicitly by lead-coder before I started). It's deleted here because the root cause it was measuring is gone.
- The now-permanently-dead `"client-prep:litellm-import"` startup-timing stage — left in place it would always report `0.00`, which this module's own stated convention reads as "measured and fast", not "no longer exists to measure" (the exact `first-frame` trap this module already fixed once).

## Structural guards, not a one-time grep
The close-scoping fix's real invariant — "`ensure_litellm_ready()` always runs before any litellm async client is created" — was first verified by grepping today's call sites by name. Per review, that's the exact blind-spot class this session hit repeatedly: a search shaped around expected names misses a differently-named site. Two new AST guards in `test_litellm_lazy_load.py` (mirroring the existing #1190 guard for `litellm.acompletion`):
- `litellm.aembedding` restricted to its one real call site (`LiteLLMEmbeddingProvider._aembedding_bounded`)
- `get_async_httpx_client` (the low-level bypass) banned from `src/reyn/` entirely

Both **falsify-verified RED** against a synthetic violation (temporarily inserted, confirmed both gates fire, then removed) before being confirmed green — not just "added and green."

**Residual risk, documented in-file, deliberately accepted rather than closed**: these gates still enumerate litellm's client-creating APIs *by name*. Routing every lazy litellm call site through `ensure_litellm_ready()` unconditionally (closing this for good) would also force it onto sites that only touch static data (`model_budget.py`/`model_cost_rate.py`/`pricing.py`/`core/registry/client.py`/`core/op_runtime/web.py` — cost maps, token counting, ssl verify; none create an async client, verified by grep), which risks pulling the import back toward startup for paths that never needed it — the exact regression this PR closes. A future litellm API under a different name would not be caught by these two gates; the in-file comment says so and where to add it.

## A pre-existing test's setup, corrected — not weakened (full distinction, since changing an existing test's setup is a common place gates quietly weaken)
`test_run_async_closes_cached_litellm_async_client` (#2787) failed after this change: its setup created a litellm async client via the low-level `get_async_httpx_client` directly, **bypassing `ensure_litellm_ready()`** — a bypass that already existed before this PR, not something introduced here.
- **What changed**: setup only (added an `ensure_litellm_ready()` call before client creation). The assertion (`session.closed is True`) is unchanged.
- **Was the old path ever a real production path?** No. Verified by grepping every other lazy `import litellm`/`from litellm...` site in `src/reyn/` (`model_budget.py`, `model_cost_rate.py`, `pricing.py`, `core/registry/client.py`, `core/op_runtime/web.py`, `router_loop.py`, `services/compaction/engine.py`) for `get_async_httpx_client`/`acompletion`/`aembedding` — none call them; they only touch static litellm data. The only two production paths that create a real async client (`recorded_acompletion`, the embedding provider) both call `ensure_litellm_ready()` first, confirmed by source and by the new AST guards above.
- **Why did the old test pass before this PR, then?** Because the OLD implementation's baseline capture was unconditional and eager (at `run_async`'s own top) — it never depended on which path the coroutine took. The bypass "worked" only because the old code didn't care about the distinction it's now testing. The old test was not weakened by this change; it was never exercising a path production actually takes, and that fact was invisible until this refactor made the dependency real.

## Test plan
- [x] `pytest tests/ -k "llm or litellm or startup or 3671 or 3434 or 2787"` — 497 passed, 8 skipped (unrelated).
- [x] Required gate: `test_run_async_never_imports_litellm_without_an_llm_call` (subprocess-based, matches `test_litellm_lazy_load.py`'s existing pattern) — green. This is the one witness that actually pins the fix; every other test here stays green whether litellm is imported eagerly or lazily.
- [x] #3434's own regression test (`test_run_async_does_not_close_a_client_created_outside_its_own_call`) — still green.
- [x] #2787's own regression test — still green, setup corrected to the real call shape (see distinction above).
- [x] Two new AST guards falsify-verified RED against a synthetic violation, then confirmed green.
- [x] Full `pytest` from repo root — 10123 passed, 49 skipped, 0 failed.
- [x] `ruff check src tests` — clean.
- [x] `python scripts/test_tier_audit.py --strict` on all changed/new test files — clean.
- [x] `python scripts/verify_module_docstrings.py` on changed src files — OK.
- [x] Doc-sync: no `docs/` files referenced the removed functions/stage name (grep-confirmed).
- [x] Rebased onto current `origin/main` — no conflicts.

---

**[lead-coder] change request（マージ前）**

- [x] `_baseline_generation` の隣に前提を一文で: 「`run_async` は `asyncio.run` を使うため入れ子・並行にならない ∴ generation は 1 つで足りる」。将来 `run_async` がスレッドから呼ばれる形になったら、この前提が最初に壊れる


⚪ **lead-coder 実測**: `litellm_bootstrap.py:80-89` に前提と、壊れる条件（別 OS スレッドからの並行呼び出しで generation が競合する）まで記載されている。
