### PR TITLE
fix(#3671): defer litellm-touching engine construction out of Session.__init__

### DIFF
--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -20,7 +20,7 @@ delegates via :meth:`force_compact_now` (P3).
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Callable, cast
+from typing import TYPE_CHECKING, Callable
 
 from reyn.config import CompactionConfig
 from reyn.core.events.events import EventLog
@@ -105,11 +105,6 @@ def _turn_to_compactor_input(
     return out
 
 
-#: Sentinel for "the compaction engine has not been built yet" (#3671
-#: follow-up) — see :attr:`CompactionController._engine`.
-_ENGINE_UNSET = object()
-
-
 class CompactionController:
     """Background head/body/tail compaction service.
 
@@ -185,7 +180,7 @@ class CompactionController:
         self._history_access = history_access
         self._latest_summary = latest_summary
         self._compaction_engine_factory = compaction_engine_factory
-        self.__engine_cache: "CompactionEngine | object" = _ENGINE_UNSET
+        self.__engine_cache: "CompactionEngine | None" = None
         self._append_history = history_appender
         self._make_summary_message = make_summary_message
         self._render_summary = render_summary
@@ -201,15 +196,18 @@ class CompactionController:
         methods below, and the couple of call sites elsewhere in this
         package that read ``controller._engine`` directly (a private
         attribute, tolerated pre-existing style) — keeps working with no
-        change, since attribute access transparently triggers this."""
-        if self.__engine_cache is _ENGINE_UNSET:
+        change, since attribute access transparently triggers this.
+
+        ``None`` (not a separate sentinel, unlike ``RouterHostAdapter``'s
+        ``_TURN_BUDGET_ENGINE_UNSET``) means "not built yet" here — safe
+        because, unlike ``TurnBudgetEngine`` (whose factory can legitimately
+        return ``None`` for a tiny-context model that cannot support
+        force-close), ``CompactionEngine``'s factory has no "built but
+        absent" case: every constructed engine is real, so ``None`` has
+        exactly one meaning and mypy narrows it without a cast."""
+        if self.__engine_cache is None:
             self.__engine_cache = self._compaction_engine_factory()
-        # The sentinel check above is the narrowing; mypy can't follow an
-        # identity comparison against a plain `object()` singleton, so this
-        # cast states what the check already guarantees (unlike
-        # TurnBudgetEngine's factory, CompactionEngine's has no legitimate
-        # "built but absent" case — every non-UNSET value is a real engine).
-        return cast(CompactionEngine, self.__engine_cache)
+        return self.__engine_cache
 
     # ── internal compaction logic ─────────────────────────────────────────────
 

--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -105,6 +105,11 @@ def _turn_to_compactor_input(
     return out
 
 
+#: Sentinel for "the compaction engine has not been built yet" (#3671
+#: follow-up) — see :attr:`CompactionController._engine`.
+_ENGINE_UNSET = object()
+
+
 class CompactionController:
     """Background head/body/tail compaction service.
 
@@ -121,9 +126,20 @@ class CompactionController:
     latest_summary:
         Zero-argument callable that returns the most recent ``"summary"``
         :class:`~reyn.runtime.chat_message.ChatMessage`, or ``None``.
-    compaction_engine:
+    compaction_engine_factory:
+        Zero-argument callable returning the
         :class:`~reyn.services.compaction.engine.CompactionEngine`
         that owns the single LLM call (PR-N3: OS-internal Python helper).
+        #3671 follow-up: a FACTORY, not the built engine — ``CompactionEngine
+        .__init__`` touches litellm's model catalog (``estimate_tokens`` /
+        ``get_max_input_tokens``) to measure its budgets; calling it eagerly
+        at Session construction put that cost on the TUI startup path for a
+        value nothing reads until compaction actually triggers, mid-turn.
+        Called AT MOST ONCE, on first reference to :attr:`_engine` (a lazy
+        property, single-owner cache) — every existing reader (internal and
+        the couple of external private-attribute reads this class has always
+        tolerated) keeps working unchanged, since attribute access transparently
+        triggers the property.
     history_appender:
         Callable ``(ChatMessage) -> None`` that appends a message to the
         persisted history.  Wraps ``Session._append_history``.
@@ -153,7 +169,7 @@ class CompactionController:
         config: CompactionConfig,
         history_access: Callable[[], list[ChatMessage]],
         latest_summary: Callable[[], ChatMessage | None],
-        compaction_engine: CompactionEngine,
+        compaction_engine_factory: "Callable[[], CompactionEngine]",
         history_appender: Callable[[ChatMessage], None],
         make_summary_message: Callable[..., ChatMessage],
         render_summary: Callable[[dict], str],
@@ -168,12 +184,27 @@ class CompactionController:
         self._threat_scan = threat_scan
         self._history_access = history_access
         self._latest_summary = latest_summary
-        self._engine = compaction_engine
+        self._compaction_engine_factory = compaction_engine_factory
+        self.__engine_cache: "CompactionEngine | object" = _ENGINE_UNSET
         self._append_history = history_appender
         self._make_summary_message = make_summary_message
         self._render_summary = render_summary
         self._merge_action_usage = merge_action_usage
         self._compacting: bool = False
+
+    @property
+    def _engine(self) -> CompactionEngine:
+        """The compaction engine, built via the factory on first reference
+        and cached (single owner, computed at most once — #3671 follow-up).
+
+        A property, not a plain attribute: every existing reader — internal
+        methods below, and the couple of call sites elsewhere in this
+        package that read ``controller._engine`` directly (a private
+        attribute, tolerated pre-existing style) — keeps working with no
+        change, since attribute access transparently triggers this."""
+        if self.__engine_cache is _ENGINE_UNSET:
+            self.__engine_cache = self._compaction_engine_factory()
+        return self.__engine_cache
 
     # ── internal compaction logic ─────────────────────────────────────────────
 

--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -20,7 +20,7 @@ delegates via :meth:`force_compact_now` (P3).
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, cast
 
 from reyn.config import CompactionConfig
 from reyn.core.events.events import EventLog
@@ -204,7 +204,12 @@ class CompactionController:
         change, since attribute access transparently triggers this."""
         if self.__engine_cache is _ENGINE_UNSET:
             self.__engine_cache = self._compaction_engine_factory()
-        return self.__engine_cache
+        # The sentinel check above is the narrowing; mypy can't follow an
+        # identity comparison against a plain `object()` singleton, so this
+        # cast states what the check already guarantees (unlike
+        # TurnBudgetEngine's factory, CompactionEngine's has no legitimate
+        # "built but absent" case — every non-UNSET value is a real engine).
+        return cast(CompactionEngine, self.__engine_cache)
 
     # ── internal compaction logic ─────────────────────────────────────────────
 

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -25,6 +25,15 @@ from reyn.runtime.services.mcp_cache_file import (
 from reyn.runtime.session_pure import merge_memory_indexes
 from reyn.security.permissions.capability_profile import compose_narrowing_mappings
 
+#: Sentinel for "the turn_budget engine has not been computed yet" — distinct
+#: from a legitimate `None` result (a tiny-context model that genuinely
+#: cannot support force-close, `try_build_default_turn_budget_engine`'s own
+#: contract). #3671 follow-up: the engine used to be built EAGERLY at Session
+#: construction, which forces `TurnBudgetEngine.__init__`'s litellm catalog
+#: lookup (`get_max_input_tokens`) onto the TUI startup path — before any
+#: turn has run and the value is needed. See `_ensure_turn_budget_engine`.
+_TURN_BUDGET_ENGINE_UNSET = object()
+
 if TYPE_CHECKING:
     from reyn.runtime.router_op_context import RouterOpContextSource
 
@@ -410,15 +419,21 @@ class RouterHostAdapter:
         # When None, only the user-global ~/.reyn/config.yaml is watched.
         # Session passes the project root so all 3 tiers are covered.
         project_root: Path | None = None,
-        # #1092 PR-F1 (chat activation): the shared turn_budget engine the chat
-        # axis budgets against. Built by Session via
-        # build_default_turn_budget_engine off the CompactionEngine's RESOLVED
-        # model (#1172-safe). Sole consumer (for now) is wrap_up_output_reserve —
-        # which hard-caps the force-close wrap-up call's output. None = no engine
-        # (legacy / test paths) → no cap (== pre-PR-F behaviour). ADDITIVE: chat
-        # never calls _force_close_call until the F2 handoff lands, so wiring the
-        # reserve here is inert until then.
-        turn_budget_engine: Any = None,
+        # #1092 PR-F1 (chat activation): builds the shared turn_budget engine
+        # the chat axis budgets against — off the CompactionEngine's RESOLVED
+        # model (#1172-safe). Sole consumer (for now) is wrap_up_output_reserve
+        # — which hard-caps the force-close wrap-up call's output. `None` = no
+        # engine (legacy / test paths) → no cap (== pre-PR-F behaviour).
+        # ADDITIVE: chat never calls _force_close_call until the F2 handoff
+        # lands, so wiring the reserve here is inert until then.
+        #
+        # #3671 follow-up: a FACTORY, not the built engine — see
+        # `_ensure_turn_budget_engine`. `try_build_default_turn_budget_engine`
+        # (the production factory Session passes) touches litellm's model
+        # catalog; calling it here at construction put that touch on the TUI
+        # startup path even though the value is not needed until the first
+        # force-close check, which only happens mid-turn.
+        turn_budget_engine_factory: "Callable[[], Any] | None" = None,
         # #1468: cooperative turn-cancel signal. Session passes
         # self._is_turn_cancel_requested; test hosts pass None (= never cancel).
         # run_loop polls via getattr(host, "_is_turn_cancel_requested", None).
@@ -433,7 +448,8 @@ class RouterHostAdapter:
         self._put_outbox_in = put_outbox_inputs
         self._live_sid_in = live_session_id_inputs
         self._threat_scan = threat_scan
-        self._turn_budget_engine = turn_budget_engine
+        self._turn_budget_engine_factory = turn_budget_engine_factory
+        self._turn_budget_engine: Any = _TURN_BUDGET_ENGINE_UNSET
         self._turn_cancel_fn = turn_cancel_fn  # #1468
         self._agent_name = agent_name
         self._agent_role = agent_role
@@ -571,8 +587,23 @@ class RouterHostAdapter:
         and force-closes only at the last-resort floor-exhausted terminal (the F2
         handoff). This is a deliberate per-axis architectural choice
         (failure-mode separation), NOT a missing proactive trigger."""
-        engine = self._turn_budget_engine
+        engine = self._ensure_turn_budget_engine()
         return engine.budget.output_reserve if engine is not None else None
+
+    def _ensure_turn_budget_engine(self) -> Any:
+        """The turn_budget engine, computing it via the factory on first
+        reference and caching the result (single owner, computed at most
+        once — #3671 follow-up).
+
+        A cached ``None`` (a tiny-context model that genuinely cannot
+        support force-close, per ``try_build_default_turn_budget_engine``'s
+        own contract) is a valid, permanent answer — distinguished from
+        "not computed yet" by the ``_TURN_BUDGET_ENGINE_UNSET`` sentinel, not
+        by ``None`` itself."""
+        if self._turn_budget_engine is _TURN_BUDGET_ENGINE_UNSET:
+            factory = self._turn_budget_engine_factory
+            self._turn_budget_engine = factory() if factory is not None else None
+        return self._turn_budget_engine
 
     def set_turn_budget_engine(self, engine: Any) -> None:
         """#1752: swap the chat turn_budget engine (rebuild-on-/model-switch).
@@ -583,6 +614,11 @@ class RouterHostAdapter:
         and rewires it here; ``wrap_up_output_reserve`` reads it fresh each turn,
         so the swap takes effect on the next turn. ``None`` (small-context model
         that cannot satisfy the force-close floor) keeps force-close inert.
+
+        Sets the CACHED value directly (not the factory) — this always wins
+        over the lazy factory: once called, :meth:`_ensure_turn_budget_engine`
+        finds ``self._turn_budget_engine`` no longer ``_TURN_BUDGET_ENGINE_UNSET``
+        and never invokes the factory (stale or not) again.
         """
         self._turn_budget_engine = engine
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -3725,13 +3725,28 @@ class Session:
         # #1092 PR-F1: turn_budget engine off the RESOLVED model. Making
         # try_build_* raise instead of return None crashes __init__ for
         # small-context models instead of degrading (session-construction.md#chat-turn_budget-engine-none-on-small-context-never-raise-1092-pr-f1).
-        from reyn.services.turn_budget import try_build_default_turn_budget_engine
-        _chat_turn_budget_engine = try_build_default_turn_budget_engine(
-            self._resolver.resolve(self.model).model,
-            use_chars4=getattr(self._compaction, "use_chars4_estimate", False),
-            # #3580: operator-tunable offload ceiling feeds the layer-1 reserve.
-            max_inline_bytes=self._offload_config.max_inline_bytes,
-        )
+        #
+        # #3671 follow-up: a DEFERRED closure (the same "*_fn kept verbatim,
+        # closing over self, resolved at call time" family this docstring
+        # already names above for RouterOpContextSource/live_session_id_fn),
+        # not an eager call. try_build_default_turn_budget_engine touches
+        # litellm's model catalog (get_max_input_tokens) — calling it here
+        # unconditionally put that cost on EVERY session construction, i.e.
+        # the TUI startup path, for a value nothing reads until the first
+        # force-close check mid-turn (owner real-machine measurement: #3671,
+        # `tui-boot` inflated 2.27s -> 6.49s once #3780 stopped prepaying the
+        # import earlier). `RouterHostAdapter._ensure_turn_budget_engine`
+        # calls this at most once, on first reference — try_build_*'s own
+        # contract (None for a small-context model, never a raise) is
+        # unchanged, just realized lazily instead of at construction.
+        def _build_chat_turn_budget_engine() -> Any:
+            from reyn.services.turn_budget import try_build_default_turn_budget_engine
+            return try_build_default_turn_budget_engine(
+                self._resolver.resolve(self.model).model,
+                use_chars4=getattr(self._compaction, "use_chars4_estimate", False),
+                # #3580: operator-tunable offload ceiling feeds the layer-1 reserve.
+                max_inline_bytes=self._offload_config.max_inline_bytes,
+            )
 
         # #3607: the ONE chat-router op-context supplier for this Session.
         # Both entry points that hand an OpContext to a chat-router op —
@@ -3844,7 +3859,9 @@ class Session:
             handle_chat_limit_checkpoint=self._handle_chat_limit_checkpoint,
             safety_extensions=self._safety_extensions,
             # #1092 PR-F1: the chat turn_budget engine (resolved-model, asserted).
-            turn_budget_engine=_chat_turn_budget_engine,
+            # #3671 follow-up: a factory, not the built engine — see the
+            # closure above.
+            turn_budget_engine_factory=_build_chat_turn_budget_engine,
             # FP-0050 / #1822 S2: content-threat scan + fence config.
             threat_scan=self._safety.threat_scan,
             op_context_source=self._router_op_context_source,  # #3607
@@ -4031,14 +4048,17 @@ class Session:
             project_dir_fn=lambda: self._workspace_base_dir or Path.cwd(),
         )
 
-        compaction_controller = CompactionController(
-            event_log=self._chat_events,
-            config=self._compaction,
-            # FP-0050/#1822 S3 (#1820): secret-redact turn text before summary.
-            threat_scan=self._safety.threat_scan,
-            history_access=lambda: self.history,
-            latest_summary=self._latest_summary,
-            compaction_engine=CompactionEngine(
+        # #3671 follow-up: a DEFERRED closure, not an eager construction —
+        # same reasoning and same family as _build_chat_turn_budget_engine
+        # above. CompactionEngine.__init__ touches litellm's model catalog
+        # (estimate_tokens/get_max_input_tokens) to measure its budgets;
+        # building it here unconditionally put that cost on EVERY session
+        # construction (the TUI startup path) for a value nothing reads
+        # until compaction actually triggers, mid-turn.
+        # CompactionController._engine (a lazy property) calls this at most
+        # once, on first reference.
+        def _build_chat_compaction_engine() -> CompactionEngine:
+            return CompactionEngine(
                 # #1172: pass a resolved model CLASS, not the raw string —
                 # unresolved, litellm raises BadRequestError and every
                 # compaction trigger fails (session-construction.md#compactionengine-model-resolved-class-not-the-cosmetic-label-1172).
@@ -4050,7 +4070,16 @@ class Session:
                 recorder=self._budget_tracker,
                 # #1190 stage (iii) Part 4: attribute chat compaction to this session's agent.
                 recorder_agent=self.agent_name,
-            ),
+            )
+
+        compaction_controller = CompactionController(
+            event_log=self._chat_events,
+            config=self._compaction,
+            # FP-0050/#1822 S3 (#1820): secret-redact turn text before summary.
+            threat_scan=self._safety.threat_scan,
+            history_access=lambda: self.history,
+            latest_summary=self._latest_summary,
+            compaction_engine_factory=_build_chat_compaction_engine,
             history_appender=self._append_history,
             make_summary_message=lambda rendered, structured, covers: ChatMessage(
                 role="summary",

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -211,6 +211,13 @@ def make_adapter(
         put_outbox_inputs=put_outbox_inputs,
         append_history=null_append_history,
         live_session_id_inputs=live_session_id_inputs,
-        turn_budget_engine=turn_budget_engine,
+        # #3671 follow-up: RouterHostAdapter takes a FACTORY now (computed at
+        # most once, on first reference — see its own module for why). This
+        # helper's own callers still pass an already-built engine value (or
+        # None), so wrap it in a trivial factory here rather than pushing the
+        # factory shape onto every call site.
+        turn_budget_engine_factory=(
+            (lambda: turn_budget_engine) if turn_budget_engine is not None else None
+        ),
         environment_backend=environment_backend,
     )

--- a/tests/_support/session.py
+++ b/tests/_support/session.py
@@ -30,6 +30,17 @@ def synthetic_t_max(t_max: int):
 
     Uses direct module-level replacement (the same pattern used in
     test_chat_compaction_engine_11axis.py) — no unittest.mock.
+
+    #3671 follow-up: CompactionEngine now builds LAZILY (on first reference
+    to ``CompactionController._engine``, a property) rather than eagerly at
+    Session construction. A caller whose with-block ends right after
+    construction (like this context manager's own docstring implies) no
+    longer covers the moment the patched value is actually read — prefer
+    ``make_session(..., monkeypatch=...)`` below, which keeps the patch live
+    for the whole calling test via pytest's own fixture, for any caller that
+    goes on to trigger compaction. This context manager is kept for
+    call sites (e.g. ``test_skill_invoke_3100.py``) that only need a
+    trivially-large t_max where the timing does not matter.
     """
     original = _mb.get_max_input_tokens
     _mb.get_max_input_tokens = lambda model, **kw: t_max  # type: ignore[assignment]
@@ -42,6 +53,7 @@ def synthetic_t_max(t_max: int):
 def make_session(
     tmp_path: Path,
     *,
+    monkeypatch: "object",
     t_max: int = 1_000_000,
     agent: Agent | None = None,
     state_log: StateLog | None = None,
@@ -109,18 +121,27 @@ def make_session(
     generation_store, journal = build_recovery(
         agent.agent_name, snapshot_path, state_log, "main",
     )
-    # Monkeypatch covers the engine's compute_budgets() call at Session init.
-    with synthetic_t_max(t_max):
-        return Session(
-            agent=agent,
-            generation_store=generation_store,
-            journal=journal,
-            output_language="en",
-            budget_tracker=bt,
-            state_log=state_log,
-            compaction_config=cfg,
-            snapshot_path=snapshot_path,
-        )
+    # Monkeypatch covers the engine's compute_budgets() call. #3671 follow-up:
+    # CompactionEngine now builds LAZILY (CompactionController._engine, a
+    # property, on first reference) rather than eagerly inside Session
+    # .__init__ — so the patch must stay live past construction, until
+    # whatever the CALLING TEST does with the session actually reads it.
+    # ``monkeypatch`` (the caller's own pytest fixture, required — every
+    # call site threads it through) restores at the calling TEST's
+    # teardown, so the patch covers the session's whole lifetime in that
+    # test: the lazy build stays lazy, genuinely exercised, wherever it
+    # happens to fire.
+    monkeypatch.setattr(_mb, "get_max_input_tokens", lambda model, **kw: t_max)
+    return Session(
+        agent=agent,
+        generation_store=generation_store,
+        journal=journal,
+        output_language="en",
+        budget_tracker=bt,
+        state_log=state_log,
+        compaction_config=cfg,
+        snapshot_path=snapshot_path,
+    )
 
 
 def push(session: Session, role: str, text: str) -> None:

--- a/tests/test_1128_step3_token_budget_headtail.py
+++ b/tests/test_1128_step3_token_budget_headtail.py
@@ -106,35 +106,39 @@ def test_clean_config_no_warning() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _make_session_with_t_max(tmp_path: Path, t_max: int):
+def _make_session_with_t_max(tmp_path: Path, monkeypatch, t_max: int):
     """Return a Session with a synthetic T_max.
 
     ``section_caps_spec_tokens=0`` keeps B_M positive for small T_max.
     ``use_chars4_estimate=True`` makes token counting deterministic.
+
+    #3671 follow-up: takes the caller's ``monkeypatch`` fixture rather than
+    manually saving/restoring ``get_max_input_tokens`` — CompactionEngine now
+    builds LAZILY (``CompactionController._engine``, a property, on first
+    reference) rather than eagerly at Session construction, so a patch that
+    un-does itself the moment this function returns would go stale before
+    the caller ever triggers the lazy build. ``monkeypatch`` restores at the
+    CALLING TEST's teardown instead, keeping the patch live for whatever
+    that test does with the session.
     """
     from reyn.config import CompactionConfig
     from reyn.core.events.state_log import StateLog
     from reyn.runtime.budget.budget import BudgetTracker, CostConfig
     from reyn.runtime.session import Session
 
-    original = _mb.get_max_input_tokens
-    _mb.get_max_input_tokens = lambda model, **kw: t_max  # type: ignore[assignment]
-    try:
-        session = make_session(
-            agent_name="default",
-            agent_role="",
-            output_language="en",
-            budget_tracker=BudgetTracker(CostConfig()),
-            state_log=StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl"),
-            compaction_config=CompactionConfig(
-                use_chars4_estimate=True,
-                section_caps_spec_tokens=0,
-            ),
-            snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
-        )
-    finally:
-        _mb.get_max_input_tokens = original
-    return session
+    monkeypatch.setattr(_mb, "get_max_input_tokens", lambda model, **kw: t_max)
+    return make_session(
+        agent_name="default",
+        agent_role="",
+        output_language="en",
+        budget_tracker=BudgetTracker(CostConfig()),
+        state_log=StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl"),
+        compaction_config=CompactionConfig(
+            use_chars4_estimate=True,
+            section_caps_spec_tokens=0,
+        ),
+        snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
+    )
 
 
 def _push(session, role: str, content: str) -> None:
@@ -155,7 +159,7 @@ def _push(session, role: str, content: str) -> None:
 _CONTENT_80TOK = "X" * 320
 
 
-def test_build_history_small_chat_returns_all_turns_raw(tmp_path) -> None:
+def test_build_history_small_chat_returns_all_turns_raw(tmp_path, monkeypatch) -> None:
     """Tier 2: a small chat (total tokens < effective_trigger) returns ALL turns
     without elide, and no turn appears more than once.
 
@@ -164,7 +168,7 @@ def test_build_history_small_chat_returns_all_turns_raw(tmp_path) -> None:
     trigger threshold.  No duplication can occur from this branch.
     """
     # T_max=2800 → effective_trigger≈489.  3 turns × 80 tokens = 240 < 489.
-    session = _make_session_with_t_max(tmp_path, t_max=2800)
+    session = _make_session_with_t_max(tmp_path, monkeypatch, t_max=2800)
     for text in ["alpha", "beta", "gamma"]:
         _push(session, "user", text)
 
@@ -179,7 +183,7 @@ def test_build_history_small_chat_returns_all_turns_raw(tmp_path) -> None:
     )
 
 
-def test_build_history_large_chat_elides_middle(tmp_path) -> None:
+def test_build_history_large_chat_elides_middle(tmp_path, monkeypatch) -> None:
     """Tier 2: a large chat (total tokens > effective_trigger) elides the middle —
     head is present, tail is present, and at least one middle turn is absent.
 
@@ -189,7 +193,7 @@ def test_build_history_large_chat_elides_middle(tmp_path) -> None:
     default-independent: changing hot_list_n or other SP-affecting defaults
     does not change whether elide fires.
     """
-    session = _make_session_with_t_max(tmp_path, t_max=2800)
+    session = _make_session_with_t_max(tmp_path, monkeypatch, t_max=2800)
     texts = [f"turn-{i}:" + _CONTENT_80TOK for i in range(30)]
     for i, text in enumerate(texts):
         _push(session, "user" if i % 2 == 0 else "assistant", text)

--- a/tests/test_3299_p4_intervention_restore_qa.py
+++ b/tests/test_3299_p4_intervention_restore_qa.py
@@ -160,7 +160,7 @@ def test_restored_free_text_answer_also_one_entry_with_both_qa() -> None:
 # ── Gate 3: LLM payload unchanged ────────────────────────────────────────────
 
 
-def test_llm_payload_unchanged_by_new_intervention_meta_keys(tmp_path: Path) -> None:
+def test_llm_payload_unchanged_by_new_intervention_meta_keys(tmp_path: Path, monkeypatch) -> None:
     """Tier 2: ``RouterHistoryBuffer.build_history`` (the actual wire-dict
     builder RouterLoop sends to the provider) produces a BYTE-IDENTICAL
     result whether or not the history carries the new
@@ -184,12 +184,12 @@ def test_llm_payload_unchanged_by_new_intervention_meta_keys(tmp_path: Path) -> 
         INTERVENTION_ANSWER_META_KEY: "Yes",
     }
 
-    session_bare = _make_router_session(tmp_path / "bare")
+    session_bare = _make_router_session(tmp_path / "bare", monkeypatch=monkeypatch)
     session_bare.history.append(ChatMessage(role="user", content="", meta=bare_meta))
     session_bare.history.append(ChatMessage(role="assistant", content="Deploying now."))
     bare_payload = session_bare._history_buffer.build_history()
 
-    session_enriched = _make_router_session(tmp_path / "enriched")
+    session_enriched = _make_router_session(tmp_path / "enriched", monkeypatch=monkeypatch)
     session_enriched.history.append(ChatMessage(role="user", content="", meta=enriched_meta))
     session_enriched.history.append(ChatMessage(role="assistant", content="Deploying now."))
     enriched_payload = session_enriched._history_buffer.build_history()

--- a/tests/test_agui_reasoning_map_p6a.py
+++ b/tests/test_agui_reasoning_map_p6a.py
@@ -170,7 +170,6 @@ def _mk_host(reasoning_config, *, outbox: list, history: list) -> RouterHostAdap
         live_session_id_inputs=LiveSessionIdInputs(
             session_id=None, live_session_id_fn=None,
         ),
-        turn_budget_engine=None,
         environment_backend=None,
         reasoning_config=reasoning_config,
         reasoning_continuity_section_fn=lambda: "",

--- a/tests/test_chat_compaction_engine_11axis.py
+++ b/tests/test_chat_compaction_engine_11axis.py
@@ -831,7 +831,7 @@ def test_force_compact_now_single_pass_no_race_recovery() -> None:
         config=CompactionConfig(use_chars4_estimate=True),
         history_access=_big_history,
         latest_summary=lambda: None,
-        compaction_engine=engine,
+        compaction_engine_factory=lambda: engine,
         history_appender=lambda m: None,
         make_summary_message=lambda rendered, structured, covers: ChatMessage(
             role="summary", content=rendered, seq=0,

--- a/tests/test_chat_router_modelspec_kwargs_1654.py
+++ b/tests/test_chat_router_modelspec_kwargs_1654.py
@@ -74,7 +74,7 @@ def _mk_host_with_kwargs():
         live_session_id_inputs=LiveSessionIdInputs(
             session_id=None, live_session_id_fn=None,
         ),
-        turn_budget_engine=None, environment_backend=None,
+        environment_backend=None,
     )
 
 

--- a/tests/test_compaction_controller_invariants.py
+++ b/tests/test_compaction_controller_invariants.py
@@ -85,7 +85,7 @@ def _make_controller(
         config=CompactionConfig(use_chars4_estimate=True),
         history_access=lambda: list(history),
         latest_summary=_latest_summary,
-        compaction_engine=engine,
+        compaction_engine_factory=lambda: engine,
         history_appender=history.append,
         make_summary_message=lambda rendered, structured, covers: ChatMessage(
             role="summary", content=rendered, seq=0,

--- a/tests/test_compaction_summary_preamble_1820.py
+++ b/tests/test_compaction_summary_preamble_1820.py
@@ -47,7 +47,7 @@ def _make_controller(history: list[ChatMessage]) -> tuple[CompactionController, 
         config=CompactionConfig(use_chars4_estimate=True),
         history_access=lambda: list(history),
         latest_summary=lambda: None,
-        compaction_engine=_SucceedingEngine(),
+        compaction_engine_factory=_SucceedingEngine,
         history_appender=history.append,
         make_summary_message=lambda rendered, structured, covers: ChatMessage(
             role="summary", content=rendered, seq=0,

--- a/tests/test_force_close_chat_handoff_1092.py
+++ b/tests/test_force_close_chat_handoff_1092.py
@@ -93,7 +93,7 @@ async def test_handoff_fires_installs_consolidation_and_converges(
     """Tier 3a: a forced overflow terminal drives the force-close handoff — it
     fires the `router_force_close_handoff` event, installs the consolidation, and
     the re-entry converges in ONE handoff (the by-construction backstop (a))."""
-    session = _make_session(tmp_path)  # viable T_max → force-close engine wired
+    session = _make_session(tmp_path, monkeypatch=monkeypatch)  # viable T_max → force-close engine wired
     for t in ("U1-old", "A1-old", "U2-old"):
         _push(session, "user" if t.startswith("U") else "assistant", t)
     _install_fake_loop(monkeypatch)
@@ -113,7 +113,7 @@ async def test_handoff_cap_raises_no_infinite_loop(tmp_path, monkeypatch) -> Non
     """Tier 3a: (cap=1 backstop) an irreducible turn (overflows even after
     consolidation) does NOT infinite-loop — after one handoff the cap raises the
     genuine dead-end. force_close fired exactly once."""
-    session = _make_session(tmp_path)  # viable T_max → force-close engine wired
+    session = _make_session(tmp_path, monkeypatch=monkeypatch)  # viable T_max → force-close engine wired
     _push(session, "user", "U1-old")
     _install_fake_loop(monkeypatch, always_overflow=True)
     events = _capture_events(session)
@@ -152,12 +152,12 @@ class _FailFirstLoop:
 
 
 @pytest.mark.asyncio
-async def test_wrap_up_bounded_fallback_fits(tmp_path) -> None:
+async def test_wrap_up_bounded_fallback_fits(tmp_path, monkeypatch) -> None:
     """Tier 2: when the richer wrap-up inputs overflow, the bounded fallback
     shrinks (through its decreasing candidates) until one fits and the
     consolidation is produced (wrap-up-fits — Fork 1's chat _force_close_call_
     with_retry analogue)."""
-    session = _make_session(tmp_path, t_max=2800)
+    session = _make_session(tmp_path, t_max=2800, monkeypatch=monkeypatch)
     for t in ("U1", "A1", "U2", "A2"):
         _push(session, "user" if t.startswith("U") else "assistant", t)
     loop = _FailFirstLoop(fail_first=2)
@@ -174,10 +174,10 @@ class _AlwaysOverflowWrapUp:
 
 
 @pytest.mark.asyncio
-async def test_wrap_up_sub_viable_raises(tmp_path) -> None:
+async def test_wrap_up_sub_viable_raises(tmp_path, monkeypatch) -> None:
     """Tier 2: if even summary-only overflows, the model is RUNTIME sub-viable →
     _force_close_wrap_up raises (the handoff loop surfaces it as a dead-end)."""
-    session = _make_session(tmp_path, t_max=2800)
+    session = _make_session(tmp_path, t_max=2800, monkeypatch=monkeypatch)
     _push(session, "user", "U1")
     with pytest.raises(ContextOverflowError):
         await session._loop_driver._force_close_wrap_up(_AlwaysOverflowWrapUp(), resolved_model="m")
@@ -187,12 +187,12 @@ async def test_wrap_up_sub_viable_raises(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_force_close_handoff_installs_covering_consolidation(tmp_path) -> None:
+async def test_force_close_handoff_installs_covering_consolidation(tmp_path, monkeypatch) -> None:
     """Tier 2: _force_close_handoff (running the REAL _force_close_wrap_up against
     a fake loop) installs a covers-all force-close summary (firing F2a's reset) —
     the consolidation reaches the slice and the covered raw turns are dropped; the
     P6 event fires."""
-    session = _make_session(tmp_path, t_max=2800)
+    session = _make_session(tmp_path, t_max=2800, monkeypatch=monkeypatch)
     session._append_history(_msg("user", "U1-covered"))
     session._append_history(_msg("assistant", "A1-covered"))
     events = _capture_events(session)

--- a/tests/test_force_close_covers_slice_1092.py
+++ b/tests/test_force_close_covers_slice_1092.py
@@ -40,11 +40,11 @@ def _append_force_close_summary(session, consolidation: str) -> ChatMessage:
 # ── the durable reset: covered raw head/tail dropped ─────────────────────────
 
 
-def test_force_close_consolidation_drops_covered_head_tail(tmp_path) -> None:
+def test_force_close_consolidation_drops_covered_head_tail(tmp_path, monkeypatch) -> None:
     """Tier 2: with a force-close consolidation as the latest summary, the slice
     is [consolidation bridge] only — the covered raw head/tail is dropped (the
     true reset), and the consolidation text reaches the prompt."""
-    session = _make_session(tmp_path)
+    session = _make_session(tmp_path, monkeypatch=monkeypatch)
     for t in ("U1-covered", "A1-covered", "U2-covered", "A2-covered"):
         _push(session, "user" if t.startswith("U") else "assistant", t)
     _append_force_close_summary(session, "CONSOLIDATED-ESSENCE")
@@ -56,11 +56,11 @@ def test_force_close_consolidation_drops_covered_head_tail(tmp_path) -> None:
         assert covered not in blob                  # covered raw head/tail dropped
 
 
-def test_post_consolidation_turns_retained_including_assistant(tmp_path) -> None:
+def test_post_consolidation_turns_retained_including_assistant(tmp_path, monkeypatch) -> None:
     """Tier 2: turns appended AFTER the consolidation are retained — including an
     assistant turn (seq=0). Pins the position-based (not seq>covers) filter: a
     seq filter would wrongly drop post-handoff assistant replies."""
-    session = _make_session(tmp_path)
+    session = _make_session(tmp_path, monkeypatch=monkeypatch)
     _push(session, "user", "U1-covered")
     _push(session, "assistant", "A1-covered")
     _append_force_close_summary(session, "CONSOL")
@@ -79,12 +79,12 @@ def test_post_consolidation_turns_retained_including_assistant(tmp_path) -> None
 # ── the gate: normal compaction summaries unaffected (byte-identical) ──────────
 
 
-def test_normal_compaction_summary_does_not_trigger_reset(tmp_path) -> None:
+def test_normal_compaction_summary_does_not_trigger_reset(tmp_path, monkeypatch) -> None:
     """Tier 2: a NORMAL compaction summary (no `consolidation` field) does NOT
     trigger the force-close reset — the raw turns still appear (head/tail+bridge
     behaviour unchanged). With a large T_max (no elide) all raw turns are
     returned, proving the reset branch did not fire."""
-    session = _make_session(tmp_path)  # default T_max huge → no elide
+    session = _make_session(tmp_path, monkeypatch=monkeypatch)  # default T_max huge → no elide
     _push(session, "user", "U1-raw")
     _push(session, "assistant", "A1-raw")
     session.history.append(ChatMessage(

--- a/tests/test_force_close_covers_through_seq_3599.py
+++ b/tests/test_force_close_covers_through_seq_3599.py
@@ -98,13 +98,13 @@ def _push_8_turns(session) -> None:
 
 
 @pytest.mark.asyncio
-async def test_top_tier_success_covers_matches_actually_fed_seqs(tmp_path) -> None:
+async def test_top_tier_success_covers_matches_actually_fed_seqs(tmp_path, monkeypatch) -> None:
     """Tier 2: when the FULL candidate (raw_middle + tail, no fallback) wins,
     covers_through_seq equals the max seq actually fed. #3658: ``head`` is
     still never fed, and here ``covers`` (== max of raw_middle+tail) advances
     past head's own seq, so head's span IS claimed-but-unfed and must be
     reported."""
-    session = _make_session(tmp_path, t_max=_T_MAX)
+    session = _make_session(tmp_path, t_max=_T_MAX, monkeypatch=monkeypatch)
     _push_8_turns(session)
     head, raw_middle, tail, _summary, seq_by_id = (
         session._history_buffer.decompose_history_for_retry()
@@ -137,7 +137,7 @@ async def test_top_tier_success_covers_matches_actually_fed_seqs(tmp_path) -> No
 
 @pytest.mark.asyncio
 async def test_tier2_fallback_does_not_overclaim_and_reports_the_drop(
-    tmp_path,
+    tmp_path, monkeypatch,
 ) -> None:
     """Tier 2: when the fallback shrinks to [summary + tail] (raw_middle
     dropped from the summarisation input), covers_through_seq must still
@@ -147,7 +147,7 @@ async def test_tier2_fallback_does_not_overclaim_and_reports_the_drop(
     raw_middle span must be reported so the loss is legible, not silently
     absorbed. #3658: covers also advances past head's own seq here, so
     head's span is claimed-but-unfed too, alongside raw_middle."""
-    session = _make_session(tmp_path, t_max=_T_MAX)
+    session = _make_session(tmp_path, t_max=_T_MAX, monkeypatch=monkeypatch)
     _push_8_turns(session)
     head, raw_middle, tail, _summary, seq_by_id = (
         session._history_buffer.decompose_history_for_retry()
@@ -183,7 +183,7 @@ async def test_tier2_fallback_does_not_overclaim_and_reports_the_drop(
 
 @pytest.mark.asyncio
 async def test_tier3_fallback_pins_covers_to_prior_watermark_not_next_seq(
-    tmp_path,
+    tmp_path, monkeypatch,
 ) -> None:
     """Tier 2: THE #3599 regression case — when even [summary + tail]
     overflows and the fallback lands on [summary] ALONE — nothing new fed to
@@ -200,7 +200,7 @@ async def test_tier3_fallback_pins_covers_to_prior_watermark_not_next_seq(
     prev_cover == 0, nothing new got fed). ``head`` itself is asserted
     non-empty below so the absence is provably the intersection collapsing,
     not head having nothing to offer in the first place."""
-    session = _make_session(tmp_path, t_max=_T_MAX)
+    session = _make_session(tmp_path, t_max=_T_MAX, monkeypatch=monkeypatch)
     _push_8_turns(session)
     head, raw_middle, tail, _summary, seq_by_id = (
         session._history_buffer.decompose_history_for_retry()

--- a/tests/test_llm_run_async_client_cache_scope_3434.py
+++ b/tests/test_llm_run_async_client_cache_scope_3434.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 import sys
 import textwrap
+from pathlib import Path
 
 from reyn.llm.llm import run_async
 
@@ -92,6 +93,62 @@ def test_run_async_never_imports_litellm_without_an_llm_call(out_of_process_reyn
             return "done"
 
         assert run_async(_llm_free()) == "done"
+        assert "litellm" not in sys.modules, sorted(
+            m for m in sys.modules if "litellm" in m
+        )
+        print("OK")
+        """
+    env = {**os.environ, "PYTHONPATH": out_of_process_reyn}
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_constructing_a_session_never_imports_litellm(tmp_path, out_of_process_reyn) -> None:
+    """Tier 2b: #3671 follow-up — widens the gate above, which the owner's
+    real-machine re-measurement caught as too narrow (issue #3671:
+    ``tui-boot`` 2.27s -> 6.49s after #3780 landed).
+
+    The gate above drives `run_async` with a synthetic `_llm_free()`
+    coroutine that never constructs a `Session` — so it could not see
+    litellm being imported at SESSION CONSTRUCTION time (`Session.__init__`
+    unconditionally builds a `TurnBudgetEngine`, which resolves
+    `get_max_input_tokens` against litellm's model catalog — see
+    `services/turn_budget/engine.py`). A real interactive TUI session always
+    constructs a `Session` during startup (`chat.py`'s `_background_attach`
+    -> `registry.attach` -> the session factory), so this — not the
+    synthetic no-op — is the shape #3671's win actually needs to hold for.
+
+    Real `Session` (via `tests._support.agent_session.make_session`, the
+    same helper 196+ other test files use — no mocks), constructed but
+    never run (`.run()` is a separate, later step; this isolates
+    CONSTRUCTION specifically). Subprocess, same reasoning as the gate
+    above: `sys.modules` must be virgin for the assertion to mean anything.
+    """
+    script = f"""
+        import sys
+        sys.path.insert(0, {str(Path(out_of_process_reyn).parent)!r})
+        from pathlib import Path
+        from tests._support.agent_session import make_session
+
+        assert "litellm" not in sys.modules, (
+            "litellm was already imported before construction even ran — "
+            "broken test setup, not what this test means to check"
+        )
+
+        make_session(
+            agent_name="probe",
+            agent_role="test",
+            output_language="en",
+            model="claude-sonnet",
+            snapshot_path=Path({str(tmp_path)!r}) / "snap.json",
+        )
         assert "litellm" not in sys.modules, sorted(
             m for m in sys.modules if "litellm" in m
         )

--- a/tests/test_reasoning_integration_1652.py
+++ b/tests/test_reasoning_integration_1652.py
@@ -80,7 +80,6 @@ def _mk_host(reasoning_config, *, outbox: list, history: list, section: str = ""
         live_session_id_inputs=LiveSessionIdInputs(
             session_id=None, live_session_id_fn=None,
         ),
-        turn_budget_engine=None,
         environment_backend=None,
         reasoning_config=reasoning_config,
         reasoning_continuity_section_fn=lambda: section,

--- a/tests/test_retry_loop_chat_wiring_1125.py
+++ b/tests/test_retry_loop_chat_wiring_1125.py
@@ -43,7 +43,9 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _make_session(tmp_path: Path, *, t_max: int = 1_000_000) -> Session:
+def _make_session(
+    tmp_path: Path, monkeypatch: "pytest.MonkeyPatch", *, t_max: int = 1_000_000
+) -> Session:
     """Create a Session with a synthetic T_max controlling effective_trigger.
 
     #1128 step 3: slicing is token-budget based (not turn-count).
@@ -60,6 +62,16 @@ def _make_session(tmp_path: Path, *, t_max: int = 1_000_000) -> Session:
       head_budget≈74, tail_budget≈112, effective_trigger≈489.
     Turns of content ``'X'*320`` each cost 80 tokens via chars4.  With 8 such
     turns (total=640 > 489), elide fires.  head=[t0], tail=[t7], middle=[t1-t6].
+
+    #3671 follow-up: takes the caller's ``monkeypatch`` fixture rather than
+    manually saving/restoring ``get_max_input_tokens`` — CompactionEngine now
+    builds LAZILY (``CompactionController._engine``, a property, on first
+    reference) rather than eagerly inside ``Session.__init__``, so a patch
+    that un-does itself the moment this function returns would go stale
+    before the caller ever triggers the lazy build. ``monkeypatch`` restores
+    at the CALLING TEST's teardown instead — the patch stays live for
+    whatever that test does with the session, matching the window the real
+    (unpatched) value would actually be read across.
     """
     import reyn.llm.model_budget as _mb
 
@@ -70,21 +82,16 @@ def _make_session(tmp_path: Path, *, t_max: int = 1_000_000) -> Session:
         use_chars4_estimate=True,  # deterministic offline token counts
         section_caps_spec_tokens=0,  # keeps B_M positive for small T_max
     )
-    original = _mb.get_max_input_tokens
-    _mb.get_max_input_tokens = lambda model, **kw: t_max  # type: ignore[assignment]  # noqa: E501
-    try:
-        session = make_session(
-            agent_name="default",
-            agent_role="",
-            output_language="en",
-            budget_tracker=bt,
-            state_log=state_log,
-            compaction_config=cfg,
-            snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
-        )
-    finally:
-        _mb.get_max_input_tokens = original
-    return session
+    monkeypatch.setattr(_mb, "get_max_input_tokens", lambda model, **kw: t_max)
+    return make_session(
+        agent_name="default",
+        agent_role="",
+        output_language="en",
+        budget_tracker=bt,
+        state_log=state_log,
+        compaction_config=cfg,
+        snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
+    )
 
 
 # Content that yields exactly 80 tokens per turn via use_chars4_estimate=True.
@@ -101,7 +108,7 @@ def _push(session: Session, role: str, text: str) -> None:
 # ── _decompose_history_for_retry correctness ─────────────────────────────────
 
 
-def test_decompose_slices_head_raw_middle_tail(tmp_path) -> None:
+def test_decompose_slices_head_raw_middle_tail(tmp_path, monkeypatch) -> None:
     """Tier 2: when total tokens > effective_trigger, decomposition produces
     non-empty head, raw_middle, and tail, and head + raw_middle + tail is a
     lossless in-order partition of all turns (no dropped or duplicated turn).
@@ -111,7 +118,7 @@ def test_decompose_slices_head_raw_middle_tail(tmp_path) -> None:
     default-independent: hot_list_n and other SP-affecting defaults don't change
     whether elide fires.
     """
-    session = _make_session(tmp_path, t_max=2800)
+    session = _make_session(tmp_path, monkeypatch, t_max=2800)
     msgs_pushed = 30
     for i in range(msgs_pushed):
         _push(session, "user" if i % 2 == 0 else "assistant", _TURN_80TOK)
@@ -134,14 +141,14 @@ def test_decompose_slices_head_raw_middle_tail(tmp_path) -> None:
     )
 
 
-def test_decompose_no_elide_when_history_fits_window(tmp_path) -> None:
+def test_decompose_no_elide_when_history_fits_window(tmp_path, monkeypatch) -> None:
     """Tier 2: when total tokens <= effective_trigger, everything is in head —
     raw_middle and tail are empty (nothing to elide).
 
     retry_loop's shrink can still trim head if needed.
     """
     # Large t_max → effective_trigger large → 3 short turns easily fit.
-    session = _make_session(tmp_path, t_max=1_000_000)
+    session = _make_session(tmp_path, monkeypatch, t_max=1_000_000)
     for i in range(3):
         _push(session, "user", f"q-{i}")
 
@@ -153,9 +160,9 @@ def test_decompose_no_elide_when_history_fits_window(tmp_path) -> None:
     assert summary is None
 
 
-def test_decompose_extracts_structured_summary(tmp_path) -> None:
+def test_decompose_extracts_structured_summary(tmp_path, monkeypatch) -> None:
     """Tier 2: a persisted summary turn surfaces its structured dict (immutable base)."""
-    session = _make_session(tmp_path)
+    session = _make_session(tmp_path, monkeypatch)
     structured = {"topic_arc": "greeting", "decisions": []}
     session.history.append(ChatMessage(
         role="summary",
@@ -170,7 +177,7 @@ def test_decompose_extracts_structured_summary(tmp_path) -> None:
     assert summary == structured
 
 
-def test_decompose_wire_shape_matches_build_history(tmp_path) -> None:
+def test_decompose_wire_shape_matches_build_history(tmp_path, monkeypatch) -> None:
     """Tier 2: decomposed head+tail turns use the same wire serialisation as
     the normal router path (_build_history_for_router).
 
@@ -181,7 +188,7 @@ def test_decompose_wire_shape_matches_build_history(tmp_path) -> None:
     This test forces the elide branch on both paths via t_max=2800 so that
     _build_history_for_router also returns head+tail (no summary bridge).
     """
-    session = _make_session(tmp_path, t_max=2800)
+    session = _make_session(tmp_path, monkeypatch, t_max=2800)
     for i in range(8):
         _push(session, "user" if i % 2 == 0 else "assistant", _TURN_80TOK)
 
@@ -200,7 +207,7 @@ def test_decompose_wire_shape_matches_build_history(tmp_path) -> None:
     )
 
 
-def test_recovery_summary_bridge_matches_normal_path(tmp_path) -> None:
+def test_recovery_summary_bridge_matches_normal_path(tmp_path, monkeypatch) -> None:
     """Tier 2: with a persisted summary, the recovery bridge text equals the
     normal router path's bridge.
 
@@ -211,7 +218,7 @@ def test_recovery_summary_bridge_matches_normal_path(tmp_path) -> None:
     """
     from reyn.runtime.session_pure import render_summary_for_storage
 
-    session = _make_session(tmp_path, t_max=2800)
+    session = _make_session(tmp_path, monkeypatch, t_max=2800)
     structured = {
         "topic_arc": "planning the trip",
         "decisions": ["book the tuesday flight"],
@@ -248,7 +255,7 @@ def test_recovery_summary_bridge_matches_normal_path(tmp_path) -> None:
 # ── wiring data contract: session decomposition feeds real retry_loop ────────
 
 
-def test_session_decomposition_feeds_retry_loop(tmp_path) -> None:
+def test_session_decomposition_feeds_retry_loop(tmp_path, monkeypatch) -> None:
     """Tier 2: the session's real decomposition + engine/learner drive retry_loop.
 
     Proves the wiring data contract end-to-end on the no-overflow path: the
@@ -258,7 +265,7 @@ def test_session_decomposition_feeds_retry_loop(tmp_path) -> None:
     engine.compact recovery is covered separately (PR-N6 Fake-engine tests).
     """
     # Large t_max → everything fits → empty raw_middle → no engine.compact LLM call.
-    session = _make_session(tmp_path, t_max=1_000_000)
+    session = _make_session(tmp_path, monkeypatch, t_max=1_000_000)
     for i in range(3):
         _push(session, "user", f"hi-{i}")
 

--- a/tests/test_session_router_history_slicing.py
+++ b/tests/test_session_router_history_slicing.py
@@ -34,7 +34,7 @@ from tests._support.session import (
 # ── No-elide branch (total <= effective_trigger) ─────────────────────────────
 
 
-def test_history_fits_in_window_returns_all_turns(tmp_path):
+def test_history_fits_in_window_returns_all_turns(tmp_path, monkeypatch):
     """Tier 2: when total tokens <= effective_trigger, all turns are returned
     in order — no elide, no duplication.
 
@@ -44,7 +44,7 @@ def test_history_fits_in_window_returns_all_turns(tmp_path):
     branch can never produce duplicates.
     """
     # Large t_max → effective_trigger large → 7 short turns easily fit.
-    session = _make_session(tmp_path, t_max=1_000_000)
+    session = _make_session(tmp_path, t_max=1_000_000, monkeypatch=monkeypatch)
     pushed = ["hello", "Hi there!", "what can you do?", "I can help...",
               "tell me about yourself", "I am a Reyn agent.", "list available skills"]
     for text in pushed:
@@ -61,16 +61,16 @@ def test_history_fits_in_window_returns_all_turns(tmp_path):
     )
 
 
-def test_empty_history_returns_empty_messages(tmp_path):
+def test_empty_history_returns_empty_messages(tmp_path, monkeypatch):
     """Tier 2: empty history → empty result."""
-    session = _make_session(tmp_path)
+    session = _make_session(tmp_path, monkeypatch=monkeypatch)
     msgs = session._history_buffer.build_history()
     assert msgs == [], f"expected empty result for empty history, got {msgs!r}"
 
 
-def test_single_turn_returns_single_message(tmp_path):
+def test_single_turn_returns_single_message(tmp_path, monkeypatch):
     """Tier 2: single turn → exactly one message, no duplication."""
-    session = _make_session(tmp_path)
+    session = _make_session(tmp_path, monkeypatch=monkeypatch)
     _push(session, "user", "hello")
     msgs = session._history_buffer.build_history()
     assert msgs == [{"role": "user", "content": "hello"}]
@@ -86,7 +86,7 @@ def test_single_turn_returns_single_message(tmp_path):
 _LONG_TEXT = "X" * 320  # 80 tokens via chars4; use with t_max=2800
 
 
-def test_history_exceeds_trigger_elides_middle(tmp_path):
+def test_history_exceeds_trigger_elides_middle(tmp_path, monkeypatch):
     """Tier 2: when total tokens > effective_trigger, the middle turns are
     elided and head + tail are returned without duplication.
 
@@ -95,7 +95,7 @@ def test_history_exceeds_trigger_elides_middle(tmp_path):
     default-independent: hot_list_n and other SP-affecting defaults don't
     change whether elide fires.
     """
-    session = _make_session(tmp_path, t_max=2800)
+    session = _make_session(tmp_path, t_max=2800, monkeypatch=monkeypatch)
     texts = [f"turn-{i}:" + _LONG_TEXT for i in range(30)]
     for i, text in enumerate(texts):
         _push(session, "user" if i % 2 == 0 else "assistant", text)
@@ -118,7 +118,7 @@ def test_history_exceeds_trigger_elides_middle(tmp_path):
     )
 
 
-def test_elide_inserts_summary_bridge_when_summary_present(tmp_path):
+def test_elide_inserts_summary_bridge_when_summary_present(tmp_path, monkeypatch):
     """Tier 2: when a summary exists and elide fires, a bridge message is
     inserted between head and tail.
 
@@ -126,7 +126,7 @@ def test_elide_inserts_summary_bridge_when_summary_present(tmp_path):
     test_history_exceeds_trigger_elides_middle for the default-independent
     size rationale).
     """
-    session = _make_session(tmp_path, t_max=2800)
+    session = _make_session(tmp_path, t_max=2800, monkeypatch=monkeypatch)
     # Inject a summary before the turns.
     session.history.append(ChatMessage(
         role="summary",

--- a/tests/test_session_writes_stay_in_its_workspace_3705.py
+++ b/tests/test_session_writes_stay_in_its_workspace_3705.py
@@ -51,7 +51,7 @@ def test_a_session_creates_nothing_in_the_directory_it_was_started_from(
     elsewhere.mkdir()
     monkeypatch.chdir(elsewhere)
 
-    session = make_session(workspace)
+    session = make_session(workspace, monkeypatch=monkeypatch)
     session._append_history(
         ChatMessage(role="user", content="a message worth persisting", ts=now())
     )
@@ -79,7 +79,7 @@ def test_the_history_lands_in_the_workspace_it_was_given(
     elsewhere.mkdir()
     monkeypatch.chdir(elsewhere)
 
-    session = make_session(workspace)
+    session = make_session(workspace, monkeypatch=monkeypatch)
     session._append_history(
         ChatMessage(role="user", content="a message worth persisting", ts=now())
     )

--- a/tests/test_slash_compact_191.py
+++ b/tests/test_slash_compact_191.py
@@ -43,7 +43,7 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _make_session(tmp_path) -> Session:
+def _make_session(tmp_path, monkeypatch) -> Session:
     """Create a Session with a small synthetic T_max to force non-empty candidates.
 
     #1128 step 3: _select_candidates uses token-budget boundaries from the engine.
@@ -55,25 +55,29 @@ def _make_session(tmp_path) -> Session:
     Turns of 'x'*4000 (=1000 tokens) each individually exceed both budgets, so
     the Axis-7 single-oversized-turn rule includes exactly one turn in head and
     one in tail.  With 8 turns: middle=[t1..t6]=6 candidates ≥ min_compact_batch=1.
+
+    #3671 follow-up: takes the caller's ``monkeypatch`` fixture rather than
+    manually saving/restoring ``get_max_input_tokens`` — CompactionEngine now
+    builds LAZILY (``CompactionController._engine``, a property, on first
+    reference) rather than eagerly at Session construction, so a patch that
+    un-does itself the moment this function returns would go stale before
+    the caller ever triggers the lazy build. ``monkeypatch`` restores at the
+    CALLING TEST's teardown instead, keeping the patch live for whatever
+    that test does with the session.
     """
     import reyn.llm.model_budget as _mb
 
-    original = _mb.get_max_input_tokens
-    _mb.get_max_input_tokens = lambda model, **kw: 2800  # type: ignore[assignment]
-    try:
-        session = make_session(
-            agent_name="default",
-            budget_tracker=BudgetTracker(CostConfig()),
-            state_log=StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl"),
-            compaction_config=CompactionConfig(
-                use_chars4_estimate=True,      # deterministic offline token counts
-                section_caps_spec_tokens=0,    # keeps B_M positive for small T_max
-            ),
-            snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
-        )
-    finally:
-        _mb.get_max_input_tokens = original
-    return session
+    monkeypatch.setattr(_mb, "get_max_input_tokens", lambda model, **kw: 2800)
+    return make_session(
+        agent_name="default",
+        budget_tracker=BudgetTracker(CostConfig()),
+        state_log=StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl"),
+        compaction_config=CompactionConfig(
+            use_chars4_estimate=True,      # deterministic offline token counts
+            section_caps_spec_tokens=0,    # keeps B_M positive for small T_max
+        ),
+        snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
+    )
 
 
 def _reply_text(ctx) -> str:
@@ -111,7 +115,7 @@ def test_compact_now_for_op_real_chat_measurement(tmp_path, monkeypatch) -> None
     so compaction bridges the already-elided middle rather than shrinking the
     view). Closes the #1177/#1182 test gap (those scripted a compact_now stub)."""
     monkeypatch.chdir(tmp_path)
-    session = _make_session(tmp_path)
+    session = _make_session(tmp_path, monkeypatch)
     _populate(session)
     _script_compaction_llm(monkeypatch)
 
@@ -132,7 +136,7 @@ def test_compact_slash_reports_compression(tmp_path, monkeypatch) -> None:
     """Tier 2: /compact runs real compaction and reports the summarised-turns +
     raw→bridge compression (not a misleading router-view 'freed' number)."""
     monkeypatch.chdir(tmp_path)
-    session = _make_session(tmp_path)
+    session = _make_session(tmp_path, monkeypatch)
     _populate(session)
     _script_compaction_llm(monkeypatch)
 
@@ -152,7 +156,7 @@ def test_compact_slash_nothing_to_compact(tmp_path, monkeypatch) -> None:
     """Tier 2: with no compactable turns, /compact reports nothing to compact
     (freed=0 path) — never a misleading 'freed' claim."""
     monkeypatch.chdir(tmp_path)
-    session = _make_session(tmp_path)
+    session = _make_session(tmp_path, monkeypatch)
     # 3 turns < head(2)+tail(2) → no candidates → force_compact_now no-ops.
     for _ in range(3):
         session._append_history(ChatMessage(role="user", content="hi", ts=_now()))


### PR DESCRIPTION
**[e2e-coder]** — owner の実機再測定（#3780 後、`tui-boot` 2.27s→6.49s）を受けた follow-up。数字は約束しません — owner の全行再測定はまだ来ていません。

## 発端

#3780 は `chat.py` の明示的な litellm prepay を除去し、`test_run_async_never_imports_litellm_without_an_llm_call` で「LLM を呼ばない限り litellm を読まない」ことをゲートしました。しかし owner の実機で `tui-boot`（TUI 起動〜初回描画）が縮むどころか **増えました**。「消えたのでなく移った」という疑いから調査開始。

## ゲートの射程（先に確認、lead-coder 指示）

既存ゲートの `_llm_free()` は合成コルーチンで、**`Session` を一切構築しません**。実際の TUI 起動では毎回 `Session` が構築される — ここが盲点でした。

`test_constructing_a_session_never_imports_litellm`（新規、`tests/test_llm_run_async_client_cache_scope_3434.py`）を追加し、**現行 main で確実に RED** であることを先に確認（実 `Session` 構築だけで `sys.modules` に litellm フルロード）。射程が足りていることをこの時点で立証してから実装に入りました。

## 母集団（名前でなく import trace で確定）

`builtins.__import__` をフックし、`reyn/` 配下のどのソース行が `import litellm` を実行しているか、`Session.__init__` の呼び出し連鎖ごとに記録 — 関数名を予想して探すのではなく、実際に発火した箇所を機械的に列挙。**母集団は 2 件**、両方 `Session.__init__` の中:

1. **`TurnBudgetEngine`**（`services/turn_budget/engine.py`）: `__init__` が T_wrap_SP 測定と `compute_turn_budget`→`get_max_input_tokens` を無条件実行。
2. **`CompactionEngine`**（`services/compaction/engine.py`）: `__init__` が T_comp_SP 測定と `compute_budgets`→`get_max_input_tokens` を無条件実行。

★ **1件目（TurnBudgetEngine）を直した直後もゲートは RED のままでした** — これが「射程の足りたゲートを先に張る」ことの効果の実例です。狭いゲート（例えば1件目だけを個別に確かめる形）だったら、1件目の修正で緑になり、CompactionEngine という兄弟が見つからずに埋もれていました。

## 実装

- **TurnBudgetEngine**: `Session.__init__` の即時構築をファクトリクロージャに変更（`__init__` 自身が既に使っている「`*_fn` を verbatim に持ち回り、呼び出し時に解決する」ファミリー — `RouterOpContextSource`/`live_session_id_fn` と同型）。`RouterHostAdapter` に新規 `turn_budget_engine_factory` パラメータ、`_ensure_turn_budget_engine()` で単一所有・遅延キャッシュ。実装前に、`wrap_up_output_reserve` の2つの消費地点（`is not None` チェック）が実ターン処理（`_force_close_call`、F2b handoff loop）からしか呼ばれず、`first_frame` より前には絶対到達しないことを確認済。
- **CompactionEngine**: `CompactionController._engine` をプレーンな属性から**遅延プロパティ**に変更（単一所有キャッシュ、初回参照時に一度だけ構築）。`CompactionController.__init__` は `compaction_engine_factory` を受け取る形に。既存の外部 private-attribute 読み手（`context_budget_advisor.py`、`router_loop_driver.py`、複数のテスト）は**無変更で動作** — 属性アクセスが透過的にプロパティを発火させるため。`try_build_default_turn_budget_engine`/`CompactionEngine` 自体の契約（tiny-context モデルで None/raise）は一切変更していません。

## テストヘルパーの副産物（7ファイル、6箇所）

`get_max_input_tokens` を monkeypatch してすぐ復元する形のヘルパーが複数（`tests/_support/session.py` の共有 `make_session` 含む）— 旧来の「構築時点で即座に litellm を読む」タイミングでは正しかったパターンですが、遅延構築後は復元がテスト本体の実際の参照より前に起きてしまい、実 litellm 値を読んで壊れました。

**最初の対処（撤回）**: ヘルパー内で構築直後に `._engine` へ触れて強制ビルドする案 → lead-coder 指摘で撤回。これだと該当テストでは遅延が一切起きず、「本番は遅延・テストは即時」という乖離ができ、今回入れた性質がテストで検証されない状態になる。

**採用した対処**: monkeypatch の窓を、pytest 自身の `monkeypatch` フィクスチャ経由でテスト本体のティアダウンまで広げる形に変更。強制ビルドは撤回し、遅延パスがテスト内で実際に通るようにしました。

**`monkeypatch=` を必須引数にした理由**: `tests/_support/session.py::make_session` に当初 `monkeypatch: object | None = None`（省略時は旧来の強制ビルドにフォールバック）を用意しましたが、owner の「後方互換は技術負債と思ってるから理由にしないで」に照らして lead-coder から「渡せない呼び出し元は何箇所か」を問われました。実際に数えたところ **渡せない呼び出し元は 0 件**（1周目の集計は5箇所・2ファイルでしたが、検索漏れで1ファイル分を見落としており、自己訂正の上で正しくは6箇所・3ファイル）— 全て単に monkeypatch フィクスチャを関数シグネチャに足せば済むだけでした。「渡せない理由」ではなく「渡すのが手間なだけ」だったので、分岐を削除し `monkeypatch` を必須パラメータにしました。

## Test plan

- [x] `test_constructing_a_session_never_imports_litellm` — 修正前 RED 確認済、修正後 GREEN
- [x] `ruff check src tests` — green
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 107 tests inspected, 0 errors
- [x] `pytest`（フルスイート、リポジトリルート）— 10130 passed, 49 skipped, 0 failed
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `try_build_default_turn_budget_engine`/tiny-context モデルの既存ピンテスト2件（`test_try_build_returns_none_for_small_context_model`、`TurnBudgetEngine(..., output_reserve=10**9, ...)` の raise）— 無変更で green（契約変更なし）

owner の実機再測定はまだ届いていません。届き次第、lead-coder 経由で確認します。