### PR TITLE
feat(#3692): flowview 0.14.0 pin — following/FollowChanged + early-scroll-release fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ dependencies = [
     # The SHA is the *commit*, not the tag object: v0.13.1/v0.12.0 are
     # LIGHTWEIGHT tags (no `^{}` peel in `git ls-remote`), same as v0.9.0,
     # unlike the annotated v0.7.0/v0.8.0.
-    "textual-flowview @ git+https://github.com/tya5/textual-flowview.git@2408cabfdc896fa5e49c1f64b8ae9f01e33d9346",
+    "textual-flowview @ git+https://github.com/tya5/textual-flowview.git@224889a494a719ec7b26b5c48a342aa654f3fefc",
     "numpy>=1.24",           # RAG index backend cosine similarity (ADR-0033)
     "croniter>=2.0",         # cron expression parsing for FP-0009 Component B
     "charset-normalizer>=3.0",  # #1452 read_file encoding detection (MIT, pure-python)

--- a/tests/test_conversation_pane_boundary_3692.py
+++ b/tests/test_conversation_pane_boundary_3692.py
@@ -126,7 +126,8 @@ def _cursor_col(flow: FlowView, row: int) -> "int | None":
     row ``row`` (``None`` if the cursor is not on this row) — read from
     :meth:`FlowView.render_line`'s PUBLIC per-segment ``style``, not any
     private cursor-position field. The cursor renders as a ``… on color(4)``
-    segment (measured against 0.13.1) regardless of the surrounding theme."""
+    segment (measured against 0.13.1, re-verified against 0.14.0) regardless
+    of the surrounding theme."""
     x = 0
     for seg in flow.render_line(row):
         if "on color(4)" in str(seg.style):

--- a/tests/test_textual_chat_phase2_3273.py
+++ b/tests/test_textual_chat_phase2_3273.py
@@ -191,7 +191,7 @@ def test_flowview_library_is_unmodified_blink_lives_in_reyn() -> None:
     # pin here is what detects a locally-forked/vendored flowview masquerading
     # as the release (a mismatch means the installed copy is not the pinned
     # one).
-    assert textual_flowview.__version__ == "0.13.1"
+    assert textual_flowview.__version__ == "0.14.0"
     # The native animation primitive reyn now drives the blink through: FlowView
     # accepts an ``animation_fps`` and owns its own animation tick.
     import inspect


### PR DESCRIPTION
**[e2e-coder]** — lead-coder 指示の2段構成の①（先行、独立PR）。②（reyn 側の逆算 `_following_tail` 撤去）は本 PR の後、別 PR。

## 背景

`tya5/textual-flowview#12`（reyn 側で投げた質問）に upstream から回答があり、**0.14.0** としてリリースされました。#3770 の根を直接埋める内容です。

## upstream の変更

- **早期 scroll-up の解放漏れ修正**: `FlowView` の sticky-bottom follow 解除が `watch_scroll_y`（`scroll_y` が実際に**変化**したときだけ発火するリアクティブウォッチャー）でのみラッチされていました。コンテンツがまだストリーミング中で `max_scroll_y` がほぼ 0 の間は、ホイールアップが来ても `scroll_y` が動けず、ウォッチャーが発火せず、「離脱したい」という意図が黙って捨てられていました。0.14.0 はこの意図を scroll の**イベント/アクション自体**で捕まえるよう修正 — 動かせる余地の有無と無関係に。
- **`FlowView.following`（bool）+ `FlowView.FollowChanged`** 追加 — 消費側が `max_scroll_y`/`scroll_offset` から逆算しなくてよくなります（#3770 の根そのもの）。

## 本 PR（①）の内容

- `pyproject.toml`: `textual-flowview` の pin を 0.14.0 タグのコミット（`224889a494a719ec7b26b5c48a342aa654f3fefc`）へ。
- `tests/test_textual_chat_phase2_3273.py`: バージョン pin ゲート（`test_textual_flowview_is_git_commit_pinned`）を `"0.14.0"` に更新。
- `tests/test_conversation_pane_boundary_3692.py`: カーソルグリフのレンダリングコメント（`0.13.1` 時点の実測）を 0.14.0 で再検証（変更なしで green — コメントに再検証済と追記）。

★ **reyn 側の逆算コード（`_following_tail`/`watch_scroll_y`→`_refresh_tail_indicator`、#3720）はこの PR では一切触っていません** — lead-coder 指示通り、②（要否は「読んでから判断」）は別 PR です。

## #3770 ゲートの witness（テストを書き換えずに green）

`tests/test_tail_away_indicator_3712.py`（#3770 が扱ったフレーク gate）を**一切書き換えずに**実行 — 6/6 green。テストの表現自体を直さずに upstream の修正だけで通ったことが、根本原因が upstream 側にあったことの witness です（#3773 と同じ形）。

## 製品側の欠陥そのものの実測（テスト green ≠ witness、lead-coder 指示）

flowview#12 の元の再現手順を**そのまま**、実際の `textual.events.MouseScrollUp` を `FlowView._on_mouse_scroll_up` に通して（`scroll_to()` のような合成呼び出しではなく）実測:

```
before early scroll:               max_scroll_y=0  following=True
immediately after early scroll:    max_scroll_y=0  following=False   ← 即座に解放
after 39 more entries streamed in: max_scroll_y=56 scroll_y=0.0 following=False
FIXED: pane stayed where the reader scrolled to, despite the early scroll happening while max_scroll_y was ~0
```

`max_scroll_y` がまだ 0 の最も早いタイミングでスクロールしても `following` が即座に `False` になり、その後 39 件のストリーミングが続いても `scroll_y=0`（離脱した位置）に留まったまま — 旧来のバグ（コンテンツが伸びるたびに底へ引き戻される）が実測で再現しないことを確認しました。

## Test plan

- [x] `tests/test_tail_away_indicator_3712.py` — テスト**無改変**で 6/6 green（upstream 修正の witness）
- [x] `tests/test_conversation_pane_boundary_3692.py` — 3/3 green
- [x] MouseScrollUp 実測 — 製品側欠陥の直接確認済（上記ログ）
- [x] `ruff check src tests` — green
- [x] `python scripts/test_tier_audit.py --strict tests/test_conversation_pane_boundary_3692.py tests/test_textual_chat_phase2_3273.py` — 15 tests inspected, 0 errors
- [x] flowview/textual_chat 関連サブセット（261件）— green
- [x] `pytest`（フルスイート）— 10229 passed, 40 skipped, 0 failed

このPRが green になった時点で #3770 を閉じられる見込みです（owner への telegram 経由の報告は lead-coder 側）。