### PR TITLE
fix(#3770): stop reconstructing follow state, read flowview 0.14.0's own

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -374,26 +374,6 @@ class _CursorFlowView(FlowView["OutboxMessage"]):
         if entry is not None:
             self.post_message(KeyCommitted(self, entry))
 
-    def watch_scroll_y(self, old_value: float, new_value: float) -> None:
-        """Tell the app the view moved (#3712).
-
-        Whether the reader is on the newest output was previously re-read only
-        when a frame arrived — and a scroll is not a frame. Scroll away in a
-        quiet moment and nothing noticed, so the next arrival was counted as
-        seen. Measured: this was the last gate's failure.
-
-        Hooked on the reactive rather than on a key or a mouse event, because
-        it is the one place every way of moving converges — arrows, PgUp, the
-        wheel, and ``scroll_end`` from ``ctrl+end`` alike. Binding the keys
-        instead would leave whichever route nobody thought of unwired, which is
-        the shape this feature keeps producing.
-        """
-        super().watch_scroll_y(old_value, new_value)
-        app = self.app
-        notify = getattr(app, "_refresh_tail_indicator", None)
-        if notify is not None:
-            notify()
-
 
 class ScrollableDrawer(ContentSwitcher):
     """The bottom drawer, with keys that can reach a readout taller than it.
@@ -1325,9 +1305,6 @@ class TextualChatApp(App):
         # the same path to the composer they did before it existed.
         #: #3712: how many entries the flow held when the reader last left the
         #: newest output, or ``None`` while they are on it.
-        #: Whether the conversation is following the newest output. Starts
-        #: true: an empty flow is, trivially, showing all of it.
-        self._following_tail = True
         #: Entries that have landed since the reader left the tail, counted as
         #: they arrive rather than derived from two reads of the model.
         self._away_arrivals = 0
@@ -2155,51 +2132,40 @@ class TextualChatApp(App):
         except Exception:
             return
         flow.scroll_end(animate=False)
-        # Cleared HERE rather than through the deferred measurement: the
-        # operator just asked to be back at the newest output, so the indicator
-        # must go with the keystroke and not a frame later. The deferred path
-        # still runs and agrees — it simply must not be what the answer waits
-        # on, since a quiet moment produces no further frame.
+        # Cleared HERE rather than waiting on the FollowChanged handler below:
+        # ``scroll_end``'s default ``immediate=False`` defers the actual
+        # scroll_y update (and so flowview's own follow-state update) until
+        # after a screen refresh — the operator just asked to be back at the
+        # newest output, so the indicator must go with the keystroke and not
+        # a frame later. ``on_flow_view_follow_changed`` still runs once that
+        # refresh happens and agrees (idempotent), it simply must not be what
+        # the answer waits on.
         self._away_arrivals = 0
-        self._following_tail = True
         self._activity.set_behind(None)
 
-    def _refresh_tail_indicator(self, *, reset: bool = False) -> None:
-        """Update whether the reader is on the newest output, and how much they
-        have missed.
+    def on_flow_view_follow_changed(self, event: "FlowView.FollowChanged") -> None:
+        """The reader left or returned to the newest output (#3712, #3770).
 
-        The count is not a difference between two observations. Comparing "how
-        many entries there were when they left" with "how many there are now"
-        makes the answer depend on WHEN each side was sampled — measured, the
-        deferred read landed before the arriving entry on one run and after it
-        on the next, giving +1 and 0 for the same events. That is a property of
-        the method, not a bug in it.
+        #3770 follow-up: this REPLACES the old ``watch_scroll_y``-driven,
+        per-frame-polled reconstruction (``scroll_target_y >= max_scroll_y``,
+        deferred via ``call_after_refresh``) now that flowview 0.14.0 tracks
+        and posts this directly (``FlowView.following`` / ``FollowChanged``)
+        — the same intent-vs-position distinction #3770 traced as the
+        reconstruction's own flaw (a wheel-up during early streaming, with no
+        room to move, released nothing under the old geometry check; flowview
+        now catches it at the scroll event itself and posts here). Firing on
+        every flip, not a per-frame poll, means a quiet-moment scroll-away is
+        seen immediately — the exact gap #3712's original fix worked around
+        by hooking a reactive watcher instead of a frame.
 
-        So the arrivals are counted where they happen instead: every entry that
-        lands while the reader is away increments a counter, and returning to
-        the tail zeroes it. Nothing remembers a baseline, so nothing can sample
-        one at the wrong moment.
+        Only the "returned" edge needs anything from THIS app: the "left"
+        edge does not have to zero or set anything — :meth:`_note_entry_landed`
+        already reads ``flow.following`` fresh on each arrival, so there is
+        nothing to remember about having left.
         """
-        self.call_after_refresh(self._measure_tail_position, reset)
-
-    def _measure_tail_position(self, reset: bool = False) -> None:
-        """Read the view and settle whether the reader is following the tail.
-
-        Deferred to after a refresh because it needs a laid-out view: on the
-        beat an entry lands, the scroll offset still trails the taller content
-        and that gap reads as "they scrolled away".
-        """
-        try:
-            flow = self.query_one(FlowView)
-        except Exception:
-            return
-        at_tail = flow.scroll_target_y >= flow.max_scroll_y
-        if at_tail or reset:
+        if event.following:
             self._away_arrivals = 0
-            self._following_tail = True
-        else:
-            self._following_tail = False
-        self._activity.set_behind(self._away_arrivals or None)
+            self._activity.set_behind(None)
 
     def _note_entry_landed(self) -> None:
         """One entry arrived — count it if the reader is not there to see it.
@@ -2208,7 +2174,7 @@ class TextualChatApp(App):
         the event rather than by a later reader of the model. ``LIVE +N`` says
         how many things happened; the things themselves are what know.
         """
-        if not self._following_tail:
+        if not self._flow.following:
             self._away_arrivals += 1
             self._activity.set_behind(self._away_arrivals)
 
@@ -3856,22 +3822,6 @@ class TextualChatApp(App):
                 # loop) and guarded so a snapshot read failure never kills the pump.
                 try:
                     self._refresh_live_chrome()
-                    # #3712: EVERY frame, DISPLAY and EVENT alike. A streamed
-                    # reply's first delta creates its entry through the EVENT
-                    # leg, so hooking only the display leg meant the one thing
-                    # that HAD arrived went unreported — the mirror of the
-                    # false positive above, and the reason this sits beside
-                    # ``_refresh_live_chrome``, which learned the same lesson
-                    # in #3338.
-                    # #3712: count what LANDED, then re-read where the reader
-                    # is. Order matters and is fixed here rather than left to
-                    # scheduling: an entry that arrives while they are away is
-                    # counted by the arrival itself, so no later read has to
-                    # reconstruct it from a remembered baseline.
-                    try:
-                        self._refresh_tail_indicator()
-                    except Exception:
-                        logger.exception("textual chat: tail indicator failed")
                     # #3680: the inputs to the layout decision (a turn
                     # starting, an item queued) arrive on these same frames,
                     # so re-deciding here is what keeps the answer from being

--- a/tests/test_tail_away_indicator_3712.py
+++ b/tests/test_tail_away_indicator_3712.py
@@ -190,19 +190,15 @@ async def _fill_and_leave_the_tail(transport, pilot, app, *, lines: int = 40):
         "viewport, so there is no tail to leave"
     )
     flow.scroll_to(y=0, animate=False)
-    # #3770: waits for the scroll's OWN deferred _refresh_tail_indicator to
-    # actually run (app._following_tail flips False) before this fixture
-    # returns — callers push further arrivals right after and need
-    # _note_entry_landed to already be counting them, which only happens
-    # once the deferred measurement has settled the departure. The wait
-    # predicate reads private state (``_following_tail``) because no public
-    # surface distinguishes "measurement not yet run" from "run, and the
-    # reader happens to be 0 entries behind" — the row's own text renders
-    # the same either way (see #3770's own tracking comment for that gap).
-    # CLAUDE.md's private-state ban is about ASSERTING on it as a verdict;
-    # this only decides WHEN to look, and the assert two lines down stays on
-    # the public ``scroll_y``/``max_scroll_y`` surface.
-    await _settle_until(pilot, lambda: not app._following_tail)
+    # #3770 follow-up: waits for flowview's own ``following`` to actually
+    # flip False before this fixture returns — callers push further
+    # arrivals right after and need ``_note_entry_landed`` to already be
+    # counting them, which only happens once the departure has settled.
+    # PUBLIC surface now (flowview 0.14.0's own ``FlowView.following`` —
+    # was reyn's private ``app._following_tail`` before this library
+    # release added the real thing; #3770's own tracking comment named
+    # this exact gap as future-consumer bait, and this is that consumer).
+    await _settle_until(pilot, lambda: not flow.following)
     # #3720 diagnostic: CI and this machine disagree on the same SHA, and the
     # rendered row is wider there — both point at FlowView's real size, which
     # #3724's compact_caps can change. Printed so the two can be compared
@@ -323,13 +319,13 @@ async def test_the_named_key_actually_returns_to_the_newest_output() -> None:
         assert "LIVE" in str(row.render())
 
         await pilot.press("ctrl+end")
-        # #3770: no deferred wait needed here — action_jump_to_latest sets
-        # scroll_y, _away_arrivals, _following_tail, and the row's own
-        # ``set_behind(None)`` all SYNCHRONOUSLY inside the key handler (its
-        # own docstring: "cleared HERE rather than through the deferred
-        # measurement"), so once the keypress message has been dispatched
-        # both assertions below are already final. A single pause is for
-        # dispatch, not for a race.
+        # #3770 follow-up: no deferred wait needed here — action_jump_to_latest
+        # sets scroll_y, _away_arrivals, and the row's own ``set_behind(None)``
+        # all SYNCHRONOUSLY inside the key handler (its own docstring:
+        # "cleared HERE rather than waiting on the FollowChanged handler"),
+        # so once the keypress message has been dispatched both assertions
+        # below are already final. A single pause is for dispatch, not for
+        # a race.
         await pilot.pause()
 
         assert flow.scroll_y >= flow.max_scroll_y, "the key did not return to the tail"


### PR DESCRIPTION
**[e2e-coder]** — #3784（①）の後続、②。「`following`/`FollowChanged` があれば reyn 側の逆算は要らなくなるはず」という lead-coder の推測を読んで判断: **要りませんでした**。

## 読んで分かったこと

`_CursorFlowView.watch_scroll_y` フックと per-frame poll（`_refresh_tail_indicator`/`_measure_tail_position`）は、`scroll_target_y >= max_scroll_y` という**同じ幾何再構成**を行っていました — これは #3770 が upstream で追跡した「意図と位置の混同」と**全く同じ形**です（早期ストリーミング中のホイールアップは `scroll_y` を動かせないので、この幾何チェックも flowview 自身のバグとは独立に見逃していました）。

## やったこと（推測された部分だけでなく、機構全体を削除）

- `_CursorFlowView.watch_scroll_y` — 唯一の追加処理（`_refresh_tail_indicator` の通知）が無くなれば純粋パススルーになるため、オーバーライドごと削除（空ラッパーとして残さない）。
- `_refresh_tail_indicator`/`_measure_tail_position` — `on_flow_view_follow_changed`（`FlowView.FollowChanged` ハンドラ）1本に統合。
- 毎フレームの poll 呼び出し（`_refresh_tail_indicator()`、DISPLAY/EVENT 両フレームで実行）も削除 — `FollowChanged` は遷移の瞬間に両方向で発火するため、「戻ってきたか」を毎フレーム確認する必要が無くなりました。
- `_following_tail`（private bool）を撤去、`_note_entry_landed` は `self._flow.following` を直接参照。
- `action_jump_to_latest` は `_away_arrivals`/`set_behind(None)` の即時リセットを維持 — `ScrollView.scroll_end()` のデフォルト `immediate=False` は実際の `scroll_y` 更新をリフレッシュ後まで遅延させる（signature を確認済、推測ではありません）ため、`FollowChanged` ハンドラだけに任せるとキー入力から1フレーム遅れます。

## テスト側

`test_tail_away_indicator_3712.py` のフィクスチャは private state（`app._following_tail`）を wait predicate として読んでいました（assert ではなく待機条件としてのみ — CLAUDE.md の禁止対象外）。これを **public な `flow.following`** の poll に置き換え — これはまさに #3770 自身の tracking comment が予告していた「将来の消費者」です:「no public surface distinguishes measurement-not-yet-run from run-and-0-behind... noted here in case it becomes relevant to a future consumer」。flowview 0.14.0 がその答えでした。

## 実測（機構削除の網羅性を直接確認、ゲート緑だけに頼らない）

削除した機構がカバーしていた範囲を実際に再現:
- 実 `MouseScrollUp` **と** 実 `pageup` キー押下（2つの異なるスクロール経路）— 両方とも `following` を正しく解放
- 離脱中の到着は引き続きカウントされる（`LIVE +N`）
- `Ctrl+End` は引き続きキー入力と同期して即座にインジケータをクリア

## Test plan

- [x] `tests/test_tail_away_indicator_3712.py` — 6/6 green
- [x] `ruff check src tests` — green
- [x] `python -m mypy` ratchet — 新規 finding 0（`scripts/mypy_ratchet.py` 全 baseline 済）
- [x] `python scripts/test_tier_audit.py --strict tests/test_tail_away_indicator_3712.py` — 6 tests, 0 errors
- [x] flowview/textual_chat 関連サブセット（340件）— green
- [x] `pytest`（フルスイート）— 10229 passed, 40 skipped, 0 failed
- [x] 実測: MouseScrollUp / pageup / arrivals-while-away / Ctrl+End の4シナリオ全て手動確認済（上記ログ）

#3770 のクローズは lead-coder が判断（本 PR で「reyn 側の自前測定」は完全撤去済 — 残骸はありません）。