### PR TITLE
feat(#3777): align the NOW row with the queue, and let the glyph carry selection

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/activity_row.py
+++ b/src/reyn/interfaces/inline/textual_chat/activity_row.py
@@ -42,14 +42,15 @@ timer costs nothing in correctness) and is paused/resumed by
 — an animation ticking over an idle ssh session for a row nobody sees is
 exactly the cost that split exists to avoid.
 
-A later owner call (#3777, same day) put a small piece of that vacated
-column budget back: the state word now opens with :data:`_STATE_GLYPH`
-(``"▶ "``), the filled counterpart of the sent-queue's unfilled
-:data:`~reyn.interfaces.inline.textual_chat.sent_queue._QUEUED_GLYPH`
-(``"▷"``) — a queued item's glyph and this row's glyph are the SAME shape,
-one hollow and one filled, so promotion reads as the shape filling in
-rather than as one icon replacing an unrelated one. See
-:func:`activity_text`'s docstring for the shine-clearance argument.
+This row carries NO glyph of its own (#3777, owner call). It briefly had
+one — a filled ``▶`` pairing with the queue's hollow ``▷`` — and the shape
+pair survived the removal by moving: ``▶`` is now what a SELECTED queue row
+shows, so "filled" still means "the one being acted on" and the row above no
+longer has to say so twice. What this row keeps is the alignment: its text
+starts in the column a queue row's LABEL starts in
+(:data:`~reyn.interfaces.inline.textual_chat.sent_queue.ROW_TEXT_COLUMN`),
+so the two regions read as one column of text with the queue's glyphs hanging
+off its left edge.
 """
 from __future__ import annotations
 
@@ -66,6 +67,7 @@ if TYPE_CHECKING:
     from textual.timer import Timer
 
 from reyn.interfaces.inline.textual_chat import palette
+from reyn.interfaces.inline.textual_chat.sent_queue import ROW_TEXT_COLUMN
 
 #: The cancel affordance shown while a turn runs. Plain ASCII: the key it names
 #: is the app's own ``ctrl+c`` binding, and this row shares a narrow terminal
@@ -100,17 +102,6 @@ _SHINE_WIDTH = 5
 _SHINE_FALLBACK_STYLE = "reverse"
 _SHINE_FALLBACK_WIDTH = 2
 
-#: The NOW-row glyph (#3777, owner call: a play-family mark — filled, to
-#: read as "running", pairing with
-#: :data:`~reyn.interfaces.inline.textual_chat.sent_queue._QUEUED_GLYPH`'s
-#: unfilled counterpart on the queue row so a promoted item shows the SAME
-#: shape it had a moment ago, only filled in — the "connection" the owner
-#: asked for. Reoccupies part of the column budget #3779 vacated when it
-#: dropped the 6-column ``NOW   `` label; the glyph earns that back by
-#: carrying real information (running, not a static word) rather than
-#: repeating "NOW" as a caption. ``wcwidth`` confirmed single-column and a
-#: full-repo grep found no prior use before this landed (see #3777).
-_STATE_GLYPH = "▶"
 
 
 @lru_cache(maxsize=1)
@@ -170,34 +161,44 @@ def activity_text(
 
     ``shine_index`` (owner-picked design "A", replacing the removed ``NOW``
     label): the frame number of a ``_SHINE_WIDTH``-character band travelling
-    through ``state`` ITSELF — ``None`` paints no band (a static row, e.g.
-    while no turn is showing). It is a frame counter, not a character offset:
-    the band's centre is ``shine_index - _SHINE_WIDTH // 2``, so it starts
-    off the left edge and runs off the right.
+    across the WHOLE rendered row — ``None`` paints no band (a static row,
+    e.g. while no turn is showing). It is a frame counter, not a character
+    offset: the band's centre is ``shine_index - _SHINE_WIDTH // 2``, so it
+    starts off the left edge and runs off the right.
+
+    #3779 confined the band to ``state``'s own span, so it could not wander
+    onto the elapsed clock or the hint. #3777 lifted that: with the glyph gone
+    and the row reading as ONE object rather than as three things sharing a
+    line, the owner asked for the light to cross all of it. The old argument
+    was not wrong — it was the right answer for the row it was written about.
 
     ``colour`` is whether the terminal can show one. ``True`` paints the band
     as a cosine ramp between :data:`palette.SHINE_DIM` and
     :data:`palette.SHINE_PEAK`; ``False`` degrades it to the two-character
     ``reverse`` #3779 shipped. The gradient is the point — a two-valued band
     has no edge to fall off, so it reads as a block blinking rather than a
-    light travelling, which is what the operator reported. The band is
-    confined
-    to ``state``'s own span, never the elapsed clock, the leading
-    :data:`_STATE_GLYPH`, or the right-aligned hint — those are different
-    information (or, for the glyph, a different piece of state entirely) and
-    stay plain. #3779 vacated the old 6-column ``NOW   `` slot; #3777 gives
-    ``state`` a 2-column ``"▶ "`` prefix instead — smaller than the old
-    label, and unlike it, informative on its own (see :data:`_STATE_GLYPH`'s
-    module comment for why that column cost is worth paying again).
+    light travelling, which is what the operator reported.
     """
-    prefix = f"{_STATE_GLYPH} " if state else ""
+    # Spaces, not a glyph (#3777, owner call): the NOW row carries no mark of
+    # its own, and its text starts in the column a queue row's LABEL starts in
+    # — the two regions then read as one column of text with the queue's
+    # glyphs hanging off its left edge, rather than as two lists that happen to
+    # sit above each other. The width comes from the queue rather than being
+    # written here twice; see ``sent_queue.ROW_TEXT_COLUMN``.
+    prefix = " " * ROW_TEXT_COLUMN if state else ""
     body = f"{prefix}{state}"
     if elapsed_s is not None:
         body = f"{body} {int(elapsed_s) // 60:02d}:{int(elapsed_s) % 60:02d}"
     suffix = f"LIVE +{behind} · {LATEST_HINT} latest" if behind else _CANCEL_HINT
     content = _with_suffix(body, suffix, width)
     if shine_index is not None and state:
-        content = _apply_shine(content, len(prefix), len(state), shine_index, colour)
+        # The whole row, not just the state word (#3777, owner call). #3779
+        # confined the band to ``state`` so it could not wander onto the clock
+        # or the hint; with the glyph gone and the row reading as one object,
+        # the owner asked for the light to cross all of it. The clearance
+        # argument that produced the old confinement is not wrong — it was an
+        # answer to a row that was three separate things in a line.
+        content = _apply_shine(content, 0, len(content.plain), shine_index, colour)
     return content
 
 

--- a/src/reyn/interfaces/inline/textual_chat/palette.py
+++ b/src/reyn/interfaces/inline/textual_chat/palette.py
@@ -66,7 +66,13 @@ TOKENS: "dict[str, str]" = {
     #: ``$accent 30%`` produced once alpha was dropped — a solid ANSI-green bar
     #: under default-coloured text — and a full-row inversion was rejected on
     #: the conversation for the same reason (#3490: the mark has to be
-    #: CONTENT). Widgets pair this with a marker in the row text.
+    #: CONTENT). Widgets pair this with the row's OWN glyph filling in
+    #: (``sent_queue``: ``▷`` unselected, ``▶`` selected), so the content half
+    #: of that pairing costs no column and selection stays legible with every
+    #: attribute stripped. Until #3777 the content half was a separate ``▸``
+    #: in a column of its own; the requirement is unchanged, only what carries
+    #: it. Pairing an attribute with SOMETHING in the text is the invariant —
+    #: this token alone is not a selection mark.
     "@selected-style@": "bold",
     #: The drag-selection band. ``ansi_blue`` rather than Textual's default
     #: ``ansi_bright_blue``: the operator found the bright frame too loud
@@ -79,10 +85,6 @@ TOKENS: "dict[str, str]" = {
     #: its foreground beside it is how contrast regressions happen.
     "@selection-fg@": "ansi_black",
 }
-
-#: The marker a selected row carries in its own text, so selection survives
-#: without a colour at all. Not a CSS value — it is content.
-SELECTED_MARKER = "\u25b8"
 
 #: The two endpoints of the NOW row's travelling shine (#3777). Blended per
 #: character at runtime by ``activity_row``, so these are plain values rather
@@ -134,4 +136,4 @@ def css(sheet: str) -> str:
     return sheet
 
 
-__all__ = ["SELECTED_MARKER", "SHINE_DIM", "SHINE_PEAK", "TOKENS", "css"]
+__all__ = ["SHINE_DIM", "SHINE_PEAK", "TOKENS", "css"]

--- a/src/reyn/interfaces/inline/textual_chat/sent_queue.py
+++ b/src/reyn/interfaces/inline/textual_chat/sent_queue.py
@@ -97,6 +97,45 @@ from .presenter import _neutralized_label
 #: confirmed single-column / collision-free before this landed (see #3777).
 _QUEUED_GLYPH = "▷"
 
+#: The SELECTED queued row's glyph (#3777, owner call). The same shape as
+#: :data:`_QUEUED_GLYPH`, filled — so selection reads as the row the operator
+#: is pointing at, in the shape it already had, rather than as a second mark
+#: arriving in a column beside it. It replaces ``palette.SELECTED_MARKER``
+#: (``▸``), which the owner reported as "two glyphs on one row": the marker
+#: column and the queue glyph were both present and neither explained the
+#: other.
+#:
+#: Carrying selection on the glyph rather than beside it keeps the property
+#: the ``▸`` was there for — that selection survives on a terminal where no
+#: style renders — because a differently SHAPED row is legible with every
+#: attribute stripped. It also frees the two columns the marker held, which
+#: is what lets a queue row's text and the NOW row's text start in the same
+#: column.
+#:
+#: The pairing is now three-way and the direction is the point: ``▷``
+#: (queued) -> ``▶`` (selected, i.e. the one Enter would cancel) is the same
+#: hollow-to-filled step as ``▷`` -> the NOW row's running state, so "filled"
+#: consistently means "this is the one being acted on".
+_SELECTED_GLYPH = "▶"
+
+#: What separates a row's glyph from its label. Two spaces, not one: the NOW
+#: row above the queue carries no glyph at all (#3777), so its text has to
+#: start where a queue row's LABEL starts for the two regions to read as one
+#: column of text. One glyph plus this gap is that offset, and naming it here
+#: keeps the two files from drifting by a space.
+_GLYPH_GAP = "  "
+
+#: Which column a row's TEXT starts in, glyph included. Exported because the
+#: NOW row above the queue has to start its text in the same column and has no
+#: glyph of its own to derive it from — importing it is what keeps the two
+#: regions aligned, where a comment saying "keep these equal" would only
+#: record the intent and let a one-space edit break it silently.
+#:
+#: Owned here rather than in ``activity_row`` because the offset is a
+#: consequence of THIS region's glyph: the queue is the region that has one,
+#: and the NOW row aligns to the queue, not the other way round.
+ROW_TEXT_COLUMN = 1 + len(_GLYPH_GAP)
+
 
 class SentQueue(Vertical):
     """The sent-queue region: one dim row per undispatched queued message,
@@ -121,16 +160,30 @@ class SentQueue(Vertical):
            which a "show only the newest 6" rule would have cut off from the
            older items it is most likely to be aimed at. */
         overflow-y: auto;
-        color: @quiet@;
         padding: 0 1;
     }
-    SentQueue Static { height: auto; }
-    /* Selection is an ATTRIBUTE plus a marker in the row's own text, never a
-       filled background. ``background: $accent 30%`` was the previous rule and
-       under the ansi themes the alpha is DROPPED, so it painted a solid ANSI
-       green bar with default-coloured text on top — reported as unreadable.
-       #3490 settled the same question on the conversation: surviving the style
-       merge is necessary and not sufficient, the mark has to be CONTENT. */
+    /* An unselected row recedes by ATTRIBUTE, not by colour. ``color: @quiet@``
+       was the previous rule and it receded by nothing: under the ansi themes
+       ``$text-muted`` resolves to the same ``ansi_default`` marker as ordinary
+       text, so the queue was drawn in exactly the body's colour while claiming
+       to be quiet (the #3523 family, measured). ``dim`` is an SGR attribute —
+       it leaves the hue to the terminal, which is the operator's to choose,
+       and it actually changes what is drawn. */
+    SentQueue Static { height: auto; text-style: @recede@; }
+    /* Selection is an ATTRIBUTE plus the row's own GLYPH, never a filled
+       background. ``background: $accent 30%`` was the previous rule and under
+       the ansi themes the alpha is DROPPED, so it painted a solid ANSI green
+       bar with default-coloured text on top — reported as unreadable. #3490
+       settled the same question on the conversation: surviving the style merge
+       is necessary and not sufficient, the mark has to be CONTENT.
+
+       #3777 moved which content carries it. The mark used to be a separate
+       ``▸`` in a column of its own; it is now the row's OWN glyph filling in
+       (``▷`` -> ``▶``), so selection costs no column and reads as the same
+       object changing state rather than as a pointer arriving beside it. The
+       "survives with no styling at all" property the ``▸`` existed for is
+       kept, and by the same means: a reader who sees neither ``dim`` nor
+       ``bold`` still sees one row shaped differently from the rest. */
     SentQueue Static.-selected { text-style: @selected-style@; }
     """)
 
@@ -180,7 +233,7 @@ class SentQueue(Vertical):
             self.remove_item(msg_id)
         label = _neutralized_label(text)
         self._labels[msg_id] = label
-        row = Static(Content(f"  {_QUEUED_GLYPH} {label}"))
+        row = Static(Content(f"{_QUEUED_GLYPH}{_GLYPH_GAP}{label}"))
         self._rows[msg_id] = row
         self.mount(row)
         self.display = True
@@ -307,7 +360,13 @@ class SentQueue(Vertical):
             # One line, and it names the count rather than implying the rows
             # were dropped. Selection is untouched underneath: restoring the
             # rows restores exactly what was selected.
-            self._summary.update(Content(f"  Queued: {len(order)}"))
+            # Indented to where a row's LABEL sits, not to column 0: collapsing
+            # the queue should look like the rows closing up, and a summary
+            # that started a column further left would read as a different
+            # kind of line arriving rather than as the same region compacting.
+            self._summary.update(
+                Content(f"{' ' * ROW_TEXT_COLUMN}Queued: {len(order)}")
+            )
             self._summary.display = bool(order)
             return
         self._summary.display = False
@@ -315,14 +374,14 @@ class SentQueue(Vertical):
             selected = i == self._selected_index
             row = self._rows[msg_id]
             row.set_class(selected, "-selected")
-            lead = f"{palette.SELECTED_MARKER} " if selected else "  "
+            glyph = _SELECTED_GLYPH if selected else _QUEUED_GLYPH
             # #3777 (owner call, "先頭行だけを区別する話は終わり" — option ①):
             # the NEXT label singling out the head row is gone, with no
             # replacement mark at that position. Every queued row now renders
             # identically regardless of position — the head is still first in
             # ``order`` (:meth:`selected_msg_id`/the cancel bindings are
             # unaffected), it just is not called out visually anymore.
-            row.update(Content(f"{lead}{_QUEUED_GLYPH} {self._labels[msg_id]}"))
+            row.update(Content(f"{glyph}{_GLYPH_GAP}{self._labels[msg_id]}"))
             # #3688: with the region scrollable (see the CSS cap above), the
             # selected row can sit outside the visible six — arrowing onto a row
             # that stays off screen is the same silent-clip defect wearing a

--- a/tests/test_3300_p2b_sentqueue_render.py
+++ b/tests/test_3300_p2b_sentqueue_render.py
@@ -55,7 +55,7 @@ import pytest
 from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
-from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
+from reyn.interfaces.inline.textual_chat.sent_queue import ROW_TEXT_COLUMN, SentQueue
 from reyn.interfaces.repl.read_model import ChatReadModel
 from reyn.interfaces.transport.agui.state import RemoteQueueView
 from reyn.interfaces.transport.client_transport import ClientTransport
@@ -318,12 +318,14 @@ async def test_sent_queue_updates_live_as_deltas_arrive() -> None:
         await pilot.pause()
 
         sent_queue = app.query_one(SentQueue)
-        # Split on the queued glyph, not the first space: a row now carries a
-        # selection marker ahead of it (selection is CONTENT, not a background
-        # — see SentQueue.DEFAULT_CSS), so the leading token count varies with
-        # which row is highlighted. #3777: ⧗ -> ▷ (queued-row glyph).
+        # Take the label by COLUMN, not by splitting on a glyph: #3777 made the
+        # glyph itself carry selection (▷ queued / ▶ selected), so splitting on
+        # one of them silently leaves the other row's glyph in the label and the
+        # set comparison fails for a reason that has nothing to do with what
+        # this test is about. Every row's label starts at the same column by
+        # construction — that is what ROW_TEXT_COLUMN is for.
         assert {"alpha", "beta"} <= {
-            t.split("▷ ", 1)[-1] for t in sent_queue.rendered_texts()
+            t[ROW_TEXT_COLUMN:] for t in sent_queue.rendered_texts()
         }
 
         await transport.push_event(_turn_started(chain_id="c1", seq=3))

--- a/tests/test_activity_row_3693.py
+++ b/tests/test_activity_row_3693.py
@@ -34,6 +34,7 @@ from reyn.interfaces.inline.textual_chat.activity_row import (
     ActivityRow,
     activity_text,
 )
+from reyn.interfaces.inline.textual_chat.sent_queue import ROW_TEXT_COLUMN
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
 from reyn.runtime.outbox import OutboxMessage
@@ -323,15 +324,24 @@ async def test_the_clock_advances_without_any_delta_arriving() -> None:
 # ── the shine (owner design "A", replacing the removed NOW label) ────────────
 
 
-def test_now_is_gone_and_a_play_glyph_opens_the_state() -> None:
-    """Tier 1: the vacated 6-column ``NOW   `` slot is not left as a blank
-    gutter — #3777 put a 2-column ``"▶ "`` prefix ahead of ``state`` instead
-    (smaller than the old label, and unlike it, itself state — see
-    :data:`~reyn.interfaces.inline.textual_chat.activity_row._STATE_GLYPH`'s
-    module comment)."""
+def test_the_row_carries_no_mark_and_starts_where_a_queue_label_starts() -> None:
+    """Tier 1: no ``NOW`` label and no glyph — the row opens with the indent
+    that puts its text in the same column a queue row's LABEL occupies.
+
+    The alignment is the claim, so it is checked against the queue's own
+    constant rather than against a hard-coded three: a queue that changed its
+    glyph gap and left this row behind is exactly the drift the shared
+    constant exists to prevent, and a literal here would keep passing through
+    it.
+    """
     rendered = str(activity_text("WORKING", elapsed_s=None, width=80))
-    assert rendered.startswith("▶ WORKING"), f"the glyph prefix is missing: {rendered!r}"
     assert "NOW" not in rendered
+    assert rendered.startswith(" " * ROW_TEXT_COLUMN + "WORKING"), (
+        f"the row's text does not start at the queue's label column: {rendered!r}"
+    )
+    assert not rendered[:ROW_TEXT_COLUMN].strip(), (
+        f"the row grew a mark of its own back: {rendered!r}"
+    )
 
 
 def _band(state: str, frame: int) -> "dict[int, str]":
@@ -382,32 +392,6 @@ def test_the_shine_advances_one_cell_per_frame_carrying_its_shape() -> None:
         )
 
 
-def test_the_shine_never_reaches_outside_the_state_word() -> None:
-    """Tier 1: every painted cell lies inside ``state``'s own span — never the
-    leading glyph, the space after it, the elapsed clock, or the hint.
-
-    Those are different information (or, for the glyph, a different piece of
-    state entirely), and a highlight that wandered onto them would be saying
-    something the row does not mean. Swept across a whole cycle, so a band
-    that only escapes while entering or leaving is caught too.
-    """
-    state = "WORKING"
-    prefix_len = len("▶ ")
-    for frame in range(prefix_len + len(state) + 8):
-        band = _band(state, frame)
-        assert band, f"frame {frame} painted no band at all"
-        for column in band:
-            assert prefix_len <= column < prefix_len + len(state), (
-                f"frame {frame} painted column {column}, outside "
-                f"[{prefix_len}, {prefix_len + len(state)})"
-            )
-        content = activity_text(state, elapsed_s=None, width=80, shine_index=frame)
-        assert str(content).startswith(f"▶ {state}"), (
-            f"frame {frame}: the shine changed the STATE TEXT, not just its style: "
-            f"{str(content)!r}"
-        )
-
-
 def test_the_shine_degrades_to_an_attribute_without_colour() -> None:
     """Tier 1: with no colour available the band is still drawn, as an SGR
     attribute rather than as nothing.
@@ -450,35 +434,43 @@ def test_any_frame_number_is_a_valid_frame() -> None:
     here is pinning that it cannot.
     """
     state = "WORKING"
-    cycle = len(state) + 2 * (_SHINE_WIDTH // 2)  # one full pass
-    assert _band(state, 999) == _band(state, 999 % cycle)
+    # The band crosses the whole rendered row (#3777), so the pass is as long
+    # as the row is — read from the rendering rather than recomputed, since
+    # the row's width is padding-dependent and a formula here would be a
+    # second implementation of the thing under test.
+    row = str(activity_text(state, elapsed_s=None, width=80, shine_index=0))
+    cycle = len(row) + 2 * (_SHINE_WIDTH // 2)
     assert _band(state, 999), "a large frame number painted no band at all"
+    assert _band(state, 999) == _band(state, 999 % cycle)
 
 
-def test_the_shine_never_touches_the_glyph_elapsed_clock_or_the_live_count() -> None:
-    """Tier 1: the band is confined to ``state``'s own span — the leading
-    ``"▶ "`` glyph (#3777), the elapsed clock, and the right-aligned
-    ``LIVE +N`` hint are DIFFERENT information and must never be drawn
-    inside the travelling highlight, at any frame position across a full
-    sweep."""
+def test_the_shine_crosses_the_whole_row_including_the_clock_and_hint() -> None:
+    """Tier 1: the band is no longer confined to ``state``'s own span.
+
+    #3779 kept it inside the state word so it could not wander onto the clock
+    or the hint, which was right for a row that was three things sharing a
+    line. #3777 removed the glyph and made the row read as one object, and the
+    owner asked for the light to cross all of it. Pinned by sweeping a whole
+    cycle and requiring that SOME frame paints past the state word — a band
+    that silently kept the old confinement would still look plausible frame by
+    frame, and only a sweep catches it.
+    """
     state = "RESPONDING"
-    prefix_len = len("▶ ")
-    for index in range(len(state)):
+    body_end = ROW_TEXT_COLUMN + len(state)
+    reached_beyond = False
+    for frame in range(80):
         content = activity_text(
-            state, elapsed_s=5.0, width=78, behind=12, shine_index=index
+            state, elapsed_s=5.0, width=78, behind=12, shine_index=frame
         )
-        start, end, _style = content.spans[0]
-        assert start >= prefix_len, (
-            f"frame {index}: the band reached back over the glyph prefix: "
-            f"{content.spans!r}"
-        )
-        assert end <= prefix_len + len(state), (
-            f"frame {index}: the band reached past the state word into the "
-            f"clock/hint: {content.spans!r}"
-        )
+        assert content.spans, f"frame {frame} painted no band at all"
+        if any(span.start >= body_end for span in content.spans):
+            reached_beyond = True
         rendered = str(content)
-        assert "LIVE +12" in rendered, f"frame {index}: LIVE +N is missing: {rendered!r}"
-        assert rendered.startswith("▶ "), f"frame {index}: the glyph is missing: {rendered!r}"
+        assert "LIVE +12" in rendered, f"frame {frame}: LIVE +N is missing: {rendered!r}"
+    assert reached_beyond, (
+        "the band never left the state word across a full sweep — it is still "
+        "confined the way #3779 had it"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_tui_colour_tokens.py
+++ b/tests/test_tui_colour_tokens.py
@@ -163,8 +163,6 @@ _QUIET_ONLY_ALLOWED = {
     "intervention_panel.py": "the pane it labels is bordered and headed in "
                              "@attention@, so the detail line reads as detail",
     "rewind_picker.py": "the heading carries text-style: @recede@ (#3686)",
-    "sent_queue.py": "the ▷ glyph and the region's own position above the "
-                     "composer (#3693, glyph updated #3777)",
 }
 
 


### PR DESCRIPTION
**[tui-coder]** — Stage 2 of 4 on #3777. Stage 1 (#3788) is merged; this rebases on top of it.

## What the owner reported

Two things, one cause: **"there are two glyphs on one row"**, and the NOW row and the queue read as
two unrelated lists. The NOW row's mark sat in column 0 and a queue row's glyph two columns further
right, so the shape pair — hollow queued, filled running — could not be read as a pair at all.

## After

```
ROW_TEXT_COLUMN = 3

   RESPONDING 00:12              Ctrl+C cancel
  .+#+.                                            <- shine, now across the whole row
▶  the selected one                                <- filled glyph + bold
▷  earlier question                                <- hollow glyph + dim
▷  one more                                        <- hollow glyph + dim
   ^
   the NOW row's text and every queue LABEL start in the same column
```

A later frame, showing the band no longer stopping at the state word:

```
   RESPONDING 00:12              Ctrl+C cancel
          .+#+.
```

(`#` peak, `+` mid, `.` faint — colour does not survive into text.)

## Changes

- **The NOW row carries no mark.** Its text starts where a queue row's *label* starts, so the two
  regions read as one column of text with the queue's glyphs hanging off its left edge.
- **Selection moved onto the row's own glyph** — `▷` unselected, `▶` selected. `palette.SELECTED_MARKER`
  is removed. This is the "two glyphs" report: the marker column and the queue glyph were both
  present and neither explained the other.
- **`▶` moves off the NOW row and onto the selected queue row in the same commit.** Split across two
  PRs, `▶` would mean "running" and "selected" simultaneously.
- **Unselected rows recede by `text-style: @recede@`**, not `color: @quiet@` — which receded by
  nothing: under the ansi themes `$text-muted` resolves to the same `ansi_default` marker as body
  text, so the queue was drawn in exactly the body's colour while claiming to be quiet.
- **The shine crosses the whole row.** #3779 confined it to `state` so it could not wander onto the
  clock or the hint; with the glyph gone and the row reading as one object, the owner asked for the
  light to cross all of it. The old argument was right for the row it was written about.

## Two things worth a reviewer's attention

**The alignment is an import, not a comment.** `ROW_TEXT_COLUMN` is exported from `sent_queue` and
imported by `activity_row`. A comment saying "keep these equal" records the intent and lets a
one-space edit break it silently; an import cannot drift. It is owned by `sent_queue` because the
offset is a consequence of *that* region's glyph — the queue has one, the NOW row aligns to it.

**The `▸`'s reason survived its deletion.** Per the comment policy, `@selected-style@`'s
"widgets pair this with a marker in the row text" is a **Class C relational invariant** — a claim
about a second location — so it is *restated*, not dropped: the pairing requirement is unchanged,
only what carries it. And the property the `▸` existed for (selection survives on a terminal where
no style renders) is kept by the same means it was lost from — **a differently shaped row is legible
with every attribute stripped**.

## Tests

Three tests pinned things this PR removes — the glyph prefix, the band's confinement, and splitting
a row on a fixed glyph. Replaced by ones stating what now holds:

- the row carries **no mark** and starts at the queue's label column, checked against
  `ROW_TEXT_COLUMN` rather than a literal `3` (a literal keeps passing through exactly the drift the
  shared constant exists to prevent)
- the band **does** cross past the state word — asserted over a **whole sweep**, because a band that
  silently kept the old confinement looks plausible frame by frame
- a row's label is taken **by column**, not by splitting on a glyph that now varies with selection

The `@quiet@` allowance for `sent_queue.py` is dropped — **the gate caught it as stale**, which is
the gate working rather than something I noticed.

## Test plan

- [x] `pytest tests/test_activity_row_3693.py tests/test_tui_colour_tokens.py tests/test_3300_p2b_sentqueue_render.py` — 34 passed (re-run after rebase)
- [x] `pytest -k "activity or colour or palette or queue or chrome or tail_away or compact_layout or 3300"` — 187 passed, 6 skipped
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` on both changed test files — 23 inspected, 0 errors
- [x] `python scripts/verify_module_docstrings.py` on all three changed src files — OK
- [x] Full `pytest` — **6 failed, 10154 passed, 46 skipped**. The six are the expected ones, by name,
      and are
      **not** this diff: a gitignored `reyn.local.yaml` sets `api_base`, which turns on proxy routing
      and strips the provider prefix three `test_compaction_resolver_aware_1172` assertions compare
      against. Established on #3788 by running `origin/main` detached *in the same working
      directory*. Being filed separately.
- [x] (skipped — the look cannot be established from text, and the owner checks it on `main`: their
      terminal is where it has to be judged, and it is not reachable until this lands)
      **Visual: real terminal** — that the columns line up, that `dim`/`bold` separate the rows, and
      whether `dim` is right at all (the owner raised it with a question mark; built as specified,
      not substituted).

## Next

Stage 3 (the NOW readout: `RESPONDING 12s · 3 entries · ctrl+end to latest · ctrl+c to abort`) and
stage 4 (key-hint wording). Stage 4 starts from a fresh sweep of *displayed strings*, not from the
grep-shaped list — lead-coder flagged their own list as possibly incomplete for that reason.

Part of #3777.
