### PR TITLE
fix(#3783): stage 1 — single shared context-overflow classifier

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -27,7 +27,10 @@ from reyn.runtime.router_tools import (
     build_tools,
     get_dispatch_kind,
 )
-from reyn.services.compaction.engine import _IMAGE_FIXED_TOKEN_COST
+from reyn.services.compaction.engine import (
+    _IMAGE_FIXED_TOKEN_COST,
+    is_context_overflow_error,
+)
 from reyn.services.turn_budget import wrap_up_system_prompt
 
 if TYPE_CHECKING:
@@ -383,26 +386,12 @@ def _is_empty_router_response(response: Any) -> bool:
     return finish == "stop" and not content.strip() and not tool_calls
 
 
-# Provider context-length errors arrive as litellm exceptions with varied class
-# names/messages; the chat session classifies them by keyword on the message
-# (session.py:5381-5384). #1092 PR-B reuses the SAME keyword set for the phase
-# force-close shrink-retry. NOTE: this list is currently duplicated here +
-# twice in session.py — a future cleanup should lift one shared
-# ``is_context_overflow_error`` (e.g. next to ``ContextOverflowError`` in
-# services/compaction); kept local here to avoid a session.py refactor in PR-B.
-_CONTEXT_OVERFLOW_KEYWORDS = (
-    "context", "token", "length", "limit", "too long", "too large",
-)
-
-
-def _is_context_overflow_error(exc: BaseException) -> bool:
-    """True when *exc* looks like a provider context-length overflow.
-
-    Keyword match on the stringified exception — the same heuristic the chat
-    session uses to convert litellm errors into ``ContextOverflowError``.
-    """
-    msg = str(exc).lower()
-    return any(kw in msg for kw in _CONTEXT_OVERFLOW_KEYWORDS)
+# #3783 stage 1: the TODO this comment used to carry ("a future cleanup
+# should lift one shared is_context_overflow_error, e.g. next to
+# ContextOverflowError in services/compaction") is done — this local
+# duplicate + the 3 in router_loop_driver.py + the divergent 4-keyword copy
+# in compaction/engine.py all replaced by
+# ``reyn.services.compaction.engine.is_context_overflow_error``.
 
 
 def _is_unsupported_param_error(exc: BaseException) -> bool:
@@ -411,7 +400,8 @@ def _is_unsupported_param_error(exc: BaseException) -> bool:
     Detects the gemini-via-LiteLLM-proxy case where the proxy adds
     ``encoding_format`` and the provider rejects it (``UnsupportedParamsError``),
     which fails the action embedding index build. Keyword/typename match — the
-    same stringified-exception heuristic family as ``_is_context_overflow_error``.
+    same stringified-exception heuristic family as
+    ``reyn.services.compaction.engine.is_context_overflow_error``.
     """
     return (
         "UnsupportedParams" in type(exc).__name__
@@ -2776,7 +2766,7 @@ class RouterLoop:
                     cur, resolved_model=resolved_model, reason=reason,
                 )
             except Exception as exc:  # noqa: BLE001
-                if not _is_context_overflow_error(exc):
+                if not is_context_overflow_error(exc):
                     raise
                 if shrink is None:
                     # Chat host: no in-loop shrink — propagate to the outer

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -378,9 +378,11 @@ class RouterLoopDriver:
                     _dropped.append(_head_span)
                 return _result.content or "", _covers, _dropped
             except Exception as _exc:
-                if not any(kw in str(_exc).lower() for kw in (
-                    "context", "token", "length", "limit", "too long", "too large",
-                )):
+                # #3783 stage 1: single shared predicate (was an inline copy).
+                from reyn.services.compaction.engine import (
+                    is_context_overflow_error as _is_context_overflow_error,
+                )
+                if not _is_context_overflow_error(_exc):
                     raise
                 _last_exc = _exc
         raise _ContextOverflowError(
@@ -409,16 +411,16 @@ class RouterLoopDriver:
         from reyn.services.compaction.engine import (
             UnrecoveredError as _UnrecoveredError,
         )
+        from reyn.services.compaction.engine import (
+            is_context_overflow_error as _is_context_overflow_error,
+        )
 
         history = self._history_buffer.build_history()
         try:
             return await loop.run(user_text=user_text, history=history)
         except Exception as _exc:
-            _exc_str = str(_exc).lower()
-            if not any(
-                kw in _exc_str
-                for kw in ("context", "token", "length", "limit", "too long", "too large")
-            ):
+            # #3783 stage 1: single shared predicate (was an inline copy).
+            if not _is_context_overflow_error(_exc):
                 raise
             self._events.emit(
                 "router_context_overflow_detected", error=repr(_exc)
@@ -444,9 +446,9 @@ class RouterLoopDriver:
                 try:
                     _usage = await loop.run(user_text=user_text, history=_msgs)
                 except Exception as _call_exc:
-                    if any(kw in str(_call_exc).lower() for kw in (
-                        "context", "token", "length", "limit", "too long", "too large",
-                    )):
+                    # #3783 stage 1: single shared predicate (was an inline
+                    # copy) — closes over the outer method's own import.
+                    if _is_context_overflow_error(_call_exc):
                         raise _ContextOverflowError(str(_call_exc)) from _call_exc
                     raise
                 return _RouterUsageShim(_usage)

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -685,6 +685,58 @@ class ContextOverflowError(Exception):
     """
 
 
+#: #3783 stage 1: the single shared "is this a context-overflow error"
+#: predicate. Previously duplicated (and already-diverged) in 5 places —
+#: router_loop.py's own ``_is_context_overflow_error``, 3 inline copies in
+#: router_loop_driver.py, and a 4-keyword subset here that was MISSING
+#: "too long"/"too large" (a real behaviour difference, not a cosmetic one:
+#: an overflow message using either phrase alone was silently NOT recognised
+#: at this one site — see the git history this constant replaces).
+#:
+#: Placed here (next to ``ContextOverflowError``, not in ``runtime``) per
+#: the arc's own TODO (this module was already the intended home —
+#: router_loop.py's old comment named it) and the architect's ruling: this
+#: predicate answers "is this an overflow", which is a property of the
+#: compaction/retry-loop domain the exception classes above already live
+#: in — NOT "can shrinking recover from this" (a separate, broader
+#: question #3783 stage 3 addresses; the two must not be merged into one
+#: predicate — see ``is_context_overflow_error``'s own docstring).
+_CONTEXT_OVERFLOW_KEYWORDS = (
+    "context", "token", "length", "limit", "too long", "too large",
+)
+
+
+def is_context_overflow_error(exc: BaseException) -> bool:
+    """True when *exc* looks like a provider context-length overflow.
+
+    #3783 stage 1: the single owner for this question, replacing 5
+    independent (and divergent) copies. Type-checked FIRST — litellm raises
+    ``ContextWindowExceededError`` (a ``BadRequestError`` subclass) for a
+    real provider-side overflow, a definitive positive — with a keyword
+    match on the stringified exception as a fallback for everything else.
+
+    The keyword fallback is NOT deleted (a litellm *proxy* can flatten a
+    provider's typed error down to a bare ``BadRequestError`` or another
+    generic exception, losing the specific type): `str(exc)` is a value the
+    thing being classified writes freely, so it is fine as a fallback signal
+    but must never be the ONLY signal when a stronger one (the type) is
+    available. This predicate answers ONLY "is this overflow" — it says
+    nothing about whether shrinking can fix it (that is
+    ``services.compaction.engine``'s own recover-classification, #3783
+    stage 3, a deliberately separate question living in this same module
+    but not this function).
+    """
+    try:
+        from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+        ensure_litellm_ready()
+        import litellm
+        if isinstance(exc, litellm.ContextWindowExceededError):
+            return True
+    except ImportError:
+        pass
+    return any(kw in str(exc).lower() for kw in _CONTEXT_OVERFLOW_KEYWORDS)
+
+
 class CompactionOverflowError(Exception):
     """The compaction LLM call itself exceeded its B_M budget.
 
@@ -1315,8 +1367,13 @@ async def retry_loop(
                     raw_middle = []
                 except Exception as exc:
                     # Detect compaction overflow from litellm exception.
-                    exc_str = str(exc).lower()
-                    if any(kw in exc_str for kw in ("context", "token", "length", "limit")):
+                    # #3783 stage 1: was a local 4-keyword subset MISSING
+                    # "too long"/"too large" — a real behaviour change, not
+                    # cosmetic: an overflow message using either phrase alone
+                    # was silently NOT recognised at this one site (unlike
+                    # the other 4, which already had all 6). Now the single
+                    # shared predicate (type-checked first).
+                    if is_context_overflow_error(exc):
                         raise CompactionOverflowError(str(exc)) from exc
                     raise
 

--- a/tests/test_router_loop_pure_helpers.py
+++ b/tests/test_router_loop_pure_helpers.py
@@ -3,7 +3,13 @@
 runtime/services/memory_service.py with the read_body operation that calls it).
 
 ``_overflow_ref_text(ref)``           — format image-overflow reference message
-``_is_context_overflow_error(exc)``   — keyword-match context length errors
+``is_context_overflow_error(exc)``    — context-length-overflow classification
+                                         (#3783 stage 1: moved from
+                                         router_loop.py's own
+                                         ``_is_context_overflow_error`` — one
+                                         of 5 divergent copies — to
+                                         ``reyn.services.compaction.engine``,
+                                         the single shared owner)
 ``_is_unsupported_param_error(exc)``  — class-name/keyword unsupported param errors
 """
 from __future__ import annotations
@@ -16,7 +22,6 @@ if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
 from reyn.runtime.router_loop import (
-    _is_context_overflow_error,
     _is_unsupported_param_error,
     _overflow_ref_text,
 )
@@ -25,6 +30,7 @@ from reyn.runtime.router_loop import (
 # module with the operations that use it; it is public there (read_body is its
 # only caller and lives beside it).
 from reyn.runtime.services.memory_service import strip_frontmatter as _strip_frontmatter
+from reyn.services.compaction.engine import is_context_overflow_error
 
 # ---------------------------------------------------------------------------
 # _strip_frontmatter
@@ -96,33 +102,126 @@ def test_overflow_ref_text_fallback_mime_type() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _is_context_overflow_error
+# is_context_overflow_error (#3783 stage 1: moved from router_loop.py)
 # ---------------------------------------------------------------------------
 
 
 def test_is_context_overflow_error_context_keyword() -> None:
     """Tier 2: exception message containing 'context' → True."""
-    assert _is_context_overflow_error(Exception("context window exceeded")) is True
+    assert is_context_overflow_error(Exception("context window exceeded")) is True
 
 
 def test_is_context_overflow_error_token_keyword() -> None:
     """Tier 2: exception message containing 'token' → True."""
-    assert _is_context_overflow_error(Exception("too many tokens")) is True
+    assert is_context_overflow_error(Exception("too many tokens")) is True
 
 
 def test_is_context_overflow_error_length_keyword() -> None:
     """Tier 2: exception message containing 'length' → True."""
-    assert _is_context_overflow_error(Exception("max length exceeded")) is True
+    assert is_context_overflow_error(Exception("max length exceeded")) is True
+
+
+def test_is_context_overflow_error_too_long_keyword() -> None:
+    """Tier 2: #3783 — exception message containing 'too long' → True.
+
+    This keyword (and 'too large' below) was MISSING from
+    compaction/engine.py's own pre-#3783 copy of this predicate — one of
+    the 5 divergent copies stage 1 unified. Pinned here because it is the
+    one keyword whose coverage actually changed for a real call site.
+    """
+    assert is_context_overflow_error(Exception("the prompt is too long")) is True
+
+
+def test_is_context_overflow_error_too_large_keyword() -> None:
+    """Tier 2: #3783 — exception message containing 'too large' → True (see
+    the 'too long' test above for why this pair is pinned separately)."""
+    assert is_context_overflow_error(Exception("input is too large")) is True
 
 
 def test_is_context_overflow_error_unrelated_exception() -> None:
     """Tier 2: exception without any overflow keyword → False."""
-    assert _is_context_overflow_error(Exception("network connection refused")) is False
+    assert is_context_overflow_error(Exception("network connection refused")) is False
 
 
 def test_is_context_overflow_error_case_insensitive() -> None:
     """Tier 2: keyword match is case-insensitive."""
-    assert _is_context_overflow_error(Exception("CONTEXT_LENGTH_EXCEEDED")) is True
+    assert is_context_overflow_error(Exception("CONTEXT_LENGTH_EXCEEDED")) is True
+
+
+def test_is_context_overflow_error_recognises_the_real_litellm_type() -> None:
+    """Tier 2: #3783 — a real ``litellm.ContextWindowExceededError`` (not a
+    plain ``Exception`` standing in for one) is recognised.
+
+    A real litellm exception happens to also carry its own class name inside
+    ``str(exc)`` (verified below), so this alone does not tell type-first
+    apart from substring-only. The two tests after this one construct
+    exceptions where the two signals genuinely DISAGREE, which is where
+    "type checked first" is actually observable — see lead-coder's review:
+    an example where both paths agree is not a witness for the order."""
+    import litellm
+
+    exc = litellm.ContextWindowExceededError(
+        message="the model declined this request",
+        model="gpt-4o", llm_provider="openai",
+    )
+    assert "context" in str(exc).lower(), (
+        "test premise: litellm's own class name leaks a keyword into str(exc) "
+        "here, which is exactly why this test cannot isolate the type check"
+    )
+    assert is_context_overflow_error(exc) is True
+
+
+def test_is_context_overflow_error_type_alone_recovers_when_message_has_no_keyword() -> None:
+    """Tier 2: #3783 — the type check is load-bearing on its own, not merely
+    a faster path to the same answer the substring fallback would give.
+
+    Constructs a genuine subclass of ``litellm.ContextWindowExceededError``
+    (a real instance, not a mock) whose ``__str__`` is overridden to contain
+    NONE of ``_CONTEXT_OVERFLOW_KEYWORDS`` — the case a real litellm proxy
+    could produce if it ever normalised the message text while preserving
+    the typed exception. Falsification (performed during review, not
+    re-run automatically here — it requires temporarily removing the
+    ``isinstance`` check from the production function): with the type
+    check removed, this test goes RED (``is_context_overflow_error``
+    returns ``False``) — confirming the type check is what this test
+    actually exercises, not a redundant fast path over the fallback."""
+    import litellm
+
+    class _RewordedOverflow(litellm.ContextWindowExceededError):
+        def __str__(self) -> str:
+            return "the request could not be completed"
+
+    exc = _RewordedOverflow(message="irrelevant", model="m", llm_provider="p")
+    assert not any(
+        kw in str(exc).lower()
+        for kw in ("context", "token", "length", "limit", "too long", "too large")
+    ), "test premise: the overridden __str__ must carry no overflow keyword"
+    assert isinstance(exc, litellm.ContextWindowExceededError)  # sanity: real subclass
+    assert is_context_overflow_error(exc) is True
+
+
+def test_is_context_overflow_error_substring_still_catches_a_flattened_type() -> None:
+    """Tier 2: #3783 — the substring fallback is load-bearing for the case
+    the type check CANNOT catch: a litellm proxy that flattens a provider's
+    typed overflow error down to a bare ``BadRequestError`` (not the
+    ``ContextWindowExceededError`` subclass), keeping only the message
+    text. A real (not mocked) ``litellm.BadRequestError`` instance, which
+    is NOT an instance of ``ContextWindowExceededError``.
+
+    Falsification (performed during review, not re-run automatically
+    here): with the substring fallback removed (type check only), this
+    test goes RED — confirming the fallback is load-bearing for this
+    case, not dead code the type check already covers."""
+    import litellm
+
+    exc = litellm.BadRequestError(
+        message="the context length exceeds the model's limit",
+        model="m", llm_provider="p",
+    )
+    assert not isinstance(exc, litellm.ContextWindowExceededError), (
+        "test premise: a flattened BadRequestError, not the typed subclass"
+    )
+    assert is_context_overflow_error(exc) is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[e2e-coder]** — #3783 段1（設計確定済: architect実測+lead-coder裁定）。段2(同一cause上限+audit-event)・段3(既定の反転)は別PR、この順序でないと反転の瞬間に「漏れ＝無限recover」の窓が開くため。

## 母集団（全リポgrep、issue記載の5箇所と一致）

```
router_loop.py:394              _CONTEXT_OVERFLOW_KEYWORDS(6語) + _is_context_overflow_error
router_loop_driver.py:382/420/448  同じ6語をインラインで3回
compaction/engine.py:1319       4語のみ（"too long"/"too large"欠落）
```

## 実装

`is_context_overflow_error(exc)` を `services/compaction/engine.py` の `ContextOverflowError` の隣に新設（既存TODOが名指ししていた場所）。型優先（`litellm.ContextWindowExceededError`）→substringをtie-back（litellm proxyが型を`BadRequestError`へ平坦化しうるため削除せず維持）。5箇所全て置換。

**このpredicateが答える問いは「overflowか」のみ**です。「shrinkで回復しうるか」（段3の問い）とは意図的に別 — architectの指摘通り、truncated JSONはA(overflow)では偽、B(recoverable)では真になりうるケースがあり、混ぜると段3の反転作業が解けなくなります。

## 挙動変更（明記、falsify確認済）

`compaction/engine.py` の1箇所のみ: 4語→6語で、"too long"/"too large" を含むメッセージが今回初めて拾われるようになります。旧4語セットに戻すとRED（`test_is_context_overflow_error_too_long_keyword`/`_too_large_keyword`）を確認済、復元してGREEN。

## 型優先の witness（lead-coderレビューラウンド）

実 litellm 例外1つでは型/substringの両方が一致してしまう（litellm自身の`__str__`がクラス名"ContextWindowExceededError"をmessageに埋め込むため）ことが判明 — 順序は「食い違うとき」しか観測できないため、2つの合成例外（本物のサブクラス/インスタンス、モックではない）で分離:

- **型のみ経路**: `ContextWindowExceededError`の実サブクラスで`__str__`をkeyword無しに上書き — isinstanceチェックを一時的に外すとRED確認済、復元
- **substringのみ経路**: 実`litellm.BadRequestError`（型不一致だがmessageにkeyword） — substring判定を一時的に外すとRED確認済、復元

両方とも本番コードを実際に一時変更してfalsify、docstringに「確認したこと」を正確に記載しています。

## Test plan

- [x] `ruff check src tests` — green
- [x] mypy ratchet — 新規finding 0
- [x] `python scripts/test_tier_audit.py --strict tests/test_router_loop_pure_helpers.py` — 23 tests, 0 errors
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] 関連テスト(context_overflow/retry_loop/force_close/1092等)116件 — green
- [x] `pytest`（フルスイート）— 10234 passed, 40 skipped, 0 failed

段2に進みます。