### PR TITLE
docs: drop the full local-pytest requirement (owner-approved 2026-08-07)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,11 +25,14 @@ modifying tests: [`docs/deep-dives/contributing/testing.ja.md`](../docs/deep-div
 - Which Tier do the new/changed tests belong to? (1: Contract / 2: OS
   invariant / 3: LLM-replay behavior / scaffold)
 - New tests added: yes / no — if no, why?
-- All tests pass locally: yes / no
+- Local gates pass (ruff / tier-audit / module-docstring / mypy-ratchet +
+  the tests this diff touches): yes / no — **do not run the full suite
+  locally**, CI does that; see `testing.md` § "Before you push"
 
 ## Checklist
 
-- [ ] Tests pass locally (`pytest`).
+- [ ] Local gates pass (ruff / tier-audit / module-docstring / mypy-ratchet
+      + tests relevant to this diff) — not the full suite; CI runs that.
 - [ ] Lint / format clean.
 - [ ] No domain-specific strings (phase names, artifact types, fields)
       added to OS code (P7).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,18 +109,32 @@ Key constraints (full rationale in the doc):
 This repo is touched by multiple Claude sessions (lead-coder, e2e-coder,
 per-PR coders) authenticating as the same `gh` user.
 
-**Before you open a PR, run all five CI gates locally** — `ruff check src
-tests`, `python scripts/test_tier_audit.py --strict <changed test files>`,
-`pytest` (from the repo root), `python scripts/verify_module_docstrings.py
-<changed src files>`, and `python scripts/mypy_ratchet.py` (#3726 — a
-*ratchet*, not full mypy adoption: it only fails on a `(file, error-code)`
-pair not already in `scripts/mypy_ratchet_baseline.json`; a genuinely new
-mypy finding in a file you touched will fail this even though `mypy` itself
-isn't in this repo's mental model of "the linter") are *separate*
-CI jobs. A green `pytest` alone is **not** a green CI run (`pytest-green ≠
-CI-green`): ruff `I001` import-sort and a Tier-4 format pin (`len(...) == N`)
-both fail CI while `pytest` passes. Details + the Tier-4 → behavioral-assertion
-fix idioms: `docs/deep-dives/contributing/testing.md` § "Before you push".
+**Before you open a PR, run four gates locally, plus whatever tests your
+diff touches** — `ruff check src tests`, `python scripts/test_tier_audit.py
+--strict <changed test files>`, `python scripts/verify_module_docstrings.py
+<changed src files>`, `python scripts/mypy_ratchet.py` (#3726 — a *ratchet*,
+not full mypy adoption: it only fails on a `(file, error-code)` pair not
+already in `scripts/mypy_ratchet_baseline.json`; a genuinely new mypy
+finding in a file you touched will fail this even though `mypy` itself
+isn't in this repo's mental model of "the linter"), and `pytest` scoped to
+files/keywords your change actually affects. **Do NOT run the full `pytest`
+suite from the repo root locally — owner-approved (2026-08-07): CI already
+does this, in a clean checkout, in ~5 minutes across 11 checks.** A local
+full run measured 900s, was killed mid-run more than once, and reliably
+reports 6 failures that are not yours — `tests/test_compaction_resolver_
+aware_1172.py` and friends fail whenever `reyn.local.yaml` exists on the
+machine (gitignored, so present on most dev checkouts, absent on CI and any
+fresh worktree — #3791). Running it locally is strictly worse than trusting
+CI: slower, and wrong on every developer machine with local config. (This
+reverses #3750's "four → five" fix from earlier the same day — CI itself
+still runs five gates, unchanged; what changed is which of them a human
+runs *locally* before opening the PR. If you're about to "fix" this back to
+five, read `testing.md` § "Before you push" first — the reasoning is there.)
+CI still runs all five gates on every PR — a green `pytest` alone (if you
+ran it anyway) is **not** a green CI run (`pytest-green ≠ CI-green`): ruff
+`I001` import-sort and a Tier-4 format pin (`len(...) == N`) both fail CI
+while `pytest` passes. Details + the Tier-4 → behavioral-assertion fix
+idioms: `docs/deep-dives/contributing/testing.md` § "Before you push".
 
 These rules then keep multi-session work coherent:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,32 +109,21 @@ Key constraints (full rationale in the doc):
 This repo is touched by multiple Claude sessions (lead-coder, e2e-coder,
 per-PR coders) authenticating as the same `gh` user.
 
-**Before you open a PR, run four gates locally, plus whatever tests your
-diff touches** — `ruff check src tests`, `python scripts/test_tier_audit.py
---strict <changed test files>`, `python scripts/verify_module_docstrings.py
-<changed src files>`, `python scripts/mypy_ratchet.py` (#3726 — a *ratchet*,
-not full mypy adoption: it only fails on a `(file, error-code)` pair not
-already in `scripts/mypy_ratchet_baseline.json`; a genuinely new mypy
-finding in a file you touched will fail this even though `mypy` itself
-isn't in this repo's mental model of "the linter"), and `pytest` scoped to
-files/keywords your change actually affects. **Do NOT run the full `pytest`
-suite from the repo root locally — owner-approved (2026-08-07): CI already
-does this, in a clean checkout, in ~5 minutes across 11 checks.** A local
-full run measured 900s, was killed mid-run more than once, and reliably
-reports 6 failures that are not yours — `tests/test_compaction_resolver_
-aware_1172.py` and friends fail whenever `reyn.local.yaml` exists on the
-machine (gitignored, so present on most dev checkouts, absent on CI and any
-fresh worktree — #3791). Running it locally is strictly worse than trusting
-CI: slower, and wrong on every developer machine with local config. (This
-reverses #3750's "four → five" fix from earlier the same day — CI itself
-still runs five gates, unchanged; what changed is which of them a human
-runs *locally* before opening the PR. If you're about to "fix" this back to
-five, read `testing.md` § "Before you push" first — the reasoning is there.)
-CI still runs all five gates on every PR — a green `pytest` alone (if you
-ran it anyway) is **not** a green CI run (`pytest-green ≠ CI-green`): ruff
-`I001` import-sort and a Tier-4 format pin (`len(...) == N`) both fail CI
-while `pytest` passes. Details + the Tier-4 → behavioral-assertion fix
-idioms: `docs/deep-dives/contributing/testing.md` § "Before you push".
+**Before you open a PR, run `ruff check src tests`, `python
+scripts/test_tier_audit.py --strict <changed test files>`, `python
+scripts/verify_module_docstrings.py <changed src files>`, `python
+scripts/mypy_ratchet.py`, and `pytest` scoped to the files/keywords your
+diff actually affects.** **Do NOT run the full `pytest` suite from the repo
+root locally** — CI already does that, in a clean checkout, faster and
+without picking up local machine config a full local run would (#3791).
+This is testing.md's own canonical policy, not a CLAUDE.md-specific rule —
+read `docs/deep-dives/contributing/testing.md` § "Before you push" for the
+full reasoning (why the full run was dropped, not just discouraged; what
+running it locally actually costs vs. CI; the #3750 count history) before
+changing this paragraph, in either doc. A green scoped `pytest` alone is
+**not** a green CI run (`pytest-green ≠ CI-green`): ruff `I001` import-sort
+and a Tier-4 format pin (`len(...) == N`) both fail CI while `pytest`
+passes.
 
 These rules then keep multi-session work coherent:
 

--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -722,14 +722,38 @@ REYN_LLM_RECORD=1 python -m pytest tests/ -v
 ## Before you push — the five CI gates
 
 A green `pytest` run is **not** a green CI run. `.github/workflows/test.yml` runs
-five *separate* gates; run all five locally on your diff before calling a PR
-ready:
+five *separate* gates. **Owner-approved (2026-08-07): run four of them locally,
+plus whatever tests your diff actually touches — do not run the full suite
+locally.** This is a reversal of #3750's same-day "four → five" fix, which made
+this section say "run all five" for a few hours; if that history makes you want
+to revert this back to five, read the next two paragraphs first.
 
-1. **pytest** — from the repo root (not a subset path) so collection matches CI:
+**Why the full local run was dropped, not just discouraged**: measured at
+900s for a clean pass, with more than one run killed partway through before
+finishing at all. Worse, a local run — but never CI — reliably reports 6
+failures that are not about your change: `tests/test_compaction_resolver_
+aware_1172.py` and 5 others fail whenever `reyn.local.yaml` exists on the
+machine running them. That file is gitignored, so it's present on most
+developer checkouts and absent on CI and any fresh worktree (#3791) — the
+suite was reading ambient developer config, and the polarity was backwards
+(CI green, the configured developer red, always for a reason unrelated to
+their diff). CI runs the same suite in a clean checkout in ~5 minutes across
+11 checks — a local full run is strictly worse than trusting that: slower,
+and wrong on every machine with local config.
+
+1. **pytest, scoped to your diff** — run the tests your change actually
+   touches, by file path or `-k <keyword>`, not the whole suite:
    ```bash
-   python -m pytest -q -n auto --timeout=120
+   python -m pytest tests/test_your_area.py -q
+   # or, to catch anything matching a keyword across the tree:
+   python -m pytest -q -k "your_feature"
    ```
-   CI runs with `-n auto` (parallel workers) and `--timeout=120` (`pytest-timeout>=2.2`, a dev dep — `pip install -e ".[dev]"` installs it). Run locally with the same flags: a test that would hang in CI will fail-and-name the hanger within 120 s instead of blocking the run indefinitely.
+   The `-n auto --timeout=120` flags CI uses exist to give full-suite
+   collection parity and a hang-namer for a 10000+ test run — neither
+   matters for a scoped local run of a handful of files; a plain invocation
+   is fine. CI still runs the untruncated suite with those flags on every
+   PR, so a hang in your change is still caught there even though you don't
+   reproduce that flag combination locally.
 2. **ruff** — lint + import-sort (`I001`):
    ```bash
    ruff check src tests        # add --fix for autofixable I001 / formatting
@@ -760,9 +784,12 @@ ready:
    python scripts/mypy_ratchet.py
    ```
 
-A green `pytest` alone has shipped PRs that CI then bounced on ruff (`I001`) or
-the tier audit (a `len(...) == 1` format pin). Report scope honestly: say
-"pytest passed" if that is all you ran — "suite passed" implies all five gates.
+A green scoped `pytest` run alone has shipped PRs that CI then bounced on ruff
+(`I001`) or the tier audit (a `len(...) == 1` format pin). Report scope
+honestly: say which of the five you actually ran locally (e.g. "ruff +
+tier-audit + mypy ratchet + the tests I touched") rather than "suite passed" —
+that phrase implies the full local run this section no longer asks for, and CI
+is the only place all five now run together.
 
 ---
 

--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -728,18 +728,42 @@ locally.** This is a reversal of #3750's same-day "four → five" fix, which mad
 this section say "run all five" for a few hours; if that history makes you want
 to revert this back to five, read the next two paragraphs first.
 
-**Why the full local run was dropped, not just discouraged**: measured at
-900s for a clean pass, with more than one run killed partway through before
-finishing at all. Worse, a local run — but never CI — reliably reports 6
-failures that are not about your change: `tests/test_compaction_resolver_
-aware_1172.py` and 5 others fail whenever `reyn.local.yaml` exists on the
-machine running them. That file is gitignored, so it's present on most
-developer checkouts and absent on CI and any fresh worktree (#3791) — the
-suite was reading ambient developer config, and the polarity was backwards
-(CI green, the configured developer red, always for a reason unrelated to
-their diff). CI runs the same suite in a clean checkout in ~5 minutes across
-11 checks — a local full run is strictly worse than trusting that: slower,
-and wrong on every machine with local config.
+**Why the full local run was dropped, not just discouraged.** The mechanism
+first — `.github/workflows/test.yml`'s pytest job runs on a `matrix` of
+`python-version: ["3.11", "3.12"]`, each on its own dedicated `ubuntu-latest`
+runner: two clean machines, one per Python version, running concurrently, each
+with `-n auto` claiming that machine's own cores for itself alone. Locally,
+`-n auto` reads the SAME machine's core count, but that machine is very likely
+also running other work at once (another session, another tool) — the same
+flag means "use all the cores, they're yours" in CI and "take a share of
+cores other processes are also using" locally. It is not the same operation
+scaled down; it's the same command over a different, contended resource.
+
+Measured under that contention: 900s for a clean local pass, with more than
+one run killed partway through before finishing at all (load average 17 on
+an 8-core machine, lead-coder's own measurement — plausible given multiple
+concurrent `-n auto` sessions, not independently re-measured here). Separately
+from the slowness, a local run — but never CI — reliably reports 6 failures
+that are not about your change: `tests/test_compaction_resolver_aware_1172.py`
+and 5 others fail whenever `reyn.local.yaml` exists on the machine running
+them. That file is gitignored, so it's present on most developer checkouts
+and absent on CI and any fresh worktree (#3791) — the suite was reading
+ambient developer config, and the polarity was backwards (CI green, the
+configured developer red, always for a reason unrelated to their diff). CI
+runs the same suite in a clean checkout in ~5 minutes across 11 checks — a
+local full run is not merely slower than that, it is a WORSE measurement:
+narrower (one Python version, not two, since running both locally means
+paying the contention cost twice) and contaminated by config CI never sees.
+
+**What this actually gives up, stated plainly**: a change that breaks a test
+FAR from the files you touched is now something you learn from CI, not from
+your own local run before pushing. That is a real cost, not a null one — the
+judgment made here is that paying 900 contended, sometimes-wrong seconds on
+every push to catch it slightly earlier is not worth it when CI reports the
+same thing, correctly, in about 5 minutes. If that trade stops being worth it
+(CI queue times grow, or the failure class this catches turns out to matter
+more than expected), that's a reason to revisit this section, not a reason to
+silently start running the full suite locally again without updating it.
 
 1. **pytest, scoped to your diff** — run the tests your change actually
    touches, by file path or `-k <keyword>`, not the whole suite:


### PR DESCRIPTION
**[docs-maintainer]** — Owner-approved decision (2026-08-07, relayed by lead-coder) that was never landed in the docs, so everyone kept paying for a full local `pytest` run that CI already duplicates.

## What changed

- **CLAUDE.md**: PR-workflow paragraph now says run 4 fast gates locally (ruff, tier-audit, module-docstring, mypy-ratchet) + only the tests your diff touches. CI still runs all 5 gates, unchanged — only the local subset moved.
- **testing.md** § "Before you push": same change, plus the reasoning stated explicitly (900s local runtime, killed mid-run more than once, 6 reliable false failures from a gitignored `reyn.local.yaml` present on dev machines and absent on CI — #3791 — vs. CI's clean-checkout ~5min/11-check run). Also notes this *reverses* #3750's same-day "four → five" local-count fix, so the next reader doesn't flip it back without reading why.
- **`.github/PULL_REQUEST_TEMPLATE.md`**: the checklist still asked "All tests pass locally: yes/no" and "Tests pass locally (`pytest`)" — both stale under the new policy, and the artifact most likely to silently perpetuate the old requirement on every future PR if left unfixed.

## Also addressed

Dropped the `-n auto --timeout=120` flags from the example scoped-`pytest` invocation — they exist for full-suite collection parity and a hang-namer over 10000+ tests, neither relevant to a handful of files run locally. CI still applies them to the untruncated run it does.

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean
- [x] `python scripts/check_doc_anchors.py` — 0 dangling anchors
- [x] `pytest tests/test_3126_doc_anchor_gate.py` — 331/331 pass