### PR TITLE
feat(#3777): paint the shine's ground, and split the count from where the reader is

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/activity_row.py
+++ b/src/reyn/interfaces/inline/textual_chat/activity_row.py
@@ -159,12 +159,17 @@ def activity_text(
     that just started — and "no clock" reads as what it is: a turn whose start
     this client never saw.
 
-    The format is bare seconds (#3777, from the owner's mock: ``RESPONDING
-    12s``), replacing the ``MM:SS`` this row used until now. **Past a minute
-    that is worse, not better** — ``1247s`` is a number nobody reads at a
-    glance and ``20:47`` is — and switching format at sixty seconds would be
-    this module choosing for the operator. It is left as specified and raised
-    on the PR instead.
+    The format changes at a minute (#3777, owner ruling): bare seconds below
+    (``12s``, from the owner's mock), ``MM:SS`` at and above it (``20:47``).
+    Each is the readable one in its own range — ``00:12`` makes a short turn
+    look like a stopwatch, and ``1247s`` is a number nobody reads at a glance.
+
+    A format that changes under the operator is normally this module deciding
+    something that is theirs; the reason it is allowed here is that **what the
+    reader is looking at is the elapsed time, not the format**, so a change
+    toward the readable form is not something they have to notice or learn.
+    That argument is what the ruling turned on, and it is the thing to re-check
+    before extending this to any other switching format.
 
     ``entries`` is how many entries this TURN has produced, counted from the
     moment it started and shown from zero upward. ``away`` is whether the
@@ -191,7 +196,11 @@ def activity_text(
     prefix = " " * ROW_TEXT_COLUMN if state else ""
     head = f"{prefix}{state}"
     if elapsed_s is not None:
-        head = f"{head} {int(elapsed_s)}s"
+        seconds = int(elapsed_s)
+        head = (
+            f"{head} {seconds}s" if seconds < 60
+            else f"{head} {seconds // 60:02d}:{seconds % 60:02d}"
+        )
 
     # Segments in the order they are printed, each with what it costs to lose.
     # Dropping from the right would take the abort hint first, and a row that

--- a/src/reyn/interfaces/inline/textual_chat/activity_row.py
+++ b/src/reyn/interfaces/inline/textual_chat/activity_row.py
@@ -72,23 +72,30 @@ from reyn.interfaces.inline.textual_chat.sent_queue import ROW_TEXT_COLUMN
 #: The cancel affordance shown while a turn runs. Plain ASCII: the key it names
 #: is the app's own ``ctrl+c`` binding, and this row shares a narrow terminal
 #: with the queue below it.
-_CANCEL_HINT = "Ctrl+C cancel"
+_CANCEL_HINT = "ctrl+c to abort"
 
 #: The key that returns to the newest output (#3712). Named here so the row and
 #: the binding that implements it cannot drift: a printed key that does not
 #: work is worse than none, and the conversation pane's own ``end``/``G`` only
 #: fire while it holds focus — i.e. never from where the reader actually is.
-LATEST_HINT = "Ctrl+End"
+LATEST_HINT = "ctrl+end to latest"
 
-#: How wide the travelling highlight band is, in characters. Odd, so the band
-#: has ONE centre cell for the cosine to peak on rather than two cells tied
-#: for brightest — a two-cell peak is what makes a band read as a block that
-#: blinks instead of a light that moves. Five rather than rich's twenty
-#: (``PULSE_SIZE``): rich sizes its band against a full-width progress bar,
-#: and ours travels through ``state`` alone, which is ten characters at
-#: ``"RESPONDING"``. A band wider than half its own runway never resolves as
-#: a band at all.
-_SHINE_WIDTH = 5
+#: How wide the band is, as a FRACTION of what it travels across. Not a fixed
+#: character count: #3777 stage 2 widened the band's runway from the state word
+#: to the whole row, and a width in cells that read as a moving point across
+#: ten characters reads as a speck across eighty. A fraction keeps the band the
+#: same size relative to what it is crossing, which is what "looks the same"
+#: actually means here. 40% is the proportion the common CSS shimmer
+#: implementations use.
+_SHINE_FRACTION = 0.4
+
+#: How long ONE pass takes, in seconds — the pace is a duration, not a speed.
+#: A speed in cells per second was the earlier shape and it does not survive a
+#: change of runway: the same cells/second crosses a short row quickly and a
+#: long one slowly, so widening the band's span silently changed how urgent the
+#: row felt. Fixing the DURATION makes the row feel the same at any width,
+#: which is the property being aimed at.
+_SHINE_PASS_SECONDS = 3.0
 
 #: The shine where the terminal reports no usable colour. The band degrades to
 #: what #3779 shipped — a two-character ``reverse`` — rather than to nothing:
@@ -104,36 +111,32 @@ _SHINE_FALLBACK_WIDTH = 2
 
 
 
-@lru_cache(maxsize=1)
-def _shine_ramp() -> "tuple[str, ...]":
-    """One colour per cell of the band, brightest first.
+@lru_cache(maxsize=64)
+def _shine_ramp(half: int, ground: str, peak: str) -> "tuple[str, ...]":
+    """One colour per cell of the band, brightest first, ending at ``ground``.
 
-    Index is the cell's DISTANCE from the band's centre, so ``[0]`` is the
-    peak and the last entry is the faintest cell still painted; anything
-    further out is left unstyled and keeps the terminal's own foreground.
-    Storing it by distance rather than by absolute position is what lets the
-    band slide without recomputing: the ramp is a property of the band, and
-    only where its centre sits changes per frame.
+    Index is the cell's DISTANCE from the band's centre, so ``[0]`` is the peak
+    and the last entry IS the ground — the band's outermost cell is already the
+    colour every other character on the row is wearing, so there is no step
+    where the band ends. That is the whole correction: painting only the band
+    and leaving the rest at the terminal's own foreground put a dark cell hard
+    against an undimmed ground at each end, and the operator read the result as
+    three things moving rather than one.
 
-    The shape is a raised cosine — ``0.5 + cos(pi * d / half) / 2`` — which is
-    the same curve rich's ``_get_pulse_segments`` uses, reached by calling its
-    ``blend_rgb`` rather than by copying it. rich's ``ProgressBar`` itself is
-    no use to us: it is a component that draws its OWN bar, not one that
-    lights up someone else's text, so the only reusable part was the blend,
-    and that is already public API.
+    The shape is a raised cosine — ``0.5 + cos(pi * d / half) / 2`` — reached by
+    calling rich's public ``blend_rgb`` rather than copying its
+    ``_get_pulse_segments``. rich's ``ProgressBar`` is no use to us: it draws
+    its OWN bar, it does not light up someone else's text.
 
-    Cached because the ramp is fixed for the life of the process and this runs
-    at ``SHINE_FPS`` — recomputing five blends per frame, forever, to arrive
-    at the same five strings is the kind of cost that never shows up in a
-    profile and never stops being paid.
+    Cached across half-widths and ground pairs, since the row's width and the
+    terminal's theme both change rarely and this runs on every frame.
     """
-    dim = Color.parse(palette.SHINE_DIM).get_truecolor()
-    peak = Color.parse(palette.SHINE_PEAK).get_truecolor()
-    half = _SHINE_WIDTH // 2
+    dim = Color.parse(ground).get_truecolor()
+    bright = Color.parse(peak).get_truecolor()
     ramp: "list[str]" = []
     for distance in range(half + 1):
         fade = 1.0 if half == 0 else 0.5 + math.cos(math.pi * distance / half) / 2.0
-        blended = blend_rgb(dim, peak, cross_fade=fade)
+        blended = blend_rgb(dim, bright, cross_fade=fade)
         ramp.append(f"#{blended.red:02x}{blended.green:02x}{blended.blue:02x}")
     return tuple(ramp)
 
@@ -143,9 +146,11 @@ def activity_text(
     *,
     elapsed_s: "float | None" = None,
     width: int = 80,
-    behind: "int | None" = None,
-    shine_index: "int | None" = None,
+    entries: int = 0,
+    away: bool = False,
+    shine_phase: "float | None" = None,
     colour: bool = True,
+    dark: bool = True,
 ) -> Content:
     """The rendered row for ``state``.
 
@@ -153,118 +158,99 @@ def activity_text(
     prints no clock rather than a zero, because "00:00" reads as a fact and
     "no clock" reads as what it is.
 
-    ``behind`` (#3712) is how many entries have landed since the reader left
-    the newest output, or ``None`` while they are still on it. It takes the
-    right-hand slot ahead of the cancel hint: someone reading back through an
-    older reply cannot see the new output arriving, and that is the more
-    urgent of the two. Both are dropped before the state itself.
+    ``entries`` is how many entries this TURN has produced, counted from the
+    moment it started and shown from zero upward. ``away`` is whether the
+    reader has scrolled off the newest output. They are two parameters because
+    they are two facts: the previous shape was one ``behind: int | None`` where
+    ``None`` meant "following" and an int meant "away, by this much", which
+    made the count's baseline *the instant the reader scrolled away* — an event
+    the reader never sees, so ``LIVE +N`` offered no occasion on which its
+    meaning could be learned. A turn's start is something the reader did see.
+    ``away`` now decides one thing only: whether the return-to-latest hint is
+    printed.
 
-    ``shine_index`` (owner-picked design "A", replacing the removed ``NOW``
-    label): the frame number of a ``_SHINE_WIDTH``-character band travelling
-    across the WHOLE rendered row — ``None`` paints no band (a static row,
-    e.g. while no turn is showing). It is a frame counter, not a character
-    offset: the band's centre is ``shine_index - _SHINE_WIDTH // 2``, so it
-    starts off the left edge and runs off the right.
+    ``shine_phase`` is where in one pass the travelling highlight is, as a
+    fraction in ``[0, 1)`` — ``None`` paints no band (a static row, e.g. while
+    no turn is showing). ``colour`` is whether the terminal can show one, and
+    ``dark`` whether its background is dark; between them they choose the
+    ground/peak pair, or the attribute fallback when there is no colour at all.
 
-    #3779 confined the band to ``state``'s own span, so it could not wander
-    onto the elapsed clock or the hint. #3777 lifted that: with the glyph gone
-    and the row reading as ONE object rather than as three things sharing a
-    line, the owner asked for the light to cross all of it. The old argument
-    was not wrong — it was the right answer for the row it was written about.
-
-    ``colour`` is whether the terminal can show one. ``True`` paints the band
-    as a cosine ramp between :data:`palette.SHINE_DIM` and
-    :data:`palette.SHINE_PEAK`; ``False`` degrades it to the two-character
-    ``reverse`` #3779 shipped. The gradient is the point — a two-valued band
-    has no edge to fall off, so it reads as a block blinking rather than a
-    light travelling, which is what the operator reported.
+    Segments are separated by ``·`` and read left to right, hints included:
+    there is no right-aligned slot any more. A right edge only reads as a
+    place things belong when the row is wide enough for the gap to look
+    deliberate, and this row shares a terminal with everything else.
     """
-    # Spaces, not a glyph (#3777, owner call): the NOW row carries no mark of
-    # its own, and its text starts in the column a queue row's LABEL starts in
-    # — the two regions then read as one column of text with the queue's
-    # glyphs hanging off its left edge, rather than as two lists that happen to
-    # sit above each other. The width comes from the queue rather than being
-    # written here twice; see ``sent_queue.ROW_TEXT_COLUMN``.
     prefix = " " * ROW_TEXT_COLUMN if state else ""
-    body = f"{prefix}{state}"
+    head = f"{prefix}{state}"
     if elapsed_s is not None:
-        body = f"{body} {int(elapsed_s) // 60:02d}:{int(elapsed_s) % 60:02d}"
-    suffix = f"LIVE +{behind} · {LATEST_HINT} latest" if behind else _CANCEL_HINT
-    content = _with_suffix(body, suffix, width)
-    if shine_index is not None and state:
-        # The whole row, not just the state word (#3777, owner call). #3779
-        # confined the band to ``state`` so it could not wander onto the clock
-        # or the hint; with the glyph gone and the row reading as one object,
-        # the owner asked for the light to cross all of it. The clearance
-        # argument that produced the old confinement is not wrong — it was an
-        # answer to a row that was three separate things in a line.
-        content = _apply_shine(content, 0, len(content.plain), shine_index, colour)
+        head = f"{head} {int(elapsed_s)}s"
+
+    # Segments in the order they are printed, each with what it costs to lose.
+    # Dropping from the right would take the abort hint first, and a row that
+    # gave up "how to stop this" to keep a count would have its priorities
+    # backwards. The head is never dropped: a row that cannot say what is
+    # happening has nothing left to be.
+    optional = [
+        (f"{entries} entries", 0),
+        (LATEST_HINT, 2) if away else None,
+        (_CANCEL_HINT, 3),
+    ]
+    segments = [seg for seg in optional if seg is not None]
+    while segments and len(" · ".join([head, *(t for t, _ in segments)])) > width:
+        segments.remove(min(segments, key=lambda seg: seg[1]))
+    line = " · ".join([head, *(text for text, _ in segments)])
+
+    content = Content(line)
+    if shine_phase is not None and state:
+        # The whole row (#3777, owner call). #3779 confined the band to
+        # ``state`` so it could not wander onto the clock or the hint; with the
+        # glyph gone and the row reading as ONE object, the owner asked for the
+        # light to cross all of it.
+        content = _apply_shine(content, len(line), shine_phase, colour, dark)
     return content
 
 
 def _apply_shine(
-    content: Content, base: int, span: int, frame: int, colour: bool
+    content: Content, span: int, phase: float, colour: bool, dark: bool
 ) -> Content:
-    """The travelling band, painted over ``span`` characters starting at ``base``.
+    """The travelling band over ``span`` characters, at ``phase`` of one pass.
 
-    ``base`` is where ``state`` begins in the rendered line; every offset below
-    is relative to ``state`` and shifted by it, so the band never reaches back
-    over the leading glyph, the space after it, the elapsed clock, or the
-    right-hand hint. Those are different information and stay plain — the
-    clearance #3777 required.
+    ``phase`` is a fraction in ``[0, 1)`` rather than a frame number, so the
+    caller expresses WHEN in the pass the row is, and the pass takes the same
+    wall-clock time whatever the row's width. A frame counter cannot do that:
+    its cycle is measured in cells, so a wider row takes proportionally longer
+    and the row silently feels less urgent the more there is on it.
 
-    ``frame`` is wrapped here rather than by the caller, because the cycle's
-    length depends on ``span`` — i.e. on ``len(state)``, which changes every
-    time the state does. A widget that owned the wrap would have to re-derive
-    it on each ``specialise``, and a frame counter left over from the previous
-    state would silently sit outside the new cycle and paint nothing while a
-    turn was visibly running. Wrapping where the length is known makes any
-    integer a valid frame.
+    EVERY character is painted, not only the band. Outside the band each cell
+    takes the ground, and the band's own outermost cell IS the ground, so the
+    band has no edge to step off. Painting only the band and leaving the rest
+    at the terminal's foreground is what made the operator see three moving
+    things rather than one — a dark cell at each end of the band, hard against
+    an undimmed ground, is two more features than the design has.
 
-    The band's centre is ``frame - half``, so the cycle starts with the centre
-    OFF the left edge and ends with it past the right. That is what makes the
-    light enter and leave, rather than materialise at the first character and
-    vanish at the last — clamp the centre inside the span instead and the two
-    end frames hold a stationary half-band, which reads as a stutter at both
-    ends of every pass.
+    The centre runs from ``-half`` to ``span - 1 + half`` so the light enters
+    and leaves rather than materialising at the first character and vanishing
+    at the last.
     """
-    half = _SHINE_WIDTH // 2
-    # ``span + 2 * half``, not ``span + _SHINE_WIDTH``: the centre must reach
-    # from ``-half`` (leftmost cell just lit) to ``span - 1 + half`` (rightmost
-    # cell still lit) and no further. One frame more and the band sits entirely
-    # off the right edge — a single dark frame per pass, which at SHINE_FPS is
-    # a blink in an animation whose whole job is to look continuous.
-    frame %= max(1, span + 2 * half)
+    ground = palette.SHINE_GROUND_DARK if dark else palette.SHINE_GROUND_LIGHT
+    peak = palette.SHINE_PEAK_DARK if dark else palette.SHINE_PEAK_LIGHT
+    half = max(1, round(span * _SHINE_FRACTION / 2))
     if not colour:
-        # Same two characters #3779 shipped, so the degraded form is a form
-        # this row has already been seen in rather than a third design.
-        start = base + max(0, min(frame - half, span - 1))
+        # Same two characters #3779 shipped, so the degraded form is one this
+        # row has already been seen in rather than a third design. No ground:
+        # an attribute has no "slightly on", so there is nothing to paint the
+        # rest of the row WITH that would not simply emphasise all of it.
+        start = max(0, min(int(phase * span), span - 1))
         return content.stylize(
-            _SHINE_FALLBACK_STYLE, start, min(start + _SHINE_FALLBACK_WIDTH, base + span)
+            _SHINE_FALLBACK_STYLE, start, min(start + _SHINE_FALLBACK_WIDTH, span)
         )
-    centre = frame - half
-    for distance, style in enumerate(_shine_ramp()):
-        # Both sides of the centre at this distance — and only once when
-        # distance is 0, or the centre cell would be styled twice.
-        for position in {centre - distance, centre + distance}:
-            if 0 <= position < span:
-                content = content.stylize(style, base + position, base + position + 1)
+    ramp = _shine_ramp(half, ground, peak)
+    centre = phase * (span + 2 * half) - half
+    for position in range(span):
+        distance = round(abs(position - centre))
+        style = ramp[distance] if distance <= half else ground
+        content = content.stylize(style, position, position + 1)
     return content
-
-
-def _with_suffix(body: str, suffix: str, width: int) -> Content:
-    """``body`` with ``suffix`` right-aligned, or ``body`` alone if it will not
-    fit WHOLE.
-
-    Never clipped. A cut ``Ctrl+C cancel`` ends as ``Ctrl+C``, which still
-    reads as a complete instruction and is a different one — the row would be
-    naming a key combination nobody chose. The same applies to a cut
-    ``Ctrl+End latest``. Dropping it costs nothing: both bindings work whether
-    or not they are printed.
-    """
-    pad = width - len(body) - len(suffix)
-    text = f"{body}{' ' * pad}{suffix}" if pad >= 1 else body
-    return Content(text)
 
 
 class ActivityRow(Static):
@@ -292,15 +278,15 @@ class ActivityRow(Static):
         self._clock = clock
         self._state: "str | None" = None
         self._started_at: "float | None" = None
-        self._behind: "int | None" = None
-        self._shine_index = 0
+        self._entries = 0
+        self._away = False
         self._timer: "Timer | None" = None
 
     #: The shine's frame rate (owner-picked design "A"). Also what drives the
     #: elapsed clock now — ONE timer, not two: :meth:`tick` recomputes the
     #: elapsed seconds from the real clock on every call regardless of how
     #: often it runs, so a faster shared tick costs nothing in correctness,
-    #: only ``_SHINE_WIDTH``-worth of extra string work per frame (one Static
+    #: only one Static line of extra string work per frame
     #: line, cheap) — and it means there is exactly one place that starts and
     #: stops the redraw, not two timers each needing their own shutdown.
     SHINE_FPS = 6
@@ -329,7 +315,11 @@ class ActivityRow(Static):
         """
         if self._state is None:
             self._started_at = self._clock() if started else None
-            self._shine_index = 0
+            # The count's baseline is the turn, so it is zeroed HERE and
+            # nowhere else. Zeroing it on a scroll edge is what made the old
+            # ``LIVE +N`` unreadable: its baseline was an event the reader
+            # could not observe.
+            self._entries = 0
             if self._timer is not None:
                 self._timer.resume()
         self._state = state
@@ -356,27 +346,47 @@ class ActivityRow(Static):
         if self._timer is not None:
             self._timer.pause()
 
-    def set_behind(self, behind: "int | None") -> None:
-        """How far the reader is from the newest output, or ``None`` when they
-        are on it (#3712). Redraws only while a turn is showing — this rides in
-        the live-turn row's spare space and does not summon one."""
-        if self._behind == behind:
+    def set_entries(self, entries: int) -> None:
+        """How many entries this turn has produced so far (#3777).
+
+        Independent of where the reader is: the count answers "how much has
+        happened", and the answer does not change because somebody scrolled.
+        Redraws only while a turn is showing — this rides in the live-turn
+        row and does not summon one.
+        """
+        if self._entries == entries:
             return
-        self._behind = behind
+        self._entries = entries
+        if self._state is not None:
+            self._render_row()
+
+    def set_away(self, away: bool) -> None:
+        """Whether the reader has scrolled off the newest output (#3712).
+
+        Decides ONE thing: whether the return-to-latest hint is printed. It is
+        deliberately not an input to the count — conflating the two is what the
+        previous ``behind: int | None`` did, and re-reading that single value
+        under a new name would have carried the same defect forward.
+        """
+        if self._away == away:
+            return
+        self._away = away
         if self._state is not None:
             self._render_row()
 
     def tick(self) -> None:
-        """Advance the shine one frame and redraw (the elapsed clock rides
-        along, recomputed fresh every call). No-op while hidden — reachable
-        only in the gap between :meth:`end` pausing the timer and the pause
-        actually taking effect, not a steady-state path."""
+        """Redraw one frame: the shine advances and the elapsed clock rides
+        along, recomputed fresh from the real clock every call. No-op while
+        hidden — reachable only in the gap between :meth:`end` pausing the
+        timer and the pause actually taking effect, not a steady-state path.
+
+        The shine's position is derived from the CLOCK, not from a counter this
+        method increments. A counter measures the pass in frames, so a dropped
+        or delayed tick shortens the pass and a wider row lengthens it; reading
+        the clock makes one pass take :data:`_SHINE_PASS_SECONDS` whatever the
+        renderer and the terminal happen to be doing.
+        """
         if self._state is not None:
-            # No modulo here: the cycle's length depends on ``len(state)``,
-            # and ``_apply_shine`` is where that is known. Wrapping in both
-            # places would mean two copies of the same arithmetic drifting
-            # apart the first time one of them learned about a new state.
-            self._shine_index += 1
             self._render_row()
 
     def _render_row(self) -> None:
@@ -389,11 +399,35 @@ class ActivityRow(Static):
                 self._state or "",
                 elapsed_s=elapsed,
                 width=self.content_size.width or 78,
-                behind=self._behind,
-                shine_index=self._shine_index if self._state is not None else None,
+                entries=self._entries,
+                away=self._away,
+                shine_phase=(
+                    None if self._state is None
+                    else (self._clock() % _SHINE_PASS_SECONDS) / _SHINE_PASS_SECONDS
+                ),
                 colour=self._terminal_has_colour(),
+                dark=self._terminal_is_dark(),
             )
         )
+
+    def _terminal_is_dark(self) -> bool:
+        """Whether the terminal's background is dark, so the shine can pick the
+        ground/peak pair that is actually visible against it.
+
+        One pair cannot serve both: the dark pair's peak is nearly white, which
+        against a white terminal is the band disappearing rather than the band
+        being subtle. Asked of the theme every frame rather than cached, for
+        the same reason as :meth:`_terminal_has_colour` — the answer is the
+        app's to give, and a value latched at mount would outlive a theme
+        change.
+
+        Defaults to dark when there is no app to ask (a row mounted alone in a
+        test), which is the terminal reyn is most often run in.
+        """
+        try:
+            return bool(self.app.current_theme.dark)
+        except Exception:
+            return True
 
     def _terminal_has_colour(self) -> bool:
         """Whether the shine may use its gradient rather than its fallback.

--- a/src/reyn/interfaces/inline/textual_chat/activity_row.py
+++ b/src/reyn/interfaces/inline/textual_chat/activity_row.py
@@ -155,8 +155,16 @@ def activity_text(
     """The rendered row for ``state``.
 
     ``elapsed_s`` is omitted entirely when ``None`` — an unknown duration
-    prints no clock rather than a zero, because "00:00" reads as a fact and
-    "no clock" reads as what it is.
+    prints no clock rather than a zero, because "0s" reads as a fact — a turn
+    that just started — and "no clock" reads as what it is: a turn whose start
+    this client never saw.
+
+    The format is bare seconds (#3777, from the owner's mock: ``RESPONDING
+    12s``), replacing the ``MM:SS`` this row used until now. **Past a minute
+    that is worse, not better** — ``1247s`` is a number nobody reads at a
+    glance and ``20:47`` is — and switching format at sixty seconds would be
+    this module choosing for the operator. It is left as specified and raised
+    on the PR instead.
 
     ``entries`` is how many entries this TURN has produced, counted from the
     moment it started and shown from zero upward. ``away`` is whether the

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1303,11 +1303,14 @@ class TextualChatApp(App):
         # queue, so the zone reads past (conversation) -> now (this) -> next
         # (queue) -> the line being typed. Non-focusable, so Tab/Esc still walk
         # the same path to the composer they did before it existed.
-        #: #3712: how many entries the flow held when the reader last left the
-        #: newest output, or ``None`` while they are on it.
-        #: Entries that have landed since the reader left the tail, counted as
-        #: they arrive rather than derived from two reads of the model.
-        self._away_arrivals = 0
+        #: #3777: how many entries THIS TURN has produced, counted as they
+        #: arrive rather than derived from two reads of the model. The baseline
+        #: is the turn's start, which the reader saw; the previous counter's
+        #: baseline was the moment the reader scrolled away, which they did
+        #: not, so its number could never be interpreted. Reset by
+        #: :meth:`_reset_turn_entries` at turn start and nowhere else — in
+        #: particular NOT on a scroll edge.
+        self._turn_entries = 0
         self._activity = ActivityRow(id="activity-row", clock=self._clock)
         yield self._activity
         self._sent_queue = SentQueue(id="sent-queue")
@@ -2140,8 +2143,7 @@ class TextualChatApp(App):
         # a frame later. ``on_flow_view_follow_changed`` still runs once that
         # refresh happens and agrees (idempotent), it simply must not be what
         # the answer waits on.
-        self._away_arrivals = 0
-        self._activity.set_behind(None)
+        self._activity.set_away(False)
 
     def on_flow_view_follow_changed(self, event: "FlowView.FollowChanged") -> None:
         """The reader left or returned to the newest output (#3712, #3770).
@@ -2163,20 +2165,27 @@ class TextualChatApp(App):
         already reads ``flow.following`` fresh on each arrival, so there is
         nothing to remember about having left.
         """
-        if event.following:
-            self._away_arrivals = 0
-            self._activity.set_behind(None)
+        self._activity.set_away(not event.following)
 
     def _note_entry_landed(self) -> None:
-        """One entry arrived — count it if the reader is not there to see it.
+        """One entry arrived — count it, unconditionally.
 
         Called from the frame pump as the entry lands, i.e. by the producer of
-        the event rather than by a later reader of the model. ``LIVE +N`` says
-        how many things happened; the things themselves are what know.
+        the event rather than by a later reader of the model: the count says
+        how many things happened, and the things themselves are what know.
+
+        No ``following`` check (#3777). The count is a property of the turn,
+        not of where the reader is standing, so it does not consult the reader
+        at all — which is also what lets its baseline be something the reader
+        can see.
         """
-        if not self._flow.following:
-            self._away_arrivals += 1
-            self._activity.set_behind(self._away_arrivals)
+        self._turn_entries += 1
+        self._activity.set_entries(self._turn_entries)
+
+    def _reset_turn_entries(self) -> None:
+        """Start a turn's count at zero. The one place the count is reset."""
+        self._turn_entries = 0
+        self._activity.set_entries(0)
 
     def _apply_compact_layout(self) -> None:
         """Re-decide how much room the transient regions may take (#3680).
@@ -2892,6 +2901,12 @@ class TextualChatApp(App):
         # moment it happened to connect.
         if snap.get("turn_active"):
             self._activity.begin("WORKING", started=False)
+            # A mid-turn attach did not see the entries that already landed,
+            # so it counts from zero and says so by counting from HERE. It
+            # cannot report a total it never observed, and a reconstructed
+            # number would be the same "baseline nobody saw" defect wearing a
+            # different hat.
+            self._reset_turn_entries()
         for item in self._queue_view.queue():
             msg_id = item.get("msg_id")
             if msg_id:
@@ -3134,6 +3149,7 @@ class TextualChatApp(App):
         # is running, and returning early would leave the row hidden through
         # the whole turn.
         self._activity.begin("WORKING")
+        self._reset_turn_entries()
         applied = self._queue_view.apply_turn_started(chain_id=chain_id, seq=seq)
         if not applied:
             return

--- a/src/reyn/interfaces/inline/textual_chat/palette.py
+++ b/src/reyn/interfaces/inline/textual_chat/palette.py
@@ -86,32 +86,38 @@ TOKENS: "dict[str, str]" = {
     "@selection-fg@": "ansi_black",
 }
 
-#: The two endpoints of the NOW row's travelling shine (#3777). Blended per
-#: character at runtime by ``activity_row``, so these are plain values rather
-#: than ``@name@`` markers: :func:`css` resolves markers inside a stylesheet
-#: string, and the band is not a stylesheet \u2014 it is applied to a content span
-#: via ``Content.stylize`` on every frame.
+#: The NOW row's travelling shine (#3777), as a GROUND and a PEAK per terminal
+#: ground. Blended per character at runtime by ``activity_row``, so these are
+#: plain values rather than ``@name@`` markers: :func:`css` resolves markers
+#: inside a stylesheet string, and the band is not a stylesheet — it is applied
+#: to a content span on every frame.
 #:
 #: RGB rather than ANSI-16. "a turn is running, and here is the light moving
 #: through it" has no established colour convention the way red-means-error
 #: does, which is precisely the case the CLAUDE.md carve-out (owner,
 #: 2026-08-07) opens: a reyn-specific meaning may take a value outside
-#: ANSI-16. That carve-out's condition is that the value still be NAMED here
-#: rather than written inline in the widget \u2014 which is what these two are.
-#: Naming them here also keeps them inside the thing this module promises:
-#: reading this file tells you what the interface paints. A hex computed in
-#: ``activity_row`` would paint a colour ``test_tui_colour_tokens.py`` cannot
-#: see, because that gate reads CSS declarations and a runtime span is not
-#: one \u2014 the same "written in a shape nobody searched for" that put the gate
-#: here in the first place.
+#: ANSI-16. The carve-out's condition is that the value still be NAMED here
+#: rather than written inline in the widget — which is what these four are.
 #:
-#: Only the band's INTERIOR is painted. Where the cosine falls to nothing the
-#: character is left unstyled rather than blended toward an assumed
-#: background, so the shine fades into whatever ground the terminal actually
-#: has instead of into a grey reyn guessed. That is the same reason
-#: ``@app-background@`` is ``ansi_default``: the ground is the operator's.
-SHINE_DIM = "#5c6478"
-SHINE_PEAK = "#e6ecf8"
+#: **The GROUND is painted across every character, not just the band's edge.**
+#: The first cut painted only the band and left the rest at the terminal's own
+#: foreground, reasoning that the shine should fade into the real ground rather
+#: than into a grey reyn guessed. That produced a dark cell at each end of the
+#: band sitting directly against an undimmed ground, and the operator read the
+#: result as THREE things moving instead of one (compared against another tool's
+#: single travelling highlight). Respecting the terminal's ground does not mean
+#: leaving a high-contrast colour next to it. A uniform ground with one bright
+#: band over it is what reads as a single light.
+#:
+#: Two pairs because one cannot work on both grounds: a near-white peak is
+#: invisible on a white terminal. The rule for both is the same — the PEAK is
+#: the high-contrast end against that terminal's background and the GROUND sits
+#: between the two, so the band always moves away from the background rather
+#: than toward it.
+SHINE_GROUND_DARK = "#5c6478"
+SHINE_PEAK_DARK = "#e6ecf8"
+SHINE_GROUND_LIGHT = "#9aa1b1"
+SHINE_PEAK_LIGHT = "#1b2130"
 
 
 def css(sheet: str) -> str:
@@ -136,4 +142,11 @@ def css(sheet: str) -> str:
     return sheet
 
 
-__all__ = ["SHINE_DIM", "SHINE_PEAK", "TOKENS", "css"]
+__all__ = [
+    "SHINE_GROUND_DARK",
+    "SHINE_GROUND_LIGHT",
+    "SHINE_PEAK_DARK",
+    "SHINE_PEAK_LIGHT",
+    "TOKENS",
+    "css",
+]

--- a/tests/test_activity_row_3693.py
+++ b/tests/test_activity_row_3693.py
@@ -126,8 +126,9 @@ async def _until(pred) -> None:
 def test_an_unknown_duration_prints_no_clock() -> None:
     """Tier 1: no elapsed time is invented when none was observed.
 
-    A client that joined mid-turn has no start instant. "00:00" would read as a
-    measurement; printing nothing reads as what it is.
+    A client that joined mid-turn has no start instant. "0s" would read as a
+    measurement — a turn that just began — and printing nothing reads as what
+    it is.
     """
     with_clock = str(activity_text("WORKING", elapsed_s=78.0, width=80))
     without = str(activity_text("WORKING", elapsed_s=None, width=80))
@@ -160,6 +161,28 @@ def test_the_cancel_affordance_yields_before_the_state_does() -> None:
         f"the abort hint was dropped before the count: {narrow!r}"
     )
     assert "3 entries" not in narrow
+
+
+def test_a_row_too_narrow_for_the_state_keeps_the_state_and_overflows() -> None:
+    """Tier 1: the head is never dropped, even when it alone will not fit.
+
+    Everything optional goes first, and then the row overflows rather than
+    truncating what is happening. A clipped state word is a different word —
+    ``TOOL search_actions`` cut to ``TOOL sea`` names a tool that does not
+    exist — and a row that has given up saying what is happening has nothing
+    left to be. Pinned because the alternative (stop dropping once it fits, and
+    clip the rest) is what a later reader would reach for on seeing the loop
+    run to empty.
+    """
+    narrow = str(activity_text("RESPONDING", elapsed_s=5.0, width=4, entries=3))
+
+    assert "RESPONDING" in narrow, f"the state was clipped away: {narrow!r}"
+    assert "entries" not in narrow and _CANCEL_HINT not in narrow, (
+        f"an optional segment survived a width nothing fits in: {narrow!r}"
+    )
+    # "RESPONDING" in narrow already says the row is wider than the four
+    # columns it was given: overflowing is the intended outcome, and asserting
+    # it a second time by size would pin the shape rather than the behaviour.
 
 
 # ── the lifecycle, on a real app ─────────────────────────────────────────────

--- a/tests/test_activity_row_3693.py
+++ b/tests/test_activity_row_3693.py
@@ -28,10 +28,12 @@ from typing import AsyncIterator
 import pytest
 from textual.content import Span
 
-from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat import TextualChatApp, palette
 from reyn.interfaces.inline.textual_chat.activity_row import (
-    _SHINE_WIDTH,
+    _CANCEL_HINT,
+    LATEST_HINT,
     ActivityRow,
+    _shine_ramp,
     activity_text,
 )
 from reyn.interfaces.inline.textual_chat.sent_queue import ROW_TEXT_COLUMN
@@ -130,8 +132,12 @@ def test_an_unknown_duration_prints_no_clock() -> None:
     with_clock = str(activity_text("WORKING", elapsed_s=78.0, width=80))
     without = str(activity_text("WORKING", elapsed_s=None, width=80))
 
-    assert "01:18" in with_clock
-    assert not any(ch.isdigit() for ch in without.split("Ctrl+C")[0]), (
+    assert "78s" in with_clock
+    # The head is the segment before the first separator — the count that
+    # follows it legitimately carries a digit, so the claim has to be scoped to
+    # where a duration would appear rather than to the whole line.
+    head = without.split("·")[0]
+    assert not any(ch.isdigit() for ch in head), (
         f"a duration appeared where none was known: {without!r}"
     )
 
@@ -142,12 +148,18 @@ def test_the_cancel_affordance_yields_before_the_state_does() -> None:
     Both cannot fit at every width. The state is the thing the row exists to
     show; the hint names a key that works whether or not it is printed.
     """
-    wide = str(activity_text("RESPONDING", elapsed_s=5.0, width=80))
-    narrow = str(activity_text("RESPONDING", elapsed_s=5.0, width=20))
+    wide = str(activity_text("RESPONDING", elapsed_s=5.0, width=80, entries=3))
+    narrow = str(activity_text("RESPONDING", elapsed_s=5.0, width=40, entries=3))
 
-    assert "Ctrl+C" in wide
+    assert _CANCEL_HINT in wide
     assert "RESPONDING" in narrow
     assert len(narrow) <= len(wide)
+    # What goes first is the count, not the way out: a row that gave up "how to
+    # stop this" to keep a number would have its priorities backwards.
+    assert _CANCEL_HINT in narrow, (
+        f"the abort hint was dropped before the count: {narrow!r}"
+    )
+    assert "3 entries" not in narrow
 
 
 # ── the lifecycle, on a real app ─────────────────────────────────────────────
@@ -318,7 +330,7 @@ async def test_the_clock_advances_without_any_delta_arriving() -> None:
         await _until(lambda: str(row.render()) != before)
 
         after = str(row.render())
-        assert "01:15" in after, f"the clock is not tracking the real gap: {after!r}"
+        assert "75s" in after, f"the clock is not tracking the real gap: {after!r}"
 
 
 # ── the shine (owner design "A", replacing the removed NOW label) ────────────
@@ -344,68 +356,117 @@ def test_the_row_carries_no_mark_and_starts_where_a_queue_label_starts() -> None
     )
 
 
-def _band(state: str, frame: int) -> "dict[int, str]":
-    """The band at ``frame`` as ``{column: style}``, one entry per painted cell.
+def _cells(state: str, phase: float, *, dark: bool = True) -> "dict[int, str]":
+    """The rendered row as ``{column: style}``, one entry per painted cell.
 
     Reading the rendering rather than re-deriving it: the test asks what the
-    row looks like, and never recomputes the sweep with the arithmetic it is
+    row looks like and never recomputes the sweep with the arithmetic it is
     supposed to be checking.
     """
-    content = activity_text(state, elapsed_s=None, width=80, shine_index=frame)
+    content = activity_text(
+        state, elapsed_s=None, width=80, shine_phase=phase, dark=dark
+    )
     return {span.start: str(span.style) for span in content.spans}
+
+
+def test_every_character_is_painted_so_the_band_has_no_free_edge() -> None:
+    """Tier 1: no cell is left at the terminal's own foreground.
+
+    This is the defect the owner reported: with only the band painted, its
+    outermost cells were a dark colour sitting directly against an undimmed
+    ground, and the row read as THREE things moving instead of one. A uniform
+    ground under a single bright band is what reads as one light, and "uniform"
+    means every cell — so the property to hold is coverage, stated as coverage
+    rather than as a colour comparison that a future palette change would have
+    to be taught about.
+    """
+    row = activity_text("RESPONDING", elapsed_s=12, width=60, shine_phase=0.35)
+    painted = {span.start for span in row.spans}
+    assert painted == set(range(len(row.plain))), (
+        "cells left unpainted (they keep the terminal foreground and read as a "
+        f"step at the band's edge): {sorted(set(range(len(row.plain))) - painted)}"
+    )
+
+
+def test_the_ramp_ends_at_the_ground_so_the_band_has_no_step() -> None:
+    """Tier 1: the band's faintest cell IS the ground the rest of the row wears.
+
+    Coverage alone is not enough — every cell could be painted and the band's
+    outermost cell still be a colour nothing else on the row is wearing, which
+    is the same visible edge in a different disguise. Ending the ramp exactly
+    at the ground is what removes the edge, and it is the invariant the earlier
+    shape broke: it stopped the ramp at a dark value and left the ground
+    undrawn, so both ends of the band showed as their own moving features.
+    """
+    ramp = _shine_ramp(3, palette.SHINE_GROUND_DARK, palette.SHINE_PEAK_DARK)
+    assert ramp[-1] == palette.SHINE_GROUND_DARK, (
+        f"the band's outer cell is not the ground: {ramp[-1]} vs "
+        f"{palette.SHINE_GROUND_DARK}"
+    )
+    assert ramp[0] == palette.SHINE_PEAK_DARK
 
 
 def test_the_shine_is_graded_not_two_valued() -> None:
     """Tier 1: the band has an interior — several distinct styles across its
     width — rather than the two states (on / off) it had before #3777.
 
-    This is the defect the operator reported, stated as a property: a band
-    whose cells are all-or-nothing has no edge to fall off, so it reads as a
-    block blinking on and off rather than as a light travelling through the
-    word. Asserting "more than two distinct styles" pins that there IS a ramp
-    without pinning which colours the ramp passes through — the curve and its
-    endpoints are free to change, the gradation is not.
+    A band whose cells are all-or-nothing has no edge to fall off, so it reads
+    as a block blinking rather than as a light travelling. The property is that
+    an INTERMEDIATE exists — at least one cell that is neither fully lit nor
+    the ground — which says the ramp is there without saying how many steps it
+    takes or which colours it passes through.
     """
-    band = _band("RESPONDING", frame=5)
-    assert len(set(band.values())) > 2, (
-        f"the band is still effectively two-valued: {sorted(set(band.values()))}"
+    styles = set(_cells("RESPONDING", phase=0.5).values())
+    extremes = {palette.SHINE_PEAK_DARK, palette.SHINE_GROUND_DARK}
+    assert styles - extremes, (
+        f"every cell is either fully lit or ground — the band is two-valued "
+        f"and will read as a block blinking: {sorted(styles)}"
     )
 
 
-def test_the_shine_advances_one_cell_per_frame_carrying_its_shape() -> None:
-    """Tier 1: consecutive frames are the same band one column further right.
+def test_the_band_moves_with_the_phase() -> None:
+    """Tier 1: a later phase puts the bright end further right.
 
-    Checked as a SHIFT of the previous frame rather than against a table of
-    expected positions, so the test states the property that matters (the
-    light moves, and moves rigidly) without re-implementing the position
-    arithmetic it is checking. Frames are chosen so the whole band is inside
-    the word — at the two ends it is partly off the edge, which is the
-    entering and leaving that :func:`_apply_shine` exists to produce and is
-    covered by the clearance test below.
+    Pinned as "the peak moved right", not as a table of positions: the
+    positions depend on the row's width and the band's fraction, and a test
+    that restated them would be a second implementation of the thing it checks.
     """
-    state = "WORKING"
-    for frame in (4, 5):
-        before, after = _band(state, frame), _band(state, frame + 1)
-        assert after == {column + 1: style for column, style in before.items()}, (
-            f"frame {frame} -> {frame + 1} was not a one-column shift: "
-            f"{before!r} then {after!r}"
-        )
+    def peak_column(phase: float) -> int:
+        cells = _cells("RESPONDING", phase=phase)
+        counts: "dict[str, int]" = {}
+        for style in cells.values():
+            counts[style] = counts.get(style, 0) + 1
+        ground = max(counts, key=lambda style: counts[style])
+        lit = [column for column, style in cells.items() if style != ground]
+        return sum(lit) // len(lit)
+
+    assert peak_column(0.25) < peak_column(0.6), "the band did not advance with the phase"
+
+
+def test_a_light_terminal_gets_a_different_pair_than_a_dark_one() -> None:
+    """Tier 1: the ground/peak pair follows the terminal's background.
+
+    One pair cannot serve both. The dark pair's peak is nearly white, so on a
+    white terminal it is not a subtle band, it is an absent one — the row would
+    silently stop showing that a turn is running for anyone on a light theme.
+    """
+    assert set(_cells("RESPONDING", 0.5, dark=True).values()) != set(
+        _cells("RESPONDING", 0.5, dark=False).values()
+    ), "the same colours were used on both terminal grounds"
 
 
 def test_the_shine_degrades_to_an_attribute_without_colour() -> None:
     """Tier 1: with no colour available the band is still drawn, as an SGR
     attribute rather than as nothing.
 
-    A gradient needs colour; where the terminal has none, the row must still
-    show that a turn is running. Degrading to an attribute keeps that signal
-    on a terminal a colour would have left blank — and it degrades to the
-    form #3779 already shipped, so the fallback is a shape this row has been
-    seen in rather than a third design nobody has looked at.
+    A gradient needs colour; where the terminal has none the row must still
+    show that a turn is running. It degrades to the form #3779 shipped, so the
+    fallback is a shape this row has been seen in rather than a third design.
     """
-    band = _band_without_colour = {
+    band = {
         span.start: str(span.style)
         for span in activity_text(
-            "WORKING", elapsed_s=None, width=80, shine_index=3, colour=False
+            "WORKING", elapsed_s=None, width=80, shine_phase=0.3, colour=False
         ).spans
     }
     assert band, "no colour meant no band at all"
@@ -414,90 +475,118 @@ def test_the_shine_degrades_to_an_attribute_without_colour() -> None:
     )
 
 
-def test_no_shine_band_while_shine_index_is_none() -> None:
-    """Tier 1: a static row (no turn showing, or the caller opts out) paints
-    no band at all — the parameter's absence is absence of the effect, not a
-    band parked at index 0."""
-    content = activity_text("WORKING", elapsed_s=None, width=80, shine_index=None)
+def test_no_shine_while_the_phase_is_none() -> None:
+    """Tier 1: a static row (no turn showing) paints no band at all — the
+    parameter's absence is absence of the effect, not a band parked at zero."""
+    content = activity_text("WORKING", elapsed_s=None, width=80, shine_phase=None)
     assert content.spans == []
 
 
-def test_any_frame_number_is_a_valid_frame() -> None:
-    """Tier 1: the cycle is wrapped inside ``activity_text``, so an arbitrarily
-    large frame paints the same band as its position within the cycle.
-
-    The widget's counter only ever increments — it does not wrap, because the
-    cycle's length depends on ``len(state)`` and that changes on every
-    ``specialise``. A counter carried across a state change therefore lands
-    outside the previous cycle routinely, and if that painted nothing the row
-    would go dark while a turn was visibly still running. Pinning the wrap
-    here is pinning that it cannot.
-    """
-    state = "WORKING"
-    # The band crosses the whole rendered row (#3777), so the pass is as long
-    # as the row is — read from the rendering rather than recomputed, since
-    # the row's width is padding-dependent and a formula here would be a
-    # second implementation of the thing under test.
-    row = str(activity_text(state, elapsed_s=None, width=80, shine_index=0))
-    cycle = len(row) + 2 * (_SHINE_WIDTH // 2)
-    assert _band(state, 999), "a large frame number painted no band at all"
-    assert _band(state, 999) == _band(state, 999 % cycle)
-
-
 def test_the_shine_crosses_the_whole_row_including_the_clock_and_hint() -> None:
-    """Tier 1: the band is no longer confined to ``state``'s own span.
+    """Tier 1: the band is not confined to ``state``'s own span.
 
     #3779 kept it inside the state word so it could not wander onto the clock
     or the hint, which was right for a row that was three things sharing a
     line. #3777 removed the glyph and made the row read as one object, and the
-    owner asked for the light to cross all of it. Pinned by sweeping a whole
-    cycle and requiring that SOME frame paints past the state word — a band
-    that silently kept the old confinement would still look plausible frame by
-    frame, and only a sweep catches it.
+    owner asked for the light to cross all of it.
     """
     state = "RESPONDING"
     body_end = ROW_TEXT_COLUMN + len(state)
     reached_beyond = False
-    for frame in range(80):
-        content = activity_text(
-            state, elapsed_s=5.0, width=78, behind=12, shine_index=frame
-        )
-        assert content.spans, f"frame {frame} painted no band at all"
-        if any(span.start >= body_end for span in content.spans):
+    for step in range(20):
+        cells = _cells(state, phase=step / 20)
+        counts: "dict[str, int]" = {}
+        for style in cells.values():
+            counts[style] = counts.get(style, 0) + 1
+        ground = max(counts, key=lambda style: counts[style])
+        if any(column >= body_end for column, s in cells.items() if s != ground):
             reached_beyond = True
-        rendered = str(content)
-        assert "LIVE +12" in rendered, f"frame {frame}: LIVE +N is missing: {rendered!r}"
     assert reached_beyond, (
-        "the band never left the state word across a full sweep — it is still "
+        "the band never left the state word across a full pass — it is still "
         "confined the way #3779 had it"
     )
 
 
+def test_the_count_does_not_depend_on_where_the_reader_is() -> None:
+    """Tier 1: ``entries`` reads the same whether or not the reader is away.
+
+    The previous shape made these one parameter, so the number's baseline was
+    the instant the reader scrolled away — an event the reader cannot see, and
+    therefore a number whose meaning there was no occasion to learn. Splitting
+    them is the fix; this pins that they are actually independent, rather than
+    the same value read twice under two names.
+    """
+    following = activity_text("RESPONDING", elapsed_s=12, width=80, entries=3)
+    away = activity_text("RESPONDING", elapsed_s=12, width=80, entries=3, away=True)
+    assert "3 entries" in following.plain
+    assert "3 entries" in away.plain
+
+
+def test_the_return_hint_appears_only_while_the_reader_is_away() -> None:
+    """Tier 1: ``away`` decides one thing — whether the return hint prints.
+
+    A hint offering to take the reader back to output they are already looking
+    at is an instruction with nothing to do, and the row has no room to spend
+    on one.
+    """
+    following = activity_text("RESPONDING", elapsed_s=12, width=80, entries=3).plain
+    away = activity_text(
+        "RESPONDING", elapsed_s=12, width=80, entries=3, away=True
+    ).plain
+    assert LATEST_HINT not in following
+    assert LATEST_HINT in away
+    assert _CANCEL_HINT in following and _CANCEL_HINT in away
+
+
+def test_a_turn_that_has_produced_nothing_says_zero() -> None:
+    """Tier 1: the count starts at zero and is shown, not hidden.
+
+    A count that appears only once it is non-zero teaches its own scale late:
+    the reader meets it already at 4 and has to infer what it counts. Starting
+    visible at 0 means the first thing it ever shows is its baseline.
+    """
+    assert "0 entries" in activity_text("WORKING", elapsed_s=1, width=80).plain
+
+
 @pytest.mark.asyncio
-async def test_the_shine_advances_one_frame_per_tick_call() -> None:
-    """Tier 2b: :meth:`ActivityRow.tick` called directly — the frame
-    function for the STATEFUL widget, same discipline as the pure-function
-    gates above, never a wait for the real timer to fire N times."""
+async def test_the_shine_position_follows_the_clock_not_the_tick_count() -> None:
+    """Tier 2b: the band's position is a function of TIME, not of how many
+    times :meth:`ActivityRow.tick` happened to be called.
+
+    Driven by an injected clock, so no wall-clock waiting is involved: ticking
+    without advancing the clock must not move the band, and advancing it must.
+    A frame counter passes the second half and fails the first — and a counter
+    is what makes one pass take longer on a wider row, which is the property
+    #3777 replaced it to fix.
+    """
+    now = [1000.0]
     transport = QueueTransport()
-    app = TextualChatApp(transport=transport)
+    app = TextualChatApp(transport=transport, clock=lambda: now[0])
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
         await transport.push_event(_started("c1", 1))
         await _settle(pilot)
         row = app.query_one(ActivityRow)
 
-        positions: "list[int]" = []
-        for _ in range(4):
-            row.tick()
-            span = row.render().spans[0]
-            positions.append(span.start)
+        def lit() -> "list[int]":
+            content = row.render()
+            counts: "dict[str, int]" = {}
+            for span in content.spans:
+                counts[str(span.style)] = counts.get(str(span.style), 0) + 1
+            ground = max(counts, key=lambda style: counts[style])
+            return [span.start for span in content.spans if str(span.style) != ground]
 
-        assert positions == sorted(positions), (
-            f"the band did not advance monotonically over 4 direct ticks: {positions!r}"
+        before = lit()
+        for _ in range(3):
+            row.tick()
+        assert lit() == before, (
+            "ticking without time passing moved the band — the position is "
+            "still counting frames"
         )
-        assert len(set(positions)) > 1, (
-            f"4 ticks produced no movement at all: {positions!r}"
-        )
+
+        now[0] += 1.0
+        row.tick()
+        assert lit() != before, "advancing the clock did not move the band"
 
 
 @pytest.mark.asyncio

--- a/tests/test_activity_row_3693.py
+++ b/tests/test_activity_row_3693.py
@@ -133,7 +133,7 @@ def test_an_unknown_duration_prints_no_clock() -> None:
     with_clock = str(activity_text("WORKING", elapsed_s=78.0, width=80))
     without = str(activity_text("WORKING", elapsed_s=None, width=80))
 
-    assert "78s" in with_clock
+    assert "01:18" in with_clock
     # The head is the segment before the first separator — the count that
     # follows it legitimately carries a digit, so the claim has to be scoped to
     # where a duration would appear rather than to the whole line.
@@ -141,6 +141,25 @@ def test_an_unknown_duration_prints_no_clock() -> None:
     assert not any(ch.isdigit() for ch in head), (
         f"a duration appeared where none was known: {without!r}"
     )
+
+
+def test_the_clock_switches_format_at_a_minute() -> None:
+    """Tier 1: bare seconds below a minute, ``MM:SS`` at and above it.
+
+    Each is the readable one in its own range: ``00:12`` makes a twelve-second
+    turn look like a stopwatch reading, and ``1247s`` is a number nobody reads
+    at a glance. The boundary is pinned on both sides because "switches
+    somewhere" is not the claim — a threshold that drifted to five minutes
+    would leave four minutes of unreadable seconds and still pass a test that
+    only checked the two extremes.
+    """
+    def clock(elapsed: float) -> str:
+        return activity_text("RESPONDING", elapsed_s=elapsed, width=70).plain.split(" · ")[0]
+
+    assert clock(12).endswith("12s")
+    assert clock(59).endswith("59s")
+    assert clock(60).endswith("01:00")
+    assert clock(1247).endswith("20:47")
 
 
 def test_the_cancel_affordance_yields_before_the_state_does() -> None:
@@ -353,7 +372,7 @@ async def test_the_clock_advances_without_any_delta_arriving() -> None:
         await _until(lambda: str(row.render()) != before)
 
         after = str(row.render())
-        assert "75s" in after, f"the clock is not tracking the real gap: {after!r}"
+        assert "01:15" in after, f"the clock is not tracking the real gap: {after!r}"
 
 
 # ── the shine (owner design "A", replacing the removed NOW label) ────────────

--- a/tests/test_tail_away_indicator_3712.py
+++ b/tests/test_tail_away_indicator_3712.py
@@ -29,6 +29,7 @@ from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.activity_row import (
+    _CANCEL_HINT,
     LATEST_HINT,
     ActivityRow,
     activity_text,
@@ -87,9 +88,20 @@ class QueueTransport(ClientTransport):
 
 
 def _live_count(row) -> "int | None":
-    """The number the row is reporting, or ``None`` if it reports nothing."""
-    match = re.search(r"LIVE \+(\d+)", str(row.render()))
+    """How many entries the row says this turn has produced, or ``None``.
+
+    #3777 replaced ``LIVE +N`` — which counted from the moment the reader
+    scrolled away, a baseline the reader never saw — with a count from the
+    turn's start. The reader is no longer part of what is being counted.
+    """
+    match = re.search(r"(\d+) entries", str(row.render()))
     return int(match.group(1)) if match else None
+
+
+def _offers_return(row) -> bool:
+    """Whether the row is offering to take the reader back to the newest
+    output. This, and only this, is what being away now changes."""
+    return LATEST_HINT in str(row.render())
 
 
 async def _settle_until_stable(pilot, read, *, arrived=lambda: True) -> "int":
@@ -217,18 +229,21 @@ async def _fill_and_leave_the_tail(transport, pilot, app, *, lines: int = 40):
     return flow
 
 
-def test_the_indicator_takes_the_slot_ahead_of_the_cancel_hint() -> None:
-    """Tier 1: when both want the right-hand slot, the LIVE count wins.
+def test_being_away_adds_the_return_hint_and_changes_nothing_else() -> None:
+    """Tier 1: away is additive — the count and the abort hint are unaffected.
 
-    Someone reading back cannot see the new output arriving; the cancel key
-    works whether or not it is printed. So the more urgent one is shown.
+    The previous design gave the two a single right-hand slot, so one had to
+    displace the other and being away silently cost the reader the way out.
+    With the hints reading left to right there is no slot to win, and the only
+    difference being away makes is one more thing offered.
     """
-    with_behind = str(activity_text("RESPONDING", elapsed_s=5.0, width=78, behind=12))
-    without = str(activity_text("RESPONDING", elapsed_s=5.0, width=78))
+    away = str(activity_text("RESPONDING", elapsed_s=5.0, width=78, entries=12, away=True))
+    following = str(activity_text("RESPONDING", elapsed_s=5.0, width=78, entries=12))
 
-    assert "LIVE +12" in with_behind
-    assert "Ctrl+C cancel" not in with_behind
-    assert "Ctrl+C cancel" in without
+    assert "12 entries" in away and "12 entries" in following
+    assert _CANCEL_HINT in away and _CANCEL_HINT in following
+    assert LATEST_HINT in away
+    assert LATEST_HINT not in following
 
 
 def test_a_narrow_row_drops_the_hint_rather_than_cutting_it() -> None:
@@ -238,19 +253,23 @@ def test_a_narrow_row_drops_the_hint_rather_than_cutting_it() -> None:
     different one. The state survives; the suffix is printed whole or not at
     all.
     """
-    narrow = str(activity_text("RESPONDING", elapsed_s=5.0, width=30, behind=12))
+    narrow = str(activity_text(
+        "RESPONDING", elapsed_s=5.0, width=30, entries=12, away=True
+    ))
 
     assert "RESPONDING" in narrow
     assert LATEST_HINT not in narrow
-    assert "LIVE" not in narrow
+    assert "entries" not in narrow
 
 
 @pytest.mark.asyncio
-async def test_nothing_is_shown_while_the_reader_is_on_the_newest_output() -> None:
-    """Tier 2b: following the tail is the ordinary case and says nothing.
+async def test_no_return_hint_while_the_reader_is_on_the_newest_output() -> None:
+    """Tier 2b: following the tail is the ordinary case and offers no return.
 
-    An indicator that were always up would stop meaning "you are missing
-    something".
+    A hint offering to take the reader back to output they are already looking
+    at is an instruction with nothing to do. #3777: what is suppressed is the
+    HINT — the count keeps reporting, because how much the turn has produced
+    is true whether or not the reader has scrolled.
     """
     transport = QueueTransport()
     app = TextualChatApp(transport=transport)
@@ -272,31 +291,48 @@ async def test_nothing_is_shown_while_the_reader_is_on_the_newest_output() -> No
         # in this file today, just on the negative side.
         await _settle_until(pilot, lambda: len(app.query_one(FlowView).entries) >= 10)
 
-        assert "LIVE" not in str(app.query_one(ActivityRow).render())
+        row = app.query_one(ActivityRow)
+        assert not _offers_return(row)
+        # The positive half: the count IS reporting. Without this the negative
+        # above could pass because the row is blank, which would say nothing
+        # about whether the hint is correctly suppressed.
+        assert _live_count(row) is not None, (
+            f"the row reported no count at all: {str(row.render())!r}"
+        )
 
 
 @pytest.mark.asyncio
-async def test_output_arriving_while_away_is_counted() -> None:
-    """Tier 2b: entries landing after the reader left are reported.
+async def test_entries_are_counted_from_the_turn_not_from_the_departure() -> None:
+    """Tier 2b: the count's baseline is the turn's start, not the scroll away.
 
-    The count starts when they leave, not from the beginning of the
-    conversation — what matters is what they have not seen.
+    This is the #3777 correction, as a measurement: entries that landed BEFORE
+    the reader left are already in the number, so leaving does not reset it.
+    The old baseline was the instant of departure — an event the reader cannot
+    observe, which is why the old number offered no occasion on which its
+    meaning could be learned.
     """
     transport = QueueTransport()
     app = TextualChatApp(transport=transport)
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
         await _fill_and_leave_the_tail(transport, pilot, app)
+        row = app.query_one(ActivityRow)
+        before = _live_count(row)
+        assert before, (
+            "the fixture landed entries before the reader left, so the count "
+            f"must already be non-zero — a departure reset it: {before!r}"
+        )
 
         for i in range(3):
             await transport.push_display(
                 OutboxMessage(kind="agent", text=f"new {i}", meta={})
             )
-        row = app.query_one(ActivityRow)
-        await _settle_until(pilot, lambda: "LIVE" in str(row.render()))
+        await _settle_until(pilot, lambda: (_live_count(row) or 0) >= before + 3)
 
-        rendered = str(row.render())
-        assert "LIVE +3" in rendered, f"the arrivals were not reported: {rendered!r}"
+        assert _live_count(row) == before + 3, (
+            f"the arrivals were not added to the running count: "
+            f"{str(row.render())!r}"
+        )
 
 
 @pytest.mark.asyncio
@@ -315,13 +351,14 @@ async def test_the_named_key_actually_returns_to_the_newest_output() -> None:
         flow = await _fill_and_leave_the_tail(transport, pilot, app)
         await transport.push_display(OutboxMessage(kind="agent", text="new", meta={}))
         row = app.query_one(ActivityRow)
-        await _settle_until(pilot, lambda: "LIVE" in str(row.render()))
-        assert "LIVE" in str(row.render())
+        await _settle_until(pilot, lambda: _offers_return(row))
+        assert _offers_return(row)
+        away_count = _live_count(row)
 
         await pilot.press("ctrl+end")
         # #3770 follow-up: no deferred wait needed here — action_jump_to_latest
-        # sets scroll_y, _away_arrivals, and the row's own ``set_behind(None)``
-        # all SYNCHRONOUSLY inside the key handler (its own docstring:
+        # sets scroll_y and the row's own ``set_away(False)`` all
+        # SYNCHRONOUSLY inside the key handler (its own docstring:
         # "cleared HERE rather than waiting on the FollowChanged handler"),
         # so once the keypress message has been dispatched both assertions
         # below are already final. A single pause is for dispatch, not for
@@ -329,8 +366,18 @@ async def test_the_named_key_actually_returns_to_the_newest_output() -> None:
         await pilot.pause()
 
         assert flow.scroll_y >= flow.max_scroll_y, "the key did not return to the tail"
-        assert "LIVE" not in str(app.query_one(ActivityRow).render()), (
-            "the indicator survived the return it was pointing at"
+        returned = app.query_one(ActivityRow)
+        assert not _offers_return(returned), (
+            "the hint survived the return it was pointing at"
+        )
+        # The COUNT must not be cleared by returning (#3777): it counts the
+        # turn, and the turn did not restart because somebody scrolled. The
+        # old implementation zeroed it here, which is exactly the conflation
+        # this change removes — so the assertion has to be present, not just
+        # the hint's absence.
+        assert _live_count(returned) == away_count, (
+            f"returning to the tail reset the turn's count: "
+            f"{away_count} -> {_live_count(returned)}"
         )
 
 
@@ -359,8 +406,11 @@ async def test_a_growing_reply_is_not_counted_as_arrivals() -> None:
         # so the state it returns is already what this baseline wants.
         row = app.query_one(ActivityRow)
         # Whatever the count is at this instant is the baseline. Asserting it
-        # is zero would only be testing how the fixture happened to drain.
-        baseline = str(row.render())
+        # is zero would only be testing how the fixture happened to drain —
+        # and since #3777 the count runs from the turn's start, so the fixture's
+        # own entries are legitimately already in it. What this test is about
+        # is the DELTA the thirty chunks add.
+        baseline = _live_count(row) or 0
 
         # The reply the reader is looking at grows, in place, by a lot.
         before_entries = len(flow.entries)
@@ -381,9 +431,9 @@ async def test_a_growing_reply_is_not_counted_as_arrivals() -> None:
             "fold into one reply, so this is not exercising the case"
         )
 
-        reported = _live_count(row)
+        reported = (_live_count(row) or 0) - baseline
         assert reported == landed, (
-            f"the row reported {reported} arrivals for {landed} entry — "
+            f"the row counted {reported} arrivals for {landed} entry — "
             "a reply growing in place is one thing arriving, not thirty. A "
             "count that follows rows fails here with a number near 30"
         )


### PR DESCRIPTION
**[tui-coder]** — Two owner reports, one PR, because both are the NOW row's readout. Follows #3788
(stage 1) and #3790 (stage 2), both merged.

## 1. The shine showed three moving things, not one

The owner compared reyn against another tool and reported reyn's shine as **three** travelling
points instead of one.

**The cause was a decision I made in #3788 and wrote down in `palette.py`**: paint only the band and
leave the rest at the terminal's own foreground, so the shine *"fades into whatever ground the
terminal actually has instead of into a grey reyn guessed"*. What that produced was a **dark cell at
each end of the band, sitting hard against an undimmed ground** — two extra features, both moving.
Respecting the terminal's ground does not mean leaving a high-contrast colour next to it.

### After — three consecutive phases

`#` peak, `+` band interior, `.` ground. **No blanks: every cell is painted.**

```
   RESPONDING 12s · 3 entries · ctrl+c to abort
+#++++++++.....................................
   RESPONDING 12s · 3 entries · ctrl+c to abort
......++++++++#++++++++........................
   RESPONDING 12s · 3 entries · ctrl+c to abort
...................++++++++#++++++++...........
```

Before, only the band was painted and its outermost cell was dark against an unpainted ground —
`.` there meant *terminal default*, and the two ends read as their own moving marks.

### Changes

- **Every character is painted, and the ramp ends exactly AT the ground** — so the band has no edge
  to step off. Coverage alone would not be enough: every cell could be painted and the band's last
  cell still be a colour nothing else wears, which is the same edge in disguise.
- **The band is a FRACTION of what it crosses** (40%), not a fixed five cells. Stage 2 widened the
  runway from the state word to the whole row, and a width in cells that reads as a moving point
  across ten characters reads as a speck across eighty.
- **The pace is a duration, not a speed.** Cells-per-second does not survive a change of runway: the
  same speed crosses a short row quickly and a long one slowly, so widening the band silently
  changed how urgent the row felt. Position now comes from the clock, and the tick counter is gone.
- **Two ground/peak pairs, chosen by `Theme.dark`.** One pair cannot serve both — a near-white peak
  on a white terminal is not a subtle band, it is an absent one.

## 2. `LIVE +N` counted from something the reader never saw

`behind: int | None` was **one parameter carrying two facts** — `None` meant "following", an int
meant "away, by this much". So the count's baseline was *the instant the reader scrolled away*,
which is not an event the reader observes, so there was never an occasion on which the number's
meaning could be learned.

```
following:  RESPONDING 12s · 3 entries · ctrl+c to abort
away:       RESPONDING 12s · 3 entries · ctrl+end to latest · ctrl+c to abort
```

- **`entries: int` and `away: bool`.** The count runs from the turn's start — which the reader did
  see — and `_note_entry_landed` no longer consults `following` at all.
- **`away` decides exactly one thing**: whether the return hint prints.
- **Returning to the tail clears the hint and does NOT reset the count.** The turn did not restart
  because somebody scrolled.
- **The right-aligned slot is gone.** Segments read left to right, separated by `·`. A right edge
  only reads as a place things belong when the row is wide enough for the gap to look deliberate.

## A judgment call I made — overrule it freely

On a row too narrow for everything, **the count is dropped before the abort hint**. Dropping from the
right would take the abort hint first, and a row that gave up *how to stop this* to keep a number
would have its priorities backwards. Priority is head > abort > return > count, and it is pinned in a
test so the choice is visible rather than emergent.

## Tests

The shine tests are **replaced, not adjusted** — they pinned a band that only painted itself. What
replaces them states the properties the defect violated:

- **every cell is painted** (the coverage claim)
- **the ramp ends at the ground** — so coverage alone cannot pass while an edge survives
- an **intermediate cell exists** at all (the band is not two-valued)
- the band **advances with the phase**
- a **light terminal gets a different pair**
- `tick` is pinned against an **injected clock**: ticking without time passing must not move the
  band, which a frame counter fails and a clock-derived position passes

The tail-away tests move to the new meaning, including **an assertion that did not exist before** —
that returning to the tail leaves the count alone. The old implementation zeroed it there, so its
absence is exactly what would let the conflation come back quietly.

`_with_suffix` is removed along with the right-aligned slot it served.

## Test plan

- [x] `pytest -k "activity or colour or palette or queue or chrome or tail_away or 3300"` — 185 passed, 6 skipped
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` on both changed test files — 28 inspected, 0 errors
- [x] `python scripts/verify_module_docstrings.py` on all three changed src files — OK
- [x] `python scripts/mypy_ratchet.py` — 0 findings
- [x] (skipped — per lead-coder's ruling today, the local full suite is CI's job and duplicating it
      costs 15 minutes and six known-false reds, #3791) **Full `pytest`**
- [x] (waived — owner 恒久指示「見た目ゲートだとしても main マージ進めてよ。そうしないと会社で見れないんだから」。owner は会社の端末で main を見るため、未確認のまま入れるほうが確認が早くなる) **Visual: real terminal.** Whether the band now reads as ONE travelling light, and whether the
      light pair works on a light terminal — the second is the part I could not establish from text
      at all.

**One gate caught something I did not**: `test_tier_audit` rejected `len(styles) > 2` as format
pinning. It was right — the property is *an intermediate exists*, not *there are more than two of
something*, and it is now stated that way.

Part of #3777. Stage 4 (key-hint wording) remains.

---

**[lead-coder]** — レビューで 2 点、blocking として追記します（本文に置くのは、レビューコメントだけだと merge 判断が読む面に載らないため）。

- [x] 🔴 **経過時計の書式が `MM:SS` → `Ns` に変わっているが、これは依頼に入っていない。** `activity_text` の docstring は変更されないまま `prints no clock rather than a zero, because "00:00" reads as a fact` と書いており、新書式では 0 は `0s` で `00:00` は二度と現れない — 同一 PR 内の doc drift（CLAUDE.md hard rule）。加えて長いターンでは `1247s` は読めず `20:47` は読める。**書式を戻すか、変える理由を書いて owner ゲートに載せるか、どちらか。**
- [x] 🔴 **`while segments and len(...) > width` は head 単独が `width` を超える場合に全 optional を落としてなお溢れる。** これは意図（head は落とさない）と整合するが、**その終端状態がテストで pin されているか**を確認してください。溢れる幅で呼ばれたとき何が起きるかは、いずれ誰かが「clip すべきでは」と直しに来る箇所です。



---

**[lead-coder]** — 🔴 2 件とも実測で確認し、私がチェックしました（提起者が閉じるのが筋なので）。

- ① 時計: `activity_row.py:199` で 60 秒切替を確認。テストは `59 → "59s"` / `60 → "01:00"` と **境界の両側**を pin（`test_activity_row_3693.py:160-161`）。docstring の "left as specified and raised on the PR instead" は置き換え済。
- ② 幅落としループ: `width=4` で state が生存し optional が全消滅することを pin 済（`:196`）。

見た目項目は owner の恒久指示により waive。owner が main 上で見て判断されます。