### PR TITLE
chore: bump textual-flowview 0.14.0 -> 0.15.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,10 +106,27 @@ dependencies = [
     # fixes the addressed-row-rail regression 0.13.0 introduced (`c` moved the
     # addressed row; 0.13.1 moves the cursor onto `current` via `set_current`
     # instead) — pinned straight to 0.13.1, 0.13.0 was never released to reyn.
+    # 0.14.0 (#3784) exposes `following`/`FollowChanged` and fixes the
+    # early-scroll-release bug; reyn's tail-away indicator drives off that
+    # event rather than the per-frame geometry poll it replaced. (This entry
+    # is retrospective — #3784 moved the pin without extending this narrative,
+    # so the comment described 0.13.1 while the pin was 0.14.0.)
+    # 0.15.1 adds a viewport overlay API (`play_overlay`/`set_overlay`/
+    # `OverlayFinished`) and nothing else. Verified as no-change-for-reyn from
+    # the DIFF, not from the release notes: `__all__` is untouched (only
+    # `__version__` moved), the sole deleted line in `_view.py` is an import
+    # widening (`Callable` -> `Callable, Iterator`), and the two insertions
+    # that land inside EXISTING methods — `on_unmount` and `render_line` — are
+    # both guarded on overlay state that initialises to None and is written
+    # only by the overlay API. reyn references none of those three names, so
+    # both guards are permanently false and the render path is unchanged.
+    # "The changelog says additive" would not have established that: an
+    # insertion into `render_line` is a change to the hot path whatever the
+    # release notes call it.
     # The SHA is the *commit*, not the tag object: v0.13.1/v0.12.0 are
     # LIGHTWEIGHT tags (no `^{}` peel in `git ls-remote`), same as v0.9.0,
     # unlike the annotated v0.7.0/v0.8.0.
-    "textual-flowview @ git+https://github.com/tya5/textual-flowview.git@224889a494a719ec7b26b5c48a342aa654f3fefc",
+    "textual-flowview @ git+https://github.com/tya5/textual-flowview.git@503a536e5dd717731125679a32ee89a1b90ae54d",
     "numpy>=1.24",           # RAG index backend cosine similarity (ADR-0033)
     "croniter>=2.0",         # cron expression parsing for FP-0009 Component B
     "charset-normalizer>=3.0",  # #1452 read_file encoding detection (MIT, pure-python)

--- a/tests/test_textual_chat_phase2_3273.py
+++ b/tests/test_textual_chat_phase2_3273.py
@@ -191,7 +191,13 @@ def test_flowview_library_is_unmodified_blink_lives_in_reyn() -> None:
     # pin here is what detects a locally-forked/vendored flowview masquerading
     # as the release (a mismatch means the installed copy is not the pinned
     # one).
-    assert textual_flowview.__version__ == "0.14.0"
+    # The version literal moves with every pin bump. It is kept because this
+    # test predates ``scripts/verify_env_identity.py`` (#3723), which now checks
+    # the same thing better — against the SHA in pyproject rather than a string
+    # someone has to remember to edit. Raised on the bump PR rather than
+    # removed here: deleting another gate mid-bump is how a bump hides a
+    # regression.
+    assert textual_flowview.__version__ == "0.15.1"
     # The native animation primitive reyn now drives the blink through: FlowView
     # accepts an ``animation_fps`` and owns its own animation tick.
     import inspect


### PR DESCRIPTION
**[tui-coder]** — Pin bump only. reyn does not use what 0.15.1 adds; the point is to keep the pin
current and to establish that nothing on screen changes.

```
pyproject.toml  224889a494a719ec7b26b5c48a342aa654f3fefc   (0.14.0)
             ->  503a536e5dd717731125679a32ee89a1b90ae54d   (0.15.1)
```

## "Purely additive" was true of the public surface and not of the code

The brief said the release is additive. **It is — at the level of `__all__`.** Read as a diff, two of
the five insertions land *inside existing methods*:

```
@@ -247,0 +248,14 @@   class FlowView       <- new
@@ -403,0 +418,12 @@   class FlowView       <- new
@@ -433,0 +460,2  @@   on_unmount           <- INSIDE an existing method
@@ -1591,0 +1620,101 @@ class FlowView      <- new
@@ -1718,0 +1848,4 @@  render_line          <- INSIDE the hot path
```

`render_line` runs for every line of every frame reyn draws. An insertion there is a change to the
hot path whatever the release notes call it.

## Why it is nonetheless a no-op for reyn

Not from the changelog — from the code:

- **`__all__` is untouched**; only `__version__` moved.
- **The sole deleted line in `_view.py`** is an import widening (`Callable` -> `Callable, Iterator`).
- Both in-place insertions are **guards**:
  ```python
  def render_line(self, y):
      if self._overlay_frame is not None:      # <- added
          return self._overlay_line(y)
  def on_unmount(self):
      if self._overlay_timer is not None:      # <- added
          self._overlay_timer.stop()
  ```
- **The guarded state initialises to `None`** (`_view.py:422`, `:425`) and is written **only** by the
  overlay API (`play_overlay` / `set_overlay`).
- **reyn references none of `play_overlay`, `set_overlay`, `OverlayFinished`** anywhere in `src` or
  `tests`. (`overlay` has three hits, all unrelated English in comments — a pipeline docstring, an
  auth spinner note, and a row-rail comment.)

So both guards are permanently false and the render path is unchanged **by construction**, which is
a different claim from "the release is additive" and the one that actually matters here.

## A drift this bump would otherwise have deepened

The `pyproject.toml` narrative stopped at **0.13.1 while the pin was already 0.14.0** — #3784 moved
the pin without extending it. Both versions are recorded now, and the 0.14.0 entry says it is
retrospective rather than reading as if the gap never existed.

## One thing raised, not decided

`test_flowview_library_is_unmodified_blink_lives_in_reyn` asserts
`textual_flowview.__version__ == "0.14.0"` — a literal that has to be edited on every bump. Its
stated contract is "flowview is not forked or monkeypatched", which the two assertions above it
(module provenance) already carry, and **`scripts/verify_env_identity.py` (#3723) now checks
venv-vs-pyproject against the SHA** — the same property, without a string anyone has to remember.

I updated the literal rather than removing the assertion. **Deleting another gate inside a
dependency bump is how a bump hides a regression**, so if it should go, it should go on its own.

## Test plan

- [x] `pytest -k "flowview or textual_chat or conversation or tail_away or activity or scroll or 3692"` — 284 passed, 6 skipped
- [x] `pytest tests/test_textual_chat_phase2_3273.py` — 12 passed (the module whose literal changed)
- [x] `python scripts/verify_env_identity.py` — OK (venv matches the new pin)
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_textual_chat_phase2_3273.py` — 0 errors
- [x] (skipped — per lead-coder's ruling today the local full suite is CI's job) **Full `pytest`**
- [x] **Visual: real terminal** — A/B in tmux at 110×32, same source tree, only the flowview
      install swapped: `diff` of the two captures is **empty**. The claim is "nothing changes",
      and it is now measured rather than argued from the diff. (First attempt was a broken
      control — it varied an unrelated source edit of mine as well; see the comment below.)
