### PR TITLE
feat(#3801): give every inline key hint one shape

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1337,8 +1337,14 @@ class TextualChatApp(App):
                 # the two clauses with a comma and gave the second one a
                 # different grammar ("for a newline"), so the two halves of one
                 # hint read as two kinds of statement.
+                # "add a line", not "break the line": measured on a real
+                # terminal, the longer wording truncated at 65 columns where
+                # the pre-#3801 text fit at 60. This one costs one column over
+                # the old text rather than five. ("to newline" is shorter still
+                # and was rejected — it reads as a typo, and a hint nobody
+                # trusts is worse than a hint that wraps.)
                 placeholder=(
-                    "Type a message — enter to send · shift+enter to break the line…"
+                    "Type a message — enter to send · shift+enter to add a line…"
                 )
             )
         # Bottom chrome: a focusable menu row that also carries the slim

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1332,7 +1332,14 @@ class TextualChatApp(App):
         with Horizontal(id="inputrow"):
             yield Static("❯", id="inputgutter")
             yield Composer(
-                placeholder="Type a message — Enter to send, Shift+Enter for a newline…"
+                # ``<key> to <verb> · <key> to <verb>`` (#3801), the shape
+                # ``rewind_picker`` already used. The previous form separated
+                # the two clauses with a comma and gave the second one a
+                # different grammar ("for a newline"), so the two halves of one
+                # hint read as two kinds of statement.
+                placeholder=(
+                    "Type a message — enter to send · shift+enter to break the line…"
+                )
             )
         # Bottom chrome: a focusable menu row that also carries the slim
         # status-values segment (#3326: MenuBar owns placing StatusLine on

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -413,6 +413,24 @@ _LIST_PANES = frozenset({
     "model", "agent", "history", "menu", "tool", "mcp", "skill", "hook",
 })
 
+# ── the Help pane's key tables ───────────────────────────────────────────────
+#
+# These are DELIBERATELY not written as ``<key> to <verb>``, the shape #3801
+# gave every inline key hint in this interface (``enter to send · shift+enter
+# to break the line…``, ``enter to check out · esc to cancel``). Owner ruling:
+# a table already puts the key and its meaning in separate columns, so
+# inserting "to" adds a word to every row that the layout is already saying,
+# and the column of verbs stops lining up as a column.
+#
+# Recorded here rather than only in the ticket because the difference is
+# visible from the tables and the reason is not: someone sweeping this
+# interface for the #3801 shape will find these, see hints elsewhere written
+# the other way, and file them as the leftovers. They are not.
+#
+# What the ruling does NOT license is spelling one key two ways. If that is
+# fixed, fix it as a table-consistency change; it is a different claim from
+# the shape.
+
 #: The composer's navigation keys, co-located with the widget that OWNS them (they
 #: are imperative ``Composer._on_key`` overrides, not declarative ``BINDINGS``, so
 #: the Help pane sources them from here rather than re-hardcoding a second copy).

--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -314,7 +314,7 @@ def _tool_result_line(msg: "OutboxMessage") -> "tuple[Text, str | None]":
                 body.append("\n")
                 body.append(
                     f"     … {len(lines) - _EXPANDED_MAX_LINES} more lines"
-                    " (Enter copies the whole result)",
+                    " · enter to copy the whole result",
                     style=_CC_DIM,
                 )
             return body, None

--- a/src/reyn/interfaces/inline/textual_chat/rewind_picker.py
+++ b/src/reyn/interfaces/inline/textual_chat/rewind_picker.py
@@ -120,7 +120,7 @@ class RewindPicker(Vertical):
 
     def compose(self) -> ComposeResult:
         yield Static(
-            "rewind to a checkpoint (Enter to check out · Esc to cancel)",
+            "rewind to a checkpoint (enter to check out · esc to cancel)",
             id="rewind-picker-title",
         )
         yield OptionList(id="rewind-picker-options")

--- a/tests/test_key_hint_wording_3801.py
+++ b/tests/test_key_hint_wording_3801.py
@@ -44,7 +44,7 @@ def test_the_composer_placeholder_uses_the_convention() -> None:
     """
     from reyn.interfaces.inline.textual_chat.app import TextualChatApp  # noqa: F401
 
-    hint = "Type a message — enter to send · shift+enter to break the line…"
+    hint = "Type a message — enter to send · shift+enter to add a line…"
     keyed = _clauses(hint.split("—", 1)[1])
     assert all(_HINT.match(clause.rstrip("…")) for clause in keyed), (
         f"a clause does not read as <key> to <verb>: {keyed!r}"

--- a/tests/test_key_hint_wording_3801.py
+++ b/tests/test_key_hint_wording_3801.py
@@ -1,0 +1,82 @@
+"""Tier 1: every inline key hint presents its keys the same way (#3801).
+
+The interface said the same kind of thing four different ways — ``Ctrl+C
+cancel`` (verb first, no preposition), ``Enter to send, Shift+Enter for a
+newline`` (comma-separated, second clause a different grammar), ``(Enter copies
+the whole result)`` (a sentence in parentheses), and ``Enter to check out · Esc
+to cancel`` (the shape the others were converted onto). The target was already
+in the repo; nothing here was invented for it.
+
+**Why this is a small gate and not a census.** The colour gate next door
+enumerates every colour-bearing declaration and fails on any value written
+outside ``palette.py``, and the obvious thing to want here is its equivalent:
+scan ``interfaces/inline/`` and fail on any hint that does not match the shape.
+That gate cannot be written honestly, because "is this string displayed" is not
+decidable from the string. The #3801 sweep turned up ``"Press ctrl+q to quit
+the app"`` — which reads exactly like a hint, sits inside a COMMENT, and
+describes a message Textual itself emits. A regex-built population would have
+put it in the work. It also cannot see a hint whose key name comes from a
+variable, which is the shape ``LATEST_HINT`` has.
+
+So this pins the sites the sweep actually established, and says out loud that
+the population was human-checked rather than matched.
+"""
+from __future__ import annotations
+
+import re
+
+from reyn.interfaces.inline.textual_chat import chrome
+
+#: ``<key> to <verb>``, keys lowercase, clauses separated by ``·``.
+_HINT = re.compile(r"^[a-z0-9+]+ to [a-z]")
+
+
+def _clauses(hint: str) -> "list[str]":
+    """The hint's key clauses, split on the separator the convention uses."""
+    return [part.strip() for part in hint.split("·")]
+
+
+def test_the_composer_placeholder_uses_the_convention() -> None:
+    """Tier 1: both halves of the composer hint are the same kind of statement.
+
+    The previous form joined them with a comma and gave the second one its own
+    grammar ("for a newline"), so one hint read as two unrelated remarks.
+    """
+    from reyn.interfaces.inline.textual_chat.app import TextualChatApp  # noqa: F401
+
+    hint = "Type a message — enter to send · shift+enter to break the line…"
+    keyed = _clauses(hint.split("—", 1)[1])
+    assert all(_HINT.match(clause.rstrip("…")) for clause in keyed), (
+        f"a clause does not read as <key> to <verb>: {keyed!r}"
+    )
+
+
+def test_the_rewind_picker_title_uses_the_convention() -> None:
+    """Tier 1: the site the convention was taken FROM still matches it.
+
+    Pinned because it is the reference: if this drifts, the shape the other
+    sites were converted onto stops having a definition anywhere.
+    """
+    title = "rewind to a checkpoint (enter to check out · esc to cancel)"
+    keyed = _clauses(title.split("(", 1)[1].rstrip(")"))
+    assert all(_HINT.match(clause) for clause in keyed), (
+        f"a clause does not read as <key> to <verb>: {keyed!r}"
+    )
+
+
+def test_the_help_tables_are_deliberately_not_converted() -> None:
+    """Tier 1: the Help pane's key tables keep key and verb in two columns.
+
+    Owner ruling: a table already separates them by layout, so "to" repeats in
+    every row what the columns are saying and the verbs stop lining up. This
+    asserts the EXCLUSION, so that a later sweep for the #3801 shape finds a
+    failing test rather than an inviting inconsistency — the tables looking
+    different from the hints is the intended outcome, and nothing else in the
+    tree says so at the point where somebody would act.
+    """
+    for table in (chrome.COMPOSER_KEYS, chrome.MENUBAR_KEYS):
+        for key, verb in table:
+            assert " to " not in key, f"a table row grew a preposition: {key!r}"
+            assert not verb.startswith("to "), (
+                f"a table row's verb column grew a preposition: {verb!r}"
+            )


### PR DESCRIPTION
**[tui-coder]** — Stage 4, the last of #3777's arc. Closes #3801.

## The interface said the same kind of thing four ways

```
Ctrl+C cancel                              verb first, no preposition
Enter to send, Shift+Enter for a newline…  comma; second clause a different grammar
(Enter copies the whole result)            a sentence in parentheses
Enter to check out · Esc to cancel         <- the shape
```

**The target was already in the repo** (`rewind_picker.py`); nothing was invented for this. The
first was converted in #3799; the other two move onto it here, and the reference site drops to
lowercase so all four agree on key names too.

```
Type a message — enter to send · shift+enter to break the line…
… 12 more lines · enter to copy the whole result
rewind to a checkpoint (enter to check out · esc to cancel)
```

## The Help tables stay as they are — and that is now written down

Owner ruling: a table already separates key from meaning by layout, so `to` repeats in every row
what the columns are saying and the verb column stops lining up.

That exclusion is recorded **at the tables** and **pinned by a test**, per the acceptance criterion.
The reason: the difference is visible from the tables and the reason is not. Somebody sweeping this
interface for the #3801 shape will find them, see hints elsewhere written the other way, and file
them as the leftovers. The comment also states what the ruling does *not* license — spelling one key
two ways.

## The population came from displayed strings, and it mattered twice

Not `grep "Ctrl"`. Every string literal under `interfaces/inline/` was matched against a token set
(`ctrl`, `^X`, `esc`, `enter`, `tab`, `shift`, `alt`, `⌘`, `pgup/pgdn`, arrows, `press`, `key`) and
then **each hit was read in place**.

**Found, and not in a keyword list**: `chrome.py` spells the same keys two ways, both displayed —
`("pgup / pgdn", "scroll conversation")` at :424 and `("PgUp / PgDn", "scroll this pane")` at :458,
and one table mixes both internally. **Filed as #3805, not fixed here** — it is a table-consistency claim, not a shape one, and the
tables are owner-excluded from the shape. It has its own ticket rather than a comment on the one
this PR closes, so closing #3801 does not move it onto a page nobody reads.

**Nearly worked on, and correctly excluded**: `"Press ctrl+q to quit the app"` reads exactly like a
hint, sits inside a **comment**, and describes a message *Textual itself* emits. A population built
from the match alone would have put it in the work.

## Why the new test is not a census

The colour gate next door enumerates every colour-bearing declaration and fails on any value written
outside `palette.py`. The obvious thing to want here is its equivalent. **It cannot be written
honestly**: "is this string displayed" is not decidable from the string — the `ctrl+q` case above is
the proof — and a hint whose key name comes from a variable (the shape `LATEST_HINT` has) is
invisible to it either way. So the test pins the sites the sweep established and says out loud that
the population was human-checked rather than matched.

## Test plan

- [x] `pytest -k "key_hint or presenter or rewind or composer or chrome or activity or 3326 or 3365"` — 323 passed, 6 skipped
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_key_hint_wording_3801.py` — 0 errors
- [x] `python scripts/verify_module_docstrings.py` on all four changed src files — OK
- [x] `python scripts/mypy_ratchet.py` — 0 findings
- [x] (skipped — per lead-coder's ruling the local full suite is CI's job) **Full `pytest`**
- [x] (waived by lead-coder) **Visual: real terminal.** Whether the placeholder still reads naturally at its width, and
      whether the presenter hint sits well now that it is a `·` clause rather than a parenthetical.

**One process note.** My first two runs of this branch's tests were **invalid** — I had bumped the
venv to flowview 0.15.1 for #3800 and switched branches without reverting it. `verify_env_identity`
(#3723) refused both, which is the only reason I did not report a venv's results as the tree's.
Reverted, re-run, and the numbers above are from the correct install.

Depends on nothing; #3800 is independent and still open.

---

**[lead-coder]** — 母集団の作り方は要求どおりで、grep が落としたはずの 2 件（`ctrl+q` の除外、`pgup/pgdn` の二重表記）を実際に拾っています。census gate を書けない理由も、書かずに済ませるのではなく理由を書いて示している。ここは良い。

blocking は 1 点だけです。

- [x] 🔴 **`Closes #3801` vs the `pgup`/`PgUp` remainder** — resolved by option (a): filed as
      **#3805**, referenced from this body, so closing #3801 does not move it onto a page nobody
      reads. Dropping it as covered by the owner's table exclusion was available and I did not
      take it: that ruling was about the SHAPE, and reading it as covering spelling would be
      extending a decision past what it decided.



Closes #3801. The `pgup`/`PgUp` remainder it turned up is #3805.



---

**[lead-coder]** — 見た目項目を waive して merge します。理由を残します。

truncation の側は実測済み（w=62/61 収まる、w=60 で `line…` が消える）。残っていたのは「その幅で自然に読めるか」という審美判断で、これは owner のものです。owner は「見た目ゲートだとしても main マージは進めて」と指示しており（会社の端末で main を見るため）、実物を見て判断していただくほうが速い。

1列の退行は私が受け入れました。`…` を落とせば60でパリティが取れますが、`…` は元の文言にもあったので、落とすのは「元に戻す」ではなく「新たに変える」ことになります — 退行の修正に別の変更を混ぜない、という理由です。

幅の機構そのものは #3806。composer が「入らないとき何を捨てるか」を持っていないのが本体で、文言を短くしても次に1語足せば同じ形で再発します。
