### PR TITLE
fix: repair 2 stale prose comments left by #3789/#3799

### DIFF
--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -179,7 +179,8 @@ actually testing became true. A straight-line `sleep(N)` — using elapsed
 time itself as the thing that makes an assertion pass — is banned outright,
 the same way it always was; this section states the discipline explicitly
 because this repo's own violations show the ban was never actually
-enforced, not because the rule itself is new.
+enforced, not because the rule itself is new. Summarized as a Key
+constraints bullet in `CLAUDE.md` too — update both if this changes.
 
 **CI's `--timeout=120` is a kill switch, not a per-test contract.** It
 exists to bound the damage a single hung test does to the rest of the run —

--- a/src/reyn/interfaces/inline/textual_chat/activity_row.py
+++ b/src/reyn/interfaces/inline/textual_chat/activity_row.py
@@ -29,12 +29,17 @@ The row used to open with a literal ``NOW`` label. Owner call (2026-08-07,
 "now とか next という文字列がださいな"): dropped it, and the state word
 itself now carries a travelling highlight ("shine", design "A" of three
 text-mockup options put to the owner) while a turn runs — see
-:data:`_SHINE_WIDTH`, :func:`_shine_ramp` and :meth:`ActivityRow.tick`. The
-band was a two-character ``reverse`` when #3779 first shipped it; the operator
-read that as a block blinking rather than a light moving, which is what a
-two-valued band is — it has no edge to fall off. #3777 replaced it with a
-cosine ramp between :data:`palette.SHINE_DIM` and :data:`palette.SHINE_PEAK`,
-keeping the old attribute band as the no-colour fallback. One
+:data:`_SHINE_FRACTION`, :func:`_shine_ramp` and :meth:`ActivityRow.tick`.
+The band was a two-character ``reverse`` when #3779 first shipped it; the
+operator read that as a block blinking rather than a light moving, which is
+what a two-valued band is — it has no edge to fall off. #3777 replaced it
+with a cosine ramp between a theme-aware ground and peak
+(:data:`palette.SHINE_GROUND_DARK`/:data:`palette.SHINE_GROUND_LIGHT` and
+:data:`palette.SHINE_PEAK_DARK`/:data:`palette.SHINE_PEAK_LIGHT` — #3799
+split what had been one fixed pair, since a near-white peak is invisible on
+a light terminal background), keeping the old attribute band as the
+no-colour fallback. The band's width is also no longer a fixed cell count:
+#3799 made it :data:`_SHINE_FRACTION` of the span it crosses. One
 timer drives both the shine and the elapsed clock (the clock is recomputed
 fresh from the real clock on every tick regardless of rate, so sharing the
 timer costs nothing in correctness) and is paused/resumed by

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -420,8 +420,12 @@ class RouterHostAdapter:
         # Session passes the project root so all 3 tiers are covered.
         project_root: Path | None = None,
         # #1092 PR-F1 (chat activation): builds the shared turn_budget engine
-        # the chat axis budgets against — off the CompactionEngine's RESOLVED
-        # model (#1172-safe). Sole consumer (for now) is wrap_up_output_reserve
+        # the chat axis budgets against. #3789 (#1172-safe): resolves its own
+        # model directly (`self._resolver.resolve(self.model).model` in
+        # Session), independent of CompactionEngine — the two used to share a
+        # resolution path, and no longer do; see `docs/reference/runtime/
+        # session-construction.md`'s compaction section for why. Sole
+        # consumer (for now) is wrap_up_output_reserve
         # — which hard-caps the force-close wrap-up call's output. `None` = no
         # engine (legacy / test paths) → no cap (== pre-PR-F behaviour).
         # ADDITIVE: chat never calls _force_close_call until the F2 handoff


### PR DESCRIPTION
**[docs-maintainer]** — Cross-reference audit dispatch (lead-coder), searching for architect's exact co-vet finding class: prose comments that confidently assert HOW something is resolved/wired, where the mechanism moved but the comment didn't — never a broken symbol reference, so ordinary dead-name grepping wouldn't catch it. Verified each independently against real `origin/main` (not the PR diff's claims) before fixing.

## Found and fixed

- **`router_host_adapter.py:422-424`** — the exact instance architect flagged. The comment said turn_budget's cap comes "off the CompactionEngine's RESOLVED model." #3789 changed this: turn_budget now resolves its own model directly (`self._resolver.resolve(self.model).model` in `session.py`), independent of `CompactionEngine`. `docs/reference/runtime/session-construction.md` was correctly synced by #3789 — only this one code comment, in a file #3789 never touched, survived stale.
- **`activity_row.py`'s module docstring** — cited 3 symbols #3799 deleted/renamed: `_SHINE_WIDTH` (→ `_SHINE_FRACTION`, proportional not fixed-cell), `palette.SHINE_DIM`/`SHINE_PEAK` (→ theme-aware `SHINE_GROUND_DARK/LIGHT` + `SHINE_PEAK_DARK/LIGHT` pairs). Confirmed all 3 old names are gone from the current tree and all replacements exist before rewriting.

## Also checked, clean

- #3795 (context-overflow classifier unification) — comments correctly updated in the same PR.
- #3797 (same-cause recover cap + audit-event) — self-contained, triad-synced.
- #3798 (my own docs-only PR) — skipped.

## Test plan
- [x] `ruff check` — clean
- [x] `python scripts/verify_module_docstrings.py` — clean
- [x] `python scripts/mypy_ratchet.py` — clean
- [x] `pytest tests/test_activity_row_3693.py` — 24/24 pass (comment-only edit, behavior unchanged)
- [x] `pytest tests/test_3126_doc_anchor_gate.py` — 331/331 pass