### PR TITLE
refactor(#3793): stage 1 — AttachedConnection (ADR-0039 D4 conformance), zero behavior change

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -496,7 +496,7 @@ class TextualChatApp(App):
     #3310 N2 reuses that SAME hydrate seam for a session SWITCH, not just a
     restart. N1 (#3321) added a ``session_attached`` chat-event — an
     ``EventFrame`` the registry puts directly on ``repl_outbox`` at the attach
-    seam, with NO ``await`` between the ``self._attached`` flip and the put —
+    seam, with NO ``await`` between the connection-switch flip and the put —
     so it is a stream BARRIER: everything on the frame stream before it
     belongs to the OLD attached session, everything after to the NEW one, by
     construction. :meth:`_handle_session_attached_event` consumes it: a cached

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -133,6 +133,72 @@ def _validate_agent_name(name: str) -> None:
         )
 
 
+class AttachedConnection:
+    """#3793 stage 1 (ADR-0039 D4 conformance) — the vocabulary architect's
+    design settled on for a "connection" (the tmux-multiplexer analogy: a
+    connection is a *client*, not a session):
+
+    - ``attached`` — the set of sessions a connection receives OUTPUT from.
+      N-capable (multiple sessions could be attached at once — stage 2/3).
+    - ``active`` — the ONE destination for un-addressed INPUT (composer free
+      text). Exactly one per connection, or None.
+    - ``addressed`` input (an id-carrying answer — ``cancel_queued(msg_id)``,
+      ``answer_intervention_by_id``) is NOT this class's concern: it already
+      reaches whichever session owns that id, independent of ``active`` —
+      unaffected by this class and must stay that way.
+
+    ★Stage 1 invariant (deliberately, not yet the end state): ``switch``
+    always fully REPLACES the previous entry — ``attached`` never holds more
+    than one key. This is what keeps stage 1 a "zero behaviour change" PR:
+    TUI and AG-UI share ONE instance of this class today (byte-identical to
+    sharing one ``_attached`` tuple), and switching still means exactly what
+    it always meant — detach the old, attach the new. Stage 2 is what
+    actually lets ``attached`` grow past one entry (giving AG-UI its own
+    instance instead of sharing the registry's).
+
+    Lives inside ``registry.py`` for stage 1 (the registry still constructs
+    and owns the one shared instance) — the design's end state moves
+    ownership to "the connection" itself, a transport-side concept core
+    should not construct; that relocation is stage 2/3, not this class's
+    definition changing.
+    """
+
+    def __init__(self) -> None:
+        self._attached: "dict[tuple[str, str], None]" = {}  # insertion-ordered set
+        self._active: "tuple[str, str] | None" = None
+        self._background_attach_error: "str | None" = None
+
+    def attached_set(self) -> "frozenset[tuple[str, str]]":
+        """The full N-capable attached set (stage 1: always 0 or 1 entries)."""
+        return frozenset(self._attached)
+
+    @property
+    def active(self) -> "tuple[str, str] | None":
+        return self._active
+
+    def is_attached(self, key: "tuple[str, str]") -> bool:
+        return key in self._attached
+
+    def switch(self, key: "tuple[str, str] | None") -> "tuple[str, str] | None":
+        """Replace the (stage 1: at-most-one) attached/active entry with
+        ``key`` (``None`` to clear/detach). Returns the PREVIOUS active key
+        (or ``None``) so the caller can detach/unwire it — mirrors what
+        ``AgentRegistry.attach``'s own ``old = self._attached`` capture did
+        before this class existed."""
+        old = self._active
+        self._attached.clear()
+        if key is not None:
+            self._attached[key] = None
+        self._active = key
+        return old
+
+    def record_background_attach_error(self, error: "str | None") -> None:
+        self._background_attach_error = error
+
+    def attach_failed(self) -> bool:
+        return self._background_attach_error is not None
+
+
 class AgentRegistry:
     """In-process map of agent_name -> Session with persistence wired in.
 
@@ -265,7 +331,12 @@ class AgentRegistry:
         # per-conversation, so they scale with sessions, not identities.
         self._tasks: dict[tuple[str, str], asyncio.Task] = {}         # (name,sid) -> session.run() task
         self._forward_tasks: dict[tuple[str, str], asyncio.Task] = {} # (name,sid) -> outbox forwarder
-        self._attached: "tuple[str, str] | None" = None              # (name, sid) focus
+        # #3793 stage 1 (ADR-0039 D4): TUI and AG-UI both point at this ONE
+        # shared instance today (zero behaviour change — see AttachedConnection's
+        # own docstring). Stage 2 gives AG-UI its own instance instead of
+        # sharing this one, which is what actually lets `attach()` on one
+        # connection stop affecting another.
+        self._connection = AttachedConnection()
         # Focus-following front-end listeners (REPL/CUI): a chat-event callback
         # (working indicator) and an intervention listener channel (ask_user) that
         # must follow the attached session across agent switches. None until a
@@ -289,14 +360,14 @@ class AgentRegistry:
         # Single queue the REPL drains; registry routes each attached agent's
         # outbox into here.
         self.repl_outbox: asyncio.Queue = asyncio.Queue()
-        # #3671 P3: the ONE place a caller doing a BACKGROUND attach (P2's
+        # #3671 P3 (now #3793 stage 1: moved onto self._connection): the ONE
+        # place a caller doing a BACKGROUND attach (P2's
         # `chat.py._background_attach`, running off the render path) can
         # record that its attach ultimately failed, so a client reading
         # `has_session() is False` can distinguish "still connecting" from
         # "gave up" (see `ClientTransport.attach_failed`). `None` = no
         # recorded failure. Cleared at the top of `attach()` so a fresh
         # attach attempt is never shadowed by a stale prior failure.
-        self._background_attach_error: str | None = None
         # #3671 P4 item C-1: post-WAL-replay snapshots `restore_all(only_names
         # =...)` deferred instead of building+running immediately — applied
         # once, lazily, the first time `get_or_load` actually constructs that
@@ -818,7 +889,7 @@ class AgentRegistry:
         are both preserved on disk."""
         if name == DEFAULT_AGENT_NAME:
             raise ValueError("cannot remove the default agent")
-        if self._attached is not None and self._attached[0] == name:
+        if self._connection.active is not None and self._connection.active[0] == name:
             raise ValueError(f"cannot remove attached agent {name!r}")
         target = self._dir / name
         if not target.is_dir():
@@ -3170,9 +3241,9 @@ class AgentRegistry:
         category error #3288 ③b designed out.
 
         ★Barrier property (design-pass, issue #3310): this call is placed
-        IMMEDIATELY after the ``self._attached = key`` flip, with NO
-        ``await`` anywhere in between (both are plain synchronous
-        statements: an attribute assignment and ``Queue.put_nowait``, never
+        IMMEDIATELY after the ``self._connection.switch(key)`` flip, with NO
+        ``await`` anywhere in between (``switch`` is a plain synchronous
+        method, and ``Queue.put_nowait`` never suspends, unlike
         ``await Queue.put``). Single event loop ⇒ nothing can interleave
         inside that synchronous region, so on the ``repl_outbox`` FIFO
         "before this frame = old session's frames, after = new session's
@@ -3195,11 +3266,11 @@ class AgentRegistry:
         # so a caller retrying after `record_background_attach_error` sees a
         # clean "connecting" state again immediately, not "failed" until
         # this attempt ALSO finishes.
-        self._background_attach_error = None
+        self._connection.record_background_attach_error(None)
         new_session = self.get_or_load(name)
         sid = _DEFAULT_SID  # FP-0043 S3: attach(name) focuses the default session
         key = (name, sid)
-        old = self._attached
+        old = self._connection.active
         if old is not None and old != key:
             old_session = self._peek_session(old[0], old[1])
             if old_session is not None:
@@ -3223,7 +3294,7 @@ class AgentRegistry:
             self._forward_tasks[key] = asyncio.create_task(
                 self._forwarder(name, sid)
             )
-        self._attached = key
+        self._connection.switch(key)
         self._announce_session_attached(name, sid)
 
         # Re-announce any pending interventions for the user. While detached,
@@ -3250,7 +3321,7 @@ class AgentRegistry:
         if target is None:
             raise KeyError(f"no session {sid!r} for agent {name!r}")
         key = (name, sid)
-        old = self._attached
+        old = self._connection.active
         if old is not None and old != key:
             old_session = self._peek_session(old[0], old[1])
             if old_session is not None:
@@ -3263,7 +3334,7 @@ class AgentRegistry:
             self._tasks[key] = asyncio.create_task(target.run())
         if key not in self._forward_tasks or self._forward_tasks[key].done():
             self._forward_tasks[key] = asyncio.create_task(self._forwarder(name, sid))
-        self._attached = key
+        self._connection.switch(key)
         self._announce_session_attached(name, sid)
         for iv in target._interventions.list_active():
             if not iv.future.done():
@@ -3299,7 +3370,7 @@ class AgentRegistry:
                     # Session shut down — propagate to REPL only if we're the
                     # attached one (otherwise REPL would terminate spuriously
                     # on a detached session's shutdown).
-                    if key == self._attached:
+                    if self._connection.is_attached(key):
                         await self.repl_outbox.put(msg)
                     return
                 if msg.kind == "__attach_request__":
@@ -3327,7 +3398,7 @@ class AgentRegistry:
                         # (re-post removed: was for Textual TUI header refresh —
                         # dead code after TUI deletion; _output_loop never used it.)
                     continue
-                if key == self._attached:
+                if self._connection.is_attached(key):
                     await self.repl_outbox.put(msg)
                 # else: drop — session is detached, transient kinds were already
                 # dropped at source, durable narration is in history.jsonl
@@ -3336,30 +3407,34 @@ class AgentRegistry:
 
     def detach(self) -> None:
         """Mark the attached session as detached without stopping its task."""
-        if self._attached is None:
+        active = self._connection.active
+        if active is None:
             return
-        session = self._peek_session(self._attached[0], self._attached[1])
+        session = self._peek_session(active[0], active[1])
         if session is not None:
             session.is_attached = False
-        self._attached = None
+        self._connection.switch(None)
 
     @property
     def attached_name(self) -> str | None:
-        # FP-0043 S3: _attached is (name, sid); the public accessor exposes the
-        # agent NAME (byte-identical to the prior str|None).
-        return self._attached[0] if self._attached is not None else None
+        # FP-0043 S3: the connection's active key is (name, sid); the public
+        # accessor exposes the agent NAME (byte-identical to the prior str|None).
+        active = self._connection.active
+        return active[0] if active is not None else None
 
     @property
     def attached_sid(self) -> str | None:
         """FP-0043 Stage 4a: the focused session-id (or None) — the public
         surface for `/session list`'s focus marker + tests, so callers don't
-        reach into `_attached`."""
-        return self._attached[1] if self._attached is not None else None
+        reach into the connection's own state."""
+        active = self._connection.active
+        return active[1] if active is not None else None
 
     def attached_session(self) -> "object | None":
-        if self._attached is None:
+        active = self._connection.active
+        if active is None:
             return None
-        return self._peek_session(self._attached[0], self._attached[1])
+        return self._peek_session(active[0], active[1])
 
     def record_background_attach_error(self, error: str) -> None:
         """#3671 P3: called by a caller doing a BACKGROUND attach (P2's
@@ -3369,14 +3444,14 @@ class AgentRegistry:
         A caller that never does a background attach never calls this; a
         transport reading `attach_failed()` before ANY attach was even
         attempted correctly still sees `False` (== "connecting")."""
-        self._background_attach_error = error
+        self._connection.record_background_attach_error(error)
 
     def attach_failed(self) -> bool:
         """#3671 P3: whether the most recent attach attempt is KNOWN to have
         given up (vs. still in flight, or having never started) — see
         `record_background_attach_error`. Cleared at the top of every
         `attach()` call, so a retry is never shadowed by a stale failure."""
-        return self._background_attach_error is not None
+        return self._connection.attach_failed()
 
     async def resume_deferred_agents(self) -> "list[str]":
         """#3671 P4 item C-1 (v2, owner ruling): proactively build+restore+run
@@ -3528,13 +3603,14 @@ class AgentRegistry:
         current attach focus.
         """
         out: list[dict] = []
+        active = self._connection.active
         for name in self.loaded_names():
             sids = sorted((self._sessions.get(name) or {}).keys())
             out.append({
                 "agent": name,
-                "attached": self._attached is not None and self._attached[0] == name,
+                "attached": active is not None and active[0] == name,
                 "sessions": [
-                    {"sid": sid, "attached": self._attached == (name, sid)}
+                    {"sid": sid, "attached": active == (name, sid)}
                     for sid in sids
                 ],
             })

--- a/tests/test_3310_n1_session_attached_barrier.py
+++ b/tests/test_3310_n1_session_attached_barrier.py
@@ -12,7 +12,7 @@ Gates covered here:
 
 1. The event is emitted on BOTH switch paths (``attach`` / ``attach_session``),
    carrying the correct ``{agent, session_id}``.
-2. ★Barrier: the flip (``self._attached = key``) and the announce
+2. ★Barrier: the flip (``self._connection.switch(key)``) and the announce
    (``repl_outbox.put_nowait``) happen with NO real ``await`` suspension in
    between, so the announce is ALWAYS the first thing a switch contributes to
    ``repl_outbox`` — even when the newly-focused session already has a frame
@@ -148,7 +148,7 @@ async def test_barrier_announce_precedes_new_sessions_own_frames(tmp_path) -> No
     possible (a bare ``await asyncio.sleep(0)`` loop — the fastest ANY real
     consumer, however it is implemented, could ever react to the flip) and
     races to put its own frame onto ``repl_outbox`` the instant it observes
-    the switch. The flip (``self._attached = key``) and the announce
+    the switch. The flip (``self._connection.switch(key)``) and the announce
     (``repl_outbox.put_nowait``) have NO real ``await`` between them (design-
     pass contract, mirroring ``Session.cancel_queued``'s no-await critical
     section, #3300 Y-server / #3306) — so no matter how fast the adversary
@@ -203,7 +203,7 @@ async def test_barrier_holds_for_attach_session_too(tmp_path) -> None:
     """Tier 2: ★race gate, the ``attach_session`` (sid-switch) call site —
     the SAME adversary as above, per-site (not cross-masked by the
     ``attach`` test): ``attach_session`` has its OWN
-    ``self._attached = key`` / announce pair (a separate code path from
+    ``self._connection.switch(key)`` / announce pair (a separate code path from
     ``attach``), so it needs its own independent proof the barrier holds
     there too."""
     reg = _registry(tmp_path)

--- a/tests/test_3310_n2_reset_hydrate.py
+++ b/tests/test_3310_n2_reset_hydrate.py
@@ -755,7 +755,8 @@ async def test_reset_queue_view_reseeds_from_new_sessions_own_queue(
             transport.push_display(OutboxMessage(kind="user", text="alpha noop"))
             await _settle(pilot)
 
-            # NOTE: flips ``registry._attached`` directly rather than calling
+            # NOTE: flips the registry's connection pointer directly (#3793
+            # stage 1: ``AttachedConnection.switch``) rather than calling
             # ``reg.attach("beta")`` again — the auto-driver was deliberately
             # stopped above (so THIS test controls dispatch); a real
             # ``attach()`` call re-boots a fresh ``session.run()`` background
@@ -767,7 +768,7 @@ async def test_reset_queue_view_reseeds_from_new_sessions_own_queue(
             # the app's ``_snapshot()`` only ever reads
             # ``registry.attached_session()``, never re-derives from a live
             # ``attach()`` call itself.
-            reg._attached = ("beta", _DEFAULT_SID)
+            reg._connection.switch(("beta", _DEFAULT_SID))
             transport.push_event(
                 "session_attached", {"agent": "beta", "session_id": _DEFAULT_SID}
             )

--- a/tests/test_3793_stage1_attached_connection.py
+++ b/tests/test_3793_stage1_attached_connection.py
@@ -1,0 +1,177 @@
+"""Tier 2: #3793 stage 1 (ADR-0039 D4 conformance) — ``AttachedConnection``.
+
+architect's design (issue #3793, owner-ratified 2026-08-08) introduces a
+3-word vocabulary — ``attached`` (N-capable output-receiving set) /
+``active`` (the one destination for un-addressed input) / ``addressed``
+(id-carrying input, unaffected by this class) — as the shape a single
+process-wide focus pointer will eventually be replaced by per-connection
+instances (stage 2/3). Stage 1's own scope is narrower and explicitly
+"zero behaviour change": wrap TODAY's single shared pointer in the new
+``AttachedConnection`` type, with BOTH the local (TUI/REPL) and remote
+(AG-UI) call sites continuing to share the ONE instance ``AgentRegistry``
+constructs — so nothing observable changes yet (that split is stage 2).
+
+This file covers:
+- ``AttachedConnection``'s own contract in isolation (no ``AgentRegistry``).
+- The zero-behaviour-change witness at the ``AgentRegistry`` level: the
+  AG-UI-shaped caller (``registry.attach(...)`` called directly, mirroring
+  ``agui/endpoint.py``) and the TUI-shaped caller
+  (``registry.attach_session(...)``) still observably interfere with each
+  other exactly as they did before stage 1 — i.e. stage 1 does NOT yet fix
+  the N:N gap (that is explicitly stage 2's job); it only changes the
+  REPRESENTATION underneath, not the behaviour.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry, AttachedConnection
+from tests._support.agent_session import make_session
+
+
+def _registry(tmp_path):
+    shared = BudgetTracker(CostConfig())
+
+    def factory(profile: AgentProfile):
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            output_language="en",
+            budget_tracker=shared,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    reg.create("beta")
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# AttachedConnection — isolated contract
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_connection_has_nothing_attached_and_no_active() -> None:
+    """Tier 2: a new connection starts empty on both axes."""
+    conn = AttachedConnection()
+    assert conn.attached_set() == frozenset()
+    assert conn.active is None
+    assert conn.attach_failed() is False
+
+
+def test_switch_sets_both_attached_and_active() -> None:
+    """Tier 2: stage 1 invariant — ``switch`` makes ``key`` both the sole
+    member of ``attached_set()`` and the ``active`` value (attached and
+    active coincide in stage 1; stage 2 is what lets them diverge)."""
+    conn = AttachedConnection()
+    key = ("alpha", _DEFAULT_SID)
+    old = conn.switch(key)
+    assert old is None
+    assert conn.attached_set() == frozenset({key})
+    assert conn.active == key
+    assert conn.is_attached(key) is True
+
+
+def test_switch_replaces_not_adds() -> None:
+    """Tier 2: stage 1 invariant — a second ``switch`` REPLACES the first
+    entry; ``attached_set()`` never grows past 1 in stage 1 (that growth is
+    stage 2's whole point).
+
+    Falsification (performed during review): changing ``switch`` to
+    ``self._attached[key] = None`` WITHOUT the preceding ``.clear()`` makes
+    this test go RED — ``attached_set()`` would contain both keys.
+    """
+    conn = AttachedConnection()
+    key_a = ("alpha", _DEFAULT_SID)
+    key_b = ("beta", _DEFAULT_SID)
+    conn.switch(key_a)
+    old = conn.switch(key_b)
+    assert old == key_a
+    assert conn.attached_set() == frozenset({key_b})
+    assert conn.active == key_b
+    assert conn.is_attached(key_a) is False
+
+
+def test_switch_to_none_detaches() -> None:
+    """Tier 2: ``switch(None)`` clears both axes (the ``detach()`` shape)."""
+    conn = AttachedConnection()
+    key = ("alpha", _DEFAULT_SID)
+    conn.switch(key)
+    old = conn.switch(None)
+    assert old == key
+    assert conn.attached_set() == frozenset()
+    assert conn.active is None
+
+
+def test_record_background_attach_error_round_trips() -> None:
+    """Tier 2: the moved ``attach_failed``/``record_background_attach_error``
+    pair behaves identically to the pre-move registry methods."""
+    conn = AttachedConnection()
+    assert conn.attach_failed() is False
+    conn.record_background_attach_error("boom")
+    assert conn.attach_failed() is True
+    conn.record_background_attach_error(None)
+    assert conn.attach_failed() is False
+
+
+# ---------------------------------------------------------------------------
+# Zero-behaviour-change witness at the AgentRegistry level
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stage1_still_shares_one_pointer_between_both_callers(tmp_path) -> None:
+    """Tier 2: #3793 stage 1's OWN scope boundary — the AG-UI-shaped caller
+    (``registry.attach``, mirroring ``agui/endpoint.py:171``) and the
+    TUI-shaped caller (``registry.attach_session``, mirroring
+    ``in_process.py``'s use) still observably interfere: attaching via one
+    shape flips what the OTHER shape's own accessors report, because both
+    still route through the SAME ``AgentRegistry._connection`` instance.
+
+    This is deliberately a POSITIVE assertion that the interference still
+    exists — proving stage 1 changed the representation, not the behaviour.
+    Stage 2's own test (not this file) is what asserts the interference is
+    GONE, on a design that gives AG-UI its own connection instance.
+    """
+    reg = _registry(tmp_path)
+    reg.get_or_load("beta")  # attach_session requires the target to already exist
+
+    await reg.attach("alpha")  # AG-UI-shaped call
+    assert reg.attached_name == "alpha"
+
+    await reg.attach_session("beta", _DEFAULT_SID)  # TUI-shaped call
+    assert reg.attached_name == "beta", (
+        "stage 1: the TUI-shaped call still overwrites what the AG-UI-shaped "
+        "call saw — same shared connection, exactly as before this PR"
+    )
+
+    await reg.attach("alpha")  # back to AG-UI-shaped
+    assert reg.attached_name == "alpha", (
+        "and the AG-UI-shaped call still overwrites the TUI-shaped one back — "
+        "confirms the single shared instance still cuts both ways"
+    )
+
+
+@pytest.mark.asyncio
+async def test_attach_still_reports_via_the_new_connection(tmp_path) -> None:
+    """Tier 2: ``AgentRegistry.attach`` populates the ``AttachedConnection``
+    instance (not a stray, disconnected ``_attached`` attribute) — checked
+    through the PUBLIC ``attached_name``/``attached_sid`` accessors, which
+    themselves read ONLY ``self._connection.active`` post-move.
+
+    Falsification (performed during review): reverting
+    ``self._connection.switch(key)`` to the old ``self._attached = key`` in
+    ``AgentRegistry.attach`` makes this test go RED — ``attached_name``/
+    ``attached_sid`` both read ``self._connection.active``, which stays
+    ``None`` when the attribute assignment silently creates an unrelated
+    ``self._attached`` name instead of updating the connection object.
+    """
+    reg = _registry(tmp_path)
+    await reg.attach("alpha")
+    assert reg.attached_name == "alpha"
+    assert reg.attached_sid == _DEFAULT_SID


### PR DESCRIPTION
**[e2e-coder]** — part of #3793 (stage 1 of 3, per architect's owner-ratified design, 2026-08-08 rewrite — not the original "focus → transport" framing, which was retracted after I found it broke on measurement; see issue history).

## What

`AgentRegistry`'s single process-wide focus pointer (`self._attached: tuple[str, str] | None`, a bare tuple) is now `self._connection: AttachedConnection` — a small new type shaped for the eventual `attached` (N-capable output-receiving set) / `active` (the one destination for un-addressed input) / `addressed` (id-carrying input, unaffected, already correct) vocabulary ADR-0039 D4 calls for.

**This PR changes representation only, not behavior.** Both the local (TUI/REPL, via `InProcessTransport`) and remote (AG-UI, via `agui/endpoint.py`'s 4 direct `registry.attach(...)` calls) continue to share the exact same ONE instance `AgentRegistry` constructs — `attach()`/`attach_session()` still fully REPLACE the prior entry (detach old, attach new), so the represented set never holds more than one member. Two connections still interfere with each other exactly as before (positively asserted by `test_stage1_still_shares_one_pointer_between_both_callers`, not assumed) — closing that gap is explicitly stage 2's job, not this one's.

## Why this shape

- `AttachedConnection.switch(key)` replaces the bare `self._attached = key` assignment at both call sites. It's a plain synchronous method with no internal `await`, so the barrier property from #3310 (switch flip immediately followed by `repl_outbox.put_nowait`, nothing can interleave) holds exactly as before — verified, not just claimed (see falsify-verification below).
- `record_background_attach_error`/`attach_failed` moved onto the connection object too (same cluster, same lifecycle). `AgentRegistry`'s own public methods of the same names are unchanged — they now delegate instead of holding the state directly, so none of the 261 external consumers (measured in the issue: src 101 / tests 160, 0 hidden dynamic-access consumers) needed to change.
- Lives inside `registry.py` for stage 1 — the registry still constructs and owns the one shared instance. The design's end state moves ownership to "the connection" itself (a concept core shouldn't construct); that relocation is stage 2/3, not a change to this class's own definition.

## Issue-body corrections made during this work (not deferred)

Per lead-coder's standing instruction (a known-false premise is fixed the moment it's known false, not at PR-merge time): the issue body's "`ensure_running`/`ensure_session_running` need no changes" claim was found false during the earlier (retracted) framing and corrected in the issue body directly, same-session, before this PR's design was even settled. That correction stands; this PR does not touch `ensure_running`.

## Found + fixed: one direct private-state test dependency

`tests/test_3310_n2_reset_hydrate.py` did `reg._attached = ("beta", _DEFAULT_SID)` as a deliberate read-side-only bypass of `attach()`'s side effects (documented in its own comment — avoiding a real `attach()` call that would race a manually-held-busy turn). Caught by running the FULL file, not just a `-k` keyword subset (the keyword filter alone would have missed it — a note for whoever reviews the falsify section below). Fixed to `reg._connection.switch(("beta", _DEFAULT_SID))` — same intent, same effect, now pointed at the type that actually holds the state.

## Stale comments fixed (CLAUDE.md doc-staleness rule)

3 comments in `test_3310_n1_session_attached_barrier.py` and 1 in `textual_chat/app.py` named the removed `self._attached = key` assignment directly, describing the exact mechanism this PR touches. Updated to name `self._connection.switch(key)` / "the connection-switch flip" instead.

## Test plan

- [x] `ruff check src tests` — green
- [x] `python scripts/mypy_ratchet.py` — green (211 findings, all baselined; 212 declared, none new)
- [x] `python scripts/test_tier_audit.py --strict tests/test_3793_stage1_attached_connection.py tests/test_3310_n2_reset_hydrate.py` — green (16/16, 0 Tier-4 violations after 1 fix: a private-state assert on `reg._connection` switched to the equivalent public `attached_name`/`attached_sid` read)
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/registry.py tests/test_3310_n1_session_attached_barrier.py src/reyn/interfaces/inline/textual_chat/app.py` — green
- [x] New test file (`test_3793_stage1_attached_connection.py`, 7 tests): `AttachedConnection`'s own contract in isolation + the zero-behavior-change witness at the `AgentRegistry` level (AG-UI-shaped and TUI-shaped callers still interfere, positively asserted) — all passed
- [x] Broad regression sweep (`registry`/`attach`/`agui`/`3300`/`repl`/`in_process`/`slash`/`3793`/`3671`-adjacent, 1368 tests) — all passed, 0 failed. First run caught the `test_3310_n2` private-state break above (running the FULL file, not the `-k` subset, is what surfaced it)
- [x] Falsify-verification performed for real (`cp` backup → mutate production → confirm RED for the exact predicted reason → restore → confirm GREEN) on: `switch()`'s replace-not-add invariant (removing `.clear()` → RED, both keys present), and the connection-wiring witness (reverting to a stray `self._attached = key` → RED, `attached_name`/`attached_sid` both read `None`)


---

**[lead-coder]** — レビュー。`_attached` タプルが完全に消えて `AttachedConnection` 1 インスタンスに集約されており、architect の「同じ 1 本を新しい型で包む」がそのまま形になっています。型は N を表現でき、`set_single` が今日の挙動を 1 に固定する — 段2 で型を変えずに N へ動ける形です。ここは良い。

merge を止めはしませんが、段2 の設計に持ち越してほしい点が 1 つあります。

- [x] 🔴 **`session.is_attached`（`session.py:1280`）が、`AttachedConnection` と同じ事実の第 2 の表現として残っています。** `registry.py:3209/3213/3257/3259/3343` の 5 箇所が手で同期しており、消費者は `session.py:6178`（`status`/`trace` を落とす判定）と `app.py:1174`。今は真実が 1 本なので両者は一致しますが、**段2 で接続ごとに N になった瞬間、`session.is_attached` は「どの接続から見て attached か」を表現できません** — 1 セッションが接続 A には attached、接続 B には非 attached、という状態が作れるからです。`:6178` はそのとき「誰にとって」落とすのかを答えられなくなります。

  この PR で直せ、とは言いません（挙動ゼロ変更の範囲を出ます）。**段2 の issue 本文に、消す対象として名前を挙げておいてください。** 書かないと、段2 で N にしたあとも 5 箇所の手動同期が残り、`AttachedConnection` と食い違ったときに黙って古い側が勝ちます。今夜このリポジトリで何度も出た形です。


**[lead-coder]** — #3793 本文の「未決」に追記されたことを確認し、私がチェックしました（提起者が閉じるのが筋なので）。
