### PR TITLE
fix(#3680): stop the compact layout deciding from its own output

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2223,7 +2223,11 @@ class TextualChatApp(App):
             drawer_open=bool(drawer.display),
             rewind_open=bool(self._rewind_picker.display),
             completion_open=bool(self._completion.display),
-            queue_items=len(queue.rendered_texts()) if queue.has_items() else 0,
+            # ``item_count``, never ``len(rendered_texts())``: the latter is
+            # what is ON SCREEN, and while summarised that is one line no
+            # matter how many are queued — so the decision would read its own
+            # output as its input and flip on every re-decide.
+            queue_items=queue.item_count(),
             turn_active=self._activity.state is not None,
             intervention_open=bool(self._iv_panel.display),
         )

--- a/src/reyn/interfaces/inline/textual_chat/sent_queue.py
+++ b/src/reyn/interfaces/inline/textual_chat/sent_queue.py
@@ -289,6 +289,24 @@ class SentQueue(Vertical):
             return [str(self._summary.content)] if self._rows else []
         return [str(row.content) for row in self._rows.values()]
 
+    def item_count(self) -> int:
+        """How many messages are queued — independent of how they are drawn.
+
+        Distinct from ``len(rendered_texts())`` on purpose. ``rendered_texts``
+        answers "what is on screen", which while summarised is ONE line
+        whatever the queue holds; this answers "how many are waiting", which
+        the collapse cannot change.
+
+        The distinction is not academic. ``_apply_compact_layout`` used
+        ``rendered_texts`` to decide whether the queue must collapse, so the
+        decision's INPUT moved with its own OUTPUT: collapse made the count
+        read 1, which said there was room, which un-collapsed it, which made
+        the count read 3 again. Measured flipping on every re-decide (#3680
+        follow-up). A count that survives the thing being decided is what
+        breaks the loop.
+        """
+        return len(self._rows)
+
     def has_items(self) -> bool:
         """Whether at least one queued row is currently shown.
 

--- a/tests/test_compact_layout_3680.py
+++ b/tests/test_compact_layout_3680.py
@@ -225,6 +225,79 @@ async def test_collapsing_the_queue_loses_no_item() -> None:
 
 
 @pytest.mark.asyncio
+async def test_re_deciding_the_layout_does_not_change_it() -> None:
+    """Tier 2b: the decision is stable under repetition — it does not feed on
+    its own result.
+
+    ``_apply_compact_layout`` runs on a resize, on a drawer opening or closing,
+    on every queued item arriving, and on the live chrome refresh. It asked the
+    queue how many items it had via ``rendered_texts()`` — which, once
+    collapsed, is ONE line however many are waiting. So collapsing made the
+    count read 1, which said there was room, which expanded it, which made the
+    count read 3 again: measured flipping on EVERY re-decide, which an operator
+    sees as the region blinking between two layouts while they do nothing.
+
+    Pinned by running the decision repeatedly rather than by asserting the
+    fixed input, because the defect was not a wrong value — each pass was
+    individually correct about what it could see. Only repetition shows it.
+    """
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(80, 16)) as pilot:
+        await pilot.pause()
+        await _crowded(app, transport, pilot)
+
+        queue = app.query_one(SentQueue)
+        settled = queue.summarised
+        for attempt in range(4):
+            app._apply_compact_layout()
+            await pilot.pause()
+            assert queue.summarised == settled, (
+                f"re-decide #{attempt + 1} flipped the layout: {settled} -> "
+                f"{queue.summarised}. The decision is reading its own output."
+            )
+
+
+@pytest.mark.asyncio
+async def test_the_item_count_survives_being_collapsed() -> None:
+    """Tier 2b: how many are queued does not change with how they are drawn.
+
+    This is the property the oscillation violated, stated on its own so it
+    holds even if the layout policy is rewritten: a caller asking "how many are
+    waiting" must get the same answer collapsed or not. ``rendered_texts()``
+    deliberately does not — it answers "what is on screen" — which is why the
+    two are separate calls.
+    """
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(80, 16)) as pilot:
+        await pilot.pause()
+        await _crowded(app, transport, pilot)
+
+        queue = app.query_one(SentQueue)
+        assert queue.summarised, "this test needs the collapsed state to be the case"
+        collapsed_count = queue.item_count()
+        collapsed_lines = len(queue.rendered_texts())
+
+        # Round-tripped through the widget rather than through a resize: at
+        # THIS height closing the drawer is not enough room (the sibling test
+        # above measures that), and the claim here is about the two reads, not
+        # about the resize plumbing.
+        queue.set_summarised(False)
+        await pilot.pause()
+
+        assert queue.item_count() == collapsed_count, (
+            f"the item count moved with the rendering: {collapsed_count} "
+            f"collapsed vs {queue.item_count()} expanded"
+        )
+        assert len(queue.rendered_texts()) != collapsed_lines, (
+            "rendered_texts() did NOT change across the collapse, so this test "
+            "would pass even if the two reads were the same call — the "
+            "distinction it exists to pin is not being exercised"
+        )
+
+
+@pytest.mark.asyncio
 async def test_room_returning_restores_the_rows() -> None:
     """Tier 2b: the policy is reversible.
 


### PR DESCRIPTION
**[tui-coder]** — A defect of mine from #3680, found while measuring #3806's premise. Not a wrong
value anywhere — every individual pass was correct about what it could see.

## The layout decision was feeding on its own result

`_apply_compact_layout` asked the queue how many items it held with `len(queue.rendered_texts())`.
That call answers **"what is on screen"**, and once the queue is collapsed what is on screen is
**one line** however many are waiting.

Measured on an 80×16 terminal, three queued, a turn running — calling the wiring four times:

```
apply #1: queue_items(read)=1  summarised=True   rows=['   Queued: 3']
apply #2: queue_items(read)=3  summarised=False  rows=['▶  message 0', '▷  message 1', '▷  message 2']
apply #3: queue_items(read)=1  summarised=True   rows=['   Queued: 3']
apply #4: queue_items(read)=3  summarised=False  rows=['▶  message 0', …]
```

It flips on **every** re-decide. The layout is re-decided on a resize, on the drawer opening or
closing, on **each queued item arriving**, and on the live chrome refresh — so on a short terminal
the region blinks between two layouts while the operator does nothing, and which one they get at any
moment depends on which phase the last re-decide landed on.

## The fix

`SentQueue.item_count()` answers "how many are waiting", which the collapse cannot change.
`rendered_texts()` keeps meaning "what is on screen". **They are separate calls because they are
separate questions**, and conflating them is the whole of this defect.

## How it surfaced

I was measuring #3806's premise — that the sent queue answers *"did it send"* while the reader is
away. It does. But `compact_caps` said the queue should be collapsed at that height while the app
was showing three rows, and chasing that discrepancy instead of writing it off as "close enough" is
what found this.

Worth noting because the discrepancy was **easy to dismiss**: the app was showing *more*
information than the policy asked for, which looks like the harmless direction.

## The gate

It runs the decision **repeatedly** rather than asserting the input value. The defect was never a
wrong number — a single pass cannot see it, only repetition can.

**Falsified** by restoring the old self-feeding input: that test goes red and the other ten stay
green.

The second test states the underlying property on its own (a count must not move with the rendering)
and **carries its own control** — it asserts `rendered_texts()` *did* change across the collapse, so
it cannot pass if the two reads ever become the same call again.

## Test plan

- [x] `pytest tests/test_compact_layout_3680.py` — 11 passed
- [x] **Falsify** — restore the old input: only the oscillation gate red
- [x] `pytest -k "compact or queue or 3688 or 3680 or chrome"` — 282 passed, 6 skipped, plus the
      three known `reyn.local.yaml` failures (#3791; `-k compact` also matches `compaction`)
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_compact_layout_3680.py` — 0 errors
- [x] `python scripts/verify_module_docstrings.py` on both changed src files — OK
- [x] (skipped — the local full suite is CI's job) **Full `pytest`**
- [x] (waived by lead-coder — owner 恒久指示「見た目ゲートだとしても main マージ進めてよ。そうしないと会社で見れないんだから」。owner は main 上の実物を見て判断される) **Visual: real terminal.** That the region no longer blinks on a short terminal while items
      arrive. The oscillation is what an operator would actually see, and a harness measures the
      state rather than the flicker.

Part of #3680; found via #3806.
