### PR TITLE
feat(#3806): esc goes back to the newest output; sending still does not

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2284,7 +2284,51 @@ class TextualChatApp(App):
         return ok
 
     def action_close_drawer(self) -> None:
-        self._open_drawer(None)
+        """``esc`` at the bottom of the ladder (#3806).
+
+        The rungs above this one each own a thing to dismiss — the completion
+        popup, the sent queue's focus, the intervention panel — and they stop
+        the event when they act. What reaches here is an ``esc`` nobody else
+        wanted, so this rung answers "there is nothing to dismiss": close the
+        drawer if it is open, otherwise go back to following the newest output.
+
+        **Only when the composer is empty.** With a draft in it, ``esc`` does
+        nothing at all rather than moving the view: someone who has typed and
+        pressed ``esc`` is most likely reaching for "never mind" on the text,
+        and scrolling the conversation instead would answer a question they did
+        not ask. ``ctrl+end`` stays the way back that works regardless, which is
+        why this rung can afford to be conditional and that one cannot.
+
+        Sending does NOT return to the tail — measured, and left that way
+        deliberately (#3806): "did it send" is answered by the sent queue and
+        the NOW row, both of which sit OUTSIDE the scrolling region. The
+        convention elsewhere (Slack, Discord, a shell) is to jump on send, and
+        the reason for it is that those interfaces have nowhere but the scroll
+        region to show that the message left. reyn does, so the convention
+        arrives here without the thing that justified it.
+        """
+        drawer = self.query_one("#drawer", ContentSwitcher)
+        if drawer.display:
+            self._open_drawer(None)
+            return
+        composer = self.query_one(Composer)
+        if not composer.has_focus:
+            # A rung that predates this one and rode on ``_open_drawer(None)``'s
+            # side effect: esc from the conversation pane (or anywhere else that
+            # let it bubble) returns focus to the composer — #3365's "esc alone
+            # owns 'back' everywhere". It has to be named here now, because the
+            # branch above no longer runs when there is no drawer to close, and
+            # an unnamed rung is one nobody knows is load-bearing until it is
+            # gone. Its own gate caught this within the hour.
+            composer.focus()
+            return
+        if composer.text.strip():
+            return
+        # Delegated, not reimplemented: ``ctrl+end`` already means exactly this
+        # and carries the reasoning for doing both the scroll and the row's
+        # state synchronously. A second copy here would be two ways back to the
+        # tail, free to drift apart.
+        self.action_jump_to_latest()
 
     def action_focus_conversation(self) -> None:
         """``Ctrl+O``: hand focus to the conversation pane (#3692 PR-B ①).

--- a/tests/test_esc_resumes_following_3806.py
+++ b/tests/test_esc_resumes_following_3806.py
@@ -1,0 +1,189 @@
+"""Tier 2b: ``esc`` is the way back to the newest output; sending is not (#3806).
+
+Two decisions live here and only one of them is code.
+
+**``esc`` resumes following** — but only from an empty composer. It is the last
+rung of a ladder whose upper rungs each own something to dismiss (the
+completion popup, the sent queue's focus, the intervention panel, the drawer);
+what reaches the bottom is an ``esc`` nobody else wanted, and "nothing to
+dismiss" is answered by going back to the live output. With a draft in the box
+it does nothing at all: someone who typed and then pressed ``esc`` is reaching
+for "never mind" on the text, and moving the view would answer a question they
+did not ask.
+
+**Sending does NOT resume following**, and that is deliberately against the
+convention. Slack, Discord and a shell all jump to the bottom on send, because
+in those interfaces the only place that can show the message left is inside the
+scrolling region. reyn's sent queue and NOW row sit OUTSIDE it, so the reason
+for the convention is absent — and a convention imported without its reason is
+just a surprise. Pinned because the next person to notice reyn behaving
+differently from Slack will be right about the difference and wrong about the
+cause, and a test is the only thing standing where that reasoning goes.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.chrome import Composer
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.runtime.outbox import OutboxMessage
+from reyn.schemas.models import Event
+
+
+class QueueTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` (the shared test idiom)."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+
+    async def push_event(self, event: Event) -> None:
+        await self._queue.put(EventFrame(event))
+
+    async def push_display(self, msg: OutboxMessage) -> None:
+        await self._queue.put(DisplayFrame(msg))
+
+    def start(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str) -> None:
+        pass
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        pass
+
+    async def cancel_inflight(self) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+
+
+async def _pump(pilot, until) -> None:
+    """Pump until ``until()`` holds.
+
+    Unbounded per the testing policy: a slower machine only makes this slower,
+    never wrongly satisfied.
+    """
+    while not until():
+        await pilot.pause()
+        await asyncio.sleep(0.01)
+
+
+async def _leave_the_tail(app, transport, pilot, *, lines: int = 40) -> FlowView:
+    """Put enough behind the reader that scrolling up genuinely leaves the tail."""
+    await transport.push_event(
+        Event(type="turn_started", data={"kind": "user", "chain_id": "c1", "seq": 1})
+    )
+    for i in range(lines):
+        await transport.push_display(OutboxMessage(kind="agent", text=f"line {i}", meta={}))
+    flow = app.query_one(FlowView)
+    await _pump(pilot, lambda: len(flow.entries) >= lines and flow.max_scroll_y > 0)
+    flow.scroll_to(y=0, animate=False)
+    await _pump(pilot, lambda: not flow.following)
+    return flow
+
+
+@pytest.mark.asyncio
+async def test_esc_from_an_empty_composer_goes_back_to_the_newest_output() -> None:
+    """Tier 2b: the bottom rung of the esc ladder."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        flow = await _leave_the_tail(app, transport, pilot)
+
+        app.query_one(Composer).focus()
+        await pilot.pause()
+        await pilot.press("escape")
+        await _pump(pilot, lambda: flow.following)
+
+        assert flow.following
+
+
+@pytest.mark.asyncio
+async def test_esc_with_a_draft_in_the_box_moves_nothing() -> None:
+    """Tier 2b: a draft makes esc mean "never mind the text", not "scroll".
+
+    Checked by pumping a while and asserting the state did NOT change, which
+    cannot be proven by waiting — so it is paired with the positive test above:
+    that one establishes that this sequence DOES resume following when the box
+    is empty, so a False here is the draft's doing and not a dead keypress.
+    """
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        flow = await _leave_the_tail(app, transport, pilot)
+
+        composer = app.query_one(Composer)
+        composer.focus()
+        await pilot.pause()
+        composer.text = "a draft"
+        await pilot.pause()
+        await pilot.press("escape")
+        for _ in range(60):
+            await pilot.pause()
+            await asyncio.sleep(0.01)
+
+        assert not flow.following, (
+            "esc scrolled the conversation while there was a draft in the box"
+        )
+        assert composer.text == "a draft", (
+            "esc cleared the draft — it is supposed to do nothing at all here"
+        )
+
+
+@pytest.mark.asyncio
+async def test_sending_does_not_go_back_to_the_newest_output() -> None:
+    """Tier 2b: the deliberate departure from the Slack/Discord convention.
+
+    Sending while reading back leaves the view where the reader put it. What
+    answers "did it send" is the sent queue and the NOW row, both outside the
+    scrolling region — which is exactly the thing those other interfaces do not
+    have, and the whole reason they jump.
+    """
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        flow = await _leave_the_tail(app, transport, pilot)
+
+        composer = app.query_one(Composer)
+        composer.focus()
+        await pilot.pause()
+        composer.text = "a message"
+        await pilot.pause()
+        await pilot.press("enter")
+        for _ in range(60):
+            await pilot.pause()
+            await asyncio.sleep(0.01)
+
+        assert not flow.following, (
+            "sending returned to the tail — the convention was restored without "
+            "the reason that justifies it elsewhere (see this module's docstring)"
+        )


### PR DESCRIPTION
**[tui-coder]** — The settled design from #3806. **Half of it needed no code**, and that half was
established by measurement rather than assumed.

## What sending does — measured, then pinned

```
after scrolling away   following=False
after enter (send)     following=False
```

Sending already does not return to the tail. **The grep would not have established that**: "reyn
calls no scroll in the send path" is a fact about reyn, and Textual or flowview restoring follow on
their own — a focus change, a refresh, a layout pass — appears nowhere in reyn's source.

Pinned by a test anyway, because it is a deliberate departure from convention: Slack, Discord and a
shell all jump on send, **because the only surface that can show the message left is inside their
scroll region**. reyn's sent queue and NOW row sit outside it — also measured
(`rows=['▶  a message'] display=True` while `following=False`). The next person to notice reyn
behaving differently will be right about the difference and wrong about the cause, and the test is
what stands where that reasoning goes.

## What esc does — the new rung

The ladder's upper rungs each own something to dismiss (completion popup, sent-queue focus,
intervention panel, drawer) and stop the event when they act. What reaches the bottom is an esc
nobody wanted, and "nothing to dismiss" is answered by going back to the live output.

**Only from an empty composer.** With a draft, esc does nothing at all — someone who typed and then
pressed esc is reaching for *never mind* on the text, and moving the view answers a question they did
not ask. `ctrl+end` remains the way back that works regardless, which is precisely what lets this
rung afford to be conditional.

## A rung I did not see, and its own gate caught it

`test_esc_from_conversation_pane_returns_to_composer` (#3365) went red.

Esc from the conversation pane returned focus to the composer **by riding on
`_open_drawer(None)`'s side effect**. My early return when no drawer was open removed it silently —
#3365's "esc alone owns back everywhere", gone, with nothing in the diff mentioning focus.

It is a named branch now instead of a side effect. **An unnamed rung is one nobody knows is
load-bearing until it is gone**, and the only reason this one was known within the hour is that
somebody had written a test for it.

The ladder as it now reads:

```
drawer open                        -> close it
composer not focused               -> focus it        (#3365, previously implicit)
composer focused, draft present    -> nothing
composer focused, empty            -> back to the newest output
```

## Test plan

- [x] `pytest tests/test_esc_resumes_following_3806.py` — 3 passed
- [x] **Falsify** — drop the draft guard: only the draft test red, other two green
- [x] `pytest tests/test_textual_chat_esc_sufficiency_3365.py …` — 11 passed (after restoring the focus rung)
- [x] `pytest -k "esc or tail_away or 3365 or drawer or activity or queue"` — 327 passed, 6 skipped
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_esc_resumes_following_3806.py` — 0 errors
- [x] `python scripts/verify_module_docstrings.py src/.../app.py` — OK
- [x] (skipped — the local full suite is CI's job) **Full `pytest`**
- [x] (waived by lead-coder — owner 恒久指示「見た目ゲートだとしても main マージ進めてよ。そうしないと会社で見れないんだから」。owner は main 上の実物を見て判断される) **Visual: real terminal.** That the four rungs feel like one ladder in use — particularly that
      esc with a draft reading as "nothing happened" is legible rather than as a dead key. A harness
      measures the state; whether it *feels* dead is not a thing it can report.

Part of #3806.
