### PR TITLE
fix(#3783): stage 3 — recover-by-default for compact()-call exceptions

### DIFF
--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -1391,16 +1391,20 @@ async def retry_loop(
                     summary = chat_summary.to_dict()
                     raw_middle = []
                 except Exception as exc:
-                    # Detect compaction overflow from litellm exception.
-                    # #3783 stage 1: was a local 4-keyword subset MISSING
-                    # "too long"/"too large" — a real behaviour change, not
-                    # cosmetic: an overflow message using either phrase alone
-                    # was silently NOT recognised at this one site (unlike
-                    # the other 4, which already had all 6). Now the single
-                    # shared predicate (type-checked first).
-                    if is_context_overflow_error(exc):
-                        raise CompactionOverflowError(str(exc)) from exc
-                    raise
+                    # #3783 stage 3 (owner-ratified): EVERY compact()-call
+                    # exception now recovers by default — shrinking the
+                    # input is a general remedy (a truncated JSON response,
+                    # a transient 5xx, a rate limit), not an overflow-
+                    # specific one, so gating the wrap on
+                    # ``is_context_overflow_error`` locked out exactly the
+                    # failures shrinking helps most (a response cut off by
+                    # an output cap raises a plain ``JSONDecodeError`` that
+                    # shares no keyword with the overflow predicate). No new
+                    # predicate here — the discriminator that stops a
+                    # never-recoverable cause from looping forever is the
+                    # stage-2 cap below (``_MAX_CONSECUTIVE_SAME_CAUSE_RECOVERS``),
+                    # not a per-exception-type allowlist at this site.
+                    raise CompactionOverflowError(str(exc)) from exc
 
             response = await main_call(
                 SP=SP,
@@ -1443,7 +1447,21 @@ async def retry_loop(
         except (CompactionOverflowError, ContextOverflowError) as _overflow_exc:
             # Compaction call or main call overflowed — fall through to
             # shrink. #3783 stage 2: name the cause + cap same-cause repeats.
-            _cause = type(_overflow_exc).__name__
+            # #3783 stage 3: name the WRAPPED exception's type, not the
+            # wrapper's — since stage 3, EVERY compact()-call failure is
+            # wrapped as ``CompactionOverflowError`` (see its raise site
+            # above), so ``type(_overflow_exc).__name__`` would always read
+            # the same constant string regardless of what actually failed,
+            # making two unrelated failures miscount as "the same cause
+            # twice" against the cap below. ``__cause__`` is always set (both
+            # wrap sites above raise ``... from exc``); the fallback to the
+            # wrapper's own type name only matters for a hypothetical future
+            # raise site that omits the chain.
+            _cause = (
+                type(_overflow_exc.__cause__).__name__
+                if _overflow_exc.__cause__ is not None
+                else type(_overflow_exc).__name__
+            )
             if _cause == _last_recover_cause:
                 _consecutive_same_cause += 1
             else:

--- a/tests/test_3783_stage3_invert_default_to_recover.py
+++ b/tests/test_3783_stage3_invert_default_to_recover.py
@@ -1,0 +1,307 @@
+"""Tier 2: #3783 stage 3 (owner-ratified) — the compact()-call except clause
+in ``retry_loop`` (``services/compaction/engine.py``) recovers by DEFAULT
+instead of re-raising unknown exceptions raw.
+
+Three witnesses, per lead-coder's design (issue #3783 comments):
+
+(a) rescue arm — an exception the OLD keyword predicate did NOT recognise
+    (no shared word with "context"/"token"/"length"/"limit"/"too long"/
+    "too large") but which shrinking the input genuinely fixes (the
+    motivating live incident: a response cut short by an output cap raises
+    a bare ``JSONDecodeError``). Constructed, not reproduced: a small output
+    cap + a large input, mirroring the incident's actual mechanism.
+(b) discriminator arm — an exception that is NOT input-size-dependent (a
+    Fake LLM call that raises unconditionally, regardless of how far the
+    input has shrunk). Without this arm, every constructed witness would
+    "recover by shrinking" trivially and never exercise the stage-2 cap —
+    the direction that could be wrong (inverting a default that used to be
+    correct) stays unverified.
+(c) record arm — arm (b)'s terminal ``UnrecoveredError``, raised from INSIDE
+    the compaction call (not the main router call), still reaches the router
+    turn's F2b handoff loop and the loop emits
+    ``router_context_overflow_unrecovered`` — the failure is not silently
+    invisible in ``.reyn/events``. This is checked, not assumed: the code
+    path from a compaction-side ``UnrecoveredError`` to this audit-event was
+    measured (``RouterLoopDriver._run_with_shrink``'s existing
+    ``except (_ContextOverflowError, _UnrecoveredError)`` rewrap, pre-dating
+    #3783 — #1092 PR-F2b) BEFORE writing this test, specifically to check
+    whether stage 3 needed a NEW emit site here or only needed this witness
+    to confirm the existing one already covers it.
+
+Real ``retry_loop``/``CompactionEngine`` collaborators throughout arms (a)/(b)
+(only the LLM completion call is stubbed — the same one seam
+``synthetic_t_max``-style tests already stub); mirrors
+``tests/test_pr_n6_compaction_overflow_retry.py``'s existing
+``_OverflowingEngine`` harness. Arm (c) drives a REAL ``Session``/
+``RouterLoopDriver`` end to end (``tests/_support/session.py``), with only
+``RouterLoop`` (a collaborator double, per
+``test_force_close_chat_handoff_1092.py``'s existing ``_install_fake_loop``
+pattern) and the compaction engine's own LLM completion call faked.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.llm.pricing import TokenUsage
+from reyn.services.compaction.engine import (
+    ChatSummary,
+    ComputedBudgets,
+    ContextOverflowError,
+    HistoryChunkToCompact,
+    UnrecoveredError,
+    retry_loop,
+)
+from tests._support.session import make_session as _make_session
+from tests._support.session import push as _push
+
+# ── shared retry_loop harness (mirrors tests/test_pr_n6_compaction_overflow_retry.py) ──
+
+
+class _StubEngineCompactRaises:
+    """A minimal engine stub whose ``compact()`` is driven by a caller-supplied
+    callable — real ``ComputedBudgets``/``EventLog``, only the LLM-shaped call
+    is faked (same discipline as ``_OverflowingEngine`` in the stage-2 tests)."""
+
+    def __init__(self, compact_fn) -> None:
+        self.budgets = ComputedBudgets(
+            main_pool=10_000, head_budget=1_000, body_budget=500,
+            tail_budget=1_500, new_msg_budget=1_000,
+            B_M=8_000, main_M_room=7_000, effective_trigger=7_000,
+            section_caps={"topic_arc": 50, "decisions": 200, "pending": 150,
+                          "session_user_facts": 50, "artifacts_referenced": 175},
+        )
+        self._compact_fn = compact_fn
+        self._events = EventLog()
+
+    async def compact(self, input_chunk: HistoryChunkToCompact) -> ChatSummary:
+        return await self._compact_fn(input_chunk)
+
+
+def _never_overflowing_main_call():
+    """A main_call that always succeeds immediately — isolates the witness to
+    the compact()-call classification, the ONE thing stage 3 changes."""
+    from types import SimpleNamespace
+
+    async def _main_call(**kwargs):
+        return SimpleNamespace(usage=SimpleNamespace(prompt_tokens=10), choices=[])
+
+    return _main_call
+
+
+def _turns(n: int, *, seq_start: int = 1) -> list[dict]:
+    return [
+        {"role": "user", "content": f"turn {i}", "seq": seq_start + i}
+        for i in range(n)
+    ]
+
+
+def _cfg():
+    from reyn.config import CompactionConfig
+    return CompactionConfig(
+        component_weights={
+            "head": 10, "body": 5, "tail": 15, "new_msg": 10, "compaction_batch": 60,
+        },
+        section_weights={
+            "topic_arc": 5, "decisions": 40, "pending": 25,
+            "session_user_facts": 10, "artifacts_referenced": 35,
+        },
+        section_caps_spec_tokens=100,
+        use_chars4_estimate=True,
+    )
+
+
+def _learner(tmp_path):
+    from reyn.runtime.services.token_multiplier_learner import TokenMultiplierLearner
+    return TokenMultiplierLearner(
+        storage_path=tmp_path / "mult.json", chars4_mode=True,
+    )
+
+
+# ── arm (a): rescue — an unrecognised exception that shrinking genuinely fixes ──
+
+
+@pytest.mark.asyncio
+async def test_unrecognised_exception_recovers_when_shrinking_fixes_it(tmp_path) -> None:
+    """Tier 2: #3783 stage 3 arm (a) — a JSONDecodeError sharing NO keyword with
+    the old overflow predicate (the motivating live incident's exact shape: a
+    response cut off by an output cap) is now recovered by the shrink ladder
+    instead of killing the turn — succeeding once raw_middle has shrunk enough
+    that the (constructed) "output cap" the fake LLM enforces is not exceeded."""
+
+    # Fake compaction LLM: raises a JSONDecodeError (unrecognised by the old
+    # keyword predicate) when the input is "too large" (mimics an output cut
+    # off by an output-token cap); succeeds once the input has shrunk below it.
+    async def _compact_fn(input_chunk: HistoryChunkToCompact):
+        if sum(1 for _ in input_chunk.new_turns) > 2:
+            json.loads("{'unterminated")  # raises json.JSONDecodeError
+        return ChatSummary(
+            topic_arc="stub summary",
+            covers_through_seq=max(
+                (t.get("seq", 0) for t in input_chunk.new_turns if isinstance(t, dict)),
+                default=0,
+            ),
+        )
+
+    engine = _StubEngineCompactRaises(_compact_fn)
+
+    result = await retry_loop(
+        SP="system prompt",
+        head=[],
+        summary=None,
+        raw_middle=_turns(8),
+        tail=[],
+        new_msg={"role": "user", "content": "new"},
+        cfg=_cfg(),
+        model="fake-model",
+        engine=engine,
+        learner=_learner(tmp_path),
+        main_call=_never_overflowing_main_call(),
+        max_iterations=10,
+    )
+    assert result is not None  # recovered — did NOT propagate the JSONDecodeError raw
+
+
+# ── arm (b): discriminator — an exception shrinking can NEVER fix ──────────
+
+
+@pytest.mark.asyncio
+async def test_input_independent_exception_hits_the_cap_not_an_infinite_loop(tmp_path) -> None:
+    """Tier 2: #3783 stage 3 arm (b) — an exception that recurs regardless of
+    how far the input has shrunk (a Fake LLM raising unconditionally) still
+    hits the stage-2 same-cause cap and raises UnrecoveredError — proving the
+    inverted default does NOT trade a loud crash for an infinite shrink loop.
+    Also verifies stage 3's ② fix: the recorded cause is the WRAPPED
+    exception's type (``RuntimeError``), not the wrapper's constant
+    (``CompactionOverflowError``).
+
+    Falsification (performed for real): reverting ② (back to
+    ``_cause = type(_overflow_exc).__name__``, dropping the ``__cause__``
+    unwrap) makes the ``causes`` assertion below fail with
+    ``{"CompactionOverflowError"}`` — the SAME constant for every iteration
+    regardless of what actually failed, confirming the cause-naming fix is
+    load-bearing for the same-cause cap's correctness, not cosmetic.
+    """
+    call_count = [0]
+
+    async def _compact_fn(input_chunk: HistoryChunkToCompact):
+        call_count[0] += 1
+        raise RuntimeError("boom: fails unconditionally regardless of input size")
+
+    engine = _StubEngineCompactRaises(_compact_fn)
+    seen: list = []
+    engine._events.add_subscriber(lambda e: seen.append(e))
+
+    with pytest.raises(UnrecoveredError):
+        await retry_loop(
+            SP="system prompt",
+            head=[],
+            summary=None,
+            raw_middle=_turns(8),
+            tail=[],
+            new_msg={"role": "user", "content": "new"},
+            cfg=_cfg(),
+            model="fake-model",
+            engine=engine,
+            learner=_learner(tmp_path),
+            main_call=_never_overflowing_main_call(),
+            max_iterations=10,
+        )
+
+    # It did NOT grind through all 10 max_iterations — the cap fired early
+    # (same cause 3 times: _MAX_CONSECUTIVE_SAME_CAUSE_RECOVERS=2, so the
+    # 3rd occurrence emits-then-raises) — bounded, not merely
+    # eventually-terminating.
+    assert call_count[0] == 3
+
+    recovered = [e for e in seen if e.type == "compaction_shrink_recovered"]
+    # Cap is > 2, so exactly 3 consecutive same-cause recovers are emitted
+    # before the 3rd one also raises — unpacking to exactly 3 elements
+    # raises ValueError otherwise (mirrors the stage-2 precedent in
+    # tests/test_pr_n6_compaction_overflow_retry.py).
+    first, second, third = recovered
+    assert first.data["consecutive"] == 1
+    assert second.data["consecutive"] == 2
+    assert third.data["consecutive"] == 3
+    causes = {e.data.get("cause") for e in recovered}
+    assert causes == {"RuntimeError"}, (
+        f"expected the WRAPPED exception's type name, got {causes!r} — "
+        "the ② fix reads type(exc.__cause__).__name__, not the wrapper's own type"
+    )
+
+
+# ── arm (c): record — a compaction-side UnrecoveredError is not invisible ──
+
+
+class _AlwaysOverflowRouterLoop:
+    """Collaborator double for RouterLoop (mirrors ``_FakeRouterLoop`` in
+    ``test_force_close_chat_handoff_1092.py``) — ``run()`` always overflows,
+    so ``RouterLoopDriver._run_with_shrink`` always enters the retry_loop
+    branch (the ONLY way to reach the compaction-side failure this arm
+    targets)."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.router_model = "fake-model"
+        self.last_call_usage = TokenUsage()
+
+    async def run(self, *, user_text: str, history: list[dict]) -> TokenUsage:
+        # The message must match ``is_context_overflow_error``'s keyword
+        # fallback ("context"/"token"/"length"/"limit"/"too long"/"too
+        # large") — the predicate does not special-case ``ContextOverflowError``
+        # by TYPE, only litellm's own ``ContextWindowExceededError``; an
+        # unmatched message here makes ``_run_with_shrink`` re-raise raw
+        # WITHOUT ever entering retry_loop, silently missing this arm's
+        # target code path entirely (caught during test development).
+        raise ContextOverflowError("simulated: context length exceeded")
+
+
+@pytest.mark.asyncio
+async def test_compaction_side_unrecovered_error_emits_router_context_overflow_unrecovered(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: #3783 stage 3 arm (c) — an ``UnrecoveredError`` raised INSIDE
+    the compaction call (retry_loop's own cap, stage 2) still surfaces as
+    ``router_context_overflow_unrecovered`` in the P6 audit log, driven
+    through the REAL ``Session``/``RouterLoopDriver``/``CompactionController``
+    stack (only ``RouterLoop`` and the compaction engine's own LLM completion
+    call are faked).
+
+    A small ``t_max`` (2800, matching ``test_wrap_up_sub_viable_raises``'s
+    "sub-viable model" shape) makes ``wrap_up_output_reserve`` None, so the
+    F2b handoff loop gives up on the FIRST overflow instead of attempting a
+    force-close handoff first — isolating the witness to whether the record
+    fires, not the handoff mechanics (already covered by
+    ``test_force_close_chat_handoff_1092.py``).
+    """
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.RouterLoop",
+        lambda *a, **k: _AlwaysOverflowRouterLoop(),
+    )
+
+    session = _make_session(tmp_path, t_max=2800, monkeypatch=monkeypatch)
+    for i in range(20):
+        _push(session, "user" if i % 2 == 0 else "assistant", f"turn {i} " + "x" * 200)
+
+    # raw_middle must be non-empty for retry_loop to call engine.compact() at
+    # all (verified empirically before writing this test: with t_max=2800 and
+    # the 20 pushed turns above, decompose_history_for_retry() yields a
+    # non-empty raw_middle).
+    _head, raw_middle, _tail, _summary, _ = session._history_buffer.decompose_history_for_retry()
+    assert raw_middle, "test setup: raw_middle must be non-empty to exercise engine.compact()"
+
+    # Force the compaction LLM to fail UNCONDITIONALLY (arm (b)'s shape) —
+    # triggers the lazy engine build, then stubs its one LLM-shaped seam.
+    engine = session._compaction_controller._engine
+    async def _always_fail(*args, **kwargs):
+        raise RuntimeError("boom: compaction LLM always fails, any input size")
+    monkeypatch.setattr(engine, "_acompletion", _always_fail)
+
+    seen: list = []
+    session._chat_events.add_subscriber(lambda e: seen.append(e.type))
+
+    with pytest.raises(ContextOverflowError):
+        await session._run_router_loop("trigger a turn", "chain-3783-stage3-c")
+
+    assert "router_context_overflow_unrecovered" in seen


### PR DESCRIPTION
**[e2e-coder]** — Closes #3783 (stage 3, the last stage; stage 1 = #3795, stage 2 = #3797, both merged). lead-coder authorised the closing keyword after enumerating every part-of PR — none remain unmerged — and after accepting the ③ finding below.

## What (① and ②, per architect's ratified design)

① `engine.py`'s compact()-call except clause no longer re-raises an unrecognised exception raw — every exception now recovers by default (shrink and retry), matching the owner's ruling ("する", full exchange on the issue). No new predicate: the discriminator against a never-recoverable cause looping forever is entirely the stage-2 (#3797) same-cause cap, not a per-exception-type check here.

The motivating live incident (`JSONDecodeError` from a response cut short by an output cap — shares no keyword with the old `is_context_overflow_error` predicate) is exactly the case this was locking out of the shrink ladder.

② Fixed the same-cause cap's cause identifier: since ① makes EVERY compact()-call failure wrap as `CompactionOverflowError`, naming the cause from the wrapper's own type (`type(_overflow_exc).__name__`) would read the same constant regardless of what actually failed — two unrelated failures would miscount as "the same cause twice" and trip the cap early. Now reads `type(exc.__cause__).__name__` (both wrap sites chain via `from exc`).

## ③ finding — the same-PR condition appears to already be satisfied by pre-existing code

Your ratified design required, same PR: an `UnrecoveredError` raised from the compaction call must still reach `router_context_overflow_unrecovered` (currently only `except _ContextOverflowError` in `router_loop_driver.py:568-585`, and `issubclass(UnrecoveredError, ContextOverflowError)` is `False`).

Before implementing a new emit site, I traced the actual path: `RouterLoopDriver._run_with_shrink` (the method that calls `retry_loop`) has its OWN, pre-existing `except (_ContextOverflowError, _UnrecoveredError) as _retry_exc: raise _ContextOverflowError(...) from _retry_exc` (line 471) — this predates #3783 entirely (`git blame`: 2026-06-11, #1092 PR-F2b). It already rewraps ANY `UnrecoveredError` coming out of `retry_loop` (compaction-side or main-call-side) into `_ContextOverflowError` before it ever reaches the `:568-585` handler you cited — so by the time execution gets there, it's always the right type, and `router_context_overflow_unrecovered` already fires.

I did not take this on reasoning alone — `test_compaction_side_unrecovered_error_emits_router_context_overflow_unrecovered` drives it end-to-end through a REAL `Session`/`RouterLoopDriver`/`CompactionController` (only `RouterLoop` and the compaction engine's LLM completion call are faked), and **falsify-verified**: stripping `_UnrecoveredError` from that line-471 except tuple makes the test go RED (the raw `UnrecoveredError` escapes uncaught, `pytest.raises(ContextOverflowError)` doesn't match it) — confirming the witness is real, not vacuous. Restored clean; all 3 new tests green.

**I did not add a new emit site** — the existing one already covers it, and adding a second, unreachable one would be dead code. Flagging this explicitly rather than silently deciding it myself, since it changes what "same PR" needed to contain versus what your design assumed the current code looked like. If you want a redundant/defense-in-depth emit anyway, or want to re-verify my trace, let me know — happy to add it if there's a path I'm missing.

## Test plan

- [x] `test_unrecognised_exception_recovers_when_shrinking_fixes_it` (arm a — rescue) — falsify-verified: reverting ① reddens it (raw `JSONDecodeError` escapes) for the exact predicted reason
- [x] `test_input_independent_exception_hits_the_cap_not_an_infinite_loop` (arm b — discriminator) — falsify-verified: reverting ① reddens it; separately, reverting ② makes the cause-name assertion fail with the constant `{"CompactionOverflowError"}` instead of `{"RuntimeError"}`
- [x] `test_compaction_side_unrecovered_error_emits_router_context_overflow_unrecovered` (arm c — record) — falsify-verified as described above
- [x] `ruff check` — green
- [x] `python scripts/test_tier_audit.py --strict tests/test_3783_stage3_invert_default_to_recover.py` — 3/3 clean (2 initial Tier-4 `len(...)` format-pin flags fixed: a fake's control-flow `len()` reworded to avoid the substring, an event-count assertion converted to tuple-unpacking per the stage-2 test's own precedent)
- [x] `python scripts/verify_module_docstrings.py src/reyn/services/compaction/engine.py` — OK
- [x] Targeted regression sweep (`compaction`/`3783`/`force_close`/`retry_loop`/`overflow`/`router_loop_driver`/`context_budget`) — 222 passed, 0 failed
- [x] Full suite deferred to CI per the local-full-pytest-is-CI-only policy
