### PR TITLE
fix(#3818): the Help pane spells esc the way the rest of the interface does

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -610,7 +610,11 @@ class TextualChatApp(App):
     BINDINGS = [
         # Global fallback so Esc closes the drawer even when focus is INSIDE it
         # (an OptionList pane); the MenuBar's own ↑/Esc handles the menu-row case.
-        ("escape", "close_drawer", "Close drawer"),
+        # ``show=False``: the Help pane's row for this key is written by hand in
+        # ``chrome.MENUBAR_KEYS`` (#3818), because rendering Textual's own
+        # identifier here spelled it ``escape`` while every other row said
+        # ``esc``. The binding is unchanged — only who describes it.
+        Binding("escape", "close_drawer", "Close drawer", show=False),
         # #3352: hide/show either gutter, handing its whole column back to the
         # conversation body. Two bindings, not one, because the upstream
         # granularity is two INDEPENDENT flags (``FlowView.left_gutter_visible``
@@ -1462,7 +1466,11 @@ class TextualChatApp(App):
             if isinstance(b, tuple):
                 if len(b) >= 3:
                     out.append((b[0], b[2]))
-            elif getattr(b, "description", ""):
+            elif getattr(b, "description", "") and getattr(b, "show", True):
+                # ``show`` is Textual's own "advertise this key" flag, and this
+                # pane is the advertisement. Honouring it is what lets a
+                # binding hand its Help row to a hand-written table (#3818)
+                # without a translation step living here.
                 out.append((b.key, b.description))
         return out
 

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -477,6 +477,14 @@ MENUBAR_KEYS: "list[tuple[str, str]]" = [
     ("pgup / pgdn", "scroll this pane"),
     ("↑", "back to composer"),
     ("esc", "back to composer"),
+    # Owned HERE rather than sourced from the app's ``BINDINGS`` (#3818). The
+    # binding still exists and still does the work — but Textual identifies the
+    # key as ``escape``, and rendering the identifier put ``escape  Close
+    # drawer`` directly under ``esc  back to composer``: one key, two
+    # spellings, one screen. reyn already owns how a key is written (every
+    # other row in every one of these tables), so the fix is to let it own this
+    # one too rather than to translate at the last moment.
+    ("esc", "close drawer"),
 ]
 
 #: Keys RESERVED by an approved-but-unimplemented feature — claimed, but bound

--- a/tests/test_key_hint_wording_3801.py
+++ b/tests/test_key_hint_wording_3801.py
@@ -64,6 +64,54 @@ def test_the_rewind_picker_title_uses_the_convention() -> None:
     )
 
 
+def test_the_help_pane_never_shows_a_key_the_way_textual_names_it() -> None:
+    """Tier 1: the Help pane spells keys reyn's way, not Textual's (#3818).
+
+    The pane is built from two sources — hand-written tables, where a person
+    writes the display name, and the app's ``BINDINGS``, where Textual's key
+    IDENTIFIER was rendered verbatim. Interleaved on one screen that produced
+    ``escape  Close drawer`` directly beneath ``esc  back to composer``: one
+    key, two spellings, adjacent.
+
+    Asserted over the RENDERED lines rather than over either source, because
+    the defect existed in neither one alone — each was internally consistent,
+    and only the pane that shows both had a problem. A test reading one table
+    would have passed throughout.
+
+    ``escape`` is the only identifier reyn writes differently today, but the
+    check is stated as "no identifier appears in the key column" so a binding
+    for ``pageup`` or ``up`` — both already spelled differently in the tables
+    (``pgup``, ``↑``) — cannot introduce the same split by simply existing.
+    """
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+
+    # Read from BINDINGS directly rather than through the app's own
+    # ``_app_binding_help``. That adapter is what production feeds the pane, so
+    # a bug there — dropping a binding — would make a test built on it pass by
+    # showing less. This asks what the pane WOULD render given everything the
+    # app declares, which is the question the defect was about.
+    pairs = [
+        (b[0], b[2]) if isinstance(b, tuple) else (b.key, b.description)
+        for b in TextualChatApp.BINDINGS
+        if isinstance(b, tuple) or (b.description and getattr(b, "show", True))
+    ]
+
+    rendered = chrome.help_pane_lines(pairs)
+    assert rendered[1:], "the pane rendered no key rows — this gate would be vacuous"
+
+    # Identifiers whose canonical Textual spelling is not how this interface
+    # writes them. Names only — the point is that none reaches the key column.
+    renamed = {"escape", "pageup", "pagedown", "up", "down"}
+    keys = {line.strip().split("  ", 1)[0] for line in rendered[1:] if "  " in line.strip()}
+    leaked = sorted(keys & renamed)
+    assert not leaked, (
+        f"the Help pane shows {leaked} in the key column — Textual's identifier "
+        "rather than how this interface writes the key. A binding's Help row "
+        "belongs in a hand-written table (chrome.*_KEYS) with show=False on the "
+        "binding, not rendered from the identifier."
+    )
+
+
 def test_the_help_tables_spell_key_names_the_way_the_hints_do() -> None:
     """Tier 1: key names in the Help tables are lowercase (#3805).
 


### PR DESCRIPTION
**[tui-coder]** — Closes #3818. One row, no new machinery.

## Before

```
esc      back to composer
escape   Close drawer
```

One key, two spellings, adjacent rows — because the pane is built from **two sources**: hand-written
tables where a person writes the display name, and the app's `BINDINGS` where Textual's key
*identifier* was rendered verbatim.

## Measured before changing anything

All seven app bindings render (`show=None` shows). And `escape` is the **only** one whose identifier
differs from how this interface writes the key:

| binding | how the tables write it | conflict |
|---|---|---|
| `escape` | `esc` | **yes** |
| `ctrl+c` `ctrl+end` `ctrl+g` `ctrl+n` `ctrl+o` `ctrl+t` | same | no |

The six `ctrl+…` bindings were never outside the *convention* — only outside the *ownership*.

## The fix moves the row rather than translating it

reyn already owns how a key is written (every other row in every one of these tables), so `escape`'s
Help row moves **into** `chrome.MENUBAR_KEYS`, beside the drawer's other keys which already live
there. **No lookup, no map.** The binding is unchanged and still does the work; `show=False` says it
is not the thing advertising itself.

`_app_binding_help` now honours `show`. That flag is Textual's own *"advertise this key"* and this
pane is the advertisement — honouring it is what lets a binding hand its Help row to a table without
a translation step living in the adapter.

## The gate asserts over the rendered pane, not over either source

**The defect existed in neither source alone.** Each was internally consistent; only the pane showing
both had a problem. A test reading one table would have passed throughout.

It is stated as *"no Textual identifier reaches the key column"* rather than naming `escape`, because
`pageup` / `pagedown` / `up` / `down` are **already** spelled differently in the tables (`pgup`, `↑`)
and simply have no shown binding today — a single `show=True` would reintroduce this **without
anyone editing a label**.

It also reads `BINDINGS` directly instead of through `_app_binding_help`: that adapter is what feeds
the pane, so a bug there (dropping a binding) would make a test built on it pass *by showing less*.

**Falsified** by restoring the 3-tuple form — that gate red, the other four green.

## Test plan

- [x] `pytest tests/test_key_hint_wording_3801.py` — 5 passed
- [x] **Falsify** — revert to the identifier-rendered form: only the new gate red
- [x] `pytest -k "help or chrome or key_hint or drawer or 3365 or esc"` — 666 passed, 6 skipped
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_key_hint_wording_3801.py` — 0 errors
- [x] `python scripts/verify_module_docstrings.py` on both changed src files — OK
- [x] `python scripts/mypy_ratchet.py` — 0 findings
- [x] (skipped — the local full suite is CI's job) **Full `pytest`**
- [x] (waived by lead-coder — owner 恒久指示「見た目ゲートだとしても main マージ進めてよ」。owner が main 上で判断) **Visual: real terminal.** That the Help pane now reads as one ledger. Worth an eye because
      **this was found on a terminal and not by grep** — adjacency is not a property text has, so the
      check that found it is the check that confirms it.

Closes #3818.

**[lead-coder]** — ゲートが一般形なのが良い。`escape` を pin するのではなく、`TextualChatApp.BINDINGS` から識別子を集めて「key 列にどれも現れない」と述べているので、`pageup` や `up` の binding が後から Help に載っても同じ場所で落ちる。`assert rendered[1:]` の vacuity guard も入っている。

`show=False` を使ったのも正しい。Textual 自身の「このキーを宣伝する」フラグを尊重する形なので、翻訳層が要らない。#3818 の設計（②を①に合流、機構ゼロ）がそのまま形になっています。
