### PR TITLE
fix(#3791): defer the F4-router-endpoints skip check to test-run time

### DIFF
--- a/tests/test_fp0001_e2e_ask_user_roundtrip.py
+++ b/tests/test_fp0001_e2e_ask_user_roundtrip.py
@@ -185,11 +185,30 @@ def _router_has_task_endpoints() -> bool:
         return False
 
 
-_SKIP_ROUTER = not _router_has_task_endpoints()
 _SKIP_REASON = (
     "F4 router endpoints (GET /a2a/tasks/{run_id}, POST /a2a/tasks/{run_id}/cancel, "
     "async_mode on message/send) are not yet mounted.  Remove this skip once F4 lands."
 )
+
+
+def _skip_unless_router_has_task_endpoints() -> None:
+    """Runtime skip (NOT a module-level ``@pytest.mark.skipif``) — #3791: a
+    ``skipif`` decorator's condition is evaluated at COLLECTION time, which
+    forced ``_router_has_task_endpoints()`` (and its ``from
+    reyn.interfaces.web.server import app``, which triggers
+    ``reyn.interfaces.web.server``'s own module-level ``load_config()`` call)
+    to run before ANY per-test fixture — including ``tests/conftest.py``'s
+    autouse ``_isolated_cwd`` — with cwd still wherever pytest was invoked
+    from. On a developer machine with ``reyn.local.yaml`` present, that one
+    collection-time import call leaked ``LITELLM_API_BASE`` (or any other
+    ``~/.reyn/secrets.env`` variable, per ADR-0030) into ``os.environ``
+    process-wide for the rest of the suite, since nothing tears it back down
+    outside a test's own fixture scope. Calling this from INSIDE each test
+    body instead means the check runs after ``_isolated_cwd`` has already
+    chdir'd to an isolated ``tmp_path`` with no ``reyn.yaml`` ancestor, so
+    ``load_config()`` never discovers a developer's real config at all."""
+    if not _router_has_task_endpoints():
+        pytest.skip(_SKIP_REASON)
 
 
 def _build_registry_for_test(tmp_path: Path):
@@ -229,13 +248,13 @@ def _build_registry_for_test(tmp_path: Path):
     return registry
 
 
-@pytest.mark.skipif(_SKIP_ROUTER, reason=_SKIP_REASON)
 def test_async_mode_message_send_returns_task_envelope(tmp_path, monkeypatch):
     """Tier 2c: POST /a2a/agents/{name} with async_mode=true returns a task
     envelope {kind: 'task', id: run_id, status: 'running'}.
 
     Requires F4 router extensions.  Skipped otherwise.
     """
+    _skip_unless_router_has_task_endpoints()
     monkeypatch.chdir(tmp_path)
 
     import reyn.interfaces.web.routers.a2a as a2a_mod
@@ -309,7 +328,6 @@ def test_async_mode_message_send_returns_task_envelope(tmp_path, monkeypatch):
         app.dependency_overrides.clear()
 
 
-@pytest.mark.skipif(_SKIP_ROUTER, reason=_SKIP_REASON)
 def test_e2e_create_with_webhook_then_cancel_fires_disposition(tmp_path, monkeypatch):
     """Tier 2c: #2839 Phase 1 — the full create→cancel→disposition wiring proof,
     re-based onto RunRegistry (the internal Task backend is no longer consulted
@@ -330,6 +348,7 @@ def test_e2e_create_with_webhook_then_cancel_fires_disposition(tmp_path, monkeyp
     session_id→contextId round-trip breaks (the sweep would find no channel and
     fire 0).
     """
+    _skip_unless_router_has_task_endpoints()
     monkeypatch.chdir(tmp_path)
 
     import reyn.interfaces.web.routers.a2a as a2a_mod
@@ -419,7 +438,6 @@ def test_e2e_create_with_webhook_then_cancel_fires_disposition(tmp_path, monkeyp
         app.dependency_overrides.clear()
 
 
-@pytest.mark.skipif(_SKIP_ROUTER, reason=_SKIP_REASON)
 def test_get_task_returns_a2a_envelope_from_run_registry(tmp_path, monkeypatch):
     """Tier 2c: (#2839 Phase 1) GET /a2a/tasks/{run_id} returns the spec A2A
     Task envelope read directly from RunRegistry. A run with
@@ -427,6 +445,7 @@ def test_get_task_returns_a2a_envelope_from_run_registry(tmp_path, monkeypatch):
     blocked→input-required overload — #2839 Phase 1 retires that interim
     placeholder, which the old Task-backed mapper's own comment flagged as an
     unfixed correctness bug: slice 7's promised block-reason split never landed)."""
+    _skip_unless_router_has_task_endpoints()
     monkeypatch.chdir(tmp_path)
 
     from reyn.interfaces.web.deps import get_registry, get_run_registry


### PR DESCRIPTION
**[e2e-coder]** — part of #3791 (PR1 of 2, per architect's split; PR2 turns `web/server.py`'s module-level config read into an app-factory closing the import-time side effect itself — separate PR, not started).

## Root cause, traced with a real stack dump (not guessed)

`tests/test_fp0001_e2e_ask_user_roundtrip.py`'s module-level `_SKIP_ROUTER = not _router_has_task_endpoints()` calls `from reyn.interfaces.web.server import app`. `web/server.py` reads config at import time (`_surfaces_config = load_config()`, needed to decide which surfaces to mount — architect confirmed this half is legitimate, not the defect). Being module-level in *this test file* means it fires during pytest **collection**, before any per-test fixture — including `conftest.py`'s autouse `_isolated_cwd` — has chdir'd away from wherever pytest was invoked.

On a developer machine with `reyn.local.yaml` present, that one collection-time call leaks whatever it read (`LITELLM_API_BASE`, or any `~/.reyn/secrets.env` variable per ADR-0030 — architect corrected my earlier broker report, which named `LITELLM_API_BASE` as "the mechanism"; the actual mechanism is "the whole file gets spread into `os.environ`") into `os.environ` **process-wide via `setdefault`**, never reset (nothing tears it down — it happened outside any test's fixture scope), contaminating 6 unrelated tests in later files for the rest of the suite. Passes in isolation because nothing precedes it to leak the var — exactly the issue's own measured table.

Architect's corrected framing (mine was half-wrong): reading config at import time (①) may be legitimate for route construction; writing the result into `os.environ` (②) is ADR-0030's explicit intent, not a defect. **The actual defect is ③: a test triggering production's init path before its own isolation fixture runs.**

## Fix

Converts the 3 `@pytest.mark.skipif(_SKIP_ROUTER, ...)` decorators (whose condition necessarily evaluates at collection time — that's what a decorator is) to a runtime `_skip_unless_router_has_task_endpoints()` call at the top of each test body. This only runs after `_isolated_cwd` has already chdir'd to an isolated `tmp_path` with no `reyn.yaml` ancestor, so `load_config()` finds no project config to leak. Minimal, test-only, zero production change (matches architect's PR1 shape).

## Population measured (architect's ask, not guessed)

AST-scanned all of `src/reyn` for module-level (true top-level, not inside any function/class, including code inside a bare `try`/`if`) calls to `load_config` — `web/server.py` is the **only** production module with this pattern. This test file was the only one importing it at module level (checked all 12 test files referencing `reyn.interfaces.web.server` — the other 11 import it inside function/fixture bodies already). No other instances of this class exist today.

## Falsify-verified for real

`git stash`ed this fix and re-ran the exact 4-file combination (`test_compaction_resolver_aware_1172.py test_llm_request_error_1676.py test_llm_router_s3b_1829.py test_fp0001_e2e_ask_user_roundtrip.py`) with `reyn.local.yaml` present — the **exact 6 originally-reported failures reproduce byte-for-byte**. Restored; all 23 pass.

## Test plan

- [x] Falsify-verified as above (RED reproduces the issue's own 6 names, then GREEN restored)
- [x] `ruff check tests/test_fp0001_e2e_ask_user_roundtrip.py` — green
- [x] `python scripts/test_tier_audit.py --strict tests/test_fp0001_e2e_ask_user_roundtrip.py` — 7/7 clean
- [x] Targeted regression sweep (`fp0001`/`web`/`a2a`/`config`/`litellm_api_base`/`compaction_resolver`/`llm_request_error`/`llm_router_s3b`/`server`) — 1262 passed, 10 skipped, 0 failed
- [x] Full suite deferred to CI per the local-full-pytest-is-CI-only policy