### PR TITLE
feat(#3691): transpose the Cost table so the scopes can say their own names

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -1052,6 +1052,11 @@ def cost_pane_lines(snap: "dict | None") -> list[str]:
     return rows
 
 
+#: Where every Ctx line's value starts. Named so the labels cannot drift out
+#: of alignment one edit at a time — the cache row had already done so.
+_CTX_LABEL_W = 13
+
+
 def ctx_pane_lines(snap: "dict | None") -> list[str]:
     """The Ctx readout — CURRENT state only (cumulative figures live in the Cost
     pane instead, see :func:`cost_pane_lines`).
@@ -1084,13 +1089,23 @@ def ctx_pane_lines(snap: "dict | None") -> list[str]:
     comp_trigger = status.get("effective_trigger", 0)
     comp_est = max(0, comp_trigger - status.get("free_window", 0))
     comp_pct = round(100 * comp_est / comp_trigger) if comp_trigger > 0 else 0
+    # The bar sits with the figure it draws (#3691). It has always visualised
+    # the WINDOW's fill, and it used to be printed after the compaction line —
+    # directly beneath "61% to trigger" while showing 42%. Two percentages, one
+    # of them a bar, adjacent and unrelated: the misreading is not a risk, it is
+    # the reading. #3691's own principle for this pane says the actual context
+    # window and the compaction estimate are not comparable and must stay
+    # visually separate; the layout was doing the opposite.
     return [
         f"window       {window:,} tokens  ({snap.get('ctx_source', 'unknown')})",
         f"prompt       {prompt_tokens:,} tokens  ({pct}% of window)",
-        f"free         {free:,} tokens",
-        _cache_hit_line("cache", recent_cached, recent_prompt),
-        f"compaction   {comp_est:,} / {comp_trigger:,} tokens est.  ({comp_pct}% to trigger)",
         f"             {_ctx_bar(prompt_tokens, window)}  {_ctx_pct(snap)}",
+        f"free         {free:,} tokens",
+        # Label column widened to match its neighbours — it was four spaces
+        # where every other label is seven, so the one line about the cache
+        # started in a different place from the five around it.
+        _cache_hit_line(f"{'cache':<{_CTX_LABEL_W}}", recent_cached, recent_prompt),
+        f"compaction   {comp_est:,} / {comp_trigger:,} tokens est.  ({comp_pct}% to trigger)",
     ]
 
 

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -936,7 +936,16 @@ def _cost_scope_state(
 #: retired renderer used, and which this port faithfully inherited) shifted the
 #: Output row's cells one column left of every other row. Deriving the width here
 #: means adding or renaming a row later cannot re-break the alignment.
-_COST_ROW_LABELS = ("COST", "Total", "Input", "Output", "Saved", "Saved%")
+#: The table's LABEL column — the scope names, spelled out (#3691). The table
+#: was transposed to make that possible: with scopes as COLUMNS they had to fit
+#: a 9-character value column and were abbreviated to ``Ses``/``Agt``/``Prj``,
+#: three strings a reader has to be taught. As rows they carry their own names,
+#: and the metric names move to the header where they already fit.
+#:
+#: It also costs two fewer lines — a header plus three scopes instead of a
+#: header plus five metrics — in a pane that competes for rows against every
+#: other drawer pane through ``compact_caps`` (#3680).
+_COST_ROW_LABELS = ("COST", "Session", "Agent", "Project")
 _COST_LABEL_W = max(len(label) for label in _COST_ROW_LABELS)
 _COST_COL_W = 9
 
@@ -951,8 +960,8 @@ def _cost_row(label: str, cells: "Sequence[str]") -> str:
 
 
 def _cost_breakdown_table(snap: dict) -> list[str]:
-    """The 5-row (Total/Input/Output/Saved/Saved%) × 3-column (Session/Agent/
-    Project) cost breakdown table.
+    """The 3-row (Session/Agent/Project) × 5-column (Total/Input/Output/Saved/
+    Saved%) cost breakdown table.
 
     Total is always the litellm-accurate authoritative figure (``cost_usd`` /
     ``cost_agent`` / ``cost_total`` — already computed via ``estimate_cost``,
@@ -969,13 +978,13 @@ def _cost_breakdown_table(snap: dict) -> list[str]:
 
     session_total = snap.get("cost_usd", 0.0)
     scopes = [
-        ("Ses", snap.get("cost_breakdown_session") or CostBreakdown(), session_total),
-        ("Agt", snap.get("cost_breakdown_agent") or CostBreakdown(),
+        ("Session", snap.get("cost_breakdown_session") or CostBreakdown(), session_total),
+        ("Agent", snap.get("cost_breakdown_agent") or CostBreakdown(),
          snap.get("cost_agent", session_total)),
-        ("Prj", snap.get("cost_breakdown_project") or CostBreakdown(),
+        ("Project", snap.get("cost_breakdown_project") or CostBreakdown(),
          snap.get("cost_total", session_total)),
     ]
-    header = _cost_row("COST", [name for name, _, _ in scopes])
+    header = _cost_row("COST", ["Total", "Input", "Output", "Saved", "Saved%"])
 
     per_scope = [
         (name, total, *_cost_scope_state(breakdown, total))
@@ -984,37 +993,27 @@ def _cost_breakdown_table(snap: dict) -> list[str]:
     any_approx = any(state == "approx" for *_rest, state in per_scope)
     any_unavail = any(state == "unavail" for *_rest, state in per_scope)
 
-    total_row = _cost_row(
-        "Total", [f"${total:.4f}" for _, total, *_ in per_scope]
-    )
-
     def _cell(value: float, state: str) -> str:
         if state == "unavail":
             return "—"
         s = f"${value:.4f}"
         return ("~" + s)[:_COST_COL_W] if state == "approx" else s
 
-    input_row = _cost_row(
-        "Input",
-        [_cell(inp, state) for _, _, inp, _out, _sav, _pct, state in per_scope],
-    )
-    output_row = _cost_row(
-        "Output",
-        [_cell(out, state) for _, _, _inp, out, _sav, _pct, state in per_scope],
-    )
-    saved_row = _cost_row(
-        "Saved",
-        [_cell(sav, state) for _, _, _inp, _out, sav, _pct, state in per_scope],
-    )
-    pct_row = _cost_row(
-        "Saved%",
-        [
-            "—" if state == "unavail" else f"{round(100 * pct)}%"
-            for _, _, _inp, _out, _sav, pct, state in per_scope
-        ],
-    )
+    scope_rows = [
+        _cost_row(
+            name,
+            [
+                f"${total:.4f}",
+                _cell(inp, state),
+                _cell(out, state),
+                _cell(sav, state),
+                "—" if state == "unavail" else f"{round(100 * pct)}%",
+            ],
+        )
+        for name, total, inp, out, sav, pct, state in per_scope
+    ]
 
-    rows = [header, total_row, input_row, output_row, saved_row, pct_row]
+    rows = [header, *scope_rows]
     if any_approx:
         rows.append("~ approx at high volume (>200k tiered pricing)")
     if any_unavail:

--- a/tests/test_3338_tui_status_chrome_liveness.py
+++ b/tests/test_3338_tui_status_chrome_liveness.py
@@ -154,6 +154,69 @@ def _saved_pct_row(lines: "list[str]") -> str:
     return next(line for line in lines if line.startswith("Session"))
 
 
+def test_the_ctx_bar_sits_with_the_figure_it_draws() -> None:
+    """Tier 2: the window bar is adjacent to the window percentage, not to the
+    compaction one (#3691).
+
+    The bar has always drawn the WINDOW's fill. It used to be printed after the
+    compaction line — a 42% bar directly beneath "61% to trigger" — so the two
+    figures the pane deliberately keeps separate were rendered as if one
+    illustrated the other. Nothing about either number was wrong; the ADJACENCY
+    was, which is not a property either line has on its own.
+
+    Pinned by position rather than by the rendered strings: the claim is about
+    which line the bar neighbours, and asserting the text would pin the
+    formatting this test does not care about.
+    """
+    from reyn.interfaces.inline.textual_chat.chrome import ctx_pane_lines
+
+    lines = ctx_pane_lines({
+        "ctx_window": 128_000,
+        "ctx_used": 54_000,
+        "ctx_source": "model catalog",
+        "ctx_recent_usage": (57_386, 18_000),
+        "ctx_compaction_status_fn": lambda: {
+            "effective_trigger": 51_000, "free_window": 20_000,
+        },
+    })
+    bar = next(i for i, ln in enumerate(lines) if "░" in ln or "▓" in ln)
+    window_pct = next(i for i, ln in enumerate(lines) if ln.startswith("prompt"))
+    compaction = next(i for i, ln in enumerate(lines) if ln.startswith("compaction"))
+
+    assert bar == window_pct + 1, (
+        f"the bar is not under the window figure it draws: line {bar}, "
+        f"window figure on line {window_pct}"
+    )
+    assert bar < compaction, (
+        "the bar is still adjacent to the compaction estimate — the two figures "
+        "this pane keeps separate read as one illustrating the other"
+    )
+
+
+def test_every_ctx_label_puts_its_value_in_the_same_column() -> None:
+    """Tier 2: the Ctx labels are one column, not five that happen to be close.
+
+    ``cache`` had drifted four characters short of its neighbours, so one line
+    in six started somewhere else. Checked across every labelled line rather
+    than against the one that was wrong — a width that is only asserted where it
+    already broke cannot notice the next label added at the wrong one.
+    """
+    from reyn.interfaces.inline.textual_chat.chrome import ctx_pane_lines
+
+    lines = ctx_pane_lines({"ctx_window": 128_000, "ctx_used": 54_000})
+    labelled = [ln for ln in lines if ln[:1].strip()]
+    assert labelled, "no labelled lines — this gate would be vacuous"
+    starts = {
+        next(i for i, ch in enumerate(ln) if i and ch != " " and ln[i - 1] == " ")
+        for ln in labelled
+    }
+    first = min(starts)
+    assert starts == {first}, (
+        f"the value column starts in {sorted(starts)} — the labels are not one "
+        f"column, they are several that happen to be close"
+    )
+
+
 #: The cost table's own lines (everything before the footnotes / token lines).
 #: Scope names since #3691 — the table was transposed so they could be spelled
 #: out instead of abbreviated to fit a value column.

--- a/tests/test_3338_tui_status_chrome_liveness.py
+++ b/tests/test_3338_tui_status_chrome_liveness.py
@@ -149,11 +149,15 @@ async def test_real_snapshot_carries_every_key_the_chrome_reads(tmp_path) -> Non
 
 
 def _saved_pct_row(lines: "list[str]") -> str:
-    return next(line for line in lines if line.startswith("Saved%"))
+    """The SESSION scope's row — Saved% is its last column since #3691
+    transposed the table (scopes are rows now, metrics are columns)."""
+    return next(line for line in lines if line.startswith("Session"))
 
 
 #: The cost table's own lines (everything before the footnotes / token lines).
-_COST_TABLE_PREFIXES = ("COST", "Total", "Input", "Output", "Saved", "Saved%")
+#: Scope names since #3691 — the table was transposed so they could be spelled
+#: out instead of abbreviated to fit a value column.
+_COST_TABLE_PREFIXES = ("COST", "Session", "Agent", "Project")
 
 
 def _cost_table_rows(lines: "list[str]") -> "list[str]":


### PR DESCRIPTION
**[tui-coder]** — First slice of #3691, taken from the part of that brief which needs no icons.

## After

```
COST       Total    Input   Output    Saved   Saved%
Session  $0.0059  $0.0041  $0.0018  $0.0007      15%
Agent    $0.0059  $0.0041  $0.0018  $0.0007      15%
Project  $0.0124  $0.0041  $0.0018  $0.0007      15%
```

## Before

```
COST        Ses      Agt      Prj
Total   $0.0059  $0.0059  $0.0124
Input   $0.0041  $0.0041  $0.0041
Output  $0.0018  $0.0018  $0.0018
Saved   $0.0007  $0.0007  $0.0007
Saved%      15%      15%      15%
```

With the scopes as **columns** they had to fit a 9-character value column, so they were `Ses` / `Agt`
/ `Prj` — three strings a reader has to be taught, in a pane whose whole job is to be read at a
glance. As **rows** they carry their own names, and the metric names move to the header where they
already fit.

**It also costs two fewer lines**, which is not incidental: the drawer's panes compete for rows
through `compact_caps` (#3680), so on a short terminal this is the difference between the token and
cache lines being on screen or not.

Nothing about the figures changes — same sources, same per-scope state handling, same `~` / `—` cells
and their footnotes. Orientation only.

## What I deliberately did not take from the mockups

**The Nerd Font glyphs and the hero value.**

- The icon work is **#3642, which the owner has held** ("全て却下"). #3691's own principles say
  terminal compatibility is a feature and Nerd Font must not be an unconditional default.
- A hero line would **add** a row to a pane already competing for them — the opposite of what this
  change is for.

This is the slice of the brief that needs neither, which is also why it can land while #3642 waits.

## Tests

Two pinned the old orientation and are updated — `_COST_TABLE_PREFIXES` (row labels are scopes now)
and `_saved_pct_row` (Saved% is the Session row's last column rather than a row of its own). **The
alignment probe they feed is unchanged and still passes**: it measures where the value columns land,
which holds by construction in either orientation, so the geometry claim was never the thing coupled
to the layout.

## Test plan

- [x] `pytest tests/test_3338_tui_status_chrome_liveness.py` — 28 passed
- [x] `pytest -k "cost or chrome or drawer or 3695 or 3338 or 3699"` — 221 passed, 6 skipped, plus the
      two known `reyn.local.yaml` failures (#3791)
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_3338_tui_status_chrome_liveness.py` — 0 errors
- [x] `python scripts/verify_module_docstrings.py src/.../chrome.py` — OK
- [x] (skipped — the local full suite is CI's job) **Full `pytest`**
- [x] **Visual: real terminal** — Cost pane opened at 100×34 and again at 72 columns; columns align,
      scope names render unabbreviated, the whole pane fits. Checked myself per the standing
      operating model rather than deferred.

Part of #3691. The remaining panes (Context, Capabilities, Model/Agent/History/Pipe/Cron/Help) are
untouched — one pane at a time, so a direction the owner dislikes costs one pane and not the drawer.

---

## Second slice: the Ctx pane's bar was next to the wrong figure

```
compaction   31,000 / 51,000 tokens est.  (61% to trigger)
             ▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░  42%      <- draws the WINDOW's fill
```

A 42% bar directly beneath *"61% to trigger"*. **Every figure was correct and every line was correct
on its own** — the adjacency was wrong, and adjacency is not a property either line has by itself, so
no per-line test could have caught it. #3691's principle for this pane is that the context window and
the compaction estimate are not comparable and must stay visually separate; the layout was doing the
opposite.

```
window       128,000 tokens  (model catalog)
prompt       54,000 tokens  (42% of window)
             ▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░  42%
free         74,000 tokens
cache        31% hit (18,000 / 57,386 prompt tokens)
compaction   31,000 / 51,000 tokens est.  (61% to trigger)
```

`cache` also began four columns short of its five neighbours. The width is named now
(`_CTX_LABEL_W`) rather than repeated in six f-strings, which is how it drifted in the first place.

Both gates **enumerate rather than target**: the bar's position is asserted against the line it draws
*and* against compaction, and the label column across *every* labelled line — a width asserted only
where it already broke cannot notice the next label added at a different one.

**Falsified** by moving the bar back under compaction: that gate red, the other 29 green.

### A process failure worth recording

I ran the gates as `gate | tail -3 && next`. **`tail`'s exit code is what `&&` sees**, so
`test_tier_audit` reported a Tier-4 violation and the commit went through anyway. Amended; the
violation is fixed (`len(starts) == 1` restated as set equality — the property is *all the same*, not
*there is one*).

It is the same shape as everything else in this PR: the check ran, and its result did not reach the
decision.
