### PR TITLE
fix(#3704): assign seq to every persisted history entry, not just user

### DIFF
--- a/src/reyn/runtime/chat_message.py
+++ b/src/reyn/runtime/chat_message.py
@@ -139,7 +139,7 @@ class ChatMessage:
     # wire-shape builder reads and embeds the binary at LLM-call time.
     content: str | list[dict] = ""
     ts: str = ""
-    seq: int = 0  # monotonic per-session sequence id; 0 for non-conversational entries
+    seq: int = 0  # monotonic per-session sequence id; #3704: 0 = no coordinate assigned (pre-fix history only — every entry now gets one at persist time, any role)
     meta: dict = field(default_factory=dict)
     # OpenAI/Anthropic tool-turn fields ─────────────────────────────────
     # ``tool_calls`` is set ONLY on ``role="assistant"`` entries where the

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -409,9 +409,12 @@ class RouterHistoryBuffer:
         # every turn, not a one-shot override): the next user turn slices
         # [consolidation] + recent turns, never re-slicing the dropped raw
         # head/tail → no immediate re-overflow. Position-based (turns after the
-        # consolidation in history order), NOT seq>covers — assistant/tool turns
-        # keep seq=0 (only user/agent get a monotonic seq), so a seq filter would
-        # wrongly drop post-handoff assistant replies. GATED to force-close
+        # consolidation in history order), NOT seq>covers — #3704 gave every
+        # role a monotonic seq at persist time, but history predating that fix
+        # still has assistant/tool entries stuck at seq==0 forever (no
+        # backfill), so a seq filter would wrongly drop their post-handoff
+        # replies on any session with pre-fix history. Position-based sidesteps
+        # the old/new-history split entirely. GATED to force-close
         # consolidations only (the dedicated `consolidation` field) — normal
         # compaction summaries fall through to the unchanged head/tail+bridge
         # path below, so normal chat stays byte-identical.

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2612,10 +2612,24 @@ class Session:
     # ── persistence ─────────────────────────────────────────────────────────────
 
     def _append_history(self, msg: ChatMessage) -> None:
-        # Assign monotonic seq for conversational entries (user/agent). Other
-        # roles (summary) keep seq=0 — they aren't part of the
-        # turn ordering used by the slicer.
-        if msg.role in ("user", "agent") and msg.seq == 0:
+        # #3704: assign a monotonic seq to every persisted entry regardless
+        # of role. Previously gated on ``msg.role in ("user", "agent")`` —
+        # ``"agent"`` was never a real role (``ChatMessage``'s role Literal
+        # has always been "user"/"assistant"/"tool"/"system"/"summary"; no
+        # commit ever introduced an "agent" role), so this condition only
+        # ever matched "user". assistant/tool entries persisted with
+        # seq==0 permanently, and CompactionController._select_candidates's
+        # ``t.seq > prev_cover`` filter (services/compaction_controller.py)
+        # reads seq==0 as "already covered" — so assistant/tool turns were
+        # silently EXCLUDED from every compaction candidate set, unfixably,
+        # since seq is set once at persist time. Owner-ratified fix
+        # (2026-08-08): drop the role gate rather than fix the spelling —
+        # ``seq == 0`` used to mean two different things ("not yet
+        # assigned" and "covered by an already-compacted summary"), and
+        # ``t.seq > prev_cover`` cannot tell them apart; removing the gate
+        # collapses it to ONE meaning ("no coordinate assigned" — true only
+        # for old, pre-fix history entries now).
+        if msg.seq == 0:
             msg.seq = self._next_seq
             self._next_seq += 1
         # #2360: anchor each turn to the WAL seq at append time so the conversation
@@ -3028,10 +3042,13 @@ class Session:
                     self.history.append(ChatMessage(**raw))
                 except Exception:
                     continue
-        # Initialize the seq counter past any seqs already in the file. Old
-        # entries without seq fall back to 0; the synthetic seq for them is
-        # assigned by the slicer at read time, so we only care about the
-        # max of explicitly-stored seqs here for the next-write counter.
+        # Initialize the seq counter past any seqs already in the file.
+        # #3704: entries persisted before the role-gate removal (assistant/
+        # tool turns from the old buggy path) have seq==0 and stay that
+        # way forever — nothing re-derives or backfills a coordinate for
+        # them at read time. ``if m.seq`` below simply ignores those
+        # zeros when finding the max, which is correct: a 0 never
+        # legitimately outranks a real assigned seq.
         max_seen = max((m.seq for m in self.history if m.seq), default=0)
         self._next_seq = max_seen + 1
 

--- a/tests/test_3704_seq_assigned_to_every_role.py
+++ b/tests/test_3704_seq_assigned_to_every_role.py
@@ -1,0 +1,138 @@
+"""Tier 2: #3704 (owner-ratified, 2026-08-08) — every persisted history entry
+gets a monotonic seq at append time, regardless of role.
+
+``Session._append_history``'s seq-assignment used to gate on
+``msg.role in ("user", "agent")`` — ``"agent"`` was never a real
+``ChatMessage`` role (the Literal has always been "user"/"assistant"/"tool"/
+"system"/"summary"), so the condition only ever matched "user". assistant/
+tool entries persisted with ``seq == 0`` forever, and
+``CompactionController._select_candidates``'s ``t.seq > prev_cover`` filter
+reads seq==0 as "already covered" — so assistant/tool turns were silently
+and permanently excluded from every compaction candidate set.
+
+Three witnesses:
+(a) assign side — every role gets a nonzero seq at persist time.
+(b) consume side — the ONE witness that shows this issue is actually fixed:
+    assistant/tool turns now appear in the compaction candidate set
+    (``t.seq > prev_cover`` passes for them). An assign-side-only witness is
+    not sufficient (architect's own framing) — seq being assigned proves
+    nothing about whether the consumer that was silently dropping these
+    turns actually picks them up now.
+(c) migration compat — old-format history (assistant/tool stuck at seq==0)
+    does not corrupt ``_next_seq`` bootstrap on load.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reyn.runtime.chat_message import ChatMessage
+from tests._support.session import make_session as _make_session
+
+# ── (a) assign side: every role gets a monotonic seq ────────────────────────
+
+
+def test_every_role_gets_a_nonzero_seq_at_persist_time(tmp_path, monkeypatch):
+    """Tier 2: #3704 arm (a) — user/assistant/tool/system entries ALL get a
+    monotonic seq when appended, not just "user".
+
+    Falsification (performed for real): reverting the role gate (restoring
+    ``if msg.role in ("user", "agent") and msg.seq == 0:``) makes this test
+    RED — assistant/tool/system entries stay at seq==0 while user does not."""
+    session = _make_session(tmp_path, monkeypatch=monkeypatch)
+
+    session._append_history(ChatMessage(role="user", content="hello", ts="t1"))
+    session._append_history(ChatMessage(role="assistant", content="hi", ts="t2"))
+    session._append_history(ChatMessage(role="tool", content="result", ts="t3"))
+    session._append_history(ChatMessage(role="system", content="note", ts="t4"))
+
+    seqs = [m.seq for m in session.history]
+    assert all(s > 0 for s in seqs), f"expected every entry to get a nonzero seq, got {seqs!r}"
+    # Monotonic: strictly increasing in append order.
+    assert seqs == sorted(seqs) and len(set(seqs)) == len(seqs)
+
+
+# ── (b) consume side: the actual fix — assistant/tool reach the compaction candidate set ──
+
+
+def test_assistant_and_tool_turns_are_not_excluded_from_compaction_candidates(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: #3704 arm (b) — the ONE witness that shows this is actually
+    fixed, not just that seq gets assigned. Drives the REAL
+    ``CompactionController._select_candidates`` (the exact consumer the
+    issue names) with a mix of roles and confirms assistant/tool turns —
+    previously stuck at seq==0, always read as "already covered" by
+    ``t.seq > prev_cover`` — now pass the filter and appear in the returned
+    candidate set.
+
+    Falsification (performed for real): reverting the role gate makes
+    assistant/tool stay at seq==0, and this test goes RED — the candidate
+    set excludes them (``t.seq > prev_cover`` is False for seq==0 whenever
+    prev_cover >= 0)."""
+    # A small t_max keeps head_budget/tail_budget small, so with enough
+    # turns the middle ones genuinely fall OUTSIDE both the head and tail
+    # slices — the actual "candidate" zone _select_candidates filters by
+    # seq. With the large default t_max, 3 tiny turns fit entirely inside
+    # head+tail and nothing is ever a "middle" candidate regardless of seq.
+    session = _make_session(tmp_path, monkeypatch=monkeypatch, t_max=20_000)
+
+    filler = "middle turn padding text " * 20
+    for i in range(40):
+        role = "user" if i % 3 == 0 else ("assistant" if i % 3 == 1 else "tool")
+        session._append_history(
+            ChatMessage(role=role, content=f"{filler} #{i}", ts=f"t{i}")
+        )
+
+    turns = list(session.history)
+    controller = session._compaction_controller
+    candidates = controller._select_candidates(turns, prev_cover=0)
+
+    candidate_roles = {t.role for t in candidates}
+    assert "assistant" in candidate_roles, (
+        f"assistant turns must reach the compaction candidate set; got roles {candidate_roles!r}"
+    )
+    assert "tool" in candidate_roles, (
+        f"tool turns must reach the compaction candidate set; got roles {candidate_roles!r}"
+    )
+
+
+# ── (c) migration: old-format history (assistant/tool stuck at 0) loads safely ──
+
+
+def test_old_format_history_with_zero_seq_assistant_turns_bootstraps_correctly(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: #3704 arm (c) — a history.jsonl written by the OLD (buggy)
+    code, where assistant/tool entries are stuck at seq==0 forever (no
+    backfill on read), does not corrupt ``_next_seq`` bootstrap: the max
+    is taken over nonzero seqs only, so the zeros are correctly ignored
+    rather than treated as "seq 0 is the latest"."""
+    session = _make_session(tmp_path, monkeypatch=monkeypatch)
+    history_path = session.history_path
+    history_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Simulates OLD-format entries: user gets real seqs, assistant/tool are
+    # frozen at 0 (exactly what the pre-fix code persisted).
+    old_entries = [
+        {"role": "user", "content": "q1", "ts": "t1", "seq": 1, "meta": {}},
+        {"role": "assistant", "content": "a1", "ts": "t2", "seq": 0, "meta": {}},
+        {"role": "user", "content": "q2", "ts": "t3", "seq": 2, "meta": {}},
+        {"role": "tool", "content": "r1", "ts": "t4", "seq": 0, "meta": {}},
+    ]
+    with history_path.open("w", encoding="utf-8") as f:
+        for e in old_entries:
+            f.write(json.dumps(e) + "\n")
+
+    session.history = []
+    session.load_history()
+
+    assert [m.seq for m in session.history] == [1, 0, 2, 0]
+
+    # Public-behavior proof that _next_seq bootstrapped past the real max
+    # (2), not confused by the zeros: a NEW entry appended after load gets
+    # the next real seq (3), not 1 (which a naive max-including-zeros, or a
+    # bootstrap that got stuck on the last zero, could produce).
+    session._append_history(ChatMessage(role="assistant", content="a2", ts="t5"))
+    assert session.history[-1].seq == 3


### PR DESCRIPTION
**[e2e-coder]** — Closes #3704. Owner-ratified design (architect, 2026-08-08: https://github.com/tya5/reyn/issues/3704#issuecomment-5224785974).

## What actually happened to this issue

The issue's original premise ("`load_history()` reads the whole transcript at startup, needs a reverse-byte-scan tail reader") was measured and rejected: 3,000 turns = 64ms, 30,000 turns (a near-realistic upper bound) = 427ms, both one-time startup costs. Not slow enough to justify a new-file-format-class mechanism. That measurement is what stopped the heavier fix from being built — the real defect surfaced from investigating whether `_next_seq` could safely bootstrap from a tail read alone.

## The real defect

`Session._append_history`'s seq-assignment gated on `msg.role in ("user", "agent")`. `"agent"` was never a real `ChatMessage` role (the `Literal` has always been `user`/`assistant`/`tool`/`system`/`summary` — no commit ever introduced `"agent"`), so the condition only ever matched `"user"`. assistant/tool entries persisted with `seq == 0` forever.

`CompactionController._select_candidates`'s `t.seq > prev_cover` filter reads `seq == 0` as "already covered by the latest summary" — so assistant/tool turns were **silently and permanently excluded from every compaction candidate set**, since seq is assigned once at persist time and there's no backfill.

Checked for a recorded decision (declared prose, the introducing commit, any trace of an "agent" role) — none found; the declaration prose (`seq: int = 0 # ... 0 for non-conversational entries`) actually says the opposite (assistant/tool ARE conversational). Not a stale rename, a condition that never reached its intended target.

## Fix (owner: "role で絞る理由はないでしょ" / "assis, tool を圧縮に入れるのが本来の仕様でしょ")

Drop the role gate entirely rather than fix the spelling. `seq == 0` used to carry two meanings ("not yet assigned" and "already covered") that `t.seq > prev_cover` can't distinguish; removing the gate collapses it to one meaning going forward. Old (pre-fix) history stays at `seq == 0` forever (no backfill) — the max-seq bootstrap on load already tolerates this correctly (`if m.seq` skips zeros), and the force-close position-based history reset already avoids seq entirely for exactly this reason. Updated 3 stale prose sites to match (including deleting a claim about a "synthetic seq... assigned by the slicer at read time" — no such code exists, 0 grep hits).

## Test plan

- [x] Arm (a) — every role gets a nonzero monotonic seq at persist time
- [x] Arm (b) — **the one witness that shows this is actually fixed**: drives the real `CompactionController._select_candidates` and confirms assistant/tool turns now pass `t.seq > prev_cover` and appear in the candidate set (an assign-side-only witness wouldn't prove the consumer that was silently dropping them actually picks them up now)
- [x] Arm (c) — old-format history (assistant/tool frozen at `seq == 0`) loads without corrupting `_next_seq` bootstrap; a new entry appended after load gets the correct next seq
- [x] Falsify-verified for real: reverting the role gate reddens all 3 for the exact predicted reasons; restored clean
- [x] `ruff check` — green
- [x] `python scripts/test_tier_audit.py --strict tests/test_3704_seq_assigned_to_every_role.py` — 3/3 clean
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] Targeted regression sweep (`history`/`compaction`/`seq`/`chat_message`/`3704`/`force_close`/`rewind`/`branch`/`active_branch`/`restore`/`router_history`) — 647 passed, 0 failed
- [x] Full suite deferred to CI per the local-full-pytest-is-CI-only policy