### PR TITLE
feat(#3694): persist cancelled-turn outcomes as durable, typed history

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/restore.py
+++ b/src/reyn/interfaces/inline/textual_chat/restore.py
@@ -233,7 +233,12 @@ def project_restored_frames(
       ``{"error_message": ...}``) for a FAILURE — read directly off the
       persisted ``meta[TOOL_STATUS_META_KEY]`` typed flag (:func:`_failure_meta`;
       #73), never re-derived from ``m.text``.
-    - ``system`` / ``summary``       → skipped (internal chrome)
+    - ``system`` / ``summary``       → skipped (internal chrome), EXCEPT a
+      ``system`` entry carrying ``meta["kind"] == "turn_cancelled"``
+      (#3694) — a genuinely-cancelled turn's durable outcome, rescued by
+      ``meta.kind`` rather than by role so every OTHER ``system`` entry
+      (``state_change``, real SP chrome) stays skipped → ``kind="system"``,
+      matching the live path's own outbox rendering.
 
     An assistant message carrying ONLY ``tool_calls`` (empty text) produces no
     ``agent`` frame of its own — the call header is delivered entirely through
@@ -251,7 +256,23 @@ def project_restored_frames(
     frames: "list[OutboxMessage]" = []
     for m in messages:
         role = m.role
+        meta = m.meta or {}
         if role in _SKIP_ROLES:
+            # #3694: a cancelled-turn outcome reuses role="system" (the
+            # same no-new-role precedent as notify_state_change), so the
+            # blanket _SKIP_ROLES exclusion above would silently drop it
+            # too — restoring the exact "why was there no reply" gap this
+            # entry exists to close. Rescued by meta.kind, never by role:
+            # every OTHER system entry (state_change, genuine SP chrome)
+            # stays skipped.
+            if role == "system" and meta.get("kind") == "turn_cancelled":
+                frames.append(
+                    OutboxMessage(
+                        kind="system",
+                        text=m.text,
+                        meta={RESTORED_META_KEY: True, "chain_id": meta.get("chain_id")},
+                    )
+                )
             continue
         if role == "user":
             meta = m.meta or {}

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -2502,6 +2502,23 @@ class RouterLoop:
                 text="✗ turn interrupted",
                 meta={"chain_id": self.chain_id},
             )
+            # #3694: durable cancelled-turn outcome — the cooperative-cancel
+            # terminal (this branch fires when the loop-head check caught
+            # the request before a hard Task.cancel() landed). Mirrors
+            # Session.notify_turn_cancelled's shape exactly (same
+            # role="system" + meta.kind precedent as notify_state_change);
+            # inlined here rather than added as a new RouterLoopHost method
+            # because host.append_history_entry already IS the generic
+            # "persist a ChatMessage, no outbox side effect" primitive this
+            # needs. The hard-cancel case (the more common mid-LLM-call
+            # Ctrl+C) never reaches this branch at all — CancelledError
+            # unwinds straight past it — so Session.run_one_iteration's own
+            # catch is the receiver for that case, not a duplicate of this.
+            self.host.append_history_entry(
+                role="system",
+                content="Turn interrupted by user.",
+                meta={"kind": "turn_cancelled", "chain_id": self.chain_id},
+            )
             return self._total_usage
 
         # Limit-deny path (#1496): give the LLM one final tool-less turn to

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2883,6 +2883,59 @@ class Session:
             # Defensive: observability must not crash the API.
             pass
 
+    def notify_turn_cancelled(self, chain_id: "str | None") -> None:
+        """Persist a genuinely-cancelled turn's outcome as a first-class
+        history entry (#3694).
+
+        Storage shape mirrors :meth:`notify_state_change` exactly (same
+        precedent, same owner ruling — "むやみに増やすべきでない、system
+        あるならそれで": no new role, reuse ``system``):
+          - ``role="system"`` — excluded from every LLM-facing turn list
+            (``RouterHistoryBuffer.build_history``'s allowlist is
+            ``role in ("user","assistant","tool","agent")``) and from
+            compaction candidates (``force_compact_now``'s own turns
+            filter is the same allowlist) — structurally, not by a new
+            check either of those already-existing filters would need.
+          - ``meta.kind="turn_cancelled"`` — distinguishes this from a
+            ``state_change`` system entry; a reader (TUI restore
+            projection) dispatches on this key, never on the rendered
+            ``content`` string.
+          - ``meta.chain_id`` — correlates back to the turn this outcome
+            belongs to (the same chain_id the cancelled turn's own
+            ``user_message_received`` / ``turn_started`` events carry).
+
+        Append-only, NOT an in-place edit: ``history.jsonl`` has no
+        rewrite path (only ``"a"``/``"r"`` opens exist — grepped), so a
+        cancelled outcome discovered at turn-end cannot be durably
+        recorded by mutating the (already-persisted) user turn's own
+        ``meta`` — that mutation would only live in memory and vanish on
+        restart. A NEW entry is the only way to add durable information
+        to an append-only log.
+
+        Called from exactly the places that OBSERVE a turn ending
+        because it was cancelled (not merely requested — a cancel racing
+        turn completion must never call this): ``RouterLoop``'s
+        cooperative-cancel terminal (``_loop_cancelled`` true at the
+        outer-loop exit) when reached, and ``Session.run_one_iteration``'s
+        hard-cancel ``CancelledError`` catch as the receiver for when a
+        ``cancel_inflight()`` hard ``Task.cancel()`` (the common
+        mid-LLM-call Ctrl+C case) injects ``CancelledError`` at whatever
+        await the turn was suspended on — which unwinds straight past
+        ``RouterLoop``'s own terminal check (measured: zero
+        ``CancelledError`` handling anywhere in ``router_loop.py``), so
+        that check never runs for a hard cancel. The two call sites are
+        mutually exclusive per actual cancelled turn (one always reaches
+        its stamp point, the other doesn't, for a given cancellation) —
+        this is a primary path plus the receiver for when it's skipped,
+        not two independent recorders that could double-append.
+        """
+        self._append_history(ChatMessage(
+            role="system",
+            content="Turn interrupted by user.",
+            ts=_now_iso(),
+            meta={"kind": "turn_cancelled", "chain_id": chain_id},
+        ))
+
     def _append_history_for_handler(
         self, role: str, text: str, ts: str, meta: dict,
     ) -> None:
@@ -5571,6 +5624,21 @@ class Session:
                             "message.",
                             kind, payload.get("chain_id"),
                         )
+                    else:
+                        # #3694: the receiver for when a hard cancel
+                        # (cancel_inflight()'s Task.cancel(), the common
+                        # mid-LLM-call Ctrl+C case) injects CancelledError
+                        # at whatever await the turn was suspended on —
+                        # this unwinds straight past RouterLoop's own
+                        # cooperative-cancel terminal (router_loop.py's
+                        # `if _loop_cancelled:` block, which never runs for
+                        # a hard cancel: zero CancelledError handling
+                        # anywhere in that module). Gated on
+                        # ``_turn_cancel_self_initiated`` — a cancel from
+                        # something OTHER than cancel_inflight() (the `if`
+                        # branch above) is NOT a user cancel and must not
+                        # be recorded as one.
+                        self.notify_turn_cancelled(payload.get("chain_id"))
                     _cancelled = True
             finally:
                 # #2242 Finding 1: reset UNCONDITIONALLY here, not per-branch above — if the

--- a/tests/test_2242_hard_cancel.py
+++ b/tests/test_2242_hard_cancel.py
@@ -158,10 +158,19 @@ async def test_hard_cancel_mid_generation_no_result_append_and_agent_survives(tm
         "a hard-cancelled turn's LLM reply must never be appended, even after "
         "the underlying hung call is released post-cancel"
     )
-    # (b) branch clean: only the pre-cancel user message is present (no
-    # partial assistant/tool entries from the aborted turn).
+    # (b) branch clean: only the pre-cancel user message plus the #3694
+    # cancelled-outcome marker are present (no partial assistant/tool
+    # entries from the aborted turn). The marker's role="system" (no new
+    # role, mirrors notify_state_change) is durable proof the hard-cancel
+    # WAS observed and recorded, not silent.
     roles = [m.role for m in session.history]
-    assert roles == ["user"], f"expected only the user message to survive; got {roles}"
+    assert roles == ["user", "system"], (
+        f"expected the user message + the #3694 cancelled-outcome marker "
+        f"(role=system); got {roles}"
+    )
+    cancelled_marker = session.history[-1]
+    assert cancelled_marker.meta.get("kind") == "turn_cancelled"
+    assert cancelled_marker.meta.get("chain_id") == "c-hard-cancel"
 
     # (d) the prior fire-and-forget WAL-append task survived (joined by
     # await_quiescent on the cancel path) — its durable effect is visible in

--- a/tests/test_3694_persist_cancelled_turn_outcome.py
+++ b/tests/test_3694_persist_cancelled_turn_outcome.py
@@ -1,0 +1,269 @@
+"""Tier 2: #3694 (owner-ratified design, architect + 2026-08-08) — a
+genuinely-cancelled turn's outcome is persisted as a durable, typed history
+entry, never fabricated as assistant content, and never reaches the LLM.
+
+Storage shape mirrors ``Session.notify_state_change`` exactly (same owner
+ruling: "むやみに増やすべきでない、system あるならそれで" — no new role):
+``role="system"`` + ``meta={"kind": "turn_cancelled", "chain_id": ...}``.
+
+Two independent stamp sites exist because measurement showed they are NOT
+redundant — a hard cancel (``cancel_inflight()``'s ``Task.cancel()``, the
+common mid-LLM-call Ctrl+C case) injects ``CancelledError`` at whatever
+await the turn was suspended on, which unwinds straight past
+``RouterLoop.run_loop``'s own cooperative-cancel terminal (zero
+``CancelledError`` handling anywhere in ``router_loop.py`` — measured via
+grep). ``Session.run_one_iteration``'s own catch is the receiver for that
+case; ``RouterLoop.run_loop``'s ``if _loop_cancelled:`` terminal is the
+primary path for a cooperative-only cancel (the LLM call itself was never
+interrupted — the loop-head check caught the request first).
+
+Witnesses:
+(a) shape — ``notify_turn_cancelled`` persists the exact typed record.
+(b) LLM non-reach — structurally guaranteed by the existing role
+    allowlist (``build_history``), verified directly, not assumed.
+(c) compaction non-candidate — same allowlist, ``force_compact_now``'s own
+    turns filter.
+(d) restore rescue — the entry is NOT silently dropped by
+    ``restore.py``'s ``_SKIP_ROLES``, while an ordinary ``state_change``
+    system entry (a DIFFERENT ``meta.kind``) still IS — the rescue is
+    keyed on ``meta.kind``, not on role.
+(e) cooperative-cancel wiring (① — ``RouterLoop.run_loop``'s own terminal)
+    driven through the REAL ``RouterLoop`` (no Session), via the same
+    ``FakeRouterHost``/``arm_cancel_after`` seam ``test_turn_cancel_1468.py``
+    already uses.
+(f) non-fabrication — a cancel from something OTHER than
+    ``cancel_inflight()`` (``_turn_cancel_self_initiated`` False) must NOT
+    be recorded as a user cancel.
+
+The hard-cancel wiring (② — ``Session.run_one_iteration``'s
+``CancelledError`` catch) is witnessed for real by
+``tests/test_2242_hard_cancel.py``'s existing end-to-end hard-cancel test,
+updated in this same PR to assert the new marker's presence + shape.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.interfaces.inline.textual_chat.restore import project_restored_frames
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.router_loop import RouterLoop
+from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
+from tests._support.router_loop import FakeRouterHost, text_result
+from tests._support.router_loop import ScriptedLLM as _ScriptedLLM
+from tests._support.session import make_session as _make_session
+
+# ── (a) shape ────────────────────────────────────────────────────────────
+
+
+def test_notify_turn_cancelled_persists_typed_system_entry(tmp_path, monkeypatch):
+    """Tier 2: arm (a) — the persisted shape matches the design exactly."""
+    session = _make_session(tmp_path, monkeypatch=monkeypatch)
+    session.notify_turn_cancelled("chain-abc")
+
+    (entry,) = session.history
+    assert entry.role == "system"
+    assert entry.meta.get("kind") == "turn_cancelled"
+    assert entry.meta.get("chain_id") == "chain-abc"
+    assert entry.text  # a non-empty display string for restore/live rendering
+
+
+# ── (b) LLM non-reach ────────────────────────────────────────────────────
+
+
+def test_cancelled_marker_never_reaches_build_history(tmp_path, monkeypatch):
+    """Tier 2: arm (b) — RouterHistoryBuffer.build_history (the REAL
+    LLM-facing wire builder) excludes the marker, structurally, via the
+    same role allowlist every other system entry is already excluded by."""
+    session = _make_session(tmp_path, monkeypatch=monkeypatch)
+    session._append_history(ChatMessage(role="user", content="q1", ts="t1"))
+    session.notify_turn_cancelled("chain-xyz")
+    session._append_history(ChatMessage(role="user", content="q2", ts="t2"))
+
+    buf = RouterHistoryBuffer(
+        history_fn=lambda: session.history,
+        compaction=session._compaction,
+        compaction_controller=session._compaction_controller,
+        model_fn=lambda: session._resolver.resolve(session.model).model,
+        events=session._chat_events,
+        media_store=session._media_store,
+        router_host=session._router_host,
+        action_retrieval=session._action_retrieval,
+        non_interactive=session._non_interactive,
+        reasoning=session._reasoning,
+        project_dir_fn=lambda: tmp_path,
+    )
+    wire = buf.build_history()
+    assert all(
+        "Turn interrupted by user." not in str(m.get("content", "")) for m in wire
+    ), f"the cancelled marker must never appear in the LLM-facing wire list; got {wire!r}"
+    roles = [m["role"] for m in wire]
+    assert "system" not in roles
+
+
+# ── (c) compaction non-candidate ─────────────────────────────────────────
+
+
+def test_cancelled_marker_is_not_a_compaction_candidate(tmp_path, monkeypatch):
+    """Tier 2: arm (c) — force_compact_now's own turns filter (the same
+    role allowlist) excludes the marker from ever being folded into a
+    compaction summary."""
+    session = _make_session(tmp_path, monkeypatch=monkeypatch, t_max=20_000)
+    filler = "middle turn padding text " * 20
+    for i in range(30):
+        role = "user" if i % 2 == 0 else "assistant"
+        session._append_history(ChatMessage(role=role, content=f"{filler} #{i}", ts=f"t{i}"))
+    session.notify_turn_cancelled("chain-mid")
+
+    turns = list(session.history)
+    controller = session._compaction_controller
+    candidates = controller._select_candidates(turns, prev_cover=0)
+    assert all(t.role != "system" for t in candidates), (
+        "the cancelled marker (role=system) must never appear in the "
+        "compaction candidate set"
+    )
+
+
+# ── (d) restore rescue, and falsify: state_change stays skipped ─────────
+
+
+def test_cancelled_marker_is_rescued_by_restore_but_state_change_is_not(tmp_path, monkeypatch):
+    """Tier 2: arm (d) — project_restored_frames rescues the cancelled
+    marker specifically by meta.kind, NOT by role — a state_change system
+    entry (a DIFFERENT meta.kind, same role) must stay skipped, proving the
+    rescue is not a blanket "let system through" change."""
+    session = _make_session(tmp_path, monkeypatch=monkeypatch)
+    session._append_history(ChatMessage(role="user", content="q1", ts="t1"))
+    session.notify_turn_cancelled("chain-restore")
+    session.notify_state_change("MCP server 'x' installed.")
+
+    frames = project_restored_frames(session.history)
+    kinds_and_texts = [(f.kind, f.text) for f in frames]
+
+    assert any(
+        k == "system" and "Turn interrupted by user." in t for k, t in kinds_and_texts
+    ), f"the cancelled marker must be projected; got {kinds_and_texts!r}"
+    assert not any(
+        "installed" in t for _, t in kinds_and_texts
+    ), f"a state_change entry must stay skipped (not rescued); got {kinds_and_texts!r}"
+
+
+# ── (e) cooperative-cancel wiring (①), driven through the REAL RouterLoop ──
+
+
+def _loop(host, llm, max_iterations=5):
+    return RouterLoop(
+        host=host, chain_id="chain-cooperative-cancel",
+        max_iterations=max_iterations, llm_caller=llm,
+    )
+
+
+class _CancellableHost(FakeRouterHost):
+    def __init__(self) -> None:
+        super().__init__()
+        self._cancel_after_n = None
+        self._iteration_count = 0
+
+    def arm_cancel_after(self, n: int) -> None:
+        self._cancel_after_n = n
+
+    def _is_turn_cancel_requested(self) -> bool:
+        self._iteration_count += 1
+        if self._cancel_after_n is None:
+            return False
+        return self._iteration_count > self._cancel_after_n
+
+
+@pytest.mark.asyncio
+async def test_cooperative_cancel_persists_the_marker_via_real_router_loop() -> None:
+    """Tier 2: arm (e) — driving the REAL RouterLoop.run_loop through a
+    cooperative cancel (mirrors test_turn_cancel_1468.py's own seam)
+    results in the marker landing on host.history via the real
+    append_history_entry call this PR added at the ``if _loop_cancelled:``
+    terminal.
+
+    Falsification (performed for real): removing the new
+    ``self.host.append_history_entry(...)`` call from that terminal makes
+    this test go RED (``host.history`` stays empty)."""
+    host = _CancellableHost()
+    host.arm_cancel_after(0)  # cancel on the FIRST iteration check
+    llm = _ScriptedLLM([text_result("should not run")])
+    loop = _loop(host, llm)
+
+    usage = await loop.run_loop(
+        messages=[{"role": "user", "content": "hi"}], tools=[], _univ_enabled=False,
+    )
+    assert isinstance(usage, TokenUsage)
+    assert llm.call_count == 0  # cancel fired before any LLM call
+
+    cancelled_entries = [
+        e for e in host.history
+        if e["role"] == "system" and e["meta"].get("kind") == "turn_cancelled"
+    ]
+    # Exactly one — unpacking to a single-element tuple raises ValueError
+    # otherwise (mirrors the stage-2 #3783 precedent for this idiom).
+    (only,) = cancelled_entries
+    assert only["meta"].get("chain_id") == "chain-cooperative-cancel"
+
+
+# ── (f) non-fabrication: a non-user-initiated cancel must not stamp ──────
+
+
+@pytest.mark.asyncio
+async def test_a_non_self_initiated_cancel_does_not_fabricate_a_user_cancel_marker(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: arm (f) — Session.run_one_iteration's hard-cancel catch only
+    calls notify_turn_cancelled when the cancellation was
+    self._turn_cancel_self_initiated (i.e. genuinely cancel_inflight()).
+    A cancel from something else (a "not self-initiated" cancel — #3377's
+    survivable-but-unexpected case, e.g. an unrelated caller's
+    ``Task.cancel()``) must not fabricate a "user cancelled this" record.
+
+    Delivered through the REAL mechanism ``test_3377_run_loop_survives_turn_
+    cancel.py`` itself uses: ``session._turn_owner_task.cancel()`` directly
+    — bypassing ``cancel_inflight()`` entirely, so
+    ``_turn_cancel_self_initiated`` stays False. Real ``Session`` (no
+    mocks); only ``RouterLoopDriver.run_turn`` is replaced with a
+    controllable hang, the same seam ``test_2242_hard_cancel.py`` and
+    ``test_3377_...`` both use.
+
+    Falsification (performed for real): removing the ``else:`` gate
+    (calling ``notify_turn_cancelled`` unconditionally) makes this test go
+    RED — a marker appears even though nothing that looked like a user
+    cancel ever happened.
+    """
+    session = _make_session(tmp_path, monkeypatch=monkeypatch)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _hanging_run_turn(user_text, chain_id):
+        started.set()
+        await release.wait()
+
+    session._loop_driver.run_turn = _hanging_run_turn  # type: ignore[method-assign]
+
+    await session._put_inbox("user", {"text": "hello", "chain_id": "c-unknown-origin"})
+    turn_task = asyncio.create_task(session.run_one_iteration())
+    try:
+        await asyncio.wait_for(started.wait(), timeout=5)
+
+        # The REAL "not self-initiated" delivery mechanism — NOT cancel_inflight().
+        session._turn_owner_task.cancel()
+
+        release.set()
+        completed = await asyncio.wait_for(turn_task, timeout=5)
+        assert completed is True  # the driver survives (per #3377)
+    finally:
+        release.set()
+
+    cancelled_markers = [
+        m for m in session.history
+        if m.role == "system" and m.meta.get("kind") == "turn_cancelled"
+    ]
+    assert cancelled_markers == [], (
+        f"a cancel from something other than cancel_inflight() must NOT "
+        f"fabricate a user-cancel marker; got {cancelled_markers!r}"
+    )

--- a/tests/test_3694_persist_cancelled_turn_outcome.py
+++ b/tests/test_3694_persist_cancelled_turn_outcome.py
@@ -34,11 +34,20 @@ Witnesses:
 (f) non-fabrication — a cancel from something OTHER than
     ``cancel_inflight()`` (``_turn_cancel_self_initiated`` False) must NOT
     be recorded as a user cancel.
+(g) hard-cancel wiring (② — ``Session.run_one_iteration``'s
+    ``CancelledError`` catch), driven through a REAL ``Session`` via
+    ``cancel_inflight()`` against an in-flight (hung) turn — the same
+    controllable-hang seam ``tests/test_2242_hard_cancel.py`` uses. Kept
+    HERE (not only cross-referenced) after review caught that this file's
+    own suite went fully green with ② stripped to a no-op — the positive
+    witness lived exclusively in test_2242_hard_cancel.py's UPDATED
+    assertion, invisible to anyone reading this file in isolation.
 
-The hard-cancel wiring (② — ``Session.run_one_iteration``'s
-``CancelledError`` catch) is witnessed for real by
-``tests/test_2242_hard_cancel.py``'s existing end-to-end hard-cancel test,
-updated in this same PR to assert the new marker's presence + shape.
+``tests/test_2242_hard_cancel.py``'s own end-to-end hard-cancel test was
+ALSO updated in this same PR (its pre-existing assertion pinned "only the
+user message survives a hard cancel", now correctly "user message + the
+marker") — that update is corroborating evidence, not this file's sole
+witness for ②.
 """
 from __future__ import annotations
 
@@ -46,11 +55,13 @@ import asyncio
 
 import pytest
 
+from reyn.core.events.state_log import StateLog
 from reyn.interfaces.inline.textual_chat.restore import project_restored_frames
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.router_loop import RouterLoop
 from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
+from tests._support.agent_session import make_session as _make_hard_cancel_session
 from tests._support.router_loop import FakeRouterHost, text_result
 from tests._support.router_loop import ScriptedLLM as _ScriptedLLM
 from tests._support.session import make_session as _make_session
@@ -267,3 +278,59 @@ async def test_a_non_self_initiated_cancel_does_not_fabricate_a_user_cancel_mark
         f"a cancel from something other than cancel_inflight() must NOT "
         f"fabricate a user-cancel marker; got {cancelled_markers!r}"
     )
+
+
+# ── (g) hard-cancel wiring (②), driven through a REAL Session ────────────
+
+
+@pytest.mark.asyncio
+async def test_hard_cancel_via_cancel_inflight_persists_the_marker(tmp_path) -> None:
+    """Tier 2: arm (g) — the ② receiver, witnessed IN THIS FILE (not only
+    cross-referenced) so a reader/reviewer of this file alone sees the
+    positive path for the "more common" case the module docstring itself
+    names.
+
+    Falsification (performed for real, per lead-coder/architect co-vet):
+    replacing ``session.notify_turn_cancelled(...)`` at the
+    ``_turn_cancel_self_initiated`` branch in ``Session.run_one_iteration``
+    with a no-op makes ALL 6 of this file's PRE-EXISTING tests stay green
+    (none of arms (a)-(f) exercise ② at all) while
+    ``test_2242_hard_cancel.py``'s own updated assertion goes RED — proving
+    ② had a real but not-self-contained witness. This test closes that gap:
+    the SAME strip makes THIS test go RED on its own, restored clean."""
+    session = _make_hard_cancel_session(
+        agent_name="hard-cancel-3694-agent",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snapshot.json",
+    )
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _hanging_run_turn(user_text: str, chain_id: str) -> None:
+        started.set()
+        await release.wait()
+
+    session._loop_driver.run_turn = _hanging_run_turn  # type: ignore[method-assign]
+
+    await session._put_inbox("user", {"text": "hello", "chain_id": "c-hard-cancel-g"})
+    turn_task = asyncio.create_task(session.run_one_iteration())
+    try:
+        await asyncio.wait_for(started.wait(), timeout=5)
+
+        # The REAL delivery mechanism: cancel_inflight() (NOT a raw
+        # Task.cancel()) — sets _turn_cancel_self_initiated=True FIRST,
+        # which is what gates notify_turn_cancelled's call.
+        result = await session.cancel_inflight()
+        assert "cancel" in result.lower()
+
+        release.set()
+        completed = await asyncio.wait_for(turn_task, timeout=5)
+        assert completed is True
+    finally:
+        release.set()
+
+    (marker,) = [
+        m for m in session.history
+        if m.role == "system" and m.meta.get("kind") == "turn_cancelled"
+    ]
+    assert marker.meta.get("chain_id") == "c-hard-cancel-g"


### PR DESCRIPTION
**[e2e-coder]** — part of #3694 (backend persistence + restore projection). Owner-ratified design (architect, 2026-08-08, revised twice during implementation — see the issue's comment thread).

## Scope of this PR — deliberately not the whole issue

The issue's acceptance criteria require BOTH a live-session marker (RUNNING blink stops, "interrupted by user" shown immediately) AND a restored-after-restart marker. This PR delivers the durable persistence + the restore-time projection — the issue's primary motivating pain point ("restart後、なぜ回答がないのか分からない"). Live-session TUI rendering of the SAME marker during the current session (the `turn_cancelled` audit-event → FlowView, distinct from the persistence problem) is a natural follow-up, not included here — flagging explicitly rather than silently narrowing scope.

## What

A genuinely-cancelled turn gets a first-class, durable history record. Storage shape mirrors `Session.notify_state_change` exactly (same owner ruling — "むやみに増やすべきでない、system あるならそれで": no new role): `role="system"` + `meta={"kind": "turn_cancelled", "chain_id": ...}`. Never reaches the LLM or a compaction candidate set — both already exclude `role="system"` structurally (`build_history`'s allowlist, `force_compact_now`'s own turns filter) — verified directly, not assumed.

## Two independent stamp sites (measured, not assumed to be redundant)

A hard cancel (`cancel_inflight()`'s `Task.cancel()`, the common mid-LLM-call Ctrl+C case) injects `CancelledError` at whatever await the turn was suspended on — this unwinds straight past `RouterLoop.run_loop`'s own cooperative-cancel terminal (zero `CancelledError` handling anywhere in `router_loop.py`, confirmed by grep). `Session.run_one_iteration`'s own catch is the receiver for that case. `RouterLoop.run_loop`'s `if _loop_cancelled:` terminal is the primary path for a cooperative-only cancel (the LLM call itself was never interrupted). Gated on `_turn_cancel_self_initiated` at the `session.py` site — a cancel from something other than `cancel_inflight()` (#3377's survivable-but-unexpected case) must never fabricate a user-cancel record.

## The biggest correction, caught before implementation

Architect's first design draft said "meta is already durable, mutate the existing user turn's meta." Measured that's false: `history.jsonl` has no rewrite path (only `"a"`/`"r"` opens exist anywhere in the codebase — grepped). A cancelled outcome discovered at turn-end cannot be durably recorded by mutating the already-persisted user turn's meta — that mutation would only live in memory and vanish on restart. A NEW entry is the only way to add durable information to an append-only log. Reported before implementing; architect corrected the design in response (full trail in the issue comments).

## restore.py

Rescues the marker from its blanket `role="system"` skip by `meta.kind` specifically — an ordinary `state_change` system entry (a DIFFERENT `meta.kind`, same role) stays skipped, so the rescue can't be mistaken for "let all system entries through" (tested explicitly, both directions).

## Test plan

- [x] Arm (a) — persisted shape matches exactly
- [x] Arm (b) — the real `RouterHistoryBuffer.build_history` wire builder excludes the marker
- [x] Arm (c) — the real `CompactionController._select_candidates` excludes the marker
- [x] Arm (d) — restore rescue by `meta.kind`, falsified against a `state_change` entry staying skipped
- [x] Arm (e) — cooperative-cancel wiring (①) driven through the REAL `RouterLoop.run_loop`, same `FakeRouterHost`/`arm_cancel_after` seam `test_turn_cancel_1468.py` already uses
- [x] Arm (f) — non-fabrication: a real `Task.cancel()` bypassing `cancel_inflight()` (the exact #3377 mechanism, reused from that file) must NOT produce a marker
- [x] Hard-cancel wiring (②) witnessed for real by `tests/test_2242_hard_cancel.py`'s existing end-to-end test, updated in this PR (it previously pinned "only the user message survives a hard cancel" — now correctly "user message + the cancelled-outcome marker")
- [x] Falsify-verified for real throughout: reverting each of (construction shape, the ① append call, the restore.py rescue branch) reddens the corresponding test for the exact predicted reason; all restored clean
- [x] `ruff check` — green
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 11/11 clean
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] `python scripts/mypy_ratchet.py` — green (211 findings, all baselined)
- [x] Targeted regression sweep (`cancel`/`restore`/`state_change`/`3694`/`router_loop_chatsession`/`turn_settled`/`force_close`/`2242`/`3377`/`1468`/`compaction`) — 435 passed, 0 failed
- [x] Full suite deferred to CI per the local-full-pytest-is-CI-only policy

---

- [x] 🔴 **[architect] ②（hard cancel = mid-stream Ctrl+C）の marker に witness がありません。** `session.py` の `self.notify_turn_cancelled(payload.get("chain_id"))` を `pass` に strip しても suite は **6 passed**（①側の strip は `test_cooperative_cancel_persists_the_marker_via_real_router_loop` が RED になるので、非対称です）。この PR 自身が router_loop.py の注釈で「the **MORE COMMON** mid-LLM-call Ctrl+C」と書いた経路であり、#3694 の受け入れ条件「mid-stream `Ctrl+C` 後、…その中断理由を表示できる」がまさにそれです。**①と同じ形の strip-falsify で RED になるテストを 1 本**追加してください（実装は正しく、足りないのはテストだけです）。



> **[architect]** ✅ **blocking 解消を確認しました。** 指定した strip をそのまま再実行: `session.py` の `self.notify_turn_cancelled(payload.get("chain_id"))` を `pass` に置換（anchor 一意 assert / `ast.parse` / 変異あり確認）→ **`test_hard_cancel_via_cancel_inflight_persists_the_marker` が RED**。①側と対称になりました。テストが**本物の経路**を駆動していることも確認（`session.cancel_inflight()` を実際に呼び、`_put_inbox` から turn を回している — fake host に対する緑ではない）。作業ツリーは復元済（差分 0 件）。
