### PR TITLE
fix(#3822): CodeAct reads its child's output through the capped reader

### DIFF
--- a/src/reyn/core/kernel/codeact_runner.py
+++ b/src/reyn/core/kernel/codeact_runner.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable
 
 from reyn.security.sandbox import kill_process_tree
+from reyn.security.sandbox._subprocess_io import communicate_capped
 
 
 def _harness_subprocess_env() -> dict[str, str]:
@@ -167,18 +168,31 @@ class CodeActRunner:
             self._service(parent_sock, dispatch, loop, final_box)
         )
 
-        # ``communicate(input=...)`` writes the request to stdin (the child reads it
-        # fully before touching the control channel), then reads stdout/stderr +
-        # waits. It runs in an executor thread, so the ``service_task`` services the
-        # control channel concurrently on the event loop while the child blocks on a
-        # mid-execution tool() call.
+        # Writes the request to stdin (the child reads it fully before touching the
+        # control channel), then reads stdout/stderr + waits. It runs in an executor
+        # thread, so the ``service_task`` services the control channel concurrently
+        # on the event loop while the child blocks on a mid-execution tool() call.
+        #
+        # ``communicate_capped``, not ``proc.communicate`` (#3822): the same reader
+        # every other command-level launch route already uses, capping each stream
+        # and draining the excess so the child never blocks on a full pipe. Plain
+        # ``communicate`` reads without a bound, and _subprocess_io's own docstring
+        # says why that is not survivable — "emitting unbounded output can OOM the
+        # host BEFORE the wall-clock timeout fires". The 30s timeout below is
+        # therefore not a substitute for the cap; it is the thing the cap exists to
+        # arrive ahead of. This seam is also the one running model-authored code, so
+        # a snippet printing in a loop is an ordinary mistake rather than an exotic
+        # one.
         request_bytes = json.dumps(request).encode("utf-8")
         comm_future = loop.run_in_executor(
-            None, lambda: proc.communicate(input=request_bytes),
+            None, lambda: communicate_capped(proc, input=request_bytes),
         )
         timed_out = False
+        truncated = False
         try:
-            stdout_b, stderr_b = await asyncio.wait_for(comm_future, timeout=timeout)
+            stdout_b, stderr_b, truncated = await asyncio.wait_for(
+                comm_future, timeout=timeout
+            )
         except asyncio.TimeoutError:
             timed_out = True
             service_task.cancel()
@@ -214,8 +228,18 @@ class CodeActRunner:
             final.pop("op", None)
             final["stdout"] = (stdout_b or b"").decode("utf-8", errors="replace")
             final["stderr"] = (stderr_b or b"").decode("utf-8", errors="replace")
+            # Surfaced, never silent (#3822). A cap that drops output without
+            # saying so leaves the reader comparing a truncated stdout against
+            # what they expected and concluding the snippet misbehaved — the
+            # #3688 shape, where a region showed less than it held and the
+            # absence was indistinguishable from the thing never existing.
+            if truncated:
+                final["truncated"] = True
             return final
-        return self._parse_response(stdout_b, stderr_b, proc.returncode)
+        response = self._parse_response(stdout_b, stderr_b, proc.returncode)
+        if truncated and isinstance(response, dict):
+            response["truncated"] = True
+        return response
 
     def _resolve_sandbox_spawn(
         self,

--- a/tests/test_codeact_output_cap_3822.py
+++ b/tests/test_codeact_output_cap_3822.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 
 import inspect
 
+import pytest
+
 from reyn.core.kernel import codeact_runner
+from reyn.core.kernel.codeact_runner import CodeActRunner
 from reyn.security.sandbox import _subprocess_io
+from reyn.security.sandbox._subprocess_io import MAX_SUBPROCESS_OUTPUT_BYTES
 
 
 def test_codeact_reads_through_the_capped_reader() -> None:
@@ -34,4 +38,33 @@ def test_codeact_reads_through_the_capped_reader() -> None:
     assert "proc.communicate(" not in inspect.getsource(codeact_runner), (
         "an uncapped `proc.communicate` read is back — plain communicate reads "
         "without a bound"
+    )
+
+
+@pytest.mark.asyncio
+async def test_hitting_the_cap_is_reported_to_the_caller() -> None:
+    """Tier 2: output past the cap sets ``truncated`` on the result.
+
+    Driven by a REAL child emitting past the real limit — no faked reader, no
+    lowered constant. The cap and the propagation are one behaviour from the
+    caller's side, and a witness that patched either would be testing the patch.
+
+    Why this exists as its own test: the cap swap and this propagation are
+    separate changes that happen to ship together. Strip the swap and the other
+    test goes red; strip only the propagation and, without this, everything
+    stays green while the caller silently stops being told its output was cut —
+    which is the #3688 shape the propagation was added to avoid.
+    """
+    async def dispatch(name: str, args: dict) -> dict:  # pragma: no cover - unused
+        return {"status": "ok", "data": {}}
+
+    over = MAX_SUBPROCESS_OUTPUT_BYTES + 1024
+    code = f"print('x' * {over})\nresult = 'done'"
+    out = await CodeActRunner().run(
+        code=code, dispatch=dispatch, allow_unsandboxed=True, timeout=120.0,
+    )
+
+    assert out.get("truncated") is True, (
+        f"output past the cap was not reported to the caller: "
+        f"{ {k: v for k, v in out.items() if k != 'stdout'} }"
     )

--- a/tests/test_codeact_output_cap_3822.py
+++ b/tests/test_codeact_output_cap_3822.py
@@ -1,0 +1,37 @@
+"""Tier 2: CodeAct reads its child's output through the capped reader (#3822)."""
+from __future__ import annotations
+
+import inspect
+
+from reyn.core.kernel import codeact_runner
+from reyn.security.sandbox import _subprocess_io
+
+
+def test_codeact_reads_through_the_capped_reader() -> None:
+    """Tier 2: the seam that runs model-authored code has the same output cap
+    every other command-level launch route has.
+
+    ``_subprocess_io``'s own docstring is the argument: *"emitting unbounded
+    output can OOM the host BEFORE the wall-clock timeout fires"*. CodeAct's
+    timeout is therefore not a substitute — the cap exists precisely because the
+    timeout arrives too late.
+
+    The first assertion is a BINDING check, not a text match: it asks whether the
+    name the runner will call resolves to the capped reader, which is a fact
+    about the module rather than about how the call happens to be spelled. The
+    second is a text match, and it is here only to catch a second, uncapped read
+    being added alongside the first.
+
+    **Limit, stated rather than papered over**: neither assertion runs a child.
+    Proving the cap behaviourally means emitting more than the limit from a real
+    snippet, which is slow and belongs to ``_subprocess_io``'s own tests — that
+    module owns the cap and tests it. What is checked here is that CodeAct is on
+    that path at all, which is the thing #3822 found it was not.
+    """
+    assert codeact_runner.communicate_capped is _subprocess_io.communicate_capped, (
+        "the runner's `communicate_capped` is not the capped reader"
+    )
+    assert "proc.communicate(" not in inspect.getsource(codeact_runner), (
+        "an uncapped `proc.communicate` read is back — plain communicate reads "
+        "without a bound"
+    )


### PR DESCRIPTION
**[tui-coder]** — The first of #3822's two divergences, the one architect ruled needs no decision.

## The divergence

```
every other command-level launch route   communicate_capped(...)   capped, drains the excess
CodeAct                                  proc.communicate(...)     no bound
```

`_subprocess_io`'s own docstring is the entire argument for why that matters:

> *"emitting unbounded output can OOM the host **before the wall-clock timeout fires**"*

So CodeAct's 30s timeout was never a substitute — **the cap exists because the timeout arrives too
late**. And the seam without it is the one running **model-authored code**, where a snippet printing
in a loop is an ordinary mistake rather than an exotic one.

## Nothing is chosen here

The limit, the drain-and-discard behaviour and the platform dispatch all stay `_subprocess_io`'s.
This only puts CodeAct on the path the rest of reyn is already on — which is why it could land ahead
of the env divergence, where a default does have to be picked.

The socketpair servicing is untouched: it runs on its own task and the reader swap does not reach it.

## `truncated` is surfaced, not dropped

A cap that silently discards output leaves the reader comparing a short stdout against what they
expected and concluding the snippet misbehaved. That is the **#3688 shape** — a region showing less
than it held, with the absence indistinguishable from the thing never existing.

## What is not claimed

**Not** that an OOM was prevented or demonstrated. It has not been. What is claimed is that one seam
had the guard its own module says is necessary and the other did not.

## The gate, and its limit

```python
assert codeact_runner.communicate_capped is _subprocess_io.communicate_capped
assert "proc.communicate(" not in inspect.getsource(codeact_runner)
```

The first is a **binding check** — a fact about what the module will call, not about how the call is
spelled. The second is a text match and is there only to catch a *second*, uncapped read being added
alongside the first.

**The limit is in the test's docstring rather than left for a reviewer to notice**: neither assertion
runs a child. Proving the cap behaviourally means emitting past the limit from a real snippet, which
is slow and belongs to the module that owns the cap and already tests it. What is checked here is
that CodeAct is on that path at all — the thing #3822 found it was not.

**Falsified** by reverting to `proc.communicate`: the gate goes red.

## Test plan

- [x] `pytest tests/test_codeact_output_cap_3822.py` — 1 passed
- [x] **Falsify** — revert to `proc.communicate`: red
- [x] `pytest -k "codeact or subprocess_io or 1593 or 1618 or 3822"` — 102 passed, 6 skipped
- [x] `ruff check src tests` — exit 0
- [x] `python scripts/test_tier_audit.py --strict` — exit 0
- [x] `python scripts/verify_module_docstrings.py` — exit 0
- [x] `python scripts/mypy_ratchet.py` — exit 0
- [x] (skipped — the local full suite is CI's job) **Full `pytest`**
- [x] (skipped — no operator-visible surface changes; `truncated` appears only in a result dict) **Visual**

Part of #3822. The env divergence stays open — it needs a default `env_passthrough`, which is the
owner call architect raised.

---

- [x] 🔴 **[architect] `truncated` の伝播に witness がありません** — addressed in `50dc0db`. A real child now emits past the real limit (`MAX_SUBPROCESS_OUTPUT_BYTES + 1024`) through `CodeActRunner().run(...)`, and the test asserts `out["truncated"] is True`. No faked reader and no lowered constant: from the caller's side the cap and the report are one behaviour, so patching either would have been testing the patch. **Falsified independently of the sibling gate** — stripping only the two propagation lines turns the new test RED and leaves the cap-swap test GREEN, so the two failures say different things. Costs 0.7s. The review was right in substance: I added a guard against silent truncation and left that guard itself unguarded, which is #3688's shape one level up.

