### PR TITLE
docs: record owner's standing waiver for the Visual Test-plan axis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,18 @@ These rules then keep multi-session work coherent:
    Manual / Visual item in the Test plan and tick the box, or replace
    `- [ ]` with `- [x] (skipped — <reason>)`. Reviewers do not merge
    while items are unchecked without an explicit waiver.
+   **Standing waiver, Visual items only (owner, 2026-08-08)**: "見た目
+   ゲートだとしても main マージ進めてよ。そうしないと会社で見れないんだ
+   から" — the operator's only way to actually SEE a visual/TTY result
+   is on `main` (their own execution environment), so waiting for a
+   visual check before merging inverts the real dependency: the check
+   needs the merge, not the other way around. Leave the Visual box
+   unchecked in the Test plan (do not fabricate a check that didn't
+   happen) and merge anyway; the operator confirms after, on `main`,
+   and a follow-up PR fixes anything they flag. **This loosens the
+   Visual axis ONLY.** Falsification, consumer-sweep, and CI gates are
+   unaffected and still block merge exactly as before — this is not a
+   general "a waiver exists somewhere, so merge unchecked" license.
 2. **Role-prefix every issue / PR body / PR comment.** Start the PR
    body AND each follow-up comment with `**[role-name]** — ` (e.g.
    `[lead-coder]`, `[e2e-coder]`, `[tui-coder]`, `[dogfood-coder]`,


### PR DESCRIPTION
**[docs-maintainer]** — Owner ruling (2026-08-08), verbatim, so the source is unambiguous to any reader including the owner: "見た目ゲートだとしても main マージ進めてよ。そうしないと会社で見れないんだから" — proceed with the main merge even for visual gates, since the operator's only way to actually see a visual/TTY result is on main (their own execution environment).

Relayed by tui-coder, who hit exactly this stall themselves — they'd placed a Visual item as blocking and were only unblocked because lead-coder happened to already hold this ruling. A session without it stalls the same way, since the ruling lived only in one peer's memory pin, not in CLAUDE.md — the surface merge decisions actually read.

## Scope, explicitly (tui-coder's request)

This loosens the **Visual axis only**. Falsification, consumer-sweep, and CI gates are unaffected and still block merge exactly as before — this is not a general "a waiver exists somewhere, so merge unchecked" license. Left that scoping line in the addition itself so it can't be read more broadly later.

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean
- [x] `pytest tests/test_3126_doc_anchor_gate.py` — 331/331 pass