### PR TITLE
refactor(#3822): wrap_command() honestly returns env, closing the leak class

### DIFF
--- a/src/reyn/environment/container_backend.py
+++ b/src/reyn/environment/container_backend.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -411,13 +412,29 @@ class DockerEnvironmentBackend:
         'exec "$@"'`` rationale); ``-i`` is always passed (unlike ``run()``,
         which only opens stdin when the caller supplies some) because a
         persistent stdio server holds bidirectional pipes open for its whole
-        lifetime. No cleanup resource is owned (unlike Seatbelt's temp profile)."""
+        lifetime. No cleanup resource is owned (unlike Seatbelt's temp profile).
+
+        ``env``, unlike every other backend's ``wrap_command()`` (#3822): the
+        returned ``argv`` is a HOST-side ``docker`` CLI invocation, not the
+        sandboxed workload itself — the workload's actual env comes from the
+        container IMAGE's own login-shell activation (conda/nvm/pyenv), a
+        deliberate fidelity boundary this class's ``run()`` already documents
+        ("Honors only policy.timeout_seconds"). ``policy.env_passthrough``
+        has no meaning for a host-side ``docker exec`` invocation, so
+        fabricating an allowlisted env here would be inventing a value with
+        nothing to scope. The honest answer for what the HOST ``docker`` CLI
+        itself needs (``DOCKER_HOST`` / ``HOME`` / ``PATH`` / docker config
+        discovery) is "the same as `run()`'s own runners already assume" —
+        neither ``_sync_runner`` nor ``_async_runner`` passes ``env=`` at
+        all, i.e. full host inherit for the CLI call itself. Returning that
+        SAME choice here keeps ``wrap_command()`` and ``run()`` consistent
+        with each other rather than inventing a THIRD, novel policy."""
         wrapped_argv = [
             self.docker_bin, "exec", "-i",
             "-w", self.repo_dir, self.container,
             "bash", "-lc", 'exec "$@"', "reyn-exec", *argv,
         ]
-        return WrappedCommand(argv=wrapped_argv, cleanup=None)
+        return WrappedCommand(argv=wrapped_argv, env=dict(os.environ), cleanup=None)
 
     async def run(
         self, argv: list[str], policy: SandboxPolicy, *, stdin: bytes | None = None,

--- a/src/reyn/security/sandbox/backend.py
+++ b/src/reyn/security/sandbox/backend.py
@@ -23,16 +23,26 @@ class WrappedCommand:
     for a PERSISTENT subprocess launch that the backend does not itself spawn
     (e.g. a stdio MCP server held open by the caller's transport) — the wrap
     prepends whatever the backend needs (a sandbox-exec invocation, a re-exec
-    shim, ...) and hands the full argv back for the caller to Popen/exec.
+    shim, ...) and hands back everything the caller needs to Popen/exec.
 
     ``argv`` is the full wrapped argv (wrapper prefix + the original command),
-    ready to launch directly. ``cleanup``, when set, releases a wrap-owned
-    resource (e.g. Seatbelt's temp ``.sb`` profile file) — the caller MUST
-    invoke it once the wrapped subprocess is torn down. ``None`` means the
-    wrap owns no such resource.
+    ready to launch directly. ``env`` is the allowlisted env every ``run()``
+    implementation already builds via ``resolve_passthrough_env(policy)`` (+
+    the ``PATH`` fallback every backend applies) — added here (#3822) because
+    a caller that only reads ``argv`` has no signal that env is a SEPARATE
+    thing it must also resolve itself, and two separate persistent-process
+    callers (CodeAct #3822, MCP stdio #3848) independently missed exactly
+    that and fell back to inheriting the full parent environment. The old
+    docstring's "hands the full argv back for the caller to Popen/exec" was
+    itself part of the gap: it declared enough for a *safe* exec while
+    actually providing only ARGV. ``cleanup``, when set, releases a
+    wrap-owned resource (e.g. Seatbelt's temp ``.sb`` profile file) — the
+    caller MUST invoke it once the wrapped subprocess is torn down. ``None``
+    means the wrap owns no such resource.
     """
 
     argv: list[str]
+    env: dict[str, str]
     cleanup: "Callable[[], None] | None" = None
 
 

--- a/src/reyn/security/sandbox/backends/landlock.py
+++ b/src/reyn/security/sandbox/backends/landlock.py
@@ -356,13 +356,19 @@ class LandlockBackend:
         Landlock has no CLI wrapper, so the shim (a re-exec-and-restrict-self
         module) IS the command-level wrap — the COMMAND-level analog of the
         Seatbelt ``sandbox-exec -f <profile>`` wrap. No cleanup resource is
-        owned (unlike Seatbelt's temp profile)."""
+        owned (unlike Seatbelt's temp profile). ``env`` is the SAME allowlisted
+        build ``run()`` uses (#3822): the shim itself reads no env (policy
+        travels via argv), so whatever env the caller launches this argv with
+        also reaches the workload unchanged across the shim's ``execvp``."""
         if not argv:
             raise ValueError("wrap_command: argv must be non-empty (command + args)")
         from ..landlock_exec import build_landlock_exec_argv
 
         executable, shim_argv = build_landlock_exec_argv(policy, argv[0], list(argv[1:]))
-        return WrappedCommand(argv=[executable, *shim_argv], cleanup=None)
+        env = resolve_passthrough_env(policy)
+        if "PATH" not in env and "PATH" in os.environ:
+            env["PATH"] = os.environ["PATH"]
+        return WrappedCommand(argv=[executable, *shim_argv], env=env, cleanup=None)
 
     async def run(
         self,

--- a/src/reyn/security/sandbox/backends/seatbelt.py
+++ b/src/reyn/security/sandbox/backends/seatbelt.py
@@ -229,7 +229,9 @@ class SeatbeltBackend:
         launch (e.g. a stdio MCP server, #1344). The SBPL profile is written to a
         temp ``.sb`` file; the returned ``cleanup`` unlinks it — the caller invokes
         it once the wrapped subprocess is torn down (mirrors ``run()``'s own
-        temp-profile lifecycle, above)."""
+        temp-profile lifecycle, above). ``env`` is the SAME allowlisted build
+        ``run()`` uses (#3822) — a caller launching the wrapped argv with this
+        env gets the identical env-scoping ``run()``'s callers get."""
         profile_text = _build_sbpl_profile(policy)
         with tempfile.NamedTemporaryFile(
             suffix=".sb", mode="w", delete=False, encoding="utf-8",
@@ -243,8 +245,13 @@ class SeatbeltBackend:
             except OSError:
                 pass
 
+        env = resolve_passthrough_env(policy)
+        if "PATH" not in env and "PATH" in os.environ:
+            env["PATH"] = os.environ["PATH"]
+
         return WrappedCommand(
             argv=["sandbox-exec", "-f", profile_path, *argv],
+            env=env,
             cleanup=_cleanup,
         )
 

--- a/src/reyn/security/sandbox/noop_backend.py
+++ b/src/reyn/security/sandbox/noop_backend.py
@@ -97,9 +97,13 @@ class NoopBackend:
         """Passthrough: argv is returned UNCHANGED — no enforcement — but the
         call still went THROUGH the sandbox abstraction (the owner-acceptable
         no-isolation case, #2620), as opposed to a caller that never consulted
-        any backend at all."""
+        any backend at all. ``env`` is still the allowlisted build (#3822):
+        no OS isolation is applied on this backend, but the ENV-scoping
+        contract (never hand a model-authored subprocess the full parent
+        environment merely because the sandbox backend is Noop) is unrelated
+        to OS enforcement and stays in force."""
         _warn_once()
-        return WrappedCommand(argv=list(argv), cleanup=None)
+        return WrappedCommand(argv=list(argv), env=_build_env(policy), cleanup=None)
 
     async def run(
         self,

--- a/tests/test_sandbox_argv0_resolve_2820.py
+++ b/tests/test_sandbox_argv0_resolve_2820.py
@@ -291,7 +291,7 @@ class _CapturingBackend:
     def wrap_command(self, argv, policy):  # pragma: no cover - unused
         from reyn.security.sandbox.backend import WrappedCommand
 
-        return WrappedCommand(argv=list(argv))
+        return WrappedCommand(argv=list(argv), env={})
 
     async def run(self, argv, policy, *, stdin=None, cwd=None, cancel_event=None):
         from reyn.security.sandbox.backend import SandboxResult

--- a/tests/test_sandbox_denial_class_2820.py
+++ b/tests/test_sandbox_denial_class_2820.py
@@ -104,7 +104,7 @@ class _ForkDenyingBackend:
     def wrap_command(self, argv, policy):  # pragma: no cover - unused here
         from reyn.security.sandbox.backend import WrappedCommand
 
-        return WrappedCommand(argv=list(argv))
+        return WrappedCommand(argv=list(argv), env={})
 
     async def run(self, argv, policy, *, stdin=None, cwd=None, cancel_event=None):
         return SandboxResult(returncode=128, stdout=b"", stderr=_REAL_FORK_STDERR)

--- a/tests/test_sandbox_wrap_command_2620.py
+++ b/tests/test_sandbox_wrap_command_2620.py
@@ -90,3 +90,56 @@ def test_landlock_wrap_command_uses_reexec_shim():
     sep = wrapped.argv.index("--")
     assert wrapped.argv[sep + 1:] == ["my-server", "--flag"]
     assert wrapped.cleanup is None
+
+
+# ── #3822: wrap_command() honestly returns env, not just argv — every
+# persistent-process caller (CodeAct, MCP stdio) that only reads .argv and
+# separately forgets to call resolve_passthrough_env silently inherits the
+# full parent environment (#3822's own finding, twice). These pin that
+# wrap_command's env matches the SAME allowlist run() already uses, for
+# every backend that implements it. ──────────────────────────────────────
+
+
+def test_noop_wrap_command_env_does_not_leak_an_unpassthroughed_var(monkeypatch):
+    """Tier 2: #3822 — a parent env var NOT in the policy allowlist / standard
+    network set does not reach wrapped.env, even on NoopBackend (no OS
+    isolation, but the env-scoping contract is unrelated to OS enforcement).
+    Strip the resolve_passthrough_env call in NoopBackend.wrap_command and
+    this goes RED."""
+    monkeypatch.setenv("REYN_3822_WRAP_TEST_MARKER", "should-not-leak")
+    backend = NoopBackend()
+    wrapped = backend.wrap_command(["cmd"], SandboxPolicy())
+    assert "REYN_3822_WRAP_TEST_MARKER" not in wrapped.env
+
+
+def test_seatbelt_wrap_command_env_does_not_leak_an_unpassthroughed_var(monkeypatch):
+    """Tier 2: #3822 — same invariant as the Noop case above, for Seatbelt."""
+    monkeypatch.setenv("REYN_3822_WRAP_TEST_MARKER", "should-not-leak")
+    backend = SeatbeltBackend()
+    wrapped = backend.wrap_command(["cmd"], SandboxPolicy())
+    assert "REYN_3822_WRAP_TEST_MARKER" not in wrapped.env
+    wrapped.cleanup()
+
+
+def test_landlock_wrap_command_env_does_not_leak_an_unpassthroughed_var(monkeypatch):
+    """Tier 2: #3822 — same invariant as the Noop case above, for Landlock."""
+    monkeypatch.setenv("REYN_3822_WRAP_TEST_MARKER", "should-not-leak")
+    backend = LandlockBackend()
+    wrapped = backend.wrap_command(["cmd"], SandboxPolicy())
+    assert "REYN_3822_WRAP_TEST_MARKER" not in wrapped.env
+
+
+def test_wrap_command_env_honors_a_declared_passthrough_name(monkeypatch):
+    """Tier 2: #3822 — a name IN policy.env_passthrough DOES reach wrapped.env
+    (the allowlist gates, it does not blanket-deny) — checked once across all
+    3 real backends so the positive and negative directions both have a
+    witness, not just the negative one above."""
+    monkeypatch.setenv("REYN_3822_WRAP_TEST_ALLOWED", "should-pass-through")
+    policy = SandboxPolicy(env_passthrough=["REYN_3822_WRAP_TEST_ALLOWED"])
+    for backend in (NoopBackend(), SeatbeltBackend(), LandlockBackend()):
+        wrapped = backend.wrap_command(["cmd"], policy)
+        assert wrapped.env.get("REYN_3822_WRAP_TEST_ALLOWED") == "should-pass-through", (
+            f"{backend.name}: declared env_passthrough name did not reach wrapped.env"
+        )
+        if wrapped.cleanup is not None:
+            wrapped.cleanup()


### PR DESCRIPTION
**[e2e-coder]** — part of #3822 (structural follow-up to the measurement comment; independent of #3848's policy-content decision, per lead-coder's framing — "何を渡すか" vs "渡し忘れられるか" are separate axes).

## Summary
`SandboxBackend` has two abstraction levels: `run()` (one-shot, always builds env via `resolve_passthrough_env`) and `wrap_command()` (argv-only — for a PERSISTENT process the backend doesn't itself spawn). Any `wrap_command()`-only caller had to separately remember to call `resolve_passthrough_env` itself, or it silently inherited the full parent environment. Two independent callers forgot: CodeAct (#3843) and MCP stdio (#3848). Per the owner's standing "close the class, not the instance, time/behavior-change both allowed" policy, this closes the CLASS so a third caller can't repeat the same silent omission.

- `WrappedCommand.env` is now a **required** field (no default) — every construction site must supply it, so a future caller cannot construct a `WrappedCommand` while silently omitting env the way the first two did.
- Seatbelt / Landlock / Noop: `wrap_command()` now populates `env` via `resolve_passthrough_env(policy)` + the same `PATH` fallback every backend's `run()` already applies — byte-identical env-scoping to what `run()`'s own callers get.
- Docker backend: deliberately different. The returned `argv` is a HOST-side `docker exec` invocation, not the sandboxed workload — the workload's env comes from the container image's own login-shell activation (`run()`'s own documented fidelity boundary, "Honors only policy.timeout_seconds"). Fabricating an allowlisted env here would scope a value meaningless at this level, so it returns `dict(os.environ)`, matching what `run()`'s own runners already assume (neither `_sync_runner` nor `_async_runner` passes `env=` at all).

## Enumeration (repo-wide grep, not sampling)
Exactly 4 `wrap_command()` implementations (Seatbelt/Landlock/Noop/Docker) and exactly 2 real, agent-reachable, production `wrap_command()`-only callers total: CodeAct and MCP stdio — both already accounted for (fixed / owner-gated). `self_test.py`'s production probe also calls `wrap_command()` but is not agent-facing and deliberately passes its own minimal `env={"PATH": ...}`, unaffected by this change since it never reads `.env`.

## Witness
`tests/test_sandbox_wrap_command_2620.py` gets 4 new tests: negative-direction leak check for each of the 3 allowlisted backends (Noop/Seatbelt/Landlock), plus one positive-direction check (a declared `env_passthrough` name reaches `wrapped.env` across all 3) so the gate isn't just "always empty". All 3 negative-direction tests independently falsify-verified: reverted each backend's fix in turn, confirmed RED for the exact marker-leak reason, restored.

Two pre-existing test-double `WrappedCommand(argv=list(argv))` construction sites (in `test_sandbox_denial_class_2820.py` / `test_sandbox_argv0_resolve_2820.py`, both explicitly marked `# pragma: no cover - unused here`) updated to `env={}` to satisfy the new required field — no behavior change, `wrap_command` is never called in those specific tests.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 34/34 OK, 0 Tier-4 violations
- [x] `pytest` across every file touching `WrappedCommand`/`wrap_command`/`container_backend` (23 files) — 223 passed, 24 skipped (platform-gated Landlock/Seatbelt tests, pre-existing)
- [x] 3 negative-direction witnesses independently falsify-verified (see above)
- [x] Repo-wide grep for every `WrappedCommand(` construction site — all updated, none missed
- [x] Noted: 3 unrelated pre-existing test files (`test_1200_chat_fs_backend.py`, `test_1289_frontend_container_chat.py`, `test_container_backend_1115_stage2.py`) fail collection with a circular-import error when run in isolation — reproduced identically on a clean `git stash` of this change, confirmed pre-existing and unrelated, not touched by this PR

---

**[lead-coder]** — ⚠️ **着地時点で `WrappedCommand.env` は、どの consumer にも読まれていません。** architect と e2e-coder の実測（consumer 全数 2 つ）:

```
codeact_runner.py:320-324  wrapped.argv, wrapped.cleanup, None, policy を返す
                           → env は返り値に含まれない
                             （policy を返して _harness_subprocess_env が後で再計算）
mcp/client.py:1489         argv だけを 2-tuple に射影
```

∴ **このフィールドは「必須で、4 実装すべてが正しく埋め、テストに守られている」が、誰も読んでいません。**

**それでもこの PR に価値があるのは、閉じたものが「忘れる」だからです** — 3 本目の
呼び出しが env を省略すると構築時に落ちます。閉じていないのは「構築してから捨てる」で、
**#3848 の 1 段目がそれを閉じます**（seam が env を運ぶ形にする)。

🔴 **次にここを読む人へ: 「必須にしたのに誰も読まない」を「だから消してよい」と
読まないでください。** 読まれるようになるのは #3848 の 1 段目です。
