### PR TITLE
fix(#3616): a failed yank says so instead of returning a bool nobody reads

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2284,15 +2284,35 @@ class TextualChatApp(App):
 
         Synchronous by contract (flowview calls it inside ``yank``), so this
         uses the blocking helper rather than the async one — the shell-out is a
-        single short-lived subprocess. Returns whether a tool actually accepted
-        the text, which is what lets a failed yank be reported rather than
-        silently look like it worked (OSC 52, the default, cannot be
-        acknowledged at all)."""
+        single short-lived subprocess.
+
+        REPORTS its own failure rather than only returning it. The bool is
+        returned because the sink contract has one, but nothing upstream reads
+        it: flowview's ``action_yank`` calls ``yank()`` and discards the value,
+        so a bool alone reaches no one. Without the report a yank onto a machine
+        with no clipboard backend is indistinguishable from a yank that worked —
+        the user presses ``y``, the selection clears, and nothing says the
+        clipboard is unchanged. That is the failure mode #3616 exists for: the
+        operator's own report came through THIS path (copy mode ``c`` -> ``y``),
+        not the entry copy, and their acceptance test is a real-machine copy on
+        a Windows shell where a missing backend is a live possibility.
+
+        Failure only. A successful yank already shows itself — the selection
+        clears — so a "copied" line per yank would be noise on the one path a
+        user repeats. The wording matches the entry-copy path
+        (:meth:`on_flow_view_entry_copied`) so the two sinks do not describe the
+        same outcome two different ways."""
+        from reyn.runtime.outbox import OutboxMessage
+
         try:
             ok = copy_to_clipboard(text)
         except Exception:
             logger.exception("textual chat: yank clipboard write failed")
-            return False
+            ok = False
+        if not ok:
+            self._ingest_frame(
+                OutboxMessage(kind="status", text="clipboard copy failed")
+            )
         return ok
 
     def action_close_drawer(self) -> None:

--- a/tests/test_yank_failure_is_visible_3616.py
+++ b/tests/test_yank_failure_is_visible_3616.py
@@ -1,0 +1,125 @@
+"""Tier 2: a yank whose clipboard write fails SAYS SO (#3616).
+
+``_write_clipboard`` returns a bool, and the sink contract has one — but nothing
+upstream reads it. flowview's ``action_yank`` calls ``yank()`` and discards the
+value, so a bool alone reaches no one. Before this, a yank on a machine with no
+clipboard backend was indistinguishable from a yank that worked: the user
+presses ``y``, the selection clears, and the clipboard silently still holds
+whatever it held before.
+
+That is the path #3616's own acceptance test runs down. The operator's report
+came through copy mode (``c`` -> ``y``), not the entry copy — and the entry copy
+is the one that already reports both outcomes. Two call sites, one sink, one of
+them mute, and the mute one is the one being tested by hand on a Windows shell
+where a missing backend is a live possibility.
+
+The failure is REAL, not simulated: ``pyperclip.set_clipboard("no")`` is
+pyperclip's own public API for "no backend available", the same technique
+``test_clipboard_pyperclip_3616.py`` uses to exercise the same state. Nothing
+about reyn's own code is patched — the app, the sink and the message pump are
+all the production ones.
+"""
+from __future__ import annotations
+
+import os
+import stat
+
+import pytest
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from tests.test_textual_chat_copy_rewind_3362 import (
+    ScriptedTransport,
+    _PickerReadModel,
+    _texts,
+)
+
+
+@pytest.fixture()
+def no_clipboard_backend():
+    """Force pyperclip into its documented no-backend state, and restore.
+
+    The chosen backend lives in pyperclip's module-level globals and otherwise
+    persists for the life of the process, so leaving it set would follow this
+    test into every later one in the same session.
+    """
+    import pyperclip
+
+    original_copy, original_paste = pyperclip.copy, pyperclip.paste
+    pyperclip.set_clipboard("no")
+    try:
+        yield
+    finally:
+        pyperclip.copy, pyperclip.paste = original_copy, original_paste
+
+
+@pytest.mark.asyncio
+async def test_a_failed_yank_reports_instead_of_going_quiet(no_clipboard_backend):
+    """Tier 2: with no clipboard backend, the yank sink puts a failure line in
+    the conversation rather than returning a bool nobody reads."""
+    app = TextualChatApp(transport=ScriptedTransport([]), read_model=_PickerReadModel())
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        ok = app._write_clipboard("何かをコピーした")
+        await pilot.pause()
+
+        assert ok is False, "the sink reported success with no backend available"
+        assert any("clipboard copy failed" in t for t in _texts(app)), (
+            f"the failed yank said nothing — the user cannot tell it from a "
+            f"successful one: {_texts(app)}"
+        )
+
+
+@pytest.fixture()
+def working_clipboard(tmp_path, monkeypatch):
+    """A REAL ``xclip`` on ``PATH`` recording its stdin, with pyperclip pinned to
+    it via the public ``set_clipboard`` API.
+
+    Same arrangement as ``test_clipboard_pyperclip_3616.py``'s ``fake_xclip``,
+    and for the same two reasons: CI hosts have no system clipboard, and
+    pyperclip's auto-detection is PLATFORM-gated (it only tries ``pbcopy`` on
+    Darwin), so pinning the backend is what makes one fake binary work on both
+    the macOS dev host and Linux CI. Duplicated rather than imported — a pytest
+    fixture in another test module is not importable, and moving it to a
+    conftest would widen its blast radius to every test in the tree for the sake
+    of one reuse.
+    """
+    import pyperclip
+
+    original_copy, original_paste = pyperclip.copy, pyperclip.paste
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    sink = tmp_path / "clip.txt"
+    script = bindir / "xclip"
+    script.write_text(
+        "#!/bin/sh\n/bin/cat > " + str(sink) + ".part\n"
+        "/bin/mv " + str(sink) + ".part " + str(sink) + "\n"
+    )
+    script.chmod(script.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setenv("PATH", str(bindir) + os.pathsep + os.environ["PATH"])
+    pyperclip.set_clipboard("xclip")
+    try:
+        yield lambda: sink.read_text() if sink.exists() else None
+    finally:
+        pyperclip.copy, pyperclip.paste = original_copy, original_paste
+
+
+@pytest.mark.asyncio
+async def test_a_successful_yank_stays_quiet(working_clipboard):
+    """Tier 2: success adds no line.
+
+    The selection clearing is already the acknowledgement, and ``y`` is the one
+    action a user repeats — a "copied" line per yank would push the conversation
+    up on every press. This is the half a report-everything implementation gets
+    wrong, and the failure test above cannot see it.
+    """
+    app = TextualChatApp(transport=ScriptedTransport([]), read_model=_PickerReadModel())
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        before = list(_texts(app))
+        ok = app._write_clipboard("copied fine")
+        await pilot.pause()
+
+        assert ok is True, "the real backend did not accept the text"
+        assert _texts(app) == before, f"a successful yank added a line: {_texts(app)}"


### PR DESCRIPTION
**[tui-coder]** — part of #3616. The arc's remaining item is the operator's real-machine copy test, and the path it runs down had no way to fail visibly.

## The defect

```
flowview  action_yank():  self.yank()          <- the bool is discarded
          yank():         self.write_clipboard(text)   <- returns bool
reyn      _write_clipboard(): returns whether the write succeeded
          docstring:  "...which is what lets a failed yank be reported rather
                       than silently look like it worked"
```

**Nothing reports it.** The sink returns a bool up a call chain that throws it away, so a yank on a machine with no clipboard backend is indistinguishable from one that worked: press `y`, the selection clears, the clipboard silently still holds what it held before. The docstring describes a capability the wiring does not deliver — the same shape as #3821's "never silently unsandboxed".

## Why this path specifically

The two call sites into this sink are not symmetric:

```
entry copy (on_flow_view_entry_copied)   reports BOTH outcomes  ("copied to clipboard" / "clipboard copy failed")
yank       (_write_clipboard)            reported NEITHER
```

And the mute one is the one under test by hand: the operator's report came through copy mode (`c` -> `y`), which I traced on this issue after ① landed. Their acceptance test is a real copy on a company Windows shell — where a missing pyperclip backend is a live possibility, not a hypothetical.

## Failure only, deliberately

A successful yank already acknowledges itself by clearing the selection, and `y` is the one action a user repeats. A "copied" line per press would push the conversation up every time. The wording matches the entry-copy path so one sink does not describe the same outcome two ways.

## Witnesses

Real app, real sink, real message pump. The failure is produced by `pyperclip.set_clipboard("no")` — pyperclip's own public API for the no-backend state, the same technique the existing `test_clipboard_pyperclip_3616.py` uses. Nothing of reyn's is patched.

Both arms falsified independently, each against a committed tree, and they fail for different reasons:

```
remove the report entirely   ->  only the failure test RED
make the report unconditional ->  only the "stays quiet" test RED
```

The second arm exists because a report-everything implementation passes the first test completely.

## Test plan

- [x] Manual: `pytest tests/test_yank_failure_is_visible_3616.py tests/test_clipboard_pyperclip_3616.py tests/test_textual_chat_copy_rewind_3362.py` -> 16 passed
- [x] Manual: both falsify arms above, each against a committed tree, each killing a different test
- [x] Manual: `ruff check src tests` -> All checks passed; `test_tier_audit.py --strict` -> 2/2 OK; `verify_module_docstrings.py` -> OK
- [x] The docstring now states what is true, including that the bool is returned for the contract's sake and read by no one
- [ ] Visual: operator confirms on their own machine that a failed copy now says so. Left unchecked per CLAUDE.md rule 1's standing Visual waiver — this needs `main` to be seen at all, and it is precisely the diagnostic that was missing from #3616's own acceptance step

## Not in scope

② (mouse selection -> the same sink) is still owner-held. This changes nothing about which paths reach the sink — only what happens when one of them fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
