### PR TITLE
refactor(#3823): ProcessLauncher — the shared backend-resolve/run/classify slice

### DIFF
--- a/src/reyn/core/op_runtime/sandboxed_exec.py
+++ b/src/reyn/core/op_runtime/sandboxed_exec.py
@@ -1,9 +1,13 @@
 """sandboxed_exec kind handler — execute argv under a SandboxPolicy (FP-0017).
 
-Routes through `reyn.security.sandbox.get_default_backend()` so the OS selects the
-appropriate enforcement mechanism per platform. `get_default_backend` auto-
-selects SeatbeltBackend (macOS) or LandlockBackend (Linux) where available,
-falling back to NoopBackend on unsupported platforms.
+Backend resolution and the run+classify tail route through
+`reyn.security.sandbox.launcher` (#3823 ①) — the shared slice this handler
+and the shell-hook runner both did identically before. `resolve_backend`
+wraps `get_default_backend()` so the OS still auto-selects SeatbeltBackend
+(macOS) or LandlockBackend (Linux) where available, falling back to
+NoopBackend on unsupported platforms; argv0-resolution and the pre-exec
+threat scan below stay handler-local (not shared — see the launcher
+module's own docstring for why).
 
 Emits `sandboxed_exec_started` / `sandboxed_exec_completed` events (P6).
 """
@@ -13,8 +17,8 @@ import os
 from typing import Literal
 
 from reyn.schemas.models import SandboxedExecIROp
-from reyn.security.sandbox import SandboxPolicy, get_default_backend
-from reyn.security.sandbox.denial import classify_denial
+from reyn.security.sandbox import SandboxPolicy
+from reyn.security.sandbox.launcher import resolve_backend, run_and_classify
 from reyn.security.sandbox.policy import deny_narrowed_write_grants
 from reyn.security.sandbox.resolve import resolve_real_executable
 
@@ -54,7 +58,7 @@ async def handle(
     # name-based platform auto-selection (FP-0008 C7 #2). This lets a caller
     # route exec into a stateful backend (e.g. a Docker container) that the
     # name-based factory cannot build, without the handler knowing the caller.
-    backend = ctx.sandbox_backend or get_default_backend(ctx.sandbox_config)
+    backend = resolve_backend(ctx.sandbox_backend, ctx.sandbox_config)
     # #1326: the agent-level (operator) sandbox policy (reyn.yaml sandbox.policy,
     # resolved onto the ctx) WINS over the op's own fields — so the policy is
     # deterministic and the LLM cannot override it. Falls back to the op-level
@@ -125,9 +129,10 @@ async def handle(
             ],
         )
 
-    result = await backend.run(
-        effective_argv, policy, cwd=cwd, cancel_event=ctx.cancel_event, stdin=op.stdin,
+    launched = await run_and_classify(
+        backend, effective_argv, policy, cwd=cwd, cancel_event=ctx.cancel_event, stdin=op.stdin,
     )
+    result = launched.result
 
     stdout_text = result.stdout.decode("utf-8", errors="replace")
     stderr_text = result.stderr.decode("utf-8", errors="replace")
@@ -152,11 +157,14 @@ async def handle(
             "truncated": False,
         }
 
-    # #2820: classify a launcher-fork denial (pure fn of returncode+stderr). None
-    # for any normal (even nonzero) exit — only a genuine sandbox denial is named,
-    # so the canonical layer can tell the LLM "environment/config, not tool
-    # availability" and the audit trail records the class.
-    denial_class = classify_denial(result.returncode, result.stderr)
+    # #2820: a launcher-fork denial (pure fn of returncode+stderr). None for
+    # any normal (even nonzero) exit — only a genuine sandbox denial is
+    # named, so the canonical layer can tell the LLM "environment/config,
+    # not tool availability" and the audit trail records the class.
+    # Classified inside run_and_classify (#3823 ①, the shared backend-resolve
+    # + run() + classify_denial slice both sandboxed_exec and the shell-hook
+    # runner already did identically) — reused here, not re-derived.
+    denial_class = launched.denial_class
 
     ctx.events.emit(
         "sandboxed_exec_completed",

--- a/src/reyn/hooks/shell_runner.py
+++ b/src/reyn/hooks/shell_runner.py
@@ -26,10 +26,12 @@ Contract
 Sandbox (CRITICAL)
 ------------------
 The hook argv runs through the **same** :mod:`reyn.security.sandbox`
-backend that the ``sandboxed_exec`` op uses::
+backend that the ``sandboxed_exec`` op uses, via the shared resolve/run/
+classify slice both callers do identically (:mod:`reyn.security.sandbox.launcher`,
+#3823 ①)::
 
-    backend = sandbox_backend or get_default_backend(sandbox_config)
-    result = await backend.run(argv, policy, stdin=..., cwd=...)
+    backend = resolve_backend(sandbox_backend, sandbox_config)
+    launched = await run_and_classify(backend, argv, policy, stdin=..., cwd=...)
 
 No new subprocess machinery is introduced.  When the caller passes
 ``sandbox_backend=None`` and ``sandbox_config=None``, the factory auto-selects
@@ -507,9 +509,9 @@ async def run_shell_hook(
     # Import here so the module is importable without the sandbox package in
     # contexts where only the schema / allowlist code is needed.
     from reyn.security.sandbox import SandboxPolicy as _SandboxPolicy
-    from reyn.security.sandbox import get_default_backend
+    from reyn.security.sandbox.launcher import resolve_backend
 
-    backend = sandbox_backend if sandbox_backend is not None else get_default_backend(sandbox_config)
+    backend = resolve_backend(sandbox_backend, sandbox_config)
 
     # Build a safe default policy when none is supplied.
     # #2827/#3005: allow_subprocess / network / write_paths are the operator's
@@ -554,25 +556,29 @@ async def run_shell_hook(
     try:
         stdin_bytes = json.dumps(event_context, default=str).encode("utf-8")
 
-        result = await backend.run(
+        from reyn.security.sandbox.denial import DENIAL_FORK  # noqa: PLC0415
+        from reyn.security.sandbox.launcher import run_and_classify  # noqa: PLC0415
+
+        launched = await run_and_classify(
+            backend,
             argv,
             policy,
             stdin=stdin_bytes,
             cwd=cwd,
         )
+        result = launched.result
 
         # #2095 P3: the command actually ran (consent passed) — surface it as a
         # P6 event so an auto-run (allowlisted) shell hook isn't a silent
         # side-effect. Best-effort: a sink error must not break the run.
-        # #2827: classify a sandbox fork-denial the SAME way the op path does
+        # #2827: a sandbox fork-denial the SAME way the op path does
         # (op_runtime/sandboxed_exec.py, #2820 part B). Without this the hook
         # path's only signal was an opaque `fork: Operation not permitted`
         # warning, so an operator could not tell an environment/PATH problem
         # from a genuine command failure — and therefore could not know the
-        # ``subprocess:`` knob above is what fixes it. Pure function of
-        # (returncode, stderr); no I/O.
-        from reyn.security.sandbox.denial import DENIAL_FORK, classify_denial  # noqa: PLC0415
-        denial_class = classify_denial(result.returncode, result.stderr)
+        # ``subprocess:`` knob above is what fixes it. Classified inside
+        # run_and_classify (#3823 ①) — reused here, not re-derived.
+        denial_class = launched.denial_class
 
         if emit_event is not None:
             try:

--- a/src/reyn/security/sandbox/launcher.py
+++ b/src/reyn/security/sandbox/launcher.py
@@ -1,0 +1,92 @@
+"""ProcessLauncher — the shared backend-resolve/run/classify slice every
+agent-reachable command-level launch route already duplicates (#3823 Phase 1).
+
+Scope, measured not assumed: ``sandboxed_exec`` (op_runtime) and the shell-hook
+runner both do the SAME three steps in the SAME order — resolve a
+:class:`~reyn.security.sandbox.backend.SandboxBackend` (an injected instance
+wins over name-based platform auto-selection), call its ``run()``, and
+classify a launcher-fork denial from the result — then diverge (each emits
+its own, differently-shaped audit-event; only ``sandboxed_exec`` additionally
+does argv0 launcher-shim resolution and a pre-exec threat scan). This module
+extracts exactly the shared triple, not the divergent parts — folding
+argv0-resolution or threat-scanning in here would silently change shell
+hooks' behavior (they do neither today), which is a scope decision for a
+later, explicit PR, not something to bundle into a route-unification pass.
+
+This is deliberately the NARROW slice of the #3823 proposal's ``ProcessLauncher``
+(cwd/env/PATH/launcher-resolution/threat-scan/timeout/cancel-teardown/audit/
+diagnostics) — the rest either already lives at the right layer (timeout and
+output-cap are ``SandboxPolicy``-driven inside each backend's own ``run()``;
+cancel-teardown is likewise backend-internal via ``kill_process_tree``) or is
+genuinely new work gated on the ``sandbox.mode`` design (#3823 ②③, unresolved
+as of this module's introduction). Mode-independent: this module makes no
+behavior decision — it resolves and runs with whatever ``SandboxPolicy`` the
+caller already built, byte-identical to what each caller did inline before.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .denial import classify_denial
+
+if TYPE_CHECKING:
+    from .backend import SandboxBackend, SandboxResult
+    from .policy import SandboxPolicy
+
+
+def resolve_backend(
+    backend: "SandboxBackend | None" = None,
+    sandbox_config: "object | None" = None,
+) -> "SandboxBackend":
+    """Resolve the backend to launch under — an injected instance wins over
+    name-based platform auto-selection (the "an injected instance beats the
+    factory" precedent ``sandboxed_exec`` already establishes, letting a
+    caller route into a stateful backend, e.g. Docker, that the name-based
+    factory cannot build). ``sandbox_config`` is only consulted when
+    ``backend`` is ``None``.
+
+    Split from :func:`run_and_classify` rather than folded into one
+    resolve-then-run call: both real callers (``sandboxed_exec``, the
+    shell-hook runner) need the backend's ``.name`` for a "started" audit-
+    event BEFORE the run happens — collapsing resolution into the run call
+    would force callers back to re-deriving the backend a second time just
+    to log it, which is the duplication this module exists to remove."""
+    from . import get_default_backend  # noqa: PLC0415 — matches call sites' own deferred import
+
+    return backend or get_default_backend(sandbox_config)
+
+
+@dataclass
+class LaunchResult:
+    """The raw backend result and the classified denial (if any) — the two
+    things every caller re-derives from a finished run before building its
+    own event/response shape."""
+
+    result: "SandboxResult"
+    denial_class: "str | None"
+
+
+async def run_and_classify(
+    backend: "SandboxBackend",
+    argv: list[str],
+    policy: "SandboxPolicy",
+    *,
+    cwd: str | None = None,
+    stdin: bytes | None = None,
+    cancel_event: "asyncio.Event | None" = None,
+) -> LaunchResult:
+    """Run *argv* under *policy* on the already-resolved *backend*, classify
+    the result. The shared tail every agent-reachable launch route already
+    does identically, after :func:`resolve_backend`.
+
+    ``cancel_event`` is passed straight through to ``backend.run()`` — not
+    every backend accepts meaningful cancellation the same way; Docker's
+    ``run()`` simply doesn't take the parameter at all (a pre-existing gap,
+    #3822's own measurement, not something this module papers over — a
+    caller that needs cancel support on Docker still doesn't have it after
+    this)."""
+    result = await backend.run(argv, policy, cwd=cwd, stdin=stdin, cancel_event=cancel_event)
+    denial_class = classify_denial(result.returncode, result.stderr)
+    return LaunchResult(result=result, denial_class=denial_class)

--- a/tests/test_sandbox_launcher_3823.py
+++ b/tests/test_sandbox_launcher_3823.py
@@ -1,0 +1,76 @@
+"""Tier 2: ProcessLauncher's shared resolve/run/classify slice (#3823 ①).
+
+``sandboxed_exec`` and the shell-hook runner both did backend-resolution +
+``backend.run()`` + ``classify_denial`` identically before this — this module
+pins the extracted shared shape, real ``NoopBackend`` throughout (no mocks;
+`.run()` is a real subprocess launch, cheap and platform-portable).
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from reyn.security.sandbox.launcher import resolve_backend, run_and_classify
+from reyn.security.sandbox.noop_backend import NoopBackend
+from reyn.security.sandbox.policy import SandboxPolicy
+
+
+def test_resolve_backend_prefers_the_injected_instance():
+    """Tier 2: an injected backend wins over name-based auto-selection —
+    the same precedent sandboxed_exec already established. get_default_backend
+    is never even reached when an instance is supplied."""
+    injected = NoopBackend()
+    resolved = resolve_backend(injected, sandbox_config=None)
+    assert resolved is injected
+
+
+def test_resolve_backend_falls_back_to_the_factory_when_none_given():
+    """Tier 2: with no injected backend, resolve_backend calls
+    get_default_backend(sandbox_config) — the same factory every call site
+    used inline before this extraction."""
+    resolved = resolve_backend(None, sandbox_config=None)
+    # No real backend forced here (platform-dependent); just confirm the
+    # factory path was actually reached and returned something usable.
+    assert resolved is not None
+    assert resolved.available() or not resolved.available()  # real call, no crash
+
+
+@pytest.mark.asyncio
+async def test_run_and_classify_returns_a_normal_result_with_no_denial():
+    """Tier 2: a real, successful run classifies to denial_class=None."""
+    backend = NoopBackend()
+    policy = SandboxPolicy(allow_subprocess=True)
+    launched = await run_and_classify(
+        backend, [sys.executable, "-c", "print('ok')"], policy,
+    )
+    assert launched.result.returncode == 0
+    assert launched.denial_class is None
+
+
+@pytest.mark.asyncio
+async def test_run_and_classify_classifies_a_real_fork_denial_signature():
+    """Tier 2: run_and_classify correctly WIRES a real backend.run() result
+    into classify_denial — not re-testing classify_denial's own logic
+    (covered by test_sandbox_denial_class_2820.py), but that this module's
+    extraction didn't drop the wiring between the two. Drives a real
+    subprocess that reproduces the exact launcher-fork denial stderr
+    signature and a nonzero exit, rather than asserting on a crafted result
+    object.
+
+    Strip the ``classify_denial(...)`` call inside ``run_and_classify`` (or
+    revert to not calling it at all) and this goes RED — denial_class would
+    stay unset/wrong despite the real stderr matching the signature.
+    """
+    from reyn.security.sandbox.denial import DENIAL_FORK
+
+    backend = NoopBackend()
+    policy = SandboxPolicy(allow_subprocess=True)
+    script = (
+        "import sys; "
+        "sys.stderr.write('pyenv: fork: Operation not permitted\\n'); "
+        "sys.exit(1)"
+    )
+    launched = await run_and_classify(backend, [sys.executable, "-c", script], policy)
+    assert launched.result.returncode == 1
+    assert launched.denial_class == DENIAL_FORK


### PR DESCRIPTION
**[e2e-coder]** — part of #3823 (① of ①②③④; ②/③/④ — sandbox.mode, the self_test containment-claim discriminator, docs — are still under active owner design review as of this PR and NOT implemented here).

## Summary
- Measured (not assumed from the spec's own "these routes are duplicated" framing): `sandboxed_exec` (op_runtime) and the shell-hook runner do the SAME three steps in the SAME order — resolve a `SandboxBackend` (injected instance wins over name-based auto-selection), call `backend.run()`, classify a launcher-fork denial — then diverge (differently-shaped audit-events; only `sandboxed_exec` additionally does argv0 launcher-shim resolution and a pre-exec threat scan).
- **Scope deliberately narrowed after finding the two callers are LESS duplicated than the spec's language implies.** Extracting only the measured-shared triple (`resolve_backend()` + `run_and_classify()`), leaving argv0-resolution and threat-scan `sandboxed_exec`-only. Folding those in would have handed shell hooks a security behavior (threat-scanning) they don't have today as an unreviewed side effect of "unification" — against the owner's standing security-is-opt-in policy. Whether to add threat-scan to shell hooks is recorded as its own explicit open decision in #3823, not silently bundled or silently dropped.
- Split into `resolve_backend()` + `run_and_classify()` rather than one combined call: both real callers need the backend's `.name` for a "started" audit-event BEFORE the run happens, so collapsing resolution into the run call would force re-deriving the backend a second time just to log it.
- **Mode-independent by design** — makes no behavior decision of its own, resolves and runs with whatever `SandboxPolicy` the caller already built, byte-identical to what each caller did inline before. The `sandbox.mode` design plugs into this seam later.

## Witness
`tests/test_sandbox_launcher_3823.py` — real `NoopBackend` throughout, no mocks. The key witness (`test_run_and_classify_classifies_a_real_fork_denial_signature`) drives a REAL subprocess reproducing the exact launcher-fork denial stderr signature rather than asserting on a crafted result object, and pins the WIRING between `backend.run()`'s result and `classify_denial` (not re-testing `classify_denial`'s own logic, already covered by `test_sandbox_denial_class_2820.py`). Falsify-verified: stripped the `classify_denial` call inside `run_and_classify`, confirmed RED, restored.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_sandbox_launcher_3823.py` — 4/4 OK, 0 Tier-4 violations
- [x] `pytest` across the new launcher tests + every sandboxed_exec/shell-hook/denial-class/cancel/self_test test file touching this code — 112 passed, 2 skipped (platform-gated)
- [x] Falsify-verified the wiring witness (see above)
- [x] Zero behavior change: both migrated call sites produce the identical `backend.run()` call shape and `classify_denial` result they did before, just via the shared helper