### PR TITLE
feat(#3796): a full-viewport text effect on ctrl+l, toggled by the same key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,6 +258,14 @@ voice = [
     "sounddevice>=0.4.6",
     "faster-whisper>=1.0.0",
 ]
+# #3796: the full-viewport text effect on ctrl+l — a joke, and the only thing
+# in reyn that wants an animation library. Its own extra rather than a core
+# dependency (owner ruling, 2026-08-08「依存は extra かな」): not everyone who
+# installs reyn should carry a dependency for a joke. Without it the key says so
+# and names this extra, so the feature is discoverable without being installed.
+effects = [
+    "terminaltexteffects>=0.12",
+]
 # OpenTelemetry (OTLP) export surface — opt-in observability. Reyn core stays
 # SDK-free unless an operator activates OTEL export (an OTLP endpoint plus this
 # extra); when the SDK isn't installed the exporter stays not-attached, fail-open.

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -725,6 +725,16 @@ class TextualChatApp(App):
         # a reader scrolling back actually is. ``priority`` so the focused
         # Input does not swallow it.
         Binding("ctrl+end", "jump_to_latest", "Back to the newest output", priority=True),
+        # #3796: a joke — a full-viewport text effect over the conversation
+        # pane, toggled by the same key. ``ctrl+l`` because its terminal
+        # meaning is "repaint the screen", which is the nearest thing this has
+        # to a convention, and because a Textual app repaints continuously so
+        # the chord does nothing today. Chosen from an enumeration of every
+        # binding this app, the composer and the pane declare, minus the ones
+        # that are terminal ALIASES rather than chords (ctrl+i/j/m/h are
+        # tab/enter/enter/backspace at the terminal and cannot be taken).
+        # ``priority`` so the focused composer does not swallow it.
+        Binding("ctrl+l", "toggle_text_effect", "Text effect (joke)", priority=True),
         # #3692 PR-A: the `c` binding that used to gate the text cursor
         # behind an explicit entry step is REMOVED, not rebound — flowview
         # 0.13 made the text cursor always-on (visual mode is the one real
@@ -2278,6 +2288,35 @@ class TextualChatApp(App):
                     text=f"interrupt failed: {type(exc).__name__}: {exc}",
                 )
             )
+
+    def action_toggle_text_effect(self) -> None:
+        """Start or stop the full-viewport text effect (#3796).
+
+        The SAME key both ways, and stopping is the library's own
+        ``stop_overlay`` — which restores the exact prior view (model, scroll
+        position, both cursors untouched). That is what makes the joke safe to
+        press: there is no reyn-side state to put back, so there is nothing for
+        reyn to put back WRONGLY.
+
+        The feed keeps running underneath. ``FlowView.render_line`` returns the
+        overlay line while one is set and never renders the content beneath, so
+        arriving output costs what it always costs and is simply not painted
+        until the effect stops — no buffering, and nothing to flush on return.
+        """
+        from reyn.interfaces.inline.textual_chat import screensaver
+        from reyn.runtime.outbox import OutboxMessage
+
+        if self._flow.overlay_active:
+            self._flow.stop_overlay()
+            return
+        if not screensaver.available():
+            self._ingest_frame(
+                OutboxMessage(kind="status", text=screensaver.unavailable_message())
+            )
+            return
+        self._flow.play_overlay(
+            screensaver.frame_factory(), fps=screensaver.DEFAULT_FPS, loop=True
+        )
 
     def _write_clipboard(self, text: str) -> bool:
         """Yank's clipboard sink: reyn's own local tool, result observable.

--- a/src/reyn/interfaces/inline/textual_chat/screensaver.py
+++ b/src/reyn/interfaces/inline/textual_chat/screensaver.py
@@ -74,10 +74,15 @@ DEFAULT_FPS = 10
 #: crawl of tiny glyphs.
 BANNER = "reyn"
 
-#: The optional dependency this needs. Not a reyn dependency — whether to take
-#: one on for a joke is an open question on #3796, so this module works out
-#: whether it is there rather than assuming it.
+#: The optional dependency this needs, and the extra that carries it.
+#:
+#: An EXTRA rather than a core dependency (owner ruling, #3796): not everyone who
+#: installs reyn should carry an animation library for a joke. The message names
+#: the extra, never the raw package — an operator told to install the package
+#: directly gets a working key and never learns the extra exists, which is the
+#: extra failing at the one job it has.
 _DEP = "terminaltexteffects"
+_EXTRA = "effects"
 
 
 def available() -> bool:
@@ -99,8 +104,8 @@ def unavailable_message() -> str:
     and this is the one failure mode of the feature that is not a bug.
     """
     return (
-        f"text effects need the optional {_DEP} package — "
-        f"pip install {_DEP}"
+        f"text effects need the optional '{_EXTRA}' extra — "
+        f"pip install 'reyn[{_EXTRA}]'"
     )
 
 

--- a/src/reyn/interfaces/inline/textual_chat/screensaver.py
+++ b/src/reyn/interfaces/inline/textual_chat/screensaver.py
@@ -1,0 +1,138 @@
+"""A full-viewport text effect over the conversation pane, on a key (#3796).
+
+A joke. It draws a TerminalTextEffects animation across the FlowView's viewport
+and stops on the same key, leaving the feed exactly where it was.
+
+Not a screensaver, despite the issue's original title. It was one until the
+operator changed the trigger:
+
+    「ジョークだし、アイドルスクリーンセーバじゃなくて、キーバインドで開始終了にしようか」
+
+That one change removed three of the five design questions the issue opened
+with — idle detection, "never start during a running turn", and opt-in default —
+because all three were about *starting without being asked*. **The risk lived in
+the trigger, not in the effect.** Worth recording: the same feature, triggered
+explicitly, needs almost none of the safety machinery it needed when it decided
+for itself.
+
+Why the frames are renderables and not raw ANSI
+-----------------------------------------------
+The effect is painted through ``FlowView.overlay``, which takes a Rich
+renderable and is **non-destructive**: the model, scroll position and both
+cursors are untouched, so stopping restores the exact prior view (upstream's
+guarantee, `textual-flowview` 0.15.3). TerminalTextEffects yields whole-screen
+ANSI strings, which ``Text.from_ansi`` converts — the upstream
+``examples/screensaver.py`` is this same composition, and its existence is what
+settled the alternative (take the screen with raw ANSI, freezing the feed).
+
+Iterating the effect is enough; ``terminal_output()`` — TTE's own context
+manager — must NOT be used here. Measured: inside it, TTE writes cursor-control
+sequences to stdout, which is Textual's screen. Outside it, iteration yields the
+same frames and writes nothing (0 bytes captured).
+
+Frame rate
+----------
+:data:`DEFAULT_FPS` is 10, not the 30 the upstream example uses. Measured on
+macOS at 100x24, per frame (generation + ``Text.from_ansi`` + Rich render), as a
+distribution rather than a mean — the cost changes over an effect's life, so a
+mean says more about how many frames were sampled than about the effect:
+
+    effect   median    p90      sustainable fps (median / p90)
+    beams    41.7ms   109.1ms          24.0 / 9.2
+    rain     18.4ms    25.2ms          54.4 / 39.7
+    slide    52.1ms   188.9ms          19.2 / 5.3
+
+**30 fps is not reached by any of the three, even at their median.** Shipping a
+default the machine cannot deliver is the kind of unpredictability the operator
+rejects elsewhere, so the default is one the machine can hold.
+
+10 is NOT "no dropped frames" — slide's slowest tenth needs ~5 fps, and a
+default that slow is not worth looking at. What 10 buys is: every effect's
+MEDIAN frame is comfortably inside the interval, so the drops are a hitch in the
+slowest tenth rather than the steady state.
+
+Not measured: over ssh (the byte counts above are raw frame sizes, not what a
+terminal's differential update actually sends), and anything on Windows/git-bash
+— which is where the operator runs reyn.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from rich.console import RenderableType
+
+#: Frames per second for the overlay. See the module docstring for the
+#: measurement this is chosen from — it is deliberately below the upstream
+#: example's 30, which no measured effect reaches.
+DEFAULT_FPS = 10
+
+#: What the effect animates. Short: an effect renders its text INTO the
+#: viewport, so a long banner is either clipped or shrinks the animation to a
+#: crawl of tiny glyphs.
+BANNER = "reyn"
+
+#: The optional dependency this needs. Not a reyn dependency — whether to take
+#: one on for a joke is an open question on #3796, so this module works out
+#: whether it is there rather than assuming it.
+_DEP = "terminaltexteffects"
+
+
+def available() -> bool:
+    """Whether the effect library is importable.
+
+    Checked through ``find_spec`` rather than a try/import: this is asked on the
+    key press, and importing the library to answer "is it here" would pay the
+    import on a press that is about to say "no".
+    """
+    import importlib.util
+
+    return importlib.util.find_spec(_DEP) is not None
+
+
+def unavailable_message() -> str:
+    """What to tell the operator when the library is absent.
+
+    Names the install, because "unavailable" without a remedy is a dead end —
+    and this is the one failure mode of the feature that is not a bug.
+    """
+    return (
+        f"text effects need the optional {_DEP} package — "
+        f"pip install {_DEP}"
+    )
+
+
+def frame_factory() -> "Callable[[int, int], Iterator[RenderableType]]":
+    """A ``(width, height) -> frames`` factory for ``FlowView.play_overlay``.
+
+    Re-invoked per loop cycle and on resize, so picking the effect INSIDE means
+    every cycle is a different one at the current size — upstream's own idiom,
+    and the reason the factory rather than a frame list is the interface.
+
+    Imports the library lazily, at the first press: reyn does not depend on it,
+    and a module-level import would make an absent optional dependency a broken
+    module rather than a feature that says it is not installed.
+    """
+    import random
+
+    from rich.text import Text
+    from terminaltexteffects.effects import (
+        effect_beams,
+        effect_rain,
+        effect_slide,
+    )
+
+    effects = [effect_beams.Beams, effect_rain.Rain, effect_slide.Slide]
+
+    def frames(width: int, height: int) -> "Iterator[RenderableType]":
+        effect = random.choice(effects)(BANNER)
+        effect.terminal_config.canvas_width = width
+        effect.terminal_config.canvas_height = height
+        # Iterated directly — see the module docstring on why
+        # ``terminal_output()`` must not wrap this.
+        for frame in effect:
+            yield Text.from_ansi(frame)
+
+    return frames

--- a/tests/test_text_effect_toggle_3796.py
+++ b/tests/test_text_effect_toggle_3796.py
@@ -1,0 +1,112 @@
+"""Tier 2: the #3796 text effect starts, stops, and gives the view back.
+
+The joke's one real hazard is not the effect — it is not getting the screen
+back. The operator runs reyn on a company machine, so an effect that could not
+be dismissed would be an accident rather than a joke. These tests pin the
+dismissal, not the animation.
+
+What is deliberately NOT pinned: what the frames look like. Those come from an
+optional third-party library, and asserting on them would make reyn's suite fail
+when someone else's effect changes.
+
+``terminaltexteffects`` is optional and is NOT a reyn dependency (#3796 ⑤ is
+open). The absent-library path is therefore the one every CI run exercises, and
+it is a supported outcome rather than a degraded one — so it gets a test of its
+own rather than being the reason the others skip.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp, screensaver
+from tests.test_textual_chat_copy_rewind_3362 import (
+    ScriptedTransport,
+    _PickerReadModel,
+    _texts,
+)
+
+requires_tte = pytest.mark.skipif(
+    not screensaver.available(),
+    reason="optional terminaltexteffects not installed (#3796 ⑤ undecided)",
+)
+
+
+@pytest.mark.asyncio
+async def test_the_key_says_so_when_the_library_is_absent() -> None:
+    """Tier 2: with the optional library missing, the key reports it and names
+    the install — instead of doing nothing, which reads as a broken key."""
+    if screensaver.available():
+        pytest.skip("library present; the absent path is what this pins")
+
+    app = TextualChatApp(transport=ScriptedTransport([]), read_model=_PickerReadModel())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.action_toggle_text_effect()
+        await pilot.pause()
+
+        assert not app._flow.overlay_active, "an overlay was started without the library"
+        said = [t for t in _texts(app) if "terminaltexteffects" in t]
+        assert said, f"the key did nothing visible: {_texts(app)}"
+        assert any("pip install" in t for t in said), (
+            f"the message does not say how to fix it: {said}"
+        )
+
+
+@requires_tte
+@pytest.mark.asyncio
+async def test_the_same_key_starts_and_stops_it() -> None:
+    """Tier 2: press once, an overlay is active; press again, it is gone.
+
+    Asserted through ``overlay_active`` — the library's own public read — rather
+    than by inspecting reyn state, because reyn keeps none: the overlay IS the
+    state, which is the property that makes the toggle safe.
+    """
+    app = TextualChatApp(transport=ScriptedTransport([]), read_model=_PickerReadModel())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        app.action_toggle_text_effect()
+        await pilot.pause()
+        assert app._flow.overlay_active, "the first press started nothing"
+
+        app.action_toggle_text_effect()
+        await pilot.pause()
+        assert not app._flow.overlay_active, (
+            "the second press left the overlay up — the joke is now an accident"
+        )
+
+
+@requires_tte
+@pytest.mark.asyncio
+async def test_the_feed_is_intact_after_the_effect() -> None:
+    """Tier 2: the conversation is unchanged by a round trip through the effect,
+    INCLUDING output that arrived while it was up.
+
+    The stronger half is the arrival: the overlay covers the viewport, so a
+    reader cannot see whether entries landed. If they were dropped instead of
+    merely hidden, every visual check would still pass and the loss would only
+    surface later, in a conversation missing a reply.
+    """
+    from reyn.runtime.outbox import OutboxMessage
+
+    app = TextualChatApp(transport=ScriptedTransport([]), read_model=_PickerReadModel())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._ingest_frame(OutboxMessage(kind="agent", text="before the effect"))
+        await pilot.pause()
+        before = list(_texts(app))
+
+        app.action_toggle_text_effect()
+        await pilot.pause()
+        app._ingest_frame(OutboxMessage(kind="agent", text="arrived during the effect"))
+        await pilot.pause()
+        app.action_toggle_text_effect()
+        await pilot.pause()
+
+        after = _texts(app)
+        assert after[: len(before)] == before, (
+            f"the effect disturbed what was already there: {before} -> {after}"
+        )
+        assert any("arrived during the effect" in t for t in after), (
+            f"output that landed under the overlay was lost, not hidden: {after}"
+        )

--- a/tests/test_text_effect_toggle_3796.py
+++ b/tests/test_text_effect_toggle_3796.py
@@ -46,10 +46,16 @@ async def test_the_key_says_so_when_the_library_is_absent() -> None:
         await pilot.pause()
 
         assert not app.query_one(FlowView).overlay_active, "an overlay was started without the library"
-        said = [t for t in _texts(app) if "terminaltexteffects" in t]
+        said = [t for t in _texts(app) if "effects" in t]
         assert said, f"the key did nothing visible: {_texts(app)}"
-        assert any("pip install" in t for t in said), (
-            f"the message does not say how to fix it: {said}"
+        # The EXTRA, not the raw package. An operator told to install
+        # `terminaltexteffects` directly gets a working key and never learns the
+        # extra exists — which is the extra failing at its one job.
+        assert any("reyn[effects]" in t for t in said), (
+            f"the message names no extra to install: {said}"
+        )
+        assert not any("pip install terminaltexteffects" in t for t in said), (
+            f"the message routes around the extra: {said}"
         )
 
 

--- a/tests/test_text_effect_toggle_3796.py
+++ b/tests/test_text_effect_toggle_3796.py
@@ -17,6 +17,7 @@ own rather than being the reason the others skip.
 from __future__ import annotations
 
 import pytest
+from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp, screensaver
 from tests.test_textual_chat_copy_rewind_3362 import (
@@ -44,7 +45,7 @@ async def test_the_key_says_so_when_the_library_is_absent() -> None:
         app.action_toggle_text_effect()
         await pilot.pause()
 
-        assert not app._flow.overlay_active, "an overlay was started without the library"
+        assert not app.query_one(FlowView).overlay_active, "an overlay was started without the library"
         said = [t for t in _texts(app) if "terminaltexteffects" in t]
         assert said, f"the key did nothing visible: {_texts(app)}"
         assert any("pip install" in t for t in said), (
@@ -67,11 +68,11 @@ async def test_the_same_key_starts_and_stops_it() -> None:
 
         app.action_toggle_text_effect()
         await pilot.pause()
-        assert app._flow.overlay_active, "the first press started nothing"
+        assert app.query_one(FlowView).overlay_active, "the first press started nothing"
 
         app.action_toggle_text_effect()
         await pilot.pause()
-        assert not app._flow.overlay_active, (
+        assert not app.query_one(FlowView).overlay_active, (
             "the second press left the overlay up — the joke is now an accident"
         )
 


### PR DESCRIPTION
**[tui-coder]** — part of #3796. A joke: `ctrl+l` paints a full-viewport text effect over the conversation pane, and the same key takes it away.

## The trigger change removed most of the design

The issue opened with five questions. The operator changed the trigger — 「アイドルスクリーンセーバじゃなくて、キーバインドで開始終了にしようか」 — and three of them stopped existing: idle detection, "never start during a running turn", and opt-in default. All three were about *starting without being asked*.

**The risk lived in the trigger, not in the effect.** Recorded in the module docstring, because the same feature triggered explicitly needs almost none of the safety machinery it needed when it decided for itself.

## Getting the screen back

The one real hazard is not the animation, it is not being able to dismiss it — the operator runs this on a company machine. Nothing here needs to restore anything: `FlowView.stop_overlay()` is non-destructive by the library's own contract (model, scroll position, both cursors untouched), and reyn keeps **no state of its own** while the effect runs. There is nothing for reyn to put back, so nothing for it to put back wrongly.

The feed keeps running underneath. `FlowView.render_line` returns the overlay line while one is set and never renders the content beneath — so output arriving during the effect costs what it always costs and is simply not painted until the effect stops. No buffering, nothing to flush on return. That is measured from the library source, not assumed: it is why the issue's "溜めるか裏で描くか" question does not arise.

## fps 10, not the upstream example's 30

Measured on macOS at 100×24, per frame (generation + `Text.from_ansi` + render), as a **distribution** — the cost changes over an effect's life, so a mean says more about how many frames were sampled than about the effect:

```
effect   median    p90      sustainable fps (median / p90)
beams    41.7ms   109.1ms          24.0 / 9.2
rain     18.4ms    25.2ms          54.4 / 39.7
slide    52.1ms   188.9ms          19.2 / 5.3
```

**No effect reaches 30 even at its median.** 10 is not "no dropped frames" either — slide's slowest tenth needs ~5 fps, and that is too slow to be worth looking at. What 10 buys is that every effect's median frame fits the interval, so drops are a hitch in the slowest tenth rather than the steady state. I said "10–15, no effect drops" first; that was my own p90 column contradicting me, and I corrected it on the issue before it shipped.

## The key

`ctrl+l` — its terminal meaning is "repaint the screen", the nearest thing this has to a convention, and a Textual app repaints continuously so the chord does nothing today. Chosen from an enumeration of every binding the app, the composer and the pane declare, minus the ones that are terminal ALIASES rather than chords (`ctrl+i/j/m/h` are tab/enter/enter/backspace and cannot be taken). Free after that: `ctrl+l`, `ctrl+r`.

## The dependency is an extra

Owner ruling (#3796 ⑤, 2026-08-08「依存は extra かな」): `terminaltexteffects` lives in an **`effects` extra**, not in the core dependencies. Nobody installing reyn carries an animation library for a joke.

The absent-library message names the **extra**, never the package:

```
text effects need the optional 'effects' extra — pip install 'reyn[effects]'
```

That distinction is asserted, not just written: an operator told to `pip install terminaltexteffects` gets a working key and never learns the extra exists, which is the extra failing at the one job it has. The test pins both halves — the extra is named, and the raw package is not.

Absent is the path CI actually exercises (no CI arm installs the extra — recorded as unmeasured below), so it has its own test rather than being the reason the others skip.

## Falsify

```
remove stop_overlay()          ->  the toggle test RED  (overlay stays up)
remove the availability guard  ->  the absent-library test RED (ModuleNotFoundError)
```

Both against a committed tree. Run twice over: once with the library installed (2 passed, 1 skipped) and once without (1 passed, 2 skipped) — the whole matrix, not one arm.

## Test plan

- [x] Manual: `pytest tests/test_text_effect_toggle_3796.py` with the library ABSENT -> 1 passed, 2 skipped
- [x] Manual: the `effects` extra resolves (`pip install 'terminaltexteffects>=0.12'`, the floor the extra declares) and the installed arm passes
- [x] Manual: no CI arm installs the extra, so the two library-present tests are skipped there — stated rather than left to be discovered from a green run that exercised one third of the file
- [x] Manual: the same file with the library INSTALLED -> 2 passed, 1 skipped
- [x] Manual: both falsify arms above, each against a committed tree
- [x] Manual: `ruff check src tests` -> All checks passed; `test_tier_audit.py --strict` -> 3/3 OK; `verify_module_docstrings.py` -> OK
- [x] Binding collision: enumerated every `BINDINGS` entry across the app/composer/pane plus Textual's own, and excluded the terminal aliases
- [x] Output arriving under the overlay is hidden, not lost — asserted, because a dropped entry would pass every visual check and only surface later as a missing reply
- [x] The measurement-only install of `terminaltexteffects` was removed afterwards; `verify_env_identity.py` OK
- [x] Visual: the operator sees what it looks like, and whether `ctrl+l` is a key they want this on. Left unchecked per the standing Visual waiver — it needs `main` to be seen  → **owner が実機で確認済（2026-08-08「screen saver いい感じ。クローズして良いよ」）。lead-coder が owner の確認を受けてチェック。**
- [x] NOT measured, and NOT measurable from here — **recorded as a remainder on #3796** (comment 5226063139) so it outlives this PR: over ssh (the byte figures are raw frame sizes, not what a terminal's differential update sends), and anything on Windows/git-bash, which is where the operator runs reyn. Neither can be produced in this environment; both surface only in the operator's own use. Checked because it is written down where it can come back, not because it was done

## Still open on the issue

⑤ (take the dependency at all) and the colour question — TTE frames carry truecolor, and whether reyn's terminal-theme policy reaches a third-party decorative effect is the operator's call. Neither blocks this: absent the library the feature says so, and no reyn palette token is involved either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



