### PR TITLE
feat(#3823): sandbox.mode config field (schema only, compat/strict/custom)

### DIFF
--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -435,10 +435,17 @@ class SandboxConfig:
             cancel-teardown still apply). ``'strict'`` — an explicit
             allow-list (today's ``SandboxPolicy`` defaults / the pre-#3823
             behavior). ``'custom'`` — the operator writes both the direction
-            and the content via ``policy`` below. Allowed:
-            ``{'compat', 'strict', 'custom'}``. NOT YET WIRED to change
-            resolved-policy behavior anywhere — see the module-level note on
-            :data:`_SANDBOX_MODES` for why.
+            and the content via ``policy`` below. Declared in the enum
+            (``{'compat', 'strict', 'custom'}``) but ``'strict'``/``'custom'``
+            currently RAISE at construction (``ValueError``, "not implemented
+            yet") rather than being silently accepted-and-ignored — resolving
+            ``mode`` into an actual policy is not wired anywhere yet (see the
+            module-level note on :data:`_SANDBOX_MODES`), and accepting a
+            value that changes nothing would be a silent lie to an operator
+            who wrote it expecting containment. Only ``'compat'`` (the
+            unchanged, already-real default) validates today; the PR that
+            wires ``'strict'``/``'custom'`` removes this guard in the same
+            diff as the tests proving the wiring works.
         policy:
             The agent-level (operator) sandbox policy: a mapping of
             ``SandboxPolicy`` kwargs (``network`` / ``write_paths`` /
@@ -474,6 +481,24 @@ class SandboxConfig:
             raise ValueError(
                 f"sandbox.mode {self.mode!r} is not one of {sorted(_SANDBOX_MODES)}"
             )
+        if self.mode != "compat":
+            raise ValueError(
+                f"sandbox.mode {self.mode!r} is not implemented yet (#3823 ②) — "
+                "only 'compat' (the current, unchanged default behavior) is "
+                "accepted until strict/custom are wired into policy resolution"
+            )
+        # #3823 ②: strict/custom are declared in the enum but not yet WIRED
+        # into any resolved-policy behavior (see the module-level note on
+        # _SANDBOX_MODES). Accepting them silently here would be a lie to the
+        # operator, not a "written but unread" internal field like #3850's
+        # WrappedCommand.env before its callers consumed it — an operator who
+        # writes `mode: strict` forms a real expectation (containment is now
+        # enforced) that nothing currently honours; the config would validate
+        # and do nothing, silently staying compat underneath. Fail loudly
+        # instead. The PR that wires strict/custom into actual policy
+        # resolution removes this guard IN THE SAME DIFF as the tests proving
+        # the wiring works — so "wired but unread" cannot happen here the way
+        # it did for the internal field.
         if self.policy is not None:
             # Fail-fast on a malformed operator policy: construct a SandboxPolicy
             # to validate the keys (unknown key → TypeError → clear ValueError).

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -397,6 +397,18 @@ class EventsConfig:
 
 _SANDBOX_BACKENDS = {"auto", "seatbelt", "landlock", "noop"}
 _SANDBOX_ON_UNSUPPORTED = {"warn", "error", "ignore"}
+# #3823 ②: compat / strict / custom — NOT "off" (owner ruling: "off" is
+# expressible as custom-with-everything-allowed, so it does not need its own
+# enum member). Schema only, as of this field's introduction: nothing in the
+# op-dispatch path reads `mode` yet — resolving it into an actual SandboxPolicy
+# is blocked on a separate design question (SandboxPolicy.write_paths is a
+# closed-enumeration/whitelist field by construction — empty means "deny all
+# writes", not "allow all" — so compat's write axis cannot be expressed with
+# today's field shape; #3823 comment thread has the open question). Adding
+# the validated enum here is safe and mode-independent regardless of how that
+# resolves.
+_SANDBOX_MODES = {"compat", "strict", "custom"}
+DEFAULT_SANDBOX_MODE = "compat"
 
 
 @dataclass
@@ -416,6 +428,17 @@ class SandboxConfig:
             ``'error'`` raises RuntimeError (useful to fail-fast in enforced
             production environments). ``'ignore'`` silently falls back.
             Allowed: ``{'warn', 'error', 'ignore'}``.
+        mode:
+            #3823 ②: which enumeration DIRECTION the resolved policy uses.
+            ``'compat'`` (default, owner-ruled "A" — a literal empty
+            deny-list, nothing blocked by default; audit/events/timeout/
+            cancel-teardown still apply). ``'strict'`` — an explicit
+            allow-list (today's ``SandboxPolicy`` defaults / the pre-#3823
+            behavior). ``'custom'`` — the operator writes both the direction
+            and the content via ``policy`` below. Allowed:
+            ``{'compat', 'strict', 'custom'}``. NOT YET WIRED to change
+            resolved-policy behavior anywhere — see the module-level note on
+            :data:`_SANDBOX_MODES` for why.
         policy:
             The agent-level (operator) sandbox policy: a mapping of
             ``SandboxPolicy`` kwargs (``network`` / ``write_paths`` /
@@ -433,6 +456,7 @@ class SandboxConfig:
 
     backend: str = "auto"
     on_unsupported: str = "warn"
+    mode: str = DEFAULT_SANDBOX_MODE
     policy: dict | None = None
 
     def __post_init__(self) -> None:
@@ -445,6 +469,10 @@ class SandboxConfig:
             raise ValueError(
                 f"sandbox.on_unsupported {self.on_unsupported!r} is not one of "
                 f"{sorted(_SANDBOX_ON_UNSUPPORTED)}"
+            )
+        if self.mode not in _SANDBOX_MODES:
+            raise ValueError(
+                f"sandbox.mode {self.mode!r} is not one of {sorted(_SANDBOX_MODES)}"
             )
         if self.policy is not None:
             # Fail-fast on a malformed operator policy: construct a SandboxPolicy
@@ -468,12 +496,13 @@ def _build_sandbox_config(raw: object) -> SandboxConfig:
     defaults = SandboxConfig()
     backend = str(raw.get("backend", defaults.backend))
     on_unsupported = str(raw.get("on_unsupported", defaults.on_unsupported))
+    mode = str(raw.get("mode", defaults.mode))
     # #1326: optional agent-level policy. Absent → None (SandboxLayer stays ⊤).
     policy_raw = raw.get("policy")
     policy = dict(policy_raw) if isinstance(policy_raw, dict) else None
     # Validation delegated to __post_init__ — raises ValueError with clear message.
     return SandboxConfig(
-        backend=backend, on_unsupported=on_unsupported, policy=policy
+        backend=backend, on_unsupported=on_unsupported, mode=mode, policy=policy
     )
 
 

--- a/tests/test_sandbox_factory.py
+++ b/tests/test_sandbox_factory.py
@@ -25,10 +25,50 @@ from reyn.security.sandbox import noop_backend as _noop_module
 
 
 def test_default_config_values():
-    """Tier 2: SandboxConfig() defaults to backend='auto', on_unsupported='warn'."""
+    """Tier 2: SandboxConfig() defaults to backend='auto', on_unsupported='warn',
+    mode='compat' (#3823 ②, owner-ruled "A")."""
     cfg = SandboxConfig()
     assert cfg.backend == "auto"
     assert cfg.on_unsupported == "warn"
+    assert cfg.mode == "compat"
+
+
+def test_config_rejects_invalid_mode():
+    """Tier 2: #3823 ② — SandboxConfig with unknown mode raises ValueError listing
+    the allowed set. "off" is deliberately NOT allowed — the owner ruling dropped
+    it (expressible as custom-with-everything-allowed instead)."""
+    with pytest.raises(ValueError, match="sandbox.mode") as exc_info:
+        SandboxConfig(mode="off")
+    msg = str(exc_info.value)
+    assert "off" in msg
+    for allowed in ("compat", "strict", "custom"):
+        assert allowed in msg
+
+
+def test_config_accepts_each_valid_mode():
+    """Tier 2: #3823 ② — compat/strict/custom are all accepted, byte-identical
+    round-trip (no normalization or silent rewriting)."""
+    for mode in ("compat", "strict", "custom"):
+        assert SandboxConfig(mode=mode).mode == mode
+
+
+def test_yaml_parse_defaults_mode_to_compat_when_absent():
+    """Tier 2: #3823 ② — a `sandbox:` YAML block that omits `mode` parses to
+    the compat default, not an error or a None. Real parser, not a hand-built
+    SandboxConfig, since this is the actual reyn.yaml -> SandboxConfig seam."""
+    from reyn.config.infra import _build_sandbox_config
+
+    cfg = _build_sandbox_config({"backend": "noop"})
+    assert cfg.mode == "compat"
+
+
+def test_yaml_parse_honors_an_explicit_mode():
+    """Tier 2: #3823 ② — an operator-declared `sandbox: {mode: strict}` reaches
+    SandboxConfig.mode unchanged."""
+    from reyn.config.infra import _build_sandbox_config
+
+    cfg = _build_sandbox_config({"mode": "strict"})
+    assert cfg.mode == "strict"
 
 
 def test_config_rejects_invalid_backend():

--- a/tests/test_sandbox_factory.py
+++ b/tests/test_sandbox_factory.py
@@ -45,11 +45,21 @@ def test_config_rejects_invalid_mode():
         assert allowed in msg
 
 
-def test_config_accepts_each_valid_mode():
-    """Tier 2: #3823 ② — compat/strict/custom are all accepted, byte-identical
-    round-trip (no normalization or silent rewriting)."""
-    for mode in ("compat", "strict", "custom"):
-        assert SandboxConfig(mode=mode).mode == mode
+def test_config_accepts_compat_mode():
+    """Tier 2: #3823 ② — 'compat' round-trips byte-identical (no normalization)."""
+    assert SandboxConfig(mode="compat").mode == "compat"
+
+
+def test_config_refuses_unwired_modes_rather_than_silently_ignoring_them():
+    """Tier 2: #3823 ② — strict/custom are declared in the enum but NOT wired
+    into any resolved-policy behavior yet, so accepting them would silently
+    lie to an operator who believes containment is now enforced (lead-coder's
+    finding, distinguished from #3850's internal-field "written but unread"
+    case: an operator forms a real expectation from config, unlike a private
+    field only code reads). Must fail loudly, not validate-and-ignore."""
+    for mode in ("strict", "custom"):
+        with pytest.raises(ValueError, match="not implemented yet"):
+            SandboxConfig(mode=mode)
 
 
 def test_yaml_parse_defaults_mode_to_compat_when_absent():
@@ -62,13 +72,24 @@ def test_yaml_parse_defaults_mode_to_compat_when_absent():
     assert cfg.mode == "compat"
 
 
-def test_yaml_parse_honors_an_explicit_mode():
-    """Tier 2: #3823 ② — an operator-declared `sandbox: {mode: strict}` reaches
-    SandboxConfig.mode unchanged."""
+def test_yaml_parse_honors_an_explicit_compat_mode():
+    """Tier 2: #3823 ② — an operator-declared `sandbox: {mode: compat}` reaches
+    SandboxConfig.mode unchanged (the one mode actually wired/accepted today)."""
     from reyn.config.infra import _build_sandbox_config
 
-    cfg = _build_sandbox_config({"mode": "strict"})
-    assert cfg.mode == "strict"
+    cfg = _build_sandbox_config({"mode": "compat"})
+    assert cfg.mode == "compat"
+
+
+def test_yaml_parse_propagates_the_not_implemented_refusal_for_strict():
+    """Tier 2: #3823 ② — an operator writing `sandbox: {mode: strict}` in
+    reyn.yaml today gets a loud, real config-load error, not a silently
+    accepted-and-ignored value. Same discriminator as the dataclass-level
+    test above, exercised through the actual YAML-parse seam."""
+    from reyn.config.infra import _build_sandbox_config
+
+    with pytest.raises(ValueError, match="not implemented yet"):
+        _build_sandbox_config({"mode": "strict"})
 
 
 def test_config_rejects_invalid_backend():


### PR DESCRIPTION
**[e2e-coder]** — part of #3823 (② schema slice only; resolving mode into actual policy behavior, and ③ the self_test discriminator, are separate follow-up work blocked on a real structural finding described below).

## Summary
- Owner ruling (verbatim "A確定だよ", #3823 comment 5225948868): `compat` is a LITERAL empty deny-list — nothing blocked by default; audit/events/timeout/cancel-teardown still apply. `strict` is an explicit allow-list (today's `SandboxPolicy` defaults / pre-#3823 behavior). `custom` lets the operator write both enumeration direction and content. `off` is deliberately NOT in the enum — the owner ruling drops it (expressible as custom-with-everything-allowed instead).
- Owner's stated reason for rejecting a "small, reasonable" default deny-list (comment 5225953550): enumerability is the discriminator, not size — "the actual dev toolchain needed" is an unenumerable set, so an operator has no way to know upfront what gets blocked, and the failure mode is "doesn't work" with no diagnostic. A small-but-derived default rejects for the identical reason a large one does.

## Deliberately schema-only — a real blocker found before going further
`SandboxPolicy.write_paths` is a closed-enumeration (whitelist) field by construction — empty means "deny all writes", not "allow all" (confirmed against both Seatbelt's and Landlock's own backend code, e.g. landlock.py's own comment: "with no write_paths that means no writes anywhere"). So `compat`'s write axis cannot be expressed with today's field shape — it needs either a type change (`write_paths: list[str] | None`, `None`=unrestricted) or a parallel `write_deny_paths` field. That's a real design decision, not something to paper over with a placeholder value.

Resolving `mode` into an actual `SandboxPolicy`, and the `enforcement_self_test` containment-claim discriminator (#3823 ③, also blocked on this same question — the discriminator needs to inspect a resolved policy's write axis too), are separate follow-up work once that's decided. Landing the validated enum now is safe and mode-independent regardless of how the write-axis question resolves.

## Witness
Falsify-verified: stripped the `mode` validation in `SandboxConfig.__post_init__`, confirmed RED (an invalid mode silently constructed instead of raising), restored.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/verify_module_docstrings.py src/reyn/config/infra.py` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_sandbox_factory.py` — 21/21 OK, 0 Tier-4 violations
- [x] `pytest tests/test_sandbox_factory.py` — 20 passed, 1 skipped (platform-gated)
- [x] `pytest -k "sandbox_config or SandboxConfig or sandbox_factory"` (repo-wide sweep) — 21 passed, 5 skipped
- [x] Falsify-verified (see above)
- [x] Grepped for positional `SandboxConfig(...)` construction sites (field-order-sensitive since `mode` was inserted before `policy`) — none found, all call sites are keyword-based

---

**[lead-coder]** — 🔴 **ブロッキング 1 件。運用者が設定できて何も起きない値が 3 つのうち 2 つあります。**

- [x] 🔴 **`strict` / `custom` は、配線が入るまで受理せず「まだ実装されていない」と言うこと** — あるいは配線が入るまでこの PR を出さないこと。**対応済 (d129e0ce4)**: `infra.py` に `is not implemented yet (#3823 ②)` を上げるガード、テスト 2 件が `match="not implemented yet"` で pin。**提起者(lead-coder)が実装とテストを確認してチェックしました** — このガードを外す PR が配線の PR になります

## 理由

module-level のコメントと docstring は正直です（`NOT YET WIRED` と明記）。**しかしそれは
コードを読む人が読む面で、運用者が読む面ではありません。**

```
運用者が reyn.yaml に mode: strict と書く
→ ★バリデーションは通る
→ ★何も起きない。★compat のまま動く
→ ★運用者は「封じ込めを有効にした」と信じる
```

**「設定を受理して無視する」は、運用者に対する黙った嘘です。** 今夜この class を 2 回
閉じました（#3850 の `WrappedCommand.env`、#3853 の `_sandbox_env`）が、**あの 2 つは
内部フィールドでした。これは operator-facing なので、より悪い**です。

## 望ましい形

```python
if self.mode not in _SANDBOX_MODES:
    raise ValueError(...)          # 既にある
if self.mode != "compat":
    raise ValueError(
        f"sandbox.mode {self.mode!r} is not implemented yet (#3823 ②: "
        "resolving it needs the write-axis design decision); only 'compat' works today"
    )
```

**そしてこのガードを外す PR が、配線の PR になります。** ガードの除去とテストの追加が
同じ差分に来るので、**「配線したのに読まれていない」を作れません** — 今夜 2 回作った形です。

⚪ **enum と既定値を今 pin する価値は認めます**（語彙が確定し、docs が着地できる）。
**否定しているのは「受理すること」だけです。**

## ⚠️ この指摘は私の側の一貫性の問題でもあります

**#3850 と #3853 では、私は「作ったが誰も読まない」を許容しました** — あちらは
内部フィールドで、次段が読むことが同じ issue に書かれていたからです。**同じ理屈を
config 面に延ばすと、運用者が嘘を設定できるようになります。** 判別子は
「読まれていないか」ではなく **「誰が期待を持つか」** でした。

