### PR TITLE
fix(#3822): DockerEnvironmentBackend gets the same output cap every other backend has

### DIFF
--- a/src/reyn/environment/container_backend.py
+++ b/src/reyn/environment/container_backend.py
@@ -41,6 +41,7 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable, Pattern
 
 from reyn.environment.backend import GrepResult
+from reyn.security.sandbox._subprocess_io import MAX_SUBPROCESS_OUTPUT_BYTES, communicate_capped
 from reyn.security.sandbox.backend import SandboxResult, WrappedCommand
 from reyn.security.sandbox.policy import SandboxPolicy
 
@@ -52,42 +53,88 @@ AsyncRunner = Callable[..., Awaitable[SandboxResult]]
 
 
 def _sync_runner(
-    argv: list[str], *, stdin: bytes | None = None, timeout: int | None = None
+    argv: list[str],
+    *,
+    stdin: bytes | None = None,
+    timeout: int | None = None,
+    max_bytes: int = MAX_SUBPROCESS_OUTPUT_BYTES,
 ) -> SandboxResult:
-    """Real sync runner: spawn argv via ``subprocess.run`` and capture output."""
+    """Real sync runner: spawn argv via ``subprocess.Popen`` + the SAME capped
+    reader every other sandbox backend uses (``communicate_capped``, #3822/
+    #3837's own finding: Docker was the one launch route still doing a plain
+    ``capture_output=True`` — unbounded — read, the exact shape #3837 fixed
+    for CodeAct). A flooding in-container process can no longer OOM the host."""
     try:
-        completed = subprocess.run(
-            argv, input=stdin, capture_output=True, timeout=timeout, check=False,
+        proc = subprocess.Popen(
+            argv,
+            stdin=subprocess.PIPE if stdin is not None else subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
-    except subprocess.TimeoutExpired:
+    except OSError as exc:
+        return SandboxResult(returncode=-1, stdout=b"", stderr=str(exc).encode())
+    try:
+        stdout_b, stderr_b, truncated = communicate_capped(
+            proc, input=stdin, max_bytes=max_bytes, timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        proc.kill()
+        proc.wait()
+        stdout_b = exc.stdout if isinstance(exc.stdout, bytes) else b""
+        stderr_b = exc.stderr if isinstance(exc.stderr, bytes) else b""
         return SandboxResult(
-            returncode=-1, stdout=b"", stderr=f"timed out after {timeout}s".encode(),
+            returncode=-1, stdout=stdout_b,
+            stderr=stderr_b + f"\ntimed out after {timeout}s".encode(),
         )
     return SandboxResult(
-        returncode=completed.returncode, stdout=completed.stdout or b"", stderr=completed.stderr or b"",
+        returncode=proc.returncode, stdout=stdout_b, stderr=stderr_b, truncated=truncated,
     )
 
 
 async def _async_runner(
-    argv: list[str], *, stdin: bytes | None = None, timeout: int | None = None
+    argv: list[str],
+    *,
+    stdin: bytes | None = None,
+    timeout: int | None = None,
+    max_bytes: int = MAX_SUBPROCESS_OUTPUT_BYTES,
 ) -> SandboxResult:
-    """Real async runner for run() (mirrors PR-A's _subprocess_runner)."""
-    proc = await asyncio.create_subprocess_exec(
-        *argv,
-        stdin=asyncio.subprocess.PIPE if stdin is not None else None,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
+    """Real async runner for run() — mirrors ``_sync_runner`` above (and every
+    other sandbox backend's own blocking-path pattern: a real ``Popen`` drained
+    off the event loop via ``run_in_executor``, not ``asyncio.create_subprocess_exec``
+    + plain ``communicate()``, so the SAME output cap applies here (#3822/#3837).
+    ``cancel_event`` support is a separate, larger follow-up (#3822's own
+    measurement recorded this as a distinct gap) — this fix is output-cap only."""
     try:
-        out, err = await asyncio.wait_for(proc.communicate(input=stdin), timeout=timeout)
-    except asyncio.TimeoutError:
-        proc.kill()
-        await proc.wait()
-        return SandboxResult(returncode=-1, stdout=b"", stderr=f"timed out after {timeout}s".encode())
-    return SandboxResult(
-        returncode=proc.returncode if proc.returncode is not None else -1,
-        stdout=out or b"", stderr=err or b"",
-    )
+        proc = subprocess.Popen(
+            argv,
+            stdin=subprocess.PIPE if stdin is not None else subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except OSError as exc:
+        return SandboxResult(returncode=-1, stdout=b"", stderr=str(exc).encode())
+
+    loop = asyncio.get_running_loop()
+
+    def _drain() -> SandboxResult:
+        try:
+            stdout_b, stderr_b, truncated = communicate_capped(
+                proc, input=stdin, max_bytes=max_bytes, timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as exc:
+            proc.kill()
+            proc.wait()
+            stdout_b = exc.stdout if isinstance(exc.stdout, bytes) else b""
+            stderr_b = exc.stderr if isinstance(exc.stderr, bytes) else b""
+            return SandboxResult(
+                returncode=-1, stdout=stdout_b,
+                stderr=stderr_b + f"\ntimed out after {timeout}s".encode(),
+            )
+        return SandboxResult(
+            returncode=proc.returncode, stdout=stdout_b, stderr=stderr_b, truncated=truncated,
+        )
+
+    return await loop.run_in_executor(None, _drain)
 
 
 # ── In-container Python snippets (read args from sys.argv; emit on stdout) ────
@@ -443,8 +490,12 @@ class DockerEnvironmentBackend:
         """``docker exec`` of argv (via a login shell) with cwd=repo_dir — NO host-diff bridge.
 
         The files are already in ``repo_dir`` (the agent edited them via the FS
-        methods above), so there is nothing to sync in. Honors only
-        ``policy.timeout_seconds`` (the fidelity boundary, as in PR-A).
+        methods above), so there is nothing to sync in. Honors
+        ``policy.timeout_seconds`` and (#3822) ``policy.max_output_bytes`` —
+        the fidelity boundary (as in PR-A) applies only to env/cwd, not to
+        the output-cap and timeout every other launch route already shares.
+        ``cancel_event`` support is a separate, larger follow-up (#3822's own
+        measurement recorded it as a distinct gap; not fixed here).
 
         The host-side ``cwd`` (= the OS's ``workspace.base_dir``) is **ignored**:
         the repo lives at the in-container ``self.repo_dir`` (``-w``), which a
@@ -474,4 +525,7 @@ class DockerEnvironmentBackend:
             "-w", self.repo_dir, self.container,
             "bash", "-lc", 'exec "$@"', "reyn-exec", *argv,
         ]
-        return await self._runner(exec_argv, stdin=stdin, timeout=policy.timeout_seconds)
+        return await self._runner(
+            exec_argv, stdin=stdin, timeout=policy.timeout_seconds,
+            max_bytes=policy.max_output_bytes,
+        )

--- a/tests/test_container_backend_1115_stage2.py
+++ b/tests/test_container_backend_1115_stage2.py
@@ -149,7 +149,7 @@ def test_run_is_login_shell_docker_exec_no_bridge(tmp_path: Path) -> None:
     """
     calls: list[list[str]] = []
 
-    async def _record_runner(argv, *, stdin=None, timeout=None) -> SandboxResult:
+    async def _record_runner(argv, *, stdin=None, timeout=None, max_bytes=None) -> SandboxResult:
         calls.append(argv)
         return SandboxResult(returncode=0, stdout=b"out", stderr=b"")
 
@@ -185,7 +185,7 @@ def test_run_adds_i_flag_only_when_stdin_provided(tmp_path: Path) -> None:
     """
     calls: list[list[str]] = []
 
-    async def _record_runner(argv, *, stdin=None, timeout=None) -> SandboxResult:
+    async def _record_runner(argv, *, stdin=None, timeout=None, max_bytes=None) -> SandboxResult:
         calls.append(argv)
         return SandboxResult(returncode=0, stdout=b"ok", stderr=b"")
 
@@ -225,7 +225,7 @@ def test_run_argv_passed_as_positional_params_not_interpolated(tmp_path: Path) -
     """
     calls: list[list[str]] = []
 
-    async def _record_runner(argv, *, stdin=None, timeout=None) -> SandboxResult:
+    async def _record_runner(argv, *, stdin=None, timeout=None, max_bytes=None) -> SandboxResult:
         calls.append(argv)
         return SandboxResult(returncode=0, stdout=b"", stderr=b"")
 

--- a/tests/test_container_backend_output_cap_3822.py
+++ b/tests/test_container_backend_output_cap_3822.py
@@ -1,0 +1,94 @@
+"""Tier 2: DockerEnvironmentBackend's exec path has the same output cap every
+other command-level launch route has (#3822's own measurement: Docker was
+the one launch route still doing an unbounded ``capture_output=True`` /
+``proc.communicate()`` read).
+
+Real subprocess throughout — no Docker daemon required: ``_sync_runner`` /
+``_async_runner`` spawn a real local ``argv`` (Docker's own run() would
+prepend a ``docker exec`` wrapper onto the SAME argv shape; the cap lives in
+the runner, independent of what's in front of it).
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from reyn.environment.container_backend import (
+    DockerEnvironmentBackend,
+    _async_runner,
+    _sync_runner,
+)
+from reyn.security.sandbox._subprocess_io import MAX_SUBPROCESS_OUTPUT_BYTES
+from reyn.security.sandbox.policy import SandboxPolicy
+
+
+def test_sync_runner_caps_output_and_reports_truncated():
+    """Tier 2: #3822 — _sync_runner drains a real over-cap child through
+    communicate_capped instead of an unbounded subprocess.run(capture_output=True)
+    read. Strip the communicate_capped call (revert to subprocess.run(capture_output=True))
+    and this goes RED — truncated would never be set and stdout would exceed the cap."""
+    over = MAX_SUBPROCESS_OUTPUT_BYTES + 1024
+    result = _sync_runner(
+        [sys.executable, "-c", f"import sys; sys.stdout.write('x' * {over})"],
+        max_bytes=MAX_SUBPROCESS_OUTPUT_BYTES,
+    )
+    assert result.truncated is True
+    assert len(result.stdout) <= MAX_SUBPROCESS_OUTPUT_BYTES
+
+
+def test_sync_runner_does_not_truncate_output_under_the_cap():
+    """Tier 2: #3822 — ordinary, well-under-cap output is untouched (no
+    false-positive truncation)."""
+    result = _sync_runner([sys.executable, "-c", "print('ok')"])
+    assert result.truncated is False
+    assert result.stdout.strip() == b"ok"
+
+
+@pytest.mark.asyncio
+async def test_async_runner_caps_output_and_reports_truncated():
+    """Tier 2: #3822 — _async_runner (what DockerEnvironmentBackend.run()
+    actually calls) has the SAME cap as the sync path. Strip the
+    communicate_capped call (revert to asyncio.create_subprocess_exec +
+    plain .communicate()) and this goes RED."""
+    over = MAX_SUBPROCESS_OUTPUT_BYTES + 1024
+    result = await _async_runner(
+        [sys.executable, "-c", f"import sys; sys.stdout.write('x' * {over})"],
+        max_bytes=MAX_SUBPROCESS_OUTPUT_BYTES,
+    )
+    assert result.truncated is True
+    assert len(result.stdout) <= MAX_SUBPROCESS_OUTPUT_BYTES
+
+
+@pytest.mark.asyncio
+async def test_docker_backend_run_passes_policy_max_output_bytes_through():
+    """Tier 2: #3822 — DockerEnvironmentBackend.run() threads
+    policy.max_output_bytes into the runner, not just a hardcoded default —
+    an operator-lowered cap (set here well below the child's real output)
+    actually takes effect end-to-end through the real backend, not just the
+    runner function in isolation."""
+    over = 2048
+    backend = DockerEnvironmentBackend(container="unused", repo_dir="/unused")
+    # No real docker binary is invoked: swap docker_bin for a no-op prefix so
+    # the "docker exec ..." argv resolves to a real local command instead.
+    # bash -lc 'exec "$@"' -- <argv> is argv-faithful (matches run()'s own
+    # exec_argv shape), so this exercises the SAME construction run() builds,
+    # just without a daemon.
+    backend.docker_bin = "bash"
+    backend.container = ""  # unused once docker_bin is bash; argv shape below ignores it
+
+    async def _local_runner(argv, *, stdin=None, timeout=None, max_bytes=None):
+        # Strip everything before the real payload argv (mirrors the existing
+        # "local runner Fake" pattern in test_container_backend_1115_stage2.py)
+        # and run it for real, honoring max_bytes exactly like the production
+        # runner would.
+        payload = argv[argv.index("reyn-exec") + 1:]
+        return await _async_runner(payload, stdin=stdin, timeout=timeout, max_bytes=max_bytes)
+
+    backend._runner = _local_runner
+    policy = SandboxPolicy(timeout_seconds=30, max_output_bytes=over)
+    result = await backend.run(
+        [sys.executable, "-c", "import sys; sys.stdout.write('x' * 8192)"], policy,
+    )
+    assert result.truncated is True
+    assert len(result.stdout) <= over


### PR DESCRIPTION
**[e2e-coder]** — part of #3822 (one of the recorded findings from the original measurement comment: Docker backend has no output cap, no policy reason — unlike the documented env/cwd fidelity boundary). Not #3823-related; self-selected from backlog while #3823's write-axis design question is with architect.

## Summary
`#3822`'s own measurement recorded this as a real gap: Docker was the one command-level launch route still doing a plain, unbounded `subprocess.run(capture_output=True)` / `asyncio.create_subprocess_exec` + `.communicate()` read — the exact "emitting unbounded output can OOM the host before the wall-clock timeout fires" shape #3837 fixed for CodeAct.

- Both `_sync_runner` (FS ops) and `_async_runner` (`run()`, what `DockerEnvironmentBackend.run()` actually calls) now spawn via `subprocess.Popen` and drain through `communicate_capped` — the same chokepoint Seatbelt/Landlock/Noop already use, matching their exact blocking-path pattern (a real `Popen` drained via `run_in_executor` for the async case).
- `policy.max_output_bytes` now threads through `run()` to the runner, where it didn't reach anywhere before.
- `cancel_event` support is a **separate, larger follow-up** (#3822's own measurement recorded it as a distinct gap) — deliberately not folded into this fix, which is output-cap only.

## Witness
`tests/test_container_backend_output_cap_3822.py` — real subprocesses throughout, no Docker daemon required (the cap lives in the runner, independent of what `docker exec` wrapper sits in front of it). Falsify-verified independently for both runners AND the end-to-end `DockerEnvironmentBackend.run()` path (confirming `policy.max_output_bytes` genuinely threads all the way through, not just the runner functions in isolation): reverted each `communicate_capped` call to the prior unbounded shape / an effectively-infinite cap, confirmed RED (`truncated` never set, full over-cap output returned), restored.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/verify_module_docstrings.py src/reyn/environment/container_backend.py` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed/new test files>` — 11/11 OK, 0 Tier-4 violations
- [x] `pytest -k "container_backend or docker or 1115 or 1332 or 1481 or 3822"` (67 tests across the repo) — 67 passed, 12 skipped
- [x] Falsify-verified for both runners + the end-to-end backend path (see above)
- [x] Noted: `test_container_backend_1115_stage2.py` fails collection in isolation with a circular-import error — reproduced identically on a clean `git stash`, confirmed pre-existing and unrelated (resolves fine when collected alongside other test files, matching a known repo-wide import-order quirk found earlier tonight)