### PR TITLE
refactor(#3691): DrawerRow — the capability panes' row grammar as slots

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -62,6 +62,7 @@ always-loaded module.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from rich.text import Text
@@ -714,6 +715,52 @@ def agent_pane_options(
 # ── the six toggle/list categories the retired "more…" sub-bar owned (#3338) ──
 
 
+@dataclass(frozen=True)
+class DrawerRow:
+    """One actionable drawer row, as slots rather than as an assembled string
+    (#3691 Phase 2).
+
+    The four capability panes (tool / mcp / skill / hook) each built their rows
+    by hand and each spelled the same grammar out again: a state mark, the name,
+    an optional ``·``-separated note, and a slash command. Four spellings of one
+    grammar is four places for a change to reach three of. #3380 added the
+    denial-reason distinction and #3615 a third reason — both had to be applied
+    where the mark was decided, and the mark was decided in more than one place.
+
+    Slots, not a redesign. The rendered text is byte-identical to what the four
+    builders produced; what changes is that a reader (and the next change) sees
+    ``state`` / ``note`` / ``command`` as separate things instead of positions
+    inside a string.
+
+    ``command=None`` means **not operable** — a denied capability, or a
+    read-only fallback listing. The builders previously used ``""`` for this,
+    which is a value the caller has to know means "inert" rather than a type
+    that says so. The registry boundary still hands out ``""`` (see
+    :meth:`as_entry`), because ``pane_commands``' index-aligned contract is a
+    list of strings and changing that is a different change from this one.
+
+    NOT used by the model / agent panes. Their rows are a tree-and-selection
+    grammar (indentation, a ``▸`` focus mark at two levels, "· active"), not a
+    state grammar — giving them a ``state`` slot would be fitting the type to
+    the refactor rather than to the code.
+    """
+
+    label: str
+    state: "str | None" = None      # "on" | "off" | "--" — None = no state mark
+    note: "str | None" = None       # the "· ..." tail: a denial reason, a scope
+    command: "str | None" = None    # None = inert (denied, or a read-only row)
+
+    @property
+    def text(self) -> str:
+        """The row as the pane renders it."""
+        head = f"[{self.state}] {self.label}" if self.state else self.label
+        return f"{head}  · {self.note}" if self.note else head
+
+    def as_entry(self) -> "tuple[str, str]":
+        """``(row, slash)`` for the registry, whose contract predates this type."""
+        return self.text, self.command or ""
+
+
 def _denied_note(reason: "str | None") -> str:
     """The annotation for a non-flippable ``[--]`` row, by ``denied_reason`` (#3380,
     ``"unknown"`` added by #3615).
@@ -770,23 +817,26 @@ def _visibility_pane_entries(
     the accessor) → "not wired". A present-but-empty list means the seam answered and
     nothing is narrowed → "(none)". These rendered identically before."""
     raw = snap.get("visibility_items")
-    rows: "list[tuple[str, str]]" = []
+    rows: "list[DrawerRow]" = []
     for it in (raw or []):
         if it.get("kind") != kind:
             continue
         if it.get("denied"):
-            rows.append((f"[--] {it['name']}  · {_denied_note(it.get('denied_reason'))}", ""))
+            rows.append(DrawerRow(
+                label=it["name"], state="--",
+                note=_denied_note(it.get("denied_reason")),
+            ))
         else:
-            rows.append((
-                f"[{'on' if it['on'] else 'off'}] {it['name']}",
-                f"/visibility {'off' if it['on'] else 'on'} {kind} {it['name']}",
+            rows.append(DrawerRow(
+                label=it["name"], state="on" if it["on"] else "off",
+                command=f"/visibility {'off' if it['on'] else 'on'} {kind} {it['name']}",
             ))
     if rows:
-        return rows
+        return [r.as_entry() for r in rows]
     names = [d["name"] for d in (snap.get(fallback_key) or [])] if fallback_key else []
     if names:
-        return [(n, "") for n in names]
-    return [("(none)", "") if raw is not None else ("(not wired)", "")]
+        return [DrawerRow(label=n).as_entry() for n in names]
+    return [DrawerRow(label="(none)" if raw is not None else "(not wired)").as_entry()]
 
 
 def _hook_pane_entries(snap: dict) -> "list[tuple[str, str]]":
@@ -796,15 +846,18 @@ def _hook_pane_entries(snap: dict) -> "list[tuple[str, str]]":
     items = snap.get("hook_items") or []
     if items:
         return [
-            (
-                f"[{'on' if h['on'] else 'off'}] {h['name']}"
-                + (f"  · {h['scope']}" if h.get("scope") else ""),
-                f"/hook {'off' if h['on'] else 'on'} {h['name']}",
-            )
+            DrawerRow(
+                label=h["name"],
+                state="on" if h["on"] else "off",
+                note=h.get("scope") or None,
+                command=f"/hook {'off' if h['on'] else 'on'} {h['name']}",
+            ).as_entry()
             for h in items
         ]
     labels = [h["label"] for h in (snap.get("hooks") or [])]
-    return [(label, "") for label in labels] or [("(none)", "")]
+    return [DrawerRow(label=label).as_entry() for label in labels] or [
+        DrawerRow(label="(none)").as_entry()
+    ]
 
 
 def pipe_pane_lines(snap: "dict | None") -> list[str]:

--- a/tests/test_drawer_row_3691.py
+++ b/tests/test_drawer_row_3691.py
@@ -1,0 +1,102 @@
+"""Tier 1: ``DrawerRow``'s slots are the row's contract (#3691 Phase 2).
+
+The four capability panes (tool / mcp / skill / hook) each assembled their rows
+by hand and each spelled the same grammar out again — a state mark, the name, an
+optional ``·``-separated note, a slash command. #3380 added the denial-reason
+distinction and #3615 a third reason; both are changes to how the mark is
+decided, and the mark was decided in more than one place.
+
+What this file pins is the TYPE's contract, not the pixels. The rendering is
+byte-identical to what the four builders produced (verified by comparing before
+and after on the same snapshot — recorded on the PR rather than landed here,
+since a byte-identity check for a completed extraction has nothing left to
+protect once the extraction is in).
+
+The load-bearing one is ``command``: a denied capability and an operable one
+must not be the same kind of thing. Previously both were strings and "inert" was
+spelled ``""``, so telling them apart was the caller's job every time.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.inline.textual_chat.chrome import (
+    DrawerRow,
+    pane_commands,
+    pane_payload,
+)
+
+_DENIED_SNAP = {
+    "visibility_items": [
+        {"kind": "tool", "name": "read_file", "on": True, "denied": False,
+         "denied_reason": None},
+        {"kind": "tool", "name": "shell", "on": False, "denied": True,
+         "denied_reason": "envelope"},
+        {"kind": "tool", "name": "web_fetch", "on": False, "denied": True,
+         "denied_reason": "turn_context"},
+        {"kind": "tool", "name": "run_pipeline", "on": False, "denied": True,
+         "denied_reason": "unknown"},
+    ]
+}
+
+
+def test_a_row_with_no_command_is_inert() -> None:
+    """Tier 1: ``command=None`` is the type saying "not operable"; the registry
+    boundary still spells that ``""`` because ``pane_commands`` hands out
+    strings."""
+    assert DrawerRow(label="shell", state="--").as_entry()[1] == ""
+    assert DrawerRow(label="x", command="/visibility on tool x").as_entry()[1] == (
+        "/visibility on tool x"
+    )
+
+
+def test_the_state_mark_is_a_slot_not_a_prefix_in_the_label() -> None:
+    """Tier 1: the mark is composed, so a row without a state has no brackets at
+    all — the read-only fallback listings depend on that."""
+    assert DrawerRow(label="github", state="on").text == "[on] github"
+    assert DrawerRow(label="github").text == "github"
+
+
+def test_the_note_is_appended_with_the_separator_the_panes_share() -> None:
+    """Tier 1: one place decides the ``·`` separator, so a pane cannot drift into
+    its own spelling of it."""
+    assert DrawerRow(label="h", state="on", note="turn_end").text == (
+        "[on] h  · turn_end"
+    )
+    assert DrawerRow(label="h", state="on").text == "[on] h"
+
+
+def test_every_denied_capability_is_unoperable_and_says_why() -> None:
+    """Tier 2: through the real pane, not the type: each denial reason reaches
+    the row as its OWN sentence, and no denied row carries a command.
+
+    The reasons differ in what the operator does next — edit a profile, wait for
+    the context to clear, or neither because authorization could not be read at
+    all (#3380, #3615). A refactor that collapsed them would still render three
+    plausible rows.
+    """
+    rows = pane_payload("tool", snapshot=_DENIED_SNAP)
+    cmds = pane_commands("tool", _DENIED_SNAP)
+
+    denied = {r: c for r, c in zip(rows, cmds) if r.startswith("[--]")}
+    # Which capabilities were refused, by name — the snapshot's three denials.
+    assert sorted(r.split()[1] for r in denied) == ["run_pipeline", "shell", "web_fetch"]
+    assert set(denied.values()) == {""}, (
+        f"a denied capability was handed an operable command: {denied}"
+    )
+    # Three reasons, three sentences: the operator's next move differs per reason,
+    # so a collapse here would still render three plausible-looking rows.
+    notes = {r.split("· ", 1)[1] for r in denied}
+    assert sorted(notes) == sorted(
+        {
+            "denied by capability profile",
+            "denied while untrusted content is in context",
+            "authorization could not be determined for this session",
+        }
+    ), f"the denial reasons are not distinct: {notes}"
+
+
+def test_an_operable_row_keeps_its_toggle() -> None:
+    """Tier 2: the extraction did not cost the panes what they are for."""
+    rows = pane_payload("tool", snapshot=_DENIED_SNAP)
+    cmds = pane_commands("tool", _DENIED_SNAP)
+    operable = {r: c for r, c in zip(rows, cmds) if c}
+    assert operable == {"[on] read_file": "/visibility off tool read_file"}


### PR DESCRIPTION
**[tui-coder]** — part of #3691. Phase 2, which the owner moved ahead of Phase 1 (「3691 は Phase 2 を先に進めていいよ」) on the finding that Phase 1's headers would mostly repeat what the tab strip already shows.

## What was duplicated

The four capability panes (tool / mcp / skill / hook) each assembled their rows by hand, and each spelled out the same grammar: a state mark, the name, an optional `·`-separated note, a slash command. Four spellings of one grammar is four places for a change to reach three of — and this grammar has been changed twice already (#3380 added the denial-reason distinction, #3615 a third reason), both times at the point where the mark is decided.

```python
DrawerRow(label=..., state="on"|"off"|"--"|None, note=..., command=...)
```

## The load-bearing slot is `command`

`command=None` is now the type saying **not operable** — a denied capability, or a read-only fallback listing. It was previously `""`, a value the caller has to know means "inert". The registry boundary still hands out `""` because `pane_commands`' index-aligned contract is a list of strings, and changing that is a different change from this one.

## Not applied to model / agent

Their rows are a tree-and-selection grammar — indentation, a `▸` focus mark at two levels, "· active". Giving them a `state` slot would be fitting the type to the refactor instead of to the code. Two grammars, two shapes; the extraction covers the four that share one.

## Byte-identical, verified against the parent commit

```
4 panes x 4 snapshot shapes (rich / fallback-listing / wired-but-empty / not-wired)
before = HEAD~1 in a detached worktree (0 occurrences of DrawerRow)
after  = this commit (9)
diff: empty
```

**The first attempt at this check was vacuous and I nearly reported it.** I ran `git stash` on an already-committed tree, so nothing was stashed and both halves of the comparison ran the same code — an identical diff that meant nothing. Worse, the `stash pop` that followed picked up an unrelated stash from another session's branch and left this checkout in a conflicted state (`DU src/reyn/chat/tui/app.py`, a path from a layout that no longer exists). The check above uses a detached worktree at `HEAD~1` instead, and proves the two trees differ before comparing their output.

⚠️ **This checkout has 5 stash entries belonging to other sessions/branches.** `git stash pop` here is not a safe undo — it pops whatever is on top, which is somebody else's work. Reported separately.

## Test plan

- [x] Manual: `pytest tests/test_drawer_row_3691.py` -> 5 passed
- [x] Manual: every suite touching these panes (`3338` chrome liveness, `3699` drawer readout, `3220` composed payload, `3615` unknown-visibility, `2971` skill visibility) -> 70 passed
- [x] Manual: the byte-identity comparison above, against a detached worktree at the parent commit, with the trees proven different first
- [x] Manual: `ruff check src tests` -> All checks passed; `test_tier_audit.py --strict` -> 5/5 OK; `verify_module_docstrings.py` -> OK; `mypy_ratchet.py` -> OK
- [x] The three denial reasons stay three distinct sentences — asserted by their text, because a collapse would still render three plausible-looking rows
- [ ] Visual: the panes look the same as before, which is the point. Left unchecked per the standing Visual waiver; byte-identity is the machine half of the same claim

## Next in this arc

Phase 1 (headers) is to be **reconsidered, reduced**, after this — its value was mostly in the right-hand primary value, and the left-hand title repeats the tab strip. Phase 3 (icon sets) is downstream of this type, since an icon's slot is a `DrawerRow` slot. **Width is already the binding constraint**: the longest row here is 75 cells against ~78 usable at 80 columns, so an icon column has to come out of something else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
