### PR TITLE
refactor(#3796): name the module for what it is — text_effect, not screensaver

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2303,19 +2303,19 @@ class TextualChatApp(App):
         arriving output costs what it always costs and is simply not painted
         until the effect stops — no buffering, and nothing to flush on return.
         """
-        from reyn.interfaces.inline.textual_chat import screensaver
+        from reyn.interfaces.inline.textual_chat import text_effect
         from reyn.runtime.outbox import OutboxMessage
 
         if self._flow.overlay_active:
             self._flow.stop_overlay()
             return
-        if not screensaver.available():
+        if not text_effect.available():
             self._ingest_frame(
-                OutboxMessage(kind="status", text=screensaver.unavailable_message())
+                OutboxMessage(kind="status", text=text_effect.unavailable_message())
             )
             return
         self._flow.play_overlay(
-            screensaver.frame_factory(), fps=screensaver.DEFAULT_FPS, loop=True
+            text_effect.frame_factory(), fps=text_effect.DEFAULT_FPS, loop=True
         )
 
     def _write_clipboard(self, text: str) -> bool:

--- a/src/reyn/interfaces/inline/textual_chat/text_effect.py
+++ b/src/reyn/interfaces/inline/textual_chat/text_effect.py
@@ -3,8 +3,8 @@
 A joke. It draws a TerminalTextEffects animation across the FlowView's viewport
 and stops on the same key, leaving the feed exactly where it was.
 
-Not a screensaver, despite the issue's original title. It was one until the
-operator changed the trigger:
+Named for what it is rather than for what it was. The issue opened as a
+screensaver and so did this module; the operator changed the trigger:
 
     「ジョークだし、アイドルスクリーンセーバじゃなくて、キーバインドで開始終了にしようか」
 

--- a/tests/test_text_effect_toggle_3796.py
+++ b/tests/test_text_effect_toggle_3796.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import pytest
 from textual_flowview import FlowView
 
-from reyn.interfaces.inline.textual_chat import TextualChatApp, screensaver
+from reyn.interfaces.inline.textual_chat import TextualChatApp, text_effect
 from tests.test_textual_chat_copy_rewind_3362 import (
     ScriptedTransport,
     _PickerReadModel,
@@ -27,7 +27,7 @@ from tests.test_textual_chat_copy_rewind_3362 import (
 )
 
 requires_tte = pytest.mark.skipif(
-    not screensaver.available(),
+    not text_effect.available(),
     reason="optional terminaltexteffects not installed (#3796 ⑤ undecided)",
 )
 
@@ -36,7 +36,7 @@ requires_tte = pytest.mark.skipif(
 async def test_the_key_says_so_when_the_library_is_absent() -> None:
     """Tier 2: with the optional library missing, the key reports it and names
     the install — instead of doing nothing, which reads as a broken key."""
-    if screensaver.available():
+    if text_effect.available():
         pytest.skip("library present; the absent path is what this pins")
 
     app = TextualChatApp(transport=ScriptedTransport([]), read_model=_PickerReadModel())
@@ -142,14 +142,14 @@ def test_the_frames_resolve_to_the_covered_text_not_a_banner() -> None:
     argument's fate is observable without pinning a third-party animation's
     intermediate pixels.
     """
-    from reyn.interfaces.inline.textual_chat import screensaver
+    from reyn.interfaces.inline.textual_chat import text_effect
 
     covered = [
         "user: what does the drawer show?",
         "",
         "● thirteen tabs; Cost and Ctx are readouts",
     ]
-    frames = list(screensaver.frame_factory()(78, len(covered), covered))
+    frames = list(text_effect.frame_factory()(78, len(covered), covered))
     assert frames, "the factory produced no frames for a non-empty screen"
 
     final = frames[-1].plain  # the factory yields rich Text


### PR DESCRIPTION
**[tui-coder]** — part of #3796, follow-up to #3859. The rename was in #3859's branch but landed after that PR merged, so it is not in `main`.

## The name denied itself

```
src/reyn/interfaces/inline/textual_chat/screensaver.py:6
  "Not a screensaver, despite the issue's original title."
```

The issue opened as a screensaver and the module took that name. The operator changed the trigger to a key, and the name did not follow — leaving a module whose docstring has to open by contradicting its own filename. That is the same drift this arc has been fixing in other people's prose all night (`set_overlay` in the pin comment, `hanging_indent_rows` after the wrap became a clip, "never silently unsandboxed"); this one is mine.

`screensaver.py` -> `text_effect.py`. No `screensaver` identifier remains in `src/` or `tests/`; the one surviving mention is upstream's own `examples/screensaver.py`, a real filename.

## How it missed the train

`gh pr view --json headRefOid` and `gh run list` both returned the PREVIOUS commit for some seconds after the push, while `git ls-remote` already showed the new one. I read the stale value, saw "11 pass", and took that as this tree's result — it was the parent's. Meanwhile the PR merged at that parent.

lead-coder's merge train was not at fault: it pins the sha and re-checks it before merging. The failure is entirely on my side, and it is the third instance today of the same shape (a fix pushed after its PR merged).

For this PR I verified the remote directly:

```
git ls-remote origin fix/3796-rename-module -> af53e75d7d75
git rev-parse HEAD                          -> af53e75d7d75
```

## Also caught here

The cherry-pick of my original commit carried `.chainlit/`, `chainlit.md` and `public/reyn.css` — 6,062 lines of unrelated local artifacts that a blanket `git add -A` had swept in. Stripped; this commit is three files.

## Test plan

- [x] Manual: `pytest tests/test_text_effect_toggle_3796.py` -> 4 passed, 1 skipped
- [x] Manual: `ruff check src tests` -> All checks passed
- [x] Manual: `grep -rn screensaver src tests` -> no identifier remains
- [x] Manual: the pushed remote sha equals the local HEAD, checked with `git ls-remote` rather than `gh`
- [x] Manual: the commit contains exactly three files (the rename, its two call sites) — verified with `git diff --cached --stat` after stripping the swept artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
