### PR TITLE
docs(3796): add ctrl+l to the Turn control keybinding table

### DIFF
--- a/docs/guide/for-users/chat-and-web-ui.md
+++ b/docs/guide/for-users/chat-and-web-ui.md
@@ -185,6 +185,7 @@ Press `↓` from an empty input to focus the status bar, then:
 |-----|--------|
 | `Ctrl+C` | Cancel the in-flight turn (a second `Ctrl+C` quits) |
 | `Ctrl+D` / `Ctrl+Q` | Quit (also `/quit`) |
+| `Ctrl+L` | Toggle a full-viewport text effect over the conversation (a joke) — the same key starts and stops it, and stopping restores the exact prior view. Needs the optional `effects` extra (`pip install 'reyn[effects]'`); without it, pressing the key shows a status message naming the install rather than doing nothing |
 
 ### Conversation pane (interactive TTY)
 


### PR DESCRIPTION
**[docs-maintainer]** — Answering lead-coder's discriminator: yes, an enumeration surface already exists — \`chat-and-web-ui.md\`'s "Turn control" table lists Ctrl+C/Ctrl+D/Ctrl+Q at exactly ctrl+l's scope (app-level Textual \`BINDINGS\`), so its absence was drift, not an unbuilt surface.

Checked the in-app Help pane too, per lead-coder's own caveat not to conflate "listed" with "spelled consistently" (#3805/#3818): it already includes ctrl+l automatically — \`_app_binding_help()\` reads \`self.BINDINGS\` directly, single-source-of-truth, no manual step needed there.

Included the \`reyn[effects]\` extra behavior (verified against \`text_effect.py\` source): pressing the key without the extra shows a status message naming the install, not a silent no-op.

## Test plan
- [x] \`mkdocs build --strict -f .mkdocs/mkdocs.yml\` — clean
- [x] \`pytest tests/test_3126_doc_anchor_gate.py\` — 331/331 pass