### PR TITLE
feat(#3860): twelve effects, chosen by measurement, and beams dropped

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/text_effect.py
+++ b/src/reyn/interfaces/inline/textual_chat/text_effect.py
@@ -30,6 +30,27 @@ manager — must NOT be used here. Measured: inside it, TTE writes cursor-contro
 sequences to stdout, which is Textual's screen. Outside it, iteration yields the
 same frames and writes nothing (0 bytes captured).
 
+Which effects
+-------------
+Twelve of TerminalTextEffects' thirty-seven, chosen by measurement rather than
+taste (#3860 — the operator's 「ちょっと種類が少なく感じる」). Every one of the
+thirty-seven resolves back to the text it was given, so that is not the filter;
+two other properties are:
+
+- **p90 >= 12 fps.** An effect whose slow tenth cannot make the interval hitches
+  visibly at :data:`DEFAULT_FPS`.
+- **<= 25 seconds per cycle.** ``loop=True`` picks a fresh effect only at the END
+  of a cycle, so a long effect does not merely take longer — it *suppresses the
+  variety*, which is the thing the operator noticed.
+
+``beams`` was in the original three and fails both (10.5 fps, 29 seconds). It is
+worth naming why that mattered more than the count: a third of the rotation was
+spending half a minute on one effect, so the *felt* variety was below three even
+before the list grew.
+
+Deliberately a flat list. The operator has not seen these yet, and narrowing it
+after they do should be a deletion, not a redesign.
+
 Frame rate
 ----------
 :data:`DEFAULT_FPS` is 10, not the 30 the upstream example uses. Measured on
@@ -104,6 +125,50 @@ def unavailable_message() -> str:
     )
 
 
+def effect_classes() -> list:
+    """The effects the key rotates through — twelve, chosen by measurement
+    (#3860; the criteria are in the module docstring).
+
+    A function rather than a module constant so the optional dependency stays
+    optional: importing the classes at module scope would make an absent
+    ``terminaltexteffects`` an ImportError on a module reyn imports for the
+    ``available()`` check alone.
+
+    Public because the LIST is the thing the operator narrows after seeing it,
+    and because a test can then check every member rather than whichever ones a
+    random draw happens to produce.
+    """
+    from terminaltexteffects.effects import (
+        effect_expand,
+        effect_highlight,
+        effect_middleout,
+        effect_pour,
+        effect_print,
+        effect_rain,
+        effect_random_sequence,
+        effect_scattered,
+        effect_slice,
+        effect_slide,
+        effect_smoke,
+        effect_wipe,
+    )
+
+    return [
+        effect_expand.Expand,
+        effect_highlight.Highlight,
+        effect_middleout.MiddleOut,
+        effect_pour.Pour,
+        effect_print.Print,
+        effect_rain.Rain,
+        effect_random_sequence.RandomSequence,
+        effect_scattered.Scattered,
+        effect_slice.Slice,
+        effect_slide.Slide,
+        effect_smoke.Smoke,
+        effect_wipe.Wipe,
+    ]
+
+
 def frame_factory() -> "Callable[[int, int, list[str]], Iterator[RenderableType]]":
     """A ``(width, height, covered) -> frames`` factory for ``play_overlay``.
 
@@ -134,13 +199,8 @@ def frame_factory() -> "Callable[[int, int, list[str]], Iterator[RenderableType]
     import random
 
     from rich.text import Text
-    from terminaltexteffects.effects import (
-        effect_beams,
-        effect_rain,
-        effect_slide,
-    )
 
-    effects = [effect_beams.Beams, effect_rain.Rain, effect_slide.Slide]
+    effects = effect_classes()
 
     def frames(
         width: int, height: int, covered: "list[str]"

--- a/src/reyn/interfaces/inline/textual_chat/text_effect.py
+++ b/src/reyn/interfaces/inline/textual_chat/text_effect.py
@@ -51,6 +51,14 @@ before the list grew.
 Deliberately a flat list. The operator has not seen these yet, and narrowing it
 after they do should be a deletion, not a redesign.
 
+**Nothing in the test suite enforces those two criteria**, and that is on
+purpose: both are wall-clock figures, so pinning them would fail on a slower CI
+host for a reason that has nothing to do with reyn. Measured (#3860) — adding a
+93-second effect back to this list leaves the suite green. What the suite does
+hold is the property the rest of the design rests on: every member resolves the
+covered text back. Anyone adding to this list is choosing the speed and the
+length themselves, with the numbers on #3860 as the reference.
+
 Frame rate
 ----------
 :data:`DEFAULT_FPS` is 10, not the 30 the upstream example uses. Measured on

--- a/tests/test_text_effect_toggle_3796.py
+++ b/tests/test_text_effect_toggle_3796.py
@@ -185,3 +185,44 @@ async def test_an_empty_screen_is_a_no_op_not_a_crash() -> None:
         assert not app.query_one(FlowView).overlay_active, (
             "an empty screen started an overlay with nothing to animate"
         )
+
+
+@requires_tte
+def test_every_offered_effect_resolves_a_real_screen() -> None:
+    """Tier 2: EVERY effect in the rotation ends holding the text it covered
+    (#3860).
+
+    The list went from three to twelve on a measurement that does not live in
+    the tree. What protects it is this: #3859's whole design rests on an effect
+    resolving back to its input, and that property was checked for three effects
+    while the list had three. Adding nine looks like adding nine words.
+
+    Iterated over :func:`text_effect.effect_classes` rather than through the
+    factory's random draw — a rotation member that a draw happened to skip would
+    be exactly the one nobody checked.
+
+    Not a performance test. How fast or how long each effect runs is what chose
+    these twelve, and those figures live on #3860: pinning them here would fail
+    on a slower CI host for a reason that has nothing to do with reyn.
+    """
+    from rich.text import Text
+
+    from reyn.interfaces.inline.textual_chat import text_effect
+
+    covered = ["● a reply on screen", "", "▸ read_file(path=README.md)"]
+    art = "\n".join(covered)
+    for cls in text_effect.effect_classes():
+        effect = cls(art)
+        effect.terminal_config.canvas_width = 60
+        effect.terminal_config.canvas_height = len(covered)
+        last = None
+        for frame in effect:
+            last = frame
+        assert last is not None, f"{cls.__name__} produced no frames"
+        final = Text.from_ansi(last).plain
+        for line in covered:
+            if line:
+                assert line in final, (
+                    f"{cls.__name__} did not resolve the screen it covered — "
+                    f"{line!r} missing from {final!r}"
+                )


### PR DESCRIPTION
**[tui-coder]** — Closes #3860. The operator: 「tte のパタンは何種類使ってる？ちょっと種類が少なく感じる」. Three effects become twelve, and one of the original three is dropped.

## The count was not the whole answer

```
beams   29.3 seconds per cycle,  10.5 fps at p90
```

`loop=True` picks a fresh effect only at the END of a cycle. So a third of the rotation was spending half a minute on one effect — **the felt variety was below three before the list grew.** Adding nine and keeping `beams` would have left that intact.

## All 37 measured; 12 selected

Every one of TerminalTextEffects' 37 effects **resolves back to the text it was given**, so that is not the filter — #3859's design property holds across the whole library. Two others do the selecting:

- **p90 ≥ 12 fps** — an effect whose slow tenth misses the interval hitches visibly at the default 10 fps.
- **≤ 25 seconds per cycle** — longer, and the effect suppresses the variety rather than merely taking time.

```
in:  expand highlight middleout pour print random_sequence
     rain scattered slice slide smoke wipe
out: beams (SLOW and LONG), and 24 others — table on #3860
```

`spray`, which upstream's example carries and reyn's list did not, is 32 seconds: it stays out on the measurement, which also answers where it went. It was not dropped deliberately — I measured three effects for the fps work and the implementation followed the measurement's population.

## I nearly reported ten effects as broken

My first survey classified ten as "does not resolve". All ten had hit **my own 600-frame cap** — a number I chose, not a property of the effect. Uncapped, all ten resolve. The category's name made a limit of the measurement look like a limit of the thing measured.

## What the tests do and do not hold

The new test runs **every** effect in the rotation over a real screen's worth of text and asserts each one ends holding it — iterating `effect_classes()` rather than the factory's random draw, because a member a draw skipped is exactly the one nobody checked.

**The two selection criteria are not enforced anywhere**, deliberately: both are wall-clock figures and would fail on a slower CI host for reasons unrelated to reyn. Verified rather than assumed — adding a 93-second effect back leaves the suite green. That non-enforcement is written into the module docstring, so the next person adding to this list knows they are choosing the speed and the length themselves.

## Test plan

- [x] Manual: `pytest tests/test_text_effect_toggle_3796.py` -> 5 passed, 1 skipped (with the `effects` extra installed)
- [x] Manual: all 37 effects surveyed for resolution, p90 and blank-input behaviour; the ten that hit the frame cap re-run uncapped
- [x] Manual: falsify — adding a 93-second effect to the rotation leaves the suite GREEN, which is why the docstring says the criteria are not test-enforced
- [x] Manual: `ruff check src tests` -> All checks passed; `test_tier_audit.py --strict` -> OK; `verify_module_docstrings.py` -> OK
- [x] The no-op guard stays one guard: blank input raises for 37/37 effects, so the premise does not vary per effect
- [x] Pushed sha verified with `git ls-remote` against local HEAD (`f15765c359bd`), not with `gh` — which returned a stale value on #3859 and cost that PR its rename
- [ ] Visual: the operator sees which of the twelve are worth keeping. Left unchecked per the standing Visual waiver — narrowing after seeing them should be a deletion from a flat list, which is why it is a flat list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
