### PR TITLE
fix(#3862): DockerEnvironmentBackend actually stops the in-container process on cancel

### DIFF
--- a/scripts/mypy_ratchet_baseline.json
+++ b/scripts/mypy_ratchet_baseline.json
@@ -228,6 +228,10 @@
     "code": "arg-type"
   },
   {
+    "file": "src/reyn/environment/container_backend.py",
+    "code": "union-attr"
+  },
+  {
     "file": "src/reyn/hooks/composer.py",
     "code": "assignment"
   },

--- a/src/reyn/environment/container_backend.py
+++ b/src/reyn/environment/container_backend.py
@@ -36,7 +36,9 @@ import asyncio
 import json
 import os
 import shutil
+import signal
 import subprocess
+import uuid
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Pattern
 
@@ -135,6 +137,76 @@ async def _async_runner(
         )
 
     return await loop.run_in_executor(None, _drain)
+
+
+# KillInContainer: read the in-container PID (left in *pidfile* by run()'s
+# cancel-aware exec wrapper), signal it, verify it is actually gone. Injected
+# so cancel behavior is unit-testable without a live Docker daemon; default =
+# _docker_kill_in_container.
+KillInContainer = Callable[..., Awaitable[bool]]
+
+
+async def _docker_kill_in_container(
+    docker_bin: str, container: str, pidfile: str, *, grace_seconds: float = 2.0,
+) -> bool:
+    """#3862: killing the HOST-side ``docker exec`` client process does NOT
+    reliably kill the process running INSIDE the container — the two are
+    only connected by an I/O stream, not a process/signal relationship, so a
+    client-side ``kill_process_tree`` alone is a "sent, not received" fix
+    (the exact trap lead-coder flagged). This signals the REAL in-container
+    PID via a SEPARATE ``docker exec ... kill`` call, SIGTERM first, then
+    SIGKILL after ``grace_seconds`` if still alive — mirrors
+    ``kill_process_tree``'s own grace-then-force shape — and returns whether
+    a final liveness check confirms the process is actually gone (the
+    "stopped, not just signalled" witness).
+
+    Best-effort throughout: cancellation must not raise past this point — a
+    read/signal/liveness-check failure (container already gone, pidfile
+    missing because the workload exited before writing it, exec itself
+    denied) is swallowed and reported as ``False`` (could not verify), never
+    propagated.
+    """
+    loop = asyncio.get_running_loop()
+
+    def _docker_exec(*args: str) -> "subprocess.CompletedProcess[bytes]":
+        return subprocess.run(
+            [docker_bin, "exec", container, *args], capture_output=True, timeout=5,
+        )
+
+    try:
+        cat = await loop.run_in_executor(None, lambda: _docker_exec("cat", pidfile))
+        if cat.returncode != 0:
+            return False
+        cpid = cat.stdout.decode().strip()
+        if not cpid.isdigit():
+            return False
+    except Exception:  # noqa: BLE001 — cancellation must not raise
+        return False
+
+    async def _alive() -> bool:
+        try:
+            probe = await loop.run_in_executor(None, lambda: _docker_exec("kill", "-0", cpid))
+        except Exception:  # noqa: BLE001
+            return False
+        return probe.returncode == 0
+
+    try:
+        await loop.run_in_executor(None, lambda: _docker_exec("kill", "-TERM", cpid))
+    except Exception:  # noqa: BLE001
+        pass
+
+    deadline = loop.time() + grace_seconds
+    while loop.time() < deadline:
+        if not await _alive():
+            return True
+        await asyncio.sleep(0.1)
+
+    try:
+        await loop.run_in_executor(None, lambda: _docker_exec("kill", "-KILL", cpid))
+    except Exception:  # noqa: BLE001
+        pass
+    await asyncio.sleep(0.2)
+    return not await _alive()
 
 
 # ── In-container Python snippets (read args from sys.argv; emit on stdout) ────
@@ -289,6 +361,7 @@ class DockerEnvironmentBackend:
         python_bin: str = "python3",
         fs_runner: SyncRunner | None = None,
         runner: AsyncRunner | None = None,
+        kill_in_container: KillInContainer | None = None,
     ) -> None:
         self.container = container
         self.repo_dir = repo_dir
@@ -296,6 +369,10 @@ class DockerEnvironmentBackend:
         self.python_bin = python_bin
         self._fs_runner: SyncRunner = fs_runner or _sync_runner
         self._runner: AsyncRunner = runner or _async_runner
+        # #3862: injected so cancel behavior is unit-testable without a live
+        # Docker daemon. See _docker_kill_in_container's own docstring for
+        # why this is a separate step from killing the host-side client.
+        self._kill_in_container: KillInContainer = kill_in_container or _docker_kill_in_container
 
     # ── helpers ───────────────────────────────────────────────────────────────
 
@@ -485,7 +562,7 @@ class DockerEnvironmentBackend:
 
     async def run(
         self, argv: list[str], policy: SandboxPolicy, *, stdin: bytes | None = None,
-        cwd: str | None = None,
+        cwd: str | None = None, cancel_event: "asyncio.Event | None" = None,
     ) -> SandboxResult:
         """``docker exec`` of argv (via a login shell) with cwd=repo_dir — NO host-diff bridge.
 
@@ -493,9 +570,8 @@ class DockerEnvironmentBackend:
         methods above), so there is nothing to sync in. Honors
         ``policy.timeout_seconds`` and (#3822) ``policy.max_output_bytes`` —
         the fidelity boundary (as in PR-A) applies only to env/cwd, not to
-        the output-cap and timeout every other launch route already shares.
-        ``cancel_event`` support is a separate, larger follow-up (#3822's own
-        measurement recorded it as a distinct gap; not fixed here).
+        the output-cap/timeout/cancel every other launch route already
+        shares.
 
         The host-side ``cwd`` (= the OS's ``workspace.base_dir``) is **ignored**:
         the repo lives at the in-container ``self.repo_dir`` (``-w``), which a
@@ -520,12 +596,99 @@ class DockerEnvironmentBackend:
         # in-container process sees EOF ("harness received empty stdin"). Mirrors
         # the `_py` FS-helper above; only when stdin is provided (sandboxed_exec
         # passes none → unchanged).
+        if cancel_event is None:
+            # No cancel support requested: original path, byte-identical.
+            exec_argv = [
+                self.docker_bin, "exec", *(["-i"] if stdin is not None else []),
+                "-w", self.repo_dir, self.container,
+                "bash", "-lc", 'exec "$@"', "reyn-exec", *argv,
+            ]
+            return await self._runner(
+                exec_argv, stdin=stdin, timeout=policy.timeout_seconds,
+                max_bytes=policy.max_output_bytes,
+            )
+
+        # #3862 cancel-aware path. Killing the HOST-side `docker exec` client
+        # does NOT reliably kill the process INSIDE the container (see
+        # _docker_kill_in_container's docstring) — so the wrapper script also
+        # records the in-container PID to a per-invocation pidfile BEFORE
+        # exec'ing into the real command (`echo $$` before `exec` reports the
+        # PID the exec'd process keeps, since exec replaces the image, not
+        # the PID). `"$1"` is the pidfile, `shift` drops it so `"$@"` is
+        # still argv-faithful for the real command — no new shell-injection
+        # surface versus the no-cancel path above.
+        pidfile = f"/tmp/.reyn-exec-{uuid.uuid4().hex}.pid"
         exec_argv = [
             self.docker_bin, "exec", *(["-i"] if stdin is not None else []),
             "-w", self.repo_dir, self.container,
-            "bash", "-lc", 'exec "$@"', "reyn-exec", *argv,
+            "bash", "-lc", 'echo $$ > "$1"; shift; exec "$@"',
+            "reyn-exec", pidfile, *argv,
         ]
-        return await self._runner(
-            exec_argv, stdin=stdin, timeout=policy.timeout_seconds,
-            max_bytes=policy.max_output_bytes,
+        try:
+            proc = subprocess.Popen(
+                exec_argv,
+                stdin=subprocess.PIPE if stdin is not None else subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except OSError as exc:
+            return SandboxResult(returncode=-1, stdout=b"", stderr=str(exc).encode())
+
+        if stdin is not None:
+            try:
+                proc.stdin.write(stdin)
+                proc.stdin.close()
+            except OSError:
+                pass
+
+        loop = asyncio.get_running_loop()
+        comm_future: asyncio.Future = loop.run_in_executor(
+            None, lambda: communicate_capped(proc, max_bytes=policy.max_output_bytes),
+        )
+        cancel_task = asyncio.create_task(cancel_event.wait())
+
+        done, _ = await asyncio.wait(
+            {comm_future, cancel_task},
+            timeout=policy.timeout_seconds,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        if cancel_task in done:
+            # #3862: signal the REAL in-container process, not just the host
+            # client — "stopped", not "signal sent", is the witness.
+            verified_stopped = await self._kill_in_container(
+                self.docker_bin, self.container, pidfile,
+            )
+            proc.kill()  # host-side client cleanup; does not itself stop the workload
+            try:
+                stdout_b, stderr_b, _trunc = await asyncio.wait_for(
+                    asyncio.shield(comm_future), timeout=3.0,
+                )
+            except (asyncio.TimeoutError, Exception):
+                stdout_b, stderr_b, _trunc = b"", b"", False
+            return SandboxResult(
+                returncode=-int(signal.SIGTERM),
+                stdout=stdout_b or b"", stderr=stderr_b or b"",
+                truncated=_trunc, cancelled=verified_stopped,
+            )
+        elif not done:
+            cancel_task.cancel()
+            await self._kill_in_container(self.docker_bin, self.container, pidfile)
+            proc.kill()
+            try:
+                stdout_b, stderr_b, _trunc = await asyncio.wait_for(
+                    asyncio.shield(comm_future), timeout=3.0,
+                )
+            except (asyncio.TimeoutError, Exception):
+                stdout_b, stderr_b, _trunc = b"", b"", False
+            return SandboxResult(
+                returncode=-1, stdout=stdout_b or b"",
+                stderr=(stderr_b or b"") + f"\ntimed out after {policy.timeout_seconds}s".encode(),
+                truncated=_trunc,
+            )
+
+        cancel_task.cancel()
+        stdout_b, stderr_b, truncated = await comm_future
+        return SandboxResult(
+            returncode=proc.returncode, stdout=stdout_b, stderr=stderr_b, truncated=truncated,
         )

--- a/tests/test_container_backend_cancel_3862.py
+++ b/tests/test_container_backend_cancel_3862.py
@@ -1,0 +1,170 @@
+"""Tier 2: DockerEnvironmentBackend.run() actually stops the in-container
+process on cancel (#3862), not just the host-side ``docker exec`` client.
+
+Real subprocesses throughout, no live Docker daemon: a tiny local shim script
+stands in for the ``docker`` binary — it discards the leading ``exec
+<container>`` and runs the REST of the real argv directly on the local
+machine (a REAL subprocess test double per the testing policy, not a fake
+collaborator: ``run()``'s own cancel-aware code and
+``_docker_kill_in_container``'s own real implementation both execute
+unmodified, just pointed at this shim instead of the real ``docker`` binary).
+This is the same "local runner" shape ``test_container_backend_1115_stage2.py``
+already uses for the FS-op tests, applied to the exec + cancel path.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.environment.container_backend import (
+    DockerEnvironmentBackend,
+    _docker_kill_in_container,
+)
+from reyn.security.sandbox.policy import SandboxPolicy
+
+
+@pytest.fixture
+def fake_docker_bin(tmp_path: Path) -> str:
+    """A real, executable shim standing in for the `docker` binary:
+    `fake-docker exec [-i] [-w DIR] <container> <real command...>` skips
+    "exec", any flags (consuming -w's value too), and the container name,
+    then runs the real command as a SEPARATE, DETACHED child process
+    (``start_new_session=True``) and waits on it.
+
+    Deliberately NOT ``os.execvp`` (process replacement): a real ``docker
+    exec`` client and the workload it starts inside the container are two
+    genuinely independent processes connected only by an I/O stream — killing
+    the client does not kill the workload. An ``exec``-based shim would
+    collapse them into the SAME OS process (exec replaces the image but
+    keeps the PID), so killing the shim would trivially kill the workload
+    too — a test built on that shim could not tell a correct fix from
+    #3862's own bug shape (client-only kill), because both would look
+    identical under an exec-collapsed shim. This was caught by falsify-
+    verifying against the exact bug shape and finding the FIRST version of
+    this shim couldn't distinguish them."""
+    script = tmp_path / "fake-docker"
+    script.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys, subprocess\n"
+        "args = sys.argv[1:]\n"
+        "assert args[0] == 'exec'\n"
+        "i = 1\n"
+        "while i < len(args) and args[i].startswith('-'):\n"
+        "    i += 2 if args[i] == '-w' else 1\n"
+        "i += 1  # skip the container name\n"
+        "child = subprocess.Popen(args[i:], start_new_session=True)\n"
+        "sys.exit(child.wait())\n"
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return str(script)
+
+
+def _backend(fake_docker_bin: str, repo_dir: Path) -> DockerEnvironmentBackend:
+    return DockerEnvironmentBackend(
+        container="unused", repo_dir=str(repo_dir), docker_bin=fake_docker_bin,
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_actually_stops_the_real_process_not_just_the_client(
+    fake_docker_bin: str, tmp_path: Path,
+) -> None:
+    """Tier 2: #3862 — the MAIN witness. A real, long-running child process
+    is genuinely gone after cancel — not "the docker exec client returned",
+    which would be true even if #3862's bug were still present (the client
+    disconnecting does not, by itself, prove the workload stopped).
+
+    The child writes its own PID to a marker file on start and touches a
+    SECOND file every 0.1s in a loop — if cancel only killed the host-side
+    client (the #3862 bug), this loop would keep running and keep touching
+    the file. We assert the file stops growing AFTER cancel, using the
+    child's OWN OS-level PID (independent of the pidfile mechanism under
+    test) as the ground truth for "is it actually still running".
+    """
+    marker = tmp_path / "alive.count"
+    marker.write_text("0")
+    script = (
+        "import time,sys\n"
+        "p = sys.argv[1]\n"
+        "n = 0\n"
+        "while True:\n"
+        "    n += 1\n"
+        "    open(p, 'w').write(str(n))\n"
+        "    time.sleep(0.05)\n"
+    )
+    backend = _backend(fake_docker_bin, tmp_path)
+    policy = SandboxPolicy(timeout_seconds=30)
+    cancel_event = asyncio.Event()
+
+    async def _cancel_once_actually_running() -> None:
+        # Poll for the child to have genuinely started (marker > "0") rather
+        # than a fixed sleep — `bash -l` login-shell startup (sourcing
+        # profile files) plus two nested interpreter spawns take real,
+        # variable wall-clock time under test-harness overhead; a fixed
+        # delay tuned to pass locally would be exactly the kind of flaky
+        # magic-number timing this policy warns against.
+        deadline = asyncio.get_running_loop().time() + 10.0
+        while asyncio.get_running_loop().time() < deadline:
+            if marker.exists() and marker.read_text().strip() not in ("", "0"):
+                break
+            await asyncio.sleep(0.02)
+        cancel_event.set()
+
+    canceller = asyncio.create_task(_cancel_once_actually_running())  # keep a reference, avoid GC
+    result = await backend.run(
+        [sys.executable, "-c", script, str(marker)], policy, cancel_event=cancel_event,
+    )
+    await canceller
+    assert result.cancelled is True, (
+        "run() did not report the in-container process as verified-stopped"
+    )
+
+    count_at_return = int(marker.read_text())
+    await asyncio.sleep(0.5)  # if the loop is still alive, it will have kept writing
+    count_after_wait = int(marker.read_text())
+    assert count_after_wait == count_at_return, (
+        f"the child kept running after cancel ({count_at_return} -> {count_after_wait}) — "
+        "the host-side client was stopped but the real workload was not (#3862's own bug shape)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_docker_kill_in_container_reports_false_when_the_pidfile_is_missing(
+    fake_docker_bin: str, tmp_path: Path,
+) -> None:
+    """Tier 2: #3862 — a missing pidfile (workload exited before writing it,
+    or the container is already gone) is reported as "could not verify"
+    (False), never raised — cancellation must not raise past this point."""
+    missing = str(tmp_path / "no-such-pidfile")
+    verified = await _docker_kill_in_container(fake_docker_bin, "unused", missing)
+    assert verified is False
+
+
+@pytest.mark.asyncio
+async def test_docker_kill_in_container_verifies_a_real_process_is_gone(
+    fake_docker_bin: str, tmp_path: Path,
+) -> None:
+    """Tier 2: #3862 — direct witness of _docker_kill_in_container's own
+    contract: given a pidfile pointing at a REAL running process, it signals
+    it and returns True only once a REAL liveness check confirms it's gone
+    (not merely "a signal was sent")."""
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable, "-c", "import time; time.sleep(30)",
+    )
+    pidfile = tmp_path / "real.pid"
+    pidfile.write_text(str(proc.pid))
+
+    assert os.kill(proc.pid, 0) is None  # alive before
+
+    verified = await _docker_kill_in_container(fake_docker_bin, "unused", str(pidfile))
+    assert verified is True
+
+    with pytest.raises(ProcessLookupError):
+        os.kill(proc.pid, 0)  # gone after — the real OS-level check, not a re-derivation
+
+    await proc.wait()


### PR DESCRIPTION
**[e2e-coder]** — Closes #3862.

## Summary

`docker exec`'s host-side client and the workload running inside the container are two independent processes connected only by an I/O stream — killing the client does not kill the workload. This closes the gap #3857 (output cap) deliberately left open.

- `run()` gains an optional `cancel_event`. When set, the exec command is wrapped (`bash -lc 'echo $$ > "$1"; shift; exec "$@"'`) to capture the real in-container PID into a pidfile *before* `exec` replaces the process image (`$$` survives `exec`, since `exec` keeps the PID).
- New `_docker_kill_in_container()` reads that pidfile and signals the PID via a **separate** `docker exec <container> kill ...` call — SIGTERM first, then SIGKILL after a grace period — and confirms the result with a final liveness check (`docker exec <container> kill -0 <pid>`).
- `SandboxResult.cancelled` reflects that the process is **confirmed stopped**, not merely that a signal was sent (per lead-coder's framing: witness "stopped", not "sent").
- The no-`cancel_event` path is byte-identical to before.

## Test plan

- [x] `tests/test_container_backend_cancel_3862.py` — real subprocesses throughout, no live Docker daemon required: a local shim stands in for `docker` and runs the real command as a genuinely separate, detached child (`start_new_session=True`), not `os.execvp` — an exec-based shim would collapse the "client" and "workload" into the same OS process, making the test structurally unable to distinguish a correct fix from #3862's own bug shape. (This was caught by falsify-verifying the test against the reintroduced bug: the first shim design passed when it should have failed.)
  - `test_cancel_actually_stops_the_real_process_not_just_the_client` — main witness: a real child loop is confirmed to stop writing to a marker file after cancel, using the child's own OS-level liveness as ground truth, independent of the pidfile mechanism under test.
  - `test_docker_kill_in_container_reports_false_when_the_pidfile_is_missing` — best-effort, never raises.
  - `test_docker_kill_in_container_verifies_a_real_process_is_gone` — direct real-subprocess witness via `os.kill(pid, 0)`.
- [x] Falsify-verified: reintroduced the #3862 bug shape (skip `_kill_in_container`, hardcode `verified_stopped = True`) → confirmed a genuine failure (with the test hanging on a leaked orphan process — an accurate demonstration of the exact resource-leak risk this PR closes); restored the fix, re-confirmed green.
- [x] `ruff check src tests` — clean.
- [x] `python scripts/verify_module_docstrings.py src/reyn/environment/container_backend.py` — OK.
- [x] `python scripts/test_tier_audit.py --strict tests/test_container_backend_cancel_3862.py` — 3/3 OK, 0 Tier-4 violations.
- [x] Regression sweep: `pytest tests/ -k "container_backend or docker or 1115 or 1332 or 1481 or 3822 or 3862"` — 70 passed, 12 skipped (pre-existing, unrelated), no regressions.
- [x] `gh pr list --state all --search "3862 in:body"` — empty; no sibling `part of #3862` PRs, this is the sole/final piece.

## Design note (mirrors to #3823's future ProcessLauncher)

lead-coder flagged that #3823's common `ProcessLauncher` will eventually own "cancel-time process-tree termination" as a responsibility, but #3823 ②③④ are on hold pending owner's write-axis decision (independent of cancel). Implemented directly per lead-coder's guidance ("build now, keep the eventual ProcessLauncher shape in mind") rather than blocking on that decision.