### PR TITLE
feat(#3869): reyn names its own process instead of showing up as python3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,13 @@ dependencies = [
                         # relies on for reasoning+tools calls.
     "pydantic>=2.0",
     "jsonschema>=4.0",
+    # #3869: names the process "reyn:<subcommand>" instead of "python3.12".
+    # CORE, not optional: the value is entirely in being able to identify a
+    # reyn process on a machine that is misbehaving, and an optional extra is
+    # never installed on the machine where that matters — the operator spent
+    # two reboots on 2026-08-09 unable to tell whether a 29 GB python was
+    # reyn. A diagnostic you have to have predicted needing is not one.
+    "setproctitle>=1.3",
     "pyyaml>=6.0",
     "prompt_toolkit>=3.0",   # plain CUI (--cui flag) keeps this
     "ddgs>=8.0",

--- a/src/reyn/interfaces/cli/__init__.py
+++ b/src/reyn/interfaces/cli/__init__.py
@@ -36,6 +36,14 @@ def main() -> None:
     mark_cli_reached()
     parser = build_parser()
     args = parser.parse_args()
+    # #3869: name the process before the subcommand runs, so anything the
+    # operator inspects afterwards (ps, Activity Monitor, a crash post-mortem)
+    # says "reyn:chat" instead of "python3.12". Set AFTER parsing because the
+    # subcommand is the whole payload of the name, and before args.func because
+    # that call is where a long-running surface (chat, serve) stops returning.
+    from reyn.runtime.proctitle import set_process_title  # noqa: PLC0415
+
+    set_process_title(getattr(args, "command", None))
     try:
         args.func(args)
     except MissingCredentialsError as exc:

--- a/src/reyn/runtime/proctitle.py
+++ b/src/reyn/runtime/proctitle.py
@@ -1,0 +1,60 @@
+"""Name reyn's own process so `ps` and Activity Monitor can identify it.
+
+WHY THIS EXISTS
+    On 2026-08-09 the operator's machine needed two reboots after a
+    ``python3.12`` process reached ~29 GB. Nothing on the machine could say
+    whether that process was reyn, a test run, a measurement script, or an
+    unrelated tool: every one of them reports the interpreter's name. The
+    interpreter's name is the one part of the answer that is never in doubt
+    and never useful.
+
+    Naming the process converts "some python is eating the machine" into
+    "reyn:chat is eating the machine" — or, just as valuable, into "this is
+    not reyn". Charter lens 8 (Product Think: predictable, legible to the
+    operator) is the one this serves.
+
+WHAT GOES IN THE NAME
+    The subcommand, and nothing else. A process title is world-readable
+    through ``ps`` — every user on the host sees it. Workspace paths, session
+    ids, prompts and file arguments are all things reyn knows at this point
+    and none of them belong in a string the whole machine can read. "Which
+    reyn is this" is answered by the subcommand; the rest is a leak with a
+    diagnostic excuse.
+
+WHEN IT DOES NOTHING
+    ``setproctitle`` is a compiled extension. If it is missing this module is
+    a no-op and reyn runs exactly as before — a diagnostic aid that can stop
+    a program from starting is worse than the diagnosis it offers.
+"""
+from __future__ import annotations
+
+PREFIX = "reyn"
+
+
+def format_title(subcommand: str | None) -> str:
+    """The title reyn would set for ``subcommand``.
+
+    Split out from :func:`set_process_title` so the naming rule can be
+    asserted without a subprocess: what the string looks like and whether the
+    OS accepted it are two different claims, and only the second one needs a
+    real process to check.
+    """
+    if not subcommand:
+        return PREFIX
+    return f"{PREFIX}:{subcommand}"
+
+
+def set_process_title(subcommand: str | None) -> bool:
+    """Set this process's visible name. Returns whether it was actually set.
+
+    The return value is the honest one: ``False`` means the machine still
+    shows ``python3.12``, which is exactly the state this module exists to
+    remove, so a caller that wants to warn about it can. Nothing in reyn
+    treats a ``False`` as an error — see the module docstring.
+    """
+    try:
+        import setproctitle  # noqa: PLC0415 — optional, and paid only on the CLI path
+    except ImportError:
+        return False
+    setproctitle.setproctitle(format_title(subcommand))
+    return True

--- a/tests/test_proctitle_3869.py
+++ b/tests/test_proctitle_3869.py
@@ -1,0 +1,79 @@
+"""#3869: reyn names its own process, so `ps` can tell it from any other python.
+
+The interesting assertion here is not that a function returns a string — it is
+that the *operating system* changed what it reports for a live process. That
+needs a real child process, because the title is a property of the process, not
+of the module: `set_process_title` returning True is a producer-side claim, and
+today's #3850 (`WrappedCommand.env` required, populated, tested, and read by
+nobody) is what a producer-side claim alone is worth.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+from reyn.runtime.proctitle import format_title, set_process_title
+
+
+def test_title_is_the_subcommand_and_nothing_else():
+    """Tier 1: #3869 — the name reyn shows is `reyn:<subcommand>`.
+
+    Pinned separately from the OS behaviour because the naming rule is a
+    contract with the operator (they read this string), while the OS call is a
+    mechanism. Strip `PREFIX` or the separator and this goes RED without
+    needing a process.
+    """
+    assert format_title("chat") == "reyn:chat"
+    assert format_title("serve") == "reyn:serve"
+    # No subcommand is a real case: `reyn` with no args, and anything that
+    # calls the helper before parsing. Naming it "reyn:" would be worse than
+    # naming it "reyn".
+    assert format_title(None) == "reyn"
+    assert format_title("") == "reyn"
+
+
+def test_ps_reports_the_new_name_for_a_live_process():
+    """Tier 2: #3869 — the OS actually reports the title for a running process.
+
+    The child sets its title and then reads its OWN `ps` line, so there is
+    nothing to wait for: no sleep, no poll, no timeout. The parent asserts on
+    what the OS said about a process that was alive at the moment it said it.
+
+    Replace `set_process_title` with a no-op (or drop `setproctitle` from the
+    dependencies) and this goes RED with the interpreter's own name, which is
+    exactly the state #3869 exists to remove.
+    """
+    child = textwrap.dedent(
+        """
+        import os, subprocess, sys
+        sys.path.insert(0, {src!r})
+        from reyn.runtime.proctitle import set_process_title
+        set_process_title("test-probe")
+        print(subprocess.run(
+            ["ps", "-p", str(os.getpid()), "-o", "args="],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip())
+        """
+    ).format(src=str(__import__("pathlib").Path(__file__).resolve().parents[1] / "src"))
+
+    out = subprocess.run(
+        [sys.executable, "-c", child], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    assert out == "reyn:test-probe", (
+        f"ps reported {out!r}; the process is still identifying itself by "
+        "interpreter, which is the failure #3869 is about"
+    )
+
+
+def test_setting_the_title_reports_whether_it_took_effect():
+    """Tier 1: #3869 — the caller can tell a real rename from a silent no-op.
+
+    `set_process_title` returns False when `setproctitle` is absent rather than
+    raising, and the return value is the only way a caller distinguishes
+    "renamed" from "still python3.12". A helper that always returned None would
+    make those two indistinguishable — the same shape as a gate whose failure
+    looks like its success.
+    """
+    assert set_process_title("selftest") is True


### PR DESCRIPTION
**[lead-coder]** — Closes #3869. Implemented by lead-coder under an explicit operator exception ("今回は緊急事態なのであなたの実装を許容です") — every peer session was down at the time and the operator was waiting on this to start reyn.

`reyn chat` now shows as `reyn:chat`.

## The failure this removes

On 2026-08-09 the operator's machine needed two reboots after a `python3.12` process reached ~29 GB. **Nothing on the machine could say whether that process was reyn.** reyn, a test run, a peer's measurement script, an unrelated tool — every one of them reports the interpreter's name. **The interpreter's name is the one part of the answer that is never in doubt and never useful.**

During the same investigation the operator read three PIDs off Activity Monitor; two of them no longer existed by the time `ps` looked. **Being able to name the process is what makes that ambiguity resolvable at all.**

## What goes in the name

**The subcommand, and nothing else.** A process title is world-readable through `ps` — every user on the host sees it. Workspace paths, session ids, prompts and file arguments are all things reyn knows at that point, and **none of them belong in a string the whole machine can read.** "Which reyn is this" is answered by the subcommand; the rest is a leak with a diagnostic excuse.

## Why `setproctitle` is a core dependency, not an extra

**The value is entirely in identifying a reyn process on a machine that is already misbehaving.** An optional extra is never installed on the machine where that matters — you would have had to predict needing it. **A diagnostic you have to have predicted needing is not one.**

If it is somehow absent, `set_process_title` returns `False` and reyn runs exactly as before. **A diagnostic aid that can stop a program from starting is worse than the diagnosis it offers.**

## Scope: this PR names reyn itself, not its children

The issue also covers child processes (MCP servers, CodeAct, `sandboxed_exec`, `docker exec`). **The operator narrowed it:** 「子プロセスだけじゃなくて reyn そのものも区別できるようにしてね」 and 「その後 reyn 起動してみるから」. **Naming the body is the leg that answers "is this reyn at all", and it is the one the operator is waiting on.**

Children are a second stage and need a measurement this PR does not: **whether a sandboxed child can write its own argv region at all** (seccomp allows `prctl`, but seatbelt is a separate question). **That measurement is recorded on #3869 and is not silently dropped by this PR closing it** — see the issue's remaining unchecked items.

## Witness

The load-bearing assertion is not that a function returns a string — it is that **the operating system changed what it reports for a live process.**

```
strip `setproctitle.setproctitle(...)` from set_process_title
  -> test_ps_reports_the_new_name_for_a_live_process FAILED
     (ps reports the interpreter, which is the failure #3869 is about)
  -> the other two tests stay GREEN
```

`set_process_title` returning `True` is a producer-side claim. **#3850 landed today with `WrappedCommand.env` required, populated by four backends, covered by tests, and read by nobody** — that is what a producer-side claim alone is worth. So the OS is asked directly: the child sets its title, then reads its own `ps` line and prints it. **No sleep, no poll, no timeout** — the child observes itself while alive.

## Test plan

- [x] `pytest tests/test_proctitle_3869.py` — 3 passed
- [x] Falsify: no-op'd `set_process_title` against a committed tree → the OS-level test RED, the other two green
- [x] **End-to-end through the real entry point**: drove `reyn._cli:main` with `argv=['reyn','chat']` and read `ps` for that pid → `reyn:chat`. (The unit test drives the helper; this drives the leg the operator will actually see.)
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_proctitle_3869.py` — 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py` on both changed src files — OK
- [x] `python scripts/mypy_ratchet.py` — OK (212 findings, all baselined; **no new entry added**)
- [x] Docs: grepped `docs/` for an exhaustive core-dependency list this PR would falsify — **none exists**, nothing to update
- [ ] 🔴 Visual: the operator sees `reyn:<subcommand>` in Activity Monitor / `ps` on their own machine. Left unchecked per the standing Visual waiver — **this is the whole point of the change and only they can see it**

## One thing this PR does not claim

**It does not identify what used 29 GB.** That process is gone and its identity was never recorded. This makes the *next* one identifiable. The audit of unbounded retention is #3868, and it is deliberately separate: **if the cause is never found, this change is still worth having.**
