### PR TITLE
test(#3872): delete two tests that pinned TerminalTextEffects, not reyn

### DIFF
--- a/tests/test_text_effect_toggle_3796.py
+++ b/tests/test_text_effect_toggle_3796.py
@@ -126,50 +126,6 @@ async def test_the_feed_is_intact_after_the_effect() -> None:
         )
 
 
-@requires_tte
-def test_the_effect_is_given_the_covered_screen(monkeypatch) -> None:
-    """Tier 1: reyn hands the effect the rows that are on screen (#3796 round 2).
-
-    The operator found the first version animating a fixed ``"reyn"`` over their
-    conversation. The witness that replaced it read the animation's FINAL FRAME
-    and asserted the covered lines came back — which pins a property of
-    TerminalTextEffects (an effect resolves to its input), not a promise reyn
-    makes. No Tier covers a third-party's behaviour, and the earlier form also
-    cost 10 GB on the branch where the factory stopped being finite (#3872).
-
-    reyn's promise ends at the hand-off: what it gives the effect is the visible
-    rows, joined, and nothing else. A real effect records that in
-    ``input_data``, so this reads it from a genuine instance — no stand-in, and
-    no frames generated. Replace the body's ``art`` with a banner and this goes
-    RED on the value itself rather than on what an animation did with it.
-    """
-    from terminaltexteffects.effects import effect_rain
-
-    from reyn.interfaces.inline.textual_chat import text_effect
-
-    covered = [
-        "user: what does the drawer show?",
-        "",
-        "● thirteen tabs; Cost and Ctx are readouts",
-    ]
-    seen: list = []
-
-    class _Recording(effect_rain.Rain):
-        def __init__(self, art: str) -> None:
-            seen.append(art)
-            super().__init__(art)
-
-    monkeypatch.setattr(text_effect, "effect_classes", lambda: [_Recording])
-    frames = text_effect.frame_factory()(78, len(covered), covered)
-    next(frames, None)  # one frame: enough to reach the construction, not to animate
-    frames.close()
-
-    assert seen, "the factory never constructed an effect"
-    assert seen[0] == "\n".join(covered), (
-        f"reyn handed the effect {seen[0]!r} instead of the screen it covered"
-    )
-
-
 
 @requires_tte
 @pytest.mark.asyncio

--- a/tests/test_text_effect_toggle_3796.py
+++ b/tests/test_text_effect_toggle_3796.py
@@ -149,10 +149,18 @@ def test_the_frames_resolve_to_the_covered_text_not_a_banner() -> None:
         "",
         "● thirteen tabs; Cost and Ctx are readouts",
     ]
-    frames = list(text_effect.frame_factory()(78, len(covered), covered))
-    assert frames, "the factory produced no frames for a non-empty screen"
+    # Only the LAST frame is read, so only the last frame is kept. `list()`
+    # here materialised every frame to look at one of them — harmless while
+    # the factory is finite, and 10 GB the moment it is not (#3872: the
+    # cache+pulse factory waits on a thread, so `list()` collected frames
+    # for as long as that thread took, which the collecting itself slowed).
+    # A test should not be the reason a machine reboots.
+    last = None
+    for frame in text_effect.frame_factory()(78, len(covered), covered):
+        last = frame
+    assert last is not None, "the factory produced no frames for a non-empty screen"
 
-    final = frames[-1].plain  # the factory yields rich Text
+    final = last.plain  # the factory yields rich Text
     for line in covered:
         if line:
             assert line in final, (
@@ -185,44 +193,3 @@ async def test_an_empty_screen_is_a_no_op_not_a_crash() -> None:
         assert not app.query_one(FlowView).overlay_active, (
             "an empty screen started an overlay with nothing to animate"
         )
-
-
-@requires_tte
-def test_every_offered_effect_resolves_a_real_screen() -> None:
-    """Tier 2: EVERY effect in the rotation ends holding the text it covered
-    (#3860).
-
-    The list went from three to twelve on a measurement that does not live in
-    the tree. What protects it is this: #3859's whole design rests on an effect
-    resolving back to its input, and that property was checked for three effects
-    while the list had three. Adding nine looks like adding nine words.
-
-    Iterated over :func:`text_effect.effect_classes` rather than through the
-    factory's random draw — a rotation member that a draw happened to skip would
-    be exactly the one nobody checked.
-
-    Not a performance test. How fast or how long each effect runs is what chose
-    these twelve, and those figures live on #3860: pinning them here would fail
-    on a slower CI host for a reason that has nothing to do with reyn.
-    """
-    from rich.text import Text
-
-    from reyn.interfaces.inline.textual_chat import text_effect
-
-    covered = ["● a reply on screen", "", "▸ read_file(path=README.md)"]
-    art = "\n".join(covered)
-    for cls in text_effect.effect_classes():
-        effect = cls(art)
-        effect.terminal_config.canvas_width = 60
-        effect.terminal_config.canvas_height = len(covered)
-        last = None
-        for frame in effect:
-            last = frame
-        assert last is not None, f"{cls.__name__} produced no frames"
-        final = Text.from_ansi(last).plain
-        for line in covered:
-            if line:
-                assert line in final, (
-                    f"{cls.__name__} did not resolve the screen it covered — "
-                    f"{line!r} missing from {final!r}"
-                )

--- a/tests/test_text_effect_toggle_3796.py
+++ b/tests/test_text_effect_toggle_3796.py
@@ -127,21 +127,24 @@ async def test_the_feed_is_intact_after_the_effect() -> None:
 
 
 @requires_tte
-def test_the_frames_resolve_to_the_covered_text_not_a_banner() -> None:
-    """Tier 2: what the effect RESOLVES TO is the covered rows (#3796 round 2).
+def test_the_effect_is_given_the_covered_screen(monkeypatch) -> None:
+    """Tier 1: reyn hands the effect the rows that are on screen (#3796 round 2).
 
     The operator found the first version animating a fixed ``"reyn"`` over their
-    conversation. My first attempt at a witness for the fix asserted that the
-    factory was *handed* the covered rows — and a banner implementation passes
-    that, because being handed an argument is not using it. Falsified exactly
-    so: reverting the body to ``art = "reyn"`` left that assertion green.
+    conversation. The witness that replaced it read the animation's FINAL FRAME
+    and asserted the covered lines came back — which pins a property of
+    TerminalTextEffects (an effect resolves to its input), not a promise reyn
+    makes. No Tier covers a third-party's behaviour, and the earlier form also
+    cost 10 GB on the branch where the factory stopped being finite (#3872).
 
-    So this reads the FRAMES. A TTE effect resolves to the text it was given
-    (measured: the final frame comes back equal to the input, blank lines and
-    indentation included), which makes the last frame the one place the
-    argument's fate is observable without pinning a third-party animation's
-    intermediate pixels.
+    reyn's promise ends at the hand-off: what it gives the effect is the visible
+    rows, joined, and nothing else. A real effect records that in
+    ``input_data``, so this reads it from a genuine instance — no stand-in, and
+    no frames generated. Replace the body's ``art`` with a banner and this goes
+    RED on the value itself rather than on what an animation did with it.
     """
+    from terminaltexteffects.effects import effect_rain
+
     from reyn.interfaces.inline.textual_chat import text_effect
 
     covered = [
@@ -149,25 +152,23 @@ def test_the_frames_resolve_to_the_covered_text_not_a_banner() -> None:
         "",
         "● thirteen tabs; Cost and Ctx are readouts",
     ]
-    # Only the LAST frame is read, so only the last frame is kept. `list()`
-    # here materialised every frame to look at one of them — harmless while
-    # the factory is finite, and 10 GB the moment it is not (#3872: the
-    # cache+pulse factory waits on a thread, so `list()` collected frames
-    # for as long as that thread took, which the collecting itself slowed).
-    # A test should not be the reason a machine reboots.
-    last = None
-    for frame in text_effect.frame_factory()(78, len(covered), covered):
-        last = frame
-    assert last is not None, "the factory produced no frames for a non-empty screen"
+    seen: list = []
 
-    final = last.plain  # the factory yields rich Text
-    for line in covered:
-        if line:
-            assert line in final, (
-                f"the effect resolved to something other than the screen it "
-                f"covered — {line!r} is missing from {final!r}"
-            )
-    assert "reyn" not in final, "a banner leaked into the frames"
+    class _Recording(effect_rain.Rain):
+        def __init__(self, art: str) -> None:
+            seen.append(art)
+            super().__init__(art)
+
+    monkeypatch.setattr(text_effect, "effect_classes", lambda: [_Recording])
+    frames = text_effect.frame_factory()(78, len(covered), covered)
+    next(frames, None)  # one frame: enough to reach the construction, not to animate
+    frames.close()
+
+    assert seen, "the factory never constructed an effect"
+    assert seen[0] == "\n".join(covered), (
+        f"reyn handed the effect {seen[0]!r} instead of the screen it covered"
+    )
+
 
 
 @requires_tte


### PR DESCRIPTION
**[lead-coder]** — Closes #3872. Implemented by lead-coder under the operator's standing emergency exception (peers are down; their machine rebooted three times today).

Two tests removed. Both belonged to something other than reyn.

## `test_every_offered_effect_resolves_a_real_screen`

Asserted that every TerminalTextEffects effect resolves to the text it was given. **That is TTE's property.** No Tier in `testing.md` covers a third-party's behaviour, and it also pinned an animation's end state, which the policy names outright.

## `test_the_frames_resolve_to_the_covered_text_not_a_banner`

Same shape wearing reyn's name.

```python
assert "reyn" not in final
```

**That is not a contract — it is one past defect's fingerprint.** Any other wrong string passes it. Its positive half ("the covered lines come back in the final frame") was TTE resolving its input again.

**I replaced it once before deleting it**, with an assertion that reyn hands the effect the covered rows. The operator stopped that too, correctly:

```python
art = "\n".join(covered)              # the code
assert seen[0] == "\n".join(covered)  # the test
```

**It can only fail when someone deliberately edits that assignment, and whoever edits it edits this too.**

## The move both versions made

**A bug appeared, and the bug's own shape was copied into the suite as "not that".** tui-coder pinned "not a banner"; I pinned "the covered rows are what we pass. **Neither states a contract — they state an incident.**

**The right number here is zero.** It is a joke feature whose correctness is visible: **the operator found the banner by looking at it, and no test did.** What is lost is the path where someone copies upstream's example back in — also a thing you see the first time you press the key.

## What this also removes

```python
frames = list(text_effect.frame_factory()(78, len(covered), covered))
```

On `main` the factory is finite, so this was merely wasteful. **On the cache+pulse branch (#3866) the same line reached 10 GB and cost the operator three reboots** — that factory waits on a worker thread, and the collecting loop starves the thread it is waiting for, so the wait never ends while the list grows. **There is no longer a frame to collect.**

## What remains in the file (four, all reyn's own)

```
the message names the extra when the library is absent
the same key opens and closes it
the feed survives the effect
an empty screen is a no-op, not the ValueError TTE raises on blank input
```

## How this got in

**`scripts/test_tier_audit.py` passed both.** Five of its six checks read the code; the Tier line is matched as a string:

```python
TIER_DOCSTRING_RE = re.compile(r"^Tier [123][abc]?:", re.IGNORECASE)
```

**A declaration is not a classification.** The only check on whether a Tier is *true* is a human reading the test — and I merged #3859 and #3864 having read their bodies, not their tests. #3855 I had called the best PR of the day; the better a PR reads, the less of it I opened.

## Test plan

- [x] `pytest tests/test_text_effect_toggle_3796.py` — 3 passed, 1 skipped (the absent-library arm skips when the extra is installed)
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_text_effect_toggle_3796.py` — 0 violations
- [x] `python scripts/mypy_ratchet.py` — OK, no new entry
- [x] Intermediate version falsify-verified before being deleted: `art = "reyn"` against a committed tree turned it RED on the value. **Recorded because it is why I know the deleted test *worked* — it was still the wrong test.**
