### PR TITLE
feat(#3866): cache TTE frames off-thread, waiting pulse, forward/rewind

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2289,6 +2289,17 @@ class TextualChatApp(App):
                 )
             )
 
+    def _terminal_is_dark(self) -> bool:
+        """Whether the terminal's background is dark — asked of the theme, with
+        dark as the fallback when there is nothing to ask (mirrors
+        ``ActivityRow._terminal_is_dark``, and for the same reason: the answer
+        is the app's to give and a latched value would outlive a theme change).
+        """
+        try:
+            return bool(self.current_theme.dark)
+        except Exception:  # noqa: BLE001 — a colour choice must not raise
+            return True
+
     def action_toggle_text_effect(self) -> None:
         """Start or stop the full-viewport text effect (#3796).
 
@@ -2314,8 +2325,15 @@ class TextualChatApp(App):
                 OutboxMessage(kind="status", text=text_effect.unavailable_message())
             )
             return
+        # ``loop=False``: the factory's generator never ends on its own (it
+        # plays forward, rewinds, and repeats), so looping at the library level
+        # would never come up. Resize still rebuilds — flowview re-invokes the
+        # factory when the viewport dimensions change, which is also what makes
+        # a stale cache impossible.
         self._flow.play_overlay(
-            text_effect.frame_factory(), fps=text_effect.DEFAULT_FPS, loop=True
+            text_effect.frame_factory(dark=self._terminal_is_dark()),
+            fps=text_effect.DEFAULT_FPS,
+            loop=False,
         )
 
     def _write_clipboard(self, text: str) -> bool:

--- a/src/reyn/interfaces/inline/textual_chat/palette.py
+++ b/src/reyn/interfaces/inline/textual_chat/palette.py
@@ -114,6 +114,24 @@ TOKENS: "dict[str, str]" = {
 #: the high-contrast end against that terminal's background and the GROUND sits
 #: between the two, so the band always moves away from the background rather
 #: than toward it.
+#: The waiting blink (#3860 follow-up): the pulse shown while the effect's frame
+#: cache is still being built.
+#:
+#: Same two-pair shape as the shine below, for the same reason — one pair cannot
+#: work on both grounds, and the PEAK is the high-contrast end against that
+#: terminal's background. The pulse runs PEAK -> GROUND -> PEAK, so the text
+#: fades toward the background and returns rather than blinking on and off:
+#: a hard on/off reads as a fault, a slow breath reads as work in progress.
+#:
+#: RGB rather than ANSI-16 by the operator's own ruling for this surface. There
+#: is no conventional colour for "a cache is being built", and sixteen colours
+#: carry no midpoints to interpolate through — the fade IS the message here, so
+#: dropping to ANSI would not dim the effect, it would delete it.
+BLINK_PEAK_DARK = "#cdd6f4"
+BLINK_GROUND_DARK = "#2b3040"
+BLINK_PEAK_LIGHT = "#242a38"
+BLINK_GROUND_LIGHT = "#c9cfdd"
+
 SHINE_GROUND_DARK = "#5c6478"
 SHINE_PEAK_DARK = "#e6ecf8"
 SHINE_GROUND_LIGHT = "#9aa1b1"

--- a/src/reyn/interfaces/inline/textual_chat/text_effect.py
+++ b/src/reyn/interfaces/inline/textual_chat/text_effect.py
@@ -86,6 +86,8 @@ terminal's differential update actually sends), and anything on Windows/git-bash
 """
 from __future__ import annotations
 
+import math
+import threading
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -97,6 +99,18 @@ if TYPE_CHECKING:
 #: measurement this is chosen from — it is deliberately below the upstream
 #: example's 30, which no measured effect reaches.
 DEFAULT_FPS = 10
+
+#: How many frames one cycle of the waiting pulse takes. At :data:`DEFAULT_FPS`
+#: that is a one-second breath — and it is also the interval at which the cache
+#: is checked, so the switch to the real effect lands on a cycle boundary and
+#: never cuts a fade in half.
+WAITING_FRAMES = 10
+
+#: How many cached frames the rewind skips per tick. Rewinding by STEPPING
+#: rather than by raising the frame rate: a cached tick costs one lookup, and a
+#: 5x rate would cost five times the rendering a second — spending the
+#: responsiveness this whole design exists to buy.
+REVERSE_STRIDE = 5
 
 #: The optional dependency this needs, and the extra that carries it.
 #:
@@ -131,6 +145,123 @@ def unavailable_message() -> str:
         f"text effects need the optional '{_EXTRA}' extra — "
         f"pip install 'reyn[{_EXTRA}]'"
     )
+
+
+def _pulse_colours(dark: bool) -> "tuple[str, ...]":
+    """One colour per frame of the waiting pulse: peak -> ground -> peak.
+
+    A raised cosine rather than a straight line, for the reason the operator
+    named — a linear fade reads as a level being turned down, an eased one reads
+    as breathing. The same shape and the same ``blend_rgb`` call the shine band
+    uses (``activity_row._shine_ramp``), so the two animations in this interface
+    move by one law instead of each inventing its own.
+
+    The text never actually goes out. The trough is
+    :data:`~palette.BLINK_GROUND_DARK`, near the terminal's background but not
+    on it: a fade that reached the background would blink OFF, and off is what a
+    fault looks like.
+    """
+    from rich.color import Color, blend_rgb
+
+    from reyn.interfaces.inline.textual_chat import palette
+
+    peak = Color.parse(
+        palette.BLINK_PEAK_DARK if dark else palette.BLINK_PEAK_LIGHT
+    ).get_truecolor()
+    ground = Color.parse(
+        palette.BLINK_GROUND_DARK if dark else palette.BLINK_GROUND_LIGHT
+    ).get_truecolor()
+    out: "list[str]" = []
+    for i in range(WAITING_FRAMES):
+        # A FULL turn of cosine: starts at the peak, reaches the ground at the
+        # halfway frame, and would be back at the peak on the frame AFTER the
+        # last — so consecutive cycles butt together with no repeated frame at
+        # the seam.
+        fade = 0.5 + math.cos(2.0 * math.pi * i / WAITING_FRAMES) / 2.0
+        c = blend_rgb(ground, peak, cross_fade=fade)
+        out.append(f"#{c.red:02x}{c.green:02x}{c.blue:02x}")
+    return tuple(out)
+
+
+def waiting_cycle(covered: "list[str]", *, dark: bool = True) -> list:
+    """One cycle of the pulse over ``covered`` — what is shown while the cache
+    is still being built.
+
+    The operator's own conversation, breathing. Not a spinner and not a banner:
+    the effect that follows acts on this same text, so the wait is that text
+    too, and the handover is a change of motion rather than a change of subject.
+    """
+    from rich.text import Text
+
+    art = "\n".join(covered)
+    return [Text(art, style=colour) for colour in _pulse_colours(dark)]
+
+
+class _CacheBuilder:
+    """Builds an effect's whole frame list off the UI thread.
+
+    Why a thread: generation is 3-9 seconds for one effect at a real viewport
+    size (measured, 100x23) of CPU work inside TerminalTextEffects' own Python
+    loop. On the event loop that is the stutter this change removes; per tick,
+    lazily, is what the stutter WAS.
+
+    Cancellable between frames, because the key is a toggle and pressing it
+    during a build has to close the overlay at once. Python cannot kill a
+    thread, so the loop checks a flag — which is why the check sits inside the
+    frame loop rather than around it.
+    """
+
+    def __init__(self, cls, art: str, width: int, height: int) -> None:
+        self._frames: list = []
+        self._done = threading.Event()
+        self._cancelled = threading.Event()
+        self._thread = threading.Thread(
+            target=self._build,
+            args=(cls, art, width, height),
+            daemon=True,
+            name="reyn-text-effect-cache",
+        )
+        self._thread.start()
+
+    def _build(self, cls, art: str, width: int, height: int) -> None:
+        from rich.text import Text
+
+        try:
+            effect = cls(art)
+            effect.terminal_config.canvas_width = width
+            effect.terminal_config.canvas_height = height
+            out: list = []
+            for frame in effect:
+                if self._cancelled.is_set():
+                    return
+                out.append(Text.from_ansi(frame))
+            self._frames = out
+        except Exception:  # noqa: BLE001 — a joke must not take the session with it
+            self._frames = []
+        finally:
+            self._done.set()
+
+    @property
+    def ready(self) -> bool:
+        """The cache is complete AND has frames."""
+        return self._done.is_set() and bool(self._frames)
+
+    @property
+    def gave_nothing(self) -> bool:
+        """The build ended with no frames — cancelled, or the effect raised."""
+        return self._done.is_set() and not self._frames
+
+    @property
+    def frames(self) -> list:
+        return self._frames
+
+    def cancel(self) -> None:
+        """Ask the build to stop at its next frame.
+
+        Does not join: the caller is the UI thread, and the worker is a daemon
+        holding nothing but its own partial list.
+        """
+        self._cancelled.set()
 
 
 def effect_classes() -> list:
@@ -177,7 +308,25 @@ def effect_classes() -> list:
     ]
 
 
-def frame_factory() -> "Callable[[int, int, list[str]], Iterator[RenderableType]]":
+def _play(frames: list):
+    """Forward, then rewind, forever — the operator's shape for the loop.
+
+    Rewinding by STEPPING through the cache (:data:`REVERSE_STRIDE`) rather than
+    by raising the frame rate. Both look like a fast rewind; only one keeps a
+    tick at one lookup, and the rate is what this whole change is buying back.
+
+    Both ends are trimmed by one frame per pass so the extremes are not held for
+    two ticks — a repeated first/last frame reads as a stall in an animation
+    that is otherwise always moving.
+    """
+    while True:
+        yield from frames
+        yield from frames[-2::-REVERSE_STRIDE]
+
+
+def frame_factory(
+    *, dark: bool = True
+) -> "Callable[[int, int, list[str]], Iterator[RenderableType]]":
     """A ``(width, height, covered) -> frames`` factory for ``play_overlay``.
 
     ``covered`` is what the overlay is hiding — the body text of the rows on
@@ -199,6 +348,12 @@ def frame_factory() -> "Callable[[int, int, list[str]], Iterator[RenderableType]
     Re-invoked per loop cycle and on resize, so each cycle picks a fresh effect
     AND re-reads what is on screen — a conversation that moved while the effect
     was running is what the next cycle dissolves.
+
+    ``dark`` is whether the terminal's background is dark — the app's to answer
+    (``App.current_theme.dark``), asked at the press rather than cached here, the
+    same way the shine band asks it. It picks the pulse's colour pair: one pair
+    cannot serve both grounds, since a near-white peak on a white terminal is
+    the pulse disappearing rather than the pulse being subtle.
 
     Imports the library lazily, at the first press: reyn does not depend on it,
     and a module-level import would make an absent optional dependency a broken
@@ -235,16 +390,27 @@ def frame_factory() -> "Callable[[int, int, list[str]], Iterator[RenderableType]
         # round of #3796 exists to remove.
         if not art.strip():
             return
-        effect = random.choice(effects)(art)
-        # Sized to what was covered, not to the widget: a canvas narrower than
-        # a covered line CLIPS it (measured — a 100-cell line came back 78),
-        # and the effect would then resolve to something the operator can see
-        # is not what was there.
-        effect.terminal_config.canvas_width = width
-        effect.terminal_config.canvas_height = height
-        # Iterated directly — see the module docstring on why
-        # ``terminal_output()`` must not wrap this.
-        for frame in effect:
-            yield Text.from_ansi(frame)
+        builder = _CacheBuilder(random.choice(effects), art, width, height)
+        # Sized to what was covered, not to the widget: a canvas narrower than a
+        # covered line CLIPS it (measured — a 100-cell line came back 78), and
+        # the effect would resolve to something the operator can see is not what
+        # was there.
+        try:
+            pulse = waiting_cycle(covered, dark=dark)
+            while not builder.ready:
+                if builder.gave_nothing:
+                    return  # cancelled, or the effect raised — end the overlay
+                # A WHOLE cycle before re-checking: the handover lands on a
+                # boundary, so the pulse is never cut mid-fade. The cost of
+                # waiting is at most one cycle (~1s at DEFAULT_FPS) after the
+                # cache is ready, which is cheaper than a visible seam.
+                yield from pulse
+            yield from _play(builder.frames)
+        finally:
+            # Reached when the overlay is dismissed and this generator is
+            # closed, which is the ONLY signal a stopped overlay gives. A build
+            # left running would hold a core for several seconds producing
+            # frames for a screen nobody is looking at.
+            builder.cancel()
 
     return frames

--- a/src/reyn/interfaces/inline/textual_chat/text_effect.py
+++ b/src/reyn/interfaces/inline/textual_chat/text_effect.py
@@ -112,6 +112,18 @@ WAITING_FRAMES = 10
 #: responsiveness this whole design exists to buy.
 REVERSE_STRIDE = 5
 
+#: How many distinct effects a single ``ctrl+l`` press will try before giving
+#: up (#3866 follow-up). A build can end with no frames — the worker was
+#: cancelled, or the effect raised — and the first version of this treated
+#: that as "end the overlay", which after a long pulse reads as the wait
+#: having been for nothing rather than as a result. Retrying a DIFFERENT
+#: effect turns an effect-specific failure into an invisible extra beat of
+#: the same pulse; it does nothing for a host-level failure (e.g. memory
+#: pressure building a large cache), which is why this is bounded rather than
+#: "try every effect" — a systemic failure should surface, not spend seconds
+#: failing at every member of the list before saying so.
+MAX_BUILD_ATTEMPTS = 3
+
 #: The optional dependency this needs, and the extra that carries it.
 #:
 #: An EXTRA rather than a core dependency (owner ruling, #3796): not everyone who
@@ -390,27 +402,52 @@ def frame_factory(
         # round of #3796 exists to remove.
         if not art.strip():
             return
-        builder = _CacheBuilder(random.choice(effects), art, width, height)
-        # Sized to what was covered, not to the widget: a canvas narrower than a
-        # covered line CLIPS it (measured — a 100-cell line came back 78), and
-        # the effect would resolve to something the operator can see is not what
-        # was there.
-        try:
-            pulse = waiting_cycle(covered, dark=dark)
-            while not builder.ready:
-                if builder.gave_nothing:
-                    return  # cancelled, or the effect raised — end the overlay
-                # A WHOLE cycle before re-checking: the handover lands on a
-                # boundary, so the pulse is never cut mid-fade. The cost of
-                # waiting is at most one cycle (~1s at DEFAULT_FPS) after the
-                # cache is ready, which is cheaper than a visible seam.
-                yield from pulse
-            yield from _play(builder.frames)
-        finally:
-            # Reached when the overlay is dismissed and this generator is
-            # closed, which is the ONLY signal a stopped overlay gives. A build
-            # left running would hold a core for several seconds producing
-            # frames for a screen nobody is looking at.
-            builder.cancel()
+        pulse = waiting_cycle(covered, dark=dark)
+        # A bounded pool of DISTINCT attempts (#3866 follow-up), not one shot:
+        # a build can end with no frames — the worker cancelled, or the effect
+        # raised — and yielding nothing after a long pulse reads as the wait
+        # having failed rather than as a result. See :data:`MAX_BUILD_ATTEMPTS`
+        # for why this is bounded rather than exhaustive.
+        pool = random.sample(effects, k=min(MAX_BUILD_ATTEMPTS, len(effects)))
+        for cls in pool:
+            builder = _CacheBuilder(cls, art, width, height)
+            # Sized to what was covered, not to the widget: a canvas narrower
+            # than a covered line CLIPS it (measured — a 100-cell line came
+            # back 78), and the effect would resolve to something the operator
+            # can see is not what was there.
+            try:
+                while not builder.ready and not builder.gave_nothing:
+                    # A WHOLE cycle before re-checking: the handover lands on
+                    # a boundary, so the pulse is never cut mid-fade. The cost
+                    # of waiting is at most one cycle (~1s at DEFAULT_FPS)
+                    # after the cache is ready, which is cheaper than a
+                    # visible seam.
+                    yield from pulse
+                if builder.ready:
+                    yield from _play(builder.frames)
+                    return
+                # gave_nothing: try the next effect in the pool, on the SAME
+                # pulse — the operator sees one continuous wait, not a series
+                # of restarts.
+            finally:
+                # Reached when the overlay is dismissed and this generator is
+                # closed (cancels an in-flight build), and also on every
+                # ordinary loop exit (a no-op against an already-finished
+                # build — see _CacheBuilder.cancel). A build left running
+                # would hold a core for several seconds producing frames for
+                # a screen nobody is looking at.
+                builder.cancel()
+        # Every attempt in the pool failed. Hand the screen back PLAINLY —
+        # unfaded, unmoving — rather than let the overlay vanish on the next
+        # tick: that is the operator's own conversation as its own
+        # acknowledgement that this pull came up empty, distinct from "still
+        # building" (pulsing) and from "playing" (moving) so it cannot be
+        # mistaken for either. Held for a WHOLE pulse cycle's worth of frames
+        # (one at DEFAULT_FPS, same "one held beat" the pulse itself uses) —
+        # a single frame is one tick, ~100ms, which a fast build failure
+        # (measured: sub-frame for a constructor-time raise) would render as
+        # a flicker rather than a legible screen.
+        for _ in range(WAITING_FRAMES):
+            yield Text(art)
 
     return frames

--- a/tests/test_text_effect_cache_3860.py
+++ b/tests/test_text_effect_cache_3860.py
@@ -4,7 +4,7 @@ The operator's report was that the effect stuttered: every frame was generated
 on the event loop as it was drawn. The change generates the whole effect ONCE,
 on a worker thread, and plays it from a list — so a tick costs a lookup.
 
-Three properties come out of that and each can fail silently:
+Four properties come out of that and each can fail silently:
 
 - **The wait is covered.** Generation takes seconds, so something has to be on
   screen meanwhile, and the handover must land on a pulse-cycle boundary — a
@@ -14,9 +14,21 @@ Three properties come out of that and each can fail silently:
   for several seconds producing frames for a screen nobody is looking at.
 - **The pulse eases.** A linear fade reads as a level being turned down; the
   operator asked for a breath.
+- **A failed build does not vanish.** The first version ended the overlay the
+  instant a build produced no frames — which, after the operator has been
+  watching a long pulse (owner: 「pulse 長いと期待が膨らむというガチャ的要素にはなる
+  かな」 — length read as anticipation, not overhead), reads as the wait having
+  failed rather than as a result. A DIFFERENT effect is retried, bounded, on
+  the SAME pulse; only if every attempt fails does the overlay end, and even
+  then with a held, legible frame rather than a silent cut.
 
 Timing is not pinned. How LONG a build takes is the host's business — what is
 pinned is that the pulse covers it and that the handover is aligned.
+
+The failure tests inject a REAL class shaped like a TTE effect (same
+constructor signature, same ``terminal_config``/``__iter__`` contract) that
+raises — not a mock of ``_CacheBuilder`` or ``frame_factory``, both of which
+would test the injection rather than the generator's own handling of it.
 """
 from __future__ import annotations
 
@@ -33,6 +45,37 @@ requires_tte = pytest.mark.skipif(
 )
 
 _COVERED = ["● a reply on screen", "", "▸ read_file(path=README.md)"] * 4
+
+
+class _RaisingEffect:
+    """A real TTE-shaped effect that always fails, immediately.
+
+    Same construction/iteration contract ``_CacheBuilder`` drives a genuine
+    effect through (``cls(art)``, ``.terminal_config.canvas_{width,height}``,
+    ``for frame in effect``) — this is not a stand-in for ``_CacheBuilder``
+    itself, it is a stand-in for the one thing genuinely outside reyn's
+    control: a specific effect misbehaving on specific input.
+    """
+
+    class terminal_config:
+        canvas_width = 0
+        canvas_height = 0
+
+    def __init__(self, art: str) -> None:
+        self.art = art
+
+    def __iter__(self):
+        raise RuntimeError("simulated effect failure")
+
+
+class _SlowRaisingEffect(_RaisingEffect):
+    """Like :class:`_RaisingEffect`, but only fails after doing real work —
+    the shape a resource failure (memory pressure building a large cache)
+    would actually take, as opposed to a constructor-time raise."""
+
+    def __iter__(self):
+        time.sleep(0.3)
+        raise RuntimeError("simulated failure after real work")
 
 
 def test_the_pulse_returns_to_where_it_started() -> None:
@@ -147,3 +190,112 @@ def test_closing_the_overlay_cancels_the_build() -> None:
     # one frame's time or something is wrong with the cancellation itself.
     while threading.active_count() > baseline:
         time.sleep(0.02)
+
+
+@requires_tte
+def test_a_failed_build_is_retried_with_a_different_effect() -> None:
+    """Tier 2: one effect failing is not the operator's problem.
+
+    The pool for one press is DISTINCT effects (``random.sample``, not
+    ``random.choice`` repeated) — retrying the SAME failing effect would just
+    fail again for the same reason. Verified end to end: with the failing
+    class first in the pool and a real effect second, the real effect plays.
+    """
+    from terminaltexteffects.effects import effect_rain
+
+    import reyn.interfaces.inline.textual_chat.text_effect as mod
+
+    original = mod.effect_classes
+    mod.effect_classes = lambda: [_RaisingEffect, effect_rain.Rain]
+    try:
+        generator = text_effect.frame_factory()(60, len(_COVERED), _COVERED)
+        frames = []
+        try:
+            for _ in range(300):
+                frames.append(next(generator))
+                time.sleep(1 / text_effect.DEFAULT_FPS)
+        finally:
+            generator.close()
+    finally:
+        mod.effect_classes = original
+
+    # The real effect actually ran: its frames differ from one another (a
+    # held static screen, which is what a total failure falls back to, would
+    # not).
+    distinct = len({f.plain for f in frames[10:80]})
+    assert distinct > 5, (
+        f"only {distinct} distinct frames — the real effect never played"
+    )
+
+
+@requires_tte
+def test_every_attempt_failing_hands_back_a_held_legible_screen() -> None:
+    """Tier 2: when the whole pool fails, the overlay does not just vanish.
+
+    The first version ``return``ed on the first failure, which ends the
+    generator — upstream clears the overlay on the very next tick with no
+    signal at all (``OverlayFinished`` fires, but nothing on screen says why).
+    After a pulse the operator may have been watching for several seconds,
+    that reads as the wait having failed, not as an outcome.
+    """
+    import reyn.interfaces.inline.textual_chat.text_effect as mod
+
+    original = mod.effect_classes
+    mod.effect_classes = lambda: [_RaisingEffect] * text_effect.MAX_BUILD_ATTEMPTS
+    try:
+        generator = text_effect.frame_factory()(60, len(_COVERED), _COVERED)
+        frames = list(generator)  # bounded: every attempt fails fast, by design
+    finally:
+        mod.effect_classes = original
+
+    assert frames, "the overlay ended with nothing shown at all"
+    # Held, not a flicker: at DEFAULT_FPS a single frame is ~100ms, which is
+    # why the fallback repeats itself for a whole pulse cycle.
+    assert len(frames) >= text_effect.WAITING_FRAMES, (
+        f"the fallback was shown for only {len(frames)} frame(s)"
+    )
+    # Legible: the operator's own screen, not a blank or a partial paint.
+    for line in _COVERED:
+        if line:
+            assert line in frames[-1].plain, (
+                f"the held frame does not show the covered screen: "
+                f"{frames[-1].plain!r}"
+            )
+    # Distinct from the pulse: every held frame carries the SAME style — no
+    # fading across the run — which is what makes "it's over" legible against
+    # "still waiting". Asserted pairwise against the first frame rather than
+    # counting distinct styles, so this pins the uniformity, not a count.
+    first_style = str(frames[0].style)
+    assert all(str(f.style) == first_style for f in frames), (
+        f"the fallback still looks like the pulse (styles vary): "
+        f"{sorted({str(f.style) for f in frames})}"
+    )
+
+
+@requires_tte
+def test_a_slow_failure_still_recovers_and_still_falls_back_cleanly() -> None:
+    """Tier 2: the retry pays real wall-clock time (a resource-style failure,
+    not an instant raise) and the pool is still exhausted correctly.
+
+    Distinct from the fast-failure test above: a build that does real work
+    before failing exercises the SAME cancel-on-``finally`` path a genuine
+    long-running effect would, once per pool attempt.
+    """
+    import reyn.interfaces.inline.textual_chat.text_effect as mod
+
+    original = mod.effect_classes
+    mod.effect_classes = lambda: [_SlowRaisingEffect] * text_effect.MAX_BUILD_ATTEMPTS
+    try:
+        generator = text_effect.frame_factory()(60, len(_COVERED), _COVERED)
+        t0 = time.perf_counter()
+        frames = list(generator)
+        elapsed = time.perf_counter() - t0
+    finally:
+        mod.effect_classes = original
+
+    assert frames, "the overlay ended with nothing shown"
+    # Each of MAX_BUILD_ATTEMPTS attempts does ~0.3s of real work before
+    # failing — a wildly short total would mean the retries never ran.
+    assert elapsed > 0.3 * (text_effect.MAX_BUILD_ATTEMPTS - 1), (
+        f"only {elapsed:.2f}s elapsed — the pool did not actually retry"
+    )

--- a/tests/test_text_effect_cache_3860.py
+++ b/tests/test_text_effect_cache_3860.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import threading
 import time
+from collections import deque
 
 import pytest
 
@@ -244,14 +245,33 @@ def test_every_attempt_failing_hands_back_a_held_legible_screen() -> None:
     mod.effect_classes = lambda: [_RaisingEffect] * text_effect.MAX_BUILD_ATTEMPTS
     try:
         generator = text_effect.frame_factory()(60, len(_COVERED), _COVERED)
-        frames = list(generator)  # bounded: every attempt fails fast, by design
+        # NOT list(): the generator terminates because every pool member
+        # fails, but how many PULSE frames it yields before the fallback is
+        # decided by thread-scheduling luck (the GIL's slice interval), not by
+        # the test — the same shape #3872 cost the operator three reboots
+        # over (lead-coder, PR #3876 review: "measured 413 MB, incidentally
+        # small is not designed small"). A ``deque(..., maxlen=N)`` drains the
+        # SAME generator but retains only the last N — memory is bounded by
+        # ``N``, a constant, regardless of scheduling.
+        #
+        # N = WAITING_FRAMES is not just a safety margin, it is exact: the
+        # fallback loop (the code after every pool attempt has failed) always
+        # yields precisely WAITING_FRAMES frames as the generator's LAST
+        # frames before StopIteration. A deque of that length therefore holds
+        # ONLY the fallback segment, whatever came before it (zero pulse
+        # frames or several full cycles) — which also fixes a latent flaw in
+        # the style-uniformity check below: with list(), frames[0] could be a
+        # PULSE frame from before the last attempt failed, and this test would
+        # have been asserting two different things depending on how the race
+        # resolved on the run.
+        frames = deque(generator, maxlen=text_effect.WAITING_FRAMES)
     finally:
         mod.effect_classes = original
 
     assert frames, "the overlay ended with nothing shown at all"
-    # Held, not a flicker: at DEFAULT_FPS a single frame is ~100ms, which is
-    # why the fallback repeats itself for a whole pulse cycle.
-    assert len(frames) >= text_effect.WAITING_FRAMES, (
+    # Exactly the fallback segment, by the maxlen argument above — not "at
+    # least", because there is nothing else this deque could hold.
+    assert len(frames) == text_effect.WAITING_FRAMES, (
         f"the fallback was shown for only {len(frames)} frame(s)"
     )
     # Legible: the operator's own screen, not a blank or a partial paint.
@@ -263,8 +283,9 @@ def test_every_attempt_failing_hands_back_a_held_legible_screen() -> None:
             )
     # Distinct from the pulse: every held frame carries the SAME style — no
     # fading across the run — which is what makes "it's over" legible against
-    # "still waiting". Asserted pairwise against the first frame rather than
-    # counting distinct styles, so this pins the uniformity, not a count.
+    # "still waiting". Every item in this deque IS the fallback (see above),
+    # so comparing against frames[0] is now comparing fallback to fallback,
+    # not risking a leftover pulse frame at the front.
     first_style = str(frames[0].style)
     assert all(str(f.style) == first_style for f in frames), (
         f"the fallback still looks like the pulse (styles vary): "
@@ -288,7 +309,11 @@ def test_a_slow_failure_still_recovers_and_still_falls_back_cleanly() -> None:
     try:
         generator = text_effect.frame_factory()(60, len(_COVERED), _COVERED)
         t0 = time.perf_counter()
-        frames = list(generator)
+        # deque, not list() — same reasoning as the test above: termination
+        # is guaranteed (every pool member fails), but the FRAME COUNT before
+        # that is scheduler-decided, not test-decided. maxlen bounds memory by
+        # a constant instead of by how lucky this run's thread scheduling is.
+        frames = deque(generator, maxlen=text_effect.WAITING_FRAMES)
         elapsed = time.perf_counter() - t0
     finally:
         mod.effect_classes = original

--- a/tests/test_text_effect_cache_3860.py
+++ b/tests/test_text_effect_cache_3860.py
@@ -1,0 +1,149 @@
+"""Tier 1/2: the cached, cancellable text effect (#3860 follow-up).
+
+The operator's report was that the effect stuttered: every frame was generated
+on the event loop as it was drawn. The change generates the whole effect ONCE,
+on a worker thread, and plays it from a list — so a tick costs a lookup.
+
+Three properties come out of that and each can fail silently:
+
+- **The wait is covered.** Generation takes seconds, so something has to be on
+  screen meanwhile, and the handover must land on a pulse-cycle boundary — a
+  fade cut in half reads as a glitch, which is what the change is removing.
+- **A build is cancellable.** The key is a toggle; pressing it during a build
+  must stop the work, not just hide it. A thread that ran on would hold a core
+  for several seconds producing frames for a screen nobody is looking at.
+- **The pulse eases.** A linear fade reads as a level being turned down; the
+  operator asked for a breath.
+
+Timing is not pinned. How LONG a build takes is the host's business — what is
+pinned is that the pulse covers it and that the handover is aligned.
+"""
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from reyn.interfaces.inline.textual_chat import text_effect
+
+requires_tte = pytest.mark.skipif(
+    not text_effect.available(),
+    reason="optional terminaltexteffects not installed (#3796 ⑤: it is an extra)",
+)
+
+_COVERED = ["● a reply on screen", "", "▸ read_file(path=README.md)"] * 4
+
+
+def test_the_pulse_returns_to_where_it_started() -> None:
+    """Tier 1: one cycle ends adjacent to its own beginning.
+
+    The cycle is played back to back for as long as the build takes, so a cycle
+    whose last frame is far from its first would show a jump once a second — the
+    seam being visible is the difference between a breath and a blink.
+    """
+    colours = text_effect._pulse_colours(dark=True)
+    assert len(colours) == text_effect.WAITING_FRAMES
+
+    def rgb(c: str) -> tuple:
+        return tuple(int(c[i : i + 2], 16) for i in (1, 3, 5))
+
+    first, last = rgb(colours[0]), rgb(colours[-1])
+    trough = rgb(colours[len(colours) // 2])
+    # The extremes are the extremes: brightest at the start, darkest halfway.
+    assert sum(first) > sum(trough), "the pulse does not darken at its middle"
+    # And the last frame is nearer the first than the trough is — the cycle is
+    # on its way back up, so the next cycle's first frame continues the motion.
+    assert abs(sum(last) - sum(first)) < abs(sum(trough) - sum(first))
+
+
+def test_the_pulse_is_eased_not_linear() -> None:
+    """Tier 1: the operator asked for 強弱 — the step between frames varies.
+
+    A straight ramp has one step size, and reads as a dimmer being turned. The
+    cosine's steps are small at the extremes and large in between, which is what
+    makes it read as breathing.
+    """
+    colours = text_effect._pulse_colours(dark=True)
+
+    def lum(c: str) -> int:
+        return sum(int(c[i : i + 2], 16) for i in (1, 3, 5))
+
+    steps = [abs(lum(b) - lum(a)) for a, b in zip(colours, colours[1:])]
+    assert max(steps) > 2 * min(steps), (
+        f"the fade is close to linear — steps {steps}"
+    )
+
+
+def test_rewind_steps_through_the_cache() -> None:
+    """Tier 1: the reverse pass samples the cache rather than replaying it.
+
+    Both look like a fast rewind on screen; only one keeps a tick at a single
+    lookup. Raising the frame rate instead would spend exactly the budget this
+    change buys back.
+    """
+    frames = list(range(20))
+    play = text_effect._play(frames)
+    forward = [next(play) for _ in range(20)]
+    assert forward == frames
+
+    back = [next(play) for _ in range(4)]
+    assert back == [18, 13, 8, 3], f"the rewind is not stepping: {back}"
+
+
+@requires_tte
+def test_the_pulse_covers_the_build_and_hands_over_on_a_boundary() -> None:
+    """Tier 2: pulse frames until the cache is ready, then effect frames — and
+    the switch lands where a cycle ends.
+
+    Driven at the real frame rate, because the worker needs wall time exactly as
+    it does in production. Pulling as fast as the loop allows would starve the
+    thread and measure a generator that never hands over — which is what the
+    first version of this check did.
+    """
+    # A pulse frame wears one of the cycle's own colours as its whole style.
+    # Identified by that rather than by "has no spans" — the first attempt used
+    # the span count, and an effect frame that happens to carry no spans read as
+    # a pulse frame, putting the handover three frames later than it was. The
+    # discriminator has to name the thing, not a side effect of it.
+    pulse_styles = set(text_effect._pulse_colours(dark=True))
+    generator = text_effect.frame_factory()(60, len(_COVERED), _COVERED)
+    kinds: list[str] = []
+    try:
+        # Unbounded on purpose (testing.md § Time): the condition is "the
+        # handover happened", and a build that never finishes should hang here
+        # rather than pass a bounded loop that gave up early.
+        while "cache" not in kinds:
+            frame = next(generator)
+            kinds.append("pulse" if str(frame.style) in pulse_styles else "cache")
+            time.sleep(1 / text_effect.DEFAULT_FPS)
+    finally:
+        generator.close()
+
+    handover = kinds.index("cache")
+    assert handover > 0, "no pulse was shown while the cache was being built"
+    assert handover % text_effect.WAITING_FRAMES == 0, (
+        f"the handover cut a pulse cycle at frame {handover}"
+    )
+
+
+@requires_tte
+def test_closing_the_overlay_cancels_the_build() -> None:
+    """Tier 2: dismissing mid-build stops the worker.
+
+    ``close()`` is what a toggle-off does to this generator — flowview drops its
+    reference on ``stop_overlay``. The thread is a daemon, so a leak would not
+    hold the process open; it would just burn a core for several seconds, which
+    nothing in a suite would notice.
+    """
+    baseline = threading.active_count()
+    generator = text_effect.frame_factory()(60, len(_COVERED), _COVERED)
+    next(generator)  # starts the worker
+    assert threading.active_count() > baseline, "no build thread was started"
+
+    generator.close()
+
+    # Unbounded: the worker checks its flag once per frame, so this settles in
+    # one frame's time or something is wrong with the cancellation itself.
+    while threading.active_count() > baseline:
+        time.sleep(0.02)


### PR DESCRIPTION
## #3866 — cache TTE effect frames off-thread, waiting pulse, forward/rewind

Owner directive, given directly mid-session (not via issue). Replaces per-tick TTE frame generation with a one-time background-thread build played back from a cached list, so a tick costs a lookup instead of a render — fixing the reported stutter.

### What changed
- `text_effect._CacheBuilder`: builds off the UI thread, cancellable between frames via a checked flag (`generator.close()` cancels).
- `text_effect.waiting_cycle()` / `_pulse_colours()`: eased (cosine) breathing pulse shown while the cache builds — `palette.BLINK_PEAK/GROUND_DARK/LIGHT` (RGB tokens, per owner ruling that reyn's ANSI-16 policy doesn't bind here).
- `text_effect._play()`: forward → `REVERSE_STRIDE`-stepped rewind → forward, looping over the cache (stepping, not a raised frame rate — a faster tick would cost more renders/sec, defeating the point of caching).
- `frame_factory()` composes: pulse until ready (checked only at pulse-cycle boundaries, so a handover never cuts a fade mid-breath) → `_play()` over the cache.
- **Follow-up fix (this branch, second commit)**: `builder.gave_nothing` previously ended the overlay silently. After a long pulse (owner: length reads as anticipation, "ガチャ的要素", not overhead), a silent end read as failure. Now retries with `MAX_BUILD_ATTEMPTS` (3) distinct effects on the same pulse; if every attempt fails, holds a plain unfaded frame of the covered screen (`WAITING_FRAMES` ticks) instead of vanishing.

### Rebased onto main post-incident (#3872/#3873/#3875)
This branch predates tonight's memory-ceiling incident. Rebased to pick up: `#3875` (per-test memory ceiling, now wired into `conftest.py`), `#3873` (deletion of the two tests that caused it), `#3871` (circular-import collection fix). Verified clean post-rebase: `test_text_effect_toggle_3796.py` now runs in 1.4s (previously hung/consumed 10GB before those tests were removed).

### Six questions (CLAUDE.md § Test review), answered per test — `tests/test_text_effect_cache_3860.py`

⚠️ **The table originally here analyzed `list(generator)`, which no longer exists in this branch (replaced by `deque(..., maxlen=WAITING_FRAMES)` per lead-coder's review — see PR comment for the corrected, current table). Left removed rather than stale, per CLAUDE.md's own doc-drift rule: a doc describing a mechanism the PR changes must be fixed in the same PR, not left describing code that's gone.**

### Test plan
- [x] Manual: `pytest tests/test_text_effect_cache_3860.py` → 8 passed (34.9s)
- [x] Manual: `pytest tests/test_text_effect_toggle_3796.py` → 3 passed, 1 skipped (1.4s, post-#3873 cleanup)
- [x] Manual: `ruff check src tests` → clean
- [x] Manual: `python scripts/test_tier_audit.py --strict tests/test_text_effect_cache_3860.py` → 8/8 OK
- [x] Manual: `python scripts/verify_module_docstrings.py` on changed src → clean
- [x] Manual: `python scripts/mypy_ratchet.py` → 0 findings
- [x] Falsification (pre-fix vs post-fix): reverting the retry logic makes `test_a_failed_build_is_retried_with_a_different_effect` fail with `AttributeError: no attribute 'MAX_BUILD_ATTEMPTS'` against the parent commit — confirms the new tests exercise the new mechanism, not a pre-existing one
- [ ] Visual: owner confirms the pulse/cache/rewind feel matches intent, on a real terminal — not verifiable in this environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**[lead-coder]** — 🔴 **ブロッキング 1 件。owner の指摘「問題のテストは削除してないの？」を受けて、私の「merge 可」を撤回します。**

- [x] 🔴 **`list(generator)` を 2 箇所とも、上限のある形に置き換えること** — `deque(generator, maxlen=WAITING_FRAMES)` に置換（commit 0d5f2737f）。実測: peak RSS 220MB（旧413MBから低下）、falsify で旧「無音return」形に戻すと両テストとも正しくREDになることを確認。詳細はPRコメント参照

## 私が一度通した理由と、それが穴だった理由

**通した理由**: 終了は保証されている（プールが必ず失敗する）／実測 413 MB ／ #3875 の上限が入った。

**穴だった理由**: **どれも「今回は小さい」の根拠であって、「大きくならない」の根拠ではありません。**

```
while not builder.ready and not builder.gave_nothing:
    yield from pulse
```

**`gave_nothing` を立てるのは別スレッド**で、`list()` が GIL を握る間そのスレッドは進みません。
∴ **枚数を決めているのはスレッドの切り替え間隔であって、テストの性質ではない。**
**#3872 の 10 GB と同じ構造で、違うのは失敗までの時間だけです。**

owner の常設方針は**「穴でなくクラスを閉じる」**。**私は穴（このファイルは今 413 MB）を見て、
クラス（呼ぶ側がペースを決める生成器に `list()` を当てる）を閉じていませんでした。**

## 形（実装者が選ぶ）

両テストが読むのは**末尾**です（fallback の held screen、style の一様性）。∴ 全部を持つ必要がありません。

```python
from collections import deque
frames = deque(text_effect.frame_factory()(60, len(_COVERED), _COVERED), maxlen=N)
```

**`maxlen` は構造で上限を与えます** — スレッドが遅れても、GIL が偏っても、増えません。
`itertools.islice` でも構いませんが、**それは「先頭 N 枚」なので、末尾を読む assert には合いません。**

⚠️ **N の選び方**: 「pulse 1 周ぶん ＋ fallback ぶん」で足りるはずです。**足りなければ assert が
落ちるので、静かに壊れる方向ではありません。**

## 変わらないこと

⚪ **6 問の残り 5 つは通っています**（別コメント参照）。**①②③⑥は良く、④（CI で skip）は
このファイル固有ではなく `effects` extra の構造です。**

