### PR TITLE
docs(#3872): say which answers block

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,10 +114,13 @@ that audit, passed review, and one of them cost the operator three reboots.
 
 Ask each test in the diff:
 
-1. **Whose contract is this?** reyn's / a third-party's / a past bug's. The last
-   two are Tier 4. (#3872: "a TTE effect resolves to its input" is TTE's promise;
-   `assert "reyn" not in final` is one defect's fingerprint, and any *other* wrong
-   string passes it.)
+1. **Which Tier does it fit — 1, 2, 3, or none?** Name the one, not the word
+   "Tier". `testing.md` is a whitelist: what fits no Tier is Tier 4 and is not
+   written. Two shapes that look like they fit and do not — **a third party's
+   property** (#3872: "a TTE effect resolves to its input" is TTE's promise, not
+   reyn's) and **a past bug's fingerprint** (`assert "reyn" not in final`, which
+   any *other* wrong string passes). Answering "it's reyn's" is not an answer:
+   reyn's own trivia fits no Tier either.
 2. **Is it the implementation, transcribed?** If the same expression appears on
    both sides, it can only fail when someone deliberately edits that line — and
    they will edit both. (#3872: `art = "\n".join(covered)` asserted back.)
@@ -145,12 +148,12 @@ So each question has a blocking answer, not just an answer:
 
 | | blocks when the answer is |
 |---|---|
-| 1 | a third party's, or a past bug's |
+| 1 | **none** — including a third party's, a past bug's, and reyn's own trivia |
 | 2 | yes — the same expression is on both sides |
 | 3 | yes — it stays green with the mechanism removed |
 | 4 | it would be green having never run, **and the PR does not say so** |
 | 5 | **anything outside the test bounds it** — a thread, a timer, the caller's pace |
-| 6 | the declared Tier is not the one question 1 reached |
+| 6 | the declared Tier is not the one question 1 named |
 
 ⚠️ 4 blocks on the *silence*, not on the skip: a file that skips whole in CI is
 often correct (an optional extra), and what makes it a defect is a green nobody

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,27 @@ Ask each test in the diff:
 6. **Is the declared Tier the true one?** Only a human can answer this; the audit
    cannot. Say which of 1's answers you reached and why.
 
+**Which answers block.** The questions produced the right observation on their
+first use and the PR merged anyway: #3876's ⑤ answer was "bounded only by the
+thread scheduler, not by the test" — written down, measured at 413 MB, and let
+through as a note. The operator had to ask why. **An answer recorded is not an
+answer acted on**, which is the same gap as an audit that reads a Tier string.
+So each question has a blocking answer, not just an answer:
+
+| | blocks when the answer is |
+|---|---|
+| 1 | a third party's, or a past bug's |
+| 2 | yes — the same expression is on both sides |
+| 3 | yes — it stays green with the mechanism removed |
+| 4 | it would be green having never run, **and the PR does not say so** |
+| 5 | **anything outside the test bounds it** — a thread, a timer, the caller's pace |
+| 6 | the declared Tier is not the one question 1 reached |
+
+⚠️ 4 blocks on the *silence*, not on the skip: a file that skips whole in CI is
+often correct (an optional extra), and what makes it a defect is a green nobody
+qualified. 5 has no such carve-out — "it is small today" is a measurement of
+today, and the runaway that started this was small until it wasn't.
+
 **Reviewer's note, on the PR:** record the answers per test before merging. A
 lead-coder merge train refuses any PR touching `tests/` without one — the promise
 "I will open the tests next time" is exactly the shape this replaces.


### PR DESCRIPTION
**[lead-coder]** — part of #3872. The operator asked whether the test-review procedure is working. **Half of it was.**

## What worked, on its first use (#3876)

- The merge train **refused the PR without a `TESTS-READ` note**, so I opened the tests
- **Question 5 returned an answer the PR body contradicted**: the body said "bounded by design"; the code is bounded by *the thread scheduler*, because `list()` holds the GIL while the thing it waits for needs it
- Question 4 surfaced that the whole file skips in CI
- I measured: 413 MB

## What did not

**I wrote all of that down and queued the merge anyway.**

"It is not bounded by the test — but it is 413 MB today" became a note rather than a stop. **The operator had to ask why the shape that cost three reboots was still there.**

**The questions were not the failure.** Treating their output as a record rather than a gate was — which is the same gap as an audit that matches a Tier *string* while nobody checks the claim. **These questions exist to close exactly that, and I reproduced it inside them on the first try.**

## The change

A blocking answer per question, so the checklist ends in a decision rather than a paragraph:

| | blocks when the answer is |
|---|---|
| 1 | a third party's, or a past bug's |
| 2 | yes — same expression both sides |
| 3 | yes — green with the mechanism removed |
| 4 | green having never run, **and the PR does not say so** |
| 5 | **anything outside the test bounds it** |
| 6 | declared Tier ≠ what question 1 reached |

⚠️ **4 blocks on the silence, not the skip.** A file that skips whole in CI is often correct — an optional extra. What makes it a defect is a green nobody qualified.

**5 gets no carve-out.** "It is small today" measures today. The 10 GB that started this was small until it was not.

## Test plan

- [x] `CLAUDE.md` only — no code
- [x] The #3876 example is the real one: [its TESTS-READ note](https://github.com/tya5/reyn/pull/3876#issuecomment-5227516531) contains the ⑤ answer I then failed to act on. **Cited rather than paraphrased, so the next reader sees the shape**
- [x] `ruff check src tests` — clean