### PR TITLE
docs(#3872): a Tier claim presupposes a named, externally-anchored contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,13 @@ Key constraints (full rationale in the doc):
   that lands the refactor**.
 - Each test docstring's first line must declare its Tier:
   `"""Tier 3a: ..."""`.
+- Declaring a Tier presupposes a named behavior/contract that exists
+  **outside** the test's own docstring (a doc, a charter lens, a decision
+  record, a user-visible promise) — not a new axis, the precondition
+  every Tier already carried. See `testing.md` § "The prerequisite every
+  tier shares." Distinct from the six questions below: that section asks
+  whether an already-tiered test is *well-formed*; this asks whether it
+  had standing to claim a tier at all.
 
 ## Test review — six questions, asked of the test's own code
 

--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -18,6 +18,77 @@ If a test cannot articulate which contract or invariant it protects, it is imple
 
 Tests in `tests/` belong to exactly one tier. The tier determines what the test pins, who the audience is, and when the test should change.
 
+### The prerequisite every tier shares
+
+**Owner ruling (2026-08-09).** This was implicit in every tier below since
+the day this document was written, but never stated as its own requirement
+— which is how a test could carry a Tier label without ever being checked
+against it. 79% of this repo's test functions currently declare `Tier 2`;
+that number describes how many tests *typed the label*, not how many meet
+what the label requires. Quoted verbatim, because the point of writing this
+down is to stop the requirement from travelling by word of mouth:
+
+> 「OS 不変条件は振る舞いと契約が前提だよ」
+> ("An OS invariant presupposes a behavior and a contract.")
+>
+> 「必要なのは振る舞いと契約」
+> ("What's required is a behavior or a contract.")
+>
+> 「こじつけた理由しかないなら削除すべき。Tier4 じゃないという判断自体も疑うべき」
+> ("If the only reason is contrived, delete it. Even the judgment that it
+> isn't Tier 4 should be doubted.")
+
+Claiming any tier — 1, 2, or 3 — presupposes two things, in order:
+
+1. **You can name, in one line, the behavior or contract this test
+   protects.** Not "it's reyn's" — reyn's own trivia can be named in one
+   line too, and fits no tier. Not the implementation ("this function is
+   written this way") and not a past bug's fingerprint ("X used to happen").
+2. **What you named exists somewhere other than this test's own
+   docstring.** A doc page, one of the [charter](../../concepts/architecture/charter.md)'s
+   eight lenses, a decision record (an issue or PR body), or a promise made
+   to a user. A reason that lives only inside the test that's supposed to
+   be justified by it is not an anchor — it's the test citing itself.
+
+```
+✓ "the overlay stays up and readable when the pool is fully dead"   — behavior
+✓ "an audit-event's type is a closed vocabulary"                     — contract
+✗ "a TTE effect resolves to its input"                — a third party's promise
+✗ "bug X used to happen here"                          — a past bug's fingerprint
+✗ "this function is written this way"                  — implementation, transcribed
+```
+
+**A test that fails this prerequisite was never classified as Tier 4 —
+it never had standing to claim a tier at all.** Tier 4 (below) is a
+considered judgment: this *shape* of test is recognized and excluded on
+purpose. Failing to name an anchor is different — there is nothing yet to
+judge. Say the shape is Tier 4 only once you can name what's missing;
+otherwise the honest state is "not yet classified."
+
+**Tier 2 (OS invariant) is where this bites hardest**, because the
+category's own name reads like permission: almost any assertion about OS
+behavior can be described as "an invariant." But an invariant is, by
+definition, something the OS has promised to always uphold — which means
+it already *is* a contract. If you cannot point to where that promise
+exists outside the test, what you have is not an invariant, and the test
+is not Tier 2 regardless of what its docstring's first line says.
+
+**This is not a new axis alongside `CLAUDE.md`'s "Test review — six
+questions"** — it's a different question, asked before those six. The six
+questions ask whether a test that already claims a tier is *well-formed*
+(does the assert survive a dead mechanism, is it a transcription, does it
+accumulate unboundedly, …). This prerequisite asks whether the test had
+any business claiming a tier in the first place. A test can pass all six
+quality questions and still fail this one — a well-formed assertion about
+something nobody promised is still pinning nothing real.
+
+**The mechanism does not check this today.** `scripts/test_tier_audit.py`
+matches a test's declared Tier line as a *string*
+(`^Tier [123][abc]?:`, case-insensitive) — a docstring that types "Tier 2:"
+passes the audit whether or not the behavior or contract it names exists
+anywhere outside that docstring. Naming an anchor and having one are
+different claims, and only a human reviewer checks the second.
+
 ### Tier 1 — Contract
 
 **Pins**: external boundaries that users / OSS contributors / integration scripts depend on.
@@ -129,7 +200,9 @@ Tests that fall in this list are **not** added to the suite, even when they woul
 
 ## Decision flow
 
-Before writing a test, answer these questions:
+Before writing a test, answer these questions. Each of Q1's tier answers
+still needs [the prerequisite above](#the-prerequisite-every-tier-shares)
+satisfied — naming a tier here is not itself the anchor.
 
 ```
 Q1. If this breaks, who notices?


### PR DESCRIPTION
**[docs-maintainer]** — owner裁定を relay された指示（lead-coder経由）に従い、`testing.md`に前提を明記しました。part of #3872.

## What

Every Tier 1/2/3 claim always presupposed a named behavior/contract that
exists **outside** the test's own docstring — this was never written down
as its own requirement, only implied. `test_tier_audit.py`'s Tier-line
check is a bare string match (`^Tier [123][abc]?:`), so a test could carry
a Tier label without the prerequisite ever being checked (79% of test
functions currently declare `Tier 2`).

## Owner's words (2026-08-09), quoted verbatim per instruction

> 「OS 不変条件は振る舞いと契約が前提だよ」
>
> 「こじつけた理由しかないなら削除すべき。Tier4 じゃないという判断自体も疑うべき」
>
> 「必要なのは振る舞いと契約」

Reproduced byte-exact in `testing.md` (verified via `expected_string in
file_content`, not by eyeballing — see the #3849 quote-reflow incident
this is the follow-up discipline for).

## Changes

- `docs/deep-dives/contributing/testing.md`: new subsection under
  `## Tier model`, **"The prerequisite every tier shares"**, stating the
  two-part test (① name the behavior/contract in one line ② the named
  thing exists somewhere other than this test's own docstring — a doc, a
  charter lens, a decision record, a user-visible promise). Failing it
  means the test never had standing to claim a Tier at all — distinct
  from Tier 4, which is a considered judgment about a recognized shape.
  Also notes `test_tier_audit.py`'s string-match gap explicitly.
- Added a one-line pointer from `## Decision flow`'s Q1 to the new
  section, so naming a tier there doesn't read as satisfying the
  prerequisite on its own.
- `CLAUDE.md`: short pointer bullet in the test key-constraints list,
  since `testing.md` is normative and CLAUDE.md is the entry point every
  session reads first (judged this needed per lead-coder's ask — the
  six-questions section already lives in CLAUDE.md, so a session reading
  only CLAUDE.md would otherwise miss this).
- **Explicitly does not contradict** CLAUDE.md's existing "Test review —
  six questions" section — cross-referenced, not duplicated. The six
  questions ask whether an already-tiered test is *well-formed*
  (quality); this prerequisite asks whether it had standing to claim a
  tier at all (existence). A test can pass all six questions and still
  fail this one.
- `testing.ja.md` left untouched — checked its Tier-model / decision-flow
  sections; it asserts nothing this change falsifies, and CLAUDE.md
  carries no blanket mirror obligation (rule 5).

## Test plan

- [x] Verbatim owner quotes present byte-exact in `testing.md`
      (`expected_string in file_content` check, all 3 pass)
- [x] `charter.md` relative link path verified to exist
      (`git cat-file -e HEAD:docs/concepts/architecture/charter.md`)
- [x] `.venv/bin/python scripts/verify_env_identity.py` → OK
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0, no new
      WARNING/Aborted lines (pre-existing ja-anchor INFO gaps only,
      unrelated to this change)
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q`
      → 332 passed
- [x] Rebased onto current `origin/main` (picked up #3883 after it
      merged mid-task) and re-ran the above gates post-rebase, all green
- [x] Remote branch head verified to match local commit via
      `git ls-remote origin refs/heads/docs/tier-existence-prerequisite`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
