### PR TITLE
chore(#3866): flowview 0.16.0 -> 0.16.1; delete two tests, not repair them

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,7 @@ dependencies = [
     # The SHA is the *commit*, not the tag object: v0.13.1/v0.12.0 are
     # LIGHTWEIGHT tags (no `^{}` peel in `git ls-remote`), same as v0.9.0,
     # unlike the annotated v0.7.0/v0.8.0.
-    "textual-flowview @ git+https://github.com/tya5/textual-flowview.git@c34ee6ed0d968ea885d2ce6815c715adbbb50faa",
+    "textual-flowview @ git+https://github.com/tya5/textual-flowview.git@3b256640678e3905cc67d6f7ba977eb79c96009b",
     "numpy>=1.24",           # RAG index backend cosine similarity (ADR-0033)
     "croniter>=2.0",         # cron expression parsing for FP-0009 Component B
     "charset-normalizer>=3.0",  # #1452 read_file encoding detection (MIT, pure-python)

--- a/tests/test_text_effect_toggle_3796.py
+++ b/tests/test_text_effect_toggle_3796.py
@@ -125,28 +125,24 @@ async def test_the_feed_is_intact_after_the_effect() -> None:
             f"output that landed under the overlay was lost, not hidden: {after}"
         )
 
-
-
-@requires_tte
-@pytest.mark.asyncio
-async def test_an_empty_screen_is_a_no_op_not_a_crash() -> None:
-    """Tier 2: the key on a fresh, empty conversation does nothing — and
-    specifically does not raise.
-
-    Not an exotic case: an empty viewport is blank rows, which join to
-    ``"\n\n\n..."``, and TTE raises ``ValueError`` on input that is non-empty
-    but carries no non-whitespace character (measured: ``""`` is accepted,
-    ``"\n\n\n"`` and ``"   "`` are not). The first thing an operator can do in
-    a new session is press the key, so this was the first thing that crashed.
-
-    A no-op is the truthful outcome rather than a fallback banner: the effect
-    acts on what is on screen, and an empty screen has nothing to act on.
-    """
-    app = TextualChatApp(transport=ScriptedTransport([]), read_model=_PickerReadModel())
-    async with app.run_test() as pilot:
-        await pilot.pause()
-        app.action_toggle_text_effect()  # must not raise
-        await pilot.pause()
-        assert not app.query_one(FlowView).overlay_active, (
-            "an empty screen started an overlay with nothing to animate"
-        )
+# The blank-screen no-op test that used to live here (#3796) is deleted, not
+# repaired, following the 0.16.1 pin bump that broke its premise (#3866 review).
+#
+# What it asserted — "a fresh session does not crash the key" — is real, but
+# already covered by a DIFFERENT test for a DIFFERENT reason: falsifying the
+# early `if not art.strip(): return` guard (removing it entirely) still did not
+# crash, because #3866's retry+fallback logic (test_every_attempt_failing_
+# hands_back_a_held_legible_screen, in test_text_effect_cache_3860.py) already
+# handles "every pool attempt fails" generally, blank input included. The early
+# guard is a skip-3-wasted-attempts optimization, not a distinct safety
+# contract — testing it separately was redundant.
+#
+# A second version of this test asserted the OPPOSITE: that a fresh session's
+# welcome placeholder ("reyn / Type a message to start / …") IS something the
+# effect animates. That one does not survive CLAUDE.md's six questions either,
+# for a sharper reason: reyn's own frame_factory does nothing with `covered`'s
+# CONTENT (it joins whatever it is handed) — whether the welcome text shows up
+# in `covered` at all is entirely flowview's capture behaviour, not reyn's. A
+# test that only fails when a THIRD PARTY changes what it reports is pinning
+# that party's property under reyn's name (Q1) — if flowview's capture shape
+# moves again, this would blame reyn for something reyn never touched.

--- a/tests/test_textual_chat_phase2_3273.py
+++ b/tests/test_textual_chat_phase2_3273.py
@@ -187,17 +187,12 @@ def test_flowview_library_is_unmodified_blink_lives_in_reyn() -> None:
     # The library's own primitives are defined in textual_flowview, untouched.
     assert Entry.set_state.__module__.startswith("textual_flowview")
     assert StateDecorator.decorate.__module__.startswith("textual_flowview")
-    # #3476/#3624: pinned to the version pyproject's git SHA resolves to — the
-    # pin here is what detects a locally-forked/vendored flowview masquerading
-    # as the release (a mismatch means the installed copy is not the pinned
-    # one).
-    # The version literal moves with every pin bump. It is kept because this
-    # test predates ``scripts/verify_env_identity.py`` (#3723), which now checks
-    # the same thing better — against the SHA in pyproject rather than a string
-    # someone has to remember to edit. Raised on the bump PR rather than
-    # removed here: deleting another gate mid-bump is how a bump hides a
-    # regression.
-    assert textual_flowview.__version__ == "0.16.0"
+    # #3476/#3624: this used to also pin ``textual_flowview.__version__`` to a
+    # literal string, but that string moves with every pin bump and always
+    # broke on one — flagged for removal on "the bump PR" back when it was
+    # written (#3866 is that bump). ``scripts/verify_env_identity.py`` (#3723)
+    # now checks the same thing better: against the SHA in pyproject rather
+    # than a string someone has to remember to edit.
     # The native animation primitive reyn now drives the blink through: FlowView
     # accepts an ``animation_fps`` and owns its own animation tick.
     import inspect


### PR DESCRIPTION
## #3866 follow-up — flowview 0.16.0 -> 0.16.1, and a deletion instead of a repair

Owner asked "flowview 最新取り込んだ?" after #3876 merged. It hadn't been — upstream had 5 new commits, including one real correctness gap.

### The gap 0.16.1 fixes

`covered` (the text handed to the effect factory) was built from `row_text` (0.16.0), which is deliberately body-only — it never included gutter/sticky-header/separator content. The overlay itself paints the FULL content width, so an effect running on `covered` was acting on less than what it visibly covers. reyn's conversation pane uses left/right gutters (toggleable — elapsed/tokens on the right), so under 0.16.0 the effect's own stated principle ("acts on what is on screen") was violated whenever a gutter was visible: gutter content sat there, untouched by the dissolve.

0.16.1's fix (upstream, same-day): `_overlay_covered_lines` now shares one composition path (`_content_line`) with `render_line` itself, so what's captured is exactly what's painted. Factory signature unchanged.

`text_effect.py` needed zero changes — verified by running the existing 8 cache tests unmodified against the new pin (all pass).

### What the rebase exposed, and what I did wrong first

Bumping the pin broke one test's premise: `"a fresh session is a blank screen"` was never quite true — reyn's own welcome placeholder ("reyn / Type a message to start / …") was always painted, just invisible to 0.16.0's narrower capture. My first pass **repaired** it — split it into two tests (a blank-canvas guard test, and a positive "welcome text is animated" test).

Owner's reaction, applying CLAUDE.md's six questions with more scrutiny than I did: **delete both, don't repair either.**

- The blank-canvas guard test is redundant. Falsifying the early `if not art.strip(): return` guard it protects does NOT crash — #3866's retry+fallback mechanism (`test_every_attempt_failing_hands_back_a_held_legible_screen`, already in `test_text_effect_cache_3860.py`) already handles "every pool attempt fails" generally, blank input included. The early guard is a skip-3-wasted-attempts optimization, not a distinct safety contract.
- The welcome-text test pins a THIRD PARTY's property under reyn's name. `text_effect.py` does nothing with `covered`'s content — it just joins whatever it's handed. Whether the welcome placeholder shows up in `covered` at all is entirely flowview's capture behaviour. If flowview's capture shape moves again, this test would blame reyn for something reyn never touched — exactly Q1's carve-out (a third party's property fits no Tier).

Both deleted, with the reasoning recorded as a residue comment at the deletion site rather than left implicit.

### What was different between my first pass and the correct one

I was in repair mode: a CI/rebase failure came in, and I fixed the assertion to match the new reality without asking whether the test should exist at all. The six questions were available and I'd literally just re-applied them to #3876 hours earlier — but applied them in "confirm this passes" order, not "should this exist" order. Recorded as a CLAUDE.md addition (separate PR, this same message thread) so the next session hits this from the start rather than rediscovering it.

### Test plan
- [x] Manual: `ruff check src tests` — clean
- [x] Manual: `pytest tests/test_text_effect_toggle_3796.py tests/test_text_effect_cache_3860.py` — 10 passed, 1 skipped (35.8s)
- [x] Manual: `python scripts/test_tier_audit.py --strict` on both changed test files — 11/11 OK
- [x] Manual: `python scripts/verify_module_docstrings.py` on changed files — clean
- [x] Manual: `python scripts/mypy_ratchet.py` — 0 findings
- [x] Manual: `python scripts/verify_env_identity.py` — OK, confirms venv matches the bumped pin (0.16.1)
- [x] Six questions, both deletions: answered in the commit message and above — both fail Q1 (redundant-with-existing-coverage / third-party-property), which is why neither survives as a repair
- [ ] Visual: not applicable — no behavior change, source untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] 🔴 **[lead-coder blocking]** (解消: c9854e0e1) `tests/test_textual_chat_phase2_3273.py` の `assert textual_flowview.__version__ == "0.16.0"` を **削除**（CI 赤の原因）。そのテスト自身のコメントが「`scripts/verify_env_identity.py` (#3723) が pyproject の SHA と照合してより厳密に同じことを見ている。**Raised on the bump PR rather than removed here**」と書いており、これがその bump PR です。⚠️ **1 行だけ。**残りの assert（`Entry.set_state.__module__` / `animation_fps` / `ReynGutter.decorate.__module__`）は「blink glyph は reyn の、cadence は native」という実在の契約を見ているので残すこと。

