### PR TITLE
docs(#3866): repair-mode vs delete-first, when a bump forces a test to move

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,37 @@ today, and the runaway that started this was small until it wasn't.
 lead-coder merge train refuses any PR touching `tests/` without one — the promise
 "I will open the tests next time" is exactly the shape this replaces.
 
+**When something forces you to touch a test — a dependency bump, a rebase, a CI
+failure — ask "should this exist" before "how do I make it pass again."** A
+flowview pin bump (0.16.0 → 0.16.1, #3886) broke one test's premise ("a fresh
+session is a blank screen" — it never quite was; reyn's own welcome placeholder
+was always painted, just invisible to the older, narrower capture). The first
+pass **repaired** it: split into a blank-canvas guard test and a positive
+welcome-text test, both green, six questions answered, gates clean. Wrong move —
+caught only because the operator asked "私ならそんなテスト捨てるけどね" (I'd just
+delete that test) after seeing the diff, not because anything in the checklist
+stopped it. Re-applying the six questions with delete as the live option, not
+repair:
+
+- The guard test was redundant — falsifying the guard it protects still didn't
+  crash, because `test_every_attempt_failing_hands_back_a_held_legible_screen`
+  already covers "every attempt fails" generally, blank input included.
+- The welcome-text test pinned a THIRD PARTY's property under reyn's name:
+  `text_effect.py` does nothing with `covered`'s content, so whether the
+  welcome placeholder shows up in `covered` at all is flowview's capture
+  behaviour, not reyn's — Q1's "third party" carve-out, missed because the
+  code on both sides of the assertion was reyn's own call site, not reyn's own
+  logic.
+
+Both deleted. **The failure mode was ORDER, not the checklist's content**: the
+same six questions were applied minutes earlier to the same PR and caught real
+things (#3876's review) — but applied in "does this still pass" order, which
+starts from the code that exists and looks for a way to keep it. Starting from
+"should this test exist at all" is a different search, and repair-mode never
+runs it. A rebase/bump forcing a touch is exactly the moment deletion is
+cheapest — the test is already broken, and "make it green" is not the only
+available action.
+
 ## PR workflow (READ BEFORE OPENING / REVIEWING A PR)
 
 This repo is touched by multiple Claude sessions (lead-coder, e2e-coder,


### PR DESCRIPTION
## Repair-mode vs delete-first, when a bump forces a test to move

Owner directive: share this with lead-coder, "とても重要なので" (this is important).

### What happened

A flowview pin bump (#3886) broke a test's premise. My first pass repaired it — split into two new tests, six questions answered per-test, all gates clean. The operator caught it instead, not the checklist: 「私ならそんなテスト捨てるけどね」(I'd just delete that test).

Re-applying the six questions with **delete** as a live option rather than repair-only:

- One test was redundant with `test_every_attempt_failing_hands_back_a_held_legible_screen` (#3866's own retry+fallback logic already covers the case it protected).
- The other pinned flowview's own capture behaviour under reyn's name — reyn's code does nothing with the content in question, so the test only fails when a third party changes, which is Q1's carve-out.

Both deleted. Full account: #3886's PR body and commit message.

### The actual finding (not just the incident)

The six questions weren't missing anything — I'd applied the SAME checklist to the SAME PR's other tests minutes earlier and it caught a real bug (#3876's list()-vs-deque issue). The difference was **order**: "does this still pass" (repair-mode) vs "should this exist at all" (delete-first). Repair-mode starts from the code that exists and searches for a way to keep it green; it never runs the second search. A dependency bump or rebase forcing a touch is exactly the moment deletion is cheapest — the test is already broken, so "make it green again" competing against "should this be here" is a fairer fight than it usually gets.

Recorded in CLAUDE.md § Test review, right after the six-questions blocking table, since it's a companion failure mode to the ones already there (an answer recorded but not acted on) — this one is an ORDER of operations gap, not a missing check.

### Test plan
- [x] Docs-only change, no code affected
- [ ] Visual: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
