### PR TITLE
docs(#3872): the circularity discriminator for an issue/PR anchor

### DIFF
--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -50,12 +50,34 @@ Claiming any tier — 1, 2, or 3 — presupposes two things, in order:
    to a user. A reason that lives only inside the test that's supposed to
    be justified by it is not an anchor — it's the test citing itself.
 
+An issue or PR number passes ② by *shape* whether or not it passes it in
+substance — "an issue exists" is not "an issue decided a behavior." A
+decision record is only a real anchor when what it decided is independent
+of the test that cites it:
+
+> **Discriminator: delete the test. Does the anchor's sentence go false?**
+> No, it still holds → the anchor describes reyn, independent of this test
+> → valid. Yes, it goes false → the anchor was describing *the test*, not
+> reyn → circular, not an anchor.
+
+The shape most likely to pass ② without meeting it: **the issue or PR that
+exists *because* this test was going to be written** — its body argues for
+adding the test, which is the same content as the test's own docstring,
+just filed in a different place. Most likely of all: **the PR that landed
+the test itself** — citing it as the anchor is, almost by construction,
+circular.
+
 ```
 ✓ "the overlay stays up and readable when the pool is fully dead"   — behavior
 ✓ "an audit-event's type is a closed vocabulary"                     — contract
+✓ issue #2074 body: "unify capability narrowing" (decides a behavior,
+  independent of any one test)
 ✗ "a TTE effect resolves to its input"                — a third party's promise
 ✗ "bug X used to happen here"                          — a past bug's fingerprint
 ✗ "this function is written this way"                  — implementation, transcribed
+✗ "PR #1234 body (names this exact test)"     — the PR that landed the test
+✗ "PR #1234 body: rationale for adding this test" — argues for the test,
+  same content as its docstring, filed elsewhere — still circular
 ```
 
 **A test that fails this prerequisite was never classified as Tier 4 —


### PR DESCRIPTION
**[docs-maintainer]** — follow-up to #3884, requested by lead-coder (architect's catch, lead-coder's own relayed gap). part of #3872.

## The hole

`testing.md`'s anchor list (#3884) explicitly permits "a decision record
(an issue or PR body)" as a valid anchor, while separately banning "the
test citing itself." Nothing closed the gap between those two: **an issue
or PR raised specifically to justify writing this exact test** sits
outside the docstring by *location*, but its content is the same as the
docstring — an argument for the test, not an independent fact about reyn.
Most acutely: **the PR that landed the test itself**, cited as its own
anchor.

## Why it matters at scale

Stage 1 measurement (architect, relayed by lead-coder): 8,474 tests, 5,273
(62%) carry an issue/PR number as an anchor candidate. Checking only "does
the issue/PR exist" (`gh issue view` returning something) would pass most
of that 62% by shape, silently reopening exactly the hole the owner's
「こじつけた理由しかないなら削除すべき」ruling was meant to close — a
declaration would substitute for a fact again, just wearing an issue
number instead of a docstring sentence.

## What's added

- A one-question discriminator: **delete the test — does the anchor's
  sentence go false?** Stays true → independent of the test → valid.
  Goes false → the anchor was describing the test, not reyn → circular.
- Real-shape examples pulled from M2's actual review batches (relayed by
  lead-coder): `PR #3138 body (names this exact test)` and `PR #2157
  body: ... (テスト PR 自身の設計 rationale)` as circular, `issue #2074
  body: "unify capability narrowing"` as valid (decides a behavior
  independent of any one test).

Placed directly after the anchor-category bullet added in #3884, before
the ✓/✗ example block (extended with the new cases) — same section, no
new heading, so a reader hits the discriminator before ever getting to
the examples.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0, no new
      WARNING/Aborted lines
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q`
      → 332 passed
- [x] Branch created off verified-current `origin/main` (post-#3887);
      remote head verified to match local via
      `git ls-remote origin refs/heads/docs/tier-anchor-circularity-discriminator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
