### PR TITLE
docs(#3872): a third-party's promise is not reyn's to test — generalize the carve-out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,14 @@ Ask each test in the diff:
    property** (#3872: "a TTE effect resolves to its input" is TTE's promise, not
    reyn's) and **a past bug's fingerprint** (`assert "reyn" not in final`, which
    any *other* wrong string passes). Answering "it's reyn's" is not an answer:
-   reyn's own trivia fits no Tier either.
+   reyn's own trivia fits no Tier either. "Third party's property" is a
+   discriminator, not a TTE-only example — it recurred unrecognized in the
+   sandbox suite (kernel-level SBPL/Landlock deny enforcement) precisely
+   because it had only ever been written down as one case. The general
+   form: *if this assert fails, whose bug is it?* — kernel/library code
+   fails it, reyn's own code doesn't. See `testing.md` § "Third-party
+   promises are not reyn's to test" for the full discriminator and the
+   twin-test tell that flags most kernel-level cases.
 2. **Is it the implementation, transcribed?** If the same expression appears on
    both sides, it can only fail when someone deliberately edits that line — and
    they will edit both. (#3872: `art = "\n".join(covered)` asserted back.)

--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -217,6 +217,66 @@ Tests that fall in this list are **not** added to the suite, even when they woul
 - **`unittest.mock` patches of `litellm`** — use the [Fake](#mock-vs-fake) (`LLMReplay`) path instead.
 - **Coverage targets** (e.g. "≥ 80% line coverage"). Coverage is a side-effect, not a goal. We do not gate PRs on it.
 - **TDD by default**. Test-first is appropriate for Tier 2 invariants (where the contract is clear before the implementation). For feature work, "make it work, then guard it" is preferred — premature tests freeze designs that haven't been validated.
+- **A third party's promise, tested as if it were reyn's** — see [Third-party promises are not reyn's to test](#third-party-promises-are-not-reyns-to-test) below.
+
+### Third-party promises are not reyn's to test
+
+**Owner ruling (2026-08-09).** The [prerequisite above](#the-prerequisite-every-tier-shares)
+already excludes a third party's property from the anchor examples (a TTE
+effect resolving to its input is TTE's promise, not reyn's) — but that was
+written down as one example, not as a discriminator, and a rule that only
+exists as an example doesn't transfer: the same shape recurred in the
+sandbox suite (kernel-level SBPL/Landlock deny enforcement) without being
+recognized as the same case, because nothing generalized "TTE" to "any
+dependency reyn doesn't own."
+
+> **外部ライブラリの機能テストを reyn に入れるべきなの？**
+> ("Should a third-party library's own functionality be tested inside
+> reyn?")
+
+**Discriminator: if this assert fails, whose bug is it?**
+
+- Apple's sandbox profile compiler, the Linux kernel, a pinned library →
+  **third-party**. reyn does not carry this test.
+- reyn's own code → reyn's, write it.
+
+**Two boundary shapes get conflated as "one thing" — they aren't:**
+
+```
+✗ THE OTHER SIDE'S PROMISE
+  "the kernel enforces the SBPL/Landlock deny"
+  "reading ~/.ssh is actually refused"
+    ← reyn's own contract is "~/.ssh is in the default policy" —
+      and a string/structural test already verifies that in CI
+
+✓ REYN'S OWN USE OF IT
+  "reyn's policy actually reaches the enforcement point and doesn't fail
+   silently"
+  "the deny leg fires on the real backend and fails on the Noop backend"
+    ← a dead wire looks identical to "denied" on either backend; this is
+      reyn's own self-diagnosis, not the kernel's behavior
+  "a backend that enforces write but ignores allow_subprocess passes
+   Stage 1" (#3017)
+    ← names what reyn's own self-test cannot witness
+```
+
+**The practical tell, before deciding either way**: look for the twin.
+
+```
+🔴 If a CI-running test already asserts the same claim at the
+   string/structural level, its kernel-level twin is almost always
+   THIRD-PARTY — the string-level test is what actually verifies reyn's
+   own contract, and the kernel-level version is re-testing the kernel.
+```
+
+**Industry framing** (the caveat below matters as much as the rule): don't
+test a dependency's own behavior — wrap it in an adapter and test the
+adapter (8th Light, "Unit Testing Code Boundaries" / "Don't Mock What You
+Don't Own"); don't test a framework's internals, the standard library, or
+a third-party library's behavior (TestRail). The caveat every source
+attaches: still write the integration test for *whether reyn is using the
+dependency correctly* — that's the ✓ column above, not excluded by this
+rule.
 
 ---
 


### PR DESCRIPTION
**[docs-maintainer]** — owner裁定を relay された指示（lead-coder経由）。CLAUDE.mdの six-questions ①の third-party carve-out を一般化しました。part of #3872.

## The gap

`CLAUDE.md`'s six-questions ① already carved out "a third party's
property" (#3872's TTE example: "a TTE effect resolves to its input" is
TTE's promise, not reyn's) — but it was written down as one example, not
a discriminator, and a rule that only exists as an example doesn't
transfer. The same shape recurred unrecognized in the sandbox suite
(kernel-level SBPL/Landlock deny enforcement), because nothing
generalized "TTE" to "any dependency reyn doesn't own."

## Owner's question (2026-08-09), relayed verbatim

> 外部ライブラリの機能テストを reyn に入れるべきなの？
> ("Should a third-party library's own functionality be tested inside reyn?")

## Discriminator

**If this assert fails, whose bug is it?** Apple's sandbox profile
compiler / the Linux kernel / a pinned library → third-party, reyn does
not carry this test. reyn's own code → reyn's, write it.

Two boundary shapes get conflated as one — they aren't:
- ✗ **the other side's promise** ("the kernel enforces the deny") — reyn's
  own contract ("~/.ssh is in the default policy") is already verified by
  a string/structural test in CI
- ✓ **reyn's own use of it** ("reyn's policy actually reaches the
  enforcement point and doesn't fail silently", "the deny leg fires on
  the real backend and fails on the Noop backend" — a dead wire looks
  identical to "denied" on either backend)

Practical tell: if a CI-running test already asserts the same claim at
the string/structural level, its kernel-level twin is almost always
third-party.

## Changes

- `docs/deep-dives/contributing/testing.md`: new subsection **"Third-party
  promises are not reyn's to test"** (in the Tier 4 area, cross-linked
  from a new Tier-4 bullet) — the discriminator, the two boundary shapes
  with real sandbox examples, the twin-test tell, and the industry
  framing (8th Light "Don't Mock What You Don't Own", TestRail) with its
  usual caveat: the adapter/integration test for "is reyn using this
  correctly" is still reyn's to write, not excluded.
- `CLAUDE.md`: extends six-questions ①'s carve-out from a TTE-only example
  to the general "whose bug is it" discriminator, pointing to testing.md
  for the full treatment — same normative/entry-point split used in
  #3884/#3888.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.jml` (via `.mkdocs/mkdocs.yml`)
      → exit 0, no new WARNING/Aborted lines
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q`
      → 334 passed (was 332 pre-#3884; +2 for the new headings/anchors)
- [x] `.venv/bin/python scripts/verify_env_identity.py` → OK (re-verified
      after reinstalling `textual-flowview` at the #3886-bumped pin)
- [x] Rebased onto current `origin/main` (picked up #3886/#3887/#3888
      mid-task); local branch renamed off the now-merged #3888 branch to
      a fresh name before push (not reused) to avoid the
      push-to-merged-branch trap
- [x] Remote branch head verified to match local via
      `git ls-remote origin refs/heads/docs/testing-third-party-promise-carveout`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
