### PR TITLE
docs(#3872): promote hook-push truthiness + undefined-var policy to reyn-yaml.md

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -819,6 +819,20 @@ hooks:
 | `write_paths` | list[string] | `[]` (the floor) | **`exec` / `exec_capture` only** — filesystem paths this hook's argv may write (`~` expanded; write implies read). Same rules as `subprocess` above; omitting the key keeps the floor, which grants **no** writes, while an explicit list — including `[]` — is your expressed will. Keep the scope tight: grant the specific directory the hook writes, never `~`. A grant does not defeat the sensitive-read deny-list — the deny wins over an overlapping grant (#2978), exactly as on the op path. Not granted by the agent-level [`sandbox.policy`](#sandboxpolicy-sub-keys) — see the boundary note under that block. |
 | `pipeline_launch` | map | _none_ | Launch a registered pipeline (one of the four schemes). `name` (required — the pipeline's registered name; unregistered → warns and skips the launch, the hook point still completes), `input_template` (optional — a `dict`'s string leaves are each Jinja2-rendered against the event's template vars; a plain string is rendered once and its output parsed as a JSON object; omitted → `input=None`). Async/detached: the result arrives later on this session's own inbox as a `pipeline_result` message. |
 
+**`wake` / `push_when` truthiness, and why a typo fails differently
+depending on the field.** A rendered `wake`/`push_when`/`session` string
+is converted to bool by case-insensitive lookup: `true`/`1`/`yes`/`on` →
+`True`; `false`/`0`/`no`/`off`/empty-string → `False`. Any other value is a
+render error. `message` uses strict undefined-variable checking — a
+typo'd variable name raises, and the whole push is skipped (loud
+failure); `wake`, `push_when`, and `session` use silent checking — a
+typo'd variable there renders as an empty string, which resolves to
+`False`/`None` (quiet, fail-safe: don't wake, don't push, or fall back to
+the current session on a broken condition). Any render failure at all —
+bad Jinja2 syntax, an unrecognised truthiness string, or `message`'s
+strict-undefined error — is caught: the push is skipped
+(`push_when=False`) and logged at WARNING, never crashes the turn.
+
 ## `composers` block
 
 Event correlation (Hook-Event Redesign Phase 4b/5, proposal


### PR DESCRIPTION
**[docs-maintainer]** — lead-coder依頼(architectのUNDOCUMENTED設計、#3879 comment 5228991469)によるhooks 17件分の実装。まずこのファイルのみ。part of #3872.

## The gap (measured)

`src/reyn/hooks/render.py`'s module docstring carries a complete
operator-facing contract: the `wake`/`push_when` truthiness table (which
string tokens map to `True`/`False`) and the strict-vs-silent
undefined-variable split (`message` raises loud on a typo; `wake` /
`push_when` / `session` fail quiet). Neither `reyn-yaml.md` nor
`hooks.md` mentioned any of it — `grep -c 'truthy\|StrictUndefined'`
against both docs returns 0. An operator writing `wake: "{{ ... }}"` had
no doc naming which tokens are accepted, or why a typo behaves
differently depending on which field it's in.

## Design followed (architect, #3879)

- **Destination = "who needs to know this to write it correctly"**, not
  subject. → `reyn-yaml.md` (the schema reference read while writing
  config), not `hooks.md` (the concept explainer).
- **Granularity = one judgment call an operator could get wrong**, not
  one line per test. → one paragraph, two judgment calls (accepted
  truthiness tokens; loud-vs-quiet undefined behavior), not a
  transcription of all 22 test functions in the file.
- **Doc ≠ docstring copy** — doc states the contract in the doc's own
  voice; the docstring keeps its own implementation rationale, untouched.

## Scope note — "no destination" is the expected outcome for most of the 17

Per architect's caveat, not all 17 promote:
- Sandbox-escape proof tests + `HookDef`'s frozen-dataclass check → reyn's
  own internal guarantee / no-mirror (nothing an operator writes).
- Schema-validation-error tests (missing `message`, mutually-exclusive
  schemes, bad hook point, wrong `wake` type, ...) → already covered by
  the existing required/type table columns and the "carries exactly one
  of four mutually-exclusive schemes" intro prose. No second gap found.

So this PR promotes exactly the two judgment calls that were genuinely
missing, and nothing else from this batch needed a destination.

## Changes

- `docs/reference/config/reyn-yaml.md`: new paragraph after the `hooks`
  block's field table (before `## composers block`) — truthiness table +
  strict/silent undefined-variable policy + the render-error safety net
  (any failure is caught, push skipped, logged at WARNING, never
  crashes).

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0, no new
      WARNING/Aborted lines
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q`
      → 334 passed
- [x] Branch created off verified-current `origin/main`; only the one
      intended file touched (`git status --short` checked before commit)
- [x] Remote branch head verified to match local via
      `git ls-remote origin refs/heads/docs/hooks-push-truthiness-undefined-promotion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
