### PR TITLE
docs: fix four stale-mechanism claims found during M2's UNDOCUMENTED review

### DIFF
--- a/docs/concepts/runtime/capability-profile.md
+++ b/docs/concepts/runtime/capability-profile.md
@@ -317,14 +317,12 @@ tool_deny:
   - delegate_to_agent
 ```
 
-**Either spelling of a tool works, and denies both.** `delegate_to_agent` and
-`delegate_to_agent` are two names for one operation, and which of them the model
-is currently *shown* varies by [tool-use cell](../tools-integrations/tool-use-schemes.md)
-and host config. A `tool_deny` entry is therefore expanded to **every invocable
-form** of the name before it becomes a gate (`_expand_tool_forms`, deriving from
-the `invoke_action` alias table rather than a hand-kept list), so writing the one
-spelling you happen to see denies the other too. Copying a name out of the
-model's current tool list is safe; it is not a way to deny only one route.
+**Each tool has exactly one invocable name.** #3429 removed the second,
+catalog-qualified spelling every action used to also carry (e.g. a former
+`file__read` alongside `read_file`) — a `tool_deny` entry now denies exactly
+the name it names, with no expansion step. Copying a name out of the model's
+current tool list is safe and complete: there is no other route to the same
+operation under a different spelling to separately deny.
 
 ## See also
 

--- a/docs/concepts/runtime/delegation-policy.md
+++ b/docs/concepts/runtime/delegation-policy.md
@@ -40,10 +40,18 @@ from `_FLOORED_DENY_CLASSES`):
 
 | Class | Denied tools | Rationale |
 |-------|-------------|-----------|
-| `re-delegation` | `delegate_to_agent`, `delegate_to_agent` | Prevent unlimited spawning chains from an unbound delegate |
-| `exec` | `exec`, `exec` | Execution requires explicit operator authorization |
+| `re-delegation` | `delegate_to_agent` | Prevent unlimited spawning chains from an unbound delegate |
+| `exec` | `exec` | Execution requires explicit operator authorization |
 | `mcp-install` | `mcp_install_registry`, `mcp_install_package`, `mcp_install_local` | MCP server installation is a high-privilege, operator-controlled action |
+| `skill-install` | `skill_install_local`, `skill_install_source` | Registering skills from untrusted content is a persistence vector (#2548); mirrors `mcp-install` |
+| `pipeline-install` | `pipeline_install_local`, `pipeline_install_source` | Registering pipelines from untrusted content — same persistence vector as `skill-install` |
+| `spawn` | `session_spawn`, `agent_spawn`, `topology_create` | Unbounded sub-session/agent spawn is a DoS vector (#2103); peer of `re-delegation` |
+| `pipeline-run` | `run_pipeline`, `run_pipeline_async`, `run_pipeline_inline`, `run_pipeline_inline_async` | Launching a pipeline is spawn-adjacent — peer of `spawn` |
 | `memory-write` | `remember_shared`, `remember_agent`, `forget_memory` | Persistence from an unbound delegate requires deliberate opt-in |
+
+(#3429 removed the second, catalog-qualified spelling every tool used to also
+carry — each denied tool above is now the tool's one and only invocable
+name, with no per-class alias expansion step.)
 
 The floor is overridable: an operator file
 `.reyn/capability_profiles/_delegate.yaml` replaces the built-in profile. A
@@ -99,15 +107,17 @@ target — it is not flagged, avoiding a false HIGH exit.
 
 | Finding | Severity | Condition |
 |---------|----------|-----------|
-| Bound profile re-grants a class | HIGH | `re-delegation` or `exec` class permitted |
+| Bound profile re-grants a class | HIGH | `re-delegation`, `exec`, `mcp-install`, `skill-install`, `pipeline-install`, `spawn`, or `pipeline-run` class permitted |
 | Bound profile re-grants a class | MED | `memory-write` or `destructive-fs` class permitted |
 | `_delegate.yaml` re-grants a class | HIGH / MED | Same class-to-severity mapping |
 | Posture nudge | INFO | `capability_default=inherit` while any topology has a delegation edge |
 
-The `destructive-fs` class (`delete_file`, `delete_file`) is **audit-only** —
-it is not on the runtime `_delegate` floor because it is already gated by the
-FILE_WRITE permission system. The audit surfaces it as a re-grant judgment for
-delegate-reachable roles.
+The `destructive-fs` class (`delete_file`) is **audit-only** — it is not on
+the runtime `_delegate` floor because it is already gated by the FILE_WRITE
+permission system. The audit surfaces it as a re-grant judgment for
+delegate-reachable roles. It is the one deliberate audit ⊋ floor delta — every
+other audit class below is single-sourced from the same `_FLOORED_DENY_CLASSES`
+the runtime floor uses, so the audit and the floor cannot drift apart.
 
 **Exit behavior**: `reyn audit` exits non-zero only on a HIGH finding — CI-safe
 (a HIGH blocks a deploy; MED and INFO are informational).
@@ -116,11 +126,15 @@ delegate-reachable roles.
 
 | Class | Severity | Tools |
 |-------|----------|-------|
-| `re-delegation` | HIGH | `delegate_to_agent`, `delegate_to_agent` |
-| `exec` | HIGH | `exec`, `exec` |
+| `re-delegation` | HIGH | `delegate_to_agent` |
+| `exec` | HIGH | `exec` |
 | `mcp-install` | HIGH | `mcp_install_registry`, `mcp_install_package`, `mcp_install_local` |
+| `skill-install` | HIGH | `skill_install_local`, `skill_install_source` |
+| `pipeline-install` | HIGH | `pipeline_install_local`, `pipeline_install_source` |
+| `spawn` | HIGH | `session_spawn`, `agent_spawn`, `topology_create` |
+| `pipeline-run` | HIGH | `run_pipeline`, `run_pipeline_async`, `run_pipeline_inline`, `run_pipeline_inline_async` |
 | `memory-write` | MED | `remember_shared`, `remember_agent`, `forget_memory` |
-| `destructive-fs` | MED | `delete_file`, `delete_file` (audit-only, not on runtime floor) |
+| `destructive-fs` | MED | `delete_file` (audit-only, not on runtime floor) |
 
 ### Usage
 

--- a/docs/concepts/runtime/safety.md
+++ b/docs/concepts/runtime/safety.md
@@ -38,7 +38,7 @@ the current configured value, and which config key to change.
 | Agent hops | `safety.loop.max_agent_hops` | 3 | ✅ | yes |
 | Chain wait | `safety.timeout.chain_seconds` | 60 | ✅ | yes |
 | Router iterations | `safety.loop.max_router_iterations` | 5 | ✅ | partial |
-| LLM call timeout | `safety.timeout.llm_call_seconds` | 60 | ❌ auto-retry/abort | — |
+| LLM call timeout | `safety.timeout.llm_call_seconds` | 60 | ✅ (#2210) | yes |
 | Media cap | `multimodal.max_bytes` | 5 MB | ❌ auto-degrade | — |
 | Summary body cap | `chat.compaction.body_token_cap` | 1500 | ❌ auto-truncate | — |
 

--- a/docs/reference/cli/mcp.md
+++ b/docs/reference/cli/mcp.md
@@ -130,7 +130,7 @@ Supported source schemes:
 | `npm:<package>[@version]` | `npm:@modelcontextprotocol/server-filesystem` | `command: npx, args: ["-y", "<package>"]` |
 | `pypi:<package>[==version]` | `pypi:mcp-server-fetch` | `command: uvx, args: ["<package>"]` |
 | `docker:<image>[:tag]` | `docker:mcp/playwright:latest` | `command: docker, args: ["run", "--rm", "-i", "<image>"]` |
-| `https://github.com/<owner>/<repo>[/...]` | `https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem` | Heuristic: known repos resolve to `@scope/<package>` npm packages; unknown repos write the config without a `command`, surfacing as a clear failure at runtime rather than a silent bad install. |
+| `https://github.com/<owner>/<repo>[/...]` | `https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem` | Heuristic: known repos resolve to `@scope/<package>` npm packages; an unknown repo returns `status: error` immediately — nothing is written to `mcp.yaml` — naming the URL and suggesting an explicit `npm:` / `pypi:` / `docker:` prefix or `mcp_install_local`. |
 
 `<SERVER_ID>` and `--source` are mutually exclusive.
 


### PR DESCRIPTION
**[docs-maintainer]** — doc-drift fixes found incidentally while re-classifying M2's remaining 43 blank-anchor tests (①②③④ sweep, per lead-coder). These are genuine stale-mechanism doc bugs, not part of the UNDOCUMENTED-promotion deliverable itself — shipping separately per the standing docs-drift-sweep duty rather than folding into the promotion PR. part of #3872.

## Four fixes, each verified against current source before writing

**1. `docs/reference/cli/mcp.md`** — an unknown GitHub repo's install failure
was documented as "writes the config without a `command`, surfacing as a
clear failure at runtime rather than a silent bad install." Read
`mcp_install.py`'s actual guard (line ~621): it returns `status: error`
**immediately, before any write**, naming the URL and suggesting an explicit
`npm:`/`pypi:`/`docker:` prefix. Nothing is ever written for this case.
Fixed to describe the real fail-loud/no-write behavior.

**2. `docs/concepts/runtime/safety.md`** — the cap-behavior table's LLM-call-
timeout row was still `❌ auto-retry/abort`. Read `llm.py`/`session.py`: #2210
routes it through `handle_limit_exceeded`, the same checkpoint every other ✅
row uses (comment at `llm.py:2634` names it explicitly). Flipped to ✅ — the
existing interactive/auto_extend/unattended `Modes` table above already
explains the three outcomes generically, so no new paragraph was needed, just
the row's own legend catching up to reality.

**3. `docs/concepts/runtime/capability-profile.md`** — a full paragraph
explained a "second, catalog-qualified spelling" (`_expand_tool_forms`)
that `tool_deny` entries needed expanding to. Read `session_api.py` /
`universal_dispatch.py`: #3429 removed the second spelling entirely — the
comment at `session_api.py:134` says outright "It used to need
`_expand_tool_forms`." Every tool now has exactly one invocable name.
Rewrote the paragraph to state that, instead of describing a removed
mechanism.

**4. `docs/concepts/runtime/delegation-policy.md`** — the same #3429 removal
left three tables with duplicated tool names as a visible fossil
(`` `delegate_to_agent`, `delegate_to_agent` `` etc.) — but reading
`_FLOORED_TOOLS` / `_FLOORED_AUDIT_SEVERITY` directly in
`capability_profile.py` turned up a much bigger gap than the duplicate
names: the built-in-floor table and the audit-classes table were each
**missing four whole classes that exist in source today** —
`skill-install`, `pipeline-install`, `spawn`, `pipeline-run` (all HIGH
severity, added by #2548/#2103 after this doc was last touched). The
Findings table's HIGH condition was also missing `mcp-install` — a
pre-existing gap unrelated to #3429. All three tables corrected against
the live source dicts.

## Why these surfaced now

Two subagents doing the ①②③④ classification pass over M2's remaining
files each independently flagged pieces of items 1 and 4 (the mcp.md
line and the delegation-policy duplicate names); I verified both against
source myself before trusting them, and in the course of reading
`capability_profile.py` directly found the four-missing-class gap in
item 4 that neither subagent's report mentioned — the value of checking
the primary source rather than transcribing the report.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0, no new
      WARNING/Aborted lines
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q`
      → 334 passed
- [x] Each of the 4 claims independently verified by reading the actual
      current source (not the subagents' summaries) before writing the
      fix — file/line citations above
- [x] Branch created off verified-current `origin/main`; remote head
      verified to match local via
      `git ls-remote origin refs/heads/docs/mcp-install-github-unknown-repo-drift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
