### PR TITLE
fix(#3880): stop pinning Textual's Tabs default height, assert reyn's own contract

### DIFF
--- a/tests/test_textual_chat_intervention_panel_3299.py
+++ b/tests/test_textual_chat_intervention_panel_3299.py
@@ -51,6 +51,7 @@ the testing policy.
 from __future__ import annotations
 
 import asyncio
+import re
 from typing import AsyncIterator
 
 import pytest
@@ -1300,28 +1301,38 @@ async def test_pending_intervention_panel_does_not_swallow_the_screen(
         )
 
 
-@pytest.mark.asyncio
-async def test_tabs_bar_height_is_the_native_fixed_two_rows() -> None:
-    """Tier 1: ★ direct witness for the root cause — the panel's internal
-    ``Tabs`` bar (the tab-caption row) must be Textual's OWN fixed
-    ``height: 2`` default, never stretched to ``auto``.
+def test_tabs_bar_has_no_height_override_reyn_relies_on_textuals_default() -> None:
+    """Tier 1: reyn's contract for the tab-caption bar is NOT setting a height
+    rule for it — not "Textual's Tabs defaults to height 2", which is
+    Textual's own promise, not reyn's (#3311's real-TTY regression made this
+    distinction concrete). An earlier revision added ``InterventionPanel
+    Tabs { height: auto; }`` by (wrong) analogy with the ``TabbedContent``
+    rule beside it; ``Tabs`` is NOT designed for auto-sizing and the override
+    resolved to ~30 rows on an 80x24 screen (tui-coder's real-TTY witness),
+    ballooning the whole panel and pushing the FlowView/Composer off-screen.
+    Every widget-STATE assertion (displayed, focused) stayed green through
+    that regression — only the actual CSS declaration catches it.
 
-    NON-VACUITY (falsification, verified locally): restoring the
-    ``InterventionPanel Tabs { height: auto; }`` rule makes the ``Tabs``
-    widget's own computed region height balloon (observed locally: from 2 to
-    over 30 rows on an 80x24 screen) instead of staying at 2."""
-    from textual.widgets import Tabs
+    Static (no real TTY, no Textual app, no ``pytest.mark.asyncio``): parses
+    ``InterventionPanel.DEFAULT_CSS`` directly, so it runs even where
+    the ``effects``/real-terminal extras are unavailable. Asserts no rule
+    targets the bare ``Tabs`` type — word-bounded so ``TabbedContent`` (a
+    different, legitimately-ruled type two lines below) never matches.
 
-    transport = RecordingTransport([_choice_intervention()], end=False)
-    app = TextualChatApp(transport=transport)
-
-    async with app.run_test(size=(80, 24)) as pilot:
-        await pilot.pause()
-        await pilot.pause()
-
-        panel = app.query_one(InterventionPanel)
-        tabs_bar = panel.query_one(TabbedContent).query_one(Tabs)
-        assert tabs_bar.region.height == 2, (
-            f"the intervention panel's Tabs bar is not Textual's native fixed "
-            f"height (2) — got {tabs_bar.region.height}; region={tabs_bar.region!r}"
-        )
+    A ``height`` rule reappearing on ``Tabs``, at ANY value — not just
+    ``auto`` — is what this guards against: reyn's contract is "we don't
+    touch it", not "Textual's default happens to be small". If Textual ever
+    changes that default, this stays green (reyn still touches nothing);
+    if reyn re-adds a rule, this goes red regardless of the value chosen.
+    """
+    css = InterventionPanel.DEFAULT_CSS
+    tabs_rule = re.search(r"\bTabs\s*\{", css)
+    assert tabs_rule is None, (
+        "InterventionPanel.DEFAULT_CSS declares a rule for the bare `Tabs` "
+        "selector — reyn's contract is to declare NONE (see #3311): adding "
+        "one here, even a seemingly-harmless height:auto by analogy with "
+        "the TabbedContent rule beside it, reproduces a real-TTY regression "
+        "where Tabs (not designed for auto-sizing) ballooned to ~30 rows on "
+        "an 80x24 screen and pushed the FlowView/Composer off-screen. "
+        f"Found: {css[tabs_rule.start():tabs_rule.start() + 80]!r}"
+    )


### PR DESCRIPTION
**[tui-coder]** — #3880のM2監査（③④）で発見した第三者混入1件の書き換え。lead-coder承認済み（書き換え案①、CSS宣言の静的検証）。

## 何を変えたか

`test_tabs_bar_height_is_the_native_fixed_two_rows`が`assert tabs_bar.region.height == 2`——**Textualの`Tabs`ウィジェットの既定高さ（2）を直接pin**していました。判別子「落ちたら誰のバグか」を適用: Textualが将来この既定値を変えても、reyn側は何もしていないのに赤くなります。

reyn側のレイアウト計算コードを`2`というリテラルでgrepしても一切現れず（コメント内のTextualバージョン言及のみ）——機械的には「削除」対象に見えました。ただし`intervention_panel.py`のDEFAULT_CSSコメントに実際のインシデント記録（#3311、実TTY witness: 以前`InterventionPanel Tabs { height: auto; }`を誤追加し、画面全体が~30行に膨張、FlowView/Composerが画面外に押し出された）があり、**このテストの目的自体（reynが誤ってheightルールを再追加することを防ぐregression guard）は正当**でした。

∴ 削除でも維持でもなく、**書き換え**: reynの契約は「Textualの既定は2」ではなく「reynは`Tabs`セレクタにheightルールを一切宣言しない」——これを直接、静的に検証する形に変更。

## 実装

```python
tabs_rule = re.search(r"\bTabs\s*\{", InterventionPanel.DEFAULT_CSS)
assert tabs_rule is None, ...
```
- 実TTY・Textualアプリ起動・`pytest.mark.asyncio`不要（静的、CSS文字列を直接パース）
- `effects`/実端末extrasが無くても走る（#3881の60 skippedに加わらない）
- 失敗メッセージに#3311を名指し（次の人が経緯を読める）
- `\bTabs\s*\{`は単語境界つきなので、隣接する正当な`TabbedContent`ルールとは衝突しない

## Test plan
- [x] Manual: `pytest tests/test_textual_chat_intervention_panel_3299.py` → 25 passed（旧24+新1）
- [x] Manual: `ruff check` → clean
- [x] Manual: `python scripts/test_tier_audit.py --strict tests/test_textual_chat_intervention_panel_3299.py` → 24/24 OK, 0 errors
- [x] Manual: `python scripts/mypy_ratchet.py` → 0 findings
- [x] Falsification: `InterventionPanel Tabs { height: auto; }`を再導入 → 新テストが赤（実行・確認・復元済み）

part of #3880

🤖 Generated with [Claude Code](https://claude.com/claude-code)