### PR TITLE
docs: promote 5 UNDOCUMENTED spawn-semantics designs (org-design.md, permission-model.md)

### DIFF
--- a/docs/concepts/multi-agent/org-design.md
+++ b/docs/concepts/multi-agent/org-design.md
@@ -67,10 +67,25 @@ of this conversation. The spawned session begins immediately; this tool
 returns a spawn-ack rather than waiting for the task to complete (async
 dispatch).
 
+⚠️ **Exclusive-wrapper mode has no catalog route for this tool.** When
+[`action_retrieval.universal_wrappers_enabled`](../tools-integrations/universal-catalog.md)
+is `true`, `session_spawn`'s individual per-tool entry is stripped (like
+`delegate_to_agent`'s) — but unlike `delegate_to_agent`, which stays
+reachable through the `multi_agent` category's catalog dispatch,
+`session_spawn` has no catalog-channel equivalent today. An operator
+enabling exclusive-wrapper mode loses `session_spawn` reachability
+entirely, with no compensating route.
+
 **`mode`**:
 
 - `ephemeral` — the session auto-vanishes after its task completes. Use
-  for one-shot work where you want no lingering state.
+  for one-shot work where you want no lingering state. "Completes" means
+  no pending work, not merely an empty inbox: if the ephemeral session
+  has itself delegated to a peer and is awaiting that peer's response, a
+  transiently-empty inbox mid-wait does not trigger teardown — vanishing
+  before the response lands would purge the session the reply is
+  addressed to. A spawned session may itself call `session_spawn` again
+  (nesting is supported); its result still routes back correctly.
 - `persistent` — the session stays registered after the task. Use when
   you need to refer back to it or continue work there.
 
@@ -197,6 +212,15 @@ mode-driven framework used by loop and budget caps:
 
 `max_depth` and `max_children` carry separate per-spawner extension keys: an
 operator-approved increase in one does not silently widen the other.
+
+`max_children` counts a parent by **identity, not name**: if a parent is
+purged and its name reused, a pre-purge orphan child does not count against
+the new, same-named parent's budget — the reused name gets its full
+`max_children` allowance, not a reduced one. This is the fan-out-accounting
+counterpart to the identity-keyed lineage rule in
+[permission-model.md § No-escalation-via-spawn](../runtime/permission-model.md#no-escalation-via-spawn-the-closed-class):
+that rule is about capability re-grant after a name reuse, this one is
+about the DoS-bound count.
 
 See [reyn-yaml § safety.spawn](../../reference/config/reyn-yaml.md#safetyspawn-fields) and
 [safety.on_limit](../../reference/config/reyn-yaml.md#safetyon_limit-fields) for full schema.

--- a/docs/concepts/runtime/permission-model.md
+++ b/docs/concepts/runtime/permission-model.md
@@ -561,7 +561,7 @@ binding explicitly re-grants within the ⊆-parent envelope.
 
 ### No-escalation-via-spawn: the closed class
 
-Four specific escalation avenues are closed by construction:
+Five specific escalation avenues are closed by construction:
 
 | Escalation avenue | Closed by |
 |---|---|
@@ -569,6 +569,7 @@ Four specific escalation avenues are closed by construction:
 | Rewind drop (lineage lost, constraint lifted) | Lineage is WAL-tracked; rewind reconstruction restores the parent link |
 | Absent parent (parent purged, constraint lifted) | Absent-parent path fails closed — gate treats missing lineage as deny |
 | Name reuse (new agent reuses purged name, fresh identity) | Identity-keyed lineage: the OS key is not the name but an internal ID; a re-used name cannot inherit the prior agent's purged lineage |
+| Absent/malformed bound profile (a `topology_create` member's declared `capability_profile` file is deleted or corrupted, constraint lifted) | Same fail-closed philosophy generalised to the profile-binding path: a **declared-but-unresolvable** binding composes the restrictive `_delegate` floor rather than silently skipping the narrowing. The discriminator is existence-of-declaration — a member with no binding at all stays genuinely unrestricted; only a binding that names a profile that can no longer be read fails closed. |
 
 ### `topology_create` profiles stay inside the envelope
 


### PR DESCRIPTION
**[docs-maintainer]** — 43件UNDOCUMENTED再判定、2103クラスタ(spawn/lineage)分の昇格 5件。part of #3872.

## Promoted (each verified against current source, not transcribed)

1. **org-design.md, `session_spawn` § ephemeral** — "task completes" ≠ "inbox empty": a session that delegated to a peer and awaits the reply is not torn down mid-wait. Verified: `test_2103_A_ephemeral_auto_vanish_1953.py`'s awaited-work guard.
2. **org-design.md, same section** — nested `session_spawn` is supported (an earlier non-main-spawn guard was lifted). Verified: `test_2103_s1bc_exec_result_routing.py::test_non_main_spawn_is_now_allowed_guard_lifted`.
3. **org-design.md § Operator-set bounds** — `max_children` counts a parent by identity, not name; a purged-then-name-reused parent gets its FULL fan-out budget. Distinct claim from the already-documented identity-keyed *capability* rule (accounting vs escalation). Verified: `test_2103_C3_spawn_limits_1953.py::test_fan_out_count_is_identity_keyed_not_name`.
4. **org-design.md, `session_spawn` intro** — exclusive-wrapper mode strips `session_spawn`'s per-tool entry with **no catalog-channel equivalent**, unlike `delegate_to_agent` (reachable via the `multi_agent` category). I independently verified this by reading `universal_dispatch.py`'s category→verb tuple directly — `session_spawn` is absent from it — in addition to the cited test.
5. **permission-model.md § No-escalation-via-spawn** — added the 5th closed escalation avenue: a `topology_create` member's declared `capability_profile` binding fails closed when the profile file is absent/malformed (gate-6), generalizing the existing absent-parent fail-closed philosophy. Verified against `test_2103_C2_fail_closed_capwalk_1953.py`'s own module docstring, which names the mechanism precisely.

## Not promoted from this cluster (for context, not acted on here)

- 8 tests were already ANCHORED to org-design.md/permission-model.md/sessions.md/capability-profile.md/time-travel.md.
- ~20 tests were NO-DESTINATION (internal dispatch/advertise wiring, WAL event-shape checks, defensive-parsing fail-safes) — reported to lead-coder, not promoted.
- 2 more UNDOCUMENTED findings from this same cluster (`multi-agent.md` reply-routing, `time-travel.md` rewind atomicity) are going out as separate PRs targeting those doc files, to keep each PR's diff scoped to one doc file's section.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0, no new WARNING/Aborted lines
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` → 334 passed
- [x] Each promoted claim independently verified against current source (test docstrings + the actual implementation, e.g. `universal_dispatch.py`'s category tuple) before writing — citations above
- [x] Branch created off verified-current `origin/main`; remote head verified via `git ls-remote origin refs/heads/docs/org-design-spawn-semantics-promotion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
