### PR TITLE
docs: promote 3 UNDOCUMENTED reliability designs (multi-agent.md, time-travel.md)

### DIFF
--- a/docs/concepts/multi-agent/multi-agent.md
+++ b/docs/concepts/multi-agent/multi-agent.md
@@ -98,6 +98,8 @@ This gives a "manager → delegate → synthesize" model: the user sees an inter
 
 This is in-process delegation only. A cross-process external peer that does not echo `from_sid` back degrades to `None` → `main` — a safe fallback (the reply reaches the Agent's main Session rather than being lost silently), not a routing failure.
 
+A different case looks similar but resolves the opposite way: `from_sid` names a real, once-live Session that is simply **no longer loaded** (the spawner Session has since gone away). This is not the "peer never echoed a sid" case above — a sid was named — so the reply is **logged and dropped**, not routed to `main`. Falling back to `main` here would reintroduce the exact misroute `#2130` fixed: an orphaned reply silently landing in the wrong Session's history instead of visibly failing.
+
 There is no dedicated reference doc for the internal `(agent, sid)` A2A routing scheme beyond this section and the code (`_a2a_send_response`) — this section is that scheme's documentation.
 
 ### chain_id

--- a/docs/concepts/runtime/time-travel.md
+++ b/docs/concepts/runtime/time-travel.md
@@ -65,6 +65,8 @@ Each checkpoint stores an **AgentSnapshot** — a point-in-time snapshot of the 
 
 The WAL is an **fsync-per-append log**: each entry is durably written via `DurabilityWorker` off the task loop. Task-loop writes are fire-and-forget except `step_started`, which blocks until durable (durable-before-side-effect invariant). Recovery restores to the last durable entry; an un-durable tail at crash is a consistent-prefix loss. Separate from the P6 audit event log — see [Events](events.md) for the WAL vs audit-event distinction.
 
+**Snapshot writes share the WAL's off-loop durability path.** `SnapshotJournal.save()` routes its write+fsync through the same `DurabilityWorker` rather than writing inline on the event loop — a slow snapshot write no longer freezes other sessions or the TUI while it completes. Ordering is the crash-consistency invariant that makes this safe: a snapshot's `applied_seq` is made durable only *after* the WAL entry for that seq is already durable, never before or concurrently — so recovery can never observe a snapshot pointing at a WAL seq that isn't actually on disk.
+
 ### Global single-seq WAL and consistent-cut
 
 All WAL events share a **global single sequence namespace**. A consistent-cut rewind at seq N is well-defined: "the state of every substrate at the moment before seq N+1 was written". The global seq makes the cut precise — there is no per-substrate clock to reconcile.
@@ -87,6 +89,8 @@ The branch registry tracks all fork lineages: when a fork-switch creates a new b
 - If `is_active_seq(seq)` is false (seq is in an abandoned interval): fork-switch — activates the abandoned branch at seq, leaving the current branch tip as a new abandoned interval.
 
 `is_active_seq` is **not** equivalent to `seq ≤ tip` — a seq can be ≤ the current tip but still be in an abandoned interval from a prior rewind. Activeness is derived from the reset-record chain, not from position relative to tip.
+
+**Deferred-purge atomicity (#2125).** Rewinding past a spawned session's spawn point drops that session's on-disk directory as part of reconstruction. The destructive removal is deferred until the as-of-cut reconstruction has actually succeeded — if reconstruction raises partway through, the session directory still exists afterward, not half-torn-down. A failed rewind leaves state intact rather than partially destroyed.
 
 At rewind and fork-switch, the runtime reconstruct honors `is_active` (following the correct fork-lineage path for the target branch).
 


### PR DESCRIPTION
**[docs-maintainer]** — 43件UNDOCUMENTED再判定、2103クラスタ残り2件の昇格(multi-agent.md, time-travel.md)。part of #3872. #3895(同クラスタ5件)の続き。

## Promoted (each verified against current source)

1. **multi-agent.md § Reply routing across delegating sessions** — a reply to a non-main sid whose session is no longer loaded (real, once-live spawner now gone) is dropped, NOT routed to main — distinct from the already-documented cross-process fallback case (peer never echoed `from_sid`). Falling back here would reintroduce the #2130 misroute. Verified: `test_2103_s1bc_exec_result_routing.py::test_gone_spawner_sid_drops_does_not_fallback_to_main`.
2. **time-travel.md § PITR snapshot and WAL-diff reconstruct** — `SnapshotJournal.save()` shares the WAL's off-loop `DurabilityWorker` path (a slow snapshot write no longer freezes other sessions/the TUI), plus the crash-consistency ordering invariant: a snapshot's `applied_seq` is durable only after its WAL entry is already durable. Verified: `test_1765_snapshot_journal_off_loop.py`'s two tests.
3. **time-travel.md § checkout primitive** — deferred-purge atomicity (#2125): a failed rewind reconstruction does not destructively drop a spawned session's on-disk directory; the rmtree is deferred until reconstruction actually succeeds. Verified: `test_2103_s1bc_session_drop.py::test_rewind_restore_failure_does_not_drop_the_session_dir`.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0, no new WARNING/Aborted lines
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` → 334 passed
- [x] Each claim independently verified against the cited test's real body/docstring before writing
- [x] Branch created off verified-current `origin/main`; remote head verified via `git ls-remote origin refs/heads/docs/reply-routing-and-rewind-atomicity-promotion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
