### PR TITLE
docs: promote 5 UNDOCUMENTED hooks/config designs (config-hot-reload.md, hooks.md, capability-profile.md)

### DIFF
--- a/docs/concepts/runtime/capability-profile.md
+++ b/docs/concepts/runtime/capability-profile.md
@@ -53,6 +53,12 @@ All fields are optional; absent or `null` means unrestricted on that axis.
 | `mcp_allow` | `list[str] \| null` | MCP server allow-list. `null` = unconstrained. |
 | `mcp_deny` | `list[str]` | MCP server deny-list. |
 
+A profile YAML left over from before the SKILL axis was removed may still
+carry `skill_allow`/`skill_deny` keys — the loader ignores them silently
+(forward-compat) rather than rejecting the file. There is no warning that
+those keys have stopped doing anything; an old profile file is not a signal
+that skill capability is being narrowed.
+
 ### Axis B — tool narrowing
 
 | Field | Type | Semantics |

--- a/docs/concepts/runtime/config-hot-reload.md
+++ b/docs/concepts/runtime/config-hot-reload.md
@@ -152,6 +152,26 @@ scopes is ADDITIVE, not override — see the 3/4-layer COMBINE above.
 The tool is write-gated: the calling workflow must declare `hooks_add` in
 `permissions.tool`, and the capability profile `tool_deny` can deny it.
 
+**Which reloader instance gets triggered.** Separately from which *file*
+`hooks_add` writes to (above), the reload it schedules always runs on the
+*calling session's own* `HotReloader` (threaded via `ToolContext.hot_reloader`)
+— never a process-wide "last constructed session" fallback. This differs from
+cron's own reload path, which does use that fallback (see its own caveat
+elsewhere in this doc); in a multi-agent setup, agent A calling `hooks_add`
+reloads A, regardless of which session was constructed most recently.
+
+**Validates before writing, not just before applying.** An invalid hook body
+(e.g. an unrecognised `on:` value) is rejected with nothing written to disk —
+this is a separate check from the reload-time "Validate-before-apply" safety
+story below, which guards a persisted-but-malformed file; this one guards the
+write itself.
+
+**Re-adding an identical hook is a no-op**, not an accumulating duplicate —
+an exception to the general "idempotency is the caller's responsibility"
+posture (see [reliability engineering](../agent-engineering/reliability-engineering.md)):
+`hooks_add` compares the new hook against existing entries and skips the
+write on an exact match.
+
 ## Safety story
 
 Hot-reload is safe-by-construction through five layers:

--- a/docs/concepts/runtime/hooks.md
+++ b/docs/concepts/runtime/hooks.md
@@ -582,7 +582,9 @@ refused, never silently dropped.
 - **Non-interactive** (`reyn run`, `mcp-serve`, headless) — falls back to the pre-bus behavior: TTY stdin prompt when available, or refused when stdin is not a TTY.
 - **Allowlist hit** — any command already in the allowlist runs silently without a prompt (auto-approved on all surfaces).
 
-Consent is fail-closed throughout: if the sandbox backend cannot be confirmed, the hook is refused rather than run unsandboxed.
+Consent is fail-closed throughout: if the sandbox backend cannot be confirmed, the hook is refused rather than run unsandboxed. An unanswered/empty consent-bus response (e.g. an intervention parked stalled because its origin channel closed) also fails closed — the hook is skipped, not run and not left hanging.
+
+**`REYN_ACCEPT_HOOKS=1` short-circuits the whole consent flow above**, including the bus path — the hook runs and the bus is never consulted, taking precedence even over an attached listener. This is the CI/automation escape hatch for environments where no operator is present to answer a prompt.
 
 **`has_active_listener` is re-checked on every dispatch, not cached (`#2095`).** Listeners attach and detach over a session's lifetime — a TUI mount, an A2A request window opening and closing — independently of when the `HookDispatcher` was constructed. Checking the listener state once at construction and caching the routing decision would let a later dispatch route a consent prompt to a listener that has since detached (a hang, or a silently dropped prompt) instead of correctly falling through to the non-interactive path (`REYN_ACCEPT_HOOKS` / fail-closed, or the `reyn run` stdin prompt on a TTY). The consent-bus wiring at this call site is byte-identical to the pre-`#2095` fallback matrix in every case EXCEPT that the routing decision (bus vs `None`) is now made per-dispatch against live listener state rather than frozen at construction — the per-dispatch check itself lives in the dispatcher, not at this construction site.
 


### PR DESCRIPTION
**[docs-maintainer]** — 43件UNDOCUMENTED再判定、2072-2095クラスタ(hooks/config)分の昇格 5件。part of #3872.

## Promoted (each verified against current source)

1. **config-hot-reload.md § Agent self-reload: `hooks_add`** — which `HotReloader` *instance* gets triggered (the calling session's own) is a separate axis from which *file* gets written (#2088, already documented) — never the process-wide "last-constructed session" fallback cron's own path uses. Verified: `test_2073_s3_hooks_write_op.py::test_per_session_route_reloads_caller_not_the_global`.
2. Same section — `hooks_add` validates the hook body *before writing*, distinct from the reload-time "Validate-before-apply" safety story (which guards a persisted-but-malformed file). Verified: `test_hooks_add_rejects_invalid_hook_no_write`.
3. Same section — re-adding an identical hook is a no-op, an explicit exception to `reliability-engineering.md`'s documented "idempotency is the caller's responsibility" posture. Verified: `test_hooks_add_dedups_idempotent`.
4. **hooks.md § Consent and allowlist** — an unanswered/empty consent-bus response fails closed (skipped, not hung); `REYN_ACCEPT_HOOKS=1` short-circuits the whole flow, even over an attached listener — unmentioned anywhere in `docs/` before this change (confirmed via grep). Verified: `test_2095_shell_hook_consent_bus.py`'s two tests.
5. **capability-profile.md § Axis A** — a profile YAML predating the removed SKILL axis may still carry `skill_allow`/`skill_deny` keys; the loader ignores them silently with no warning. Verified: `test_2074_s1_capability_spec_axes.py::test_loader_ignores_skill_keys`.

(Branched after #3893 merged, so this diff is clean against the already-fixed `capability-profile.md` — no conflict with that PR's `_expand_tool_forms` removal.)

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0, no new WARNING/Aborted lines
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` → 334 passed
- [x] Each claim independently verified against the cited test's real body before writing
- [x] Branch created off verified-current `origin/main`; remote head verified via `git ls-remote origin refs/heads/docs/hooks-add-and-consent-bus-promotion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
