### PR TITLE
docs(#3904): protect credentials from sandboxed commands, fix stale network default

### DIFF
--- a/.mkdocs/mkdocs.yml
+++ b/.mkdocs/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
               - guide/for-users/time-travel.md
               - guide/for-users/manage-permissions.md
               - guide/for-users/configure-sandbox.md
+              - guide/for-users/protect-credentials-in-shell-commands.md
               - guide/for-users/cap-spending.md
           - Files & integrations:
               - guide/for-users/work-with-files.md

--- a/docs/guide/for-users/configure-sandbox.md
+++ b/docs/guide/for-users/configure-sandbox.md
@@ -88,7 +88,7 @@ restriction: op-level fields govern, and the SandboxLayer is unrestricted.
 
 | Field | Type | Default | Meaning |
 |---|---|---|---|
-| `network` | bool | `false` | Allow outbound network. The primary exfiltration gate. |
+| `network` | bool | `true` (owner decision, 2026-06-05) | Allow outbound network. Set `network: false` explicitly to close it. |
 | `write_paths` | list of paths | `[]` | Paths the process may write (tight guard). Write implies read — a path listed here is also re-opened for *reading* even if `read_deny_paths` would deny it, so grant specific directories rather than `~`. `~` is expanded. |
 | `read_deny_paths` | list of paths | `[]` | Sensitive paths to deny from the broad read surface (defense-in-depth). Enforced only on backends that support deny-after-allow (Seatbelt); not enforceable on Landlock. |
 | `read_paths` | list of paths | `[]` | Legacy — formerly the strict read allowlist. Reads are broad by default; this field now documents intended read targets only. |
@@ -100,12 +100,16 @@ restriction: op-level fields govern, and the SandboxLayer is unrestricted.
 
 ### Scoping model
 
-reyn uses a **broad-read, tight-write, network-gated** model:
+reyn uses a **broad-read, tight-write, network-open-by-default** model:
 
 - **Reads are broad.** The process can read most of the filesystem. System-path
   enumeration for dylib loading works without enumeration in policy.
-- **Network is the exfiltration gate.** With `network: false` (the default),
-  the process can read broadly but cannot send data out.
+- **Network is open by default.** `network` defaults to `true` (owner decision,
+  2026-06-05) — a sandboxed process can reach the network unless you set
+  `network: false` explicitly. This follows reyn's standing UX-over-security
+  posture: security mechanisms here are opt-in, not opt-out — see [Protect
+  credentials from sandboxed commands](protect-credentials-in-shell-commands.md)
+  for what this means for a command that can read a secret.
 - **Writes are tight.** Only paths in `write_paths` are writable.
 - **`read_deny_paths` is defense-in-depth.** Carves out sensitive locations from
   the broad read surface where the backend can express a deny-after-allow rule.

--- a/docs/guide/for-users/protect-credentials-in-shell-commands.md
+++ b/docs/guide/for-users/protect-credentials-in-shell-commands.md
@@ -1,0 +1,105 @@
+---
+type: how-to
+topic: config
+audience: [human]
+applies_to: [reyn.yaml, sandboxed_exec, hooks]
+---
+
+# Protect credentials from sandboxed commands
+
+Any command reyn runs through the sandbox — a `sandboxed_exec` op, or a
+hook's `exec` / `exec_capture` — is still your machine's process. The
+sandbox bounds *where a process can write* and *how it may reach the
+network* (see [Configure the sandbox](configure-sandbox.md)); it does not
+curate *what the command can see*. **Choose what you let a sandboxed
+command run with the same trust you'd give a command typed into your own
+shell.**
+
+This is a standing design choice, not a gap waiting to be closed: reyn's
+security mechanisms are opt-in, favoring predictability and a small
+number of knobs over a machine that silently decides what an operator
+did or didn't mean to expose. **Protecting a credential from a sandboxed
+command is your responsibility, exercised at the point you write the
+command** — not something the sandbox does for you underneath.
+
+## Network is already open by default
+
+`network` in `sandbox.policy` defaults to `true` (owner decision,
+2026-06-05) — a sandboxed child process can already reach the network the
+same way your own shell can, unless you set `network: false` for it:
+
+```yaml
+sandbox:
+  policy:
+    network: false
+```
+
+## Environment variables are currently a curated allowlist — and that's changing
+
+Today, a sandboxed command's environment carries only `sandbox.policy`'s
+declared `env_passthrough` entries plus a small curated set of non-secret
+proxy/CA variables — not your shell's full environment. A command reading
+`OPENAI_API_KEY` or a similar credential var does **not** see it by
+default today, unless you've explicitly added that name to
+`env_passthrough`.
+
+**This default is planned to change** (design settled in `#3901`): the
+env axis is moving to the same opt-out posture `network` already has —
+passed through unless you explicitly deny it. Once that ships, the same
+shell-level trust this page asks for on network already applies to
+environment variables too, with no further warning at the point it
+happens. Write commands today as if that's already the case, so the
+change doesn't catch you by surprise.
+
+## The command's stdout becomes the agent's context
+
+Whatever a `sandboxed_exec`/`exec_capture` command prints to stdout is
+returned as the op's result and read directly by the LLM in the next
+turn. Don't run a command that might print a secret to stdout — an
+`echo $API_KEY`, a verbose client that logs a bearer token, a tool that
+dumps its own config — even if you trust where the command's *output* is
+going next, because the very next place it goes is the model's context
+window.
+
+## Choosing which commands to run — the method, not a list
+
+There is no list of "safe" commands, because safety depends on what your
+own environment currently holds, which reyn cannot see from inside a
+command's argv. The questions that matter, before you let a
+`sandboxed_exec`/hook command run:
+
+- **Would you run this exact command in your own shell, in this
+  environment, right now?** If the answer is no — because you're not sure
+  what it reads, or you'd want to check first — that's the answer for the
+  sandboxed version too. The sandbox does not make an otherwise-risky
+  command safe to run unattended.
+- **Does the command need to read the environment at all?** A command
+  that has no reason to touch env vars can't leak one it never reads. Keep
+  the command's own scope narrow rather than relying on the sandbox to
+  narrow it for you.
+- **Is a secret reachable from THIS shell's environment, not just from a
+  file on disk?** A credential sitting in `~/.aws/credentials` is not
+  exposed by a command's env unless something has already loaded it into
+  a variable. Check what your shell — and therefore reyn's — actually has
+  set before assuming a command is safe because you don't see the
+  credential in the config you wrote.
+
+## Credential env vars reyn's own LLM providers read
+
+reyn's own LLM-provider clients read credentials from these environment
+variables today: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`,
+`AZURE_API_KEY`, `GOOGLE_API_KEY`, `LITELLM_API_KEY`.
+
+**This list is not the boundary of what's risky — it's an example of the
+shape.** Every LLM provider, cloud vendor, and SaaS tool you use has its
+own credential env var, and reyn has no way to enumerate all of them for
+you. Any variable your shell has set that a command could read is worth
+the same scrutiny, whether or not it appears on this list.
+
+## See also
+
+- [Configure the sandbox](configure-sandbox.md) — the sandbox's actual
+  scope (paths, network, subprocess spawn) and what it does and does not
+  bound
+- [Concepts: Sandbox and permissions](../../concepts/architecture/sandbox-vs-permission.md) —
+  why sandbox and permission are separate layers with different jobs


### PR DESCRIPTION
**[docs-maintainer]** — #3904 (lead-coder依頼、#3901確定版§7が仕様)。part of #3901.

## Fact-check before writing (per this repo's standing verify-before-write practice)

§7's draft main thesis was "環境変数もネットワークも素通しです" (both env vars AND
network already pass through). Before writing that as present-tense fact, I
verified it against source:

- **network**: confirmed already open — `DEFAULT_SANDBOX_NETWORK = True`
  (`policy.py:185`), always applied via `resolve_sandbox_policy`'s floor
  regardless of operator config.
- **env**: confirmed **NOT** open — `resolve_passthrough_env` (`policy.py:92-113`,
  its own docstring calls it "the shared chokepoint all three backends call")
  only forwards `policy.env_passthrough` (dataclass default `[]`) union a
  curated non-secret proxy/CA allowlist. Both `sandboxed_exec` and hook
  `exec`/`exec_capture` (via `shell_runner.py`) route through this same function.

Flagged this to lead-coder before writing anything (thread on #3901) — confirmed
correct, "env compat" is a recorded owner decision (#3901 §2) that hasn't
shipped yet (PR-B will implement it). Writing the doc as if it already had
would have created new doc-drift on day one, the exact thing #3893 (today's
earlier doc-drift batch) fixed four instances of.

## What's shipped

- **New**: `docs/guide/for-users/protect-credentials-in-shell-commands.md`
  — main thesis: choose `sandboxed_exec`/hook commands with shell-level
  trust, grounded in what's true today (network open) plus what's coming
  (env axis moving to the same posture per #3901, stated as *planned*, not
  present). Covers stdout entering the LLM's context (verified against
  `sandboxed_exec.py`'s three `stdout_text` call sites), the
  choosing-commands *method* (not an enumeration, per instruction), and the
  6 credential env vars reyn's own LLM providers read today (verified
  against `credentials.py:34-37` / `llm.py:1657-1658`) with the required
  "this isn't the boundary of what's risky" caveat given equal prominence.
  Does **not** say reyn protects the operator (protection is the doc's job
  per the owner's ruling) and does **not** mention output masking (owner
  rejected — masking would itself require reading `os.environ`).
- **`configure-sandbox.md`**: fixes the two now-false `network: false`
  default claims (field table + "Network is the exfiltration gate" prose)
  to the verified `true` default, linking to the new guide.
- **`.mkdocs/mkdocs.yml`**: nav entry for the new page.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0, no new WARNING/Aborted lines
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` → 334 passed
- [x] All 6 env var names verified against the cited source lines
- [x] Network/env default claims independently verified against `policy.py`, not transcribed from the brief
- [x] Branch created off verified-current `origin/main`; remote head verified via `git ls-remote origin refs/heads/docs/protect-credentials-in-shell-commands`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
