### PR TITLE
fix(#3908): delete #3902's transcribed strip-falsify test

### DIFF
--- a/tests/core/test_3868_event_log_ingested_derived_state.py
+++ b/tests/core/test_3868_event_log_ingested_derived_state.py
@@ -19,11 +19,17 @@ but a wrong one is still a lie). What changed is the CLASS of growth:
 
 Still unbounded in principle (read enough distinct paths, this grows
 forever) — the bound is on WORK done (each entry costs a real file read +
-permission gate), not on how much an agent can emit. The tests below make
-this falsifiable rather than asserted:
+permission gate), not on how much an agent can emit. Three tests below,
+not all of them falsifying the mechanism the same way:
 
   1. Non-read events, however many, leave the derived state at size 0.
+     ``0`` is also what a DEAD fold produces, so this test alone cannot
+     distinguish "the fold works" from "the fold is gone" — it's the
+     false-positive-immune control (real strip-falsify below still
+     leaves it green), not a witness that the mechanism is live.
   2. Repeated reads of the SAME path leave it at size 1 (not N).
+  3. A full read followed by a truncated read on the same path stays
+     ``full`` (sticky full).
 
 Real ``EventLog`` throughout (no mocks) — ``ingested_path_count`` is the
 public witness (CLAUDE.md: no private-state assertions), not a read of the
@@ -38,11 +44,11 @@ same expression both sides), and a real strip of the production fold block
 in ``events.py`` leaves it GREEN (it asserts what the hand-written stub
 does, not what production does with the fold removed) — the opposite of
 what "STRIP-FALSIFY" in its name claimed. The real strip-falsify for tests
-1 and 2 above is executed and recorded in the PR body, not encoded as a
-test: deleting the fold block in ``EventLog.emit()`` turns both RED
-(confirmed via a positive control — ``grep -c '_ingested\\[path\\]'
-src/reyn/core/events/events.py`` → 0 after the strip), then the tree is
-restored.
+2 and 3 above is executed and recorded in the PR body, not encoded as a
+test: deleting the fold block in ``EventLog.emit()`` turns both RED while
+test 1 stays green (confirmed via a positive control — ``grep -c
+'_ingested\\[path\\]' src/reyn/core/events/events.py`` → 0 after the
+strip), then the tree is restored.
 """
 from __future__ import annotations
 

--- a/tests/core/test_3868_event_log_ingested_derived_state.py
+++ b/tests/core/test_3868_event_log_ingested_derived_state.py
@@ -19,18 +19,30 @@ but a wrong one is still a lie). What changed is the CLASS of growth:
 
 Still unbounded in principle (read enough distinct paths, this grows
 forever) — the bound is on WORK done (each entry costs a real file read +
-permission gate), not on how much an agent can emit. Three tests below make
+permission gate), not on how much an agent can emit. The tests below make
 this falsifiable rather than asserted:
 
   1. Non-read events, however many, leave the derived state at size 0.
   2. Repeated reads of the SAME path leave it at size 1 (not N).
-  3. Removing the fold (the mechanism) makes both 1 and 2 fail — the direct
-     strip-falsify the growth-class claim needs, so this file doesn't stay
-     green with the mechanism dead.
 
 Real ``EventLog`` throughout (no mocks) — ``ingested_path_count`` is the
 public witness (CLAUDE.md: no private-state assertions), not a read of the
 private ``_ingested`` dict.
+
+A fourth test, ``test_removing_the_fold_breaks_both_size_claims``, was
+removed (#3908, architect co-vet on #3868 comment 5229519141): it built a
+hand-written ``_NoFoldEventLog`` subclass whose ``emit()`` skips the fold,
+then asserted that stub's own behavior back — a transcribed implementation
+(CLAUDE.md's six-question review, Q1 "none": reyn's own trivia; Q2 "yes":
+same expression both sides), and a real strip of the production fold block
+in ``events.py`` leaves it GREEN (it asserts what the hand-written stub
+does, not what production does with the fold removed) — the opposite of
+what "STRIP-FALSIFY" in its name claimed. The real strip-falsify for tests
+1 and 2 above is executed and recorded in the PR body, not encoded as a
+test: deleting the fold block in ``EventLog.emit()`` turns both RED
+(confirmed via a positive control — ``grep -c '_ingested\\[path\\]'
+src/reyn/core/events/events.py`` → 0 after the strip), then the tree is
+restored.
 """
 from __future__ import annotations
 
@@ -84,44 +96,3 @@ def test_sticky_full_survives_a_later_truncated_read() -> None:
 
     assert log.compute_ingested("/repo/big.txt", "/repo/big.txt") == "full"
     assert log.ingested_path_count == 1
-
-
-def test_removing_the_fold_breaks_both_size_claims() -> None:
-    """Tier 1: STRIP-FALSIFY — with the emit()-time fold removed (simulated
-    by constructing an EventLog whose emit() never populates ``_ingested``,
-    the same class shape a future refactor accidentally deleting the fold
-    would produce), both prior claims go false: the "same path stays at 1"
-    test would instead see 0 (nothing tracked at all), proving those tests
-    exercise the real mechanism and are not vacuously true.
-    """
-
-    class _NoFoldEventLog(EventLog):
-        """A real EventLog subclass whose emit() skips the #3868 fold —
-        not a mock of EventLog, a genuine (if deliberately broken) instance
-        with the SAME public surface, so this drives the same code paths
-        the tests above do."""
-
-        def emit(self, type: str, **data):  # noqa: A002 - matches base signature
-            # Bypass EventLog.emit entirely so the fold never runs, while
-            # still producing a real Event and appending to `_events` (the
-            # rest of the class's own invariants).
-            from reyn.schemas.models import Event
-
-            event = Event(type=type, data=data)
-            self._events.append(event)
-            for sub in self._subscribers:
-                sub(event)
-            return event
-
-    log = _NoFoldEventLog()
-    for _ in range(200):
-        _emit_read(log, "/repo/README.md")
-
-    assert log.ingested_path_count == 0, (
-        "with the fold removed, ingested_path_count is non-zero — this test "
-        "no longer falsifies the mechanism"
-    )
-    assert log.compute_ingested("/repo/README.md", "/repo/README.md") == "none", (
-        "with the fold removed, compute_ingested still reports the read — "
-        "the fold is not what drives this claim after all"
-    )


### PR DESCRIPTION
**[e2e-coder]** — Closes #3908.

## What

`tests/core/test_3868_event_log_ingested_derived_state.py`'s 4th test,
`test_removing_the_fold_breaks_both_size_claims`, claimed to be a
STRIP-FALSIFY witness for #3902's `EventLog._ingested` fold, but was a
transcribed implementation: it hand-wrote a `_NoFoldEventLog` subclass
whose `emit()` skips the fold, then asserted that stub's own written
behavior back. Deleted (architect co-vet, #3868 comment 5229519141).

## Six-question review of the deleted test (why it had to go)

1. **Tier**: none — "a class that doesn't fold, doesn't fold" is reyn's
   own trivia, not an externally-anchored contract.
2. **Implementation transcribed?** Yes — the same computation (skip the
   fold, land on 0) is written once in the stub and re-asserted as the
   test's expectation.
3. **Stays green with the mechanism dead?** Yes — see falsify-verification
   below: stripping the REAL fold in `events.py` leaves this test GREEN,
   because it never calls production's `emit()`, only the stub's.
4. N/A (not a "never ran" case — it did run, just never on production code).
5. Bounded fixture, no accumulation concern.
6. Declared Tier ("Tier 1: STRIP-FALSIFY") was not the true one — none.

Also a CLAUDE.md Fake-ban violation: a hand-rolled stand-in class was
built where the real strip (delete one block in production, run pytest)
is cheap and IS the genuine witness — proven below.

## Falsify-verification (executed myself, not just citing architect's prior run)

```
strip:            deleted the #3868 fold block inside EventLog.emit()
                   (src/reyn/core/events/events.py, the `if type ==
                   "tool_executed": ...` block populating `_ingested`)
positive control:  grep -c '_ingested\[path\]' src/reyn/core/events/events.py -> 0
result:            2 failed, 1 passed
  test_repeated_reads_of_the_same_path_stay_at_size_one   -> RED
  test_sticky_full_survives_a_later_truncated_read        -> RED
  test_non_read_events_leave_ingested_state_at_zero       -> stays GREEN
    (expected — this test's own claim is "0 either way", so it can't
     distinguish live/dead mechanism; that's the intended
     false-positive-immune case #3902 already documented, not a hole)
tree restored, confirmed `git diff --stat` clean, re-ran: 3/3 green.
```

This matches architect's #3868 comment 5229519141 measurement exactly.

## Why no replacement test

Per #3908's instruction: the witness is "2 tests go red when the fold is
removed", which is a statement about the *relationship between a git
diff and a test run* — encoding it as a test would mean writing another
hand-rolled broken-fold stand-in, reproducing the exact defect being
removed. Recorded here in the PR body instead, per tonight's
falsify-verification standard (execute + positive control + tree
restored).

## Test plan

- [x] `pytest tests/core/test_3868_event_log_ingested_derived_state.py` — 3 passed.
- [x] Falsify-verification above, executed directly (not reasoned through).
- [x] `ruff check tests/core/test_3868_event_log_ingested_derived_state.py` — clean.
- [x] `python scripts/test_tier_audit.py --strict tests/core/test_3868_event_log_ingested_derived_state.py` — 3/3 OK, 0 Tier-4.
- [x] `python scripts/verify_module_docstrings.py tests/core/test_3868_event_log_ingested_derived_state.py` — OK.
- [x] `python scripts/mypy_ratchet.py` — OK, 212 findings, all baselined.
- [x] Working tree confirmed clean after the strip/restore cycle (only the intended test file is touched in the final diff).


---

**[lead-coder]** — TESTS-READ 済み。**削除の判断・六問・strip の記録、いずれも妥当です。**
🔴 **1 点だけ blocking。docstring と PR 本文が 食い違っています。**

- [x] 🔴 **module docstring の 列挙から 1 本目を «falsifiable» の 根拠として 外す** → fixed in `672b2f376` "fix(#3910): correct docstring — test 1 does not falsify the mechanism". Test 1 kept (as instructed), now explicitly labeled the false-positive-immune control; the falsifying claim moved to tests 2 and 3 only.
      PR 本文は 正しく書いています ── *"this test's own claim is '0 either way', so it
      can't distinguish live/dead mechanism"*。
      **docstring は そう書いていません**:
      > The tests below make this falsifiable rather than asserted:
      >   1. Non-read events, however many, leave the derived state at size 0.
      🔴 **1 本目は 機構が 死んでも 緑** ∴ **falsifiable にしているのは 2 本目（と sticky）だけ**です。
      ⚠️ **次に この file を 読む人が 見るのは docstring で、PR 本文では ありません。**
      **測定結果が «誰も 読み返さない 面» に 載り、誤った主張が «全員が 見る 面» に 残る**
      ── **この PR が 消している 欠陥と 同じ 形**です。
      ⚪ **1 本目を 消す必要は ありません。«区別できない» と 明記して 残してください**
      （★false-positive 側の 対照として 価値が あります ── PR 本文の 括弧書きが まさに それ）。

⚪ 六問（★私の 側）:
```
① Tier   ★1（★EventLog の 公開契約）── ★残る 3 本とも 妥当
② 転写   ★なし（★消えたのが それ）
③ 死んで緑 ★2 本目・sticky は RED ★実行で 確認済（★positive control 付き）
④ skip   ★なし
⑤ 蓄積   ★なし
⑥ 一致
```

