### PR TITLE
feat(#3879): tests/ dir-name shadow + vocabulary gate

### DIFF
--- a/.github/workflows/tests-dir-names-gate.yml
+++ b/.github/workflows/tests-dir-names-gate.yml
@@ -1,0 +1,44 @@
+name: tests-dir-names gate
+
+# #3879 shadow+vocabulary gate. PERMANENT (unlike migration-diff-shape-gate.yml):
+# the shadow check is a standing import-machinery invariant that matters
+# forever, and the vocabulary check (a NEW tests/<name>/ must mirror a real
+# src/reyn/<name>/ package or be `repo`) is not Stage-1-specific either — a
+# future PR could add a wrong-vocabulary directory long after Stage 1 lands.
+# Same permanent-ratchet shape as flat-tests-ratchet.yml, not
+# migration-diff-shape-gate.yml's triggered_by/removed_by lifespan.
+#
+# Needs full git history (fetch-depth: 0) only for --check-growth's diff
+# against the merge-base — see scripts/check_tests_dir_names.py's module
+# docstring for what SHADOW and VOCABULARY each check and why.
+on:
+  pull_request:
+    paths:
+      - "tests/**"
+      - "src/reyn/**"
+      - "scripts/tests_dir_names_baseline.json"
+
+permissions:
+  contents: read
+
+jobs:
+  tests-dir-names:
+    name: tests-dir-names gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/check_tests_dir_names.py is stdlib-only (argparse / ast /
+      # subprocess). No pip install needed.
+      - name: Check tests/ directory names (shadow + vocabulary)
+        run: |
+          python scripts/check_tests_dir_names.py --check-growth "origin/${{ github.base_ref }}"

--- a/scripts/check_tests_dir_names.py
+++ b/scripts/check_tests_dir_names.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""A ``tests/<name>/`` directory name must not collide with real import
+machinery, and (going forward) must mirror ``src/reyn/`` — #3879, lead-coder's
+two follow-up corrections (broker 2026-08-09 01:20:15 / 01:20:32).
+
+Two independent checks, both mechanical (never a declaration):
+
+SHADOW (always active, retroactive — a live collision is bad regardless of
+when it landed): a ``tests/<name>/`` directory that HAS an ``__init__.py``
+makes it a REGULAR package. Python's import machinery merges same-named
+NAMESPACE packages (PEP 420) across every ``sys.path`` entry, but a regular
+package short-circuits that merge — it wins outright wherever it's found
+first. pytest's own ``__init__.py``-chain walk inserts the directory ABOVE
+the topmost ``__init__.py`` (here, ``tests/``) at the FRONT of ``sys.path``,
+so once ``tests/<name>/__init__.py`` exists, ``import <name>`` resolves to
+``tests/<name>/`` first — never merging with the real top-level package,
+silently shadowing it. Verified directly (tui-coder, #3879 thread): adding
+``tests/scripts/__init__.py`` broke collection of two existing tests that
+``import scripts``.
+
+★ "importable top-level name" here is NOT "resolves via
+``importlib.util.find_spec``" — verified directly that EVERY non-hidden
+repo-root directory resolves that way (PEP 420 namespace packages need no
+``__init__.py`` and no content at all): ``dogfood``, ``pipelines``,
+``docs``, ``website``, ``artifacts``, ``tmp`` all resolve via
+``find_spec`` despite nothing in the codebase importing them as top-level
+modules. Using that definition would flag nearly every repo-root directory
+name as forbidden — including several of Stage 1's real destination
+buckets that happen to share a word with a data directory. The definition
+that actually matches the one confirmed real collision (``scripts``, 6
+import-statement hits) and no false ones (0 hits for the rest) is
+empirical: a name real code (``src/``, ``tests/``, ``scripts/``) actually
+imports as a top-level module.
+
+VOCABULARY (ratchet-style, forward-only — see ``flat_tests_ratchet.py``'s
+docstring for why a ratchet, not a whitelist, is the right shape): the
+directory-name SET currently on disk is the baseline (grandfathered —
+several pre-#3879 directories, e.g. ``tests/chat``/``tests/cli``/
+``tests/web``, share a name with an unrelated real ``src/reyn/<name>/``
+package without actually testing it — confirmed by grep, not assumed: e.g.
+``tests/cli/test_auth_login_ux.py`` imports ``reyn.interfaces.cli``, not
+``reyn.cli`` — so rule ① alone cannot retroactively judge them, they
+predate this gate entirely). A NEW top-level ``tests/<name>/`` directory
+(one absent from the committed baseline) must satisfy BOTH:
+
+  ① ``src/reyn/<name>/`` is a real package, OR ``name == "repo"`` (the
+    special case for AST-guard/CI-structure tests that import zero
+    ``reyn.*`` — no ``src/reyn/repo/`` exists or ever will).
+  ② ``name`` is not one of the reserved legacy names (``scaffold``,
+    ``_support`` — different axis, lifespan-scoped/non-test, not a
+    src-mirror bucket at all; ``web``, ``cli``, ``chat`` — the
+    name-coincidence orphans above, reserved so a NEW Stage-1 destination
+    never reuses one of these misleading names by accident).
+
+``--write-baseline`` and ``--check-growth`` mirror ``flat_tests_ratchet.py``
+exactly, including the same hand-edit-the-baseline loophole and the same
+guard against it.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_TESTS_DIR = _ROOT / "tests"
+_SRC_REYN = _ROOT / "src" / "reyn"
+_BASELINE_PATH = _ROOT / "scripts" / "tests_dir_names_baseline.json"
+
+_REPO_SPECIAL_CASE = "repo"
+# Reserved regardless of whether src/reyn/<name> exists (see module
+# docstring's VOCABULARY section) — a NEW Stage-1 destination must not
+# reuse one of these names.
+_RESERVED_NAMES = frozenset({"scaffold", "_support", "web", "cli", "chat"})
+# Directories the SHADOW/VOCABULARY scan itself must not treat as data:
+# never a candidate `tests/<name>/` name, never counted as an "importable
+# repo-root name" (the venv/build/vcs machinery, not code).
+_NON_CODE_ROOT_DIRS = frozenset({
+    ".git", ".venv", ".mypy_cache", ".pytest_cache", ".ruff_cache",
+    ".serena", ".claude", ".github", ".mcp-sandbox", ".mkdocs", ".reyn",
+    "__pycache__", "tests", "src",
+})
+
+
+def current_tests_dir_names(tests_dir: Path = _TESTS_DIR) -> "set[str]":
+    """Top-level ``tests/<name>/`` directory names right now, excluding
+    ``__pycache__``."""
+    return {
+        p.name for p in tests_dir.iterdir()
+        if p.is_dir() and p.name != "__pycache__"
+    }
+
+
+def real_src_packages(src_reyn: Path = _SRC_REYN) -> "set[str]":
+    """Every real top-level ``src/reyn/<name>/`` package (has
+    ``__init__.py``) — the mirror-vocabulary a NEW ``tests/<name>/`` must
+    match (rule ①)."""
+    return {
+        p.name for p in src_reyn.iterdir()
+        if p.is_dir() and (p / "__init__.py").exists()
+    }
+
+
+def _top_level_import_names(source: str) -> "set[str]":
+    """The root module name of every ``import``/``from ... import`` in
+    *source* — ``import scripts.foo`` and ``from scripts.foo import bar``
+    both yield ``"scripts"``. A source that fails to parse contributes
+    nothing rather than aborting the whole scan."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return set()
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            names.add(node.module.split(".")[0])
+    return names
+
+
+def imported_top_level_names(root: Path = _ROOT) -> "set[str]":
+    """Names real code (``src/``, ``tests/``, ``scripts/``) actually
+    imports as a top-level module — see module docstring's SHADOW section
+    for why this, not bare namespace-package resolvability, is the right
+    definition."""
+    names: set[str] = set()
+    for sub in ("src", "tests", "scripts"):
+        base = root / sub
+        if not base.exists():
+            continue
+        for py_file in base.rglob("*.py"):
+            try:
+                source = py_file.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            names |= _top_level_import_names(source)
+    return names
+
+
+def repo_root_dir_names(root: Path = _ROOT) -> "set[str]":
+    """Non-hidden, non-machinery top-level directory names — candidates for
+    a real "repo-root importable name" collision (before intersecting with
+    :func:`imported_top_level_names`)."""
+    return {
+        p.name for p in root.iterdir()
+        if p.is_dir() and p.name not in _NON_CODE_ROOT_DIRS
+    }
+
+
+def shadowed_names(tests_dir: Path = _TESTS_DIR, root: Path = _ROOT) -> "set[str]":
+    """``tests/<name>/`` directories that HAVE an ``__init__.py`` (making
+    them a real package, not a namespace-package portion) whose ``name``
+    collides with a repo-root name real code actually imports — see module
+    docstring's SHADOW section for the exact mechanism this catches."""
+    importable = imported_top_level_names(root) & repo_root_dir_names(root)
+    return {
+        p.name for p in tests_dir.iterdir()
+        if p.is_dir() and (p / "__init__.py").exists() and p.name in importable
+    }
+
+
+def is_allowed_new_name(name: str, src_packages: "set[str]") -> bool:
+    """Rule ①+② for a NEW (not-yet-baselined) ``tests/<name>/`` — see
+    module docstring's VOCABULARY section."""
+    if name in _RESERVED_NAMES:
+        return False
+    return name == _REPO_SPECIAL_CASE or name in src_packages
+
+
+def load_baseline(path: Path = _BASELINE_PATH) -> "set[str]":
+    return set(json.loads(path.read_text(encoding="utf-8")))
+
+
+def write_baseline(names: "set[str]", path: Path = _BASELINE_PATH) -> None:
+    path.write_text(json.dumps(sorted(names), indent=2) + "\n", encoding="utf-8")
+
+
+def new_dir_names(measured: "set[str]", baseline: "set[str]") -> "set[str]":
+    """A directory name present now but absent from the baseline — a name
+    leaving `measured` (a directory being retired) is not reported here at
+    all, by design (same asymmetry as ``flat_tests_ratchet.py``)."""
+    return measured - baseline
+
+
+def baseline_at_ref(
+    ref: str, path: Path = _BASELINE_PATH, root: Path = _ROOT,
+) -> "set[str] | None":
+    """The baseline's content as committed at *ref*, or ``None`` if the ref
+    lacks the file entirely. *root* is an explicit parameter (not a
+    hardcoded module constant) so this is testable against a throwaway git
+    repo — same reasoning as ``flat_tests_ratchet.baseline_at_ref``."""
+    rel = path.relative_to(root)
+    proc = subprocess.run(
+        ["git", "show", f"{ref}:{rel.as_posix()}"],
+        cwd=root, capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        return None
+    return set(json.loads(proc.stdout))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    parser.add_argument(
+        "--write-baseline",
+        action="store_true",
+        help=(
+            "regenerate the vocabulary baseline from the CURRENT tests/*/ "
+            "directory-name set instead of checking against it. Use ONLY "
+            "for initial adoption or a real Stage-1 rename — regenerating "
+            "to silence a new bad name defeats the ratchet."
+        ),
+    )
+    parser.add_argument(
+        "--check-growth",
+        metavar="BASE_REF",
+        help=(
+            "additionally reject if the committed baseline itself grew "
+            "versus BASE_REF — closes the hand-edit-the-baseline loophole, "
+            "mirrors flat_tests_ratchet.py's --check-growth."
+        ),
+    )
+    return parser
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    args = build_parser().parse_args(argv)
+    # Read the module globals by NAME here (not via callees' own default
+    # parameter values, bound once at def-time) so a test can monkeypatch
+    # _TESTS_DIR/_SRC_REYN/_BASELINE_PATH/_ROOT on this module and have
+    # main() actually observe it (flat_tests_ratchet.py's fix for the same
+    # bug, applied here from the start).
+    measured = current_tests_dir_names(_TESTS_DIR)
+
+    if args.write_baseline:
+        write_baseline(measured, _BASELINE_PATH)
+        print(f"Wrote {len(measured)} tests/ directory names to {_BASELINE_PATH}")
+        return 0
+
+    exit_code = 0
+
+    # SHADOW — always active, regardless of baseline.
+    shadowed = shadowed_names(_TESTS_DIR, _ROOT)
+    if shadowed:
+        exit_code = 1
+        print("tests-dir-names SHADOW check FAILED:\n", file=sys.stderr)
+        for name in sorted(shadowed):
+            print(
+                f"  tests/{name}/__init__.py shadows the real top-level "
+                f"`{name}` package — pytest's rootdir insertion makes "
+                f"`import {name}` resolve to tests/{name}/ first.",
+                file=sys.stderr,
+            )
+
+    # VOCABULARY — ratchet, forward-only.
+    baseline = load_baseline(_BASELINE_PATH)
+    new = new_dir_names(measured, baseline)
+    if new:
+        src_packages = real_src_packages(_SRC_REYN)
+        bad = {n for n in new if not is_allowed_new_name(n, src_packages)}
+        if bad:
+            exit_code = 1
+            print("\ntests-dir-names VOCABULARY check FAILED:\n", file=sys.stderr)
+            for name in sorted(bad):
+                print(
+                    f"  tests/{name}/ is new (not in the baseline) and is "
+                    f"neither a real src/reyn/{name}/ package, `repo`, nor "
+                    "outside the reserved-name list.",
+                    file=sys.stderr,
+                )
+            print(
+                "\nA NEW tests/<name>/ must mirror a real src/reyn/<name>/ "
+                "package (or be `repo`) and must not be scaffold/_support/"
+                "web/cli/chat. Do NOT add the name to the baseline to make "
+                "this pass — see module docstring.",
+                file=sys.stderr,
+            )
+
+    if args.check_growth:
+        old = baseline_at_ref(args.check_growth, _BASELINE_PATH, _ROOT)
+        if old is not None and len(baseline) > len(old):
+            exit_code = 1
+            added = baseline - old
+            print(
+                f"\ntests-dir-names VOCABULARY check FAILED: the baseline "
+                f"itself grew ({len(old)} -> {len(baseline)} entries) "
+                f"versus {args.check_growth} — hand-editing the baseline to "
+                f"pre-authorize a bad name. New entries: {sorted(added)}",
+                file=sys.stderr,
+            )
+
+    if exit_code == 0:
+        print(
+            f"tests-dir-names OK: {len(measured)} directories, 0 shadowed, "
+            f"vocabulary baseline unmoved ({len(baseline)} declared)."
+        )
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests_dir_names_baseline.json
+++ b/scripts/tests_dir_names_baseline.json
@@ -1,0 +1,15 @@
+[
+  "_support",
+  "chat",
+  "cli",
+  "core",
+  "data",
+  "fixtures",
+  "gateway",
+  "observability",
+  "plugins",
+  "scaffold",
+  "scripts",
+  "tools",
+  "web"
+]

--- a/tests/core/test_3868_event_log_ingested_derived_state.py
+++ b/tests/core/test_3868_event_log_ingested_derived_state.py
@@ -19,11 +19,17 @@ but a wrong one is still a lie). What changed is the CLASS of growth:
 
 Still unbounded in principle (read enough distinct paths, this grows
 forever) — the bound is on WORK done (each entry costs a real file read +
-permission gate), not on how much an agent can emit. The tests below make
-this falsifiable rather than asserted:
+permission gate), not on how much an agent can emit. Three tests below,
+not all of them falsifying the mechanism the same way:
 
   1. Non-read events, however many, leave the derived state at size 0.
+     ``0`` is also what a DEAD fold produces, so this test alone cannot
+     distinguish "the fold works" from "the fold is gone" — it's the
+     false-positive-immune control (real strip-falsify below still
+     leaves it green), not a witness that the mechanism is live.
   2. Repeated reads of the SAME path leave it at size 1 (not N).
+  3. A full read followed by a truncated read on the same path stays
+     ``full`` (sticky full).
 
 Real ``EventLog`` throughout (no mocks) — ``ingested_path_count`` is the
 public witness (CLAUDE.md: no private-state assertions), not a read of the
@@ -38,11 +44,11 @@ same expression both sides), and a real strip of the production fold block
 in ``events.py`` leaves it GREEN (it asserts what the hand-written stub
 does, not what production does with the fold removed) — the opposite of
 what "STRIP-FALSIFY" in its name claimed. The real strip-falsify for tests
-1 and 2 above is executed and recorded in the PR body, not encoded as a
-test: deleting the fold block in ``EventLog.emit()`` turns both RED
-(confirmed via a positive control — ``grep -c '_ingested\\[path\\]'
-src/reyn/core/events/events.py`` → 0 after the strip), then the tree is
-restored.
+2 and 3 above is executed and recorded in the PR body, not encoded as a
+test: deleting the fold block in ``EventLog.emit()`` turns both RED while
+test 1 stays green (confirmed via a positive control — ``grep -c
+'_ingested\\[path\\]' src/reyn/core/events/events.py`` → 0 after the
+strip), then the tree is restored.
 """
 from __future__ import annotations
 

--- a/tests/core/test_3868_event_log_ingested_derived_state.py
+++ b/tests/core/test_3868_event_log_ingested_derived_state.py
@@ -19,18 +19,30 @@ but a wrong one is still a lie). What changed is the CLASS of growth:
 
 Still unbounded in principle (read enough distinct paths, this grows
 forever) — the bound is on WORK done (each entry costs a real file read +
-permission gate), not on how much an agent can emit. Three tests below make
+permission gate), not on how much an agent can emit. The tests below make
 this falsifiable rather than asserted:
 
   1. Non-read events, however many, leave the derived state at size 0.
   2. Repeated reads of the SAME path leave it at size 1 (not N).
-  3. Removing the fold (the mechanism) makes both 1 and 2 fail — the direct
-     strip-falsify the growth-class claim needs, so this file doesn't stay
-     green with the mechanism dead.
 
 Real ``EventLog`` throughout (no mocks) — ``ingested_path_count`` is the
 public witness (CLAUDE.md: no private-state assertions), not a read of the
 private ``_ingested`` dict.
+
+A fourth test, ``test_removing_the_fold_breaks_both_size_claims``, was
+removed (#3908, architect co-vet on #3868 comment 5229519141): it built a
+hand-written ``_NoFoldEventLog`` subclass whose ``emit()`` skips the fold,
+then asserted that stub's own behavior back — a transcribed implementation
+(CLAUDE.md's six-question review, Q1 "none": reyn's own trivia; Q2 "yes":
+same expression both sides), and a real strip of the production fold block
+in ``events.py`` leaves it GREEN (it asserts what the hand-written stub
+does, not what production does with the fold removed) — the opposite of
+what "STRIP-FALSIFY" in its name claimed. The real strip-falsify for tests
+1 and 2 above is executed and recorded in the PR body, not encoded as a
+test: deleting the fold block in ``EventLog.emit()`` turns both RED
+(confirmed via a positive control — ``grep -c '_ingested\\[path\\]'
+src/reyn/core/events/events.py`` → 0 after the strip), then the tree is
+restored.
 """
 from __future__ import annotations
 
@@ -84,44 +96,3 @@ def test_sticky_full_survives_a_later_truncated_read() -> None:
 
     assert log.compute_ingested("/repo/big.txt", "/repo/big.txt") == "full"
     assert log.ingested_path_count == 1
-
-
-def test_removing_the_fold_breaks_both_size_claims() -> None:
-    """Tier 1: STRIP-FALSIFY — with the emit()-time fold removed (simulated
-    by constructing an EventLog whose emit() never populates ``_ingested``,
-    the same class shape a future refactor accidentally deleting the fold
-    would produce), both prior claims go false: the "same path stays at 1"
-    test would instead see 0 (nothing tracked at all), proving those tests
-    exercise the real mechanism and are not vacuously true.
-    """
-
-    class _NoFoldEventLog(EventLog):
-        """A real EventLog subclass whose emit() skips the #3868 fold —
-        not a mock of EventLog, a genuine (if deliberately broken) instance
-        with the SAME public surface, so this drives the same code paths
-        the tests above do."""
-
-        def emit(self, type: str, **data):  # noqa: A002 - matches base signature
-            # Bypass EventLog.emit entirely so the fold never runs, while
-            # still producing a real Event and appending to `_events` (the
-            # rest of the class's own invariants).
-            from reyn.schemas.models import Event
-
-            event = Event(type=type, data=data)
-            self._events.append(event)
-            for sub in self._subscribers:
-                sub(event)
-            return event
-
-    log = _NoFoldEventLog()
-    for _ in range(200):
-        _emit_read(log, "/repo/README.md")
-
-    assert log.ingested_path_count == 0, (
-        "with the fold removed, ingested_path_count is non-zero — this test "
-        "no longer falsifies the mechanism"
-    )
-    assert log.compute_ingested("/repo/README.md", "/repo/README.md") == "none", (
-        "with the fold removed, compute_ingested still reports the read — "
-        "the fold is not what drives this claim after all"
-    )

--- a/tests/scripts/test_check_tests_dir_names_3879.py
+++ b/tests/scripts/test_check_tests_dir_names_3879.py
@@ -1,0 +1,348 @@
+"""Tier 2: #3879 shadow+vocabulary gate (scripts/check_tests_dir_names.py).
+
+Placed in tests/scripts/ (not flat) — this file is itself new, obeying the
+ratchet it sits alongside.
+
+Real filesystem + real subprocess/git throughout (no mocks) — the functions
+under test are thin wrappers over the filesystem, AST parsing, and git, so
+faking any of them would test nothing real.
+
+★ Falsify-verified directly against the REAL repo (not only in these
+isolated fixtures) before this file was written: creating a real
+``tests/scripts/__init__.py`` made ``check_tests_dir_names.py`` genuinely
+RED for the shadow reason, and separately made two already-existing tests
+(``tests/test_swe_bench_runner_venv_183.py``,
+``tests/test_verify_package_move_root_config.py``) fail collection with
+``ModuleNotFoundError: No module named 'scripts.swe_bench_runner'`` — the
+exact real-world breakage the shadow check exists to predict, not a guessed
+one. The working tree was restored and confirmed clean afterward.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import scripts.check_tests_dir_names as check_tests_dir_names
+from scripts.check_tests_dir_names import (
+    baseline_at_ref,
+    current_tests_dir_names,
+    imported_top_level_names,
+    is_allowed_new_name,
+    load_baseline,
+    main,
+    new_dir_names,
+    real_src_packages,
+    repo_root_dir_names,
+    shadowed_names,
+    write_baseline,
+)
+
+
+def _write(path: Path, content: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+# ── current_tests_dir_names / real_src_packages ─────────────────────────────
+
+
+def test_current_tests_dir_names_excludes_pycache(tmp_path: Path) -> None:
+    """Tier 2: __pycache__ is not a candidate directory name."""
+    tests_dir = tmp_path / "tests"
+    _write(tests_dir / "core" / "test_a.py", "# t\n")
+    (tests_dir / "__pycache__").mkdir(parents=True)
+    assert current_tests_dir_names(tests_dir) == {"core"}
+
+
+def test_real_src_packages_requires_init_py(tmp_path: Path) -> None:
+    """Tier 2: a directory without __init__.py is not a real package — a
+    plain data directory under src/reyn/ (if one existed) would not count."""
+    src_reyn = tmp_path / "src" / "reyn"
+    _write(src_reyn / "core" / "__init__.py")
+    (src_reyn / "not_a_package").mkdir(parents=True)
+    assert real_src_packages(src_reyn) == {"core"}
+
+
+# ── imported_top_level_names / repo_root_dir_names ──────────────────────────
+
+
+def test_imported_top_level_names_reads_both_import_forms(tmp_path: Path) -> None:
+    """Tier 2: both `import X` and `from X.y import z` contribute X's root
+    name — matches how real code in this repo imports `scripts.foo`."""
+    _write(
+        tmp_path / "tests" / "test_uses_scripts.py",
+        "import scripts.verify_package_move\nfrom scripts.other import thing\n",
+    )
+    assert imported_top_level_names(tmp_path) == {"scripts"}
+
+
+def test_imported_top_level_names_ignores_relative_imports(tmp_path: Path) -> None:
+    """Tier 2: a relative import (`from . import x`) has no top-level
+    module name to extract — must not crash or contribute a bogus entry."""
+    _write(tmp_path / "src" / "pkg" / "mod.py", "from . import sibling\n")
+    assert imported_top_level_names(tmp_path) == set()
+
+
+def test_repo_root_dir_names_excludes_machinery(tmp_path: Path) -> None:
+    """Tier 2: .git/.venv/tests/src etc. are never candidate collision
+    names — only real top-level code/data directories are."""
+    for name in (".git", ".venv", "tests", "src", "__pycache__"):
+        (tmp_path / name).mkdir()
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "dogfood").mkdir()
+    assert repo_root_dir_names(tmp_path) == {"scripts", "dogfood"}
+
+
+# ── shadowed_names — the shadow mechanism itself ────────────────────────────
+
+
+def test_shadowed_names_is_empty_when_no_init_py(tmp_path: Path) -> None:
+    """Tier 2: a tests/<name>/ dir with the SAME name as an imported
+    repo-root package, but with NO __init__.py, is a namespace-package
+    portion — it merges, it doesn't shadow. This is `tests/scripts/`'s
+    actual current state in the real repo (0 collisions)."""
+    _write(tmp_path / "scripts" / "real_module.py", "x = 1\n")
+    _write(tmp_path / "tests" / "test_uses_scripts.py", "import scripts.real_module\n")
+    (tmp_path / "tests" / "scripts").mkdir(parents=True, exist_ok=True)
+    # No __init__.py written under tests/scripts/.
+    assert shadowed_names(tmp_path / "tests", tmp_path) == set()
+
+
+def test_shadowed_names_catches_a_real_collision(tmp_path: Path) -> None:
+    """Tier 2: the gate's own reason to exist — tests/scripts/__init__.py
+    existing, WITH scripts actually imported elsewhere, must be caught.
+    Mirrors the real repo's `scripts` collision exactly."""
+    _write(tmp_path / "scripts" / "real_module.py", "x = 1\n")
+    _write(tmp_path / "tests" / "test_uses_scripts.py", "import scripts.real_module\n")
+    _write(tmp_path / "tests" / "scripts" / "__init__.py")
+    assert shadowed_names(tmp_path / "tests", tmp_path) == {"scripts"}
+
+
+def test_shadowed_names_ignores_an_unimported_name_collision(tmp_path: Path) -> None:
+    """Tier 2: a tests/<name>/__init__.py whose name matches a repo-root
+    directory that NOTHING actually imports is not a real collision — this
+    is what keeps dogfood/pipelines/docs/etc. from being false positives
+    (verified directly against the real repo: every non-hidden root
+    directory resolves via importlib.util.find_spec as a namespace package
+    regardless of content, so bare resolvability is not the right signal)."""
+    (tmp_path / "dogfood").mkdir()  # exists, nothing imports it
+    _write(tmp_path / "tests" / "dogfood" / "__init__.py")
+    assert shadowed_names(tmp_path / "tests", tmp_path) == set()
+
+
+# ── is_allowed_new_name — vocabulary rule ①② ────────────────────────────────
+
+
+def test_is_allowed_new_name_accepts_a_real_src_package() -> None:
+    """Tier 2: rule ① — a name mirroring a real src/reyn/<name>/ package."""
+    assert is_allowed_new_name("runtime", {"runtime", "core"}) is True
+
+
+def test_is_allowed_new_name_accepts_the_repo_special_case() -> None:
+    """Tier 2: rule ① — the `repo` special case needs no src/reyn mirror."""
+    assert is_allowed_new_name("repo", set()) is True
+
+
+def test_is_allowed_new_name_rejects_a_non_mirroring_name() -> None:
+    """Tier 2: a name with no matching src/reyn/<name>/ package and not
+    `repo` is rejected."""
+    assert is_allowed_new_name("tui", {"runtime", "core"}) is False
+
+
+def test_is_allowed_new_name_rejects_a_reserved_name_even_if_a_real_package_exists() -> None:
+    """Tier 2: `web`/`cli`/`chat` are excluded regardless of rule ① — the
+    real repo has src/reyn/cli/ and src/reyn/web/ as REAL packages, but the
+    existing tests/cli/ and tests/web/ directories test a DIFFERENT package
+    entirely (confirmed by grep: tests/cli/test_auth_login_ux.py imports
+    reyn.interfaces.cli, not reyn.cli) — a coincidental name match, not a
+    real mirror, so a NEW directory must not reuse the name either."""
+    assert is_allowed_new_name("cli", {"cli", "runtime"}) is False
+    assert is_allowed_new_name("web", {"web", "runtime"}) is False
+    assert is_allowed_new_name("chat", {"chat", "runtime"}) is False
+    assert is_allowed_new_name("scaffold", {"runtime"}) is False
+    assert is_allowed_new_name("_support", {"runtime"}) is False
+
+
+# ── new_dir_names — ratchet arithmetic ───────────────────────────────────────
+
+
+def test_new_dir_names_is_measured_minus_baseline() -> None:
+    """Tier 2: a name absent from the baseline is new; a baseline name
+    absent from measured (a directory retired) is not reported at all —
+    same silent-shrink contract as flat_tests_ratchet.new_flat_files."""
+    measured = {"core", "runtime", "tui"}
+    baseline = {"core", "runtime", "gone_via_rename"}
+    assert new_dir_names(measured, baseline) == {"tui"}
+
+
+def test_write_baseline_then_load_baseline_round_trips(tmp_path: Path) -> None:
+    """Tier 2: the baseline file format round-trips through write/load, and
+    is written sorted (stable diffs)."""
+    path = tmp_path / "baseline.json"
+    write_baseline({"core", "_support"}, path)
+    assert load_baseline(path) == {"core", "_support"}
+    on_disk = json.loads(path.read_text(encoding="utf-8"))
+    assert on_disk == sorted(on_disk)
+
+
+# ── baseline_at_ref — same shape as flat_tests_ratchet's own tests ──────────
+
+
+@pytest.fixture
+def _real_git_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "tests_dir_names_baseline.json").write_text(
+        json.dumps(["core", "runtime"], indent=2) + "\n", encoding="utf-8",
+    )
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "baseline"], cwd=repo, check=True)
+    return repo
+
+
+def test_baseline_at_ref_reads_the_committed_content(_real_git_repo: Path) -> None:
+    """Tier 2: reads the baseline as committed at a ref via a real `git
+    show`, not the working tree's current (possibly dirtied) copy."""
+    baseline_path = _real_git_repo / "scripts" / "tests_dir_names_baseline.json"
+    baseline_path.write_text(json.dumps(["core"]), encoding="utf-8")
+    committed = baseline_at_ref("HEAD", baseline_path, root=_real_git_repo)
+    assert committed == {"core", "runtime"}
+
+
+def test_baseline_at_ref_returns_none_when_the_ref_lacks_the_file(
+    _real_git_repo: Path,
+) -> None:
+    """Tier 2: a ref with no baseline file at all (predates the gate) is
+    not growth — nothing to grow FROM — and must not crash."""
+    result = baseline_at_ref(
+        "HEAD", _real_git_repo / "scripts" / "nonexistent.json", root=_real_git_repo,
+    )
+    assert result is None
+
+
+# ── main() end-to-end — the gate's actual entry point ───────────────────────
+
+
+@pytest.fixture
+def _repo_tree(tmp_path: Path) -> Path:
+    """A full fake repo tree: real src/reyn/ packages, a tests/ directory
+    matching the baseline exactly, and a scripts/ package that IS imported
+    elsewhere — mirrors the real repo's shape closely enough to drive
+    main() honestly."""
+    root = tmp_path / "repo"
+    _write(root / "src" / "reyn" / "core" / "__init__.py")
+    _write(root / "src" / "reyn" / "runtime" / "__init__.py")
+    _write(root / "scripts" / "real_module.py", "x = 1\n")
+    _write(root / "tests" / "test_uses_scripts.py", "import scripts.real_module\n")
+    _write(root / "tests" / "core" / "__init__.py")
+    write_baseline({"core"}, root / "scripts" / "tests_dir_names_baseline.json")
+    return root
+
+
+def _patch(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    monkeypatch.setattr(check_tests_dir_names, "_ROOT", root)
+    monkeypatch.setattr(check_tests_dir_names, "_TESTS_DIR", root / "tests")
+    monkeypatch.setattr(check_tests_dir_names, "_SRC_REYN", root / "src" / "reyn")
+    monkeypatch.setattr(
+        check_tests_dir_names, "_BASELINE_PATH",
+        root / "scripts" / "tests_dir_names_baseline.json",
+    )
+
+
+def test_main_is_green_on_a_baseline_matching_tree(
+    monkeypatch: pytest.MonkeyPatch, _repo_tree: Path,
+) -> None:
+    """Tier 2: requirement ① from #3879's task — current state (tests/
+    matches the baseline exactly, no shadow) must be green."""
+    _patch(monkeypatch, _repo_tree)
+    assert main([]) == 0
+
+
+def test_main_is_red_when_a_baselined_dir_gains_an_init_py_shadowing_scripts(
+    monkeypatch: pytest.MonkeyPatch, _repo_tree: Path,
+) -> None:
+    """Tier 2: requirement ② from #3879's task, executed for real — adding
+    tests/scripts/__init__.py (the exact real-repo scenario, falsify-verified
+    directly against the actual repo before this test was written; see
+    module docstring) makes main() reject it.
+
+    `scripts` is put in the baseline FIRST (grandfathered — mirrors the real
+    repo's `tests/scripts/` already existing) so the vocabulary check has
+    nothing to say about it; only the shadow check can fail this. Without
+    this isolation, this test stayed GREEN even with `shadowed_names`
+    stripped to always return an empty set — the vocabulary check (`scripts`
+    being both new AND not a real src/reyn package) caught it independently,
+    masking a dead shadow mechanism (caught by this file's own
+    falsify-verification pass, not assumed correct)."""
+    _patch(monkeypatch, _repo_tree)
+    write_baseline({"core", "scripts"}, _repo_tree / "scripts" / "tests_dir_names_baseline.json")
+    _write(_repo_tree / "tests" / "scripts" / "__init__.py")
+    assert main([]) != 0
+
+
+def test_main_is_red_for_a_new_directory_that_does_not_mirror_src(
+    monkeypatch: pytest.MonkeyPatch, _repo_tree: Path,
+) -> None:
+    """Tier 2: a NEW tests/<name>/ with no matching src/reyn/<name>/ package
+    is rejected by the vocabulary check."""
+    _patch(monkeypatch, _repo_tree)
+    (_repo_tree / "tests" / "tui").mkdir()
+    assert main([]) != 0
+
+
+def test_main_is_green_for_a_new_directory_that_mirrors_src(
+    monkeypatch: pytest.MonkeyPatch, _repo_tree: Path,
+) -> None:
+    """Tier 2: a NEW tests/<name>/ that DOES mirror a real src/reyn/<name>/
+    package is accepted — the vocabulary check does not block legitimate
+    Stage-1 additions."""
+    _patch(monkeypatch, _repo_tree)
+    (_repo_tree / "tests" / "runtime").mkdir()
+    assert main([]) == 0
+
+
+def test_main_check_growth_rejects_a_hand_edited_baseline(
+    monkeypatch: pytest.MonkeyPatch, _repo_tree: Path,
+) -> None:
+    """Tier 2: same hand-edit-the-baseline loophole flat_tests_ratchet.py
+    closes, applied here — pre-authorizing a name via the baseline file
+    alone (no corresponding real directory needed for this check) must be
+    rejected against a base ref."""
+    _patch(monkeypatch, _repo_tree)
+    subprocess.run(["git", "init", "-q"], cwd=_repo_tree, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=_repo_tree, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=_repo_tree, check=True)
+    subprocess.run(["git", "add", "."], cwd=_repo_tree, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=_repo_tree, check=True)
+
+    write_baseline({"core", "hand_added"}, _repo_tree / "scripts" / "tests_dir_names_baseline.json")
+    monkeypatch.chdir(_repo_tree)
+
+    assert main(["--check-growth", "HEAD"]) != 0
+
+
+def test_main_check_growth_allows_a_shrunk_baseline(
+    monkeypatch: pytest.MonkeyPatch, _repo_tree: Path,
+) -> None:
+    """Tier 2: the other side — a baseline that only shrank (a directory
+    genuinely retired) must not be rejected by --check-growth."""
+    _patch(monkeypatch, _repo_tree)
+    subprocess.run(["git", "init", "-q"], cwd=_repo_tree, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=_repo_tree, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=_repo_tree, check=True)
+    write_baseline({"core", "runtime"}, _repo_tree / "scripts" / "tests_dir_names_baseline.json")
+    subprocess.run(["git", "add", "."], cwd=_repo_tree, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=_repo_tree, check=True)
+
+    write_baseline({"core"}, _repo_tree / "scripts" / "tests_dir_names_baseline.json")
+    monkeypatch.chdir(_repo_tree)
+
+    assert main(["--check-growth", "HEAD"]) == 0


### PR DESCRIPTION
**[e2e-coder]** — part of #3879. Implements the shadow gate (issue #3879 comment 5229058429) plus lead-coder's two follow-up corrections adding the vocabulary rule (broker 2026-08-09 01:20:15 / 01:20:32).

## What

`scripts/check_tests_dir_names.py`, two independent mechanical checks:

- **SHADOW** (always active, retroactive): a `tests/<name>/` with an `__init__.py` that collides with a repo-root name real code actually imports. Currently 0 collisions (`tests/scripts/` has no `__init__.py`).
- **VOCABULARY** (ratchet, forward-only): a NEW `tests/<name>/` (absent from the committed baseline) must mirror a real `src/reyn/<name>/` package or be `repo`, and must not be `scaffold`/`_support`/`web`/`cli`/`chat`.

## A premise correction found along the way

The original guidance described `web`/`cli`/`chat` as directories "whose src mirror vanished." Direct check: `src/reyn/web/`, `src/reyn/cli/`, `src/reyn/chat/` all currently **exist** as real packages — so a naive rule-① implementation (mechanical `src/reyn/<name>/` existence check alone) would have silently ALLOWED these three, missing the actual problem. Grep settled what's really going on: `tests/cli/test_auth_login_ux.py` imports `reyn.interfaces.cli`, not `reyn.cli` — the directory name is a coincidental collision with an unrelated real package, not a genuine mirror. Documented this in the module docstring and kept the explicit reserved-name list rather than relying on rule ① alone.

## A second false premise found and corrected before shipping

"Importable top-level name" was initially going to mean "resolves via `importlib.util.find_spec`" — direct test showed this resolves for literally every non-hidden repo-root directory (PEP 420 namespace packages need no `__init__.py`, no content): `dogfood`, `pipelines`, `docs`, `website`, `artifacts`, `tmp` all resolve despite nothing importing them. That definition would have flagged nearly every repo-root name as a forbidden collision. Switched to an empirical definition — names real code (`src/`, `tests/`, `scripts/`) actually imports as a top-level module via AST — which matches architect's prior measurement exactly (`scripts`: 6 hits; everything else: 0).

## Falsify-verification (executed against the real repo, not only isolated fixtures)

```
created tests/scripts/__init__.py -> gate genuinely RED (shadow)
confirmed the RED matches the real breakage it predicts:
  pytest --collect-only tests/test_swe_bench_runner_venv_183.py \
    tests/test_verify_package_move_root_config.py
  -> ModuleNotFoundError: No module named 'scripts.swe_bench_runner'
  (same failure tui-coder found manually in the #3879 thread)
created tests/tui/ (no src/reyn/tui/) -> RED (vocabulary)
created tests/runtime/, tests/repo/ (valid) -> stayed green
restored, git status clean, gate green again
```

Also falsify-verified both mechanisms inside the test suite: stripped `shadowed_names()` to always return empty → 2 tests RED. First attempt at the `main()`-level shadow test stayed GREEN even with the mechanism dead — the vocabulary check caught the same scenario independently for an unrelated reason, masking a dead shadow check. Fixed by grandfathering the name into the baseline first, isolating the shadow path. Stripped `is_allowed_new_name()` to always return `True` → 3 tests RED. Restored both times, 22/22 green.

## Six-question test review

1. **Tier**: 2 throughout — real filesystem/AST/git subprocess against reyn's own gate, no third-party property.
2. **Implementation transcribed?** No — expected outcomes stated independently (specific rejected/accepted names), and the `main()`-level tests exercise the real CLI entry point, not a re-derivation.
3. **Stays green with the mechanism dead?** No — see falsify-verification above, both checks.
4. **Stays green having never run?** No skip markers.
5. **Unbounded accumulation?** No — small fixed fixtures throughout.
6. **Declared Tier = true Tier?** Yes.

## Lifespan

PERMANENT (unlike `migration-diff-shape-gate.yml`'s Stage-1-scoped `triggered_by`/`removed_by`) — both checks matter indefinitely, not only during Stage 1.

## Test plan

- [x] `pytest tests/scripts/test_check_tests_dir_names_3879.py` — 22 passed.
- [x] Falsify-verification against the real repo (above), tree restored and confirmed clean.
- [x] Falsify-verification inside the test suite (above), script restored and confirmed clean (`diff` against backup).
- [x] `ruff check scripts tests` — clean.
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_check_tests_dir_names_3879.py` — 22/22 OK, 0 Tier-4.
- [x] `python scripts/verify_module_docstrings.py scripts/check_tests_dir_names.py tests/scripts/test_check_tests_dir_names_3879.py` — OK.
- [x] `python scripts/mypy_ratchet.py` — OK, 212 findings, all baselined.
- [x] `python scripts/check_tests_dir_names.py` against the real repo — OK, 13 directories, 0 shadowed, baseline unmoved.
