### PR TITLE
fix(#3909): detect copy-without-deleting-the-original in the M1 gate

### DIFF
--- a/scripts/check_migration_diff_shape.py
+++ b/scripts/check_migration_diff_shape.py
@@ -231,11 +231,35 @@ def is_tests_copy(line: str) -> bool:
     added to :func:`diff_name_status`, this exact scenario reports as
     ``C100  <old>  <new>``, and a genuine, unrelated ``git mv`` elsewhere in
     the SAME diff still reports plain ``R100`` — the two are not confused
-    with each other in a mixed batch."""
+    with each other in a mixed batch.
+
+    ★ Corrected in review (lead-coder, reproduced against the REAL repo, not
+    a design read — see PR #3913): the first version matched ``C`` on
+    EITHER side (``parts[1] OR parts[2]``) and didn't exclude
+    ``__init__.py``. A brand-new, EMPTY ``tests/<pkg>/__init__.py`` — the
+    exact shape a legitimate Stage-1 migration PR creates for every new
+    destination package — is trivially "100% similar" to every OTHER
+    empty ``__init__.py`` anywhere in the tree (empty files are all
+    byte-identical to each other), so ``-C --find-copies-harder`` matched
+    it against some UNRELATED empty ``__init__.py`` elsewhere (e.g.
+    ``src/reyn/data/pipelines/__init__.py``) and reported ``C100`` — this
+    gate rejecting its own legitimate migration operation, the same shape
+    #3885 already had to fix once. Two conditions now required together:
+
+    - the SOURCE (old) path specifically must be under ``tests/`` — a
+      match whose source is OUTSIDE ``tests/`` (an unrelated empty file
+      elsewhere in the repo) is not a real "copied from a tests/ file"
+      scenario, just an empty-content coincidence.
+    - the destination is NOT an ``__init__.py`` — that shape is already
+      legitimately handled by :func:`offending_lines`'s own empty-content
+      check (:data:`_INIT_SUFFIX`), which is unaffected by this change."""
     parts = line.split("\t")
     if not parts[0].startswith("C") or len(parts) != 3:
         return False
-    return parts[1].startswith("tests/") or parts[2].startswith("tests/")
+    old_path, new_path = parts[1], parts[2]
+    if new_path.endswith("/" + _INIT_SUFFIX) or new_path == _INIT_SUFFIX:
+        return False
+    return old_path.startswith("tests/")
 
 
 def is_tests_deletion(line: str) -> bool:
@@ -344,6 +368,24 @@ def offending_lines(lines: "list[str]", root: Path = _ROOT) -> "list[str]":
             continue
 
         if status == "M" and len(parts) == 2 and parts[1] in _ALLOWED_MODIFIED_PATHS:
+            continue
+
+        if status.startswith("C") and len(parts) == 3:
+            # A `C` (copy) match onto an EMPTY __init__.py is the same
+            # false-positive :func:`is_tests_copy` excludes from
+            # activation (#3913): an empty new __init__.py is trivially
+            # "100% similar" to every OTHER empty file anywhere in the
+            # tree, so -C --find-copies-harder can match it against an
+            # unrelated empty file even when a REAL rename elsewhere in
+            # the same diff already activated the gate. Same allowance as
+            # the `A`-status empty-__init__.py case above, content
+            # verified the same way — not just the path.
+            new_path = parts[2]
+            if new_path.endswith("/" + _INIT_SUFFIX) or new_path == _INIT_SUFFIX:
+                content = blob_at_head(new_path, root)
+                if content == b"":
+                    continue
+            offenders.append(line)
             continue
 
         offenders.append(line)

--- a/scripts/check_migration_diff_shape.py
+++ b/scripts/check_migration_diff_shape.py
@@ -78,9 +78,36 @@ the gate meant to guard against exactly that shape.
   this — not re-forbidden here).
 
 Everything else UNDER ``tests/`` (or the baseline file) — any other
-``A``/``M``/``D``, or a rename below 100% similarity — fails the gate. A
-change entirely OUTSIDE ``tests/`` and not the baseline is left alone (not
-this gate's concern, whatever else may check it).
+``A``/``M``/``D``, a rename below 100% similarity (which, with ``-C
+--find-copies-harder`` added for #3909, is what a rewrite-disguised-as-a-move
+now reports as — ``R099``, not the plain ``A``/``D`` pair an ``-M100%``-only
+diff would show — still rejected the same way, only similarity ``"100"`` is
+ever allowed), or any ``C`` (copy) line — fails the gate. A change entirely
+OUTSIDE ``tests/`` and not the baseline is left alone (not this gate's
+concern, whatever else may check it).
+
+## #3909 — the hole this gate had: copy without deleting the original
+
+architect measured three real diff shapes against the ``-M100%``-only
+version of this gate (issue #3879 comment 5229557446): a proper
+``git mv`` passes, a rewrite-with-the-original-deleted is caught (the ``A``
++ ``D`` pair), but a rewrite that COPIES to the destination and leaves the
+original in place passes silently — nothing was deleted for either
+activation signal to react to, so ``gate_is_active`` stayed ``False`` and
+the copy was never even evaluated. The failure shape is the worst kind:
+the same test content exists at two paths, both green, and nothing says
+which one is canonical.
+
+A "total ``tests/`` ``.py`` count is unchanged" gate — the first shape
+considered — was rejected: it also fires on the single most common
+operation in this repo, adding an ordinary new test (issue #3909 body has
+the measured table). The chosen fix instead detects the property that
+actually distinguishes a copy-left-behind from an ordinary new test: git's
+own ``-C --find-copies-harder`` already computes "this new file's content
+matches an existing file elsewhere in the tree" — an ordinary new test
+shares no content with anything, so it never gets a ``C`` line; a
+copy-left-behind always does. See :func:`is_tests_copy` and
+:func:`gate_is_active`'s third signal.
 
 ## Lifespan — this gate is temporary, unlike Stage 0's ratchet
 
@@ -106,13 +133,29 @@ _INIT_SUFFIX = "__init__.py"
 
 
 def diff_name_status(base: str, root: Path = _ROOT) -> "list[str]":
-    """Raw ``git diff -M100% --name-status <base>...HEAD`` lines.
+    """Raw ``git diff -M100% -C --find-copies-harder --name-status
+    <base>...HEAD`` lines.
 
-    Three-dot (``base...HEAD``, merge-base diff) — the same comparison
-    GitHub's own PR diff view uses, so this gate agrees with what a reviewer
-    actually sees, not with whatever line HEAD happens to have crossed."""
+    ``-C --find-copies-harder`` (added for #3909) does not change how ``①``
+    a proper move or ``②`` a rewrite-disguised-as-a-move are classified —
+    verified directly (a real throwaway repo, not assumed): a pure
+    ``git mv`` still reports plain ``R100``, and a 1-line-appended "rewrite
+    disguised as a move, original deleted" still reports as a rename
+    (``R099``, not the ``-M100%``-only run's ``A``/``D`` pair — a real
+    behavior shift, but harmless: ``offending_lines`` only ever allowed
+    ``similarity == "100"``, so an ``R099`` line still falls through to
+    "offender" exactly as its old ``A``/``D`` shape did). What ``-C`` adds
+    is detecting ``③`` — a copy that leaves the ORIGINAL file in place
+    (``C100  <old>  <new>``), invisible to ``-M100%`` alone since nothing
+    was deleted for it to pair against. Three-dot (``base...HEAD``,
+    merge-base diff) — the same comparison GitHub's own PR diff view uses,
+    so this gate agrees with what a reviewer actually sees, not with
+    whatever line HEAD happens to have crossed."""
     proc = subprocess.run(
-        ["git", "diff", "-M100%", "--name-status", f"{base}...HEAD"],
+        [
+            "git", "diff", "-M100%", "-C", "--find-copies-harder",
+            "--name-status", f"{base}...HEAD",
+        ],
         cwd=root, capture_output=True, text=True, check=True,
     )
     return [line for line in proc.stdout.splitlines() if line]
@@ -131,14 +174,28 @@ def blob_at_head(path: str, root: Path = _ROOT) -> "bytes | None":
 
 
 def is_tests_rename(line: str) -> bool:
-    """Whether *line* is a pure (R100) rename whose NEW path lands under
-    ``tests/`` — one of the two activation signals for the whole gate (see
-    :func:`gate_is_active`)."""
+    """Whether *line* is ANY rename (any similarity — not just R100) whose
+    NEW path lands under ``tests/`` — one of the activation signals for the
+    whole gate (see :func:`gate_is_active`).
+
+    ★ Widened from "R100 only" to "any similarity" during #3909's own
+    falsify-verification: adding ``-C --find-copies-harder`` to
+    :func:`diff_name_status` (needed to detect #3909's copy-left-behind
+    hole) has a side effect nobody predicted from the design alone — git's
+    broadened similarity search now classifies a rewrite-disguised-as-move
+    (one appended line, original deleted) as a LOW-similarity rename
+    (``R075`` in one measured case), not the ``A``/``D`` pair the
+    ``-M100%``-only gate used to see. An activation check requiring
+    ``similarity == "100"`` never sees that line at all — a genuine
+    regression this test file's own falsify-verification caught (a
+    pre-existing test started failing after #3909's diff-command change,
+    not a hypothetical). Activation only needs to know "a rename touched
+    tests/" — whether it's ALLOWED (only similarity ``"100"`` is) remains
+    :func:`offending_lines`'s job, unaffected by this widening."""
     parts = line.split("\t")
     if not parts[0].startswith("R"):
         return False
-    similarity = parts[0][1:]
-    return similarity == "100" and len(parts) == 3 and parts[2].startswith("tests/")
+    return len(parts) == 3 and parts[2].startswith("tests/")
 
 
 def is_new_file_in_tests_subdir(line: str) -> bool:
@@ -163,6 +220,24 @@ def is_new_file_in_tests_subdir(line: str) -> bool:
     return path.count("/") >= 2 and path.startswith("tests/")
 
 
+def is_tests_copy(line: str) -> bool:
+    """Whether *line* is a ``C`` (copy) status line touching ``tests/`` on
+    either side — the third activation signal, for #3909's remaining hole:
+    "copy the file to the destination, but forget to delete the original"
+    passes ``is_tests_rename`` (no ``R`` line — nothing was deleted for git
+    to pair against) AND ``is_new_file_in_tests_subdir`` + ``is_tests_deletion``
+    together (no ``D`` line either, by construction — that's the whole bug).
+    Verified directly (real throwaway repo): with ``-C --find-copies-harder``
+    added to :func:`diff_name_status`, this exact scenario reports as
+    ``C100  <old>  <new>``, and a genuine, unrelated ``git mv`` elsewhere in
+    the SAME diff still reports plain ``R100`` — the two are not confused
+    with each other in a mixed batch."""
+    parts = line.split("\t")
+    if not parts[0].startswith("C") or len(parts) != 3:
+        return False
+    return parts[1].startswith("tests/") or parts[2].startswith("tests/")
+
+
 def is_tests_deletion(line: str) -> bool:
     """Whether *line* deletes a ``.py`` file somewhere under ``tests/`` —
     paired with :func:`is_new_file_in_tests_subdir` to distinguish "a file
@@ -179,9 +254,12 @@ def gate_is_active(lines: "list[str]") -> bool:
     review correction: a self-declared signal is exactly the
     declaration-vs-reality gap this whole audit exists to close — Tier
     labels, "falsify done" claims, hand-edited baselines, all the same
-    shape). Two signals, either one activates:
+    shape). Three signals, any one activates:
 
-    - :func:`is_tests_rename` — a pure R100 rename under ``tests/``.
+    - :func:`is_tests_rename` — ANY rename (R100 or a lower-similarity
+      inexact rename) under ``tests/`` — only pure R100 is ALLOWED, but any
+      similarity ACTIVATES the gate (widened for #3909, see the function's
+      own docstring).
     - :func:`is_new_file_in_tests_subdir` **AND** :func:`is_tests_deletion`
       TOGETHER — a brand-new ``.py`` appearing in a ``tests/`` subdirectory
       while a ``.py`` disappears from somewhere under ``tests/``, which is
@@ -198,6 +276,17 @@ def gate_is_active(lines: "list[str]") -> bool:
       "appeared AND something disappeared" can — the same shape the
       R100-rename signal already captures for the simple case, generalized
       to the fully-rewritten one.
+    - :func:`is_tests_copy` — a ``C`` status line under ``tests/`` (#3909):
+      the file was COPIED to the destination but the ORIGINAL was never
+      deleted. This needs no AND-partner the way the subdir-file signal
+      does — a copy that keeps the original cannot masquerade as an
+      ordinary new-test-addition PR the way a bare "new file appeared"
+      can, because ``git`` itself already found a same-content SOURCE
+      file elsewhere in the tree (an ordinary new test, by construction,
+      shares no content with anything else — see #3909's issue body for
+      why a "total .py count is unchanged" invariant was considered and
+      rejected: it would also reject the single most common operation in
+      this repo, adding an ordinary new test).
 
     No signal anywhere → this PR isn't touching tests/'s Stage-1 migration
     at all, whatever it claims to be, and an ordinary Q3/Q4 assert-repair PR
@@ -206,7 +295,8 @@ def gate_is_active(lines: "list[str]") -> bool:
     has_rename = any(is_tests_rename(line) for line in lines)
     has_new_subdir_file = any(is_new_file_in_tests_subdir(line) for line in lines)
     has_deletion = any(is_tests_deletion(line) for line in lines)
-    return has_rename or (has_new_subdir_file and has_deletion)
+    has_copy = any(is_tests_copy(line) for line in lines)
+    return has_rename or (has_new_subdir_file and has_deletion) or has_copy
 
 
 def _in_scope(line: str) -> bool:

--- a/tests/scripts/test_check_migration_diff_shape_3879.py
+++ b/tests/scripts/test_check_migration_diff_shape_3879.py
@@ -19,6 +19,7 @@ from scripts.check_migration_diff_shape import (
     blob_at_head,
     diff_name_status,
     gate_is_active,
+    is_tests_copy,
     offending_lines,
 )
 
@@ -62,12 +63,20 @@ def test_pure_rename_is_clean(_repo: Path) -> None:
 def test_rewrite_disguised_as_a_move_is_caught(_repo: Path) -> None:
     """Tier 2: THE gate's whole reason to exist — owner's exact scenario.
     An agent told to "move" the file instead deletes the old one and writes
-    a new file at the destination with ONE extra line. `git diff -M100%`
-    reports this as separate A/D lines (verified: NOT a lower-similarity
-    Rxxx — confirmed directly in the module docstring's own measurement),
-    and the gate must ACTIVATE on this shape (no rename exists — only
-    `is_new_file_in_tests_subdir` catches it, per the #3885 review fix) and
-    flag both lines as offenders.
+    a new file at the destination with ONE extra line.
+
+    ★ The exact diff SHAPE this produces changed under #3909's own
+    falsify-verification, caught by this very test going red after that
+    change (not assumed from the design): with the ``-M100%``-only gate
+    (pre-#3909), this reported as separate ``A``/``D`` lines. Adding ``-C
+    --find-copies-harder`` (needed for #3909's copy-left-behind detection)
+    makes git's broadened similarity search classify this as a LOW-similarity
+    RENAME instead (``R075`` measured for this exact tiny fixture — the
+    percentage itself is not asserted below, since it is a function of file
+    size/content and would be a brittle pin; only that it is a non-100
+    rename line touching both paths). Either shape must still be rejected —
+    :func:`offending_lines` only ever allows similarity ``"100"``, so this
+    remains caught either way, just via a different line shape.
 
     ★ Checking activation explicitly, not just calling offending_lines()
     directly, closes a real gap this session's own falsify-verification
@@ -88,11 +97,14 @@ def test_rewrite_disguised_as_a_move_is_caught(_repo: Path) -> None:
         "ratchet caught before the fix"
     )
     offenders = offending_lines(lines, root=_repo)
-    assert "A\ttests/core/test_a.py" in offenders, (
-        f"the new (rewritten) file's A line was not flagged: {offenders!r}"
-    )
-    assert "D\ttests/test_a.py" in offenders, (
-        f"the deleted old file's D line was not flagged: {offenders!r}"
+    matching = [
+        line for line in offenders
+        if line.startswith("R") and not line.startswith("R100\t")
+        and "tests/test_a.py" in line and "tests/core/test_a.py" in line
+    ]
+    assert matching, (
+        f"no non-100-similarity rename line referencing both the old and "
+        f"new path was flagged as an offender: {offenders!r}"
     )
 
 
@@ -298,3 +310,115 @@ def test_blob_at_head_returns_none_for_a_missing_path(_repo: Path) -> None:
     only for an __init__.py-shaped A line, but the helper itself must not
     crash on a path that does not exist at HEAD."""
     assert blob_at_head("tests/does_not_exist/__init__.py", root=_repo) is None
+
+
+# ── #3909 — copy without deleting the original ──────────────────────────────
+# architect's measurement (issue #3879 comment 5229557446): a copy to the
+# destination that leaves the original file in place activated NEITHER prior
+# signal (no R100 rename — nothing was deleted for git to pair against; no
+# new-subdir-file+deletion pair either, by construction). Both this gate's
+# activation AND its rejection needed a third signal. Falsify-verified
+# directly against a real repo BEFORE writing these tests (not assumed from
+# the design): a real `cp` + `git add` (no `rm`) genuinely reports
+# `C100 <old> <new>` under `-C --find-copies-harder`, and a genuine unrelated
+# `git mv` in the SAME diff still reports plain `R100` — the two are not
+# confused with each other in a mixed batch (see module docstring).
+
+
+def test_copy_without_deleting_the_original_is_caught(_repo: Path) -> None:
+    """Tier 2: THE hole #3909 exists to close — copying the file to the
+    destination without deleting the original passed silently before this
+    fix (gate_is_active stayed False, offending_lines was never even
+    called)."""
+    core = _repo / "tests" / "core"
+    core.mkdir()
+    (core / "test_a.py").write_text("line1\nline2\nline3\n", encoding="utf-8")
+    # Deliberately NOT `git mv` / no deletion of tests/test_a.py — the
+    # original stays, exactly the bug shape.
+    _commit_all(_repo, "copy without deleting the original")
+
+    lines = diff_name_status("HEAD~1", root=_repo)
+    assert gate_is_active(lines), (
+        "a copy-without-delete did not activate the gate — the exact hole "
+        "#3909 exists to close"
+    )
+    offenders = offending_lines(lines, root=_repo)
+    assert any(line.startswith("C") for line in offenders), (
+        f"no C (copy) line was flagged as an offender: {offenders}"
+    )
+
+
+def test_is_tests_copy_requires_a_tests_path() -> None:
+    """Tier 2: non-vacuity — a copy entirely OUTSIDE tests/ is not this
+    gate's concern (mirrors the existing outside-tests exclusion for
+    renames)."""
+    assert is_tests_copy("C100\tscripts/old.py\tscripts/new.py") is False
+    assert is_tests_copy("C100\ttests/old.py\ttests/new.py") is True
+
+
+def test_a_pure_copy_left_behind_scenario_alone_is_correctly_isolated(
+    _repo: Path,
+) -> None:
+    """Tier 2: lead-coder's required pre-check (a) — a mixed batch where
+    ONE file is a genuine `git mv` and a SEPARATE, content-DISTINCT file is
+    copied-without-deleting must flag only the copy, not the legitimate
+    move. Content must be genuinely distinct (not merely a second copy of
+    the same fixture) — falsify-verification found git's copy/rename
+    matcher picks ANY same-content deleted file as a source when multiple
+    candidates share content, which would confound this test if both
+    fixture files were identical."""
+    (_repo / "tests" / "test_b.py").write_text(
+        "distinct line one\ndistinct line two\ndistinct line three\n",
+        encoding="utf-8",
+    )
+    _commit_all(_repo, "add a second, content-distinct file")
+
+    core = _repo / "tests" / "core"
+    core.mkdir()
+    subprocess.run(
+        ["git", "mv", "tests/test_a.py", "tests/core/test_a_moved.py"],
+        cwd=_repo, check=True,
+    )
+    (core / "test_b_copy.py").write_text(
+        "distinct line one\ndistinct line two\ndistinct line three\n",
+        encoding="utf-8",
+    )
+    # tests/test_b.py is NOT deleted — the copy-left-behind half of this
+    # mixed batch.
+    _commit_all(_repo, "real move + separate copy-left-behind")
+
+    lines = diff_name_status("HEAD~2", root=_repo)
+    offenders = offending_lines(lines, root=_repo)
+    offender_text = "\n".join(offenders)
+    assert "test_a_moved.py" not in offender_text, (
+        f"the legitimate git-mv was wrongly flagged: {offenders}"
+    )
+    assert any("test_b_copy.py" in line for line in offenders), (
+        f"the copy-left-behind was not flagged: {offenders}"
+    )
+
+
+def test_a_new_test_plus_new_init_py_still_leaves_the_gate_inactive(
+    _repo: Path,
+) -> None:
+    """Tier 2: lead-coder's required pre-check (b) — the #3885 deadlock
+    scenario (a brand-new test file + a brand-new empty __init__.py, no
+    deletion, no pre-existing file with matching content) must STILL leave
+    the gate inactive after #3909's fix. A genuinely new test shares no
+    content with anything already in the tree, so -C finds no copy source
+    for it — unlike the copy-left-behind scenario above, where the content
+    DOES already exist elsewhere."""
+    newpkg = _repo / "tests" / "newpkg"
+    newpkg.mkdir()
+    (newpkg / "test_new.py").write_text(
+        "brand new content shared with nothing else in the tree\n",
+        encoding="utf-8",
+    )
+    (newpkg / "__init__.py").write_text("", encoding="utf-8")
+    _commit_all(_repo, "new test file + new empty __init__.py, both genuinely new")
+
+    lines = diff_name_status("HEAD~1", root=_repo)
+    assert not gate_is_active(lines), (
+        "a genuinely new test file + new __init__.py (no matching content "
+        "anywhere else) incorrectly activated the gate after #3909's fix"
+    )

--- a/tests/scripts/test_check_migration_diff_shape_3879.py
+++ b/tests/scripts/test_check_migration_diff_shape_3879.py
@@ -351,9 +351,25 @@ def test_copy_without_deleting_the_original_is_caught(_repo: Path) -> None:
 def test_is_tests_copy_requires_a_tests_path() -> None:
     """Tier 2: non-vacuity — a copy entirely OUTSIDE tests/ is not this
     gate's concern (mirrors the existing outside-tests exclusion for
-    renames)."""
+    renames). The SOURCE side specifically must be under tests/ — a copy
+    whose source is OUTSIDE tests/ (#3913's false-positive shape) does not
+    count, even though the DESTINATION is under tests/."""
     assert is_tests_copy("C100\tscripts/old.py\tscripts/new.py") is False
     assert is_tests_copy("C100\ttests/old.py\ttests/new.py") is True
+    assert is_tests_copy("C100\tsrc/reyn/data/pipelines/old.py\ttests/new.py") is False
+
+
+def test_is_tests_copy_excludes_init_py_destinations() -> None:
+    """Tier 2: #3913 — a C-status match landing on an __init__.py
+    destination is never a real activation signal, regardless of source.
+    An empty __init__.py is trivially "100% similar" to every OTHER empty
+    file in the tree, so -C --find-copies-harder can match a brand-new,
+    legitimate tests/<pkg>/__init__.py against some unrelated empty file
+    ANYWHERE (real repro: src/reyn/data/pipelines/__init__.py) — that
+    shape is already legitimately handled elsewhere (the empty-content
+    check), not by this activation signal."""
+    assert is_tests_copy("C100\tsrc/reyn/data/pipelines/__init__.py\ttests/runtime/__init__.py") is False
+    assert is_tests_copy("C100\ttests/other/__init__.py\ttests/runtime/__init__.py") is False
 
 
 def test_a_pure_copy_left_behind_scenario_alone_is_correctly_isolated(
@@ -395,6 +411,54 @@ def test_a_pure_copy_left_behind_scenario_alone_is_correctly_isolated(
     )
     assert any("test_b_copy.py" in line for line in offenders), (
         f"the copy-left-behind was not flagged: {offenders}"
+    )
+
+
+def test_a_new_package_init_py_matching_an_unrelated_empty_file_is_allowed(
+    _repo: Path,
+) -> None:
+    """Tier 2: #3913 — the REAL reproduction lead-coder ran against the
+    actual repo (issue #3879, PR #3913 review): a legitimate Stage-1
+    migration PR (a real git-mv rename, activating the gate) that ALSO
+    creates a brand-new tests/<pkg>/__init__.py must not be rejected just
+    because that empty __init__.py happens to -C-match some UNRELATED
+    empty file elsewhere in the tree. An unrelated empty file (mirroring
+    src/reyn/data/pipelines/__init__.py in the real repro) is added to the
+    fixture repo specifically so `-C --find-copies-harder` has a same-
+    content candidate to (wrongly, pre-fix) match against."""
+    (_repo / "unrelated").mkdir()
+    (_repo / "unrelated" / "__init__.py").write_text("", encoding="utf-8")
+    _commit_all(_repo, "add an unrelated empty __init__.py elsewhere in the tree")
+
+    # The migration PR's diff must be measured from THIS commit as base —
+    # the unrelated file needs to exist in the diff's BASE state (like
+    # src/reyn/data/pipelines/__init__.py already sitting on main before
+    # the real migration PR opened), not appear WITHIN the diffed range
+    # itself. Falsify-verified this distinction directly: diffing from two
+    # commits back (spanning both this commit and the next) made the
+    # unrelated file ALSO look newly-added within the diff, and git's
+    # copy matcher then reported plain `A` lines for both files instead of
+    # the real `C100` match — silently making this test vacuous. Confirmed
+    # against a real throwaway repo before fixing.
+    base = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=_repo, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+    core = _repo / "tests" / "core"
+    core.mkdir()
+    subprocess.run(
+        ["git", "mv", "tests/test_a.py", "tests/core/test_a.py"],
+        cwd=_repo, check=True,
+    )
+    (core / "__init__.py").write_text("", encoding="utf-8")
+    _commit_all(_repo, "real move + new package __init__.py")
+
+    lines = diff_name_status(base, root=_repo)
+    assert gate_is_active(lines), "the real git-mv rename should activate the gate"
+    offenders = offending_lines(lines, root=_repo)
+    assert offenders == [], (
+        f"a legitimate new empty __init__.py, C-matched against an "
+        f"unrelated empty file, was wrongly flagged: {offenders}"
     )
 
 

--- a/tests/scripts/test_check_migration_diff_shape_3879.py
+++ b/tests/scripts/test_check_migration_diff_shape_3879.py
@@ -467,11 +467,27 @@ def test_a_new_test_plus_new_init_py_still_leaves_the_gate_inactive(
 ) -> None:
     """Tier 2: lead-coder's required pre-check (b) — the #3885 deadlock
     scenario (a brand-new test file + a brand-new empty __init__.py, no
-    deletion, no pre-existing file with matching content) must STILL leave
-    the gate inactive after #3909's fix. A genuinely new test shares no
-    content with anything already in the tree, so -C finds no copy source
-    for it — unlike the copy-left-behind scenario above, where the content
-    DOES already exist elsewhere."""
+    deletion) must STILL leave the gate inactive after #3909's fix.
+
+    ★ Corrected in review (lead-coder, #3913 follow-up): the first version
+    of this fixture had NO pre-existing empty file anywhere in the tree, so
+    the new __init__.py had no possible C-match candidate at all — it
+    always fell back to a plain `A` line REGARDLESS of whether #3913's
+    fix (condition ②: dest is not `__init__.py`) was present or stripped,
+    the same "docstring claims a witness the fixture doesn't actually
+    exercise" gap this PR's own reproduction fixture
+    (``test_a_new_package_init_py_matching_an_unrelated_empty_file_is_allowed``)
+    is built specifically to catch. Verified directly (a throwaway repo,
+    not assumed): with no pre-existing empty file, this exact scenario's
+    diff reports `A tests/newpkg/__init__.py` / `A tests/newpkg/test_new.py`
+    — never a `C` line — so condition ② was never exercised here. Fixed by
+    adding a pre-existing empty file to the fixture (mirroring lead-coder's
+    own real-repo reproduction 1:1), which DOES give the new __init__.py a
+    same-content match, making this test a genuine test of condition ②
+    rather than a vacuous one."""
+    (_repo / "unrelated_elsewhere.py").write_text("", encoding="utf-8")
+    _commit_all(_repo, "add a pre-existing empty file elsewhere in the tree")
+
     newpkg = _repo / "tests" / "newpkg"
     newpkg.mkdir()
     (newpkg / "test_new.py").write_text(
@@ -483,6 +499,7 @@ def test_a_new_test_plus_new_init_py_still_leaves_the_gate_inactive(
 
     lines = diff_name_status("HEAD~1", root=_repo)
     assert not gate_is_active(lines), (
-        "a genuinely new test file + new __init__.py (no matching content "
-        "anywhere else) incorrectly activated the gate after #3909's fix"
+        "a genuinely new test file + new __init__.py, with a pre-existing "
+        "empty file elsewhere as a possible C-match candidate, incorrectly "
+        "activated the gate after #3909/#3913's fix"
     )


### PR DESCRIPTION
**[e2e-coder]** — Closes #3909.

## What

architect measured a third gap in #3885's M1 gate (issue #3879 comment 5229557446): a rewrite that COPIES to the destination but never deletes the original passes silently — no `R100` rename (nothing was deleted to pair against), and the subdir-file+deletion signal needs an actual deletion too. Same test content ends up at two paths, both green, nothing says which is canonical.

The proposed "total `tests/` `.py` count is unchanged" fix was **rejected** (per the issue body) — it also fires on the single most common operation in this repo, adding an ordinary new test.

## Fix

- `diff_name_status` now runs `git diff -M100% -C --find-copies-harder --name-status` (was `-M100%` alone).
- New activation signal `is_tests_copy`: a `C` status line under `tests/`. An ordinary new test shares no content with anything already in the tree, so `-C` never finds a copy source for it; a copy-left-behind always does.

## A regression found by execution, not assumed from the design

Adding `-C --find-copies-harder` changed how a *different* existing scenario is classified: a rewrite-disguised-as-move (one line appended, original deleted) used to report as separate `A`/`D` lines under `-M100%` alone. With `-C` added, git's broadened similarity search now reports it as a **low-similarity rename** instead (`R075` for this fixture's exact size). The activation check (`is_tests_rename`, which required `similarity == "100"`) never saw that line — a pre-existing test (`test_rewrite_disguised_as_a_move_is_caught`) went genuinely RED from this change, not a hypothetical.

Fixed by widening `is_tests_rename`'s **activation** role to any similarity (any `R`-status line touching `tests/` activates the gate). `offending_lines`'s **allow** logic is untouched — it only ever accepted `similarity == "100"`, so this rewrite shape is still correctly rejected, just via a different line shape (`Rxxx` instead of `A`+`D`).

## Falsify-verification (executed against a real throwaway repo, before writing any test)

```
copy + keep original              -> C100 (previously invisible entirely)
proper git mv                     -> still plain R100, unaffected by -C
rewrite + delete original         -> now Rxxx (was A/D) — still rejected,
                                      only similarity "100" is ever allowed
mixed batch (real mv + separate
  copy-left-behind, DISTINCT
  content)                        -> move stays clean, only the copy flagged
```

★ The mixed-batch experiment initially used two fixture files with **identical** content by accident — git's copy/rename matcher picked the SAME deleted source for both destinations, confounding the result. Caught and corrected (distinct content per file) before writing the corresponding test — noted in the test's own docstring as a real pitfall, not silently fixed.

Both of lead-coder's required pre-checks, run for real before implementing:
- (a) new test + new `__init__.py`, no pre-existing content match anywhere → stays inactive.
- (b) mixed batch (one real move + one separate copy-left-behind) → both classified correctly in the same diff.

## Falsify-verification inside the test suite

Stripped `gate_is_active`'s `has_copy` signal → 1 test RED. Restored. Stripped `is_tests_copy`'s body to always return `False` → 2 tests RED (one stayed green — it drives `offending_lines()` directly, which independently catches a `C` line via its generic "no allow condition matched" fallback, unrelated to `is_tests_copy`; not a hole). Restored both times, confirmed clean via `diff` against a backup file, 17/17 green.

## Six-question test review

1. **Tier**: 2 throughout — real git repos, reyn's own gate script.
2. **Implementation transcribed?** No — expected line shapes/paths asserted independently of the production regex/status-parsing logic.
3. **Stays green with the mechanism dead?** No — both new signals falsify-verified RED when stripped (above).
4. **Stays green having never run?** No skip markers.
5. **Unbounded accumulation?** No — small fixed fixtures.
6. **Declared Tier = true Tier?** Yes.

## Test plan

- [x] `pytest tests/scripts/test_check_migration_diff_shape_3879.py` — 17 passed (14 existing + 3 new, one existing test updated for the real classification-shape change).
- [x] Falsify-verification against a real throwaway repo (above).
- [x] Falsify-verification inside the test suite (above), script restored and confirmed clean.
- [x] `ruff check scripts tests` — clean.
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_check_migration_diff_shape_3879.py` — 17/17 OK, 0 Tier-4 (one `len(offenders) == 1` count-pin found and fixed along the way).
- [x] `python scripts/verify_module_docstrings.py scripts/check_migration_diff_shape.py tests/scripts/test_check_migration_diff_shape_3879.py` — OK.
- [x] `python scripts/mypy_ratchet.py` — OK, 212 findings, all baselined.
- [x] `python scripts/check_migration_diff_shape.py --base origin/main` against this branch's own diff — "gate inactive" (no rename in this PR itself), as expected.


---

**[lead-coder]** — 🔴 **blocking。実リポで 再現しました。**

- [x] 🔴 **`is_tests_copy` に 2 条件を 入れる ── 現状、Stage 1 の 移行 PR 自身が 落ちます** → fixed in `71ab83154`: source must be under `tests/` AND destination must not be `__init__.py` (both, matching the exact 2 conditions above). Also fixed `offending_lines` — a `C`+empty-`__init__.py` line reaching there (gate already active via an unrelated real rename) needed the same allowance, content-verified via `blob_at_head` like the existing `A`-status case.

  **実測（★このリポ、`main` に対して）:**
  ```sh
  mkdir -p tests/runtime && : > tests/runtime/__init__.py
  printf 'def test_x():\n    assert True\n' > tests/runtime/test_zz_probe.py
  git add -N tests/runtime/__init__.py tests/runtime/test_zz_probe.py
  git diff -M100% -C --find-copies-harder --name-status HEAD
  ```
  ```
  🔴 C100  src/reyn/data/pipelines/__init__.py   tests/runtime/__init__.py
     A     tests/runtime/test_zz_probe.py
  ```
  ```
  ★is_tests_copy(C 行) ★parts[2].startswith("tests/") ★→ ★True ★→ ★gate 活性化
  ★offending_lines(A 行) ★A ＋ 非 __init__.py ★→ 🔴 ★offender
  ```
  🔴 **「新しいテストを `tests/<pkg>/` に 1 本 書く」＝ Stage 1 の 移行 PR が やること そのもの、が 拒否されます。**
  ⚠️ **#3885 の docstring が 記録している «activated on THIS VERY PR / reject its own
  introducing PR» と 同じ 結果**で、**一度 直した穴の 再現**です。

  ⚪ **原因**: `--find-copies-harder` は **同一 blob を 無差別に 対応付ける**。
  **空の `__init__.py` は 全部 同じ blob** ∴ **src 配下の 空 `__init__.py` が 写し元に 選ばれる。**

  ⚪ **入れる条件（★#3909 本文の 確定内容、★architect 実測）:**
  ```
  ★① ★写しの «元» が ★tests/ 配下（★現状は ★parts[1] or parts[2] の ★or）
  ★② ★写しの «先» が ★__init__.py でない
  ```
  ⚠️ **② は おまけでは ありません** ── `tests/core/__init__.py` が 既に main に 在るので
  **① だけでは 塞がりません**（★git が どの 空 blob を 選ぶかは 不定）。
  ⚪ `_INIT_SUFFIX` は **既に 132 行に 在り**、`offending_lines` が 使っています。同じものを。

- [x] 🔴 **事前確認 (a) を 実リポで やり直す** → reran the exact 4 commands against this real repo (`main`, no pathspec restriction), post-fix:
  ```
  mkdir -p tests/runtime && : > tests/runtime/__init__.py
  printf 'def test_x():\n    assert True\n' > tests/runtime/test_zz_probe.py
  git add -N tests/runtime/__init__.py tests/runtime/test_zz_probe.py
  git diff -M100% -C --find-copies-harder --name-status HEAD
  ```
  raw diff still shows `C100  src/reyn/data/pipelines/__init__.py  tests/runtime/__init__.py` (git's own detection is unchanged, as expected — the fix is in the script's interpretation). Ran the actual script (`check_migration_diff_shape.py --base <pre-probe-commit>`) against a real commit of this exact scenario on this branch → `OK: gate inactive`. Probe commit then reverted with `git reset --soft` (not `--hard`, to avoid re-losing the fix — see commit message for that near-miss). Also added the corresponding fixture-based test to the suite (`test_a_new_package_init_py_matching_an_unrelated_empty_file_is_allowed`), itself falsify-verified.

  本文は *"new test + new `__init__.py`, **no pre-existing content match anywhere** → stays inactive"*
  と 書いています。🔴 **その但し書きが 条件を 外しています** ──
  **実リポには 空 `__init__.py` が 多数 在る** ∴ **«match が 無い» fixture は
  実リポの 条件を 再現していません。**
  ⚪ **上の 4 行を そのまま 実リポで 走らせて 確認してください。**

  ⚠️ **測るときの 落とし穴（★私が 踏みました）**: `git diff ... -- tests/runtime` と
  **pathspec で 絞ると `--find-copies-harder` が 写し元を 探せず、`A` しか 出ません。**
  **絞らずに 測ってください。**私の 1 回目は それで 偽陰性でした。



---

**[lead-coder]** — ⚪ **blocking 2 件とも 解消、確認しました。TESTS-READ 済み（★テストを 開いて 読みました）。**

```
✅ ★is_tests_copy ★old_path.startswith("tests/") ★AND ★new_path が __init__.py でない
✅ ★私が 測った ★C100 src/…/__init__.py → tests/runtime/__init__.py ★→ ★False ∴ ★不活性
✅ ★skip 0 ／ ★count-pin 0 ／ ★fake なし（★実 git repo）
```

🔴 **168 行が この PR の 白眉**です ── `test_a_new_package_init_py_matching_an_unrelated_empty_file_is_allowed`。
**私の 再現を fixture に 持っています**（★base コミットに 無関係な 空 `__init__.py` を 置く）。
**さらに その 空虚化の 罠を 自分で 踏んで 直した 記録**が コメントに 残っている:
> diffing from two commits back … made the unrelated file ALSO look newly-added
> within the diff … **silently making this test vacuous.**
**«base に 在る» と «diff の 中で 生まれる» の 差**で、**踏まなければ 気づけない 種類**です。

## ⚠️ 1 点 blocking（★小さい）

- [x] ⚠️ **216 行 `test_a_new_test_plus_new_init_py_still_leaves_the_gate_inactive` の
      fixture に、無関係な 空ファイルを 足す（★168 行と 同じ 形）** → fixed in `4ad40a0d8`, applied option A (fixture change, 1:1 with your reproduction). Verified directly against a throwaway repo BEFORE fixing that the un-fixed fixture really did fall back to a plain `A` line (never `C`) — confirmed the vacuity claim, not assumed. Falsify-verified after the fix: stripping condition ② now makes this specific test go genuinely RED.

  docstring が **«lead-coder's required pre-check»** を 名乗っていますが、
  **私の 再現の 条件を fixture が 持っていません:**
  ```
  ★_repo ★tests/test_a.py（★3 行）★1 個だけ ── ★空ファイルが ★無い
  ★→ ★新規の 空 __init__.py に ★写し元候補が 無い ★→ ★git は A を 出す（★C でない）
  🔴 ★→ ★条件②（__init__.py 除外）を ★消しても ★このテストは 緑
  ```
  ⚠️ **私の 事前確認 (a) が 実リポで 意味を 持ったのは «空 `__init__.py` が 多数 在る» からで、
  それを 除いた fixture は、貴殿の 当初の (a) が 通ってしまったのと 同じ 形**です。

  ⚪ **機構自体は 守られています** ── 条件② は **168 行が** 落とせば RED、
  条件① は `test_is_tests_copy_requires_a_tests_path` が 見ています。
  ∴ **穴ではなく «名乗りと 中身の ずれ»。**直し方は 2 つ、どちらでも:
  ```
  ★A ★fixture に 空ファイルを 足す ★→ ★条件②を 消すと ★このテストも RED（★受理側 → 真の witness）
  ★B ★docstring を 直す ── ★«写し元候補が 無い 場合» と 書き、★#3914 で 入った 新ルールどおり
      ★拒否側（★168 行 / test_copy_without_deleting_the_original_is_caught）を ★名指しする
  ```
  ⚪ **A を 薦めます**（★私の 再現と 1:1 に なる）。**B でも 規約は 満たします。**

## ⚪ 別件、記録だけ

e2e-coder 報告: **litellm は openai の キー欠落で `InternalServerError` を投げ、`AuthenticationError` は anthropic だけ** ──
**#3905 の «AuthenticationError を捕まえる» 設計が プロバイダ横断で 成り立ちません。**
⚠️ **私が «typed な llm_provider が 在るから ハードコードは 不要» と 論じた 根拠の 一部**です。
**ハードコード削除（★owner 裁定）は 変わりませんが、捕捉する 例外の 選び方は #3905 で 測り直してください。**

