### PR TITLE
docs(#3872): the accept-side exception to six-questions ③ needs a reject-side pointer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ So each question has a blocking answer, not just an answer:
 |---|---|
 | 1 | **none** — including a third party's, a past bug's, and reyn's own trivia |
 | 2 | yes — the same expression is on both sides |
-| 3 | yes — it stays green with the mechanism removed |
+| 3 | yes — it stays green with the mechanism removed, unless it names the reject-side test that proves the mechanism can fail |
 | 4 | it would be green having never run, **and the PR does not say so** |
 | 5 | **anything outside the test bounds it** — a thread, a timer, the caller's pace |
 | 6 | the declared Tier is not the one question 1 named |
@@ -173,6 +173,21 @@ So each question has a blocking answer, not just an answer:
 often correct (an optional extra), and what makes it a defect is a green nobody
 qualified. 5 has no such carve-out — "it is small today" is a measurement of
 today, and the runaway that started this was small until it wasn't.
+
+**3's exception, precisely.** An accept-side test (a false-positive control —
+"this shape must NOT trip the gate") is *supposed* to stay green with the
+mechanism removed; that's what makes it accept-side. But self-declaring that
+in a docstring is not sufficient on its own — a suite of nothing but
+accept-side tests would all pass this exception, all stay green, with the
+gate itself dead. The docstring must *name the reject-side test that proves
+the gate can fail* — self-declaration plus a pointer to its actual contrast,
+not self-declaration alone. One sentence carries both: "Accept-side: a
+mirrors-src directory must NOT trip the gate (the reject side is
+`test_…` below)." Don't reduce this to a fixed phrase ("accept-side / control")
+— naming *what* it contrasts against is what satisfies the pointer, and a
+boilerplate phrase with no name satisfies neither. The reject-side test does
+not have to live in the same file (a gate built across separate files, e.g.
+the `#3885` migration-diff-shape gate, still qualifies).
 
 **Reviewer's note, on the PR:** record the answers per test before merging. A
 lead-coder merge train refuses any PR touching `tests/` without one — the promise


### PR DESCRIPTION
**[docs-maintainer]** — #3912(lead-coder依頼)。CLAUDE.md六問③の行のみ編集。part of #3872.

## The gap

Row ③ ("does the assert stay green with the mechanism dead?") has no
carve-out for an accept-side / false-positive-control test — which is
*supposed* to stay green with the mechanism removed. Applied literally,
every accept-side test reads as blocking.

## Two real outcomes from tonight (#3910 / #3911) fixed the condition

lead-coder's first draft of the exception (a docstring self-declaring
"accept-side/control" is exempt) repeats exactly the self-declaration-
as-witness shape this whole session has spent tonight closing — a suite
of nothing but accept-side tests would all pass that exception, all stay
green, with the gate itself dead. The corrected condition needs **both**:

```
① the docstring names itself accept-side/control
② it names the reject-side test that proves the gate can fail
```

One sentence satisfies both: `"Accept-side: a mirrors-src directory must
NOT trip the gate (the reject side is test_… below)."` — naming *what*
it contrasts against is what makes ① non-boilerplate and satisfies ② at
the same time. Confirmed against the two real cases: `#3910` fails ①
(claimed "falsifiable" while it wasn't) → correctly blocked; `#3911`
satisfies both (names its reject-side counterpart) → correctly passed.

## Scope, per explicit instruction

`testing.md` is **not** touched — verified myself: `grep -c "blocks when
the answer is"` → `CLAUDE.md` 1, `testing.md` 0. Editing both would have
created the exact drift the table itself exists to prevent (lead-coder's
own first-draft note that "both files have the table" was itself the
mistake here — writing to a doc that doesn't have the table would have
been the actual drift-creating move).

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0, no new WARNING/Aborted lines
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` → 334 passed
- [x] Independently verified `testing.md` has 0 copies of this table before and after the edit
- [x] Branch rebased onto current `origin/main` (picked up #3885/#3910/#3911 mid-task); remote head verified via `git ls-remote origin refs/heads/docs/six-questions-accept-side-exception`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
