### PR TITLE
fix(#3905): align SandboxPolicy.network's declared default with reality

### DIFF
--- a/scripts/sandbox_seccomp_x86_64_live_smoke.py
+++ b/scripts/sandbox_seccomp_x86_64_live_smoke.py
@@ -133,7 +133,7 @@ def _run_child_preexec_probe(workdir: str, ruleset: object | None) -> None:
     # probe's own "defend (must be refused): subprocess spawn / os.fork" arms
     # below are specifically about the OPT-OUT leg, so they must not silently
     # start passing-by-accident once the default itself grants subprocess.
-    policy = SandboxPolicy(write_paths=[workdir], allow_subprocess=False)
+    policy = SandboxPolicy(write_paths=[workdir], allow_subprocess=False, network=False)
 
     def _popen(argv: list[str], **kw: object) -> subprocess.CompletedProcess:
         return subprocess.run(
@@ -246,7 +246,7 @@ print("workload-ok")
     # filter, since it is irrevocable and survives fork+exec. A separate policy
     # (allow_subprocess=True) drives this probe: the `policy` object above is
     # deliberately allow_subprocess=False for the deny arms further down.
-    subprocess_pipe_policy = SandboxPolicy(write_paths=[workdir], allow_subprocess=True)
+    subprocess_pipe_policy = SandboxPolicy(write_paths=[workdir], allow_subprocess=True, network=False)
 
     def _popen_subprocess_allowed(argv: list[str]) -> subprocess.CompletedProcess:
         return subprocess.run(
@@ -402,9 +402,10 @@ import sys
 sys.path.insert(0, {os.getcwd()!r})
 from reyn.security.sandbox.landlock_exec import _apply_seccomp
 from reyn.security.sandbox.policy import SandboxPolicy
-# allow_subprocess=False explicitly (#3202 default flip) — this probe's
-# "defend (must be refused): subprocess spawn" arm below is the opt-out leg.
-_apply_seccomp(SandboxPolicy(write_paths=[{workdir!r}], allow_subprocess=False))
+# allow_subprocess=False, network=False explicitly (#3202 / #3905 default
+# flips) — this probe's "defend (must be refused): subprocess spawn" arm
+# below is the opt-out leg, and network must stay the tight leg too.
+_apply_seccomp(SandboxPolicy(write_paths=[{workdir!r}], allow_subprocess=False, network=False))
 {code_after_apply}
 """
         return subprocess.run(
@@ -480,7 +481,7 @@ def _validate_shim_entry_point(workdir: str) -> None:
     # allow_subprocess=True: this probe is about the entry point being reachable
     # at all, not about the fork gate (the self-test's spawn probe owns that).
     policy_arg = _policy_to_json(
-        SandboxPolicy(write_paths=[workdir], allow_subprocess=True)
+        SandboxPolicy(write_paths=[workdir], allow_subprocess=True, network=False)
     )
     shim_probe = f"""
 import sys
@@ -526,7 +527,7 @@ def _validate_denial_classification(workdir: str) -> None:
     # allow_subprocess=False explicitly (#3202 default flip): this probe's whole
     # point is that a REFUSED fork classifies as DENIAL_FORK, so the fork must
     # actually be denied here rather than accidentally allowed by the default.
-    policy = SandboxPolicy(write_paths=[workdir], allow_subprocess=False)
+    policy = SandboxPolicy(write_paths=[workdir], allow_subprocess=False, network=False)
     shapes = {
         "ls / | wc -l": "ls / | wc -l",
         "ls /; echo done": "ls /; echo done",

--- a/src/reyn/security/sandbox/policy.py
+++ b/src/reyn/security/sandbox/policy.py
@@ -6,17 +6,29 @@ selection lives in `reyn.security.sandbox.backend.get_default_backend()`.
 
 Scoping model (#1199 realignment, per-axis):
     write   — tight workspace-allowlist (``write_paths``) = the hard guard.
-    network — tight (default off / allowlist) = the exfiltration gate.
+    network — allowlist-CAPABLE (the backend can express a network deny),
+              but the DEFAULT is ON, not off — owner decision 2026-06-05
+              (see :data:`DEFAULT_SANDBOX_NETWORK`). An operator who wants
+              isolation sets it off via ``reyn.yaml sandbox.policy``.
     exec    — controlled (``allow_subprocess``).
     read    — **broad-allow by default**. The strict read-allowlist was
-              abolished: the network gate (off by default) blocks
-              exfiltration, so a broad read surface is safe and avoids the
-              system-path enumeration that broke Landlock on Linux. A
-              defense-in-depth ``read_deny_paths`` carves out sensitive
-              credential locations where the backend can express it.
+              abolished in favor of a defense-in-depth deny-list — this is
+              independent of the network default above (both were true
+              when the axis was tight-by-default; only the network default
+              itself changed).
+
+★ CORRECTED (#3905 follow-up, found by owner spotting the mismatch, not a
+design read): this section previously said "network — tight (default off /
+allowlist)", which was true of #1199's ORIGINAL design but went stale when
+the owner later flipped the RESOLVED default to ON (2026-06-05) without
+updating this docstring. The dataclass's own field default carried the
+SAME staleness — see :data:`DEFAULT_SANDBOX_NETWORK`, the single source
+both now read from.
 
 Fields:
-    network: allow outbound network access from the sandboxed process
+    network: allow outbound network access from the sandboxed process.
+        Defaults to :data:`DEFAULT_SANDBOX_NETWORK` (True) — see that
+        constant's own docstring for the owner decision and rationale.
     read_paths: legacy read-allowlist. Under the broad-read scoping model it
         no longer restricts reads (reads are broad by default); retained for
         backward compatibility and as documentation of intended read targets.
@@ -114,11 +126,22 @@ def resolve_passthrough_env(policy: "SandboxPolicy") -> dict[str, str]:
     return {name: os.environ[name] for name in names if name in os.environ}
 
 
+# The network default lives in ONE place so the owner can flip it trivially
+# (no hardcode scatter — #3905: this used to ALSO be hardcoded separately as
+# the SandboxPolicy dataclass field's own default, which drifted out of sync
+# with this constant when the owner changed it and nobody noticed until the
+# mismatch itself derailed a design discussion). Owner decision 2026-06-05:
+# default ON (the operator, not the LLM, owns the policy; an operator who
+# wants isolation sets it off via reyn.yaml sandbox.policy). Used by the
+# dataclass default below, the chat factories, and MCP wrap.
+DEFAULT_SANDBOX_NETWORK: bool = True
+
+
 @dataclass
 class SandboxPolicy:
     """Declarative sandbox policy. See module docstring for field semantics."""
 
-    network: bool = False
+    network: bool = DEFAULT_SANDBOX_NETWORK
     read_paths: list[str] = field(default_factory=list)
     write_paths: list[str] = field(default_factory=list)
     read_deny_paths: list[str] = field(
@@ -130,10 +153,12 @@ class SandboxPolicy:
     # deny-by-default — anything the reyn-launching shell can already do, the
     # sandbox must not silently refuse (the concrete trigger: a corporate-
     # proxy/sandbox host denying plugin-install's pip (materialise) under the
-    # old False floor). This is DELIBERATELY NOT the same policy as #3196-style
-    # credential/exfiltration axes (``read_deny_paths``, ``network``) — those
-    # stay deny-by-default because they gate secret exposure, not developer
-    # UX; do not read this flip as license to loosen those. An explicit
+    # old False floor). ``read_deny_paths`` stays deny-by-default because it
+    # gates secret exposure, not developer UX — do not read this flip as
+    # license to loosen that axis. ``network`` is NOT deny-by-default either
+    # (see :data:`DEFAULT_SANDBOX_NETWORK` — corrected #3905, this comment
+    # previously grouped it with ``read_deny_paths`` as staying tight, which
+    # was already stale by the time it was read). An explicit
     # ``allow_subprocess=False`` at any call site is unaffected (explicit
     # writes always win over the floor — #2964).
     allow_subprocess: bool = True
@@ -178,13 +203,6 @@ def deny_narrowed_write_grants(policy: SandboxPolicy) -> list[tuple[str, str]]:
 
 # ── default sandbox policy resolution (#1339 / sandbox-model completion) ──────
 #
-# The network default lives in ONE place so the owner can flip it trivially
-# (no hardcode scatter). Owner decision 2026-06-05: default ON (the operator,
-# not the LLM, owns the policy; an operator who wants isolation sets it off via
-# reyn.yaml sandbox.policy). Used by both the chat factories and MCP wrap.
-DEFAULT_SANDBOX_NETWORK: bool = True
-
-
 def resolve_sandbox_policy(
     config_policy: dict | None, *, write_paths: list[str] | None = None
 ) -> dict:

--- a/tests/test_op_sandboxed_exec.py
+++ b/tests/test_op_sandboxed_exec.py
@@ -35,12 +35,20 @@ from reyn.security.sandbox import noop_backend as _noop_module
 
 
 def test_policy_defaults():
-    """Tier 2: SandboxPolicy() default field values (owner decision 2026-07-22,
-    #3202: ``allow_subprocess`` defaults True — a UX-blocking axis is opt-in
-    restricted via explicit ``allow_subprocess=False``, not deny-by-default;
-    the other axes are unaffected and stay tight-by-default)."""
+    """Tier 2: SandboxPolicy() default field values.
+
+    ``network`` defaults to True (owner decision 2026-06-05, see
+    ``DEFAULT_SANDBOX_NETWORK`` in ``reyn.security.sandbox.policy``) and
+    ``allow_subprocess`` defaults to True (owner decision 2026-07-22,
+    #3202) — both UX-facing axes are opt-in RESTRICTED via an explicit
+    ``network=False`` / ``allow_subprocess=False``, not deny-by-default.
+    ``read_deny_paths`` is the axis that stays tight-by-default (a
+    non-empty deny-list, asserted elsewhere) — corrected here (#3905) after
+    this assertion pinned a STALE dataclass default (``network is False``)
+    that had drifted out of sync with the actual resolved policy for
+    weeks, undetected because nothing compared the two."""
     p = SandboxPolicy()
-    assert p.network is False
+    assert p.network is True
     assert p.read_paths == []
     assert p.write_paths == []
     assert p.allow_subprocess is True

--- a/tests/test_sandbox_seccomp.py
+++ b/tests/test_sandbox_seccomp.py
@@ -65,14 +65,20 @@ def test_syscall_allowlist_includes_baseline() -> None:
 
 def test_syscall_allowlist_no_network_by_default() -> None:
     """Tier 2: egress-capable network syscalls absent when policy.network is
-    False (default). `socket`/`bind` are deliberately excluded from this
-    assertion — #3060 made them unconditional (see
+    False. `socket`/`bind` are deliberately excluded from this assertion —
+    #3060 made them unconditional (see
     test_syscall_allowlist_socket_and_bind_always_allowed below); neither one
     alone can move a byte, so their presence here does not weaken the
-    network=False guarantee this test protects."""
+    network=False guarantee this test protects.
+
+    ``network=False`` is passed EXPLICITLY (#3905) — the dataclass's own
+    bare default is no longer False (owner decision 2026-06-05, network
+    defaults ON), so relying on a bare ``SandboxPolicy()`` here would test
+    "what the default happens to be today" rather than the actual claim
+    this test makes ("network syscalls are absent when network is off")."""
     from reyn.security.sandbox.backends.seccomp import _build_syscall_allowlist
 
-    result = _build_syscall_allowlist(SandboxPolicy())
+    result = _build_syscall_allowlist(SandboxPolicy(network=False))
     assert "connect" not in result
     assert "sendto" not in result
     assert "sendmsg" not in result
@@ -304,8 +310,12 @@ def test_syscall_allowlist_includes_async_runtime_and_durability_primitives() ->
     from reyn.security.sandbox.backends.seccomp import _build_syscall_allowlist
 
     # Present regardless of policy — an async runtime needs these to start under
-    # the most restrictive policy (network off, subprocess off).
-    result = _build_syscall_allowlist(SandboxPolicy())
+    # the most restrictive policy (network off, subprocess off). network=False
+    # passed EXPLICITLY (#3905) — the dataclass's bare default is no longer
+    # network-off (owner decision 2026-06-05), so the later "connect must stay
+    # absent" assertion below needs an actually-restrictive policy, not
+    # whatever the default happens to be today.
+    result = _build_syscall_allowlist(SandboxPolicy(network=False))
     for name in (
         # event-loop startup (round 1)
         "socketpair",


### PR DESCRIPTION
**[e2e-coder]** — owner directive relayed by lead-coder: `dataclass も修正してよそれ`.

## What

`SandboxPolicy.network`'s dataclass-declared default (`False`) diverged from the value actually used in every real call path (`resolve_sandbox_policy`'s floor → `DEFAULT_SANDBOX_NETWORK`, `True` since the owner's 2026-06-05 decision). Two sources of truth, one stale — and the mismatch itself derailed tonight's sandbox/compat design discussion: lead-coder and architect both read the declared `False` and wrote "network compat opens exfiltration" repeatedly before realizing network was already open.

Fixed: `network: bool = DEFAULT_SANDBOX_NETWORK` (moved above the dataclass so it can be referenced — one source of truth, no more scatter). Also fixed the module docstring's "Scoping model" section and a field comment, both independently repeating the same stale claim — doc-sync in the same PR per CLAUDE.md's hard rule.

## Consumer sweep (①, before implementing)

`grep "SandboxPolicy()"` across `src/` and `tests/`: **zero `src/` hits** — production never constructs a bare `SandboxPolicy()`, always via `resolve_sandbox_policy` or explicit fields, so **`resolve_sandbox_policy`'s own output is completely unaffected by this change**. ~25 `tests/` hits, checked individually.

Exactly 3 relied on the bare default specifically being `network=False`:

- `test_op_sandboxed_exec.py::test_policy_defaults` — asserted `p.network is False` → flipped to `True`.
- `test_sandbox_seccomp.py::test_syscall_allowlist_no_network_by_default` — asserted network syscalls absent under a bare policy → changed to `SandboxPolicy(network=False)` explicit, preserving the real tested claim instead of riding the default.
- `test_sandbox_seccomp.py::test_syscall_allowlist_includes_async_runtime_and_durability_primitives` — asserted `connect` stays absent under a bare policy meant to represent "the most restrictive policy" → same fix.

All other bare `SandboxPolicy()` sites (seatbelt / #1199 / wrap_command / landlock / landlock_exec_shim / subprocess_io_capped / remaining seccomp cases) checked individually — none assert anything about the network value.

## Out of scope, flagged not silently folded in or dropped

Two **different** `network: bool = False` fields exist elsewhere:
- `SandboxedExecIROp` in `schemas/models.py` (the LLM-facing op field, explicitly documented as "mirroring" `SandboxPolicy`)
- a launch-config class in `environment/container_launcher.py`

Neither is the mismatch the owner named (that was specifically `policy.py`'s dataclass vs `resolve_sandbox_policy`'s floor). Each may have its own correct rationale for staying `False` by default at the LLM-facing/container-isolation layer, distinct from the operator-facing floor this PR fixes — I did not investigate deeply enough to say either way, and did not touch either. Flagging for a separate call rather than silently expanding scope or silently leaving a possibly-related finding unmentioned.

## Test plan

- [x] `pytest tests/test_op_sandboxed_exec.py tests/test_sandbox_seccomp.py tests/test_sandbox_seatbelt.py tests/test_1199_effective_permission.py tests/test_sandbox_wrap_command_2620.py tests/test_sandbox_landlock.py tests/test_landlock_exec_shim_1344e.py tests/test_subprocess_io_capped_1934.py` — 88 passed, 4 skipped (unrelated platform gates), 0 failed.
- [x] `ruff check src/reyn/security/sandbox/policy.py tests/test_op_sandboxed_exec.py tests/test_sandbox_seccomp.py` — clean.
- [x] `python scripts/test_tier_audit.py --strict tests/test_op_sandboxed_exec.py tests/test_sandbox_seccomp.py` — 39/39 OK, 0 Tier-4.
- [x] `python scripts/verify_module_docstrings.py src/reyn/security/sandbox/policy.py` — OK.
- [x] `python scripts/mypy_ratchet.py` — OK, 212 findings, all baselined.


---

**[lead-coder]** — 🔴 **CI 赤の 原因を 特定しました。consumer sweep が 2 重に 外しています。**

- [x] 🔴 **`scripts/sandbox_seccomp_x86_64_live_smoke.py` の policy に `network=False` を 明示する** → fixed in `e6dac3efd`, all 5 sites (:136, :249, :408, :484, :530 after the edits shift lines). Redid the consumer sweep AST-based (not line-grep) across `src/`+`tests/`+`scripts/` together, catching both axes this missed: 87 call sites with no `network=` and no `**kwargs`. Reviewed every non-`scripts/` hit individually — none depend on the default. One production `src/` site remains open: `codeact_runner.py:315`'s `SandboxPolicy(**policy_dict)` — a `**kwargs` unpack the AST scan correctly can't resolve statically, overlapping #3907's "minimal synthesis path" investigation. Flagged separately, not guessed at.

  **一次証拠**（★job 93195064856、★`seccomp-BPF live probe (x86_64)`）:
  ```
  🔴 FAIL: callsite1 defend: connect (TCP egress) — TimeoutExpired(... s.connect(('93.184.216.34', 80)))
  🔴 FAIL: callsite1 defend (must be refused): sendto (UDP egress) — rc=0
  ✅ 20/22 probes as expected  ← ★落ちたのは ★ネットワーク deny の 2 本 «だけ»
  ```
  `connect` が **拒否されず タイムアウトまで 待った** ＝ **実際に 外へ 出ようとした。**

  **原因**（★:136 / :249 / :407 / :483 / :529）:
  ```python
  policy = SandboxPolicy(write_paths=[workdir], allow_subprocess=False)   # ← network を 渡していない
  ```
  **既定を 引き継ぐ ∴ 今回 True に なり、seccomp allowlist に ネットワーク syscall が 入った。**

  ⚪ **直し方は 本文が 既に やっているもの と 同じ** ── tests/ の seccomp 2 件に 当てた
  **「既定に 乗らず `network=False` を 明示して 本来の 主張を 保つ」**を、**このファイルにも。**
  **probe の 実際の 主張は «`network: false` の 下で egress は 拒否される»** であって、
  **«既定が False»** では ありません。

## 🔴 sweep が 外した 2 つの 軸

```
★軸① ★場所 ★src/ と tests/ を 見た ★→ 🔴 ★scripts/ が 範囲外
       ★scripts/sandbox_seccomp_x86_64_live_smoke.py ★5 箇所
       ★scripts/sandbox_load_method_witness_3229.py   ★6 箇所（★こちらは network を 明示済み ∴ 無傷）
★軸② ★形  ★`SandboxPolicy()`（★引数なし）で 数えた
       ★→ 🔴 ★`SandboxPolicy(write_paths=..., allow_subprocess=...)` ＝ ★network «だけ» 省いた 構築が 落ちる
```
⚠️ **本文の «zero src/ hits ∴ resolve_sandbox_policy は 無傷» は 正しい**のですが、
**その «hits» の 定義が 引数なし構築だった**ため、**既定に 乗っている 構築が 数えられていません。**

⚪ **列挙の 形（★#3901 で tui-coder にも 渡したもの）:**
```sh
grep -rn "SandboxPolicy(" src tests scripts | grep -v "network"
```
**«network を 渡していない 全構築»** が 母集団です。**«引数なし» は その 部分集合**。

⚪ **CI が 捕まえた のが 良い形**です ── ⚠️ **ただし この probe は Linux 限定 job** ∴
**同じ 見落としが macOS 側に あれば ローカルでは 出ません。**上の grep で 一度 全部 見てください。

## ⚪ 本文の 良い点（★記録）

**範囲外 2 件（`SandboxedExecIROp` / `container_launcher.py`）を «調べ切っていない» と 明記して
触っていない**のは 正しい判断です。**#3907 で `SandboxedExecIROp` 側は 別途 扱っています。**

