### PR TITLE
fix(#3907-1): exec.py's minimal-synthesis path resolves default_sandbox_policy

### DIFF
--- a/src/reyn/tools/exec.py
+++ b/src/reyn/tools/exec.py
@@ -89,6 +89,8 @@ async def op_context_from_tool_context(ctx: ToolContext) -> Any:
         return legacy_ctx
 
     # Minimal synthesis path (= test sites / narrow callers).
+    from reyn.security.sandbox.policy import resolve_sandbox_policy
+
     return OpContext(
         workspace=ctx.workspace,
         events=ctx.events,
@@ -110,6 +112,17 @@ async def op_context_from_tool_context(ctx: ToolContext) -> Any:
         caller="direct",
         parent_run_id=None,
         sandbox_config=sandbox_config,
+        # #3907①: this path had no access to reyn.yaml sandbox.policy at all
+        # (no `rs`/op_context_factory here to read it through), so
+        # ctx.default_sandbox_policy stayed None — the op_runtime handler's
+        # only fallback then is `SandboxedExecIROp`'s own raw op-field
+        # defaults (op_runtime/sandboxed_exec.py:69-74), a DIFFERENT
+        # computation than every other op path, which resolves through this
+        # SAME floor. resolve_sandbox_policy(None) applies the floor (no
+        # operator config to merge here — there's genuinely nothing to read
+        # it from on this path) rather than leaving this one path uniquely
+        # computed from op fields alone.
+        default_sandbox_policy=resolve_sandbox_policy(None),
     )
 
 

--- a/tests/test_sandbox_model_completion_1339.py
+++ b/tests/test_sandbox_model_completion_1339.py
@@ -146,3 +146,63 @@ def test_router_adapter_factory_resolves_concrete_policy():
     pol = adapter.make_router_op_context().default_sandbox_policy
     assert pol is not None
     assert pol["network"] is DEFAULT_SANDBOX_NETWORK
+
+
+# ── (D) #3907① — exec.py's minimal-synthesis path also resolves a concrete
+# default_sandbox_policy (was None → the same op-fields fallback gap (B) above
+# closed, but for the ONE remaining OpContext-building call site that had no
+# op_context_factory to delegate to at all) ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_minimal_synthesis_path_enforces_the_floor_not_the_op_default(
+    tmp_path,
+) -> None:
+    """Tier 2: #3907① — NOT just "the field got filled" (lead-coder's explicit
+    correction: filled is not a witness that it's ENFORCED). Drives the REAL
+    minimal-synthesis code path (a ToolContext with router_state=None, forcing
+    op_context_from_tool_context to skip op_context_factory entirely) through
+    the REAL op_runtime handler, and asserts the EMITTED event's enforced
+    ``network`` value — mirroring test_handler_event_shows_enforced_policy_network
+    above, the same "enforced, not requested" witness shape.
+
+    Before #3907①: ctx.default_sandbox_policy stayed None on this path, so the
+    handler fell back to SandboxedExecIROp's own raw field default
+    (network=False) — DIFFERENT from every other OpContext-building path in
+    the codebase, which resolves through resolve_sandbox_policy's floor
+    (network=True, owner decision 2026-06-05). The op itself requests nothing
+    (bare argv) — if the fix did nothing, the enforced value would still read
+    False (the op-fallback default), indistinguishable from a no-op fill."""
+    from reyn.core.events.events import EventLog
+    from reyn.data.workspace.workspace import Workspace
+    from reyn.tools.exec import op_context_from_tool_context
+    from reyn.tools.types import ToolContext
+
+    events = EventLog()
+    ws = Workspace(events=events, base_dir=tmp_path)
+    tool_ctx = ToolContext(
+        events=events,
+        permission_resolver=None,
+        workspace=ws,
+        caller_kind="router",
+        router_state=None,  # forces the minimal-synthesis branch — no factory to delegate to
+    )
+
+    legacy_ctx = await op_context_from_tool_context(tool_ctx)
+    assert legacy_ctx.default_sandbox_policy is not None, (
+        "ctx.default_sandbox_policy is still None on the minimal-synthesis "
+        "path — the fix did not take effect"
+    )
+
+    from reyn.core.op_runtime.sandboxed_exec import handle
+    from reyn.schemas.models import SandboxedExecIROp
+
+    op = SandboxedExecIROp(kind="sandboxed_exec", argv=["/bin/echo", "x"])
+    await handle(op, legacy_ctx)
+    started = [e for e in events.all() if e.type == "sandboxed_exec_started"]
+    (ev,) = started
+    assert ev.data["network"] is True, (
+        "the minimal-synthesis path enforced the op's own raw default "
+        "(network=False) instead of the floor (network=True) — the fix did "
+        "not change what the handler actually uses, only that a field is set"
+    )


### PR DESCRIPTION
**[e2e-coder]** — part of #3907 (item ① only, per instruction — items ②-④ of the issue's own broader field-removal plan are a separate PR).

## What

`op_context_from_tool_context`'s "minimal synthesis" branch (reached when `rs.op_context_factory` is unavailable) built its `OpContext` without setting `default_sandbox_policy` — it stayed `None`. The op_runtime handler's only fallback then is `SandboxedExecIROp`'s own raw op-field defaults (`op_runtime/sandboxed_exec.py:69-74`) — a **different** computation than every other OpContext-building path, which resolves through `resolve_sandbox_policy`'s floor. Operator intent (`reyn.yaml sandbox.policy`) never reaches this path.

Fix: `default_sandbox_policy=resolve_sandbox_policy(None)`. Applies the floor — there's genuinely no accessible operator config object on this path to merge (matching the literal instruction).

## Witness (not just "the field got filled")

Per your explicit correction — a `ctx.default_sandbox_policy is not None` assert is not a witness that it's enforced. Drove the real minimal-synthesis path end to end: a `ToolContext` with `router_state=None` forcing the branch, through `op_context_from_tool_context`, through the real `op_runtime.sandboxed_exec` handler, asserting the **emitted event's enforced** `network` value. The op requests nothing (bare `argv`) — before the fix this reads `False` (the op's own raw default), after: `True` (the floor, owner decision 2026-06-05).

Falsify-verified: stripped the fix → this specific test goes RED, all 8 others stay green. Restored, confirmed clean via `diff`, 9/9 green.

## Reachability measurement (your explicit ask)

Grepped every production `ToolContext(...)` construction site — 8 total:

- 7 reach tool execution and **all** populate `router_state.op_context_factory`, either directly (`RouterCallerState(op_context_factory=...)`, `plugin.py:133`) or via `build_resource_caller_state(host)` — the shared factory `router_loop.py` (×3), `pipeline_executor_driver.py`, `slash/plugin.py`, and `pipe.py`'s `_resolve_router_state` (itself a prior bug fix for exactly this gap — see its own comment: "NOT the hardcoded router_state=None gap") all use.
- The 8th (`capability_visibility.py`'s `catalog_entries`) never calls `op_context_from_tool_context` at all — it only enumerates tool **schemas** for the LLM catalog, never executes.

**Conclusion: the minimal-synthesis path is not currently reached in production.** This closes a real inconsistency (a path that computes sandbox policy differently from every other path in the codebase) and guards against a future caller hitting it — not a live security gap today.

## Test plan

- [x] `pytest tests/test_sandbox_model_completion_1339.py` — 9 passed.
- [x] Falsify-verification above, `exec.py` restored and confirmed clean (`diff` against backup).
- [x] `ruff check src/reyn/tools/exec.py tests/test_sandbox_model_completion_1339.py` — clean.
- [x] `python scripts/test_tier_audit.py --strict tests/test_sandbox_model_completion_1339.py` — 9/9 OK, 0 Tier-4.
- [x] `python scripts/verify_module_docstrings.py src/reyn/tools/exec.py` — OK.
- [x] `python scripts/mypy_ratchet.py` — OK, 212 findings, all baselined.
- [x] Production reachability measured directly (above), not assumed from the "narrow callers" comment.
