### PR TITLE
docs(#3872): six-questions ③ asks to name the RED line, not imagine a dead mechanism

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,10 +138,20 @@ Ask each test in the diff:
 2. **Is it the implementation, transcribed?** If the same expression appears on
    both sides, it can only fail when someone deliberately edits that line — and
    they will edit both. (#3872: `art = "\n".join(covered)` asserted back.)
-3. **Would it stay green with the mechanism dead?** Assert a value a dead
-   mechanism cannot produce. "Was handed X" is not a witness for "used X"
-   (#3859), and #3850 landed a field that was required, populated, tested, and
-   read by nobody.
+3. **Can you name the production `file:line` that turns this test RED — and
+   have you actually watched it turn red?** Not "a value a dead mechanism
+   cannot produce" in the abstract: a specific line, struck out or inverted,
+   with the RED it produced recorded in the PR body. Asking "would it stay
+   green with the mechanism dead?" invites constructing a dead mechanism
+   *inside the test* to answer it — a hand-written stub that subclasses the
+   production class and breaks one branch, then asserts the stub behaves as
+   written. That stub is not the production line; it never runs the
+   production code at all, so it stays green forever regardless of what
+   happens to the real thing (`#3902`'s `_NoFoldEventLog`, `#3916`'s
+   `_PreNineOhOneAgentLayer` — see `testing.md` § "The strip-falsify
+   mimicry" for why this recurs even from authors who correctly avoided a
+   mock). "Was handed X" is not a witness for "used X" (#3859), and #3850
+   landed a field that was required, populated, tested, and read by nobody.
 4. **Would it stay green having never run?** skip / collection error / zero
    collected all wear green's colour. Name what a missing optional dependency
    silently skips — CI has no `effects` extra, so #3796's file skips whole and
@@ -164,7 +174,7 @@ So each question has a blocking answer, not just an answer:
 |---|---|
 | 1 | **none** — including a third party's, a past bug's, and reyn's own trivia |
 | 2 | yes — the same expression is on both sides |
-| 3 | yes — it stays green with the mechanism removed, unless it names the reject-side test that proves the mechanism can fail |
+| 3 | it cannot name an observed production RED — a stub's own scripted behavior is not one — unless it names the reject-side test that proves the mechanism can fail |
 | 4 | it would be green having never run, **and the PR does not say so** |
 | 5 | **anything outside the test bounds it** — a thread, a timer, the caller's pace |
 | 6 | the declared Tier is not the one question 1 named |

--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -555,6 +555,51 @@ asserts on the resolved instance (`loop.router_model`, …) rather than raw
 constructor kwargs. It is the seam analogue of the rule above: adapt to the
 contract, don't bypass it.
 
+### The strip-falsify mimicry
+
+Two independent sessions, one hour apart, wrote the same shape (`#3902`'s
+`_NoFoldEventLog`, `#3916`'s `_PreNineOhOneAgentLayer`):
+
+1. Subclass the production class; override the method under test with a
+   hand-written body that breaks the one branch being checked.
+2. Assert the subclass behaves the way it was just written to behave.
+3. Call it a strip-falsify — a proof the mechanism is load-bearing.
+
+It proves nothing: the production method never runs. Deleting the real
+mechanism entirely leaves this test exactly as green as it started, because
+the test was never exercising the real thing — it was exercising a stand-in
+whose behavior the test's own author dictated one line above the assert.
+Both authors even wrote the disclaimer the [Mock vs Fake](#mock-vs-fake)
+section asks for — `#3902`: *"not a mock of EventLog, a genuine (if
+deliberately broken) instance"*; `#3916`: *"not a mock, a genuine instance
+sharing every other method"* — and both are correct: neither is a mock.
+**That's exactly why this recurs.** The Fake ban's own reason (a mock's
+signature can drift silently from the real API) doesn't apply to a real
+subclass with one overridden method, so avoiding a mock reads as clearing
+the bar. It doesn't — the bar these tests miss is different: does the test
+ever run the production code it claims to falsify? A genuine instance that
+never calls the real method under test fails that bar exactly like a mock
+does, for an unrelated reason a mock's own ban never named.
+
+**Why this is the natural landing spot for question ③ above.** The old
+phrasing — "would it stay green with the mechanism dead?" — asks you to
+imagine a dead mechanism, which you can always construct *inside the test
+itself*. Once you've built one there, the test can assert against it
+forever without ever touching the real code path. The rephrased question —
+name the production `file:line` and show the RED you actually watched it
+produce — cannot be answered by a stub, because a stub is not a production
+line. The honest answer to the new question has nowhere to live but the PR
+body (a file:line plus an observed RED is not a docstring assertion), which
+is also where `#3910`'s own writeup already put it — the fix here is making
+that the question's natural landing spot, not the exception the previous
+phrasing needed hunting down.
+
+**The alternative**: strip the real mechanism (comment it out, invert the
+real condition, delete the real branch), run the test, watch it go RED,
+restore the mechanism, and record the file:line plus what you saw in the
+PR body. That's the only thing that actually witnesses the mechanism is
+load-bearing — no construction inside the test can substitute for it.
+
 ### When a Fake is justified — and what it requires
 
 Everything above states when a Fake is FORBIDDEN (the real collaborator is


### PR DESCRIPTION
**[docs-maintainer]** — #3917(lead-coder依頼、#3916をblockしているため優先)。CLAUDE.md六問③の問い自体の書き換え+testing.mdへの独立節追加、同一PR。part of #3872.

## The anti-pattern (two independent sessions, one hour apart)

`#3902`'s `_NoFoldEventLog` and `#3916`'s `_PreNineOhOneAgentLayer`: subclass
the production class, override the branch under test with a hand-written
stub, assert the stub behaves as written, call it a strip-falsify. The
production method never runs — deleting it leaves the test exactly as
green. Both authors wrote the Mock-vs-Fake disclaimer correctly (`#3902`:
"not a mock of EventLog, a genuine (if deliberately broken) instance";
`#3916`: "not a mock, a genuine instance sharing every other method") and
were still wrong, because the mock ban's own reason (signature drift)
doesn't cover this failure mode.

## The fix: change the question, not add a prohibition

architect's reframe, adopted over lead-coder's own first draft
(name-and-forbid-the-shape, explicitly downgraded to "a hole, not a class
fix" per the owner's standing instruction): the old ③ ("would it stay green
with the mechanism dead?") invites imagining a dead mechanism — which you
can always construct *inside the test itself* to answer the question. The
new ③ asks something a stub cannot answer: **name the production
`file:line` that turns this test RED, and show the RED you actually
watched it produce.** A stub is not a production line, so the honest
answer has nowhere to live but the PR body — which is also where `#3910`'s
own writeup already put it.

## Changes

- **CLAUDE.md**: rewrites item ③'s question and its blocking-table cell.
  The `#3914` accept-side exception is preserved (adapted phrasing, same
  two-part condition: names itself accept-side AND names its reject-side
  counterpart).
- **testing.md**: new `### The strip-falsify mimicry` section (prose, not
  a table copy — verified `grep -c "blocks when the answer is"` →
  `CLAUDE.md` 1, `testing.md` 0, same check as `#3914`) explaining why
  this recurs even from authors who correctly avoided a mock, plus the
  real alternative (strip the real mechanism, watch the RED, restore it,
  record file:line + what you saw).
- **No new gate** — per `#3917`'s decision, distinguishing "assert targets
  a collaborator" (legitimate observation instrument) from "assert targets
  the stub's own scripted behavior" (this anti-pattern) is a semantic
  judgment call, not mechanizable.

## Verification note

`#3902`'s exact docstring quote verified against `git show` of the
now-deleted test (pre-`#3910` commit). `#3916`'s stub is on an
open/blocking PR — I could not locate it in `gh pr diff 3916`'s current
output (4605 lines, no `_PreNineOhOneAgentLayer` hits), so that quote is
cited from lead-coder's own `#3917` issue body (a primary record they
authored directly, not a third-hand paraphrase) rather than independently
re-verified against the PR diff.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0, no new WARNING/Aborted lines
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` → 335 passed
- [x] Independently re-verified `testing.md` still has 0 copies of the blocking table after this edit
- [x] Branch created off verified-current `origin/main`; remote head verified via `git ls-remote origin refs/heads/docs/six-questions-q3-name-the-red-line`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
