### PR TITLE
docs(#3919): consumer sweep's population is src/tests/scripts, not just src/tests

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -553,7 +553,14 @@ source tree, not `reyn`'s — rather than widening the pattern.
 searched>`" — an unscoped N reads as total. Before trusting a 0 or a small
 N, name every location the defect COULD live (adjacent files in the same
 subsystem, a dependency's own source, a sibling directory) and confirm each
-was actually searched, not just the one that felt likely.
+was actually searched, not just the one that felt likely. Concretely for a
+consumer sweep of `src/` construction sites: the population is `src/` /
+`tests/` / `scripts/`, not just the first two — `scripts/` runs CI-only
+probes that import `src/` without being called either "implementation" or
+"test," which is exactly why a sweep worded as "across src and tests" keeps
+skipping it (three independent same-night sessions, 2026-08-09, each
+scoped a sweep to src+tests, and each hit the same `scripts/` file in CI —
+the miss was never a bad regex, only ever the file-set).
 
 ## 18. A claim's subject can fail to hold up three different ways — existence, identity, and effect need different detection
 


### PR DESCRIPTION
**[docs-maintainer]** — #3919(lead-coder依頼)。doc 1行のみ、gate無し。part of #3872.

## Where I looked, and what I found

Searched `docs/` and `CLAUDE.md` for any place that already explains "consumer
sweep" as a technique — only one hit, a passing mention in a list of gate
types in `CLAUDE.md` (line 276), no explanatory section anywhere. Given no
dedicated home exists yet, the closest genuine fit is
`verification-hazards.md` § 17 "Scope, not just pattern — a grep's
directory/file-set decides the census as much as its regex does" — that
section's own pattern class *is* exactly this incident (a correct regex,
an incomplete file-set), with two existing same-day (2026-08-02) instances
already documented there in the same style.

## What's added

One sentence appended to that section's existing "Apply" paragraph: the
consumer-sweep population is `src/` / `tests/` / `scripts/`, not just the
first two — `scripts/` runs CI-only real-backend probes that import `src/`
without being called either "implementation" or "test," which is why a
sweep worded "across src and tests" keeps skipping it. Cites the concrete
incident: three independent same-night sessions (`#3915`, `#3916`, and
`#3913`'s own `tests/runtime`-scoped pathspec) each hit the identical
`scripts/*.py` file in CI.

## Placement decisions (both per lead-coder's own lean, endorsed)

- **No new gate** — all three misses were caught by CI on the very next
  run (a round-trip's worth of time, not a shipped defect); a gate would
  duplicate what CI already provides.
- **CLAUDE.md untouched** — its rules are Tier-1 hard rules, not scanning
  technique, and it already points readers to `verification-hazards.md`
  for exactly this class of hazard.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0, no new WARNING/Aborted lines
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` → 334 passed
- [x] Branch created off verified-current `origin/main`; remote head verified via `git ls-remote origin refs/heads/docs/consumer-sweep-population-scripts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
