### PR TITLE
docs(#3872): six-questions ③ asks who'd miss the test, not whether execution answers for you

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,20 +138,26 @@ Ask each test in the diff:
 2. **Is it the implementation, transcribed?** If the same expression appears on
    both sides, it can only fail when someone deliberately edits that line — and
    they will edit both. (#3872: `art = "\n".join(covered)` asserted back.)
-3. **Can you name the production `file:line` that turns this test RED — and
-   have you actually watched it turn red?** Not "a value a dead mechanism
-   cannot produce" in the abstract: a specific line, struck out or inverted,
-   with the RED it produced recorded in the PR body. Asking "would it stay
-   green with the mechanism dead?" invites constructing a dead mechanism
-   *inside the test* to answer it — a hand-written stub that subclasses the
-   production class and breaks one branch, then asserts the stub behaves as
-   written. That stub is not the production line; it never runs the
-   production code at all, so it stays green forever regardless of what
-   happens to the real thing (`#3902`'s `_NoFoldEventLog`, `#3916`'s
+3. **Who would miss this test if it were gone?** Not whether the assert
+   currently fires — whether execution can tell you that for free, and
+   review should not re-derive what a CI run already answers. Three
+   answers: *nobody* → delete. *A situation only this test itself
+   constructs* (production never builds that configuration) → delete.
+   *A production consumer, or another real mechanism* → keep. The middle
+   answer is the discriminator, and it catches more than one shape: a
+   hand-written stub that subclasses the production class and breaks one
+   branch (`#3902`'s `_NoFoldEventLog`, `#3916`'s
    `_PreNineOhOneAgentLayer` — see `testing.md` § "The strip-falsify
-   mimicry" for why this recurs even from authors who correctly avoided a
-   mock). "Was handed X" is not a witness for "used X" (#3859), and #3850
-   landed a field that was required, populated, tested, and read by nobody.
+   mimicry"), and — same answer, different shape — a manually assembled
+   collaborator list with one layer removed by hand
+   (`#3916`'s `test_falsification_removing_a_layer_regrants_a_denied_capability`:
+   `EffectivePermission([AgentLayer(decl)])`, a combination production
+   never constructs). Both fail this question on the same line, because
+   both are configurations only the test itself builds, not something a
+   real caller ever hands it. "Was handed X" is not a witness for "used X"
+   (#3859), and #3850 landed a field that was required, populated, tested,
+   and read by nobody — the honest answer to "who would miss it" was
+   already "nobody."
 4. **Would it stay green having never run?** skip / collection error / zero
    collected all wear green's colour. Name what a missing optional dependency
    silently skips — CI has no `effects` extra, so #3796's file skips whole and
@@ -174,7 +180,7 @@ So each question has a blocking answer, not just an answer:
 |---|---|
 | 1 | **none** — including a third party's, a past bug's, and reyn's own trivia |
 | 2 | yes — the same expression is on both sides |
-| 3 | it cannot name an observed production RED — a stub's own scripted behavior is not one — unless it names the reject-side test that proves the mechanism can fail |
+| 3 | **nobody**, or only a configuration this test itself constructed |
 | 4 | it would be green having never run, **and the PR does not say so** |
 | 5 | **anything outside the test bounds it** — a thread, a timer, the caller's pace |
 | 6 | the declared Tier is not the one question 1 named |
@@ -184,20 +190,17 @@ often correct (an optional extra), and what makes it a defect is a green nobody
 qualified. 5 has no such carve-out — "it is small today" is a measurement of
 today, and the runaway that started this was small until it wasn't.
 
-**3's exception, precisely.** An accept-side test (a false-positive control —
-"this shape must NOT trip the gate") is *supposed* to stay green with the
-mechanism removed; that's what makes it accept-side. But self-declaring that
-in a docstring is not sufficient on its own — a suite of nothing but
-accept-side tests would all pass this exception, all stay green, with the
-gate itself dead. The docstring must *name the reject-side test that proves
-the gate can fail* — self-declaration plus a pointer to its actual contrast,
-not self-declaration alone. One sentence carries both: "Accept-side: a
-mirrors-src directory must NOT trip the gate (the reject side is
-`test_…` below)." Don't reduce this to a fixed phrase ("accept-side / control")
-— naming *what* it contrasts against is what satisfies the pointer, and a
-boilerplate phrase with no name satisfies neither. The reject-side test does
-not have to live in the same file (a gate built across separate files, e.g.
-the `#3885` migration-diff-shape gate, still qualifies).
+**3 needs no accept-side exception.** An accept-side test ("this shape must
+NOT trip the gate") is not a special case of question 3 — it has its own
+job, catching over-firing, and its consumer is the gate's own users, who
+would be wrongly blocked without it. Asked "who would miss this test," an
+accept-side test answers the same way any other real test does: the
+operators the gate would have false-positived against. No carve-out is
+needed because question 3 was never the wrong question for it — question 3
+in its earlier phrasing ("would it stay green with the mechanism dead?")
+was the wrong question for it, since an accept-side test is *supposed* to
+stay green with the gate's deny-firing mechanism removed. Asking who'd miss
+it instead of whether it's green resolves this without a special case.
 
 **Reviewer's note, on the PR:** record the answers per test before merging. A
 lead-coder merge train refuses any PR touching `tests/` without one — the promise

--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -581,24 +581,31 @@ ever run the production code it claims to falsify? A genuine instance that
 never calls the real method under test fails that bar exactly like a mock
 does, for an unrelated reason a mock's own ban never named.
 
-**Why this is the natural landing spot for question ③ above.** The old
-phrasing — "would it stay green with the mechanism dead?" — asks you to
-imagine a dead mechanism, which you can always construct *inside the test
-itself*. Once you've built one there, the test can assert against it
-forever without ever touching the real code path. The rephrased question —
-name the production `file:line` and show the RED you actually watched it
-produce — cannot be answered by a stub, because a stub is not a production
-line. The honest answer to the new question has nowhere to live but the PR
-body (a file:line plus an observed RED is not a docstring assertion), which
-is also where `#3910`'s own writeup already put it — the fix here is making
-that the question's natural landing spot, not the exception the previous
-phrasing needed hunting down.
+**Why "would it stay green with the mechanism dead?" invited this.** That
+phrasing asks you to imagine a dead mechanism, and imagining one is
+something you can always do *inside the test itself* — build a stub, break
+one branch by hand, assert the stub does what you just wrote it to do. The
+question CLAUDE.md's six questions now asks instead — **who would miss
+this test if it were gone?** — cannot be answered by imagining anything: a
+stub or a hand-assembled collaborator list is a configuration only the
+test itself builds, so the honest answer to "who relies on this" is
+nobody. Owner's framing (2026-08-09): a test review should not ask
+questions execution already answers for free — "does this assert
+currently fire" is exactly that, which is what made the file:line/RED
+phrasing tried here first the wrong fix too: it still asked about
+*execution*, only moved the record of it from the test to the PR body.
+"Who would miss it" asks about *existence*, which review — not
+execution — is the only thing that can answer.
 
-**The alternative**: strip the real mechanism (comment it out, invert the
-real condition, delete the real branch), run the test, watch it go RED,
-restore the mechanism, and record the file:line plus what you saw in the
-PR body. That's the only thing that actually witnesses the mechanism is
-load-bearing — no construction inside the test can substitute for it.
+**The conclusion, once you can name the shape: delete the test.** A test
+whose only defensible witness is its own hand-built double is not a test
+of the mechanism it claims to falsify — it is a test of the double, and
+the double is not load-bearing to anyone. There is no version of this
+shape worth keeping "if only it ran the real strip" — a strip-falsify that
+actually exercises the mechanism does not need this shape at all (see
+[the prerequisite every tier shares](#the-prerequisite-every-tier-shares):
+a claim needs an anchor outside the test, and a stub the test built for
+itself is not one).
 
 ### When a Fake is justified — and what it requires
 


### PR DESCRIPTION
**[docs-maintainer]** — 🔴 URGENT — #3922(lead-coder依頼)。今夜私が書いた#3914/#3920を撤回・差し替え。#3916以降のPRが既に旧形式で書かれ始めているため優先対応。part of #3872.

## Owner's correction

> 「テストレビューは実行すればわかる観点は不要だよ。目的はテストであるべきか、テスト負債になるか、が重要」
> ("A test review doesn't need a question execution already answers for you. The point is whether it should be a test at all, whether it becomes debt.")

Both #3914 and #3920 asked "is this test EFFECTIVE" (does it fire, does it
stay green) instead of "should this test EXIST." lead-coder's own diagnosis,
relayed:

- **#3914** created an exemption for accept-side tests conditioned on
  self-declaration + naming a reject-side counterpart. Wrong premise: an
  accept-side test never needed an exemption from ③ — it has its own job
  (catching over-firing) and its own real consumer (the gate's users,
  wrongly blocked without it). The old ③ phrasing was simply the wrong
  question to ask of it, not a case needing a carve-out.
- **#3920** rephrased ③ to "name the production file:line and watch it
  turn RED" — still an execution question, just relocated the record to
  the PR body. It also **misses the actual target case**: `#3916`'s
  `test_falsification_removing_a_layer_regrants_a_denied_capability`
  hand-assembles `EffectivePermission([AgentLayer(decl)])` with a layer
  manually stripped — a combination production never constructs — and can
  honestly answer "yes, I watched it go red," passing #3920's own question
  while testing nothing production does.

## The fix

New ③: **"Who would miss this test if it were gone?"**

- *Nobody* → delete.
- *A configuration only this test itself constructs* (production never
  builds it) → delete.
- *A production consumer, or another real mechanism* → keep.

The middle answer is the discriminator, and it catches both target shapes
on the same line: a hand-written stub subclass (`#3902`, `#3916`'s
`_PreNineOhOneAgentLayer`) AND a hand-assembled collaborator list with a
layer removed (`#3916`'s `test_falsification_removing_a_layer_regrants_a_denied_capability`)
— both are configurations only the test itself builds, never something a
real caller hands it.

## Changes

- **CLAUDE.md**: item ③'s question text, its blocking-table cell, and the
  `#3914` exception paragraph are all replaced — no separate accept-side
  carve-out is needed (explained inline why).
- **testing.md**: "The strip-falsify mimicry" section is **kept** (the
  anti-pattern description and both real examples are still accurate) —
  only its conclusion changes, from "strip the mechanism, watch it go RED,
  record it" (still an execution-answers-this instruction) to "delete the
  test."

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0, no new WARNING/Aborted lines
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` → 336 passed
- [x] Verified `testing.md` still has 0 copies of the blocking table (unchanged from #3914/#3920's own verification)
- [x] Branch created off verified-current `origin/main`; remote head verified via `git ls-remote origin refs/heads/docs/six-questions-existence-not-execution`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
