### PR TITLE
fix(#3924): --grant-file-write comments falsely claimed read is scoped like write

### DIFF
--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -593,9 +593,13 @@ def _run(args: argparse.Namespace) -> None:
     perm_config = getattr(session_cfg.config, "permissions", {}) or {}
     # #187: --grant-file-write grants file.read/write at the resolver layer
     # (mirrors `reyn run` run.py:126 + the eval swe_bench path
-    # eval_benchmark.py:742). The grant is bounded by the sandbox write_paths ∩
-    # (env-backend repo zone), so the effective scope is the working tree, not
-    # global. setdefault preserves any explicit operator setting.
+    # eval_benchmark.py:742). write is bounded by the sandbox write_paths ∩
+    # (env-backend repo zone), so its effective scope is the working tree, not
+    # global. read is NOT bounded the same way: the resolve_sandbox_policy
+    # floor never sets read_paths, so SandboxLayer.FILE_READ resolves to ⊤
+    # (unconstrained) here — this grant's read reaches anywhere the process
+    # can read, not just the working tree (#3924). setdefault preserves any
+    # explicit operator setting.
     if getattr(args, "grant_file_write", False):
         perm_config.setdefault("file.read", "allow")
         perm_config.setdefault("file.write", "allow")

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -127,8 +127,12 @@ def _get_perm_resolver():
         # Copy so the #1401 grant setdefault below never mutates the shared config.
         perm_config = dict(getattr(config, "permissions", {}) or {})
         # #1401: --grant-file-write grants file.read/write at the resolver layer
-        # (mirrors `reyn chat`/run.py/eval). Bounded by the sandbox write_paths ∩
-        # the env-backend repo zone. setdefault preserves explicit operator config.
+        # (mirrors `reyn chat`/run.py/eval). write is bounded by the sandbox
+        # write_paths ∩ the env-backend repo zone. read is NOT bounded the same
+        # way: the resolve_sandbox_policy floor never sets read_paths, so
+        # SandboxLayer.FILE_READ resolves to ⊤ (unconstrained) here — this
+        # grant's read reaches anywhere the process can read, not just the
+        # repo zone (#3924). setdefault preserves explicit operator config.
         _ov = get_cli_scoped_overrides()
         if _ov.grant_file_write:
             perm_config.setdefault("file.read", "allow")


### PR DESCRIPTION
**[docs-maintainer]** — #3924(a)のみ(owner挙動判断待ちなしで進められる分)。lead-coder依頼。

## What

`--grant-file-write` の2箇所のコメントが、実際の挙動と食い違っていました:

> "The grant is bounded by the sandbox write_paths ∩ (env-backend repo
> zone), so the effective scope is the working tree, not global."

write は真。read は偽 — `resolve_sandbox_policy`のfloorは`read_paths`を設定しないため、
`SandboxLayer.FILE_READ`はこの経路で常に⊤(無制限)に解決します。この grant の read は
working tree 限定ではなく、プロセスが読めるどこでも読めます。`policy.py`のfloor keys
(network/write_paths/read_deny_paths、read_paths不在)と`SandboxLayer.allows()`の
FILE_READ分岐を直接読んで独立検証済み、lead-coderの#3924実測と一致。

コメントのみの修正 — 挙動は変えません。readを実際に狭めるかはowner判断で#3924が
明示的に保留(SWE-bench経由の`--grant-file-write`実利用がrepo外参照読み取りに
依存している可能性)。

## サイト差異の指摘

#3924は4箇所(chat.py, web/deps.py, pipe.py, registry_bootstrap.py)が同じ偽コメントを
持つとしていましたが、4箇所全て直接確認したところ:
- `chat.py:596-598` / `web/deps.py:130-131` → 該当コメント実在、本PRで修正
- `pipe.py`の`grant_file_write`ブロック(~line 630)→ スコープに関するコメント自体が
  存在しない
- `registry_bootstrap.py`の近傍コメント(~line 150)→ 別の話(fail-closedデフォルト、
  http.getブランケット付与しない)で、read境界について何も主張していない、内容も正確

この2箇所は「偽の主張」自体が存在しないため、修正不要と判断し触っていません。

## Test plan

- [x] `ruff check src/reyn/interfaces/cli/commands/chat.py src/reyn/interfaces/web/deps.py` → clean
- [x] `.venv/bin/python scripts/mypy_ratchet.py` → 212 findings, all baselined (no new)
- [x] `.venv/bin/python scripts/verify_module_docstrings.py <changed files>` → OK
- [x] Claim independently re-verified against `policy.py`'s floor + `SandboxLayer.allows()`, not transcribed from #3924
- [x] Branch rebased onto current `origin/main`; remote head verified via `git ls-remote origin refs/heads/fix/3924a-grant-file-write-read-comment-accuracy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
