### PR TITLE
feat(#3868): PR-2 mechanical collect_events conversion (68 files)

### DIFF
--- a/scripts/dogfood_1822_content_threat_verify.py
+++ b/scripts/dogfood_1822_content_threat_verify.py
@@ -123,20 +123,34 @@ _LEGIT_EXEC = [
 ]
 
 
-def _events_of(events: EventLog, kind: str) -> list:
-    return [e for e in events.all() if e.type == kind]
+def _collect(log: EventLog) -> list:
+    """#3868 PR-2: EventLog.all() is being removed (no longer a real
+    production API — see events.py's module docstring). Collect via a
+    subscriber instead, mirroring production's EventStore-as-subscriber
+    mechanism (the same pattern as tests/_support/events.py's
+    collect_events, not imported here — scripts/ cannot depend on
+    tests/_support, a test-only module). Call this immediately after
+    constructing *log*, before any action this script observes."""
+    collected: list = []
+    log.add_subscriber(collected.append)
+    return collected
+
+
+def _events_of(collected: list, kind: str) -> list:
+    return [e for e in collected if e.type == kind]
 
 
 async def _exec_blocks(cfg: ThreatScanConfig, argv: list[str]) -> tuple[bool, list]:
     """Call the REAL handle(); True if it raised PermissionError at the scan gate.
     Returns (blocked, exec_threat_blocked events)."""
     ev = EventLog()
+    ev_events = _collect(ev)
     ctx = _CtxShim(cfg, ev)
     try:
         await exec_handle(_OpShim(argv), ctx, "control_ir")
-        return False, _events_of(ev, "exec_threat_blocked")
+        return False, _events_of(ev_events, "exec_threat_blocked")
     except PermissionError:
-        return True, _events_of(ev, "exec_threat_blocked")
+        return True, _events_of(ev_events, "exec_threat_blocked")
 
 
 def _exec_scan_blocks(cfg: ThreatScanConfig, argv: list[str]):
@@ -154,8 +168,9 @@ async def _run() -> int:
     print("== 1. Class A tool-result SCAN (context) — attack neutralization ==")
     hits = 0
     for label, payload in _ATTACK_CONTEXT:
-        ev = EventLog(); RouterHostAdapter.scan_tool_result(_SeamShim(cfg, ev), payload)
-        m = _events_of(ev, "threat_scan_match"); ok = bool(m); hits += ok
+        ev = EventLog(); ev_events = _collect(ev)
+        RouterHostAdapter.scan_tool_result(_SeamShim(cfg, ev), payload)
+        m = _events_of(ev_events, "threat_scan_match"); ok = bool(m); hits += ok
         ids = ",".join(sorted({e.data.get("pattern_id") for e in m})) or "-"
         print(f"  [{'DETECT' if ok else 'MISS  '}] {label:20} → {ids}")
     print(f"  → context-scope attack detection: {hits}/{len(_ATTACK_CONTEXT)}\n")
@@ -170,9 +185,10 @@ async def _run() -> int:
     print("== 3. Class B agent-write BLOCK (strict) — poisoned writes ==")
     blocked = 0; strict_corpus = _ATTACK_CONTEXT + _ATTACK_STRICT
     for label, payload in strict_corpus:
-        ev = EventLog(); hit = RouterHostAdapter.scan_for_block(_SeamShim(cfg, ev), payload, scope="strict")
+        ev = EventLog(); ev_events = _collect(ev)
+        hit = RouterHostAdapter.scan_for_block(_SeamShim(cfg, ev), payload, scope="strict")
         blk = hit is not None; blocked += blk
-        be = _events_of(ev, "threat_block")
+        be = _events_of(ev_events, "threat_block")
         print(f"  [{'BLOCK' if blk else 'pass ':5}] {label:20} "
               f"→ {('event=' + be[0].data.get('pattern_id')) if be else '-'}")
     print(f"  → write-block coverage: {blocked}/{len(strict_corpus)}\n")
@@ -190,9 +206,11 @@ async def _run() -> int:
     print("== 5. FALSE-POSITIVE rate (realistic legit corpora) ==")
     fp_scan = fp_block = 0
     for payload in _LEGIT:
-        ev = EventLog(); RouterHostAdapter.scan_tool_result(_SeamShim(cfg, ev), payload)
-        sm = _events_of(ev, "threat_scan_match")
-        ev2 = EventLog(); bh = RouterHostAdapter.scan_for_block(_SeamShim(cfg, ev2), payload, scope="strict")
+        ev = EventLog(); ev_events = _collect(ev)
+        RouterHostAdapter.scan_tool_result(_SeamShim(cfg, ev), payload)
+        sm = _events_of(ev_events, "threat_scan_match")
+        ev2 = EventLog()
+        bh = RouterHostAdapter.scan_for_block(_SeamShim(cfg, ev2), payload, scope="strict")
         if sm:
             fp_scan += 1
             print(f"  [scan-FP ] {','.join(sorted({e.data.get('pattern_id') for e in sm})):22} ← {payload[:54]!r}")

--- a/scripts/spike_preflight.py
+++ b/scripts/spike_preflight.py
@@ -347,6 +347,17 @@ async def _check4_events_log() -> None:
             captured_events.append({"type": ev.type, "data": ev.data})
 
         ev_log = EventLog(subscribers=[_capture])
+        # #3868 PR-2: EventLog.all() is being removed (a full-history read is
+        # no longer a real production API — see events.py's module
+        # docstring). Collect via a second subscriber instead, mirroring the
+        # real EventStore-as-subscriber mechanism, so real Event objects
+        # (not the plain dicts _capture keeps) are available for the
+        # EventStore round-trip check below. Added BEFORE any emit() this
+        # script cares about, same requirement as tests/_support/events.py's
+        # collect_events (not duplicated here — scripts/ cannot import
+        # tests/_support, a test-only module).
+        raw_events: list = []
+        ev_log.add_subscriber(raw_events.append)
 
         # Emit the same event the kernel emits on each LLM call
         ev_log.emit("llm_called", phase="check", model="gemini-2.5-flash")
@@ -371,7 +382,7 @@ async def _check4_events_log() -> None:
         from reyn.core.events.event_store import EventStore
         tmp_dir = Path(tempfile.mkdtemp(prefix="spike_preflight_events_"))
         store = EventStore(tmp_dir)
-        for ev_raw in ev_log.all():
+        for ev_raw in raw_events:
             store.write(ev_raw)
 
         read_back = list(store.iter_all())

--- a/tests/_support/events.py
+++ b/tests/_support/events.py
@@ -1,0 +1,46 @@
+"""``collect_events`` — the test-side mirror of production's real subscriber
+mechanism, for #3868 PR-2/PR-3.
+
+architect's design (#3868 comment 5229065773): PR-3 deletes ``EventLog._events``
+/ ``all()`` / ``to_json()`` entirely — the derived ``ingested`` state (PR-1)
+means the OS itself never needs a full-history read again. But ~230 test call
+sites still read ``.all()``/``.to_json()`` to assert on what happened during a
+test run. A "retain history only during tests" flag was explicitly REJECTED:
+it would make tests exercise a code path production never runs, so a green
+test would no longer witness production behavior (#3037's dead-permission-gate
+shape, generalized).
+
+The fix instead: production ALREADY has the real mechanism for "collect
+everything that happens" — ``EventStore`` is wired as an ``EventLog``
+subscriber (``session.py``), so every emitted ``Event`` reaches it via the
+SAME ``add_subscriber``/``emit`` path every other subscriber uses. Tests use
+that exact mechanism instead of a special read-back API: a plain list,
+appended to by a subscriber function, is functionally identical to what
+``EventStore`` does, minus the disk write.
+
+Call :func:`collect_events` ONCE, right after the ``EventLog`` (or
+``EventLog``-holding object) a test will emit into is constructed — BEFORE
+any ``emit()`` call the test wants to observe. The returned list is LIVE: it
+keeps growing as the log emits, so a test may reference it repeatedly (a
+polling loop like ``lambda: any(e.type == "x" for e in collected)`` works
+unchanged) — it is not a one-shot snapshot the way ``.all()`` was. Emits that
+happened BEFORE :func:`collect_events` was called are NOT retroactively
+captured (a subscriber only sees what is emitted after it is added) — this is
+the one behavior difference from ``.all()``, and it is why the call must move
+to right after construction, not stay at the assertion site.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def collect_events(log: Any) -> list[Any]:
+    """Return a list that live-collects every :class:`Event` *log* emits from
+    this call onward, via a real ``add_subscriber`` — the same mechanism
+    production's ``EventStore`` uses, not a read-back of history.
+
+    Call this immediately after constructing *log* (or as soon as a test
+    holds a reference to it), before any ``emit()`` the test cares about."""
+    collected: list[Any] = []
+    log.add_subscriber(collected.append)
+    return collected

--- a/tests/core/test_3868_collect_events_helper.py
+++ b/tests/core/test_3868_collect_events_helper.py
@@ -1,0 +1,67 @@
+"""Tier 2: #3868 PR-2 — the ``collect_events`` test helper.
+
+Real ``EventLog`` throughout (no mocks) — the helper is a thin wrapper over
+``EventLog.add_subscriber``, so faking it would test nothing real.
+"""
+from __future__ import annotations
+
+from reyn.core.events.events import EventLog
+from tests._support.events import collect_events
+
+
+def test_collect_events_captures_emits_after_the_call() -> None:
+    """Tier 2: an event emitted AFTER collect_events() is called appears in
+    the returned list."""
+    log = EventLog()
+    collected = collect_events(log)
+    log.emit("tool_executed", op="read_file", path="/tmp/x")
+    assert [e.type for e in collected] == ["tool_executed"]
+
+
+def test_collect_events_does_not_retroactively_capture_prior_emits() -> None:
+    """Tier 2: the one real behavior difference from ``.all()`` — a
+    subscriber only sees what is emitted AFTER it is added, so an emit
+    BEFORE collect_events() is called is not retroactively captured. This
+    is why the call must move to right after construction, not stay at the
+    assertion site (see module docstring's own note on this)."""
+    log = EventLog()
+    log.emit("llm_request", model="x")
+    collected = collect_events(log)
+    assert collected == []
+
+
+def test_collect_events_list_is_live_across_repeated_reference() -> None:
+    """Tier 2: the returned list keeps growing as the log emits — a polling
+    pattern (``any(... for e in collected)`` called repeatedly, matching the
+    real-world wait-until-condition shape many existing tests use) sees each
+    new emit without calling collect_events() again."""
+    log = EventLog()
+    collected = collect_events(log)
+    assert not any(e.type == "config_reloaded" for e in collected)
+    log.emit("config_reloaded", source="test")
+    assert any(e.type == "config_reloaded" for e in collected)
+
+
+def test_collect_events_captures_multiple_emits_in_order() -> None:
+    """Tier 2: multiple emits are collected in emission order — matching
+    ``.all()``'s own ordering guarantee, so a mechanical replacement
+    preserves any order-dependent assertion."""
+    log = EventLog()
+    collected = collect_events(log)
+    log.emit("a")
+    log.emit("b")
+    log.emit("c")
+    assert [e.type for e in collected] == ["a", "b", "c"]
+
+
+def test_collect_events_uses_the_real_subscriber_mechanism_not_a_readback() -> None:
+    """Tier 2: strip-falsify — removing the ``add_subscriber`` call inside
+    ``collect_events`` (simulated here by using a real EventLog whose
+    subscriber list is never populated) makes this fail the same way it
+    would if ``collect_events`` degraded to a no-op stub. Verifies the
+    helper is genuinely wired to production's real subscriber path
+    (``EventLog.add_subscriber``/``emit``'s ``for sub in self._subscribers``
+    loop), not a separately-maintained read-back of ``_events``."""
+    log = EventLog()
+    collected = collect_events(log)
+    assert log.subscribers == [collected.append]

--- a/tests/observability/test_otel_exporter.py
+++ b/tests/observability/test_otel_exporter.py
@@ -39,6 +39,7 @@ from reyn.observability.otel_exporter import (
     reset_otel_exporter_singleton,
 )
 from reyn.schemas.models import Event
+from tests._support.events import collect_events
 
 # The OTEL SDK is an OPT-IN dependency (reyn[observability]). CI installs the
 # extra so these tests run with real in-memory OTLP capture; a dev/env without
@@ -194,6 +195,7 @@ def test_sr5_fail_open_export_error_does_not_break_run(tmp_path: Path) -> None:
         otel_logger=None,
     )
     log = EventLog(subscribers=[store, exporter])
+    collected = collect_events(log)
 
     # Emitting through the EventLog must NOT raise even though every span start
     # raises inside the exporter (fail-open swallow).
@@ -206,7 +208,7 @@ def test_sr5_fail_open_export_error_does_not_break_run(tmp_path: Path) -> None:
     for e in _full_run():
         assert e.type in written
     # in-memory EventLog record is complete too
-    assert [ev.type for ev in log.all()] == [e.type for e in _full_run()]
+    assert [ev.type for ev in collected] == [e.type for e in _full_run()]
 
 
 # ── 1b. SR4 recovery-independence gate (inverted truncate-falsify) ────────────

--- a/tests/scaffold/test_family3_hook_event_bundle_byte_identical.py
+++ b/tests/scaffold/test_family3_hook_event_bundle_byte_identical.py
@@ -77,6 +77,7 @@ from reyn.runtime.hot_reload import HotReloader, get_active_hot_reloader
 from reyn.runtime.session import Session, _HookEventBundle
 from reyn.runtime.session_params import ReactivityConfig
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 _TIMEOUT = 2.0  # bounds every await so a broken wiring fails RED, never hangs
 
@@ -233,6 +234,7 @@ class TestFamily3HookEventBundleByteIdentical:
         ``emit_event``; that event lands in ``session._audit_events``, observed
         via the EventLog's public ``all()`` read."""
         s = _make_session(tmp_path)
+        collected = collect_events(s._audit_events)
         # Attach ONE never-drained subscriber, then overflow it: HookBus's
         # default subscriber queue is bounded (128), so >128 undrained
         # publishes guarantees at least one drop.
@@ -240,7 +242,7 @@ class TestFamily3HookEventBundleByteIdentical:
         try:
             for i in range(200):
                 s._hook_bus.publish(HookEvent(kind="turn_end", payload={"i": i}))
-            types = [e.type for e in s._audit_events.all()]
+            types = [e.type for e in collected]
             assert "bus_subscriber_dropped" in types
         finally:
             _sub.close()
@@ -255,9 +257,10 @@ class TestFamily3HookEventBundleByteIdentical:
         its ``events`` sink, which lands in ``session._audit_events`` (EventLog
         ``all()``) iff the sink IS that EventLog."""
         s = _make_session(tmp_path)
-        before = len(s._audit_events.all())
+        collected = collect_events(s._audit_events)
+        before = len(collected)
         await s._hot_reloader.apply_all(exclude=frozenset({"cron"}))
-        after = [e.type for e in s._audit_events.all()]
+        after = [e.type for e in collected]
         assert len(after) > before
         assert "config_reloaded" in after
 

--- a/tests/test_2073_s1_hot_reloader.py
+++ b/tests/test_2073_s1_hot_reloader.py
@@ -17,6 +17,7 @@ import pytest
 from reyn.config.loader import load_hot_reload_config
 from reyn.core.events.events import EventLog
 from reyn.runtime.hot_reload import HotReloader
+from tests._support.events import collect_events
 
 # ── SAFETY: the IN-set boundary (the OUT-set is never read) ──────────────────
 
@@ -54,10 +55,11 @@ async def test_nothing_pending_is_noop(tmp_path: Path) -> None:
     """Tier 2: apply_pending with no scheduled reload returns None + emits nothing
     (zero-overhead happy path)."""
     events = EventLog()
+    collected = collect_events(events)
     hr = HotReloader(project_root=tmp_path, events=events)
     assert hr.pending is False
     assert await hr.apply_pending() is None
-    assert [e.type for e in events.all()] == []
+    assert [e.type for e in collected] == []
 
 
 @pytest.mark.asyncio
@@ -65,6 +67,7 @@ async def test_request_then_apply_emits_event_and_clears(tmp_path: Path) -> None
     """Tier 2: request_reload schedules; apply_pending re-reads the IN-set, emits the
     config_reloaded P6 event (review-focus b), and clears pending."""
     events = EventLog()
+    collected = collect_events(events)
     hr = HotReloader(project_root=tmp_path, events=events)
     hr.request_reload(source="operator")
     assert hr.pending is True
@@ -73,7 +76,7 @@ async def test_request_then_apply_emits_event_and_clears(tmp_path: Path) -> None
     assert summary is not None and summary["source"] == "operator"
     assert hr.pending is False
     reloaded_sources = [
-        e.data["source"] for e in events.all() if e.type == "config_reloaded"
+        e.data["source"] for e in collected if e.type == "config_reloaded"
     ]
     assert reloaded_sources == ["operator"]  # exactly one reload, by the operator
 
@@ -83,6 +86,7 @@ async def test_idempotent_within_turn(tmp_path: Path) -> None:
     """Tier 2: multiple requests before a boundary collapse into ONE apply (1 turn =
     1 config snapshot); the last source wins."""
     events = EventLog()
+    collected = collect_events(events)
     hr = HotReloader(project_root=tmp_path, events=events)
     hr.request_reload(source="a")
     hr.request_reload(source="b")
@@ -91,7 +95,7 @@ async def test_idempotent_within_turn(tmp_path: Path) -> None:
     assert await hr.apply_pending() is None  # only one apply
     # collapsed into a single apply (one event), last source wins
     assert [
-        e.data["source"] for e in events.all() if e.type == "config_reloaded"
+        e.data["source"] for e in collected if e.type == "config_reloaded"
     ] == ["b"]
 
 

--- a/tests/test_2073_s2_reapply_seams.py
+++ b/tests/test_2073_s2_reapply_seams.py
@@ -19,6 +19,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.runtime.hot_reload import HotReloader, validate_in_set
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 # ── validate-before-apply (the structural IN-set check) ─────────────────────
 
@@ -60,6 +61,7 @@ async def test_bad_in_set_is_rejected_no_seam_runs(tmp_path: Path) -> None:
     # the loader's job-list merge but fails validate)
     (reyn_dir / "cron.yaml").write_text("cron:\n  jobs:\n    - name: j1\n", encoding="utf-8")
     events = EventLog()
+    collected = collect_events(events)
     hr = HotReloader(project_root=tmp_path, events=events)
     calls: list = []
 
@@ -73,7 +75,7 @@ async def test_bad_in_set_is_rejected_no_seam_runs(tmp_path: Path) -> None:
 
     assert summary["rejected"]                 # the reload was rejected
     assert calls == []                         # no seam ran (rollback)
-    assert [e.type for e in events.all() if e.type == "config_reloaded"] == []
+    assert [e.type for e in collected if e.type == "config_reloaded"] == []
 
 
 # ── the real reapply seams (real minimal Session) ──────────────────────────

--- a/tests/test_2597_p1_reconnect_resync_read.py
+++ b/tests/test_2597_p1_reconnect_resync_read.py
@@ -28,6 +28,7 @@ import pytest
 from reyn.core.events.events import EventLog
 from reyn.mcp.client import MCPError
 from reyn.mcp.connection_service import MCPConnectionService
+from tests._support.events import collect_events
 
 _SUPPORT_DIR = Path(__file__).parent / "_support"
 _SUBSCRIBABLE_SERVER = _SUPPORT_DIR / "mcp_subscribable_resources_server.py"
@@ -64,6 +65,7 @@ async def test_reconnect_emits_synthetic_resource_updated_for_missed_disconnect_
     be silently lost, since the fresh session never received any push for it)
     is surfaced via the synthetic resync signal, not dropped."""
     events = EventLog(subscribers=[])
+    collected = collect_events(events)
     service = MCPConnectionService(emit_sink=lambda et, **d: events.emit(et, **d))
     try:
         client = await service.get("srv", _stdio_cfg(_SUBSCRIBABLE_SERVER))
@@ -78,9 +80,9 @@ async def test_reconnect_emits_synthetic_resource_updated_for_missed_disconnect_
         await client.list_resources()
 
         await _wait_for(
-            lambda: any(e.type == "mcp_resource_updated" for e in events.all())
+            lambda: any(e.type == "mcp_resource_updated" for e in collected)
         )
-        matching = [e for e in events.all() if e.type == "mcp_resource_updated"]
+        matching = [e for e in collected if e.type == "mcp_resource_updated"]
         (only_event,) = matching  # exactly one — the synthetic resync, no real push occurred
         assert only_event.data.get("server") == "srv"
         assert only_event.data.get("uri") == _URI
@@ -102,6 +104,7 @@ async def test_first_open_emits_no_synthetic_update():
     ``mcp_resource_updated`` event of any kind (real or synthetic) may appear,
     since neither a push nor a reconnect happened."""
     events = EventLog(subscribers=[])
+    collected = collect_events(events)
     service = MCPConnectionService(emit_sink=lambda et, **d: events.emit(et, **d))
     try:
         client = await service.get("srv", _stdio_cfg(_SUBSCRIBABLE_SERVER))
@@ -111,7 +114,7 @@ async def test_first_open_emits_no_synthetic_update():
         await client.list_resources()
 
         await asyncio.sleep(0.1)  # give any (wrongly) synthetic emit a fair chance
-        matching = [e for e in events.all() if e.type == "mcp_resource_updated"]
+        matching = [e for e in collected if e.type == "mcp_resource_updated"]
         assert matching == [], (
             "the first open (and further calls against the still-live "
             "connection) must not emit any mcp_resource_updated — only a "
@@ -141,6 +144,7 @@ async def test_reconnect_resync_also_fires_hook_trigger_identically_to_real_push
 
     trigger = _RecordingTrigger()
     events = EventLog(subscribers=[])
+    collected = collect_events(events)
     service = MCPConnectionService(
         emit_sink=lambda et, **d: events.emit(et, **d),
         hook_trigger=trigger,
@@ -154,7 +158,7 @@ async def test_reconnect_resync_also_fires_hook_trigger_identically_to_real_push
         await client.list_resources()
 
         await _wait_for(
-            lambda: any(e.type == "mcp_resource_updated" for e in events.all())
+            lambda: any(e.type == "mcp_resource_updated" for e in collected)
         )
         await _wait_for(lambda: len(trigger.calls) >= 1)
 

--- a/tests/test_2597_prompts_consumption.py
+++ b/tests/test_2597_prompts_consumption.py
@@ -31,6 +31,7 @@ from reyn.mcp.pool import MCPClientPool
 from reyn.schemas.models import MCPGetPromptIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 from reyn.user_intervention import InterventionAnswer, InterventionBus, UserIntervention
+from tests._support.events import collect_events
 
 
 class _UnusedBus(InterventionBus):
@@ -274,6 +275,7 @@ def test_execute_gets_real_prompt_and_emits_events(tmp_path):
     from reyn.core.op_runtime.mcp_get_prompt import _execute
 
     events = EventLog()
+    collected = collect_events(events)
     op = MCPGetPromptIROp(kind="mcp_get_prompt", server="prompts-srv", name=_PROMPT_NAME, arguments={})
 
     async def _it():
@@ -286,7 +288,7 @@ def test_execute_gets_real_prompt_and_emits_events(tmp_path):
     assert result["status"] == "ok"
     assert result["messages"][0]["content"]["text"] == _PROMPT_TEXT
 
-    types_seen = [e.type for e in events.all()]
+    types_seen = [e.type for e in collected]
     assert "mcp_prompt_get" in types_seen
     assert "mcp_prompt_get_completed" in types_seen
     assert "mcp_prompt_get_failed" not in types_seen
@@ -298,6 +300,7 @@ def test_handle_denies_without_permissions_mcp_declared(tmp_path):
     does not declare the server under `mcp`, mirroring the `mcp_read_resource`
     op's own require_mcp gate exactly."""
     events = EventLog()
+    collected = collect_events(events)
     resolver = PermissionResolver(config_permissions={}, project_root=tmp_path, interactive=False)
     # No mcp=[...] on the decl — the AgentLayer grant is empty.
     ctx = _make_ctx(tmp_path, events, resolver=resolver, decl=PermissionDecl())
@@ -307,8 +310,8 @@ def test_handle_denies_without_permissions_mcp_declared(tmp_path):
     result = _run(execute_op(op, ctx))
 
     assert result["status"] == "denied"
-    denials = [e for e in events.all() if e.type == "permission_denied"]
-    assert denials, f"expected permission_denied event; got {[e.type for e in events.all()]}"
+    denials = [e for e in collected if e.type == "permission_denied"]
+    assert denials, f"expected permission_denied event; got {[e.type for e in collected]}"
     assert denials[0].data.get("kind") == "mcp_get_prompt"
 
 
@@ -317,6 +320,7 @@ def test_handle_allows_and_gets_when_permissions_mcp_granted(tmp_path):
     `mcp: allow`, so require_mcp passes and the REAL prompt is fetched end-to-end
     through execute_op (permission gate -> gateway -> real subprocess)."""
     events = EventLog()
+    collected = collect_events(events)
     resolver = PermissionResolver(
         config_permissions={"mcp": "allow"}, project_root=tmp_path, interactive=False,
     )
@@ -334,7 +338,7 @@ def test_handle_allows_and_gets_when_permissions_mcp_granted(tmp_path):
     result = _run(_it())
     assert result["status"] == "ok"
     assert result["messages"][0]["content"]["text"] == _PROMPT_TEXT
-    assert not [e for e in events.all() if e.type == "permission_denied"]
+    assert not [e for e in collected if e.type == "permission_denied"]
 
 
 def test_execute_reports_error_for_unconfigured_server(tmp_path):

--- a/tests/test_2597_s2a_mcp_resources_consumption.py
+++ b/tests/test_2597_s2a_mcp_resources_consumption.py
@@ -32,6 +32,7 @@ from reyn.mcp.pool import MCPClientPool
 from reyn.schemas.models import MCPReadResourceIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 from reyn.user_intervention import InterventionAnswer, InterventionBus, UserIntervention
+from tests._support.events import collect_events
 
 
 class _UnusedBus(InterventionBus):
@@ -293,6 +294,7 @@ def test_execute_reads_real_resource_and_emits_events(tmp_path):
     from reyn.core.op_runtime.mcp_read_resource import _execute
 
     events = EventLog()
+    collected = collect_events(events)
     op = MCPReadResourceIROp(kind="mcp_read_resource", server="resources-srv", uri=_RESOURCE_URI)
 
     async def _it():
@@ -305,7 +307,7 @@ def test_execute_reads_real_resource_and_emits_events(tmp_path):
     assert result["status"] == "ok"
     assert result["contents"][0]["text"] == _RESOURCE_TEXT
 
-    types_seen = [e.type for e in events.all()]
+    types_seen = [e.type for e in collected]
     assert "mcp_resource_read" in types_seen
     assert "mcp_resource_read_completed" in types_seen
     assert "mcp_resource_read_failed" not in types_seen
@@ -317,6 +319,7 @@ def test_handle_denies_without_permissions_mcp_declared(tmp_path):
     does not declare the server under `mcp`, mirroring the `mcp` (call_tool) op's
     own require_mcp gate exactly."""
     events = EventLog()
+    collected = collect_events(events)
     resolver = PermissionResolver(config_permissions={}, project_root=tmp_path, interactive=False)
     # No mcp=[...] on the decl — the AgentLayer grant is empty.
     ctx = _make_ctx(tmp_path, events, resolver=resolver, decl=PermissionDecl())
@@ -326,8 +329,8 @@ def test_handle_denies_without_permissions_mcp_declared(tmp_path):
     result = _run(execute_op(op, ctx))
 
     assert result["status"] == "denied"
-    denials = [e for e in events.all() if e.type == "permission_denied"]
-    assert denials, f"expected permission_denied event; got {[e.type for e in events.all()]}"
+    denials = [e for e in collected if e.type == "permission_denied"]
+    assert denials, f"expected permission_denied event; got {[e.type for e in collected]}"
     assert denials[0].data.get("kind") == "mcp_read_resource"
 
 
@@ -336,6 +339,7 @@ def test_handle_allows_and_reads_when_permissions_mcp_granted(tmp_path):
     `mcp: allow`, so require_mcp passes and the REAL resource is read end-to-end
     through execute_op (permission gate -> gateway -> real subprocess)."""
     events = EventLog()
+    collected = collect_events(events)
     resolver = PermissionResolver(
         config_permissions={"mcp": "allow"}, project_root=tmp_path, interactive=False,
     )
@@ -353,7 +357,7 @@ def test_handle_allows_and_reads_when_permissions_mcp_granted(tmp_path):
     result = _run(_it())
     assert result["status"] == "ok"
     assert result["contents"][0]["text"] == _RESOURCE_TEXT
-    assert not [e for e in events.all() if e.type == "permission_denied"]
+    assert not [e for e in collected if e.type == "permission_denied"]
 
 
 def test_execute_reports_error_for_unconfigured_server(tmp_path):

--- a/tests/test_2597_s2b_mcp_notifications_bridge.py
+++ b/tests/test_2597_s2b_mcp_notifications_bridge.py
@@ -28,6 +28,7 @@ from reyn.runtime.services import (
     RouterHostAdapter,
     SendToAgentInputs,
 )
+from tests._support.events import collect_events
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
 # bundled into two frozen, default-free dataclasses. These module-level
@@ -142,6 +143,7 @@ async def test_tool_list_changed_notification_emits_event_and_invalidates_cache(
     FP-0037), so the next ``ensure_mcp_tools_cached()`` re-probes instead of serving
     the now-possibly-stale cached list."""
     events = EventLog(subscribers=[])
+    collected = collect_events(events)
     adapter = _make_adapter(tmp_path=tmp_path, events=events)
 
     service = MCPConnectionService(
@@ -170,7 +172,7 @@ async def test_tool_list_changed_notification_emits_event_and_invalidates_cache(
         while adapter.mcp_tools_cache_snapshot is not None:
             await asyncio.sleep(0.02)
 
-        matching = [e for e in events.all() if e.type == "mcp_tool_list_changed"]
+        matching = [e for e in collected if e.type == "mcp_tool_list_changed"]
         (only_event,) = matching  # exactly one — the single real notification sent
         assert only_event.data.get("server") == "srv"
     finally:
@@ -196,6 +198,7 @@ async def test_progress_notification_not_double_emitted_by_bridge(tmp_path: Path
     ALSO emitting (mirroring ``op_runtime/mcp.py``'s ``_on_progress``), exactly ONE
     ``mcp_progress`` event lands per reported progress step, not two."""
     events = EventLog(subscribers=[])
+    collected = collect_events(events)
     service = MCPConnectionService(emit_sink=lambda et, **d: events.emit(et, **d))
     try:
         client = await service.get("srv", _CFG)
@@ -213,7 +216,7 @@ async def test_progress_notification_not_double_emitted_by_bridge(tmp_path: Path
         )
         assert result["isError"] is False
 
-        matching = [e for e in events.all() if e.type == "mcp_progress"]
+        matching = [e for e in collected if e.type == "mcp_progress"]
         first_step, second_step = matching  # exactly ONE event per progress step, not two
         assert first_step.data.get("server") == "srv"
         assert second_step.data.get("server") == "srv"
@@ -310,6 +313,7 @@ async def test_tools_cache_invalidate_fault_does_not_block_event_emit(tmp_path: 
     ``mcp_tool_list_changed`` event from still being emitted — the two side effects
     are independent and one failing must not silently swallow the other."""
     events = EventLog(subscribers=[])
+    collected = collect_events(events)
 
     def _boom_invalidate(server: str) -> None:
         raise RuntimeError("cache invalidation exploded")
@@ -323,6 +327,6 @@ async def test_tools_cache_invalidate_fault_does_not_block_event_emit(tmp_path: 
     notification = types.ServerNotification(types.ToolListChangedNotification())
     await handler.dispatch(notification)  # must not raise
 
-    matching = [e for e in events.all() if e.type == "mcp_tool_list_changed"]
+    matching = [e for e in collected if e.type == "mcp_tool_list_changed"]
     (only_event,) = matching  # exactly one — invalidate faulting must not swallow the emit
     assert only_event.data.get("server") == "srv"

--- a/tests/test_2597_s2b_resource_subscriptions.py
+++ b/tests/test_2597_s2b_resource_subscriptions.py
@@ -36,6 +36,7 @@ from reyn.mcp.gateway import MCPFault, MCPGateway
 from reyn.schemas.models import MCPSubscribeResourceIROp, MCPUnsubscribeResourceIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 from reyn.user_intervention import InterventionAnswer, InterventionBus, UserIntervention
+from tests._support.events import collect_events
 
 _SUPPORT_DIR = Path(__file__).parent / "_support"
 _SUBSCRIBABLE_SERVER = _SUPPORT_DIR / "mcp_subscribable_resources_server.py"
@@ -156,6 +157,7 @@ async def test_held_connection_subscribe_receives_real_push_as_event():
     chain (MCPClient.subscribe_resource -> ReynMCPMessageHandler.
     on_resource_updated -> emit_sink -> EventLog) end to end."""
     events = EventLog(subscribers=[])
+    collected = collect_events(events)
     service = MCPConnectionService(emit_sink=lambda et, **d: events.emit(et, **d))
     try:
         client = await service.get("srv", _stdio_cfg(_SUBSCRIBABLE_SERVER))
@@ -166,10 +168,10 @@ async def test_held_connection_subscribe_receives_real_push_as_event():
         assert result["isError"] is False
 
         await _wait_for(
-            lambda: any(e.type == "mcp_resource_updated" for e in events.all())
+            lambda: any(e.type == "mcp_resource_updated" for e in collected)
         )
 
-        matching = [e for e in events.all() if e.type == "mcp_resource_updated"]
+        matching = [e for e in collected if e.type == "mcp_resource_updated"]
         (only_event,) = matching  # exactly one push for one bump_and_notify call
         assert only_event.data.get("server") == "srv"
         assert only_event.data.get("uri") == _URI
@@ -202,6 +204,7 @@ async def test_subscription_survives_transport_death_reconnect():
     mcp.ClientSession (which otherwise has no memory of the old session's
     subscriptions)."""
     events = EventLog(subscribers=[])
+    collected = collect_events(events)
     service = MCPConnectionService(emit_sink=lambda et, **d: events.emit(et, **d))
     try:
         client = await service.get("srv", _stdio_cfg(_SUBSCRIBABLE_SERVER))
@@ -223,9 +226,9 @@ async def test_subscription_survives_transport_death_reconnect():
         assert result["isError"] is False
 
         await _wait_for(
-            lambda: any(e.type == "mcp_resource_updated" for e in events.all())
+            lambda: any(e.type == "mcp_resource_updated" for e in collected)
         )
-        matching = [e for e in events.all() if e.type == "mcp_resource_updated"]
+        matching = [e for e in collected if e.type == "mcp_resource_updated"]
         assert matching, (
             "a server-side push on the RECONNECTED session produced no "
             "mcp_resource_updated event — the subscription did not survive the "
@@ -283,6 +286,7 @@ async def test_subscribe_execute_real_subscribe_and_emits_events():
     from reyn.core.op_runtime.mcp_subscribe_resource import _execute
 
     events = EventLog()
+    collected = collect_events(events)
     service = MCPConnectionService()
     op = MCPSubscribeResourceIROp(kind="mcp_subscribe_resource", server="srv", uri=_URI)
 
@@ -294,7 +298,7 @@ async def test_subscribe_execute_real_subscribe_and_emits_events():
 
     assert result["status"] == "ok"
     assert result["uri"] == _URI
-    types_seen = [e.type for e in events.all()]
+    types_seen = [e.type for e in collected]
     assert "mcp_resource_subscribe" in types_seen
     assert "mcp_resource_subscribed" in types_seen
     assert "mcp_resource_subscribe_failed" not in types_seen
@@ -308,6 +312,7 @@ async def test_unsubscribe_execute_real_round_trip():
     from reyn.core.op_runtime.mcp_unsubscribe_resource import _execute as _unsub_execute
 
     events = EventLog()
+    collected = collect_events(events)
     service = MCPConnectionService()
     sub_op = MCPSubscribeResourceIROp(kind="mcp_subscribe_resource", server="srv", uri=_URI)
     unsub_op = MCPUnsubscribeResourceIROp(kind="mcp_unsubscribe_resource", server="srv", uri=_URI)
@@ -320,7 +325,7 @@ async def test_unsubscribe_execute_real_round_trip():
         await service.aclose()
 
     assert result["status"] == "ok"
-    types_seen = [e.type for e in events.all()]
+    types_seen = [e.type for e in collected]
     assert "mcp_resource_unsubscribed" in types_seen
 
 
@@ -329,6 +334,7 @@ def test_subscribe_handle_denies_without_permissions_mcp_declared():
     PermissionDecl does not declare the server under `mcp` (mirrors
     mcp_read_resource's own test)."""
     events = EventLog()
+    collected = collect_events(events)
     resolver = PermissionResolver(config_permissions={}, project_root=Path("."), interactive=False)
     ctx = _make_ctx(events, resolver=resolver, decl=PermissionDecl())
     ctx.intervention_bus = _UnusedBus()
@@ -337,7 +343,7 @@ def test_subscribe_handle_denies_without_permissions_mcp_declared():
     result = _run(execute_op(op, ctx))
 
     assert result["status"] == "denied"
-    denials = [e for e in events.all() if e.type == "permission_denied"]
+    denials = [e for e in collected if e.type == "permission_denied"]
     assert denials
     assert denials[0].data.get("kind") == "mcp_subscribe_resource"
 

--- a/tests/test_2608_h1_mcp_resource_updated_hook.py
+++ b/tests/test_2608_h1_mcp_resource_updated_hook.py
@@ -29,6 +29,7 @@ from reyn.mcp.connection_service import MCPConnectionService
 from reyn.runtime.session import Session
 from reyn.runtime.session_params import ReactivityConfig
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 _SUPPORT_DIR = Path(__file__).parent / "_support"
 _SUBSCRIBABLE_SERVER = _SUPPORT_DIR / "mcp_subscribable_resources_server.py"
@@ -117,6 +118,7 @@ async def test_real_mcp_push_fires_configured_hook_into_session_inbox(tmp_path):
         },
     ]
     session = _make_session(tmp_path, hooks_config=hooks_config)
+    collected = collect_events(session._audit_events)
     try:
         client = await session._mcp_connection_service.get("srv", _stdio_cfg(_SUBSCRIBABLE_SERVER))
         await client.subscribe_resource(_URI)
@@ -127,7 +129,7 @@ async def test_real_mcp_push_fires_configured_hook_into_session_inbox(tmp_path):
         # The EventLog side (②b, unchanged) still fires — confirms the receive-loop
         # actually processed the push before we assert on the NEW hook side.
         await _wait_for(
-            lambda: any(e.type == "mcp_resource_updated" for e in session._audit_events.all())
+            lambda: any(e.type == "mcp_resource_updated" for e in collected)
         )
 
         # #2608 H1: the hook side — the templated push landed in the (public) inbox.
@@ -149,6 +151,7 @@ async def test_no_configured_hook_leaves_hook_side_a_pure_noop(tmp_path):
     is the byte-identical-to-today behavior the H1 design requires when no such
     hook is configured for the session."""
     session = _make_session(tmp_path, hooks_config=None)
+    collected = collect_events(session._audit_events)
     try:
         client = await session._mcp_connection_service.get("srv", _stdio_cfg(_SUBSCRIBABLE_SERVER))
         await client.subscribe_resource(_URI)
@@ -157,7 +160,7 @@ async def test_no_configured_hook_leaves_hook_side_a_pure_noop(tmp_path):
         assert result["isError"] is False
 
         await _wait_for(
-            lambda: any(e.type == "mcp_resource_updated" for e in session._audit_events.all())
+            lambda: any(e.type == "mcp_resource_updated" for e in collected)
         )
         # Give the (no-op) hook dispatch a fair chance to have run before asserting
         # the negative — the drain task still runs, HookDispatcher.dispatch() is

--- a/tests/test_2608_hook_push_fired_event.py
+++ b/tests/test_2608_hook_push_fired_event.py
@@ -22,6 +22,7 @@ from reyn.core.events.events import EventLog
 from reyn.hooks.dispatcher import HookDispatcher
 from reyn.hooks.registry import HookRegistry
 from reyn.hooks.schema import HookDef, PushBlock
+from tests._support.events import collect_events
 
 
 class _Recorder:
@@ -50,13 +51,14 @@ async def test_template_push_wake_true_emits_hook_push_fired():
     """Tier 2: an E (wake=true) template_push fire emits `hook_push_fired` with
     hook_name/point/wake/target_session metadata — NO message body (secrets-safe)."""
     log = EventLog()
+    collected = collect_events(log)
     hook = HookDef(name="my-hook", on="turn_end",
                     template_push=PushBlock(message="secret payload text", wake=True))
     disp = _dispatcher([hook], log)
 
     await disp.dispatch("turn_end", {})
 
-    (fired_event,) = [e for e in log.all() if e.type == "hook_push_fired"]
+    (fired_event,) = [e for e in collected if e.type == "hook_push_fired"]
     data = fired_event.data
     assert data["hook_name"] == "my-hook"
     assert data["point"] == "turn_end"
@@ -70,13 +72,14 @@ async def test_template_push_wake_false_also_emits_hook_push_fired():
     """Tier 2: a C (wake=false) ride-along push ALSO fires the event — every push
     path (not just E) is now observable, closing the gap for BOTH."""
     log = EventLog()
+    collected = collect_events(log)
     hook = HookDef(name="ctx-hook", on="turn_start",
                     template_push=PushBlock(message="note", wake=False))
     disp = _dispatcher([hook], log)
 
     await disp.dispatch("turn_start", {})
 
-    (fired_event,) = [e for e in log.all() if e.type == "hook_push_fired"]
+    (fired_event,) = [e for e in collected if e.type == "hook_push_fired"]
     assert fired_event.data["wake"] is False
 
 
@@ -85,13 +88,14 @@ async def test_push_when_false_does_not_emit():
     """Tier 2: a conditional push that resolves to push_when=False never fires —
     no event either (mirrors: nothing was pushed, so nothing to report as fired)."""
     log = EventLog()
+    collected = collect_events(log)
     hook = HookDef(name="skipped", on="turn_end",
                     template_push=PushBlock(message="x", push_when="false"))
     disp = _dispatcher([hook], log)
 
     await disp.dispatch("turn_end", {})
 
-    assert [e for e in log.all() if e.type == "hook_push_fired"] == []
+    assert [e for e in collected if e.type == "hook_push_fired"] == []
 
 
 @pytest.mark.asyncio
@@ -115,6 +119,7 @@ async def test_shell_exec_hook_still_emits_hook_shell_executed_not_push_fired():
     that event is a PUSH-fire signal only, distinct from the pre-existing
     hook_shell_executed (run-side) signal."""
     log = EventLog()
+    collected = collect_events(log)
     hook = HookDef(name="shell-h", on="session_start", exec=("true",))
     disp = HookDispatcher(
         HookRegistry([hook]),
@@ -126,4 +131,4 @@ async def test_shell_exec_hook_still_emits_hook_shell_executed_not_push_fired():
 
     await disp.dispatch("session_start", {})
 
-    assert [e for e in log.all() if e.type == "hook_push_fired"] == []
+    assert [e for e in collected if e.type == "hook_push_fired"] == []

--- a/tests/test_2608_run_loop_pickup.py
+++ b/tests/test_2608_run_loop_pickup.py
@@ -40,6 +40,7 @@ from reyn.llm.pricing import TokenUsage
 from reyn.runtime.session import Session
 from reyn.runtime.session_params import ReactivityConfig
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 _EMPTY_USAGE = TokenUsage(prompt_tokens=5, completion_tokens=3)
 
@@ -113,6 +114,7 @@ async def test_dispatch_external_event_wakes_idle_run_loop_and_runs_hook_turn(
         },
     ]
     session = _make_session(tmp_path, hooks_config=hooks_config)
+    collected = collect_events(session._audit_events)
 
     run_task = asyncio.create_task(session.run())
     try:
@@ -120,7 +122,7 @@ async def test_dispatch_external_event_wakes_idle_run_loop_and_runs_hook_turn(
         await asyncio.sleep(0.1)
         assert session.inbox.empty()
         hook_turns_before = [
-            e for e in session._audit_events.all()
+            e for e in collected
             if e.type == "turn_started" and e.data.get("kind") == "hook"
         ]
         assert hook_turns_before == []
@@ -142,11 +144,11 @@ async def test_dispatch_external_event_wakes_idle_run_loop_and_runs_hook_turn(
         await _wait_for(
             lambda: any(
                 e.type == "turn_started" and e.data.get("kind") == "hook"
-                for e in session._audit_events.all()
+                for e in collected
             )
         )
         (hook_turn_started,) = [
-            e for e in session._audit_events.all()
+            e for e in collected
             if e.type == "turn_started" and e.data.get("kind") == "hook"
         ]
         assert hook_turn_started.data.get("kind") == "hook"
@@ -156,7 +158,7 @@ async def test_dispatch_external_event_wakes_idle_run_loop_and_runs_hook_turn(
         await _wait_for(
             lambda: any(
                 e.type == "turn_settled" and e.data.get("kind") == "hook"
-                for e in session._audit_events.all()
+                for e in collected
             )
         )
 

--- a/tests/test_2708_p31_spawn_bridge_present.py
+++ b/tests/test_2708_p31_spawn_bridge_present.py
@@ -42,6 +42,7 @@ from reyn.runtime.session import Session
 from reyn.runtime.session_api import run_pipeline_attached, start_pipeline_run
 from reyn.runtime.session_params import PresentationWiring
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 _MARKER = "REYN2708P31BRIDGEMARKER"
 
@@ -98,7 +99,7 @@ def _presentations(msgs: list) -> list:
 
 
 def _driver_sid_from(events) -> "str | None":
-    for e in events.all():
+    for e in events:
         if e.type == "pipeline_run_attached":
             return e.data.get("driver_sid")
     return None
@@ -116,6 +117,7 @@ async def test_attached_present_reaches_parent_by_construction_single_delivery(
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     reg = _agent_registry(tmp_path, state_log)
     caller = reg.get_or_load("worker")
+    collected = collect_events(caller.router_host.events)
 
     outcome = await run_pipeline_attached(
         reg,
@@ -130,7 +132,7 @@ async def test_attached_present_reaches_parent_by_construction_single_delivery(
     )
     assert outcome["status"] == "ok"
 
-    driver_sid = _driver_sid_from(caller.router_host.events)
+    driver_sid = _driver_sid_from(collected)
     assert driver_sid is not None
 
     # Parent surface: exactly one presentation, carrying the marker.
@@ -159,6 +161,7 @@ async def test_attached_present_audit_event_bridged_to_parent_log(
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     reg = _agent_registry(tmp_path, state_log)
     caller = reg.get_or_load("worker")
+    collected = collect_events(caller.router_host.events)
 
     await run_pipeline_attached(
         reg,
@@ -171,11 +174,11 @@ async def test_attached_present_audit_event_bridged_to_parent_log(
         tool="run_pipeline",
         caller_events=caller.router_host.events,
     )
-    driver_sid = _driver_sid_from(caller.router_host.events)
+    driver_sid = _driver_sid_from(collected)
     assert driver_sid is not None
 
     bridged = [
-        e for e in caller.router_host.events.all()
+        e for e in collected
         if e.type == "presented" and e.data.get("bridged_from")
     ]
     assert bridged, (
@@ -201,6 +204,7 @@ async def test_detached_present_not_bridged_to_caller(tmp_path: Path, monkeypatc
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     reg = _agent_registry(tmp_path, state_log)
     caller = reg.get_or_load("worker")
+    collected = collect_events(caller.router_host.events)
 
     rid = await start_pipeline_run(
         reg,
@@ -222,7 +226,7 @@ async def test_detached_present_not_bridged_to_caller(tmp_path: Path, monkeypatc
     assert read_result(run_dir) is not None, "detached pipeline run did not reach terminal"
 
     bridged = [
-        e for e in caller.router_host.events.all()
+        e for e in collected
         if e.type == "presented" and e.data.get("bridged_from")
     ]
     assert bridged == [], "a detached present was unexpectedly bridged to the caller log"

--- a/tests/test_2708_p32a_spawn_bridge_intervention.py
+++ b/tests/test_2708_p32a_spawn_bridge_intervention.py
@@ -45,6 +45,7 @@ from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session  # noqa: E402
 from reyn.runtime.session_api import run_pipeline_attached, start_pipeline_run  # noqa: E402
 from reyn.runtime.session_params import PresentationWiring
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 _QUESTION = "REYN2708P32A which branch?"
 _ANSWER = "REYN2708P32A-the-blue-branch"
@@ -105,8 +106,8 @@ def _interventions(msgs: list) -> list:
     return [m for m in msgs if getattr(m, "kind", None) == "intervention"]
 
 
-def _driver_sid_from(events) -> "str | None":
-    for e in events.all():
+def _driver_sid_from(collected) -> "str | None":
+    for e in collected:
         if e.type == "pipeline_run_attached":
             return e.data.get("driver_sid")
     return None
@@ -124,6 +125,7 @@ async def test_attached_ask_user_reaches_parent_operator_and_answer_flows_back(
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     reg = _agent_registry(tmp_path, state_log)
     caller = reg.get_or_load("worker")
+    caller_collected = collect_events(caller.router_host.events)
     # The live operator: register a listener on the parent under the chat channel the
     # bridge routes to (the same id repl.py binds via bind_focus_listeners).
     caller.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
@@ -150,10 +152,11 @@ async def test_attached_ask_user_reaches_parent_operator_and_answer_flows_back(
         await wait_until(lambda: bool(caller.interventions.list_active()), timeout=15.0)
         # Capture the driver session while it is still live (the persistent driver is
         # removed from the registry once the attached run completes).
-        driver_sid = _driver_sid_from(caller.router_host.events)
+        driver_sid = _driver_sid_from(caller_collected)
         assert driver_sid is not None
         driver = reg.get_session("worker", driver_sid)
         assert driver is not None
+        driver_collected = collect_events(driver.router_host.events)
         # The operator was prompted on the parent surface (an "intervention" announce on
         # the parent's own outbox — the same queue+kind a chat-native ask_user reaches).
         assert _interventions(_drain(caller.outbox)), (
@@ -174,7 +177,7 @@ async def test_attached_ask_user_reaches_parent_operator_and_answer_flows_back(
     # ``user_answered_intervention`` on the PARENT's log (dispatch ran on the parent), with
     # the real answer text, not the empty auto-refuse.
     answered = [
-        e for e in caller.router_host.events.all()
+        e for e in caller_collected
         if e.type == "user_answered_intervention"
     ]
     assert any(e.data.get("answer_text") == _ANSWER for e in answered), (
@@ -183,7 +186,7 @@ async def test_attached_ask_user_reaches_parent_operator_and_answer_flows_back(
     # And it flowed back INTO the driver's ask_user op (its P6 ``user_intervention_received``
     # carries the real answer, not the fabricated empty auto-refuse text).
     received = [
-        e for e in driver.router_host.events.all()
+        e for e in driver_collected
         if e.type == "user_intervention_received"
     ]
     assert received, "no user_intervention_received on the driver log (ask never resolved)"

--- a/tests/test_2761_pr2_hotreload_immediate_apply.py
+++ b/tests/test_2761_pr2_hotreload_immediate_apply.py
@@ -47,6 +47,7 @@ from reyn.runtime.session import Session
 from reyn.runtime.session_params import CapabilityScope
 from reyn.security.permissions.permissions import PermissionDecl
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -216,6 +217,7 @@ async def test_apply_now_rejects_malformed_in_set_atomically(tmp_path: Path) -> 
     (cfg / "skills.yaml").write_text("skills: not-a-mapping\n", encoding="utf-8")
     ran, make_seam = _seam_recorder()
     events = EventLog()
+    collected = collect_events(events)
     hr = HotReloader(project_root=tmp_path, events=events)
     hr.register_seam("skills", make_seam("skills"))
 
@@ -223,7 +225,7 @@ async def test_apply_now_rejects_malformed_in_set_atomically(tmp_path: Path) -> 
 
     assert "rejected" in summary
     assert ran == {}, "no seam may run when the IN-set is rejected"
-    assert any(e.type == "config_reload_rejected" for e in events.all())
+    assert any(e.type == "config_reload_rejected" for e in collected)
 
 
 @pytest.mark.asyncio
@@ -232,12 +234,13 @@ async def test_apply_now_emits_config_reloaded_with_source(tmp_path: Path) -> No
     carrying the install source (observability of a mid-turn config change)."""
     _ran, make_seam = _seam_recorder()
     events = EventLog()
+    collected = collect_events(events)
     hr = HotReloader(project_root=tmp_path, events=events)
     hr.register_seam("skills", make_seam("skills"))
 
     await hr.apply_now(source="skill_install")
 
-    sources = [e.data["source"] for e in events.all() if e.type == "config_reloaded"]
+    sources = [e.data["source"] for e in collected if e.type == "config_reloaded"]
     assert sources == ["skill_install"]
 
 

--- a/tests/test_2957_prb_elide_advisor_token_unification.py
+++ b/tests/test_2957_prb_elide_advisor_token_unification.py
@@ -47,6 +47,7 @@ from reyn.services.compaction.engine import (
     _IMAGE_FIXED_TOKEN_COST,
     estimate_tokens_for_any_turn,
 )
+from tests._support.events import collect_events
 
 _MODEL = "gpt-3.5-turbo"
 
@@ -330,6 +331,7 @@ def test_elide_total_advisor_and_reference_three_way_agree():
         ),
     ]
     buf, advisor, events = _make_pair(history, media_store=None)
+    collected = collect_events(events)
 
     wire = buf.build_history()
     assert wire[0]["content"] == [{"type": "text", "text": "look"}], (
@@ -338,7 +340,7 @@ def test_elide_total_advisor_and_reference_three_way_agree():
         "ChatMessage's content"
     )
 
-    elide_events = [e for e in events.all() if e.type == "elide_evaluated"]
+    elide_events = [e for e in collected if e.type == "elide_evaluated"]
     assert elide_events, (
         "build_history must emit its internal elide-threshold total as a "
         "public audit-event — without this, elide's own accounting is "

--- a/tests/test_3070_mcp_probe_error_surfaced.py
+++ b/tests/test_3070_mcp_probe_error_surfaced.py
@@ -50,6 +50,7 @@ from reyn.core.pipeline.parser import PipelineParseError, parse_pipeline_dsl
 from reyn.core.pipeline.schema import SchemaRegistry
 from reyn.mcp.client import MCPClient
 from reyn.schemas.models import MCPIROp
+from tests._support.events import collect_events
 
 _PREFLIGHT_SCHEMA = {"fields": {"status": {"type": "enum", "values": ["ok"]}}}
 
@@ -129,6 +130,7 @@ def test_mcp_completed_event_carries_the_real_error_text_on_isError() -> None:
 
     real_text = "Error calling tool 'list_metadata': No module named 'sqlite_vec'"
     events = EventLog()
+    collected = collect_events(events)
     ctx = OpContext(
         workspace=None,  # type: ignore[arg-type]
         events=events,
@@ -143,7 +145,7 @@ def test_mcp_completed_event_carries_the_real_error_text_on_isError() -> None:
     op = MCPIROp(kind="mcp", server="reyn_vector_store", tool="list_metadata", args={})
     asyncio.run(mcp_op_handler._execute(op, ctx))
 
-    completed = [e for e in events.all() if e.type == "mcp_completed"]
+    completed = [e for e in collected if e.type == "mcp_completed"]
     # exactly one `mcp_completed` event: this single-unpack IS the assertion
     # (raises ValueError if zero or more than one landed), not a length pin.
     (only,) = completed
@@ -160,6 +162,7 @@ def test_mcp_completed_event_carries_no_error_text_on_success() -> None:
     from reyn.security.permissions.permissions import PermissionDecl
 
     events = EventLog()
+    collected = collect_events(events)
     ctx = OpContext(
         workspace=None,  # type: ignore[arg-type]
         events=events,
@@ -183,7 +186,7 @@ def test_mcp_completed_event_carries_no_error_text_on_success() -> None:
     op = MCPIROp(kind="mcp", server="reyn_chunker", tool="chunk", args={})
     asyncio.run(mcp_op_handler._execute(op, ctx))
 
-    completed = [e for e in events.all() if e.type == "mcp_completed"]
+    completed = [e for e in collected if e.type == "mcp_completed"]
     (only,) = completed
     assert only.data["is_error"] is False
     assert only.data["error"] is None

--- a/tests/test_3377_run_loop_survives_turn_cancel.py
+++ b/tests/test_3377_run_loop_survives_turn_cancel.py
@@ -38,6 +38,7 @@ import pytest
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 AGENT = "cancel-survival-agent"
 
@@ -212,6 +213,7 @@ async def test_cancelling_the_session_still_stops_the_loop_and_records_it(
     """
     caplog.set_level(logging.WARNING, logger="reyn.runtime.session")
     session, state_log = _make_session(tmp_path)
+    collected = collect_events(session._audit_events)
     _started, release, seen = _install_hanging_first_turn(session)
     run_task = asyncio.create_task(session.run())
     try:
@@ -231,7 +233,7 @@ async def test_cancelling_the_session_still_stops_the_loop_and_records_it(
         assert session.halted_reason == "cancelled", (
             f"the loop ended without a halt record; got {session.halted_reason!r}"
         )
-        halted = [e for e in session._audit_events.all() if e.type == "session_halted"]
+        halted = [e for e in collected if e.type == "session_halted"]
         (halt_event,) = halted
         assert halt_event.data.get("reason") == "cancelled"
         assert any("cancelled" in m for m in _warnings(caplog))

--- a/tests/test_3475_probe_degradation_visibility_and_timeout_config.py
+++ b/tests/test_3475_probe_degradation_visibility_and_timeout_config.py
@@ -57,6 +57,7 @@ from reyn.config import SafetyConfig, TimeoutConfig
 from reyn.core.events.event_schema import AUDIT_EVENT_KINDS
 from reyn.core.events.state_log import StateLog
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 _REPO = Path(__file__).resolve().parents[1]
 _ROUTER_HOST_ADAPTER = _REPO / "src" / "reyn" / "runtime" / "services" / "router_host_adapter.py"
@@ -183,10 +184,11 @@ async def test_probe_timeout_emits_visible_degradation_event(tmp_path: Path):
         session, server = _make_probe_session(
             tmp_path, mcp_probe_seconds=0.05, probe_cb=_slow_probe,
         )
+        collected = collect_events(session.router_host.events)
         await _drive_first_turn(session)
 
         degradations = [
-            e for e in session.router_host.events.all()
+            e for e in collected
             if e.type == "mcp_tool_probe_degraded"
         ]
         assert len(degradations) >= 1, (
@@ -219,10 +221,11 @@ async def test_probe_exception_emits_visible_degradation_event(tmp_path: Path):
             tmp_path, mcp_probe_seconds=TimeoutConfig().mcp_probe_seconds,
             probe_cb=_broken_probe,
         )
+        collected = collect_events(session.router_host.events)
         await _drive_first_turn(session)
 
         degradations = [
-            e for e in session.router_host.events.all()
+            e for e in collected
             if e.type == "mcp_tool_probe_degraded"
         ]
         assert len(degradations) >= 1

--- a/tests/test_3794_p3_audit_event_identifier_rename.py
+++ b/tests/test_3794_p3_audit_event_identifier_rename.py
@@ -31,6 +31,7 @@ import re
 from pathlib import Path
 
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 EXCLUDED_DIR_NAMES = {".venv", "site", ".git", "__pycache__"}
@@ -88,9 +89,10 @@ def test_public_emit_seam_and_private_field_write_the_same_event_log(tmp_path) -
         agent_name="p3-witness",
         snapshot_path=tmp_path / "snapshot.json",
     )
-    before = len(session._audit_events.all())
+    collected = collect_events(session._audit_events)
+    before = len(collected)
     session.emit_audit_event("p3_witness_kind", marker="p3-rename-witness")
-    after = session._audit_events.all()
+    after = collected
     assert len(after) == before + 1
     assert after[-1].type == "p3_witness_kind"
     assert after[-1].data.get("marker") == "p3-rename-witness"

--- a/tests/test_action_embedding_index.py
+++ b/tests/test_action_embedding_index.py
@@ -35,6 +35,7 @@ from reyn.tools.action_index import (
     ActionEmbeddingIndex,
     compute_catalog_hash,
 )
+from tests._support.events import collect_events
 
 
 @pytest.fixture(autouse=True)
@@ -469,6 +470,7 @@ def test_build_redacts_secret_in_short_description_before_embed(
     provider-direct redaction bypass this Part A closes."""
     provider = _FakeEmbeddingProvider()
     ctx = _ctx_for(provider, monkeypatch)
+    collected = collect_events(ctx.events)
     idx = ActionEmbeddingIndex()
     secret_desc = 'api_key = "abcdefghijklmnopqrstuvwxyz123456"'
     _run(idx.build(
@@ -484,4 +486,4 @@ def test_build_redacts_secret_in_short_description_before_embed(
     assert "REDACTED" in embedded_text
     # The seam firing is observable (P6 audit-event trace) on the ctx used
     # for the build.
-    assert any(e.type == "embed_secret_redacted" for e in ctx.events.all())
+    assert any(e.type == "embed_secret_redacted" for e in collected)

--- a/tests/test_budget_gateway_invariants.py
+++ b/tests/test_budget_gateway_invariants.py
@@ -5,7 +5,7 @@ Policy compliance (`docs/deep-dives/contributing/testing.md`):
 - No private-state assertions. Observation flows through:
     - gateway.total_usage / gateway.total_cost_usd (public properties)
     - gateway.router_cap (public property)
-    - events.all() (EventLog public read accessor)
+    - collect_events(events) (a real subscriber-collected list — tests/_support/events.py)
     - RouterCapExceeded exception attributes (public)
 - Each test docstring's first line starts with `Tier 2: ...`.
 """
@@ -19,6 +19,7 @@ from reyn.llm.pricing import TokenUsage
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
 from reyn.runtime.errors import RouterCapExceeded
 from reyn.runtime.services.budget_gateway import BudgetGateway
+from tests._support.events import collect_events
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -144,6 +145,7 @@ def test_router_cap_fires_at_nth_invocation():
     rejection with cap=3.
     """
     gw, events = _make_gateway(cap=3)
+    collected = collect_events(events)
 
     # Three calls within cap: all succeed; counter reaches 3.
     gw.check_and_increment_router_cap("msg1")
@@ -163,7 +165,7 @@ def test_router_cap_fires_at_nth_invocation():
     assert exc.last_reason == "ran_out_of_ideas"
 
     # Exactly one event emitted (only on the violation, not on the three preceding calls).
-    emitted = events.all()
+    emitted = collected
     exhausted_events = [e for e in emitted if e.type == "router_retry_exhausted"]
     assert exhausted_events, "router_retry_exhausted event must be emitted on cap violation"
     assert sum(1 for _ in exhausted_events) == 1, (
@@ -186,6 +188,7 @@ def test_router_cap_long_user_text_truncated():
     (counter is already 1 >= cap=1).
     """
     gw, events = _make_gateway(cap=1)
+    collected = collect_events(events)
 
     # First call within cap.
     gw.check_and_increment_router_cap("seed")
@@ -195,7 +198,7 @@ def test_router_cap_long_user_text_truncated():
     with pytest.raises(RouterCapExceeded):
         gw.check_and_increment_router_cap(long_text)
 
-    emitted = events.all()
+    emitted = collected
     exhausted_events = [e for e in emitted if e.type == "router_retry_exhausted"]
     assert exhausted_events, "router_retry_exhausted event must be emitted"
     # user_message must be truncated — verify it matches exactly the first 200 chars.
@@ -215,6 +218,7 @@ def test_reset_router_turn_counter_clears_state():
     and the last_reason, so the next turn starts fresh.
     """
     gw, events = _make_gateway(cap=3)
+    collected = collect_events(events)
 
     # Burn two slots and set a reason.
     gw.check_and_increment_router_cap("first")
@@ -242,7 +246,7 @@ def test_reset_router_turn_counter_clears_state():
     # No router_retry_exhausted event from the first two calls (they
     # were within budget). Only one event from the cap violation.
     exhausted_events = [
-        e for e in events.all() if e.type == "router_retry_exhausted"
+        e for e in collected if e.type == "router_retry_exhausted"
     ]
     assert exhausted_events, "router_retry_exhausted event must be emitted on cap violation"
     assert not exhausted_events[1:], (

--- a/tests/test_cache_token_capture_1772.py
+++ b/tests/test_cache_token_capture_1772.py
@@ -24,6 +24,7 @@ from litellm.types.utils import PromptTokensDetailsWrapper, Usage
 from reyn.core.events.events import EventLog, set_llm_request_event_log
 from reyn.llm.llm import _extract_cache_tokens, _extract_usage, recorded_acompletion
 from reyn.llm.pricing import TokenUsage
+from tests._support.events import collect_events
 
 
 def test_extract_anthropic_style_read_and_creation() -> None:
@@ -126,6 +127,7 @@ def test_cost_event_carries_flat_cache_tokens(monkeypatch, _reset_event_log) -> 
     monkeypatch.delenv("OPENAI_API_BASE", raising=False)
     monkeypatch.setattr(litellm, "acompletion", _resp)
     log = EventLog()
+    collected = collect_events(log)
     set_llm_request_event_log(log)
 
     asyncio.run(recorded_acompletion(
@@ -136,7 +138,7 @@ def test_cost_event_carries_flat_cache_tokens(monkeypatch, _reset_event_log) -> 
         emit_cost_events=True,
     ))
 
-    resp = next(e for e in log.all() if e.type == "llm_response_received")
+    resp = next(e for e in collected if e.type == "llm_response_received")
     assert resp.data["prompt_tokens"] == 3000
     assert resp.data["cached_tokens"] == 2719
     assert resp.data["cache_creation_tokens"] == 0

--- a/tests/test_chat_compaction_engine.py
+++ b/tests/test_chat_compaction_engine.py
@@ -75,12 +75,14 @@ def test_trim_head_single_oversized_turn_emits_event() -> None:
     must not raise.
     """
     from reyn.core.events.events import EventLog
+    from tests._support.events import collect_events
     events = EventLog()
+    collected = collect_events(events)
     # 4000-char turn → ~1000 tokens (chars//4); cap=10
     turns = _turns(["x" * 4000])
     result = trim_head(turns, max_tokens=10, events=events)
     assert len(result) >= 1, "degenerate single-turn must still be included"
-    trunc_events = [e for e in events.all() if e.type == "turn_too_large_truncated"]
+    trunc_events = [e for e in collected if e.type == "turn_too_large_truncated"]
     assert trunc_events, "must emit turn_too_large_truncated for oversized turn"
     assert trunc_events[0].data["budget_kind"] == "head"
 
@@ -123,11 +125,13 @@ def test_trim_tail_single_oversized_turn_emits_event() -> None:
     turn_too_large_truncated is emitted (Axis 7).
     """
     from reyn.core.events.events import EventLog
+    from tests._support.events import collect_events
     events = EventLog()
+    collected = collect_events(events)
     turns = _turns(["x" * 4000])
     result = trim_tail(turns, max_tokens=10, events=events)
     assert len(result) >= 1
-    trunc_events = [e for e in events.all() if e.type == "turn_too_large_truncated"]
+    trunc_events = [e for e in collected if e.type == "turn_too_large_truncated"]
     assert trunc_events
     assert trunc_events[0].data["budget_kind"] == "tail"
 

--- a/tests/test_chat_compaction_engine_11axis.py
+++ b/tests/test_chat_compaction_engine_11axis.py
@@ -52,6 +52,7 @@ from reyn.services.compaction.engine import (
     trim_head,
     trim_tail,
 )
+from tests._support.events import collect_events
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -446,11 +447,12 @@ def test_hard_truncate_summary_emits_event_when_truncating() -> None:
     truncates.
     """
     events = EventLog()
+    collected = collect_events(events)
     text = "x" * 400  # 100 tokens
     result = hard_truncate_summary(
         text, body_budget=50, model="", events=events, use_chars4=True
     )
-    emitted = [e for e in events.all() if e.type == "body_summary_hard_truncated"]
+    emitted = [e for e in collected if e.type == "body_summary_hard_truncated"]
     assert emitted, "body_summary_hard_truncated event must be emitted"
     assert emitted[0].data["kept_tokens"] == 50
     assert len(result) < len(text)
@@ -459,9 +461,10 @@ def test_hard_truncate_summary_emits_event_when_truncating() -> None:
 def test_hard_truncate_summary_no_event_when_within_budget() -> None:
     """Tier 2: hard_truncate_summary does NOT emit event when no truncation occurs."""
     events = EventLog()
+    collected = collect_events(events)
     text = "a" * 40  # 10 tokens
     hard_truncate_summary(text, body_budget=100, model="", events=events, use_chars4=True)
-    emitted = [e for e in events.all() if e.type == "body_summary_hard_truncated"]
+    emitted = [e for e in collected if e.type == "body_summary_hard_truncated"]
     assert not emitted
 
 
@@ -475,10 +478,11 @@ def test_trim_head_oversized_turn_event_has_required_fields() -> None:
     kept_tokens, budget_kind fields (Axis 7 spec).
     """
     events = EventLog()
+    collected = collect_events(events)
     turns = [{"role": "user", "text": "x" * 4000, "seq": 42}]
     trim_head(turns, max_tokens=10, model="", use_chars4=True, events=events)
     ev = next(
-        (e for e in events.all() if e.type == "turn_too_large_truncated"), None
+        (e for e in collected if e.type == "turn_too_large_truncated"), None
     )
     assert ev is not None
     assert ev.data["turn_seq"] == 42
@@ -492,10 +496,11 @@ def test_trim_tail_oversized_turn_event_has_required_fields() -> None:
     kept_tokens, budget_kind fields (Axis 7 spec).
     """
     events = EventLog()
+    collected = collect_events(events)
     turns = [{"role": "user", "text": "x" * 4000, "seq": 99}]
     trim_tail(turns, max_tokens=10, model="", use_chars4=True, events=events)
     ev = next(
-        (e for e in events.all() if e.type == "turn_too_large_truncated"), None
+        (e for e in collected if e.type == "turn_too_large_truncated"), None
     )
     assert ev is not None
     assert ev.data["turn_seq"] == 99
@@ -809,6 +814,7 @@ def test_force_compact_now_single_pass_no_race_recovery() -> None:
     from reyn.runtime.services.compaction_controller import CompactionController
 
     events = EventLog()
+    collected = collect_events(events)
     engine = _CountingEngine()
 
     # 600 large turns — stays well "over budget"; pre-#1128 this drove a 2nd
@@ -845,7 +851,7 @@ def test_force_compact_now_single_pass_no_race_recovery() -> None:
     assert engine.compact_call_count == 1, (
         f"force_compact_now must run exactly one pass, got {engine.compact_call_count}"
     )
-    unrecovered = [e for e in events.all() if e.type == "force_compact_race_unrecovered"]
+    unrecovered = [e for e in collected if e.type == "force_compact_race_unrecovered"]
     assert not unrecovered, (
         "single-pass force_compact_now must not emit force_compact_race_unrecovered"
     )

--- a/tests/test_cli_secret.py
+++ b/tests/test_cli_secret.py
@@ -27,6 +27,7 @@ from reyn.interfaces.cli.commands.secret import (
     run_set,
 )
 from reyn.security.secrets.store import load_secrets, save_secret
+from tests._support.events import collect_events
 
 # ── helper ────────────────────────────────────────────────────────────────────
 
@@ -112,7 +113,8 @@ def test_run_set_saves_secret_and_emits_event(tmp_path, capsys):
     secrets = tmp_path / "secrets.env"
 
     audit_log = _get_audit_log()
-    before = len(audit_log.all())
+    collected = collect_events(audit_log)
+    before = len(collected)
 
     args = _make_args("REYN_CLI_SET=testval")
     # Monkey-patch the store path by monkeypatching save_secret
@@ -123,7 +125,7 @@ def test_run_set_saves_secret_and_emits_event(tmp_path, capsys):
     # behavior via the store tests.
     run_set(args)
 
-    events = audit_log.all()
+    events = collected
     new_events = events[before:]
     assert any(e.type == "secret_set" and e.data.get("key") == "REYN_CLI_SET" for e in new_events)
     # Value is always masked
@@ -133,12 +135,13 @@ def test_run_set_saves_secret_and_emits_event(tmp_path, capsys):
 def test_run_set_value_masked_in_event():
     """Tier 2: the audit event for secret_set never contains the actual value."""
     audit_log = _get_audit_log()
-    before = len(audit_log.all())
+    collected = collect_events(audit_log)
+    before = len(collected)
 
     args = _make_args("REYN_SET_MASK=supersecret")
     run_set(args)
 
-    events = audit_log.all()
+    events = collected
     new_events = events[before:]
     for e in new_events:
         if e.type == "secret_set":
@@ -170,11 +173,12 @@ def test_run_clear_removes_key_and_emits_event(capsys):
     save_secret("REYN_CLEAR_ME", "to_be_removed")
 
     audit_log = _get_audit_log()
-    before = len(audit_log.all())
+    collected = collect_events(audit_log)
+    before = len(collected)
 
     run_clear(_make_clear_args("REYN_CLEAR_ME"))
 
-    events = audit_log.all()
+    events = collected
     new_events = events[before:]
     assert any(
         e.type == "secret_cleared" and e.data.get("key") == "REYN_CLEAR_ME"
@@ -185,11 +189,12 @@ def test_run_clear_removes_key_and_emits_event(capsys):
 def test_run_clear_missing_key_no_event(capsys):
     """Tier 2: run_clear on a missing key emits no audit event (nothing changed)."""
     audit_log = _get_audit_log()
-    before = len(audit_log.all())
+    collected = collect_events(audit_log)
+    before = len(collected)
 
     run_clear(_make_clear_args("DEFINITELY_NOT_STORED_XYZ_123"))
 
-    events = audit_log.all()
+    events = collected
     new_events = events[before:]
     # No event emitted when key was not found
     assert not any(e.type == "secret_cleared" for e in new_events)
@@ -200,12 +205,13 @@ def test_run_clear_missing_key_no_event(capsys):
 def test_run_rotate_saves_and_emits_rotated_event(capsys):
     """Tier 2: run_rotate saves the new value and emits 'secret_rotated' event."""
     audit_log = _get_audit_log()
-    before = len(audit_log.all())
+    collected = collect_events(audit_log)
+    before = len(collected)
 
     args = _make_args("REYN_ROTATE_KEY=new_rotated_value")
     run_rotate(args)
 
-    events = audit_log.all()
+    events = collected
     new_events = events[before:]
     assert any(
         e.type == "secret_rotated" and e.data.get("key") == "REYN_ROTATE_KEY"
@@ -216,12 +222,13 @@ def test_run_rotate_saves_and_emits_rotated_event(capsys):
 def test_run_rotate_value_masked_in_event():
     """Tier 2: the audit event for secret_rotated never contains the actual value."""
     audit_log = _get_audit_log()
-    before = len(audit_log.all())
+    collected = collect_events(audit_log)
+    before = len(collected)
 
     args = _make_args("REYN_ROTATE_MASK=another_secret")
     run_rotate(args)
 
-    events = audit_log.all()
+    events = collected
     new_events = events[before:]
     for e in new_events:
         if e.type == "secret_rotated":

--- a/tests/test_compaction_controller_invariants.py
+++ b/tests/test_compaction_controller_invariants.py
@@ -4,7 +4,8 @@ Policy compliance (docs/deep-dives/contributing/testing.md):
 - No unittest.mock usage.  Real EventLog, real CompactionConfig, real
   ChatMessage instances.
 - No private-state assertions.  Observation flows through:
-    - events.all() (EventLog public read accessor)
+    - collect_events(event_log) (tests/_support/events.py — a live subscriber
+      list, the same mechanism production's EventStore subscriber uses)
     - event.type / event.data (public fields on Event)
 - Each test docstring's first line starts with ``Tier 2: ...``.
 
@@ -31,6 +32,7 @@ from reyn.services.compaction.engine import (
     ComputedBudgets,
     HistoryChunkToCompact,
 )
+from tests._support.events import collect_events
 
 # Synthetic budgets: head/tail each fit ~one 50-token turn ("x"*200 via chars4),
 # so a 7-turn history yields head=[t1], tail=[t7], middle=[t2..t6] = candidates.
@@ -70,9 +72,10 @@ def _make_controller(
     *,
     history: list[ChatMessage],
     engine: CompactionEngine,
-) -> tuple[CompactionController, EventLog, list[ChatMessage]]:
-    """Return a (controller, events, history) triple ready for testing."""
+) -> tuple[CompactionController, list, list[ChatMessage]]:
+    """Return a (controller, collected, history) triple ready for testing."""
     events = EventLog()
+    collected = collect_events(events)
 
     def _latest_summary():
         for m in reversed(history):
@@ -93,7 +96,7 @@ def _make_controller(
         ),
         render_summary=lambda s: str(s),
     )
-    return ctrl, events, history
+    return ctrl, collected, history
 
 
 def _history(n: int) -> list[ChatMessage]:
@@ -119,11 +122,11 @@ def test_force_compact_no_candidates_emits_forced_sync_no_started():
     to compact), force_compact_now emits compaction_check(outcome='forced_sync')
     with candidate_count=0 and does NOT emit compaction_started.
     """
-    ctrl, events, _ = _make_controller(history=_history(2), engine=_AbortingEngine())
+    ctrl, collected, _ = _make_controller(history=_history(2), engine=_AbortingEngine())
 
     asyncio.run(ctrl.force_compact_now())
 
-    emitted = events.all()
+    emitted = collected
     forced = [e for e in emitted if e.type == "compaction_check"
               and e.data.get("outcome") == "forced_sync"]
     started = [e for e in emitted if e.type == "compaction_started"]
@@ -141,11 +144,11 @@ def test_force_compact_with_candidates_appends_summary():
     """Tier 2: with a compactable middle, force_compact_now runs the engine
     (compaction_started + compaction_completed) and appends a summary entry.
     """
-    ctrl, events, hist = _make_controller(history=_history(7), engine=_SucceedingEngine())
+    ctrl, collected, hist = _make_controller(history=_history(7), engine=_SucceedingEngine())
 
     asyncio.run(ctrl.force_compact_now())
 
-    emitted = events.all()
+    emitted = collected
     assert [e for e in emitted if e.type == "compaction_started"], "expected compaction_started"
     assert [e for e in emitted if e.type == "compaction_completed"], "expected compaction_completed"
     summaries = [m for m in hist if m.role == "summary"]
@@ -161,10 +164,10 @@ def test_force_compact_engine_failure_emits_failed():
     """Tier 2: when the engine raises mid-compaction, force_compact_now emits
     compaction_failed and returns (the try/except swallows the engine error
     rather than propagating it to the caller)."""
-    ctrl, events, _ = _make_controller(history=_history(7), engine=_AbortingEngine())
+    ctrl, collected, _ = _make_controller(history=_history(7), engine=_AbortingEngine())
 
     asyncio.run(ctrl.force_compact_now())  # must not raise
 
-    assert [e for e in events.all() if e.type == "compaction_failed"], (
+    assert [e for e in collected if e.type == "compaction_failed"], (
         "engine failure during force_compact_now must emit compaction_failed"
     )

--- a/tests/test_cui_permission_answer_resumes_2690.py
+++ b/tests/test_cui_permission_answer_resumes_2690.py
@@ -52,6 +52,7 @@ from reyn.llm.pricing import TokenUsage
 from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session
 from reyn.security.permissions.permissions import PermissionResolver
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 _USAGE = TokenUsage(prompt_tokens=5, completion_tokens=3)
 
@@ -132,12 +133,12 @@ def _make_session(project_root: Path, *, wal: Path, snap: Path) -> Session:
     return session
 
 
-def _granted_paths(session: Session) -> list[str]:
+def _granted_paths(collected: list) -> list[str]:
     """Paths for which a ``permission_granted`` event fired — the event the
     reporter found MISSING for the hung write."""
     return [
         e.data.get("path")
-        for e in session._audit_events.all()
+        for e in collected
         if e.type == "permission_granted"
     ]
 
@@ -167,6 +168,7 @@ async def test_cui_write_approval_answer_resumes_blocked_turn(tmp_path, monkeypa
     session = _make_session(
         proj, wal=tmp_path / "state.wal", snap=tmp_path / "snap.json",
     )
+    collected = collect_events(session._audit_events)
     run_task = asyncio.create_task(session.run())
     try:
         await session.submit_user_text("write the file")
@@ -191,7 +193,7 @@ async def test_cui_write_approval_answer_resumes_blocked_turn(tmp_path, monkeypa
         # The intervention future resolved: nothing pending, and the
         # permission_granted event the reporter found MISSING is now emitted.
         assert session.interventions.head() is None
-        await _poll(lambda: str(out) in _granted_paths(session), task=run_task)
+        await _poll(lambda: str(out) in _granted_paths(collected), task=run_task)
     finally:
         await session.shutdown()
         try:
@@ -223,6 +225,7 @@ async def test_cui_read_approval_answer_resumes_identically(tmp_path, monkeypatc
     session = _make_session(
         proj, wal=tmp_path / "state.wal", snap=tmp_path / "snap.json",
     )
+    collected = collect_events(session._audit_events)
     run_task = asyncio.create_task(session.run())
     try:
         await session.submit_user_text("read the outside file")
@@ -231,7 +234,7 @@ async def test_cui_read_approval_answer_resumes_identically(tmp_path, monkeypatc
 
         await route_input_line(_transport_for(session), "y", None)
 
-        await _poll(lambda: str(outside) in _granted_paths(session), task=run_task)
+        await _poll(lambda: str(outside) in _granted_paths(collected), task=run_task)
         assert session.interventions.head() is None
     finally:
         await session.shutdown()

--- a/tests/test_embed_attempts_observation_3047.py
+++ b/tests/test_embed_attempts_observation_3047.py
@@ -39,6 +39,7 @@ from reyn.runtime.budget.budget import BudgetTracker, CostConfig
 from reyn.runtime.services.budget_gateway import BudgetGateway
 from reyn.schemas.models import EmbedIROp
 from reyn.security.permissions.permissions import PermissionDecl
+from tests._support.events import collect_events
 
 # A real litellm-priceable embedding model, so the recorded figure is a real
 # `litellm.model_cost` lookup rather than a fabricated rate.
@@ -163,6 +164,7 @@ async def test_real_retry_populates_attempts_and_op_emits_embed_attempts(
     monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: provider)
 
     ctx, events, _gateway = _ctx_with_gateway()
+    collected = collect_events(events)
     result = await embed_handle(
         EmbedIROp(kind="embed", texts=["hello"], embedding_model="standard"), ctx
     )
@@ -174,8 +176,8 @@ async def test_real_retry_populates_attempts_and_op_emits_embed_attempts(
     # not carry `attempts` — the provider populates the data, the op emits it).
     # The real retry loop ran twice: attempt 1 (500) + attempt 2 (200), so the
     # provider-populated count reaches the event as 2 (not the vacuous 1).
-    attempts_events = [e for e in events.all() if e.type == "embed_attempts"]
-    assert attempts_events, [e.type for e in events.all()]
+    attempts_events = [e for e in collected if e.type == "embed_attempts"]
+    assert attempts_events, [e.type for e in collected]
     payload = attempts_events[0].data
     assert payload["attempts"] == 2, payload
     assert payload["successful_batches"] == 1, payload

--- a/tests/test_embed_bound_cancel_3043.py
+++ b/tests/test_embed_bound_cancel_3043.py
@@ -44,6 +44,7 @@ from reyn.data.embedding.litellm_provider import (
 from reyn.data.workspace.workspace import Workspace
 from reyn.schemas.models import EmbedIROp
 from reyn.security.permissions.permissions import PermissionDecl
+from tests._support.events import collect_events
 
 _MODEL = "openai/text-embedding-3-small"
 
@@ -257,6 +258,7 @@ async def test_cancel_event_interrupts_a_stalled_embed_op_immediately(
     """
     cancel_event = asyncio.Event()
     ctx, events = _make_ctx(cancel_event=cancel_event)
+    collected = collect_events(events)
 
     async def _fire_soon() -> None:
         await asyncio.sleep(0.3)
@@ -269,7 +271,7 @@ async def test_cancel_event_interrupts_a_stalled_embed_op_immediately(
     )
 
     assert result["status"] == "cancelled"
-    assert "embed_cancelled" in [e.type for e in events.all()]
+    assert "embed_cancelled" in [e.type for e in collected]
 
 
 @pytest.mark.asyncio
@@ -287,6 +289,7 @@ async def test_uncancelled_embed_keeps_its_normal_failure_shape(
     does not reshape the outcome, so `status="cancelled"` means a cancel and
     nothing else (a provider failure still raises, and emits no cancel event)."""
     ctx, events = _make_ctx(cancel_event=asyncio.Event())  # never set
+    collected = collect_events(events)
 
     with pytest.raises(RuntimeError, match="Embedding failed"):
         await asyncio.wait_for(
@@ -294,4 +297,4 @@ async def test_uncancelled_embed_keeps_its_normal_failure_shape(
             timeout=60.0,
         )
 
-    assert "embed_cancelled" not in [e.type for e in events.all()]
+    assert "embed_cancelled" not in [e.type for e in collected]

--- a/tests/test_exec_scan_1822.py
+++ b/tests/test_exec_scan_1822.py
@@ -54,8 +54,10 @@ async def test_handle_blocks_malicious_command(tmp_path: Path):
     from reyn.data.workspace.workspace import Workspace
     from reyn.schemas.models import SandboxedExecIROp
     from reyn.security.permissions.permissions import PermissionDecl
+    from tests._support.events import collect_events
 
     events = EventLog()
+    collected = collect_events(events)
     ctx = OpContext(
         workspace=Workspace(events=events),
         events=events,
@@ -67,7 +69,7 @@ async def test_handle_blocks_malicious_command(tmp_path: Path):
     with pytest.raises(PermissionError):
         await handle(op, ctx)
 
-    assert any(e.type == "exec_threat_blocked" for e in events.all())
+    assert any(e.type == "exec_threat_blocked" for e in collected)
 
 
 @pytest.mark.asyncio
@@ -84,8 +86,10 @@ async def test_handle_no_scan_when_disabled(tmp_path: Path):
     from reyn.data.workspace.workspace import Workspace
     from reyn.schemas.models import SandboxedExecIROp
     from reyn.security.permissions.permissions import PermissionDecl
+    from tests._support.events import collect_events
 
     events = EventLog()
+    collected = collect_events(events)
     ctx = OpContext(
         workspace=Workspace(events=events),
         events=events,
@@ -100,4 +104,4 @@ async def test_handle_no_scan_when_disabled(tmp_path: Path):
         await handle(op, ctx)
     except PermissionError as e:
         assert "threat pattern" not in str(e)
-    assert not any(e.type == "exec_threat_blocked" for e in events.all())
+    assert not any(e.type == "exec_threat_blocked" for e in collected)

--- a/tests/test_file_ops_offload_2782.py
+++ b/tests/test_file_ops_offload_2782.py
@@ -55,6 +55,7 @@ from reyn.security.permissions.permissions import PermissionResolver
 from reyn.tools import get_default_registry
 from reyn.tools.dispatch import invoke_tool
 from reyn.tools.types import RouterCallerState, ToolContext
+from tests._support.events import collect_events
 
 
 def _resolver(tmp_path: Path) -> PermissionResolver:
@@ -126,6 +127,7 @@ def test_edit_file_emits_tool_executed_event(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     (tmp_path / "c.txt").write_text("one two\n")
     events = EventLog()
+    collected = collect_events(events)
     ws = Workspace(events=events)
     ctx = ToolContext(
         events=events, permission_resolver=_resolver(tmp_path), workspace=ws,
@@ -133,7 +135,7 @@ def test_edit_file_emits_tool_executed_event(tmp_path, monkeypatch):
     )
     asyncio.run(invoke_tool(get_default_registry(), "edit_file",
                             {"path": "c.txt", "old_string": "one", "new_string": "1"}, ctx))
-    emitted = [e for e in events.all() if e.type == "tool_executed" and e.data.get("op") == "edit_file"]
+    emitted = [e for e in collected if e.type == "tool_executed" and e.data.get("op") == "edit_file"]
     assert emitted, "tool_executed must fire after the offloaded edit, not be lost"
     assert emitted[0].data["replacements"] == 1
     assert not any(e.data.get("replacements") != 1 for e in emitted), "must not emit a duplicate/mismatched event"
@@ -146,6 +148,7 @@ def test_edit_file_validation_error_does_not_emit(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     (tmp_path / "d.txt").write_text("only this\n")
     events = EventLog()
+    collected = collect_events(events)
     ws = Workspace(events=events)
     ctx = ToolContext(
         events=events, permission_resolver=_resolver(tmp_path), workspace=ws,
@@ -154,7 +157,7 @@ def test_edit_file_validation_error_does_not_emit(tmp_path, monkeypatch):
     result = asyncio.run(invoke_tool(get_default_registry(), "edit_file",
                                      {"path": "d.txt", "old_string": "nope", "new_string": "x"}, ctx))
     assert result["status"] == "error"
-    assert not any(e.type == "tool_executed" for e in events.all())
+    assert not any(e.type == "tool_executed" for e in collected)
 
 
 def test_grep_files_runs_off_the_main_thread(tmp_path, monkeypatch):

--- a/tests/test_fp0016_b_oauth_refresh.py
+++ b/tests/test_fp0016_b_oauth_refresh.py
@@ -34,6 +34,7 @@ from reyn.security.secrets.oauth import (
     load_oauth_token,
     save_oauth_token,
 )
+from tests._support.events import collect_events
 
 # ── helpers ────────────────────────────────────────────────────────────────
 
@@ -232,6 +233,7 @@ async def test_get_valid_token_refreshes_when_expired(oauth_store_path: Path) ->
         )
 
     events = EventLog()
+    collected = collect_events(events)
     client = _mock_transport(_handler)
     try:
         result = await get_valid_token("github", events=events, http_client=client)
@@ -247,7 +249,7 @@ async def test_get_valid_token_refreshes_when_expired(oauth_store_path: Path) ->
     assert not saved.is_expired()
 
     # P6 token_refreshed event emitted
-    emitted = [e for e in events.all() if e.type == "token_refreshed"]
+    emitted = [e for e in collected if e.type == "token_refreshed"]
     assert emitted, "expected at least one token_refreshed event"
     assert emitted[0].data["key"] == "github"
     assert "expires_at" in emitted[0].data
@@ -289,6 +291,7 @@ async def test_refresh_missing_access_token_raises(oauth_store_path: Path) -> No
         return httpx.Response(200, json={"expires_in": 3600})
 
     events = EventLog()
+    collected = collect_events(events)
     client = _mock_transport(_handler)
     try:
         with pytest.raises(OAuthRefreshError, match="missing 'access_token'"):
@@ -296,7 +299,7 @@ async def test_refresh_missing_access_token_raises(oauth_store_path: Path) -> No
     finally:
         await client.aclose()
 
-    failures = [e for e in events.all() if e.type == "token_refresh_failed"]
+    failures = [e for e in collected if e.type == "token_refresh_failed"]
     assert failures, "expected at least one token_refresh_failed event"
     assert failures[0].data["key"] == "github"
     assert failures[0].data["re_auth_required"] is False
@@ -314,6 +317,7 @@ async def test_refresh_400_marks_re_auth_required(oauth_store_path: Path) -> Non
         return httpx.Response(400, json={"error": "invalid_grant"})
 
     events = EventLog()
+    collected = collect_events(events)
     client = _mock_transport(_handler)
     try:
         with pytest.raises(OAuthRefreshError) as exc_info:
@@ -323,7 +327,7 @@ async def test_refresh_400_marks_re_auth_required(oauth_store_path: Path) -> Non
     assert exc_info.value.re_auth_required is True
     assert exc_info.value.status_code == 400
 
-    failures = [e for e in events.all() if e.type == "token_refresh_failed"]
+    failures = [e for e in collected if e.type == "token_refresh_failed"]
     assert failures[0].data["re_auth_required"] is True
 
 

--- a/tests/test_fp0016_c_device_grant.py
+++ b/tests/test_fp0016_c_device_grant.py
@@ -31,6 +31,7 @@ from reyn.security.secrets.oauth import (
     OAuthProviderConfig,
     device_grant_flow,
 )
+from tests._support.events import collect_events
 
 # ── helpers ────────────────────────────────────────────────────────────────
 
@@ -115,6 +116,7 @@ async def test_device_grant_flow_success() -> None:
         user_action_calls.append(data)
 
     events = EventLog()
+    collected = collect_events(events)
     provider = _make_provider()
     client = _mock_transport(_handler)
     try:
@@ -137,7 +139,7 @@ async def test_device_grant_flow_success() -> None:
     assert user_action_calls[0]["verification_uri"] == "https://example.com/device"
 
     # P6 events
-    emitted = events.all()
+    emitted = collected
     started = [e for e in emitted if e.type == "oauth_login_started"]
     completed = [e for e in emitted if e.type == "oauth_login_completed"]
     assert started, "oauth_login_started event must be emitted"
@@ -331,6 +333,7 @@ async def test_device_grant_flow_emits_events() -> None:
         return poll_responses.popleft()
 
     events = EventLog()
+    collected = collect_events(events)
     provider = _make_provider()
     client = _mock_transport(_handler)
     try:
@@ -343,7 +346,7 @@ async def test_device_grant_flow_emits_events() -> None:
     finally:
         await client.aclose()
 
-    all_events = events.all()
+    all_events = collected
     started = next(e for e in all_events if e.type == "oauth_login_started")
     completed = next(e for e in all_events if e.type == "oauth_login_completed")
 

--- a/tests/test_fp0016_d_e2e_confused_deputy.py
+++ b/tests/test_fp0016_d_e2e_confused_deputy.py
@@ -35,6 +35,7 @@ from pathlib import Path
 import pytest
 
 from reyn.security.secrets import CredentialScopeError, ScopedSecretStore
+from tests._support.events import collect_events
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -287,6 +288,7 @@ def test_sub_skill_credential_scope_event_emitted(tmp_path: Path) -> None:
     from reyn.core.events.events import EventLog
 
     events = EventLog()
+    collected = collect_events(events)
     allowed = ["github_token"]
 
     # Mirror the event emission from run_skill.handle():
@@ -298,7 +300,7 @@ def test_sub_skill_credential_scope_event_emitted(tmp_path: Path) -> None:
 
     # The event must appear in the log.
     found = [
-        e for e in events.all()
+        e for e in collected
         if e.type == "sub_skill_credential_scope"
     ]
     (evt,) = found
@@ -311,6 +313,7 @@ def test_sub_skill_credential_scope_event_wildcard(tmp_path: Path) -> None:
     from reyn.core.events.events import EventLog
 
     events = EventLog()
+    collected = collect_events(events)
     allowed = ["*"]
 
     events.emit(
@@ -320,7 +323,7 @@ def test_sub_skill_credential_scope_event_wildcard(tmp_path: Path) -> None:
     )
 
     found = [
-        e for e in events.all()
+        e for e in collected
         if e.type == "sub_skill_credential_scope"
     ]
     (evt_wildcard,) = found

--- a/tests/test_fp0056_canonical_degraded_invariant.py
+++ b/tests/test_fp0056_canonical_degraded_invariant.py
@@ -49,6 +49,7 @@ from reyn.core.offload.canonical import (
 )
 from reyn.core.pipeline.executor import Pipeline, PipelineExecutor, ToolStep
 from reyn.tools import get_default_registry
+from tests._support.events import collect_events
 
 get_default_registry()
 
@@ -172,6 +173,7 @@ async def test_empty_mapper_at_call_site_emits_degraded_event_and_warns(
         }
 
     events = EventLog()
+    collected = collect_events(events)
     pipeline = Pipeline(steps=[ToolStep(name="buggy_tool", args={}, output="r")])
     with caplog.at_level(logging.WARNING, logger="reyn.core.pipeline.executor"):
         await PipelineExecutor().run(
@@ -180,12 +182,12 @@ async def test_empty_mapper_at_call_site_emits_degraded_event_and_warns(
         )
 
     # Exactly one degraded event for the one empty-mapping tool step (unpack asserts the count).
-    [degraded] = [e for e in events.all() if e.type == CANONICAL_DEGRADED_EVENT]
+    [degraded] = [e for e in collected if e.type == CANONICAL_DEGRADED_EVENT]
     assert degraded.data["source"] == _EMPTY_PRODUCER_ID
     assert degraded.data["reason"]  # a non-empty reason category
 
     # No result content bytes in ANY event payload — the event carries the source identity only.
-    all_payloads = json.dumps([e.data for e in events.all()])
+    all_payloads = json.dumps([e.data for e in collected])
     assert secret_body not in all_payloads
     assert "content" not in degraded.data
 
@@ -209,12 +211,13 @@ async def test_mapped_producer_with_content_does_not_emit_degraded_event() -> No
         }
 
     events = EventLog()
+    collected = collect_events(events)
     pipeline = Pipeline(steps=[ToolStep(name="run_shell", args={}, output="r")])
     await PipelineExecutor().run(
         pipeline, None,
         tool_dispatch=_dispatch, state_log=None, run_id="run-fp0056-degraded-ok", events=events,
     )
 
-    assert not [e for e in events.all() if e.type == CANONICAL_DEGRADED_EVENT], (
+    assert not [e for e in collected if e.type == CANONICAL_DEGRADED_EVENT], (
         "a producer that surfaced content must not emit the canonical_degraded audit event"
     )

--- a/tests/test_fp0056_canonical_fallback_event.py
+++ b/tests/test_fp0056_canonical_fallback_event.py
@@ -38,6 +38,7 @@ from reyn.core.offload.canonical import (
 )
 from reyn.core.pipeline.executor import Pipeline, PipelineExecutor, ToolStep
 from reyn.tools import get_default_registry
+from tests._support.events import collect_events
 
 get_default_registry()
 
@@ -96,6 +97,7 @@ async def test_unregistered_fallback_emits_event_with_source_id_and_no_body() ->
         }
 
     events = EventLog()
+    collected = collect_events(events)
     pipeline = Pipeline(steps=[ToolStep(name="mystery_tool", args={}, output="r")])
     await PipelineExecutor().run(
         pipeline, None,
@@ -103,13 +105,13 @@ async def test_unregistered_fallback_emits_event_with_source_id_and_no_body() ->
     )
 
     # Exactly one fallback event for the one unregistered tool step (unpack asserts the count).
-    [fallback_event] = [e for e in events.all() if e.type == CANONICAL_FALLBACK_EVENT]
+    [fallback_event] = [e for e in collected if e.type == CANONICAL_FALLBACK_EVENT]
     payload = fallback_event.data
     assert payload["source"] == "an_unregistered_producer_id"
     assert payload["reason"] == "unregistered"
 
     # No result content bytes in ANY event payload — the event carries the source identity only.
-    all_payloads = json.dumps([e.data for e in events.all()])
+    all_payloads = json.dumps([e.data for e in collected])
     assert secret_body not in all_payloads
     assert "content" not in payload  # the raw result field name is not forwarded either
 
@@ -128,12 +130,13 @@ async def test_real_mapper_producer_does_not_emit_fallback_event() -> None:
         }
 
     events = EventLog()
+    collected = collect_events(events)
     pipeline = Pipeline(steps=[ToolStep(name="run_shell", args={}, output="r")])
     await PipelineExecutor().run(
         pipeline, None,
         tool_dispatch=_dispatch, state_log=None, run_id="run-fp0056-f2-mapped", events=events,
     )
 
-    assert not [e for e in events.all() if e.type == CANONICAL_FALLBACK_EVENT], (
+    assert not [e for e in collected if e.type == CANONICAL_FALLBACK_EVENT], (
         "a mapped producer must not emit the fallback audit event"
     )

--- a/tests/test_fp0056_error_seam.py
+++ b/tests/test_fp0056_error_seam.py
@@ -35,6 +35,7 @@ from reyn.core.offload.canonical import (
 )
 from reyn.core.pipeline.executor import Pipeline, PipelineExecutor, ToolStep
 from reyn.tools import get_default_registry
+from tests._support.events import collect_events
 
 get_default_registry()
 
@@ -288,6 +289,7 @@ async def test_recall_error_at_pipeline_chokepoint_renders_non_empty_no_degraded
         }
 
     events = EventLog()
+    collected = collect_events(events)
     pipeline = Pipeline(steps=[ToolStep(name="semantic_search", args={}, output="r")])
     result = await PipelineExecutor().run(
         pipeline, None,
@@ -299,6 +301,6 @@ async def test_recall_error_at_pipeline_chokepoint_renders_non_empty_no_degraded
     assert ctx_value["text"].strip(), "semantic_search error must reach ctx as non-empty text"
     assert "semantic_search requires" in ctx_value["text"]
     # An error is error-classified → it does NOT masquerade as a lost success → no degraded event.
-    assert not [e for e in events.all() if e.type == CANONICAL_DEGRADED_EVENT], (
+    assert not [e for e in collected if e.type == CANONICAL_DEGRADED_EVENT], (
         "an error result (non-empty, error-classified) must not trip canonical_degraded"
     )

--- a/tests/test_fp0056_m3_fail_visible.py
+++ b/tests/test_fp0056_m3_fail_visible.py
@@ -42,6 +42,7 @@ from reyn.core.offload.canonical import (
 )
 from reyn.core.pipeline.executor import Pipeline, PipelineExecutor, ToolStep
 from reyn.tools import get_default_registry
+from tests._support.events import collect_events
 
 get_default_registry()
 
@@ -245,16 +246,17 @@ async def test_file_discriminator_miss_emits_fallback_event_end_to_end() -> None
         }
 
     events = EventLog()
+    collected = collect_events(events)
     pipeline = Pipeline(steps=[ToolStep(name="glob_files", args={}, output="r")])
     await PipelineExecutor().run(
         pipeline, None,
         tool_dispatch=_dispatch, state_log=None, run_id="run-fp0056-m3", events=events,
     )
 
-    [fallback_event] = [e for e in events.all() if e.type == CANONICAL_FALLBACK_EVENT]
+    [fallback_event] = [e for e in collected if e.type == CANONICAL_FALLBACK_EVENT]
     assert fallback_event.data["source"] == "file"
     assert fallback_event.data["reason"] == "discriminator_miss"
 
     # No result content bytes in ANY event payload — the event carries the source identity only.
-    all_payloads = json.dumps([e.data for e in events.all()])
+    all_payloads = json.dumps([e.data for e in collected])
     assert secret_match not in all_payloads

--- a/tests/test_group_aware_trim_2289.py
+++ b/tests/test_group_aware_trim_2289.py
@@ -18,6 +18,7 @@ from reyn.services.compaction.engine import (
     trim_head,
     trim_tail,
 )
+from tests._support.events import collect_events
 
 _M = ""  # model (unused with use_chars4)
 
@@ -115,9 +116,10 @@ def test_over_budget_single_cycle_kept_whole_with_new_event():
     not a truncation)."""
     turns = [_asst_tc("t1", 80, 1), _tool("t1", 80, 2)]  # 20 + 20 = 40 tokens, alone > 25
     events = EventLog()
+    collected = collect_events(events)
     head = trim_head(turns, max_tokens=25, model=_M, use_chars4=True, events=events)
     assert [t["seq"] for t in head] == [1, 2], "the whole cycle survives (call + result), over budget"
-    kinds = [e.type for e in events.all()]
+    kinds = [e.type for e in collected]
     assert "tool_cycle_kept_whole_over_budget" in kinds, "the keep-whole event is emitted"
     assert "turn_too_large_truncated" not in kinds, "it is NOT reported as a truncation (no loss)"
 
@@ -127,8 +129,9 @@ def test_over_budget_non_cycle_turn_keeps_legacy_truncated_event():
     event (backward-compat — the group change only adds the cycle case)."""
     turns = [_user(200, 1)]  # 50 tokens alone > 25
     events = EventLog()
+    collected = collect_events(events)
     trim_head(turns, max_tokens=25, model=_M, use_chars4=True, events=events)
-    kinds = [e.type for e in events.all()]
+    kinds = [e.type for e in collected]
     assert "turn_too_large_truncated" in kinds
     assert "tool_cycle_kept_whole_over_budget" not in kinds
 

--- a/tests/test_intervention_agent_routing.py
+++ b/tests/test_intervention_agent_routing.py
@@ -34,6 +34,7 @@ from reyn.runtime.session import Session
 from reyn.runtime.session_buses import AgentRequestBus
 from reyn.user_intervention import InterventionAnswer, UserIntervention
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 
 def _recovery_kwargs(agent_name: str) -> dict:
@@ -114,13 +115,14 @@ def test_default_routing_emits_user_channel_event(tmp_path: Path) -> None:
     traces, future routing-policy analysis) can see the decision.
     """
     session = make_session(agent_name="t")
+    collected = collect_events(session._audit_events)
     iv = UserIntervention(kind="ask_user", prompt="Q?")
 
     asyncio.run(session.handle_intervention(iv))
 
     # session._audit_events is the EventLog used for chat-side events.
     events = [
-        e for e in session._audit_events.to_json()
+        e for e in [e.model_dump(mode="json") for e in collected]
         if e.get("type") == "intervention_routed"
     ]
     assert events, "intervention_routed event must fire on each handle_intervention call"
@@ -161,12 +163,13 @@ def test_self_answer_branch_emits_self_answer_event() -> None:
     ``route="self_answer"``.
     """
     session = _SelfAnsweringSession(agent=Agent(agent_name="t"), **_recovery_kwargs("t"))
+    collected = collect_events(session._audit_events)
     iv = UserIntervention(kind="permission.shell", prompt="Run ls?")
 
     asyncio.run(session.handle_intervention(iv))
 
     events = [
-        e for e in session._audit_events.to_json()
+        e for e in [e.model_dump(mode="json") for e in collected]
         if e.get("type") == "intervention_routed"
     ]
     assert events
@@ -219,21 +222,23 @@ def test_parent_delegate_branch_emits_parent_delegate_event() -> None:
     event on the parent's audit_events log.
     """
     parent = _SelfAnsweringSession(agent=Agent(agent_name="parent"), **_recovery_kwargs("parent"))
+    parent_collected = collect_events(parent._audit_events)
     child = _DelegatingSession(agent=Agent(agent_name="child"), **_recovery_kwargs("child"))
+    child_collected = collect_events(child._audit_events)
     child.set_parent(parent)
 
     iv = UserIntervention(kind="ask_user", prompt="Q?")
     asyncio.run(child.handle_intervention(iv))
 
     child_events = [
-        e for e in child._audit_events.to_json()
+        e for e in [e.model_dump(mode="json") for e in child_collected]
         if e.get("type") == "intervention_routed"
     ]
     assert child_events
     assert child_events[-1]["data"]["route"] == "parent_delegate"
 
     parent_events = [
-        e for e in parent._audit_events.to_json()
+        e for e in [e.model_dump(mode="json") for e in parent_collected]
         if e.get("type") == "intervention_routed"
     ]
     assert parent_events
@@ -261,6 +266,7 @@ def test_self_answer_takes_precedence_over_parent_delegate() -> None:
     design (issue #254 design discussion log).
     """
     parent = _SelfAnsweringSession(agent=Agent(agent_name="parent"), **_recovery_kwargs("parent"))
+    parent_collected = collect_events(parent._audit_events)
     child = _SelfAndParentSession(agent=Agent(agent_name="child"), **_recovery_kwargs("child"))
     child.set_parent(parent)
 
@@ -274,7 +280,7 @@ def test_self_answer_takes_precedence_over_parent_delegate() -> None:
     # And the parent's audit_events has NO intervention_routed event
     # (= parent's handle_intervention was never invoked).
     parent_events = [
-        e for e in parent._audit_events.to_json()
+        e for e in [e.model_dump(mode="json") for e in parent_collected]
         if e.get("type") == "intervention_routed"
     ]
     assert not parent_events

--- a/tests/test_llm_call_retry.py
+++ b/tests/test_llm_call_retry.py
@@ -54,6 +54,7 @@ from reyn.llm.llm import (
     _is_retryable_exc,
     _llm_call_with_retry,
 )
+from tests._support.events import collect_events
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -175,6 +176,7 @@ async def test_no_retry_on_success(monkeypatch):
     monkeypatch.setattr(llm_mod.asyncio, "sleep", lambda _: _no_op_coro())
 
     log = _make_event_log()
+    collected = collect_events(log)
     resp = _fake_response()
 
     async def _ok():
@@ -183,7 +185,7 @@ async def test_no_retry_on_success(monkeypatch):
     result = await _llm_call_with_retry(_ok, "model-x", log)
     assert result is resp
 
-    types = [e.type for e in log.all()]
+    types = [e.type for e in collected]
     assert "llm_call_retry" not in types
     assert "llm_call_retry_exhausted" not in types
 
@@ -211,6 +213,7 @@ async def test_retry_and_succeed(monkeypatch):
     monkeypatch.setattr(llm_mod.asyncio, "sleep", _fake_sleep)
 
     log = _make_event_log()
+    collected = collect_events(log)
     resp = _fake_response()
     stub = _FailThenSucceedCallable(
         fail_count=1,
@@ -223,9 +226,9 @@ async def test_retry_and_succeed(monkeypatch):
     assert stub.call_count == 2
 
     # Exactly one retry event (present) and no exhausted event (absent)
-    retry_events = [e for e in log.all() if e.type == "llm_call_retry"]
+    retry_events = [e for e in collected if e.type == "llm_call_retry"]
     assert retry_events, "at least one llm_call_retry event must be emitted after a timeout"
-    assert not any(e.type == "llm_call_retry_exhausted" for e in log.all()), (
+    assert not any(e.type == "llm_call_retry_exhausted" for e in collected), (
         "llm_call_retry_exhausted must NOT be emitted when retry succeeds"
     )
 
@@ -262,6 +265,7 @@ async def test_all_retries_exhausted(monkeypatch):
     monkeypatch.setattr(llm_mod.asyncio, "sleep", _fake_sleep_noop)
 
     log = _make_event_log()
+    collected = collect_events(log)
     exc = litellm.exceptions.ServiceUnavailableError("503", response=None, llm_provider="test", model="m")
     stub = _AlwaysFailCallable(exc)
 
@@ -270,7 +274,7 @@ async def test_all_retries_exhausted(monkeypatch):
 
     assert stub.call_count == _LLM_RETRY_MAX_ATTEMPTS
 
-    exhausted = [e for e in log.all() if e.type == "llm_call_retry_exhausted"]
+    exhausted = [e for e in collected if e.type == "llm_call_retry_exhausted"]
     assert exhausted, "llm_call_retry_exhausted must be emitted when all retries fail"
     assert exhausted[0].data["model"] == "model-503"
     assert exhausted[0].data["error_kind"] == "ServiceUnavailableError"
@@ -299,6 +303,7 @@ async def test_4xx_no_retry(monkeypatch):
     monkeypatch.setattr(llm_mod.asyncio, "sleep", _record_sleep)
 
     log = _make_event_log()
+    collected = collect_events(log)
     exc = litellm.exceptions.BadRequestError(
         "invalid request", response=None, llm_provider="test", model="m"
     )
@@ -311,7 +316,7 @@ async def test_4xx_no_retry(monkeypatch):
     assert stub.call_count == 1
     assert sleep_calls == []
 
-    types = [e.type for e in log.all()]
+    types = [e.type for e in collected]
     assert "llm_call_retry" not in types
     assert "llm_call_retry_exhausted" not in types
 
@@ -342,6 +347,7 @@ async def test_httpx_errors_retried(monkeypatch):
 
     for exc_cls in (httpx.ConnectError, httpx.ReadTimeout):
         log = _make_event_log()
+        collected = collect_events(log)
         try:
             raw_exc = exc_cls("connection failed")
         except TypeError:
@@ -358,7 +364,7 @@ async def test_httpx_errors_retried(monkeypatch):
         assert result is resp, f"{exc_cls.__name__} should be retried"
         assert stub.call_count == 2
 
-        retry_events = [e for e in log.all() if e.type == "llm_call_retry"]
+        retry_events = [e for e in collected if e.type == "llm_call_retry"]
         assert retry_events, f"{exc_cls.__name__}: expected at least one llm_call_retry event"
 
 
@@ -445,6 +451,7 @@ async def test_empty_choices_retried_then_succeed(monkeypatch):
     monkeypatch.setattr(llm_mod.asyncio, "sleep", _fake_sleep_noop)
 
     log = _make_event_log()
+    collected = collect_events(log)
     valid = _fake_response()
     stub = _ReturnEmptyThenValidCallable(empty_count=1, valid_response=valid)
 
@@ -452,10 +459,10 @@ async def test_empty_choices_retried_then_succeed(monkeypatch):
     assert result is valid
     assert stub.call_count == 2
 
-    retry_events = [e for e in log.all() if e.type == "llm_call_retry"]
+    retry_events = [e for e in collected if e.type == "llm_call_retry"]
     assert retry_events, "empty choices must emit a llm_call_retry event"
     assert retry_events[0].data["error_kind"] == "EmptyLLMResponseError"
-    assert not any(e.type == "llm_call_retry_exhausted" for e in log.all())
+    assert not any(e.type == "llm_call_retry_exhausted" for e in collected)
 
 
 # ---------------------------------------------------------------------------
@@ -476,6 +483,7 @@ async def test_empty_choices_exhausted_raises_named_error(monkeypatch):
     monkeypatch.setattr(llm_mod.asyncio, "sleep", _fake_sleep_noop)
 
     log = _make_event_log()
+    collected = collect_events(log)
     stub = _AlwaysEmptyCallable()
 
     with pytest.raises(EmptyLLMResponseError):
@@ -483,7 +491,7 @@ async def test_empty_choices_exhausted_raises_named_error(monkeypatch):
 
     assert stub.call_count == _LLM_RETRY_MAX_ATTEMPTS
 
-    exhausted = [e for e in log.all() if e.type == "llm_call_retry_exhausted"]
+    exhausted = [e for e in collected if e.type == "llm_call_retry_exhausted"]
     assert exhausted, "persistent empty choices must emit llm_call_retry_exhausted"
     assert exhausted[0].data["error_kind"] == "EmptyLLMResponseError"
 

--- a/tests/test_llm_request_error_1676.py
+++ b/tests/test_llm_request_error_1676.py
@@ -21,6 +21,7 @@ import pytest
 
 from reyn.core.events.events import EventLog, set_llm_request_event_log
 from reyn.llm.llm import recorded_acompletion
+from tests._support.events import collect_events
 
 
 class _FakeProviderError(Exception):
@@ -72,13 +73,14 @@ def test_error_event_emitted_and_reraised(monkeypatch) -> None:
                              response_text="405 page"),
     )
     log = EventLog()
+    collected = collect_events(log)
     set_llm_request_event_log(log)
 
     with pytest.raises(_FakeProviderError):
         _call(monkeypatch, temperature=0.5)
 
     # Exactly one llm_request_error (unpack-enforcement).
-    (err,) = [e for e in log.all() if e.type == "llm_request_error"]
+    (err,) = [e for e in collected if e.type == "llm_request_error"]
     data = err.data
     assert data["model"] == "gpt-5.4"
     assert data["purpose"] == "main"
@@ -99,12 +101,13 @@ def test_error_body_not_truncated(monkeypatch) -> None:
                              response_text=""),
     )
     log = EventLog()
+    collected = collect_events(log)
     set_llm_request_event_log(log)
 
     with pytest.raises(_FakeProviderError):
         _call(monkeypatch)
 
-    (err,) = [e for e in log.all() if e.type == "llm_request_error"]
+    (err,) = [e for e in collected if e.type == "llm_request_error"]
     # Exact equality proves the whole body survived (no truncation).
     assert err.data["provider_body"] == long_body
 
@@ -122,12 +125,13 @@ def test_error_event_redacts_secret_value(monkeypatch) -> None:
         ),
     )
     log = EventLog()
+    collected = collect_events(log)
     set_llm_request_event_log(log)
 
     with pytest.raises(_FakeProviderError):
         _call(monkeypatch, api_key="sk-supersecret-123")
 
-    (err,) = [e for e in log.all() if e.type == "llm_request_error"]
+    (err,) = [e for e in collected if e.type == "llm_request_error"]
     data = err.data
     # The secret must not leak anywhere in the captured error event.
     assert "sk-supersecret-123" not in repr(data), "secret value must be scrubbed"

--- a/tests/test_llm_request_event_1669.py
+++ b/tests/test_llm_request_event_1669.py
@@ -31,6 +31,7 @@ from reyn.core.events.events import (
     set_llm_request_event_log,
 )
 from reyn.llm.llm import _redact_llm_request_params, recorded_acompletion
+from tests._support.events import collect_events
 
 
 @pytest.fixture(autouse=True)
@@ -71,6 +72,7 @@ def test_event_emitted_with_non_message_params(monkeypatch) -> None:
     `llm_request` event carrying model / purpose / the non-message params (proves
     the ContextVar read propagates into the call — lead's propagation verify)."""
     log = EventLog()
+    collected = collect_events(log)
     set_llm_request_event_log(log)
 
     _call(
@@ -80,9 +82,9 @@ def test_event_emitted_with_non_message_params(monkeypatch) -> None:
         extra_body={"thinking": {"budget": 1024}},
     )
 
-    kinds = [e.type for e in log.all()]
+    kinds = [e.type for e in collected]
     assert kinds == ["llm_request"], f"expected exactly one llm_request; got {kinds}"
-    data = log.all()[0].data
+    data = collected[0].data
     assert data["model"] == "gpt-5.4"
     assert data["purpose"] == "main"
     assert data["params"]["reasoning_effort"] == "low"
@@ -96,11 +98,12 @@ def test_event_excludes_messages(monkeypatch) -> None:
     """Tier 2: #1669 — the event NEVER carries `messages` (owner: 'メッセージ以外').
     The secret message body must not leak anywhere in the event data."""
     log = EventLog()
+    collected = collect_events(log)
     set_llm_request_event_log(log)
 
     _call(monkeypatch, temperature=0.1)
 
-    data = log.all()[0].data
+    data = collected[0].data
     assert "messages" not in data
     assert "messages" not in data["params"]
     assert "secret message body" not in repr(data)
@@ -109,12 +112,13 @@ def test_event_excludes_messages(monkeypatch) -> None:
 def test_event_tools_count_not_array(monkeypatch) -> None:
     """Tier 2: #1669 — `tools` is surfaced as a count, never the (large) array."""
     log = EventLog()
+    collected = collect_events(log)
     set_llm_request_event_log(log)
 
     tools = [{"type": "function", "function": {"name": f"t{i}"}} for i in range(18)]
     _call(monkeypatch, tools=tools, temperature=0.0)
 
-    data = log.all()[0].data
+    data = collected[0].data
     assert data["tools_count"] == 18
     assert "tools" not in data["params"], "the tools array must not be in the event"
 
@@ -122,11 +126,12 @@ def test_event_tools_count_not_array(monkeypatch) -> None:
 def test_event_redacts_secret_fields(monkeypatch) -> None:
     """Tier 2: #1669 — secret-like params (api_key / authorization) are redacted."""
     log = EventLog()
+    collected = collect_events(log)
     set_llm_request_event_log(log)
 
     _call(monkeypatch, api_key="sk-super-secret", authorization="Bearer tok-123")
 
-    params = log.all()[0].data["params"]
+    params = collected[0].data["params"]
     assert params["api_key"] == "***REDACTED***"
     assert params["authorization"] == "***REDACTED***"
     assert "sk-super-secret" not in repr(params)

--- a/tests/test_mcp_install_local_hot_reload.py
+++ b/tests/test_mcp_install_local_hot_reload.py
@@ -27,6 +27,7 @@ from types import SimpleNamespace
 from reyn.core.events.events import EventLog
 from reyn.runtime.hot_reload import HotReloader
 from reyn.tools.types import ToolContext
+from tests._support.events import collect_events
 
 
 def _ctx(project_root: Path) -> ToolContext:
@@ -83,6 +84,7 @@ def test_local_install_schedules_reload(tmp_path: Path) -> None:
     with the right source via the PUBLIC events log, not a private-state read.
     """
     events = EventLog()
+    collected = collect_events(events)
     reloader = HotReloader(project_root=tmp_path, events=events)
     result = _run_install(reloader, tmp_path)
     assert result["status"] == "ok", f"install failed: {result}"
@@ -91,7 +93,7 @@ def test_local_install_schedules_reload(tmp_path: Path) -> None:
     asyncio.run(reloader.apply_pending())
     # Tuple-unpack: raises ValueError if there isn't EXACTLY one — a
     # behavioural assertion (one reload, not a repeat), not a length pin.
-    (reload_event,) = [e for e in events.all() if e.type == "config_reloaded"]
+    (reload_event,) = [e for e in collected if e.type == "config_reloaded"]
     assert reload_event.data["source"] == "mcp_install_local"
 
 

--- a/tests/test_mcp_install_op.py
+++ b/tests/test_mcp_install_op.py
@@ -31,6 +31,7 @@ from reyn.core.op_runtime.mcp_install import handle as mcp_install_handle
 from reyn.schemas.models import MCPInstallIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 from reyn.user_intervention import InterventionAnswer, UserIntervention
+from tests._support.events import collect_events
 
 # ---------------------------------------------------------------------------
 # Fixtures: fake server.json responses
@@ -373,6 +374,7 @@ def test_secret_value_not_in_event(tmp_path, monkeypatch):
     decl = _phase5_install_decl(resolver)
     bus = _AutoApproveInterventionBus()
     ctx = _make_op_ctx(tmp_path, resolver, bus, decl)
+    collected = collect_events(ctx.events)
 
     op = MCPInstallIROp(
         kind="mcp_install",
@@ -384,7 +386,7 @@ def test_secret_value_not_in_event(tmp_path, monkeypatch):
     with _patch_registry_get(_SECRET_SERVER_RESPONSE):
         _run(mcp_install_handle(op, ctx))
 
-    events = ctx.events.all()
+    events = collected
     install_events = [e for e in events if e.type == "mcp_server_installed"]
     assert install_events, "Expected mcp_server_installed event"
 
@@ -466,6 +468,7 @@ def test_event_emitted_on_success(tmp_path, monkeypatch):
     decl = _phase5_install_decl(resolver)
     bus = _AutoApproveInterventionBus()
     ctx = _make_op_ctx(tmp_path, resolver, bus, decl)
+    collected = collect_events(ctx.events)
 
     op = MCPInstallIROp(
         kind="mcp_install",
@@ -478,7 +481,7 @@ def test_event_emitted_on_success(tmp_path, monkeypatch):
 
     assert result["status"] == "ok"
 
-    events = ctx.events.all()
+    events = collected
     install_events = [e for e in events if e.type == "mcp_server_installed"]
     assert install_events, "expected mcp_server_installed event"
 

--- a/tests/test_mcp_progress_and_timeout.py
+++ b/tests/test_mcp_progress_and_timeout.py
@@ -37,6 +37,7 @@ import pytest
 from reyn.core.events.events import EventLog
 from reyn.mcp.client import MCPClient
 from reyn.schemas.models import MCPIROp
+from tests._support.events import collect_events
 
 
 class _StubPool:
@@ -217,6 +218,7 @@ def test_op_handler_progress_callback_emits_mcp_progress_event() -> None:
     from reyn.security.permissions.permissions import PermissionDecl
 
     events = EventLog()
+    collected = collect_events(events)
     ctx = OpContext(
         workspace=None,  # type: ignore[arg-type]
         events=events,
@@ -235,7 +237,7 @@ def test_op_handler_progress_callback_emits_mcp_progress_event() -> None:
     # At least two mcp_progress events should have been emitted with the
     # structured fields the forwarder consumes.
     progress_events = [
-        e.model_dump(mode="json") for e in events.all()
+        e.model_dump(mode="json") for e in collected
         if e.type == "mcp_progress"
     ]
     assert progress_events, "expected mcp_progress events to be emitted"

--- a/tests/test_mcp_source_install.py
+++ b/tests/test_mcp_source_install.py
@@ -189,6 +189,7 @@ from reyn.core.op_runtime.mcp_install import handle as mcp_install_handle
 from reyn.schemas.models import MCPInstallIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 from reyn.user_intervention import InterventionAnswer, UserIntervention
+from tests._support.events import collect_events
 
 
 class _AutoApproveInterventionBus:
@@ -343,6 +344,7 @@ def test_source_event_includes_source_field(tmp_path, monkeypatch):
     decl = _phase5_source_install_decl(resolver)
     bus = _AutoApproveInterventionBus()
     ctx = _make_op_ctx(tmp_path, resolver, bus, decl)
+    collected = collect_events(ctx.events)
 
     source_spec = "npm:@modelcontextprotocol/server-filesystem"
     op = MCPInstallIROp(
@@ -355,7 +357,7 @@ def test_source_event_includes_source_field(tmp_path, monkeypatch):
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/npx")
     _run(mcp_install_handle(op, ctx))
 
-    events = ctx.events.all()
+    events = collected
     install_events = [e for e in events if e.type == "mcp_server_installed"]
     assert install_events, "Expected mcp_server_installed event"
     evt = install_events[0]

--- a/tests/test_memory_service_invariants.py
+++ b/tests/test_memory_service_invariants.py
@@ -24,6 +24,7 @@ import pytest
 from reyn.config.chat import ThreatScanConfig
 from reyn.core.events.events import EventLog
 from reyn.runtime.services.memory_service import MemoryService
+from tests._support.events import collect_events
 
 # ---------------------------------------------------------------------------
 # Helpers — thin closure-based fakes for file callbacks
@@ -133,10 +134,11 @@ def _make_service(
     *,
     threat_scan=None,
     knowledge_sync=None,
-) -> tuple[MemoryService, EventLog]:
+) -> tuple[MemoryService, list]:
     """Construct a MemoryService with real EventLog and closure-based file
     callbacks rooted at *tmp_path*."""
     events = EventLog()
+    collected = collect_events(events)
     fw, fr, fd, fri = _make_callbacks(tmp_path)
     svc = MemoryService(
         agent_workspace_dir=tmp_path / "agents" / "test_agent",
@@ -148,7 +150,7 @@ def _make_service(
         threat_scan=threat_scan,
         knowledge_sync=knowledge_sync,
     )
-    return svc, events
+    return svc, collected
 
 
 # ---------------------------------------------------------------------------
@@ -282,7 +284,7 @@ async def test_poisoned_remember_is_rejected_and_nothing_is_persisted(
     assert not (Path(svc.memory_dir("agent")) / "MEMORY.md").exists()
     assert result["error"]["kind"] == "threat_blocked"
     assert result["error"]["pattern_id"]
-    assert "threat_block" in [e.type for e in events.all()]
+    assert "threat_block" in [e.type for e in events]
 
 
 @pytest.mark.asyncio
@@ -302,7 +304,7 @@ async def test_legit_remember_is_not_blocked_by_an_enabled_scan(
 
     assert result["saved"] == "ordinary"
     assert Path(svc.memory_path("agent", "ordinary")).exists()
-    assert "threat_block" not in [e.type for e in events.all()]
+    assert "threat_block" not in [e.type for e in events]
 
 
 @pytest.mark.asyncio
@@ -353,7 +355,7 @@ async def test_forget_surfaces_a_knowledge_deindex_failure(tmp_path: Path) -> No
 
 @pytest.mark.asyncio
 async def test_events_emitted_for_remember_and_forget(tmp_path: Path) -> None:
-    """Tier 2: remember emits memory_saved; forget emits memory_deleted. Read via EventLog.all()."""
+    """Tier 2: remember emits memory_saved; forget emits memory_deleted. Read via collect_events()."""
     svc, events = _make_service(tmp_path)
 
     await svc.remember(
@@ -365,18 +367,18 @@ async def test_events_emitted_for_remember_and_forget(tmp_path: Path) -> None:
         body="content",
     )
 
-    emitted = [e.type for e in events.all()]
+    emitted = [e.type for e in events]
     assert "memory_saved" in emitted
 
-    saved_event = next(e for e in events.all() if e.type == "memory_saved")
+    saved_event = next(e for e in events if e.type == "memory_saved")
     assert saved_event.data["slug"] == "evt-test"
     assert saved_event.data["layer"] == "agent"
 
     await svc.forget(layer="agent", slug="evt-test")
 
-    emitted_after = [e.type for e in events.all()]
+    emitted_after = [e.type for e in events]
     assert "memory_deleted" in emitted_after
 
-    deleted_event = next(e for e in events.all() if e.type == "memory_deleted")
+    deleted_event = next(e for e in events if e.type == "memory_deleted")
     assert deleted_event.data["slug"] == "evt-test"
     assert deleted_event.data["layer"] == "agent"

--- a/tests/test_model_budget.py
+++ b/tests/test_model_budget.py
@@ -22,6 +22,7 @@ from reyn.llm.model_budget import (
     get_max_input_tokens,
     get_max_input_tokens_source,
 )
+from tests._support.events import collect_events
 
 
 def test_known_model_returns_positive_int() -> None:
@@ -41,12 +42,13 @@ def test_unknown_model_returns_fallback() -> None:
 def test_fallback_emits_observability_event() -> None:
     """Tier 2: fallback for an unknown model emits model_budget_fallback event (P6)."""
     events = EventLog()
+    collected = collect_events(events)
     # Use a unique model name to avoid being filtered by the process-global
     # "warned_models" set from other tests — suffix with a unique token.
     model = "unknown/test-only-fallback-event-model-abc123"
     get_max_input_tokens(model, events=events, phase="test_phase", run_id="run-1")
 
-    fallback_events = [e for e in events.all() if e.type == "model_budget_fallback"]
+    fallback_events = [e for e in collected if e.type == "model_budget_fallback"]
     assert len(fallback_events) >= 1
     ev = fallback_events[0]
     assert ev.data["model"] == model
@@ -90,8 +92,9 @@ def test_prefix_strip_resolution_emits_no_fallback_event() -> None:
     if get_max_input_tokens(_BARE) == _FALLBACK_MAX_INPUT_TOKENS:
         pytest.skip(f"litellm catalog lacks {_BARE!r} in this env")
     events = EventLog()
+    collected = collect_events(events)
     get_max_input_tokens(f"openai/{_BARE}", events=events)
-    assert not [e for e in events.all() if e.type == "model_budget_fallback"]
+    assert not [e for e in collected if e.type == "model_budget_fallback"]
 
 
 def test_unknown_prefixed_model_still_falls_back() -> None:
@@ -99,11 +102,12 @@ def test_unknown_prefixed_model_still_falls_back() -> None:
     keeps the 128K fallback — prefix-strip only improves resolution, never hides
     a genuinely-unknown model."""
     events = EventLog()
+    collected = collect_events(events)
     model = "openai/totally-made-up-proxy-model-1162-xyz"
     result = get_max_input_tokens(model, events=events)
     assert result == _FALLBACK_MAX_INPUT_TOKENS
     # the fallback event still fires for the genuinely-unknown model (unchanged).
-    assert [e for e in events.all() if e.type == "model_budget_fallback"]
+    assert [e for e in collected if e.type == "model_budget_fallback"]
 
 
 def test_source_for_cataloged_model_names_litellm() -> None:

--- a/tests/test_op_embed.py
+++ b/tests/test_op_embed.py
@@ -19,6 +19,7 @@ from reyn.data.embedding.provider import EmbedBatchResult
 from reyn.data.workspace.workspace import Workspace
 from reyn.schemas.models import ALL_OP_KINDS, OP_KIND_MODEL_MAP, EmbedIROp, Op
 from reyn.security.permissions.permissions import PermissionDecl
+from tests._support.events import collect_events
 
 # ---------------------------------------------------------------------------
 # Fake provider (real EmbeddingProvider-protocol instance, not a mock)
@@ -178,6 +179,7 @@ async def test_embed_pre_embed_redaction_seam_fires_on_a_secret(
     monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: fake)
 
     ctx = _make_ctx(tmp_path)
+    collected = collect_events(ctx.events)
     secret_text = 'api_key = "abcdefghijklmnopqrstuvwxyz123456"'
     op = EmbedIROp(kind="embed", texts=[secret_text, "harmless text"], embedding_model="standard")
     result = await execute_op(op, ctx)
@@ -190,7 +192,7 @@ async def test_embed_pre_embed_redaction_seam_fires_on_a_secret(
     # the harmless text is untouched
     assert fake.received_texts[1] == "harmless text"
     # the seam firing is observable (P6 audit-event trace)
-    assert any(e.type == "embed_secret_redacted" for e in ctx.events.all())
+    assert any(e.type == "embed_secret_redacted" for e in collected)
 
 
 # ---------------------------------------------------------------------------
@@ -222,12 +224,13 @@ async def test_embed_no_redaction_event_when_no_secret_present(
     monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: fake)
 
     ctx = _make_ctx(tmp_path)
+    collected = collect_events(ctx.events)
     op = EmbedIROp(kind="embed", texts=["just some ordinary sentence"], embedding_model="standard")
     result = await execute_op(op, ctx)
 
     assert result.get("status") != "error", result
     assert fake.received_texts == ["just some ordinary sentence"]
-    assert not any(e.type == "embed_secret_redacted" for e in ctx.events.all())
+    assert not any(e.type == "embed_secret_redacted" for e in collected)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_op_index_drop.py
+++ b/tests/test_op_index_drop.py
@@ -20,6 +20,7 @@ from reyn.data.index.source_manifest import SourceEntry, get_source_manifest
 from reyn.data.workspace.workspace import Workspace
 from reyn.schemas.models import IndexDropIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from tests._support.events import collect_events
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -145,6 +146,7 @@ async def test_drop_emits_p6_event(tmp_path: Path, monkeypatch: pytest.MonkeyPat
         await _seed(tmp_path, "audit_src")
 
         events = EventLog()
+        collected = collect_events(events)
         ws = Workspace(events=events)
         resolver = _resolver(tmp_path, config={"index_drop": "allow"})
         ctx = OpContext(
@@ -158,8 +160,8 @@ async def test_drop_emits_p6_event(tmp_path: Path, monkeypatch: pytest.MonkeyPat
         op = IndexDropIROp(kind="index_drop", source="audit_src")
         await execute_op(op, ctx)
 
-        # Verify event was emitted (EventLog.all() returns Event objects with .type)
-        event_types = [e.type for e in events.all()]
+        # Verify event was emitted (collect_events() returns Event objects with .type)
+        event_types = [e.type for e in collected]
         assert "index_dropped" in event_types
     finally:
         os.environ.pop("REYN_INDEX_DROP_AUTO_APPROVE", None)

--- a/tests/test_op_index_update.py
+++ b/tests/test_op_index_update.py
@@ -22,6 +22,7 @@ from reyn.data.index.backends.sqlite import SqliteIndexBackend
 from reyn.data.workspace.workspace import Workspace
 from reyn.schemas.models import IndexUpdateIROp
 from reyn.security.permissions.permissions import PermissionDecl
+from tests._support.events import collect_events
 
 # ---------------------------------------------------------------------------
 # Fake provider
@@ -309,6 +310,7 @@ async def test_index_update_cost_warning_fires_over_threshold(
     monkeypatch.setattr(_config_mod, "load_config", lambda *a, **kw: _FakeReynConfig())
 
     ctx = _make_ctx(tmp_path)
+    collected = collect_events(ctx.events)
     op = IndexUpdateIROp(
         kind="index_update", source="docs",
         chunks=[
@@ -322,7 +324,7 @@ async def test_index_update_cost_warning_fires_over_threshold(
     assert result["cost_warning"] is not None
     assert result["cost_warning"]["chunk_count"] == 2
     assert result["cost_warning"]["threshold"] == 1
-    assert any(e.type == "index_update_cost_warning" for e in ctx.events.all())
+    assert any(e.type == "index_update_cost_warning" for e in collected)
 
 
 @pytest.mark.asyncio
@@ -336,6 +338,7 @@ async def test_index_update_no_cost_warning_under_threshold(
     monkeypatch.chdir(tmp_path)
 
     ctx = _make_ctx(tmp_path)
+    collected = collect_events(ctx.events)
     op = IndexUpdateIROp(
         kind="index_update", source="docs",
         chunks=[_chunk("chunk a", "ha", "a.md")],
@@ -344,7 +347,7 @@ async def test_index_update_no_cost_warning_under_threshold(
 
     assert result.get("status") != "error", result
     assert result["cost_warning"] is None
-    assert not any(e.type == "index_update_cost_warning" for e in ctx.events.all())
+    assert not any(e.type == "index_update_cost_warning" for e in collected)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_op_runtime_load_skill_3247.py
+++ b/tests/test_op_runtime_load_skill_3247.py
@@ -1,16 +1,12 @@
-"""Tier 2: the dedicated `load_skill` op (FP-0066 P0, #3247) — extracted OUT
-of `file.read`'s former `is_skill_body_path` special-case.
+"""Tier 2: the dedicated `load_skill` op (FP-0066 P0, #3247) — the current
+home for `file.handle` + `FileIROp` SKILL.md integration coverage
+(#3196/#3198 provenance + allowlist witnesses): these tests construct
+`LoadSkillIROp` and call `reyn.core.op_runtime.load_skill.handle` directly.
+The pure-function tests (`load_skill_body` / `is_skill_body_path` /
+`resolve_plugin_root`) live in `tests/plugins/test_skill_load.py` — a
+separate module, unaffected by which op handles the SKILL.md-path case.
 
-Moved here from `tests/plugins/test_skill_load.py`'s integration section
-(the `file.handle` + `FileIROp` tests, #3196/#3198 provenance + allowlist
-witnesses) — those tests now construct `LoadSkillIROp` and call
-`reyn.core.op_runtime.load_skill.handle` directly instead. The pure-function
-tests (`load_skill_body` / `is_skill_body_path` / `resolve_plugin_root`)
-stayed in `tests/plugins/test_skill_load.py` unchanged — this extraction
-did not touch those functions' own signatures or behavior, only WHO calls
-them.
-
-Also pins the STRIP-FALSIFY half of the extraction (#3247): a `file.read` of
+Also pins the STRIP-FALSIFY half of `load_skill`'s design (#3247): a `file.read` of
 a `SKILL.md` path — even a REGISTERED one — is now a PLAIN read, byte-
 identical, no expansion, no `skill_body_loaded` event. This is the structural
 proof that the responsibility actually LEFT `file.py`, not just that
@@ -34,6 +30,7 @@ from reyn.data.skills.registry import SkillEntry
 from reyn.data.workspace.workspace import Workspace
 from reyn.schemas.models import FileIROp, LoadSkillIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from tests._support.events import collect_events
 
 
 def _run(coro):
@@ -68,7 +65,7 @@ def _make_ctx(
     return ctx, events
 
 
-def _assert_not_expanded(result: dict, events: EventLog, monkeypatch) -> None:
+def _assert_not_expanded(result: dict, collected: list, monkeypatch) -> None:
     """Shared negative-witness assertion: the RAW token survives (never
     blanked, never resolved), and no skill_body_loaded event fires."""
     monkeypatch.setenv(_SENTINEL_ENV_VAR, _SENTINEL_ENV_VALUE)
@@ -78,7 +75,7 @@ def _assert_not_expanded(result: dict, events: EventLog, monkeypatch) -> None:
         "survive UNEXPANDED"
     )
     assert _SENTINEL_ENV_VALUE not in result["content"]
-    assert not [e for e in events.all() if e.type == "skill_body_loaded"]
+    assert not [e for e in collected if e.type == "skill_body_loaded"]
 
 
 @pytest.mark.parametrize(
@@ -102,10 +99,11 @@ def test_load_skill_does_not_expand_unregistered_skill_md(tmp_path, monkeypatch,
     skill_path.write_text(_SENTINEL_BODY, encoding="utf-8")
     rel_path = str(skill_path.relative_to(project_root))
     ctx, events = _make_ctx(project_root)  # available_skills=None -- nothing registered
+    collected = collect_events(events)
 
     result = _run(load_skill_handle(LoadSkillIROp(kind="load_skill", path=rel_path), ctx))
 
-    _assert_not_expanded(result, events, monkeypatch)
+    _assert_not_expanded(result, collected, monkeypatch)
 
 
 def test_load_skill_does_not_expand_unregistered_plugin_root(tmp_path, monkeypatch):
@@ -130,6 +128,7 @@ def test_load_skill_does_not_expand_unregistered_plugin_root(tmp_path, monkeypat
     project_root = tmp_path / "project-root-real"
     project_root.mkdir()
     events = EventLog()
+    collected = collect_events(events)
     resolver = PermissionResolver(
         config_permissions={}, project_root=project_root, interactive=False,
     )
@@ -148,7 +147,7 @@ def test_load_skill_does_not_expand_unregistered_plugin_root(tmp_path, monkeypat
 
     result = _run(load_skill_handle(LoadSkillIROp(kind="load_skill", path=str(skill_path)), ctx))
 
-    _assert_not_expanded(result, events, monkeypatch)
+    _assert_not_expanded(result, collected, monkeypatch)
 
 
 def test_load_skill_expands_config_registered_skill_md(tmp_path, monkeypatch):
@@ -166,13 +165,14 @@ def test_load_skill_expands_config_registered_skill_md(tmp_path, monkeypatch):
     rel_path = str(skill_path.relative_to(project_root))
     entry = SkillEntry(name="greeter", description="d", path=rel_path)
     ctx, events = _make_ctx(project_root, available_skills=[entry])
+    collected = collect_events(events)
 
     result = _run(load_skill_handle(LoadSkillIROp(kind="load_skill", path=rel_path), ctx))
 
     assert result["status"] == "ok", result
     assert f"secret={_SENTINEL_ENV_VALUE}" in result["content"]
 
-    skill_load_events = [e for e in events.all() if e.type == "skill_body_loaded"]
+    skill_load_events = [e for e in collected if e.type == "skill_body_loaded"]
     assert skill_load_events, "expected a skill_body_loaded audit-event to be emitted"
     event = next(e for e in skill_load_events if e.data["path"] == rel_path)
     assert event.data["provenance"] == "config_entry"
@@ -196,6 +196,7 @@ def test_load_skill_config_registered_skill_md_env_denied_by_default(tmp_path, m
     rel_path = str(skill_path.relative_to(project_root))
     entry = SkillEntry(name="greeter", description="d", path=rel_path)
     ctx, events = _make_ctx(project_root, available_skills=[entry], env_expand=())
+    collected = collect_events(events)
 
     result = _run(load_skill_handle(LoadSkillIROp(kind="load_skill", path=rel_path), ctx))
 
@@ -203,7 +204,7 @@ def test_load_skill_config_registered_skill_md_env_denied_by_default(tmp_path, m
     assert f"secret=${{env:{_SENTINEL_ENV_VAR}}}" in result["content"]
     assert _SENTINEL_ENV_VALUE not in result["content"]
 
-    skill_load_events = [e for e in events.all() if e.type == "skill_body_loaded"]
+    skill_load_events = [e for e in collected if e.type == "skill_body_loaded"]
     event = next(e for e in skill_load_events if e.data["path"] == rel_path)
     assert event.data["provenance"] == "config_entry"  # provenance gate still passed
     assert event.data["env_tokens_expanded"] == 0
@@ -234,12 +235,13 @@ def test_load_skill_symlink_judged_by_resolved_target_not_literal_path(tmp_path,
     rel_symlink_path = str(symlink_path.relative_to(project_root))
 
     ctx, events = _make_ctx(project_root, available_skills=[entry])
+    collected = collect_events(events)
 
     result = _run(load_skill_handle(LoadSkillIROp(kind="load_skill", path=rel_symlink_path), ctx))
 
     assert result["status"] == "ok", result
     assert f"secret={_SENTINEL_ENV_VALUE}" in result["content"]
-    skill_load_events = [e for e in events.all() if e.type == "skill_body_loaded"]
+    skill_load_events = [e for e in collected if e.type == "skill_body_loaded"]
     assert any(e.data["provenance"] == "config_entry" for e in skill_load_events)
 
 
@@ -255,6 +257,7 @@ def test_load_skill_dotdot_path_judged_by_resolved_target(tmp_path, monkeypatch)
     rel_path = str(skill_path.relative_to(project_root))
     entry = SkillEntry(name="greeter", description="d", path=rel_path)
     ctx, events = _make_ctx(project_root, available_skills=[entry])
+    collected = collect_events(events)
 
     dotdot_path = "skills/other-skill-name/../greeter/SKILL.md"
 
@@ -262,7 +265,7 @@ def test_load_skill_dotdot_path_judged_by_resolved_target(tmp_path, monkeypatch)
 
     assert result["status"] == "ok", result
     assert f"secret={_SENTINEL_ENV_VALUE}" in result["content"]
-    skill_load_events = [e for e in events.all() if e.type == "skill_body_loaded"]
+    skill_load_events = [e for e in collected if e.type == "skill_body_loaded"]
     assert any(e.data["provenance"] == "config_entry" for e in skill_load_events)
 
 
@@ -291,6 +294,7 @@ def test_load_skill_resolves_path_exactly_once_per_call(tmp_path, monkeypatch):
     rel_path = str(skill_path.relative_to(project_root))
     entry = SkillEntry(name="greeter", description="d", path=rel_path)
     ctx, events = _make_ctx(project_root, available_skills=[entry])
+    collected = collect_events(events)
 
     calls: list[str] = []
     real_resolve_path_for_gate = load_skill_module.resolve_path_for_gate
@@ -308,7 +312,7 @@ def test_load_skill_resolves_path_exactly_once_per_call(tmp_path, monkeypatch):
         f"expected `op.path` to be resolved exactly ONCE (for {rel_path!r}) "
         f"for this load, got these resolve call(s): {calls!r}"
     )
-    skill_load_events = [e for e in events.all() if e.type == "skill_body_loaded"]
+    skill_load_events = [e for e in collected if e.type == "skill_body_loaded"]
     assert any(e.data["provenance"] == "config_entry" for e in skill_load_events)
 
 
@@ -323,12 +327,13 @@ def test_load_skill_does_not_expand_non_skill_md_file(tmp_path):
     other_path = project_root / "notes.md"
     other_path.write_text("Project: ${REYN_PROJECT_DIR}\n", encoding="utf-8")
     ctx, events = _make_ctx(project_root)
+    collected = collect_events(events)
 
     result = _run(load_skill_handle(LoadSkillIROp(kind="load_skill", path="notes.md"), ctx))
 
     assert result["status"] == "ok", result
     assert "Project: ${REYN_PROJECT_DIR}" in result["content"]
-    assert not [e for e in events.all() if e.type == "skill_body_loaded"]
+    assert not [e for e in collected if e.type == "skill_body_loaded"]
 
 
 def test_plugin_install_bakes_plugin_root_load_skill_resolves_the_rest(tmp_path, monkeypatch):
@@ -373,6 +378,7 @@ def test_plugin_install_bakes_plugin_root_load_skill_resolves_the_rest(tmp_path,
             str(project_root / ".reyn" / "config" / cfg), "test", "file.write",
         )
     events = EventLog()
+    collected = collect_events(events)
     ws = Workspace(
         events=events, base_dir=project_root,
         permission_resolver=resolver, actor="test",
@@ -410,7 +416,7 @@ def test_plugin_install_bakes_plugin_root_load_skill_resolves_the_rest(tmp_path,
     assert f"skill={skill_path.parent.resolve()}" in content
     assert f"project={project_root.resolve()}" in content
     assert "${REYN_SKILL_DIR}" not in content
-    plugin_events = [e for e in events.all() if e.type == "skill_body_loaded"]
+    plugin_events = [e for e in collected if e.type == "skill_body_loaded"]
     assert any(e.data.get("provenance") == "plugin" for e in plugin_events)
     assert "${REYN_PROJECT_DIR}" not in content
 
@@ -434,6 +440,7 @@ def test_file_read_never_expands_a_skill_md_even_when_registered(tmp_path, monke
     rel_path = str(skill_path.relative_to(project_root))
     entry = SkillEntry(name="greeter", description="d", path=rel_path)
     ctx, events = _make_ctx(project_root, available_skills=[entry])
+    collected = collect_events(events)
 
     result = _run(file_handle(FileIROp(kind="file", op="read", path=rel_path), ctx))
 
@@ -443,7 +450,7 @@ def test_file_read_never_expands_a_skill_md_even_when_registered(tmp_path, monke
         "expansion pass moved to load_skill and must not run here"
     )
     assert _SENTINEL_ENV_VALUE not in result["content"]
-    assert not [e for e in events.all() if e.type == "skill_body_loaded"], (
+    assert not [e for e in collected if e.type == "skill_body_loaded"], (
         "file.read must never emit skill_body_loaded -- that responsibility "
         "belongs exclusively to the load_skill op now"
     )

--- a/tests/test_op_semantic_search.py
+++ b/tests/test_op_semantic_search.py
@@ -23,6 +23,7 @@ from reyn.data.index.backends.sqlite import SqliteIndexBackend
 from reyn.data.workspace.workspace import Workspace
 from reyn.schemas.models import SemanticSearchIROp
 from reyn.security.permissions.permissions import PermissionDecl
+from tests._support.events import collect_events
 
 # ---------------------------------------------------------------------------
 # Fake provider
@@ -249,6 +250,7 @@ async def test_recall_embed_failure_falls_back(tmp_path: Path, monkeypatch: pyte
     monkeypatch.chdir(tmp_path)
 
     ctx = _make_ctx(tmp_path)
+    collected = collect_events(ctx.events)
     op = SemanticSearchIROp(
         kind="semantic_search", query="q", sources=["s1"], top_k=5, embedding_model="standard",
     )
@@ -256,7 +258,7 @@ async def test_recall_embed_failure_falls_back(tmp_path: Path, monkeypatch: pyte
 
     assert result["chunks"] == []
     assert result["mode"] == "fallback"
-    assert any(e.type == "semantic_search_embed_failed" for e in ctx.events.all())
+    assert any(e.type == "semantic_search_embed_failed" for e in collected)
 
 
 # ---------------------------------------------------------------------------
@@ -476,6 +478,7 @@ async def test_semantic_search_query_embed_redacts_secret_at_egress(
     await _seed(tmp_path, "docs", [_chunk("some chunk", [1.0, 0.0, 0.0], "c1")])
 
     ctx = _make_ctx(tmp_path)
+    collected = collect_events(ctx.events)
     # A secret-shaped query (matches the FP-0050 redact_secrets patterns —
     # same shape as tests/test_op_embed.py's PRE-embed seam test).
     secret_query = 'api_key = "abcdefghijklmnopqrstuvwxyz123456"'
@@ -492,4 +495,4 @@ async def test_semantic_search_query_embed_redacts_secret_at_egress(
     assert "REDACTED" in fake.received_texts[0]
     # The seam firing on the QUERY path is observable (P6 audit-event) —
     # mirrors index_update's ingestion redaction.
-    assert any(e.type == "embed_secret_redacted" for e in ctx.events.all())
+    assert any(e.type == "embed_secret_redacted" for e in collected)

--- a/tests/test_pending_intervention_268.py
+++ b/tests/test_pending_intervention_268.py
@@ -50,6 +50,7 @@ from reyn.user_intervention import (
     UserIntervention,
 )
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 # ── 1. UserIntervention origin_channel_id field ───────────────────────
 
@@ -294,6 +295,7 @@ def test_handle_intervention_emits_user_channel_stalled_route_event() -> None:
     distinct from the regular ``"user_channel"`` route event.
     """
     session = make_session(agent_name="test")
+    collected = collect_events(session._audit_events)
     session.register_intervention_listener("tui:current")
 
     async def _drive() -> None:
@@ -311,7 +313,7 @@ def test_handle_intervention_emits_user_channel_stalled_route_event() -> None:
     asyncio.run(_drive())
 
     routed_events = [
-        e for e in session._audit_events.to_json()
+        e for e in [ev.model_dump(mode="json") for ev in collected]
         if e.get("type") == "intervention_routed"
     ]
     assert routed_events
@@ -362,6 +364,7 @@ def test_discard_pending_intervention_emits_audit_event_on_success() -> None:
     trail when the iv was actually discarded.
     """
     session = make_session(agent_name="test")
+    collected = collect_events(session._audit_events)
     session.register_intervention_listener("tui:current")
 
     async def _drive() -> None:
@@ -382,7 +385,7 @@ def test_discard_pending_intervention_emits_audit_event_on_success() -> None:
     asyncio.run(_drive())
 
     discarded = [
-        e for e in session._audit_events.to_json()
+        e for e in [ev.model_dump(mode="json") for ev in collected]
         if e.get("type") == "pending_intervention_discarded"
     ]
     assert discarded

--- a/tests/test_permission_denied_audit.py
+++ b/tests/test_permission_denied_audit.py
@@ -14,7 +14,8 @@ Additional P6 invariants:
 Design note:
   - ``execute_op`` catches PermissionError from handlers and emits
     ``permission_denied`` (kind, path, reason) before returning status="denied".
-  - ``EventLog.all()`` is the public observation surface (P6).
+  - ``collect_events`` (a real ``add_subscriber`` collector) is the public
+    observation surface (P6).
   - File existence / absence on ``tmp_path`` is the public workspace
     observation surface (P5).
   - No unittest.mock, no private-state assertions.
@@ -30,6 +31,7 @@ from reyn.core.op_runtime.context import OpContext
 from reyn.data.workspace.workspace import Workspace
 from reyn.schemas.models import FileIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from tests._support.events import collect_events
 
 # ── helpers ────────────────────────────────────────────────────────────────────
 
@@ -110,6 +112,7 @@ def test_permission_denied_emits_p6_event(tmp_path, monkeypatch):
     """
     monkeypatch.chdir(tmp_path)
     events = EventLog()
+    collected = collect_events(events)
     resolver = _make_resolver(tmp_path)
     ctx = _make_ctx(tmp_path, events, resolver=resolver)
 
@@ -118,9 +121,9 @@ def test_permission_denied_emits_p6_event(tmp_path, monkeypatch):
 
     _run(execute_op(op, ctx))
 
-    denial_events = [e for e in events.all() if e.type == "permission_denied"]
+    denial_events = [e for e in collected if e.type == "permission_denied"]
     assert denial_events, (
-        f"expected at least one permission_denied event; got: {[e.type for e in events.all()]}"
+        f"expected at least one permission_denied event; got: {[e.type for e in collected]}"
     )
 
 
@@ -135,6 +138,7 @@ def test_permission_denied_event_carries_op_kind(tmp_path, monkeypatch):
     """
     monkeypatch.chdir(tmp_path)
     events = EventLog()
+    collected = collect_events(events)
     resolver = _make_resolver(tmp_path)
     ctx = _make_ctx(tmp_path, events, resolver=resolver)
 
@@ -143,7 +147,7 @@ def test_permission_denied_event_carries_op_kind(tmp_path, monkeypatch):
 
     _run(execute_op(op, ctx))
 
-    denial_events = [e for e in events.all() if e.type == "permission_denied"]
+    denial_events = [e for e in collected if e.type == "permission_denied"]
     assert denial_events, "permission_denied event must be emitted"
     assert denial_events[0].data.get("kind") == "file", (
         f"expected kind='file' in event data, got: {denial_events[0].data}"
@@ -162,6 +166,7 @@ def test_permission_allow_then_deny_only_first_executes(tmp_path, monkeypatch):
     """
     monkeypatch.chdir(tmp_path)
     events = EventLog()
+    collected = collect_events(events)
     # Config grants write everywhere — but absolute external paths are still
     # blocked by Workspace._resolve_write (absolute path check).
     # Use config-allowed write for CWD, default-denied for outside.
@@ -186,13 +191,13 @@ def test_permission_allow_then_deny_only_first_executes(tmp_path, monkeypatch):
     assert not denied_target.exists(), "second (denied) op must not create file"
 
     # P6: at least one denial event (second op was denied)
-    denial_events = [e for e in events.all() if e.type == "permission_denied"]
+    denial_events = [e for e in collected if e.type == "permission_denied"]
     assert denial_events, (
-        f"expected permission_denied event for second op; got: {[e.type for e in events.all()]}"
+        f"expected permission_denied event for second op; got: {[e.type for e in collected]}"
     )
 
     # P6: first op emitted a tool_executed event (audit of successful execution)
-    executed_events = [e for e in events.all() if e.type == "tool_executed"]
+    executed_events = [e for e in collected if e.type == "tool_executed"]
     assert len(executed_events) >= 1, (
         "first allowed op must emit a tool_executed event (P6 audit truth)"
     )
@@ -209,6 +214,7 @@ def test_permission_denied_read_emits_p6_event(tmp_path, monkeypatch):
     """
     monkeypatch.chdir(tmp_path)
     events = EventLog()
+    collected = collect_events(events)
     resolver = _make_resolver(tmp_path)
     ctx = _make_ctx(tmp_path, events, resolver=resolver)
 
@@ -219,9 +225,9 @@ def test_permission_denied_read_emits_p6_event(tmp_path, monkeypatch):
 
     assert result["status"] == "denied"
 
-    denial_events = [e for e in events.all() if e.type == "permission_denied"]
+    denial_events = [e for e in collected if e.type == "permission_denied"]
     assert denial_events, (
-        f"denied read must emit permission_denied event; got: {[e.type for e in events.all()]}"
+        f"denied read must emit permission_denied event; got: {[e.type for e in collected]}"
     )
     assert denial_events[0].data.get("kind") == "file"
 
@@ -237,6 +243,7 @@ def test_allowed_op_emits_no_denial_event(tmp_path, monkeypatch):
     """
     monkeypatch.chdir(tmp_path)
     events = EventLog()
+    collected = collect_events(events)
     resolver = _make_resolver(tmp_path)
     ctx = _make_ctx(tmp_path, events, resolver=resolver)
 
@@ -247,7 +254,7 @@ def test_allowed_op_emits_no_denial_event(tmp_path, monkeypatch):
 
     assert result["status"] == "ok"
 
-    denial_events = [e for e in events.all() if e.type == "permission_denied"]
+    denial_events = [e for e in collected if e.type == "permission_denied"]
     assert not denial_events, (
         f"successful op must emit no permission_denied events; got: {denial_events}"
     )

--- a/tests/test_present_op_fp0054_pra.py
+++ b/tests/test_present_op_fp0054_pra.py
@@ -27,6 +27,7 @@ from reyn.core.present import (
 from reyn.data.workspace.workspace import Workspace
 from reyn.schemas.models import PresentIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from tests._support.events import collect_events
 
 
 def _resolver(tmp_path: Path, config_permissions: dict | None = None) -> PermissionResolver:
@@ -393,12 +394,13 @@ def test_presented_event_carries_required_fields(tmp_path):
     """Tier 1: the presented (P6) event carries the required audit fields incl.
     surface + OS-computed ingested + the drop list."""
     ctx, events = _ctx(tmp_path, _resolver(tmp_path))
+    collected = collect_events(events)
     op = PresentIROp(
         kind="present", data_inline={"a": 1},
         blueprint={"component": "text", "text": {"$bind": "/a"}},
     )
     _run(handle(op, ctx))
-    ev = [e for e in events.all() if e.type == "presented"]
+    ev = [e for e in collected if e.type == "presented"]
     assert ev, "present emitted no presented event"
     d = ev[-1].data
     for field in ("data_ref", "view", "surface", "ingested",
@@ -413,19 +415,20 @@ def test_ingested_is_os_computed_from_prior_read(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     (tmp_path / "ref.json").write_text(json.dumps({"a": 1}))
     ctx, events = _ctx(tmp_path, _resolver(tmp_path))
+    collected = collect_events(events)
 
     op = PresentIROp(
         kind="present", data_ref="ref.json",
         blueprint={"component": "text", "text": {"$bind": "/a"}},
     )
     _run(handle(op, ctx))
-    first = [e for e in events.all() if e.type == "presented"][-1]
+    first = [e for e in collected if e.type == "presented"][-1]
     assert first.data["ingested"] == "none"
 
     # Simulate a prior full read of the ref, then present again → 'full'.
     events.emit("tool_executed", op="read_file", path="ref.json")
     _run(handle(op, ctx))
-    second = [e for e in events.all() if e.type == "presented"][-1]
+    second = [e for e in collected if e.type == "presented"][-1]
     assert second.data["ingested"] == "full"
 
 
@@ -434,13 +437,14 @@ def test_ingested_partial_on_truncated_read(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     (tmp_path / "ref.json").write_text(json.dumps({"a": 1}))
     ctx, events = _ctx(tmp_path, _resolver(tmp_path))
+    collected = collect_events(events)
     events.emit("tool_executed", op="read_file", path="ref.json", truncated=True)
     op = PresentIROp(
         kind="present", data_ref="ref.json",
         blueprint={"component": "text", "text": {"$bind": "/a"}},
     )
     _run(handle(op, ctx))
-    ev = [e for e in events.all() if e.type == "presented"][-1]
+    ev = [e for e in collected if e.type == "presented"][-1]
     assert ev.data["ingested"] == "partial"
 
 
@@ -514,13 +518,14 @@ def test_event_carries_no_content_bytes(tmp_path):
     """Tier 2: the presented event payload carries refs + stats only — the bound
     data values never appear in the audit event (data is durable in the ref)."""
     ctx, events = _ctx(tmp_path, _resolver(tmp_path))
+    collected = collect_events(events)
     secret_value = "UNIQUE_SENTINEL_CONTENT_9f3a"
     op = PresentIROp(
         kind="present", data_inline={"a": secret_value},
         blueprint={"component": "text", "text": {"$bind": "/a"}},
     )
     _run(handle(op, ctx))
-    ev = [e for e in events.all() if e.type == "presented"][-1]
+    ev = [e for e in collected if e.type == "presented"][-1]
     serialized = json.dumps(ev.data)
     assert secret_value not in serialized
 
@@ -539,6 +544,7 @@ def test_view_arg_round_trips_against_the_registry(tmp_path):
         {"component": "text", "text": {"$bind": "/a"}},
     ])
     ctx, events = _ctx(tmp_path, _resolver(tmp_path))
+    collected = collect_events(events)
     ctx.presentation_registry = registry
     op = PresentIROp(kind="present", data_inline={"a": 1}, view="authors")
 
@@ -546,7 +552,7 @@ def test_view_arg_round_trips_against_the_registry(tmp_path):
 
     assert ack["mode"] == "view"
     assert ack["ok"] is True
-    ev = [e for e in events.all() if e.type == "presented"][-1]
+    ev = [e for e in collected if e.type == "presented"][-1]
     assert ev.data["view"] == "authors"
     assert ev.data["mode"] == "view"
 
@@ -556,13 +562,14 @@ def test_inline_blueprint_view_field_is_a_stable_hash(tmp_path):
     identity) is a stable ``blueprint:<hash>`` — never the blueprint bytes
     themselves."""
     ctx, events = _ctx(tmp_path, _resolver(tmp_path))
+    collected = collect_events(events)
     op = PresentIROp(
         kind="present", data_inline={"a": 1},
         blueprint={"component": "text", "text": {"$bind": "/a"}},
     )
     ack = _run(handle(op, ctx))
     assert ack["mode"] == "blueprint"
-    ev = [e for e in events.all() if e.type == "presented"][-1]
+    ev = [e for e in collected if e.type == "presented"][-1]
     assert ev.data["view"].startswith("blueprint:")
 
 
@@ -590,6 +597,7 @@ def test_omitting_view_and_blueprint_routes_to_default_viewer(tmp_path):
     the intended rendering, not a fallback — distinct from the all-missed→fallback
     case, which still carries a note)."""
     ctx, events = _ctx(tmp_path, _resolver(tmp_path))
+    collected = collect_events(events)
     renderer = _RecordingRenderer()
     ctx.presentation_renderer = renderer
     op = PresentIROp(kind="present", data_inline={"author": "amy", "title": "hello"})
@@ -608,7 +616,7 @@ def test_omitting_view_and_blueprint_routes_to_default_viewer(tmp_path):
     surfaced = _all_leaf_text(renderer.rendered[-1])
     assert "amy" in surfaced and "hello" in surfaced
 
-    ev = [e for e in events.all() if e.type == "presented"][-1]
+    ev = [e for e in collected if e.type == "presented"][-1]
     assert ev.data["view"] is None
     assert ev.data["mode"] == "default"
 

--- a/tests/test_present_registry_fp0054_prc.py
+++ b/tests/test_present_registry_fp0054_prc.py
@@ -35,6 +35,7 @@ from reyn.runtime.session_params import PresentationWiring
 from reyn.schemas.models import ALL_OP_KINDS, PresentIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 # A named template (operator config) whose value is a blueprint — the same
 # declarative component tree an inline blueprint is.
@@ -77,6 +78,7 @@ def _ctx(
     renderer: "_RecordingRenderer | None" = None,
 ) -> tuple[OpContext, EventLog]:
     events = EventLog()
+    collected = collect_events(events)
     ws = Workspace(events=events, permission_resolver=_resolver(tmp_path))
     ctx = OpContext(
         workspace=ws,
@@ -87,7 +89,7 @@ def _ctx(
         presentation_registry=registry,
         presentation_renderer=renderer,
     )
-    return ctx, events
+    return ctx, collected
 
 
 def _run(coro):
@@ -214,7 +216,7 @@ def test_registered_template_records_name_in_presented_event(tmp_path: Path) -> 
     registry = build_presentation_registry({"entries": {"authors": {"blueprint": _AUTHORS_TEMPLATE}}})
     ctx, events = _ctx(tmp_path, registry=registry, renderer=_RecordingRenderer())
     _run(handle(PresentIROp(kind="present", data_inline=data, view="authors"), ctx))
-    ev = [e for e in events.all() if e.type == "presented"][-1]
+    ev = [e for e in events if e.type == "presented"][-1]
     assert ev.data["view"] == "authors"
     assert ev.data["bindings_resolved"] >= 1
 
@@ -243,7 +245,7 @@ def test_unknown_template_falls_to_generic_viewer_not_error(tmp_path: Path) -> N
     surfaced = _all_leaf_text(renderer.rendered[-1])
     assert "amy" in surfaced and "hello" in surfaced
     # And the presented event still fired (audit-first).
-    assert [e for e in events.all() if e.type == "presented"]
+    assert [e for e in events if e.type == "presented"]
 
 
 def test_all_bindings_miss_template_falls_to_fallback_viewer(tmp_path: Path) -> None:
@@ -458,16 +460,16 @@ def test_fallback_event_carries_no_content_bytes(tmp_path: Path) -> None:
     ctx, events = _ctx(tmp_path, registry=registry, renderer=_RecordingRenderer())
     _run(handle(PresentIROp(
         kind="present", data_inline={"note": secret}, view="does_not_exist"), ctx))
-    ev = [e for e in events.all() if e.type == "presented"][-1]
+    ev = [e for e in events if e.type == "presented"][-1]
     assert secret not in json.dumps(ev.data)
 
 
 # ── Tier 2 (#2671): fallback_stage disambiguates the audit record ─────────────
 
 
-def _presented(events: EventLog) -> dict:
+def _presented(events: list) -> dict:
     """The newest `presented` event's data payload."""
-    return [e for e in events.all() if e.type == "presented"][-1].data
+    return [e for e in events if e.type == "presented"][-1].data
 
 
 def test_literal_only_view_records_null_fallback_stage(tmp_path: Path) -> None:

--- a/tests/test_present_replay_fp0054_prd.py
+++ b/tests/test_present_replay_fp0054_prd.py
@@ -20,23 +20,25 @@ from reyn.core.present import load_ref_from_disk, replay_presentation
 from reyn.data.workspace.workspace import Workspace
 from reyn.schemas.models import PresentIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from tests._support.events import collect_events
 
 
-def _ctx(tmp_path: Path) -> tuple[OpContext, EventLog]:
+def _ctx(tmp_path: Path) -> tuple[OpContext, list]:
     resolver = PermissionResolver(
         config_permissions={}, project_root=tmp_path, interactive=False,
     )
     events = EventLog()
+    collected = collect_events(events)
     ws = Workspace(events=events, permission_resolver=resolver)
     ctx = OpContext(
         workspace=ws, events=events, permission_decl=PermissionDecl(),
         permission_resolver=resolver, actor="present_replay_test",
     )
-    return ctx, events
+    return ctx, collected
 
 
-def _presented_event(events: EventLog) -> dict:
-    evs = [e for e in events.all() if e.type == "presented"]
+def _presented_event(events: list) -> dict:
+    evs = [e for e in events if e.type == "presented"]
     assert evs, "present emitted no presented event"
     return evs[-1].data
 

--- a/tests/test_responses_api_routing_1678.py
+++ b/tests/test_responses_api_routing_1678.py
@@ -56,6 +56,7 @@ from reyn.llm.llm import (
     _may_need_responses_endpoint,
     recorded_acompletion,
 )
+from tests._support.events import collect_events
 
 
 @pytest.fixture(autouse=True)
@@ -235,6 +236,7 @@ def test_405_still_captures_raw_via_1676(monkeypatch) -> None:
         raise _FakeProviderError("Method Not Allowed", 405)
     monkeypatch.setattr(litellm, "acompletion", _raise_405)
     log = EventLog()
+    collected = collect_events(log)
     set_llm_request_event_log(log)
 
     with pytest.raises(ResponsesEndpointRequiredError):
@@ -243,5 +245,5 @@ def test_405_still_captures_raw_via_1676(monkeypatch) -> None:
             purpose="main", recorder=None,
             extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
         ))
-    (err,) = [e for e in log.all() if e.type == "llm_request_error"]
+    (err,) = [e for e in collected if e.type == "llm_request_error"]
     assert err.data["status_code"] == 405

--- a/tests/test_resummarize_3tier_271.py
+++ b/tests/test_resummarize_3tier_271.py
@@ -31,6 +31,7 @@ from reyn.services.compaction.engine import (
     HistoryChunkToCompact,
     estimate_tokens,
 )
+from tests._support.events import collect_events
 
 _MODEL = "gpt-4o"
 
@@ -41,13 +42,14 @@ def _resp(content: str) -> SimpleNamespace:
     )
 
 
-def _engine(passes: int = 1) -> tuple[CompactionEngine, EventLog]:
+def _engine(passes: int = 1) -> tuple[CompactionEngine, list]:
     events = EventLog()
+    collected = collect_events(events)
     cfg = CompactionConfig(use_chars4_estimate=True, resummarize_passes=passes)
-    return CompactionEngine(_MODEL, events, cfg), events
+    return CompactionEngine(_MODEL, events, cfg), collected
 
 
-def _run(monkeypatch, engine, events, *, compaction_arc: str, resummarize_arc: str):
+def _run(monkeypatch, engine, collected, *, compaction_arc: str, resummarize_arc: str):
     """Monkeypatch litellm.acompletion to script both calls; run compact once."""
     calls = {"compaction": 0, "resummarize": 0}
 
@@ -71,15 +73,15 @@ def _run(monkeypatch, engine, events, *, compaction_arc: str, resummarize_arc: s
         section_token_caps={},
     )
     summary = asyncio.run(engine.compact(chunk))
-    return summary, calls, [e.type for e in events.all()]
+    return summary, calls, [e.type for e in collected]
 
 
 def test_t1_fit_no_resummarize(monkeypatch) -> None:
     """Tier 2: a topic_arc within body_budget is unchanged — no re-summarize, no event."""
-    engine, events = _engine()
+    engine, collected = _engine()
     bb = engine.budgets.body_budget
     arc = "x " * (bb // 2)  # ~bb/2 tokens (chars//4 of "x " repeats) — fits
-    summary, calls, types = _run(monkeypatch, engine, events, compaction_arc=arc, resummarize_arc="short")
+    summary, calls, types = _run(monkeypatch, engine, collected, compaction_arc=arc, resummarize_arc="short")
     assert calls["resummarize"] == 0, "T1 fit must not invoke the re-summarize LLM"
     assert "summary_resummarized" not in types
     assert estimate_tokens(summary.topic_arc, _MODEL, use_chars4=True) <= bb
@@ -87,11 +89,11 @@ def test_t1_fit_no_resummarize(monkeypatch) -> None:
 
 def test_t2_resummarize_fits(monkeypatch) -> None:
     """Tier 2: an overshooting topic_arc is re-summarized (event emitted) and fits."""
-    engine, events = _engine()
+    engine, collected = _engine()
     bb = engine.budgets.body_budget
     big = "word " * (bb * 4)            # ~4·bb tokens — overshoot
     small = "compressed summary " * (bb // 8)  # fits under bb
-    summary, calls, types = _run(monkeypatch, engine, events, compaction_arc=big, resummarize_arc=small)
+    summary, calls, types = _run(monkeypatch, engine, collected, compaction_arc=big, resummarize_arc=small)
     assert calls["resummarize"] == 1, "T2 must invoke the re-summarize LLM once"
     assert "summary_resummarized" in types
     # T2 result fit → no hard-truncate needed.
@@ -105,11 +107,11 @@ def test_t3_floor_when_resummarize_still_overshoots(monkeypatch) -> None:
     The deterministic bound `topic_arc ≤ body_budget` holds even when the LLM
     re-summary itself overshoots — the dead-end-free guarantee is never violated.
     """
-    engine, events = _engine()
+    engine, collected = _engine()
     bb = engine.budgets.body_budget
     big = "word " * (bb * 4)             # overshoot
     still_big = "still too long " * (bb * 2)  # re-summary ALSO overshoots
-    summary, calls, types = _run(monkeypatch, engine, events, compaction_arc=big, resummarize_arc=still_big)
+    summary, calls, types = _run(monkeypatch, engine, collected, compaction_arc=big, resummarize_arc=still_big)
     assert calls["resummarize"] == 1
     assert "summary_resummarized" in types
     assert "body_summary_hard_truncated" in types, "T3 floor must fire when T2 overshoots"
@@ -120,10 +122,10 @@ def test_t3_floor_when_resummarize_still_overshoots(monkeypatch) -> None:
 
 def test_passes_zero_skips_resummarize(monkeypatch) -> None:
     """Tier 2: resummarize_passes=0 skips T2 (straight to the T3 floor = pre-#271)."""
-    engine, events = _engine(passes=0)
+    engine, collected = _engine(passes=0)
     bb = engine.budgets.body_budget
     big = "word " * (bb * 4)
-    summary, calls, types = _run(monkeypatch, engine, events, compaction_arc=big, resummarize_arc="short")
+    summary, calls, types = _run(monkeypatch, engine, collected, compaction_arc=big, resummarize_arc="short")
     assert calls["resummarize"] == 0, "passes=0 must not invoke re-summarize"
     assert "summary_resummarized" not in types
     assert "body_summary_hard_truncated" in types  # T3 floor still bounds it

--- a/tests/test_router_loop_swallow_instrument_187.py
+++ b/tests/test_router_loop_swallow_instrument_187.py
@@ -13,8 +13,8 @@ error type + repr, so any future swallowed loop error is primary-evidence
 outbox message still goes out unchanged — the instrument is additive.
 
 The failure is injected with a real async stub (a Fake that raises) — no
-MagicMock — and the assertion reads the public EventLog surface
-(``_audit_events.all()``), not private state.
+MagicMock — and the assertion reads the public EventLog surface via a real
+``add_subscriber`` (``collect_events``), not private state.
 """
 from __future__ import annotations
 
@@ -22,6 +22,7 @@ import pytest
 
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 
 @pytest.mark.asyncio
@@ -33,6 +34,7 @@ async def test_swallowed_router_loop_exception_emits_p6_event():
     event log even when the outbox only carries a classified summary.
     """
     s = make_session(agent_name="t")
+    collected = collect_events(s._audit_events)
 
     async def _raise_mid_work(text: str, chain_id: str) -> None:
         # Stand-in for the real mid-work crash (final call_llm raising after
@@ -45,7 +47,7 @@ async def test_swallowed_router_loop_exception_emits_p6_event():
     await s._handle_inbox_text("hello", chain_id="c-test")
 
     terminated = [
-        e for e in s._audit_events.all()
+        e for e in collected
         if e.type == "router_loop_terminated_by_exception"
     ]
     assert terminated, (

--- a/tests/test_sandbox_denial_class_2820.py
+++ b/tests/test_sandbox_denial_class_2820.py
@@ -14,6 +14,7 @@ import pytest
 from reyn.core.offload.canonical import sandboxed_exec_to_canonical
 from reyn.security.sandbox.backend import SandboxResult
 from reyn.security.sandbox.denial import DENIAL_FORK, classify_denial
+from tests._support.events import collect_events
 
 # The exact stderr the incident produced (bare ``python3`` → pyenv shim → pyenv
 # forks under (deny process-fork)). Captured, not synthesized.
@@ -124,6 +125,7 @@ async def test_handler_surfaces_denial_class_and_argv0_end_to_end():
     from reyn.security.permissions.permissions import PermissionDecl
 
     events = EventLog()
+    collected = collect_events(events)
     workspace = Workspace(events=events)
     ctx = OpContext(
         workspace=workspace,
@@ -143,7 +145,7 @@ async def test_handler_surfaces_denial_class_and_argv0_end_to_end():
     assert result["denial_class"] == DENIAL_FORK
     assert "argv0_resolved" in result  # present (value may be None if python3 off PATH)
 
-    completed = [e for e in events.all() if e.type == "sandboxed_exec_completed"]
+    completed = [e for e in collected if e.type == "sandboxed_exec_completed"]
     assert completed, "sandboxed_exec_completed not emitted"
     assert completed[0].data.get("denial_class") == DENIAL_FORK
     assert "argv0_resolved" in completed[0].data

--- a/tests/test_serial_tool_dispatch_2344.py
+++ b/tests/test_serial_tool_dispatch_2344.py
@@ -22,6 +22,7 @@ import pytest
 from reyn.core.dispatch.dispatcher import DispatchContext, dispatch_tool
 from reyn.core.events.events import EventLog
 from reyn.runtime.router_loop import RouterLoop
+from tests._support.events import collect_events
 from tests._support.router_loop import FakeRouterHost
 
 
@@ -114,6 +115,7 @@ class _RealEventDispatchLoop(RouterLoop):
         super().__init__(*a, **k)
         self.shared: dict = {"written": False}
         self.event_log = EventLog()
+        self.event_log_collected = collect_events(self.event_log)
 
     async def _dispatch_resolved(
         self, name: str, args: dict, *, raw_name: "str | None" = None,
@@ -132,10 +134,11 @@ class _RealEventDispatchLoop(RouterLoop):
         return await dispatch_tool(name=name, args=args, ctx=dctx, invoker=_invoker)
 
 
-def _tool_event_seq(event_log: EventLog) -> list[tuple[str, str]]:
+def _tool_event_seq(collected: list) -> list[tuple[str, str]]:
     """The (type, tool) sequence from the REAL EventLog's append-order replay source
-    (``all()`` — the same list ``to_json()`` and every append-order consumer iterate)."""
-    return [(e.type, e.data.get("tool")) for e in event_log.all()
+    (the live ``collect_events`` list — the same append order ``to_json()`` and every
+    append-order consumer iterate)."""
+    return [(e.type, e.data.get("tool")) for e in collected
             if e.type in ("tool_called", "tool_returned")]
 
 
@@ -153,7 +156,7 @@ async def test_audit_event_order_is_declaration_order_contiguous(tmp_path):
     loop = _RealEventDispatchLoop(host=FakeRouterHost(), chain_id="chain-2344", max_iterations=5)
     await loop.dispatch([{"name": "write", "args": {}}, {"name": "read", "args": {}}])
 
-    assert _tool_event_seq(loop.event_log) == [
+    assert _tool_event_seq(loop.event_log_collected) == [
         ("tool_called", "write"), ("tool_returned", "write"),
         ("tool_called", "read"), ("tool_returned", "read"),
     ], "real EventLog must append the audit events in contiguous declaration order"
@@ -173,7 +176,7 @@ async def test_replay_reproduces_declaration_order(tmp_path):
     await loop.dispatch([{"name": "write", "args": {}}, {"name": "read", "args": {}}])
 
     # replay = iterate the real EventLog in append order (P6 replay semantics for the audit log).
-    log = _tool_event_seq(loop.event_log)
+    log = _tool_event_seq(loop.event_log_collected)
     boundary = log.index(("tool_called", "read"))  # the tool-call boundary cut
     assert log[:boundary] == [("tool_called", "write"), ("tool_returned", "write")], \
         "the pre-cut prefix replays exactly the completed first call (no straddle)"

--- a/tests/test_session_invariants.py
+++ b/tests/test_session_invariants.py
@@ -44,6 +44,7 @@ from reyn.user_intervention import (
     UserIntervention,
 )
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -1042,6 +1043,7 @@ async def test_peer_no_reply_marker_surfaced_to_user_not_absorbed(
     from reyn.runtime.session import _no_reply_marker
 
     session = _make_session(tmp_path, agent_name="default_agent")
+    audit_collected = collect_events(session._audit_events)
 
     # Inject a no-reply marker as if a specialist peer sent it.
     marker = _no_reply_marker("specialist", "router completed without producing a text reply")
@@ -1083,7 +1085,7 @@ async def test_peer_no_reply_marker_surfaced_to_user_not_absorbed(
     )
 
     # Audit event log must contain peer_reply_failed_surfaced event (P6 audit).
-    audit_event_types = [e.type for e in session._audit_events.all()]
+    audit_event_types = [e.type for e in audit_collected]
     assert "peer_reply_failed_surfaced" in audit_event_types, (
         f"B2-H2: expected 'peer_reply_failed_surfaced' audit event; got: {audit_event_types!r}"
     )
@@ -1123,6 +1125,7 @@ async def test_peer_no_reply_marker_forwarded_upstream_in_pending_chain(
     session = _make_session(
         tmp_path, agent_name="relay_agent", registry=registry
     )
+    audit_collected = collect_events(session._audit_events)
 
     # Manually register a pending chain: relay_agent is waiting on "specialist"
     # for a request that came from "origin_agent".
@@ -1184,7 +1187,7 @@ async def test_peer_no_reply_marker_forwarded_upstream_in_pending_chain(
     )
 
     # Audit event log must contain peer_reply_failed_surfaced event (P6 audit).
-    audit_event_types = [e.type for e in session._audit_events.all()]
+    audit_event_types = [e.type for e in audit_collected]
     assert "peer_reply_failed_surfaced" in audit_event_types, (
         f"B2-H2 relay: expected 'peer_reply_failed_surfaced' audit event; got: {audit_event_types!r}"
     )

--- a/tests/test_skill_invoke_3100.py
+++ b/tests/test_skill_invoke_3100.py
@@ -29,6 +29,7 @@ from reyn.interfaces.skill_invoke import (
     substitute_arguments,
 )
 from reyn.runtime.session_params import CapabilityScope
+from tests._support.events import collect_events
 
 # ── Axis 3: parsing / stacking ──────────────────────────────────────────────
 
@@ -391,6 +392,7 @@ async def test_session_skill_invoke_collision_is_loud(tmp_path):
     session = _session_with_skills(
         tmp_path, [entry], collisions={"shared": ["project", "dynamic"]},
     )
+    collected = collect_events(session._audit_events)
 
     consumed, text = await session._maybe_handle_skill_invoke(":shared go")
     assert consumed is False
@@ -404,7 +406,7 @@ async def test_session_skill_invoke_collision_is_loud(tmp_path):
 
     # (2) a real audit-event was emitted (P6 band member) — read through the
     # session's real EventLog, not a private queue.
-    collision_events = [e for e in session._audit_events.all() if e.type == "skill_invoke_collision"]
+    collision_events = [e for e in collected if e.type == "skill_invoke_collision"]
     assert collision_events, "expected a skill_invoke_collision audit-event to fire"
     assert all(e.data.get("name") == "shared" for e in collision_events)
 

--- a/tests/test_spawn_routing_detached_fail_mode_2708.py
+++ b/tests/test_spawn_routing_detached_fail_mode_2708.py
@@ -47,6 +47,7 @@ from reyn.runtime.session_buses import (
 from reyn.runtime.session_params import PresentationWiring
 from reyn.user_intervention import UserIntervention
 from tests._support.agent_session import make_session
+from tests._support.events import collect_events
 
 
 def _scripted_llm():
@@ -124,6 +125,7 @@ async def test_present_op_via_audit_only_sink_fires_audit_event_and_no_orphan() 
     from reyn.security.permissions.permissions import PermissionDecl
 
     events = EventLog()
+    collected = collect_events(events)
     sink = AuditOnlyPresentationConsumer().sink(object())
     ctx = OpContext(
         workspace=Workspace(events=events), events=events, permission_decl=PermissionDecl(),
@@ -135,7 +137,7 @@ async def test_present_op_via_audit_only_sink_fires_audit_event_and_no_orphan() 
     )
     result = await handle(op, ctx)
     assert result["ok"] is True  # present succeeded (not errored/lost)
-    presented = [e for e in events.all() if e.type == "presented"]
+    presented = [e for e in collected if e.type == "presented"]
     assert presented, "the AuditOnly present did NOT emit a 'presented' audit event — trail lost"
     # The sink's own surface is the null/no-op surface — the visible draw reached no orphan queue.
     assert presented[0].data.get("surface") == [sink.surface_name]
@@ -169,6 +171,7 @@ async def test_ask_user_op_via_audit_only_bridge_returns_typed_refusal() -> None
     from reyn.security.permissions.permissions import PermissionDecl
 
     events = EventLog()
+    collected = collect_events(events)
     ctx = OpContext(
         workspace=Workspace(events=events), events=events, permission_decl=PermissionDecl(),
         intervention_bus=AuditOnlyInterventionBridge().bus(),
@@ -178,7 +181,7 @@ async def test_ask_user_op_via_audit_only_bridge_returns_typed_refusal() -> None
     assert result["status"] == "refused", "ask_user did not surface the typed refusal"
     assert result["reason"] == NO_SURFACE_REFUSAL_REASON
     assert result["answer"] == ""  # never a fabricated non-empty answer
-    received = [e for e in events.all() if e.type == "user_intervention_received"]
+    received = [e for e in collected if e.type == "user_intervention_received"]
     assert any(e.data.get("refused") is True for e in received), (
         "the refusal was not recorded as refused=True — it looked like a normal empty answer"
     )

--- a/tests/test_usage_provenance_3351.py
+++ b/tests/test_usage_provenance_3351.py
@@ -35,6 +35,7 @@ from reyn.core.turn_scope import active_turn
 from reyn.llm.llm import call_llm_tools, recorded_acompletion
 from reyn.llm.pricing import TokenUsage, UsageSource, parse_usage_source
 from reyn.runtime.budget.budget import BudgetLedger, BudgetTracker, CostConfig
+from tests._support.events import collect_events
 
 # Unreachable by any token_counter estimate of the tiny prompt below, so the
 # provider leg cannot pass on an estimate that happens to land nearby.
@@ -218,9 +219,10 @@ def test_the_cost_audit_event_reports_where_the_numbers_came_from(
             _make_streaming_acompletion(provider_reports_usage=reports_usage),
         )
         log = EventLog()
+        collected = collect_events(log)
         set_llm_request_event_log(log)
         _run_turn(tracker, chain_id)
-        event = next(e for e in log.all() if e.type == "llm_response_received")
+        event = next(e for e in collected if e.type == "llm_response_received")
         payload = json.loads(json.dumps(event.data))  # as an audit reader sees it
         missing = required - set(payload)
         assert not missing, f"llm_response_received is missing declared audit fields: {missing}"

--- a/tests/test_web_fetch_failed_event_2110.py
+++ b/tests/test_web_fetch_failed_event_2110.py
@@ -11,7 +11,8 @@ that ``web_fetch_failed`` was emitted would go RED — only ``web_fetch_started`
 would appear in the event log.
 
 Real components:
-- Real ``EventLog`` (public ``.all()`` API — not private state).
+- Real ``EventLog`` observed via ``collect_events`` (a real ``add_subscriber``
+  collector — not private state).
 - Real ``OpContext`` wired with real ``PermissionResolver`` (permission_resolver=None
   skips the per-host gate; the handler reaches the httpx layer and the fake
   transport raises the expected exception).
@@ -34,6 +35,7 @@ import pytest
 from reyn.core.events.events import EventLog
 from reyn.core.op_runtime.web import handle_web_fetch
 from reyn.schemas.models import WebFetchIROp
+from tests._support.events import collect_events
 
 
 def _make_ctx(events: EventLog) -> Any:
@@ -107,13 +109,14 @@ class _RequestErrorStreamCtx:
 def test_failed_web_fetch_timeout_emits_web_fetch_failed(monkeypatch) -> None:
     """Tier 2: a timed-out web_fetch emits a terminal web_fetch_failed event.
 
-    Falsification: without the fix, EventLog.all() would contain only
+    Falsification: without the fix, the collected events would contain only
     ``web_fetch_started`` and NO ``web_fetch_failed`` — the assertion on
     the failed-event types list would be empty → RED.
     """
     monkeypatch.setattr(httpx, "AsyncClient", _TimeoutClient)
 
     events = EventLog()
+    collected = collect_events(events)
     op = WebFetchIROp(kind="web_fetch", url="https://example.com")
     result = asyncio.run(handle_web_fetch(op=op, ctx=_make_ctx(events)))
 
@@ -121,13 +124,13 @@ def test_failed_web_fetch_timeout_emits_web_fetch_failed(monkeypatch) -> None:
     assert result["status"] == "timeout"
     assert result["kind"] == "web_fetch"
 
-    emitted_types = [e.type for e in events.all()]
+    emitted_types = [e.type for e in collected]
 
     # started MUST be present (regression guard)
     assert "web_fetch_started" in emitted_types
 
     # terminal failed event MUST be present — this is the new invariant
-    failed_events = [e for e in events.all() if e.type == "web_fetch_failed"]
+    failed_events = [e for e in collected if e.type == "web_fetch_failed"]
     assert failed_events, (
         "Expected a web_fetch_failed terminal event but none was emitted. "
         f"Emitted: {emitted_types}"
@@ -149,10 +152,11 @@ def test_failed_web_fetch_timeout_no_completed_event(monkeypatch) -> None:
     monkeypatch.setattr(httpx, "AsyncClient", _TimeoutClient)
 
     events = EventLog()
+    collected = collect_events(events)
     op = WebFetchIROp(kind="web_fetch", url="https://example.com")
     asyncio.run(handle_web_fetch(op=op, ctx=_make_ctx(events)))
 
-    emitted_types = [e.type for e in events.all()]
+    emitted_types = [e.type for e in collected]
     assert "web_fetch_completed" not in emitted_types, (
         f"web_fetch_completed must not fire on timeout. Emitted: {emitted_types}"
     )
@@ -170,6 +174,7 @@ def test_failed_web_fetch_request_error_emits_web_fetch_failed(monkeypatch) -> N
     monkeypatch.setattr(httpx, "AsyncClient", _RequestErrorClient)
 
     events = EventLog()
+    collected = collect_events(events)
     op = WebFetchIROp(kind="web_fetch", url="https://example.com")
     result = asyncio.run(handle_web_fetch(op=op, ctx=_make_ctx(events)))
 
@@ -177,10 +182,10 @@ def test_failed_web_fetch_request_error_emits_web_fetch_failed(monkeypatch) -> N
     assert result["status"] == "error"
     assert result["kind"] == "web_fetch"
 
-    emitted_types = [e.type for e in events.all()]
+    emitted_types = [e.type for e in collected]
     assert "web_fetch_started" in emitted_types
 
-    failed_events = [e for e in events.all() if e.type == "web_fetch_failed"]
+    failed_events = [e for e in collected if e.type == "web_fetch_failed"]
     assert failed_events, (
         "Expected a web_fetch_failed terminal event but none was emitted. "
         f"Emitted: {emitted_types}"
@@ -197,10 +202,11 @@ def test_failed_web_fetch_request_error_no_completed_event(monkeypatch) -> None:
     monkeypatch.setattr(httpx, "AsyncClient", _RequestErrorClient)
 
     events = EventLog()
+    collected = collect_events(events)
     op = WebFetchIROp(kind="web_fetch", url="https://example.com")
     asyncio.run(handle_web_fetch(op=op, ctx=_make_ctx(events)))
 
-    emitted_types = [e.type for e in events.all()]
+    emitted_types = [e.type for e in collected]
     assert "web_fetch_completed" not in emitted_types, (
         f"web_fetch_completed must not fire on RequestError. Emitted: {emitted_types}"
     )
@@ -218,11 +224,11 @@ def test_web_fetch_started_precedes_web_fetch_failed(monkeypatch) -> None:
     monkeypatch.setattr(httpx, "AsyncClient", _TimeoutClient)
 
     events = EventLog()
+    collected = collect_events(events)
     op = WebFetchIROp(kind="web_fetch", url="https://example.com")
     asyncio.run(handle_web_fetch(op=op, ctx=_make_ctx(events)))
 
-    all_events = events.all()
-    types = [e.type for e in all_events]
+    types = [e.type for e in collected]
 
     assert "web_fetch_started" in types
     assert "web_fetch_failed" in types


### PR DESCRIPTION
**[e2e-coder]** — part of #3868 (PR-2). architect's design: issue #3868 comment 5229065773.

## What

`collect_events()` — a real `add_subscriber`-based collector (`tests/_support/events.py`), mirroring production's `EventStore`-as-subscriber mechanism — replaces `EventLog.all()`/`.to_json()` reads across the test population, ahead of PR-3 deleting those methods entirely. A test-only "retain history" flag was explicitly rejected by architect's design: it would make tests exercise a code path production never runs, so a green test would stop witnessing production behavior.

**Scope**: 68 files converted mechanically in this PR + 2 `scripts/` consumers and the helper itself in earlier commits on this branch (75 files total on the branch). Population = `src`/`tests`/`scripts` per your #3919 correction. 6 files deliberately deferred (overlap with #3916/PR-B, per your explicit call): `test_2978_deny_always_wins.py`, `test_network_egress_env_completeness_3075.py`, `test_op_sandboxed_exec.py`, `test_sandbox_argv0_resolve_2820.py`, `test_sandbox_model_completion_1339.py`, `test_subprocess_cancel_1470.py`.

## 🔴 Non-conforming hunks — complete enumeration

**1 file, 1 hunk, left unconverted:**

```
tests/test_pipeline_is6_attached.py:631
    driver_events = driver_session.router_host.events.all()
```

Reason: the driver session is spawned dynamically inside `run_pipeline_attached(...)`; its `EventLog` reference is only discoverable AFTER the run completes, from data on the caller's own log. `collect_events` is forward-only (a real subscriber added at call time) — it cannot retroactively capture events from an `EventLog` it never had a reference to before they were emitted. Rewiring via the file's `event_sink` factory hook was considered and rejected: it would merge the driver session's events into a shared list, silently broadening the assertion's current scope beyond what the test's own docstring claims (the driver session's OWN EventLog, not a merged view).

**Everywhere else: 0 non-conforming hunks.**

## Pattern (one before/after; the rest are line-for-line the same shape)

Before (`tests/test_2073_s1_hot_reloader.py`, committed earlier on this branch as the pattern reference):
```python
events = EventLog()
hr = HotReloader(project_root=tmp_path, events=events)
...
assert [e.type for e in events.all()] == []
```

After:
```python
events = EventLog()
collected = collect_events(events)
hr = HotReloader(project_root=tmp_path, events=events)
...
assert [e.type for e in collected] == []
```

`collect_events()` is called immediately after construction, before any `emit()` the assertions observe — it's a real subscriber (like production's `EventStore`), not a history read-back, so it only sees what's emitted from that point forward.

Where the `EventLog` isn't locally constructed (a private attribute like `session._audit_events`, or a fixture/helper-returned `events`/`ctx.events`), the same call is inserted wherever that object first becomes reachable in the relevant scope, verified per-case to resolve to a real `EventLog` — never a guessed placement.

## Mechanical assert-unchanged verification

No assert's logic, threshold, or condition changed anywhere — only the expression each assert reads events FROM (`.all()` → the `collected` variable already holding the same events).

- Every file's own isolated `pytest` pass count is **identical before → after** (recorded per-file, listed in the commit message).
- **Combined run, all 68 files together**: `710 passed, 0 failed`.
- `ruff check`: clean on all 68 files.
- Ran a script classifying every added/removed diff line across all 68 files against the expected shapes (import / `collect_events()` call / `.all()`-or-`.to_json()` removal / a `collected`-derived reference). It flagged 38 added + 51 removed lines it couldn't classify automatically — all turned out to be legitimate variants my classifier was too narrow for (helper-signature type annotations `EventLog` → `list`, parameter/variable renames threaded through call sites, docstring updates describing the new mechanism). Manually read the full `git diff` for a sample of the flagged files (`test_memory_service_invariants.py`, `test_2708_p31_spawn_bridge_present.py`, `test_2708_p32a_spawn_bridge_intervention.py`, `test_resummarize_3tier_271.py`) — every hunk in each is exactly one of: the import line, a `collect_events(...)` call insertion, a rename propagated through a helper signature/call site, or a `.all()`/`.to_json()` read replaced by the already-collected variable. No assert logic changed in any of them. Did not read all 68 files' diffs line-by-line; relying on this sample plus the pass-count-unchanged check plus each batch's own independent grep/ruff sweep for the remainder — flagging this explicitly rather than implying full manual coverage.

## Drive-by fix

`tests/test_op_runtime_load_skill_3247.py`'s module docstring carried pre-existing refactor narrative ("Moved here from `tests/plugins/test_skill_load.py`...") unrelated to this PR's own diff — caught by `verify_module_docstrings.py` while running the gate battery on the touched-file set. Fixed since the file was already open for this PR's edit; reworded to describe current-state test organization rather than the historical move.

## Test plan

- [x] `pytest` across all 68 modified files, combined single invocation — 710 passed, 0 failed.
- [x] `ruff check` — All checks passed! (all 68 files).
- [x] `python scripts/verify_module_docstrings.py` — OK, 0 refactor-narrative violations (all 68 files, after the drive-by fix).
- [x] `python scripts/test_tier_audit.py --strict` — 702 tests inspected, 0 Tier-4 violations (all 68 files).
- [x] `python scripts/mypy_ratchet.py` — OK, 212 findings, all baselined.
- [x] Non-conforming hunk enumeration above — complete, 1 entry, reasoned not guessed.
- [x] Pattern example above — before/after, matches every other converted site's shape.
- [x] Assert-unchanged verification above — mechanical (diff-hunk-shape check), not just "tests still pass."
