### PR TITLE
fix(#3930): migration-gate second signal needs basename equality, not independent-AND

### DIFF
--- a/scripts/check_migration_diff_shape.py
+++ b/scripts/check_migration_diff_shape.py
@@ -271,6 +271,58 @@ def is_tests_deletion(line: str) -> bool:
     return parts[0] == "D" and len(parts) == 2 and parts[1].startswith("tests/") and parts[1].endswith(".py")
 
 
+def has_matching_basename_rewrite_pair(lines: "list[str]") -> bool:
+    """Whether the diff contains a new-subdir ``.py`` file (see
+    :func:`is_new_file_in_tests_subdir`) and a deleted ``tests/`` ``.py``
+    file (see :func:`is_tests_deletion`) that share the SAME basename — the
+    fixed, corrected shape of the second activation signal (#3930).
+
+    ★ Corrected in review (lead-coder's #3930, reproduced on the real repo,
+    not a design read — see PR #3929's own real CI red): the original
+    signal only checked "does a new-subdir file exist ANYWHERE in the diff"
+    AND "does a deletion exist ANYWHERE in the diff" as two INDEPENDENT
+    booleans, with no requirement they are the SAME transformation. An
+    ordinary PR that happens to add one new test file (per the vocabulary
+    gate, #3911) AND delete one unrelated obsolete test file (per the
+    six-questions ③ criterion, #3923) — both things this session actively
+    encourages doing in the SAME PR — satisfies that shape by coincidence.
+
+    ★ Content similarity CANNOT fix this (measured, not assumed): the
+    signal exists specifically for a FULLY-rewritten move — zero bytes
+    shared between old and new content, so no similarity threshold, however
+    low, can distinguish "a deliberate 0%-similar disguised move" from "two
+    genuinely unrelated files" — verified directly against real throwaway
+    repos: BOTH cases produce independent ``A``/``D`` lines, never a paired
+    ``R``/``C``, at any threshold from git's own default down to ``-M1%``.
+    Lowering the similarity threshold (the first idea considered) was
+    measured and REJECTED for this reason — it cannot work even in
+    principle for the 0%-similarity case this signal targets.
+
+    ★ What actually distinguishes them: a real "move" — however much its
+    CONTENT changed — overwhelmingly preserves the file's NAME (that is
+    close to what "move" means; a rename that ALSO changes the filename is
+    unusual enough that Stage 1's own actual practice is a byte-identical
+    ``git mv`` with the name unchanged). Two genuinely unrelated files
+    essentially never share a basename by coincidence (verified: #3929's
+    real diff has ``test_2708_cred_check_chokepoint.py`` deleted and
+    ``test_3905_cli_authentication_error_boundary.py`` added — no
+    resemblance). So basename equality is the signal: require the new-
+    subdir file and the deleted file to share the SAME
+    ``Path(...).name``."""
+    import posixpath
+
+    new_names = set()
+    for line in lines:
+        if is_new_file_in_tests_subdir(line):
+            new_names.add(posixpath.basename(line.split("\t")[1]))
+    if not new_names:
+        return False
+    for line in lines:
+        if is_tests_deletion(line) and posixpath.basename(line.split("\t")[1]) in new_names:
+            return True
+    return False
+
+
 def gate_is_active(lines: "list[str]") -> bool:
     """The gate applies ONLY to a PR whose diff shows REAL evidence of a
     tests/ migration — never a label, a branch-name convention, or any
@@ -284,22 +336,35 @@ def gate_is_active(lines: "list[str]") -> bool:
       inexact rename) under ``tests/`` — only pure R100 is ALLOWED, but any
       similarity ACTIVATES the gate (widened for #3909, see the function's
       own docstring).
-    - :func:`is_new_file_in_tests_subdir` **AND** :func:`is_tests_deletion`
-      TOGETHER — a brand-new ``.py`` appearing in a ``tests/`` subdirectory
-      while a ``.py`` disappears from somewhere under ``tests/``, which is
-      what a FULLY-rewritten "move" (zero bytes shared, so ``-M100%``
-      detects no rename at all) looks like: appear here, disappear there.
+    - :func:`has_matching_basename_rewrite_pair` — a brand-new ``.py``
+      appearing in a ``tests/`` subdirectory while a ``.py`` of the SAME
+      BASENAME disappears from somewhere under ``tests/``, which is what a
+      FULLY-rewritten "move" (zero bytes shared, so ``-M100%`` detects no
+      rename at all) looks like: appear here, disappear there, same name.
 
-      ★ Corrected TWICE in review, both times found by actually running the
-      gate rather than by reading the design: the first version of this
-      signal was "new file in a subdirectory" ALONE — which activated on
-      THIS VERY PR (adding a genuinely new test file, no deletion anywhere)
-      and made the gate reject its own introducing PR (CI failure,
-      lead-coder's finding, not a design read). "Appeared" alone cannot
-      distinguish a migration from an ordinary new-test-addition; only
-      "appeared AND something disappeared" can — the same shape the
-      R100-rename signal already captures for the simple case, generalized
-      to the fully-rewritten one.
+      ★ Corrected THREE times in review, every time found by actually
+      running the gate rather than by reading the design:
+      1. The first version was "new file in a subdirectory" ALONE — which
+         activated on this gate's OWN introducing PR (adding a genuinely
+         new test file, no deletion anywhere) and made the gate reject
+         itself (CI failure, lead-coder's finding).
+      2. The second version added "AND a deletion exists somewhere in the
+         diff" — but as two INDEPENDENT booleans over the whole line list,
+         with no requirement the appearance and disappearance are the SAME
+         transformation. #3930 (lead-coder, real CI red on #3929): an
+         ordinary PR adding one new test file (per the vocabulary gate,
+         #3911) AND deleting one unrelated obsolete test file (per the
+         six-questions ③ criterion, #3923) — both things this session
+         actively encourages in the SAME PR — satisfied that shape by pure
+         coincidence and activated the gate on a PR that was not a
+         migration at all.
+      3. This version: requires the appeared and disappeared files to
+         share a BASENAME — see :func:`has_matching_basename_rewrite_pair`
+         for why content similarity cannot fix this (measured: the 0%-
+         similarity case this signal targets is, by construction,
+         indistinguishable by content from two unrelated files at any
+         threshold) and why basename equality is the real distinguishing
+         property instead.
     - :func:`is_tests_copy` — a ``C`` status line under ``tests/`` (#3909):
       the file was COPIED to the destination but the ORIGINAL was never
       deleted. This needs no AND-partner the way the subdir-file signal
@@ -317,10 +382,9 @@ def gate_is_active(lines: "list[str]") -> bool:
     OR a plain new-test-addition PR (like this one) passes through
     untouched."""
     has_rename = any(is_tests_rename(line) for line in lines)
-    has_new_subdir_file = any(is_new_file_in_tests_subdir(line) for line in lines)
-    has_deletion = any(is_tests_deletion(line) for line in lines)
+    has_matching_pair = has_matching_basename_rewrite_pair(lines)
     has_copy = any(is_tests_copy(line) for line in lines)
-    return has_rename or (has_new_subdir_file and has_deletion) or has_copy
+    return has_rename or has_matching_pair or has_copy
 
 
 def _in_scope(line: str) -> bool:

--- a/tests/scripts/test_check_migration_diff_shape_3879.py
+++ b/tests/scripts/test_check_migration_diff_shape_3879.py
@@ -19,6 +19,7 @@ from scripts.check_migration_diff_shape import (
     blob_at_head,
     diff_name_status,
     gate_is_active,
+    has_matching_basename_rewrite_pair,
     is_tests_copy,
     offending_lines,
 )
@@ -502,4 +503,96 @@ def test_a_new_test_plus_new_init_py_still_leaves_the_gate_inactive(
         "a genuinely new test file + new __init__.py, with a pre-existing "
         "empty file elsewhere as a possible C-match candidate, incorrectly "
         "activated the gate after #3909/#3913's fix"
+    )
+
+
+# ── #3930 — an unrelated new file + an unrelated deletion is not a move ─────
+# #3929's real CI failure: an unrelated new test file (a brand-new
+# tests/interfaces/ addition) landed in the SAME diff as an unrelated
+# deletion (a wholly separate file's removal elsewhere in tests/), with no
+# relationship between the two beyond both touching tests/. The prior
+# signal (`has_new_subdir_file AND has_deletion`, independent of each
+# other) treated "something appeared AND something disappeared anywhere in
+# tests/" as evidence of a disguised move — which any PR that both adds a
+# new test file and deletes an unrelated one will trip. The fix requires
+# the appeared/disappeared pair to share a BASENAME before treating them as
+# one rewrite-disguised-as-move candidate (`has_matching_basename_rewrite_
+# pair`), since basename equality is the one signal that survives even a
+# 0%-content-overlap disguised move (see the sibling test below) while
+# discriminating it from two unrelated files.
+
+
+def test_an_unrelated_new_file_and_an_unrelated_deletion_leaves_the_gate_inactive(
+    _repo: Path,
+) -> None:
+    """Tier 2: #3930 — the real #3929 CI false positive, reproduced. A new
+    test file appearing in one subdirectory and an unrelated pre-existing
+    file being deleted elsewhere, with DIFFERENT basenames, must not
+    activate the gate — this exact shape wrongly failed #3929's real CI
+    before this fix (measured directly against the real PR diff, not
+    assumed from the design)."""
+    (_repo / "tests" / "test_unrelated_to_delete.py").write_text(
+        "some content nobody moved\n", encoding="utf-8",
+    )
+    _commit_all(_repo, "add a second, unrelated flat test file")
+
+    core = _repo / "tests" / "core"
+    core.mkdir()
+    (core / "test_brand_new.py").write_text(
+        "a genuinely new test file, unrelated to anything deleted\n",
+        encoding="utf-8",
+    )
+    (_repo / "tests" / "test_unrelated_to_delete.py").unlink()
+    _commit_all(_repo, "add an unrelated new file + delete an unrelated old one")
+
+    lines = diff_name_status("HEAD~1", root=_repo)
+    assert not has_matching_basename_rewrite_pair(lines), (
+        "an unrelated new file (test_brand_new.py) and an unrelated "
+        "deletion (test_unrelated_to_delete.py) — different basenames — "
+        "were wrongly paired as a disguised-move candidate"
+    )
+    assert not gate_is_active(lines), (
+        "an unrelated new-file-in-subdir + unrelated deletion elsewhere, "
+        "with no basename relationship, incorrectly activated the gate — "
+        "the exact #3929 false positive this fix closes"
+    )
+
+
+def test_a_same_basename_zero_similarity_disguised_move_still_activates_the_gate(
+    _repo: Path,
+) -> None:
+    """Tier 2: non-vacuity for the test above — the signal's actual
+    purpose (a 0%-content-overlap disguised move, indistinguishable from
+    an unrelated add+delete by content alone) must still be caught via
+    basename equality. Uses fully disjoint random content on both sides
+    (no shared line) so git's own similarity search — measured directly
+    beforehand — reports plain `A`/`D` lines rather than a low-similarity
+    `R` line, exercising `has_matching_basename_rewrite_pair` itself
+    rather than the `is_tests_rename` signal."""
+    import random
+
+    rnd = random.Random(2024)
+    old_lines = [f"old_unique_line_{i}_{rnd.random()}" for i in range(50)]
+    (_repo / "tests" / "test_a.py").write_text("\n".join(old_lines) + "\n", encoding="utf-8")
+    _commit_all(_repo, "replace tests/test_a.py with disjoint content")
+
+    core = _repo / "tests" / "core"
+    core.mkdir()
+    new_lines = [f"new_unique_line_{i}_{rnd.random()}" for i in range(50)]
+    (core / "test_a.py").write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+    (_repo / "tests" / "test_a.py").unlink()
+    _commit_all(_repo, "disguised move: same basename, zero content overlap")
+
+    lines = diff_name_status("HEAD~1", root=_repo)
+    assert all(not line.startswith(("R", "C")) for line in lines), (
+        f"fixture assumption broken — expected plain A/D lines, got: {lines!r}"
+    )
+    assert has_matching_basename_rewrite_pair(lines), (
+        "a same-basename, zero-similarity disguised move was not recognized "
+        "as a rewrite-pair candidate"
+    )
+    assert gate_is_active(lines), (
+        "a same-basename disguised move with zero content overlap did not "
+        "activate the gate — the signal's original purpose, which the "
+        "#3930 basename-equality fix must preserve"
     )


### PR DESCRIPTION
**[e2e-coder]** — top-priority fix for #3930 (lead-coder flagged: "not your implementation's fault... please fix ASAP" — the migration-diff-shape gate's own false positive was blocking #3929).

## What broke

#3929's real CI: an unrelated new test file (`tests/interfaces/test_3905_cli_authentication_error_boundary.py`) landed in the same diff as an unrelated deletion (`tests/test_2708_cred_check_chokepoint.py`) — no relationship beyond both touching `tests/`. The gate's second activation signal, `has_new_subdir_file AND has_deletion` (independent of each other), treats "something appeared AND something disappeared anywhere in tests/" as evidence of a disguised move — which any PR that both adds a new test and deletes an unrelated one trips.

## Why the first proposed fix (similarity threshold) doesn't work

lead-coder's proposed fix (require the appeared/disappeared pair to clear a low similarity threshold before pairing) was measured directly and found insufficient for the signal's own original purpose: a genuine same-basename, 0%-content-overlap disguised move produces the IDENTICAL diff shape (plain `A`/`D` lines, no `R`/`C`) as #3929's genuinely-unrelated case, at every threshold including git's own default — verified against two throwaway repos, one a real disguised move and one two unrelated files, both producing indistinguishable `A`/`D` pairs. Content similarity cannot discriminate the two cases by construction.

## The fix

`has_matching_basename_rewrite_pair` replaces the independent-AND composition: the appeared file and a disappeared file must share a **basename** before being treated as one rewrite-disguised-as-move candidate. Basename equality survives even 0% content overlap (a real move overwhelmingly preserves the filename) while not falsely pairing #3929's unrelated files (different basenames).

## Falsify-verification (executed, not reasoned)

- Reproduced #3929's real diff directly:
  `git diff -M100% -C --find-copies-harder --name-status origin/main...origin/fix/3905-remove-credential-hardcode -- tests/` → confirmed `gate_is_active()` is now `False` for this exact diff (measured `True` under the old composition, `False` under the fix — both measured directly, not inferred).
- New regression test (`test_an_unrelated_new_file_and_an_unrelated_deletion_leaves_the_gate_inactive`) reproduces the shape; stripped the fix back to the old independent-AND composition and confirmed the test goes RED for the documented reason (`assert not True`); restored the fix and confirmed GREEN again.
- Non-vacuity test (`test_a_same_basename_zero_similarity_disguised_move_still_activates_the_gate`): a genuine same-basename, 0%-similarity disguised move (git reports plain `A`/`D`, not `R` — measured directly beforehand) still activates the gate via the new function, preserving the signal's original purpose.

## Test plan

- [x] `ruff check scripts tests` — green
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_check_migration_diff_shape_3879.py` — 21/21 OK, 0 errors
- [x] `pytest tests/scripts/test_check_migration_diff_shape_3879.py` — 21 passed
- [x] `python scripts/verify_module_docstrings.py scripts/check_migration_diff_shape.py tests/scripts/test_check_migration_diff_shape_3879.py` — OK
- [x] `python scripts/mypy_ratchet.py` — 212 findings, all baselined
- [x] Falsify-verified against #3929's real PR diff (see above) — gate now reports inactive
- [x] Falsify-verified the new regression test itself (strip fix → RED, restore → GREEN)
- [x] Non-vacuity: genuine disguised-move shape still activates the gate

Once this merges, #3929's CI should be re-checked to confirm it now goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)