### PR TITLE
docs(#3872): the strip-falsify discriminator is assert-target, not super()-call

### DIFF
--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -581,6 +581,40 @@ ever run the production code it claims to falsify? A genuine instance that
 never calls the real method under test fails that bar exactly like a mock
 does, for an unrelated reason a mock's own ban never named.
 
+**"Does the test run the production code" is necessary but not
+sufficient — the shape recurs even through a `super()` call.** A subclass
+can call `super()` (so the real method genuinely executes) and still
+commit this anti-pattern, if what gets asserted is the subclass's own
+post-processing of that call, not anything about what production actually
+did. The real discriminator is narrower: **is the hand-built stub the
+*target of the assert*, or only an *input condition* feeding a real
+production check?**
+
+```
+✗ calls super(), then mangles the result, then asserts the mangled value
+  — the assert examines the stub's own arithmetic, production ran but
+  wasn't checked
+✓ never calls super() at all, but only as an input a real production
+  function is asked to classify — the assert examines what PRODUCTION
+  concluded, not what the stub did
+```
+
+`#3917`'s own census turned up a legitimate instance of the second shape:
+`_WholesaleDead` in `test_sandbox_self_test_2983.py` is a `NoopBackend`
+subclass whose `wrap_command` hand-breaks the `allow_subprocess=False`
+branch (the real #2962 shape — a filter that kills the target command
+outright). The test that uses it does not assert anything about
+`_WholesaleDead`'s own behavior; it asserts that reyn's real
+`probe_subprocess_enforcement`, handed this backend, correctly reports it
+as **not** enforcing — the stub is the input condition, production's own
+classification is what's under test, and the docstring names the exact
+production line the strip would kill (*"Strip the non-forking control
+from `probe_subprocess_enforcement` and this test fails"*). Whether the
+stub calls `super()` is a useful first screen (a stub that never calls
+production obviously can't be an input condition to it) but not the rule
+itself — a stub can call `super()` and still fail this bar if the assert
+never asks production anything.
+
 **Why "would it stay green with the mechanism dead?" invited this.** That
 phrasing asks you to imagine a dead mechanism, and imagining one is
 something you can always do *inside the test itself* — build a stub, break


### PR DESCRIPTION
**[docs-maintainer]** — 小さい追記(lead-coder依頼)。testing.md § "The strip-falsify mimicry"(#3923)の判別子を精緻化。part of #3872. #3917を閉じるための最後の1件。

## The gap

The section's stated bar — "does the test ever run the production code it
claims to falsify?" — is necessary but not sufficient. Today's `#3917`
census (31 candidates → 0 real violations, both directions verified)
confirmed its own screening heuristic ("does the override call `super()`?")
is not the actual rule: a subclass can call `super()` (production genuinely
runs) and still commit the same anti-pattern, if the assert examines the
subclass's own post-processed result rather than anything production
concluded.

## The real discriminator

**Is the hand-built stub the *target of the assert*, or only an *input
condition* feeding a real production check?**

Verified against the census's own confirmed-legitimate example:
`test_sandbox_self_test_2983.py`'s `_WholesaleDead` (a `NoopBackend`
subclass hand-breaking the `allow_subprocess=False` branch — the real
`#2962` shape). Its test never asserts on `_WholesaleDead`'s own behavior
— it asserts that production's own `probe_subprocess_enforcement`
correctly classifies this backend as **not** enforcing. The stub is the
input condition; production's own classification is what's under test.
The docstring even names the exact production line the strip would kill.

`super()`-call remains a fine first screen (a stub that never touches
production obviously can't be an input condition to it) but stating it AS
the rule silently admits the disguised variant (super() + mangle-then-
assert).

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0, no new WARNING/Aborted lines
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` → 336 passed
- [x] `_WholesaleDead` example re-verified directly against `tests/test_sandbox_self_test_2983.py`, not transcribed from the issue thread
- [x] Branch created off verified-current `origin/main`; remote head verified via `git ls-remote origin refs/heads/docs/strip-falsify-target-vs-input-condition`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
