### PR TITLE
fix(#3928): read driver-session events from disk, not EventLog.all()

### DIFF
--- a/tests/test_pipeline_is6_attached.py
+++ b/tests/test_pipeline_is6_attached.py
@@ -167,6 +167,34 @@ def _bare_ctx(state_log: "StateLog | None" = None) -> ToolContext:
     )
 
 
+def _read_disk_events(events_dir: Path, *, run_id: str) -> "list[dict]":
+    """#3928: read a session's OWN on-disk audit-event JSONL log (rotated
+    into ``YYYY-MM/`` subdirs by ``EventStore``) instead of ``EventLog.all()``
+    — #3868 removes the unbounded in-memory list ``.all()`` reads, and this
+    is the one site #3927's mechanical conversion could not reach (the
+    driver-session's ``EventLog`` reference is only obtainable AFTER the
+    attached run returns, via the bridge marker's ``driver_sid`` — no forward
+    subscriber can be attached before that). Filters by ``data.run_id`` since
+    an audit event carries no session-identity field of its own (only
+    ``type``/``timestamp``/``data`` — schemas/models.py:972) and, per #3928's
+    own measurement, a driver session's directory is physically distinct from
+    its caller's (``sessions/<sid>/chat`` vs the bare ``agents/<name>/chat``)
+    even when they share an agent_name, so no cross-session filtering is
+    needed beyond run_id disambiguating concurrent runs within one file."""
+    out: "list[dict]" = []
+    if not events_dir.is_dir():
+        return out
+    for f in sorted(events_dir.rglob("*.jsonl")):
+        for line in f.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            raw = json.loads(line)
+            if raw.get("data", {}).get("run_id") == run_id:
+                out.append(raw)
+    return out
+
+
 def _steps(n: int) -> Pipeline:
     return Pipeline(steps=[
         ToolStep(name="is6_step", args={"tag": f"s{i}"}, output=f"o{i}")
@@ -628,13 +656,24 @@ async def test_attached_run_emits_bridge_marker_on_callers_own_eventlog(
     assert driver_sid != "main"
     driver_session = reg.get_session("worker", driver_sid)
     assert driver_session is not None
-    driver_events = driver_session.router_host.events.all()
-    started = [e for e in driver_events if e.type == "pipeline_step_started"]
-    completed = [e for e in driver_events if e.type == "pipeline_step_completed"]
-    assert {e.data["step_index"] for e in started} == {0, 1}
-    assert {e.data["step_index"] for e in completed} == {1, 2}
-    assert all(e.data["total_steps"] == 2 for e in started + completed)
-    assert all(e.data["step_kind"] == "tool" for e in started + completed)
+
+    # #3928: read the driver-session's own on-disk audit-event log instead of
+    # EventLog.all() — #3868 removes the unbounded in-memory list. Drain
+    # first: run_pipeline_attached does not call aclose() on the driver's
+    # EventStore (measured directly, #3928 issue comment), so an event
+    # submitted to the off-loop write worker on the pump's last step can
+    # still be in flight when this line runs — measured directly too (3 of
+    # the 4 step events were on disk before the drain, 4 after, in the same
+    # run). aclose_event_store() is idempotent so this is safe even if a
+    # later teardown also calls it.
+    await driver_session.aclose_event_store()
+    driver_events = _read_disk_events(driver_session.events_dir, run_id=outcome["run_id"])
+    started = [e for e in driver_events if e["type"] == "pipeline_step_started"]
+    completed = [e for e in driver_events if e["type"] == "pipeline_step_completed"]
+    assert {e["data"]["step_index"] for e in started} == {0, 1}
+    assert {e["data"]["step_index"] for e in completed} == {1, 2}
+    assert all(e["data"]["total_steps"] == 2 for e in started + completed)
+    assert all(e["data"]["step_kind"] == "tool" for e in started + completed)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[e2e-coder]** — #3868 PR-2's (#3927) one deferred hunk, design D (architect, #3928).

## Background

#3927 mechanically converted every `EventLog.all()` call site to `collect_events()` except one: `tests/test_pipeline_is6_attached.py`'s bridge-marker test checks the dynamically-spawned driver-session's `pipeline_step_started`/`pipeline_step_completed` events, but the driver's `EventLog` reference is only obtainable AFTER `run_pipeline_attached()` returns (via the bridge marker's `driver_sid`) — no forward subscriber can be attached before the events land, so `collect_events()`'s forward-only pattern structurally cannot cover this site.

Architect's design D (#3928, comment 5229936266): read the driver-session's own on-disk `.reyn/events` audit log instead of its in-memory `EventLog.all()` list. Options A (new spawn arg used only by tests) and B (a permanent `.all()` exception) were rejected — both undermine PR-3's goal (bounding the in-memory list); C (delete the test) fails #3923's "who would miss it" (the #2570 TUI bridge depends on exactly this property).

## Two required pre-implementation measurements (both done, both measured directly)

**① Does the driver session's `events_dir` actually differ from the caller's?** — the single point on which D's success or failure hinges (architect + lead-coder both flagged this unmeasured).

Measured directly against a real `run_pipeline_attached()` call (real `AgentRegistry`/`Session`, isolated tmp cwd):
```
caller.events_dir:         .../agents/worker/chat
driver_session.events_dir: .../agents/worker/sessions/<sid>/chat
SAME PATH: False
```
Same `agent_name` ("worker") on both sides, but physically distinct directories — `set_events_dir()` assigns the sid-scoped path at spawn. Not the rejected `event_sink` "events mix" shape.

**② Is the driver's `EventStore` drained before the test reads it back?**

`grep -n aclose src/reyn/runtime/session_api.py` → 0 hits; read `run_pipeline_attached()` to its end — no drain call anywhere on the attached-pump path. Measured the race directly: reading the driver's disk events immediately after the pump returned found **3 of 4** expected step events; after `driver_session.aclose_event_store()` (a public, idempotent seam, `session.py:7711`), **4 of 4**. This is a real, measured race, not a theoretical one.

## Falsify-verification

- New read path (`_read_disk_events`, filters by `data.run_id` since audit events carry no session-identity field of their own): broke the `run_id` filter, confirmed the test goes RED for the right reason (`assert set() == {0, 1}` — empty, not vacuous), restored, confirmed green.
- Full file: 9/9 passing before and after.

## Production changes

**Zero** — this is the design's stated advantage over options A/B.

## Test plan

- [x] `ruff check tests/test_pipeline_is6_attached.py` — green
- [x] `python scripts/test_tier_audit.py --strict tests/test_pipeline_is6_attached.py` — 9/9 OK
- [x] `pytest tests/test_pipeline_is6_attached.py` — 9 passed
- [x] `python scripts/verify_module_docstrings.py tests/test_pipeline_is6_attached.py` — OK
- [x] `python scripts/mypy_ratchet.py` — 212 findings, all baselined
- [x] Both design-D pre-conditions measured directly (see above), not assumed
- [x] Falsify-verified the new read path (broken filter → RED, restored → GREEN)

Part of #3868 (does not close it — PR-3 still pending, now unblocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)