### PR TITLE
docs(#3935): a PR touching tests/ waits on reviewer TESTS-READ before self-merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -404,6 +404,23 @@ These rules then keep multi-session work coherent:
    to add it as `- [ ] 🔴 <point>` (append, don't remove the author's own
    items) and does not merge while it's unchecked; the author checks it off
    once addressed, in the same PR body, with the fixing commit noted.
+8. **A PR touching `tests/` does not self-merge until a reviewer's
+   TESTS-READ note lands on the PR.** "A lead-coder merge train refuses
+   any PR touching `tests/` without one" (Test review, above) describes
+   what *that train's own script* does — it is not a rule that reaches a
+   session merging directly. `#3916` (75 files, 31 under `tests/`) merged
+   with no TESTS-READ ever posted: not blocked, not late — the gate
+   the sentence implied was never wired to that path at all, the same
+   declared-vs-actual gap this file has been naming all session, this
+   time in its own PR-workflow section. The content was sound (confirmed
+   post-hoc) and the author was not at fault — "resume" was said without
+   the caveat that merge still waits on TESTS-READ, an omission on the
+   reviewer's side, not a violation on the implementer's. No CI gate: a
+   check for "a comment containing a fixed string exists" makes passing
+   the check the goal (an empty TESTS-READ satisfies it) — the same shape
+   already closed elsewhere in this file. A doc line is the proportionate
+   fix; only a human reading the PR before merging can tell a real
+   TESTS-READ from an empty one.
 
 ## Pre-conclusion observation checklist (READ BEFORE WRITING ANY FINDING / 結論)
 


### PR DESCRIPTION
**[docs-maintainer]** — #3935(lead-coder依頼)。CLAUDE.md PR workflowに新規rule 8追加。

## What happened

`#3916`(75ファイル、うちtests/ 31)がTESTS-READ一度も無いままmergeされました。
ブロックされたのでも遅れたのでもなく — 「lead-coder merge trainはtests/を触るPRを
TESTS-READ無しでは拒否する」という文はlead-coder自身のtrain scriptの挙動を
説明していたに過ぎず、直接mergeする経路には元々何も掛かっていませんでした。
CLAUDE.mdが今夜ずっと指摘してきた「宣言≠機構」の、CLAUDE.md自身のPR workflow節での
再演です。

## Fault attribution (指示通り明記)

- 中身は健全(post-hoc確認済み)、tui-coderに落ち度なし
- lead-coder側の非: 「再開してよい」と言う際に「ただしmergeはTESTS-READの後」を
  添え忘れた

## No CI gate (指示通り)

「特定文字列を含むコメントの存在」をCIが見る形は通すことが目的化する(空のTESTS-READで
通る) — #3917で潰したstrip-falsify anti-patternと同じ形。doc 1行が比例した対処、
という判断も本文に明記しました。

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0, no new WARNING/Aborted lines
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` → 336 passed
- [x] Branch created off verified-current `origin/main`; remote head verified via `git ls-remote origin refs/heads/docs/pr-workflow-self-merge-tests-read`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
