### PR TITLE
fix(#3934): config mirror gate passes vacuously for common field names

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -962,6 +962,7 @@ policy for `sandboxed_exec` ops + the OS's in-process file/http gates.
 sandbox:
   backend: auto          # auto | seatbelt | landlock | noop
   on_unsupported: warn   # warn | error | ignore
+  mode: compat           # compat (only implemented value today) | strict | custom
   policy:                # optional — the agent-level (operator) sandbox policy
     network: true
     write_paths: ["{{workspace}}", "/tmp"]
@@ -997,6 +998,7 @@ sandbox:
 |-----|------|---------|-------------|
 | `backend` | string | `auto` | Enforcement backend. `auto` lets the OS pick: macOS < 26 → `seatbelt` (sandbox-exec SBPL), Linux ≥ 5.13 with `sandbox-linux` extra → `landlock` (+ optional seccomp-BPF), otherwise → `noop` (audit-only, no enforcement). Explicit values force a specific backend. |
 | `on_unsupported` | string | `warn` | Policy when **no OS sandbox backend is available** — whether an explicit `backend` was forced-but-unavailable, `backend: auto` found no platform backend (the auto path honors this too), OR the selected backend **failed its enforcement self-test** (it is present but did not deny — such a backend is treated exactly like an absent one). `warn` logs a WARNING at selection and falls back to `noop` (default — not silent). `error` raises `RuntimeError` (**fail-closed** — refuse to run AI-generated code unsandboxed; set this where enforcement is required, and it works with the default `backend: auto` and against a present-but-inert backend). `ignore` silently falls back. |
+| `mode` | string | `compat` | #3823 ②: which enumeration DIRECTION the resolved policy uses. `compat` (default) is a literal empty deny-list — nothing blocked by default (audit/events/timeout/cancel-teardown still apply). `strict` would be an explicit allow-list; `custom` would let the operator write both direction and content via `policy` below. Both are declared in the enum but **RAISE at construction** (`ValueError`, "not implemented yet") rather than being silently accepted and ignored — resolving `mode` into an actual policy is not wired anywhere yet. Only `compat` validates today. |
 | `policy` | map | _none_ | **Agent-level (operator) sandbox policy.** When set, it is the deterministic policy applied to sandboxed ops **and** folded into the `SandboxLayer` of the permission intersection (`∩`) for the OS's in-process file/http gates, on the `network`/`subprocess`/`env` axes — **winning over** op-declared fields, so a skill or the LLM cannot widen it. `write_paths` (and the read/write deny-lists) do NOT participate in that intersection: an operator cannot know in advance what directory an op needs, so the kernel backend consumes them directly (#3901 PR-B ③). Omitted (the default) means **no agent-level restriction**: the `SandboxLayer` stays the identity (`⊤`) and op-level fields govern, exactly as before. Sandbox authorization is an operator/run concern. See sub-keys below. |
 
 ### `sandbox.policy` sub-keys

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -277,6 +277,56 @@
 
 
 # -----------------------------------------------------------------------------
+# skills: skill registry — raw dict passed to build_skill_registry at
+# session/router construction. Absent/empty (default) → no skills registered
+# beyond whatever a skill directory scan finds elsewhere. Merged across
+# config tiers by name (explicit entries win on collision).
+#
+#   entries.<name>.path:        "skills/foo/SKILL.md"
+#   entries.<name>.description: one-line description (optional)
+#   entries.<name>.enabled:     true (default) | false — false drops the
+#                                entry from the registry outright
+#   entries.<name>.visibility:  menu (default) | on_demand | hidden — which
+#                                discovery surface the skill reaches: menu =
+#                                the L1 system-prompt Skills menu; on_demand =
+#                                the skill_list tool only (no standing token
+#                                cost); hidden = no model-facing surface.
+# -----------------------------------------------------------------------------
+# skills:
+#   entries:
+#     my-skill:
+#       path: "skills/my-skill/SKILL.md"
+#       description: "One-line description"
+#       enabled: true
+#       visibility: menu
+
+
+# -----------------------------------------------------------------------------
+# pipelines: pipeline registry — raw dict passed to build_pipeline_registry
+# at session-factory time. Pipelines are registered PURELY via explicit
+# ``pipelines.entries`` declarations (a *.yaml file with no config entry is
+# invisible to every session). Absent/empty (default) → no pipelines loaded.
+# Merged across config tiers by name (explicit entries win on collision) —
+# same union-merge shape as ``skills`` above.
+#
+#   entries.<key>.path:        "pipelines/hello.yaml" — parsed via
+#                               parse_pipeline_docs (a file may hold multiple
+#                               pipeline: documents)
+#   entries.<key>.description: one-line description (optional)
+#   entries.<key>.enabled:     true (default) | false
+#
+# The config entry key is a pure namespace label — every pipeline registers
+# as {key}.{declared-name} regardless of the key's own text.
+# -----------------------------------------------------------------------------
+# pipelines:
+#   entries:
+#     hello_cli:
+#       path: "pipelines/hello.yaml"
+#       description: "One-line description"
+#       enabled: true
+
+
+# -----------------------------------------------------------------------------
 # skill_search: BM25 skill pre-filter.
 # When the catalog has more than ``threshold`` skills, the router narrows
 # ``invoke_skill.name`` enum to the top-``top_k`` BM25 keyword matches before
@@ -691,6 +741,9 @@
 #   max_concurrent_batches: 1     # 1–10 (phase 2 will raise this)
 #   max_retries: 3                # 0–10
 #   retry_backoff: exponential    # exponential | linear
+#   timeout: 60.0                 # seconds; caps how long reyn WAITS per attempt —
+#                                 # does not cap how many HTTP requests the provider
+#                                 # receives (the SDK client retries underneath this)
 #   tokenizer: cl100k_base        # tiktoken encoding for chunk-size estimation
 #   cost_warn_threshold: 10000    # ask-user gate fires above this chunk count
 
@@ -791,6 +844,10 @@
 #     require_token_on_loopback: true  # also require the token on loopback TCP (secure default for shared hosts)
 #     tls_certfile: null            # operator TLS cert (T3); null → self-signed TOFU generated at startup
 #     tls_keyfile: null             # operator TLS key (T3); must be set together with tls_certfile
+#   surfaces:                       # FP-0058 P2: per-surface opt-in/opt-out (launch-time-only, never LLM-settable)
+#     enabled:                      # surface name -> explicit override; absent = surface's secure-default applies
+#       a2a: {enabled: true}        # CLI --enable/--disable beats this, which beats the secure-default
+#       mcp: {enabled: true}
 
 
 # -----------------------------------------------------------------------------
@@ -839,7 +896,8 @@
 
 # -----------------------------------------------------------------------------
 # sandbox: which enforcement backend to use + what to do when the
-# requested backend isn't available on the host platform.
+# requested backend isn't available on the host platform, plus the
+# operator-level sandbox policy applied to sandboxed ops.
 #
 #   backend:        auto | seatbelt | landlock | noop
 #                   ``auto`` (default) picks: macOS <26 → seatbelt,
@@ -847,10 +905,38 @@
 #   on_unsupported: warn (default, log + fall back to noop)
 #                   error (raise; useful in enforced production)
 #                   ignore (silent fallback)
+#   mode:           #3823 ②: which enumeration DIRECTION the resolved
+#                   policy uses. ``compat`` (default) — a literal empty
+#                   deny-list, nothing blocked by default (audit/events/
+#                   timeout/cancel-teardown still apply). ``strict``/
+#                   ``custom`` are declared but NOT YET WIRED — they raise
+#                   at construction rather than being silently accepted
+#                   and ignored.
+#   policy:         optional — the agent-level (operator) sandbox policy,
+#                   a mapping of SandboxPolicy kwargs (network /
+#                   write_paths / write_deny_paths / read_deny_paths /
+#                   deny_subprocess / env_deny_names / timeout_seconds).
+#                   #3901: every axis except write_paths defaults to full
+#                   compat (nothing extra restricted) — write_paths is the
+#                   one operator-unknowable value the kernel backend
+#                   consumes directly, so it stays closed by default. When
+#                   set, the policy is the deterministic value applied to
+#                   sandboxed ops AND folded into the permission
+#                   intersection on the network/subprocess/env axes —
+#                   WINNING over op-declared fields, so a skill or the LLM
+#                   cannot widen it. Omitted (default) = no agent-level
+#                   restriction.
 # -----------------------------------------------------------------------------
 # sandbox:
 #   backend: auto
 #   on_unsupported: warn
+#   mode: compat
+#   policy:
+#     network: true
+#     write_paths: ["{{workspace}}", "/tmp"]
+#     deny_subprocess: false
+#     env_deny_names: []
+#     timeout_seconds: 600
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_config_mirror_coverage_1056.py
+++ b/tests/test_config_mirror_coverage_1056.py
@@ -12,21 +12,57 @@ documented in BOTH mirrors. It derives the expected field set from the schema
 (zero hand-enumeration), so it auto-extends as fields change.
 
 Granularity = **field NAME** (word-boundary), plus every top-level section.
-Rationale:
+
+#3934: raw whole-FILE word-boundary presence (the original design) passes
+**vacuously** for a common field name — `mode` / `policy` / `enabled` / `path`
+/ `timeout` etc. appear *somewhere* in a 1000+-line file regardless of whether
+the field they belong to is documented at all. Measured directly: before this
+fix, `sandbox.mode` (a real `SandboxConfig` field, `infra.py:466`) was entirely
+undocumented in BOTH mirrors and the gate stayed green, because the bare word
+"mode" is used by six unrelated sections (`safety.on_limit.mode`, `tool_search`
+deferred mode, container mode, ...). The gate is least effective exactly where
+it matters most: an ordinary, common-sounding new field name.
+
+Fix: presence is now checked **within the field's own top-level section**,
+not the whole file — `_present(name, text)` demoted to a same-section check.
+Each mirror's section boundaries are found structurally (a YAML-comment
+header `# <name>:` / `# <name>.<subfield>:` for the example; a Markdown
+`## `<name>` block` heading for the docs — the two files have genuinely
+different structure, so two marker patterns, not one generic parser: a single
+structure parser produced false negatives in earlier development, per the
+module's original note, which is still true of a fully general approach).
+A top-level name occasionally has more than one heading occurrence in the
+same file (`chat` in the docs: a compact summary block near the top, and the
+detailed compaction worked-example far below) — every occurrence's slice is
+searched, not just the first.
+
+When no section marker is found for a given top-level name at all, the check
+falls back to the ORIGINAL whole-file presence check for that name's leaves —
+this never turns a currently-passing field red; it only closes the vacuous-
+pass hole where a marker IS found. Top-level section names themselves must
+appear either as a marker OR inside backticks (covers the docs' compact
+"Top-level keys" summary table, ``| `name` | ... |``, which never gets its
+own `## block` heading for scalar-only fields) — never a bare, unscoped word
+match, which is exactly the hole this issue closes at the section level too
+(`skills` / `pipelines` were never documented in the example at all, masked
+by the words appearing in unrelated prose elsewhere in the file).
+
+Rationale for name-level (not fully dotted-path) granularity, unchanged from
+the original design:
   - Repeated dataclass types (e.g. `CostLimitConfig` appears 9× across
     cost.* / safety.loop.*_per_chain) are documented ONCE as a shape, not 36
     times — name-level coverage matches that good-docs practice, whereas
     dotted-key-precise coverage would force bloated per-instance tables.
   - Word-boundary raw-text presence is robust against the mirrors' ad-hoc
     structure (commented nested YAML in the example; Markdown tables + YAML
-    blocks + prose in the docs). A structure parser produced false-negatives
-    in development; raw presence does not.
+    blocks + prose in the docs).
 
-Known limitation (acceptable for a drift guard): a *new* field that reuses an
-*existing* field name (e.g. another `timeout`) is not caught by the name check
-alone — but a new top-level section or a genuinely new field name is. The
-top-level section check below backstops the most impactful drift.
-"""
+Known limitation (acceptable for a drift guard, unchanged): a *new* field
+that reuses an *existing* field name AND lands in a section that already
+documents that name for a DIFFERENT sibling field is still not caught by the
+name check alone (e.g. two different `timeout` fields in the same section) —
+but a new top-level section, a genuinely new field name, or (as of #3934) a
+common name reused ACROSS sections, is."""
 from __future__ import annotations
 
 import re
@@ -38,52 +74,152 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 _EXAMPLE = _REPO_ROOT / "reyn.local.yaml.example"
 _DOCS = _REPO_ROOT / "docs" / "reference" / "config" / "reyn-yaml.md"
 
+# A commented (or literal) top-level key header in the YAML example, e.g.
+# "# sandbox:" or "# chat.compaction:" (a dotted sub-path in the header text
+# is allowed — several sections introduce themselves that way). Exactly one
+# optional space after "#" — NOT `\s*` — so a deeply-indented worked-example
+# line inside another section's own comment block (e.g. "#       model: ..."
+# nested three levels under `embedding.classes.local-mini`) is never
+# mistaken for that name's own top-level header.
+_EXAMPLE_HEADER = lambda name: re.compile(  # noqa: E731
+    r"^#\s?" + re.escape(name) + r"(\.[a-zA-Z_]+)*:",
+)
+# A Markdown top-level block heading in the docs, e.g. "## `sandbox` block"
+# or "## `cron:` block" (some headings carry the colon inside the backticks).
+_DOCS_HEADER = lambda name: re.compile(  # noqa: E731
+    r"^##\s+`?" + re.escape(name) + r":?`?\s+block\b",
+)
+_SEPARATOR = re.compile(r"^#\s*-{5,}\s*$")
+
 
 def _present(name: str, text: str) -> bool:
     """True when *name* appears as a whole word in *text*."""
     return re.search(r"\b" + re.escape(name) + r"\b", text) is not None
 
 
-def _schema_field_names() -> set[str]:
-    """Every distinct leaf field-name in the ReynConfig schema."""
-    return {n.key.rsplit(".", 1)[-1] for n in walk_config_schema()}
+def _backtick_present(name: str, text: str) -> bool:
+    """True when *name* appears backtick-quoted — covers a Markdown table
+    row (`` | `name` | ... | ``) that never gets its own `## block` heading
+    because the field is a scalar with no sub-fields to elaborate on."""
+    return re.search(r"`" + re.escape(name) + r"`", text) is not None
 
 
-def _schema_top_level() -> set[str]:
+def _schema_top_level() -> "set[str]":
     """Every top-level ReynConfig section/field name."""
     return {n.key.split(".", 1)[0] for n in walk_config_schema()}
 
 
-def test_example_documents_every_config_field() -> None:
-    """Tier 2: reyn.local.yaml.example mentions every config field name + section.
+def _leaves_by_top() -> "dict[str, set[str]]":
+    """Top-level name -> the set of its own leaf field names (own name
+    excluded — a scalar top-level field's presence is covered by the
+    top-level check alone, not re-checked as a trivial one-field section)."""
+    out: "dict[str, set[str]]" = {}
+    for n in walk_config_schema():
+        top = n.key.split(".", 1)[0]
+        leaf = n.key.rsplit(".", 1)[-1]
+        if leaf != top:
+            out.setdefault(top, set()).add(leaf)
+    return out
 
-    A field added to ReynConfig but never added to the example template fails
-    here — the example is advertised as an "exhaustive" mirror, so a silent gap
-    is drift. Derives the field set from the live schema (no hand-enumeration).
-    """
+
+def _widen_to_separator(lines: "list[str]", idx: int) -> int:
+    """Walk a header-line index backward to the nearest preceding
+    `# ---...---` rule — several sections carry descriptive prose (which
+    itself mentions leaf field names) ABOVE the literal `# <name>:` comment
+    line, bounded by the SAME separator that opens the section; without this
+    a name mentioned only in that prose (e.g. `component_weights` in the
+    `chat` section's intro, ahead of its own `# chat:` line) reads as
+    outside the section it is actually introducing."""
+    j = idx
+    while j > 0:
+        j -= 1
+        if _SEPARATOR.match(lines[j]):
+            return j
+    return idx
+
+
+def _section_slices(
+    text: str, header_pat_fn, *, widen: bool,
+) -> "tuple[dict[str, list[tuple[int, int]]], list[str]]":
+    """name -> every (start, end) line-range where *name*'s own header
+    appears, each running to the NEXT header of ANY name (a top-level key
+    can legitimately be documented in more than one place — the docs'
+    `chat` block has both a compact summary near the top and a detailed
+    compaction worked-example much later; both must count)."""
+    lines = text.splitlines()
+    tops = sorted(_schema_top_level())
+    all_markers: "list[tuple[int, str]]" = []
+    for name in tops:
+        pat = header_pat_fn(name)
+        for i, line in enumerate(lines):
+            if pat.match(line):
+                start = _widen_to_separator(lines, i) if widen else i
+                all_markers.append((start, name))
+    all_markers.sort()
+    slices: "dict[str, list[tuple[int, int]]]" = {}
+    for i, (start, name) in enumerate(all_markers):
+        end = all_markers[i + 1][0] if i + 1 < len(all_markers) else len(lines)
+        slices.setdefault(name, []).append((start, end))
+    return slices, lines
+
+
+def _missing(text: str, header_pat_fn, *, widen: bool) -> "tuple[list[str], list[str]]":
+    """Returns (missing_top_level, missing_leaf) for *text* — the shared
+    check both mirror tests run, parameterized only by the file-specific
+    header pattern (the two mirrors have genuinely different structure)."""
+    slices, lines = _section_slices(text, header_pat_fn, widen=widen)
+
+    missing_top = sorted(
+        name for name in _schema_top_level()
+        if name not in slices and not _backtick_present(name, text)
+    )
+
+    missing_leaf: "list[str]" = []
+    for top, leaves in sorted(_leaves_by_top().items()):
+        ranges = slices.get(top)
+        for leaf in sorted(leaves):
+            if ranges:
+                ok = any(_present(leaf, "\n".join(lines[s:e])) for s, e in ranges)
+            else:
+                # No section marker found for this top-level name at all —
+                # fall back to the original whole-file check so a currently-
+                # passing field never regresses; this only closes the hole
+                # where a marker IS found (see module docstring).
+                ok = _present(leaf, text)
+            if not ok:
+                missing_leaf.append(f"{top}.{leaf}")
+    return missing_top, missing_leaf
+
+
+def test_example_documents_every_config_field() -> None:
+    """Tier 2: reyn.local.yaml.example mentions every config field name +
+    section — WITHIN the section that field actually belongs to (#3934).
+
+    A field added to ReynConfig but never added to the example template
+    fails here — the example is advertised as an "exhaustive" mirror, so a
+    silent gap is drift. Derives the field set from the live schema (no
+    hand-enumeration)."""
     text = _EXAMPLE.read_text(encoding="utf-8")
-    missing_fields = sorted(n for n in _schema_field_names() if not _present(n, text))
-    missing_top = sorted(t for t in _schema_top_level() if not _present(t, text))
-    assert not missing_fields and not missing_top, (
-        f"reyn.local.yaml.example is missing config fields {missing_fields} "
+    missing_top, missing_leaf = _missing(text, _EXAMPLE_HEADER, widen=True)
+    assert not missing_top and not missing_leaf, (
+        f"reyn.local.yaml.example is missing config fields {missing_leaf} "
         f"and top-level sections {missing_top} — add a documented block "
         f"mirroring the new ReynConfig field(s)."
     )
 
 
 def test_docs_documents_every_config_field() -> None:
-    """Tier 2: docs/reference/config/reyn-yaml.md mentions every field name + section.
+    """Tier 2: docs/reference/config/reyn-yaml.md mentions every field name +
+    section — WITHIN the section that field actually belongs to (#3934).
 
-    Same drift guard for the reference doc. A new config field must appear in
-    the reference (a table row, YAML example, or prose mention) — derived from
-    the live schema, zero hand-enumeration.
-    """
+    Same drift guard for the reference doc. A new config field must appear
+    in the reference (a table row, YAML example, or prose mention) — derived
+    from the live schema, zero hand-enumeration."""
     text = _DOCS.read_text(encoding="utf-8")
-    missing_fields = sorted(n for n in _schema_field_names() if not _present(n, text))
-    missing_top = sorted(t for t in _schema_top_level() if not _present(t, text))
-    assert not missing_fields and not missing_top, (
+    missing_top, missing_leaf = _missing(text, _DOCS_HEADER, widen=False)
+    assert not missing_top and not missing_leaf, (
         f"docs/reference/config/reyn-yaml.md is missing config fields "
-        f"{missing_fields} and top-level sections {missing_top} — document the "
+        f"{missing_leaf} and top-level sections {missing_top} — document the "
         f"new ReynConfig field(s) in the reference."
     )
 
@@ -96,3 +232,56 @@ def test_mirror_files_exist() -> None:
     """
     assert _EXAMPLE.is_file(), f"missing config example mirror: {_EXAMPLE}"
     assert _DOCS.is_file(), f"missing config reference doc: {_DOCS}"
+
+
+def test_a_common_field_name_undocumented_in_its_own_section_is_caught() -> None:
+    """Tier 2: #3934's own repro, pinned. `sandbox.mode` — a real
+    `SandboxConfig` field (infra.py:466) — is invisible to a bare
+    word-boundary scan of either mirror because "mode" is used by several
+    UNRELATED sections (`safety.on_limit.mode`, deferred `tool_search` mode,
+    container mode, ...); before #3934 the gate stayed green regardless.
+    Constructs a synthetic mirror text carrying "mode" only OUTSIDE the
+    sandbox section and asserts the fix reports it missing — RED for the
+    right reason, not just "the field isn't mentioned at all"."""
+    text = (
+        "# unrelated: some section that happens to use the word mode.\n"
+        "# unrelated:\n"
+        "#   mode: whatever\n"
+        "\n"
+        "# -----------------------------------------------------------------\n"
+        "# sandbox: which enforcement backend to use.\n"
+        "# -----------------------------------------------------------------\n"
+        "# sandbox:\n"
+        "#   backend: auto\n"
+        "#   on_unsupported: warn\n"
+    )
+    slices, lines = _section_slices(text, _EXAMPLE_HEADER, widen=True)
+    sandbox_ranges = slices.get("sandbox", [])
+    assert sandbox_ranges, "the synthetic sandbox header was not found at all"
+    sandbox_text = "\n".join("\n".join(lines[s:e]) for s, e in sandbox_ranges)
+    assert _present("mode", text), "fixture sanity: the word 'mode' must appear SOMEWHERE"
+    assert not _present("mode", sandbox_text), (
+        "'mode' must NOT be visible inside sandbox's own section in this "
+        "fixture — it only appears in the unrelated section above it"
+    )
+
+
+def test_a_field_documented_within_its_own_section_is_accepted() -> None:
+    """Tier 2: non-vacuity for the test above — a field genuinely documented
+    inside its OWN section's slice is found, so the fix does not just widen
+    the deny surface to reject everything."""
+    text = (
+        "# -----------------------------------------------------------------\n"
+        "# sandbox: which enforcement backend to use.\n"
+        "# -----------------------------------------------------------------\n"
+        "# sandbox:\n"
+        "#   backend: auto\n"
+        "#   mode: compat\n"
+    )
+    slices, lines = _section_slices(text, _EXAMPLE_HEADER, widen=True)
+    sandbox_ranges = slices.get("sandbox", [])
+    assert sandbox_ranges, "the synthetic sandbox header was not found at all"
+    sandbox_text = "\n".join("\n".join(lines[s:e]) for s, e in sandbox_ranges)
+    assert _present("mode", sandbox_text), (
+        "a field genuinely documented inside its own section was not found"
+    )

--- a/tests/test_config_mirror_coverage_1056.py
+++ b/tests/test_config_mirror_coverage_1056.py
@@ -78,8 +78,8 @@ _DOCS = _REPO_ROOT / "docs" / "reference" / "config" / "reyn-yaml.md"
 # "# sandbox:" or "# chat.compaction:" (a dotted sub-path in the header text
 # is allowed — several sections introduce themselves that way). Exactly one
 # optional space after "#" — NOT `\s*` — so a deeply-indented worked-example
-# line inside another section's own comment block (e.g. "#       model: ..."
-# nested three levels under `embedding.classes.local-mini`) is never
+# line inside another section's own comment block (e.g. a per-class "model:"
+# line nested three levels under `embedding.classes.<name>`) is never
 # mistaken for that name's own top-level header.
 _EXAMPLE_HEADER = lambda name: re.compile(  # noqa: E731
     r"^#\s?" + re.escape(name) + r"(\.[a-zA-Z_]+)*:",


### PR DESCRIPTION
**[e2e-coder]** — #3934: the config-mirror drift gate (`test_config_mirror_coverage_1056.py`) passed vacuously for common field names.

## Real gap (owner-motivated, #3934)

`sandbox.mode` (a real `SandboxConfig` field, `infra.py:466`) was entirely undocumented in **both** `reyn.local.yaml.example` and `docs/reference/config/reyn-yaml.md`, and the gate stayed green — because the bare word "mode" appears *somewhere* in a 1000+-line file regardless of whether the field it belongs to is documented at all (six unrelated sections use it: `safety.on_limit.mode`, `tool_search`'s deferred mode, container mode, ...). The gate is least effective exactly where it matters most: an ordinary, common-sounding new field name.

## Fix

Presence is now checked **within the field's own top-level section**, not the whole file. Section boundaries are found structurally per mirror (the two files have genuinely different structure, so two marker patterns — a single generic structure parser produced false negatives in earlier development, per the module's own original note):
- example: a YAML-comment header `# <name>:` / `# <name>.<subfield>:`, widened backward to the nearest `# ---` rule (several sections carry descriptive prose, itself naming leaf fields, ABOVE the literal header line)
- docs: a Markdown `` ## `<name>` block `` heading

A top-level name can legitimately have more than one heading occurrence in the same file (docs' `chat` block: a compact summary near the top, and the detailed compaction worked-example far below) — every occurrence's slice is searched, not just the first. When no section marker is found at all, the check falls back to the ORIGINAL whole-file check, so a currently-passing field never regresses — the fix only closes the hole where a marker IS found.

Top-level section names themselves must appear as a marker OR backtick-quoted (covers the docs' compact "Top-level keys" summary table) — never a bare, unscoped word. This closes the same hole at the section level too: `skills`/`pipelines` were never documented in the example at all, masked by the words appearing in unrelated prose elsewhere in the file.

## Real drift the fixed gate found — fixed in the same diff (CLAUDE.md's doc-goes-stale-in-the-same-PR rule)

- `reyn.local.yaml.example`: `skills`/`pipelines` sections entirely missing; `sandbox.mode`/`sandbox.policy`, `embedding.timeout`, `web.surfaces.enabled` undocumented within their sections
- `docs/reference/config/reyn-yaml.md`: `sandbox.mode` undocumented

(Note: this branch was based off main after #3916 merged, which had also touched the `sandbox.policy` vocabulary — `deny_subprocess`/`env_deny_names`/`write_deny_paths` replacing the pre-#3901 names. My additions were updated to match the post-#3916 vocabulary, not the stale one.)

## Falsify-verification

- Two dedicated unit tests exercise the section-scoping mechanism directly via synthetic text: a field mentioned only OUTSIDE its own section is caught; a field genuinely documented INSIDE its own section is accepted (non-vacuity).
- Reintroduced a real bug found during development (`\s*` instead of `\s?` in the example's header regex — over-permissive indent matching, e.g. a deeply-nested worked-example line `"#       model: ..."` inside `embedding.classes.local-mini` mistaken for a top-level header) and confirmed it makes the real `test_example_documents_every_config_field` go RED for the documented reason (spurious section-splitting hid real `embedding.*` fields); restored, confirmed green.

## Test plan

- [x] `ruff check src tests` — green
- [x] `python scripts/test_tier_audit.py --strict tests/test_config_mirror_coverage_1056.py` — 5/5 OK
- [x] `pytest tests/test_config_mirror_coverage_1056.py` — 5 passed
- [x] `python scripts/verify_module_docstrings.py tests/test_config_mirror_coverage_1056.py` — OK
- [x] `python scripts/mypy_ratchet.py` — 212 findings, all baselined
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, no new anchor/link regressions from the docs table edit
- [x] Falsify-verified the section-scoping mechanism (synthetic caught/accepted unit tests) and the real dev-time regex bug (RED → restored → GREEN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)