### PR TITLE
docs(#3924): documenting an in-flight mechanism as absent invites a same-night rewrite

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -751,6 +751,49 @@ comparison is computable — not as a general claim). A `0` or a clean run
 answers only the one you actually checked; treat an unestablished premise
 as unmeasured, not as confirmed absent.
 
+## 19. Documenting an in-flight mechanism as absent invites a same-night rewrite
+
+2026-08-09: a single false claim (`--grant-file-write` "is bounded by the
+sandbox write-paths") recurred across four faces, discovered one at a time
+rather than enumerated up front — each fix believed it was the last:
+
+```
+① src comment (#3916)         "sandbox bounds it" → "no scope of its own"
+② docs/reference/cli/* (#3938) same claim, same fix
+③ argparse --help text (#3943) same claim, same fix — found only while
+                                re-grepping for ① and ②, not anticipated
+🔴 ④ #3925/#3942 landed        the FIX ITSELF ("no scope … doesn't exist
+                                yet") went stale within the hour — ①②③ all
+                                needed a second edit, to "scoped to the
+                                zone root"
+```
+
+Each individual fix was correct *and verified* at the time it was written —
+this is not §1's "declaration ≠ reality" (nothing was declared falsely) and
+not §17's scope hazard (every face that was searched for was found). The
+failure is temporal: **"doesn't exist yet" is a claim about the state of an
+in-flight mechanism, and an in-flight mechanism's whole point is that its
+state is about to change.** Writing the absence as a bare fact makes the
+doc correct only until the mechanism lands — at which point every site that
+said "doesn't exist yet" needs a second edit, and nothing marks those sites
+as needing one.
+
+**The fix that survives the landing, written once:** name both states in
+the same sentence — *"today X; `#NNNN` will make it Y"* — rather than *"X,
+because Y doesn't exist yet."* The first form is still true the moment
+`#NNNN` lands (the doc now under-describes a shipped improvement instead of
+asserting a false absence); the second form is falsified by the exact event
+it was two paragraphs away from anticipating.
+
+**Apply**: when a fix note or a doc explains the CURRENT state of a
+mechanism that a linked, open issue is actively about to change, write the
+future state alongside the current one, not as a separate follow-up. And
+don't stop counting faces after the first re-grep confirms the fix you
+already made — a claim repeated across N call sites was written by N
+different authors at N different times; assume there's an (N+1)th until a
+grep across the whole tree (§17: `src`/`tests`/`scripts`/`docs`, not just
+the file you started with) comes back empty.
+
 ## See also
 
 - [Testing policy](testing.md) — Tier model, Mock vs Fake, decision flow.


### PR DESCRIPTION
**[docs-maintainer]** — lead-coder依頼。今夜のgrant-file-write測定(現在#3943のPRコメントにしかなく誰も読み返さない)をverification-hazards.mdへ移動。part of #3924.

## What

`--grant-file-write`の同一の偽claimが今夜4面で繰り返されました(src comment → docs/reference/cli → argparse help text → 修正自体("no scope … doesn't exist yet")が#3925/#3942着地で1時間以内に偽に)。各修正はその時点で正しく検証済みでした — §1(宣言≠実体)でも§17(scope hazard)でもない、時間軸の問題です。

## Placement

§18の直後に§19として新設。lead-coder自身の「専用の節を作らず既存に足すほうを推す」(#3921と同じ理由)というleanに対し、内容が既存のどのセクションとも異なる軸(temporal、not spatial)だったため新規節としましたが、既存の番号体系に自然に接続する形にしています。

## Two lessons captured

1. **「まだ無い」は in-flight な機構の一時的状態についての主張** — 「今はX、`#NNNN`でYになる」と両方書けば、着地後も1回の記述で持ちこたえる。単なる不在の主張は着地の瞬間に偽になる。
2. **面の数え漏れ** — 最初の再grepで確認できた修正で「これで全部」と思わないこと。§17の全木grep(src/tests/scripts/docs)が空になるまで(N+1)面目の存在を仮定する。

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0, no new WARNING/Aborted lines
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` → 336 passed
- [x] Branch created off verified-current `origin/main`; remote head verified via `git ls-remote origin refs/heads/docs/verification-hazards-inflight-mechanism`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
