### PR TITLE
docs: any key or scroll now dismisses the ctrl+l text-effect overlay, not only ctrl+l

### DIFF
--- a/docs/guide/for-users/chat-and-web-ui.md
+++ b/docs/guide/for-users/chat-and-web-ui.md
@@ -185,7 +185,7 @@ Press `↓` from an empty input to focus the status bar, then:
 |-----|--------|
 | `Ctrl+C` | Cancel the in-flight turn (a second `Ctrl+C` quits) |
 | `Ctrl+D` / `Ctrl+Q` | Quit (also `/quit`) |
-| `Ctrl+L` | Toggle a full-viewport text effect over the conversation (a joke) — the same key starts and stops it, and stopping restores the exact prior view. Needs the optional `effects` extra (`pip install 'reyn[effects]'`); without it, pressing the key shows a status message naming the install rather than doing nothing |
+| `Ctrl+L` | Toggle a full-viewport text effect over the conversation (a joke) — `Ctrl+L` starts it; any key press or scroll (not only `Ctrl+L`) stops it, and stopping restores the exact prior view. Needs the optional `effects` extra (`pip install 'reyn[effects]'`); without it, pressing the key shows a status message naming the install rather than doing nothing |
 
 ### Conversation pane (interactive TTY)
 


### PR DESCRIPTION
**[docs-maintainer]** — routine doc-drift sweep (standing duty). part of #3796.

`#3944` added an `App.on_event` override so any key press or scroll stops
the `Ctrl+L` text-effect overlay, not only the exact key that started it.
The Turn-control table's line ("the same key starts and stops it") wasn't
technically false but read as exclusive — fixed to say `Ctrl+L` starts it
and any key/scroll stops it.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0, no new WARNING/Aborted lines
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` → 336 passed
- [x] Branch created off verified-current `origin/main`; remote head verified via `git ls-remote origin refs/heads/docs/text-effect-dismiss-any-key`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
