### PR TITLE
feat(#3868): PR-3 — delete EventLog._events/.all()/.to_json() entirely

### DIFF
--- a/src/reyn/core/events/events.py
+++ b/src/reyn/core/events/events.py
@@ -48,21 +48,20 @@ class EventLog:
         agent_id: str | None = None,
         run_id: str | None = None,
     ) -> None:
-        self._events: list[Event] = []
         # #3868 PR-1: a folded derived state for `present`'s "was this ref
         # already read this session?" question (source.py's compute_ingested),
-        # built incrementally in emit() instead of re-scanned from `_events`
-        # on every present call. Keyed on the read's own `path`; "full" is
-        # STICKY — a later truncated read on the same path never downgrades
-        # it, because the operator (or a prior full read) already saw the
-        # whole thing. This is NOT a bounded cache: `_events` still holds
-        # everything (PR-1 keeps both so existing `.all()`/`.to_json()`
-        # consumers stay green while callers migrate — PR-2/PR-3 retire
-        # them). What changed is the GROWTH CLASS this dict is subject to:
-        # O(distinct paths ever read), not O(every event ever emitted) —
-        # see compute_ingested's docstring for why that is still unbounded
-        # in principle but bounded by real work (a file read + permission
-        # gate) rather than by talk.
+        # built incrementally in emit() instead of re-scanned from an
+        # unbounded full-history list on every present call. Keyed on the
+        # read's own `path`; "full" is STICKY — a later truncated read on the
+        # same path never downgrades it, because the operator (or a prior
+        # full read) already saw the whole thing. What changed is the GROWTH
+        # CLASS this dict is subject to: O(distinct paths ever read), not
+        # O(every event ever emitted) — see compute_ingested's docstring for
+        # why that is still unbounded in principle but bounded by real work
+        # (a file read + permission gate) rather than by talk. #3868 PR-3:
+        # the unbounded `_events` full-history list this fold replaced is
+        # gone — `all()`/`to_json()` (its only readers) retired in PR-2's
+        # collect_events() migration first.
         self._ingested: dict[str, str] = {}
         self._subscribers: list[Callable[[Event], None]] = list(subscribers or [])
         # FP-0016 Component E: agent_id is auto-injected into every event
@@ -139,9 +138,8 @@ class EventLog:
         if self._run_id and "run_id" not in data:
             data = {**data, "run_id": self._run_id}
         event = Event(type=type, data=data)
-        self._events.append(event)
         # #3868 PR-1: fold this event's contribution to `_ingested` at emit
-        # time (a dict update) instead of re-scanning `_events` at every
+        # time (a dict update) instead of re-scanning full history at every
         # `present` call (was O(session length) per call, source.py:154).
         # Early-return on the common case (not a read) first — `emit` is a
         # hot path (every op, every tool call) and this only has work to do
@@ -167,7 +165,7 @@ class EventLog:
         """``ingested`` ∈ ``{none, partial, full}`` for a present ``data_ref``
         (#3868 PR-1) — an O(1) lookup into the state :meth:`emit` folds
         incrementally, replacing source.py's former O(session length) scan
-        over ``all()``.
+        over the full event history.
 
         Checked under BOTH keys a caller might resolve a ref by (the raw
         ``data_ref`` and its ``resolved`` form — source.py's own pre-existing
@@ -196,12 +194,6 @@ class EventLog:
         if a == "partial" or b == "partial":
             return "partial"
         return "none"
-
-    def all(self) -> list[Event]:
-        return list(self._events)
-
-    def to_json(self) -> list[dict]:
-        return [e.model_dump(mode="json") for e in self._events]
 
 
 def _find_reyn_dir(start: Path) -> Path | None:

--- a/tests/core/test_3901_sandbox_axis_unenforced.py
+++ b/tests/core/test_3901_sandbox_axis_unenforced.py
@@ -96,8 +96,10 @@ async def test_unenforced_axis_emits_audit_event_through_real_op_dispatch(tmp_pa
     from reyn.data.workspace.workspace import Workspace
     from reyn.schemas.models import SandboxedExecIROp
     from reyn.security.permissions.permissions import PermissionDecl
+    from tests._support.events import collect_events
 
     events = EventLog()
+    collected = collect_events(events)
     ws = Workspace(events=events)
     ctx = OpContext(
         workspace=ws,
@@ -110,7 +112,7 @@ async def test_unenforced_axis_emits_audit_event_through_real_op_dispatch(tmp_pa
     op = SandboxedExecIROp(kind="sandboxed_exec", argv=["/bin/echo", "hi"])
     await handle(op, ctx)
 
-    unenforced = [e for e in events.all() if e.type == "sandbox_axis_unenforced"]
+    unenforced = [e for e in collected if e.type == "sandbox_axis_unenforced"]
     assert unenforced, "expected a sandbox_axis_unenforced audit-event"
     assert unenforced[0].data["backend"] == "landlock"
     assert unenforced[0].data["axes"] == ["read_deny_paths"]
@@ -128,11 +130,13 @@ async def test_enforced_axis_emits_no_unenforced_event(tmp_path):
     from reyn.data.workspace.workspace import Workspace
     from reyn.schemas.models import SandboxedExecIROp
     from reyn.security.permissions.permissions import PermissionDecl
+    from tests._support.events import collect_events
 
     class _SeatbeltShapedBackend(_LandlockShapedBackend):
         name = "seatbelt"
 
     events = EventLog()
+    collected = collect_events(events)
     ws = Workspace(events=events)
     ctx = OpContext(
         workspace=ws,
@@ -145,7 +149,7 @@ async def test_enforced_axis_emits_no_unenforced_event(tmp_path):
     op = SandboxedExecIROp(kind="sandboxed_exec", argv=["/bin/echo", "hi"])
     await handle(op, ctx)
 
-    assert [e for e in events.all() if e.type == "sandbox_axis_unenforced"] == []
+    assert [e for e in collected if e.type == "sandbox_axis_unenforced"] == []
 
 
 @pytest.mark.asyncio
@@ -159,8 +163,10 @@ async def test_landlock_with_no_deny_lists_emits_no_unenforced_event(tmp_path):
     from reyn.data.workspace.workspace import Workspace
     from reyn.schemas.models import SandboxedExecIROp
     from reyn.security.permissions.permissions import PermissionDecl
+    from tests._support.events import collect_events
 
     events = EventLog()
+    collected = collect_events(events)
     ws = Workspace(events=events)
     ctx = OpContext(
         workspace=ws,
@@ -172,4 +178,4 @@ async def test_landlock_with_no_deny_lists_emits_no_unenforced_event(tmp_path):
     op = SandboxedExecIROp(kind="sandboxed_exec", argv=["/bin/echo", "hi"])
     await handle(op, ctx)
 
-    assert [e for e in events.all() if e.type == "sandbox_axis_unenforced"] == []
+    assert [e for e in collected if e.type == "sandbox_axis_unenforced"] == []

--- a/tests/test_3475_probe_degradation_visibility_and_timeout_config.py
+++ b/tests/test_3475_probe_degradation_visibility_and_timeout_config.py
@@ -27,7 +27,7 @@ assignment of a plain async function onto `router_host.mcp_list_tools`) — not 
 The single most important property asserted here is NOT "the mechanism ran" — it is what
 the operator/LLM actually receives: the literal audit-event payload
 (`event.type`, `event.data["server"]`, `event.data["reason"]`) an operator reading
-`.reyn/events` (or `router_host.events.all()`, its in-memory mirror) would see, and the
+`.reyn/events` would see, and the
 literal wall-clock behaviour change (timeout fires or doesn't) a non-default config value
 produces. #3512's strip-D arm went GREEN because every witness there was "a function was
 called", never "the string a consumer reads" — this file assigns the audit-event's own


### PR DESCRIPTION
**[e2e-coder]** — #3868 PR-3, the final PR of architect's 3-PR design: the actual memory-bounding fix.

## Recap

- PR-1 (merged): moved "was this ref already read" off a full-history scan into an incrementally-folded `_ingested` dict.
- PR-2 (#3927 + #3933 + #3940, all merged): converted every real test-side `.all()`/`.to_json()` consumer to `collect_events()` — a real `add_subscriber`-based collector mirroring production's own `EventStore`-as-subscriber mechanism.
- **PR-3 (this PR)**: deletes `_events` (the unbounded list every `emit()` call appended to, for the entire life of a session) along with its only two readers, `all()`/`to_json()`.

## Two real consumers found during PR-3's own re-sweep (missed by PR-2's population)

- `tests/core/test_3901_sandbox_axis_unenforced.py` — 3 live `.all()` sites, converted to `collect_events()` following the established pattern.
- `tests/test_3475_probe_degradation_visibility_and_timeout_config.py` — a stale docstring parenthetical claiming `router_host.events.all()` is "its in-memory mirror" (the file's own test bodies already used `collect_events()`; only the prose was stale) — corrected in the same diff.

Zero other `EventLog._events` reach-ins exist anywhere in the repo (full-repo grep, not src/tests-only — the many other `self._events = events` hits across the codebase are unrelated: other classes' own attributes holding a reference to an `EventLog` instance, not `EventLog`'s own internal list).

## Falsify-verification

Constructed a real `EventLog`, confirmed `.all()`/`.to_json()` now raise `AttributeError`, confirmed `emit()`/`compute_ingested()`/`ingested_path_count` (the public API this PR does not touch) still work correctly.

## Verification breadth

Ran all 199 test files that import `EventLog` directly (the full population this diff could affect) in 5 batches — **1644 tests passed**. 2 pre-existing, unrelated issues found and confirmed via `git stash` against unmodified `main` (not caused by this change, not fixed by it either):
- `tests/test_stream_repaint_coalesce_3570.py` hangs identically on unmodified main (a TUI timing test, environment-specific).
- 13 failures across `test_3310_n2_reset_hydrate.py` / `test_3540_intervention_answer_fold.py`, identical on unmodified main (`AttributeError: 'NoneType' object has no attribute 'build_presentation'` — a `capability_visibility` scheme-resolution issue, unrelated to `events.py`).

## Test plan

- [x] `ruff check` (touched files) — green
- [x] `python scripts/test_tier_audit.py --strict` (touched test files) — 14/14 OK
- [x] `pytest` (2 touched test files) — 14 passed
- [x] `python scripts/verify_module_docstrings.py` (touched files) — OK
- [x] `python scripts/mypy_ratchet.py` — 212 findings, all baselined
- [x] Full EventLog-consumer sweep (199 files, 5 batches) — 1644 passed, 2 pre-existing unrelated issues confirmed via `git stash`
- [x] Falsify-verified the removal (`.all()`/`.to_json()` now raise `AttributeError`)

Closes #3868 (the #3868 PR-3 arc — this is the last PR of the 3-PR design).

Per rule 8 (#3936): this touches `tests/`, so it waits on reviewer TESTS-READ before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)