### PR TITLE
feat(#3846): wire present's image component to fetch and show its src URL

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -420,6 +420,7 @@ chat:
     left: true            # TUI left gutter (state marker, 2 cols) shown at start
     right: true           # TUI right gutter (elapsed/tokens, 12 cols) shown at start
   neutralize_body: false  # opt-in ESC/OSC strip on agent-reply/tool-result body text
+  image_url_schemes: []   # opt-in scheme allowlist for present's image src fetch
 ```
 
 ### `chat.render_mode`
@@ -473,6 +474,25 @@ terminal on both the TUI conversation pane and the plain (`--cui`) renderer.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `neutralize_body` | bool | `false` | Strip ESC/control sequences from agent-reply and tool-result body text before rendering. |
+
+### `chat.image_url_schemes`
+
+Opt-in narrowing of which URL schemes `present`'s `image` component will
+fetch (#3846, owner ruling C). Default `[]` — unrestricted, both `http` and
+`https` are fetched — the owner's stated rationale: "even without the bytes,
+the record of what was presented is enough" (the value is the audit record
+that an image was presented, not reyn proxying/verifying the bytes). Set to a
+non-empty list to restrict to exactly those schemes, e.g. `["https"]` to
+reject plain `http`. Any scheme outside `{http, https}` is always rejected
+regardless of this setting — nothing else is fetchable through an `httpx`
+client. `src` is written by the model (`present`'s blueprint is LLM-authored),
+so the fetch always routes through the SSRF-pinned client
+(`_network.py`'s `build_async_http_client(pin_ssrf=True)`) unconditionally,
+independent of this scheme setting.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `image_url_schemes` | list[str] | `[]` | Restrict `present`'s image-src fetch to these schemes; empty = unrestricted (http + https). |
 
 ### `chat.reasoning` fields
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -478,6 +478,14 @@
 # untrusted model reply could otherwise reach the terminal.
 #   neutralize_body: false
 
+# chat.image_url_schemes: opt-in narrowing of which URL schemes `present`'s
+# `image` component will fetch (#3846). Default [] = unrestricted (both
+# http and https are fetched) — owner ruling: "even without the bytes, the
+# record of what was presented is enough". Set to restrict to a subset,
+# e.g. ["https"] to reject plain http. Any scheme outside {http, https} is
+# always rejected regardless of this list (nothing else is fetchable).
+#   image_url_schemes: []
+
 
 # -----------------------------------------------------------------------------
 # events: audit-log rotation policy. Chat events land under

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -654,12 +654,24 @@ class ChatConfig:
     neutralizer to the conversation body text, where a raw ESC/OSC sequence
     from tool output or an untrusted model reply could otherwise reach the
     terminal.
+
+    ``image_url_schemes`` (#3846, owner ruling C): opt-in narrowing of which
+    URL schemes ``present``'s ``image`` component will fetch — default empty
+    (unrestricted: both ``http`` and ``https`` are fetched, the owner's
+    stated default: "even without the bytes, the record of what was
+    presented is enough"). A non-empty list restricts to exactly those
+    schemes (e.g. ``["https"]`` to reject plain ``http``); any scheme outside
+    ``{"http", "https"}`` is always rejected regardless of this setting (an
+    httpx client cannot fetch anything else). Same rationale as
+    ``neutralize_body`` for living under ``chat:`` rather than ``safety:`` —
+    this is a display-boundary narrowing, not a stop condition.
     """
     compaction: CompactionConfig = field(default_factory=CompactionConfig)
     reasoning: ReasoningConfig = field(default_factory=ReasoningConfig)
     render_mode: Literal["alt-screen", "inline", "plain", "auto"] = "alt-screen"
     gutters: GutterConfig = field(default_factory=GutterConfig)
     neutralize_body: bool = False
+    image_url_schemes: "list[str]" = field(default_factory=list)
 
 
 def _build_reasoning_config(raw: object) -> ReasoningConfig:
@@ -714,11 +726,16 @@ def _build_chat_config(raw: object) -> ChatConfig:
     gutters = _build_gutter_config(raw.get("gutters"))
     # #3318: so does the opt-in body-neutralize flag (default False/compat).
     neutralize_body = bool(raw.get("neutralize_body", ChatConfig().neutralize_body))
+    # #3846: so does the opt-in image-src scheme allowlist (default []/unrestricted).
+    raw_schemes = raw.get("image_url_schemes")
+    image_url_schemes = (
+        [str(s) for s in raw_schemes] if isinstance(raw_schemes, list) else []
+    )
     compaction_raw = raw.get("compaction") or {}
     if not isinstance(compaction_raw, dict):
         return ChatConfig(  # type: ignore[arg-type]
             reasoning=reasoning, render_mode=render_mode, gutters=gutters,
-            neutralize_body=neutralize_body,
+            neutralize_body=neutralize_body, image_url_schemes=image_url_schemes,
         )
     # #1128: head_size/tail_size (step 3) + trigger_total_tokens/min_compact_batch
     # (PR-a, axis-1 removal) were removed — head/tail sizing is token-budget via
@@ -799,6 +816,7 @@ def _build_chat_config(raw: object) -> ChatConfig:
     return ChatConfig(
         compaction=compaction, reasoning=reasoning, render_mode=render_mode,  # type: ignore[arg-type]
         gutters=gutters, neutralize_body=neutralize_body,
+        image_url_schemes=image_url_schemes,
     )
 
 

--- a/src/reyn/core/present/image_fetch.py
+++ b/src/reyn/core/present/image_fetch.py
@@ -1,0 +1,151 @@
+"""Fetch resolution for `present`'s `image` component's `src` URL (#3846 ①).
+
+Owner ruling (#3846, 2026-08-09): image delivery is C — `src` is not restricted
+to reyn-issued URIs by default (unrestricted, neutralize-only); an operator can
+opt into a scheme allowlist via `chat.image_url_schemes` (empty/unset = no
+restriction). "Even without the bytes, the record of what was presented is
+enough" is the owner's stated rationale — the value is the audit record, not
+reyn proxying the bytes.
+
+Deliberately client-side (this module), not server-side (`core/op_runtime`):
+architect's measurement (#3846) found AG-UI has no byte-serving route (its 3
+endpoints are all JSON/SSE), so a remote client resolves `src` itself, the same
+way the local TUI does — this module is that one resolution path both share
+(`present`'s `src` slot is written by the model, per `binding.py`'s
+`_render_text_slot`, so it is exactly the LLM-supplied class
+`build_async_http_client(pin_ssrf=True)` names itself for).
+
+Kept OUTSIDE `interfaces/repl/present_renderer.py` deliberately: that module's
+own docstring declares it "Pure: ... No I/O" (FP-0054 PR-B invariant) — a
+render function must never itself decide to fetch. Callers resolve `src` here
+FIRST (async, bounded, cacheable) and hand the *result* into the pure render
+path as an already-decided value.
+
+V1 does not follow redirects across a scheme downgrade/upgrade beyond
+`httpx`'s own default handling, and does not implement web_fetch's manual
+per-hop `_gate_hop` beyond what `PinnedAsyncHTTPTransport` itself does per
+request — its own docstring states every httpx-internal redirect hop calls the
+transport again independently, so `follow_redirects=True` stays SSRF-safe here
+without reimplementing web_fetch's hop loop; the difference from web_fetch is
+scope (present's image fetch is display-only — no manual redirect gate for a
+concern web_fetch has, like MIME/robots policy, that doesn't apply here) not
+resolution.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Practical fetchable schemes — the only two an httpx client can dial at all.
+# `allowed_schemes` (the opt-in restriction) can only narrow WITHIN this set,
+# never widen it: passing e.g. "file" in the allowlist still errors here.
+_FETCHABLE_SCHEMES = frozenset({"http", "https"})
+
+#: Bounded so `present`'s image fetch can never itself become a hang — the
+#: caller (a render pass) is on a UX-visible clock, unlike an agent-driven
+#: `web_fetch` call the user has already accepted waiting on.
+DEFAULT_TIMEOUT_SECONDS = 5.0
+
+#: A display image, not an LLM context payload — smaller than web_fetch's own
+#: cap is reasonable, but this is a starting number, not a measured one.
+DEFAULT_MAX_BYTES = 5_000_000
+
+
+@dataclass(frozen=True)
+class ImageResolution:
+    """The settled outcome of one `src` resolution — cached by the presenter
+    layer (keyed by `src`) so a render pass is a pure dict lookup, never a
+    fetch. Exactly one of ok=True (with `body`/`content_type`) or ok=False
+    (with `error`) is meaningful at a time; the unused fields carry their
+    empty default rather than `None` so callers doing `f"{r.error}"`-style
+    formatting need no extra `or ""` guard."""
+
+    ok: bool
+    body: bytes = b""
+    content_type: str = ""
+    error: str = ""
+
+
+class ImageFetchError(Exception):
+    """Raised for any resolution failure — bad scheme, timeout, oversize
+    response, or the underlying HTTP request itself failing. The caller
+    (presenter-layer) is expected to catch this and render a failure state,
+    never let it propagate as an unhandled render crash."""
+
+
+async def fetch_image_bytes(
+    src: str,
+    *,
+    allowed_schemes: "list[str] | None" = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+) -> "tuple[bytes, str]":
+    """Fetch `src`, returning `(body_bytes, content_type)`.
+
+    Raises :class:`ImageFetchError` on any failure. `allowed_schemes` is the
+    opt-in `chat.image_url_schemes` narrowing (owner ruling C): `None` or an
+    empty list means no restriction beyond `_FETCHABLE_SCHEMES` itself (both
+    http and https allowed); a non-empty list restricts to exactly those
+    schemes (e.g. `["https"]` to reject plain http).
+
+    Always routes through `build_async_http_client(pin_ssrf=True)` —
+    unconditional, not itself an opt-in: `src` is written by the model
+    (`present`'s blueprint is LLM-authored), the same trust class
+    `_network.py` names `build_async_http_client`'s `pin_ssrf` for.
+    """
+    from urllib.parse import urlparse
+
+    parsed = urlparse(src)
+    scheme = parsed.scheme.lower()
+    if scheme not in _FETCHABLE_SCHEMES:
+        raise ImageFetchError(
+            f"cannot fetch {src!r}: scheme {scheme!r} is not http/https"
+        )
+    if allowed_schemes and scheme not in allowed_schemes:
+        raise ImageFetchError(
+            f"cannot fetch {src!r}: scheme {scheme!r} is not in the "
+            f"configured chat.image_url_schemes allowlist {list(allowed_schemes)!r}"
+        )
+
+    import httpx
+
+    from reyn._network import build_async_http_client
+    from reyn._ssrf_guard import SSRFBlocked
+
+    try:
+        async with build_async_http_client(
+            timeout=timeout,
+            follow_redirects=True,
+            headers={"User-Agent": "reyn/1.0"},
+            pin_ssrf=True,
+            egress="present_image",
+        ) as client:
+            async with client.stream("GET", src) as response:
+                response.raise_for_status()
+                content_type = response.headers.get("content-type", "")
+                chunks: "list[bytes]" = []
+                total = 0
+                async for chunk in response.aiter_bytes():
+                    total += len(chunk)
+                    if total > max_bytes:
+                        raise ImageFetchError(
+                            f"cannot fetch {src!r}: response exceeds the "
+                            f"{max_bytes}-byte cap"
+                        )
+                    chunks.append(chunk)
+                return b"".join(chunks), content_type
+    except SSRFBlocked as exc:
+        # The pin's own denial (loopback / link-local / cloud-metadata /
+        # RFC1918 without operator opt-in) — a policy reject, not a network
+        # failure, but the presenter layer needs exactly ONE exception type
+        # to catch, not this plus httpx's hierarchy separately.
+        raise ImageFetchError(f"cannot fetch {src!r}: {exc}") from exc
+    except httpx.TimeoutException as exc:
+        raise ImageFetchError(
+            f"cannot fetch {src!r}: request timed out after {timeout}s"
+        ) from exc
+    except httpx.HTTPStatusError as exc:
+        raise ImageFetchError(
+            f"cannot fetch {src!r}: HTTP {exc.response.status_code}"
+        ) from exc
+    except httpx.RequestError as exc:
+        raise ImageFetchError(f"cannot fetch {src!r}: {exc}") from exc

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2756,6 +2756,8 @@ class TextualChatApp(App):
         # #3712: an entry just arrived. Counted HERE, by the thing that
         # produced it — not reconstructed later from two reads of the model.
         self._note_entry_landed()
+        if kind == "presentation":
+            self._begin_image_resolutions(entry, msg)
         if kind == "intervention":
             self._present_intervention(msg, entry)
         else:
@@ -3062,6 +3064,38 @@ class TextualChatApp(App):
             self._flow.animate_entry(entry, 1.0 / self.RUNNING_BODY_FPS, lambda e: e.update())
         except Exception:
             logger.exception("textual chat: could not start running-tool indicator")
+
+    def _begin_image_resolutions(
+        self, entry: "Entry[OutboxMessage]", msg: "OutboxMessage"
+    ) -> None:
+        """Kick a background fetch (#3846 ②) for every `image` component's
+        `src` in a freshly-arrived ``kind="presentation"`` entry.
+
+        Scans ``msg.meta["nodes"]`` (the `present`-op render model) for
+        ``component == "image"`` nodes, delegating the actual cache/fetch/
+        redraw-on-completion machinery to :meth:`ReynPresenter.
+        begin_image_resolution` — this method's own job is only "detect that
+        a new frame needs resolving, and hand the presenter the Entry it
+        will call ``.update()`` on once settled" (the presenter has no
+        reference to any Entry/FlowView on its own; the app owns those).
+        Fully guarded, same rationale as :meth:`_begin_running_indicator`:
+        a broken image render must never break the frame pump."""
+        try:
+            nodes = (msg.meta or {}).get("nodes") or []
+            allowed = list(
+                getattr(getattr(self._config, "chat", None), "image_url_schemes", None)
+                or []
+            ) or None
+            for node in nodes:
+                if not isinstance(node, dict) or node.get("component") != "image":
+                    continue
+                src = node.get("src")
+                if isinstance(src, str) and src:
+                    self._presenter.begin_image_resolution(
+                        entry, src, allowed_schemes=allowed
+                    )
+        except Exception:
+            logger.exception("textual chat: could not start image resolution")
 
     def _seed_queue_view(self) -> None:
         """Seed :attr:`_queue_view` from a fresh read-model snapshot — called

--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -342,12 +342,19 @@ def _running_indicator(msg: "OutboxMessage", now: float) -> Text:
 
 
 def _body_and_background(
-    msg: "OutboxMessage", *, neutralize_body: bool = False
+    msg: "OutboxMessage",
+    *,
+    neutralize_body: bool = False,
+    image_cache: "dict[str, object] | None" = None,
 ) -> "tuple[RenderableType, str | None]":
     """The body renderable + optional full-row background for one display frame.
 
     ``neutralize_body`` (#3318, default off) is forwarded to the shared
     ``_body_renderable`` call below — see its docstring.
+
+    ``image_cache`` (#3846, default None) is forwarded to the ``presentation``
+    kind's ``render_presentation_nodes`` call — see that function's own
+    docstring for why it must stay a pure dict lookup.
 
     Reuses the plain renderer's per-kind body construction (markdown for the
     agent reply, the tool-summary helpers for tool rows, the ``_KIND_LINE`` body
@@ -379,7 +386,7 @@ def _body_and_background(
     meta = msg.meta or {}
     if kind == "presentation":
         from reyn.interfaces.repl.present_renderer import render_presentation_nodes
-        return render_presentation_nodes(meta.get("nodes", [])), None
+        return render_presentation_nodes(meta.get("nodes", []), image_cache=image_cache), None
     if meta.get(_PIPELINE_RUN_KEY) is not None:
         return _pipeline_row(meta), None
     # kind == "intervention" is intercepted earlier, in ``ReynPresenter.present``
@@ -441,6 +448,79 @@ class ReynPresenter:
         # #3318: opt-in body ESC/OSC neutralize (chat.neutralize_body), default
         # off — see _body_and_background/_body_renderable's own docstrings.
         self._neutralize_body = neutralize_body
+        # #3846 ②: settled image `src` resolutions, keyed by src — see
+        # begin_image_resolution's own docstring. A plain dict (present() is
+        # only ever awaited from the app's own single-threaded event loop, so
+        # no lock is needed for this read/write pattern).
+        self._image_cache: "dict[str, object]" = {}
+        self._image_inflight: "set[str]" = set()
+
+    def begin_image_resolution(
+        self,
+        entry: object,
+        src: str,
+        *,
+        allowed_schemes: "list[str] | None" = None,
+    ) -> None:
+        """Kick a background fetch for `src` if it is not already cached or
+        in flight (#3846 ②) — the ONE mutation point for :attr:`_image_cache`.
+
+        Fire-and-forget, mirroring ``TextualChatApp._begin_running_indicator``'s
+        shape (start something async, let it settle in the background) but
+        ONE-SHOT rather than periodic: there is no polling tick here, only a
+        single completion callback (``entry.update()``) once the fetch settles
+        — an image's byte count does not change moment to moment the way a
+        running tool's elapsed time does, so there is nothing to re-tick.
+
+        ``entry`` is untyped here (``object``, not ``Entry[OutboxMessage]``)
+        deliberately: this module must not import ``textual_flowview``'s
+        ``Entry`` at type-check time for a value it only ever calls
+        ``.update()`` on — the caller (``TextualChatApp``, which already
+        depends on flowview) passes the real, correctly-typed object; this
+        module only needs the one method.
+        """
+        if src in self._image_cache or src in self._image_inflight:
+            return
+        import asyncio
+
+        self._image_inflight.add(src)
+        asyncio.create_task(self._resolve_image(entry, src, allowed_schemes))
+
+    async def _resolve_image(
+        self, entry: object, src: str, allowed_schemes: "list[str] | None",
+    ) -> None:
+        from reyn.core.present.image_fetch import (
+            ImageFetchError,
+            ImageResolution,
+            fetch_image_bytes,
+        )
+
+        try:
+            body, content_type = await fetch_image_bytes(
+                src, allowed_schemes=allowed_schemes
+            )
+            self._image_cache[src] = ImageResolution(
+                ok=True, body=body, content_type=content_type
+            )
+        except ImageFetchError as exc:
+            self._image_cache[src] = ImageResolution(ok=False, error=str(exc))
+        except Exception:
+            # Cosmetic (a failed image render must never break the pump) —
+            # same guard shape as _begin_running_indicator's own try/except.
+            import logging
+
+            logging.getLogger(__name__).exception(
+                "textual chat: image resolution crashed for %r", src
+            )
+            self._image_cache[src] = ImageResolution(
+                ok=False, error="internal error resolving the image"
+            )
+        finally:
+            self._image_inflight.discard(src)
+            try:
+                entry.update()  # type: ignore[attr-defined]
+            except Exception:
+                pass
 
     def _measure(self, renderable: RenderableType, width: int) -> int:
         self._probe.size = (max(width, 1), 200)
@@ -520,7 +600,7 @@ class ReynPresenter:
         if item.kind == "tool_call_started" and meta.get(_RUNNING_SINCE_KEY) is not None:
             return self._present_running_tool(item, width)
         body, background = _body_and_background(
-            item, neutralize_body=self._neutralize_body
+            item, neutralize_body=self._neutralize_body, image_cache=self._image_cache
         )
         return Presentation(
             height=self._measure(body, width),

--- a/src/reyn/interfaces/repl/present_renderer.py
+++ b/src/reyn/interfaces/repl/present_renderer.py
@@ -91,7 +91,7 @@ def _render_code_or_diff(node: dict, *, lexer: str) -> "Any":
     return Syntax(node.get("text", ""), lexer, word_wrap=True, background_color="default")
 
 
-def _render_node(node: dict) -> "Any":
+def _render_node(node: dict, image_cache: "dict[str, Any] | None" = None) -> "Any":
     from rich.markdown import Markdown
     from rich.text import Text
 
@@ -112,20 +112,58 @@ def _render_node(node: dict) -> "Any":
     if component == "list":
         return _render_list(node)
     if component == "image":
-        alt = node.get("alt") or node.get("src") or ""
-        return Text(f"[image: {alt}]", style="dim")
+        return _render_image(node, image_cache)
     # Unregistered/future component — never crash the render loop over one bad node.
     return Text(f"<unsupported present component {component!r}>", style="dim")
 
 
-def render_presentation_nodes(nodes: list[dict]) -> "Any":
+def _render_image(node: dict, image_cache: "dict[str, Any] | None") -> "Any":
+    """The `image` component (#3846 ②) — a PURE dict lookup, never a fetch.
+
+    `image_cache` (an app-owned `dict[str, ImageResolution]`, see
+    `core/present/image_fetch.py`) is populated ELSEWHERE, by a resolution
+    stage kicked off when the frame first arrives (`TextualChatApp.
+    _begin_image_resolutions` -> `ReynPresenter.begin_image_resolution`) —
+    this module's own docstring bans doing that fetch here (the "Pure: ...
+    No I/O" invariant). `image_cache=None` (every non-TUI caller — plain
+    ``ConsoleChatRenderer``, `reyn pipe`'s `StdoutPresentationRenderer`, and
+    every existing test that calls this function without the new kwarg) gets
+    the pre-#3846 `[image: alt]` text, byte-identical — no resolution stage
+    exists on those surfaces yet (#3846 ③ tracks plain's own sync-fetch
+    follow-up; ③ tracks real pixel rendering, a separate deps decision)."""
+    from rich.text import Text
+
+    alt = node.get("alt") or ""
+    src = node.get("src") or ""
+    label = alt or src
+    if image_cache is None or not isinstance(src, str) or src not in image_cache:
+        return Text(f"[image: {label}]", style="dim")
+    res = image_cache[src]
+    if res.ok:
+        # V1 renders a LOADED status line, not real pixels (#3846 ③, a
+        # separate textual-image/pillow-deps decision) — see this
+        # function's own docstring for why that split is deliberate.
+        return Text(
+            f"[image loaded: {label} — {len(res.body)} bytes, "
+            f"{res.content_type or 'unknown type'}]",
+            style="dim",
+        )
+    return Text(f"[image failed: {label} — {res.error}]", style="dim")
+
+
+def render_presentation_nodes(
+    nodes: list[dict], *, image_cache: "dict[str, Any] | None" = None
+) -> "Any":
     """Convert a `ResolvedPresentation.nodes` render model into ONE Rich renderable
     (a `Group` of per-node renderables) — the one-shot inline block `present` prints
     to the conversation scrollback. See module docstring for the markup-inert
-    invariant every branch here must preserve."""
+    invariant every branch here must preserve.
+
+    `image_cache` (#3846 ②, default None) is forwarded to the `image`
+    component branch — see :func:`_render_image`."""
     from rich.console import Group
 
-    return Group(*[_render_node(node) for node in nodes])
+    return Group(*[_render_node(node, image_cache) for node in nodes])
 
 
 class StdoutPresentationRenderer:

--- a/tests/core/test_3846_image_fetch.py
+++ b/tests/core/test_3846_image_fetch.py
@@ -1,0 +1,174 @@
+"""Tier 2: `core/present/image_fetch.py` — #3846 ① image-src resolution.
+
+``pin_ssrf=True`` is unconditional in this module (never a caller choice).
+Its own loopback denial is UNconditional too (`_ssrf_guard._deny_reason`
+checks `ip.is_loopback` before the `allow_private` opt-in even applies), so —
+same as `tests/test_web_fetch_download_cap_1913.py`'s own approach for the
+identical reason — a real local `HTTPServer` on 127.0.0.1 is structurally
+unreachable through the pinned transport and cannot serve as "a real
+collaborator" here; there is no real, deterministic remote HTTPS image host
+to fetch in CI either. The httpx.AsyncClient stand-in below is a real-shaped
+class (implements the exact `__aenter__`/`__aexit__`/`.stream()` surface this
+module calls), not a MagicMock — same idiom the existing web_fetch download-
+cap test already uses for this exact class of problem.
+
+The SSRF-block path itself is `_ssrf_guard`'s own tested contract
+(`tests/test_ssrf_guard_1956.py`) — not re-proven here. What IS tested here
+is `image_fetch`'s OWN logic: scheme gate, allowlist gate, size cap, SSRFBlocked
+wrapping, and that a normal response round-trips (bytes + content-type).
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+import pytest
+
+from reyn.core.present.image_fetch import ImageFetchError, fetch_image_bytes
+
+
+class _StreamResp:
+    def __init__(
+        self, *, body: bytes, content_type: str = "image/png", status: int = 200,
+    ) -> None:
+        self.headers = httpx.Headers({"content-type": content_type})
+        self.status_code = status
+        self._body = body
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            request = httpx.Request("GET", "http://example.invalid/x")
+            response = httpx.Response(self.status_code, request=request)
+            raise httpx.HTTPStatusError(
+                f"{self.status_code}", request=request, response=response
+            )
+
+    async def aiter_bytes(self):  # noqa: ANN201
+        for i in range(0, len(self._body), 16):
+            yield self._body[i : i + 16]
+
+
+class _StreamCtx:
+    def __init__(self, resp: "_StreamResp | Exception") -> None:
+        self._resp = resp
+
+    async def __aenter__(self) -> _StreamResp:
+        if isinstance(self._resp, Exception):
+            raise self._resp
+        return self._resp
+
+    async def __aexit__(self, *a: object) -> None:
+        return None
+
+
+def _client_factory(resp: "_StreamResp | Exception"):
+    class _Client:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_Client":
+            return self
+
+        async def __aexit__(self, *a: object) -> None:
+            return None
+
+        def stream(self, method: str, url: str) -> _StreamCtx:
+            return _StreamCtx(resp)
+
+    return _Client
+
+
+def _fetch(monkeypatch, resp: "_StreamResp | Exception", **kwargs: Any):
+    monkeypatch.setattr(httpx, "AsyncClient", _client_factory(resp))
+    return asyncio.run(fetch_image_bytes("https://example.com/x.png", **kwargs))
+
+
+def test_fetches_bytes_and_content_type(monkeypatch) -> None:
+    """Tier 2: a normal 200 response returns (body, content-type) verbatim."""
+    body, content_type = _fetch(
+        monkeypatch, _StreamResp(body=b"\x89PNG\r\n\x1a\nfake", content_type="image/png")
+    )
+    assert body == b"\x89PNG\r\n\x1a\nfake"
+    assert content_type == "image/png"
+
+
+def test_non_http_scheme_rejected_without_a_client_call(monkeypatch) -> None:
+    """Tier 2: a non-http(s) scheme (file://) is rejected by the scheme gate
+    itself — httpx.AsyncClient is monkeypatched to RAISE if constructed, so
+    this test also proves the gate fires before any client is even built."""
+    def _boom(**kwargs):
+        raise AssertionError("no client should be constructed for a bad scheme")
+    monkeypatch.setattr(httpx, "AsyncClient", _boom)
+    with pytest.raises(ImageFetchError, match="not http/https"):
+        asyncio.run(fetch_image_bytes("file:///etc/passwd"))
+
+
+def test_allowed_schemes_narrows_within_http_https(monkeypatch) -> None:
+    """Tier 2: `allowed_schemes=["https"]` rejects a plain-http src even
+    though http is itself a fetchable scheme in general — the opt-in
+    allowlist narrows WITHIN the fetchable set, without a client call."""
+    def _boom(**kwargs):
+        raise AssertionError("the allowlist gate must fire before any fetch")
+    monkeypatch.setattr(httpx, "AsyncClient", _boom)
+    with pytest.raises(ImageFetchError, match="not in the configured"):
+        asyncio.run(
+            fetch_image_bytes("http://example.com/x.png", allowed_schemes=["https"])
+        )
+
+
+def test_allowed_schemes_permits_a_listed_scheme(monkeypatch) -> None:
+    """Tier 2: falsification pair — the SAME allowlist mechanism does not
+    block a scheme that IS listed (proves the gate discriminates, not just
+    denies everything)."""
+    monkeypatch.setattr(
+        httpx, "AsyncClient", _client_factory(_StreamResp(body=b"ok"))
+    )
+    body, _ = asyncio.run(
+        fetch_image_bytes("http://example.com/x.png", allowed_schemes=["http"])
+    )
+    assert body == b"ok"
+
+
+def test_response_over_the_byte_cap_is_rejected(monkeypatch) -> None:
+    """Tier 2: a response larger than `max_bytes` raises rather than being
+    silently truncated or fully buffered — a streamed check, since this
+    stand-in sends no Content-Length header at all."""
+    with pytest.raises(ImageFetchError, match="exceeds the"):
+        _fetch(monkeypatch, _StreamResp(body=b"A" * 500), max_bytes=100)
+
+
+def test_a_larger_cap_allows_the_same_response(monkeypatch) -> None:
+    """Tier 2: falsification pair — raising the cap past the same response's
+    size lets it through, proving the cap (not something else) was the
+    reject reason above."""
+    body, _ = _fetch(monkeypatch, _StreamResp(body=b"A" * 500), max_bytes=10_000)
+    assert body == b"A" * 500
+
+
+def test_http_error_status_is_reported(monkeypatch) -> None:
+    """Tier 2: a 404 response raises ImageFetchError naming the status,
+    rather than returning the error page's body as if it were image bytes."""
+    with pytest.raises(ImageFetchError, match="404"):
+        _fetch(monkeypatch, _StreamResp(body=b"", status=404))
+
+
+def test_timeout_is_reported(monkeypatch) -> None:
+    """Tier 2: an httpx timeout is wrapped as ImageFetchError, naming the
+    configured timeout — not left as a bare httpx exception the presenter
+    layer would need to know about specifically."""
+    with pytest.raises(ImageFetchError, match="timed out"):
+        _fetch(monkeypatch, httpx.TimeoutException("timed out"), timeout=2.5)
+
+
+def test_ssrf_denial_is_reported_as_image_fetch_error(monkeypatch) -> None:
+    """Tier 2: the SSRF pin's own denial (SSRFBlocked, a PermissionError
+    subclass — NOT an httpx.RequestError) is wrapped too, so the presenter
+    layer catches exactly ONE exception type regardless of WHY the fetch
+    failed. `_ssrf_guard`'s own suite proves loopback/link-local/etc are
+    actually denied; this proves image_fetch does not let that denial leak
+    past its own error boundary as a raw, uncaught exception type."""
+    from reyn._ssrf_guard import SSRFBlocked
+
+    with pytest.raises(ImageFetchError):
+        _fetch(monkeypatch, SSRFBlocked("blocked fetch to 127.0.0.1 (loopback)"))

--- a/tests/core/test_3846_image_resolution_e2e.py
+++ b/tests/core/test_3846_image_resolution_e2e.py
@@ -1,0 +1,197 @@
+"""Tier 2: #3846 ①②③(scoped) — end-to-end image `src` resolution through the
+REAL TextualChatApp -> ReynPresenter -> render_presentation_nodes chain.
+
+Drives a real ``kind="presentation"`` frame with an ``image`` component node
+through ``TextualChatApp`` (not a hand-authored unit call), confirming:
+- the placeholder renders BEFORE resolution settles;
+- the SAME entry re-renders with the loaded state AFTER the background
+  fetch completes (proves the redraw-trigger, not just the cache write);
+- a failed fetch renders a distinguishable failure state, not the same
+  placeholder text a fetch that never started would show (the #3688 "two
+  different things look the same" class).
+
+``httpx.AsyncClient`` is monkeypatched with a real-shaped stand-in — the
+SAME necessity as ``tests/core/test_3846_image_fetch.py`` (pin_ssrf=True's
+loopback denial is unconditional, so there is no real reachable collaborator
+to hit from CI).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+from test_textual_chat_phase4_right_gutter_3283 import QueueTransport
+from textual_flowview import FlowView
+
+from reyn.config.chat import ChatConfig
+from reyn.config.root import ReynConfig
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _StreamResp:
+    def __init__(self, *, body: bytes, content_type: str = "image/png") -> None:
+        self.headers = httpx.Headers({"content-type": content_type})
+        self.status_code = 200
+        self._body = body
+
+    def raise_for_status(self) -> None:
+        pass
+
+    async def aiter_bytes(self):  # noqa: ANN201
+        yield self._body
+
+
+class _StreamCtx:
+    def __init__(self, resp: "_StreamResp | Exception") -> None:
+        self._resp = resp
+
+    async def __aenter__(self) -> _StreamResp:
+        if isinstance(self._resp, Exception):
+            raise self._resp
+        return self._resp
+
+    async def __aexit__(self, *a: object) -> None:
+        return None
+
+
+def _client_factory(resp: "_StreamResp | Exception"):
+    class _Client:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_Client":
+            return self
+
+        async def __aexit__(self, *a: object) -> None:
+            return None
+
+        def stream(self, method: str, url: str) -> _StreamCtx:
+            return _StreamCtx(resp)
+
+    return _Client
+
+
+def _presentation_frame(src: str) -> OutboxMessage:
+    return OutboxMessage(
+        kind="presentation",
+        text="",
+        meta={"nodes": [{"component": "image", "src": src, "alt": "a cat"}]},
+    )
+
+
+async def _entry_text(app: TextualChatApp, entry: object) -> str:
+    """Render `entry` through the app's REAL presenter — the same call
+    ``FlowView`` itself makes to draw a row — and flatten to plain text.
+    Reading `entry.item.text` (the raw OutboxMessage field) would NOT work
+    here: a `presentation`-kind message's visible content comes from
+    `meta["nodes"]` via `render_presentation_nodes`, computed at render
+    time, not stored on `.text`."""
+    import io
+
+    from rich.console import Console
+
+    presentation = await app._presenter.present(entry.item, width=100)
+    buf = io.StringIO()
+    Console(file=buf, color_system=None, width=100).print(presentation.renderable)
+    return buf.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_placeholder_renders_before_resolution_settles(monkeypatch) -> None:
+    """Tier 2: before the background fetch resolves, the entry shows the
+    PLACEHOLDER text (the pre-#3846 shape), not a crash and not the loaded
+    state prematurely."""
+    monkeypatch.setattr(
+        httpx, "AsyncClient", _client_factory(_StreamResp(body=b"\x89PNG-bytes"))
+    )
+    app = TextualChatApp(transport=QueueTransport())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._ingest_frame(_presentation_frame("https://example.com/cat.png"))
+        # No pause yet — the fetch task is scheduled but hasn't had a chance
+        # to run on the event loop.
+        entry = list(app.query_one(FlowView).entries)[-1]
+        text = await _entry_text(app, entry)
+        assert "[image: a cat]" in text, text
+
+
+@pytest.mark.asyncio
+async def test_loaded_state_replaces_the_placeholder_after_resolution(monkeypatch) -> None:
+    """Tier 2: ★ the redraw witness — after the background fetch settles, the
+    entry's ``revision`` (flowview's own public, monotonic "was ``.update()``
+    called" counter — bumped by NOTHING else in this test) has advanced, AND
+    the SAME entry now renders the loaded state.
+
+    ``revision`` is the load-bearing half: calling ``present()`` directly (as
+    :func:`_entry_text` does, to read content) would show the loaded state
+    from cache alone even if the redraw trigger were dead — a first version
+    of this test asserted content only and stayed GREEN with
+    ``entry.update()`` deleted from the implementation (caught by falsifying
+    it directly). Content is still asserted too — a bumped revision with the
+    WRONG content displayed would be an equally real bug."""
+    body = b"\x89PNG-bytes-here"
+    monkeypatch.setattr(
+        httpx, "AsyncClient", _client_factory(_StreamResp(body=body, content_type="image/png"))
+    )
+    app = TextualChatApp(transport=QueueTransport())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._ingest_frame(_presentation_frame("https://example.com/cat.png"))
+        entry = list(app.query_one(FlowView).entries)[-1]
+        revision_before = entry.revision
+        # Let the scheduled fetch task run to completion, then let the
+        # entry.update() redraw materialize.
+        await pilot.pause()
+        await pilot.pause()
+        assert entry.revision > revision_before, (
+            "entry.revision never advanced — the redraw trigger did not fire"
+        )
+        text = await _entry_text(app, entry)
+        assert "[image loaded: a cat" in text, text
+        assert str(len(body)) in text, text
+        assert "[image: a cat]" not in text, "the placeholder never cleared: " + text
+
+
+@pytest.mark.asyncio
+async def test_a_failed_fetch_renders_a_distinguishable_failure_state(monkeypatch) -> None:
+    """Tier 2: a fetch failure does NOT reuse the placeholder text (the
+    #3688 "invisible/unreachable read as the same thing" class named in the
+    #3846 design thread) — its own distinct failure state names the src."""
+    monkeypatch.setattr(
+        httpx, "AsyncClient", _client_factory(httpx.TimeoutException("timed out"))
+    )
+    app = TextualChatApp(transport=QueueTransport())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._ingest_frame(_presentation_frame("https://example.com/cat.png"))
+        entry = list(app.query_one(FlowView).entries)[-1]
+        await pilot.pause()
+        await pilot.pause()
+        text = await _entry_text(app, entry)
+        assert "[image failed: a cat" in text, text
+        assert "[image: a cat]" not in text, text
+        assert "[image loaded:" not in text, text
+
+
+@pytest.mark.asyncio
+async def test_config_scheme_allowlist_reaches_the_fetch_call(monkeypatch) -> None:
+    """Tier 2: `chat.image_url_schemes` (a REAL ReynConfig, not a stub) reaches
+    the actual fetch call — an https-only allowlist rejects a plain-http src,
+    surfacing as the failure state (proves the config value was actually
+    threaded app -> presenter -> fetch, not merely stored)."""
+    def _boom(**kwargs: Any):
+        raise AssertionError("the allowlist gate must reject before any client call")
+    monkeypatch.setattr(httpx, "AsyncClient", _boom)
+    config = ReynConfig(chat=ChatConfig(image_url_schemes=["https"]))
+    app = TextualChatApp(transport=QueueTransport(), config=config)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._ingest_frame(_presentation_frame("http://example.com/cat.png"))
+        entry = list(app.query_one(FlowView).entries)[-1]
+        await pilot.pause()
+        await pilot.pause()
+        text = await _entry_text(app, entry)
+        assert "[image failed: a cat" in text, text
+        assert "configured" in text.lower() or "scheme" in text.lower(), text

--- a/tests/core/test_3846_image_url_schemes_config.py
+++ b/tests/core/test_3846_image_url_schemes_config.py
@@ -1,0 +1,33 @@
+"""Tier 1: `chat.image_url_schemes` config parsing (#3846, owner ruling C).
+
+Default unrestricted ([]) — the owner's stated default for image-src fetch
+scope. See `core/present/image_fetch.py` for where this list is consumed.
+"""
+from __future__ import annotations
+
+from reyn.config.chat import ChatConfig, _build_chat_config
+
+
+def test_image_url_schemes_defaults_unrestricted() -> None:
+    """Tier 1: ChatConfig.image_url_schemes defaults to [] (owner ruling C)."""
+    assert ChatConfig().image_url_schemes == []
+
+
+def test_chat_image_url_schemes_parses_a_list() -> None:
+    """Tier 1: `chat.image_url_schemes: [https]` in reyn.yaml parses through."""
+    assert _build_chat_config({"image_url_schemes": ["https"]}).image_url_schemes == [
+        "https"
+    ]
+
+
+def test_chat_image_url_schemes_absent_stays_unrestricted() -> None:
+    """Tier 1: falsification pair — omitting the key keeps the [] default
+    (this field does not accidentally narrow for any other chat: block)."""
+    assert _build_chat_config({"render_mode": "plain"}).image_url_schemes == []
+
+
+def test_chat_image_url_schemes_non_list_value_is_ignored() -> None:
+    """Tier 1: a malformed value (not a list) falls back to unrestricted
+    rather than crashing config load — same defensive-parse contract every
+    other chat: field in this loader follows."""
+    assert _build_chat_config({"image_url_schemes": "https"}).image_url_schemes == []


### PR DESCRIPTION
**[tui-coder]** — #3846: wire `present`'s `image` component to fetch and show its `src` URL.

## Scope (①②③ split, agreed with lead-coder before implementation)

- ① fetch resolution (`core/present/image_fetch.py`, new module)
- ② TUI wiring (background fetch → cache → one-shot redraw on completion)
- ③ real pixel rendering (`textual-image`/`pillow`, a separate new-deps decision) and plain (`--cui`)'s own sync-fetch — **out of scope here, tracked as a remainder in #3846**. V1 renders a `[image loaded: alt — N bytes, content-type]` status line.

## Owner ruling

C (URL) — `src` is unrestricted by default (neutralize-only); opt-in scheme allowlist via `chat.image_url_schemes`. "Even without the bytes, the record of what was presented is enough."

## Design

- `image_fetch.py` lives **outside** `present_renderer.py` deliberately — that module's own docstring declares "Pure: ... No I/O" (FP-0054 PR-B invariant). Always routes through `build_async_http_client(pin_ssrf=True)` unconditionally (`src` is model-written).
- `ReynPresenter` owns the `image_cache` + kicks a background `asyncio` task on first sight of an unresolved `src`, then calls `entry.update()` once settled — one-shot, mirroring `_begin_running_indicator`'s shape without the periodic tick.
- `render_presentation_nodes`'s image branch stays a pure dict lookup; `image_cache=None` (every non-TUI caller) gets the pre-#3846 `[image: alt]` text, byte-identical.

## Findings recorded to #3846 during this work

- AG-UI has no byte-serving route → resolution belongs client-side (confirmed independently, then again via architect's measurement).
- MCP's own resource-URI guidance independently confirms C's shape for external URLs; a reyn-internal `media_store` path is a different scheme entirely and is **not** mixed into `src` here (future `reyn://` + read path, blocked on AG-UI #126, tracked separately).
- `/image` slash command doesn't use `media_store` — out of scope for this PR.
- `web_fetch` already uses `pin_ssrf=True` for its own image retrieval — confirms this module's boundary matches the existing trust class elsewhere.

## A real test-design bug caught by falsification

First version of the redraw-witness test asserted rendered content only (via a direct `present()` call), which stayed GREEN even with `entry.update()` deleted — `present()` recomputes from the cache fresh every call, so the test never exercised the redraw mechanism, only the cache write. Fixed by asserting `entry.revision` (flowview's own public, monotonic "was `.update()` called" counter) advanced, in addition to content. Re-falsified: 1/4 e2e tests correctly went RED with the trigger stripped, the rest stayed green.

## Test plan

- [x] `ruff check src tests` → clean
- [x] `python scripts/mypy_ratchet.py` → 212 findings, all baselined (no new)
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` → 17/17 OK
- [x] `python scripts/verify_module_docstrings.py <changed files>` → OK
- [x] `python scripts/flat_tests_ratchet.py --check-growth main` → OK (`tests/core/` already baselined)
- [x] `mkdocs build --strict` → 0 warnings
- [x] `pytest tests/test_config_mirror_coverage_1056.py` → 5 passed (3-way `chat.image_url_schemes` mirror)
- [x] `pytest tests/core/test_3846_image_fetch.py` → 9 passed
- [x] `pytest tests/core/test_3846_image_url_schemes_config.py` → 4 passed
- [x] `pytest tests/core/test_3846_image_resolution_e2e.py` → 4 passed LOCALLY (temporary, unshipped theme-registration workaround for the SAME pre-existing local env issue #3944's PR already documented and confirmed CI-clean — not fixed here, out of scope)
- [x] `pytest -k "3846 or present_op or present_renderer or present_sink or 2770 or config_mirror"` → 88 passed, 6 skipped (only this PR's own 4 e2e tests fail locally, on the env issue above)
- [ ] 🔵 Visual (owner waiver applies, standing merge policy)

## Note per #3936 (TESTS-READ gate)

This PR touches `tests/` — holding for a TESTS-READ before self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
