### PR TITLE
feat(#3823): unenforced-axis reason wording + paired WARN log

### DIFF
--- a/src/reyn/core/op_runtime/sandboxed_exec.py
+++ b/src/reyn/core/op_runtime/sandboxed_exec.py
@@ -13,17 +13,24 @@ Emits `sandboxed_exec_started` / `sandboxed_exec_completed` events (P6).
 """
 from __future__ import annotations
 
+import logging
 import os
 from typing import Literal
 
 from reyn.schemas.models import SandboxedExecIROp
 from reyn.security.sandbox import SandboxPolicy
 from reyn.security.sandbox.launcher import resolve_backend, run_and_classify
-from reyn.security.sandbox.policy import deny_narrowed_write_grants, unenforced_axes
+from reyn.security.sandbox.policy import (
+    deny_narrowed_write_grants,
+    unenforced_axes,
+    unenforced_axis_reason,
+)
 from reyn.security.sandbox.resolve import resolve_real_executable
 
 from . import register
 from .context import OpContext
+
+_logger = logging.getLogger(__name__)
 
 
 async def handle(
@@ -147,18 +154,38 @@ async def handle(
             ],
         )
 
-    # #3901 §4③: the selected backend may not be able to express an axis the
-    # policy configured (Landlock cannot carve a read/write deny-list out of
-    # an allowed parent — a structural LSM constraint, not a bug). Doc-only
-    # visibility reads as "written but nobody checks it" — this makes the gap
-    # an audit-event instead, mirroring sandbox_policy_narrowed's precedent.
-    # Deliberately NOT wired into enforcement_self_test (CLAUDE.md hard rule).
+    # #3901 §4③ / #3823: the selected backend may not be able to express an
+    # axis the policy configured (Landlock cannot carve a read/write deny-list
+    # out of an allowed parent — a structural LSM constraint, not a bug).
+    # Doc-only visibility reads as "written but nobody checks it" — this
+    # makes the gap an audit-event (for later reconstruction) AND a WARN log
+    # line (visible at the moment it happens, the same channel
+    # sandbox.on_unsupported's own WARN already uses for a backend that is
+    # entirely absent — see security/sandbox/__init__.py's _noop_with_policy;
+    # that is a DIFFERENT call site, since it fires at backend SELECTION
+    # time, before a policy's individual axes are even known, whereas this
+    # fires at op DISPATCH time once both the backend and the policy are
+    # resolved — #3823's own "same site?" question, answered: no). Not
+    # `error` — reyn cannot promise a policy is enforced, only report what a
+    # backend actually did with it (owner: "sandbox 抽象は ポリシを 保証できない.
+    # backend が できる 範囲で 保証するしか ない"). Deliberately NOT wired into
+    # enforcement_self_test (CLAUDE.md hard rule).
     unenforced = unenforced_axes(backend.name, policy)
     if unenforced:
+        reason = unenforced_axis_reason(backend.name)
         ctx.events.emit(
             "sandbox_axis_unenforced",
             backend=backend.name,
             axes=unenforced,
+            reason=reason,
+        )
+        _logger.warning(
+            "Sandbox: policy axis(es) %s were configured but the %s backend "
+            "cannot enforce them — %s. The policy was written but not "
+            "applied for these axes.",
+            unenforced,
+            backend.name,
+            reason,
         )
 
     launched = await run_and_classify(

--- a/src/reyn/security/sandbox/policy.py
+++ b/src/reyn/security/sandbox/policy.py
@@ -296,6 +296,37 @@ def unenforced_axes(backend_name: str, policy: SandboxPolicy) -> list[str]:
     return axes
 
 
+#: #3823: per-backend prose explaining WHY an axis is unenforced there — the
+#: same 2-value classification (enforced/unenforced) architect and lead-coder
+#: settled on (owner: "reyn が allow_env_names を書けると公開している以上,
+#: Docker で効かないのは backend が強制できない — Landlock の deny と同じ状態"),
+#: only the WORDING differs by backend/reason. Landlock is the only backend
+#: this fires for today (Seatbelt enforces both deny-lists via SBPL
+#: deny-after-allow); the dict stays keyed by backend name (not hardcoded to
+#: one message) so a future backend with a DIFFERENT reason for the same
+#: unenforced state (e.g. a container backend whose image, not reyn, decides
+#: what env reaches the process) gets its own prose without a new axis value.
+_UNENFORCED_AXIS_REASONS: dict[str, str] = {
+    "landlock": (
+        "this backend cannot express a deny-list here — Landlock is an LSM "
+        "allowlist-only constraint (you cannot carve a subpath out of an "
+        "allowed parent)"
+    ),
+}
+
+
+def unenforced_axis_reason(backend_name: str) -> str:
+    """Human-readable reason *backend_name* cannot enforce an axis
+    :func:`unenforced_axes` names — for the audit-event payload and the
+    paired WARN log line (#3823). Falls back to a generic statement for a
+    backend not in :data:`_UNENFORCED_AXIS_REASONS` (defensive; every backend
+    :func:`unenforced_axes` currently classifies as incapable has an entry)."""
+    return _UNENFORCED_AXIS_REASONS.get(
+        backend_name,
+        f"this backend ({backend_name!r}) cannot enforce this axis",
+    )
+
+
 # ── default sandbox policy resolution (#1339 / sandbox-model completion) ──────
 #
 def resolve_sandbox_policy(

--- a/tests/core/test_3901_sandbox_axis_unenforced.py
+++ b/tests/core/test_3901_sandbox_axis_unenforced.py
@@ -116,6 +116,64 @@ async def test_unenforced_axis_emits_audit_event_through_real_op_dispatch(tmp_pa
     assert unenforced, "expected a sandbox_axis_unenforced audit-event"
     assert unenforced[0].data["backend"] == "landlock"
     assert unenforced[0].data["axes"] == ["read_deny_paths"]
+    # #3823: the audit-event names WHY, not just WHICH axes — the report is
+    # "policy X was given, backend Y did Z with it", not a bare axis list.
+    assert "cannot express a deny-list" in unenforced[0].data["reason"]
+
+
+@pytest.mark.asyncio
+async def test_unenforced_axis_also_emits_a_warn_log_line(tmp_path, caplog):
+    """Tier 2: #3823 — the audit-event alone lands in .reyn/events, a surface
+    nobody re-reads without cause (the same "written but nobody checks it"
+    shape #3899 named). A WARN log line is the paired, at-the-moment
+    visibility — the same channel sandbox.on_unsupported's own WARN already
+    uses for a wholly-absent backend, reused here for the narrower "backend
+    present but this axis unenforceable" case."""
+    import logging
+
+    from reyn.core.events.events import EventLog
+    from reyn.core.op_runtime.context import OpContext
+    from reyn.core.op_runtime.sandboxed_exec import handle
+    from reyn.data.workspace.workspace import Workspace
+    from reyn.schemas.models import SandboxedExecIROp
+    from reyn.security.permissions.permissions import PermissionDecl
+
+    events = EventLog()
+    ws = Workspace(events=events)
+    ctx = OpContext(
+        workspace=ws,
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=None,
+        sandbox_backend=_LandlockShapedBackend(),
+        default_sandbox_policy={"read_deny_paths": [str(tmp_path / "secret")]},
+    )
+    op = SandboxedExecIROp(kind="sandboxed_exec", argv=["/bin/echo", "hi"])
+    with caplog.at_level(logging.WARNING, logger="reyn.core.op_runtime.sandboxed_exec"):
+        await handle(op, ctx)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "expected a WARN log line when an axis is unenforced"
+    assert "read_deny_paths" in warnings[0].getMessage()
+    assert "landlock" in warnings[0].getMessage()
+
+
+def test_unenforced_axis_reason_names_the_structural_cause() -> None:
+    """Tier 1: #3823 — the reason string is per-backend prose, not a bare
+    axis-name echo; a future backend with a DIFFERENT reason for the same
+    unenforced state gets its own text (owner: a Docker-shaped backend
+    "not enforcing env" is the SAME 2-value state as Landlock's deny-list
+    gap, but a DIFFERENT reason — the image decides, not a kernel
+    constraint). Falls back to a generic statement for an unlisted backend
+    rather than raising, matching unenforced_axes' own defensive posture."""
+    from reyn.security.sandbox.policy import unenforced_axis_reason
+
+    landlock_reason = unenforced_axis_reason("landlock")
+    assert "Landlock" in landlock_reason or "landlock" in landlock_reason
+    assert "allowlist" in landlock_reason
+
+    fallback_reason = unenforced_axis_reason("some-future-backend")
+    assert "some-future-backend" in fallback_reason
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[e2e-coder]** — #3823 item ③ (independent of ①②, which await a design confirmation on #3823).

Per #3823's settled spec: `sandbox_axis_unenforced` stays 2-value (enforced/unenforced — the earlier 3rd "not_applicable" value was withdrawn by both architect and lead-coder), but the wording now names WHY, and the audit-event (a `.reyn/events` surface nobody re-reads without cause) is paired with a WARN log line for at-the-moment visibility, reusing the same channel `sandbox.on_unsupported`'s own WARN already uses for a wholly-absent backend.

## `unenforced_axis_reason()`

Per-backend prose (Landlock: "cannot express a deny-list — LSM allowlist-only constraint"), keyed by backend name so a future backend with a DIFFERENT reason for the same 2-value state (e.g. a container backend whose image decides env, not reyn) gets its own text without a new axis value.

## Measured (per lead-coder's explicit "未測定" flag): the WARN sites are DIFFERENT, not the same

`sandbox.on_unsupported`'s WARN fires at backend SELECTION time (`security/sandbox/__init__.py`'s `_noop_with_policy`) — before a policy's individual axes are even known. `sandbox_axis_unenforced` fires at op DISPATCH time (`sandboxed_exec.py`), once both the backend and the resolved policy exist. Confirmed by reading both call sites directly — `sandboxed_exec.py` needed its own module-level logger.

## Not `error`

Per owner's ruling on this issue: reyn cannot promise a policy is enforced, only report what a backend actually did with it. No stop mechanism added, per spec.

## Falsify-verification

Stripped the reason/WARN wiring back to the pre-#3823 bare audit-event — confirmed the new WARN-log test goes RED (empty caplog) for the documented reason. Restored, confirmed 10/10 green.

## Test plan

- [x] `ruff check` (touched files) — green
- [x] `python scripts/test_tier_audit.py --strict tests/core/test_3901_sandbox_axis_unenforced.py` — 10/10 OK
- [x] `pytest tests/core/test_3901_sandbox_axis_unenforced.py` — 10 passed
- [x] `python scripts/verify_module_docstrings.py` (touched files) — OK
- [x] `python scripts/mypy_ratchet.py` — 212 findings, all baselined
- [x] Falsify-verified (strip → RED, restore → GREEN)

Part of #3823 (does not close it — ①/② still pending).

Per rule 8 (#3936): this touches `tests/`, so it waits on reviewer TESTS-READ before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)