### PR TITLE
docs: rule 7's reviewer blocking-point edit inherits rule 4's closing-keyword trap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -404,6 +404,22 @@ These rules then keep multi-session work coherent:
    to add it as `- [ ] 🔴 <point>` (append, don't remove the author's own
    items) and does not merge while it's unchecked; the author checks it off
    once addressed, in the same PR body, with the fixing commit noted.
+   **Rule 4 applies to this edit too** — a reviewer's appended text lands
+   on the same PR body surface rule 4 governs, and `check_pr_closing_intent.py`
+   deliberately strips backticks before matching (the criterion is *use vs
+   mention*, not "is it fenced"), so pointing out that a PR wrongly wrote
+   `Closes #X` by quoting `` `Closes #X` `` in your own blocking item still
+   trips the gate — the correct PR being blocked over how the correction
+   was phrased (#3559's shape again: the disciplined party pays). Point at
+   the problem without writing the keyword next to the number — name which
+   line has it wrong, or say "uses the closing keyword" without the keyword
+   itself; a literal `<!-- closing-check: discussing #N -->` comment is the
+   last resort when the keyword must appear verbatim. **This applies when
+   handing someone else phrasing to use, too, not only when writing your
+   own PR body** — a brief, a dispatch message, or a review request that
+   pairs the keyword with a number gets copied faithfully by whoever
+   receives it, and the trap fires on THEIR PR, not the sender's. Check
+   phrasing you're about to hand off the same way you'd check your own.
 8. **A PR touching `tests/` does not self-merge until a reviewer's
    TESTS-READ note lands on the PR.** "A lead-coder merge train refuses
    any PR touching `tests/` without one" (Test review, above) describes


### PR DESCRIPTION
**[docs-maintainer]** — lead-coder依頼。CLAUDE.md rule 7の実体あるギャップを埋める。

## The gap

rule 7はレビュアがPR本文にblocking項目を追記することを求めていますが、その追記自体が
rule 4の対象になるとはどこにも書かれていませんでした。

## Today's incident

lead-coderが別PRのレビューで、あるPRの本文の閉じキーワードをより安全な形へ変えるべき、
という指摘をblocking項目として書きました。指摘文中でその安全でない表現をバッククォートで
引用しましたが、`check_pr_closing_intent.py`のgateはそれでも赤くなりました。script本体を
直接確認して検証済み: このscriptはmatchingの前にバッククォート文字を意図的に全て
取り除きます(判定基準は「使用か言及か」であってfenceされているかどうかではない、と
scriptのモジュールdocstring自身が明記)。正しい指摘をした側がCIを赤にする、という
これまでのパターン(#3559)の再演です。

## What's added to rule 7

レビュアの追記もrule 4が適用される同じPR本文面に載ること、閉じキーワード問題を指摘する
際はキーワードと番号を並べて書かないこと(該当行を名指しするか、キーワード自体を使わずに
「閉じキーワードを使っている」とだけ言う)、verbatim引用がどうしても必要な場合の最終手段
として`<!-- closing-check: discussing #N -->`マーカー(script内に実在すること確認済み)
が使えること、を追記しました。

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0, no new WARNING/Aborted lines
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` → 336 passed
- [x] `check_pr_closing_intent.py`のbacktick-stripping挙動をsource直接確認済み
- [x] `<!-- closing-check: discussing #N -->`マーカーの実在をsource直接確認済み
- [x] Branch created off verified-current `origin/main`; remote head verified via `git ls-remote origin refs/heads/docs/rule7-inherits-rule4-closing-keyword-trap`
- [x] このPR本文自体、閉じキーワードと課題番号を隣接させない形で書いています(rule 4のtrapを自分で踏まないため)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
