### PR TITLE
test(#3891): relabel Tier 2 -> Tier 1, strengthen 7 vacuous _summarize_result tests

### DIFF
--- a/tests/test_repl_renderer_pure_helpers.py
+++ b/tests/test_repl_renderer_pure_helpers.py
@@ -1,9 +1,21 @@
-"""Tier 2: pure helpers in interfaces/repl/renderer.py.
+"""Tier 1: pure helpers in interfaces/repl/renderer.py.
 
   ``_meta_prefix(meta)``     — builds [skill#run_id] prefix from meta dict
   ``_short(v, n)``           — collapses whitespace + truncates any value
   ``_summarize_args(args)``  — compact k=v summary of a tool args dict
   ``_summarize_result(tool, result)`` — human one-line tool result summary
+
+#3891: relabeled from a stale "Tier 2" (these are directly-testable function
+contracts, not OS-level invariants reyn promises externally — the original
+"Tier 2" was a mislabel, not a Tier-4 formatting trivia problem).
+
+#3891 (owner-directed): a relabel alone was rejected — the six-questions Q3
+("would it stay green with the mechanism dead?") was run against every test
+in `_summarize_result`'s group, since display-formatting helpers are exactly
+where a substring assertion coincidentally overlaps the same helper's own
+dict/list `repr()` fallback, silently surviving the branch it claims to test
+being deleted or subtly broken. 7 of 11 were found vacuous this way and
+strengthened; see each test's own docstring for its specific finding.
 """
 from __future__ import annotations
 
@@ -27,27 +39,27 @@ from reyn.interfaces.repl.renderer import (
 
 
 def test_meta_prefix_both_skill_and_run_id() -> None:
-    """Tier 2: actor + run_id_short → '[skill#abcd] ' prefix."""
+    """Tier 1: actor + run_id_short → '[skill#abcd] ' prefix."""
     assert _meta_prefix({"actor": "research", "run_id_short": "ab12"}) == "[research#ab12] "
 
 
 def test_meta_prefix_skill_only() -> None:
-    """Tier 2: actor without run_id_short → '[skill] ' prefix."""
+    """Tier 1: actor without run_id_short → '[skill] ' prefix."""
     assert _meta_prefix({"actor": "finder"}) == "[finder] "
 
 
 def test_meta_prefix_run_id_only() -> None:
-    """Tier 2: run_id_short without actor → '[#abcd] ' prefix."""
+    """Tier 1: run_id_short without actor → '[#abcd] ' prefix."""
     assert _meta_prefix({"run_id_short": "cd34"}) == "[#cd34] "
 
 
 def test_meta_prefix_empty_meta() -> None:
-    """Tier 2: empty meta dict → empty string."""
+    """Tier 1: empty meta dict → empty string."""
     assert _meta_prefix({}) == ""
 
 
 def test_meta_prefix_unrelated_keys_ignored() -> None:
-    """Tier 2: keys other than actor/run_id_short produce empty string."""
+    """Tier 1: keys other than actor/run_id_short produce empty string."""
     assert _meta_prefix({"status": "done", "turn_id": "42"}) == ""
 
 
@@ -57,41 +69,41 @@ def test_meta_prefix_unrelated_keys_ignored() -> None:
 
 
 def test_short_none_returns_empty() -> None:
-    """Tier 2: None input returns empty string."""
+    """Tier 1: None input returns empty string."""
     assert _short(None) == ""
 
 
 def test_short_short_string_unchanged() -> None:
-    """Tier 2: string under the default cap is returned as-is."""
+    """Tier 1: string under the default cap is returned as-is."""
     assert _short("hello world") == "hello world"
 
 
 def test_short_collapses_whitespace() -> None:
-    """Tier 2: multiple spaces/newlines are collapsed to single spaces."""
+    """Tier 1: multiple spaces/newlines are collapsed to single spaces."""
     assert _short("a  b\n  c") == "a b c"
 
 
 def test_short_truncates_at_default_limit() -> None:
-    """Tier 2: string exceeding 60 chars is truncated with '…' at position 59."""
+    """Tier 1: string exceeding 60 chars is truncated with '…' at position 59."""
     long = "x" * 65
     result = _short(long)
     assert result == "x" * 59 + "…"
 
 
 def test_short_custom_limit() -> None:
-    """Tier 2: explicit n truncates at that length (9 chars + '…' = n=10)."""
+    """Tier 1: explicit n truncates at that length (9 chars + '…' = n=10)."""
     result = _short("a" * 20, n=10)
     assert result == "a" * 9 + "…"
 
 
 def test_short_non_string_uses_repr() -> None:
-    """Tier 2: non-string values are repr'd before truncation."""
+    """Tier 1: non-string values are repr'd before truncation."""
     result = _short(42)
     assert result == "42"
 
 
 def test_short_dict_uses_repr() -> None:
-    """Tier 2: dict is repr'd (not JSON-encoded)."""
+    """Tier 1: dict is repr'd (not JSON-encoded)."""
     result = _short({"a": 1}, n=100)
     assert "a" in result
     assert "1" in result
@@ -103,31 +115,36 @@ def test_short_dict_uses_repr() -> None:
 
 
 def test_summarize_args_empty_dict() -> None:
-    """Tier 2: empty dict returns empty string."""
+    """Tier 1: empty dict returns empty string."""
     assert _summarize_args({}) == ""
 
 
 def test_summarize_args_none() -> None:
-    """Tier 2: None returns empty string."""
+    """Tier 1: None returns empty string."""
     assert _summarize_args(None) == ""
 
 
 def test_summarize_args_single_key() -> None:
-    """Tier 2: single-key dict renders as 'key=value'."""
+    """Tier 1: single-key dict renders as 'key=value'.
+
+    The ``"path="`` (with the ``=``) is the discriminating check — a dead
+    dict-branch falls to the bare-value path, whose ``repr()`` output uses
+    ``'path':`` (a colon, from Python dict repr), never ``path=``."""
     result = _summarize_args({"path": "/tmp/file.txt"})
     assert "path=" in result
     assert "/tmp/file.txt" in result
 
 
 def test_summarize_args_multiple_keys() -> None:
-    """Tier 2: multiple keys render comma-separated."""
+    """Tier 1: multiple keys render comma-separated. Same ``=``-vs-``:``
+    discriminator as the single-key test above."""
     result = _summarize_args({"a": "x", "b": "y"})
     assert "a=" in result
     assert "b=" in result
 
 
 def test_summarize_args_bare_string() -> None:
-    """Tier 2: non-dict arg is shortened to a one-liner."""
+    """Tier 1: non-dict arg is shortened to a one-liner."""
     result = _summarize_args("hello")
     assert "hello" in result
 
@@ -138,64 +155,105 @@ def test_summarize_args_bare_string() -> None:
 
 
 def test_summarize_result_none_returns_done() -> None:
-    """Tier 2: None result → 'done'."""
+    """Tier 1: None result → 'done'."""
     assert _summarize_result("any_tool", None) == "done"
 
 
 def test_summarize_result_empty_string_returns_done() -> None:
-    """Tier 2: empty-string result → 'done'."""
+    """Tier 1: empty-string result → 'done'."""
     assert _summarize_result("any_tool", "") == "done"
 
 
 def test_summarize_result_list_uses_item_count() -> None:
-    """Tier 2: list result → 'N items'."""
+    """Tier 1: list result → 'N items', exact match.
+
+    #3891 Q3 finding: the prior ``"3" in result`` substring check stayed
+    green even with the whole list-counting branch DELETED — ``repr([1, 2,
+    3])`` is ``"[1, 2, 3]"``, which itself contains ``"3"``, so the assertion
+    could not tell "the branch computed 3" from "the branch never ran and
+    Python's own list repr happened to have a 3 in it". Exact equality on
+    the branch's own wording closes that gap."""
     result = _summarize_result("any_tool", [1, 2, 3])
-    assert "3" in result
+    assert result == "3 items"
 
 
 def test_summarize_result_list_singular() -> None:
-    """Tier 2: single-element list uses singular 'item'."""
+    """Tier 1: single-element list uses singular 'item', exact match.
+
+    #3891 Q3 finding: the prior ``"1 item" in result`` check stays green even
+    against a BROKEN singular/plural ternary (always appending 's') — "1
+    item" is a substring of "1 items", so a pluralization regression was
+    invisible to this test. Exact equality closes that gap."""
     result = _summarize_result("any_tool", ["x"])
-    assert "1 item" in result
+    assert result == "1 item"
 
 
 def test_summarize_result_list_search_shows_count() -> None:
-    """Tier 2: list from a search tool includes the item count."""
+    """Tier 1: list from a search tool uses the word 'results', not 'items'.
+
+    #3891 Q3 finding: the prior ``"2" in result`` check never verified the
+    thing its own docstring claimed ("includes the item count" — but not
+    that a SEARCH tool's word differs from a non-search tool's). ``repr([1,
+    2])`` also contains "2", so the assertion passed whether or not the
+    ``"search" in t`` branch ran at all. Exact equality on the actual
+    'results' wording closes both gaps."""
     result = _summarize_result("web_search", [1, 2])
-    assert "2" in result
+    assert result == "2 results"
 
 
 def test_summarize_result_read_op_counts_lines() -> None:
-    """Tier 2: dict with op=read and content counts newlines + 1."""
+    """Tier 1: dict with op=read and content counts newlines + 1, exact match."""
     result = _summarize_result("read_file", {"op": "read", "content": "line1\nline2\nline3"})
-    assert "Read 3 lines" in result or "3 line" in result
+    assert result == "Read 3 lines"
 
 
 def test_summarize_result_read_op_singular() -> None:
-    """Tier 2: single-line content uses 'line' not 'lines'."""
+    """Tier 1: single-line content uses 'line' not 'lines', exact match.
+
+    #3891 Q3 finding: same substring-survives-pluralization-bug class as
+    ``test_summarize_result_list_singular`` above — "1 line" is a substring
+    of "1 lines"."""
     result = _summarize_result("read_file", {"op": "read", "content": "one line"})
-    assert "1 line" in result
+    assert result == "Read 1 line"
 
 
 def test_summarize_result_write_op_with_path() -> None:
-    """Tier 2: dict with op=write includes the path in the result."""
+    """Tier 1: dict with op=write includes the path in the result, exact match.
+
+    #3891 Q3 finding: the prior ``"/out.txt" in result`` check stayed green
+    even with the whole write-branch DELETED — the dict's own
+    ``repr({"op": "write", "path": "/out.txt"})`` contains ``/out.txt`` too.
+    Exact equality on the branch's own "Wrote ..." wording closes that gap."""
     result = _summarize_result("write_file", {"op": "write", "path": "/out.txt"})
-    assert "/out.txt" in result
+    assert result == "Wrote /out.txt"
 
 
 def test_summarize_result_edit_op_with_path() -> None:
-    """Tier 2: dict with op=edit includes the path in the result."""
+    """Tier 1: dict with op=edit includes the path in the result, exact match.
+
+    #3891 Q3 finding: same repr-fallback-survives-deletion class as
+    ``test_summarize_result_write_op_with_path`` above."""
     result = _summarize_result("edit_file", {"op": "edit", "path": "/src.py"})
-    assert "/src.py" in result
+    assert result == "Edited /src.py"
 
 
 def test_summarize_result_dict_with_status() -> None:
-    """Tier 2: dict with a status key → status string."""
+    """Tier 1: dict with a status key → the bare status string, exact match.
+
+    #3891 Q3 finding: the prior ``"ok" in result`` check stayed green even
+    with the ``if status: return str(status)`` branch DELETED —
+    ``repr({"status": "ok"})`` contains ``ok`` too. Exact equality closes
+    that gap."""
     result = _summarize_result("any_tool", {"status": "ok"})
-    assert "ok" in result
+    assert result == "ok"
 
 
 def test_summarize_result_fallback_repr() -> None:
-    """Tier 2: unrecognised non-empty value degrades to truncated repr."""
+    """Tier 1: unrecognised non-empty value degrades to truncated repr.
+
+    Unlike the dict-branch tests above, this test's OWN subject is the
+    fallback path itself (a bare ``42``, matching no dict/list branch at
+    all) — there is no earlier branch for it to vacuously survive the
+    deletion of."""
     result = _summarize_result("any_tool", 42)
-    assert "42" in result
+    assert result == "42"


### PR DESCRIPTION
**[tui-coder]** — test(#3891): relabel Tier 2 → Tier 1, strengthen 7 vacuous `_summarize_result` tests.

## Not just a relabel

Per lead-coder's redirect on the original proposal: ran six-questions Q1/Q2/Q3 against all 28 tests, since display-formatting helpers are exactly where a test tends toward Tier 4 (pinning exact formatting — banned) or a vacuous Q3.

**21/28 needed no change** — `_meta_prefix`/`_short`/`_summarize_args` already assert exact equality or use a discriminating substring (`"key="` vs a dict-repr's `"key:"`).

**7/28 (all in `_summarize_result`) were genuinely vacuous under Q3** — a substring assertion that coincidentally also appears in the *same dict/list's own `repr()` fallback*, so the test stays green with the branch it claims to guard either deleted outright or subtly broken (pluralization). All 7 fixed to exact equality on the branch's real output wording.

## Six-questions record, per finding

| Test | Q1 | Q2 | Q3 (before fix) |
|---|---|---|---|
| `list_uses_item_count` | Tier 1 | no transcription | ❌ `"3" in result` — `repr([1,2,3])` also has "3" |
| `list_singular` | Tier 1 | no transcription | ❌ `"1 item" in result` — substring of "1 items" |
| `list_search_shows_count` | Tier 1 | no transcription | ❌ never checked "results" vs "items" at all |
| `read_op_singular` | Tier 1 | no transcription | ❌ same pluralization-substring gap |
| `write_op_with_path` | Tier 1 | no transcription | ❌ `repr({"op":"write","path":...})` also has the path |
| `edit_op_with_path` | Tier 1 | no transcription | ❌ same repr-fallback-survives-deletion class |
| `dict_with_status` | Tier 1 | no transcription | ❌ `repr({"status":"ok"})` also has "ok" |

The other 21 all answer Q1=Tier 1, Q2=no transcription, Q3=correctly distinguishes (verified — see falsification below).

## Falsification

6 distinct mutations (7th shares its exact mutation with `list_singular`, already proven): disabled the search-word ternary, the write branch, the edit branch, the status fallback, and broke the singular/plural ternary in two places (list count, read-line count). Each isolated to exactly the 1 test claiming to guard it; 28/28 green after each restore.

## Test plan

- [x] `ruff check tests/test_repl_renderer_pure_helpers.py` → clean
- [x] `python scripts/mypy_ratchet.py` → 212 findings, all baselined (no new)
- [x] `python scripts/test_tier_audit.py --strict tests/test_repl_renderer_pure_helpers.py` → 28/28 OK
- [x] `python scripts/verify_module_docstrings.py` → OK
- [x] `python scripts/flat_tests_ratchet.py --check-growth main` → OK (existing file)
- [x] `pytest tests/test_repl_renderer_pure_helpers.py tests/test_inline_renderer_cutover.py tests/test_markdown_palette_gate_3469.py` → 64 passed (no consumer relied on the old weaker assertions)
- [x] Falsification (6 mutations) → each correctly isolated to 1 test, 28/28 restored

## Note per #3936 (TESTS-READ gate)

This PR touches `tests/` — holding for a TESTS-READ before self-merging.

Closes #3891. part of #3880 (the wider arc this issue is one piece of).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
