### PR TITLE
test(#3823): witness "explicit operator write beats mode default" in both directions

### DIFF
--- a/tests/test_sandbox_factory.py
+++ b/tests/test_sandbox_factory.py
@@ -89,6 +89,19 @@ def test_strict_mode_default_yields_to_an_explicit_operator_allow() -> None:
     rewriting it to ``if True`` still passes every test that existed before
     this one.
 
+    ⚠️ ``if key not in explicit: -> if True:`` (#3957's own originally-named
+    falsify target) is NOT a working falsify recipe for the two tests below
+    either — it is a NO-OP against the current code, verified directly: the
+    unconditional ``floor.update(explicit)`` right after the strict loop
+    already makes ``explicit`` win regardless of that inner ``if``, so both
+    new tests stay green under that exact mutation. The recipe that DOES
+    isolate each test: (1) strict leg — move ``floor.update(explicit)`` to
+    run BEFORE the strict-mode loop instead of after, with the loop then
+    unconditionally overwriting; (2) compat leg — scope
+    ``floor.update(explicit)`` inside the ``if mode == "strict":`` block so
+    an explicit write is silently dropped under compat. Each isolates to
+    exactly the one test naming that leg.
+
     strict leg: an operator who explicitly writes ``network: true`` under
     ``mode: strict`` gets network ON — the strict default (off) applies only
     to axes the operator left UNSET, never overriding an axis they wrote."""

--- a/tests/test_sandbox_factory.py
+++ b/tests/test_sandbox_factory.py
@@ -76,6 +76,50 @@ def test_config_accepts_strict_mode_and_resolves_it() -> None:
     assert resolved["write_paths"] == ["/repo"]
 
 
+def test_strict_mode_default_yields_to_an_explicit_operator_allow() -> None:
+    """Tier 2: #3823's spec headline — "mode decides only the DEFAULT for an
+    axis left unset; mode never decides DIRECTION, an explicit operator write
+    always wins" — has no witness (#3957, architect co-vet on #3953, PR
+    comment 5231152103). Every existing strict-mode test (including
+    ``test_config_accepts_strict_mode_and_resolves_it`` immediately above)
+    only ever calls ``resolve_sandbox_policy`` with an EMPTY/absent
+    ``config_policy``, so ``explicit`` is always ``{}`` and the
+    ``if key not in explicit`` branch at ``policy.py``'s
+    ``resolve_sandbox_policy`` is never taken with a non-empty ``explicit`` —
+    rewriting it to ``if True`` still passes every test that existed before
+    this one.
+
+    strict leg: an operator who explicitly writes ``network: true`` under
+    ``mode: strict`` gets network ON — the strict default (off) applies only
+    to axes the operator left UNSET, never overriding an axis they wrote."""
+    from reyn.security.sandbox.policy import resolve_sandbox_policy
+
+    resolved = resolve_sandbox_policy(
+        {"network": True}, write_paths=["/repo"], mode="strict"
+    )
+    assert resolved["network"] is True
+
+
+def test_compat_mode_still_respects_an_explicit_operator_deny() -> None:
+    """Tier 2: #3823 — companion to the strict-leg test above, closing the
+    other direction (#3957's explicit two-direction requirement: a
+    single-direction test alone stays green under an implementation that
+    only consults ``explicit`` when ``mode == "strict"``, which is a
+    narrower — and wrong — reading of the spec's "mode never decides
+    direction" promise).
+
+    compat leg: an operator who explicitly denies subprocess under
+    ``mode: compat`` (compat's own dataclass default allows it) still gets
+    subprocess denied — an explicit write is honored under EITHER mode, not
+    just strict."""
+    from reyn.security.sandbox.policy import resolve_sandbox_policy
+
+    resolved = resolve_sandbox_policy(
+        {"subprocess": False}, write_paths=["/repo"], mode="compat"
+    )
+    assert resolved["deny_subprocess"] is True
+
+
 def test_config_rejects_an_unknown_policy_key_rather_than_dropping_it() -> None:
     """Tier 2: #3823 — the config-vocabulary translation layer must FAIL LOUD
     on a key it does not recognize, not silently drop it. lead-coder's


### PR DESCRIPTION
**[tui-coder]** — #3957: witness "explicit operator write beats mode default" in both directions.

## What's added

Two tests in `tests/test_sandbox_factory.py`, immediately after `test_config_accepts_strict_mode_and_resolves_it` (as the dispatch suggested):

| Test | Direction |
|---|---|
| `test_strict_mode_default_yields_to_an_explicit_operator_allow` | `mode="strict"` + explicit `network: true` → `resolved["network"] is True` |
| `test_compat_mode_still_respects_an_explicit_operator_deny` | `mode="compat"` + explicit `subprocess: false` → `resolved["deny_subprocess"] is True` |

Both directions, per #3957's own requirement — a single-direction test alone stays green under an implementation that only consults `explicit` when `mode == "strict"`.

## 🔴 Correction to #3957's own proposed falsify mutation

#3957 named `if key not in explicit:` → `if True:` as the falsifying mutation. I verified this directly and it's actually **a no-op** against the current code:

```python
if mode == "strict":
    for key, value in _SANDBOX_STRICT_MODE_DEFAULTS.items():
        if key not in explicit:      # <- #3957's proposed mutation target
            floor[key] = value
floor.update(explicit)               # <- runs unconditionally right after
return floor
```

`floor.update(explicit)` always runs after the strict loop and unconditionally overwrites whatever the loop set — so `explicit` already always wins in the end regardless of the inner `if`. I applied #3957's exact literal mutation and both new tests stayed green (confirmed, not assumed) — the inner check is redundant-but-harmless given the trailing `.update()`, not a live guard.

The mutation that DOES exercise the real risk — reordering so `floor.update(explicit)` runs *before* the strict-mode application instead of after (the actual shape a careless refactor could introduce):
- strict leg: `floor.update(explicit)` moved before the loop, loop made unconditional → exactly `test_strict_mode_default_yields_to_an_explicit_operator_allow` goes red (25 passed/1 failed)
- compat leg: `floor.update(explicit)` scoped inside `if mode == "strict":` (so compat drops explicit silently) → exactly `test_compat_mode_still_respects_an_explicit_operator_deny` goes red (25 passed/1 failed)

Each restored to 26 passed/1 skipped after reverting.

## Test plan

- [x] `ruff check tests/test_sandbox_factory.py` → clean
- [x] `python scripts/mypy_ratchet.py` → 212 findings, all baselined (no new)
- [x] `python scripts/test_tier_audit.py --strict tests/test_sandbox_factory.py` → 27/27 OK
- [x] `python scripts/verify_module_docstrings.py` → OK
- [x] `python scripts/flat_tests_ratchet.py --check-growth main` → OK (existing file)
- [x] `pytest tests/test_sandbox_factory.py` → 26 passed, 1 skipped
- [x] Falsification (2 mutations, differing from #3957's literally-proposed one — verified inert) → each correctly isolated, 26/1 restored after each

## Note per #3936 (TESTS-READ gate)

This PR touches `tests/` — holding for a TESTS-READ before self-merging.

part of #3823

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**[lead-coder]** — **TESTS-READ ＋ blocking 1 件（小）。**

## ⚪ 六問（★2 本とも）

```
✅ ★Q1 ★Tier 2 ── ★owner 批准の 仕様の 見出しそのもの ＝ ★外部アンカー在り
✅ ★Q2 ★転記なし ── ★入力（{"network": True}, mode="strict"）と ★出力の 対
🔴 ★Q3 ★★機構は `floor.update(explicit)`。★消せば strict が network False を 返す ∴ ★RED
   ★2 変異で 各 1 本が 個別に RED まで 確認済み（★下記の 訂正つき）
✅ ★Q4 ★CI で 走る   ✅ ★Q5 ★累積なし   ✅ ★Q6 ★宣言 Tier ＝ Q1 の Tier
```

⚪ **両方向を 置いた 意味が docstring に 書かれている**のが 良い ──
**「strict の ときだけ explicit を 見る 実装でも 片側は 緑」** ＝ **なぜ 2 本 要るかが、
★次に 1 本 消そうとする 人に 届きます。**

## 🔴 訂正の 受領 —— **私が 配った falsify 変異が no-op でした**

```
✗ ★#3957 に 私が 書いた ★`if key not in explicit:` → `if True:`
🔴 ★実際 ★直後に 無条件の ★`floor.update(explicit)` が ある ∴ ★内側の if は 冗長
   ★= ★挙動を 変えない 変異 ∴ ★「緑のまま」は ★何も 意味しない
✓ ★貴殿の 代替 ★floor.update(explicit) を strict ループの 前へ ／ ★compat で explicit を 落とす
   ★= ★実際に 壊れる 変異
```

⚠️ **architect の 結論（★explicit の witness が 無い）は 正しく、★根拠だけが 誤り**でした。
**私は その 根拠を «検証手順» として issue に 書いて 配りました** —— **推定した 原因を
指示に «原因» として 書く**という、私が 記録している 失敗の 形です。

🔴 **∴ 一般形（★この PR の 外にも 効きます）:
★変異させても 挙動が 変わらない 変異は falsify では ない。
★「変異後も 緑」が 意味を 持つのは、★その 変異が RED に できた ときだけ。**

## 🔴 blocking（★1 行）

- [x] 🔴 **docstring の «`if True` に 書き換えても 通る» の 一文に、★それが no-op である ことを 足す。** — fixed in f94f5a9c6: docstring now explicitly names the no-op and the 2 mutations that actually isolate each test.
  現状の 文は **事実として 正しい**（★この テスト以前の 全テストは 通る）**ですが、★読んだ 人が
  «`if True:` が 有効な falsify»と 受け取ります** —— **実際には この 変異は どの テストも
  RED に できません。** ⚠️ **効かない 変異レシピを 残すのは、★レシピが 無いより 悪い**（★次の 人が
  それで «テストが 弱い» と 誤診する）。**貴殿が 実際に 使った 2 変異を 書いてください。**

