### PR TITLE
docs: sync 4 docs with #3823's sandbox.policy config vocabulary (#3953)

### DIFF
--- a/docs/concepts/runtime/permission-model.md
+++ b/docs/concepts/runtime/permission-model.md
@@ -390,11 +390,11 @@ what compat-by-default means for a command that can read a secret.
 
 | Axis | Policy | Rationale |
 |---|---|---|
-| write | tight workspace-allowlist (`write_paths`), closed by default | The one axis an operator cannot know in advance (a workspace floor value) and therefore cannot express as permission — bounds what a process can persist. |
+| write (`allow_write_paths`) | tight workspace-allowlist, closed by default | The one axis an operator cannot know in advance (a workspace floor value) and therefore cannot express as permission — bounds what a process can persist. |
 | network | open by default (owner decision, 2026-06-05, generalised to full compat by `#3901`) | A sandboxed process reaches the network the same way the launching shell can, unless `network: false` is set explicitly. |
-| exec (`deny_subprocess`) | open by default | Child-process spawning is allowed unless denied explicitly (enforced on Linux via seccomp, macOS via Seatbelt). |
-| env (`env_deny_names`) | open by default | The whole environment passes through, same trust level as the launching shell, unless specific names are denied. |
-| read | **broad-allow by default** + optional sensitive deny-list, empty by default | Unchanged since #1199 — the strict read-allowlist was abolished; `read_deny_paths` is opt-in defense-in-depth, not a default protection. |
+| exec (`subprocess`) | open by default | Child-process spawning is allowed unless `subprocess: false` is set explicitly (enforced on Linux via seccomp, macOS via Seatbelt). |
+| env (`deny_env_names`, or `allow_env_names` to switch to allow-list semantics) | open by default | The whole environment passes through, same trust level as the launching shell, unless specific names are denied (or, under `allow_env_names`, unless a name isn't on the list). |
+| read | **broad-allow by default** + optional sensitive deny-list, empty by default | Unchanged since #1199 — the strict read-allowlist was abolished; `deny_read_paths` is opt-in defense-in-depth, not a default protection. |
 
 **Why broad read was originally safe, and why that argument no longer
 carries the whole weight.** The original #1199 design reasoned that a
@@ -410,10 +410,10 @@ Code's read-restriction-as-secondary posture) — what changed is that
 **reyn no longer promises the exfiltration gate is closed by default**;
 protecting a credential a sandboxed command can read is now the
 operator's own responsibility, exercised explicitly (`network: false`,
-`env_deny_names`, `read_deny_paths`), the same posture `#3901`'s owner
+`deny_env_names`, `deny_read_paths`), the same posture `#3901`'s owner
 ruling applies to every non-write axis.
 
-**Defense-in-depth deny-list, opt-in.** `read_deny_paths` (empty by
+**Defense-in-depth deny-list, opt-in.** `deny_read_paths` (empty by
 default since `#3901`; previously defaulted to OS-level credential
 stores — `~/.ssh`, `~/.aws`, `~/.gnupg`, …) carves sensitive locations out
 of the broad read surface **when an operator sets it**. It is not a

--- a/docs/concepts/runtime/sandbox.md
+++ b/docs/concepts/runtime/sandbox.md
@@ -20,6 +20,16 @@ Defined in `src/reyn/security/sandbox/policy.py` — the dataclass every backend
 (#3901 — the two are not mirrors of one another; `reyn/core/op_runtime/
 sandboxed_exec.py` converts one into the other).
 
+**These are `SandboxPolicy`'s own internal field names — not what an operator
+writes in `reyn.yaml`.** `#3823` layered a separate, decoupled config
+vocabulary on top (`allow_write_paths` / `deny_read_paths` / `deny_write_paths`
+/ `subprocess` / `allow_env_names` / `deny_env_names`), translated into the
+internal names below by `_translate_sandbox_policy_config` before construction
+— see [`reyn.yaml` § `sandbox.policy` sub-keys](../../reference/config/reyn-yaml.md#sandbox-block)
+or [Configure the sandbox](../../guide/for-users/configure-sandbox.md) for the
+vocabulary you actually write. This table is the internal reference for
+reading `policy.py` itself.
+
 Every field except `write_paths` defaults to full compat (owner ruling B,
 #3901): the sandbox's job is bounding what happens *behind* a permitted
 action, not re-deciding what the launching shell could already do.
@@ -114,7 +124,7 @@ sandbox:
 
 Sandbox configuration is **operator-level** — set in `reyn.yaml` or via CLI flags, not per-workflow or per-phase. See [`reyn.yaml` reference → `sandbox:`](../../reference/config/reyn-yaml.md) for the full config schema.
 
-> **Phase-level `default_sandbox_policy` was removed.** Sandbox policy is agent-level operator configuration, not a per-phase workflow declaration — configure it in [`reyn.yaml sandbox.policy`](../../reference/config/reyn-yaml.md). When set, that policy is the deterministic policy for sandboxed ops + the `SandboxLayer` of the permission intersection for the `network`/`subprocess`/`env` axes (it wins over op-declared fields, so a workflow or the LLM cannot widen it) — `write_paths` (and the read/write deny-lists) do NOT participate in that intersection, since they are values an operator cannot know in advance and the kernel backend consumes them directly (#3901 PR-B ③); absent, the op-level fields govern. The `phase.md` frontmatter key is no longer parsed.
+> **Phase-level `default_sandbox_policy` was removed.** Sandbox policy is agent-level operator configuration, not a per-phase workflow declaration — configure it in [`reyn.yaml sandbox.policy`](../../reference/config/reyn-yaml.md). When set, that policy is the deterministic policy for sandboxed ops + the `SandboxLayer` of the permission intersection for the `network`/`subprocess`/`env` axes (it wins over op-declared fields, so a workflow or the LLM cannot widen it) — `allow_write_paths` (and the read/write deny-lists) do NOT participate in that intersection, since they are values an operator cannot know in advance and the kernel backend consumes them directly (#3901 PR-B ③); absent, the op-level fields govern. The `phase.md` frontmatter key is no longer parsed.
 
 ## See also
 

--- a/docs/guide/for-users/configure-sandbox.md
+++ b/docs/guide/for-users/configure-sandbox.md
@@ -42,13 +42,13 @@ A backend from this table is used only if it **passes an enforcement self-test**
 
 ## Reyn checks that your sandbox really sandboxes
 
-When Reyn picks a backend, it first proves the backend works **on your machine**. It launches short subprocesses through that backend and tries two things the policy forbids: writing a file outside the writable paths, and spawning a process with `deny_subprocess` on. Both must be refused. If either goes through, the backend is not enforcing what it claims, and Reyn treats it exactly as if it were not installed — applying your `on_unsupported` setting.
+When Reyn picks a backend, it first proves the backend works **on your machine**. It launches short subprocesses through that backend and tries two things the policy forbids: writing a file outside the writable paths, and spawning a process with `subprocess: false` set. Both must be refused. If either goes through, the backend is not enforcing what it claims, and Reyn treats it exactly as if it were not installed — applying your `on_unsupported` setting.
 
 This matters because "the sandbox is installed" and "the sandbox works" are different things. A backend can be present and importable while enforcing nothing at all — right OS, package imports fine, and yet every restriction silently absent. Checking only for presence cannot tell those apart. So Reyn checks the thing you actually care about: whether a forbidden action gets refused.
 
 The two **checks** are separate on purpose, because they can fail independently — different mechanisms enforce them, and on Linux one can be dead while the other works. But the **protection** does not decompose the same way, which is why Reyn requires both rather than keeping whichever one passes.
 
-On Linux, path rules come from Landlock and the syscall gate from seccomp-BPF. Without the syscall gate, Landlock's write boundary is real but not airtight: it governs ordinary writes, and Landlock has no `chmod` right at all, so with seccomp absent a sandboxed process can still `truncate` a file or `chmod` a directory **outside** `write_paths` — no layer stops it. Measured on Linux 6.8 with Landlock enforcing and the syscall filter absent: `open()` on a file outside `write_paths` was refused, while `os.truncate()` on that same file **succeeded and emptied it**. The syscall filter is what refuses those calls, by not listing them.
+On Linux, path rules come from Landlock and the syscall gate from seccomp-BPF. Without the syscall gate, Landlock's write boundary is real but not airtight: it governs ordinary writes, and Landlock has no `chmod` right at all, so with seccomp absent a sandboxed process can still `truncate` a file or `chmod` a directory **outside** `allow_write_paths` — no layer stops it. Measured on Linux 6.8 with Landlock enforcing and the syscall filter absent: `open()` on a file outside `allow_write_paths` was refused, while `os.truncate()` on that same file **succeeded and emptied it**. The syscall filter is what refuses those calls, by not listing them.
 
 So "writes are enforced, spawning is not" is not a coherent state to ship, and a write-only check would have called that host sandboxed.
 
@@ -60,26 +60,29 @@ What you should expect to see:
 
 If you see the warning, your AI code has been running without isolation. The message names the backend and the failure so you can fix it or fail closed deliberately.
 
-**Scope.** The check verifies the filesystem write boundary and the process-spawn gate. It does not exercise the network gate or `read_deny_paths`, so a passing check means two restrictions were proven — a good signal, not a guarantee of every restriction listed below. The spawn check doubles as evidence that the Linux syscall filter **loaded at all**, which is what keeps the `truncate`/`chmod` hole above closed.
+**Scope.** The check verifies the filesystem write boundary and the process-spawn gate. It does not exercise the network gate or `deny_read_paths`, so a passing check means two restrictions were proven — a good signal, not a guarantee of every restriction listed below. The spawn check doubles as evidence that the Linux syscall filter **loaded at all**, which is what keeps the `truncate`/`chmod` hole above closed.
 
 ## Set the agent-level sandbox policy
 
 `sandbox.policy` lets the operator declare a deterministic, operator-controlled
-sandbox policy. When set, it applies to all `sandboxed_exec` ops **and** to the
-`SandboxLayer` of the permission intersection for the `network`/`subprocess`/`env`
-axes — a workflow or the LLM cannot widen it. `write_paths` (and the read/write
-deny-lists) do NOT participate in that intersection: they are values an operator
-cannot know in advance (the op declares what directory it needs), so the kernel
-backend consumes them directly rather than through the permission ∩ (#3901).
+sandbox policy, in a config vocabulary decoupled from the internal enforcement
+fields it maps to (`#3823`). When set, it applies to all `sandboxed_exec` ops
+**and** to the `SandboxLayer` of the permission intersection for the
+`network`/`subprocess`/`env` axes — a workflow or the LLM cannot widen it.
+`allow_write_paths` (and the read/write deny-lists) do NOT participate in that
+intersection: they are values an operator cannot know in advance (the op
+declares what directory it needs), so the kernel backend consumes them
+directly rather than through the permission ∩ (`#3901`).
 
 ```yaml
 sandbox:
   backend: auto
+  mode: compat           # compat | strict — the DEFAULT for any key left unset below
   policy:
     network: false
-    write_paths:
+    allow_write_paths:
       - "{{workspace}}/output"
-    read_deny_paths:
+    deny_read_paths:
       - "~/.ssh"
       - "~/.aws"
     timeout_seconds: 120
@@ -87,24 +90,30 @@ sandbox:
 
 When `sandbox.policy` is absent (the default), there is no agent-level
 restriction: op-level fields govern, and the SandboxLayer is unrestricted.
+Unknown keys under `policy` fail loudly at config load — a typo never
+silently resolves to "nothing to deny".
 
 ### Policy fields
 
-Every field except `write_paths` defaults to full compat (owner ruling, #3901):
-the sandbox's job is bounding what happens *behind* a permitted action, not
-re-deciding what the launching shell could already do.
+Every field except `allow_write_paths` defaults to full compat under
+`mode: compat` (the default; owner ruling, `#3901`/`#3823`): the sandbox's job
+is bounding what happens *behind* a permitted action, not re-deciding what the
+launching shell could already do. Setting `mode: strict` flips every axis
+except `allow_write_paths` (and read, which has no mode-based default at all)
+to its closed default — an explicit key under `policy` always wins over `mode`.
 
 | Field | Type | Default | Meaning |
 |---|---|---|---|
-| `network` | bool | `true` (owner decision, 2026-06-05; reaffirmed as full compat by #3901 owner ruling B) | Allow outbound network. The primary exfiltration gate — a config-allowed host is still denied under `network: false`. Set `network: false` explicitly to close it. |
-| `write_paths` | list of paths | `[]` | Paths the process may write (tight guard) — the one field that stays closed by default (an operator-unknowable value, #3901). Write implies read — a path listed here is also re-opened for *reading* even if `read_deny_paths` would deny it, so grant specific directories rather than `~`. `~` is expanded. |
-| `read_deny_paths` | list of paths | `[]` (compat) | Sensitive paths to deny from the broad read surface (defense-in-depth, **opt-in**). Enforced only on backends that support deny-after-allow (Seatbelt); not enforceable on Landlock. Before #3901 this defaulted to 7 OS-level credential paths — set it explicitly to get that protection back. Denies only the READ axis; see `write_deny_paths` for the write axis. |
-| `write_deny_paths` | list of paths | `[]` | The write axis's own deny-list (#3901), mirroring `read_deny_paths`. Denies only the WRITE axis — before #3901 a `read_deny_paths` entry also (undocumentedly) denied writes on Seatbelt; that coupling is gone, so list a path in both fields if you want it protected on both axes. |
-| `deny_subprocess` | bool | `false` (compat) | Deny child-process spawning. Enforced on Linux (seccomp) and macOS (Seatbelt). |
-| `env_deny_names` | list of strings | `[]` (compat) | Env vars WITHHELD from the process. Empty (the default) means the whole environment passes through, same trust level as the launching shell. |
+| `network` | bool | `true` (compat); `false` under `mode: strict` | Allow outbound network. The primary exfiltration gate — a config-allowed host is still denied under `network: false`. Set `network: false` explicitly to close it. |
+| `subprocess` | bool | `true` (compat) — positive framing, `true` = allowed; `false` under `mode: strict` | Whether the process may spawn children. Set `subprocess: false` to deny it. |
+| `allow_write_paths` | list of paths | `[]` | Paths the process may write (tight guard) — the one field that stays closed by default regardless of `mode` (an operator-unknowable value, `#3901`). Write implies read — a path listed here is also re-opened for *reading* even if `deny_read_paths` would deny it, so grant specific directories rather than `~`. `~` is expanded. |
+| `deny_read_paths` | list of paths | `[]` (compat) | Sensitive paths to deny from the broad read surface (defense-in-depth, **opt-in**). Enforced only on backends that support deny-after-allow (Seatbelt); not enforceable on Landlock. Before `#3901` this defaulted to 7 OS-level credential paths — set it explicitly to get that protection back. No mode-based default (no `allow_read_paths` concept, #1199) — `strict` cannot narrow reads any tighter than `compat`. Denies only the READ axis; see `deny_write_paths` for the write axis. |
+| `deny_write_paths` | list of paths | `[]` | The write axis's own deny-list (`#3901`), mirroring `deny_read_paths`. Denies only the WRITE axis — before `#3901` a `deny_read_paths` entry also (undocumentedly) denied writes on Seatbelt; that coupling is gone, so list a path in both fields if you want it protected on both axes. |
+| `allow_env_names` | list of strings \| `null` | `null` (deny-list-only); `[]` under `mode: strict` | SWITCHES the env axis to allow-list semantics when set to a list — only those names pass through (still intersected with `deny_env_names`, deny always wins). |
+| `deny_env_names` | list of strings | `[]` (compat) | Env vars WITHHELD from the process. Empty (the default) means the whole environment passes through, same trust level as the launching shell. |
 | `timeout_seconds` | int | `60` | Wall-clock limit; process is killed on expiry. |
 
-**`deny_subprocess: true` is the cheapest, most predictable hardening available for a workload that never needs to spawn anything.** It is a single boolean, and its effect is total and immediate: child-process spawning is denied outright, with no partial states to reason about later. If your workload genuinely needs to exec (a build step, a CLI wrapper), this setting isn't for you — you're bound instead by the sandbox boundary plus the audit trail every exec leaves (`sandboxed_exec_started`/`_completed`/`_cancelled` record the `argv` — see [Reference: events](../../reference/runtime/events.md)).
+**`subprocess: false` is the cheapest, most predictable hardening available for a workload that never needs to spawn anything.** It is a single boolean, and its effect is total and immediate: child-process spawning is denied outright, with no partial states to reason about later. If your workload genuinely needs to exec (a build step, a CLI wrapper), this setting isn't for you — you're bound instead by the sandbox boundary plus the audit trail every exec leaves (`sandboxed_exec_started`/`_completed`/`_cancelled` record the `argv` — see [Reference: events](../../reference/runtime/events.md)).
 
 ### Scoping model
 
@@ -113,17 +122,23 @@ reyn uses a **broad-read, tight-write, network-open-by-default** model:
 - **Reads are broad.** The process can read most of the filesystem. System-path
   enumeration for dylib loading works without enumeration in policy.
 - **Network is open by default.** `network` defaults to `true` (owner decision,
-  2026-06-05; reaffirmed as full compat across every non-`write_paths` axis by
-  #3901 owner ruling B) — a sandboxed process can reach the network unless you
-  set `network: false` explicitly. This follows reyn's standing UX-over-security
-  posture: security mechanisms here are opt-in, not opt-out — see [Protect
-  credentials from sandboxed commands](protect-credentials-in-shell-commands.md)
-  for what this means for a command that can read a secret.
-- **Writes are tight.** Only paths in `write_paths` are writable — the one axis
-  that stays closed by default (an operator-unknowable value, #3901).
-- **`read_deny_paths`/`write_deny_paths` are defense-in-depth, opt-in.** Carve out
+  2026-06-05; reaffirmed as full compat across every non-`allow_write_paths`
+  axis by `#3901` owner ruling B) — a sandboxed process can reach the network
+  unless you set `network: false` explicitly. This follows reyn's standing
+  UX-over-security posture: security mechanisms here are opt-in, not opt-out —
+  see [Protect credentials from sandboxed
+  commands](protect-credentials-in-shell-commands.md) for what this means for
+  a command that can read a secret.
+- **Writes are tight.** Only paths in `allow_write_paths` are writable — the
+  one axis that stays closed by default regardless of `mode` (an
+  operator-unknowable value, `#3901`).
+- **`deny_read_paths`/`deny_write_paths` are defense-in-depth, opt-in.** Carve out
   sensitive locations from the broad read/write surface where the backend can
   express a deny-after-allow rule; empty (nothing carved out) by default.
+- **`mode: strict`** flips network/subprocess/env to their closed defaults in
+  one setting, for an operator who wants the pre-compat posture back without
+  writing every key explicitly — see [reyn.yaml §
+  `sandbox.mode`](../../reference/config/reyn-yaml.md#sandbox-block).
 
 ## Per-backend behavior
 
@@ -134,11 +149,11 @@ on macOS.
 
 | Field | Enforcement |
 |---|---|
-| `write_paths` | Enforced |
+| `allow_write_paths` | Enforced |
 | `network` | Enforced. A loopback-only `network-bind` (`localhost:*`) is always allowed regardless of `network`, mirroring Landlock's `socket`/`bind` exception above ([#3060](https://github.com/tya5/reyn/issues/3060)) — `network-outbound`/`network-inbound` stay gated on `network`. |
-| `read_deny_paths` | **Enforced** — SBPL deny-after-allow |
-| `write_deny_paths` | **Enforced** — SBPL deny-after-allow, independent of `read_deny_paths` (#3901: each denies only its own axis) |
-| `deny_subprocess` | **Enforced** — denies `process-fork` when on; the target's own exec still works via `process-exec*` |
+| `deny_read_paths` | **Enforced** — SBPL deny-after-allow |
+| `deny_write_paths` | **Enforced** — SBPL deny-after-allow, independent of `deny_read_paths` (#3901: each denies only its own axis) |
+| `subprocess` | **Enforced** — `subprocess: false` denies `process-fork`; the target's own exec still works via `process-exec*` |
 | `timeout_seconds` | Enforced |
 
 ### Landlock (Linux)
@@ -147,11 +162,11 @@ Uses the Linux Landlock LSM with path-beneath allowlist rules.
 
 | Field | Enforcement |
 |---|---|
-| `write_paths` | Enforced — path-beneath write rules |
-| `network` | **Enforced, unconditionally** ([#3030](https://github.com/tya5/reyn/issues/3030) fixed). Landlock itself never restricts network on any kernel: the pinned `landlock` package exposes no network-rule API, so the deny is carried entirely by a seccomp-BPF default-deny **allowlist** — every syscall not named (including `connect`/`sendmsg`/`accept`/`listen` when `network: false`, and unconditionally io_uring's `io_uring_setup`/`io_uring_enter`, which a syscall-name denylist cannot express) is refused. This filter used to be skipped ENTIRELY whenever `deny_subprocess` was off (`false`) — the stdio MCP default — which silently dropped the network gate along with it; it now loads unconditionally, so `network: false` is enforced regardless of `deny_subprocess`. Two exceptions, always allowed regardless of `network` ([#3060](https://github.com/tya5/reyn/issues/3060)): **(1)** `socket`/`bind` — neither one alone transmits or receives a byte, and a benign import-time IPv6-support probe in a common HTTP-client dependency (`bind`s to `::1` on port 0 and never `connect`s) used to be refused as collateral damage; **(2)** `sendto`/`recvfrom` **when their address argument is NULL** — the connected AF_UNIX socketpair CPython's asyncio event loop uses to wake itself (`send`/`recv` lower to `sendto`/`recvfrom` with a NULL address), whose wholesale denial left every stdio MCP server's loop unable to pump, so the server served 0 bytes. Dialing an actual peer still requires `connect` (denied), and the **addressed** form of `sendto` (`sendto(fd, …, &sockaddr, …)` — real UDP egress) has a non-NULL address and stays denied by that same condition. |
-| `read_deny_paths` | **Not enforced** — Landlock is allowlist-only and cannot carve a subpath out of an allowed parent. The network gate (see the `network` row) is the compensating exfiltration control, and — since #3030 — applies regardless of `deny_subprocess`. Do not rely on this platform to contain a process that can read a secret; network denial only stops it leaving. |
-| `write_deny_paths` | **Not enforced** — same allowlist-only limitation as `read_deny_paths` above. |
-| `deny_subprocess` | **Enforced** — seccomp-BPF refuses `fork`/`clone` when on. Landlock is not selected unless the self-test witnesses this deny on your host, so this is a checked claim rather than a hope that `pyseccomp` is installed and loading |
+| `allow_write_paths` | Enforced — path-beneath write rules |
+| `network` | **Enforced, unconditionally** ([#3030](https://github.com/tya5/reyn/issues/3030) fixed). Landlock itself never restricts network on any kernel: the pinned `landlock` package exposes no network-rule API, so the deny is carried entirely by a seccomp-BPF default-deny **allowlist** — every syscall not named (including `connect`/`sendmsg`/`accept`/`listen` when `network: false`, and unconditionally io_uring's `io_uring_setup`/`io_uring_enter`, which a syscall-name denylist cannot express) is refused. This filter used to be skipped ENTIRELY whenever `subprocess` was `true` (allowed) — the stdio MCP default — which silently dropped the network gate along with it; it now loads unconditionally, so `network: false` is enforced regardless of `subprocess`. Two exceptions, always allowed regardless of `network` ([#3060](https://github.com/tya5/reyn/issues/3060)): **(1)** `socket`/`bind` — neither one alone transmits or receives a byte, and a benign import-time IPv6-support probe in a common HTTP-client dependency (`bind`s to `::1` on port 0 and never `connect`s) used to be refused as collateral damage; **(2)** `sendto`/`recvfrom` **when their address argument is NULL** — the connected AF_UNIX socketpair CPython's asyncio event loop uses to wake itself (`send`/`recv` lower to `sendto`/`recvfrom` with a NULL address), whose wholesale denial left every stdio MCP server's loop unable to pump, so the server served 0 bytes. Dialing an actual peer still requires `connect` (denied), and the **addressed** form of `sendto` (`sendto(fd, …, &sockaddr, …)` — real UDP egress) has a non-NULL address and stays denied by that same condition. |
+| `deny_read_paths` | **Not enforced** — Landlock is allowlist-only and cannot carve a subpath out of an allowed parent. The network gate (see the `network` row) is the compensating exfiltration control, and — since #3030 — applies regardless of `subprocess`. Do not rely on this platform to contain a process that can read a secret; network denial only stops it leaving. |
+| `deny_write_paths` | **Not enforced** — same allowlist-only limitation as `deny_read_paths` above. |
+| `subprocess` | **Enforced** — seccomp-BPF refuses `fork`/`clone` when `subprocess: false`. Landlock is not selected unless the self-test witnesses this deny on your host, so this is a checked claim rather than a hope that `pyseccomp` is installed and loading |
 | `timeout_seconds` | Enforced |
 
 ### Noop

--- a/docs/guide/for-users/protect-credentials-in-shell-commands.md
+++ b/docs/guide/for-users/protect-credentials-in-shell-commands.md
@@ -35,17 +35,30 @@ sandbox:
 ```
 
 A sandboxed command's environment is, by the same posture, your shell's
-full environment — not a curated subset. There is no allowlist to opt
-into: every variable your shell has set is visible to the command unless
-you explicitly deny specific names via `env_deny_names`
-(`#3901` PR-B ④ — the whole environment passes through by default, same
-trust level as the launching shell):
+full environment — not a curated subset by default. Every variable your
+shell has set is visible to the command unless you explicitly deny
+specific names via `deny_env_names` (`#3901`/`#3823` — the whole
+environment passes through by default, same trust level as the launching
+shell):
 
 ```yaml
 sandbox:
   policy:
-    env_deny_names:
+    deny_env_names:
       - OPENAI_API_KEY
+```
+
+If you'd rather opt IN a short list than deny individual names, set
+`allow_env_names` to a list — this switches the axis to allow-list
+semantics (`#3823`): only the names you list pass through, still
+intersected with `deny_env_names` on top:
+
+```yaml
+sandbox:
+  policy:
+    allow_env_names:
+      - PATH
+      - HOME
 ```
 
 Both defaults follow the same design choice this page opened with:


### PR DESCRIPTION
**[docs-maintainer]** — continuing tonight's sandbox-doc sweep, found while independently checking #3953 after it merged. part of #3823.

## What happened

#3953 (merged) shipped a THIRD sandbox.policy vocabulary change tonight,
layering a config-facing translation on top of the #3901-era internal
field names: `allow_write_paths` / `deny_read_paths` / `deny_write_paths`
/ `subprocess` (positive-sense, inverted from internal `deny_subprocess`)
/ `allow_env_names` (new — a genuine allowlist) / `deny_env_names` —
decoupled from `SandboxPolicy`'s own internal names via
`_translate_sandbox_policy_config`, which fails loudly on an unknown key
(verified directly against `policy.py`).

`reyn-yaml.md` and `reyn.local.yaml.example` were fixed in #3953 itself
(lead-coder's own blocking review caught it before merge). Four more docs
I wrote/touched earlier tonight — before #3823 shipped — still taught the
now-superseded internal vocabulary as the config vocabulary.

## Fixed

- **`configure-sandbox.md`**: full field-table + prose rewrite (Policy
  fields, Scoping model, both per-backend enforcement tables), added the
  `sandbox.mode: strict` example, cross-linked to `reyn-yaml.md`'s
  sandbox block.
- **`protect-credentials-in-shell-commands.md`**: `env_deny_names` →
  `deny_env_names`, and added the new `allow_env_names` option — the doc
  previously said "there is no allowlist to opt into," which #3823 made
  false.
- **`permission-model.md`**: the "Sandbox scoping model" table + two
  prose paragraphs I added in tonight's earlier passes (#3899/#3938),
  updated to the config vocabulary.
- **`sandbox.md`**: the "`SandboxPolicy` field reference" table documents
  the INTERNAL dataclass names, which #3823 left unchanged (verified) —
  added an explicit note distinguishing it from the config vocabulary,
  since sitting next to "configure it in reyn.yaml" without that
  distinction now misleads a reader into writing a rejected key. Also
  fixed the one operator-facing callout that used the internal name.

## Scope note

Not touched: `.ja.md` siblings (no blanket mirror obligation), journal/
proposal docs (immutable / historical), `hooks.md`'s own per-hook
`write_paths:` (confirmed a genuinely different surface, per lead-coder's
own note on #3953 — the hook-level sandbox scope, not agent-level
`sandbox.policy`), and `control-ir.md`'s `SandboxedExecIROp` fields
(explicitly documented, both here and in `sandbox.md` itself, as a
deliberately separate, un-mirrored vocabulary).

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → exit 0, no new WARNING/Aborted lines
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` → 336 passed
- [x] Every claim verified against current `policy.py` (`_SANDBOX_POLICY_CONFIG_KEY_TO_FIELD`, `_translate_sandbox_policy_config`) before writing, not transcribed from #3953's PR body
- [x] Branch rebased onto current `origin/main` (picked up #3953/#3956/#3958 mid-task); remote head verified via `git ls-remote origin refs/heads/docs/sandbox-config-vocabulary-3823-sync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
