### PR TITLE
fix(#3974): reset's own scope was wrong — web/deps' lru_caches never cleared

### DIFF
--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -217,14 +217,41 @@ class CliScopedOverrides:
 _cli_scoped: "CliScopedOverrides | None" = None
 
 
+def _clear_module_lru_caches() -> None:
+    """Clear every ``@lru_cache``d module-level singleton in this module —
+    enumerated (``dir(module)`` + ``hasattr(..., "cache_clear")``), never
+    hand-named (#3974: the defect this fixes was exactly a hand-named reset
+    silently drifting out of sync with the caches that actually needed
+    clearing — ``_load_config``/``_get_project_root`` were added after
+    ``set_cli_scoped_overrides`` already existed, and nothing forced the
+    two to stay in sync). A future ``@lru_cache`` added to this module is
+    covered automatically; the reset never needs a second edit."""
+    import sys
+    module = sys.modules[__name__]
+    for name in dir(module):
+        member = getattr(module, name, None)
+        cache_clear = getattr(member, "cache_clear", None)
+        if callable(cache_clear):
+            cache_clear()
+
+
 def set_cli_scoped_overrides(overrides: "CliScopedOverrides | None") -> None:
     """Set/clear the CLI-scoped overrides. `reyn web` run() calls this ONCE
-    before uvicorn.run (no-reload). Resetting the cached lazy singletons here
-    keeps the next perm-resolver / registry build pick the new overrides up."""
+    before uvicorn.run (no-reload). Resets EVERY cached lazy singleton in
+    this module (#3974) — not just perm_resolver/registry — so "reset"
+    means what it says: the next read of anything this module caches
+    (config, project root, perm resolver, registry) reflects the current
+    on-disk state, not a stale value from before the reset. Production
+    impact is a no-op either way (nothing is cached yet at `reyn web`
+    startup, the only non-test caller); test isolation is the actual
+    beneficiary — a test no longer needs its own ad-hoc
+    ``deps._load_config.cache_clear()`` call to see a ``reyn.yaml`` it just
+    rewrote."""
     global _cli_scoped, _perm_resolver, _registry
     _cli_scoped = overrides
     _perm_resolver = None
     _registry = None
+    _clear_module_lru_caches()
 
 
 def get_cli_scoped_overrides() -> "CliScopedOverrides":
@@ -234,7 +261,11 @@ def get_cli_scoped_overrides() -> "CliScopedOverrides":
 @contextmanager
 def cli_scoped_overrides(overrides: "CliScopedOverrides"):
     """Test isolation: apply the overrides for the block, restore after
-    (incl. the cached perm-resolver / registry singletons)."""
+    (incl. the cached perm-resolver / registry / config / project-root
+    singletons — #3974: the restore-on-exit path gets the SAME reset
+    ``set_cli_scoped_overrides`` applies on enter, so a config change made
+    INSIDE the block doesn't leak its cached read to whatever runs after
+    this block exits)."""
     global _cli_scoped, _perm_resolver, _registry
     prev = (_cli_scoped, _perm_resolver, _registry)
     set_cli_scoped_overrides(overrides)
@@ -242,6 +273,7 @@ def cli_scoped_overrides(overrides: "CliScopedOverrides"):
         yield
     finally:
         _cli_scoped, _perm_resolver, _registry = prev
+        _clear_module_lru_caches()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_web_scoped_capabilities_1401.py
+++ b/tests/test_web_scoped_capabilities_1401.py
@@ -167,13 +167,13 @@ def _write_reyn_yaml(tmp_path: Path, *, permissions: dict | None = None) -> None
         for key, value in permissions.items():
             lines.append(f'  "{key}": {value!r}' if isinstance(value, str) else f'  "{key}": {value}')
     (tmp_path / "reyn.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
-    # deps._load_config / _get_project_root are process-global lru_caches
-    # (unlike the holder, which cli_scoped_overrides resets on its own) — a
-    # reyn.yaml rewrite mid-test is invisible to _get_perm_resolver() unless
-    # these are cleared too, the same class of staleness this test module's
-    # own R1 section exists to avoid.
-    deps._load_config.cache_clear()
-    deps._get_project_root.cache_clear()
+    # #3974: deps._load_config / _get_project_root are process-global
+    # lru_caches — set_cli_scoped_overrides / cli_scoped_overrides now
+    # clear them as part of "reset" (previously only perm_resolver/registry
+    # were reset, which is the exact staleness this test module's R1
+    # section originally worked around with its own manual cache_clear()
+    # calls here). No manual clear needed anymore: _web_can_write's own
+    # cli_scoped_overrides(...) entry clears the caches for us.
 
 
 async def _web_can_write(target: str, sandbox: "SandboxPolicy", *, ws) -> bool:


### PR DESCRIPTION
**[e2e-coder]** — Implements all 3 items lead-coder specified for #3974 (my own finding while landing #3924/#3973).

## ① The real fix
`_clear_module_lru_caches()` enumerates every `@lru_cache`'d module-level singleton in `deps.py` (`dir(module)` + `hasattr(..., "cache_clear")`) rather than naming caches by hand — the exact shape of the original defect (`_load_config`/`_get_project_root` were added to the module *after* `set_cli_scoped_overrides` already existed, and nothing forced the two to stay in sync). A future `@lru_cache` added here is covered automatically. Wired into **both** `set_cli_scoped_overrides` (enter) and `cli_scoped_overrides`'s `finally` block (exit) — the exit path previously restored the holder/perm_resolver/registry but not the lru_caches, so a config change made *inside* a `with cli_scoped_overrides(...)` block could leak its cached read to whatever ran after the block exited.

## ② Full-repo sweep (counted all 8 `@lru_cache` sites first, then checked each)
- `config/loader.py`'s `_find_project_root_uncached` — already covered by `conftest.py`'s own autouse fixture.
- `runtime/reyn_repo.py::resolve_reyn_root`, `interfaces/transport/frames.py::forwarded_frame_kinds`, `interfaces/inline/textual_chat/activity_row.py::_shine_ramp` — pure/static computations, no associated reset concept, no state to go stale.

**Zero additional instances of the defect class found.**

## ③ Witness
`test_web_scoped_capabilities_1401.py::test_grant_file_write_gates_real_in_repo_write` already exercises a `reyn.yaml` rewrite between two calls. Falsify-verified against **both** clear sites independently: stripping either alone still passed (the other compensated), stripping both together → RED for the exact reason (stale `allow` persisting), confirming the fix is genuinely load-bearing.

## Test plan
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 7 tests, 0 errors
- [x] `python scripts/verify_module_docstrings.py` — clean
- [x] `python scripts/mypy_ratchet.py` — 212 findings, all baselined
- [x] Consumer sweep: full `tests/web/` population + 3 more files referencing `deps.py`/`cli_scoped_overrides` — 87 passed, 1 skipped, no regression
- [x] Falsify-verify both clear sites independently — RED confirmed only when both stripped
- [ ] Visual — n/a, no UI surface

Closes #3974

🤖 Generated with [Claude Code](https://claude.com/claude-code)