### PR TITLE
feat(#3616①): TextualChatApp.copy_to_clipboard override routes through the local sink

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2378,6 +2378,70 @@ class TextualChatApp(App):
             loop=False,
         )
 
+    def copy_to_clipboard(self, text: str) -> None:
+        """#3616②: override ``App.copy_to_clipboard`` so every
+        Textual-originated copy goes through reyn's own local-tool sink
+        instead of the framework default's raw OSC 52 write.
+
+        Textual calls this from exactly 3 places, none of them FlowView's own
+        cursor-based yank (that already routes through :meth:`_write_clipboard`
+        via the ``clipboard=`` constructor seam, ``#3507``/``#3692`` — this
+        override does not change that path, it only stops being a NO-OP for
+        the other 3): ``Screen.action_copy_text`` (the generic mouse-drag
+        text-selection copy, bound to ``ctrl+c``/``super+c``), and
+        ``TextArea``/``Input``'s own copy actions on a text selection inside
+        those widgets. All 3 currently hit the same broken-on-some-terminals
+        OSC 52 path ``#3617`` already fixed for the keyboard yank;
+        redirecting all 3 to the SAME already-proven-correct sink is the
+        identical fix, not a wider blast radius.
+
+        ⚠️ Fixes the SINK only, and — measured after this override was first
+        written — does not by itself close #3616②. Two separate gaps stack
+        on top of it, both traced with real pilot probes rather than assumed:
+
+        1. **Trigger reachability**: reyn's own ``ctrl+c`` binding
+           (``Binding("ctrl+c", "cancel_turn", priority=True)``, ``#3498``,
+           owner decision "interrupt unconditionally") consumes ``ctrl+c``
+           before ``Screen`` ever sees it — with an active Screen-level
+           selection, ``ctrl+c`` calls this method 0 times and
+           ``cancel_inflight`` 1 time; ``super+c`` (Cmd+C) calls this method
+           1 time. The owner's acceptance machine is Windows + git bash,
+           which has no ``super+c`` equivalent.
+        2. **Selection itself (#3972, filed, upstream)**: mouse-drag inside
+           ``FlowView`` — the conversation pane, where the owner's actual
+           copy target lives — does not populate ``Screen.selections`` at
+           all (measured: identical drag on a plain ``Static`` widget DOES
+           select, via ``get_selected_text()``, using Textual's own
+           ``test_selection.py::test_double_width`` incantation; the same
+           drag on ``FlowView`` returns ``None``). So even with (1) solved,
+           ``FlowView.yank()``'s own body
+           (``text = self.screen.get_selected_text() or ""``) has nothing to
+           send for a mouse-only selection — this override's sink is never
+           reached via that path either. #3972 is a ``textual-flowview``
+           (also ``tya5``-owned) integration gap, tracked separately.
+
+        This override still stands on its own: it is unconditionally correct
+        for ``TextArea``/``Input`` copy actions (reyn's own ``SearchBar``
+        query field, ``InterventionPanel``'s free-text ``Input``), which
+        likely DO populate a normal Screen selection (untested here, out of
+        this override's own scope) — landing it now closes that slice
+        without waiting on #3972 or a decision on revisiting #3498.
+
+        Deliberately NOT ``super().copy_to_clipboard(text)`` (which would
+        ALSO fire the OSC 52 write) — dual-writing risks the exact bug this
+        fixes: an async/buffered OSC 52 escape sequence reaching the
+        terminal after pyperclip already set the OS clipboard correctly
+        could overwrite it with the garbled result. ``#3617``'s own
+        keyboard-yank sink didn't dual-write either; matching that
+        precedent. Still sets ``self._clipboard`` directly (Textual's own
+        in-memory bookkeeping ``TextArea``/``Input``'s PASTE actions read
+        via ``self.app.clipboard`` for in-session paste-back, independent
+        of the OS clipboard this method's SINK choice is about) —
+        the one piece of the parent's behavior worth keeping.
+        """
+        self._clipboard = text
+        self._write_clipboard(text)
+
     def _write_clipboard(self, text: str) -> bool:
         """Yank's clipboard sink: reyn's own local tool, result observable.
 

--- a/tests/interfaces/test_copy_to_clipboard_sink_3616.py
+++ b/tests/interfaces/test_copy_to_clipboard_sink_3616.py
@@ -1,0 +1,217 @@
+"""#3616①: ``TextualChatApp.copy_to_clipboard`` override routes every
+Textual-originated copy through reyn's own local-tool sink (pyperclip via
+:meth:`TextualChatApp._write_clipboard`) instead of the framework default's
+raw OSC 52 write.
+
+Scoped narrowly, matching the override's own docstring: this closes the sink
+for ``TextArea``/``Input``'s native copy action (an ``Input`` — reyn's
+``SearchBar`` query field — is used here as the real, reachable witness) and
+for Textual's generic ``Screen``-level selection copy in the abstract. It
+does NOT claim FlowView mouse-drag selection works end to end — that is
+tracked separately (#3972, a ``textual-flowview`` integration gap this
+override cannot reach around).
+
+Real ``TextualChatApp`` + real minimal ``ClientTransport`` — no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from test_textual_chat_phase4_right_gutter_3283 import QueueTransport
+from textual.widgets import Input
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.search_bar import SearchBar
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _CancelTrackingTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` that counts
+    ``cancel_inflight`` calls — ``QueueTransport``'s own is a no-op, and this
+    file's regression guard needs the count."""
+
+    def __init__(self) -> None:
+        self.cancel_calls = 0
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        await asyncio.Event().wait()
+        yield DisplayFrame(OutboxMessage(kind="agent", text=""))  # pragma: no cover
+
+    async def submit_user_text(self, text: str) -> str:
+        return ""
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:
+        self.cancel_calls += 1
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+@pytest.mark.asyncio
+async def test_copy_to_clipboard_routes_through_the_local_sink_not_osc52() -> None:
+    """Tier 2: calling ``App.copy_to_clipboard`` (Textual's own entry point,
+    what ``Screen.action_copy_text``/``Input.action_copy``/``TextArea``'s own
+    copy action all call) on ``TextualChatApp`` writes through
+    ``_write_clipboard`` and emits NO OSC 52 escape sequence to the driver —
+    the framework default's OSC 52 write is fully replaced, not
+    dual-written (dual-writing would risk an async OSC 52 write reaching the
+    terminal after pyperclip already set the clipboard correctly,
+    overwriting it with the garbled result — the exact bug #3617 fixed)."""
+    app = TextualChatApp(transport=QueueTransport())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        write_calls: list[str] = []
+        orig_write = app._write_clipboard
+
+        def _spy_write(text: str) -> bool:
+            write_calls.append(text)
+            return orig_write(text)
+
+        app._write_clipboard = _spy_write  # type: ignore[method-assign]
+
+        driver_writes: list[str] = []
+        # No assert on the driver's presence — a real app.run_test() pilot
+        # always has one; if it didn't, .write below would raise on its own,
+        # which is diagnostic enough without asserting on private state.
+        driver = app._driver
+        orig_driver_write = driver.write
+
+        def _spy_driver_write(data: str) -> None:
+            driver_writes.append(data)
+            return orig_driver_write(data)
+
+        app._driver.write = _spy_driver_write  # type: ignore[method-assign]
+
+        app.copy_to_clipboard("hello clipboard")
+
+        assert write_calls == ["hello clipboard"], (
+            f"expected exactly one _write_clipboard call, got {write_calls!r}"
+        )
+        osc52_writes = [
+            d for d in driver_writes if isinstance(d, str) and "\x1b]52" in d
+        ]
+        assert osc52_writes == [], (
+            f"OSC 52 escape sequence was written despite the override: {osc52_writes!r}"
+        )
+        assert app.clipboard == "hello clipboard", (
+            "the in-memory app.clipboard (used by TextArea/Input's own "
+            "in-session paste-back) must still be updated"
+        )
+
+
+@pytest.mark.asyncio
+async def test_search_bar_input_copy_action_reaches_the_local_sink() -> None:
+    """Tier 2: the real, reachable witness — ``Input.action_copy`` (bound to
+    ``ctrl+c,super+c`` inside Textual's own ``Input`` widget) on reyn's
+    ``SearchBar`` query field calls ``app.copy_to_clipboard``, which this
+    override redirects to the local sink. Uses ``super+c`` (not ``ctrl+c``):
+    reyn's own app-level ``ctrl+c`` binding
+    (``cancel_turn``, ``priority=True``, ``#3498``) consumes ``ctrl+c``
+    before any widget sees it, on any focused widget — measured separately
+    (issue #3616, pilot probe) — so ``super+c`` is the only currently
+    reachable trigger for this override to matter through, from any widget."""
+    app = TextualChatApp(transport=QueueTransport())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+n")  # #3476 ⑤: opens the search bar, focuses its Input
+        await pilot.pause()
+
+        query_input = app.query_one(SearchBar).query_one(Input)
+        assert query_input.has_focus, "test setup: search bar Input did not take focus"
+
+        query_input.insert_text_at_cursor("needle")
+        await pilot.pause()
+        query_input.action_select_all()
+        await pilot.pause()
+        assert query_input.selected_text == "needle", (
+            f"test setup: select-all did not select the typed text, "
+            f"got {query_input.selected_text!r}"
+        )
+
+        write_calls: list[str] = []
+        orig_write = app._write_clipboard
+
+        def _spy_write(text: str) -> bool:
+            write_calls.append(text)
+            return orig_write(text)
+
+        app._write_clipboard = _spy_write  # type: ignore[method-assign]
+
+        await pilot.press("super+c")
+        await pilot.pause()
+
+        assert write_calls == ["needle"], (
+            f"Input's own copy action did not reach the local sink via the "
+            f"override, got {write_calls!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_ctrl_c_still_interrupts_the_turn_unaffected_by_the_override() -> None:
+    """Tier 2: regression guard — the copy-sink override does not touch
+    ``#3498``'s ``ctrl+c`` -> ``cancel_turn`` binding. With a selection
+    active in the SearchBar's Input, ``ctrl+c`` still interrupts (never
+    copies) — the override changes WHERE a reached copy goes, not WHETHER
+    ``ctrl+c`` reaches a copy action at all."""
+    transport = _CancelTrackingTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+n")
+        await pilot.pause()
+        query_input = app.query_one(SearchBar).query_one(Input)
+        query_input.insert_text_at_cursor("needle")
+        await pilot.pause()
+        query_input.action_select_all()
+        await pilot.pause()
+
+        write_calls: list[str] = []
+        orig_write = app._write_clipboard
+
+        def _spy_write(text: str) -> bool:
+            write_calls.append(text)
+            return orig_write(text)
+
+        app._write_clipboard = _spy_write  # type: ignore[method-assign]
+
+        cancel_calls_before = transport.cancel_calls
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+
+        assert write_calls == [], (
+            f"ctrl+c must not reach the copy sink, got {write_calls!r}"
+        )
+        assert transport.cancel_calls == cancel_calls_before + 1, (
+            "ctrl+c must still interrupt the turn (#3498), unaffected by the "
+            "copy-sink override"
+        )


### PR DESCRIPTION
**[tui-coder]** — #3616①: `TextualChatApp.copy_to_clipboard` override routes through the local sink.

## What

Overrides `App.copy_to_clipboard` so every Textual-originated copy — `Screen`'s generic mouse-drag text-selection copy, `TextArea`/`Input`'s own native copy action — goes through reyn's already-proven-correct local sink (`_write_clipboard` → pyperclip, `#3617`) instead of the framework default's raw OSC 52 write. FlowView's own cursor-based yank (`#3507`/`#3692`, the `clipboard=` constructor seam) is unaffected — this closes the sink for the other 3 Textual call sites, which currently all hit the same terminal-garbling class `#3617` fixed for the keyboard yank.

Deliberately **not** `super().copy_to_clipboard()` (would also fire the OSC 52 write) — dual-writing risks an async OSC 52 write reaching the terminal after pyperclip already set the clipboard correctly, overwriting it with the garbled result. Still sets `self._clipboard` directly (Textual's own in-memory bookkeeping `TextArea`/`Input`'s paste actions read).

## Scope — closes the sink only, per the measured findings already on issue #3616

Two gaps remain, both measured with real pilot probes, neither this PR's job:

1. **`ctrl+c` reachability** — reyn's own `priority=True` `cancel_turn` binding (`#3498`) consumes `ctrl+c` before `Screen` ever sees it. `super+c` (Cmd+C) DOES reach this override — but the owner's acceptance machine is Windows + git bash, no `super+c` equivalent there.
2. **FlowView mouse-drag selection itself (`#3972`, filed, upstream `textual-flowview`)** — mouse-drag inside FlowView doesn't populate `Screen.selections` at all (measured against Textual's own working precedent for a plain `Static` widget).

Landing this now still closes real ground: `TextArea`/`Input`'s own native copy action (reyn's `SearchBar` query field, `InterventionPanel`'s free-text `Input`) reaches this sink today via `super+c`, independent of both gaps above — verified with a real `Input` selection + real keypress.

## Test plan

- [x] `ruff check` (both changed files) → clean
- [x] `python scripts/mypy_ratchet.py` → 212 findings, all baselined (no new)
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_copy_to_clipboard_sink_3616.py` → 3/3 OK
- [x] `python scripts/verify_module_docstrings.py` → OK
- [x] `python scripts/flat_tests_ratchet.py --check-growth main` → OK (new file in `tests/interfaces/`)
- [x] `pytest tests/interfaces/test_copy_to_clipboard_sink_3616.py` → 3 passed
- [x] `pytest` across every copy/clipboard/search/intervention-adjacent test file → 50 passed, unaffected
- [x] Falsification (override neutered to no-op) → exactly the 2 tests that depend on the sink go red, the `ctrl+c` regression guard correctly stays green (it's asserting the override does NOT change `ctrl+c` behavior). Restored, re-verified green.

## Note per #3936 (TESTS-READ gate)

This PR touches `tests/` — holding for a TESTS-READ before self-merging.

part of #3616

🤖 Generated with [Claude Code](https://claude.com/claude-code)
