### PR TITLE
feat(#3698②): bump fastmcp 3.4.2 -> 3.4.5, regression-free

### DIFF
--- a/docs/reference/runtime/mcp-conformance.json
+++ b/docs/reference/runtime/mcp-conformance.json
@@ -2,7 +2,7 @@
   {
     "transport": "stdio",
     "server": "tests/_support/mcp_fastmcp_echo_server.py",
-    "dep_version": "fastmcp 3.4.2, mcp-sdk 1.26.0",
+    "dep_version": "fastmcp 3.4.5, mcp-sdk 1.26.0",
     "negotiated": "2025-11-25",
     "lifecycle": "legacy-initialize",
     "advertised": [
@@ -30,7 +30,7 @@
   {
     "transport": "http",
     "server": "tests/_support/mcp_fastmcp_echo_server.py",
-    "dep_version": "fastmcp 3.4.2, mcp-sdk 1.26.0",
+    "dep_version": "fastmcp 3.4.5, mcp-sdk 1.26.0",
     "negotiated": "2025-11-25",
     "lifecycle": "legacy-initialize",
     "advertised": [
@@ -58,7 +58,7 @@
   {
     "transport": "sse",
     "server": "tests/_support/mcp_fastmcp_echo_server.py",
-    "dep_version": "fastmcp 3.4.2, mcp-sdk 1.26.0",
+    "dep_version": "fastmcp 3.4.5, mcp-sdk 1.26.0",
     "negotiated": "2025-11-25",
     "lifecycle": "legacy-initialize",
     "advertised": [

--- a/docs/reference/runtime/mcp-conformance.md
+++ b/docs/reference/runtime/mcp-conformance.md
@@ -8,7 +8,7 @@ Every cell is one of `ok` / `error:<ExceptionType>` / `not_measurable` (with the
 ## stdio
 
 - **server**: `tests/_support/mcp_fastmcp_echo_server.py`
-- **dep_version**: fastmcp 3.4.2, mcp-sdk 1.26.0
+- **dep_version**: fastmcp 3.4.5, mcp-sdk 1.26.0
 - **negotiated**: 2025-11-25
 - **lifecycle**: legacy-initialize
 - **advertised**: ['logging', 'prompts', 'resources', 'tools']
@@ -34,7 +34,7 @@ Every cell is one of `ok` / `error:<ExceptionType>` / `not_measurable` (with the
 ## http
 
 - **server**: `tests/_support/mcp_fastmcp_echo_server.py`
-- **dep_version**: fastmcp 3.4.2, mcp-sdk 1.26.0
+- **dep_version**: fastmcp 3.4.5, mcp-sdk 1.26.0
 - **negotiated**: 2025-11-25
 - **lifecycle**: legacy-initialize
 - **advertised**: ['logging', 'prompts', 'resources', 'tools']
@@ -60,7 +60,7 @@ Every cell is one of `ok` / `error:<ExceptionType>` / `not_measurable` (with the
 ## sse
 
 - **server**: `tests/_support/mcp_fastmcp_echo_server.py`
-- **dep_version**: fastmcp 3.4.2, mcp-sdk 1.26.0
+- **dep_version**: fastmcp 3.4.5, mcp-sdk 1.26.0
 - **negotiated**: 2025-11-25
 - **lifecycle**: legacy-initialize
 - **advertised**: ['logging', 'prompts', 'resources', 'tools']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,7 @@ dependencies = [
     "numpy>=1.24",           # RAG index backend cosine similarity (ADR-0033)
     "croniter>=2.0",         # cron expression parsing for FP-0009 Component B
     "charset-normalizer>=3.0",  # #1452 read_file encoding detection (MIT, pure-python)
-    "fastmcp==3.4.2",        # MCP client is a first-class capability Session.__init__ always constructs (import chain: session -> mcp.connection_service -> mcp.message_handler -> fastmcp), so fastmcp is effectively required — promoted from the former [mcp] extra so a core `reyn chat` no longer ImportErrors on fresh installs.
+    "fastmcp==3.4.5",        # #3698②: bumped from 3.4.2 — measured regression-free (the conformance matrix below is byte-identical across all 3 transports x 5 columns except dep_version itself; 43 real MCP-path tests green). MCP client is a first-class capability Session.__init__ always constructs (import chain: session -> mcp.connection_service -> mcp.message_handler -> fastmcp), so fastmcp is effectively required — promoted from the former [mcp] extra so a core `reyn chat` no longer ImportErrors on fresh installs.
     "pyperclip>=1.9",        # #3616 ①: cross-platform clipboard, replacing a
                               # hand-rolled pbcopy/wl-copy/xclip/xsel/clip
                               # dispatch table whose Windows arm piped UTF-8


### PR DESCRIPTION
**[tui-coder]** — #3698②: bumps the `fastmcp` pin, regression-free per the conformance matrix Phase 0/① built specifically for this.

## What / why

Ran `scripts/mcp_conformance.py` (unchanged) against 3.4.5, diffed against the 3.4.2 baseline (`#3971`): **3 transports (stdio/http/sse) × 5 measured columns, every cell byte-identical** — only `dep_version` itself differs. Zero diff is the measured result, not "nothing to report".

Corroborating: `tests/test_mcp_client.py` + `tests/test_mcp_install_op.py` + `tests/test_mcp_drop_server.py` (43 tests, real MCP client/server round-trips, no mocks) all green under 3.4.5.

Regenerates `mcp-conformance.json`/`.md` so the **next** upgrade's baseline is 3.4.5, not stale 3.4.2 — without this, a future `3.4.5 → 3.4.6` diff would be confounded with whatever this bump already introduced (the exact hazard Phase 0/1 exists to avoid).

Not a new dependency (patch bump of an existing pin), no UX impact (measured) — doesn't fall under the owner's "consult on UX-affecting behavior changes" rule, consistent with how `#3970` (a genuinely new dependency) is handled separately.

`#3698` Phase 0/①/② close here; Phase 2/3 (boundary extraction, lifecycle) remain, tracked separately.

## Test plan

- [x] `ruff check pyproject.toml` → clean
- [x] `python scripts/mypy_ratchet.py` → 212 findings, all baselined (no new)
- [x] `python -m mkdocs build --strict` → exit 0
- [x] `python scripts/verify_module_docstrings.py` → OK
- [x] `python scripts/mcp_conformance.py` → exit 0, both output files regenerated
- [x] Diff against 3.4.2 baseline → only `dep_version` differs (3×5, byte-identical otherwise)
- [x] `pytest tests/test_mcp_client.py tests/test_mcp_install_op.py tests/test_mcp_drop_server.py` → 43 passed

No `tests/` files touched — no TESTS-READ gate applies.

part of #3698

🤖 Generated with [Claude Code](https://claude.com/claude-code)