### PR TITLE
docs(#3985): #2081 S1/S2 stale docstring + ADR-0038 rewind-2b overclaim in feature-map.md

### DIFF
--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -216,7 +216,7 @@ mindmap
 
 #### Time-Travel / Rewind (Resume)
 
-User-facing point-in-time rewind with branching. Phase 1 and Phase 2 (2a/2b/2c/2d) are production. Concurrent-live-fork (parallel live branches) is owner-rejected out-of-scope. Full design: [ADR-0038](deep-dives/decisions/0038-user-facing-time-travel-rewind.md).
+User-facing point-in-time rewind with branching. Phase 1 and Phase 2 (2a/2c/2d) are production; 2b's substrate reads (`list_branches`, `list_rewind_points(include_abandoned=True)`) exist but its own tree-layout consumer (`branch_tree.py::build_branch_tree_rows`) has zero production caller — see the two rows below. Concurrent-live-fork (parallel live branches) is owner-rejected out-of-scope. Full design: [ADR-0038](deep-dives/decisions/0038-user-facing-time-travel-rewind.md) (its status line predates this correction — flagged separately, not edited here).
 
 | Feature | Description | Documentation |
 |---------|-------------|---------------|
@@ -225,10 +225,10 @@ User-facing point-in-time rewind with branching. Phase 1 and Phase 2 (2a/2b/2c/2
 | PITR reconstruct | Point-in-time snapshot + WAL-diff reconstruction to target seq | [Time-Travel concepts](concepts/runtime/time-travel.md) · Crash Recovery |
 | Consistent-cut rewind | Both substrates (runtime state + workspace shadow-git `as-of-N`) rewound atomically | [Time-Travel concepts](concepts/runtime/time-travel.md) |
 | Append-only reset-record | Undo appends a reset-record at seq R; history before R is preserved on the current branch (no destructive rewrite) | [Time-Travel concepts](concepts/runtime/time-travel.md) |
-| Retention window + GC | Configurable checkpoint retention window; stale snapshots GC'd automatically | [How-to: rewind](guide/for-users/time-travel.md) |
+| Retention floor clamp (mechanism only — **not config-wired**) | `RetentionPolicy`/`compute_retention_floor` (ADR-0038 D5) correctly clamp the WAL floor given a policy — but `RetentionPolicy.from_config` is never called from any production config-load path (`AgentRegistry` is always built with `retention_policy=None` → live/no-deeper-retention), and no `reyn.yaml` schema recognizes a `retention:` key at all. Every non-default `RetentionPolicy(...)` construction in the repo is in `tests/`. Matches `time-travel.md`'s own "designed, not yet wired" pending-features entry — this row previously claimed the opposite | [How-to: rewind](guide/for-users/time-travel.md) |
 | Branch registry | Abandoned-interval lineage: each fork receives a registry entry with origin seq | [Time-Travel concepts](concepts/runtime/time-travel.md) |
 | `checkout(seq)` unified primitive | Active-branch seq → undo; inactive-branch seq → fork-switch. One primitive for both directions | [Time-Travel concepts](concepts/runtime/time-travel.md) |
-| Multi-fork tree UX | Always-tree picker with per-branch anchor labels | [How-to: rewind](guide/for-users/time-travel.md) |
+| Multi-fork tree UX (**substrate only — not wired into the picker**) | The 2a substrate (`list_branches`, `list_rewind_points(include_abandoned=True)`) is real and covers the fork-switch/checkout path; the 2b tree-layout function (`branch_tree.py::build_branch_tree_rows`) has a unit test (`tests/test_branch_tree_2b.py`) as its only caller anywhere in the repo — `rewind_picker.py` (the actual `/rewind` widget) has no "branch"/"abandoned" logic at all and lists current-branch checkpoints only, matching `time-travel.md`'s own "not yet wired" pending-features entry | [How-to: rewind](guide/for-users/time-travel.md) |
 | Act-turn runtime-only rewind | Ghost-Replay memo truncate for rewind within an in-flight turn (no substrate round-trip) | [Time-Travel concepts](concepts/runtime/time-travel.md) |
 | Container-mode shadow-git | Shadow-git `as-of-N` rewind supported inside the container environment backend | [How-to: rewind](guide/for-users/time-travel.md) |
 | Deterministic CI rewind gate | `test_live_rewind_gate.py` — Phase-1 rewind deterministic gate | — |

--- a/tests/test_2081_s1_delegation_config.py
+++ b/tests/test_2081_s1_delegation_config.py
@@ -1,8 +1,13 @@
 """Tier 1: #2081 S1 — the ``delegation:`` config field (config-selectable policy).
 
-S1 adds ``delegation.capability_default`` (inherit|deny, default=inherit). S1 is
-INERT — nothing consumes the value yet (S2 wires the unbound-delegate fallback). So
-this slice only pins the contract: parse / default / validate / load_config round-trip.
+S1 adds ``delegation.capability_default`` (inherit|deny, default=inherit). S1 was
+INERT at landing — nothing consumed the value yet. #2092 (S2) has since wired the
+consumer: ``registry.py``'s unbound-delegate fallback reads
+``self._delegation_capability_default`` and, under ``deny``, applies the
+restrictive ``_delegate`` floor (see ``docs/concepts/runtime/capability-profile.md``
+§ "gateway:delegation-unsafe"). This slice's own scope is unchanged — it only pins
+the S1 contract: parse / default / validate / load_config round-trip — S2's wiring
+is covered by its own tests, not this file's.
 
 The default (``inherit``) keeps a fresh install byte-identical to pre-#2081.
 """


### PR DESCRIPTION
**[docs-maintainer]** — #3985: fixed the flagged docstring, then swept for the same shape elsewhere per the dispatch's own request (①だけ直すと次の段階実装で同じことが起きる).

## ① The flagged instance

`tests/test_2081_s1_delegation_config.py`'s module docstring said "S1 is INERT —
nothing consumes the value yet (S2 wires the unbound-delegate fallback)". Verified:
`#2092` (S2) landed long ago and `registry.py:3873` genuinely reads
`self._delegation_capability_default` at runtime (`if effective_delegate and
self._delegation_capability_default == "deny":`), plus `audit.py:131` reads it for a
CLI nudge. 6 real `src/` consumers total. Rewrote the docstring to describe both
stages' current state; the test file's own SCOPE is unchanged (S1's contract only —
S2 has its own tests).

## ② The sweep — same shape, opposite direction, found in `feature-map.md` + ADR-0038

Grepped `docs/` for every "not yet wired" / "designed, not yet wired" style claim and
checked each against its actual `src/` consumer (not just whether the doc file was
touched recently). Two of `feature-map.md`'s own Time-Travel rows overclaim relative
to `time-travel.md`'s honest pending-features table — same underlying bug class
(#3945 §19: an in-flight mechanism described as landed/absent past the point where
that stopped being true), just the doc is ahead of the code instead of behind it:

- **"Retention window + GC"**: `RetentionPolicy`/`compute_retention_floor` (ADR-0038
  D5) are real, unit-tested math — but `RetentionPolicy.from_config` has **zero**
  production callers (`grep -rn "RetentionPolicy.from_config\|retention_policy="
  src/` — only the dataclass's own file and `AgentRegistry`'s constructor param
  default). `AgentRegistry` is always built with `retention_policy=None` (live) in
  `registry_bootstrap.py`. `reyn.yaml`'s schema has no `retention:` key at all. Every
  non-default `RetentionPolicy(...)` construction in the repo is in `tests/`.
  `time-travel.md` already correctly says "⏳ designed, not yet wired" for this exact
  feature — `feature-map.md` said the opposite.

- **"Multi-fork tree UX"**: the 2a substrate (`list_branches`,
  `list_rewind_points(include_abandoned=True)`) is real and used for
  fork-switch/checkout. The 2b tree-**layout** function
  (`branch_tree.py::build_branch_tree_rows`) has exactly **one** caller in the whole
  repo: `tests/test_branch_tree_2b.py`. `rewind_picker.py` (the actual `/rewind`
  Textual widget) has zero `"branch"`/`"abandoned"` logic — confirmed by grep — and
  lists current-branch checkpoints only, exactly matching `time-travel.md`'s own
  "not yet wired" pending-features row.

Fixed both rows in `feature-map.md` to state the substrate-vs-UI split precisely, and
softened the section header ("Phase 1 and Phase 2 (2a/2b/2c/2d) are production" → 2b's
UI consumer specifically called out as unwired).

## Not touched, flagged instead

**ADR-0038's own status line** — `**Status**: **Accepted + Implemented** (2026-06-13)
— Phase 1 and Phase 2 (2a/2b/2c/2d) are production ... verified by docs-maintainer
(5/5 seams)` — is upstream of both wrong `feature-map.md` rows and predates this
correction. Per CLAUDE.md's ADR immutable gate, an ADR body (status line included) is
an owner/lead-reviewed surface — flagging to lead-coder in the broker report rather
than editing it in this PR. Whether the earlier "verified 5/5 seams" check simply
didn't include the config-wiring seam, or config wiring was never actually part of
what got verified, is worth confirming before touching the ADR itself.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` — 336 passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_2081_s1_delegation_config.py` — 8/8 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py tests/test_2081_s1_delegation_config.py` — OK
- [x] `ruff check tests/test_2081_s1_delegation_config.py docs/feature-map.md` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
