### PR TITLE
refactor(#3879): extract 2 cross-test-imported helpers into tests/_support/ (M4-0)

### DIFF
--- a/tests/_support/mcp_cache_test_helpers.py
+++ b/tests/_support/mcp_cache_test_helpers.py
@@ -1,0 +1,100 @@
+"""Shared RouterHostAdapter + probe helpers for MCP tools-cache tests.
+
+``CountingProbe`` is a real async callable that records which servers a
+``mcp_list_tools`` probe was invoked for; ``make_mcp_cache_adapter`` builds a
+``RouterHostAdapter`` wired to it, with every other collaborator a no-op via
+``tests._support.router_host_adapter``'s shared null callbacks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.core.events.events import EventLog
+from reyn.llm.model_resolver import ModelResolver
+from reyn.runtime.services import (
+    LiveSessionIdInputs,
+    McpGatewayInputs,
+    MemoryService,
+    PutOutboxInputs,
+    RouterHostAdapter,
+    SendToAgentInputs,
+)
+from tests._support.router_host_adapter import (
+    make_op_context_source,
+    null_append_history,
+    null_file_delete,
+    null_file_read,
+    null_file_regen,
+    null_file_write,
+    null_mcp_call_tool,
+    null_put_outbox,
+    null_send_to_agent,
+)
+
+_EMPTY_OP_CTX = make_op_context_source()
+_EMPTY_MCP_GATEWAY = McpGatewayInputs(
+    mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
+)
+
+
+class CountingProbe:
+    """Real async callable that records which servers were probed."""
+
+    def __init__(self, tools_by_server: dict[str, list[dict]] | None = None) -> None:
+        self.calls: list[str] = []
+        self._tools = tools_by_server or {}
+
+    async def __call__(self, server_name: str) -> list[dict]:
+        self.calls.append(server_name)
+        return list(self._tools.get(server_name, []))
+
+
+def make_mcp_cache_adapter(
+    *,
+    tmp_path: Path,
+    mcp_servers: dict | None,
+    probe: CountingProbe,
+    state_dir: Path,
+) -> RouterHostAdapter:
+    events = EventLog(subscribers=[])
+    workspace = tmp_path / "agents" / "test-agent"
+    memory = MemoryService(
+        agent_workspace_dir=workspace,
+        events=events,
+        file_write=null_file_write,
+        file_read=null_file_read,
+        file_delete=null_file_delete,
+        file_regenerate_index=null_file_regen,
+    )
+    adapter = RouterHostAdapter(
+        agent_name="test-agent",
+        agent_role="test",
+        output_language="en",
+        op_context_source=_EMPTY_OP_CTX,
+        permission_resolver=None,
+        mcp_servers=mcp_servers,
+        project_context="",
+        events=events,
+        resolver=ModelResolver({}),
+        memory=memory,
+        journal=None,
+        agent_registry=None,
+        agent_workspace_dir=workspace,
+        mcp_call_tool=null_mcp_call_tool,
+        mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
+        send_to_agent_inputs=SendToAgentInputs(
+            send_to_agent=null_send_to_agent, delegation_tracker=lambda: None,
+        ),
+        put_outbox_inputs=PutOutboxInputs(
+            put_outbox=null_put_outbox, agent_replies_tracker=lambda: None,
+        ),
+        append_history=null_append_history,
+        live_session_id_inputs=LiveSessionIdInputs(
+            session_id=None, live_session_id_fn=None,
+        ),
+        state_dir=state_dir,
+    )
+    # #3447: mcp_list_tools is now a real RouterHostAdapter method — see the
+    # same-shaped note in test_mcp_lazy_tools_cache.py's _make_adapter_with_mcp.
+    adapter.mcp_list_tools = probe
+    return adapter

--- a/tests/_support/textual_chat_test_helpers.py
+++ b/tests/_support/textual_chat_test_helpers.py
@@ -1,0 +1,92 @@
+"""Shared TextualChatApp test helpers: a queue-backed transport double and a
+presenter that records the widths it was asked to render at.
+
+``started`` builds a ``tool_call_started`` outbox message. ``QueueTransport``
+is a ``ClientTransport`` double that hands scripted display frames off an
+``asyncio.Queue``. ``WidthRecordingPresenter`` wraps ``ReynPresenter`` and
+records each width it presents at, for tests asserting on layout reflow.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+from reyn.interfaces.inline.textual_chat import ReynPresenter
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+def started(op_id: str, tool: str = "grep") -> OutboxMessage:
+    return OutboxMessage(
+        kind="tool_call_started", text=tool, meta={"tool": tool, "op_id": op_id, "args": {}}
+    )
+
+
+class QueueTransport(ClientTransport):
+    """A real :class:`ClientTransport` fed one frame at a time from a queue, so a
+    test can push a ``started`` frame, inspect the RUNNING row, THEN push the
+    completion and inspect the settle — with the stream staying open in between
+    (mirrors ``test_textual_chat_phase2b_live_tool_3283.py``'s helper)."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[OutboxMessage]" = asyncio.Queue()
+        self.submitted: list[str] = []
+
+    async def push(self, msg: OutboxMessage) -> None:
+        await self._queue.put(msg)
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        while True:
+            msg = await self._queue.get()
+            yield DisplayFrame(msg)
+
+    async def submit_user_text(self, text: str) -> None:
+        self.submitted.append(text)
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+class WidthRecordingPresenter(ReynPresenter):
+    """A real :class:`ReynPresenter` SUBCLASS (not a mock) that records the
+    ``width`` FlowView hands ``present()`` for each entry — this is the BODY
+    width (content width minus BOTH gutters), the one surface that actually
+    exposes what the right gutter's column cost the conversation content.
+    ``FlowView.region.width`` stays the FULL terminal width regardless of
+    gutter configuration (gutter consumption is internal to flowview and not
+    otherwise observable from outside it) — a co-vet finding on #3337, this
+    class is the fix: it reads the real value off the real collaboration
+    seam, not a private flowview attribute."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.widths: "list[int]" = []
+
+    async def present(self, item: "OutboxMessage", width: int):
+        self.widths.append(width)
+        return await super().present(item, width)

--- a/tests/core/test_3846_image_resolution_e2e.py
+++ b/tests/core/test_3846_image_resolution_e2e.py
@@ -21,13 +21,13 @@ from typing import Any
 
 import httpx
 import pytest
-from test_textual_chat_phase4_right_gutter_3283 import QueueTransport
 from textual_flowview import FlowView
 
 from reyn.config.chat import ChatConfig
 from reyn.config.root import ReynConfig
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.runtime.outbox import OutboxMessage
+from tests._support.textual_chat_test_helpers import QueueTransport
 
 
 class _StreamResp:

--- a/tests/interfaces/test_3318_body_neutralize.py
+++ b/tests/interfaces/test_3318_body_neutralize.py
@@ -24,7 +24,6 @@ import io
 import pytest
 from rich.console import Console
 from rich.text import Text
-from test_textual_chat_phase4_right_gutter_3283 import QueueTransport
 
 from reyn.config.chat import ChatConfig, _build_chat_config
 from reyn.config.root import ReynConfig
@@ -40,6 +39,7 @@ from reyn.interfaces.repl.renderer import (
     format_inline_message,
 )
 from reyn.runtime.outbox import OutboxMessage
+from tests._support.textual_chat_test_helpers import QueueTransport
 
 _RAW_ESC = "\x1bdanger\x1b[31m"  # a bare ESC + a CSI (color) sequence
 

--- a/tests/interfaces/test_copy_to_clipboard_sink_3616.py
+++ b/tests/interfaces/test_copy_to_clipboard_sink_3616.py
@@ -19,7 +19,6 @@ import asyncio
 from typing import AsyncIterator
 
 import pytest
-from test_textual_chat_phase4_right_gutter_3283 import QueueTransport
 from textual.widgets import Input
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
@@ -27,6 +26,7 @@ from reyn.interfaces.inline.textual_chat.search_bar import SearchBar
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
+from tests._support.textual_chat_test_helpers import QueueTransport
 
 
 class _CancelTrackingTransport(ClientTransport):

--- a/tests/test_3473_replay_environment_precondition.py
+++ b/tests/test_3473_replay_environment_precondition.py
@@ -286,10 +286,12 @@ async def test_the_recorded_catalog_is_injected_so_a_probe_that_never_answers_is
     same thing more slowly and less certainly; this is the same real-async-
     callable probe seam `test_mcp_cache_warm_start.py` already drives.
     """
-    import sys
-
-    sys.path.insert(0, str(Path(__file__).parent))
-    from test_mcp_cache_warm_start import _CountingProbe, _make_adapter  # noqa: E402
+    from tests._support.mcp_cache_test_helpers import (
+        CountingProbe as _CountingProbe,
+    )
+    from tests._support.mcp_cache_test_helpers import (
+        make_mcp_cache_adapter as _make_adapter,
+    )
 
     state_dir = tmp_path / "state"
     snapshot = {"reyn_markitdown": [{"name": "convert_to_markdown", "description": "d"}]}

--- a/tests/test_mcp_cache_warm_start.py
+++ b/tests/test_mcp_cache_warm_start.py
@@ -22,145 +22,29 @@ from pathlib import Path
 
 import pytest
 
-from reyn.core.events.events import EventLog
-from reyn.llm.model_resolver import ModelResolver
-from reyn.runtime.services import (
-    LiveSessionIdInputs,
-    McpGatewayInputs,
-    MemoryService,
-    PutOutboxInputs,
-    RouterHostAdapter,
-    SendToAgentInputs,
-)
-
-# #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
-# bundled into two frozen, default-free dataclasses. These module-level
-# constants are the "all fields unset" instances this file's tests reuse.
-from tests._support.router_host_adapter import make_op_context_source  # noqa: E402
-
-_EMPTY_OP_CTX = make_op_context_source()
-_EMPTY_MCP_GATEWAY = McpGatewayInputs(
-    mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
-)
-
 from reyn.runtime.services.mcp_cache_file import (
     ToolsAnswered,
     cache_file_path,
     write_cache,
 )
 
-# ---------------------------------------------------------------------------
-# Null callbacks (same shape as in test_mcp_lazy_tools_cache.py)
-# ---------------------------------------------------------------------------
-
-
-async def _null_file_read(path: str) -> dict:
-    return {"content": ""}
-
-
-async def _null_file_write(path: str, content: str) -> dict:
-    return {"path": path, "written": True}
-
-
-async def _null_file_delete(path: str) -> dict:
-    return {"path": path, "deleted": True}
-
-
-async def _null_file_regen(*, path, output_path, entry_template, header) -> dict:
-    return {"path": path, "output_path": output_path, "entries": 0}
-
-
-async def _null_mcp_call_tool(server: str, tool: str, args: dict) -> dict:
-    return {}
-
-
-async def _null_send_to_agent(*, to, request, depth, chain_id) -> None:
-    pass
-
-
-async def _null_put_outbox(msg) -> None:
-    pass
-
-
-def _null_append_history(msg) -> None:
-    pass
+# #3879 M4-0: _CountingProbe / _make_adapter (+ the null-callback duplicates
+# they used) moved to tests/_support/mcp_cache_test_helpers.py (byte-identical
+# apart from dropping the leading underscore and reusing router_host_adapter.py's
+# existing null_* callbacks instead of a second copy of the same six) — a
+# module OTHER test files import from cannot migrate as a pure git mv under
+# Stage 1. Aliased back to the original module-local names so everything
+# below is unchanged.
+from tests._support.mcp_cache_test_helpers import (  # noqa: E402
+    CountingProbe as _CountingProbe,
+)
+from tests._support.mcp_cache_test_helpers import (
+    make_mcp_cache_adapter as _make_adapter,
+)
 
 
 async def _null_spawn_plan_task(*, plan_id, runtime, chain_id, parent_chain_id=None) -> None:
     pass
-
-
-# ---------------------------------------------------------------------------
-# Callable probe class (tracks invocations without mocks)
-# ---------------------------------------------------------------------------
-
-
-class _CountingProbe:
-    """Real async callable that records which servers were probed."""
-
-    def __init__(self, tools_by_server: dict[str, list[dict]] | None = None) -> None:
-        self.calls: list[str] = []
-        self._tools = tools_by_server or {}
-
-    async def __call__(self, server_name: str) -> list[dict]:
-        self.calls.append(server_name)
-        return list(self._tools.get(server_name, []))
-
-
-# ---------------------------------------------------------------------------
-# Adapter factory
-# ---------------------------------------------------------------------------
-
-
-def _make_adapter(
-    *,
-    tmp_path: Path,
-    mcp_servers: dict | None,
-    probe: _CountingProbe,
-    state_dir: Path,
-) -> RouterHostAdapter:
-    events = EventLog(subscribers=[])
-    workspace = tmp_path / "agents" / "test-agent"
-    memory = MemoryService(
-        agent_workspace_dir=workspace,
-        events=events,
-        file_write=_null_file_write,
-        file_read=_null_file_read,
-        file_delete=_null_file_delete,
-        file_regenerate_index=_null_file_regen,
-    )
-    adapter = RouterHostAdapter(
-        agent_name="test-agent",
-        agent_role="test",
-        output_language="en",
-        op_context_source=_EMPTY_OP_CTX,
-        permission_resolver=None,
-        mcp_servers=mcp_servers,
-        project_context="",
-        events=events,
-        resolver=ModelResolver({}),
-        memory=memory,
-        journal=None,
-        agent_registry=None,
-        agent_workspace_dir=workspace,
-        mcp_call_tool=_null_mcp_call_tool,
-        mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent_inputs=SendToAgentInputs(
-            send_to_agent=_null_send_to_agent, delegation_tracker=lambda: None,
-        ),
-        put_outbox_inputs=PutOutboxInputs(
-            put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
-        ),
-        append_history=_null_append_history,
-        live_session_id_inputs=LiveSessionIdInputs(
-            session_id=None, live_session_id_fn=None,
-        ),
-        state_dir=state_dir,
-    )
-    # #3447: mcp_list_tools is now a real RouterHostAdapter method — see the
-    # same-shaped note in test_mcp_lazy_tools_cache.py's _make_adapter_with_mcp.
-    adapter.mcp_list_tools = probe
-    return adapter
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sandbox_model_completion_1339.py
+++ b/tests/test_sandbox_model_completion_1339.py
@@ -169,9 +169,9 @@ def test_chat_session_factory_resolves_concrete_policy(tmp_path):
 def test_router_adapter_factory_resolves_concrete_policy():
     """Tier 2: #1339 reproduce-first —the RouterHostAdapter router OpContext also
     carries a concrete default_sandbox_policy (wire-full-path — both factories)."""
-    from test_router_host_adapter_invariants import _make_adapter
+    from tests._support.router_host_adapter import make_adapter
 
-    adapter = _make_adapter()
+    adapter = make_adapter()
     pol = adapter.make_router_op_context().default_sandbox_policy
     assert pol is not None
     assert pol["network"] is DEFAULT_SANDBOX_NETWORK

--- a/tests/test_textual_chat_gutter_toggle_3352.py
+++ b/tests/test_textual_chat_gutter_toggle_3352.py
@@ -48,11 +48,6 @@ policy.
 from __future__ import annotations
 
 import pytest
-from test_textual_chat_phase4_right_gutter_3283 import (  # noqa: E402 — sibling test module
-    QueueTransport,
-    _started,
-    _WidthRecordingPresenter,
-)
 from textual.app import App
 from textual.screen import Screen
 from textual.widgets import OptionList, TextArea
@@ -73,6 +68,15 @@ from reyn.interfaces.inline.textual_chat.completion import CompletionPopup
 from reyn.interfaces.inline.textual_chat.gutter import RIGHT_GUTTER_WIDTH
 from reyn.interfaces.inline.textual_chat.intervention_panel import InterventionPanel
 from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
+from tests._support.textual_chat_test_helpers import (  # noqa: E402
+    QueueTransport,
+)
+from tests._support.textual_chat_test_helpers import (
+    WidthRecordingPresenter as _WidthRecordingPresenter,
+)
+from tests._support.textual_chat_test_helpers import (
+    started as _started,
+)
 
 #: The two keys under test, and the action each is expected to run.
 LEFT_KEY = "ctrl+g"

--- a/tests/test_textual_chat_phase4_right_gutter_3283.py
+++ b/tests/test_textual_chat_phase4_right_gutter_3283.py
@@ -74,11 +74,20 @@ from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.outbox import OutboxMessage
 
-
-def _started(op_id: str, tool: str = "grep") -> OutboxMessage:
-    return OutboxMessage(
-        kind="tool_call_started", text=tool, meta={"tool": tool, "op_id": op_id, "args": {}}
-    )
+# #3879 M4-0: QueueTransport / _started / _WidthRecordingPresenter moved to
+# tests/_support/textual_chat_test_helpers.py (byte-identical) — other test
+# modules import them from here, which the Stage-1 migration gate cannot
+# tolerate once this file moves. Aliased back to the original module-local
+# names so everything below is unchanged.
+from tests._support.textual_chat_test_helpers import (  # noqa: E402
+    QueueTransport,
+)
+from tests._support.textual_chat_test_helpers import (
+    WidthRecordingPresenter as _WidthRecordingPresenter,
+)
+from tests._support.textual_chat_test_helpers import (
+    started as _started,
+)
 
 
 def _completed(op_id: str, tool: str = "grep") -> OutboxMessage:


### PR DESCRIPTION
**[tui-coder]** — M4-0: the content PR that unblocks M4's bucket-migration PRs.

**Revised after CI red** — see PR comment below for the full story;
summary: this PR originally also moved `tests/_async_wait.py` →
`tests/_support/async_wait.py`. That's gone now — lead-coder independently
re-read `gate_is_active()` at the same time I was diagnosing the same CI
failure from the other direction, and we landed on the identical root
cause and fix.

## Why

M4's Stage-1 migration-diff-shape gate (`scripts/check_migration_diff_shape.py`)
activates on **ANY** rename-shaped diff line under `tests/` (`gate_is_active`'s
signal 1 — even a low-similarity inexact rename, per #3909's widening) — and
once active, only pure `R100` renames / empty `__init__.py` adds / the
Stage-0 baseline shrink are allowed. A move-plus-import-fix PR is therefore
**structurally impossible as a single PR**: the move itself activates the
gate, and the accompanying import-site edits the move needs are then
rejected by that same gate — regardless of how the move is performed
(`git mv`, copy+delete, or copy+keep-both; `-C --find-copies-harder` catches
a byte-identical add even with the old file left untouched, via a C-status
copy).

So `tests/_async_wait.py` stays exactly where it is. It's a non-test root
helper, not a test file the M4 migration ever plans to touch — the bare
`from _async_wait import wait_until` already works today only because
pytest puts each test file's own directory on `sys.path`, a mechanism M4
doesn't affect either way.

The two OTHER extractions below were never the actual problem: pulling a
class/function OUT of an existing test file that stays in place (replaced
by a small import) is a plain content edit (`A` + `M` lines), not a rename
or copy — confirmed directly against CI's own offender list, which
classified both new `_support/` files as plain `A`, never `R`/`C`.

part of #3879

## What changed

- `QueueTransport` / `started` / `WidthRecordingPresenter` extracted from
  `test_textual_chat_phase4_right_gutter_3283.py` into
  `tests/_support/textual_chat_test_helpers.py` — byte-identical apart from
  the module-local underscore-prefixed names losing their underscore
  (matching this package's existing `_support/` convention, e.g.
  `router_host_adapter.make_adapter`, not `_make_adapter`). 4 consumer files
  updated — including `test_textual_chat_gutter_toggle_3352.py`, which
  turned out to need all three symbols, not only `QueueTransport`.
- `CountingProbe` / `make_mcp_cache_adapter` extracted from
  `test_mcp_cache_warm_start.py` into
  `tests/_support/mcp_cache_test_helpers.py` — byte-identical apart from the
  same underscore convention, plus `make_adapter` renamed
  `make_mcp_cache_adapter` to avoid colliding with the different,
  general-purpose `router_host_adapter.make_adapter`. Along the way: the
  source file carried 8 duplicate `_null_*` callback functions already
  present byte-identically in `tests/_support/router_host_adapter.py`; the
  new module imports and reuses those instead of re-duplicating a third
  copy. 2 consumer files updated.
- `test_sandbox_model_completion_1339.py`'s
  `from test_router_host_adapter_invariants import _make_adapter` was a
  misdiagnosis in the original punch list: that file doesn't define
  `_make_adapter` itself — it already re-exports
  `tests._support.router_host_adapter.make_adapter` under a local alias.
  Fixed to import `make_adapter` directly from there instead — a pure
  content edit, no new file.

Module docstrings on the two new `_support/` files are current-state only
(no refactor narrative), per the moved-module docstring convention.

## Verification

- `python scripts/check_migration_diff_shape.py --base origin/main` — now
  reports **inactive** (no rename-shaped line in the diff at all).
- `ruff check` — clean.
- `python scripts/test_tier_audit.py --strict <touched files>` — 76 tests
  inspected, 0 Tier-4 violations.
- `python scripts/verify_module_docstrings.py <new _support/ files>` — clean.
- `python scripts/mypy_ratchet.py` — OK, 212 findings ≤ 213 baselined.
- `python scripts/flat_tests_ratchet.py` — OK, unaffected.
- `pytest` scoped to all 10 touched files — 95 passed. Run under a
  temporary, always-reverted local `conftest.py` monkeypatch registering
  the `ansi-dark` Theme the globally-installed `textual==8.2.0` doesn't
  ship (pre-existing #3723 env-identity gap). `diff` against the pre-edit
  backup confirmed cleanly reverted before commit.

## Test plan

- [x] `check_migration_diff_shape.py --base origin/main` — inactive
- [x] `ruff check` clean
- [x] `test_tier_audit.py --strict` clean (76 tests, 0 violations)
- [x] `verify_module_docstrings.py` clean on both new files
- [x] `mypy_ratchet.py` — no new debt
- [x] `flat_tests_ratchet.py` — unaffected
- [x] `pytest` on all 10 touched files — 95 passed (local theme workaround
      applied + reverted for verification only)
- [x] TESTS-READY from lead-coder — 投稿済み（PR コメント、2026-08-09）。gate も私が走らせて `inactive` を確認しました。
      review per PR-workflow rule 8, not self-merging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
