### PR TITLE
refactor(#3879): close the depth-counted repo-root failure class (M4 prep)

### DIFF
--- a/tests/_support/paths.py
+++ b/tests/_support/paths.py
@@ -1,0 +1,42 @@
+"""Repo-root discovery for tests, by walking up from a file's own location
+to the nearest ancestor containing ``pyproject.toml`` — never by counting
+directory levels from a call site.
+
+A depth-counted root (``Path(__file__).parent.parent``, or an explicit
+``.parents[N]``) is correct only as long as the file's own position in the
+tree never changes; moving the file to a different depth silently breaks
+it, and the breakage is invisible at the diff level (a byte-identical
+``git mv`` still reports a pure rename) — it only surfaces at test-run
+time, as a wrong path. The marker walk here is depth-independent: it is
+correct at any location, including this module's own, permanently.
+
+``REPO_ROOT`` is resolved once, at import time. If no ancestor carries
+``pyproject.toml`` (this module has moved outside the repo, or the repo
+itself lost its marker), resolution raises loudly rather than silently
+falling back to the current working directory.
+
+No ``SRC`` / ``SCRIPTS`` convenience constants are exported here: the
+111 call sites this module was built for don't agree on what "SRC"
+should even point at (some want ``src/``, some want ``src/reyn/``, one
+wants ``scripts/dogfood_trace.py``) — each keeps composing its own
+suffix from ``REPO_ROOT`` rather than a shared constant nobody would
+actually consume.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _find_repo_root(start: Path) -> Path:
+    """Walk *start* and its ancestors for the nearest ``pyproject.toml``.
+    Raises ``RuntimeError`` — never returns a guess — if none is found."""
+    for candidate in (start, *start.parents):
+        if (candidate / "pyproject.toml").is_file():
+            return candidate
+    raise RuntimeError(
+        f"no pyproject.toml found walking up from {start} — repo root "
+        "could not be located; refusing to silently fall back to cwd"
+    )
+
+
+REPO_ROOT = _find_repo_root(Path(__file__).resolve())

--- a/tests/_support/test_paths_repo_root_3879.py
+++ b/tests/_support/test_paths_repo_root_3879.py
@@ -1,0 +1,43 @@
+"""Tier 2: tests/_support/paths.py resolves the repo root by walking up
+for a pyproject.toml marker, and raises rather than guessing when none
+exists — #3879's fix for the depth-counted-root failure class (111 test
+files computed repo-root as Path(__file__).parent.parent-style directory
+counting, which silently breaks the moment the file's own depth changes;
+confirmed directly on #3989's builtin-bucket move).
+"""
+from __future__ import annotations
+
+import pytest
+
+from tests._support.paths import REPO_ROOT, _find_repo_root
+
+
+def test_repo_root_resolves_to_the_real_repo_root() -> None:
+    """Tier 2: the witness condition lead-coder asked for — REPO_ROOT
+    actually carries pyproject.toml, not merely "some directory that
+    didn't raise"."""
+    assert (REPO_ROOT / "pyproject.toml").is_file()
+
+
+def test_resolution_is_depth_independent() -> None:
+    """Tier 2: falsification target — a depth-counted root
+    (Path(__file__).parent.parent) would resolve to a DIFFERENT directory
+    depending on how deep *start* is nested — the whole bug class this
+    module exists to close. Build two starting points at different depths
+    under the SAME real repo tree and confirm both resolve to the
+    identical root, proving the answer does not depend on how many
+    directories separate *start* from the root."""
+    shallow = REPO_ROOT / "tests"
+    deep = REPO_ROOT / "tests" / "_support"
+    assert _find_repo_root(shallow) == REPO_ROOT
+    assert _find_repo_root(deep) == REPO_ROOT
+
+
+def test_no_marker_found_raises_instead_of_guessing(tmp_path) -> None:
+    """Tier 2: falsification — point the walk at pytest's tmp_path, a
+    fresh directory created outside this repo's tree (under the OS temp
+    root, which carries no pyproject.toml on any CI runner or dev machine
+    this suite runs on). A silent cwd/None fallback would pass this call
+    with no error; the raise is the behavior being tested."""
+    with pytest.raises(RuntimeError, match="no pyproject.toml found"):
+        _find_repo_root(tmp_path)

--- a/tests/cli/test_agent_list_hides_archived.py
+++ b/tests/cli/test_agent_list_hides_archived.py
@@ -15,7 +15,9 @@ import argparse
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/cli/test_auth_login_ux.py
+++ b/tests/cli/test_auth_login_ux.py
@@ -22,7 +22,9 @@ from pathlib import Path
 
 import pytest
 
-_SRC = Path(__file__).parent.parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/cli/test_auth_login_ux_p2.py
+++ b/tests/cli/test_auth_login_ux_p2.py
@@ -21,7 +21,9 @@ from pathlib import Path
 
 import pytest
 
-_SRC = Path(__file__).parent.parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/cli/test_auth_login_ux_p3.py
+++ b/tests/cli/test_auth_login_ux_p3.py
@@ -23,7 +23,9 @@ from pathlib import Path
 
 import pytest
 
-_SRC = Path(__file__).parent.parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/cli/test_pending_slash_command.py
+++ b/tests/cli/test_pending_slash_command.py
@@ -16,7 +16,9 @@ from pathlib import Path
 
 import pytest
 
-_SRC = Path(__file__).parent.parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_0060_phase1_f3a_builtin_tier.py
+++ b/tests/test_0060_phase1_f3a_builtin_tier.py
@@ -43,7 +43,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
@@ -59,7 +61,7 @@ from reyn.builtin.registry import (
 from reyn.config.loader import _merge
 from reyn.core.op_runtime.context import OpContext, provenance_from_ctx
 
-_REPO_ROOT = Path(__file__).parent.parent
+_REPO_ROOT = REPO_ROOT
 
 
 class _StubWorkspace:

--- a/tests/test_0060_phase2_f3b_builtin_content.py
+++ b/tests/test_0060_phase2_f3b_builtin_content.py
@@ -67,8 +67,9 @@ from reyn.prompt.router_frame import (
 )
 from reyn.runtime.session_params import PresentationWiring
 from tests._support.agent_session import make_session
+from tests._support.paths import REPO_ROOT
 
-_REPO_ROOT = Path(__file__).parent.parent
+_REPO_ROOT = REPO_ROOT
 _CHEAT_SHEET_PATH = Path(BUILTIN_SKILLS["reyn-cheat-sheet"]["path"])
 _FLAGSHIP_PIPELINE_PATH = Path(BUILTIN_PIPELINES["flagship"]["path"])
 

--- a/tests/test_2421_mcp_seam_completeness.py
+++ b/tests/test_2421_mcp_seam_completeness.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from tests._support.paths import REPO_ROOT
+
 # The seam: the pool constructs clients; client.py defines the class (+ docstring examples).
 _ALLOWED = {"mcp/pool.py", "mcp/client.py", "mcp/connection_service.py"}
 # ``MCPClient(`` construction — the paren distinguishes it from the ``MCPClientPool`` /
@@ -27,7 +29,7 @@ def test_no_direct_mcpclient_construction_outside_seam():
     the contain-all boundary + task-affine/reconnect lifecycle (the sibling-sweep-miss class that
     caused the list-path crash). RED if a direct construction reappears anywhere in src outside the
     pool/client/connection-service seam."""
-    src = Path(__file__).resolve().parents[1] / "src" / "reyn"
+    src = REPO_ROOT / "src" / "reyn"
     offenders: list[str] = []
     for py in src.rglob("*.py"):
         rel = py.relative_to(src).as_posix()

--- a/tests/test_2608_dogfood_hook_liveness.py
+++ b/tests/test_2608_dogfood_hook_liveness.py
@@ -25,8 +25,9 @@ import pytest
 from reyn.core.events.event_store import EventStore
 from reyn.core.events.events import EventLog
 from reyn.core.events.state_log import StateLog
+from tests._support.paths import REPO_ROOT
 
-SCRIPT = Path(__file__).parent.parent / "scripts" / "dogfood_trace.py"
+SCRIPT = REPO_ROOT / "scripts" / "dogfood_trace.py"
 
 
 def _run(args: list[str]) -> tuple[str, int]:

--- a/tests/test_3024_env_identity.py
+++ b/tests/test_3024_env_identity.py
@@ -23,7 +23,9 @@ from pathlib import Path
 
 import pytest
 
-_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "verify_env_identity.py"
+from tests._support.paths import REPO_ROOT
+
+_SCRIPT = REPO_ROOT / "scripts" / "verify_env_identity.py"
 
 
 def _load():

--- a/tests/test_3162_rag_skill_body_read_reachable.py
+++ b/tests/test_3162_rag_skill_body_read_reachable.py
@@ -41,8 +41,9 @@ from reyn.core.op_runtime.plugin_install import plugins_root
 from reyn.data.workspace.workspace import Workspace
 from reyn.schemas.models import FileIROp, PluginInstallIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from tests._support.paths import REPO_ROOT
 
-_REPO_ROOT = Path(__file__).parent.parent
+_REPO_ROOT = REPO_ROOT
 _REAL_SKILL_DIR = (
     _REPO_ROOT / "src" / "reyn" / "builtin" / "plugins" / "rag" / "skills"
     / "build-and-query-rag-corpus"

--- a/tests/test_3233_inprocess_env_identity.py
+++ b/tests/test_3233_inprocess_env_identity.py
@@ -24,7 +24,9 @@ from pathlib import Path
 
 import pytest
 
-_REPO_ROOT = Path(__file__).resolve().parents[1]
+from tests._support.paths import REPO_ROOT
+
+_REPO_ROOT = REPO_ROOT
 _SCRIPT = _REPO_ROOT / "scripts" / "verify_env_identity.py"
 
 

--- a/tests/test_3237_worktree_clean_gate.py
+++ b/tests/test_3237_worktree_clean_gate.py
@@ -37,7 +37,9 @@ from pathlib import Path
 
 import pytest
 
-_SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+from tests._support.paths import REPO_ROOT
+
+_SCRIPTS_DIR = REPO_ROOT / "scripts"
 
 
 def _import_cleanup_module():

--- a/tests/test_3475_probe_degradation_visibility_and_timeout_config.py
+++ b/tests/test_3475_probe_degradation_visibility_and_timeout_config.py
@@ -58,8 +58,9 @@ from reyn.core.events.event_schema import AUDIT_EVENT_KINDS
 from reyn.core.events.state_log import StateLog
 from tests._support.agent_session import make_session
 from tests._support.events import collect_events
+from tests._support.paths import REPO_ROOT
 
-_REPO = Path(__file__).resolve().parents[1]
+_REPO = REPO_ROOT
 _ROUTER_HOST_ADAPTER = _REPO / "src" / "reyn" / "runtime" / "services" / "router_host_adapter.py"
 _MCP_CLI = _REPO / "src" / "reyn" / "interfaces" / "cli" / "commands" / "mcp.py"
 _CHAT_CONFIG = _REPO / "src" / "reyn" / "config" / "chat.py"

--- a/tests/test_3546_pipeline_driver_narrowing_inheritance.py
+++ b/tests/test_3546_pipeline_driver_narrowing_inheritance.py
@@ -155,6 +155,7 @@ from reyn.runtime.spawn_routing import AuditOnlyNoSurface
 from reyn.tools.pipeline_verbs import _handle_run_pipeline
 from reyn.tools.types import RouterCallerState, ToolContext
 from tests._support.agent_session import make_session
+from tests._support.paths import REPO_ROOT
 
 _DENIED_TOOL = "p3546_denied_step"
 
@@ -780,7 +781,7 @@ _SITE_PARENT_LAYERS: "dict[tuple[str, str], _SiteDeclaration]" = {
 }
 
 
-_SRC = Path(__file__).resolve().parents[1] / "src"
+_SRC = REPO_ROOT / "src"
 
 
 @dataclass(frozen=True)

--- a/tests/test_3723_flowview_pin_check.py
+++ b/tests/test_3723_flowview_pin_check.py
@@ -28,7 +28,9 @@ from pathlib import Path
 
 import pytest
 
-_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "verify_env_identity.py"
+from tests._support.paths import REPO_ROOT
+
+_SCRIPT = REPO_ROOT / "scripts" / "verify_env_identity.py"
 
 _PIN_URL = "https://github.com/tya5/textual-flowview.git"
 _PIN_SHA = "5a72da086f1e8e3fc0c93b0806b53a5fd5fb1c7f"

--- a/tests/test_3726_mypy_ratchet.py
+++ b/tests/test_3726_mypy_ratchet.py
@@ -20,7 +20,9 @@ import json
 import sys
 from pathlib import Path
 
-_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "mypy_ratchet.py"
+from tests._support.paths import REPO_ROOT
+
+_SCRIPT = REPO_ROOT / "scripts" / "mypy_ratchet.py"
 
 
 def _load():

--- a/tests/test_3792_pr2_router_loop_injection.py
+++ b/tests/test_3792_pr2_router_loop_injection.py
@@ -207,10 +207,11 @@ async def test_no_injection_when_queue_is_empty() -> None:
 import re
 from pathlib import Path
 
+from tests._support.paths import REPO_ROOT
 from tests._support.router_host_adapter import make_adapter
 
 _ROUTER_LOOP_SRC = (
-    Path(__file__).resolve().parents[1] / "src" / "reyn" / "runtime" / "router_loop.py"
+    REPO_ROOT / "src" / "reyn" / "runtime" / "router_loop.py"
 ).read_text()
 
 

--- a/tests/test_3794_p2_no_audit_event_prose.py
+++ b/tests/test_3794_p2_no_audit_event_prose.py
@@ -31,7 +31,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+from tests._support.paths import REPO_ROOT
+
 EXCLUDED_DIR_NAMES = {".venv", "site", ".git", "__pycache__"}
 # Dated dogfood/investigation logs — historical statements, exempt (see
 # module docstring).

--- a/tests/test_3794_p3_audit_event_identifier_rename.py
+++ b/tests/test_3794_p3_audit_event_identifier_rename.py
@@ -32,8 +32,8 @@ from pathlib import Path
 
 from tests._support.agent_session import make_session
 from tests._support.events import collect_events
+from tests._support.paths import REPO_ROOT
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
 EXCLUDED_DIR_NAMES = {".venv", "site", ".git", "__pycache__"}
 SELF_PATH = Path(__file__).resolve()
 

--- a/tests/test_a2a_capability_claim_interim.py
+++ b/tests/test_a2a_capability_claim_interim.py
@@ -33,6 +33,8 @@ import inspect
 
 import pytest
 
+from tests._support.paths import REPO_ROOT
+
 
 def _maybe_skip_if_router_unavailable() -> None:
     """Skip when ``reyn.interfaces.web.routers.a2a`` can't import (= optional
@@ -110,7 +112,7 @@ def test_push_notifications_claim_backed_by_webhook_post_call_sites() -> None:
     _maybe_skip_if_router_unavailable()
     from pathlib import Path
 
-    repo_root = Path(__file__).parent.parent / "src" / "reyn" / "interfaces" / "web"
+    repo_root = REPO_ROOT / "src" / "reyn" / "interfaces" / "web"
     a2a_router_src = (repo_root / "routers" / "a2a.py").read_text(
         encoding="utf-8",
     )

--- a/tests/test_a2a_webhook_progress_267_gap2.py
+++ b/tests/test_a2a_webhook_progress_267_gap2.py
@@ -42,6 +42,7 @@ pytest.importorskip("fastapi", reason="fastapi not installed ([web] extra missin
 
 from reyn.core.events.events import EventLog  # noqa: E402
 from reyn.schemas.models import Event  # noqa: E402
+from tests._support.paths import REPO_ROOT
 
 
 class _FakeRunRegistry:
@@ -350,7 +351,7 @@ def test_handle_async_mode_attaches_bridge_around_send_to_agent_impl() -> None:
     from pathlib import Path
 
     src_path = (
-        Path(__file__).parent.parent
+        REPO_ROOT
         / "src" / "reyn" / "interfaces" / "web" / "routers" / "a2a.py"
     )
     tree = ast.parse(src_path.read_text(encoding="utf-8"))

--- a/tests/test_agent_construction_via_factory_997.py
+++ b/tests/test_agent_construction_via_factory_997.py
@@ -26,7 +26,9 @@ from __future__ import annotations
 import ast
 import pathlib
 
-_SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "reyn"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src" / "reyn"
 
 # Parent-propagation exemptions (paths relative to src/reyn). These construct an
 # Agent from an already-wired parent context, not a fresh config — from_config

--- a/tests/test_agui_mapping_completeness.py
+++ b/tests/test_agui_mapping_completeness.py
@@ -36,9 +36,10 @@ from reyn.interfaces.transport.frames import (
     forwarded_frame_kinds,
 )
 from reyn.runtime.outbox import OutboxMessage
+from tests._support.paths import REPO_ROOT
 
 _RENDERER = (
-    Path(__file__).resolve().parents[1]
+    REPO_ROOT
     / "src" / "reyn" / "interfaces" / "repl" / "renderer.py"
 )
 

--- a/tests/test_audit_event_kind_vocabulary_3410.py
+++ b/tests/test_audit_event_kind_vocabulary_3410.py
@@ -48,8 +48,9 @@ from reyn.core.events.event_schema import (
     KIND_EMIT_SEAMS,
     DynamicEmitSite,
 )
+from tests._support.paths import REPO_ROOT
 
-_REPO = Path(__file__).resolve().parents[1]
+_REPO = REPO_ROOT
 _SRC = _REPO / "src" / "reyn"
 _EVENTS_REFERENCE = _REPO / "docs" / "reference" / "runtime" / "events.md"
 _EVENTS_CONCEPT = _REPO / "docs" / "concepts" / "runtime" / "events.md"

--- a/tests/test_browser_reyn_decode_tripwire.py
+++ b/tests/test_browser_reyn_decode_tripwire.py
@@ -21,9 +21,10 @@ from pathlib import Path
 from reyn.interfaces.transport.agui.protocol import _encode_display
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
+from tests._support.paths import REPO_ROOT
 
 _INDEX_HTML = (
-    Path(__file__).resolve().parents[1]
+    REPO_ROOT
     / "src" / "reyn" / "interfaces" / "web" / "openui" / "static" / "index.html"
 )
 

--- a/tests/test_charter_citations_reference_live_content_3592.py
+++ b/tests/test_charter_citations_reference_live_content_3592.py
@@ -27,7 +27,9 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-_REPO = Path(__file__).resolve().parents[1]
+from tests._support.paths import REPO_ROOT
+
+_REPO = REPO_ROOT
 _CHARTER = _REPO / "docs" / "concepts" / "architecture" / "charter.md"
 _FEATURE_MAP = _REPO / "docs" / "feature-map.md"
 

--- a/tests/test_compaction_outcome_dist.py
+++ b/tests/test_compaction_outcome_dist.py
@@ -12,7 +12,9 @@ import subprocess
 import sys
 from pathlib import Path
 
-SCRIPT = Path(__file__).parent.parent / "scripts" / "compaction_outcome_dist.py"
+from tests._support.paths import REPO_ROOT
+
+SCRIPT = REPO_ROOT / "scripts" / "compaction_outcome_dist.py"
 
 
 def _run(args: list[str]) -> tuple[str, int]:

--- a/tests/test_config_loader_pure_helpers.py
+++ b/tests/test_config_loader_pure_helpers.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_config_mirror_coverage_1056.py
+++ b/tests/test_config_mirror_coverage_1056.py
@@ -69,8 +69,9 @@ import re
 from pathlib import Path
 
 from reyn.config.config_schema import walk_config_schema
+from tests._support.paths import REPO_ROOT
 
-_REPO_ROOT = Path(__file__).resolve().parents[1]
+_REPO_ROOT = REPO_ROOT
 _EXAMPLE = _REPO_ROOT / "reyn.local.yaml.example"
 _DOCS = _REPO_ROOT / "docs" / "reference" / "config" / "reyn-yaml.md"
 

--- a/tests/test_copy_mode_3507.py
+++ b/tests/test_copy_mode_3507.py
@@ -29,6 +29,7 @@ from reyn.interfaces.inline.textual_chat.gutter import _MARK_RAIL
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
+from tests._support.paths import REPO_ROOT
 
 
 class _Transport(ClientTransport):
@@ -168,7 +169,7 @@ def _binding_surfaces() -> "dict[str, list[str]]":
     import ast
     import pathlib
 
-    package = pathlib.Path(__file__).resolve().parents[1] / (
+    package = REPO_ROOT / (
         "src/reyn/interfaces/inline/textual_chat"
     )
     surfaces: dict[str, list[str]] = {}

--- a/tests/test_detect_attractor.py
+++ b/tests/test_detect_attractor.py
@@ -19,11 +19,13 @@ from typing import Any
 
 import pytest
 
+from tests._support.paths import REPO_ROOT
+
 # ---------------------------------------------------------------------------
 # Import the module under test (not on sys.path by default)
 # ---------------------------------------------------------------------------
 
-_SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+_SCRIPTS_DIR = REPO_ROOT / "scripts"
 
 
 def _import_detect() -> Any:

--- a/tests/test_dogfood_batch_tools.py
+++ b/tests/test_dogfood_batch_tools.py
@@ -30,7 +30,9 @@ from pathlib import Path
 
 import pytest
 
-_SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+from tests._support.paths import REPO_ROOT
+
+_SCRIPTS_DIR = REPO_ROOT / "scripts"
 if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
 
@@ -43,7 +45,6 @@ from dogfood_aggregate import (  # noqa: E402
 from dogfood_batch_config import load_batch_config  # noqa: E402
 from dogfood_batch_dispatch import render_worker_prompt  # noqa: E402
 
-REPO_ROOT = Path(__file__).parent.parent
 B43_JOURNAL = (
     REPO_ROOT
     / "docs/deep-dives/journal/dogfood/2026-05-20-batch-43-post-empty-stop-retry"

--- a/tests/test_dogfood_fresh_mode.py
+++ b/tests/test_dogfood_fresh_mode.py
@@ -21,11 +21,13 @@ from pathlib import Path
 
 import pytest
 
+from tests._support.paths import REPO_ROOT
+
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
 
-SCRIPT = Path(__file__).parent.parent / "scripts" / "dogfood_fresh_reset.sh"
+SCRIPT = REPO_ROOT / "scripts" / "dogfood_fresh_reset.sh"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dogfood_long_session_skill_wait.py
+++ b/tests/test_dogfood_long_session_skill_wait.py
@@ -26,7 +26,9 @@ import pytest
 
 # scripts/ is not on sys.path during normal test discovery; add it lazily so
 # the driver module is importable without restructuring the dogfood scripts.
-_SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+from tests._support.paths import REPO_ROOT
+
+_SCRIPTS_DIR = REPO_ROOT / "scripts"
 if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
 

--- a/tests/test_dogfood_trace_llm_modes.py
+++ b/tests/test_dogfood_trace_llm_modes.py
@@ -11,7 +11,9 @@ import subprocess
 import sys
 from pathlib import Path
 
-SCRIPT = Path(__file__).parent.parent / "scripts" / "dogfood_trace.py"
+from tests._support.paths import REPO_ROOT
+
+SCRIPT = REPO_ROOT / "scripts" / "dogfood_trace.py"
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_dogfood_trace_multi_file.py
+++ b/tests/test_dogfood_trace_multi_file.py
@@ -14,7 +14,9 @@ import subprocess
 import sys
 from pathlib import Path
 
-SCRIPT = Path(__file__).parent.parent / "scripts" / "dogfood_trace.py"
+from tests._support.paths import REPO_ROOT
+
+SCRIPT = REPO_ROOT / "scripts" / "dogfood_trace.py"
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_dogfood_trace_tool.py
+++ b/tests/test_dogfood_trace_tool.py
@@ -10,7 +10,9 @@ import subprocess
 import sys
 from pathlib import Path
 
-SCRIPT = Path(__file__).parent.parent / "scripts" / "dogfood_trace.py"
+from tests._support.paths import REPO_ROOT
+
+SCRIPT = REPO_ROOT / "scripts" / "dogfood_trace.py"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dogfood_variant_replay.py
+++ b/tests/test_dogfood_variant_replay.py
@@ -30,7 +30,9 @@ import pytest
 
 # scripts/ is not on sys.path during normal test discovery; add it
 # lazily so the script module is importable without restructuring.
-_SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+from tests._support.paths import REPO_ROOT
+
+_SCRIPTS_DIR = REPO_ROOT / "scripts"
 if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
 

--- a/tests/test_dogfood_workspace_rooting_1431.py
+++ b/tests/test_dogfood_workspace_rooting_1431.py
@@ -19,8 +19,10 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+from tests._support.paths import REPO_ROOT
+
 _DOGFOOD = (
-    Path(__file__).resolve().parents[1]
+    REPO_ROOT
     / "src" / "reyn" / "interfaces" / "cli" / "commands" / "dogfood.py"
 )
 

--- a/tests/test_embedding_bench_manifest.py
+++ b/tests/test_embedding_bench_manifest.py
@@ -28,9 +28,10 @@ import yaml
 
 from reyn.tools.types import ToolContext
 from reyn.tools.universal_catalog import CATEGORIES, LIST_ACTIONS
+from tests._support.paths import REPO_ROOT
 
 _MANIFEST_PATH = (
-    Path(__file__).parent.parent
+    REPO_ROOT
     / "tests" / "data" / "embedding_bench" / "manifest.yaml"
 )
 _ALLOWED_AXES = {"precision", "call_rate"}

--- a/tests/test_enumerate_all_scheme_1593.py
+++ b/tests/test_enumerate_all_scheme_1593.py
@@ -19,7 +19,9 @@ from types import SimpleNamespace
 
 import pytest
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_events_pure_helpers.py
+++ b/tests/test_events_pure_helpers.py
@@ -13,7 +13,9 @@ from pathlib import Path
 
 import pytest
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_fp0001_a2a_endpoints.py
+++ b/tests/test_fp0001_a2a_endpoints.py
@@ -27,7 +27,9 @@ from pathlib import Path
 import pytest
 
 # Ensure the worktree src is importable.
-_WORKTREE_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_WORKTREE_SRC = REPO_ROOT / "src"
 if str(_WORKTREE_SRC) not in sys.path:
     sys.path.insert(0, str(_WORKTREE_SRC))
 

--- a/tests/test_fp0001_e2e_ask_user_roundtrip.py
+++ b/tests/test_fp0001_e2e_ask_user_roundtrip.py
@@ -41,12 +41,13 @@ from pathlib import Path
 import pytest
 
 from tests._support.agent_session import make_session
+from tests._support.paths import REPO_ROOT
 
 # ---------------------------------------------------------------------------
 # Path setup: ensure tests can import from src/
 # ---------------------------------------------------------------------------
 
-_WORKTREE_SRC = Path(__file__).parent.parent / "src"
+_WORKTREE_SRC = REPO_ROOT / "src"
 if str(_WORKTREE_SRC) not in sys.path:
     sys.path.insert(0, str(_WORKTREE_SRC))
 

--- a/tests/test_fp0036_coverage.py
+++ b/tests/test_fp0036_coverage.py
@@ -17,12 +17,12 @@ from reyn.dev.dogfood.coverage import (
     parse_feature_map,
 )
 from reyn.dev.dogfood.scenarios import Scenario, ScenarioSet
+from tests._support.paths import REPO_ROOT
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
-REPO_ROOT = Path(__file__).parent.parent
 FEATURE_MAP_PATH = REPO_ROOT / "docs" / "feature-map.md"
 
 

--- a/tests/test_fp0036_scenarios_loader.py
+++ b/tests/test_fp0036_scenarios_loader.py
@@ -28,6 +28,7 @@ from reyn.dev.dogfood import (
     ScenarioSet,
     load_scenario_set,
 )
+from tests._support.paths import REPO_ROOT
 
 # ── helpers ───────────────────────────────────────────────────────────────
 
@@ -133,7 +134,7 @@ def test_long_session_v1_loads(tmp_path: Path) -> None:
     this file have expected blocks and some don't — both shapes must load.
     """
     long_session_path = (
-        Path(__file__).parent.parent / "dogfood" / "scenarios" / "long_session_v1.yaml"
+        REPO_ROOT / "dogfood" / "scenarios" / "long_session_v1.yaml"
     )
     ss = load_scenario_set(long_session_path)
     assert isinstance(ss, ScenarioSet)

--- a/tests/test_fp0063_p4_builtin_rag_skill.py
+++ b/tests/test_fp0063_p4_builtin_rag_skill.py
@@ -88,8 +88,9 @@ from tests._support.builtin_skill_tool_names import (
     qualified_tool_calls_referenced,
     real_catalog_tool_names,
 )
+from tests._support.paths import REPO_ROOT
 
-_REPO_ROOT = Path(__file__).parent.parent
+_REPO_ROOT = REPO_ROOT
 _PLUGIN_DIR = _REPO_ROOT / "src" / "reyn" / "builtin" / "plugins" / "rag"
 _SKILL_NAME = "build-and-query-rag-corpus"
 _SKILL_DIR = _PLUGIN_DIR / "skills" / _SKILL_NAME

--- a/tests/test_fp0066_p4a_transport_axis_3247.py
+++ b/tests/test_fp0066_p4a_transport_axis_3247.py
@@ -45,7 +45,9 @@ from pathlib import Path
 
 import pytest
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_hooks_pure_helpers.py
+++ b/tests/test_hooks_pure_helpers.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_intervention_source_agent.py
+++ b/tests/test_intervention_source_agent.py
@@ -21,7 +21,9 @@ import sys
 from contextvars import copy_context
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_lifecycle_forwarder_tool_call_events.py
+++ b/tests/test_lifecycle_forwarder_tool_call_events.py
@@ -27,7 +27,9 @@ import asyncio
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_litellm_gemini_prefix_1162.py
+++ b/tests/test_litellm_gemini_prefix_1162.py
@@ -15,7 +15,9 @@ from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).parent.parent
+from tests._support.paths import REPO_ROOT
+
+ROOT = REPO_ROOT
 
 # Tracked config files that must NOT use any hardcoded <provider>/gemini- string.
 # Class-ref shorthands (e.g. gemini-flash-lite) are the correct form.

--- a/tests/test_llm_callable_claim_resolves_3548.py
+++ b/tests/test_llm_callable_claim_resolves_3548.py
@@ -35,8 +35,9 @@ import re
 from pathlib import Path
 
 from reyn.tools import get_default_registry
+from tests._support.paths import REPO_ROOT
 
-_SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
+_SRC = REPO_ROOT / "src" / "reyn"
 
 # ``(?<!NOT )`` keeps a NEGATED claim ("NOT LLM-callable ...") from being read as
 # an assertion — the correction #3548 lands uses exactly that wording, so without

--- a/tests/test_llm_replay_diff.py
+++ b/tests/test_llm_replay_diff.py
@@ -22,7 +22,9 @@ from pathlib import Path
 from pathlib import Path as _Path
 from typing import Any
 
-_SCRIPTS_DIR = _Path(__file__).parent.parent / "scripts"
+from tests._support.paths import REPO_ROOT
+
+_SCRIPTS_DIR = REPO_ROOT / "scripts"
 
 
 def _import_replay():

--- a/tests/test_llm_replay_from_attractor.py
+++ b/tests/test_llm_replay_from_attractor.py
@@ -23,7 +23,9 @@ from pathlib import Path
 from pathlib import Path as _Path
 from typing import Any
 
-_SCRIPTS_DIR = _Path(__file__).parent.parent / "scripts"
+from tests._support.paths import REPO_ROOT
+
+_SCRIPTS_DIR = REPO_ROOT / "scripts"
 
 
 def _import_replay():

--- a/tests/test_llm_replay_patch.py
+++ b/tests/test_llm_replay_patch.py
@@ -23,7 +23,9 @@ from typing import Any
 
 import pytest
 
-_SCRIPTS_DIR = _Path(__file__).parent.parent / "scripts"
+from tests._support.paths import REPO_ROOT
+
+_SCRIPTS_DIR = REPO_ROOT / "scripts"
 
 
 def _import_replay():

--- a/tests/test_llm_replay_script.py
+++ b/tests/test_llm_replay_script.py
@@ -136,7 +136,9 @@ def _write_trace_with_tools(
 
 from pathlib import Path as _Path
 
-_SCRIPTS_DIR = _Path(__file__).parent.parent / "scripts"
+from tests._support.paths import REPO_ROOT
+
+_SCRIPTS_DIR = REPO_ROOT / "scripts"
 
 
 def _import_replay():

--- a/tests/test_mcp_capability_advertising_271_m3.py
+++ b/tests/test_mcp_capability_advertising_271_m3.py
@@ -33,6 +33,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._support.paths import REPO_ROOT
+
 pytest.importorskip("mcp", reason="MCP SDK not installed")
 
 
@@ -69,7 +71,7 @@ def test_no_notify_changed_calls_in_mcp_server_source() -> None:
     in the declaration is honest).
     """
     src_path = (  # #1682: impl moved to reyn/mcp/server.py (old path = shim)
-        Path(__file__).parent.parent
+        REPO_ROOT
         / "src" / "reyn" / "mcp" / "server.py"
     )
     src = src_path.read_text(encoding="utf-8")
@@ -154,7 +156,7 @@ def test_cancellation_wire_exists_in_call_tool_handler() -> None:
     # now a re-export shim). This source-grep test reads the impl FILE, so it must
     # point at the new path.
     src_path = (
-        Path(__file__).parent.parent
+        REPO_ROOT
         / "src" / "reyn" / "mcp" / "server.py"
     )
     tree = ast.parse(src_path.read_text(encoding="utf-8"))

--- a/tests/test_mcp_gateway_cancel_event_completeness_2813.py
+++ b/tests/test_mcp_gateway_cancel_event_completeness_2813.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from tests._support.paths import REPO_ROOT
+
 # One-shot, non-interactive CLI commands — no per-turn cancel_event exists to pass.
 _ALLOWED = {"interfaces/cli/commands/mcp.py"}
 
@@ -59,7 +61,7 @@ def test_every_mcpgateway_construction_passes_cancel_event():
     op_runtime/ or runtime/ omits cancel_event= — the same structural-gate shape
     as test_2421_mcp_seam_completeness.py, applied to the #2813 cancel-race
     contract instead of the transport-construction contract."""
-    root = Path(__file__).resolve().parents[1] / "src" / "reyn"
+    root = REPO_ROOT / "src" / "reyn"
     scoped_dirs = [root / "core" / "op_runtime", root / "runtime"]
     offenders: list[str] = []
     for scoped in scoped_dirs:

--- a/tests/test_mcp_iv_support_270_phase_b.py
+++ b/tests/test_mcp_iv_support_270_phase_b.py
@@ -37,6 +37,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._support.paths import REPO_ROOT
+
 pytest.importorskip("mcp", reason="MCP SDK not installed")
 
 
@@ -328,7 +330,7 @@ def test_iv_input_required_capability_backed_by_in_source_wire() -> None:
     ``answer_intervention`` tool dispatch. Pin both wires.
     """
     src_path = (  # #1682: impl moved to reyn/mcp/server.py (old path = shim)
-        Path(__file__).parent.parent
+        REPO_ROOT
         / "src" / "reyn" / "mcp" / "server.py"
     )
     src = src_path.read_text(encoding="utf-8")

--- a/tests/test_memory_cron_pure_helpers.py
+++ b/tests/test_memory_cron_pure_helpers.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_multi_agent_p7.py
+++ b/tests/test_multi_agent_p7.py
@@ -42,6 +42,7 @@ from reyn.runtime.services.chain_manager import ChainManager
 from reyn.runtime.session import Session
 from reyn.runtime.topology import Topology
 from tests._support.agent_session import make_session
+from tests._support.paths import REPO_ROOT
 
 # ---------------------------------------------------------------------------
 # Helpers shared across tests
@@ -255,7 +256,7 @@ def _read_source(repo_root: Path, rel_path: str) -> str:
 def _repo_root() -> Path:
     """Locate the repo root from the test file's location."""
     # tests/ sits one level below the repo root.
-    return Path(__file__).parent.parent
+    return REPO_ROOT
 
 
 def test_os_topology_dispatch_has_no_skill_specific_strings():

--- a/tests/test_outbox_vocabulary.py
+++ b/tests/test_outbox_vocabulary.py
@@ -29,8 +29,9 @@ from reyn.runtime.outbox import (
     VOCABULARY,
     OutboxMessage,
 )
+from tests._support.paths import REPO_ROOT
 
-_SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
+_SRC = REPO_ROOT / "src" / "reyn"
 
 
 def test_construction_accepts_every_vocabulary_kind() -> None:

--- a/tests/test_proctitle_3869.py
+++ b/tests/test_proctitle_3869.py
@@ -14,6 +14,7 @@ import sys
 import textwrap
 
 from reyn.runtime.proctitle import format_title, set_process_title
+from tests._support.paths import REPO_ROOT
 
 
 def test_title_is_the_subcommand_and_nothing_else():
@@ -55,7 +56,7 @@ def test_ps_reports_the_new_name_for_a_live_process():
             capture_output=True, text=True, check=True,
         ).stdout.strip())
         """
-    ).format(src=str(__import__("pathlib").Path(__file__).resolve().parents[1] / "src"))
+    ).format(src=str(REPO_ROOT / "src"))
 
     out = subprocess.run(
         [sys.executable, "-c", child], capture_output=True, text=True, check=True

--- a/tests/test_progress_lifecycle_fanout_3357.py
+++ b/tests/test_progress_lifecycle_fanout_3357.py
@@ -33,8 +33,9 @@ from reyn.core.events.progress_lifecycle import (
     PROGRESS_LIFECYCLE_EVENTS,
     format_progress_message,
 )
+from tests._support.paths import REPO_ROOT
 
-_SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
+_SRC = REPO_ROOT / "src" / "reyn"
 # The declaration module names every kind in prose. An AST walk already ignores
 # prose, so this exclusion is belt-and-braces: it also rules out a future
 # illustrative ``emit(...)`` inside the declaration vouching for its own member.

--- a/tests/test_registry_model_resolver_pure_helpers.py
+++ b/tests/test_registry_model_resolver_pure_helpers.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_repl_renderer_pure_helpers.py
+++ b/tests/test_repl_renderer_pure_helpers.py
@@ -22,7 +22,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_reyn_local_example_benchmark_permissions.py
+++ b/tests/test_reyn_local_example_benchmark_permissions.py
@@ -28,8 +28,9 @@ from pathlib import Path
 import pytest
 
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from tests._support.paths import REPO_ROOT
 
-_EXAMPLE_PATH = Path(__file__).resolve().parents[1] / "reyn.local.yaml.example"
+_EXAMPLE_PATH = REPO_ROOT / "reyn.local.yaml.example"
 
 
 def _out_of_zone_path(tmp_path: Path) -> str:

--- a/tests/test_reyn_web_proc.py
+++ b/tests/test_reyn_web_proc.py
@@ -15,7 +15,9 @@ import sys
 import time
 from pathlib import Path
 
-SCRIPT = Path(__file__).parent.parent / "scripts" / "_reyn_web_proc.py"
+from tests._support.paths import REPO_ROOT
+
+SCRIPT = REPO_ROOT / "scripts" / "_reyn_web_proc.py"
 
 
 def _alive(pid: int) -> bool:

--- a/tests/test_router_loop_pure_helpers.py
+++ b/tests/test_router_loop_pure_helpers.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_router_op_context_single_source_1412.py
+++ b/tests/test_router_op_context_single_source_1412.py
@@ -26,7 +26,9 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-_SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src" / "reyn"
 _FACTORY_REL = "runtime/router_op_context.py"
 
 

--- a/tests/test_scoped_session_factory_invariant_1402.py
+++ b/tests/test_scoped_session_factory_invariant_1402.py
@@ -38,8 +38,9 @@ from pathlib import Path
 
 from reyn.runtime.factory_config import SessionFactoryConfig
 from reyn.runtime.scoped_session_factory import build_scoped_chat_session
+from tests._support.paths import REPO_ROOT
 
-_SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
+_SRC = REPO_ROOT / "src" / "reyn"
 
 # The ONE module allowed to construct Session directly.
 _FACTORY_REL = "runtime/scoped_session_factory.py"

--- a/tests/test_session_pure_extraction_3679_s1.py
+++ b/tests/test_session_pure_extraction_3679_s1.py
@@ -38,8 +38,9 @@ from reyn.runtime.session_pure import (
     new_chain_id,
     render_summary_for_storage,
 )
+from tests._support.paths import REPO_ROOT
 
-_REPO_ROOT = Path(__file__).resolve().parents[1]
+_REPO_ROOT = REPO_ROOT
 
 
 def test_new_chain_id_is_a_pure_function_no_self():

--- a/tests/test_session_pure_helpers.py
+++ b/tests/test_session_pure_helpers.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_skill_invoke_3100.py
+++ b/tests/test_skill_invoke_3100.py
@@ -14,7 +14,9 @@ from pathlib import Path
 
 import pytest
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_slash_agent.py
+++ b/tests/test_slash_agent.py
@@ -13,7 +13,9 @@ from pathlib import Path
 
 import pytest
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_slash_cancel_answer_completer.py
+++ b/tests/test_slash_cancel_answer_completer.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_slash_concept.py
+++ b/tests/test_slash_concept.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_slash_destructive_confirm_parity.py
+++ b/tests/test_slash_destructive_confirm_parity.py
@@ -20,7 +20,9 @@ from pathlib import Path
 
 import pytest
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_slash_help_per_command.py
+++ b/tests/test_slash_help_per_command.py
@@ -35,7 +35,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_slash_image_completer.py
+++ b/tests/test_slash_image_completer.py
@@ -19,7 +19,9 @@ from pathlib import Path
 
 import pytest
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_slash_memory.py
+++ b/tests/test_slash_memory.py
@@ -12,7 +12,9 @@ from pathlib import Path
 
 import pytest
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_slash_pending_extended_and_reset_preview.py
+++ b/tests/test_slash_pending_extended_and_reset_preview.py
@@ -14,7 +14,9 @@ import asyncio
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_slash_picker_hint_sweep.py
+++ b/tests/test_slash_picker_hint_sweep.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_slash_reset_docs_link.py
+++ b/tests/test_slash_reset_docs_link.py
@@ -17,7 +17,9 @@ import asyncio
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_slash_rewind_1f.py
+++ b/tests/test_slash_rewind_1f.py
@@ -16,7 +16,9 @@ from pathlib import Path
 
 import pytest
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_slash_see_also_field.py
+++ b/tests/test_slash_see_also_field.py
@@ -19,7 +19,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_slash_suggest_for_unknown.py
+++ b/tests/test_slash_suggest_for_unknown.py
@@ -26,7 +26,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_slash_suggest_prefix_bias.py
+++ b/tests/test_slash_suggest_prefix_bias.py
@@ -22,7 +22,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_slash_usage_extension.py
+++ b/tests/test_slash_usage_extension.py
@@ -29,7 +29,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_snapshot_generations_pure_helpers.py
+++ b/tests/test_snapshot_generations_pure_helpers.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_spawn_routing_gate_2708.py
+++ b/tests/test_spawn_routing_gate_2708.py
@@ -32,8 +32,9 @@ from reyn.runtime.spawn_routing import (
     _REVIEWED_SELF_BOUND_SPAWN_SITES,
     ReviewedNA,
 )
+from tests._support.paths import REPO_ROOT
 
-_SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
+_SRC = REPO_ROOT / "src" / "reyn"
 
 # The three spawn seams whose calls must declare a routing decision. ``spawn_session_recorded`` /
 # ``spawn_ephemeral_session`` are unambiguous names; ``spawn_session`` collides with

--- a/tests/test_ssrf_guard_pure_helpers.py
+++ b/tests/test_ssrf_guard_pure_helpers.py
@@ -9,7 +9,9 @@ import ipaddress
 import sys
 from pathlib import Path
 
-_SRC = Path(__file__).parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 

--- a/tests/test_st_removal_grep_zero_3128.py
+++ b/tests/test_st_removal_grep_zero_3128.py
@@ -42,7 +42,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+from tests._support.paths import REPO_ROOT
+
 THIS_FILE = Path(__file__).resolve()
 
 # Split so this file's own bytes never contain the literal symbol strings

--- a/tests/test_stream_client_single_writer_boundary.py
+++ b/tests/test_stream_client_single_writer_boundary.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-_SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src" / "reyn"
 
 # The writer surface the client must not import directly. ``runtime.outbox`` (the
 # display DTO) and ``interfaces.repl.renderer`` are display types, NOT this set.

--- a/tests/test_textual_chat_phase1_3273.py
+++ b/tests/test_textual_chat_phase1_3273.py
@@ -28,8 +28,9 @@ from reyn.interfaces.repl.stream_client import run_output_loop
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
+from tests._support.paths import REPO_ROOT
 
-_REPO_ROOT = Path(__file__).resolve().parents[1]
+_REPO_ROOT = REPO_ROOT
 
 
 class ScriptedTransport(ClientTransport):

--- a/tests/test_textual_chat_phase2_3273.py
+++ b/tests/test_textual_chat_phase2_3273.py
@@ -59,8 +59,9 @@ from reyn.interfaces.repl.renderer import (
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
+from tests._support.paths import REPO_ROOT
 
-_REPO_ROOT = Path(__file__).resolve().parents[1]
+_REPO_ROOT = REPO_ROOT
 
 
 class ScriptedTransport(ClientTransport):

--- a/tests/test_textual_chat_phase3_3273.py
+++ b/tests/test_textual_chat_phase3_3273.py
@@ -30,8 +30,9 @@ import pytest
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
+from tests._support.paths import REPO_ROOT
 
-_REPO_ROOT = Path(__file__).resolve().parents[1]
+_REPO_ROOT = REPO_ROOT
 
 
 class ScriptedTransport(ClientTransport):

--- a/tests/test_textual_chat_phase4_3273.py
+++ b/tests/test_textual_chat_phase4_3273.py
@@ -47,8 +47,9 @@ from reyn.interfaces.slash import REGISTRY, SlashCommand, SlashRegistry
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
+from tests._support.paths import REPO_ROOT
 
-_REPO_ROOT = Path(__file__).resolve().parents[1]
+_REPO_ROOT = REPO_ROOT
 
 # A real-shaped status snapshot (ONLY keys ``interfaces/inline/app.py:_snapshot``
 # actually produces — no invented field). Reused across the wiring tests.

--- a/tests/test_textual_chat_phase5_3273.py
+++ b/tests/test_textual_chat_phase5_3273.py
@@ -55,8 +55,9 @@ from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
+from tests._support.paths import REPO_ROOT
 
-_REPO_ROOT = Path(__file__).resolve().parents[1]
+_REPO_ROOT = REPO_ROOT
 
 
 # ── real seam impls (no mocks) ────────────────────────────────────────────────

--- a/tests/test_transport_dual_stream_completeness.py
+++ b/tests/test_transport_dual_stream_completeness.py
@@ -19,9 +19,10 @@ from pathlib import Path
 
 from reyn.interfaces.repl.status import _WAITING_ON_BY_EVENT
 from reyn.interfaces.transport.frames import forwarded_frame_kinds
+from tests._support.paths import REPO_ROOT
 
 _RENDERER = (
-    Path(__file__).resolve().parents[1]
+    REPO_ROOT
     / "src" / "reyn" / "interfaces" / "repl" / "renderer.py"
 )
 

--- a/tests/test_web_scoped_capabilities_1401.py
+++ b/tests/test_web_scoped_capabilities_1401.py
@@ -42,8 +42,9 @@ from reyn.interfaces.web.deps import (
 )
 from reyn.security.permissions.permissions import PermissionDecl
 from reyn.security.sandbox.policy import SandboxPolicy
+from tests._support.paths import REPO_ROOT
 
-_SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
+_SRC = REPO_ROOT / "src" / "reyn"
 
 
 def _ns(**kw) -> argparse.Namespace:

--- a/tests/test_workspace_root_not_cwd_3705.py
+++ b/tests/test_workspace_root_not_cwd_3705.py
@@ -22,8 +22,9 @@ from pathlib import Path
 
 from reyn.runtime.agent import Agent
 from reyn.runtime.services.recovery import default_snapshot_path
+from tests._support.paths import REPO_ROOT
 
-_REPO_ROOT = Path(__file__).resolve().parents[1]
+_REPO_ROOT = REPO_ROOT
 _SRC_ROOT = _REPO_ROOT / "src"
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ws_consolidation_complete.py
+++ b/tests/test_ws_consolidation_complete.py
@@ -19,7 +19,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-_SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
+from tests._support.paths import REPO_ROOT
+
+_SRC = REPO_ROOT / "src" / "reyn"
 
 # The consolidated AG-UI UI transport surface. The invariant is that none of
 # these drain a Session outbox directly — they subscribe to the OutboxHub.

--- a/tests/web/test_a2a.py
+++ b/tests/web/test_a2a.py
@@ -23,7 +23,9 @@ from pathlib import Path
 import pytest
 
 # Ensure the worktree src is importable.
-_WORKTREE_SRC = Path(__file__).parent.parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_WORKTREE_SRC = REPO_ROOT / "src"
 if str(_WORKTREE_SRC) not in sys.path:
     sys.path.insert(0, str(_WORKTREE_SRC))
 

--- a/tests/web/test_auth_gate_middleware.py
+++ b/tests/web/test_auth_gate_middleware.py
@@ -24,7 +24,9 @@ from pathlib import Path
 # Ensure the worktree src is importable even when the main-tree src appears
 # earlier on sys.path (editable-install collision) — mirrors the sibling
 # route-mount tests so the fully-mounted worktree app is the one under test.
-_WORKTREE_SRC = Path(__file__).parent.parent.parent / "src"
+from tests._support.paths import REPO_ROOT
+
+_WORKTREE_SRC = REPO_ROOT / "src"
 if str(_WORKTREE_SRC) not in sys.path:
     sys.path.insert(0, str(_WORKTREE_SRC))
 

--- a/tests/web/test_mcp_sse.py
+++ b/tests/web/test_mcp_sse.py
@@ -19,8 +19,10 @@ from pathlib import Path
 
 import pytest
 
+from tests._support.paths import REPO_ROOT
+
 # Ensure the worktree src is importable (mirrors test_smoke.py).
-_WORKTREE_SRC = Path(__file__).parent.parent.parent / "src"
+_WORKTREE_SRC = REPO_ROOT / "src"
 if str(_WORKTREE_SRC) not in sys.path:
     sys.path.insert(0, str(_WORKTREE_SRC))
 

--- a/tests/web/test_openui_shell.py
+++ b/tests/web/test_openui_shell.py
@@ -12,11 +12,13 @@ from pathlib import Path
 
 import pytest
 
+from tests._support.paths import REPO_ROOT
+
 # ---------------------------------------------------------------------------
 # Ensure the worktree src is importable even when the main-tree src appears
 # earlier in sys.path (editable-install collision).
 # ---------------------------------------------------------------------------
-_WORKTREE_SRC = Path(__file__).parent.parent.parent / "src"
+_WORKTREE_SRC = REPO_ROOT / "src"
 if str(_WORKTREE_SRC) not in sys.path:
     sys.path.insert(0, str(_WORKTREE_SRC))
 

--- a/tests/web/test_resources_router.py
+++ b/tests/web/test_resources_router.py
@@ -26,9 +26,11 @@ from pathlib import Path
 
 import pytest
 
+from tests._support.paths import REPO_ROOT
+
 # Same path-bootstrap pattern as tests/web/test_smoke.py — keep the
 # worktree src ahead of any editable-install collision.
-_WORKTREE_SRC = Path(__file__).parent.parent.parent / "src"
+_WORKTREE_SRC = REPO_ROOT / "src"
 if str(_WORKTREE_SRC) not in sys.path:
     sys.path.insert(0, str(_WORKTREE_SRC))
 

--- a/tests/web/test_smoke.py
+++ b/tests/web/test_smoke.py
@@ -16,11 +16,13 @@ from pathlib import Path
 
 import pytest
 
+from tests._support.paths import REPO_ROOT
+
 # ---------------------------------------------------------------------------
 # Ensure the worktree src is importable even when the main-tree src appears
 # earlier in sys.path (editable-install collision).
 # ---------------------------------------------------------------------------
-_WORKTREE_SRC = Path(__file__).parent.parent.parent / "src"
+_WORKTREE_SRC = REPO_ROOT / "src"
 if str(_WORKTREE_SRC) not in sys.path:
     sys.path.insert(0, str(_WORKTREE_SRC))
 


### PR DESCRIPTION
**[tui-coder]** — M4 prep: the structural fix for #3989's finding, per lead-coder's design correction.

part of #3879

## Why

#3989 found that a byte-identical `git mv` can still change a test's behavior: 111 test files compute their own repo-root as `Path(__file__).parent.parent` (or an explicit `.parents[N]`) — a count of "how many directories separate me from the repo root" baked into each call site. That count is correct only as long as the file's own depth in the tree never changes; moving the file to a different depth (exactly what every remaining M4 bucket migration does) silently breaks it. The breakage is invisible at the diff level — a byte-identical rename still reports as a pure `R100` — and only surfaces at test-run time, as a wrong path.

My first proposal (centralize the depth count in one shared module) only moves the counting to one place — that module breaks the same way on its own next move. lead-coder's correction: the structural fix is a **marker walk** — search upward from a file's own location for the nearest ancestor containing `pyproject.toml`. That answer is correct at any depth, including the walking module's own, permanently.

## What changed

- **`tests/_support/paths.py`** (new): `REPO_ROOT`, resolved once via `_find_repo_root()` — walks up for `pyproject.toml`, raises `RuntimeError` (never guesses / falls back to cwd) if none is found. (`SRC`/`SCRIPTS` convenience constants were removed after review — see blocking item below.)
- **`tests/_support/test_paths_repo_root_3879.py`** (new): Tier 2, 3 tests — `REPO_ROOT` genuinely carries `pyproject.toml`; resolution is depth-independent (falsified: a depth-counted `_find_repo_root` fails this); no-marker-found raises rather than silently guessing (falsified: a silent fallback fails this). All falsifications applied and restored.
- **111 test files converted**: each file's own `Path(__file__)`-depth-count expression replaced with the imported `REPO_ROOT` name; every other suffix segment (`"src"`, `"scripts"`, `"dogfood/scenarios/..."`, etc.) preserved byte-for-byte as each file originally wrote it — no attempt to force every caller onto a shared `SRC`/`SCRIPTS` convention, since the wild population already disagrees on what "SRC" points at (some want `src/`, some want `src/reyn/`). `SRC`/`SCRIPTS` were initially exported as convenience constants for new code, then removed after review found zero real consumers — see blocking item below.
- **One real bug found and fixed**, exposed (not introduced) by the mechanical substitution: `tests/test_proctitle_3869.py` used `__import__("pathlib").Path(...)` — the regex correctly matched only the `Path(__file__)...` fragment, leaving a dangling `__import__("pathlib").` prefix attached to the new bare `REPO_ROOT` name. Fixed to the plain imported name.
- 5 files had a redundant `REPO_ROOT = REPO_ROOT` self-assignment (their original local name already was `REPO_ROOT`) — removed as dead code.

Blast-radius classification (all 111, no false positives) was posted to lead-coder in broker before this PR started.

## Verification

- `check_migration_diff_shape.py --base origin/main` — inactive (content-only, no renames — same shape-conflict class as M4-0).
- `ruff check` — clean.
- `python scripts/test_tier_audit.py --strict <touched files>` — 973 + 4 new tests inspected, 0 Tier-4 violations.
- `python scripts/verify_module_docstrings.py tests/_support/paths.py` — clean.
- `python scripts/mypy_ratchet.py` — OK, no new debt.
- `python scripts/flat_tests_ratchet.py` — OK (the new witness test lives in `tests/_support/`, not flat).
- `python scripts/check_tests_dir_names.py` — 16 directories, 0 shadowed.
- `pytest` on all 111 converted files + the new witness — **zero regressions, byte-for-byte confirmed**: an identical `git stash` A/B run against unmodified `origin/main` on the SAME 111-file selection shows the exact same 26 pre-existing failures (24 `TextualChatApp` ansi-dark local-env gap #3723, 1 pre-existing `session_pure` subprocess env issue — both confirmed unrelated to this change by running the failing tests against unmodified `origin/main` directly) and the same pass count.

## Test plan

- [x] `check_migration_diff_shape.py --base origin/main` — inactive (content-only)
- [x] `ruff check` clean
- [x] `test_tier_audit.py --strict` clean (977 tests total, 0 violations)
- [x] `verify_module_docstrings.py` clean
- [x] `mypy_ratchet.py` — no new debt
- [x] `flat_tests_ratchet.py` — unaffected
- [x] `check_tests_dir_names.py` — 16 dirs, 0 shadowed
- [x] `pytest` A/B vs origin/main — zero regressions (26/26 identical pre-existing failures, same pass count)
- Holding for review per PR-workflow rule 8 (touches `tests/`) — not self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
**[lead-coder]** — **TESTS-READ ＋ 🔴 blocking 1 件（★小、★今日ずっと閉じてきた 欠陥クラスです）。**

## ⚪ 設計は 要求どおり、★witness も 本物

```
✅ ★marker-walk ── ★深さを 数えない。★docstring が «なぜ» を 正確に 書いている
   ★「the breakage is invisible at the diff level（★byte-identical git mv still reports
   ★a pure rename）— ★it only surfaces at test-run time」
✅ ★no-marker → ★RuntimeError ── ★「refusing to silently fall back to cwd」
✅ ★witness ★深さ非依存性を ★実際に 測っている
   ★_find_repo_root(shallow) == _find_repo_root(deep) == REPO_ROOT
   ★= ★実装の 転記では なく ★性質の 検証
✅ ★条件② ★git stash A/B で ★origin/main と 完全一致（★既存失敗 26 件、★regression 0）
```
⚪ **既存失敗 26 件を «同一» と 示した**のが 正しい ── **«緑だった» では なく «変わらなかった»。**

## 🔴 blocking —— **`SRC` / `SCRIPTS` に 消費者が いません**

```
★私が 数えました（★自身の テストを 除く）
   ★REPO_ROOT ★111 箇所
   🔴 ★SRC      ★★0
   🔴 ★SCRIPTS  ★★0
```
⚠️ **∴ «宣言され、★テストされ、★誰も 使わない» —— ★#3907 / #3850 / #3962 と ★同じ 形**です。
**しかも ★test_src_and_scripts_are_real_repo_relative_directories が
★«実在する» を assert している ∴ ★死んでいる ことが ★緑で 隠れます。**

⚪ **経緯は 理解しています** —— **`src/` と `src/reyn/` の 流儀不一致を 吸収する ため、
★各 file が 自分の suffix を 保った**。**それは 正しい 判断**です。**問題は ★使わないと
決めた 定数を ★残した こと。**

- [x] 🔴 **`SRC` / `SCRIPTS` を 削除する（★`REPO_ROOT` だけ 残す）。**
  **併せて ★test_src_and_scripts_… も 削除。**
  ⚪ **[tui-coder] addressed** — 同commitにamend (`SRC`/`SCRIPTS`定数+witness削除、`REPO_ROOT`のみ残置)、force-push済み。CI再実行中。
  ⚪ **将来 要るなら その ときに 足す** —— **«要るかも» で 置いた 定数が、★今日 私たちが
  1 日 かけて 掃除した もの**です。
  ⚪ **もし «残す» なら、★111 件の うち suffix が `src/reyn` の 9 件を ★SRC に 寄せる** ——
  **★消費者を 作る ほう。★どちらでも 可ですが、★«定義だけ» は 不可。**

## ⚪ 機械置換で 見つけた バグ

⚪ **`__import__("pathlib").Path(…)` の 変則形で ★`__import__("pathlib").REGEX 置換後` が
宙に 浮いた**件、**手で 直した のは 正しい。**
⚪ **«他に 無いか» の 根拠**: **条件②の A/B が ★origin/main と 完全一致** ∴
**★同型が 残っていれば ★collection error か NameError で ★差分に 出ます。★出ていない。**
**これは ★数えた わけでは ない が、★CI が 母集団 全体を 通した ことの 帰結**です。

