### PR TITLE
refactor(#3879): close a _support/ blind spot in the depth-counted repo-root class (M4)

### DIFF
--- a/tests/_support/builtin_skill_tool_names.py
+++ b/tests/_support/builtin_skill_tool_names.py
@@ -20,8 +20,8 @@ from pathlib import Path
 
 from reyn.tools.types import RouterCallerState, ToolContext
 from reyn.tools.universal_catalog import catalog_entries
+from tests._support.paths import REPO_ROOT
 
-REPO_ROOT = Path(__file__).parent.parent.parent
 BUILTIN_DIR = REPO_ROOT / "src" / "reyn" / "builtin"
 
 


### PR DESCRIPTION
**[tui-coder]** — Last M4-related task tonight per lead-coder's instruction — no new bucket migrations after this.

part of #3879, follow-up to #3990/#3997

## Why

`tests/_support/builtin_skill_tool_names.py` computed `REPO_ROOT` as `Path(__file__).parent.parent.parent` — #3990/#3997's blast-radius measurement excluded `tests/_support/` from the population entirely (reasoning: `_support/` doesn't move, so nothing there breaks on a bucket migration). That's true today, but incomplete as a property: `_support/` itself computing its own repo-root by depth-counting means the same failure fires the day `_support/` is reorganized. "Doesn't move today" is a state, not a guarantee.

## What changed

Converted to import `REPO_ROOT` from `tests/_support/paths.py` (marker walk), the same fix applied to the 133 files #3990/#3997 already converted. Content-only — no rename, gate stays inactive.

## Verification

- `ruff check` — clean.
- `python scripts/mypy_ratchet.py` — OK, no new debt.
- `python scripts/verify_module_docstrings.py` — clean.
- `pytest` on both consumers (`test_fp0063_p4_builtin_rag_skill.py`, `test_builtin_skill_tool_name_drift_3092.py`) — 14 passed; a `git stash` A/B against unmodified `origin/main` on the same selection shows the identical 14/14 — zero regressions.

## Test plan

- [x] `ruff check` clean
- [x] `mypy_ratchet.py` — no new debt
- [x] `verify_module_docstrings.py` clean
- [x] `pytest` A/B vs origin/main — zero regressions (14/14 identical)
- Not self-merging per PR-workflow rule 8; lead-coder is running the merge train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)