### PR TITLE
refactor(#3879): close a tests/_support/ sibling-lookup depth dependency (M4 prep)

### DIFF
--- a/tests/test_2608_h1_mcp_resource_updated_hook.py
+++ b/tests/test_2608_h1_mcp_resource_updated_hook.py
@@ -30,8 +30,9 @@ from reyn.runtime.session import Session
 from reyn.runtime.session_params import ReactivityConfig
 from tests._support.agent_session import make_session
 from tests._support.events import collect_events
+from tests._support.paths import REPO_ROOT
 
-_SUPPORT_DIR = Path(__file__).parent / "_support"
+_SUPPORT_DIR = REPO_ROOT / "tests" / "_support"
 _SUBSCRIBABLE_SERVER = _SUPPORT_DIR / "mcp_subscribable_resources_server.py"
 _URI = "resource://counter"
 


### PR DESCRIPTION
**[tui-coder]** — M4 prep for the `hooks` bucket — a new sub-variant of the depth-dependency class, caught by the pre-move `__file__` audit before any gate/CI exposure.

part of #3879, same class as #3990/#3997/#3998

## Why

Pre-move audit for the `hooks` bucket found `test_2608_h1_mcp_resource_updated_hook.py` computing `_SUPPORT_DIR = Path(__file__).parent / "_support"` — a single-`.parent` variant of the same depth-dependency class #3990/#3997/#3998 closed, just targeting `tests/_support/` (a sibling directory) instead of the repo root. Correct today only because the file sits directly under `tests/`; moving it to `tests/hooks/` would silently redirect the lookup to a nonexistent `tests/hooks/_support/`, breaking the real MCP subprocess server script (`tests/_support/mcp_subscribable_resources_server.py`) this test spawns.

## What changed

Converted to `REPO_ROOT / "tests" / "_support"` using the same `tests/_support/paths.py` marker-walk `REPO_ROOT` already relied on by 133 other files. Content-only — no rename, gate stays inactive.

## Verification

- `check_migration_diff_shape.py --base origin/main` — inactive (content-only).
- `ruff check` — clean.
- `python scripts/mypy_ratchet.py` — OK, no new debt.
- `python scripts/verify_module_docstrings.py` — clean.
- `python scripts/test_tier_audit.py --strict` — 7 tests, 0 violations.
- `pytest` — 7 passed; a `git worktree` A/B against unmodified `origin/main` on the same file shows the identical 7/7 — zero regressions. (Used a worktree rather than `git stash` for the A/B — see #4001 for why.)

## Test plan

- [x] `check_migration_diff_shape.py --base origin/main` — inactive (content-only)
- [x] `ruff check` clean
- [x] `mypy_ratchet.py` — no new debt
- [x] `verify_module_docstrings.py` clean
- [x] `test_tier_audit.py --strict` clean (7 tests, 0 violations)
- [x] `pytest` A/B vs origin/main — zero regressions (7/7 identical)
- Not self-merging per PR-workflow rule 8; lead-coder is running the merge train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)