### PR TITLE
docs: verification-hazards §13 gets #4009's migration-gate as 4th instance

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -817,6 +817,65 @@ different authors at N different times; assume there's an (N+1)th until a
 grep across the whole tree (§17: `src`/`tests`/`scripts`/`docs`, not just
 the file you started with) comes back empty.
 
+## 20. The enumeration hit and the classification missed — a correct population is not a correct verdict
+
+2026-08-09/10, three sessions independently hit the same shape during the
+same M4 test-migration arc, each getting the POPULATION right and the
+PER-ITEM CLASSIFICATION wrong:
+
+- **e2e-coder (#3976):** an AST scan surfaced a real call site; the session
+  classified it as "correctly uses `default_sandbox_policy`" without
+  reading that SAME call's other kwargs, which carried the actual defect.
+  The hit was found; what it meant was not checked.
+- **lead-coder (#3995→#4002):** the `__file__`-rooted-expression superset
+  was enumerated correctly (every such expression in the tree), but the
+  per-expression verdict used the wrong predicate ("does it leave its own
+  directory") — misclassifying `Path(reyn.__file__)` (a different
+  package's file, not a hazard) as dangerous, and `Path(__file__).parent /
+  "_support"` (one hop, but `_support` doesn't travel with a moved file)
+  as safe.
+- **tui-coder (#4011):** a grep for `"tests/<name>.py"` string literals
+  returned 30+ hits. A SAMPLE of a few were confirmed prose/docstring
+  cross-references, and that verdict was extrapolated to the rest without
+  checking each one — one of the un-sampled hits was actually a
+  `_TCLI = "tests/…py"` registry constant, a programmatic reference, not
+  prose.
+
+**Why the pattern recurs together:** getting the population right is a
+*procedural* improvement (switch grep to an AST scan, take the superset
+instead of a hand-picked list) and it registers consciously as progress.
+Classification has no equivalent shortcut — it can only be done one item
+at a time — so "the count matches" or "the shape looks the same" becomes
+tempting as a stopping point. The sample-then-extrapolate failure is
+specifically MORE likely right after a population is correctly closed, not
+less: the confidence earned from getting the harder procedural step right
+transfers to the easier-feeling classification step, where it doesn't
+belong. This is a different shape than §4's census-vs-structure gap (a
+COUNT that turned out wrong) and different from §13's gate-scope gap (an
+assertion that covers less than it claims) — here the set itself was
+correct throughout, and the verdicts attached to its members were not.
+
+**Apply:**
+- After writing "the population is closed," ask "is the classification
+  closed" as a SEPARATE question — the two are independent claims, and one
+  being true says nothing about the other.
+- If a verdict was reached by sampling N of M hits and extrapolating,
+  write that down as sampling, not as a checked result. Written down, the
+  next reader can challenge it; left implicit, it reads as measurement.
+- Past the point where classifying each hit by hand doesn't scale, hand
+  the classification to a MECHANISM, not a person re-reading faster — the
+  `#4009` migration gate's own "a′" answer is exactly this: instead of
+  inferring whether a moved `__file__` expression is now broken, it
+  re-resolves the expression against the file's real post-move location
+  and checks existence directly, no classification step at all.
+- Every instance above was caught by something OTHER than the sweep that
+  produced the miscount: CI (#3989/#3994), `ruff`'s `I001` surfacing an
+  unusual import (#4011's dotted-form gap), or the referenced side's own
+  test suite (#4011's registry constant). An audit does not reliably find
+  its own blind spot — plan for a second, independent mechanism to catch
+  what the first one's classification step missed, rather than trusting a
+  repeated pass by the same method.
+
 ## See also
 
 - [Testing policy](testing.md) — Tier model, Mock vs Fake, decision flow.

--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -394,6 +394,29 @@ actually promises.
   projection helper" is provable and was proven; "no NEW seam can ever
   route around it" is a different, harder claim that needed a structurally
   different assertion (the AST gate), not a bigger version of the same one.
+- **A migration-safety gate's founding axiom** (2026-08-09/10,
+  `check_migration_diff_shape.py`, #3995→#4002→#4009): "byte-identical
+  `R100` rename ⇒ safe" is a provable, easy-to-state property, and CI
+  enforced it correctly. It is a narrower claim than "this file's behavior
+  is unchanged by the move" — false in principle for any
+  `Path(__file__)`-rooted expression, whose meaning depends on the file's
+  OWN location. The design went through two retracted attempts to widen the
+  SAME predicate before landing on the right shape: first, "flag by
+  hop-count" (retracted — `Path(__file__).parent / "_support"` is one hop
+  but still breaks on a move, because `_support` doesn't travel with the
+  file); second, "classify by whether the target travels with the file"
+  (retracted — that's a property of the MOVE, not the source text,
+  undecidable statically). What shipped instead is **two separate,
+  narrower mechanisms**, not one bigger predicate: a move-time check that
+  re-resolves every `__file__` expression against the file's REAL new
+  location (no inference needed, the move already happened), and a
+  static add-time check restricted to a filesystem-derived structural
+  proxy (does the expression reach `tests/` or one of its current direct
+  children) — deliberately not attempting the undecidable general claim.
+  Both new gates then found 30 real, pre-existing instances of the defect
+  class on their first whole-tree run, confirming "declared byte-identical
+  ⇒ safe" had been true only for the specific property it checked, never
+  the broader one readers assumed from its name.
 
 **Apply**: when writing or reviewing a gate, write out the FULL property the
 surrounding prose/docstring promises, then check whether the assertion


### PR DESCRIPTION
**[docs-maintainer]** — cross-reference audit off tonight's M4 arc merges (per lead-coder's request), plus one addition.

## Audit result: clean

```
#4009 a′+b gate (check_file_depth_reference.py / _file_depth_predicate.py /
      .github/workflows/file-depth-reference-gate.yml) — new, but no
      existing docs/ or CLAUDE.md claim references these scripts by name
      (same as check_migration_diff_shape.py itself, never documented
      anywhere before tonight either)
#4007/#4010 tools/llm bucket moves — grepped docs/ + CLAUDE.md for any
      `tests/<moved-filename>` reference; zero hits
#3990/#3997/#3998/#4002 depth-reference closures — internal test-infra
      fixes, no external doc surface
```

## One addition: #4009 as a 4th instance of verification-hazards.md §13

`check_migration_diff_shape.py`'s founding axiom — "byte-identical `R100`
rename ⇒ safe" — is exactly §13's shape ("A gate can prove the property
that's easy to state, and never touch the property that matters"): a
provable, easy property (byte-identical rename) that's narrower than the
harder claim readers assume from the gate's name ("this move is safe").
The design's own two retracted widening attempts before landing on two
separate, deliberately narrower mechanisms — read directly from #4009's
own module docstrings, which record the retraction history — is a clean,
well-evidenced same-shape addition alongside the section's existing 3
same-day instances.

## Flagged, not written here

Lead-coder's request also named a second theme from tonight — "audit
doesn't find its own blind spot" (3 sessions independently hit this).
§13 was the clean fit for the gate-scope theme; the blind-spot theme
doesn't have as clean an existing home in `verification-hazards.md`, and
I don't have the specific instances lead-coder has in mind (only my own
partial view — the ADR-0038 "5/5 seams" scoping question from earlier
tonight, which turned out to be a documented-scope issue rather than a
missed blind spot once lead-coder investigated it). Speculatively
authoring a new section from a general impression risks the exact
"declaration vs verified" gap this doc itself warns about — asking
lead-coder for the specific instances before writing it.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` — 336 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**[docs-maintainer]** — Update: added §20 as a follow-up commit, now that memory-curator's broadcast (`feedback_the_enumeration_hit_and_the_classification_missed`) supplied the specific instances behind the second theme flagged above.

## §20: The enumeration hit and the classification missed

Three sessions independently hit the same shape in the M4 arc: e2e-coder (#3976, AST-scan hit classified without checking the same call's other kwargs), lead-coder (#3995→#4002, `__file__` superset enumerated correctly but per-expression predicate misclassified both directions), tui-coder (#4011, sampled a few grep hits as prose and extrapolated the verdict to 30+ without checking each one — one un-sampled hit was a real registry constant). Verified #4011's claim directly against its own PR body before writing this ("a broad grep ... found 30+ hits, all confirmed by sampling to be prose/docstring cross-references").

Distinct from §4 (a count that was wrong) and §13 (an assertion narrower than its claimed scope) — here the population was correct throughout and the per-item verdicts were not, with the specific trap being that confidence from closing the population transfers to the classification step where it doesn't belong.

## Test plan (§20 addition)

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` — 336 passed