### PR TITLE
docs(#4014): index proposals 0061-0066, fix ADR-0034's stale reference paths

### DIFF
--- a/docs/deep-dives/decisions/0034-a2a-task-lifecycle.md
+++ b/docs/deep-dives/decisions/0034-a2a-task-lifecycle.md
@@ -166,11 +166,17 @@ to `true` once the router extensions land.
 
 ## References
 
-- `src/reyn/web/run_registry.py` — `RunRegistry`, `RunEntry`
-- `src/reyn/web/a2a_intervention.py` — `A2AInterventionBus`
-- `src/reyn/web/notifications.py` — `post_webhook`
-- `src/reyn/web/routers/a2a.py` — router extensions
-- `src/reyn/chat/session.py` — `register_intervention_override`
+- `src/reyn/interfaces/web/run_registry.py` — `RunRegistry`, `RunEntry`
+- `src/reyn/interfaces/web/a2a_intervention.py` — `A2AInterventionBus`
+- `src/reyn/interfaces/web/notifications.py` — `post_webhook`
+- `src/reyn/interfaces/web/routers/a2a.py` — router extensions
+- `register_intervention_override` (path unresolvable as of 2026-08-10 — no `def
+  register_intervention_override` anywhere in `src/`, only 3 stale comment/docstring
+  references; the actual call site now passes the bus directly,
+  `send_to_agent_impl(..., intervention_override=bus, ...)` in
+  `src/reyn/interfaces/web/routers/a2a.py`. The Decision/Consequences prose above
+  is untouched per the ADR immutable gate — this is a citation-currency note, not
+  a claim the mechanism no longer works)
 - `docs/concepts/multi-agent/a2a.md` — user-facing protocol documentation
 - ADR-0008 / ADR-0016 — intervention buffering precedent (`InterventionBus`
   contract that `A2AInterventionBus` implements)

--- a/docs/deep-dives/proposals/README.ja.md
+++ b/docs/deep-dives/proposals/README.ja.md
@@ -116,4 +116,10 @@ SMALL / MEDIUM / LARGE（根拠付き）。
 | [0058](0058-web-surface-modularity.md) | Web surface modularity + Chainlit retire | owner-ratified; Phase 1-4 landed(#2837/#2849/#2850)、Phase 5(任意 refactor fold)は未着手 | LARGE |
 | [0059](0059-hook-event-redesign.md) | Hook-Event Redesign(Event Bus / reactivity substrate) | owner-ratified; Phase 1-5 landed(#2871–#2885) | LARGE |
 | [0060](0060-llm-wielding-foundation.md) | LLM-Wielding Foundation — agent が構築したものを実際に使うための基盤 | closed(2026-07-13); floor + show 済み、Addendum A/B/C 確定、enhancement/loop layer は owner により de-scope | LARGE |
+| [0061](0061-repo-self-access-and-packaging-standardization.md) | Repo self-access + packaging standardization | done — 追跡対象 3 PR 全て merge(#2923/#2924/#2925) | MEDIUM |
+| [0062](0062-structured-output-ephemeral-sessions-agent-steps.md) | Ephemeral session + pipeline agent step の構造化出力 | done — 即日 landed(2026-07-13、#2934) | SMALL |
+| [0063](0063-builtin-turnkey-user-rag.md) | Builtin turnkey user RAG(builtin mcp + skill + pipeline) | landed — PC/P2/P3/P4 merge(#2949/#2952/#2966/#3008)、0064 P5(#3078)へ統合 | LARGE |
+| [0064](0064-plugin-model.md) | reyn 向け Plugin model(author → test → promote reusable capabilities) | Accepted + Implemented — 全 5 phase landed、umbrella #3066 CLOSED | LARGE |
+| [0065](0065-orchestration-foundation.md) | Orchestration foundation — external-event plugins を first-class unit として | Proposed(owner review 待ち、2026-07-20) | LARGE |
+| [0066](0066-retrieval-two-groups-two-axes.md) | Retrieval 再設計: two groups(action / knowledge)× two axes(scheme × transport) | Proposed — owner design-of-record(2026-07-24/25)、owner GO 待ち | LARGE |
 | [0067](0067-task-model-and-arbiter.md) | タスクモデルと inbox arbiter — [ADR-0040](../decisions/0040-task-as-os-concept.md) の sequencing/interface | Accepted(2026-08-10、owner)— **未実装**; tracking #3978 | LARGE |

--- a/docs/deep-dives/proposals/README.md
+++ b/docs/deep-dives/proposals/README.md
@@ -120,4 +120,10 @@ Links to related ADRs, PRs, and docs.
 | [0058](0058-web-surface-modularity.md) | Web surface modularity + Chainlit retire | owner-ratified; Phases 1-4 landed (#2837/#2849/#2850), Phase 5 (optional refactor fold) open | LARGE |
 | [0059](0059-hook-event-redesign.md) | Hook-Event Redesign (Event Bus / reactivity substrate) | owner-ratified; Phases 1-5 landed (#2871–#2885) | LARGE |
 | [0060](0060-llm-wielding-foundation.md) | LLM-Wielding Foundation — making the agent actually use what it can build | closed (2026-07-13); floor + show delivered, Addenda A/B/C settled, enhancement/loop layers de-scoped by owner | LARGE |
+| [0061](0061-repo-self-access-and-packaging-standardization.md) | Repo self-access + packaging standardization | done — all 3 tracked PRs merged (#2923/#2924/#2925) | MEDIUM |
+| [0062](0062-structured-output-ephemeral-sessions-agent-steps.md) | Structured output for ephemeral sessions + pipeline agent steps | done — landed same day (2026-07-13, #2934) | SMALL |
+| [0063](0063-builtin-turnkey-user-rag.md) | Builtin turnkey user RAG (builtin mcp + skill + pipeline) | landed — PC/P2/P3/P4 merged (#2949/#2952/#2966/#3008), folded into 0064 P5 (#3078) | LARGE |
+| [0064](0064-plugin-model.md) | Plugin model for reyn (author → test → promote reusable capabilities) | Accepted + Implemented — all 5 phases landed, umbrella #3066 CLOSED | LARGE |
+| [0065](0065-orchestration-foundation.md) | Orchestration foundation — external-event plugins as a first-class unit | Proposed (awaiting owner review, 2026-07-20) | LARGE |
+| [0066](0066-retrieval-two-groups-two-axes.md) | Retrieval redesign: two groups (action / knowledge) × two axes (scheme × transport) | Proposed — owner design-of-record (2026-07-24/25), awaiting owner GO to phase-implement | LARGE |
 | [0067](0067-task-model-and-arbiter.md) | Task model and the inbox arbiter — sequencing and interface for [ADR-0040](../decisions/0040-task-as-os-concept.md) | Accepted (2026-08-10, owner) — **not yet implemented**; tracking #3978 | LARGE |


### PR DESCRIPTION
**[docs-maintainer]** — closes both items architect filed in #4014.

## ① proposals/README.md + README.ja.md — 6 missing entries

Added 0061-0066 to both files (status text taken from each proposal's own Status
header, matched to the existing table's style). Same gap-class #4013 already fixed
on the `decisions/` side.

## ② ADR-0034 References — stale paths

Fixed the four confirmed simple renames from the pre-#1682-reorg layout:

```
src/reyn/web/run_registry.py       → src/reyn/interfaces/web/run_registry.py
src/reyn/web/a2a_intervention.py   → src/reyn/interfaces/web/a2a_intervention.py
src/reyn/web/notifications.py      → src/reyn/interfaces/web/notifications.py
src/reyn/web/routers/a2a.py        → src/reyn/interfaces/web/routers/a2a.py
```

🔴 **The fifth citation turned out to be more than a path fix.** `register_intervention_override`
resolves to **zero** definitions anywhere in `src/` — only 3 stale comment/docstring mentions
(including two test files). The mechanism itself changed shape: the override bus is now passed
directly as a keyword argument (`send_to_agent_impl(..., intervention_override=bus, ...)` in
`routers/a2a.py`), not registered on the session by `chain_id` the way the ADR's Decision section
describes. I did **not** rewrite the Decision/Consequences body (ADR immutable gate) and did not
guess at the new contract's exact shape — added a citation-currency note in References only,
flagging this as its own real finding rather than papering over it with an unverified rewrite.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` — 336 passed

Closes #4014

🤖 Generated with [Claude Code](https://claude.com/claude-code)
