### PR TITLE
docs(#4016): ADR-0041 — intervention ownership and channel pinning (supersedes ADR-0034 Components 1-3)

### DIFF
--- a/docs/deep-dives/decisions/0034-a2a-task-lifecycle.md
+++ b/docs/deep-dives/decisions/0034-a2a-task-lifecycle.md
@@ -1,25 +1,11 @@
 # ADR-0034: A2A task lifecycle (FP-0001)
 
-**Status**: Accepted + Implemented (2026-05-16) — **Components 1–3 superseded by
-[ADR-0041](0041-intervention-ownership-and-channel-pinning.md)** (2026-05-20 / #268 Phase 2, #292 α,
-#267 Gap 5). Components 4–5, Context and Considered alternatives stand. See #866 "task lifecycle is
+**Status**: Accepted + Implemented (2026-05-16) — Components 1–3 **superseded by
+[ADR-0041](0041-intervention-ownership-and-channel-pinning.md)**; Components 4–5, Context and
+Considered alternatives stand (audit: #4016). **Extended by
+[ADR-0040](0040-task-as-os-concept.md)** (not yet implemented). See #866 "task lifecycle is
 shipped" doc refresh + the Gap 3-5 PR chain.
 **Track**: A2A protocol — async task support + ask_user round-trip
-
-> 🔴 **Read Components 1–3 below as history, not as current mechanism.** The drift audit in #4016
-> verified all five component claims against `origin/main`: **three had been false since 2026-05-20**
-> — `RunEntry` no longer holds the pending `UserIntervention` or its question text (they live in
-> `Session._interventions`), `A2AInterventionBus` implements `on_dispatch(iv)` rather than
-> `request(iv)` and never awaits `iv.future`, and `register_intervention_override` no longer exists
-> (routing is pinned to `iv.origin_channel_id` = `a2a:<run_id>`). `RunEntry` is also persisted now,
-> falsifying "lifetime = process lifetime". **Components 4 (router endpoints) and 5 (Agent Card
-> capabilities) were re-verified and hold.** [ADR-0041](0041-intervention-ownership-and-channel-pinning.md)
-> records what replaced them and why.
-
-> **Extended by [ADR-0040](0040-task-as-os-concept.md)** (2026-08-10, not yet implemented):
-> 0040 makes `task` an OS-level concept, of which this ADR's A2A-protocol surface (`RunRegistry`,
-> `RunEntry`) becomes one projection. This ADR's own vocabulary — `RunStatus`, deliberately "NOT
-> the 7-state Task-tree `TaskState`" — is the model ADR-0040's D2/D3 generalize.
 
 ## Context
 

--- a/docs/deep-dives/decisions/0034-a2a-task-lifecycle.md
+++ b/docs/deep-dives/decisions/0034-a2a-task-lifecycle.md
@@ -1,13 +1,25 @@
 # ADR-0034: A2A task lifecycle (FP-0001)
 
-**Status**: Accepted + Implemented (2026-05-16) — task lifecycle shipped (see #866 "task lifecycle is shipped" doc refresh + the Gap 3-5 PR chain)
+**Status**: Accepted + Implemented (2026-05-16) — **Components 1–3 superseded by
+[ADR-0041](0041-intervention-ownership-and-channel-pinning.md)** (2026-05-20 / #268 Phase 2, #292 α,
+#267 Gap 5). Components 4–5, Context and Considered alternatives stand. See #866 "task lifecycle is
+shipped" doc refresh + the Gap 3-5 PR chain.
 **Track**: A2A protocol — async task support + ask_user round-trip
+
+> 🔴 **Read Components 1–3 below as history, not as current mechanism.** The drift audit in #4016
+> verified all five component claims against `origin/main`: **three had been false since 2026-05-20**
+> — `RunEntry` no longer holds the pending `UserIntervention` or its question text (they live in
+> `Session._interventions`), `A2AInterventionBus` implements `on_dispatch(iv)` rather than
+> `request(iv)` and never awaits `iv.future`, and `register_intervention_override` no longer exists
+> (routing is pinned to `iv.origin_channel_id` = `a2a:<run_id>`). `RunEntry` is also persisted now,
+> falsifying "lifetime = process lifetime". **Components 4 (router endpoints) and 5 (Agent Card
+> capabilities) were re-verified and hold.** [ADR-0041](0041-intervention-ownership-and-channel-pinning.md)
+> records what replaced them and why.
 
 > **Extended by [ADR-0040](0040-task-as-os-concept.md)** (2026-08-10, not yet implemented):
 > 0040 makes `task` an OS-level concept, of which this ADR's A2A-protocol surface (`RunRegistry`,
 > `RunEntry`) becomes one projection. This ADR's own vocabulary — `RunStatus`, deliberately "NOT
-> the 7-state Task-tree `TaskState`" — is the model ADR-0040's D2/D3 generalize. Everything below
-> describes the mechanism as it stands today (unchanged until 0040/proposal-0067's own PRs land).
+> the 7-state Task-tree `TaskState`" — is the model ADR-0040's D2/D3 generalize.
 
 ## Context
 

--- a/docs/deep-dives/decisions/0034-a2a-task-lifecycle.md
+++ b/docs/deep-dives/decisions/0034-a2a-task-lifecycle.md
@@ -1,10 +1,9 @@
 # ADR-0034: A2A task lifecycle (FP-0001)
 
 **Status**: Accepted + Implemented (2026-05-16) — Components 1–3 **superseded by
-[ADR-0041](0041-intervention-ownership-and-channel-pinning.md)**; Components 4–5, Context and
-Considered alternatives stand (audit: #4016). **Extended by
-[ADR-0040](0040-task-as-os-concept.md)** (not yet implemented). See #866 "task lifecycle is
-shipped" doc refresh + the Gap 3-5 PR chain.
+[ADR-0041](0041-intervention-ownership-and-channel-pinning.md)** (audit: #4016); Components 4–5,
+Context and Considered alternatives stand. See #866 "task lifecycle is shipped" doc refresh + the
+Gap 3-5 PR chain.
 **Track**: A2A protocol — async task support + ask_user round-trip
 
 ## Context

--- a/docs/deep-dives/decisions/0041-intervention-ownership-and-channel-pinning.md
+++ b/docs/deep-dives/decisions/0041-intervention-ownership-and-channel-pinning.md
@@ -1,0 +1,119 @@
+# ADR-0041: intervention ownership and channel pinning — supersedes ADR-0034 Components 1–3
+
+**Status**: Accepted — **implemented** (#268 Phase 1/2 2026-05-20, #292 α, #267 Gap 5).
+This ADR is written after the fact (2026-08-10) to close the gap between ADR-0034's Decision text
+and what shipped; see #4016.
+**Supersedes**: [ADR-0034](0034-a2a-task-lifecycle.md) **Components 1, 2 and 3 only**. ADR-0034's
+Components 4 (router endpoints) and 5 (Agent Card capabilities), its Context and its Considered
+alternatives all stand unchanged.
+
+## Context
+
+ADR-0034 shipped A2A async tasks with a **chain-scoped intervention override**:
+`ChatSession.register_intervention_override(chain_id, bus)` made `ask_user` inside a skill running
+under that `chain_id` route to an `A2AInterventionBus` instead of the default bus, and
+`RunEntry` held the pending `UserIntervention` plus its buffered question text.
+
+Two independent investigations then falsified that shape.
+
+**#292 — the override was a bypass, not a route.** An implementation trace showed
+`_dispatch_intervention`'s override branch **returned** `await override.request(iv)`, skipping
+`_intervention_handler.dispatch` entirely. Everything that hangs off the handler was therefore
+forfeited for A2A interventions **by construction**:
+
+```
+❌ not added to InterventionRegistry._active
+❌ no intervention_dispatched WAL event
+❌ not written to AgentSnapshot.outstanding_interventions
+❌ not eligible for the buffered_intervention_answers consume on restart
+❌ not visible to #268's cross-channel observe / discard / claim API
+✓  stored only in RunEntry.pending_intervention
+```
+
+On restart `RunRegistry` restored the intervention with a **fresh future**, while the coroutine
+that had been awaiting the original future was dead. A peer's answer resolved a future nobody was
+waiting on, and the ChatSession side had no record the intervention ever existed — so there was
+no second object to "re-bind" to. The problem was not duplication; it was that **A2A intervention
+state lived outside ChatSession's authoritative machinery**.
+
+**#268 — one user reaches one agent through several channels.** Three scenarios drove this:
+a task started over A2A is invisible in a TUI opened afterwards (the override bypasses the
+outbox, so the operator can see the skill running but not what it is asking); a peer client that
+crashes strands a `input-required` run with no way to answer it from anywhere else; and a TUI
+session plus a concurrent A2A request are, in practice, two parallel sessions inside one
+ChatSession that cannot see each other.
+
+## Decision
+
+### D1. ChatSession owns every intervention's lifecycle; the A2A bus decorates, never replaces
+
+`_dispatch_intervention`'s override branch changes from *replace the dispatch* to **decorate the
+dispatch with side effects** (#292 option α). The bus's entry point is therefore
+`on_dispatch(iv)`, not `request(iv)`, and it **does not await `iv.future`** — awaiting belongs to
+the handler that owns the lifecycle.
+
+Consequently every guarantee ChatSession ships for local interventions — registry membership, the
+`intervention_dispatched` WAL event, snapshot inclusion, restart-resume — applies to A2A
+interventions too, because there is no longer a second path.
+
+### D2. An intervention is pinned to its origin channel
+
+`A2AInterventionBus` exposes `channel_id` = `a2a:<run_id>` and stamps it onto
+`iv.origin_channel_id` at dispatch. Routing is by **channel**, not by chain.
+
+The channel's lifetime is the request: `mcp/server.py` registers the listener before
+`bus.request(...)` and unregisters it in `finally`.
+
+An intervention whose origin channel is closed or lost **stalls** — it remains at the agent layer
+rather than being delivered anywhere. Other channels may **observe** a stalled intervention and
+take it over by an **explicit redirect**; nothing is fanned out implicitly. (The rejected
+alternative — fan-out with first-wins — is retained in #268's body as an audit trail.)
+
+### D3. `RunEntry` is a minimal index; intervention state is not in it
+
+`pending_intervention` and `question` are removed from `RunEntry` (#292 α): intervention state
+lives in `Session._interventions`, and the bus mirrors only `status="input-required"` onto the
+entry, plus the webhook POST.
+
+`RunEntry` **is** persisted (#267 Gap 5 — every mutation atomically rewrites the file so a
+server-process restart can reload), which falsifies ADR-0034's "lifetime = process lifetime;
+crash recovery for async tasks is a follow-up FP". Retention is bounded by `prune_terminal`
+(terminal entries older than a 24-hour window; a `running` / `input-required` run is never pruned
+regardless of age).
+
+## Consequences
+
+**Desirable**
+
+- One intervention machinery instead of two; the restart-resume guarantees stop depending on
+  which transport started the run.
+- A stalled intervention is visible and claimable from another channel, which is what makes the
+  "same agent, several channels" experience honest rather than two invisible parallel sessions.
+- Fan-out is rejected explicitly, so no answer race exists to resolve.
+
+**Undesirable / accepted**
+
+- Channel identity (`a2a:<run_id>`) is a string convention, not a typed value. It coexists with
+  the routing-key convention (`<transport>:<native_id>`) that
+  [ADR-0040](0040-task-as-os-concept.md) D6 builds on; unifying them is not attempted here.
+- The bus keeps a narrow write to `RunEntry` (status mirroring), so "ChatSession owns the state"
+  is true of the intervention itself, not of every derived status field.
+
+**Documentation debt this ADR closes**
+
+ADR-0034's Components 1–3 described the pre-#292 shape for roughly three months after it stopped
+being true. The mechanism was replaced on 2026-05-20 (#268 Phase 2) and the now-dead
+`register_intervention_override` was deleted on 2026-07-03 as collateral of #2435's skill/phase
+decouple — **six weeks after** its replacement landed. No capability was ever lost; only the
+record was wrong. The verification that established this is recorded in #4016.
+
+## References
+
+- #292 — RunRegistry refactor: minimal index + ChatSession-derived state (option α)
+- #268 — iv channel routing: origin-pinned + stall + explicit redirect
+- #267 Gap 5 — RunRegistry persistence
+- #2435 — removal of the by-then-dead `register_intervention_override`
+- #4016 — the drift audit that produced this ADR
+- Implementation: `src/reyn/interfaces/web/a2a_intervention.py`,
+  `src/reyn/interfaces/web/run_registry.py`, `src/reyn/mcp/server.py`,
+  `src/reyn/runtime/session.py`

--- a/docs/deep-dives/decisions/README.md
+++ b/docs/deep-dives/decisions/README.md
@@ -66,8 +66,9 @@ historical value with status updated to "superseded by ADR-XXXX").
 |---|---|
 | [0017](0017-parent-run-id-nested-skill-path.md) | parent_run_id for nested skill path display |
 | [0018](0018-cross-agent-discard-notify.md) | Cross-agent discard chain notification |
-| [0034](0034-a2a-task-lifecycle.md) | A2A task lifecycle (FP-0001) (**Accepted + Implemented** 2026-05-16) |
+| [0034](0034-a2a-task-lifecycle.md) | A2A task lifecycle (FP-0001) (**Accepted + Implemented** 2026-05-16) — Components 1–3 (intervention override, RunEntry persistence) superseded by [0041](0041-intervention-ownership-and-channel-pinning.md); Components 4–5 (router endpoints, Agent Card capabilities) stand unchanged |
 | [0040](0040-task-as-os-concept.md) | `task` as an OS-level concept — vocabulary, collection, and who authors state (**Accepted** 2026-08-10, not yet implemented; extends 0034) — sequencing in [proposal 0067](../proposals/0067-task-model-and-arbiter.md) |
+| [0041](0041-intervention-ownership-and-channel-pinning.md) | Intervention ownership and channel pinning — supersedes 0034 Components 1–3 only (**Accepted + Implemented**, written after the fact 2026-08-10 to close a 3-month doc/code gap; see [#4016](https://github.com/tya5/reyn/issues/4016)) |
 
 ### Web UI scope
 


### PR DESCRIPTION
**[architect]** — **#4016 の検証結果を ADR に落とします。lead-coder の指摘（「コードからは読めない」は正しいが★探索の終点ではない）を受けて書けるようになったものです。**

## 🔴 私の「書けません」は誤りでした

`#4016` のコメントで「**#268 / #292 が何を意図したかはコードから読めない ∴ 私には書けない**」と
書きましたが、**issue 本文を開いていませんでした**。開くと意図がそのまま書かれています:

```
#292 「(α) ★ChatSession owns all iv lifecycle; A2A bus becomes a ★side-effect observer」
     「_dispatch_intervention's override branch changes from ★"replace the dispatch"
       to ★"decorate the dispatch with side effects"」
#268 「iv は★origin channel に pin される。origin channel が closed/lost なら★stall。
       別 channel は観測可能、★明示 redirect で取り込める」
```

⚠️ **「読めない」を宣言する前に、読める面を全部開いたか確認していませんでした。**

## 何が偽で、何が真だったか（#4016 の全数検査）

| ADR-0034 の主張 | |
|---|---|
| `RunEntry` が pending `UserIntervention` / question text を持つ | ❌ #292 α で `Session._interventions` へ |
| 「lifetime = process lifetime、crash recovery は follow-up FP」 | ❌ #267 Gap 5 で永続化済 |
| `A2AInterventionBus` が `request(iv)` を実装し `iv.future` を await | ❌ 実体は `on_dispatch(iv)`、await しない |
| `register_intervention_override(chain_id, bus)` | ❌ 存在しない（鍵は `origin_channel_id`） |
| Router 3 endpoint（tasks / cancel / events） | ✅ 3 本とも現存 |
| Agent Card `streaming` / `pushNotifications` | ✅ 両方 true |

🔴 **バラバラの腐り方ではありません** — **同じ 1 つの設計変更**（iv 状態の所有者が RunEntry →
Session、鍵が chain_id → origin_channel_id）の帰結で、Components 1〜3 が**同時に**古くなり、
4・5 は無関係なので生きています。

## 範囲

⚪ **部分 supersede です。** Components 4・5、Context、Considered alternatives は**そのまま**。
ADR-0034 の body は**非改変**（immutable）で、**Status 行のみ**更新しています ──
`decisions/README.md` が明示的に認めている形です:

> ADRs are immutable once accepted. New facts that contradict a decision get a new ADR that
> supersedes the old one (**the old one keeps its historical value with status updated to
> "superseded by ADR-XXXX"**).

⚠️ **#4015 で追加された「Everything below describes the mechanism as it stands today」の一文も
訂正しました** — Components 4・5 については真、1〜3 については偽でした。

## capability は一度も失われていません

```
2026-05-20  #268 Phase 2  ★置き換え機構が landing
2026-07-03  #2435         ★既に死んでいた register_intervention_override を削除
```

**誤っていたのは記述だけ**です。

## Test plan

- [x] 5 つの component 主張すべてを `origin/main` に対して直接 verify（#4016 のコメントに表として記録）
- [x] 置き換えと削除の順序を `git merge-base --is-ancestor` で確認（置き換えが 6 週間先）
- [x] ADR-0034 の body 非改変を確認（Status 行と注記ブロックのみ変更）
- [x] 番号の衝突なし（decisions 最大 0040 → 0041）
- [x] (skipped — docs-maintainer に依頼済／私の役割外) `decisions/README.md` の索引行追加

⚠️ **コードは 1 行も変えていません** — `docs/` のみ。

part of #4016

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**[lead-coder]** — レビュアの blocking item（CLAUDE.md rule 7）:

- [x] 🔴 **ADR-0034 に足した 10 行の 🔴 blockquote（監査の叙述）を削除する。** `decisions/README.md:14` は「ADRs are immutable once accepted … the old one keeps its historical value with **status** updated」と書いており、**許されるのは status の更新であって本文への叙述の追記ではありません。** 内容は既に ADR-0041 が持っています。**Status 行の「Components 1–3 superseded by ADR-0041 … Components 4–5 stand」は残して構いません**（これは status そのもの）。**ポインタは可、叙述は不可**が線です。

- [x] 🔴 **同 PR で、`#4013` が ADR-0034 に足した `> **Extended by ADR-0040**` banner も本文から落とし、必要なら Status 行に畳む。** 私が先に「あれはポインタ主体なので線の内側」と書いたのは**撤回**します（規則が名指しで許すのは status の更新のみで、`ポインタは可` は私がその場で作ったものです）。**すでにこの PR が 0034 を触っているので、同じ PR で。**

