### PR TITLE
docs: fix session_spawn rename drift in feature-map.md + ADR-0040 (#4017 fallout)

### DIFF
--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -719,8 +719,9 @@ Cross-surface `ask_user` and permission routing — the same prompt reaches the 
 
 > **Design only, not yet implemented:** [ADR-0040](deep-dives/decisions/0040-task-as-os-concept.md) +
 > [proposal 0067](deep-dives/proposals/0067-task-model-and-arbiter.md) (accepted 2026-08-10, tracking
-> #3978) unify `run_pipeline_async`, `delegate_to_agent`, `session_spawn`, and the A2A async run
-> under one `task` concept (one execution + a handle) with a single collection surface, retiring
+> #3978) unify `run_pipeline_async`, `delegate_to_agent`, `spawn_session` (renamed from
+> `session_spawn` by #4004/#4017), and the A2A async run under one `task` concept (one execution
+> and a handle) with a single collection surface, retiring
 > `delegate_to_agent` and the three `run_pipeline_*` async variants in favor of `run_prompt` /
 > `run_pipeline(collect=…)`. The table above describes the CURRENT, shipped mechanism —
 > `delegate_to_agent` is live and unchanged until this arc's own PRs land.


### PR DESCRIPTION
**[docs-maintainer]** — #4017's `session_spawn`→`spawn_session` rename orphaned a doc reference I added just hours earlier, plus one in ADR-0040.

## What happened

Earlier tonight (#3978's dispatch) I added a "design only, not yet implemented" callout to `feature-map.md`'s Multi-Agent section, naming `session_spawn` among the mechanisms ADR-0040/proposal-0067 will unify. #4017 landed right after — an owner-ratified rename (`agent_spawn`→`spawn_agent`, `session_spawn`→`spawn_session`, `topology_create`→`create_topology`) — and correctly updated the LLM org-design table just below my callout. My own note, sitting in the same file, was left naming the old spelling: a direct self-contradiction within one doc section.

## Fixes

- `feature-map.md`: callout now says `spawn_session`, with a parenthetical noting the rename and its PRs (#4004/#4017).
- `docs/deep-dives/decisions/0040-task-as-os-concept.md`: its Context table (accepted 2026-08-10, before #4017 landed) also names `session_spawn`. Added a footnote after the table rather than editing the cell — ADR immutable gate, same non-body-edit pattern used twice already tonight for ADR-0034.
- Checked `proposal 0067` for the same drift — it never names these spawn tools at all (only `run_prompt`/`run_pipeline`/`delegate_to_agent`), so no change needed there.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` — 336 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**[docs-maintainer]** — Update: withdrew the ADR-0040 footnote per lead-coder's retraction of the pointer-note carve-out (`decisions/README.md`'s preamble permits ONLY a status-line update in an already-accepted ADR — no footnotes, no blockquotes, nothing else in the body). Kept the `feature-map.md` fix (not an ADR, no immutability concern). `docs/deep-dives/decisions/0040-task-as-os-concept.md` is now untouched by this PR.

## Test plan (updated)

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` — 336 passed
