### PR TITLE
fix(#4001): tests/__init__.py closes the mcp bucket-name collision structurally

### DIFF
--- a/scripts/flat_tests_ratchet.py
+++ b/scripts/flat_tests_ratchet.py
@@ -55,8 +55,16 @@ _TESTS_DIR = _ROOT / "tests"
 def measured_flat_files(tests_dir: Path = _TESTS_DIR) -> "set[str]":
     """Every ``.py`` file that is a DIRECT child of ``tests_dir`` right now —
     ``tests_dir.glob("*.py")`` does not recurse, so a file already moved into
-    a subdirectory is correctly absent."""
-    return {p.name for p in tests_dir.glob("*.py")}
+    a subdirectory is correctly absent.
+
+    ``__init__.py`` is excluded: it is a package marker (#4001 — makes
+    ``tests/`` a real package so pytest's import-mode walk never stops at
+    ``tests/`` itself, closing the tests/<bucket>/ name-collision class),
+    not a test file. This ratchet's INVARIANT is about new flat TESTS, and a
+    package marker is not one — the same class of exclusion
+    ``check_migration_diff_shape.py`` already grants an empty
+    ``tests/<pkg>/__init__.py`` bucket-marker addition."""
+    return {p.name for p in tests_dir.glob("*.py") if p.name != "__init__.py"}
 
 
 def load_baseline(path: Path = _BASELINE_PATH) -> "set[str]":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,15 +82,24 @@ pytest_plugins = ["pytester"]
 
 # ── Repo-root on sys.path (stable ``tests`` package imports) ───────────────────
 #
-# ``tests/`` has no ``__init__.py`` (it is collected from the rootdir as an
-# implicit namespace package). That makes ``from tests._support... import X``
-# resolve only when the repo root happens to be on ``sys.path`` — true under
-# ``python -m pytest`` from the repo root, but NOT under bare ``pytest`` or when
-# invoked from another cwd / an IDE runner, where it fails with
-# ``ModuleNotFoundError: No module named 'tests'``. Inserting the repo root here
-# (this conftest loads for any collected test, including a single isolated file)
-# makes ``tests`` and ``tests._support`` importable in every invocation style,
-# so shared helpers do not depend on how pytest was started.
+# ``tests/__init__.py`` exists (#4001: without it, pytest's prepend import mode
+# stops walking up at the first ancestor lacking ``__init__.py`` — which used
+# to be ``tests/`` itself, so a bucket like the former ``tests/mcp/`` collected
+# as the TOP-LEVEL module ``mcp``, shadowing the real third-party ``mcp`` SDK
+# package on ``sys.path`` the instant any test imported it). With
+# ``tests/__init__.py`` present, that walk continues past ``tests/`` to the
+# repo root, and every collected test resolves as ``tests.<bucket>.test_x`` (or
+# ``tests.test_x`` for a flat file) — a name that can never collide with an
+# installed distribution's own top-level name.
+#
+# ``from tests._support... import X`` still only resolves when the repo root is
+# on ``sys.path`` — true under ``python -m pytest`` from the repo root, but NOT
+# under bare ``pytest`` or when invoked from another cwd / an IDE runner, where
+# it fails with ``ModuleNotFoundError: No module named 'tests'``. Inserting the
+# repo root here (this conftest loads for any collected test, including a
+# single isolated file) makes ``tests`` and ``tests._support`` importable in
+# every invocation style, so shared helpers do not depend on how pytest was
+# started.
 _REPO_ROOT = str(Path(__file__).resolve().parent.parent)
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)


### PR DESCRIPTION
**[tui-coder]** — Closes #4001's actual collision structurally, rather than widening `check_tests_dir_names.py`'s shadow-collision population (Plan A died on measurement: `mcp` is transitive, 2 extras deep via `fastmcp[client,server]` → `fastmcp-slim` → `mcp<2.0,>=1.24.0`, never named in `pyproject.toml`, so a pyproject-declaration-based population wouldn't have caught it — see #4001 comment thread for the full measurement).

Closes #4001

## What changed

`tests/__init__.py` (empty) makes `tests/` a real package. Pytest's default "prepend" import mode walks up from a collected test file until it hits the first ancestor WITHOUT an `__init__.py`, inserts that ancestor onto `sys.path`, and imports the test relative to it. Before this change, `tests/` itself was that stopping point (no `__init__.py`) — so `tests/mcp/test_x.py` collected as the TOP-LEVEL module `mcp.test_x`, meaning `import mcp` anywhere in that test's import chain resolved to `tests/mcp/__init__.py` instead of the real third-party MCP SDK, exactly the failure #4001 reported. With `tests/__init__.py` present, the walk continues past `tests/` to the repo root, and every test resolves as `tests.<bucket>.test_x` (or `tests.test_x` flat) — a name that can never collide with an installed distribution's own top-level name, for `mcp` or any future bucket.

`conftest.py`'s sys.path-insertion comment updated — it asserted `tests/` has no `__init__.py` as a current-state fact; that's now false, so the comment is rewritten to explain the new mechanism (module-docstring current-state-only discipline, same rule the M4 bucket-migration PRs already follow for moved code).

## Why not Plan A (pyproject-declared dependencies as the gate's population)

Measured and reported in #4001: `mcp` never appears as a string in `pyproject.toml` — it's `fastmcp-slim`'s own `client`/`server` extras' sub-dependency (`importlib.metadata.distribution("fastmcp-slim").requires` confirms `mcp<2.0,>=1.24.0; extra == 'client'`/`'server'`). A pyproject-only population would miss the exact collision that broke the bucket. Catching transitive collisions deterministically would need a committed lock file, which reyn doesn't have today (checked: no `*.lock`, no `requirements*.txt`) — a bigger structural addition than this fix. This PR sidesteps the population question entirely by removing the mechanism that makes any name collision possible in the first place.

## Verification

- `collect-only` across the full repo: **10522 tests, zero collection errors.**
- **Reproduced the original bug directly**: copied the 18 `mcp`-axis candidate files into a scratch `tests/mcp/` (uncommitted, discarded after verification — not part of this diff), confirmed collection now succeeds and `test_mcp_oauth_2597_s4.py` (the file that actually walks `fastmcp`'s OAuth import chain into `mcp.client.auth`) passes **15/15**. Directly confirmed `import mcp` resolves to the real site-packages SDK (`/…/site-packages/mcp/__init__.py`), not `tests/mcp/`, once the test module's own qualname is `tests.mcp.test_mcp_oauth_2597_s4`.
- `check_file_depth_reference.py` — clean (re-verified against #4022's landed fix, rebased onto it before push).
- `check_tests_dir_names.py` — clean, 0 shadowed.
- `flat_tests_ratchet.py` — **initial CI run correctly caught a false positive**: `measured_flat_files()` globbed `*.py` without excluding `__init__.py` (a package marker, not a test), so adding `tests/__init__.py` looked like ratchet growth. Fixed by excluding `__init__.py` from the measured set (same exclusion class `check_migration_diff_shape.py` already grants an empty `tests/<pkg>/__init__.py` bucket-marker addition); baseline regenerated for confirmation, unchanged at 411 names. Squashed into this PR's single commit.
- `ruff check tests/__init__.py tests/conftest.py` — clean.
- `mypy_ratchet.py` — OK, no new debt.
- `verify_module_docstrings.py` — clean.
- **Not** run as a full local `pytest` (per `testing.md`'s "Before you push" policy and lead-coder's correction mid-review — CI does the full run in a clean checkout; the collect-only sweep + the direct bug-reproduction above are the pre-push evidence, not an exhaustive local suite run).

## Follow-up (not this PR)

Once this lands, `check_tests_dir_names.py`'s shadow-collision axis becomes structurally unreachable for any `tests/<bucket>/` — the check still runs and still passes, just against a population that can no longer produce a real collision. Simplifying/removing that now-partially-redundant check is a separate decision, not folded into this fix (scope: close #4001's actual collision, nothing else).

## Test plan

- [x] `collect-only` — 10522 tests, zero errors
- [x] Direct reproduction of the original `mcp` collision — now resolves, 15/15 on the specific OAuth-import-chain test
- [x] `check_file_depth_reference.py` — clean, rebased onto #4022
- [x] `check_tests_dir_names.py` — clean
- [x] `ruff check` — clean
- [x] `mypy_ratchet.py` — no new debt
- [x] `verify_module_docstrings.py` — clean
- Not self-merging per PR-workflow rule 8; lead-coder is running the merge train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

