### PR TITLE
fix(#3879): remove a hardcoded-path assert the pending core-bucket move breaks

### DIFF
--- a/tests/builtin/test_0060_phase1_f3a_builtin_tier.py
+++ b/tests/builtin/test_0060_phase1_f3a_builtin_tier.py
@@ -266,4 +266,13 @@ def test_no_stdlib_glob_in_source_or_config() -> None:
     root_py = (_REPO_ROOT / "src" / "reyn" / "config" / "root.py").read_text(encoding="utf-8")
     assert 'scan_dirs: ["skills"]' not in root_py
     assert not (_REPO_ROOT / "tests" / "test_workspace_glob_stdlib_perm.py").exists()
-    assert (_REPO_ROOT / "tests" / "test_workspace_glob_outside_root_perm.py").exists()
+    # A hardcoded-path existence check for the RENAMED replacement
+    # (test_workspace_glob_outside_root_perm.py) used to live here too —
+    # removed (#4025 M4 review): the file is mid-relocation under the M4
+    # bucket migration, and a fixed `tests/<name>` path is exactly the
+    # fragile pattern that arc spends the night closing elsewhere. The
+    # two asserts above already establish Addendum A2's completion (the
+    # misleading old name is gone, the source no longer scans it); the
+    # rename itself (not merely a deletion) is preserved permanently in
+    # git history, not by a path pinned to one moment of the repo's
+    # ongoing reorganisation.

--- a/tests/builtin/test_fp0063_p3_rag_pipelines.py
+++ b/tests/builtin/test_fp0063_p3_rag_pipelines.py
@@ -886,8 +886,8 @@ def test_ingest_file_discovery_aborts_clean_on_unreadable_input_path(
     project_root = _write_project(tmp_path, out_of_process_reyn)
     # A folder OUTSIDE project_root with no permission grant -- Workspace's
     # own default-deny boundary for absolute paths outside base_dir/state_dir
-    # (see tests/test_workspace_glob_outside_root_perm.py) with `reyn pipe
-    # run`'s non-interactive resolver (`_build_run_tool_context`: "fail-
+    # (see tests/core/test_workspace_glob_outside_root_perm.py) with `reyn
+    # pipe run`'s non-interactive resolver (`_build_run_tool_context`: "fail-
     # closed by default"), so the PermissionError is real, not simulated.
     outside_docs = tmp_path.parent / f"{tmp_path.name}_outside_docs"
     outside_docs.mkdir()


### PR DESCRIPTION
**[e2e-coder]** — split out from `#4025` (M4's core-bucket migration, blocked by this) per lead-coder's review and `check_migration_diff_shape.py`'s own designed behavior: it explicitly rejects "an unrelated content edit riding along in the same PR" as a pure migration (`test_a_content_edit_mixed_with_a_real_move_is_rejected`) — this fix is exactly that shape (an unrelated file, not among `#4025`'s moving 274, needing a small content change). Landing this first lets `#4025` rebase back to a genuinely pure rename.

## The reference lives on the SIDE THAT DOESN'T MOVE

`#4025`'s own audited population was "the moving files' own outward references" (the `#4002`/`#4019` direction: a moving file naming something OUTSIDE itself). This break is the OPPOSITE direction: `tests/builtin/test_0060_phase1_f3a_builtin_tier.py` (already relocated by `#4003`, staying put) hardcodes the path to `tests/test_workspace_glob_outside_root_perm.py` — one of the files `#4025` moves — the `#4006` direction, which reading every moving file's own content can never surface, no matter how many times.

Comprehensively swept using the corrected direction (lead-coder's method): every `.py` file under `tests/` scanned for a string-literal `Constant` containing one of `#4025`'s 273 moved filenames, filtered to non-docstring occurrences reached through a real file-access call (`Path`/`.exists`/`.is_file`/`open`/`read_text`/`spec_from_file_location`/`import_module` — not prose mentioning a filename in a comment or docstring, which `#4006`'s own `test_pipeline_a2_spawn_ephemeral_session.py` false-positive already showed can masquerade as a real reference). **Exactly 1 hit** — the one CI already caught on `#4025`. No hidden second instance.

## Fix — asked "should this exist" before "how do I make it pass"

The specific assert (`assert (_REPO_ROOT / "tests" / "test_workspace_glob_outside_root_perm.py").exists()`) pinned a THIRD file's location as a side effect of an Addendum-A2-completeness check — a hardcoded `tests/<name>` path, exactly the fragile pattern M4 spends the night closing everywhere else. Removed rather than repaired (path-updated to `tests/core/...`): the two remaining asserts in the same test already establish Addendum A2's completion (the misleading old name is gone; the source no longer scans it) — the RENAME itself (not merely a deletion) is preserved permanently in git history, not by a path pinned to one moment of an actively-reorganizing tree.

Also fixed a non-blocking prose mention of the same stale path in `tests/builtin/test_fp0063_p3_rag_pipelines.py:889` (a comment, not an executable reference — confirmed by the same directional sweep — but accuracy-fixed here since it's the same eventual move causing the drift).

part of #3879

## Test plan

- [x] `ruff check tests/builtin/` — clean
- [x] `pytest tests/builtin/test_0060_phase1_f3a_builtin_tier.py` — 11 passed
- [x] Comprehensive reverse-direction sweep (documented above) — exactly 1 real hit found, now fixed
- [x] `check_migration_diff_shape.py --base origin/main` — gate inactive (content-only, no rename in this diff — confirms this is properly split from `#4025`)
- Not self-merging; sequenced ahead of `#4025` (M4's core bucket, currently blocked on this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)