### PR TITLE
fix: check_doc_anchors.py's vacuity floors survive python -O (#4027 follow-up)

### DIFF
--- a/scripts/check_doc_anchors.py
+++ b/scripts/check_doc_anchors.py
@@ -124,6 +124,17 @@ def _is_excluded(doc_relpath: Path, patterns: list[str]) -> bool:
     return any(posix == p or posix.startswith(p + "/") for p in patterns)
 
 
+def _require_vacuity_floor(count: int, floor: int, message: str) -> None:
+    """Fail loud (not an `assert`) when a link-extraction count falls below
+    its measured floor — `assert` is stripped entirely under `python -O`
+    (lead-coder, 2026-08-10, follow-up to #4021: fixing only one of this
+    script's two floors to survive `-O` would make "a floor exists" true
+    only in appearance, since CI doesn't pass `-O` today but nothing pins
+    that). `SystemExit` has no such escape hatch."""
+    if count < floor:
+        raise SystemExit(message)
+
+
 def _md_to_html_path(md_relpath: str) -> Path:
     """Mirror mkdocs' directory-url convention: foo/bar.md -> foo/bar/index.html,
     foo/bar.ja.md -> ja/foo/bar/index.html, index.md -> index.html."""
@@ -216,12 +227,13 @@ def check_deep_dives_link_existence() -> int:
     # capture branches) must fail loud, not report "0 broken" as if that
     # meant "0 links reviewed and all fine." 283 measured at gate-landing
     # (2026-08-10, #4021); floor set below that to tolerate organic growth.
-    assert total_links >= 200, (
+    _require_vacuity_floor(
+        total_links, 200,
         f"Extracted only {total_links} relative .md links from "
         f"docs/deep-dives/{{{','.join(DEEP_DIVES_LINK_EXISTENCE_SUBDIRS)}}}/ "
         "— 283 measured when this gate landed (#4021). A `> 0` guard only "
         "catches total regex breakage; a partial regression would still "
-        "pass while quietly checking a fraction of the target subdirs."
+        "pass while quietly checking a fraction of the target subdirs.",
     )
 
     print(
@@ -306,14 +318,15 @@ def main() -> int:
             if anchor not in ids:
                 anchor_not_found.append((str(rel), link))
 
-    assert total_links >= 400, (
+    _require_vacuity_floor(
+        total_links, 400,
         f"Extracted only {total_links} anchor-bearing links from docs/ — "
         "the repo-wide count was 461 when this gate landed (#3667). `> 0` "
         "only catches total regex breakage; a partial regression (e.g. one "
         "of the two LINK_RE alternatives silently stops matching) would "
         "still pass a `> 0` guard while quietly checking a fraction of "
         "docs/. This floor is deliberately below 461 to tolerate organic "
-        "doc growth/removal, not a hardcoded count pin."
+        "doc growth/removal, not a hardcoded count pin.",
     )
 
     print(f"checked {total_links} anchor-bearing links")


### PR DESCRIPTION
**[docs-maintainer]** — Small follow-up to #4027, per lead-coder's request (kept out of that PR).

**Depends on #4027** (this branch is built on top of it, not on `main` — `main` doesn't have `check_deep_dives_link_existence`'s `>= 200` floor yet). This PR's diff will look larger than intended until #4027 merges first; once it does, this one collapses to just the one commit shown below.

## What

Both of `scripts/check_doc_anchors.py`'s vacuity floors (the new `check_deep_dives_link_existence`'s `>= 200`, #4027; the existing `#3667`'s `>= 400`) were plain `assert` statements — stripped entirely under `python -O`. CI doesn't pass `-O` today, so both were live in practice, but fixing only one would make "a floor exists" true only in appearance across the file — lead-coder's exact framing for why this needs to touch both together.

Added a tiny shared helper, `_require_vacuity_floor(count, floor, message)`, raising `SystemExit` instead of asserting. Converted both call sites in the same commit.

## Verification

Falsify-verified directly against `python -O`, not inferred from the CPython docs:
```
python -O -c "assert False, '...'"                          # silently no-ops
python -O -c "... _require_vacuity_floor(0, 200, '...')"    # raises SystemExit
```

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0
- [x] `python scripts/check_doc_anchors.py` — exit 0
- [x] `ruff check scripts/check_doc_anchors.py` — clean
- [x] `python scripts/verify_module_docstrings.py scripts/check_doc_anchors.py` — OK
- [x] Falsify-verified under real `python -O` (see above)
- No `tests/` files touched — no TESTS-READ gate applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
