### PR TITLE
docs(#4031): verification-hazards §21 — the search's shape decides the population

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -891,7 +891,7 @@ been caught by fixing the other**.
   `tests/`. For `tests/fixtures/llm/fp0063_arc_witness`, `.parent` is
   `tests/fixtures/llm`, so branch (b) was False; branch (a) ("outside
   `tests/`") was also False, because it is inside. The issue's own summary:
-  「**穴の 形は «`.parent` 単発» でも «多段 join» でも ありません** ——
+  「**穴の 形は «`.parent` 単発」でも «多段 join» でも ありません** ——
   **«tests-root peer の «中» に 何階層か 入った» という 深さです。**
   `tests/fixtures` 直下なら 捕まり、`tests/fixtures/llm/...` だと 抜ける」.
   The item was not misclassified — **it received no verdict at all**, because

--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -876,6 +876,94 @@ correct throughout, and the verdicts attached to its members were not.
   what the first one's classification step missed, rather than trusting a
   repeated pass by the same method.
 
+## 21. The search's shape decides the population — and a predicate can leave a gap no item falls into
+
+§20 is about a population that was closed and verdicts that were not. This
+section is the step before: the population itself was never whole, because
+the *form* of the search — not its scope, not its spelling — excluded a class
+of item silently. Three independent mechanisms hit this on one night
+(2026-08-09/10), each in a different form, and **no two of them would have
+been caught by fixing the other**.
+
+- **A two-branch predicate with a gap between the branches (#4019).** The
+  `b` gate's `_references_a_fixed_tests_location()` asked
+  `if target.parent == tests_dir` — the target must be a *direct child* of
+  `tests/`. For `tests/fixtures/llm/fp0063_arc_witness`, `.parent` is
+  `tests/fixtures/llm`, so branch (b) was False; branch (a) ("outside
+  `tests/`") was also False, because it is inside. The issue's own summary:
+  「**穴の 形は «`.parent` 単発» でも «多段 join» でも ありません** ——
+  **«tests-root peer の «中» に 何階層か 入った» という 深さです。**
+  `tests/fixtures` 直下なら 捕まり、`tests/fixtures/llm/...` だと 抜ける」.
+  The item was not misclassified — **it received no verdict at all**, because
+  the two branches did not partition the space.
+
+- **A population taken from the moving side (#4025).** The `core` bucket
+  audit enumerated 「移動する 274 件」. The reference that broke lived in
+  `tests/builtin/` — a directory that was **not moving** (it had already
+  migrated in #4003): a `_REPO_ROOT / "tests" / "test_workspace_glob_outside_root_perm.py"`
+  existence assert pointing at a file this PR moved away. The reviewer's
+  correction: 「**«移動する ファイルの 中の 参照» を いくら 数えても この 1 件は
+  出ません。正しい 母集団は «移動する 集合を 参照している 全ファイル» —— 向きが 逆**」.
+  Scope was not the problem; **reading every moving file, without limit, never
+  produces this item.**
+
+- **A literal that must begin where the pattern expects (#4006).** The census
+  grep required the quote to be immediately followed by `tests/`, so a string
+  such as `"REDded tests/test_X.py::…"` — the path appearing mid-literal —
+  never matched. Re-measured: 「従来 知られていた 母集団 17 件 / 取り直した
+  母集団 287 件」. This one is §3/§4's token-spelling shape and §17's
+  census-scope shape wearing a third face, and is included here only because
+  it fired the same night through a third mechanism.
+
+**Why these are three axes and not one.** Widening the file-set (§17) fixes
+the third and neither of the first two. Fixing the predicate's branches fixes
+the first and neither of the others. Reversing the direction fixes the second
+alone. They share a single sentence — *the form of the search decided which
+items could ever appear* — and share no remedy.
+
+⚠️ **The author of this section committed the second one while writing the
+surrounding work.** The #4021 link-gate specification, written the same night,
+defined its population as "links **from** `deep-dives/{decisions,proposals,
+contributing,spec}`" — outgoing only. Links pointing **into** those directories
+(50 of them, from the built docs) were left unguarded, and the omission was
+found by a peer's pin rather than by re-reading the spec. Having just written
+"time-tense decides which directories are in scope," the direction axis was
+dropped in the same paragraph: **finding one axis feels like having found the
+axis.**
+
+### What actually closed them
+
+Not a checklist. All three were caught by a mechanism performing the real
+operation and observing the result:
+
+- #4019 — a **pre-move audit that actually moved files**, not a predicate about
+  what a move would do
+- #4025 — **CI's own pytest run** after the move landed
+- #4006 — a **re-measurement triggered by #4025's red**, not by re-reading the
+  original grep
+
+This is §20's last bullet at population scope: the sweep does not find its own
+blind spot. It is also why `a′` (#4009) is the shape to copy — it **re-resolves
+the expression against the file's real post-move location** instead of
+classifying whether a move would break it. A predicate reasons about a
+population it has already narrowed; performing the operation cannot narrow what
+it has not yet touched.
+
+**Apply**:
+
+- For any move or rename, take **two** populations and say so: ① what the
+  moving set references, ② **what references the moving set**. ②'s search runs
+  in the opposite direction — build the list of names being moved and match it
+  against string literals across the whole repo; a `__file__`-resolution scan
+  cannot produce it.
+- When a gate's predicate has branches, ask what falls into **neither**. Two
+  conditions that both return False are indistinguishable from a clean item;
+  a predicate that partitions ("inside its own home, at any depth" vs "not")
+  has no such gap, while one built from two positive tests does.
+- State the population's **form** alongside its size, the way §17 asks for
+  scope: "287, matched by `<pattern>`, over `<file-set>`, in the `<direction>`
+  direction." A bare count carries none of the three.
+
 ## See also
 
 - [Testing policy](testing.md) — Tier model, Mock vs Fake, decision flow.


### PR DESCRIPTION
**[architect]** — **lead-coder からの割当。`verification-hazards.md` に 1 節。docs のみ、`scripts/` `tests/` は触っていません。**

## 🔴 依頼どおりに書くと §17 / §20 の再説になるので、範囲を変えました

lead の 3 軸を既存節に当てると:

```
① 述語の形       → 🔴 §20 が★既に #3995→#4002（私自身の誤り）を実例として収録
③ リテラルの綴り → §3/§4（token spelling が狭い）── §17 冒頭が明示的に区別している
🔴 ② 参照の向き   → ★どこにも無い
```

⚪ **②が新しい理由**: §17 は「**どこを**探したか」（scope / file-set）。②は「**参照はどちら側に
書かれているか**」で、**範囲を無限に広げても出ません** — 動く側を 1 万回読んでも、参照が
動かない側に在れば出ない。**scope の一般化ではなく別軸**です。

⚪ **①も、よく見ると §20 とは段が違いました**: §20 は「population 正・per-item verdict 誤」。
#4019 は `target.parent == tests_dir` と `tests/` の外、という **2 分岐のどちらにも掛からない**
形で、**誤った判定ではなく★判定が付かなかった**。∴ §21 に「分岐の隙間」として収録しています。

∴ **§21 の主題は「探索の形が母集団を決める」**とし、②を本体、①を第 2 の形、③は
§3/§4・§17 への送りとして 1 段落に留めました。

## §20 との段の違い（依頼された明示）

```
§20  母集団は★閉じていた。per-item の★判定が誤り
§21  🔴 母集団が★そもそも whole でなかった ── 探索の★形が、現れうる item を先に絞っていた
```

冒頭にこの 1 文を置いています。

## 「防ぎ方」は今夜実際に効いたものだけ

⚠️ ご指示どおり、**チェックリストに足す系は書いていません**（3 回とも効かなかった側）。書いたのは:

```
#4019 → ★実際にファイルを動かす pre-move audit（tui-coder）
#4025 → ★CI 自身の pytest
#4006 → ★#4025 の赤をきっかけにした再測定
⚪ 総括: a′（#4009）が写すべき形 ── ★移動後の実在を再解決する。分類しない
```

## ⚠️ 私自身が同夜に②を踏んでいるので、節の中に名指しで書きました

```
#4021 の仕様（同じ夜に私が書いた）は母集団を「deep-dives ★から出るリンク」と定義
→ ★入る 50 本が無防備のまま。peer の pin が見つけた
🔴 「時制で対象を絞る」と書いた★直後の段落で、向きの軸を落としている
   ＝「軸を 1 つ見つけると、それで母集団が決まった気になる」
```

## Test plan

- [x] 3 件の事実を**原文引用で収集**（subagent に委譲、根拠を出させてそれを引用 — owner 指示 2026-08-10）
- [x] 既存 §3/§4 / §17 / §20 と読み比べ、重複箇所を送りに変更
- [x] §20 との段の違いを冒頭に明示（依頼項目）
- [x] 「防ぎ方」は実際に効いた 3 機構のみ（依頼項目）
- [x] 節番号の衝突なし（§20 の次、`## See also` の前）

part of #4031

🤖 Generated with [Claude Code](https://claude.com/claude-code)