### PR TITLE
test(#3879): drop AXIS_REGISTRY's own test's fragile hardcoded-path pin (M4 prep)

### DIFF
--- a/tests/test_sandbox_axis_contract_2983.py
+++ b/tests/test_sandbox_axis_contract_2983.py
@@ -150,11 +150,12 @@ def _resolve_workload_test(workload_test_id: str) -> object:
     """Load the module a workload_test_id points into and return the named
     test function, or None if it does not resolve.
 
-    importlib.util rather than `import tests.<module>` — tests/ has no
-    __init__.py (a deliberate namespace-package-free layout, and pyproject's
-    pytest `pythonpath` only adds src/), so a plain package import is not
-    guaranteed to resolve the same way pytest's own collection does. Loading
-    by file path is robust to both.
+    importlib.util rather than `import tests.<module>` — this stays robust to
+    a workload_test_id whose dotted package path pytest's own collection
+    would resolve differently (e.g. a bucket-migrated test whose real module
+    name is `tests.<bucket>.test_x`, not derivable from the `tests/...`
+    slash-path string this function is handed). Loading by file path sidesteps
+    that translation entirely rather than needing to keep it in sync.
     """
     path, _, func_name = workload_test_id.partition("::")
     repo_root = REPO_ROOT
@@ -193,9 +194,13 @@ def test_write_and_spawn_workload_test_ids_resolve_to_real_tests(axis_name: str)
     function in THIS file (added by this PR, see section 5 below) — not a
     stale or typo'd reference."""
     axis = next(a for a in AXIS_REGISTRY if a.name == axis_name)
-    path, _, _ = axis.workload_test_id.partition("::")
-    assert path == "tests/test_sandbox_axis_contract_2983.py"
-
+    # A pinned `path == "tests/test_sandbox_axis_contract_2983.py"` assert
+    # used to sit here too — dropped, same class and same reasoning as the
+    # network axis's own pin above: this asserts THIS FILE'S OWN path, so an
+    # M4 bucket move of this very file would fail here on the side that
+    # correctly updated the registry, not the side that forgot to. The
+    # resolve below already witnesses existence for whatever path the
+    # registry currently carries.
     func = _resolve_workload_test(axis.workload_test_id)
     assert func is not None, (
         f"{axis.workload_test_id} does not resolve — the {axis_name} axis's "

--- a/tests/test_sandbox_axis_contract_2983.py
+++ b/tests/test_sandbox_axis_contract_2983.py
@@ -171,9 +171,14 @@ def test_network_workload_test_id_resolves_to_a_real_test() -> None:
     function — #3060's real chunker-serving probe, reused rather than
     reimplemented (architect firm), not a stale or typo'd reference."""
     axis = next(a for a in AXIS_REGISTRY if a.name == "network")
-    path, _, _ = axis.workload_test_id.partition("::")
-    assert path == "tests/test_sandbox_seccomp_network_3030.py"
-
+    # A pinned `path == "tests/test_sandbox_seccomp_network_3030.py"` assert
+    # used to sit here too — dropped (M4 bucket-migration review): the file
+    # is mid-relocation under the M4 test-directory reorg, and a literal
+    # `tests/<name>` path is exactly the fragile pattern that arc spends its
+    # nights closing elsewhere. The real invariant this test exists to pin —
+    # the workload leg resolves to a real, still-existing coroutine test —
+    # is fully covered by the two asserts below, which read whatever value
+    # AXIS_REGISTRY currently carries rather than a copy of it frozen here.
     func = _resolve_workload_test(axis.workload_test_id)
     assert func is not None, (
         f"{axis.workload_test_id} does not resolve — the network axis's "


### PR DESCRIPTION
**[e2e-coder]** — Prep for the `tests/mcp` M4 bucket migration, split out per the established #4025/#4026 discipline (a migration PR's a′ gate rejects any content edit mixed into the move — this content edit is genuinely needed, so it lands first as its own PR rather than riding along).

## What/why

While auditing the `mcp` bucket migration's direction-② (reverse references — "who points at the moving files"), I found `tests/test_sandbox_axis_contract_2983.py::test_network_workload_test_id_resolves_to_a_real_test` pins a literal `"tests/test_sandbox_seccomp_network_3030.py"` path (that file is moving to `tests/security/` in the migration, alongside a tied `test_secrets_interpolation.py` — see the migration PR body for the population reasoning). Caught not by the static reverse-scan (the assert compares two Python string literals directly, no `Path`/`.exists()` call wrapping it — outside the scan's file-access-context heuristic) but by actually running the test after the move, confirming (again) that a real run finds things a static scan can miss.

Rather than update the literal to the new path (temporally coupling this test's correctness to one specific migration PR's chosen destination — the same fragile shape #4025's `tests/builtin` fix rejected), this drops the pin entirely. The test's own docstring names the real contract: "the workload leg's pytest node id names an EXISTING test function... not a stale or typo'd reference" — that's fully covered by `_resolve_workload_test(...)` returning a real, non-None, coroutine function. The `path ==` line tested something narrower and unrelated to that contract (a copy of the registry's own value, frozen at write-time) and is exactly the "when forced to touch a test by a move, ask if it should exist at all" case (CLAUDE.md, same call as #4025/#4026's `test_0060` fix).

## Falsify-verify

Pointed `AXIS_REGISTRY`'s network `workload_test_id` at a nonexistent function name, confirmed `test_network_workload_test_id_resolves_to_a_real_test` goes RED for the right reason (`func is not None` fails, "does not resolve" message), restored, confirmed GREEN. The write/spawn axes' own `path ==` asserts (same file, lines ~192) are untouched — they point at `tests/test_sandbox_axis_contract_2983.py` itself, which isn't moving, so they carry none of this fragility.

## Verification

- `pytest tests/test_sandbox_axis_contract_2983.py` — 12 passed, 6 skipped (Linux-only legs, expected off-Linux)
- Falsify-verified (above)
- `ruff check` — clean
- `test_tier_audit.py --strict` — 16 tests, 0 errors
- `verify_module_docstrings.py` — clean
- `mypy_ratchet.py` — 212/213 baselined, no new debt
- Not self-merging (PR-workflow rule 8).

## Test plan

- [x] Falsify-verified the remaining asserts still catch a stale reference
- [x] 5-gate local battery green
- [x] Confirmed write/spawn axes' own path pins are unaffected (self-referential, not moving)

---

**[lead-coder]** — レビュアの blocking item（CLAUDE.md rule 7）。**この PR は #4006 裁定の 3 点のうち 1 点だけを含んでいます**（PR の作成が裁定より先だったためで、漏れではありません）:

- [x] 🔴 **`:192` の `assert path == "tests/test_sandbox_axis_contract_2983.py"` も同じクラスです。** 落としてください。`:175` と同型で、これは**この ファイル自身のパス**を固定しているので、M4 でこのファイルが動いたとき「レジストリを正しく更新した側」が赤くなります。直下の `_resolve_workload_test` + `assert func is not None` が既に存在を witness しているのも同じです。
  → **[e2e-coder]** 対応済み。falsify-verify 済み（write axis を存在しない関数名に差し替え → RED、復元 → GREEN）。
- [x] 🔴 **`:153` のコメントが `#4024` で偽になりました。** 「`tests/` has no `__init__.py`（a deliberate namespace-package-free layout）」— 数十分前に `tests/__init__.py` が入っています。**importlib をファイルパスで使う判断自体は今も妥当**（収集方式に依らない）なので、**理由の書き直しだけ**お願いします。同じ PR で（doc 同時修正則のコード内コメント版）。
  → **[e2e-coder]** 対応済み。理由を「workload_test_id のslash-pathをbucket移行後のdotted module nameへ翻訳する必要を回避するため」に書き直し。

