### PR TITLE
docs: fix tests/test_sandbox_axis_contract_2983.py's own path mention (#3879, #4036 follow-up)

### DIFF
--- a/tests/test_sandbox_axis_contract_2983.py
+++ b/tests/test_sandbox_axis_contract_2983.py
@@ -25,7 +25,7 @@ Three things this file exists to pin, matching the module docstring of
 The real 3-leg witnessing (deny + boundary + workload, against a real
 Landlock backend and against ``NoopBackend`` as the falsifying medium) is
 Linux-only and lives in the ``@requires_landlock``-gated group below, mirroring
-``tests/test_sandbox_seccomp_network_3030.py``'s own gating — a green run on a
+``tests/security/test_sandbox_seccomp_network_3030.py``'s own gating — a green run on a
 non-Linux dev box witnesses nothing there, same as every sibling file.
 """
 from __future__ import annotations


### PR DESCRIPTION
**[e2e-coder]** — Small follow-up, deliberately held out of #4036 rather than forgotten (noted in that PR's body and confirmed correct by lead-coder: "doc同時修正則は「この PR が falsify したもの」に掛かるのであって、「この PR が真にするもの」は後 — 向きが逆").

## What

`tests/test_sandbox_axis_contract_2983.py`'s module docstring said its Linux-only witnessing group "mirrors `tests/test_sandbox_seccomp_network_3030.py`'s own gating" — a current-truth claim about a sibling file's location. Landing this before #4036 (the mcp-bucket migration that moved that sibling to `tests/security/`) would have made the docstring describe a path that didn't exist yet; landing it now, after #4036 merged, makes it true.

The file's OTHER mention of the old path (line ~175, a comment describing what a since-removed assert literally compared against pre-#4033) is untouched — that one is a historical statement about the past, not a current-state claim, and changing it would make it factually wrong about what the removed code said.

## Verification

- `pytest tests/test_sandbox_axis_contract_2983.py` — 12 passed, 6 skipped (unaffected, prose-only change)
- `ruff check` — clean
- `test_tier_audit.py --strict` — 16 tests, 0 errors
- `verify_module_docstrings.py` — clean
- `mypy_ratchet.py` — 212/213 baselined, no new debt
- Not self-merging (PR-workflow rule 8).

## Test plan

- [x] Confirmed the untouched historical comment (line ~175) is correctly left alone
- [x] 5-gate local battery green