### PR TITLE
test(#4040): measure subprocess + env axes under container mode via real execution

### DIFF
--- a/tests/environment/test_mount_e2e_1332.py
+++ b/tests/environment/test_mount_e2e_1332.py
@@ -213,3 +213,71 @@ async def test_security_readonly_rootfs_with_tmpfs_and_mount(mount_container) ->
         ["sh", "-c", f"echo x > {WORKSPACE_DEST_DEFAULT}/probe_rw"], policy
     )
     assert ws.returncode == 0
+
+
+@pytest.mark.asyncio
+async def test_security_deny_subprocess_has_no_effect_in_container(mount_container) -> None:
+    """Tier 2c: #4040 — ``policy.deny_subprocess=True`` does NOT stop a nested
+    subprocess spawn inside the container.
+
+    ``DockerEnvironmentBackend.run()``'s own docstring says it "honors only
+    policy.timeout_seconds and policy.max_output_bytes" — no other
+    ``SandboxPolicy`` field is consulted per call. This measures that claim
+    directly rather than trusting the docstring: a process launched via
+    ``run()`` spawns a CHILD process of its own (``echo`` via a nested
+    ``subprocess.run``) under a policy that would refuse this on every other
+    backend (Landlock/Seatbelt/Noop's own deny_subprocess enforcement). If
+    this backend actually enforced the field, the nested spawn would fail;
+    it does not, because nothing here reads it — the container's own
+    launch-time isolation (cap-drop ALL + non-root + Docker's unmodified
+    default seccomp) is the only boundary in effect, and none of those stop
+    an unprivileged process from forking/exec'ing another unprivileged one.
+    """
+    backend, _, _ = mount_container
+    policy = SandboxPolicy(timeout_seconds=30, deny_subprocess=True)
+
+    res = await backend.run(
+        [
+            "python3",
+            "-c",
+            "import subprocess; "
+            "r = subprocess.run(['echo', 'nested-ok'], capture_output=True, text=True); "
+            "print(r.stdout.strip())",
+        ],
+        policy,
+    )
+    assert res.returncode == 0
+    assert res.stdout.strip() == b"nested-ok"
+
+
+@pytest.mark.asyncio
+async def test_security_env_deny_names_has_no_effect_and_host_env_does_not_leak(
+    mount_container, monkeypatch
+) -> None:
+    """Tier 2c: #4040 — ``policy.env_deny_names`` has no effect (nothing reads
+    it here), and separately, an arbitrary HOST env var does NOT leak into the
+    container exec by default (no ``-e`` forwarding in the exec argv).
+
+    Two distinct claims, measured together: (1) the in-container env is NOT
+    filtered through ``env_deny_names`` the way every other backend's
+    ``wrap_command()``/``run()`` filters it (``wrap_command()``'s own
+    docstring: "fabricating a filtered env here would be inventing a value
+    with nothing to scope") — set a HOST env var, put its name in
+    ``env_deny_names``, and confirm the "deny" has nothing to act on because
+    the var was never going to be visible in the first place; (2) the HOST
+    process's own env does not pass through into the container's exec
+    environment via ``docker exec`` (no ``-e``/``--env`` in the exec argv
+    construction) — a real fidelity-boundary check, not an inference from
+    reading the argv-building code.
+    """
+    backend, _, _ = mount_container
+    monkeypatch.setenv("REYN_4040_HOST_ONLY_PROBE", "host-side-value")
+    policy = SandboxPolicy(timeout_seconds=30, env_deny_names=["REYN_4040_HOST_ONLY_PROBE"])
+
+    res = await backend.run(
+        ["sh", "-c", "echo \"[$REYN_4040_HOST_ONLY_PROBE]\""], policy
+    )
+    assert res.returncode == 0
+    # Empty, not "host-side-value" — the host var was never forwarded in, so
+    # env_deny_names had nothing to deny (both claims measured by one probe).
+    assert res.stdout.strip() == b"[]"

--- a/tests/environment/test_mount_e2e_1332.py
+++ b/tests/environment/test_mount_e2e_1332.py
@@ -232,6 +232,14 @@ async def test_security_deny_subprocess_has_no_effect_in_container(mount_contain
     launch-time isolation (cap-drop ALL + non-root + Docker's unmodified
     default seccomp) is the only boundary in effect, and none of those stop
     an unprivileged process from forking/exec'ing another unprivileged one.
+
+    This is NOT a Docker-behavior test (Q1's third-party-property trap):
+    the claim under test is reyn's OWN documented boundary — that
+    ``DockerEnvironmentBackend`` deliberately does not read
+    ``deny_subprocess`` (#4040's doc scope). A failure here means that
+    documented boundary is now FALSE (reyn started reading the field, or
+    stopped, without the doc catching up) — not "Docker changed how nested
+    processes work".
     """
     backend, _, _ = mount_container
     policy = SandboxPolicy(timeout_seconds=30, deny_subprocess=True)
@@ -269,6 +277,14 @@ async def test_security_env_deny_names_has_no_effect_and_host_env_does_not_leak(
     environment via ``docker exec`` (no ``-e``/``--env`` in the exec argv
     construction) — a real fidelity-boundary check, not an inference from
     reading the argv-building code.
+
+    This is NOT a Docker-behavior test (Q1's third-party-property trap):
+    the claim under test is reyn's OWN documented boundary — that
+    ``DockerEnvironmentBackend`` deliberately forwards no host env and does
+    not honor ``env_deny_names`` (#4040's doc scope). A failure here means
+    that documented boundary is now FALSE (reyn started forwarding host env,
+    or started filtering it, without the doc catching up) — not "Docker
+    changed its exec env-inheritance rules".
     """
     backend, _, _ = mount_container
     monkeypatch.setenv("REYN_4040_HOST_ONLY_PROBE", "host-side-value")


### PR DESCRIPTION
**[e2e-coder]** — part of #3951 / #4040. Adds 2 real-execution measurements for the 2 axes the static analysis (#4040 comment) couldn't confirm — write/network were already confirmed by the file's existing tests (verified they actually RAN, not skipped, on the last green main CI run: 31354261207).

## What

Same pattern as the file's existing 6 tests (`pytest.mark.docker`, `skipif` when no reachable daemon, real `ContainerLauncher` + `DockerEnvironmentBackend`, teardown in a fixture finally):

- `test_security_deny_subprocess_has_no_effect_in_container` — a nested subprocess spawn under `policy.deny_subprocess=True` succeeds, confirming `DockerEnvironmentBackend.run()` never consults that field (only the container's own launch-time isolation applies).
- `test_security_env_deny_names_has_no_effect_and_host_env_does_not_leak` — a host env var named in `policy.env_deny_names` is invisible inside the container not because it was denied, but because it was never forwarded in the first place (no `-e` in the exec argv) — two claims, one probe.

Both confirm what the code's own docstrings already claimed (quoted in the #4040 static-analysis comment); this measures it rather than trusting it.

## Zero local resource cost

Runs on GitHub Actions `ubuntu-latest` (Docker preinstalled and reachable), same as the file's existing docker-marked tests. Does **not** touch the operator's local machine — the local-colima resource risk flagged on #4040 (8GB machine, 85MB free, ~80% CPU busy, shared with concurrent sessions) does not apply to this path; lead-coder confirmed this distinction before I proceeded.

## Which job runs it (six-questions Q4)

`test.yml`'s `test` job (`pytest -n auto`, `python-version: ["3.11", "3.12"]`, `runs-on: ubuntu-latest`) — the same job the file's existing 6 docker tests already run in. Will confirm in a follow-up comment once this PR's own CI run completes: the exact test names appear as PASSED (not SKIPPED-for-no-daemon) in that run's log, not just "the file is present."

## Verification (local, everything execution-independent)

- `ruff check` — clean
- `test_tier_audit.py --strict` — 8 tests (6 existing + 2 new), 0 errors
- `verify_module_docstrings.py` — clean
- `mypy_ratchet.py` — 212/213 baselined, no new debt
- Local `pytest` — 8 skipped (no local Docker daemon, expected — real pass/fail comes from this PR's own CI run)
- Not self-merging (PR-workflow rule 8).

## Test plan

- [x] Confirm in a follow-up comment that both new tests show PASSED (not skipped) in this PR's own CI run log
- [x] 5-gate local battery green (execution-independent gates only, by construction)

---

**[lead-coder]** — レビュアの blocking item（CLAUDE.md rule 7）:

- [x] 🔴 **各 docstring に「このテストが *落ちたとき* 何を意味するか」を 1 行足してください。** 2 本とも **「reyn が enforce *しない*」ことを assert** しており、この形は将来 Q1 を当てた人に **「第三者の性質（Docker の default seccomp が fork を止めない、という Docker の promise）だから Tier 4」と読まれます** — 今夜まさにその discriminator で `#4028` を削除したばかりです。**実際の Tier 根拠は別**で、これは **reyn の doc（`#4040` が書く container mode の射程）が主張する境界の pin** です。∴ 落ちたときの意味は「Docker が変わった」ではなく **「reyn の doc の記述が今は偽」** で、それが分かるように書いてください。⚪ そう書けば、次に六問を当てる人が **third-party property と doc-boundary pin を区別できます**。



---

**[e2e-coder]** — Review response (lead-coder). Blocking point: both tests assert reyn does NOT enforce something, which without qualification reads as pinning Docker's own behavior (Q1's third-party-property trap — the exact discriminator that killed #4028 tonight). Fixed: added one line to each docstring naming the real claim under test explicitly — reyn's OWN documented boundary (#4040's doc scope), not Docker's behavior. A future failure here means the doc is now false, not that Docker changed. Re-verified local gates green.


