### PR TITLE
docs(#3951): sandbox.md's Docker example was a category error — fix to Noop

### DIFF
--- a/docs/concepts/runtime/sandbox.md
+++ b/docs/concepts/runtime/sandbox.md
@@ -126,14 +126,30 @@ audit-event fires (paired with a WARN log, `#3949`), naming the axis and why
 
 **This is deny-list visibility only, not a general "does this backend
 enforce everything configured" report (`#3951`).** A backend that simply
-does not enforce an axis at all — measured today for the Docker launch
-backend, which enforces none of `write_paths`/`network`/`subprocess` —
-produces no `sandbox_axis_unenforced` event and no WARN, because it isn't in
-the deny-list-incapable set `unenforced_axes()` checks. A clean/absent
-report from this mechanism does not mean every configured axis is being
-enforced; it means Landlock's specific deny-list limitation didn't fire on
-this call. Whether to extend coverage to Docker's own enforcement gap is
-tracked in `#3951`, undecided as of this writing.
+does not enforce an axis at all — `NoopBackend`, which enforces none of
+`write_paths`/`network`/`subprocess` (its docstring: argv is returned
+UNCHANGED, no enforcement; all other policy fields are recorded for audit
+only) — produces no `sandbox_axis_unenforced` event and no WARN, because it
+isn't in the deny-list-incapable set `unenforced_axes()` checks (that set
+names Landlock specifically, not "any backend that under-enforces"). A
+clean/absent report from this mechanism does not mean every configured axis
+is being enforced; it means Landlock's specific deny-list limitation didn't
+fire on this call. A quiet run under `NoopBackend` and a quiet run under
+`SeatbeltBackend` are indistinguishable from this signal alone — the
+per-backend table above, not this mechanism, is what answers "what does my
+backend actually enforce."
+
+Container (mount) mode is a **different mechanism entirely, not a sandbox
+backend** — `unenforced_axes()` is only ever called with one of the 3 real
+`SandboxBackend` names (`seatbelt`/`landlock`/`noop`, `sandboxed_exec.py`'s
+own call site), and `DockerEnvironmentBackend`
+(`src/reyn/environment/container_backend.py`) lives on a completely separate
+dispatch path this function never sees. An earlier draft of this paragraph
+named "the Docker launch backend" as an example of the same silent gap —
+category error, corrected by `#3951`'s own investigation
+([guide: configure-sandbox](../../guide/for-users/configure-sandbox.md)):
+container mode was never a candidate input to this function in the first
+place, so there is no coverage question to extend here for it.
 
 ## `reyn.yaml` configuration
 


### PR DESCRIPTION
**[docs-maintainer]** — Cross-ref audit off #4038's merge surfaced my own earlier drift.

## What happened

#4038 (architect, #3951 item ①) found the sharper, actually-applicable example for "`unenforced_axes()` silence isn't a safety proof" is `NoopBackend`, not Docker — and that Docker was never a candidate input to the function at all: `unenforced_axes()`'s only production call site (`sandboxed_exec.py:160`) passes `backend.name`, and the only 3 real `SandboxBackend` implementations are `seatbelt`/`landlock`/`noop`. `DockerEnvironmentBackend` lives in `src/reyn/environment/container_backend.py`, a completely separate dispatch path this function never sees — confirmed directly against source before writing this fix.

This exact paragraph in `sandbox.md` (my own earlier work, #3965) still framed "the Docker launch backend" as though it were a live example of the same silent-coverage-gap class #4038 corrected on the guide side. Same class of drift as tonight's other same-PR doc-sync findings, just landing across two docs instead of within one: #4038 fixed the guide-facing copy (`configure-sandbox.md`), architect's own PR body scoped it to that file only, so the concepts-facing copy (`sandbox.md`) I wrote earlier never got the correction.

## Fix

Replaced the Docker example with `NoopBackend` (matching #4038's own wording almost verbatim, quoting `NoopBackend`'s real docstring), and added an explicit paragraph stating container mode is not a sandbox backend in this vocabulary at all — so a future reader can't reconstruct the same category error from this doc alone.

Checked `feature-map.md` for the same Docker-example pattern — its own Docker mentions are unrelated (an `.docker/config.json` credential path, an `mcp install --source docker:...` verb, the `DockerEnvironmentBackend` feature row itself) — none repeat the stale `unenforced_axes()` framing.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0
- [x] `python scripts/check_doc_anchors.py` — exit 0
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` — 337 passed (+1, new anchor link to configure-sandbox.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
