### PR TITLE
docs(#3951): correct #4038 — Docker IS a sandbox backend, and it is the sharpest case

### DIFF
--- a/docs/guide/for-users/configure-sandbox.md
+++ b/docs/guide/for-users/configure-sandbox.md
@@ -188,13 +188,27 @@ two deny-list fields, and only on a backend that is specifically deny-list
 incapable, which today means Landlock alone. It is not a general "your policy
 was not enforced" check.
 
-🔴 **Silence is therefore not a clean bill of health.** The clearest case is
-Noop: it enforces nothing at all — `allow_write_paths`, `network` and
-`subprocess` are recorded for audit and otherwise ignored — and it emits **no**
-`sandbox_axis_unenforced` warning for any of them, because the check asks
-"can this backend express a deny-list?", not "does this backend enforce what
-you configured?". A quiet run under Noop and a quiet run under Seatbelt look
-identical from this signal alone.
+🔴 **Silence is therefore not a clean bill of health.** The check asks "can
+this backend express a deny-list?", not "does this backend enforce what you
+configured?" — so a backend that enforces little or nothing passes it in
+silence.
+
+The sharpest case is the **Docker backend** (`--env-backend=docker`, below).
+It is a sandbox backend — the same object serves as both the environment and
+the sandbox backend for a container agent — and its `run()` **honors only
+`policy.timeout_seconds`**. Configure `allow_write_paths`, `network` or
+`subprocess` under it and none of them is applied, and **no
+`sandbox_axis_unenforced` warning is emitted**, because Docker is not
+deny-list-incapable in the sense this check tests for; it is simply not
+enforcing those axes at all, which the check does not look at. Isolation does
+come from the container boundary itself — but it is the image and the mount
+set that provide it, not the policy fields you wrote.
+
+Noop is the same shape with nothing left to fall back on: it enforces nothing,
+records the policy for audit, and likewise warns about nothing.
+
+A quiet run under Docker or Noop and a quiet run under Seatbelt are
+indistinguishable from this signal alone.
 
 **What to rely on instead:** the per-backend tables above state, field by field,
 what each backend actually enforces. Read the table for the backend you are
@@ -208,10 +222,11 @@ Two other mechanisms are easy to mistake for this one, and neither widens it:
   boundary and the process-spawn gate on your host. It runs at backend
   *selection*; this warning runs at op *dispatch*, once the policy's individual
   axes are known.
-- Container (mount) mode below is a **different mechanism**, not one of the
-  backends in this section — the three sandbox backends are Seatbelt, Landlock
-  and Noop. The tables above do not describe container mode, and this warning
-  does not report on it.
+- Container (mount) mode below is a **different kind of isolation** from the
+  three profile-based backends tabled above (Seatbelt, Landlock, Noop) — the
+  container boundary, not a policy applied to a host process. It is still a
+  sandbox backend as far as this warning is concerned, which is exactly why the
+  silence described above covers it too.
 
 ## Run in a container (mount mode)
 


### PR DESCRIPTION
**[architect]** — 🔴 **#4038（merged）に偽が乗っていたので訂正します。lead-coder が独立に測って確認済、#3951 は再オープン済。docs のみ。**

## 何が偽だったか

```
❌「the three sandbox backends are Seatbelt, Landlock and Noop」
❌「Container (mount) mode … ★not one of the backends in this section」
```

## 実測

```
container_backend.py:350-353
  class DockerEnvironmentBackend:  """… ★dual-Protocol, bridge-free"""
      ★name: str = "docker"
  ＋ available():493 / self_test():505 / wrap_command():531 / run():564
session-construction.md:50-53（★既存 doc）
  「for a docker agent it is the SAME object as environment_backend
   （★DockerEnvironmentBackend satisfies ★both protocols）」
sandboxed_exec.py:160  ★unenforced_axes(backend.name, policy) に backend.name を渡す
∴ 🔴 この節が扱っているまさにその呼び出し点で、backend.name は ★"docker" になりうる
```

⚪ **強制範囲**: `run()` の docstring が「**Honors only `policy.timeout_seconds`**」と明記。

## ∴ Docker は「範囲外」ではなく★最も鋭い実例です

```
Noop  ★enforcement が無いことが★名前と doc から明らか。読者は身構える
🔴 Docker ★隔離のために★意図的に選ぶ backend が、write / network / subprocess を
      ★素通しし、★何も警告しない ── ★身構える理由が無いところに穴がある
```

∴ 節の主例を **Docker に差し替え、Noop を第 2 の実例として残しました。**
container-mode の箇条書きも「別の**機構**（backend ではない）」から「別の**種類の隔離**
（ただしこの警告にとっては sandbox backend）」に直しています。

## 🔴 どう間違えたか

```
`name=` を ★src/reyn/security/sandbox/ 配下に限って列挙 → 3 つ ── ★範囲内では正しい
🔴 ★「探索範囲の外」を「存在しない」と読んだ
   委譲した収集は「Docker は指定ディレクトリ外のため範囲外」と★明記していた
```

**§17（scope, not just pattern）であり、私が数時間前に #4032 で書いた §21 そのもの**です。
⚠️ **節を書いた当人が、同じ夜に同じ穴に落ちました。**

⚪ **lead-coder の指摘**（broker）も記録に値します: 彼らの「確認」は**私と同じディレクトリを
grep して同じ 0 件を得た**もので、「**主張者の方法を再利用した検証は検証ではない**」
── **co-vet が誤ったのではなく、co-vet が検証されなかった**という形です。

## Test plan

- [x] `DockerEnvironmentBackend` の Protocol 適合を実測（`name` / 4 メソッドの実在）
- [x] `session-construction.md:50-53` の既存記述と突き合わせ
- [x] `sandboxed_exec.py:160` が `backend.name` を渡すことを確認
- [x] `run()` docstring の「Honors only policy.timeout_seconds」を確認
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — ★実行、**exit 0**

⚠️ **`#4043` も私の誤った発見を根拠に `sandbox.md` の Docker 例を Noop に「修正」しています。**
**元の Docker 例が正しい**ので、そちらは docs-maintainer が再訂正する手配です（lead-coder 割当）。

part of #3951

🤖 Generated with [Claude Code](https://claude.com/claude-code)
