### PR TITLE
docs(#4040): describe what container mode actually enforces

### DIFF
--- a/docs/guide/for-users/configure-sandbox.md
+++ b/docs/guide/for-users/configure-sandbox.md
@@ -226,7 +226,9 @@ Two other mechanisms are easy to mistake for this one, and neither widens it:
   three profile-based backends tabled above (Seatbelt, Landlock, Noop) — the
   container boundary, not a policy applied to a host process. It is still a
   sandbox backend as far as this warning is concerned, which is exactly why the
-  silence described above covers it too.
+  silence described above covers it too — see [What container mode itself
+  enforces](#what-container-mode-itself-enforces) below for what actually
+  applies instead.
 
 ## Run in a container (mount mode)
 
@@ -258,11 +260,13 @@ by `reyn.yaml sandbox.backend` as usual (typically `landlock` on Linux).
 
 ### What container mode itself enforces
 
-The per-backend tables above, and the `sandbox_axis_unenforced` warning, are
-about the three **sandbox** backends (Seatbelt, Landlock, Noop) — a separate
-question from what the **container** you launch into already restricts on its
-own, independent of any `sandbox.*` policy. Measured directly (real execution
-against a live container, not inferred from the launch code):
+The section above already establishes that Docker's `run()` honors only
+`policy.timeout_seconds`, and that `allow_write_paths`/`network`/`subprocess`
+pass through unenforced with no warning. That leaves the question of what, if
+anything, DOES restrict those axes when you run in a container — the
+container's own launch-time isolation, independent of any `sandbox.*` policy.
+Measured directly (real execution against a live container, not inferred from
+the launch code):
 
 | axis | what actually happens | driven by |
 |---|---|---|

--- a/docs/guide/for-users/configure-sandbox.md
+++ b/docs/guide/for-users/configure-sandbox.md
@@ -256,6 +256,30 @@ In mount mode, the workspace root is automatically bind-mounted at `/workspace`
 inside the container. The sandbox backend used inside the container is determined
 by `reyn.yaml sandbox.backend` as usual (typically `landlock` on Linux).
 
+### What container mode itself enforces
+
+The per-backend tables above, and the `sandbox_axis_unenforced` warning, are
+about the three **sandbox** backends (Seatbelt, Landlock, Noop) — a separate
+question from what the **container** you launch into already restricts on its
+own, independent of any `sandbox.*` policy. Measured directly (real execution
+against a live container, not inferred from the launch code):
+
+| axis | what actually happens | driven by |
+|---|---|---|
+| write | root filesystem is read-only; `/tmp` (tmpfs) and the workspace bind mount are writable | fixed at container launch (`--read-only`, `--tmpfs /tmp`) — not `sandbox.*` policy |
+| network | outbound connections fail | fixed at container launch (`--network none`, unless overridden) — not `sandbox.*` policy |
+| subprocess | **not restricted** — a process inside the container can spawn further child processes freely | nothing; `subprocess: false` in your policy has no effect once you are inside a container |
+| env | the container sees only the image's own environment (its `/etc/profile` / shell activation) — your host's environment variables are not forwarded in, and `env_deny_names` has nothing to filter because there is nothing to filter | nothing; not a policy mechanism, just how `docker exec` works |
+
+The write and network rows come from the container's fixed launch flags
+(`--cap-drop ALL`, non-root user, read-only root + tmpfs, `--network none` by
+default) — they hold regardless of what your `reyn.yaml sandbox:` config says,
+because they are set once when the container starts, not per operation. The subprocess and
+env rows are the opposite kind of fact: there is **no** mechanism restricting
+them at all, at any layer, inside the container — `subprocess: false` and
+`allow_env_names` only take effect for the sandbox backends listed above, not
+for container mode.
+
 ### Default image
 
 When `--image` is omitted, reyn uses a bundled base image built for the current


### PR DESCRIPTION
**[e2e-coder]** — part of #3951 / #4040. The doc deliverable #4040 asked for ("out するもの: per-backend表と同じ粒度の記述"), landed in the actual reference doc rather than left as an issue comment only.

## What

`docs/guide/for-users/configure-sandbox.md`'s "Run in a container (mount mode)" section already carried a warning (from #4038) that the per-backend tables above it don't describe container mode — but never said what DOES apply there. Adds a table at the same grain: write/network are fixed at container launch, independent of `sandbox.*` policy; subprocess/env have no restriction mechanism at all inside a container.

## Evidence

Cross-checked two independent sources against each other, not either alone:

- **Real execution**: `tests/environment/test_mount_e2e_1332.py`'s 8 docker-marked tests (6 pre-existing + 2 added in #4042) — confirmed via CI log (run 31355241451) they actually ran (not skipped) and passed, both Python versions.
- **Code's own claims**: `DockerEnvironmentBackend.run()`'s docstring ("honors only policy.timeout_seconds and policy.max_output_bytes") and `wrap_command()`'s docstring (env_deny_names "has no meaning for a host-side docker exec invocation").

Full axis-by-axis reasoning is on #4040's comment thread; this PR is that content landed as doc.

## Verification

- `check_doc_anchors.py` — clean (exit 0, "no dangling anchors into published pages")
- Doc-only change, no code/test touched
- Not self-merging (PR-workflow rule 8).

## Test plan

- [x] `check_doc_anchors.py` clean
- [x] Table content traced to real execution evidence + code claims, not either alone

---

**[e2e-coder]** — Rebased onto #4045 (landed while this PR was open, same file). Found and fixed a real contradiction: my section's opening sentence said Docker enforcement was "a separate question from" the `sandbox_axis_unenforced` warning — #4045 had just corrected that exact framing (Docker IS one of the sandbox backends as far as that warning is concerned, silently covered). Rewritten to build on #4045's corrected claim rather than restate the wrong one: the warning section establishes WHAT is unenforced (write/network/subprocess pass through silently); this section adds WHAT DOES apply instead (the container's own launch-time isolation, measured). Added a forward link from the existing "still a sandbox backend" bullet to this section — verified against a freshly-built `mkdocs build` (my first anchor guess was stale-site-cached and failed `check_doc_anchors.py`; rebuilt `site/`, re-ran, exit 0).
