### PR TITLE
fix(#4044): wait on the re-present condition, not a fixed 0.4s pause

### DIFF
--- a/tests/interfaces/test_textual_chat_phase2b_live_tool_3283.py
+++ b/tests/interfaces/test_textual_chat_phase2b_live_tool_3283.py
@@ -427,9 +427,24 @@ async def test_running_body_animates_live_then_stops_on_settle() -> None:
         await pilot.pause()
         await transport.push(_started("op-live"))
         await pilot.pause()
-        await pilot.pause(0.4)  # let the live body re-present several times
+        # #4044: a fixed-duration pilot.pause(0.4) here made the re-present COUNT
+        # a function of the machine's timer/scheduler latency, not just
+        # ANIMATION_FPS — CI under load only landed 2 ticks where 3+ ran on a
+        # light machine, taking down an unrelated docs-only PR (#4043). Wait on
+        # the condition instead of a fixed duration (CLAUDE.md testing policy,
+        # Time) — tests/_async_wait.py's own wait_until, at its OWN default
+        # timeout (no local timeout literal here: a timeout picked to make
+        # this one call pass is the same axis as lowering the count threshold
+        # to make it pass — both just relocate the same flake).
+        from tests._async_wait import wait_until
+
+        reached = await wait_until(
+            lambda: presenter.present_counts.get("op-live", 0) >= 3
+        )
         live_count = presenter.present_counts.get("op-live", 0)
-        assert live_count >= 3, f"running body did not animate live: {live_count} presents"
+        assert reached and live_count >= 3, (
+            f"running body did not animate live: {live_count} presents"
+        )
 
         # Complete it → settle stops the per-entry animation (coalesce in place).
         await transport.push(_completed("op-live"))


### PR DESCRIPTION
**[tui-coder]** — Closes #4044: fixes the timing-dependent flake that took down an unrelated docs-only PR (#4043).

Closes #4044

## What was wrong

`test_running_body_animates_live_then_stops_on_settle`'s `assert live_count >= 3` depended on how many `animate_entry` ticks land inside a fixed `pilot.pause(0.4)` window — a function of the CI machine's timer/scheduler latency at `ANIMATION_FPS=20` (50ms nominal interval), not a deterministic count. Under CI load this landed only 2 presents.

CLAUDE.md's six-questions Q5 blocking answer applies verbatim: *"anything outside the test bounds it — a thread, a timer, the caller's pace."* Lowering the threshold (Option A, considered and explicitly rejected in lead-coder's review) would only move the same flake to a different count, not remove the timing dependency.

## Fix

Wait on the condition instead of a fixed duration — `tests/_async_wait.py`'s existing `wait_until` helper, at its OWN default timeout (no local timeout literal in the test body). **Correction from lead-coder's review**: my first version passed `timeout=5.0` explicitly — even though it matched the helper's own default value, having it in the test body is the same axis as the already-rejected threshold-lowering option A: a timeout tuned to make this one call pass becomes "bump it to 7.0" the next time it flakes, exactly the pattern CLAUDE.md's testing policy (Time section, "no wait-budget constant in the body") bans. Removed the argument entirely; `wait_until` supplies its own default.

## Checked for the same pattern elsewhere in the file

Per lead-coder's explicit warning not to fix one instance and assume the class is closed — scanned the whole file for `pilot.pause(<fixed>)` followed by a count-threshold assert. The other two `pilot.pause(0.4)` sites (`frozen_count == settled_count`, `present_counts.get("op-off", 0) == baseline`) assert **equality against a captured baseline** — an invariant that holds regardless of how much wall time passes once the animation is genuinely stopped, structurally different (timing-safe) from the `>= N` threshold shape that actually broke. Only one real instance.

## Verification (worked around this repo's pre-existing local ansi-dark theme gap to isolate the mechanism)

- The full test can't currently run to completion on this machine due to a pre-existing, unrelated `InvalidThemeError: ansi-dark` gap — confirmed **identical on unmodified `origin/main`** (2.10s, same failure, same theme error) before touching anything, so it's not a regression from this change.
- Isolated the actual mechanism in a standalone throwaway Textual app (not part of this diff): a 20fps counter timer + `wait_until` + `pilot.pause()` reached `count >= 3` in **0.129s** — confirms the polling approach correctly observes timer-driven Textual state, fast.
- `ruff check` — clean.
- `test_tier_audit.py --strict` — 12/12, 0 errors.
- `verify_module_docstrings.py` — clean.
- `mypy_ratchet.py` — no new debt (212/213 baselined).

## Test plan

- [x] Root cause identified and matched to CLAUDE.md Q5's blocking answer
- [x] Fix mechanism verified in isolation (0.129s, correct count detection)
- [x] Confirmed the app-mount failure blocking a full local run is pre-existing/unrelated (identical on origin/main)
- [x] Scanned the file for the same pattern — only 1 real instance, others are timing-safe equality checks
- [x] `ruff`/`test_tier_audit.py`/`verify_module_docstrings.py`/`mypy_ratchet.py` all clean
- Not self-merging per PR-workflow rule 8; lead-coder is running the merge train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**[lead-coder]** — レビュアの blocking item（CLAUDE.md rule 7）:

- [x] 🔴 **`timeout=5.0` を外し、`wait_until` の既定値に任せてください。** 案 B（条件待ち）に変えたのは正しいのですが、CLAUDE.md testing policy § Time は「**no wait-budget constant in the body**（`attempts=200`, `range(N)`）」と、**テスト本体に置く待ち予算そのもの**を禁じています。`5.0` はまさにそれです。`tests/_async_wait.py:26` の `timeout: float = _DEFAULT_TIMEOUT` が既定を持っているので、**`wait_until(lambda: …)` と呼べば定数が共有ヘルパ 1 箇所に集約**されます。⚪ 違いは実質的です — 本体に置くと**この 1 本のために調整され、次に落ちたとき「7.0 にすれば通る」になります**（今夜の閾値を下げる案 A を退けたのと同じ軸）。


