### PR TITLE
docs: index ADR-0027a-d in decisions/README.md

### DIFF
--- a/docs/deep-dives/decisions/README.md
+++ b/docs/deep-dives/decisions/README.md
@@ -89,6 +89,10 @@ historical value with status updated to "superseded by ADR-XXXX").
 |---|---|
 | [0026](0026-unified-tool-registry.md) | Unified tool registry — single ToolDefinition for router and phase surfaces (Proposed) |
 | [0027](0027-audit-seal-separation.md) | AuditSeal を Events (P6) から分離 — compliance と operational の責務境界 (Proposed) |
+| [0027a](0027a-audit-seal-hash-chain-topology.md) | Hash chain topology for AuditSeal (Proposed, depends on 0027) |
+| [0027b](0027b-audit-seal-config-hash-scope.md) | `config_hash` scope for AuditSeal (Proposed, depends on 0027) |
+| [0027c](0027c-audit-seal-plan-mode-integration.md) | `seal_unit` and plan-mode integration for AuditSeal (Proposed, depends on 0027 + 0023) |
+| [0027d](0027d-audit-seal-writer-failure-semantics.md) | AuditContext writer failure semantics (Proposed, depends on 0027) |
 | [0029](0029-mcp-install-permission.md) | `mcp_install` permission — install-time gating として permission system に追加 (Proposed) |
 | [0030](0030-universal-secret-handling.md) | Universal secret handling — `${VAR}` 全 yaml + `~/.reyn/secrets.env` + `reyn secret` CLI (Proposed) |
 | [0033](0033-rag-extensible-os.md) | RAG-extensible OS — `embed` / `index_*` / `recall` ops + `index_docs` stdlib + `IndexBackend` protocol (**Accepted** 2026-05-10) |


### PR DESCRIPTION
**[docs-maintainer]** — Part of #4034.

## Background

architect re-filed #4014's item ③ as #4034 after the original comment landed on a closed issue (#4014) 1m51s after it closed — nobody reads a closed issue again, so the remainder rotted invisibly. Same class of oversight #4013/#4015 already fixed twice tonight for other index gaps (6 ADRs, 6 proposals) — this closes the last one, the branch-numbered `0027a-d` series.

## Verified before writing

- All 4 files exist (`0027a`/`0027b`/`0027c`/`0027d`, both `.md`).
- No other open or merged PR references #4034 (`gh pr list --search "4034 in:body"` → 0 results, matching lead-coder's own independent check).
- Both of #4021's new link-existence gates (outgoing + external-incoming, landed earlier tonight) pass clean against the new rows — the exact "don't add a link to something that doesn't exist" concern lead-coder raised, checked with the actual gate rather than by inspection alone.

`decisions/` has no `README.ja.md` (unlike `proposals/`), so this is the only index file to update.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0
- [x] `python scripts/check_doc_anchors.py` — exit 0 (276 outgoing + 47 external-incoming, 0 broken either way)
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` — 337 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
