### PR TITLE
feat(#4008): add the bare-tests-import-reference gate

### DIFF
--- a/.github/workflows/bare-tests-import-reference-gate.yml
+++ b/.github/workflows/bare-tests-import-reference-gate.yml
@@ -1,0 +1,43 @@
+name: bare-tests-import-reference gate
+
+# #4008: reject any nested tests/ file that bare-imports a name matching an
+# existing flat tests/*.py module — resolves today only because pytest's
+# prepend import mode puts a FLAT consumer's own directory on sys.path, and
+# silently breaks the moment that CONSUMER (not the imported module) moves
+# to a different bucket. The sys.path-dependent sibling of
+# file-depth-reference-gate.yml's __file__-rooted-path class — same
+# permanent lifespan reasoning (a silent path failure the moment a file
+# moves to a different depth can recur for as long as tests/ has
+# subdirectories at all), a distinct AST shape, kept as its own gate.
+# See scripts/check_bare_tests_import_reference.py's module docstring for
+# the full design rationale (issue #4008).
+#
+# No diff/base-ref needed — a whole-tree scan against a baseline of zero,
+# same shape as file-depth-reference-gate.yml. A shallow checkout is enough.
+on:
+  pull_request:
+    paths:
+      - "tests/**"
+
+permissions:
+  contents: read
+
+jobs:
+  bare-tests-import-reference:
+    name: bare-tests-import-reference gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/check_bare_tests_import_reference.py is stdlib-only (ast /
+      # pathlib / sys). No pip install needed.
+      - name: Check no nested tests/ file bare-imports a flat module
+        run: |
+          python scripts/check_bare_tests_import_reference.py

--- a/scripts/check_bare_tests_import_reference.py
+++ b/scripts/check_bare_tests_import_reference.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""#4008 — the bare-import sibling of the ``__file__``-depth class
+(#3995/#4002/#4019, ``check_file_depth_reference.py``). A DIFFERENT
+resolution mechanism, deliberately kept as its own gate rather than folded
+into that one (see this issue's own body for the three reasons: distinct
+AST shape, distinct population of zero at write time, and this arc's own
+established convention of one gate per failure class).
+
+## The failure this closes
+
+``from _async_wait import wait_until`` — no ``tests.`` prefix, no relative
+dots — resolves TODAY only because pytest's default "prepend" import mode
+puts a FLAT consumer's own directory (``tests/``) onto ``sys.path``. A
+consumer already living in a subdirectory (``tests/hooks/``) does NOT get
+``tests/`` itself inserted (its own directory does, per the same import-mode
+rule) — so the identical bare import silently ``ModuleNotFoundError``s the
+moment that CONSUMER moves into a bucket, even though the imported module
+(``tests/_async_wait.py``) itself never moved. 19 real instances of exactly
+this were found and fixed the same night this issue was filed (converted to
+``from tests._support.async_wait import wait_until`` — the same
+depth-independent, ``REPO_ROOT``-anchored pattern the ``__file__`` class
+converges on).
+
+## Why this is a STATIC, add-time proxy, not a move-time check
+
+Unlike ``check_migration_diff_shape.py``'s a′ (which needs a real move to
+compare before/after), this failure is fully determined by a file's CURRENT
+position: a nested file bare-importing a name that happens to match an
+EXISTING flat ``tests/*.py`` basename is *already* relying on the "prepend"
+mode's sys.path quirk today, whether or not that particular file ever moves
+again. So the check is a pure population scan, no diff needed — mirroring
+``check_file_depth_reference.py``'s own "whole-tree scan against a baseline
+of zero" shape, verified fresh against the real tree (0 hits) before this
+gate shipped, exactly as that gate's own docstring records doing.
+
+## Scope
+
+In scope: every ``tests/**/*.py`` file whose OWN directory is not
+``tests_dir`` itself — a file already flat in ``tests/`` root cannot exhibit
+this failure (its own directory already puts ``tests/`` on ``sys.path``, so
+a bare import of a flat-module sibling name resolves correctly and stays
+correct regardless of whether OTHER files move; if it moves off tests/
+root, it stops being flat and enters this gate's own scope). ``conftest.py``
+is excluded at any depth (see ``check_file_depth_reference.py``'s module
+docstring — the one file class that structurally never moves).
+
+Flagged: a top-level (``level == 0``) ``ast.ImportFrom`` whose ``module``'s
+FIRST dotted component matches the basename (no ``.py``) of an existing
+flat ``tests/*.py`` file. No name list, no hardcoded module names — a
+structural comparison against the real, current flat population, so a
+future flat file added tomorrow is covered automatically, the same way
+``check_file_depth_reference.py``'s ``_support``/``fixtures`` detection
+needs no hardcoded directory names either.
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_TESTS_DIR = _ROOT / "tests"
+_STRUCTURALLY_EXEMPT = frozenset({"conftest.py"})
+
+
+def flat_module_basenames(tests_dir: Path = _TESTS_DIR) -> "set[str]":
+    """Every flat ``tests/*.py`` file's importable basename right now
+    (``__init__.py`` excluded — a package marker, not an importable
+    module name a bare import would ever name)."""
+    return {
+        p.stem for p in tests_dir.glob("*.py") if p.name != "__init__.py"
+    }
+
+
+def _bare_imports_of_a_flat_module(
+    path: Path, flat_names: "set[str]"
+) -> "list[str]":
+    """The ``ImportFrom`` module names in *path* that are top-level
+    (``level == 0``) and whose first dotted component names an existing
+    flat ``tests/*.py`` module — the exact shape that resolves ONLY
+    because of the consumer's own current (flat-adjacent) sys.path
+    position, per the module docstring."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, SyntaxError):
+        return []
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            top = node.module.split(".", 1)[0]
+            if top in flat_names:
+                hits.append(node.module)
+    return hits
+
+
+def offending_files(tests_dir: Path = _TESTS_DIR) -> "list[tuple[Path, list[str]]]":
+    """Every NESTED ``tests/**/*.py`` file (not flat in ``tests_dir`` itself)
+    carrying at least one bare import of an existing flat module, paired
+    with the offending module names — the gate's entire decision, isolated
+    from CLI/printing so it is directly testable."""
+    flat_names = flat_module_basenames(tests_dir)
+    offenders: list[tuple[Path, list[str]]] = []
+    for path in sorted(tests_dir.rglob("*.py")):
+        if path.parent == tests_dir:
+            continue  # a flat file's own directory already IS tests_dir
+        if path.name in _STRUCTURALLY_EXEMPT:
+            continue
+        hits = _bare_imports_of_a_flat_module(path, flat_names)
+        if hits:
+            offenders.append((path, hits))
+    return offenders
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    del argv  # no options — a whole-tree scan against a baseline of zero
+    offenders = offending_files(_TESTS_DIR)
+
+    if not offenders:
+        print(
+            "OK: no nested tests/ file bare-imports a name that matches "
+            "an existing flat tests/*.py module."
+        )
+        return 0
+
+    print("bare-tests-import-reference gate FAILED:\n", file=sys.stderr)
+    print(
+        f"{len(offenders)} file(s) bare-import a name that resolves ONLY "
+        "because of their own current sys.path position (pytest's "
+        "'prepend' import mode puts a FLAT consumer's directory on "
+        "sys.path; a nested consumer's does not) — this SILENTLY BREAKS "
+        "(ModuleNotFoundError, or a different-job skip) the moment the "
+        "CONSUMER moves to a different bucket, even though the imported "
+        "module itself never moved (#4008):",
+        file=sys.stderr,
+    )
+    for path, modules in offenders:
+        rel = path.relative_to(_ROOT)
+        for module in modules:
+            print(f"  {rel}: from {module} import ...", file=sys.stderr)
+
+    print(
+        "\nUse an explicit, depth-independent import instead — e.g. "
+        "`from tests._support.<name> import ...` (requires tests/__init__.py, "
+        "already present, #4001) rather than a bare top-level name.\n"
+        "\nThis gate's own starting population is zero, so any hit here is "
+        "a new regression, not inherited debt.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_check_bare_tests_import_reference_4008.py
+++ b/tests/scripts/test_check_bare_tests_import_reference_4008.py
@@ -1,0 +1,144 @@
+"""Tier 2: #4008 — the bare-import-reference gate (the sys.path-dependent
+sibling of #3995/#4002/#4019's `__file__`-depth class).
+
+Real filesystem fixtures throughout (a real `tmp_path` tree of `.py`
+files, real directories) — the function under test reads real file
+content and compares real module names, so faking the filesystem would
+test nothing real.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_bare_tests_import_reference import (
+    flat_module_basenames,
+    offending_files,
+)
+
+
+def test_a_nested_bare_import_of_an_existing_flat_module_is_flagged(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: THE real-world instance — a nested consumer bare-imports a
+    name that matches an existing flat tests/*.py module. Resolves today
+    only because pytest's prepend import mode puts the CONSUMER's own
+    directory on sys.path; breaks the moment the consumer moves again."""
+    (tmp_path / "_async_wait.py").write_text("def wait_until(): ...\n", encoding="utf-8")
+    hooks = tmp_path / "hooks"
+    hooks.mkdir()
+    (hooks / "test_a.py").write_text(
+        "from _async_wait import wait_until\n", encoding="utf-8"
+    )
+    offenders = offending_files(tmp_path)
+    assert offenders == [(hooks / "test_a.py", ["_async_wait"])]
+
+
+def test_a_flat_files_own_bare_import_is_never_flagged(tmp_path: Path) -> None:
+    """Tier 2: a FLAT file's own directory already IS tests_dir, so its own
+    bare import of a flat sibling is correct today and stays correct
+    regardless of what else moves — only NESTED consumers are in scope."""
+    (tmp_path / "_async_wait.py").write_text("def wait_until(): ...\n", encoding="utf-8")
+    (tmp_path / "test_a.py").write_text(
+        "from _async_wait import wait_until\n", encoding="utf-8"
+    )
+    offenders = offending_files(tmp_path)
+    assert offenders == []
+
+
+def test_a_dotted_import_of_a_real_package_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 2: `from reyn.core.x import y` (a real installed package, not a
+    flat tests/ sibling) must not be flagged — the check only fires when
+    the FIRST dotted component matches an EXISTING flat tests/*.py
+    basename, not any bare-looking import."""
+    hooks = tmp_path / "hooks"
+    hooks.mkdir()
+    (hooks / "test_a.py").write_text(
+        "from reyn.core.kernel import module_is_allowed\n", encoding="utf-8"
+    )
+    offenders = offending_files(tmp_path)
+    assert offenders == []
+
+
+def test_an_explicit_tests_prefixed_import_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 2: the FIX this gate steers toward — `from tests._support.x
+    import y` (an explicit, depth-independent import, level==0 but the
+    top-level component is `tests`, never a flat module basename) is not
+    flagged, even though the target module (`async_wait.py`) also happens
+    to exist flat somewhere unrelated in this fixture."""
+    (tmp_path / "async_wait.py").write_text("def wait_until(): ...\n", encoding="utf-8")
+    hooks = tmp_path / "hooks"
+    hooks.mkdir()
+    (hooks / "test_a.py").write_text(
+        "from tests._support.async_wait import wait_until\n", encoding="utf-8"
+    )
+    offenders = offending_files(tmp_path)
+    assert offenders == []
+
+
+def test_a_relative_import_is_never_flagged(tmp_path: Path) -> None:
+    """Tier 2: a relative import (`from . import x`, `level > 0`) is a
+    different, already-depth-safe mechanism (resolves relative to the
+    importing package, not sys.path) — out of this gate's scope by
+    construction (`node.level == 0` in the predicate)."""
+    hooks = tmp_path / "hooks"
+    hooks.mkdir()
+    (hooks / "__init__.py").write_text("", encoding="utf-8")
+    (hooks / "_local.py").write_text("X = 1\n", encoding="utf-8")
+    (hooks / "test_a.py").write_text("from ._local import X\n", encoding="utf-8")
+    offenders = offending_files(tmp_path)
+    assert offenders == []
+
+
+def test_conftest_is_structurally_exempt_at_any_depth(tmp_path: Path) -> None:
+    """Tier 2: conftest.py never moves (pytest resolves the nearest one to
+    the file being collected) — the same structural exemption
+    check_file_depth_reference.py grants it, for the identical reason."""
+    (tmp_path / "_async_wait.py").write_text("def wait_until(): ...\n", encoding="utf-8")
+    hooks = tmp_path / "hooks"
+    hooks.mkdir()
+    (hooks / "conftest.py").write_text(
+        "from _async_wait import wait_until\n", encoding="utf-8"
+    )
+    offenders = offending_files(tmp_path)
+    assert offenders == []
+
+
+def test_the_check_needs_no_curated_module_name(tmp_path: Path) -> None:
+    """Tier 2: non-vacuity — a flat module name NEVER SEEN before (not
+    `_async_wait`, not anything hardcoded anywhere) is still caught,
+    because the check is a structural comparison against the real,
+    current flat population, not a name-membership test against a list."""
+    (tmp_path / "some_brand_new_flat_module_xyz.py").write_text(
+        "X = 1\n", encoding="utf-8"
+    )
+    hooks = tmp_path / "hooks"
+    hooks.mkdir()
+    (hooks / "test_a.py").write_text(
+        "from some_brand_new_flat_module_xyz import X\n", encoding="utf-8"
+    )
+    offenders = offending_files(tmp_path)
+    assert offenders == [(hooks / "test_a.py", ["some_brand_new_flat_module_xyz"])]
+
+
+def test_flat_module_basenames_excludes_init(tmp_path: Path) -> None:
+    """Tier 2: __init__.py is a package marker, not an importable module
+    name a bare import would ever name — excluded from the flat set."""
+    (tmp_path / "__init__.py").write_text("", encoding="utf-8")
+    (tmp_path / "test_a.py").write_text("X = 1\n", encoding="utf-8")
+    assert flat_module_basenames(tmp_path) == {"test_a"}
+
+
+def test_the_real_repo_tree_is_currently_clean() -> None:
+    """Tier 2: the gate's own starting population — verified against the
+    real, current tree (not assumed), matching check_file_depth_reference.py's
+    own "run it before shipping it" discipline. 19 real instances were
+    fixed the same night this gate was designed (#4008); this asserts they
+    stayed fixed."""
+    from scripts.check_bare_tests_import_reference import _ROOT, _TESTS_DIR
+
+    assert _TESTS_DIR == _ROOT / "tests"
+    offenders = offending_files(_TESTS_DIR)
+    assert offenders == [], (
+        f"real regression(s) found: {offenders} — this gate's baseline is "
+        "zero, so any hit here is new, not inherited debt"
+    )


### PR DESCRIPTION
**[e2e-coder]** — Closes #4008.

## What

`scripts/check_bare_tests_import_reference.py` — a whole-tree static scan flagging a nested `tests/` file that bare-imports a name matching an existing flat `tests/*.py` module. This resolves TODAY only because pytest's "prepend" import mode puts a FLAT consumer's own directory on `sys.path` — a nested consumer's directory does not get `tests/` itself inserted, so the identical bare import silently `ModuleNotFoundError`s the moment the CONSUMER (not the imported module) moves into a bucket. 19 real instances of exactly this were found and fixed the same night #4008 was filed (in the #3995 a′+b PR).

Deliberately its own gate, not folded into `check_file_depth_reference.py` — different AST shape (`ImportFrom`, not a `__file__`-rooted path expression), and this arc's own convention of one gate per failure class (see #4008's own body for the full reasoning).

## `owner:decide` label

Re-assessed per lead-coder's instruction, given tonight's label-audit pattern (several `owner:decide` issues turned out already settled in the body). The issue body already specified a complete, unambiguous design with no real policy tradeoff — removed the label and proceeded from the design (recorded on #4008).

## Verification

- Ran the detector against the real tree BEFORE wiring the gate — 0 hits, confirming the 19 instances fixed earlier tonight are the whole population (mirrors `check_file_depth_reference.py`'s own "verify before shipping" discipline). Pinned by `test_the_real_repo_tree_is_currently_clean`.
- Falsify-verified: stripped the `flat_names` membership check, confirmed the 2 tests expecting a flagged offender go RED for the right reason, restored, confirmed GREEN.
- `pytest tests/scripts/test_check_bare_tests_import_reference_4008.py tests/scripts/test_check_file_depth_reference_3995.py` — 27 passed (both gates coexist without interference)
- `ruff check` — clean
- `test_tier_audit.py --strict` — 9 tests, 0 errors
- `verify_module_docstrings.py` — clean
- `mypy_ratchet.py` — 212/213 baselined, no new debt
- New CI workflow (`bare-tests-import-reference-gate.yml`) — mirrors `file-depth-reference-gate.yml`'s structure exactly, `path: tests/**` trigger, YAML validated locally
- Not self-merging (PR-workflow rule 8).

## Test plan

- [x] Verified real-tree population is zero before wiring the gate
- [x] Falsify-verified (RED for the right reason, restored to GREEN)
- [x] Coexistence with the sibling gate's test suite confirmed
- [x] 5-gate local battery green