### PR TITLE
fix(#4051): structurally close the Composer-focus race after an intervention arrives

### DIFF
--- a/tests/interfaces/test_textual_chat_intervention_panel_3299.py
+++ b/tests/interfaces/test_textual_chat_intervention_panel_3299.py
@@ -379,8 +379,26 @@ async def test_composer_submit_during_pending_intervention_is_always_a_new_turn(
 
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
-        app.query_one(Composer).focus()
-        await pilot.pause()
+        composer = app.query_one(Composer)
+        # #4051: the arriving intervention frame's own hidden→shown transition
+        # posts a TabbedContent.TabActivated message that schedules a DEFERRED
+        # call_after_refresh(radios[0].focus) (intervention_panel.py's
+        # on_tabbed_content_tab_activated) — a ONE-SHOT callback that can land
+        # on any later refresh, including one after a plain composer.focus()
+        # call, stealing focus back to the RadioSet with nothing left to
+        # re-claim it: the keypresses below then land on the RadioSet instead
+        # of the Composer, submit_user_text is never called, and
+        # transport.submitted stays empty forever (the wait at the bottom of
+        # this test is unbounded by design, #3748). A single focus() + wait-
+        # for-condition does not structurally close this — the one-shot steal
+        # can still land AFTER the check passes. RE-ASSERT focus every pump
+        # until it demonstrably sticks, so the race resolves regardless of
+        # which pump the deferred callback lands on (same "wait on the
+        # condition, not a pause count" shape as #4044's fix, but the
+        # condition here needs an accompanying retry, not just an observation).
+        while app.focused is not composer:
+            composer.focus()
+            await pilot.pause()
         await pilot.press("y", "e", "s")
         await pilot.press("enter")
         # #3720: wait for the submit to ARRIVE, not for one turn of the loop.


### PR DESCRIPTION
**[tui-coder]** — Structural fix for #4051's 1/42 CI hang (took down an unrelated docs-only PR, #4049).

part of #4051

## Root cause (traced, not directly reproduced — see verification note)

The arriving intervention frame's own hidden→shown transition posts a `TabbedContent.TabActivated` message that schedules a **deferred** `call_after_refresh(radios[0].focus)` (`intervention_panel.py`'s `on_tabbed_content_tab_activated`). This is a one-shot callback that can land on any later refresh cycle — including one after the test's own plain `composer.focus()` call — stealing focus back to the `RadioSet` with nothing left to re-claim it. The subsequent keypresses then land on the `RadioSet` instead of the `Composer`, `submit_user_text` is never called, and `transport.submitted` stays empty forever (the wait at the bottom of this test is unbounded by design, #3748 — correctly so, per owner policy; CI's own 120s timeout is the intended kill-switch).

## Fix shape (per lead-coder's review, corrected from my first draft)

An assert-based fix (`assert app.focused is composer` before pressing) would only turn the hang into a fast RED — the race itself stays, just relocated to a different failure mode. A single `focus()` + wait-for-condition **also** doesn't structurally close it, since the one-shot steal can still land AFTER the check passes, with nothing left to re-trigger it.

Fixed by **re-asserting focus every pump** until it demonstrably sticks:
```python
while app.focused is not composer:
    composer.focus()
    await pilot.pause()
```
The steal is guaranteed one-shot (the `TabActivated` message only fires once, for this test's single intervention arrival), so this converges in at most 2 iterations regardless of which pump the deferred callback lands on. Correct by construction — whether or not the race actually fires on a given run.

## ⚠️ Verification note — could not dynamically reproduce or falsify locally

The SAME test hangs identically with and without this change (confirmed via `git stash` A/B — both time out at 120s+ with zero output). This is a pre-existing local-environment gap unrelated to this fix, in the same family as the `ansi-dark` theme-registration issue this session hit repeatedly (#4011/#4018/#4044) — though this particular symptom is a silent hang rather than an immediate crash, not fully traced, out of scope for this fix. **CI is the only execution surface that can confirm this change.** Per lead-coder's explicit direction: the fix is correct by construction (waits for a condition, not a race outcome) and does not require observing the 1/42 flake disappear to be valid.

## Checked for the same pattern elsewhere in the file

No other test in this file focuses the Composer immediately after an intervention frame arrives without already going through `_settle_until` for a different condition first — this is the only site with this exact shape.

## Verification

- `ruff check` — clean.
- `test_tier_audit.py --strict` — 24/24, 0 errors.
- `verify_module_docstrings.py` — clean.
- `mypy_ratchet.py` — no new debt (212/213 baselined).
- **Not** locally run to completion — see verification note above.

## Test plan

- [x] Root cause traced precisely to the deferred `call_after_refresh` focus-steal mechanism
- [x] Fix corrected per review (assert → structural re-assert loop)
- [x] Confirmed via A/B that the local hang is pre-existing and unrelated to this change
- [x] Scanned the file for the same pattern — only one instance
- [x] `ruff`/`test_tier_audit.py`/`verify_module_docstrings.py`/`mypy_ratchet.py` all clean
- [x] CI execution — pytest (Python 3.11) pass (5m40s), pytest (Python 3.12) pass (6m12s), all other checks green. https://github.com/tya5/reyn/actions/runs/31359161655
- Not self-merging per PR-workflow rule 8; lead-coder is running the merge train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

