### PR TITLE
feat(#3698): P2 — localize fastmcp direct imports behind a boundary module

### DIFF
--- a/src/reyn/mcp/_fastmcp_boundary.py
+++ b/src/reyn/mcp/_fastmcp_boundary.py
@@ -1,0 +1,107 @@
+"""#3698 P2 — the single seam every reyn-side `fastmcp` import goes through.
+
+## What this closes, and what it does NOT close
+
+Before this module, 8 sites across 3 files (`client.py` ×5, `elicitation.py`
+×1, `message_handler.py` ×2) each imported directly from `fastmcp.*`. A
+future SDK swap (the MCP Python SDK v2 target, #3698) had to find and
+change every one of those call sites individually. This module makes them
+one seam — a future swap edits THIS file's bodies, not 8 scattered call
+sites.
+
+**That claim is honest only for 6 of the 8 symbols.** `client.py`'s and
+`elicitation.py`'s imports are plain symbol imports — construct-and-use,
+never subclassed — so re-exporting them here is genuine, complete
+decoupling: the CALLER never names `fastmcp` again. `message_handler.py`'s
+`MessageHandler`/`TaskNotificationHandler` are different: `ReynMCPMessageHandler`
+INHERITS from `TaskNotificationHandler` (see that module's own docstring),
+depending on its `dispatch()` routing logic and its `_client_ref` attribute
+contract — a real behavioral coupling, not just an import path. Re-exporting
+the base class here relocates WHERE the name is imported from; it does
+**not** remove that coupling. A future SDK swap still has to either find an
+equivalent base class in the new SDK with the same routing contract, or
+rewrite `ReynMCPMessageHandler` to compose rather than inherit (reimplementing
+the dispatch routing reyn currently gets for free — tui-coder's #3698
+measurement scoped this as the real Phase-3 cost). Re-exporting these two
+here is for import-LOCATION consistency (one file names `fastmcp`, not
+three) — it is deliberately NOT claimed as removing the inheritance
+dependency, which stays exactly as coupled as before this module existed.
+
+## Why the 6 real accessors are functions, not module-level re-exports
+
+`client.py`'s 5 sites and `elicitation.py`'s 1 site were all DEFERRED
+imports (inside a method body, not at module top) before this change —
+`client.py`'s own first import is wrapped in a `try/except ImportError`
+that raises a friendly reyn-specific error ("The 'fastmcp' package is
+required...") rather than a bare traceback. Turning these into a plain
+module-level `from fastmcp import Client` here would change WHEN the
+import (and any ImportError) fires — from "the first time a connection is
+actually opened" to "the first time `reyn.mcp` is imported at all",
+independent of whether MCP is ever used in a given run. Each accessor
+function below preserves the original timing exactly: the import inside it
+only executes when the caller actually calls the function, same as the
+inline import it replaces.
+
+## Why `MessageHandler`/`TaskNotificationHandler` are plain re-exports, not functions
+
+`message_handler.py`'s 2 sites were already module-level (not deferred) —
+`class ReynMCPMessageHandler(TaskNotificationHandler):` needs its base class
+resolved at class-definition (import) time, which Python cannot defer into
+a function call. So these two stay module-level imports here too — no
+timing change from before this module existed, in either direction.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+# Module-level (see docstring): message_handler.py's class statement needs
+# these resolved at import time, exactly as before this module existed.
+from fastmcp.client.messages import MessageHandler as MessageHandler
+from fastmcp.client.tasks import TaskNotificationHandler as TaskNotificationHandler
+
+
+def import_fastmcp_client() -> "type[Any]":
+    """``fastmcp.Client`` — client.py's ``initialize()``, wrapped there in a
+    try/except that raises a reyn-specific "package required" error on
+    ``ImportError`` (unchanged by this function; the caller still wraps
+    THIS call the same way)."""
+    from fastmcp import Client
+
+    return Client
+
+
+def import_stdio_transport() -> "type[Any]":
+    """``fastmcp.client.transports.StdioTransport`` — client.py's ``_open_stdio``."""
+    from fastmcp.client.transports import StdioTransport
+
+    return StdioTransport
+
+
+def import_streamable_http_transport() -> "type[Any]":
+    """``fastmcp.client.transports.StreamableHttpTransport`` — client.py's
+    ``_open_http``."""
+    from fastmcp.client.transports import StreamableHttpTransport
+
+    return StreamableHttpTransport
+
+
+def import_sse_transport() -> "type[Any]":
+    """``fastmcp.client.transports.SSETransport`` — client.py's ``_open_sse``."""
+    from fastmcp.client.transports import SSETransport
+
+    return SSETransport
+
+
+def import_oauth() -> "type[Any]":
+    """``fastmcp.client.auth.OAuth`` — client.py's ``_build_oauth_auth``."""
+    from fastmcp.client.auth import OAuth
+
+    return OAuth
+
+
+def import_elicit_result() -> "type[Any]":
+    """``fastmcp.client.elicitation.ElicitResult`` — elicitation.py's
+    ``build_elicitation_handler``."""
+    from fastmcp.client.elicitation import ElicitResult
+
+    return ElicitResult

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -807,7 +807,9 @@ class MCPClient:
         if self._initialized:
             return
         try:
-            from fastmcp import Client as FastMCPClient
+            from reyn.mcp._fastmcp_boundary import import_fastmcp_client
+
+            FastMCPClient = import_fastmcp_client()
         except ImportError as exc:
             raise MCPError(
                 "The 'fastmcp' package is required for MCP support. "
@@ -1575,7 +1577,9 @@ class MCPClient:
         return wrapped.argv[0], list(wrapped.argv[1:])
 
     def _open_stdio(self) -> "Any":
-        from fastmcp.client.transports import StdioTransport
+        from reyn.mcp._fastmcp_boundary import import_stdio_transport
+
+        StdioTransport = import_stdio_transport()
 
         command = self._config.get("command")
         if not command:
@@ -1694,7 +1698,9 @@ class MCPClient:
                 "subsequent headless/non-interactive runs."
             )
 
-        from fastmcp.client.auth import OAuth
+        from reyn.mcp._fastmcp_boundary import import_oauth
+
+        OAuth = import_oauth()
 
         scopes = auth_cfg.get("scopes")
         return OAuth(
@@ -1734,7 +1740,9 @@ class MCPClient:
             SDK knob, applied as this transport's default instead of the
             old connect-level timeout.
         """
-        from fastmcp.client.transports import StreamableHttpTransport
+        from reyn.mcp._fastmcp_boundary import import_streamable_http_transport
+
+        StreamableHttpTransport = import_streamable_http_transport()
 
         url = self._config.get("url")
         if not url:
@@ -1756,7 +1764,9 @@ class MCPClient:
     def _open_sse(self) -> "Any":
         """Open the SSE transport (#2597 S1 free win — FastMCP ships it, so no
         incremental cost to wire vs. leaving the pre-swap ``NotImplementedError``)."""
-        from fastmcp.client.transports import SSETransport
+        from reyn.mcp._fastmcp_boundary import import_sse_transport
+
+        SSETransport = import_sse_transport()
 
         url = self._config.get("url")
         if not url:

--- a/src/reyn/mcp/elicitation.py
+++ b/src/reyn/mcp/elicitation.py
@@ -269,7 +269,9 @@ def build_elicitation_handler(
     ``"auto_decline"`` (per-server config override ``elicitation:
     auto_decline``) always auto-declines, even with a live listener attached.
     """
-    from fastmcp.client.elicitation import ElicitResult
+    from reyn.mcp._fastmcp_boundary import import_elicit_result
+
+    ElicitResult = import_elicit_result()
     from mcp.types import ElicitRequestFormParams
 
     async def _emit(event: str, **fields: Any) -> None:

--- a/src/reyn/mcp/message_handler.py
+++ b/src/reyn/mcp/message_handler.py
@@ -58,8 +58,18 @@ import logging
 import weakref
 from typing import Any, Callable
 
-from fastmcp.client.messages import MessageHandler
-from fastmcp.client.tasks import TaskNotificationHandler
+# #3698 P2: imported via the boundary module for import-LOCATION
+# consistency only — this is a RELOCATION, not a decoupling. The base
+# class below is still directly INHERITED (see ReynMCPMessageHandler's
+# class statement + this module's own docstring: dispatch()'s routing
+# logic + the _client_ref attribute contract are both real, unremoved
+# coupling to fastmcp's class hierarchy). A future SDK swap still needs
+# either an equivalent base class or a composition rewrite here — this
+# import alone does not provide that boundary (contrast client.py's/
+# elicitation.py's accessor functions in _fastmcp_boundary.py, which DO
+# fully decouple their callers). See _fastmcp_boundary.py's module
+# docstring for the full reasoning.
+from reyn.mcp._fastmcp_boundary import MessageHandler, TaskNotificationHandler
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
**[e2e-coder]** — part of #3698 (P2). Measurement + design proposal posted on the issue before this implementation.

## What

`src/reyn/mcp/_fastmcp_boundary.py` — the single seam every reyn-side `fastmcp` import goes through, replacing the 8 direct-import sites measured across `client.py` (×5), `elicitation.py` (×1), `message_handler.py` (×2). The 2 `rag` plugin server-side files (`vector_store_server.py`/`chunker_server.py`, `from fastmcp import FastMCP` to BUILD a server) are the opposite direction from `MCPConnectionService`'s client role — out of this P2's scope, confirmed on the issue.

## Honest split — 6/8 real decoupling, 2/8 relocation only

`client.py`/`elicitation.py`'s 6 sites are plain construct-and-use imports — genuinely decoupled by this boundary. `message_handler.py`'s 2 sites are an INHERITANCE dependency (`ReynMCPMessageHandler(TaskNotificationHandler)`) — re-exporting the base class here relocates the import path but does not remove the coupling (`dispatch()`'s routing logic + the `_client_ref` attribute contract are still directly inherited from fastmcp's class). Marked in code (not just this PR body, which "flows and disappears" — lead-coder's explicit ask), at `message_handler.py`'s own import site, so a future reader there sees the caveat without needing to find this PR or the boundary module's docstring. The composition rewrite that would actually remove this coupling is Phase 3 work, out of scope here.

## Timing preserved

`client.py`'s 5 / `elicitation.py`'s 1 were deferred (function-local) imports before this change — one wrapped in a `try/except ImportError` for a friendly reyn-specific error message. The boundary module's 6 corresponding accessor functions defer their own `fastmcp` import identically, so WHEN the import (and any `ImportError`) fires is unchanged. `message_handler.py`'s 2 were already module-level (a class statement needs its base resolved at import time) — stays module-level in the boundary module too.

## Verification

- `ruff check` — clean
- `mypy_ratchet.py` — 211/213 baselined (2 fewer than before — explicit return-type annotations on the new accessors), no new debt
- `verify_module_docstrings.py` — clean
- `pytest` — 163 passed: the full `tests/mcp/` bucket (138) + `test_fastmcp_core_dep_import_chain.py` (confirms `fastmcp` still lands in `sys.modules` via the relocated module-level import — a fresh-subprocess test, not masked by an already-imported module) + `test_2597_slice3_mcp_elicitation.py` + `test_mcp_client_sandbox_wrap.py`. All real fastmcp client/server round-trips, no mocks.
- No test file changed — `test_tier_audit.py` not applicable to this diff.
- Not self-merging (PR-workflow rule 8).

## Test plan

- [x] Confirmed no test patches these symbols as module attributes (`grep` across `tests/`)
- [x] Confirmed `message_handler.MessageHandler`/`TaskNotificationHandler` still resolve to the identical real fastmcp classes post-refactor
- [x] Full mcp-bucket + import-chain + oauth/elicitation/sandbox-wrap suites green

---

**[lead-coder]** — レビュアの blocking item（CLAUDE.md rule 7）:

- [x] 🔴 **境界が「規約」なのか「強制されている」のかを PR 本文に明記してください。** 現状、`src/reyn/mcp/_fastmcp_boundary.py` の外から `import fastmcp` することを止めるものが**見当たりません**（`scripts/` に該当チェックは無し、ruff にもそのルールは入っていません）。∴ **明日 誰かが `client.py` に直接 import を書いても、何も赤くなりません** — 境界は「今そうなっている」状態であって、不変条件ではない。⚪ **gate を今作れとは言いません**（P2 の範囲を超えます）。**「これは規約であって強制ではない」と本文に 1 行**書いてください。⚠️ 書かないと、次に読む人が「境界がある＝守られる」と読みます — **今夜まさにその形（宣言と実在の差）を何度も扱いました**。


---

**[e2e-coder]** — One line, per lead-coder's review: **this boundary is a convention, not an enforcement.** Nothing in `scripts/`/ruff stops a future direct `import fastmcp` outside `_fastmcp_boundary.py` — writing one tomorrow, in `client.py` or anywhere else, would not go red. A gate for this is deliberately out of scope for P2 (the natural place is Phase 3, alongside the composition rewrite); without this line a future reader could read "a boundary module exists" as "the boundary is enforced," which it currently is not.

