### PR TITLE
feat(#3811): SMIL timeline sampler (first slice)

### DIFF
--- a/src/reyn/core/present/smil.py
+++ b/src/reyn/core/present/smil.py
@@ -1,0 +1,401 @@
+"""SMIL timeline sampler (#3811 first slice) — a declarative-subset evaluator,
+NOT a SMIL runtime.
+
+Lightweight rasterizers (cairosvg, resvg) render only an SVG's static initial
+state; SMIL/CSS/script animation is explicitly out of scope for them. A full
+SMIL runtime (event/syncbase triggers, spline easing, additive/accumulate,
+motion-along-path) is a stateful time+event model, orthogonal to a pure
+rasterizer. This module evaluates neither — it evaluates a measured,
+LLM-authored SUBSET of SMIL (#3811 comment thread: 12 prompts x 2 models,
+real reyn-run LLM output, not synthetic fixtures) at a single point in time
+``t``, producing a STATIC svg snapshot a rasterizer can already handle.
+
+The supported profile (measured coverage: 29/32 real animation elements,
+91%) is exactly the design notes on #3811:
+
+- Elements: ``<animate>``, ``<animateTransform>`` (translate/scale/rotate),
+  ``<set>``.
+- Timing: ``dur``, ``begin`` (OFFSET-ONLY — ``begin="click"``/syncbase is the
+  "no events" boundary, measured 0/32 in real output), ``repeatCount``,
+  ``fill="freeze"``.
+- Interpolation: ``from``/``to``/``values`` + ``keyTimes`` + ``calcMode``
+  ``linear``/``discrete`` (``spline`` measured 1/32 — degrade to linear, see
+  :func:`sample_svg_at`'s violation reporting, not silently ignored).
+- Animatable attributes (allowlist, with their value type): ``opacity``
+  (number), ``fill``/``stroke`` (color), ``x``/``y``/``cx``/``cy``/``r``/
+  ``width``/``height`` (length, unitless), ``transform`` (via
+  ``animateTransform`` only), ``stroke-dashoffset`` (number),
+  ``stroke-dasharray`` (number — #3811's measured MVP-profile gap: without
+  it, ``stroke-dashoffset``'s draw-on-a-line idiom has no dash pattern to
+  offset against, so allowing one without the other is not a smaller
+  profile, it is a broken one).
+
+Explicitly OUT of this slice (each is a measured absence, not a guess —
+0/32 or an isolated, out-of-use-case sample in the #3811 measurement):
+``animateMotion``, ``calcMode="spline"``, ``additive``/``accumulate``,
+path-data (``d``) morphing, event/syncbase ``begin``.
+
+★ Every construct this sampler does not evaluate is dropped from the
+snapshot (the target attribute stays at its SVG-authored base value — safe,
+because a declarative animation's base value is always a valid still state
+in its own right, same "ignore is safe" reasoning #3811's design notes give
+for exactly this case). Dropping is never silent: :func:`sample_svg_at`
+ALWAYS returns the violations it found alongside the snapshot, so a caller
+that only looks at the snapshot has to affirmatively discard them to lose
+the record — no separate opt-in validator pass to forget to run (lead-coder
+review, #3811: this repo hit three "the ignore mechanism itself has no
+trace" incidents in one night — a validator that runs only if asked is the
+same shape).
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from xml.etree import ElementTree as ET
+
+_SVG_NS = "http://www.w3.org/2000/svg"
+ET.register_namespace("", _SVG_NS)
+
+_ANIMATE_TAGS = frozenset(
+    {f"{{{_SVG_NS}}}animate", f"{{{_SVG_NS}}}set", f"{{{_SVG_NS}}}animateTransform"}
+)
+# SMIL elements this sampler recognizes as animation directives AT ALL, so it
+# can tell "an out-of-profile animation element" (a violation) apart from
+# "an ordinary SVG element that happens to sit near one" (not this module's
+# concern).
+_ALL_SMIL_ANIMATION_TAGS = _ANIMATE_TAGS | {
+    f"{{{_SVG_NS}}}animateMotion",
+    f"{{{_SVG_NS}}}animateColor",  # SVG2-deprecated, but real authors still emit it
+    f"{{{_SVG_NS}}}mpath",
+}
+
+_LENGTH_ATTRS = frozenset({"x", "y", "cx", "cy", "r", "width", "height"})
+_NUMBER_ATTRS = frozenset({"opacity", "stroke-dashoffset", "stroke-dasharray"})
+_COLOR_ATTRS = frozenset({"fill", "stroke"})
+# The full allowlist — anything else on attributeName is a violation.
+_ALLOWED_ATTRS = _LENGTH_ATTRS | _NUMBER_ATTRS | _COLOR_ATTRS
+
+_TRANSFORM_KINDS = frozenset({"translate", "scale", "rotate", "skewX", "skewY"})
+
+_HEX_COLOR_RE = re.compile(r"^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
+_RGB_COLOR_RE = re.compile(
+    r"^rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$", re.IGNORECASE
+)
+
+
+@dataclass(frozen=True)
+class SmilViolation:
+    """One construct this sampler did not evaluate — the target attribute
+    was left at its base (unanimated) value instead. Never discarded
+    internally; always returned alongside the snapshot (module docstring)."""
+
+    kind: str
+    detail: str
+    element_tag: str
+
+
+def _local_tag(elem: "ET.Element") -> str:
+    tag = elem.tag
+    return tag.rsplit("}", 1)[-1] if "}" in tag else tag
+
+
+def _parse_offset_seconds(value: "str | None", *, default: float = 0.0) -> "float | None":
+    """Parse a ``begin``/``dur`` offset like ``\"1.5s\"``/``\"200ms\"``/``\"2\"``.
+
+    Returns ``None`` if ``value`` is not a plain numeric offset (event/
+    syncbase forms like ``\"click\"``/``\"x.end\"``/``\"indefinite\"`` all
+    fail this parse — the caller reports that as a violation, never guesses
+    a fallback offset for them)."""
+    if value is None:
+        return default
+    value = value.strip()
+    m = re.fullmatch(r"([+-]?\d+(?:\.\d+)?)(s|ms)?", value)
+    if not m:
+        return None
+    num = float(m.group(1))
+    return num / 1000.0 if m.group(2) == "ms" else num
+
+
+def _parse_color(value: str) -> "tuple[float, float, float] | None":
+    value = value.strip()
+    m = _HEX_COLOR_RE.match(value)
+    if m:
+        hexpart = m.group(1)
+        if len(hexpart) == 3:
+            hexpart = "".join(c * 2 for c in hexpart)
+        return tuple(int(hexpart[i : i + 2], 16) for i in (0, 2, 4))  # type: ignore[return-value]
+    m = _RGB_COLOR_RE.match(value)
+    if m:
+        return (float(m.group(1)), float(m.group(2)), float(m.group(3)))
+    return None
+
+
+def _format_color(rgb: "tuple[float, float, float]") -> str:
+    r, g, b = (max(0, min(255, round(c))) for c in rgb)
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def _lerp(a: float, b: float, frac: float) -> float:
+    return a + (b - a) * frac
+
+
+def _format_number(n: float) -> str:
+    return str(int(n)) if float(n).is_integer() else f"{n:g}"
+
+
+def _interpolate_value(a: str, b: str, frac: float, attr_name: str) -> str:
+    if attr_name in _COLOR_ATTRS:
+        ca, cb = _parse_color(a), _parse_color(b)
+        if ca is None or cb is None:
+            return a if frac < 1.0 else b
+        return _format_color((_lerp(ca[0], cb[0], frac), _lerp(ca[1], cb[1], frac), _lerp(ca[2], cb[2], frac)))
+    # animateTransform values (rotate="angle cx cy", translate="x y",
+    # scale="sx sy") are space-separated NUMBER LISTS, not a single scalar —
+    # interpolate each component independently. A plain scalar attribute
+    # (opacity, x, r, ...) is the len==1 case of the same code path.
+    parts_a, parts_b = a.split(), b.split()
+    if len(parts_a) != len(parts_b) or not parts_a:
+        return a if frac < 1.0 else b
+    try:
+        floats_a = [float(p) for p in parts_a]
+        floats_b = [float(p) for p in parts_b]
+    except ValueError:
+        return a if frac < 1.0 else b
+    return " ".join(
+        _format_number(_lerp(fa, fb, frac)) for fa, fb in zip(floats_a, floats_b)
+    )
+
+
+def _keyframes(elem: "ET.Element") -> "tuple[list[str], list[float]] | None":
+    """Return (values, key_times) for an animate/set element, or None if it
+    has neither a from/to pair nor a values list (a violation the caller
+    reports)."""
+    values_attr = elem.get("values")
+    if values_attr is not None:
+        values = [v.strip() for v in values_attr.split(";")]
+        key_times_attr = elem.get("keyTimes")
+        if key_times_attr is not None:
+            key_times = [float(k.strip()) for k in key_times_attr.split(";")]
+        elif len(values) > 1:
+            key_times = [i / (len(values) - 1) for i in range(len(values))]
+        else:
+            key_times = [0.0]
+        return values, key_times
+    to_val = elem.get("to")
+    if to_val is None:
+        return None
+    from_val = elem.get("from")
+    if from_val is None:
+        # <set> has no "from" at all; a bare <animate to="..."> with no
+        # "from" has no defined base to interpolate from in this profile —
+        # treated as a snap-to-value (matches <set>'s own semantics), not a
+        # violation: MVP profile lists <set> as in-scope and this collapses
+        # to the same "the value snaps at begin" behaviour.
+        return [to_val], [0.0]
+    return [from_val, to_val], [0.0, 1.0]
+
+
+def _evaluate_element(
+    anim: "ET.Element", t: float, violations: "list[SmilViolation]"
+) -> "tuple[str, str] | None":
+    """Returns (attribute_name, value_at_t) for one animate/set/
+    animateTransform element, or None if it produced a violation (nothing
+    to apply — the target attribute is left at its base value)."""
+    tag = _local_tag(anim)
+    attr_name = anim.get("attributeName")
+    is_transform = tag == "animateTransform"
+
+    if not is_transform:
+        if attr_name is None or attr_name not in _ALLOWED_ATTRS:
+            violations.append(
+                SmilViolation(
+                    "unknown_attribute",
+                    f"attributeName={attr_name!r} is outside the supported allowlist",
+                    tag,
+                )
+            )
+            return None
+    else:
+        transform_kind = anim.get("type", "")
+        if transform_kind not in _TRANSFORM_KINDS:
+            violations.append(
+                SmilViolation(
+                    "unsupported_transform_type",
+                    f"animateTransform type={transform_kind!r} is not supported",
+                    tag,
+                )
+            )
+            return None
+
+    begin = _parse_offset_seconds(anim.get("begin"), default=0.0)
+    if begin is None:
+        violations.append(
+            SmilViolation(
+                "event_or_syncbase_begin",
+                f"begin={anim.get('begin')!r} is not an offset — event/syncbase "
+                "timing is out of this sampler's profile",
+                tag,
+            )
+        )
+        return None
+
+    dur = _parse_offset_seconds(anim.get("dur"), default=None)  # type: ignore[arg-type]
+    if dur is None and anim.get("dur") is not None:
+        violations.append(
+            SmilViolation("unparseable_dur", f"dur={anim.get('dur')!r}", tag)
+        )
+        return None
+
+    calc_mode = anim.get("calcMode", "linear")
+    if calc_mode not in ("linear", "discrete"):
+        violations.append(
+            SmilViolation(
+                "unsupported_calc_mode",
+                f"calcMode={calc_mode!r} degraded to 'linear' (spline/paced not "
+                "evaluated)",
+                tag,
+            )
+        )
+        calc_mode = "linear"
+
+    if anim.get("additive") not in (None, "replace") or anim.get("accumulate") not in (
+        None,
+        "none",
+    ):
+        violations.append(
+            SmilViolation(
+                "additive_or_accumulate",
+                "additive/accumulate is not supported — replace/none assumed",
+                tag,
+            )
+        )
+        # Not fatal to the whole element: fall through and still evaluate
+        # the base from/to/values timeline, just without the accumulation
+        # the design note flags as visibly lossy either way.
+
+    keyframes = _keyframes(anim)
+    if keyframes is None:
+        violations.append(
+            SmilViolation(
+                "missing_from_to_or_values",
+                "neither a from/to pair nor a values list",
+                tag,
+            )
+        )
+        return None
+    values, key_times = keyframes
+
+    fill = anim.get("fill", "remove")
+    if fill not in ("freeze", "remove"):
+        fill = "remove"
+
+    # SMIL's own default (absent repeatCount) is 1 — plays exactly once, not
+    # indefinitely. Only the literal "indefinite" means unbounded.
+    repeat_count_raw = anim.get("repeatCount")
+    is_indefinite_repeat = repeat_count_raw == "indefinite"
+    repeat_count: "float | None" = None if is_indefinite_repeat else 1.0
+    if not is_indefinite_repeat and repeat_count_raw is not None:
+        try:
+            repeat_count = float(repeat_count_raw)
+        except ValueError:
+            violations.append(
+                SmilViolation(
+                    "unparseable_repeat_count", f"repeatCount={repeat_count_raw!r}", tag
+                )
+            )
+            repeat_count = 1.0
+
+    active_dur = dur if dur is not None else 0.0
+    if active_dur <= 0.0:
+        value = values[-1]
+    else:
+        elapsed = t - begin
+        if elapsed < 0.0:
+            value = values[0]
+        else:
+            total_span = (
+                active_dur * repeat_count if repeat_count is not None else None
+            )
+            if not is_indefinite_repeat and total_span is not None and elapsed >= total_span:
+                value = values[-1] if fill == "freeze" else values[0]
+            else:
+                cycle_pos = elapsed % active_dur
+                frac = cycle_pos / active_dur
+                value = _value_at_fraction(
+                    values, key_times, frac, calc_mode, attr_name or "transform"
+                )
+
+    if is_transform:
+        return "transform", _render_transform(anim.get("type", ""), value)
+    assert attr_name is not None  # validated above for the non-transform branch
+    return attr_name, value
+
+
+def _value_at_fraction(
+    values: "list[str]", key_times: "list[float]", frac: float, calc_mode: str, attr_name: str
+) -> str:
+    if len(values) == 1:
+        return values[0]
+    last = len(key_times) - 1
+    for i in range(last):
+        is_last_segment = i == last - 1
+        # Each segment [key_times[i], key_times[i+1]) is half-open (SMIL's
+        # own discrete-step semantic: hold values[i] up to, but not
+        # including, the next keyframe, then step) — except the LAST
+        # segment, which is closed on both ends so frac==1.0 still resolves.
+        in_segment = (
+            key_times[i] <= frac <= key_times[i + 1]
+            if is_last_segment
+            else key_times[i] <= frac < key_times[i + 1]
+        )
+        if in_segment:
+            if calc_mode == "discrete":
+                return values[i]
+            span = key_times[i + 1] - key_times[i]
+            local_frac = (frac - key_times[i]) / span if span > 0 else 0.0
+            return _interpolate_value(values[i], values[i + 1], local_frac, attr_name)
+    return values[-1]
+
+
+def _render_transform(kind: str, value: str) -> str:
+    return f"{kind}({value})"
+
+
+def sample_svg_at(svg_text: str, t: float) -> "tuple[str, tuple[SmilViolation, ...]]":
+    """Evaluate the supported SMIL subset (module docstring) in ``svg_text``
+    at time ``t`` (seconds), returning a STATIC svg snapshot plus every
+    profile violation encountered — never silently dropped, see module
+    docstring.
+
+    Every ``<animate>``/``<set>``/``<animateTransform>`` child element is
+    removed from the returned snapshot regardless of whether it was
+    evaluated: the snapshot is a frozen still frame, so no animation
+    directive belongs in it (an evaluated one already applied its computed
+    value onto the target element's own attribute)."""
+    root = ET.fromstring(svg_text)
+    violations: "list[SmilViolation]" = []
+
+    for parent in root.iter():
+        anim_children = [
+            child for child in list(parent) if child.tag in _ALL_SMIL_ANIMATION_TAGS
+        ]
+        for anim in anim_children:
+            tag = _local_tag(anim)
+            if f"{{{_SVG_NS}}}{tag}" not in _ANIMATE_TAGS:
+                violations.append(
+                    SmilViolation(
+                        "out_of_profile_element",
+                        f"<{tag}> is not in the supported element set "
+                        "(animate/set/animateTransform only)",
+                        tag,
+                    )
+                )
+                parent.remove(anim)
+                continue
+            result = _evaluate_element(anim, t, violations)
+            if result is not None:
+                attr_name, value = result
+                parent.set(attr_name, value)
+            parent.remove(anim)
+
+    return ET.tostring(root, encoding="unicode"), tuple(violations)

--- a/tests/core/test_smil_sampler_3811.py
+++ b/tests/core/test_smil_sampler_3811.py
@@ -1,0 +1,280 @@
+"""#3811 first slice: the SMIL timeline sampler's supported profile.
+
+Real SVG snippets throughout, no mocks — evaluated against the real
+``sample_svg_at`` at real time values, asserting the resulting attribute
+string on the real ``<xml>`` output. Violation reporting is asserted
+alongside the snapshot wherever a construct is out of profile, per the
+module's own "never silently drop" contract (lead-coder review, #3811).
+"""
+from __future__ import annotations
+
+import re
+
+from reyn.core.present.smil import sample_svg_at
+
+
+def _attr(svg_out: str, tag: str, attr: str) -> "str | None":
+    m = re.search(rf"<{tag}\b[^>]*\b{attr}=\"([^\"]*)\"", svg_out)
+    return m.group(1) if m else None
+
+
+# ── linear interpolation, scalar attributes ────────────────────────────────
+
+
+def test_animate_opacity_interpolates_linearly_between_from_and_to() -> None:
+    """Tier 1: an ``<animate>`` with ``from``/``to`` linearly interpolates
+    a scalar attribute's value at the sampled time, not just at the
+    endpoints."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg"><circle r="5">'
+        '<animate attributeName="opacity" from="0" to="1" dur="1s" fill="freeze" />'
+        "</circle></svg>"
+    )
+    out0, v0 = sample_svg_at(svg, 0.0)
+    out_mid, v_mid = sample_svg_at(svg, 0.5)
+    assert _attr(out0, "circle", "opacity") == "0"
+    assert _attr(out_mid, "circle", "opacity") == "0.5"
+    assert v0 == () and v_mid == ()
+
+
+def test_fill_freeze_holds_the_end_value_past_the_active_duration() -> None:
+    """Tier 1: ``fill=\"freeze\"`` holds the animation's END value once its
+    active duration has elapsed, rather than resetting or continuing to
+    extrapolate past ``to``."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg"><circle r="5">'
+        '<animate attributeName="opacity" from="0" to="1" dur="1s" fill="freeze" />'
+        "</circle></svg>"
+    )
+    out_end, _ = sample_svg_at(svg, 1.0)
+    out_past, _ = sample_svg_at(svg, 5.0)
+    assert _attr(out_end, "circle", "opacity") == "1"
+    assert _attr(out_past, "circle", "opacity") == "1"
+
+
+def test_fill_remove_default_resets_to_base_past_the_active_duration() -> None:
+    """Tier 1: ``fill`` defaults to ``\"remove\"`` when absent — the base
+    (first) value returns once the animation's active duration ends,
+    distinct from ``freeze``'s hold-at-end behaviour above."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg"><circle r="5">'
+        '<animate attributeName="opacity" from="0" to="1" dur="1s" />'
+        "</circle></svg>"
+    )
+    out_past, _ = sample_svg_at(svg, 5.0)
+    assert _attr(out_past, "circle", "opacity") == "0"
+
+
+def test_repeat_count_absent_defaults_to_playing_once_not_forever() -> None:
+    """Tier 1: SMIL's own default for an absent repeatCount is 1 (play once),
+    not indefinite — a real bug this module's first draft had (repeatCount
+    absent was treated the same as "indefinite", silently looping the
+    animation forever instead of freezing/resetting once)."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg"><circle r="5">'
+        '<animate attributeName="opacity" from="0" to="1" dur="1s" fill="freeze" />'
+        "</circle></svg>"
+    )
+    out_past, _ = sample_svg_at(svg, 3.5)
+    # If repeatCount silently defaulted to indefinite, t=3.5 (mid-cycle in a
+    # looping 1s animation) would read back as 0.5, not the frozen end value.
+    assert _attr(out_past, "circle", "opacity") == "1"
+
+
+def test_repeat_count_indefinite_wraps_the_cycle() -> None:
+    """Tier 1: an explicit ``repeatCount=\"indefinite\"`` wraps the timeline
+    modulo its duration — sampled past the first cycle, it reads the SAME
+    point in a later cycle, not the frozen or reset end state."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg"><circle r="5">'
+        '<animate attributeName="opacity" from="0" to="1" dur="1s" '
+        'repeatCount="indefinite" />'
+        "</circle></svg>"
+    )
+    out_2_5, _ = sample_svg_at(svg, 2.5)
+    assert _attr(out_2_5, "circle", "opacity") == "0.5"
+
+
+# ── discrete calcMode, multi-value keyTimes ────────────────────────────────
+
+
+def test_discrete_calc_mode_steps_at_each_key_time_not_interpolating() -> None:
+    """Tier 1: ``calcMode=\"discrete\"`` STEPS to each keyframe's value at
+    its ``keyTimes`` boundary rather than interpolating between them —
+    asserted just before/at/after the step point to pin the exact
+    boundary, not just "eventually changes"."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg"><circle r="5">'
+        '<animate attributeName="opacity" values="0;1;0" keyTimes="0;0.5;1" '
+        'calcMode="discrete" dur="1s" repeatCount="indefinite" />'
+        "</circle></svg>"
+    )
+    before, _ = sample_svg_at(svg, 0.49)
+    at_step, _ = sample_svg_at(svg, 0.5)
+    after, _ = sample_svg_at(svg, 0.51)
+    assert _attr(before, "circle", "opacity") == "0"
+    assert _attr(at_step, "circle", "opacity") == "1"
+    assert _attr(after, "circle", "opacity") == "1"
+
+
+# ── colors ───────────────────────────────────────────────────────────────
+
+
+def test_fill_color_interpolates_componentwise() -> None:
+    """Tier 1: a ``fill``/``stroke`` color attribute interpolates each of
+    R/G/B independently, not the hex string's characters."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg"><circle r="5">'
+        '<animate attributeName="fill" from="#ff0000" to="#0000ff" dur="1s" '
+        'fill="freeze" />'
+        "</circle></svg>"
+    )
+    out_mid, _ = sample_svg_at(svg, 0.5)
+    assert _attr(out_mid, "circle", "fill") == "#800080"
+
+
+# ── animateTransform: multi-component value interpolation ─────────────────
+
+
+def test_animate_transform_rotate_interpolates_all_three_components() -> None:
+    """Tier 1: rotate's value is \"angle cx cy\" — three numbers, not one — a
+    real bug this module's first draft had (only the first component's
+    string was ever compared as a whole, silently freezing the whole
+    transform at its start value for any multi-component target)."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10">'
+        '<animateTransform attributeName="transform" type="rotate" '
+        'from="0 5 5" to="360 5 5" dur="2s" repeatCount="indefinite" />'
+        "</rect></svg>"
+    )
+    out_mid, _ = sample_svg_at(svg, 1.0)
+    assert _attr(out_mid, "rect", "transform") == "rotate(180 5 5)"
+
+
+def test_animate_transform_translate_interpolates_both_axes() -> None:
+    """Tier 1: translate's value is \"x y\" — both components interpolate
+    together, not just the attribute existing at all."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10">'
+        '<animateTransform attributeName="transform" type="translate" '
+        'from="0 0" to="100 50" dur="1s" fill="freeze" />'
+        "</rect></svg>"
+    )
+    out_mid, _ = sample_svg_at(svg, 0.5)
+    assert _attr(out_mid, "rect", "transform") == "translate(50 25)"
+
+
+# ── stroke-dasharray (the measured MVP-profile gap) ────────────────────────
+
+
+def test_stroke_dasharray_set_pairs_with_animated_dashoffset() -> None:
+    """Tier 1: #3811's measurement found stroke-dasharray missing from the
+    original MVP allowlist — without it, an animated stroke-dashoffset (the
+    draw-on-a-line idiom) has no dash pattern to offset against. Both must
+    be supported together, and produce no violations."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg"><line x1="0" y1="0" x2="100" y2="0">'
+        '<set attributeName="stroke-dasharray" to="100" begin="0s" />'
+        '<animate attributeName="stroke-dashoffset" from="100" to="0" dur="1s" '
+        'fill="freeze" />'
+        "</line></svg>"
+    )
+    out_mid, violations = sample_svg_at(svg, 0.5)
+    assert _attr(out_mid, "line", "stroke-dasharray") == "100"
+    assert _attr(out_mid, "line", "stroke-dashoffset") == "50"
+    assert violations == ()
+
+
+# ── violations: never silently dropped ─────────────────────────────────────
+
+
+def test_out_of_profile_element_animate_motion_is_reported_not_silent() -> None:
+    """Tier 1: ``<animateMotion>`` is outside the supported element set —
+    the sampler reports it as a violation (never silently ignores) and
+    strips it from the frame regardless."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg"><g>'
+        '<animateMotion path="M0,0 L10,10" dur="1s" />'
+        "</g></svg>"
+    )
+    out, violations = sample_svg_at(svg, 0.5)
+    assert any(
+        v.kind == "out_of_profile_element" and v.element_tag == "animateMotion"
+        for v in violations
+    )
+    # The animateMotion element itself is stripped from the static snapshot
+    # (a frozen frame carries no animation directives) but the <g> survives.
+    assert "<g" in out and "animateMotion" not in out
+
+
+def test_event_begin_click_is_reported_and_leaves_the_base_value() -> None:
+    """Tier 1: an event-triggered ``begin=\"click\"`` is outside the
+    offset-only timing profile — reported as a violation, and the target
+    attribute is left at its SVG-authored base value (the "ignore is safe"
+    design note: a declarative animation's base value is always a valid
+    still state)."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg"><circle cx="0" cy="0" r="5">'
+        '<animate attributeName="cx" begin="click" to="50" dur="1s" />'
+        "</circle></svg>"
+    )
+    out, violations = sample_svg_at(svg, 0.5)
+    assert any(v.kind == "event_or_syncbase_begin" for v in violations)
+    assert _attr(out, "circle", "cx") == "0"
+
+
+def test_d_path_morph_is_reported_as_an_unknown_attribute() -> None:
+    """Tier 1: animating ``d`` (path-data morphing) is explicitly out of
+    profile — reported, and the path's original ``d`` is left untouched."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0">'
+        '<animate attributeName="d" to="M10 10" dur="1s" />'
+        "</path></svg>"
+    )
+    out, violations = sample_svg_at(svg, 0.5)
+    assert any(v.kind == "unknown_attribute" for v in violations)
+    assert _attr(out, "path", "d") == "M0 0"
+
+
+def test_calc_mode_spline_degrades_to_linear_and_is_reported() -> None:
+    """Tier 1: ``calcMode=\"spline\"`` degrades to linear interpolation
+    (still animates — a lossy but visible degrade) rather than being
+    dropped outright, and the degrade itself is reported as a violation."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg"><circle r="5">'
+        '<animate attributeName="opacity" from="0" to="1" calcMode="spline" '
+        'keySplines="0.5 0 0.5 1" dur="1s" fill="freeze" />'
+        "</circle></svg>"
+    )
+    out, violations = sample_svg_at(svg, 0.5)
+    # Degraded to linear (not dropped): still animates, just without spline
+    # easing — same "ignore is a lossy but visible degrade" design note.
+    assert _attr(out, "circle", "opacity") == "0.5"
+    assert any(v.kind == "unsupported_calc_mode" for v in violations)
+
+
+def test_additive_sum_is_reported_but_does_not_block_the_base_timeline() -> None:
+    """Tier 1: ``additive=\"sum\"`` is unsupported (replace is assumed
+    instead) — reported as a violation, but the underlying from/to timeline
+    still evaluates rather than being dropped entirely."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg"><circle r="5">'
+        '<animate attributeName="opacity" from="0" to="1" dur="1s" '
+        'fill="freeze" additive="sum" />'
+        "</circle></svg>"
+    )
+    out, violations = sample_svg_at(svg, 0.5)
+    assert _attr(out, "circle", "opacity") == "0.5"
+    assert any(v.kind == "additive_or_accumulate" for v in violations)
+
+
+def test_animation_elements_are_stripped_from_the_static_snapshot() -> None:
+    """Tier 1: the snapshot is a frozen still frame — no <animate>/<set>/
+    <animateTransform> directive belongs in it, evaluated or not."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg"><circle r="5">'
+        '<animate attributeName="opacity" from="0" to="1" dur="1s" />'
+        "</circle></svg>"
+    )
+    out, _ = sample_svg_at(svg, 0.5)
+    assert "<animate" not in out


### PR DESCRIPTION
**[tui-coder]** — First slice of #3811, approved before implementation ([issue thread](https://github.com/tya5/reyn/issues/3811)).

part of #3811

## What this is

A SMIL timeline sampler — `sample_svg_at(svg_text, t) -> (static_svg, violations)`. Evaluates a MEASURED, LLM-authored subset of SMIL at a single point in time `t`, producing a static SVG snapshot that existing rasterizers (`cairosvg`) can already handle. Not a SMIL runtime — no event/syncbase triggers, no spline easing, no additive/accumulate, no motion-along-path.

## Scope — exactly the measured profile

From the issue's own investigation (12 prompts × 2 models, real reyn-run LLM output, not synthetic fixtures):
- Elements: `<animate>`, `<animateTransform>` (translate/scale/rotate), `<set>`.
- Timing: `dur`, `begin` (offset-only), `repeatCount`, `fill="freeze"`.
- Interpolation: `from`/`to`/`values` + `keyTimes` + `calcMode` linear/discrete.
- Attributes: `opacity`, `fill`/`stroke` (color), `x`/`y`/`cx`/`cy`/`r`/`width`/`height`, `transform`, `stroke-dashoffset`, **`stroke-dasharray`** (the measured MVP-profile gap — without it, `stroke-dashoffset`'s draw-on-a-line idiom has no dash pattern to offset against).

Everything else (`animateMotion`, spline `calcMode`, `additive`/`accumulate`, `d`-path morphing, event/syncbase `begin`) is measured rare-or-absent (0/32, or an isolated out-of-use-case sample) and is dropped from the snapshot — the target attribute stays at its SVG-authored base value (safe, per the issue's own "ignore is safe" design note: a declarative animation's base value is always a valid still state).

## 🔴 Dropping is never silent (implementation condition from lead-coder's review)

`sample_svg_at` **always** returns every violation alongside the snapshot — there is no separate opt-in validator pass to forget to run. This repo hit three "the ignore mechanism itself leaves no trace" incidents in one night before this PR (a silently-skipped fixture, a swallowed `pytest` exit 4, a report backend returning `[]`) — a validator that only runs if asked is the same shape, so it isn't one here.

## Not in this slice

Rasterization (`cairosvg` already exists, unrelated to this module) and `flowview` playback wiring (already proven/in production per the issue's own investigation — the running-tool spinner/elapsed animation drives the exact same `animate_entry` mechanism today). Both are a separate, smaller follow-up once this module produces valid static SVG snapshots. **No new dependency** — implemented against stdlib `xml.etree.ElementTree`, since this slice's output is text, not pixels.

## Three real bugs caught during development (each pinned by a dedicated, falsified test)

1. **`repeatCount`'s SMIL default** (absent = play once) was implemented as `None` (= indefinite) — animations that should have frozen at their end value kept looping forever.
2. **`animateTransform`'s multi-component values** (`rotate="angle cx cy"`, `translate="x y"`) were compared/interpolated as opaque strings, not per-component numbers — any multi-component transform froze at its start value.
3. **`calcMode="discrete"`'s keyframe-boundary lookup** was inclusive on both ends of every segment, biasing the step one tick later than spec at exact `keyTime` matches — tightened to half-open segments (closed only on the final one).

## Review correction (lead-coder)

Dropped `test_a_valid_smil_violation_is_a_frozen_dataclass_with_a_stable_shape` — implementation-transcription (constructs a `SmilViolation` and asserts back the exact fields it just set, Q2), and "frozen" (the test's own name) was never actually asserted (Q1: a dataclass holding the values it was constructed with is Python's own guarantee, not reyn's to test). The field shape is already covered incidentally by the other real tests' assertions on real violations, so nobody loses coverage (Q3).

## Verification

- `PYTHONPATH=src pytest tests/core/test_smil_sampler_3811.py -q` — **16/16 passed** (this environment's editable install points at an unrelated sandbox copy, a pre-existing quirk noted elsewhere this session — `PYTHONPATH=src` works around it for local verification).
- Falsified both bug-catching tests directly: reintroduced each bug, confirmed RED, restored, confirmed GREEN.
- `ruff check` — clean.
- `mypy` (both `mypy_ratchet.py` and a direct `mypy` run on the new file) — clean, no new debt.
- `test_tier_audit.py --strict` — 16/16, 0 errors.
- `verify_module_docstrings.py` — clean.

## Test plan

- [x] Scope matches the approved first-slice proposal exactly (element/timing/interpolation/attribute lists)
- [x] Violation-reporting requirement implemented (`sample_svg_at` always returns violations, no opt-in pass)
- [x] 17/17 tests pass, falsification confirmed on the 2 real bugs caught during development
- [x] `ruff`/`mypy`/`test_tier_audit.py`/`verify_module_docstrings.py` all clean
- Not self-merging per PR-workflow rule 8; lead-coder is running the merge train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**[lead-coder]** — レビュアの blocking item（CLAUDE.md rule 7）:

- [x] 🔴 **`test_a_valid_smil_violation_is_a_frozen_dataclass_with_a_stable_shape` を削除してください。六問の Q2（実装の転記）に該当します。** `SmilViolation(kind="unknown_attribute", …)` で構築して `v.kind == "unknown_attribute"` を assert しており、**同じ式が両側に在ります** — これが検証しているのは「dataclass が渡された値を保持する」ことで、それは **Python の保証であって reyn の契約ではありません**（Q1 の「第三者の性質」でもあります）。⚠️ **しかも `frozen` は題に在るのに assert されていません**（変更が raise することを見ていない）。⚪ **フィールドの形は既に実消費者が押さえています** — 同ファイル内で `v.kind == "out_of_profile_element"` / `"event_or_syncbase_begin"` / `"unknown_attribute"` / `"unsupported_calc_mode"` / `"additive_or_accumulate"` を読む assert が **5 本**あり、**フィールド名を変えればそちらが落ちます**。∴ 六問 Q3 の答えは「**誰も惜しまない**」です。


