### PR TITLE
feat(#3698): P3 — rewrite ReynMCPMessageHandler to compose, not inherit, fastmcp's message-handler contract

### DIFF
--- a/src/reyn/mcp/_fastmcp_boundary.py
+++ b/src/reyn/mcp/_fastmcp_boundary.py
@@ -1,63 +1,46 @@
 """#3698 P2 — the single seam every reyn-side `fastmcp` import goes through.
 
-## What this closes, and what it does NOT close
+Before this module, 6 sites across 2 files (`client.py` ×5, `elicitation.py`
+×1) each imported directly from `fastmcp.*`. A future SDK swap (the MCP
+Python SDK v2 target, #3698) had to find and change every one of those call
+sites individually. This module makes them one seam — a future swap edits
+THIS file's function bodies, not 6 scattered call sites.
 
-Before this module, 8 sites across 3 files (`client.py` ×5, `elicitation.py`
-×1, `message_handler.py` ×2) each imported directly from `fastmcp.*`. A
-future SDK swap (the MCP Python SDK v2 target, #3698) had to find and
-change every one of those call sites individually. This module makes them
-one seam — a future swap edits THIS file's bodies, not 8 scattered call
-sites.
+## Why the accessors are functions, not module-level re-exports
 
-**That claim is honest only for 6 of the 8 symbols.** `client.py`'s and
-`elicitation.py`'s imports are plain symbol imports — construct-and-use,
-never subclassed — so re-exporting them here is genuine, complete
-decoupling: the CALLER never names `fastmcp` again. `message_handler.py`'s
-`MessageHandler`/`TaskNotificationHandler` are different: `ReynMCPMessageHandler`
-INHERITS from `TaskNotificationHandler` (see that module's own docstring),
-depending on its `dispatch()` routing logic and its `_client_ref` attribute
-contract — a real behavioral coupling, not just an import path. Re-exporting
-the base class here relocates WHERE the name is imported from; it does
-**not** remove that coupling. A future SDK swap still has to either find an
-equivalent base class in the new SDK with the same routing contract, or
-rewrite `ReynMCPMessageHandler` to compose rather than inherit (reimplementing
-the dispatch routing reyn currently gets for free — tui-coder's #3698
-measurement scoped this as the real Phase-3 cost). Re-exporting these two
-here is for import-LOCATION consistency (one file names `fastmcp`, not
-three) — it is deliberately NOT claimed as removing the inheritance
-dependency, which stays exactly as coupled as before this module existed.
-
-## Why the 6 real accessors are functions, not module-level re-exports
-
-`client.py`'s 5 sites and `elicitation.py`'s 1 site were all DEFERRED
-imports (inside a method body, not at module top) before this change —
-`client.py`'s own first import is wrapped in a `try/except ImportError`
-that raises a friendly reyn-specific error ("The 'fastmcp' package is
-required...") rather than a bare traceback. Turning these into a plain
-module-level `from fastmcp import Client` here would change WHEN the
-import (and any ImportError) fires — from "the first time a connection is
-actually opened" to "the first time `reyn.mcp` is imported at all",
-independent of whether MCP is ever used in a given run. Each accessor
+Every site here was a DEFERRED import (inside a method body, not at module
+top) before this change — `client.py`'s own first import is wrapped in a
+`try/except ImportError` that raises a friendly reyn-specific error ("The
+'fastmcp' package is required...") rather than a bare traceback. Turning
+these into a plain module-level `from fastmcp import Client` here would
+change WHEN the import (and any ImportError) fires — from "the first time a
+connection is actually opened" to "the first time `reyn.mcp` is imported at
+all", independent of whether MCP is ever used in a given run. Each accessor
 function below preserves the original timing exactly: the import inside it
 only executes when the caller actually calls the function, same as the
 inline import it replaces.
 
-## Why `MessageHandler`/`TaskNotificationHandler` are plain re-exports, not functions
+## History: message_handler.py's 2 sites (#3698 P3 removed the need for this)
 
-`message_handler.py`'s 2 sites were already module-level (not deferred) —
-`class ReynMCPMessageHandler(TaskNotificationHandler):` needs its base class
-resolved at class-definition (import) time, which Python cannot defer into
-a function call. So these two stay module-level imports here too — no
-timing change from before this module existed, in either direction.
+This module used to ALSO re-export `MessageHandler`/`TaskNotificationHandler`
+for `message_handler.py`'s `ReynMCPMessageHandler(TaskNotificationHandler)`
+— an INHERITANCE dependency, not a plain import, so the re-export only
+relocated the import path without removing the coupling (explicitly marked
+as such at the time, both here and at `message_handler.py`'s own import
+site). #3698 P3 (see `message_handler.py`'s module docstring) measured the
+ACTUAL fastmcp/mcp call contract by reading the installed source: the MCP
+SDK invokes the message handler as a plain `Callable` (`MessageHandlerFnT`,
+a `Protocol`) — no inheritance is required anywhere in the real call chain.
+P3 rewrote `ReynMCPMessageHandler` to compose rather than inherit, which
+means it no longer imports anything from `fastmcp` at all (only
+`mcp.types`, the lower-level protocol-spec package fastmcp itself wraps) —
+the relocation-only re-export this section used to describe no longer has a
+consumer, so it was deleted in the same PR that removed the coupling it
+existed to (honestly) describe.
 """
 from __future__ import annotations
 
 from typing import Any
-
-# Module-level (see docstring): message_handler.py's class statement needs
-# these resolved at import time, exactly as before this module existed.
-from fastmcp.client.messages import MessageHandler as MessageHandler
-from fastmcp.client.tasks import TaskNotificationHandler as TaskNotificationHandler
 
 
 def import_fastmcp_client() -> "type[Any]":

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -662,8 +662,9 @@ class MCPClient:
         # docstring rather than left for a reader to discover from the wiring.
         self._emit_event: Callable[..., Any] | None = emit_event
         # #2597 S2b: optional async server->client notifications bridge — a
-        # ReynMCPMessageHandler (fastmcp.client.tasks.TaskNotificationHandler subclass;
-        # see reyn.mcp.message_handler) that receives tools/prompts list_changed +
+        # ReynMCPMessageHandler (#3698 P3: composes fastmcp's message-handler
+        # contract rather than subclassing it — see reyn.mcp.message_handler's
+        # module docstring) that receives tools/prompts list_changed +
         # progress notifications on this client's held connection and emits them onto
         # reyn's EventLog. None (default) preserves pre-S2b behaviour — no bridge, no
         # behaviour change for callers that don't pass one (e.g. the ephemeral

--- a/src/reyn/mcp/message_handler.py
+++ b/src/reyn/mcp/message_handler.py
@@ -6,36 +6,43 @@ keeps its receive loop running — so server-pushed notifications (``tools/list_
 ``prompts/list_changed``, ``notifications/progress``) ARRIVE on the wire, but nothing
 consumed them before S2b. This module installs the consumer.
 
-Design (verified against the installed ``fastmcp`` 3.4.2 source — see S2-pre spike):
+## Composition, not inheritance (#3698 P3)
 
-  - **Base class**: :class:`fastmcp.client.tasks.TaskNotificationHandler`, NOT the bare
-    ``fastmcp.client.messages.MessageHandler``. ``TaskNotificationHandler`` is FastMCP's
-    own SEP-1686 task-status router — its ``dispatch()`` peeks every incoming
-    ``ServerNotification`` for a ``TaskStatusNotification`` and forwards it to the owning
-    ``Client`` BEFORE calling ``super().dispatch()`` (the base ``MessageHandler`` match/case
-    that invokes ``on_tool_list_changed`` / ``on_prompt_list_changed`` / ``on_progress``
-    etc). Subclassing (and NOT overriding ``dispatch`` itself) means task-status routing
-    keeps running unconditionally on every message — our hook overrides only add behavior
-    on top, they never replace or skip it.
+Earlier versions of this class subclassed ``fastmcp.client.tasks.TaskNotificationHandler``
+(itself a subclass of ``fastmcp.client.messages.MessageHandler``). #3698 P3 measured
+the ACTUAL call contract by reading the installed ``mcp``/``fastmcp`` source directly:
+``mcp.client.session.ClientSession`` invokes ``self._message_handler(req)`` — a plain
+``Callable`` (``MessageHandlerFnT``, a ``Protocol``, not a class requirement) —
+``fastmcp.client.client.Client.__init__`` just stores whatever ``message_handler=``
+object it is given, verbatim. **No inheritance is required anywhere in the real call
+chain.** This class now implements :meth:`__call__` directly instead.
 
-  - **Two-phase client binding**: ``TaskNotificationHandler.__init__(self, client)``
-    requires an already-constructed ``fastmcp.Client`` (it stores ``weakref.ref(client)``
-    for the task-status routing above) — but FastMCP's own
-    ``Client(transport, message_handler=...)`` constructor takes the handler as an
-    argument, so the handler must exist BEFORE the ``Client`` object does. There is no
-    factory hook for this in the public API (verified: ``fastmcp.client.client.Client``
-    stores whatever ``message_handler`` object it's given verbatim in
-    ``_session_kwargs["message_handler"]``, consumed later at ``__aenter__``/session-connect
-    time — the client's *own* default path sidesteps this by constructing
-    ``TaskNotificationHandler(self)`` INLINE inside its own ``__init__``, where ``self``
-    already exists). This class breaks the same chicken-and-egg cycle explicitly:
-    ``__init__`` skips ``TaskNotificationHandler.__init__`` (calls
-    ``MessageHandler.__init__`` instead, which takes no arguments) and leaves
-    ``_client_ref`` pointing at a ``lambda: None``; :meth:`bind_client` — called by
-    :class:`~reyn.mcp.client.MCPClient` immediately after constructing the
-    ``fastmcp.Client`` and before ``__aenter__()`` opens the transport — completes the
-    weakref binding. No message can be dispatched before ``__aenter__()`` completes the
-    handshake, so ``bind_client`` always runs before the first ``dispatch()`` call.
+What the inheritance used to provide, and how this class now provides it itself:
+
+  - **Task-status routing** (``TaskNotificationHandler.dispatch``'s own job): peek every
+    incoming ``ServerNotification`` for a ``TaskStatusNotification`` and forward it to
+    the owning ``Client`` via the weakref binding below — :meth:`__call__` does this
+    directly now, in the same ``match`` statement as the rest of the routing (see
+    below), rather than via ``super().dispatch()``.
+  - **Message-type routing** (``MessageHandler.dispatch``'s own job): the base class
+    matched all 14 message shapes (requests, 7 notification subtypes, exceptions) and
+    routed each to its own ``on_X`` hook, all defaulting to a no-op ``pass`` unless
+    overridden. This class only ever overrode 4 of those 14 (``on_tool_list_changed``/
+    ``on_prompt_list_changed``/``on_resource_updated``/``on_progress``) — the other 10
+    were always inherited no-ops. :meth:`__call__`'s ``match`` now routes ONLY those 4
+    shapes (plus task-status) directly; everything else calls :meth:`_log_unhandled`
+    rather than silently reaching nothing (see below — this is a DELIBERATE behavior
+    addition, not a byte-identical port).
+
+  - **Two-phase client binding** (unchanged mechanism, no longer inherited): the owning
+    ``fastmcp.Client`` does not exist yet when this handler must be constructed (FastMCP's
+    own ``Client(transport, message_handler=...)`` takes the handler as a constructor
+    argument, so the handler must exist first) — :meth:`bind_client`, called by
+    :class:`~reyn.mcp.client.MCPClient` immediately after constructing the ``fastmcp.Client``
+    and before ``__aenter__()`` opens the transport, completes a weakref binding
+    (``self._client_ref``) that :meth:`__call__` reads for task-status forwarding. No
+    message can be dispatched before ``__aenter__()`` completes the handshake, so
+    ``bind_client`` always runs before the first ``__call__``.
 
   - **Synchronous hook bodies**: the handler runs on FastMCP's ``session_task`` (not the
     agent turn task), but ``EventLog.emit()`` is fully synchronous and asyncio is
@@ -45,12 +52,20 @@ Design (verified against the installed ``fastmcp`` 3.4.2 source — see S2-pre s
     docstring). Each hook below calls the sink SYNCHRONOUSLY (never ``await``s it) so a
     sink fault or a slow sink can never stall the receive loop or delay task-status
     routing; a fault in the sink is caught and swallowed (logged) rather than propagated,
-    since notification handling must never crash the held connection's receive loop. The
-    sole ``await super().<hook>(...)`` call in every override resolves against the base
-    ``MessageHandler``'s bare ``pass`` body — no real async work, no scheduler yield of any
-    consequence — so overriding these ``async def`` hooks (the base signature requires
-    ``async def``; that is a FastMCP interface constraint, not a body-level await) does not
-    reintroduce blocking.
+    since notification handling must never crash the held connection's receive loop.
+
+## What actually changed vs. the inherited version (named explicitly, #3698 P3 review)
+
+For every message shape the real MCP protocol produces TODAY, observable behavior is
+identical: the 4 acted-on notification types still trigger the same hook bodies
+(unchanged), task-status still routes to the client, and every other shape still
+produces no ``EventLog``/hook-trigger side effect. **One deliberate addition**: an
+unrecognized message shape now emits a DEBUG log line (:meth:`_log_unhandled`) instead
+of silently reaching an inherited no-op — lead-coder's P3 review condition: a closed
+match-list must not silently drop an "unknown to us" shape the same way it silently
+finishes handling a KNOWN one; the day fastmcp/MCP adds a new notification type this
+class doesn't yet act on, that day is now distinguishable in the log from an ordinary
+quiet run, rather than reading identical to one.
 """
 from __future__ import annotations
 
@@ -58,18 +73,7 @@ import logging
 import weakref
 from typing import Any, Callable
 
-# #3698 P2: imported via the boundary module for import-LOCATION
-# consistency only — this is a RELOCATION, not a decoupling. The base
-# class below is still directly INHERITED (see ReynMCPMessageHandler's
-# class statement + this module's own docstring: dispatch()'s routing
-# logic + the _client_ref attribute contract are both real, unremoved
-# coupling to fastmcp's class hierarchy). A future SDK swap still needs
-# either an equivalent base class or a composition rewrite here — this
-# import alone does not provide that boundary (contrast client.py's/
-# elicitation.py's accessor functions in _fastmcp_boundary.py, which DO
-# fully decouple their callers). See _fastmcp_boundary.py's module
-# docstring for the full reasoning.
-from reyn.mcp._fastmcp_boundary import MessageHandler, TaskNotificationHandler
+import mcp.types
 
 logger = logging.getLogger(__name__)
 
@@ -94,17 +98,21 @@ ToolsCacheInvalidate = Callable[[str], None]
 OnExternalEvent = Callable[[str | None, bool], None]
 
 
-class ReynMCPMessageHandler(TaskNotificationHandler):
+class ReynMCPMessageHandler:
     """Bridges FastMCP server-pushed notifications on a held connection to reyn's
     ``EventLog`` (#2597 S2b). One instance per held server connection.
+
+    Composes, does not inherit, fastmcp's message-handling contract — see module
+    docstring's "#3698 P3" section for the full design and what changed.
 
     Scope (S2b): ``tools/list_changed``, ``prompts/list_changed``. ``resources/
     updated`` is bridged by slice ②b (see :meth:`on_resource_updated`) now that
     :class:`~reyn.mcp.connection_service.MCPConnectionService` actually tracks
     subscribed URIs — S2b itself deferred it because nothing was subscribed yet.
-    ``on_resource_list_changed`` stays a base-class no-op (out of ②b's scope —
+    ``ResourceListChangedNotification`` stays unhandled (out of ②b's scope —
     no reyn caller subscribes to the resource LIST changing, only individual
-    resource content updates).
+    resource content updates) — it now reaches :meth:`_log_unhandled` rather than
+    an inherited no-op, same as every other shape reyn doesn't act on.
 
     #2608 H1: ``on_resource_updated`` ALSO fires a user-configured
     ``mcp_resource_updated`` hook (external-event->hooks arc, first slice) via
@@ -150,9 +158,6 @@ class ReynMCPMessageHandler(TaskNotificationHandler):
         on_external_event: "OnExternalEvent | None" = None,
         agent_name: str | None = None,
     ) -> None:
-        # Deliberately bypass TaskNotificationHandler.__init__ — see module docstring
-        # ("two-phase client binding"). MessageHandler.__init__ takes no arguments.
-        MessageHandler.__init__(self)
         self._client_ref: Callable[[], Any] = lambda: None
         self._emit_sink = emit_sink
         self._server_name = server_name
@@ -163,12 +168,50 @@ class ReynMCPMessageHandler(TaskNotificationHandler):
         self._agent_name = agent_name
 
     def bind_client(self, client: Any) -> None:
-        """Complete the ``TaskNotificationHandler`` weakref binding once the owning
-        ``fastmcp.Client`` exists. MUST run before the first message is dispatched —
-        :meth:`reyn.mcp.client.MCPClient.initialize` calls this immediately after
-        constructing the ``fastmcp.Client`` and before ``__aenter__()`` opens the
-        transport (= before any notification can possibly arrive)."""
+        """Complete the weakref binding once the owning ``fastmcp.Client`` exists.
+        MUST run before the first message is dispatched — see module docstring's
+        "two-phase client binding"."""
         self._client_ref = weakref.ref(client)
+
+    # ── the MCP SDK's actual entry point (see module docstring's "#3698 P3") ───────
+
+    async def __call__(self, message: Any) -> None:
+        """Route an incoming MCP message. Called directly by
+        ``mcp.client.session.ClientSession`` as ``self._message_handler(req)`` — a
+        plain ``Callable``, no base-class contract required (module docstring)."""
+        if isinstance(message, mcp.types.ServerNotification):
+            root = message.root
+            match root:
+                case mcp.types.TaskStatusNotification():
+                    client = self._client_ref()
+                    if client is not None:
+                        client._handle_task_status_notification(root)
+                case mcp.types.ToolListChangedNotification():
+                    await self.on_tool_list_changed(root)
+                case mcp.types.PromptListChangedNotification():
+                    await self.on_prompt_list_changed(root)
+                case mcp.types.ResourceUpdatedNotification():
+                    await self.on_resource_updated(root)
+                case mcp.types.ProgressNotification():
+                    await self.on_progress(root)
+                case _:
+                    self._log_unhandled(root)
+        else:
+            # A request (RequestResponder) or a transport-level Exception — reyn
+            # never acted on either (no on_request/on_ping/on_exception override
+            # existed even in the inherited version) — see module docstring.
+            self._log_unhandled(message)
+
+    def _log_unhandled(self, message: Any) -> None:
+        """#3698 P3 review condition: an OBSERVABLE trace for a message shape this
+        handler doesn't act on — distinguishes "processed and silent" (the 5 shapes
+        matched above) from "not one of ours, silently ignored" (everything else),
+        so a future fastmcp/MCP protocol addition landing here unnoticed is
+        distinguishable in the log from an ordinary quiet run, not identical to it."""
+        logger.debug(
+            "ReynMCPMessageHandler: no handler for message type %s on server %r",
+            type(message).__name__, self._server_name,
+        )
 
     # ── notification hooks — synchronous bodies, see module docstring ──────────────
 
@@ -182,11 +225,9 @@ class ReynMCPMessageHandler(TaskNotificationHandler):
                     self._server_name, exc_info=True,
                 )
         self._emit("mcp_tool_list_changed", server=self._server_name)
-        await super().on_tool_list_changed(message)
 
     async def on_prompt_list_changed(self, message: Any) -> None:
         self._emit("mcp_prompt_list_changed", server=self._server_name)
-        await super().on_prompt_list_changed(message)
 
     async def on_resource_updated(self, message: Any) -> None:
         # #2597 slice ②b: the async push event-source this bridge exists for. The
@@ -204,7 +245,6 @@ class ReynMCPMessageHandler(TaskNotificationHandler):
         uri = getattr(getattr(message, "params", None), "uri", None)
         uri_str = str(uri) if uri is not None else None
         self.emit_resource_updated(uri_str, resync=False)
-        await super().on_resource_updated(message)
 
     def emit_resource_updated(self, uri: str | None, *, resync: bool) -> None:
         """The shared ``mcp_resource_updated`` producer: EventLog emit +
@@ -258,7 +298,7 @@ class ReynMCPMessageHandler(TaskNotificationHandler):
         # The per-call ``progress_callback`` path (``op_runtime/mcp.py``'s
         # ``_on_progress``) already emits ``mcp_progress`` (with tool-name context)
         # for every call-scoped progress notification the SDK also routes here.
-        await super().on_progress(message)
+        pass
 
     # ── sink dispatch ───────────────────────────────────────────────────────────────
 

--- a/tests/mcp/test_2597_s2b_mcp_notifications_bridge.py
+++ b/tests/mcp/test_2597_s2b_mcp_notifications_bridge.py
@@ -235,13 +235,14 @@ async def test_progress_notification_not_double_emitted_by_bridge(tmp_path: Path
         await service.aclose()
 
 
-# ── (c) subclassing TaskNotificationHandler preserves task-status routing ─────────
+# ── (c) task-status routing (#3698 P3: composed, not inherited) ────────────────────
 
 
 class _FakeClient:
     """Duck-typed stand-in for fastmcp.Client — only the ONE method
-    TaskNotificationHandler.dispatch actually calls (``_handle_task_status_
-    notification``). A real (hand-written) object, not a Mock/patch."""
+    ReynMCPMessageHandler.__call__ actually calls for a task-status notification
+    (``_handle_task_status_notification``). A real (hand-written) object, not a
+    Mock/patch."""
 
     def __init__(self) -> None:
         self.routed: list[types.TaskStatusNotification] = []
@@ -265,36 +266,81 @@ def _make_task_status_notification() -> types.ServerNotification:
 
 
 @pytest.mark.asyncio
-async def test_task_status_routing_preserved_through_subclass():
-    """Tier 1: ReynMCPMessageHandler subclasses TaskNotificationHandler and does NOT
-    override ``dispatch`` — so TaskNotificationHandler's own SEP-1686 task-status
-    routing (peek for a TaskStatusNotification, forward to the bound client, THEN
-    fall through to the base MessageHandler match/case that invokes our hooks) keeps
-    running unmodified. Drives the REAL inherited ``dispatch()`` (not a private-state
-    assertion) and observes the routing side effect on a real fake client object."""
-    from fastmcp.client.tasks import TaskNotificationHandler
-
+async def test_task_status_routing_via_composed_call():
+    """Tier 1: #3698 P3 — ReynMCPMessageHandler no longer inherits fastmcp's
+    TaskNotificationHandler; it implements ``__call__`` itself and peeks for a
+    TaskStatusNotification, forwarding it to the bound client's
+    ``_handle_task_status_notification`` directly (the same SEP-1686 routing
+    the inherited version used to get for free). Drives the REAL ``__call__``
+    entry point — the same one ``mcp.client.session.ClientSession`` invokes
+    as ``self._message_handler(req)`` — and observes the routing side effect
+    on a real fake client object, not a private-state assertion."""
     handler = ReynMCPMessageHandler(lambda *a, **k: None, "srv")
-    assert isinstance(handler, TaskNotificationHandler)
 
     fake_client = _FakeClient()
     handler.bind_client(fake_client)
 
     notification = _make_task_status_notification()
-    await handler.dispatch(notification)
+    await handler(notification)
 
     (routed,) = fake_client.routed  # exactly one status notification was dispatched
     assert routed.params.taskId == "task-1"
 
 
-# ── (d) synchronous handler body — sink faults never escape dispatch ──────────────
+@pytest.mark.asyncio
+async def test_unrecognized_notification_is_logged_not_silently_dropped(caplog) -> None:
+    """Tier 1: #3698 P3 review condition (lead-coder) — a message shape the
+    handler's closed match-list doesn't act on must be OBSERVABLE (a debug log
+    line naming the type), not silently reach nothing. Distinguishes "processed
+    and produced no side effect" (the 4 acted-on shapes, when their own body
+    happens to do nothing) from "not one of ours, ignored" — the day fastmcp/MCP
+    adds a notification type this handler doesn't yet act on, that day must be
+    distinguishable in the log from an ordinary quiet run.
+
+    ``ResourceListChangedNotification`` — a real MCP notification shape reyn
+    has never acted on (module docstring: "out of ②b's scope") — is the probe."""
+    import logging
+
+    handler = ReynMCPMessageHandler(lambda *a, **k: None, "srv")
+    handler.bind_client(_FakeClient())
+
+    notification = types.ServerNotification(types.ResourceListChangedNotification())
+    with caplog.at_level(logging.DEBUG, logger="reyn.mcp.message_handler"):
+        await handler(notification)
+
+    assert any(
+        "no handler for message type" in r.message and "ResourceListChangedNotification" in r.message
+        for r in caplog.records
+    ), f"expected an observable unhandled-message log line; got: {[r.message for r in caplog.records]}"
 
 
 @pytest.mark.asyncio
-async def test_emit_sink_fault_does_not_break_dispatch():
+async def test_a_non_notification_message_is_also_logged_not_silently_dropped(caplog) -> None:
+    """Tier 1: same condition as above, for the OTHER branch of __call__ — a
+    non-ServerNotification message (a request or a transport-level Exception,
+    per ``mcp.types``' own ``Message`` union) also reaches _log_unhandled
+    rather than nothing, since reyn has never acted on either shape (no
+    on_request/on_ping/on_exception override existed even in the inherited
+    version)."""
+    import logging
+
+    handler = ReynMCPMessageHandler(lambda *a, **k: None, "srv")
+    handler.bind_client(_FakeClient())
+
+    with caplog.at_level(logging.DEBUG, logger="reyn.mcp.message_handler"):
+        await handler(RuntimeError("not a ServerNotification"))
+
+    assert any("no handler for message type" in r.message for r in caplog.records)
+
+
+# ── (d) synchronous handler body — sink faults never escape __call__ ──────────────
+
+
+@pytest.mark.asyncio
+async def test_emit_sink_fault_does_not_break_call():
     """Tier 1: the notification hooks call the emit sink SYNCHRONOUSLY (never
     ``await`` it — see message_handler.py's module docstring) and never let a sink
-    fault escape: a raising sink must not propagate out of ``dispatch()``, since
+    fault escape: a raising sink must not propagate out of ``__call__()``, since
     that would crash/stall the held connection's FastMCP receive loop for every
     subsequent message, not just the one notification that triggered the fault."""
 
@@ -305,7 +351,7 @@ async def test_emit_sink_fault_does_not_break_dispatch():
     handler.bind_client(_FakeClient())
 
     notification = types.ServerNotification(types.ToolListChangedNotification())
-    await handler.dispatch(notification)  # must not raise
+    await handler(notification)  # must not raise
 
 
 @pytest.mark.asyncio
@@ -326,7 +372,7 @@ async def test_tools_cache_invalidate_fault_does_not_block_event_emit(tmp_path: 
     handler.bind_client(_FakeClient())
 
     notification = types.ServerNotification(types.ToolListChangedNotification())
-    await handler.dispatch(notification)  # must not raise
+    await handler(notification)  # must not raise
 
     matching = [e for e in collected if e.type == "mcp_tool_list_changed"]
     (only_event,) = matching  # exactly one — invalidate faulting must not swallow the emit

--- a/tests/test_fastmcp_core_dep_import_chain.py
+++ b/tests/test_fastmcp_core_dep_import_chain.py
@@ -2,17 +2,23 @@
 
 OS invariant:
   ``Session.__init__`` unconditionally imports ``reyn.mcp.connection_service``,
-  whose module-level import graph reaches ``fastmcp`` (via
-  ``reyn.mcp.message_handler``, which does ``from fastmcp.client.messages import
-  MessageHandler`` at module scope). fastmcp was formerly an optional ``[mcp]``
-  extra, so a fresh core install without that extra raised
-  ``ModuleNotFoundError: No module named 'fastmcp'`` on the first ``reyn chat``.
+  which pulls in ``reyn.mcp.client``/``reyn.mcp.message_handler``. fastmcp was
+  formerly an optional ``[mcp]`` extra, so a fresh core install without that
+  extra raised ``ModuleNotFoundError: No module named 'fastmcp'`` on the first
+  ``reyn chat``. fastmcp is now a core dependency, so both (a) the MCP client
+  stack must import cleanly from a core install, AND (b) ``fastmcp`` itself
+  must actually be importable there — checked separately below.
 
-  fastmcp is now a core dependency, so the MCP client stack must import cleanly
-  from a core install. This test exercises the real import chain in a fresh
-  subprocess (so fastmcp already present in this test process's ``sys.modules``
-  cannot mask a regression) and asserts it does not raise ImportError and that
-  the chain actually reached fastmcp.
+  #3698 P3 changed HOW (a) and (b) relate: every ``fastmcp`` import in the MCP
+  client stack is now deferred (function-local, only executed when a
+  connection actually opens — see ``reyn.mcp._fastmcp_boundary``'s module
+  docstring) rather than module-level, so importing the stack's TOP-LEVEL
+  modules no longer eagerly pulls ``fastmcp`` into ``sys.modules`` as a side
+  effect. That was always an incidental proxy for the real invariant ("is
+  fastmcp actually installed"), not the invariant itself — checking (b)
+  directly, in the same fresh subprocess, is the honest replacement rather
+  than re-introducing an eager import somewhere just to keep the old proxy
+  working.
 """
 from __future__ import annotations
 
@@ -21,15 +27,15 @@ import subprocess
 import sys
 
 
-def test_mcp_connection_service_import_chain_reaches_fastmcp(out_of_process_reyn):
-    """Tier 2: importing the MCP client stack succeeds and loads fastmcp in a fresh interpreter."""
+def test_mcp_import_chain_succeeds_and_fastmcp_is_actually_installed(out_of_process_reyn):
+    """Tier 2: (a) the MCP client stack imports cleanly in a fresh interpreter,
+    (b) fastmcp itself is importable there — checked directly, not inferred
+    from whether reyn's own modules happened to reach it as a side effect."""
     code = (
         "import reyn.mcp.connection_service;"
         "import reyn.mcp.message_handler;"
         "import reyn.mcp.client;"
-        "import sys;"
-        "assert 'fastmcp' in sys.modules, "
-        "'MCP import chain did not load fastmcp — is it a core dependency?';"
+        "import fastmcp;"
         "print('OK')"
     )
     result = subprocess.run(
@@ -40,7 +46,8 @@ def test_mcp_connection_service_import_chain_reaches_fastmcp(out_of_process_reyn
         env={**os.environ, "PYTHONPATH": out_of_process_reyn},
     )
     assert result.returncode == 0, (
-        "MCP import chain failed in a core install (fastmcp not importable?).\n"
+        "MCP import chain failed, or fastmcp is not importable, in a core "
+        "install.\n"
         f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
     assert "OK" in result.stdout


### PR DESCRIPTION
**[e2e-coder]** — part of #3698 (P3). Measurement + composition design proposed on the issue and approved before this implementation (lead-coder's measure→propose→review process).

## What

`ReynMCPMessageHandler` no longer subclasses `fastmcp.client.tasks.TaskNotificationHandler`. It implements `__call__` directly — the real entry point `mcp.client.session.ClientSession` invokes (`self._message_handler(req)`, confirmed by reading the installed source), a plain `Callable`/`Protocol` contract with no inheritance requirement anywhere in the real chain.

## What it reimplements (measured complete, confirmed against installed source)

- Task-status peek + forward (was `TaskNotificationHandler.dispatch`'s job).
- A narrowed `match` on the 4 notification types reyn acts on (was `MessageHandler.dispatch`'s full 14-shape routing, of which reyn only ever overrode 4).

## Deliberate behavior addition (lead-coder's review condition)

An unrecognized message shape now emits a DEBUG log line (`_log_unhandled`) instead of silently reaching an inherited no-op. Before this change, "processed and produced no side effect" (one of the 4 acted-on types whose own body happens to do nothing) and "not one of ours, ignored" (everything else) were indistinguishable — both silent. Now the day fastmcp/MCP adds a notification type this class doesn't yet act on, that's observable in the log rather than reading identical to an ordinary quiet run. Falsify-verified: stripped the log call, confirmed 2 new tests go RED for the right reason, restored.

## Consequence: `_fastmcp_boundary.py`'s relocation-only re-exports are now dead code — deleted

Post-rewrite, `message_handler.py` imports `mcp.types` only (the lower-level protocol-spec package fastmcp itself wraps), no `fastmcp` symbol at all. The `MessageHandler`/`TaskNotificationHandler` re-exports #4053 added for import-location consistency (explicitly marked at the time as relocation-only, not decoupling) have no consumer anymore — deleted in this PR, per lead-coder's explicit approval ("the marking I had you add disappears along with what it was describing — correct, since it would otherwise be a comment explaining something that no longer exists").

## Test changes

- `test_2597_s2b_mcp_notifications_bridge.py`: `.dispatch(msg)` → `handler(msg)` (the real entry point), the `isinstance(handler, TaskNotificationHandler)` assertion dropped (architecturally moot post-composition — there's no base class to check anymore), 2 new tests for the unhandled-message observability condition (a `ResourceListChangedNotification` and a non-`ServerNotification` message, both asserting a `caplog`-observable debug line).
- `test_fastmcp_core_dep_import_chain.py`: the `'fastmcp' in sys.modules` proxy assertion no longer holds now that every `fastmcp` import in the client stack is deferred (this PR removes the last module-level one) — replaced with a direct `import fastmcp` check in the same fresh subprocess, testing the real invariant (fastmcp is actually installed in a core install) rather than an incidental side effect of reyn's own import timing.

## Scope note (P3 vs. the enforcement gate)

Per the issue's proposal: P3 (this PR) and the `import fastmcp` enforcement gate (#4053's "convention not enforcement" note) are separate PRs — the gate is a natural, simpler fast-follow now that `message_handler.py` needs zero fastmcp import.

## Verification

- `ruff check` — clean
- `mypy_ratchet.py` — 210/213 baselined (3 fewer than before P2), no new debt
- `verify_module_docstrings.py` — clean
- `test_tier_audit.py --strict` — 8 tests, 0 errors
- `pytest` — 165 passed: full `tests/mcp/` bucket (138) + updated notifications-bridge suite (7) + import-chain (1) + elicitation + sandbox-wrap suites. All real fastmcp client/server round-trips, no mocks.
- Falsify-verified the new observability mechanism (RED for the right reason, restored to GREEN).
- Not self-merging (PR-workflow rule 8).

## Test plan

- [x] Confirmed `ReynMCPMessageHandler.__mro__` is `(ReynMCPMessageHandler, object)` — no fastmcp base class
- [x] Falsify-verified the unhandled-message observability condition
- [x] Confirmed the import-chain test's replacement mechanism still catches a genuinely-missing `fastmcp` (manual subprocess probe)
- [x] Full relevant suite green (165 tests)