### PR TITLE
feat(#3698): add the fastmcp-import enforcement gate

### DIFF
--- a/.github/workflows/fastmcp-import-boundary-gate.yml
+++ b/.github/workflows/fastmcp-import-boundary-gate.yml
@@ -1,0 +1,41 @@
+name: fastmcp-import-boundary gate
+
+# #3698: reject a direct `import fastmcp` anywhere under src/reyn/mcp/ except
+# _fastmcp_boundary.py (P2, #4053) — the single seam every reyn-side fastmcp
+# import goes through, so a future SDK swap edits one file's function
+# bodies, not scattered call sites. P2 landed the boundary as a CONVENTION,
+# explicitly not enforced (its own PR body said so); this gate is the
+# enforcement half, landed once P3 (#4055) removed the one remaining
+# inheritance-based exception. See scripts/check_fastmcp_import_boundary.py's
+# module docstring for the full design rationale (issue #3698).
+#
+# No diff/base-ref needed — a whole-directory scan against a baseline of
+# zero, same shape as file-depth-reference-gate.yml /
+# bare-tests-import-reference-gate.yml. A shallow checkout is enough.
+on:
+  pull_request:
+    paths:
+      - "src/reyn/mcp/**"
+
+permissions:
+  contents: read
+
+jobs:
+  fastmcp-import-boundary:
+    name: fastmcp-import-boundary gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/check_fastmcp_import_boundary.py is stdlib-only (ast /
+      # pathlib / sys). No pip install needed.
+      - name: Check no src/reyn/mcp/ file imports fastmcp outside the boundary
+        run: |
+          python scripts/check_fastmcp_import_boundary.py

--- a/scripts/check_fastmcp_import_boundary.py
+++ b/scripts/check_fastmcp_import_boundary.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""#3698 — the enforcement half of the fastmcp import boundary (P2/P3 were
+the convention half).
+
+P2 (#4053) introduced ``src/reyn/mcp/_fastmcp_boundary.py`` as the single
+seam every reyn-side ``fastmcp`` import goes through, but nothing stopped a
+future direct ``import fastmcp`` anywhere else in ``src/reyn/mcp/`` — the PR
+said so explicitly ("this boundary is a convention, not an enforcement"),
+scoped to land once P3 (#4055) removed the one remaining inheritance-based
+exception (``message_handler.py``'s subclass of ``fastmcp.client.tasks.
+TaskNotificationHandler``, which genuinely needed a direct import at the
+time). Post-P3, the boundary's own starting population is verified zero —
+``_fastmcp_boundary.py`` is the ONLY file under ``src/reyn/mcp/`` that
+imports ``fastmcp`` — so this gate has nothing to grandfather.
+
+## Scope: ``src/reyn/mcp/`` only, not the whole repo
+
+``src/reyn/builtin/plugins/rag/scripts/{vector_store_server,chunker_server}.py``
+also import ``fastmcp`` directly (``from fastmcp import FastMCP``) — but
+that is reyn's own BUNDLED MCP *server* code (building a server with
+fastmcp's server framework), the opposite direction from
+``MCPConnectionService``'s *client* role this boundary exists for. #3698's
+own scope (measured in P2's issue comment) was always the client stack —
+gating the whole repo would incorrectly flag a legitimate, unrelated use of
+the package.
+
+## Why a whole-directory static scan, not a diff/base-ref check
+
+Same reasoning as ``check_bare_tests_import_reference.py``/
+``check_file_depth_reference.py``: whether a file imports ``fastmcp``
+directly is fully determined by its CURRENT content, no move or diff
+needed. A pure population scan against a real, verified-zero baseline.
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_MCP_DIR = _ROOT / "src" / "reyn" / "mcp"
+_BOUNDARY_FILE = "_fastmcp_boundary.py"
+
+
+def _imports_fastmcp_directly(path: Path) -> bool:
+    """Does *path* contain a top-level ``import fastmcp`` / ``from fastmcp
+    import ...`` / ``from fastmcp.<sub> import ...`` anywhere in its AST
+    (module-level or deferred inside a function — both are in scope, since
+    the boundary module already covers both timing patterns; see its own
+    module docstring)?"""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, SyntaxError):
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(alias.name == "fastmcp" or alias.name.startswith("fastmcp.") for alias in node.names):
+                return True
+        elif isinstance(node, ast.ImportFrom):
+            if node.module and (node.module == "fastmcp" or node.module.startswith("fastmcp.")):
+                return True
+    return False
+
+
+def offending_files(mcp_dir: Path = _MCP_DIR) -> "list[Path]":
+    """Every ``.py`` file directly under *mcp_dir* (not ``_fastmcp_boundary.py``
+    itself) that imports ``fastmcp`` directly — the gate's entire decision,
+    isolated from CLI/printing so it is directly testable."""
+    offenders = []
+    for path in sorted(mcp_dir.glob("*.py")):
+        if path.name == _BOUNDARY_FILE:
+            continue
+        if _imports_fastmcp_directly(path):
+            offenders.append(path)
+    return offenders
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    del argv  # no options — a whole-directory scan against a baseline of zero
+    offenders = offending_files(_MCP_DIR)
+
+    if not offenders:
+        print(
+            "OK: no file under src/reyn/mcp/ imports fastmcp directly except "
+            "_fastmcp_boundary.py."
+        )
+        return 0
+
+    print("fastmcp-import-boundary gate FAILED:\n", file=sys.stderr)
+    print(
+        f"{len(offenders)} file(s) under src/reyn/mcp/ import fastmcp directly, "
+        "outside the boundary module (#3698 P2/P3):",
+        file=sys.stderr,
+    )
+    for path in offenders:
+        print(f"  {path.relative_to(_ROOT)}", file=sys.stderr)
+    print(
+        "\nAdd an accessor function to src/reyn/mcp/_fastmcp_boundary.py "
+        "instead and import from there — that module is the single seam a "
+        "future SDK swap edits, not scattered call sites.\n"
+        "\nThis gate's own starting population is zero, so any hit here is "
+        "a new regression, not inherited debt.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_check_fastmcp_import_boundary_3698.py
+++ b/tests/scripts/test_check_fastmcp_import_boundary_3698.py
@@ -1,0 +1,98 @@
+"""Tier 2: #3698 — the fastmcp-import-boundary enforcement gate.
+
+Real filesystem fixtures throughout (a real `tmp_path` tree of `.py`
+files) — the function under test reads real file content and parses real
+ASTs, so faking the filesystem would test nothing real.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_fastmcp_import_boundary import offending_files
+
+
+def test_a_direct_module_level_import_is_flagged(tmp_path: Path) -> None:
+    """Tier 2: THE case #3698 P2/P3 warned would go unnoticed — a future
+    direct `import fastmcp` outside the boundary module."""
+    (tmp_path / "_fastmcp_boundary.py").write_text("X = 1\n", encoding="utf-8")
+    (tmp_path / "client.py").write_text("import fastmcp\n", encoding="utf-8")
+    offenders = offending_files(tmp_path)
+    assert offenders == [tmp_path / "client.py"]
+
+
+def test_a_from_fastmcp_submodule_import_is_flagged(tmp_path: Path) -> None:
+    """Tier 2: `from fastmcp.client.auth import OAuth` shape — a submodule
+    import, not the bare package name."""
+    (tmp_path / "_fastmcp_boundary.py").write_text("X = 1\n", encoding="utf-8")
+    (tmp_path / "client.py").write_text(
+        "from fastmcp.client.auth import OAuth\n", encoding="utf-8"
+    )
+    offenders = offending_files(tmp_path)
+    assert offenders == [tmp_path / "client.py"]
+
+
+def test_a_deferred_function_local_import_is_also_flagged(tmp_path: Path) -> None:
+    """Tier 2: a deferred (function-local) import is in scope too — the
+    boundary module itself uses deferred imports for the same reason
+    (preserving timing), so a NEW direct import elsewhere must be caught
+    regardless of whether it's module-level or deferred."""
+    (tmp_path / "_fastmcp_boundary.py").write_text("X = 1\n", encoding="utf-8")
+    (tmp_path / "client.py").write_text(
+        "def f():\n    from fastmcp import Client\n    return Client\n",
+        encoding="utf-8",
+    )
+    offenders = offending_files(tmp_path)
+    assert offenders == [tmp_path / "client.py"]
+
+
+def test_the_boundary_module_itself_is_exempt(tmp_path: Path) -> None:
+    """Tier 2: `_fastmcp_boundary.py` is where these imports are SUPPOSED to
+    live — never flagged, no matter how many it has."""
+    (tmp_path / "_fastmcp_boundary.py").write_text(
+        "import fastmcp\nfrom fastmcp.client.auth import OAuth\n", encoding="utf-8"
+    )
+    offenders = offending_files(tmp_path)
+    assert offenders == []
+
+
+def test_an_import_of_an_unrelated_package_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 2: `import mcp.types` (the lower-level protocol-spec package
+    fastmcp itself wraps, not fastmcp) must not false-positive — only a
+    module named exactly `fastmcp` or `fastmcp.<sub>` counts."""
+    (tmp_path / "_fastmcp_boundary.py").write_text("X = 1\n", encoding="utf-8")
+    (tmp_path / "message_handler.py").write_text(
+        "import mcp.types\nfrom mcp.types import ServerNotification\n",
+        encoding="utf-8",
+    )
+    offenders = offending_files(tmp_path)
+    assert offenders == []
+
+
+def test_a_package_named_fastmcp_prefixed_is_not_confused_with_fastmcp(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: non-vacuity for the exact-match / dotted-prefix rule — a
+    hypothetical unrelated package whose name merely STARTS WITH the same
+    letters (e.g. `fastmcplib`, not a real package, but the rule must not
+    match on a bare substring) is not flagged."""
+    (tmp_path / "_fastmcp_boundary.py").write_text("X = 1\n", encoding="utf-8")
+    (tmp_path / "client.py").write_text("import fastmcplib\n", encoding="utf-8")
+    offenders = offending_files(tmp_path)
+    assert offenders == []
+
+
+def test_the_real_repo_tree_is_currently_clean() -> None:
+    """Tier 2: the gate's own starting population — verified against the
+    real, current tree (not assumed), matching the sibling gates' own
+    "run it before shipping it" discipline. #3698 P3 removed the last
+    remaining direct fastmcp import outside the boundary module
+    (message_handler.py's inheritance-based one); this asserts it stayed
+    removed."""
+    from scripts.check_fastmcp_import_boundary import _MCP_DIR, _ROOT
+
+    assert _MCP_DIR == _ROOT / "src" / "reyn" / "mcp"
+    offenders = offending_files(_MCP_DIR)
+    assert offenders == [], (
+        f"real regression(s) found: {offenders} — this gate's baseline is "
+        "zero, so any hit here is new, not inherited debt"
+    )


### PR DESCRIPTION
**[e2e-coder]** — part of #3698 (the enforcement gate #4053 deliberately scoped out, landing now that P3/#4055 closed the population).

## What

`scripts/check_fastmcp_import_boundary.py` — rejects a direct `import fastmcp` (module-level or deferred) anywhere under `src/reyn/mcp/` except `_fastmcp_boundary.py` itself. #4053's own PR body was explicit: "this boundary is a convention, not an enforcement" — nothing stopped a future direct import from bypassing it. Now that P3 (#4055) removed the one remaining legitimate exception (`message_handler.py`'s fastmcp base class, before it was rewritten to compose), the boundary's real population is zero outside `_fastmcp_boundary.py`, so this gate has nothing to grandfather.

## Scope: `src/reyn/mcp/` only

`src/reyn/builtin/plugins/rag/scripts/{vector_store_server,chunker_server}.py` also import `fastmcp` directly — reyn's own bundled MCP **server** scripts (building a server with `fastmcp.FastMCP`), the opposite direction from `MCPConnectionService`'s client role. Gating the whole repo would incorrectly flag this legitimate, unrelated use — confirmed out of scope on #3698's own issue thread (P2's measurement comment).

## Verification

- Ran the detector against the real tree BEFORE wiring the gate — 0 hits outside `_fastmcp_boundary.py`, confirming P3 genuinely closed the population. Pinned by `test_the_real_repo_tree_is_currently_clean`.
- Falsify-verified: stripped the `Import`-node match arm, confirmed the flagged-case test goes RED for the right reason, restored, confirmed GREEN.
- `ruff check` — clean
- `test_tier_audit.py --strict` — 7 tests, 0 errors
- `verify_module_docstrings.py` — clean
- `mypy_ratchet.py` — 210/213 baselined, no new debt
- New CI workflow (`fastmcp-import-boundary-gate.yml`) — mirrors the sibling gates' structure exactly, `path: src/reyn/mcp/**` trigger, YAML validated locally
- Not self-merging (PR-workflow rule 8).

## Test plan

- [x] Verified real-tree population is zero before wiring the gate
- [x] Falsify-verified (RED for the right reason, restored to GREEN)
- [x] Confirmed the rag-plugin server files are correctly out of scope (directory-scoped gate)
- [x] 5-gate local battery green
