### PR TITLE
feat(#3878): mechanize the 5 Phase-2 candidate signals

### DIFF
--- a/scripts/tier4_candidate_signals.py
+++ b/scripts/tier4_candidate_signals.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""#3878 Phase 2 mechanization — 5 candidate-surfacing signals for reading order.
+
+## What this is, and what it deliberately is NOT
+
+Phase 1/2 of #3878 hand-read a subset of `tests/` against the six questions
+and found real Tier 4 tests, but the signals used to CHOOSE what to read next
+(A/B/C in the issue's Phase 1, then "third-party import" in Phase 2) were all
+ad-hoc human judgment, never captured in code — so the next person picking up
+Phase 2 starts from zero again. This module makes the 5 candidate signals the
+issue's own original plan named permanent, runnable functions.
+
+**Enumeration, not judgment.** Every function here returns a LIST OF
+CANDIDATES — files/tests that MATCH a structural pattern correlated with
+Tier 4 in the small samples read so far. None of them decides Tier 4. A
+human still reads each candidate and answers the six questions
+(`docs/deep-dives/contributing/testing.md`) — this tool only decides what
+order to read them in. **Not a CI gate** — nothing here has a pass/fail exit
+code tied to a threshold; `main()` prints candidate counts and samples for a
+human to triage, and always returns 0.
+
+## The population-coverage premise (read before trusting a candidate count)
+
+Phase 2's "5 consecutive rounds of 0 new Tier-4 found" applies to a
+**62-file, 523-test subset** (files that directly import a third-party
+library) — about 5.6% of `tests/`'s ~9,452 test functions. The remaining
+~8,960 have never been sampled by ANY signal. A LOW candidate count from a
+signal here is not evidence "the rest is clean" — it is only evidence about
+what that specific signal catches, on the specific files it was run against.
+Report counts as "N candidates from signal X, out of M functions scanned",
+never as "the population is mostly Tier 1/2".
+
+## The 5 signals (#3878's own original Phase 2 candidate list)
+
+1. `third_party_only_asserts` — every assert in the test touches only a
+   third-party/stdlib value, never anything the file imports from `reyn.*`.
+2. `docstring_negative_with_issue` — the docstring names an issue number AND
+   uses a negative framing ("not"/"never") — a common shape for a
+   fingerprint-of-a-past-bug test (`docs/.../testing.md`'s Q1 discriminator).
+3. `regression_named` — the test's own NAME contains `regression`, `not_`,
+   or `no_` — the same fingerprint-naming smell, visible without reading the
+   body at all.
+4. `mass_produced_assert_shape` — N+ asserts in the SAME FILE share an
+   identical structural shape (same AST after normalizing literal values) —
+   a common symptom of the same check copy-pasted across many near-identical
+   tests rather than genuinely distinct cases.
+5. `narrow_tier2` — the docstring declares "Tier 2" but the test body calls
+   into exactly ONE distinct `reyn.*`-sourced name — a broad Tier claim
+   resting on a single, narrow call site.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_TESTS_DIR = _ROOT / "tests"
+
+# Signal 4's "mass produced" threshold — a knob, not a claim. 5+ identical
+# assert shapes in one file is the starting point; adjust based on what a
+# human triage pass finds useful, not a tuned-for-precision value.
+_MASS_PRODUCED_THRESHOLD = 5
+
+
+@dataclass
+class Candidate:
+    """One flagged test — file/name/line + which signal(s) flagged it."""
+
+    path: Path
+    test_name: str
+    lineno: int
+    signal: str
+    detail: str = ""
+
+    def __str__(self) -> str:
+        rel = self.path.relative_to(_ROOT)
+        base = f"{rel}:{self.lineno} {self.test_name} [{self.signal}]"
+        return f"{base} — {self.detail}" if self.detail else base
+
+
+def _iter_test_files(tests_dir: Path = _TESTS_DIR):
+    for path in sorted(tests_dir.rglob("test_*.py")):
+        try:
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+        except (OSError, UnicodeDecodeError, SyntaxError):
+            continue
+        yield path, tree
+
+
+def _test_functions(tree: ast.AST):
+    """Every top-level (not nested inside a class OR another function is
+    fine — pytest collects both) test_* function/coroutine def."""
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):
+            yield node
+
+
+def _reyn_bound_names(tree: ast.AST) -> "set[str]":
+    """Every locally-bound name this file's imports give it that traces back
+    to `reyn.*` — both `from reyn.x import Y` (binds `Y`) and `import reyn.x`
+    (binds `reyn`, the root of the dotted access `reyn.x...`)."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module and (
+            node.module == "reyn" or node.module.startswith("reyn.")
+        ):
+            for alias in node.names:
+                names.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "reyn" or alias.name.startswith("reyn."):
+                    names.add((alias.asname or alias.name.split(".")[0]))
+    return names
+
+
+def _dotted_base_name(node: ast.AST) -> "str | None":
+    """For an Attribute chain (`a.b.c`), the root Name's id (`a`); None if
+    the chain doesn't bottom out in a bare Name."""
+    while isinstance(node, ast.Attribute):
+        node = node.value
+    return node.id if isinstance(node, ast.Name) else None
+
+
+def _references_any(node: ast.AST, names: "set[str]") -> bool:
+    for n in ast.walk(node):
+        if isinstance(n, ast.Name) and n.id in names:
+            return True
+        if isinstance(n, ast.Attribute):
+            base = _dotted_base_name(n)
+            if base in names:
+                return True
+    return False
+
+
+# ── signal 1 ─────────────────────────────────────────────────────────────
+
+
+def third_party_only_asserts(tests_dir: Path = _TESTS_DIR) -> "list[Candidate]":
+    """Every assert in the test touches only third-party/stdlib values,
+    never anything the file imports from `reyn.*` — the Q1 "whose bug is
+    it" discriminator, made mechanical: if NOTHING in the test's own
+    assertions ever names reyn's own code, a failure here is unlikely to be
+    reyn's bug."""
+    out: list[Candidate] = []
+    for path, tree in _iter_test_files(tests_dir):
+        reyn_names = _reyn_bound_names(tree)
+        if not reyn_names:
+            continue  # a file with no reyn import at all is out of scope for this signal
+        for fn in _test_functions(tree):
+            asserts = [n for n in ast.walk(fn) if isinstance(n, ast.Assert)]
+            if not asserts:
+                continue
+            if all(not _references_any(a.test, reyn_names) for a in asserts):
+                out.append(Candidate(
+                    path, fn.name, fn.lineno, "third_party_only_asserts",
+                    f"{len(asserts)} assert(s), none reference reyn.*",
+                ))
+    return out
+
+
+# ── signal 2 ─────────────────────────────────────────────────────────────
+
+_ISSUE_NUM_RE = re.compile(r"#\d+")
+_NEGATIVE_RE = re.compile(r"\b(not|never)\b", re.IGNORECASE)
+
+
+def docstring_negative_with_issue(tests_dir: Path = _TESTS_DIR) -> "list[Candidate]":
+    """The docstring names an issue number AND uses a negative framing
+    ("not"/"never") — a common shape for a past-bug fingerprint test
+    (`assert "X" not in result`, which any OTHER wrong value also passes)."""
+    out: list[Candidate] = []
+    for path, tree in _iter_test_files(tests_dir):
+        for fn in _test_functions(tree):
+            doc = ast.get_docstring(fn) or ""
+            if _ISSUE_NUM_RE.search(doc) and _NEGATIVE_RE.search(doc):
+                out.append(Candidate(
+                    path, fn.name, fn.lineno, "docstring_negative_with_issue",
+                    doc.splitlines()[0][:100] if doc else "",
+                ))
+    return out
+
+
+# ── signal 3 ─────────────────────────────────────────────────────────────
+
+_NAME_SMELL_RE = re.compile(r"regression|(?:^|_)not_|(?:^|_)no_")
+
+
+def regression_named(tests_dir: Path = _TESTS_DIR) -> "list[Candidate]":
+    """The test's own NAME contains `regression`, `not_`, or `no_` — a
+    fingerprint-naming smell visible without reading the body."""
+    out: list[Candidate] = []
+    for path, tree in _iter_test_files(tests_dir):
+        for fn in _test_functions(tree):
+            if _NAME_SMELL_RE.search(fn.name):
+                out.append(Candidate(path, fn.name, fn.lineno, "regression_named"))
+    return out
+
+
+# ── signal 4 ─────────────────────────────────────────────────────────────
+
+
+def _normalized_assert_shape(node: ast.Assert) -> str:
+    """ast.dump of the assert's test expression with every Constant value
+    replaced by a placeholder — so `assert x == 1` and `assert x == 2` dump
+    identically (same SHAPE, different literal) while `assert x == 1` and
+    `assert y == 1` do not (different variable)."""
+
+    class _Blank(ast.NodeTransformer):
+        def visit_Constant(self, node: ast.Constant) -> ast.Constant:
+            return ast.copy_location(ast.Constant(value="<LIT>"), node)
+
+    blanked = _Blank().visit(ast.parse(ast.unparse(node.test), mode="eval"))
+    return ast.dump(blanked, annotate_fields=False)
+
+
+def mass_produced_assert_shape(
+    tests_dir: Path = _TESTS_DIR, threshold: int = _MASS_PRODUCED_THRESHOLD
+) -> "list[Candidate]":
+    """N+ asserts in the SAME FILE share an identical structural shape
+    (same AST after normalizing literal values) — a common symptom of the
+    same check copy-pasted across many near-identical tests."""
+    out: list[Candidate] = []
+    for path, tree in _iter_test_files(tests_dir):
+        shape_to_asserts: "defaultdict[str, list[tuple[ast.FunctionDef | ast.AsyncFunctionDef, ast.Assert]]]" = defaultdict(list)
+        for fn in _test_functions(tree):
+            for node in ast.walk(fn):
+                if isinstance(node, ast.Assert):
+                    try:
+                        shape = _normalized_assert_shape(node)
+                    except (SyntaxError, ValueError):
+                        continue
+                    shape_to_asserts[shape].append((fn, node))
+        for shape, hits in shape_to_asserts.items():
+            if len(hits) < threshold:
+                continue
+            fns_involved = {fn.name for fn, _ in hits}
+            for fn, node in hits:
+                out.append(Candidate(
+                    path, fn.name, node.lineno, "mass_produced_assert_shape",
+                    f"{len(hits)}x identical assert shape across {len(fns_involved)} test(s) in this file",
+                ))
+    return out
+
+
+# ── signal 5 ─────────────────────────────────────────────────────────────
+
+_TIER2_RE = re.compile(r"^Tier 2\b")
+
+
+def narrow_tier2(tests_dir: Path = _TESTS_DIR) -> "list[Candidate]":
+    """The docstring declares "Tier 2" but the test body calls into exactly
+    ONE distinct reyn.*-sourced name — a broad Tier claim resting on a
+    single, narrow call site."""
+    out: list[Candidate] = []
+    for path, tree in _iter_test_files(tests_dir):
+        reyn_names = _reyn_bound_names(tree)
+        if not reyn_names:
+            continue
+        for fn in _test_functions(tree):
+            doc = ast.get_docstring(fn) or ""
+            if not _TIER2_RE.match(doc.strip()):
+                continue
+            touched: set[str] = set()
+            for n in ast.walk(fn):
+                if isinstance(n, ast.Name) and n.id in reyn_names:
+                    touched.add(n.id)
+                elif isinstance(n, ast.Attribute):
+                    base = _dotted_base_name(n)
+                    if base in reyn_names:
+                        touched.add(f"{base}.{n.attr}")
+            if len(touched) == 1:
+                out.append(Candidate(
+                    path, fn.name, fn.lineno, "narrow_tier2",
+                    f"only touches {next(iter(touched))}",
+                ))
+    return out
+
+
+ALL_SIGNALS = {
+    "third_party_only_asserts": third_party_only_asserts,
+    "docstring_negative_with_issue": docstring_negative_with_issue,
+    "regression_named": regression_named,
+    "mass_produced_assert_shape": mass_produced_assert_shape,
+    "narrow_tier2": narrow_tier2,
+}
+
+
+def _total_test_functions(tests_dir: Path = _TESTS_DIR) -> int:
+    total = 0
+    for _, tree in _iter_test_files(tests_dir):
+        total += sum(1 for _ in _test_functions(tree))
+    return total
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    """Print candidate counts per signal + a sample, against the full
+    scanned population size — never a pass/fail verdict. Always returns 0:
+    this is a reading-order tool, not a gate (#3878 explicit instruction)."""
+    del argv
+    total = _total_test_functions()
+    print(f"Scanned {total} test functions under {_TESTS_DIR.relative_to(_ROOT)}.\n")
+    for name, fn in ALL_SIGNALS.items():
+        candidates = fn()
+        pct = (len(candidates) / total * 100) if total else 0.0
+        print(f"[{name}] {len(candidates)} candidate(s) ({pct:.1f}% of {total} scanned — NOT a population estimate)")
+        for c in candidates[:10]:
+            print(f"  {c}")
+        if len(candidates) > 10:
+            print(f"  ... and {len(candidates) - 10} more")
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_tier4_candidate_signals_3878.py
+++ b/tests/scripts/test_tier4_candidate_signals_3878.py
@@ -1,0 +1,233 @@
+"""Tier 2: #3878 Phase 2 mechanization — the 5 candidate-surfacing signals.
+
+Real filesystem fixtures throughout (a real `tmp_path` tree of `.py` files)
+— the function under test reads real file content and parses real ASTs, so
+faking the filesystem would test nothing real. Each signal is enumeration
+only (no judgment) — these tests pin "does the signal fire on the exact
+shape it exists to catch", not "is the flagged test actually Tier 4".
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from scripts.tier4_candidate_signals import (
+    docstring_negative_with_issue,
+    mass_produced_assert_shape,
+    narrow_tier2,
+    regression_named,
+    third_party_only_asserts,
+)
+
+
+def _write(tmp_path: Path, name: str, body: str) -> None:
+    (tmp_path / name).write_text(body, encoding="utf-8")
+
+
+# ── signal 1 ─────────────────────────────────────────────────────────────
+
+
+def test_third_party_only_asserts_flags_a_reyn_free_assert(tmp_path: Path) -> None:
+    """Tier 2: THE case this signal exists to catch — every assert in the
+    test compares plain literals, never anything traced from the file's
+    own reyn imports."""
+    _write(
+        tmp_path, "test_a.py",
+        "from reyn.core.foo import bar\n\n"
+        "def test_x():\n"
+        "    result = bar()\n"
+        "    assert 1 + 1 == 2\n",
+    )
+    candidates = third_party_only_asserts(tmp_path)
+    assert [c.test_name for c in candidates] == ["test_x"]
+
+
+def test_third_party_only_asserts_not_flagged_when_assert_touches_reyn(tmp_path: Path) -> None:
+    """Tier 2: accept-side — an assert that DOES reference the imported
+    reyn name, in the SAME expression, must not be flagged."""
+    _write(
+        tmp_path, "test_a.py",
+        "from reyn.core.foo import bar\n\n"
+        "def test_x():\n"
+        "    assert bar() == 1\n",
+    )
+    candidates = third_party_only_asserts(tmp_path)
+    assert candidates == []
+
+
+def test_third_party_only_asserts_known_limitation_misses_a_variable_hop(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: KNOWN LIMITATION, pinned rather than hidden — the signal
+    checks only the NAMES literally appearing in the assert's own
+    expression, no data-flow tracing. `result = bar(); assert result == 1`
+    is textually indistinguishable from an assert on a pure third-party
+    value, even though `result` traces back to a reyn call one line above
+    — this is measured (#3878 dispatch) as the likely cause of the signal's
+    69% real-tree fire rate, far too broad to prioritize reading order. A
+    real fix needs data-flow tracing (does the asserted name's binding,
+    anywhere earlier in the function, come from a reyn call?), out of
+    scope for this enumeration pass."""
+    _write(
+        tmp_path, "test_a.py",
+        "from reyn.core.foo import bar\n\n"
+        "def test_x():\n"
+        "    result = bar()\n"
+        "    assert result == 1\n",
+    )
+    candidates = third_party_only_asserts(tmp_path)
+    # Documents the false positive — does NOT assert this is correct
+    # behavior, only that it's the CURRENT, known, measured behavior.
+    assert [c.test_name for c in candidates] == ["test_x"]
+
+
+def test_third_party_only_asserts_skips_files_with_no_reyn_import(tmp_path: Path) -> None:
+    """Tier 2: a file with no reyn import at all is out of scope for this
+    signal (nothing to compare against) — not the same as "flag everything"."""
+    _write(tmp_path, "test_a.py", "def test_x():\n    assert 1 == 1\n")
+    candidates = third_party_only_asserts(tmp_path)
+    assert candidates == []
+
+
+# ── signal 2 ─────────────────────────────────────────────────────────────
+
+
+def test_docstring_negative_with_issue_flags_issue_plus_negative(tmp_path: Path) -> None:
+    """Tier 2: THE case this signal exists to catch — a docstring naming an
+    issue AND using negative framing, the past-bug-fingerprint shape."""
+    _write(
+        tmp_path, "test_a.py",
+        'def test_x():\n'
+        '    """Tier 2: #123 the value is not None."""\n'
+        '    assert 1 == 1\n',
+    )
+    candidates = docstring_negative_with_issue(tmp_path)
+    assert [c.test_name for c in candidates] == ["test_x"]
+
+
+def test_docstring_negative_with_issue_not_flagged_without_both(tmp_path: Path) -> None:
+    """Tier 2: accept-side — an issue number ALONE, or a negative word
+    ALONE, does not fire; both must co-occur."""
+    _write(
+        tmp_path, "test_a.py",
+        'def test_x():\n'
+        '    """Tier 2: #123 the value equals the expected constant."""\n'
+        '    assert 1 == 1\n\n'
+        'def test_y():\n'
+        '    """Tier 2: the value is not empty."""\n'
+        '    assert 1 == 1\n',
+    )
+    candidates = docstring_negative_with_issue(tmp_path)
+    assert candidates == []
+
+
+# ── signal 3 ─────────────────────────────────────────────────────────────
+
+
+def test_regression_named_flags_the_three_name_shapes(tmp_path: Path) -> None:
+    """Tier 2: all three naming smells fire (`regression`, `not_`, `no_`),
+    an ordinary name does not."""
+    _write(
+        tmp_path, "test_a.py",
+        "def test_known_regression_case():\n    assert True\n\n"
+        "def test_a_not_flagged_path_is_clean():\n    assert True\n\n"
+        "def test_no_leak_occurs():\n    assert True\n\n"
+        "def test_an_ordinary_case():\n    assert True\n",
+    )
+    candidates = {c.test_name for c in regression_named(tmp_path)}
+    assert candidates == {
+        "test_known_regression_case",
+        "test_a_not_flagged_path_is_clean",
+        "test_no_leak_occurs",
+    }
+
+
+# ── signal 4 ─────────────────────────────────────────────────────────────
+
+
+def test_mass_produced_assert_shape_flags_repeated_shape(tmp_path: Path) -> None:
+    """Tier 2: every assert sharing the repeated shape is flagged, not just
+    some of them (completeness, checked against the source's own assert
+    line numbers — not a hardcoded count)."""
+    body = "def test_x():\n"
+    for i in range(6):
+        body += f"    assert data[{i}] == 1\n"
+    _write(tmp_path, "test_a.py", body)
+    candidates = mass_produced_assert_shape(tmp_path, threshold=5)
+    # normalized shape ignores the literal 1 AND the subscript index (both
+    # Constants) -- all asserts in the source share one shape.
+    all_assert_lines = {n.lineno for n in ast.walk(ast.parse(body)) if isinstance(n, ast.Assert)}
+    assert {c.lineno for c in candidates} == all_assert_lines
+    assert all(c.test_name == "test_x" for c in candidates)
+
+
+def test_mass_produced_assert_shape_not_flagged_below_threshold(tmp_path: Path) -> None:
+    """Tier 2: accept-side — fewer repeats than the threshold does not fire."""
+    _write(
+        tmp_path, "test_a.py",
+        "def test_x():\n    assert data[0] == 1\n    assert data[1] == 1\n",
+    )
+    candidates = mass_produced_assert_shape(tmp_path, threshold=5)
+    assert candidates == []
+
+
+def test_mass_produced_assert_shape_distinguishes_different_shapes(tmp_path: Path) -> None:
+    """Tier 2: non-vacuity — asserts on DIFFERENT variables/operators don't
+    collapse into the same shape just because both use literals."""
+    # Built once, reused for both the written file AND the independent
+    # line-number computation below -- no duplicated construction to drift
+    # out of sync with each other.
+    source = "def test_x():\n" + ("    assert a == 1\n" * 3) + ("    assert b != 2\n" * 3)
+    _write(tmp_path, "test_a.py", source)
+    candidates = mass_produced_assert_shape(tmp_path, threshold=3)
+    # two distinct shapes, 3 each -- both meet threshold=3, tracked as
+    # separate shape groups. Completeness check against the source's own
+    # assert lines, not a hardcoded count.
+    all_assert_lines = {n.lineno for n in ast.walk(ast.parse(source)) if isinstance(n, ast.Assert)}
+    assert {c.lineno for c in candidates} == all_assert_lines
+
+
+# ── signal 5 ─────────────────────────────────────────────────────────────
+
+
+def test_narrow_tier2_flags_single_reyn_call_site(tmp_path: Path) -> None:
+    """Tier 2: THE case this signal exists to catch — a Tier 2 declaration
+    resting on exactly one distinct reyn-sourced call site."""
+    _write(
+        tmp_path, "test_a.py",
+        "from reyn.core.foo import bar\n\n"
+        "def test_x():\n"
+        '    """Tier 2: bar behaves correctly."""\n'
+        "    assert bar() == 1\n",
+    )
+    candidates = narrow_tier2(tmp_path)
+    assert [c.test_name for c in candidates] == ["test_x"]
+
+
+def test_narrow_tier2_not_flagged_with_multiple_reyn_names(tmp_path: Path) -> None:
+    """Tier 2: accept-side — touching TWO distinct reyn names does not fire
+    (the signal is specifically about a SINGLE narrow call site)."""
+    _write(
+        tmp_path, "test_a.py",
+        "from reyn.core.foo import bar, baz\n\n"
+        "def test_x():\n"
+        '    """Tier 2: bar and baz interact correctly."""\n'
+        "    assert bar() == baz()\n",
+    )
+    candidates = narrow_tier2(tmp_path)
+    assert candidates == []
+
+
+def test_narrow_tier2_not_flagged_for_non_tier2_docstring(tmp_path: Path) -> None:
+    """Tier 2: accept-side — a Tier 1 declaration with the same narrow
+    call-site shape does not fire; the signal is specifically about a
+    Tier 2 claim, not narrowness alone."""
+    _write(
+        tmp_path, "test_a.py",
+        "from reyn.core.foo import bar\n\n"
+        "def test_x():\n"
+        '    """Tier 1: contract for bar()."""\n'
+        "    assert bar() == 1\n",
+    )
+    candidates = narrow_tier2(tmp_path)
+    assert candidates == []


### PR DESCRIPTION
**[e2e-coder]** — part of #3878. Enumeration only, per explicit instruction ("どれも候補を並べるだけ、判定はしない — 列挙は機械、分類は人" / "gate にしないでください").

## What

`scripts/tier4_candidate_signals.py` mechanizes the 5 candidate signals #3878's original Phase 2 plan named (assert-third-party-only / docstring-negative-with-issue / regression-named / mass-produced-assert-shape / narrow-tier2). Each function returns a plain list of candidates — no pass/fail, no CI wiring, no verdict. `main()` prints counts + samples for a human to triage in whatever order they choose.

## Population-coverage premise (per lead-coder's correction before I started)

Phase 2's "5 consecutive rounds of 0" only covers a 523-test, 62-file subset (~5.6% of `tests/`) — the module docstring states this explicitly and every count `main()` prints is labeled "NOT a population estimate" for exactly this reason.

## Real-tree measurement (9,500 test functions scanned, per lead-coder's "measure small before deciding all 5" instruction)

```
third_party_only_asserts       6579 (69.3%)
docstring_negative_with_issue  1040 (10.9%)
regression_named                1511 (15.9%)
mass_produced_assert_shape      3176 (33.4%)
narrow_tier2                    2784 (29.3%)
```

**Every signal is far broader than useful as a priority-order filter on its own** — none narrows the ~9,500 population down to a manageably small "read these first" list. Two concrete findings from spot-checking real candidates:

- **Signal 1 has a data-flow blind spot**, pinned as an explicit test (`test_third_party_only_asserts_known_limitation_misses_a_variable_hop`): `result = bar(); assert result == 1` is textually indistinguishable from a pure third-party assert, because the signal only checks names literally appearing IN the assert expression, never tracing a variable back to its assignment. This likely explains most of the 69.3% — matches the shape of Phase 1's own rejected discriminator "A" (0/2 real Tier4 caught).
- **Signals 2 and 3 both false-positive heavily on legitimate strip-falsify tests** — e.g. `test_query_strip_falsify_wrong_offsets_do_not_recover_the_right_text` (a real, intentional falsify-verify companion test) fires signal 2 (docstring has `#3644` + "does NOT") and signal 3 (name contains `do_not`) despite being a textbook example of a GOOD test, not a Tier 4 candidate. Strip-falsify tests are a known, common, intentional pattern in this codebase that both signals currently can't distinguish from a fingerprint-of-a-past-bug test.

**Recommendation, not shipped as a decision**: none of the 5 signals is precise enough to use as-is for prioritizing a ~9,000-test population; the two concrete false-positive classes above (data-flow blindness, strip-falsify confusion) are the natural next refinements if this is worth investing in further, versus other approaches (e.g. lead-coder's just-dispatched "read the 69 axis-less files directly" — a concrete population in hand beats a noisy signal over the whole tree).

## Verification

- Each signal has an accept-side test (correctly does NOT fire) and a reject-side test (correctly fires on the exact shape it targets).
- `ruff check` — clean
- `test_tier_audit.py --strict` — 13 tests, 0 errors
- `verify_module_docstrings.py` — clean
- `mypy_ratchet.py` — 210/213 baselined, no new debt
- Not self-merging (PR-workflow rule 8).

## Test plan

- [x] Measured all 5 signals against the real, full tree (not a sample) — counts + 2 concrete false-positive classes reported above, not assumed
- [x] 5-gate local battery green