### PR TITLE
docs: add "Where a new test file goes" to testing.md (#3879 bucket-placement rules)

### DIFF
--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -823,6 +823,81 @@ This is the only sanctioned use of snapshot tests in the codebase.
 
 ---
 
+## Where a new test file goes
+
+`tests/<name>/` bucket placement is enforced by `scripts/check_tests_dir_names.py`
+(a CI gate — declared, not just described) but the *reasoning* behind that gate's
+rules lives only in its own docstring, which nobody reads before writing a test.
+This section is the human-readable form; #3879's bucket-reorganization arc
+(2026-08-09/10) is where each rule below was settled, several after a wrong
+first attempt corrected in the same thread.
+
+**Split by subject, not by mirroring `src/reyn/`.** Mirroring the real package
+tree (`tests/<name>/` for a real `src/reyn/<name>/`) is the *default* shape and
+covers most buckets, but it is not the only valid one — `tests/chat`/`tests/cli`/
+`tests/web` are pre-#3879 buckets that share a name with an unrelated
+`src/reyn/<name>/` package without actually testing it (grandfathered, not a
+template to extend), and `tests/repo/` is a deliberate, permanent special case
+for AST-guard/CI-structure tests that import zero `reyn.*` at all — there is no
+`src/reyn/repo/` and never will be. A same-night correction: a first attempt at
+this same bucket used the invented name `tests/structure/` before checking
+whether an existing, already-reserved name (`repo`) already covered the exact
+use case — grep the existing vocabulary before inventing a new word.
+
+**A new NON-MIRROR bucket name requires editing the gate, not just moving
+files.** `check_tests_dir_names.py`'s rule ① is a closed set: a real
+`src/reyn/<name>/` package, or the literal `repo` special case — nothing else
+passes. When a genuinely new subject (e.g. `tests/intervention/` for
+`user_intervention.py`/`intervention_choices.py`, both top-level single-file
+modules with no `src/reyn/intervention/` package to mirror) needs its own
+bucket, the fix is adding that name to the gate's explicit exception list —
+a deliberate, reviewed code change, not a baseline edit and not "rule ① now
+means whatever seems reasonable." The alternative (loosen ① to "any subject
+name is fine") was considered and rejected: it would make the vocabulary check
+meaningless, since nothing would ever fail it again. An explicit-list edit
+means a new non-mirror bucket only exists because someone deliberately added
+it and said why — "silently accumulates" cannot happen to a list you have to
+edit to grow.
+
+**3 files justifies a bucket; 1–2 does not.** Measured against the smallest
+existing buckets on `origin/main` (`observability`: 2, `chat`: 3, `scaffold`: 4)
+— 3 is within precedent, not a new low bar. The line stays at "don't create a
+bucket for 1–2 files"; 3 is where a bucket becomes worth the name.
+
+**`__init__.py` presence/absence is not a placement axis.** It decides a
+*different* question — the SHADOW check (same gate, same file): a
+`tests/<name>/` directory that HAS an `__init__.py` becomes a regular Python
+package, which can silently shadow a real top-level import if `<name>` collides
+with something real code imports (confirmed directly: adding
+`tests/scripts/__init__.py` broke two existing tests that `import scripts`).
+Whether to bundle a set of test files together is a subject-matching decision;
+whether the resulting directory needs (or must avoid) an `__init__.py` is a
+completely separate, mechanical safety check on top of that decision — treating
+"these files happen to share `__init__.py` status" as a reason to group them is
+answering the wrong question.
+
+**AST import-count is a starting hypothesis, not a verdict — read the file.**
+An AST scan of which `reyn.*` symbol a test imports most is a fast first pass,
+and it can still be wrong the same way a naive grep can: the winning import can
+be a repeated INGREDIENT (a fake/helper class instantiated 2–3 times inside the
+file) rather than the file's actual SUBJECT. Two files that "won" an
+intervention-related import count on this exact night turned out, on reading
+the module docstring and what the asserts actually check, to be about
+permission-decl / JIT-ask logic — `user_intervention` types only supplied a
+fake bus's vocabulary. Confirming the count against the file's own module
+docstring and the subject of its assertions is not optional extra rigor; it is
+the step that makes the count trustworthy.
+
+**"Can be moved" is not "should be moved."** A file whose subject genuinely
+fits a new or different bucket is still allowed to stay where a **prior**,
+already-settled placement decision put it, if moving it would only be
+justified by "it counted highest on one of several methods" rather than a
+clearer reason. Flag the judgment call in the PR body (which bucket it could
+also fit, and why it's staying) rather than resolving it silently — a
+placement's own reasoning is worth recording even when the answer is "leave it."
+
+---
+
 ## Filesystem isolation (= no real `~/.reyn/` pollution)
 
 Tests **must not** modify the developer's real `~/.reyn/` files. The repository's `tests/conftest.py` already enforces this for the secret store via an autouse fixture that sets `REYN_SECRETS_PATH` to `tmp_path / "secrets.env"` for every test. As a result:


### PR DESCRIPTION
**[docs-maintainer]** — Dispatched by lead-coder: `testing.md` had no human-readable explanation of `tests/<name>/` bucket-placement rules — only `check_tests_dir_names.py`'s own docstring (the enforced surface), which nobody reads before writing a test.

## Six rules recorded, each grounded in a real same-night (#3879, 2026-08-09/10) instance

- **Split by subject, mirroring `src/reyn/` is the default, not the only shape** — `chat`/`cli`/`web` are grandfathered non-mirror names, `repo` is the deliberate permanent special case. Corrected from an invented `structure` name to the already-reserved `repo` in the same thread — grep the existing vocabulary before inventing a new word.
- **A genuinely new non-mirror bucket name requires editing the gate's explicit exception list**, not a baseline edit — deliberate, reviewed growth instead of silent accumulation.
- **3 files justifies a bucket** — measured against real smallest existing buckets. I re-verified this myself rather than copying the cited numbers unchecked: my first count (maxdepth-limited, excluding `__init__.py`) didn't match; recounting with `__init__.py` included (`chat`: 3, `observability`: 2, `scaffold`: 4) matched exactly — confirmed before writing it into the doc.
- **`__init__.py` presence is a different axis** (the SHADOW check) from subject-based bucket placement, not a grouping criterion.
- **An AST import-count is a hypothesis to verify by reading the file, not a verdict** — a repeated ingredient (a fake/helper instantiated several times) can out-count the file's real subject.
- **"Can be moved" is not "should be moved"** — a file settled by a prior decision can stay there even if it also fits a new bucket, with the judgment call recorded rather than resolved silently.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0
- [x] `python scripts/check_doc_anchors.py` — exit 0
- [x] `.venv/bin/python -m pytest tests/test_3126_doc_anchor_gate.py -q` — 338 passed
- [x] Bucket counts (3/2/4) re-verified directly against `origin/main`, not copied from the #3879 thread unchecked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
