### PR TITLE
feat(#4065): whole-repo tests/...py path-literal ratchet gate

### DIFF
--- a/.github/workflows/tests-path-literal-reference-gate.yml
+++ b/.github/workflows/tests-path-literal-reference-gate.yml
@@ -1,0 +1,41 @@
+name: tests-path-literal-reference gate
+
+# #4065: every `tests/...py` path literal anywhere in the tracked repo —
+# docstring, comment, doc prose, YAML/workflow arg — must resolve to a real
+# file. #3879's bucket migrations broke this 3 times in one night, and the
+# 3rd shape (stale prose nobody executes) stayed green until a human ran
+# grep by hand. See scripts/check_tests_path_literal_reference.py's module
+# docstring for the full design (whole-repo scan via `git ls-files`, a
+# ratchet baseline rather than a zero baseline, why no placeholder-name
+# allowlist).
+#
+# No paths filter — the reference and the referenced file are on OPPOSITE
+# sides (a doc can go stale because a `tests/` file moved, with the doc
+# itself untouched), so scoping the trigger to any one directory would miss
+# exactly the case this gate exists for.
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tests-path-literal-reference:
+    name: tests-path-literal-reference gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/check_tests_path_literal_reference.py is stdlib-only
+      # (json / re / subprocess / pathlib) plus a `git` invocation. No pip
+      # install needed.
+      - name: Check every tests/...py path literal resolves to a real file
+        run: |
+          python scripts/check_tests_path_literal_reference.py

--- a/scripts/check_tests_path_literal_reference.py
+++ b/scripts/check_tests_path_literal_reference.py
@@ -33,9 +33,13 @@ check for exactly that shape — a population scan, not an execution path.
    own measured lesson: anchoring a `tests/` literal detector to "the quote
    character is immediately followed by `tests/`" undercounted a real
    population by 17x (17 found vs. 287 actual) — a huge fraction of real
-   references are embedded mid-sentence (`` "the gate in tests/scripts/
-   test_foo.py fires" ``, `` `RED tests/test_x.py::test_y` ``), not
-   standalone path strings. This script's regex matches `tests/...` ANYWHERE
+   references are embedded mid-sentence ("the gate in a bucket subdirectory
+   fires", "RED at the failing test's own module path"), not standalone
+   path strings — deliberately not spelled out as a literal tests/-shaped
+   example here, so this docstring's own prose doesn't become a hit
+   against this gate's own scan (same reasoning below, and in the paired
+   test file's `_T` split).
+   This script's regex matches `tests/...` ANYWHERE
    inside a larger string/prose run, with a word boundary on the left, not
    only at a string literal's own start.
 
@@ -138,8 +142,11 @@ _SCAN_SUFFIXES = frozenset({".py", ".md", ".yml", ".yaml", ".rst", ".txt", ".jso
 # scripts/flat_tests_disposition.json (#3879 S2) is the SAME shape as
 # CHANGELOG.md, not the same shape as this gate's own baseline: its
 # `moved` entries are keyed on the file's OLD flat path by design — "this
-# WAS at tests/foo.py, now at tests/bar/foo.py" is the record, and the old
-# path correctly never resolves again. Counting that as gate debt would
+# file used to be at the flat root, now lives in a bucket subdirectory" is
+# the record (deliberately not spelled as a literal tests/-shaped example
+# here, so this docstring's own prose doesn't become a hit against this
+# gate's own scan), and the old path correctly never resolves again.
+# Counting that as gate debt would
 # charge #3879's own disposition-tracking artifact for doing its job
 # (lead-coder review, #4065 follow-up): every file it records as moved
 # would cost one baseline entry here, forever, which is backwards for the

--- a/scripts/check_tests_path_literal_reference.py
+++ b/scripts/check_tests_path_literal_reference.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""#4065 — every `tests/...py` path literal, repo-wide, must resolve to a real file.
+
+## The class this closes
+
+A path literal referencing a `tests/` file — in a docstring, a code comment,
+a doc's prose, a YAML/workflow file's command args — goes stale the moment
+that file moves, UNLESS something checks it. #3879's bucket migrations broke
+this 3 times, each caught by a DIFFERENT, weaker mechanism:
+
+  - #4025: a stale assert inside `tests/builtin/` — caught because CI ran it
+    and it went RED.
+  - #4036: a stale `pytest <path>` arg inside a `.github/workflows/*.yml`
+    file — caught because pytest happened to exit 4 (0 collected) rather
+    than silently passing. Coincidental, not a mechanism.
+  - #4062/#4063: stale prose in `docs/`/`src/`/`scripts/` — caught only by
+    a human running `grep` by hand. **Nothing executes this text, so
+    nothing was ever going to turn red on its own.**
+
+The third shape is the dangerous one: it stays green forever, because
+nothing exercises it. This script is the missing "does it still exist"
+check for exactly that shape — a population scan, not an execution path.
+
+## Two mistakes this design deliberately avoids (both made twice during #3879)
+
+1. **Scoping the population to `tests/` alone.** The reference and the
+   referenced file are on OPPOSITE sides — the reference lives in `docs/`,
+   `src/`, `scripts/`, `.github/`, anywhere in the repo, while only the
+   referenced FILE lives under `tests/`. Scoping the SCAN to `tests/` (the
+   #3879 bucket-migration PRs' own repeated mistake) misses every one of
+   these by construction. This script scans the WHOLE tracked repository.
+2. **Requiring the match to start right after an opening quote.** #4006's
+   own measured lesson: anchoring a `tests/` literal detector to "the quote
+   character is immediately followed by `tests/`" undercounted a real
+   population by 17x (17 found vs. 287 actual) — a huge fraction of real
+   references are embedded mid-sentence (`` "the gate in tests/scripts/
+   test_foo.py fires" ``, `` `RED tests/test_x.py::test_y` ``), not
+   standalone path strings. This script's regex matches `tests/...` ANYWHERE
+   inside a larger string/prose run, with a word boundary on the left, not
+   only at a string literal's own start.
+
+## Scope: text content, not just Python source
+
+Docstrings, code comments, plain string literals, Markdown prose, YAML
+values, workflow files — anywhere a person or tool might type a path. The
+scan is a plain regex over raw file text, not an AST walk restricted to
+`.py` files — the whole point is to catch prose in `.md`/`.yml` too, which
+an AST-based scan structurally cannot see.
+
+## A ratchet, not a zero baseline (#4065's own design pivot)
+
+A real, whole-repo measurement returns several hundred hits, most of them
+pre-existing debt (a reference that WAS real and went stale when its file
+moved, long before this gate existed — not something a #3879-era PR
+introduced). Requiring that backlog closed before adoption defers adoption
+indefinitely, so — same skeleton as ``mypy_ratchet.py`` — this is a
+committed BASELINE of every ``(referencing_file, literal)`` pair the tree
+currently carries. A pair not in the baseline is new — CI fails immediately.
+A pair that WAS in the baseline and is gone (because someone fixed it, or
+the referencing file itself moved/was deleted) just silently stops
+appearing; nothing has to be edited to let a fix "count."
+
+Deliberately keyed on ``(referencing_file, literal)``, not on the line
+number: an unrelated edit shifting a line above a reference must never
+itself flip the gate red, the same reasoning ``mypy_ratchet.py`` gives for
+excluding its own error line number from the key.
+
+**No placeholder-name allowlist.** A hand-picked list of "illustrative
+example" basenames (``test_a.py``, ``test_x.py``, ...) was considered and
+rejected: it would silently swallow every FUTURE reference sharing one of
+those names too, including a genuine new stale reference, defeating the one
+thing a ratchet is for — surfacing every new addition for a human to triage.
+The baseline already grandfathers every current illustrative-example hit
+(measured, not guessed) exactly like any other pre-existing entry; nothing
+about "is this one illustrative" needs to be decided up front.
+
+## Verified baseline
+
+## Population: `git ls-files`, not a directory walk
+
+The scan population is TRACKED files (`git ls-files`), not `Path.rglob()`
+filtered by a hand-maintained excluded-directories list. `git ls-files`
+already answers "is this real repo content" with zero rules of its own to
+keep in sync — `site/` (mkdocs' build output), `.venv/`, `__pycache__/`,
+node_modules, every build/VCS-internal directory, are simply never in its
+output, because none of them are tracked. A future build tool that dumps
+its own generated tree somewhere new is excluded automatically, for free,
+the same day it starts being gitignored — no second exclusion list to
+remember to extend (lead-coder review, #4065: a directory-exclusion list
+for `site/` would have needed re-deriving by hand for every future
+generated-output directory; `git ls-files` needs none).
+
+Run directly against the real repo tree; see ``check_tests_path_literal_reference_baseline.json``
+and the paired test file's ``test_the_real_repo_tree_measurement_matches_the_baseline``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_BASELINE_PATH = _ROOT / "scripts" / "check_tests_path_literal_reference_baseline.json"
+
+# A tests/... path-shaped literal: word-boundary on the left (so "xtests/foo"
+# doesn't match), "tests/" itself, then one or more path segments ending in
+# .py — NOT anchored to the start of a string/quote, matches anywhere inside
+# a larger run of text (#4006's own lesson — see module docstring).
+_PATH_LITERAL_RE = re.compile(r"(?<![\w/])tests/[\w][\w./-]*\.py")
+
+# File types worth scanning for a tests/ path reference — prose (.md), code
+# (.py), config/CI (.yml/.yaml), anything text-based a person could type a
+# path into. Deliberately broad per the issue's own "docstring / comment /
+# string / YAML / Markdown" scope.
+_SCAN_SUFFIXES = frozenset({".py", ".md", ".yml", ".yaml", ".rst", ".txt", ".json"})
+
+# CHANGELOG.md is TRACKED (so `git ls-files` does not exclude it the way it
+# excludes a gitignored build directory), but it's a historical record — a
+# past entry correctly names a path that was real AT THE TIME the entry was
+# written, then the repo moved on. Rewriting history to keep a changelog
+# "accurate" about the present is backwards; this file's job is to say what
+# happened, not what's still true. This is why CHANGELOG.md needs an
+# explicit rule while `site/` does not (lead-coder review, #4065): tracked
+# vs. gitignored is exactly the line between "needs a rule" and "the
+# population definition already handles it."
+#
+# check_tests_path_literal_reference_baseline.json is THIS gate's own
+# committed baseline — it necessarily embeds hundreds of `tests/...py`
+# literal strings as DATA (the very things the scan reports), which the
+# generic regex-over-text-content scan would otherwise re-match as if they
+# were prose/code references and count once per baseline entry per run —
+# an entirely self-inflicted, ever-growing false-positive population,
+# caught the first time `--write-baseline` was run against itself.
+_EXCLUDED_FILES = frozenset({"CHANGELOG.md", "check_tests_path_literal_reference_baseline.json"})
+
+
+def _iter_scan_files(root: Path = _ROOT):
+    """Every TRACKED file worth scanning — `git ls-files`, filtered to
+    :data:`_SCAN_SUFFIXES` and :data:`_EXCLUDED_FILES`. See the module
+    docstring's "Population" section for why this is `git ls-files` and not
+    a directory walk."""
+    proc = subprocess.run(
+        ["git", "ls-files"], cwd=root, capture_output=True, text=True, check=True,
+    )
+    for line in proc.stdout.splitlines():
+        rel = Path(line)
+        if rel.suffix not in _SCAN_SUFFIXES:
+            continue
+        if rel.name in _EXCLUDED_FILES:
+            continue
+        yield root / rel
+
+
+def _ever_tracked_tests_py(root: Path = _ROOT) -> "set[str]":
+    """Every `tests/*.py` path that has EVER been a real tracked file, at
+    any point in the repo's full history — the "never-existed" vs. "stale"
+    class discriminator (lead-coder review, #4065): a literal naming a path
+    that never once existed is an illustrative example or a doc's promise
+    that was never built (a doc-accuracy defect worse than staleness, but
+    harmless to run — never a real file moving), while a literal naming a
+    path that WAS real and now isn't is a genuine stale reference (fix the
+    path). Collapsing the two loses exactly the information a future triage
+    pass needs and would have to re-measure from scratch."""
+    proc = subprocess.run(
+        ["git", "log", "--all", "--name-only", "--pretty=format:", "--", "tests/*.py"],
+        cwd=root, capture_output=True, text=True, check=True,
+    )
+    return {line.strip() for line in proc.stdout.splitlines() if line.strip()}
+
+
+def offending_references(root: Path = _ROOT) -> "list[tuple[Path, str, int]]":
+    """Every (referencing_file, tests/-path-literal, line_number) where the
+    literal does NOT resolve to a real file under *root* — the gate's
+    entire decision, isolated from CLI/printing so it is directly
+    testable."""
+    offenders: list[tuple[Path, str, int]] = []
+    for path in _iter_scan_files(root):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for m in _PATH_LITERAL_RE.finditer(line):
+                literal = m.group(0)
+                if not (root / literal).is_file():
+                    offenders.append((path, literal, lineno))
+    return offenders
+
+
+def measured_pairs(root: Path = _ROOT) -> "set[tuple[str, str]]":
+    """The ``{(referencing_file, literal)}`` set — the ratchet's key,
+    deliberately dropping the line number (see module docstring: an
+    unrelated edit shifting a line above a reference must not itself flip
+    the gate red)."""
+    return {
+        (str(path.relative_to(root)), literal)
+        for path, literal, _lineno in offending_references(root)
+    }
+
+
+def classify(literal: str, ever_tracked: "set[str]") -> str:
+    """``"stale"`` if *literal* was ever a real tracked `tests/*.py` file
+    (it moved or was deleted — fix the reference), else
+    ``"never-existed"`` (an illustrative example, OR a doc naming a test
+    that was promised and never built — see :func:`_ever_tracked_tests_py`).
+    Not used to decide inclusion — every pair is baselined regardless of
+    class; this is recorded metadata for a future triage pass, never a
+    filter (lead-coder review, #4065: an exclusion rule needs a machine-
+    checkable condition, and "illustrative in context" is a judgment, not
+    one — collapsing the classes here would lose exactly the same
+    information a filter would have hidden)."""
+    return "stale" if literal in ever_tracked else "never-existed"
+
+
+def load_baseline(path: Path = _BASELINE_PATH) -> "set[tuple[str, str]]":
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return {(entry["file"], entry["literal"]) for entry in data}
+
+
+def write_baseline(
+    pairs: "set[tuple[str, str]]", ever_tracked: "set[str]", path: Path = _BASELINE_PATH,
+) -> None:
+    data = [
+        {"file": f, "literal": lit, "class": classify(lit, ever_tracked)}
+        for f, lit in sorted(pairs)
+    ]
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def new_pairs(
+    measured: "set[tuple[str, str]]", baseline: "set[tuple[str, str]]"
+) -> "set[tuple[str, str]]":
+    """The ratchet check itself: any measured pair the baseline does not
+    already declare is new — a pair leaving the measured set (a fix, or the
+    referencing file itself moving/being deleted) is not reported here at
+    all, by design (see module docstring)."""
+    return measured - baseline
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--write-baseline",
+        action="store_true",
+        help=(
+            "regenerate the baseline from a fresh scan instead of checking "
+            "against it. Use ONLY after actually fixing/triaging references — "
+            "regenerating to silence a new failure defeats the ratchet (see "
+            "module docstring)."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    measured = measured_pairs(_ROOT)
+
+    if args.write_baseline:
+        write_baseline(measured, _ever_tracked_tests_py(_ROOT))
+        print(f"Wrote {len(measured)} (referencing_file, literal) pair(s) to {_BASELINE_PATH}")
+        return 0
+
+    baseline = load_baseline()
+    new = new_pairs(measured, baseline)
+
+    if not new:
+        print(
+            f"tests-path-literal-reference ratchet OK: {len(measured)} reference(s), "
+            f"all baselined ({len(baseline)} declared)."
+        )
+        return 0
+
+    print("tests-path-literal-reference ratchet FAILED:\n", file=sys.stderr)
+    print(
+        f"{len(new)} new (referencing_file, literal) pair(s) not in the baseline "
+        f"({_BASELINE_PATH.relative_to(_ROOT)}) — a tests/ file reference that no "
+        "longer resolves and wasn't there before:",
+        file=sys.stderr,
+    )
+    for file, literal in sorted(new):
+        print(f"  {file}: {literal}", file=sys.stderr)
+    print(
+        "\nUpdate the reference to the file's current location (or remove it "
+        "if the file was deleted). If the literal is a deliberate "
+        "illustrative example (not a real path), that's fine too — but say "
+        "so and regenerate the baseline (--write-baseline) rather than "
+        "leaving it unexplained.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_tests_path_literal_reference.py
+++ b/scripts/check_tests_path_literal_reference.py
@@ -134,7 +134,21 @@ _SCAN_SUFFIXES = frozenset({".py", ".md", ".yml", ".yaml", ".rst", ".txt", ".jso
 # were prose/code references and count once per baseline entry per run —
 # an entirely self-inflicted, ever-growing false-positive population,
 # caught the first time `--write-baseline` was run against itself.
-_EXCLUDED_FILES = frozenset({"CHANGELOG.md", "check_tests_path_literal_reference_baseline.json"})
+#
+# scripts/flat_tests_disposition.json (#3879 S2) is the SAME shape as
+# CHANGELOG.md, not the same shape as this gate's own baseline: its
+# `moved` entries are keyed on the file's OLD flat path by design — "this
+# WAS at tests/foo.py, now at tests/bar/foo.py" is the record, and the old
+# path correctly never resolves again. Counting that as gate debt would
+# charge #3879's own disposition-tracking artifact for doing its job
+# (lead-coder review, #4065 follow-up): every file it records as moved
+# would cost one baseline entry here, forever, which is backwards for the
+# same reason rewriting CHANGELOG.md's history would be.
+_EXCLUDED_FILES = frozenset({
+    "CHANGELOG.md",
+    "check_tests_path_literal_reference_baseline.json",
+    "flat_tests_disposition.json",
+})
 
 
 def _iter_scan_files(root: Path = _ROOT):

--- a/scripts/check_tests_path_literal_reference.py
+++ b/scripts/check_tests_path_literal_reference.py
@@ -151,10 +151,19 @@ _SCAN_SUFFIXES = frozenset({".py", ".md", ".yml", ".yaml", ".rst", ".txt", ".jso
 # (lead-coder review, #4065 follow-up): every file it records as moved
 # would cost one baseline entry here, forever, which is backwards for the
 # same reason rewriting CHANGELOG.md's history would be.
+#
+# scripts/flat_tests_arc_population.json (#3879 S5, #4072) is the SAME
+# shape again: a FROZEN, point-in-time snapshot of every flat filename
+# Stage 0 committed — most of them have since moved into a bucket by
+# design, so most of the 1,129 entries never resolve, and never should.
+# It carries no `to` field pointing anywhere current to fall back on
+# (unlike disposition.json's `moved` entries) — it is pure historical
+# population data, read-only, the same class as CHANGELOG.md.
 _EXCLUDED_FILES = frozenset({
     "CHANGELOG.md",
     "check_tests_path_literal_reference_baseline.json",
     "flat_tests_disposition.json",
+    "flat_tests_arc_population.json",
 })
 
 

--- a/scripts/check_tests_path_literal_reference_baseline.json
+++ b/scripts/check_tests_path_literal_reference_baseline.json
@@ -1620,11 +1620,6 @@
     "class": "never-existed"
   },
   {
-    "file": "tests/gateway/test_api.py",
-    "literal": "tests/test_3595_step1b_external_producer_slash_reachability.py",
-    "class": "stale"
-  },
-  {
     "file": "tests/hooks/test_hook_composer.py",
     "literal": "tests/test_3180_durable_pending_store.py",
     "class": "stale"
@@ -1710,11 +1705,6 @@
     "class": "stale"
   },
   {
-    "file": "tests/interfaces/test_3300_p3_cancel_by_id.py",
-    "literal": "tests/test_3300_p2a_queue_state_publish.py",
-    "class": "stale"
-  },
-  {
     "file": "tests/interfaces/test_3310_n1_session_attached_barrier.py",
     "literal": "tests/test_agui_profile_completeness.py",
     "class": "stale"
@@ -1722,11 +1712,6 @@
   {
     "file": "tests/interfaces/test_3310_n2_reset_hydrate.py",
     "literal": "tests/test_2242_hard_cancel.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/interfaces/test_3310_n2_reset_hydrate.py",
-    "literal": "tests/test_3300_p2a_queue_state_publish.py",
     "class": "stale"
   },
   {
@@ -1855,11 +1840,6 @@
     "class": "stale"
   },
   {
-    "file": "tests/interfaces/test_textual_chat_intervention_panel_3299.py",
-    "literal": "tests/test_textual_chat_copy_rewind_3362.py",
-    "class": "stale"
-  },
-  {
     "file": "tests/interfaces/test_textual_chat_phase2_3273.py",
     "literal": "tests/test_textual_chat_row_contrast_3367.py",
     "class": "stale"
@@ -1897,11 +1877,6 @@
   {
     "file": "tests/llm/test_2608_run_loop_pickup.py",
     "literal": "tests/test_2608_h4_fs_watcher.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/llm/test_3792_pr2_router_loop_injection.py",
-    "literal": "tests/test_3792_pr2_session_injection.py",
     "class": "stale"
   },
   {
@@ -2227,11 +2202,6 @@
   {
     "file": "tests/security/test_codeact_runner_1593.py",
     "literal": "tests/test_sandbox_landlock.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/security/test_sandbox_axis_contract_2983.py",
-    "literal": "tests/test_sandbox_axis_contract_2983.py",
     "class": "stale"
   },
   {

--- a/scripts/check_tests_path_literal_reference_baseline.json
+++ b/scripts/check_tests_path_literal_reference_baseline.json
@@ -800,6 +800,416 @@
     "class": "never-existed"
   },
   {
+    "file": "scripts/check_tests_path_literal_reference.py",
+    "literal": "tests/test_x.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_2081_s1_delegation_config.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_2421_mcp_seam_completeness.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_3024_env_identity.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_3126_doc_anchor_gate.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_3233_inprocess_env_identity.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_3237_worktree_clean_gate.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_3723_flowview_pin_check.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_3726_mypy_ratchet.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_3794_p2_no_audit_event_prose.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_3794_p3_audit_event_identifier_rename.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_action_retrieval_config.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_agent_construction_via_factory_997.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_artifact_validator_resolve_path.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_audit_events_single_assignment_3408.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_builtin_skill_tool_name_drift_3092.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_charter_citations_reference_live_content_3592.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_check_pr_closing_intent.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_compaction_outcome_dist.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_config_cascade.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_config_loader_malformed.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_config_loader_pure_helpers.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_config_mcp_merge_1146.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_config_mirror_coverage_1056.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_config_package_reexport_1682.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_cost_chokepoint_ast_guard_1190.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_cwd_sandbox_aware_1477.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_detect_attractor.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_dogfood_batch_compaction_grant_opt_in.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_dogfood_batch_config_scenario_count_autoderive.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_dogfood_batch_tools.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_dogfood_dispatch_absolute_deliverable.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_dogfood_dispatch_verdict_scoping_guidance.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_dogfood_enforcement_profile.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_dogfood_long_session_skill_wait.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_dogfood_trace_llm_modes.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_dogfood_trace_multi_file.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_dogfood_trace_tool.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_dogfood_variant_replay.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_dogfood_workspace_rooting_1431.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_embedding_config.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_embedding_provider.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_environment_import_no_circular_3867.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_fastmcp_core_dep_import_chain.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_fp0009_b_cron_config.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_httpx_lazy_load_cli_entry.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_index_backend.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_litellm_api_base_single_writer_ast_guard_2683.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_llm_replay_diff.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_llm_replay_from_attractor.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_llm_replay_patch.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_llm_replay_script.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_mcp_gateway_cancel_event_completeness_2813.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_media_store.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_media_store_pure_helpers.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_memory_rewrite_index_e2e.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_missing_fixture_fails_loud_3662.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_pipe_proxy_bootstrap_2682.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_present_sink_ast_guard_2708.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_project_context_agents_md.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_python_harness_no_litellm_import.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_reyn_web_proc.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_root_markdown_relative_links.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_router_op_context_single_source_1412.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_scheme_self_register_1608.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_session_shutdown_acompletion_warning.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_source_manifest.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_source_manifest_chunk_count_coerce.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_sqlite_index_pure_helpers.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_st_removal_grep_zero_3128.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_stream_client_single_writer_boundary.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_swe_bench_runner.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_swe_bench_runner_chat_187.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_swe_bench_runner_venv_183.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_text_codec.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_threat_scan_config_1822.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_tier_audit_format_pin.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_tier_audit_private_state_ast.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_tier_audit_source_segment_cache_3670.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_verify_package_move_root_config.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_web_auth_config_contract.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/flat_tests_disposition.json",
+    "literal": "tests/test_ws_consolidation_complete.py",
+    "class": "stale"
+  },
+  {
     "file": "scripts/flat_tests_ratchet.py",
     "literal": "tests/test_3595_s4_slash_handler_seam.py",
     "class": "stale"
@@ -2078,6 +2488,71 @@
     "file": "tests/scripts/test_check_tests_dir_names_3879.py",
     "literal": "tests/test_verify_package_move_root_config.py",
     "class": "stale"
+  },
+  {
+    "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
+    "literal": "tests/scripts/test_foo.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
+    "literal": "tests/services/test_gone.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
+    "literal": "tests/services/test_long_gone.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
+    "literal": "tests/services/test_x.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
+    "literal": "tests/test_a.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
+    "literal": "tests/test_also_gone.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
+    "literal": "tests/test_gone.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
+    "literal": "tests/test_moved_away.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
+    "literal": "tests/test_new_gone.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_flat_tests_disposition_check_3879.py",
+    "literal": "tests/test_a.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_flat_tests_disposition_check_3879.py",
+    "literal": "tests/test_b.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_flat_tests_disposition_check_3879.py",
+    "literal": "tests/test_c.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_flat_tests_disposition_check_3879.py",
+    "literal": "tests/x/test_a.py",
+    "class": "never-existed"
   },
   {
     "file": "tests/security/test_1199_s31b_mcp_cutover.py",

--- a/scripts/check_tests_path_literal_reference_baseline.json
+++ b/scripts/check_tests_path_literal_reference_baseline.json
@@ -801,413 +801,18 @@
   },
   {
     "file": "scripts/check_tests_path_literal_reference.py",
-    "literal": "tests/test_x.py",
+    "literal": "tests/bar/foo.py",
     "class": "never-existed"
   },
   {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_2081_s1_delegation_config.py",
-    "class": "stale"
+    "file": "scripts/check_tests_path_literal_reference.py",
+    "literal": "tests/foo.py",
+    "class": "never-existed"
   },
   {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_2421_mcp_seam_completeness.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_3024_env_identity.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_3126_doc_anchor_gate.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_3233_inprocess_env_identity.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_3237_worktree_clean_gate.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_3723_flowview_pin_check.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_3726_mypy_ratchet.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_3794_p2_no_audit_event_prose.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_3794_p3_audit_event_identifier_rename.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_action_retrieval_config.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_agent_construction_via_factory_997.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_artifact_validator_resolve_path.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_audit_events_single_assignment_3408.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_builtin_skill_tool_name_drift_3092.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_charter_citations_reference_live_content_3592.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_check_pr_closing_intent.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_compaction_outcome_dist.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_config_cascade.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_config_loader_malformed.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_config_loader_pure_helpers.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_config_mcp_merge_1146.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_config_mirror_coverage_1056.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_config_package_reexport_1682.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_cost_chokepoint_ast_guard_1190.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_cwd_sandbox_aware_1477.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_detect_attractor.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_dogfood_batch_compaction_grant_opt_in.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_dogfood_batch_config_scenario_count_autoderive.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_dogfood_batch_tools.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_dogfood_dispatch_absolute_deliverable.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_dogfood_dispatch_verdict_scoping_guidance.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_dogfood_enforcement_profile.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_dogfood_long_session_skill_wait.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_dogfood_trace_llm_modes.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_dogfood_trace_multi_file.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_dogfood_trace_tool.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_dogfood_variant_replay.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_dogfood_workspace_rooting_1431.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_embedding_config.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_embedding_provider.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_environment_import_no_circular_3867.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_fastmcp_core_dep_import_chain.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_fp0009_b_cron_config.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_httpx_lazy_load_cli_entry.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_index_backend.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_litellm_api_base_single_writer_ast_guard_2683.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_llm_replay_diff.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_llm_replay_from_attractor.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_llm_replay_patch.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_llm_replay_script.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_mcp_gateway_cancel_event_completeness_2813.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_media_store.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_media_store_pure_helpers.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_memory_rewrite_index_e2e.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_missing_fixture_fails_loud_3662.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_pipe_proxy_bootstrap_2682.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_present_sink_ast_guard_2708.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_project_context_agents_md.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_python_harness_no_litellm_import.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_reyn_web_proc.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_root_markdown_relative_links.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_router_op_context_single_source_1412.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_scheme_self_register_1608.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_session_shutdown_acompletion_warning.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_source_manifest.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_source_manifest_chunk_count_coerce.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_sqlite_index_pure_helpers.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_st_removal_grep_zero_3128.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_stream_client_single_writer_boundary.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_swe_bench_runner.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_swe_bench_runner_chat_187.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_swe_bench_runner_venv_183.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_text_codec.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_threat_scan_config_1822.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_tier_audit_format_pin.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_tier_audit_private_state_ast.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_tier_audit_source_segment_cache_3670.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_verify_package_move_root_config.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_web_auth_config_contract.py",
-    "class": "stale"
-  },
-  {
-    "file": "scripts/flat_tests_disposition.json",
-    "literal": "tests/test_ws_consolidation_complete.py",
-    "class": "stale"
+    "file": "scripts/check_tests_path_literal_reference.py",
+    "literal": "tests/test_x.py",
+    "class": "never-existed"
   },
   {
     "file": "scripts/flat_tests_ratchet.py",
@@ -1416,11 +1021,6 @@
   },
   {
     "file": "src/reyn/runtime/registry.py",
-    "literal": "tests/test_2103_s1bc_session_spawn_tool.py",
-    "class": "stale"
-  },
-  {
-    "file": "src/reyn/runtime/registry.py",
     "literal": "tests/test_registry_restore_all_only_names_3671_p4c1.py",
     "class": "stale"
   },
@@ -1562,6 +1162,11 @@
   {
     "file": "tests/_support/builtin_skill_tool_names.py",
     "literal": "tests/test_catalog_entries_1593.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/_support/builtin_skill_tool_names.py",
+    "literal": "tests/test_fp0063_p4_builtin_rag_skill.py",
     "class": "stale"
   },
   {
@@ -1772,6 +1377,11 @@
   {
     "file": "tests/core/test_3783_stage3_invert_default_to_recover.py",
     "literal": "tests/test_pr_n6_compaction_overflow_retry.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_3846_image_fetch.py",
+    "literal": "tests/test_ssrf_guard_1956.py",
     "class": "stale"
   },
   {
@@ -2246,6 +1856,11 @@
   },
   {
     "file": "tests/llm/test_2608_run_loop_pickup.py",
+    "literal": "tests/test_2608_h1_mcp_resource_updated_hook.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/llm/test_2608_run_loop_pickup.py",
     "literal": "tests/test_2608_h4_fs_watcher.py",
     "class": "stale"
   },
@@ -2270,6 +1885,26 @@
     "class": "stale"
   },
   {
+    "file": "tests/plugins/test_fp0063_p4_builtin_rag_skill.py",
+    "literal": "tests/test_builtin_skill_tool_name_drift_3092.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/plugins/test_fp0063_p4_builtin_rag_skill.py",
+    "literal": "tests/test_plugin_install.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/plugins/test_fp0063_p4_builtin_rag_skill.py",
+    "literal": "tests/test_skill_md_default_inline_cap_gate.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/plugins/test_fp0063_p4_builtin_rag_skill.py",
+    "literal": "tests/test_skill_references_gate_3162.py",
+    "class": "stale"
+  },
+  {
     "file": "tests/plugins/test_skill_load.py",
     "literal": "tests/test_op_runtime_load_skill_3247.py",
     "class": "stale"
@@ -2277,6 +1912,11 @@
   {
     "file": "tests/repo/test_3794_p3_audit_event_identifier_rename.py",
     "literal": "tests/test_audit_event_kind_vocabulary_3410.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/repo/test_builtin_skill_tool_name_drift_3092.py",
+    "literal": "tests/test_fp0063_p4_builtin_rag_skill.py",
     "class": "stale"
   },
   {
@@ -2350,6 +1990,16 @@
     "class": "stale"
   },
   {
+    "file": "tests/runtime/test_fp0063_arc_witness.py",
+    "literal": "tests/test_op_embed.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_fp0063_arc_witness.py",
+    "literal": "tests/test_replay_fixture_no_stacking_3634.py",
+    "class": "stale"
+  },
+  {
     "file": "tests/runtime/test_intervention_bus_protocols.py",
     "literal": "tests/test_intervention_legacy_alias_deprecated.py",
     "class": "stale"
@@ -2362,6 +2012,11 @@
   {
     "file": "tests/runtime/test_media_cap_272.py",
     "literal": "tests/test_file_read_binary_retire_rtr_1449.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_pipeline_a2_spawn_ephemeral_session.py",
+    "literal": "tests/test_2103_s1bc_session_spawn_tool.py",
     "class": "stale"
   },
   {
@@ -2435,6 +2090,11 @@
     "class": "stale"
   },
   {
+    "file": "tests/scripts/test_check_file_depth_reference_3995.py",
+    "literal": "tests/test_fp0063_arc_witness.py",
+    "class": "stale"
+  },
+  {
     "file": "tests/scripts/test_check_migration_diff_shape_3879.py",
     "literal": "tests/core/test_a.py",
     "class": "never-existed"
@@ -2488,6 +2148,11 @@
     "file": "tests/scripts/test_check_tests_dir_names_3879.py",
     "literal": "tests/test_verify_package_move_root_config.py",
     "class": "stale"
+  },
+  {
+    "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
+    "literal": "tests/core/test_moved_away.py",
+    "class": "never-existed"
   },
   {
     "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
@@ -2590,6 +2255,11 @@
     "class": "stale"
   },
   {
+    "file": "tests/test_3546_pipeline_driver_narrowing_inheritance.py",
+    "literal": "tests/test_pipeline_a2_spawn_ephemeral_session.py",
+    "class": "stale"
+  },
+  {
     "file": "tests/test_3561_spawn_session_seam_reachability.py",
     "literal": "tests/test_pipeline_r5_run_agent_step.py",
     "class": "stale"
@@ -2607,41 +2277,6 @@
   {
     "file": "tests/test_3792_pr2_session_injection.py",
     "literal": "tests/test_3792_pr2_router_loop_injection.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/test_fp0063_arc_witness.py",
-    "literal": "tests/test_op_embed.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/test_fp0063_arc_witness.py",
-    "literal": "tests/test_replay_fixture_no_stacking_3634.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/test_fp0063_p4_builtin_rag_skill.py",
-    "literal": "tests/test_builtin_skill_tool_name_drift_3092.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/test_fp0063_p4_builtin_rag_skill.py",
-    "literal": "tests/test_plugin_install.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/test_fp0063_p4_builtin_rag_skill.py",
-    "literal": "tests/test_skill_md_default_inline_cap_gate.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/test_fp0063_p4_builtin_rag_skill.py",
-    "literal": "tests/test_skill_references_gate_3162.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/test_pipeline_a2_spawn_ephemeral_session.py",
-    "literal": "tests/test_2103_s1bc_session_spawn_tool.py",
     "class": "stale"
   },
   {

--- a/scripts/check_tests_path_literal_reference_baseline.json
+++ b/scripts/check_tests_path_literal_reference_baseline.json
@@ -2000,6 +2000,61 @@
     "class": "stale"
   },
   {
+    "file": "tests/runtime/test_3546_pipeline_driver_narrowing_inheritance.py",
+    "literal": "tests/test_2103_s1bc_session_spawn_tool.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_3546_pipeline_driver_narrowing_inheritance.py",
+    "literal": "tests/test_3093_pipeline_registry_spawn_propagation.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_3546_pipeline_driver_narrowing_inheritance.py",
+    "literal": "tests/test_3556_session_spawn_narrowing_inheritance.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_3546_pipeline_driver_narrowing_inheritance.py",
+    "literal": "tests/test_3561_spawn_session_seam_reachability.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_3546_pipeline_driver_narrowing_inheritance.py",
+    "literal": "tests/test_pipeline_a2_spawn_ephemeral_session.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_3553_agent_step_worker_narrowing_inheritance.py",
+    "literal": "tests/test_3546_pipeline_driver_narrowing_inheritance.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_3556_session_spawn_narrowing_inheritance.py",
+    "literal": "tests/test_3546_pipeline_driver_narrowing_inheritance.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_3561_spawn_session_seam_reachability.py",
+    "literal": "tests/test_3546_pipeline_driver_narrowing_inheritance.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_3561_spawn_session_seam_reachability.py",
+    "literal": "tests/test_pipeline_r5_run_agent_step.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_3562_slash_session_new_narrowing_inheritance.py",
+    "literal": "tests/test_3546_pipeline_driver_narrowing_inheritance.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_3562_slash_session_new_narrowing_inheritance.py",
+    "literal": "tests/test_3561_spawn_session_seam_reachability.py",
+    "class": "stale"
+  },
+  {
     "file": "tests/runtime/test_3595_s2_pipeline_nudge_origin.py",
     "literal": "tests/test_pipeline_is6_attached.py",
     "class": "stale"
@@ -2212,26 +2267,6 @@
   {
     "file": "tests/security/test_sandbox_seccomp_network_3030.py",
     "literal": "tests/test_plugin_install.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/test_3546_pipeline_driver_narrowing_inheritance.py",
-    "literal": "tests/test_2103_s1bc_session_spawn_tool.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/test_3546_pipeline_driver_narrowing_inheritance.py",
-    "literal": "tests/test_3093_pipeline_registry_spawn_propagation.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/test_3546_pipeline_driver_narrowing_inheritance.py",
-    "literal": "tests/test_pipeline_a2_spawn_ephemeral_session.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/test_3561_spawn_session_seam_reachability.py",
-    "literal": "tests/test_pipeline_r5_run_agent_step.py",
     "class": "stale"
   },
   {

--- a/scripts/check_tests_path_literal_reference_baseline.json
+++ b/scripts/check_tests_path_literal_reference_baseline.json
@@ -1375,6 +1375,16 @@
     "class": "stale"
   },
   {
+    "file": "tests/core/test_3792_pr2_session_injection.py",
+    "literal": "tests/test_3300_p3_cancel_by_id.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_3792_pr2_session_injection.py",
+    "literal": "tests/test_3792_pr2_router_loop_injection.py",
+    "class": "stale"
+  },
+  {
     "file": "tests/core/test_3846_image_fetch.py",
     "literal": "tests/test_ssrf_guard_1956.py",
     "class": "stale"
@@ -1610,6 +1620,11 @@
     "class": "never-existed"
   },
   {
+    "file": "tests/gateway/test_api.py",
+    "literal": "tests/test_3595_step1b_external_producer_slash_reachability.py",
+    "class": "stale"
+  },
+  {
     "file": "tests/hooks/test_hook_composer.py",
     "literal": "tests/test_3180_durable_pending_store.py",
     "class": "stale"
@@ -1675,6 +1690,11 @@
     "class": "stale"
   },
   {
+    "file": "tests/interfaces/test_3300_p2a_queue_state_publish.py",
+    "literal": "tests/test_2242_hard_cancel.py",
+    "class": "stale"
+  },
+  {
     "file": "tests/interfaces/test_3300_p2b_sentqueue_render.py",
     "literal": "tests/test_user_submitted_render_3300.py",
     "class": "stale"
@@ -1690,6 +1710,11 @@
     "class": "stale"
   },
   {
+    "file": "tests/interfaces/test_3300_p3_cancel_by_id.py",
+    "literal": "tests/test_3300_p2a_queue_state_publish.py",
+    "class": "stale"
+  },
+  {
     "file": "tests/interfaces/test_3310_n1_session_attached_barrier.py",
     "literal": "tests/test_agui_profile_completeness.py",
     "class": "stale"
@@ -1697,6 +1722,11 @@
   {
     "file": "tests/interfaces/test_3310_n2_reset_hydrate.py",
     "literal": "tests/test_2242_hard_cancel.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_3310_n2_reset_hydrate.py",
+    "literal": "tests/test_3300_p2a_queue_state_publish.py",
     "class": "stale"
   },
   {
@@ -1820,6 +1850,16 @@
     "class": "stale"
   },
   {
+    "file": "tests/interfaces/test_textual_chat_copy_rewind_3362.py",
+    "literal": "tests/test_agui_control_filter.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_textual_chat_intervention_panel_3299.py",
+    "literal": "tests/test_textual_chat_copy_rewind_3362.py",
+    "class": "stale"
+  },
+  {
     "file": "tests/interfaces/test_textual_chat_phase2_3273.py",
     "literal": "tests/test_textual_chat_row_contrast_3367.py",
     "class": "stale"
@@ -1857,6 +1897,11 @@
   {
     "file": "tests/llm/test_2608_run_loop_pickup.py",
     "literal": "tests/test_2608_h4_fs_watcher.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/llm/test_3792_pr2_router_loop_injection.py",
+    "literal": "tests/test_3792_pr2_session_injection.py",
     "class": "stale"
   },
   {
@@ -1930,6 +1975,11 @@
     "class": "stale"
   },
   {
+    "file": "tests/runtime/test_2708_p32a_spawn_bridge_intervention.py",
+    "literal": "tests/test_2103_s1bc_exec_result_routing.py",
+    "class": "stale"
+  },
+  {
     "file": "tests/runtime/test_2946_item2_restore_all_bucketing.py",
     "literal": "tests/test_multi_session_restore.py",
     "class": "stale"
@@ -1972,6 +2022,11 @@
   {
     "file": "tests/runtime/test_3475_mcp_probe_priming_all_turn_kinds.py",
     "literal": "tests/test_session_refresh_mcp_servers.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_3595_s2_pipeline_nudge_origin.py",
+    "literal": "tests/test_pipeline_is6_attached.py",
     "class": "stale"
   },
   {
@@ -2175,18 +2230,18 @@
     "class": "stale"
   },
   {
+    "file": "tests/security/test_sandbox_axis_contract_2983.py",
+    "literal": "tests/test_sandbox_axis_contract_2983.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/security/test_sandbox_axis_contract_2983.py",
+    "literal": "tests/test_sandbox_seccomp_network_3030.py",
+    "class": "stale"
+  },
+  {
     "file": "tests/security/test_sandbox_seccomp_network_3030.py",
     "literal": "tests/test_plugin_install.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/test_2708_p32a_spawn_bridge_intervention.py",
-    "literal": "tests/test_2103_s1bc_exec_result_routing.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/test_3300_p2a_queue_state_publish.py",
-    "literal": "tests/test_2242_hard_cancel.py",
     "class": "stale"
   },
   {
@@ -2207,31 +2262,6 @@
   {
     "file": "tests/test_3561_spawn_session_seam_reachability.py",
     "literal": "tests/test_pipeline_r5_run_agent_step.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/test_3595_s2_pipeline_nudge_origin.py",
-    "literal": "tests/test_pipeline_is6_attached.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/test_3792_pr2_session_injection.py",
-    "literal": "tests/test_3300_p3_cancel_by_id.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/test_3792_pr2_session_injection.py",
-    "literal": "tests/test_3792_pr2_router_loop_injection.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/test_sandbox_axis_contract_2983.py",
-    "literal": "tests/test_sandbox_seccomp_network_3030.py",
-    "class": "stale"
-  },
-  {
-    "file": "tests/test_textual_chat_copy_rewind_3362.py",
-    "literal": "tests/test_agui_control_filter.py",
     "class": "stale"
   },
   {

--- a/scripts/check_tests_path_literal_reference_baseline.json
+++ b/scripts/check_tests_path_literal_reference_baseline.json
@@ -1,0 +1,2262 @@
+[
+  {
+    "file": ".github/workflows/test.yml",
+    "literal": "tests/test_2608_h4_fs_watcher.py",
+    "class": "stale"
+  },
+  {
+    "file": ".github/workflows/test.yml",
+    "literal": "tests/test_3595_s4_slash_handler_seam.py",
+    "class": "stale"
+  },
+  {
+    "file": ".github/workflows/test.yml",
+    "literal": "tests/test_mcp_client.py",
+    "class": "stale"
+  },
+  {
+    "file": "CLAUDE.md",
+    "literal": "tests/test_audit_event_kind_vocabulary_3410.py",
+    "class": "stale"
+  },
+  {
+    "file": "CLAUDE.md",
+    "literal": "tests/test_tui_colour_tokens.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/concepts/runtime/events.ja.md",
+    "literal": "tests/test_chat_turn_completed_inline.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/concepts/runtime/events.ja.md",
+    "literal": "tests/test_mcp_search_tool_invariants.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/concepts/runtime/events.ja.md",
+    "literal": "tests/test_session_lifecycle_events_1800.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/concepts/runtime/events.md",
+    "literal": "tests/test_chat_turn_completed_inline.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/concepts/runtime/events.md",
+    "literal": "tests/test_mcp_search_tool_invariants.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/concepts/runtime/events.md",
+    "literal": "tests/test_session_lifecycle_events_1800.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/concepts/runtime/intervention-delivery.md",
+    "literal": "tests/test_3049_driver_router_op_intervention_reaches_originator.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/concepts/runtime/intervention-delivery.md",
+    "literal": "tests/test_3053_budget_bus_bridge_aware.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/concepts/tools-integrations/skills.md",
+    "literal": "tests/test_skill_references_gate_3162.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/concepts/tools-integrations/universal-catalog.ja.md",
+    "literal": "tests/test_no_qualified_tool_names_3429.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/concepts/tools-integrations/universal-catalog.ja.md",
+    "literal": "tests/test_qualified_name_provider_grammar_1456.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/concepts/tools-integrations/universal-catalog.md",
+    "literal": "tests/test_no_qualified_tool_names_3429.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/concepts/tools-integrations/universal-catalog.md",
+    "literal": "tests/test_qualified_name_provider_grammar_1456.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/contributing/cli-redesign.md",
+    "literal": "tests/cli/test_tui_smoke.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/contributing/cli-redesign.md",
+    "literal": "tests/test_3595_s4_slash_handler_seam.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/contributing/testing.ja.md",
+    "literal": "tests/test_os_invariants.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/contributing/testing.ja.md",
+    "literal": "tests/test_replay_fixture_no_stacking_3634.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/contributing/testing.ja.md",
+    "literal": "tests/test_replay_my_area.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "docs/deep-dives/contributing/testing.ja.md",
+    "literal": "tests/test_replay_skill_router.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/contributing/testing.md",
+    "literal": "tests/scripts/__init__.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "docs/deep-dives/contributing/testing.md",
+    "literal": "tests/test_compaction_resolver_aware_1172.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/contributing/testing.md",
+    "literal": "tests/test_fp0063_p2_builtin_mcp_rag.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/contributing/testing.md",
+    "literal": "tests/test_fp0063_p3_rag_pipelines.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/contributing/testing.md",
+    "literal": "tests/test_os_invariants.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/contributing/testing.md",
+    "literal": "tests/test_replay_fixture_no_stacking_3634.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/contributing/testing.md",
+    "literal": "tests/test_replay_my_area.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "docs/deep-dives/contributing/testing.md",
+    "literal": "tests/test_replay_skill_router.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/contributing/testing.md",
+    "literal": "tests/test_your_area.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "docs/deep-dives/contributing/verification-hazards.md",
+    "literal": "tests/test_X.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "docs/deep-dives/decisions/0021-g12-attractor-structural-fix-design.md",
+    "literal": "tests/test_router_empty_response.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/decisions/0022-plan-mode-crash-fail-safe.md",
+    "literal": "tests/test_plan_lifecycle_crash.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/decisions/0022-plan-mode-crash-fail-safe.md",
+    "literal": "tests/test_planner.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/decisions/0023-plan-mode-forward-replay.md",
+    "literal": "tests/test_plan_lifecycle_crash.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/decisions/0026-unified-tool-registry.md",
+    "literal": "tests/test_plan_async_dispatch.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/decisions/0026-unified-tool-registry.md",
+    "literal": "tests/test_tool_registry_invariants.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/decisions/0035-phase-tool-calls-unification.md",
+    "literal": "tests/test_op_loop_resume_memo_1212.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-04-batch-1-practice/findings/F04-cost-always-zero.md",
+    "literal": "tests/test_session_cost_accumulation.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-04-batch-2-real/findings.md",
+    "literal": "tests/test_chat_router_i18n.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-04-batch-2-real/findings/B2-H1-specialist-describe-invoke-fail.md",
+    "literal": "tests/test_router_system_prompt.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-04-batch-2-real/findings/B2-H2-default-silent-absorption-marker.md",
+    "literal": "tests/test_session_invariants.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-04-batch-4-retest/findings/B4-H2-copy-to-work-act-budget.md",
+    "literal": "tests/test_copy_to_work_phase.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-04-batch-4-retest/findings/B4-H2-copy-to-work-act-budget.md",
+    "literal": "tests/test_copy_to_work_preprocessor.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-04-batch-6-non-attractor/findings/B6-S1-M1-hypothesis-a-tier3-verify.md",
+    "literal": "tests/test_copy_to_work_validation_judgment.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-04-batch-7-post-infra-verify/findings/B7-G12-truncation-fix.md",
+    "literal": "tests/test_router_skill_description_truncation.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-04-batch-7-post-infra-verify/findings/B7-RETRO-H2-fix-design.md",
+    "literal": "tests/test_router_list_skills_input_hint.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-05-batch-11-non-determinism-reduction/findings/B11-R1-path-typo-fix.md",
+    "literal": "tests/test_improvement_session_schema.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-05-batch-11-non-determinism-reduction/findings/B11-R2-g12-fix-verify.md",
+    "literal": "tests/test_router_skill_description_truncation.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-05-batch-11-non-determinism-reduction/findings/B11-R3-text-reply-fix-verify.md",
+    "literal": "tests/test_replay_skill_router.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-05-batch-11-non-determinism-reduction/findings/B11-R3-text-reply-fix-verify.md",
+    "literal": "tests/test_router_system_prompt.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-05-batch-9-fix-wave/findings.md",
+    "literal": "tests/test_eval_builder_path_resolution.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-05-batch-9-fix-wave/findings/B9-G15-diagnosis.md",
+    "literal": "tests/test_g15_noninteractive_startup_guard.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-05-batch-9-fix-wave/findings/B9-G15-fix-verify.md",
+    "literal": "tests/test_g15_noninteractive_startup_guard.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-05-batch-9-fix-wave/findings/B9-G16-fix-verify.md",
+    "literal": "tests/test_g16_eval_builder_routing_wording.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-05-batch-9-fix-wave/findings/B9-G17-fix-verify.md",
+    "literal": "tests/test_eval_builder_path_resolution.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-06-batch-12-real-milestone/findings/B12-M2-fixture-audit.md",
+    "literal": "tests/test_copy_to_work_validation_judgment.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-06-batch-12-real-milestone/findings/B12-M2-fixture-audit.md",
+    "literal": "tests/test_replay_skill_improver.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-06-batch-12-real-milestone/findings/B12-M2-fixture-audit.md",
+    "literal": "tests/test_skill_postprocessor_executor.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-06-batch-12-real-milestone/findings/B12-R1-fix-verify.md",
+    "literal": "tests/test_b11_stdlib_default_read_zone.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-06-batch-12-real-milestone/findings/B12-R1-fix-verify.md",
+    "literal": "tests/test_g15_noninteractive_startup_guard.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-06-batch-12-real-milestone/findings/B12-R1-fix-verify.md",
+    "literal": "tests/test_skill_improver_stdlib_read_perm.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-06-batch-13-revert-and-real-milestone/findings/B13-R1-revert-g15.md",
+    "literal": "tests/test_g15_noninteractive_startup_guard.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-06-batch-13-revert-and-real-milestone/findings/B13-R2-revert-stdlib-default-zone.md",
+    "literal": "tests/test_b11_stdlib_default_read_zone.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-06-batch-13-revert-and-real-milestone/findings/B13-R2-revert-stdlib-default-zone.md",
+    "literal": "tests/test_g15_noninteractive_startup_guard.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-06-batch-13-revert-and-real-milestone/findings/B13-R2-revert-stdlib-default-zone.md",
+    "literal": "tests/test_skill_improver_stdlib_read_perm.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-06-batch-13-revert-and-real-milestone/findings/B13-R3-v3-wording-fix.md",
+    "literal": "tests/test_router_system_prompt.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-06-batch-14-stability-extension/findings.md",
+    "literal": "tests/test_replay_skill_improver.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-06-batch-14-stability-extension/findings/B14-R1-fix-verify.md",
+    "literal": "tests/test_run_skill_model_class.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-06-batch-14-stability-extension/findings/B14-R2-fixture-fix.md",
+    "literal": "tests/test_replay_skill_improver.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-06-batch-14-stability-extension/prelude.md",
+    "literal": "tests/test_replay_skill_improver.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-08-batch-16-plan-mode-validation/findings/S5-large-output-spill.md",
+    "literal": "tests/plan/test_plan_registry_spill.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-10-batch-17-rag-phase-1/findings.md",
+    "literal": "tests/test_index_docs_skill.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-10-batch-17-rag-phase-1/findings.md",
+    "literal": "tests/test_router_indexed_sources.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-10-batch-17-rag-phase-1/findings.md",
+    "literal": "tests/test_tool_recall.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-10-batch-17-rag-phase-1/findings/S9-cost-preflight.md",
+    "literal": "tests/test_candidate_abort.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-10-batch-17-rag-phase-1/prelude.md",
+    "literal": "tests/test_embedding_provider.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-10-batch-17-rag-phase-1/retrospective.md",
+    "literal": "tests/test_tool_recall.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-17-ablation-wave-plateau-diagnosis/results/results-H4-description.md",
+    "literal": "tests/test_skill_description_disambiguation.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-17-batch-36-alias-schema-verify/retrospective.md",
+    "literal": "tests/test_event_store_stale_path_recovery.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-17-batch-38-d2-scope-verify/workers/findings-worker-3.md",
+    "literal": "tests/test_judge_phase_schema.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/2026-05-23-batch-52-post-fp0042-complete/retrospective.md",
+    "literal": "tests/test_session_factory_sandbox_config_uniform.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/giveup-tracker.md",
+    "literal": "tests/test_mcp_server.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/dogfood/giveup-tracker.md",
+    "literal": "tests/test_router_empty_response.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/feature-verify/2026-05-09-adr0026-m2-poc-success.md",
+    "literal": "tests/test_replay_skill_router.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/feature-verify/2026-05-09-adr0026-m2-poc-success.md",
+    "literal": "tests/test_web_search_unified.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/feature-verify/2026-05-11-adr-a-starvation-feasibility/track4_baseline_starvation.md",
+    "literal": "tests/spike/__init__.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "docs/deep-dives/journal/feature-verify/2026-05-11-adr-a-starvation-feasibility/track4_baseline_starvation.md",
+    "literal": "tests/spike/test_adr_a_starvation_repro.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "docs/deep-dives/journal/feature-verify/2026-05-11-adr-a-starvation-feasibility/track4_baseline_starvation.md",
+    "literal": "tests/test_mcp_server.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/feature-verify/2026-05-11-adr-a-starvation-feasibility/track5_pumping_prototype.md",
+    "literal": "tests/spike/__init__.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "docs/deep-dives/journal/feature-verify/2026-05-11-adr-a-starvation-feasibility/track5_pumping_prototype.md",
+    "literal": "tests/spike/test_adr_a_pumping_prototype.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "docs/deep-dives/journal/feature-verify/2026-05-11-adr-a-starvation-feasibility/track5_pumping_prototype.md",
+    "literal": "tests/test_mcp_server.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/insights/2026-05-07-plan-mode-crash-resilience-phase1.md",
+    "literal": "tests/test_plan_lifecycle_crash.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/tier-c1-cleanup-sweep-design/1533-2a2-checkout-design.md",
+    "literal": "tests/test_registry_checkout_2a2.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/tier-c1-cleanup-sweep-design/1533-2a3-act-turn-design.md",
+    "literal": "tests/test_act_turn_rewind_2a3.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/tier-c1-cleanup-sweep-design/1533-phase2-e2e-live-gate-design.md",
+    "literal": "tests/test_live_fork_gate.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/journal/tier-c1-cleanup-sweep-design/1533-phase2-e2e-live-gate-design.md",
+    "literal": "tests/test_live_rewind_gate.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0003-budget-exceed-user-approval.ja.md",
+    "literal": "tests/test_budget_extend_chain.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0003-budget-exceed-user-approval.md",
+    "literal": "tests/test_budget_extend_chain.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0004-safety-config-ux.ja.md",
+    "literal": "tests/test_safety_config.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0004-safety-config-ux.md",
+    "literal": "tests/test_safety_config.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0005-safety-as-checkpoint.ja.md",
+    "literal": "tests/test_safety_limit_handler.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0005-safety-as-checkpoint.ja.md",
+    "literal": "tests/test_safety_on_limit.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0005-safety-as-checkpoint.ja.md",
+    "literal": "tests/test_safety_phase2_wiring.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0005-safety-as-checkpoint.md",
+    "literal": "tests/test_safety_limit_handler.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0005-safety-as-checkpoint.md",
+    "literal": "tests/test_safety_on_limit.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0005-safety-as-checkpoint.md",
+    "literal": "tests/test_safety_phase2_wiring.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0011-remove-narrator.ja.md",
+    "literal": "tests/test_multi_agent_p7.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0011-remove-narrator.ja.md",
+    "literal": "tests/test_narrator_drift.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0011-remove-narrator.ja.md",
+    "literal": "tests/test_replay_narrator.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0011-remove-narrator.ja.md",
+    "literal": "tests/test_router_loop_chatsession.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0011-remove-narrator.md",
+    "literal": "tests/test_multi_agent_p7.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0011-remove-narrator.md",
+    "literal": "tests/test_narrator_drift.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0011-remove-narrator.md",
+    "literal": "tests/test_replay_narrator.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0011-remove-narrator.md",
+    "literal": "tests/test_router_loop_chatsession.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0017-sandboxed-execution.ja.md",
+    "literal": "tests/test_sandbox_factory.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0017-sandboxed-execution.ja.md",
+    "literal": "tests/test_sandbox_landlock.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0017-sandboxed-execution.ja.md",
+    "literal": "tests/test_sandbox_seatbelt.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0017-sandboxed-execution.ja.md",
+    "literal": "tests/test_sandbox_seccomp.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0017-sandboxed-execution.md",
+    "literal": "tests/test_sandbox_factory.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0017-sandboxed-execution.md",
+    "literal": "tests/test_sandbox_landlock.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0017-sandboxed-execution.md",
+    "literal": "tests/test_sandbox_seatbelt.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0017-sandboxed-execution.md",
+    "literal": "tests/test_sandbox_seccomp.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0050-content-threat-scan.md",
+    "literal": "tests/test_returns_external_content_flagset_1822.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0051-tool-result-viewer-registry-llm-template.md",
+    "literal": "tests/cli/test_tool_result_viewer_registry.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0051-tool-result-viewer-registry-llm-template.md",
+    "literal": "tests/cli/test_tool_result_viewer_template.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0056-canonical-coverage-enforcement.md",
+    "literal": "tests/test_fp0056_canonical_coverage_gate.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0061-repo-self-access-and-packaging-standardization.md",
+    "literal": "tests/test_0060_d5b_docs_mirror.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/0064-plugin-model.md",
+    "literal": "tests/test_builtin_plugins_registry_disk_parity.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/phase-8-require-web-fetch-removal.md",
+    "literal": "tests/test_permission_collapse_phase3.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/phase-8-require-web-fetch-removal.md",
+    "literal": "tests/test_permission_prompt_phrasing.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/deep-dives/proposals/phase-8-require-web-fetch-removal.md",
+    "literal": "tests/test_web_fetch_unified.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/feature-map.md",
+    "literal": "tests/test_branch_tree_2b.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/guide/for-reyn-developers/add-an-op-kind.md",
+    "literal": "tests/test_3193_op_status_classifier_coverage.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/guide/for-reyn-developers/write-replay-tests.md",
+    "literal": "tests/test_llm_tools.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/guide/for-reyn-developers/write-replay-tests.md",
+    "literal": "tests/test_replay_fixture_no_stacking_3634.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/guide/for-reyn-developers/write-replay-tests.md",
+    "literal": "tests/test_replay_my_area.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "docs/reference/runtime/agui-transport.ja.md",
+    "literal": "tests/test_agent_delta_audit_event_3288.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/reference/runtime/agui-transport.ja.md",
+    "literal": "tests/test_agui_control_filter.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/reference/runtime/agui-transport.md",
+    "literal": "tests/test_agent_delta_audit_event_3288.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/reference/runtime/agui-transport.md",
+    "literal": "tests/test_agui_control_filter.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/reference/runtime/agui-transport.md",
+    "literal": "tests/test_textual_chat_row_contrast_3367.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/reference/runtime/session-construction.md",
+    "literal": "tests/test_router_host_adapter_param_gate_3482.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/reference/runtime/tool-naming.md",
+    "literal": "tests/test_no_qualified_tool_names_3429.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/reference/runtime/tool-naming.md",
+    "literal": "tests/test_tool_naming_convention_gate_3223.py",
+    "class": "stale"
+  },
+  {
+    "file": "docs/reference/test-tier-audit.ja.md",
+    "literal": "tests/test_new_feature.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "docs/reference/test-tier-audit.ja.md",
+    "literal": "tests/test_router.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "docs/reference/test-tier-audit.ja.md",
+    "literal": "tests/test_util.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "docs/reference/test-tier-audit.md",
+    "literal": "tests/test_new_feature.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "docs/reference/test-tier-audit.md",
+    "literal": "tests/test_router.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "docs/reference/test-tier-audit.md",
+    "literal": "tests/test_util.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "docs/reference/testing/replay.md",
+    "literal": "tests/test_replay_fixture_no_stacking_3634.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/_file_depth_predicate.py",
+    "literal": "tests/hooks/test_x.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "scripts/check_file_depth_reference.py",
+    "literal": "tests/runtime/x.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "scripts/check_file_depth_reference.py",
+    "literal": "tests/x.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "scripts/check_migration_diff_shape.py",
+    "literal": "tests/test_a.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "scripts/check_tests_dir_names.py",
+    "literal": "tests/scripts/__init__.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "scripts/flat_tests_ratchet.py",
+    "literal": "tests/test_3595_s4_slash_handler_seam.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/measure_router_host_adapter_consumers.py",
+    "literal": "tests/test_router_host_adapter_param_gate_3482.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/mypy_ratchet.py",
+    "literal": "tests/test_3595_s4_slash_handler_seam.py",
+    "class": "stale"
+  },
+  {
+    "file": "scripts/test_tier_audit.py",
+    "literal": "tests/test_foo.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "src/reyn/_network.py",
+    "literal": "tests/network/test_egress_env_completeness.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "src/reyn/core/events/event_schema.py",
+    "literal": "tests/test_audit_event_kind_vocabulary_3410.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/core/events/progress_lifecycle.py",
+    "literal": "tests/test_progress_lifecycle_fanout_3357.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/core/offload/canonical.py",
+    "literal": "tests/test_fp0056_canonical_coverage_gate.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/__init__.py",
+    "literal": "tests/test_fp0056_canonical_coverage_gate.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/embed.py",
+    "literal": "tests/test_op_semantic_search.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/core/op_runtime/status_classify.py",
+    "literal": "tests/test_3193_op_status_classifier_coverage.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/core/part_type_registry.py",
+    "literal": "tests/test_0060_d5d_doc_ref_registry_gate.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/data/index/coordinator.py",
+    "literal": "tests/test_index_coordinator_3247_p2a.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/dev/dogfood/verifiers/asset_refs.py",
+    "literal": "tests/test_dogfood_scenario_asset_refs_contract.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/dev/testing/network_gate.py",
+    "literal": "tests/test_network_gate_3451.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/dev/testing/network_gate.py",
+    "literal": "tests/test_network_gate_boundary_completeness_3451.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/dev/testing/replay.py",
+    "literal": "tests/test_replay_fixture_no_stacking_3634.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/dev/testing/replay_stacking.py",
+    "literal": "tests/test_replay_fixture_no_stacking_3634.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/hooks/durable_pending_store.py",
+    "literal": "tests/test_3180_composer_pending_truncate_falsify.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/chat.py",
+    "literal": "tests/test_startup_client_before_attach_3671_p2.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/interfaces/cli/commands/pipe.py",
+    "literal": "tests/test_2575_pipeline_disk_registration.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/interfaces/inline/textual_chat/app.py",
+    "literal": "tests/test_agui_control_filter.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/interfaces/inline/textual_chat/presenter.py",
+    "literal": "tests/test_textual_chat_row_contrast_3367.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/interfaces/repl/renderer.py",
+    "literal": "tests/test_markdown_palette_gate_3469.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/interfaces/repl/stream_client.py",
+    "literal": "tests/test_stream_client_own_echo_3287.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/interfaces/slash/__init__.py",
+    "literal": "tests/test_3595_s4_slash_handler_seam.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/interfaces/transport/agui/profile.py",
+    "literal": "tests/test_agui_profile_completeness.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/interfaces/transport/agui/protocol.py",
+    "literal": "tests/test_agui_control_filter.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/interfaces/transport/client_transport.py",
+    "literal": "tests/test_3595_s4_slash_handler_seam.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/interfaces/transport/frames.py",
+    "literal": "tests/test_transport_dual_stream_completeness.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/llm/llm.py",
+    "literal": "tests/test_streaming_usage_provider_supplied_3348.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/mcp/server.py",
+    "literal": "tests/test_3595_client_input_provenance_gate.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/prompt/__init__.py",
+    "literal": "tests/scaffold/test_sp_prompt_package_phase1_byte_identical.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "src/reyn/prompt/__init__.py",
+    "literal": "tests/scaffold/test_sp_prompt_package_phase2_byte_identical.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "src/reyn/prompt/__init__.py",
+    "literal": "tests/test_llm_facing_text_english_only.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/prompt/__init__.py",
+    "literal": "tests/test_sp_prompt_package_loop_control_nudges.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "src/reyn/prompt/router_frame.py",
+    "literal": "tests/scaffold/test_sp_prompt_package_phase1_byte_identical.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "src/reyn/prompt/router_frame.py",
+    "literal": "tests/test_llm_facing_text_english_only.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/runtime/outbox.py",
+    "literal": "tests/test_agui_profile_completeness.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/runtime/outbox.py",
+    "literal": "tests/test_outbox_vocabulary.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/runtime/presentation_consumer.py",
+    "literal": "tests/test_present_sink_na_ratchet_2708.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/runtime/registry.py",
+    "literal": "tests/test_2103_s1bc_session_spawn_tool.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/runtime/registry.py",
+    "literal": "tests/test_registry_restore_all_only_names_3671_p4c1.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/runtime/reyn_repo.py",
+    "literal": "tests/test_0061_repo_self_access_parity.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/runtime/scoped_session_factory.py",
+    "literal": "tests/test_scoped_session_factory_invariant_1402.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/runtime/services/execution_driver.py",
+    "literal": "tests/test_execution_driver_seam.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/runtime/services/router_history_buffer.py",
+    "literal": "tests/test_2957_prb_elide_advisor_token_unification.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/runtime/services/router_host_adapter.py",
+    "literal": "tests/test_router_host_adapter_param_gate_3482.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/runtime/services/snapshot_journal.py",
+    "literal": "tests/test_3300_p3_cancel_by_id.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/runtime/session.py",
+    "literal": "tests/test_3300_p3_cancel_by_id.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/runtime/session.py",
+    "literal": "tests/test_3595_s4_slash_handler_seam.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/runtime/spawn_routing.py",
+    "literal": "tests/test_spawn_routing_gate_2708.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/runtime/turn_origin.py",
+    "literal": "tests/test_3595_client_input_provenance_gate.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/security/permissions/capability_profile.py",
+    "literal": "tests/test_2111_floor_alias_completeness.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/security/permissions/capability_profile.py",
+    "literal": "tests/test_3501_untrusted_narrowing_opt_in.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/security/permissions/effective.py",
+    "literal": "tests/test_3501_untrusted_narrowing_opt_in.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/security/sandbox/backends/landlock.py",
+    "literal": "tests/test_subprocess_cancel_1470.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/security/sandbox/noop_backend.py",
+    "literal": "tests/test_sandbox_self_test_2983.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/services/compaction/engine.py",
+    "literal": "tests/test_compaction_resolver_aware_1172.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/tools/knowledge.py",
+    "literal": "tests/test_returns_external_content_flagset_1822.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/tools/schemes/_category_exposure.py",
+    "literal": "tests/test_tool_use_category_content_fence_3376.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/tools/types.py",
+    "literal": "tests/test_0060_d5d_doc_ref_registry_gate.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/tools/types.py",
+    "literal": "tests/test_tool_schema_3383_process_history_independence.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/tools/universal_catalog.py",
+    "literal": "tests/test_resource_collapse_invariant_3026.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/tools/universal_catalog.py",
+    "literal": "tests/test_universal_catalog.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/tools/universal_dispatch.py",
+    "literal": "tests/test_no_qualified_tool_names_3429.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/tools/universal_dispatch.py",
+    "literal": "tests/test_resource_collapse_invariant_3026.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/tools/universal_dispatch.py",
+    "literal": "tests/test_universal_catalog.py",
+    "class": "stale"
+  },
+  {
+    "file": "src/reyn/user_intervention.py",
+    "literal": "tests/test_intervention_legacy_alias_deprecated.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/_support/builtin_skill_tool_names.py",
+    "literal": "tests/test_builtin_skill_tool_name_drift_3092.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/_support/builtin_skill_tool_names.py",
+    "literal": "tests/test_catalog_entries_1593.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/_support/tool_use_negative_examples.py",
+    "literal": "tests/test_fp0066_p4a_transport_axis_3247.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/builtin/test_0060_phase1_f3a_builtin_tier.py",
+    "literal": "tests/test_0060_f3b_sibling_builtins.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/builtin/test_0060_phase1_f3a_builtin_tier.py",
+    "literal": "tests/test_0060_phase2_f3b_builtin_content.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/builtin/test_0060_phase1_f3a_builtin_tier.py",
+    "literal": "tests/test_0061_repo_self_access_parity.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/builtin/test_0060_phase1_f3a_builtin_tier.py",
+    "literal": "tests/test_workspace_glob_stdlib_perm.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/builtin/test_builtin_plugins_registry_disk_parity.py",
+    "literal": "tests/test_builtin_registry_disk_parity.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/builtin/test_fp0063_p3_rag_pipelines.py",
+    "literal": "tests/test_3010_empty_success_fact_data_path.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/builtin/test_fp0063_p3_rag_pipelines.py",
+    "literal": "tests/test_op_embed.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/builtin/test_fp0063_p3_rag_pipelines.py",
+    "literal": "tests/test_plugin_install.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/builtin/test_shipped_skill_name_standard_conformance_3567.py",
+    "literal": "tests/test_skill_md_default_inline_cap_gate.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/builtin/test_skill_md_default_inline_cap_gate.py",
+    "literal": "tests/test_builtin_registry_disk_parity.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/cli/test_httpx_lazy_load_cli_entry.py",
+    "literal": "tests/test_llm_call_retry.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/config/test_action_retrieval_config.py",
+    "literal": "tests/test_embedding_config.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/conftest.py",
+    "literal": "tests/test_3233_inprocess_env_identity.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/conftest.py",
+    "literal": "tests/test_a2a_runentry_task_migration_1981.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/conftest.py",
+    "literal": "tests/test_fp0001_a2a_endpoints.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/conftest.py",
+    "literal": "tests/test_fp0063_p3_rag_pipelines.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/conftest.py",
+    "literal": "tests/test_markdown_palette_gate_3469.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/conftest.py",
+    "literal": "tests/test_network_gate_3451.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_0060_phase2_f3b_builtin_content.py",
+    "literal": "tests/test_pipeline_is3_dsl_parser.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_0060_phase2_f3b_builtin_content.py",
+    "literal": "tests/test_pipeline_r5_run_agent_step.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_2103_C2_fail_closed_capwalk_1953.py",
+    "literal": "tests/test_cascade_profile_preserve_2103.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_2242_hard_cancel.py",
+    "literal": "tests/test_2884_hook_driven_turns_truncation_falsify.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_2242_hard_cancel.py",
+    "literal": "tests/test_turn_cancel_1468.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_2575_pipeline_disk_registration.py",
+    "literal": "tests/test_asyncio_diagnostics.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_2708_p31_spawn_bridge_present.py",
+    "literal": "tests/test_2103_s1bc_exec_result_routing.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_2884_hook_driven_turns_truncation_falsify.py",
+    "literal": "tests/test_2259_config_truncation_bug.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_2884_hook_driven_turns_truncation_falsify.py",
+    "literal": "tests/test_hook_loop_valve_1800_7.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_3082_recovery_wiring.py",
+    "literal": "tests/scaffold/test_family2_recovery_bundle_byte_identical.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_3099_on_error_canonical_seam.py",
+    "literal": "tests/test_fp0063_p3_rag_pipelines.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_3101_rag_ingest_upfront_permission_gate.py",
+    "literal": "tests/test_config_write_jit_bus_3086.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_3101_rag_ingest_upfront_permission_gate.py",
+    "literal": "tests/test_fp0063_p3_rag_pipelines.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_3101_rag_ingest_upfront_permission_gate.py",
+    "literal": "tests/test_require_file_jit_ask_1505.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_3104_fallback_structured_error_stamp.py",
+    "literal": "tests/test_3099_on_error_canonical_seam.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_3162_rag_skill_body_read_reachable.py",
+    "literal": "tests/test_3162_plugin_body_read_parity.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_3193_op_status_classifier_coverage.py",
+    "literal": "tests/test_network_egress_env_completeness_3075.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_3212_plugin_install_concurrency.py",
+    "literal": "tests/test_action_embedding_index_concurrency.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_3377_run_loop_survives_turn_cancel.py",
+    "literal": "tests/test_2242_hard_cancel.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_3475_probe_degradation_visibility_and_timeout_config.py",
+    "literal": "tests/test_3475_mcp_probe_priming_all_turn_kinds.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_3475_probe_degradation_visibility_and_timeout_config.py",
+    "literal": "tests/test_audit_event_kind_vocabulary_3410.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_3475_probe_degradation_visibility_and_timeout_config.py",
+    "literal": "tests/test_mcp_lazy_tools_cache.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_3783_stage3_invert_default_to_recover.py",
+    "literal": "tests/test_pr_n6_compaction_overflow_retry.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_3846_image_fetch.py",
+    "literal": "tests/test_web_fetch_download_cap_1913.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_3901_sandbox_axis_unenforced.py",
+    "literal": "tests/test_sandbox_landlock.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_action_embedding_build_failure_1458.py",
+    "literal": "tests/test_index_coordinator_3247_p2b.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_action_embedding_build_failure_1458.py",
+    "literal": "tests/test_index_coordinator_3247_p2d.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_action_embedding_index.py",
+    "literal": "tests/test_op_embed.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_action_embedding_index.py",
+    "literal": "tests/test_universal_handlers.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_action_embedding_index_concurrency.py",
+    "literal": "tests/test_index_coordinator_3247_p2a.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_action_embedding_index_concurrency.py",
+    "literal": "tests/test_index_coordinator_3247_p2b.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_action_embedding_index_concurrency.py",
+    "literal": "tests/test_op_embed.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_anchor_full_message_2c.py",
+    "literal": "tests/test_anchor_text_1547.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_audit_event_kind_vocabulary_3410.py",
+    "literal": "tests/test_progress_lifecycle_fanout_3357.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_config_write_jit_bus_3086.py",
+    "literal": "tests/test_require_file_jit_ask_1505.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_emit_hook_event_0059_phase5_part2.py",
+    "literal": "tests/test_hook_composer_reachability_phase5.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_emit_hook_event_0059_phase5_part2.py",
+    "literal": "tests/test_hook_loop_valve_1800_7.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_fp0057_phase0_index_consolidation.py",
+    "literal": "tests/test_op_embed.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_fp0066_p1a_embedding_enabled_gate.py",
+    "literal": "tests/test_2895_retrieval_scheme_requires_embedding.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_fp0066_p1a_embedding_enabled_gate.py",
+    "literal": "tests/test_embedding_config.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_fp0066_p1a_embedding_enabled_gate.py",
+    "literal": "tests/test_universal_catalog.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_fp0066_p3a_knowledge_ingest.py",
+    "literal": "tests/test_index_coordinator_3247_p2a.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_fp0066_p3b_repo_knowledge_ingest.py",
+    "literal": "tests/test_fp0066_p3a_knowledge_ingest.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_index_coordinator_3247_p2a.py",
+    "literal": "tests/test_action_embedding_index.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_index_coordinator_3247_p2b.py",
+    "literal": "tests/test_action_embedding_build_failure_1458.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_index_coordinator_3247_p2b.py",
+    "literal": "tests/test_index_coordinator_3247_p2a.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_index_coordinator_3247_p2d.py",
+    "literal": "tests/test_action_embedding_index.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_index_coordinator_3247_p2d.py",
+    "literal": "tests/test_index_coordinator_3247_p2b.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_mcp_drop_server.py",
+    "literal": "tests/test_1199_effective_permission.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_mcp_drop_server.py",
+    "literal": "tests/test_permissions_mcp_install.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_mcp_install_op.py",
+    "literal": "tests/test_1199_effective_permission.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_mcp_offload_raw_2336.py",
+    "literal": "tests/test_2425_canonical_tool_result.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_mechanism_routing_frame_0060.py",
+    "literal": "tests/test_part_type_registry_taxonomy_0060.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_op_embed.py",
+    "literal": "tests/test_op_recall.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_op_index_update.py",
+    "literal": "tests/test_op_embed.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_op_semantic_search.py",
+    "literal": "tests/test_op_embed.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_part_type_registry_taxonomy_0060.py",
+    "literal": "tests/test_hook_event_schema_registry_sync_0059.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_plugin_install.py",
+    "literal": "tests/test_require_file_jit_ask_1505.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_restore_all_subscription_scan_bound_2944.py",
+    "literal": "tests/test_active_branch_history_scan_bound_2941.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_retrieval_sink_identity_3408.py",
+    "literal": "tests/test_agent_delta_audit_event_3288.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_search_knowledge_3247_p3c.py",
+    "literal": "tests/test_fp0066_p3a_knowledge_ingest.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_session_intervention_persistence.py",
+    "literal": "tests/test_session_invariants.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_spawn_routing_detached_fail_mode_2708.py",
+    "literal": "tests/test_2103_s1bc_exec_result_routing.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/core/test_state_log_truncate.py",
+    "literal": "tests/test_3436_unknown_wal_kind_reader_tolerant.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/data/test_memory_rewrite_index_e2e.py",
+    "literal": "tests/test_memory_invariants.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/dev/test_missing_fixture_fails_loud_3662.py",
+    "literal": "tests/test_network_gate_3451.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/dev/test_network_gate_3451.py",
+    "literal": "tests/x.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/dev/test_rekey_fixtures_tool.py",
+    "literal": "tests/test_x.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/environment/test_environment_import_no_circular_3867.py",
+    "literal": "tests/test_x.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/hooks/test_hook_composer.py",
+    "literal": "tests/test_3180_durable_pending_store.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/hooks/test_hook_composer_reachability_phase5.py",
+    "literal": "tests/test_hook_event_bus_0059_phase4a.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/hooks/test_hook_composer_reachability_phase5.py",
+    "literal": "tests/test_hook_loop_valve_1800_7.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/hooks/test_hook_event_schema_registry_sync_0059.py",
+    "literal": "tests/test_1800_wake_drain.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/hooks/test_hook_event_schema_registry_sync_0059.py",
+    "literal": "tests/test_2608_run_loop_pickup.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/hooks/test_hook_sandbox_policy_legibility_3005.py",
+    "literal": "tests/test_hook_subprocess_per_site_2827.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/hooks/test_hook_subprocess_per_site_2827.py",
+    "literal": "tests/test_op_sandboxed_exec.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_2280_durability_halt_observability.py",
+    "literal": "tests/test_2259_pr3_recovery_semantics_falsify.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_2839_a2a_run_registry_truncate_falsify.py",
+    "literal": "tests/test_2884_hook_driven_turns_truncation_falsify.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_3288_3c_tui_delta_coalesce.py",
+    "literal": "tests/test_agent_delta_no_visible_garbage_3288.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_3288_3c_tui_delta_coalesce.py",
+    "literal": "tests/test_stream_spinner_3530.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_3300_intervention_answer_eventify.py",
+    "literal": "tests/test_3540_intervention_answer_fold.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_3300_intervention_answer_eventify.py",
+    "literal": "tests/test_user_echo_broadcast.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_3300_p2b_sentqueue_render.py",
+    "literal": "tests/test_user_submitted_render_3300.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_3300_p3_cancel_by_id.py",
+    "literal": "tests/test_2242_hard_cancel.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_3300_p3_cancel_by_id.py",
+    "literal": "tests/test_2884_hook_driven_turns_truncation_falsify.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_3310_n1_session_attached_barrier.py",
+    "literal": "tests/test_agui_profile_completeness.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_3310_n2_reset_hydrate.py",
+    "literal": "tests/test_2242_hard_cancel.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_3310_n2_reset_hydrate.py",
+    "literal": "tests/test_textual_chat_intervention_panel_3299.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_3328_connect_remote_parity_witness.py",
+    "literal": "tests/test_mcp_client.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_a2a_webhook_progress_267_gap2.py",
+    "literal": "tests/test_progress_lifecycle_fanout_3357.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_agent_delta_audit_event_3288.py",
+    "literal": "tests/test_agui_profile_completeness.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_agent_delta_audit_event_3288.py",
+    "literal": "tests/test_user_submitted_render_3300.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_agent_delta_no_visible_garbage_3288.py",
+    "literal": "tests/test_3300_p2b_sentqueue_render.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_agent_delta_no_visible_garbage_3288.py",
+    "literal": "tests/test_stream_spinner_3530.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_agent_delta_no_visible_garbage_3288.py",
+    "literal": "tests/test_user_submitted_render_3300.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_agent_delta_round_index_3656.py",
+    "literal": "tests/test_3288_3c_tui_delta_coalesce.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_agui_multi_content_streaming_3288.py",
+    "literal": "tests/test_agui_control_filter.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_cui_permission_answer_resumes_2690.py",
+    "literal": "tests/test_repl_intervention_listener.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_fp0001_a2a_endpoints.py",
+    "literal": "tests/test_a2a_capability_claim_interim.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_fp0001_e2e_ask_user_roundtrip.py",
+    "literal": "tests/test_fp0001_a2a_intervention_bus.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_fp0001_run_registry.py",
+    "literal": "tests/test_a2a_iv_kind_choices_267_gap4.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_fp0001_run_registry.py",
+    "literal": "tests/test_fp0001_a2a_intervention_bus.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_loop_probe_3539.py",
+    "literal": "tests/test_3288_3c_tui_delta_coalesce.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_mcp_refresh_cli.py",
+    "literal": "tests/test_3475_probe_degradation_visibility_and_timeout_config.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_plugin_cli_surface.py",
+    "literal": "tests/test_plugin_install.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_reyn_embeddings_cli.py",
+    "literal": "tests/test_index_backend.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_run_registry_persist.py",
+    "literal": "tests/test_intervention_restore.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_stream_drain_yield_3570.py",
+    "literal": "tests/test_transport_bit_identical.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_stream_repaint_coalesce_3570.py",
+    "literal": "tests/test_3327_answer_bypasses_sentqueue.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_stream_repaint_coalesce_3570.py",
+    "literal": "tests/test_agent_delta_audit_event_3288.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_stream_repaint_coalesce_3570.py",
+    "literal": "tests/test_stream_spinner_3530.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_textual_chat_phase2_3273.py",
+    "literal": "tests/test_textual_chat_row_contrast_3367.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_textual_chat_streaming_visibility_3283.py",
+    "literal": "tests/test_3288_3c_tui_delta_coalesce.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_textual_chat_streaming_visibility_3283.py",
+    "literal": "tests/test_stream_repaint_coalesce_3570.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_textual_chat_streaming_visibility_3283.py",
+    "literal": "tests/test_stream_spinner_3530.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/interfaces/test_user_submitted_render_3300.py",
+    "literal": "tests/test_3300_p2b_sentqueue_render.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/llm/test_2608_run_loop_pickup.py",
+    "literal": "tests/test_1800_wake_drain.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/llm/test_2608_run_loop_pickup.py",
+    "literal": "tests/test_2608_h4_fs_watcher.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/llm/test_llm_streaming_delta_emission_3288.py",
+    "literal": "tests/test_agent_delta_audit_event_3288.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/mcp/test_2597_s2b_mcp_notifications_bridge.py",
+    "literal": "tests/test_mcp_lazy_tools_cache.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/mcp/test_mcp_capability_advertising_271_m3.py",
+    "literal": "tests/test_progress_lifecycle_fanout_3357.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/mcp/test_mcp_client_stderr_capture.py",
+    "literal": "tests/test_mcp_client.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/plugins/test_skill_load.py",
+    "literal": "tests/test_op_runtime_load_skill_3247.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/repo/test_3794_p3_audit_event_identifier_rename.py",
+    "literal": "tests/test_audit_event_kind_vocabulary_3410.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_0061_repo_self_access_parity.py",
+    "literal": "tests/test_0061_repo_self_access_parity.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_2073_s2_reapply_seams.py",
+    "literal": "tests/test_3097_config_projection_refresh_family_gate.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_2548_skill_registry_pr_a.py",
+    "literal": "tests/test_2971_skill_visibility.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_2946_item2_restore_all_bucketing.py",
+    "literal": "tests/test_multi_session_restore.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_3036_spawned_session_mcp_refresh.py",
+    "literal": "tests/test_mcp_hot_reload_2372.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_3093_pipeline_registry_spawn_propagation.py",
+    "literal": "tests/test_2103_s1bc_exec_result_routing.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_3093_pipeline_registry_spawn_propagation.py",
+    "literal": "tests/test_2581_pipeline_hotreload.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_3093_pipeline_registry_spawn_propagation.py",
+    "literal": "tests/test_pipeline_is2_driver_session.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_3097_config_projection_refresh_family_gate.py",
+    "literal": "tests/test_2581_pipeline_hotreload.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_3097_config_projection_refresh_family_gate.py",
+    "literal": "tests/test_3036_spawned_session_mcp_refresh.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_3475_mcp_probe_priming_all_turn_kinds.py",
+    "literal": "tests/test_2242_hard_cancel.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_3475_mcp_probe_priming_all_turn_kinds.py",
+    "literal": "tests/test_session_refresh_mcp_servers.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_3694_persist_cancelled_turn_outcome.py",
+    "literal": "tests/test_2242_hard_cancel.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_a2a_bus_stamping_268_phase2.py",
+    "literal": "tests/test_2103_s1bc_exec_result_routing.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_intervention_bus_protocols.py",
+    "literal": "tests/test_intervention_legacy_alias_deprecated.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_mcp_search_tool_invariants.py",
+    "literal": "tests/test_audit_event_kind_vocabulary_3410.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_media_cap_272.py",
+    "literal": "tests/test_file_read_binary_retire_rtr_1449.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_pipeline_driver_resource_caller_state_2567.py",
+    "literal": "tests/test_pipeline_is2_driver_session.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_pipeline_driver_resource_caller_state_2567.py",
+    "literal": "tests/test_pipeline_is5_surfacing.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_pipeline_driver_resource_caller_state_2567.py",
+    "literal": "tests/test_router_caller_state_mcp_servers.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_plugin_slash_surface.py",
+    "literal": "tests/test_2548_skill_hotreload_toggle_pr_b.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_plugin_slash_surface.py",
+    "literal": "tests/test_plugin_cli_surface.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_reyn_repo_resolver.py",
+    "literal": "tests/test_reyn_repo_resolver.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_router_host_adapter_param_gate_3482.py",
+    "literal": "tests/test_check_pr_closing_intent.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_router_tools.py",
+    "literal": "tests/test_op_semantic_search.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_session_invariants.py",
+    "literal": "tests/scaffold/test_chain_manager.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_session_invariants.py",
+    "literal": "tests/scaffold/test_intervention_registry.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_session_pure_extraction_3679_s1.py",
+    "literal": "tests/test_force_close_covers_slice_1092.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_session_pure_extraction_3679_s1.py",
+    "literal": "tests/test_retry_loop_chat_wiring_1125.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/runtime/test_workspace_root_not_cwd_3705.py",
+    "literal": "tests/test_session_writes_stay_in_its_workspace_3705.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/scripts/test_3726_mypy_ratchet.py",
+    "literal": "tests/test_3595_s4_slash_handler_seam.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/scripts/test_check_migration_diff_shape_3879.py",
+    "literal": "tests/core/test_a.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_check_migration_diff_shape_3879.py",
+    "literal": "tests/core/test_a_moved.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_check_migration_diff_shape_3879.py",
+    "literal": "tests/does_not_exist/__init__.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_check_migration_diff_shape_3879.py",
+    "literal": "tests/newpkg/__init__.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_check_migration_diff_shape_3879.py",
+    "literal": "tests/newpkg/test_new.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_check_migration_diff_shape_3879.py",
+    "literal": "tests/test_a.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_check_migration_diff_shape_3879.py",
+    "literal": "tests/test_b.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_check_pr_closing_intent.py",
+    "literal": "tests/test_tier_audit_format_pin.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/scripts/test_check_tests_dir_names_3879.py",
+    "literal": "tests/scripts/__init__.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_check_tests_dir_names_3879.py",
+    "literal": "tests/test_swe_bench_runner_venv_183.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/scripts/test_check_tests_dir_names_3879.py",
+    "literal": "tests/test_verify_package_move_root_config.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/security/test_1199_s31b_mcp_cutover.py",
+    "literal": "tests/test_permissions.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/security/test_codeact_runner_1593.py",
+    "literal": "tests/test_sandbox_landlock.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/security/test_sandbox_seccomp_network_3030.py",
+    "literal": "tests/test_plugin_install.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/test_2708_p32a_spawn_bridge_intervention.py",
+    "literal": "tests/test_2103_s1bc_exec_result_routing.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/test_3300_p2a_queue_state_publish.py",
+    "literal": "tests/test_2242_hard_cancel.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/test_3546_pipeline_driver_narrowing_inheritance.py",
+    "literal": "tests/test_2103_s1bc_session_spawn_tool.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/test_3546_pipeline_driver_narrowing_inheritance.py",
+    "literal": "tests/test_3093_pipeline_registry_spawn_propagation.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/test_3561_spawn_session_seam_reachability.py",
+    "literal": "tests/test_pipeline_r5_run_agent_step.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/test_3595_s2_pipeline_nudge_origin.py",
+    "literal": "tests/test_pipeline_is6_attached.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/test_3792_pr2_session_injection.py",
+    "literal": "tests/test_3300_p3_cancel_by_id.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/test_3792_pr2_session_injection.py",
+    "literal": "tests/test_3792_pr2_router_loop_injection.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/test_fp0063_arc_witness.py",
+    "literal": "tests/test_op_embed.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/test_fp0063_arc_witness.py",
+    "literal": "tests/test_replay_fixture_no_stacking_3634.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/test_fp0063_p4_builtin_rag_skill.py",
+    "literal": "tests/test_builtin_skill_tool_name_drift_3092.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/test_fp0063_p4_builtin_rag_skill.py",
+    "literal": "tests/test_plugin_install.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/test_fp0063_p4_builtin_rag_skill.py",
+    "literal": "tests/test_skill_md_default_inline_cap_gate.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/test_fp0063_p4_builtin_rag_skill.py",
+    "literal": "tests/test_skill_references_gate_3162.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/test_pipeline_a2_spawn_ephemeral_session.py",
+    "literal": "tests/test_2103_s1bc_session_spawn_tool.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/test_sandbox_axis_contract_2983.py",
+    "literal": "tests/test_sandbox_seccomp_network_3030.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/test_textual_chat_copy_rewind_3362.py",
+    "literal": "tests/test_agui_control_filter.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/tools/test_2895_retrieval_scheme_requires_embedding.py",
+    "literal": "tests/test_action_retrieval_wiring.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/tools/test_2895_retrieval_scheme_requires_embedding.py",
+    "literal": "tests/test_embedding_config.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/tools/test_catalog_entries_1593.py",
+    "literal": "tests/test_no_qualified_tool_names_3429.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/tools/test_catalog_unified.py",
+    "literal": "tests/test_tool_registry_handlers.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/tools/test_delegate_to_agent_unified.py",
+    "literal": "tests/test_tool_registry_handlers.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/tools/test_pipeline_is5_surfacing.py",
+    "literal": "tests/test_router_caller_state_mcp_servers.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/tools/test_pipeline_is5_surfacing.py",
+    "literal": "tests/test_session_invariants.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/tools/test_router_call_mcp_tool_enum.py",
+    "literal": "tests/test_router_invoke_skill_enum.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/tools/test_tier3_op_description_positive_frame.py",
+    "literal": "tests/test_tier3_op_description_positive_frame.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/tools/test_tool_description_relocation.py",
+    "literal": "tests/test_tool_schema_3383_process_history_independence.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/tools/test_tool_naming_convention_gate_3223.py",
+    "literal": "tests/test_no_qualified_tool_names_3429.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/tools/test_universal_catalog.py",
+    "literal": "tests/test_universal_handlers.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/tools/test_universal_dispatch.py",
+    "literal": "tests/test_no_qualified_tool_names_3429.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/tools/test_universal_handlers.py",
+    "literal": "tests/test_op_embed.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/web/test_a2a.py",
+    "literal": "tests/test_a2a_capability_claim_interim.py",
+    "class": "stale"
+  },
+  {
+    "file": "tests/web/test_mcp_sse.py",
+    "literal": "tests/test_mcp_server.py",
+    "class": "stale"
+  }
+]

--- a/scripts/check_tests_path_literal_reference_baseline.json
+++ b/scripts/check_tests_path_literal_reference_baseline.json
@@ -791,27 +791,22 @@
   },
   {
     "file": "scripts/check_migration_diff_shape.py",
+    "literal": "tests/foo/bar.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "scripts/check_migration_diff_shape.py",
+    "literal": "tests/old/path.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "scripts/check_migration_diff_shape.py",
     "literal": "tests/test_a.py",
     "class": "never-existed"
   },
   {
     "file": "scripts/check_tests_dir_names.py",
     "literal": "tests/scripts/__init__.py",
-    "class": "never-existed"
-  },
-  {
-    "file": "scripts/check_tests_path_literal_reference.py",
-    "literal": "tests/bar/foo.py",
-    "class": "never-existed"
-  },
-  {
-    "file": "scripts/check_tests_path_literal_reference.py",
-    "literal": "tests/foo.py",
-    "class": "never-existed"
-  },
-  {
-    "file": "scripts/check_tests_path_literal_reference.py",
-    "literal": "tests/test_x.py",
     "class": "never-existed"
   },
   {
@@ -2148,56 +2143,6 @@
     "file": "tests/scripts/test_check_tests_dir_names_3879.py",
     "literal": "tests/test_verify_package_move_root_config.py",
     "class": "stale"
-  },
-  {
-    "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
-    "literal": "tests/core/test_moved_away.py",
-    "class": "never-existed"
-  },
-  {
-    "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
-    "literal": "tests/scripts/test_foo.py",
-    "class": "never-existed"
-  },
-  {
-    "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
-    "literal": "tests/services/test_gone.py",
-    "class": "never-existed"
-  },
-  {
-    "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
-    "literal": "tests/services/test_long_gone.py",
-    "class": "never-existed"
-  },
-  {
-    "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
-    "literal": "tests/services/test_x.py",
-    "class": "never-existed"
-  },
-  {
-    "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
-    "literal": "tests/test_a.py",
-    "class": "never-existed"
-  },
-  {
-    "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
-    "literal": "tests/test_also_gone.py",
-    "class": "never-existed"
-  },
-  {
-    "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
-    "literal": "tests/test_gone.py",
-    "class": "never-existed"
-  },
-  {
-    "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
-    "literal": "tests/test_moved_away.py",
-    "class": "never-existed"
-  },
-  {
-    "file": "tests/scripts/test_check_tests_path_literal_reference_4065.py",
-    "literal": "tests/test_new_gone.py",
-    "class": "never-existed"
   },
   {
     "file": "tests/scripts/test_flat_tests_disposition_check_3879.py",

--- a/scripts/flat_tests_disposition.json
+++ b/scripts/flat_tests_disposition.json
@@ -1253,11 +1253,41 @@
     "bundle": "backfill-3879-arc-start",
     "pr": 4011
   },
+  "tests/test_3546_pipeline_driver_narrowing_inheritance.py": {
+    "disposition": "moved",
+    "to": "tests/runtime/test_3546_pipeline_driver_narrowing_inheritance.py",
+    "bundle": "narrowing-cluster",
+    "pr": 4079
+  },
   "tests/test_3552_mcp_install_probe_permission_gate.py": {
     "disposition": "moved",
     "to": "tests/security/test_3552_mcp_install_probe_permission_gate.py",
     "bundle": "backfill-3879-arc-start",
     "pr": 4005
+  },
+  "tests/test_3553_agent_step_worker_narrowing_inheritance.py": {
+    "disposition": "moved",
+    "to": "tests/runtime/test_3553_agent_step_worker_narrowing_inheritance.py",
+    "bundle": "narrowing-cluster",
+    "pr": 4079
+  },
+  "tests/test_3556_session_spawn_narrowing_inheritance.py": {
+    "disposition": "moved",
+    "to": "tests/runtime/test_3556_session_spawn_narrowing_inheritance.py",
+    "bundle": "narrowing-cluster",
+    "pr": 4079
+  },
+  "tests/test_3561_spawn_session_seam_reachability.py": {
+    "disposition": "moved",
+    "to": "tests/runtime/test_3561_spawn_session_seam_reachability.py",
+    "bundle": "narrowing-cluster",
+    "pr": 4079
+  },
+  "tests/test_3562_slash_session_new_narrowing_inheritance.py": {
+    "disposition": "moved",
+    "to": "tests/runtime/test_3562_slash_session_new_narrowing_inheritance.py",
+    "bundle": "narrowing-cluster",
+    "pr": 4079
   },
   "tests/test_3593_preserve_envelope_when_base_unreadable.py": {
     "disposition": "moved",

--- a/tests/scripts/test_check_tests_path_literal_reference_4065.py
+++ b/tests/scripts/test_check_tests_path_literal_reference_4065.py
@@ -132,6 +132,25 @@ def test_flat_tests_disposition_json_is_excluded_even_though_tracked(tmp_path) -
     assert offenders == []
 
 
+def test_flat_tests_arc_population_json_is_excluded_even_though_tracked(tmp_path) -> None:
+    """Tier 1: scripts/flat_tests_arc_population.json (#3879 S5, #4072) is
+    the same shape again — a FROZEN, point-in-time snapshot of every flat
+    filename Stage 0 committed. Most of its entries have since moved into
+    a bucket by design, so most never resolve, and never should; it has
+    no `to` field to fall back on (unlike disposition.json's `moved`
+    entries). Discovered live: rebasing #4068 onto #4072 turned this
+    single file into 1,121 offenders (lead-coder-independent, caught by
+    running the gate against the real post-#4072 tree)."""
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "flat_tests_arc_population.json").write_text(
+        json.dumps([_T + "test_long_since_moved.py"]) + "\n", encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    offenders = offending_references(tmp_path)
+    assert offenders == []
+
+
 # ── classify — the never-existed vs. stale discriminator ───────────────────
 
 

--- a/tests/scripts/test_check_tests_path_literal_reference_4065.py
+++ b/tests/scripts/test_check_tests_path_literal_reference_4065.py
@@ -1,0 +1,172 @@
+"""Tier 1: scripts/check_tests_path_literal_reference.py's regex/ratchet contract.
+
+Same skeleton as `tests/scripts/test_3726_mypy_ratchet.py`'s ratchet tests —
+a committed baseline set only ever shrinks; a measured entry not in it is
+new and must be surfaced, an entry that silently disappears from the
+measured set (a fix, or the referencing file moving/being deleted) is not
+itself reported. Here the measured set is `(referencing_file, tests/-path-
+literal)` pairs rather than mypy `(file, error-code)` pairs, and the
+population is `git ls-files` rather than a mypy run, but the ratchet logic
+(`new_pairs`) is the same shape: `measured - baseline`, nothing more.
+
+Real filesystem fixtures for the regex/resolution tests (a real `tmp_path`
+tree) — no mocks, the whole point is these are pure functions over real
+text/files.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+
+from scripts.check_tests_path_literal_reference import (
+    _BASELINE_PATH,
+    _PATH_LITERAL_RE,
+    _ROOT,
+    classify,
+    load_baseline,
+    new_pairs,
+    offending_references,
+)
+
+# ── the regex itself — #4006's own lesson (mid-sentence, not quote-anchored) ─
+
+
+def test_a_mid_sentence_reference_is_matched() -> None:
+    """Tier 1: #4006 measured 17x undercounting from anchoring to "right
+    after a quote character" — the regex must match `tests/...py` embedded
+    anywhere in a larger prose run, not only a standalone string literal."""
+    line = 'See the gate in tests/scripts/test_foo.py for the -O witness.'
+    matches = [m.group(0) for m in _PATH_LITERAL_RE.finditer(line)]
+    assert matches == ["tests/scripts/test_foo.py"]
+
+
+def test_a_bare_substring_without_a_word_boundary_is_not_matched() -> None:
+    """Tier 1: "xtests/foo.py" must not match — the left word-boundary
+    exists specifically to reject a `tests/` occurring mid-identifier."""
+    line = "xtests/foo.py"
+    assert list(_PATH_LITERAL_RE.finditer(line)) == []
+
+
+# ── offending_references — resolution against a real tmp tree ──────────────
+
+
+def test_a_literal_resolving_to_a_real_file_is_not_offending(tmp_path) -> None:
+    """Tier 1: `tests/services/test_x.py` existing on disk is not an
+    offender, even though the scan matched it."""
+    (tmp_path / "tests" / "services").mkdir(parents=True)
+    (tmp_path / "tests" / "services" / "test_x.py").write_text("", encoding="utf-8")
+    (tmp_path / "note.md").write_text(
+        "see tests/services/test_x.py for details\n", encoding="utf-8"
+    )
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    offenders = offending_references(tmp_path)
+    assert offenders == []
+
+
+def test_a_literal_not_resolving_is_offending(tmp_path) -> None:
+    """Tier 1: `tests/services/test_gone.py` referenced but absent on disk
+    IS an offender — the gate's whole reason to exist."""
+    (tmp_path / "note.md").write_text(
+        "see tests/services/test_gone.py for details\n", encoding="utf-8"
+    )
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    offenders = offending_references(tmp_path)
+    assert offenders == [(tmp_path / "note.md", "tests/services/test_gone.py", 1)]
+
+
+def test_an_untracked_file_is_not_scanned(tmp_path) -> None:
+    """Tier 1: the population is `git ls-files` (tracked content), not a
+    directory walk — an untracked file (e.g. a gitignored build artifact
+    like mkdocs' `site/`) must not contribute offenders, with zero
+    exclusion rule naming it."""
+    (tmp_path / "note.md").write_text(
+        "see tests/services/test_gone.py for details\n", encoding="utf-8"
+    )
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    # note.md is never `git add`-ed — untracked.
+    offenders = offending_references(tmp_path)
+    assert offenders == []
+
+
+def test_changelog_md_is_excluded_even_though_tracked(tmp_path) -> None:
+    """Tier 1: CHANGELOG.md IS tracked (so `git ls-files` alone would
+    include it) but is explicitly excluded — a historical record naming a
+    path that was real when written is not a defect."""
+    (tmp_path / "CHANGELOG.md").write_text(
+        "- fixed tests/services/test_long_gone.py\n", encoding="utf-8"
+    )
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    offenders = offending_references(tmp_path)
+    assert offenders == []
+
+
+# ── classify — the never-existed vs. stale discriminator ───────────────────
+
+
+def test_a_literal_never_tracked_classifies_never_existed() -> None:
+    """Tier 1: a literal absent from the full-history tracked-file set is
+    `never-existed` — an illustrative example or an unbuilt promise, never
+    a real file that moved."""
+    assert classify("tests/test_a.py", ever_tracked=set()) == "never-existed"
+
+
+def test_a_literal_once_tracked_classifies_stale() -> None:
+    """Tier 1: a literal present in the full-history tracked-file set is
+    `stale` — it WAS a real file and the reference wasn't updated when it
+    moved or was deleted."""
+    ever = {"tests/test_moved_away.py"}
+    assert classify("tests/test_moved_away.py", ever_tracked=ever) == "stale"
+
+
+# ── new_pairs — the ratchet check itself ────────────────────────────────────
+
+
+def test_a_pair_in_the_baseline_is_not_new() -> None:
+    """Tier 1: grandfathered debt does not fail the gate."""
+    baseline = {("docs/foo.md", "tests/test_gone.py")}
+    measured = {("docs/foo.md", "tests/test_gone.py")}
+    assert new_pairs(measured, baseline) == set()
+
+
+def test_a_pair_absent_from_the_baseline_is_new() -> None:
+    """Tier 1: the load-bearing case — a reference that goes stale AFTER
+    the baseline was written must be caught."""
+    baseline = {("docs/foo.md", "tests/test_gone.py")}
+    measured = {("docs/foo.md", "tests/test_gone.py"), ("docs/bar.md", "tests/test_new_gone.py")}
+    assert new_pairs(measured, baseline) == {("docs/bar.md", "tests/test_new_gone.py")}
+
+
+def test_a_pair_leaving_the_measured_set_is_not_reported() -> None:
+    """Tier 1: a fix (or the referencing file itself moving away) silently
+    drops out — nothing has to be edited in the baseline to let a fix
+    "count", the same discipline `mypy_ratchet.py`'s own docstring names."""
+    baseline = {("docs/foo.md", "tests/test_gone.py"), ("docs/bar.md", "tests/test_also_gone.py")}
+    measured = {("docs/foo.md", "tests/test_gone.py")}
+    assert new_pairs(measured, baseline) == set()
+
+
+# ── the real committed baseline ─────────────────────────────────────────────
+
+
+def test_the_real_baseline_has_no_new_pairs_against_the_current_tree() -> None:
+    """Tier 1: the load-bearing witness — running the real scan against the
+    real repo tree, right now, must find nothing beyond what's baselined.
+    This is the gate itself, run as a test."""
+    baseline = load_baseline()
+    measured = {
+        (str(path.relative_to(_ROOT)), literal)
+        for path, literal, _lineno in offending_references(_ROOT)
+    }
+    assert new_pairs(measured, baseline) == set()
+
+
+def test_every_baseline_entry_has_a_valid_class() -> None:
+    """Tier 1: schema check — every entry declares `class` as one of the
+    two values `classify()` can return, not silently omitted or free text."""
+    data = json.loads(_BASELINE_PATH.read_text(encoding="utf-8"))
+    assert data, "baseline must not be empty — a real, measured population"
+    for entry in data:
+        assert entry["class"] in ("stale", "never-existed"), entry

--- a/tests/scripts/test_check_tests_path_literal_reference_4065.py
+++ b/tests/scripts/test_check_tests_path_literal_reference_4065.py
@@ -103,6 +103,24 @@ def test_changelog_md_is_excluded_even_though_tracked(tmp_path) -> None:
     assert offenders == []
 
 
+def test_flat_tests_disposition_json_is_excluded_even_though_tracked(tmp_path) -> None:
+    """Tier 1: scripts/flat_tests_disposition.json (#3879 S2) is the same
+    shape as CHANGELOG.md, not the gate's own baseline shape — its `moved`
+    entries are keyed on the file's OLD flat path BY DESIGN, so the old
+    path correctly never resolving is the record, not a defect. Without
+    this exclusion, every file #3879 records as moved would cost one
+    baseline entry here forever (lead-coder review, #4065 follow-up)."""
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "flat_tests_disposition.json").write_text(
+        '{"tests/test_moved_away.py": {"disposition": "moved", "to": "tests/core/test_moved_away.py"}}\n',
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    offenders = offending_references(tmp_path)
+    assert offenders == []
+
+
 # ── classify — the never-existed vs. stale discriminator ───────────────────
 
 

--- a/tests/scripts/test_check_tests_path_literal_reference_4065.py
+++ b/tests/scripts/test_check_tests_path_literal_reference_4065.py
@@ -28,22 +28,29 @@ from scripts.check_tests_path_literal_reference import (
     offending_references,
 )
 
-# ── the regex itself — #4006's own lesson (mid-sentence, not quote-anchored) ─
+# Every fixture literal below is a `tests/...py`-shaped example this file's
+# OWN tests deliberately construct to exercise the scanner — none of them
+# is a real path. Spelled as `_T + "..."` rather than one contiguous
+# string, so this file's own source text never contains a run this gate's
+# regex would itself match (lead-coder review, #4068: without the split,
+# this file's own fixture literals grew the gate's baseline every time a
+# test was added — 9 -> 10 in one PR, measured, not assumed).
+_T = "tests/"
 
 
 def test_a_mid_sentence_reference_is_matched() -> None:
     """Tier 1: #4006 measured 17x undercounting from anchoring to "right
     after a quote character" — the regex must match `tests/...py` embedded
     anywhere in a larger prose run, not only a standalone string literal."""
-    line = 'See the gate in tests/scripts/test_foo.py for the -O witness.'
+    line = "See the gate in " + _T + "scripts/test_foo.py for the -O witness."
     matches = [m.group(0) for m in _PATH_LITERAL_RE.finditer(line)]
-    assert matches == ["tests/scripts/test_foo.py"]
+    assert matches == [_T + "scripts/test_foo.py"]
 
 
 def test_a_bare_substring_without_a_word_boundary_is_not_matched() -> None:
     """Tier 1: "xtests/foo.py" must not match — the left word-boundary
     exists specifically to reject a `tests/` occurring mid-identifier."""
-    line = "xtests/foo.py"
+    line = "x" + _T + "foo.py"
     assert list(_PATH_LITERAL_RE.finditer(line)) == []
 
 
@@ -51,12 +58,13 @@ def test_a_bare_substring_without_a_word_boundary_is_not_matched() -> None:
 
 
 def test_a_literal_resolving_to_a_real_file_is_not_offending(tmp_path) -> None:
-    """Tier 1: `tests/services/test_x.py` existing on disk is not an
-    offender, even though the scan matched it."""
+    """Tier 1: a literal existing on disk (`services/test_x.py`, under
+    the `_T` root below) is not an offender, even though the scan
+    matched it."""
     (tmp_path / "tests" / "services").mkdir(parents=True)
     (tmp_path / "tests" / "services" / "test_x.py").write_text("", encoding="utf-8")
     (tmp_path / "note.md").write_text(
-        "see tests/services/test_x.py for details\n", encoding="utf-8"
+        "see " + _T + "services/test_x.py for details\n", encoding="utf-8"
     )
     subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
     subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
@@ -65,15 +73,16 @@ def test_a_literal_resolving_to_a_real_file_is_not_offending(tmp_path) -> None:
 
 
 def test_a_literal_not_resolving_is_offending(tmp_path) -> None:
-    """Tier 1: `tests/services/test_gone.py` referenced but absent on disk
-    IS an offender — the gate's whole reason to exist."""
+    """Tier 1: a literal (`services/test_gone.py`, under the `_T` root
+    below) referenced but absent on disk IS an offender — the gate's
+    whole reason to exist."""
     (tmp_path / "note.md").write_text(
-        "see tests/services/test_gone.py for details\n", encoding="utf-8"
+        "see " + _T + "services/test_gone.py for details\n", encoding="utf-8"
     )
     subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
     subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
     offenders = offending_references(tmp_path)
-    assert offenders == [(tmp_path / "note.md", "tests/services/test_gone.py", 1)]
+    assert offenders == [(tmp_path / "note.md", _T + "services/test_gone.py", 1)]
 
 
 def test_an_untracked_file_is_not_scanned(tmp_path) -> None:
@@ -82,7 +91,7 @@ def test_an_untracked_file_is_not_scanned(tmp_path) -> None:
     like mkdocs' `site/`) must not contribute offenders, with zero
     exclusion rule naming it."""
     (tmp_path / "note.md").write_text(
-        "see tests/services/test_gone.py for details\n", encoding="utf-8"
+        "see " + _T + "services/test_gone.py for details\n", encoding="utf-8"
     )
     subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
     # note.md is never `git add`-ed — untracked.
@@ -95,7 +104,7 @@ def test_changelog_md_is_excluded_even_though_tracked(tmp_path) -> None:
     include it) but is explicitly excluded — a historical record naming a
     path that was real when written is not a defect."""
     (tmp_path / "CHANGELOG.md").write_text(
-        "- fixed tests/services/test_long_gone.py\n", encoding="utf-8"
+        "- fixed " + _T + "services/test_long_gone.py\n", encoding="utf-8"
     )
     subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
     subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
@@ -112,7 +121,9 @@ def test_flat_tests_disposition_json_is_excluded_even_though_tracked(tmp_path) -
     baseline entry here forever (lead-coder review, #4065 follow-up)."""
     (tmp_path / "scripts").mkdir()
     (tmp_path / "scripts" / "flat_tests_disposition.json").write_text(
-        '{"tests/test_moved_away.py": {"disposition": "moved", "to": "tests/core/test_moved_away.py"}}\n',
+        json.dumps({
+            _T + "test_moved_away.py": {"disposition": "moved", "to": _T + "core/test_moved_away.py"},
+        }) + "\n",
         encoding="utf-8",
     )
     subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
@@ -128,15 +139,15 @@ def test_a_literal_never_tracked_classifies_never_existed() -> None:
     """Tier 1: a literal absent from the full-history tracked-file set is
     `never-existed` — an illustrative example or an unbuilt promise, never
     a real file that moved."""
-    assert classify("tests/test_a.py", ever_tracked=set()) == "never-existed"
+    assert classify(_T + "test_a.py", ever_tracked=set()) == "never-existed"
 
 
 def test_a_literal_once_tracked_classifies_stale() -> None:
     """Tier 1: a literal present in the full-history tracked-file set is
     `stale` — it WAS a real file and the reference wasn't updated when it
     moved or was deleted."""
-    ever = {"tests/test_moved_away.py"}
-    assert classify("tests/test_moved_away.py", ever_tracked=ever) == "stale"
+    ever = {_T + "test_moved_away.py"}
+    assert classify(_T + "test_moved_away.py", ever_tracked=ever) == "stale"
 
 
 # ── new_pairs — the ratchet check itself ────────────────────────────────────
@@ -144,25 +155,25 @@ def test_a_literal_once_tracked_classifies_stale() -> None:
 
 def test_a_pair_in_the_baseline_is_not_new() -> None:
     """Tier 1: grandfathered debt does not fail the gate."""
-    baseline = {("docs/foo.md", "tests/test_gone.py")}
-    measured = {("docs/foo.md", "tests/test_gone.py")}
+    baseline = {("docs/foo.md", _T + "test_gone.py")}
+    measured = {("docs/foo.md", _T + "test_gone.py")}
     assert new_pairs(measured, baseline) == set()
 
 
 def test_a_pair_absent_from_the_baseline_is_new() -> None:
     """Tier 1: the load-bearing case — a reference that goes stale AFTER
     the baseline was written must be caught."""
-    baseline = {("docs/foo.md", "tests/test_gone.py")}
-    measured = {("docs/foo.md", "tests/test_gone.py"), ("docs/bar.md", "tests/test_new_gone.py")}
-    assert new_pairs(measured, baseline) == {("docs/bar.md", "tests/test_new_gone.py")}
+    baseline = {("docs/foo.md", _T + "test_gone.py")}
+    measured = {("docs/foo.md", _T + "test_gone.py"), ("docs/bar.md", _T + "test_new_gone.py")}
+    assert new_pairs(measured, baseline) == {("docs/bar.md", _T + "test_new_gone.py")}
 
 
 def test_a_pair_leaving_the_measured_set_is_not_reported() -> None:
     """Tier 1: a fix (or the referencing file itself moving away) silently
     drops out — nothing has to be edited in the baseline to let a fix
     "count", the same discipline `mypy_ratchet.py`'s own docstring names."""
-    baseline = {("docs/foo.md", "tests/test_gone.py"), ("docs/bar.md", "tests/test_also_gone.py")}
-    measured = {("docs/foo.md", "tests/test_gone.py")}
+    baseline = {("docs/foo.md", _T + "test_gone.py"), ("docs/bar.md", _T + "test_also_gone.py")}
+    measured = {("docs/foo.md", _T + "test_gone.py")}
     assert new_pairs(measured, baseline) == set()
 
 


### PR DESCRIPTION
**[e2e-coder]** — #4065, paused earlier this session for a scope/design rework, now resumed per lead-coder's go-ahead.

## The class this closes

A `tests/...py` path literal — in a docstring, comment, doc prose, YAML/workflow arg — goes stale the moment that file moves, unless something checks it. #3879's bucket migrations broke this 3 times in one night: #4025 (caught because CI ran the stale assert and it went RED), #4036 (caught because pytest happened to exit 4, coincidental), #4062/#4063 (caught only by a human running grep by hand — nothing executes prose, so nothing was ever going to turn red on its own). This gate is the missing "does it still exist" check for the third, dangerous shape.

## Design (per lead-coder review of the paused attempt)

- **Ratchet, not zero baseline** — real measurement: 452 `(referencing_file, literal)` pairs, same skeleton as `mypy_ratchet.py`. New pairs fail CI; pre-existing debt doesn't block adoption.
- **No placeholder-name allowlist** — considered and rejected: an exclusion condition needs to be machine-checkable, and "illustrative in context" is a judgment call, not one. A hardcoded list would silently swallow every future reference sharing one of those names too, defeating the ratchet's whole point.
- **Population = `git ls-files`**, not a directory walk with a hand-maintained exclusion list. `site/` (mkdocs' gitignored build output) disappears with zero rules of its own; a future generated-output directory is excluded the day it's gitignored, automatically.
- **`CHANGELOG.md` stays an explicit exclusion** — it IS tracked (so `ls-files` alone includes it), but a historical entry naming a path real when written is correct, not stale. Tracked-vs-gitignored is exactly the line between "needs a rule" and "the population definition already handles it."
- **Every baseline entry carries `class: never-existed | stale`** — 412 stale / 40 never-existed in the current measurement. Opposite in meaning (stale = a real file moved, fix the path; never-existed = an illustrative example OR a doc's promise never built, a doc-accuracy defect worse than staleness but harmless to run) and must not be collapsed into one count. Not used to filter — recorded for a future triage pass.

## Verification

- `ruff check scripts tests` — clean
- `test_tier_audit.py --strict` — 13/13
- `verify_module_docstrings.py` — clean
- `mypy_ratchet.py` — 210/213, unchanged
- `pytest tests/scripts/test_check_tests_path_literal_reference_4065.py` — 13 passed
- Falsify-verified: stripped one known-real baseline entry (`tests/test_fp0063_arc_witness.py` → `tests/test_replay_fixture_no_stacking_3634.py`), confirmed RED for the exact reason, restored, confirmed GREEN.

## Test plan

- [x] Whole-repo scan, not scoped to `tests/` (the #3879 PRs' own repeated mistake)
- [x] Baseline regenerated against latest `origin/main` (post #4062, #4067)
- [x] CI workflow added (`.github/workflows/tests-path-literal-reference-gate.yml`), no paths filter (reference and referenced file are on opposite sides)
- [x] 5-gate local battery green


- [x] 🔴 **gate 自身のテスト由来 10 件を baseline から外す** — リテラルを実行時連結にする（`_T = "tests/"` ＋ `_T + "test_a.py"`）。名前空間の外に出す案は撤回（gate の照合経路を通らなくなるため）。lead-coder review

