### PR TITLE
refactor(#3879): narrowing-cluster PR-1 — test_3546's measured_by resolver -> REPO_ROOT

### DIFF
--- a/tests/test_3546_pipeline_driver_narrowing_inheritance.py
+++ b/tests/test_3546_pipeline_driver_narrowing_inheritance.py
@@ -1068,7 +1068,6 @@ def test_every_declared_site_names_a_behavioural_test_or_a_reason() -> None:
     ever gets — a stale name (a renamed or deleted test) fails here rather than
     quietly leaving the site unmeasured.
     """
-    tests_root = Path(__file__).resolve().parent
     for (mod, fn), decl in sorted(_SITE_PARENT_LAYERS.items()):
         assert decl.parent_layers.strip(), f"{mod}::{fn} declares no parent layers"
         assert (
@@ -1081,7 +1080,7 @@ def test_every_declared_site_names_a_behavioural_test_or_a_reason() -> None:
         )
         for ref in decl.measured_by:
             path_part, _, test_name = ref.partition("::")
-            path = tests_root.parent / path_part
+            path = REPO_ROOT / path_part
             assert path.is_file(), f"{mod}::{fn} names a missing test file: {ref}"
             tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
             defined = {

--- a/tests/test_3546_pipeline_driver_narrowing_inheritance.py
+++ b/tests/test_3546_pipeline_driver_narrowing_inheritance.py
@@ -558,11 +558,18 @@ class _SiteDeclaration:
     unmeasured_reason: str = ""
 
 
-_S3546 = "tests/test_3546_pipeline_driver_narrowing_inheritance.py"
-_S3553 = "tests/test_3553_agent_step_worker_narrowing_inheritance.py"
-_S3556 = "tests/test_3556_session_spawn_narrowing_inheritance.py"
-_S3561 = "tests/test_3561_spawn_session_seam_reachability.py"
-_S3562 = "tests/test_3562_slash_session_new_narrowing_inheritance.py"
+# Derived from this file's OWN location (never a hardcoded literal): all 5
+# narrowing-cluster siblings always move together into the same destination
+# bucket, so their repo-relative directory is identical to this file's own
+# — computing it here means a future M4 bucket move needs zero string
+# updates for these 5 constants, only `git mv` (see #4069 -- this sidesteps
+# the class entirely rather than relying on the rename-substitution rule).
+_OWN_DIR = Path(__file__).resolve().parent.relative_to(REPO_ROOT).as_posix()
+_S3546 = f"{_OWN_DIR}/test_3546_pipeline_driver_narrowing_inheritance.py"
+_S3553 = f"{_OWN_DIR}/test_3553_agent_step_worker_narrowing_inheritance.py"
+_S3556 = f"{_OWN_DIR}/test_3556_session_spawn_narrowing_inheritance.py"
+_S3561 = f"{_OWN_DIR}/test_3561_spawn_session_seam_reachability.py"
+_S3562 = f"{_OWN_DIR}/test_3562_slash_session_new_narrowing_inheritance.py"
 
 #: Every spawn site in ``src/``, with the parent layers its ``narrowing=`` value
 #: composes and the behavioural test that measures that claim. A site missing from


### PR DESCRIPTION
**[tui-coder]** — Narrowing-cluster PR-1 of 2 (lead-coder's option-b ruling, broker 2026-08-10): fix `test_3546`'s own `measured_by` resolver to use `REPO_ROOT` instead of `tests_root.parent`.

part of #3879

## Why this comes first, content-only, no rename

`test_every_declared_site_names_a_behavioural_test_or_a_reason` resolved each `measured_by` entry via `tests_root.parent / path_part`, where `tests_root = Path(__file__).resolve().parent`. That formula silently assumes this file lives directly in `tests/` (so `tests_root.parent == repo root`) — true today, but breaks the moment this file (or a sibling whose `measured_by` entries it resolves) moves into a `tests/<bucket>/` subdirectory: `tests_root` becomes `tests/<bucket>`, `tests_root.parent` becomes `tests/`, and the stored `path_part` (which still starts with `tests/`) doubles up into `tests/tests/<bucket>/...`.

Fixed to `REPO_ROOT / path_part` — `REPO_ROOT` (`tests._support.paths`, already imported in this file for `_SRC`) is a marker-walk anchor, stable regardless of this file's own location.

This lands **before** any of the 5 narrowing-cluster files move (`test_3546` itself, `3553`, `3556`, `3561`, `3562`), so the resolution mechanism is already correct by the time PR-2 does the actual rename + `measured_by` path-string updates — PR-2 only needs to change 5 string literals, not fix a second location-dependent bug at the same time.

## Gate status

`check_migration_diff_shape.py` reports **inactive** — no `R100` rename under `tests/` in this diff, so it's entirely out of that gate's scope (lead-coder's own point ②).

## Verification

- `check_migration_diff_shape.py --base origin/main` — inactive (confirms no rename).
- `check_file_depth_reference.py` — clean.
- `ruff check` — clean.
- `mypy_ratchet.py` — 210/213 baselined, no new debt.
- `test_tier_audit.py --strict` — 12/12, 0 errors.
- `verify_module_docstrings.py` — clean.
- `pytest tests/test_3546_pipeline_driver_narrowing_inheritance.py` — **12 passed**.

## Test plan

- [x] Gate confirmed inactive (content-only, no rename)
- [x] pytest 12/12
- [x] All other gates clean
- Not self-merging per PR-workflow rule 8; lead-coder is running the merge train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
