### PR TITLE
feat(#4069): check_migration_diff_shape.py — permit content changes fully explained by the PR's own rename mapping

### DIFF
--- a/scripts/check_migration_diff_shape.py
+++ b/scripts/check_migration_diff_shape.py
@@ -157,6 +157,41 @@ sharing only the underlying AST resolver, not one shared predicate — the
 "1機構" framing this docstring originally used was itself part of what
 got retracted.
 
+## #4069 — a content-change line explained ENTIRELY by this PR's own rename
+
+The blanket "no content changes" rule (above) has one real structural hole:
+a reference that CANNOT be written correctly before the move it depends on
+has already happened — a Python ``import`` statement naming the moved
+module's dotted path, or a ``measured_by``-style registry string resolved
+by ``path.is_file()`` — either breaks immediately if written early (import-
+time ``ModuleNotFoundError`` / an assertion failing against a location that
+doesn't exist yet), so the only structurally possible place to fix it is
+the SAME commit as the move. Before this addition, such a fix could only be
+merged as a declared "human review" exception — a PROMISE a reviewer read
+every changed line, not a mechanism (#4071 hit exactly this: 3 files,
+7 changed lines, all of this shape).
+
+The rule (lead-coder, #4069, verified against #4071's real 7 lines before
+shipping — 7/7 explained): build this PR's own rename mapping from its
+R100 lines (old path → new path), then for a content-changed ``M`` file
+under ``tests/``, check EVERY changed line — paired within its own diff
+HUNK, never across hunk boundaries, and only when a hunk's removed/added
+line counts match 1:1 (anything else cannot be explained this
+mechanically and stays rejected) — asks: does substituting every mapping
+entry into the OLD line, in EITHER form (the raw ``tests/old/path.py``
+string, or its dotted-import equivalent ``tests.old.path``), produce
+EXACTLY the NEW line? If every changed line in the file passes, the whole
+file is permitted; a single line that doesn't reduces to the plain
+rejection. See :func:`is_explained_by_rename_substitution`.
+
+This is not a loosening of the "no content changes" rule — it identifies,
+mechanically, from the diff's own R100 lines (no external list, no human
+judgment call), exactly the subset that had structurally no other order to
+land in. #4064's rejected proposal ("relax rule ① to any coherent subject")
+went the OPPOSITE direction: that one substituted a human judgment call for
+a mechanical one; this one substitutes a mechanical check for what was
+previously only a human promise to read the diff.
+
 ## Lifespan — this gate is temporary, unlike Stage 0's ratchet
 
 Stage 0's ratchet (``flat_tests_ratchet.py``) is permanent: it must keep
@@ -460,13 +495,115 @@ def _in_scope(line: str) -> bool:
     return any(p.startswith("tests/") for p in paths)
 
 
-def offending_lines(lines: "list[str]", root: Path = _ROOT) -> "list[str]":
-    """Every in-scope diff line that is NOT one of the three allowed shapes
-    — the gate's entire decision, isolated from I/O so it is directly
+def rename_mapping(lines: "list[str]") -> "dict[str, str]":
+    """This PR's own R100 renames as an ``{old path: new path}`` map — the
+    ONLY input :func:`is_explained_by_rename_substitution` reads (#4069):
+    no external list, no baseline, nothing but this diff's own allowed
+    moves."""
+    mapping: "dict[str, str]" = {}
+    for line in lines:
+        parts = line.split("\t")
+        if parts[0] == "R100" and len(parts) == 3:
+            mapping[parts[1]] = parts[2]
+    return mapping
+
+
+def _dotted_module_path(path: str) -> str:
+    """``tests/foo/bar.py`` -> ``tests.foo.bar`` — the form a Python
+    ``import``/``from`` statement names a moved module by, as opposed to
+    the slash-path form a ``measured_by``-style string literal uses. A
+    rename substitution must try both, since #4071's 7 real lines used
+    each form in different files."""
+    stem = path[:-len(".py")] if path.endswith(".py") else path
+    return stem.replace("/", ".")
+
+
+def _line_explained_by_rename(old_line: str, new_line: str, mapping: "dict[str, str]") -> bool:
+    """Does substituting every entry of *mapping* into *old_line* — in
+    EITHER its path form or its dotted-import form — produce exactly
+    *new_line*? The whole rule from #4069's single line of substitution
+    logic, made total over both spellings a reference can use."""
+    explained = old_line
+    for old_path, new_path in mapping.items():
+        explained = explained.replace(old_path, new_path)
+        explained = explained.replace(
+            _dotted_module_path(old_path), _dotted_module_path(new_path),
+        )
+    return explained == new_line
+
+
+def _diff_hunks_for_file(base: str, path: str, root: Path) -> "list[tuple[list[str], list[str]]]":
+    """Every hunk of ``git diff -U0 <base>...HEAD -- <path>`` as
+    ``(removed_lines, added_lines)`` pairs, one entry per hunk — zero
+    context lines, since only the actual changed lines matter here.
+    Hunk boundaries are preserved deliberately (lead-coder's own
+    correction on #4069: pairing removed/added lines by position ACROSS
+    the whole file, ignoring hunk boundaries, was an explicitly-flagged
+    shortcut in the verification script, not something the real
+    implementation may do — two unrelated single-line hunks elsewhere in
+    the same file could otherwise cross-pair and "explain" a change that
+    isn't actually a rename substitution)."""
+    proc = subprocess.run(
+        ["git", "diff", "-U0", f"{base}...HEAD", "--", path],
+        cwd=root, capture_output=True, text=True, check=True,
+    )
+    hunks: "list[tuple[list[str], list[str]]]" = []
+    removed: "list[str]" = []
+    added: "list[str]" = []
+    for line in proc.stdout.splitlines():
+        if line.startswith("@@"):
+            if removed or added:
+                hunks.append((removed, added))
+            removed, added = [], []
+        elif line.startswith("-") and not line.startswith("---"):
+            removed.append(line[1:])
+        elif line.startswith("+") and not line.startswith("+++"):
+            added.append(line[1:])
+    if removed or added:
+        hunks.append((removed, added))
+    return hunks
+
+
+def is_explained_by_rename_substitution(
+    path: str, base: str, mapping: "dict[str, str]", root: Path = _ROOT,
+) -> bool:
+    """#4069: whether every changed line in *path* (an ``M`` file, not
+    itself renamed) is fully explained by substituting THIS PR's own
+    rename *mapping* — permitted even though it is a content change,
+    because the reference could not have been written correctly before
+    the move happened (see module docstring's #4069 section). Requires
+    EVERY hunk's removed/added line counts to match 1:1 (anything else —
+    an added or removed line with no counterpart — cannot be explained
+    this mechanically) AND every paired line to satisfy
+    :func:`_line_explained_by_rename`. No mapping, or no hunks at all
+    (e.g. a binary-diff edge case), is conservatively NOT explained."""
+    if not mapping:
+        return False
+    hunks = _diff_hunks_for_file(base, path, root)
+    if not hunks:
+        return False
+    for removed, added in hunks:
+        if len(removed) != len(added):
+            return False
+        for old_line, new_line in zip(removed, added):
+            if not _line_explained_by_rename(old_line, new_line, mapping):
+                return False
+    return True
+
+
+def offending_lines(lines: "list[str]", root: Path = _ROOT, base: "str | None" = None) -> "list[str]":
+    """Every in-scope diff line that is NOT one of the allowed shapes —
+    the gate's entire decision, isolated from I/O so it is directly
     testable against a hand-built line list. Only called once
     :func:`gate_is_active` has confirmed this PR is a migration PR at all;
     an out-of-scope line (outside ``tests/``, not the baseline) is skipped
-    here, not flagged — see :func:`_in_scope`."""
+    here, not flagged — see :func:`_in_scope`.
+
+    *base* is optional (defaults to skipping the #4069 rename-substitution
+    check entirely) so existing callers/tests that only care about the
+    ORIGINAL shapes — and have no real git history to diff against — keep
+    working unchanged; :func:`main` always passes it."""
+    mapping = rename_mapping(lines) if base is not None else {}
     offenders = []
     for line in lines:
         if not _in_scope(line):
@@ -506,6 +643,16 @@ def offending_lines(lines: "list[str]", root: Path = _ROOT) -> "list[str]":
             continue
 
         if status == "M" and len(parts) == 2 and parts[1] in _ALLOWED_MODIFIED_PATHS:
+            continue
+
+        if (
+            status == "M" and len(parts) == 2 and base is not None
+            and is_explained_by_rename_substitution(parts[1], base, mapping, root)
+        ):
+            # #4069: this M line's every changed line is exactly the OLD
+            # line with this PR's own rename mapping substituted in — not
+            # a rewrite, the one shape of "content change riding a rename
+            # PR" that has no other order to land in.
             continue
 
         if status.startswith("C") and len(parts) == 3:
@@ -594,7 +741,7 @@ def main(argv: "list[str] | None" = None) -> int:
         )
         return 0
 
-    offenders = offending_lines(lines)
+    offenders = offending_lines(lines, base=args.base)
 
     if not offenders:
         print(
@@ -639,7 +786,12 @@ def main(argv: "list[str] | None" = None) -> int:
             "new path, and split any real content change into a SEPARATE PR "
             "(this gate cannot tell 'legitimate unrelated fix' from 'the "
             "exact rewrite this gate exists to catch' — it rejects both on "
-            "purpose).",
+            "purpose).\n\n"
+            "An `M` line above IS allowed automatically (#4069) if every "
+            "changed line is exactly the old line with this PR's own R100 "
+            "rename mapping substituted in (path or dotted-import form) — "
+            "if it's still here, at least one changed line in that file "
+            "isn't explained that mechanically.",
             file=sys.stderr,
         )
     return 1

--- a/tests/scripts/test_check_migration_diff_shape_3879.py
+++ b/tests/scripts/test_check_migration_diff_shape_3879.py
@@ -23,6 +23,7 @@ from scripts.check_migration_diff_shape import (
     is_tests_copy,
     offending_lines,
     position_dependent_rename_lines,
+    rename_mapping,
 )
 
 
@@ -680,3 +681,235 @@ def test_a_same_basename_zero_similarity_disguised_move_still_activates_the_gate
         "activate the gate — the signal's original purpose, which the "
         "#3930 basename-equality fix must preserve"
     )
+
+
+# ── #4069 — a content change explained ENTIRELY by this PR's own rename ────
+
+
+@pytest.fixture
+def _repo_with_referencing_sibling(tmp_path: Path) -> Path:
+    """A real git repo with two committed files: ``tests/test_a.py`` (the
+    file this bundle's #4069 tests move) and ``tests/test_b.py``, which
+    references it by path string and by dotted-import — the shape #4071's
+    real `test_3595_client_input_provenance_gate.py` / `test_yank_failure_
+    is_visible_3616.py` had."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    tests_dir = repo / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_a.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (tests_dir / "test_b.py").write_text(
+        "from tests.test_a import VALUE\n"
+        "\n"
+        "REGISTRY_PATH = \"tests/test_a.py\"\n"
+        "UNRELATED = 1\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+    return repo
+
+
+def test_m_line_explained_by_rename_path_form_is_allowed(_repo_with_referencing_sibling: Path) -> None:
+    """Tier 2: (#4069) test_b.py's REGISTRY_PATH string is exactly the old
+    path with test_a's own rename substituted in — a real instance of
+    #4071's test_3595_client_input_provenance_gate.py shape. This M line
+    must be permitted, not just the rename itself."""
+    repo = _repo_with_referencing_sibling
+    core = repo / "tests" / "core"
+    core.mkdir()
+    subprocess.run(["git", "mv", "tests/test_a.py", "tests/core/test_a.py"], cwd=repo, check=True)
+    (repo / "tests" / "test_b.py").write_text(
+        "from tests.test_a import VALUE\n"
+        "\n"
+        "REGISTRY_PATH = \"tests/core/test_a.py\"\n"
+        "UNRELATED = 1\n",
+        encoding="utf-8",
+    )
+    _commit_all(repo, "move test_a, update test_b's registry string")
+
+    lines = diff_name_status("HEAD~1", root=repo)
+    assert offending_lines(lines, root=repo, base="HEAD~1") == [], (
+        "a path-string reference fully explained by this PR's own rename "
+        "mapping was not permitted"
+    )
+
+
+def test_m_line_explained_by_rename_dotted_import_form_is_allowed(_repo_with_referencing_sibling: Path) -> None:
+    """Tier 2: (#4069) test_b.py's `from tests.test_a import` line follows
+    the SAME rename, in its dotted-import spelling rather than the
+    path-string spelling — #4071's test_yank_failure_is_visible_3616.py /
+    test_text_effect_toggle_3796.py shape. Both spellings must be tried."""
+    repo = _repo_with_referencing_sibling
+    core = repo / "tests" / "core"
+    core.mkdir()
+    subprocess.run(["git", "mv", "tests/test_a.py", "tests/core/test_a.py"], cwd=repo, check=True)
+    (repo / "tests" / "test_b.py").write_text(
+        "from tests.core.test_a import VALUE\n"
+        "\n"
+        "REGISTRY_PATH = \"tests/test_a.py\"\n"
+        "UNRELATED = 1\n",
+        encoding="utf-8",
+    )
+    _commit_all(repo, "move test_a, update test_b's dotted import")
+
+    lines = diff_name_status("HEAD~1", root=repo)
+    assert offending_lines(lines, root=repo, base="HEAD~1") == [], (
+        "a dotted-import reference fully explained by this PR's own rename "
+        "mapping was not permitted"
+    )
+
+
+def test_m_line_without_base_stays_rejected(_repo_with_referencing_sibling: Path) -> None:
+    """Tier 2: (#4069) falsification pair for the two accept-side tests
+    above — omitting `base` (the pre-#4069 call shape, and what every
+    OTHER test in this file uses) must NOT auto-permit the change; the new
+    rule is opt-in via `base`, not a default loosening."""
+    repo = _repo_with_referencing_sibling
+    core = repo / "tests" / "core"
+    core.mkdir()
+    subprocess.run(["git", "mv", "tests/test_a.py", "tests/core/test_a.py"], cwd=repo, check=True)
+    (repo / "tests" / "test_b.py").write_text(
+        "from tests.test_a import VALUE\n"
+        "\n"
+        "REGISTRY_PATH = \"tests/core/test_a.py\"\n"
+        "UNRELATED = 1\n",
+        encoding="utf-8",
+    )
+    _commit_all(repo, "move test_a, update test_b's registry string")
+
+    lines = diff_name_status("HEAD~1", root=repo)
+    offenders = offending_lines(lines, root=repo)
+    assert any("test_b.py" in line for line in offenders), (
+        "the M line was permitted even without base= — #4069 must not "
+        "activate implicitly"
+    )
+
+
+def test_m_line_with_an_unexplained_extra_change_stays_rejected(_repo_with_referencing_sibling: Path) -> None:
+    """Tier 2: (#4069) falsification — if test_b.py ALSO changes something
+    the rename mapping cannot explain (here: UNRELATED's value), the whole
+    file stays rejected. #4069 permits ONLY a pure rename-substitution
+    rewrite, not "mostly explained"."""
+    repo = _repo_with_referencing_sibling
+    core = repo / "tests" / "core"
+    core.mkdir()
+    subprocess.run(["git", "mv", "tests/test_a.py", "tests/core/test_a.py"], cwd=repo, check=True)
+    (repo / "tests" / "test_b.py").write_text(
+        "from tests.test_a import VALUE\n"
+        "\n"
+        "REGISTRY_PATH = \"tests/core/test_a.py\"\n"
+        "UNRELATED = 2\n",
+        encoding="utf-8",
+    )
+    _commit_all(repo, "move test_a, update registry string AND an unrelated value")
+
+    lines = diff_name_status("HEAD~1", root=repo)
+    offenders = offending_lines(lines, root=repo, base="HEAD~1")
+    assert any("test_b.py" in line for line in offenders), (
+        "a file with one rename-explained line and one UNEXPLAINED line "
+        "was wrongly permitted in full"
+    )
+
+
+def test_hunk_with_unequal_added_removed_counts_stays_rejected(_repo_with_referencing_sibling: Path) -> None:
+    """Tier 2: (#4069) a hunk that removes 1 line but adds 2 (or vice
+    versa) cannot be reduced to a 1:1 substitution check at all — this
+    must stay rejected rather than guessing a pairing."""
+    repo = _repo_with_referencing_sibling
+    core = repo / "tests" / "core"
+    core.mkdir()
+    subprocess.run(["git", "mv", "tests/test_a.py", "tests/core/test_a.py"], cwd=repo, check=True)
+    (repo / "tests" / "test_b.py").write_text(
+        "from tests.test_a import VALUE\n"
+        "\n"
+        "REGISTRY_PATH = \"tests/core/test_a.py\"\n"
+        "REGISTRY_PATH_EXTRA_LINE = \"tests/core/test_a.py\"\n"
+        "UNRELATED = 1\n",
+        encoding="utf-8",
+    )
+    _commit_all(repo, "move test_a, replace one line with two")
+
+    lines = diff_name_status("HEAD~1", root=repo)
+    offenders = offending_lines(lines, root=repo, base="HEAD~1")
+    assert any("test_b.py" in line for line in offenders), (
+        "a hunk with mismatched removed/added line counts was permitted "
+        "without a real 1:1 substitution check"
+    )
+
+
+def test_pairing_does_not_cross_hunk_boundaries(_repo_with_referencing_sibling: Path) -> None:
+    """Tier 2: (#4069) falsification for hunk-scoped pairing specifically
+    (lead-coder's own correction on the design: a whole-file zip of
+    removed/added lines — checking only the GLOBAL removed/added line
+    COUNT, not each hunk's own — was an explicitly-flagged shortcut, not
+    the real rule).
+
+    A global-count check alone is fooled here: hunk 1 removes 2 lines and
+    adds only 1 (a real content COLLAPSE, not a pure substitution — one
+    of the two old registrations is dropped); hunk 2, separated by
+    padding, adds 1 new line with nothing removed. Globally 2 removed ==
+    2 added, so a whole-file line-count check sees no problem, and a
+    naive order-preserving zip across both hunks HAPPENS to pair each
+    removed line with a substitution-correct added line (because the
+    dropped registration's replacement was relocated into hunk 2) — every
+    individual pair passes :func:`_line_explained_by_rename`, so a
+    global-count implementation would WRONGLY permit this file. Hunk-scoped
+    pairing catches it immediately: hunk 1 alone has 2 removed vs 1 added,
+    which can never reduce to a 1:1 substitution check, so it is rejected
+    without even looking at content — this is exactly the "these counts
+    already disqualify the hunk" case a purely global check cannot see."""
+    repo = _repo_with_referencing_sibling
+    padding = "\n".join(f"pad_{i} = {i}" for i in range(20))
+    (repo / "tests" / "test_b.py").write_text(
+        "from tests.test_a import VALUE\n"
+        "REGISTRY_A = \"tests/test_a.py\"\n"
+        "REGISTRY_B = \"tests/test_a.py\"\n"
+        f"{padding}\n"
+        "TRAILING = 1\n",
+        encoding="utf-8",
+    )
+    _commit_all(repo, "test_b registers test_a twice, with padding after")
+
+    core = repo / "tests" / "core"
+    core.mkdir()
+    subprocess.run(["git", "mv", "tests/test_a.py", "tests/core/test_a.py"], cwd=repo, check=True)
+    (repo / "tests" / "test_b.py").write_text(
+        "from tests.test_a import VALUE\n"
+        # hunk 1: 2 lines removed, only 1 added — REGISTRY_B's
+        # registration is dropped here, not substituted.
+        "REGISTRY_A = \"tests/core/test_a.py\"\n"
+        f"{padding}\n"
+        # hunk 2: 0 lines removed, 1 added — REGISTRY_B's replacement,
+        # relocated after the padding instead of staying in hunk 1.
+        "REGISTRY_B = \"tests/core/test_a.py\"\n"
+        "TRAILING = 1\n",
+        encoding="utf-8",
+    )
+    _commit_all(repo, "move test_a; collapse+relocate test_b's registrations")
+
+    lines = diff_name_status("HEAD~1", root=repo)
+    offenders = offending_lines(lines, root=repo, base="HEAD~1")
+    assert any("test_b.py" in line for line in offenders), (
+        "a hunk with 2 removed / 1 added lines was permitted because a "
+        "SEPARATE hunk's extra added line balanced the GLOBAL count — "
+        "pairing must be scoped per hunk, not per file"
+    )
+
+
+def test_rename_mapping_reads_only_r100_lines(_repo: Path) -> None:
+    """Tier 2: (#4069) rename_mapping() — the sole input the whole rule
+    reads — includes only R100 (byte-identical, ALLOWED) renames, never a
+    low-similarity rename (which offending_lines rejects on its own, and
+    must not ALSO leak into explaining some other file's content change)."""
+    core = _repo / "tests" / "core"
+    core.mkdir()
+    subprocess.run(["git", "mv", "tests/test_a.py", "tests/core/test_a.py"], cwd=_repo, check=True)
+    _commit_all(_repo, "pure move")
+
+    lines = diff_name_status("HEAD~1", root=_repo)
+    mapping = rename_mapping(lines)
+    assert mapping == {"tests/test_a.py": "tests/core/test_a.py"}


### PR DESCRIPTION
**[tui-coder]** — #4069: a content-change line explained by this PR's own rename mapping is permitted.

part of #3879

## The hole this closes

The blanket "no content changes" rule in `check_migration_diff_shape.py` has one real structural hole: a reference that CANNOT be written correctly before the move it depends on has already happened — a Python `import` statement naming the moved module's dotted path, or a `measured_by`-style registry string resolved by `path.is_file()`. Either breaks immediately if written early (import-time `ModuleNotFoundError`, or an assertion against a location that doesn't exist yet). The only structurally possible place to fix such a reference is the SAME commit as the move. Before this, such a fix could only merge as a declared "human review" exception — a promise a reviewer read every line, not a mechanism (#4071 hit exactly this: 3 files, 7 changed lines).

## The rule (lead-coder's design, #4069, verified against #4071's real 7 lines before shipping)

Build this PR's own rename mapping from its `R100` lines (old path → new path), then for a content-changed `M` file under `tests/`, check EVERY changed line — paired within its own diff HUNK, never across hunk boundaries, and only when a hunk's removed/added line counts match 1:1 — and ask: does substituting every mapping entry into the OLD line (path form OR dotted-import form) produce exactly the NEW line? Every changed line passing permits the whole file; one that doesn't leaves the plain rejection unchanged.

This is not a loosening of the "no content changes" rule — it mechanically identifies, from the diff's own `R100` lines (no external list, no human judgment call), exactly the subset that had structurally no other order to land in. The opposite direction of #4064's rejected proposal (relax rule ① to "any coherent subject" — a human judgment call); this substitutes a mechanical check for what was previously only a human promise.

## Hunk-scoped, not whole-file — falsify-verified, not assumed

Lead-coder's own verification script used a file-wide zip of removed/added lines as an explicit shortcut, flagged in their own message as NOT the real implementation. I deliberately reintroduced that exact bug (global line-count check + order-preserving zip across all hunks) and confirmed `test_pairing_does_not_cross_hunk_boundaries` goes red: a hunk with 2 removed / 1 added lines was wrongly permitted because a SEPARATE hunk's extra added line balanced the GLOBAL count. Reverted after confirming.

## Verification

- Ran against `feat/3879-bundle-f-final-24`'s actual diff (#4071): the 3 previously-flagged `M` lines (`test_yank_failure_is_visible_3616.py`, `test_text_effect_toggle_3796.py`, `test_3595_client_input_provenance_gate.py`) all pass automatically now — gate reports 26 diff lines, all pure renames / empty `__init__.py` additions / baseline shrink. Matches lead-coder's own 7/7 result exactly.
- `pytest tests/scripts/test_check_migration_diff_shape_3879.py` — **30/30** (23 original untouched + 7 new: 2 accept-side, 3 reject-side falsification pairs, the hunk-boundary falsifier above, `rename_mapping()`'s own R100-only scope).
- `ruff check` — clean.
- `mypy_ratchet.py` — 210/213 baselined, no new debt.
- `test_tier_audit.py --strict` — 30/30, 0 errors.
- `verify_module_docstrings.py` — clean.
- Backward compatibility: the new check is opt-in via a `base` parameter on `offending_lines()` that only `main()` passes — every pre-existing caller/test keeps working unchanged without it (all 23 original tests pass untouched).

## Test plan

- [x] Verified against #4071's real diff — 7/7 explained, matches lead-coder's independent result
- [x] Hunk-boundary requirement falsify-verified (deliberately broke it, confirmed red, reverted)
- [x] 30/30 pytest, all other gates clean
- Not self-merging per PR-workflow rule 8; lead-coder is running the merge train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
