### PR TITLE
docs(#4074): fix stale migration-diff-shape axiom framing after #4073

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -417,6 +417,19 @@ actually promises.
   class on their first whole-tree run, confirming "declared byte-identical
   ⇒ safe" had been true only for the specific property it checked, never
   the broader one readers assumed from its name.
+  **Update (2026-08-10, #4069→#4073)**: the axiom itself did not loosen —
+  a reference that CANNOT be written correctly before its own move lands
+  (an `import` of the moved module's dotted path, a `path.is_file()`
+  registry string) has no other legal order to land in, so permitting it
+  is not a bigger version of "byte-identical ⇒ safe", it is a mechanical
+  identification of the subset that was never byte-identical-capable in
+  the first place. The check builds the PR's own rename mapping from its
+  `R100` lines and verifies every changed line, hunk-scoped, resolves
+  under that mapping — no external list, no human judgment call. This is
+  the opposite direction from #4064's rejected proposal (widen rule ① to
+  "any coherent subject", a human judgment call): #4073 substitutes a
+  mechanical check for what could previously only merge as a declared,
+  unverifiable "a human read every line" promise.
 
 **Apply**: when writing or reviewing a gate, write out the FULL property the
 surrounding prose/docstring promises, then check whether the assertion


### PR DESCRIPTION
**[docs-maintainer]** — part of #4074 (filed by lead-coder after catching this at merge-review time for #4073).

## What was stale

`docs/deep-dives/contributing/verification-hazards.md:397-419`'s "migration-safety gate's founding axiom" entry described `check_migration_diff_shape.py` as enforcing "byte-identical `R100` rename ⇒ safe" with no exception — accurate through #4009, falsified by #4073 (#4069's design), which permits a narrow class of content changes: lines fully explained by the PR's own rename mapping.

## The fix

Added an update paragraph making the distinction lead-coder flagged explicit: the axiom itself didn't loosen. A reference that cannot be written correctly before its own move lands (an `import` of the moved module's dotted path, a `path.is_file()` registry string) was never byte-identical-capable to begin with — mechanically identifying that subset via the PR's own `R100` mapping, hunk-scoped, is a narrower operation than the axiom, not a bigger one. Contrasted with #4064's rejected "any coherent subject" proposal (a human judgment call) per #4073's own docstring — #4073 goes the opposite direction, substituting a mechanical check for what could only previously merge as an unverifiable human promise.

## Also checked (per lead-coder's request to grep other tonight's mechanisms)

- `#4065`'s path-literal ratchet gate — still open in `#4068`, not yet merged; no doc claim to fix yet.
- `#4066`/`#4072`'s `flat_tests_disposition`/`flat_tests_arc_population`/`flat_tests_ratchet` — zero `docs/` hits; these are `#3879`-arc-internal bookkeeping scripts, not a standing mechanism any doc describes, consistent with earlier same-night triage.

## Test plan

- [x] `python scripts/check_doc_anchors.py` — exit 0, no dangling anchors
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0 (remaining INFO lines are pre-existing ja-mirror anchor gaps, unrelated to this change)
- [x] Confirmed via `gh pr diff 4073` that the actual landed mechanism matches this doc's new description (hunk-scoped, R100-mapping-only, no external list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
