### PR TITLE
docs(#4065): add path-literal reference ratchet as pre-push gate #6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,13 @@ per-PR coders) authenticating as the same `gh` user.
 **Before you open a PR, run `ruff check src tests`, `python
 scripts/test_tier_audit.py --strict <changed test files>`, `python
 scripts/verify_module_docstrings.py <changed src files>`, `python
-scripts/mypy_ratchet.py`, and `pytest` scoped to the files/keywords your
+scripts/mypy_ratchet.py`, `python
+scripts/check_tests_path_literal_reference.py` (#4065/#4068 — a `tests/...py`
+path-literal ratchet, ~2.6s; on a PR that moves/renames a `tests/...py` file,
+its whole-repo baseline goes stale the moment `main` moves underneath your
+branch, so re-run it right before pushing, not earlier in the session —
+#4068 rebased 4 times over this before the cause was identified, #3880),
+and `pytest` scoped to the files/keywords your
 diff actually affects.** **Do NOT run the full `pytest` suite from the repo
 root locally** — CI already does that, in a clean checkout, faster and
 without picking up local machine config a full local run would (#3791).

--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -1159,13 +1159,33 @@ silently start running the full suite locally again without updating it.
    ```bash
    python scripts/mypy_ratchet.py
    ```
+6. **path-literal reference ratchet** — `scripts/check_tests_path_literal_reference.py`
+   (#4065). Same ratchet shape as #5 against
+   `scripts/check_tests_path_literal_reference_baseline.json`, but a different
+   population: every `tests/...py` path literal repo-wide (docstring, comment,
+   doc prose, YAML/workflow arg), checked against `git ls-files` — not the
+   pytest collection, so a moved test's OLD path lingering in prose elsewhere
+   fails here even though nothing executes that prose. Costs ~2.6s against
+   mypy ratchet's ~76s (#4068 measurement, 2026-08-10) — cheap enough that cost
+   is never the reason to skip it:
+   ```bash
+   python scripts/check_tests_path_literal_reference.py
+   ```
+   ⚠️ **This gate scans the whole repo, so its baseline goes stale the moment
+   `main` moves underneath your branch** — a PR that both moves tests AND
+   updates the baseline can pass locally, then fail in CI once a sibling PR's
+   own move landed on `main` first. #4068 hit this 4 times in one night before
+   the cause was identified (#3880). On any PR that moves or renames a
+   `tests/...py` file, rebase onto latest `main` and run this gate again
+   immediately before pushing — not once, earlier in the session.
 
 A green scoped `pytest` run alone has shipped PRs that CI then bounced on ruff
 (`I001`) or the tier audit (a `len(...) == 1` format pin). Report scope
-honestly: say which of the five you actually ran locally (e.g. "ruff +
-tier-audit + mypy ratchet + the tests I touched") rather than "suite passed" —
-that phrase implies the full local run this section no longer asks for, and CI
-is the only place all five now run together.
+honestly: say which of the six you actually ran locally (e.g. "ruff +
+tier-audit + mypy ratchet + path-literal ratchet + the tests I touched")
+rather than "suite passed" — that phrase implies the full local run this
+section no longer asks for, and CI is the only place all six now run
+together.
 
 ---
 


### PR DESCRIPTION
**[docs-maintainer]** — Dispatched by lead-coder after I flagged the gap while checking #4068 for doc drift: `check_tests_path_literal_reference.py` (#4065) was CI-only, missing from both `testing.md`'s "Before you push" checklist and CLAUDE.md's mirrored PR-workflow paragraph.

## Decision (lead-coder, measured not assumed)

"Same shape as gate #5 (mypy_ratchet)" alone wasn't the reason — lead-coder measured cost: new gate ~2.6s vs. mypy_ratchet's ~76s, 30x cheaper than an already-accepted gate, so cost was never a valid objection. Benefit is tonight itself: this exact break class (a move leaving a stale reference on the non-moving side) surfaced only after CI in #4025/#4036/#4062/#4071, forcing rebases each time.

## What changed

- `testing.md` "Before you push": added gate #6 with its own invocation, cost figure, and a stale-baseline caveat lead-coder asked to be recorded explicitly — the gate scans the whole repo, so its baseline goes stale the moment `main` moves underneath a branch. #4068 itself rebased 4 times over exactly this before the cause was identified (#3880); the caveat tells the next person to re-run it right before push on any PR touching `tests/...py` moves, not earlier in the session.
- CLAUDE.md's mirrored paragraph: added the same gate + invocation + staleness caveat, condensed.
- Both "five"/"六" count references updated to six.

## Test plan

- [x] `python scripts/check_doc_anchors.py` — exit 0
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0 (remaining INFO lines are pre-existing ja-mirror gaps)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK, 470/470 baselined (sanity check that my own doc edits didn't introduce a new stale path-literal reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
