### PR TITLE
feat(#3978): P0 — current_task / inbox-item attribute types (types and state only)

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -106,6 +106,7 @@ from reyn.runtime.session_pure import (
     render_summary_for_storage,
 )
 from reyn.runtime.spawn_tracker import SpawnTracker
+from reyn.runtime.task_types import CurrentTask
 from reyn.runtime.turn_origin import TurnOrigin
 from reyn.security.permissions.permissions import PermissionResolver
 from reyn.services.compaction.engine import CompactionEngine
@@ -1063,6 +1064,13 @@ class Session:
         self._last_sender: str | None = None
         # Reply-to attribution captured from an inbound payload's reply_to (FP-0041 #489 PR-D2)
         self._last_reply_to: Any = None
+        # Proposal 0067 P0 (#3978): typed home for the present-tense task
+        # state, additive and unread by anything yet — _last_sender /
+        # _last_reply_to above remain the live attribution path until P1
+        # extracts InboxArbiter and migrates onto this field. See
+        # reyn.runtime.task_types.CurrentTask's own docstring for why each
+        # field exists and where it comes from.
+        self.current_task: "CurrentTask | None" = None
         # Outbox interceptor for external transport (e.g. Slack via MCP); None skips interception (FP-0041 #489 PR-D2)
         self._outbox_interceptor: Any = None
         self._mcp_servers = mcp_servers

--- a/src/reyn/runtime/task_types.py
+++ b/src/reyn/runtime/task_types.py
@@ -1,0 +1,79 @@
+"""current_task / inbox-item attributes — proposal 0067 P0 (types and state only).
+
+**No behaviour change.** This module exists to give the concepts proposal
+0067's "Types and substrate" section names — ``requester``, ``reply_to``,
+``kind``, ``collect``, ``on_settle``, ``schema``, ``ttl_seconds``, ``wake`` —
+a real, importable, typed home before anything reads or writes them. Nothing
+in this PR wires :data:`Session.current_task` into dispatch, attribution, or
+delivery; every existing code path (``_last_sender`` / ``_last_reply_to`` /
+the untyped ``(kind, payload)`` inbox tuple) is untouched. P1 extracts the
+``InboxArbiter`` and is the first consumer.
+
+``Requester`` is #2130's ``(agent, sid)`` addressing primitive, typed —
+``session.py``'s own attribution code today carries the same pair as a free-
+form ``sender`` string label (e.g. ``"user:tui"``, ``"a2a:<peer_agent>"``);
+this type does not replace that label (changing what's rendered to the LLM
+would be a behaviour change), it gives P1 a real type to migrate onto.
+
+Field-by-field source, all from proposal 0067 (docs/deep-dives/proposals/
+0067-task-model-and-arbiter.md):
+
+- ``requester`` — "typed wrapper over (agent_name, session_id) — #2130's
+  primitive" (§ Types and substrate).
+- ``reply_to`` — "``TransportRef | None`` — volatile; None after crash"
+  (same section); :class:`reyn.runtime.transport.TransportRef` already
+  exists and is reused here, not redefined.
+- ``kind`` / ``collect`` / ``on_settle`` / ``schema`` / ``ttl_seconds`` —
+  the ``run_prompt`` issuing signature (§ Issuing): ``kind`` is the task
+  class (`prompt` / `pipeline` / `exec` per §12's retraction "3 kind +
+  resource generation"; NOT the same axis as ``ToolDefinition.dispatch_kind``
+  or the inbox tuple's ``TurnOrigin``, both pre-existing, unrelated
+  classifications this PR does not touch), ``collect`` is `"attached" |
+  "async"`, ``on_settle`` is `"deliver" | "<pipeline name>" | "drop"`
+  (deliberately ``str``, not a closed enum — a pipeline name is
+  registry-defined, not a fixed set).
+- ``wake`` — "a task's settle always wakes its issuer (ADR-0040 D5)";
+  defaults to ``True`` for that reason, distinct from ``send_to_session``'s
+  selectable ``wake`` (§ Delivery, message vs task — messages, not tasks,
+  are where "don't wake" applies).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from reyn.runtime.transport import TransportRef
+
+TaskKind = Literal["prompt", "pipeline", "exec"]
+CollectMode = Literal["attached", "async"]
+
+
+@dataclass(frozen=True)
+class Requester:
+    """#2130's ``(agent, session_id)`` addressing primitive, typed.
+
+    ``sid`` is namespaced per agent (``registry.py:591``), so the pair is
+    the address — not either half alone (proposal 0067 § Issuing, citing
+    ``session.py:3038``'s "#2130 first-class (agent, sid) routing" comment).
+    """
+    agent_name: str
+    session_id: str
+
+
+@dataclass
+class CurrentTask:
+    """The present-tense task state a session's inbox arbiter (P1) will
+    read and write. Every field is optional/defaulted because nothing
+    constructs a non-default instance yet in this PR — the type exists so
+    P1 has one to populate, not because P0 populates it.
+
+    Mutable (not frozen): a task's state changes over its own lifetime
+    (settling, e.g.) once P1 wires this in; P0 does not mutate it."""
+    requester: "Requester | None" = None
+    reply_to: "TransportRef | None" = None
+    kind: "TaskKind | None" = None
+    collect: "CollectMode | None" = None
+    on_settle: "str | None" = None
+    schema: "str | None" = None
+    ttl_seconds: "int | None" = None
+    wake: bool = True

--- a/tests/runtime/test_task_types_3978_p0.py
+++ b/tests/runtime/test_task_types_3978_p0.py
@@ -1,0 +1,146 @@
+"""Tier 2: proposal 0067 P0 — current_task / inbox-item attribute types (#3978).
+
+Types and state only, no behaviour change (per the proposal's own P0
+scope) — these tests verify the type contract exists and is constructible,
+and that Session gains the new field WITHOUT anything reading or writing
+it. The "no behaviour change" half of the claim is verified by the
+existing session-attribution tests (test_session_dispatch_attribution.py
+etc.) staying green untouched — this file does not re-test attribution.
+
+Real Session instances throughout (no mocks) — the object under test for
+the Session-integration checks is Session itself, so faking it would test
+nothing real.
+"""
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.session import Session
+from reyn.runtime.task_types import CurrentTask, Requester
+from reyn.runtime.transport import TuiRef
+from tests._support.agent_session import make_session
+
+
+def _make_session(tmp_path: Path, *, agent_name: str = "test_agent") -> Session:
+    return make_session(
+        agent_name=agent_name,
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Requester — #2130's (agent, session_id) primitive, typed
+# ---------------------------------------------------------------------------
+
+
+def test_requester_holds_the_agent_session_pair() -> None:
+    """Tier 2: Requester carries exactly the (agent_name, session_id) pair
+    #2130 names as the addressing primitive."""
+    r = Requester(agent_name="researcher", session_id="s-42")
+    assert r.agent_name == "researcher"
+    assert r.session_id == "s-42"
+
+
+def test_requester_is_frozen() -> None:
+    """Tier 2: Requester is immutable — an address, not mutable state (the
+    same reasoning TransportRef's own variants are frozen for)."""
+    r = Requester(agent_name="researcher", session_id="s-42")
+    with pytest.raises(FrozenInstanceError):
+        r.agent_name = "other"  # type: ignore[misc]
+
+
+def test_requester_equality_is_by_value() -> None:
+    """Tier 2: two Requesters naming the same pair compare equal — a
+    dataclass default, but load-bearing here since P1 will use this as a
+    dict/set key candidate for arbiter bookkeeping."""
+    assert Requester(agent_name="a", session_id="s") == Requester(agent_name="a", session_id="s")
+    assert Requester(agent_name="a", session_id="s") != Requester(agent_name="a", session_id="s2")
+
+
+# ---------------------------------------------------------------------------
+# CurrentTask — every field proposal 0067 § Types and substrate names
+# ---------------------------------------------------------------------------
+
+
+def test_current_task_defaults_are_all_none_except_wake() -> None:
+    """Tier 2: a default-constructed CurrentTask carries no task — every
+    field is None except `wake`, which defaults True per ADR-0040 D5
+    ("a task's settle always wakes its issuer")."""
+    t = CurrentTask()
+    assert t.requester is None
+    assert t.reply_to is None
+    assert t.kind is None
+    assert t.collect is None
+    assert t.on_settle is None
+    assert t.schema is None
+    assert t.ttl_seconds is None
+    assert t.wake is True
+
+
+def test_current_task_holds_every_proposal_0067_field() -> None:
+    """Tier 2: the load-bearing construction — every field the proposal's
+    'Types and substrate' section names is settable and read back
+    unchanged, including a real TransportRef (not a stand-in) for reply_to."""
+    requester = Requester(agent_name="researcher", session_id="s-1")
+    reply_to = TuiRef()
+    t = CurrentTask(
+        requester=requester,
+        reply_to=reply_to,
+        kind="prompt",
+        collect="async",
+        on_settle="deliver",
+        schema="my_schema",
+        ttl_seconds=300,
+        wake=False,
+    )
+    assert t.requester == requester
+    assert t.reply_to is reply_to
+    assert t.kind == "prompt"
+    assert t.collect == "async"
+    assert t.on_settle == "deliver"
+    assert t.schema == "my_schema"
+    assert t.ttl_seconds == 300
+    assert t.wake is False
+
+
+def test_current_task_is_mutable() -> None:
+    """Tier 2: unlike Requester, CurrentTask is NOT frozen — a task's own
+    state changes over its lifetime once P1 wires this in (settling from
+    running to delivered, etc.); P0 doesn't mutate it, but the type must
+    allow it."""
+    t = CurrentTask()
+    t.kind = "pipeline"
+    assert t.kind == "pipeline"
+
+
+# ---------------------------------------------------------------------------
+# Session integration — additive field, no behaviour change
+# ---------------------------------------------------------------------------
+
+
+def test_session_gains_current_task_defaulting_to_none(tmp_path: Path) -> None:
+    """Tier 2: a freshly constructed Session carries `current_task = None`
+    — the new field exists and is inert; nothing in construction populates
+    it (that's P1's job)."""
+    session = _make_session(tmp_path)
+    assert session.current_task is None
+
+
+def test_session_current_task_is_independently_settable(tmp_path: Path) -> None:
+    """Tier 2: current_task is a real, externally-assignable attribute (not
+    a read-only property standing in for something else) — proving the
+    field is genuinely additive state, not a computed alias over
+    _last_sender/_last_reply_to (which stay untouched, see module
+    docstring)."""
+    session = _make_session(tmp_path)
+    task = CurrentTask(kind="exec")
+    session.current_task = task
+    assert session.current_task is task
+    # _last_sender/_last_reply_to are the STILL-LIVE attribution path this
+    # PR does not touch — setting current_task must not perturb them.
+    assert session.last_sender() is None


### PR DESCRIPTION
**[e2e-coder]** — part of #3978. Proposal 0067 § Types and substrate, P0.

## What this adds

A typed home for the concepts proposal 0067's P0 names, before anything reads or writes them:

- **`Requester`** (new) — #2130's `(agent_name, session_id)` addressing primitive, typed and frozen. `session.py`'s own attribution code today carries the same pair as a free-form `sender` string label (`"user:tui"`, `"a2a:<peer_agent>"`) — this does **not** replace that label (changing what's rendered to the LLM would be a behaviour change), it gives P1 a real type to migrate onto.
- **`CurrentTask`** (new) — the present-tense task-state container P1's `InboxArbiter` will read/write: `requester`, `reply_to` (reuses the existing `TransportRef` union, not a redefinition), `kind` (`prompt`/`pipeline`/`exec`), `collect` (`attached`/`async`), `on_settle`, `schema`, `ttl_seconds`, `wake` (defaults `True` per ADR-0040 D5). Mutable, not frozen — a task's state changes over its own lifetime once P1 wires this in.
- **`Session.current_task: CurrentTask | None = None`** — a new, additive field alongside the existing `_last_sender` / `_last_reply_to`, which stay the live attribution path, completely untouched. Nothing in this PR constructs a non-default `CurrentTask` or reads `session.current_task` anywhere.

## No behaviour change — verified, not assumed

- `test_session_dispatch_attribution.py`, `test_transport_ref.py`, `test_session_invariants.py`, and the broader `tests/runtime/` suite (1597 tests) pass unchanged.
- 9 pre-existing failures (textual theme registration in a headless env; a subprocess-import PYTHONPATH environment artifact) reproduce **identically on a clean `main` checkout with none of this PR's changes applied** — confirmed by stashing and re-running both ways.

## Witness for "this stage is done"

Per lead-coder's explicit instruction not to force-fit their own provisional completion criterion (still under architect co-vet): every field proposal 0067's "Types and substrate" section names exists, is importable from one module, is covered by a construction/defaults/mutability contract test, and zero existing behavior-test outcome changed. Falsify-verified: removing `Session.current_task` makes the new field-presence test RED for the exact reason, restored, confirmed GREEN.

## Verification

- `ruff check src tests` — clean
- `test_tier_audit.py --strict` — 8/8
- `verify_module_docstrings.py` — clean
- `mypy_ratchet.py` — 210/213, unchanged
- `check_tests_path_literal_reference.py` (pre-push gate #6) — clean
- `pytest tests/runtime/test_task_types_3978_p0.py` — 8 passed
- `pytest tests/runtime/` (minus 2 confirmed-preexisting-broken tests) — 1597 passed

## Test plan

- [x] Every proposal-0067-named field present, typed, tested
- [x] Zero behavior change, verified against a clean-main baseline for every failure encountered
- [x] Falsify-verified the load-bearing Session-field test
- [x] 5-gate local battery green