### PR TITLE
feat(#3978): P1' — keep the task open while its issuer delegates

### DIFF
--- a/src/reyn/runtime/message_bus.py
+++ b/src/reyn/runtime/message_bus.py
@@ -189,8 +189,20 @@ class MessageBus:
 
         Cross-chain note: we do not filter by chain_id here — this is
         intentionally conservative.  See module docstring (ADR-E).
+
+        Proposal 0067 P1' (#3978): ``current_task`` closes exactly the gap
+        this docstring's own promise ("AND no running actions AND no
+        running plans") never checked — a top-level ``dispatch_kind="async"``
+        delegation (e.g. ``delegate_to_agent``) used to end the turn with the
+        inbox empty, so this returned True while the peer's real answer was
+        still outstanding; the caller (this class's own ``request``) would
+        then hand back the "delegated" ack as if it were final. See
+        ``inter_agent_messaging.py``'s ``handle_agent_response`` for where
+        the marker is cleared once the real answer settles.
         """
         if not agent.inbox.empty():
+            return False
+        if agent.current_task is not None:
             return False
         return True
 

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -622,6 +622,12 @@ class RouterLoopHost(RouterLoopCore, Protocol):
     async def send_to_agent(self, *, to: str, request: str, depth: int,
                             chain_id: str) -> None: ...
 
+    # Proposal 0067 P1' (#3978): mark the session's current_task as
+    # outstanding — called from the async-dispatch block below, right before
+    # the turn exits to let the delegate work. Sync (a plain attribute set,
+    # not an awaited call) — see RouterHostAdapter's implementation.
+    def mark_task_pending(self) -> None: ...
+
     # #2103 S1bc: spawn a fresh-context session under THIS agent for a task.
     # Multi-session hosts (the chat RouterHostAdapter) implement it; others leave
     # it unbound (= hasattr-guarded at caller-state build).
@@ -2253,6 +2259,15 @@ class RouterLoop:
                     if get_dispatch_kind(tc["function"]["name"]) == "async"
                 )
                 if async_count:
+                    # Proposal 0067 P1' (#3978): mark the session's own task
+                    # as still outstanding BEFORE exiting the turn — this is
+                    # exactly the turn-boundary MessageBus.request's
+                    # quiescence check needs to see, so a delegating
+                    # top-level requester keeps waiting for the peer's real
+                    # answer instead of returning this ack as if it were
+                    # final (the bug P1' exists to close; see
+                    # message_bus.py's _is_quiescent).
+                    self.host.mark_task_pending()
                     # B55 R-7 (2026-05-25): non-plan async dispatch (=
                     # delegate_to_agent or other peer-async tools). Mirror
                     # task / plan spawn_ack format: `[task_spawned]

--- a/src/reyn/runtime/services/inter_agent_messaging.py
+++ b/src/reyn/runtime/services/inter_agent_messaging.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     from reyn.core.events.events import EventLog
     from reyn.runtime.limits.limit_handler import LimitDecision
     from reyn.runtime.services.chain_manager import ChainManager, _PendingChain
+    from reyn.runtime.task_types import CurrentTask
 
 logger = logging.getLogger(__name__)
 
@@ -189,6 +190,12 @@ class InterAgentMessaging:
         set_router_loop_delegations: "Callable[[list[dict] | None], None]",
         get_router_loop_agent_replies: "Callable[[], list[str] | None]",
         set_router_loop_agent_replies: "Callable[[list[str] | None], None]",
+        # Proposal 0067 P1' (#3978): current_task get/set, same mutable-ref-
+        # owned-by-Session pattern as the two pairs above. handle_agent_response
+        # is the settle point for a top-level (non-relay) delegation — see its
+        # own docstring for the capture-before/finally-compare clearing logic.
+        get_current_task: "Callable[[], CurrentTask | None]",
+        set_current_task: "Callable[[CurrentTask | None], None]",
         # FP-0050/#1822 S4b (EP5, Class A): content-threat scan + fence config.
         # Inbound peer text (request/response) is fenced before entering history.
         threat_scan: "object | None" = None,
@@ -221,6 +228,8 @@ class InterAgentMessaging:
         self._set_router_loop_delegations = set_router_loop_delegations
         self._get_router_loop_agent_replies = get_router_loop_agent_replies
         self._set_router_loop_agent_replies = set_router_loop_agent_replies
+        self._get_current_task = get_current_task
+        self._set_current_task = set_current_task
 
     # ── Public API (mirrors former session._<name> methods) ─────────────────
 
@@ -573,51 +582,68 @@ class InterAgentMessaging:
             return
 
         # User-initiated chain: PR11 path, reply goes to user.
-
-        # B2-H2 fix: if the peer's reply is a no-reply marker, bypass the LLM
-        # entirely and surface the failure deterministically. Without this,
-        # gemini-2.5-flash-lite interprets the marker as a polite conversational
-        # reply (e.g. "かしこまりました") and the user never learns that the peer
-        # failed.
-        if _is_no_reply_marker(response):
-            parsed = _parse_no_reply_marker(response)
-            peer = parsed[0] if parsed else from_agent or "<unknown>"
-            reason = parsed[1] if parsed else "no reply produced"
-            msg_template = _PEER_REPLY_FAILED_MSG.get(
-                self._output_language or "en", _PEER_REPLY_FAILED_MSG["en"],
-            )
-            user_text = msg_template.format(peer=peer, reason=reason)
-            await self._put_outbox(OutboxMessage(
-                kind="agent",
-                text=user_text,
-                meta={"chain_id": chain_id, "peer_failure": True},
-            ))
-            self._events.emit(
-                "peer_reply_failed_surfaced",
-                chain_id=chain_id,
-                peer=peer,
-                reason=reason,
-            )
-            return
-
+        #
+        # Proposal 0067 P1' (#3978): this branch is the SETTLE point for the
+        # session's own current_task, set (see router_loop.py's async-dispatch
+        # block, RouterHostAdapter.send_to_agent) when dispatch_kind="async"
+        # first exited the turn to delegate. Capture-before / finally-compare:
+        # clear current_task only if THIS call didn't itself set a NEW one (a
+        # further delegation triggered while processing this very response) —
+        # an unconditional clear would wipe out that fresh re-set and break
+        # multi-round delegation chains. finally (not except-only) so a
+        # genuine exception clears it too — lead-coder review, #3978: an
+        # error here must not leave the task marked outstanding forever
+        # (worse than the bug P1' exists to close — a session that delegated
+        # and can never again report quiescent).
+        task_before = self._get_current_task()
         try:
-            # B55 R-7: pass the structured `[task_completed] kind=agent`
-            # injection (= history's last entry, also user-role) so the
-            # router sees the same lifecycle marker the SP rule covers
-            # — parity with agent / plan completion paths.
-            await self._run_router_loop(injected_text, chain_id)
-        except RouterCapExceeded as exc:
-            await self._emit_router_cap_exhausted_user(exc, chain_id=chain_id)
-            return
-        except Exception as exc:
-            _detail = f"{type(exc).__name__}: {exc}"
-            if len(_detail) > 72:
-                _detail = _detail[:69] + "…"
-            await self._put_outbox(OutboxMessage(
-                kind="error", text=f"router failed (agent_response): {_detail}",
-                meta={"chain_id": chain_id},
-            ))
-            return
+            # B2-H2 fix: if the peer's reply is a no-reply marker, bypass the LLM
+            # entirely and surface the failure deterministically. Without this,
+            # gemini-2.5-flash-lite interprets the marker as a polite conversational
+            # reply (e.g. "かしこまりました") and the user never learns that the peer
+            # failed.
+            if _is_no_reply_marker(response):
+                parsed = _parse_no_reply_marker(response)
+                peer = parsed[0] if parsed else from_agent or "<unknown>"
+                reason = parsed[1] if parsed else "no reply produced"
+                msg_template = _PEER_REPLY_FAILED_MSG.get(
+                    self._output_language or "en", _PEER_REPLY_FAILED_MSG["en"],
+                )
+                user_text = msg_template.format(peer=peer, reason=reason)
+                await self._put_outbox(OutboxMessage(
+                    kind="agent",
+                    text=user_text,
+                    meta={"chain_id": chain_id, "peer_failure": True},
+                ))
+                self._events.emit(
+                    "peer_reply_failed_surfaced",
+                    chain_id=chain_id,
+                    peer=peer,
+                    reason=reason,
+                )
+                return
+
+            try:
+                # B55 R-7: pass the structured `[task_completed] kind=agent`
+                # injection (= history's last entry, also user-role) so the
+                # router sees the same lifecycle marker the SP rule covers
+                # — parity with agent / plan completion paths.
+                await self._run_router_loop(injected_text, chain_id)
+            except RouterCapExceeded as exc:
+                await self._emit_router_cap_exhausted_user(exc, chain_id=chain_id)
+                return
+            except Exception as exc:
+                _detail = f"{type(exc).__name__}: {exc}"
+                if len(_detail) > 72:
+                    _detail = _detail[:69] + "…"
+                await self._put_outbox(OutboxMessage(
+                    kind="error", text=f"router failed (agent_response): {_detail}",
+                    meta={"chain_id": chain_id},
+                ))
+                return
+        finally:
+            if self._get_current_task() is task_before:
+                self._set_current_task(None)
 
     async def _resolve_pending_chain(
         self,

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -307,6 +307,13 @@ class RouterHostAdapter:
         # exactly like a phase host (no-op seam).
         peek_mid_turn_injection: "Callable[[], Awaitable[dict | None]] | None" = None,
         commit_mid_turn_injection: "Callable[[str], Awaitable[None]] | None" = None,
+        # Proposal 0067 P1' (#3978): mark_task_pending — bare, no shared-
+        # consumer partner (same reasoning as the peek/commit pair above).
+        # None-default so pre-existing hand-built adapters stay valid;
+        # RouterLoopHost.mark_task_pending is unconditional (not
+        # getattr-guarded) but a None here becomes a no-op lambda below,
+        # not a missing attribute.
+        mark_task_pending: "Callable[[], None] | None" = None,
         # #1953 dynamic-wire + #2103 S1bc-exec: the chat session identity
         # (``emit_hook_event`` builds the LLM's own ``llm:<session_id>:*``
         # namespace from it — never an op field the LLM could forge) and the
@@ -544,6 +551,8 @@ class RouterHostAdapter:
         # #3792
         self._peek_mid_turn_injection_cb = peek_mid_turn_injection
         self._commit_mid_turn_injection_cb = commit_mid_turn_injection
+        # Proposal 0067 P1' (#3978)
+        self._mark_task_pending_cb = mark_task_pending
         # FP-0034 PR-3b-iii
         self._universal_wrappers_enabled = universal_wrappers_enabled
         # B25-S5-1
@@ -1167,6 +1176,16 @@ class RouterHostAdapter:
         tracker = self._send_to_agent_in.delegation_tracker()
         if tracker is not None:
             tracker.append({"to": to, "request": request})
+
+    def mark_task_pending(self) -> None:
+        """Proposal 0067 P1' (#3978): forward to ``Session.current_task``
+        when wired. None-safe (same reasoning as
+        :meth:`peek_mid_turn_injection`) — an adapter built without the
+        callback (pre-#3978 test construction) is a no-op, matching what a
+        host that never implemented the concept would do."""
+        if self._mark_task_pending_cb is None:
+            return
+        self._mark_task_pending_cb()
 
     async def spawn_session(self, *, request: str, mode: str,
                             narrowing: "dict | None", chain_id: str) -> dict:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2498,6 +2498,19 @@ class Session:
         # the zero-residue guarantee robust independent of that assignment.
         self._hook_driven_turns = 0
         self._inflight_wal_tasks.clear()
+        # current_task (proposal 0067 P1', #3978): NOT part of AgentSnapshot
+        # (deliberately volatile, same framing ADR-0040 gives reply_to — "None
+        # after crash"), so a genuine process crash is naturally safe: a
+        # fresh Session() defaults current_task to None and restore_state
+        # never sets it. A REWIND is a different recovery path — the SAME
+        # live Session object survives, so without this explicit clear a
+        # mid-delegation current_task would outlive the rewind and
+        # MessageBus._is_quiescent would report non-quiescent forever for a
+        # delegation the rewound timeline no longer contains (lead-coder
+        # review, #3978: "委譲したまま二度と返らないセッション" — worse than
+        # the bug P1' exists to close). See the paired truncate/rewind-style
+        # falsify test.
+        self.current_task = None
 
     @property
     def pending_user_images(self) -> list[dict]:
@@ -4029,6 +4042,8 @@ class Session:
             # #3792: mid-turn CLIENT_INPUT injection.
             peek_mid_turn_injection=self._peek_mid_turn_injection,
             commit_mid_turn_injection=self._commit_mid_turn_injection,
+            # Proposal 0067 P1' (#3978)
+            mark_task_pending=lambda: setattr(self, "current_task", CurrentTask()),
             universal_wrappers_enabled=self._action_retrieval.universal_wrappers_enabled,
             action_embedding_index=self._action_embedding_index,
             embedding_provider=self._embedding_provider,
@@ -4393,6 +4408,10 @@ class Session:
             set_router_loop_delegations=lambda v: setattr(self, "_router_loop_delegations", v),
             get_router_loop_agent_replies=lambda: self._router_loop_agent_replies,
             set_router_loop_agent_replies=lambda v: setattr(self, "_router_loop_agent_replies", v),
+            # Proposal 0067 P1' (#3978): same mutable-ref-owned-by-Session
+            # pattern as the two pairs above.
+            get_current_task=lambda: self.current_task,
+            set_current_task=lambda v: setattr(self, "current_task", v),
             # #2103 S1bc-exec: read this session's LIVE sid (spawned sessions are stamped
             # post-construction, so a cached value would be stale) for the responder_sid
             # tag; + the trusted spawned-task lookup for rendering a returning result.

--- a/tests/_support/router_loop.py
+++ b/tests/_support/router_loop.py
@@ -69,6 +69,8 @@ class FakeRouterHost:
         self.history: list[dict] = []
         self.skill_calls: list[dict] = []
         self.agent_sends: list[dict] = []
+        # Proposal 0067 P1' (#3978)
+        self.mark_task_pending_calls: int = 0
         self.spawn_calls: list[dict] = []
         self.file_writes: list[tuple[str, str]] = []
         self.file_deletes: list[str] = []
@@ -154,6 +156,12 @@ class FakeRouterHost:
                             chain_id: str) -> None:
         self.agent_sends.append({"to": to, "request": request, "depth": depth,
                                   "chain_id": chain_id})
+
+    def mark_task_pending(self) -> None:
+        """Proposal 0067 P1' (#3978): records the call so a test can assert
+        the async-dispatch block fired it, mirroring RouterHostAdapter's
+        own forwarding method."""
+        self.mark_task_pending_calls += 1
 
     async def spawn_session(self, *, request: str, mode: str,
                             narrowing: "dict | None", chain_id: str) -> dict:

--- a/tests/runtime/test_a2a_handler_invariants.py
+++ b/tests/runtime/test_a2a_handler_invariants.py
@@ -98,6 +98,8 @@ def _build_handler(
     _state: dict[str, Any] = {
         "delegations": None,
         "agent_replies": None,
+        # Proposal 0067 P1' (#3978): mirrors session.current_task.
+        "current_task": None,
     }
 
     async def _put_outbox(msg: OutboxMessage) -> None:
@@ -172,6 +174,8 @@ def _build_handler(
         set_router_loop_delegations=lambda v: _state.update({"delegations": v}),
         get_router_loop_agent_replies=lambda: _state["agent_replies"],
         set_router_loop_agent_replies=lambda v: _state.update({"agent_replies": v}),
+        get_current_task=lambda: _state["current_task"],
+        set_current_task=lambda v: _state.update({"current_task": v}),
     )
 
     trackers: dict[str, Any] = {

--- a/tests/runtime/test_a2a_router_cap_wrapup_1538.py
+++ b/tests/runtime/test_a2a_router_cap_wrapup_1538.py
@@ -142,6 +142,9 @@ def _make_inter_agent_messaging(emit_fn: _RecordingEmit) -> InterAgentMessaging:
         set_router_loop_delegations=lambda _v: None,
         get_router_loop_agent_replies=lambda: None,
         set_router_loop_agent_replies=lambda _v: None,
+        # Proposal 0067 P1' (#3978)
+        get_current_task=lambda: None,
+        set_current_task=lambda _v: None,
     )
 
 

--- a/tests/runtime/test_task_types_3978_p1_prime.py
+++ b/tests/runtime/test_task_types_3978_p1_prime.py
@@ -1,0 +1,321 @@
+"""Tier 2: proposal 0067 P1' — keep the task open while its issuer delegates (#3978).
+
+Two witnesses architect specified for this stage:
+  ① dispatch_kind="async" no longer closes the task — MessageBus.request
+     must NOT return early with just the "delegated" ack while a delegation
+     is outstanding, even with an empty inbox (the exact gap #3978's
+     Verification notes table names: "its docstring promises three
+     conditions; the implementation checks inbox.empty() only"). Exercised
+     via bus.request()'s own public timeout behavior, not the private
+     _is_quiescent staticmethod (testing.md Tier 4: no private-state
+     assertion — test_tier_audit.py itself catches a direct call).
+  ② the requester's real answer settles current_task, not a "delegated" ack
+     — handle_agent_response's set/clear logic must survive multi-round
+     delegation AND exceptions (lead-coder review: "誰が消すか" must be
+     guaranteed by finally, not the happy path).
+
+Plus lead-coder's two required failure-path decisions:
+  - exception path clears current_task (finally, not except-only)
+  - crash/rewind: current_task does not survive either recovery path.
+
+Real Session + real InterAgentMessaging instances throughout (the
+InterAgentMessaging harness below is the same "real instance + plain stub
+callbacks" pattern test_a2a_handler_invariants.py already established — no
+mocks, no MagicMock/AsyncMock).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.agent_snapshot import AgentSnapshot
+from reyn.core.events.event_store import EventStore
+from reyn.core.events.events import EventLog
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.message_bus import MessageBus
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.services.chain_manager import ChainManager
+from reyn.runtime.services.inter_agent_messaging import InterAgentMessaging
+from reyn.runtime.services.snapshot_journal import SnapshotJournal
+from reyn.runtime.session import Session
+from reyn.runtime.task_types import CurrentTask
+from tests._support.agent_session import make_session
+
+# ---------------------------------------------------------------------------
+# ① MessageBus.request respects current_task — real Session, public surface
+# ---------------------------------------------------------------------------
+
+
+def _session(tmp_path: Path, *, agent_name: str = "test_agent") -> Session:
+    return make_session(
+        agent_name=agent_name,
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
+    )
+
+
+@pytest.mark.asyncio
+async def test_request_keeps_polling_while_current_task_is_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: THE load-bearing witness ① — bus.request() must NOT return
+    early with just the 'delegated' ack while current_task is set (mirrors
+    router_loop.py's async-dispatch block, which sets this right before
+    ending the turn to let a delegation run). Before this PR,
+    MessageBus._is_quiescent checked inbox.empty() only, so request()
+    would have returned instantly (elapsed ~= 0) with the ack as if it
+    were the final answer. Same monkeypatch-the-turn-handler pattern
+    test_transport_ref.py's own MessageBus tests use (real Session, real
+    MessageBus, no LLM required)."""
+    from reyn.runtime.transport import McpRef
+
+    session = _session(tmp_path)
+
+    async def _fake_handle_inbox_text(self: Session, text: str, *, chain_id: str) -> None:
+        await self._put_outbox(OutboxMessage(kind="agent", text="delegated, standby"))
+        self.current_task = CurrentTask()  # mirrors router_loop.py's async-dispatch SET
+
+    monkeypatch.setattr(Session, "_handle_inbox_text", _fake_handle_inbox_text)
+
+    bus = MessageBus()
+    start = asyncio.get_event_loop().time()
+    replies = await bus.request(
+        session, kind="user", payload={"text": "hello"},
+        reply_to=McpRef(request_id="test-p1prime"), timeout=0.1,
+    )
+    elapsed = asyncio.get_event_loop().time() - start
+
+    # The turn DID run and its ack WAS collected...
+    assert any(r.text == "delegated, standby" for r in replies)
+    # ...but request() did not return the instant the ack landed — it kept
+    # polling for the full timeout window because current_task was never
+    # cleared (nothing in this test clears it — the real clear point is
+    # handle_agent_response, covered by ② below).
+    assert elapsed >= 0.1
+
+
+# ---------------------------------------------------------------------------
+# ② handle_agent_response's set/clear semantics — real InterAgentMessaging
+# ---------------------------------------------------------------------------
+
+
+def _build_handler(
+    tmp_path: Path,
+    *,
+    agent_name: str = "specialist",
+    router_actions: "list | None" = None,
+) -> "tuple[InterAgentMessaging, dict[str, Any]]":
+    """Real InterAgentMessaging wired with plain stub callbacks — same
+    pattern test_a2a_handler_invariants.py's own `_build_handler` uses.
+    `state["current_task"]` mirrors Session.current_task via the same
+    get/set-callable injection Session itself uses in production."""
+    state_log = StateLog(tmp_path / "state.wal")
+    event_store = EventStore(tmp_path / "events")
+    event_log = EventLog(subscribers=[event_store])
+    journal = SnapshotJournal(
+        agent_name=agent_name, snapshot_path=tmp_path / "snap.json", state_log=state_log,
+    )
+    chain_manager = ChainManager(
+        journal=journal, events=event_log, chain_timeout_seconds=0.0, max_hop_depth=3,
+    )
+
+    state: dict[str, Any] = {"current_task": None, "outbox": [], "history": []}
+    _router_call_count = [0]
+    _actions = router_actions or []
+
+    async def _run_router_loop(text: str, chain_id: str) -> None:
+        idx = _router_call_count[0]
+        _router_call_count[0] += 1
+        if idx < len(_actions):
+            await _actions[idx](text, chain_id, state)
+
+    async def _put_outbox(msg: OutboxMessage) -> None:
+        state["outbox"].append(msg)
+
+    def _append_history(role: str, text: str, ts: str, meta: dict) -> None:
+        state["history"].append({"role": role, "text": text, "ts": ts, "meta": meta})
+
+    async def _handle_chat_limit_checkpoint(**kwargs):  # type: ignore[no-untyped-def]
+        from reyn.runtime.limits.limit_handler import LimitDecision
+        return LimitDecision(allow_continue=True, extension=0.0, reason="test-allow")
+
+    async def _send_request_callback(to, from_agent, request, depth, chain_id) -> None:
+        pass
+
+    async def _send_response_callback(
+        to, from_agent, response, depth, chain_id, responder_sid=None, to_sid=None,
+    ) -> None:
+        pass
+
+    async def _on_chain_timeout_fire(chain_id: str) -> None:
+        pass
+
+    handler = InterAgentMessaging(
+        event_log=event_log,
+        chain_manager=chain_manager,
+        agent_name=agent_name,
+        max_hop_depth=3,
+        safety_extensions={},
+        output_language="en",
+        append_history=_append_history,
+        put_outbox=_put_outbox,
+        handle_chat_limit_checkpoint=_handle_chat_limit_checkpoint,
+        run_router_loop=_run_router_loop,
+        reset_router_turn_counter=lambda: None,
+        send_request_callback=_send_request_callback,
+        send_response_callback=_send_response_callback,
+        on_chain_timeout_fire=_on_chain_timeout_fire,
+        emit_router_cap_exhausted_fn=lambda exc, *, chain_id, **_kw: asyncio.sleep(0),
+        get_router_loop_delegations=lambda: None,
+        set_router_loop_delegations=lambda v: None,
+        get_router_loop_agent_replies=lambda: None,
+        set_router_loop_agent_replies=lambda v: None,
+        get_current_task=lambda: state["current_task"],
+        set_current_task=lambda v: state.update({"current_task": v}),
+    )
+    return handler, state
+
+
+@pytest.mark.asyncio
+async def test_normal_completion_clears_current_task(tmp_path: Path) -> None:
+    """Tier 2: witness ② core case — the router loop produces a real final
+    answer (pushes to outbox, no further delegation) → current_task clears.
+    This is the state MessageBus._is_quiescent needs to see True again so
+    the requester's poll loop picks up the real answer, not the ack."""
+    async def _final_answer(text, chain_id, state):
+        state["outbox"].append(OutboxMessage(kind="agent", text="the real answer", meta={}))
+
+    handler, state = _build_handler(tmp_path, router_actions=[_final_answer])
+    state["current_task"] = CurrentTask()  # simulates router_loop.py's prior SET
+
+    await handler.handle_agent_response({
+        "from_agent": "peer", "response": "peer's reply", "depth": 1,
+        "chain_id": "chain-not-registered",
+    })
+
+    assert state["current_task"] is None
+    assert any(m.text == "the real answer" for m in state["outbox"])
+
+
+@pytest.mark.asyncio
+async def test_redelegation_during_settle_is_not_wiped(tmp_path: Path) -> None:
+    """Tier 2: THE multi-round-chain correctness witness — if processing
+    this response ITSELF triggers a new delegation (the router stub sets a
+    NEW current_task, mirroring router_loop.py's async-dispatch block firing
+    again), the finally clause must NOT wipe it out. An unconditional
+    `finally: current_task = None` would break exactly this case."""
+    fresh_task = CurrentTask()
+
+    async def _redelegates(text, chain_id, state):
+        state["current_task"] = fresh_task  # mirrors host.mark_task_pending()
+
+    handler, state = _build_handler(tmp_path, router_actions=[_redelegates])
+    state["current_task"] = CurrentTask()  # the task being settled
+
+    await handler.handle_agent_response({
+        "from_agent": "peer", "response": "peer's reply", "depth": 1,
+        "chain_id": "chain-not-registered",
+    })
+
+    assert state["current_task"] is fresh_task
+
+
+@pytest.mark.asyncio
+async def test_exception_during_settle_clears_current_task(tmp_path: Path) -> None:
+    """Tier 2: lead-coder's required failure-path decision ① — an exception
+    raised while processing the settling response must still clear
+    current_task (finally, not except-only). Without this, a router error
+    on the settle turn leaves current_task marked outstanding forever —
+    exactly the 'delegated and can never report quiescent again' failure
+    mode lead-coder named as worse than the bug P1' exists to close."""
+    async def _boom(text, chain_id, state):
+        raise ValueError("simulated router failure")
+
+    handler, state = _build_handler(tmp_path, router_actions=[_boom])
+    state["current_task"] = CurrentTask()
+
+    await handler.handle_agent_response({
+        "from_agent": "peer", "response": "peer's reply", "depth": 1,
+        "chain_id": "chain-not-registered",
+    })
+
+    assert state["current_task"] is None
+    assert any("router failed" in m.text for m in state["outbox"])
+
+
+@pytest.mark.asyncio
+async def test_no_reply_marker_path_also_clears_current_task(tmp_path: Path) -> None:
+    """Tier 2: the B2-H2 no-reply-marker early-return branch is INSIDE the
+    try/finally too — a peer failure surfaced this way must also settle
+    current_task, not just the try/except's own two branches."""
+    from reyn.runtime.services.inter_agent_messaging import _no_reply_marker
+
+    handler, state = _build_handler(tmp_path)
+    state["current_task"] = CurrentTask()
+
+    await handler.handle_agent_response({
+        "from_agent": "peer",
+        "response": _no_reply_marker("peer", "peer crashed"),
+        "depth": 1,
+        "chain_id": "chain-not-registered",
+    })
+
+    assert state["current_task"] is None
+
+
+# ---------------------------------------------------------------------------
+# Failure-path decision ② — current_task does not survive crash OR rewind
+# ---------------------------------------------------------------------------
+
+
+def test_crash_then_fresh_session_restore_has_no_current_task(tmp_path: Path) -> None:
+    """Tier 2: the PROCESS-CRASH path — current_task is deliberately NOT part
+    of AgentSnapshot (same 'volatile; None after crash' framing ADR-0040
+    gives reply_to), so a fresh process's fresh Session() defaults it to
+    None, and restore_state (which never touches current_task) leaves it
+    there. A crashed session mid-delegation never resumes 'stuck'."""
+    agent_name = "alpha"
+    log = StateLog(tmp_path / "wal")
+    old_session = make_session(
+        agent_name=agent_name, state_log=log, snapshot_path=tmp_path / "snap.json",
+    )
+    old_session.current_task = CurrentTask()  # mid-delegation when "crash" happens
+
+    # A crash never persists current_task (not in AgentSnapshot) — simulate
+    # the recovery snapshot as it would genuinely be reconstructed, carrying
+    # no current_task field at all.
+    snapshot = AgentSnapshot.empty(agent_name)
+
+    # The real recovery path constructs a BRAND NEW Session in the new
+    # process, then calls restore_state on it — not the old, crashed object.
+    new_session = make_session(
+        agent_name=agent_name, state_log=log, snapshot_path=tmp_path / "snap2.json",
+    )
+    new_session.restore_state(snapshot)
+
+    assert new_session.current_task is None
+
+
+@pytest.mark.asyncio
+async def test_rewind_clears_current_task_on_the_same_live_session(tmp_path: Path) -> None:
+    """Tier 2: THE falsify-verified failure-path decision ② — a REWIND (not
+    a crash) keeps the SAME Session object alive; without an explicit clear
+    in reset_for_rewind, a mid-delegation current_task would outlive the
+    rewind and MessageBus._is_quiescent would report non-quiescent forever
+    for a delegation the rewound timeline no longer contains. This is the
+    'delegated and never returns' failure lead-coder named as worse than
+    P1's own bug — falsify-verified by temporarily removing the clear line
+    from reset_for_rewind, confirming this test goes RED, then restoring."""
+    log = StateLog(tmp_path / "wal")
+    session = make_session(
+        agent_name="alpha", state_log=log, snapshot_path=tmp_path / "snap.json",
+    )
+    session.current_task = CurrentTask()  # mid-delegation before the rewind
+
+    await session.reset_for_rewind()
+    session.restore_state(AgentSnapshot.empty("alpha"))
+
+    assert session.current_task is None


### PR DESCRIPTION
**[e2e-coder]** — part of #3978. Proposal 0067 P1' (strictly before P1 per the proposal's own sequencing).

## Root cause, precisely traced

`MessageBus._is_quiescent` checked only `agent.inbox.empty()`, despite its own docstring promising "inbox empty AND no running actions AND no running plans" — exactly the gap #3978's Verification notes table names. A top-level `dispatch_kind="async"` delegation (`delegate_to_agent`) ends the turn with the inbox empty right after pushing a "delegated, standby" ack to outbox. `MessageBus.request` then saw `quiescent=True` and handed that ack back as if it were the final answer — while the peer's real reply, which **does** get processed correctly once it lands (`InterAgentMessaging.handle_agent_response`'s `chain_id`-not-registered branch already re-runs the router and produces a real synthesized answer), just sat unconsumed in the inbox with nothing left to pump it.

## Fix

- `router_loop.py`'s async-dispatch block calls the new `RouterLoopHost.mark_task_pending()` right before the turn exits, setting `session.current_task` (proposal 0067 P0's own field) — the same mutable-ref-owned-by-Session get/set-callable injection pattern `_router_loop_delegations` already established, threaded through `RouterHostAdapter` and `InterAgentMessaging` (2 new required constructor params).
- `message_bus.py`'s `_is_quiescent` additionally checks `agent.current_task is None`.
- `inter_agent_messaging.py`'s `handle_agent_response` (the top-level, non-relay settle point) wraps its whole body in capture-before/finally-compare: clears `current_task` **only if the call didn't itself set a NEW one** (a further delegation triggered while processing this very response — an unconditional clear would break multi-round chains). `finally`, not except-only.

## Lead-coder's two required failure-path decisions — both falsify-verified

1. **Exception path**: covered by the `finally` above — falsify-verified (a simulated router exception still clears `current_task`).
2. **Crash/rewind**: `current_task` is deliberately NOT part of `AgentSnapshot` (same "volatile; None after crash" framing ADR-0040 gives `reply_to`), so a genuine process crash is naturally safe. A **rewind** is a different path — the SAME live Session object survives — so `reset_for_rewind()` now explicitly clears `current_task` too. Falsify-verified: removing that line reproduces exactly the "delegated and never returns" failure lead-coder named as worse than the bug P1' exists to close.

## Consumer sweep

2 pre-existing `InterAgentMessaging` direct-construction test files updated with the 2 new required constructor params; the shared `FakeRouterHost` test fixture gained `mark_task_pending()` — this was an unguarded `AttributeError` on every `delegate_to_agent`-dispatching test until fixed, caught by running the **full** `tests/runtime/` suite, not just the new test file (the exact discipline CLAUDE.md's refactoring guidance names: "an in-flight sibling caller is invisible to the branch's own test file").

## Verification

- Full `tests/runtime/` (1591 passed) + `tests/core/` + `tests/llm/` — all green
- `ruff check`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py` (210/213), `check_tests_path_literal_reference.py` — all clean
- Falsify-verified 2 mechanisms: the `_is_quiescent` extension and the `reset_for_rewind` clear

## Test plan

- [x] Witness ① (task no longer closes early) — public-surface test via `MessageBus.request()`'s own timeout behavior, not the private `_is_quiescent` (test_tier_audit.py itself catches a direct call)
- [x] Witness ② (real answer settles, multi-round chains preserved, exceptions clear) — 4 tests against a real `InterAgentMessaging`
- [x] Both required failure-path decisions falsify-verified
- [x] Full consumer sweep, not just the new test file