### PR TITLE
feat(#3978): P3 — the task_settled builtin hook point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Hook-Event Redesign (proposal 0059), Phases 1-3**: typed `HookEvent` + a builtin Schema Registry declaring each of the 10 builtin hook points' payload field set (Phase 1, `c319285`); a unified Ingress Adapter consolidating hook-firing entry points (Phase 2, `f4db86c`); an `EventPattern` match grammar generalizing `matcher` field-name matching, schema-validated at config-load time for builtin points (Phase 3, `3ff41bc`).
+- **Hook-Event Redesign (proposal 0059), Phases 1-3**: typed `HookEvent` + a builtin Schema Registry declaring each of the 9 builtin hook points' payload field set (Phase 1, `c319285`); a unified Ingress Adapter consolidating hook-firing entry points (Phase 2, `f4db86c`); an `EventPattern` match grammar generalizing `matcher` field-name matching, schema-validated at config-load time for builtin points (Phase 3, `3ff41bc`).
 
 - **B22 RAG affordance-bias schema-layer fix — 0/3 → 3/3 first-attempt 100% recovery**
   (= 2026-05-10, commit `9fdecd1`). 5 parallel sonnet context-analysis agents

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -973,9 +973,9 @@
 #   pipeline_launch — launch a registered pipeline (async/detached), input
 #                    Jinja2-rendered from the event's template vars.
 #
-#   on:            the 10 builtin points — turn_start | turn_end | session_start |
-#                  session_end | task_start | task_end | mcp_resource_updated |
-#                  file_changed | cron_fired | webhook_received — plus the two
+#   on:            the 9 builtin points — turn_start | turn_end | session_start |
+#                  session_end | mcp_resource_updated | file_changed |
+#                  cron_fired | webhook_received | task_settled — plus the two
 #                  open namespaces ``composed:<name>`` (a Composer's output,
 #                  below) and, as a Composer INPUT only (never a hook's own
 #                  ``on:``), ``llm:<session_id>:<event_name>`` (LLM-emitted via

--- a/src/reyn/hooks/schema_registry.py
+++ b/src/reyn/hooks/schema_registry.py
@@ -62,10 +62,17 @@ _LIFECYCLE_POINTS: "tuple[str, ...]" = (
 _EXTERNAL_POINTS: "tuple[str, ...]" = (
     "mcp_resource_updated", "file_changed", "cron_fired", "webhook_received",
 )
+# proposal 0067 P3 — neither a session lifecycle transition nor an external
+# ingress signal; a THIRD category for "an async unit of work reached a
+# terminal disposition" (today: only the pipeline-async terminal-delivery
+# producer — see build_hook_payload's own P3 note below for why delegate_to_
+# agent's chain-resolve path is deliberately NOT a second producer yet).
+_TASK_POINTS: "tuple[str, ...]" = ("task_settled",)
 
 BARE_TO_KIND: "dict[str, str]" = {
     **{p: f"builtin:lifecycle:{p}" for p in _LIFECYCLE_POINTS},
     **{p: f"builtin:external:{p}" for p in _EXTERNAL_POINTS},
+    **{p: f"builtin:task:{p}" for p in _TASK_POINTS},
 }
 KIND_TO_BARE: "dict[str, str]" = {kind: bare for bare, kind in BARE_TO_KIND.items()}
 
@@ -109,6 +116,15 @@ BUILTIN_HOOK_SCHEMAS: "dict[str, frozenset[str]]" = {
     "builtin:external:file_changed": frozenset({"point", "path", "event_type"}),
     "builtin:external:cron_fired": frozenset({"point", "job_name", "to"}),
     "builtin:external:webhook_received": frozenset({"point", "transport", "sender"}),
+    # proposal 0067 P3: producer = the pipeline-async terminal-delivery path
+    # ONLY (owner ruling via lead-coder, 2026-08-10) — delegate_to_agent's
+    # chain-resolve path is a SEPARATE, still-unwired "settle"-shaped
+    # completion today; folding it in is P6's job (retiring delegate_to_agent
+    # repurposes pending_chains as this point's second producer). Recorded
+    # here, not silently dropped, per CLAUDE.md's arc-closure remainder rule.
+    "builtin:task:task_settled": frozenset(
+        {"point", "task_id", "kind", "status", "session", "result"},
+    ),
 }
 
 # The schema-driven OPEN SET of valid builtin ``on:`` values — the single
@@ -149,7 +165,16 @@ ALLOWED_HOOK_KINDS: "frozenset[str]" = frozenset(BUILTIN_HOOK_SCHEMAS)
 # closed by ``tests/hooks/test_context_safe_gate_3978.py``'s own
 # membership check (``CONTEXT_UNSAFE_FIELDS[kind] <= BUILTIN_HOOK_SCHEMAS[kind]``
 # for every kind), not by convention.
-CONTEXT_UNSAFE_FIELDS: "dict[str, frozenset[str]]" = {}
+CONTEXT_UNSAFE_FIELDS: "dict[str, frozenset[str]]" = {
+    # proposal 0067 P3, ADR-0040 D3: `result` is LLM-authored content (the
+    # task's own output) — the FIRST field this deny-list actually excludes.
+    # Not covered by the "current fields are safe" owner ruling (that
+    # covered the 8 pre-P3 builtin schemas only): P3's OWN design already
+    # specifies "result: context_safe false" (proposal §"The task
+    # mechanism"), so this entry is the payload's authors' declared intent,
+    # not a narrowing added after the fact.
+    "builtin:task:task_settled": frozenset({"result"}),
+}
 
 
 def safe_context_fields(kind_or_point: str, context: dict) -> dict:

--- a/src/reyn/runtime/services/pipeline_executor_driver.py
+++ b/src/reyn/runtime/services/pipeline_executor_driver.py
@@ -103,6 +103,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from reyn.hooks.schema_registry import build_hook_payload
 from reyn.runtime.session_pure import new_chain_id
 
 if TYPE_CHECKING:
@@ -428,6 +429,22 @@ class PipelineExecutorDriver:
         await target.submit_pipeline_result(
             run_id=wo.run_id, pipeline_name=wo.pipeline_name, status=status,
             text=text, chain_id=new_chain_id(),
+        )
+        # proposal 0067 P3: task_settled fires AFTER delivery succeeds
+        # (delivery-anchored, matching the point's own name — "settled"
+        # means the result already reached its destination, not merely
+        # that this driver decided to send it). kind="pipeline" is a
+        # placeholder value (P4 has not landed the prompt|pipeline|exec
+        # vocabulary yet) — the ONLY producer wired today, per lead-coder's
+        # ruling (delegate_to_agent's chain-resolve path is a separate,
+        # still-unwired "settle"-shaped completion; folding it in is P6's
+        # job, see BUILTIN_HOOK_SCHEMAS's own comment on this point).
+        await target.dispatch_external_event(
+            "task_settled",
+            build_hook_payload(
+                "task_settled", task_id=wo.run_id, kind="pipeline",
+                status=status, session=wo.reply_to_sid or "main", result=text,
+            ),
         )
         return True
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2419,9 +2419,8 @@ class Session:
         return out
 
     async def dispatch_external_event(self, point: str, template_vars: dict) -> None:
-        """#2608 H5: public entry point for an OUT-OF-SESSION external-event
-        source (cron / webhook ingress) to fire a hook on THIS session's
-        dispatcher.
+        """#2608 H5: public entry point for an OUT-OF-SESSION source to fire
+        a hook on THIS session's dispatcher.
 
         H1 (``mcp_resource_updated``) and H4 (``file_changed``) both fire
         their hook via a ``hook_trigger`` closure captured over
@@ -2436,6 +2435,13 @@ class Session:
         dispatch`` already gives every H1/H4 guarantee (per-hook isolation —
         never raises; H2 matcher evaluated before a hook's action runs;
         empty-registry is a byte-identical no-op).
+
+        proposal 0067 P3: ``reyn.runtime.services.pipeline_executor_driver.
+        PipelineExecutorDriver._deliver`` calls this on the REPLY session
+        (the issuer waiting on the task, not the driver-session that ran
+        it) to fire ``task_settled`` right after ``pipeline_result`` is
+        delivered — the same "resolve a Session it doesn't own, long after
+        its own ``__init__``" shape H5/H4 already needed a public seam for.
         """
         await self._hook_dispatcher.dispatch(point, template_vars)
 

--- a/tests/core/test_pipeline_is2_driver_session.py
+++ b/tests/core/test_pipeline_is2_driver_session.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -347,6 +348,157 @@ async def test_run_pipeline_async_launches_and_delivers_result(tmp_path: Path, m
     assert await _wait_for(
         lambda: reg.get_session("worker", invocation["driver_sid"]) is None
     )
+
+
+# ── #3978 P3: task_settled — delivery-anchored ordering + strip-falsify ─────
+
+
+def _capture_hook_dispatch(monkeypatch, captured: list) -> None:
+    """Record (point, dict(template_vars)) on every real ``HookDispatcher.dispatch``
+    call, then delegate to the real implementation — same record-then-delegate
+    idiom as ``test_hook_event_schema_registry_sync_0059.py``'s own capture
+    helper (every builtin producer funnels through this one class method)."""
+    from reyn.hooks import dispatcher as dispatcher_mod
+
+    original = dispatcher_mod.HookDispatcher.dispatch
+
+    async def _recording_dispatch(self, point, template_vars):
+        captured.append((point, dict(template_vars)))
+        return await original(self, point, template_vars)
+
+    monkeypatch.setattr(dispatcher_mod.HookDispatcher, "dispatch", _recording_dispatch)
+
+
+@pytest.mark.asyncio
+async def test_task_settled_fires_after_delivery_and_the_handle_is_then_gone(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2c: (#3978 P3, lead-coder's witness spec) anchor on DELIVERY — wait
+    for the result to appear in the issuer's own history (``scripted.calls``,
+    no sleep) — then confirm ``task_settled`` was the thing that carried it
+    (payload matches the real work-order), and immediately after (polled, no
+    sleep) confirm the run's handle is gone: no ``describe_task`` verb exists
+    yet (P4), so the driver-session's own A10 reclaim is the standing proxy
+    for "this task can no longer be found" — the same fact
+    ``test_run_pipeline_async_launches_and_delivers_result`` already
+    witnesses, reused here rather than re-tested, per the six-questions Q1
+    read (that reclaim mechanism is pre-existing code this PR did not touch)."""
+    _install_side_effect_tool(monkeypatch)
+    captured: list[tuple[str, dict]] = []
+    _capture_hook_dispatch(monkeypatch, captured)
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    scripted = _ScriptedAgentReply("acknowledged")
+    reg = _agent_registry(tmp_path, state_log, scripted)
+    out_file = tmp_path / "out.txt"
+
+    pipeline_registry = PipelineRegistry()
+    pipeline_registry.register("p", _three_step_pipeline(out_file))
+
+    caller = reg.get_or_load("worker")
+    ctx = ToolContext(
+        events=caller._router_host.events,
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=RouterCallerState(
+            pipeline_registry=pipeline_registry,
+            agent_registry=reg,
+            host=caller._router_host,
+        ),
+        state_log=state_log,
+    )
+
+    result = await _handle_run_pipeline_async({"name": "p", "input": {"seed": 10}}, ctx)
+    run_id = result["data"]["run_id"]
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", run_id)
+
+    # Delivery-anchored: the issuer's own history actually carries the result
+    # (a real scripted-LLM turn consumed the pipeline_result inbox message).
+    assert await _wait_for(lambda: scripted.calls >= 1)
+    # task_settled was dispatched — and, since _deliver awaits
+    # submit_pipeline_result BEFORE dispatching it (source order), its
+    # presence here is itself the ordering proof: it cannot have fired before
+    # the delivery ``scripted.calls`` just witnessed.
+    settled = [payload for point, payload in captured if point == "task_settled"]
+    (payload,) = settled  # exactly-once dispatch: unpack fails on 0 or >1
+    assert payload["task_id"] == run_id
+    assert payload["status"] == "ok"
+    assert payload["session"] == "main"
+
+    # Immediately after (polled, unbounded — no sleep budget): the handle is
+    # gone. describe_task doesn't exist yet (P4) — the driver-session's A10
+    # reclaim is the only "can this task still be found" surface today.
+    invocation = json.loads((run_dir / "invocation.json").read_text(encoding="utf-8"))
+    assert await _wait_for(
+        lambda: reg.get_session("worker", invocation["driver_sid"]) is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_task_settled_never_fires_when_reply_agent_no_longer_exists(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2c: strip-falsify direction 1 of 2 — ``_deliver``'s pre-existing
+    fail-safe (module docstring: "a vanished reply target is LOGGED and
+    dropped ... NEVER rerouted to main") returns False before ever reaching
+    the new P3 dispatch call. Proves the new call sits AFTER this early
+    return in ``_deliver``'s control flow, not before it."""
+    from reyn.runtime.services.pipeline_executor_driver import PipelineExecutorDriver
+
+    captured: list[tuple[str, dict]] = []
+    _capture_hook_dispatch(monkeypatch, captured)
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log, None)
+    wo = replace(
+        _crash_state_work_order(
+            "gone-agent-run", _three_step_pipeline(tmp_path / "o.txt"), input={"seed": 1},
+        ),
+        reply_to_agent="does-not-exist",
+    )
+    driver = PipelineExecutorDriver(wo, registry=reg, state_log=state_log)
+    # Bind a real, live driver-session (production always does this before the
+    # first nudge — module docstring) so a falsified dispatch call reachable
+    # via ``self._session`` would genuinely fire, not merely crash on a None
+    # attribute — the falsify-verification for this pair uses this binding.
+    worker = reg.get_or_load("worker")
+    driver.bind_session(worker, worker._router_host)
+
+    delivered = await driver._deliver(status="ok", output={"x": 1}, error=None)
+
+    assert delivered is False
+    assert not any(point == "task_settled" for point, _ in captured)
+
+
+@pytest.mark.asyncio
+async def test_task_settled_never_fires_when_reply_session_is_not_loaded(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2c: strip-falsify direction 2 of 2 — the SIBLING fail-safe branch
+    (a non-main ``reply_to_sid`` that isn't a live loaded session) also
+    returns False before the new P3 dispatch call, matching direction 1
+    above. Both early-exit branches of ``_deliver`` are covered, not just
+    one — a single-branch test would leave the other unguarded."""
+    from reyn.runtime.services.pipeline_executor_driver import PipelineExecutorDriver
+
+    captured: list[tuple[str, dict]] = []
+    _capture_hook_dispatch(monkeypatch, captured)
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log, None)
+    wo = replace(
+        _crash_state_work_order(
+            "unloaded-sid-run", _three_step_pipeline(tmp_path / "o.txt"), input={"seed": 1},
+            driver_sid="drv-unloaded",
+        ),
+        reply_to_sid="not-a-loaded-session",
+    )
+    driver = PipelineExecutorDriver(wo, registry=reg, state_log=state_log)
+    worker = reg.get_or_load("worker")
+    driver.bind_session(worker, worker._router_host)
+
+    delivered = await driver._deliver(status="ok", output={"x": 1}, error=None)
+
+    assert delivered is False
+    assert not any(point == "task_settled" for point, _ in captured)
 
 
 @pytest.mark.asyncio

--- a/tests/hooks/test_context_safe_gate_3978.py
+++ b/tests/hooks/test_context_safe_gate_3978.py
@@ -27,12 +27,22 @@ from reyn.hooks.schema_registry import (
 # ── CONTEXT_UNSAFE_FIELDS itself ────────────────────────────────────────────
 
 
-def test_context_unsafe_fields_is_empty_for_every_builtin_kind_today() -> None:
-    """Tier 2: owner ruling (2026-08-10) — all 8 builtin schemas' current
-    fields are context_safe. The empty default IS the current real state,
-    not a placeholder (see schema_registry.py's own module comment)."""
-    for kind in BUILTIN_HOOK_SCHEMAS:
+def test_context_unsafe_fields_is_empty_for_the_original_8_builtin_kinds() -> None:
+    """Tier 2: owner ruling (2026-08-10) — the 8 PRE-P3 builtin schemas'
+    fields are all context_safe. The empty default for each of THESE 8 is
+    the current real state, not a placeholder (see schema_registry.py's own
+    module comment). ``task_settled`` (P3, added after this ruling) is
+    the deliberate exception — see the next test."""
+    pre_p3_kinds = frozenset(BUILTIN_HOOK_SCHEMAS) - {"builtin:task:task_settled"}
+    for kind in pre_p3_kinds:
         assert CONTEXT_UNSAFE_FIELDS.get(kind, frozenset()) == frozenset()
+
+
+def test_context_unsafe_fields_excludes_task_settled_result() -> None:
+    """Tier 2: proposal 0067 P3 / ADR-0040 D3 — ``result`` is LLM-authored
+    task output, declared context_safe: false in the design itself (not a
+    narrowing added after the fact, unlike a hypothetical future field)."""
+    assert CONTEXT_UNSAFE_FIELDS["builtin:task:task_settled"] == frozenset({"result"})
 
 
 def test_context_unsafe_fields_only_names_real_schema_fields() -> None:
@@ -102,6 +112,21 @@ def test_safe_context_fields_accepts_bare_or_canonical_point_form(
 
 
 # ── render_push's message gate ───────────────────────────────────────────────
+
+
+def test_task_settled_result_cannot_be_interpolated_into_message() -> None:
+    """Tier 2: (#3978 P3, lead-coder's 5th acceptance condition) the REAL
+    production entry — not a monkeypatched injection — for task_settled's
+    own CONTEXT_UNSAFE_FIELDS declaration. A message template referencing
+    `result` (LLM-authored task output, ADR-0040 D3) is blocked by the
+    gate that already exists for it in the shipped registry, no injection
+    needed to prove it."""
+    push = PushBlock(message="task finished: {{ result }}")
+
+    result = render_push(push, {"result": "leak me"}, "task_settled")
+
+    assert result.push_when is False
+    assert result.message == ""
 
 
 def test_render_push_message_cannot_interpolate_an_unsafe_field(

--- a/tests/hooks/test_hook_composed_matcher_schema_2889.py
+++ b/tests/hooks/test_hook_composed_matcher_schema_2889.py
@@ -5,7 +5,7 @@ left in.
 Root cause (see the architect's design comment on #2889): ``composed:*`` is
 an open namespace, so a ``matcher`` on a ``composed:*`` hook was NOT
 schema-checked at load — a typo'd field silently never matches at dispatch,
-exactly the footgun Phase 3 closed for the 10 builtin points. Fix: every
+exactly the footgun Phase 3 closed for the 9 builtin points. Fix: every
 composed event, across all 7 Composer ops, is emitted by the single
 ``_emit_composed`` producer (``reyn.hooks.composer``) with the FIXED payload
 shape ``{"inputs": [...], "correlation_key": <key>}`` — so the schema is

--- a/tests/hooks/test_hook_composer_reachability_phase5.py
+++ b/tests/hooks/test_hook_composer_reachability_phase5.py
@@ -129,7 +129,7 @@ def test_composed_kind_now_loads_as_on_target():
     """Tier 1: ``on: composed:<name>`` — fail-loud-rejected in Phase 4b (the
     §9 example's own annotation) — now loads successfully. ``composed:<name>``
     is accepted as an OPEN namespace (by prefix), not enumerated in the fixed
-    ``ALLOWED_HOOK_POINTS`` frozenset (which stays the 10 builtin points)."""
+    ``ALLOWED_HOOK_POINTS`` frozenset (which stays the 9 builtin points)."""
     registry = load_hooks([
         {"on": "composed:deploy_approved", "template_push": {"message": "go", "wake": True}},
     ])

--- a/tests/hooks/test_hook_event_schema_registry_sync_0059.py
+++ b/tests/hooks/test_hook_event_schema_registry_sync_0059.py
@@ -45,10 +45,13 @@ from types import SimpleNamespace
 import pytest
 
 from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import Pipeline, TransformStep
+from reyn.core.pipeline.registry import PipelineRegistry
 from reyn.hooks import dispatcher as dispatcher_mod
 from reyn.hooks.ingress import McpIngressAdapter
 from reyn.hooks.loader import load_hooks
 from reyn.hooks.registry import HookRegistry
+from reyn.hooks.schema import ALLOWED_HOOK_POINTS
 from reyn.hooks.schema_registry import (
     BUILTIN_HOOK_SCHEMAS,
     HookSchemaError,
@@ -60,8 +63,11 @@ from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.mcp.message_handler import ReynMCPMessageHandler
 from reyn.runtime.cron.routing import dispatch_cron_fired
+from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 from reyn.runtime.webhook_routing import dispatch_webhook_received
+from reyn.tools.pipeline_verbs import _handle_run_pipeline_async
+from reyn.tools.types import RouterCallerState, ToolContext
 from tests._support.agent_session import make_session
 
 _EMPTY_USAGE = TokenUsage(prompt_tokens=5, completion_tokens=3)
@@ -186,12 +192,48 @@ async def test_all_eight_builtin_points_dispatch_schema_matching_payloads(
         "file_changed", path="/repo/src/main.py", event_type="modified",
     ))
 
+    # ── task_settled (#3978 P3, pipeline-async terminal-delivery producer) ──
+    # driven via a REAL run_pipeline_async through to completion — the same
+    # AgentRegistry-backed setup test_pipeline_is2_driver_session.py's own
+    # delivery test uses, minimized to a single pure TransformStep (no tool
+    # needed to reach a terminal, schema-matching payload).
+    async def _scripted(**kwargs: object) -> LLMToolCallResult:
+        return _text_result("ack")
+
+    registry = AgentRegistry(
+        project_root=tmp_path / "task-settled-arc",
+        session_factory=lambda profile, **kw: make_session(
+            agent_name=profile.name, state_log=StateLog(tmp_path / "task-settled-arc" / ".reyn" / "wal.jsonl"),
+        ),
+        state_log=StateLog(tmp_path / "task-settled-arc" / ".reyn" / "wal.jsonl"),
+    )
+    registry.create("worker")
+    caller = registry.get_or_load("worker")
+    caller._loop_driver._loop_observer = lambda loop: setattr(loop, "_llm_caller", _scripted)
+    pipeline_registry = PipelineRegistry()
+    pipeline_registry.register("p", Pipeline(steps=[TransformStep(value="1 + 1", output="t0")]))
+    ctx = ToolContext(
+        events=caller._router_host.events, permission_resolver=None, workspace=None,
+        caller_kind="router",
+        router_state=RouterCallerState(
+            pipeline_registry=pipeline_registry, agent_registry=registry, host=caller._router_host,
+        ),
+        state_log=StateLog(tmp_path / "task-settled-arc" / ".reyn" / "wal.jsonl"),
+    )
+    launch = await _handle_run_pipeline_async({"name": "p", "input": {}}, ctx)
+    assert launch["status"] == "started"
+    await _wait_for(lambda: any(p == "task_settled" for p, _ in captured))
+
     seen_points = {p for p, _ in captured}
-    expected_points = {
-        "session_start", "session_end", "turn_start", "turn_end",
-        "cron_fired", "webhook_received",
-        "mcp_resource_updated", "file_changed",
-    }
+    # Derived from ALLOWED_HOOK_POINTS (the schema-driven open set), not
+    # hand-copied (lead-coder's #3978 P3 finding): a hardcoded literal here
+    # is exactly the gap that let a 9th declared-but-unproduced point
+    # (task_settled) pass silently — declaring a point in BARE_TO_KIND/
+    # BUILTIN_HOOK_SCHEMAS without ALSO exercising its real producer here
+    # left "every dispatch call-site's assembled payload == the shipped
+    # schema" (this file's own docstring) true only for the 8 points this
+    # set happened to name by hand.
+    expected_points = set(ALLOWED_HOOK_POINTS)
     missing = expected_points - seen_points
     assert not missing, f"builtin points never captured: {sorted(missing)}"
 


### PR DESCRIPTION
**[tui-coder]** — proposal 0067 P3: the `task_settled` builtin hook point.

## What

- `builtin:task:task_settled` — a new third hook-point category (`_TASK_POINTS`), neither session lifecycle nor external ingress: "an async unit of work reached a terminal disposition."
- Producer: `PipelineExecutorDriver._deliver` dispatches it on the REPLY session, AFTER `submit_pipeline_result` succeeds (delivery-anchored). The two pre-existing fail-safe early returns (reply agent gone / reply session not loaded) sit before this call.
- `CONTEXT_UNSAFE_FIELDS["builtin:task:task_settled"] = {"result"}` (ADR-0040 D3 — task result is LLM-authored, so it can't be interpolated into a hook `message`; it can still ride `include`, per P2).

## Investigation finding, reported and ruled on before implementation

The proposal's "the settle path" (singular) framing doesn't match today's codebase: `delegate_to_agent`'s chain-resolve path (`inter_agent_messaging.py`) is a SECOND, independent "settle"-shaped completion mechanism, not wired here. Per lead-coder's ruling, this is deliberately deferred to P6 (retiring `delegate_to_agent` repurposes `pending_chains` as this point's second producer) — recorded as a remainder in `BUILTIN_HOOK_SCHEMAS`'s own code comment, not left silent (CLAUDE.md arc-closure rule).

## Side-effect fix: coverage-gate defect

Found while tracing task_settled's producer (not deliberately sought), independently re-measured by lead-coder: `test_hook_event_schema_registry_sync_0059.py`'s `expected_points` was a hardcoded 8-name literal — a 9th declared-but-unproduced point would have passed silently. Now derives from `ALLOWED_HOOK_POINTS`. Confirmed RED with `task_settled` declared but no producer wired, confirmed GREEN once the producer landed — a real red→green transition, not just a static assertion.

## Also included: #3996 stale "10 hook points" cleanup

4 remaining references (`CHANGELOG.md`, `reyn.local.yaml.example`, 2 test docstrings) still said "10"; true count is 9 (confirmed via `ALLOWED_HOOK_POINTS`, PYTHONPATH-verified against local `src/`, not the stale editable-install path).

## Tests (real collaborators throughout, no mocks)

`tests/core/test_pipeline_is2_driver_session.py`:
- `test_task_settled_fires_after_delivery_and_the_handle_is_then_gone` — delivery-anchored (waits for the result in the issuer's own history, no sleep), confirms the dispatched payload, then confirms the driver-session handle is reclaimed (`describe_task` doesn't exist yet — P4 — so A10's existing reclaim assertion is reused as the "task can no longer be found" proxy, not re-tested, per the six-questions Q1 read).
- Strip-falsify ×2 (both `_deliver` early-exit branches — reply agent gone / reply session not loaded): `task_settled` never fires. **Falsify-verified**: temporarily hoisted the dispatch call before the fail-safe checks, confirmed both tests go genuinely red at the intended assertion (not a crash), then reverted.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 59/59 OK (one Tier-4 format-pin finding fixed: `len(settled) == 1` → tuple-unpack)
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (210/213 baselined, unchanged)
- [x] `pytest tests/hooks/ tests/core/test_pipeline_is2_driver_session.py` — 341 passed
- [x] Falsify-verified the 2 new strip-falsify tests (confirmed genuine red→green)
- [ ] Visual — n/a (no TUI-visible change)

part of #3978

🤖 Generated with [Claude Code](https://claude.com/claude-code)
