### PR TITLE
docs(#3978): document task_settled + fix stale builtin hook-point count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Hook-Event Redesign (proposal 0059), Phases 1-3**: typed `HookEvent` + a builtin Schema Registry declaring each of the 9 builtin hook points' payload field set (Phase 1, `c319285`); a unified Ingress Adapter consolidating hook-firing entry points (Phase 2, `f4db86c`); an `EventPattern` match grammar generalizing `matcher` field-name matching, schema-validated at config-load time for builtin points (Phase 3, `3ff41bc`).
+- **Hook-Event Redesign (proposal 0059), Phases 1-3**: typed `HookEvent` + a builtin Schema Registry declaring each of the 10 builtin hook points' payload field set (Phase 1, `c319285` — `task_start`/`task_end` were still live then, later removed by #3214; today's count is 9, but this entry describes Phase 1's own state); a unified Ingress Adapter consolidating hook-firing entry points (Phase 2, `f4db86c`); an `EventPattern` match grammar generalizing `matcher` field-name matching, schema-validated at config-load time for builtin points (Phase 3, `3ff41bc`).
 
 - **B22 RAG affordance-bias schema-layer fix — 0/3 → 3/3 first-attempt 100% recovery**
   (= 2026-05-10, commit `9fdecd1`). 5 parallel sonnet context-analysis agents

--- a/docs/concepts/runtime/hooks.md
+++ b/docs/concepts/runtime/hooks.md
@@ -324,6 +324,32 @@ never wait on a hook action — dispatch is scheduled as a fire-and-forget
 background task, so a slow hook (e.g. a multi-second `exec`) can never
 stall the ingress that triggered it.
 
+## Task points
+
+A **task point** is neither a session lifecycle transition nor an external
+ingress signal — it fires when an async unit of work reaches a terminal
+disposition. Proposal 0067 P3 adds the first (and today, only) one.
+
+### `task_settled`
+
+Fires after a `run_pipeline`-launched async pipeline's result has been
+delivered to the issuing session's history (delivery-anchored — the hook
+fires only once `submit_pipeline_result` has succeeded). `delegate_to_agent`'s
+own chain-resolve completion path is a separate, still-unwired "settle"-shaped
+mechanism today — folding it into this same point is deferred (recorded as an
+open remainder in `BUILTIN_HOOK_SCHEMAS`'s own code comment, not silently
+dropped).
+
+Template vars:
+
+| Var | Meaning |
+|-----|---------|
+| `task_id` | The settled task's handle. |
+| `kind` | The task kind (e.g. `pipeline`). |
+| `status` | The terminal status the task settled with. |
+| `session` | The issuing session. |
+| `result` | The task's own LLM-authored output. **Not** `context_safe` (ADR-0040 D3) — cannot be interpolated into a `template_push`'s `message`; use `include` (below) to carry it as fenced, attributed content instead. |
+
 ## Matcher: narrowing which events fire a hook
 
 A hook may set `matcher`, a `dict[str, str]` of field → pattern, evaluated
@@ -341,8 +367,8 @@ hooks:
   `path`, which match via a shell-style glob (`fnmatch`) — so
   `file:///repo/**` matches any URI under that prefix, and `/repo/src/**`
   matches any watched path under that directory.
-- For the 10 **builtin** hook points (6 lifecycle + `mcp_resource_updated` /
-  `file_changed` / `cron_fired` / `webhook_received`), a matcher field must be
+- For the 9 **builtin** hook points (the 4 lifecycle points + `mcp_resource_updated` /
+  `file_changed` / `cron_fired` / `webhook_received` + `task_settled`), a matcher field must be
   one the point's builtin schema actually carries — a typo'd or nonexistent
   field name (e.g. a lifecycle point's matcher naming `server`/`uri`, or
   `payload.srever`) is a **load-time `HookConfigError`**, rejected before the

--- a/docs/concepts/runtime/hooks.md
+++ b/docs/concepts/runtime/hooks.md
@@ -39,17 +39,18 @@ valid in one is not necessarily valid in the other:
 | `file_changed` | `builtin:external:file_changed` | a watched path changes ([`fs_watch`](../../reference/config/reyn-yaml.md#fs_watch-block) required) | ✅ | ✅ |
 | `cron_fired` | `builtin:external:cron_fired` | a message-based `cron:` job delivers | ✅ | ✅ |
 | `webhook_received` | `builtin:external:webhook_received` | an inbound webhook resolves to this session | ✅ | ✅ |
+| `task_settled` | `builtin:task:task_settled` | an async task (today: a `run_pipeline` async launch) reaches a terminal disposition | ✅ | ✅ |
 | — (open) | `composed:<name>` | a Composer (see below) publishes its correlated output | ✅ | ✅ (chaining — another Composer's output) |
 | — (open) | `llm:<session_id>:<event_name>` | the LLM itself emits one via `emit_hook_event` (always its own session) | ❌ **rejected at load** (`HookConfigError`) | ✅ |
 
 **`llm:*` can never be a hook's `on:` value — only a Composer input.** A
-`hooks:` entry only accepts the 8 builtin bare/namespaced forms above or a
+`hooks:` entry only accepts the 9 builtin bare/namespaced forms above or a
 `composed:<name>` prefix; anything else (including a well-formed
 `llm:<session_id>:<event_name>`) is a load-time `HookConfigError`. To react
 to an LLM-emitted event, correlate it through a `composers:` entry into a
 `composed:<name>` event, then put your `hooks:` entry's `on:` on THAT
 composed kind — see the [worked example](#llm-authored-hook-events-emit_hook_event)
-below. The bare/namespaced-form duality only applies within the 8 builtin
+below. The bare/namespaced-form duality only applies within the 9 builtin
 points — it does not extend `on:`'s acceptance to `llm:*`.
 
 ### The 4 config schemes — every field
@@ -115,7 +116,7 @@ template vars before the hook's action runs.
 - Match rule by field **name**: `uri` and `path` use a shell-style glob
   (`fnmatch`); every other field name is exact string equality.
 - Absent or empty `matcher` → the hook always fires.
-- For the 8 builtin points, a matcher field outside that point's payload
+- For the 9 builtin points, a matcher field outside that point's payload
   (a typo, or a field the point never carries) is a **load-time
   `HookConfigError`** — rejected before the hook can ever run.
 - For a hook's `matcher` on a `composed:*` `on:` target, or a Composer

--- a/src/reyn/hooks/render.py
+++ b/src/reyn/hooks/render.py
@@ -12,9 +12,11 @@ WHICH fields of ``context`` are safe to interpolate into ``message`` — see
 Before P2, ``render_push`` had no way to make this distinction at all (it
 received only the raw context dict, no notion of which kind produced it) —
 "build the gate before adding the first field that needs it" (the
-proposal's own framing) required this signature change NOW, even though
-today's 8 builtin schemas mark every field safe (so the filter is a no-op
-in practice until a future field is declared unsafe).
+proposal's own framing) required this signature change NOW, even though at
+P2 landing time every builtin schema marked every field safe (the filter
+was a no-op in practice). P3 (same arc) is that "future field": ``result``
+on ``builtin:task:task_settled`` is the first real exclusion — see
+``reyn.hooks.schema_registry.CONTEXT_UNSAFE_FIELDS``.
 
 The gate applies to ``message`` ONLY — ``wake``/``push_when``/``session``
 render against the FULL, unfiltered context (those fields never surface

--- a/src/reyn/hooks/schema_registry.py
+++ b/src/reyn/hooks/schema_registry.py
@@ -20,7 +20,7 @@ per-``event_name`` value allowlist — the future OUT-set config file layers
 name-level curation ON TOP of this structural gate, it does not replace it.
 
 ``BUILTIN_HOOK_SCHEMAS`` is the single source of truth for what field-set
-each of reyn's 8 builtin hook-points carries — mirroring the
+each of reyn's 9 builtin hook-points carries — mirroring the
 ``OP_KIND_MODEL_MAP`` ↔ ``control-ir.md`` sync discipline (CLAUDE.md hard
 rule): every dispatch call site MUST build its payload through
 ``build_hook_payload`` (below), which validates the assembled dict against
@@ -181,7 +181,8 @@ def safe_context_fields(kind_or_point: str, context: dict) -> dict:
     """*context* filtered down to fields safe for hook-push MESSAGE
     interpolation (``reyn.hooks.render.render_push``) — every key in
     *context* except the ones ``CONTEXT_UNSAFE_FIELDS`` names for this
-    kind. A kind with no entry (today: all 8 builtins) removes nothing —
+    kind. A kind with no entry (today: 8 of the 9 builtins — every one
+    except ``builtin:task:task_settled``) removes nothing —
     ``dict.get(kind, frozenset())`` is the empty-deny-list default (see
     module docstring above).
 

--- a/tests/hooks/test_hook_composed_matcher_schema_2889.py
+++ b/tests/hooks/test_hook_composed_matcher_schema_2889.py
@@ -5,7 +5,10 @@ left in.
 Root cause (see the architect's design comment on #2889): ``composed:*`` is
 an open namespace, so a ``matcher`` on a ``composed:*`` hook was NOT
 schema-checked at load — a typo'd field silently never matches at dispatch,
-exactly the footgun Phase 3 closed for the 9 builtin points. Fix: every
+exactly the footgun Phase 3 closed for the 10 builtin points (task_start/
+task_end were still live then; #3214 later removed them, and #4087 added
+task_settled — today's count is 9, but this sentence describes Phase 3's
+own state, not today's). Fix: every
 composed event, across all 7 Composer ops, is emitted by the single
 ``_emit_composed`` producer (``reyn.hooks.composer``) with the FIXED payload
 shape ``{"inputs": [...], "correlation_key": <key>}`` — so the schema is

--- a/tests/hooks/test_hook_event_schema_registry_sync_0059.py
+++ b/tests/hooks/test_hook_event_schema_registry_sync_0059.py
@@ -3,11 +3,13 @@ CI sync gate (proposal ``docs/deep-dives/proposals/0059-hook-event-redesign.md``
 §4), mirroring the ``OP_KIND_MODEL_MAP`` <-> ``control-ir.md`` sync discipline
 (CLAUDE.md hard rule).
 
-Every one of reyn's 8 builtin hook-points now funnels its payload through
+Every one of reyn's 9 builtin hook-points now funnels its payload through
 ``reyn.hooks.schema_registry.build_hook_payload`` at its ONE producer call
 site (``reyn.runtime.session`` /
 ``reyn.mcp.message_handler`` / ``reyn.runtime.fs_watcher`` /
-``reyn.runtime.cron.routing`` / ``reyn.runtime.webhook_routing``) — so a call
+``reyn.runtime.cron.routing`` / ``reyn.runtime.webhook_routing`` /
+``reyn.runtime.services.pipeline_executor_driver`` for ``task_settled``,
+#3978 P3) — so a call
 site's assembled payload IS the shipped schema BY CONSTRUCTION: a missing,
 renamed, or extra field raises ``HookSchemaError`` immediately at that call
 site, not just detectable by a separate after-the-fact diff.
@@ -16,7 +18,7 @@ This file drives the REAL production call sites (no mocks — real ``Session``,
 real ``HookDispatcher``, real op handlers, real ingress-routing functions) and
 captures the EXACT field-set each dispatches, proving:
 
-1. byte-identical coverage — every one of the 8 builtin points is actually
+1. byte-identical coverage — every one of the 9 builtin points is actually
    exercised and its captured payload key-set matches
    ``BUILTIN_HOOK_SCHEMAS`` exactly (the values are the same ones the
    pre-Phase-1 ad-hoc dict literals carried — only the schema-check is new).
@@ -129,10 +131,10 @@ def _make_session(tmp_path: Path) -> Session:
 
 
 @pytest.mark.asyncio
-async def test_all_eight_builtin_points_dispatch_schema_matching_payloads(
+async def test_all_nine_builtin_points_dispatch_schema_matching_payloads(
     tmp_path, monkeypatch,
 ):
-    """Tier 2: every one of the 8 builtin hook-points, exercised via its REAL
+    """Tier 2: every one of the 9 builtin hook-points, exercised via its REAL
     production call site, dispatches a payload whose key-set EXACTLY matches
     ``BUILTIN_HOOK_SCHEMAS`` for that point — the byte-identical proof."""
     captured: list[tuple[str, dict]] = []


### PR DESCRIPTION
**[docs-maintainer]** — Found while triaging #4087 (proposal 0067 P3, `task_settled` hook point) for doc drift, as part of standing broker-inbox monitoring.

## Two problems in `docs/concepts/runtime/hooks.md`

1. **Stale count, pre-existing**: the matcher section said "10 builtin hook points (6 lifecycle + 4 external)". Both numbers were wrong even before tonight — confirmed via `ALLOWED_HOOK_POINTS`/`_LIFECYCLE_POINTS`: pre-P3 was 8 total (4 lifecycle, not 6). This predates #4087 and was missed by #4037's earlier "10 builtin hook points" cleanup pass (that PR fixed 6 sites elsewhere; this one wasn't caught).
2. **Missing entirely**: #4087 added a third hook-point category (`_TASK_POINTS`, `builtin:task:task_settled`) — a whole new dispatch category ("neither session lifecycle nor external ingress") with zero doc coverage. `## Lifecycle points` and `## External-event points` both exist as sections; there was no `## Task points`.

## Fix

- Corrected the matcher-section count to 9 (4 lifecycle + 4 external + `task_settled`), verified directly against `ALLOWED_HOOK_POINTS` on current `main`.
- Added a `## Task points` section (mirroring the existing lifecycle/external sections' format) documenting `task_settled`: delivery-anchored firing (after `submit_pipeline_result` succeeds), its template vars, the deliberately-deferred `delegate_to_agent` producer (matching `BUILTIN_HOOK_SCHEMAS`'s own code-comment framing, not silently omitted), and `result`'s non-`context_safe` status per ADR-0040 D3 (can't interpolate into `message`, use `include`).

## Test plan

- [x] `python scripts/check_doc_anchors.py` — exit 0
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0 (remaining INFO lines are pre-existing ja-mirror gaps)
- [x] `python scripts/check_tests_path_literal_reference.py` (gate #6) — OK
- [x] Count (9) verified directly: `python3 -c "import sys; sys.path.insert(0,'src'); from reyn.hooks.schema import ALLOWED_HOOK_POINTS; print(sorted(ALLOWED_HOOK_POINTS))"` on current `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)



- [x] 🔴 **同じファイルに 8 と 9 が併存** — :46 / :52 / :118 が「8 builtin」のまま（実装は 9）。⚠️ 歴史を書いている箇所（pre-P3 は 8 だった）は 8 のままが正しいので、機械的置換をしないこと

