### PR TITLE
feat(#3978): the settle path — on_settle execution + immediate deletion

### DIFF
--- a/docs/concepts/runtime/hooks.md
+++ b/docs/concepts/runtime/hooks.md
@@ -333,12 +333,20 @@ disposition. Proposal 0067 P3 adds the first (and today, only) one.
 
 ### `task_settled`
 
-Fires after a `run_pipeline`-launched async pipeline's result has been
-delivered to the issuing session's history (delivery-anchored — the hook
-fires only once `submit_pipeline_result` has succeeded). `delegate_to_agent`'s
-own chain-resolve completion path is a separate, still-unwired "settle"-shaped
-mechanism today — folding it into this same point is deferred (recorded as an
-open remainder in `BUILTIN_HOOK_SCHEMAS`'s own code comment, not silently
+Fires when a `run_pipeline`-launched async pipeline's task reaches a
+terminal disposition — **independent of whether delivery to the issuing
+session actually succeeded** (ADR-0040 D4④). A task's `on_settle`
+disposition (`"deliver"` | `"<pipeline name>"` | `"drop"`) executes first,
+then `task_settled` fires unconditionally, even when delivery was dropped
+by a fail-safe (the reply agent no longer exists, or the reply session
+isn't loaded) or when the disposition itself was `"drop"`. This is
+deliberate: a Composer's `all` combinator waits for every one of N tasks to
+settle, and if the hook were gated on delivery success, a single dropped
+or undeliverable task would mean `all` never fires — composition rests on
+"settled", not on "delivered". `delegate_to_agent`'s own chain-resolve
+completion path is a separate, still-unwired "settle"-shaped mechanism
+today — folding it into this same point is deferred (recorded as an open
+remainder in `BUILTIN_HOOK_SCHEMAS`'s own code comment, not silently
 dropped).
 
 Template vars:

--- a/src/reyn/core/pipeline/work_order.py
+++ b/src/reyn/core/pipeline/work_order.py
@@ -83,6 +83,13 @@ class PipelineWorkOrder:
     driver_sid: str
     spawn_seq: "int | None" = None
     schema_defs: "dict[str, dict[str, Any]] | None" = None
+    # proposal 0067 / ADR-0040 D4: the settle disposition — "deliver" (default,
+    # byte-identical to pre-settle-path behaviour) | "<pipeline name>" | "drop".
+    # No launch site sets anything but the default today (no LLM-facing param
+    # exposes it yet — that is P7's job); the field exists so the settle path
+    # can read it, same "type lands ahead of its issuing surface" shape P0
+    # already established for CurrentTask.on_settle.
+    on_settle: str = "deliver"
 
 
 def _atomic_write(path: "Path", content: dict) -> None:

--- a/src/reyn/runtime/services/chain_manager.py
+++ b/src/reyn/runtime/services/chain_manager.py
@@ -220,6 +220,58 @@ class ChainManager:
         await self._journal.record_chain_resolve(chain_id=chain_id)
         return chain
 
+    async def settle(
+        self,
+        chain_id: str,
+        *,
+        on_settle: str,
+        deliver: "Callable[[], Awaitable[None]]",
+        launch_pipeline: "Callable[[str], Awaitable[None]] | None" = None,
+    ) -> _PendingChain | None:
+        """Execute a task's settle disposition, then pop its handle — same
+        function, mirroring ``resolve()``'s pop+cancel_timeout+journal shape
+        (ADR-0040 D4: "push-at-settle with immediate deletion", "no
+        retention, no clock"; the settle-path acceptance condition is
+        exactly this — ONE settle function, no ``pipeline``/``run_id`` in
+        its signature, so P6 can point ``delegate_to_agent``'s own
+        chain-resolve completion at this SAME function later).
+
+        ``on_settle`` (proposal 0067 § Issuing / ADR-0040 D4①):
+          - ``"deliver"`` — await ``deliver()`` (the caller's own delivery
+            callback — e.g. posting a ``pipeline_result``/``agent_response``
+            inbox message; this method has no opinion on what "deliver"
+            means for a given task kind).
+          - ``"drop"`` — no-op; the disposition is intentionally discarded.
+          - anything else — a pipeline NAME to launch via
+            ``launch_pipeline`` (D4: "filters a large result before it
+            reaches the issuer's context"). Scope of the actual launch is
+            not yet decided (proposal 0067 P4/P7) — a caller that doesn't
+            pass ``launch_pipeline`` gets ``NotImplementedError`` rather
+            than a silent no-op, so an unimplemented disposition fails
+            loud, not quiet.
+
+        Tolerates a missing handle exactly like ``resolve()`` does (``pop``
+        with a ``None`` default, no error) — the disposition still
+        executes; only the bookkeeping (pop/cancel_timeout/journal) is a
+        no-op when nothing was registered for ``chain_id`` (e.g. a run
+        launched before this mechanism existed, mid-recovery from an older
+        on-disk work-order)."""
+        if on_settle == "drop":
+            pass
+        elif on_settle == "deliver":
+            await deliver()
+        else:
+            if launch_pipeline is None:
+                raise NotImplementedError(
+                    f"ChainManager.settle(on_settle={on_settle!r}): pipeline-name "
+                    "dispositions are not yet implemented (proposal 0067 P4/P7)"
+                )
+            await launch_pipeline(on_settle)
+        chain = self._chains.pop(chain_id, None)
+        self.cancel_timeout(chain_id)
+        await self._journal.record_chain_resolve(chain_id=chain_id)
+        return chain
+
     def find_chain(self, chain_id: str) -> _PendingChain | None:
         """Return the in-memory _PendingChain for ``chain_id``, or None.
 

--- a/src/reyn/runtime/services/pipeline_executor_driver.py
+++ b/src/reyn/runtime/services/pipeline_executor_driver.py
@@ -117,6 +117,34 @@ logger = logging.getLogger(__name__)
 MAX_RESUME_ATTEMPTS = 3
 
 
+async def resolve_reply_target(
+    registry: "AgentRegistry", agent: str, sid: str,
+) -> "tuple[Any | None, str | None]":
+    """Resolve a live (agent, sid) reply target through the registry.
+
+    Mirrors ``Session._a2a_send_response``'s routing (non-main sid -> the
+    specific live session, fail-closed if not loaded and NEVER rerouted to
+    main; main -> cold-load + ensure_running). Shared by the settle-path's
+    two symmetric call sites — launch-time handle registration
+    (``_spawn_pipeline_driver_session``) and settle-time delivery
+    (``PipelineExecutorDriver._deliver``) — so a task's collection handle
+    only ever exists where a delivery would actually be attempted.
+
+    Returns ``(target, None)`` on success or ``(None, reason)`` on failure
+    (never raises — the fail-safe IS the return value)."""
+    if not registry.exists(agent):
+        return None, f"reply agent {agent!r} no longer exists"
+    if sid and sid != "main":
+        target = registry.get_session(agent, sid)
+        if target is None:
+            return None, f"reply session ({agent!r}, {sid!r}) is not loaded"
+        registry.ensure_session_running(agent, sid)
+        return target, None
+    target = registry.get_or_load(agent)
+    await registry.ensure_running(agent)
+    return target, None
+
+
 class PipelineExecutorDriver:
     """ExecutionDriver that runs/resumes ONE pipeline work-order per nudge."""
 
@@ -369,8 +397,9 @@ class PipelineExecutorDriver:
         named_stores: "dict | None" = None,
     ) -> None:
         """Deliver the result to the reply address (when ``notify_reply``), THEN
-        write the terminal marker, then arm the standard ephemeral vanish for
-        this session (A10: the driver-session must not leak past terminal).
+        write the terminal marker, THEN fire ``task_settled`` (settle-path,
+        #3978), then arm the standard ephemeral vanish for this session (A10:
+        the driver-session must not leak past terminal).
 
         IS-6: on the sync ATTACHED path ``notify_reply`` is False — the attached
         caller reads the terminal marker in-band via ``read_result``, so posting
@@ -389,6 +418,30 @@ class PipelineExecutorDriver:
             output=_json_safe(output), error=error,
             named_stores=_json_safe(named_stores) if named_stores is not None else None,
         )
+        # proposal 0067 settle path (#3978): task_settled fires on the FACT
+        # of settling — independent of whether delivery succeeded (ADR-0040
+        # D4④, architect ruling "B", adopted 2026-08-10). Decisive reason,
+        # not "separately"'s wording alone: §4-b's Composer `all` combinator
+        # waits for every one of N tasks to settle; if task_settled were
+        # gated on delivery success, a single on_settle="drop" (or a
+        # vanished-reply-target fail-safe) would mean that task NEVER fires
+        # its settle event, and `all` would wait forever — composition rests
+        # on "settled", not on "delivered". Dispatched through THIS
+        # driver-session (`self._session`, always live at this point in the
+        # run), not the possibly-unresolvable reply `target` — the payload's
+        # own `session` field already records WHICH session the settle
+        # concerns; the DISPATCH surface does not need to be that session.
+        # kind="pipeline" is a placeholder value (P4 has not landed the
+        # prompt|pipeline|exec vocabulary yet).
+        if self._notify_reply and self._session is not None:
+            await self._session.dispatch_external_event(
+                "task_settled",
+                build_hook_payload(
+                    "task_settled", task_id=self._work_order.run_id, kind="pipeline",
+                    status=status, session=self._work_order.reply_to_sid or "main",
+                    result=self._format_result_text(status=status, output=output, error=error),
+                ),
+            )
         # Reuse the existing ephemeral auto-vanish teardown (quiesce + cancel
         # run-loop + drop + session_vanished + per-session dir purge) instead of
         # a second teardown path. Same private poke spawn_session_recorded uses.
@@ -398,54 +451,36 @@ class PipelineExecutorDriver:
     async def _deliver(
         self, *, status: str, output: Any, error: "str | None",
     ) -> bool:
-        """Post the ``pipeline_result`` to the reply (agent, sid). Mirrors
-        ``Session._a2a_send_response``'s routing (non-main sid → the specific
-        live session; main → cold-load + ensure_running) including its
-        fail-safe: a vanished reply target is LOGGED and dropped (never
-        rerouted to main), and the run still goes terminal (``delivered:
-        false`` in result.json) so it cannot re-wake forever."""
+        """Post the ``pipeline_result`` to the reply (agent, sid) via the
+        settle path (proposal 0067 § "the settle path"): resolve the reply
+        target (``resolve_reply_target`` — fail-safe: a vanished reply
+        target is LOGGED and dropped, never rerouted to main, and the run
+        still goes terminal so it cannot re-wake forever), then execute
+        this run's ``on_settle`` disposition through the reply session's
+        OWN ``ChainManager.settle()`` — the same pop+cancel_timeout+journal
+        operation ``delegate_to_agent``'s chain-resolve already uses
+        (D4: "immediate deletion", same function as delivery, not a
+        separate later step). ``task_settled`` is NOT dispatched here — see
+        ``_finish``, which fires it independent of this method's outcome."""
         wo = self._work_order
-        registry = self._registry
-        if not registry.exists(wo.reply_to_agent):
+        target, reason = await resolve_reply_target(
+            self._registry, wo.reply_to_agent, wo.reply_to_sid,
+        )
+        if target is None:
             logger.warning(
-                "pipeline_result for run %r dropped: reply agent %r no longer exists",
-                wo.run_id, wo.reply_to_agent,
+                "pipeline_result for run %r dropped: %s "
+                "(fail-safe — NOT rerouted to main)", wo.run_id, reason,
             )
             return False
-        if wo.reply_to_sid and wo.reply_to_sid != "main":
-            target = registry.get_session(wo.reply_to_agent, wo.reply_to_sid)
-            if target is None:
-                logger.warning(
-                    "pipeline_result for run %r dropped: reply session (%r, %r) is "
-                    "no longer loaded (fail-safe — NOT rerouted to main)",
-                    wo.run_id, wo.reply_to_agent, wo.reply_to_sid,
-                )
-                return False
-            registry.ensure_session_running(wo.reply_to_agent, wo.reply_to_sid)
-        else:
-            target = registry.get_or_load(wo.reply_to_agent)
-            await registry.ensure_running(wo.reply_to_agent)
         text = self._format_result_text(status=status, output=output, error=error)
-        await target.submit_pipeline_result(
-            run_id=wo.run_id, pipeline_name=wo.pipeline_name, status=status,
-            text=text, chain_id=new_chain_id(),
-        )
-        # proposal 0067 P3: task_settled fires AFTER delivery succeeds
-        # (delivery-anchored, matching the point's own name — "settled"
-        # means the result already reached its destination, not merely
-        # that this driver decided to send it). kind="pipeline" is a
-        # placeholder value (P4 has not landed the prompt|pipeline|exec
-        # vocabulary yet) — the ONLY producer wired today, per lead-coder's
-        # ruling (delegate_to_agent's chain-resolve path is a separate,
-        # still-unwired "settle"-shaped completion; folding it in is P6's
-        # job, see BUILTIN_HOOK_SCHEMAS's own comment on this point).
-        await target.dispatch_external_event(
-            "task_settled",
-            build_hook_payload(
-                "task_settled", task_id=wo.run_id, kind="pipeline",
-                status=status, session=wo.reply_to_sid or "main", result=text,
-            ),
-        )
+
+        async def _post() -> None:
+            await target.submit_pipeline_result(
+                run_id=wo.run_id, pipeline_name=wo.pipeline_name, status=status,
+                text=text, chain_id=new_chain_id(),
+            )
+
+        await target.chains.settle(wo.run_id, on_settle=wo.on_settle, deliver=_post)
         return True
 
     def _format_result_text(

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -516,7 +516,10 @@ async def _spawn_pipeline_driver_session(
         pipeline_run_dir,
         write_invocation,
     )
-    from reyn.runtime.services.pipeline_executor_driver import PipelineExecutorDriver
+    from reyn.runtime.services.pipeline_executor_driver import (
+        PipelineExecutorDriver,
+        resolve_reply_target,
+    )
 
     root = reyn_root(state_log.path)
     if root is None:
@@ -567,6 +570,29 @@ async def _spawn_pipeline_driver_session(
         schema_defs=schema_registry.as_dict() if schema_registry is not None else None,
     )
     write_invocation(pipeline_run_dir(root, rid), work_order)
+    if notify_reply:
+        # proposal 0067 settle path (#3978): register this run's collection
+        # handle on the REPLY session's own ChainManager (pending_chains,
+        # repurposed per the proposal's own P6 note) BEFORE the driver ever
+        # runs — settle-time (``PipelineExecutorDriver._deliver``) pops it
+        # via the SAME ``resolve_reply_target`` this call mirrors. The sync
+        # ATTACHED path (``notify_reply=False``) creates no handle at all
+        # (ADR-0040 D4: "collect='attached' creates nothing — nothing to
+        # retain, on_settle is ignored"). A resolution failure here is
+        # non-fatal — it just means no handle exists yet (the same "no
+        # handle" case ``ChainManager.settle()`` already tolerates); the
+        # run still launches and ``_deliver``'s own fail-safe re-discovers
+        # the vanished target at settle time.
+        reply_target, _reason = await resolve_reply_target(
+            registry, reply_to_agent, reply_to_sid,
+        )
+        if reply_target is not None:
+            await reply_target.chains.register(
+                chain_id=rid, from_user=False, depth=0,
+                original_text=pipeline_name, sender=None,
+                origin_agent=reply_to_agent,
+                origin_sid=None if reply_to_sid == "main" else reply_to_sid,
+            )
     session = registry.get_session(reply_to_agent, sid)
     if session is None:
         raise RuntimeError(

--- a/tests/core/test_pipeline_is2_driver_session.py
+++ b/tests/core/test_pipeline_is2_driver_session.py
@@ -335,8 +335,15 @@ async def test_run_pipeline_async_launches_and_delivers_result(tmp_path: Path, m
     run_dir = pipeline_run_dir(tmp_path / ".reyn", run_id)
     # invocation.json is on disk BEFORE completion (work-order-at-birth).
     assert (run_dir / "invocation.json").is_file()
+    # proposal 0067 settle path (#3978): the collection handle is registered
+    # on the REPLY session's ChainManager as part of launch itself — before
+    # the background pump has had a chance to run (no await between launch
+    # returning and this check), so this observes registration, not a race.
+    assert caller.chains.has(run_id)
 
     assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    # ADR-0040 D4 "immediate deletion": once settled, the handle is gone.
+    assert not caller.chains.has(run_id)
     terminal = _result_json(run_dir)
     assert terminal["status"] == "ok" and terminal["delivered"] is True
     # Real tool side effects: transform seeded 10 → 11, then the fixed line.
@@ -435,14 +442,17 @@ async def test_task_settled_fires_after_delivery_and_the_handle_is_then_gone(
 
 
 @pytest.mark.asyncio
-async def test_task_settled_never_fires_when_reply_agent_no_longer_exists(
+async def test_task_settled_still_fires_when_reply_agent_no_longer_exists(
     tmp_path: Path, monkeypatch,
 ) -> None:
-    """Tier 2c: strip-falsify direction 1 of 2 — ``_deliver``'s pre-existing
-    fail-safe (module docstring: "a vanished reply target is LOGGED and
-    dropped ... NEVER rerouted to main") returns False before ever reaching
-    the new P3 dispatch call. Proves the new call sits AFTER this early
-    return in ``_deliver``'s control flow, not before it."""
+    """Tier 2c: settle-path (#3978) — ADR-0040 D4④, architect ruling "B"
+    (adopted 2026-08-10, overturning P3's own strip-falsify pair as merged):
+    ``task_settled`` fires on the FACT of settling, independent of whether
+    delivery succeeded. ``_deliver``'s pre-existing fail-safe (a vanished
+    reply agent — module docstring: "LOGGED and dropped ... NEVER rerouted
+    to main") still returns False/no inbox delivery, but ``_finish`` fires
+    task_settled anyway — a Composer's ``all`` combinator waiting on N
+    tasks must see this one settle too, or composition never fires."""
     from reyn.runtime.services.pipeline_executor_driver import PipelineExecutorDriver
 
     captured: list[tuple[str, dict]] = []
@@ -456,28 +466,27 @@ async def test_task_settled_never_fires_when_reply_agent_no_longer_exists(
         reply_to_agent="does-not-exist",
     )
     driver = PipelineExecutorDriver(wo, registry=reg, state_log=state_log)
-    # Bind a real, live driver-session (production always does this before the
-    # first nudge — module docstring) so a falsified dispatch call reachable
-    # via ``self._session`` would genuinely fire, not merely crash on a None
-    # attribute — the falsify-verification for this pair uses this binding.
     worker = reg.get_or_load("worker")
     driver.bind_session(worker, worker._router_host)
 
-    delivered = await driver._deliver(status="ok", output={"x": 1}, error=None)
+    await driver._finish(status="ok", output={"x": 1})
 
-    assert delivered is False
-    assert not any(point == "task_settled" for point, _ in captured)
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", "gone-agent-run")
+    terminal = _result_json(run_dir)
+    assert terminal["delivered"] is False  # the fail-safe still drops delivery
+    (payload,) = [p for point, p in captured if point == "task_settled"]
+    assert payload["task_id"] == "gone-agent-run"
+    assert payload["status"] == "ok"
 
 
 @pytest.mark.asyncio
-async def test_task_settled_never_fires_when_reply_session_is_not_loaded(
+async def test_task_settled_still_fires_when_reply_session_is_not_loaded(
     tmp_path: Path, monkeypatch,
 ) -> None:
-    """Tier 2c: strip-falsify direction 2 of 2 — the SIBLING fail-safe branch
-    (a non-main ``reply_to_sid`` that isn't a live loaded session) also
-    returns False before the new P3 dispatch call, matching direction 1
-    above. Both early-exit branches of ``_deliver`` are covered, not just
-    one — a single-branch test would leave the other unguarded."""
+    """Tier 2c: settle-path (#3978) — the SIBLING fail-safe branch (a
+    non-main ``reply_to_sid`` that isn't a live loaded session) also still
+    fires task_settled, matching the direction above. Both early-exit
+    branches of ``_deliver`` are covered, not just one."""
     from reyn.runtime.services.pipeline_executor_driver import PipelineExecutorDriver
 
     captured: list[tuple[str, dict]] = []
@@ -495,9 +504,43 @@ async def test_task_settled_never_fires_when_reply_session_is_not_loaded(
     worker = reg.get_or_load("worker")
     driver.bind_session(worker, worker._router_host)
 
-    delivered = await driver._deliver(status="ok", output={"x": 1}, error=None)
+    await driver._finish(status="ok", output={"x": 1})
 
-    assert delivered is False
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", "unloaded-sid-run")
+    terminal = _result_json(run_dir)
+    assert terminal["delivered"] is False
+    (payload,) = [p for point, p in captured if point == "task_settled"]
+    assert payload["task_id"] == "unloaded-sid-run"
+    assert payload["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_task_settled_does_not_fire_on_the_sync_attached_path(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2c: strip-falsify, accept-side sibling — ``notify_reply=False``
+    (the sync ATTACHED path, IS-6) fires NO task_settled at all (ADR-0040
+    D4: "collect='attached' creates nothing at all — there is nothing to
+    retain, and on_settle is ignored"). Without this, "task_settled fires
+    on settling independent of delivery" could be misread as "always fires
+    unconditionally" — this pins the one real case where it must not."""
+    from reyn.runtime.services.pipeline_executor_driver import PipelineExecutorDriver
+
+    captured: list[tuple[str, dict]] = []
+    _capture_hook_dispatch(monkeypatch, captured)
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log, None)
+    wo = _crash_state_work_order(
+        "attached-run", _three_step_pipeline(tmp_path / "o.txt"), input={"seed": 1},
+    )
+    driver = PipelineExecutorDriver(
+        wo, registry=reg, state_log=state_log, notify_reply=False,
+    )
+    worker = reg.get_or_load("worker")
+    driver.bind_session(worker, worker._router_host)
+
+    await driver._finish(status="ok", output={"x": 1})
+
     assert not any(point == "task_settled" for point, _ in captured)
 
 

--- a/tests/runtime/test_chain_manager_settle_3978.py
+++ b/tests/runtime/test_chain_manager_settle_3978.py
@@ -1,0 +1,200 @@
+"""Tier 2: OS invariant — ChainManager.settle() (proposal 0067, "the settle path").
+
+ADR-0040 D4: "push-at-settle with immediate deletion" — a task's on_settle
+disposition (``"deliver"`` | ``"<pipeline name>"`` | ``"drop"``) executes,
+then its handle is popped, IN THE SAME FUNCTION (mirroring ``resolve()``'s
+existing pop+cancel_timeout+journal shape — this is the acceptance
+condition: ONE settle function, no ``pipeline``/``run_id`` in its
+signature, so a later PR (P6) can point ``delegate_to_agent``'s own
+chain-resolve completion at this SAME function).
+
+Real ``ChainManager``/``SnapshotJournal``/``StateLog`` throughout — no
+mocks, matching ``test_chain_manager_find_chain.py``'s established pattern.
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.services.chain_manager import ChainManager
+from reyn.runtime.services.snapshot_journal import SnapshotJournal
+
+
+class _NullEvents:
+    def emit(self, *_args, **_kwargs) -> None:
+        pass
+
+
+def _make_manager(tmp_path: Path) -> ChainManager:
+    log = StateLog(tmp_path / "wal.jsonl")
+    journal = SnapshotJournal(
+        agent_name="alpha", snapshot_path=tmp_path / "snap.json", state_log=log,
+    )
+    return ChainManager(
+        journal=journal, events=_NullEvents(), chain_timeout_seconds=0, max_hop_depth=10,
+    )
+
+
+# ── acceptance condition ①: one settle function, kind-agnostic signature ───
+
+
+def test_settle_signature_names_no_pipeline_or_run_id():
+    """Tier 1: the settle-path acceptance condition itself, grep-checkable
+    at the type level — ``ChainManager.settle`` takes no parameter literally
+    named ``pipeline`` or ``run_id`` (the generic ``chain_id`` is reused,
+    same as every other ChainManager method), so P6 can point
+    ``delegate_to_agent``'s own completion at this SAME function without a
+    signature change. (``launch_pipeline`` — the disposition-execution
+    callback for the "<pipeline name>" case, D4 — is exempt by design: the
+    condition bars a pipeline-RUN-SPECIFIC argument like a raw ``pipeline``
+    definition object or a ``run_id`` string, not the word "pipeline"
+    appearing anywhere, since "<pipeline name>" is itself a generic
+    disposition any task kind can choose.)"""
+    params = set(inspect.signature(ChainManager.settle).parameters)
+    assert "pipeline" not in params
+    assert "run_id" not in params
+
+
+# ── on_settle dispatch ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_settle_deliver_runs_the_deliver_callback(tmp_path: Path):
+    """Tier 2: on_settle="deliver" awaits the caller's own deliver callback."""
+    mgr = _make_manager(tmp_path)
+    await mgr.register(
+        chain_id="run-1", from_user=False, depth=0, original_text="p", sender=None,
+    )
+    calls = []
+
+    async def _deliver() -> None:
+        calls.append("delivered")
+
+    await mgr.settle("run-1", on_settle="deliver", deliver=_deliver)
+    assert calls == ["delivered"]
+
+
+@pytest.mark.asyncio
+async def test_settle_drop_never_calls_deliver(tmp_path: Path):
+    """Tier 2: on_settle="drop" is a no-op disposition — deliver is never
+    called (ADR-0040 D4: the disposition is intentionally discarded)."""
+    mgr = _make_manager(tmp_path)
+    await mgr.register(
+        chain_id="run-2", from_user=False, depth=0, original_text="p", sender=None,
+    )
+    calls = []
+
+    async def _deliver() -> None:
+        calls.append("delivered")
+
+    await mgr.settle("run-2", on_settle="drop", deliver=_deliver)
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_settle_pipeline_name_without_launcher_raises_not_implemented(
+    tmp_path: Path,
+):
+    """Tier 2: an on_settle value that isn't "deliver"/"drop" is a pipeline
+    NAME (ADR-0040 D4) — without a ``launch_pipeline`` callback this fails
+    LOUD (NotImplementedError), not as a silent no-op, since the actual
+    launch-and-reroute mechanism is still unbuilt (proposal 0067 P4/P7)."""
+    mgr = _make_manager(tmp_path)
+    await mgr.register(
+        chain_id="run-3", from_user=False, depth=0, original_text="p", sender=None,
+    )
+
+    async def _deliver() -> None:
+        pass
+
+    with pytest.raises(NotImplementedError):
+        await mgr.settle("run-3", on_settle="filter_pipeline", deliver=_deliver)
+
+
+@pytest.mark.asyncio
+async def test_settle_pipeline_name_with_launcher_calls_it_with_the_name(
+    tmp_path: Path,
+):
+    """Tier 2: accept-side sibling — a caller that DOES pass
+    ``launch_pipeline`` gets it invoked with the on_settle value (the
+    pipeline name), not ``deliver``."""
+    mgr = _make_manager(tmp_path)
+    await mgr.register(
+        chain_id="run-4", from_user=False, depth=0, original_text="p", sender=None,
+    )
+    launched = []
+
+    async def _deliver() -> None:
+        raise AssertionError("deliver must not run for a pipeline-name disposition")
+
+    async def _launch(name: str) -> None:
+        launched.append(name)
+
+    await mgr.settle(
+        "run-4", on_settle="filter_pipeline", deliver=_deliver, launch_pipeline=_launch,
+    )
+    assert launched == ["filter_pipeline"]
+
+
+# ── immediate deletion, same function as the disposition ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_settle_pops_the_handle_in_the_same_call(tmp_path: Path):
+    """Tier 2: ADR-0040 D4 "immediate deletion" — after settle() returns,
+    the handle is gone from the manager (mirrors resolve()'s pop)."""
+    mgr = _make_manager(tmp_path)
+    await mgr.register(
+        chain_id="run-5", from_user=False, depth=0, original_text="p", sender=None,
+    )
+    assert mgr.has("run-5")
+
+    async def _deliver() -> None:
+        pass
+
+    await mgr.settle("run-5", on_settle="deliver", deliver=_deliver)
+
+    assert not mgr.has("run-5")
+    assert mgr.find_chain("run-5") is None
+
+
+@pytest.mark.asyncio
+async def test_settle_returns_the_popped_handle(tmp_path: Path):
+    """Tier 2: settle() returns the popped _PendingChain (same as resolve()'s
+    own return contract) — a caller can still read origin_agent/origin_sid
+    off the return value after it's gone from the manager."""
+    mgr = _make_manager(tmp_path)
+    await mgr.register(
+        chain_id="run-6", from_user=False, depth=0, original_text="p", sender=None,
+        origin_agent="worker", origin_sid="s1",
+    )
+
+    async def _deliver() -> None:
+        pass
+
+    popped = await mgr.settle("run-6", on_settle="deliver", deliver=_deliver)
+
+    assert popped is not None
+    assert popped.origin_agent == "worker"
+    assert popped.origin_sid == "s1"
+
+
+@pytest.mark.asyncio
+async def test_settle_tolerates_a_missing_handle(tmp_path: Path):
+    """Tier 2: settle() on an unregistered chain_id still executes the
+    disposition (mirrors resolve()'s ``pop(id, None)`` — no error on a
+    missing entry) — a pre-existing run from before this mechanism landed
+    must not crash at settle."""
+    mgr = _make_manager(tmp_path)
+    calls = []
+
+    async def _deliver() -> None:
+        calls.append("delivered")
+
+    popped = await mgr.settle("never-registered", on_settle="deliver", deliver=_deliver)
+
+    assert popped is None
+    assert calls == ["delivered"]


### PR DESCRIPTION
**[tui-coder]** — proposal 0067, the settle path (on_settle execution + immediate handle deletion).

## Why this PR exists

CP2 was initially judged "P3 landed → continue", then retracted: P3 only landed the `task_settled` hook-point declaration/schema/producer, not the settle path itself (`on_settle` execution, immediate handle deletion) — a distinction the PR title ("the task_settled builtin hook point") already made correctly; the CP judgment had collapsed two things into one step. This PR is that next, previously-uncounted step.

## What landed

- **`ChainManager.settle()`** — a single, kind-agnostic function: executes the `on_settle` disposition (`deliver` / `drop` / `<pipeline name>`), then pops the handle in the SAME function (mirrors `resolve()`'s existing shape). No `pipeline`/`run_id` param — acceptance condition, so P6 can point `delegate_to_agent`'s own completion at this same function later.
- **`pending_chains` as the handle substrate** — `_spawn_pipeline_driver_session` now registers a handle on the reply session's own `ChainManager` at launch (async path only). Measured before implementing (architect's ask, via lead-coder): today's `run_pipeline_async` registers **no handle at all** — "the result arrives as a NEW turn trigger" — so this PR is what creates the thing that gets deleted, not just adding deletion to something pre-existing.
- **`on_settle` 3-value dispatch** — new `PipelineWorkOrder.on_settle: str = "deliver"` field (byte-identical default; no LLM-facing param exposes anything else yet — P7's job).
- **`task_settled` decouples from delivery success** — ADR-0040 D4④, architect ruling "B" (routed to architect rather than decided by me or lead-coder unilaterally, since it reverses a behavior I'd already shipped in #4087). Decisive reason: a Composer's `all` combinator waiting on N tasks would never fire if one task's `on_settle="drop"` (or a delivery fail-safe) meant that task's `task_settled` never fired.
- **P3's own strip-falsify pair rewritten, same PR** — the 2 tests I shipped in #4087 asserted the opposite of the above; both rewritten to assert `task_settled` DOES fire on both fail-safe branches, plus a new accept-side sibling pinning the one case where it must NOT fire (sync attached path). Falsify-verified in both directions.
- **Doc fix, same PR** — `docs/concepts/runtime/hooks.md`'s `task_settled` section (merged in #4088, moments before this PR) described the pre-settle-path, delivery-gated behavior; updated here per CLAUDE.md's doc-freshness rule.

## Tests

- `tests/runtime/test_chain_manager_settle_3978.py` (new, 8 tests): acceptance-condition signature check, on_settle 3-way dispatch, immediate deletion, return value, missing-handle tolerance.
- `tests/core/test_pipeline_is2_driver_session.py`: existing e2e delivery test extended with handle-registered→handle-gone witnesses (falsify-verified both directions: registration disabled → red; deletion disabled → red, both reverted). The 2 P3 strip-falsify tests rewritten + 1 new accept-side test added.

All real collaborators throughout — no mocks.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 27/27 OK
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (209/213 baselined)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/hooks/ tests/core/test_pipeline_is2_driver_session.py tests/runtime/` — 354 passed (10 pre-existing unrelated failures on `main` too — Textual theme-registration env issue, confirmed via `git stash` before this diff)
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean (only pre-existing ja-mirror INFO gaps)
- [x] Falsify-verified: `ChainManager.settle()`'s dispatch/deletion (2 directions), the 2 rewritten strip-falsify tests (2 directions)
- [ ] Visual — n/a (no TUI-visible change)

## Known judgment call, flagged for review

`launch_pipeline` (the `"<pipeline name>"` disposition's callback parameter name) contains the substring "pipeline", which the acceptance-condition test checks by exact-name rather than substring match — documented in that test's own docstring. If this reads as too permissive, happy to rename to something more generic (e.g. `launch_definition`).

part of #3978

🤖 Generated with [Claude Code](https://claude.com/claude-code)
