### PR TITLE
feat(#3978): P1 — extract InboxArbiter, fix reply_to staleness, rekey agent_locks to (agent, sid)

### DIFF
--- a/scripts/mypy_ratchet_baseline.json
+++ b/scripts/mypy_ratchet_baseline.json
@@ -612,6 +612,10 @@
     "code": "attr-defined"
   },
   {
+    "file": "src/reyn/runtime/inbox_arbiter.py",
+    "code": "arg-type"
+  },
+  {
     "file": "src/reyn/runtime/lifecycle_forwarder.py",
     "code": "arg-type"
   },

--- a/src/reyn/mcp/server.py
+++ b/src/reyn/mcp/server.py
@@ -244,9 +244,12 @@ async def send_to_agent_impl(
     chain_id = new_chain_id()
     req_id = f"mcp-{chain_id}"
 
-    # Serialize concurrent calls to the same agent — the lock keeps
-    # baseline → MessageBus.request → history-read atomic per agent.
-    async with _get_agent_lock(agent_name):
+    # Serialize concurrent calls to the same (agent, sid) session — the lock
+    # keeps baseline → MessageBus.request → history-read atomic per session
+    # (proposal 0067 P1, #3978: rekeyed from agent_name alone — this lock
+    # protects THIS session's history, and an agent can have more than one
+    # live session; see agent_locks.py's own docstring).
+    async with _get_agent_lock(agent_name, sid):
         baseline = len(session.history)
         bus = MessageBus()
         # issue #268 Phase 2: when the override exposes a stable

--- a/src/reyn/runtime/agent_locks.py
+++ b/src/reyn/runtime/agent_locks.py
@@ -1,22 +1,39 @@
-"""Per-agent serialization lock registry — shared by ALL transport layers.
+"""Per-session serialization lock registry — shared by ALL transport layers.
 
 MCP (``reyn.mcp.server``) and A2A (``reyn.interfaces.web.routers.a2a``) both drive
 ``Session.run_one_iteration`` for the same shared session instance. Without
 cross-transport coordination a concurrent MCP request and an A2A drain loop on
-the same agent race at every ``await`` inside ``run_one_iteration``, corrupting
+the same session race at every ``await`` inside ``run_one_iteration``, corrupting
 ``session.history`` (both callers mutate it concurrently).
 
 The fix: every transport that drives ``run_one_iteration`` acquires the same
-per-agent ``asyncio.Lock`` before entering the critical section.
+per-session ``asyncio.Lock`` before entering the critical section.
 
 This module is the single registry for those locks.  Both ``mcp_server`` and
 ``a2a`` import ``get_agent_lock`` from here; on a given event loop they therefore
-share the same lock object for any given agent name.
+share the same lock object for any given (agent, sid) pair.
 
 Design constraints:
-- The lock is keyed by the *agent name string* — the same identity used by
-  ``AgentRegistry.get_or_load``.  Transport callers must use the canonical
-  name (not a URL slug or alias) so the key matches.
+- **Keyed by (agent_name, sid), not agent_name alone (proposal 0067 P1,
+  #3978 — architect A-2 axis-mismatch finding).** What this lock actually
+  protects is ``session.history`` — a property of ONE Session instance, not
+  of an agent name. An agent can have more than one live session
+  (``AgentRegistry.get_session(name, sid)`` — e.g. a per-delegation
+  ``a2a:<id>`` session alongside "main", see ``mcp.server._get_session``);
+  keying by agent name alone made every sid for the same agent share ONE
+  lock, serializing sessions that share no state and never race each
+  other — an over-broad lock, not an incorrect one, but a real axis
+  mismatch against what the docstring above claims it protects. ``sid``
+  follows ``AgentRegistry``'s own convention: ``None``/absent means the
+  agent's "main" session — the two are treated as the SAME key (canonicalized
+  to the literal string ``"main"`` below) so a bare
+  ``get_agent_lock(agent_name)`` call still serializes against an explicit
+  ``get_agent_lock(agent_name, "main")`` call for the same agent, exactly as
+  it always did for callers that never pass a sid.
+- The lock is keyed by the *agent name string* plus the *session id string* —
+  the same identity used by ``AgentRegistry.get_or_load`` /
+  ``AgentRegistry.get_session``.  Transport callers must use the canonical
+  agent name (not a URL slug or alias) so the key matches.
 - ``asyncio.Lock`` is not thread-safe, but Reyn runs on a single asyncio
   event loop, so this is fine.
 - **Loop-aware keying (#1762).** An ``asyncio.Lock`` binds to the event loop it
@@ -36,36 +53,48 @@ from __future__ import annotations
 import asyncio
 import weakref
 
-# Per-running-loop registries of per-agent locks (#1762). Keyed by the event loop
-# so each loop gets distinct lock objects (an asyncio.Lock is bound to the loop it
-# is awaited on). WeakKeyDictionary → a dead loop's locks are GC'd with it.
-# Callers must NOT mutate this directly; use ``get_agent_lock`` only.
-_LOCKS_BY_LOOP: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[str, asyncio.Lock]]" = (
+# Per-running-loop registries of per-(agent, sid) locks (#1762). Keyed by the
+# event loop so each loop gets distinct lock objects (an asyncio.Lock is bound
+# to the loop it is awaited on). WeakKeyDictionary → a dead loop's locks are
+# GC'd with it. Callers must NOT mutate this directly; use ``get_agent_lock``
+# only. Key type is ``tuple[str, str]`` — (agent_name, sid), sid canonicalized
+# to "main" for the absent/None case (proposal 0067 P1, #3978).
+_LOCKS_BY_LOOP: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[tuple[str, str], asyncio.Lock]]" = (
     weakref.WeakKeyDictionary()
 )
 
 
-def get_agent_lock(agent_name: str) -> asyncio.Lock:
-    """Return the per-agent ``asyncio.Lock`` for *agent_name* on the running loop.
+def get_agent_lock(agent_name: str, sid: "str | None" = None) -> asyncio.Lock:
+    """Return the per-(agent, sid) ``asyncio.Lock`` on the running loop.
 
     Must be called from within a running event loop — every transport driver
     acquires the lock inside its ``async with`` critical section, so a running
     loop is always present at the call site.
 
-    Identity guarantee: repeated calls with the same name **on the same loop**
-    return the **same** ``asyncio.Lock`` object; different names yield distinct
-    objects. Different loops yield distinct objects by design — an
-    ``asyncio.Lock`` is bound to the loop it is awaited on, so cross-loop reuse
-    would raise ``"bound to a different event loop"`` (#1762). Production runs on
-    a single loop, so this is transparent there.
+    ``sid``: the session id, same convention as ``AgentRegistry.get_session`` /
+    ``mcp.server._get_session`` — ``None`` or omitted means the agent's "main"
+    session, canonicalized to the literal key ``"main"`` here so it matches an
+    explicit ``sid="main"`` caller.
+
+    Identity guarantee: repeated calls with the same ``(agent_name, sid)``
+    **on the same loop** return the **same** ``asyncio.Lock`` object;
+    different pairs yield distinct objects — including two different sids for
+    the SAME agent, which now serialize independently instead of sharing one
+    lock (the axis-mismatch fix: this lock protects one Session's
+    ``history``, not everything sharing an agent name). Different loops yield
+    distinct objects by design — an ``asyncio.Lock`` is bound to the loop it
+    is awaited on, so cross-loop reuse would raise ``"bound to a different
+    event loop"`` (#1762). Production runs on a single loop, so this is
+    transparent there.
 
     Thread-safety: NOT thread-safe (``dict.setdefault`` is not atomic across
     threads), but Reyn is single-threaded asyncio — concurrent coroutines on the
     same loop are safe because the GIL serializes the ``setdefault`` call.
     """
+    key = (agent_name, sid or "main")
     loop = asyncio.get_running_loop()
     per_loop = _LOCKS_BY_LOOP.get(loop)
     if per_loop is None:
         per_loop = {}
         _LOCKS_BY_LOOP[loop] = per_loop
-    return per_loop.setdefault(agent_name, asyncio.Lock())
+    return per_loop.setdefault(key, asyncio.Lock())

--- a/src/reyn/runtime/inbox_arbiter.py
+++ b/src/reyn/runtime/inbox_arbiter.py
@@ -1,0 +1,409 @@
+"""InboxArbiter — owns the inbox drain / dispatch-attribution state cluster
+extracted from Session (proposal 0067 P1, #3978).
+
+Before this extraction, four pieces of state (`_pending_inbox_item`,
+`_cancelled_msg_ids`, `_next_turn_context`, `_last_sender`/`_last_reply_to`)
+and the methods that read/write them (`_consume_inbox`,
+`_peek_mid_turn_injection`, `_drain_to_wake`, `_stage_next_turn_context`,
+`_handle_sender_attribution`) lived directly on ``Session`` alongside ~40
+unrelated fields — one more example of the field-usage cluster the
+`refactoring` skill's Extract Class step targets: these methods touch each
+other's state and nothing else Session owns (external deps are threaded in
+at construction, see below).
+
+Byte-identical extraction where the prior inline body allowed it
+(`consume_inbox`, `peek_mid_turn_injection`, `stage_next_turn_context`,
+`drain_to_wake`) — moved, not rewritten. `handle_sender_attribution` is the
+one exception: extraction is also where the reply_to staleness bug (see its
+own docstring) is closed, since fixing it required threading `kind` through
+to the attribution call, a signature change that only makes sense to make
+once, at the same time as the move.
+
+`Session` still owns `_commit_mid_turn_injection`, `cancel_queued`,
+`restore_state`, `reset_for_rewind`, and the ``_next_turn_context`` flush in
+``_run_router_loop`` — each of those reaches into this arbiter's public
+attributes (`pending_inbox_item` / `cancelled_msg_ids` / `next_turn_context`)
+rather than owning a private copy, keeping exactly one holder of each field.
+Those methods were not named in the P1 dispatch and have responsibilities
+(recovery, cancellation-API, router-turn bookkeeping) wider than "inbox
+arbitration" — moving them too would widen this class past its own name.
+
+External dependencies are injected as plain callables/objects at
+construction (the same "real instance + plain stub callbacks" shape
+``InterAgentMessaging`` already uses) rather than a back-reference to
+``Session``, so a test can construct this class with hand-written stubs
+without a full ``Session``.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any, Callable
+
+from reyn.runtime.turn_origin import TurnOrigin
+
+if TYPE_CHECKING:
+    from reyn.runtime.services.snapshot_journal import SnapshotJournal
+
+
+# FP-0041 (#489) PR-A: humanic dispatch attribution helper — moved from
+# ``session.py`` verbatim (byte-identical relocation, see module docstring).
+#
+# Sender envelope strings follow ``<transport>:<id>[:<display>]``. This
+# helper produces a human-readable label for inclusion in state_change
+# summaries so the LLM sees "bob (Slack)" instead of "slack:U456:bob".
+# Unknown / malformed senders fall through to the raw string.
+_SENDER_TRANSPORT_DISPLAY = {
+    "user":     "user",
+    "slack":    "Slack",
+    "line":     "LINE",
+    "cron":     "scheduled cron job",
+    "a2a":      "peer agent",
+    "webhook":  "external webhook",
+}
+
+
+def _format_sender_label(sender: "str | None") -> str:
+    """Format a sender envelope string for LLM-visible state_change text.
+
+    Examples
+    --------
+    ``"slack:U456:bob"`` → ``"bob (Slack)"``
+    ``"slack:U456"`` → ``"slack user U456"``
+    ``"cron:morning_news"`` → ``"scheduled cron job 'morning_news'"``
+    ``"user:tui"`` → ``"user (TUI)"``
+    ``"a2a:news_agent"`` → ``"peer agent 'news_agent'"``
+    ``None`` → ``"an unknown sender"`` (= used in first-turn pre-state)
+
+    Falls through to the raw string when the transport is not in the
+    known list — keeps the dispatch resilient to new sources added by
+    future PRs without label updates here.
+    """
+    if sender is None:
+        return "an unknown sender"
+    parts = sender.split(":", 2)
+    if not parts or not parts[0]:
+        return sender
+    transport = parts[0]
+    rest = parts[1:] if len(parts) > 1 else []
+    transport_label = _SENDER_TRANSPORT_DISPLAY.get(transport)
+    if transport_label is None:
+        return sender
+    if transport == "user":
+        surface = rest[0].upper() if rest else ""
+        return f"user ({surface})" if surface else "user"
+    if transport == "slack" or transport == "line":
+        if len(rest) >= 2 and rest[1]:
+            return f"{rest[1]} ({transport_label})"
+        if len(rest) >= 1 and rest[0]:
+            return f"{transport_label.lower()} user {rest[0]}"
+        return transport_label
+    if transport == "cron":
+        if rest and rest[0]:
+            return f"{transport_label} '{rest[0]}'"
+        return transport_label
+    if transport == "a2a":
+        if rest and rest[0]:
+            return f"{transport_label} '{rest[0]}'"
+        return transport_label
+    if transport == "webhook":
+        if rest and rest[0]:
+            return f"{transport_label} ({rest[0]})"
+        return transport_label
+    return sender
+
+
+class InboxArbiter:
+    """Owns inbox-drain + dispatch-attribution state for one Session.
+
+    Constructed once per Session, alongside its journal. All journal /
+    history / audit side effects are injected as callables so this class
+    has no back-reference to Session.
+    """
+
+    def __init__(
+        self,
+        *,
+        inbox: "asyncio.Queue",
+        journal: "SnapshotJournal",
+        notify_state_change: "Callable[..., None]",
+    ) -> None:
+        self._inbox = inbox
+        self._journal = journal
+        self._notify_state_change = notify_state_change
+
+        # #3792: a 1-slot, volatile (not WAL/snapshot-backed) peek buffer —
+        # see ``peek_mid_turn_injection``'s own docstring.
+        self.pending_inbox_item: "tuple[str, dict] | None" = None
+        # #3300 P3 (Y-server): msg_ids cancelled via ``Session.cancel_queued``
+        # while still sitting in the (durable) ``asyncio.Queue`` — see
+        # ``consume_inbox``/``drain_to_wake``.
+        self.cancelled_msg_ids: "set[str]" = set()
+        # In-memory staging for wake=false ride-along messages, durably
+        # persisted in the snapshot (#1800 slice 4b).
+        self.next_turn_context: "list[dict]" = []
+        # Sender of the most-recently-dispatched inbox item, for
+        # sender-transition state_change entries (FP-0041 #489 PR-A).
+        self.last_sender: "str | None" = None
+        # Reply-to attribution captured from an inbound payload's reply_to
+        # (FP-0041 #489 PR-D2).
+        self.last_reply_to: Any = None
+
+    async def consume_inbox(self) -> "tuple[str, dict] | None":
+        """Wait for next inbox message; on receive, record `inbox_consume`
+        via journal (skipped for shutdown signals which are out-of-band).
+
+        #3300 P3 (Y-server) skip-at-consume: if the dequeued item's msg_id was
+        already cancelled (``Session.cancel_queued`` — its snapshot.inbox entry
+        + WAL ``inbox_cancel`` tombstone were already recorded synchronously at
+        cancel time), this discards the physical ``asyncio.Queue`` entry
+        WITHOUT recording a redundant ``inbox_consume`` (the item is already
+        gone from the snapshot) and returns ``None`` — the caller
+        (``drain_to_wake``) must treat this as "nothing dequeued yet" and
+        loop again, never dispatching a turn for a cancelled item.
+
+        #3792: reads ``self.pending_inbox_item`` FIRST, ahead of a fresh
+        ``self._inbox.get()``. An item can land there via
+        ``peek_mid_turn_injection`` — either because the running turn ended
+        (cancel / cap / overflow / LLM exception) before
+        ``Session._commit_mid_turn_injection`` ever fired (carry-forward: the
+        item is simply processed as an ordinary new turn here, exactly as if
+        the peek had never happened), or because the peeked head was an
+        INELIGIBLE origin (peek deliberately leaves it there rather than
+        skipping past it — see that method). Checking here first is what
+        makes both cases land correctly instead of being stranded behind a
+        ``self._inbox.get()`` that would never see them again.
+        """
+        if self.pending_inbox_item is not None:
+            kind, payload = self.pending_inbox_item
+            self.pending_inbox_item = None
+        else:
+            kind, payload = await self._inbox.get()
+        msg_id = payload.get("_msg_id") if isinstance(payload, dict) else None
+        if kind != "shutdown" and msg_id in self.cancelled_msg_ids:
+            self.cancelled_msg_ids.discard(msg_id)
+            return None
+        if kind != "shutdown":
+            await self._journal.consume_inbox(msg_id=msg_id)
+        return kind, payload
+
+    async def peek_mid_turn_injection(self) -> "dict | None":
+        """#3792: non-blocking, non-committing peek at the inbox head for a
+        mid-turn ``CLIENT_INPUT`` injection candidate.
+
+        Returns ``{"payload": dict, "msg_id": str}`` when the head is an
+        eligible, uncancelled ``CLIENT_INPUT`` message; ``None`` otherwise
+        (empty queue, or an ineligible-origin head).
+
+        Does NOT commit — ``self._journal``/``snapshot.inbox`` (the SSoT)
+        is untouched either way. The dequeued item (if any) is held in
+        ``self.pending_inbox_item`` so it is never lost: an eligible
+        candidate stays there until ``Session._commit_mid_turn_injection``
+        actually commits it (the caller must have spliced it into the wire
+        first — see ``RouterLoop.run_loop``'s seam); an ineligible-origin
+        head also stays there, UNCONSUMED, so the ordinary turn-boundary
+        ``consume_inbox`` picks it up next, in arrival order — a queue
+        whose head is ineligible STOPS here rather than skipping ahead
+        (#3792 design: skipping would silently reorder arrival, and that
+        reordering would leave no trace anywhere).
+
+        A CANCELLED head (``Session.cancel_queued`` already pruned it from
+        the snapshot) is the one case this DOES discard outright — mirrors
+        ``consume_inbox``'s own skip-at-consume handling, since a cancelled
+        item was never going to be eligible for anything.
+        """
+        while True:
+            if self.pending_inbox_item is None:
+                try:
+                    self.pending_inbox_item = self._inbox.get_nowait()
+                except asyncio.QueueEmpty:
+                    return None
+            kind, payload = self.pending_inbox_item
+            msg_id = payload.get("_msg_id") if isinstance(payload, dict) else None
+            if kind != "shutdown" and msg_id in self.cancelled_msg_ids:
+                self.cancelled_msg_ids.discard(msg_id)
+                self.pending_inbox_item = None
+                continue
+            if kind != TurnOrigin.CLIENT_INPUT:
+                return None
+            return {"payload": payload, "msg_id": msg_id}
+
+    async def stage_next_turn_context(self, kind: str, payload: dict) -> None:
+        """Stage a wake=false ride-along (C) into next-turn context, durably
+        (B=persist): append to the in-memory buffer + record the WAL/snapshot
+        entry. Shared by ``drain_to_wake`` (inbox ride-alongs) and the
+        ``HookDispatcher`` (#1800 slice 5b — direct C-staging that bypasses the
+        inbox). Byte-behavior-identical extraction of the prior inline pair."""
+        self.next_turn_context.append({"kind": kind, "payload": payload})
+        await self._journal.record_next_turn_context_staged(kind=kind, payload=payload)
+
+    async def drain_to_wake(
+        self,
+    ) -> "tuple[list[tuple[str, dict]], tuple[str, dict]] | tuple[None, None]":
+        """Drain the inbox up to and including the first ``wake=true`` message.
+
+        Each inbox payload carries an optional ``wake`` bool (default ``True``
+        when absent).  Every producer but the hook dispatcher (``TurnOrigin``'s
+        other members) never sets ``wake``; the absent-means-True default makes them
+        all behaviorally identical to wake=true, so the common/back-compat
+        path returns immediately after the first blocking get with no
+        ride-alongs.
+
+        Returns ``(ride_alongs, trigger)`` where:
+
+        - ``ride_alongs``  — list of ``(kind, payload)`` tuples for every
+          ``wake=false`` message drained before the trigger.  Staged for the
+          next turn as context (slice 4b).  Empty in the common case.
+        - ``trigger``      — the first ``wake=true`` (or absent-wake) message;
+          this drives the turn.
+
+        Special case: if the first blocking get yields ``shutdown``, returns
+        ``(None, None)`` so the caller can signal loop exit.
+
+        Decision A (RESOLVED, issuecomment-4773744053): if the queue empties
+        while holding only ``wake=false`` ride-alongs (no trigger yet),
+        re-enter the blocking wait.  Ride-alongs NEVER trigger a turn alone.
+
+        Per-message ``inbox_consume`` is recorded via ``consume_inbox`` for
+        EACH drained message (ride-alongs and the trigger alike), so the
+        snapshot stays correct on crash+restore.
+        """
+        ride_alongs: "list[tuple[str, dict]]" = []
+
+        while True:
+            # (a) Blocking wait — preserves the idle-sleep property exactly
+            # as the previous single-get path did.  Also records
+            # inbox_consume via _consume_inbox (journaled, P6-clean).
+            # #3300 P3 (Y-server): `None` means the dequeued item was
+            # cancelled (skip-at-consume) — loop again without treating it
+            # as a trigger or ride-along.
+            step = await self.consume_inbox()
+            if step is None:
+                continue
+            kind0, p0 = step
+
+            # (b) Shutdown sentinel: propagate immediately regardless of any
+            # already-accumulated ride-alongs.
+            if kind0 == "shutdown":
+                return None, None
+
+            # (c) wake=true (or absent → default True): this is the trigger.
+            # Common/back-compat path — returns after the first blocking get
+            # with no ride-alongs.
+            if p0.get("wake", True):
+                return ride_alongs, (kind0, p0)
+
+            # (d) wake=false ride-along: stage durably (B=persist) the
+            # moment it is consumed, BEFORE re-entering the blocking wait
+            # for the trigger.  This closes the gap: without this, a crash
+            # in the blocking wait would lose the consumed-but-not-persisted
+            # ride-along.
+            await self.stage_next_turn_context(kind0, p0)
+            ride_alongs.append((kind0, p0))
+
+            # Non-blocking drain: collect additional wake=false messages until
+            # either a wake=true trigger arrives or the queue is momentarily
+            # empty (Decision A: re-enter the blocking wait in that case).
+            while True:
+                try:
+                    kind_nb, p_nb = self._inbox.get_nowait()
+                except asyncio.QueueEmpty:
+                    # Queue empty, no trigger yet — re-enter outer blocking
+                    # wait (Decision A).
+                    break
+
+                msg_id_nb = (
+                    p_nb.get("_msg_id") if isinstance(p_nb, dict) else None
+                )
+                # #3300 P3 (Y-server) skip-at-consume: same discard as the
+                # blocking path above — a cancelled item is never dispatched
+                # and never gets a redundant inbox_consume.
+                if kind_nb != "shutdown" and msg_id_nb in self.cancelled_msg_ids:
+                    self.cancelled_msg_ids.discard(msg_id_nb)
+                    continue
+                if kind_nb != "shutdown":
+                    await self._journal.consume_inbox(msg_id=msg_id_nb)
+
+                if kind_nb == "shutdown":
+                    return None, None
+
+                if p_nb.get("wake", True):
+                    return ride_alongs, (kind_nb, p_nb)
+
+                # wake=false via non-blocking path: stage durably before
+                # accumulating (same B=persist guarantee as the outer path).
+                await self.stage_next_turn_context(kind_nb, p_nb)
+                ride_alongs.append((kind_nb, p_nb))
+
+    def handle_sender_attribution(self, payload: object) -> None:
+        """Surface a sender transition to the LLM as a state_change entry
+        (= FP-0041 (#489) PR-A humanic dispatch attribution).
+
+        When the sender of an inbox item differs from the prior turn's
+        sender, emit a state_change history entry so the LLM reads
+        "[context shift] Now responding to <X> via <transport>.
+        Previous turn was from <Y>." before processing the new turn.
+        Without this, merged-inbox multi-consumer dispatch produces a
+        confused linear feed where the LLM can't tell who's talking.
+
+        ``sender`` convention (= envelope shape):
+          - ``user:tui`` / ``user:web`` / ``user:cli`` — local human user
+          - ``slack:<user_id>[:<display_name>]`` — Slack consumer
+          - ``line:<user_id>[:<display_name>]`` — LINE consumer
+          - ``cron:<job_name>`` — scheduled fire
+          - ``a2a:<peer_agent>`` — peer-agent message
+          - ``webhook:<source>`` — external event source (= Phase 2)
+
+        Payloads without a ``sender`` field are dispatched unchanged
+        (= backward compat for existing inbox producers that haven't
+        adopted the convention yet). No state_change is emitted in
+        that case; ``self.last_sender`` is unchanged.
+
+        FP-0041 #489 PR-D2 originally captured ``reply_to`` from the payload
+        ONLY when present, preserving the previous value otherwise, on the
+        stated theory that a missing ``reply_to`` "falls through to the
+        default surface" downstream. #3978 P1 co-vet (architect + lead-coder,
+        two independently-run verifications converging on the same finding)
+        established that theory was never true: ``Session._put_outbox`` /
+        ``_put_outbox_nowait`` both default a message's ``reply_to`` from
+        ``last_reply_to`` BEFORE the external-transport interceptor ever
+        runs, so a preserved stale value IS delivered, not bypassed — a
+        CRON/HOOK/AGENT_STEP/PIPELINE_RESULT turn (none of which ever carry
+        ``reply_to`` — verified against every inbox-payload-constructing
+        call site in ``src/reyn/``) running after a Slack/webhook-originated
+        turn inherited and misdelivered to that turn's transport. No
+        producer relies on the omission meaning "keep inheriting" (same
+        sweep); the two producers that ever set ``reply_to`` at all
+        (``gateway.api``'s webhook dispatch, ``interfaces.web.server``'s
+        cron notify) each resend it on every payload that wants it, and the
+        cron path's own comment already documents the intended fallback:
+        "No notify → no reply_to → interceptor falls through → event-log
+        only (current behaviour)". The fix below makes that the ACTUAL
+        behavior instead of an aspirational comment: ``reply_to`` is always
+        taken from THIS payload, never inherited from the last one.
+        """
+        if not isinstance(payload, dict):
+            return
+        self.last_reply_to = payload.get("reply_to")
+        new_sender = payload.get("sender")
+        if not new_sender or not isinstance(new_sender, str):
+            return
+        if new_sender == self.last_sender:
+            return
+        prev_label = _format_sender_label(self.last_sender)
+        new_label = _format_sender_label(new_sender)
+        if self.last_sender is None:
+            summary = (
+                f"[context shift] Now responding to {new_label}. "
+                f"This is the first attributed turn this session."
+            )
+        else:
+            summary = (
+                f"[context shift] Now responding to {new_label}. "
+                f"Previous turn was from {prev_label}."
+            )
+        try:
+            self._notify_state_change(summary, source="dispatch_attribution")
+        except Exception:
+            # Defensive: attribution emission must not crash dispatch.
+            pass
+        self.last_sender = new_sender

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -60,6 +60,7 @@ from reyn.runtime.chat_message import (  # #312 C1: extracted VO + helpers
 )
 from reyn.runtime.error_format import classify_router_error
 from reyn.runtime.errors import AgentStepError, RouterCapExceeded, StructuredOutputError
+from reyn.runtime.inbox_arbiter import InboxArbiter
 from reyn.runtime.limits.limit_handler import (
     LimitDecision,
     handle_limit_exceeded,
@@ -313,70 +314,10 @@ def _extract_tool_call_records(
     return out
 
 
-# FP-0041 (#489) PR-A: humanic dispatch attribution helper.
-#
-# Sender envelope strings follow ``<transport>:<id>[:<display>]``. This
-# helper produces a human-readable label for inclusion in state_change
-# summaries so the LLM sees "bob (Slack)" instead of "slack:U456:bob".
-# Unknown / malformed senders fall through to the raw string.
-_SENDER_TRANSPORT_DISPLAY = {
-    "user":     "user",
-    "slack":    "Slack",
-    "line":     "LINE",
-    "cron":     "scheduled cron job",
-    "a2a":      "peer agent",
-    "webhook":  "external webhook",
-}
-
-
-def _format_sender_label(sender: str | None) -> str:
-    """Format a sender envelope string for LLM-visible state_change text.
-
-    Examples
-    --------
-    ``"slack:U456:bob"`` → ``"bob (Slack)"``
-    ``"slack:U456"`` → ``"slack user U456"``
-    ``"cron:morning_news"`` → ``"scheduled cron job 'morning_news'"``
-    ``"user:tui"`` → ``"user (TUI)"``
-    ``"a2a:news_agent"`` → ``"peer agent 'news_agent'"``
-    ``None`` → ``"an unknown sender"`` (= used in first-turn pre-state)
-
-    Falls through to the raw string when the transport is not in the
-    known list — keeps the dispatch resilient to new sources added by
-    future PRs without label updates here.
-    """
-    if sender is None:
-        return "an unknown sender"
-    parts = sender.split(":", 2)
-    if not parts or not parts[0]:
-        return sender
-    transport = parts[0]
-    rest = parts[1:] if len(parts) > 1 else []
-    transport_label = _SENDER_TRANSPORT_DISPLAY.get(transport)
-    if transport_label is None:
-        return sender
-    if transport == "user":
-        surface = rest[0].upper() if rest else ""
-        return f"user ({surface})" if surface else "user"
-    if transport == "slack" or transport == "line":
-        if len(rest) >= 2 and rest[1]:
-            return f"{rest[1]} ({transport_label})"
-        if len(rest) >= 1 and rest[0]:
-            return f"{transport_label.lower()} user {rest[0]}"
-        return transport_label
-    if transport == "cron":
-        if rest and rest[0]:
-            return f"{transport_label} '{rest[0]}'"
-        return transport_label
-    if transport == "a2a":
-        if rest and rest[0]:
-            return f"{transport_label} '{rest[0]}'"
-        return transport_label
-    if transport == "webhook":
-        if rest and rest[0]:
-            return f"{transport_label} ({rest[0]})"
-        return transport_label
-    return sender
+# FP-0041 (#489) PR-A: humanic dispatch attribution helper — moved to
+# ``reyn.runtime.inbox_arbiter`` (proposal 0067 P1, #3978), the only caller
+# (``InboxArbiter.handle_sender_attribution``, née
+# ``Session._handle_sender_attribution``).
 
 
 def _format_config_reloaded(data: dict) -> str:
@@ -1060,16 +1001,9 @@ class Session:
         self._eager_embedding_build = eager_embedding_build
         # agent_id is owned by Agent (identity SSoT); the field + its prior
         # None-fallback default were removed (#3133 P0-follow-up, see docs/reference/runtime/session-construction.md#identity-the-agent-value-object-fp-0043-stage-2).
-        # Sender of the most-recently-dispatched inbox item, for sender-transition state_change entries (FP-0041 #489 PR-A)
-        self._last_sender: str | None = None
-        # Reply-to attribution captured from an inbound payload's reply_to (FP-0041 #489 PR-D2)
-        self._last_reply_to: Any = None
         # Proposal 0067 P0 (#3978): typed home for the present-tense task
-        # state, additive and unread by anything yet — _last_sender /
-        # _last_reply_to above remain the live attribution path until P1
-        # extracts InboxArbiter and migrates onto this field. See
-        # reyn.runtime.task_types.CurrentTask's own docstring for why each
-        # field exists and where it comes from.
+        # state. See reyn.runtime.task_types.CurrentTask's own docstring for
+        # why each field exists and where it comes from.
         self.current_task: "CurrentTask | None" = None
         # Outbox interceptor for external transport (e.g. Slack via MCP); None skips interception (FP-0041 #489 PR-D2)
         self._outbox_interceptor: Any = None
@@ -1156,8 +1090,9 @@ class Session:
         # dequeue leaves no stale Queue entry to skip (a fresh process starts
         # with an empty asyncio.Queue and repopulates it from the recovered
         # snapshot, which already excludes the cancelled item — see
-        # `restore_state`).
-        self._cancelled_msg_ids: "set[str]" = set()
+        # `restore_state`). Owned by ``self._inbox_arbiter`` (proposal 0067
+        # P1, #3978 — InboxArbiter extraction), constructed below once
+        # ``self.inbox`` exists.
         self._turn_owner_task: "asyncio.Task | None" = None  # lets await_quiescent skip its wait when called re-entrantly from the owning task
         # #2242: True only for the window between cancel_inflight() calling
         # `_turn_owner_task.cancel()` and run_one_iteration observing the
@@ -1178,8 +1113,9 @@ class Session:
         self._halted_reason: "str | None" = None  # #2259 PR-3: set on FAIL-STOP, see session-construction.md#family-2-recovery-wal-journal
         # In-memory buffer of restored-then-resolved intervention answers (PR-intervention-link L6, see docs/reference/runtime/session-construction.md#safety-limits-interactive-mode)
         self._buffered_intervention_answers: dict[str, "InterventionAnswer"] = {}
-        # In-memory staging for wake=false ride-along messages, durably persisted in the snapshot (#1800 slice 4b, see session-construction.md#safety-limits-interactive-mode)
-        self._next_turn_context: list[dict] = []
+        # In-memory staging for wake=false ride-along messages, durably
+        # persisted in the snapshot (#1800 slice 4b). Owned by
+        # ``self._inbox_arbiter`` (proposal 0067 P1, #3978).
 
         # HookBus/HookDispatcher/fs_watcher/composers/hot_reloader built together below; the config-derivation feeding them stays inline as builder inputs (#1800 slice 5b / #3082 Family 3, see session-construction.md#family-3-hook-event-reactivity)
         self._startup_hooks_raw: list = hooks_config if isinstance(hooks_config, list) else []
@@ -1229,18 +1165,20 @@ class Session:
 
         self.history: list[ChatMessage] = []
         self.inbox: asyncio.Queue = asyncio.Queue()
-        # #3792: a 1-slot, volatile (not WAL/snapshot-backed) peek buffer.
-        # ``asyncio.Queue`` has no peek/un-get API (see ``_consume_inbox``'s
-        # own docstring on this), so ``peek_mid_turn_injection`` dequeues via
-        # ``get_nowait()`` into THIS slot without telling the journal — the
-        # snapshot-backed SSoT (``self._journal``) stays untouched until
-        # ``commit_mid_turn_injection`` actually commits. ``_consume_inbox``
-        # (the ordinary turn-boundary dequeue) checks this slot FIRST so an
-        # item peeked-but-never-committed (abnormal exit mid-turn, or an
-        # ineligible-origin head the peek deliberately did not act on) is
-        # never stranded or reordered — it surfaces exactly where it would
-        # have if the peek had never happened.
-        self._pending_inbox_item: "tuple[str, dict] | None" = None
+        # Proposal 0067 P1 (#3978): InboxArbiter owns the inbox-drain +
+        # dispatch-attribution state cluster (pending peek buffer,
+        # cancelled-msg-id skip-set, staged wake=false ride-alongs,
+        # last_sender / last_reply_to) — see reyn.runtime.inbox_arbiter's
+        # module docstring for what moved and what stayed here (and why).
+        # ``notify_state_change`` is passed as a bound method reference
+        # (resolved at call time, not at this line — the method is defined
+        # later in this class, same shape callback-injection already uses
+        # elsewhere in Session, e.g. InterAgentMessaging's construction).
+        self._inbox_arbiter = InboxArbiter(
+            inbox=self.inbox,
+            journal=self._journal,
+            notify_state_change=self.notify_state_change,
+        )
         self.outbox: asyncio.Queue = asyncio.Queue()
         # event_store -> audit_events -> outbox_hub (+ opt-in OTEL), byte-identical extraction (#3082 Family 1, see session-construction.md#family-1-audit-event-spine-p6)
         _audit_bundle = self._build_audit_event_bundle(observability_config)
@@ -1870,9 +1808,10 @@ class Session:
         Captured by the sender-attribution path and used by
         ``_put_outbox`` to default the outbox message's ``reply_to``
         when the caller did not supply one. Tests verify the capture
-        + default chain through this surface.
+        + default chain through this surface. Proposal 0067 P1 (#3978):
+        the value itself lives on ``self._inbox_arbiter.last_reply_to``.
         """
-        return self._last_reply_to
+        return self._inbox_arbiter.last_reply_to
 
     @property
     def on_perm_persist_cb(self):
@@ -2474,7 +2413,7 @@ class Session:
             outstanding_interventions      → self._interventions (clear)
                                              + self._restore_intervention_tasks
             buffered_intervention_answers  → self._buffered_intervention_answers
-            next_turn_context              → self._next_turn_context
+            next_turn_context              → self._inbox_arbiter.next_turn_context
             hook_driven_turns              → self._hook_driven_turns (#2884; restore_state's
                                                plain assignment is unconditional, so no
                                                separate clear step is needed here)
@@ -2498,12 +2437,29 @@ class Session:
             self._restore_intervention_tasks = []
         self._buffered_intervention_answers.clear()
         # next_turn_context (#1800-4b)
-        self._next_turn_context.clear()
+        self._inbox_arbiter.next_turn_context.clear()
         # hook_driven_turns (#2884): reset the loop-valve counter mirror. restore_state
         # re-assigns it wholesale from the reconstructed snapshot, but clearing here keeps
         # the zero-residue guarantee robust independent of that assignment.
         self._hook_driven_turns = 0
         self._inflight_wal_tasks.clear()
+        # pending_inbox_item / cancelled_msg_ids / last_sender / last_reply_to
+        # (proposal 0067 P1, #3978 InboxArbiter extraction): the same latent
+        # gap current_task's own comment below names — NONE of these four
+        # were part of AgentSnapshot before this extraction either, and
+        # reset_for_rewind never cleared them (only next_turn_context and
+        # hook_driven_turns were). A genuine process crash was already safe
+        # (fresh Session() defaults win, restore_state never sets them), but
+        # a REWIND reuses the SAME live Session — without this, a peeked
+        # mid-turn item, a stale cancel-skip entry, or a stale sender/
+        # reply_to attribution from BEFORE the rewound point would silently
+        # outlive it. Discovered while moving this state into one holder for
+        # this extraction; fixed here rather than deferred, matching the
+        # current_task precedent immediately below.
+        self._inbox_arbiter.pending_inbox_item = None
+        self._inbox_arbiter.cancelled_msg_ids.clear()
+        self._inbox_arbiter.last_sender = None
+        self._inbox_arbiter.last_reply_to = None
         # current_task (proposal 0067 P1', #3978): NOT part of AgentSnapshot
         # (deliberately volatile, same framing ADR-0040 gives reply_to — "None
         # after crash"), so a genuine process crash is naturally safe: a
@@ -2722,71 +2678,13 @@ class Session:
                 out.append(m)
         return out
 
-    def _handle_sender_attribution(self, payload: object) -> None:
-        """Surface a sender transition to the LLM as a state_change entry
-        (= FP-0041 (#489) PR-A humanic dispatch attribution).
-
-        When the sender of an inbox item differs from the prior turn's
-        sender, emit a state_change history entry so the LLM reads
-        "[context shift] Now responding to <X> via <transport>.
-        Previous turn was from <Y>." before processing the new turn.
-        Without this, merged-inbox multi-consumer dispatch produces a
-        confused linear feed where the LLM can't tell who's talking.
-
-        ``sender`` convention (= envelope shape):
-          - ``user:tui`` / ``user:web`` / ``user:cli`` — local human user
-          - ``slack:<user_id>[:<display_name>]`` — Slack consumer
-          - ``line:<user_id>[:<display_name>]`` — LINE consumer
-          - ``cron:<job_name>`` — scheduled fire
-          - ``a2a:<peer_agent>`` — peer-agent message
-          - ``webhook:<source>`` — external event source (= Phase 2)
-
-        Payloads without a ``sender`` field are dispatched unchanged
-        (= backward compat for existing inbox producers that haven't
-        adopted the convention yet). No state_change is emitted in
-        that case; ``self._last_sender`` is unchanged.
-        """
-        if not isinstance(payload, dict):
-            return
-        # FP-0041 #489 PR-D2: capture reply_to from payload regardless
-        # of sender transition (= even a same-sender follow-up may have
-        # a new reply_to, e.g. different Slack thread). When the payload
-        # doesn't carry reply_to, the previous value is preserved (=
-        # downstream interceptor handles the "no reply_to" case by
-        # falling through to the default surface).
-        reply_to = payload.get("reply_to")
-        if reply_to is not None:
-            self._last_reply_to = reply_to
-        new_sender = payload.get("sender")
-        if not new_sender or not isinstance(new_sender, str):
-            return
-        if new_sender == self._last_sender:
-            return
-        prev_label = _format_sender_label(self._last_sender)
-        new_label = _format_sender_label(new_sender)
-        if self._last_sender is None:
-            summary = (
-                f"[context shift] Now responding to {new_label}. "
-                f"This is the first attributed turn this session."
-            )
-        else:
-            summary = (
-                f"[context shift] Now responding to {new_label}. "
-                f"Previous turn was from {prev_label}."
-            )
-        try:
-            self.notify_state_change(summary, source="dispatch_attribution")
-        except Exception:
-            # Defensive: attribution emission must not crash dispatch.
-            pass
-        self._last_sender = new_sender
-
     def last_sender(self) -> str | None:
         """Return the most-recently-attributed sender label or None if no
         message has been routed yet. Read-only accessor for
-        ``_last_sender`` — write side stays internal to the dispatch
-        attribution path."""
-        return self._last_sender
+        ``InboxArbiter.last_sender`` — write side stays internal to the
+        dispatch attribution path (proposal 0067 P1, #3978: moved onto
+        ``self._inbox_arbiter``, see ``InboxArbiter.handle_sender_attribution``)."""
+        return self._inbox_arbiter.last_sender
 
     def _on_audit_event_for_state_change(self, event) -> None:
         """Generic events-log subscriber that converts known emitter events
@@ -3528,7 +3426,7 @@ class Session:
         hook_dispatcher = HookDispatcher(
             self._build_hook_registry(boot_in_set),
             put_inbox=self._put_inbox,
-            stage_next_turn_context=self._stage_next_turn_context,
+            stage_next_turn_context=self._inbox_arbiter.stage_next_turn_context,
             # #2072: route a push whose `session` names a different session to THAT session
             # (cross-session); `current_session_id` keeps a self/unnamed push local.
             cross_session_put=self._cross_session_hook_put,
@@ -4046,7 +3944,7 @@ class Session:
             put_outbox_inputs=_put_outbox_inputs,  # #3482
             append_history=self._append_history,
             # #3792: mid-turn CLIENT_INPUT injection.
-            peek_mid_turn_injection=self._peek_mid_turn_injection,
+            peek_mid_turn_injection=self._inbox_arbiter.peek_mid_turn_injection,
             commit_mid_turn_injection=self._commit_mid_turn_injection,
             # Proposal 0067 P1' (#3978)
             mark_task_pending=lambda: setattr(self, "current_task", CurrentTask()),
@@ -5123,90 +5021,11 @@ class Session:
         cancelled = await self._journal.cancel_inbox(msg_id=msg_id)
         if not cancelled:
             return False
-        self._cancelled_msg_ids.add(msg_id)
+        self._inbox_arbiter.cancelled_msg_ids.add(msg_id)
         self._audit_events.emit(
             "inbox_cancel", msg_id=msg_id, seq=self._bump_queue_seq(),
         )
         return True
-
-    async def _consume_inbox(self) -> "tuple[str, dict] | None":
-        """Wait for next inbox message; on receive, record `inbox_consume`
-        via journal (skipped for shutdown signals which are out-of-band).
-
-        #3300 P3 (Y-server) skip-at-consume: if the dequeued item's msg_id was
-        already cancelled (``Session.cancel_queued`` — its snapshot.inbox entry
-        + WAL ``inbox_cancel`` tombstone were already recorded synchronously at
-        cancel time), this discards the physical ``asyncio.Queue`` entry
-        WITHOUT recording a redundant ``inbox_consume`` (the item is already
-        gone from the snapshot) and returns ``None`` — the caller
-        (``_drain_to_wake``) must treat this as "nothing dequeued yet" and
-        loop again, never dispatching a turn for a cancelled item.
-
-        #3792: reads ``self._pending_inbox_item`` FIRST, ahead of a fresh
-        ``self.inbox.get()``. An item can land there via
-        ``peek_mid_turn_injection`` — either because the running turn ended
-        (cancel / cap / overflow / LLM exception) before
-        ``commit_mid_turn_injection`` ever fired (carry-forward: the item is
-        simply processed as an ordinary new turn here, exactly as if the
-        peek had never happened), or because the peeked head was an
-        INELIGIBLE origin (peek deliberately leaves it there rather than
-        skipping past it — see that method). Checking here first is what
-        makes both cases land correctly instead of being stranded behind a
-        ``self.inbox.get()`` that would never see them again.
-        """
-        if self._pending_inbox_item is not None:
-            kind, payload = self._pending_inbox_item
-            self._pending_inbox_item = None
-        else:
-            kind, payload = await self.inbox.get()
-        msg_id = payload.get("_msg_id") if isinstance(payload, dict) else None
-        if kind != "shutdown" and msg_id in self._cancelled_msg_ids:
-            self._cancelled_msg_ids.discard(msg_id)
-            return None
-        if kind != "shutdown":
-            await self._journal.consume_inbox(msg_id=msg_id)
-        return kind, payload
-
-    async def _peek_mid_turn_injection(self) -> "dict | None":
-        """#3792: non-blocking, non-committing peek at the inbox head for a
-        mid-turn ``CLIENT_INPUT`` injection candidate.
-
-        Returns ``{"payload": dict, "msg_id": str}`` when the head is an
-        eligible, uncancelled ``CLIENT_INPUT`` message; ``None`` otherwise
-        (empty queue, or an ineligible-origin head).
-
-        Does NOT commit — ``self._journal``/``snapshot.inbox`` (the SSoT)
-        is untouched either way. The dequeued item (if any) is held in
-        ``self._pending_inbox_item`` so it is never lost: an eligible
-        candidate stays there until ``commit_mid_turn_injection`` actually
-        commits it (the caller must have spliced it into the wire first —
-        see ``RouterLoop.run_loop``'s seam); an ineligible-origin head also
-        stays there, UNCONSUMED, so the ordinary turn-boundary
-        ``_consume_inbox`` picks it up next, in arrival order — a queue
-        whose head is ineligible STOPS here rather than skipping ahead
-        (#3792 design: skipping would silently reorder arrival, and that
-        reordering would leave no trace anywhere).
-
-        A CANCELLED head (``Session.cancel_queued`` already pruned it from
-        the snapshot) is the one case this DOES discard outright — mirrors
-        ``_consume_inbox``'s own skip-at-consume handling, since a cancelled
-        item was never going to be eligible for anything.
-        """
-        while True:
-            if self._pending_inbox_item is None:
-                try:
-                    self._pending_inbox_item = self.inbox.get_nowait()
-                except asyncio.QueueEmpty:
-                    return None
-            kind, payload = self._pending_inbox_item
-            msg_id = payload.get("_msg_id") if isinstance(payload, dict) else None
-            if kind != "shutdown" and msg_id in self._cancelled_msg_ids:
-                self._cancelled_msg_ids.discard(msg_id)
-                self._pending_inbox_item = None
-                continue
-            if kind != TurnOrigin.CLIENT_INPUT:
-                return None
-            return {"payload": payload, "msg_id": msg_id}
 
     async def _commit_mid_turn_injection(self, msg_id: str) -> None:
         """#3792: commit (pop) the item the most recent successful
@@ -5235,18 +5054,18 @@ class Session:
         (architect's point 4: the loop valve must not reset).
 
         No-op (raises nothing, commits nothing) if ``msg_id`` does not match
-        the currently held ``self._pending_inbox_item`` — defensive: this
-        would only happen if the caller calls commit without a matching
-        prior peek, which is a caller bug, not a runtime condition to paper
-        over silently as a success.
+        the currently held ``self._inbox_arbiter.pending_inbox_item`` —
+        defensive: this would only happen if the caller calls commit
+        without a matching prior peek, which is a caller bug, not a runtime
+        condition to paper over silently as a success.
         """
-        if self._pending_inbox_item is None:
+        if self._inbox_arbiter.pending_inbox_item is None:
             return
-        kind, payload = self._pending_inbox_item
+        kind, payload = self._inbox_arbiter.pending_inbox_item
         held_msg_id = payload.get("_msg_id") if isinstance(payload, dict) else None
         if held_msg_id != msg_id:
             return
-        self._pending_inbox_item = None
+        self._inbox_arbiter.pending_inbox_item = None
         self._append_history(ChatMessage(
             role="user", content=payload.get("text") or "", ts=_now_iso(),
             meta=payload.get("meta") or {},
@@ -5258,15 +5077,6 @@ class Session:
             chain_id=payload.get("chain_id"),
             seq=self._bump_queue_seq(),
         )
-
-    async def _stage_next_turn_context(self, kind: str, payload: dict) -> None:
-        """Stage a wake=false ride-along (C) into next-turn context, durably
-        (B=persist): append to the in-memory buffer + record the WAL/snapshot
-        entry. Shared by ``_drain_to_wake`` (inbox ride-alongs) and the
-        ``HookDispatcher`` (#1800 slice 5b — direct C-staging that bypasses the
-        inbox). Byte-behavior-identical extraction of the prior inline pair."""
-        self._next_turn_context.append({"kind": kind, "payload": payload})
-        await self._journal.record_next_turn_context_staged(kind=kind, payload=payload)
 
     async def _launch_pipeline_from_hook(self, name: str, input_data: "dict | None") -> None:
         """#2608 H3: launch a registered Pipeline from a hook's
@@ -5328,118 +5138,6 @@ class Session:
             schema_registry=schema_registry,
         )
 
-    async def _drain_to_wake(
-        self,
-    ) -> tuple[list[tuple[str, dict]], tuple[str, dict]] | tuple[None, None]:
-        """Drain the inbox up to and including the first ``wake=true`` message.
-
-        Each inbox payload carries an optional ``wake`` bool (default ``True``
-        when absent).  Every producer but the hook dispatcher (``TurnOrigin``'s
-        other members) never sets ``wake``; the absent-means-True default makes them
-        all behaviorally identical to wake=true, so the common/back-compat
-        path returns immediately after the first blocking get with no
-        ride-alongs.
-
-        Returns ``(ride_alongs, trigger)`` where:
-
-        - ``ride_alongs``  — list of ``(kind, payload)`` tuples for every
-          ``wake=false`` message drained before the trigger.  Staged for the
-          next turn as context (slice 4b — see TODO below).  Empty in the
-          common case.
-        - ``trigger``      — the first ``wake=true`` (or absent-wake) message;
-          this drives the turn.
-
-        Special case: if the first blocking get yields ``shutdown``, returns
-        ``(None, None)`` so the caller can signal loop exit.
-
-        Decision A (RESOLVED, issuecomment-4773744053): if the queue empties
-        while holding only ``wake=false`` ride-alongs (no trigger yet),
-        re-enter the blocking wait.  Ride-alongs NEVER trigger a turn alone.
-
-        Per-message ``inbox_consume`` is recorded via ``_consume_inbox`` for
-        EACH drained message (ride-alongs and the trigger alike), so the
-        snapshot stays correct on crash+restore.
-
-        #1800 slice 4a.  ``wake=false`` ride-along staging (slice 4b) is the
-        next step; no ``wake=false`` producers exist yet, so the collected
-        list is returned but not consumed here.
-
-        #1800 slice 4b: each ``wake=false`` ride-along is staged durably
-        (B=persist) **here**, immediately after its ``inbox_consume``.
-        Staging in ``_drain_to_wake`` rather than in ``run_one_iteration``
-        closes the crash window: a crash while blocking-waiting for the
-        trigger (Decision A) leaves the C's already in the WAL + snapshot,
-        so restore_state recovers them.  ``run_one_iteration`` still
-        receives ``ride_alongs`` (4a contract) but no longer re-stages them.
-        The common path (no wake=false) never calls
-        ``record_next_turn_context_staged``, preserving 4a equivalence.
-        """
-        ride_alongs: list[tuple[str, dict]] = []
-
-        while True:
-            # (a) Blocking wait — preserves the idle-sleep property exactly
-            # as the previous single-get path did.  Also records
-            # inbox_consume via _consume_inbox (journaled, P6-clean).
-            # #3300 P3 (Y-server): `None` means the dequeued item was
-            # cancelled (skip-at-consume) — loop again without treating it
-            # as a trigger or ride-along.
-            step = await self._consume_inbox()
-            if step is None:
-                continue
-            kind0, p0 = step
-
-            # (b) Shutdown sentinel: propagate immediately regardless of any
-            # already-accumulated ride-alongs.
-            if kind0 == "shutdown":
-                return None, None
-
-            # (c) wake=true (or absent → default True): this is the trigger.
-            # Common/back-compat path — returns after the first blocking get
-            # with no ride-alongs.
-            if p0.get("wake", True):
-                return ride_alongs, (kind0, p0)
-
-            # (d) wake=false ride-along: stage durably (B=persist) the
-            # moment it is consumed, BEFORE re-entering the blocking wait
-            # for the trigger.  This closes the gap: without this, a crash
-            # in the blocking wait would lose the consumed-but-not-persisted
-            # ride-along.
-            await self._stage_next_turn_context(kind0, p0)
-            ride_alongs.append((kind0, p0))
-
-            # Non-blocking drain: collect additional wake=false messages until
-            # either a wake=true trigger arrives or the queue is momentarily
-            # empty (Decision A: re-enter the blocking wait in that case).
-            while True:
-                try:
-                    kind_nb, p_nb = self.inbox.get_nowait()
-                except asyncio.QueueEmpty:
-                    # Queue empty, no trigger yet — re-enter outer blocking
-                    # wait (Decision A).
-                    break
-
-                msg_id_nb = (
-                    p_nb.get("_msg_id") if isinstance(p_nb, dict) else None
-                )
-                # #3300 P3 (Y-server) skip-at-consume: same discard as the
-                # blocking path above — a cancelled item is never dispatched
-                # and never gets a redundant inbox_consume.
-                if kind_nb != "shutdown" and msg_id_nb in self._cancelled_msg_ids:
-                    self._cancelled_msg_ids.discard(msg_id_nb)
-                    continue
-                if kind_nb != "shutdown":
-                    await self._journal.consume_inbox(msg_id=msg_id_nb)
-
-                if kind_nb == "shutdown":
-                    return None, None
-
-                if p_nb.get("wake", True):
-                    return ride_alongs, (kind_nb, p_nb)
-
-                # wake=false via non-blocking path: stage durably before
-                # accumulating (same B=persist guarantee as the outer path).
-                await self._stage_next_turn_context(kind_nb, p_nb)
-                ride_alongs.append((kind_nb, p_nb))
 
     def restore_state(self, snapshot: AgentSnapshot) -> None:
         """Adopt a recovered snapshot: install in journal, repopulate the
@@ -5468,8 +5166,8 @@ class Session:
                 text=ans.get("text", ""),
                 choice_id=ans.get("choice_id"),
             )
-        # #1800 slice 4b: restore the staged next-turn-context buffer — see docs/reference/runtime/session-construction.md#safety-limits-interactive-mode (`_next_turn_context`).
-        self._next_turn_context = [
+        # #1800 slice 4b: restore the staged next-turn-context buffer — see docs/reference/runtime/session-construction.md#safety-limits-interactive-mode (`InboxArbiter.next_turn_context`).
+        self._inbox_arbiter.next_turn_context = [
             entry for entry in snapshot.next_turn_context
             if isinstance(entry, dict)
         ]
@@ -5554,7 +5252,7 @@ class Session:
         # ride_alongs holds wake=false C messages accumulated before the
         # trigger.  They are already staged durably by _drain_to_wake (4b);
         # no further persist needed here.
-        ride_alongs, trigger = await self._drain_to_wake()
+        ride_alongs, trigger = await self._inbox_arbiter.drain_to_wake()
         if trigger is None:
             # shutdown sentinel
             return False
@@ -5594,7 +5292,7 @@ class Session:
         # FP-0041 (#489) PR-A: surface a sender change as a state_change
         # entry — removing this call collapses multi-consumer attribution
         # into one undifferentiated feed (authoring-guide.md#sender-attribution-as-state_change-fp-0041-489).
-        self._handle_sender_attribution(payload)
+        self._inbox_arbiter.handle_sender_attribution(payload)
         # #1800 slice 5a: turn lifecycle audit event (P6). Emitted after the
         # trigger is consumed and before dispatch, so slice 5b can attach the
         # turn_start hook here. chain_id from the payload (may be absent for
@@ -6080,8 +5778,8 @@ class Session:
         # so C messages only attach to an actually-running router turn (flow-
         # trace §3 risk note: a slash-command short-circuit must NOT consume
         # the staged C's — they wait for the real turn).
-        if self._next_turn_context:
-            for entry in self._next_turn_context:
+        if self._inbox_arbiter.next_turn_context:
+            for entry in self._inbox_arbiter.next_turn_context:
                 hook_kind = entry.get("kind", "hook")
                 payload_data = entry.get("payload", {})
                 hook_name = payload_data.get("name", hook_kind)
@@ -6091,7 +5789,7 @@ class Session:
                     content=_format_hook_attribution(hook_name, hook_text),
                     ts=_now_iso(),
                 ))
-            self._next_turn_context.clear()
+            self._inbox_arbiter.next_turn_context.clear()
             await self._journal.record_next_turn_context_cleared()
 
         # R-D4: WAL size safety-net check at the chat turn boundary — see
@@ -6224,7 +5922,8 @@ class Session:
 
         FP-0041 #489 PR-D2: outbox reply_to + external transport interceptor.
           - When ``msg.reply_to`` is unset and the session has a recent
-            inbox-captured ``_last_reply_to``, the outbox message
+            inbox-captured ``self._inbox_arbiter.last_reply_to`` (proposal
+            0067 P1, #3978), the outbox message
             inherits it (= so the agent's reply automatically routes
             back to the producer's transport without each emit site
             needing to know).
@@ -6238,9 +5937,9 @@ class Session:
             dispatch surfaces to TUI rather than silently disappearing).
         """
         # PR-D2: default reply_to from last captured inbox reply_to.
-        if msg.reply_to is None and self._last_reply_to is not None:
+        if msg.reply_to is None and self._inbox_arbiter.last_reply_to is not None:
             from dataclasses import replace
-            msg = replace(msg, reply_to=self._last_reply_to)
+            msg = replace(msg, reply_to=self._inbox_arbiter.last_reply_to)
         # PR-D2: external transport interceptor.
         if self._outbox_interceptor is not None:
             from reyn.runtime.transport import ExternalRef
@@ -6287,9 +5986,9 @@ class Session:
         ``/cost`` line typed in the TUI away from the TUI would contradict that
         ruling rather than preserve behaviour.
         """
-        if msg.reply_to is None and self._last_reply_to is not None:
+        if msg.reply_to is None and self._inbox_arbiter.last_reply_to is not None:
             from dataclasses import replace
-            msg = replace(msg, reply_to=self._last_reply_to)
+            msg = replace(msg, reply_to=self._inbox_arbiter.last_reply_to)
         # #3793 stage 2: the "nobody is watching, drop status/trace" gate
         # (formerly ``if not self.is_attached: return`` here) is now derived
         # from ``self.outbox_hub.has_subscribers()`` instead of a manually-

--- a/tests/core/test_1800_c_staging.py
+++ b/tests/core/test_1800_c_staging.py
@@ -198,7 +198,7 @@ async def test_c_staging_ride_alongs_injected_as_system_messages(
     )
 
     # _next_turn_context must be empty after the turn.
-    n_ntc = len(session._next_turn_context)
+    n_ntc = len(session._inbox_arbiter.next_turn_context)
     assert n_ntc == 0, (
         f"_next_turn_context must be empty after turn; got {n_ntc} entries"
     )
@@ -289,11 +289,11 @@ async def test_c_staging_persist_and_restore(tmp_path) -> None:
     # restore_state expects the snapshot to already have next_turn_context.
     session4.restore_state(restored_snap)
 
-    n_recovered = len(session4._next_turn_context)
+    n_recovered = len(session4._inbox_arbiter.next_turn_context)
     assert n_recovered == 1, (
         f"restore_state must recover 1 next_turn_context entry; got {n_recovered}"
     )
-    (recovered_entry,) = session4._next_turn_context
+    (recovered_entry,) = session4._inbox_arbiter.next_turn_context
     assert recovered_entry.get("kind") == "hook", (
         f"Recovered entry kind must be 'hook'; got {recovered_entry!r}"
     )
@@ -387,7 +387,7 @@ async def test_c_staging_durable_during_drain_wait(tmp_path) -> None:
 
     # Start _drain_to_wake concurrently.  It will consume the wake=false C,
     # stage it durably, then block waiting for a trigger (Decision A).
-    drain_task = asyncio.create_task(session._drain_to_wake())
+    drain_task = asyncio.create_task(session._inbox_arbiter.drain_to_wake())
 
     # Wait until the drain has DURABLY staged the C. Both the WAL append AND the snapshot
     # save fsync OFF the event loop (#1765 1a-i/1a-ii) on a worker thread, and the snapshot
@@ -446,12 +446,12 @@ async def test_c_staging_durable_during_drain_wait(tmp_path) -> None:
     recovered_snap = AgentSnapshot.load(session.agent_name, session._snapshot_path)
     session2.restore_state(recovered_snap)
 
-    n_recovered = len(session2._next_turn_context)
+    n_recovered = len(session2._inbox_arbiter.next_turn_context)
     assert n_recovered == 1, (
         f"restore_state must recover 1 next_turn_context entry after crash; "
         f"got {n_recovered}"
     )
-    (recovered_entry,) = session2._next_turn_context
+    (recovered_entry,) = session2._inbox_arbiter.next_turn_context
     assert recovered_entry.get("kind") == "hook", (
         f"Recovered entry kind must be 'hook'; got {recovered_entry!r}"
     )
@@ -480,7 +480,7 @@ async def test_c_staging_slash_command_does_not_consume_staged(
     session = _make_session(tmp_path)
 
     # Stage a C message manually.
-    session._next_turn_context.append(
+    session._inbox_arbiter.next_turn_context.append(
         {"kind": "hook", "payload": {"name": "pending_hook", "text": "pending-context"}}
     )
 
@@ -492,7 +492,7 @@ async def test_c_staging_slash_command_does_not_consume_staged(
     assert consumed is True, "/help must be claimed by the client slash layer"
 
     # The staged entries must still be in _next_turn_context.
-    n_ntc = len(session._next_turn_context)
+    n_ntc = len(session._inbox_arbiter.next_turn_context)
     assert n_ntc == 1, (
         f"Slash command must NOT consume staged C messages; "
         f"expected 1 entry in _next_turn_context, got {n_ntc}"

--- a/tests/core/test_1800_wake_drain.py
+++ b/tests/core/test_1800_wake_drain.py
@@ -216,7 +216,7 @@ async def test_drain_to_wake_wake_true_first_returns_immediately(
     # Enqueue a wake=true message directly (explicit flag set to True).
     await session._put_inbox("user", {"text": "hi", "wake": True})
 
-    ride_alongs, trigger = await session._drain_to_wake()
+    ride_alongs, trigger = await session._inbox_arbiter.drain_to_wake()
 
     assert ride_alongs == [], (
         f"Expected no ride-alongs for wake=true first message; got {ride_alongs}"
@@ -240,7 +240,7 @@ async def test_drain_to_wake_absent_wake_treated_as_true(tmp_path) -> None:
     # submit_user_text does NOT set wake — this is the back-compat case.
     await session.submit_user_text("back-compat")
 
-    ride_alongs, trigger = await session._drain_to_wake()
+    ride_alongs, trigger = await session._inbox_arbiter.drain_to_wake()
 
     assert ride_alongs == [], (
         f"Absent wake must be treated as True; ride-alongs must be empty: {ride_alongs}"
@@ -264,7 +264,7 @@ async def test_drain_to_wake_collects_ride_alongs_then_trigger(tmp_path) -> None
     await session._put_inbox("user", {"text": "ride2", "wake": False})
     await session._put_inbox("user", {"text": "trigger", "wake": True})
 
-    ride_alongs, trigger = await session._drain_to_wake()
+    ride_alongs, trigger = await session._inbox_arbiter.drain_to_wake()
 
     # Exactly 2 ride-alongs — unpack-enforcement idiom.
     ra1, ra2 = ride_alongs
@@ -293,7 +293,7 @@ async def test_drain_to_wake_shutdown_returns_none_none(tmp_path) -> None:
     # Shutdown is enqueued out-of-band (no WAL, no _msg_id).
     await session.inbox.put(("shutdown", {}))
 
-    ride_alongs, trigger = await session._drain_to_wake()
+    ride_alongs, trigger = await session._inbox_arbiter.drain_to_wake()
 
     assert ride_alongs is None, (
         f"Shutdown must return (None, None) not ({ride_alongs!r}, ...)"
@@ -320,7 +320,7 @@ async def test_drain_to_wake_inbox_consume_per_message(tmp_path) -> None:
     await session._put_inbox("user", {"text": "t1", "wake": True})
 
     # Drain: should consume both and record 2 inbox_consume WAL events.
-    ride_alongs, trigger = await session._drain_to_wake()
+    ride_alongs, trigger = await session._inbox_arbiter.drain_to_wake()
 
     # Exactly 1 ride-along — unpack-enforcement idiom.
     (only_ra,) = ride_alongs
@@ -372,7 +372,7 @@ async def test_drain_to_wake_only_wake_false_then_trigger_arrives(
     trigger_task = asyncio.create_task(_delayed_trigger())
 
     ride_alongs, trigger = await asyncio.wait_for(
-        session._drain_to_wake(), timeout=2.0
+        session._inbox_arbiter.drain_to_wake(), timeout=2.0
     )
 
     await trigger_task

--- a/tests/core/test_3792_pr2_session_injection.py
+++ b/tests/core/test_3792_pr2_session_injection.py
@@ -95,7 +95,7 @@ async def test_only_client_input_origin_is_peek_eligible(tmp_path):
             tmp_path / f"{origin.value}.wal", tmp_path / f"{origin.value}.json",
         )
         await session._put_inbox(origin, kwargs)
-        result = await session._peek_mid_turn_injection()
+        result = await session._inbox_arbiter.peek_mid_turn_injection()
         assert result is None, f"origin {origin!r} must NOT be peek-eligible"
         await state_log.aclose()
 
@@ -104,7 +104,7 @@ async def test_only_client_input_origin_is_peek_eligible(tmp_path):
         tmp_path / "client_input.wal", tmp_path / "client_input.json",
     )
     await session.submit_user_text("hello")
-    result = await session._peek_mid_turn_injection()
+    result = await session._inbox_arbiter.peek_mid_turn_injection()
     assert result is not None
     assert result["payload"]["text"] == "hello"
     await state_log.aclose()
@@ -136,17 +136,17 @@ async def test_ineligible_head_blocks_peek_and_surfaces_via_normal_drain_in_orde
     )
     await session.submit_user_text("second, eligible")
 
-    peeked = await session._peek_mid_turn_injection()
+    peeked = await session._inbox_arbiter.peek_mid_turn_injection()
     assert peeked is None, "the ineligible AGENT_REQUEST head must block the peek"
 
-    kind, payload = await session._consume_inbox()
+    kind, payload = await session._inbox_arbiter.consume_inbox()
     assert kind == TurnOrigin.AGENT_REQUEST, (
         "the FIRST item _consume_inbox returns must be the same ineligible "
         "head the peek saw — not the 2nd (eligible) item out of order"
     )
     assert payload["request"] == "r"
 
-    kind2, payload2 = await session._consume_inbox()
+    kind2, payload2 = await session._inbox_arbiter.consume_inbox()
     assert kind2 == TurnOrigin.CLIENT_INPUT
     assert payload2["text"] == "second, eligible"
 
@@ -168,7 +168,7 @@ async def test_peek_without_commit_carries_forward_to_normal_consume(tmp_path):
 
     Falsification (performed during review): if ``_consume_inbox`` read
     ``self.inbox.get()`` unconditionally (ignoring
-    ``self._pending_inbox_item``), this test goes RED with an indefinite
+    ``self._inbox_arbiter.pending_inbox_item``), this test goes RED with an indefinite
     hang (the queue is empty — the item is stuck in the buffer forever) —
     demonstrated by using ``asyncio.wait_for`` with a short timeout instead
     of a bare await, so the failure mode is a clean test failure, not a
@@ -179,11 +179,11 @@ async def test_peek_without_commit_carries_forward_to_normal_consume(tmp_path):
     session, state_log = _make_session(tmp_path / "s.wal", tmp_path / "s.json")
     await session.submit_user_text("carry me")
 
-    peeked = await session._peek_mid_turn_injection()
+    peeked = await session._inbox_arbiter.peek_mid_turn_injection()
     assert peeked is not None
     # Deliberately do NOT commit — simulates the abnormal exit.
 
-    kind, payload = await asyncio.wait_for(session._consume_inbox(), timeout=2.0)
+    kind, payload = await asyncio.wait_for(session._inbox_arbiter.consume_inbox(), timeout=2.0)
     assert kind == TurnOrigin.CLIENT_INPUT
     assert payload["text"] == "carry me"
     assert payload["_msg_id"] == peeked["msg_id"]
@@ -215,7 +215,7 @@ async def test_commit_appends_history_prunes_snapshot_emits_turn_started(tmp_pat
     session._audit_events.add_subscriber(lambda e: events.append(e))
 
     msg_id = await session.submit_user_text("inject me", attribution=None)
-    peeked = await session._peek_mid_turn_injection()
+    peeked = await session._inbox_arbiter.peek_mid_turn_injection()
     assert peeked is not None
     assert peeked["msg_id"] == msg_id
 
@@ -258,7 +258,7 @@ async def test_commit_does_not_reset_hook_driven_turns(tmp_path):
     session._hook_driven_turns = 7  # setup (write): no public setter exists
 
     msg_id = await session.submit_user_text("inject me")
-    await session._peek_mid_turn_injection()
+    await session._inbox_arbiter.peek_mid_turn_injection()
     await session._commit_mid_turn_injection(msg_id)
 
     assert session.hook_driven_turns == 7
@@ -293,7 +293,7 @@ async def test_commit_truncate_falsify(tmp_path):
 
     msg_id = await session.submit_user_text("inject me")
     keep_id = await session.submit_user_text("stays queued")
-    await session._peek_mid_turn_injection()
+    await session._inbox_arbiter.peek_mid_turn_injection()
     await session._commit_mid_turn_injection(msg_id)
     await session.journal.flush()
 

--- a/tests/core/test_reset_for_rewind.py
+++ b/tests/core/test_reset_for_rewind.py
@@ -91,7 +91,7 @@ def test_reset_for_rewind_clear_scope_covers_all_agentsnapshot_fields():
         "pending_chains": "session._chains.reset()",
         "outstanding_interventions": "session._interventions.clear() + restore tasks",
         "buffered_intervention_answers": "session._buffered_intervention_answers cleared",
-        "next_turn_context": "session._next_turn_context cleared",
+        "next_turn_context": "session._inbox_arbiter.next_turn_context cleared",
         # #2884: the loop-valve counter mirror is reset to 0 (restore_state re-assigns
         # it wholesale from the reconstructed snapshot; the reset keeps zero-residue robust).
         "hook_driven_turns": "session._hook_driven_turns reset to 0",

--- a/tests/core/test_session_dispatch_attribution.py
+++ b/tests/core/test_session_dispatch_attribution.py
@@ -35,10 +35,10 @@ from pathlib import Path
 import pytest
 
 from reyn.core.events.state_log import StateLog
+from reyn.runtime.inbox_arbiter import _format_sender_label
 from reyn.runtime.session import (
     ChatMessage,
     Session,
-    _format_sender_label,
 )
 from tests._support.agent_session import make_session
 
@@ -78,7 +78,7 @@ def test_first_sender_triggers_first_attributed_turn_entry(tmp_path):
     session = _make_session(tmp_path)
     assert session.last_sender() is None
 
-    session._handle_sender_attribution({"sender": "slack:U456:bob"})
+    session._inbox_arbiter.handle_sender_attribution({"sender": "slack:U456:bob"})
 
     entries = _attribution_entries(session)
     assert entries, "expected attribution entry"
@@ -98,10 +98,10 @@ def test_sender_transition_emits_state_change(tmp_path):
     turn was from Y."
     """
     session = _make_session(tmp_path)
-    session._handle_sender_attribution({"sender": "cron:morning_news"})
+    session._inbox_arbiter.handle_sender_attribution({"sender": "cron:morning_news"})
     pre_count = len(_attribution_entries(session))
 
-    session._handle_sender_attribution({"sender": "slack:U456:bob"})
+    session._inbox_arbiter.handle_sender_attribution({"sender": "slack:U456:bob"})
 
     entries = _attribution_entries(session)
     assert len(entries) == pre_count + 1
@@ -121,12 +121,12 @@ def test_same_sender_consecutive_does_not_emit(tmp_path):
     only fires on the boundary between consumers.
     """
     session = _make_session(tmp_path)
-    session._handle_sender_attribution({"sender": "user:tui"})
+    session._inbox_arbiter.handle_sender_attribution({"sender": "user:tui"})
     pre_count = len(_attribution_entries(session))
 
     # Same sender again — no new transition.
-    session._handle_sender_attribution({"sender": "user:tui"})
-    session._handle_sender_attribution({"sender": "user:tui"})
+    session._inbox_arbiter.handle_sender_attribution({"sender": "user:tui"})
+    session._inbox_arbiter.handle_sender_attribution({"sender": "user:tui"})
 
     assert len(_attribution_entries(session)) == pre_count
     assert session.last_sender() == "user:tui"
@@ -145,7 +145,7 @@ def test_payload_without_sender_skips_attribution(tmp_path):
     pre_count = len(_attribution_entries(session))
     pre_last = session.last_sender()
 
-    session._handle_sender_attribution({"text": "hello", "chain_id": "c1"})
+    session._inbox_arbiter.handle_sender_attribution({"text": "hello", "chain_id": "c1"})
 
     assert len(_attribution_entries(session)) == pre_count
     assert session.last_sender() == pre_last  # unchanged
@@ -157,7 +157,7 @@ def test_empty_sender_string_skips_attribution(tmp_path):
     producers that haven't fully populated the field.
     """
     session = _make_session(tmp_path)
-    session._handle_sender_attribution({"sender": ""})
+    session._inbox_arbiter.handle_sender_attribution({"sender": ""})
 
     assert len(_attribution_entries(session)) == 0
     assert session.last_sender() is None
@@ -173,10 +173,10 @@ def test_non_dict_payload_does_not_crash(tmp_path):
     dispatch. Defensive isolation.
     """
     session = _make_session(tmp_path)
-    session._handle_sender_attribution(None)
-    session._handle_sender_attribution("string-not-dict")
-    session._handle_sender_attribution(["list-not-dict"])
-    session._handle_sender_attribution(42)
+    session._inbox_arbiter.handle_sender_attribution(None)
+    session._inbox_arbiter.handle_sender_attribution("string-not-dict")
+    session._inbox_arbiter.handle_sender_attribution(["list-not-dict"])
+    session._inbox_arbiter.handle_sender_attribution(42)
 
     assert len(_attribution_entries(session)) == 0
     assert session.last_sender() is None
@@ -190,9 +190,9 @@ def test_three_way_transition_each_fires(tmp_path):
     state_change entries — one per boundary.
     """
     session = _make_session(tmp_path)
-    session._handle_sender_attribution({"sender": "user:tui"})
-    session._handle_sender_attribution({"sender": "cron:nightly"})
-    session._handle_sender_attribution({"sender": "a2a:peer_one"})
+    session._inbox_arbiter.handle_sender_attribution({"sender": "user:tui"})
+    session._inbox_arbiter.handle_sender_attribution({"sender": "cron:nightly"})
+    session._inbox_arbiter.handle_sender_attribution({"sender": "a2a:peer_one"})
 
     entries = _attribution_entries(session)
     e0, e1, e2 = entries
@@ -265,7 +265,7 @@ def test_attribution_resilient_to_notify_state_change_failure(
     monkeypatch.setattr(session, "notify_state_change", _boom)
 
     # Must not raise.
-    session._handle_sender_attribution({"sender": "slack:U456:bob"})
+    session._inbox_arbiter.handle_sender_attribution({"sender": "slack:U456:bob"})
 
     # _last_sender did update despite the failure.
     assert session.last_sender() == "slack:U456:bob"

--- a/tests/interfaces/test_3300_p2a_queue_state_publish.py
+++ b/tests/interfaces/test_3300_p2a_queue_state_publish.py
@@ -187,7 +187,7 @@ async def test_queued_user_messages_reflects_undispatched_inbox_queue(tmp_path):
 
     # Dispatch (consume) the first item directly — mirrors what
     # ``run_one_iteration`` does before the turn body runs.
-    await session._consume_inbox()
+    await session._inbox_arbiter.consume_inbox()
     remaining = session.queued_user_messages()
     assert [item["text"] for item in remaining] == ["second"]
 

--- a/tests/runtime/test_3595_client_input_provenance_gate.py
+++ b/tests/runtime/test_3595_client_input_provenance_gate.py
@@ -256,7 +256,7 @@ _CLIENT_INPUT_SITES: "dict[tuple[str, str], _SiteDeclaration]" = {
         ),
         measured_by=(),
     ),
-    ("reyn/runtime/session.py", "Session._peek_mid_turn_injection"): _SiteDeclaration(
+    ("reyn/runtime/inbox_arbiter.py", "InboxArbiter.peek_mid_turn_injection"): _SiteDeclaration(
         role="reads",
         reason=(
             "#3792: the mid-turn injection origin gate. Only a CLIENT_INPUT-origin "
@@ -266,7 +266,10 @@ _CLIENT_INPUT_SITES: "dict[tuple[str, str], _SiteDeclaration]" = {
             "as if this method did not exist. Reads the kind as an eligibility "
             "check, the same fail-safe if/else shape as "
             "Session._stamp_execution_context above: an unmapped or non-human "
-            "origin cannot reach the permissive (inject) side."
+            "origin cannot reach the permissive (inject) side. Proposal 0067 P1 "
+            "(#3978): moved from Session._peek_mid_turn_injection onto "
+            "InboxArbiter.peek_mid_turn_injection (InboxArbiter extraction) —"
+            " byte-identical relocation, same site, new qualname."
         ),
         measured_by=(
             "tests/core/test_3792_pr2_session_injection.py::"

--- a/tests/runtime/test_agent_locks_shared_1128.py
+++ b/tests/runtime/test_agent_locks_shared_1128.py
@@ -1,9 +1,9 @@
-"""Tier 2: OS invariant tests for the shared per-agent lock registry (#1128).
+"""Tier 2: OS invariant tests for the shared per-(agent, sid) lock registry (#1128, #3978).
 
 Pins the cross-transport serialization guarantee introduced in PR-b of
 issue #1128: MCP and A2A must acquire the SAME ``asyncio.Lock`` for a
-given agent name so concurrent MCP+A2A calls to the same session serialize
-rather than racing on ``session.history``.
+given (agent, sid) session so concurrent MCP+A2A calls to the same session
+serialize rather than racing on ``session.history``.
 
 Invariants exercised (identity invariants hold WITHIN a running loop — the
 registry is loop-aware since #1762, see ``agent_locks`` docstring):
@@ -18,6 +18,14 @@ registry is loop-aware since #1762, see ``agent_locks`` docstring):
   (e) #1762 regression: a contended lock used across distinct event loops
       (= pytest-asyncio's per-test fresh loops) must NOT raise "bound to a
       different event loop" — loop-aware keying gives each loop its own lock.
+  (f) Proposal 0067 P1 (#3978, architect A-2 axis-mismatch finding): two
+      different ``sid``s for the SAME agent name now yield DISTINCT locks —
+      this lock protects one Session's ``history``, not everything sharing
+      an agent name, and an agent can have more than one live session
+      (a per-delegation ``a2a:<id>`` session alongside "main").
+  (g) ``sid=None`` (the default, meaning "main") is the SAME key as an
+      explicit ``sid="main"`` — a bare pre-#3978-style call still serializes
+      against an explicit-sid caller for the same agent's main session.
 
 Policy compliance (docs/deep-dives/contributing/testing.ja.md):
 - No unittest.mock / MagicMock / AsyncMock / patch.
@@ -188,3 +196,74 @@ def test_agent_lock_reusable_across_event_loops() -> None:
     # RuntimeError("... bound to a different event loop"); loop-aware keying passes.
     asyncio.run(contended_once())
     asyncio.run(contended_once())
+
+
+# ---------------------------------------------------------------------------
+# (f)/(g) Proposal 0067 P1 (#3978): (agent_name, sid) axis
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_different_sids_for_same_agent_return_distinct_locks() -> None:
+    """Tier 2: get_agent_lock("x", "main") and get_agent_lock("x", "a2a:1")
+    return DISTINCT lock objects (#3978 architect A-2: the lock protects one
+    Session's history, and one agent name can have more than one live
+    session — a per-delegation sid must not serialize against "main").
+
+    Falsify-verified: reverting ``get_agent_lock`` to key by ``agent_name``
+    alone (the pre-#3978 shape) makes this go RED — both calls would return
+    the same object.
+    """
+    lock_main = get_agent_lock("shared-agent", "main")
+    lock_delegation = get_agent_lock("shared-agent", "a2a:peer-1")
+    assert lock_main is not lock_delegation, (
+        "get_agent_lock must return distinct asyncio.Lock objects for "
+        "different sids of the SAME agent — sharing one lock across "
+        "sessions that share no state over-serializes them"
+    )
+
+
+@pytest.mark.asyncio
+async def test_absent_sid_is_the_same_key_as_explicit_main() -> None:
+    """Tier 2: get_agent_lock("x") (sid omitted) and get_agent_lock("x", "main")
+    return the SAME lock object — the omitted-sid convention canonicalizes
+    to "main", so a caller that never passes sid still serializes correctly
+    against a caller that explicitly names the main session.
+    """
+    lock_bare = get_agent_lock("bare-vs-main-agent")
+    lock_explicit_main = get_agent_lock("bare-vs-main-agent", "main")
+    assert lock_bare is lock_explicit_main, (
+        "get_agent_lock(name) and get_agent_lock(name, \"main\") must be the "
+        "same key — omitted sid means the main session, same as explicit "
+        "sid=\"main\""
+    )
+
+
+@pytest.mark.asyncio
+async def test_different_sid_locks_do_not_serialize_against_each_other() -> None:
+    """Tier 2: concurrent coroutines holding locks for DIFFERENT sids of the
+    same agent do NOT block each other — the behavioral counterpart to (f).
+    Mirrors (d)'s serialization test, but proves the opposite: distinct
+    sessions run freely in parallel.
+    """
+    agent = "parallel-sid-agent"
+    main_entered = asyncio.Event()
+    delegation_entered = asyncio.Event()
+    entered: set[str] = set()
+
+    async def hold(sid: str, own: "asyncio.Event", other: "asyncio.Event") -> None:
+        async with get_agent_lock(agent, sid):
+            entered.add(sid)
+            own.set()
+            # Wait for the OTHER sid's coroutine to also be inside its own
+            # critical section concurrently — if they were serialized by a
+            # shared lock, this would deadlock (the other could never enter
+            # while this one waits on an event only the other sets) and the
+            # test would time out rather than pass.
+            await asyncio.wait_for(other.wait(), timeout=2.0)
+
+    await asyncio.gather(
+        hold("main", main_entered, delegation_entered),
+        hold("a2a:peer-2", delegation_entered, main_entered),
+    )
+    assert entered == {"main", "a2a:peer-2"}

--- a/tests/runtime/test_fp0041_prd2_outbox_interceptor.py
+++ b/tests/runtime/test_fp0041_prd2_outbox_interceptor.py
@@ -4,17 +4,17 @@ End-to-end reply path completion for the Slack chat-transport. PR-D
 landed inbound (= Slack → Reyn inbox). PR-D2 completes outbound:
 
   inbox payload reply_to (= ExternalRef from PR-D handler)
-    → Session captures into self._last_reply_to
+    → InboxArbiter captures into self.last_reply_to
     → agent reply via _put_outbox
-    → reply_to defaults from _last_reply_to (when not explicit)
+    → reply_to defaults from InboxArbiter.last_reply_to (when not explicit)
     → _outbox_interceptor invoked (= PR-D2 wiring)
     → make_outbox_interceptor dispatches via route_to_mcp (PR-C)
     → Slack MCP server chat.postMessage (= operator-installed)
 
 Tests:
 
-  1. Sender attribution also captures reply_to into _last_reply_to
-  2. _put_outbox defaults missing reply_to from _last_reply_to
+  1. Sender attribution also captures reply_to into last_reply_to
+  2. _put_outbox defaults missing reply_to from last_reply_to
   3. _put_outbox invokes interceptor when reply_to is ExternalRef
   4. Interceptor return True → message NOT queued (= consumed by
      external transport, no TUI duplicate)
@@ -28,6 +28,15 @@ Tests:
 Tier 2 because this is the load-bearing wiring that makes Slack
 chat-transport actually work end-to-end. Without it, PR-D inbound
 delivers messages but no reply ever reaches Slack.
+
+Proposal 0067 P1 (#3978) co-vet (architect + lead-coder, #3978): a
+payload with no ``reply_to`` now CLEARS ``last_reply_to`` to ``None``
+instead of preserving the previous value. The prior "preserve" behavior
+was itself the misdelivery bug this arc closed — the stale value WAS
+consumed by ``_put_outbox``/``_put_outbox_nowait`` before the interceptor
+ever ran, contradicting the comment that justified it ("falls through to
+the default surface"). See ``InboxArbiter.handle_sender_attribution``'s
+own docstring for the full finding.
 """
 from __future__ import annotations
 
@@ -65,24 +74,34 @@ def test_attribution_captures_reply_to_from_payload(tmp_path):
     """
     session = _make_session(tmp_path)
     rt = ExternalRef(transport="slack", destination={"channel": "C1"})
-    session._handle_sender_attribution({
+    session._inbox_arbiter.handle_sender_attribution({
         "sender": "slack:U1",
         "reply_to": rt,
     })
     assert session.last_reply_to is rt
 
 
-def test_attribution_does_not_clear_reply_to_when_payload_lacks_it(tmp_path):
-    """Tier 2: a follow-up payload without reply_to preserves the
-    previously captured value (= same-thread follow-ups inherit the
-    original reply_to without each producer needing to re-attach).
+def test_attribution_clears_reply_to_when_payload_lacks_it(tmp_path):
+    """Tier 2: a follow-up payload without reply_to CLEARS the
+    previously captured value to None (proposal 0067 P1 co-vet, #3978:
+    the old "preserve" behavior was the misdelivery bug this arc closed
+    — a reply_to-less turn used to inherit the PREVIOUS turn's stale
+    destination in ``_put_outbox``. A same-thread Slack follow-up that
+    wants to keep replying to the same thread must resend ``reply_to``
+    on every payload — verified against the real producers, see
+    ``InboxArbiter.handle_sender_attribution``'s docstring).
+
+    Falsify-verified: reverting ``InboxArbiter.handle_sender_attribution``
+    to only overwrite ``last_reply_to`` when the payload carries one (the
+    pre-fix behavior) makes this go RED with the old
+    ``assert session.last_reply_to is rt``.
     """
     session = _make_session(tmp_path)
     rt = ExternalRef(transport="slack", destination={"channel": "C1"})
-    session._handle_sender_attribution({"sender": "slack:U1", "reply_to": rt})
+    session._inbox_arbiter.handle_sender_attribution({"sender": "slack:U1", "reply_to": rt})
     # Second payload, no reply_to.
-    session._handle_sender_attribution({"sender": "slack:U1"})
-    assert session.last_reply_to is rt
+    session._inbox_arbiter.handle_sender_attribution({"sender": "slack:U1"})
+    assert session.last_reply_to is None
 
 
 def test_attribution_updates_reply_to_when_payload_carries_new_one(tmp_path):
@@ -90,9 +109,9 @@ def test_attribution_updates_reply_to_when_payload_carries_new_one(tmp_path):
     (= different Slack thread / different transport).
     """
     session = _make_session(tmp_path)
-    session._last_reply_to = ExternalRef(transport="slack", destination={"channel": "C1"})
+    session._inbox_arbiter.last_reply_to = ExternalRef(transport="slack", destination={"channel": "C1"})
     new_rt = ExternalRef(transport="slack", destination={"channel": "C2"})
-    session._handle_sender_attribution({
+    session._inbox_arbiter.handle_sender_attribution({
         "sender": "slack:U1", "reply_to": new_rt,
     })
     assert session.last_reply_to is new_rt
@@ -109,7 +128,7 @@ async def test_put_outbox_inherits_reply_to_from_last(tmp_path):
     """
     session = _make_session(tmp_path)
     rt = ExternalRef(transport="slack", destination={"channel": "C1"})
-    session._last_reply_to = rt
+    session._inbox_arbiter.last_reply_to = rt
 
     msg = OutboxMessage(kind="agent", text="hello back")
     await session._put_outbox(msg)
@@ -124,7 +143,7 @@ async def test_put_outbox_keeps_explicit_reply_to(tmp_path):
     that explicitly sets reply_to wins).
     """
     session = _make_session(tmp_path)
-    session._last_reply_to = ExternalRef(transport="slack", destination={"channel": "C1"})
+    session._inbox_arbiter.last_reply_to = ExternalRef(transport="slack", destination={"channel": "C1"})
 
     explicit = TuiRef()
     msg = OutboxMessage(kind="agent", text="x", reply_to=explicit)

--- a/tests/runtime/test_session_invariants.py
+++ b/tests/runtime/test_session_invariants.py
@@ -832,7 +832,7 @@ async def test_p6_chain_state_changes_emit_events(tmp_path, monkeypatch):
     })
 
     # ── inbox_consume ─────────────────────────────────────────────────────
-    kind, payload = await session._consume_inbox()
+    kind, payload = await session._inbox_arbiter.consume_inbox()
     assert kind == "agent_request"
     chain_id = payload["chain_id"]
 


### PR DESCRIPTION
**[e2e-coder]** — Proposal 0067 P1: extract `InboxArbiter` out of `Session`, fix the reply_to staleness bug, rekey `agent_locks` onto the (agent, sid) axis.

## What

1. **`InboxArbiter` extraction** (`src/reyn/runtime/inbox_arbiter.py`, new). Moves the cohesive inbox-drain / dispatch-attribution field cluster off `Session`:
   - state: `pending_inbox_item`, `cancelled_msg_ids`, `next_turn_context`, `last_sender`, `last_reply_to`
   - methods: `consume_inbox` (was `Session._consume_inbox`), `peek_mid_turn_injection`, `stage_next_turn_context`, `drain_to_wake`, `handle_sender_attribution` (was `Session._handle_sender_attribution`)
   - `_format_sender_label` + its transport-label table moved with it (only caller)

   `Session` keeps `_commit_mid_turn_injection`, `cancel_queued`, `restore_state`, `reset_for_rewind`, and the `_run_router_loop` next-turn-context flush — each now reaches into `self._inbox_arbiter`'s public attributes rather than owning a private copy. One holder per field.

   **Deviation from the literal dispatch, flagged deliberately**: `_run_turn_body`'s kind-dispatch block was named as a 4th target but does NOT touch any InboxArbiter-owned field — it just routes by `kind` to five unrelated `Session._handle_*` methods. Per the refactoring skill's coupling check, moving it would mean injecting 5+ handler callables for zero state ownership (the "wrong extraction target" smell), so it stays in `Session`. Line/function counts below reflect this.

2. **The reply_to staleness fix** (co-vet: architect + lead-coder, independently converged, both confirmed in #3978 broker thread). `InboxArbiter.handle_sender_attribution` used to preserve `last_reply_to` across calls that carried no `reply_to`, on the stated theory ("the previous value is preserved... downstream interceptor handles the no-reply_to case by falling through to the default surface") that this was harmless. Verified false: `Session._put_outbox`/`_put_outbox_nowait` both default a message's `reply_to` from `last_reply_to` **before** the interceptor ever runs, so the stale value was actually delivered — a CRON/HOOK/AGENT_STEP/PIPELINE_RESULT turn (none of which ever carry `reply_to`), or even a local CLIENT_INPUT typed right after a Slack-originated turn, inherited and misdelivered to the previous turn's transport.

   Fix: `reply_to` is now **always** taken from the current payload (`self.last_reply_to = payload.get("reply_to")`), never inherited. Verified against every inbox-payload-constructing call site in `src/reyn/` — no producer relies on omission meaning "keep inheriting"; the two producers that ever set `reply_to` (`gateway.api`'s webhook dispatch, `interfaces.web.server`'s cron notify) each resend it on every payload that wants it, and the cron path's own comment already documented the intended fallback ("No notify → no reply_to → interceptor falls through → event-log only").

   Per-producer observed post-fix destination (no new default invented — this is just what already runs once the stale override stops firing):
   - `cron` (no notify): `reply_to=None` → `_put_outbox` skips the interceptor entirely, message goes to the normal `self.outbox` queue exactly as the CRON handler's own comment always claimed.
   - `AGENT_RESPONSE` / `PIPELINE_RESULT`: never set `reply_to` in the payload; same normal-queue fallthrough.
   - `HOOK`: not constructed via a `reply_to`-bearing payload anywhere in `src/reyn/`; same fallthrough.
   - Slack/webhook producers that DO want a destination: unaffected — they resend `reply_to` on every payload.

3. **`agent_locks.get_agent_lock` rekeyed onto `(agent_name, sid)`** (architect A-2 finding: the lock protects one `Session`'s `history`, not an agent name — an agent can have more than one live session, e.g. a per-delegation `a2a:<id>` session alongside "main"). `sid=None`/omitted canonicalizes to `"main"`, so existing bare callers are unaffected. The one real call site (`mcp/server.py:249`, inside `send_to_agent_impl`) now passes its own `sid` parameter through.

## Testing

- New: `src/reyn/runtime/inbox_arbiter.py` — byte-identical-where-possible extraction (see module docstring).
- New tests in `tests/runtime/test_agent_locks_shared_1128.py`: (f)/(g)/(h) — different sids yield distinct locks, absent-sid canonicalizes to "main", concurrent different-sid holders don't serialize. Falsify-verified: reverting the key to `agent_name`-only makes (f)/(h) go RED for the exact reason.
- Rewrote `test_attribution_does_not_clear_reply_to_when_payload_lacks_it` → `test_attribution_clears_reply_to_when_payload_lacks_it` (the old test pinned the bug).
- Consumer sweep: 9 pre-existing test files reached into the moved private state directly (`session._handle_sender_attribution`, `session._drain_to_wake()`, `session._consume_inbox()`, `session._peek_mid_turn_injection()`, `session._next_turn_context`, `session._last_reply_to`) — all updated to the new `session._inbox_arbiter.*` surface. Includes updating `test_3595_client_input_provenance_gate.py`'s AST-walk site registry (`Session._peek_mid_turn_injection` → `InboxArbiter.peek_mid_turn_injection`) since the `TurnOrigin.CLIENT_INPUT` reference physically moved files.
- `mypy_ratchet_baseline.json`: added `(inbox_arbiter.py, arg-type)` — the exact same pre-existing `SnapshotJournal.consume_inbox(msg_id: str)` vs `str|None` looseness that was already baselined for `session.py`, relocated with the code (not a new defect).

Local gates: ruff (src+tests) clean, `test_tier_audit.py --strict` on all 10 changed/touched test files (87 tests, 0 Tier-4), `verify_module_docstrings.py` clean, `mypy_ratchet.py` OK (211/214 baselined), `check_tests_path_literal_reference.py` OK. Full `tests/runtime/` + `tests/core/` + `tests/mcp/` + `tests/web/` + `tests/interfaces/` sweep green (only pre-existing, unrelated `setproctitle`-environment flakes deselected — confirmed identical failures on pre-branch main).

## agent_locks.py key witness

Not automated (a live-process `ps` environment flake already affects two unrelated proctitle tests in this repo on this machine, so a similar OS-dependent witness for the lock axis wasn't added) — the mechanism-level falsify-verified tests above are the witness for this PR; the wiring call site itself is a 4-line change with no branching to hide a bug in.

Part of #3978 (P1 stage). Arc continues per the proposal's remaining stages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
