### PR TITLE
docs(#4094): fix stale agent-lock comments after the (agent, sid) rekey

### DIFF
--- a/src/reyn/interfaces/web/routers/a2a.py
+++ b/src/reyn/interfaces/web/routers/a2a.py
@@ -60,7 +60,6 @@ from reyn.runtime.a2a_routing import (
     a2a_session_id,
     resolve_a2a_session,
 )
-from reyn.runtime.agent_locks import get_agent_lock
 from reyn.runtime.session_pure import new_chain_id
 
 logger = logging.getLogger(__name__)

--- a/src/reyn/mcp/server.py
+++ b/src/reyn/mcp/server.py
@@ -61,10 +61,13 @@ _IDLE_POLL_INTERVAL_SECONDS: float = 0.05
 _IDLE_GRACE_SECONDS: float = 0.05
 
 
-# Per-agent serialization lock — shared across ALL transport layers (MCP +
-# A2A).  ``_get_agent_lock`` is imported from ``reyn.runtime.agent_locks`` at the
-# top of this file so MCP and A2A share the SAME lock object per agent name.
-# See that module for the full rationale.
+# Per-(agent, sid) serialization lock (proposal 0067 P1, #3978 — rekeyed
+# from agent_name alone; this lock protects THIS session's history, and an
+# agent can have more than one live session). ``_get_agent_lock`` is imported
+# from ``reyn.runtime.agent_locks`` at the top of this file; A2A traffic
+# reaches this same lock by routing through ``send_to_agent_impl`` below
+# rather than acquiring its own (see that module's docstring for the full
+# rationale, including why a2a.py's own import of it is vestigial).
 #
 # FP-0013: with MessageBus, the inbox is the serialization point but the
 # lock is retained as a belt-and-suspenders measure during the migration

--- a/src/reyn/mcp/server.py
+++ b/src/reyn/mcp/server.py
@@ -67,7 +67,7 @@ _IDLE_GRACE_SECONDS: float = 0.05
 # from ``reyn.runtime.agent_locks`` at the top of this file; A2A traffic
 # reaches this same lock by routing through ``send_to_agent_impl`` below
 # rather than acquiring its own (see that module's docstring for the full
-# rationale, including why a2a.py's own import of it is vestigial).
+# rationale).
 #
 # FP-0013: with MessageBus, the inbox is the serialization point but the
 # lock is retained as a belt-and-suspenders measure during the migration

--- a/src/reyn/runtime/agent_locks.py
+++ b/src/reyn/runtime/agent_locks.py
@@ -12,10 +12,9 @@ per-session ``asyncio.Lock`` before entering the critical section.
 This module is the single registry for those locks. ``mcp.server.send_to_agent_impl``
 is the one call site that actually acquires a lock today — ``a2a.py`` routes
 through ``send_to_agent_impl`` itself (``reyn.interfaces.web.routers.a2a``
-imports it from ``reyn.mcp.server``) rather than acquiring its own; a2a's OWN
-``get_agent_lock`` import is a leftover from a drain loop #2442 removed
-(the acquire went with it, the import didn't) and is not itself part of the
-current protection path. On a given event loop, every caller that reaches
+imports it from ``reyn.mcp.server``) rather than acquiring its own. (It
+carried a vestigial ``get_agent_lock`` import until #4095 — the acquire went
+with the drain loop #2442 removed, the import didn't.) On a given event loop, every caller that reaches
 ``send_to_agent_impl`` shares the same lock object for a given (agent, sid) pair.
 
 Design constraints:

--- a/src/reyn/runtime/agent_locks.py
+++ b/src/reyn/runtime/agent_locks.py
@@ -9,9 +9,14 @@ the same session race at every ``await`` inside ``run_one_iteration``, corruptin
 The fix: every transport that drives ``run_one_iteration`` acquires the same
 per-session ``asyncio.Lock`` before entering the critical section.
 
-This module is the single registry for those locks.  Both ``mcp_server`` and
-``a2a`` import ``get_agent_lock`` from here; on a given event loop they therefore
-share the same lock object for any given (agent, sid) pair.
+This module is the single registry for those locks. ``mcp.server.send_to_agent_impl``
+is the one call site that actually acquires a lock today — ``a2a.py`` routes
+through ``send_to_agent_impl`` itself (``reyn.interfaces.web.routers.a2a``
+imports it from ``reyn.mcp.server``) rather than acquiring its own; a2a's OWN
+``get_agent_lock`` import is a leftover from a drain loop #2442 removed
+(the acquire went with it, the import didn't) and is not itself part of the
+current protection path. On a given event loop, every caller that reaches
+``send_to_agent_impl`` shares the same lock object for a given (agent, sid) pair.
 
 Design constraints:
 - **Keyed by (agent_name, sid), not agent_name alone (proposal 0067 P1,

--- a/tests/runtime/test_agent_locks_shared_1128.py
+++ b/tests/runtime/test_agent_locks_shared_1128.py
@@ -10,9 +10,6 @@ registry is loop-aware since #1762, see ``agent_locks`` docstring):
   (a) ``get_agent_lock("x")`` is idempotent: repeated calls on the same loop
       return the identical lock object (``is`` identity).
   (b) Different agent names yield distinct lock objects.
-  (c) MCP and A2A obtain the SAME lock object for the same agent_name on the
-      same loop — both import from ``reyn.runtime.agent_locks``; the per-loop
-      registry ensures identity.
   (d) Concurrent coroutines acquiring the same lock are serialized:
       critical sections do not overlap (behavioral, not count-pin).
   (e) #1762 regression: a contended lock used across distinct event loops
@@ -71,40 +68,6 @@ async def test_different_names_return_distinct_locks() -> None:
     assert lock_a is not lock_b, (
         "get_agent_lock must return distinct asyncio.Lock objects for different "
         "agent names — sharing a lock across agents would over-serialize"
-    )
-
-
-# ---------------------------------------------------------------------------
-# (c) Cross-transport sharing: MCP and A2A import from the same registry
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_mcp_and_a2a_share_same_lock_registry() -> None:
-    """Tier 2: MCP and A2A obtain the same lock object for the same agent_name (same loop).
-
-    This is the central cross-transport guarantee of #1128 PR-b: both
-    mcp_server and a2a import ``get_agent_lock`` (aliased as
-    ``_get_agent_lock`` in mcp_server) from ``reyn.runtime.agent_locks``.
-    Because Python module imports are singletons, the module-level
-    ``_AGENT_LOCKS`` dict is shared, so the same agent_name yields the
-    same ``asyncio.Lock`` object regardless of which transport calls it.
-    """
-    # Import MCP's accessor — it is aliased as _get_agent_lock in mcp_server
-    # but the underlying function is the same object from agent_locks.
-    from reyn.mcp.server import (
-        _get_agent_lock as mcp_get_lock,  # type: ignore[attr-defined]  # noqa: PLC0415
-    )
-
-    agent = "cross-transport-agent"
-    lock_via_agent_locks = get_agent_lock(agent)
-    lock_via_mcp = mcp_get_lock(agent)
-
-    assert lock_via_agent_locks is lock_via_mcp, (
-        "MCP's _get_agent_lock and reyn.runtime.agent_locks.get_agent_lock must "
-        "return the SAME asyncio.Lock object for the same agent_name. "
-        "If they differ, a concurrent MCP+A2A pair on the same agent bypasses "
-        "the serialization guarantee."
     )
 
 


### PR DESCRIPTION
**[docs-maintainer]** — Dispatched by lead-coder as #4094, two `#4090` docstring-drift findings from a self-review pass.

## Finding 1: `src/reyn/mcp/server.py:64-72`

The comment above `_get_agent_lock`'s import said "MCP and A2A share the SAME lock object per agent name" — the pre-#4090 keying model, directly contradicting the already-correct comment 180 lines below at the actual call site (`:252`, which #4090 itself updated: "rekeyed from agent_name alone ... an agent can have more than one live session"). Same file, two comments disagreeing.

## Finding 2: `src/reyn/runtime/agent_locks.py`'s module docstring

Claimed "Both `mcp_server` and `a2a` import `get_agent_lock` from here" as the basis for "they share the same lock object" — true of the import statement, false of the actual protection path. Traced via `git log -S "get_agent_lock" -- src/reyn/interfaces/web/routers/a2a.py`: a2a.py's own acquire (a drain loop calling `async with get_agent_lock(agent_name): await session.run_one_iteration()`) was removed whole by `#2442` (running_skills surface removal) — the import survived as dead code, the acquire didn't. Confirmed today's real protection path: a2a.py imports and calls `mcp.server.send_to_agent_impl` directly (`grep get_agent_lock( src/reyn/interfaces/web/routers/a2a.py` → zero hits; `send_to_agent_impl` → 2 call sites), which is the one live acquire site.

## Fix

Both rewritten to describe the current path precisely: `send_to_agent_impl` acquires; a2a.py reaches the same lock by routing through that function, not via its own (vestigial) import.

## Why #4092 missed these

Architect's diagnosis, relayed by lead-coder: #4092's own stale-ref sweep scoped its population to `docs/` only, missing these 2 `src/` docstrings — the third time tonight a cleanup's own population was scoped too narrowly (`#3996`'s src+docs-only, `#4025`'s tests/-only, now this). Noted, not re-litigated here — that's lead-coder's/architect's process finding to act on, not mine to fix in this PR.

## Left untouched

Proposal 0067's "Verification notes for implementers" table entry describing this same pre-fix keying bug — a design-time observations table motivating each build stage (explicitly states "P0/P1 move identity to the session axis"), same historical-rationale reasoning already applied to ADR-0040 and this same proposal's method-name mentions earlier tonight.

## Test plan

- [x] `ruff check src/reyn/runtime/agent_locks.py src/reyn/mcp/server.py` — clean
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/agent_locks.py src/reyn/mcp/server.py` — OK
- [x] `python scripts/check_doc_anchors.py` — exit 0
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] Traced the a2a.py acquire removal via `git log -S`, not assumed from lead-coder's summary alone

fixes #4094

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**[lead-coder]** — reviewer's blocking items (rule 7):

- [ ] 🔴 `tests/runtime/test_agent_locks_shared_1128.py` — delete `test_mcp_and_a2a_share_same_lock_registry` and the file-header `(c)` bullet (same false claim as the one this PR removes from `agent_locks.py`; the test also fails six-questions Q2 and Q3). Do not repair it.
- [ ] 🔴 `src/reyn/interfaces/web/routers/a2a.py:63` — remove the dead `get_agent_lock` import (F401 is globally ignored, so no gate declares it dead; this import is what the false prose was reading as evidence).
