### PR TITLE
docs(#3978): record the cancel/describe_task reading in proposal 0067 (ADR restored)

### DIFF
--- a/docs/deep-dives/decisions/0040-task-as-os-concept.md
+++ b/docs/deep-dives/decisions/0040-task-as-os-concept.md
@@ -249,9 +249,28 @@ bug — it relocates it.
 **Undesirable / accepted**
 
 - **`cancel` is added to the canonical verb lexicon.** It is not a fifth removal verb — R2's four
-  (`delete` / `drop` / `forget` / `uninstall`) all mean "a thing ceases to exist", while a
-  cancelled task's record persists with `status="cancelled"`. The gate keeps `CANONICAL_VERBS`
-  and `REMOVAL_VERBS` as separate frozensets, so R2 is untouched.
+  (`delete` / `drop` / `forget` / `uninstall`) name the *disappearance of a thing* as their whole
+  purpose, while `cancel` names **stopping work that is in progress**. What a cancel produces is a
+  **settle** carrying `status="cancelled"`, delivered on the same `on_settle` path as any other
+  settle — not a second teardown route. The gate keeps `CANONICAL_VERBS` and `REMOVAL_VERBS` as
+  separate frozensets, so R2 is untouched.
+
+  ⚠️ Read this against D4, which it otherwise appears to contradict. An earlier wording here said
+  "a cancelled task's record persists", which reads as *registry* retention and so as an exception
+  to D4's immediate deletion. It is not one. Two different things are being named:
+
+  | | at settle |
+  |---|---|
+  | the **handle** (`task_id` → the pending entry) | **deleted**, D4, uniformly for every settle — cancelled included |
+  | the **audit-event record** (P6 `.reyn/events`) | **persists** — this is what "the record" meant |
+
+  `cancel` causes no deletion that a normal settle would not also cause; the handle's disappearance
+  is D4's behaviour, not the verb's. This is the same distinction §D4 already draws when it says
+  reyn "records it; that is observation, not retention" — stated there about delivery, and it holds
+  identically here. A consequence worth stating explicitly, because it decides an implementation
+  question: since handles are gone at settle, `describe_task` can only ever observe a **non-terminal**
+  status. `completed` / `failed` / `cancelled` exist in the vocabulary and reach the audit trail and
+  the requester's delivery, but never a `describe_task` reply.
 - **Four LLM-visible tools retire**: `delegate_to_agent`, and `run_pipeline_{async,inline,inline_async}`
   collapsing into `run_pipeline(collect=…, inline=…)`. Renames of LLM-visible strings require the
   system prompt and tool descriptions to move in the same PR.

--- a/docs/deep-dives/decisions/0040-task-as-os-concept.md
+++ b/docs/deep-dives/decisions/0040-task-as-os-concept.md
@@ -249,28 +249,9 @@ bug — it relocates it.
 **Undesirable / accepted**
 
 - **`cancel` is added to the canonical verb lexicon.** It is not a fifth removal verb — R2's four
-  (`delete` / `drop` / `forget` / `uninstall`) name the *disappearance of a thing* as their whole
-  purpose, while `cancel` names **stopping work that is in progress**. What a cancel produces is a
-  **settle** carrying `status="cancelled"`, delivered on the same `on_settle` path as any other
-  settle — not a second teardown route. The gate keeps `CANONICAL_VERBS` and `REMOVAL_VERBS` as
-  separate frozensets, so R2 is untouched.
-
-  ⚠️ Read this against D4, which it otherwise appears to contradict. An earlier wording here said
-  "a cancelled task's record persists", which reads as *registry* retention and so as an exception
-  to D4's immediate deletion. It is not one. Two different things are being named:
-
-  | | at settle |
-  |---|---|
-  | the **handle** (`task_id` → the pending entry) | **deleted**, D4, uniformly for every settle — cancelled included |
-  | the **audit-event record** (P6 `.reyn/events`) | **persists** — this is what "the record" meant |
-
-  `cancel` causes no deletion that a normal settle would not also cause; the handle's disappearance
-  is D4's behaviour, not the verb's. This is the same distinction §D4 already draws when it says
-  reyn "records it; that is observation, not retention" — stated there about delivery, and it holds
-  identically here. A consequence worth stating explicitly, because it decides an implementation
-  question: since handles are gone at settle, `describe_task` can only ever observe a **non-terminal**
-  status. `completed` / `failed` / `cancelled` exist in the vocabulary and reach the audit trail and
-  the requester's delivery, but never a `describe_task` reply.
+  (`delete` / `drop` / `forget` / `uninstall`) all mean "a thing ceases to exist", while a
+  cancelled task's record persists with `status="cancelled"`. The gate keeps `CANONICAL_VERBS`
+  and `REMOVAL_VERBS` as separate frozensets, so R2 is untouched.
 - **Four LLM-visible tools retire**: `delegate_to_agent`, and `run_pipeline_{async,inline,inline_async}`
   collapsing into `run_pipeline(collect=…, inline=…)`. Renames of LLM-visible strings require the
   system prompt and tool descriptions to move in the same PR.

--- a/docs/deep-dives/proposals/0067-task-model-and-arbiter.md
+++ b/docs/deep-dives/proposals/0067-task-model-and-arbiter.md
@@ -167,6 +167,34 @@ Measured during design; each has bitten or would bite:
 | `_last_reply_to` | inherited when a trigger carries no `reply_to` (`session.py:2731-2733`) — a live misdelivery path that P1 removes. |
 | chain timers | re-armed *fresh* on restore, so a crash extends the deadline (P8). |
 | hook points | eight, not ten (#3996). |
+| `RunStatus` | the status vocabulary D3 describes **already exists** — `run_registry.py:64`, five members, and the `input_required` transition is live at `a2a_intervention.py:124`. What is missing is a bridge to the chain handle, not a state machine. Reusing it from `runtime/` would be a new layering inversion (`runtime/ → interfaces/web/` is currently 0 imports; the reverse is 10), so it moves to `runtime/task_types.py` beside `TaskKind` / `Requester`. The rename to `TaskStatus` waits for P6, same treatment as `requester`. |
+
+### Reading ADR-0040 on what a cancel leaves behind
+
+The ADR's `cancel`-verb entry says "a cancelled task's record persists with
+`status="cancelled"`", which against D4 (immediate deletion, no retention) reads as registry
+retention for one status. It is not. Two different things are named, and D4 §"records it; that is
+observation, not retention" already draws the same line:
+
+| | at settle |
+|---|---|
+| the **handle** (`task_id` → the pending entry) | **deleted** — D4, uniformly for every settle, cancelled included |
+| the **audit-event record** (P6 `.reyn/events`) | **persists** — this is "the record" |
+
+Two implementation questions were being decided from that sentence on 2026-08-10, which is why it
+is written out here rather than left to the reader:
+
+- **Does a cancel settle?** Yes — `status=cancelled`, delivered on the same `on_settle` path.
+  A cancel that did not settle would leave a requester who asked for delivery with nothing, and
+  would give teardown a second route (the settle path's own acceptance condition is one function).
+- **What is `describe_task`'s status domain?** Since every settle deletes the handle, a
+  `describe_task` reply can only ever carry a **non-terminal** status: `running` or
+  `input-required`. `completed` / `failed` / `cancelled` are real, and reach the audit trail and
+  the requester's delivery — but never a `describe_task` reply.
+
+⚠️ This is a **reading** of an accepted ADR, recorded on the mutable surface because ADRs are
+immutable once accepted (`decisions/README.md:14`). It adds no decision the owner did not accept;
+where it draws a consequence, the consequence is marked as such above.
 
 LLM-visible strings change in P-1, P4, P5, P6 and P7. Each of those PRs updates the system
 prompt, `descriptions/catalog.py` and the affected docs **in the same PR** (CLAUDE.md's


### PR DESCRIPTION
**[architect]** — part of #3978. **block を受けて全面的に置き場を変えました。**

## ✅ block は正しく、私の理由づけがまさに規則の禁じている形でした

```
decisions/README.md:14   「ADRs are immutable once accepted」
ADR-0040 冒頭            Status: Accepted (2026-08-10, owner)
```
🔴 **「自分の書いた文が曖昧だったので直す」は、この規則が名指しで禁じている当のもの**です ──
**後から読む人が、owner が accept した決定と著者の後知恵を分離できなくなる。**
🔴 **さらに指摘のとおり、追加分の最終段落（handle が消える ∴ describe_task は非 terminal のみ）は
曖昧さの解消を超えて★新しい帰結を決めていました。** 曖昧さ修正の看板で決定を足しています。

⚠️ **私は同じ晩に「gate を歴史に掛けると機械が記録の書き換えを強制する」と書いています。**
**ADR の immutability は同じ原理**で、**それを持ちながら破りました。**
**規則を読まずに編集したのが原因**です（対象の doc class を統べる README を開いていない）。

## 変更

```
✅ ADR-0040        ★accept された姿へ復帰 ── blob hash 一致で確認済み
                   origin/main: ff239b7e…  HEAD: ff239b7e…（同一）
✅ proposal 0067   「Verification notes for implementers」へ移設
                   ＝ この arc が測った罠を置いている★可変面。ADR 冒頭が既にリンクしている先
```
⚪ **情報は失われません。** ⚪ **「これは accept された ADR の★読解であって、可変面に置くのは
ADR が immutable だから」と★本文に明記**しました ── **決定は足していない、帰結を引いた箇所は
帰結と明示、と読者が判別できる形にしています。**

⚪ **併せて 1 行**: `RunStatus` の行を Verification notes に追加（D3 の status 語彙は
`run_registry.py:64` に★既に在り、`input_required` 遷移も `a2a_intervention.py:124` で生きている ∴
P4 に要るのは状態機械でなく橋。`runtime/ → interfaces/web/` が現在 0 import なので
`task_types.py` へ移す）。

## Test plan

- [x] doc のみ（`src/` / `tests/` 変更なし）∴ pytest 対象なし
- [x] **ADR-0040 が `origin/main` と byte-identical であることを★blob hash で確認**
      （「戻した」と書くだけにせず実測 ── `git diff --stat` も 0067 の 1 ファイルのみ）
- [x] 移設先が ADR 冒頭のリンク経由で到達可能なことを確認
- [ ] (skipped — Visual 項目なし)
