### PR TITLE
feat(#3978): P4 — task status field + the cancel-hook substrate

### DIFF
--- a/src/reyn/interfaces/web/run_registry.py
+++ b/src/reyn/interfaces/web/run_registry.py
@@ -51,33 +51,20 @@ import logging
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+# #3978 P4: RunStatus moved to runtime/task_types.py (architect ruling,
+# 2026-08-10) — re-exported here unchanged so this module's own docstring
+# below (and its 3 existing consumers, all importing from THIS module) see
+# zero behavior/import-site change. See task_types.RunStatus's own
+# docstring for the layering-direction rationale.
+from reyn.runtime.task_types import RunStatus
 
 if TYPE_CHECKING:
     from reyn.runtime.channel_state import ChannelState
 
 logger = logging.getLogger(__name__)
-
-
-class RunStatus(str, Enum):
-    """The narrow, flat run-status vocabulary A2A needs (#2839 Phase 1).
-
-    Deliberately NOT the 7-state Task-tree ``TaskState`` (unassigned /
-    ready / running / blocked / done / failed / aborted) — this enum
-    only carries what an A2A async run's lifecycle actually produces:
-    the running default, the terminal outcomes, and the one
-    interactive state (``INPUT_REQUIRED`` — an ask_user escalation is
-    pending). ``str`` subclass so persisted JSON + wire comparisons
-    (``entry.status == "running"``) keep working without a shim.
-    """
-
-    RUNNING = "running"
-    INPUT_REQUIRED = "input-required"
-    COMPLETED = "completed"
-    FAILED = "failed"
-    CANCELLED = "cancelled"
 
 
 _TERMINAL_RUN_STATUSES: frozenset[RunStatus] = frozenset({

--- a/src/reyn/runtime/services/chain_manager.py
+++ b/src/reyn/runtime/services/chain_manager.py
@@ -80,10 +80,11 @@ class _PendingChain:
     # cancel_inflight / *Driver.request_cancel's own zero-arg shape; see
     # pipeline_executor_driver.PipelineExecutorDriver.request_cancel).
     # VOLATILE, held on THIS SAME dataclass rather than a second dict
-    # (lead-coder's ruling: "the hole where a callback survives after its
-    # chain is popped, and cancel_task can act on a task nothing runs
-    # anymore, is structurally impossible when there is only ONE store —
-    # not two that must be kept in sync"). `None` after a crash-recovered
+    # (architect's ruling, #3978 issue comments, 2026-08-10 — lead-coder's
+    # own contribution was narrower: that settle() clearing two stores in
+    # the SAME function is correct; collapsing to ONE store so the hole
+    # cannot exist structurally, rather than being closed by discipline,
+    # was architect's call). `None` after a crash-recovered
     # restore (the live callable belonged to the dead process) — a caller
     # (cancel_task) that finds `cancel is None` MUST NOT report success:
     # nothing is actually listening.

--- a/src/reyn/runtime/services/chain_manager.py
+++ b/src/reyn/runtime/services/chain_manager.py
@@ -19,6 +19,8 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Protocol, runtime_checkable
 
+from reyn.runtime.task_types import RunStatus
+
 if TYPE_CHECKING:
     from reyn.core.events.agent_snapshot import AgentSnapshot
     from reyn.runtime.task_types import Requester
@@ -63,6 +65,29 @@ class _PendingChain:
     # substrate). ``describe_task``/``list_tasks`` read this; a handle
     # registered with no ``kind`` is not yet describable as a typed task.
     kind: "str | None" = None
+    # proposal 0067 P4 (#3978): describe_task's status field (architect
+    # ruling, 2026-08-10) — typed RunStatus, not a bare string, so a LATER
+    # value (INPUT_REQUIRED, once the ask_user bridge lands — a separate
+    # step) is a value addition, not a caller-side type change. VOLATILE —
+    # deliberately NOT threaded through register()'s persisted `fields`
+    # dict, so it is never written to the journal/WAL. A crash-recovered
+    # handle has no way to truthfully know it was mid-ask_user, so it
+    # defaults back to RUNNING on restore() rather than persist a stale
+    # claim.
+    status: "RunStatus" = field(default=RunStatus.RUNNING, compare=False, repr=False)
+    # proposal 0067 P4 (#3978), architect ruling 2026-08-10: the task's
+    # cancel hook — cooperative, argument-zero (mirrors Session.
+    # cancel_inflight / *Driver.request_cancel's own zero-arg shape; see
+    # pipeline_executor_driver.PipelineExecutorDriver.request_cancel).
+    # VOLATILE, held on THIS SAME dataclass rather than a second dict
+    # (lead-coder's ruling: "the hole where a callback survives after its
+    # chain is popped, and cancel_task can act on a task nothing runs
+    # anymore, is structurally impossible when there is only ONE store —
+    # not two that must be kept in sync"). `None` after a crash-recovered
+    # restore (the live callable belonged to the dead process) — a caller
+    # (cancel_task) that finds `cancel is None` MUST NOT report success:
+    # nothing is actually listening.
+    cancel: "Callable[[], None] | None" = field(default=None, compare=False, repr=False)
 
     @property
     def requester(self) -> "Requester":
@@ -174,6 +199,7 @@ class ChainManager:
         origin_depth: int = 0,
         origin_sid: "str | None" = None,
         kind: "str | None" = None,
+        cancel: "Callable[[], None] | None" = None,
     ) -> _PendingChain:
         """Register a new pending chain and persist it via the journal.
 
@@ -201,6 +227,11 @@ class ChainManager:
             ``None`` for a legacy delegate-relay chain (no producer sets
             this today — P6 assigns one when ``delegate_to_agent``'s own
             completion folds into this substrate).
+        cancel:
+            proposal 0067 P4 (#3978): the task's cooperative cancel hook
+            (argument-zero), or ``None`` if this task cannot be cancelled
+            (e.g. a legacy delegate-relay chain). VOLATILE — never
+            persisted (see ``_PendingChain.cancel``'s own docstring).
         """
         chain = _PendingChain(
             chain_id=chain_id,
@@ -210,6 +241,7 @@ class ChainManager:
             waiting_on=set(waiting_on or []),
             origin_sid=origin_sid,
             kind=kind,
+            cancel=cancel,
         )
         self._chains[chain_id] = chain
 

--- a/src/reyn/runtime/services/pipeline_executor_driver.py
+++ b/src/reyn/runtime/services/pipeline_executor_driver.py
@@ -53,8 +53,17 @@ because no registry ever reached the executor):
   the next step boundary and raises ``PipelineCancelled``: the driver writes a
   TERMINAL ``cancelled`` marker (so the recovery scan never resurrects an
   intentionally-cancelled run) while LEAVING the R4 generation snapshots on
-  disk (abort-now, resume-later — R6). Cancel only reaches a sync/attached run
-  (async is detached), so a cancelled run is always ``notify_reply=False``.
+  disk (abort-now, resume-later — R6). Cancel used to reach only a
+  sync/attached run (async is detached — nothing forwarded a cancel signal
+  to a driver-session nobody is attached to) — proposal 0067 P4 (#3978)
+  closes that gap: launch-time registration on the settle-path handle
+  (``session_api._spawn_pipeline_driver_session``) captures THIS driver's
+  ``request_cancel`` as the task's ``cancel`` hook (``ChainManager``'s
+  ``_PendingChain.cancel``, cooperative and argument-zero, same shape as
+  the sync path's forward), so ``cancel_task`` can reach a DETACHED async
+  run too. ``notify_reply`` is no longer 1:1 with "was this cancelled via
+  the attached path" — an async run's cancelled terminal still delivers
+  (settles) via the normal ``_finish``/``_deliver`` path below.
 - after terminal, the driver marks its session ephemeral so the standard
   post-turn vanish teardown (``Session._maybe_schedule_ephemeral_vanish`` →
   ``registry.remove_session``) reclaims it — the driver-session never leaks
@@ -278,13 +287,17 @@ class PipelineExecutorDriver:
                     invoker_session=self._session,
                 )
         except PipelineCancelled as exc:
-            # IS-6: an intentional Ctrl-C stop at a step boundary. TERMINAL (so
-            # the recovery scan never zombie-resurrects a user-cancelled run) but
+            # IS-6: an intentional stop at a step boundary. TERMINAL (so the
+            # recovery scan never zombie-resurrects a user-cancelled run) but
             # the R4 generation snapshots are LEFT ON DISK — abort-now, yet a
             # future explicit-resume tool could continue from ``step_index``.
-            # Cancel only reaches here on the sync/attached path (async is
-            # detached, no Ctrl-C), so ``notify_reply`` is False → no inbox turn;
-            # the attached caller reads ``status=cancelled`` inline.
+            # Two reachable sources today: a Ctrl-C on the sync/attached path
+            # (``notify_reply=False`` — the attached caller reads
+            # ``status=cancelled`` inline via ``read_result``, no inbox turn)
+            # and, since proposal 0067 P4 (#3978), ``cancel_task`` reaching a
+            # DETACHED async run's ``request_cancel`` hook via the settle-path
+            # handle (``notify_reply=True`` — this ``_finish`` call below
+            # settles/delivers exactly like any other terminal status).
             await self._finish(
                 status="cancelled",
                 error=str(exc),

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -570,6 +570,16 @@ async def _spawn_pipeline_driver_session(
         schema_defs=schema_registry.as_dict() if schema_registry is not None else None,
     )
     write_invocation(pipeline_run_dir(root, rid), work_order)
+    session = registry.get_session(reply_to_agent, sid)
+    if session is None:
+        raise RuntimeError(
+            f"pipeline launch: spawned driver-session ({reply_to_agent!r}, "
+            f"{sid!r}) not found in the registry"
+        )
+    driver = PipelineExecutorDriver(
+        work_order, registry=registry, state_log=state_log,
+        notify_reply=notify_reply,
+    )
     if notify_reply:
         # proposal 0067 settle path (#3978): register this run's collection
         # handle on the REPLY session's own ChainManager (pending_chains,
@@ -583,6 +593,19 @@ async def _spawn_pipeline_driver_session(
         # handle" case ``ChainManager.settle()`` already tolerates); the
         # run still launches and ``_deliver``'s own fail-safe re-discovers
         # the vanished target at settle time.
+        #
+        # proposal 0067 P4 (#3978), architect ruling 2026-08-10: the
+        # DRIVER's own ``request_cancel`` (the SAME argument-zero hook
+        # ``run_pipeline_attached`` already forwards via
+        # ``register_cancel_forward`` for the sync path) is captured here
+        # as this handle's ``cancel`` — the async path had NO cancel
+        # reachability before this (nothing forwards a cancel signal to a
+        # detached driver-session; only an ATTACHED caller's
+        # cancel_inflight ever reached ``request_cancel``). ``cancel_task``
+        # reads this off the handle; it does NOT branch on ``kind`` to
+        # pick a mechanism (architect's correction — the three
+        # cancellation mechanisms differ in what LIVE OBJECT they need,
+        # not in which method name to call).
         reply_target, _reason = await resolve_reply_target(
             registry, reply_to_agent, reply_to_sid,
         )
@@ -593,19 +616,9 @@ async def _spawn_pipeline_driver_session(
                 origin_agent=reply_to_agent,
                 origin_sid=None if reply_to_sid == "main" else reply_to_sid,
                 kind="pipeline",
+                cancel=driver.request_cancel,
             )
-    session = registry.get_session(reply_to_agent, sid)
-    if session is None:
-        raise RuntimeError(
-            f"pipeline launch: spawned driver-session ({reply_to_agent!r}, "
-            f"{sid!r}) not found in the registry"
-        )
-    session.set_loop_driver(
-        PipelineExecutorDriver(
-            work_order, registry=registry, state_log=state_log,
-            notify_reply=notify_reply,
-        )
-    )
+    session.set_loop_driver(driver)
     return session, rid, sid
 
 

--- a/src/reyn/runtime/task_types.py
+++ b/src/reyn/runtime/task_types.py
@@ -40,12 +40,45 @@ Field-by-field source, all from proposal 0067 (docs/deep-dives/proposals/
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Literal
 
 from reyn.runtime.transport import TransportRef
 
 TaskKind = Literal["prompt", "pipeline", "exec"]
 CollectMode = Literal["attached", "async"]
+
+
+class RunStatus(str, Enum):
+    """The narrow, flat run-status vocabulary A2A needs (#2839 Phase 1),
+    relocated here (#3978 P4, architect ruling 2026-08-10) so both
+    ``runtime/`` (``ChainManager``/``describe_task``) and
+    ``interfaces/web/`` (``RunEntry``) can import ONE vocabulary without a
+    layering inversion: ``runtime/`` → ``interfaces/web/`` had ZERO imports
+    before this move, and ``interfaces/web/`` → ``runtime/`` is the
+    established direction (10 files) — so the type moves here rather than
+    ``runtime`` reaching into ``interfaces.web.run_registry``.
+    ``reyn.interfaces.web.run_registry`` re-exports this name unchanged
+    (``from reyn.runtime.task_types import RunStatus``) — zero behavior
+    change, zero import-site churn for its existing 3 consumers.
+
+    Deliberately NOT the 7-state Task-tree ``TaskState`` (unassigned /
+    ready / running / blocked / done / failed / aborted) — this enum
+    only carries what an A2A async run's lifecycle actually produces:
+    the running default, the terminal outcomes, and the one
+    interactive state (``INPUT_REQUIRED`` — an ask_user escalation is
+    pending). ``str`` subclass so persisted JSON + wire comparisons
+    (``entry.status == "running"``) keep working without a shim.
+
+    A rename to ``TaskStatus`` (matching this module's other task-model
+    names) is deferred to P6, same "read-site first, rename later" shape
+    as ``_PendingChain.requester``."""
+
+    RUNNING = "running"
+    INPUT_REQUIRED = "input-required"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
 
 
 @dataclass(frozen=True)

--- a/tests/core/test_pipeline_is2_driver_session.py
+++ b/tests/core/test_pipeline_is2_driver_session.py
@@ -399,14 +399,18 @@ async def test_the_registered_cancel_hook_actually_stops_a_running_async_run(
     spec — "cancel_task actually stops a running task". Before this PR,
     NOTHING forwarded a cancel signal to a DETACHED async pipeline run
     (only an ATTACHED caller's ``cancel_inflight`` ever reached
-    ``request_cancel``). Real mid-flight interruption, not a pre-empted
-    launch: step 1's real side effect (a real file write) is confirmed to
-    have landed, THEN cancel fires while step 1's tool call is still
-    in-flight (gated on an ``asyncio.Event`` — the plain pipeline's steps
-    have no internal ``await`` point, so without this gate every step lands
-    in the same event-loop tick, and there is no observable mid-flight
-    window at all), THEN step 1 is allowed to return — confirming step 2's
-    side effect NEVER lands (the run stopped BETWEEN steps, not after
+    ``request_cancel``). This test witnesses the registered HOOK stopping a
+    running task, driven directly via ``chain.cancel()`` — ``cancel_task``
+    (the LLM-facing tool) doesn't exist yet in this PR; its own reachability
+    from a tool call is a separate PR's witness. Real mid-flight
+    interruption, not a pre-empted launch: step 1's real side effect (a real
+    file write) is confirmed to have landed, THEN cancel fires while step
+    1's tool call is still in-flight (gated on an ``asyncio.Event`` — the
+    plain pipeline's steps have no internal ``await`` point, so without this
+    gate every step lands in the same event-loop tick, and there is no
+    observable mid-flight window at all), THEN step 1 is allowed to return
+    — confirming step 2's side effect NEVER lands (the run stopped BETWEEN
+    steps, not after
     completing) — plus the full settle-path contract: terminal status is
     "cancelled", task_settled fires with that status, and the handle is
     gone."""

--- a/tests/core/test_pipeline_is2_driver_session.py
+++ b/tests/core/test_pipeline_is2_driver_session.py
@@ -150,6 +150,40 @@ def _install_side_effect_tool(monkeypatch) -> None:
     monkeypatch.setattr(tools_pkg, "get_default_registry", _with_tool)
 
 
+def _install_gated_side_effect_tool(monkeypatch, gate: "asyncio.Event") -> None:
+    """Like ``_install_side_effect_tool``, but the handler blocks on ``gate``
+    AFTER writing its line and BEFORE returning — so a test can create a
+    real, deterministic mid-flight window (the write is observably done,
+    but the executor hasn't reached the next step-boundary cancel_check
+    yet) instead of racing an instantaneous, no-await pipeline where every
+    step lands in the same event-loop tick."""
+    import reyn.tools as tools_pkg
+    from reyn.tools.types import ToolDefinition, ToolGates
+
+    async def _handler(args, ctx):
+        p = Path(args["path"])
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with p.open("a", encoding="utf-8") as f:
+            f.write(str(args["line"]) + "\n")
+        await gate.wait()
+        return {"line": str(args["line"])}
+
+    tool = ToolDefinition(
+        name="is2_append", description="IS-2 test: gated append.",
+        parameters={"type": "object", "properties": {}},
+        gates=ToolGates(router="allow"), handler=_handler,
+        category="io", purity="side_effect",
+    )
+    base_build = tools_pkg.get_default_registry
+
+    def _with_tool():
+        registry = base_build()
+        registry.register(tool)
+        return registry
+
+    monkeypatch.setattr(tools_pkg, "get_default_registry", _with_tool)
+
+
 def _bare_ctx(state_log: "StateLog | None" = None) -> ToolContext:
     from reyn.core.events.events import EventLog
     return ToolContext(
@@ -355,6 +389,76 @@ async def test_run_pipeline_async_launches_and_delivers_result(tmp_path: Path, m
     assert await _wait_for(
         lambda: reg.get_session("worker", invocation["driver_sid"]) is None
     )
+
+
+@pytest.mark.asyncio
+async def test_the_registered_cancel_hook_actually_stops_a_running_async_run(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2c: proposal 0067 P4 (#3978), lead-coder's original P4 witness
+    spec — "cancel_task actually stops a running task". Before this PR,
+    NOTHING forwarded a cancel signal to a DETACHED async pipeline run
+    (only an ATTACHED caller's ``cancel_inflight`` ever reached
+    ``request_cancel``). Real mid-flight interruption, not a pre-empted
+    launch: step 1's real side effect (a real file write) is confirmed to
+    have landed, THEN cancel fires while step 1's tool call is still
+    in-flight (gated on an ``asyncio.Event`` — the plain pipeline's steps
+    have no internal ``await`` point, so without this gate every step lands
+    in the same event-loop tick, and there is no observable mid-flight
+    window at all), THEN step 1 is allowed to return — confirming step 2's
+    side effect NEVER lands (the run stopped BETWEEN steps, not after
+    completing) — plus the full settle-path contract: terminal status is
+    "cancelled", task_settled fires with that status, and the handle is
+    gone."""
+    gate = asyncio.Event()
+    _install_gated_side_effect_tool(monkeypatch, gate)
+    captured: list[tuple[str, dict]] = []
+    _capture_hook_dispatch(monkeypatch, captured)
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    scripted = _ScriptedAgentReply("acknowledged")
+    reg = _agent_registry(tmp_path, state_log, scripted)
+    out_file = tmp_path / "out.txt"
+
+    pipeline_registry = PipelineRegistry()
+    pipeline_registry.register("p", _three_step_pipeline(out_file))
+
+    caller = reg.get_or_load("worker")
+    ctx = ToolContext(
+        events=caller._router_host.events,
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=RouterCallerState(
+            pipeline_registry=pipeline_registry,
+            agent_registry=reg,
+            host=caller._router_host,
+        ),
+        state_log=state_log,
+    )
+
+    result = await _handle_run_pipeline_async({"name": "p", "input": {"seed": 10}}, ctx)
+    run_id = result["data"]["run_id"]
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", run_id)
+
+    # Anchor on real mid-flight execution: step 1's write landed, but its
+    # tool call is still blocked on `gate` — the executor is genuinely
+    # inside step 1, not merely queued to start it.
+    assert await _wait_for(lambda: out_file.is_file() and out_file.read_text() == "11\n")
+
+    chain = caller.chains.get(run_id)
+    assert chain is not None and chain.cancel is not None
+    chain.cancel()
+    gate.set()  # let step 1's tool call return — the step boundary check follows
+
+    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    terminal = _result_json(run_dir)
+    assert terminal["status"] == "cancelled"
+    # Step 2's side effect NEVER lands — stopped between steps, not after.
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["11"]
+    (settled,) = [p for point, p in captured if point == "task_settled"]
+    assert settled["task_id"] == run_id
+    assert settled["status"] == "cancelled"
+    assert not caller.chains.has(run_id)
 
 
 # ── #3978 P3: task_settled — delivery-anchored ordering + strip-falsify ─────


### PR DESCRIPTION
**[tui-coder]** — proposal 0067 P4, status field + cancel-hook substrate (architect ruling, 2026-08-10: both "don't build new, use what's there").

## status — RunStatus moved, not reinvented

`RunStatus` (`running`/`input-required`/`completed`/`failed`/`cancelled`) already existed in `interfaces/web/run_registry.py`. Moved to `runtime/task_types.py` (fixing a layering direction — `runtime` → `interfaces/web` had 0 imports before this, `interfaces/web` → `runtime` is the established direction) and re-exported unchanged from `run_registry.py` — zero behavior change for its 3 existing consumers.

`_PendingChain.status: RunStatus = RunStatus.RUNNING` — typed, volatile (never persisted), so a later `input-required` bridge is a value addition, not a caller-side type change.

## cancel — one store, not two

`_PendingChain.cancel: Callable[[], None] | None` — on the SAME dataclass as `kind`/`status`, not a second dict (lead-coder's ruling: two stores that must both clear at settle is a structural hole; one store means "chain popped ⇒ hook gone" by construction). Also volatile.

Async pipeline launch now captures `PipelineExecutorDriver.request_cancel` as this hook — closing a real gap: async runs had NO cancel path before this (only an attached caller's `cancel_inflight` ever reached it).

## Stale docs fixed in the same PR

`pipeline_executor_driver.py` asserted "cancel only reaches sync/attached runs" in two places — true before, false after. Fixed both.

## Tests

New witness in `tests/core/test_pipeline_is2_driver_session.py`: lead-coder's original P4 spec, "cancel_task actually stops a running task". Real mid-flight interruption via a new gated-tool helper (an `asyncio.Event`-blocked tool call creates an observable window between step 1 landing and step 2 starting — the existing pipeline has no internal await point otherwise). Falsify-verified (dropped the cancel-hook wiring, confirmed genuine red, reverted).

All real collaborators — no mocks.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 32/32 OK
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (210/214 baselined)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/core/test_pipeline_is2_driver_session.py tests/runtime/test_chain_manager_settle_3978.py tests/runtime/test_chain_manager_find_chain.py tests/core/test_agent_snapshot.py tests/hooks/` — 370 passed
- [x] `pytest tests/interfaces/test_run_registry.py tests/interfaces/test_fp0001_run_registry.py tests/interfaces/test_2839_a2a_run_registry_truncate_falsify.py tests/interfaces/test_a2a_task_view_1953.py` — 26 passed (RunStatus move sanity)
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean (pre-existing ja-mirror INFO gaps only)
- [x] Falsify-verified the cancel-hook witness (confirmed genuine red, reverted)
- [ ] Visual — n/a (no TUI-visible change)

## Remaining P4 scope (not in this PR)

The actual `run_prompt`/`describe_task`/`list_tasks`/`cancel_task` LLM-facing tools, `cancel` → `CANONICAL_VERBS`, and `run_prompt(attached)`'s dispatch — the last is waiting on `PEER_SESSION` (a shared new `TurnOrigin` member, per architect's P4/P5 ruling) landing from the parallel P5 PR.

part of #3978

🤖 Generated with [Claude Code](https://claude.com/claude-code)
