### PR TITLE
docs(#3978): P7's params are name/definition, and the S3 deny pair needs an equality check

### DIFF
--- a/docs/deep-dives/proposals/0067-task-model-and-arbiter.md
+++ b/docs/deep-dives/proposals/0067-task-model-and-arbiter.md
@@ -26,9 +26,9 @@ the stale hook-point count (**#3996**).
 | `list_tasks` | `kind?` | `[{task_id, kind, status, session}]` — running only | lexicon `list` | `sync` |
 | `cancel_task` | `task_id` | `{task_id, status}` | **`cancel`, added to the lexicon** | `sync` |
 | `send_to_session` | `agent`, `session`, `text`, `wake=False` | `{}` | pairs with existing `send_to_agent` | `sync` |
-| `run_pipeline` | `pipeline`, `collect`, `inline`, `on_settle`, … | as `run_prompt` | lexicon `run` | `sync` |
+| `run_pipeline` | `name`, `definition`, `collect`, `on_settle`, … | as `run_prompt` | lexicon `run` | `sync` |
 | ~~`delegate_to_agent`~~ | — | — | — | retired |
-| ~~`run_pipeline_{async,inline,inline_async}`~~ | — | — | — | retired (folded into `collect` / `inline`) |
+| ~~`run_pipeline_{async,inline,inline_async}`~~ | — | — | — | retired (folded into `collect`) |
 
 ```
 new tools   5      4 task-facing + 1 delivery
@@ -139,7 +139,10 @@ P6    retire delegate_to_agent (its own PR; 129 files mention it, whole-repo, at
       re-measure before starting, and see the scope note below for what is NOT work)
       pending_chains is repurposed as P3/P4's collection substrate
 
-P7    run_pipeline: four names → one (collect / inline as arguments)
+P7    run_pipeline: four names → one (`collect` carries the attached/async axis)
+      The two SOURCE params are unchanged: `name` (a registered pipeline) and `definition`
+      (an ad-hoc DSL string) — exactly one, validated, never inferred from which is present.
+      P7 adds `collect` and `on_settle` and renames nothing.
 
 P8    ttl expiry: reuse the chain-timeout shape, plus persist `arm_at`
       chain_manager.py:362 re-arms "a fresh timeout watchdog" on restore, so a crash currently
@@ -167,7 +170,33 @@ Measured during design; each has bitten or would bite:
 | `_last_reply_to` | inherited when a trigger carries no `reply_to` (`session.py:2731-2733`) — a live misdelivery path that P1 removes. |
 | chain timers | re-armed *fresh* on restore, so a crash extends the deadline (P8). |
 | hook points | eight, not ten (#3996). |
+| S3 deny sets | the launch-verb deny exists **twice** — `_PIPELINE_STEP_DENY_TOOLS` (`tools/pipeline_verbs.py:211`, R6 S3, pipeline tool steps) and `_DELEGATION_DENY_TOOLS` (`runtime/session_api.py:136`, R5, agent steps). Same five names today. Both files say "kept in lock-step" and **nothing enforces it**: the only place `tests/` names both is a module docstring, and no test compares them. P6 and P7 each touch both. See the note below. |
 | `RunStatus` | the status vocabulary D3 describes **already exists** — `run_registry.py:64`, five members, and the `input_required` transition is live at `a2a_intervention.py:124`. What is missing is a bridge to the chain handle, not a state machine. Reusing it from `runtime/` would be a new layering inversion (`runtime/ → interfaces/web/` is currently 0 imports; the reverse is 10), so it moves to `runtime/task_types.py` beside `TaskKind` / `Requester`. The rename to `TaskStatus` waits for P6, same treatment as `requester`. |
+
+### The two S3 deny sets stay two, and get an equality check
+
+They are not one fact stored twice — they are two rules (R5 on agent steps, R6 S3 on pipeline tool
+steps) that currently name the same tools. Divergence could one day be correct: a tool safe to call
+from an agent step but not from a pipeline tool step. Collapsing them into one set would forbid that
+structurally, which is the opposite of the reasoning that put the cancel hook onto `_PendingChain`
+as a single field — there, one fact lived in two places and any divergence was a bug.
+
+The discriminator is **one fact, or two rules that agree** — not "are there two containers".
+
+What the pair does need is a check, because the agreement is currently asserted only in prose:
+
+- `set(_PIPELINE_STEP_DENY_TOOLS) == set(_DELEGATION_DENY_TOOLS)`
+- plus a non-empty assertion on both — `set() == set()` is green, so an emptied set would pass the
+  equality check while denying nothing
+- and a docstring line saying that diverging them means editing this test deliberately
+
+That converts silent drift into a red test without forbidding a deliberate divergence.
+
+⚠️ The drift is **asymmetric**, and the safe direction is the one P6/P7 will actually take. Failing
+to *remove* a retired name over-denies and is harmless. Failing to *add* a future launch verb to one
+of the two leaves that surface under-denied — a real hole, and the direction nothing is watching.
+
+Put the check on whichever of P6 / P7 touches both files first.
 
 ### `input_required` is spelled three ways
 


### PR DESCRIPTION
**[architect]** — part of #3978。**予告した P7 の param 名訂正 ＋ S3 deny pair の裁定を doc 化。両方とも★私の記述が実装者に spec として届いたもの。**

## ① param 名 ── ★現行維持（`name=` / `definition=`）

```
0067:29 旧  | run_pipeline | ★`pipeline`, `collect`, ★`inline`, `on_settle`, … |
        新  | run_pipeline | ★`name`, ★`definition`, `collect`, `on_settle`, … |
0067:142 旧  「(collect / ★inline as arguments)」 ← ★軸の名前を書いたのに param 名に読める
        新  collect が attached/async 軸を運ぶ、★source param 2 つは不変、と明記
```
🔴 **e2e が P7 を scope するとき「registered ★`pipeline` name」と★私の表を引用してきて発覚**しました。
⚪ **`inline=` は boolean に読めるのに DSL 文字列を運び、`pipeline=` は `run_pipeline(pipeline=…)` で冗長**
── **現行名のほうが正しいので、P7 は★何も rename しません**（追加は `collect` / `on_settle` のみ）。

## ② S3 deny pair ── ★2 つのまま。ただし等価 assert を足す

**lead-coder が「cancel hook で倉庫を 1 つにさせたのと矛盾では」と正しく問うたもの。**

```
判別子は ★「倉庫が 2 つか」ではない → ★「事実が 1 つか、規則が 2 つが一致しているか」
  cancel hook  1 つの事実が 2 箇所 ∴ ★乖離は常にバグ ∴ 畳む
  deny pair    R5(agent step) と R6 S3(pipeline tool step) の★別規則が今は同じ名前を挙げている
               ∴ ★乖離が正当な場合があり得る ∴ 畳むとそれを★構造的に禁じてしまう
```

🔴 **測って出た本題**: **「kept in lock-step」を強制するものが★0 件**
（両ファイルのコメント ＋ test の module docstring ＝ **3 つとも散文**。`tests/` に `==` の assert 無し）。

```
✅ set(_PIPELINE_STEP_DENY_TOOLS) == set(_DELEGATION_DENY_TOOLS)
✅ ★両方が空でないことも assert ── ★set() == set() は緑になる
✅ 「乖離させるならこの test を意図的に書き換えよ」と docstring に
```
⚠️ **非対称性も記録**: **退役名の消し忘れ＝過剰 deny＝無害**（P6 / P7 が踏むのはこちら）／
**将来の launch 動詞を片方にだけ足す＝under-deny＝★本物の穴**（**誰も見ていない方向**）。

## Test plan

- [x] doc のみ（`src/` / `tests/` 変更なし）∴ pytest 対象なし
- [x] **2 集合の中身が実際に同一であることを★両定義から抽出して比較**（5 名一致）
      ── e2e の行番号を信じず、`git show` で両方の定義を読んで突き合わせ
- [x] **lock-step を強制する test の不在を確認** ── `tests/` の両名参照は
      `test_pipeline_is4_inline.py` の★module docstring のみ（コード参照 0、`==` assert 0）
- [x] 現行 param 名を実コードで確認（`pipeline_verbs.py` の `"name"` / `"definition"` schema）
- [ ] (skipped — Visual 項目なし)

⚠️ **未測**: 「R5 と R6 S3 の乖離が正当にあり得る」は★rule ID と呼び出し点からの推論で、
**実例は見つけていません。** **両者が同一要件の 2 実装だと判明すれば ②の結論は覆ります。**
