### PR TITLE
docs(#4091): stop writing "N builtin points" — the recurring drift site

### DIFF
--- a/docs/concepts/runtime/hooks.md
+++ b/docs/concepts/runtime/hooks.md
@@ -44,14 +44,14 @@ valid in one is not necessarily valid in the other:
 | — (open) | `llm:<session_id>:<event_name>` | the LLM itself emits one via `emit_hook_event` (always its own session) | ❌ **rejected at load** (`HookConfigError`) | ✅ |
 
 **`llm:*` can never be a hook's `on:` value — only a Composer input.** A
-`hooks:` entry only accepts the 9 builtin bare/namespaced forms above or a
-`composed:<name>` prefix; anything else (including a well-formed
+`hooks:` entry only accepts the builtin bare/namespaced forms in the table
+above or a `composed:<name>` prefix; anything else (including a well-formed
 `llm:<session_id>:<event_name>`) is a load-time `HookConfigError`. To react
 to an LLM-emitted event, correlate it through a `composers:` entry into a
 `composed:<name>` event, then put your `hooks:` entry's `on:` on THAT
 composed kind — see the [worked example](#llm-authored-hook-events-emit_hook_event)
-below. The bare/namespaced-form duality only applies within the 9 builtin
-points — it does not extend `on:`'s acceptance to `llm:*`.
+below. The bare/namespaced-form duality only applies within the builtin
+points listed in the table — it does not extend `on:`'s acceptance to `llm:*`.
 
 ### The 4 config schemes — every field
 
@@ -116,7 +116,7 @@ template vars before the hook's action runs.
 - Match rule by field **name**: `uri` and `path` use a shell-style glob
   (`fnmatch`); every other field name is exact string equality.
 - Absent or empty `matcher` → the hook always fires.
-- For the 9 builtin points, a matcher field outside that point's payload
+- For a builtin point, a matcher field outside that point's payload
   (a typo, or a field the point never carries) is a **load-time
   `HookConfigError`** — rejected before the hook can ever run.
 - For a hook's `matcher` on a `composed:*` `on:` target, or a Composer

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -973,7 +973,7 @@
 #   pipeline_launch — launch a registered pipeline (async/detached), input
 #                    Jinja2-rendered from the event's template vars.
 #
-#   on:            the 9 builtin points — turn_start | turn_end | session_start |
+#   on:            the builtin points — turn_start | turn_end | session_start |
 #                  session_end | mcp_resource_updated | file_changed |
 #                  cron_fired | webhook_received | task_settled — plus the two
 #                  open namespaces ``composed:<name>`` (a Composer's output,

--- a/src/reyn/hooks/schema.py
+++ b/src/reyn/hooks/schema.py
@@ -93,10 +93,12 @@ from reyn.hooks.schema_registry import BARE_TO_KIND
 # kind table) rather than hand-maintained here — a future builtin point (the
 # proposal's "future point" list: pre/post_tool_use, pipeline_start/end) is
 # added there (schema + one dispatch call site) and automatically becomes a
-# recognised ``on:`` value here, with zero edits to this module. The 8
-# points today are unchanged: turn_start/turn_end, session_start/
-# session_end (lifecycle), mcp_resource_updated
-# (#2608 H1), file_changed (#2608 H4), cron_fired/webhook_received (#2608 H5).
+# recognised ``on:`` value here, with zero edits to this module. See
+# ``schema_registry.py``'s own ``_LIFECYCLE_POINTS``/``_EXTERNAL_POINTS``/
+# ``_TASK_POINTS`` for the current membership — deliberately not re-listed
+# here, so this comment can't itself go stale the way it just did (it named
+# a fixed 8-point enumeration that silently excluded ``task_settled``, #3978
+# P3, once that landed).
 # The registry's namespaced kind (e.g. ``builtin:lifecycle:turn_end``) is
 # ALSO accepted in ``on:`` — a permanent alias of the bare form below,
 # normalized by ``reyn.hooks.loader`` — but this frozenset (the internal

--- a/src/reyn/hooks/schema_registry.py
+++ b/src/reyn/hooks/schema_registry.py
@@ -20,7 +20,7 @@ per-``event_name`` value allowlist — the future OUT-set config file layers
 name-level curation ON TOP of this structural gate, it does not replace it.
 
 ``BUILTIN_HOOK_SCHEMAS`` is the single source of truth for what field-set
-each of reyn's 9 builtin hook-points carries — mirroring the
+each of reyn's builtin hook-points carries — mirroring the
 ``OP_KIND_MODEL_MAP`` ↔ ``control-ir.md`` sync discipline (CLAUDE.md hard
 rule): every dispatch call site MUST build its payload through
 ``build_hook_payload`` (below), which validates the assembled dict against

--- a/tests/hooks/test_context_safe_gate_3978.py
+++ b/tests/hooks/test_context_safe_gate_3978.py
@@ -1,12 +1,15 @@
 """Tier 2: proposal 0067 P2 — the context_safe gate + hook-push ``include``.
 
 "Build the gate before adding the first field that needs it" (proposal §
-"The gate, before the field that needs it") — today's 8 builtin schemas
-mark every field safe (``CONTEXT_UNSAFE_FIELDS`` is empty, owner ruling
-2026-08-10), so this file exercises the MECHANISM directly (via
-``monkeypatch`` on the real module-level dict, not a fake collaborator —
-the dict itself is the production data structure) rather than waiting for
-a real unsafe field to exist.
+"The gate, before the field that needs it") — at P2 landing time every
+builtin schema marked every field safe (``CONTEXT_UNSAFE_FIELDS`` was
+empty, owner ruling 2026-08-10), so this file originally exercised the
+MECHANISM directly (via ``monkeypatch`` on the real module-level dict, not
+a fake collaborator — the dict itself is the production data structure)
+rather than waiting for a real unsafe field to exist. P3 (same arc, same
+PR sequence) is that real field: ``task_settled.result`` is the first
+actual ``CONTEXT_UNSAFE_FIELDS`` exclusion — see
+``test_context_unsafe_fields_excludes_task_settled_result`` below.
 
 Real ``PushBlock``/``render_push`` throughout — no mocks. Policy per
 ``docs/deep-dives/contributing/testing.md``.

--- a/tests/hooks/test_hook_composer_reachability_phase5.py
+++ b/tests/hooks/test_hook_composer_reachability_phase5.py
@@ -129,7 +129,7 @@ def test_composed_kind_now_loads_as_on_target():
     """Tier 1: ``on: composed:<name>`` — fail-loud-rejected in Phase 4b (the
     §9 example's own annotation) — now loads successfully. ``composed:<name>``
     is accepted as an OPEN namespace (by prefix), not enumerated in the fixed
-    ``ALLOWED_HOOK_POINTS`` frozenset (which stays the 9 builtin points)."""
+    ``ALLOWED_HOOK_POINTS`` frozenset (the fixed set of builtin points)."""
     registry = load_hooks([
         {"on": "composed:deploy_approved", "template_push": {"message": "go", "wake": True}},
     ])

--- a/tests/hooks/test_hook_event_schema_registry_sync_0059.py
+++ b/tests/hooks/test_hook_event_schema_registry_sync_0059.py
@@ -133,7 +133,7 @@ def _make_session(tmp_path: Path) -> Session:
 
 
 @pytest.mark.asyncio
-async def test_all_nine_builtin_points_dispatch_schema_matching_payloads(
+async def test_every_builtin_point_dispatches_schema_matching_payload(
     tmp_path, monkeypatch,
 ):
     """Tier 2: every builtin hook-point, exercised via its REAL

--- a/tests/hooks/test_hook_event_schema_registry_sync_0059.py
+++ b/tests/hooks/test_hook_event_schema_registry_sync_0059.py
@@ -3,7 +3,7 @@ CI sync gate (proposal ``docs/deep-dives/proposals/0059-hook-event-redesign.md``
 §4), mirroring the ``OP_KIND_MODEL_MAP`` <-> ``control-ir.md`` sync discipline
 (CLAUDE.md hard rule).
 
-Every one of reyn's 9 builtin hook-points now funnels its payload through
+Every one of reyn's builtin hook-points now funnels its payload through
 ``reyn.hooks.schema_registry.build_hook_payload`` at its ONE producer call
 site (``reyn.runtime.session`` /
 ``reyn.mcp.message_handler`` / ``reyn.runtime.fs_watcher`` /
@@ -18,10 +18,12 @@ This file drives the REAL production call sites (no mocks — real ``Session``,
 real ``HookDispatcher``, real op handlers, real ingress-routing functions) and
 captures the EXACT field-set each dispatches, proving:
 
-1. byte-identical coverage — every one of the 9 builtin points is actually
-   exercised and its captured payload key-set matches
-   ``BUILTIN_HOOK_SCHEMAS`` exactly (the values are the same ones the
-   pre-Phase-1 ad-hoc dict literals carried — only the schema-check is new).
+1. byte-identical coverage — every builtin point (``expected_points`` below
+   derives this set from ``ALLOWED_HOOK_POINTS`` at test-run time, not a
+   hand-copied literal) is actually exercised and its captured payload
+   key-set matches ``BUILTIN_HOOK_SCHEMAS`` exactly (the values are the
+   same ones the pre-Phase-1 ad-hoc dict literals carried — only the
+   schema-check is new).
 2. the strip-falsify direction — narrowing a schema entry (as if a call site
    had drifted) makes the NEXT real call through that site raise
    ``HookSchemaError`` — the gate actually catches drift, not just documents
@@ -134,7 +136,7 @@ def _make_session(tmp_path: Path) -> Session:
 async def test_all_nine_builtin_points_dispatch_schema_matching_payloads(
     tmp_path, monkeypatch,
 ):
-    """Tier 2: every one of the 9 builtin hook-points, exercised via its REAL
+    """Tier 2: every builtin hook-point, exercised via its REAL
     production call site, dispatches a payload whose key-set EXACTLY matches
     ``BUILTIN_HOOK_SCHEMAS`` for that point — the byte-identical proof."""
     captured: list[tuple[str, dict]] = []

--- a/tests/hooks/test_hook_event_schema_registry_sync_0059.py
+++ b/tests/hooks/test_hook_event_schema_registry_sync_0059.py
@@ -93,7 +93,7 @@ def _capture_dispatch(monkeypatch, captured: list) -> None:
     push/shell/pipeline routing all still run for real — only observation is
     added). Every builtin producer (in-process or out-of-process) funnels
     through some ``HookDispatcher`` instance's ``dispatch``, so patching the
-    class method here captures all 8 points uniformly."""
+    class method here captures every builtin point uniformly."""
     original = dispatcher_mod.HookDispatcher.dispatch
 
     async def _recording_dispatch(self, point, template_vars):


### PR DESCRIPTION
**[docs-maintainer]** — part of #4091, dispatched by lead-coder. Structural fix per architect's #3996 prescription: stop writing "N builtin points" as a literal number in prose anywhere — the sync-by-hand pattern that caused #4088's drift (and would cause the same thing again at the next added point).

## Measured before touching anything, per lead-coder's request

At each of the 4 named sites (`hooks.md:119`, `reyn.local.yaml.example:976`, `test_hook_composer_reachability_phase5.py:132`, `test_hook_event_schema_registry_sync_0059.py:21`): is the number load-bearing in an assertion, or pure descriptive prose?

All 4 are prose-only. `test_hook_event_schema_registry_sync_0059.py`'s actual assertion already derives its expected-point set dynamically (`expected_points = set(ALLOWED_HOOK_POINTS)`) — the code was already correct, only its own docstring restated a hardcoded number. `test_hook_composer_reachability_phase5.py` has no count-based assertion anywhere in the file (verified via grep). No "derive from registry instead of deleting" case applied here — every site is genuinely droppable.

## Scope expanded beyond the 4 named sites

Fixing only the 4 named sites while leaving `hooks.md`'s own other 2 "9 builtin" mentions (lines I wrote myself earlier tonight, same file) would recreate the exact bug this PR exists to close, in the same file, on the next point addition. Ran `grep -rnE "[0-9]+ builtin (hook|point)"` across `docs/ CLAUDE.md reyn.local.yaml.example CHANGELOG.md tests/ src/ scripts/` and fixed every live-state instance found — 9 sites total (the 4 named + `hooks.md`'s other 2 + `schema_registry.py`'s own module docstring + 2 more test-file docstring mentions in the same 2 files).

## Left untouched, confirmed correctly scoped (not this bug's shape)

- `CHANGELOG.md` / `test_hook_composed_matcher_schema_2889.py`'s "10" — historically accurate (Phase 1/3's real count, `task_start`/`task_end` still live then, fixed earlier tonight in #4088's follow-up commits).
- `test_context_safe_gate_3978.py` / `schema_registry.py`'s "8 pre-P3" / "PRE-P3" mentions — explicitly scoped to a past state, not a live claim.
- `schema_registry.py`'s "8 of the 9 builtins" (`CONTEXT_UNSAFE_FIELDS` default note) — left deliberately: this fraction conveys real information (one schema carries the exception, the rest don't), not a redundant restatement of the total count. Genericizing it would lose content, not just remove drift-risk.
- Function names carrying a count (`test_all_nine_builtin_points_...`, renamed from "eight" earlier tonight per lead-coder's own review) — not re-renamed again; the dispatch was about prose, and re-renaming per point addition is its own kind of thrash.

## Test plan

- [x] `ruff check` on all 5 touched files — clean
- [x] `python scripts/check_doc_anchors.py` — exit 0
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0 (remaining INFO lines are pre-existing ja-mirror gaps)
- [x] `python scripts/test_tier_audit.py --strict` on both touched test files — 12/12 OK
- [x] `python scripts/verify_module_docstrings.py src/reyn/hooks/schema_registry.py` — OK
- [x] `pytest tests/hooks/test_hook_event_schema_registry_sync_0059.py tests/hooks/test_hook_composer_reachability_phase5.py -q` — 12/12 passed
- [x] `python scripts/check_tests_path_literal_reference.py` (gate #6) — OK
- [x] CI gate this PR is subject to (`test_audit_event_kind_vocabulary_3410.py`-style) doesn't cover hook-point count — noted, out of scope for this PR per lead-coder's own message: "数を消せるなら消すのが唯一の構造的対処"

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**[lead-coder]** — reviewer's blocking item (rule 7):

- [ ] 🔴 `tests/hooks/test_hook_event_schema_registry_sync_0059.py:134` — the count survives spelled out in the test's own function name (`test_all_nine_builtin_points_...`). Rename to drop it. The sweep's needle matched the digit form only; re-run it with a spelled-out-number needle before pushing.

- [ ] 🔴 `src/reyn/hooks/schema.py:96-97` — the derivation comment states the count as a literal ("The 8 points today"), which is 9 today. Drop the number; the sentence works as "The points today are unchanged: …". The number and the noun sit on different lines, which is why the sweep's line-oriented needle missed it.
- [ ] 🔴 (再掲) `tests/hooks/test_hook_event_schema_registry_sync_0059.py:134` — spelled-out count in the function name.


## ✅ ★この PR に 足して ほしい もの

- [ ] 🔴 `tests/hooks/test_hook_event_schema_registry_sync_0059.py:96` — "captures all 8 points uniformly" is a live claim and 9 is the count today; this file is already in the diff.
- [ ] 🔴 `tests/hooks/test_context_safe_gate_3978.py:4` — both halves are stale: the count (8 → 9) and, more importantly, "`CONTEXT_UNSAFE_FIELDS` is empty", which is no longer true (`builtin:task:task_settled` → `{result}`). Fix here or file it, but do not leave the gate's own test describing a world where nothing is denied.
