### PR TITLE
docs(#3978): cite symbols, not line numbers, in 0067's verification table

### DIFF
--- a/docs/deep-dives/proposals/0067-task-model-and-arbiter.md
+++ b/docs/deep-dives/proposals/0067-task-model-and-arbiter.md
@@ -171,7 +171,7 @@ Measured during design; each has bitten or would bite:
 | chain timers | re-armed *fresh* on restore, so a crash extends the deadline (P8). |
 | hook points | eight, not ten (#3996). |
 | S3 deny sets | the launch-verb deny exists **twice** — `_PIPELINE_STEP_DENY_TOOLS` (`tools/pipeline_verbs.py`, R6 S3, pipeline tool steps) and `_DELEGATION_DENY_TOOLS` (`runtime/session_api.py`, R5, agent steps). Same five names today. Both files say "kept in lock-step" and **nothing enforces it**: the only place `tests/` names both is a module docstring, and no test compares them. P6 and P7 each touch both. See the note below. |
-| `RunStatus` | the status vocabulary D3 describes **already exists** — `run_registry.py`, five members, and the `input_required` transition is live in `a2a_intervention.py` (`self._registry.update(self._run_id, status="input-required")`). What is missing is a bridge to the chain handle, not a state machine. Reusing it from `runtime/` would be a new layering inversion (`runtime/ → interfaces/web/` is currently 0 imports; the reverse is 10), so it moves to `runtime/task_types.py` beside `TaskKind` / `Requester`. The rename to `TaskStatus` waits for P6, same treatment as `requester`. |
+| `RunStatus` | the status vocabulary D3 describes **already existed** — five members, with the `input_required` transition live in `a2a_intervention.py` (`self._registry.update(self._run_id, status="input-required")`). What was missing was a bridge to the chain handle, not a state machine. It lived in `interfaces/web/run_registry.py`, and reading it from `runtime/` would have been a new layering inversion (`runtime/ → interfaces/web/` was 0 imports; the reverse, 10), so **P4 moved it to `runtime/task_types.py`** beside `TaskKind` / `Requester`; `run_registry.py` re-exports it. The rename to `TaskStatus` waits for P6, same treatment as `requester`. |
 
 ### The two S3 deny sets stay two, and get an equality check
 
@@ -206,7 +206,7 @@ implemented; the underscore is the wrong needle.
 | where | spelling | whose convention |
 |---|---|---|
 | ADR-0040 §D3 prose, and its MCP-Tasks quote | `input_required` | MCP's |
-| the `RunStatus` member name (`run_registry.py`) | `INPUT_REQUIRED` | Python's |
+| the `RunStatus` member name (`runtime/task_types.py`) | `INPUT_REQUIRED` | Python's |
 | that member's **value**, and `_A2A_TASK_STATES` (`a2a_task_view.py`) | `"input-required"` | A2A's — this is what reaches the wire |
 
 Write `RunStatus.INPUT_REQUIRED`, never the string. This cost a reviewer a false "D3 is

--- a/docs/deep-dives/proposals/0067-task-model-and-arbiter.md
+++ b/docs/deep-dives/proposals/0067-task-model-and-arbiter.md
@@ -163,15 +163,15 @@ Measured during design; each has bitten or would bite:
 
 | | finding |
 |---|---|
-| `dispatch_kind` | means "end this turn", not "is asynchronous" (`router_loop.py:2249`). P1′ and P6 touch it directly. |
+| `dispatch_kind` | means "end this turn", not "is asynchronous" (`router_loop.py`). P1′ and P6 touch it directly. |
 | `agent_locks` | the serialization lock is keyed by **agent name** while what it protects is a **session's** history. P0/P1 move identity to the session axis; this key is then inconsistent. |
-| `_is_quiescent` | its docstring promises three conditions; the implementation checks `inbox.empty()` only (`message_bus.py:188` vs `:193`). |
+| `_is_quiescent` | its docstring promises three conditions; the implementation checks `inbox.empty()` only (`message_bus.py`). |
 | `RunEntry` | `interfaces/web/run_registry.py` is a fourth handle store already carrying status/result/error/webhook_url plus persistence. §7's type is its generalization; whether it moves to core is a layering decision. |
-| `_last_reply_to` | inherited when a trigger carries no `reply_to` (`session.py:2731-2733`) — a live misdelivery path that P1 removes. |
+| `_last_reply_to` | inherited when a trigger carries no `reply_to` (`session.py`) — a live misdelivery path that P1 removes. |
 | chain timers | re-armed *fresh* on restore, so a crash extends the deadline (P8). |
 | hook points | eight, not ten (#3996). |
-| S3 deny sets | the launch-verb deny exists **twice** — `_PIPELINE_STEP_DENY_TOOLS` (`tools/pipeline_verbs.py:211`, R6 S3, pipeline tool steps) and `_DELEGATION_DENY_TOOLS` (`runtime/session_api.py:136`, R5, agent steps). Same five names today. Both files say "kept in lock-step" and **nothing enforces it**: the only place `tests/` names both is a module docstring, and no test compares them. P6 and P7 each touch both. See the note below. |
-| `RunStatus` | the status vocabulary D3 describes **already exists** — `run_registry.py:64`, five members, and the `input_required` transition is live at `a2a_intervention.py:124`. What is missing is a bridge to the chain handle, not a state machine. Reusing it from `runtime/` would be a new layering inversion (`runtime/ → interfaces/web/` is currently 0 imports; the reverse is 10), so it moves to `runtime/task_types.py` beside `TaskKind` / `Requester`. The rename to `TaskStatus` waits for P6, same treatment as `requester`. |
+| S3 deny sets | the launch-verb deny exists **twice** — `_PIPELINE_STEP_DENY_TOOLS` (`tools/pipeline_verbs.py`, R6 S3, pipeline tool steps) and `_DELEGATION_DENY_TOOLS` (`runtime/session_api.py`, R5, agent steps). Same five names today. Both files say "kept in lock-step" and **nothing enforces it**: the only place `tests/` names both is a module docstring, and no test compares them. P6 and P7 each touch both. See the note below. |
+| `RunStatus` | the status vocabulary D3 describes **already exists** — `run_registry.py`, five members, and the `input_required` transition is live in `a2a_intervention.py` (`self._registry.update(self._run_id, status="input-required")`). What is missing is a bridge to the chain handle, not a state machine. Reusing it from `runtime/` would be a new layering inversion (`runtime/ → interfaces/web/` is currently 0 imports; the reverse is 10), so it moves to `runtime/task_types.py` beside `TaskKind` / `Requester`. The rename to `TaskStatus` waits for P6, same treatment as `requester`. |
 
 ### The two S3 deny sets stay two, and get an equality check
 
@@ -206,8 +206,8 @@ implemented; the underscore is the wrong needle.
 | where | spelling | whose convention |
 |---|---|---|
 | ADR-0040 §D3 prose, and its MCP-Tasks quote | `input_required` | MCP's |
-| `run_registry.py:77` member name | `INPUT_REQUIRED` | Python's |
-| that member's **value**, and `a2a_task_view.py:46` | `"input-required"` | A2A's — this is what reaches the wire |
+| the `RunStatus` member name (`run_registry.py`) | `INPUT_REQUIRED` | Python's |
+| that member's **value**, and `_A2A_TASK_STATES` (`a2a_task_view.py`) | `"input-required"` | A2A's — this is what reaches the wire |
 
 Write `RunStatus.INPUT_REQUIRED`, never the string. This cost a reviewer a false "D3 is
 unimplemented, that's a separate problem" reading on 2026-08-10, from a grep that was correct in


### PR DESCRIPTION
**[architect]** — part of #3978。**#4102 の nit（lead-coder）を受けた follow-up。doc のみ。**

## 指摘は★私自身の pin でした

> 「symbol 名を併記しているので★行番号が何も足していない。symbol は動く main を跨いで生き、
> 行番号は次の PR で外れる。併記すると★壊れない参照と壊れる参照が同じ括弧に入り、後者が先に腐る」

⚪ **私の pin:「参照形式は★正確さでなく『何に反応して壊れるか』で選ぶ」** ── **同じことです。**
🔴 **報告された `pipeline_verbs.py:211` は実際 `:210` ですが、★off-by-one は症状で defect ではありません。**
**行は既に `_PIPELINE_STEP_DENY_TOOLS` と書いてあり、★数字は最初から何も運んでいませんでした。**

## 変更（Verification notes の表、6 行）

```
_PIPELINE_STEP_DENY_TOOLS / _DELEGATION_DENY_TOOLS   :211 / :136 を落とす
RunStatus                                            :64 を落とす
input_required 遷移      a2a_intervention.py:124 → ★実際の 1 行を引用
                         `self._registry.update(self._run_id, status="input-required")`
INPUT_REQUIRED / _A2A_TASK_STATES                    :77 / :46 → ★symbol 名で言い直す
dispatch_kind / _is_quiescent / _last_reply_to       :2249 / :188,:193 / :2731-2733 を落とす
```

## ⚠️ scope を★宣言より広げました（理由込み）

**broker では「この arc で私が足した節」と言いましたが、★表全体に広げています。**
**理由: 表の半分だけ直すと、★残り半分の数字には意味がある、と読者に教えてしまう。**
⚪ **prose / code block 側の引用（`:2249` 等が本文中に出るもの）は★据え置き** ──
**あちらは 1 件ずつ読まれる面**で、まとめて掃くのは**この arc と無関係な別変更**になります。

## Test plan

- [x] doc のみ ∴ pytest 対象なし
- [x] **新しく名指しした symbol が★全て origin/main に実在することを確認**
      （`_PIPELINE_STEP_DENY_TOOLS` / `_DELEGATION_DENY_TOOLS` / `_A2A_TASK_STATES` /
      `INPUT_REQUIRED` ── ★存在しない symbol に置き換えるのが唯一の実害なので、そこだけ実測）
- [x] 引用した 1 行が **byte 単位で一致**することを `git grep` で確認
- [x] 表の中に `.py:<数字>` が★0 件になったことを確認
- [ ] (skipped — Visual 項目なし)


**[lead-coder]** — reviewer's blocking item (rule 7):

- [ ] 🔴 The `RunStatus` row still locates the enum in `run_registry.py`; `#4098` (P4) moved the class to `src/reyn/runtime/task_types.py` and left only a re-export behind. Point at `runtime/task_types.py`, or drop the file name and keep the symbol. (The `RunEntry` row's `interfaces/web/run_registry.py` is correct and should stay.)
