### PR TITLE
feat(#3978): P4 — describe_task / list_tasks / cancel_task

### DIFF
--- a/docs/concepts/tools-integrations/universal-catalog.ja.md
+++ b/docs/concepts/tools-integrations/universal-catalog.ja.md
@@ -249,7 +249,7 @@ gate は pure function; runtime は `embedding.enabled`(FP-0066 §7)
 ## System prompt placement (§D9)
 
 `action_retrieval.universal_wrappers_enabled` が true のとき、 router
-system prompt に **`## Action categories`** section が加わり、 13
+system prompt に **`## Action categories`** section が加わり、 全
 category と canonical-default 意味論を列挙する。 この section は
 `## Capabilities` と `## Behaviour` の間に位置し、 static prompt-cache
 prefix 内に留まる (= 2 回目以降の request は warm cache を hit)。

--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -1475,6 +1475,58 @@ def skill_list_to_canonical(result: dict) -> CanonicalToolResult:
     return _records_to_canonical(text, skills)
 
 
+def describe_task_to_canonical(result: dict) -> CanonicalToolResult:
+    """``describe_task`` result -> canonical (proposal 0067 P4, #3978). A
+    single-task "describe" view — ``{task_id, kind, status, session,
+    requester}`` (``ttl_seconds`` deferred to P8) — records as ONE
+    structured attachment, mirroring every other Bucket B describe mapper's
+    shape (``_records_to_canonical`` with a dict, not a list)."""
+    if not result.get("ok"):
+        return CanonicalToolResult(
+            text=f"task not found: {result.get('error', '')}", attachments=[], source_ref=None, meta={},
+        )
+    text = f"task {result.get('task_id')}: {result.get('status')} ({result.get('kind')})"
+    return _records_to_canonical(text, result)
+
+
+def list_tasks_to_canonical(result: dict) -> CanonicalToolResult:
+    """``list_tasks`` result -> canonical (proposal 0067 P4, #3978).
+    ``tasks`` entries carry ``{task_id, kind, status, session}`` — only
+    RUNNING tasks (ADR-0040 D4: a settled task's handle is already gone).
+    """
+    tasks = result.get("tasks") or []
+    n = len(tasks)
+    preview = _bounded_join(tasks, "task_id")
+    text = f"{n} running task{'s' if n != 1 else ''}" + (f": {preview}" if preview else "") + "."
+    return _records_to_canonical(text, tasks)
+
+
+_CANCEL_TASK_STATUSES = frozenset({"cancel_requested", "error"})
+
+
+def cancel_task_to_canonical(result: dict) -> CanonicalToolResult:
+    """``cancel_task`` result -> canonical (proposal 0067 P4, #3978).
+    Deliberately does NOT summarize a bare "cancelled" for every outcome —
+    the architect's witness requirement (a caller finding no live cancel
+    hook must not read this as success) has to survive offload too, or the
+    LLM-visible text itself becomes the silent lie the requirement exists
+    to prevent. ``status`` here already carries the distinction
+    (``cancel_requested`` vs an explicit error status) — this mapper never
+    collapses it to a bare "ok".
+
+    ``status`` IS this mapper's inner discriminator (FP-0056 M3, #2695): a
+    value outside the two ``cancel_task`` actually emits is a
+    discriminator-miss, not a bare status echo — the guard
+    (``test_fp0056_m3_fail_visible.py``) drives every registered mapper
+    with a discriminator-less ``{"status": <sentinel>}`` probe specifically
+    to catch a mapper that echoes an unrecognized status verbatim."""
+    status = result.get("status")
+    if status not in _CANCEL_TASK_STATUSES:
+        raise CanonicalDiscriminatorMiss(f"cancel_task_to_canonical: unknown status {status!r}")
+    text = f"task {result.get('task_id')}: {status}"
+    return _records_to_canonical(text, result)
+
+
 def pipeline_list_to_canonical(result: dict) -> CanonicalToolResult:
     """``pipeline_list`` result -> canonical (#3026). ``pipelines`` entries carry
     ``{name, description}`` — the discovery view of every REGISTERED pipeline.

--- a/src/reyn/prompt/universal_slots.py
+++ b/src/reyn/prompt/universal_slots.py
@@ -243,6 +243,13 @@ ACTION_CATEGORIES_LINES = [
         ".reyn/pipelines/<name>/)."
     ),
     (
+        "- **task** — describe/list/cancel a currently RUNNING async task "
+        "(a run_prompt/run_pipeline launch): `describe_task` for one by its "
+        "task_id, `list_tasks` for all (optionally filtered by kind), "
+        "`cancel_task` to request cooperative stop. A settled task has no "
+        "handle — its result arrives as a push, not via these."
+    ),
+    (
         "- **presentation_management** — manage named presentation templates: "
         "`presentation_install_local` to register a named presentation "
         "blueprint (a declarative component tree) into "

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -167,6 +167,11 @@ class RouterHostAdapter:
     pipeline_registry:
         PipelineRegistry (or None, IS-5) — the ``run_pipeline`` tool's
         lookup source, exposed via ``get_pipeline_registry()``.
+    chains:
+        ChainManager (or None) — proposal 0067 P4 (#3978)'s
+        describe_task/list_tasks/cancel_task read/act against THIS
+        session's own pending_chains, exposed via ``get_chains()``
+        (mirrors ``get_pipeline_registry()``, same threading shape).
     agent_workspace_dir:
         Path to ``.reyn/agents/<agent_name>`` — used for ``get_memory_index``.
     mcp_call_tool:
@@ -269,6 +274,7 @@ class RouterHostAdapter:
         state_log: Any = None,                  # StateLog | None — #2248 PR-A2 (config emit)
         agent_registry: Any,                    # AgentRegistry | None
         pipeline_registry: Any = None,          # PipelineRegistry | None — IS-5
+        chains: Any = None,                     # ChainManager | None — #3978 P4
         presentation_registry: Any = None,      # PresentationRegistry | None — FP-0054 PR-C
         record_spawned_task: "Callable[[str, str], None] | None" = None,  # #2103 S1bc-exec
         agent_workspace_dir: Path,
@@ -527,6 +533,7 @@ class RouterHostAdapter:
         self._state_log = state_log  # #2259 PR-1: WAL head for config generation emit
         self._registry = agent_registry
         self._pipeline_registry = pipeline_registry  # IS-5: run_pipeline lookup source
+        self._chains = chains  # #3978 P4: describe_task/list_tasks/cancel_task lookup source
         # FP-0054 PR-C: operator named-template registry (presentations.yaml). Held on
         # the adapter (like _pipeline_registry) so make_router_op_context threads the
         # CURRENT snapshot into each OpContext; the pipelines/skills-style hot-reload
@@ -833,6 +840,14 @@ class RouterHostAdapter:
         against the session's actual registered pipelines instead of the
         None landmine."""
         return self._pipeline_registry
+
+    def get_chains(self) -> Any:
+        """The session's ChainManager (or None) — proposal 0067 P4 (#3978):
+        read by ``build_resource_caller_state`` to populate
+        ``RouterCallerState.chains`` so ``describe_task``/``list_tasks``/
+        ``cancel_task`` act against THIS session's own pending_chains
+        (mirrors ``get_pipeline_registry()``, same threading shape)."""
+        return self._chains
 
     def get_presentation_registry(self) -> Any:
         """The adapter's captured PresentationRegistry (or None) — FP-0054 PR-C.

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -3911,6 +3911,10 @@ class Session:
             # RouterCallerState.pipeline_registry by
             # RouterLoop._build_router_caller_state.
             pipeline_registry=self._pipeline_registry,
+            # proposal 0067 P4 (#3978): describe_task/list_tasks/cancel_task
+            # act against THIS session's own pending_chains — mirrors
+            # pipeline_registry above.
+            chains=self.chains,
             # FP-0054 PR-C: the session's PresentationRegistry — mirrors
             # pipeline_registry above; the adapter threads its CURRENT snapshot into
             # each router OpContext, and _reapply_presentations swaps both copies.

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -124,6 +124,7 @@ def get_default_registry() -> ToolRegistry:
         SKILL_INSTALL_SOURCE,
         SKILL_LIST,
     )
+    from reyn.tools.task_verbs import CANCEL_TASK, DESCRIBE_TASK, LIST_TASKS
     from reyn.tools.topology_create import TOPOLOGY_CREATE
 
     # FP-0034 PR-3a: universal catalog wrappers (registered in registry;
@@ -307,6 +308,12 @@ def get_default_registry() -> ToolRegistry:
     # identical (invocation.json carries the full serialized Pipeline).
     registry.register(RUN_PIPELINE_INLINE)
     registry.register(RUN_PIPELINE_INLINE_ASYNC)
+    # proposal 0067 P4 (#3978): describe_task / list_tasks / cancel_task —
+    # read/act against the settle-path handle substrate (ChainManager),
+    # threaded via RouterCallerState.chains.
+    registry.register(DESCRIBE_TASK)
+    registry.register(LIST_TASKS)
+    registry.register(CANCEL_TASK)
     # ── FP-0034 universal catalog wrappers (router-only) ─────────────────
     # PR-3a registers them in the registry; PR-3b will add them to
     # build_tools() output and refactor the SP. Handlers wire through

--- a/src/reyn/tools/descriptions/catalog.py
+++ b/src/reyn/tools/descriptions/catalog.py
@@ -62,7 +62,10 @@ invoke_action = ToolDescription(
     tool_name="invoke_action",
     surfaced=(
         "router (gates.router=allow) — the universal "
-        "catalog's single dispatch entry point for all 13 action categories"
+        "catalog's single dispatch entry point for every action category "
+        "(no fixed count named here — see universal_catalog.CATEGORIES for "
+        "the live enumeration; a hardcoded count here has drifted stale "
+        "at least twice already, #3978 P4)"
     ),
     purpose=(
         "Execute any catalog action by name — the ONE dispatch "
@@ -78,7 +81,7 @@ invoke_action = ToolDescription(
         "are invoked through this single entry point. "
         "WHEN NOT: For chitchat or self-questions, reply without tools. "
         "PREFERRED OVER: Legacy per-kind tools (call_mcp_tool, etc.) — "
-        "invoke_action covers all 13 action categories uniformly. "
+        "invoke_action covers every action category uniformly. "
         "On unknown action_name, returns an error with similar-name suggestions. "
         ""
         "SPAWN-ACK HANDLING: when an action result is {status:'spawned', ...}, the "

--- a/src/reyn/tools/task_verbs.py
+++ b/src/reyn/tools/task_verbs.py
@@ -1,0 +1,203 @@
+"""describe_task / list_tasks / cancel_task — proposal 0067 P4 (#3978).
+
+Read/act against the CALLING session's own ``ChainManager`` (the
+settle-path handle substrate — ``reyn.runtime.services.chain_manager``),
+threaded via ``RouterCallerState.chains`` (mirrors ``pipeline_registry``'s
+own threading, ``RouterHostAdapter.get_chains()``).
+
+Per ADR-0040 D4 ("push-at-settle with immediate deletion") a settled
+task's handle is gone — so all three ops answer only about RUNNING tasks;
+there is no ``read_task_result``. A handle with ``kind=None`` (a legacy
+delegate-relay chain, not yet a typed task — proposal 0067 P6 assigns one
+when ``delegate_to_agent``'s completion folds into this substrate) is
+excluded from every read here: it is not describable as a task today.
+
+``cancel_task``'s one hard requirement (architect, #3978): a handle whose
+``cancel`` hook is ``None`` (a crash-recovered chain — the live callable
+belonged to the dead process) MUST NOT be reported as a success. Reporting
+"cancelled" while the task keeps running is the same silent lie as
+displaying an unenforced ``ttl_seconds`` would be.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from reyn.core.offload.canonical import (
+    cancel_task_to_canonical,
+    describe_task_to_canonical,
+    list_tasks_to_canonical,
+)
+from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
+
+
+def _chains(ctx: ToolContext) -> Any:
+    rs = getattr(ctx, "router_state", None)
+    return getattr(rs, "chains", None) if rs is not None else None
+
+
+def _describe(chain: Any) -> dict[str, Any]:
+    requester = chain.requester
+    return {
+        "task_id": chain.chain_id,
+        "kind": chain.kind,
+        "status": chain.status.value,
+        "session": chain.origin_sid or "main",
+        "requester": {
+            "agent_name": requester.agent_name,
+            "session_id": requester.session_id,
+        },
+    }
+
+
+# ── describe_task ────────────────────────────────────────────────────────────
+
+_DESCRIBE_TASK_DESCRIPTION = (
+    "Describe one currently RUNNING task by its task_id (the handle a "
+    "run_prompt/run_pipeline async launch returned). A settled task's "
+    "handle no longer exists — use this for progress checking or anomaly "
+    "detection, not to retrieve a finished result (results arrive via a "
+    "task_settled push, not a poll)."
+)
+
+_DESCRIBE_TASK_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "task_id": {
+            "type": "string",
+            "description": "The task's handle, as returned by its async launch.",
+        },
+    },
+    "required": ["task_id"],
+}
+
+
+async def _handle_describe_task(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
+    chains = _chains(ctx)
+    task_id = args["task_id"]
+    chain = chains.get(task_id) if chains is not None else None
+    if chain is None or chain.kind is None:
+        return {"ok": False, "error": f"no running task {task_id!r}"}
+    return {"ok": True, **_describe(chain)}
+
+
+DESCRIBE_TASK = ToolDefinition(
+    canonical=describe_task_to_canonical,
+    name="describe_task",
+    router_dispatched=True,
+    description=_DESCRIBE_TASK_DESCRIPTION,
+    parameters=_DESCRIBE_TASK_PARAMETERS,
+    gates=ToolGates(router="allow"),
+    handler=_handle_describe_task,
+    category="discovery",
+    purity="read_only",
+)
+
+
+# ── list_tasks ───────────────────────────────────────────────────────────────
+
+_LIST_TASKS_DESCRIPTION = (
+    "List currently RUNNING tasks (async run_prompt/run_pipeline launches "
+    "not yet settled), optionally filtered by kind. Settled tasks are not "
+    "listed — their handle no longer exists (ADR-0040 D4)."
+)
+
+_LIST_TASKS_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "kind": {
+            "type": "string",
+            "description": (
+                "Optional — restrict to one task kind (e.g. 'prompt', "
+                "'pipeline'). Omit to list every running task."
+            ),
+        },
+    },
+}
+
+
+async def _handle_list_tasks(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
+    chains = _chains(ctx)
+    if chains is None:
+        return {"tasks": []}
+    kind_filter = args.get("kind")
+    tasks = []
+    for chain_id in chains.all_chain_ids():
+        chain = chains.get(chain_id)
+        if chain is None or chain.kind is None:
+            continue
+        if kind_filter is not None and chain.kind != kind_filter:
+            continue
+        described = _describe(chain)
+        del described["requester"]  # list view: {task_id, kind, status, session} only
+        tasks.append(described)
+    return {"tasks": tasks}
+
+
+LIST_TASKS = ToolDefinition(
+    canonical=list_tasks_to_canonical,
+    name="list_tasks",
+    router_dispatched=True,
+    description=_LIST_TASKS_DESCRIPTION,
+    parameters=_LIST_TASKS_PARAMETERS,
+    gates=ToolGates(router="allow"),
+    handler=_handle_list_tasks,
+    category="discovery",
+    purity="read_only",
+)
+
+
+# ── cancel_task ──────────────────────────────────────────────────────────────
+
+_CANCEL_TASK_DESCRIPTION = (
+    "Request cooperative cancellation of a currently RUNNING task by its "
+    "task_id. Returns immediately with status='cancel_requested' — the "
+    "task stops at its next safe boundary, and its settle (task_settled) "
+    "still fires with status='cancelled' once it does. A task recovered "
+    "after a crash cannot be cancelled (no live process to signal); this "
+    "returns an explicit error, never a false 'cancelled'."
+)
+
+_CANCEL_TASK_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "task_id": {
+            "type": "string",
+            "description": "The task's handle, as returned by its async launch.",
+        },
+    },
+    "required": ["task_id"],
+}
+
+
+async def _handle_cancel_task(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
+    chains = _chains(ctx)
+    task_id = args["task_id"]
+    chain = chains.get(task_id) if chains is not None else None
+    if chain is None or chain.kind is None:
+        return {"task_id": task_id, "status": "error", "error": f"no running task {task_id!r}"}
+    if chain.cancel is None:
+        # Architect's witness requirement (#3978): a recovered handle's
+        # cancel hook belonged to the dead process — reporting success
+        # here would be the exact silent lie an unenforced ttl_seconds is.
+        return {
+            "task_id": task_id, "status": "error",
+            "error": (
+                f"task {task_id!r} cannot be cancelled — no live process is "
+                "reachable (likely a handle recovered after a crash)"
+            ),
+        }
+    chain.cancel()
+    return {"task_id": task_id, "status": "cancel_requested"}
+
+
+CANCEL_TASK = ToolDefinition(
+    canonical=cancel_task_to_canonical,
+    name="cancel_task",
+    router_dispatched=True,
+    description=_CANCEL_TASK_DESCRIPTION,
+    parameters=_CANCEL_TASK_PARAMETERS,
+    gates=ToolGates(router="allow"),
+    handler=_handle_cancel_task,
+    category="io",
+    purity="side_effect",
+)

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -72,6 +72,12 @@ class RouterCallerState:
     # don't support run_pipeline.
     pipeline_registry: Any = None
 
+    # proposal 0067 P4 (#3978): the ChainManager describe_task/list_tasks/
+    # cancel_task read/act against — THIS session's own pending_chains, not
+    # a global. Threaded the same way as pipeline_registry above (populated
+    # by build_resource_caller_state from host.get_chains()).
+    chains: Any = None
+
     # Async dispatch callbacks (= for delegate_to_agent / plan
     # handlers that need to interact with chain / task lifecycle)
     send_to_agent: Callable[..., Awaitable[Any]] | None = None
@@ -287,6 +293,9 @@ async def build_resource_caller_state(host: Any) -> "RouterCallerState":
         ),
         pipeline_registry=(
             getattr(host, "get_pipeline_registry", lambda: None)()
+        ),
+        chains=(
+            getattr(host, "get_chains", lambda: None)()
         ),
     )
 

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -143,6 +143,9 @@ CATEGORIES: Final[tuple[str, ...]] = (
     # pipeline dynamic actions; ``pipeline`` is now launch
     # verbs + ``pipeline_list`` only.)
     "pipeline_management",
+    # proposal 0067 P4 (#3978): describe_task / list_tasks / cancel_task —
+    # read/act against a currently-running async task's settle-path handle.
+    "task",
     # proposal 0060 Phase 1 Layer A (A8): presentation management ops (install).
     # Single verb (no source/git-fetch counterpart — a blueprint is inline
     # declarative data). Management plane — mirrors ``skill_management`` /

--- a/src/reyn/tools/universal_dispatch.py
+++ b/src/reyn/tools/universal_dispatch.py
@@ -176,6 +176,11 @@ _CATEGORY_ACTIONS: Final[dict[str, tuple[str, ...]]] = {
     ),
     # The management plane for pipelines, mirroring ``skill_management``.
     "pipeline_management": ("pipeline_install_local", "pipeline_install_source"),
+    # proposal 0067 P4 (#3978): describe/list/cancel a currently-running
+    # async task (run_prompt/run_pipeline launch) — reads/acts against the
+    # settle-path handle substrate. No read_task_result: a settled task's
+    # handle is gone (ADR-0040 D4); results arrive via task_settled, not a poll.
+    "task": ("describe_task", "list_tasks", "cancel_task"),
     # proposal 0060 Phase 1 Layer A (A8): register a named presentation
     # template. Single verb — a blueprint is inline declarative data, never
     # file-backed, so there is no source/git-fetch counterpart.

--- a/tests/_support/router_loop.py
+++ b/tests/_support/router_loop.py
@@ -51,12 +51,14 @@ class FakeRouterHost:
         file_permissions: dict | None = None,
         mcp_servers: list[dict] | None = None,
         threat_scan: Any = None,
+        chains: Any = None,  # proposal 0067 P4 (#3978): ChainManager | None
     ):
         self._skills = skills or []
         self._agents = agents or []
         self._memory_index = memory_index or {"status": "not_found", "content": ""}
         self._file_permissions = file_permissions
         self._mcp_servers = mcp_servers or []
+        self._chains = chains
 
         # Track calls
         self.outbox: list[dict] = []
@@ -126,6 +128,14 @@ class FakeRouterHost:
 
     def get_mcp_servers(self) -> list[dict]:
         return self._mcp_servers
+
+    def get_chains(self) -> Any:
+        """proposal 0067 P4 (#3978): mirrors RouterHostAdapter.get_chains()
+        — the production seam ``build_resource_caller_state`` reads to
+        populate ``RouterCallerState.chains``. Returns whatever
+        ``chains=`` this fake was constructed with (None by default,
+        matching a host that doesn't support the settle-path substrate)."""
+        return self._chains
 
     def get_web_fetch_allowed(self) -> bool:
         return False

--- a/tests/runtime/test_2123_router_dispatch_sot_1953.py
+++ b/tests/runtime/test_2123_router_dispatch_sot_1953.py
@@ -81,6 +81,10 @@ _EXPECTED_DISPATCH: "frozenset[str]" = frozenset({
     "pipeline_install_local", "pipeline_install_source",
     "pipeline_list", "run_pipeline", "run_pipeline_async",
     "run_pipeline_inline", "run_pipeline_inline_async",
+    # proposal 0067 P4 (#3978): describe_task / list_tasks / cancel_task —
+    # router_dispatched=True, dispatched via invoke_action like the catalog
+    # actions above.
+    "describe_task", "list_tasks", "cancel_task",
     "presentation_install_local",
     "reyn_repo_glob", "reyn_repo_grep",
     "skill_install_local", "skill_install_source", "skill_list",

--- a/tests/tools/test_returns_external_content_flagset_1822.py
+++ b/tests/tools/test_returns_external_content_flagset_1822.py
@@ -211,6 +211,13 @@ _NOT_EXTERNAL = {
     # runs (same "ACK here, fenced at its own seam" rationale as above).
     "run_pipeline_inline",
     "run_pipeline_inline_async",
+    # proposal 0067 P4 (#3978): describe_task / list_tasks / cancel_task all
+    # return OS-assembled structured data (task_id/kind/status/session/
+    # requester, drawn from ChainManager's own in-memory state) — no
+    # external content of any kind.
+    "describe_task",
+    "list_tasks",
+    "cancel_task",
 }
 
 

--- a/tests/tools/test_task_verbs_3978.py
+++ b/tests/tools/test_task_verbs_3978.py
@@ -1,0 +1,228 @@
+"""Tier 2: describe_task / list_tasks / cancel_task (proposal 0067 P4, #3978).
+
+Real ``ChainManager``/``SnapshotJournal``/``StateLog`` throughout — no
+mocks, matching ``test_chain_manager_settle_3978.py``'s established
+pattern. The handlers are driven directly (``_handle_describe_task`` etc.)
+against a real ``ToolContext``/``RouterCallerState`` carrying a real
+``ChainManager``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.services.chain_manager import ChainManager
+from reyn.runtime.services.snapshot_journal import SnapshotJournal
+from reyn.tools.task_verbs import (
+    _handle_cancel_task,
+    _handle_describe_task,
+    _handle_list_tasks,
+)
+from reyn.tools.types import RouterCallerState, ToolContext
+
+
+class _NullEvents:
+    def emit(self, *_args, **_kwargs) -> None:
+        pass
+
+
+def _make_manager(tmp_path: Path) -> ChainManager:
+    log = StateLog(tmp_path / "wal.jsonl")
+    journal = SnapshotJournal(
+        agent_name="alpha", snapshot_path=tmp_path / "snap.json", state_log=log,
+    )
+    return ChainManager(
+        journal=journal, events=_NullEvents(), chain_timeout_seconds=0, max_hop_depth=10,
+    )
+
+
+def _ctx(chains) -> ToolContext:
+    return ToolContext(
+        events=_NullEvents(), permission_resolver=None, workspace=None,
+        caller_kind="router",
+        router_state=RouterCallerState(chains=chains),
+    )
+
+
+# ── describe_task ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_describe_task_returns_full_shape_for_a_running_task(tmp_path: Path):
+    """Tier 2: proposal 0067's describe_task shape — {task_id, kind, status,
+    session, requester} — for a real, registered running task."""
+    mgr = _make_manager(tmp_path)
+    await mgr.register(
+        chain_id="run-1", from_user=False, depth=0, original_text="p", sender=None,
+        origin_agent="worker", origin_sid="s1", kind="pipeline",
+    )
+
+    result = await _handle_describe_task({"task_id": "run-1"}, _ctx(mgr))
+
+    assert result["ok"] is True
+    assert result["task_id"] == "run-1"
+    assert result["kind"] == "pipeline"
+    assert result["status"] == "running"
+    assert result["session"] == "s1"
+    assert result["requester"] == {"agent_name": "worker", "session_id": "s1"}
+
+
+@pytest.mark.asyncio
+async def test_describe_task_unknown_id_returns_error_not_a_crash(tmp_path: Path):
+    """Tier 2: an unregistered task_id degrades to an explicit error, not a
+    KeyError/crash (mirrors ChainManager's own tolerant lookups)."""
+    mgr = _make_manager(tmp_path)
+
+    result = await _handle_describe_task({"task_id": "never-registered"}, _ctx(mgr))
+
+    assert result["ok"] is False
+    assert "never-registered" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_describe_task_excludes_untyped_legacy_delegate_chains(tmp_path: Path):
+    """Tier 2: a chain registered with no ``kind`` (every EXISTING
+    delegate-relay call site, unchanged by P4) is not yet a typed task —
+    describe_task must not describe it (it would report ``kind: None``,
+    which is not one of prompt/pipeline/exec and answers a question the
+    caller didn't ask)."""
+    mgr = _make_manager(tmp_path)
+    await mgr.register(
+        chain_id="legacy-1", from_user=False, depth=0, original_text="p", sender="peer",
+    )
+
+    result = await _handle_describe_task({"task_id": "legacy-1"}, _ctx(mgr))
+
+    assert result["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_describe_task_with_no_chains_source_returns_error(tmp_path: Path):
+    """Tier 2: a narrow test host (or a host that doesn't support this
+    substrate) degrades to 'not found', not a crash — mirrors
+    ``pipeline_list``'s own ``registry is None`` degrade."""
+    result = await _handle_describe_task({"task_id": "run-1"}, _ctx(None))
+    assert result["ok"] is False
+
+
+# ── list_tasks ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_lists_only_typed_running_tasks(tmp_path: Path):
+    """Tier 2: list_tasks enumerates only typed (kind != None) handles, in
+    the {task_id, kind, status, session} list shape — no requester field."""
+    mgr = _make_manager(tmp_path)
+    await mgr.register(
+        chain_id="run-2", from_user=False, depth=0, original_text="p", sender=None,
+        origin_agent="worker", origin_sid=None, kind="pipeline",
+    )
+    await mgr.register(
+        chain_id="legacy-2", from_user=False, depth=0, original_text="p", sender="peer",
+    )
+
+    result = await _handle_list_tasks({}, _ctx(mgr))
+
+    ids = {t["task_id"] for t in result["tasks"]}
+    assert ids == {"run-2"}
+    (task,) = result["tasks"]
+    assert task["kind"] == "pipeline"
+    assert task["status"] == "running"
+    assert task["session"] == "main"
+    assert "requester" not in task  # list view omits it (describe_task carries it)
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_filters_by_kind(tmp_path: Path):
+    """Tier 2: a kind filter narrows the listing to matching tasks only."""
+    mgr = _make_manager(tmp_path)
+    await mgr.register(
+        chain_id="run-3", from_user=False, depth=0, original_text="p", sender=None,
+        kind="pipeline",
+    )
+    await mgr.register(
+        chain_id="run-4", from_user=False, depth=0, original_text="p", sender=None,
+        kind="prompt",
+    )
+
+    result = await _handle_list_tasks({"kind": "prompt"}, _ctx(mgr))
+
+    assert {t["task_id"] for t in result["tasks"]} == {"run-4"}
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_with_no_chains_source_returns_empty(tmp_path: Path):
+    """Tier 2: a narrow test host with no chains substrate returns an empty
+    list, not a crash (mirrors pipeline_list's own None-registry degrade)."""
+    result = await _handle_list_tasks({}, _ctx(None))
+    assert result["tasks"] == []
+
+
+# ── cancel_task ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_calls_the_hook_and_returns_cancel_requested(tmp_path: Path):
+    """Tier 2: a task with a live cancel hook has it called, and the tool
+    returns {task_id, status: cancel_requested}."""
+    mgr = _make_manager(tmp_path)
+    calls = []
+    await mgr.register(
+        chain_id="run-5", from_user=False, depth=0, original_text="p", sender=None,
+        kind="pipeline", cancel=lambda: calls.append("cancelled"),
+    )
+
+    result = await _handle_cancel_task({"task_id": "run-5"}, _ctx(mgr))
+
+    assert result == {"task_id": "run-5", "status": "cancel_requested"}
+    assert calls == ["cancelled"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_without_a_live_hook_never_reports_success(tmp_path: Path):
+    """Tier 2: architect's witness requirement (#3978) — a handle whose
+    ``cancel`` is None (a crash-recovered chain; the live callable belonged
+    to the dead process) must get an explicit, distinguishable error, NOT a
+    silent 'cancelled' while the task keeps running."""
+    mgr = _make_manager(tmp_path)
+    await mgr.register(
+        chain_id="run-6", from_user=False, depth=0, original_text="p", sender=None,
+        kind="pipeline",  # no cancel= — mirrors a recovered handle
+    )
+
+    result = await _handle_cancel_task({"task_id": "run-6"}, _ctx(mgr))
+
+    assert result["status"] == "error"
+    assert result["status"] != "cancel_requested"
+    assert "run-6" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_unknown_id_returns_error(tmp_path: Path):
+    """Tier 2: falsification pair to the accept-side cancel test — an
+    unregistered task_id also gets an explicit error, not a crash."""
+    mgr = _make_manager(tmp_path)
+
+    result = await _handle_cancel_task({"task_id": "never-registered"}, _ctx(mgr))
+
+    assert result["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_untyped_legacy_chain_returns_error(tmp_path: Path):
+    """Tier 2: strip-falsify sibling of the describe_task legacy-chain
+    test — cancel_task must not act on an untyped chain either (a task_id
+    that resolves to a delegate-relay entry, not a typed task)."""
+    mgr = _make_manager(tmp_path)
+    calls = []
+    await mgr.register(
+        chain_id="legacy-3", from_user=False, depth=0, original_text="p", sender="peer",
+        cancel=lambda: calls.append("should not run"),
+    )
+
+    result = await _handle_cancel_task({"task_id": "legacy-3"}, _ctx(mgr))
+
+    assert result["status"] == "error"
+    assert calls == []

--- a/tests/tools/test_task_verbs_3978.py
+++ b/tests/tools/test_task_verbs_3978.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from reyn.core.events.state_log import StateLog
+from reyn.runtime.router_loop import RouterLoop
 from reyn.runtime.services.chain_manager import ChainManager
 from reyn.runtime.services.snapshot_journal import SnapshotJournal
 from reyn.tools.task_verbs import (
@@ -21,6 +22,7 @@ from reyn.tools.task_verbs import (
     _handle_list_tasks,
 )
 from reyn.tools.types import RouterCallerState, ToolContext
+from tests._support.router_loop import FakeRouterHost
 
 
 class _NullEvents:
@@ -226,3 +228,47 @@ async def test_cancel_task_untyped_legacy_chain_returns_error(tmp_path: Path):
 
     assert result["status"] == "error"
     assert calls == []
+
+
+# ── production-wiring witness (lead-coder block on #4106) ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_describe_task_reaches_a_real_chain_manager_through_the_real_router_loop(
+    tmp_path: Path,
+):
+    """Tier 2: every test above builds ``RouterCallerState(chains=mgr)``
+    directly — proving the HANDLER is correct, but never exercising the
+    production WIRING (``build_resource_caller_state``'s own
+    ``host.get_chains()`` read, the seam ``RouterHostAdapter.get_chains()``
+    /``Session``'s ``chains=self.chains`` construction-time wiring mirrors
+    in production). Dropping that ONE wiring line degrades SILENTLY — no
+    exception, `chains=None` renders as an ordinary "no running task"
+    error the handler itself already covers — so a test that never drives
+    the real seam cannot tell "wiring removed" from "task genuinely not
+    found". This drives a REAL ``RouterLoop._invoke_router_tool`` call
+    (the exact production dispatch path — REGISTRY_DISPATCH_TOOLS →
+    ``_invoke_via_registry`` → ``_build_router_caller_state`` →
+    ``build_resource_caller_state`` → ``host.get_chains()``) against a
+    ``FakeRouterHost`` carrying a REAL, task-registered ``ChainManager`` —
+    same shape as ``test_session_spawn_dispatches_to_host_not_unhandled``
+    (#2120's own spawn_session-advertised-but-undispatched precedent)."""
+    mgr = _make_manager(tmp_path)
+    await mgr.register(
+        chain_id="run-e2e", from_user=False, depth=0, original_text="p", sender=None,
+        origin_agent="worker", origin_sid="s1", kind="pipeline",
+    )
+    host = FakeRouterHost(chains=mgr)
+    loop = RouterLoop(host=host, chain_id="chain-test")
+
+    result = await loop._invoke_router_tool("describe_task", {"task_id": "run-e2e"})
+
+    assert not (isinstance(result, dict) and "unhandled tool" in str(result.get("error", ""))), (
+        f"describe_task hit the unhandled-tool fall-through: {result}"
+    )
+    assert result.get("ok") is True, (
+        f"describe_task did not reach the real ChainManager through production "
+        f"wiring (chains=None would render as ok=False, not a crash): {result}"
+    )
+    assert result["task_id"] == "run-e2e"
+    assert result["kind"] == "pipeline"

--- a/tests/tools/test_tool_naming_convention_gate_3223.py
+++ b/tests/tools/test_tool_naming_convention_gate_3223.py
@@ -47,6 +47,11 @@ CANONICAL_VERBS: frozenset[str] = frozenset(
         # owner-ratified rename sweep, see docs/reference/runtime/tool-naming.md
         # § "family-prefix validity condition".
         "create",
+        # proposal 0067 P4 (#3978), architect ruling: NOT a 5th removal verb
+        # (R2's four — delete/drop/forget/uninstall — all mean "a thing
+        # ceases to exist"; a cancelled task's record persists as an
+        # audit-event, only the handle is gone). Added for cancel_task.
+        "cancel",
     }
 )
 

--- a/tests/tools/test_universal_catalog.py
+++ b/tests/tools/test_universal_catalog.py
@@ -85,6 +85,9 @@ def test_categories_master_table_order() -> None:
         # ``pipeline__`` resource category; management plane (mirrors
         # ``skill_management``).
         "pipeline_management",
+        # proposal 0067 P4 (#3978): describe_task / list_tasks / cancel_task —
+        # read/act against a currently-running async task's settle-path handle.
+        "task",
         # proposal 0060 Phase 1 Layer A (A8): presentation management ops
         # (install). Management plane (mirrors skill_management /
         # pipeline_management); required for presentation_install_local to

--- a/tests/tools/test_universal_dispatch.py
+++ b/tests/tools/test_universal_dispatch.py
@@ -319,6 +319,11 @@ _ACTION_CONTRACT_SAMPLES: list[tuple[str, dict[str, Any]]] = [
      {"definition": "pipeline: p\nsteps:\n  - transform: {value: \"1\"}\n"}),
     ("run_pipeline_inline_async",
      {"definition": "pipeline: p\nsteps:\n  - transform: {value: \"1\"}\n"}),
+    # task category (proposal 0067 P4, #3978) — describe/cancel require the
+    # task's handle; list_tasks takes an optional kind filter.
+    ("describe_task", {"task_id": "pipeline-my_pipeline-abc123"}),
+    ("list_tasks", {}),
+    ("cancel_task", {"task_id": "pipeline-my_pipeline-abc123"}),
     # plugin_management category (ADR 0064 P2, #3083) — install requires
     # source (a {kind, ...} object); uninstall requires name.
     ("install_plugin",


### PR DESCRIPTION
**[tui-coder]** — proposal 0067 P4: `describe_task` / `list_tasks` / `cancel_task`.

## The tools

- `describe_task(task_id)` → `{task_id, kind, status, session, requester}` (`ttl_seconds` deferred to P8).
- `list_tasks(kind?)` → `{tasks: [{task_id, kind, status, session}]}`.
- `cancel_task(task_id)` → `{task_id, status}`. **Architect's hard requirement**: a handle whose `cancel` hook is `None` (crash-recovered — the live callable belonged to the dead process) returns an explicit error, never a false `"cancel_requested"`.

All three exclude untyped legacy delegate-relay chains (`kind=None`) — not a typed task yet (P6's job). No `read_task_result`: a settled task's handle is already gone (ADR-0040 D4); results arrive via `task_settled`, never a poll.

## Wiring

`RouterCallerState.chains` + `RouterHostAdapter.get_chains()` (mirrors `pipeline_registry`'s own threading), a new `"task"` catalog category (closes the reachability gate #3464), 3 new canonical mappers, `cancel` added to `CANONICAL_VERBS` (not a 5th removal verb — architect: audit record persists, only the handle is gone).

## Real regressions found + fixed by the large-scope regression run

- `cancel_task_to_canonical` echoed an unrecognized status verbatim — the exact FP-0056 M3 "None: ok" pattern (#2695) that gate exists to catch. Now raises `CanonicalDiscriminatorMiss` outside the 2 real values. **Falsify-verified.**
- `test_2123_router_dispatch_sot_1953.py`'s dispatch-set golden updated for the 3 new tools (a deliberate "no behavior change" oracle by its own docstring — an intentional accept-side update, not a bug).

## Stale-count fix (byproduct, not a bandage)

`invoke_action`'s description hardcoded "13 action categories" — already stale before this PR (true count was 15 pre-`task`, 16 with it). Structural fix: dropped the number entirely rather than writing a new hardcoded "16" (a circular-import obstacle prevents deriving `len(CATEGORIES)` at description-build time without restructuring `ToolDescription` into lazy text — out of scope here). Also fixed the JA doc's matching live "13" claim; left a historical dogfood research record (point-in-time measurement, not live-state) untouched.

## Tests

`tests/tools/test_task_verbs_3978.py` — 11 tests, real `ChainManager` throughout. Falsify-verified the cancel "never silent success" requirement.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 97/97 OK
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (210/214 baselined)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/tools/ tests/core/ tests/runtime/ tests/hooks/` — 5372+ passed (14 pre-existing unrelated failures confirmed on `main` too — Textual theme env issue + image-resolution E2E, via `git stash`)
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean
- [x] Falsify-verified the `cancel_task_to_canonical` discriminator fix
- [ ] Visual — n/a (no TUI-visible change)

## Remaining P4/#3978 scope (not in this PR)

`run_prompt` (attached/async) — attached mode waits on the shared `PEER_SESSION` `TurnOrigin` member landing from the parallel P5 PR; async mode's design (task_id vs chain_id unification) is still an open question on the issue. The `[task_completed] kind=` migration (`agent`/`spawned_session` → `prompt`/`pipeline`/`exec`) is also still pending an architect ruling on the issue (a genuine two-axis conflict, not a mechanical rename).

part of #3978

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**[lead-coder]** — reviewer's blocking item (rule 7):

- [x] 🔴 No test witnesses that the real `RouterLoop` binds `chains` — all 11 hand-build `RouterCallerState(chains=...)`, so dropping `router_loop.py:153`'s `chains=self.chains` leaves them green while the three tools degrade to a permanent "no chains source" error for the LLM. Add the sibling of `tests/runtime/test_router_loop.py:571`, falsified by dropping that line. **Addressed**: added `test_describe_task_reaches_a_real_chain_manager_through_the_real_router_loop` (drives a real `RouterLoop._invoke_router_tool` against a `FakeRouterHost` carrying a real `ChainManager`, same shape as `test_session_spawn_dispatches_to_host_not_unhandled`). Falsify-verified by dropping `build_resource_caller_state`'s `host.get_chains()` read (the actual shared wiring seam both the real `RouterHostAdapter` and this fake go through) — confirmed genuinely red at the intended assertion, reverted.

