### PR TITLE
docs(#3978): fix feature-map.md's stale-on-arrival race + #4106's missing row

### DIFF
--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -713,6 +713,7 @@ Cross-surface `ask_user` and permission routing — the same prompt reaches the 
 | MessageBus | Quiescence-based coordination with `reply_to` correlation | [Multi-agent config](reference/config/multi-agent.md) |
 | `delegate_to_agent` | Async-dispatch to peer with topology permission gate | [Multi-agent concepts](concepts/multi-agent/multi-agent.md) |
 | `send_to_session` | Fire-and-forget delivery to a specific `(agent, session)` — no reply is collected; `wake=True` starts a turn on it now, `wake=False` (default) queues it as context for the target's next turn | [Multi-agent concepts](concepts/multi-agent/multi-agent.md) |
+| `describe_task` / `list_tasks` / `cancel_task` | Read/act against the settle-path task handle (`ChainManager`) — `describe_task` returns `{task_id, kind, status, session, requester}`, `list_tasks` lists running handles by kind, `cancel_task` never reports a fabricated success on a crash-recovered handle whose live callable is gone | [Multi-agent concepts](concepts/multi-agent/multi-agent.md) |
 | Agent hops cap | Max delegation depth via `safety.loop.max_agent_hops` | [reyn-yaml § safety](reference/config/reyn-yaml.md#safety-block) |
 | `chain_id` propagation | Trace multi-hop chains in P6 events | [Events reference](reference/runtime/events.md) |
 
@@ -724,8 +725,8 @@ Cross-surface `ask_user` and permission routing — the same prompt reaches the 
 > `session_spawn` by #4004/#4017), and the A2A async run under one `task` concept (one execution
 > and a handle) with a single collection surface, retiring
 > `delegate_to_agent` and the three `run_pipeline_*` async variants in favor of `run_prompt` /
-> `run_pipeline(collect=…)`. `send_to_session` (P5) has landed — see the row above; the
-> remaining `run_prompt` / `describe_task` / `list_tasks` / `cancel_task` tools and
+> `run_pipeline(collect=…)`. `send_to_session` (P5) and `describe_task` / `list_tasks` /
+> `cancel_task` (P4) have landed — see the row above; `run_prompt` (attached and async) and
 > `delegate_to_agent`'s retirement are still pending. `delegate_to_agent` stays live and
 > unchanged until its own retirement PR lands.
 


### PR DESCRIPTION
**[docs-maintainer]** — Found while triaging #4101 (P5, `send_to_session`) for doc drift as part of standing broker-inbox monitoring.

## Finding 1: a stale-on-arrival race between two parallel PRs

#4101's own `feature-map.md` note said "the remaining `run_prompt` / `describe_task` / `list_tasks` / `cancel_task` tools ... are still pending" — false the moment it landed on `main`. #4106 (P4: `describe_task`/`list_tasks`/`cancel_task`) merged 16 minutes *before* #4101 (`2026-08-10T15:39:38Z` vs `15:55:42Z`) — two parallel PRs racing on the same doc's claim, and #4101's branch was evidently cut before #4106 landed, so its own status claim about a sibling PR was wrong by the time it merged. Verified directly against `src/reyn/tools/__init__.py` — all 3 tools are registered today. Corrected the note: only `run_prompt` (attached and async) and `delegate_to_agent`'s retirement genuinely remain pending.

## Finding 2: #4106 never added its own feature-map.md row

#4106's diff only touched `universal-catalog.ja.md` — no `feature-map.md` entry for its 3 new tools at all, unlike #4101's own `send_to_session` row right above where this one now sits. Added one, sourced from #4106's own PR body (return shapes, `cancel_task`'s crash-recovered-handle guarantee against a fabricated success).

## Test plan

- [x] `python scripts/check_doc_anchors.py` — exit 0
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0 (remaining INFO lines are pre-existing ja-mirror gaps)
- [x] `python scripts/check_tests_path_literal_reference.py` (gate #6) — OK
- [x] Confirmed all 3 P4 tools registered in `tools/__init__.py` on current `main`, not inferred from the PR body alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
