### PR TITLE
docs(#3978): P8 requires #4108 — the line assumed arbitrary chain fields could be persisted

### DIFF
--- a/docs/deep-dives/proposals/0067-task-model-and-arbiter.md
+++ b/docs/deep-dives/proposals/0067-task-model-and-arbiter.md
@@ -147,8 +147,13 @@ P7    run_pipeline: four names → one (`collect` carries the attached/async axi
       P7 adds `collect` and `on_settle` and renames nothing.
 
 P8    ttl expiry: reuse the chain-timeout shape, plus persist `arm_at`
-      chain_manager.py:362 re-arms "a fresh timeout watchdog" on restore, so a crash currently
+      chain_manager.py re-arms "a fresh timeout watchdog" on restore, so a crash currently
       extends the effective deadline
+      🔴 Requires #4108 first. This line assumed a chain field could simply be persisted;
+         it could not. `ChainManager.update()` forwards any field to the WAL, but the
+         snapshot write-back handled `waiting_on` alone — so `arm_at` would have been
+         dropped from reconstruction AND the same call would have overwritten `waiting_on`
+         with `[]`, destroying live state. P8 is the first caller that would have hit it.
 ```
 
 ### Observation (explicitly not bounding)


### PR DESCRIPTION
**[architect]** — part of #3978。**予告した 1 行（#4110 の co-vet で出た sequencing）。doc のみ。**

## 何が抜けていたか

**0067 の P8 は「persist `arm_at`」と書いており、★chain に field を足して `update()` に渡せば
永続化される、と読めます。★できません。**

```
ChainManager.update()      ★任意の field を WAL へ流す
snapshot への書き戻し       ★waiting_on だけを扱う（#4108）
∴ arm_at を渡すと          ① 再構築に載らない
                          ② ★同じ呼び出しが waiting_on を [] に破壊する
                          ── P8 が★その両方に触れる最初の caller
```
🔴 **私が確かめずに書きました。** ⚪ **note ではなく★hard prerequisite として記録**しています ──
**失敗が両方向とも沈黙する**（WAL は正しく見え、壊れた `waiting_on` は
**開発中に誰も走らせない再構築でしか表面化しない**）ため。

⚪ **併せて同じ行から行番号を 1 つ落としました**（`#4105` で本ファイルに入れた引用形式）──
**効くのは `chain_manager.py` の re-arm 挙動**であって、**行は動きます。**

## Test plan

- [x] doc のみ ∴ pytest 対象なし
- [x] **`origin/main` に対して P8 行を確認**してから編集（worktree ではなく ── 本日 2 度
      worktree を読んで誤読しかけたため、`HEAD` と `origin/main` を並べて出してから作業）
- [x] #4108 の defect 内容を **issue 本文と #4110 の diff の両方**で確認
- [ ] (skipped — Visual 項目なし)

⚠️ **#4110 は執筆時点で ★OPEN** です。**本 PR は「P8 の前に #4108 が要る」と書くだけ**で、
**#4110 の merge に依存しません**（順序の記録であって、修正の記録ではない）。
