### PR TITLE
docs: an ADR that names a string makes renaming it an ADR decision

### DIFF
--- a/docs/deep-dives/decisions/README.md
+++ b/docs/deep-dives/decisions/README.md
@@ -15,6 +15,20 @@ ADRs are immutable once accepted. New facts that contradict a decision
 get a new ADR that supersedes the old one (the old one keeps its
 historical value with status updated to "superseded by ADR-XXXX").
 
+One consequence, because it has been missed: **an ADR that names a string
+makes renaming that string an ADR decision, not a sweep.** If `collect="attached"`
+appears in an accepted ADR's body, changing the value to something else falsifies
+a sentence in a document nobody may edit — so the cost is a superseding ADR, not a
+rename PR across code, catalog, prompt and fixtures. Before proposing to rename an
+LLM-visible string, grep `decisions/` for it.
+
+The distinction that matters is whether the ADR **decides** the change or
+**states** the thing being changed. ADR-0040 names `delegate_to_agent` as a tool it
+decides to retire; retiring it implements the ADR. The same ADR also states that
+`collect="attached"` creates nothing at all; renaming that value would make the
+sentence false. Same file, opposite relationship, and only the second one needs a
+new ADR.
+
 ## Index
 
 ### Persistence model


### PR DESCRIPTION
**[architect]** — **doc のみ 1 段落。`decisions/README.md` に、immutability の★帰結を 1 つ書きます。**

## 何が抜けていたか

**README は「ADRs are immutable once accepted」と書いていますが、
★それに人が最もよくぶつかる形**を書いていません。**私は今夜 2 回ぶつかりました:**

```
1 回目  accept 済み ADR を★直接編集した（#4096 で復帰、blob 一致で確認済み）
2 回目  LLM 可視文字列の★改名を裁定した ── ★ADR がその値を名指ししているか見ずに
        ADR-0040 D4:「`collect="attached"` creates nothing at all」
        ∴ 改名は「★誰も編集してよくない文書の一文を偽にする」работ でした
```
⚪ **1 回目は自分で踏んで学びました。2 回目は★撤回後に、実装者の戻しを検証していて気づきました**
（撤回理由は別件 ── 語彙の再解釈 ── で、**この欠陥は撤回の理由ではありません**）。

## 追記した内容

```
帰結    ADR が文字列を★名指ししているなら、その改名は ★sweep ではなく ADR 判断。
        提案の前に ★decisions/ を grep する
判別    ADR がその変更を ★決めている のか、変更対象を ★述べている のか
          ADR-0040 は `delegate_to_agent` を「retire する」と★決めている
            → P6 が retire するのは ★ADR の実装。矛盾しない
          同じ ADR が `collect="attached"` の挙動を ★述べている
            → 改名は★その一文を偽にする。superseding ADR が要る
        ★同じファイル、逆の関係。後者だけが新しい ADR を要求する
```

## Test plan

- [x] doc のみ ∴ pytest 対象なし
- [x] **README に rename / 改名の記述が★既に無いことを確認**してから追記（重複回避）
- [x] **ADR-0040 が両方の形を実際に持つことを本文で確認**
      （`delegate_to_agent` の retire 宣言 ／ `collect="attached"` の挙動記述）
- [x] `origin/main` に対して読み取り（worktree ではなく）
- [ ] (skipped — Visual 項目なし)

⚠️ **私が測っていないこと**: **他の ADR が同種の「文字列を述べている」箇所を
どれだけ持つか**は★数えていません。**本追記は規則を書いたもので、
★既存の抵触を洗い出したものではありません。**
