### PR TITLE
fix(security): extend the re-delegation floor to send_to_session (#3978)

### DIFF
--- a/docs/concepts/runtime/delegation-policy.ja.md
+++ b/docs/concepts/runtime/delegation-policy.ja.md
@@ -32,7 +32,7 @@ delegation:
 
 | クラス | 拒否されるツール | 理由 |
 |--------|----------------|------|
-| `re-delegation` | `delegate_to_agent`、`run_prompt`、`send_to_session` | 未信頼コンテンツから他エージェントのコンテキストへ到達させない — `run_prompt`（proposal 0067 P4d）と `send_to_session`（P5）は `delegate_to_agent` と同じ経路でこれを行う。`send_to_session` は `wake=False` も含む（architect 裁定、2026-08-10） |
+| `re-delegation` | `delegate_to_agent`、`send_to_session` | 未信頼コンテンツから他エージェントのコンテキストへ到達させない — `send_to_session`（proposal 0067 P5）は `delegate_to_agent` と同じ経路でこれを行う。`wake=False` も含む（architect 裁定、2026-08-10）。`run_prompt`（P4d）もこのフロアに属するが、#4117 自身の doc drift として #4123 が別途対応する |
 | `exec` | `exec`、`exec` | 実行には明示的なオペレーター認証が必要 |
 | `mcp-install` | `mcp_install_registry`、`mcp_install_package`、`mcp_install_local` | MCP サーバーインストールは高権限のオペレーター管理アクション |
 | `memory-write` | `remember_shared`、`remember_agent`、`forget_memory` | アンバウンド委任エージェントからの永続化には意図的なオプトインが必要 |
@@ -81,7 +81,7 @@ delegation:
 
 | クラス | 重大度 | ツール |
 |--------|--------|--------|
-| `re-delegation` | HIGH | `delegate_to_agent`、`run_prompt`、`send_to_session` |
+| `re-delegation` | HIGH | `delegate_to_agent`、`send_to_session` |
 | `exec` | HIGH | `exec`、`exec` |
 | `mcp-install` | HIGH | `mcp_install_registry`、`mcp_install_package`、`mcp_install_local` |
 | `memory-write` | MED | `remember_shared`、`remember_agent`、`forget_memory` |

--- a/docs/concepts/runtime/delegation-policy.ja.md
+++ b/docs/concepts/runtime/delegation-policy.ja.md
@@ -32,7 +32,7 @@ delegation:
 
 | クラス | 拒否されるツール | 理由 |
 |--------|----------------|------|
-| `re-delegation` | `delegate_to_agent`、`delegate_to_agent` | アンバウンド委任エージェントからの無制限スポーニングチェーンを防止 |
+| `re-delegation` | `delegate_to_agent`、`run_prompt`、`send_to_session` | 未信頼コンテンツから他エージェントのコンテキストへ到達させない — `run_prompt`（proposal 0067 P4d）と `send_to_session`（P5）は `delegate_to_agent` と同じ経路でこれを行う。`send_to_session` は `wake=False` も含む（architect 裁定、2026-08-10） |
 | `exec` | `exec`、`exec` | 実行には明示的なオペレーター認証が必要 |
 | `mcp-install` | `mcp_install_registry`、`mcp_install_package`、`mcp_install_local` | MCP サーバーインストールは高権限のオペレーター管理アクション |
 | `memory-write` | `remember_shared`、`remember_agent`、`forget_memory` | アンバウンド委任エージェントからの永続化には意図的なオプトインが必要 |
@@ -81,7 +81,7 @@ delegation:
 
 | クラス | 重大度 | ツール |
 |--------|--------|--------|
-| `re-delegation` | HIGH | `delegate_to_agent`、`delegate_to_agent` |
+| `re-delegation` | HIGH | `delegate_to_agent`、`run_prompt`、`send_to_session` |
 | `exec` | HIGH | `exec`、`exec` |
 | `mcp-install` | HIGH | `mcp_install_registry`、`mcp_install_package`、`mcp_install_local` |
 | `memory-write` | MED | `remember_shared`、`remember_agent`、`forget_memory` |

--- a/docs/concepts/runtime/delegation-policy.ja.md
+++ b/docs/concepts/runtime/delegation-policy.ja.md
@@ -32,7 +32,7 @@ delegation:
 
 | クラス | 拒否されるツール | 理由 |
 |--------|----------------|------|
-| `re-delegation` | `delegate_to_agent`、`run_prompt`、`send_to_session` | 未信頼コンテンツから他エージェントのコンテキストへ到達させない — `run_prompt`（proposal 0067 P4d）と `send_to_session`（P5）は `delegate_to_agent` と同じ経路でこれを行う。`send_to_session` は `wake=False` も含む（architect 裁定、2026-08-10）。EN 版の同表は `run_prompt` を #4123（#4117 自身の doc drift 対応、EN のみ）に委ねているため `send_to_session` だけを持つ — #4123 は ja を触らないため、この ja 表は本 PR がまとめて 3 名を持つ |
+| `re-delegation` | `delegate_to_agent`、`run_prompt`、`send_to_session` | 未信頼コンテンツから他エージェントのコンテキストへ到達させない — `run_prompt`（proposal 0067 P4d）と `send_to_session`（P5）は `delegate_to_agent` と同じ経路でこれを行う。`send_to_session` は `wake=False` も含む（architect 裁定、2026-08-10） |
 | `exec` | `exec`、`exec` | 実行には明示的なオペレーター認証が必要 |
 | `mcp-install` | `mcp_install_registry`、`mcp_install_package`、`mcp_install_local` | MCP サーバーインストールは高権限のオペレーター管理アクション |
 | `memory-write` | `remember_shared`、`remember_agent`、`forget_memory` | アンバウンド委任エージェントからの永続化には意図的なオプトインが必要 |

--- a/docs/concepts/runtime/delegation-policy.ja.md
+++ b/docs/concepts/runtime/delegation-policy.ja.md
@@ -32,7 +32,7 @@ delegation:
 
 | クラス | 拒否されるツール | 理由 |
 |--------|----------------|------|
-| `re-delegation` | `delegate_to_agent`、`send_to_session` | 未信頼コンテンツから他エージェントのコンテキストへ到達させない — `send_to_session`（proposal 0067 P5）は `delegate_to_agent` と同じ経路でこれを行う。`wake=False` も含む（architect 裁定、2026-08-10）。`run_prompt`（P4d）もこのフロアに属するが、#4117 自身の doc drift として #4123 が別途対応する |
+| `re-delegation` | `delegate_to_agent`、`run_prompt`、`send_to_session` | 未信頼コンテンツから他エージェントのコンテキストへ到達させない — `run_prompt`（proposal 0067 P4d）と `send_to_session`（P5）は `delegate_to_agent` と同じ経路でこれを行う。`send_to_session` は `wake=False` も含む（architect 裁定、2026-08-10）。EN 版の同表は `run_prompt` を #4123（#4117 自身の doc drift 対応、EN のみ）に委ねているため `send_to_session` だけを持つ — #4123 は ja を触らないため、この ja 表は本 PR がまとめて 3 名を持つ |
 | `exec` | `exec`、`exec` | 実行には明示的なオペレーター認証が必要 |
 | `mcp-install` | `mcp_install_registry`、`mcp_install_package`、`mcp_install_local` | MCP サーバーインストールは高権限のオペレーター管理アクション |
 | `memory-write` | `remember_shared`、`remember_agent`、`forget_memory` | アンバウンド委任エージェントからの永続化には意図的なオプトインが必要 |
@@ -81,7 +81,7 @@ delegation:
 
 | クラス | 重大度 | ツール |
 |--------|--------|--------|
-| `re-delegation` | HIGH | `delegate_to_agent`、`send_to_session` |
+| `re-delegation` | HIGH | `delegate_to_agent`、`run_prompt`、`send_to_session` |
 | `exec` | HIGH | `exec`、`exec` |
 | `mcp-install` | HIGH | `mcp_install_registry`、`mcp_install_package`、`mcp_install_local` |
 | `memory-write` | MED | `remember_shared`、`remember_agent`、`forget_memory` |

--- a/docs/concepts/runtime/delegation-policy.md
+++ b/docs/concepts/runtime/delegation-policy.md
@@ -126,7 +126,7 @@ the runtime floor uses, so the audit and the floor cannot drift apart.
 
 | Class | Severity | Tools |
 |-------|----------|-------|
-| `re-delegation` | HIGH | `delegate_to_agent`, `send_to_session` |
+| `re-delegation` | HIGH | `delegate_to_agent`, `run_prompt`, `send_to_session` |
 | `exec` | HIGH | `exec` |
 | `mcp-install` | HIGH | `mcp_install_registry`, `mcp_install_package`, `mcp_install_local` |
 | `skill-install` | HIGH | `skill_install_local`, `skill_install_source` |

--- a/docs/concepts/runtime/delegation-policy.md
+++ b/docs/concepts/runtime/delegation-policy.md
@@ -40,7 +40,7 @@ from `_FLOORED_DENY_CLASSES`):
 
 | Class | Denied tools | Rationale |
 |-------|-------------|-----------|
-| `re-delegation` | `delegate_to_agent`, `run_prompt` | Prevent unlimited spawning chains from an unbound delegate; `run_prompt` (proposal 0067 P4d, #3978) reaches another agent's context synchronously — same effect class |
+| `re-delegation` | `delegate_to_agent`, `run_prompt`, `send_to_session` | Prevent an unbound delegate from reaching into another agent's context — `run_prompt` (proposal 0067 P4d, #4117) and `send_to_session` (P5, #4101) both do this the same way `delegate_to_agent` does; `send_to_session`'s `wake=False` is included (architect ruling, 2026-08-10) |
 | `exec` | `exec` | Execution requires explicit operator authorization |
 | `mcp-install` | `mcp_install_registry`, `mcp_install_package`, `mcp_install_local` | MCP server installation is a high-privilege, operator-controlled action |
 | `skill-install` | `skill_install_local`, `skill_install_source` | Registering skills from untrusted content is a persistence vector (#2548); mirrors `mcp-install` |
@@ -126,7 +126,7 @@ the runtime floor uses, so the audit and the floor cannot drift apart.
 
 | Class | Severity | Tools |
 |-------|----------|-------|
-| `re-delegation` | HIGH | `delegate_to_agent`, `run_prompt` |
+| `re-delegation` | HIGH | `delegate_to_agent`, `run_prompt`, `send_to_session` |
 | `exec` | HIGH | `exec` |
 | `mcp-install` | HIGH | `mcp_install_registry`, `mcp_install_package`, `mcp_install_local` |
 | `skill-install` | HIGH | `skill_install_local`, `skill_install_source` |

--- a/docs/concepts/runtime/delegation-policy.md
+++ b/docs/concepts/runtime/delegation-policy.md
@@ -126,7 +126,7 @@ the runtime floor uses, so the audit and the floor cannot drift apart.
 
 | Class | Severity | Tools |
 |-------|----------|-------|
-| `re-delegation` | HIGH | `delegate_to_agent`, `run_prompt`, `send_to_session` |
+| `re-delegation` | HIGH | `delegate_to_agent`, `send_to_session` |
 | `exec` | HIGH | `exec` |
 | `mcp-install` | HIGH | `mcp_install_registry`, `mcp_install_package`, `mcp_install_local` |
 | `skill-install` | HIGH | `skill_install_local`, `skill_install_source` |

--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -384,25 +384,26 @@ _FLOORED_TOOLS: "dict[str, frozenset[str]]" = {
         "remember_agent",
         "forget_memory",
     }),
-    # re-delegation — no spawning peers from untrusted content. Proposal 0067
-    # P4d (#3978), architect ruling 2026-08-10: run_prompt joins here, same
-    # PR as the tool itself (landing the tool without its floor entry would
-    # open a window where the tool exists but nothing denies it from
-    # untrusted content). The reasoning that puts delegate_to_agent on this
-    # floor is not a single comment about THAT tool — it is the floor's own
-    # grammar, which names EFFECTS, not tool names (memory-write denies
-    # "persist", not "call remember_shared"; pipeline-install's own comment
-    # draws the identical distinction: the callee runs under its narrowed
-    # identity, but the REGISTRATION action itself must not be reachable).
-    # run_prompt drives a peer session's turn synchronously and returns its
-    # reply in-band — the same "reach another agent's context" effect
-    # delegate_to_agent has, argument-independent (an argument-conditioned
-    # deny would make the discriminator depend on the very input being
-    # classified, which the floor avoids by design). send_to_session
-    # belongs on this same floor for the identical reason — tracked
-    # separately (already on main; its own PR adds it here) rather than in
-    # this same change, since it predates this PR.
-    "re-delegation": frozenset({"delegate_to_agent", "run_prompt"}),
+    # re-delegation — no reaching into another agent's context from untrusted
+    # content. Architect ruling (2026-08-10, #3978): this floor's own
+    # constituent comments name an EFFECT ("no spawning peers from untrusted
+    # content"), not a specific mechanism — memory-write bars persistence,
+    # mcp/skill/pipeline-install bar registration REGARDLESS of whether the
+    # called tool's own work then runs under the invoker's narrowed identity
+    # (pipeline-install's own comment already draws that exact distinction).
+    # send_to_session (proposal 0067 P5, #4101) and run_prompt (P4d, #4117)
+    # both reach ANOTHER agent's context the same way delegate_to_agent
+    # does — only the name differs — and BOTH now land here, together with
+    # delegate_to_agent (#4117 added run_prompt in the same PR as the tool
+    # itself, avoiding a window where the tool exists but nothing denies it
+    # from untrusted content; this file's own #4122 added send_to_session
+    # separately, since it predates run_prompt's own PR). send_to_session
+    # (wake=False) is included: it queues a string into a peer's NEXT turn
+    # silently (no immediate wake), which is the quieter, not the safer,
+    # form of the same injection path. No argument-conditioned deny (e.g.
+    # wake= alone) — the classifier must not depend on input from the very
+    # content being classified.
+    "re-delegation": frozenset({"delegate_to_agent", "run_prompt", "send_to_session"}),
     # code execution. #3226 Phase 1: the #2593 pipeline DSL `shell` tool
     # (thin sugar over sandboxed_exec, same subprocess-exec threat surface)
     # was removed outright — it was the sole `/bin/sh -c <str>` injection

--- a/tests/security/test_2111_floor_alias_completeness.py
+++ b/tests/security/test_2111_floor_alias_completeness.py
@@ -80,6 +80,21 @@ def test_every_floored_name_is_in_the_floor() -> None:
             assert name in _BUILTIN_UNTRUSTED_DENY, f"{cls}: {name!r} missing from floor"
 
 
+def test_re_delegation_names_all_three_reach_effects() -> None:
+    """Tier 2: architect catch (#3978, on the #4117/#4122 merge-order
+    conflict) — the vacuity guard above catches a class going EMPTY, not one
+    losing a MEMBER while staying non-empty. #4117 (P4d) added
+    ``run_prompt`` and #4122 (this PR) added ``send_to_session`` to the same
+    ``"re-delegation"`` frozenset LITERAL, in two parallel PRs; resolving
+    that conflict by silently keeping only one side's addition would leave
+    the class non-empty (so the vacuity guard stays green) while a real
+    reach-another-agent's-context tool goes unfloored. Names all three
+    directly rather than relying on set-membership-implies-completeness."""
+    assert _FLOORED_TOOLS["re-delegation"] == frozenset({
+        "delegate_to_agent", "run_prompt", "send_to_session",
+    })
+
+
 def test_every_floored_name_is_a_registered_tool() -> None:
     """Tier 2: #2111's gap-class in the opposite direction, re-guarded for #3429.
 

--- a/tests/security/test_2111_floor_alias_completeness.py
+++ b/tests/security/test_2111_floor_alias_completeness.py
@@ -56,6 +56,22 @@ def _all_floored_forms() -> list[str]:
 # ── completeness-invariant (SoT-derived) ────────────────────────────────────
 
 
+def test_no_floor_class_is_empty() -> None:
+    """Tier 2: vacuity guard — an emptied floor class (``frozenset()``) would
+    pass ``test_every_floored_name_is_in_the_floor`` vacuously (nothing to
+    check) while denying nothing, silently disabling that class's whole
+    threat coverage. Same shape as #4110's chain-field vacuity guard.
+
+    Named ahead of need: proposal 0067 P6 (#3978) retires ``delegate_to_agent``,
+    the ONLY member ``re-delegation`` had before this PR added
+    ``send_to_session`` — without that addition (architect ruling, #3978:
+    send_to_session/run_prompt reach another agent's context the same way
+    delegate_to_agent does), P6 would leave ``re-delegation`` empty and this
+    test would have caught it before merge."""
+    for cls, names in _FLOORED_TOOLS.items():
+        assert names, f"{cls}: floor class is empty — denies nothing, looks like a guard"
+
+
 def test_every_floored_name_is_in_the_floor() -> None:
     """Tier 2: each name declared in a floor class reaches the flat deny union
     the two builtin profiles are built from."""


### PR DESCRIPTION
**[e2e-coder]** — part of #3978. Security floor extension: add `send_to_session` to the `re-delegation` capability floor class.

## Why

Architect ruling (2026-08-10, on #3978): the `_FLOORED_TOOLS` classes each name an **effect**, not a specific mechanism — `memory-write`'s comment says "no persistence from untrusted content" (not "no calling `remember_shared`"), and `pipeline-install`'s existing comment already draws the decisive distinction: "a pipeline's own steps run under the launching invoker's narrowed identity, but the REGISTRATION action itself must not be reachable from untrusted content." `delegate_to_agent`'s presence in `re-delegation` already rejected "the callee runs under its own identity, so it's safe" as an excuse for that same class of capability. `send_to_session` (proposal 0067 P5, #4101) reaches another agent's context the same way `delegate_to_agent` does — only the name differs.

## Scope

- **Whole-tool deny, no argument condition.** `send_to_session(wake=False)` is included — it queues a string into a peer's *next* turn silently (no immediate wake), which is the **quieter**, not the safer, form of the same untrusted-content-injects-into-another-agent's-context path. An argument-conditioned deny (`wake=True` only) would make the classifier depend on input from the content being classified — the same line the owner drew elsewhere tonight (a discriminator must not come from the side being classified).
- **This PR is `send_to_session` only.** `run_prompt` gets the same floor treatment in #4117 (P4d), landing together with the tool itself so no "tool exists, floor doesn't" window opens between two PRs. Target is current `main`, independent of #4117's branch state.
- **Not a vulnerability claim.** Neither architect nor I have traced whether an untrusted-content path can currently reach `send_to_session` at all. This is a **consistency** fix — the same class of capability belongs in the same floor class — recorded as such, not as "found exploitable."

## Vacuity guard, added ahead of need

`test_no_floor_class_is_empty` (falsify-verified: emptied `re-delegation` → RED with the exact diagnostic, restored → green). Proposal 0067 P6 retires `delegate_to_agent`, which was `re-delegation`'s **only** member before this PR — without `send_to_session` now in the class, P6 would leave `re-delegation` an empty `frozenset()` that denies nothing while still reading as a guard. Same shape as tonight's #4110 chain-field vacuity fix. This also satisfies the "no empty floor class" condition lead-coder/architect both flagged as a P6 acceptance condition — landing it here means P6 doesn't pay for it twice.

The existing `test_2111_floor_alias_completeness.py` completeness/live-gate tests are all SoT-derived from `_FLOORED_TOOLS` itself (not hand-listed), so they automatically cover the new entry with zero further edits — verified: 56/56 pass, including the new test.

## Docs

`docs/concepts/runtime/delegation-policy.md` — both floor tables (permission-floor + `reyn audit` audit-class) updated in the same PR.

Filed #4121 (unrelated, pre-existing, found while doc-sweeping): `capability-profile.ja.md` still describes the pre-#3429 dual-spelling `_expand_tool_forms` mechanism, contradicting its own EN sibling right below the same code example. Not fixed here — predates and is unrelated to this PR's scope.

## Gates

`ruff check src tests` clean. `test_tier_audit.py --strict` on the changed test file: 8 tests, 0 Tier-4 violations. `verify_module_docstrings.py`: OK. `mypy_ratchet.py`: OK, 210 findings all baselined (no new). `check_tests_path_literal_reference.py`: OK. Scoped pytest (`tests/security/` + delegation-audit + pipeline/skill-install consumers): 731 passed, 27 skipped (platform-gated extras, pre-existing).

## TESTS-READ

- `test_no_floor_class_is_empty` — ① Tier 2 (OS invariant: no floor class silently denies nothing), matches CLAUDE.md's own #4110 precedent from tonight, named outside this test's own docstring. ② Not the implementation transcribed — asserts `names` truthy, doesn't mirror any specific set construction. ③ Who'd miss it: P6's implementer (me, next) — without this guard, retiring `delegate_to_agent` silently empties `re-delegation` with no test catching it. A real future PR, not a configuration only this test constructs. ④ Would not stay green having never run — no skip markers. ⑤ No accumulation (single pass over a small dict, no loop/wait). ⑥ Declared Tier matches.

part of #3978

## Post-merge-order-collision update (2026-08-10, later)

`#4117` merged before this PR, changing `_FLOORED_TOOLS["re-delegation"]` on `main` to `{delegate_to_agent, run_prompt}` without touching `delegation-policy.md`'s two tables — a real doc drift on `main`, independently caught by architect/lead-coder/docs-maintainer's standing watch/tui, in that rough order, the same night. Rebasing this PR onto the new `main` required a manual (not auto) merge of `_FLOORED_TOOLS`'s literal to all three names, `{delegate_to_agent, run_prompt, send_to_session}`.

**EN vs JA doc split (deliberate, not an oversight)**: `#4123` (tui) separately fixes `#4117`'s own doc drift, EN-only (`delegation-policy.md`'s two tables get `run_prompt`). `#4123` does not touch `delegation-policy.ja.md` (tui's own call: a separate, broader `.ja.md` staleness — `#4121` — makes it not the right PR to touch that file). Since nothing else covers the `.ja.md` tables, **this PR's `.ja.md` edit carries all three names** (`delegate_to_agent`, `run_prompt`, `send_to_session`), while its EN edit carries `send_to_session` only (leaving `run_prompt` to `#4123`). This asymmetry is intentional — each PR owns exactly the surface nothing else covers.

Added `test_re_delegation_names_all_three_reach_effects` (exact-membership assert, falsify-verified) after architect/lead-coder both caught: the vacuity guard added earlier in this PR catches a class going EMPTY, not one silently losing ONE of two simultaneous additions while staying non-empty — exactly the risk two PRs editing the same frozenset literal from the same base created.

**Known residual risk, flagged for the merge-train**: `delegation-policy.md`'s EN table (the exact same line `#4123` also edits) will conflict whichever of `#4122`/`#4123` merges second — same class of hazard as the code-side conflict, but with no exact-membership test on the doc side (a markdown table isn't machine-checked). Whoever resolves that conflict should keep BOTH `run_prompt` and `send_to_session` — do not let either drop silently.

**Doc-side guard gap, recorded for P6**: unlike the code side (which now has `test_re_delegation_names_all_three_reach_effects`), the doc tables have no exact-membership test — this conflict resolution is protected by visual review only. P6's acceptance-condition list already includes "decide whether to build a doc↔code gate or drop the manual enumeration"; this incident (#4122/#4123/#4124 all touching the same doc line, twice, the same night) is a concrete data point for that decision, not a reason to build the gate mid-conflict here.
