### PR TITLE
docs(#3978): delegation-policy.md drift from #4117's re-delegation floor change

### DIFF
--- a/docs/concepts/runtime/delegation-policy.md
+++ b/docs/concepts/runtime/delegation-policy.md
@@ -40,7 +40,7 @@ from `_FLOORED_DENY_CLASSES`):
 
 | Class | Denied tools | Rationale |
 |-------|-------------|-----------|
-| `re-delegation` | `delegate_to_agent` | Prevent unlimited spawning chains from an unbound delegate |
+| `re-delegation` | `delegate_to_agent`, `run_prompt` | Prevent unlimited spawning chains from an unbound delegate; `run_prompt` (proposal 0067 P4d, #3978) reaches another agent's context synchronously — same effect class |
 | `exec` | `exec` | Execution requires explicit operator authorization |
 | `mcp-install` | `mcp_install_registry`, `mcp_install_package`, `mcp_install_local` | MCP server installation is a high-privilege, operator-controlled action |
 | `skill-install` | `skill_install_local`, `skill_install_source` | Registering skills from untrusted content is a persistence vector (#2548); mirrors `mcp-install` |
@@ -126,7 +126,7 @@ the runtime floor uses, so the audit and the floor cannot drift apart.
 
 | Class | Severity | Tools |
 |-------|----------|-------|
-| `re-delegation` | HIGH | `delegate_to_agent` |
+| `re-delegation` | HIGH | `delegate_to_agent`, `run_prompt` |
 | `exec` | HIGH | `exec` |
 | `mcp-install` | HIGH | `mcp_install_registry`, `mcp_install_package`, `mcp_install_local` |
 | `skill-install` | HIGH | `skill_install_local`, `skill_install_source` |


### PR DESCRIPTION
**[tui-coder]** — fix the drift lead-coder caught on main after #4117 landed: `delegation-policy.md` names the re-delegation floor's tools, and `run_prompt` joined `_FLOORED_TOOLS["re-delegation"]` in #4117 without a doc update in the same PR (my miss — the file has zero test/script gate coverage, per lead-coder's confirmation, so nothing caught it before merge).

## What

Both `re-delegation` table rows (built-in deny-set + audit classes) now name `run_prompt` alongside `delegate_to_agent`, with the same rationale `capability_profile.py`'s own comment carries.

## Not touched

`delegation-policy.ja.md` — pre-existing, unrelated drift there (a duplicated `delegate_to_agent、delegate_to_agent` entry), tracked separately as #4121. No blanket en/ja mirror obligation (CLAUDE.md); this PR doesn't falsify anything the ja doc currently claims beyond what #4121 already covers.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — builds clean (pre-existing INFO-level ja-anchor warnings only).
- [x] `python scripts/verify_module_docstrings.py docs/concepts/runtime/delegation-policy.md` — OK.
- [x] Confirmed 0 test/script hits reference `delegation-policy` (this doc has no gate — the drift this PR fixes was undetectable by CI).
- [ ] Visual — n/a (docs-only).

part of #3978

🤖 Generated with [Claude Code](https://claude.com/claude-code)
