### PR TITLE
docs(#3978): re-delegation floor gained run_prompt, doc didn't

### DIFF
--- a/docs/concepts/runtime/delegation-policy.ja.md
+++ b/docs/concepts/runtime/delegation-policy.ja.md
@@ -32,7 +32,7 @@ delegation:
 
 | クラス | 拒否されるツール | 理由 |
 |--------|----------------|------|
-| `re-delegation` | `delegate_to_agent`、`delegate_to_agent` | アンバウンド委任エージェントからの無制限スポーニングチェーンを防止 |
+| `re-delegation` | `delegate_to_agent`、`run_prompt` | アンバウンド委任エージェントからの無制限スポーニングチェーンを防止 |
 | `exec` | `exec`、`exec` | 実行には明示的なオペレーター認証が必要 |
 | `mcp-install` | `mcp_install_registry`、`mcp_install_package`、`mcp_install_local` | MCP サーバーインストールは高権限のオペレーター管理アクション |
 | `memory-write` | `remember_shared`、`remember_agent`、`forget_memory` | アンバウンド委任エージェントからの永続化には意図的なオプトインが必要 |
@@ -81,7 +81,7 @@ delegation:
 
 | クラス | 重大度 | ツール |
 |--------|--------|--------|
-| `re-delegation` | HIGH | `delegate_to_agent`、`delegate_to_agent` |
+| `re-delegation` | HIGH | `delegate_to_agent`、`run_prompt` |
 | `exec` | HIGH | `exec`、`exec` |
 | `mcp-install` | HIGH | `mcp_install_registry`、`mcp_install_package`、`mcp_install_local` |
 | `memory-write` | MED | `remember_shared`、`remember_agent`、`forget_memory` |

--- a/docs/concepts/runtime/delegation-policy.md
+++ b/docs/concepts/runtime/delegation-policy.md
@@ -40,7 +40,7 @@ from `_FLOORED_DENY_CLASSES`):
 
 | Class | Denied tools | Rationale |
 |-------|-------------|-----------|
-| `re-delegation` | `delegate_to_agent` | Prevent unlimited spawning chains from an unbound delegate |
+| `re-delegation` | `delegate_to_agent`, `run_prompt` | Prevent unlimited spawning chains from an unbound delegate |
 | `exec` | `exec` | Execution requires explicit operator authorization |
 | `mcp-install` | `mcp_install_registry`, `mcp_install_package`, `mcp_install_local` | MCP server installation is a high-privilege, operator-controlled action |
 | `skill-install` | `skill_install_local`, `skill_install_source` | Registering skills from untrusted content is a persistence vector (#2548); mirrors `mcp-install` |
@@ -126,7 +126,7 @@ the runtime floor uses, so the audit and the floor cannot drift apart.
 
 | Class | Severity | Tools |
 |-------|----------|-------|
-| `re-delegation` | HIGH | `delegate_to_agent` |
+| `re-delegation` | HIGH | `delegate_to_agent`, `run_prompt` |
 | `exec` | HIGH | `exec` |
 | `mcp-install` | HIGH | `mcp_install_registry`, `mcp_install_package`, `mcp_install_local` |
 | `skill-install` | HIGH | `skill_install_local`, `skill_install_source` |


### PR DESCRIPTION
**[docs-maintainer]** — Found while triaging #4117 (P4d, `run_prompt`) for doc drift.

## What was stale

#4117 landed a same-PR security fix per architect's ruling: `_FLOORED_TOOLS["re-delegation"]` now reads `frozenset({"delegate_to_agent", "run_prompt"})` in `capability_profile.py` (verified directly against the source before fixing). `delegation-policy.md`'s two tables (built-in deny-set, audit classes) still listed only `delegate_to_agent` for that class.

## Also fixed

`delegation-policy.ja.md`'s same two rows — pre-existing, unrelated to tonight's arc: both said "`delegate_to_agent`、`delegate_to_agent`" (a literal duplicate-string bug, not a translation lag). Fixed to `delegate_to_agent`/`run_prompt`, matching the corrected EN rows since I was already touching this exact table.

## Left untouched (out of scope)

The JA file's other pre-existing gaps — `exec`'s own `"exec"、"exec"` duplicate, and the missing `skill-install`/`pipeline-install`/`spawn`/`pipeline-run` rows the EN table carries. These predate and are unrelated to what #4117 falsified; JA is a curated partial mirror, not obligated to track every EN row (CLAUDE.md rule 5).

## Test plan

- [x] `python scripts/check_doc_anchors.py` — exit 0
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0 (remaining INFO lines are pre-existing ja-mirror gaps, unrelated)
- [x] `python scripts/check_tests_path_literal_reference.py` (gate #6) — OK
- [x] Confirmed `_FLOORED_TOOLS["re-delegation"]` directly in `src/reyn/security/permissions/capability_profile.py` on current `main`, not inferred from the PR body

🤖 Generated with [Claude Code](https://claude.com/claude-code)
