### PR TITLE
feat(#3978): P9 — session_inbox_depth + task_settle_undelivered audit-event

### DIFF
--- a/docs/deep-dives/proposals/0067-task-model-and-arbiter.md
+++ b/docs/deep-dives/proposals/0067-task-model-and-arbiter.md
@@ -197,6 +197,21 @@ P8    ttl expiry: reuse the chain-timeout shape, plus persist `arm_at`
 P9    inbox depth on the monitoring read surface; an audit-event for a settle whose destination
       is gone
       ⚠️ Neither is a valve. `check_pre_llm` already bounds spend regardless of producer.
+      ✅ Half 1: `describe_task`/`list_tasks` gain `session_inbox_depth` (architect ruling
+         2026-08-10 — named to make clear it's a SESSION property, not a task property, per
+         lead-coder's review; an instantaneous `asyncio.Queue.qsize()` read, documented as such
+         in the field's own LLM-visible description).
+      🔴 Known scope limit (architect, not a defect — record here rather than silently accept):
+         this surface only reflects sessions that HAVE a running task. `send_to_session`
+         (P5) pushes onto a peer's inbox WITHOUT creating a task, so "queued but no task"
+         is a normal, unobservable-by-this-surface state. Closing that gap needs a
+         session-subject read surface (not a task-subject one) and is out of P9's range.
+      ✅ Half 2: `task_settle_undelivered` audit-event (renamed from an earlier
+         `task_settle_undeliverable` draft — architect: existing kinds follow
+         `<subject>_<past-participle>`, not an adjective), emitted alongside the existing
+         `logger.warning` in `PipelineExecutorDriver._deliver`'s `target is None` branch —
+         the DROP behavior itself is unchanged (0067's own arc-wide rule: observe a
+         vanished destination, never invent a new one for it).
 ```
 
 ## Verification notes for implementers

--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -209,6 +209,7 @@ skill_invoke_collision
 state_change_notified
 summary_resummarize_failed
 summary_resummarized
+task_settle_undelivered
 threat_block
 threat_scan_match
 token_refresh_failed
@@ -402,6 +403,7 @@ the AG-UI transport maps to `RUN_STARTED` / `TOOL_CALL_END` — see
 | `agent_response_received` | Originating agent pulled an `agent_response` from its inbox | `from_agent`, `depth`, `chain_id` |
 | `agent_message_refused` | A send was refused (e.g. exceeded `safety.loop.max_agent_hops`) | `reason`, `to_agent`, `depth`, `chain_id` |
 | `chain_timeout` | A pending chain exceeded `safety.timeout.chain_seconds` and was force-resolved with a synthetic error response upstream | `chain_id`, `waiting_on` (sorted list of agents that hadn't replied), `timeout_seconds`, `origin_agent` |
+| `task_settle_undelivered` | A task's settle disposition executed, but its reply target `(agent, sid)` is no longer resolvable (agent removed / session not loaded) — the settle still goes terminal; delivery is dropped, fail-safe, NEVER rerouted to `main` (proposal 0067 P9, #3978) | `run_id`, `reply_to_agent`, `reply_to_sid`, `reason` |
 
 `chain_id` is uuid4 hex; one per top-level user submission, propagated unchanged across every hop. Cross-agent reconstruction is `grep <chain_id>` over each agent's `events.jsonl` plus `history.jsonl`.
 

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -381,6 +381,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "state_change_notified",
     "summary_resummarize_failed",
     "summary_resummarized",
+    "task_settle_undelivered",
     "threat_block",
     "threat_scan_match",
     "token_refresh_failed",

--- a/src/reyn/runtime/services/pipeline_executor_driver.py
+++ b/src/reyn/runtime/services/pipeline_executor_driver.py
@@ -484,6 +484,20 @@ class PipelineExecutorDriver:
                 "pipeline_result for run %r dropped: %s "
                 "(fail-safe — NOT rerouted to main)", wo.run_id, reason,
             )
+            # Proposal 0067 P9 (#3978), architect ruling 2026-08-10: a durable
+            # record of this ALREADY-EXISTING drop, alongside the log line
+            # above — not a new delivery path (the drop behavior itself is
+            # unchanged; lead-coder's framing: "follow each producer's
+            # existing default, don't invent a new destination"). Best-effort
+            # (self._session may be None — should not happen at this point in
+            # the driver's own lifecycle, but this emit must never be why a
+            # settle fails): the run still goes terminal regardless.
+            if self._session is not None:
+                self._session._audit_events.emit(  # noqa: SLF001 — same-module driver/session pairing
+                    "task_settle_undelivered",
+                    run_id=wo.run_id, reply_to_agent=wo.reply_to_agent,
+                    reply_to_sid=wo.reply_to_sid, reason=reason,
+                )
             return False
         text = self._format_result_text(status=status, output=output, error=error)
 

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -857,6 +857,27 @@ class RouterHostAdapter:
         (mirrors ``get_pipeline_registry()``, same threading shape)."""
         return self._chains
 
+    def get_inbox_depth(self) -> "int | None":
+        """THIS session's current inbox queue depth (or None if unresolvable)
+        — proposal 0067 P9 (#3978), architect ruling 2026-08-10: read by
+        ``build_resource_caller_state`` to populate
+        ``RouterCallerState.session_inbox_depth``.
+
+        Resolves the live Session the SAME way ``send_to_session``'s caller
+        resolution does (``self._registry.get_session(self._agent_name,
+        caller_sid)``) rather than threading a NEW constructor param — no new
+        wiring needed, ``self._registry``/``self._agent_name`` already exist
+        for exactly this shape. Instantaneous read (``asyncio.Queue.qsize()``)
+        — see ``RouterCallerState.session_inbox_depth``'s own docstring for
+        the staleness caveat this value's field description must also carry."""
+        if self._registry is None:
+            return None
+        sid = self.live_session_id or "main"
+        session = self._registry.get_session(self._agent_name, sid)
+        if session is None:
+            return None
+        return session.inbox.qsize()
+
     def get_presentation_registry(self) -> Any:
         """The adapter's captured PresentationRegistry (or None) — FP-0054 PR-C.
         ``make_router_op_context`` reads it into each router OpContext's

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -869,11 +869,28 @@ class RouterHostAdapter:
         wiring needed, ``self._registry``/``self._agent_name`` already exist
         for exactly this shape. Instantaneous read (``asyncio.Queue.qsize()``)
         — see ``RouterCallerState.session_inbox_depth``'s own docstring for
-        the staleness caveat this value's field description must also carry."""
+        the staleness caveat this value's field description must also carry.
+
+        ⚠️ ``build_resource_caller_state`` calls this on EVERY router turn,
+        unconditionally, for every host — unlike ``get_chains()`` (a stored
+        attribute read, no live call), this makes a LIVE call on
+        ``self._registry``. Falsify-verified regression (#4127 CI): a
+        narrower test double implementing only PART of the registry
+        interface (e.g. ``get_or_load``/``exists`` but no ``get_session`` —
+        a legitimate, deliberately-minimal stub, not a bug in it) made this
+        raise ``AttributeError`` mid-turn, which propagated far enough to
+        derail an UNRELATED test's dispatch flow. ``getattr`` with a
+        default, not a direct method call, so an incomplete registry
+        degrades to ``None`` — the same tolerance ``get_mcp_servers()`` /
+        other duck-typed accessors on this class already have — rather than
+        breaking a turn that never asked for this observability field."""
         if self._registry is None:
             return None
+        get_session = getattr(self._registry, "get_session", None)
+        if get_session is None:
+            return None
         sid = self.live_session_id or "main"
-        session = self._registry.get_session(self._agent_name, sid)
+        session = get_session(self._agent_name, sid)
         if session is None:
             return None
         return session.inbox.qsize()

--- a/src/reyn/tools/task_verbs.py
+++ b/src/reyn/tools/task_verbs.py
@@ -35,13 +35,33 @@ def _chains(ctx: ToolContext) -> Any:
     return getattr(rs, "chains", None) if rs is not None else None
 
 
-def _describe(chain: Any) -> dict[str, Any]:
+def _inbox_depth(ctx: ToolContext) -> "int | None":
+    """THIS session's current inbox depth — proposal 0067 P9 (#3978).
+
+    ``chains`` is scoped to THE CALLING session's own ChainManager (module
+    docstring), so every task these tools can even see was registered with
+    ``origin_sid`` equal to this same calling session — the depth is
+    therefore homogeneous across every task in a given response; no
+    per-task resolution is needed."""
+    rs = getattr(ctx, "router_state", None)
+    return getattr(rs, "session_inbox_depth", None) if rs is not None else None
+
+
+def _describe(chain: Any, *, inbox_depth: "int | None" = None) -> dict[str, Any]:
     requester = chain.requester
     return {
         "task_id": chain.chain_id,
         "kind": chain.kind,
         "status": chain.status.value,
         "session": chain.origin_sid or "main",
+        # Proposal 0067 P9 (#3978), architect ruling 2026-08-10: an
+        # INSTANTANEOUS read of the task's own (= this calling session's)
+        # inbox queue depth — by the time this reply reaches the LLM the
+        # real value may already differ (see the field description surfaced
+        # to the model, task_verbs.py's tool-description constants below).
+        # None when unresolvable (e.g. no live registry in this context) —
+        # never a silent 0, which would misread as "definitely empty".
+        "session_inbox_depth": inbox_depth,
         "requester": {
             "agent_name": requester.agent_name,
             "session_id": requester.session_id,
@@ -56,7 +76,10 @@ _DESCRIBE_TASK_DESCRIPTION = (
     "run_prompt/run_pipeline async launch returned). A settled task's "
     "handle no longer exists — use this for progress checking or anomaly "
     "detection, not to retrieve a finished result (results arrive via a "
-    "task_settled push, not a poll)."
+    "task_settled push, not a poll). session_inbox_depth is a snapshot of "
+    "this task's own session's inbox queue depth at the moment of this "
+    "call — it may already be stale by the time you read it, and null "
+    "means it could not be resolved."
 )
 
 _DESCRIBE_TASK_PARAMETERS: dict[str, Any] = {
@@ -77,7 +100,7 @@ async def _handle_describe_task(args: Mapping[str, Any], ctx: ToolContext) -> To
     chain = chains.get(task_id) if chains is not None else None
     if chain is None or chain.kind is None:
         return {"ok": False, "error": f"no running task {task_id!r}"}
-    return {"ok": True, **_describe(chain)}
+    return {"ok": True, **_describe(chain, inbox_depth=_inbox_depth(ctx))}
 
 
 DESCRIBE_TASK = ToolDefinition(
@@ -98,7 +121,12 @@ DESCRIBE_TASK = ToolDefinition(
 _LIST_TASKS_DESCRIPTION = (
     "List currently RUNNING tasks (async run_prompt/run_pipeline launches "
     "not yet settled), optionally filtered by kind. Settled tasks are not "
-    "listed — their handle no longer exists (ADR-0040 D4)."
+    "listed — their handle no longer exists (ADR-0040 D4). Each entry's "
+    "session_inbox_depth is a snapshot of this session's own inbox queue "
+    "depth at the moment of this call (may already be stale by the time "
+    "you read it; null means it could not be resolved) — the SAME value "
+    "for every entry, since list_tasks only ever sees tasks registered on "
+    "this same calling session."
 )
 
 _LIST_TASKS_PARAMETERS: dict[str, Any] = {
@@ -120,6 +148,7 @@ async def _handle_list_tasks(args: Mapping[str, Any], ctx: ToolContext) -> ToolR
     if chains is None:
         return {"tasks": []}
     kind_filter = args.get("kind")
+    inbox_depth = _inbox_depth(ctx)
     tasks = []
     for chain_id in chains.all_chain_ids():
         chain = chains.get(chain_id)
@@ -127,8 +156,8 @@ async def _handle_list_tasks(args: Mapping[str, Any], ctx: ToolContext) -> ToolR
             continue
         if kind_filter is not None and chain.kind != kind_filter:
             continue
-        described = _describe(chain)
-        del described["requester"]  # list view: {task_id, kind, status, session} only
+        described = _describe(chain, inbox_depth=inbox_depth)
+        del described["requester"]  # list view: {task_id, kind, status, session, session_inbox_depth}
         tasks.append(described)
     return {"tasks": tasks}
 

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -78,6 +78,18 @@ class RouterCallerState:
     # by build_resource_caller_state from host.get_chains()).
     chains: Any = None
 
+    # Proposal 0067 P9 (#3978), architect ruling 2026-08-10: THIS session's
+    # current inbox queue depth (a plain int — an INSTANTANEOUS read, taken
+    # when this caller-state was built; by the time describe_task/list_tasks
+    # returns it to the LLM the real value may already differ, hence why the
+    # field's own LLM-visible description says so explicitly rather than
+    # implying a live value). None when the host can't resolve it (e.g. no
+    # live session backing this call). Observation only — see
+    # AgentRegistry.is_session_running's docstring for the same "does not
+    # imply a valve" caveat class; check_pre_llm bounds spend regardless of
+    # this number.
+    session_inbox_depth: "int | None" = None
+
     # Async dispatch callbacks (= for delegate_to_agent / plan
     # handlers that need to interact with chain / task lifecycle)
     send_to_agent: Callable[..., Awaitable[Any]] | None = None
@@ -313,6 +325,9 @@ async def build_resource_caller_state(host: Any) -> "RouterCallerState":
         ),
         chains=(
             getattr(host, "get_chains", lambda: None)()
+        ),
+        session_inbox_depth=(
+            getattr(host, "get_inbox_depth", lambda: None)()
         ),
     )
 

--- a/tests/_support/router_loop.py
+++ b/tests/_support/router_loop.py
@@ -52,6 +52,7 @@ class FakeRouterHost:
         mcp_servers: list[dict] | None = None,
         threat_scan: Any = None,
         chains: Any = None,  # proposal 0067 P4 (#3978): ChainManager | None
+        inbox_depth: "int | None" = None,  # proposal 0067 P9 (#3978)
     ):
         self._skills = skills or []
         self._agents = agents or []
@@ -59,6 +60,7 @@ class FakeRouterHost:
         self._file_permissions = file_permissions
         self._mcp_servers = mcp_servers or []
         self._chains = chains
+        self._inbox_depth = inbox_depth
 
         # Track calls
         self.outbox: list[dict] = []
@@ -138,6 +140,13 @@ class FakeRouterHost:
         ``chains=`` this fake was constructed with (None by default,
         matching a host that doesn't support the settle-path substrate)."""
         return self._chains
+
+    def get_inbox_depth(self) -> "int | None":
+        """proposal 0067 P9 (#3978): mirrors RouterHostAdapter.get_inbox_depth()
+        — the production seam ``build_resource_caller_state`` reads to
+        populate ``RouterCallerState.session_inbox_depth``. Returns whatever
+        ``inbox_depth=`` this fake was constructed with (None by default)."""
+        return self._inbox_depth
 
     def get_web_fetch_allowed(self) -> bool:
         return False

--- a/tests/core/test_pipeline_is2_driver_session.py
+++ b/tests/core/test_pipeline_is2_driver_session.py
@@ -633,6 +633,83 @@ async def test_task_settled_still_fires_when_reply_session_is_not_loaded(
 
 
 @pytest.mark.asyncio
+async def test_deliver_emits_task_settle_undelivered_when_reply_agent_gone(
+    tmp_path: Path,
+) -> None:
+    """Tier 2c: proposal 0067 P9 (#3978), architect ruling 2026-08-10 — the
+    SAME vanished-reply-agent fail-safe as the sibling test above ALSO emits
+    a durable ``task_settle_undelivered`` audit-event, alongside the
+    pre-existing ``logger.warning``. The drop behavior itself is unchanged
+    (``delivered`` still False) — this only adds an observable record of it.
+
+    Real ``EventLog`` subscriber (no mock) — the same seam
+    ``_on_chain_peer_discarded``'s own emit is verified through elsewhere in
+    this test suite."""
+    from reyn.runtime.services.pipeline_executor_driver import PipelineExecutorDriver
+
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log, None)
+    wo = replace(
+        _crash_state_work_order(
+            "gone-agent-audit-run", _three_step_pipeline(tmp_path / "o.txt"), input={"seed": 1},
+        ),
+        reply_to_agent="does-not-exist",
+    )
+    driver = PipelineExecutorDriver(wo, registry=reg, state_log=state_log)
+    worker = reg.get_or_load("worker")
+    driver.bind_session(worker, worker._router_host)
+
+    captured_events: list = []
+    worker._audit_events.add_subscriber(lambda ev: captured_events.append(ev))
+
+    await driver._finish(status="ok", output={"x": 1})
+
+    matching = [ev for ev in captured_events if ev.type == "task_settle_undelivered"]
+    assert matching, f"expected a task_settle_undelivered event; got: {captured_events}"
+    event = matching[0]
+    assert event.data["run_id"] == "gone-agent-audit-run"
+    assert event.data["reply_to_agent"] == "does-not-exist"
+    assert "reply agent" in event.data["reason"]
+
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", "gone-agent-audit-run")
+    terminal = _result_json(run_dir)
+    assert terminal["delivered"] is False  # drop behavior itself is unchanged
+
+
+@pytest.mark.asyncio
+async def test_deliver_does_not_emit_task_settle_undelivered_on_successful_delivery(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2c: falsify pair for the test above — a NORMAL delivery (reply
+    target resolves) must NOT emit ``task_settle_undelivered``. Without this,
+    a bug that fires the event unconditionally would pass the positive test
+    alone."""
+    from reyn.runtime.services.pipeline_executor_driver import PipelineExecutorDriver
+
+    captured: list[tuple[str, dict]] = []
+    _capture_hook_dispatch(monkeypatch, captured)
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log, None)
+    wo = _crash_state_work_order(
+        "delivered-audit-run", _three_step_pipeline(tmp_path / "o.txt"), input={"seed": 1},
+    )
+    driver = PipelineExecutorDriver(wo, registry=reg, state_log=state_log)
+    worker = reg.get_or_load("worker")
+    driver.bind_session(worker, worker._router_host)
+
+    captured_events: list = []
+    worker._audit_events.add_subscriber(lambda ev: captured_events.append(ev))
+
+    await driver._finish(status="ok", output={"x": 1})
+
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", "delivered-audit-run")
+    terminal = _result_json(run_dir)
+    assert terminal["delivered"] is True  # sanity: this run's delivery actually succeeded
+    matching = [ev for ev in captured_events if ev.type == "task_settle_undelivered"]
+    assert matching == []
+
+
+@pytest.mark.asyncio
 async def test_task_settled_does_not_fire_on_the_sync_attached_path(
     tmp_path: Path, monkeypatch,
 ) -> None:

--- a/tests/runtime/test_router_host_adapter_invariants.py
+++ b/tests/runtime/test_router_host_adapter_invariants.py
@@ -410,3 +410,74 @@ def test_make_router_op_context_no_factory_leaves_bus_none(tmp_path):
 
     op_ctx = adapter.make_router_op_context()
     assert op_ctx.intervention_bus is None
+
+
+# ---------------------------------------------------------------------------
+# Test: get_inbox_depth() tolerates a partial registry (#4127 CI falsify)
+# ---------------------------------------------------------------------------
+
+class _PartialAgentRegistry:
+    """A registry double implementing only PART of AgentRegistry — no
+    ``get_session``. This is a legitimate, deliberately-minimal stub (the
+    same shape as ``tests/llm/test_router_loop_chatsession.py``'s
+    ``_StubAgentRegistry``, which has ``get_or_load``/``exists``/etc. but no
+    ``get_session``), not a bug in the stub itself.
+
+    #4127 CI regression: ``RouterHostAdapter.get_inbox_depth()`` originally
+    called ``self._registry.get_session(...)`` directly, so a registry
+    double shaped exactly like this one raised ``AttributeError`` mid-turn
+    when ``build_resource_caller_state`` called it unconditionally — and
+    that propagated far enough to derail FOUR unrelated tests'
+    turn-dispatch flow in ``tests/llm/test_router_loop_chatsession.py`` and
+    ``tests/runtime/test_session_invariants.py``. This test falsifies that
+    regression directly against the adapter."""
+
+    def get_or_load(self, agent_name: str) -> object:
+        raise AssertionError("get_inbox_depth must not reach get_or_load")
+
+    def exists(self, agent_name: str) -> bool:
+        return True
+
+
+def test_get_inbox_depth_tolerates_a_registry_without_get_session(tmp_path):
+    """Tier 2: get_inbox_depth() degrades to None, not AttributeError, when
+    the wired registry lacks get_session — #4127 CI falsify regression."""
+    workspace = tmp_path / "agents" / "partial-registry-test"
+    events = EventLog(subscribers=[])
+    memory = MemoryService(
+        agent_workspace_dir=workspace,
+        events=events,
+        file_write=_null_file_write,
+        file_read=_null_file_read,
+        file_delete=_null_file_delete,
+        file_regenerate_index=_null_file_regen,
+    )
+    adapter = RouterHostAdapter(
+        agent_name="partial-registry-test",
+        agent_role="role",
+        output_language=None,
+        op_context_source=_EMPTY_OP_CTX,
+        permission_resolver=None,
+        mcp_servers=None,
+        project_context="",
+        events=events,
+        resolver=ModelResolver({}),
+        memory=memory,
+        journal=None,
+        agent_registry=_PartialAgentRegistry(),
+        agent_workspace_dir=workspace,
+        mcp_call_tool=_null_mcp_call_tool,
+        mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
+        send_to_agent_inputs=SendToAgentInputs(
+            send_to_agent=_null_send_to_agent, delegation_tracker=lambda: None,
+        ),
+        put_outbox_inputs=PutOutboxInputs(
+            put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
+        ),
+        append_history=_null_append_history,
+        live_session_id_inputs=LiveSessionIdInputs(
+            session_id=None, live_session_id_fn=None,
+        ),
+    )
+
+    assert adapter.get_inbox_depth() is None

--- a/tests/tools/test_task_verbs_3978.py
+++ b/tests/tools/test_task_verbs_3978.py
@@ -40,11 +40,11 @@ def _make_manager(tmp_path: Path) -> ChainManager:
     )
 
 
-def _ctx(chains) -> ToolContext:
+def _ctx(chains, *, inbox_depth: "int | None" = None) -> ToolContext:
     return ToolContext(
         events=_NullEvents(), permission_resolver=None, workspace=None,
         caller_kind="router",
-        router_state=RouterCallerState(chains=chains),
+        router_state=RouterCallerState(chains=chains, session_inbox_depth=inbox_depth),
     )
 
 
@@ -109,6 +109,39 @@ async def test_describe_task_with_no_chains_source_returns_error(tmp_path: Path)
     assert result["ok"] is False
 
 
+@pytest.mark.asyncio
+async def test_describe_task_reports_session_inbox_depth(tmp_path: Path):
+    """Tier 2: proposal 0067 P9 (#3978), architect ruling 2026-08-10 —
+    ``describe_task`` echoes ``RouterCallerState.session_inbox_depth``
+    verbatim (the instantaneous read is done at caller-state build time;
+    the handler itself does no resolution)."""
+    mgr = _make_manager(tmp_path)
+    await mgr.register(
+        chain_id="run-depth", from_user=False, depth=0, original_text="p", sender=None,
+        origin_agent="worker", origin_sid="s1", kind="pipeline",
+    )
+
+    result = await _handle_describe_task({"task_id": "run-depth"}, _ctx(mgr, inbox_depth=3))
+
+    assert result["session_inbox_depth"] == 3
+
+
+@pytest.mark.asyncio
+async def test_describe_task_session_inbox_depth_defaults_to_none(tmp_path: Path):
+    """Tier 2: falsify pair — when the caller state carries no depth (the
+    default), the field is explicitly None, never a silently-wrong 0 (which
+    would misread as "definitely empty")."""
+    mgr = _make_manager(tmp_path)
+    await mgr.register(
+        chain_id="run-nodepth", from_user=False, depth=0, original_text="p", sender=None,
+        kind="pipeline",
+    )
+
+    result = await _handle_describe_task({"task_id": "run-nodepth"}, _ctx(mgr))
+
+    assert result["session_inbox_depth"] is None
+
+
 # ── list_tasks ───────────────────────────────────────────────────────────────
 
 
@@ -134,6 +167,26 @@ async def test_list_tasks_lists_only_typed_running_tasks(tmp_path: Path):
     assert task["status"] == "running"
     assert task["session"] == "main"
     assert "requester" not in task  # list view omits it (describe_task carries it)
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_session_inbox_depth_same_for_every_entry(tmp_path: Path):
+    """Tier 2: proposal 0067 P9 (#3978) — every entry in list_tasks carries
+    the SAME session_inbox_depth, because ``chains`` is scoped to THIS
+    calling session's own ChainManager (module docstring) — every task
+    list_tasks can even see was registered with the same origin session."""
+    mgr = _make_manager(tmp_path)
+    await mgr.register(
+        chain_id="run-5", from_user=False, depth=0, original_text="p", sender=None, kind="pipeline",
+    )
+    await mgr.register(
+        chain_id="run-6b", from_user=False, depth=0, original_text="p", sender=None, kind="prompt",
+    )
+
+    result = await _handle_list_tasks({}, _ctx(mgr, inbox_depth=7))
+
+    depths = {t["session_inbox_depth"] for t in result["tasks"]}
+    assert depths == {7}
 
 
 @pytest.mark.asyncio
@@ -272,3 +325,28 @@ async def test_describe_task_reaches_a_real_chain_manager_through_the_real_route
     )
     assert result["task_id"] == "run-e2e"
     assert result["kind"] == "pipeline"
+
+
+@pytest.mark.asyncio
+async def test_describe_task_session_inbox_depth_reaches_production_wiring(
+    tmp_path: Path,
+):
+    """Tier 2: production-wiring witness for ``session_inbox_depth`` —
+    proposal 0067 P9 (#3978). Mirrors the ``chains`` witness above (same
+    class of gap: every OTHER test here builds ``RouterCallerState``
+    directly, bypassing ``build_resource_caller_state``'s own
+    ``host.get_inbox_depth()`` read entirely). Drives the SAME real
+    ``RouterLoop._invoke_router_tool`` path against a ``FakeRouterHost``
+    constructed with ``inbox_depth=``."""
+    mgr = _make_manager(tmp_path)
+    await mgr.register(
+        chain_id="run-depth-e2e", from_user=False, depth=0, original_text="p", sender=None,
+        origin_agent="worker", origin_sid="s1", kind="pipeline",
+    )
+    host = FakeRouterHost(chains=mgr, inbox_depth=5)
+    loop = RouterLoop(host=host, chain_id="chain-test")
+
+    result = await loop._invoke_router_tool("describe_task", {"task_id": "run-depth-e2e"})
+
+    assert result.get("ok") is True
+    assert result["session_inbox_depth"] == 5


### PR DESCRIPTION
**[tui-coder]** — proposal 0067 P9 (#3978): observation-only additions — `session_inbox_depth` on `describe_task`/`list_tasks`, and a `task_settle_undelivered` audit-event for a settle whose destination is gone. Both ruled by architect on #3978 (2026-08-10); design history recorded there in full (initial proposal, lead-coder's staleness/naming review, the ruling itself).

## Half 1: `session_inbox_depth`

An INSTANTANEOUS `asyncio.Queue.qsize()` read of the task's own (= the calling session's) inbox depth, taken when the caller-state is built. The field's own LLM-visible description states the staleness explicitly. Wiring mirrors `chains`'s existing threading exactly — `RouterHostAdapter.get_inbox_depth()` (resolves the live session via `self._registry`, no new constructor param) → `build_resource_caller_state` → `RouterCallerState.session_inbox_depth` → `task_verbs.py`'s `_describe()`.

Named `session_inbox_depth`, not `inbox_depth`, per lead-coder's review: it's a SESSION property, not a TASK property — two tasks sharing one session report the identical value.

**Known scope limit** (architect, not a defect — recorded in `0067-task-model-and-arbiter.md` rather than silently accepted): this surface only reflects sessions that HAVE a running task. `send_to_session` (P5) pushes onto a peer's inbox WITHOUT creating a task, so "queued but no task" is a normal, unobservable-by-this-surface state.

## Half 2: `task_settle_undelivered`

`PipelineExecutorDriver._deliver`'s existing `target is None` fail-safe now ALSO emits a durable `task_settle_undelivered` audit-event alongside the pre-existing `logger.warning`. The drop behavior itself is UNCHANGED — this only adds an observable, `.reyn/events`-durable record.

Named `task_settle_undelivered` (not the earlier draft `task_settle_undeliverable`) per architect: existing kinds follow `<subject>_<past-participle>` (`llm_called`, `permission_granted`), not an adjective. Closed-vocabulary 3-part change, same PR: emit + `AUDIT_EVENT_KINDS` + `docs/reference/runtime/events.md`.

## Test plan

- [x] `ruff check src tests` — green.
- [x] Production-wiring witness (mirrors the #4106 `chains` precedent): `test_describe_task_session_inbox_depth_reaches_production_wiring` drives a REAL `RouterLoop._invoke_router_tool` call through `FakeRouterHost`'s new `get_inbox_depth()`, not a hand-built `RouterCallerState`.
- [x] Falsify-verified the audit-event emit: temporarily disabled it, confirmed the positive test goes RED; restored, green again. Accept-side sibling confirms the emit is conditional, not unconditional.
- [x] `test_audit_event_kind_vocabulary_3410.py`: 10/10 passed (closed-vocabulary gate, both directions).
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — OK (one Tier-4 format-pin caught and fixed: `len(matching) == 1` → existence check).
- [x] `python scripts/mypy_ratchet.py` — 210/214 baselined, no new findings.
- [x] `python scripts/check_tests_path_literal_reference.py` — OK.
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK.
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — builds clean.
- [x] Full `tests/core` + `tests/tools` + `tests/security` + `test_router_loop.py` sweep: 4175 passed, 4 failed (`test_3846_image_resolution_e2e.py` — confirmed pre-existing on a clean checkout, same textual-theme-registration class as every other unrelated failure seen this session).
- [ ] Visual — n/a (no TUI-visible change; router-only tool fields + an audit-event).

part of #3978

🤖 Generated with [Claude Code](https://claude.com/claude-code)
