### PR TITLE
fix(#4099): unbound the 9 test-owned wait-budget poll helpers

### DIFF
--- a/tests/core/test_2649_pipeline_error_envelope.py
+++ b/tests/core/test_2649_pipeline_error_envelope.py
@@ -276,7 +276,7 @@ async def test_run_pipeline_cancelled_renders_error_kind_message(tmp_path: Path,
 
     dispatch_task = asyncio.ensure_future(_dispatch_run_pipeline({"name": "gated"}, ctx, events))
     try:
-        assert await _wait_for_event(step0_running)
+        await _wait_for_event(step0_running)
         assert caller is agent_reg.get_session("worker", "main")
         await caller.cancel_inflight()
         release_step0.set()
@@ -294,12 +294,17 @@ async def test_run_pipeline_cancelled_renders_error_kind_message(tmp_path: Path,
     assert f"run_id: {run_id}" in content, "run_id must stay reachable for the LLM"
 
 
-async def _wait_for_event(evt: asyncio.Event, timeout: float = 15.0) -> bool:
-    try:
-        await asyncio.wait_for(evt.wait(), timeout=timeout)
-        return True
-    except asyncio.TimeoutError:
-        return False
+async def _wait_for_event(evt: asyncio.Event, *, delay: float = 0.02) -> None:
+    """The pipeline-cancel test's step-0 handler and the awaiting test body run
+    off separate tasks (the handler sets ``step0_running`` from inside the
+    dispatched pipeline step). Unbounded per the owner's testing policy
+    (docs/deep-dives/contributing/testing.md, ## Time): no test carries a time
+    budget, marker or in-body -- a slower environment only makes this slower,
+    never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
+    contract.
+    """
+    while not evt.is_set():
+        await asyncio.sleep(delay)
 
 
 # ── secondary blast radius: the memory-write threat_blocked (co-vet finding) ──

--- a/tests/core/test_emit_hook_event_0059_phase5_part2.py
+++ b/tests/core/test_emit_hook_event_0059_phase5_part2.py
@@ -84,13 +84,16 @@ _POLL_TIMEOUT = 3.0
 _POLL_INTERVAL = 0.01
 
 
-async def _wait_until(predicate, *, timeout: float = _POLL_TIMEOUT) -> None:
-    loop = asyncio.get_event_loop()
-    deadline = loop.time() + timeout
+async def _wait_until(predicate, *, delay: float = _POLL_INTERVAL) -> None:
+    """Poll until a hook-driven-turn condition (subscriber attached, a
+    ``safety_limit_checkpoint`` recorded) becomes true. Unbounded per the
+    owner's testing policy (docs/deep-dives/contributing/testing.md, ## Time):
+    no test carries a time budget, marker or in-body -- a slower environment
+    only makes this slower, never fail it; CI's --timeout=120 is the
+    blast-radius kill-switch, not a contract.
+    """
     while not predicate():
-        if loop.time() >= deadline:
-            raise AssertionError(f"condition not met within {timeout}s")
-        await asyncio.sleep(_POLL_INTERVAL)
+        await asyncio.sleep(delay)
 
 
 def _op_context(*, session_id: str, hook_bus: HookBus, events: EventLog) -> OpContext:

--- a/tests/core/test_pipeline_is2_driver_session.py
+++ b/tests/core/test_pipeline_is2_driver_session.py
@@ -212,13 +212,16 @@ def _three_step_pipeline(out_file: Path) -> Pipeline:
     )
 
 
-async def _wait_for(pred, timeout: float = 15.0) -> bool:
-    deadline = asyncio.get_event_loop().time() + timeout
-    while asyncio.get_event_loop().time() < deadline:
-        if pred():
-            return True
-        await asyncio.sleep(0.05)
-    return False
+async def _wait_for(predicate, *, delay: float = 0.05) -> None:
+    """Poll until a pipeline/driver-session async result (result.json,
+    scripted-agent delivery, or driver-session reclaim) lands. Unbounded per
+    the owner's testing policy (docs/deep-dives/contributing/testing.md,
+    ## Time): no test carries a time budget, marker or in-body -- a slower
+    environment only makes this slower, never fail it; CI's --timeout=120 is
+    the blast-radius kill-switch, not a contract.
+    """
+    while not predicate():
+        await asyncio.sleep(delay)
 
 
 def _result_json(run_dir: Path) -> "dict | None":
@@ -381,7 +384,7 @@ async def test_run_pipeline_async_launches_and_delivers_result(tmp_path: Path, m
     # returning and this check), so this observes registration, not a race.
     assert caller.chains.has(run_id)
 
-    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    await _wait_for(lambda: _result_json(run_dir) is not None)
     # ADR-0040 D4 "immediate deletion": once settled, the handle is gone.
     assert not caller.chains.has(run_id)
     terminal = _result_json(run_dir)
@@ -389,10 +392,10 @@ async def test_run_pipeline_async_launches_and_delivers_result(tmp_path: Path, m
     # Real tool side effects: transform seeded 10 → 11, then the fixed line.
     assert out_file.read_text(encoding="utf-8").splitlines() == ["11", "second"]
     # The invoker actually CONSUMED the pipeline_result (a scripted-LLM turn ran).
-    assert await _wait_for(lambda: scripted.calls >= 1)
+    await _wait_for(lambda: scripted.calls >= 1)
     # A10: the driver-session vanishes after terminal.
     invocation = json.loads((run_dir / "invocation.json").read_text(encoding="utf-8"))
-    assert await _wait_for(
+    await _wait_for(
         lambda: reg.get_session("worker", invocation["driver_sid"]) is None
     )
 
@@ -455,14 +458,14 @@ async def test_the_registered_cancel_hook_actually_stops_a_running_async_run(
     # Anchor on real mid-flight execution: step 1's write landed, but its
     # tool call is still blocked on `gate` — the executor is genuinely
     # inside step 1, not merely queued to start it.
-    assert await _wait_for(lambda: out_file.is_file() and out_file.read_text() == "11\n")
+    await _wait_for(lambda: out_file.is_file() and out_file.read_text() == "11\n")
 
     chain = caller.chains.get(run_id)
     assert chain is not None and chain.cancel is not None
     chain.cancel()
     gate.set()  # let step 1's tool call return — the step boundary check follows
 
-    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    await _wait_for(lambda: _result_json(run_dir) is not None)
     terminal = _result_json(run_dir)
     assert terminal["status"] == "cancelled"
     # Step 2's side effect NEVER lands — stopped between steps, not after.
@@ -539,7 +542,7 @@ async def test_task_settled_fires_after_delivery_and_the_handle_is_then_gone(
 
     # Delivery-anchored: the issuer's own history actually carries the result
     # (a real scripted-LLM turn consumed the pipeline_result inbox message).
-    assert await _wait_for(lambda: scripted.calls >= 1)
+    await _wait_for(lambda: scripted.calls >= 1)
     # task_settled was dispatched — and, since _deliver awaits
     # submit_pipeline_result BEFORE dispatching it (source order), its
     # presence here is itself the ordering proof: it cannot have fired before
@@ -554,7 +557,7 @@ async def test_task_settled_fires_after_delivery_and_the_handle_is_then_gone(
     # gone. describe_task doesn't exist yet (P4) — the driver-session's A10
     # reclaim is the only "can this task still be found" surface today.
     invocation = json.loads((run_dir / "invocation.json").read_text(encoding="utf-8"))
-    assert await _wait_for(
+    await _wait_for(
         lambda: reg.get_session("worker", invocation["driver_sid"]) is None
     )
 
@@ -788,11 +791,11 @@ async def test_pipeline_run_async_reachable_via_invoke_action(
     run_dir = pipeline_run_dir(tmp_path / ".reyn", run_id)
     assert (run_dir / "invocation.json").is_file()
 
-    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    await _wait_for(lambda: _result_json(run_dir) is not None)
     terminal = _result_json(run_dir)
     assert terminal["status"] == "ok" and terminal["delivered"] is True
     assert out_file.read_text(encoding="utf-8").splitlines() == ["11", "second"]
-    assert await _wait_for(lambda: scripted.calls >= 1)
+    await _wait_for(lambda: scripted.calls >= 1)
 
 
 @pytest.mark.asyncio
@@ -945,7 +948,7 @@ async def test_registered_pipeline_enforces_verify_schema_async(
     run_id = result["data"]["run_id"]
     run_dir = pipeline_run_dir(tmp_path / ".reyn", run_id)
 
-    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    await _wait_for(lambda: _result_json(run_dir) is not None)
     terminal = _result_json(run_dir)
     assert terminal["status"] == "failed"
     assert "failed schema" in terminal["error"]
@@ -1007,13 +1010,13 @@ async def test_truncate_falsify_recovery_source_survives_wal_truncation(
     reg2 = _agent_registry(tmp_path, state_log2, scripted)
     await reg2.restore_all()
 
-    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    await _wait_for(lambda: _result_json(run_dir) is not None)
     terminal = _result_json(run_dir)
     assert terminal["status"] == "ok" and terminal["delivered"] is True
     # Exactly-once: steps 0-1 replayed (no new "11" line), only step 2 ran.
     assert out_file.read_text(encoding="utf-8").splitlines() == ["11", "second"]
     # The invoker consumed the re-delivered result.
-    assert await _wait_for(lambda: scripted.calls >= 1)
+    await _wait_for(lambda: scripted.calls >= 1)
 
 
 @pytest.mark.asyncio
@@ -1081,7 +1084,7 @@ async def test_truncate_falsify_schema_defs_survives_wal_truncation(
     reg2 = _agent_registry(tmp_path, state_log2, scripted)
     await reg2.restore_all()
 
-    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    await _wait_for(lambda: _result_json(run_dir) is not None)
     terminal = _result_json(run_dir)
     # The resumed step 2 hit a REAL schema violation (schema_defs survived
     # truncation intact) — not "no schema_registry was provided", which is
@@ -1093,7 +1096,7 @@ async def test_truncate_falsify_schema_defs_survives_wal_truncation(
     # step 2's tool call DOES execute (the schema check runs on its result,
     # AFTER the real side effect — same order as a live, non-recovered run).
     assert out_file.read_text(encoding="utf-8").splitlines() == ["11", "second"]
-    assert await _wait_for(lambda: scripted.calls >= 1)
+    await _wait_for(lambda: scripted.calls >= 1)
 
 
 @pytest.mark.asyncio
@@ -1122,7 +1125,7 @@ async def test_recovery_before_first_gen_preserves_original_input(
     reg2 = _agent_registry(tmp_path, state_log2, scripted)
     await reg2.restore_all()
 
-    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    await _wait_for(lambda: _result_json(run_dir) is not None)
     assert _result_json(run_dir)["status"] == "ok"
     assert out_file.read_text(encoding="utf-8").splitlines() == ["11", "second"]
 
@@ -1163,12 +1166,12 @@ async def test_recovery_steps_done_but_undelivered_redelivers_without_rerun(
     reg2 = _agent_registry(tmp_path, state_log2, scripted)
     await reg2.restore_all()
 
-    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    await _wait_for(lambda: _result_json(run_dir) is not None)
     terminal = _result_json(run_dir)
     assert terminal["status"] == "ok" and terminal["delivered"] is True
     # Exactly-once: nothing re-ran.
     assert out_file.read_text(encoding="utf-8").splitlines() == lines_before
-    assert await _wait_for(lambda: scripted.calls >= 1)
+    await _wait_for(lambda: scripted.calls >= 1)
 
 
 @pytest.mark.asyncio
@@ -1198,12 +1201,12 @@ async def test_poison_run_past_resume_cap_fails_terminally(tmp_path: Path, monke
     reg2 = _agent_registry(tmp_path, state_log2, scripted)
     await reg2.restore_all()
 
-    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    await _wait_for(lambda: _result_json(run_dir) is not None)
     terminal = _result_json(run_dir)
     assert terminal["status"] == "failed"
     assert "resume" in terminal["error"]
     assert not out_file.exists(), "no step may execute past the poison cap"
-    assert await _wait_for(lambda: scripted.calls >= 1)  # failure IS delivered
+    await _wait_for(lambda: scripted.calls >= 1)  # failure IS delivered
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_pipeline_is4_inline.py
+++ b/tests/core/test_pipeline_is4_inline.py
@@ -175,13 +175,16 @@ def _result_json(run_dir: Path) -> "dict | None":
     return json.loads(p.read_text(encoding="utf-8")) if p.is_file() else None
 
 
-async def _wait_for(pred, timeout: float = 15.0) -> bool:
-    deadline = asyncio.get_event_loop().time() + timeout
-    while asyncio.get_event_loop().time() < deadline:
-        if pred():
-            return True
-        await asyncio.sleep(0.05)
-    return False
+async def _wait_for(predicate, *, delay: float = 0.05) -> None:
+    """Wait for an async-launched inline run's terminal marker (result.json) or
+    the invoker's scripted LLM callback count to reach the expected condition.
+    Unbounded per the owner's testing policy (docs/deep-dives/contributing/testing.md,
+    ## Time): no test carries a time budget, marker or in-body -- a slower
+    environment only makes this slower, never fail it; CI's --timeout=120 is the
+    blast-radius kill-switch, not a contract.
+    """
+    while not predicate():
+        await asyncio.sleep(delay)
 
 
 # A generated definition an agent might emit: transform -> tool -> agent, plus a
@@ -266,11 +269,11 @@ async def test_inline_async_happy_path_launches_and_delivers(
     run_dir = pipeline_run_dir(tmp_path / ".reyn", result["data"]["run_id"])
     assert (run_dir / "invocation.json").is_file()
 
-    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    await _wait_for(lambda: _result_json(run_dir) is not None)
     terminal = _result_json(run_dir)
     assert terminal["status"] == "ok" and terminal["delivered"] is True
     assert out_file.read_text(encoding="utf-8").splitlines() == ["hi async"]
-    assert await _wait_for(lambda: scripted.calls >= 1)
+    await _wait_for(lambda: scripted.calls >= 1)
 
 
 # ── #2572: inline pipeline runtime verify:schema enforcement ────────────────
@@ -360,7 +363,7 @@ async def test_inline_async_enforces_verify_schema_failure(
     assert result["status"] == "started"
     run_dir = pipeline_run_dir(tmp_path / ".reyn", result["data"]["run_id"])
 
-    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    await _wait_for(lambda: _result_json(run_dir) is not None)
     terminal = _result_json(run_dir)
     assert terminal["status"] == "failed"
     assert "failed schema" in terminal["error"]
@@ -624,9 +627,9 @@ async def test_inline_run_crash_resumes_exactly_once_after_wal_truncation(
     reg2 = _agent_registry(tmp_path, state_log2, scripted)
     await reg2.restore_all()
 
-    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    await _wait_for(lambda: _result_json(run_dir) is not None)
     terminal = _result_json(run_dir)
     assert terminal["status"] == "ok" and terminal["delivered"] is True
     # Exactly-once: steps 0-1 replayed (no duplicate a/b), only step 2 executed.
     assert out_file.read_text(encoding="utf-8").splitlines() == ["a", "b", "c"]
-    assert await _wait_for(lambda: scripted.calls >= 1)
+    await _wait_for(lambda: scripted.calls >= 1)

--- a/tests/core/test_pipeline_is6_attached.py
+++ b/tests/core/test_pipeline_is6_attached.py
@@ -207,13 +207,17 @@ def _result_json(run_dir: Path) -> "dict | None":
     return json.loads(p.read_text(encoding="utf-8")) if p.is_file() else None
 
 
-async def _wait_for(pred, timeout: float = 15.0) -> bool:
-    deadline = asyncio.get_event_loop().time() + timeout
-    while asyncio.get_event_loop().time() < deadline:
-        if pred():
-            return True
-        await asyncio.sleep(0.05)
-    return False
+async def _wait_for(predicate, *, delay: float = 0.05) -> None:
+    """Waits for a driver-spawned pump/recovery task (a scripted LLM callable
+    fired, a step gate observed, a crash-recovery result marker written to
+    disk) to reach its condition on its own schedule. Unbounded per the
+    owner's testing policy (docs/deep-dives/contributing/testing.md, ## Time):
+    no test carries a time budget, marker or in-body -- a slower environment
+    only makes this slower, never fail it; CI's --timeout=120 is the
+    blast-radius kill-switch, not a contract.
+    """
+    while not predicate():
+        await asyncio.sleep(delay)
 
 
 # ── attached happy path: live events + inline result ─────────────────────────
@@ -339,7 +343,7 @@ async def test_notify_reply_true_driver_DOES_deliver_positive_control(
     assert marker["status"] == "ok" and marker["delivered"] is True
     # The reply session (worker, main) actually consumed the pipeline_result.
     reg.ensure_session_running("worker", "main")
-    assert await _wait_for(lambda: scripted.calls >= 1)
+    await _wait_for(lambda: scripted.calls >= 1)
 
 
 # ── §3: cancel is terminal + the R4 journal stays resumable ──────────────────
@@ -527,7 +531,7 @@ async def test_attached_caller_cancel_inflight_stops_pipeline_at_boundary(
     ))
     try:
         # Wait until step 0 is really in flight (started + awaiting the gate).
-        assert await _wait_for(step0_running.is_set)
+        await _wait_for(step0_running.is_set)
         # THE BUG UNDER TEST: cancel via the CALLER session's public seam — the
         # SAME instance run_pipeline_attached resolves as the reply address. Not
         # a direct driver.request_cancel.
@@ -596,7 +600,7 @@ async def test_crash_while_attached_recovers_and_delivers_via_inbox(
     reg2 = _agent_registry(tmp_path, state_log2, scripted)
     await reg2.restore_all()
 
-    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    await _wait_for(lambda: _result_json(run_dir) is not None)
     marker = _result_json(run_dir)
     assert marker["status"] == "ok"
     # Recovery delivered via inbox (notify_reply flipped to True on re-wake).
@@ -604,7 +608,7 @@ async def test_crash_while_attached_recovers_and_delivers_via_inbox(
     # Exactly-once: steps 0-1 replayed from the snapshot, only step 2 executed.
     assert out_file.read_text(encoding="utf-8").splitlines() == ["s0", "s1", "s2"]
     # The caller consumed the re-delivered pipeline_result.
-    assert await _wait_for(lambda: scripted.calls >= 1)
+    await _wait_for(lambda: scripted.calls >= 1)
 
 
 # ── §5: TUI bridge marker + total_steps (#2570) ───────────────────────────────
@@ -709,5 +713,5 @@ async def test_async_launch_does_not_emit_bridge_marker(
     # Let the detached pump run to completion so the async result actually
     # reaches the caller's inbox — the marker-absence check covers the whole
     # async lifecycle, not just the launch instant.
-    assert await _wait_for(lambda: scripted.calls >= 1)
+    await _wait_for(lambda: scripted.calls >= 1)
     assert not any(e.type == "pipeline_run_attached" for e in caller_events)

--- a/tests/hooks/test_2608_h3_pipeline_launch_hook.py
+++ b/tests/hooks/test_2608_h3_pipeline_launch_hook.py
@@ -363,13 +363,17 @@ def _agent_registry_with_hooks(
     return reg
 
 
-async def _wait_for(pred, timeout: float = 15.0) -> bool:
-    deadline = asyncio.get_event_loop().time() + timeout
-    while asyncio.get_event_loop().time() < deadline:
-        if pred():
-            return True
-        await asyncio.sleep(0.05)
-    return False
+async def _wait_for(predicate, *, delay: float = 0.05) -> None:
+    """Poll until the launched pipeline's side effect (and the invoking
+    session's ``pipeline_result``-driven scripted turn) becomes observable.
+    Unbounded per the owner's testing policy
+    (docs/deep-dives/contributing/testing.md, ## Time): no test carries a time
+    budget, marker or in-body -- a slower environment only makes this slower,
+    never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
+    contract.
+    """
+    while not predicate():
+        await asyncio.sleep(delay)
 
 
 @pytest.mark.asyncio
@@ -407,10 +411,10 @@ async def test_e2e_hook_launches_registered_pipeline_with_threaded_input(
 
     await caller._hook_dispatcher.dispatch("session_start", {"event": {"count": 7}})
 
-    assert await _wait_for(lambda: out_file.exists() and out_file.read_text(encoding="utf-8").strip())
+    await _wait_for(lambda: out_file.exists() and out_file.read_text(encoding="utf-8").strip())
     assert out_file.read_text(encoding="utf-8").splitlines() == ["7"]
     # The invoker actually consumed the pipeline_result (a scripted-LLM turn ran).
-    assert await _wait_for(lambda: scripted.calls >= 1)
+    await _wait_for(lambda: scripted.calls >= 1)
 
 
 @pytest.mark.asyncio

--- a/tests/hooks/test_hook_composer_reachability_phase5.py
+++ b/tests/hooks/test_hook_composer_reachability_phase5.py
@@ -61,16 +61,16 @@ _POLL_TIMEOUT = 3.0
 _POLL_INTERVAL = 0.01
 
 
-async def _wait_until(predicate, *, timeout: float = _POLL_TIMEOUT) -> None:
-    """Poll ``predicate`` (a zero-arg callable) until it's true or ``timeout``
-    elapses — avoids a brittle fixed ``sleep(N)`` guess while staying
-    deterministic-enough for CI (no unbounded wait)."""
-    loop = asyncio.get_event_loop()
-    deadline = loop.time() + timeout
+async def _wait_until(predicate, *, delay: float = _POLL_INTERVAL) -> None:
+    """Poll ``predicate`` (a zero-arg callable) until it's true — waiting for
+    composer/consumer wiring (bus subscriber counts, a pushed turn landing, a
+    safety_limit_checkpoint firing) to become observable. Unbounded per the
+    owner's testing policy (docs/deep-dives/contributing/testing.md, ## Time):
+    no test carries a time budget, marker or in-body -- a slower environment
+    only makes this slower, never fail it; CI's --timeout=120 is the
+    blast-radius kill-switch, not a contract."""
     while not predicate():
-        if loop.time() >= deadline:
-            raise AssertionError(f"condition not met within {timeout}s")
-        await asyncio.sleep(_POLL_INTERVAL)
+        await asyncio.sleep(delay)
 
 
 def _make_session(

--- a/tests/runtime/test_3093_pipeline_registry_spawn_propagation.py
+++ b/tests/runtime/test_3093_pipeline_registry_spawn_propagation.py
@@ -188,13 +188,16 @@ def _install_pipeline_to_disk(tmp_path: Path, *, key: str = "ns") -> None:
     )
 
 
-async def _wait_for(pred, timeout: float = 15.0) -> bool:
-    deadline = asyncio.get_event_loop().time() + timeout
-    while asyncio.get_event_loop().time() < deadline:
-        if pred():
-            return True
-        await asyncio.sleep(0.05)
-    return False
+async def _wait_for(predicate, *, delay: float = 0.05) -> None:
+    """Wait for the async-detached driver session's pipeline run to post its
+    terminal result file (``read_result(run_dir) is not None``). Unbounded per
+    the owner's testing policy (docs/deep-dives/contributing/testing.md, ##
+    Time): no test carries a time budget, marker or in-body -- a slower
+    environment only makes this slower, never fail it; CI's --timeout=120 is
+    the blast-radius kill-switch, not a contract.
+    """
+    while not predicate():
+        await asyncio.sleep(delay)
 
 
 @pytest.mark.asyncio
@@ -253,7 +256,7 @@ async def test_async_detached_run_resolves_sibling_via_family_gate(
     run_id = result["data"]["run_id"]
     run_dir = pipeline_run_dir(tmp_path / ".reyn", run_id)
 
-    assert await _wait_for(lambda: read_result(run_dir) is not None)
+    await _wait_for(lambda: read_result(run_dir) is not None)
     terminal = read_result(run_dir)
     assert terminal["status"] == "ok", terminal
     # The sibling's OWN step really ran (not just that `call` resolved a stub).

--- a/tests/scaffold/test_family3_hook_event_bundle_byte_identical.py
+++ b/tests/scaffold/test_family3_hook_event_bundle_byte_identical.py
@@ -97,13 +97,18 @@ def _make_session(
     )
 
 
-async def _wait_until(pred, *, timeout: float = _TIMEOUT) -> None:
-    """Poll ``pred`` to True within ``timeout`` (a broken wiring never
-    satisfies it, so the caller's assertion fails RED)."""
-    async def _loop() -> None:
-        while not pred():
-            await asyncio.sleep(0.01)
-    await asyncio.wait_for(_loop(), timeout=timeout)
+async def _wait_until(pred, *, delay: float = 0.01) -> None:
+    """Poll ``pred`` — waiting on a family hook_bus subscriber attaching or a
+    dispatched/published hook-event landing on its subscriber/inbox — to True.
+    A broken wiring never satisfies it, so the caller's own assertion fails
+    RED, not this poll. Unbounded per the owner's testing policy
+    (docs/deep-dives/contributing/testing.md, ## Time): no test carries a time
+    budget, marker or in-body -- a slower environment only makes this slower,
+    never fail it; CI's --timeout=120 is the blast-radius kill-switch, not a
+    contract.
+    """
+    while not pred():
+        await asyncio.sleep(delay)
 
 
 class TestFamily3HookEventBundleByteIdentical:


### PR DESCRIPTION
**[tui-coder]** — Fixes #4099. Mechanical, test-only fix per lead-coder's recommendation of the two options offered (over #4113, which needs an architect design round first).

## What

CLAUDE.md / `docs/deep-dives/contributing/testing.md` § Time bans a wait-budget constant in a test's body — tests wait on a condition unboundedly, and CI's own `--timeout=120` is the only bound. Measured 21 files defining a local `_wait_for`/`_wait_until` poll helper (`git grep -lE 'def _wait_for|def _wait_until' -- tests`, one more than lead-coder's original 20 — `tests/scaffold/test_family3_hook_event_bundle_byte_identical.py`, likely missed by a basic-regex `git grep` without `-E`). 12 of the 21 already match the unbounded shape (a plain `while not predicate(): await asyncio.sleep(delay)`, no timeout param). This PR fixes the remaining 9, which each took a `timeout=` param and either silently returned `False` or raised their own `AssertionError`/`TimeoutError` on a deadline — a merely-slow machine gets a wrong, locally-invented failure instead of CI's own kill switch doing that job, with no "what was I waiting for" diagnostic surviving into the failure.

## Scope decision

Issue #4099 itself framed "converge all 20/21 files onto one shared helper" as `案、未確定` (proposed, undecided). This PR does **not** do that consolidation — it only removes the actual policy violation (the wait-budget constant) in the 9 non-compliant files, converting each to the same shape the other 12 already independently use. Consolidating into one shared helper is a separate, still-undecided design question.

## Verification

- All 9 files pass individually (each fixed and verified by a dedicated subagent) and together: `pytest <9 files> -q` → **100 passed**.
- `ruff check <9 files>` → clean.
- `python scripts/test_tier_audit.py --strict <9 files>` → 89 tests inspected, 0 errors.
- `python scripts/check_tests_path_literal_reference.py` → OK.
- `python scripts/mypy_ratchet.py` → OK, 210 findings (unchanged baseline).
- Branched fresh off `origin/main` (post-#4127 merge) — no rebase needed.

## Test plan

- [x] `pytest` on all 9 changed files together — 100 passed
- [x] `ruff check` on all 9 changed files — clean
- [x] `test_tier_audit.py --strict` on all 9 changed files — 0 errors
- [x] `check_tests_path_literal_reference.py` — OK
- [x] `mypy_ratchet.py` — OK
- [ ] Visual — n/a, test-only change with no UI surface
