### PR TITLE
docs(#3978): drop the retired delegate_to_agent diagram from the public site

### DIFF
--- a/website/_design/claude_design_prompt_architecture.md
+++ b/website/_design/claude_design_prompt_architecture.md
@@ -163,28 +163,13 @@ SECTION 04 — Beyond a single agent
   - Section number + label: {{ARCH_S04_NUM}} / {{ARCH_S04_LABEL}}
   - Heading: {{ARCH_S04_HEADING_HTML}}
   - Body paragraph: {{ARCH_S04_BODY}}
-  - Two diagrams side by side on desktop, stacked on mobile.
-    Left = A2A delegation chain. Right = MCP server/client symmetry.
-    Each in its own white card with 1px border.
-    Left diagram code:
-    ```
-    sequenceDiagram
-        participant U as User (depth=0)
-        participant A as Agent A (depth=1)
-        participant B as Agent B (depth=2)
-        participant C as Agent C (depth=3=limit)
-        U->>A: message
-        Note over A: RouterLoop → delegate_to_agent
-        A->>B: send(to=B, depth=1, chain_id=xyz)
-        Note over B: RouterLoop → delegate_to_agent
-        B->>C: send(to=C, depth=2, chain_id=xyz)
-        Note over C: depth=3 = max_hop_depth
-        C-->>B: result (chain_id=xyz)
-        B-->>A: result (chain_id=xyz)
-        A-->>U: final reply
-        Note over A,C: chain timeout = 60s
-    ```
-    Right diagram code:
+  - One diagram: MCP server/client symmetry, in its own white card with
+    1px border. (A second diagram depicting an A2A delegation chain via
+    `delegate_to_agent` was removed — that capability retired without a
+    like-for-like successor in proposal 0067 P6, #3978; `run_prompt` is
+    a 1:1 sync call with no depth/chain-hop/fan-out. Redraw once the
+    task-model arc lands a replacement for that shape, if one arrives.)
+    Diagram code:
     ```
     flowchart LR
         subgraph SRV["MCP Server — implemented (reyn mcp serve)"]

--- a/website/architecture.html
+++ b/website/architecture.html
@@ -505,25 +505,6 @@ sequenceDiagram
     <div class="diagram-grid">
       <div class="diagram-card">
         <div class="mermaid">
-sequenceDiagram
-    participant U as User (depth=0)
-    participant A as Agent A (depth=1)
-    participant B as Agent B (depth=2)
-    participant C as Agent C (depth=3=limit)
-    U->>A: message
-    Note over A: RouterLoop → delegate_to_agent
-    A->>B: send(to=B, depth=1, chain_id=xyz)
-    Note over B: RouterLoop → delegate_to_agent
-    B->>C: send(to=C, depth=2, chain_id=xyz)
-    Note over C: depth=3 = max_hop_depth
-    C-->>B: result (chain_id=xyz)
-    B-->>A: result (chain_id=xyz)
-    A-->>U: final reply
-    Note over A,C: chain timeout = 60s
-        </div>
-      </div>
-      <div class="diagram-card">
-        <div class="mermaid">
 flowchart LR
     subgraph SRV["MCP Server — implemented (reyn mcp serve)"]
         direction TB

--- a/website/copy.yaml
+++ b/website/copy.yaml
@@ -194,8 +194,8 @@ ARCH_S04_NUM: "04"
 ARCH_S04_LABEL: "Beyond a single agent"
 ARCH_S04_HEADING_HTML: "Reyn talks <em>out.</em><br/>Reyn is talked <em>to.</em>"
 ARCH_S04_BODY: >-
-  Agents delegate to other Agents asynchronously through a topology gate
-  — network, team, or pipeline — with hop depth capped at three.
+  Agents reach other Agents through a topology gate — network, team, or
+  pipeline — permission-scoped the same way any other capability is.
   From outside, Reyn exposes itself as an MCP server: Claude Code, Cursor,
   and any MCP-aware client can call list_agents() and send_to_agent().
   Inside Phases, Control IR ops can call external MCP servers as well —


### PR DESCRIPTION
**[docs-maintainer]** — Fixes the public architecture page's stale `delegate_to_agent` claim, per architect's ruling on #3978 requested via lead-coder.

## The ruling

`run_prompt` has no depth/chain-hop/fan-out params (0067's IF table, `main@3f8e6f82`) — the multi-hop async delegation chain the diagram depicted (`depth=`/`chain_id=`/60s chain timeout) is a **retired capability with no successor**, not a renamed one. This settles the two questions I couldn't answer myself when I first flagged this:

1. Tool-name substitution is not valid — it would claim "the mechanism is alive, only the name changed," which is false.
2. Waiting for P4e is also not valid — P4e won't bring this shape back (`run_prompt` is 1:1). A public page is a reason to fix this now, not a reason to wait — readers have no way to falsify a wrong "how it works" claim.

## What changed

- `website/architecture.html` — removed the `delegate_to_agent` sequence diagram entirely. The sibling MCP-server/client diagram (uses `"Control IR (mcp op)"`) is unaffected — Control IR is CLAUDE.md's own live typed-op system, unrelated to the already-established-dead Phase-executor envelope.
- `website/_design/claude_design_prompt_architecture.md` — same removal in the design-prompt source, with a note recording why and what would need to land before redrawing.
- `website/copy.yaml` — `ARCH_S04_BODY`'s prose made the identical claim ("hop depth capped at three"); rewritten to describe the current, permission-scoped reach mechanism without naming a depth cap that no longer exists.

## Swept the rest of the page

Per lead-coder's note that architect's own review didn't see the actual HTML or scan the rest of the page — swept all of `website/` for the same class of stale claim (`delegate_to_agent`, `run_pipeline_async`/`_inline`/`_inline_async`). No other tracked file references any of them (`website/dist/` is a gitignored build artifact, not source).

## Flagged, not fixed here

`ARCH_S04_BODY`'s "Inside Phases, Control IR ops can call external MCP servers" sentence may *also* be stale — the Phase-executor workflow engine is a separate, already-established-dead mechanism per `llm-invocation-surfaces.md`'s own banner. Distinct claim from this PR's scope, needs its own verification before touching.

## Test plan

- [x] Rebuilt via `website/build.py` — clean, 33 tokens substituted, no broken template references
- [x] `grep -c delegate_to_agent website/dist/architecture.html` — 0 (regenerated output confirmed clean; `dist/` itself not committed, gitignored)
- [x] `python3 -c "import yaml; yaml.safe_load(open('website/copy.yaml'))"` — valid YAML
- [x] `python scripts/check_doc_anchors.py` — exit 0 (unaffected, sanity check)
- [x] Swept `website/` for the same stale-mechanism class beyond just `delegate_to_agent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
