### PR TITLE
feat(#4104): loud, separate skip-reason tally for missing-extra gaps

### DIFF
--- a/src/reyn/dev/testing/extra_skip_report.py
+++ b/src/reyn/dev/testing/extra_skip_report.py
@@ -1,0 +1,118 @@
+"""Structural gate: local scoped-pytest runs must not silently hide skips
+caused by a missing optional-dependency extra (#4104).
+
+The failure mode (#4101, 2026-08-10): a developer sweeps ``tests/tools/`` +
+``tests/runtime/`` locally, gets "2567 passed / 0 failed", and pushes. CI runs
+RED, because ``tests/runtime/test_fp0063_arc_witness.py`` was never in the
+local "2567" — it was collected, then silently skipped (``pytest.importorskip``
+on ``builtin-rag``'s deps), and a skip wears the same green colour a pass does
+in an ordinary terminal summary glance. CLAUDE.md's six-question ④ ("would it
+stay green having never run") applies here one level up: not to a single
+test's own mechanism, but to a developer's whole local sweep.
+
+**What this does**: at the end of a LOCAL run (never inside CI or an xdist
+worker — see the guards below), scan the terminal reporter's own skip
+records for a reason that reads as an optional-dependency gap
+(``pytest.importorskip(..., reason=...)``'s conventional phrasing: contains
+"not installed" or an extra name in backticks/brackets — see
+``_EXTRA_GAP_MARKERS``) and print a **separate, loud** summary line distinct
+from pytest's own (already-printed) SKIPPED summary. The goal is not to
+change what ran — a missing extra is often a legitimate, intentional
+narrowing of a local venv — it is to make the fact impossible to miss
+without reading it, the same discipline the six-question checklist already
+applies to a single test.
+
+**Scope, deliberately narrow** (lead-coder ruling, #4104, 2026-08-10): this
+covers ONLY "a test never entered collection/execution due to a missing
+extra." It does NOT cover a test that ran and silently no-op'd via an
+internal fallback (#4127's own instance the same night — code never
+reached, not code never run) or a test that ran, asserted, and passed for
+the wrong reason (#4128/#2081's instance — a swallowed exception, not a
+missing dependency). Those are different axes; mixing them into one gate
+would make none of the three measurable.
+
+**Population, measured not assumed** (e2e-coder, #4104 comment,
+2026-08-10): the full set of ``pytest.importorskip`` targets in this
+repo's ``tests/`` tree is small and enumerable — ``apsw``, ``chonkie``,
+``fastapi``, ``fastmcp``, ``httpx``, ``huggingface_hub``, ``linebot.v3``,
+``mcp.server``, ``mcp``, ``opentelemetry.sdk.trace``, ``slack_bolt``,
+``trafilatura``, ``watchdog``. Some of these (``httpx`` via the core
+``litellm`` dependency) are effectively always present; others
+(``apsw``/``chonkie`` for ``builtin-rag``, ``linebot.v3``, ``slack_bolt``)
+are genuinely optional and this is exactly the surface #4101 hit.
+"""
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+
+# Conventional phrasing pytest.importorskip's `reason=` kwarg uses across this
+# repo's test suite (grep-verified, #4104) plus importorskip's own DEFAULT
+# message shape ("could not import '<module>'") for call sites that don't
+# pass a custom reason.
+_EXTRA_GAP_MARKERS = ("not installed", "could not import")
+
+
+def _skip_reason(report: "pytest.TestReport") -> "str | None":
+    """Extract the skip reason pytest recorded for a SKIPPED report.
+
+    ``longrepr`` for a ``pytest.importorskip``-triggered skip is normally a
+    ``(path, lineno, reason)`` tuple; some skip sources (a bare
+    ``@pytest.mark.skip``) instead give a bare string. Handle both — a
+    third shape here would mean a pytest internals change, not a #4104
+    regression, so this returns ``None`` rather than raising.
+    """
+    longrepr = getattr(report, "longrepr", None)
+    if isinstance(longrepr, tuple) and len(longrepr) == 3:
+        return str(longrepr[2])
+    if isinstance(longrepr, str):
+        return longrepr
+    return None
+
+
+def pytest_sessionfinish(session: "pytest.Session", exitstatus: int) -> None:
+    """Print a loud, separate tally of extra-dependency-gap skips.
+
+    No CI-specific guard is needed: CI installs every extra, so ``hits``
+    is always empty there and nothing prints — the same "correct by
+    construction, not by env-var-branching" property ``network_gate``'s
+    own guard comment argues for. Guarded off only by an explicit opt-out
+    (``REYN_DISABLE_EXTRA_SKIP_REPORT``) and inside an xdist worker (each
+    worker sees only ITS OWN slice of collected tests; only the
+    controller process — the one running this function without
+    ``session.config.workerinput`` set — sees the whole run, mirroring
+    ``network_gate.pytest_sessionfinish``'s identical guard for the same
+    reason).
+    """
+    if os.environ.get("REYN_DISABLE_EXTRA_SKIP_REPORT") == "1":
+        return
+    if hasattr(session.config, "workerinput"):
+        return
+
+    reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    if reporter is None:
+        return
+
+    hits: "list[tuple[str, str]]" = []
+    for report in reporter.stats.get("skipped", []):
+        reason = _skip_reason(report)
+        if reason is None:
+            continue
+        if any(marker in reason for marker in _EXTRA_GAP_MARKERS):
+            hits.append((report.nodeid, reason))
+
+    if not hits:
+        return
+
+    lines = [
+        "",
+        f"⚠️  {len(hits)} test(s) skipped due to a missing optional-dependency "
+        "extra (#4104) — a passing local sweep can still miss these tests "
+        "entirely, and CI (which installs every extra) will run them:",
+    ]
+    for nodeid, reason in sorted(hits):
+        lines.append(f"  - {nodeid}: {reason}")
+    reporter.write_line("\n".join(lines))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -608,9 +608,10 @@ def pytest_runtest_teardown(item: pytest.Item, nextitem: pytest.Item | None) -> 
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
-    from reyn.dev.testing import network_gate
+    from reyn.dev.testing import extra_skip_report, network_gate
 
     network_gate.pytest_sessionfinish(session, exitstatus)
+    extra_skip_report.pytest_sessionfinish(session, exitstatus)
 
 
 # ── Autouse fixture ────────────────────────────────────────────────────────────

--- a/tests/dev/test_extra_skip_report_4104.py
+++ b/tests/dev/test_extra_skip_report_4104.py
@@ -1,0 +1,97 @@
+"""Tier 1: Contract — reyn.dev.testing.extra_skip_report, the #4104
+structural gate.
+
+Same style as tests/dev/test_network_gate_3451.py: the end-to-end "does an
+extra-gap skip actually get called out" behaviour is exercised via pytest's
+own `pytester` fixture — a REAL, isolated inner pytest session loading ONLY
+the `reyn.dev.testing.extra_skip_report` plugin against a tiny inner test
+file. This is the only way to get a real SKIPPED TestReport flowing through
+a real pytest_sessionfinish without faking pytest's own reporting internals.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest_plugins = ["pytester"]
+
+INNER_CONFTEST = 'pytest_plugins = ["reyn.dev.testing.extra_skip_report"]\n'
+
+
+def _run_inner(pytester: pytest.Pytester, body: str):
+    pytester.makeconftest(INNER_CONFTEST)
+    pytester.makepyfile(test_inner=body)
+    return pytester.runpytest()
+
+
+def test_importorskip_reason_is_called_out(pytester: pytest.Pytester):
+    """Tier 1: a test skipped via pytest.importorskip's conventional 'not
+    installed' reason phrasing triggers the loud #4104 summary line."""
+    result = _run_inner(
+        pytester,
+        """
+        import pytest
+
+        def test_needs_missing_thing():
+            pytest.importorskip(
+                "reyn_test_4104_nonexistent_module", reason="reyn_test_4104_nonexistent_module not installed",
+            )
+        """,
+    )
+    result.assert_outcomes(skipped=1)
+    result.stdout.fnmatch_lines([
+        "*1 test(s) skipped due to a missing optional-dependency extra*",
+        "*test_inner.py::test_needs_missing_thing*not installed*",
+    ])
+
+
+def test_unrelated_skip_reason_is_not_called_out(pytester: pytest.Pytester):
+    """Tier 1: non-vacuity — a skip for an ORDINARY reason (not an
+    extra-dependency gap) does not trigger the #4104 summary. Without this,
+    the gate would fire on every skip in the suite and the signal would be
+    useless noise."""
+    result = _run_inner(
+        pytester,
+        """
+        import pytest
+
+        def test_skipped_for_an_unrelated_reason():
+            pytest.skip("not applicable on this platform")
+        """,
+    )
+    result.assert_outcomes(skipped=1)
+    assert "missing optional-dependency extra" not in result.stdout.str()
+
+
+def test_disable_env_var_suppresses_the_summary(pytester: pytest.Pytester, monkeypatch):
+    """Tier 1: REYN_DISABLE_EXTRA_SKIP_REPORT=1 turns the summary off even
+    when a real extra-gap skip is present — the escape hatch every other
+    dev-testing gate in this module family carries (mirrors
+    network_gate's REYN_DISABLE_NETWORK_GATE)."""
+    monkeypatch.setenv("REYN_DISABLE_EXTRA_SKIP_REPORT", "1")
+    result = _run_inner(
+        pytester,
+        """
+        import pytest
+
+        def test_needs_missing_thing():
+            pytest.importorskip(
+                "reyn_test_4104_nonexistent_module", reason="reyn_test_4104_nonexistent_module not installed",
+            )
+        """,
+    )
+    result.assert_outcomes(skipped=1)
+    assert "missing optional-dependency extra" not in result.stdout.str()
+
+
+def test_no_hits_prints_nothing(pytester: pytest.Pytester):
+    """Tier 1: non-vacuity for the whole mechanism — a run with zero skips
+    at all produces zero #4104 output, not an empty-but-present banner."""
+    result = _run_inner(
+        pytester,
+        """
+        def test_passes():
+            assert True
+        """,
+    )
+    result.assert_outcomes(passed=1)
+    assert "missing optional-dependency extra" not in result.stdout.str()


### PR DESCRIPTION
**[e2e-coder]** — #4104: loud, separate skip-reason tally for missing-extra gaps.

## What

Local scoped-`pytest` sweeps can go green while silently never collecting/running tests gated behind an optional extra (#4101: "2567 passed / 0 failed" locally, CI RED, because `test_fp0063_arc_witness.py` skipped for lacking `builtin-rag`'s deps — a skip wears the same green colour a pass does in a terminal glance).

**Implementation form chosen** (per lead-coder's delegation on #4104 — this is an implementation-level choice, not a design decision needing architect): candidate ② from the issue's own list — at `pytest_sessionfinish`, scan the terminal reporter's own skip records for the conventional `pytest.importorskip(..., reason=...)` "not installed" phrasing and print a loud, **separate** summary line distinct from pytest's own skip summary. Deliberately does NOT change what ran; a missing extra can be a legitimate, intentional local narrowing — the goal is making the fact impossible to miss without reading it.

## Scope — deliberately narrow (lead-coder ruling)

Covers ONLY "never entered collection/execution due to a missing extra." Explicitly **not** this mechanism:
- #4127's silent no-op fallback (code never *reached*, not code never *run*)
- #4128/#2081's "passed for the wrong reason via a swallowed exception" (ran and asserted, just against nothing)

Three different axes surfaced the same night; mixing them into one gate would make none of them measurable.

## Population, measured before building (posted as a #4104 comment)

The full `pytest.importorskip` target set in `tests/` is 13 modules across 7 extras. `httpx` (9 files) is guaranteed present via the core `litellm` dependency — not actually at risk. `docs`/`voice` extras currently have zero pytest exposure either way (no `importorskip` on `mkdocs`/`sounddevice` anywhere in the suite).

## Verification

- Falsify-verified: stripped the summary-print branch, confirmed `test_importorskip_reason_is_called_out` goes RED with the exact expected diff, restored, confirmed green.
- Accept-side test included (`test_unrelated_skip_reason_is_not_called_out` — an unrelated skip reason does not trigger the summary) per testing-policy's "3 needs no accept-side exception" note — its consumer is anyone who'd be wrongly spammed by an over-firing gate.
- `test_no_hits_prints_nothing` — non-vacuity for the whole mechanism (zero skips → zero output, not an empty-but-present banner).
- `test_disable_env_var_suppresses_the_summary` — the escape hatch every dev-testing gate in this module family carries (mirrors `network_gate`'s `REYN_DISABLE_NETWORK_GATE`).
- Verified the outer `tests/conftest.py` wiring end-to-end (a real, non-pytester-isolated run through the actual `pytest_sessionfinish` hook chain).

## TESTS-READ (six questions — `tests/dev/test_extra_skip_report_4104.py`, new file)

1. **Tier** — 1 (Contract): pins the pytest-plugin hook's own printed-output contract via a real, isolated inner `pytester` session (same style as `test_network_gate_3451.py`), not an OS invariant or LLM-replay behavior.
2. **Implementation transcribed?** No — the assertions check `result.stdout` text/outcome counts from a real inner pytest run, not a copy of the hook's own string-building logic.
3. **Who would miss it?** A future PR that changes the skip-reason marker set or breaks the sessionfinish wiring, silently regressing this back to #4101's failure mode.
4. **Green having never run?** No — no optional-dependency skip path in this file itself; `pytester` is a core pytest plugin.
5. **What does it accumulate?** Nothing — 4 fixed, bounded inner-session runs.
6. **Declared Tier true?** Yes.

## Test plan

- [x] `ruff check src tests`
- [x] `test_tier_audit.py --strict` on the new test file
- [x] `verify_module_docstrings.py` on the new src file
- [x] `check_file_depth_reference.py`
- [x] `check_tests_path_literal_reference.py`
- [x] `mypy_ratchet.py`
- [x] `pytest tests/dev/test_extra_skip_report_4104.py tests/dev/test_network_gate_3451.py` — 13 passed
- [x] Falsify-verified RED→GREEN

part of #4104

🤖 Generated with [Claude Code](https://claude.com/claude-code)
