### PR TITLE
docs(#3978): avoid "delegate" in ARCH_S04_BODY, same word as the retired tool

### DIFF
--- a/website/copy.yaml
+++ b/website/copy.yaml
@@ -194,8 +194,9 @@ ARCH_S04_NUM: "04"
 ARCH_S04_LABEL: "Beyond a single agent"
 ARCH_S04_HEADING_HTML: "Reyn talks <em>out.</em><br/>Reyn is talked <em>to.</em>"
 ARCH_S04_BODY: >-
-  Agents delegate to other Agents through a topology gate
-  — network, team, or pipeline.
+  Agents reach other Agents through a topology gate
+  — network, team, or pipeline — permission-scoped the same way any
+  other capability is.
   From outside, Reyn exposes itself as an MCP server: Claude Code, Cursor,
   and any MCP-aware client can call list_agents() and send_to_agent().
   Inside Phases, Control IR ops can call external MCP servers as well —


### PR DESCRIPTION
**[docs-maintainer]** — Small follow-up split out of #4130, which was closed as fully covered by #4131 except this one line — architect's diff review found it, lead-coder assigned it to me (the #4130 author, wording already drafted).

## Why

`ARCH_S04_BODY`'s "Agents delegate to other Agents through a topology gate" is not false — an agent reaching another agent through a topology gate is real (it's why `run_prompt` joined the re-delegation floor in #4117/#4122). Both architect and lead-coder confirmed: this is a clarification, not a correction. But `delegate` is the same word as the just-retired `delegate_to_agent` tool name, sitting on the public architecture page right next to where the diagram depicting that tool used to be. Rewording to avoid the collision.

## What changed

`website/copy.yaml`'s `ARCH_S04_BODY` — "delegate to" → "reach", with a permission-scoping clause added for context.

## Explicitly NOT included

The other #4130 difference (deleting the diagram source from `_design/claude_design_prompt_architecture.md` instead of STALE-annotating it) — both architect and lead-coder judged #4131's keep-and-annotate approach better (preserves the pre-retirement record while still preventing a future page regeneration from reproducing the diagram), so that stays as #4131 landed it.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('website/copy.yaml'))"` — valid YAML
- [x] `python website/build.py` — clean rebuild, no missing-token errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
