### PR TITLE
feat(#3978): P4e — materialize requester as a stored field, remove from_user

### DIFF
--- a/src/reyn/core/events/agent_snapshot.py
+++ b/src/reyn/core/events/agent_snapshot.py
@@ -285,13 +285,11 @@ class AgentSnapshot:
             msg_id = event.get("msg_id")
             self.inbox = [m for m in self.inbox if m.get("id") != msg_id]
         elif kind == "chain_register":
-            self.pending_chains[event["chain_id"]] = {
+            chain_entry = {
                 "chain_id": event["chain_id"],
-                "origin_agent": event["origin_agent"],
                 "origin_depth": int(event["origin_depth"]),
                 "original_request": event["original_request"],
                 "waiting_on": list(event.get("waiting_on", [])),
-                "origin_sid": event.get("origin_sid"),
                 # #3978 P4: the task kind (prompt/pipeline/exec) — persisted
                 # key is "task_kind" (chain_manager.py's own record_chain_register
                 # collision note: "kind" is SnapshotJournal._wal_append_nowait's
@@ -301,6 +299,25 @@ class AgentSnapshot:
                 # back out under the same key.
                 "task_kind": event.get("task_kind"),
             }
+            # proposal 0067 P4e (#3978): "requester" is a nested
+            # {"agent_name", "session_id"} value (ChainManager.register()'s
+            # own docstring) — mirrored through as-is when present. A
+            # pre-P4e WAL event (recorded under the old flat "origin_agent"/
+            # "origin_sid" keys) has no "requester" key — NORMALIZED into the
+            # same nested shape here, at replay time, rather than carrying
+            # the legacy flat keys forward into ``pending_chains``: every
+            # entry this branch produces uses ONE shape regardless of which
+            # WAL-event generation wrote it, so nothing downstream (including
+            # ChainManager.restore(), which reads "requester" unconditionally
+            # after this normalization) needs its own legacy-fallback branch.
+            if "requester" in event:
+                chain_entry["requester"] = event["requester"]
+            else:
+                chain_entry["requester"] = {
+                    "agent_name": event.get("origin_agent", ""),
+                    "session_id": event.get("origin_sid") or "main",
+                }
+            self.pending_chains[event["chain_id"]] = chain_entry
         elif kind == "chain_update":
             # #4108: field-name-INDEPENDENT write-back — mirrors every
             # non-routing key the event actually carries, rather than

--- a/src/reyn/runtime/services/chain_manager.py
+++ b/src/reyn/runtime/services/chain_manager.py
@@ -19,7 +19,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Protocol, runtime_checkable
 
-from reyn.runtime.task_types import RunStatus
+from reyn.runtime.task_types import Requester, RunStatus
 
 if TYPE_CHECKING:
     from reyn.core.events.agent_snapshot import AgentSnapshot
@@ -40,24 +40,31 @@ class _PendingChain:
 
     Created when an agent receives an ``agent_request`` and decides to
     further delegate (router emits ``messages_to_agents``). The reply to
-    the upstream ``origin_agent`` is held back until every entry in
+    the upstream ``requester`` is held back until every entry in
     ``waiting_on`` has returned an ``agent_response`` for this chain_id.
     On the final response, the agent re-runs its router so the LLM can
     compose a synthesized answer with all delegate replies in history,
-    then sends that answer to ``origin_agent`` at ``origin_depth``.
+    then sends that answer to ``requester`` at ``origin_depth``.
 
     Note: session.py retains an identical copy until wave 2 imports this.
     """
 
     chain_id: str
-    origin_agent: str
+    # proposal 0067 P4e (#3978), architect ruling 2026-08-10: ADR-0040 D6's
+    # ``Requester(agent_name, session_id)`` stored as ONE nested field, not
+    # two flat ones — "the pair is the address, not either half alone"
+    # (``Requester``'s own docstring), and #2130 already lived the flat-2-key
+    # failure mode once (a missing ``origin_sid`` silently misdelivered to
+    # ``main``). A flat pair structurally permits writing one half without
+    # the other; a nested value does not. Was ``origin_agent``/``origin_sid``
+    # (two flat fields) plus a `.requester` DERIVED property (P4, #3978) —
+    # this rename makes the property redundant by making the field itself
+    # BE what the property used to compute. See ``register()``'s docstring
+    # for the WAL-persisted shape.
+    requester: Requester
     origin_depth: int
     original_request: str
     waiting_on: set[str] = field(default_factory=set)
-    # #2130: the origin's session id — so the resolved chain reply routes back to the
-    # specific (origin_agent, origin_sid), not the origin agent's main session. None →
-    # main-case (user-initiated / external peer / pre-#2130 journal entries).
-    origin_sid: "str | None" = None
     # proposal 0067 P4 (#3978): the task kind (prompt/pipeline/exec) this
     # handle represents — None for a delegate-relay chain, which stays
     # OUTSIDE the task vocabulary permanently. NOT because of its
@@ -95,27 +102,6 @@ class _PendingChain:
     # (cancel_task) that finds `cancel is None` MUST NOT report success:
     # nothing is actually listening.
     cancel: "Callable[[], None] | None" = field(default=None, compare=False, repr=False)
-
-    @property
-    def requester(self) -> "Requester":
-        """ADR-0040 D6's ``Requester(agent_name, session_id)`` — derived
-        from ``(origin_agent, origin_sid)``, NOT a second stored field.
-
-        Measured (lead-coder, 2026-08-10): these two fields already ARE
-        D6's Requester in substance — the docstring above already says
-        "routes back to the specific (origin_agent, origin_sid)". Adding a
-        separate ``requester`` field would duplicate storage for the same
-        fact. The RENAME (making ``origin_agent``/``origin_sid`` literally
-        ``requester.agent_name``/``requester.session_id``) is deferred to
-        run_prompt(collect="async")'s own PR (architect ruling, #3978: P6
-        retired delegate_to_agent with no fold — nothing consumes this
-        field's rename before that async producer exists) — this read
-        accessor lets P4's ``describe_task`` consumer be satisfied today
-        without committing to that rename now; a later PR changing the
-        field names underneath won't change this property's callers."""
-        from reyn.runtime.task_types import Requester
-
-        return Requester(agent_name=self.origin_agent, session_id=self.origin_sid or "main")
 
 
 # ── Journal protocol ──────────────────────────────────────────────────────────
@@ -198,14 +184,12 @@ class ChainManager:
         self,
         *,
         chain_id: str,
-        from_user: bool,
         depth: int,
         original_text: str,
         sender: str | None,
         waiting_on: set[str] | None = None,
-        origin_agent: str = "",
+        requester: "Requester | None" = None,
         origin_depth: int = 0,
-        origin_sid: "str | None" = None,
         kind: "str | None" = None,
         cancel: "Callable[[], None] | None" = None,
     ) -> _PendingChain:
@@ -215,18 +199,28 @@ class ChainManager:
         ----------
         chain_id:
             Unique identifier for the chain.
-        from_user:
-            True when the chain originates from a user message.
         depth:
             Current hop depth (used as ``origin_depth`` when not specified).
         original_text:
             The original request text.
         sender:
-            Agent name that sent the request, or None for user-initiated chains.
+            Agent name that sent the request, or None for user-initiated
+            chains. Also the fallback for ``requester.agent_name`` when
+            ``requester`` is not passed explicitly.
         waiting_on:
             Set of agent names this chain is waiting for.
-        origin_agent:
-            The agent to reply to when the chain resolves.
+        requester:
+            proposal 0067 P4e (#3978), architect ruling 2026-08-10: ADR-0040
+            D6's ``Requester(agent_name, session_id)`` — the address to
+            reply to when the chain resolves, stored as ONE value (see
+            ``_PendingChain.requester``'s own docstring for why a flat
+            2-field pair was rejected). Defaults to
+            ``Requester(sender or "", "main")`` when omitted, mirroring the
+            pre-materialization defaulting (``origin_agent or sender or
+            ""`` / an implicit ``origin_sid`` of ``None`` → ``"main"``) —
+            every production call site passes this explicitly today; the
+            default exists for callers (and tests) that don't need a
+            specific reply target.
         origin_depth:
             The depth at which to send the reply upstream.
         kind:
@@ -242,25 +236,35 @@ class ChainManager:
             (e.g. a legacy delegate-relay chain). VOLATILE — never
             persisted (see ``_PendingChain.cancel``'s own docstring).
         """
+        resolved_requester = requester or Requester(
+            agent_name=sender or "", session_id="main"
+        )
         chain = _PendingChain(
             chain_id=chain_id,
-            origin_agent=origin_agent or sender or "",
+            requester=resolved_requester,
             origin_depth=origin_depth or depth,
             original_request=original_text,
             waiting_on=set(waiting_on or []),
-            origin_sid=origin_sid,
             kind=kind,
             cancel=cancel,
         )
         self._chains[chain_id] = chain
 
         fields: dict[str, Any] = {
-            "origin_agent": chain.origin_agent,
+            # proposal 0067 P4e (#3978): persisted as ONE nested value, not
+            # two flat keys — #4110's field-name-independent WAL/snapshot
+            # mirror makes nesting free (any JSON-serializable value passes
+            # through unchanged); a flat pair would let a future caller omit
+            # one half without a construction-time error, the exact shape
+            # #2130 already misdelivered on once (a missing origin_sid
+            # silently routed to "main").
+            "requester": {
+                "agent_name": chain.requester.agent_name,
+                "session_id": chain.requester.session_id,
+            },
             "origin_depth": chain.origin_depth,
             "original_request": chain.original_request,
             "waiting_on": sorted(chain.waiting_on),
-            "from_user": from_user,
-            "origin_sid": chain.origin_sid,  # #2130
             # Persisted key is "task_kind", not "kind" — SnapshotJournal's
             # own _wal_append_nowait(kind: str, **fields) takes "kind" as
             # the WAL EVENT type positional (e.g. "chain_register"); a
@@ -491,13 +495,31 @@ class ChainManager:
         Call this after the journal has installed a recovered snapshot.
         """
         for cid, chain_dict in self._journal.snapshot.pending_chains.items():
+            # proposal 0067 P4e (#3978): the persisted "requester" key is a
+            # nested {"agent_name", "session_id"} value (see register()'s
+            # own docstring) — reconstructed here rather than read as a flat
+            # pair. Pre-P4e journal entries (recorded under the old
+            # "origin_agent"/"origin_sid" keys) have no "requester" key at
+            # all; that legacy shape is read as a fallback so an
+            # already-persisted chain from before this rename still
+            # restores correctly rather than losing its reply address.
+            requester_dict = chain_dict.get("requester")
+            if requester_dict is not None:
+                requester = Requester(
+                    agent_name=requester_dict["agent_name"],
+                    session_id=requester_dict["session_id"],
+                )
+            else:
+                requester = Requester(
+                    agent_name=chain_dict.get("origin_agent", ""),
+                    session_id=chain_dict.get("origin_sid") or "main",
+                )
             self._chains[cid] = _PendingChain(
                 chain_id=chain_dict["chain_id"],
-                origin_agent=chain_dict["origin_agent"],
+                requester=requester,
                 origin_depth=int(chain_dict["origin_depth"]),
                 original_request=chain_dict["original_request"],
                 waiting_on=set(chain_dict.get("waiting_on", [])),
-                origin_sid=chain_dict.get("origin_sid"),  # #2130 (None for pre-#2130 entries)
                 kind=chain_dict.get("task_kind"),  # #3978 P4 (None for pre-P4 entries)
             )
             self.arm_timeout(cid, on_fire=on_fire)

--- a/src/reyn/runtime/services/chain_timeout_glue.py
+++ b/src/reyn/runtime/services/chain_timeout_glue.py
@@ -112,15 +112,24 @@ class ChainTimeoutGlue:
             chain_id=chain_id,
             waiting_on=waiting,
             timeout_seconds=self._chain_timeout_seconds,
-            origin_agent=pending.origin_agent,
+            # proposal 0067 P4e (#3978): field KEY unchanged (see the
+            # matching comment in session.py's chain_peer_discarded emit —
+            # audit payload shape, not the closed AUDIT_EVENT_KINDS
+            # vocabulary), value now reads the materialized requester field.
+            origin_agent=pending.requester.agent_name,
         )
         try:
             await self._send_agent_response(
-                to=pending.origin_agent,
+                to=pending.requester.agent_name,
                 response=error_text,
                 depth=pending.origin_depth,
                 chain_id=chain_id,
-                to_sid=getattr(pending, "origin_sid", None),  # #2130
+                # proposal 0067 P4e (#3978): direct access, not the previous
+                # defensive getattr(pending, "origin_sid", None) — requester
+                # is a required field on _PendingChain (never absent), so
+                # the defensiveness that inconsistency flagged (#3978 P4e
+                # scope measurement) no longer has anything to guard against.
+                to_sid=pending.requester.session_id,  # #2130
             )
         except Exception as exc:
             await self._put_outbox(OutboxMessage(

--- a/src/reyn/runtime/services/inter_agent_messaging.py
+++ b/src/reyn/runtime/services/inter_agent_messaging.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.session_pure import new_chain_id
+from reyn.runtime.task_types import Requester
 
 if TYPE_CHECKING:
     from reyn.core.events.events import EventLog
@@ -384,7 +385,7 @@ class InterAgentMessaging:
         from_agent = payload.get("from_agent", "")
         # #2130: the REQUESTER's session id (None for the main-case / external peers) — so
         # this agent's reply routes back to the SPECIFIC (from_agent, from_sid), threaded
-        # to every send_agent_response below + the pending chain's origin_sid.
+        # to every send_agent_response below + the pending chain's requester.session_id.
         from_sid = payload.get("from_sid")
         # FP-0050/#1822 S4b (EP5, Class A): fence + scan the untrusted peer
         # request before it enters history (a remote agent is outside the trust
@@ -471,14 +472,16 @@ class InterAgentMessaging:
             waiting_on = {d["to"] for d in dispatched}
             await self._chains.register(
                 chain_id=chain_id,
-                from_user=False,
                 depth=depth,
                 original_text=request,
                 sender=from_agent,
                 waiting_on=waiting_on,
-                origin_agent=from_agent,
+                # #2130: route the chain reply back to the specific
+                # (from_agent, from_sid) — proposal 0067 P4e (#3978):
+                # requester is the materialized stored form, not a derived
+                # property, of that same address.
+                requester=Requester(agent_name=from_agent, session_id=from_sid or "main"),
                 origin_depth=depth,
-                origin_sid=from_sid,  # #2130: route the chain reply back to (origin_agent, origin_sid)
             )
             self._chains.arm_timeout(
                 chain_id, on_fire=self._on_chain_timeout_fire,
@@ -511,8 +514,8 @@ class InterAgentMessaging:
         - chain_id ∈ self._chains → multi-hop relay. Drop sender
           from waiting_on; when waiting_on becomes empty, re-invoke router
           and forward the synthesized reply (or fresh delegations) on the
-          same chain. Reply goes to the chain's ``origin_agent``, NOT
-          ``from_agent``.
+          same chain. Reply goes to the chain's ``requester.agent_name``,
+          NOT ``from_agent``.
         - chain_id ∉ self._chains → user-initiated chain (PR11
           compatibility). The router's reply_text is treated as a
           user-facing message (outbox + history); further delegations
@@ -691,15 +694,15 @@ class InterAgentMessaging:
                 self._output_language or "en", _PEER_REPLY_FAILED_MSG["en"],
             )
             user_text = msg_template.format(peer=peer, reason=reason)
-            # Forward the failure upstream — the pending chain always has an
-            # origin_agent (chains from user requests don't reach _resolve_pending_chain;
+            # Forward the failure upstream — the pending chain always has a
+            # requester (chains from user requests don't reach _resolve_pending_chain;
             # they are handled by the `chain_id ∉ self._chains` branch above).
             await self.send_agent_response(
-                to=pending.origin_agent,
+                to=pending.requester.agent_name,
                 response=user_text,
                 depth=pending.origin_depth,
                 chain_id=chain_id,
-                to_sid=pending.origin_sid,  # #2130
+                to_sid=pending.requester.session_id,  # #2130
             )
             self._events.emit(
                 "peer_reply_failed_surfaced",
@@ -723,14 +726,14 @@ class InterAgentMessaging:
             # of whether LLM wrap-up succeeded — user-facing and agent-protocol are
             # orthogonal: origin agent must know the chain ended on cap (#1538).
             await self.send_agent_response(
-                to=pending.origin_agent,
+                to=pending.requester.agent_name,
                 response=_no_reply_marker(
                     self.agent_name,
                     f"router retry budget exhausted ({exc.count}/{exc.cap}) "
                     f"resolving chain",
                 ),
                 depth=pending.origin_depth, chain_id=chain_id,
-                to_sid=pending.origin_sid,  # #2130
+                to_sid=pending.requester.session_id,  # #2130
             )
             await self._chains.resolve(chain_id)
             return
@@ -745,13 +748,13 @@ class InterAgentMessaging:
             ))
             # F6/F7 fix: structured marker upstream, not "".
             await self.send_agent_response(
-                to=pending.origin_agent,
+                to=pending.requester.agent_name,
                 response=_no_reply_marker(
                     self.agent_name,
                     f"router error during chain resolve: {exc}",
                 ),
                 depth=pending.origin_depth, chain_id=chain_id,
-                to_sid=pending.origin_sid,  # #2130
+                to_sid=pending.requester.session_id,  # #2130
             )
             await self._chains.resolve(chain_id)
             return
@@ -782,9 +785,9 @@ class InterAgentMessaging:
             )
         # History already appended by put_outbox.
         await self.send_agent_response(
-            to=pending.origin_agent, response=final_reply,
+            to=pending.requester.agent_name, response=final_reply,
             depth=pending.origin_depth, chain_id=chain_id,
-            to_sid=pending.origin_sid,  # #2130
+            to_sid=pending.requester.session_id,  # #2130
         )
         await self._chains.resolve(chain_id)
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -6923,15 +6923,20 @@ class Session:
             peer=peer,
             reason=reason,
             waiting_on=waiting,
-            origin_agent=pending.origin_agent,
+            # proposal 0067 P4e (#3978): field KEY unchanged (this audit
+            # event's payload shape is not part of the closed AUDIT_EVENT_KINDS
+            # vocabulary, but .reyn/events has consumers outside reyn — see
+            # CLAUDE.md — so only the VALUE's source moved to the
+            # materialized requester field, not the emitted key name).
+            origin_agent=pending.requester.agent_name,
         )
         try:
             await self._send_agent_response(
-                to=pending.origin_agent,
+                to=pending.requester.agent_name,
                 response=error_text,
                 depth=pending.origin_depth,
                 chain_id=chain_id,
-                to_sid=pending.origin_sid,  # #2130
+                to_sid=pending.requester.session_id,  # #2130
             )
         except Exception as exc:  # noqa: BLE001 — never wedge the loop
             await self._put_outbox(OutboxMessage(

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -107,6 +107,7 @@ from typing import TYPE_CHECKING, Any
 
 from reyn.runtime.errors import AgentStepError
 from reyn.runtime.session_pure import new_chain_id
+from reyn.runtime.task_types import Requester
 from reyn.runtime.transport import SystemRef
 from reyn.runtime.turn_origin import TurnOrigin
 
@@ -629,10 +630,9 @@ async def _spawn_pipeline_driver_session(
         )
         if reply_target is not None:
             await reply_target.chains.register(
-                chain_id=rid, from_user=False, depth=0,
+                chain_id=rid, depth=0,
                 original_text=pipeline_name, sender=None,
-                origin_agent=reply_to_agent,
-                origin_sid=None if reply_to_sid == "main" else reply_to_sid,
+                requester=Requester(agent_name=reply_to_agent, session_id=reply_to_sid),
                 kind="pipeline",
                 cancel=driver.request_cancel,
             )

--- a/src/reyn/tools/task_verbs.py
+++ b/src/reyn/tools/task_verbs.py
@@ -40,8 +40,8 @@ def _inbox_depth(ctx: ToolContext) -> "int | None":
 
     ``chains`` is scoped to THE CALLING session's own ChainManager (module
     docstring), so every task these tools can even see was registered with
-    ``origin_sid`` equal to this same calling session — the depth is
-    therefore homogeneous across every task in a given response; no
+    ``requester.session_id`` equal to this same calling session — the depth
+    is therefore homogeneous across every task in a given response; no
     per-task resolution is needed."""
     rs = getattr(ctx, "router_state", None)
     return getattr(rs, "session_inbox_depth", None) if rs is not None else None
@@ -53,7 +53,7 @@ def _describe(chain: Any, *, inbox_depth: "int | None" = None) -> dict[str, Any]
         "task_id": chain.chain_id,
         "kind": chain.kind,
         "status": chain.status.value,
-        "session": chain.origin_sid or "main",
+        "session": chain.requester.session_id,
         # Proposal 0067 P9 (#3978), architect ruling 2026-08-10: an
         # INSTANTANEOUS read of the task's own (= this calling session's)
         # inbox queue depth — by the time this reply reaches the LLM the

--- a/tests/core/test_agent_snapshot.py
+++ b/tests/core/test_agent_snapshot.py
@@ -206,16 +206,19 @@ def test_truncate_falsify_snapshot_backed_kept_state_survives(tmp_path: Path):
 def test_chain_register_replay_carries_origin_sid_and_task_kind():
     """Tier 2: #3978 P4 — a chain_register event's ``origin_sid`` (#2130) and
     ``task_kind`` (P4) fields must survive PURE WAL REPLAY, not just a
-    snapshot save/load round-trip. Before this fix, ``apply_events``'s own
-    ``chain_register`` branch hardcoded a 5-field dict that silently dropped
-    both — a crash recovered via replay (rather than a loaded snapshot file)
-    would reconstruct a pending_chains entry missing them, which
-    ``ChainManager.restore()`` then reads back as ``None`` regardless of
-    what was actually registered. This directly affects P4's
-    ``_PendingChain.requester`` property (derived from
-    ``origin_agent``/``origin_sid``) and ``describe_task``/``list_tasks``
-    (which read ``kind``): a wrong ``origin_sid`` silently mis-attributes
-    the requester to "main"."""
+    snapshot save/load round-trip. Before the original P4 fix, ``apply_events``'s
+    own ``chain_register`` branch hardcoded a 5-field dict that silently
+    dropped both — a crash recovered via replay (rather than a loaded
+    snapshot file) would reconstruct a pending_chains entry missing them.
+
+    proposal 0067 P4e (#3978): this test now exercises the LEGACY event
+    shape specifically (flat ``origin_agent``/``origin_sid`` keys, no
+    ``requester`` key) — the shape a pre-P4e WAL entry actually has.
+    ``apply_events`` normalizes it into the current nested ``requester``
+    shape at replay time (same normalization ``ChainManager.restore()``
+    then reads unconditionally), so this is now also the falsify-coverage
+    for that legacy-to-current normalization, not just the original
+    origin_sid/task_kind drop."""
     snap = _snap("agent_x")
     snap.apply_events([
         _event(
@@ -225,15 +228,18 @@ def test_chain_register_replay_carries_origin_sid_and_task_kind():
         ),
     ])
     chain = snap.pending_chains["c-kind"]
-    assert chain["origin_sid"] == "sid-7"
+    assert chain["requester"] == {"agent_name": "a", "session_id": "sid-7"}
     assert chain["task_kind"] == "pipeline"
 
 
 def test_chain_register_replay_defaults_origin_sid_and_task_kind_to_none():
     """Tier 2: falsification pair — an event carrying neither field (a
-    pre-#2130/pre-P4 WAL entry) still replays cleanly, defaulting both to
-    ``None`` rather than raising a ``KeyError`` (both are ``event.get``,
-    not ``event[...]``)."""
+    pre-#2130/pre-P4 WAL entry) still replays cleanly, defaulting
+    ``requester.session_id`` to ``"main"`` (proposal 0067 P4e, #3978:
+    ``Requester.session_id`` is typed ``str``, never ``None`` — the same
+    normalization ``ChainManager.register()``'s own no-``requester``-passed
+    default applies) and ``task_kind`` to ``None`` rather than raising a
+    ``KeyError``."""
     snap = _snap("agent_x")
     snap.apply_events([
         _event(
@@ -242,7 +248,7 @@ def test_chain_register_replay_defaults_origin_sid_and_task_kind_to_none():
         ),
     ])
     chain = snap.pending_chains["c-old"]
-    assert chain["origin_sid"] is None
+    assert chain["requester"] == {"agent_name": "a", "session_id": "main"}
     assert chain["task_kind"] is None
 
 
@@ -354,6 +360,95 @@ def test_truncate_falsify_chain_update_field_survives_wal_truncation(tmp_path: P
     truncated = AgentSnapshot.load("agent_x", tmp_path / "snap-ttl.json")
     truncated.apply_events([])  # seq 3/4 events truncated
     assert "c-walonly" not in truncated.pending_chains  # WAL-only state LOST
+
+
+def test_truncate_falsify_requester_survives_wal_truncation(tmp_path: Path):
+    """Tier 2c: CLAUDE.md's recovery-feature PR gate — proposal 0067 P4e
+    (#3978) materializes ``requester`` as ``_PendingChain``'s stored reply
+    address (was two flat fields, ``origin_agent``/``origin_sid``, behind a
+    derived property). Same shape as
+    ``test_truncate_falsify_chain_update_field_survives_wal_truncation``
+    above: bake a chain_register-carried ``requester`` into a saved
+    snapshot (``applied_seq`` past its own seq), then reload and replay an
+    EMPTY tail (simulating the source WAL event truncated below the
+    snapshot's own seq) — ``requester`` must still be correct, because it
+    survives via the snapshot, not via replaying the (now-gone) WAL entry.
+    The WAL-only control proves this isn't trivially passing."""
+    snap = _snap("agent_x")
+    snap.apply_events([
+        _event(
+            "chain_register", seq=1, chain_id="c-req",
+            origin_depth=0, original_request="x",
+            requester={"agent_name": "worker", "session_id": "sid-9"},
+        ),
+    ])
+    assert snap.applied_seq == 1
+    assert snap.pending_chains["c-req"]["requester"] == {
+        "agent_name": "worker", "session_id": "sid-9",
+    }
+
+    # Serialize → the snapshot carries requester + applied_seq=1.
+    snap.save(tmp_path / "snap-req.json")
+
+    # TRUNCATE: replay an EMPTY tail (the source WAL event, seq 1, is gone
+    # below the truncation floor) — apply_events skips seq<=applied_seq
+    # regardless, so this simulates "the event isn't even offered" faithfully.
+    reloaded = AgentSnapshot.load("agent_x", tmp_path / "snap-req.json")
+    reloaded.apply_events([])
+    assert reloaded.pending_chains["c-req"]["requester"] == {
+        "agent_name": "worker", "session_id": "sid-9",
+    }, (
+        "requester must survive WAL truncation below its chain_register's "
+        "seq — it is baked into the SAVED snapshot, not replayed from the "
+        "(now-gone) event"
+    )
+
+    # WAL-only CONTROL: a DIFFERENT chain, registered entirely AFTER the
+    # snapshot's applied_seq, is WAL-only — present when its event is
+    # replayed, LOST when it's truncated instead. Proves the assertion
+    # above is snapshot-backed survival, not something that always passes.
+    later_event = _event(
+        "chain_register", seq=2, chain_id="c-walonly-req",
+        origin_depth=0, original_request="y",
+        requester={"agent_name": "other", "session_id": "sid-2"},
+    )
+    replayed = AgentSnapshot.load("agent_x", tmp_path / "snap-req.json")
+    replayed.apply_events([later_event])
+    assert replayed.pending_chains["c-walonly-req"]["requester"] == {
+        "agent_name": "other", "session_id": "sid-2",
+    }  # present WITH its event
+    truncated = AgentSnapshot.load("agent_x", tmp_path / "snap-req.json")
+    truncated.apply_events([])  # seq 2 event truncated
+    assert "c-walonly-req" not in truncated.pending_chains  # WAL-only state LOST
+
+
+def test_chain_register_replay_normalizes_legacy_origin_keys_into_requester(tmp_path: Path):
+    """Tier 2c: CLAUDE.md's recovery-feature PR gate, legacy-shape half —
+    a chain_register WAL event recorded BEFORE proposal 0067 P4e (flat
+    ``origin_agent``/``origin_sid`` keys, no ``requester`` key at all) must
+    still reconstruct a correct ``requester`` value, not a KeyError and not
+    a dropped field — the SAME truncate-survives shape as the test above,
+    but for an event generation this PR did not write. Falsifies the
+    normalization ``apply_events``'s ``chain_register`` branch performs at
+    replay time (see its own comment): baked into a saved snapshot, then
+    replayed past an empty (truncated) tail."""
+    snap = _snap("agent_x")
+    snap.apply_events([
+        _event(
+            "chain_register", seq=1, chain_id="c-legacy",
+            origin_agent="legacy-worker", origin_sid="legacy-sid",
+            origin_depth=0, original_request="x",
+        ),
+    ])
+    assert snap.pending_chains["c-legacy"]["requester"] == {
+        "agent_name": "legacy-worker", "session_id": "legacy-sid",
+    }
+    snap.save(tmp_path / "snap-legacy.json")
+    reloaded = AgentSnapshot.load("agent_x", tmp_path / "snap-legacy.json")
+    reloaded.apply_events([])  # TRUNCATE: the legacy event is gone
+    assert reloaded.pending_chains["c-legacy"]["requester"] == {
+        "agent_name": "legacy-worker", "session_id": "legacy-sid",
+    }, "a legacy-shape chain_register's normalized requester must survive truncation too"
 
 
 def test_chain_update_replay_writes_only_real_pending_chain_fields():

--- a/tests/core/test_await_quiescent.py
+++ b/tests/core/test_await_quiescent.py
@@ -58,7 +58,7 @@ async def test_await_quiescent_cancels_chain_timeout_timer_no_append(tmp_path):
     # The chain must be registered so the watchdog's "still pending?" check passes
     # and on_fire would actually run (otherwise the fire short-circuits).
     await session._chains.register(
-        chain_id="c1", from_user=True, depth=0, original_text="q", sender=None,
+        chain_id="c1", depth=0, original_text="q", sender=None,
     )
 
     async def _on_fire(chain_id: str) -> None:

--- a/tests/core/test_reset_for_rewind.py
+++ b/tests/core/test_reset_for_rewind.py
@@ -44,7 +44,7 @@ async def test_reset_for_rewind_then_restore_state_zero_residue(tmp_path):
     # ── populate pre-rewind live state (OLD markers) ──
     session.inbox.put_nowait(("user", {"text": "OLD"}))
     await session._chains.register(
-        chain_id="OLD-chain", from_user=True, depth=0,
+        chain_id="OLD-chain", depth=0,
         original_text="old", sender=None,
     )
     session._buffered_intervention_answers["OLD-run"] = InterventionAnswer(text="OLD")

--- a/tests/runtime/test_2103_A_ephemeral_auto_vanish_1953.py
+++ b/tests/runtime/test_2103_A_ephemeral_auto_vanish_1953.py
@@ -94,7 +94,7 @@ async def test_ephemeral_does_not_vanish_while_awaiting_delegation(tmp_path):
 
     # the spawned session delegated to a peer + awaits its response (pending chain;
     # the inbox is transiently empty between the delegate-send and the response).
-    await eph._chains.register(chain_id="c1", from_user=False, depth=1,
+    await eph._chains.register(chain_id="c1", depth=1,
                                original_text="sub", sender="alice", waiting_on={"peer"})
     eph._maybe_schedule_ephemeral_vanish()
     # drain any (erroneously) scheduled teardown so the assertion reflects the true

--- a/tests/runtime/test_a2a_handler_invariants.py
+++ b/tests/runtime/test_a2a_handler_invariants.py
@@ -375,7 +375,7 @@ async def test_multi_hop_pending_chain_registered(
     assert "peer_c" in pending.waiting_on, (
         "waiting_on must contain the delegated agent"
     )
-    assert pending.origin_agent == "upstream_a"
+    assert pending.requester.agent_name == "upstream_a"
 
     # No immediate upstream response should be sent (deferred path).
     upstream_responses = [r for r in responses if r["to"] == "upstream_a"]

--- a/tests/runtime/test_chain_manager_find_chain.py
+++ b/tests/runtime/test_chain_manager_find_chain.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.services.chain_manager import ChainManager, _PendingChain
 from reyn.runtime.services.snapshot_journal import SnapshotJournal
+from reyn.runtime.task_types import Requester
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -59,12 +60,11 @@ def test_find_chain_returns_pending_when_registered(tmp_path: Path):
     async def go():
         await mgr.register(
             chain_id="X-001",
-            from_user=False,
             depth=1,
             original_text="hello",
             sender="caller",
             waiting_on={"B"},
-            origin_agent="A",
+            requester=Requester(agent_name="A", session_id="main"),
             origin_depth=1,
         )
 
@@ -72,7 +72,7 @@ def test_find_chain_returns_pending_when_registered(tmp_path: Path):
     found = mgr.find_chain("X-001")
     assert isinstance(found, _PendingChain)
     assert found.chain_id == "X-001"
-    assert found.origin_agent == "A"
+    assert found.requester.agent_name == "A"
     assert found.waiting_on == {"B"}
 
 
@@ -89,12 +89,11 @@ def test_find_chain_is_read_only(tmp_path: Path):
     async def go():
         await mgr.register(
             chain_id="X-002",
-            from_user=False,
             depth=1,
             original_text="hi",
             sender="caller",
             waiting_on={"B"},
-            origin_agent="A",
+            requester=Requester(agent_name="A", session_id="main"),
             origin_depth=1,
         )
 
@@ -120,12 +119,11 @@ def test_find_chain_returns_none_after_resolve(tmp_path: Path):
     async def go():
         await mgr.register(
             chain_id="X-003",
-            from_user=False,
             depth=1,
             original_text="hi",
             sender="caller",
             waiting_on={"B"},
-            origin_agent="A",
+            requester=Requester(agent_name="A", session_id="main"),
             origin_depth=1,
         )
         await mgr.resolve("X-003")

--- a/tests/runtime/test_chain_manager_settle_3978.py
+++ b/tests/runtime/test_chain_manager_settle_3978.py
@@ -23,6 +23,7 @@ import pytest
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.services.chain_manager import ChainManager
 from reyn.runtime.services.snapshot_journal import SnapshotJournal
+from reyn.runtime.task_types import Requester
 
 
 class _NullEvents:
@@ -49,7 +50,7 @@ async def test_registered_kind_is_readable_back(tmp_path: Path):
     via ``get``/``find_chain`` (describe_task/list_tasks's own read path)."""
     mgr = _make_manager(tmp_path)
     await mgr.register(
-        chain_id="run-k1", from_user=False, depth=0, original_text="p", sender=None,
+        chain_id="run-k1", depth=0, original_text="p", sender=None,
         kind="pipeline",
     )
     assert mgr.get("run-k1").kind == "pipeline"
@@ -65,7 +66,7 @@ async def test_registered_kind_defaults_to_none_for_legacy_delegate_chains(
     value from any of prompt/pipeline/exec, not a crash."""
     mgr = _make_manager(tmp_path)
     await mgr.register(
-        chain_id="run-k2", from_user=False, depth=0, original_text="p", sender=None,
+        chain_id="run-k2", depth=0, original_text="p", sender=None,
     )
     assert mgr.get("run-k2").kind is None
 
@@ -79,8 +80,8 @@ async def test_requester_derives_from_origin_agent_and_sid(tmp_path: Path):
     origin_sid)"). Real, non-default sid."""
     mgr = _make_manager(tmp_path)
     chain = await mgr.register(
-        chain_id="run-k3", from_user=False, depth=0, original_text="p", sender=None,
-        origin_agent="worker", origin_sid="s7",
+        chain_id="run-k3", depth=0, original_text="p", sender=None,
+        requester=Requester(agent_name="worker", session_id="s7"),
     )
     assert chain.requester.agent_name == "worker"
     assert chain.requester.session_id == "s7"
@@ -97,8 +98,7 @@ async def test_requester_session_id_defaults_to_main_when_origin_sid_none(
     ``Requester``'s own type (``session_id: str``) can't even represent."""
     mgr = _make_manager(tmp_path)
     chain = await mgr.register(
-        chain_id="run-k4", from_user=False, depth=0, original_text="p", sender=None,
-        origin_agent="worker", origin_sid=None,
+        chain_id="run-k4", depth=0, original_text="p", sender="worker",
     )
     assert chain.requester.session_id == "main"
 
@@ -131,7 +131,7 @@ async def test_settle_deliver_runs_the_deliver_callback(tmp_path: Path):
     """Tier 2: on_settle="deliver" awaits the caller's own deliver callback."""
     mgr = _make_manager(tmp_path)
     await mgr.register(
-        chain_id="run-1", from_user=False, depth=0, original_text="p", sender=None,
+        chain_id="run-1", depth=0, original_text="p", sender=None,
     )
     calls = []
 
@@ -148,7 +148,7 @@ async def test_settle_drop_never_calls_deliver(tmp_path: Path):
     called (ADR-0040 D4: the disposition is intentionally discarded)."""
     mgr = _make_manager(tmp_path)
     await mgr.register(
-        chain_id="run-2", from_user=False, depth=0, original_text="p", sender=None,
+        chain_id="run-2", depth=0, original_text="p", sender=None,
     )
     calls = []
 
@@ -169,7 +169,7 @@ async def test_settle_pipeline_name_without_launcher_raises_not_implemented(
     launch-and-reroute mechanism is still unbuilt (proposal 0067 P4/P7)."""
     mgr = _make_manager(tmp_path)
     await mgr.register(
-        chain_id="run-3", from_user=False, depth=0, original_text="p", sender=None,
+        chain_id="run-3", depth=0, original_text="p", sender=None,
     )
 
     async def _deliver() -> None:
@@ -188,7 +188,7 @@ async def test_settle_pipeline_name_with_launcher_calls_it_with_the_name(
     pipeline name), not ``deliver``."""
     mgr = _make_manager(tmp_path)
     await mgr.register(
-        chain_id="run-4", from_user=False, depth=0, original_text="p", sender=None,
+        chain_id="run-4", depth=0, original_text="p", sender=None,
     )
     launched = []
 
@@ -213,7 +213,7 @@ async def test_settle_pops_the_handle_in_the_same_call(tmp_path: Path):
     the handle is gone from the manager (mirrors resolve()'s pop)."""
     mgr = _make_manager(tmp_path)
     await mgr.register(
-        chain_id="run-5", from_user=False, depth=0, original_text="p", sender=None,
+        chain_id="run-5", depth=0, original_text="p", sender=None,
     )
     assert mgr.has("run-5")
 
@@ -233,8 +233,8 @@ async def test_settle_returns_the_popped_handle(tmp_path: Path):
     off the return value after it's gone from the manager."""
     mgr = _make_manager(tmp_path)
     await mgr.register(
-        chain_id="run-6", from_user=False, depth=0, original_text="p", sender=None,
-        origin_agent="worker", origin_sid="s1",
+        chain_id="run-6", depth=0, original_text="p", sender=None,
+        requester=Requester(agent_name="worker", session_id="s1"),
     )
 
     async def _deliver() -> None:
@@ -243,8 +243,8 @@ async def test_settle_returns_the_popped_handle(tmp_path: Path):
     popped = await mgr.settle("run-6", on_settle="deliver", deliver=_deliver)
 
     assert popped is not None
-    assert popped.origin_agent == "worker"
-    assert popped.origin_sid == "s1"
+    assert popped.requester.agent_name == "worker"
+    assert popped.requester.session_id == "s1"
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_chain_peer_discarded_notify.py
+++ b/tests/runtime/test_chain_peer_discarded_notify.py
@@ -27,6 +27,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
+from reyn.runtime.task_types import Requester
 from tests._support.agent_session import make_session
 
 # ---------------------------------------------------------------------------
@@ -96,12 +97,11 @@ def test_handler_resolves_chain_and_emits_audit_event(tmp_path: Path):
         # A registers a chain waiting on B
         await sess_a.chains.register(
             chain_id="X-001",
-            from_user=True,
             depth=1,
             original_text="please research X",
             sender="user",
             waiting_on={"B"},
-            origin_agent="user",
+            requester=Requester(agent_name="user", session_id=""),
             origin_depth=0,
         )
         assert sess_a.chains.find_chain("X-001") is not None
@@ -152,12 +152,11 @@ def test_notify_finds_waiter_and_returns_true(tmp_path: Path):
     async def go():
         await sess_a.chains.register(
             chain_id="X-002",
-            from_user=True,
             depth=1,
             original_text="task",
             sender="user",
             waiting_on={"B"},
-            origin_agent="user",
+            requester=Requester(agent_name="user", session_id=""),
             origin_depth=0,
         )
         notified = await registry.notify_chain_discarded(
@@ -196,12 +195,11 @@ def test_notify_excludes_self_from_scan(tmp_path: Path):
         # B registers a chain (irrelevant to the discard)
         await sess_b.chains.register(
             chain_id="X-self",
-            from_user=False,
             depth=1,
             original_text="t",
             sender="caller",
             waiting_on={"C"},
-            origin_agent="A",
+            requester=Requester(agent_name="A", session_id=""),
             origin_depth=1,
         )
         # B notifies for the same chain_id

--- a/tests/runtime/test_multi_agent_p7.py
+++ b/tests/runtime/test_multi_agent_p7.py
@@ -40,6 +40,7 @@ from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.services.chain_manager import ChainManager
 from reyn.runtime.session import Session
+from reyn.runtime.task_types import Requester
 from reyn.runtime.topology import Topology
 from tests._support.agent_session import make_session
 from tests._support.paths import REPO_ROOT
@@ -142,22 +143,20 @@ async def test_two_simultaneous_delegations_both_resolve(tmp_path: Path):
     # test pure chain mechanics).
     await sess_a.chains.register(
         chain_id=chain_ab,
-        from_user=True,
         depth=1,
         original_text="task for B",
         sender=None,
         waiting_on={"B"},
-        origin_agent="",
+        requester=Requester(agent_name="", session_id="main"),
         origin_depth=0,
     )
     await sess_a.chains.register(
         chain_id=chain_ac,
-        from_user=True,
         depth=1,
         original_text="task for C",
         sender=None,
         waiting_on={"C"},
-        origin_agent="",
+        requester=Requester(agent_name="", session_id="main"),
         origin_depth=0,
     )
 
@@ -352,12 +351,11 @@ async def test_chain_resolve_does_not_inspect_skill_name():
     for cid in skill_like_ids:
         await mgr.register(
             chain_id=cid,
-            from_user=False,
             depth=1,
             original_text="request",
             sender="upstream",
             waiting_on={"downstream"},
-            origin_agent="upstream",
+            requester=Requester(agent_name="upstream", session_id="main"),
             origin_depth=1,
         )
 

--- a/tests/runtime/test_session_invariants.py
+++ b/tests/runtime/test_session_invariants.py
@@ -37,6 +37,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.session import Session
+from reyn.runtime.task_types import Requester
 from reyn.user_intervention import (
     InterventionAnswer,
     InterventionChoice,
@@ -238,9 +239,11 @@ async def test_chain_register_emits_wal_event(tmp_path, monkeypatch):
     session = _make_session(tmp_path, on_limit=OnLimitConfig(mode="unattended"))
 
     await session.chains.register(
-        chain_id="chain-reg-001", from_user=False, depth=1,
+        chain_id="chain-reg-001", depth=1,
         original_text="do something", sender="origin_agent",
-        waiting_on={"peer_agent"}, origin_agent="origin_agent", origin_depth=1,
+        waiting_on={"peer_agent"},
+        requester=Requester(agent_name="origin_agent", session_id="main"),
+        origin_depth=1,
     )
 
     await session._journal.flush()  # #2259 PR-2b: drain async WAL writes
@@ -254,10 +257,12 @@ async def test_chain_register_emits_wal_event(tmp_path, monkeypatch):
     assert ev.get("chain_id") == "chain-reg-001", (
         f"chain_id mismatch: {ev.get('chain_id')!r}"
     )
-    assert "origin_agent" in ev, f"Missing 'origin_agent' in WAL event: {ev}"
+    assert "requester" in ev, f"Missing 'requester' in WAL event: {ev}"
+    assert ev["requester"].get("agent_name") == "origin_agent", (
+        f"requester.agent_name mismatch in WAL event: {ev}"
+    )
     assert "origin_depth" in ev, f"Missing 'origin_depth' in WAL event: {ev}"
     assert "waiting_on" in ev, f"Missing 'waiting_on' in WAL event: {ev}"
-    assert "from_user" in ev, f"Missing 'from_user' in WAL event: {ev}"
 
     # Snapshot must reflect the chain as pending.
     snapshot = AgentSnapshot.load(session.agent_name, session._snapshot_path)
@@ -293,9 +298,11 @@ async def test_chain_resolve_clears_snapshot_and_emits_resolve(tmp_path, monkeyp
 
     # Phase 1: register a pending chain directly.
     await session.chains.register(
-        chain_id="chain-res-001", from_user=False, depth=1,
+        chain_id="chain-res-001", depth=1,
         original_text="synthesize", sender="origin_agent",
-        waiting_on={"peer_agent"}, origin_agent="origin_agent", origin_depth=1,
+        waiting_on={"peer_agent"},
+        requester=Requester(agent_name="origin_agent", session_id="main"),
+        origin_depth=1,
     )
     assert session.chains.has("chain-res-001"), (
         "Chain should be pending after registration"
@@ -384,9 +391,11 @@ async def test_chain_timeout_fires_upstream_error_and_emits_event(tmp_path, monk
     # timeout watchdog — the same two-call pairing every real producer uses
     # (inter_agent_messaging.py's own delegation registration site).
     await session.chains.register(
-        chain_id="chain-timeout-001", from_user=False, depth=1,
+        chain_id="chain-timeout-001", depth=1,
         original_text="do slow work", sender="upstream_agent",
-        waiting_on={"slow_peer"}, origin_agent="upstream_agent", origin_depth=1,
+        waiting_on={"slow_peer"},
+        requester=Requester(agent_name="upstream_agent", session_id="main"),
+        origin_depth=1,
     )
     session.chains.arm_timeout(
         "chain-timeout-001", on_fire=session._on_chain_timeout_fire,
@@ -489,7 +498,7 @@ async def test_restore_reconstructs_chains_and_inbox_from_snapshot(tmp_path, mon
     )
     pc = session.chains.get(chain_id)
     assert pc is not None
-    assert pc.origin_agent == "origin"
+    assert pc.requester.agent_name == "origin"
     assert "peer_agent" in pc.waiting_on
 
 
@@ -814,12 +823,11 @@ async def test_p6_chain_state_changes_emit_events(tmp_path, monkeypatch):
     # ── chain_register ────────────────────────────────────────────────────
     await session.chains.register(
         chain_id=chain_id,
-        from_user=False,
         depth=1,
         original_text="hello",
         sender="upstream",
         waiting_on={"downstream"},
-        origin_agent="upstream",
+        requester=Requester(agent_name="upstream", session_id="main"),
         origin_depth=1,
     )
 
@@ -1107,12 +1115,11 @@ async def test_peer_no_reply_marker_forwarded_upstream_in_pending_chain(
     chain_id = "chain-b2h2-relay-001"
     await session.chains.register(
         chain_id=chain_id,
-        from_user=False,
         depth=2,
         original_text="what is the recipe?",
         sender="origin_agent",
         waiting_on={"specialist"},
-        origin_agent="origin_agent",
+        requester=Requester(agent_name="origin_agent", session_id="main"),
         origin_depth=1,
     )
 

--- a/tests/tools/test_task_verbs_3978.py
+++ b/tests/tools/test_task_verbs_3978.py
@@ -16,6 +16,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.runtime.router_loop import RouterLoop
 from reyn.runtime.services.chain_manager import ChainManager
 from reyn.runtime.services.snapshot_journal import SnapshotJournal
+from reyn.runtime.task_types import Requester
 from reyn.tools.task_verbs import (
     _handle_cancel_task,
     _handle_describe_task,
@@ -57,8 +58,8 @@ async def test_describe_task_returns_full_shape_for_a_running_task(tmp_path: Pat
     session, requester} — for a real, registered running task."""
     mgr = _make_manager(tmp_path)
     await mgr.register(
-        chain_id="run-1", from_user=False, depth=0, original_text="p", sender=None,
-        origin_agent="worker", origin_sid="s1", kind="pipeline",
+        chain_id="run-1", depth=0, original_text="p", sender=None,
+        requester=Requester(agent_name="worker", session_id="s1"), kind="pipeline",
     )
 
     result = await _handle_describe_task({"task_id": "run-1"}, _ctx(mgr))
@@ -92,7 +93,7 @@ async def test_describe_task_excludes_untyped_legacy_delegate_chains(tmp_path: P
     caller didn't ask)."""
     mgr = _make_manager(tmp_path)
     await mgr.register(
-        chain_id="legacy-1", from_user=False, depth=0, original_text="p", sender="peer",
+        chain_id="legacy-1", depth=0, original_text="p", sender="peer",
     )
 
     result = await _handle_describe_task({"task_id": "legacy-1"}, _ctx(mgr))
@@ -117,8 +118,8 @@ async def test_describe_task_reports_session_inbox_depth(tmp_path: Path):
     the handler itself does no resolution)."""
     mgr = _make_manager(tmp_path)
     await mgr.register(
-        chain_id="run-depth", from_user=False, depth=0, original_text="p", sender=None,
-        origin_agent="worker", origin_sid="s1", kind="pipeline",
+        chain_id="run-depth", depth=0, original_text="p", sender=None,
+        requester=Requester(agent_name="worker", session_id="s1"), kind="pipeline",
     )
 
     result = await _handle_describe_task({"task_id": "run-depth"}, _ctx(mgr, inbox_depth=3))
@@ -133,7 +134,7 @@ async def test_describe_task_session_inbox_depth_defaults_to_none(tmp_path: Path
     would misread as "definitely empty")."""
     mgr = _make_manager(tmp_path)
     await mgr.register(
-        chain_id="run-nodepth", from_user=False, depth=0, original_text="p", sender=None,
+        chain_id="run-nodepth", depth=0, original_text="p", sender=None,
         kind="pipeline",
     )
 
@@ -151,11 +152,11 @@ async def test_list_tasks_lists_only_typed_running_tasks(tmp_path: Path):
     the {task_id, kind, status, session} list shape — no requester field."""
     mgr = _make_manager(tmp_path)
     await mgr.register(
-        chain_id="run-2", from_user=False, depth=0, original_text="p", sender=None,
-        origin_agent="worker", origin_sid=None, kind="pipeline",
+        chain_id="run-2", depth=0, original_text="p", sender=None,
+        requester=Requester(agent_name="worker", session_id="main"), kind="pipeline",
     )
     await mgr.register(
-        chain_id="legacy-2", from_user=False, depth=0, original_text="p", sender="peer",
+        chain_id="legacy-2", depth=0, original_text="p", sender="peer",
     )
 
     result = await _handle_list_tasks({}, _ctx(mgr))
@@ -177,10 +178,10 @@ async def test_list_tasks_session_inbox_depth_same_for_every_entry(tmp_path: Pat
     list_tasks can even see was registered with the same origin session."""
     mgr = _make_manager(tmp_path)
     await mgr.register(
-        chain_id="run-5", from_user=False, depth=0, original_text="p", sender=None, kind="pipeline",
+        chain_id="run-5", depth=0, original_text="p", sender=None, kind="pipeline",
     )
     await mgr.register(
-        chain_id="run-6b", from_user=False, depth=0, original_text="p", sender=None, kind="prompt",
+        chain_id="run-6b", depth=0, original_text="p", sender=None, kind="prompt",
     )
 
     result = await _handle_list_tasks({}, _ctx(mgr, inbox_depth=7))
@@ -194,11 +195,11 @@ async def test_list_tasks_filters_by_kind(tmp_path: Path):
     """Tier 2: a kind filter narrows the listing to matching tasks only."""
     mgr = _make_manager(tmp_path)
     await mgr.register(
-        chain_id="run-3", from_user=False, depth=0, original_text="p", sender=None,
+        chain_id="run-3", depth=0, original_text="p", sender=None,
         kind="pipeline",
     )
     await mgr.register(
-        chain_id="run-4", from_user=False, depth=0, original_text="p", sender=None,
+        chain_id="run-4", depth=0, original_text="p", sender=None,
         kind="prompt",
     )
 
@@ -225,7 +226,7 @@ async def test_cancel_task_calls_the_hook_and_returns_cancel_requested(tmp_path:
     mgr = _make_manager(tmp_path)
     calls = []
     await mgr.register(
-        chain_id="run-5", from_user=False, depth=0, original_text="p", sender=None,
+        chain_id="run-5", depth=0, original_text="p", sender=None,
         kind="pipeline", cancel=lambda: calls.append("cancelled"),
     )
 
@@ -243,7 +244,7 @@ async def test_cancel_task_without_a_live_hook_never_reports_success(tmp_path: P
     silent 'cancelled' while the task keeps running."""
     mgr = _make_manager(tmp_path)
     await mgr.register(
-        chain_id="run-6", from_user=False, depth=0, original_text="p", sender=None,
+        chain_id="run-6", depth=0, original_text="p", sender=None,
         kind="pipeline",  # no cancel= — mirrors a recovered handle
     )
 
@@ -273,7 +274,7 @@ async def test_cancel_task_untyped_legacy_chain_returns_error(tmp_path: Path):
     mgr = _make_manager(tmp_path)
     calls = []
     await mgr.register(
-        chain_id="legacy-3", from_user=False, depth=0, original_text="p", sender="peer",
+        chain_id="legacy-3", depth=0, original_text="p", sender="peer",
         cancel=lambda: calls.append("should not run"),
     )
 
@@ -308,8 +309,8 @@ async def test_describe_task_reaches_a_real_chain_manager_through_the_real_route
     (#2120's own spawn_session-advertised-but-undispatched precedent)."""
     mgr = _make_manager(tmp_path)
     await mgr.register(
-        chain_id="run-e2e", from_user=False, depth=0, original_text="p", sender=None,
-        origin_agent="worker", origin_sid="s1", kind="pipeline",
+        chain_id="run-e2e", depth=0, original_text="p", sender=None,
+        requester=Requester(agent_name="worker", session_id="s1"), kind="pipeline",
     )
     host = FakeRouterHost(chains=mgr)
     loop = RouterLoop(host=host, chain_id="chain-test")
@@ -340,8 +341,8 @@ async def test_describe_task_session_inbox_depth_reaches_production_wiring(
     constructed with ``inbox_depth=``."""
     mgr = _make_manager(tmp_path)
     await mgr.register(
-        chain_id="run-depth-e2e", from_user=False, depth=0, original_text="p", sender=None,
-        origin_agent="worker", origin_sid="s1", kind="pipeline",
+        chain_id="run-depth-e2e", depth=0, original_text="p", sender=None,
+        requester=Requester(agent_name="worker", session_id="s1"), kind="pipeline",
     )
     host = FakeRouterHost(chains=mgr, inbox_depth=5)
     loop = RouterLoop(host=host, chain_id="chain-test")


### PR DESCRIPTION
**[tui-coder]** — part of #3978 (P4e). Does **not** close P4e — two of P4e's three pieces (the `requester` materialization rename, `from_user`'s removal), scoped separately per lead-coder's explicit split (mechanical/fully-specified work first, in its own PR; the reply-routing producer+consumer fold is a separate, still-to-be-designed PR).

⚠️ **Branch name note**: this branch is named `feat/4131-...` because that was the next-expected PR number when I created it — #4131 was taken by an unrelated merge (`fix(#3978): drop the retired multi-hop delegate-relay diagram`) before I pushed. The actual PR number here will differ; the branch name is stale, not a mistake in the work itself.

## What (architect ruling, 2026-08-10, both raised as open questions before implementation)

**`requester`: one nested field, not two flat ones.** `_PendingChain.origin_agent`/`.origin_sid` (behind a derived `.requester` property) become ONE stored `requester: Requester` field. Reasons: `Requester`'s own docstring — "the pair is the address, not either half alone" — and #2130's own real incident (a missing `origin_sid` silently misdelivered a reply to `"main"`). A flat 2-key pair structurally permits writing one half without the other; a nested value does not. `origin_depth` stays separate (not part of `Requester`).

**`from_user`: removed entirely.** Confirmed (post-P6 re-measurement, posted to #3978): 2 production call sites, both pass `from_user=False` unconditionally; written to the WAL fields dict but never read back anywhere. Per the proposal's own framing — it feeds nothing, so it goes.

## WAL/journal shape — CLAUDE.md's recovery-feature gate applies

`register()`'s persisted `"requester"` key is a nested `{"agent_name", "session_id"}` dict. `AgentSnapshot.apply_events`'s `chain_register` branch (pure WAL-replay reconstruction) **normalizes** a pre-P4e event (old flat `origin_agent`/`origin_sid` keys, no `"requester"` key) into the same nested shape at replay time — every `pending_chains` entry this branch produces uses one shape regardless of which WAL-event generation wrote it.

Two new truncate-falsify tests (same PR, per the gate), falsify-verified (reverted, confirmed genuinely red, restored):
- `test_truncate_falsify_requester_survives_wal_truncation`
- `test_chain_register_replay_normalizes_legacy_origin_keys_into_requester`

## Test population — measured, not assumed

21 files reference `origin_agent`/`origin_depth`/`origin_sid`/`.requester` (pre-P6 SHA `e1936d1ef`, post-P6 SHA `3f8e6f825`, both posted to #3978 — P6 produced zero functional changes in this scope). A **separate** `from_user=` grep (not covered by the original needle) found 3 more files the original measurement missed — caught by a full repo-wide sweep after the mechanical rename, not assumed complete.

## Verification

- 114 tests across every touched file pass together.
- Broader sweep (`tests/runtime/ tests/core/ tests/tools/ tests/chat/ tests/llm/`, 5794 passed) — the only 14 failures are pre-existing, confirmed via `git stash` to fail **identically without this diff**: 13 are the known local `InvalidThemeError('ansi-dark')` signature (#3791's trap), 1 is a subprocess-import test failing because this machine's pip-installed `reyn` resolves to an unrelated sandbox path.
- ruff / mypy_ratchet / tier_audit / path-literal-reference / module-docstrings all clean.
- Rebased cleanly onto latest main (post #4131/#4132).

## Test plan

- [x] 114 scoped tests pass together
- [x] Broader sweep run, 14 pre-existing unrelated failures confirmed via git-stash control
- [x] ruff clean
- [x] mypy_ratchet clean
- [x] tier_audit --strict on all changed test files: 0 errors
- [x] path-literal-reference OK
- [x] module-docstrings OK
- [x] Recovery-feature gate: 2 truncate-falsify tests added, falsify-verified
- [ ] Visual — n/a, no UI surface
