### PR TITLE
docs(#4135): mark the multi-hop delegate substrate no-current-producer

### DIFF
--- a/docs/concepts/multi-agent/multi-agent.md
+++ b/docs/concepts/multi-agent/multi-agent.md
@@ -74,12 +74,10 @@ A single `AgentRegistry` instance per process owns all loaded agents and the Ses
 > `InterAgentMessaging.send_to_agent`, `_PendingChain` registration) is
 > still present in code but structurally unreachable — its sole consumer,
 > `delegate_to_agent`, was retired in proposal 0067 P6. No tool wired today
-> populates `dispatched`, so `register(waiting_on=...)` never fires.
-> Rewriting this section waits for P4e's second half (reply-routing), which
-> reactivates the same substrate under a different shape — `|waiting_on| ==
-> 1`, not the multi-hop join described below, which is permanently retired.
-> Read what follows as a description of the mechanism's pre-retirement
-> shape, not current behavior.
+> populates `dispatched`, so `register(waiting_on=...)` never fires. The
+> multi-hop join (`|waiting_on| >= 2`) this section describes is
+> permanently retired. Read what follows as a description of the
+> mechanism's pre-retirement shape, not current behavior.
 
 When a router decision emits `messages_to_agents: [{to, request}, ...]`, the Session routes each entry to the target's inbox as an `agent_request` payload:
 

--- a/docs/concepts/multi-agent/multi-agent.md
+++ b/docs/concepts/multi-agent/multi-agent.md
@@ -69,6 +69,18 @@ A single `AgentRegistry` instance per process owns all loaded agents and the Ses
 
 ## Agent-to-agent messaging
 
+> **No current producer** (architect ruling, #3978/#4135, 2026-08-10): the
+> substrate this section describes (`RouterCallerState.send_to_agent`,
+> `InterAgentMessaging.send_to_agent`, `_PendingChain` registration) is
+> still present in code but structurally unreachable — its sole consumer,
+> `delegate_to_agent`, was retired in proposal 0067 P6. No tool wired today
+> populates `dispatched`, so `register(waiting_on=...)` never fires.
+> Rewriting this section waits for P4e's second half (reply-routing), which
+> reactivates the same substrate under a different shape — `|waiting_on| ==
+> 1`, not the multi-hop join described below, which is permanently retired.
+> Read what follows as a description of the mechanism's pre-retirement
+> shape, not current behavior.
+
 When a router decision emits `messages_to_agents: [{to, request}, ...]`, the Session routes each entry to the target's inbox as an `agent_request` payload:
 
 ```

--- a/docs/reference/config/multi-agent.ja.md
+++ b/docs/reference/config/multi-agent.ja.md
@@ -31,9 +31,9 @@ safety:
 > **現行 producer 無し**（architect 裁定、#3978/#4135、2026-08-10）: この 2 つの設定が制御する
 > 多段 `messages_to_agents`/`_PendingChain` 機構は、今日は構造的に到達不能です — 唯一の
 > consumer だった `delegate_to_agent` は proposal 0067 P6 で退役しました。両設定とそれが
-> 構成する enforcement コードはそのまま残っており、P4e 後半が同じ substrate を 1:1 の形
-> （`|waiting_on| == 1`）で再活性化するのを待っています — 以下に記述する多段 join では
-> ありません。以下は退役前の姿の記述として読んでください。現行の挙動ではありません。
+> 構成する enforcement コードはそのまま残っています。以下に記述する多段 join
+> （`|waiting_on| >= 2`）は恒久的に退役済みです。以下は退役前の姿の記述として読んでください。
+> 現行の挙動ではありません。
 
 ## `safety.loop.max_agent_hops`（整数、デフォルト `3`）
 

--- a/docs/reference/config/multi-agent.ja.md
+++ b/docs/reference/config/multi-agent.ja.md
@@ -28,6 +28,13 @@ safety:
 
 完全なスキーマは [リファレンス: `reyn.yaml` — `safety` ブロック](reyn-yaml.md#safety-block) を参照してください。
 
+> **現行 producer 無し**（architect 裁定、#3978/#4135、2026-08-10）: この 2 つの設定が制御する
+> 多段 `messages_to_agents`/`_PendingChain` 機構は、今日は構造的に到達不能です — 唯一の
+> consumer だった `delegate_to_agent` は proposal 0067 P6 で退役しました。両設定とそれが
+> 構成する enforcement コードはそのまま残っており、P4e 後半が同じ substrate を 1:1 の形
+> （`|waiting_on| == 1`）で再活性化するのを待っています — 以下に記述する多段 join では
+> ありません。以下は退役前の姿の記述として読んでください。現行の挙動ではありません。
+
 ## `safety.loop.max_agent_hops`（整数、デフォルト `3`）
 
 ランタイムがそれ以上の送信を拒否する前に、agent 間メッセージチェーンが何ホップ深くトラバースできるかを制限します。LangGraph の再帰制限に倣っています。

--- a/docs/reference/config/multi-agent.md
+++ b/docs/reference/config/multi-agent.md
@@ -32,9 +32,8 @@ See [Reference: `reyn.yaml` — `safety` block](reyn-yaml.md#safety-block) for t
 > multi-hop `messages_to_agents`/`_PendingChain` mechanism these two
 > settings gate is structurally unreachable today — its sole consumer,
 > `delegate_to_agent`, was retired in proposal 0067 P6. Both settings and
-> the enforcement code they configure remain in place, waiting for P4e's
-> second half to reactivate the same substrate under a 1:1 shape
-> (`|waiting_on| == 1`) — not the multi-hop join this page describes below.
+> the enforcement code they configure remain in place. The multi-hop join
+> (`|waiting_on| >= 2`) this page describes below is permanently retired.
 > Read what follows as the pre-retirement shape, not current behavior.
 
 ## `safety.loop.max_agent_hops` (integer, default `3`)

--- a/docs/reference/config/multi-agent.md
+++ b/docs/reference/config/multi-agent.md
@@ -28,6 +28,15 @@ safety:
 
 See [Reference: `reyn.yaml` — `safety` block](reyn-yaml.md#safety-block) for the full schema.
 
+> **No current producer** (architect ruling, #3978/#4135, 2026-08-10): the
+> multi-hop `messages_to_agents`/`_PendingChain` mechanism these two
+> settings gate is structurally unreachable today — its sole consumer,
+> `delegate_to_agent`, was retired in proposal 0067 P6. Both settings and
+> the enforcement code they configure remain in place, waiting for P4e's
+> second half to reactivate the same substrate under a 1:1 shape
+> (`|waiting_on| == 1`) — not the multi-hop join this page describes below.
+> Read what follows as the pre-retirement shape, not current behavior.
+
 ## `safety.loop.max_agent_hops` (integer, default `3`)
 
 Caps how deep an agent-to-agent message chain may traverse before the runtime refuses further sends. Modeled after LangGraph's recursion limit.


### PR DESCRIPTION
**[docs-maintainer]** — Minimal fix per architect's ruling on #3978, tracking #4135.

## Finding

`docs/concepts/multi-agent/multi-agent.md`'s "Agent-to-agent messaging" section and `docs/reference/config/multi-agent.md`/`.ja.md`'s `max_agent_hops`/`chain_seconds` settings describe a multi-hop `messages_to_agents`/`_PendingChain` mechanism as current behavior. It's structurally unreachable today, not word-collision — traced the full call chain myself before posting to #4135:

- `RouterCallerState.send_to_agent`'s sole consumer was `delegate_to_agent.py` — retired in P6.
- `Session._send_to_agent` has zero remaining callers (`grep -rn "\._send_to_agent(" src/reyn/` — nothing).
- `grep -rn "\.send_to_agent\b" src/reyn/` across the whole tree turns up only the dead binding chain and comments — no live consumer anywhere.
- `dispatched` (the list `register(waiting_on=...)` reads) is therefore always empty; the registration branch never fires.

This matches architect's own falsification of an earlier claim on the same issue ("substrate is live via P4e's requester") — that conflated a call site being *updated* (P4e did touch `inter_agent_messaging.py:472`) with it being *executed* (nothing calls into it).

## Why minimal, not a full rewrite

Architect's ruling is the opposite of the website diagram's (#4130/#4131/#4133): there, the capability retired with no successor. Here, **P4e's second half reactivates the same substrate** under a different shape (`|waiting_on| == 1`, not the multi-hop join this content describes) — so a full rewrite now would be rewritten again once P4e lands. Minimal fix: mark the sections as pre-retirement/no-current-producer, leave the descriptive content in place as a starting point for the eventual rewrite.

## What changed

Added a `> **No current producer**` callout to all 3 files (`multi-agent.md`, `config/multi-agent.md`, `config/multi-agent.ja.md`), immediately before the section/settings it applies to. Section content itself untouched.

## Test plan

- [x] `python scripts/check_doc_anchors.py` — exit 0
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0 (remaining INFO lines are pre-existing ja-mirror gaps)
- [x] `python scripts/check_tests_path_literal_reference.py` (gate #6) — OK
- [x] Full call-chain trace performed directly against `src/reyn/`, not inferred from either party's claim in the broker thread

part of #4135 (full rewrite tracked there, deferred to post-P4e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



- [x] ✅ (解消 — 3 ファイルとも P4e 再活性化の主張を削除、確定事実のみ残った) [lead-coder] callout が「P4e 後半が同じ substrate を再活性化する」と書いているが、その producer は裁定待ち（#3978 ③）。戻るものを `_PendingChain`/`waiting_on` の登録と書き、producer は名指ししない



