### PR TITLE
docs(#4121): sync capability-profile.ja.md's #3429 dual-spelling fix

### DIFF
--- a/docs/concepts/runtime/capability-profile.ja.md
+++ b/docs/concepts/runtime/capability-profile.ja.md
@@ -171,13 +171,11 @@ tool_deny:
   - send_to_session
 ```
 
-**どちらの綴りで書いても、両方が deny されます。** `delegate_to_agent` と
-`delegate_to_agent` は 1 つの操作の 2 つの名前で、モデルに現在 *見えている* のがどちらかは
-[tool-use のセル](../tools-integrations/tool-use-schemes.md)とホスト設定で変わります。
-`tool_deny` のエントリは gate になる前に **invocable な全形**へ展開されるため
-(`_expand_tool_forms` — 手書きリストではなく `invoke_action` の alias テーブルから導出)、
-たまたま目にした方の綴りを書けばもう一方も deny されます。モデルの現在のツール一覧から
-名前を写して構いません。逆に、片方の経路だけを deny する手段ではありません。
+**各ツールは invocable な名前を 1 つだけ持ちます。** `#3429` が、かつて全アクションが
+併せ持っていた第二の catalog-qualified な綴り（例: `read_file` と並んで存在した旧
+`file__read`）を削除しました — `tool_deny` のエントリは現在、それが名指す名前だけを
+展開なしで deny します。モデルの現在のツール一覧から名前を写せば安全かつ十分です:
+別綴りで同じ操作に到達する経路はもう存在しません。
 
 ## 参照
 


### PR DESCRIPTION
**[docs-maintainer]** — Picking up #4121, filed by e2e-coder while doc-sweeping an unrelated small security-floor PR.

## What was stale

`docs/concepts/runtime/capability-profile.ja.md` (~line 173-177) still described the PRE-`#3429` mechanism: a `tool_deny` entry expanding to "all invocable forms" via a since-removed `_expand_tool_forms` alias-table lookup, framed as denying "both spellings" of a tool name. `#3429` removed the second, catalog-qualified spelling every action used to carry — there's no expansion step anymore; a `tool_deny` entry denies exactly the name it names. The EN sibling (`capability-profile.md`) already states this correctly right below the same YAML example — the `.ja.md`'s own `#3429` sync was apparently missed at the time.

## Also fixed

The literal `` `delegate_to_agent` と `delegate_to_agent` は1つの操作の2つの名前 `` duplicate-word bug e2e-coder flagged in the issue — itself evidence the paragraph predated `#3429` and was never revisited since.

## Fix

Rewrote to match the EN sibling's current framing: one invocable name per tool, `#3429` removed the second spelling, copying a name from the model's current tool list is safe and complete.

## Test plan

- [x] `python scripts/check_doc_anchors.py` — exit 0
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0 (remaining INFO lines are pre-existing ja-mirror gaps)
- [x] `python scripts/check_tests_path_literal_reference.py` (gate #6) — OK
- [x] Cross-checked against the EN sibling's current (accurate) prose before translating, not guessed

Closes #4121

🤖 Generated with [Claude Code](https://claude.com/claude-code)
