### PR TITLE
fix(#4142): C — remove the dead RouterCallerState.send_to_agent field

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -4036,9 +4036,6 @@ class RouterLoop:
         * Catalog ``_fn`` callables wrap RouterLoop's private helpers
           (``_list_agents`` / ``_describe_agent``) so the registry handlers
           stay decoupled from RouterLoopHost type.
-        * ``send_to_agent`` is bound with ``chain_id`` and ``depth=0`` at
-          population time so the delegate handler signature stays pure
-          ``(to, request)``.
 
         Forward-looking fields (``available_agents`` for schema enrichment,
         identity / cost / model context) are also populated so future handler
@@ -4062,11 +4059,6 @@ class RouterLoop:
         from reyn.tools.types import build_resource_caller_state
 
         resource_state = await build_resource_caller_state(self.host)
-
-        async def _send_to_agent_bound(*, to: str, request: str) -> None:
-            await self.host.send_to_agent(
-                to=to, request=request, depth=0, chain_id=self.chain_id,
-            )
 
         # #2103 S1bc: session-spawn binding. Only multi-session hosts (the chat
         # RouterHostAdapter) implement ``spawn_session``; a host without it leaves
@@ -4174,8 +4166,6 @@ class RouterLoop:
             # Catalog access (= activated handlers)
             list_agents_fn=self._list_agents,
             describe_agent_fn=self._describe_agent,
-            # Async dispatch (= activated handlers)
-            send_to_agent=_send_to_agent_bound,
             # Proposal 0067 P4d (#3978): run_prompt(collect="attached") dispatch
             # (None for non-multi-session hosts).
             run_prompt_result_fn=_run_prompt_result_bound,

--- a/src/reyn/runtime/services/inter_agent_messaging.py
+++ b/src/reyn/runtime/services/inter_agent_messaging.py
@@ -253,6 +253,12 @@ class InterAgentMessaging:
         guard, default 3). chain_id (PR14) identifies the logical request
         thread for cross-agent trace; it propagates verbatim to the target's
         inbox payload and is recorded in history meta + events.
+
+        Not the MCP tool ``reyn:send_to_agent`` (#4142) — same name, two
+        unrelated mechanisms: this is the internal transport
+        ``run_prompt(collect="async")`` (via ``Session._send_to_agent``)
+        delivers through; the MCP tool drives a target session's turn
+        directly via ``MessageBus.request`` and never reaches this method.
         """
         # FP-0005: extension granted by safety-limit checkpoint raises
         # the effective hop cap for this chain.

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -52,7 +52,7 @@ class RouterCallerState:
     Populated by RouterLoop / dispatch_tool when invoking a
     ToolDefinition handler in router context. Handlers that need
     session-scoped resources (agent registry, MCP servers, etc.)
-    or async-dispatch callbacks (send_to_agent)
+    or async-dispatch callbacks
     consume them via this object.
 
     All fields are Optional so test contexts can populate only the
@@ -90,10 +90,6 @@ class RouterCallerState:
     # this number.
     session_inbox_depth: "int | None" = None
 
-    # Async dispatch callbacks (= for delegate_to_agent / plan
-    # handlers that need to interact with chain / task lifecycle)
-    send_to_agent: Callable[..., Awaitable[Any]] | None = None
-
     # #2103 S1bc: session-spawn dispatch. The spawn_session handler spawns a
     # fresh-context session under the agent (rewind-tracked via session_spawned),
     # applies the per-session capability narrowing (S1a), and submits the task.
@@ -116,10 +112,10 @@ class RouterCallerState:
 
     # Proposal 0067 P5 (#3978): send_to_session dispatch — fire-and-forget
     # delivery to a peer (agent, session) via TurnOrigin.PEER_SESSION.
-    # Bound by RouterLoop with no pre-bound identity (the target agent/session
-    # are per-call args, unlike send_to_agent's chain_id); None when the host
-    # doesn't support multi-session delivery (= duck-typed / hasattr-guarded
-    # at caller-state build, same pattern as spawn_session_fn above).
+    # Bound by RouterLoop with no pre-bound identity — the target agent/
+    # session are per-call args; None when the host doesn't support
+    # multi-session delivery (= duck-typed / hasattr-guarded at
+    # caller-state build, same pattern as spawn_session_fn above).
     send_to_session_fn: Callable[..., Awaitable[Any]] | None = None
 
     # Proposal 0067 P4d (#3978): run_prompt(collect="attached") dispatch — sends
@@ -260,7 +256,7 @@ class RouterCallerState:
 # #2567: the host-derived subset of RouterCallerState — every field a
 # RouterHostAdapter (or compatible host) alone can populate, with NO
 # loop-local state (chain_id / budget / router_model / available_tool_names /
-# excluded_categories / send_to_agent / spawn_*_fn / topology_create_fn /
+# excluded_categories / spawn_*_fn / topology_create_fn /
 # catalog-callback / memory-callback fields — those belong to a live
 # RouterLoop turn and stay None here by construction).
 #

--- a/tests/runtime/test_pipeline_driver_resource_caller_state_2567.py
+++ b/tests/runtime/test_pipeline_driver_resource_caller_state_2567.py
@@ -156,8 +156,13 @@ async def test_resource_caller_state_factory_matches_router_loop_build(
     # side — proving the factory does NOT reach into loop-local state.
     assert from_loop.chain_id == "c1"
     assert from_factory.chain_id is None
-    assert from_loop.send_to_agent is not None
-    assert from_factory.send_to_agent is None
+    # send_to_agent (the original example here) removed in #4142 C — a
+    # RouterCallerState field with zero readers in src/reyn/tools/ (its
+    # sole prior consumer, delegate_to_agent, retired in proposal 0067 P6,
+    # #3978); list_agents_fn is the same "unconditionally loop-bound, no
+    # hasattr guard" shape _FakeHost above still exercises.
+    assert from_loop.list_agents_fn is not None
+    assert from_factory.list_agents_fn is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_tool_registry_invariants.py
+++ b/tests/tools/test_tool_registry_invariants.py
@@ -346,7 +346,7 @@ def test_router_caller_state_defaults_all_none():
     state = RouterCallerState()
     assert state.agent_registry is None
     assert state.available_agents is None
-    assert state.send_to_agent is None
+    assert state.send_to_session_fn is None
     assert state.chain_id is None
     assert state.budget is None
     assert state.router_model is None
@@ -409,7 +409,7 @@ def test_router_caller_state_partial_population():
 
     assert state.agent_registry is sentinel_registry
     assert state.available_agents is None
-    assert state.send_to_agent is None
+    assert state.send_to_session_fn is None
     assert state.chain_id is None
     assert state.budget is None
     assert state.router_model is None
@@ -423,13 +423,13 @@ def test_router_caller_state_full_population():
     sentinel_budget = object()
     sentinel_memory = object()
 
-    async def _send_to_agent(*a, **kw):
+    async def _send_to_session(*a, **kw):
         pass
 
     state = RouterCallerState(
         agent_registry=sentinel_agent_reg,
         available_agents=[{"name": "a1"}],
-        send_to_agent=_send_to_agent,
+        send_to_session_fn=_send_to_session,
         chain_id="chain-xyz",
         budget=sentinel_budget,
         router_model="openai/gpt-4o",
@@ -439,7 +439,7 @@ def test_router_caller_state_full_population():
 
     assert state.agent_registry is sentinel_agent_reg
     assert state.available_agents == [{"name": "a1"}]
-    assert state.send_to_agent is _send_to_agent
+    assert state.send_to_session_fn is _send_to_session
     assert state.chain_id == "chain-xyz"
     assert state.budget is sentinel_budget
     assert state.router_model == "openai/gpt-4o"


### PR DESCRIPTION
**[e2e-coder]** — #4142 C: remove the dead `RouterCallerState.send_to_agent` field.

## What

Architect ruling (#4142, 2026-08-10, `main@a4c1cd76` measured): `send_to_agent` sits in 3 layers, one of which is dead residue causing real confusion — the owner, lead-coder, and tui-coder each separately misread this name.

| Layer | What | Status |
|---|---|---|
| ① MCP tool | `reyn:send_to_agent(agent_name, message)` (`mcp/server.py`) | ✅ live (external clients) |
| ② internal transport | `InterAgentMessaging.send_to_agent(...)` | ✅ live — what `run_prompt(collect="async")` delivers through (via `Session._send_to_agent`) |
| ③ LLM-visible tool | — | 🔴 **absent**. Its sole reader, `delegate_to_agent`, retired in proposal 0067 P6 (#4128) |

③'s residue: `RouterCallerState.send_to_agent` kept being injected (`router_loop.py`'s `_send_to_agent_bound` bound it unconditionally on every turn) with **zero readers** in `src/reyn/tools/` — which is what made ③ look alive when it wasn't.

## C: remove the residue

- `RouterCallerState.send_to_agent` field (`types.py`) — deleted, plus its docstring/comment mentions.
- `_send_to_agent_bound` closure + its field assignment (`router_loop.py`) — deleted. Confirmed zero other references before removing (architect had flagged this as unmeasured).
- Docstring bullet describing the `send_to_agent` bind convention — removed (`_build_router_caller_state`'s docstring).

Verified independently (not just trusting the report): zero readers of `RouterCallerState.send_to_agent` anywhere in `src/reyn/` — grepped for the attribute-access pattern specifically (`router_state.send_to_agent` / `caller_state.send_to_agent` / dict-style access), not just the field name (which also appears in ~15 test files, all of which construct the **unrelated** `SendToAgentInputs(send_to_agent=..., delegation_tracker=...)` bundle `RouterHostAdapter` uses for a different purpose entirely — confirmed by reading `RouterHostAdapter.send_to_agent()`'s own body).

## A rejected, B is one docstring line (architect's ruling, not re-litigated)

A (rename ②) was rejected — ② is the live, correctly-working side; renaming it to fix confusion ③'s residue created punishes the wrong layer, and doesn't even remove the confusion (① still shares the name). B is not a doc section (architect: "a section explains what could be deleted" — wrong order) — one docstring line on `InterAgentMessaging.send_to_agent` stating it is NOT the MCP tool. Verified the premise before writing it: read `mcp/server.py`'s `send_to_agent_impl` — it drives the target session's turn directly via `MessageBus.request`, never reaching `InterAgentMessaging.send_to_agent` at all. ② and ① share nothing but the name; the docstring line is accurate, not an assumption.

## Residue found, NOT in scope, flagged separately

`RouterLoopHost.send_to_agent` (the **protocol method itself** — `router_loop.py`'s interface + `RouterHostAdapter`'s implementation) has **zero remaining callers** in `src/reyn/` after this PR (its only caller was the closure just removed). This is a deeper layer than what was assigned ("field + bind") — not unilaterally removed here; flagging for lead-coder/architect to rule on separately, since it touches the Protocol interface itself and I haven't verified no OTHER `RouterLoopHost` implementation depends on it existing.

## Tests

3 tests in `test_tool_registry_invariants.py` constructed `RouterCallerState(send_to_agent=...)` directly as an example "async dispatch callback" field — swapped for `send_to_session_fn` (a live one, same category). 1 test in `test_pipeline_driver_resource_caller_state_2567.py` used `send_to_agent` as an example of a "loop-local, unconditionally-bound" field (unlike the hasattr-guarded `spawn_session_fn` etc., which the test's `_FakeHost` doesn't implement) — swapped for `list_agents_fn`, the same shape.

## Verification

- Consumer sweep: grepped the whole repo for both the attribute-access pattern and the field-name-as-kwarg pattern; confirmed the ~15 `SendToAgentInputs(send_to_agent=...)` test call sites are unrelated.
- Full scoped sweep: `tests/runtime/` + `tests/core/` + `tests/chat/` + `tests/tools/` + `tests/llm/` (excluding known-flaky textual tests): **5786 passed, 2 skipped, 10 failed** — all 10 confirmed pre-existing via `git stash` (same set #4140's sweep found: the #3791 "ansi-dark" trap and an unrelated image-resolution e2e suite). The 1 additional flake #4140's sweep saw once (`test_intervention_agent_subscriber.py`) did NOT recur here, consistent with it being a genuine inter-file test-order flake rather than anything in this diff's scope.
- 151 tests across every directly-touched/consumer file.

## Gates

- `ruff check src tests` — clean
- `test_tier_audit.py --strict` — 34 inspected, 0 errors
- `verify_module_docstrings.py` — OK
- `mypy_ratchet.py` — 210 findings, all baselined
- `check_file_depth_reference.py` — OK
- `check_tests_path_literal_reference.py` — 118 references, all baselined

## Test plan

- [x] `ruff check src tests`
- [x] `test_tier_audit.py --strict` on changed test files
- [x] `verify_module_docstrings.py` on changed src files
- [x] `mypy_ratchet.py`
- [x] `check_file_depth_reference.py`
- [x] `check_tests_path_literal_reference.py`
- [x] Scoped `pytest` — 151 passed on every consumer file
- [x] Full `tests/runtime`+`tests/core`+`tests/chat`+`tests/tools`+`tests/llm` sweep — 5786 passed, 10 pre-existing failures confirmed via `git stash`

part of #4142

🤖 Generated with [Claude Code](https://claude.com/claude-code)
