### PR TITLE
fix(#4113): reyn run-once no longer spawns a self-running runner

### DIFF
--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -809,7 +809,16 @@ def _run(args: argparse.Namespace) -> None:
         if not skip_restore:
             if not await _safe_restore():
                 return False
-        await registry.attach(name)
+        # #4113, architect ruling 2026-08-10: start_runner=False — `_run_once`
+        # (below) drives the session to completion itself via
+        # send_to_agent_impl's MessageBus.request pump; a background
+        # session.run() task would race that SAME pump on the identical
+        # Session object (the exact same-process double-pump architect's
+        # ruling names). `attach()` still LOADS the scoped session (so
+        # send_to_agent_impl's own get_or_load fallback finds this
+        # already-scoped session, not a fresh unscoped one) — only the
+        # runner is skipped.
+        await registry.attach(name, start_runner=False)
         return True
 
     async def _main_chat() -> None:

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -3269,10 +3269,29 @@ class AgentRegistry:
             EventFrame(Event(type="session_attached", data={"agent": name, "session_id": sid}))
         )
 
-    async def attach(self, name: str) -> "object":
+    async def attach(self, name: str, *, start_runner: bool = True) -> "object":
         """Switch the attached agent to `name`. Loads + starts session.run()
         and the outbox forwarder for the new agent if not already running.
-        Old agent stays in `self._tasks` (background)."""
+        Old agent stays in `self._tasks` (background).
+
+        ``start_runner`` (#4113, architect ruling 2026-08-10): False skips
+        ONLY the ``asyncio.create_task(new_session.run())`` line below —
+        load happens regardless (``get_or_load`` a few lines down), and
+        every other side effect (forwarder, focus-listener wiring,
+        connection switch, announce, pending-intervention replay) is
+        UNCHANGED. Exists for ``reyn run-once``: fixing the "violating
+        side" of a same-process double-pump (`registry.attach()`'s own
+        background `session.run()` loop racing `send_to_agent_impl`'s
+        inline `MessageBus.request` pump on the identical Session object —
+        the exact shape `a2a.py`'s "self-running OR inline-driven, never
+        both" invariant forbids) rather than adding a generic "refuse if a
+        runner exists" gate at the pump layer, which would break every
+        already-shipped MCP/A2A caller that legitimately drives a
+        self-running session inline today (architect: the same
+        "fix becomes an outage" shape as the MCP double-pump warning,
+        this time concrete). `_run_once`'s own design never needed the
+        runner — it drives the session to completion via
+        `send_to_agent_impl` itself; the runner's job (nothing else)."""
         # #3671 P3: a fresh attach attempt (or its `get_or_load` below, which
         # can itself raise) is never shadowed by a PRIOR background attempt's
         # recorded failure — clear it up front rather than only on success,
@@ -3300,7 +3319,7 @@ class AgentRegistry:
             self._wire_focus_listeners(new_session)
         # Boot session.run() + forwarder on first attach. Keep them alive
         # across detach/re-attach cycles — shutdown drains via `running_tasks()`.
-        if key not in self._tasks or self._tasks[key].done():
+        if start_runner and (key not in self._tasks or self._tasks[key].done()):
             self._tasks[key] = asyncio.create_task(new_session.run())
         if key not in self._forward_tasks or self._forward_tasks[key].done():
             self._forward_tasks[key] = asyncio.create_task(

--- a/tests/runtime/test_attach_no_runner_4113.py
+++ b/tests/runtime/test_attach_no_runner_4113.py
@@ -1,0 +1,224 @@
+"""Tier 2: #4113, architect ruling 2026-08-10 — ``AgentRegistry.attach(...,
+start_runner=False)`` skips ONLY the background ``session.run()`` task,
+nothing else.
+
+Context: ``reyn run-once`` (`interfaces/cli/commands/chat.py`'s
+`_restore_and_attach`) used to call bare ``registry.attach(name)`` — which
+unconditionally spawns a background ``session.run()`` loop on the SAME
+Session object `_run_once` then drives inline via
+``send_to_agent_impl``'s ``MessageBus.request`` pump. Both pumps
+(``run_one_iteration()``) run concurrently on the identical Session, in
+the identical process — the exact "self-running AND inline-driven"
+violation `a2a.py`'s own invariant forbids ("never both"). Fully
+demonstrated by reading the code (measured, #4113 issue comment), not
+requiring a live reproduction to know it's real.
+
+Fix (this PR): fix the VIOLATING SIDE (`attach()`'s own call site in
+`run-once`), not a generic pump-layer gate — a generic "refuse if a
+runner exists" gate at the pump layer would break every already-shipped
+MCP/A2A caller that legitimately drives a self-running session inline
+today (architect's own MCP double-pump warning, same shape, this time
+concrete: "the fix becomes an outage").
+
+Pins:
+  1. ``start_runner=False`` — no `session.run()` task is created for that
+     key, but the session IS still loaded (``get_or_load``) and the
+     forwarder/focus-listener/connection-switch/announce side effects are
+     UNCHANGED (only the runner is skipped).
+  2. Default (``start_runner=True``, the un-named param — every existing
+     caller) is byte-identical to before: a runner IS created. This is
+     the accept-side sibling proving the new param doesn't silently
+     change the default caller's behavior.
+  3. Falsify pair: with `start_runner=False`, `MessageBus.request`
+     (`_run_once`'s own pump) does NOT race a background task — confirmed
+     by the ABSENCE of that task, not by trusting the flag alone.
+
+All assertions go through ``AgentRegistry.is_session_running(name, sid)``
+(a public read, not private-state access) — the SAME predicate
+``attach``/``ensure_running``/``ensure_session_running`` already re-derive
+inline before creating a new task.
+
+The registry-level tests above pin the MECHANISM (does `start_runner=`
+actually gate task creation); the module also includes a BEHAVIORAL
+witness (below) — driving the REAL `reyn chat --once` entry point and
+observing, from a public read, that no runner is live while the session
+is driven inline — pinning that `chat.py`'s own once-path call site
+actually USES the mechanism. The mechanism working correctly is not
+evidence the call site uses it (same "declared vs. executed" trap this
+whole issue's own thread hit twice already: lead-coder's premature
+"substrate is live" claim, and this session's own re-measurement habit).
+A first version of this witness read `chat.py`'s source and matched the
+literal call string — lead-coder correctly blocked it (six-question ②:
+transcribing the implementation back as the assertion only fails if both
+sides are edited together, and false-positives on any refactor that
+keeps behavior but changes call syntax); replaced with the behavioral
+version below.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
+from tests._support.agent_session import make_session
+
+
+def _registry(tmp_path):
+    shared = BudgetTracker(CostConfig())
+
+    def factory(profile: AgentProfile):
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            output_language="en",
+            budget_tracker=shared,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_start_runner_false_loads_but_does_not_spawn_a_run_task(tmp_path):
+    """Tier 2: the #4113 fix's core pin — attach(start_runner=False) loads
+    the session (get_or_load) but starts NO background session.run() task
+    for (name, "main")."""
+    reg = _registry(tmp_path)
+
+    session = await reg.attach("alpha", start_runner=False)
+
+    assert session is not None
+    assert not reg.is_session_running("alpha", _DEFAULT_SID), (
+        "start_runner=False must not create a session.run() task"
+    )
+
+    await reg.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_default_start_runner_still_spawns_a_run_task(tmp_path):
+    """Tier 2: accept-side sibling — every EXISTING caller (bare
+    `registry.attach(name)`, no kwarg) keeps byte-identical behavior. The
+    new param's default must not silently change what already ships."""
+    reg = _registry(tmp_path)
+
+    session = await reg.attach("alpha")
+
+    assert session is not None
+    assert reg.is_session_running("alpha", _DEFAULT_SID), (
+        "the default (start_runner=True) must still create a session.run() task"
+    )
+
+    await reg.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_falsify_start_runner_false_actually_prevents_the_race(tmp_path):
+    """Tier 2c: falsify — confirms the fix by first calling attach() the
+    OLD way (bare, no start_runner kwarg — exactly what reyn run-once
+    used to do) and observing that a run() task DOES then exist for the
+    once-path's key, before a fresh registry with the real
+    start_runner=False call confirms it's absent. Proves the assertions
+    above are meaningfully load-bearing, not trivially true regardless of
+    the parameter."""
+    old_reg = _registry(tmp_path / "old")
+    await old_reg.attach("alpha")
+    assert old_reg.is_session_running("alpha", _DEFAULT_SID), (
+        "sanity check: the pre-fix call shape genuinely creates a runner "
+        "(if this fails, the falsify below proves nothing)"
+    )
+    await old_reg.shutdown()
+
+    fixed_reg = _registry(tmp_path / "fixed")
+    await fixed_reg.attach("alpha", start_runner=False)
+    assert not fixed_reg.is_session_running("alpha", _DEFAULT_SID), (
+        "the fix must prevent the runner that the falsify step just proved "
+        "the old call shape creates"
+    )
+    await fixed_reg.shutdown()
+
+
+def _run_chat_once(tmp_path, monkeypatch, *, on_send=None):
+    """Drive the REAL `reyn chat --once` entry point (`chat.run(args)`) —
+    mirrors `test_startup_dedup_3671_p4a.py`'s `_run_chat_once` exactly
+    (same substitutions: fake `send_to_agent_impl`, stdin). `on_send`, if
+    given, is called with the LIVE `registry` from inside the fake send —
+    the exact moment the real one would be pumping the session inline,
+    so a caller can observe registry state precisely where the old bug's
+    race would have been active."""
+    import argparse
+    import io
+
+    from reyn.interfaces.cli.commands.chat import register as chat_register
+
+    monkeypatch.chdir(tmp_path)
+    top = argparse.ArgumentParser()
+    sub = top.add_subparsers()
+    chat_register(sub)
+    args = top.parse_args(["chat"])
+    args.once = True
+
+    async def _fake_send(registry, *, agent_name, message, timeout=0,
+                          intervention_override=None, sid=None,
+                          inbox_kind="user") -> dict:
+        if on_send is not None:
+            on_send(registry, agent_name)
+        return {"reply": "ok", "limit_stopped": False}
+
+    monkeypatch.setattr("reyn.mcp.server.send_to_agent_impl", _fake_send)
+    monkeypatch.setattr("sys.stdin", io.StringIO("hi"))
+
+    from reyn.interfaces.cli.commands import chat as chat_mod
+    chat_mod.run(args)
+
+
+def test_run_once_path_has_no_live_runner_while_driving_inline(tmp_path, monkeypatch):
+    """Tier 2: behavioral witness on the REAL once-path, replacing an
+    earlier static-source version lead-coder correctly blocked (six-
+    question ②: transcribing the implementation's own call-string back
+    as the assertion only fails if BOTH sides are edited together, and
+    false-positives on any refactor that keeps behavior but changes call
+    syntax). This drives the ACTUAL `reyn chat --once` entry point
+    (`chat.run(args)`, same harness `test_startup_dedup_3671_p4a.py`
+    uses) and observes `AgentRegistry.is_session_running` (public) from
+    INSIDE the faked `send_to_agent_impl` — the exact moment the real
+    pump would be racing a background runner if the fix were absent."""
+    observed = {}
+
+    def _observe(registry, agent_name):
+        observed["is_running"] = registry.is_session_running(agent_name, _DEFAULT_SID)
+
+    _run_chat_once(tmp_path, monkeypatch, on_send=_observe)
+
+    assert observed.get("is_running") is False, (
+        "reyn chat --once must not have a live session.run() runner while "
+        "send_to_agent_impl drives the session inline — a live runner here "
+        "would race the inline pump on the identical Session object (#4113)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_interactive_path_still_starts_a_live_runner(tmp_path):
+    """Tier 2: accept-side sibling — `_background_attach` (the REAL,
+    independently-importable function `reyn chat`'s interactive path
+    calls — module-level per its own docstring, not a nested closure)
+    still starts a runner. Confirms the fix is scoped to the once-path
+    only — an interactive `reyn chat` session IS the legitimate
+    self-running case this whole invariant exists to protect."""
+    from reyn.interfaces.cli.commands.chat import _background_attach
+
+    reg = _registry(tmp_path)
+
+    await _background_attach(reg, "alpha", skip_restore=True)
+
+    assert reg.is_session_running("alpha", _DEFAULT_SID), (
+        "_background_attach (reyn chat's interactive path) must still "
+        "start a live runner — unaffected by the #4113 once-path fix"
+    )
+
+    await reg.shutdown()


### PR DESCRIPTION
**[tui-coder]** — part of #4113. Fixes the concrete, same-process double-pump: `reyn run-once` starts a background `session.run()` runner AND drives the same Session inline via `send_to_agent_impl`, both calling `run_one_iteration()` on the identical object concurrently, no MCP or external actor needed.

## Architect ruling (2026-08-10)

Fix the VIOLATING SIDE (`attach()`'s own call site in run-once), not a generic pump-layer gate — a generic "refuse if a runner exists" gate would break every already-shipped MCP/A2A caller that legitimately drives a self-running session inline today (the same "the fix becomes an outage" shape as architect's earlier MCP double-pump warning, this time concrete). `run_prompt`'s own tool-layer refusal is unchanged — different layer, different reasoning.

## The fix

`AgentRegistry.attach(name, *, start_runner: bool = True)` — gates ONLY the `session.run()` task spawn; every other side effect (load, forwarder, focus-listener, announce, connection switch) is unchanged. `chat.py`'s once-path passes `start_runner=False`; the interactive path is untouched (a real interactive session IS the legitimate self-running case).

Swept for other shipped `attach()` + inline-drive combinations (lead-coder's ask): only 2 real call sites exist repo-wide, AG-UI moved off `attach()` to `ensure_running` already, the A2A router always passes a non-"main" sid.

## Tests (5, `tests/runtime/test_attach_no_runner_4113.py`)

Registry-level mechanism pins + falsify pair, plus a behavioral witness driving the REAL `reyn chat --once` entry point and observing `is_session_running` (public) from inside the faked `send_to_agent_impl` — the exact moment the race would be live. A first version statically matched `chat.py`'s source string; lead-coder correctly blocked it (six-question ②: transcribes the implementation as the assertion, false-positives on any syntax-preserving refactor) — replaced with the behavioral version, falsify-verified correctly this time.

## Verification

- All 5 tests falsify-verified (reverted the fix, confirmed genuinely red via observed runtime state, not a string match; restored).
- `tests/runtime/` (1640 tests) — only the 10 known pre-existing, unrelated `InvalidThemeError`/subprocess-import failures already confirmed via git-stash control earlier tonight.
- 85 targeted CLI/interfaces/startup tests most likely affected by an `AgentRegistry.attach()` change — all pass.
- ruff / mypy_ratchet / tier_audit --strict / path-literal-reference / module-docstrings all clean.
- Branched fresh off latest main.

## Test plan

- [x] 5 tests pass, falsify-verified (including a self-correction on the first witness version)
- [x] `tests/runtime/` full sweep — only known pre-existing unrelated failures
- [x] 85 targeted CLI/interfaces tests pass
- [x] ruff clean
- [x] mypy_ratchet clean
- [x] tier_audit --strict: 0 errors
- [x] path-literal-reference OK
- [x] module-docstrings OK
- [ ] Visual — n/a, no UI surface
