### PR TITLE
fix(#4150): remove dead RouterLoopHost.send_to_agent protocol member + adapter impl

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -467,7 +467,7 @@ class RouterLoopCore(Protocol):
     is the only production implementor today.)
 
     The chat-extras (agents/mcp/memory/web/file/reyn_repo/embedding/
-    discovery/spawn/send_to_agent) live on ``RouterLoopHost`` below; they are
+    discovery/spawn) live on ``RouterLoopHost`` below; they are
     reached only via the chat-discovery setup, the chat system-prompt build, or
     chat-dispatch handlers.
     """
@@ -620,10 +620,6 @@ class RouterLoopHost(RouterLoopCore, Protocol):
     async def reyn_repo_read(self, *, path: str) -> dict:
         """RouterLoopHost: read the file at ``<reyn_root>/path`` as text."""
         ...
-
-    # Action callbacks (async)
-    async def send_to_agent(self, *, to: str, request: str, depth: int,
-                            chain_id: str) -> None: ...
 
     # Proposal 0067 P1' (#3978): mark the session's current_task as
     # outstanding — called from the async-dispatch block below, right before
@@ -4089,7 +4085,7 @@ class RouterLoop:
         # Proposal 0067 P5 (#3978): send_to_session binding (mirror
         # session-spawn). Only multi-session hosts implement it; a host
         # without it leaves this None. No pre-bound identity — target
-        # agent/session are per-call args, unlike send_to_agent's chain_id.
+        # agent/session are per-call args.
         _send_to_session_bound: Any = None
         if hasattr(self.host, "send_to_session") and callable(
             getattr(self.host, "send_to_session", None)

--- a/src/reyn/runtime/services/__init__.py
+++ b/src/reyn/runtime/services/__init__.py
@@ -16,7 +16,6 @@ from reyn.runtime.services.router_host_adapter import (
     McpGatewayInputs,
     PutOutboxInputs,
     RouterHostAdapter,
-    SendToAgentInputs,
 )
 from reyn.runtime.services.router_loop_driver import RouterLoopDriver
 from reyn.runtime.services.snapshot_journal import SnapshotJournal

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -79,20 +79,6 @@ class McpGatewayInputs:
 
 
 @dataclass(frozen=True)
-class SendToAgentInputs:
-    """#3482: the two params whose consumer set is EXACTLY
-    ``{adapter.send_to_agent, router_loop::_send_to_agent_bound}`` — the peer
-    dispatch callback and the tracker its result is appended to. One dedicated
-    method reads both and nothing else does, so they travel together.
-
-    Pure value object — no defaults, no construction logic (see
-    :class:`McpGatewayInputs`'s docstring for the rationale)."""
-
-    send_to_agent: "Callable[..., Awaitable[None]]"
-    delegation_tracker: "Callable[[], list[dict] | None]"
-
-
-@dataclass(frozen=True)
 class PutOutboxInputs:
     """#3482: the two params whose consumer set is EXACTLY
     ``{adapter.put_outbox, router_loop::run_loop}`` — the raw outbox put and
@@ -218,11 +204,6 @@ class RouterHostAdapter:
           registry / pipeline executor (spawn-time flip), mirroring
           ``live_session_id_fn``'s same staleness hazard. ``None`` (test
           construction) behaves as never-ephemeral.
-    send_to_agent_inputs:
-        :class:`SendToAgentInputs` — the peer-dispatch callback ``(*, to,
-        request, depth, chain_id) -> None`` plus the ``list[dict] | None``
-        delegation tracker it records into (#3482 bundle: exact consumer-set
-        match on ``send_to_agent``).
     put_outbox_inputs:
         :class:`PutOutboxInputs` — the raw ``(OutboxMessage) -> None`` put plus
         the ``list[str] | None`` agent-replies tracker (#3482 bundle: exact
@@ -309,7 +290,6 @@ class RouterHostAdapter:
         # cluster (#3482); ``append_history`` stays bare because its consumer
         # set is strictly larger than ``put_outbox``'s (append_history_entry
         # reads it too).
-        send_to_agent_inputs: SendToAgentInputs,
         put_outbox_inputs: PutOutboxInputs,
         append_history: Callable,
         # #3792: mid-turn CLIENT_INPUT injection — a peek/commit pair, both
@@ -486,7 +466,6 @@ class RouterHostAdapter:
     ) -> None:
         self._op_ctx_source = op_context_source
         self._mcp_gateway = mcp_gateway_inputs
-        self._send_to_agent_in = send_to_agent_inputs
         self._put_outbox_in = put_outbox_inputs
         self._live_sid_in = live_session_id_inputs
         self._threat_scan = threat_scan
@@ -559,9 +538,16 @@ class RouterHostAdapter:
         # #3447/#3482: raw inputs for the 5 mcp_list_* methods this adapter
         # implements directly (folded off Session — see class docstring),
         # bundled into mcp_gateway_inputs (single reader: _mcp_list_via_gateway).
-        # Action callbacks — the dispatch/outbox pairs live on their #3482
-        # bundles (``self._send_to_agent_in`` / ``self._put_outbox_in``); the
-        # ``send_to_agent`` / ``put_outbox`` methods read them there.
+        # Action callbacks — the outbox put lives on its #3482 bundle
+        # (``self._put_outbox_in``); the ``put_outbox`` method reads it
+        # there. ``send_to_agent`` (the RouterLoopHost protocol member +
+        # this adapter's own implementation) retired in #4150 — zero
+        # callers after P6 (#3978) removed the sole producer of the
+        # closure that used to reach it (router_loop.py's
+        # _send_to_agent_bound, removed in #4144). The LIVE peer-dispatch
+        # transport is InterAgentMessaging.send_to_agent, reached via
+        # Session._send_to_agent directly — this adapter is not on that
+        # path.
         self._append_history_cb = append_history
         # #3792
         self._peek_mid_turn_injection_cb = peek_mid_turn_injection
@@ -1226,17 +1212,6 @@ class RouterHostAdapter:
         return self._memory
 
     # --- Action callbacks ---
-
-    async def send_to_agent(self, *, to: str, request: str, depth: int,
-                            chain_id: str) -> None:
-        """Dispatch to peer and record delegation for pending-chain registration."""
-        await self._send_to_agent_in.send_to_agent(
-            to=to, request=request, depth=depth, chain_id=chain_id,
-        )
-        # Track delegations so callers can register _PendingChain after the loop.
-        tracker = self._send_to_agent_in.delegation_tracker()
-        if tracker is not None:
-            tracker.append({"to": to, "request": request})
 
     def mark_task_pending(self) -> None:
         """Proposal 0067 P1' (#3978): forward to ``Session.current_task``
@@ -2655,7 +2630,6 @@ class RouterHostAdapter:
 
 ROUTER_HOST_ADAPTER_BUNDLE_TYPES: "tuple[str, ...]" = (
     "McpGatewayInputs",
-    "SendToAgentInputs",
     "PutOutboxInputs",
     "LiveSessionIdInputs",
 )

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -84,7 +84,6 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    SendToAgentInputs,
     SnapshotJournal,
 )
 from reyn.runtime.services.chain_manager import _PendingChain
@@ -3764,10 +3763,9 @@ class Session:
         comment above ``record_spawned_task`` below). Eager-izing any of them
         would freeze a per-turn value at construction time — the Family 3/5
         deferred/eager pitfall repeated here for a third and heavier family.
-        ``record_spawned_task`` (a bound method) and the two tracker lambdas
-        (``send_to_agent_inputs.delegation_tracker`` /
-        ``put_outbox_inputs.agent_replies_tracker``) are likewise kept
-        verbatim, still closing over ``self``.
+        ``record_spawned_task`` (a bound method) and
+        ``put_outbox_inputs.agent_replies_tracker`` (a tracker lambda) are
+        likewise kept verbatim, still closing over ``self``.
 
         PR-refactor-session-1 wave 3 PR3: RouterHostAdapter — concrete
         RouterLoopHost implementation extracted from Session. Constructed
@@ -3884,16 +3882,18 @@ class Session:
             mcp_agent_id=self._agent.agent_id,
             ephemeral_fn=lambda: self._ephemeral,
         )
-        # #3482: three more measured consumer-set clusters (sole readers:
-        # RouterHostAdapter.send_to_agent / .put_outbox / .live_session_id).
-        # Same values, same call-time semantics as the flat kwargs they
-        # replace — the trackers stay lambdas over the live Session fields and
-        # live_session_id_fn stays a deferred read (the constructor's cached
-        # session_id is stale for a spawned session).
-        _send_to_agent_inputs = SendToAgentInputs(
-            send_to_agent=self._send_to_agent,
-            delegation_tracker=lambda: self._router_loop_delegations,
-        )
+        # #3482: two more measured consumer-set clusters (sole readers:
+        # RouterHostAdapter.put_outbox / .live_session_id) — #4150 retired
+        # the third (send_to_agent_inputs): the adapter's own send_to_agent
+        # method it fed had zero callers after P6 (#3978) removed the sole
+        # producer of the closure that used to reach it. self._send_to_agent
+        # (the callback it wrapped) stays live — it's P4e's own transport,
+        # reached directly via Session._send_to_agent, not through this
+        # bundle or this adapter. Same values, same call-time semantics as
+        # the flat kwargs they replace — the trackers stay lambdas over the
+        # live Session fields and live_session_id_fn stays a deferred read
+        # (the constructor's cached session_id is stale for a spawned
+        # session).
         _put_outbox_inputs = PutOutboxInputs(
             put_outbox=self._put_outbox,
             agent_replies_tracker=lambda: self._router_loop_agent_replies,
@@ -3968,7 +3968,6 @@ class Session:
             # gateway-identity inputs need threading through (mcp_gateway_inputs
             # bundle, built above), not a callback per listing method.
             mcp_gateway_inputs=_mcp_gateway_inputs,
-            send_to_agent_inputs=_send_to_agent_inputs,  # #3482
             put_outbox_inputs=_put_outbox_inputs,  # #3482
             append_history=self._append_history,
             # #3792: mid-turn CLIENT_INPUT injection.

--- a/tests/_support/mcp_cache_test_helpers.py
+++ b/tests/_support/mcp_cache_test_helpers.py
@@ -17,7 +17,6 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    SendToAgentInputs,
 )
 from tests._support.router_host_adapter import (
     make_op_context_source,
@@ -28,7 +27,6 @@ from tests._support.router_host_adapter import (
     null_file_write,
     null_mcp_call_tool,
     null_put_outbox,
-    null_send_to_agent,
 )
 
 _EMPTY_OP_CTX = make_op_context_source()
@@ -82,9 +80,6 @@ def make_mcp_cache_adapter(
         agent_workspace_dir=workspace,
         mcp_call_tool=null_mcp_call_tool,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent_inputs=SendToAgentInputs(
-            send_to_agent=null_send_to_agent, delegation_tracker=lambda: None,
-        ),
         put_outbox_inputs=PutOutboxInputs(
             put_outbox=null_put_outbox, agent_replies_tracker=lambda: None,
         ),

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -17,7 +17,6 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    SendToAgentInputs,
 )
 
 # Every RouterOpContextSource field, all inert. Deliberately spelled out
@@ -87,10 +86,6 @@ async def null_mcp_call_tool(server: str, tool: str, args: dict) -> dict:
     return {}
 
 
-async def null_send_to_agent(*, to, request, depth, chain_id) -> None:
-    pass
-
-
 async def null_put_outbox(msg) -> None:
     pass
 
@@ -104,7 +99,6 @@ def make_adapter(
     agent_workspace_dir: Path | None = None,
     events: EventLog | None = None,
     memory: MemoryService | None = None,
-    delegation_list: "list[dict] | None" = None,
     agent_replies_list: "list[str] | None" = None,
     resolver: ModelResolver | None = None,
     turn_budget_engine: object = None,
@@ -162,7 +156,6 @@ def make_adapter(
     if resolver is None:
         resolver = ModelResolver({})
 
-    _delegations = delegation_list
     _replies = agent_replies_list
 
     op_context_source = make_op_context_source(
@@ -176,10 +169,6 @@ def make_adapter(
         mcp_connection_service=None,
         mcp_agent_id=None,
         ephemeral_fn=None,
-    )
-    send_to_agent_inputs = SendToAgentInputs(
-        send_to_agent=null_send_to_agent,
-        delegation_tracker=lambda: _delegations,
     )
     put_outbox_inputs = PutOutboxInputs(
         put_outbox=null_put_outbox,
@@ -209,7 +198,6 @@ def make_adapter(
         agent_workspace_dir=workspace,
         mcp_call_tool=null_mcp_call_tool,
         mcp_gateway_inputs=mcp_gateway_inputs,
-        send_to_agent_inputs=send_to_agent_inputs,
         put_outbox_inputs=put_outbox_inputs,
         append_history=null_append_history,
         live_session_id_inputs=live_session_id_inputs,

--- a/tests/_support/router_loop.py
+++ b/tests/_support/router_loop.py
@@ -72,6 +72,12 @@ class FakeRouterHost:
         # so both producers of a #3633-shaped duplicate are exercised.
         self.history: list[dict] = []
         self.skill_calls: list[dict] = []
+        # #4150: the send_to_agent method that appended here is retired (its
+        # Protocol member + RouterHostAdapter implementation both had zero
+        # callers after #3978/#4144). This list now stays permanently empty —
+        # kept only because test_3378_advertise_enforce_agreement.py still
+        # asserts on it. Flagged as a follow-up, not resolved here (out of
+        # scope for the CI-fix this PR was already carrying).
         self.agent_sends: list[dict] = []
         # Proposal 0067 P1' (#3978)
         self.mark_task_pending_calls: int = 0
@@ -172,11 +178,6 @@ class FakeRouterHost:
                                    chain_id: str) -> dict:
         self.skill_calls.append({"skill": skill, "input": input, "chain_id": chain_id})
         return {"status": "ok", "skill": skill}
-
-    async def send_to_agent(self, *, to: str, request: str, depth: int,
-                            chain_id: str) -> None:
-        self.agent_sends.append({"to": to, "request": request, "depth": depth,
-                                  "chain_id": chain_id})
 
     def mark_task_pending(self) -> None:
         """Proposal 0067 P1' (#3978): records the call so a test can assert

--- a/tests/_support/router_loop.py
+++ b/tests/_support/router_loop.py
@@ -76,8 +76,8 @@ class FakeRouterHost:
         # Protocol member + RouterHostAdapter implementation both had zero
         # callers after #3978/#4144). This list now stays permanently empty —
         # kept only because test_3378_advertise_enforce_agreement.py still
-        # asserts on it. Flagged as a follow-up, not resolved here (out of
-        # scope for the CI-fix this PR was already carrying).
+        # asserts on it. That assertion is vacuous (#4155): filed, not
+        # resolved here (out of scope for the CI-fix this PR was carrying).
         self.agent_sends: list[dict] = []
         # Proposal 0067 P1' (#3978)
         self.mark_task_pending_calls: int = 0

--- a/tests/core/test_mcp_lazy_tools_cache.py
+++ b/tests/core/test_mcp_lazy_tools_cache.py
@@ -31,7 +31,6 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
@@ -64,10 +63,6 @@ async def _null_file_regen(*, path, output_path, entry_template, header) -> dict
 
 async def _null_mcp_call_tool(server: str, tool: str, args: dict) -> dict:
     return {}
-
-
-async def _null_send_to_agent(*, to, request, depth, chain_id) -> None:
-    pass
 
 
 async def _null_put_outbox(msg) -> None:
@@ -117,9 +112,6 @@ def _make_adapter_with_mcp(
         agent_workspace_dir=workspace,
         mcp_call_tool=_null_mcp_call_tool,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent_inputs=SendToAgentInputs(
-            send_to_agent=_null_send_to_agent, delegation_tracker=lambda: None,
-        ),
         put_outbox_inputs=PutOutboxInputs(
             put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
         ),

--- a/tests/interfaces/test_agui_reasoning_map_p6a.py
+++ b/tests/interfaces/test_agui_reasoning_map_p6a.py
@@ -62,7 +62,6 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
@@ -159,9 +158,6 @@ def _mk_host(reasoning_config, *, outbox: list, history: list) -> RouterHostAdap
         agent_workspace_dir=workspace,
         mcp_call_tool=_noop,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent_inputs=SendToAgentInputs(
-            send_to_agent=_noop, delegation_tracker=lambda: [],
-        ),
         put_outbox_inputs=PutOutboxInputs(
             put_outbox=lambda msg: outbox.append(msg) or _noop(),
             agent_replies_tracker=lambda: [],

--- a/tests/interfaces/test_mcp_yaml_mtime_watch.py
+++ b/tests/interfaces/test_mcp_yaml_mtime_watch.py
@@ -30,7 +30,6 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
@@ -74,10 +73,6 @@ async def _null_file_regen(*, path, output_path, entry_template, header) -> dict
 
 async def _null_mcp_call_tool(server: str, tool: str, args: dict) -> dict:
     return {}
-
-
-async def _null_send_to_agent(*, to, request, depth, chain_id) -> None:
-    pass
 
 
 async def _null_put_outbox(msg) -> None:
@@ -157,9 +152,6 @@ def _make_adapter(
         agent_workspace_dir=workspace,
         mcp_call_tool=_null_mcp_call_tool,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent_inputs=SendToAgentInputs(
-            send_to_agent=_null_send_to_agent, delegation_tracker=lambda: None,
-        ),
         put_outbox_inputs=PutOutboxInputs(
             put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
         ),
@@ -587,9 +579,6 @@ async def test_session_handle_user_message_calls_yaml_watch_before_reload(
         agent_workspace_dir=workspace,
         mcp_call_tool=_null_mcp_call_tool,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent_inputs=SendToAgentInputs(
-            send_to_agent=_null_send_to_agent, delegation_tracker=lambda: None,
-        ),
         put_outbox_inputs=PutOutboxInputs(
             put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
         ),

--- a/tests/llm/test_3633_history_double_append.py
+++ b/tests/llm/test_3633_history_double_append.py
@@ -146,7 +146,6 @@ def test_adapter_put_outbox_persist_false_skips_history_append(tmp_path):
         MemoryService,
         PutOutboxInputs,
         RouterHostAdapter,
-        SendToAgentInputs,
     )
     from tests._support.router_host_adapter import (
         make_op_context_source,
@@ -155,7 +154,6 @@ def test_adapter_put_outbox_persist_false_skips_history_append(tmp_path):
         null_file_regen,
         null_file_write,
         null_mcp_call_tool,
-        null_send_to_agent,
     )
 
     outbox: list[dict] = []
@@ -193,9 +191,6 @@ def test_adapter_put_outbox_persist_false_skips_history_append(tmp_path):
         mcp_call_tool=null_mcp_call_tool,
         mcp_gateway_inputs=McpGatewayInputs(
             mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
-        ),
-        send_to_agent_inputs=SendToAgentInputs(
-            send_to_agent=null_send_to_agent, delegation_tracker=lambda: None,
         ),
         put_outbox_inputs=PutOutboxInputs(
             put_outbox=_put_outbox, agent_replies_tracker=lambda: None,

--- a/tests/llm/test_chat_router_modelspec_kwargs_1654.py
+++ b/tests/llm/test_chat_router_modelspec_kwargs_1654.py
@@ -25,7 +25,6 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
@@ -64,9 +63,6 @@ def _mk_host_with_kwargs():
         journal=None, agent_registry=None,
         agent_workspace_dir=workspace,
         mcp_call_tool=_noop, mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent_inputs=SendToAgentInputs(
-            send_to_agent=_noop, delegation_tracker=lambda: [],
-        ),
         put_outbox_inputs=PutOutboxInputs(
             put_outbox=_noop, agent_replies_tracker=lambda: [],
         ),

--- a/tests/llm/test_router_loop_chatsession.py
+++ b/tests/llm/test_router_loop_chatsession.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from typing import Protocol
 
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
+from reyn.runtime.router_loop import RouterLoopHost
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 
@@ -120,25 +122,37 @@ def test_user_message_chitchat_appended_to_history(tmp_path, monkeypatch):
 # Test 4: RouterLoopHost protocol satisfied by Session
 # ---------------------------------------------------------------------------
 
+def _router_loop_host_member_names() -> list[str]:
+    """Walk RouterLoopHost's MRO and collect every declared public member
+    name (methods + property/annotation-only attributes), across it and its
+    RouterLoopCore base — the same set `hasattr` needs to probe for a real
+    Protocol-conformance check.
+
+    #4153 post-mortem: a hand-written mirror of this list (a hardcoded
+    ``required = [...]``) went stale the moment ``send_to_agent`` was
+    removed from the Protocol — the mirror kept the retired name and the
+    test asserted for it forever, independent of what the Protocol actually
+    declares. Deriving the set here means a future member addition/removal
+    on the Protocol is reflected automatically, with nothing to keep in
+    sync by hand."""
+    names: set[str] = set()
+    for klass in RouterLoopHost.__mro__:
+        if klass is object or klass is Protocol or klass.__module__ == "typing":
+            continue
+        names.update(k for k in vars(klass) if not k.startswith("_"))
+        names.update(
+            k for k in getattr(klass, "__annotations__", {}) if not k.startswith("_")
+        )
+    return sorted(names)
+
+
 def test_chatsession_satisfies_host_protocol(tmp_path, monkeypatch):
-    """Tier 1: public contract — RouterHostAdapter (session.router_host) exposes all RouterLoopHost required methods and property types. Protocol compliance test; fails when required API is removed or renamed from the adapter."""
+    """Tier 1: public contract — RouterHostAdapter (session.router_host) exposes every RouterLoopHost Protocol member. Protocol compliance test; fails when required API is removed or renamed from the adapter."""
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
     host = session.router_host
 
-    required = [
-        "chat_id", "agent_name", "agent_role",
-        "list_available_agents",
-        "get_memory_index", "get_file_permissions", "get_mcp_servers",
-        # #3607: the memory-store capability, in place of the two path helpers
-        # (memory_path / memory_dir) + four file primitives (file_read /
-        # file_write / file_delete / file_regenerate_index) the router used to
-        # assemble the memory operations out of.
-        "memory",
-        "send_to_agent", "put_outbox",
-        "mcp_list_servers", "mcp_list_tools", "mcp_call_tool",
-        "resolve_model",
-    ]
+    required = _router_loop_host_member_names()
     missing = [m for m in required if not hasattr(host, m)]
     assert missing == [], f"Missing protocol members on RouterHostAdapter: {missing}"
 

--- a/tests/llm/test_router_loop_chatsession.py
+++ b/tests/llm/test_router_loop_chatsession.py
@@ -153,6 +153,13 @@ def test_chatsession_satisfies_host_protocol(tmp_path, monkeypatch):
     host = session.router_host
 
     required = _router_loop_host_member_names()
+    # lead-coder review: a derivation that silently returns [] (e.g. the
+    # vars()/__annotations__ walk stops finding anything after an unrelated
+    # typing-internals change) makes `missing` vacuously [] too — green
+    # without checking anything. Guard the derivation itself, not just its
+    # result. Falsify-verified: with the derivation forced to return [],
+    # this assert fires (not the missing== one).
+    assert required, "Protocol member derivation returned nothing — the gate would pass vacuously"
     missing = [m for m in required if not hasattr(host, m)]
     assert missing == [], f"Missing protocol members on RouterHostAdapter: {missing}"
 

--- a/tests/mcp/test_2597_s2b_mcp_notifications_bridge.py
+++ b/tests/mcp/test_2597_s2b_mcp_notifications_bridge.py
@@ -26,7 +26,6 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    SendToAgentInputs,
 )
 from tests._support.events import collect_events
 
@@ -62,10 +61,6 @@ async def _null_file_delete(path: str) -> dict:
 
 async def _null_file_regen(*, path, output_path, entry_template, header) -> dict:
     return {"path": path, "output_path": output_path, "entries": 0}
-
-
-async def _null_send_to_agent(*, to, request, depth, chain_id) -> None:
-    pass
 
 
 async def _null_put_outbox(msg) -> None:
@@ -113,9 +108,6 @@ def _make_adapter(*, tmp_path: Path, events: EventLog) -> RouterHostAdapter:
         agent_workspace_dir=workspace,
         mcp_call_tool=_null_mcp_call_tool,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent_inputs=SendToAgentInputs(
-            send_to_agent=_null_send_to_agent, delegation_tracker=lambda: None,
-        ),
         put_outbox_inputs=PutOutboxInputs(
             put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
         ),

--- a/tests/runtime/test_3520_unknown_probe_is_not_an_answer.py
+++ b/tests/runtime/test_3520_unknown_probe_is_not_an_answer.py
@@ -47,7 +47,6 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    SendToAgentInputs,
 )
 from reyn.runtime.services.mcp_cache_file import cache_file_path, read_cache
 
@@ -87,10 +86,6 @@ async def _null_file_regen(*, path, output_path, entry_template, header) -> dict
 
 async def _null_mcp_call_tool(server: str, tool: str, args: dict) -> dict:
     return {}
-
-
-async def _null_send_to_agent(*, to, request, depth, chain_id) -> None:
-    pass
 
 
 async def _null_put_outbox(msg) -> None:
@@ -148,9 +143,6 @@ def _make_adapter(*, tmp_path: Path, state_dir: Path, probe) -> RouterHostAdapte
         agent_workspace_dir=workspace,
         mcp_call_tool=_null_mcp_call_tool,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent_inputs=SendToAgentInputs(
-            send_to_agent=_null_send_to_agent, delegation_tracker=lambda: None,
-        ),
         put_outbox_inputs=PutOutboxInputs(
             put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
         ),

--- a/tests/runtime/test_action_retrieval_wiring.py
+++ b/tests/runtime/test_action_retrieval_wiring.py
@@ -29,7 +29,6 @@ from reyn.runtime.services.router_host_adapter import (
     McpGatewayInputs,
     PutOutboxInputs,
     RouterHostAdapter,
-    SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
@@ -83,9 +82,6 @@ def _make_adapter(
         agent_workspace_dir=Path("/tmp"),
         mcp_call_tool=_noop_callable,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent_inputs=SendToAgentInputs(
-            send_to_agent=_noop_callable, delegation_tracker=lambda: None,
-        ),
         put_outbox_inputs=PutOutboxInputs(
             put_outbox=_noop_callable, agent_replies_tracker=lambda: None,
         ),

--- a/tests/runtime/test_reasoning_integration_1652.py
+++ b/tests/runtime/test_reasoning_integration_1652.py
@@ -29,7 +29,6 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    SendToAgentInputs,
 )
 
 # #3482: RouterHostAdapter's op-context/mcp-gateway constructor params were
@@ -69,9 +68,6 @@ def _mk_host(reasoning_config, *, outbox: list, history: list, section: str = ""
         agent_workspace_dir=workspace,
         mcp_call_tool=_noop,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent_inputs=SendToAgentInputs(
-            send_to_agent=_noop, delegation_tracker=lambda: [],
-        ),
         put_outbox_inputs=PutOutboxInputs(
             put_outbox=lambda msg: outbox.append(msg) or _noop(),
             agent_replies_tracker=lambda: [],

--- a/tests/runtime/test_router_host_adapter_invariants.py
+++ b/tests/runtime/test_router_host_adapter_invariants.py
@@ -20,7 +20,6 @@ from reyn.runtime.services import (
     MemoryService,
     PutOutboxInputs,
     RouterHostAdapter,
-    SendToAgentInputs,
 )
 
 # ---------------------------------------------------------------------------
@@ -81,9 +80,6 @@ from tests._support.router_host_adapter import (
 )
 from tests._support.router_host_adapter import (
     null_put_outbox as _null_put_outbox,
-)
-from tests._support.router_host_adapter import (
-    null_send_to_agent as _null_send_to_agent,
 )
 
 # ---------------------------------------------------------------------------
@@ -167,64 +163,15 @@ def test_events_identity(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Test 4: delegation tracker via callback
+# (Formerly) Test 4: delegation tracker via callback — deleted in #4150.
+# RouterHostAdapter.send_to_agent() (and the RouterLoopHost protocol member
+# it implemented) had zero callers after P6 (#3978) removed the sole
+# producer of the closure that used to reach it (router_loop.py's
+# _send_to_agent_bound, removed in #4144) — this test drove the now-deleted
+# method directly, so its subject is gone. The live peer-dispatch transport,
+# InterAgentMessaging.send_to_agent (reached via Session._send_to_agent),
+# never went through this adapter method and is untouched.
 # ---------------------------------------------------------------------------
-
-def test_delegation_tracker_appended_on_send_to_agent(tmp_path):
-    """Tier 2: send_to_agent appends to the delegation tracker list supplied via callback.
-
-    When the delegation_tracker callback returns a mutable list, calling
-    send_to_agent must append a dict with 'to' and 'request' keys.
-    """
-    tracker: list[dict] = []
-    calls: list[dict] = []
-
-    async def fake_send(*, to, request, depth, chain_id) -> None:
-        calls.append({"to": to, "request": request})
-
-    adapter = RouterHostAdapter(
-        agent_name="alpha",
-        agent_role="role",
-        output_language=None,
-        op_context_source=_EMPTY_OP_CTX,
-        permission_resolver=None,
-        mcp_servers=None,
-        project_context="",
-        events=EventLog(subscribers=[]),
-        resolver=ModelResolver({}),
-        memory=MemoryService(
-            agent_workspace_dir=tmp_path / "agents" / "alpha",
-            events=EventLog(subscribers=[]),
-            file_write=_null_file_write,
-            file_read=_null_file_read,
-            file_delete=_null_file_delete,
-            file_regenerate_index=_null_file_regen,
-        ),
-        journal=None,
-        agent_registry=None,
-        agent_workspace_dir=tmp_path / "agents" / "alpha",
-        mcp_call_tool=_null_mcp_call_tool,
-        mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent_inputs=SendToAgentInputs(
-            send_to_agent=fake_send, delegation_tracker=lambda: tracker,
-        ),
-        put_outbox_inputs=PutOutboxInputs(
-            put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
-        ),
-        append_history=_null_append_history,
-        live_session_id_inputs=LiveSessionIdInputs(
-            session_id=None, live_session_id_fn=None,
-        ),
-    )
-
-    asyncio.run(adapter.send_to_agent(
-        to="beta", request="hello from alpha", depth=1, chain_id="chain-x",
-    ))
-
-    (entry,) = tracker
-    assert entry["to"] == "beta"
-    assert entry["request"] == "hello from alpha"
-
 
 # ---------------------------------------------------------------------------
 # #53 regression — permission_resolver property + intervention_bus wiring
@@ -277,9 +224,6 @@ def test_adapter_exposes_permission_resolver_property(tmp_path):
         agent_workspace_dir=workspace,
         mcp_call_tool=_null_mcp_call_tool,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent_inputs=SendToAgentInputs(
-            send_to_agent=_null_send_to_agent, delegation_tracker=lambda: None,
-        ),
         put_outbox_inputs=PutOutboxInputs(
             put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
         ),
@@ -338,9 +282,6 @@ def test_make_router_op_context_wires_intervention_bus(tmp_path):
         agent_workspace_dir=workspace,
         mcp_call_tool=_null_mcp_call_tool,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent_inputs=SendToAgentInputs(
-            send_to_agent=_null_send_to_agent, delegation_tracker=lambda: None,
-        ),
         put_outbox_inputs=PutOutboxInputs(
             put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
         ),
@@ -396,9 +337,6 @@ def test_make_router_op_context_no_factory_leaves_bus_none(tmp_path):
         agent_workspace_dir=workspace,
         mcp_call_tool=_null_mcp_call_tool,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent_inputs=SendToAgentInputs(
-            send_to_agent=_null_send_to_agent, delegation_tracker=lambda: None,
-        ),
         put_outbox_inputs=PutOutboxInputs(
             put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
         ),
@@ -468,9 +406,6 @@ def test_get_inbox_depth_tolerates_a_registry_without_get_session(tmp_path):
         agent_workspace_dir=workspace,
         mcp_call_tool=_null_mcp_call_tool,
         mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
-        send_to_agent_inputs=SendToAgentInputs(
-            send_to_agent=_null_send_to_agent, delegation_tracker=lambda: None,
-        ),
         put_outbox_inputs=PutOutboxInputs(
             put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
         ),


### PR DESCRIPTION
**[e2e-coder]** — Implements architect's #4150 ruling in full: removes ①③ (both measured zero-caller after #4144), leaves ⑤ (`InterAgentMessaging.send_to_agent`, the live P4e transport) untouched.

## What
- `RouterLoopHost.send_to_agent` Protocol member (`router_loop.py`) — removed
- `RouterHostAdapter.send_to_agent()` concrete method (`router_host_adapter.py`) — removed
- `SendToAgentInputs` frozen dataclass — removed (its only remaining consumer was the method above)
- `SendToAgentInputs` dropped from `ROUTER_HOST_ADAPTER_BUNDLE_TYPES` (#3482 gate)
- `Session`'s `_send_to_agent_inputs` construction / `send_to_agent_inputs=` kwarg — removed (`self._send_to_agent` and `self._router_loop_delegations` both stay independently live elsewhere, untouched)
- `test_delegation_tracker_appended_on_send_to_agent` deleted — its subject no longer exists (six-question review: "who would miss this test" → nobody, the live transport never went through it)
- `SendToAgentInputs` import/construction removed from all 10 RouterHostAdapter-building test files (mechanical sweep, same shared-builder pattern each time)

## Architect's 3 flagged unknowns (#4150), measured
- [x] `SendToAgentInputs`/`_send_to_agent_in` orphaned by ③'s removal — confirmed, both removed in this PR
- [x] Removing the Protocol member affects another implementation — `RouterHostAdapter` is the sole production implementer; no test fake separately implements the full `RouterLoopHost` Protocol (structural typing, grepped for other `send_to_agent` defs — none)
- [x] Alternate spelling (`getattr`-based dispatch) reaching ②/③ — grepped, zero hits

## Verification
- Full repo grep for `SendToAgentInputs`/`send_to_agent_inputs` → zero hits outside historical/ADR-style comments (one, describing #3482's original finding, left untouched as accurate history)
- 5 local gates green post-rebase: ruff, `test_tier_audit.py --strict` (70 tests, 0 errors), `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py` (+ `check_file_depth_reference.py`)
- Scoped consumer sweep: every `RouterHostAdapter`-constructing test file + `router_loop`/`router_host_adapter`/`session`/`send_to_agent`-keyed tests in `tests/runtime/` — 311 passed, 1 pre-existing unrelated failure (`test_session_pure_extraction_3679_s1` — a bare `python -c` subprocess import resolving against a stale global site-packages install; confirmed failing identically with this diff stashed out)

## Test plan
- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict <changed test files>`
- [x] `python scripts/verify_module_docstrings.py <changed src files>`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] Scoped pytest sweep (see Verification above)
- [ ] (Visual — N/A, no UI surface touched)

part of #4150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

- [x] 🔴 (解消) [lead-coder] 導出が空を返したら無検査で緑になる — `assert required` の vacuity guard を 1 行
- [x] 🔴 (解消 — #4155 起票) [lead-coder] `agent_sends` が永久に空になり `test_3378_advertise_enforce_agreement.py` の assert が空虚 — PR コメントでなく起票する（残件は filed か explicitly dropped）

