### PR TITLE
docs(#4153): SendToAgentInputs bundle no longer exists

### DIFF
--- a/docs/reference/runtime/session-construction.md
+++ b/docs/reference/runtime/session-construction.md
@@ -387,15 +387,20 @@ argument lists for one object, which had diverged on twelve fields.
 
 **#3482 param bundling**: `RouterHostAdapter.__init__` groups every real
 consumer-set cluster (measured by AST, not by name prefix) into frozen,
-default-free dataclasses built just before the constructor call — four of
-them, each named after the sole consumer the measurement found:
+default-free dataclasses built just before the constructor call — three of
+them today (`ROUTER_HOST_ADAPTER_BUNDLE_TYPES`), each named after the sole
+consumer the measurement found:
 
 | bundle | fields | sole consumer |
 | --- | --- | --- |
 | `McpGatewayInputs` | `mcp_connection_service`/`mcp_agent_id`/`ephemeral_fn` (#3447's Path A fold) | `_mcp_list_via_gateway` |
-| `SendToAgentInputs` | `send_to_agent`/`delegation_tracker` | the `send_to_agent` method |
 | `PutOutboxInputs` | `put_outbox`/`agent_replies_tracker` | the `put_outbox` method |
 | `LiveSessionIdInputs` | `session_id`/`live_session_id_fn` | the `live_session_id` property |
+
+(`SendToAgentInputs` was a fourth bundle here — removed along with the dead
+`RouterLoopHost.send_to_agent`/`RouterHostAdapter.send_to_agent` Protocol
+member it existed solely to serve, #4144/#4153; `InterAgentMessaging.send_to_agent`,
+the still-live P4e delivery transport, is a different, unrelated method.)
 
 Session still builds each field with the exact same expression as before
 (same object, same order, same call-time semantics — `ephemeral_fn` /


### PR DESCRIPTION
**[docs-maintainer]** — Found while triaging #4153 (removal of the dead `RouterLoopHost.send_to_agent` Protocol member) for doc drift.

## What was stale

`docs/reference/runtime/session-construction.md`'s #3482 param-bundling table still listed `SendToAgentInputs` as one of "four" current bundles. #4144/#4153 removed it along with the dead Protocol member it existed solely to serve.

## Fix

Removed the row, corrected the count to three — verified directly against `ROUTER_HOST_ADAPTER_BUNDLE_TYPES` on current `main` (`McpGatewayInputs`/`PutOutboxInputs`/`LiveSessionIdInputs` only). Added a parenthetical explaining why it's gone rather than silently dropping the row, and noting `InterAgentMessaging.send_to_agent` (the still-live P4e delivery transport) is a different, unrelated method — same distinction I already documented in `multi-agent.md` for the same removal.

## Left untouched

The separate "five bundles below" / "sixth bundle" phrasing in the adjacent #3607 paragraph — its counting basis isn't something #4153 falsified, and I haven't traced it precisely enough to correct with confidence. Flagging here rather than guessing at a fix.

## Test plan

- [x] `python scripts/check_doc_anchors.py` — exit 0
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0 (remaining INFO lines are pre-existing ja-mirror gaps)
- [x] `python scripts/check_tests_path_literal_reference.py` (gate #6) — OK
- [x] Confirmed the 3-bundle count directly against `ROUTER_HOST_ADAPTER_BUNDLE_TYPES` in `src/reyn/runtime/services/router_host_adapter.py` on current `main`

part of #3978

🤖 Generated with [Claude Code](https://claude.com/claude-code)