### PR TITLE
docs(#4091): stop restating the builtin hook-point count in hooks.md

### DIFF
--- a/docs/concepts/runtime/hooks.md
+++ b/docs/concepts/runtime/hooks.md
@@ -379,9 +379,9 @@ hooks:
   `path`, which match via a shell-style glob (`fnmatch`) — so
   `file:///repo/**` matches any URI under that prefix, and `/repo/src/**`
   matches any watched path under that directory.
-- For the 9 **builtin** hook points (the 4 lifecycle points + `mcp_resource_updated` /
-  `file_changed` / `cron_fired` / `webhook_received` + `task_settled`), a matcher field must be
-  one the point's builtin schema actually carries — a typo'd or nonexistent
+- For a **builtin** hook point (the lifecycle + external + task points listed
+  in the table above), a matcher field must be one the point's builtin schema
+  actually carries — a typo'd or nonexistent
   field name (e.g. a lifecycle point's matcher naming `server`/`uri`, or
   `payload.srever`) is a **load-time `HookConfigError`**, rejected before the
   hook can ever run (a schema-external matcher would otherwise never fire —

--- a/docs/concepts/runtime/hooks.md
+++ b/docs/concepts/runtime/hooks.md
@@ -39,7 +39,7 @@ valid in one is not necessarily valid in the other:
 | `file_changed` | `builtin:external:file_changed` | a watched path changes ([`fs_watch`](../../reference/config/reyn-yaml.md#fs_watch-block) required) | ✅ | ✅ |
 | `cron_fired` | `builtin:external:cron_fired` | a message-based `cron:` job delivers | ✅ | ✅ |
 | `webhook_received` | `builtin:external:webhook_received` | an inbound webhook resolves to this session | ✅ | ✅ |
-| `task_settled` | `builtin:task:task_settled` | an async task (today: a `run_pipeline` async launch) reaches a terminal disposition | ✅ | ✅ |
+| `task_settled` | `builtin:task:task_settled` | an async task (see below for its producers) reaches a terminal disposition | ✅ | ✅ |
 | — (open) | `composed:<name>` | a Composer (see below) publishes its correlated output | ✅ | ✅ (chaining — another Composer's output) |
 | — (open) | `llm:<session_id>:<event_name>` | the LLM itself emits one via `emit_hook_event` (always its own session) | ❌ **rejected at load** (`HookConfigError`) | ✅ |
 


### PR DESCRIPTION
**[docs-maintainer]** — part of #4091.

`hooks.md:382`'s "For the 9 **builtin** hook points (the 4 lifecycle points + ...)" was a manual-sync site #4091 flagged: correct today, but nothing gates it against drift when a hook point is added (unlike `control-ir.md`/`events.md`'s checked pairs — `AUDIT_EVENT_KINDS` has CI, this doesn't). Reworded to point at the table two sections above, which already enumerates every builtin point by name — the count added nothing the table didn't already say.

The other 3 sites #4091 originally named turned out to already be fine on current main: `reyn.local.yaml.example:976` enumerates points by name (no count), and both cited test files (`test_hook_composer_reachability_phase5.py`, `test_hook_event_schema_registry_sync_0059.py`) already derive their expected-point sets from `ALLOWED_HOOK_POINTS` rather than hardcoding a number. Only `hooks.md:382` needed a fix.

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean (pre-existing en/ja anchor INFO lines only, unrelated to this file)
- [x] Manual read of surrounding paragraph for flow
- N/A ruff / mypy_ratchet / pytest — docs-only change, no src/tests touched


- [x] 🔴 (解消) [lead-coder] 同ファイル `:42` の表の `task_settled` 行が古い（「today: a `run_pipeline` async launch」— P4e #4138 で `run_prompt(collect="async")` が 2 つ目の producer になった。同ファイル `:352` は既に正しい）。この PR で一緒に直す

