### PR TITLE
docs(#4107): fix 3 stale hardcoded counts in prose (composer/io/universal_sp)

### DIFF
--- a/src/reyn/hooks/composer.py
+++ b/src/reyn/hooks/composer.py
@@ -148,7 +148,7 @@ class ComposerConfigError(ValueError):
 
 
 class ComposerOp(str, Enum):
-    """The seven §5 composition ops."""
+    """The eight §5 composition ops."""
 
     ALL = "all"
     ANY = "any"

--- a/src/reyn/tools/descriptions/io.py
+++ b/src/reyn/tools/descriptions/io.py
@@ -8,7 +8,7 @@ its origin tool module; the origin module now aliases its
 ``_X_DESCRIPTION`` module constant to ``io.NAME.text`` so every call
 site is unchanged.
 
-Covers: file.py's 6 verbs (read_file / write_file / delete_file /
+Covers: file.py's 7 verbs (read_file / write_file / delete_file /
 edit_file / list_directory / grep_files / glob_files).
 
 FP-0066 P1b: ``drop_source`` and ``index_update`` — the agent-facing

--- a/src/reyn/tools/schemes/_universal_sp.py
+++ b/src/reyn/tools/schemes/_universal_sp.py
@@ -37,7 +37,7 @@ def build_universal_tool_use_slots(
     non_claude: bool = False,  # #1791 A2: non-Claude operational-steering hygiene in slot_in_behaviour
     available_skills: "list | None" = None,  # #2548 PR-A: SkillEntry list for ## Skills block
 ) -> "dict[str, str]":
-    """Build the four positional tool-use SP slots for the universal-category path.
+    """Build the positional tool-use SP slots (listed below) for the universal-category path.
 
     Called by each scheme's ``build_presentation`` to fill the slot-map they
     pass as ``tool_use_sp`` to ``build_system_prompt``. Returns a dict with ONLY


### PR DESCRIPTION
**[docs-maintainer]** — part of #4107 (fixes the 3 count-correctness items; the `needs:owner-decision` policy question — should prose restate counts at all — stays open, untouched here per lead-coder's split).

Independently re-measured all 3 against current `origin/main` before fixing (not just trusting lead-coder's census numbers):

| file | was | measured |
|---|---|---|
| `src/reyn/hooks/composer.py:151` | "seven" | `ComposerOp` enum = **8** members (DEADLINE, #3166) |
| `src/reyn/tools/descriptions/io.py:11` | "6 verbs" | same sentence enumerates **7** |
| `src/reyn/tools/schemes/_universal_sp.py:37` | "four" slots | function builds **6** (matches `prompt/__init__.py:31`'s table, which was already correct — only this docstring was stale) |

`composer.py`/`io.py` got the corrected number restated in place (context reads naturally with one there); `_universal_sp.py` was reworded to point at the bulleted slot list two lines below instead — same durable-fix shape used for #4091/#4158, since restating "6" there would just recreate the same drift risk the moment a 7th slot is added. Judgment calls on wording, not policy — flagged as such in the commit message.

The 4th item #4107 originally listed (`composer.py:96-97`... actually `schema.py:96-97`, newline-split) was already fixed by #4103 — confirmed, not touched here.

Also flagged but NOT fixed (out of scope, not one of #4107's 3 named items): `src/reyn/tools/scheme.py:130` says "all three slots via build_universal_tool_use_slots" — a different count/context I haven't traced the basis of.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/verify_module_docstrings.py <changed files>` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (210/214 baselined, unchanged)
- [x] `pytest tests/hooks -k composer` — 39 passed
- [x] `pytest tests/test_sp_prompt_package_coverage.py tests/tools/test_router_sp_universal_categories.py tests/hooks/test_hook_composer.py` — 42 passed
