### PR TITLE
fix(#4155): drop test_3378's vacuous host.agent_sends assertion

### DIFF
--- a/tests/_support/router_loop.py
+++ b/tests/_support/router_loop.py
@@ -72,13 +72,6 @@ class FakeRouterHost:
         # so both producers of a #3633-shaped duplicate are exercised.
         self.history: list[dict] = []
         self.skill_calls: list[dict] = []
-        # #4150: the send_to_agent method that appended here is retired (its
-        # Protocol member + RouterHostAdapter implementation both had zero
-        # callers after #3978/#4144). This list now stays permanently empty —
-        # kept only because test_3378_advertise_enforce_agreement.py still
-        # asserts on it. That assertion is vacuous (#4155): filed, not
-        # resolved here (out of scope for the CI-fix this PR was carrying).
-        self.agent_sends: list[dict] = []
         # Proposal 0067 P1' (#3978)
         self.mark_task_pending_calls: int = 0
         self.spawn_calls: list[dict] = []

--- a/tests/runtime/test_3378_advertise_enforce_agreement.py
+++ b/tests/runtime/test_3378_advertise_enforce_agreement.py
@@ -142,11 +142,22 @@ def test_ephemeral_contextual_denied_tools_are_not_advertised() -> None:
 
 def test_ephemeral_contextual_denied_tool_is_rejected_on_every_call_shape() -> None:
     """Tier 2: hiding is NOT denying (#187) — an unadvertised tool named anyway is
-    still rejected, whether called natively or unwrapped from ``invoke_action``."""
+    still rejected, whether called natively or unwrapped from ``invoke_action``.
+
+    #4155: this used to also assert ``host.agent_sends == []`` as proof the denied
+    tool's handler never executed. That field went vacuous during the proposal-0067
+    P4d/P4e migration (#3978) — ``run_prompt`` dispatch moved off ``host.send_to_agent``
+    onto the registry (``run_prompt_result_fn``/``run_prompt_async_fn``), so nothing
+    populates ``agent_sends`` for this tool regardless of whether the gate below works;
+    the assertion could never fail for the reason it named. Dropped rather than
+    rewritten (six-question ③: nobody would miss it) — ``_is_excluded`` below already
+    checks ``error.kind == "tool_excluded"`` specifically, the kind a REAL handler
+    error (e.g. a missing ``run_prompt_result_fn``) would not produce, so it already
+    proves the handler was never reached, not merely that denial was reported.
+    """
     contextual = _untrusted_contextual()
-    host = FakeRouterHost()
     loop = RouterLoop(
-        host=host,
+        host=FakeRouterHost(),
         chain_id="c-3378",
         max_iterations=3,
         contextual_permission=contextual,
@@ -161,7 +172,6 @@ def test_ephemeral_contextual_denied_tool_is_rejected_on_every_call_shape() -> N
     for result in (native, wrapped):
         assert _is_excluded(result), result
         assert target in result["error"]["message"]
-    assert host.agent_sends == [], "the denied tool's handler executed"
 
 
 def test_wrapper_itself_stays_advertised_under_an_allow_list_contextual() -> None:


### PR DESCRIPTION
**[tui-coder]** — part of #4155.

## What

`test_3378_advertise_enforce_agreement.py::test_ephemeral_contextual_denied_tool_is_rejected_on_every_call_shape` asserted `host.agent_sends == []` as proof the denied tool's handler never executed. That went vacuous during proposal-0067's P4d/P4e migration (#3978): `run_prompt`'s dispatch moved off `host.send_to_agent` onto the registry (`run_prompt_result_fn`/`run_prompt_async_fn`), so nothing populates `agent_sends` for `run_prompt` regardless of whether the permission gate works.

#4150 already removed the orphaned `FakeRouterHost.send_to_agent` method (its sole writer) and filed #4155 for this remaining judgment call.

## Six-question read (this test)

1. **Tier**: 2 (OS invariant — advertise/enforce agreement, #3378).
2. **Transcription**: no — `agent_sends` was never a mirror of the implementation under test.
3. **Who would miss it**: **nobody**. The field can never be populated by `run_prompt` dispatch whether the gate works or not — the assertion could never fail for the reason it named.
4. **Stay green never-run**: n/a.
5. **Accumulation**: n/a.
6. **Declared vs true Tier**: the assertion's *stated* purpose ("the denied tool's handler executed") doesn't hold — the field it reads is structurally disconnected from that claim now.

**Decision: dropped, not rewritten.** The remaining `assert _is_excluded(result)` already checks `error.kind == "tool_excluded"` specifically — a kind a real handler error (e.g. a missing `run_prompt_result_fn`) would not produce — so it already proves the handler was never reached, not merely that denial was reported. Rewriting the dropped line against some other `FakeRouterHost` attribute would manufacture coverage with no corresponding real regression to catch.

Also removed the now-fully-dead `agent_sends` attribute from `tests/_support/router_loop.py` — nothing reads or writes it after this change (grep confirms zero other references repo-wide).

## Falsify-verify

Temporarily disabled the pre-dispatch exclude gate (`RouterLoop._excluded_result`, forced `return None`) and reran the target test — genuinely RED via the remaining `_is_excluded` assertion (`AssertionError` on `unknown_tool` result, not `tool_excluded`). Restored, reran clean.

## Test plan

- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_3378_advertise_enforce_agreement.py` — 13/13 OK
- [x] `python scripts/mypy_ratchet.py` — OK (210/214 baselined, unchanged)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/runtime/test_3378_advertise_enforce_agreement.py` — 14/14 passed
- [x] `pytest` across all 27 consumers of `tests/_support/router_loop.py` — 168/168 passed
- [x] Falsify-verify (see above) — genuinely RED with the gate disabled, restored
