### PR TITLE
fix(#4159): RouterHostAdapter's universal_wrappers_enabled ctor param no longer defaults

### DIFF
--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -316,12 +316,16 @@ class RouterHostAdapter:
         live_session_id_inputs: LiveSessionIdInputs,
         # FP-0034 PR-3b-iii/iv: universal catalog wrapper visibility
         # (= reyn.yaml action_retrieval.universal_wrappers_enabled).
-        # Session passes True by default since PR-3b-iv flipped the
-        # ActionRetrievalConfig default; this constructor parameter
-        # still defaults to False so direct callers (= tests that build
-        # adapters by hand) preserve the prior tools= shape and don't
-        # accidentally activate wrappers without intent.
-        universal_wrappers_enabled: bool = False,
+        # #4159: no default — this param used to default to False while
+        # ActionRetrievalConfig's own default is True (PR-3b-iv), a silent
+        # implicit/config mismatch: the production call site (Session)
+        # always passed it explicitly so the mismatch never fired, but any
+        # OTHER construction path that forgot to thread it would silently
+        # get False without ever knowing the config said True — a missing
+        # kwarg raising a loud TypeError closes that class outright (every
+        # caller must now say what it means), rather than defaulting to
+        # either value and leaving a forgetful caller undetectable.
+        universal_wrappers_enabled: bool,
         # FP-0034 Phase 2 step 1: ActionEmbeddingIndex + EmbeddingProvider
         # for search_actions.  When all three are set (= operator set
         # ``embedding.enabled: true`` (FP-0066 §7) AND Session built a

--- a/tests/_support/mcp_cache_test_helpers.py
+++ b/tests/_support/mcp_cache_test_helpers.py
@@ -88,6 +88,7 @@ def make_mcp_cache_adapter(
             session_id=None, live_session_id_fn=None,
         ),
         state_dir=state_dir,
+        universal_wrappers_enabled=False,  # #4159: preserves prior implicit default
     )
     # #3447: mcp_list_tools is now a real RouterHostAdapter method — see the
     # same-shaped note in test_mcp_lazy_tools_cache.py's _make_adapter_with_mcp.

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -113,6 +113,10 @@ def make_adapter(
     intervention_answer: "str | None" = None,  # #2175: interactive-mode bus answer (choice_id, e.g. "yes")
     peek_mid_turn_injection: "object | None" = None,  # #3792
     commit_mid_turn_injection: "object | None" = None,  # #3792
+    # #4159: RouterHostAdapter's own ctor param no longer defaults (closes the
+    # implicit-False/config-True mismatch); this shared test builder keeps its
+    # own False default so existing callers of make_adapter() are unaffected.
+    universal_wrappers_enabled: bool = False,
 ) -> RouterHostAdapter:
     """Construct a minimal RouterHostAdapter with real collaborators."""
     if events is None:
@@ -212,4 +216,5 @@ def make_adapter(
         environment_backend=environment_backend,
         peek_mid_turn_injection=peek_mid_turn_injection,  # #3792
         commit_mid_turn_injection=commit_mid_turn_injection,  # #3792
+        universal_wrappers_enabled=universal_wrappers_enabled,  # #4159
     )

--- a/tests/core/test_mcp_lazy_tools_cache.py
+++ b/tests/core/test_mcp_lazy_tools_cache.py
@@ -120,6 +120,7 @@ def _make_adapter_with_mcp(
             session_id=None, live_session_id_fn=None,
         ),
         state_dir=tmp_path / "state",
+        universal_wrappers_enabled=False,  # #4159: preserves prior implicit default
     )
     # #3447: mcp_list_tools is now a real RouterHostAdapter method (folded off
     # Session's former callback-injected _mcp_list_tools). This test suite's

--- a/tests/interfaces/test_agui_reasoning_map_p6a.py
+++ b/tests/interfaces/test_agui_reasoning_map_p6a.py
@@ -169,6 +169,7 @@ def _mk_host(reasoning_config, *, outbox: list, history: list) -> RouterHostAdap
         environment_backend=None,
         reasoning_config=reasoning_config,
         reasoning_continuity_section_fn=lambda: "",
+        universal_wrappers_enabled=False,  # #4159: preserves prior implicit default
     )
 
 

--- a/tests/interfaces/test_mcp_yaml_mtime_watch.py
+++ b/tests/interfaces/test_mcp_yaml_mtime_watch.py
@@ -161,6 +161,7 @@ def _make_adapter(
         ),
         state_dir=state_dir,
         project_root=project_root,
+        universal_wrappers_enabled=False,  # #4159: preserves prior implicit default
     )
 
 
@@ -588,6 +589,7 @@ async def test_session_handle_user_message_calls_yaml_watch_before_reload(
         ),
         state_dir=state_dir,
         project_root=None,
+        universal_wrappers_enabled=False,  # #4159: preserves prior implicit default
     )
 
     # Simulate the turn-boundary calls that session._handle_user_message makes.

--- a/tests/llm/test_3633_history_double_append.py
+++ b/tests/llm/test_3633_history_double_append.py
@@ -199,6 +199,7 @@ def test_adapter_put_outbox_persist_false_skips_history_append(tmp_path):
         live_session_id_inputs=LiveSessionIdInputs(
             session_id=None, live_session_id_fn=None,
         ),
+        universal_wrappers_enabled=False,  # #4159: preserves prior implicit default
     )
 
     asyncio.run(adapter.put_outbox(

--- a/tests/llm/test_chat_router_modelspec_kwargs_1654.py
+++ b/tests/llm/test_chat_router_modelspec_kwargs_1654.py
@@ -71,6 +71,7 @@ def _mk_host_with_kwargs():
             session_id=None, live_session_id_fn=None,
         ),
         environment_backend=None,
+        universal_wrappers_enabled=False,  # #4159: preserves prior implicit default
     )
 
 

--- a/tests/mcp/test_2597_s2b_mcp_notifications_bridge.py
+++ b/tests/mcp/test_2597_s2b_mcp_notifications_bridge.py
@@ -116,6 +116,7 @@ def _make_adapter(*, tmp_path: Path, events: EventLog) -> RouterHostAdapter:
             session_id=None, live_session_id_fn=None,
         ),
         state_dir=tmp_path / "state",
+        universal_wrappers_enabled=False,  # #4159: preserves prior implicit default
     )
     # #3447: mcp_list_tools is now a real RouterHostAdapter method — see the
     # same-shaped note in test_mcp_lazy_tools_cache.py's _make_adapter_with_mcp.

--- a/tests/runtime/test_3520_unknown_probe_is_not_an_answer.py
+++ b/tests/runtime/test_3520_unknown_probe_is_not_an_answer.py
@@ -151,6 +151,7 @@ def _make_adapter(*, tmp_path: Path, state_dir: Path, probe) -> RouterHostAdapte
             session_id=None, live_session_id_fn=None,
         ),
         state_dir=state_dir,
+        universal_wrappers_enabled=False,  # #4159: preserves prior implicit default
     )
     # #3447 / existing convention in this suite: mcp_list_tools is a real
     # RouterHostAdapter method, so the probe is wired by shadowing that one

--- a/tests/runtime/test_reasoning_integration_1652.py
+++ b/tests/runtime/test_reasoning_integration_1652.py
@@ -79,6 +79,7 @@ def _mk_host(reasoning_config, *, outbox: list, history: list, section: str = ""
         environment_backend=None,
         reasoning_config=reasoning_config,
         reasoning_continuity_section_fn=lambda: section,
+        universal_wrappers_enabled=False,  # #4159: preserves prior implicit default
     )
 
 

--- a/tests/runtime/test_router_host_adapter_invariants.py
+++ b/tests/runtime/test_router_host_adapter_invariants.py
@@ -231,6 +231,7 @@ def test_adapter_exposes_permission_resolver_property(tmp_path):
         live_session_id_inputs=LiveSessionIdInputs(
             session_id=None, live_session_id_fn=None,
         ),
+        universal_wrappers_enabled=False,  # #4159: preserves prior implicit default
     )
 
     assert adapter.permission_resolver is sentinel, (
@@ -290,6 +291,7 @@ def test_make_router_op_context_wires_intervention_bus(tmp_path):
             session_id=None, live_session_id_fn=None,
         ),
         intervention_bus_factory=lambda: sentinel_bus,
+        universal_wrappers_enabled=False,  # #4159: preserves prior implicit default
     )
 
     op_ctx = adapter.make_router_op_context()
@@ -344,6 +346,7 @@ def test_make_router_op_context_no_factory_leaves_bus_none(tmp_path):
         live_session_id_inputs=LiveSessionIdInputs(
             session_id=None, live_session_id_fn=None,
         ),
+        universal_wrappers_enabled=False,  # #4159: preserves prior implicit default
     )
 
     op_ctx = adapter.make_router_op_context()
@@ -413,6 +416,7 @@ def test_get_inbox_depth_tolerates_a_registry_without_get_session(tmp_path):
         live_session_id_inputs=LiveSessionIdInputs(
             session_id=None, live_session_id_fn=None,
         ),
+        universal_wrappers_enabled=False,  # #4159: preserves prior implicit default
     )
 
     assert adapter.get_inbox_depth() is None


### PR DESCRIPTION
**[e2e-coder]** — Implements architect's ruling (option ②) on #4159: a silent implicit/config default mismatch flagged during #4154's investigation.

## The mismatch

- `ActionRetrievalConfig.universal_wrappers_enabled` defaults to `True` (config side, since PR-3b-iv)
- `RouterHostAdapter`'s own ctor param defaulted to `False` (adapter side)

Production (`Session`) always passed it explicitly, so this never fired live. But any OTHER construction path that forgot to thread it would silently land on `False` without ever knowing the config said `True` — and because the two defaults disagreed, a forgotten kwarg was **undetectable**: if both sides agreed, forgetting it would either work correctly or fail loudly; only the disagreement lets a caller silently land on the wrong value.

## Fix

`universal_wrappers_enabled` is now a required keyword-only argument. Closes the class, not the instance — every future caller must say what it means.

**Falsify-verified**: temporarily removed the kwarg from one call site → `TypeError: missing 1 required keyword-only argument: 'universal_wrappers_enabled'`, 6/9 tests in that file failed with that exact message. Restored, green again.

## Scope

11 test call sites omitted the kwarg (relying on the now-removed default) and needed the explicit `universal_wrappers_enabled=False` (preserving prior behavior — implicit made explicit, no functional change):
- `tests/_support/router_host_adapter.py` (shared `make_adapter()` builder — gained its own explicit param, defaulting to `False` so its own callers stay unaffected)
- `tests/_support/mcp_cache_test_helpers.py`
- `tests/core/test_mcp_lazy_tools_cache.py`
- `tests/interfaces/test_agui_reasoning_map_p6a.py`
- `tests/interfaces/test_mcp_yaml_mtime_watch.py` (2 sites — including an `_OrderTrackingAdapter` subclass forwarding `**kwargs`)
- `tests/llm/test_3633_history_double_append.py`
- `tests/llm/test_chat_router_modelspec_kwargs_1654.py`
- `tests/mcp/test_2597_s2b_mcp_notifications_bridge.py`
- `tests/runtime/test_3520_unknown_probe_is_not_an_answer.py`
- `tests/runtime/test_reasoning_integration_1652.py`
- `tests/runtime/test_router_host_adapter_invariants.py` (4 sites)

`tests/runtime/test_action_retrieval_wiring.py` already threaded it explicitly. `session.py` (the sole production call site) already passed it explicitly too.

## Verification
- Full grep sweep for `RouterHostAdapter(` construction sites across `src`+`tests` — every one now supplies the argument
- Scoped sweep (every `RouterHostAdapter`-constructing test file + `tests/tools/`, 1017 tests) green
- 5 local gates: ruff, `test_tier_audit.py --strict` (62 tests, 0 errors), `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py` (+ `check_file_depth_reference.py`)

## Test plan
- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict <changed test files>`
- [x] `python scripts/verify_module_docstrings.py <changed src files>`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] Falsify-verify: removing the kwarg raises the exact TypeError
- [x] Scoped pytest sweep (1017 tests, see Verification above)
- [ ] (Visual — N/A, no UI surface touched)

part of #4159

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>