### PR TITLE
fix(#4157): embedding_index_build_complete now carries total_tokens/cost_usd/embedding_model

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -275,6 +275,7 @@ See [Concepts: multi-agent](../../concepts/multi-agent/multi-agent.md) — "Agen
 |------|-------------|
 | `llm_called` | `model` (+ `chain_id` when the call belongs to a delegation chain) |
 | `llm_response_received` | `prompt_tokens`, `completion_tokens`, `cached_tokens`, `cache_creation_tokens`, `cost_usd`, `usage_source` (+ `chain_id`) |
+| `embedding_index_build_complete` | `source_id`, `chunk_count`, `total_tokens`, `cost_usd`, `embedding_model` (a disk-adopt/no-fresh-build completion carries `total_tokens`/`cost_usd` as `null` — no embed call happened that run, not a cost of zero) |
 
 `usage_source` says where the token counts came from: `provider` (the provider
 reported them) or `estimated` (the provider's stream carried no usage, so

--- a/src/reyn/data/index/coordinator.py
+++ b/src/reyn/data/index/coordinator.py
@@ -123,10 +123,20 @@ __all__ = [
 class EmbedWriteResult:
     """Return shape of ``embed_verify_write`` — the write outcome plus the
     embed op's resolved model id (some callers, e.g. ``index_update``, must
-    record the resolved model on subsequent chunk metadata / the manifest)."""
+    record the resolved model on subsequent chunk metadata / the manifest).
+
+    #4157: ``total_tokens``/``cost_usd`` are the embed op's OWN already-
+    computed values (``op_runtime/embed.py``'s result dict, sourced from
+    ``EmbedBatchResult.total_tokens`` + ``estimate_embedding_cost``) —
+    threaded through here rather than re-measured, so a build's audit trail
+    can report what it actually cost without a second cost computation.
+    ``cost_usd`` is ``None`` when the model has no known pricing (mirrors
+    the op's own ``priced`` flag)."""
 
     write_result: WriteResult
     resolved_model: str
+    total_tokens: int
+    cost_usd: float | None
 
 
 def assert_vector_count_match(
@@ -201,7 +211,14 @@ async def embed_verify_write(
         for item, vector in zip(items, vectors)
     ]
     write_result = await backend.write(source, records, mode=mode)  # type: ignore[arg-type]
-    return EmbedWriteResult(write_result=write_result, resolved_model=resolved_model)
+    return EmbedWriteResult(
+        write_result=write_result,
+        resolved_model=resolved_model,
+        # #4157: already computed by the embed op itself — carried through,
+        # not re-measured.
+        total_tokens=int(result.get("total_tokens", 0)),
+        cost_usd=result.get("cost_usd"),
+    )
 
 
 # ── IndexCoordinator public interface (#3247 firm §1) ──────────────────────
@@ -533,6 +550,15 @@ class IndexCoordinator:
                     self._emit(
                         events, "embedding_index_build_complete",
                         source_id=source_id, chunk_count=chunk_count,
+                        # #4157: no fresh embed call happened on this path
+                        # (disk-adopt cache hit) — None, not 0, so the audit
+                        # trail doesn't read as "a build ran and cost
+                        # nothing" when no build ran at all.
+                        embedding_model=(
+                            entry.embedding_model if entry is not None else None
+                        ),
+                        total_tokens=None,
+                        cost_usd=None,
                     )
                     outcome = BuildOutcome(
                         source_id=source_id, triggered=True, background=False,
@@ -585,6 +611,14 @@ class IndexCoordinator:
         self._emit(
             events, "embedding_index_build_complete",
             source_id=source_id, chunk_count=chunk_count,
+            # #4157: total_tokens/cost_usd/model were already computed by the
+            # embed op (EmbedWriteResult carries them through, not
+            # re-measured) — previously dropped here, leaving only
+            # chunk_count in the audit trail and no way to reconstruct what
+            # a build actually cost after the fact.
+            embedding_model=result.resolved_model,
+            total_tokens=result.total_tokens,
+            cost_usd=result.cost_usd,
         )
         outcome = BuildOutcome(
             source_id=source_id, triggered=True, background=False, chunk_count=chunk_count,

--- a/tests/core/test_index_coordinator_3247_p2a.py
+++ b/tests/core/test_index_coordinator_3247_p2a.py
@@ -283,6 +283,59 @@ def test_embed_verify_write_refuses_partial_write(monkeypatch: pytest.MonkeyPatc
     assert stat["chunk_count"] == 0, "no partial write must have reached the backend"
 
 
+def test_embed_verify_write_carries_the_embed_ops_own_cost_fields(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Tier 2: #4157 — EmbedWriteResult carries total_tokens/cost_usd from
+    the embed op's OWN result (EmbedBatchResult.total_tokens +
+    estimate_embedding_cost), not re-measured. "standard" isn't a real
+    litellm-priced model name, so cost_usd correctly comes back None
+    (unpriced != free, #1829) while total_tokens is still the real count —
+    proving the two are threaded independently, not one derived from the
+    other's presence."""
+    ctx = _ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    backend = SqliteIndexBackend(workspace_root=tmp_path)
+    items = [{"id": "a", "text": "alpha"}, {"id": "b", "text": "beta"}]
+
+    result = _run(embed_verify_write(
+        ctx=ctx, texts=[it["text"] for it in items], model_class="standard",
+        items=items, to_chunk_record=_to_chunk_record, backend=backend,
+        source="cost_test", mode="replace", item_noun="items", label="build",
+    ))
+
+    assert result.total_tokens == 2, "one token per item, from the fake provider"
+    assert result.cost_usd is None, "unpriced model — None, not fabricated 0.0"
+
+
+def test_build_complete_event_carries_cost_fields_not_just_chunk_count(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Tier 2: #4157 — embedding_index_build_complete's audit-event payload
+    reports total_tokens/cost_usd/embedding_model, not chunk_count alone.
+    Before this fix the event carried only chunk_count (1609 in the
+    owner-witnessed live report) — the same values EmbedWriteResult now
+    carries are asserted on the actual EMITTED event, not just the return
+    value, since the event is what the audit trail actually persists."""
+    from tests._support.events import collect_events
+
+    events = EventLog()
+    collected = collect_events(events)
+    coord = IndexCoordinator(tmp_path)
+    ctx = _ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    items = [{"id": "a", "text": "alpha"}, {"id": "b", "text": "beta"}]
+    coord.register_builder("skill", _working_build_fn(ctx, items), kind="dynamic")
+
+    _run(coord.ensure_built("skill", await_completion=True, events=events))
+
+    (complete,) = [e for e in collected if e.type == "embedding_index_build_complete"]
+    assert complete.data["chunk_count"] == 2
+    assert complete.data["total_tokens"] == 2, (
+        f"the event must carry total_tokens, not just chunk_count: {complete.data}"
+    )
+    assert complete.data["embedding_model"] == "standard"
+    assert "cost_usd" in complete.data
+
+
 def test_strip_falsify_neutered_guard_accepts_partial_write(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Tier 2: (strip-falsify, #3247 architect-required) neutering the
     unified all-or-nothing guard (monkeypatch it to a no-op) causes the


### PR DESCRIPTION
**[e2e-coder]** — Implements lead-coder's ruling on #4157: owner ran a live embedding build and asked what it cost; `.reyn/events` only had `chunk_count` (1609). The values were already computed and silently dropped, not missing.

## The gap

`op_runtime/embed.py`'s embed op ALREADY returns `total_tokens`/`cost_usd`/`model` in its result dict (`EmbedBatchResult.total_tokens` + `estimate_embedding_cost`). `embed_verify_write` only read `vectors`+`model` from that result — the rest was computed and discarded before ever reaching `EmbedWriteResult`, and therefore before ever reaching the `embedding_index_build_complete` audit event.

## Fix

Neither a new progress-event field (progress is mid-build; cost is a property of the whole build) nor a second event (two completion signals for one build) — per the ruling, the existing `embedding_index_build_complete` event gains the fields. Kind unchanged, so the closed-vocabulary `AUDIT_EVENT_KINDS` gate (#3410) is untouched (verified green).

- `EmbedWriteResult` gained `total_tokens: int` / `cost_usd: float | None`, threaded from the embed op's own result — not re-measured
- Real-build completion emission now includes `embedding_model`/`total_tokens`/`cost_usd`
- The disk-adopt/no-fresh-embed-call completion emission carries the same fields as `None` (not `0`) — no build happened this call, so the trail reads "no data", not "cost nothing"

## Doc check

Grepped `docs/` (`control-ir.md`, `events.md`) for any field-level description of this event's payload — found none; `events.md`'s only mention is the bare kind name in the closed-vocabulary list, unaffected by adding fields to an existing kind. Nothing to update.

## Verification

Two new tests, falsify-verified: the real `EmbedWriteResult` return AND the actual emitted event's `.data` (not just the return value, since the event is what the audit trail persists) both go RED against the pre-fix source (`AttributeError` / `KeyError: 'total_tokens'`), GREEN with the fix. `cost_usd` correctly comes back `None` for an unpriced test model name (unpriced ≠ free, #1829) while `total_tokens` is a real positive count — proving the two fields are threaded independently, not one derived from the other's presence.

Targeted sweep of every `IndexCoordinator`/`embed_verify_write` consumer (92 tests, including the closed-vocabulary kind gate) — all green. 5 local gates: ruff, `test_tier_audit.py --strict` (16 tests, 0 errors), `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py` (+ `check_file_depth_reference.py`).

## Test plan
- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict tests/core/test_index_coordinator_3247_p2a.py`
- [x] `python scripts/verify_module_docstrings.py src/reyn/data/index/coordinator.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] Falsify-verify: both new tests RED against pre-fix source, GREEN with fix
- [x] Targeted consumer sweep (92 tests, see Verification above)
- [ ] (Visual — N/A, no UI surface touched)

Closes #4157 — confirmed no remainder: both embedding_index_build_complete emission sites in the codebase are fixed by this PR (grep-verified, no third site exists), and the field-level doc gap lead-coder caught is closed too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

- [x] 🔴 (解消) [lead-coder] `events.md` の「LLM and context」表（Kind | Key payload）に `embedding_index_build_complete` の行を追加 — この表が外部 consumer 向けに payload を書いている面で、#4157 の目的（コストを events から再構成できる）はこの面が無いと伝わらない


