### PR TITLE
docs(config): reyn-yaml top-level key table — complete the key set, mark surface + hot-reload

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -25,13 +25,17 @@ models:
 `reyn.local.yaml`（＝ **PRJ スコープ**）にしか書けず、`load_config` が
 **起動時に一度だけ**読みます — 実行中に編集しても、**再起動するまで効きません**。
 
-例外は 6 つのレジストリ（`mcp` / `cron` / `hooks` / `skills` / `pipelines` /
-`presentations`）で、これらは `.reyn/config/<名前>.yaml` にも書けます。**そちら側に
-書いた分だけがターン境界で読み直され**（= hot reload）、`reyn.yaml` 側に書いた同じ
-キーは他と同じく再起動待ちです。**ファイル分割そのものが write-gate の境界**である
-ため（`config/loader.py` の `_HOT_RELOAD_FILES`、#2073）、hot reload のローダは
-`reyn.yaml` を構造的に読みません — 「hot reload される設定」を増やしたい場合は、
-`reyn.yaml` に書き足すのではなく `.reyn/config/` 側へ置きます。
+例外はランタイム可変なレジストリ群で、これらは `.reyn/config/<名前>.yaml` にも
+書けます。**`.reyn/config/` 側に書いた分だけがターン境界で読み直され**（= hot
+reload）、`reyn.yaml` 側に書いた同じキーは他と同じく再起動待ちです。
+**ファイル分割そのものが write-gate の境界**であるため（#2073）、hot reload の
+ローダは `reyn.yaml` を構造的に読みません — 「hot reload される設定」を増やしたい
+場合は、`reyn.yaml` に書き足すのではなく `.reyn/config/` 側へ置きます。
+
+**どのキーがこの例外に入るかの一次の出所は `src/reyn/config/loader.py` の
+`_HOT_RELOAD_FILES`** です。下の表の各行はそこから引いていますが、**個数や
+名前の一覧をここから読み取らず、`_HOT_RELOAD_FILES` を読んでください** — 追加
+されてもこの散文は自動追随しません。
 
 ⚠️ **例外の例外**: `composers` は `hooks` と同じ 4 層の結合（`reyn.yaml` ∪
 `.reyn/config/hooks.yaml` ∪ エージェントごと ∪ セッションごと）で読まれますが、

--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -21,33 +21,67 @@ models:
 
 ## トップレベルキー
 
-| キー | 型 | 説明 |
-|-----|------|-------------|
-| `model` | 文字列 | デフォルトのモデルクラス。`models` を通じて解決されます。`--model` でオーバーライド。 |
-| `models` | マップ | クラス名 → LiteLLM モデル文字列 **または** dict（以下参照）。 |
-| `output_language` | 文字列 | デフォルトの出力言語コード（例: `en`、`ja`）。`--output-language` でオーバーライド。 |
-| `safety` | マップ | ランタイムの停止条件: ループ検出上限、タイムアウト、上限超過時ポリシー。以下参照。 |
-| `cost` | マップ | バジェット上限とレート制限（エージェントごと、日次、月次）。以下参照。 |
-| `web` | マップ | `web_fetch` と MCP レジストリ呼び出しの SSL 設定。以下参照。 |
-| `sandbox` | マップ | `sandboxed_exec` のバックエンド選択・非対応プラットフォームポリシー・agent-level サンドボックスポリシー。以下参照。 |
-| `action_retrieval` | マップ | ユニバーサルカタログの可視化 + 検索設定。以下参照。 |
-| `embedding` | マップ | RAG 埋め込みモデルクラスとバッチ設定。以下参照。 |
-| `chat` | マップ | チャットセッションの Head/Body/Tail 圧縮設定。以下参照。 |
-| `voice` | マップ | ⚠️ 現在利用不可(consumerなし)。以下参照。 |
-| `events` | マップ | チャットセッションイベントファイルの監査ログローテーションポリシー。以下参照。 |
-| `observability` | マップ | P6 監査イベントの OpenTelemetry (OTLP) エクスポート（オプトイン）。デフォルトは無効。以下参照。 |
-| `tool_use` | マップ | chat レイヤーの tool-use scheme x transport セレクタ（`scheme`、`transport`）。以下参照。 |
-| `mcp` | マップ | MCP サーバー定義。以下参照。 |
-| `python` | マップ | Python preprocessor の追加許可モジュール。以下参照。 |
-| `agent` | マップ | P6 イベント監査証跡と送信 HTTP ヘッダー用のエージェント識別子。以下参照。 |
-| `auth` | マップ | `reyn auth login` 用の OAuth プロバイダー設定。以下参照。 |
-| `cron` | マップ | スケジュール付きスキル実行。以下参照。 |
-| `external_transports` | マップ | チャット向け受信トランスポート → MCP ツールルーティング（Slack / LINE / Discord など）。以下参照。 |
-| `multimodal` | マップ | バイナリメディア（画像・音声）のサイズ上限・超過時の挙動・アーティファクト保存先。以下参照。 |
-| `permissions` | マップ | デフォルトの Permission ポリシー。以下参照。 |
-| `prompt_cache_enabled` | bool | システムプロンプトに Anthropic プロンプトキャッシュマーカーを付与。デフォルト `true`。 |
-| `project_context_path` | 文字列 | すべての Phase システムプロンプトに注入する Markdown ファイル。未設定（デフォルト）: cross-tool 標準を auto-resolve — `AGENTS.md` があればそれ、なければ `REYN.md`（legacy fallback）。明示パスで 1 ファイルに固定、`""` で無効化。下記の注記参照。 |
-| `api_base` | 文字列 | LiteLLM プロキシベース URL。通常は `reyn.local.yaml`（gitignored）に設定。 |
+**「書く面 / 再読込」列の読み方。** ほとんどのキーは `reyn.yaml` /
+`reyn.local.yaml`（＝ **PRJ スコープ**）にしか書けず、`load_config` が
+**起動時に一度だけ**読みます — 実行中に編集しても、**再起動するまで効きません**。
+
+例外は 6 つのレジストリ（`mcp` / `cron` / `hooks` / `skills` / `pipelines` /
+`presentations`）で、これらは `.reyn/config/<名前>.yaml` にも書けます。**そちら側に
+書いた分だけがターン境界で読み直され**（= hot reload）、`reyn.yaml` 側に書いた同じ
+キーは他と同じく再起動待ちです。**ファイル分割そのものが write-gate の境界**である
+ため（`config/loader.py` の `_HOT_RELOAD_FILES`、#2073）、hot reload のローダは
+`reyn.yaml` を構造的に読みません — 「hot reload される設定」を増やしたい場合は、
+`reyn.yaml` に書き足すのではなく `.reyn/config/` 側へ置きます。
+
+⚠️ **例外の例外**: `composers` は `hooks` と同じ 4 層の結合（`reyn.yaml` ∪
+`.reyn/config/hooks.yaml` ∪ エージェントごと ∪ セッションごと）で読まれますが、
+**hot reload されません** — 追加・削除は次のセッション開始で効きます。
+
+なお、この表が扱う軸は **PRJ（`reyn.yaml`）と `.reyn/config/` の 2 面だけ**です。
+`hooks` / `composers` / permission 系はさらに**エージェント面**
+（`.reyn/agents/<名前>/`、`.reyn/capability_profiles/<名前>.yaml`）と
+**セッション面**（`<session-state-dir>/config.yaml`）にも書けます。
+そちらは [permission-model](../../concepts/runtime/permission-model.md) を参照。
+
+| キー | 型 | 書く面 / 再読込 | 説明 |
+|-----|------|-----|-------------|
+| `model` | 文字列 | PRJ のみ・**再起動** | デフォルトのモデルクラス。`models` を通じて解決されます。`--model` でオーバーライド。 |
+| `models` | マップ | PRJ のみ・**再起動** | クラス名 → LiteLLM モデル文字列 **または** dict（以下参照）。 |
+| `output_language` | 文字列 | PRJ のみ・**再起動** | デフォルトの出力言語コード（例: `en`、`ja`）。`--output-language` でオーバーライド。 |
+| `safety` | マップ | PRJ のみ・**再起動** | ランタイムの停止条件: ループ検出上限、タイムアウト、上限超過時ポリシー。以下参照。 |
+| `cost` | マップ | PRJ のみ・**再起動** | バジェット上限とレート制限（エージェントごと、日次、月次）。以下参照。 |
+| `web` | マップ | PRJ のみ・**再起動** | `web_fetch` と MCP レジストリ呼び出しの SSL 設定。以下参照。 |
+| `sandbox` | マップ | PRJ のみ・**再起動** | `sandboxed_exec` のバックエンド選択・非対応プラットフォームポリシー・agent-level サンドボックスポリシー。以下参照。 |
+| `action_retrieval` | マップ | PRJ のみ・**再起動** | ユニバーサルカタログの可視化 + 検索設定。以下参照。 |
+| `embedding` | マップ | PRJ のみ・**再起動** | RAG 埋め込みモデルクラスとバッチ設定。以下参照。 |
+| `chat` | マップ | PRJ のみ・**再起動** | チャットセッションの Head/Body/Tail 圧縮設定。以下参照。 |
+| `voice` | マップ | PRJ のみ・**再起動** | ⚠️ 現在利用不可(consumerなし)。以下参照。 |
+| `events` | マップ | PRJ のみ・**再起動** | チャットセッションイベントファイルの監査ログローテーションポリシー。以下参照。 |
+| `observability` | マップ | PRJ のみ・**再起動** | P6 監査イベントの OpenTelemetry (OTLP) エクスポート（オプトイン）。デフォルトは無効。以下参照。 |
+| `tool_use` | マップ | PRJ のみ・**再起動** | chat レイヤーの tool-use scheme x transport セレクタ（`scheme`、`transport`）。以下参照。 |
+| `mcp` | マップ | 両方（`.reyn/config/mcp.yaml` 側は **hot reload**） | MCP サーバー定義。以下参照。 |
+| `python` | マップ | PRJ のみ・**再起動** | Python preprocessor の追加許可モジュール。以下参照。 |
+| `agent` | マップ | PRJ のみ・**再起動** | P6 イベント監査証跡と送信 HTTP ヘッダー用のエージェント識別子。以下参照。 |
+| `auth` | マップ | PRJ のみ・**再起動** | `reyn auth login` 用の OAuth プロバイダー設定。以下参照。 |
+| `cron` | マップ | 両方（`.reyn/config/cron.yaml` 側は **hot reload**） | スケジュール付きスキル実行。以下参照。 |
+| `external_transports` | マップ | PRJ のみ・**再起動** | チャット向け受信トランスポート → MCP ツールルーティング（Slack / LINE / Discord など）。以下参照。 |
+| `multimodal` | マップ | PRJ のみ・**再起動** | バイナリメディア（画像・音声）のサイズ上限・超過時の挙動・アーティファクト保存先。以下参照。 |
+| `permissions` | マップ | PRJ のみ・**再起動** | デフォルトの Permission ポリシー。以下参照。 |
+| `prompt_cache_enabled` | bool | PRJ のみ・**再起動** | システムプロンプトに Anthropic プロンプトキャッシュマーカーを付与。デフォルト `true`。 |
+| `project_context_path` | 文字列 | PRJ のみ・**再起動** | すべての Phase システムプロンプトに注入する Markdown ファイル。未設定（デフォルト）: cross-tool 標準を auto-resolve — `AGENTS.md` があればそれ、なければ `REYN.md`（legacy fallback）。明示パスで 1 ファイルに固定、`""` で無効化。下記の注記参照。 |
+| `api_base` | 文字列 | PRJ のみ・**再起動** | LiteLLM プロキシベース URL。通常は `reyn.local.yaml`（gitignored）に設定。 |
+| `llm` | マップ | PRJ のみ・**再起動** | LLM 層の設定（ルーティング #1829 / リトライ #1835）。 |
+| `model_class_by_purpose` | マップ | PRJ のみ・**再起動** | 用途名 → モデルクラス。用途ごとに既定クラスを差し替えます。 |
+| `delegation` | マップ | PRJ のみ・**再起動** | エージェント間委任のポリシー（#2081）。 |
+| `cost_warn` | マップ | PRJ のみ・**再起動** | 高コストモデルを選ぶ前の事前警告（#1830 / FP-0052）。 |
+| `offload` | マップ | PRJ のみ・**再起動** | tool 結果のサイズゲートの opt-in スイッチ。 |
+| `render_template` | マップ | PRJ のみ・**再起動** | `render_template` op の出力上限（FP-0055 / #2679）。 |
+| `fs_watch` | マップ | PRJ のみ・**再起動** | オペレータが宣言するファイル監視パス（#2608 H4）。 |
+| `hooks` | リスト | 両方（`.reyn/config/hooks.yaml` 側は **hot reload**） | hook 定義。Session 構築時に `load_hooks` が解析。空（既定）→ HookDispatcher は no-op。 |
+| `composers` | リスト | 両方（ただし **hot reload されない**・再起動） | composer 定義。空（既定）→ `start_composers` は呼ばれません。 |
+| `skills` | マップ | 両方（`.reyn/config/skills.yaml` 側は **hot reload**） | skill 宣言。設定層をまたいで名前でマージ（明示エントリが衝突時に勝つ）。 |
+| `pipelines` | マップ | 両方（`.reyn/config/pipelines.yaml` 側は **hot reload**） | pipeline 宣言。`skills` と同じ union-merge。 |
+| `presentations` | マップ | 両方（`.reyn/config/presentations.yaml` 側は **hot reload**） | presentation テンプレート宣言。`skills` / `pipelines` と同じ union-merge。 |
 
 > **プロジェクトコンテキストファイル（`project_context_path`）。** 未設定のとき
 > Reyn は `AGENTS.md` を読みます — Claude Code・Codex・opencode 等も読む cross-tool

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -25,14 +25,18 @@ models:
 in `reyn.yaml` / `reyn.local.yaml` (= **PRJ scope**), which `load_config` reads
 **once at startup** — editing them mid-run has no effect **until a restart**.
 
-The exception is the six registries (`mcp`, `cron`, `hooks`, `skills`,
-`pipelines`, `presentations`), which may also be written in
+The exception is the runtime-mutable registries, which may also be written in
 `.reyn/config/<name>.yaml`. **Only what is written on that side is re-read at the
 turn boundary** (= hot reload); the same key written in `reyn.yaml` waits for a
 restart like everything else. **The file split *is* the write-gate boundary**
-(`_HOT_RELOAD_FILES` in `config/loader.py`, #2073), so the hot-reload loader
-structurally never opens `reyn.yaml` — to make a setting hot-reloadable, put it
-under `.reyn/config/` rather than adding to `reyn.yaml`.
+(#2073), so the hot-reload loader structurally never opens `reyn.yaml` — to make
+a setting hot-reloadable, put it under `.reyn/config/` rather than adding to
+`reyn.yaml`.
+
+**`_HOT_RELOAD_FILES` in `src/reyn/config/loader.py` is the source of which keys
+are in that exception.** The rows below are derived from it, but **do not read a
+count or a name list out of this prose** — it does not follow the registry when
+one is added.
 
 ⚠️ **One exception to the exception**: `composers` is read from the same 4-layer
 combine as `hooks` (`reyn.yaml` ∪ `.reyn/config/hooks.yaml` ∪ per-agent ∪

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -21,36 +21,70 @@ models:
 
 ## Top-level keys
 
-| Key | Type | Description |
-|-----|------|-------------|
-| `model` | string | Default model class. Resolved via `models`. Override with `--model`. |
-| `models` | map | Class name → LiteLLM model string **or** dict (see below). |
-| `model_class_by_purpose` | map | Per-purpose model-class override (`router` / `control_ir` / `tool` / `judge`). Unset purpose → `model`. `compaction` is NOT a valid key (#3785) — compaction always follows the conversation model. See below. |
-| `output_language` | string | Default output language code (e.g. `en`, `ja`). Override with `--output-language`. |
-| `safety` | map | Runtime stop conditions: loop-detection caps, timeouts, on-limit policy. See below. |
-| `cost` | map | Budget caps and rate limits (per-agent, daily, monthly). See below. |
-| `web` | map | SSL settings for `web_fetch` and MCP registry calls, the gateway auth model, and (`web.surfaces`) which `reyn web` surfaces are mounted. See below. |
-| `sandbox` | map | Sandboxed-exec backend selection, unsupported-platform policy, and the agent-level sandbox policy. See below. |
-| `hooks` | list | Agent-lifecycle hooks — template_push / exec / exec_capture hooks at lifecycle points. See below. |
-| `action_retrieval` | map | Universal catalog visibility + retrieval settings. See below. |
-| `embedding` | map | RAG embedding model classes and batch settings. See below. |
-| `chat` | map | Chat-session compaction settings. See below. |
-| `voice` | map | ⚠️ Currently unavailable (no consumer). See below. |
-| `events` | map | Audit-log rotation policy for chat-session event files. See below. |
-| `observability` | map | Opt-in OpenTelemetry (OTLP) export of P6 audit-events. Off by default. See below. |
-| `tool_use` | map | Chat-layer tool-use scheme x transport selector (`scheme`, `transport`). See below. |
-| `mcp` | map | MCP server definitions. See below. |
-| `python` | map | Python preprocessor additional allowed-modules. See below. |
-| `agent` | map | Agent identity for P6 event audit trail and outgoing HTTP header. See below. |
-| `auth` | map | OAuth provider configurations for `reyn auth login`. See below. |
-| `cron` | map | Scheduled skill executions. See below. |
-| `external_transports` | map | Inbound transport → MCP tool routing for chat (Slack / LINE / Discord etc.). See below. |
-| `multimodal` | map | Binary media (image/audio) size cap, on-oversize behaviour, and artefact storage paths. See below. |
-| `permissions` | map | Default permission policy. See below. |
-| `prompt_cache_enabled` | bool | Attach Anthropic prompt-cache markers to system prompts. Default `true`. |
-| `project_context_path` | string | Markdown file injected into every phase system prompt. Unset (default): auto-resolves the cross-tool standard — `AGENTS.md` if present, else `REYN.md` (legacy fallback). Set an explicit path to pin one file; set `""` to disable. See note below. |
-| `api_base` | string | LiteLLM proxy base URL. Typically set in `reyn.local.yaml` (gitignored). |
-| `tool_calls_op_loop_skills` | list | **Transitional.** Skill names opted into the native-tools op-loop — the phase act-loop drives the shared `RouterLoop.run_loop` (the converged op-loop): ops are emitted as native `tool_calls`, run through the shared executor, and threaded as native tool-role message-history. Default empty = all skills use json-mode (unchanged). Removed once the op-loop becomes the default. |
+**How to read the "Written on / reload" column.** Most keys can only be written
+in `reyn.yaml` / `reyn.local.yaml` (= **PRJ scope**), which `load_config` reads
+**once at startup** — editing them mid-run has no effect **until a restart**.
+
+The exception is the six registries (`mcp`, `cron`, `hooks`, `skills`,
+`pipelines`, `presentations`), which may also be written in
+`.reyn/config/<name>.yaml`. **Only what is written on that side is re-read at the
+turn boundary** (= hot reload); the same key written in `reyn.yaml` waits for a
+restart like everything else. **The file split *is* the write-gate boundary**
+(`_HOT_RELOAD_FILES` in `config/loader.py`, #2073), so the hot-reload loader
+structurally never opens `reyn.yaml` — to make a setting hot-reloadable, put it
+under `.reyn/config/` rather than adding to `reyn.yaml`.
+
+⚠️ **One exception to the exception**: `composers` is read from the same 4-layer
+combine as `hooks` (`reyn.yaml` ∪ `.reyn/config/hooks.yaml` ∪ per-agent ∪
+per-session) but is **not** hot-reloaded — added or removed entries take effect
+at the next session start.
+
+Note that this table's axis is only the two **project-level** surfaces
+(`reyn.yaml` and `.reyn/config/`). `hooks`, `composers`, and the permission keys
+can additionally be written on an **agent** surface (`.reyn/agents/<name>/`,
+`.reyn/capability_profiles/<name>.yaml`) and a **session** surface
+(`<session-state-dir>/config.yaml`) — see
+[permission-model](../../concepts/runtime/permission-model.md).
+
+| Key | Type | Written on / reload | Description |
+|-----|------|-----|-------------|
+| `model` | string | PRJ only · **restart** | Default model class. Resolved via `models`. Override with `--model`. |
+| `models` | map | PRJ only · **restart** | Class name → LiteLLM model string **or** dict (see below). |
+| `model_class_by_purpose` | map | PRJ only · **restart** | Per-purpose model-class override (`router` / `control_ir` / `tool` / `judge`). Unset purpose → `model`. `compaction` is NOT a valid key (#3785) — compaction always follows the conversation model. See below. |
+| `output_language` | string | PRJ only · **restart** | Default output language code (e.g. `en`, `ja`). Override with `--output-language`. |
+| `safety` | map | PRJ only · **restart** | Runtime stop conditions: loop-detection caps, timeouts, on-limit policy. See below. |
+| `cost` | map | PRJ only · **restart** | Budget caps and rate limits (per-agent, daily, monthly). See below. |
+| `web` | map | PRJ only · **restart** | SSL settings for `web_fetch` and MCP registry calls, the gateway auth model, and (`web.surfaces`) which `reyn web` surfaces are mounted. See below. |
+| `sandbox` | map | PRJ only · **restart** | Sandboxed-exec backend selection, unsupported-platform policy, and the agent-level sandbox policy. See below. |
+| `hooks` | list | both (`.reyn/config/hooks.yaml` side is **hot-reloaded**) | Agent-lifecycle hooks — template_push / exec / exec_capture hooks at lifecycle points. See below. |
+| `action_retrieval` | map | PRJ only · **restart** | Universal catalog visibility + retrieval settings. See below. |
+| `embedding` | map | PRJ only · **restart** | RAG embedding model classes and batch settings. See below. |
+| `chat` | map | PRJ only · **restart** | Chat-session compaction settings. See below. |
+| `voice` | map | PRJ only · **restart** | ⚠️ Currently unavailable (no consumer). See below. |
+| `events` | map | PRJ only · **restart** | Audit-log rotation policy for chat-session event files. See below. |
+| `observability` | map | PRJ only · **restart** | Opt-in OpenTelemetry (OTLP) export of P6 audit-events. Off by default. See below. |
+| `tool_use` | map | PRJ only · **restart** | Chat-layer tool-use scheme x transport selector (`scheme`, `transport`). See below. |
+| `mcp` | map | both (`.reyn/config/mcp.yaml` side is **hot-reloaded**) | MCP server definitions. See below. |
+| `python` | map | PRJ only · **restart** | Python preprocessor additional allowed-modules. See below. |
+| `agent` | map | PRJ only · **restart** | Agent identity for P6 event audit trail and outgoing HTTP header. See below. |
+| `auth` | map | PRJ only · **restart** | OAuth provider configurations for `reyn auth login`. See below. |
+| `cron` | map | both (`.reyn/config/cron.yaml` side is **hot-reloaded**) | Scheduled skill executions. See below. |
+| `external_transports` | map | PRJ only · **restart** | Inbound transport → MCP tool routing for chat (Slack / LINE / Discord etc.). See below. |
+| `multimodal` | map | PRJ only · **restart** | Binary media (image/audio) size cap, on-oversize behaviour, and artefact storage paths. See below. |
+| `permissions` | map | PRJ only · **restart** | Default permission policy. See below. |
+| `prompt_cache_enabled` | bool | PRJ only · **restart** | Attach Anthropic prompt-cache markers to system prompts. Default `true`. |
+| `project_context_path` | string | PRJ only · **restart** | Markdown file injected into every phase system prompt. Unset (default): auto-resolves the cross-tool standard — `AGENTS.md` if present, else `REYN.md` (legacy fallback). Set an explicit path to pin one file; set `""` to disable. See note below. |
+| `api_base` | string | PRJ only · **restart** | LiteLLM proxy base URL. Typically set in `reyn.local.yaml` (gitignored). |
+| `llm` | map | PRJ only · **restart** | LLM-layer config: routing (#1829) and retry (#1835). |
+| `delegation` | map | PRJ only · **restart** | Cross-agent delegation policy (#2081). |
+| `cost_warn` | map | PRJ only · **restart** | Pre-selection awareness for high-cost models (#1830 / FP-0052). |
+| `offload` | map | PRJ only · **restart** | Opt-in switch for the tool-result size gates. |
+| `render_template` | map | PRJ only · **restart** | Operator-tunable output bounds for the `render_template` op (FP-0055 / #2679). |
+| `fs_watch` | map | PRJ only · **restart** | Operator-declared filesystem watch paths (#2608 H4). |
+| `composers` | list | both (but **not** hot-reloaded · **restart**) | Composer definitions. Empty (default) → `start_composers` is never called. |
+| `skills` | map | both (`.reyn/config/skills.yaml` side is **hot-reloaded**) | Skill declarations. Merged across config tiers by name (an explicit entry wins a collision). |
+| `pipelines` | map | both (`.reyn/config/pipelines.yaml` side is **hot-reloaded**) | Pipeline declarations. Same union-merge shape as `skills`. |
+| `presentations` | map | both (`.reyn/config/presentations.yaml` side is **hot-reloaded**) | Presentation-template declarations. Same union-merge shape as `skills` / `pipelines`. |
 
 > **Project context file (`project_context_path`).** Left unset, Reyn reads
 > `AGENTS.md` — the cross-tool convention that Claude Code, Codex, opencode and


### PR DESCRIPTION
**[architect]** — docs-only. No `src/` or `tests/` touched.

Owner asked two things about `docs/reference/config/reyn-yaml.ja.md`'s top-level
key table: whether it had omissions (「盛るではなくて、漏れがないかな？という質問ね」),
and then to distinguish hot-reload scope (「`.reyn/` 配下は hot reload 対応で
`reyn.{local.,}yaml` は hot reload 非対応かつ PRJ スコープで区別して欲しいよ」).

## What was measured

`ReynConfig` in `src/reyn/config/root.py` has **37** top-level fields, counted by
AST over `AnnAssign` targets on `origin/main`, not by grep — my first regex pass
said 38 (it captured `out` from an unrelated line).

| | rows before | fields | delta |
|---|---|---|---|
| `reyn-yaml.ja.md` | 25 | 37 | 12 missing |
| `reyn-yaml.md` | 28 | 37 | 10 missing **and 1 that no longer exists** |

The two docs had also drifted *from each other* — en already documented `hooks`
and `model_class_by_purpose`; ja did not.

**`tool_calls_op_loop_skills`** was listed in en as a live (if "transitional")
key. `git grep tool_calls_op_loop_skills origin/main -- src/` returns **zero
hits**; the only surviving references are two decision records and this table.
Row removed.

## What changed

Both tables now enumerate exactly the 37 fields — verified programmatically
after the edit (`missing: none, extra: none`, both files), not by re-reading.

A **"written on / reload"** column was added to the single existing table rather
than splitting into two tables. A split would list the six registries twice and
create a which-copy-is-authoritative question; the same-setting-two-sources shape
has cost this repo twice recently.

Column values are grounded in `_HOT_RELOAD_FILES` in `src/reyn/config/loader.py`
and the comment above it — the IN-set of six registries the hot-reload loader
re-reads at the turn boundary, and its own statement that "the file-split IS the
write-gate boundary (owner-confirmed #2073)". So:

- `mcp` / `cron` / `hooks` / `skills` / `pipelines` / `presentations` → both
  surfaces, the `.reyn/config/*.yaml` side hot-reloaded
- everything else → PRJ only, restart

**`composers` is the third state** and is marked as such: it is read from the
same 4-layer combine as `hooks` (including `.reyn/config/hooks.yaml`) but is
**startup-only**. This is the doc's own existing claim two sections down; the
first draft of this table had it wrong as "PRJ only" and the row was corrected
before commit. "Written under `.reyn/`" does not imply hot-reloaded.

The intro paragraph also states the table's axis is the **two project-level
surfaces only**, and points at `permission-model.md` for the agent surface
(`.reyn/agents/<name>/`, `.reyn/capability_profiles/<name>.yaml`) and the
session surface (`<session-state-dir>/config.yaml`) — which is what the owner's
original question was actually about.

## Test plan

- [x] `ReynConfig` field set extracted by AST from `git show
      origin/main:src/reyn/config/root.py` — 37 fields
- [x] Post-edit re-verification of both tables against that set: `missing: none,
      extra: none`
- [x] `tool_calls_op_loop_skills` absence confirmed with `git grep` on
      `origin/main -- src/` (zero hits) before removing the row
- [x] Column counts checked on every row of both tables (4 cells, no malformed
      pipe rows)
- [x] `scripts/check_doc_anchors.py` — **green** (`exit=0`, "no dangling
      anchors into published pages") after rebuilding `site/` with
      `mkdocs build --strict -f .mkdocs/mkdocs.yml` (7.2s, clean). The script
      resolves anchors against the **built site**, not the Markdown source.
      My first run used a `site/` built before `7c8a54a2` landed and reported
      one `ANCHOR_NOT_FOUND` that does not exist — see the correction comment
      below. Nothing to file; nothing pre-existing.
- [x] `permission-model.md` link target resolves from
      `docs/reference/config/`
- [ ] (skipped — docs-only, no `src/`/`tests/` in the diff) `ruff` /
      `test_tier_audit` / `mypy_ratchet` / `pytest`

## Scope of what I read

Both files' top-level key table and the prose immediately around it, plus the
three other places in `reyn-yaml.md` that mention hot-reload (`web` at ~806,
composers at ~993, `fs_watch` security at ~1377) to check for contradiction —
none found; the composers one is what corrected the row above. I did **not**
re-verify the per-key detail sections further down either file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
