### PR TITLE
docs(#4081): drop stale test-path claims from testing.md/testing.ja.md

### DIFF
--- a/docs/deep-dives/contributing/testing.ja.md
+++ b/docs/deep-dives/contributing/testing.ja.md
@@ -435,7 +435,9 @@ JSONL、1 行 1 レコード:
 
 ### モンキーパッチのライフサイクル
 
-`tests/conftest.py` は `@pytest.mark.replay` を持つテストに対して `LLMReplay` をインストールし、`try/finally` で復元します。マーカーを持たないテストは本物の `litellm.acompletion` を参照します。`tests/test_replay_skill_router.py` の `test_no_monkeypatch_leak` で検証済みです。
+`tests/conftest.py` は `@pytest.mark.replay` を持つテストに対して `LLMReplay` をインストールし、`try/finally` で復元します。マーカーを持たないテストは本物の `litellm.acompletion` を参照します。
+
+#4081: この節は以前 `tests/test_replay_skill_router.py` の `test_no_monkeypatch_leak` を「検証済み」の根拠として引用していましたが、そのファイルは #2435 の skill/phase decouple で削除され（サブシステム丸ごとの削除で、リネームではありません）、後継のテストもありません。上記の機構自体は今も生きています（`tests/conftest.py` の `_llm_replay` fixture で確認できます）が、no-leak 保証を専門に固定するテストは現在存在しません。
 
 ---
 
@@ -445,15 +447,11 @@ JSONL、1 行 1 レコード:
 # すべてのテスト
 python -m pytest tests/ -v
 
-# リプレイテストのみ
-python -m pytest tests/test_replay_*.py -v
-
-# OS 不変条件テストのみ（Tier 2）
-python -m pytest tests/test_os_invariants.py -v
-
 # 強制記録モード（稼働中の LLM が必要）
 REYN_LLM_RECORD=1 python -m pytest tests/ -v
 ```
+
+#4081: このブロックは以前 `python -m pytest tests/test_replay_*.py -v` と `python -m pytest tests/test_os_invariants.py -v` も示していましたが、glob もリテラルパスも今は何にも一致しません（`tests/test_replay_skill_router.py` 系と `tests/test_os_invariants.py` は #2435/#2438 の skill/phase engine 一括削除で消え、後継はありません）。未検証の新しい例に差し替えるのではなく削除しました——自分の変更が実際に触るファイル/キーワードにスコープを絞って実行してください（下の「プッシュ前」参照）。
 
 ---
 

--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -1049,7 +1049,9 @@ JSONL, one record per line:
 
 ### Monkeypatch lifecycle
 
-`tests/conftest.py` installs `LLMReplay` for tests with `@pytest.mark.replay` and restores in `try/finally`. Tests without the marker see real `litellm.acompletion`. Verified by `test_no_monkeypatch_leak` in `tests/test_replay_skill_router.py`.
+`tests/conftest.py` installs `LLMReplay` for tests with `@pytest.mark.replay` and restores in `try/finally`. Tests without the marker see real `litellm.acompletion`.
+
+#4081: this section used to cite `test_no_monkeypatch_leak` in `tests/test_replay_skill_router.py` as the test that verifies the try/finally restore — that file was deleted in the #2435 skill/phase decouple (no successor; the deletion was a whole-subsystem removal, not a rename) and nothing replaced the specific test. The mechanism above is still live (read `tests/conftest.py`'s `_llm_replay` fixture to confirm), but no dedicated test currently pins the no-leak guarantee.
 
 ---
 
@@ -1059,15 +1061,11 @@ JSONL, one record per line:
 # All tests
 python -m pytest tests/ -v
 
-# Only replay tests
-python -m pytest tests/test_replay_*.py -v
-
-# Only OS invariant tests (Tier 2)
-python -m pytest tests/test_os_invariants.py -v
-
 # Force record mode (live LLM required)
 REYN_LLM_RECORD=1 python -m pytest tests/ -v
 ```
+
+#4081: this block used to also show `python -m pytest tests/test_replay_*.py -v` and `python -m pytest tests/test_os_invariants.py -v` — both the glob and the literal path resolve to nothing today (the `tests/test_replay_skill_router.py` family and `tests/test_os_invariants.py` were removed in the #2435/#2438 skill/phase-engine bulk deletions, no successor). Dropped rather than replaced with an unverified new example — scope your own run to the files/keywords your change actually touches (see "Before you push" below).
 
 ---
 


### PR DESCRIPTION
**[tui-coder]** — part of #4081.

## What

#4081 tracks 470 `tests/...py` path-literal citations. Triaged down to a real work list:

```
470 → 73 stale (via check_tests_path_literal_reference.py's baseline)
    → 25 non-journal/non-scaffold-context
    → 4 actually fixable
```

The other 21 in that 25-bucket were read and deliberately left untouched (see #4081 comments for the per-item classification):
- **proposals (15)** — all classify as historical record (changelog-style "Implemented"/"Phase X implemented" entries with dates+commit hashes, or executed plan-of-record items like "Component D — delete these test files"), not present-tense claims.
- **decisions/ADR (5)** — out of scope by the project's ADR-immutability convention.
- **cli-redesign.md (1)** — same historical-record shape as the proposals (a numbered migration plan referencing already-completed prior steps).
- **test-citing-test (8 of 9)** — dangling "see also"/provenance pointers with no functional effect; genuinely harmless.

This PR fixes the remaining 4 — the only two genuinely **live claims** in the whole 25-item bucket, both in `testing.md`/`testing.ja.md` (ja+en pairs of the same two claims):

1. **"Verified by `test_no_monkeypatch_leak` in `tests/test_replay_skill_router.py`"** — that file was deleted in #2435's skill/phase decouple (no successor; whole-subsystem removal, confirmed via `git log --all --diff-filter=R --follow`, zero rename events). No test currently pins the no-leak guarantee it cited. Dropped the specific citation rather than inventing an unverified new one; kept the description of the still-live mechanism (`tests/conftest.py`'s try/finally install/restore — read that fixture to confirm it's accurate).
2. **The "Running tests" example block's two dead commands** (`tests/test_replay_*.py` glob, `tests/test_os_invariants.py` literal) — neither resolves to anything (same #2435 removal, plus #2438's bulk skill/phase-engine delete for the latter). Dropped rather than replaced with an unverified new example.

Both edits carry a `#4081` note in the doc explaining what was removed and why.

## Not in this PR (recorded on #4081, not silently dropped)

- **`test_mcp_sse.py → test_mcp_server.py`** — the one test-citing-test entry that's more than a dangling pointer: it claims coverage of `list_agents_impl`/`send_to_agent_impl` lives in the (now-deleted) `tests/test_mcp_server.py`. Fixing this needs confirming where that coverage actually lives today (moved vs dropped), not just a reference swap — left open on the issue.

## Test plan

- [x] `ruff check docs/` — clean
- [x] `python scripts/check_tests_path_literal_reference.py` — OK, unchanged count (the fixed sections still mention the dead paths, now inside explanatory `#4081` notes rather than as live claims — same baselined "stale" classification, no new violation)
- [x] `python scripts/mypy_ratchet.py` — OK, unaffected (doc-only change)
- [x] Doc-only change — no test-tier-audit / module-docstring gates apply
- [ ] Visual/docs-build: not run locally (doc-only prose edit, CI's own `docs build (strict)` gate covers this)
