### PR TITLE
docs(config): reyn-yaml — seven key descriptions that understate their key, and two duplicate-anchor sections

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -703,7 +703,7 @@ auth:
 - [コンセプト: シークレット管理](../../concepts/runtime/secret-handling.md) — OAuth ライフサイクルと認証情報スコープ
 - [コンセプト: マルチエージェント](../../concepts/multi-agent/multi-agent.md) — エージェント識別子伝播
 
-## `cron:` ブロック
+## `cron` ブロック
 
 定期的なメッセージ配信をスケジュールします。スケジューラーは `reyn web` の一部（= FastAPI lifespan で起動）として、または `reyn cron run` 経由のフォアグラウンドプロセスとして実行されます。
 
@@ -1099,7 +1099,7 @@ embedding:
 
 3 つの組み込みクラスはすべて litellm 経由の OpenAI backed です。in-process のローカルバックエンドはありません（#3128 で `local-mini` / `local-e5` sentence-transformers クラスと `reyn[local-embed]` extras を削除済み）— ローカル / オフラインモデルが必要な operator は、自前で立てた litellm proxy 背後のモデルを指す custom `embedding.classes` エントリを追加します。セットアップ手順は [Concepts: RAG — Local and offline embedding models](../../concepts/data-retrieval/rag.md#local-and-offline-embedding-models)（英語）を参照。
 
-## `chat` ブロック
+## `chat` ブロック {#chat-compaction-block}
 
 チャットは最初にコンテキストウィンドウを生のターンで充填し、履歴が
 effective trigger（`component_weights` からモデルの実際のコンテキストウィンドウに対して

--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -52,20 +52,20 @@ reload）、`reyn.yaml` 側に書いた同じキーは他と同じく再起動�
 | `model` | 文字列 | PRJ のみ・**再起動** | デフォルトのモデルクラス。`models` を通じて解決されます。`--model` でオーバーライド。 |
 | `models` | マップ | PRJ のみ・**再起動** | クラス名 → LiteLLM モデル文字列 **または** dict（以下参照）。 |
 | `output_language` | 文字列 | PRJ のみ・**再起動** | デフォルトの出力言語コード（例: `en`、`ja`）。`--output-language` でオーバーライド。 |
-| `safety` | マップ | PRJ のみ・**再起動** | ランタイムの停止条件: ループ検出上限、タイムアウト、上限超過時ポリシー。以下参照。 |
+| `safety` | マップ | PRJ のみ・**再起動** | ランタイムの上限**と content 層の防御**: ループ検出上限、タイムアウト、上限超過時ポリシー、非信頼コンテンツの threat scan + fence（`safety.threat_scan`、FP-0050）、LLM spawn ツリーの上限（`safety.spawn`、DoS ガード）。以下参照。 |
 | `cost` | マップ | PRJ のみ・**再起動** | バジェット上限とレート制限（エージェントごと、日次、月次）。以下参照。 |
-| `web` | マップ | PRJ のみ・**再起動** | `web_fetch` と MCP レジストリ呼び出しの SSL 設定。以下参照。 |
+| `web` | マップ | PRJ のみ・**再起動** | **無関係な 2 つのサブシステムが同居しています。** (a) `web_fetch` ツールと MCP レジストリ呼び出しの SSL 設定（`web.fetch`）、(b) `reyn web` ゲートウェイ: 認証モデル（`web.auth`）、WebSocket 受信フレーム上限（`web.ws_max_size`）、マウントするサーフェス（`web.surfaces`）。以下参照。 |
 | `sandbox` | マップ | PRJ のみ・**再起動** | `sandboxed_exec` のバックエンド選択・非対応プラットフォームポリシー・agent-level サンドボックスポリシー。以下参照。 |
 | `action_retrieval` | マップ | PRJ のみ・**再起動** | ユニバーサルカタログの可視化 + 検索設定。以下参照。 |
 | `embedding` | マップ | PRJ のみ・**再起動** | RAG 埋め込みモデルクラスとバッチ設定。以下参照。 |
-| `chat` | マップ | PRJ のみ・**再起動** | チャットセッションの Head/Body/Tail 圧縮設定。以下参照。 |
+| `chat` | マップ | PRJ のみ・**再起動** | チャットセッションのランタイム設定: 履歴の圧縮、reasoning（"thinking"）テキストの扱い、対話レンダラ（`render_mode`）、TUI の gutter、body の neutralize、許可する画像 URL スキーム。以下参照。 |
 | `voice` | マップ | PRJ のみ・**再起動** | ⚠️ 現在利用不可(consumerなし)。以下参照。 |
-| `events` | マップ | PRJ のみ・**再起動** | チャットセッションイベントファイルの監査ログローテーションポリシー。以下参照。 |
+| `events` | マップ | PRJ のみ・**再起動** | `.reyn/events` 配下の P6 **audit-event** ファイルのローテーション（サイズ / 経過時間 / 掃除周期）。WAL-event でも hook-event でもありません。以下参照。 |
 | `observability` | マップ | PRJ のみ・**再起動** | P6 監査イベントの OpenTelemetry (OTLP) エクスポート（オプトイン）。デフォルトは無効。以下参照。 |
 | `tool_use` | マップ | PRJ のみ・**再起動** | chat レイヤーの tool-use scheme x transport セレクタ（`scheme`、`transport`）。以下参照。 |
 | `mcp` | マップ | 両方（`.reyn/config/mcp.yaml` 側は **hot reload**） | MCP サーバー定義。以下参照。 |
-| `python` | マップ | PRJ のみ・**再起動** | Python preprocessor の追加許可モジュール。以下参照。 |
-| `agent` | マップ | PRJ のみ・**再起動** | P6 イベント監査証跡と送信 HTTP ヘッダー用のエージェント識別子。以下参照。 |
+| `python` | マップ | PRJ のみ・**再起動** | Python preprocessor が import してよい追加モジュール（`python.allowed_modules`）— このリスト 1 つがキーの全体です。以下参照。 |
+| `agent` | マップ | PRJ のみ・**再起動** | エージェントの**識別子のみ**（`agent.id`）— P6 監査証跡と送信 HTTP ヘッダーに刻まれます。**エージェントの定義・設定はしません**（エージェント定義は `.reyn/agents/<名前>/`）。以下参照。 |
 | `auth` | マップ | PRJ のみ・**再起動** | `reyn auth login` 用の OAuth プロバイダー設定。以下参照。 |
 | `cron` | マップ | 両方（`.reyn/config/cron.yaml` 側は **hot reload**） | スケジュール付きスキル実行。以下参照。 |
 | `external_transports` | マップ | PRJ のみ・**再起動** | チャット向け受信トランスポート → MCP ツールルーティング（Slack / LINE / Discord など）。以下参照。 |
@@ -77,7 +77,7 @@ reload）、`reyn.yaml` 側に書いた同じキーは他と同じく再起動�
 | `llm` | マップ | PRJ のみ・**再起動** | LLM 層の設定（ルーティング #1829 / リトライ #1835）。 |
 | `model_class_by_purpose` | マップ | PRJ のみ・**再起動** | 用途名 → モデルクラス。用途ごとに既定クラスを差し替えます。 |
 | `delegation` | マップ | PRJ のみ・**再起動** | エージェント間委任のポリシー（#2081）。 |
-| `cost_warn` | マップ | PRJ のみ・**再起動** | 高コストモデルを選ぶ前の事前警告（#1830 / FP-0052）。 |
+| `cost_warn` | マップ | PRJ のみ・**再起動** | 高コストモデルのゲート（#1830 / FP-0052）: 選択前に警告し、名前に反して**ブロックもできます**（`cost_warn.block_on_high_cost`）。以下参照。 |
 | `offload` | マップ | PRJ のみ・**再起動** | tool 結果のサイズゲートの opt-in スイッチ。 |
 | `render_template` | マップ | PRJ のみ・**再起動** | `render_template` op の出力上限（FP-0055 / #2679）。 |
 | `fs_watch` | マップ | PRJ のみ・**再起動** | オペレータが宣言するファイル監視パス（#2608 H4）。 |

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -56,21 +56,21 @@ can additionally be written on an **agent** surface (`.reyn/agents/<name>/`,
 | `models` | map | PRJ only · **restart** | Class name → LiteLLM model string **or** dict (see below). |
 | `model_class_by_purpose` | map | PRJ only · **restart** | Per-purpose model-class override (`router` / `control_ir` / `tool` / `judge`). Unset purpose → `model`. `compaction` is NOT a valid key (#3785) — compaction always follows the conversation model. See below. |
 | `output_language` | string | PRJ only · **restart** | Default output language code (e.g. `en`, `ja`). Override with `--output-language`. |
-| `safety` | map | PRJ only · **restart** | Runtime stop conditions: loop-detection caps, timeouts, on-limit policy. See below. |
+| `safety` | map | PRJ only · **restart** | Runtime bounds **and content-layer defenses**: loop-detection caps, timeouts, on-limit policy, the untrusted-content threat scan + fence (`safety.threat_scan`, FP-0050), and operator bounds on the LLM spawn tree (`safety.spawn`, a DoS guard). See below. |
 | `cost` | map | PRJ only · **restart** | Budget caps and rate limits (per-agent, daily, monthly). See below. |
-| `web` | map | PRJ only · **restart** | SSL settings for `web_fetch` and MCP registry calls, the gateway auth model, and (`web.surfaces`) which `reyn web` surfaces are mounted. See below. |
+| `web` | map | PRJ only · **restart** | **Two unrelated subsystems share this key.** (a) the `web_fetch` tool and MCP registry calls: SSL settings (`web.fetch`); (b) the `reyn web` gateway: auth model (`web.auth`), WebSocket inbound-frame ceiling (`web.ws_max_size`), and which surfaces are mounted (`web.surfaces`). See below. |
 | `sandbox` | map | PRJ only · **restart** | Sandboxed-exec backend selection, unsupported-platform policy, and the agent-level sandbox policy. See below. |
 | `hooks` | list | both (`.reyn/config/hooks.yaml` side is **hot-reloaded**) | Agent-lifecycle hooks — template_push / exec / exec_capture hooks at lifecycle points. See below. |
 | `action_retrieval` | map | PRJ only · **restart** | Universal catalog visibility + retrieval settings. See below. |
 | `embedding` | map | PRJ only · **restart** | RAG embedding model classes and batch settings. See below. |
-| `chat` | map | PRJ only · **restart** | Chat-session compaction settings. See below. |
+| `chat` | map | PRJ only · **restart** | Chat-session runtime knobs: history compaction, reasoning/"thinking" text handling, the interactive renderer (`render_mode`), TUI gutters, body neutralization, and permitted image-URL schemes. See below. |
 | `voice` | map | PRJ only · **restart** | ⚠️ Currently unavailable (no consumer). See below. |
-| `events` | map | PRJ only · **restart** | Audit-log rotation policy for chat-session event files. See below. |
+| `events` | map | PRJ only · **restart** | Rotation policy (size / age / cleanup period) for the P6 **audit-event** files under `.reyn/events`. Not WAL-events, not hook-events. See below. |
 | `observability` | map | PRJ only · **restart** | Opt-in OpenTelemetry (OTLP) export of P6 audit-events. Off by default. See below. |
 | `tool_use` | map | PRJ only · **restart** | Chat-layer tool-use scheme x transport selector (`scheme`, `transport`). See below. |
 | `mcp` | map | both (`.reyn/config/mcp.yaml` side is **hot-reloaded**) | MCP server definitions. See below. |
-| `python` | map | PRJ only · **restart** | Python preprocessor additional allowed-modules. See below. |
-| `agent` | map | PRJ only · **restart** | Agent identity for P6 event audit trail and outgoing HTTP header. See below. |
+| `python` | map | PRJ only · **restart** | Additional modules the Python preprocessor may import (`python.allowed_modules`) — that one list is the whole key. See below. |
+| `agent` | map | PRJ only · **restart** | Agent **identity** only (`agent.id`) — stamped on the P6 audit trail and the outgoing HTTP header. Does **not** define or configure agents; agent definitions live in `.reyn/agents/<name>/`. See below. |
 | `auth` | map | PRJ only · **restart** | OAuth provider configurations for `reyn auth login`. See below. |
 | `cron` | map | both (`.reyn/config/cron.yaml` side is **hot-reloaded**) | Scheduled skill executions. See below. |
 | `external_transports` | map | PRJ only · **restart** | Inbound transport → MCP tool routing for chat (Slack / LINE / Discord etc.). See below. |
@@ -81,7 +81,7 @@ can additionally be written on an **agent** surface (`.reyn/agents/<name>/`,
 | `api_base` | string | PRJ only · **restart** | LiteLLM proxy base URL. Typically set in `reyn.local.yaml` (gitignored). |
 | `llm` | map | PRJ only · **restart** | LLM-layer config: routing (#1829) and retry (#1835). |
 | `delegation` | map | PRJ only · **restart** | Cross-agent delegation policy (#2081). |
-| `cost_warn` | map | PRJ only · **restart** | Pre-selection awareness for high-cost models (#1830 / FP-0052). |
+| `cost_warn` | map | PRJ only · **restart** | High-cost-model gate (#1830 / FP-0052): warns before an expensive model is selected — and, despite the name, **can block it** (`cost_warn.block_on_high_cost`). See below. |
 | `offload` | map | PRJ only · **restart** | Opt-in switch for the tool-result size gates. |
 | `render_template` | map | PRJ only · **restart** | Operator-tunable output bounds for the `render_template` op (FP-0055 / #2679). |
 | `fs_watch` | map | PRJ only · **restart** | Operator-declared filesystem watch paths (#2608 H4). |

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -1012,11 +1012,15 @@ reload-time reconciliation yet).
 
 ## `fs_watch` block
 
-Declares filesystem paths whose changes fire the `file_changed`
-[external-event hook](../../concepts/runtime/hooks.md#file_changed). Restart-only
-(OUT-set) — there is no op or tool verb that lets an agent register or widen
-a watch; a filesystem-wide change feed is treated as the same class of
-concern as sandbox policy.
+Operator-declared filesystem paths whose changes fire the `file_changed`
+[external-event hook](../../concepts/runtime/hooks.md#file_changed) (#2608 H4).
+Each path is watched recursively. To scope a hook to a sub-tree, give it
+`on: file_changed` plus a `matcher: {path: "..."}` glob — see the `hooks:`
+block above.
+
+Restart-only (OUT-set) — there is no op or tool verb that lets an agent
+register or widen a watch; a filesystem-wide change feed is treated as the
+same class of concern as sandbox policy.
 
 ```yaml
 fs_watch:
@@ -1320,7 +1324,7 @@ See also:
 - [Concepts: secret handling](../../concepts/runtime/secret-handling.md) — OAuth lifecycle and credential scoping
 - [Concepts: multi-agent](../../concepts/multi-agent/multi-agent.md) — agent identity propagation
 
-## `cron:` block
+## `cron` block
 
 Schedule recurring message dispatches. The scheduler runs as part of
 `reyn web` (= started in the FastAPI lifespan) or as a foreground
@@ -1364,42 +1368,6 @@ cron:
 - `docs/reference/cli/cron.md` — `reyn cron run/list/status`
 - `docs/concepts/data-retrieval/operational-intelligence.md` — scheduling a
   recurring events-log indexing agent
-
-## `fs_watch:` block
-
-Operator-declared filesystem watch paths (#2608 H4). Each path is watched
-recursively; a create/modify/delete under it fires the `file_changed`
-external-event hook (see the `hooks:` block above — `on: file_changed`, plus
-a `matcher: {path: "..."}` glob to scope a hook to a sub-tree).
-
-```yaml
-fs_watch:
-  paths:
-    - /repo/src
-    - /repo/docs
-  debounce_seconds: 0.2   # coalesce a write-burst on one path into ONE fire
-```
-
-### Fields
-
-- **`paths`** (optional, default `[]`) — list of directories to watch,
-  recursively. Empty (the default) → the watcher never starts.
-- **`debounce_seconds`** (optional, default `0.2`) — a burst of writes to the
-  SAME path within this window coalesces to one hook fire.
-
-### Security
-
-`fs_watch:` is **OUT-set only** — restart-only, loaded from
-`reyn.yaml`/`reyn.local.yaml`, never from a `.reyn/*.yaml` hot-reload file.
-There is no op or tool verb an agent can use to register or widen a watch —
-a filesystem-wide change-notification feed is an info-gathering surface, so
-it gets the same operator-only gate as `sandbox:` policy.
-
-### Requirements
-
-Requires the optional `watchdog` package (`pip install reyn[fs-watch]`). If
-`paths` is configured but `watchdog` isn't installed, the feature logs a
-warning and stays off — the rest of the session is unaffected.
 
 ## `permissions` block
 
@@ -1903,7 +1871,7 @@ Built-in classes (active when `classes:` is empty or absent):
 
 All three built-in classes are OpenAI-backed via litellm. There is no in-process local backend (#3128 removed the `local-mini` / `local-e5` sentence-transformers classes and the `reyn[local-embed]` extras) — an operator who wants a local/offline model adds a custom `embedding.classes` entry naming a model served behind an operator-run litellm proxy. See [Concepts: RAG — Local and offline embedding models](../../concepts/data-retrieval/rag.md#local-and-offline-embedding-models) for the setup.
 
-## `chat` block
+## `chat` block {#chat-compaction-block}
 
 Chat fills the context window with raw turns first; compaction fires when the
 history exceeds the effective trigger (window-relative, derived from


### PR DESCRIPTION
**[architect]** — docs-only. No `src/` or `tests/` touched. Follows #4169 on the
same file pair; owner asked for the cheap, non-breaking half of a top-level-key
review first.

Two independent commits, reviewable separately.

## 1. Seven descriptions that understate what the key holds

Method: extract each sub-config class's actual `AnnAssign` fields with `ast`,
compare against the table's one-line description.

| key | what the description missed |
|---|---|
| `safety` | **3 of 5 fields.** Omitted `threat_scan` (the untrusted-content scan + fence, FP-0050) and `spawn` (the spawn-tree DoS bound) |
| `chat` | 1 of 6 ("compaction settings") |
| `web` | **One key, two unrelated subsystems** — the `web_fetch` tool's SSL config and the `reyn web` gateway's auth / ws ceiling / surfaces. en named all but `ws_max_size`; **ja named only the SSL half** |
| `cost_warn` | Named "warn"; `block_on_high_cost` blocks |
| `agent` | Description was accurate, but `agent:` reads as "configure agents" and holds only `agent.id`. Now says agent definitions live in `.reyn/agents/<name>/` |
| `python` | Holds `allowed_modules` and nothing else |
| `events` | Bare "event" — it is the P6 **audit-event** file rotation, not WAL-events, not hook-events |

`safety` is the one that mattered most: a reader scanning the table for where
the prompt-injection fence is configured had no reason to open it.

**Descriptions only** — no key renamed, added, or removed. The naming and
structural findings from the same review (e.g. the LLM domain occupying six
top-level keys; the registry-vs-policy split being load-bearing in code and
invisible in the config surface) are breaking changes and are not in this PR.

## 2. Two duplicate headings that split one anchor in two

Measured on the **built site**, not the source:

```
id="fs_watch-block"   id="fs_watch-block_1"
id="chat-block"       id="chat-block_1"
```

Four inbound links (`feature-map.md`, `hooks.md` ×2, `hooks.ja.md`) point at
`#fs_watch-block`, so every one resolved to the first section and the second was
unreachable by any link on the site.

**`check_doc_anchors.py` was green through all of this** — the anchor it checks
exists. Nothing checks that the *other* section is reachable, which is why a
duplicate heading is invisible to it.

- **`fs_watch` ×2 were near-duplicates** — same two fields, same defaults, same
  watchdog requirement, same OUT-set rationale, written twice in two shapes (a
  table and a bullet list). Folded the second's only unique content (the
  `matcher: {path}` sub-tree scoping tip, the #2608 H4 reference) into the first
  and deleted it.
- **`chat` ×2 are genuinely different topics that collided on a name** — general
  runtime knobs vs compaction internals. Renamed the second to `chat.compaction`
  (`id="chatcompaction-block"`), which is what it documents.
- Dropped the trailing colon from `## cron:` in both languages. The colon was
  invisible to the slug, so `#cron-block` is unchanged and **no link moves**.

## Corrections to my own earlier claims, recorded so the next reader doesn't inherit them

- I first reported that the "Full field reference" links landed on a section
  *without* a field reference. **Wrong** — the surviving `fs_watch` section has
  the field table. The defect was the unreachable duplicate, not a misdirected
  link.
- I first reported en's `web` description omitted `surfaces` and `ws_max_size`.
  It omitted only `ws_max_size`.
- I first reported `mcp` and `model_class_by_purpose` as "See below" with no
  section. **Both are documented** (`## MCP servers`; an `h3` under `## models`)
  — my `^## ` scan missed the h3 and the differently-worded heading. Neither is
  a defect and neither is touched here.
- I reported a `解決順序` heading duplicated 4× in ja. It occurs **once**; the
  count was a shell aggregation artifact, confirmed against a Python `Counter`.

## Test plan

- [x] Both tables still enumerate exactly the 37 `ReynConfig` fields after the
      rebase (`missing: none, extra: none`) — the field set re-extracted by AST
      from `git show origin/main:src/reyn/config/root.py`, not reused from
      before the merge
- [x] Every described field verified against the sub-config class's actual
      `AnnAssign` list (`SafetyConfig`, `ChatConfig`, `WebConfig`,
      `CostWarnConfig`, `AgentConfig`, `PythonConfig`, `EventsConfig`)
- [x] Zero duplicate `##` headings remain in either file (Python `Counter`,
      not `sort | uniq`)
- [x] Rebuilt the site: `fs_watch-block` is now a single id, `chat-block` and
      `chatcompaction-block` are distinct, `cron-block` unchanged
- [x] `scripts/check_doc_anchors.py` green against the fresh build
- [x] Column counts intact on every row of both tables
- [ ] (skipped — docs-only, no `src/`/`tests/` in the diff) `ruff` /
      `test_tier_audit` / `mypy_ratchet` / `pytest`

## Scope of what I read

The top-level key table in both files, the seven sub-config classes above, both
`fs_watch` sections and both `chat` sections in full, and the four inbound
`#fs_watch-block` links. I did **not** audit the remaining ~25 detail sections
for the same description-vs-fields drift — the seven here came from the keys
whose one-liners I could falsify against a class definition, so **this is not a
claim that the other sections are accurate**, only that these seven were not.

The `mkdocs` INFO lines about ja lacking `#fs_watch-block` are the known en/ja
parity backlog (#2967), unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)