### PR TITLE
fix(#4166): CodeActRunner races cancel_event, kills the subprocess

### DIFF
--- a/src/reyn/core/kernel/codeact_runner.py
+++ b/src/reyn/core/kernel/codeact_runner.py
@@ -121,12 +121,24 @@ class CodeActRunner:
         timeout: float = 30.0,
         cwd: str | None = None,
         allow_unsandboxed: bool = False,
+        cancel_event: "asyncio.Event | None" = None,
     ) -> dict[str, Any]:
         """Execute ``code`` in the CodeAct harness; service its tool() proxy via
         ``dispatch``. Returns the harness response dict
         (``{ok: True, result}`` | ``{ok: False, kind, error, traceback?}``), plus a
-        ``status`` field (``ok`` | ``error`` | ``timeout`` | ``sandbox_unavailable``)
-        for the scheme layer.
+        ``status`` field (``ok`` | ``error`` | ``timeout`` | ``cancelled`` |
+        ``sandbox_unavailable``) for the scheme layer.
+
+        ``cancel_event`` (#4166, mirrors #1470's ``noop_backend``/``landlock``
+        cancel-aware ``run()`` race): when provided, races the harness's
+        completion against ``cancel_event.wait()`` the SAME way the sibling
+        ``sandboxed_exec`` op's non-CodeAct subprocess launches already do —
+        this runner did its own ``Popen`` instead of going through
+        ``SandboxBackend.run()`` (see the module docstring for why: it needs a
+        duplex control channel live during execution), so it never got the
+        cancel-aware race the shared backend path has carried since #1470.
+        ``cancel_event=None`` (the default) is byte-identical to before —
+        only the wall-clock ``timeout`` bounds the run.
 
         **Fail-closed** (owner-signed): CodeAct runs ONLY under an available OS
         sandbox (Seatbelt / Landlock). When no real backend is available the run is
@@ -209,28 +221,63 @@ class CodeActRunner:
         # a snippet printing in a loop is an ordinary mistake rather than an exotic
         # one.
         request_bytes = json.dumps(request).encode("utf-8")
-        comm_future = loop.run_in_executor(
+        comm_future: asyncio.Future = loop.run_in_executor(
             None, lambda: communicate_capped(proc, input=request_bytes),
         )
         timed_out = False
+        cancelled = False
         truncated = False
+        # #4166: cancel_event=None is the byte-identical original path
+        # (asyncio.wait_for against the wall-clock timeout alone). When
+        # provided, race BOTH the timeout and the event — mirrors
+        # noop_backend.py's cancel-aware run() (#1470) exactly, so a
+        # cancel_inflight() during a running snippet kills the subprocess
+        # instead of completing it out from under the (already-settled)
+        # task, the gap #4166 measured live.
         try:
-            stdout_b, stderr_b, truncated = await asyncio.wait_for(
-                comm_future, timeout=timeout
-            )
-        except asyncio.TimeoutError:
-            timed_out = True
-            service_task.cancel()
-            await kill_process_tree(proc)
-            stdout_b, stderr_b = b"", b""
-        else:
-            # Normal exit: the child sent op="final" then closed the channel (EOF), so
-            # DRAIN the service task (bounded) to populate final_box, rather than
-            # cancelling it mid-frame.
-            try:
-                await asyncio.wait_for(service_task, timeout=2.0)
-            except Exception:  # noqa: BLE001 — drain best-effort; cancel if it hangs
-                service_task.cancel()
+            if cancel_event is None:
+                try:
+                    stdout_b, stderr_b, truncated = await asyncio.wait_for(
+                        comm_future, timeout=timeout
+                    )
+                except asyncio.TimeoutError:
+                    timed_out = True
+                    service_task.cancel()
+                    await kill_process_tree(proc)
+                    stdout_b, stderr_b = b"", b""
+                else:
+                    # Normal exit: the child sent op="final" then closed the channel
+                    # (EOF), so DRAIN the service task (bounded) to populate
+                    # final_box, rather than cancelling it mid-frame.
+                    try:
+                        await asyncio.wait_for(service_task, timeout=2.0)
+                    except Exception:  # noqa: BLE001 — drain best-effort; cancel if it hangs
+                        service_task.cancel()
+            else:
+                cancel_task = asyncio.create_task(cancel_event.wait())
+                done, _ = await asyncio.wait(
+                    {comm_future, cancel_task},
+                    timeout=timeout,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if cancel_task in done:
+                    cancelled = True
+                    service_task.cancel()
+                    await kill_process_tree(proc)
+                    stdout_b, stderr_b = b"", b""
+                elif not done:
+                    timed_out = True
+                    cancel_task.cancel()
+                    service_task.cancel()
+                    await kill_process_tree(proc)
+                    stdout_b, stderr_b = b"", b""
+                else:
+                    cancel_task.cancel()
+                    stdout_b, stderr_b, truncated = comm_future.result()
+                    try:
+                        await asyncio.wait_for(service_task, timeout=2.0)
+                    except Exception:  # noqa: BLE001 — drain best-effort; cancel if it hangs
+                        service_task.cancel()
         finally:
             try:
                 parent_sock.close()
@@ -239,6 +286,11 @@ class CodeActRunner:
             if cleanup is not None:
                 cleanup()
 
+        if cancelled:
+            return {
+                "ok": False, "status": "cancelled",
+                "kind": "Cancelled", "error": "codeact run was cancelled",
+            }
         if timed_out:
             return {
                 "ok": False, "status": "timeout",

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3744,6 +3744,19 @@ class RouterLoop:
                 # default, owner ruling B) — PATH passes by default now,
                 # where the old allow-list had to name it explicitly.
                 or {"network": False, "deny_subprocess": True},
+                # #4166: the SAME per-turn cancel_event the non-CodeAct
+                # sandboxed_exec op already races via ctx.cancel_event
+                # (make_router_op_context() is the public factory that
+                # builds that same OpContext — reusing it here rather than
+                # adding a second cancel_event holder on the adapter).
+                # getattr-guarded like sandbox_config above: a phase/test
+                # host that doesn't implement it degrades to cancel_event=
+                # None (byte-identical — the pre-#4166 behaviour).
+                "cancel_event": (
+                    self.host.make_router_op_context().cancel_event
+                    if callable(getattr(self.host, "make_router_op_context", None))
+                    else None
+                ),
             },
         )
         exec_res = await self._scheme.execute(interp, exec_ctx, ops=self)

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2030,10 +2030,27 @@ class Session:
         mode). Returns a human-readable summary string.
 
         #1468 cooperative layer: sets the cooperative cancellation flag so the
-        turn's run_loop breaks at the next tool-iteration boundary. A slow tool
-        already in flight completes before the cancel takes effect (subprocess
-        kill is a follow-up scope). Any spawned tasks are cancelled immediately
-        via asyncio task cancellation (existing behaviour, preserved here).
+        turn's run_loop breaks at the next tool-iteration boundary, AND sets
+        the per-turn ``cancel_event`` (``RouterLoopDriver.cancel_event``,
+        threaded onto the router's OpContext via
+        ``RouterHostAdapter._set_cancel_event`` — #1470) that a currently-
+        running sandboxed subprocess tool races against. Any spawned tasks
+        are cancelled immediately via asyncio task cancellation (existing
+        behaviour, preserved here).
+
+        #4166 correction (this docstring previously said "subprocess kill is
+        a follow-up scope" — that was stale even when written: the regular
+        ``sandboxed_exec`` op's non-CodeAct launches have raced
+        ``cancel_event`` and killed the process group since #1470;
+        ``CodeActRunner`` was the one launch route that reinvented its own
+        ``Popen`` instead of going through ``SandboxBackend.run()`` and so
+        never got it — #4166 closed that gap). A tool NOT wired to
+        ``cancel_event`` at all (this Session's set is #1470's
+        ``sandboxed_exec``/CodeAct plus whatever else threads
+        ``OpContext.cancel_event`` through — MCP calls, embed, plugin
+        install; grep ``cancel_event=ctx.cancel_event`` for the current
+        list) still only observes the cooperative flag at the next
+        iteration boundary, same as before.
 
         #2242 hard layer: ALSO cancels ``_turn_owner_task`` directly (the
         per-turn sub-task ``run_one_iteration`` spawns to run ``_run_turn_body``

--- a/src/reyn/tools/schemes/_content_fence_cell.py
+++ b/src/reyn/tools/schemes/_content_fence_cell.py
@@ -198,6 +198,10 @@ class ContentFenceCellScheme:
             timeout=extra.get("timeout", 30.0),
             cwd=extra.get("cwd"),
             allow_unsandboxed=extra.get("allow_unsandboxed", False),
+            # #4166: the same per-turn cancel_event the sibling (non-CodeAct)
+            # sandboxed_exec op already races via ctx.cancel_event — None
+            # (the key absent) is byte-identical to before.
+            cancel_event=extra.get("cancel_event"),
         )
         return ExecutionResult(tool_results=[out])
 

--- a/tests/security/test_codeact_cancel_4166.py
+++ b/tests/security/test_codeact_cancel_4166.py
@@ -1,0 +1,88 @@
+"""Tier 2: #4166 — CodeActRunner.run(cancel_event=...) actually kills a
+running snippet's subprocess, mirroring the cancel-aware race
+``noop_backend``/``landlock`` already carry for the sibling (non-CodeAct)
+sandboxed_exec op since #1470.
+
+Real subprocess, real asyncio.Event, real wall-clock — no fakes of the
+process or the race. The falsifying witness is elapsed time: the snippet
+sleeps far longer than the test waits before cancelling, so if the kill
+did NOT happen the run would take (and this test would observe) the full
+sleep duration instead of returning promptly.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from reyn.core.kernel.codeact_runner import CodeActRunner
+
+
+async def _dispatch(name: str, args: dict) -> dict:
+    return {"status": "ok", "data": None}
+
+
+@pytest.mark.asyncio
+async def test_cancel_event_kills_a_running_snippet_promptly() -> None:
+    """Tier 2: cancel_event.set() during a long-running snippet returns
+    status='cancelled' well before the snippet's own sleep would finish —
+    the process was actually killed, not merely marked cancelled while
+    left running to completion."""
+    runner = CodeActRunner()
+    cancel_event = asyncio.Event()
+    code = "import time\ntime.sleep(30)\nresult = 'never gets here'"
+
+    async def _cancel_soon() -> None:
+        await asyncio.sleep(0.3)
+        cancel_event.set()
+
+    canceller = asyncio.create_task(_cancel_soon())
+    start = time.monotonic()
+    out = await runner.run(
+        code=code, dispatch=_dispatch, allow_unsandboxed=True,
+        timeout=30.0, cancel_event=cancel_event,
+    )
+    elapsed = time.monotonic() - start
+    await canceller
+
+    assert out["status"] == "cancelled", out
+    assert out["ok"] is False, out
+    # The falsifying witness: if kill_process_tree did NOT actually run,
+    # the 30s sleep would have to complete (or the 30s timeout would fire)
+    # before this returns. Cancelling within 0.3s must not cost anywhere
+    # near that — generous margin, not pinning exact timing.
+    assert elapsed < 5.0, (
+        f"took {elapsed:.1f}s after a 0.3s cancel — the subprocess was not "
+        "actually killed, only marked cancelled while left running"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_event_never_set_runs_to_completion_unaffected() -> None:
+    """Tier 2: accept-side sibling — cancel_event is provided (not None) but
+    never fires, so the run must complete normally exactly as if no
+    cancel_event had been passed at all. Proves the new race arm doesn't
+    change behaviour for the ordinary (uncancelled) case."""
+    runner = CodeActRunner()
+    cancel_event = asyncio.Event()
+    code = "result = 1 + 1"
+    out = await runner.run(
+        code=code, dispatch=_dispatch, allow_unsandboxed=True,
+        cancel_event=cancel_event,
+    )
+    assert out["ok"] is True, out
+    assert out["result"] == 2
+    assert cancel_event.is_set() is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_event_omitted_still_runs_the_pre_4166_call_shape() -> None:
+    """Tier 2: the default (cancel_event=None, the call shape every existing
+    caller used before #4166) still works — the new parameter is additive."""
+    runner = CodeActRunner()
+    out = await runner.run(
+        code="result = 'ok'", dispatch=_dispatch, allow_unsandboxed=True,
+    )
+    assert out["ok"] is True, out
+    assert out["result"] == "ok"


### PR DESCRIPTION
**[tui-coder]** — closes #4166. Part of #3903's implementation order (① this, then ② the user-facing slash command).

## What

`CodeActRunner` did its own `Popen` (needs a duplex control channel live during execution — see the module docstring) instead of going through `SandboxBackend.run()`, so it never got the cancel-aware subprocess-kill race `noop_backend.py`/`landlock.py` have carried for the sibling (non-CodeAct) `sandboxed_exec` op since #1470. This is the exact gap live-verified for real during #3978's P4a-c `cancel_task` check: `cancel_requested` was accepted, but a running `python.safe` sleep kept going 23s+ past the request.

`CodeActRunner.run()` gains an optional `cancel_event: asyncio.Event | None = None` parameter (`None` = byte-identical to before). When provided, it races the harness's completion against **both** the wall-clock timeout and `cancel_event.wait()` (`asyncio.wait` + `FIRST_COMPLETED`), mirroring `noop_backend.py`'s #1470 race exactly, and returns a distinct `status='cancelled'` (not `'timeout'`) when the event wins.

`router_loop.py`'s `_run_codeblock_round` threads the **same** per-turn `cancel_event` the non-CodeAct op already races (via `RouterHostAdapter.make_router_op_context().cancel_event` — the existing public factory for that `OpContext`, no new cancel_event holder added) into `exec_ctx.extra`; getattr-guarded so a phase/test host without the method degrades to `cancel_event=None`. `_content_fence_cell.py`'s `execute()` forwards it to the runner.

Also fixes `Session.cancel_inflight()`'s docstring, stale since #1470 landed subprocess kill for the non-CodeAct path (it said "subprocess kill is a follow-up scope" as if no subprocess kill existed anywhere — filed as #4166 per CLAUDE.md's remainder-must-be-filed-or-dropped discipline).

## Falsify-verify

Temporarily forced `cancel_event = None` inside `run()` and confirmed the new test genuinely goes RED (30s timeout instead of a prompt cancellation), then restored.

## Six-question read (3 new tests, `tests/security/test_codeact_cancel_4166.py`)

| test | Tier | notes |
|---|---|---|
| `test_cancel_event_kills_a_running_snippet_promptly` | 2 | falsifying witness is elapsed wall-clock time (<5s after a 0.3s cancel vs. the snippet's 30s sleep) — proves the subprocess was actually killed, not merely marked cancelled while left running |
| `test_cancel_event_never_set_runs_to_completion_unaffected` | 2c | accept-side sibling — `cancel_event` provided but never fires, confirms the new race arm doesn't change the ordinary case |
| `test_cancel_event_omitted_still_runs_the_pre_4166_call_shape` | 2 | the default (`cancel_event=None`) stays additive-only |

(Renamed the third from an initial `..._is_byte_identical_to_before` — `test_tier_audit.py --strict` correctly flagged that name as a scaffold-bounded-life keyword; this is a permanent regression guard, not extracted-refactor scaffolding, so the fix was the name, not a move to `tests/scaffold/`.)

## Test plan

- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/security/test_codeact_cancel_4166.py` — 3/3 OK
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (one new `[type-var]` finding fixed by annotating `comm_future: asyncio.Future`, not baselined away)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK, unaffected
- [x] Targeted sweep — all CodeAct + cancel-related + content_fence tests, 163 tests, all green (a `getattr` guard on `make_router_op_context()` was needed after the first run found a fake test host in `test_codeact_coexistence_1593.py` that doesn't implement it)
- [x] Falsify-verify (see above) — genuinely RED with the race disabled, restored
