### PR TITLE
fix(#4173): all-Japanese headings no longer collapse to positional _N anchors

### DIFF
--- a/.mkdocs/mkdocs.yml
+++ b/.mkdocs/mkdocs.yml
@@ -41,6 +41,17 @@ theme:
     scheme: default
     primary: custom
 
+# #4173: injects a per-character-ASCII-fold-or-keep slugify for the `toc`
+# extension below (config-level `slugify:` can't reach it — a bare-module-name
+# `!!python/name:` YAML tag only resolves if the module happens to already be
+# importable from mkdocs's own CWD, which `.mkdocs/` is not). Byte-identical
+# output to python-markdown's own default slugify for every character it can
+# already ASCII-fold (Latin diacritics, circled numerals, ...); differs only
+# for a character whose fold would be empty (Japanese has none), where it
+# keeps the original character instead of dropping it. See reyn_slugify_hook.py.
+hooks:
+  - reyn_slugify_hook.py
+
 plugins:
   - search
   - i18n:

--- a/.mkdocs/reyn_slugify_hook.py
+++ b/.mkdocs/reyn_slugify_hook.py
@@ -1,0 +1,44 @@
+"""Custom `toc` slugify used by `.mkdocs/mkdocs.yml` (#4173).
+
+Same slug output as python-markdown's own default `toc.slugify` for every
+character it can already ASCII-fold (Latin diacritics, circled numerals,
+etc. via NFKD) — this function changes NOTHING for those. It differs only
+for a character NFKD+ascii-fold would otherwise drop entirely (CJK has no
+compatibility decomposition to ASCII), where it keeps the original
+character instead of silently vanishing it. That vanishing is #4173's bug:
+an all-Japanese heading folds to an empty slug, so mkdocs falls back to a
+purely positional id (`_1`, `_2`, ...) that shifts if a heading is added
+above it anywhere on the page.
+"""
+from __future__ import annotations
+
+import re
+import unicodedata
+
+
+def slugify(value: str, separator: str) -> str:
+    """Per-character ASCII-fold-or-keep, then the same regex pipeline
+    ``markdown.extensions.toc.slugify`` applies. Per-character (not
+    per-string) NFKD is deliberate: a whole-string NFKD+ascii-encode('ignore')
+    is what silently drops CJK text today — folding one character at a time
+    and falling back to the original only when THAT character's own fold is
+    empty preserves every existing ASCII/Latin/circled-numeral anchor
+    byte-for-byte while no longer dropping non-foldable characters."""
+    folded_chars = []
+    for ch in value:
+        ascii_ch = unicodedata.normalize("NFKD", ch).encode("ascii", "ignore").decode("ascii")
+        folded_chars.append(ascii_ch if ascii_ch else ch)
+    folded = "".join(folded_chars)
+    folded = re.sub(r"[^\w\s-]", "", folded).strip().lower()
+    return re.sub(r"[{}\s]+".format(re.escape(separator)), separator, folded)
+
+
+def on_config(config, **kwargs):
+    """Inject this module's ``slugify`` as the ``toc`` extension's slugify
+    function. Done here, in code, rather than via a `!!python/name:`/
+    `!!python/object/apply:` tag in mkdocs.yml — a hook file is loaded with
+    its own directory on ``sys.path`` (mkdocs's own `Hooks` config option),
+    so a plain top-level `import` resolves regardless of the CWD mkdocs is
+    invoked from, unlike a YAML python tag naming a bare module name."""
+    config["mdx_configs"].setdefault("toc", {})["slugify"] = slugify
+    return config

--- a/docs/concepts/runtime/hooks.ja.md
+++ b/docs/concepts/runtime/hooks.ja.md
@@ -30,7 +30,7 @@ audience: [human, agent]
 
 ### `mcp_resource_updated`
 
-このセッションが `subscribe_mcp_resource` で購読した resource に対して、サーバが `resources/updated` 通知をプッシュしたときに発火します（[Resource subscriptions](../tools-integrations/mcp.ja.md#resource-subscriptions) 参照）。MCP receive-loop タスクから、境界付きキューを介してセッション自身のイベントループ上でドレインされます — エージェント自身のターンの仕組みからではないため、ターン境界だけでなくターンの間でも発火し得ます。
+このセッションが `subscribe_mcp_resource` で購読した resource に対して、サーバが `resources/updated` 通知をプッシュしたときに発火します（[Resource subscriptions](../tools-integrations/mcp.ja.md#resource-subscriptions-非同期プッシュのイベントソース) 参照）。MCP receive-loop タスクから、境界付きキューを介してセッション自身のイベントループ上でドレインされます — エージェント自身のターンの仕組みからではないため、ターン境界だけでなくターンの間でも発火し得ます。
 
 `template_push` / `pipeline_launch` のレンダリングで使えるテンプレート変数:
 
@@ -107,7 +107,7 @@ hooks:
 - **`template_push`** — 設定の Jinja2 テンプレートから組み立てるプッシュ指示。
 - **`exec`** — 純粋な副作用として実行するサンドボックス argv（出力は無視）。#3226 Phase 4 で `shell_exec` からリネーム(命名の誠実化のみ — セキュリティ上の変更ではない。この仕組みは元々 `/bin/sh -c <文字列>` を一度も実行しておらず、常に `shell=False` で argv を実行していた)。payload は **argv リストのみ**(クリーンブレイク — 文字列形式の後方互換は無い)。
 - **`exec_capture`** — **stdout が JSON プッシュ指示**であるサンドボックス argv。`template_push` と同じ経路でプッシュされます(違いは指示のソースのみ: キャプチャした stdout か Jinja2 レンダーか)。#3226 Phase 4 で `shell_push` からリネーム、同じく argv リストのみの payload。
-- **`pipeline_launch`** — 発火イベントのテンプレート変数からレンダリングした input で、登録済みの [pipeline](pipelines.ja.md) を起動します。詳細は下記の [Pipeline launch](#pipeline-pipeline_launch) を参照。
+- **`pipeline_launch`** — 発火イベントのテンプレート変数からレンダリングした input で、登録済みの [pipeline](pipelines.ja.md) を起動します。詳細は下記の [Pipeline launch](#pipeline-起動pipeline_launch) を参照。
 
 ## 4 つのケイパビリティ
 
@@ -302,5 +302,5 @@ hooks:
 - [パーミッションモデル](permission-model.md) — シェルフックのコンセントフロー
 - [サンドボックス](sandbox.md) — シェルフックの実行環境
 - [reyn-yaml § hooks](../../reference/config/reyn-yaml.md#hooks-block) — フル設定リファレンス
-- [MCP § Resource subscriptions](../tools-integrations/mcp.ja.md#resource-subscriptions) — `mcp_resource_updated` 外部イベントポイントの発生源
+- [MCP § Resource subscriptions](../tools-integrations/mcp.ja.md#resource-subscriptions-非同期プッシュのイベントソース) — `mcp_resource_updated` 外部イベントポイントの発生源
 - [Pipeline](pipelines.ja.md) — `pipeline_launch` フックが起動するもの

--- a/docs/concepts/runtime/permission-model.ja.md
+++ b/docs/concepts/runtime/permission-model.ja.md
@@ -236,7 +236,7 @@ permission system は OS runtime の一部であり、 OS の上に乗る別レ�
 | `mcp` | `list[str]` | per-server | MCP 呼び出し時 implicit | サーバー名の allowlist |
 | `python` | `list[{module, function, mode, timeout}]` | per-step | `require_python_step()` | mode ∈ {`safe`, `unsafe`} |
 | `tool` | `list[str]` | per-tool | `require_tool()` | 名前指定 tool allowlist |
-| `shell` | *(live gate なし)* | — | — | **Doc drift、ここでは未修正のまま flag のみ**: この行はかつて bool `permissions.shell` 軸の gate site として `require_shell()` を挙げていた。`require_shell()` は現行コードベースに存在しない（`grep -rn "require_shell"` は `src/` 全体で 0 件）— この行がかつて指していた subprocess-exec gate は、raw `shell` op が撤廃された際（#1352-A/#1352-L3）に retire 済み。subprocess access は現在、`sandboxed_exec` の seam で `SandboxPolicy.deny_subprocess`（#3901 PR-B ④ で `allow_subprocess` からリネーム・意味反転、`permissions:` dict のエントリではなく sandbox config 側で宣言）により bound される。この行が支えていた、今や stale な rationale については下記 [`shell` だけが bool である理由](#shell-bool) 参照。 |
+| `shell` | *(live gate なし)* | — | — | **Doc drift、ここでは未修正のまま flag のみ**: この行はかつて bool `permissions.shell` 軸の gate site として `require_shell()` を挙げていた。`require_shell()` は現行コードベースに存在しない（`grep -rn "require_shell"` は `src/` 全体で 0 件）— この行がかつて指していた subprocess-exec gate は、raw `shell` op が撤廃された際（#1352-A/#1352-L3）に retire 済み。subprocess access は現在、`sandboxed_exec` の seam で `SandboxPolicy.deny_subprocess`（#3901 PR-B ④ で `allow_subprocess` からリネーム・意味反転、`permissions:` dict のエントリではなく sandbox config 側で宣言）により bound される。この行が支えていた、今や stale な rationale については下記 [`shell` だけが bool である理由](#shell-だけが-bool-である理由) 参照。 |
 | `allowed_mcp` | `list[str] \| None` | ACL filter | MCP 呼び出し時 implicit | per-agent restriction、 `mcp` 軸と cross-cut |
 
 ### `shell` だけが bool である理由
@@ -369,7 +369,7 @@ FP-0016 Component D は、当時 `run_skill` op（現在は削除済み）経由
 — `security/secrets/store.py` の `ScopedSecretStore` / `CredentialScopeError` クラス自体は
 まだ存在しますが、`OpContext.secret_store` は現行ランタイムで常に `None` です。現在
 クレデンシャルスコーピングの enforcement は機能していません。シークレットアクセスは
-[`secret.write` 宣言軸](#taxonomy) と `~/.reyn/secrets.env` に対する
+[`secret.write` 宣言軸](#宣言軸の-taxonomy) と `~/.reyn/secrets.env` に対する
 OS レベルのファイルパーミッションでのみゲートされています。
 
 ## パーミッションシステムではないもの

--- a/docs/concepts/tools-integrations/mcp.ja.md
+++ b/docs/concepts/tools-integrations/mcp.ja.md
@@ -127,7 +127,7 @@ phase frontmatter         LLM が Control IR を発行    OS がディスパッ�
 - `subscribe_mcp_resource(server, uri)` / `unsubscribe_mcp_resource(server, uri)` — いずれも `read_mcp_resource` と同じ方法でゲートされます(`mcp_subscribe_resource` / `mcp_unsubscribe_resource` Control IR op、`permissions.mcp: [server_name]`)。さらに、サーバーがネゴシエートした `resources.subscribe` サブケイパビリティによる追加ゲートがあります — サーバーは `subscribe` を広告せずに `resources` を広告できます(list/read は動作する)(例えば、今日 FastMCP の高レベル `FastMCP()` クラスで構築されたすべてのサーバー — 基盤となる SDK は、FastMCP サーバーがどんなハンドラを登録していても `resources.subscribe=False` をハードコードします)。
 - **永続接続が必須です。** 購読は held(セッション寿命の)接続の上でのみ意味を持ちます — 購読中の URI 集合は `MCPConnectionService` 上にインメモリで存在します(ランタイムのみ; 購読はそれ自体のデータを持たないため、完全に再確立可能で、WAL 化されません)。エフェメラルなチャットセッションは、両方の op を、1 回限りの接続が閉じた瞬間に消える購読を受け入れるのではなく、明確なエラーで拒否します。
 - **トランスポート断からの reconnect を生き延びます。** 接続が切れる(サブプロセス死亡、HTTP 切断)と、以前の購読の記憶を持たない新しい MCP セッションが開かれます。`MCPConnectionService` は、追跡していたすべての購読を新しい接続に対して自動的に再発行するため、切断前にセットアップされた購読は、reyn が接続を回復した後もプッシュを届け続けます。
-- **プッシュはツール結果ではなく EventLog に着地します。** `resources/updated` 通知が届くたびに、どの Control IR op 呼び出しとも独立して `mcp_resource_updated`(`server`、`uri`、`resync`)が非同期に発行されます。この通知は同時に**フックディスパッチャーにも配線**されており、`mcp_resource_updated` を購読するフックが直接反応できます([フック § 外部イベントポイント](../runtime/hooks.ja.md#_2)参照)— EventLog はワークフロー作者が読み戻せる監査トレイルのシグナルであり続けます。
+- **プッシュはツール結果ではなく EventLog に着地します。** `resources/updated` 通知が届くたびに、どの Control IR op 呼び出しとも独立して `mcp_resource_updated`(`server`、`uri`、`resync`)が非同期に発行されます。この通知は同時に**フックディスパッチャーにも配線**されており、`mcp_resource_updated` を購読するフックが直接反応できます([フック § 外部イベントポイント](../runtime/hooks.ja.md#外部イベントポイント)参照)— EventLog はワークフロー作者が読み戻せる監査トレイルのシグナルであり続けます。
 
 ### Prompts: 一覧 + 取得
 
@@ -355,5 +355,5 @@ MCP は *外部ケイパビリティへのアクセス* に適したツールで
 - [コンセプト: シークレット管理](../runtime/secret-handling.md) — `~/.reyn/secrets.env` と `${VAR}` interpolation
 - [リファレンス: `reyn.yaml`](../../reference/config/reyn-yaml.md#mcp-servers) — `mcp.servers:` の完全なスキーマ
 - [コンセプト: パーミッションモデル](../runtime/permission-model.md) — `file.write` / `http.get` / `permissions.mcp` と collapse arc
-- [コンセプト: フック](../runtime/hooks.ja.md#_2) — `mcp_resource_updated` 外部イベントフックポイント
+- [コンセプト: フック](../runtime/hooks.ja.md#外部イベントポイント) — `mcp_resource_updated` 外部イベントフックポイント
 - [modelcontextprotocol.io](https://modelcontextprotocol.io) — 仕様、サーバーレジストリ、公式 SDK

--- a/docs/concepts/tools-integrations/universal-catalog.ja.md
+++ b/docs/concepts/tools-integrations/universal-catalog.ja.md
@@ -147,7 +147,7 @@ schema を既に返すため。 edge case 用にのみ残す: 単一名 lookup�
 
 ### `invoke_action(action_name, args) → <target の result>`
 
-membership table (下記 [Membership](#membership-action) 参照) 経由で
+membership table (下記 [Membership](#membership-action-名の意味) 参照) 経由で
 target tool に dispatch する。 wrapper は transparent: target handler は
 完全な `ToolContext` 下で動くので、 permission gate / events / budget /
 workspace 効果は legacy tool を直接 call した場合と完全に同一。 未知の
@@ -401,4 +401,4 @@ action_retrieval:
 - [`src/reyn/runtime/router_tools.py`](https://github.com/anthropics/reyn) — `build_tools` integration (flag-gate された wrapper)
 - [`src/reyn/runtime/router_system_prompt.py`](https://github.com/anthropics/reyn) — `## Action categories` section
 - [`src/reyn/config/embedding.py`](https://github.com/anthropics/reyn) — `ActionRetrievalConfig`
-- [`docs/reference/config/reyn-yaml.ja.md`](../../reference/config/reyn-yaml.ja.md#action_retrieval) — config reference
+- [`docs/reference/config/reyn-yaml.ja.md`](../../reference/config/reyn-yaml.ja.md#action_retrieval-ブロック) — config reference

--- a/docs/guide/for-users/enable-semantic-search.ja.md
+++ b/docs/guide/for-users/enable-semantic-search.ja.md
@@ -2,7 +2,7 @@
 
 `reyn chat` には、LLM が実行可能なことを発見するための 2 つの手段が同梱されています: 高速な **`list_actions`** ブラウザ（= カテゴリ接頭辞による列挙、常時利用可能）と、**`search_actions`** セマンティック検索（= 全アクションの埋め込みインデックスに対する自然言語クエリ）です。本ガイドではセマンティックな経路を有効にする手順を説明します。
 
-> **TL;DR**: `search_actions` は **デフォルトで無効**（semantic search はプロジェクト全体で opt-in の方針）。すでに埋め込み API キーがある場合は `reyn secret set OPENAI_API_KEY` のあと `reyn.yaml` で `embedding.enabled: true` を設定するだけ — proxy も追加インストールも不要です。API キーなしでローカルモデルを使いたい場合は **litellm proxy** の背後にモデルを立て、reyn からそこを指してください（後述の [経路 B](#b-api-litellm-proxy) を参照）。
+> **TL;DR**: `search_actions` は **デフォルトで無効**（semantic search はプロジェクト全体で opt-in の方針）。すでに埋め込み API キーがある場合は `reyn secret set OPENAI_API_KEY` のあと `reyn.yaml` で `embedding.enabled: true` を設定するだけ — proxy も追加インストールも不要です。API キーなしでローカルモデルを使いたい場合は **litellm proxy** の背後にモデルを立て、reyn からそこを指してください（後述の [経路 B](#経路-b-埋め込み-api-契約なし-litellm-proxy-ローカルモデル) を参照）。
 
 ## どんなときに欲しくなるか
 
@@ -142,7 +142,7 @@ standard  litellm  openai/text-embedding-3-small   .reyn/cache/index/actions    
 strong    litellm  openai/text-embedding-3-large   .reyn/cache/index/actions      0.31        0  (never)
 ```
 
-**Pre-flight curl が失敗する** — 上記 [§ Pre-flight](#pre-flight-opt-in) の失敗パターンを参照してください: 401（キー誤り）、404（モデル名 / proxy `model_list` 不一致）、400 unsupported-param（proxy の `drop_params: true` 未設定、#1616）、connection refused（何も listen していない / `LITELLM_API_BASE` が誤り）。
+**Pre-flight curl が失敗する** — 上記 [§ Pre-flight](#pre-flight-エンドポイントが実際に応答するか確認するopt-in-の前に行う) の失敗パターンを参照してください: 401（キー誤り）、404（モデル名 / proxy `model_list` 不一致）、400 unsupported-param（proxy の `drop_params: true` 未設定、#1616）、connection refused（何も listen していない / `LITELLM_API_BASE` が誤り）。
 
 **クラスを切り替えても古い結果が返る** — Reyn のアクションインデックスは一度に 1 つの埋め込みクラスを保持します。クラスの切り替えは次セッションで自動的に再埋め込みをトリガーしますが、`reyn embeddings rebuild` で先行して強制できます。
 

--- a/docs/guide/for-users/write-a-pipeline.ja.md
+++ b/docs/guide/for-users/write-a-pipeline.ja.md
@@ -20,7 +20,7 @@ steps:
 - pipeline は `pipeline:` キーの名前(`greet`)の下に登録されます。ファイル名ではありません — `pipelines/greet.yaml` は何にリネームしても `greet` として登録され続けます。
 - 各ステップは、自身の種別(`transform`、`tool`、`agent`、または合成プリミティブ(Pipeline DSL リファレンス参照)のいずれか)を名前とする単一キーのマッピングです。
 - `ctx.name` はこの pipeline が期待する seed input です。`greeting` は最初のステップの `output` で書き込まれた後、それ以降のすべてのステップから `ctx.greeting` として利用可能になります。bare name のショートカットはありません — `ctx.greeting` の代わりに bare な `greeting` として読もうとするとステップが失敗します。すべての expression は `ctx`(すべての named store)と `pipe`(直前のステップ自身の結果)の 2 つだけをトップレベルキーとして持つコンテキストに対して評価されるためです。完全なルールと実例のトレースは [ステップ間のデータフロー](../../reference/runtime/pipeline-dsl.ja.md#data-flow-between-steps) を参照してください。
-- `!expr` は `argv` をリテラルのリストではなく評価すべき expression としてマークします — [リテラル vs `!expr`](../../reference/runtime/pipeline-dsl.ja.md#vs-expr) 参照。
+- `!expr` は `argv` をリテラルのリストではなく評価すべき expression としてマークします — [リテラル vs `!expr`](../../reference/runtime/pipeline-dsl.ja.md#リテラル-vs-expr) 参照。
 - `exec` は operator のサンドボックスの中で `argv` を実行します(argv のみ — シェル解釈はありません)。前のステップの pipe data は `stdin_pipe: !expr pipe` 引数で STDIN に渡せます — この pipeline はその入力を使いませんが、完全な STDIN/STDOUT の契約は[リファレンスの `exec` ステップの説明](../../reference/runtime/pipeline-dsl.ja.md#tool-step-results)を参照してください。
 
 ## 2. 登録する
@@ -79,7 +79,7 @@ run_pipeline(
 )
 ```
 
-定義は parse され、静的解析ゲートを通されます — schema 参照が解決すること、ツール名が解決すること、どのステップも別の pipeline を起動したり delegate したりしないこと、`agent` ステップが起動者自身の identity の下でのみ実行されること — **何かが spawn される前に**。不正な定義は明確に失敗し何も spawn しません。良い定義は、登録済み pipeline と全く同様に crash-recoverable です。その完全な定義が run 自身の recovery 状態と共に移動するためです。同じ `collect=`/`on_settle=` の同期 vs 非同期の選択が、登録済み `name=` 起動と同様に inline `definition=` 起動にも適用されます。完全なゲートのチェックリストは [Ad-hoc inline 起動](../../reference/runtime/pipeline-dsl.ja.md#ad-hoc-inline) を参照してください。
+定義は parse され、静的解析ゲートを通されます — schema 参照が解決すること、ツール名が解決すること、どのステップも別の pipeline を起動したり delegate したりしないこと、`agent` ステップが起動者自身の identity の下でのみ実行されること — **何かが spawn される前に**。不正な定義は明確に失敗し何も spawn しません。良い定義は、登録済み pipeline と全く同様に crash-recoverable です。その完全な定義が run 自身の recovery 状態と共に移動するためです。同じ `collect=`/`on_settle=` の同期 vs 非同期の選択が、登録済み `name=` 起動と同様に inline `definition=` 起動にも適用されます。完全なゲートのチェックリストは [Ad-hoc inline 起動](../../reference/runtime/pipeline-dsl.ja.md#ad-hoc-inline-起動) を参照してください。
 
 ## 実践例: fan out してから merge する
 

--- a/docs/reference/cli/chat.ja.md
+++ b/docs/reference/cli/chat.ja.md
@@ -46,7 +46,7 @@ chat 固有のフラグ:
 | `--banner` | オフ | ASCII アートの起動バナー（グラデーション REYN ロゴ + agent/モデル情報）を表示。 |
 | `--eager-embedding-build` | オフ | 初回ターンでアクション埋め込みインデックスのビルドを同期的に待機(1 回のみ約 2〜5 秒)。`search_actions` を即時利用可能にする。 |
 | `--exclude-tools NAMES` | — | agent の LLM 可視カタログから隠すツール名(カンマ区切り、例 `web_search,web_fetch`)。ツール自体は存在し、agent が名前で呼び出せば実行されるが、このセッションではモデルの発見サーフェスには表示されない。 |
-| `--connect <URL>` | オフ | ローカルセッションを起動する代わりに、リモートの `reyn web` サーバーへ AG-UI(HTTP+SSE)経由でアタッチする(例: `--connect http://127.0.0.1:8080`)。位置引数 `agent_name` でサーバー上の agent を選択。`pip install reyn[web]` が必要。TTY であっても常にプレーンコンソールセッションとして描画される(`--cui` と同じ出力スタイル)— インラインステータスバーやスラッシュ補完メニューは無し。`/rewind` はインタラクティブピッカーでなくプレーンなテキストリストにフォールバック。[How-to: リモートシンクライアント](../../guide/for-users/chat-and-web-ui.ja.md#reyn-chat-connect) 参照。 |
+| `--connect <URL>` | オフ | ローカルセッションを起動する代わりに、リモートの `reyn web` サーバーへ AG-UI(HTTP+SSE)経由でアタッチする(例: `--connect http://127.0.0.1:8080`)。位置引数 `agent_name` でサーバー上の agent を選択。`pip install reyn[web]` が必要。TTY であっても常にプレーンコンソールセッションとして描画される(`--cui` と同じ出力スタイル)— インラインステータスバーやスラッシュ補完メニューは無し。`/rewind` はインタラクティブピッカーでなくプレーンなテキストリストにフォールバック。[How-to: リモートシンクライアント](../../guide/for-users/chat-and-web-ui.ja.md#リモートシンクライアント-reyn-chat-connect) 参照。 |
 | `--token <SECRET>` | オフ | `--connect` 用のベアラートークン(`reyn web` が起動時に表示するシークレット、または `web.auth.token` で設定したトークン)。`REYN_WEB_AUTH_TOKEN` 環境変数にフォールバック。同一マシンの UDS サーバーではトークン不要な場合がある。 |
 
 ## agent Workspace

--- a/docs/reference/config/budget.ja.md
+++ b/docs/reference/config/budget.ja.md
@@ -44,7 +44,7 @@ cost:
     hard_limit: 50.00    # 今月 $50.00 を超えたら拒否
 ```
 
-> **移行案内**: `router_invocations_per_turn` は `cost:` から `safety.loop` に移動しました。代わりに `safety.loop.max_router_calls_per_turn` を使用してください。[リファレンス: `reyn.yaml` — `safety` ブロック](reyn-yaml.ja.md#safety) を参照。
+> **移行案内**: `router_invocations_per_turn` は `cost:` から `safety.loop` に移動しました。代わりに `safety.loop.max_router_calls_per_turn` を使用してください。[リファレンス: `reyn.yaml` — `safety` ブロック](reyn-yaml.ja.md#safety-ブロック) を参照。
 
 ### フィールドリファレンス
 

--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -910,7 +910,7 @@ cost:
 | `monthly_tokens` | プロセスグローバル | 台帳ファイル | 月初（現地時間） |
 | `monthly_cost_usd` | プロセスグローバル | 台帳ファイル | 月初（現地時間） |
 
-> **注意**: ルーター呼び出し上限（`max_router_calls_per_turn`）は `safety.loop` 配下にあります。上記の [`safety` ブロック](#safety) を参照してください。
+> **注意**: ルーター呼び出し上限（`max_router_calls_per_turn`）は `safety.loop` 配下にあります。上記の [`safety` ブロック](#safety-ブロック) を参照してください。
 
 **上限の動作:** ハード上限を超えると、LLM の呼び出しが行われる前に拒否されます。現在の使用状況を見るには `/budget`、メモリ内カウンターをクリアするには `/budget reset` を使用します（日次/月次は reset の影響を受けません。永続台帳に基づいています）。
 
@@ -963,7 +963,7 @@ mcp:
 | `call_timeout_seconds` | float | すべて（任意） | **すべての MCP op（list / call / probe）に対する end-to-end の上限**。既定 `120`、`<= 0` で無効化。server への接続と op の実行の両方を含む ∴ **起動（launch）も、この上限で打ち切られる**。特定 server が遅いと分かっている場合は上げ、速いと分かっていて fail-fast したい場合は下げる。per-call としては MCP SDK の `read_timeout_seconds` に渡され、`type: http` で `timeout` が設定する session レベルの既定を override する。 |
 | `init_timeout` | float | すべて（任意） | **server が MCP handshake を完了するまで待つ上限**。既定 `60`、`0` でこの上限を無効化。handshake のみを縛り、tool call は縛らない ∴ 上げても遅い tool が timeout することはない。**起動したが黙っている** server（典型例: `command: uvx <pkg>` — 初回実行時に PyPI から取得する間、何も喋らない）はここで止まる。expire 時、reyn は原因の候補と対処を名指しするエラーを返す。既定が `call_timeout_seconds` の `120` より **下** なのは意図的: 両方が起動を覆うため、**先に発火した方が operator の読むメッセージを決める** — 汎用の per-op timeout は「なぜ起動が止まったか」を語れない。∴ 本当に遅い server に猶予が要るなら **両方を上げる**（`init_timeout` 単独では `call_timeout_seconds` を超える時間は買えない）。初回起動が遅いことへの恒久的な対処は、パッケージを事前 install して `command` を install 済みの実行ファイルに向けること — offline / proxy 越しでも起動できるようになるのも、この形。 |
 | `auth` | string \| map | すべて（任意、`http` のみ） | サーバーごとの OAuth 2.1 設定。文字列 `"oauth"` または `{type: oauth, scopes?, client_id?, client_secret?}`。`http` トランスポート以外(`stdio`/`sse`)で指定するとエラー。詳細は [コンセプト: MCP § OAuth](../../concepts/tools-integrations/mcp.ja.md#oauth) 参照。 |
-| `elicitation` | string | すべて（任意） | `prompt`(デフォルト) — サーバー起動の構造化入力要求(`elicitation/create`)がコンセントプロンプトとして表示される。`auto_decline` — そのようなすべての要求をプロンプトせずに decline する。[コンセプト: MCP § Elicitation](../../concepts/tools-integrations/mcp.ja.md#elicitation) 参照。 |
+| `elicitation` | string | すべて（任意） | `prompt`(デフォルト) — サーバー起動の構造化入力要求(`elicitation/create`)がコンセントプロンプトとして表示される。`auto_decline` — そのようなすべての要求をプロンプトせずに decline する。[コンセプト: MCP § Elicitation](../../concepts/tools-integrations/mcp.ja.md#elicitation-サーバーからの構造化入力要求) 参照。 |
 | `elicitation_timeout_seconds` | float | すべて（任意） | elicitation プロンプトに人間が回答するためのウォールクロック期限。デフォルト `120`。期限を過ぎた未回答の要求はキャンセルされます。 |
 
 サーバーは設定ソースをまたいでマージされます: `~/.reyn/config.yaml` ⊕ `reyn.yaml` ⊕ `reyn.local.yaml`。マージは `mcp.servers` キーの shallow union です。マシンごとの `reyn.local.yaml` が残りを再宣言せずに単一サーバーを追加・上書きできます。

--- a/docs/reference/runtime/events.ja.md
+++ b/docs/reference/runtime/events.ja.md
@@ -73,13 +73,13 @@ SSoT は `src/reyn/core/events/event_schema.py` の `AUDIT_EVENT_KINDS` で、�
 | 種類 | トリガー | 主要なペイロード |
 |------|---------|-------------|
 | `mcp_initialized` | （再）接続のたびに、サーバーの `initialize` ハンドシェイクが完了した時点で発行。 | `server`、`negotiated_version`、`capabilities` |
-| `mcp_resource_updated` | 購読中の resource のサーバープッシュ `resources/updated` 通知、またはトランスポート断からの reconnect 後に再購読された URI ごとに発火する合成 resync。フックディスパッチャーにも外部イベントフックポイントとして配線されています — [コンセプト: フック](../../concepts/runtime/hooks.ja.md#_2) 参照。 | `server`、`uri`、`resync`（reconnect resync なら `true`、実際のプッシュなら `false`） |
+| `mcp_resource_updated` | 購読中の resource のサーバープッシュ `resources/updated` 通知、またはトランスポート断からの reconnect 後に再購読された URI ごとに発火する合成 resync。フックディスパッチャーにも外部イベントフックポイントとして配線されています — [コンセプト: フック](../../concepts/runtime/hooks.ja.md#外部イベントポイント) 参照。 | `server`、`uri`、`resync`（reconnect resync なら `true`、実際のプッシュなら `false`） |
 | `mcp_elicitation_requested` | サーバーが `elicitation/create` 構造化入力要求を発行。 | `server`、`field_keys`（要求されたスキーマのプロパティ*名*のみ — 値は決して含まない） |
 | `mcp_elicitation_answered` | 要求が `accept` または `decline` に解決される（人間の選択、または `auto_decline` 設定による `decline`）。 | `server`、`field_keys`、`action`（`"accept"` \| `"decline"`） |
 | `mcp_elicitation_timed_out` | `elicitation_timeout_seconds` までに回答が届かなかった。 | `server`、`field_keys` |
 | `mcp_elicitation_auto_declined` | プロンプトせずに decline された — `reason` はサーバーが `elicitation: auto_decline` を設定している場合とヘッドレスコンテキスト（ライブの介入リスナーが無い）を区別する。 | `server`、`field_keys`、`reason`（`"server_configured"` \| `"headless"`） |
 
-これらのイベントはいずれも、人間が入力した回答やフィールドの*値*を一切含みません — 要求されたスキーマのプロパティ名のみです。[コンセプト: MCP § Elicitation](../../concepts/tools-integrations/mcp.ja.md#elicitation) で説明されているセンシティブフィールドの扱いと一致します。
+これらのイベントはいずれも、人間が入力した回答やフィールドの*値*を一切含みません — 要求されたスキーマのプロパティ名のみです。[コンセプト: MCP § Elicitation](../../concepts/tools-integrations/mcp.ja.md#elicitation-サーバーからの構造化入力要求) で説明されているセンシティブフィールドの扱いと一致します。
 
 ## クレデンシャルと OAuth
 

--- a/docs/reference/runtime/pipeline-dsl.ja.md
+++ b/docs/reference/runtime/pipeline-dsl.ja.md
@@ -95,7 +95,7 @@ steps:
 
 ## 形式文法 {#formal-grammar}
 
-以下の EBNF は**規範的な、現行の**文法です — 初期の設計提案からではなく、`parse_pipeline_dsl`(`src/reyn/core/pipeline/parser.py`)から直接導出されています。今日パーサが受け付けるものを正確にカバーしています: これに適合する定義はクリーンに parse でき、違反は拒否されます。YAML のマッピングキーは無順序です — 以下の線形な並びは可読性のためであり、位置的な要求ではありません。`NAME` は識別子的な bare 文字列、`EXPR` は [R1 expression](#r1-expression) のソース文字列、`TPL` は `agent.prompt` のテンプレート文字列(`{ctx.dotted.path}` / `{pipe}` 補間、R1 ではない)です。
+以下の EBNF は**規範的な、現行の**文法です — 初期の設計提案からではなく、`parse_pipeline_dsl`(`src/reyn/core/pipeline/parser.py`)から直接導出されています。今日パーサが受け付けるものを正確にカバーしています: これに適合する定義はクリーンに parse でき、違反は拒否されます。YAML のマッピングキーは無順序です — 以下の線形な並びは可読性のためであり、位置的な要求ではありません。`NAME` は識別子的な bare 文字列、`EXPR` は [R1 expression](#r1-expression-言語) のソース文字列、`TPL` は `agent.prompt` のテンプレート文字列(`{ctx.dotted.path}` / `{pipe}` 補間、R1 ではない)です。
 
 ```ebnf
 Document      ::= YamlDoc ("---" YamlDoc)*        (* テキスト全体で PipelineDoc はちょうど 1 つ *)
@@ -184,7 +184,7 @@ FieldType     ::= "{" "type:" ("bool" | "string") "}"
 
 ### `transform`
 
-純粋なステップです: `value` は現在のコンテキスト(`ctx`/`pipe` — [ステップ間のデータフロー](#data-flow-between-steps)参照)に対して [R1 expression](#r1-expression) として評価され、その結果がこのステップの pipe data になります(`output` が設定されていれば、その named store にも書き込まれます)。
+純粋なステップです: `value` は現在のコンテキスト(`ctx`/`pipe` — [ステップ間のデータフロー](#data-flow-between-steps)参照)に対して [R1 expression](#r1-expression-言語) として評価され、その結果がこのステップの pipe data になります(`output` が設定されていれば、その named store にも書き込まれます)。
 
 ```yaml
 - transform: {value: "'Hello, ' + ctx.name + '!'", output: greeting}
@@ -206,7 +206,7 @@ FieldType     ::= "{" "type:" ("bool" | "string") "}"
 | キー | 必須 | 意味 |
 |-----|------|------|
 | `name` | 必須 | ツール / アクション名(リテラル文字列)。 |
-| `args` | 任意 | 引数名 → 値 のマッピング。各値は `!expr` タグが付いていない限り**リテラル**([リテラル vs `!expr`](#vs-expr)参照)。 |
+| `args` | 任意 | 引数名 → 値 のマッピング。各値は `!expr` タグが付いていない限り**リテラル**([リテラル vs `!expr`](#リテラル-vs-expr)参照)。 |
 | `schema` | 任意 | 結果が適合すべき登録済み schema 名(`verify: schema` — [Schema](#schema-verify-schema)参照)。不適合はステップを失敗させる(下記の `text`/`structured` 変換前の、生のツール結果に対してチェックされる)。 |
 | `output` | 任意 | 結果を書き込む named store。 |
 
@@ -233,7 +233,7 @@ offload したり cap したりは絶対にしません。pipeline ステップ�
 
 **`meta` を安全に読む。** `meta` は producer がシグナルを出さないと存在しないため、
 そうした producer に対して素の `ctx.<name>.meta.<field>` パスは**例外を投げます**
-(素のパスは safe navigation ではありません — [R1 式言語](#r1-expression)
+(素のパスは safe navigation ではありません — [R1 式言語](#r1-expression-言語)
 参照)。これは意図的です: シグナルに依存するステップは、黙って既定値を読むのではなく、
 大きな音を立てて失敗すべきだからです。シグナルが本当に任意の場合は `get(...)` を使います:
 
@@ -290,7 +290,7 @@ LLM 駆動の leaf ステップです: `prompt`(テンプレート文字列)が�
 | キー | 必須 | 意味 |
 |-----|------|------|
 | `prompt` | 必須 | テンプレート文字列 — `{ctx.dotted.path}` / `{pipe}` 参照が補間される(値のみ、演算子なし — これは R1 expression ではなく文字列補間)。 |
-| `identity` | 任意 | 実行するエージェント identity。デフォルトは run の起動者。**登録済み** pipeline は任意の identity を指定できるが、**inline で エージェントが生成した** pipeline は起動者自身の identity のみ指定可能 — 別のエージェントの identity を指定すると capability escalation として静的解析ゲートに拒否される([Ad-hoc inline 起動](#ad-hoc-inline)参照)。 |
+| `identity` | 任意 | 実行するエージェント identity。デフォルトは run の起動者。**登録済み** pipeline は任意の identity を指定できるが、**inline で エージェントが生成した** pipeline は起動者自身の identity のみ指定可能 — 別のエージェントの identity を指定すると capability escalation として静的解析ゲートに拒否される([Ad-hoc inline 起動](#ad-hoc-inline-起動)参照)。 |
 | `capabilities` | 任意 | `{tools: [NAME*]}` — ephemeral session のツール surface を narrowing する。restrict-only: pipeline のステップが起動者自身の envelope を超えることは決してない。 |
 | `schema` | 任意 | `tool` と同じ `verify: schema` セマンティクスを、parse された JSON 応答に適用。 |
 | `output` | 任意 | 結果を書き込む named store。 |
@@ -505,7 +505,7 @@ fields:
 
 `minimum`/`maximum` は schema 登録時にチェックされ(`minimum` は `maximum` を超えてはならず、指定する場合はどちらも数値でなければならない)、値の validate 時にも強制されます — 境界(両端含む)の外の値は `out_of_range` エラーになります(`missing_required` / `type_mismatch` / `enum_invalid` / `unresolved_ref` / `unknown_type` と並ぶ種別)。`number` のみが対象です: `bool`/`string` には自然な範囲という概念が無く、`string` の長さ上限や `list`/array の要素数上限は別の(まだ需要が実証されていない)話です。
 
-`tool`/`agent` ステップの `schema: NAME` キーは、その結果(`agent` の場合は parse された JSON 応答)が適合すべき登録済み schema を指定します — 不適合はステップを失敗させます。同じ DSL ドキュメント集合内で宣言された schema(独立した `schema:` ドキュメント)は、[ad-hoc な inline pipeline](#ad-hoc-inline) でもこれを可能にするものです。その schema は同じ定義文字列と共に移動するためです。
+`tool`/`agent` ステップの `schema: NAME` キーは、その結果(`agent` の場合は parse された JSON 応答)が適合すべき登録済み schema を指定します — 不適合はステップを失敗させます。同じ DSL ドキュメント集合内で宣言された schema(独立した `schema:` ドキュメント)は、[ad-hoc な inline pipeline](#ad-hoc-inline-起動) でもこれを可能にするものです。その schema は同じ定義文字列と共に移動するためです。
 
 ## 起動
 

--- a/docs/reference/runtime/present.ja.md
+++ b/docs/reference/runtime/present.ja.md
@@ -31,7 +31,7 @@ guard/renderer の分割）については [コンセプト: Present レイヤ](
 ```
 
 **データソース**を厳密に1つ、`view` / `blueprint` は**最大1つ**（両方省略も有効——後述の
-[任意の view/blueprint](#viewblueprint) を参照）:
+[任意の view/blueprint](#任意の-viewblueprint-既定レンダリング) を参照）:
 
 | 引数 | 型 | 備考 |
 |---|---|---|

--- a/tests/scripts/test_3126_doc_anchor_gate.py
+++ b/tests/scripts/test_3126_doc_anchor_gate.py
@@ -16,25 +16,33 @@ comment or doc link is covered automatically.
 
 Two renderers, two slug algorithms — the caveat this gate exists to encode:
 
-- **mkdocs** (`markdown.extensions.toc.slugify` — the ASCII-only default;
-  ``.mkdocs/mkdocs.yml``'s ``toc:`` block sets only ``permalink: true``, no
-  ``slugify:`` override, so `TocExtension`'s own default applies, confirmed
-  live: ``TocExtension().getConfig("slugify")`` returns ``slugify``, not
-  ``slugify_unicode``): collapses consecutive hyphens, so an em-dash with a
-  space on each side produces a *single* hyphen, AND strips non-ASCII
-  characters entirely — a CJK-only heading slugifies to ``""``, which
-  `unique()` (imported for real, same as mkdocs' own treeprocessor calls)
-  turns into an opaque, order-dependent ``_1``/``_2``/... fallback id. This
-  gate previously imported ``slugify_unicode`` instead and asserted a pure-CJK
-  heading survives unchanged (#3667 co-vet, lead-coder + docs-maintainer,
-  2026-08): that model was never actually checked against a real mkdocs
-  build, only against itself — a live build showed real ids like
-  ``ad-hoc-inline`` (CJK suffix dropped) where the old model computed
-  ``ad-hoc-inline-起動``, so citations correct under the old model were
-  silently broken on the published site. Confirmed the real function
-  produces the exact real-world id in both cases before making this fix.
+- **mkdocs**: ``.mkdocs/mkdocs.yml`` wires a custom ``slugify`` (#4173's
+  ``.mkdocs/reyn_slugify_hook.py``, injected via mkdocs' ``hooks:`` config
+  option — not `markdown.extensions.toc`'s own default) into the ``toc``
+  extension's config at ``on_config`` time. This module IMPORTS that real
+  function (loaded from its file path, since ``.mkdocs/`` is not an
+  installed package) rather than assuming which algorithm mkdocs uses —
+  the exact mistake this gate made twice before: it originally hardcoded
+  ``markdown.extensions.toc.slugify`` (correct when written, since mkdocs
+  had no override then); #3667 co-vet swapped in a hand-written
+  ``slugify_unicode`` model, checked only against itself, never against a
+  real build, and asserted a pure-CJK heading survives unchanged — wrong
+  (a live build showed real ids like ``ad-hoc-inline``, CJK suffix
+  dropped, where that model computed ``ad-hoc-inline-起動``); #4173 then
+  changed what mkdocs ACTUALLY uses again, and this gate's own re-derived
+  ``markdown.extensions.toc.slugify`` import (from the #3667 fix) went
+  stale within the same night, RED against #4173's own PR (`hooks.ja.md`'s
+  real, mkdocs-built anchor ``#pipeline-起動pipeline_launch`` reading as a
+  nonexistent slug under the gate's separately-hardcoded old rule) — three
+  incidents, one shape: this file re-declaring which function mkdocs uses
+  instead of asking mkdocs' own config for it. Importing the function
+  object directly closes that recurrence — the next mkdocs-side slugify
+  change needs no matching edit here.
 - **GitHub's own renderer**: does NOT collapse consecutive hyphens, so the
-  same em-dash heading gets a *double* hyphen there.
+  same em-dash heading gets a *double* hyphen there. Modeled separately
+  (`_github_slugify`, below) — GitHub's algorithm has no config knob this
+  gate could import from; it stays a maintained model of what GitHub's
+  renderer actually does, unrelated to mkdocs' own choice of function.
 
 ``docs/deep-dives/**`` (plus any other ``.mkdocs/mkdocs.yml``
 ``exclude_docs:`` entry, read from that file at test time — never
@@ -56,12 +64,13 @@ implementation-level pin.
 """
 from __future__ import annotations
 
+import importlib.util
 import re
 from pathlib import Path
 
 import pytest
 import yaml
-from markdown.extensions.toc import slugify, unique
+from markdown.extensions.toc import unique
 
 from tests._support.paths import REPO_ROOT
 
@@ -69,6 +78,25 @@ _REPO_ROOT = REPO_ROOT
 _DOCS = _REPO_ROOT / "docs"
 _SRC = _REPO_ROOT / "src" / "reyn"
 _MKDOCS_CFG = _REPO_ROOT / ".mkdocs" / "mkdocs.yml"
+_SLUGIFY_HOOK = _REPO_ROOT / ".mkdocs" / "reyn_slugify_hook.py"
+
+
+def _load_real_mkdocs_slugify():
+    """Import ``slugify`` from the SAME file mkdocs' own ``hooks:`` config
+    option loads (``.mkdocs/reyn_slugify_hook.py``) — not a re-derived
+    model of it. ``.mkdocs/`` is not an installed package, so this mirrors
+    what mkdocs' own ``Hooks`` config option does internally
+    (``importlib.util.spec_from_file_location`` on the file path) rather
+    than adding it to ``sys.path`` and using a bare ``import``, which would
+    risk colliding with an unrelated top-level module of the same name."""
+    spec = importlib.util.spec_from_file_location("reyn_slugify_hook", _SLUGIFY_HOOK)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.slugify
+
+
+slugify = _load_real_mkdocs_slugify()
 
 _FENCE_RE = re.compile(r"^\s*```")
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
@@ -471,21 +499,23 @@ def test_caveat_github_and_mkdocs_diverge_on_consecutive_hyphens(
     assert "faking-a-datastate-object--same-ban-sharper-failure-mode" in github_slugs
 
 
-def test_pure_cjk_heading_falls_back_to_opaque_ordered_id(tmp_path: Path) -> None:
-    """Tier 1: mkdocs' actual runtime slugify (the ASCII-only default —
-    ``.mkdocs/mkdocs.yml`` sets no ``slugify:`` override) strips a pure-CJK
-    heading's text to ``""``; `unique()` then assigns an opaque,
-    ORDER-DEPENDENT ``_1``/``_2``/... id — the same fallback mkdocs' own
-    treeprocessor uses, since `unique` is imported for real, not
-    reimplemented. Confirmed against a live build: this is why a
-    pure-Japanese heading's citation must use an explicit
-    ``{#custom-id}`` override, never the heading text itself, and why
-    inserting a heading above shifts every anchor below it silently."""
+def test_pure_cjk_heading_slugs_to_its_own_text_not_an_opaque_ordered_id(
+    tmp_path: Path,
+) -> None:
+    """Tier 1: mkdocs' actual runtime slugify (#4173's
+    ``.mkdocs/reyn_slugify_hook.py``, imported for real above — never
+    reimplemented) keeps a pure-CJK heading's text as its own slug, rather
+    than folding it to ``""`` and falling back to an opaque, ORDER-DEPENDENT
+    ``_1``/``_2``/... id (the pre-#4173 behavior this file's own docstring
+    describes as the recurrence this gate exists to catch). Two distinct
+    CJK headings must produce two distinct, stable, citable slugs — the
+    positive case for #4173's fix, using the same imported function this
+    whole gate stands on, not a model of it."""
     doc = tmp_path / "sample.md"
     doc.write_text("## 判断フロー\n## 別の見出し\n", encoding="utf-8")
     slugs = heading_slugs(doc, use_github=False)
-    assert "判断フロー" not in slugs
-    assert {"_1", "_2"} <= slugs
+    assert {"判断フロー", "別の見出し"} <= slugs
+    assert not slugs & {"_1", "_2"}
 
 
 def test_attr_list_explicit_id_overrides_autoslug(tmp_path: Path) -> None:


### PR DESCRIPTION
**[docs-maintainer]** — implements #4173 (architect-filed, "実装は私はしません" — picking it up per lead-coder's dispatch).

## Why not architect's proposed 1-line fix

The issue itself flagged both of these as unverified; I verified them independently, by a different method than either measurement in the issue used:

1. **`!!python/name:pymdownx.slugs.slugify` doesn't load at all.** It's a factory (`slugify(**kwargs) -> callable`), not a plain `(text, sep)` function — the `toc` extension calls it with 2 positional args and gets `TypeError: slugify() takes 0 positional arguments but 2 were given`. Confirmed by actually running the build, not just reading the source.
2. **"EN anchors never move" doesn't hold at scale.** Architect's own measurement compared 6 hand-picked ASCII headings. A full anchor-id diff — every `id="..."` on every built EN page, before vs. after, not a spot check — shows `pymdownx.slugs.slugify(case='lower')` moves **69 of 120** EN pages: it doesn't collapse repeated separators the way python-markdown's own default slugify does, so any EN heading with an em-dash (`## Foo — bar`, this repo's dominant heading convention) gets a doubled hyphen. I also tried `functools.partial(toc.slugify, unicode=True)` (markdown's own built-in unicode flag) — better, but still moves 4 EN pages, because it also stops ASCII-folding circled numerals (①②③) and Latin diacritics (Diátaxis) that the *current* default already folds successfully via NFKD.

## The fix

`.mkdocs/reyn_slugify_hook.py`: NFKD+ascii-fold **character-by-character**, falling back to the original character only when *that specific character's* fold is empty (CJK has no compatibility decomposition to ASCII — that's the actual bug; a circled numeral or accented Latin letter folds successfully, so those keep behaving exactly as today). Full before/after `id=` diff: **zero EN pages changed.** ja positional-id pages: 80 → 2 (the 2 remaining are genuinely repeated headings on one page — five literal `### Install` sections — colliding identically on the EN side too; out of scope, not what #4173 describes).

Wired via mkdocs's `hooks:` mechanism (an `on_config` callback assigning the function object directly) rather than a YAML python-tag naming a bare module — `.mkdocs/` isn't on `sys.path` when mkdocs parses its own config from the repo root (confirmed by trying it — `ModuleNotFoundError`), and a hook file's own directory *is* added to `sys.path` by mkdocs's `Hooks` option before import, so a plain top-level `import` in the hook module resolves regardless of CWD.

## ① EN-anchor confirmation — done, by a different method than architect's

See above — full-page id diff, not a re-run of the same 6-heading spot check.

## ② ja incoming-link inventory — done, two classes found

- **3 positional-anchor links** (`hooks.ja.md#_2`, referenced from `mcp.ja.md` ×2 and `events.ja.md`): silently misdirected exactly as the issue describes — they read "外部イベントポイント" (external event points) but `#_2` currently resolves to "ライフサイクルポイント" (lifecycle points), a different section. Fixed to the real anchor.
- **14 more, found only by re-running the gates** (not by grep — these are hand-typed ASCII anchors like `#action_retrieval`/`#safety`/`#taxonomy`, not positional): several mixed EN/JA headings (e.g. "`action_retrieval` ブロック") currently, accidentally, fold to a stable ASCII-only slug because today's bug drops the Japanese suffix entirely — and existing cross-references across the ja docs depend on that accidental anchor. This fix's real (Japanese-preserving) slugify changes those too, since it's the same underlying bug. Traced each to its heading's correct new anchor and fixed all 14.

## ③ Gates green — verified against a real `git worktree` of `origin/main`, not a stash

(A stash-based first attempt at this comparison produced a false 26-error result from a stale `site/` dir left over from an earlier build — caught before relying on it, redone with a proper worktree checkout.)

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — INFO-line output byte-identical to `origin/main`'s (worktree-diffed, only path-prefix lines differ)
- [x] `python scripts/check_doc_anchors.py` — exit 0, output byte-identical to `origin/main`'s
- [x] `ruff check .mkdocs/reyn_slugify_hook.py src tests` — clean
- [x] `python scripts/verify_module_docstrings.py .mkdocs/reyn_slugify_hook.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (210/214 baselined, unchanged)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [ ] (Visual — N/A, static-site build change; the anchor-diff methodology above is the real verification here)

part of #4173
