### PR TITLE
feat(#4166): /cancel slash command, Session.cancel_inflight() reports what it actually did

### DIFF
--- a/src/reyn/interfaces/slash/__init__.py
+++ b/src/reyn/interfaces/slash/__init__.py
@@ -293,6 +293,7 @@ async def reply_error(ctx: SlashContext, text: str) -> None:
 from reyn.interfaces.slash import agent as _agent_mod  # noqa: E402, F401
 from reyn.interfaces.slash import agents as _agents_mod  # noqa: E402, F401
 from reyn.interfaces.slash import budget as _budget_mod  # noqa: E402, F401
+from reyn.interfaces.slash import cancel as _cancel_mod  # noqa: E402, F401
 from reyn.interfaces.slash import chat as _chat_mod  # noqa: E402, F401
 from reyn.interfaces.slash import clear_history as _clear_history_mod  # noqa: E402, F401
 from reyn.interfaces.slash import compact as _compact_mod  # noqa: E402, F401

--- a/src/reyn/interfaces/slash/cancel.py
+++ b/src/reyn/interfaces/slash/cancel.py
@@ -1,0 +1,32 @@
+"""``/cancel`` — the user-facing slash-command cancel口 (#3903).
+
+Esc / Ctrl+C already cancel the in-flight turn (``app.py``'s keybindings,
+both delegating straight to ``ClientTransport.cancel_inflight()`` — the
+same seam this command uses). #3903's owner ruling required a cancel口
+reachable via slash command specifically, distinct from the keybindings:
+a slash command is discoverable (``/help``, Tab-completion), scriptable,
+and reachable from any client that types text but doesn't wire a
+keybinding (e.g. a plain ``--cui`` terminal without the inline CUI's key
+handling). No confirmation step, unlike ``/reset``: cancelling an
+in-flight turn is low-stakes and trivially retried (re-prompt), the same
+posture Esc/Ctrl+C already take without asking.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.slash import SlashContext, reply, slash
+
+
+@slash(
+    "cancel",
+    summary="Cancel the in-flight turn (same as Esc / Ctrl+C)",
+)
+async def cancel_cmd(ctx: "SlashContext", args: str) -> None:
+    """``/cancel`` — reports WHAT was cancelled, never a blanket "done": the
+    live #4166 finding was `cancel_task` returning `cancel_requested` while
+    the target kept running with no way to tell. `ClientTransport.
+    cancel_inflight()`'s own contract (#3903) now returns the real outcome
+    (`Session.cancel_inflight()`'s summary for local/server-side dispatch;
+    a generic string only for the one fire-and-forget wire path this
+    command never actually routes through — see `agui/client.py`)."""
+    summary = await ctx.transport.cancel_inflight()
+    await reply(ctx, f"⏹ {summary}")

--- a/src/reyn/interfaces/slash/dispatch.py
+++ b/src/reyn/interfaces/slash/dispatch.py
@@ -203,8 +203,8 @@ class _ErrorWatchingTransport(ClientTransport):
             choice_id, intervention_id=intervention_id
         )
 
-    async def cancel_inflight(self) -> None:
-        await self._inner.cancel_inflight()
+    async def cancel_inflight(self) -> str:
+        return await self._inner.cancel_inflight()
 
     async def cancel_queued(self, msg_id: str) -> bool:
         return await self._inner.cancel_queued(msg_id)

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -249,8 +249,16 @@ class AgUiTransport(ClientTransport):
         # echoes render locally through the renderer, not this seam. No-op here.
         return None
 
-    async def cancel_inflight(self) -> None:
+    async def cancel_inflight(self) -> str:
+        # #3903: fire-and-forget over the wire (no response frame in this
+        # protocol) — this is the Esc/Ctrl+C keyboard path only. /cancel
+        # (the slash command) does NOT route through here: ClientTransport.
+        # run_slash_command's own docstring says AgUiTransport POSTs the
+        # slash command for the SERVER to run via execute_slash_command,
+        # which calls Session.cancel_inflight() directly and gets the real
+        # summary — this generic string is never what a /cancel reply shows.
         await self._send({"type": "cancel_inflight"})
+        return "cancel requested"
 
     async def cancel_queued(self, msg_id: str) -> bool:
         # #3300 P3 (Y-server) remote parity: POST the cancel-by-id op; the

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -144,8 +144,15 @@ class ClientTransport(ABC):
         into the display stream, in order with the session's own output."""
 
     @abstractmethod
-    async def cancel_inflight(self) -> None:
-        """Cooperatively cancel the in-flight turn (ctrl-c seam)."""
+    async def cancel_inflight(self) -> str:
+        """Cooperatively cancel the in-flight turn (ctrl-c seam).
+
+        Returns a human-readable summary of WHAT was cancelled (#3903's
+        ``/cancel`` slash command surfaces it verbatim) — never a claim of
+        success unconditionally: a transport that cannot observe the real
+        outcome (e.g. a fire-and-forget wire message) returns a
+        best-effort/generic string rather than asserting something was
+        actually stopped."""
 
     async def run_slash_command(self, name: str, args: str) -> bool:
         """Run the registered slash command ``name`` with ``args``; ``True`` iff

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -236,13 +236,15 @@ class InProcessTransport(ClientTransport):
         # in FIFO order with the session's own output, then re-tagged by the pump.
         self._registry.repl_outbox.put_nowait(msg)
 
-    async def cancel_inflight(self) -> None:
+    async def cancel_inflight(self) -> str:
         s = self._attached()
         if s is None:
-            return
+            return "no session attached"
         cancel_fn = getattr(s, "cancel_inflight", None)
         if callable(cancel_fn):
-            await cancel_fn()
+            result = await cancel_fn()
+            return result if isinstance(result, str) else "✗ cancelled turn"
+        return "nothing was running"
 
     async def cancel_queued(self, msg_id: str) -> bool:
         s = self._attached()

--- a/src/reyn/interfaces/transport/session_bound.py
+++ b/src/reyn/interfaces/transport/session_bound.py
@@ -124,8 +124,8 @@ class SessionBoundTransport(ClientTransport):
     def put_display(self, msg: "OutboxMessage") -> None:
         self._display_sink(msg)
 
-    async def cancel_inflight(self) -> None:
-        await self._session.cancel_inflight()
+    async def cancel_inflight(self) -> str:
+        return await self._session.cancel_inflight()
 
     async def cancel_queued(self, msg_id: str) -> bool:
         return bool(await self._session.cancel_queued(msg_id))

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2030,10 +2030,27 @@ class Session:
         mode). Returns a human-readable summary string.
 
         #1468 cooperative layer: sets the cooperative cancellation flag so the
-        turn's run_loop breaks at the next tool-iteration boundary. A slow tool
-        already in flight completes before the cancel takes effect (subprocess
-        kill is a follow-up scope). Any spawned tasks are cancelled immediately
-        via asyncio task cancellation (existing behaviour, preserved here).
+        turn's run_loop breaks at the next tool-iteration boundary, AND sets
+        the per-turn ``cancel_event`` (``RouterLoopDriver.cancel_event``,
+        threaded onto the router's OpContext via
+        ``RouterHostAdapter._set_cancel_event`` — #1470) that a currently-
+        running sandboxed subprocess tool races against. Any spawned tasks
+        are cancelled immediately via asyncio task cancellation (existing
+        behaviour, preserved here).
+
+        #4166 correction (this docstring previously said "subprocess kill is
+        a follow-up scope" — that was stale even when written: the regular
+        ``sandboxed_exec`` op's non-CodeAct launches have raced
+        ``cancel_event`` and killed the process group since #1470;
+        ``CodeActRunner`` was the one launch route that reinvented its own
+        ``Popen`` instead of going through ``SandboxBackend.run()`` and so
+        never got it — #4166 closed that gap). A tool NOT wired to
+        ``cancel_event`` at all (this Session's set is #1470's
+        ``sandboxed_exec``/CodeAct plus whatever else threads
+        ``OpContext.cancel_event`` through — MCP calls, embed, plugin
+        install; grep ``cancel_event=ctx.cancel_event`` for the current
+        list) still only observes the cooperative flag at the next
+        iteration boundary, same as before.
 
         #2242 hard layer: ALSO cancels ``_turn_owner_task`` directly (the
         per-turn sub-task ``run_one_iteration`` spawns to run ``_run_turn_body``
@@ -2076,16 +2093,25 @@ class Session:
         other caller (Ctrl-C via the transport, the AG-UI endpoint,
         ``remove_session``) runs on a different task and is unaffected.
         """
-        self._loop_driver.request_cancel()
-        if (
+        # #3903: was anything actually running, BEFORE the cancel attempt —
+        # the return value used to say "✗ cancelled turn" unconditionally,
+        # even when there was nothing in flight (the same shape #4166 found
+        # live in cancel_task's own reply: an accepted request that reports
+        # success regardless of whether anything was actually stopped).
+        running_turn = (
             self._turn_owner_task is not None
             and asyncio.current_task() is not self._turn_owner_task
-            and self._turn_owner_task.cancel()
-        ):
+            and not self._turn_owner_task.done()
+        )
+        self._loop_driver.request_cancel()
+        if running_turn and self._turn_owner_task.cancel():
             self._turn_cancel_self_initiated = True
-        for forward in list(self._cancel_forward_targets):
+        forwards = list(self._cancel_forward_targets)
+        for forward in forwards:
             forward()
-        return "✗ cancelled turn"
+        if running_turn or forwards:
+            return "✗ cancelled turn"
+        return "nothing was running"
 
     def register_cancel_forward(self, forward: "Callable[[], None]") -> "Callable[[], None]":
         """#2588: register ``forward`` to also fire on the next ``cancel_inflight``.

--- a/tests/_support/slash.py
+++ b/tests/_support/slash.py
@@ -116,8 +116,8 @@ class RecordingTransport(ClientTransport):
             )
         return bool(await self._session.answer_oldest_intervention_choice(choice_id))
 
-    async def cancel_inflight(self) -> None:
-        await self._session.cancel_inflight()
+    async def cancel_inflight(self) -> str:
+        return await self._session.cancel_inflight()
 
     async def run_slash_command(self, name: str, args: str) -> bool:
         # The SAME one line ``InProcessTransport.run_slash_command`` runs — the

--- a/tests/interfaces/test_cancel_slash_3903.py
+++ b/tests/interfaces/test_cancel_slash_3903.py
@@ -1,0 +1,93 @@
+"""Tier 2: #3903 — /cancel slash command, and Session.cancel_inflight()'s
+accurate (not unconditional) result summary.
+
+Pre-#3903, ``Session.cancel_inflight()`` returned ``"✗ cancelled turn"``
+unconditionally — even when nothing was in flight — the same shape #4166
+found live in ``cancel_task``'s own reply (a request accepted and reported
+as successful regardless of the actual outcome). ``ClientTransport.
+cancel_inflight()``'s return type changed from ``None`` to ``str`` so
+``/cancel`` (the missing user-facing口 owner ruled must exist) can surface
+the real outcome instead of a blanket "done".
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.interfaces.slash.cancel import cancel_cmd
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+from tests._support.slash import RecordingTransport, slash_ctx
+
+AGENT = "cancel-slash-agent"
+
+
+def _make_session(tmp_path: Path) -> Session:
+    from reyn.core.events.state_log import StateLog
+
+    state_log = StateLog(tmp_path / "state.wal")
+    return make_session(
+        agent_name=AGENT, state_log=state_log, snapshot_path=tmp_path / "snapshot.json",
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_inflight_reports_nothing_running_when_nothing_is(tmp_path):
+    """Tier 2: a fresh session with no in-flight turn and no cancel-forward
+    targets returns an outcome distinguishable from a real cancel — not the
+    same "✗ cancelled turn" string a genuine cancel returns."""
+    session = _make_session(tmp_path)
+    result = await session.cancel_inflight()
+    assert "cancel" not in result.lower(), (
+        f"a no-op cancel_inflight() must not claim it cancelled anything: {result!r}"
+    )
+    assert result == "nothing was running"
+
+
+@pytest.mark.asyncio
+async def test_cancel_inflight_reports_a_forwarded_cancel_as_something_happening(tmp_path):
+    """Tier 2: accept-side sibling — when a cancel-forward target IS
+    registered (the #2588 pipeline-attach shape), cancel_inflight() must NOT
+    report "nothing was running" even though THIS session's own
+    _turn_owner_task is None; something was still cancelled."""
+    session = _make_session(tmp_path)
+    forwarded: list[bool] = []
+    unregister = session.register_cancel_forward(lambda: forwarded.append(True))
+    try:
+        result = await session.cancel_inflight()
+    finally:
+        unregister()
+    assert forwarded == [True]
+    assert result != "nothing was running"
+
+
+@pytest.mark.asyncio
+async def test_cancel_cmd_reply_echoes_the_transport_summary(tmp_path):
+    """Tier 2: /cancel's reply is whatever ctx.transport.cancel_inflight()
+    reports — not a hardcoded "done" independent of the real outcome (the
+    #4166 shape this command exists to avoid repeating)."""
+    session = _make_session(tmp_path)
+    ctx = slash_ctx(session)
+    await cancel_cmd(ctx, "")
+    transport = ctx.transport
+    assert isinstance(transport, RecordingTransport)
+    texts = [m.text for m in transport.displayed]
+    assert any("nothing was running" in t for t in texts), texts
+
+
+@pytest.mark.asyncio
+async def test_cancel_cmd_reports_a_real_cancel_distinctly(tmp_path):
+    """Tier 2: falsify pair — with a cancel-forward target registered (so
+    cancel_inflight() reports something DID happen), /cancel's reply must
+    say something different from the nothing-running case above."""
+    session = _make_session(tmp_path)
+    unregister = session.register_cancel_forward(lambda: None)
+    try:
+        ctx = slash_ctx(session)
+        await cancel_cmd(ctx, "")
+    finally:
+        unregister()
+    texts = [m.text for m in ctx.transport.displayed]
+    assert not any("nothing was running" in t for t in texts), texts
+    assert any("cancel" in t.lower() for t in texts), texts


### PR DESCRIPTION
**[tui-coder]** — Add `/cancel`, a user-facing slash command to cancel the in-flight turn.

## Scope note (corrected 2× — see below)

This PR **is** part of #3903, per lead-coder's clarification: #3903's issue body (③, "LLM が
呼べる cancel op = 0 件") describes the state **at filing time**, since resolved by `cancel_task`
(#4106). Owner then added a **later** condition (2026-08-11, not reflected in the issue body):
"a-2 で良い。ただし llm/user 両方が cancel できる口が必要" + "user はスラッシュコマンド経由" —
i.e. both an LLM-callable op (already done, #4106) AND a user-facing口 **via slash command**
(this PR) are required. This PR is that user-side口.

*(Earlier revision of this note incorrectly said #3903 was unrelated — that read only the
issue body, which is stale relative to the owner's later decision. Correcting rather than
leaving the wrong claim up.)*

**No closing keyword** — correct either way: #3903's remaining piece (the a-2 body itself,
removing the background wall-clock timeout cap) is not done in this PR, so #3903 stays open.

The mechanism this PR touches originates in #4166 (the `cancel_inflight()`
docstring/subprocess-kill gap; CLOSED, landed as #4175) — this PR closes a matching
unconditional-success bug in `cancel_inflight()`'s own reply and adds the missing
user-reachable口 for the same mechanism.

## Why

Esc/Ctrl+C already cancel the in-flight turn via `ClientTransport.cancel_inflight()`, but no
slash-command口 existed. A slash command is discoverable (`/help`, Tab-completion), scriptable,
and reachable from any client that types text but doesn't wire a keybinding (e.g. plain `--cui`).

## What changed

- **`src/reyn/interfaces/slash/cancel.py`** (new): `/cancel`, reusing `cancel_inflight()` — no new stop path invented. No confirmation step (same low-stakes posture as Esc/Ctrl+C — cancelling is trivially retried).
- **`Session.cancel_inflight()`** (`session.py`): fixed an unconditional-success bug — it always returned `"✗ cancelled turn"` even when nothing was running, the same shape #4166 found live in `cancel_task`'s own reply. Now computes whether a turn was really running / a cancel-forward target fired, BEFORE reporting, and returns `"nothing was running"` when neither happened. Also restores the #4166 docstring fix (accidentally dropped by a stash-merge during this branch's own setup — caught and fixed before committing, diff-verified clean against `main`).
- **`ClientTransport.cancel_inflight()`**: abstract return type `None -> str`, so a caller can surface the real outcome. Propagated through all 6 implementations (`InProcessTransport`, `SessionBoundTransport`, `dispatch.py`'s internal wrapper, `AgUiTransport`, `tests/_support/slash.py`'s `RecordingTransport`).
- **`AgUiTransport.cancel_inflight()`** is a documented exception: fire-and-forget wire message (no response frame in this protocol), used only by the remote UI's Esc/Ctrl+C keyboard shortcut. `/cancel` does NOT route through it — remote slash commands execute **server-side** (`ClientTransport.run_slash_command`'s own docstring: `AgUiTransport` POSTs the command, the server runs it via `execute_slash_command` against the real `Session`), so `/cancel` gets the real `Session.cancel_inflight()` summary on both local and remote surfaces with no wire-protocol change needed.

## Verification

- Falsify-verified the `cancel_inflight()` fix: temporarily reverted to the unconditional return, confirmed 2 of the 4 new tests genuinely go RED, restored.
- Full gate suite clean: `ruff check src tests`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py`.
- 1500-test sweep of `tests/interfaces/` (+ related runtime tests) — all green.
- AG-UI-specific sweep (102 tests, all 27 `*agui*` files) — confirmed none assert on the old `-> None` return shape before changing it.
- `tests/runtime/test_session_pure_extraction_3679_s1.py::test_session_pure_importable_without_first_importing_session` fails identically on a clean `main` checkout (confirmed via stash) — the known global `python3`-shim-resolves-to-a-stale-checkout artifact, unrelated to this diff.

## Test plan

- [x] `ruff check src tests` clean
- [x] `test_tier_audit.py --strict` clean on new/changed tests
- [x] `verify_module_docstrings.py` clean
- [x] `mypy_ratchet.py` clean (210/214 baselined, no new)
- [x] `check_tests_path_literal_reference.py` clean
- [x] Targeted sweep: `tests/interfaces/` (1500 passed, 1 skipped) + AG-UI suite (102 passed)
- [x] Falsify-verified `cancel_inflight()`'s new return-value logic
- [ ] Visual/manual: none applicable (no TUI-rendering change; `/cancel`'s reply text is exercised by the new tests)

TESTS-READ / approved / auto-merge armed by lead-coder — holding for CI, not self-merging.
