### PR TITLE
docs: sweep tonight's #4179/#3907 sandboxed_exec drift (2 real hits)

### DIFF
--- a/docs/concepts/runtime/sandbox.ja.md
+++ b/docs/concepts/runtime/sandbox.ja.md
@@ -24,7 +24,8 @@ Reyn のサンドボックスレイヤーは、ワークフローが宣言した
 | `write_deny_paths` | `list[str]` | `[]` | 書き込み軸専用の deny リスト（#3901）、`read_deny_paths` と対をなす。#3901 以前は Seatbelt が `read_deny_paths` の未文書化の副作用として書き込みも deny していたが、Landlock はその副作用を再現しておらず OS ごとに同一ポリシーの意味が違っていた — このフィールドが両バックエンドの読む real field を1つにしてそのギャップを閉じます。書き込み軸のみ deny。 |
 | `deny_subprocess` | `bool` | `false`（compat） | サンドボックス対象プロセスの子プロセス生成を deny — #3901 以前の `allow_subprocess` の deny-list 形の逆。Linux (seccomp) / macOS (Seatbelt: `true` の時 `process-fork` を deny、対象自身の exec は `process-exec*` で動作) で適用。 |
 | `env_deny_names` | `list[str]` | `[]`（compat） | サブプロセスへ引き渡さない環境変数名 — #3901 以前の `env_passthrough` allowlist の deny-list 形の逆。デフォルト（空）は環境全体が引き渡される、つまり起動元シェルと同じ信頼レベルを意味する。 |
-| `timeout_seconds` | `int` | `60` | ウォールクロック上限（超過時にプロセスを強制終了） |
+| `timeout_seconds` | `int` | `120`（#3903①、2026-08-11 — 以前は `60`） | ウォールクロック上限（超過時にプロセスを強制終了）。LLM の `exec` 呼び出しは `max_timeout_seconds` までより高い値を要求できる。 |
+| `max_timeout_seconds` | `int` | `600`（#3903①） | `timeout_seconds`（policy のデフォルトと LLM が要求する override の両方）が照合される operator 制御の上限 — 狭めれば LLM が要求できる範囲が実際に狭まる。LLM がこれを広げることはできない。拒否（切り詰めない）の挙動は [`sandboxed_exec` op リファレンス](../../reference/runtime/control-ir.ja.md#sandboxed_exec) を参照。 |
 
 ## バックエンド選択テーブル
 

--- a/docs/concepts/runtime/sandbox.md
+++ b/docs/concepts/runtime/sandbox.md
@@ -49,7 +49,8 @@ action, not re-deciding what the launching shell could already do.
 | `write_deny_paths` | `list[str]` | `[]` | The write axis's own deny-list (#3901), mirroring `read_deny_paths`. Before #3901, Seatbelt denied writes as an undocumented side-effect of `read_deny_paths`; Landlock never replicated that side-effect, so the same policy meant different things per OS — this field closes that gap with one real field both backends read. Denies only the WRITE axis. |
 | `deny_subprocess` | `bool` | `false` (compat) | Deny the sandboxed process from spawning children — the deny-list-shaped inverse of the pre-#3901 `allow_subprocess`. Enforced on Linux (seccomp) and macOS (Seatbelt: `process-fork` denied when `true`; the target's own exec still works via `process-exec*`). |
 | `env_deny_names` | `list[str]` | `[]` (compat) | Environment variable names WITHHELD from the subprocess — the deny-list-shaped inverse of the pre-#3901 `env_passthrough` allowlist. Empty (the default) means the WHOLE environment passes through, the same trust level as the launching shell. |
-| `timeout_seconds` | `int` | `60` | Wall-clock limit; process is killed on expiry. |
+| `timeout_seconds` | `int` | `120` (#3903①, 2026-08-11 — was `60`) | Wall-clock limit; process is killed on expiry. The LLM's `exec` call may request a higher value up to `max_timeout_seconds`. |
+| `max_timeout_seconds` | `int` | `600` (#3903①) | The operator-controlled ceiling `timeout_seconds` (both the policy default and any LLM-requested override) is checked against — narrowing it genuinely narrows what the LLM can ask for; the LLM can never widen it. See the [`sandboxed_exec` op reference](../../reference/runtime/control-ir.md#sandboxed_exec) for the reject-not-clamp behavior. |
 
 ## Backend selection table
 

--- a/docs/reference/runtime/control-ir.ja.md
+++ b/docs/reference/runtime/control-ir.ja.md
@@ -153,7 +153,7 @@ rows: 500          # #3664: すべての行状スロット(table/list と keyval
 
 ## `sandboxed_exec`
 
-Control IR の op kind は `sandboxed_exec` のまま変わりません（`OP_KIND_MODEL_MAP["sandboxed_exec"]` / `SandboxedExecIROp`）。この op に到達する router/phase ツールは `sandboxed_exec` から **`exec`** へ改名されました（#3226 Phase 3、catalog qualified name は **`exec`**）— この改名は tool/qualified-name のみで、この op のスキーマ・イベント・結果形状には影響しません。
+Control IR の op kind は `sandboxed_exec` のまま変わりません（`OP_KIND_MODEL_MAP["sandboxed_exec"]` / `SandboxedExecIROp`）。この op に到達する router/phase ツールは `sandboxed_exec` から **`exec`** へ改名されました（#3226 Phase 3、catalog qualified name は **`exec`**）— この改名は tool/qualified-name のみで、この op のスキーマ・イベント・結果形状には影響しません。op kind と tool 名はそれ以来異なります。2つの文字列を橋渡しするテーブル（`op_runtime.contextual_gate._OP_KIND_TOOLS`）がかつて存在しましたが、#3513 で削除されました — 唯一の consumer だった `control_ir_executor` / `preprocessor_executor` が #2434 でファイルごと削除され、`src/` 内に呼び出し元が無くなっていたためです。op dispatch が独自の contextual narrowing を要するかどうかは #3546 で追跡中で、ここでは未解決です。
 
 宣言された `SandboxPolicy` と OS が選択した `SandboxBackend` を介して `argv` を実行します。分離強制が必要な（または将来必要になる）ケースで `shell` を置き換えます。
 
@@ -161,23 +161,19 @@ Control IR の op kind は `sandboxed_exec` のまま変わりません（`OP_KI
 {
   "kind": "sandboxed_exec",
   "argv": ["echo", "hello"],
-  "network": false,
-  "read_paths": ["{{workspace}}"],
-  "write_paths": ["{{workspace}}/output"],
-  "allow_subprocess": false,
-  "env_passthrough": ["PATH"],
-  "timeout_seconds": 60
+  "stdin": null,
+  "timeout_seconds": null
 }
 ```
 
 フィールド:
 - `argv`（必須）— コマンドと引数。`argv[0]` が実行可能ファイル。
-- `network`（省略可、デフォルト `false`）— アウトバウンドネットワークを許可。
-- `read_paths`（省略可）— プロセスが読み取り可能なファイルシステムパス（glob パターン可）。
-- `write_paths`（省略可）— プロセスが書き込み可能なファイルシステムパス。
-- `allow_subprocess`（省略可、デフォルト `true`）— 子プロセス生成の許可。
-- `env_passthrough`（省略可）— 引き渡す環境変数名（それ以外は除去）。
-- `timeout_seconds`（省略可、デフォルト `60`）— ウォールクロック上限。
+- `stdin`（省略可、デフォルト `None`）— プロセスの stdin に書き込むバイト列（pipeline `tool` step は前ステップの pipe-data を `args: {argv: [...], stdin_pipe: !expr pipe}` 経由で JSON としてここに渡せる — [Pipeline DSL](pipeline-dsl.ja.md#tool) 参照）。
+- `timeout_seconds`（省略可、デフォルト `None`）— **#3903①（2026-08-11、下の段落からの意図的な方針転換）**: LLM は `SandboxPolicy.timeout_seconds` 自身のデフォルトを超える前景ウォールクロックタイムアウトを、`SandboxPolicy.max_timeout_seconds`（operator 自身が設定する上限 — ハードコード値ではない）まで要求できます（`max_timeout_seconds` をデフォルトの 600 秒より狭めた operator にはその上限が実際に強制される。LLM が operator 自身の狭い設定を広げることはできない）。`None`（デフォルト）は policy 自身の `timeout_seconds` を使う。上限を超える値は**拒否**され（`status: "error"`、実際に設定された上限を名指し）、静かに切り詰められることはない — それをすると、下の段落で閉じたはずの「advertised だが無視される」形が、フィールドが黙って落とされる代わりに値が黙って変わる形で再来してしまう。非正の値も同様に拒否される。
+
+**他の policy フィールドは無い**（`network` / `read_paths` / `write_paths` / `allow_subprocess` / `env_passthrough` — #3907 で削除）: 実際に run を統制する sandbox policy の他の軸は、この op からは**一切**設定できません。agent レベル（operator）の `sandbox.policy`（`reyn.yaml`、`resolve_sandbox_policy` 経由で解決 — [`sandbox` config block](../config/reyn-yaml.ja.md#sandbox-ブロック) 参照）、それが無ければ operator の compat/strict デフォルトが使われます — いずれにせよ LLM には見えず広げられない値です（#1326/#1339: operator-or-default policy は op が要求するどんな値にも常に勝つ）。この op はかつて、operator policy が解決されなかった場合のフォールバック source として 5 つの policy フィールドを持っていましたが、#3907① の実測でそのパスは production で到達不能（すべての context-building path が具体的な policy を解決する）と判明したため、advertised-but-ignored な knob として残すのではなく削除されました。
+
+`timeout_seconds` もかつて同じ道をたどりました（#3962 で同じ defect class として削除 — ただし 1 issue 遅れて。ウォールクロック上限は permission 軸ではないため #3907 の一掃を生き延び、1 issue 分長く dead のまま残った）が、上の 5 つとは**異なる軸**です: boundedness であって permission ではない（#3903 自身の framing）。今回は本物の reader を伴って戻ってきました（上記参照） — これが、この方針転換を #3962 が閉じたギャップの再開と区別する点です。
 
 **バックエンド選択**: `get_default_backend()` がプラットフォームに応じて選択します。macOS < 26 では `SeatbeltBackend`（sandbox-exec SBPL）。Linux ≥ 5.13 かつ `sandbox-linux` extra インストール済みの場合は `LandlockBackend`（+ オプションの seccomp-BPF スタック）。その他のプラットフォームまたは選択バックエンドが利用不可の場合は `NoopBackend`（監査のみ、強制なし）にフォールバック — 初回使用時に一行 WARN を出力。`reyn.yaml` の `sandbox.backend`（`auto` | `seatbelt` | `landlock` | `noop`）および `sandbox.on_unsupported`（`warn` | `error` | `ignore`）で上書き可能。
 


### PR DESCRIPTION
**[docs-maintainer]** — lead-coder's sweep dispatch: search `docs/` by mechanism name for staleness from tonight's 6 landed PRs (#4175/#4180/#4179/#4183/#4177/#4168), following tui's finding that `configure-sandbox.md` still said `60` after #4179 (#4186). Two more real hits found, both by mechanism name, not by re-checking the same 2 files:

## 1. `docs/concepts/runtime/sandbox.md` / `.ja.md`

`SandboxPolicy`'s own field table — a *separate* table from `reyn-yaml.md`'s config-reference table (already fixed by #4179) — still said `timeout_seconds` defaults to `60` and never listed `max_timeout_seconds` at all. Same shape as the `configure-sandbox.md` instance tui found: a second doc describing the same field, missed because #4179's own PR only touched the config-reference table.

## 2. `docs/reference/runtime/control-ir.ja.md`'s `sandboxed_exec` section

Much larger, pre-existing gap — this one predates tonight by months, not hours: it never received **#3907's field-removal treatment at all** (still listed `network`/`read_paths`/`write_paths`/`allow_subprocess`/`env_passthrough` as op-level fields — all removed long ago) *or* tonight's #3903① rewrite. Rewrote the whole section to match `control-ir.md`'s current EN content, translated faithfully (not summarized): the op-kind/tool-name history paragraph, the `argv`/`stdin`/`timeout_seconds`-only JSON example, the #3903① `timeout_seconds` field description, the "no other policy fields" paragraph, and the `timeout_seconds`-history paragraph.

## Sweep coverage (measured range, per lead-coder's ask — "0 found" needs the range stated)

- `CodeActRunner` (#4175) — grepped `docs/`, 0 hits, nothing to fix.
- `/cancel` (#4180) — already fixed in #4181.
- fractional-timeout-rejected (#4183) — checked whether `control-ir.md`'s EN `sandboxed_exec` section describes the schema's JSON-Schema type; it doesn't, at any granularity, so nothing there needed to move.
- `embedding_index_build_complete` (#4168) — already verified correct earlier this session (`events.md`'s payload table already has the 3 new fields).
- slugify (#4177) — my own PR, already closed out via #4173.

## A self-caught mistake before committing

My first pass at `control-ir.ja.md`'s new `sandbox` config-block link used `#sandbox-block`, copying the EN anchor pattern — wrong. Ran `check_doc_anchors.py` before committing (not after), which caught it: the real ja anchor is `#sandbox-ブロック` (the heading text itself, per #4173's slugify fix), not the EN string.

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean
- [x] `python scripts/check_doc_anchors.py` — exit 0
- N/A ruff / mypy_ratchet / pytest — docs-only
