### PR TITLE
docs(#4196): mark control-ir.ja.md as an explicit partial translation

### DIFF
--- a/docs/reference/runtime/control-ir.ja.md
+++ b/docs/reference/runtime/control-ir.ja.md
@@ -8,6 +8,18 @@ audience: [human, agent]
 
 Control IR は LLM が artifact と並行して出力できる副作用 op のリストです。OS は各 op をディスパッチし、LLM（または次の Phase）が消費するために結果を返します。
 
+> ⚠️ **このページは部分訳です（#4196）。** `OP_KIND_MODEL_MAP`（`src/reyn/schemas/models.py`）が
+> 定義する op kind は現在 32 件ですが、このページが記述しているのは 16 件のみです — 残り 16 件
+> （`mcp_read_resource` / `mcp_subscribe_resource` / `mcp_unsubscribe_resource` /
+> `mcp_get_prompt` / `render_template` / `mcp_drop_server` / `embed` / `index_update` /
+> `compact` / `skill_install` / `load_skill` / `pipeline_install` / `presentation_install` /
+> `plugin_install` / `plugin_uninstall` / `emit_hook_event`）は**このページに一切記載がありません**
+> （「翻訳が古い」のではなく、そもそも節が存在しません）。それらの op を調べる際は
+> [英語版 Control IR reference](control-ir.md) を参照してください。
+> CLAUDE.md は en/ja の一律ミラーを義務としていません（ja は意図的な部分 subset）——
+> この注記は「未翻訳であること」自体を欠陥だと言っているのではなく、**部分訳であることを
+> このページ自身が今まで一度も明示していなかった**ことに対するものです。
+
 ## Op の種類
 
 | 種類 | 目的 | 必要な Permission |

--- a/docs/reference/runtime/control-ir.ja.md
+++ b/docs/reference/runtime/control-ir.ja.md
@@ -13,8 +13,9 @@ Control IR は LLM が artifact と並行して出力できる副作用 op の�
 > （`mcp_read_resource` / `mcp_subscribe_resource` / `mcp_unsubscribe_resource` /
 > `mcp_get_prompt` / `render_template` / `mcp_drop_server` / `embed` / `index_update` /
 > `compact` / `skill_install` / `load_skill` / `pipeline_install` / `presentation_install` /
-> `plugin_install` / `plugin_uninstall` / `emit_hook_event`）は**このページに一切記載がありません**
-> （「翻訳が古い」のではなく、そもそも節が存在しません）。それらの op を調べる際は
+> `plugin_install` / `plugin_uninstall` / `emit_hook_event`）は**専用の節がありません**
+> （「翻訳が古い」のではなく、そもそも節が存在しません — 一部は他 op の説明文中に言及される
+> だけで、それ自体の記述は持ちません）。それらの op を調べる際は
 > [英語版 Control IR reference](control-ir.md) を参照してください。
 > CLAUDE.md は en/ja の一律ミラーを義務としていません（ja は意図的な部分 subset）——
 > この注記は「未翻訳であること」自体を欠陥だと言っているのではなく、**部分訳であることを


### PR DESCRIPTION
**[docs-maintainer]** — part of #4196 (the "cheap" option — explicit partial-translation notice). A follow-up PR can pick off the ~16 missing sections incrementally; this lands the accuracy fix immediately rather than waiting on that larger effort.

## Correction along the way

I reported `OP_KIND_MODEL_MAP` as 31 kinds in #4195/#4196 — wrong, verified directly (`len(OP_KIND_MODEL_MAP) == 32`, every key listed and counted by hand). Corrected numbers used in this notice:

- **EN**: 32/32 covered (after #4195's `mcp_drop_server` fix lands)
- **JA**: 16/32 have *some* documentation (a summary-table row and/or a dedicated section), **16/32 have none at all** — not stale, structurally absent

## What changed

Added a callout right under `control-ir.ja.md`'s intro, naming the 16 missing op kinds explicitly and pointing at the EN page for them. Explicitly NOT framed as a mirror obligation (CLAUDE.md rejects that) — the problem this closes is a partial doc reading as complete, not the untranslated content itself.

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean
- [x] `python scripts/check_doc_anchors.py` — exit 0
- N/A ruff / mypy_ratchet / pytest — docs-only

part of #4196
