### PR TITLE
fix(#4159): make_adapter() test helper — same required-kwarg fix, one layer up

### DIFF
--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -95,6 +95,7 @@ def null_append_history(msg) -> None:
 
 
 def make_adapter(
+    *,
     agent_name: str = "test-agent",
     agent_workspace_dir: Path | None = None,
     events: EventLog | None = None,
@@ -113,10 +114,15 @@ def make_adapter(
     intervention_answer: "str | None" = None,  # #2175: interactive-mode bus answer (choice_id, e.g. "yes")
     peek_mid_turn_injection: "object | None" = None,  # #3792
     commit_mid_turn_injection: "object | None" = None,  # #3792
-    # #4159: RouterHostAdapter's own ctor param no longer defaults (closes the
-    # implicit-False/config-True mismatch); this shared test builder keeps its
-    # own False default so existing callers of make_adapter() are unaffected.
-    universal_wrappers_enabled: bool = False,
+    # #4159 (remainder recorded on the issue, closed out here): this test
+    # builder used to keep its OWN False default one layer above
+    # RouterHostAdapter's own now-required kwarg — the exact same
+    # implicit/config mismatch shape one level removed, and the exact
+    # "vacuous pass" risk a wrapper-visibility assertion could silently
+    # exercise the wrong path under. No default now; every caller states
+    # what it means. All params are keyword-only (the bare ``*`` above) so
+    # this doesn't need to move in the parameter list.
+    universal_wrappers_enabled: bool,
 ) -> RouterHostAdapter:
     """Construct a minimal RouterHostAdapter with real collaborators."""
     if events is None:

--- a/tests/core/test_0060_phase1_layer_a.py
+++ b/tests/core/test_0060_phase1_layer_a.py
@@ -172,7 +172,7 @@ def test_turn_origin_maps_every_known_kind_and_fails_safe_on_unmapped(tmp_path):
     kind fell through to "user_directed", this test goes RED (a Phase-4-gate
     bypass — 0060 SS2.7)."""
     s = make_session(agent_name="alice", state_log=StateLog(tmp_path / "wal.jsonl"))
-    adapter = make_adapter(
+    adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_name="alice", turn_origin_fn=lambda: s._current_turn_origin,
     )
 
@@ -288,7 +288,7 @@ async def test_hook_turn_through_real_tool_path_stamps_auto_improvement(tmp_path
     # a REAL autonomous turn: a hook self-continuation (NOT a user turn).
     s._stamp_execution_context("hook", {"text": "autonomous continuation"})
 
-    adapter = make_adapter(
+    adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_name="alice",
         turn_origin_fn=lambda: s._current_turn_origin,
         workspace_base_dir=tmp_path,

--- a/tests/core/test_2103_C2_fail_closed_capwalk_1953.py
+++ b/tests/core/test_2103_C2_fail_closed_capwalk_1953.py
@@ -126,7 +126,8 @@ async def test_topology_create_edges_confined_to_subtree_members(tmp_path):
     reg.create("coord")
     await reg.create_agent("worker", parent="coord")
     reg.create("outsider")  # operator-top, not wired by coord
-    adapter = make_adapter(agent_name="coord", agent_registry=reg)
+    adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
+        agent_name="coord", agent_registry=reg)
 
     res = await adapter.create_topology(name="org", kind="network", members=["coord", "worker"])
     assert res["status"] == "created"

--- a/tests/core/test_2103_C2b_identity_keyed_lineage_1953.py
+++ b/tests/core/test_2103_C2b_identity_keyed_lineage_1953.py
@@ -86,7 +86,8 @@ async def test_name_reuse_after_purge_rejects_orphan_forge_guard(tmp_path):
     assert not reg.is_spawn_descendant("worker", "coord")  # stale edge → not a descendant
 
     # forge-guard: the reused-name coord cannot wire the orphan it never spawned
-    adapter = make_adapter(agent_name="coord", agent_registry=reg)
+    adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
+        agent_name="coord", agent_registry=reg)
     res = await adapter.create_topology(
         name="grab", kind="network", members=["coord", "worker"],
     )
@@ -102,7 +103,8 @@ async def test_no_reuse_preserves_subtree_membership(tmp_path):
     await reg.create_agent("coord")
     await reg.create_agent("worker", parent="coord")
     assert reg.is_spawn_descendant("worker", "coord")
-    adapter = make_adapter(agent_name="coord", agent_registry=reg)
+    adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
+        agent_name="coord", agent_registry=reg)
     res = await adapter.create_topology(name="org", kind="network", members=["coord", "worker"])
     assert res["status"] == "created"
 

--- a/tests/core/test_2103_C3_spawn_limits_1953.py
+++ b/tests/core/test_2103_C3_spawn_limits_1953.py
@@ -70,12 +70,14 @@ async def test_spawn_rejected_beyond_max_depth(tmp_path):
     await reg.create_agent("a2", parent="a1")       # depth 2 (== max)
 
     # boundary: spawning under a1 (depth 1) → child depth 2 == max → ALLOWED
-    res_ok = await make_adapter(agent_name="a1", agent_registry=reg).spawn_agent(
+    res_ok = await make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
+        agent_name="a1", agent_registry=reg).spawn_agent(
         name="a1b", role="")
     assert res_ok["status"] == "spawned"
 
     # spawning under a2 (depth 2) → child depth 3 > max → REJECTED
-    res = await make_adapter(agent_name="a2", agent_registry=reg).spawn_agent(
+    res = await make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
+        agent_name="a2", agent_registry=reg).spawn_agent(
         name="a3", role="")
     assert res["status"] == "error"
     assert res["kind"] == "spawn_limit_exceeded"
@@ -90,7 +92,8 @@ async def test_spawn_rejected_beyond_max_children(tmp_path):
     next is rejected. RED if the fan-out bound isn't enforced."""
     reg = _registry(tmp_path, max_children=2)
     await reg.create_agent("p")
-    adapter = make_adapter(agent_name="p", agent_registry=reg)
+    adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
+        agent_name="p", agent_registry=reg)
 
     assert (await adapter.spawn_agent(name="c1", role=""))["status"] == "spawned"
     assert (await adapter.spawn_agent(name="c2", role=""))["status"] == "spawned"
@@ -118,7 +121,8 @@ async def test_fan_out_count_is_identity_keyed_not_name(tmp_path):
     assert reg.spawn_child_count("par") == 0          # identity-keyed (a name count → 1)
 
     # so the reused par gets its FULL fan-out budget (not charged for the orphan)
-    adapter = make_adapter(agent_name="par", agent_registry=reg)
+    adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
+        agent_name="par", agent_registry=reg)
     assert (await adapter.spawn_agent(name="n1", role=""))["status"] == "spawned"
     assert (await adapter.spawn_agent(name="n2", role=""))["status"] == "spawned"
     assert (await adapter.spawn_agent(name="n3", role=""))["status"] == "error"  # now at cap
@@ -138,7 +142,8 @@ async def test_topology_create_rejected_beyond_max_children(tmp_path):
     await reg.create_agent("w1", parent="coord")
     await reg.create_agent("w2", parent="coord")
     await reg.create_agent("w3", parent="coord")
-    adapter = make_adapter(agent_name="coord", agent_registry=reg)
+    adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
+        agent_name="coord", agent_registry=reg)
 
     res = await adapter.create_topology(
         name="big", kind="network", members=["coord", "w1", "w2", "w3"],  # 4 > 2

--- a/tests/core/test_2175_spawn_limits_on_limit_1953.py
+++ b/tests/core/test_2175_spawn_limits_on_limit_1953.py
@@ -41,7 +41,8 @@ async def test_depth_unattended_rejects(tmp_path):
     await reg.create_agent("a0")
     await reg.create_agent("a1", parent="a0")
     await reg.create_agent("a2", parent="a1")  # at depth 2 == max
-    adapter = make_adapter(agent_name="a2", agent_registry=reg,
+    adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
+        agent_name="a2", agent_registry=reg,
                            on_limit=OnLimitConfig(mode="unattended"))
     res = await adapter.spawn_agent(name="a3", role="")  # depth 3 > 2
     assert res["status"] == "error" and res["kind"] == "spawn_limit_exceeded"
@@ -60,7 +61,7 @@ async def test_depth_interactive_approve_extends_and_proceeds(tmp_path):
     await reg.create_agent("a1", parent="a0")
     await reg.create_agent("a2", parent="a1")  # depth 2 == max
     ext: dict = {}
-    adapter = make_adapter(
+    adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_name="a2", agent_registry=reg,
         on_limit=OnLimitConfig(mode="interactive", ask_timeout_seconds=0.0),
         safety_extensions=ext, intervention_answer="yes",
@@ -78,7 +79,7 @@ async def test_depth_interactive_decline_rejects(tmp_path):
     await reg.create_agent("a0")
     await reg.create_agent("a1", parent="a0")
     await reg.create_agent("a2", parent="a1")
-    adapter = make_adapter(
+    adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_name="a2", agent_registry=reg,
         on_limit=OnLimitConfig(mode="interactive", ask_timeout_seconds=0.0),
         intervention_answer="no",
@@ -96,7 +97,7 @@ async def test_fanout_auto_extend_then_exhausts(tmp_path):
     (spawned), the next exhausts the budget and rejects."""
     reg = _registry(tmp_path, max_children=2)
     await reg.create_agent("p")
-    adapter = make_adapter(
+    adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_name="p", agent_registry=reg,
         on_limit=OnLimitConfig(mode="auto_extend", auto_extend_times=1),
         safety_extensions={},
@@ -124,7 +125,7 @@ async def test_fanout_and_topology_use_separate_extension_keys(tmp_path):
     await reg.create_agent("w2", parent="coord")
     ext: dict = {}
     # approve a 3rd direct child (fan-out extension)
-    spawn_adapter = make_adapter(
+    spawn_adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_name="coord", agent_registry=reg,
         on_limit=OnLimitConfig(mode="interactive", ask_timeout_seconds=0.0),
         safety_extensions=ext, intervention_answer="yes",
@@ -134,7 +135,7 @@ async def test_fanout_and_topology_use_separate_extension_keys(tmp_path):
     # topology-members extension is UNTOUCHED by the fan-out approval
     assert ext.get("max_topology_members:coord", 0) == 0
     # a 4-member topology (> base 2) under UNATTENDED → still rejected (its own key)
-    topo_adapter = make_adapter(
+    topo_adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_name="coord", agent_registry=reg,
         on_limit=OnLimitConfig(mode="unattended"), safety_extensions=ext,
     )
@@ -155,6 +156,9 @@ async def test_no_approval_means_base_limit_holds(tmp_path):
     reg = _registry(tmp_path, max_depth=1)
     await reg.create_agent("a0")
     await reg.create_agent("a1", parent="a0")  # depth 1 == max
-    adapter = make_adapter(agent_name="a1", agent_registry=reg)  # no on_limit → no checkpoint
+    adapter = make_adapter(
+        universal_wrappers_enabled=False,  # #4159: not exercised by this test
+        agent_name="a1", agent_registry=reg,
+    )  # no on_limit → no checkpoint
     res = await adapter.spawn_agent(name="a2", role="")  # depth 2 > 1
     assert res["status"] == "error" and res["kind"] == "spawn_limit_exceeded"

--- a/tests/core/test_sandbox_model_completion_1339.py
+++ b/tests/core/test_sandbox_model_completion_1339.py
@@ -180,7 +180,7 @@ def test_router_adapter_factory_resolves_concrete_policy():
     carries a concrete default_sandbox_policy (wire-full-path — both factories)."""
     from tests._support.router_host_adapter import make_adapter
 
-    adapter = make_adapter()
+    adapter = make_adapter(universal_wrappers_enabled=False)  # #4159: not exercised by this test
     pol = adapter.make_router_op_context().default_sandbox_policy
     assert pol is not None
     assert pol["network"] is DEFAULT_SANDBOX_NETWORK

--- a/tests/llm/test_3792_pr2_router_loop_injection.py
+++ b/tests/llm/test_3792_pr2_router_loop_injection.py
@@ -259,7 +259,7 @@ async def test_router_loop_peek_and_commit_names_resolve_on_the_real_adapter() -
     async def _real_commit(msg_id: str) -> None:
         commit_calls.append(msg_id)
 
-    adapter = make_adapter(
+    adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         peek_mid_turn_injection=_real_peek,
         commit_mid_turn_injection=_real_commit,
     )

--- a/tests/runtime/test_2103_C1_topology_create_tool_1953.py
+++ b/tests/runtime/test_2103_C1_topology_create_tool_1953.py
@@ -102,7 +102,8 @@ async def test_create_topology_accepts_subtree_members_and_routes_through_emit_s
     reg = _registry(tmp_path)
     reg.create("coord")
     await reg.create_agent("worker", parent="coord")
-    adapter = make_adapter(agent_name="coord", agent_registry=reg)
+    adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
+        agent_name="coord", agent_registry=reg)
 
     res = await adapter.create_topology(
         name="myteam", kind="network", members=["coord", "worker"],
@@ -125,7 +126,8 @@ async def test_create_topology_rejects_non_subtree_member(tmp_path):
     reg.create("coord")
     await reg.create_agent("worker", parent="coord")
     reg.create("outsider")  # exists, but NOT spawned by coord (operator-top peer)
-    adapter = make_adapter(agent_name="coord", agent_registry=reg)
+    adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
+        agent_name="coord", agent_registry=reg)
 
     res = await adapter.create_topology(
         name="grab", kind="network", members=["coord", "outsider"],
@@ -151,7 +153,8 @@ async def test_create_topology_rejects_non_subtree_member_in_profile_binding(tmp
     reg.create("coord")
     await reg.create_agent("worker", parent="coord")
     reg.create("outsider")
-    adapter = make_adapter(agent_name="coord", agent_registry=reg)
+    adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
+        agent_name="coord", agent_registry=reg)
 
     res = await adapter.create_topology(
         name="grab2", kind="network",

--- a/tests/runtime/test_2737_session_spawn_depth_cap.py
+++ b/tests/runtime/test_2737_session_spawn_depth_cap.py
@@ -112,7 +112,7 @@ async def test_session_spawn_beyond_cap_is_rejected(tmp_path: Path) -> None:
     main = reg.get_or_load("worker")
     child_sid = await _nest_once(reg, main)  # nesting depth 1 == max
 
-    adapter = make_adapter(
+    adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_name="worker", agent_registry=reg, session_id=child_sid,
         on_limit=OnLimitConfig(mode="unattended"),
     )
@@ -136,7 +136,7 @@ async def test_session_spawn_within_cap_still_works(tmp_path: Path) -> None:
     main = reg.get_or_load("worker")
     child_sid = await _nest_once(reg, main)  # nesting depth 1; cap 2 ⇒ one more allowed
 
-    adapter = make_adapter(
+    adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_name="worker", agent_registry=reg, session_id=child_sid,
         on_limit=OnLimitConfig(mode="unattended"),
     )
@@ -163,7 +163,7 @@ async def test_session_spawn_interactive_approve_extends_and_proceeds(
     child_sid = await _nest_once(reg, main)  # depth 1 == max
 
     ext: dict = {}
-    adapter = make_adapter(
+    adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_name="worker", agent_registry=reg, session_id=child_sid,
         on_limit=OnLimitConfig(mode="interactive", ask_timeout_seconds=0.0),
         safety_extensions=ext, intervention_answer="yes",

--- a/tests/runtime/test_cwd_sandbox_aware_1477.py
+++ b/tests/runtime/test_cwd_sandbox_aware_1477.py
@@ -38,7 +38,7 @@ def test_get_cwd_with_container_backend_returns_repo_dir(tmp_path: Path) -> None
     get_cwd() returns the container path, not the host cwd."""
     container_path = "/testbed"
     backend = _FakeContainerBackend(repo_dir=container_path)
-    adapter = _make_adapter(
+    adapter = _make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_workspace_dir=tmp_path / "agents" / "test",
         environment_backend=backend,
     )
@@ -49,7 +49,7 @@ def test_get_cwd_with_host_backend_returns_os_getcwd(tmp_path: Path) -> None:
     """Tier 2: #1477 — when environment_backend has no repo_dir (HostBackend),
     get_cwd() falls back to os.getcwd() — existing behaviour preserved."""
     backend = _FakeHostBackend()
-    adapter = _make_adapter(
+    adapter = _make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_workspace_dir=tmp_path / "agents" / "test",
         environment_backend=backend,
     )
@@ -59,7 +59,7 @@ def test_get_cwd_with_host_backend_returns_os_getcwd(tmp_path: Path) -> None:
 def test_get_cwd_with_no_backend_returns_os_getcwd(tmp_path: Path) -> None:
     """Tier 2: #1477 — when no environment_backend is set (None), get_cwd()
     returns os.getcwd() — backward-compat for host-only sessions."""
-    adapter = _make_adapter(
+    adapter = _make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_workspace_dir=tmp_path / "agents" / "test",
     )
     assert adapter.get_cwd() == os.getcwd()
@@ -70,7 +70,7 @@ def test_get_cwd_container_differs_from_host(tmp_path: Path) -> None:
     Confirms the fix actually changes the value (not a no-op)."""
     container_path = "/testbed"
     backend = _FakeContainerBackend(repo_dir=container_path)
-    adapter = _make_adapter(
+    adapter = _make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_workspace_dir=tmp_path / "agents" / "test",
         environment_backend=backend,
     )

--- a/tests/runtime/test_force_close_chat_activation_1092.py
+++ b/tests/runtime/test_force_close_chat_activation_1092.py
@@ -70,7 +70,8 @@ def test_adapter_exposes_reserve_when_engine_present() -> None:
     """Tier 2: with a turn_budget engine, wrap_up_output_reserve ==
     engine.budget.output_reserve (the cap RouterLoop._force_close_call applies)."""
     eng = build_default_turn_budget_engine("gpt-4o-mini", use_chars4=True)
-    adapter = _make_adapter(turn_budget_engine=eng)
+    adapter = _make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
+        turn_budget_engine=eng)
     assert adapter.wrap_up_output_reserve == eng.budget.output_reserve
     assert adapter.wrap_up_output_reserve == DEFAULT_WRAP_UP_OUTPUT_RESERVE_TOKENS
 
@@ -78,7 +79,7 @@ def test_adapter_exposes_reserve_when_engine_present() -> None:
 def test_adapter_reserve_none_without_engine() -> None:
     """Tier 2: no engine (legacy / test paths) → None → no cap (== the
     pre-PR-F chat behaviour; the cap only engages once an engine is wired)."""
-    adapter = _make_adapter()
+    adapter = _make_adapter(universal_wrappers_enabled=False)
     assert adapter.wrap_up_output_reserve is None
 
 
@@ -87,7 +88,7 @@ def test_adapter_does_not_expose_proactive_trigger() -> None:
     (the wrap-up cap) but NOT should_force_close (the proactive trigger). This is
     the deliberate per-axis choice: phase force-closes proactively, chat only at
     the F2 floor-exhausted terminal."""
-    adapter = _make_adapter(
+    adapter = _make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         turn_budget_engine=build_default_turn_budget_engine("gpt-4o-mini", use_chars4=True)
     )
     assert not hasattr(adapter, "should_force_close")

--- a/tests/runtime/test_router_host_adapter_invariants.py
+++ b/tests/runtime/test_router_host_adapter_invariants.py
@@ -92,7 +92,10 @@ def test_adapter_protocol_conformance(tmp_path):
     Uses @runtime_checkable isinstance check — catches missing methods at
     refactor time without requiring a real LLM or full session.
     """
-    adapter = _make_adapter(agent_workspace_dir=tmp_path / "agents" / "test-agent")
+    adapter = _make_adapter(
+        agent_workspace_dir=tmp_path / "agents" / "test-agent",
+        universal_wrappers_enabled=False,  # #4159: not exercised by this test
+    )
     assert isinstance(adapter, RouterLoopHost), (
         "RouterHostAdapter must satisfy RouterLoopHost protocol structurally"
     )
@@ -128,6 +131,7 @@ def test_adapter_exposes_the_memory_capability_itself(tmp_path):
         agent_workspace_dir=workspace,
         events=events,
         memory=memory,
+        universal_wrappers_enabled=False,  # #4159: not exercised by this test
     )
 
     assert adapter.memory is memory
@@ -156,6 +160,7 @@ def test_events_identity(tmp_path):
     adapter = _make_adapter(
         agent_workspace_dir=tmp_path / "agents" / "test-agent",
         events=events,
+        universal_wrappers_enabled=False,  # #4159: not exercised by this test
     )
     assert adapter.events is events, (
         "adapter.events must be the same EventLog instance as injected"
@@ -192,6 +197,7 @@ def test_adapter_exposes_permission_resolver_property(tmp_path):
     sentinel = object()  # any non-None value — we only assert identity
     adapter = _make_adapter(
         agent_workspace_dir=tmp_path / "agents" / "alpha",
+        universal_wrappers_enabled=False,  # #4159: not exercised by this test
     )
     # Re-build with the resolver argument set — _make_adapter doesn't take it.
     from reyn.core.events.events import EventLog

--- a/tests/runtime/test_sp_environment_sysinfo_1479.py
+++ b/tests/runtime/test_sp_environment_sysinfo_1479.py
@@ -75,7 +75,7 @@ def test_env_info_host_backend_derives_from_platform_module(tmp_path: Path) -> N
     """Tier 2: #1479 — host backend path: platform/os_version/shell derived
     from local platform module + os.environ. date always present."""
     import platform
-    adapter = _make_adapter(
+    adapter = _make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_workspace_dir=tmp_path / "agents" / "test",
         environment_backend=_FakeHostBackend(),
     )
@@ -94,7 +94,7 @@ def test_env_info_container_backend_uses_backend_values(tmp_path: Path) -> None:
         os_version="5.15.0",
         shell="/bin/bash",
     )
-    adapter = _make_adapter(
+    adapter = _make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_workspace_dir=tmp_path / "agents" / "test",
         environment_backend=backend,
     )
@@ -111,7 +111,7 @@ def test_env_info_container_backend_no_probe_omits_platform_shell(tmp_path: Path
     regression: showing host darwin/zsh for a linux container = wrong context.
     """
     backend = _FakeContainerBackendNoInfo(repo_dir="/testbed")
-    adapter = _make_adapter(
+    adapter = _make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_workspace_dir=tmp_path / "agents" / "test",
         environment_backend=backend,
     )
@@ -125,7 +125,7 @@ def test_env_info_container_backend_no_probe_omits_platform_shell(tmp_path: Path
 def test_env_info_no_backend_derives_from_platform_module(tmp_path: Path) -> None:
     """Tier 2: #1479 — no backend: same as host backend (fallback to platform)."""
     import platform
-    adapter = _make_adapter(
+    adapter = _make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_workspace_dir=tmp_path / "agents" / "test",
     )
     info = adapter.get_environment_info()
@@ -144,7 +144,7 @@ def test_env_info_git_repo_detection_true(tmp_path: Path) -> None:
         repo_dir=str(tmp_path), platform="linux", os_version="5.15.0",
         shell="/bin/bash", is_git_repo=True,
     )
-    adapter = _make_adapter(
+    adapter = _make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_workspace_dir=tmp_path / "agents" / "test",
         environment_backend=backend,
     )
@@ -158,7 +158,7 @@ def test_env_info_git_repo_detection_false(tmp_path: Path) -> None:
         repo_dir=str(tmp_path), platform="linux", os_version="5.15.0",
         shell="/bin/bash", is_git_repo=False,
     )
-    adapter = _make_adapter(
+    adapter = _make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_workspace_dir=tmp_path / "agents" / "test",
         environment_backend=backend,
     )
@@ -173,7 +173,7 @@ def test_env_info_git_repo_omitted_when_probe_degrades(tmp_path: Path) -> None:
         repo_dir=str(tmp_path), platform="linux", os_version="5.15.0",
         shell="/bin/bash", is_git_repo=None,
     )
-    adapter = _make_adapter(
+    adapter = _make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
         agent_workspace_dir=tmp_path / "agents" / "test",
         environment_backend=backend,
     )


### PR DESCRIPTION
**[e2e-coder]** — Implements #4159's recorded remainder (production side already fixed in #4167; this closes the test-helper side).

## The gap

`tests/_support/router_host_adapter.py`'s `make_adapter()` kept its OWN `universal_wrappers_enabled: bool = False` default one layer above `RouterHostAdapter.__init__`'s own now-required kwarg (#4167) — the exact same implicit/config mismatch shape recreated one level removed. 70 call sites across ~20 files silently got `False`; any test wanting to exercise config-True behavior that forgot to pass it explicitly would get a vacuous pass. Recorded as this issue's open remainder at #4167's merge time, not touched there to keep that PR's falsify focus clean.

## Fix

Architect's ruling (option ②, required kwarg — "closes the class") applied here too: `make_adapter()` gained a bare `*` (confirmed zero positional callers across the whole sweep) and dropped its own default.

**Scope measured before touching anything**: grepped for `"universal_wrappers"` / `"get_universal_wrappers_enabled"` across all 20 files using `make_adapter()` — only 3 reference the concept at all, and those 3 either already pass it explicitly (`test_router_host_adapter_invariants.py`, `test_action_retrieval_wiring.py` — has its own local wrapper, always parametrized) or construct `RouterHostAdapter` directly (`#4167` already forces those explicit). The other ~17 files construct the adapter for unrelated purposes (spawn limits, sandbox cwd, mtime watch, MCP cache warm-start, …) and never assert on this axis — safe to mechanically thread `universal_wrappers_enabled=False` (behavior-preserving).

**12 files / 39 call sites** import and call the SHARED `make_adapter()` directly and needed the explicit kwarg added. The other ~8 files either call their own local `_make_adapter` wrapper (which already hardcodes the kwarg internally, e.g. `test_3520_unknown_probe_is_not_an_answer.py`, `test_mcp_cache_warm_start.py` via `make_mcp_cache_adapter`) or construct `RouterHostAdapter` directly — both already safe, untouched.

## Falsify-verification

Reintroduced `make_adapter()`'s own `False` default, removed the explicit kwarg from one call site — the test still passed (it doesn't assert on this axis), confirming the fix's real value is the missing-kwarg guard itself (a future forgetful caller now crashes loudly at construction instead of silently inheriting `False`), not any assertion in today's tests. Restored, all green.

## #4165 note

Lead-coder flagged #4165 (same field reaching `build_tools()` as `False` in a live run, source unconfirmed) as related — worth checking if this PR's investigation surfaced the source. It didn't: this fix is entirely test-side (`tests/_support/`), and #4165 is a live-run/production-path question this PR doesn't touch or explain. Not claiming a connection beyond "same field."

## Verification
- 5 local gates green: `ruff check src tests`, `test_tier_audit.py --strict` (89 tests, 0 errors), `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py`.
- Broad sweep: `tests/runtime/` + `tests/core/` + all 19 directly-touched/adjacent files — 4186 passed, 1 pre-existing unrelated failure (`test_session_pure_extraction_3679_s1`'s subprocess-import isolation test — confirmed via stash-and-rerun on origin state, a PYTHONPATH resolution issue untouched by this diff).

## Test plan
- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict <13 changed test files>`
- [x] `python scripts/verify_module_docstrings.py tests/_support/router_host_adapter.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] Falsify-verified (see above)
- [x] Broad consumer sweep (4186 tests, 1 pre-existing unrelated failure confirmed)
- [ ] (Visual — N/A, test-only change)

part of #4159

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
