### PR TITLE
fix(#4186): DEFAULT_BACKGROUND_EXEC_TIMEOUT_SECONDS 1800 -> 3600 (owner-specified)

### DIFF
--- a/src/reyn/security/sandbox/policy.py
+++ b/src/reyn/security/sandbox/policy.py
@@ -215,16 +215,19 @@ DEFAULT_MAX_EXEC_TIMEOUT_SECONDS: int = 600
 # budget bound it instead"; it would remove the only instrument that bounds
 # THIS resource (process wall-clock time is not tokens or dollars).
 #
-# DEFAULT_BACKGROUND_EXEC_TIMEOUT_SECONDS is a judgment call (tui-coder,
-# 2026-08-11), not a measured or owner-specified number — the same posture
-# #4179's own 120/600 took ("realizing a spec, not something a measurement
-# should block"), scaled up for the background case: 30 minutes is long
-# enough to cover the class of background work #3903's own reference section
-# describes (a build step, a long-running install) without being unbounded.
-# Open to revision by whoever picks the actual number next; the type/shape
-# (a real int, operator-settable, distinct from foreground) is the owner
-# ruling, this magnitude is not.
-DEFAULT_BACKGROUND_EXEC_TIMEOUT_SECONDS: int = 1800
+# DEFAULT_BACKGROUND_EXEC_TIMEOUT_SECONDS: owner-specified (architect,
+# issue #3903 comment 2026-08-11 — "owner 確認: 背景の既定は 3600 秒、
+# config で変更可能"), not a judgment call this file is making. An
+# earlier version of this comment said 1800 was "a judgment call... not a
+# measured or owner-specified number" — that was true of the FIRST value
+# tried, but the owner ruling existed on the issue thread the whole time;
+# it simply hadn't been relayed over broker yet when the first version
+# landed (architect's own correction, same day: "私は #3903 に owner
+# 確認... と書いています。原因は私です — issue に書いたが broker で流さな
+# かった"). 3600 is the confirmed value; the type/shape (a real int,
+# operator-settable, distinct from foreground) was always the owner
+# ruling, and this magnitude now is too.
+DEFAULT_BACKGROUND_EXEC_TIMEOUT_SECONDS: int = 3600
 # owner ruling (2026-08-11, relayed via lead-coder): the background CEILING's
 # default is None (no cap) — NOT a large sentinel int. A sentinel (e.g.
 # 2**31-1) would still be a real number an LLM-supplied override could be

--- a/src/reyn/security/sandbox/policy.py
+++ b/src/reyn/security/sandbox/policy.py
@@ -215,18 +215,9 @@ DEFAULT_MAX_EXEC_TIMEOUT_SECONDS: int = 600
 # budget bound it instead"; it would remove the only instrument that bounds
 # THIS resource (process wall-clock time is not tokens or dollars).
 #
-# DEFAULT_BACKGROUND_EXEC_TIMEOUT_SECONDS: owner-specified (architect,
-# issue #3903 comment 2026-08-11 — "owner 確認: 背景の既定は 3600 秒、
-# config で変更可能"), not a judgment call this file is making. An
-# earlier version of this comment said 1800 was "a judgment call... not a
-# measured or owner-specified number" — that was true of the FIRST value
-# tried, but the owner ruling existed on the issue thread the whole time;
-# it simply hadn't been relayed over broker yet when the first version
-# landed (architect's own correction, same day: "私は #3903 に owner
-# 確認... と書いています。原因は私です — issue に書いたが broker で流さな
-# かった"). 3600 is the confirmed value; the type/shape (a real int,
-# operator-settable, distinct from foreground) was always the owner
-# ruling, and this magnitude now is too.
+# DEFAULT_BACKGROUND_EXEC_TIMEOUT_SECONDS: owner-specified (#3903,
+# 2026-08-11), operator-settable via config — the type/shape (a real int,
+# distinct from the foreground default) is owner ruling too.
 DEFAULT_BACKGROUND_EXEC_TIMEOUT_SECONDS: int = 3600
 # owner ruling (2026-08-11, relayed via lead-coder): the background CEILING's
 # default is None (no cap) — NOT a large sentinel int. A sentinel (e.g.

--- a/tests/core/test_op_sandboxed_exec.py
+++ b/tests/core/test_op_sandboxed_exec.py
@@ -72,7 +72,7 @@ def test_policy_defaults():
     assert p.env_deny_names == []
     assert p.timeout_seconds == 120
     assert p.max_timeout_seconds == 600
-    assert p.background_timeout_seconds == 1800
+    assert p.background_timeout_seconds == 3600
     assert p.background_max_timeout_seconds is None
 
 

--- a/tests/security/test_sandbox_factory.py
+++ b/tests/security/test_sandbox_factory.py
@@ -258,7 +258,7 @@ def test_unknown_config_keys_flags_an_unknown_sandbox_policy_key() -> None:
 
 def test_config_background_timeout_defaults_independently_of_foreground() -> None:
     """Tier 2: #3903 a-2 — background_timeout_seconds/background_max_timeout_seconds
-    resolve to their OWN dataclass defaults (1800 / None) when the operator
+    resolve to their OWN dataclass defaults (3600 / None) when the operator
     sets only the foreground pair — the single-shared-field shape #3903's
     issue body named as the problem ("一時セッション内でも同じ 60 秒") is gone:
     setting foreground's timeout_seconds must not also move background's.
@@ -277,8 +277,8 @@ def test_config_background_timeout_defaults_independently_of_foreground() -> Non
     )
     policy = SandboxPolicy(**resolved)
     assert policy.timeout_seconds == 30
-    assert policy.background_timeout_seconds == 1800, (
-        "background_timeout_seconds must resolve to its OWN default (1800), "
+    assert policy.background_timeout_seconds == 3600, (
+        "background_timeout_seconds must resolve to its OWN default (3600), "
         "not be dragged by the foreground override"
     )
     assert policy.background_max_timeout_seconds is None


### PR DESCRIPTION
**[tui-coder]** — fix-forward for #4186: `DEFAULT_BACKGROUND_EXEC_TIMEOUT_SECONDS` 1800 → 3600 (owner-specified value, relay gap).

## Why

architect had already written the owner's confirmed value (3600s) on the #3903 issue thread on 2026-08-11, but it never reached broker — so #4186 landed with my own self-described "judgment call" of 1800 instead. Not my error (architect's own correction, same day): the ruling existed on the issue, it just hadn't been relayed.

Re-confirmed with owner directly: "if there's an industry-standard basis, 1800 is fine too" → the 30-minute figure was a judgment call, not an industry standard, so the confirmed value stays **3600**.

## What changed

- `DEFAULT_BACKGROUND_EXEC_TIMEOUT_SECONDS: int = 1800` → `3600`.
- The constant's own comment corrected — it previously said "not a measured or owner-specified number," which is now false and would mislead a future reader into thinking the magnitude is still free to pick.
- `background_max_timeout_seconds` (stays `None`) — unchanged, architect confirmed that field was correct as landed.
- Test assertions updated (2 files).

## Scope

Deliberately separate from #3903 a-2 ③ (lead-coder: mixing this into the ③ wiring diff would bury the value correction). Single-constant change, should land fast — ③ builds on top of this.

## Test plan

- [x] `ruff check src tests` clean
- [x] `mypy_ratchet.py` clean
- [x] `verify_module_docstrings.py` clean
- [x] Targeted sweep: `tests/security/` + `test_op_sandboxed_exec.py`, 741 passed
- [ ] Visual/manual: none applicable (constant + comment change only)
