### PR TITLE
docs(#4081): update test_mcp_sse.py's coverage note now that #4199 closed the list_agents_impl gap

### DIFF
--- a/tests/web/test_mcp_sse.py
+++ b/tests/web/test_mcp_sse.py
@@ -8,16 +8,16 @@ the SDK is correct).
 
 We do NOT exercise the full JSON-RPC handshake here — that's owned
 by the upstream ``mcp`` SDK. The backing impl the two transports share
-(``src/reyn/mcp/server.py``) is NOT uniformly covered: ``send_to_agent_impl``
-is called for real by ``tests/runtime/test_transport_ref.py`` (plus
-exercised, faked, elsewhere) — but ``list_agents_impl`` has NO test that
-calls it directly (#4081; production caller: ``server.py``'s ``_call_tool``
-handler). Don't confuse this with the SAME-NAMED but unrelated
-``list_agents`` router tool (``src/reyn/tools/catalog.py``'s
-``LIST_AGENTS``/``_handle_list_agents``) — grepping for ``list_agents``
-alone finds that tool's own tests and reads as coverage of this one.
-``tests/test_mcp_server.py``, the file this docstring used to cite, does
-not exist.
+(``src/reyn/mcp/server.py``) is covered directly, not through this file:
+``send_to_agent_impl`` by ``tests/runtime/test_transport_ref.py`` (plus
+exercised, faked, elsewhere), and ``list_agents_impl`` by
+``tests/mcp/test_4189_list_agents_impl_real_consumer.py`` (#4189/#4199 —
+closed the gap #4081 originally found here). Don't confuse either with the
+SAME-NAMED but unrelated ``list_agents`` router tool
+(``src/reyn/tools/catalog.py``'s ``LIST_AGENTS``/``_handle_list_agents``)
+— grepping for ``list_agents`` alone finds that tool's own tests and reads
+as coverage of this one. ``tests/test_mcp_server.py``, the file this
+docstring used to cite before #4081, does not exist.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
**[docs-maintainer]** — follow-up to my own #4188. That PR's docstring accurately said `list_agents_impl` had no test calling it directly — true at the time, falsified within the hour by #4189/#4199, which added `tests/mcp/test_4189_list_agents_impl_real_consumer.py` (3 real calls, grep-verified). Updated the note to cite the new coverage instead of describing a now-closed gap.

## Test plan
- [x] `ruff check tests/web/test_mcp_sse.py` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/web/test_mcp_sse.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- N/A pytest / mypy_ratchet / verify_module_docstrings — comment-only change
