### PR TITLE
chore(#4174 T1): delete the dead python: config surface

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -64,7 +64,6 @@ reload）、`reyn.yaml` 側に書いた同じキーは他と同じく再起動�
 | `observability` | マップ | PRJ のみ・**再起動** | P6 監査イベントの OpenTelemetry (OTLP) エクスポート（オプトイン）。デフォルトは無効。以下参照。 |
 | `tool_use` | マップ | PRJ のみ・**再起動** | chat レイヤーの tool-use scheme x transport セレクタ（`scheme`、`transport`）。以下参照。 |
 | `mcp` | マップ | 両方（`.reyn/config/mcp.yaml` 側は **hot reload**） | MCP サーバー定義。以下参照。 |
-| `python` | マップ | PRJ のみ・**再起動** | Python preprocessor が import してよい追加モジュール（`python.allowed_modules`）— このリスト 1 つがキーの全体です。以下参照。 |
 | `agent` | マップ | PRJ のみ・**再起動** | エージェントの**識別子のみ**（`agent.id`）— P6 監査証跡と送信 HTTP ヘッダーに刻まれます。**エージェントの定義・設定はしません**（エージェント定義は `.reyn/agents/<名前>/`）。以下参照。 |
 | `auth` | マップ | PRJ のみ・**再起動** | `reyn auth login` 用の OAuth プロバイダー設定。以下参照。 |
 | `cron` | マップ | 両方（`.reyn/config/cron.yaml` 側は **hot reload**） | スケジュール付きスキル実行。以下参照。 |
@@ -1232,25 +1231,6 @@ voice:
 | `cpu_threads` | int | `4` | faster-whisper の CPU スレッド数。`0` = OpenMP デフォルト。Apple Silicon での OpenMP/Python スレッドデッドロックを避けるため 4 に固定しています。 |
 | `num_workers` | int | `1` | 並列転写ストリーム数。`1` でメモリとスレッド使用量を低く保ちます。 |
 | `max_duration_s` | float | `300.0` | この秒数を超える録音を自動キャンセル。放置録音によるメモリ増大を防ぎます。 |
-
-## `python` ブロック
-
-Python preprocessor 設定。セーフモードでインポートできるモジュールの組み込み許可リストを拡張します。
-
-```yaml
-python:
-  allowed_modules:
-    - math
-    - statistics
-    - json
-    - re
-```
-
-| フィールド | 型 | デフォルト | 説明 |
-|-------|------|---------|-------------|
-| `allowed_modules` | list[string] | `[]` | セーフモード Python preprocessor ステップが組み込み stdlib 許可リストに加えてインポートできる追加モジュール名。内部で I/O を行うライブラリ（例: `pandas`、`requests`）はセーフモードのサンドボックスを無効化します — 慎重に管理してください。 |
-
-> Python ステップは常にサンドボックス化されます。`mode: unsafe` の宣言はロード時に拒否されます — 生の I/O は `run_op` ステップに分離するか、permission でゲートされた `reyn.api.safe.*` サーフェスを使用してください。完全な Permission 文法は [Reference: permissions](permissions.md) を参照してください。
 
 ## `multimodal` ブロック
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -69,7 +69,6 @@ can additionally be written on an **agent** surface (`.reyn/agents/<name>/`,
 | `observability` | map | PRJ only · **restart** | Opt-in OpenTelemetry (OTLP) export of P6 audit-events. Off by default. See below. |
 | `tool_use` | map | PRJ only · **restart** | Chat-layer tool-use scheme x transport selector (`scheme`, `transport`). See below. |
 | `mcp` | map | both (`.reyn/config/mcp.yaml` side is **hot-reloaded**) | MCP server definitions. See below. |
-| `python` | map | PRJ only · **restart** | Additional modules the Python preprocessor may import (`python.allowed_modules`) — that one list is the whole key. See below. |
 | `agent` | map | PRJ only · **restart** | Agent **identity** only (`agent.id`) — stamped on the P6 audit trail and the outgoing HTTP header. Does **not** define or configure agents; agent definitions live in `.reyn/agents/<name>/`. See below. |
 | `auth` | map | PRJ only · **restart** | OAuth provider configurations for `reyn auth login`. See below. |
 | `cron` | map | both (`.reyn/config/cron.yaml` side is **hot-reloaded**) | Scheduled skill executions. See below. |
@@ -2009,25 +2008,6 @@ voice:
 | `cpu_threads` | int | `4` | CPU threads for faster-whisper. `0` = OpenMP default. Pinning to 4 avoids OpenMP/Python-threading deadlocks on Apple Silicon. |
 | `num_workers` | int | `1` | Parallel transcription streams. `1` keeps memory + thread usage low. |
 | `max_duration_s` | float | `300.0` | Auto-cancel recordings longer than this (seconds). Prevents runaway memory growth from unattended recordings. |
-
-## `python` block
-
-Python preprocessor settings. Extends the built-in safe-mode allowlist of importable modules.
-
-```yaml
-python:
-  allowed_modules:
-    - math
-    - statistics
-    - json
-    - re
-```
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `allowed_modules` | list[string] | `[]` | Additional module names that safe-mode Python preprocessor steps may import, on top of the built-in stdlib allowlist. Libraries with internal I/O (e.g. `pandas`, `requests`) defeat safe-mode sandboxing — curate carefully. |
-
-> Python steps are always sandboxed. A `mode: unsafe` declaration is rejected at load — split raw I/O out via a `run_op` step, or use the permission-gated `reyn.api.safe.*` surface. See [Reference: permissions](permissions.md) for the full permission grammar.
 
 ## `multimodal` block
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -339,17 +339,6 @@
 #   backend: bm25
 
 
-# -----------------------------------------------------------------------------
-# python: settings for the python preprocessor step.
-# ``allowed_modules`` extends the stdlib allow-list with extra modules that
-# user code may ``import`` in *safe* mode. Curate carefully — libraries that
-# internally perform I/O (pandas, requests, ...) defeat sandboxing.
-# -----------------------------------------------------------------------------
-# python:
-#   allowed_modules:
-#     - numpy
-#     - dateutil
-
 
 # -----------------------------------------------------------------------------
 # agent: runtime identity used in audit events and the

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -362,19 +362,6 @@ def _build_auth_config(raw: object) -> AuthConfig:
 
 
 @dataclass
-class PythonConfig:
-    """`python` section — settings for the python preprocessor step."""
-    # Modules that user code may import in pure mode in addition to the
-    # stdlib allowlist. Curate carefully: libraries that internally do I/O
-    # (pandas.read_csv, requests, etc.) defeat pure-mode sandboxing.
-    allowed_modules: list[str] = field(default_factory=list)
-                                      # (= 5 min default). Prevents runaway memory
-                                      # growth + multi-GB transcribe calls if the
-                                      # user walks away mid-recording. 16 kHz mono
-                                      # float32 ≈ 64 KB/s, so 5 min is ~19 MB.
-
-
-@dataclass
 class EventsConfig:
     """`events:` — audit log rotation policy (PR20).
 
@@ -821,15 +808,6 @@ def _build_fs_watch_config(raw: object) -> FsWatchConfig:
     except (TypeError, ValueError):
         debounce_seconds = 0.2
     return FsWatchConfig(paths=paths, debounce_seconds=debounce_seconds)
-
-
-def _build_python_config(raw: object) -> PythonConfig:
-    if not isinstance(raw, dict):
-        return PythonConfig()
-    modules = raw.get("allowed_modules") or []
-    if not isinstance(modules, list):
-        modules = []
-    return PythonConfig(allowed_modules=[str(m) for m in modules])
 
 
 def _build_events_config(raw: object) -> EventsConfig:

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -30,7 +30,6 @@ from reyn.config.infra import (  # #1682 #3 cross-section
     _build_events_config,
     _build_fs_watch_config,
     _build_llm_config,
-    _build_python_config,
     _build_sandbox_config,
 )
 from reyn.config.media import (  # #1682 #3 cross-section
@@ -783,7 +782,6 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         ),
         permissions=_as_config_dict(merged.get("permissions"), "permissions"),
         mcp=_as_config_dict(merged.get("mcp"), "mcp"),
-        python=_build_python_config(merged.get("python")),
         agent=_build_agent_config(merged.get("agent")),
         delegation=_build_delegation_config(merged.get("delegation")),
         auth=_build_auth_config(merged.get("auth")),

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -53,7 +53,6 @@ from reyn.config.infra import (
     EventsConfig,
     FsWatchConfig,
     LLMConfig,
-    PythonConfig,
     SandboxConfig,
 )
 from reyn.config.media import (
@@ -176,8 +175,6 @@ class ReynConfig:
     #           Authorization: "Bearer ${GITHUB_TOKEN}"
     #           X-API-Version: "2024-01-01"
     mcp: dict = field(default_factory=dict)
-    # Python preprocessor step settings.
-    python: PythonConfig = field(default_factory=PythonConfig)
     # FP-0016 Component E — agent identity for audit trail + HTTP header
     # propagation. Default `reyn/<hostname>` when reyn.yaml has no
     # `agent:` block. Read by Session to construct its EventLog and


### PR DESCRIPTION
**[docs-maintainer]** — implements #4174 T1 (`python:` config deletion). Re-measured on fresh `origin/main` before deleting, per the issue's own condition — not reusing the prior night's finding, per lead-coder's explicit warning against the shape #4159 had (a stale issue body handed off without re-checking).

## Re-measurement (fresh, this PR)

- `config.python`: zero references anywhere in `src/reyn/` (grepped on a fresh checkout).
- The one production `ExecContext(extra={...})` construction site (`router_loop.py`'s `_run_codeblock_round`, the only caller of `_content_fence_cell.py`'s `execute()`) has exactly 4 keys: `dispatch`, `dispatchable_catalog`, `sandbox_policy`, `cancel_event`. No `allowed_modules` key — `extra.get("allowed_modules")` is always `None` in production.
- `_validate_safe_ast`/`_build_restricted_builtins` (the functions that actually consume `allowed_modules`) have exactly one caller in the whole tree: `_codeact_harness.py` — the same dead path. No separate pipeline "python preprocessor step" reads `config.python` either (`core/pipeline/expr.py` is a different, import-free expression evaluator, by its own module docstring).
- Confirmed live, not just via grep: `load_config()` succeeds and `hasattr(cfg, "python")` is `False` after removal.

## What was removed

- `PythonConfig` dataclass + `_build_python_config` parser (`config/infra.py`)
- `ReynConfig.python` field + import (`config/root.py`)
- `loader.py`'s wiring call + import
- `docs/reference/config/reyn-yaml.md` + `.ja.md`: the `` `python` block `` section and its top-level-key summary-table row
- `reyn.local.yaml.example`'s commented `python:` example

## Deliberately NOT touched (out of T1's scope)

`allowed_modules` as a runtime **parameter** on `CodeActRunner` / `_content_fence_cell.py` / `_python_harness.py` stays — that's the sandbox's own safe-mode import-allowlist mechanism, real infrastructure with its own tests, just never fed a non-default value by any current caller now that the only config path to it is gone. T1's scope is the config *surface* (`python:` in `reyn.yaml`), not this lower-level mechanism.

No test referenced `PythonConfig`/`python:` config anywhere (grepped before touching anything) — nothing to update there.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/verify_module_docstrings.py <changed files>` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (210/214 baselined, unchanged)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean
- [x] `python scripts/check_doc_anchors.py` — exit 0
- [x] Live config-load check: `load_config()` succeeds, `hasattr(cfg, "python")` is `False`
- [x] `pytest tests/config/` — 149 passed
- [x] `pytest tests/ -k config` — 679 passed, 3 skipped (unrelated missing optional extras)

part of #4174
