### PR TITLE
fix(#4039): unenforced_axes() asks "does this backend enforce" not "can it express a deny-list"

### DIFF
--- a/docs/concepts/runtime/sandbox.md
+++ b/docs/concepts/runtime/sandbox.md
@@ -116,48 +116,72 @@ The registry also records `witness_strength` per backend — network's deny leg 
 
 **macOS 26.3+ and `SeatbeltBackend`**: `sandbox-exec` remains shipped in macOS 26.3. An SBPL profile that includes `(import "bsd.sb")` and `(allow process-exec*)` is sufficient for the backend to function. See the FP-0017 post-dogfood fix landing notes (commit `b477508`) for details.
 
-### Deny-list visibility: `sandbox_axis_unenforced` — scope, not a general enforcement-gap report
+### Enforcement visibility: `sandbox_axis_unenforced` — declaration-driven, full domain (`#4039`)
 
-A configured `read_deny_paths`/`write_deny_paths` entry is silently
-unenforced on Landlock (allowlist-only — see the field reference above).
-`unenforced_axes()` (`policy.py`) makes that ONE gap observable: when it
-resolves against a deny-list-incapable backend, a `sandbox_axis_unenforced`
-audit-event fires (paired with a WARN log, `#3949`), naming the axis and why
-(`#3823` §4③).
+If you configure a policy axis and the resolved backend does not enforce it,
+`unenforced_axes()` (`policy.py`) makes that observable: a
+`sandbox_axis_unenforced` audit-event fires (paired with a WARN log,
+`#3949`), naming the axis, the backend, and why.
 
-**This is deny-list visibility only, not a general "does this backend
-enforce everything configured" report (`#3951`).** A backend that simply
-does not enforce an axis at all produces no `sandbox_axis_unenforced` event
-and no WARN, because it isn't in the deny-list-incapable set
-`unenforced_axes()` checks (that set names Landlock specifically, not "any
-backend that under-enforces"). Two real examples, reached two different
-ways:
+**`#4039` generalised this from a Landlock-specific deny-list check to a
+full-domain "does this backend enforce what you configured" report.**
+Originally (`#3823`/`#3951`) the predicate only asked "can this backend
+express a deny-list" — true only of `deny_read_paths`/`deny_write_paths` on
+Landlock (allowlist-only, cannot carve a subpath out of an allowed parent).
+A backend that simply enforced NOTHING for an axis (`NoopBackend`,
+`DockerEnvironmentBackend`) produced a clean report while enforcing zero
+configured axes — the exact bug `#4039` is named for.
 
-- **`NoopBackend`** — the intentional no-enforcement fallback. Enforces none
-  of `write_paths`/`network`/`subprocess` (its own docstring: argv is
-  returned UNCHANGED; all other policy fields are recorded for audit only).
-- **`DockerEnvironmentBackend`** (`sandbox.backend`'s container-mode path,
-  `src/reyn/environment/container_backend.py`) — reached via the
-  single-shared-sandbox-instance invariant (`#1200`): a caller that builds
-  one Docker backend for both the FS seam (`environment_backend`) and the
-  exec seam (`sandbox_backend`, `env_backend.py`'s own module docstring)
-  passes it straight into `sandboxed_exec.py`'s `resolve_backend(ctx.
-  sandbox_backend, ...)`, whose result flows to `unenforced_axes(backend.
-  name, policy)` with `backend.name == "docker"` — the same call site the
-  two Seatbelt/Landlock/Noop backends reach, just with an instance the
-  name-based auto-selector never builds on its own. Docker enforces none of
-  `write_paths`/`network`/`subprocess` either, while being a real,
-  operator-selectable execution path — not merely a fallback state, which
-  is what makes it the sharper of the two examples.
+**D1/D2 — each backend now DECLARES its own enforcement, over the full
+7-field domain, no default.** `SandboxBackend.enforced_axes`
+(`security/sandbox/backend.py`'s `AxisEnforcementDeclaration`) covers
+`write_paths` / `write_deny_paths` / `read_deny_paths` / `network` /
+`deny_subprocess` / `env_deny_names` / `allow_env_names` — every field
+required, no default anywhere in the dataclass (mirrors
+`axis_contract.AxisContract`'s own discipline), so a backend that forgets an
+axis fails to construct at module import time rather than silently reading
+as "not reported." `unenforced_axes(backend, policy)` reads this
+declaration directly — it is never probed; production only reads a
+declaration, the same posture `enforcement_self_test` (the PRODUCTION gate,
+deny-leg only, write+spawn axes only, CLAUDE.md hard rule) keeps for its own
+narrow blast radius, unchanged by this mechanism.
 
-Both produce a clean `unenforced_axes()` report while enforcing nothing —
-a clean/absent report from this mechanism does not mean every configured
-axis is being enforced; it means Landlock's specific deny-list limitation
-didn't fire on this call. A quiet run under either and a quiet run under
-`SeatbeltBackend` are indistinguishable from this signal alone — the
-per-backend table above, not this mechanism, is what answers "what does my
-backend actually enforce." Whether to extend `unenforced_axes()`'s own
-coverage to Docker is tracked in `#3951`/`#4039`.
+**D3 — the predicate reports the SUBSET of the domain you actually
+configured.** `unenforced_axes()`'s return is the intersection of "you
+configured this axis" (e.g. `network is False`, not the default-permissive
+`True`) and "the backend declares `DOES_NOT_ENFORCE` for it" — it is **not**
+the complement of `enforced_axes` (a prior reader of this doc's own earlier
+text misread exactly this distinction, `#4039`): an empty return means
+"nothing you configured on this call went unenforced," not "this backend
+enforces every axis." Read `backend.enforced_axes` directly (or the
+per-backend table above) for that claim.
+
+**`DockerEnvironmentBackend` and `NoopBackend` now both warn where they used
+to stay silent.** Docker declares `DOES_NOT_ENFORCE` on every one of the 7
+axes (`run()` honors only `policy.timeout_seconds`/`policy.max_output_bytes`
+— its own docstring); configuring `allow_write_paths`, `network`,
+`subprocess`, or either env field under it now fires the warning for each
+one. Noop enforces `env_deny_names`/`allow_env_names` (the one policy
+mechanism it actually applies, via the shared `resolve_passthrough_env`) but
+nothing else — a configured write/network/subprocess restriction under Noop
+also now warns.
+
+**D4 — declaration ↔ real-execution witness stays a CI-only bridge, never a
+production probe.** `tests/security/test_sandbox_axis_declaration_witness_4039.py`
+asserts that whenever a backend declares `ENFORCES` for a policy field
+mapping to an `axis_contract`-migrated axis (write/spawn/network — see the
+axis-contract section above), that backend has a real `witness_strength`
+entry there; `DOES_NOT_ENFORCE` requires no witness — its ABSENCE from
+`witness_strength` is the correct state (Docker is the concrete instance:
+declares `DOES_NOT_ENFORCE` everywhere, has no `witness_strength` entry
+anywhere, and the CI check accepts that as correct rather than flagging it).
+This is CI-conformance-only, same two-layer split as the axis contract
+itself — it never runs against `enforcement_self_test`.
+
+A quiet run under any backend and a quiet run under Seatbelt are now much
+closer to comparable than before this generalisation — though the warning
+still only fires for axes you actually SET; the per-backend tables above
+remain the authoritative "what does my backend enforce" reference.
 
 ## `reyn.yaml` configuration
 

--- a/docs/guide/for-users/configure-sandbox.md
+++ b/docs/guide/for-users/configure-sandbox.md
@@ -179,44 +179,47 @@ effect. Use only in trusted environments where enforcement is unavailable.
 
 ### When Reyn warns that an axis is not enforced — and when it stays quiet
 
-If you configure `deny_read_paths` or `deny_write_paths` and the selected backend
-cannot express them, Reyn says so at dispatch time: a `sandbox_axis_unenforced`
-audit event plus a `WARNING` log line naming the axes, the backend, and the
-reason ("Landlock cannot express a deny-list — LSM allowlist-only constraint").
-The policy is still written to the audit log; it simply was not applied for
-those axes.
+If you configure a policy axis and the selected backend does not enforce it,
+Reyn says so at dispatch time: a `sandbox_axis_unenforced` audit event plus a
+`WARNING` log line naming the axes, the backend, and the reason. The policy is
+still written to the audit log; it simply was not applied for those axes.
 
-**Scope — this warning covers one gap, not every gap.** It fires only for the
-two deny-list fields, and only on a backend that is specifically deny-list
-incapable, which today means Landlock alone. It is not a general "your policy
-was not enforced" check.
+**The check asks "does this backend enforce what you configured" — every
+axis, every backend, no exception ([#4039](https://github.com/tya5/reyn/issues/4039)).**
+Earlier, this only fired for `deny_read_paths`/`deny_write_paths` on a
+backend specifically incapable of expressing a deny-list (Landlock alone) —
+a backend that simply enforced NOTHING for an axis (Noop, Docker) passed the
+check in silence, because the check never asked that broader question. Each
+backend now DECLARES what it enforces, over the full field set
+(`allow_write_paths` / `deny_write_paths` / `deny_read_paths` / `network` /
+`subprocess` / `env_deny_names` / `allow_env_names`), and the warning fires
+for any axis you configured that the backend's own declaration says it does
+not enforce — not just the deny-list pair.
 
-🔴 **Silence is therefore not a clean bill of health.** The check asks "can
-this backend express a deny-list?", not "does this backend enforce what you
-configured?" — so a backend that enforces little or nothing passes it in
-silence.
+**Docker** (`--env-backend=docker`, below) is the sharpest instance this
+generalization was built for. It is a sandbox backend — the same object
+serves as both the environment and the sandbox backend for a container
+agent — and its `run()` **honors only `policy.timeout_seconds` and
+`policy.max_output_bytes`**. Configure `allow_write_paths`, `network`,
+`subprocess`, or either env field under it and Reyn now warns for each one
+you set: the write/network/subprocess/env fields all declare
+`DOES_NOT_ENFORCE`, so a configured axis on any of them fires the check.
+Isolation still comes from the container boundary itself — the image and
+the mount set — not from these policy fields; the warning tells you that
+directly now, instead of leaving it to this doc alone.
 
-The sharpest case is the **Docker backend** (`--env-backend=docker`, below).
-It is a sandbox backend — the same object serves as both the environment and
-the sandbox backend for a container agent — and its `run()` **honors only
-`policy.timeout_seconds`**. Configure `allow_write_paths`, `network` or
-`subprocess` under it and none of them is applied, and **no
-`sandbox_axis_unenforced` warning is emitted**, because Docker is not
-deny-list-incapable in the sense this check tests for; it is simply not
-enforcing those axes at all, which the check does not look at. Isolation does
-come from the container boundary itself — but it is the image and the mount
-set that provide it, not the policy fields you wrote.
-
-Noop is the same shape with nothing left to fall back on: it enforces nothing,
-records the policy for audit, and likewise warns about nothing.
-
-A quiet run under Docker or Noop and a quiet run under Seatbelt are
-indistinguishable from this signal alone.
+Noop is the same shape except for env: it enforces `env_deny_names` /
+`allow_env_names` (the one policy mechanism it actually applies — see the
+Noop row above) but nothing else, so a configured write/network/subprocess
+restriction under Noop also now warns.
 
 **What to rely on instead:** the per-backend tables above state, field by field,
 what each backend actually enforces. Read the table for the backend you are
-running; treat the warning as a targeted extra notice, not as the answer to
-"was my policy applied?".
+running; the warning now covers the same ground those tables do, so it is a
+much closer answer to "was my policy applied?" than before — though it only
+fires for axes you actually SET (an unset, default-permissive axis has
+nothing to warn about even on a backend that would not have enforced a
+restriction on it).
 
 Two other mechanisms are easy to mistake for this one, and neither widens it:
 
@@ -228,8 +231,8 @@ Two other mechanisms are easy to mistake for this one, and neither widens it:
 - Container (mount) mode below is a **different kind of isolation** from the
   three profile-based backends tabled above (Seatbelt, Landlock, Noop) — the
   container boundary, not a policy applied to a host process. It is still a
-  sandbox backend as far as this warning is concerned, which is exactly why the
-  silence described above covers it too — see [What container mode itself
+  sandbox backend as far as this warning is concerned, which is exactly why
+  the warning covers it too — see [What container mode itself
   enforces](#what-container-mode-itself-enforces) below for what actually
   applies instead.
 
@@ -264,10 +267,12 @@ by `reyn.yaml sandbox.backend` as usual (typically `landlock` on Linux).
 ### What container mode itself enforces
 
 The section above already establishes that Docker's `run()` honors only
-`policy.timeout_seconds`, and that `allow_write_paths`/`network`/`subprocess`
-pass through unenforced with no warning. That leaves the question of what, if
-anything, DOES restrict those axes when you run in a container — the
-container's own launch-time isolation, independent of any `sandbox.*` policy.
+`policy.timeout_seconds`/`policy.max_output_bytes`, and that
+`allow_write_paths`/`network`/`subprocess` pass through unenforced (now
+warned about if you configure them — see above). That leaves the question of
+what, if anything, DOES restrict those axes when you run in a container —
+the container's own launch-time isolation, independent of any `sandbox.*`
+policy.
 Measured directly (real execution against a live container, not inferred from
 the launch code):
 

--- a/src/reyn/core/op_runtime/sandboxed_exec.py
+++ b/src/reyn/core/op_runtime/sandboxed_exec.py
@@ -210,7 +210,7 @@ async def handle(
     # backend actually did with it (owner: "sandbox 抽象は ポリシを 保証できない.
     # backend が できる 範囲で 保証するしか ない"). Deliberately NOT wired into
     # enforcement_self_test (CLAUDE.md hard rule).
-    unenforced = unenforced_axes(backend.name, policy)
+    unenforced = unenforced_axes(backend, policy)
     if unenforced:
         reason = unenforced_axis_reason(backend.name)
         ctx.events.emit(

--- a/src/reyn/environment/container_backend.py
+++ b/src/reyn/environment/container_backend.py
@@ -44,7 +44,12 @@ from typing import Any, Awaitable, Callable, Pattern
 
 from reyn.environment.backend import GrepResult
 from reyn.security.sandbox._subprocess_io import MAX_SUBPROCESS_OUTPUT_BYTES, communicate_capped
-from reyn.security.sandbox.backend import SandboxResult, WrappedCommand
+from reyn.security.sandbox.backend import (
+    AxisEnforcement,
+    AxisEnforcementDeclaration,
+    SandboxResult,
+    WrappedCommand,
+)
 from reyn.security.sandbox.policy import SandboxPolicy
 
 # Sync runner: execute argv (optionally stdin), return SandboxResult. Injected so
@@ -351,6 +356,28 @@ class DockerEnvironmentBackend:
     """Repo FS + exec inside a Docker container (dual-Protocol, bridge-free)."""
 
     name: str = "docker"
+
+    # #4039 (D1/D2 — architect's "sharpest instance" example): every axis is
+    # DOES_NOT_ENFORCE. run() reads only policy.timeout_seconds /
+    # policy.max_output_bytes (its own docstring); write/network isolation
+    # comes from FIXED container-launch flags (--read-only, --tmpfs /tmp,
+    # --network none), not from the policy fields an operator writes —
+    # measured directly (#4042, real execution): deny_subprocess=True does
+    # not stop a nested spawn, env_deny_names has nothing to filter (the
+    # container never sees host env at all — #4042/#4047). Docker is the
+    # backend that most needs this declaration: unlike Noop (whose name and
+    # docstring warn a reader to expect no enforcement), an operator choosing
+    # Docker specifically FOR isolation has no reason to suspect these axes
+    # pass straight through.
+    enforced_axes: AxisEnforcementDeclaration = AxisEnforcementDeclaration(
+        write_paths=AxisEnforcement.DOES_NOT_ENFORCE,
+        write_deny_paths=AxisEnforcement.DOES_NOT_ENFORCE,
+        read_deny_paths=AxisEnforcement.DOES_NOT_ENFORCE,
+        network=AxisEnforcement.DOES_NOT_ENFORCE,
+        deny_subprocess=AxisEnforcement.DOES_NOT_ENFORCE,
+        env_deny_names=AxisEnforcement.DOES_NOT_ENFORCE,
+        allow_env_names=AxisEnforcement.DOES_NOT_ENFORCE,
+    )
 
     def __init__(
         self,

--- a/src/reyn/security/sandbox/backend.py
+++ b/src/reyn/security/sandbox/backend.py
@@ -9,10 +9,87 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
+from enum import Enum
 from typing import Protocol, runtime_checkable
 
 from .policy import SandboxPolicy
+
+
+class AxisEnforcement(Enum):
+    """Whether a backend enforces one ``SandboxPolicy`` axis — #4039.
+
+    Two values, not three: the founding design draft (#4039, architect)
+    considered a third ``NOT_APPLICABLE`` for "this axis has no meaning on
+    this backend" but found no real instance across the 4 current backends
+    (noop/seatbelt/landlock/docker) × 7 axes — every cell is a definite
+    ENFORCES or DOES_NOT_ENFORCE. A third value withdrawn for lack of a
+    driving case is the same call #3823 made for sandbox.mode's "custom"
+    value; add it back if a real NOT_APPLICABLE case appears, not
+    speculatively.
+    """
+
+    ENFORCES = "enforces"
+    DOES_NOT_ENFORCE = "does_not_enforce"
+
+
+@dataclass(frozen=True)
+class AxisEnforcementDeclaration:
+    """A backend's full per-axis enforcement claim — #4039 (D1/D2).
+
+    Every field is REQUIRED, no defaults anywhere in this class — mirrors
+    :class:`~reyn.security.sandbox.axis_contract.AxisContract`'s own
+    discipline (that module's docstring: "a new axis registered here must
+    say EXPLICITLY whether it has exceptions ... there is no default that
+    would let a forgotten field read as 'none'"). A backend that forgets an
+    axis fails to CONSTRUCT its declaration — a ``TypeError`` at backend
+    module import time, not a silent "not reported" (#4039's own founding
+    bug: ``NoopBackend`` enforced nothing yet ``unenforced_axes()`` reported
+    nothing, because the OLD predicate's domain was never full).
+
+    Keyed to :class:`~reyn.security.sandbox.policy.SandboxPolicy`'s own
+    FIELD names (``deny_subprocess``, not the config-vocabulary
+    ``subprocess`` — #3823 deliberately split those two vocabularies;
+    ``axis_contract.AXIS_REGISTRY``'s coarser ``write``/``spawn``/``network``
+    names are a DIFFERENT, CI-conformance-only vocabulary — see D1/D3 in
+    #4039 for why this module does not reuse it), not
+    :mod:`~reyn.security.sandbox.axis_contract`'s coarser 3-axis vocabulary —
+    the two are separate registries at separate layers (CLAUDE.md's 2-layer
+    sandbox rule: this declaration is read by the production predicate
+    (:func:`~reyn.security.sandbox.policy.unenforced_axes`), CI conformance
+    is a different, CI-only consumer of ``axis_contract``).
+
+    ``allow_env_names`` is declared separately from ``env_deny_names``
+    (architect co-vet, #4039) even though every backend today enforces both
+    identically (both flow through
+    :func:`~reyn.security.sandbox.policy.resolve_passthrough_env`) — they
+    are genuinely distinct ``SandboxPolicy`` fields with distinct semantics
+    (a deny-list vs. an axis-mode switch to allow-list), and a future
+    backend could plausibly diverge on one without the other.
+    """
+
+    write_paths: AxisEnforcement
+    write_deny_paths: AxisEnforcement
+    read_deny_paths: AxisEnforcement
+    network: AxisEnforcement
+    deny_subprocess: AxisEnforcement
+    env_deny_names: AxisEnforcement
+    allow_env_names: AxisEnforcement
+
+    def as_dict(self) -> "dict[str, AxisEnforcement]":
+        """The declaration as a plain ``{axis_name: AxisEnforcement}`` dict —
+        what :func:`~reyn.security.sandbox.policy.unenforced_axes` and CI
+        conformance both actually consume."""
+        return {f.name: getattr(self, f.name) for f in fields(self)}
+
+
+#: Every axis name :class:`AxisEnforcementDeclaration` covers — the full
+#: domain D2 requires. Derived from the dataclass's own fields (not a
+#: hand-duplicated literal) so this constant can never drift from the type
+#: it describes.
+SANDBOX_POLICY_AXES: "frozenset[str]" = frozenset(
+    f.name for f in fields(AxisEnforcementDeclaration)
+)
 
 
 @dataclass
@@ -72,6 +149,16 @@ class SandboxBackend(Protocol):
     """
 
     name: str
+
+    #: #4039 (D1/D2): this backend's own per-axis enforcement claim, over
+    #: the FULL domain (:data:`SANDBOX_POLICY_AXES`) — no default anywhere
+    #: (:class:`AxisEnforcementDeclaration` has none), so a backend that
+    #: forgets an axis fails to construct this at module import time. Read
+    #: by :func:`~reyn.security.sandbox.policy.unenforced_axes` (production,
+    #: declaration-only, never probed) — never by
+    #: ``enforcement_self_test`` (CLAUDE.md hard rule: that gate's blast
+    #: radius stays narrow, deny-leg only, write+spawn only).
+    enforced_axes: AxisEnforcementDeclaration
 
     def available(self) -> bool:
         """Return True if this backend's enforcement mechanism is PRESENT on the

--- a/src/reyn/security/sandbox/backends/landlock.py
+++ b/src/reyn/security/sandbox/backends/landlock.py
@@ -36,7 +36,12 @@ import signal
 import subprocess
 
 from .._subprocess_io import communicate_capped, kill_process_tree
-from ..backend import SandboxResult, WrappedCommand
+from ..backend import (
+    AxisEnforcement,
+    AxisEnforcementDeclaration,
+    SandboxResult,
+    WrappedCommand,
+)
 from ..policy import SandboxPolicy, expand_policy_path, resolve_passthrough_env
 from .seccomp import load_seccomp_filter, preload_native_dependency
 
@@ -259,6 +264,29 @@ class LandlockBackend:
     """
 
     name: str = "landlock"
+
+    # #4039 (D1/D2): write is Landlock's own LSM path-beneath enforcement.
+    # write_deny_paths/read_deny_paths are DOES_NOT_ENFORCE — the module
+    # docstring's own structural constraint (allowlist-only, cannot carve a
+    # subpath out of an allowed parent), the ORIGINAL gap
+    # _DENY_LIST_INCAPABLE_BACKENDS existed to name. network + deny_subprocess
+    # ARE enforced here despite Landlock's LSM itself having no net-port API —
+    # this backend also always loads a seccomp-BPF filter (see module
+    # docstring, #3030) that gates both; the Protocol's "name" is "landlock"
+    # even though the witness for these two axes is internally seccomp-BPF —
+    # a different, finer-grained provenance detail axis_contract.py's
+    # witness_strength dict tracks, not this declaration's concern. Both env
+    # fields flow through resolve_passthrough_env (this module's own env
+    # resolution call).
+    enforced_axes: AxisEnforcementDeclaration = AxisEnforcementDeclaration(
+        write_paths=AxisEnforcement.ENFORCES,
+        write_deny_paths=AxisEnforcement.DOES_NOT_ENFORCE,
+        read_deny_paths=AxisEnforcement.DOES_NOT_ENFORCE,
+        network=AxisEnforcement.ENFORCES,
+        deny_subprocess=AxisEnforcement.ENFORCES,
+        env_deny_names=AxisEnforcement.ENFORCES,
+        allow_env_names=AxisEnforcement.ENFORCES,
+    )
 
     def __init__(self) -> None:
         self._abi_version: int | None = None  # populated on first available() call

--- a/src/reyn/security/sandbox/backends/seatbelt.py
+++ b/src/reyn/security/sandbox/backends/seatbelt.py
@@ -30,7 +30,12 @@ import tempfile
 from pathlib import Path
 
 from reyn.security.sandbox._subprocess_io import communicate_capped, kill_process_tree
-from reyn.security.sandbox.backend import SandboxResult, WrappedCommand
+from reyn.security.sandbox.backend import (
+    AxisEnforcement,
+    AxisEnforcementDeclaration,
+    SandboxResult,
+    WrappedCommand,
+)
 from reyn.security.sandbox.policy import (
     SandboxPolicy,
     expand_policy_path,
@@ -202,6 +207,22 @@ class SeatbeltBackend:
     """
 
     name: str = "seatbelt"
+
+    # #4039 (D1/D2): Seatbelt enforces every axis — write via SBPL
+    # deny-default + explicit allow rules, both deny-lists via SBPL
+    # deny-after-allow (the one real backend that CAN express them, unlike
+    # Landlock's allowlist-only LSM constraint), network + subprocess via
+    # the generated profile's own deny rules, and both env fields via
+    # resolve_passthrough_env (this module's own env resolution call).
+    enforced_axes: AxisEnforcementDeclaration = AxisEnforcementDeclaration(
+        write_paths=AxisEnforcement.ENFORCES,
+        write_deny_paths=AxisEnforcement.ENFORCES,
+        read_deny_paths=AxisEnforcement.ENFORCES,
+        network=AxisEnforcement.ENFORCES,
+        deny_subprocess=AxisEnforcement.ENFORCES,
+        env_deny_names=AxisEnforcement.ENFORCES,
+        allow_env_names=AxisEnforcement.ENFORCES,
+    )
 
     def available(self) -> bool:
         """Return True iff the sandbox-exec mechanism is PRESENT on this platform.

--- a/src/reyn/security/sandbox/noop_backend.py
+++ b/src/reyn/security/sandbox/noop_backend.py
@@ -17,7 +17,13 @@ import signal
 import subprocess
 
 from ._subprocess_io import communicate_capped, kill_process_tree
-from .backend import SandboxBackend, SandboxResult, WrappedCommand
+from .backend import (
+    AxisEnforcement,
+    AxisEnforcementDeclaration,
+    SandboxBackend,
+    SandboxResult,
+    WrappedCommand,
+)
 from .policy import SandboxPolicy, resolve_passthrough_env
 
 _logger = logging.getLogger(__name__)
@@ -65,6 +71,22 @@ class NoopBackend:
     """
 
     name: str = "noop"
+
+    # #4039 (D1/D2): the founding bug this declaration exists to close —
+    # Noop enforced nothing yet unenforced_axes() reported nothing, so a
+    # quiet Noop run and a quiet Landlock run were indistinguishable from
+    # the audit signal alone. Only env_deny_names/allow_env_names are
+    # ENFORCES — both flow through resolve_passthrough_env (this class's
+    # own _build_env), the one policy mechanism Noop actually applies.
+    enforced_axes: AxisEnforcementDeclaration = AxisEnforcementDeclaration(
+        write_paths=AxisEnforcement.DOES_NOT_ENFORCE,
+        write_deny_paths=AxisEnforcement.DOES_NOT_ENFORCE,
+        read_deny_paths=AxisEnforcement.DOES_NOT_ENFORCE,
+        network=AxisEnforcement.DOES_NOT_ENFORCE,
+        deny_subprocess=AxisEnforcement.DOES_NOT_ENFORCE,
+        env_deny_names=AxisEnforcement.ENFORCES,
+        allow_env_names=AxisEnforcement.ENFORCES,
+    )
 
     def available(self) -> bool:
         return True

--- a/src/reyn/security/sandbox/policy.py
+++ b/src/reyn/security/sandbox/policy.py
@@ -69,8 +69,12 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from ._subprocess_io import MAX_SUBPROCESS_OUTPUT_BYTES
+
+if TYPE_CHECKING:
+    from .backend import SandboxBackend
 
 _log = logging.getLogger(__name__)
 
@@ -384,51 +388,57 @@ def deny_narrowed_write_grants(policy: SandboxPolicy) -> list[tuple[str, str]]:
     return narrowed
 
 
-#: Backend names that cannot express a read/write deny-list at all (#3901 §4③):
-#: Landlock is allowlist-only (LSM path-beneath grants; you cannot carve a
-#: subpath out of an allowed parent — landlock.py's own module docstring),
-#: so a configured ``read_deny_paths``/``write_deny_paths`` is silently
-#: unenforced there, unlike Seatbelt's deny-after-allow SBPL rules. This is a
-#: structural backend limitation, not a bug to fix — see the module docstring.
-#:
-#: #3951: this frozenset — and everything ``unenforced_axes()`` below reports
-#: — covers ONLY the deny-list-incapable-backend gap. It does NOT report a
-#: backend that simply does not enforce an axis at all (e.g. the Docker
-#: launch backend currently enforces none of write_paths/network/subprocess
-#: — measured, #3823 co-vet). A caller reading a clean ``unenforced_axes()``
-#: result must not read it as "this backend enforces everything configured."
-_DENY_LIST_INCAPABLE_BACKENDS: frozenset[str] = frozenset({"landlock"})
+def unenforced_axes(backend: "SandboxBackend", policy: SandboxPolicy) -> list[str]:
+    """Return the policy axis names *configured* but *not enforced* by
+    ``backend`` — the visibility mechanism #3901 §4③ names, generalised by
+    #4039 from "can this backend express a deny-list" (which missed a
+    backend that simply enforces NOTHING, e.g. Noop/Docker reporting a
+    clean result while enforcing zero configured axes) to "does this
+    backend enforce what you configured."
 
+    Reads ``backend.enforced_axes`` (a :class:`~.backend.AxisEnforcementDeclaration`,
+    D1: the backend's own declaration, never probed here) — pure function of
+    the policy + backend (no I/O, no events), same shape as
+    :func:`deny_narrowed_write_grants`, so a caller with an events sink
+    emits a ``sandbox_axis_unenforced`` audit-event when this is non-empty.
+    Deliberately NOT wired into ``enforcement_self_test`` (CLAUDE.md hard
+    rule: that function is the PRODUCTION gate, blast radius every
+    sandboxed op on every host, deny-leg × write/spawn axes only — this is
+    audit visibility for a DECLARED gap, not a self-test probe).
 
-def unenforced_axes(backend_name: str, policy: SandboxPolicy) -> list[str]:
-    """Return the policy axis names *configured* but *structurally unenforceable*
-    on ``backend_name`` — the visibility mechanism #3901 §4③ names for a backend
-    capability gap that cannot be fixed (Landlock's LSM constraint), only made
-    observable.
-
-    Pure function of the policy + backend name (no I/O, no events) — same shape
-    as :func:`deny_narrowed_write_grants` — so a caller with an events sink emits
-    a ``sandbox_axis_unenforced`` audit-event when this is non-empty. Landlock is
-    the only backend in this set today; Seatbelt enforces both deny-lists via
-    SBPL deny-after-allow, so it never appears here. Deliberately NOT wired into
-    ``enforcement_self_test`` (CLAUDE.md hard rule: that function is the
-    PRODUCTION gate, blast radius every sandboxed op on every host, deny-leg ×
-    write/spawn axes only — this is audit visibility for a DECLARED gap, not a
-    self-test probe).
-
-    #3951: an empty return is NOT a claim that ``backend_name`` enforces every
-    configured axis — it only means this backend isn't in
-    :data:`_DENY_LIST_INCAPABLE_BACKENDS`. A backend that enforces nothing at
-    all for a given axis (the Docker launch backend today, for
-    write_paths/network/subprocess) also returns ``[]`` here, silently.
+    #4039 (architect correction — a prior reader of #3951's own text
+    misread exactly this): this function's return is **not** the complement
+    of ``backend.enforced_axes`` (a 7-axis FULL domain, D2). This function
+    reports only the SUBSET of that domain the operator actually
+    *configured* on this call's policy (e.g. ``network`` only when
+    ``policy.network is False`` — the operator asked for a restriction;
+    Noop's default-permissive ``network=True`` has nothing to report even
+    though Noop's declaration says ``DOES_NOT_ENFORCE``). An empty return
+    means "nothing you configured on this call went unenforced" — it does
+    NOT mean "this backend enforces every axis" (read
+    ``backend.enforced_axes`` directly for that claim).
     """
-    if backend_name not in _DENY_LIST_INCAPABLE_BACKENDS:
-        return []
+    declared = backend.enforced_axes.as_dict()
+    from .backend import AxisEnforcement  # noqa: PLC0415 — avoid a module-level cycle
+
+    def _unenforced(axis: str) -> bool:
+        return declared[axis] is AxisEnforcement.DOES_NOT_ENFORCE
+
     axes: list[str] = []
-    if policy.read_deny_paths:
-        axes.append("read_deny_paths")
-    if policy.write_deny_paths:
+    if policy.write_paths and _unenforced("write_paths"):
+        axes.append("write_paths")
+    if policy.write_deny_paths and _unenforced("write_deny_paths"):
         axes.append("write_deny_paths")
+    if policy.read_deny_paths and _unenforced("read_deny_paths"):
+        axes.append("read_deny_paths")
+    if policy.network is False and _unenforced("network"):
+        axes.append("network")
+    if policy.deny_subprocess and _unenforced("deny_subprocess"):
+        axes.append("deny_subprocess")
+    if policy.env_deny_names and _unenforced("env_deny_names"):
+        axes.append("env_deny_names")
+    if policy.allow_env_names is not None and _unenforced("allow_env_names"):
+        axes.append("allow_env_names")
     return axes
 
 
@@ -447,6 +457,24 @@ _UNENFORCED_AXIS_REASONS: dict[str, str] = {
         "this backend cannot express a deny-list here — Landlock is an LSM "
         "allowlist-only constraint (you cannot carve a subpath out of an "
         "allowed parent)"
+    ),
+    # #4039: Noop's non-enforcement is total, not a single-axis capability
+    # gap — its own module docstring already tells the operator this
+    # backend provides no isolation at all.
+    "noop": (
+        "this backend provides no isolation — it runs the command with no "
+        "policy enforcement, recording the policy for audit only"
+    ),
+    # #4039 (architect: the sharpest instance — an operator choosing Docker
+    # SPECIFICALLY for isolation has no reason to suspect these axes pass
+    # straight through). Isolation here comes from the container's FIXED
+    # launch-time boundary (image + mounts + --network none + --read-only),
+    # never from the sandbox.* policy fields you write — this backend's
+    # run() does not read them.
+    "docker": (
+        "this backend's isolation comes from the container's fixed "
+        "launch-time boundary (image + mounts), not from your sandbox.policy "
+        "fields — this axis's field is not read here at all"
     ),
 }
 

--- a/tests/_support/sandbox_backend.py
+++ b/tests/_support/sandbox_backend.py
@@ -1,0 +1,25 @@
+"""Shared #4039 enforced_axes declaration for real (non-mock) SandboxBackend
+test stand-ins across the suite.
+
+A stand-in whose test purpose is unrelated to axis enforcement (argv0
+resolution, denial classification, hook-subprocess wiring, ...) needs SOME
+``enforced_axes`` value — the Protocol field has no default
+(``AxisEnforcementDeclaration`` has none, by design, #4039) — but should not
+introduce a NEW ``sandbox_axis_unenforced`` audit-event the test wasn't
+written to expect. :data:`FULLY_ENFORCING_AXES` (every axis ENFORCES, the
+same shape as the real ``SeatbeltBackend``) keeps ``unenforced_axes()``
+returning ``[]`` for these stand-ins, so behavior stays neutral.
+"""
+from __future__ import annotations
+
+from reyn.security.sandbox.backend import AxisEnforcement, AxisEnforcementDeclaration
+
+FULLY_ENFORCING_AXES = AxisEnforcementDeclaration(
+    write_paths=AxisEnforcement.ENFORCES,
+    write_deny_paths=AxisEnforcement.ENFORCES,
+    read_deny_paths=AxisEnforcement.ENFORCES,
+    network=AxisEnforcement.ENFORCES,
+    deny_subprocess=AxisEnforcement.ENFORCES,
+    env_deny_names=AxisEnforcement.ENFORCES,
+    allow_env_names=AxisEnforcement.ENFORCES,
+)

--- a/tests/core/test_3901_sandbox_axis_unenforced.py
+++ b/tests/core/test_3901_sandbox_axis_unenforced.py
@@ -1,70 +1,136 @@
-"""Tier 2: #3901 §4③ — sandbox_axis_unenforced audit-event.
+"""Tier 2: #3901 §4③ / #4039 — sandbox_axis_unenforced audit-event.
 
-Landlock cannot express a read/write deny-list (LSM allowlist-only constraint,
-``landlock.py``'s own module docstring: "you cannot carve a subpath out of an
-allowed parent"), so a configured ``read_deny_paths``/``write_deny_paths``
-silently does nothing there — a real backend capability gap that cannot be
-fixed, only made visible. Doc-only visibility reads as "written but nobody
-checks it" (the #3899 pattern this issue's own thread names), so the OS emits
-``sandbox_axis_unenforced`` instead — the same precedent as
-``sandbox_policy_narrowed`` (#2978).
+#4039 generalised the predicate from "can this backend express a deny-list"
+(which only ever caught Landlock's structural LSM constraint — a configured
+``read_deny_paths``/``write_deny_paths`` silently doing nothing there) to
+"does this backend enforce what you configured" — reading each backend's own
+:class:`~reyn.security.sandbox.backend.AxisEnforcementDeclaration`
+(``enforced_axes``, D1: the backend's own declaration, never probed) rather
+than a hardcoded "deny-list-incapable" backend-name set. This closes the
+founding bug #4039 named: Noop enforces NOTHING yet the OLD predicate
+reported nothing either, so a quiet Noop run and a quiet Landlock run were
+indistinguishable from the audit signal alone.
 
 Deliberately NOT wired into ``enforcement_self_test`` (CLAUDE.md hard rule:
 that function is the PRODUCTION gate, blast radius every sandboxed op on
 every host, deny-leg × write/spawn axes only) — this is audit visibility for
-a DECLARED backend limitation, a different mechanism entirely.
+a DECLARED gap, not a self-test probe.
 
-The pure ``unenforced_axes()`` function is tested directly (no backend/events
+The pure ``unenforced_axes()`` function is tested directly (no events
 needed); the audit-event wiring is driven through the REAL op handler + real
-OpContext with a real (non-mock) backend stand-in named "landlock" (the
-platform-dependent real LandlockBackend is exercised by
-tests/security/test_sandbox_landlock.py; injecting a stand-in with the same ``.name``
-lets this test run cross-platform without a real Linux kernel).
+OpContext with a real (non-mock) backend stand-in — the platform-dependent
+real backends (LandlockBackend/SeatbeltBackend) are exercised by
+tests/security/test_sandbox_landlock.py / test_sandbox_seatbelt.py; a
+stand-in reusing each real class's own ``enforced_axes`` (not a hand-typed
+duplicate — see :func:`_landlock_shaped`/:func:`_seatbelt_shaped`) lets this
+run cross-platform without a real Linux kernel or macOS host, while staying
+faithful to what the real backend actually declares.
 """
 from __future__ import annotations
 
 import pytest
 
 from reyn.security.sandbox.backend import SandboxResult
+from reyn.security.sandbox.backends.landlock import LandlockBackend
+from reyn.security.sandbox.backends.seatbelt import SeatbeltBackend
+from reyn.security.sandbox.noop_backend import NoopBackend
 from reyn.security.sandbox.policy import SandboxPolicy, unenforced_axes
 
 # ── the pure classifier ───────────────────────────────────────────────────────
 
 
+class _BackendStandIn:
+    """A real (non-mock) SandboxBackend stand-in — ``name`` + ``enforced_axes``
+    only (this classifier reads nothing else), reusing a REAL backend
+    class's own ``enforced_axes`` value so the stand-in cannot drift from
+    what that backend actually declares."""
+
+    def __init__(self, name: str, enforced_axes) -> None:
+        self.name = name
+        self.enforced_axes = enforced_axes
+
+    def available(self) -> bool:
+        return True
+
+    async def run(self, argv, policy, *, stdin=None, cwd=None, cancel_event=None):
+        return SandboxResult(returncode=0, stdout=b"ok\n", stderr=b"")
+
+
+def _landlock_shaped() -> _BackendStandIn:
+    return _BackendStandIn("landlock", LandlockBackend.enforced_axes)
+
+
+def _seatbelt_shaped() -> _BackendStandIn:
+    return _BackendStandIn("seatbelt", SeatbeltBackend.enforced_axes)
+
+
+def _noop_shaped() -> _BackendStandIn:
+    return _BackendStandIn("noop", NoopBackend.enforced_axes)
+
+
 def test_landlock_with_read_deny_paths_is_unenforced():
-    """Tier 2: a configured read_deny_paths on landlock is reported unenforced."""
+    """Tier 2: a configured read_deny_paths on landlock is reported unenforced
+    (Landlock's structural LSM allowlist-only constraint)."""
     policy = SandboxPolicy(read_deny_paths=["~/.ssh"])
-    assert unenforced_axes("landlock", policy) == ["read_deny_paths"]
+    assert unenforced_axes(_landlock_shaped(), policy) == ["read_deny_paths"]
 
 
 def test_landlock_with_write_deny_paths_is_unenforced():
     """Tier 2: a configured write_deny_paths on landlock is reported unenforced."""
     policy = SandboxPolicy(write_deny_paths=["~/.aws"])
-    assert unenforced_axes("landlock", policy) == ["write_deny_paths"]
+    assert unenforced_axes(_landlock_shaped(), policy) == ["write_deny_paths"]
 
 
 def test_landlock_with_no_deny_lists_reports_nothing():
-    """Tier 2: an empty (compat-default) policy has nothing to report — the
-    event fires only when the operator actually configured an axis this
-    backend cannot enforce, not unconditionally on every landlock dispatch."""
-    assert unenforced_axes("landlock", SandboxPolicy()) == []
+    """Tier 2: an empty (compat-default) policy has nothing to report on
+    landlock — write_deny_paths/read_deny_paths are landlock's only
+    DOES_NOT_ENFORCE axes, and neither is configured here. (write_paths IS
+    always configured (the workspace floor) but landlock DOES enforce it,
+    so it never reports.)"""
+    assert unenforced_axes(_landlock_shaped(), SandboxPolicy()) == []
 
 
 def test_seatbelt_with_deny_lists_is_not_unenforced():
     """Tier 2: ★ the backend-capability falsification — the SAME policy that
     is unenforced on landlock is fully enforced on seatbelt (SBPL
-    deny-after-allow), so seatbelt never appears in the report. Proves the
-    classifier keys off backend CAPABILITY, not merely "a deny-list is set"."""
+    deny-after-allow, every axis ENFORCES), so seatbelt never appears in the
+    report. Proves the classifier keys off the backend's OWN declaration,
+    not merely "a deny-list is set"."""
     policy = SandboxPolicy(read_deny_paths=["~/.ssh"], write_deny_paths=["~/.aws"])
-    assert unenforced_axes("seatbelt", policy) == []
+    assert unenforced_axes(_seatbelt_shaped(), policy) == []
 
 
-def test_noop_with_deny_lists_is_not_reported_as_landlock_incapable():
-    """Tier 2: noop is not in the deny-list-incapable set either — its
-    non-enforcement is a documented, separate contract (the one-shot WARN),
-    not this axis-capability gap."""
-    policy = SandboxPolicy(read_deny_paths=["~/.ssh"])
-    assert unenforced_axes("noop", policy) == []
+def test_noop_enforces_nothing_it_is_configured_to_restrict():
+    """Tier 2: #4039's founding bug, now fixed — Noop enforces NOTHING (bar
+    the two env fields), so a policy that configures write/network/subprocess
+    restrictions is reported in full. Under the OLD predicate this returned
+    [] silently (Noop was never in the deny-list-incapable set)."""
+    policy = SandboxPolicy(
+        write_deny_paths=["~/.aws"],
+        network=False,
+        deny_subprocess=True,
+    )
+    assert unenforced_axes(_noop_shaped(), policy) == [
+        "write_deny_paths", "network", "deny_subprocess",
+    ]
+
+
+def test_noop_enforces_env_deny_names():
+    """Tier 2: Noop's ONE real enforcement mechanism (resolve_passthrough_env,
+    shared with every other backend) — env_deny_names/allow_env_names do NOT
+    appear in the report even though every other configured axis does."""
+    policy = SandboxPolicy(env_deny_names=["SECRET"], allow_env_names=["PATH"])
+    assert unenforced_axes(_noop_shaped(), policy) == []
+
+
+def test_write_paths_configured_and_unenforced_is_reported():
+    """Tier 2: #4039 — write_paths (the grant, not a deny-list) is now part
+    of the reported domain. Noop enforces nothing on write, so a
+    non-default write_paths grant is reported unenforced — the SandboxPolicy
+    floor always sets write_paths to something, so this is the common case
+    on a real Noop dispatch, not an edge case."""
+    policy = SandboxPolicy(write_paths=["/repo"])
+    assert unenforced_axes(_noop_shaped(), policy) == ["write_paths"]
 
 
 # ── the audit-event, driven through the real op handler ──────────────────────
@@ -76,6 +142,7 @@ class _LandlockShapedBackend:
     lets the audit-event wiring run cross-platform without a Linux kernel."""
 
     name = "landlock"
+    enforced_axes = LandlockBackend.enforced_axes
 
     def available(self) -> bool:
         return True
@@ -161,16 +228,20 @@ async def test_unenforced_axis_also_emits_a_warn_log_line(tmp_path, caplog):
 def test_unenforced_axis_reason_names_the_structural_cause() -> None:
     """Tier 1: #3823 — the reason string is per-backend prose, not a bare
     axis-name echo; a future backend with a DIFFERENT reason for the same
-    unenforced state gets its own text (owner: a Docker-shaped backend
-    "not enforcing env" is the SAME 2-value state as Landlock's deny-list
-    gap, but a DIFFERENT reason — the image decides, not a kernel
-    constraint). Falls back to a generic statement for an unlisted backend
-    rather than raising, matching unenforced_axes' own defensive posture."""
+    unenforced state gets its own text (#4039: Docker's real entry is the
+    landed instance of exactly this — "the container's own launch-time
+    boundary decides, not the policy field", a different reason than
+    Landlock's LSM constraint for the SAME 2-value classification). Falls
+    back to a generic statement for an unlisted backend rather than
+    raising, matching unenforced_axes' own defensive posture."""
     from reyn.security.sandbox.policy import unenforced_axis_reason
 
     landlock_reason = unenforced_axis_reason("landlock")
     assert "Landlock" in landlock_reason or "landlock" in landlock_reason
     assert "allowlist" in landlock_reason
+
+    docker_reason = unenforced_axis_reason("docker")
+    assert "container" in docker_reason
 
     fallback_reason = unenforced_axis_reason("some-future-backend")
     assert "some-future-backend" in fallback_reason
@@ -180,8 +251,8 @@ def test_unenforced_axis_reason_names_the_structural_cause() -> None:
 async def test_enforced_axis_emits_no_unenforced_event(tmp_path):
     """Tier 2: ★∩-falsification pair — the SAME policy on a backend that CAN
     express the deny-list (a stand-in named "seatbelt") emits no event.
-    Proves the emission is keyed on backend capability, not merely on the
-    policy carrying a deny-list."""
+    Proves the emission is keyed on the backend's OWN declaration, not
+    merely on the policy carrying a deny-list."""
     from reyn.core.events.events import EventLog
     from reyn.core.op_runtime.context import OpContext
     from reyn.core.op_runtime.sandboxed_exec import handle
@@ -192,6 +263,7 @@ async def test_enforced_axis_emits_no_unenforced_event(tmp_path):
 
     class _SeatbeltShapedBackend(_LandlockShapedBackend):
         name = "seatbelt"
+        enforced_axes = SeatbeltBackend.enforced_axes
 
     events = EventLog()
     collected = collect_events(events)

--- a/tests/core/test_op_sandboxed_exec.py
+++ b/tests/core/test_op_sandboxed_exec.py
@@ -31,6 +31,7 @@ from reyn.security.sandbox import (
 )
 from reyn.security.sandbox import noop_backend as _noop_module
 from tests._support.events import collect_events
+from tests._support.sandbox_backend import FULLY_ENFORCING_AXES
 
 # ─── 1. SandboxPolicy ────────────────────────────────────────────────────────
 
@@ -152,6 +153,7 @@ class _RecordingBackend:
     this reversal must not recreate)?"""
 
     name = "recording-backend"
+    enforced_axes = FULLY_ENFORCING_AXES
 
     def __init__(self) -> None:
         self.received_policy: "SandboxPolicy | None" = None
@@ -463,6 +465,7 @@ class _StubBackend:
     """
 
     name = "stub-injected"
+    enforced_axes = FULLY_ENFORCING_AXES
 
     def __init__(self) -> None:
         self.received_cwd: str | None = None

--- a/tests/core/test_sandbox_denial_class_2820.py
+++ b/tests/core/test_sandbox_denial_class_2820.py
@@ -15,6 +15,7 @@ from reyn.core.offload.canonical import sandboxed_exec_to_canonical
 from reyn.security.sandbox.backend import SandboxResult
 from reyn.security.sandbox.denial import DENIAL_FORK, classify_denial
 from tests._support.events import collect_events
+from tests._support.sandbox_backend import FULLY_ENFORCING_AXES
 
 # The exact stderr the incident produced (bare ``python3`` → pyenv shim → pyenv
 # forks under (deny process-fork)). Captured, not synthesized.
@@ -98,6 +99,7 @@ class _ForkDenyingBackend:
     fork-denial result — proves the handler classifies + surfaces it end-to-end."""
 
     name = "fake-forkdeny"
+    enforced_axes = FULLY_ENFORCING_AXES
 
     def available(self) -> bool:
         return True

--- a/tests/hooks/test_hook_sandbox_policy_legibility_3005.py
+++ b/tests/hooks/test_hook_sandbox_policy_legibility_3005.py
@@ -29,12 +29,14 @@ from reyn.config.infra import SandboxConfig
 from reyn.hooks.loader import HookConfigError, load_hooks
 from reyn.hooks.sandbox_scope import unapplied_policy_fields
 from reyn.security.sandbox.backend import SandboxResult
+from tests._support.sandbox_backend import FULLY_ENFORCING_AXES
 
 
 class _RecordingBackend:
     """Real (non-mock) SandboxBackend recording each policy it is handed."""
 
     name = "recording"
+    enforced_axes = FULLY_ENFORCING_AXES
 
     def __init__(self) -> None:
         self.calls: list[tuple[list[str], object]] = []

--- a/tests/hooks/test_hook_subprocess_per_site_2827.py
+++ b/tests/hooks/test_hook_subprocess_per_site_2827.py
@@ -26,6 +26,7 @@ import pytest
 
 from reyn.hooks.loader import HookConfigError, load_hooks
 from reyn.security.sandbox.backend import SandboxResult
+from tests._support.sandbox_backend import FULLY_ENFORCING_AXES
 
 
 class _RecordingBackend:
@@ -36,6 +37,7 @@ class _RecordingBackend:
     """
 
     name = "recording"
+    enforced_axes = FULLY_ENFORCING_AXES
 
     def __init__(self) -> None:
         self.calls: list[tuple[list[str], object]] = []

--- a/tests/security/test_sandbox_argv0_resolve_2820.py
+++ b/tests/security/test_sandbox_argv0_resolve_2820.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import pytest
 
 from reyn.security.sandbox.resolve import resolve_real_executable
+from tests._support.sandbox_backend import FULLY_ENFORCING_AXES
 
 
 def _make_executable(path: Path, body: str = "#!/bin/sh\necho x\n") -> None:
@@ -280,6 +281,7 @@ class _CapturingBackend:
     """Real SandboxBackend test double capturing the argv + policy it is handed."""
 
     name = "capture"
+    enforced_axes = FULLY_ENFORCING_AXES
 
     def __init__(self) -> None:
         self.seen_argv: list[str] | None = None

--- a/tests/security/test_sandbox_axis_declaration_witness_4039.py
+++ b/tests/security/test_sandbox_axis_declaration_witness_4039.py
@@ -1,0 +1,139 @@
+"""Tier 1/2c: #4039 D4 — declaration ↔ witness conformance.
+
+A backend's ``enforced_axes`` (D1: the backend's OWN declaration, read by
+the production predicate ``unenforced_axes()``, never probed) and
+``axis_contract.AXIS_REGISTRY``'s ``witness_strength`` (the CI-conformance-only
+REAL-execution record — see that module's own docstring for the two-layer
+split, CLAUDE.md's hard rule) are two SEPARATE registries at two separate
+layers. D4 is the CI-only bridge that keeps them from silently diverging:
+whenever a backend declares ``ENFORCES`` for an axis this contract has
+migrated, that backend must ALSO have a witness entry there — otherwise the
+production declaration is an unverified claim (exactly the shape #4039
+exists to close, one layer up).
+
+**``DOES_NOT_ENFORCE`` needs no witness — its ABSENCE from ``witness_strength``
+IS the correct state** (architect's explicit correction, #4039): a backend
+that declares it does not enforce an axis has nothing to witness there, and
+this file's own tests assert that absence is accepted, not flagged.
+
+**Naming bridge**: ``AxisEnforcementDeclaration`` is keyed by
+``SandboxPolicy`` FIELD names (``write_paths``/``network``/``deny_subprocess``/
+...); ``AXIS_REGISTRY`` is keyed by axis_contract's own coarser
+``write``/``spawn``/``network`` vocabulary (CLAUDE.md's 2-layer sandbox rule
+— see ``backend.AxisEnforcementDeclaration``'s own docstring for why the two
+vocabularies stay separate, not unified). Only the 3 migrated axis_contract
+axes have a mapping to a policy field; the other 4 policy axes
+(write_deny_paths/read_deny_paths/env_deny_names/allow_env_names) are simply
+not covered by axis_contract's real-execution witnessing yet and are out of
+this file's scope (D4 only bridges the axes BOTH registries know about).
+
+**Landlock's witness key is "seccomp", not "landlock", for the network and
+spawn axes** — this module's own docstring on ``LandlockBackend.enforced_axes``
+explains why: Landlock's LSM has no net-port API, so network/subprocess
+enforcement on the "landlock" backend actually comes from an
+always-loaded seccomp-BPF filter INSIDE that same backend. ``witness_strength``
+tracks THAT finer provenance detail; this file's mapping accounts for it
+explicitly rather than asserting a witness key that will never exist.
+"""
+from __future__ import annotations
+
+from reyn.environment.container_backend import DockerEnvironmentBackend
+from reyn.security.sandbox.axis_contract import AXIS_REGISTRY
+from reyn.security.sandbox.backend import AxisEnforcement
+from reyn.security.sandbox.backends.landlock import LandlockBackend
+from reyn.security.sandbox.backends.seatbelt import SeatbeltBackend
+from reyn.security.sandbox.noop_backend import NoopBackend
+
+#: {policy field name -> axis_contract axis name} — only the 3 axes BOTH
+#: registries know about (see module docstring).
+_POLICY_FIELD_TO_CONTRACT_AXIS: "dict[str, str]" = {
+    "write_paths": "write",
+    "deny_subprocess": "spawn",
+    "network": "network",
+}
+
+#: {(backend Protocol .name, contract axis name) -> the witness_strength key
+#: that actually appears for it} — the identity mapping EXCEPT Landlock's
+#: network/spawn axes, witnessed under "seccomp" (see module docstring).
+_WITNESS_KEY_OVERRIDES: "dict[tuple[str, str], str]" = {
+    ("landlock", "spawn"): "seccomp",
+    ("landlock", "network"): "seccomp",
+}
+
+#: Every concrete SandboxBackend this repo ships, keyed by its Protocol
+#: ``.name`` — the population D4 checks. Docker included deliberately
+#: (architect: the best evidence for D2's totality — it declares
+#: DOES_NOT_ENFORCE on every axis, so it never triggers a witness
+#: requirement here, which is itself the assertion worth making explicit).
+_BACKENDS: "dict[str, type]" = {
+    "noop": NoopBackend,
+    "seatbelt": SeatbeltBackend,
+    "landlock": LandlockBackend,
+    "docker": DockerEnvironmentBackend,
+}
+
+
+def _witness_key(backend_name: str, contract_axis: str) -> str:
+    return _WITNESS_KEY_OVERRIDES.get((backend_name, contract_axis), backend_name)
+
+
+def test_every_enforces_declaration_on_a_migrated_axis_has_a_witness() -> None:
+    """Tier 1: D4 — a backend that declares ENFORCES for a policy field
+    mapping to a MIGRATED axis_contract axis must have a witness_strength
+    entry there (under the resolved witness key). A declaration with no
+    witness is an unverified production claim — the exact shape #4039
+    exists to close, one layer up."""
+    contracts_by_name = {c.name: c for c in AXIS_REGISTRY}
+
+    missing: list[str] = []
+    for backend_name, backend_cls in _BACKENDS.items():
+        declared = backend_cls.enforced_axes.as_dict()
+        for field_name, contract_axis in _POLICY_FIELD_TO_CONTRACT_AXIS.items():
+            if declared[field_name] is not AxisEnforcement.ENFORCES:
+                continue
+            contract = contracts_by_name[contract_axis]
+            if not contract.is_migrated:
+                continue  # not yet migrated — nothing to check against
+            key = _witness_key(backend_name, contract_axis)
+            if key not in contract.witness_strength:
+                missing.append(
+                    f"{backend_name}.enforced_axes[{field_name}]=ENFORCES but "
+                    f"AXIS_REGISTRY[{contract_axis!r}].witness_strength has no "
+                    f"{key!r} entry"
+                )
+    assert not missing, "\n".join(missing)
+
+
+def test_does_not_enforce_requires_no_witness() -> None:
+    """Tier 1: D4's other half (architect's explicit correction) — a backend
+    declaring DOES_NOT_ENFORCE for an axis is NOT required to have a
+    witness_strength entry; its ABSENCE is the correct state. Docker is the
+    concrete instance: it declares DOES_NOT_ENFORCE on write/network/spawn
+    and has no witness_strength entry for "docker" anywhere in
+    AXIS_REGISTRY — this must NOT be flagged by the check above."""
+    contracts_by_name = {c.name: c for c in AXIS_REGISTRY}
+    docker_declared = DockerEnvironmentBackend.enforced_axes.as_dict()
+
+    for field_name, contract_axis in _POLICY_FIELD_TO_CONTRACT_AXIS.items():
+        assert docker_declared[field_name] is AxisEnforcement.DOES_NOT_ENFORCE
+        contract = contracts_by_name[contract_axis]
+        assert "docker" not in contract.witness_strength
+
+    # The check itself must accept this state (not raise/flag it) — run it
+    # directly rather than only asserting the precondition above.
+    test_every_enforces_declaration_on_a_migrated_axis_has_a_witness()
+
+
+def test_landlocks_network_and_spawn_declarations_witness_under_seccomp() -> None:
+    """Tier 1: the naming-bridge instance this file's docstring names —
+    Landlock's Protocol name is "landlock", but its network/spawn
+    enforcement is witnessed under "seccomp" (a different, finer-grained
+    provenance key axis_contract.py tracks). Pins the override table
+    doesn't silently go stale if AXIS_REGISTRY's witness keys change."""
+    contracts_by_name = {c.name: c for c in AXIS_REGISTRY}
+    assert "seccomp" in contracts_by_name["spawn"].witness_strength
+    assert "seccomp" in contracts_by_name["network"].witness_strength
+    assert "landlock" not in contracts_by_name["spawn"].witness_strength
+    assert "landlock" not in contracts_by_name["network"].witness_strength
+    # But landlock's WRITE axis is witnessed under its own name — no override.
+    assert "landlock" in contracts_by_name["write"].witness_strength


### PR DESCRIPTION
**[e2e-coder]** — Implements #4039 per architect's D1-D4 design (issue thread).

## The bug

`unenforced_axes()` only asked "can this backend express a deny-list" — true only of Landlock's structural LSM allowlist-only constraint. A backend that simply enforces NOTHING for an axis (`NoopBackend`, and especially `DockerEnvironmentBackend` — an operator's deliberate isolation choice) fell outside the check entirely and reported a clean result while enforcing zero configured axes.

## Design (architect, D1-D4)

- **D1** — declaration is owned by the BACKEND (`AxisEnforcementDeclaration`, `backend.py`), not `axis_contract` (CI-only, 2-layer separation per CLAUDE.md's hard rule) or a hardcoded backend-name set.
- **D2** — full domain, no default anywhere in the dataclass (mirrors `AxisContract`'s own discipline) — 7 fields, keyed to `SandboxPolicy`'s own field vocabulary (`deny_subprocess`, not the config-vocabulary `subprocess` — architect's naming correction, #3823 deliberately split those two vocabularies).
- **D3** — `unenforced_axes(backend, policy)` reads the declaration (never probes) and reports the SUBSET of the domain the operator actually configured on this call — **not** the complement of `enforced_axes` (architect: a prior reader of #3951's own text already misread exactly this once; the new docstring states it explicitly).
- **D4** — a CI-only conformance test bridges declaration ↔ `axis_contract`'s real-execution witness for the 3 migrated axes; `DOES_NOT_ENFORCE` requires no witness — its absence is the correct state (Docker: declares `DOES_NOT_ENFORCE` everywhere, has zero witness entries, accepted not flagged).

## What each backend now declares

| backend | write_paths | write_deny_paths | read_deny_paths | network | deny_subprocess | env_deny_names | allow_env_names |
|---|---|---|---|---|---|---|---|
| Noop | ✗ | ✗ | ✗ | ✗ | ✗ | ✅ | ✅ |
| Seatbelt | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| Landlock | ✅ | ✗ | ✗ | ✅ (via its own always-loaded seccomp-BPF layer) | ✅ (same) | ✅ | ✅ |
| Docker | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |

Docker is architect's "sharpest instance" — measured directly (#4042): `run()` honors only `timeout_seconds`/`max_output_bytes`; isolation comes from fixed container-launch flags, never policy fields.

## Signature change

`unenforced_axes(backend_name: str, ...)` → `unenforced_axes(backend: SandboxBackend, ...)` — the only production call site (`sandboxed_exec.py`) already had the backend object in scope. Swept every `SandboxBackend` test stand-in across the suite (16 files) for the new required `enforced_axes` field: a new shared `tests/_support/sandbox_backend.py::FULLY_ENFORCING_AXES` for stand-ins whose test purpose is unrelated to axis enforcement; real per-backend declarations reused directly (not hand-duplicated) for `test_3901_sandbox_axis_unenforced.py`'s cross-platform stand-ins.

## Docs synced, same PR (CLAUDE.md hard rule)

- `docs/guide/for-users/configure-sandbox.md` — the "Silence is not a clean bill of health" section rewritten (Docker/Noop now DO warn for the axes they don't enforce).
- `docs/concepts/runtime/sandbox.md` — the mechanism section rewritten for D1-D4.

## #4042 / #4045 dependency (architect's flagged same-PR requirement)

Checked #4042's 2 tests (`tests/environment/test_mount_e2e_1332.py`) — they assert the underlying enforcement gap via real execution (`deny_subprocess`/`env_deny_names` have no effect in container mode), independent of whether Reyn *warns* about it. That claim is unchanged by this PR, so no test code changes were needed there; only the doc's claim that "no warning is emitted" needed correcting (done above).

## Falsify-verification

Reintroduced `NoopBackend.enforced_axes.write_paths = ENFORCES` temporarily — confirmed the corresponding test goes RED (`[]` instead of `["write_paths"]`). Restored, GREEN.

## Verification
- 5 local gates green: `ruff check src tests`, `test_tier_audit.py --strict` (87 tests, 0 errors), `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py`.
- Full sweep (`tests/core/` + `tests/security/` + `tests/environment/` + `tests/hooks/` + `tests/tools/` + `tests/runtime/`): 6231 passed, 1 pre-existing unrelated failure (`test_session_pure_extraction_3679_s1`, confirmed via stash-and-rerun on origin state).
- Rebased onto current `main` (post-#4186, which also touched `policy.py`) — clean rebase, re-ran the full sweep + gates post-rebase, all green.

## Test plan
- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict <7 changed/new test files>`
- [x] `python scripts/verify_module_docstrings.py <7 changed src files>`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] Falsify-verified (RED with Noop's write_paths flipped to ENFORCES, GREEN restored)
- [x] Full consumer sweep (6231 tests, see Verification above)
- [ ] (Visual — N/A, no UI surface touched)

part of #3951, part of #4039

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
