### PR TITLE
docs(#4204): remove 2 false convention-claims about project-root resolution

### DIFF
--- a/src/reyn/interfaces/cli/commands/embeddings.py
+++ b/src/reyn/interfaces/cli/commands/embeddings.py
@@ -76,7 +76,21 @@ def _resolve_action_index_dir(project_root: Path) -> Path:
 
 
 def _get_project_root() -> Path:
-    """Return cwd as the project root (consistent with other reyn commands)."""
+    """Return raw cwd as the project root.
+
+    #4204: this does NOT match the convention every other CLI command
+    module (chat.py / config.py / dogfood.py / mcp.py / memory.py /
+    permissions.py / pipe.py / plugin.py) converges on —
+    ``_find_project_root(Path.cwd()) or Path.cwd()``, which walks up from
+    cwd to find the actual project root (a `reyn.yaml`/`.reyn/` marker)
+    rather than anchoring wherever the operator happened to launch from.
+    A prior version of this docstring claimed the opposite ("consistent
+    with other reyn commands") — false, and left uncorrected long enough
+    that the false claim was itself the risk (the next reader who trusted
+    it would copy this shape believing it matched the rest of the CLI).
+    Fixing the underlying cwd-vs-project_root gap is tracked separately
+    (#4204 bucket A); this docstring only stops asserting something untrue.
+    """
     return Path.cwd()
 
 

--- a/src/reyn/interfaces/slash/image.py
+++ b/src/reyn/interfaces/slash/image.py
@@ -144,8 +144,17 @@ async def image_cmd(ctx: "SlashContext", args: str) -> None:
         )
         return
 
-    # Resolve relative to CWD (= the same scope Session uses for
-    # file reads). Absolute paths are honoured as-is.
+    # Resolve relative to CWD. #4204: this is NOT the same scope Session
+    # uses for file reads, despite a prior version of this comment
+    # claiming so — Session._workspace_base_dir is the actual value other
+    # Session file-read call sites resolve against
+    # (session.py:3695/4133, `self._workspace_base_dir or Path.cwd()`),
+    # and ctx.session is reachable from this handler (see the
+    # getattr(ctx.session, ...) calls elsewhere in this file), so this
+    # site could read it too but does not. Absolute paths are honoured
+    # as-is. Fixing the scope mismatch itself is tracked separately
+    # (#4204 bucket A); this comment only stops asserting something
+    # untrue.
     path = Path(path_str).expanduser()
     if not path.is_absolute():
         path = Path.cwd() / path


### PR DESCRIPTION
**[e2e-coder]** — Implements the ① step of #4204 per lead-coder's staged instruction (fix the false convention-claims first, before the larger behavior sweep).

## The 2 false claims (each verified directly, not trusted from the dispatch list)

1. **`embeddings.py:78`** — `_get_project_root()`'s docstring claimed returning bare `Path.cwd()` was "consistent with other reyn commands." Verified false: 8 other CLI command modules (chat/config/dogfood/mcp/memory/permissions/pipe/plugin) converge on `_find_project_root(Path.cwd()) or Path.cwd()`; `embeddings.py` never calls `_find_project_root` at all (grepped, zero occurrences).

2. **`slash/image.py:151`** — the comment claimed CWD resolution was "the same scope Session uses for file reads." Verified false: `Session._workspace_base_dir` is the actual value other Session file-read call sites resolve against (`session.py:3695`/`4133`), and `ctx.session` is reachable from this handler (other `getattr(ctx.session, ...)` calls already exist in the same file) — `image_cmd` could read it too but doesn't.

## Scope

Comment/docstring-only. The underlying cwd-vs-project_root behavior gap each claim was covering for is real but stays in #4204 bucket A's larger 16-site sweep, not this PR — fixing the misleading TEXT first is the priority named in the issue: a future reader trusting either claim copies the "just use cwd" shape believing it matches the rest of the codebase, propagating the defect.

## Verification
- 5 local gates green: `ruff check src tests`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py` (no test files touched, `test_tier_audit.py` not applicable).
- Targeted sweep: `tests/interfaces/test_reyn_embeddings_cli.py` + `tests/interfaces/test_slash_image_pure_helpers.py` + `tests/interfaces/test_slash_image_completer.py` — 35 passed.

## Test plan
- [x] `ruff check src tests`
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/cli/commands/embeddings.py src/reyn/interfaces/slash/image.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] Targeted consumer sweep (35 tests, see Verification above)
- [ ] (Visual — N/A, comment-only change)

part of #4204

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
