### PR TITLE
fix(#4204): dogfood.py's storage dir anchors on raw cwd, not project root

### DIFF
--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -247,7 +247,14 @@ def _no_subcommand(args: argparse.Namespace) -> None:  # pragma: no cover
 # ---------------------------------------------------------------------------
 
 def _dogfood_base_dir() -> Path:
-    return Path.cwd() / ".reyn" / "dogfood"
+    # #4204: was bare Path.cwd() — a real defect (the file's OWN :475 in
+    # the same module correctly uses _find_project_root, so this wasn't
+    # even an internally consistent convention). reyn dogfood launched
+    # from a subdirectory of the project silently reads/writes runs +
+    # baselines under a phantom .reyn/dogfood/ instead of the real
+    # project's.
+    from reyn.config import _find_project_root
+    return (_find_project_root(Path.cwd()) or Path.cwd()) / ".reyn" / "dogfood"
 
 
 def _runs_dir() -> Path:

--- a/tests/interfaces/test_dogfood_base_dir_cwd_4204.py
+++ b/tests/interfaces/test_dogfood_base_dir_cwd_4204.py
@@ -1,0 +1,53 @@
+"""Tier 2: #4204 bucket A — dogfood.py's storage dir anchors on the project
+root, not raw cwd.
+
+`_dogfood_base_dir()` previously returned `Path.cwd() / ".reyn" / "dogfood"`
+directly — a real defect, not just a docstring claim: the SAME module's own
+`:475` (the `run` scenario-dispatch path) already correctly uses
+`_find_project_root(Path.cwd()) or Path.cwd()`, so this wasn't even an
+internally consistent convention within the file. `reyn dogfood` launched
+from a subdirectory of the project silently read/wrote runs + baselines
+under a phantom `.reyn/dogfood/` instead of the real project's.
+
+`_runs_dir()`/`_baselines_dir()` both delegate to `_dogfood_base_dir()`, so
+this one fix covers both.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.interfaces.cli.commands.dogfood import (
+    _baselines_dir,
+    _dogfood_base_dir,
+    _runs_dir,
+)
+
+
+def test_base_dir_resolves_to_project_root_from_a_subdirectory(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: launched from a subdirectory, the dogfood storage dir still
+    anchors on the project root (the `reyn.yaml` ancestor), not the
+    subdirectory."""
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    subdir = tmp_path / "src" / "nested"
+    subdir.mkdir(parents=True)
+    monkeypatch.chdir(subdir)
+
+    assert _dogfood_base_dir() == tmp_path / ".reyn" / "dogfood"
+    assert not (subdir / ".reyn").exists()
+
+
+def test_runs_and_baselines_dirs_share_the_same_fix(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: both derived dirs delegate to _dogfood_base_dir(), so they
+    inherit the fix — a real witness that the delegation wasn't
+    shadowed/duplicated somewhere."""
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    subdir = tmp_path / "src" / "nested"
+    subdir.mkdir(parents=True)
+    monkeypatch.chdir(subdir)
+
+    assert _runs_dir() == tmp_path / ".reyn" / "dogfood" / "runs"
+    assert _baselines_dir() == tmp_path / ".reyn" / "dogfood" / "baselines"

--- a/tests/runtime/test_workspace_root_not_cwd_3705.py
+++ b/tests/runtime/test_workspace_root_not_cwd_3705.py
@@ -195,13 +195,14 @@ def _cwd_relative_reyn_sites(py_file: Path) -> "list[int]":
 #   `make_session`, and not implicated in the incident (a test never
 #   constructs `reyn agent list` / `reyn events` / etc. the way it
 #   constructs a `Session`):
-#   interfaces/cli/commands/{dogfood,events,mcp,web}.py,
+#   interfaces/cli/commands/{events,mcp,web}.py,
 #   interfaces/web/server.py (the `reyn web` server's own persist paths),
 #   dev/dogfood/runner.py.
-#   (#4204 bucket A: `agent.py` moved OFF this list — it now anchors on
+#   (#4204 bucket A: `agent.py` and `dogfood.py` moved OFF this list —
+#   they now anchor on
 #   `_find_project_root(Path.cwd()) or Path.cwd()` like the other CLI
 #   command modules that already made this switch, rather than a bare
-#   cwd-relative literal, so it no longer appears in the sweep below.)
+#   cwd-relative literal, so neither appears in the sweep below.)
 # - Deferred (filed separately, NOT fixed here): `interfaces/slash/memory.py`
 #   (#3721) — the `/memory` chat command calls `list_entries()`/`find_one()`
 #   with no arguments, falling into the same `memory_dir()` cwd-relative
@@ -217,7 +218,6 @@ _ALLOWED_SITES: "dict[str, int]" = {
     "src/reyn/runtime/services/router_host_adapter.py": 1,
     "src/reyn/dev/testing/replay_preconditions.py": 1,
     "src/reyn/data/memory/memory_paths.py": 1,  # Session-owned fallback (root=None), see comment above
-    "src/reyn/interfaces/cli/commands/dogfood.py": 1,
     "src/reyn/interfaces/cli/commands/events.py": 1,
     "src/reyn/interfaces/cli/commands/mcp.py": 2,
     "src/reyn/interfaces/cli/commands/web.py": 1,


### PR DESCRIPTION
**[e2e-coder]** — Continuing #4204 bucket A. This PR: `dogfood.py`'s storage dir.

## Verified directly

`_dogfood_base_dir()` returned `Path.cwd() / ".reyn" / "dogfood"` directly — the same module's OWN `:475` (the `run` scenario-dispatch path) already correctly uses `_find_project_root(Path.cwd()) or Path.cwd()`, so this wasn't even an internally consistent convention within the file. `reyn dogfood` launched from a subdirectory of the project silently read/wrote runs + baselines under a phantom `.reyn/dogfood/` instead of the real project's. `_runs_dir()`/`_baselines_dir()` both delegate to `_dogfood_base_dir()`, so one fix covers both.

## Falsify-verification

New tests: `_dogfood_base_dir()` resolves to the project root from a subdirectory (not the subdirectory itself), and `_runs_dir()`/`_baselines_dir()` both inherit the fix through delegation. Reverted to bare `Path.cwd()` temporarily, confirmed both tests go RED (resolved to the subdirectory instead of the project root). Restored, GREEN.

## Verification
- 5 local gates green: `ruff check src tests`, `test_tier_audit.py --strict` (2 tests, 0 errors), `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py`.
- Targeted sweep: dogfood-CLI-adjacent test suites — 7 passed.

## Test plan
- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_dogfood_base_dir_cwd_4204.py`
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/cli/commands/dogfood.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] Falsify-verified (RED with bare Path.cwd(), GREEN restored)
- [x] Targeted consumer sweep (7 tests, see Verification above)
- [ ] (Visual — N/A, no UI surface touched)

part of #4204

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
