### PR TITLE
docs(#4215): external monitoring is pull — cron + events how-to guide

### DIFF
--- a/.mkdocs/mkdocs.yml
+++ b/.mkdocs/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
               - guide/for-users/oauth-login.md
               - guide/for-users/manage-memory.md
               - guide/for-users/write-a-pipeline.md
+              - guide/for-users/monitor-and-improve-with-cron.md
       - For Reyn developers:
           - guide/for-reyn-developers/index.md
           - Concepts & principles:

--- a/docs/guide/for-users/monitor-and-improve-with-cron.md
+++ b/docs/guide/for-users/monitor-and-improve-with-cron.md
@@ -1,0 +1,91 @@
+# Monitor and improve with cron
+
+A common pattern: wake an agent periodically, have it read what happened
+since the last wake, and let it act on that — flag a stuck task, tighten a
+prompt, adjust a pipeline. This guide builds that pattern out of two
+existing pieces, `cron.jobs` and `.reyn/events/`, with no new mechanism.
+
+## Why pull, not push
+
+reyn also has a **push** mechanism for reaching another session directly —
+a hook's `template_push` / `shell_push` fields can target a specific
+`session` (see the [`hooks` block](../../reference/config/reyn-yaml.md) field
+table). That is the right tool when a session needs to actively notify
+another one at the moment something happens.
+
+For *monitoring*, pull is the better fit and the recommended pattern:
+
+- The monitored session does nothing to cooperate — no hook to register, no
+  awareness that it's being watched. Everything it needs already lands in
+  its own audit log.
+- The monitor reads on its own schedule, from a log that already exists.
+  There's nothing to wire on the monitored side, and nothing to break there
+  either.
+
+## 1. Wake a monitoring agent on a schedule
+
+Add a `cron` job that dispatches a message to the agent that will do the
+monitoring:
+
+```yaml
+cron:
+  jobs:
+    - name: watch_and_improve
+      to: improver_agent
+      message: "Check .reyn/events/ for anything since your last run and act on it."
+      schedule: "*/30 * * * *"   # every 30 minutes
+      enabled: true
+```
+
+See the [`cron` block reference](../../reference/config/reyn-yaml.md) for the
+full field list, and [`reyn cron run/list/status`](../../reference/cli/cron.md)
+for running the scheduler standalone.
+
+## 2. Read what happened from the event log
+
+Every project writes a structured, append-only event log under
+`.reyn/events/` — one JSONL file per run, nested under
+`agents/<agent>/.../<YYYY-MM>/`. `reyn events` replays it:
+
+```bash
+# a single run's log
+reyn events .reyn/events/agents/improver_agent/chat/2026-08/abc123.jsonl
+
+# every log under a directory, walked recursively, oldest first
+reyn events .reyn/events/agents/ --since 2026-08-01
+
+# only completion-shaped events
+reyn events .reyn/events/agents/ --filter turn_settled --filter session_completed
+```
+
+For "what finished since I last looked," the completion-shaped kinds are
+the ones worth filtering for (see the full
+[kind vocabulary](../../reference/runtime/events.md) for the closed set):
+
+| Kind | Signals |
+|---|---|
+| `turn_settled` | a turn reached a terminal state; payload carries `kind` and, when the turn was part of a chain, `chain_id` |
+| `session_completed` | a session ended; payload carries `agent_name` |
+| `pipeline_step_completed` | one pipeline step finished; payload carries `run_id`, `step_index`, `step_kind`, `total_steps` |
+| `chain_timeout` | a chain gave up waiting on a reply; payload carries `chain_id`, `waiting_on`, `timeout_seconds`, `origin_agent` |
+| `task_settle_undelivered` | a completion couldn't be delivered back to its waiter; payload carries `run_id`, `reply_to_agent`, `reply_to_sid`, `reason` |
+
+`--since`/`--until` bound the walk to files in that date range;
+`reyn events purge --before <DATE>` trims old logs once the monitor no
+longer needs them.
+
+## 3. Act on it
+
+The improving agent's own message (step 1) can name the action directly —
+"flag anything that timed out," "if the same pipeline step keeps failing,
+propose a fix" — and it has the ordinary agent surface (editing a prompt
+file, a pipeline YAML, filing a note) to act with. Nothing about steps 1–2
+requires the monitored session to do anything differently, or requires the
+monitoring agent to run inside the same session at all.
+
+## See also
+
+- [`cron` block reference](../../reference/config/reyn-yaml.md)
+- [`reyn cron` CLI reference](../../reference/cli/cron.md)
+- [Events reference](../../reference/runtime/events.md) — full kind vocabulary and payload documentation
+- [`reyn events` CLI reference](../../reference/cli/events.md)

--- a/docs/reference/cli/cron.ja.md
+++ b/docs/reference/cli/cron.ja.md
@@ -172,6 +172,6 @@ cron:
 ## 関連情報
 
 - [Reference: `reyn.yaml`](../config/reyn-yaml.md) — `cron:` 設定ブロック
-- [コンセプト: Operational Intelligence](../../concepts/data-retrieval/operational-intelligence.md) — スケジュール実行のユースケース
+- [Guide: Monitor and improve with cron](../../guide/for-users/monitor-and-improve-with-cron.md) — スケジュール実行のユースケース例: 監視・改善エージェントを起こす（EN のみ）
 - [コンセプト: A2A プロトコル](../../concepts/multi-agent/a2a.md) — `RunRegistry` パターンと将来の Web モードステータス API
 - [Reference: `reyn run-once`](run-once.md) — ヘッドレス単発 agent 実行(cron の inbox メッセージ配送とは別の dispatch パス)

--- a/docs/reference/cli/cron.md
+++ b/docs/reference/cli/cron.md
@@ -172,6 +172,6 @@ All times are UTC. The scheduler uses [`croniter`](https://pypi.org/project/cron
 ## Related
 
 - [Reference: `reyn.yaml`](../config/reyn-yaml.md) — `cron:` configuration block
-- [Concepts: Operational Intelligence](../../concepts/data-retrieval/operational-intelligence.md) — use-cases for scheduled execution
+- [Guide: Monitor and improve with cron](../../guide/for-users/monitor-and-improve-with-cron.md) — a scheduled-execution use-case: waking a monitoring/improvement agent
 - [Concepts: A2A protocol](../../concepts/multi-agent/a2a.md) — `RunRegistry` pattern and future web-mode status API
 - [Reference: `reyn run-once`](run-once.md) — headless single-shot agent invocation (a different dispatch path from cron's inbox-message delivery)

--- a/docs/reference/cli/events.md
+++ b/docs/reference/cli/events.md
@@ -20,7 +20,7 @@ reyn events purge [OPTIONS]
 
 | Mode | Description |
 |------|-------------|
-| *(positional PATH)* | Stream events from a JSONL file to stdout. |
+| *(positional PATH)* | Stream events from a `.jsonl` file, or every `.jsonl` file under a directory (walked recursively, oldest first), to stdout. |
 | `purge` | Delete event files older than a given date. |
 
 ## Options — replay mode
@@ -53,6 +53,7 @@ reyn events purge [OPTIONS]
 ```bash
 reyn events .reyn/events/agents/reyn/chat/2026-05/abc123.jsonl
 reyn events .reyn/events/agents/reyn/chat/2026-05/abc123.jsonl --filter permission_denied
+reyn events .reyn/events/agents/ --since 2026-05-01     # every log under a directory
 reyn events purge --before 2026-04-01
 reyn events purge --before 2026-04-01 --dry-run
 ```

--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -739,8 +739,8 @@ cron:
 ### 関連情報
 
 - `docs/reference/cli/cron.md` — `reyn cron run/list/status`
-- `docs/concepts/data-retrieval/operational-intelligence.md` — イベントログの定期
-  indexing agent をスケジュールする
+- `docs/guide/for-users/monitor-and-improve-with-cron.md` — `cron.jobs` と
+  `.reyn/events/` を組み合わせて監視・改善エージェントを起こす方法（EN のみ）
 
 ## `permissions` ブロック
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -1366,8 +1366,8 @@ cron:
 ### Cross-references
 
 - `docs/reference/cli/cron.md` — `reyn cron run/list/status`
-- `docs/concepts/data-retrieval/operational-intelligence.md` — scheduling a
-  recurring events-log indexing agent
+- `docs/guide/for-users/monitor-and-improve-with-cron.md` — using `cron.jobs`
+  together with `.reyn/events/` to wake a monitoring/improvement agent
 
 ## `permissions` block
 


### PR DESCRIPTION
**[docs-maintainer]** — #4215 の ③（外部監視は pull ＝ cron + events）。**コード差分ゼロ、doc のみ。**

着手前に issue スレッド（本文 + コメント）を通読し、architect の「owner の記憶が測定を2度上回った」注意点を確認しました。追加のスレッド内容はコメント1件（lead-coder の割り当て、#4218 起票の別件）のみで、③ 自体の設計には影響なしでした。

## 追加

`docs/guide/for-users/monitor-and-improve-with-cron.md` — 新規 how-to guide。

- `cron.jobs` で監視/改善エージェントを定期起床させる
- `.reyn/events/` + `reyn events` で完了系イベント（`turn_settled` / `session_completed` / `pipeline_step_completed` / `chain_timeout` / `task_settle_undelivered`、payload は各実装/doc から実測）を読む
- なぜ push（既存の #2072 cross-session push、`template_push`/`shell_push` の `session` field）ではなく pull か、を簡潔に説明 — pull は被監視側が何も協力しなくて済む、が owner の「reactive を広げない」意図と一致する理由

nav（`.mkdocs/mkdocs.yml`）にも追加、`mkdocs build --strict` で新規ページ由来の警告ゼロを確認済み。

## 同 PR で直した隣接 drift

調査中に見つけた、同じ「retire 済みページへの誤ったユースケース主張」が3箇所:

- `reyn-yaml.md` / `.ja.md` の `cron` block cross-reference が `operational-intelligence.md`（明示的に retire 済みと書いてある historical page）を指していた → 新guideへ repoint
- `cron.md` / `.ja.md` の Related セクションも同じ stale pointer → 同様に repoint
- `reference/cli/events.md` の Modes 表が「PATH = 単一ファイルのみ」としか書いておらず、実装（`events.py` の `_collect_files`）はディレクトリ再帰も受け付ける。新guideの例がこの挙動に依存するため、同PRで doc を実装に合わせて修正（directory 説明 + example 追加）

## Test plan

- [x] `mkdocs build -f .mkdocs/mkdocs.yml --strict` — 新規ページ由来の warning/abort なし（既存の EN→JA anchor-parity INFO 群は今回の変更と無関係、pre-existing）
- [x] `python scripts/check_doc_anchors.py` — exit 0, "no dangling anchors into published pages"（pre-existing の未解決anchor一覧は本PRの変更と無関係）
- [x] `ruff check src tests` — All checks passed（src/tests 側の差分なし、doc のみ）
- [x] closing-keyword trap regex を commit message・本PR bodyの両方に適用 — hit なし
- N/A: `test_tier_audit.py` / `verify_module_docstrings.py` / `mypy_ratchet.py` / `check_tests_path_literal_reference.py` — src/tests 配下の変更ゼロにつき対象ファイルなし
- [ ] Visual — N/A（doc のみ、mkdocs strict build で構造的に確認済み。標準の waiver 適用対象外〔そもそも visual gate が無いカテゴリ〕）

part of #4215 (③のみ。①②は別担当・別PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
