### PR TITLE
feat(#4194): bottom-chrome config-warning indicator for unrecognized reyn.yaml keys

### DIFF
--- a/docs/guide/for-users/chat-and-web-ui.md
+++ b/docs/guide/for-users/chat-and-web-ui.md
@@ -218,6 +218,26 @@ consistent with the renderer's own state.
 > Slash commands are documented in the
 > [`reyn chat` reference](../../reference/cli/chat.md#slash-commands).
 
+### Config-warning indicator
+
+If `reyn.yaml` / `reyn.local.yaml` / `~/.reyn/config.yaml` contains a key
+`reyn` does not recognize (a typo, or a key from a since-renamed config
+version), it is not applied — and a one-line indicator appears in the
+bottom chrome, above the menu row, naming how many keys were skipped:
+
+```
+⚠ 2 config keys not applied → reyn config validate
+```
+
+It stays visible for the whole session (fixing this requires a restart —
+`reyn.yaml` is read once at startup) and never scrolls away with the
+conversation. Run `reyn config validate` for the detail this line
+deliberately omits: which key, why, and — for a renamed key — the exact new
+name to use. This covers `reyn.yaml`'s operator-editable config only; the
+separately hot-reloaded `.reyn/*.yaml` registries (mcp/cron/skills/
+pipelines/presentations) warn to the log on the same unknown-key check but
+are not (yet) reflected in this indicator.
+
 ---
 
 ## Choosing which surfaces are hosted (`--enable` / `--disable`)

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -143,7 +143,7 @@ def build_policy_tier_config(cwd: Path | None = None) -> dict:
     return merged
 
 
-def _warn_unknown_config_keys(policy_tier_merged: dict) -> None:
+def _warn_unknown_config_keys(policy_tier_merged: dict) -> int:
     """#4174 T0: log ONE warning naming every unknown/renamed config key
     found in the policy-tier config (``user_global`` + ``project`` +
     ``project_local`` merged — the operator-editable files; the 5
@@ -162,12 +162,18 @@ def _warn_unknown_config_keys(policy_tier_merged: dict) -> None:
     resolved sandbox policy — dropping a policy key makes the config
     LOOSER, not silently inert like an ordinary dropped key, so an
     operator relying on it must see what's actually in force.
+
+    Returns the unknown-key count (#4194: the log-only warning is invisible
+    in the interactive CUI — ``_setup_interactive_logging`` redirects all
+    logs to a file, per architect's live measurement — so the count is
+    also returned for :func:`load_config` to attach to the ``ReynConfig``
+    it builds, giving the CUI's bottom chrome something to read).
     """
     from reyn.config import config_schema
 
     unknown = config_schema.unknown_config_keys(policy_tier_merged)
     if not unknown:
-        return
+        return 0
 
     import logging
     log = logging.getLogger(__name__)
@@ -195,6 +201,7 @@ def _warn_unknown_config_keys(policy_tier_merged: dict) -> None:
         )
 
     log.warning("Unrecognized config key(s) found:\n" + "\n".join(f"  - {line}" for line in lines))
+    return len(unknown)
 
 
 def _as_config_dict(val: object, key: str) -> dict:
@@ -612,7 +619,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # registry files below are merged in — those are checked separately
         # at their own load points (runtime.hot_reload.validate_in_set),
         # not duplicated here.
-        _warn_unknown_config_keys(merged)
+        unknown_config_key_count = _warn_unknown_config_keys(merged)
 
         # Issue #470: dynamic MCP registry separated from static config.
         # ``.reyn/mcp.yaml`` carries op-managed server entries; merged
@@ -679,7 +686,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # #4174 T0: no project root — only builtin + user_global are in
         # `merged`, still worth checking (a mistyped ~/.reyn/config.yaml
         # key should not go unreported just because there's no project).
-        _warn_unknown_config_keys(merged)
+        unknown_config_key_count = _warn_unknown_config_keys(merged)
 
     # ADR-0030: apply ${VAR} interpolation across all string fields of the
     # merged config dict.  At this point os.environ already contains values
@@ -818,6 +825,10 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         skills=_as_config_dict(merged.get("skills"), "skills"),
         pipelines=_as_config_dict(merged.get("pipelines"), "pipelines"),
         presentations=_as_config_dict(merged.get("presentations"), "presentations"),
+        # #4194: policy-tier unknown-key count — see the field's own
+        # docstring in root.py for why this is `schema_internal` (a
+        # runtime-computed fact, not an operator-settable key).
+        unknown_config_key_count=unknown_config_key_count,
     )
     _validate_retrieval_scheme_embedding(_cfg)
     _validate_skill_visibility(_cfg)

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -355,6 +355,29 @@ class ReynConfig:
     # union-merge shape as ``skills`` / ``pipelines`` (see ``_merge`` in loader.py).
     presentations: dict = field(default_factory=dict)
 
+    # #4194: the policy-tier unknown/renamed config-key COUNT
+    # (``loader._warn_unknown_config_keys``'s return value, attached here
+    # after construction). `schema_internal` because this is the OPPOSITE
+    # of an operator-settable key — it is a runtime-computed FACT about
+    # the config the operator wrote, not something the operator writes
+    # themselves; `walk_config_schema` must never advertise it as a
+    # `reyn.yaml` key (`reyn config set unknown_config_key_count: 5` would
+    # be nonsense). Read by `Session.unknown_config_key_count`, which is
+    # what the interactive CUI's bottom chrome reads — the warning this
+    # counts previously only ever reached a log file
+    # (`_setup_interactive_logging` redirects all logs there), invisible
+    # to the operator. Scope: policy tier only (`reyn.yaml`/
+    # `reyn.local.yaml`/`~/.reyn/config.yaml`) — matches `reyn config
+    # validate`'s own scope exactly, so the indicator's "run reyn config
+    # validate" guidance is always answerable by that command. The
+    # hot-reload IN-set (`.reyn/*.yaml`) has its OWN separate unknown-key
+    # warn path (`hot_reload._warn_unknown_hot_reload_keys`) that this
+    # count does NOT include — that remaining silence is real and is
+    # tracked separately (#4235), not covered by this field.
+    unknown_config_key_count: int = field(
+        default=0, metadata={"schema_internal": True},
+    )
+
     def model_class_for(self, purpose: str) -> str:
         """#1672: the model CLASS for a logical call *purpose*.
 

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -75,9 +75,11 @@ from .activity_row import ActivityRow
 from .chrome import (
     _MENU_TABS,
     Composer,
+    ConfigWarningLine,
     MenuBar,
     _literal_option_content,
     build_drawer_pane,
+    config_warning_text,
     pane_commands,
     pane_needs_literal_rows,
     pane_payload,
@@ -850,6 +852,14 @@ class TextualChatApp(App):
         color: @quiet@;
         padding: 0 1;
     }
+    /* #4194: bold, not a colour — palette.py's own rule (@attention@ is the
+       ONLY semantic colour this CUI claims, for the intervention panel;
+       everything else that must stand out uses an attribute so the hue
+       stays the terminal theme's to choose). ConfigWarningLine's own
+       DEFAULT_CSS sets height/text-style/padding; nothing else to add
+       here — unlike MenuBar/StatusLine, this widget owns its full sheet
+       because it is a plain top-level sibling, not something MenuBar
+       repositions. */
     /* #3326: when StatusLine SHARES a row with Tab widgets (MenuBar._repack's
        merge case), width: auto keeps it sized to its own text instead of
        stretching to consume the row's remaining space (which would push the
@@ -1369,6 +1379,22 @@ class TextualChatApp(App):
                     "Type a message — enter to send · shift+enter to add a line…"
                 )
             )
+        # #4194: the config-warning indicator, mounted BEFORE MenuBar so it
+        # sits above the menu row in compose order (measured, headless
+        # ``App.run_test``: this ordering plus `1fr` FlowView is what leaves
+        # the always-visible last row — MenuBar/StatusLine — untouched,
+        # exactly where #2280's halt banner already depends on it staying).
+        # Conditionally yielded, not yielded-then-hidden: `unknown_config_key_count`
+        # is fixed for the whole session (reyn.yaml needs a restart to
+        # change), so there is no later render tick that would need to grow
+        # this row in — an operator on a clean config never pays even the
+        # empty-row layout cost the #4194 measurement confirmed a present
+        # row would take.
+        config_warning = config_warning_text(
+            getattr(self._config, "unknown_config_key_count", 0)
+        )
+        if config_warning is not None:
+            yield ConfigWarningLine(config_warning, id="config-warning")
         # Bottom chrome: a focusable menu row that also carries the slim
         # status-values segment (#3326: MenuBar owns placing StatusLine on
         # whichever row has room, collapsing the two previously-separate rows

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -1351,6 +1351,42 @@ def status_line_text(
     return base
 
 
+def config_warning_text(count: int) -> "str | None":
+    """The bottom-chrome config-warning indicator's text, or ``None`` when
+    there is nothing to show (#4194).
+
+    Architect's ruling (#4194 issue thread, 2026-08-11) fixes exactly THREE
+    properties, form left to the implementer: ①doesn't
+    scroll away with the conversation ②stays visible for as long as the
+    condition holds ③directs the operator to ``reyn config validate`` for
+    the 4-element detail (result / destination / full list / fix command) —
+    this line deliberately carries NONE of that detail itself, only a count
+    and the command name. Scope: the POLICY TIER only (``reyn.yaml`` /
+    ``reyn.local.yaml`` / ``~/.reyn/config.yaml``) — the same scope
+    ``reyn config validate`` itself checks (``config.py``'s ``_validate``
+    uses ``build_policy_tier_config``), so the indicator's own guidance is
+    always answerable by the command it names. The hot-reload IN-set
+    (``.reyn/*.yaml`` — mcp/cron/skills/pipelines/presentations) has its
+    OWN separate unknown-key warning path that ``validate`` does NOT cover
+    (lead-coder's explicit scoping call, #4194) — deliberately not counted
+    here; that remaining silence is real and tracked separately (#4235).
+
+    ``count`` (not a snapshot dict, unlike :func:`status_line_text`): this
+    value is CONFIG-derived, not session/live-state-derived — it is fixed
+    for the whole session lifetime once ``load_config()`` runs (``reyn.yaml``
+    changes need a restart to take effect, unlike the hot-reload IN-set),
+    so there is no live snapshot to route through, only
+    ``ReynConfig.unknown_config_key_count`` itself.
+
+    ``⚠`` matches the existing ``HALTED`` banner glyph above (same
+    single-cell-width class of symbol, same "something needs attention"
+    register) rather than introducing a new one."""
+    if not count:
+        return None
+    plural = "" if count == 1 else "s"
+    return f"⚠ {count} config key{plural} not applied → reyn config validate"
+
+
 def build_drawer_pane(tab_id: str, rows: "Sequence[str]") -> Widget:
     """Build the mounted drawer pane widget for ``tab_id`` from its display
     ``rows``: an :class:`OptionList` for a picker pane, a Rich :class:`Static`
@@ -1392,6 +1428,34 @@ class StatusLine(Static):
     menu row has room for it (usually the last), or given its own extra row
     when none does. Never yielded directly by the app; see
     :meth:`MenuBar._repack`."""
+
+
+class ConfigWarningLine(Static):
+    """#4194: the bottom-chrome config-warning indicator — a persistent,
+    non-scrolling row naming how many policy-tier ``reyn.yaml`` keys were
+    NOT applied, pointing at ``reyn config validate`` for detail. See
+    :func:`config_warning_text` for the scope and content rules.
+
+    A plain top-level sibling of :class:`MenuBar` in the app's compose
+    order (unlike :class:`StatusLine`, which MenuBar itself owns and
+    positions) — real-terminal geometry measurement (headless
+    ``App.run_test``, #4194) confirmed a fixed ``height: 1`` sibling here
+    is absorbed cleanly by ``textual_flowview.FlowView``'s (the
+    conversation pane) ``1fr`` sizing at both 80×24 and 60×20 — no overlap, no clipping,
+    every other chrome row just shifts down by one. The app's own
+    ``compose()``/``_refresh_status`` mount and update it conditionally
+    (absent entirely when there is nothing to warn about, not merely
+    hidden — see the app for why: an EMPTY always-visible row would still
+    occupy the layout slot the measurement showed the conversation pane
+    giving up)."""
+
+    DEFAULT_CSS = """
+    ConfigWarningLine {
+        height: 1;
+        text-style: bold;
+        padding: 0 1;
+    }
+    """
 
 
 #: Horizontal cells a :class:`Tab` adds around its label (``Tab``'s own

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -296,6 +296,13 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         "queue": v.get("queue", []),
         "turn_active": v.get("turn_active", False),
         "queue_seq": v.get("queue_seq", 0),
+        # #4194: session-local (the ReynConfig each side loaded from ITS OWN
+        # reyn.yaml — not projected onto the wire, same frame-sufficiency
+        # boundary as model_classes/agent_names above). A remote client's
+        # policy-tier config is the SERVER's, not the client's, so there is
+        # nothing meaningful to report here; 0 degrades gracefully (no
+        # indicator shown) rather than fabricating a count.
+        "unknown_config_key_count": 0,
     }
 
 

--- a/src/reyn/interfaces/repl/status.py
+++ b/src/reyn/interfaces/repl/status.py
@@ -453,6 +453,15 @@ def _snapshot(registry, config=None):
         "mcp_servers": _extract_mcp_servers(config) if config is not None else [],
         "hooks": _extract_hooks(config) if config is not None else [],
         "skills": _extract_skills(config) if config is not None else [],
+        # #4194: the policy-tier unknown/renamed config-key count
+        # (ReynConfig.unknown_config_key_count, set once at load_config()
+        # time — see that field's own docstring in root.py). Read every
+        # render tick like every other config-derived field above, so the
+        # bottom-chrome indicator's own render logic stays a pure function
+        # of this snapshot, same as everything else it draws from.
+        "unknown_config_key_count": (
+            getattr(config, "unknown_config_key_count", 0) if config is not None else 0
+        ),
         # #2285: session-scoped capability visibility + hook applicability toggles.
         # #3378: ``visibility_items`` is ``None`` when the session wires no visibility
         # seam (or it raised) and a possibly-empty LIST when it does — the renderer

--- a/tests/interfaces/test_config_warning_chrome_4194.py
+++ b/tests/interfaces/test_config_warning_chrome_4194.py
@@ -1,0 +1,182 @@
+"""Tier 2: #4194 — the bottom-chrome config-warning indicator.
+
+Owner condition: the interactive CUI must show SOMETHING when a
+``reyn.yaml``/``reyn.local.yaml``/``~/.reyn/config.yaml`` key was not
+applied — architect's live measurement found the existing
+``_warn_unknown_config_keys`` warning only ever reached a log file
+(``_setup_interactive_logging`` redirects all logs there), invisible to an
+operator running the interactive CUI. Architect's design ruling fixes three
+properties, form left to the implementer: ①doesn't scroll away with the
+conversation ②stays visible for as long as the condition holds ③directs the
+operator to ``reyn config validate`` for detail.
+
+No mocks of collaborators: a real ``ReynConfig`` (cheaply constructible —
+just ``ReynConfig(unknown_config_key_count=N)``), a real ``TextualChatApp``
+run headless via ``App.run_test`` (the same harness
+``test_conversation_chrome_separation.py`` already uses for chrome-geometry
+assertions).
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.config import ReynConfig
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.chrome import (
+    ConfigWarningLine,
+    config_warning_text,
+)
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import EventFrame
+from reyn.schemas.models import Event
+
+
+class _Transport(ClientTransport):
+    """Minimal real ClientTransport implementing the CURRENT full abstract
+    surface (test_conversation_chrome_separation.py's own stub predates
+    #3903/#4166's cancel_inflight()/has_session()/etc additions and would
+    no longer instantiate — this one is up to date)."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+
+    async def push_event(self, event: Event) -> None:
+        await self._queue.put(EventFrame(event))
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str) -> str:  # pragma: no cover
+        return ""
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return False
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def cancel_inflight(self) -> str:
+        return "nothing was running"
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+# ─── 1. config_warning_text — pure function ──────────────────────────────
+
+
+def test_config_warning_text_none_when_zero():
+    """Tier 2: a clean config (no unknown keys) shows nothing — the
+    indicator does not occupy a row for a no-op condition."""
+    assert config_warning_text(0) is None
+
+
+def test_config_warning_text_singular_and_plural():
+    """Tier 2: the count is legible English — "1 config key" not "1 config
+    keys" — and always names the fix command by name, matching architect's
+    ③ requirement (directs to `reyn config validate`)."""
+    assert config_warning_text(1) == "⚠ 1 config key not applied → reyn config validate"
+    assert config_warning_text(3) == "⚠ 3 config keys not applied → reyn config validate"
+
+
+# ─── 2. Real headless app — the indicator actually mounts (or doesn't) ───
+
+
+@pytest.mark.asyncio
+async def test_indicator_absent_on_a_clean_config():
+    """Tier 2b: accept-side sibling — a config with 0 unknown keys mounts
+    NO ConfigWarningLine at all (not merely hidden — see the widget's own
+    docstring for why absence, not hiding, is the design). Without this
+    test, an implementation that always shows a "0 keys" row would still
+    pass every other test in this file."""
+    config = ReynConfig(unknown_config_key_count=0)
+    app = TextualChatApp(transport=_Transport(), config=config)
+    async with app.run_test(size=(90, 24)):
+        assert len(app.query("ConfigWarningLine")) == 0
+
+
+@pytest.mark.asyncio
+async def test_indicator_mounts_and_shows_the_count():
+    """Tier 2: the owner's literal condition — a config with unknown keys
+    shows something in the interactive CUI, not just a log line. Positive
+    witness: the real mounted widget's text names the actual count."""
+    config = ReynConfig(unknown_config_key_count=2)
+    app = TextualChatApp(transport=_Transport(), config=config)
+    async with app.run_test(size=(90, 24)):
+        widget = app.query_one(ConfigWarningLine)
+        assert "2 config keys" in str(widget.content)
+        assert "reyn config validate" in str(widget.content)
+
+
+@pytest.mark.asyncio
+async def test_indicator_does_not_scroll_away_or_clip_the_conversation():
+    """Tier 2: architect's ①doesn't-scroll-away + the #4194 geometry
+    measurement's own safety claim — mounting the indicator does not
+    overlap or clip FlowView (the conversation pane), it simply takes one
+    row that FlowView's `1fr` sizing absorbs. Appending messages (so
+    FlowView actually has scrollable content) and re-checking the
+    indicator is still mounted and at a fixed, non-conversation-following
+    position is the closest a headless test gets to "does not scroll
+    away" — a row inside the conversation's own scroll region would move
+    with it; this one is a sibling outside that region."""
+    from textual_flowview import FlowView
+
+    from reyn.interfaces.inline.textual_chat import Composer
+    from reyn.runtime.outbox import OutboxMessage
+
+    config = ReynConfig(unknown_config_key_count=1)
+    app = TextualChatApp(transport=_Transport(), config=config)
+    async with app.run_test(size=(90, 24)) as pilot:
+        app.query_one(Composer).focus()
+        await pilot.pause()
+        indicator = app.query_one(ConfigWarningLine)
+        y_before = indicator.region.y
+        for i in range(6):
+            app.conversation.append(OutboxMessage(kind="agent", text=f"reply {i}"))
+        await pilot.pause()
+        flow = app.query_one(FlowView)
+        # No overlap: the indicator's row is entirely above or below FlowView's
+        # region, never inside its y-range.
+        flow_top, flow_bottom = flow.region.y, flow.region.y + flow.region.height
+        assert not (flow_top <= indicator.region.y < flow_bottom), (
+            f"indicator at y={indicator.region.y} overlaps FlowView "
+            f"[{flow_top}, {flow_bottom})"
+        )
+        # Still mounted at a stable position — did not get pushed off-screen
+        # or removed by the conversation growing.
+        assert app.query_one(ConfigWarningLine).region.y == y_before
+
+
+@pytest.mark.asyncio
+async def test_indicator_absent_when_config_is_none():
+    """Tier 2b: accept-side sibling for the pre-session/no-config shape —
+    ``TextualChatApp(config=None)`` (the default every other app test in
+    this package already constructs with) must not raise and must not
+    mount the indicator. Real production shape: a remote client or an
+    early construction window before config is threaded through."""
+    app = TextualChatApp(transport=_Transport())
+    async with app.run_test(size=(90, 24)):
+        assert len(app.query("ConfigWarningLine")) == 0


### PR DESCRIPTION
**[tui-coder]** — #4194: bottom-chrome config-warning indicator for unrecognized `reyn.yaml` keys.

## Why

Architect's live measurement (issue #4194 thread): #4174 T0's unknown-config-key warning only ever reached a log file — `_setup_interactive_logging` redirects all logs there, invisible to an operator running the interactive CUI. Owner condition: the interactive CUI must show something.

## Design (architect's ruling)

Fixes exactly THREE properties, form left to the implementer:
1. Doesn't scroll away with the conversation
2. Stays visible for as long as the condition holds
3. Directs the operator to `reyn config validate` for the 4-element detail (result / destination / full list / fix command) — this indicator carries NONE of that detail itself, only a count.

**Scope: policy tier only** (`reyn.yaml` / `reyn.local.yaml` / `~/.reyn/config.yaml`) — the same scope `reyn config validate` itself checks, so the indicator's own guidance is always answerable by the command it names (lead-coder's explicit scoping call). The hot-reload IN-set (`.reyn/*.yaml`) has its OWN separate unknown-key warning path `validate` does not cover — that remaining silence is real and tracked separately as **#4235**, not this PR.

## My first-measure (assigned before implementation)

Real-terminal geometry check via headless `App.run_test` at two sizes, before writing any widget code: a `Static(height:1)` sibling mounted after `MenuBar` is absorbed cleanly by `FlowView`'s `1fr` sizing at both 80×24 (18→17 rows) and 60×20 (13→12 rows) — no overlap, no clipping, every other chrome row just shifts down by one.

## What changed

- `loader._warn_unknown_config_keys` now returns the count (was `-> None`).
- `ReynConfig.unknown_config_key_count: int` — `schema_internal=True` (the existing, previously-unused opt-out mechanism): a runtime-computed fact, never an operator-settable key.
- `status._snapshot()` / `read_model.project_remote_snapshot()` carry the same field, consistent with every other config-derived snapshot key. Remote defaults to 0.
- `chrome.config_warning_text(count) -> str | None` — pure function, takes the count directly (fixed for the session lifetime, no per-frame snapshot needed).
- `chrome.ConfigWarningLine(Static)` — new top-level compose sibling. `bold`, not a colour — `palette.py`'s own stated invariant: `@attention@` is the ONLY semantic colour this CUI claims; an attribute leaves the hue to the terminal theme.
- `app.py`'s `compose()` conditionally yields it — ABSENT entirely on a clean config, not merely hidden.

## Verification

- Falsify-verified: reverted `chrome.py`/`app.py`, confirmed the whole new test module fails to import.
- Gate suite clean: `ruff`, `mypy_ratchet`, `test_tier_audit --strict`, `verify_module_docstrings`, `check_tests_path_literal_reference`, `mkdocs build --strict`.
- Targeted sweep: `tests/config/` + `tests/interfaces/` + `tests/hooks/` — 2074 passed, 1 skipped.

No JA doc mirror (CLAUDE.md rule 5 — no blanket obligation; nothing in the JA sibling is falsified by this addition).

## Test plan

- [x] `ruff check src tests` clean
- [x] `mypy_ratchet.py` clean (210/214 baselined, no new)
- [x] `test_tier_audit.py --strict` clean on new tests
- [x] `verify_module_docstrings.py` clean
- [x] `check_tests_path_literal_reference.py` clean
- [x] `mkdocs build --strict` clean
- [x] Targeted sweep: `tests/config/` + `tests/interfaces/` + `tests/hooks/` (2074 passed, 1 skipped)
- [x] Falsify-verified (whole test module fails to import without the widget)
- [ ] Visual/manual: none applicable per the standing waiver (owner ruling — visual gates don't block main merge; will confirm on `main` after landing)

part of #4194 (not closing — T3/T4/T5 rename PRs remain gated on this landing; the hot-reload IN-set remainder is #4235).
