### PR TITLE
feat(#4231 C): reyn config validate reports config keys disabled by another key's value

### DIFF
--- a/src/reyn/config/config_schema.py
+++ b/src/reyn/config/config_schema.py
@@ -304,6 +304,133 @@ def unknown_config_keys(
 
 
 # ---------------------------------------------------------------------------
+# #4231 (C): known keys DISABLED by another key's current value
+# ---------------------------------------------------------------------------
+
+
+@_dataclass(frozen=True)
+class DisabledByHint:
+    """A KNOWN, correctly-spelled config key whose value has no effect
+    under the CURRENT value of another key it depends on.
+
+    A DIFFERENT category than :class:`RenamedKeyHint` / :func:`unknown_config_keys`
+    (#4174 T0 handles unknown keys — a typo, or a key that never existed).
+    This one is for a key that IS real, IS spelled correctly, and is
+    genuinely read somewhere in the codebase — architect's #4231 ruling:
+    the discriminator for "does this deserve a check, or deletion" is
+    "is there at least one read path" (``universal_wrappers_enabled`` has
+    one — the ``universal-category`` scheme genuinely consumes it — vs.
+    #3907/#3962's fields that NO code ever read, which were deleted, not
+    documented-as-inert). A key that would ever fall into THIS category
+    but has zero read paths anywhere belongs back in the delete-it
+    discipline, not here.
+
+    Same 4-element warning discipline #4174 T0's own report already
+    established (architect, #4231): state the result plainly, name the
+    conflicting key (and ideally its current value), batch every finding
+    in one pass (never early-return), and give an actionable fix.
+    """
+
+    #: Plain statement of the result — "has no effect under the current
+    #: tool_use.scheme" — always shown.
+    note: str
+    #: The OTHER key this one's applicability depends on, dotted
+    #: (``"tool_use.scheme"``) — so the operator knows what to look at.
+    dependency_key: str
+    #: One concrete remedy — change the dependency, or drop the disabled
+    #: key. Never "this has no effect" alone (the #4179 lesson: name what
+    #: to do next, don't just report a state).
+    fix: str
+
+
+def _check_universal_wrappers_enabled_scheme_mismatch(
+    raw: dict,
+) -> "DisabledByHint | None":
+    """#4231: ``action_retrieval.universal_wrappers_enabled`` only affects
+    the ``universal-category`` ``tool_use.scheme`` — the OTHER schemes
+    (``enumerate-all`` the #1657 owner default, and ``retrieval``) have
+    their own, mutually-exclusive presentation mechanism and never read
+    it (``router_loop.py``'s ``base_tools()``: "the universal wrappers
+    OFF... enumerate-all adds catalog_entries ON TOP OF the wrappers,
+    INSTEAD").
+
+    Re-measured before writing this check (architect's own explicit
+    caveat on the #4231 ruling — "re-measure before implementing, don't
+    build a mechanism on an assumption"): ``universal_wrappers_enabled``
+    DOES have a real read path — ``RouterHostAdapter.
+    get_universal_wrappers_enabled()`` returns the live config value,
+    consumed by ``_category_exposure.build_category_exposure`` (imported
+    by ``universal_category.py``'s scheme, and nowhere else) to compute
+    real ``sp_facts`` differences (``search_actions_enabled``'s formula
+    changes under it). Confirmed via a full read-path trace, not assumed.
+
+    Fires ONLY when the raw file EXPLICITLY sets the flag to ``True``
+    (the resolved *default* is also ``True`` — firing on the unset
+    default would warn nearly every operator who never touched this key
+    at all, which is not what "explicit" means in architect's ruling)."""
+    action_retrieval = raw.get("action_retrieval")
+    if not isinstance(action_retrieval, dict):
+        return None
+    if action_retrieval.get("universal_wrappers_enabled") is not True:
+        return None
+    tool_use = raw.get("tool_use")
+    scheme = tool_use.get("scheme") if isinstance(tool_use, dict) else None
+    if scheme is None:
+        scheme = "enumerate-all"  # the #1657 owner default (execution.py's own)
+    if scheme == "universal-category":
+        return None
+    return DisabledByHint(
+        note=(
+            f"action_retrieval.universal_wrappers_enabled: true has no effect "
+            f"under tool_use.scheme: {scheme!r} — only the 'universal-category' "
+            f"scheme uses universal wrappers; {scheme!r} has its own, "
+            f"mutually-exclusive presentation mechanism."
+        ),
+        dependency_key="tool_use.scheme",
+        fix=(
+            "set tool_use.scheme: universal-category to make this flag apply, "
+            "or remove action_retrieval.universal_wrappers_enabled if you did "
+            "not intend to opt into the universal-category scheme."
+        ),
+    )
+
+
+#: #4231 (C): registered (key -> check) pairs, one per known
+#: dependency-disabled config knob. Deliberately a small, explicit
+#: registry rather than a general "declare key dependencies" framework —
+#: architect's own ruling scoped that broader mechanism to a SEPARATE,
+#: larger issue (other same-shaped knobs likely exist — embedding.* under
+#: embedding.enabled=false, offload.* under offload.enabled=false — but
+#: are UNENUMERATED; adding one here does not imply they're covered).
+_DISABLED_KEY_CHECKS: "dict[str, Any]" = {
+    "action_retrieval.universal_wrappers_enabled": (
+        _check_universal_wrappers_enabled_scheme_mismatch
+    ),
+}
+
+
+def disabled_config_keys(raw: "dict | None") -> "dict[str, DisabledByHint]":
+    """Return ``{dotted_key: DisabledByHint}`` for every KNOWN config key in
+    *raw* whose value is currently inert because of another key's value —
+    #4231 (C)'s "make the inconsistency speak" mechanism, the sibling of
+    :func:`unknown_config_keys` (#4174 T0) for a DIFFERENT defect class
+    (a real key, silently ignored under the current configuration, vs. a
+    key that was never real at all).
+
+    Collects every finding in one pass (never early-returns) — the SAME
+    "report all problems at once" discipline :func:`unknown_config_keys`
+    already established."""
+    if not isinstance(raw, dict):
+        return {}
+    result: "dict[str, DisabledByHint]" = {}
+    for key, check in _DISABLED_KEY_CHECKS.items():
+        hint = check(raw)
+        if hint is not None:
+            result[key] = hint
+    return result
+
+
+# ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 

--- a/src/reyn/interfaces/cli/commands/config.py
+++ b/src/reyn/interfaces/cli/commands/config.py
@@ -274,7 +274,10 @@ def _migrate_mcp(*, dry_run: bool = False) -> None:
 def _validate() -> None:
     """#4174 T0: report every unknown/renamed config key found in the
     operator-editable policy tier (reyn.yaml / reyn.local.yaml /
-    ~/.reyn/config.yaml).
+    ~/.reyn/config.yaml). #4231 (C): also report every KNOWN key whose
+    value is silently inert under another key's current value (a
+    DIFFERENT defect class — the key is real and correctly spelled, but
+    the configuration as a whole makes it a no-op).
 
     Uses ``build_policy_tier_config`` — the SAME construction
     ``load_config``'s own startup warning uses (architect's explicit
@@ -282,23 +285,39 @@ def _validate() -> None:
     a second hand-reconstructed merge). Exits 0 regardless of findings
     (owner ruling: warn, never hard-fail — this command REPORTS, it does
     not gate anything)."""
-    from reyn.config.config_schema import unknown_config_keys
+    from reyn.config.config_schema import disabled_config_keys, unknown_config_keys
     from reyn.config.loader import build_policy_tier_config
 
     merged = build_policy_tier_config()
     unknown = unknown_config_keys(merged)
-    if not unknown:
-        print("No unknown or renamed config keys found.")
+    disabled = disabled_config_keys(merged)
+
+    if not unknown and not disabled:
+        print("No unknown, renamed, or disabled-by-dependency config keys found.")
         return
 
-    print(f"Found {len(unknown)} unrecognized config key(s):\n")
-    for key, hint in sorted(unknown.items()):
-        print(f"  {key}")
-        if hint:
-            print(f"    -> {hint.note}")
-        else:
-            print("    -> not applied; see 'reyn config fields' for valid keys.")
-    print("\nRun 'reyn config migrate' to fix renamed keys automatically.")
+    if unknown:
+        print(f"Found {len(unknown)} unrecognized config key(s):\n")
+        for key, hint in sorted(unknown.items()):
+            print(f"  {key}")
+            if hint:
+                print(f"    -> {hint.note}")
+            else:
+                print("    -> not applied; see 'reyn config fields' for valid keys.")
+        print("\nRun 'reyn config migrate' to fix renamed keys automatically.")
+
+    if disabled:
+        if unknown:
+            print()
+        print(
+            f"Found {len(disabled)} config key(s) that are known but currently "
+            f"have no effect:\n"
+        )
+        for key, disabled_hint in sorted(disabled.items()):
+            print(f"  {key}")
+            print(f"    -> {disabled_hint.note}")
+            print(f"    -> depends on: {disabled_hint.dependency_key}")
+            print(f"    -> fix: {disabled_hint.fix}")
 
 
 def _migrate(*, dry_run: bool = False) -> None:

--- a/tests/config/test_4231_c_disabled_by_dependency_config_keys.py
+++ b/tests/config/test_4231_c_disabled_by_dependency_config_keys.py
@@ -1,0 +1,138 @@
+"""Tier 2: #4231 (C) — ``reyn config validate`` reports a KNOWN,
+correctly-spelled config key whose value is currently inert because of
+ANOTHER key's value (``disabled_config_keys`` /
+``_check_universal_wrappers_enabled_scheme_mismatch`` in
+``config_schema.py``).
+
+A DIFFERENT defect class than #4174 T0's ``unknown_config_keys`` (a typo
+or a key that never existed): here the key IS real and genuinely read
+somewhere — architect's own re-measurement (confirmed independently
+before writing this test, per the standing "don't build a mechanism on
+an assumption" instruction) traced ``action_retrieval.
+universal_wrappers_enabled`` through ``RouterHostAdapter.
+get_universal_wrappers_enabled()`` into
+``_category_exposure.build_category_exposure`` — imported ONLY by
+``universal_category.py``'s ``tool_use.scheme: universal-category`` cell,
+never by ``enumerate-all`` (the #1657 owner default) or ``retrieval``.
+So the flag is real, but silently a no-op under the default scheme —
+architect's own "advertised, and readable, but inert under the current
+config as a whole" class, which #3907/#3962's already-established
+"nobody ever reads it → delete" discipline does not cover.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.config.config_schema import disabled_config_keys
+
+# ── the pure primitive ───────────────────────────────────────────────────
+
+
+def test_explicit_true_under_the_default_scheme_is_flagged() -> None:
+    """Tier 2: the exact operator shape the issue names — the flag written
+    explicitly true, no tool_use.scheme (→ the enumerate-all default)."""
+    result = disabled_config_keys({"action_retrieval": {"universal_wrappers_enabled": True}})
+    assert "action_retrieval.universal_wrappers_enabled" in result
+    hint = result["action_retrieval.universal_wrappers_enabled"]
+    assert "enumerate-all" in hint.note
+    assert hint.dependency_key == "tool_use.scheme"
+    assert "universal-category" in hint.fix
+
+
+def test_explicit_true_under_universal_category_scheme_is_not_flagged() -> None:
+    """Tier 2: accept-side — the ONE scheme that actually reads the flag
+    must never trip the warning (a false positive here would teach
+    operators to ignore the report entirely, the same #4174 T0 concern)."""
+    result = disabled_config_keys({
+        "action_retrieval": {"universal_wrappers_enabled": True},
+        "tool_use": {"scheme": "universal-category"},
+    })
+    assert result == {}
+
+
+def test_explicit_true_under_retrieval_scheme_is_flagged() -> None:
+    """Tier 2: the SAME mismatch under the other non-wrappers scheme
+    (retrieval), not just the default — the check is keyed on "is the
+    scheme universal-category", not on "is it exactly enumerate-all"."""
+    result = disabled_config_keys({
+        "action_retrieval": {"universal_wrappers_enabled": True},
+        "tool_use": {"scheme": "retrieval"},
+    })
+    assert "action_retrieval.universal_wrappers_enabled" in result
+    assert "retrieval" in result["action_retrieval.universal_wrappers_enabled"].note
+
+
+def test_key_absent_entirely_is_not_flagged() -> None:
+    """Tier 2: regression guard — a config that never touches this key at
+    all produces no finding, even though the RESOLVED default is also
+    True (firing on the unset default would warn nearly every operator
+    who never touched this key — not what "explicit" means in
+    architect's ruling)."""
+    assert disabled_config_keys({}) == {}
+    assert disabled_config_keys({"action_retrieval": {}}) == {}
+
+
+def test_explicit_false_is_never_flagged() -> None:
+    """Tier 2: an operator who explicitly opted OUT is never told their
+    (already-inert, already-intentional) choice is inert."""
+    result = disabled_config_keys({
+        "action_retrieval": {"universal_wrappers_enabled": False},
+    })
+    assert result == {}
+
+
+# ── the reyn config validate CLI surface ─────────────────────────────────
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+@pytest.fixture()
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+    monkeypatch.setattr("reyn.config._find_project_root", lambda _cwd: tmp_path)
+    monkeypatch.setattr("reyn.config.loader._find_project_root", lambda _cwd: tmp_path)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_validate_reports_the_disabled_key_with_all_four_elements(project, capsys):
+    """Tier 2: the CLI wiring — reyn config validate's output carries the
+    SAME 4-element discipline #4174 T0 established (architect's explicit
+    requirement on #4231's ruling): the RESULT stated plainly, the
+    CONFLICTING key named, and a concrete FIX — not just 'this is
+    inert'."""
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _write_yaml(
+        project / "reyn.yaml",
+        "model: standard\naction_retrieval:\n  universal_wrappers_enabled: true\n",
+    )
+    _validate()
+    out = capsys.readouterr().out
+    assert "action_retrieval.universal_wrappers_enabled" in out
+    assert "no effect" in out
+    assert "tool_use.scheme" in out  # the named dependency
+    assert "universal-category" in out  # the concrete fix
+
+
+def test_validate_does_not_flag_universal_category_scheme(project, capsys):
+    """Tier 2: CLI accept-side — the correctly-paired config (scheme
+    actually set to universal-category) produces the clean report."""
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _write_yaml(
+        project / "reyn.yaml",
+        "model: standard\n"
+        "action_retrieval:\n  universal_wrappers_enabled: true\n"
+        "tool_use:\n  scheme: universal-category\n",
+    )
+    _validate()
+    out = capsys.readouterr().out
+    assert "No unknown, renamed, or disabled-by-dependency config keys found." in out

--- a/tests/interfaces/test_config_validate_migrate_command_4174.py
+++ b/tests/interfaces/test_config_validate_migrate_command_4174.py
@@ -41,13 +41,15 @@ def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 def test_validate_reports_no_findings_on_a_well_formed_config(project, capsys):
     """Tier 2: #4174 T0 accept-side — a real, valid reyn.yaml produces
-    'no unknown keys' output, not a false-positive warning."""
+    'no unknown keys' output, not a false-positive warning. #4231 (C)
+    widened the message when it added the disabled-by-dependency
+    category (a well-formed config trips neither)."""
     from reyn.interfaces.cli.commands.config import _validate
 
     _write_yaml(project / "reyn.yaml", "model: standard\nsandbox:\n  mode: strict\n")
     _validate()
     out = capsys.readouterr().out
-    assert "No unknown or renamed config keys found." in out
+    assert "No unknown, renamed, or disabled-by-dependency config keys found." in out
 
 
 def test_validate_reports_an_unrecognized_top_level_key(project, capsys):


### PR DESCRIPTION
**[e2e-coder]** — part of #4231 (architect's ruling: option (C), "make the inconsistency speak"). Design is architect's + lead-coder's own follow-up instructions.

## First hand: re-measured before implementing

Lead-coder's explicit first instruction: "(C) を書く前に、present() 側が本当に config を読んでいることを直接確かめてください" — architect's own ruling carried an explicit unmeasured caveat (if the wrappers-using scheme doesn't actually read the flag, this falls back to the #3907/#3962 delete class instead).

Traced the read path directly: `action_retrieval.universal_wrappers_enabled` → `RouterHostAdapter.get_universal_wrappers_enabled()` (a real config-derived value, not hardcoded) → `capability_visibility.py`'s `layer_ctx["univ_enabled"]` → `_category_exposure.build_category_exposure`'s `sp_facts["universal_wrappers_enabled"]` / `search_actions_enabled`'s formula — a genuine, observable difference. `_category_exposure` is imported **only** by `universal_category.py`'s `tool_use.scheme: universal-category` cell — never by `enumerate-all` (the #1657 owner default) or `retrieval`.

**Confirmed: this is a real, scoped knob (exclusive-by-design with `enumerate-all`'s own mechanism), not a dead one.** Architect's ruling holds — (C), not deletion.

## What

New category in `config_schema.py`, a sibling of #4174 T0's `unknown_config_keys` for a DIFFERENT defect class (a real, correctly-spelled key vs. a typo/removed one):

- `DisabledByHint(note, dependency_key, fix)` — same 4-element discipline T0 established (state the result plainly, name the conflicting key, batch every finding in one pass, give an actionable fix — not just "this is inert").
- `disabled_config_keys(raw)` — a small explicit registry (`_DISABLED_KEY_CHECKS`), deliberately **not** the general "declare key dependencies" framework — architect scoped that broader mechanism to its own, larger issue (other same-shaped knobs likely exist — `embedding.*`/`offload.*` under their own `.enabled` flags — unenumerated here, not claimed covered).
- Fires **only** when `universal_wrappers_enabled` is explicitly `true` in the raw file. The resolved default is *also* `true` — firing on the unset default would warn nearly every operator who never touched the key at all, which isn't what "explicit" means in the ruling.

Wired into `reyn config validate` (lead-coder's explicit destination — "作った本人なので新カテゴリはそこに乗る") as a second report block alongside T0's own.

## Falsify-verification

Forced the check to always fire regardless of scheme. Both accept-side tests (the correctly-paired `universal-category` config) go RED as predicted. Restored, confirmed all 18 GREEN.

## Gates (local)

- `ruff check` — clean
- `test_tier_audit.py --strict` — 18/18 OK
- `verify_module_docstrings.py` — OK
- `mypy_ratchet.py` — OK after a variable-name collision fix (two loops sharing a `hint` name confused mypy's flow narrowing across `RenamedKeyHint | None` vs `DisabledByHint` — renamed the second loop's variable, no new findings)
- `check_tests_path_literal_reference.py` — OK
- Broader regression sweep: `tests/config/` + `tests/interfaces/test_config_validate_migrate_command_4174.py` (167 passed)

## Test plan

- [x] New disabled-by-dependency test suite (unit + CLI level), falsify-verified RED→GREEN
- [x] Full local 5-gate battery green
- [x] `tests/config/` broad sweep green
- [x] Existing T0 CLI test updated for the new combined "no findings" message wording
- [ ] (Visual — N/A, no UI surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
