### PR TITLE
docs(#3987): narrow ADR-0038's Implemented claim — 2 pieces still unwired

### DIFF
--- a/docs/deep-dives/decisions/0038-user-facing-time-travel-rewind.md
+++ b/docs/deep-dives/decisions/0038-user-facing-time-travel-rewind.md
@@ -5,6 +5,15 @@ are production (see `docs/feature-map.md` § Time-Travel / Rewind); concurrent-l
 is owner-rejected out-of-scope. Authored design-first for issue
 #1533; flow-trace verified by docs-maintainer (5/5 seams); ADR + plan reviewed and
 signed off by lead-coder.
+**Status correction** (2026-08-11, docs-maintainer): "Implemented" above does not
+cover **2b's tree-layout UI** (`branch_tree.py::build_branch_tree_rows` has no
+production caller — only its own unit test) or **D5's retention-window config**
+(`RetentionPolicy.from_config` has no caller anywhere in `src/`; the sole
+construction site always uses the bare default). Both re-verified unwired as of
+this correction, against `origin/main`. The "5/5 seams" flow-trace above verified
+where a rewind must hook into existing code, not end-to-end config/UI wiring for
+these two — the two claims read together implied more than the trace established.
+Tracked in #3987; current state in `docs/feature-map.md`.
 **Track**: Core state-model — successor seam to ADR-0001 (WAL+snapshot),
 ADR-0002 (forward-replay), ADR-0023 (PlanSnapshot).
 **Owner status**: design judgments co-designed + confirmed with owner (issue


### PR DESCRIPTION
**[docs-maintainer]** — #3987、architectの裁定(判別子: 決定そのものはimmutable、世界についての事実の主張=status/日付は規則の内側)に従い、ADR-0038のstatus行を訂正しました。

## 形

- `Implemented`を消さず、主張の範囲を狭める(未配線2件を名指しで除外)
- **本文は1バイトも変更していません**(`git diff`で確認済み — 既存3行は無変更、新規段落を追加したのみ)
- supersedeはしていません(決定は何も変わっていないため、architectの裁定通り)

## 追加した段落

再検証(origin/main、本日)に基づき、2b(`build_branch_tree_rows`の production caller 無し)とD5(`RetentionPolicy.from_config`のcaller 無し)がImplementedの主張に含まれないことを明記。「5/5 seams」が検証したのはrewindのhook point(既存コードのどこに触るか)であって、config/UI配線のend-to-endではないことも明記 — #3987がまさにこの読み違いを追跡した経緯です。

## Test plan

- [x] `git diff`で既存本文の非変更を確認(status行への追記のみ)
- [x] `mkdocs build -f .mkdocs/mkdocs.yml --strict` — abortなし
- [x] `python scripts/check_doc_anchors.py` — exit 0
- [x] `ruff check src tests` — All checks passed(src/tests差分なし)
- [x] closing-keyword trap を commit message・本PR body両方に適用 — hit なし
- N/A: `test_tier_audit.py` / `verify_module_docstrings.py` / `mypy_ratchet.py` / `check_tests_path_literal_reference.py` — 対象ファイルなし
- [ ] Visual — N/A(doc のみ)

part of #3987(issueはwiring追跡として引き続きopenのまま)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
