### PR TITLE
feat(#4223): remove inline/auto from chat.render_mode, keep 2 values

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -448,7 +448,7 @@ pane's two gutter columns' start state.
 
 ```yaml
 chat:
-  render_mode: alt-screen # interactive chat renderer: alt-screen (default) | inline | plain | auto
+  render_mode: alt-screen # interactive chat renderer: alt-screen (default) | plain
   reasoning:
     continuity: true      # persist reasoning to history + replay recent turns
     display: true         # show reasoning in the UI (TUI + web, collapsible)
@@ -470,11 +470,13 @@ terminal.
 | Value | Behaviour |
 |-------|-----------|
 | `alt-screen` | **Default.** Full-screen Textual (alt-screen driver). Terminal scrollback is auto-saved on enter and restored on exit; the previous conversation is rebuilt from `history.jsonl` on restart. This is the recommended mode. |
-| `inline` | Legacy bounded inline driver — keeps your pre-launch scrollback in place above a bounded region. **Caveat**: upstream reports Textual inline-driver bugs here (on resize old frames stack, and the conversation pane can collapse to ~1 line), but reyn's own live-TTY integration did not reproduce the resize-stacking bug across 4+ resizes in a real terminal ([witness](https://github.com/tya5/reyn/pull/3291#issuecomment-5081647531)) — treat this mode as not verified-broken but also not verified-clean. Kept as an escape hatch for users who prefer scrollback-in-place; `alt-screen` remains the recommended default. |
 | `plain` | Force the plain line-based renderer (`ConsoleChatRenderer`, no Textual), genuinely equivalent to `--cui` — same renderer and same input-loop driver, not just the input driver. |
-| `auto` | Resolve to `alt-screen` on a TTY (behaviourally identical to `alt-screen` given the non-TTY→`plain` guard). |
 
-An unrecognised value warns and falls back to `alt-screen`.
+An unrecognised value — including a stale `inline` or `auto` from before this
+table was narrowed to two values (owner instruction, `inline`'s legacy
+bounded driver was removed; `auto` was behaviourally identical to
+`alt-screen` and carried no distinct behaviour) — warns and falls back to
+`alt-screen`.
 
 ### `chat.gutters` fields
 

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -577,30 +577,27 @@ class ReasoningConfig:
     recent_turns: int = 3
 
 
-# #3273 (#3285/#3286): the interactive chat renderer/driver selection. The
-# Textual conversation-pane app has two driver modes; ``plain`` forces the
+# #3273 (#4223 removed ``inline``/``auto`` — owner instruction, 2026-08-11):
+# the interactive chat renderer/driver selection. The Textual conversation-
+# pane app has ONE driver mode (full-screen alt-screen); ``plain`` forces the
 # ConsoleChatRenderer path even on a TTY.
 #
-# - ``alt-screen`` (DEFAULT): full-screen Textual (alt-screen driver). Sidesteps
-#   the two upstream inline-driver bugs — stale frames stacking on resize (#3285)
-#   and the pane collapsing to ~1 line (#3286) — and auto-saves/restores terminal
-#   scrollback on enter/exit.
-# - ``inline``: the legacy bounded inline driver, kept as an escape hatch for
-#   users who prefer their pre-launch scrollback preserved in place above the
-#   region. CAVEAT: upstream reports the Textual inline-driver bugs #3285
-#   (resize stacking) and #3286 (pane collapse) here, but reyn's own live-TTY
-#   integration did NOT reproduce #3285 across 4+ resizes in a real terminal
-#   (https://github.com/tya5/reyn/pull/3291#issuecomment-5081647531) — treat
-#   this mode as not verified-broken but also not verified-clean; it is still
-#   not the recommended default.
+# - ``alt-screen`` (DEFAULT): full-screen Textual (alt-screen driver).
+#   Auto-saves/restores terminal scrollback on enter/exit.
 # - ``plain``: force the plain ConsoleChatRenderer (no Textual), equivalent to
 #   ``--cui`` (#3292: the renderer selection in ``chat.py`` forces this too,
 #   not only the input-driver choice ``client_driver.resolve_render_mode``
 #   makes — genuine equivalence, not a hybrid).
-# - ``auto``: resolve to ``alt-screen`` on a real TTY (identical to ``alt-screen``
-#   given the TTY guard, which falls any interactive mode back to ``plain`` off a
-#   TTY); provided as the Codex-style ``auto/always/never`` affordance.
-CHAT_RENDER_MODES = ("alt-screen", "inline", "plain", "auto")
+#
+# #4223 removed the legacy bounded ``inline`` driver (upstream Textual bugs
+# #3285/#3286 — reyn's own live-TTY integration reproduced #3286 but did NOT
+# reproduce #3285 across 4+ resizes) and ``auto`` (behaviourally IDENTICAL to
+# ``alt-screen`` given the TTY guard — a name-only third option, no distinct
+# behaviour to preserve). An operator with a stale ``render_mode: inline`` or
+# ``render_mode: auto`` in their config is not broken: :func:`_build_render_mode`
+# below already warns-and-falls-back to ``alt-screen`` on any unrecognized
+# value, the same graceful path an ordinary typo already took.
+CHAT_RENDER_MODES = ("alt-screen", "plain")
 
 
 @dataclass
@@ -634,14 +631,13 @@ class ChatConfig:
     ``gutters`` (#3352): the TTY conversation pane's per-side gutter start
     state — see :class:`GutterConfig`.
 
-    ``render_mode`` (#3273): selects the interactive chat renderer/driver —
-    ``alt-screen`` (default, full-screen), ``inline`` (legacy bounded driver;
-    upstream reports bugs #3285/#3286 there, not reproduced live in reyn's own
-    integration — see the ``CHAT_RENDER_MODES`` comment above), ``plain``
-    (force ``ConsoleChatRenderer``, genuine ``--cui`` equivalence, #3292), or
-    ``auto`` (resolve to alt-screen on a TTY). A non-TTY session always falls
-    back to ``plain`` regardless of this value (the interactive Textual drivers
-    need a real terminal).
+    ``render_mode`` (#3273, narrowed to 2 values by #4223): selects the
+    interactive chat renderer/driver — ``alt-screen`` (default, full-screen)
+    or ``plain`` (force ``ConsoleChatRenderer``, genuine ``--cui``
+    equivalence, #3292). A non-TTY session always falls back to ``plain``
+    regardless of this value (the interactive Textual driver needs a real
+    terminal). See the ``CHAT_RENDER_MODES`` comment above for why the
+    former ``inline``/``auto`` values were removed.
 
     ``neutralize_body`` (#3318): opt-in ESC/OSC-control-sequence stripping on
     the agent-reply / tool-result BODY text (owner ruling B — default OFF,
@@ -668,7 +664,7 @@ class ChatConfig:
     """
     compaction: CompactionConfig = field(default_factory=CompactionConfig)
     reasoning: ReasoningConfig = field(default_factory=ReasoningConfig)
-    render_mode: Literal["alt-screen", "inline", "plain", "auto"] = "alt-screen"
+    render_mode: Literal["alt-screen", "plain"] = "alt-screen"
     gutters: GutterConfig = field(default_factory=GutterConfig)
     neutralize_body: bool = False
     image_url_schemes: "list[str]" = field(default_factory=list)

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -315,8 +315,9 @@ def _renderer_is_interactive(*, is_interactive: bool, render_mode: str) -> bool:
     (https://github.com/tya5/reyn/pull/3291#issuecomment-5081647531). ``plain``
     now forces the SAME ``ConsoleChatRenderer`` a real ``--cui`` invocation
     gets — genuine equivalence, not a doc-only claim. Every other
-    ``render_mode`` value (``alt-screen`` / ``inline`` / ``auto``, or an
-    already-defaulted unknown value) leaves ``is_interactive`` untouched.
+    ``render_mode`` value (``alt-screen``, or an already-defaulted unknown
+    value — #4223 removed the ``inline``/``auto`` values this comment used
+    to also name) leaves ``is_interactive`` untouched.
     """
     return is_interactive and render_mode != "plain"
 

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -4302,10 +4302,14 @@ async def run_textual_chat(
     scrollback-preservation rationale that originally motivated inline is now
     redundant — alt-screen auto-saves/restores terminal scrollback on
     enter/exit, and Phase 5 restore rebuilds the conversation from
-    ``history.jsonl`` on restart. ``inline=True`` remains selectable as an
-    escape hatch (``chat.render_mode: inline``) for scrollback-preferring
-    users; ``alt-screen`` stays the recommended default regardless. Returns so
-    the driver's caller can tear the transport down + print the cost summary.
+    ``history.jsonl`` on restart. This ``inline: bool`` PARAMETER is
+    unchanged and still selectable by a caller that passes it explicitly;
+    #4223 removed ONLY the ``chat.render_mode: inline`` CONFIG value that
+    used to drive it here (owner instruction — the config-facing escape
+    hatch, not this function's own parameter, which #4223's own invariant
+    left untouched). ``alt-screen`` stays the recommended default
+    regardless. Returns so the driver's caller can tear the transport down
+    + print the cost summary.
     """
     # #3671: the framework's own startup begins here — terminal setup, first
     # layout, first paint. Everything before it is reyn assembling things;

--- a/src/reyn/interfaces/repl/client_driver.py
+++ b/src/reyn/interfaces/repl/client_driver.py
@@ -48,9 +48,12 @@ logger = logging.getLogger(__name__)
 def resolve_render_mode(mode: str, *, is_tty: bool) -> str:
     """Resolve a configured ``chat.render_mode`` + TTY presence to a concrete path.
 
-    Returns one of ``"alt-screen"``, ``"inline"``, ``"plain"`` — the three
-    physical render paths (the first two are the Textual conversation-pane app's
-    driver modes; the last is the plain :class:`ChatRenderer`).
+    Returns one of ``"alt-screen"``, ``"plain"`` — the two physical render
+    paths (the first is the Textual conversation-pane app's one driver mode;
+    the second is the plain :class:`ChatRenderer`). #4223 removed the legacy
+    ``"inline"`` bounded driver and the ``"auto"`` config value (owner
+    instruction — the latter was behaviourally IDENTICAL to ``"alt-screen"``
+    given the TTY guard below, a name-only third option).
 
     The TTY guard is universal: a non-TTY session (piped, CI, sandbox with no
     real terminal, or a host where alt-screen would silently no-op) can never
@@ -64,24 +67,24 @@ def resolve_render_mode(mode: str, *, is_tty: bool) -> str:
     defensive fallback for any caller that reaches here with an app-input
     renderer despite a ``"plain"`` config. The net effect (renderer forced
     Console + this fallback) is genuine ``--cui`` equivalence, not a hybrid.
-    ``"inline"`` selects the legacy bounded inline driver — upstream reports
-    resize-frame-stacking (#3285) and pane-collapse (#3286) there, but reyn's
-    live-TTY integration did NOT reproduce #3285 across 4+ resizes in a real
-    terminal (tui-coder,
-    https://github.com/tya5/reyn/pull/3291#issuecomment-5081647531); treat
-    ``inline`` as **not verified-broken** here but **also not verified-clean**
-    — re-check live before citing either claim. ``"auto"`` and ``"alt-screen"``
-    both resolve to ``"alt-screen"`` (full-screen). An unrecognised mode is
-    treated as the ``alt-screen`` default — config parsing already
-    validates+warns, this is a belt-and-braces fallback.
+    Any unrecognised mode (including a stale ``"inline"``/``"auto"`` left
+    over in an operator's config after #4223) is treated as the
+    ``"alt-screen"`` default — config parsing already validates+warns, this
+    is a belt-and-braces fallback.
     """
     if not is_tty:
         return "plain"
     if mode == "plain":
         return "plain"
-    if mode == "inline":
-        return "inline"
-    # "alt-screen", "auto", or any unexpected value → full-screen alt-screen.
+    # #4223: "inline" removed. "alt-screen" or any unexpected value (a stale
+    # "inline"/"auto" left over in an operator's config, or anything else)
+    # → full-screen alt-screen — the SAME fall-through this line already
+    # provided for "auto"/unexpected before #4223, deliberately kept wide
+    # rather than narrowed to `if mode == "alt-screen":` (architect's
+    # invariant, #4223: narrowing this line removes the belt half of the
+    # belt-and-braces pairing with `_build_render_mode`'s own warn-fallback
+    # — an unexpected value that slips past config validation would then
+    # have nowhere to land).
     return "alt-screen"
 
 
@@ -108,9 +111,10 @@ async def run_chat_client(
 ) -> None:
     """Input-driver selection + (plain) banner/output loop + wait + teardown.
 
-    When the renderer ``uses_app_input()``, ``chat.render_mode`` (#3273) +
-    ``is_tty`` are resolved by :func:`resolve_render_mode` to one of three paths:
-    ``alt-screen`` / ``inline`` (both the Textual conversation-pane app
+    When the renderer ``uses_app_input()``, ``chat.render_mode`` (#3273,
+    narrowed to 2 values by #4223) + ``is_tty`` are resolved by
+    :func:`resolve_render_mode` to one of two paths: ``alt-screen`` (the
+    Textual conversation-pane app
     :func:`~reyn.interfaces.inline.textual_chat.run_textual_chat`, which owns
     both input and output and drains ``transport.frames()`` itself — imported
     LAZILY here so the flowview/textual dependency is touched on that path only)
@@ -159,12 +163,17 @@ async def run_chat_client(
             with stage("client-prep:tui-import"):
                 from reyn.interfaces.inline.textual_chat import run_textual_chat  # noqa: PLC0415
             mark_tui_import_done()
+            # #4223: `resolve_render_mode` can no longer return "inline" (the
+            # config value was removed), so `resolved` here is always
+            # "alt-screen" — no `inline=` kwarg to compute; `run_textual_chat`'s
+            # own `inline: bool = False` default already selects alt-screen
+            # (that parameter and its behavior are untouched, #4223's
+            # invariant — see the function's own docstring).
             await run_textual_chat(
                 transport=transport,
                 read_model=read_model,
                 agent_name=agent_name,
                 config=config,
-                inline=(resolved == "inline"),
             )
             return
 

--- a/tests/interfaces/test_chat_render_mode_3273.py
+++ b/tests/interfaces/test_chat_render_mode_3273.py
@@ -2,15 +2,20 @@
 
 The #3273 TUI pivot makes the interactive chat renderer/driver operator-selectable
 instead of hardcoding one render mode (charter "no uncustomizable hardcoded
-choices"). Two OS invariants are pinned here:
+choices"). #4223 (owner instruction, 2026-08-11) narrowed the declared values
+from four to two — ``inline`` (the legacy bounded Textual driver, upstream
+bugs #3285/#3286) and ``auto`` (behaviourally identical to ``alt-screen``
+given the TTY guard below, a name-only third option) are gone. Two OS
+invariants are pinned here:
 
-- **config parse**: ``chat.render_mode`` accepts the four declared values
-  (``alt-screen`` default / ``inline`` / ``plain`` / ``auto``); an unknown value
-  falls back to the ``alt-screen`` default rather than aborting or silently
-  selecting a bogus path.
+- **config parse**: ``chat.render_mode`` accepts the two declared values
+  (``alt-screen`` default / ``plain``); an unknown value — including a
+  stale ``inline``/``auto`` left over from before #4223 — falls back to the
+  ``alt-screen`` default rather than aborting or silently selecting a
+  bogus path.
 - **resolution + TTY guard**: :func:`resolve_render_mode` maps
-  ``(mode, is_tty)`` to one of the three physical paths. A non-TTY session ALWAYS
-  resolves to ``plain`` regardless of mode (the interactive Textual drivers need a
+  ``(mode, is_tty)`` to one of the two physical paths. A non-TTY session ALWAYS
+  resolves to ``plain`` regardless of mode (the interactive Textual driver needs a
   real terminal — this is the guard that keeps CI / piped / sandbox paths off the
   alt-screen driver). On a TTY each mode routes to its own path.
 - **renderer selection (#3292)**: :func:`~reyn.interfaces.cli.commands.chat.
@@ -48,7 +53,7 @@ def test_render_mode_default_is_alt_screen() -> None:
 
 @pytest.mark.parametrize("mode", CHAT_RENDER_MODES)
 def test_render_mode_each_declared_value_parses(mode: str) -> None:
-    """Tier 2: each of the four declared values round-trips through the parser."""
+    """Tier 2: each of the two declared values round-trips through the parser."""
     assert _build_chat_config({"render_mode": mode}).render_mode == mode
     # And still parses when a sibling compaction block is present (the two parse
     # independently).
@@ -66,21 +71,46 @@ def test_render_mode_unknown_value_falls_back_to_default() -> None:
         assert _build_chat_config({"render_mode": 123}).render_mode == "alt-screen"
 
 
+def test_render_mode_stale_inline_or_auto_falls_back_to_default() -> None:
+    """Tier 2: #4223 — an operator whose config still says ``render_mode:
+    inline`` or ``render_mode: auto`` from before #4223 removed those values
+    is not broken by the removal: they hit the SAME unknown-value
+    warn-and-fall-back path an ordinary typo already took (config parsing
+    treats a former-valid, now-removed value identically to one that was
+    never valid — there is no separate "used to work" carve-out)."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert _build_chat_config({"render_mode": "inline"}).render_mode == "alt-screen"
+        assert _build_chat_config({"render_mode": "auto"}).render_mode == "alt-screen"
+
+
 @pytest.mark.parametrize("mode", ["alt-screen", "inline", "plain", "auto", "bogus"])
 def test_non_tty_always_resolves_plain(mode: str) -> None:
-    """Tier 2: the universal TTY guard — no configured mode can enter an
-    interactive Textual driver without a real terminal; every mode → plain."""
+    """Tier 2: the universal TTY guard — no mode string can enter an
+    interactive Textual driver without a real terminal; every mode → plain.
+    ``resolve_render_mode`` itself stays permissive of any string input
+    (config-level validation is a separate layer, see
+    ``_build_render_mode``'s own tests above) — ``inline``/``auto`` are
+    included here as arbitrary strings, not as claims they are still valid
+    config values post-#4223."""
     assert resolve_render_mode(mode, is_tty=False) == "plain"
 
 
 def test_tty_resolution_routes_each_mode() -> None:
-    """Tier 2: on a TTY, each mode routes to its own physical path — alt-screen
-    and auto to full-screen alt-screen, inline to the legacy bounded driver, plain
-    to the plain renderer. An unexpected value defaults to alt-screen."""
+    """Tier 2: on a TTY, ``alt-screen`` routes to full-screen alt-screen and
+    ``plain`` to the plain renderer — the two live paths post-#4223. Every
+    OTHER string (a former-valid ``inline``/``auto``, or anything else
+    unexpected) falls through to ``alt-screen``, the SAME belt-and-braces
+    default `resolve_render_mode`'s own docstring describes — #4223
+    deliberately did NOT narrow this fall-through (architect's invariant:
+    narrowing it to `if mode == "alt-screen":` would remove the belt half
+    of its pairing with `_build_render_mode`'s own warn-fallback)."""
     assert resolve_render_mode("alt-screen", is_tty=True) == "alt-screen"
-    assert resolve_render_mode("auto", is_tty=True) == "alt-screen"
-    assert resolve_render_mode("inline", is_tty=True) == "inline"
     assert resolve_render_mode("plain", is_tty=True) == "plain"
+    # Former-valid values, now removed (#4223) — same fall-through as any
+    # other unexpected string, not a special "used to be inline" case.
+    assert resolve_render_mode("auto", is_tty=True) == "alt-screen"
+    assert resolve_render_mode("inline", is_tty=True) == "alt-screen"
     # Belt-and-braces: an unvalidated/unexpected mode on a TTY → alt-screen default.
     assert resolve_render_mode("something-else", is_tty=True) == "alt-screen"
 


### PR DESCRIPTION
**[tui-coder]** —

Owner instruction (#4223): `chat.render_mode` narrows from 4 declared
values to 2 (`alt-screen` default / `plain`). `"inline"` (the legacy
bounded Textual driver, upstream bugs #3285/#3286) and `"auto"`
(behaviourally identical to `alt-screen` given `resolve_render_mode`'s
TTY guard — a name-only third option) are removed.

## What changed

- `config/chat.py`: `CHAT_RENDER_MODES` narrowed to `("alt-screen",
  "plain")`; `ChatConfig.render_mode` `Literal` narrowed to match;
  docstrings rewritten.
- `interfaces/repl/client_driver.py`: `resolve_render_mode`'s single
  `if mode == "inline": return "inline"` branch removed. The trailing
  `return "alt-screen"` fall-through is **deliberately not narrowed**
  (architect's invariant: narrowing it to `if mode == "alt-screen":`
  would remove the belt half of its pairing with `_build_render_mode`'s
  own warn-fallback — an unexpected value that slips past config
  validation would then have nowhere to land). A stale `inline`/`auto`
  left in an operator's config from before #4223 now falls through to
  `alt-screen`, same as any other unrecognised string.
  `run_chat_client`'s call site no longer computes an `inline=` kwarg —
  `run_textual_chat`'s own `inline: bool = False` default already
  selects alt-screen.
- `interfaces/cli/commands/chat.py`: `_renderer_is_interactive`'s
  docstring updated to drop the inline/auto mention.
- `interfaces/inline/textual_chat/app.py`: **ONE docstring sentence**
  in `run_textual_chat`. This is the only touch inside `textual_chat/`,
  the directory architect's invariant said not to touch for #4223.
  Judged **outside the scope of that invariant, not a violation of
  it** (lead-coder ruling, requested before making this edit): the
  invariant is a condition for not changing *behavior*; this sentence
  asserted a config value (`chat.render_mode: inline`) that no longer
  exists after this PR, and CLAUDE.md's doc-drift hard rule requires
  fixing a falsified doc claim in the same PR. **Zero behavior
  change** — the `inline: bool` parameter and all its behavior are
  completely untouched; only the sentence describing the (now-removed)
  config escape hatch was rewritten to describe the parameter's own
  unchanged default-`False` selectability instead.
- `tests/interfaces/test_chat_render_mode_3273.py`: rewritten for 2
  values; added `test_render_mode_stale_inline_or_auto_falls_back_to_default`;
  `test_tty_resolution_routes_each_mode` rewritten to assert
  `"inline"`/`"auto"` now fall through to `"alt-screen"` like any other
  unrecognised string (falsify-verified genuinely RED against the
  pre-change `resolve_render_mode`).
- `docs/reference/config/reyn-yaml.md`: `chat.render_mode` table
  narrowed to 2 rows, YAML example comment updated.
  (`reyn-yaml.ja.md` has no such table — checked, no edit needed,
  CLAUDE.md rule 5.)

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python3 scripts/mypy_ratchet.py` — clean (210/214 baselined, no new)
- [x] `python3 scripts/test_tier_audit.py --strict tests/interfaces/test_chat_render_mode_3273.py` — 11 OK, 0 errors
- [x] `python3 scripts/verify_module_docstrings.py <changed src files>` — clean
- [x] `python3 scripts/check_tests_path_literal_reference.py` — clean
- [x] Falsify-verify: stashed the source diff, confirmed 2 of the
  render-mode tests genuinely fail RED against the pre-#4223 code
  (asserting the old `"inline"` return value), restored.
- [x] Targeted regression sweep on a freshly synced `main`:
  `tests/config/ tests/interfaces/ -k "chat or render or repl or
  client_driver"` → 424 passed, 0 failed.
- [x] (Manual/Visual, tui-coder personally, not delegated) real-terminal
  check via tmux + a live `reyn chat` process with `chat.render_mode:
  alt-screen` configured: full alt-screen chrome renders correctly
  (welcome banner, composer, menu bar, status line); forced a pane
  resize and confirmed reflow with no frame-stacking or 1-line-collapse
  — flowview/gutter/blink (#3283) stays byte-identical, architect's
  stated acceptance condition.

part of #4223

🤖 Generated with [Claude Code](https://claude.com/claude-code)
