### PR TITLE
fix(#4193): remove a false counter-example from OpContext.ephemeral's comment

### DIFF
--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -256,11 +256,9 @@ class OpContext:
     #
     # NOT a `background` field, deliberately (architect/lead-coder ruling,
     # #3903 issue thread, 2026-08-11): ephemeral and background are NOT the
-    # same predicate. `spawn_ephemeral_session` is fire-and-forget
+    # same predicate. `spawn_session`'s tool dispatch is fire-and-forget
     # regardless of mode, so a PERSISTENT spawn is also unwaited-on and
-    # still gets the foreground pair here (tracked gap, #4193) — and
-    # `run_pipeline_attached`'s ephemeral driver session IS attached
-    # (foreground, someone is waiting) yet is still ephemeral. A single
+    # still gets the foreground pair here (tracked gap, #4193). A single
     # bool cannot represent both axes correctly, so this field carries only
     # what it actually measures. Direction of the implication this field
     # licenses: "an ephemeral exec gets the background timeout pair" is
@@ -268,6 +266,18 @@ class OpContext:
     # reader who inverts that direction will misjudge the persistent-spawn
     # gap as already covered. False by default (direct/test construction,
     # non-chat OpContext).
+    #
+    # #4193 co-vet correction (2026-08-11, docs-maintainer): an earlier
+    # revision of this comment claimed `run_pipeline_attached`'s driver
+    # session was "ephemeral yet attended" as a second counter-example.
+    # Verified false by direct trace: `_spawn_pipeline_driver_session`
+    # (`session_api.py`) always spawns with `mode="persistent"` (so the
+    # crash-recovery re-wake scan can find it), and `_ephemeral` is set
+    # ONLY at `mode == "ephemeral"`'s one assignment site
+    # (`registry.py`'s `spawn_session_recorded`). That driver session is
+    # therefore never ephemeral — it correctly gets the foreground pair
+    # (attached ⇒ someone is waiting), for the ordinary reason a plain
+    # boolean read would suggest, not despite one.
     ephemeral: bool = False
 
     # #1800 slice 5c: the awaited HookDispatcher (the Session's instance, with the


### PR DESCRIPTION
**[docs-maintainer]** — #4193、コードのみのコメント修正です(挙動変更なし)。lead-coderの裁定に従い、`context.py:262-263`の偽の反例を削除し訂正しました。

## 確認済み

```
_spawn_pipeline_driver_session (session_api.py:474)
  spawn_session_recorded(mode="persistent") ── crash recovery re-wake目的で常にpersistent
Session._ephemeral 代入 (registry.py:3099)
  if mode == "ephemeral": のみ ── 唯一の代入箇所
```

∴ `run_pipeline_attached`のdriver sessionは一度もephemeralになったことがなく、前景timeoutが
当たるのは「attached=待たれているから」という通常の理由であって、「ephemeralなのに」ではありません。

①(persistent spawnの不整合、issueの本題)の記述はそのまま残しています。

## Test plan

- [x] `ruff check src/reyn/core/op_runtime/context.py` — All checks passed
- [x] `python scripts/verify_module_docstrings.py src/reyn/core/op_runtime/context.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK(210/214 baselined、未変更)
- [x] `pytest tests/core/test_op_sandboxed_exec.py -q` — 28 passed
- [x] closing-keyword trap を commit message・本PR body両方に適用 — hit なし
- N/A: `test_tier_audit.py` / `check_tests_path_literal_reference.py` — テストファイル変更なし
- [ ] Visual — N/A(コメントのみ)

part of #4193

🤖 Generated with [Claude Code](https://claude.com/claude-code)
