### PR TITLE
ci(#4239): run the required checks on merge_group too (must land before enabling the queue)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,16 @@ on:
   push:
     branches: [main]
   pull_request:
+  # #4239: the merge queue evaluates required checks on a synthetic
+  # `merge_group` ref (main + the queued PRs), NOT on the PR branch — a
+  # required check that never fires there leaves every queued PR waiting
+  # forever. Only the 4 REQUIRED contexts live in this workflow (pytest
+  # 3.11/3.12, ruff, test-tier audit), so this trigger is the whole of what
+  # the queue needs. The steps that branch on `github.event_name ==
+  # "pull_request"` fall through to their full-tree arm here, which is the
+  # correct behaviour for a merge group: there is no single "base" PR to
+  # scope a changed-files diff against.
+  merge_group:
 
 jobs:
   test:


### PR DESCRIPTION
**[lead-coder]** — part of #4239. **Must land BEFORE the merge queue is enabled** — see the ordering note below.

## Why

The merge queue evaluates required status checks on a synthetic `merge_group` ref (main + the queued PRs), **not** on the PR branch. A required context that never fires there leaves **every queued PR waiting forever**. So the trigger has to exist first.

```
required contexts (measured: gh api …/branches/main/protection)
   pytest (Python 3.11) / pytest (Python 3.12) / ruff / test-tier audit
   ★all 4 live in .github/workflows/test.yml
∴ this one `merge_group:` line is the whole of what the queue needs
```

The other 12 workflows stay `pull_request`-only on purpose — they are **not** required contexts, and they still run on each PR before it is enqueued.

## The two conditional steps

`test-tier audit` and `module-docstring narrative check` branch on `github.event_name == "pull_request"` to scope themselves to changed files. On a merge group they fall through to the **full-tree arm** — which is correct, not a fallback accident: a merge group has no single base PR to diff against, and the full-tree arm is the same invariant net a push to main already runs (measured share: ~7s and ~2.3s).

## Ordering (owner-approved plan)

```
1. ★this PR lands (normal path, current serialized flow)
2. then  branch protection: enable the merge queue
```

Doing 2 before 1 is the footgun this PR exists to avoid.

## Test plan
- [x] `on:` block parses (workflow YAML syntax) — checked by GitHub on push
- [x] No behavioural change for `push` / `pull_request` events (trigger added, nothing removed)
- N/A ruff / pytest / mypy — CI config only, no Python touched
