### PR TITLE
feat(#4235): reyn config validate now also covers the hot-reload IN-set

### DIFF
--- a/src/reyn/interfaces/cli/commands/config.py
+++ b/src/reyn/interfaces/cli/commands/config.py
@@ -273,32 +273,66 @@ def _migrate_mcp(*, dry_run: bool = False) -> None:
 
 def _validate() -> None:
     """#4174 T0: report every unknown/renamed config key found in the
-    operator-editable policy tier (reyn.yaml / reyn.local.yaml /
-    ~/.reyn/config.yaml). #4231 (C): also report every KNOWN key whose
-    value is silently inert under another key's current value (a
-    DIFFERENT defect class — the key is real and correctly spelled, but
-    the configuration as a whole makes it a no-op).
+    operator-editable POLICY TIER (reyn.yaml / reyn.local.yaml /
+    ~/.reyn/config.yaml). #4231 (C): also report every KNOWN policy-tier
+    key whose value is silently inert under another key's current value
+    (a DIFFERENT defect class — the key is real and correctly spelled,
+    but the configuration as a whole makes it a no-op). #4235: also
+    report unknown/renamed keys, separately again, for the hot-reload
+    IN-set (``.reyn/{mcp,cron,hooks,skills,pipelines,presentations}.yaml``)
+    — a DIFFERENT config surface with a DIFFERENT remedy (edit-and-restart
+    for the policy tier vs. edit-and-next-turn for the IN-set), so all
+    three findings are reported as separate labeled sections rather than
+    merged into one dict: merging would lose exactly the "which one do I
+    fix, and how" information a finding needs to be actionable
+    (lead-coder/docs-maintainer ruling, #4235).
+
+    Policy-tier and IN-set unknown-key detection both use the SAME
+    ``unknown_config_keys`` (config_schema.py) — a tier is just a raw dict
+    to it, and #4235's own investigation confirmed the IN-set's merged
+    dict (``load_hot_reload_config``) uses the identical top-level key
+    vocabulary (``mcp``/``cron``/``hooks``/... are ordinary ``ReynConfig``
+    fields too) — no new validation logic, only a second call with a
+    second load. ``disabled_config_keys`` (#4231 C) is checked against the
+    policy tier only — the one dependency it currently knows about
+    (``action_retrieval.universal_wrappers_enabled`` vs.
+    ``tool_use.scheme``) lives there.
 
     Uses ``build_policy_tier_config`` — the SAME construction
     ``load_config``'s own startup warning uses (architect's explicit
     requirement: this command must check exactly what startup checks, not
-    a second hand-reconstructed merge). Exits 0 regardless of findings
-    (owner ruling: warn, never hard-fail — this command REPORTS, it does
-    not gate anything)."""
+    a second hand-reconstructed merge) — and ``load_hot_reload_config``,
+    the same loader the hot-reload mechanism itself uses to build the
+    IN-set every turn. Exits 0 regardless of findings (owner ruling: warn,
+    never hard-fail — this command REPORTS, it does not gate anything).
+
+    ⚠️ Known remaining gap (#4235's own recorded scope, not closed here):
+    the #4194 CUI status indicator counts POLICY-TIER findings only (tui
+    decision) — this PR widens ``validate``'s own scope to the IN-set
+    without widening the indicator to match, so the two surfaces'
+    coverage diverges again (the indicator undercounts relative to what
+    ``validate`` can now show). Left as-is; closing it is a separate
+    decision.
+    """
     from reyn.config.config_schema import disabled_config_keys, unknown_config_keys
-    from reyn.config.loader import build_policy_tier_config
+    from reyn.config.loader import build_policy_tier_config, load_hot_reload_config
 
-    merged = build_policy_tier_config()
-    unknown = unknown_config_keys(merged)
-    disabled = disabled_config_keys(merged)
+    policy_merged = build_policy_tier_config()
+    policy_unknown = unknown_config_keys(policy_merged)
+    disabled = disabled_config_keys(policy_merged)
+    in_set_merged = load_hot_reload_config()
+    in_set_unknown = unknown_config_keys(in_set_merged)
 
-    if not unknown and not disabled:
+    if not policy_unknown and not disabled and not in_set_unknown:
         print("No unknown, renamed, or disabled-by-dependency config keys found.")
         return
 
-    if unknown:
-        print(f"Found {len(unknown)} unrecognized config key(s):\n")
-        for key, hint in sorted(unknown.items()):
+    if policy_unknown:
+        print(
+            f"Policy tier (reyn.yaml / reyn.local.yaml / ~/.reyn/config.yaml) — "
+            f"{len(policy_unknown)} unrecognized config key(s):\n"
+        )
+        for key, hint in sorted(policy_unknown.items()):
             print(f"  {key}")
             if hint:
                 print(f"    -> {hint.note}")
@@ -307,7 +341,7 @@ def _validate() -> None:
         print("\nRun 'reyn config migrate' to fix renamed keys automatically.")
 
     if disabled:
-        if unknown:
+        if policy_unknown:
             print()
         print(
             f"Found {len(disabled)} config key(s) that are known but currently "
@@ -318,6 +352,26 @@ def _validate() -> None:
             print(f"    -> {disabled_hint.note}")
             print(f"    -> depends on: {disabled_hint.dependency_key}")
             print(f"    -> fix: {disabled_hint.fix}")
+
+    if in_set_unknown:
+        if policy_unknown or disabled:
+            print()
+        print(
+            f"Hot-reload IN-set (.reyn/{{mcp,cron,hooks,skills,pipelines,"
+            f"presentations}}.yaml) — {len(in_set_unknown)} unrecognized "
+            f"config key(s):\n"
+        )
+        for key, hint in sorted(in_set_unknown.items()):
+            print(f"  {key}")
+            if hint:
+                print(f"    -> {hint.note}")
+            else:
+                print("    -> not applied; see 'reyn config fields' for valid keys.")
+        print(
+            "\nIN-set keys apply on the next turn automatically (no restart, "
+            "no 'reyn config migrate' support for this tier — edit the "
+            ".reyn/*.yaml file directly)."
+        )
 
 
 def _migrate(*, dry_run: bool = False) -> None:

--- a/tests/interfaces/test_4235_validate_in_set.py
+++ b/tests/interfaces/test_4235_validate_in_set.py
@@ -1,0 +1,122 @@
+"""Tier 2: #4235 — ``reyn config validate`` widened to also report unknown/
+renamed config keys in the hot-reload IN-set (``.reyn/{mcp,cron,hooks,
+skills,pipelines,presentations}.yaml``), not just the policy tier
+(reyn.yaml / reyn.local.yaml / ~/.reyn/config.yaml).
+
+Companion to ``test_config_validate_migrate_command_4174.py`` (#4174 T0's
+own policy-tier coverage, unchanged by this PR — its own accept/reject
+tests still pass verbatim). Design (lead-coder + docs-maintainer ruling):
+the two tiers are reported as SEPARATE labeled sections, never merged
+into one dict — a policy-tier fix means "edit reyn.yaml and restart"; an
+IN-set fix means "edit .reyn/*.yaml, applies next turn automatically" —
+merging would lose exactly that "which one, and how" information.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+@pytest.fixture()
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+    monkeypatch.setattr("reyn.config._find_project_root", lambda _cwd: tmp_path)
+    monkeypatch.setattr("reyn.config.loader._find_project_root", lambda _cwd: tmp_path)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_an_unknown_in_set_key_is_reported_in_its_own_labeled_section(
+    project, capsys,
+):
+    """Tier 2: an unrecognized top-level key in an IN-set file (here,
+    .reyn/config/hooks.yaml — any of the 6 IN-set files merges into the
+    same top-level dict) is reported under the IN-SET section, separately
+    from the policy-tier section, with IN-set-specific remedy text (no
+    restart, no 'reyn config migrate' mention)."""
+    _write_yaml(project / "reyn.yaml", "model: standard\n")
+    _write_yaml(
+        project / ".reyn" / "config" / "hooks.yaml",
+        "totally_bogus_in_set_key: 1\n",
+    )
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _validate()
+    out = capsys.readouterr().out
+    assert "Hot-reload IN-set" in out
+    assert "totally_bogus_in_set_key" in out
+    assert "next turn automatically" in out
+    # The policy tier is clean — its OWN section must not appear at all.
+    assert "Policy tier" not in out
+
+
+def test_an_unknown_policy_tier_key_does_not_leak_into_the_in_set_section(
+    project, capsys,
+):
+    """Tier 2: accept-side for the IN-set half — a policy-tier-only
+    problem (reyn.yaml) produces ONLY the policy-tier section; a clean
+    IN-set must not spuriously grow an empty or spurious second section."""
+    _write_yaml(project / "reyn.yaml", "totally_made_up_top_level_key: 1\n")
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _validate()
+    out = capsys.readouterr().out
+    assert "Policy tier" in out
+    assert "totally_made_up_top_level_key" in out
+    assert "Hot-reload IN-set" not in out
+
+
+def test_both_tiers_unknown_are_reported_as_two_separate_sections(project, capsys):
+    """Tier 2: both tiers dirty at once — two clearly separated sections,
+    each naming ONLY its own tier's key (never merged into one list,
+    which would lose which tier — and therefore which remedy — a finding
+    belongs to)."""
+    _write_yaml(project / "reyn.yaml", "totally_made_up_top_level_key: 1\n")
+    _write_yaml(
+        project / ".reyn" / "config" / "cron.yaml",
+        "totally_bogus_in_set_key: 1\n",
+    )
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _validate()
+    out = capsys.readouterr().out
+    assert "Policy tier" in out
+    assert "Hot-reload IN-set" in out
+    policy_idx = out.index("Policy tier")
+    in_set_idx = out.index("Hot-reload IN-set")
+    # The IN-set key must not appear inside the policy-tier section (i.e.
+    # before the IN-set heading) and vice versa.
+    assert "totally_made_up_top_level_key" in out[policy_idx:in_set_idx]
+    assert "totally_bogus_in_set_key" not in out[policy_idx:in_set_idx]
+    assert "totally_bogus_in_set_key" in out[in_set_idx:]
+
+
+def test_a_well_formed_in_set_produces_no_findings(project, capsys):
+    """Tier 2: accept-side — real, valid IN-set files touching several
+    registries never trip the new section (a false positive here would
+    teach operators to ignore the report, the same #4174 T0 concern)."""
+    _write_yaml(project / "reyn.yaml", "model: standard\n")
+    _write_yaml(
+        project / ".reyn" / "config" / "mcp.yaml",
+        "mcp:\n  servers: {}\n",
+    )
+    _write_yaml(
+        project / ".reyn" / "config" / "hooks.yaml",
+        "hooks: []\n",
+    )
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _validate()
+    out = capsys.readouterr().out
+    # #4231 (C)'s disabled-by-dependency check landed on main after this
+    # test was first written and shares the same "all clean" branch — the
+    # message is now the unified 3-way string, not the 2-tier-only one.
+    assert "No unknown, renamed, or disabled-by-dependency config keys found." in out


### PR DESCRIPTION
**[e2e-coder]** — part of #4235. Design is settled (lead-coder's comment on the issue — option (a), "merge is wrong, two labeled sections is right").

## What

`reyn config validate` reports unknown/renamed config keys for the operator-editable policy tier only (`reyn.yaml`/`reyn.local.yaml`/`~/.reyn/config.yaml`). The hot-reload IN-set (`.reyn/{mcp,cron,hooks,skills,pipelines,presentations}.yaml`) has its own unknown-key warning (`hot_reload.py`'s `_warn_unknown_hot_reload_keys`), but it reaches **no operator-visible surface at all**: not the #4194 CUI indicator (policy-tier-only by tui's own decision), and not `validate` (which never looked at the IN-set). This PR closes the `validate` half.

Adds a **second labeled section** to `_validate()`'s output — deliberately **not** merged into one dict, per the ruling: the remedy differs by tier (policy tier → edit `reyn.yaml` and restart; IN-set → edit `.reyn/*.yaml`, applies automatically next turn), and merging would lose exactly that "which tier, and how do I fix it" information.

Both tiers reuse the same, unchanged `unknown_config_keys` (config_schema.py) — a tier is just a raw dict to it — and `load_hot_reload_config` (loader.py:844, unchanged, the same loader hot-reload itself uses). No new validation logic, no merge logic: two existing functions, called twice, printed under two headings.

## Known, documented gap (not closed here)

The #4194 CUI indicator's coverage (policy tier only) now diverges from `validate`'s own (both tiers) — widening the indicator to match is a separate decision, per the issue's own explicit note. Recorded in `_validate()`'s docstring so it doesn't read as "already covered."

## Recorded but unaddressed (per the issue, not this PR's scope)

Whether a single-registry IN-set file (e.g. `.reyn/config/mcp.yaml`) containing a top-level key that belongs to a DIFFERENT registry (or a valid `ReynConfig` field entirely outside the IN-set vocabulary, e.g. a stray `safety:`) is detected — `unknown_config_keys` validates against the full `ReynConfig` schema, so a valid-but-wrong-registry key is out of scope by construction. Not measured, not touched.

## Falsify-verification

Disabled the IN-set unknown-key computation. 2 tests go RED with the exact predicted failures (no IN-set section appears at all; the both-tiers-dirty test loses its second section). Restored, confirmed all 4 new tests + the existing 11 T0 CLI tests GREEN.

## Gates (local)

- `ruff check` — clean
- `test_tier_audit.py --strict` — 4/4 OK
- `verify_module_docstrings.py` — OK
- `mypy_ratchet.py` — OK (no new findings)
- `check_tests_path_literal_reference.py` — OK
- Broader regression sweep: `tests/config/` + `tests/interfaces/test_4235_validate_in_set.py` + `tests/interfaces/test_config_validate_migrate_command_4174.py` (164 passed)

⚠️ Note for the merger: this branch is based on main BEFORE #4242 (#4231 C) lands — that PR also adds a second block to `_validate()` (a different category, "disabled by dependency"). Expect a straightforward rebase conflict on the same function once #4242 merges; both additions are independent (different sections, different data sources) so the merge is mechanical.

## Test plan

- [x] New two-section test suite, falsify-verified RED→GREEN
- [x] Full local 5-gate battery green
- [x] `tests/config/` + related `tests/interfaces/` sweep green (164 tests)
- [ ] (Visual — N/A, no UI surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
