### PR TITLE
ci(#4239): a draft PR no longer spends CI — promotion is the request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches: [main]
   pull_request:
+    # #4239 (owner ruling, 2026-08-11): opening a PR and spending CI on it
+    # are DIFFERENT decisions with different costs — "review this" is cheap
+    # and wanted immediately; "verify this against today's main" is expensive
+    # and has to take its turn. They were coupled: every open ran the full
+    # matrix, the PR then sat BEHIND for an hour, and the front-of-queue push
+    # ran it again (measured 2026-08-11: agent.py 5 CI runs, audit.py 4).
+    # `ready_for_review` is NOT in the default type set, so it has to be
+    # listed explicitly for the draft -> ready promotion to start CI at all.
+    types: [opened, synchronize, reopened, ready_for_review]
   # #4239: the merge queue evaluates required checks on a synthetic
   # `merge_group` ref (main + the queued PRs), NOT on the PR branch — a
   # required check that never fires there leaves every queued PR waiting
@@ -19,6 +28,11 @@ jobs:
   test:
     name: pytest (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    # #4239: a draft PR is 'not yet asking for CI' — the guard is what
+    #        separates PR creation from CI spend. Promotion (gh pr ready)
+    #        fires `ready_for_review` above and runs this once, near the
+    #        front of the queue, instead of once at open + once per rebase.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     timeout-minutes: 15
 
     strategy:
@@ -84,6 +98,11 @@ jobs:
   lint:
     name: ruff
     runs-on: ubuntu-latest
+    # #4239: a draft PR is 'not yet asking for CI' — the guard is what
+    #        separates PR creation from CI spend. Promotion (gh pr ready)
+    #        fires `ready_for_review` above and runs this once, near the
+    #        front of the queue, instead of once at open + once per rebase.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     timeout-minutes: 5
 
     steps:
@@ -106,6 +125,11 @@ jobs:
   mypy-ratchet:
     name: mypy (ratchet)
     runs-on: ubuntu-latest
+    # #4239: a draft PR is 'not yet asking for CI' — the guard is what
+    #        separates PR creation from CI spend. Promotion (gh pr ready)
+    #        fires `ready_for_review` above and runs this once, near the
+    #        front of the queue, instead of once at open + once per rebase.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     timeout-minutes: 10
 
     steps:
@@ -137,6 +161,11 @@ jobs:
   docs:
     name: docs build (strict)
     runs-on: ubuntu-latest
+    # #4239: a draft PR is 'not yet asking for CI' — the guard is what
+    #        separates PR creation from CI spend. Promotion (gh pr ready)
+    #        fires `ready_for_review` above and runs this once, near the
+    #        front of the queue, instead of once at open + once per rebase.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     timeout-minutes: 10
 
     steps:
@@ -177,6 +206,11 @@ jobs:
   audit:
     name: test-tier audit
     runs-on: ubuntu-latest
+    # #4239: a draft PR is 'not yet asking for CI' — the guard is what
+    #        separates PR creation from CI spend. Promotion (gh pr ready)
+    #        fires `ready_for_review` above and runs this once, near the
+    #        front of the queue, instead of once at open + once per rebase.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     # PR events: audit only changed test files — 0.194s/file vs 5-9min
     # for the full 652-file corpus.  main push: full run is preserved
     # as the invariant safety net.


### PR DESCRIPTION
**[lead-coder]** — part of #4239, **owner ruling (2026-08-11): PR 作成と CI 起動を分離する**.

## The coupling being removed

```
before   open a PR            → ★full matrix runs immediately
         sit BEHIND ~1h        （このリポは merge に up-to-date を要求 ∴ 着地は 直列）
         front-of-queue push  → ★full matrix runs again
measured 2026-08-11  agent.py ★5 CI runs / audit.py ★4 — 1 本着地させるのに
after    open as draft        → ★0
         gh pr ready          → ★1（＝明示的な依頼）
```

## Why draft, and why per-job

- **draft is the natural "not yet asking for CI" state** — it already exists in GitHub, needs no second source of truth, and `gh pr ready` is a real, visible request.
- **`ready_for_review` is NOT in the default `pull_request` type set.** Without listing it, promotion would start nothing and a queued PR would wait forever — this is the footgun the PR body of #4248 named for `merge_group`, in a second place.
- **The guard is per-job, not on the workflow**, so `merge_group` and `push` keep running unconditionally: neither carries a `pull_request` payload, and the `github.event_name != 'pull_request'` arm is what lets them through.

## The one trade, and how it is covered

**A draft's redness is not visible until promotion.** Owner's ruling covers it in two parts: the normal path is **the author asking explicitly** (promote → CI runs immediately, so nothing is hidden from someone who asked), and **forgotten promotions are swept periodically by backlog-watcher**. A draft that stops moving is **a question for its author** — not something to promote on their behalf, since "still drafting" and "forgot to ask" look identical from outside.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` — parses
- [x] All 5 jobs carry the guard (`test` / `lint` / `mypy-ratchet` / `docs` / `audit`) — grep-verified 5/5
- [x] Required contexts (pytest ×2, ruff, test-tier audit) all live in these jobs — `gh api …/branches/main/protection` measured
- [ ] Visual/manual: N/A (CI config only)
