### PR TITLE
fix(#4077): raise textual floor to 8.2.8 — fixes scoped-run failures at older versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,11 +68,19 @@ dependencies = [
     # Git-pinned to a specific commit of the PUBLIC repo (no auth needed).
     # Phase 1 promotes `textual` to an explicit DIRECT dep now that the app code
     # imports `textual.app`/`textual.widgets` directly (Phase 0 left it transitive
-    # via flowview) — same reasoning that keeps rich direct above. Floor matches
-    # flowview's own requirement (textual>=0.80). The app module is imported
-    # LAZILY on the TTY path only, so the plain / --cui / non-TTY / CI paths never
-    # touch textual or flowview and stay green even if flowview fails to resolve.
-    "textual>=0.80",
+    # via flowview) — same reasoning that keeps rich direct above. The app module
+    # is imported LAZILY on the TTY path only, so the plain / --cui / non-TTY /
+    # CI paths never touch textual or flowview and stay green even if flowview
+    # fails to resolve.
+    # #4077: floor raised from flowview's own bare requirement (textual>=0.80)
+    # to 8.2.8 — a scoped `tests/interfaces/` run at 8.2.0 reproducibly failed
+    # (test_3310_n2_reset_hydrate.py: 9/9 failed; test_textual_chat_intervention_
+    # panel_3299.py: hung) with an AttributeError chain rooted in
+    # `build_presentation`; the SAME scope at 8.2.8 is 9/9 + 25/25 green, no
+    # hang. Confirmed on this env only (not bisected below 8.2.8 to find the
+    # exact minimum) — if you drop this floor, #4077's scoped-run failures can
+    # come back.
+    "textual>=8.2.8",
     # v0.12.0 (5a72da0), up from v0.9.0 (#3624). 0.5.0: animated jumps,
     # body_width/effective gutter widths. 0.6.0: empty state,
     # scroll_to_entry(align=), opt-in keyboard cursor, ReachedTop/ReachedBottom


### PR DESCRIPTION
**[e2e-coder]** — part of #4077. Follow-up from a reproduction check: lead-coder asked me to verify #4077's original claim on current main before committing to the expensive full re-measurement (the issue's own thread had already falsified both prior co-location hypotheses).

## What I found

- `test_3310_n2_reset_hydrate.py` standalone: 9/9 **green** (was 9 failed)
- `test_textual_chat_intervention_panel_3299.py` standalone: 25/25 **green**, no hang (was hanging)
- My env: `textual==8.2.8` — matches tui-coder's own "the fixed version" finding, but `pyproject.toml`'s floor was only `textual>=0.80` (flowview's own bare requirement), so this isn't guaranteed on a fresh install elsewhere or on a different day.

**Conclusion**: #4077's remaining substance isn't "co-location mode" (both of lead-coder's own hypotheses on that were falsified by tui-coder's condition A/B/C measurements) — it's an under-pinned `textual` floor not forcing the version the failures are already fixed at. Raised the floor to `textual>=8.2.8`, with a comment explaining why and noting it's confirmed-not-bisected (8.2.8 is a known-good point, not a measured minimum).

## What stays open (per lead-coder — not closed by this PR)

tui-coder's separate CPU-contention hypothesis for `test_text_effect_cache_3860.py::test_a_failed_build_is_retried_with_a_different_effect` (a real background thread racing a real 300x wall-clock sleep loop under xdist worker contention) is untouched — a different mechanism entirely, unconfirmed by either of us. Recorded as UNVERIFIED, not resolved.

## Gates

This is a dependency-floor change in `pyproject.toml` only, no source/test files touched — the usual 5-gate battery doesn't apply (no ruff/tier-audit/docstring findings possible on a toml edit). Verified directly: both previously-failing test files pass at the new floor (34/34 combined), and the version specifier parses correctly.

## Test plan

- [x] Both originally-failing tests confirmed green standalone at the new floor (34/34)
- [x] Version specifier sanity-checked (`packaging.requirements.Requirement`)
- [x] No lock file in the repo to also update (pyproject.toml is the single source)
- [ ] (Visual — N/A, no UI surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
