### PR TITLE
chore(#4081): trim 1 orphaned path-literal baseline entry (src/reyn/_network.py)

### DIFF
--- a/scripts/check_tests_path_literal_reference_baseline.json
+++ b/scripts/check_tests_path_literal_reference_baseline.json
@@ -450,11 +450,6 @@
     "class": "never-existed"
   },
   {
-    "file": "src/reyn/_network.py",
-    "literal": "tests/network/test_egress_env_completeness.py",
-    "class": "never-existed"
-  },
-  {
     "file": "src/reyn/prompt/__init__.py",
     "literal": "tests/scaffold/test_sp_prompt_package_phase1_byte_identical.py",
     "class": "never-existed"


### PR DESCRIPTION
**[e2e-coder]** — part of #4081. Found opportunistically while measuring lead-coder's specific "残件①" ask (test_mcp_sse.py -> test_mcp_server.py).

## test_mcp_sse.py finding (no code change needed)

Confirmed already fully resolved: the false "list_agents_impl / send_to_agent_impl covered here" claim was fixed in #4188 (docstring now correctly says "does not exist"), and the list_agents_impl coverage gap was closed in #4189 (tests/mcp/test_4189_list_agents_impl_real_consumer.py). Nothing left to do for this item — matches tonight's pattern of issues already fixed before being picked back up.

## What this PR actually does

The gate's own output ("118 reference(s), all baselined (119 declared)") showed a genuine orphaned entry unrelated to test_mcp_sse.py. Diffed `measured_pairs()` against `load_baseline()` (the script's own functions) to find it: `(src/reyn/_network.py, tests/network/test_egress_env_completeness.py)`.

Confirmed `tests/network/test_egress_env_completeness.py` doesn't exist (never did — baselined `class: never-existed`), and `src/reyn/_network.py` no longer contains the literal at all (zero grep matches) — someone already fixed the false reference in the source without regenerating the baseline. Harmless per the gate's own tolerant design (a fix silently stops appearing, no edit required to "count"), but trimming it matches #4081's own stated goal.

## Verification

Before: `118 reference(s), all baselined (119 declared)`. After: `118 reference(s), all baselined (118 declared)` — exact match. Confirmed via `git stash`/`stash pop` that reverting reproduces the 118/119 mismatch and restoring fixes it.

## Test plan

- [x] Gate re-run before/after, confirmed the discrepancy and the fix
- [x] JSON validity confirmed (`json.loads`)
- [x] test_mcp_sse.py's own item confirmed already resolved via #4188 + #4189 (no code change needed here)
- [ ] (Visual — N/A, no UI surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)