### PR TITLE
fix(#3830): recursively scrub secrets from dict/list-shaped provider error bodies

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1675,15 +1675,28 @@ def _collect_secret_values(base_kwargs: dict) -> list[str]:
 
 
 def _scrub_secrets(value: object, secrets: list[str]) -> object:
-    """#1676: replace any known secret value occurring in a string with a marker.
-    Non-strings pass through unchanged (dict/list provider bodies are kept whole —
-    providers do not echo your API key in the error body, and the full body is the
-    root-cause signal we must NOT truncate)."""
-    if not isinstance(value, str) or not secrets:
+    """#1676/#3830: replace any known secret VALUE occurring in a string with a
+    marker, recursing through dict/list structure to reach every string leaf.
+
+    #3830: the original version returned dict/list bodies UNCHANGED on the
+    (wrong) assumption that "providers do not echo your API key in the error
+    body" — a proxy's 401 quoting the token it rejected is ordinary provider
+    behaviour, and litellm's parsed error bodies are dicts, so that branch let
+    a credential straight into the durable audit log. Recursing preserves the
+    root-cause detail #1676 exists to capture (same shape, same non-secret
+    keys/values, nothing truncated or dropped) while closing the leak — a
+    pattern-value scrub, not a blanket redaction of the whole structure."""
+    if not secrets:
         return value
-    for s in secrets:
-        if s:
-            value = value.replace(s, "***REDACTED***")
+    if isinstance(value, str):
+        for s in secrets:
+            if s:
+                value = value.replace(s, "***REDACTED***")
+        return value
+    if isinstance(value, dict):
+        return {k: _scrub_secrets(v, secrets) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_scrub_secrets(v, secrets) for v in value]
     return value
 
 
@@ -1708,11 +1721,13 @@ def _emit_llm_request_error(
             "status_code": getattr(exc, "status_code", None),
         }
         # litellm exceptions carry the provider body on ``.body`` (often the parsed
-        # error dict) and/or ``.response`` (an httpx.Response). Capture BOTH, whole.
+        # error dict) and/or ``.response`` (an httpx.Response). Capture BOTH, whole
+        # (#3830: "whole" means shape-preserved, not unscrubbed — a dict body is
+        # walked recursively same as a string one).
         body = getattr(exc, "body", None)
         if body is not None:
             detail["provider_body"] = (
-                body if isinstance(body, (dict, list))
+                _scrub_secrets(body, secrets) if isinstance(body, (dict, list))
                 else _scrub_secrets(str(body), secrets)
             )
         resp = getattr(exc, "response", None)

--- a/tests/core/test_llm_request_error_1676.py
+++ b/tests/core/test_llm_request_error_1676.py
@@ -140,6 +140,41 @@ def test_error_event_redacts_secret_value(monkeypatch) -> None:
     assert data["params"]["api_key"] == "***REDACTED***"
 
 
+def test_error_event_redacts_secret_value_in_dict_shaped_body(monkeypatch) -> None:
+    """Tier 2: #3830 — a secret value echoed inside a DICT-shaped provider body
+    (litellm's parsed JSON error, the common real-world shape) is scrubbed the
+    same as a string body, WITHOUT flattening the structure — the non-secret
+    keys/values (root-cause detail #1676 exists to capture) survive unchanged."""
+    monkeypatch.setattr(
+        litellm, "acompletion",
+        _raising_acompletion(
+            message="Auth failed",
+            status_code=401,
+            body={
+                "error": {
+                    "message": "rejected token sk-supersecret-123",
+                    "type": "invalid_request_error",
+                },
+            },
+            response_text="",
+        ),
+    )
+    log = EventLog()
+    collected = collect_events(log)
+    set_llm_request_event_log(log)
+
+    with pytest.raises(_FakeProviderError):
+        _call(monkeypatch, api_key="sk-supersecret-123")
+
+    (err,) = [e for e in collected if e.type == "llm_request_error"]
+    data = err.data
+    assert "sk-supersecret-123" not in repr(data), "secret value must be scrubbed"
+    # The structure and non-secret detail survive — this is a value scrub, not
+    # a blanket "drop the dict body" redaction.
+    assert data["provider_body"]["error"]["type"] == "invalid_request_error"
+    assert "***REDACTED***" in data["provider_body"]["error"]["message"]
+
+
 def test_no_event_when_ambient_log_unset_but_still_raises(monkeypatch) -> None:
     """Tier 2: #1676 — with no ambient EventLog (tests / CLI), no event is emitted
     but the exception STILL propagates (capture is best-effort; re-raise is not)."""


### PR DESCRIPTION
**[e2e-coder]** —

## Re-measured against fresh main first

Confirmed the gap is still live before touching anything: `tests/core/test_llm_request_error_1676.py::test_error_event_redacts_secret_value` currently passes only because its fixture uses a STRING-shaped `body`. The redaction code (`llm.py`'s `_emit_llm_request_error`) explicitly skipped scrubbing when `provider_body` is a dict/list, on the stated assumption "providers do not echo your API key in the error body" — false for a 401 that quotes the rejected token, and litellm's parsed JSON error bodies are dicts, the common real-world shape.

## Fix

`_scrub_secrets` now recurses through dict/list structure to reach every string leaf, applying the same known-secret-**value** replace already used for string bodies — not a blanket "drop the dict" redaction. Non-secret detail (status code, error type, other dict keys) survives unchanged, preserving the root-cause signal #1676 exists to capture.

`_emit_llm_request_error`'s `provider_body` branch now calls `_scrub_secrets(body, secrets)` for the dict/list case too, instead of passing it through untouched.

## Test

New `test_error_event_redacts_secret_value_in_dict_shaped_body`: a nested dict body (`{"error": {"message": "rejected token sk-...", "type": "invalid_request_error"}}`) — asserts the secret is gone from the event's `repr()` AND that the sibling `type` field and structure survive untouched (proves this is a value scrub, not a truncation).

**Falsify-verified**: reverted only the `_scrub_secrets` change (kept the new test), ran it — RED with the exact predicted leak (`'sk-supersecret-123' is contained here: ...`). Restored, GREEN.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/core/test_llm_request_error_1676.py` — 5 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/llm/llm.py` — clean
- [x] `python scripts/mypy_ratchet.py` — clean (212/216 baselined, no new)
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] `pytest tests/core/test_llm_request_error_1676.py` — 5 passed
- [x] `pytest tests/core/ -k llm` — 60 passed, 0 failed (regression sweep)
- [x] Falsify-verify (see above)

part of #3830

🤖 Generated with [Claude Code](https://claude.com/claude-code)