### PR TITLE
ci(#4257): hourly sweep of the 5 whole-tree gate scripts against main

### DIFF
--- a/.github/workflows/main-hourly-gate-sweep.yml
+++ b/.github/workflows/main-hourly-gate-sweep.yml
@@ -55,22 +55,31 @@ jobs:
           python-version: "3.11"
 
       # All 5 are stdlib-only (ast / pathlib / sys) — no pip install needed,
-      # same as their per-PR counterparts. Run in sequence; any non-zero
-      # exit fails the job (default `run:` behaviour, no `continue-on-error`)
-      # so a single red gate is enough to redden the whole sweep — #4257's
-      # own test-plan requirement ("a red gate you can't fail is a gate that
-      # says nothing").
+      # same as their per-PR counterparts. Any non-zero exit fails its own
+      # step (default `run:` behaviour), which reddens the job overall — a
+      # single red gate is enough, #4257's own test-plan requirement ("a
+      # red gate you can't fail is a gate that says nothing"). Each step
+      # still carries `if: ${{ !cancelled() }}` so a step 1 failure does
+      # NOT skip steps 2-5 (the default without it) — this runs once an
+      # hour, so knowing all 5 outcomes from one run matters more here than
+      # in a per-PR gate: without it, only the first failure is visible and
+      # recovery has to wait a full cycle to learn about the rest.
       - name: bare-tests-import-reference
+        if: ${{ !cancelled() }}
         run: python scripts/check_bare_tests_import_reference.py
 
       - name: fastmcp-import-boundary
+        if: ${{ !cancelled() }}
         run: python scripts/check_fastmcp_import_boundary.py
 
       - name: file-depth-reference
+        if: ${{ !cancelled() }}
         run: python scripts/check_file_depth_reference.py
 
       - name: tests-path-literal-reference
+        if: ${{ !cancelled() }}
         run: python scripts/check_tests_path_literal_reference.py
 
       - name: flat-tests-ratchet
+        if: ${{ !cancelled() }}
         run: python scripts/flat_tests_ratchet.py

--- a/.github/workflows/main-hourly-gate-sweep.yml
+++ b/.github/workflows/main-hourly-gate-sweep.yml
@@ -1,0 +1,76 @@
+name: main hourly gate sweep
+
+# #4257: 5 of the whole-tree gate scripts (bare-tests-import-reference,
+# fastmcp-import-boundary, file-depth-reference, tests-path-literal-reference,
+# flat-tests-ratchet) normally run on `pull_request` only. With strict=false
+# (#4239) a PR merges on its own green, so a violation created by the
+# COMBINATION of two independently-green PRs is never caught at merge time —
+# the next PR to touch that path inherits a red gate an innocent change
+# didn't cause. This workflow re-runs those 5 against `main` on an hourly
+# schedule (plus workflow_dispatch for an on-demand check) so that
+# composition gap has a witness, without adding `push: branches: [main]` to
+# the 5 existing per-PR workflows (owner: keep this in ONE new file, don't
+# touch them).
+#
+# Deliberately only 5 of the 7 candidates from #4257's original scan — the
+# other 2 (migration-diff-shape-gate, tests-dir-names-gate) invoke their
+# scripts with a diff/merge-base argument (`--base origin/<PR base ref>` /
+# a merge-base comparison) that has no meaning against `main` alone: there
+# is no "PR" here to diff against, and passing any other ref would not
+# actually stand in for one. Left out, not silently dropped — see the PR
+# body for the same reasoning recorded where a reviewer will read it.
+#
+# `check-pr-closing-intent` / `dogfood-finding-triage` are excluded for the
+# same reason #4257's issue body gives: the former inspects a PR body (main
+# has no such artifact — running it would be an always-green check watching
+# nothing), the latter isn't `pull_request`/`push`-triggered at all.
+#
+# Deliberately NOT a required status check (not referenced from branch
+# protection) — this runs on a schedule independent of any one PR, so
+# folding its result into a PR's merge gate would block merges on an
+# unrelated periodic run.
+on:
+  schedule:
+    # GitHub's own scheduler is best-effort under load — "roughly hourly",
+    # not "always at :00". See the module comment above for why that's fine
+    # here (this is a composition-gap witness, not a merge gate).
+    - cron: "0 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  gate-sweep:
+    name: main hourly gate sweep
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # All 5 are stdlib-only (ast / pathlib / sys) — no pip install needed,
+      # same as their per-PR counterparts. Run in sequence; any non-zero
+      # exit fails the job (default `run:` behaviour, no `continue-on-error`)
+      # so a single red gate is enough to redden the whole sweep — #4257's
+      # own test-plan requirement ("a red gate you can't fail is a gate that
+      # says nothing").
+      - name: bare-tests-import-reference
+        run: python scripts/check_bare_tests_import_reference.py
+
+      - name: fastmcp-import-boundary
+        run: python scripts/check_fastmcp_import_boundary.py
+
+      - name: file-depth-reference
+        run: python scripts/check_file_depth_reference.py
+
+      - name: tests-path-literal-reference
+        run: python scripts/check_tests_path_literal_reference.py
+
+      - name: flat-tests-ratchet
+        run: python scripts/flat_tests_ratchet.py


### PR DESCRIPTION
**[docs-maintainer]** — #4257。新規1ファイルのみ、既存workflowは無変更です。

## 実装

`.github/workflows/main-hourly-gate-sweep.yml` — schedule(cron "0 * * * *"、GitHubのbest-effort前提を明記)+ workflow_dispatch。5スクリプトを順に実行、continue-on-errorなし(1本でも落ちればjob全体が赤)。

## 7本→5本に絞った理由(実際に走るコマンドを読んで判断)

```
含めた5本(diff/base-ref不要、main単独でも意味を持つ):
  check_bare_tests_import_reference.py
  check_fastmcp_import_boundary.py
  check_file_depth_reference.py
  check_tests_path_literal_reference.py
  flat_tests_ratchet.py(--check-growthは付けない — これがdiff側の追加チェック)

除外した2本:
  migration-diff-shape-gate  ── --base "origin/${{ github.base_ref }}" が必須、main単独に比較相手なし
  tests-dir-names-gate       ── merge-base比較が必須、同上
  check-pr-closing-intent / dogfood-finding-triage は元issueの通りscope外(PR本文検査/非push-trigger)
```

## Test plan

- [x] 5スクリプトすべてを実際にローカルで単体実行し、標準出力・exit 0を確認(diff/base-ref不要であることの直接確認)
- [ ] `workflow_dispatch`で手動起動し、5本すべてが実際に実行されたことをログで確認(スキップされて緑、を除外)
- [ ] わざと1本落ちる状態を作って赤になることを確認
- [ ] 最初のschedule起動を`gh run list --workflow main-hourly-gate-sweep.yml`で確認
- [x] required contextsには追加していません(branch protectionは無変更)
- [x] YAML構文確認(`python3 -c "import yaml; yaml.safe_load(...)"`) — OK
- [x] closing-keyword trap を commit message・本PR body両方に適用 — hit なし

⚠️ 上3件のTest plan項目はmerge後(実際にworkflowが起動してから)でないと確認できません — draftのまま/mergeを待ってから追って確認・チェックします。

part of #4257

🤖 Generated with [Claude Code](https://claude.com/claude-code)
