### PR TITLE
fix(#4193 ①): a new attended axis fixes persistent-spawn's wrong foreground timeout

### DIFF
--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -257,15 +257,16 @@ class OpContext:
     # NOT a `background` field, deliberately (architect/lead-coder ruling,
     # #3903 issue thread, 2026-08-11): ephemeral and background are NOT the
     # same predicate. `spawn_session`'s tool dispatch is fire-and-forget
-    # regardless of mode, so a PERSISTENT spawn is also unwaited-on and
-    # still gets the foreground pair here (tracked gap, #4193). A single
-    # bool cannot represent both axes correctly, so this field carries only
-    # what it actually measures. Direction of the implication this field
-    # licenses: "an ephemeral exec gets the background timeout pair" is
-    # correct; "background-ness is decided by this field" is NOT — a
-    # reader who inverts that direction will misjudge the persistent-spawn
-    # gap as already covered. False by default (direct/test construction,
-    # non-chat OpContext).
+    # regardless of mode, so a PERSISTENT spawn is also unwaited-on and used
+    # to still get the foreground pair here — closed by #4193, see
+    # :attr:`attended` below. A single bool cannot represent both axes
+    # correctly, so this field carries only what it actually measures.
+    # Direction of the implication this field licenses: "an ephemeral exec
+    # gets the background timeout pair" is correct; "background-ness is
+    # decided by this field" is NOT — a reader who inverts that direction
+    # will misjudge #4193's persistent-spawn gap as already covered by this
+    # field alone. False by default (direct/test construction, non-chat
+    # OpContext).
     #
     # #4193 co-vet correction (2026-08-11, docs-maintainer): an earlier
     # revision of this comment claimed `run_pipeline_attached`'s driver
@@ -279,6 +280,39 @@ class OpContext:
     # (attached ⇒ someone is waiting), for the ordinary reason a plain
     # boolean read would suggest, not despite one.
     ephemeral: bool = False
+
+    # #4193 ①: whether the caller that spawned this SESSION is itself
+    # waiting on it — a SEPARATE axis from :attr:`ephemeral` (session-sticky,
+    # decided by the spawning CALLER at spawn time, not derived from `mode`).
+    # `session_spawn`'s tool dispatch (`RouterHostAdapter.spawn_session`)
+    # sets this False regardless of mode — it returns a spawn-ack and submits
+    # the task without awaiting completion, so mode="persistent" through
+    # that one path was the exact gap #4193 opened on (persistent ⇏
+    # attended). Every other spawn path (the attached pipeline driver, the
+    # `agent`-step ephemeral worker) leaves the default True. True by
+    # default: the common case (an interactive chat turn, direct/test
+    # construction) has someone waiting.
+    #
+    # `sandboxed_exec.handle` combines this with `ephemeral` as
+    # `ephemeral or not attended` — architect ruling, #4193, 2026-08-11.
+    # ⚠️ THE TWO TERMS ARE NOT REDUNDANT — do not simplify to `not attended`
+    # alone. The true predicate this pair approximates is "is a HUMAN
+    # waiting", and there are three states, not two:
+    #   interactive chat turn   a human waits              → foreground
+    #   agent-step leaf worker  a PROGRAM waits (ephemeral  → background
+    #                           =True, attended=True — MessageBus.request
+    #                           synchronously awaits ONE prompt, but the
+    #                           thing on the other end isn't a human)
+    #   session_spawn           nobody waits (attended=False) → background
+    # `ephemeral` carries the middle row; `not attended` carries the last
+    # row. Removing the `ephemeral` disjunct breaks the middle row: an
+    # agent-step worker's execs would narrow from the background pair
+    # (3600s) to the foreground pair (120s), and an agent step that itself
+    # runs a long exec would start failing — the falsify witness is
+    # `tests/core/test_op_sandboxed_exec.py`'s own
+    # ephemeral-and-attended-still-gets-background case (#4193), which a
+    # naive `not attended`-only rule fails.
+    attended: bool = True
 
     # #1800 slice 5c: the awaited HookDispatcher (the Session's instance, with the
     # loaded hooks registry + the _put_inbox/_stage/_run_shell seams from 5b),

--- a/src/reyn/core/op_runtime/sandboxed_exec.py
+++ b/src/reyn/core/op_runtime/sandboxed_exec.py
@@ -81,14 +81,18 @@ async def handle(
     )
     policy = SandboxPolicy(**ctx.default_sandbox_policy)
 
-    # #3903 a-2 ③: which timeout pair applies. ``ctx.ephemeral`` carries
-    # ``Session._ephemeral`` (see OpContext.ephemeral's own docstring for
-    # the precise, one-directional claim this licenses — an ephemeral
-    # exec gets the background pair; this is NOT a general "is this call
-    # background" test, and a PERSISTENT spawn still gets the foreground
-    # pair here, a known gap tracked in #4193, not covered by this PR).
+    # #3903 a-2 ③ / #4193 ①: which timeout pair applies. ``ctx.ephemeral or
+    # not ctx.attended`` — architect ruling, #4193, 2026-08-11. See
+    # ``OpContext.attended``'s own docstring for the full 3-state table this
+    # approximates ("is a human waiting") and why BOTH disjuncts are load-
+    # bearing, not redundant: `ephemeral` alone would miss an unattended
+    # persistent spawn (#4193's opening gap); `not attended` alone would
+    # break an agent-step leaf worker (ephemeral=True, attended=True — a
+    # program, not a human, is waiting via `MessageBus.request`), narrowing
+    # it from the background pair to the foreground one and failing any
+    # agent step that itself runs a long exec.
     import dataclasses
-    if ctx.ephemeral:
+    if ctx.ephemeral or not ctx.attended:
         effective_default = policy.background_timeout_seconds
         effective_max = policy.background_max_timeout_seconds
     else:

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -3012,6 +3012,7 @@ class AgentRegistry:
         self, name: str, *, mode: str = "persistent",
         narrowing: "dict | None" = None,
         base_dir: "Path | None" = None,
+        attended: bool = True,
         presentation_consumer: "object | None",
         intervention_bridge: "object | None",
     ) -> str:
@@ -3025,6 +3026,16 @@ class AgentRegistry:
         it. Mirrors ``create_agent`` (the agent CREATE seam): the mechanism stays sync;
         the event marks the LLM action. ``session_spawned`` is config-complete
         (mode + narrowing) for symmetric re-materialise. Returns the new sid.
+
+        ``attended`` (#4193 ①, default ``True``): whether THIS CALLER is going to
+        wait on the spawned session — a CALLER decision, never derived from
+        ``mode``. The one caller that passes ``False`` is
+        ``RouterHostAdapter.spawn_session`` (the ``session_spawn`` LLM tool's
+        dispatch target): it returns a spawn-ack and submits the task without
+        awaiting completion, regardless of ``mode``. Every other caller
+        (the attached pipeline driver, the ``agent``-step ephemeral worker)
+        leaves the default — see ``Session._attended``'s own docstring and
+        ``OpContext.attended``'s for what this feeds.
 
         ``base_dir`` (#4200 2/2) is a SIBLING persisted value, not composed the way
         ``narrowing`` is: this method does NOT validate it — restrict-only enforcement
@@ -3110,6 +3121,12 @@ class AgentRegistry:
         spawned_session = self._peek_session(name, sid)
         if spawned_session is not None:
             await spawned_session.refresh_config_projections()
+            # #4193 ①: caller-declared, NOT mode-derived — unlike ``_ephemeral``
+            # below, this is set unconditionally from the ``attended`` argument
+            # every time (default True leaves the Session's own True default
+            # unchanged; ``RouterHostAdapter.spawn_session`` is the one caller
+            # that passes False).
+            spawned_session._attended = attended
         if mode == "ephemeral":
             # #2103: mark the live session so it auto-vanishes once its task is done
             # (Session._maybe_schedule_ephemeral_vanish, via this registry's

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -65,6 +65,7 @@ def build_router_op_context(
     run_id: str | None = None,  # chat router is outside run scope (#FP-0021)
     cancel_event: Any = None,  # #1470: asyncio.Event for mid-subprocess cancel
     ephemeral: bool = False,  # #3903 a-2 ③: Session._ephemeral, live — see OpContext.ephemeral's own docstring for what this DOES and does NOT mean
+    attended: bool = True,  # #4193 ①: Session._attended, live — a SEPARATE axis from ephemeral, see OpContext.attended's own docstring
     threat_scan: Any = None,  # FP-0050/#1822 S5 (EP4): exec command-scan config
     contextual_permission: Any = None,  # #1827 S3: per-session capability narrowing → OpContext
     session_id: str | None = None,
@@ -168,6 +169,7 @@ def build_router_op_context(
         ),
         cancel_event=cancel_event,
         ephemeral=ephemeral,
+        attended=attended,
         threat_scan=threat_scan,
         contextual_permission=contextual_permission,
         session_id=session_id,
@@ -250,6 +252,7 @@ class RouterOpContextSource:
         budget_gateway: Any,
         available_skills_fn: Any,
         ephemeral_fn: Any,  # #3903 a-2 ③: Session._ephemeral, live — same reason turn_origin_fn/session_id_fn are `_fn`s, not values (reassigned post-construction)
+        attended_fn: Any,  # #4193 ①: Session._attended, live — same reason as ephemeral_fn above
     ) -> None:
         self._events = events
         self._permission_resolver = permission_resolver
@@ -280,6 +283,7 @@ class RouterOpContextSource:
         self._budget_gateway = budget_gateway
         self._available_skills_fn = available_skills_fn
         self._ephemeral_fn = ephemeral_fn
+        self._attended_fn = attended_fn
         self._cancel_event: Any = None
 
     @property
@@ -334,6 +338,7 @@ class RouterOpContextSource:
             compact_now=self._compact_now,
             cancel_event=self._cancel_event,
             ephemeral=self._resolve(self._ephemeral_fn, False),
+            attended=self._resolve(self._attended_fn, True),
             threat_scan=self._threat_scan,
             contextual_permission=self._resolve(self._contextual_permission_fn),
             session_id=self._resolve(self._session_id_fn),

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -1402,6 +1402,13 @@ class RouterHostAdapter:
         sid = await self._registry.spawn_session_recorded(
             self._agent_name, mode=mode, narrowing=narrowing,
             base_dir=resolved_base_dir,
+            # #4193 ①: this method returns a spawn-ack and submits the task
+            # below WITHOUT awaiting its completion — regardless of ``mode``.
+            # A persistent spawn through this one path is exactly the gap
+            # #4193 opened (fire-and-forget, but used to get the foreground
+            # timeout pair as if someone were waiting). See
+            # ``OpContext.attended``'s own docstring for the full picture.
+            attended=False,
             presentation_consumer=_routing.presentation_consumer,
             intervention_bridge=_routing.intervention_bridge,
         )

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -978,6 +978,14 @@ class Session:
         # The vanish-scheduling state (_vanish_scheduled / _vanish_task) is owned by
         # SpawnTracker, constructed below (see #3133 P3 Extract Class, spawn_tracker.py).
         self._ephemeral: bool = False
+        # #4193 ①: whether the caller that spawned this session is itself waiting
+        # on it — a SEPARATE axis from ``_ephemeral`` above, set post-construction
+        # by ``AgentRegistry.spawn_session_recorded`` from an explicit CALLER
+        # decision, never derived from ``mode``. True by default: the common case
+        # (an interactive chat session, direct/test construction) has someone
+        # waiting. See ``OpContext.attended``'s own docstring for the full
+        # 3-state table this feeds.
+        self._attended: bool = True
         # Lazily-resolved minimal _untrusted profile cache (#1827 S4b, see docs/reference/runtime/session-construction.md#capability-permission-visibility)
         self._untrusted_contextual_cache = None
         # excluded_categories (#1667) + the visibility override (#2285) are owned by
@@ -3994,6 +4002,10 @@ class Session:
             # above and the existing ``ephemeral_fn`` this Session already
             # threads to the MCP gateway (``_mcp_list_via_gateway``, below).
             ephemeral_fn=lambda: self._ephemeral,
+            # #4193 ①: live — ``_attended`` is reassigned post-construction the
+            # same way ``_ephemeral`` is (``AgentRegistry.spawn_session_recorded``,
+            # not mode-derived — see ``Session._attended``'s own docstring).
+            attended_fn=lambda: self._attended,
         )
         # #3482/#3447: the 3-param mcp-gateway cluster (sole reader:
         # RouterHostAdapter._mcp_list_via_gateway) — a real consumer-set

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -54,6 +54,7 @@ _INERT_OP_CONTEXT_SOURCE_FIELDS: dict = {
     "budget_gateway": None,
     "available_skills_fn": None,
     "ephemeral_fn": None,  # #3903 a-2 ③
+    "attended_fn": None,  # #4193 ①
 }
 
 

--- a/tests/core/test_op_sandboxed_exec.py
+++ b/tests/core/test_op_sandboxed_exec.py
@@ -320,6 +320,70 @@ async def test_sandboxed_exec_non_ephemeral_omitted_timeout_stays_foreground():
 
 
 @pytest.mark.asyncio
+async def test_sandboxed_exec_unattended_omitted_timeout_gets_the_background_default():
+    """Tier 2: #4193 ① — the gap this issue closes. A NON-ephemeral,
+    UNATTENDED session's exec (the ``session_spawn`` LLM tool's
+    fire-and-forget dispatch — nobody is waiting, regardless of
+    ``mode``) gets the background pair, same as an ephemeral exec does —
+    proving ``not ctx.attended`` alone (independent of ``ctx.ephemeral``)
+    routes to the background default. Before #4193 this ctx (ephemeral
+    stays at its own False default) got the foreground pair, the exact
+    bug this issue opened on."""
+    import dataclasses
+
+    ctx, _events = _make_ctx()
+    ctx = dataclasses.replace(ctx, attended=False)
+    backend = _RecordingBackend()
+    ctx.sandbox_backend = backend
+    op = SandboxedExecIROp(kind="sandboxed_exec", argv=["/bin/echo", "x"])
+
+    await execute_op(op, ctx)
+
+    assert backend.received_policy is not None
+    assert backend.received_policy.timeout_seconds == 3600, (
+        f"an unattended (fire-and-forget) exec must get the background "
+        f"default (3600), got {backend.received_policy.timeout_seconds}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sandboxed_exec_ephemeral_and_attended_still_gets_the_background_default():
+    """Tier 2: #4193 ① — the falsify witness architect's own review of this
+    fix required (#4193 co-vet, 2026-08-11): ``ctx.ephemeral or not
+    ctx.attended`` has TWO disjuncts and neither is redundant, despite how
+    it looks. The real predicate the pair approximates is "is a HUMAN
+    waiting", and there are three states, not two — an agent-step leaf
+    worker (``spawn_ephemeral_session`` + ``run_agent_step``'s synchronous
+    ``MessageBus.request``) is the one case where BOTH ``ephemeral=True``
+    AND ``attended=True`` are real at once: a PROGRAM is waiting
+    (attended), but that worker's own execs still need the background
+    pair (ephemeral) because no human is at the other end of that wait.
+
+    This is the ONE case a naive simplification to ``not ctx.attended``
+    alone (dropping the ``ephemeral`` disjunct as "apparently redundant")
+    would break — narrowing an agent-step exec from 3600s to 120s and
+    failing any agent step that itself runs a long exec. A gate that does
+    not pin this exact combination does not protect the fix at all."""
+    import dataclasses
+
+    ctx, _events = _make_ctx()
+    ctx = dataclasses.replace(ctx, ephemeral=True, attended=True)
+    backend = _RecordingBackend()
+    ctx.sandbox_backend = backend
+    op = SandboxedExecIROp(kind="sandboxed_exec", argv=["/bin/echo", "x"])
+
+    await execute_op(op, ctx)
+
+    assert backend.received_policy is not None
+    assert backend.received_policy.timeout_seconds == 3600, (
+        f"an ephemeral-AND-attended exec (the agent-step leaf worker shape) "
+        f"must still get the background default (3600) — a 'not attended "
+        f"alone' simplification would have narrowed this to 120, got "
+        f"{backend.received_policy.timeout_seconds}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_sandboxed_exec_ephemeral_llm_override_checked_against_background_max():
     """Tier 2: #3903 a-2 ③ — an ephemeral exec's LLM-supplied timeout is
     checked against policy.background_max_timeout_seconds (None = no cap

--- a/tests/runtime/test_2103_s1bc_session_spawn_tool.py
+++ b/tests/runtime/test_2103_s1bc_session_spawn_tool.py
@@ -98,6 +98,54 @@ async def test_spawn_session_recorded_no_narrowing_is_inert(tmp_path: Path) -> N
     assert any(e.get("kind") == "session_spawned" for e in reg.state_log.iter_from(0))
 
 
+@pytest.mark.asyncio
+async def test_spawn_session_recorded_attended_false_reaches_the_sessions_op_context(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #4193 ① — the end-to-end wiring witness. ``attended=False`` passed
+    to ``spawn_session_recorded`` (the parameter ``RouterHostAdapter.spawn_session``
+    — the ``session_spawn`` LLM tool's dispatch target — sets unconditionally,
+    regardless of ``mode``, see that method's own comment) reaches the SPAWNED
+    session's own live-built ``OpContext`` — not just ``Session._attended`` in
+    isolation, but the actual value ``sandboxed_exec.handle`` would read for an
+    op running inside that session. Read via ``_make_router_op_context()``, the
+    same accessor a dozen other tests in this suite already use as the public
+    product of a Session (not private state — it's the OpContext ITSELF, this
+    just triggers its on-demand construction)."""
+    reg = _registry(tmp_path)
+    sid = await reg.spawn_session_recorded(
+        "worker", mode="persistent", attended=False,
+        presentation_consumer=None, intervention_bridge=None,
+    )
+    session = reg.get_session("worker", sid)
+    assert session is not None
+    ctx = session._make_router_op_context()
+    assert ctx.attended is False, (
+        "attended=False at spawn time did not reach the spawned session's own "
+        "OpContext — sandboxed_exec would still pick the foreground pair for "
+        "this fire-and-forget session, the exact #4193 gap"
+    )
+
+
+@pytest.mark.asyncio
+async def test_spawn_session_recorded_default_attended_stays_true(tmp_path: Path) -> None:
+    """Tier 2: accept-side sibling — a spawn that does NOT pass ``attended``
+    (the attached pipeline driver's and the agent-step worker's own call
+    sites, neither of which name it) leaves the spawned session's OpContext
+    at ``attended=True``, the common "someone is waiting" case. Isolates the
+    branch actually exercised by the test above: same call, only the
+    ``attended`` argument differs."""
+    reg = _registry(tmp_path)
+    sid = await reg.spawn_session_recorded(
+        "worker", mode="persistent",
+        presentation_consumer=None, intervention_bridge=None,
+    )
+    session = reg.get_session("worker", sid)
+    assert session is not None
+    ctx = session._make_router_op_context()
+    assert ctx.attended is True
+
+
 # ── the tool: registration + schema + handler dispatch ──────────────────────
 
 


### PR DESCRIPTION
**[tui-coder]** —

The gap: `session_spawn`'s tool dispatch (`RouterHostAdapter.spawn_session`)
returns a spawn-ack and submits the task without awaiting completion —
regardless of `mode`. A persistent-mode spawn through that one path was
therefore fire-and-forget (nobody waiting) yet still got the FOREGROUND
`sandboxed_exec` timeout pair (120s), because `OpContext.ephemeral` (`mode
== "ephemeral"` only) was the sole axis `sandboxed_exec.handle` read.

## Traced the call graph first

Posted to architect for design confirmation before touching anything (per
lead-coder's instruction to escalate design calls): the real predicate is
WHICH CALLER spawned the session, not `mode`.

- `session_spawn` tool dispatch: always unattended, both modes.
- `run_agent_step` (`spawn_ephemeral_session`): attended — `MessageBus.
  request` synchronously awaits one prompt-response.
- `_spawn_pipeline_driver_session` (`run_pipeline_attached`): attended —
  the pipeline executor directly awaits the driver.

## Architect ruling (#4193 issue comment, 2026-08-11)

Approved the shape (session-sticky flag, named `attended` not `background`
— the latter would re-collapse the false equivalence with `ephemeral`
#3903③ deliberately avoided), approved the boundary (`session_spawn` tool
= always False regardless of mode), and caught a real trap before it
shipped: `ephemeral or not attended` reads as redundant (an unattended
exec is already covered by `ephemeral`, right?) but is NOT — the true
predicate is "is a HUMAN waiting", and there are three states:

```
interactive chat turn    a human waits                  -> foreground
agent-step leaf worker   a PROGRAM waits (ephemeral=True -> background
                          AND attended=True — MessageBus
                          .request synchronously awaits,
                          but the waiter isn't human)
session_spawn            nobody waits (attended=False)   -> background
```

Dropping the `ephemeral` disjunct to "simplify" to `not attended` alone
would narrow an agent-step worker's execs from the background pair
(3600s) to the foreground one (120s), failing any agent step that itself
runs a long exec. This PR pins that exact combination with a
falsify-verified test.

## What changed

- `core/op_runtime/context.py`: new `OpContext.attended: bool = True`
  field, with the residual comment architect required — WHY both
  disjuncts are load-bearing ("removing X breaks Y" form, comments.md).
- `core/op_runtime/sandboxed_exec.py`: `if ctx.ephemeral:` -> `if
  ctx.ephemeral or not ctx.attended:`.
- `runtime/router_op_context.py`: `attended` threaded through
  `build_router_op_context` / `RouterOpContextSource` (mirrors
  `ephemeral`'s own `_fn`-supplied-callable shape exactly).
- `runtime/session.py`: new `Session._attended: bool = True`, threaded
  the same way `_ephemeral` already is.
- `runtime/registry.py`: `spawn_session_recorded` gains `attended: bool
  = True`; sets it unconditionally (NOT mode-derived, unlike
  `_ephemeral`'s `mode == "ephemeral"` gate).
- `runtime/services/router_host_adapter.py`: `RouterHostAdapter.
  spawn_session` (the `session_spawn` LLM tool's dispatch target) passes
  `attended=False` — the one caller that does.
- `tests/_support/router_host_adapter.py`: the loud-fail-by-design
  `_INERT_OP_CONTEXT_SOURCE_FIELDS` dict gains `attended_fn`.
- `tests/core/test_op_sandboxed_exec.py`: 3 new tests — unattended-
  persistent gets background (the fix), and the required falsify witness
  (ephemeral=True AND attended=True still gets background).
- `tests/runtime/test_2103_s1bc_session_spawn_tool.py`: 2 new
  end-to-end wiring tests (real AgentRegistry + real Session factory, no
  mocks) — `attended=False` at spawn time reaches the spawned session's
  own live `OpContext`.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python3 scripts/mypy_ratchet.py` — clean (212/216 baselined, no new)
- [x] `python3 scripts/test_tier_audit.py --strict` on both touched test
  files — 38 OK, 0 errors
- [x] `python3 scripts/verify_module_docstrings.py` — clean
- [x] `python3 scripts/check_tests_path_literal_reference.py` — clean
- [x] Falsify-verify #1: the critical ephemeral-and-attended test
  genuinely failed against a `not ctx.attended`-only implementation,
  confirming it pins the exact trap architect named.
- [x] Falsify-verify #2: the end-to-end wiring test genuinely failed
  when `spawned_session._attended = attended` was removed from
  registry.py.
- [x] Full `tests/core/` sweep: 2505 passed, 1 pre-existing unrelated
  failure (`setproctitle` module absent in this local venv — reproduces
  identically on a clean `main` checkout, confirmed before attributing
  it here).
- [x] Targeted `tests/runtime/ tests/core/` sweep on spawn/ephemeral/
  attended/sandboxed_exec/router_op_context/router_host_adapter: 217
  passed.

part of #4193

🤖 Generated with [Claude Code](https://claude.com/claude-code)
