### PR TITLE
feat(#3787): read-only turn-boundary edit detection for AGENTS.md/REYN.md

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -174,6 +174,7 @@ presentation_install_blocked
 presentation_installed
 presentation_load_failed
 presented
+project_context_changed
 router_context_overflow_detected
 router_context_overflow_unrecovered
 router_empty_response_detected
@@ -369,6 +370,7 @@ Required fields are declared in `src/reyn/core/events/event_schema.py`.
 | `turn_started` | A trigger has been consumed from the inbox and is about to be dispatched. | `kind` — the inbox message kind that triggered this turn, so a subscriber can tell human triggers from automated ones without parsing the payload. The vocabulary is CLOSED and enumerated in `TurnOrigin` (`src/reyn/runtime/turn_origin.py`) — read the member values there rather than a list here, which is how `"task_ready"` outlived the task system in this row. #3595 made `kind == "user"` TRUE rather than approximate: a pipeline agent step's prompt (step 1), a webhook / MCP / A2A / cron push (step 1b), and the attached-pipeline run nudge (S2) each used to arrive claiming it; each now carries its own member, so `"user"` means an operator typed the line at a first-party client and nothing else does. `chain_id`; `seq` |
 | `turn_completed` | The router loop reached a terminal condition — router path only. | `chain_id` |
 | `turn_settled` | The turn is done, for EVERY turn kind including slash / intervention short-circuits that return before the router. The reliable clear signal for a working indicator started on `turn_started`. | `kind`; `chain_id` (may be absent for non-user triggers) |
+| `project_context_changed` | Turn boundary (`ProjectContextWatcher.check`, `src/reyn/runtime/project_context_watch.py`, #3787): the project context file's (`AGENTS.md` / `REYN.md`) mtime differs from what was last observed. Fires once per edit, never repeats until the file changes again. **Detection only** — the live `project_context` a session's system prompt was built with is NOT reloaded; the file is fenced as untrusted operator data before it reaches the prompt (`RouterHostAdapter.get_project_context`), so re-reading it is deliberately not wired through the LLM-writable hot-reload IN-set. What to do with a detected change (surface-only vs. actually reload) is an open decision, not yet made. | `path` |
 
 ## Tool dispatch
 

--- a/scripts/mypy_ratchet_baseline.json
+++ b/scripts/mypy_ratchet_baseline.json
@@ -640,10 +640,6 @@
     "code": "misc"
   },
   {
-    "file": "src/reyn/runtime/project_context_watch.py",
-    "code": "attr-defined"
-  },
-  {
     "file": "src/reyn/runtime/registry.py",
     "code": "arg-type"
   },

--- a/scripts/mypy_ratchet_baseline.json
+++ b/scripts/mypy_ratchet_baseline.json
@@ -640,6 +640,10 @@
     "code": "misc"
   },
   {
+    "file": "src/reyn/runtime/project_context_watch.py",
+    "code": "attr-defined"
+  },
+  {
     "file": "src/reyn/runtime/registry.py",
     "code": "arg-type"
   },

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -76,6 +76,34 @@ def _load_yaml(path: Path) -> dict:
 DEFAULT_PROJECT_CONTEXT_FILES: tuple[str, ...] = ("AGENTS.md", "REYN.md")
 
 
+def resolve_project_context_path(config: ReynConfig, project_root: "Path | None") -> "Path | None":
+    """Resolve WHICH file :func:`load_project_context` would read, without
+    reading it — the same candidate walk, extracted (#3787) so a caller that
+    only needs the path (e.g. the turn-boundary edit-detection watcher) isn't
+    forced to also pay for + discard a full read.
+
+    Same resolution as :func:`load_project_context`'s docstring: ``None`` →
+    auto-resolve (``AGENTS.md`` else ``REYN.md``, first EXISTING wins);
+    explicit non-empty → pin that file; explicit ``""`` → disabled (``None``).
+    Returns ``None`` when disabled or no candidate exists.
+    """
+    if project_root is None:
+        return None
+    rel = config.project_context_path
+    if rel is None:
+        candidates: tuple[str, ...] = DEFAULT_PROJECT_CONTEXT_FILES
+    else:
+        rel = rel.strip()
+        if not rel:
+            return None
+        candidates = (rel,)
+    for name in candidates:
+        target = project_root / name
+        if target.is_file():
+            return target
+    return None
+
+
 def load_project_context(config: ReynConfig, project_root: Path) -> str:
     """Read the project context markdown file for the system prompt.
 
@@ -92,24 +120,13 @@ def load_project_context(config: ReynConfig, project_root: Path) -> str:
     system-prompt section. The first EXISTING candidate is authoritative even
     if empty (AGENTS.md present-but-empty does not fall through to REYN.md).
     """
-    if project_root is None:
+    target = resolve_project_context_path(config, project_root)
+    if target is None:
         return ""
-    rel = config.project_context_path
-    if rel is None:
-        candidates: tuple[str, ...] = DEFAULT_PROJECT_CONTEXT_FILES
-    else:
-        rel = rel.strip()
-        if not rel:
-            return ""
-        candidates = (rel,)
-    for name in candidates:
-        target = project_root / name
-        if target.is_file():
-            try:
-                return target.read_text(encoding="utf-8").strip()
-            except OSError:
-                return ""
-    return ""
+    try:
+        return target.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
 
 
 def build_policy_tier_config(cwd: Path | None = None) -> dict:

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -346,6 +346,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "presentation_installed",
     "presentation_load_failed",
     "presented",
+    "project_context_changed",
     "router_context_overflow_detected",
     "router_context_overflow_unrecovered",
     "router_empty_response_detected",

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -498,7 +498,7 @@ def _run(args: argparse.Namespace) -> None:
         _run_remote(args)
         return
 
-    from reyn.config import _find_project_root, load_project_context
+    from reyn.config import _find_project_root, load_project_context, resolve_project_context_path
     from reyn.interfaces.repl.repl import run_repl
     from reyn.llm.llm import run_async
     from reyn.runtime.factory_config import SessionFactoryConfig
@@ -599,6 +599,8 @@ def _run(args: argparse.Namespace) -> None:
     # container file-zone anchor (file_zone_root). It isn't used before then.
 
     project_context = load_project_context(session_cfg.config, project_root)
+    # #3787: read-only turn-boundary edit-detection watcher target.
+    project_context_path = resolve_project_context_path(session_cfg.config, project_root)
 
     # #1289: build the agent-level EnvironmentBackend (host / docker attach|launch)
     # and pass the SAME instance to BOTH Session seams (FS environment_backend
@@ -657,6 +659,7 @@ def _run(args: argparse.Namespace) -> None:
             output_language=output_language,
             prompt_cache_enabled=session_cfg.config.prompt_cache_enabled,
             project_context=project_context,
+            project_context_path=project_context_path,
             agent_role=profile.role,
             compaction_config=session_cfg.config.chat.compaction,
             reasoning_config=session_cfg.config.chat.reasoning,  # #1652

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -465,7 +465,12 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
     from dataclasses import replace
     from pathlib import Path
 
-    from reyn.config import _find_project_root, load_config, load_project_context
+    from reyn.config import (
+        _find_project_root,
+        load_config,
+        load_project_context,
+        resolve_project_context_path,
+    )
     from reyn.core.events.event_store import EventStore
     from reyn.dev.dogfood.runner import ScenarioRunResult
     from reyn.llm.model_resolver import ModelResolver
@@ -490,6 +495,8 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
     output_language = config.output_language
     safety = config.safety
     project_context = load_project_context(config, project_root)
+    # #3787: read-only turn-boundary edit-detection watcher target.
+    project_context_path = resolve_project_context_path(config, project_root)
     perm_config = getattr(config, "permissions", {}) or {}
 
     perm_resolver = PermissionResolver(
@@ -542,6 +549,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 output_language=output_language,
                 prompt_cache_enabled=config.prompt_cache_enabled,
                 project_context=project_context,
+                project_context_path=project_context_path,
                 agent_role=profile.role,
                 compaction_config=config.chat.compaction,
                 reasoning_config=config.chat.reasoning,  # #1652

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -400,7 +400,7 @@ def _anchor_project_root(args: argparse.Namespace) -> Path:
 
 
 def run_serve(args: argparse.Namespace) -> None:
-    from reyn.config import load_project_context
+    from reyn.config import load_project_context, resolve_project_context_path
     from reyn.core.events.state_log import StateLog
     from reyn.llm.llm import run_async
     from reyn.mcp.server import serve_stdio
@@ -442,6 +442,8 @@ def run_serve(args: argparse.Namespace) -> None:
     )
 
     project_context = load_project_context(session_cfg.config, project_root)
+    # #3787: read-only turn-boundary edit-detection watcher target.
+    project_context_path = resolve_project_context_path(session_cfg.config, project_root)
 
     def _session_factory(profile: AgentProfile, *, presentation_consumer=None, intervention_bridge=None):
         # #1827 S3: resolve the agent's topology capability_profile (None/∅ unbound).
@@ -463,6 +465,7 @@ def run_serve(args: argparse.Namespace) -> None:
             output_language=output_language,
             prompt_cache_enabled=session_cfg.config.prompt_cache_enabled,
             project_context=project_context,
+            project_context_path=project_context_path,
             agent_role=profile.role,
             compaction_config=session_cfg.config.chat.compaction,
             reasoning_config=session_cfg.config.chat.reasoning,  # #1652

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -286,7 +286,7 @@ _registry = None
 def _get_registry():
     global _registry
     if _registry is None:
-        from reyn.config import load_project_context
+        from reyn.config import load_project_context, resolve_project_context_path
         from reyn.runtime.factory_config import SessionFactoryConfig
         from reyn.runtime.presentation_consumer import NullPresentationConsumer
         from reyn.runtime.profile import AgentProfile
@@ -299,6 +299,8 @@ def _get_registry():
         budget_tracker = _get_budget_tracker()
         perm_resolver = _get_perm_resolver()
         project_context = load_project_context(config, root)
+        # #3787: read-only turn-boundary edit-detection watcher target.
+        project_context_path = resolve_project_context_path(config, root)
 
         # #2683: ``LITELLM_API_BASE`` export folded into ``load_config()`` — the
         # single canonical writer (universal chokepoint). ``_load_config()`` above
@@ -355,6 +357,7 @@ def _get_registry():
                 output_language=output_language,
                 prompt_cache_enabled=config.prompt_cache_enabled,
                 project_context=project_context,
+                project_context_path=project_context_path,
                 agent_role=profile.role,
                 compaction_config=config.chat.compaction,
                 reasoning_config=config.chat.reasoning,  # #1652

--- a/src/reyn/runtime/project_context_watch.py
+++ b/src/reyn/runtime/project_context_watch.py
@@ -1,0 +1,76 @@
+"""ProjectContextWatcher — read-only turn-boundary edit detection for the
+project context file (AGENTS.md / REYN.md), #3787.
+
+Deliberately NOT the #2073 HotReloader mechanism: that machinery re-reads
+the IN-set (``.reyn/{mcp,cron,hooks,skills,pipelines,presentations}.yaml``)
+because an LLM-op (``skill_install`` etc.) can request a reload — the IN-set
+IS "the face the LLM is allowed to write". The project context file is
+different in kind, not just format: ``RouterHostAdapter.get_project_context``
+fences + scans its content before it reaches the system prompt (FP-0050/
+#1822 S4b, EP3 Class A) — reyn itself treats this file as UNTRUSTED
+operator-authored data. Wiring it into the LLM-writable IN-set would let the
+LLM write its own untrusted-data source, an inversion the fence exists to
+prevent. So this watcher only ever READS: it detects that the file changed
+and emits an audit-event; it never re-reads the content into the live
+prompt itself (architect ruling, #3787 — what to DO with a detected change,
+notify-only vs. actually replace, is an open owner decision, ③).
+
+mtime-based, not content-hash: this is a detection *signal*, not a cache
+guard — the system prompt renderer is deterministic on ``project_context``
+content, so re-reading the SAME content every turn would still hit the
+prompt cache regardless of how the change is detected (architect
+correction, #3787 — a hash-based re-render would guard nothing an mtime
+check doesn't already surface, and would cost a full read every turn for
+no benefit). One event per edit is the goal; the mtime comparison gives
+that at the cost of one ``stat()`` per turn.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class ProjectContextWatcher:
+    """Turn-boundary check: has the project context file's mtime moved since
+    construction (or the last detected change)? Read-only — never touches
+    the live ``project_context`` string a `Session` was built with."""
+
+    def __init__(self, *, path: "Path | None", events: "object | None") -> None:
+        self._path = path
+        self._events = events
+        self._last_mtime_ns = self._stat(path)
+
+    @staticmethod
+    def _stat(path: "Path | None") -> "int | None":
+        if path is None:
+            return None
+        try:
+            return path.stat().st_mtime_ns
+        except OSError:
+            # Deleted / unreadable since construction — treated as "no baseline
+            # to compare against" rather than a change; a later re-appearance
+            # will compare against this None and fire (arguably correct: the
+            # file coming back IS an edit relative to what the session started
+            # with).
+            return None
+
+    def check(self) -> bool:
+        """Call at the turn boundary. Returns True (and emits exactly one
+        ``project_context_changed`` P6 event) the first time the file's
+        mtime differs from the last observed value; False otherwise
+        (including: never configured, file missing both times, unchanged).
+
+        Idempotent per edit: after firing, the new mtime becomes the
+        baseline, so an unchanged file never fires again on subsequent
+        turns."""
+        if self._path is None:
+            return False
+        current = self._stat(self._path)
+        if current == self._last_mtime_ns:
+            return False
+        self._last_mtime_ns = current
+        if self._events is not None:
+            self._events.emit("project_context_changed", path=str(self._path))
+        return True

--- a/src/reyn/runtime/project_context_watch.py
+++ b/src/reyn/runtime/project_context_watch.py
@@ -31,13 +31,15 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from reyn.core.events.events import EventLog
+
 
 class ProjectContextWatcher:
     """Turn-boundary check: has the project context file's mtime moved since
     construction (or the last detected change)? Read-only — never touches
     the live ``project_context`` string a `Session` was built with."""
 
-    def __init__(self, *, path: "Path | None", events: "object | None") -> None:
+    def __init__(self, *, path: "Path | None", events: "EventLog | None") -> None:
         self._path = path
         self._events = events
         self._last_mtime_ns = self._stat(path)

--- a/src/reyn/runtime/registry_bootstrap.py
+++ b/src/reyn/runtime/registry_bootstrap.py
@@ -139,7 +139,7 @@ def build_agent_registry_from_project(
     against (e.g. an ``AgentStep``'s own ``identity`` narrows further, or
     falls back to the pipeline run's ``default_identity``).
     """
-    from reyn.config import load_project_context
+    from reyn.config import load_project_context, resolve_project_context_path
     from reyn.llm.model_resolver import ModelResolver
     from reyn.runtime.factory_config import SessionFactoryConfig
     from reyn.runtime.presentation_consumer import OutboxPresentationConsumer
@@ -163,6 +163,11 @@ def build_agent_registry_from_project(
     )
 
     project_context = load_project_context(config, project_root)
+    # #3787: the resolved path (not just the content) so Session can watch it
+    # for edits at the turn boundary — read-only detection, see
+    # ProjectContextWatcher's module docstring for why this is not the #2073
+    # hot-reload IN-set.
+    project_context_path = resolve_project_context_path(config, project_root)
     resolver = ModelResolver(
         config.models,
         default_class=config.model,
@@ -196,6 +201,7 @@ def build_agent_registry_from_project(
             output_language=config.output_language,
             prompt_cache_enabled=config.prompt_cache_enabled,
             project_context=project_context,
+            project_context_path=project_context_path,
             agent_role=profile.role,
             compaction_config=config.chat.compaction,
             reasoning_config=config.chat.reasoning,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -883,6 +883,11 @@ class Session:
         output_language: str | None = None,
         prompt_cache_enabled: bool = True,
         project_context: str = "",
+        # #3787: the resolved AGENTS.md/REYN.md path this session's ``project_context``
+        # was read from (``None`` when disabled/absent) — read-only turn-boundary edit
+        # detection ONLY; see ``ProjectContextWatcher``'s module docstring for why this
+        # is not wired through the #2073 hot-reload IN-set.
+        project_context_path: "Path | None" = None,
         compaction_config: "CompactionConfig | None" = None,
         reasoning_config: "ReasoningConfig | None" = None,  # #1652 chat.reasoning
         registry: "AgentRegistry | None" = None,
@@ -1250,6 +1255,13 @@ class Session:
         # Publish as the process-wide active reloader so the hooks-write LLM-op can request_reload (#2073 S3, see session-construction.md#family-3-hook-event-reactivity)
         from reyn.runtime.hot_reload import set_active_hot_reloader
         set_active_hot_reloader(self._hot_reloader)
+        # #3787: project-context (AGENTS.md/REYN.md) read-only edit-detection watcher.
+        # Deliberately NOT the HotReloader above — see ProjectContextWatcher's module
+        # docstring for why this file cannot go through the LLM-writable IN-set.
+        from reyn.runtime.project_context_watch import ProjectContextWatcher
+        self._project_context_watcher = ProjectContextWatcher(
+            path=project_context_path, events=self._audit_events,
+        )
         # Publish this session's EventLog as the ambient LLM-chokepoint sink (#1669, see docs/reference/runtime/session-construction.md#family-1-audit-event-spine-p6)
         from reyn.core.events.events import set_llm_request_event_log
         set_llm_request_event_log(self._audit_events)
@@ -7881,6 +7893,9 @@ class Session:
         # #2073 S1: config hot-reload turn-boundary safe-point (timing-B):
         # docs/concepts/runtime/config-hot-reload.md#turn-boundary-safe-point-timing-b
         await self._hot_reloader.apply_pending()
+        # #3787: project-context edit detection — read-only, emits at most once per
+        # edit; does NOT reload ``self._project_context`` (see ProjectContextWatcher).
+        self._project_context_watcher.check()
         # ADR-0038 Stage 1a: turn boundary = a user-facing checkpoint. #1547: the
         # user message is this checkpoint's anchor for the rewind-timeline preview.
         # #1533 2c: the FULL message is persisted alongside (edit-prefill source).

--- a/tests/runtime/test_3787_project_context_watch.py
+++ b/tests/runtime/test_3787_project_context_watch.py
@@ -1,0 +1,106 @@
+"""Tier 2: #3787 — ``ProjectContextWatcher`` detects an edit to the project
+context file (AGENTS.md/REYN.md) at the turn boundary via mtime comparison,
+and emits a ``project_context_changed`` P6 event exactly once per edit.
+
+Read-only by design (architect ruling, #3787): the watcher never re-reads the
+file's content into anything — it only compares ``stat().st_mtime_ns`` and
+emits a detection signal. What consumes that signal (surface-only vs. actually
+reloading the live prompt) is a separate, not-yet-made owner decision — this
+test file covers ONLY the detection mechanism, never a reload.
+
+No mocks: a real ``EventLog`` + real files on ``tmp_path``, real ``os.utime``
+to force a distinguishable mtime.
+"""
+from __future__ import annotations
+
+import os
+
+from reyn.core.events.events import EventLog
+from reyn.runtime.project_context_watch import ProjectContextWatcher
+from tests._support.events import collect_events
+
+
+def _touch(path, *, mtime_ns: int) -> None:
+    path.write_text("content", encoding="utf-8")
+    os.utime(path, ns=(mtime_ns, mtime_ns))
+
+
+def test_no_configured_path_never_fires(tmp_path) -> None:
+    """Tier 2: #3787 — ``path=None`` (context disabled or never resolved) is a
+    permanent no-op, never touches the event log."""
+    log = EventLog()
+    collected = collect_events(log)
+    watcher = ProjectContextWatcher(path=None, events=log)
+
+    assert watcher.check() is False
+    assert watcher.check() is False
+    assert not [e for e in collected if e.type == "project_context_changed"]
+
+
+def test_unchanged_file_never_fires(tmp_path) -> None:
+    """Tier 2: #3787 — accept-side: a file whose mtime never moves produces no
+    event across repeated turn-boundary checks (no false positives)."""
+    agents_md = tmp_path / "AGENTS.md"
+    _touch(agents_md, mtime_ns=1_000_000_000)
+    log = EventLog()
+    collected = collect_events(log)
+    watcher = ProjectContextWatcher(path=agents_md, events=log)
+
+    for _ in range(3):
+        assert watcher.check() is False
+    assert not [e for e in collected if e.type == "project_context_changed"]
+
+
+def test_edit_fires_exactly_once(tmp_path) -> None:
+    """Tier 2: #3787 — an mtime change fires the event exactly once, then goes
+    quiet again (idempotent per edit — a subsequent unchanged check does not
+    repeat it)."""
+    agents_md = tmp_path / "AGENTS.md"
+    _touch(agents_md, mtime_ns=1_000_000_000)
+    log = EventLog()
+    collected = collect_events(log)
+    watcher = ProjectContextWatcher(path=agents_md, events=log)
+
+    assert watcher.check() is False  # baseline, nothing changed yet
+
+    _touch(agents_md, mtime_ns=2_000_000_000)  # the "edit"
+    assert watcher.check() is True
+    assert watcher.check() is False  # same mtime again — quiet
+    assert watcher.check() is False
+
+    (event,) = [e for e in collected if e.type == "project_context_changed"]
+    assert event.data["path"] == str(agents_md)
+
+
+def test_a_second_edit_fires_again(tmp_path) -> None:
+    """Tier 2: #3787 — the detector re-arms: a SECOND edit after the first was
+    observed fires its own event (not a one-shot "changed once, ever")."""
+    agents_md = tmp_path / "AGENTS.md"
+    _touch(agents_md, mtime_ns=1_000_000_000)
+    log = EventLog()
+    collected = collect_events(log)
+    watcher = ProjectContextWatcher(path=agents_md, events=log)
+    watcher.check()  # baseline
+
+    _touch(agents_md, mtime_ns=2_000_000_000)
+    assert watcher.check() is True
+
+    _touch(agents_md, mtime_ns=3_000_000_000)
+    assert watcher.check() is True
+
+    # Unpack-enforcement: exactly two fires, one per edit (not zero, not more).
+    (first, second) = [e for e in collected if e.type == "project_context_changed"]
+    assert first.data["path"] == second.data["path"] == str(agents_md)
+
+
+def test_no_events_sink_is_a_safe_no_op(tmp_path) -> None:
+    """Tier 2: #3787 — accept-side: ``events=None`` (no ambient EventLog, e.g.
+    CLI one-shot paths) still detects the change (return value) without
+    raising, it just cannot emit anywhere."""
+    agents_md = tmp_path / "AGENTS.md"
+    _touch(agents_md, mtime_ns=1_000_000_000)
+    watcher = ProjectContextWatcher(path=agents_md, events=None)
+    watcher.check()
+
+    _touch(agents_md, mtime_ns=2_000_000_000)
+    assert watcher.check() is True  # detected, no raise, nothing to assert on a sink


### PR DESCRIPTION
**[e2e-coder]** —

## Scope: the non-controversial part only (per lead-coder's explicit split)

Consult-before-implementing on #3787 (issue + broker) surfaced 3 design points; architect ruled on all 3 (posted to #3787). ③ ("what to do with a detected change — notify-only vs. actually reload") is an **open owner decision, not made here**. This PR implements only what both lead-coder and architect signed off as uncontroversial: read-only detection, one audit-event, no LLM write path.

## Why not the #2073 hot-reload IN-set

`RouterHostAdapter.get_project_context()` fences + scans the file's content before it reaches the system prompt (FP-0050/#1822 S4b, EP3 Class A) — reyn itself treats AGENTS.md/REYN.md as **untrusted operator data**. The IN-set exists for files an LLM-op is allowed to write (`skill_install` etc.); folding this file into it would let the LLM write its own untrusted-data source. This is the decisive reason (architect correction) — not "different file format."

## What changed

- **`ProjectContextWatcher`** (new, `src/reyn/runtime/project_context_watch.py`): mtime-based, read-only. `check()` at the turn boundary (same call site as `HotReloader.apply_pending()`) — fires `project_context_changed` at most once per edit, never re-reads content into the live prompt.
- **mtime, not content-hash**: architect correction on my initial framing — the SP renderer is deterministic on content, so re-reading the same content every turn already hits the prompt cache regardless of detection method. This is a *notification signal*, not a cache guard (comments say this explicitly, so a future reader doesn't reinstate a wrong "protects cache" rationale).
- **New audit-event kind `project_context_changed`**: emit + `AUDIT_EVENT_KINDS` declaration + `events.md` doc, same PR (#3410 vocabulary gate requires the 3-part change together).
- **`loader.py`**: extracted `resolve_project_context_path` from `load_project_context`'s candidate walk (the watcher needs the resolved PATH, not the read content) — `load_project_context` now calls it internally, behavior-identical.
- **`Session.__init__`**: new `project_context_path` param, watcher constructed alongside `HotReloader`, checked alongside `apply_pending()`.
- All 5 `load_project_context` call sites (`registry_bootstrap.py`, `web/deps.py`, `dogfood.py`, `chat.py`, `mcp.py`) now also resolve + pass `project_context_path`.

## Test

New `tests/runtime/test_3787_project_context_watch.py` (5 tests): no-path no-op, unchanged-file no false positive, single edit fires exactly once, a second edit re-arms and fires again, `events=None` detects without raising.

**Falsify-verified**: disabled the mtime-comparison branch, ran the suite — 3/5 went RED with the predicted "detection never fires" failure, restored, green.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_3787_project_context_watch.py` — 5 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py` (touched src files) — clean
- [x] `python scripts/mypy_ratchet.py` — clean (212/216 baselined, **net -1**: typed `events` as `"EventLog | None"` (TYPE_CHECKING import, the real runtime value) instead of `"object | None"` — resolves `.emit()` properly, no baseline entry needed. Follow-up: `HotReloader` carries the same `object | None` pattern 6× for the identical reason; same fix applies there too — separate PR, e2e-coder picking it up.
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] `pytest tests/runtime/test_3787_project_context_watch.py tests/core/test_audit_event_kind_vocabulary_3410.py tests/config/ tests/runtime/test_2073_s1_hot_reloader.py` — 179 passed
- [x] `pytest tests/runtime/test_scoped_session_factory_invariant_1402.py tests/runtime/test_2093_factory_config_bundle.py tests/runtime/test_2585_pr2_ephemeral_non_interactive_force.py` — 9 passed (Session-construction regression sweep, all 5 call sites touched)
- [x] Falsify-verify (see above)

part of #3787

🤖 Generated with [Claude Code](https://claude.com/claude-code)
