### PR TITLE
fix(runtime): type HotReloader's events param as EventLog, not object

### DIFF
--- a/scripts/mypy_ratchet_baseline.json
+++ b/scripts/mypy_ratchet_baseline.json
@@ -616,10 +616,6 @@
     "code": "call-arg"
   },
   {
-    "file": "src/reyn/runtime/hot_reload.py",
-    "code": "attr-defined"
-  },
-  {
     "file": "src/reyn/runtime/inbox_arbiter.py",
     "code": "arg-type"
   },

--- a/src/reyn/runtime/hot_reload.py
+++ b/src/reyn/runtime/hot_reload.py
@@ -28,6 +28,8 @@ from reyn.config.loader import load_hot_reload_config
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from reyn.core.events.events import EventLog
+
 _log = logging.getLogger(__name__)
 
 # A component reapply seam: ``(name, async fn(in_set) -> changed: bool)``. #2073 S2
@@ -168,7 +170,7 @@ class HotReloader:
         self,
         *,
         project_root: "Path | None",
-        events: "object | None",
+        events: "EventLog | None",
         seams: "list[ReapplySeam] | None" = None,
         validate: "Callable[[dict], str | None] | None" = None,
     ) -> None:


### PR DESCRIPTION
**[e2e-coder]** —

Follow-up to #3787 (PR #4263, lead-coder review): `ProjectContextWatcher`'s `events` param was fixed from `"object | None"` to `"EventLog | None"` there rather than baselining a new mypy debt. `HotReloader` carries the identical pattern — `events: "object | None"`, 6 unresolved `.emit()` call sites, all pre-baselined debt.

## Verified before fixing

Every call site — the one production site (`Session._build_hook_event_bundle`, passes `audit_events` which is typed `EventLog` throughout `Session`) and all ~30 test-file call sites across 8 test files — already passes a concrete `EventLog`. No caller relies on `object`-level looseness.

## Fix

`events: "object | None"` → `"EventLog | None"` (TYPE_CHECKING import, no runtime cost). mypy resolves `.emit()` at all 6 sites. Removed the now-satisfied `hot_reload.py` / `attr-defined` baseline entry — net debt reduction, not just "still passes."

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/mypy_ratchet.py` — clean, 211/215 declared (was 212/216 after #4263 — net -1, entry removed not just satisfied)
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/hot_reload.py` — clean
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] `pytest tests/runtime/test_2073_s1_hot_reloader.py tests/runtime/test_2073_s2_reapply_seams.py tests/tools/test_2073_s3_hooks_write_op.py tests/core/test_2761_pr2_hotreload_immediate_apply.py tests/core/test_2761_pr3_mcp_immediate_probe.py tests/core/test_mcp_install_local_hot_reload.py tests/core/test_4215_1_hooks_add_session_local.py tests/runtime/test_3636_config_reloaded_history_duplicate.py` — 71 passed (every test file that constructs a `HotReloader`)
- [x] test_tier_audit — N/A, no test files touched (type-annotation-only change)

Not test-touching (annotation-only), so no TESTS-READ needed per the "PR touching tests/" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)