### PR TITLE
fix(#4145): 5x stuffing-sleep → Event().wait() (bucket④ B-stuffing)

### DIFF
--- a/tests/interfaces/test_fp0001_run_registry.py
+++ b/tests/interfaces/test_fp0001_run_registry.py
@@ -175,9 +175,10 @@ async def test_cancel_cancels_task_and_sets_status() -> None:
     registry = _make_registry()
     entry = _make_entry(registry)
 
-    # Create a long-running task so it doesn't finish before we cancel
+    # Keep the task alive until cancelled — no timed wait, no observation;
+    # this is pure filler so cancel() has something to act on.
     async def _long_running() -> None:
-        await asyncio.sleep(999)
+        await asyncio.Event().wait()
 
     task = asyncio.create_task(_long_running())
     registry.attach_task(entry.run_id, task)

--- a/tests/interfaces/test_progress_bridge_task_leak_3390.py
+++ b/tests/interfaces/test_progress_bridge_task_leak_3390.py
@@ -188,7 +188,9 @@ def test_a2a_bridge_detach_still_cancels_inflight_task_while_removal_wired() -> 
     async def _slow_send(ordinal: int, event_type: str, message: str) -> None:
         sent_events.append("started")
         try:
-            await asyncio.sleep(5.0)
+            # Never completes on its own — only detach()'s cancel() ends
+            # this wait, which is exactly what the test is exercising.
+            await asyncio.Event().wait()
         except asyncio.CancelledError:
             sent_events.append("cancelled")
             raise

--- a/tests/mcp/test_2597_slice3_mcp_elicitation.py
+++ b/tests/mcp/test_2597_slice3_mcp_elicitation.py
@@ -54,7 +54,9 @@ class _HangingBus:
 
     async def request(self, iv: UserIntervention) -> InterventionAnswer:
         self.seen.append(iv)
-        await asyncio.sleep(9999)
+        # Never resolves — the handler's own timeout is what ends this wait,
+        # not a fixed delay racing it.
+        await asyncio.Event().wait()
         raise AssertionError("unreachable")  # pragma: no cover
 
 

--- a/tests/runtime/test_attach_request_forwarded.py
+++ b/tests/runtime/test_attach_request_forwarded.py
@@ -53,7 +53,7 @@ class _FakeSession:
 
     async def run(self) -> None:
         try:
-            await asyncio.sleep(3600)
+            await asyncio.Event().wait()
         except asyncio.CancelledError:
             pass
 

--- a/tests/runtime/test_rewind_inflight_disposition_2115.py
+++ b/tests/runtime/test_rewind_inflight_disposition_2115.py
@@ -32,7 +32,7 @@ async def test_inflight_disposition_counts_cancelled_vs_finished():
         return None
 
     async def _hangs() -> None:
-        await asyncio.sleep(60)
+        await asyncio.Event().wait()
 
     finished_t = asyncio.ensure_future(_finishes())
     await asyncio.gather(finished_t, return_exceptions=True)   # let it complete
@@ -64,11 +64,11 @@ async def test_await_quiescent_redrains_append_scheduled_during_join(tmp_path):
     follow_up: list[asyncio.Task] = []
 
     async def _second() -> None:
-        await asyncio.sleep(60)   # hangs — only the re-drain's cancel settles it
+        await asyncio.Event().wait()   # hangs — only the re-drain's cancel settles it
 
     async def _first() -> None:
         try:
-            await asyncio.sleep(60)
+            await asyncio.Event().wait()
         finally:
             # Scheduled WHILE _first is being joined (after a one-shot snapshot
             # would have been taken) — the race the re-drain must catch.


### PR DESCRIPTION
**[docs-maintainer]** — #4145 bucket④ triage identified 5 "stuffing sleep" instances: a large fixed `asyncio.sleep(N)` used purely to keep a task pending/cancellable, not as a wait on any condition. Each is replaced with `await asyncio.Event().wait()`, which never completes on its own (an `Event` with no `.set()` call anywhere in these files) and therefore ends the same way the original did — only via `.cancel()` — at zero time-budget cost.

One commit per file, per lead-coder's request.

## Files
- `tests/interfaces/test_fp0001_run_registry.py:180` — `sleep(999)` keeping a task alive for `cancel()` to act on.
- `tests/interfaces/test_progress_bridge_task_leak_3390.py:191` — `_slow_send` fake, `sleep(5.0)`; test asserts `"cancelled" in sent_events` after `detach()`.
- `tests/mcp/test_2597_slice3_mcp_elicitation.py:57` — `_HangingBus.request()`, `sleep(9999)`, followed by `raise AssertionError("unreachable")`.
- `tests/runtime/test_attach_request_forwarded.py:56` — `_FakeSession.run()`, `sleep(3600)`.
- `tests/runtime/test_rewind_inflight_disposition_2115.py:35,67,71` — 3 hang-tasks settled by direct `.cancel()` or `await_quiescent()`'s re-drain.

## Verification performed (per lead-coder's ask)

**Same-reason-green, all 5 files:**
```
python -m pytest tests/interfaces/test_fp0001_run_registry.py tests/interfaces/test_progress_bridge_task_leak_3390.py tests/mcp/test_2597_slice3_mcp_elicitation.py tests/runtime/test_attach_request_forwarded.py tests/runtime/test_rewind_inflight_disposition_2115.py -q
→ 34 passed
```
- `test_progress_bridge_task_leak_3390.py::test_a2a_bridge_detach_still_cancels_inflight_task_while_removal_wired` still asserts `"cancelled" in sent_events` post-detach — passes unchanged, confirming cancellation, not completion, is what ends the wait.
- `test_2597_slice3_mcp_elicitation.py::test_timeout_returns_cancel` — the `_HangingBus`-driven test whose whole point is that the handler's own timeout (not the bus) fires — still passes; the `raise AssertionError("unreachable")` after the wait stays unreachable.

**Falsify (does the replaced wait genuinely depend on cancellation, not merely happen to pass):**
```python
async def _long_running():
    await asyncio.Event().wait()
task = asyncio.create_task(_long_running())
await asyncio.wait_for(asyncio.shield(task), timeout=2)  # → TimeoutError
```
Confirms the wait does NOT complete on its own within 2s — only an external `.cancel()` ends it. Also grepped all 5 files for `.set()`: zero calls, so every `Event()` in this diff is genuinely cancel-only, not accidentally satisfiable.

Additionally ran the #4145-specific falsify on the run_registry test directly: commenting out `registry.cancel(entry.run_id)` turns the test red (`status == RunStatus.RUNNING`, not `cancelled`) — confirming the test's own assertions, not just the replaced wait, still depend on the cancel actually firing.

## Test plan
- [x] `ruff check` on the 5 changed files — clean
- [x] `python scripts/test_tier_audit.py --strict <5 files>` — 34/34 OK, 0 Tier-4
- [x] `python scripts/mypy_ratchet.py` — OK (baseline unchanged)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK (baseline unchanged)
- [x] Scoped pytest on the 5 files — 34 passed
- [x] Falsify: `Event().wait()` alone does not complete within 2s (cancel-only)
- [x] Falsify: `test_cancel_cancels_task_and_sets_status` turns red when `cancel()` is skipped

part of #4145
