### PR TITLE
fix(#4264 ①): subprocess-cancel tests wait on a readiness marker, not a fixed sleep

### DIFF
--- a/tests/security/test_subprocess_cancel_1470.py
+++ b/tests/security/test_subprocess_cancel_1470.py
@@ -62,19 +62,34 @@ async def test_noop_cancel_event_set_kills_subprocess() -> None:
     assert result.returncode != 0  # killed, not clean exit
 
 
+async def _wait_for_file(path) -> None:
+    """#4264 ①: unbounded poll on a real filesystem condition — no attempt
+    cap (testing.md § Time, owner ruling 2026-08-06: a fixed retry count is
+    itself banned, not just a fixed sleep duration; a hang here surfaces via
+    CI's own kill switch, not a silently-exhausted budget)."""
+    while not path.exists():
+        await asyncio.sleep(0.01)
+
+
 @pytest.mark.asyncio
-async def test_noop_cancel_mid_run_kills_subprocess() -> None:
-    """Tier 2: cancel_event set mid-run → subprocess killed before sleep completes."""
+async def test_noop_cancel_mid_run_kills_subprocess(tmp_path) -> None:
+    """Tier 2: cancel_event set mid-run → subprocess killed before sleep completes.
+
+    #4264 ①: cancel fires once the child has WRITTEN A READY MARKER (an
+    observable real condition — the child is actually running, not merely
+    Popen-spawned), not after a fixed sleep guessing the same thing."""
     backend = NoopBackend()
     event = asyncio.Event()
+    ready = tmp_path / "ready"
+    script = f"touch {ready}\nsleep 60\n"
 
     async def _fire_cancel() -> None:
-        await asyncio.sleep(0.05)
+        await _wait_for_file(ready)
         event.set()
 
     fire_task = asyncio.create_task(_fire_cancel())
     result = await backend.run(
-        ["/bin/sleep", "60"], _POLICY, cancel_event=event
+        ["/bin/sh", "-c", script], _POLICY, cancel_event=event
     )
     await fire_task
     assert result.cancelled
@@ -82,20 +97,26 @@ async def test_noop_cancel_mid_run_kills_subprocess() -> None:
 
 
 @pytest.mark.asyncio
-async def test_noop_cancel_partial_stdout() -> None:
-    """Tier 2: cancel after partial output → partial stdout captured."""
+async def test_noop_cancel_partial_stdout(tmp_path) -> None:
+    """Tier 2: cancel after partial output → partial stdout captured.
+
+    #4264 ①: the ready marker is written AFTER ``echo partial_output`` in
+    the same sequential script, so its existence guarantees the echo already
+    ran (and its output already reached the pipe) before cancel can fire —
+    replacing the old "may or may not include the first line" guess with a
+    real ordering guarantee, not just a longer sleep."""
     backend = NoopBackend()
     event = asyncio.Event()
+    ready = tmp_path / "ready"
 
-    # Script writes a line, then sleeps for 60s. Cancel fires after a short
-    # delay so we get the first line but the sleep is interrupted.
-    script = textwrap.dedent("""\
+    script = textwrap.dedent(f"""\
         echo partial_output
+        touch {ready}
         sleep 60
     """)
 
     async def _fire_cancel() -> None:
-        await asyncio.sleep(0.1)
+        await _wait_for_file(ready)
         event.set()
 
     fire_task = asyncio.create_task(_fire_cancel())
@@ -105,9 +126,11 @@ async def test_noop_cancel_partial_stdout() -> None:
     await fire_task
 
     assert result.cancelled
-    # Partial output may or may not include the first line depending on
-    # buffering and timing, but the subprocess must have been killed.
     assert result.returncode != 0
+    assert b"partial_output" in result.stdout, (
+        "the ready marker is written strictly after the echo, so its "
+        "existence guarantees the output was already captured"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[e2e-coder]** —

#4264 ①: both named sites (`test_noop_cancel_mid_run_kills_subprocess`, `test_noop_cancel_partial_stdout` in `tests/security/test_subprocess_cancel_1470.py`) used a fixed `asyncio.sleep()` to approximate "the child process has started running" before firing `cancel_event` — the observation-channel-absence pattern #4145/#4264 name.

Note: the issue's own cited reference example (`test_mcp_client.py`'s `for _ in range(100): sleep(0.05)`) is itself now non-compliant with testing.md's current normative text (owner ruling 2026-08-06 explicitly rejects "bless bounded polling" as a sanctioned exception) — flagged to lead-coder separately, not copied here.

## Fix

Each child script now writes a readiness marker file (`touch {ready}`) before its long-running work; the cancel-firing task waits **unboundedly** on that file's existence (no attempt cap).

`test_noop_cancel_partial_stdout`'s marker is written strictly AFTER the echo in the same sequential script, so its existence now also proves ordering deterministically — replaced the old "may or may not include the first line" hedge with a real assertion.

## Falsify-verify

Reverted both waits to a racy near-zero sleep:
- `test_noop_cancel_partial_stdout` failed **20/20** — confirms the readiness wait is genuinely load-bearing.
- `test_noop_cancel_mid_run_kills_subprocess` passed 20/20 even racy (Popen's synchronous fork+exec already makes this specific race low-risk in practice) — converted anyway on policy grounds, not because it was observed to flake.

Restored, both pass reliably (10/10 repeated runs).

This is the session's first landed witness for the "②" pattern (unbounded wait on a state PRODUCTION changes — here, the child process writing the marker — as opposed to "①" value-injection like #4263's `os.utime`) in the broader #4145 time-dependency sweep.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/security/test_subprocess_cancel_1470.py` — 11 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py` — clean
- [x] `python scripts/mypy_ratchet.py` — clean, no new findings
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] `pytest tests/security/test_subprocess_cancel_1470.py` (full file) — 9 passed, 2 skipped (platform-gated)
- [x] Falsify-verify (see above, 20/20 + 10/10)

part of #4264, part of #4145

🤖 Generated with [Claude Code](https://claude.com/claude-code)