### PR TITLE
fix(#4145): 3x bounded-retry/deadline disguised waits → unconditional wait

### DIFF
--- a/tests/core/test_2708_p31_spawn_bridge_present.py
+++ b/tests/core/test_2708_p31_spawn_bridge_present.py
@@ -217,11 +217,10 @@ async def test_detached_present_not_bridged_to_caller(tmp_path: Path, monkeypatc
     )
     run_dir = pipeline_run_dir(reyn_root(state_log.path), rid)
 
-    # Drive the detached pump to terminal (result marker written).
-    deadline = asyncio.get_event_loop().time() + 15.0
-    while asyncio.get_event_loop().time() < deadline:
-        if read_result(run_dir) is not None:
-            break
+    # Drive the detached pump to terminal (result marker written). Unbounded
+    # per the testing policy — a wall-clock deadline is a wait duration
+    # rewritten as a bound, and fails the same way on a slow host.
+    while read_result(run_dir) is None:
         await asyncio.sleep(0.05)
     assert read_result(run_dir) is not None, "detached pipeline run did not reach terminal"
 

--- a/tests/interfaces/test_esc_resumes_following_3806.py
+++ b/tests/interfaces/test_esc_resumes_following_3806.py
@@ -129,16 +129,25 @@ async def test_esc_from_an_empty_composer_goes_back_to_the_newest_output() -> No
 async def test_esc_with_a_draft_in_the_box_moves_nothing() -> None:
     """Tier 2b: a draft makes esc mean "never mind the text", not "scroll".
 
-    Checked by pumping a while and asserting the state did NOT change, which
-    cannot be proven by waiting — so it is paired with the positive test above:
-    that one establishes that this sequence DOES resume following when the box
-    is empty, so a False here is the draft's doing and not a dead keypress.
+    "esc did nothing" has no positive predicate of its own to wait on, so it
+    is proven via a causal successor instead of elapsed time: a real,
+    positively-observable event is pushed through the SAME message pump right
+    after the escape keypress, and this test waits (unbounded) for THAT to
+    land. Textual's pump processes messages in order, so once the marker
+    entry is rendered, escape's own handler (had it done anything) has
+    already run — the negative checks below reflect settled state, not an
+    early sample.
+
+    Paired with the positive test above: that one establishes that this
+    sequence DOES resume following when the box is empty, so a False here is
+    the draft's doing and not a dead keypress.
     """
     transport = QueueTransport()
     app = TextualChatApp(transport=transport)
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
         flow = await _leave_the_tail(app, transport, pilot)
+        entries_before = len(flow.entries)
 
         composer = app.query_one(Composer)
         composer.focus()
@@ -146,9 +155,10 @@ async def test_esc_with_a_draft_in_the_box_moves_nothing() -> None:
         composer.text = "a draft"
         await pilot.pause()
         await pilot.press("escape")
-        for _ in range(60):
-            await pilot.pause()
-            await asyncio.sleep(0.01)
+        await transport.push_display(
+            OutboxMessage(kind="agent", text="after-escape marker", meta={})
+        )
+        await _pump(pilot, lambda: len(flow.entries) > entries_before)
 
         assert not flow.following, (
             "esc scrolled the conversation while there was a draft in the box"
@@ -166,12 +176,19 @@ async def test_sending_does_not_go_back_to_the_newest_output() -> None:
     answers "did it send" is the sent queue and the NOW row, both outside the
     scrolling region — which is exactly the thing those other interfaces do not
     have, and the whole reason they jump.
+
+    "sending did not resume following" has no positive predicate of its own,
+    so it is proven via a causal successor (same pattern as the draft-esc
+    test above): a real event is pushed through the SAME message pump right
+    after "enter", and this test waits (unbounded) for THAT to land before
+    checking the negative.
     """
     transport = QueueTransport()
     app = TextualChatApp(transport=transport)
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
         flow = await _leave_the_tail(app, transport, pilot)
+        entries_before = len(flow.entries)
 
         composer = app.query_one(Composer)
         composer.focus()
@@ -179,9 +196,10 @@ async def test_sending_does_not_go_back_to_the_newest_output() -> None:
         composer.text = "a message"
         await pilot.pause()
         await pilot.press("enter")
-        for _ in range(60):
-            await pilot.pause()
-            await asyncio.sleep(0.01)
+        await transport.push_display(
+            OutboxMessage(kind="agent", text="after-send marker", meta={})
+        )
+        await _pump(pilot, lambda: len(flow.entries) > entries_before)
 
         assert not flow.following, (
             "sending returned to the tail — the convention was restored without "

--- a/tests/mcp/test_mcp_client.py
+++ b/tests/mcp/test_mcp_client.py
@@ -51,7 +51,9 @@ class _HttpEchoServer:
             )
         )
         # Poll until the socket accepts connections instead of a fixed sleep.
-        for _ in range(100):
+        # Unbounded per the testing policy — a capped attempt count is a wait
+        # duration rewritten as a count, and fails the same way on a slow host.
+        while True:
             try:
                 with socket.create_connection(("127.0.0.1", self.port), timeout=0.1):
                     break
@@ -256,7 +258,9 @@ def test_sse_transport_round_trip() -> None:
             )
         )
         try:
-            for _ in range(100):
+            # Unbounded per the testing policy — see the identical poll in
+            # _HttpEchoServer.__aenter__ above for the rationale.
+            while True:
                 try:
                     with socket.create_connection(("127.0.0.1", port), timeout=0.1):
                         break


### PR DESCRIPTION
**[docs-maintainer]** — Re-audit of my own "already-correct poll-loop" bucket④ classification (per lead-coder catching 2 cited `for _ in range(100)` instances). Found 3 more files with the same "wait duration rewritten as a bounded count/deadline" defect and fixed all three, one commit per file.

## Files

- `tests/mcp/test_mcp_client.py:54,259` — `for _ in range(100): ... sleep(0.05)` on `OSError` while polling for the socket to accept connections → `while True:` (unconditional).
- `tests/core/test_2708_p31_spawn_bridge_present.py:221-225` — `deadline = time() + 15.0; while time() < deadline:` (same defect, spelled with a wall-clock deadline instead of a counter) → `while read_result(run_dir) is None:` (unconditional).
- `tests/interfaces/test_esc_resumes_following_3806.py:149,182` — the e2e-coder "prove-a-negative" subclass: `for _ in range(60): pause(); sleep(0.01)` trying to prove "esc/send did NOT move the view" by pumping a fixed count, with no causal link to the fact under test. Fixed via a causal-successor: push one more real, positively-observable event through the same Textual message pump right after the keypress, and wait (unbounded, via the file's own existing `_pump(pilot, until)` helper) for THAT to land — Textual processes messages in order, so once the marker renders, the keypress's own handler has already run.

## Verification

**Same-reason-green:**
```
python -m pytest tests/mcp/test_mcp_client.py tests/core/test_2708_p31_spawn_bridge_present.py tests/interfaces/test_esc_resumes_following_3806.py -q
→ 20 passed
```

**Falsify, all 3 (each confirmed to hang, not silently pass):**
- `test_mcp_client.py` — pointed the connect-poll at a port that will never accept (`("127.0.0.1", 1)`): `timeout 8 pytest ... --timeout=5` → exit 124 (killed by the outer timeout, never returned on its own).
- `test_2708_p31_spawn_bridge_present.py` — pointed the marker-read at a directory that will never contain it: same `timeout 8` kill (exit 124).
- `test_esc_resumes_following_3806.py` — removed the causal-successor marker push, leaving the `_pump` wait with nothing to ever satisfy it: same `timeout 8` kill (exit 124).

All three confirm the replaced waits are genuinely gated on their real condition — not a coincidental fast pass.

## Test plan
- [x] `ruff check` on the 3 changed files — clean
- [x] `python scripts/test_tier_audit.py --strict <3 files>` — 20/20 OK, 0 Tier-4
- [x] `python scripts/mypy_ratchet.py` — OK (baseline unchanged)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK (baseline unchanged)
- [x] Scoped pytest on the 3 files — 20 passed
- [x] Falsify all 3: confirmed hang (timeout-killed) when the real condition is made unreachable

part of #4145
