### PR TITLE
fix(#4264 ②): drop the redundant fixed-sleep-then-reread negative check

### DIFF
--- a/tests/environment/test_container_backend_cancel_3862.py
+++ b/tests/environment/test_container_backend_cancel_3862.py
@@ -82,9 +82,23 @@ async def test_cancel_actually_stops_the_real_process_not_just_the_client(
     The child writes its own PID to a marker file on start and touches a
     SECOND file every 0.1s in a loop — if cancel only killed the host-side
     client (the #3862 bug), this loop would keep running and keep touching
-    the file. We assert the file stops growing AFTER cancel, using the
-    child's OWN OS-level PID (independent of the pidfile mechanism under
-    test) as the ground truth for "is it actually still running".
+    the file.
+
+    #4264 ②: the "still writing?" check is a single read RIGHT AFTER
+    ``result.cancelled is True``, not a fixed-sleep-then-reread. This is
+    not a weaker check — it is the SAME check, already discharged: ``run()``
+    only sets ``cancelled=True`` from ``_docker_kill_in_container``'s own
+    return value, and that function returns ``True`` ONLY after a real
+    ``kill -0`` liveness probe confirms the in-container process is
+    genuinely gone (see its docstring). So by the time this assert runs,
+    "the child has stopped writing" is already causally proven — the OS
+    itself confirmed the process is dead before ``run()`` ever returned.
+    A fixed real-time wait-then-reread here would not verify anything the
+    ``cancelled`` assert above didn't already verify by a stronger method
+    (an OS-level liveness check, not elapsed wall-clock time); it would
+    only be re-checking an already-proven fact more weakly. Do not
+    reintroduce a sleep here to "be extra sure" — the OS-level check this
+    already relies on is stronger than any timeout you could add.
     """
     marker = tmp_path / "alive.count"
     marker.write_text("0")
@@ -129,15 +143,12 @@ async def test_cancel_actually_stops_the_real_process_not_just_the_client(
     )
     await canceller
     assert result.cancelled is True, (
-        "run() did not report the in-container process as verified-stopped"
-    )
-
-    count_at_return = int(marker.read_text())
-    await asyncio.sleep(0.5)  # if the loop is still alive, it will have kept writing
-    count_after_wait = int(marker.read_text())
-    assert count_after_wait == count_at_return, (
-        f"the child kept running after cancel ({count_at_return} -> {count_after_wait}) — "
-        "the host-side client was stopped but the real workload was not (#3862's own bug shape)"
+        "run() did not report the in-container process as verified-stopped — "
+        "this IS the liveness proof (see docstring): a False here means either "
+        "the kill signal never reached the real process, or the post-kill "
+        "kill -0 probe still found it alive — either way, the host-side "
+        "client was stopped but the real workload was not (#3862's own bug "
+        "shape)"
     )
 
 


### PR DESCRIPTION
**[e2e-coder]** —

Design consult before implementing (lead-coder): proposed 2 options, lead-coder chose ① — see #4264 for the exchange.

## Why the sleep is redundant, not just banned

`test_cancel_actually_stops_the_real_process_not_just_the_client`'s negative check ("did the child stop writing?") used to be: read the counter, `sleep(0.5)`, reread, assert equal. But `result.cancelled` is already `_docker_kill_in_container`'s own return value (`container_backend.py:700`, `cancelled=verified_stopped`), and that function returns `True` **only after a real `kill -0` liveness probe confirms the process is genuinely gone**. So by the time `assert result.cancelled is True` runs, "the process is dead" is already causally proven by an OS-level check — the fixed-sleep-then-reread was re-verifying the same fact by a weaker method (elapsed time) than the one already relied on.

## Why not the other option (add a boundary-probe command)

Considered replacing the sleep with running a separate lightweight command through the same backend as a causal "enough time has passed" checkpoint. Rejected (lead-coder): that pattern would exist ONLY to keep a now-redundant assert alive — closer to the six-question Q3 shape ("a configuration only the test itself constructs") than to something a real consumer needs.

## Docstring requirement

Per review: the reasoning for why the negative is already covered is now written in the test's own docstring — without it, a future reader sees a removed safety net and reinstates it.

## A separate finding (not this PR's fix — tracked as #4271)

Falsify-verify surfaced something real: reintroducing the exact #3862 bug shape (host client killed, in-container workload orphaned, never actually verified) makes this gate **hang** rather than go RED — a pre-existing defect in the gate's own expressive power, present whether or not this PR's redundant-assert removal lands (confirmed by testing both the with-kill-call and skip-kill-call falsify variants). Filed as #4271 rather than expanded here, since it's a different axis (gate expressiveness) from #4264's scope (time-dependency removal).

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 3 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py` — clean
- [x] `python scripts/mypy_ratchet.py` — clean, no new findings
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] `pytest tests/environment/test_container_backend_cancel_3862.py` — 3 passed
- [x] Falsify (deeper than usual, reported separately as #4271): confirmed both variants; production code restored to a clean 0-diff state before this PR

part of #4264, part of #4145

🤖 Generated with [Claude Code](https://claude.com/claude-code)