### PR TITLE
fix(#4264 ③): stream-echo tests wait on run_output_loop's own state, not a fixed sleep

### DIFF
--- a/tests/interfaces/test_stream_client_own_echo_3287.py
+++ b/tests/interfaces/test_stream_client_own_echo_3287.py
@@ -90,6 +90,17 @@ class _Recorder:
         return False
 
 
+async def _wait_until(predicate) -> None:
+    """#4264 ③: unbounded poll on run_output_loop's own OBSERVABLE effects
+    (``own_submissions`` shrinking, ``renderer.events`` growing) — no fixed
+    sleep, no attempt cap (testing.md § Time). No new production signal:
+    both are state the loop already mutates for real consumers (the set it
+    was handed, the renderer it renders into), not a hook added for this
+    test's own sake."""
+    while not predicate():
+        await asyncio.sleep(0.01)
+
+
 class _QueueTransport(ClientTransport):
     """A real, minimal ClientTransport: yields queued frames; ``submit_user_text``
     returns a caller-scripted msg_id (mirroring the production contract —
@@ -187,7 +198,12 @@ async def test_matching_own_submission_is_not_rerendered_and_is_consumed() -> No
     task = asyncio.create_task(
         run_output_loop(transport, renderer, own_submissions=own_submissions)
     )
-    await asyncio.sleep(0.05)
+    # #4264 ③: own_submissions emptying IS the loop's own observable effect
+    # of having consumed the matching event — wait on that, not a sleep.
+    await _wait_until(lambda: not own_submissions)
+    # The other two queued frames (turn_started/turn_settled) still need a
+    # moment to drain after the matching id is consumed.
+    await _wait_until(lambda: "turn_settled" in [e.type for e in renderer.events])
     task.cancel()
     await asyncio.gather(task, return_exceptions=True)
 
@@ -213,7 +229,9 @@ async def test_non_matching_event_still_renders_and_set_untouched() -> None:
     task = asyncio.create_task(
         run_output_loop(transport, renderer, own_submissions=own_submissions)
     )
-    await asyncio.sleep(0.05)
+    # #4264 ③: wait for the loop's own observable effect (the event actually
+    # reaching the renderer) instead of a sleep.
+    await _wait_until(lambda: "user_submitted" in [e.type for e in renderer.events])
     task.cancel()
     await asyncio.gather(task, return_exceptions=True)
 
@@ -249,7 +267,10 @@ async def test_same_text_two_clients_does_not_cross_match_by_id() -> None:
     task = asyncio.create_task(
         run_output_loop(transport, renderer, own_submissions=own_submissions)
     )
-    await asyncio.sleep(0.05)
+    # #4264 ③: own_submissions emptying means BOTH queued events have been
+    # consumed — "m-theirs" (rendered) and "m-mine" (matched, suppressed) —
+    # since the loop processes the FIFO queue one at a time.
+    await _wait_until(lambda: not own_submissions)
     task.cancel()
     await asyncio.gather(task, return_exceptions=True)
 
@@ -276,7 +297,8 @@ async def test_own_submissions_none_preserves_the_event_as_sole_echo() -> None:
     await transport.push(EventFrame(_user_submitted_event("piped line", "m-piped")))
 
     task = asyncio.create_task(run_output_loop(transport, renderer, own_submissions=None))
-    await asyncio.sleep(0.05)
+    # #4264 ③: wait for the loop's own observable effect instead of a sleep.
+    await _wait_until(lambda: "user_submitted" in [e.type for e in renderer.events])
     task.cancel()
     await asyncio.gather(task, return_exceptions=True)
 
@@ -304,17 +326,32 @@ async def test_connection_id_suppresses_with_no_msg_id_correlation_at_all() -> N
     await transport.push(
         EventFrame(_user_submitted_event("hello", "m-999", auth_connection_id="conn-mine"))
     )
+    # #4264 ③: this proves an ABSENCE (the suppressed event never renders),
+    # so there is no positive effect of ITS OWN processing to wait on. A
+    # sentinel event, pushed onto the SAME transport queue right after it,
+    # gives one: the loop drains its single FIFO queue strictly in order
+    # (one `transport.frames()` consumer, `async for`), so by the time the
+    # sentinel appears in renderer.events, the suppressed event ahead of it
+    # has already been fully processed — same path, same order (the #4267/
+    # #4269 causal-successor shape, applied here without a new production
+    # hook: renderer.events is already the real consumer both this test and
+    # every sibling above rely on).
+    await transport.push(EventFrame(_user_submitted_event("sentinel", "m-sentinel")))
 
     task = asyncio.create_task(
         run_output_loop(
             transport, renderer, own_submissions=None, own_connection_id="conn-mine",
         )
     )
-    await asyncio.sleep(0.05)
+    await _wait_until(lambda: "m-sentinel" in [
+        e.data.get("msg_id") for e in renderer.events if e.type == "user_submitted"
+    ])
     task.cancel()
     await asyncio.gather(task, return_exceptions=True)
 
-    assert "user_submitted" not in [e.type for e in renderer.events], (
+    assert "m-999" not in [
+        e.data.get("msg_id") for e in renderer.events if e.type == "user_submitted"
+    ], (
         "an event carrying THIS client's own connection_id must be "
         "suppressed without ever needing a matching msg_id in own_submissions"
     )
@@ -338,7 +375,8 @@ async def test_connection_id_mismatch_still_renders_another_clients_turn() -> No
             transport, renderer, own_submissions=None, own_connection_id="conn-mine",
         )
     )
-    await asyncio.sleep(0.05)
+    # #4264 ③: wait for the loop's own observable effect instead of a sleep.
+    await _wait_until(lambda: "user_submitted" in [e.type for e in renderer.events])
     task.cancel()
     await asyncio.gather(task, return_exceptions=True)
 


### PR DESCRIPTION
**[e2e-coder]** —

Design consult before implementing (lead-coder, following the ordering they specified: look for an existing observable effect before adding any production signal). Single commit — the 6 sites share one helper and are tightly coupled; happy to split on request but a mid-file 4/2 split turned out awkward to do cleanly via `git add -p` given the shared helper.

## Scope widened from 1 site to 6 (measured, not assumed)

The issue named only `:190`. Re-measured the whole file: 5 identical siblings (`asyncio.sleep(0.05)` → `task.cancel()`), same author, same pattern. Fixing 1 while leaving 5 in the same file would be a half-fix.

## No new production hook

Per lead-coder's specified order (① existing observable effect → ② only then a new signal, and only if it has a real non-test consumer → ③ else question the test itself): found ①. `own_submissions` (a real set the loop consumes from) and `renderer.events` (the real recorder every test already asserts against) are both state `run_output_loop` already mutates for real consumers.

## Two shapes

- **4 positive-effect sites**: wait for `"user_submitted" in renderer.events`, or for `own_submissions` to empty.
- **2 absence-proving sites**: one still has a real positive signal (`own_submissions` emptying — the matched id IS consumed even though never rendered). The other has none of its own, so a **sentinel** `user_submitted` event is pushed onto the SAME transport queue right after the suppressed one — per review requirement, the sentinel travels the identical path/order as the suppressed event (`_QueueTransport`'s single FIFO queue, one `async for` consumer), so its arrival in `renderer.events` proves the suppressed event ahead of it already finished processing. Same causal-successor shape as #4267/#4269, no new production API.

## Falsify-verify

20 runs with a no-op `_wait_until`: 5/6 sites went RED consistently. The 6th (the sentinel-negative test) passed even falsified — expected: "nothing rendered yet" trivially satisfies "not rendered" before the loop has run at all, the same structural limit #4264①'s `mid_run` subprocess test hit (converted on policy grounds regardless, not because it was observed flaky). Restored, 9/9 stable across 10 repeated runs.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 9 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py` — clean
- [x] `python scripts/mypy_ratchet.py` — clean, no new findings
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] `pytest tests/interfaces/test_stream_client_own_echo_3287.py` — 9 passed
- [x] Falsify-verify (see above, 20 runs + 10-run stability check)

part of #4145 (the broader time-dependency sweep continues there).

Closes #4264 — verified before writing this: all other #4264 sub-PRs (#4267 ①, #4272 ②, #4270 ⑤) are merged, ④ was excluded with recorded reasoning (issue comment, already the blessed unbounded-poll shape), this PR is ③, the last of the 5 items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
