### PR TITLE
fix(#4275): wait_until becomes unconditional — drop bounded timeout

### DIFF
--- a/tests/_async_wait.py
+++ b/tests/_async_wait.py
@@ -10,33 +10,35 @@ These helpers are the explicit, deterministic replacement (NOT a global fixture 
 NOT a to_thread-sync monkeypatch — those would mask the real async timing). Each
 call site passes the exact predicate it needs (pending iv registered, snapshot
 mutated, WAL event durable, …), so the assertion the test makes is preserved.
+
+#4275: ``wait_until`` used to take a ``timeout`` and return ``bool`` — a bounded
+poll whose own docstring argued "the generous timeout only guards against a
+genuinely-stuck operation." Per the #4145 owner ruling (no exception for
+time-dependent tests unless reyn's own logic is genuinely under test — a bounded
+failure constant is a wait duration rewritten as a number, and it duplicates
+CI's own kill switch), the wait is now unconditional: it returns ``None`` and
+blocks until ``predicate()`` holds. A predicate that never holds hangs the test,
+surfaced by CI's `--timeout=120`, not by a local number chosen for this call.
 """
 from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
 
-_DEFAULT_TIMEOUT = 5.0
 _DEFAULT_INTERVAL = 0.005
 
 
 async def wait_until(
     predicate: Callable[[], bool],
     *,
-    timeout: float = _DEFAULT_TIMEOUT,
     interval: float = _DEFAULT_INTERVAL,
-) -> bool:
-    """Poll ``predicate()`` until it is truthy or ``timeout`` elapses.
+) -> None:
+    """Poll ``predicate()`` until it is truthy. Unbounded — see module docstring.
 
-    Returns True if the predicate became truthy, False on timeout (so the caller's
-    ``assert`` still pins the real condition rather than a fixed sleep). Bounded —
-    the awaited WAL/to_thread work lands within a few ms; the generous timeout only
-    guards against a genuinely-stuck operation."""
-    loop = asyncio.get_event_loop()
-    deadline = loop.time() + timeout
-    while True:
-        if predicate():
-            return True
-        if loop.time() >= deadline:
-            return False
+    Returns nothing: by the time this returns, ``predicate()`` holds, so the
+    caller has nothing left to check on this axis. A predicate that never
+    becomes true hangs the test, surfaced by CI's own timeout kill switch
+    rather than a bounded failure constant local to this call.
+    """
+    while not predicate():
         await asyncio.sleep(interval)

--- a/tests/interfaces/test_3328_connect_remote_parity_witness.py
+++ b/tests/interfaces/test_3328_connect_remote_parity_witness.py
@@ -147,7 +147,7 @@ class _RealServer:
         self._orig_get_registry = endpoint_mod.get_registry
         endpoint_mod.get_registry = lambda: self._registry
         self._task = asyncio.create_task(self._server.serve())
-        await wait_until(lambda: self._server.started, timeout=10.0)
+        await wait_until(lambda: self._server.started)
         return self
 
     async def __aexit__(self, *exc_info) -> None:
@@ -249,7 +249,7 @@ async def test_connect_over_real_socket_reconstructs_history_like_local_hydrate(
         # input loop's readline() against the SSE handshake + backlog
         # delivery (the input loop can win, ending the client having
         # rendered nothing at all, a false pass this guards against).
-        await wait_until(lambda: len(renderer.messages) >= len(local_oracle), timeout=10.0)
+        await wait_until(lambda: len(renderer.messages) >= len(local_oracle))
         stdin.send_line("/quit")
         await asyncio.wait_for(remote_task, timeout=10.0)
         stdin.close()
@@ -340,7 +340,7 @@ async def test_connect_intervention_round_trip_matches_local_unfenced_answer(
                 # dispatching (mirrors production: a real client always
                 # connects, THEN a turn may raise an intervention).
                 await wait_until(
-                    lambda: session._interventions.has_active_listener(), timeout=5.0,
+                    lambda: session._interventions.has_active_listener(),
                 )
 
                 remote_iv = UserIntervention(kind="ask_user", prompt="Proceed?", run_id="r-remote")
@@ -348,7 +348,7 @@ async def test_connect_intervention_round_trip_matches_local_unfenced_answer(
                     session._intervention_handler.dispatch(remote_iv)
                 )
                 await wait_until(
-                    lambda: transport.pending_intervention_head() is not None, timeout=5.0,
+                    lambda: transport.pending_intervention_head() is not None,
                 )
                 assert renderer.messages, "the intervention prompt must render before it is answered"
 
@@ -371,8 +371,7 @@ async def test_connect_intervention_round_trip_matches_local_unfenced_answer(
     session.register_intervention_listener("test-local")
     local_iv = UserIntervention(kind="ask_user", prompt="Proceed?", run_id="r-local")
     local_task = asyncio.ensure_future(session._intervention_handler.dispatch(local_iv))
-    got_local = await wait_until(lambda: bool(session._interventions.list_active()), timeout=5.0)
-    assert got_local, "local intervention never reached pending"
+    await wait_until(lambda: bool(session._interventions.list_active()))
     local_answered = await session.answer_oldest_intervention_text("yes-locally")
     assert local_answered is True
     local_answer = await asyncio.wait_for(local_task, timeout=5.0)

--- a/tests/interfaces/test_textual_chat_phase2b_live_tool_3283.py
+++ b/tests/interfaces/test_textual_chat_phase2b_live_tool_3283.py
@@ -432,17 +432,15 @@ async def test_running_body_animates_live_then_stops_on_settle() -> None:
         # ANIMATION_FPS — CI under load only landed 2 ticks where 3+ ran on a
         # light machine, taking down an unrelated docs-only PR (#4043). Wait on
         # the condition instead of a fixed duration (CLAUDE.md testing policy,
-        # Time) — tests/_async_wait.py's own wait_until, at its OWN default
-        # timeout (no local timeout literal here: a timeout picked to make
+        # Time) — tests/_async_wait.py's own wait_until, unbounded (#4275: no
+        # local timeout literal — a bounded failure constant picked to make
         # this one call pass is the same axis as lowering the count threshold
         # to make it pass — both just relocate the same flake).
         from tests._async_wait import wait_until
 
-        reached = await wait_until(
-            lambda: presenter.present_counts.get("op-live", 0) >= 3
-        )
+        await wait_until(lambda: presenter.present_counts.get("op-live", 0) >= 3)
         live_count = presenter.present_counts.get("op-live", 0)
-        assert reached and live_count >= 3, (
+        assert live_count >= 3, (
             f"running body did not animate live: {live_count} presents"
         )
 

--- a/tests/runtime/test_2708_p32a_spawn_bridge_intervention.py
+++ b/tests/runtime/test_2708_p32a_spawn_bridge_intervention.py
@@ -148,7 +148,7 @@ async def test_attached_ask_user_reaches_parent_operator_and_answer_flows_back(
         # The bridged ask_user dispatches on the PARENT: its iv lands in the PARENT's
         # active-intervention queue (proof the ask reached the parent, not the driver's
         # own listener-less registry which would have auto-refused instantly).
-        await wait_until(lambda: bool(caller.interventions.list_active()), timeout=15.0)
+        await wait_until(lambda: bool(caller.interventions.list_active()))
         # Capture the driver session while it is still live (the persistent driver is
         # removed from the registry once the attached run completes).
         driver_sid = _driver_sid_from(caller_collected)
@@ -223,7 +223,7 @@ async def test_attached_ask_user_not_stalled_uses_live_parent_listener(
 
     run_task = asyncio.ensure_future(_drive())
     try:
-        await wait_until(lambda: bool(caller.interventions.list_active()), timeout=15.0)
+        await wait_until(lambda: bool(caller.interventions.list_active()))
         # Delivered (active), NOT stalled — the parent's live listener owns it.
         assert caller.list_stalled_interventions() == [], (
             "the bridged ask_user was parked in the parent's stalled queue instead of "

--- a/tests/runtime/test_session_invariants.py
+++ b/tests/runtime/test_session_invariants.py
@@ -406,9 +406,7 @@ async def test_chain_timeout_fires_upstream_error_and_emits_event(tmp_path, monk
     # WAL append: `ChainManager.fire_timeout` awaits `record_chain_timeout_fired`
     # before returning the chain the upstream response is built from — so the
     # `flush()` below drains an append that is already queued.
-    assert await wait_until(lambda: bool(upstream_received)), (
-        "chain timeout never fired within the bounded wait"
-    )
+    await wait_until(lambda: bool(upstream_received))
 
     # WAL must contain chain_register → chain_timeout_fired.
     await session._journal.flush()  # #2259 PR-2b: drain async WAL writes


### PR DESCRIPTION
**[docs-maintainer]** — #4275: `tests/_async_wait.py::wait_until` becomes unconditional. Per the #4145 owner ruling, a bounded failure constant (`timeout=5.0` here) is a wait duration rewritten as a number, and it duplicates CI's own `--timeout=120` kill switch — the helper's own docstring argued exactly the justification the ruling named and rejected.

## Scope correction from the issue body

The issue estimated 21 importing files needing individual review for False-branch dependents. Actual enumeration: **19 real importers** (2 of the 21 — `test_flat_tests_ratchet_3879.py`, `test_check_bare_tests_import_reference_4008.py` — only reference the module/function name as fixture *string content* for testing other scripts, never actually call it). Of those 19, **53 call sites total, but only 3 files use the return value** (`assert await wait_until(...)`, `reached = await wait_until(...)`, `got_local = await wait_until(...)`) and **2 files pass `timeout=`** (1 overlaps with the return-value set). Every other call site is a bare `await wait_until(...)` with the result discarded — those needed zero changes, since a caller that never inspected the bool is unaffected by the bool disappearing.

## Changes

- `tests/_async_wait.py` — `wait_until` drops `timeout`/returns `None`; polls `predicate()` unconditionally.
- `test_session_invariants.py` — dropped the now-invalid `assert await wait_until(...), "..."` wrapper (1 site).
- `test_textual_chat_phase2b_live_tool_3283.py` — dropped `reached = ...; assert reached and live_count >= 3` → `await wait_until(...); assert live_count >= 3` (1 site).
- `test_3328_connect_remote_parity_witness.py` — dropped 5 `timeout=` kwargs + 1 `got_local = ...; assert got_local, "..."` wrapper.
- `test_2708_p32a_spawn_bridge_intervention.py` — dropped 2 `timeout=15.0` kwargs.

## Test-plan item done first (per lead-coder's ask, before committing to the design)

Measured bounded-vs-unconditional diagnosability directly rather than assuming — posted as [issue comment](https://github.com/tya5/reyn/issues/4275#issuecomment-5252280166). Summary: bounded gives a custom assertion message pointing at the exact line; unconditional + `pytest --timeout` gives no custom message and its traceback (both `signal` and `thread` methods) never shows the waiting test's own line — it bottoms out in asyncio/selector internals. Diagnosability is measurably worse for the unconditional form; the ruling's rationale (bounded constants are arbitrary + duplicate the kill switch) is a correctness/design axis, not a diagnosability one, so the direction doesn't change — but this is a real cost worth naming, not a free lunch.

## Verification

**Same-reason-green**, all 19 real-importer files (101 tests):
```
python -m pytest <19 files> -q
→ 101 passed
```

**Falsify**: replaced a real predicate with `lambda: False` in `test_session_invariants.py` — `timeout 12 pytest ... --timeout=8` → killed by pytest-timeout (exit 1, `Failed: Timeout (>8.0s) from pytest-timeout.`), confirming the wait is genuinely gated on the predicate, not trivially satisfied.

## Test plan
- [x] Enumerate the 21 `wait_until` importers, name which depend on the False branch — done above (19 real importers; 3 use the return value, 2 pass `timeout=`)
- [x] Unconditional-ize the helper, rewrite every affected caller, one PR (this PR)
- [ ] inline 12-file dedup — separate PR, per the issue's own plan (not this one)
- [x] Falsify: unconditional-ized wait genuinely hangs on a never-true predicate, surfaced by CI's kill switch; measured comparison against the bounded form's diagnosability posted to the issue
- [x] `ruff check` on all 5 changed files — clean
- [x] `python scripts/test_tier_audit.py --strict <4 test files>` — 32/32 OK (the 5th changed file, `_async_wait.py`, is a helper module, not a test file)
- [x] `python scripts/mypy_ratchet.py` — OK (211/215, baseline unchanged, count went down)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK (baseline unchanged)
- [x] `python scripts/verify_module_docstrings.py tests/_async_wait.py` — OK

part of #4275
