### PR TITLE
fix(#4275): dedup 7 of 12 inline deadline-poll files to wait_until

### DIFF
--- a/tests/core/test_spawn_routing_detached_fail_mode_2708.py
+++ b/tests/core/test_spawn_routing_detached_fail_mode_2708.py
@@ -46,6 +46,7 @@ from reyn.runtime.session_buses import (
 )
 from reyn.runtime.session_params import PresentationWiring
 from reyn.user_intervention import UserIntervention
+from tests._async_wait import wait_until
 from tests._support.agent_session import make_session
 from tests._support.events import collect_events
 
@@ -209,12 +210,7 @@ async def test_detached_present_is_audit_only_no_orphan_outbox(
         reply_to_agent="worker", reply_to_sid="main", state_log=state_log,
     )
     run_dir = pipeline_run_dir(reyn_root(state_log.path), rid)
-    deadline = asyncio.get_event_loop().time() + 10.0
-    while asyncio.get_event_loop().time() < deadline:
-        if read_result(run_dir) is not None:
-            break
-        await asyncio.sleep(0.05)
-    assert read_result(run_dir) is not None, "detached present pipeline did not reach terminal"
+    await wait_until(lambda: read_result(run_dir) is not None)
 
     # The detached driver was spawned AuditOnly (its present sink is the no-op) — identify it as
     # the built session carrying that routing decision. RED if the detached spawn self-bound
@@ -263,16 +259,11 @@ async def test_detached_ask_user_refuses_deliberately_no_hang(
     )
     run_dir = pipeline_run_dir(reyn_root(state_log.path), rid)
 
-    # NO HANG: terminal within a tight window (the pre-fix hang never reached it in >6s).
-    deadline = asyncio.get_event_loop().time() + 5.0
-    while asyncio.get_event_loop().time() < deadline:
-        if read_result(run_dir) is not None:
-            break
-        await asyncio.sleep(0.02)
-    assert read_result(run_dir) is not None, (
-        "detached ask_user did NOT reach terminal within 5s — the origin-pin park/hang was not "
-        "closed by the AuditOnly refusal."
-    )
+    # If the origin-pin park/hang regresses, this now hangs until CI's kill switch
+    # (--timeout=120) fires instead of failing locally within a fixed window — the
+    # regression still surfaces red, just via the kill switch rather than a bounded
+    # assert (#4275: a bounded constant here is a wait duration rewritten as a number).
+    await wait_until(lambda: read_result(run_dir) is not None)
 
     # The driver was spawned AuditOnly (the routing that turns the pre-fix hang into a deliberate
     # refusal) — identify it as the built session carrying an AuditOnly intervention bridge. The
@@ -376,13 +367,7 @@ async def test_session_spawn_child_ask_user_reaches_parent_operator_no_hang(
     bus = child.intervention_bridge.bus(run_id="r", actor="child")
     iv = UserIntervention(kind="ask_user", prompt="which branch?")
     deliver = asyncio.ensure_future(bus.deliver(iv))
-    loop = asyncio.get_event_loop()
-    deadline = loop.time() + 5.0
-    while loop.time() < deadline and not parent.interventions.list_active():
-        await asyncio.sleep(0.02)
-    assert parent.interventions.list_active(), (
-        "the child's ask_user never reached the parent operator's active queue (parked/hung)."
-    )
+    await wait_until(lambda: bool(parent.interventions.list_active()))
     consumed = await parent._maybe_answer_oldest_intervention("blue")
     assert consumed is True
     answer = await asyncio.wait_for(deliver, timeout=5.0)  # resolves (no hang)
@@ -432,14 +417,7 @@ async def test_session_spawn_grandchild_ask_user_reaches_root_operator_transitiv
     bus = grandchild.intervention_bridge.bus(run_id="r", actor="gc")
     iv = UserIntervention(kind="ask_user", prompt="which branch?")
     deliver = asyncio.ensure_future(bus.deliver(iv))
-    loop = asyncio.get_event_loop()
-    deadline = loop.time() + 5.0
-    while loop.time() < deadline and not root.interventions.list_active():
-        await asyncio.sleep(0.02)
-    assert root.interventions.list_active(), (
-        "the grandchild's ask_user did NOT reach the ROOT operator — it parked on the immediate "
-        "headless parent's listener-less registry (the recursive hang edge)."
-    )
+    await wait_until(lambda: bool(root.interventions.list_active()))
     answered = await root._maybe_answer_oldest_intervention("blue")
     assert answered is True
     answer = await asyncio.wait_for(deliver, timeout=5.0)  # resolves via root operator, no hang

--- a/tests/environment/test_container_backend_cancel_3862.py
+++ b/tests/environment/test_container_backend_cancel_3862.py
@@ -26,6 +26,7 @@ from reyn.environment.container_backend import (
     _docker_kill_in_container,
 )
 from reyn.security.sandbox.policy import SandboxPolicy
+from tests._async_wait import wait_until
 
 
 @pytest.fixture
@@ -130,11 +131,9 @@ async def test_cancel_actually_stops_the_real_process_not_just_the_client(
         # variable wall-clock time under test-harness overhead; a fixed
         # delay tuned to pass locally would be exactly the kind of flaky
         # magic-number timing this policy warns against.
-        deadline = asyncio.get_running_loop().time() + 10.0
-        while asyncio.get_running_loop().time() < deadline:
-            if marker.exists() and marker.read_text().strip() not in ("", "0"):
-                break
-            await asyncio.sleep(0.02)
+        await wait_until(
+            lambda: marker.exists() and marker.read_text().strip() not in ("", "0")
+        )
         cancel_event.set()
 
     canceller = asyncio.create_task(_cancel_once_actually_running())  # keep a reference, avoid GC

--- a/tests/interfaces/test_3310_n3_remote_switch_parity.py
+++ b/tests/interfaces/test_3310_n3_remote_switch_parity.py
@@ -133,14 +133,35 @@ def _texts(msgs: "list[OutboxMessage]") -> "list[str]":
     return [f"{m.kind}:{m.text}" for m in msgs]
 
 
+async def _collect_all(agen) -> "list":
+    """Collect every item from an async generator until it terminates.
+
+    #4275 (co-vet #3322 (b) is superseded, not just amended — that review's
+    "collecting unboundedly turns a structural break into an undiagnosable
+    CI-timeout hang" is exactly the justification the #4145 owner ruling
+    names and rejects: a local bounded window duplicates CI's own kill
+    switch and adds an arbitrary failure constant). Every caller here
+    deliberately pushes an ``__end__`` sentinel, which ``AgUiEmitter.stream()``
+    returns on, so the stream is naturally finite. If a switch-follow
+    mechanism regresses and the stream never terminates, this hangs,
+    surfaced by CI's kill switch rather than a local window that would
+    silently truncate the collected list instead of failing.
+    """
+    return [item async for item in agen]
+
+
 async def _collect_within(agen, *, window: float) -> "list":
-    """Collect items off an async generator for a BOUNDED wall-clock window,
-    never awaiting past it (co-vet #3322 (b)). When a switch-follow mechanism
-    is broken the underlying stream can be permanently stranded and simply
-    never terminate; collecting unboundedly turns that structural break into
-    a slow, undiagnosable CI-timeout hang. Bounding here means a broken build
-    fails FAST, and the caller's own assertions — pointed at whatever WAS
-    collected in the window — name exactly what's missing."""
+    """Collect items off an async generator for a BOUNDED wall-clock window.
+
+    #4275 NOTE (not yet converted): unlike ``_collect_all`` above, the one
+    remaining caller of this helper (``test_switch_announce_precedes_any_new_
+    session_audit_event``) drives ``source.frames()`` without ever pushing an
+    ``__end__`` sentinel — there is no natural termination signal to wait on,
+    only a wall-clock settle window after driving the adversary + switch
+    request. This is the same shape as the #4275 issue's still-open inline
+    dedup item, not a mechanical conversion — left bounded pending a real
+    design (e.g. a quiet-period/settle signal) rather than guessed at here.
+    """
     out: list = []
     it = agen.__aiter__()
     loop = asyncio.get_event_loop()
@@ -157,8 +178,8 @@ async def _collect_within(agen, *, window: float) -> "list":
     return out
 
 
-async def _run_emitter_to_frames(emitter: AgUiEmitter, *, window: float = 3.0) -> "list":
-    sse = "".join(await _collect_within(emitter.stream(), window=window))
+async def _run_emitter_to_frames(emitter: AgUiEmitter) -> "list":
+    sse = "".join(await _collect_all(emitter.stream()))
 
     async def _noop_send(_payload):
         return None
@@ -194,7 +215,7 @@ async def test_remote_switch_has_no_scrollback_without_the_refire(tmp_path) -> N
 
         switch_task = asyncio.create_task(_switch())
         try:
-            frames = await _run_emitter_to_frames(emitter, window=3.0)
+            frames = await _run_emitter_to_frames(emitter)
         finally:
             await switch_task
             source.close()
@@ -270,7 +291,7 @@ async def test_remote_switch_parity_a_b_a_with_staleness(tmp_path) -> None:
 
         drive_task = asyncio.create_task(_drive())
         try:
-            frames = await _run_emitter_to_frames(emitter, window=3.0)
+            frames = await _run_emitter_to_frames(emitter)
         finally:
             await drive_task
             source.close()
@@ -409,7 +430,7 @@ async def test_barrier_precedes_refire_on_the_wire(tmp_path) -> None:
 
         switch_task = asyncio.create_task(_switch())
         try:
-            sse = "".join(await _collect_within(emitter.stream(), window=3.0))
+            sse = "".join(await _collect_all(emitter.stream()))
         finally:
             await switch_task
             source.close()

--- a/tests/interfaces/test_agui_control_filter.py
+++ b/tests/interfaces/test_agui_control_filter.py
@@ -71,25 +71,17 @@ def _registry(tmp_path):
     return reg
 
 
-async def _collect_within(agen, *, window: float) -> "list":
-    """Collect from an async generator for a BOUNDED wall-clock window.
+async def _collect_all(agen) -> "list":
+    """Collect every item from an async generator until it terminates.
 
-    A broken tap can strand the stream permanently; bounding turns that into a
-    fast, named assertion failure instead of a CI timeout.
+    #4275: the caller always pushes an ``__end__`` sentinel, which
+    ``AgUiEmitter.stream()`` returns on — the stream is naturally finite, so
+    no wall-clock window is needed. If a caller regresses and never sends
+    ``__end__``, this hangs, surfaced by CI's kill switch rather than a
+    bounded window that would silently truncate the collected list instead
+    of failing.
     """
-    out: list = []
-    it = agen.__aiter__()
-    loop = asyncio.get_event_loop()
-    deadline = loop.time() + window
-    while True:
-        remaining = deadline - loop.time()
-        if remaining <= 0:
-            break
-        try:
-            out.append(await asyncio.wait_for(it.__anext__(), timeout=remaining))
-        except (asyncio.TimeoutError, StopAsyncIteration):
-            break
-    return out
+    return [item async for item in agen]
 
 
 async def _wire_events(frames):
@@ -202,7 +194,7 @@ async def test_forwarder_continue_does_not_keep_a_sentinel_off_the_wire(
 
     task = asyncio.create_task(_drive())
     try:
-        sse = "".join(await _collect_within(emitter.stream(), window=5.0))
+        sse = "".join(await _collect_all(emitter.stream()))
     finally:
         await task
         source.close()

--- a/tests/runtime/test_2769_agent_step_intervention_reaches_invoker.py
+++ b/tests/runtime/test_2769_agent_step_intervention_reaches_invoker.py
@@ -59,6 +59,7 @@ from reyn.runtime.session_params import PresentationWiring
 from reyn.schemas.models import PresentIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 from reyn.user_intervention import UserIntervention
+from tests._async_wait import wait_until
 from tests._support.agent_session import make_session
 
 
@@ -153,14 +154,7 @@ async def test_attached_agent_step_ask_user_reaches_invoker_operator(tmp_path: P
     bus = worker.intervention_bridge.bus(run_id="r", actor="agent-step")
     iv = UserIntervention(kind="ask_user", prompt="which branch?")
     deliver = asyncio.ensure_future(bus.deliver(iv))
-    loop = asyncio.get_event_loop()
-    deadline = loop.time() + 5.0
-    while loop.time() < deadline and not invoker.interventions.list_active():
-        await asyncio.sleep(0.02)
-    assert invoker.interventions.list_active(), (
-        "the agent-step ask_user never reached the invoker operator's active queue (it refused "
-        "locally instead of bridging to the originator)."
-    )
+    await wait_until(lambda: bool(invoker.interventions.list_active()))
     # The operator was prompted on the invoker's own surface (chat-native intervention announce).
     assert _by_kind(_drain(invoker.outbox), "intervention"), (
         "the operator was never prompted on the invoker surface — the bridged ask_user did not "
@@ -200,14 +194,7 @@ async def test_attached_agent_step_permission_reaches_invoker_operator(tmp_path:
         kind="permission.generic", prompt="Allow tool 'shell'?", choices=generic_yn_choices(),
     )
     deliver = asyncio.ensure_future(bus.deliver(iv))
-    loop = asyncio.get_event_loop()
-    deadline = loop.time() + 5.0
-    while loop.time() < deadline and not invoker.interventions.list_active():
-        await asyncio.sleep(0.02)
-    assert invoker.interventions.list_active(), (
-        "the agent-step PERMISSION prompt never reached the invoker operator — the routing swap "
-        "must be bus-wide (permission.* / safety.limit / elicitation), not ask_user-only."
-    )
+    await wait_until(lambda: bool(invoker.interventions.list_active()))
     # The operator picks the affirmative choice on the invoker surface (the authoritative
     # closed-set choice path the inline selector uses — bypasses text/hotkey match_choice).
     consumed = await invoker.answer_oldest_intervention_choice(YES)

--- a/tests/runtime/test_3049_driver_router_op_intervention_reaches_originator.py
+++ b/tests/runtime/test_3049_driver_router_op_intervention_reaches_originator.py
@@ -42,6 +42,7 @@ from reyn.runtime.session_api import _build_agent_step_narrowing, spawn_ephemera
 from reyn.runtime.session_params import PresentationWiring
 from reyn.runtime.spawn_routing import AuditOnlyNoSurface, BridgeToParent
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from tests._async_wait import wait_until
 from tests._support.agent_session import make_session
 
 _SERVER = "reyn3049_probe_server"
@@ -112,14 +113,7 @@ async def test_attached_driver_mcp_permission_reaches_originator_operator(tmp_pa
 
     gate = asyncio.ensure_future(resolver.require_mcp(decl, _SERVER, bus))
 
-    loop = asyncio.get_event_loop()
-    deadline = loop.time() + 5.0
-    while loop.time() < deadline and not originator.interventions.list_active():
-        await asyncio.sleep(0.02)
-    assert originator.interventions.list_active(), (
-        "the driver's MCP permission prompt never reached the ORIGINATOR operator's active queue — "
-        "it orphaned on the driver's own listener-less registry (the #3049 stall)."
-    )
+    await wait_until(lambda: bool(originator.interventions.list_active()))
     # Delivered to the LIVE listener, not parked stalled on the parent (the bridge stamps the
     # channel the operator actually listens on).
     assert originator.list_stalled_interventions() == [], (
@@ -153,14 +147,7 @@ async def test_attached_driver_permission_kind_agnostic_same_bus(tmp_path: Path)
     decl = PermissionDecl(tool=[_TOOL])
 
     gate = asyncio.ensure_future(resolver.require_tool(decl, _TOOL, bus))
-    loop = asyncio.get_event_loop()
-    deadline = loop.time() + 5.0
-    while loop.time() < deadline and not originator.interventions.list_active():
-        await asyncio.sleep(0.02)
-    assert originator.interventions.list_active(), (
-        "a tool-authority permission prompt on the same driver bus did NOT reach the originator — "
-        "delivery must ride the bus seam uniformly, not per permission-gate."
-    )
+    await wait_until(lambda: bool(originator.interventions.list_active()))
     consumed = await originator.answer_oldest_intervention_choice(YES)
     assert consumed is True
     await asyncio.wait_for(gate, timeout=5.0)

--- a/tests/runtime/test_3053_budget_bus_bridge_aware.py
+++ b/tests/runtime/test_3053_budget_bus_bridge_aware.py
@@ -54,6 +54,7 @@ from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session
 from reyn.runtime.session_api import _build_agent_step_narrowing, spawn_ephemeral_session
 from reyn.runtime.session_params import PresentationWiring
 from reyn.runtime.spawn_routing import AuditOnlyNoSurface, BridgeToParent
+from tests._async_wait import wait_until
 from tests._support.agent_session import make_session
 
 
@@ -127,14 +128,7 @@ async def test_attached_driver_budget_exceed_prompt_reaches_originator_operator(
     check = BudgetCheck(allowed=False, hard_dimension="test_budget")
     gate = asyncio.ensure_future(_budget_exceed_allows_continue(check, "worker"))
 
-    loop = asyncio.get_event_loop()
-    deadline = loop.time() + 5.0
-    while loop.time() < deadline and not originator.interventions.list_active():
-        await asyncio.sleep(0.02)
-    assert originator.interventions.list_active(), (
-        "the driver's budget-exceed prompt never reached the ORIGINATOR operator's active "
-        "queue — it auto-refused on the driver's own listener-less registry (the #3053 gap)."
-    )
+    await wait_until(lambda: bool(originator.interventions.list_active()))
     assert originator.list_stalled_interventions() == [], (
         "the bridged budget-exceed prompt was parked in the originator's stalled queue "
         "instead of its live listener."


### PR DESCRIPTION
**[docs-maintainer]** — #4275's remaining item: the 12 inline `deadline = time() + N; while ...` files, deduped to the (now-unconditional, per #4276) `wait_until` helper form.

## Scope: 7 of 12 files converted, 5 deliberately left open

Re-enumerated against fresh `origin/main` (post-#4276) and read every site's actual semantics rather than converting mechanically:

**Converted (7 files, all verified green + falsified)**:
- `test_spawn_routing_detached_fail_mode_2708.py` (4 sites), `test_3049_driver_router_op_intervention_reaches_originator.py` (2), `test_3053_budget_bus_bridge_aware.py` (1 — **this is #4145's formerly-known bucket①② "genuine" file**, re-confirmed NOT an exception), `test_2769_agent_step_intervention_reaches_invoker.py` (2), `test_container_backend_cancel_3862.py` (1) — all straightforward predicate-waits, `deadline+condition` → `wait_until(lambda: condition)`.
- `test_agui_control_filter.py` + `test_3310_n3_remote_switch_parity.py` (3 of 4 `_collect_within` sites) — `AgUiEmitter.stream()` naturally terminates on an `__end__` sentinel that every converted caller always pushes, so the wall-clock window was pure insurance against a hypothetical hang (the exact justification the #4145 ruling rejects). Renamed to `_collect_all`, drops the window entirely.

**Deliberately NOT converted — real design gaps, not guessed at**:
- `test_3310_n3_remote_switch_parity.py`'s 4th `_collect_within` call (`test_switch_announce_precedes_any_new_session_audit_event`) — drives `source.frames()` with no `__end__` ever pushed. No natural termination signal exists; left bounded with an explicit code comment naming this as open.
- `tests/core/test_1800_wake_drain.py`, `test_1800_c_staging.py`, `tests/interfaces/test_user_submitted_render_3300.py`'s shared `_run_n_turns_then_shutdown` helper (3 files, same helper duplicated) — **attempted and reverted**. `turns_done[0] >= n` looked like a clean predicate, but `test_wake_drain_equivalence_three_messages` (n=3) hung: `run_one_iteration()`'s batching means `turns_done` doesn't map 1:1 to messages submitted, so the OLD bounded wait was never actually gating on reaching exactly `n` — it was a courtesy pause before the REAL check (WAL `inbox_put`/`inbox_consume` event counts, asserted afterward regardless of how far `turns_done` got). Converting it to unconditional would hang on a passing test. Reverted cleanly; these 3 files are untouched in this PR.
- `test_2708_p32a_spawn_bridge_intervention.py`'s 1 remaining inline site (line ~271, separate from the `wait_until` calls #4276 already fixed) — a **prove-a-negative** (`while time()<deadline: assert list_active()==[]`), same shape as the earlier `test_esc_resumes_following_3806.py` fix in #4269, needs a causal-successor redesign, not a mechanical swap. Left open.

## Verification

**Same-reason-green**, all 7 converted files (36 tests):
```
python -m pytest <7 files> -q → 36 passed
```

**Falsify** (2, covering both converted shapes):
- `test_agui_control_filter.py::test_forwarder_continue_does_not_keep_a_sentinel_off_the_wire` — removed the `__end__` push → `timeout 10 pytest ... --timeout=6` → killed (exit 124), confirming `_collect_all` is genuinely gated on stream termination, not silently returning a truncated list within a window as the old bounded form did.
- The `_run_n_turns_then_shutdown` hang itself (found via the same falsify discipline, not assumed) is the reason those 3 files are excluded — a real, caught mistake, not a hypothetical.

## Test plan
- [x] inline 12 files enumerated fresh against `origin/main` (post-#4276)
- [x] 7 converted where the wait genuinely gates a used condition; verified green
- [x] 5 left open with an explicit reason each (2 real design gaps, 3 reverted after a caught false-positive)
- [x] `ruff check` on all 7 changed files — clean
- [x] `python scripts/test_tier_audit.py --strict <7 files>` — 36/36 OK, 0 Tier-4
- [x] `python scripts/mypy_ratchet.py` — OK (baseline unchanged)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK (baseline unchanged)
- [x] Falsify: `_collect_all` hangs (kill-switch) when `__end__` never arrives

part of #4275
