### PR TITLE
fix(#4274): wire web_fetch.* config into a live OpContext.web_fetch_config

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -483,7 +483,7 @@ web_fetch:
 
 `web_fetch.allow_private_ips`（bool, デフォルト `false`）は SSRF 対策。`true` のとき `web_fetch` / `safe.http` がプライベート RFC1918/ULA アドレスへ到達できます（エンタープライズの内部 fetch 向け opt-in）。link-local / クラウドメタデータ（`169.254.169.254`）/ ループバックはこのフラグに関わらず**常に**拒否されます。HTTP リダイレクトは hop ごとに再検証（allowlist + IP-deny）されるため、allowlist 済みホストが内部ターゲットへリダイレクトすることはできません。`REYN_FETCH_ALLOW_PRIVATE_IPS` 環境変数にもエクスポートされ、safe.http サブプロセス + レジストリクライアントが同じ opt-in を参照します。
 
-> ⚠️ **#4274（未対応）**: `web_fetch.*` は現在、実際のチャットセッションの op 実行には配線されていません — `web_fetch.verify_ssl: false`（や `ca_bundle` / `allow_private_ips`）を設定しても、パース・validate は通りますが、実際の `web_fetch` 呼び出しには届きません（常に環境変数 / デフォルト経路にフォールスルーします）。これは #4174 T4 の改名が作った・悪化させたものではない既存のギャップで、別途追跡されています。
+> ℹ️ **#4274**: `web_fetch.*` は現在、実際のチャットセッションの `web_fetch` op 実行に配線されています（`SessionFactoryConfig.web_fetch_config` → `Session` → router `OpContext`）。これが入るまでは、パース・validate は通っても実際の `web_fetch` 呼び出しには届きませんでした — #4174 T4 の改名が作った・悪化させたものではない既存のギャップでした。`verify_ssl: false` や `allow_private_ips: true` のような非デフォルト値を設定したまま気づいていなかった環境では、これから実際に効くようになります。
 
 ## `gateway` ブロック
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -791,13 +791,14 @@ Priority chain (highest first):
 | `web_fetch.max_download_bytes` | int | `10485760` (10MB) | Maximum response bytes `web_fetch` reads off the wire. A response whose `Content-Length` exceeds this is rejected before any body is downloaded; a chunked / unknown-length body is aborted once the stream passes the ceiling (status `too_large`). Guards against an unbounded-body memory blow-up from a hostile or runaway URL. `<= 0` or non-integer falls back to the default. |
 | `web_fetch.allow_private_ips` | bool | `false` | SSRF opt-in. When `true`, `web_fetch` / `safe.http` may fetch **private** RFC1918/ULA addresses (enterprise internal-fetch). Link-local, cloud-metadata (`169.254.169.254`), and loopback are **always** denied regardless of this flag. HTTP redirects are re-validated per hop (both the host allowlist and the IP-deny), so an allowlisted host cannot redirect to an internal target. Also exported to the `REYN_FETCH_ALLOW_PRIVATE_IPS` env var so the safe.http subprocess and registry clients honor the same opt-in. |
 
-> ⚠️ **#4274 (open)**: `web_fetch.*` is not currently wired to a live chat
-> session's op execution — an operator setting `web_fetch.verify_ssl: false`
-> (or `ca_bundle` / `allow_private_ips`) sees it parse and validate clean,
-> but the value never reaches a real `web_fetch` call today (it always
-> falls through to the env-var / default path instead). This is a
-> pre-existing gap the #4174 T4 rename did not fix or worsen — tracked
-> separately.
+> ℹ️ **#4274**: `web_fetch.*` now reaches every live chat session's
+> `web_fetch` op execution (`SessionFactoryConfig.web_fetch_config` →
+> `Session` → the router `OpContext`). Before this landed, the block parsed
+> and validated clean but never reached a real `web_fetch` call — a
+> pre-existing gap the #4174 T4 rename did not itself fix or worsen. An
+> operator who set a non-default value (e.g. `verify_ssl: false` or
+> `allow_private_ips: true`) and never noticed it doing nothing will now
+> see it actually take effect.
 
 ## `gateway` block
 

--- a/docs/reference/runtime/session-construction.md
+++ b/docs/reference/runtime/session-construction.md
@@ -760,6 +760,14 @@ trust decision on a specific skill, discovered later if at all.
   or `--image PATH`, drained on the next user-message turn (attached to that
   `ChatMessage`'s `media` field). litellm-style content parts:
   `{"type": "image_url", "image_url": {"url": "data:...;base64,..."}}`.
+- `_web_fetch_config` (#4274) — `reyn.yaml` `web_fetch.*` (SSL verify / private-IP
+  opt-in / download-byte cap), plumbed straight into the router `OpContext.web_fetch_config`
+  the `web_fetch` op reads. Same shape as `_multimodal_config` above (a plain value, not a
+  per-turn supplier — `WebFetchConfig` doesn't change mid-session). Threaded from
+  `SessionFactoryConfig.web_fetch_config` (#2093 bundle), so it reaches all five
+  session-factory sites uniformly; before #4274 the field existed on `OpContext` (#4174 T4)
+  but no factory site ever populated it, so every real session silently ignored an
+  operator's `web_fetch:` block.
 
 ## Safety, limits & interactive mode
 

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -258,10 +258,9 @@ class ReynConfig:
     # litellm.ssl_verify → SSL_CERT_FILE → True (default).
     # #4174 T4: this field was `web` (renamed here, unchanged shape). The
     # OTHER half of the old `web:` key — the `reyn web` gateway's own
-    # settings — is the SEPARATE `gateway` field below; #4274 tracks that
-    # this OpContext.web_fetch_config wiring is not actually consumed by
-    # any live session today (a pre-existing gap this rename does not fix
-    # or worsen).
+    # settings — is the SEPARATE `gateway` field below. #4274: this value now
+    # reaches every live session's OpContext.web_fetch_config via
+    # SessionFactoryConfig — see factory_config.py.
     web_fetch: WebFetchConfig = field(default_factory=WebFetchConfig)
     # #4174 T4: the `reyn web` gateway's own settings (auth model, WS frame
     # ceiling, per-surface mount overrides) — split from `web:` because that

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -182,9 +182,11 @@ class OpContext:
     # here. #4174 T4: renamed from `web_config: WebConfig | None` (the type
     # ITSELF is now WebFetchConfig directly, not a `.fetch`-nested wrapper —
     # WebConfig no longer exists, split into WebFetchConfig + GatewayConfig).
-    # #4274: no real construction site actually sets this today (checked:
-    # zero `web_fetch_config=` / `web_config=` call sites in src/ outside
-    # this declaration) — a pre-existing gap this rename does not fix.
+    # #4274: wired live — reaches every chat-router OpContext via
+    # SessionFactoryConfig.web_fetch_config → Session._web_fetch_config →
+    # RouterOpContextSource → build_router_op_context. BEHAVIOR CHANGE: an
+    # operator's `web_fetch:` block in reyn.yaml (verify_ssl / allow_private_ips /
+    # max_download_bytes) was silently ignored before this and now takes effect.
     web_fetch_config: "WebFetchConfig | None" = None
 
     # FP-0017 follow-up: declarative sandbox config for sandboxed_exec op.

--- a/src/reyn/runtime/factory_config.py
+++ b/src/reyn/runtime/factory_config.py
@@ -1,11 +1,14 @@
 """#2093: the shared session-factory config bundle — completeness-by-construction.
 
-The four session-factory sites (cli/chat, cli/dogfood, web/deps, cli/mcp)
-each thread a set of UNIFORM, reyn.yaml-config-derived args identically into
-``build_scoped_chat_session`` (8) and ``AgentRegistry`` (3). Historically a new uniform
-arg had to be added at all four sites by hand — and was silently missed at one
-(``sandbox_config`` at the A2A factory; ``delegation_capability_default`` at
-``mcp.py``).
+The five session-factory sites (cli/chat, cli/dogfood, web/deps, cli/mcp,
+runtime/registry_bootstrap) each thread a set of UNIFORM, reyn.yaml-config-derived
+args identically into ``build_scoped_chat_session`` (8) and ``AgentRegistry`` (3).
+Historically a new uniform arg had to be added at all five sites by hand — and was
+silently missed at one (``sandbox_config`` at the A2A factory;
+``delegation_capability_default`` at ``mcp.py``). #4274 is the same class again, one
+level up: ``web_fetch_config`` was declared on ``OpContext`` (#4174 T4) with zero
+production construction sites at all — every factory site was silently missing it,
+not just one.
 
 ``SessionFactoryConfig.from_config`` is the SINGLE point that maps ``ReynConfig`` →
 those uniform args. Every site builds the bundle once and passes it to both consumers,
@@ -31,6 +34,11 @@ class SessionFactoryConfig:
     # ── build_scoped_chat_session uniform config (8) ────────────────────────
     sandbox_config: Any
     multimodal_config: Any
+    # #4274: reyn.yaml web_fetch.* (verify_ssl / allow_private_ips / max_download_bytes,
+    # #4174 T4) — declared on OpContext since T4 but never populated at any factory
+    # site until this field existed. Same shape as multimodal_config: a plain value,
+    # not a per-turn supplier (WebFetchConfig doesn't change mid-session).
+    web_fetch_config: Any
     action_retrieval_config: Any
     embedding_config: Any
     router_config: Any
@@ -106,6 +114,8 @@ class SessionFactoryConfig:
         return cls(
             sandbox_config=config.sandbox,
             multimodal_config=config.multimodal,
+            # #4274: the previously-dead web_fetch.* config, now threaded live.
+            web_fetch_config=config.web_fetch,
             action_retrieval_config=config.action_retrieval,
             embedding_config=config.embedding,
             router_config=config.llm.router,

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -60,6 +60,7 @@ def build_router_op_context(
     presentation_renderer: Any,  # #2708 P1: REQUIRED (no default) — the present sink must be an EXPLICIT decision (a PresentationRenderer or None), never a silent omission.
     presentation_registry: Any = None,  # FP-0054 PR-C: operator named-template registry (hot-reloadable)
     multimodal_config: Any = None,  # #364
+    web_fetch_config: Any = None,  # #4274: reyn.yaml web_fetch.* → the web_fetch op's SSL/SSRF/size gates
     media_store: Any = None,  # #383
     compact_now: Any = None,  # #272/#1128
     run_id: str | None = None,  # chat router is outside run scope (#FP-0021)
@@ -158,6 +159,7 @@ def build_router_op_context(
         presentation_renderer=presentation_renderer,
         presentation_registry=presentation_registry,
         multimodal_config=multimodal_config,
+        web_fetch_config=web_fetch_config,  # #4274
         media_store=media_store,
         compact_now=compact_now,
         sandbox_backend=sandbox_backend,
@@ -239,6 +241,7 @@ class RouterOpContextSource:
         presentation_renderer_factory: Any,
         presentation_registry_fn: Any,
         multimodal_config: Any,
+        web_fetch_config: Any,  # #4274: reyn.yaml web_fetch.* — plain value, same shape as multimodal_config
         media_store_fn: Any,
         compact_now: Any,
         threat_scan: Any,
@@ -270,6 +273,7 @@ class RouterOpContextSource:
         self._presentation_renderer_factory = presentation_renderer_factory
         self._presentation_registry_fn = presentation_registry_fn
         self._multimodal_config = multimodal_config
+        self._web_fetch_config = web_fetch_config
         self._media_store_fn = media_store_fn
         self._compact_now = compact_now
         self._threat_scan = threat_scan
@@ -334,6 +338,7 @@ class RouterOpContextSource:
             presentation_renderer=self._resolve(self._presentation_renderer_factory),
             presentation_registry=self._resolve(self._presentation_registry_fn),
             multimodal_config=self._multimodal_config,
+            web_fetch_config=self._web_fetch_config,  # #4274
             media_store=self._resolve(self._media_store_fn),
             compact_now=self._compact_now,
             cancel_event=self._cancel_event,

--- a/src/reyn/runtime/scoped_session_factory.py
+++ b/src/reyn/runtime/scoped_session_factory.py
@@ -162,6 +162,7 @@ def build_scoped_chat_session(
             intervention_bridge=intervention_bridge,
         ),
         multimodal_config=factory_config.multimodal_config,
+        web_fetch_config=factory_config.web_fetch_config,  # #4274
         action_retrieval_config=factory_config.action_retrieval_config,
         embedding_config=factory_config.embedding_config,
         router_config=factory_config.router_config,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -32,6 +32,7 @@ from reyn.config import (  # noqa: F401
     RenderTemplateConfig,
     RouterConfig,
     SafetyConfig,
+    WebFetchConfig,
 )
 from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.anchor_store import truncate_anchor as _truncate_anchor
@@ -903,6 +904,10 @@ class Session:
         budget_tracker: BudgetTracker | None = None,
         snapshot_path: "Path | None" = None,
         multimodal_config: "MultimodalConfig | None" = None,
+        # #4274: reyn.yaml web_fetch.* → the chat-router OpContext's web_fetch_config
+        # (verify_ssl / allow_private_ips / max_download_bytes). Plain value, same
+        # shape as multimodal_config — not a per-turn supplier.
+        web_fetch_config: "WebFetchConfig | None" = None,
         action_retrieval_config: "ActionRetrievalConfig | None" = None,
         # Chat-layer tool-use scheme name, threaded to RouterLoop (#1593 PR-2, default per #1657)
         chat_tool_use_scheme: str = "enumerate-all",
@@ -1003,6 +1008,8 @@ class Session:
         self._non_interactive = bool(non_interactive)
         # Media-size gate config, plumbed to spawned Agents + router host adapter (#364, see session-construction.md#multimodal-media)
         self._multimodal_config = multimodal_config
+        # #4274: stored so RouterOpContextSource can thread it into OpContext.web_fetch_config.
+        self._web_fetch_config = web_fetch_config
         # Single MediaStore instance per Session (#383 PR-C, see session-construction.md#multimodal-media)
         from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
         if multimodal_config is not None:
@@ -3979,6 +3986,7 @@ class Session:
             # so a newly-registered template is visible on the next op.
             presentation_registry_fn=lambda: self._presentation_registry,
             multimodal_config=self._multimodal_config,
+            web_fetch_config=self._web_fetch_config,  # #4274
             media_store_fn=lambda: self._media_store,  # #383/#2409
             compact_now=self._compact_now_for_op,  # #272/#1128
             threat_scan=self._safety.threat_scan,  # FP-0050/#1822

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -41,6 +41,7 @@ _INERT_OP_CONTEXT_SOURCE_FIELDS: dict = {
     "presentation_renderer_factory": None,
     "presentation_registry_fn": None,
     "multimodal_config": None,
+    "web_fetch_config": None,  # #4274
     "media_store_fn": None,
     "compact_now": None,
     "threat_scan": None,

--- a/tests/core/test_web_fetch_config_session_wiring_4274.py
+++ b/tests/core/test_web_fetch_config_session_wiring_4274.py
@@ -1,0 +1,152 @@
+"""Tier 2c: operator `web_fetch:` yaml reaches the web_fetch op THROUGH a real
+Session (#4274).
+
+#4174 T4 renamed `web:` → `web_fetch:` and declared `OpContext.web_fetch_config`,
+but no factory site ever populated it — every real chat session handed the
+`web_fetch` op a `None` config, silently ignoring `web_fetch.verify_ssl` /
+`allow_private_ips` / `max_download_bytes`. #4274 wires
+`SessionFactoryConfig.web_fetch_config` → `Session._web_fetch_config` →
+`RouterOpContextSource` → both router `OpContext` builders.
+
+**This is a genuine behavior change**: an operator who set a non-default
+`web_fetch:` value (e.g. `verify_ssl: false`, `allow_private_ips: true`, or a
+tighter `max_download_bytes`) and never noticed it doing nothing will now see
+it actually take effect.
+
+The point of #4274 is the Session→op link — the config value only matters if a
+real Session threads it into the OpContext the op actually reads (same
+reasoning as #2679's `render_template_bounds` guard, mirrored here). Both
+Session-side OpContext builders are driven — `Session._make_router_op_context`
+(file/MCP twin) and `Session._router_host.make_router_op_context`
+(RouterHostAdapter twin, the path the `web_fetch` TOOL actually dispatches
+through on chat + pipeline) — since #4174 T4's own lesson (`getattr(config,
+"web", None)` invisible to grep, caught only by the regression suite) is that
+one of two twin builders silently missing a wire is exactly the failure shape
+to guard against.
+
+``max_download_bytes`` (not ``allow_private_ips``) is the probe: the SSRF
+guard hard-denies loopback regardless of ``allow_private_ips`` (policy, #1956
+— not a config knob), so a loopback fetch can't distinguish "config wired" from
+"config absent" on that field. The download cap has no such floor — a real
+local HTTP server response either fits under the configured cap or trips it,
+with no other axis in the way. The SSRF guard itself is patched to a no-op
+(the external/boundary seam here — #1956's own policy is not what this test
+is about; only a loopback TEST SERVER makes the download-cap probe possible
+without standing up real internet infrastructure).
+
+Falsify-verified: stripping the `web_fetch_config=` forwarding from either
+`RouterOpContextSource.__init__`'s call in `Session` or from
+`build_router_op_context`/`RouterOpContextSource.build` makes
+`ctx.web_fetch_config` come back `None`, so the op falls back to its 10 MiB
+built-in default instead of the configured 5-byte cap and
+`test_tight_max_download_bytes_reaches_the_op_through_both_builders` goes RED
+(status flips from "too_large" to "ok").
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+from reyn.config import WebFetchConfig
+from reyn.config.loader import load_config
+from reyn.core.op_runtime.web import handle_web_fetch
+from reyn.schemas.models import WebFetchIROp
+from tests._support.agent_session import make_session
+
+_BODY = b"X" * 1000  # well over a 5-byte cap, well under the 10 MiB default
+
+
+class _H(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+        self.wfile.write(_BODY)
+
+    def log_message(self, *a):  # silence
+        pass
+
+
+def _fetch(url: str, ctx) -> dict:
+    op = WebFetchIROp(kind="web_fetch", url=url)
+    return asyncio.run(handle_web_fetch(op=op, ctx=ctx))
+
+
+def test_tight_max_download_bytes_reaches_the_op_through_both_builders(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2c: a NON-DEFAULT `web_fetch.max_download_bytes: 5` yaml value
+    round-trips through `load_config` into a real `Session`, and BOTH
+    Session-side OpContext builders hand the op a cap that rejects a
+    1000-byte response (default cap is 10 MiB — this response would pass
+    uncapped)."""
+    (tmp_path / "reyn.yaml").write_text(
+        "model: standard\nweb_fetch:\n  max_download_bytes: 5\n"
+    )
+
+    cfg = load_config(cwd=tmp_path)
+    assert cfg.web_fetch.max_download_bytes == 5
+
+    # The production shape: the frontend factories pass `config.web_fetch`
+    # into the Session via SessionFactoryConfig (registry_bootstrap / chat.py /
+    # dogfood.py / mcp.py / web/deps.py — see factory_config.py).
+    session = make_session(agent_name="t", web_fetch_config=cfg.web_fetch)
+
+    # Boundary seam: #1956's SSRF policy hard-denies loopback unconditionally
+    # (not a config knob — see module docstring), so a real loopback test
+    # server can't otherwise reach the download-cap check this test is about.
+    from reyn import _ssrf_guard
+    monkeypatch.setattr(_ssrf_guard, "assert_fetch_host_allowed", lambda *a, **k: None)
+
+    srv = HTTPServer(("127.0.0.1", 0), _H)
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        url = f"http://127.0.0.1:{port}/big"
+
+        # Builder 1 — Session._make_router_op_context (file/MCP twin).
+        r_session = _fetch(url, session._make_router_op_context())
+        assert r_session["status"] == "too_large", r_session
+
+        # Builder 2 — RouterHostAdapter.make_router_op_context (the
+        # op_context_factory the web_fetch tool actually dispatches through
+        # on chat + pipeline).
+        r_host = _fetch(url, session._router_host.make_router_op_context())
+        assert r_host["status"] == "too_large", r_host
+    finally:
+        srv.shutdown()
+
+
+def test_default_config_leaves_the_response_uncapped_through_a_real_session(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2c: with no `web_fetch:` section the Session gets the safe
+    default (10 MiB), so the same 1000-byte response is NOT capped through
+    either builder — the operator config is opt-in, default behaviour
+    unchanged by #4274's wiring."""
+    (tmp_path / "reyn.yaml").write_text("model: standard\n")
+
+    cfg = load_config(cwd=tmp_path)
+    assert cfg.web_fetch == WebFetchConfig()
+
+    session = make_session(agent_name="t", web_fetch_config=cfg.web_fetch)
+
+    from reyn import _ssrf_guard
+    monkeypatch.setattr(_ssrf_guard, "assert_fetch_host_allowed", lambda *a, **k: None)
+
+    srv = HTTPServer(("127.0.0.1", 0), _H)
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        url = f"http://127.0.0.1:{port}/big"
+        for builder in (
+            session._make_router_op_context,
+            session._router_host.make_router_op_context,
+        ):
+            result = _fetch(url, builder())
+            assert result["status"] == "ok", result
+            assert result["content"] == _BODY.decode()
+    finally:
+        srv.shutdown()


### PR DESCRIPTION
**[tui-coder]** — ⚠️ **BEHAVIOR CHANGE**: this makes a previously-silently-ignored config block actually take effect. An operator who set `web_fetch.verify_ssl: false`, `web_fetch.allow_private_ips: true`, or a non-default `web_fetch.max_download_bytes` / `ca_bundle` in `reyn.yaml` and never noticed it doing nothing will now see it actually apply to real `web_fetch` calls.

Closes #4274.

## What

`OpContext.web_fetch_config` was declared by #4174 T4 but had **zero real construction sites** — every live chat session handed the `web_fetch` op a `None` config, silently falling through to the env-var/litellm default chain instead of the operator's `web_fetch:` block. This wires it live:

`SessionFactoryConfig.web_fetch_config` (#2093 uniform-config bundle) → `Session._web_fetch_config` → `RouterOpContextSource` → both router `OpContext` builders (`Session._make_router_op_context` and `RouterHostAdapter.make_router_op_context`).

### Construction-site coverage (condition ③)

Per T4's own lesson — `getattr(config, "web", None)`-shaped access is structurally invisible to grep, and only the regression suite caught it — I did not treat a grep count as proof of completeness:

- `SessionFactoryConfig.from_config` already reaches all **five** real `build_scoped_chat_session` call sites (`registry_bootstrap.py`, `interfaces/web/deps.py`, `interfaces/cli/commands/chat.py`, `interfaces/cli/commands/dogfood.py`, `interfaces/cli/commands/mcp.py`) — confirmed via grep AND via the src-wide AST-walk guard `test_scoped_session_factory_invariant_1402.py::test_chatsession_constructed_only_in_scoped_factory`, which fails on any construction site outside the one chokepoint.
- Also fixed `factory_config.py`'s own stale docstring ("four" sites → "five", matching `from_config`'s own already-correct "all five factory sites" claim — an internal inconsistency found during investigation, unrelated to but adjacent to the #4274 gap itself).
- Ran the full `tests/core/ tests/runtime/ tests/interfaces/ tests/web/` regression sweep (not just a targeted subset) — it caught a real, unanticipated break: `tests/_support/router_host_adapter.py`'s `_INERT_OP_CONTEXT_SOURCE_FIELDS` (a hand-spelled dict of every `RouterOpContextSource` field, deliberately kept default-free per that class's own design so a new field forces a LOUD `TypeError` instead of a silent `None`) broke 8 test files' collection with exactly that TypeError the moment `web_fetch_config` was added as a required param. This is a good witness in the other direction from tonight's usual finding: the design intent written in that file's own comment ("adding a field makes `make_op_context_source` raise TypeError here — one loud edit instead of a quiet None in every test") is not just declared, it actually fired as designed. Fixed by adding the field to that dict.

### Falsify test (condition ②)

`tests/core/test_web_fetch_config_session_wiring_4274.py` drives a **real** `Session` from a **real** `load_config`, then exercises **both** twin `OpContext` builders (mirroring #2679's `render_template_bounds` guard test). Probes via `max_download_bytes` — `allow_private_ips` can't be used as the probe because #1956's SSRF policy hard-denies loopback unconditionally (not a config knob), so a loopback fetch can't distinguish "wired" from "not wired" on that field; the download cap has no such floor.

Falsify-verified RED independently at both hops (stripped `web_fetch_config=` forwarding at `session.py`'s `RouterOpContextSource(...)` call → RED; restored → GREEN; then repeated at `router_op_context.py`'s `build_router_op_context`'s `OpContext(...)` call → RED; restored → GREEN).

## Docs

- `docs/reference/config/reyn-yaml.md` / `.ja.md`: the `#4274 (open)` warning callout → wired confirmation, with the behavior-change note.
- `docs/reference/runtime/session-construction.md`: new `_web_fetch_config` entry in the Multimodal/media section (closest structural cousin to `_multimodal_config` — a plain value, not a per-turn supplier).
- `docs/deep-dives/proposals/phase-8-require-web-fetch-removal.md` and `0058-web-surface-modularity.md` still mention the pre-#4174-T4-split `web_fetch_config`/`WebConfig` shape — left untouched (historical proposal records of what was proposed at the time), named here rather than silently rewritten or silently ignored, per the established doc-drift discipline from T4/T5.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/mypy_ratchet.py` — 0 findings
- [x] `python scripts/test_tier_audit.py --strict tests/core/test_web_fetch_config_session_wiring_4274.py` — 2/2 OK
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] Falsify-verified both hops (session.py, router_op_context.py) — RED without the wire, GREEN restored
- [x] `tests/core/test_web_fetch_config_session_wiring_4274.py`, `tests/runtime/test_scoped_session_factory_invariant_1402.py`, `tests/core/test_web_fetch_ssrf_redirect_1956.py`, `tests/interfaces/test_web_ws_max_size_config_1934.py` — 17/17 pass
- [x] Full `tests/core/ tests/runtime/ tests/interfaces/ tests/web/` regression sweep — 5869 passed, 6 skipped, 3 failed. The 3 failures are all `#3869` setproctitle tests, unrelated to this PR (environmental: `setproctitle` package not installed in this venv; none of them reference any file this PR touches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

