### PR TITLE
feat(#3698 stage1): replace fastmcp with the official mcp SDK for the client (stdio + non-OAuth http/sse)

### DIFF
--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -793,16 +793,24 @@ class MCPClient:
 
         Idempotent: a second call is a no-op.
 
-        #3698 stage 1: ``stdio`` now goes through the official ``mcp`` SDK
-        directly (:meth:`_initialize_stdio`) — fastmcp is no longer in this
-        transport's path at all. ``http``/``sse`` still go through
-        :meth:`_initialize_fastmcp` pending their own stage-1 follow-up
-        commits (same PR, reported per-transport — see the commit history).
+        #3698 stage 1: ``stdio``/``http``/``sse`` all go through the official
+        ``mcp`` SDK directly now (:meth:`_initialize_stdio` /
+        :meth:`_initialize_http_or_sse`) — fastmcp is only still in the path
+        for an OAuth-configured http server (:meth:`_initialize_fastmcp`),
+        pending OAuth's own follow-up commit: the official SDK's
+        ``OAuthClientProvider`` needs a ``redirect_handler``/
+        ``callback_handler`` pair implementing the actual browser-flow
+        orchestration fastmcp's own ``OAuth`` class currently does
+        internally — a materially bigger, separately-scoped lift than the
+        method-name/kwarg-shape differences the other transports needed
+        (flagged to lead-coder before starting it).
         """
         if self._initialized:
             return
         if self._type == "stdio":
             await self._initialize_stdio()
+        elif self._type in ("http", "sse") and not self._config.get("auth"):
+            await self._initialize_http_or_sse()
         else:
             await self._initialize_fastmcp()
 
@@ -943,6 +951,94 @@ class MCPClient:
         # a later object, unlike fastmcp's Client.initialize_result) — never
         # None on a successful call, but read defensively anyway in case a
         # future SDK version's contract changes underneath us.
+        if init_result is not None:
+            self._negotiated_version = str(init_result.protocolVersion)
+            self._server_capabilities = init_result.capabilities
+        else:
+            self._negotiated_version = None
+            self._server_capabilities = None
+
+    async def _initialize_http_or_sse(self) -> None:
+        """#3698 stage 1: http/sse (no OAuth configured) via the official
+        ``mcp`` SDK, no fastmcp. Same ``AsyncExitStack`` lifetime model as
+        :meth:`_initialize_stdio` (see its docstring); no stdio-only hints
+        (network-disabled / write-denial / stderr tail) since neither
+        transport spawns a subprocess.
+
+        ``streamablehttp_client`` yields a 3-tuple (``read, write,
+        get_session_id``) — one MORE element than stdio's/sse's 2-tuple
+        (measured via its own return-type annotation); ``sse_client``
+        matches stdio's 2-tuple shape exactly (measured by reading its
+        source's own ``yield read_stream, write_stream``). Only the
+        ``read``/``write`` pair is needed here; the session-id callable
+        (http-only, used for session resumption) is not currently consumed
+        by anything in reyn — same scope as this stage's other transports,
+        where only what reyn ALREADY read off the fastmcp wrapper carries
+        over, not the full surface a future caller might eventually want.
+        """
+        from contextlib import AsyncExitStack
+
+        from mcp.client.session import ClientSession
+
+        init_timeout = float(self._config.get("init_timeout", _DEFAULT_INIT_TIMEOUT_SECONDS))
+        url = self._config.get("url")
+        if not url:
+            raise MCPError(f"{self._type} MCP server config requires 'url'")
+        headers = {str(k): str(v) for k, v in (self._config.get("headers") or {}).items()}
+        if self._agent_id and "X-Reyn-Agent-Id" not in headers:
+            headers["X-Reyn-Agent-Id"] = self._agent_id
+        read_timeout = self._config.get("timeout", 30)
+
+        stack = AsyncExitStack()
+        try:
+            if self._type == "http":
+                # Deliberately the deprecated headers/timeout/auth-kwarg
+                # `streamablehttp_client`, not its replacement
+                # `streamable_http_client` — the latter takes a pre-built
+                # `httpx.AsyncClient` instead, which would mean
+                # reimplementing headers/timeout wiring by hand for no
+                # behavioral gain right now (a real future improvement, out
+                # of this PR's scope: a like-for-like swap, not a redesign).
+                from mcp.client.streamable_http import streamablehttp_client
+
+                read, write, _get_session_id = await stack.enter_async_context(
+                    streamablehttp_client(url, headers=headers, timeout=read_timeout)
+                )
+            else:
+                from mcp.client.sse import sse_client
+
+                read, write = await stack.enter_async_context(
+                    sse_client(url, headers=headers, timeout=read_timeout)
+                )
+            elicitation_callback = None
+            if self._elicitation_handler is not None:
+                elicitation_callback = _adapt_elicitation_handler(self._elicitation_handler)
+            session = await stack.enter_async_context(
+                ClientSession(
+                    read, write,
+                    message_handler=self._message_handler,
+                    elicitation_callback=elicitation_callback,
+                )
+            )
+            if init_timeout > 0:
+                init_result = await asyncio.wait_for(session.initialize(), timeout=init_timeout)
+            else:
+                init_result = await session.initialize()
+        except MCPError:
+            await stack.aclose()
+            raise
+        except Exception as exc:
+            await stack.aclose()
+            hint = ""
+            if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
+                hint = _INIT_TIMEOUT_HINT.format(
+                    seconds=init_timeout, server=self._server_name or "<server-name>",
+                )
+            raise MCPError(f"MCP initialize failed: {exc}{hint}") from exc
+
+        self._client = session
+        self._exit_stack = stack
+        self._initialized = True
         if init_result is not None:
             self._negotiated_version = str(init_result.protocolVersion)
             self._server_capabilities = init_result.capabilities

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -409,6 +409,70 @@ _INIT_TIMEOUT_HINT = (
     "is not enough)."
 )
 
+async def _close_stack_after_init_failure(exc: BaseException, stack: "Any") -> BaseException:
+    """Close ``stack`` after an ``initialize()`` failure and return the exception
+    the caller should format into :class:`MCPError`'s message — OR re-raise
+    ``exc`` UNCHANGED if it is genuine cancellation of the host task (never
+    swallow / relabel a real cancel as a connection failure).
+
+    #4282-adjacent CI-red root-cause fix (discovered while #4282 was in
+    flight; landed ahead of it since it blocked #4283's own merge):
+    live-verified (disposable probes against a real connection-refused
+    target and a real hung-server target — not assumed) that
+    ``asyncio.wait_for()`` wrapping an anyio-native call tree
+    (``stdio_client``/``streamablehttp_client``/``sse_client`` +
+    ``ClientSession``, all anyio cancel-scope based) corrupts anyio's
+    per-task cancel-scope bookkeeping across ``wait_for``'s internal Task
+    boundary: it surfaces as a bare, uninformative ``CancelledError`` at the
+    ``session.initialize()`` await point, THEN a
+    "Attempted to exit cancel scope in a different task" ``RuntimeError``
+    when the stack is later closed — hiding the REAL failure (e.g. a plain
+    connection-refused) entirely. Switching the caller to
+    ``anyio.fail_after()`` (anyio-native, no such corruption) fixes both
+    halves: the real failure now surfaces cleanly from ``stack.aclose()``
+    as an ``ExceptionGroup`` wrapping the actual exception (e.g.
+    ``httpx.ConnectError``) once the task group's cancel scope unwinds
+    normally.
+
+    Discriminating "genuine external cancel of THIS host task" (e.g.
+    :func:`reyn.core.cancellable.race_cancellable`'s watcher, or any other
+    real ``Task.cancel()`` against us) from "an internal anyio cancel-scope
+    propagating a SIBLING task's failure as ``CancelledError`` at OUR await
+    point" turned out to NOT be answerable via ``Task.cancelling()`` alone
+    — live-measured: it reads 1 in BOTH cases, because anyio's asyncio
+    backend implements cross-task cancel-scope cancellation via the exact
+    same ``Task.cancel()`` primitive an external caller would use, so the
+    counter cannot tell them apart. The reliable signal instead: **whether
+    closing the stack reveals a concrete underlying failure.** A genuinely
+    externally-cancelled task group has no failed child to report —
+    ``stack.aclose()`` completes with NO exception (live-verified: cancel a
+    real host task mid-``session.initialize()`` against a hung server,
+    ``aclose()`` closes clean). An internally-failed one DOES (the
+    ``ExceptionGroup`` above). So: if ``exc`` is ``CancelledError`` AND
+    ``stack.aclose()`` closes clean, this was genuine cancellation —
+    re-raise ``exc`` untouched so it reaches ``race_cancellable``'s own
+    (correct) translation to :class:`~reyn.core.cancellable.Cancelled`
+    unmolested, never becoming a misleading ``MCPError``.
+    """
+    real_exc: BaseException = exc
+    try:
+        await stack.aclose()
+    except BaseException as close_exc:
+        real_exc = close_exc
+    else:
+        if isinstance(exc, asyncio.CancelledError):
+            raise exc
+    # Unwrap a single-member ExceptionGroup down to its one real leaf so the
+    # MCPError message names the actual failure (e.g. "ConnectError: All
+    # connection attempts failed") instead of anyio's generic "unhandled
+    # errors in a TaskGroup" wrapper text. A multi-member group is left
+    # as-is — its own str() is still more informative than picking one
+    # arbitrary member.
+    while isinstance(real_exc, BaseExceptionGroup) and len(real_exc.exceptions) == 1:
+        real_exc = real_exc.exceptions[0]
+    return real_exc
+
+
 # #2597 capability/version gate slice: the ``ServerCapabilities`` fields FastMCP's
 # ``mcp.types.InitializeResult.capabilities`` may carry — each is either a capability
 # object (server advertises it) or None (server does not). ``experimental`` and
@@ -887,6 +951,7 @@ class MCPClient:
         """
         from contextlib import AsyncExitStack
 
+        import anyio
         from mcp.client.session import ClientSession
         from mcp.client.stdio import StdioServerParameters, stdio_client
 
@@ -932,26 +997,36 @@ class MCPClient:
                 )
             )
             # #3028/#3698 stage 1: reyn now owns the handshake bound directly
-            # (asyncio.wait_for) instead of relying on fastmcp's opaque
-            # init_timeout constructor kwarg (anyio.fail_after wrapped in two
-            # layers of RuntimeError — see the removed _looks_like_init_timeout
-            # for why that indirection existed and why it no longer does).
-            # init_timeout == 0 disables THIS bound (#3028's own documented
-            # escape hatch) — asyncio.wait_for(timeout=0) means "fire almost
-            # immediately", the OPPOSITE of disabled, so 0 must skip the
+            # instead of relying on fastmcp's opaque init_timeout constructor
+            # kwarg (anyio.fail_after wrapped in two layers of RuntimeError —
+            # see the removed _looks_like_init_timeout for why that
+            # indirection existed and why it no longer does).
+            # #4282-adjacent fix: anyio.fail_after(), not asyncio.wait_for() —
+            # see _close_stack_after_init_failure's docstring for the full
+            # root-cause (asyncio.wait_for corrupts anyio's per-task
+            # cancel-scope bookkeeping across an anyio-native call tree like
+            # this one). init_timeout == 0 disables THIS bound (#3028's own
+            # documented escape hatch) — anyio.fail_after(0), like
+            # asyncio.wait_for(timeout=0), means "fire almost immediately"
+            # (live-verified), the OPPOSITE of disabled, so 0 must skip the
             # wrapper entirely rather than being passed through.
             if init_timeout > 0:
-                init_result = await asyncio.wait_for(session.initialize(), timeout=init_timeout)
+                with anyio.fail_after(init_timeout):
+                    init_result = await session.initialize()
             else:
                 init_result = await session.initialize()
         except MCPError:
             self.close_stderr_capture()
             await stack.aclose()
             raise
-        except Exception as exc:
+        except (Exception, asyncio.CancelledError) as exc:
             tail = self.read_stderr_tail()
             self.close_stderr_capture()
-            await stack.aclose()
+            # A fresh name, not a rebind of `exc` — _close_stack_after_init_failure
+            # returns `BaseException` (broader than the `Exception | CancelledError`
+            # this except clause narrowed `exc` to), so reassigning `exc` itself
+            # would widen its statically-known type for every later reference.
+            real_exc = await _close_stack_after_init_failure(exc, stack)
             from reyn.security.sandbox.policy import DEFAULT_SANDBOX_NETWORK
 
             hint = ""
@@ -972,23 +1047,23 @@ class MCPClient:
                     "Declaring `write_paths` replaces the built-in per-runtime "
                     "defaults; the server's working directory is always granted."
                 )
-            # #3698 stage 1: no more chain-walking predicate — asyncio.wait_for
+            # #3698 stage 1: no more chain-walking predicate — anyio.fail_after
             # raises a plain TimeoutError (__cause__=None) directly, live-
             # verified against a stdio server that starts and never speaks
             # (see this commit's message for the probe output). The old
             # fastmcp-only branch needed _looks_like_init_timeout because
             # fastmcp implemented its OWN init_timeout via anyio.fail_after,
             # re-wrapped in two layers of RuntimeError before it reached us.
-            if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
+            if isinstance(real_exc, (TimeoutError, asyncio.TimeoutError)):
                 hint += _INIT_TIMEOUT_HINT.format(
                     seconds=init_timeout, server=self._server_name or "<server-name>",
                 )
             if tail:
                 raise MCPError(
-                    f"MCP initialize failed: {exc}{hint}\n"
+                    f"MCP initialize failed: {real_exc}{hint}\n"
                     f"--- subprocess stderr (tail) ---\n{tail}"
-                ) from exc
-            raise MCPError(f"MCP initialize failed: {exc}{hint}") from exc
+                ) from real_exc
+            raise MCPError(f"MCP initialize failed: {real_exc}{hint}") from real_exc
 
         self._client = session
         self._exit_stack = stack
@@ -1034,6 +1109,7 @@ class MCPClient:
         """
         from contextlib import AsyncExitStack
 
+        import anyio
         from mcp.client.session import ClientSession
 
         init_timeout = float(self._config.get("init_timeout", _DEFAULT_INIT_TIMEOUT_SECONDS))
@@ -1076,21 +1152,31 @@ class MCPClient:
                     elicitation_callback=elicitation_callback,
                 )
             )
+            # #4282-adjacent fix: anyio.fail_after(), not asyncio.wait_for() —
+            # see _close_stack_after_init_failure's docstring for the full
+            # root-cause (this is the exact bug that made #4283's CI red:
+            # asyncio.wait_for corrupts anyio's per-task cancel-scope
+            # bookkeeping across an anyio-native call tree like this one,
+            # turning a plain connection-refused into an uninformative bare
+            # CancelledError instead of a reportable MCPError).
             if init_timeout > 0:
-                init_result = await asyncio.wait_for(session.initialize(), timeout=init_timeout)
+                with anyio.fail_after(init_timeout):
+                    init_result = await session.initialize()
             else:
                 init_result = await session.initialize()
         except MCPError:
             await stack.aclose()
             raise
-        except Exception as exc:
-            await stack.aclose()
+        except (Exception, asyncio.CancelledError) as exc:
+            # A fresh name, not a rebind of `exc` — see the matching comment in
+            # _initialize_stdio's except clause for why.
+            real_exc = await _close_stack_after_init_failure(exc, stack)
             hint = ""
-            if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
+            if isinstance(real_exc, (TimeoutError, asyncio.TimeoutError)):
                 hint = _INIT_TIMEOUT_HINT.format(
                     seconds=init_timeout, server=self._server_name or "<server-name>",
                 )
-            raise MCPError(f"MCP initialize failed: {exc}{hint}") from exc
+            raise MCPError(f"MCP initialize failed: {real_exc}{hint}") from real_exc
 
         self._client = session
         self._exit_stack = stack

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -1,19 +1,48 @@
 """
-MCP client — thin wrapper around ``fastmcp.Client`` (v3.4.2; #2597 S1).
+MCP client (v#2597 S1; #3698 stage 1).
 
 Supports two transports today: ``stdio`` and ``http`` (Streamable HTTP);
-``sse`` uses FastMCP's ``SSETransport`` (previously ``NotImplementedError`` —
-a free win from the swap: no incremental cost to wire once FastMCP's own
-transport inference exists).
+``sse`` uses the SSE client (previously ``NotImplementedError`` — a free
+win from the original fastmcp swap: no incremental cost to wire once
+FastMCP's own transport inference existed).
 
-Each ``MCPClient`` owns a single ``fastmcp.Client`` opened on
-:meth:`initialize` and torn down on :meth:`close`. FastMCP's ``Client`` is
-itself a reentrant async context manager wrapping the transport + the
-underlying ``mcp.ClientSession``; MCPClient enters it once and holds it open
+#3698 stage 1: ``stdio`` and non-OAuth-configured ``http``/``sse`` now go
+through the official ``mcp`` SDK DIRECTLY (``mcp.client.session.
+ClientSession`` + ``mcp.client.{stdio,streamable_http,sse}``) — fastmcp is
+no longer in those paths at all. An OAuth-configured ``http`` server still
+goes through fastmcp's ``Client`` (:meth:`_initialize_fastmcp`), split out
+to its own issue (#4282) rather than attempted here — the official SDK's
+``OAuthClientProvider`` needs a caller-supplied browser-redirect +
+localhost-callback implementation fastmcp currently provides internally,
+PLUS a second adapter for reyn's own token storage (fastmcp's
+``AsyncKeyValue`` protocol vs. the official SDK's ``TokenStorage``
+protocol — genuinely different shapes, not a rename) — materially more
+than the method-name/kwarg differences the other transports needed. The
+"OAuth 2.1" section below is still accurate for that path.
+
+⚠️ **This module is a HYBRID, not a completed migration** — a state a
+future reader could easily misread as "done" without this paragraph:
+  - ``fastmcp`` stays a REQUIRED dependency (not optional, not vendored)
+    until #4282 lands, because the OAuth path still needs it.
+  - The ``mcp<2.0`` pin (owned by ``fastmcp-slim``'s own dependency
+    constraint, not reyn's) CANNOT be relaxed until #4282 lands either —
+    #3698's own stage 2 (adopting ``mcp>=2.0`` for ``2026-07-28`` support)
+    is gated on #4282, not on "the remaining transports": there are no
+    remaining transports once this PR lands, only the remaining
+    DEPENDENCY that #4282 removes.
+  - Do not read "stage 1 landed" as "fastmcp can be removed from
+    pyproject.toml" — that is #4282's own landing condition, not this
+    one's.
+
+Each ``MCPClient`` owns a single connection opened on :meth:`initialize` and
+torn down on :meth:`close`. The official-SDK path holds it open via an
+``contextlib.AsyncExitStack`` (see :meth:`_initialize_stdio`'s docstring for
+why — the SDK expresses the SAME connection as two SEPARATE async context
+managers, not fastmcp's one reentrant object); the fastmcp/OAuth path still
+enters ``fastmcp.Client`` directly. Either way, the connection stays open
 for the object's lifetime (matching the previous hand-rolled client's
 caching semantics on ``OpContext.mcp_clients`` / the pool's subprocess-reuse
-contract — FastMCP's ``StdioTransport(keep_alive=True)`` is the same
-persistent-subprocess semantics).
+contract — persistent-subprocess semantics for stdio either way).
 
 Environment variable expansion:
   ``${VAR_NAME}`` in any string config value is replaced with
@@ -25,11 +54,14 @@ Capability / version gate (#2597 capability slice):
   MCP's ``initialize`` handshake natively negotiates BOTH a protocol version
   and a set of server capabilities (tools/resources/prompts/logging/
   completions) in one round trip — rather than sprinkling version checks
-  across reyn, :meth:`initialize` captures both ONCE, right after FastMCP's
-  ``client.__aenter__()`` completes the handshake (verified against fastmcp
-  3.4.2: ``Client.initialize_result`` — an ``mcp.types.InitializeResult`` —
-  is populated at that point; see ``initialize()``'s inline comment for the
-  exact source-file/line trail). :meth:`supports` answers "did the server
+  across reyn, :meth:`initialize` captures both ONCE, right after the
+  handshake completes. #3698 stage 1 re-measured this against the official
+  SDK directly (live probe, not read from docs): ``ClientSession.
+  initialize()`` RETURNS the ``mcp.types.InitializeResult`` directly (a plain
+  return value, not a property read off a separate object the way fastmcp's
+  ``Client.initialize_result`` — populated by ``client.__aenter__()``,
+  verified against fastmcp 3.4.2 — worked; that description stays accurate
+  for the OAuth/fastmcp path only). :meth:`supports` answers "did the server
   advertise capability X" (conservative False before initialize / on a
   missing result); :func:`require_capability` is the enforcement seam —
   call it before issuing a request for a gated feature so an unsupported
@@ -43,13 +75,20 @@ Capability / version gate (#2597 capability slice):
 
 Elicitation (#2597 slice ③ — server->client ``elicitation/create``):
   an optional ``elicitation_handler`` (constructor kwarg, same shape as
-  ``message_handler``) is forwarded verbatim to ``fastmcp.Client(...,
-  elicitation_handler=...)`` — passing ANY non-None handler is itself what
-  makes FastMCP declare the ``elicitation`` client capability during the
-  initialize handshake. See :mod:`reyn.mcp.elicitation` for the handler
+  ``message_handler``) — on the fastmcp/OAuth path, forwarded verbatim to
+  ``fastmcp.Client(..., elicitation_handler=...)``. #3698 stage 1: on the
+  official-SDK path, ``_adapt_elicitation_handler`` wraps it first — reyn's
+  own handler is shaped ``(message, response_type, params, context)``
+  (fastmcp's ``ElicitationHandler`` protocol), while the official SDK's
+  ``ElicitationFnT`` is ``(context, params)`` — 2 args, opposite order,
+  entirely different shape (measured by reading both protocols directly,
+  not assumed). Passing ANY non-None (adapted or not) handler is itself
+  what declares the ``elicitation`` client capability during the initialize
+  handshake, on both paths. See :mod:`reyn.mcp.elicitation` for the handler
   that routes a server's structured question through reyn's consent path
   (:class:`~reyn.mcp.connection_service.MCPConnectionService` builds one per
-  held connection); this module only plumbs the constructor kwarg through.
+  held connection); this module only plumbs the constructor kwarg through
+  (adapted or not).
 
 OAuth 2.1 (#2597 slice ④ — the umbrella's LAST slice, hosted MCP servers like
 GitHub MCP / Atlassian that require browser-based OAuth rather than a static
@@ -412,9 +451,26 @@ def _is_transport_death(exc: BaseException) -> bool:
     signals genuine MCP transport death — as opposed to an application-level
     protocol error the server responded with while alive and connected.
 
-    #2597 F1 predicate — verified by reading the installed fastmcp 3.4.2 +
-    mcp SDK source AND by live-probing both branches against the real
-    ``tests/_support/mcp_fastmcp_echo_server.py`` test double over stdio:
+    #2597 F1 predicate — originally verified by reading the installed
+    fastmcp 3.4.2 + mcp SDK source AND by live-probing both branches
+    against the real ``tests/_support/mcp_fastmcp_echo_server.py`` test
+    double over stdio. **#3698 stage 1 re-measurement**: this predicate's
+    own logic needed ZERO code changes — it already reads
+    ``mcp.shared.exceptions.McpError``/``mcp.types.CONNECTION_CLOSED``
+    directly from the official SDK, never through a fastmcp-shaped
+    wrapper, so the classification below is unchanged for the
+    stdio/non-OAuth-http/sse call sites that now go through
+    ``ClientSession`` directly. Re-confirmed live against the official
+    SDK path (``_initialize_stdio`` + a killed-subprocess probe): the
+    ``McpError``/``CONNECTION_CLOSED`` branch fires exactly the same way
+    as it did for fastmcp, since both sit on the same underlying
+    ``mcp.shared.session.BaseSession`` receive loop. The
+    ``RuntimeError("Server session was closed unexpectedly")`` branch
+    remains fastmcp-specific (fastmcp's ``Client._context_manager`` wraps
+    the error in this exact message) — it is dead weight for the
+    stdio/non-OAuth-http/sse call sites now that they bypass fastmcp
+    entirely, but is kept because the OAuth-http path (``_initialize_fastmcp``)
+    still routes through fastmcp's ``Client`` and can still raise it:
 
       - ``mcp.shared.exceptions.McpError`` whose ``.error.code`` equals
         ``mcp.types.CONNECTION_CLOSED`` (``-32000``). ``mcp.shared.session.
@@ -1467,6 +1523,16 @@ class MCPClient:
         class — see ``tests/_support/mcp_subscribable_resources_server.py``'s
         module docstring for the full fact-check). This is a REFUSAL, the same
         shape as :func:`require_capability` — not a transport failure.
+
+        **#3698 stage 1 re-measurement**: this declaration was already reading
+        ``mcp.types.ServerCapabilities``/``ResourcesCapability`` directly — the
+        official SDK's own types, not a fastmcp-shaped projection — since
+        ``self._server_capabilities`` is populated from ``ClientSession.
+        initialize()``'s ``InitializeResult.capabilities`` on the stdio/
+        non-OAuth-http/sse path (and from fastmcp's ``Client.initialize_result.
+        capabilities`` — same underlying SDK type — on the OAuth/fastmcp path).
+        No code or behavior change; re-confirmed by re-reading both call sites'
+        population code, not just this predicate's read side.
         """
         server = self.server_name or "<unknown>"
         version = self.negotiated_version or "<unknown>"

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -94,6 +94,7 @@ bearer token):
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import signal
@@ -278,41 +279,22 @@ _TOOL_CALL_WRITE_DENIAL_HINT = (
     "server's working directory is always granted."
 )
 
-def _looks_like_init_timeout(exc: BaseException) -> bool:
-    """Whether *exc* is FastMCP's ``init_timeout`` firing on the MCP handshake.
-
-    Structural, not textual: the ``__cause__`` chain is walked for a
-    ``TimeoutError``, because the wording that reaches us carries no usable
-    signal. MEASURED against the real client (fastmcp 3.4.2) with a stdio server
-    that starts and never speaks — the chain arrives as::
-
-        MCPError: MCP initialize failed: Client failed to connect: Failed to
-                  initialize server session
-          __cause__ RuntimeError: Client failed to connect: Failed to initialize …
-          __cause__ RuntimeError: Failed to initialize server session
-          __cause__ TimeoutError
-
-    i.e. FastMCP re-raises its ``anyio.fail_after`` TimeoutError as a bare
-    ``RuntimeError`` whose message names neither a timeout nor the elapsed
-    seconds, but preserves the TimeoutError as ``__cause__``. So the chain is the
-    only load-bearing evidence in the failure; matching the string would pin
-    wording FastMCP owns and can reword in a patch release.
-
-    Deliberately walks ``__cause__`` only, never ``__context__``: an unrelated
-    error raised while *handling* some incidental TimeoutError would be linked by
-    ``__context__``, and treating that as "the handshake timed out" would attach
-    a confidently wrong remedy to it. Defensive on depth — an exception chain is
-    not structurally guaranteed to be acyclic, and a hint must never be the
-    reason a failure path hangs.
-    """
-    seen: set[int] = set()
-    cur: BaseException | None = exc
-    while cur is not None and id(cur) not in seen:
-        seen.add(id(cur))
-        if isinstance(cur, TimeoutError):
-            return True
-        cur = cur.__cause__
-    return False
+# #3698 stage 1 (removed): ``_looks_like_init_timeout`` used to walk an
+# exception's ``__cause__`` chain looking for a ``TimeoutError``, because
+# fastmcp's OWN ``init_timeout`` mechanism (``anyio.fail_after`` inside
+# ``Client.initialize()``) re-raised it wrapped in two layers of opaque
+# ``RuntimeError`` — the chain-walk existed only to see through that
+# wrapping. Once reyn bounds the stdio handshake itself
+# (``asyncio.wait_for(session.initialize(), timeout=...)`` in
+# ``_initialize_stdio``), the exception that actually reaches the caller on
+# timeout is a plain ``TimeoutError`` with ``__cause__ is None`` — live-
+# verified against a stdio server that starts and never speaks (see the
+# commit removing this function for the probe output). Detecting it is now
+# a direct ``isinstance(exc, TimeoutError)`` at the call site; no separate
+# predicate function is needed. If a future reader hits an opaque multi-
+# layer wrapping again (e.g. from some other library reyn adopts), THIS is
+# the shape that pattern takes and why — re-derive the chain-walk from this
+# note rather than from scratch.
 
 
 # #3028: how long to wait for a server to answer the MCP handshake before giving up.
@@ -502,80 +484,37 @@ def _classify_and_raise(exc: Exception, message: str) -> NoReturn:
     raise MCPError(message) from exc
 
 
-def _extract_stdio_child_pid(fastmcp_client: "Any") -> int | None:
-    """#2714 best-effort: return the OS pid of the stdio subprocess backing
-    ``fastmcp_client``, or None if it can't be located.
+def _extract_stdio_child_pid(stdio_cm: "Any") -> int | None:
+    """#2714 best-effort: return the OS pid of the stdio subprocess opened by
+    the official SDK's ``stdio_client(...)`` async context manager, or None
+    if it can't be located.
 
-    fastmcp 3.4.2's ``StdioTransport`` deliberately keeps the spawned subprocess
-    handle OFF the transport object (its connect-task holds it in a task-local
-    ``AsyncExitStack`` so the task owns no back-reference), and neither fastmcp nor
-    the mcp SDK exposes the pid on any public surface. So we walk the connect-task's
-    coroutine / async-generator frame chain (through the mcp ``stdio_client``
-    generator's ``AsyncExitStack``) to find the ``anyio.abc.Process`` and read its
-    ``pid``.
+    #3698 stage 1: ``stdio_client`` is an ``@asynccontextmanager``-decorated
+    generator function; ``contextlib.asynccontextmanager`` wraps it in an
+    ``_AsyncGeneratorContextManager`` whose ``.gen`` attribute IS the entered
+    generator, and ``anyio.abc.Process`` lives in that generator's OWN local
+    variable (``process``) once entered — one hop, since ``MCPClient`` holds
+    the entered context manager directly (via its own ``AsyncExitStack`), not
+    behind fastmcp's extra task-local indirection the pre-swap
+    ``_walk_frames_for_process_pid`` BFS existed to reach. Live-verified: the
+    extracted pid matched the server's own ``os.getpid()`` exactly (see the
+    commit message introducing this function for the probe output).
 
-    Every step is defensive: any structural drift from a fastmcp/mcp upgrade returns
-    None, and the belt-and-suspenders reap then simply falls back to the async
-    graceful teardown — byte-identical to pre-#2714 behaviour. Captured ONCE at
-    connect (structure known-good) and only ever used as a terminate target, so a
-    stale/None value can never do worse than the pre-fix orphan."""
+    Defensive throughout: any structural drift from an ``mcp`` SDK upgrade
+    returns None, and the belt-and-suspenders reap then simply falls back to
+    the async graceful teardown — byte-identical to pre-#2714 behaviour.
+    Captured ONCE at connect (structure known-good) and only ever used as a
+    terminate target, so a stale/None value can never do worse than the
+    pre-fix orphan."""
     try:
-        from anyio.abc import Process as _AnyioProcess
-    except Exception:  # pragma: no cover — anyio ships with fastmcp
-        return None
-    transport = getattr(fastmcp_client, "transport", None)
-    connect_task = getattr(transport, "_connect_task", None)
-    get_coro = getattr(connect_task, "get_coro", None)
-    if get_coro is None:
-        return None
-    try:
-        return _walk_frames_for_process_pid(get_coro(), _AnyioProcess)
+        frame = getattr(getattr(stdio_cm, "gen", None), "ag_frame", None)
+        if frame is None:
+            return None
+        process = frame.f_locals.get("process")
+        pid = getattr(process, "pid", None)
+        return pid if isinstance(pid, int) else None
     except Exception:  # noqa: BLE001 — pid capture is best-effort, never fatal
         return None
-
-
-def _walk_frames_for_process_pid(root_coro: "Any", process_type: type) -> int | None:
-    """Breadth-first walk of a coroutine/async-generator/AsyncExitStack graph rooted
-    at ``root_coro``, returning the ``pid`` of the first ``process_type`` instance
-    found in any frame's locals. Bounded (``id``-deduped, step-capped) so a cyclic
-    or pathological graph can never loop forever. Helper for
-    :func:`_extract_stdio_child_pid` — see there for why the walk is necessary."""
-    pending: list[Any] = [root_coro]
-    seen: set[int] = set()
-    steps = 0
-    while pending and steps < 500:
-        steps += 1
-        node = pending.pop()
-        if node is None or id(node) in seen:
-            continue
-        seen.add(id(node))
-        # An AsyncExitStack node: descend into the context managers it will exit
-        # (the mcp stdio_client generator + the ClientSession live here).
-        callbacks = getattr(node, "_exit_callbacks", None)
-        if callbacks is not None:
-            for cb in callbacks:
-                callback = cb[1] if isinstance(cb, tuple) and len(cb) == 2 else None
-                target = getattr(callback, "__self__", None)
-                gen = getattr(target, "gen", None)  # _AsyncGeneratorContextManager.gen
-                if gen is not None:
-                    pending.append(gen)
-                inner_stack = getattr(target, "_exit_stack", None)  # ClientSession
-                if inner_stack is not None:
-                    pending.append(inner_stack)
-            continue
-        frame = getattr(node, "cr_frame", None) or getattr(node, "ag_frame", None)
-        if frame is not None:
-            for value in frame.f_locals.values():
-                if isinstance(value, process_type):
-                    pid = getattr(value, "pid", None)
-                    if isinstance(pid, int):
-                        return pid
-                if getattr(value, "_exit_callbacks", None) is not None:
-                    pending.append(value)
-        awaited = getattr(node, "cr_await", None) or getattr(node, "ag_await", None)
-        if awaited is not None:
-            pending.append(awaited)
-    return None
 
 
 # ── Client ───────────────────────────────────────────────────────────────────
@@ -684,7 +623,19 @@ class MCPClient:
         # None (default) means auto-detect via sys.stdin.isatty() at the point
         # _open_http actually needs the answer — see _is_non_interactive().
         self._non_interactive_override: bool | None = non_interactive
-        self._client: Any = None  # fastmcp.Client when initialized
+        self._client: Any = None  # official mcp.ClientSession (stdio) or fastmcp.Client (http/sse, pending #3698 stage 1) when initialized
+        # #3698 stage 1: holds the entered stdio_client + ClientSession async
+        # context managers open for this object's lifetime — the official
+        # SDK's connection lifecycle is a pair of async context managers, not
+        # fastmcp.Client's single reentrant __aenter__/close() object, so an
+        # AsyncExitStack is what reproduces the same "open once, use across
+        # many calls, close later" pattern (live-verified: initialize() then
+        # TWO separate call_tool()s against the SAME held session, then a
+        # clean stack.aclose() — see the commit message for the probe). None
+        # until initialize() actually opens a stdio connection; the http/sse
+        # paths still use fastmcp's own Client (pending stage-1 follow-up
+        # commits) and leave this None.
+        self._exit_stack: "Any | None" = None
         self._initialized = False
         # Captures subprocess stderr for stdio transport so initialize
         # failures (e.g. self-made MCP server exits immediately, writes
@@ -800,13 +751,208 @@ class MCPClient:
         """
         return self._initialized
 
+    async def _paginate_official_sdk(self, list_fn: Any, items_attr: str) -> list[Any]:
+        """#3698 stage 1: fastmcp's ``Client.list_tools()`` (and its sibling
+        list methods) auto-paginate internally, following ``nextCursor`` —
+        reyn relied on that. The official SDK's raw ``ClientSession.
+        list_tools(cursor=...)`` returns ONE page (a ``ListToolsResult``
+        object with ``.tools``/``.nextCursor``, not a bare list) and does
+        NOT paginate on its own — measured directly (its own return
+        annotation; ``ClientSession`` has no auto-paginating convenience
+        layer fastmcp added on top). This reproduces fastmcp's behavior:
+        follow ``nextCursor`` until it's ``None``, same 250-page guard
+        (a malformed/adversarial server cycling cursors forever must not
+        hang this call) as the pre-swap comment on the fastmcp path named."""
+        items: list[Any] = []
+        cursor: str | None = None
+        for _ in range(250):
+            result = await list_fn(cursor)
+            items.extend(getattr(result, items_attr))
+            cursor = result.nextCursor
+            if cursor is None:
+                break
+        return items
+
+    @property
+    def _uses_official_sdk(self) -> bool:
+        """#3698 stage 1: True once ``self._client`` is the official SDK's
+        ``ClientSession`` directly (stdio, migrated) rather than fastmcp's
+        ``Client`` (http/sse, pending their own stage-1 commits). The two
+        expose a few operations under different names/paths for the SAME
+        protocol call (``call_tool_mcp`` vs ``call_tool``, ``.session.
+        subscribe_resource`` vs ``.subscribe_resource`` directly) — this is
+        the single dispatch point every such call site branches on, so the
+        distinction disappears in one place once http/sse migrate too rather
+        than needing to be re-found at each call site. ``self._exit_stack``
+        is only ever set by ``_initialize_stdio`` — a reliable proxy with no
+        separate bookkeeping."""
+        return self._exit_stack is not None
+
     async def initialize(self) -> None:
         """Open the transport and complete the MCP handshake.
 
         Idempotent: a second call is a no-op.
+
+        #3698 stage 1: ``stdio`` now goes through the official ``mcp`` SDK
+        directly (:meth:`_initialize_stdio`) — fastmcp is no longer in this
+        transport's path at all. ``http``/``sse`` still go through
+        :meth:`_initialize_fastmcp` pending their own stage-1 follow-up
+        commits (same PR, reported per-transport — see the commit history).
         """
         if self._initialized:
             return
+        if self._type == "stdio":
+            await self._initialize_stdio()
+        else:
+            await self._initialize_fastmcp()
+
+    async def _initialize_stdio(self) -> None:
+        """#3698 stage 1: stdio via the official ``mcp`` SDK, no fastmcp.
+
+        Connection-lifetime model: fastmcp's ``Client`` is a single reentrant
+        async context manager an ``MCPClient`` enters once and holds open for
+        its own lifetime. The official SDK expresses the SAME connection as
+        TWO separate async context managers (``stdio_client`` for the
+        transport, ``ClientSession`` for the protocol session) that are
+        normally used inside one ``async with`` block. An
+        ``contextlib.AsyncExitStack`` reproduces the "open once, use across
+        many calls, close later" pattern instead — live-verified against the
+        real echo test-double (initialize → two separate call_tool()s against
+        the SAME held session → a clean ``stack.aclose()``) before this was
+        written, not assumed from reading the API alone.
+        """
+        from contextlib import AsyncExitStack
+
+        from mcp.client.session import ClientSession
+        from mcp.client.stdio import StdioServerParameters, stdio_client
+
+        # Computed BEFORE the try block: the except handler's init-timeout hint
+        # needs this value even if the exception fires before the handshake
+        # itself starts (a bad command / sandbox-wrap failure), so it cannot
+        # live inside the try (unbound-on-early-exception otherwise).
+        init_timeout = float(self._config.get("init_timeout", _DEFAULT_INIT_TIMEOUT_SECONDS))
+        stack = AsyncExitStack()
+        try:
+            command = self._config.get("command")
+            if not command:
+                raise MCPError("stdio MCP server config requires 'command'")
+            args = list(self._config.get("args") or [])
+            command, args = self._sandbox_wrap_stdio(command, args)
+            env = self._config.get("env")
+            # Subprocess stderr capture for diagnostic readback on init
+            # failure — same tempfile.TemporaryFile pattern _open_stdio used
+            # for fastmcp's log_file=; the official SDK's stdio_client takes
+            # an errlog= TextIO directly (a real fileno, same requirement).
+            try:
+                self._stderr_capture = tempfile.TemporaryFile(mode="w+t", encoding="utf-8")
+            except Exception:  # noqa: BLE001 — temp-file failure is non-fatal
+                self._stderr_capture = None
+            params = StdioServerParameters(
+                command=command,
+                args=args,
+                env=dict(env) if env else None,
+                cwd=self._config.get("cwd"),
+            )
+            stdio_cm = stdio_client(
+                params, **({"errlog": self._stderr_capture} if self._stderr_capture else {}),
+            )
+            read, write = await stack.enter_async_context(stdio_cm)
+            elicitation_callback = None
+            if self._elicitation_handler is not None:
+                elicitation_callback = _adapt_elicitation_handler(self._elicitation_handler)
+            session = await stack.enter_async_context(
+                ClientSession(
+                    read, write,
+                    message_handler=self._message_handler,
+                    elicitation_callback=elicitation_callback,
+                )
+            )
+            # #3028/#3698 stage 1: reyn now owns the handshake bound directly
+            # (asyncio.wait_for) instead of relying on fastmcp's opaque
+            # init_timeout constructor kwarg (anyio.fail_after wrapped in two
+            # layers of RuntimeError — see the removed _looks_like_init_timeout
+            # for why that indirection existed and why it no longer does).
+            # init_timeout == 0 disables THIS bound (#3028's own documented
+            # escape hatch) — asyncio.wait_for(timeout=0) means "fire almost
+            # immediately", the OPPOSITE of disabled, so 0 must skip the
+            # wrapper entirely rather than being passed through.
+            if init_timeout > 0:
+                init_result = await asyncio.wait_for(session.initialize(), timeout=init_timeout)
+            else:
+                init_result = await session.initialize()
+        except MCPError:
+            self.close_stderr_capture()
+            await stack.aclose()
+            raise
+        except Exception as exc:
+            tail = self.read_stderr_tail()
+            self.close_stderr_capture()
+            await stack.aclose()
+            from reyn.security.sandbox.policy import DEFAULT_SANDBOX_NETWORK
+
+            hint = ""
+            if not self._config.get("network", DEFAULT_SANDBOX_NETWORK):
+                hint = (
+                    "\nHint (#1344): this MCP server is sandboxed with network "
+                    "DISABLED (`network: false` in its config). If it needs "
+                    "network access, set `network: true` (or remove the override)."
+                )
+            if _looks_like_write_denial(tail):
+                hint += (
+                    "\nHint (#2976): the sandbox DENIED a write to a path outside "
+                    "this server's granted write scope (the stderr below names "
+                    "the exact path). A launcher that bootstraps into a per-user "
+                    "cache needs that cache granted. Add the path to this "
+                    "server's `write_paths` in its MCP config, e.g.\n"
+                    "    write_paths: [\"~/.npm\"]\n"
+                    "Declaring `write_paths` replaces the built-in per-runtime "
+                    "defaults; the server's working directory is always granted."
+                )
+            # #3698 stage 1: no more chain-walking predicate — asyncio.wait_for
+            # raises a plain TimeoutError (__cause__=None) directly, live-
+            # verified against a stdio server that starts and never speaks
+            # (see this commit's message for the probe output). The old
+            # fastmcp-only branch needed _looks_like_init_timeout because
+            # fastmcp implemented its OWN init_timeout via anyio.fail_after,
+            # re-wrapped in two layers of RuntimeError before it reached us.
+            if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
+                hint += _INIT_TIMEOUT_HINT.format(
+                    seconds=init_timeout, server=self._server_name or "<server-name>",
+                )
+            if tail:
+                raise MCPError(
+                    f"MCP initialize failed: {exc}{hint}\n"
+                    f"--- subprocess stderr (tail) ---\n{tail}"
+                ) from exc
+            raise MCPError(f"MCP initialize failed: {exc}{hint}") from exc
+
+        self._client = session
+        self._exit_stack = stack
+        self._initialized = True
+        # #2714: capture the stdio subprocess pid now (structure known-good
+        # right after the handshake) for the belt-and-suspenders reap in
+        # close(). #3698 stage 1: reads it off the ENTERED stdio_client
+        # generator's own frame directly — one hop, not fastmcp's task-local
+        # AsyncExitStack indirection _walk_frames_for_process_pid existed
+        # for. Live-verified: the extracted pid matched the server's own
+        # os.getpid() exactly (see this commit's message for the probe).
+        self._child_pid = _extract_stdio_child_pid(stdio_cm)
+        # #2597 capability/version gate: read the negotiated version +
+        # capabilities right after the handshake. init_result is the plain
+        # return value of session.initialize() here (not a property read off
+        # a later object, unlike fastmcp's Client.initialize_result) — never
+        # None on a successful call, but read defensively anyway in case a
+        # future SDK version's contract changes underneath us.
+        if init_result is not None:
+            self._negotiated_version = str(init_result.protocolVersion)
+            self._server_capabilities = init_result.capabilities
+        else:
+            self._negotiated_version = None
+            self._server_capabilities = None
+
+    async def _initialize_fastmcp(self) -> None:
+        """http/sse transports — unchanged fastmcp path, pending #3698 stage
+        1's own follow-up commits for these two transports."""
         try:
             from reyn.mcp._fastmcp_boundary import import_fastmcp_client
 
@@ -879,6 +1025,11 @@ class MCPClient:
             from reyn.security.sandbox.policy import DEFAULT_SANDBOX_NETWORK
 
             hint = ""
+            # #3698 stage 1: the stdio-gated hints below are now unreachable —
+            # this method only ever runs for http/sse (stdio moved to
+            # _initialize_stdio above) — kept as dead-but-harmless conditions
+            # rather than restructured, since this whole method is itself
+            # temporary pending http/sse's own stage-1 follow-up commits.
             if self._type == "stdio" and not self._config.get(
                 "network", DEFAULT_SANDBOX_NETWORK
             ):
@@ -904,19 +1055,6 @@ class MCPClient:
                     "Declaring `write_paths` replaces the built-in per-runtime "
                     "defaults; the server's working directory is always granted."
                 )
-            # #3028: stdio-gated for the same reason the two hints above are — the
-            # remedy it names (pre-install the package the launcher is fetching) only
-            # exists where reyn spawned a process. An http/sse handshake that times
-            # out already explains itself: the SDK's read timeout raises "Timed out
-            # while waiting for response to InitializeRequest. Waited N seconds",
-            # naming both the request and the duration this wording lacks.
-            if self._type == "stdio" and _looks_like_init_timeout(exc):
-                hint += _INIT_TIMEOUT_HINT.format(
-                    seconds=float(
-                        self._config.get("init_timeout", _DEFAULT_INIT_TIMEOUT_SECONDS)
-                    ),
-                    server=self._server_name or "<server-name>",
-                )
             if tail:
                 # #2976: the hint goes BEFORE the stderr dump, not after it. The
                 # message is later summarised by pool.describe_fault(limit=600),
@@ -934,13 +1072,6 @@ class MCPClient:
 
         self._client = client
         self._initialized = True
-        # #2714: capture the stdio subprocess pid now (structure known-good right
-        # after the handshake) for the belt-and-suspenders reap in close(). Best-
-        # effort and stdio-only — non-stdio transports own no subprocess, and any
-        # structural drift in a future fastmcp/mcp upgrade simply yields None (the
-        # reap then no-ops, falling back to the async graceful teardown).
-        if self._type == "stdio":
-            self._child_pid = _extract_stdio_child_pid(client)
         # #2597 capability/version gate: read the negotiated version + capabilities
         # right after the handshake completes. ``initialize_result`` is populated by
         # ``client.__aenter__()`` above (fastmcp 3.4.2: ``Client.initialize_result``
@@ -1004,18 +1135,38 @@ class MCPClient:
         # server never advertised "tools" rather than let the request reach the
         # server and bounce back as a confusing raw protocol error.
         require_capability(self, "tools")
+        # #3698 stage 1: fastmcp's call_tool_mcp and the official SDK's plain
+        # call_tool take the SAME two concepts (a progress callback, a
+        # per-call read timeout) under DIFFERENT kwarg names
+        # (progress_handler/timeout vs progress_callback/read_timeout_seconds
+        # — measured by reading ClientSession.call_tool's own signature) —
+        # NOT interchangeable via **kwargs, so each branch builds its own.
         kwargs: dict[str, Any] = {}
-        if progress_callback is not None:
-            kwargs["progress_handler"] = progress_callback
-        if timeout_seconds is not None:
-            from datetime import timedelta
-            kwargs["timeout"] = timedelta(seconds=timeout_seconds)
+        if self._uses_official_sdk:
+            if progress_callback is not None:
+                kwargs["progress_callback"] = progress_callback
+            if timeout_seconds is not None:
+                from datetime import timedelta
+                kwargs["read_timeout_seconds"] = timedelta(seconds=timeout_seconds)
+        else:
+            if progress_callback is not None:
+                kwargs["progress_handler"] = progress_callback
+            if timeout_seconds is not None:
+                from datetime import timedelta
+                kwargs["timeout"] = timedelta(seconds=timeout_seconds)
         try:
             # call_tool_mcp (not FastMCP's raise_on_error-by-default call_tool)
             # returns the RAW mcp.types.CallToolResult unchanged — same object
             # shape _result_to_dict already flattens, so op_runtime/mcp.py's
-            # consumed shape stays byte-identical.
-            result = await self._client.call_tool_mcp(name, args or {}, **kwargs)
+            # consumed shape stays byte-identical. #3698 stage 1: the official
+            # SDK's OWN plain call_tool() is already the raw/no-raise variant
+            # (measured by reading ClientSession.call_tool's source: it
+            # returns CallToolResult unconditionally, never raises on
+            # isError) — no _mcp-suffixed name exists there to begin with.
+            if self._uses_official_sdk:
+                result = await self._client.call_tool(name, args or {}, **kwargs)
+            else:
+                result = await self._client.call_tool_mcp(name, args or {}, **kwargs)
         except Exception as exc:
             _classify_and_raise(exc, f"MCP tools/call error: {exc}")
         return self._annotate_write_denial(_result_to_dict(result))
@@ -1069,12 +1220,20 @@ class MCPClient:
         ``nextCursor`` up to a 250-page guard) instead of a single page-1
         request — #2597 S1 free win: servers with >1 page of tools no
         longer silently truncate.
+
+        #3698 stage 1: the official SDK's raw ``ClientSession.list_tools()``
+        has no such auto-pagination (measured: it returns ONE
+        ``ListToolsResult`` page, not a flat list) — see
+        :meth:`_paginate_official_sdk`, which reproduces fastmcp's behavior.
         """
         await self.initialize()
         # #2597 capability/version gate: same seam as call_tool — see there.
         require_capability(self, "tools")
         try:
-            tools = await self._client.list_tools()
+            if self._uses_official_sdk:
+                tools = await self._paginate_official_sdk(self._client.list_tools, "tools")
+            else:
+                tools = await self._client.list_tools()
         except Exception as exc:
             _classify_and_raise(exc, f"MCP tools/list error: {exc}")
         return [_tool_to_dict(t) for t in tools]
@@ -1091,7 +1250,12 @@ class MCPClient:
         await self.initialize()
         require_capability(self, "resources")
         try:
-            resources = await self._client.list_resources()
+            if self._uses_official_sdk:
+                resources = await self._paginate_official_sdk(
+                    self._client.list_resources, "resources",
+                )
+            else:
+                resources = await self._client.list_resources()
         except Exception as exc:
             _classify_and_raise(exc, f"MCP resources/list error: {exc}")
         return [_resource_to_dict(r) for r in resources]
@@ -1103,7 +1267,12 @@ class MCPClient:
         await self.initialize()
         require_capability(self, "resources")
         try:
-            templates = await self._client.list_resource_templates()
+            if self._uses_official_sdk:
+                templates = await self._paginate_official_sdk(
+                    self._client.list_resource_templates, "resourceTemplates",
+                )
+            else:
+                templates = await self._client.list_resource_templates()
         except Exception as exc:
             _classify_and_raise(exc, f"MCP resources/templates/list error: {exc}")
         return [_resource_to_dict(t) for t in templates]
@@ -1118,11 +1287,22 @@ class MCPClient:
         down to just ``.contents``) so the shape-flattening lives in ONE
         place (:func:`_read_resource_result_to_dict`), mirroring how
         :meth:`call_tool` uses ``call_tool_mcp`` for the same reason.
+
+        #3698 stage 1: the official SDK's OWN plain ``read_resource`` never
+        had fastmcp's convenience-stripping layer to begin with — it already
+        returns the full ``ReadResourceResult`` (live-verified: called
+        against the real echo server's ``resource://pid``, ``.contents``
+        reachable directly, no fastmcp in the path). ``uri`` is typed
+        ``AnyUrl`` on that method but accepts a plain ``str`` — pydantic
+        coerces it at the request-params model boundary (also live-verified).
         """
         await self.initialize()
         require_capability(self, "resources")
         try:
-            result = await self._client.read_resource_mcp(uri)
+            if self._uses_official_sdk:
+                result = await self._client.read_resource(uri)
+            else:
+                result = await self._client.read_resource_mcp(uri)
         except Exception as exc:
             _classify_and_raise(exc, f"MCP resources/read error: {exc}")
         return _read_resource_result_to_dict(result)
@@ -1139,7 +1319,10 @@ class MCPClient:
         await self.initialize()
         require_capability(self, "prompts")
         try:
-            prompts = await self._client.list_prompts()
+            if self._uses_official_sdk:
+                prompts = await self._paginate_official_sdk(self._client.list_prompts, "prompts")
+            else:
+                prompts = await self._client.list_prompts()
         except Exception as exc:
             _classify_and_raise(exc, f"MCP prompts/list error: {exc}")
         return [_prompt_to_dict(p) for p in prompts]
@@ -1155,11 +1338,18 @@ class MCPClient:
         lives in ONE place (:func:`_get_prompt_result_to_dict`), mirroring
         how :meth:`read_resource` uses ``read_resource_mcp`` for the same
         reason.
+
+        #3698 stage 1: the official SDK's OWN plain ``get_prompt`` has no
+        such extra convenience kwargs to begin with — same signature shape
+        (``name``, ``arguments``), full ``GetPromptResult`` returned.
         """
         await self.initialize()
         require_capability(self, "prompts")
         try:
-            result = await self._client.get_prompt_mcp(name=name, arguments=arguments)
+            if self._uses_official_sdk:
+                result = await self._client.get_prompt(name=name, arguments=arguments)
+            else:
+                result = await self._client.get_prompt_mcp(name=name, arguments=arguments)
         except Exception as exc:
             _classify_and_raise(exc, f"MCP prompts/get error: {exc}")
         return _get_prompt_result_to_dict(result)
@@ -1207,12 +1397,19 @@ class MCPClient:
         re-read the resource to see the new content; see
         :mod:`reyn.mcp.message_handler`'s ``on_resource_updated`` for the
         EventLog bridge.
+
+        #3698 stage 1: once ``self._client`` IS the ``ClientSession`` directly
+        (stdio), the ``.session`` indirection fastmcp needed is gone — call
+        the method on ``self._client`` itself.
         """
         await self.initialize()
         require_capability(self, "resources")
         self._require_resources_subscribe_capability()
         try:
-            await self._client.session.subscribe_resource(uri)
+            if self._uses_official_sdk:
+                await self._client.subscribe_resource(uri)
+            else:
+                await self._client.session.subscribe_resource(uri)
         except Exception as exc:
             _classify_and_raise(exc, f"MCP resources/subscribe error: {exc}")
 
@@ -1224,7 +1421,10 @@ class MCPClient:
         require_capability(self, "resources")
         self._require_resources_subscribe_capability()
         try:
-            await self._client.session.unsubscribe_resource(uri)
+            if self._uses_official_sdk:
+                await self._client.unsubscribe_resource(uri)
+            else:
+                await self._client.session.unsubscribe_resource(uri)
         except Exception as exc:
             _classify_and_raise(exc, f"MCP resources/unsubscribe error: {exc}")
 
@@ -1247,7 +1447,9 @@ class MCPClient:
             self._reap_child_process()  # nothing opened, or already closed once — still idempotent
             return
         client = self._client
+        exit_stack = self._exit_stack
         self._client = None
+        self._exit_stack = None
         self._initialized = False
         # #2597 capability/version gate: a closed client re-negotiates on the next
         # initialize() (or duck-typed callers who happen to keep querying supports()
@@ -1256,11 +1458,33 @@ class MCPClient:
         self._negotiated_version = None
         self._server_capabilities = None
         try:
-            await client.close()
-        except Exception:
+            # #3698 stage 1: stdio was opened via self._exit_stack (the official
+            # SDK's stdio_client + ClientSession, entered as two separate async
+            # context managers — see _initialize_stdio) — closing means exiting
+            # THAT stack, not calling .close() on the ClientSession object
+            # (which has no such method; only __aexit__ via the stack it was
+            # entered through). http/sse still open via fastmcp's Client,
+            # which owns its own close().
+            if exit_stack is not None:
+                await exit_stack.aclose()
+            else:
+                await client.close()
+        except (Exception, asyncio.CancelledError):
             # Best-effort graceful cleanup; transport may already be down. The
             # belt-and-suspenders reap in the finally still terminates the OS
             # subprocess even when this graceful path raised (the #2714 guard).
+            # #3698 stage 1: asyncio.CancelledError joins Exception here
+            # (Python 3.8+ makes it a BaseException, not an Exception
+            # subclass) — measured live: the official SDK's stdio_client
+            # exits via anyio.create_task_group(), whose __aexit__ can
+            # surface a CancelledError from an in-flight subprocess-wait
+            # when the CALLER's own task is being torn down concurrently
+            # (tests/mcp/test_2597_s2a_mcp_connection_service.py's pool
+            # teardown hit this). This is the SAME class of teardown fault
+            # the surrounding docstring already documents tolerating for
+            # Windows (BrokenResourceError/BaseExceptionGroup) — the
+            # finally-reap below is what actually guarantees the child dies,
+            # not this try succeeding.
             pass
         finally:
             # #2714: explicit terminate runs on BOTH the success and the fault path
@@ -1781,6 +2005,31 @@ class MCPClient:
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────
+
+def _adapt_elicitation_handler(fastmcp_shaped_handler: Any) -> Any:
+    """#3698 stage 1: adapt reyn's own ``(message, response_type, params,
+    context) -> ...`` elicitation handler (``reyn.mcp.elicitation.
+    build_elicitation_handler``, built to fastmcp's
+    ``fastmcp.client.elicitation.ElicitationHandler`` calling convention) to
+    the official SDK's ``ElicitationFnT`` — ``(context, params) ->
+    ElicitResult | ErrorData``, TWO positional args in the OPPOSITE order.
+
+    Measured before writing this: reyn's own handler body never reads
+    ``response_type`` past its signature declaration (grepped — zero uses;
+    the module docstring itself says it's "only used as the None-vs-not-None
+    signal for does this elicitation carry a schema at all", and the handler
+    body already gets that from ``isinstance(params, ElicitRequestFormParams)``
+    directly) — so passing ``None`` here loses nothing. ``message`` is
+    ``params.message`` on every real ``ElicitRequestParams`` shape (form or
+    URL) the official SDK sends.
+    """
+    async def _adapted(context: Any, params: Any) -> Any:
+        return await fastmcp_shaped_handler(
+            getattr(params, "message", ""), None, params, context,
+        )
+
+    return _adapted
+
 
 def _result_to_dict(result: Any) -> dict[str, Any]:
     """Flatten an ``mcp.types.CallToolResult`` into the shape

--- a/tests/mcp/test_mcp_client.py
+++ b/tests/mcp/test_mcp_client.py
@@ -214,6 +214,65 @@ def test_close_releases_resources() -> None:
     asyncio.run(_run_it())
 
 
+def test_initialize_against_unreachable_http_raises_mcp_error_not_cancelled() -> None:
+    """Tier 1: #4282-adjacent falsify direction ① — a genuinely unreachable
+    remote (connection refused, port 1) surfaces as MCPError, not a bare
+    asyncio.CancelledError leaking past every except clause. #4283's CI red
+    was exactly this: the official SDK's streamablehttp_client internally
+    fails a POST-request task inside its OWN anyio task group, which cancels
+    the sibling task our initialize() is awaiting on — asyncio.wait_for (the
+    pre-fix code) corrupted anyio's per-task cancel-scope bookkeeping across
+    that boundary, hiding the real ConnectError behind an uninformative
+    CancelledError. See _close_stack_after_init_failure's docstring in
+    client.py for the full root-cause and live-probe evidence."""
+    cfg = {"type": "http", "url": "http://127.0.0.1:1/mcp", "timeout": 3}
+
+    async def _run_it():
+        client = MCPClient(cfg)
+        await client.initialize()
+
+    with pytest.raises(MCPError, match="MCP initialize failed"):
+        asyncio.run(_run_it())
+
+
+def test_initialize_cancelled_externally_propagates_as_cancellation_not_mcp_error(
+    tmp_path,
+) -> None:
+    """Tier 1: #4282-adjacent falsify direction ② — a GENUINE external
+    cancellation of the task running initialize() (mirrors
+    reyn.core.cancellable.race_cancellable's watcher / Session's own
+    hard-cancel calling Task.cancel()) must propagate as CancelledError, NOT
+    get mistranslated into MCPError. Without this direction, a fix for ①
+    that broadly caught every CancelledError and wrapped it in MCPError
+    would make "the user pressed cancel" indistinguishable from "the server
+    is unreachable" — exactly the trap lead-coder flagged on #4283's review.
+
+    Uses the SAME real "silent stdio server" pattern (a subprocess that
+    spawns and sleeps forever, never touching stdin/stdout) as
+    ``test_3028_mcp_stdio_init_timeout.py`` — so initialize() is genuinely
+    blocked waiting on I/O when the external cancel() lands, the same shape
+    a Ctrl-C mid-handshake would hit in production. Exercises the stdio
+    path specifically (lead-coder's review asked to check it alongside
+    http/sse — its exception handling shares the same
+    _close_stack_after_init_failure helper, so a discriminator bug here
+    would misreport a stdio cancel too)."""
+    server = tmp_path / "silent_server.py"
+    server.write_text("import time\nwhile True:\n    time.sleep(3600)\n", encoding="utf-8")
+    cfg = {"type": "stdio", "command": sys.executable, "args": [str(server)]}
+
+    async def _run_it():
+        client = MCPClient(cfg)
+        task = asyncio.ensure_future(client.initialize())
+        # Give initialize() a moment to actually reach the blocked I/O wait
+        # (not cancel it before it has even spawned the subprocess).
+        await asyncio.sleep(0.2)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(_run_it())
+
+
 def test_call_tool_propagates_tool_error_not_transport_crash() -> None:
     """Tier 1: framework boundary — a tool that raises server-side surfaces as
     ``isError: True`` in the result (MCP protocol-level tool error), not an MCPError —

--- a/tests/mcp/test_mcp_client_stderr_capture.py
+++ b/tests/mcp/test_mcp_client_stderr_capture.py
@@ -162,33 +162,46 @@ def test_open_stdio_allocates_stderr_capture() -> None:
         del cm
 
 
-def test_initialize_failure_includes_stderr_tail_in_error() -> None:
+def test_initialize_failure_includes_stderr_tail_in_error(monkeypatch) -> None:
     """Tier 2: when initialize fails after stderr was written, the
     MCPError carries the tail as part of the message.
 
-    Uses the public ``initialize`` API with a deliberately broken
-    transport opener that raises after writing to the capture file —
-    simulating a subprocess that emits diagnostic text then exits.
+    #3698 stage 1: stdio now goes through ``_initialize_stdio`` directly
+    (the official SDK's ``stdio_client``, not fastmcp's ``_open_transport``/
+    ``_open_stdio`` — those are only reachable via the http/sse fastmcp path
+    now). Patches ``mcp.client.stdio.stdio_client`` at the SOURCE module —
+    ``_initialize_stdio``'s own ``from mcp.client.stdio import ...`` is a
+    local import re-executed on every call, so it re-reads whatever this
+    monkeypatch has installed there, same mechanism the module docstring's
+    item 1 already relied on for the (now-superseded) fastmcp seam.
+
+    ``_initialize_stdio`` allocates its OWN ``self._stderr_capture`` (it
+    can't be pre-populated by the test the way the old fastmcp seam allowed
+    — the real flow's own temp file didn't exist yet at that point either)
+    — so the fake CM writes the diagnostic text into whatever file
+    ``errlog=`` it's called with, simulating what a real subprocess's stderr
+    capture would have produced before dying.
     """
     pytest.importorskip("mcp")
     client = _client()
-    # Pre-allocate a capture so the simulated transport can write into
-    # it before the failure. Real flow allocates this in _open_stdio.
-    client._stderr_capture = tempfile.TemporaryFile(mode="w+t", encoding="utf-8")
-    client._stderr_capture.write("Traceback: ImportError: missing dep 'foo'\n")
-    client._stderr_capture.flush()
 
     class _BrokenAsyncCM:
+        def __init__(self, errlog):
+            self._errlog = errlog
+
         async def __aenter__(self):
+            if self._errlog is not None:
+                self._errlog.write("Traceback: ImportError: missing dep 'foo'\n")
+                self._errlog.flush()
             raise RuntimeError("subprocess died before handshake")
 
         async def __aexit__(self, *args):
             return False
 
-    def _broken_transport():
-        return _BrokenAsyncCM()
+    def _broken_stdio_client(params, errlog=None):
+        return _BrokenAsyncCM(errlog)
 
-    client._open_transport = _broken_transport  # type: ignore[method-assign]
+    monkeypatch.setattr("mcp.client.stdio.stdio_client", _broken_stdio_client)
 
     import asyncio
     with pytest.raises(MCPError) as excinfo:


### PR DESCRIPTION
**[e2e-coder]** — #3698 stage 1: replace fastmcp with the official `mcp` SDK for reyn's MCP CLIENT path, staying on `mcp<2.0` (fastmcp's own dependency floor). Like-for-like library swap, not a protocol/version upgrade — stage 2 (`mcp>=2.0`) is a separately-driven follow-up.

## Scope

- **Migrated to the official SDK directly** (`ClientSession` + `mcp.client.{stdio,streamable_http,sse}`): `stdio` transport (fully), `http`/`sse` transports WITHOUT OAuth configured (fully).
- **Stays on fastmcp's `Client`, out of scope for this PR**: OAuth-configured `http` servers — split to **#4282**. The official SDK's OAuth support needs reyn to implement its own browser-redirect + localhost-callback flow (fastmcp does this internally today) plus a second token-storage protocol adapter (fastmcp's `AsyncKeyValue` vs. the official SDK's `TokenStorage`) — qualitatively larger than the other transports.

## ⚠️ This is a HYBRID, not a completed migration

`fastmcp` stays a REQUIRED dependency and the `mcp<2.0` pin cannot be relaxed until #4282 lands. Stage 2 is gated on #4282, not on "remaining transports" — there are none left after this PR, only the remaining dependency #4282 removes. Documented prominently in the module's top-level docstring so a future reader doesn't misread "stage 1 landed" as "fastmcp can be removed."

## Commits (split by concern)

1. `feat(#3698 stage1): stdio transport moves from fastmcp to the official mcp SDK` — transport swap body, dead-branch removal (`_looks_like_init_timeout`, the old `RuntimeError("Server session was closed unexpectedly")`-only path), self-implemented `init_timeout` bound via `asyncio.wait_for` (with the `init_timeout == 0` special case — `wait_for(timeout=0)` means "fire almost immediately," the OPPOSITE of "0 disables the bound").
2. `feat(#3698 stage1): http/sse (non-OAuth) transport moves to the official mcp SDK` — same pattern for http/sse; handles the yield-shape difference between `streamablehttp_client` (3-tuple) and `sse_client` (2-tuple).
3. `docs(#3698 stage1): re-measure the 5 fastmcp-verified declarations (item④)` — the PR's real evaluation axis. Each of the 5 "verified/measured against fastmcp X.Y.Z" docstring locations now describes what was re-measured against the official SDK directly.

## Real finding worth calling out

**Pagination**: the official SDK's raw `list_tools`/`list_resources`/`list_resource_templates`/`list_prompts` do NOT auto-paginate the way fastmcp's convenience wrappers did — they return one `ListXResult` page object with `.tools`/`.nextCursor`, not a flat list. This was the ONE of 6 method-name/kwarg-shape sites where an assumption was made instead of a live measurement, and it broke in testing (`ValueError: dictionary update sequence element #0 has length 4; 2 is required` in `test_stdio_transport_round_trip`). Fixed via a new `_paginate_official_sdk` helper (250-page guard, matching fastmcp's own bound). Concrete evidence for why every one of the 6 sites was measured against the real, running SDK — not assumed from docs — before writing production code.

Other real mismatches caught the same way: `call_tool_mcp`→`call_tool`, `read_resource_mcp`→`read_resource`, `get_prompt_mcp`→`get_prompt` (SDK's plain methods are already the no-raise variant fastmcp needed a `_mcp` suffix to reach); `progress_handler`/`timeout` (fastmcp) vs `progress_callback`/`read_timeout_seconds` (SDK) — different names for the same concepts; elicitation handler shape `(message, response_type, params, context)` (fastmcp) vs `(context, params)` (SDK) — opposite argument order, adapted via `_adapt_elicitation_handler`; `asyncio.CancelledError` (a `BaseException`, not caught by `except Exception:`) surfacing from the official SDK's `anyio.create_task_group()`-based teardown under concurrent cancellation — caught by `test_call_result_parity_with_one_shot_pool`, widened the `close()` except clause.

## Verification

All architectural/behavioral claims verified via disposable, non-committed probe scripts run directly against the real, already-installed `mcp==1.26.0` SDK and `tests/_support/mcp_fastmcp_echo_server.py` — never assumed from API docs alone (e.g. AsyncExitStack lifecycle model, pid extraction via `.gen.ag_frame.f_locals["process"]`, the `McpError`/`CONNECTION_CLOSED` transport-death branch).

Local 5-gate battery, all green:
- `ruff check src tests`
- `python scripts/test_tier_audit.py --strict tests/mcp/test_mcp_client_stderr_capture.py`
- `python scripts/verify_module_docstrings.py src/reyn/mcp/client.py`
- `python scripts/mypy_ratchet.py`
- `python scripts/check_tests_path_literal_reference.py`

Test sweep (API-consumer-based, not file-touched-based — grepped `reyn.mcp.client` importers across the whole repo):
- `tests/mcp/` full bucket: 154 passed
- 15-file cross-directory consumer sweep (builtin/core/interfaces/runtime/security): 169 passed, 14 skipped

Branch rebased onto current `main` post-push (dropped 2 locally-duplicated commits whose content had already landed upstream via a differently-hashed squash merge — `git rebase --skip` after confirming identical patch content); re-ran the full gate battery + sweep after the rebase, all green.

## Reviewer note (lead-coder, non-blocking)

`test_initialize_failure_includes_stderr_tail_in_error` witnesses reyn's own "errlog → MCPError message" wiring, but not that a real child process's stderr actually reaches the official SDK's `stdio_client`'s `errlog` file — that plumbing's responsible party changed from fastmcp to the official SDK in this PR, and no test in the file starts a real subprocess to witness the handoff. Pre-existing gap (not introduced here), but this PR is the most visible place the responsible side swapped. Filed as **#4285** rather than fixed inline, per lead-coder's own "別 PR で構いません" — not blocking this PR's merge.

## Test plan

- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict tests/mcp/test_mcp_client_stderr_capture.py`
- [x] `python scripts/verify_module_docstrings.py src/reyn/mcp/client.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `tests/mcp/` full bucket (154 passed)
- [x] 15-file consumer sweep across builtin/core/interfaces/runtime/security (169 passed, 14 skipped)
- [x] (skipped — no TUI/visual surface touched by this PR)
- [x] real-subprocess stderr→errlog witness gap (lead-coder, non-blocking) — filed as #4285, not fixed inline
- [x] 🔴 CI red: unreachable http surfaced as bare CancelledError instead of MCPError — root-caused (asyncio.wait_for corrupting anyio per-task cancel-scope bookkeeping across an anyio-native call tree) and fixed via anyio.fail_after() + a stack-close-based cancel-vs-failure discriminator; falsified both directions (unreachable→MCPError, genuine external cancel→still CancelledError). See commit 8f0081882.

part of #3698

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
