### PR TITLE
fix(#4280 ①): _run_n_turns_then_shutdown waits on a real predicate

### DIFF
--- a/tests/core/test_1800_c_staging.py
+++ b/tests/core/test_1800_c_staging.py
@@ -42,6 +42,7 @@ from reyn.interfaces.slash.dispatch import maybe_dispatch_slash
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.session import Session
+from tests._async_wait import wait_until
 from tests._support.agent_session import make_session
 from tests._support.slash import local_transport
 
@@ -96,29 +97,23 @@ def _make_llm_stub_fn(result):  # type: ignore[no-untyped-def]
     return _stub
 
 
-async def _run_n_turns_then_shutdown(
-    session: Session,
-    n: int,
-    timeout: float = 5.0,
-) -> None:
-    """Run the session loop until n turns complete, then shutdown."""
-    turns_done = [0]
-    original_run_one = session.run_one_iteration
+async def _run_n_turns_then_shutdown(session: Session, n: int) -> None:
+    """Run the session loop until every submitted user message has been
+    drained and no turn is in flight, then shutdown.
 
-    async def _counting_run_one() -> bool:
-        result = await original_run_one()
-        if result:
-            turns_done[0] += 1
-        return result
-
-    session.run_one_iteration = _counting_run_one  # type: ignore[method-assign]
-
+    #4280: NOT "wait until run_one_iteration() has returned truthy n times" —
+    wake=true batching lets a single run_one_iteration() drain a wake=true
+    trigger AND its wake=False ride-alongs together, so a counted-return
+    version does not map 1:1 to messages submitted. queued_user_messages()
+    + turn_active (both public, documented, in-memory) name the real
+    condition directly: once the wake=True kind="user" trigger is gone from
+    the queue, its ride-alongs were necessarily drained with it (same
+    _drain_to_wake batch), and turn_active confirms the batch's processing
+    has also settled.
+    """
+    del n  # kept for call-site clarity; the real predicate no longer counts
     run_task = asyncio.create_task(session.run())
-    deadline = asyncio.get_event_loop().time() + timeout
-    while turns_done[0] < n:
-        if asyncio.get_event_loop().time() > deadline:
-            break
-        await asyncio.sleep(0.005)
+    await wait_until(lambda: not session.queued_user_messages() and not session.turn_active)
     await session.shutdown()
     try:
         await asyncio.wait_for(run_task, timeout=2.0)

--- a/tests/core/test_1800_wake_drain.py
+++ b/tests/core/test_1800_wake_drain.py
@@ -35,6 +35,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.session import Session
+from tests._async_wait import wait_until
 from tests._support.agent_session import make_session
 
 # ---------------------------------------------------------------------------
@@ -69,30 +70,22 @@ def _wal_events(tmp_path: Path) -> list[dict]:
     return list(log.iter_from(0))
 
 
-async def _run_n_turns_then_shutdown(
-    session: Session,
-    n: int,
-    timeout: float = 3.0,
-) -> None:
-    """Run the session loop until n turns complete, then shutdown."""
-    turns_done = [0]
-    original_run_one = session.run_one_iteration
+async def _run_n_turns_then_shutdown(session: Session, n: int) -> None:
+    """Run the session loop until every submitted message has been drained
+    and no turn is in flight, then shutdown.
 
-    async def _counting_run_one() -> bool:
-        result = await original_run_one()
-        if result:
-            turns_done[0] += 1
-        return result
-
-    session.run_one_iteration = _counting_run_one  # type: ignore[method-assign]
-
+    #4280: NOT "wait until run_one_iteration() has returned truthy n times" —
+    that looked like a real predicate but wasn't one. wake=true batching lets
+    a single ``run_one_iteration()`` drain more than one queued message, so
+    ``turns_done`` does not map 1:1 to messages submitted; a converted version
+    of the old counting form hung on the 3-message case. The real condition
+    this test needs is "every submitted message has actually been consumed",
+    which ``queued_user_messages()`` + ``turn_active`` (both public,
+    documented, in-memory, no WAL read needed) name directly.
+    """
+    del n  # kept for call-site clarity; the real predicate no longer counts
     run_task = asyncio.create_task(session.run())
-    # Wait until n turns complete, then shutdown.
-    deadline = asyncio.get_event_loop().time() + timeout
-    while turns_done[0] < n:
-        if asyncio.get_event_loop().time() > deadline:
-            break
-        await asyncio.sleep(0.005)
+    await wait_until(lambda: not session.queued_user_messages() and not session.turn_active)
     await session.shutdown()
     try:
         await asyncio.wait_for(run_task, timeout=2.0)

--- a/tests/interfaces/test_user_submitted_render_3300.py
+++ b/tests/interfaces/test_user_submitted_render_3300.py
@@ -68,6 +68,7 @@ from reyn.llm.pricing import TokenUsage
 from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.session import Session
 from reyn.schemas.models import Event
+from tests._async_wait import wait_until
 from tests._support.agent_session import make_session
 
 _RAW_ESC = "\x1b[31mdanger\x1b[0m"
@@ -91,23 +92,13 @@ def _make_llm_stub_fn(result):  # type: ignore[no-untyped-def]
     return _stub
 
 
-async def _run_n_turns_then_shutdown(session: Session, n: int, timeout: float = 3.0) -> None:
-    turns_done = [0]
-    original_run_one = session.run_one_iteration
-
-    async def _counting_run_one() -> bool:
-        result = await original_run_one()
-        if result:
-            turns_done[0] += 1
-        return result
-
-    session.run_one_iteration = _counting_run_one  # type: ignore[method-assign]
+async def _run_n_turns_then_shutdown(session: Session, n: int) -> None:
+    """#4280: real predicate, not a turns_done count — see test_1800_wake_drain.py's
+    identical helper for the full rationale (a converted counting version hangs
+    when wake=true batching drains more than one message per run_one_iteration())."""
+    del n  # kept for call-site clarity; the real predicate no longer counts
     run_task = asyncio.create_task(session.run())
-    deadline = asyncio.get_event_loop().time() + timeout
-    while turns_done[0] < n:
-        if asyncio.get_event_loop().time() > deadline:
-            break
-        await asyncio.sleep(0.005)
+    await wait_until(lambda: not session.queued_user_messages() and not session.turn_active)
     await session.shutdown()
     try:
         await asyncio.wait_for(run_task, timeout=2.0)


### PR DESCRIPTION
**[docs-maintainer]** — #4280 item ①: fixes the 3 files where `_run_n_turns_then_shutdown` (duplicated across `test_1800_wake_drain.py` / `test_1800_c_staging.py` / `test_user_submitted_render_3300.py`) was found to have no real predicate — `turns_done[0] >= n` looked like one but wasn't.

## Root cause

`wake=true` batching lets a single `run_one_iteration()` drain more than one queued message (that's the whole point of the wake-drain primitive). So `turns_done` — incremented once per `run_one_iteration()` call that returned truthy — does not map 1:1 to `n` messages submitted. Discovered by actually converting the wait to unconditional (#4279) and watching `test_wake_drain_equivalence_three_messages` (n=3) hang forever, not by reading the code.

## Fix

The real condition these tests need is "every submitted message has been drained and no turn is in flight" — named directly by two already-public, already-documented, in-memory `Session` accessors:
- `Session.queued_user_messages()` — the undispatched `kind=="user"` inbox queue (reads the snapshot-backed state kept current alongside `append_inbox`/`consume_inbox`, per its own docstring — no WAL-flush timing risk).
- `Session.turn_active` — `True` while a turn is dispatched and in flight (already surfaced for client rendering per its docstring: "used alongside `queued_user_messages`").

`test_1800_c_staging.py`'s wake=False "ride-along" (`kind="hook"`) messages aren't `kind=="user"`, so `queued_user_messages()` doesn't see them directly — but `_drain_to_wake` collects them in the SAME batch as the `kind="user"` wake=True trigger, so once the trigger is gone from the queue, its ride-alongs are necessarily gone with it.

## Verification

**Same-reason-green**, all 3 files (26 tests):
```
python -m pytest <3 files> -q → 26 passed
```
Notably includes the previously-hanging `test_wake_drain_equivalence_three_messages`.

**Falsify**: replaced the predicate with `lambda: False` in `test_1800_wake_drain.py` → `timeout 10 pytest ... --timeout=6` → killed (exit 124), confirming the wait is genuinely gated.

## Test plan
- [x] `ruff check` on all 3 changed files — clean
- [x] `python scripts/test_tier_audit.py --strict <3 files>` — 26/26 OK, 0 Tier-4
- [x] `python scripts/mypy_ratchet.py` — OK (baseline unchanged)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK (baseline unchanged)
- [x] Scoped pytest — 26 passed, including the previously-hanging 3-message case
- [x] Falsify: `lambda: False` hangs (kill switch), confirming genuine gating

part of #4280
