### PR TITLE
feat(#4174 T3): consolidate LLM domain (model/models/model_class_by_purpose/api_base/prompt_cache_enabled) into llm:

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -12,11 +12,12 @@ applies_to: [reyn.yaml]
 ## 最小限の例
 
 ```yaml
-model: standard
-models:
-  light:    gemini-flash-lite
-  standard: openai/gpt-4o
-  strong:   anthropic/claude-3-5-sonnet-20241022
+llm:
+  model: standard
+  models:
+    light:    gemini-flash-lite
+    standard: openai/gpt-4o
+    strong:   anthropic/claude-3-5-sonnet-20241022
 ```
 
 ## トップレベルキー
@@ -60,8 +61,6 @@ reload）、`reyn.yaml` 側に書いた同じキーは他と同じく再起動�
 
 | キー | 型 | 書く面 / 再読込 | 説明 |
 |-----|------|-----|-------------|
-| `model` | 文字列 | PRJ のみ・**再起動** | デフォルトのモデルクラス。`models` を通じて解決されます。`--model` でオーバーライド。 |
-| `models` | マップ | PRJ のみ・**再起動** | クラス名 → LiteLLM モデル文字列 **または** dict（以下参照）。 |
 | `output_language` | 文字列 | PRJ のみ・**再起動** | デフォルトの出力言語コード（例: `en`、`ja`）。`--output-language` でオーバーライド。 |
 | `safety` | マップ | PRJ のみ・**再起動** | ランタイムの上限**と content 層の防御**: ループ検出上限、タイムアウト、上限超過時ポリシー、非信頼コンテンツの threat scan + fence（`safety.threat_scan`、FP-0050）、LLM spawn ツリーの上限（`safety.spawn`、DoS ガード）。以下参照。 |
 | `cost` | マップ | PRJ のみ・**再起動** | バジェット上限とレート制限（エージェントごと、日次、月次）。以下参照。 |
@@ -82,11 +81,8 @@ reload）、`reyn.yaml` 側に書いた同じキーは他と同じく再起動�
 | `external_transports` | マップ | PRJ のみ・**再起動** | チャット向け受信トランスポート → MCP ツールルーティング（Slack / LINE / Discord など）。以下参照。 |
 | `multimodal` | マップ | PRJ のみ・**再起動** | バイナリメディア（画像・音声）のサイズ上限、超過時の挙動、アーティファクト保存先、およびそれらを配信する `base_url`。以下参照。 |
 | `permissions` | マップ | PRJ のみ・**再起動** | デフォルトの Permission ポリシー。以下参照。 |
-| `prompt_cache_enabled` | bool | PRJ のみ・**再起動** | システムプロンプトに Anthropic プロンプトキャッシュマーカーを付与。デフォルト `true`。 |
 | `project_context_path` | 文字列 | PRJ のみ・**再起動** | すべての Phase システムプロンプトに注入する Markdown ファイル。未設定（デフォルト）: cross-tool 標準を auto-resolve — `AGENTS.md` があればそれ、なければ `REYN.md`（legacy fallback）。明示パスで 1 ファイルに固定、`""` で無効化。下記の注記参照。 |
-| `api_base` | 文字列 | PRJ のみ・**再起動** | LiteLLM プロキシベース URL。通常は `reyn.local.yaml`（gitignored）に設定。 |
-| `llm` | マップ | PRJ のみ・**再起動** | LLM 層の設定（ルーティング #1829 / リトライ #1835）。 |
-| `model_class_by_purpose` | マップ | PRJ のみ・**再起動** | 用途名 → モデルクラス。用途ごとに既定クラスを差し替えます。 |
+| `llm` | マップ | PRJ のみ・**再起動** | LLM 層の設定: モデル選択（`llm.model` デフォルトクラス、`llm.models` クラス → LiteLLM 文字列マップ、`llm.model_class_by_purpose` 用途別上書き、`llm.api_base` プロキシ URL、`llm.prompt_cache_enabled`）に加え、ルーティング（#1829）とリトライ（#1835）。以下参照。#4174 T3: `model` / `models` / `model_class_by_purpose` / `api_base` / `prompt_cache_enabled` は同名のトップレベルキーからここへ移動しました（形は同じ、ネストが変わっただけ）。 |
 | `delegation` | マップ | PRJ のみ・**再起動** | エージェント間委任のポリシー（#2081）。 |
 | `cost_warn` | マップ | PRJ のみ・**再起動** | 高コストモデルのゲート（#1830 / FP-0052）: 選択前に警告し、名前に反して**ブロックもできます**（`cost_warn.block_on_high_cost`）。以下参照。 |
 | `offload` | マップ | PRJ のみ・**再起動** | tool 結果のサイズゲートの opt-in スイッチ。 |
@@ -109,9 +105,18 @@ reload）、`reyn.yaml` 側に書いた同じキーは他と同じく再起動�
 > を推奨。標準に依らず特定ファイルに固定するには `project_context_path` にそのパスを
 > 設定、`""` でプロジェクトコンテキストを一切注入しない。
 
-## `models` ブロック
+## `llm` ブロック
 
-`models:` の各エントリはクラス名を LiteLLM モデル文字列 **または** per-class LLM パラメータを宣言する dict にマップします。
+LLM 層の設定: モデル選択（`llm.model` / `llm.models` / `llm.model_class_by_purpose`
+— この節 — に加え `llm.api_base` / `llm.prompt_cache_enabled`）、そして
+`llm.router` / `llm.retry`（opt-in litellm.Router + Reyn 自前リトライの
+バックオフタイミング）。#4174 T3: モデル選択は同名のトップレベルキー
+`model:` / `models:` / `model_class_by_purpose:` からここへ移動しました
+（形は同じ、ネストが変わっただけ）。
+
+### `llm.models` ブロック
+
+`llm.models:` の各エントリはクラス名を LiteLLM モデル文字列 **または** per-class LLM パラメータを宣言する dict にマップします。
 
 ### モデルクラス と モデル名 — 解決ルール
 
@@ -129,10 +134,11 @@ config には2種類の位置があり、逆のルールに従います。同じ
 str 値に **`/` が含まれる** 場合、LiteLLM モデル文字列として直接使用されます：
 
 ```yaml
-models:
-  light:    gemini-flash-lite
-  standard: openai/gpt-4o
-  strong:   anthropic/claude-3-5-sonnet-20241022
+llm:
+  models:
+    light:    gemini-flash-lite
+    standard: openai/gpt-4o
+    strong:   anthropic/claude-3-5-sonnet-20241022
 ```
 
 str 形式を使用している既存の `reyn.yaml` はすべて変更なしで動作します。
@@ -143,8 +149,9 @@ str 値に **`/` が含まれない** 場合、`{extends: <name>}` の省略形�
 名前はフラット namespace（ユーザーエントリ + built-in カタログ）で解決されます：
 
 ```yaml
-models:
-  standard: claude-sonnet-thinking     # 等価: standard: {extends: claude-sonnet-thinking}
+llm:
+  models:
+    standard: claude-sonnet-thinking     # 等価: standard: {extends: claude-sonnet-thinking}
 ```
 
 不明な省略形（ユーザーエントリにも built-in にも存在しない名前）は起動エラーになります。
@@ -152,17 +159,18 @@ models:
 ### dict 形式 — plain kwargs
 
 ```yaml
-models:
-  standard: gemini-flash-lite   # str 形式も dict エントリと併用可能
+llm:
+  models:
+    standard: gemini-flash-lite   # str 形式も dict エントリと併用可能
 
-  strong:
-    model: anthropic/claude-3-7-sonnet      # 必須
-    temperature: 0.0
-    max_completion_tokens: 16000             # max_tokens より推奨 — 下記注意
-    extra_body:
-      thinking:
-        type: enabled
-        budget_tokens: 8000
+    strong:
+      model: anthropic/claude-3-7-sonnet      # 必須
+      temperature: 0.0
+      max_completion_tokens: 16000             # max_tokens より推奨 — 下記注意
+      extra_body:
+        thinking:
+          type: enabled
+          budget_tokens: 8000
 ```
 
 | フィールド | 必須 | 説明 |
@@ -202,10 +210,11 @@ EmptyLLMResponseError: LLM returned a 200 response with empty choices
 （`ValueError`、fail-fast）:
 
 ```yaml
-models:
-  strong:
-    model: openai/gpt-5
-    stream: true   # ロード時に ValueError — このキーを削除してください
+llm:
+  models:
+    strong:
+      model: openai/gpt-5
+      stream: true   # ロード時に ValueError — このキーを削除してください
 ```
 
 ### `reasoning_effort`（モデルごとの推論バジェット）
@@ -213,10 +222,11 @@ models:
 モデルが回答前にどれだけ「思考」するかを設定します。分かりやすさのためモデル定義ごとに宣言します:
 
 ```yaml
-models:
-  light:
-    model: gemini-flash-lite
-    reasoning_effort: low      # minimal | low | medium | high | disable | none
+llm:
+  models:
+    light:
+      model: gemini-flash-lite
+      reasoning_effort: low      # minimal | low | medium | high | disable | none
 ```
 
 - **有効な値**: `minimal`, `low`, `medium`, `high`, `disable`, `none`。無効な値は litellm の呼び出し中ではなく**コンフィグロード時に fail-fast**（不正値を示す明確な `ValueError`）。
@@ -239,22 +249,23 @@ models:
 参照される名前はフラット namespace（ユーザーエントリ + built-in カタログ）で解決されます。
 
 ```yaml
-models:
-  # claude-sonnet-thinking built-in を継承し、budget_tokens を 8000 → 4000 に変更。
-  # extra_body.thinking.type: enabled は base から引き継がれます（deep merge）。
-  reasoning-light:
-    extends: claude-sonnet-thinking
-    extra_body:
-      thinking:
-        budget_tokens: 4000
+llm:
+  models:
+    # claude-sonnet-thinking built-in を継承し、budget_tokens を 8000 → 4000 に変更。
+    # extra_body.thinking.type: enabled は base から引き継がれます（deep merge）。
+    reasoning-light:
+      extends: claude-sonnet-thinking
+      extra_body:
+        thinking:
+          budget_tokens: 4000
 
-  # マルチレベル: reasoning-heavy は上で定義した reasoning-light を extends。
-  reasoning-heavy:
-    extends: reasoning-light
-    extra_body:
-      thinking:
-        budget_tokens: 16000
-    max_completion_tokens: 32000
+    # マルチレベル: reasoning-heavy は上で定義した reasoning-light を extends。
+    reasoning-heavy:
+      extends: reasoning-light
+      extra_body:
+        thinking:
+          budget_tokens: 16000
+      max_completion_tokens: 32000
 ```
 
 **Deep merge**: ネストした dict は再帰的にマージされます。`extra_body.thinking` の下に指定したキーのみがオーバーライドされ、兄弟キー（例：`type: enabled`）は base から引き継がれます。スカラーとリストは置換されます（マージされません）。
@@ -832,16 +843,15 @@ permissions:
 
 ```yaml
 # reyn.yaml — ${VAR} はすべての文字列フィールドで使用可能
-models:
-  default-sonnet:
-    model: claude-sonnet-4-5
-    api_key: ${ANTHROPIC_API_KEY}          # LLM API キー — secrets.env またはシェルから解決
-    extra_body:
-      headers:
-        Authorization: ${LITELLM_PROXY_TOKEN}
-
-litellm:
-  api_base: ${LITELLM_API_BASE}            # LiteLLM プロキシ URL
+llm:
+  models:
+    default-sonnet:
+      model: claude-sonnet-4-5
+      api_key: ${ANTHROPIC_API_KEY}          # LLM API キー — secrets.env またはシェルから解決
+      extra_body:
+        headers:
+          Authorization: ${LITELLM_PROXY_TOKEN}
+  api_base: ${LITELLM_API_BASE}            # LiteLLM プロキシ URL（#4174 T3: litellm: ではなく llm: にネスト）
 
 mcp:
   servers:
@@ -876,20 +886,35 @@ API キーとトークンは環境変数から来なければなりません。`
 
 `reyn.yaml` や `reyn.local.yaml` にトークン値をインラインで貼り付けないでください。これらは git にコミットされ、リポジトリへのアクセス権を持つすべての人が読めます。
 
-## プロキシ / `api_base`
+## `llm` ブロック
+
+### プロキシ / `llm.api_base`
 
 モデルをローカルの LiteLLM プロキシ経由でルーティングする場合は、URL を `reyn.yaml` ではなく `reyn.local.yaml`（gitignored）に書きます。環境変数の参照も使えます：
 
 ```yaml
 # reyn.local.yaml
-api_base: ${LITELLM_API_BASE}    # または直接書く: http://localhost:4000
+llm:
+  api_base: ${LITELLM_API_BASE}    # または直接書く: http://localhost:4000
+```
+
+### `llm.prompt_cache_enabled`
+
+デフォルト `true`。システムプロンプトに Anthropic 形式の `cache_control`
+マーカーを付与し、プロンプトキャッシュ対応プロバイダー（Anthropic、AWS
+Bedrock Claude）がプレフィックスを再利用できるようにします。対応しない
+プロバイダー（Gemini / OpenAI プロキシ）はこのマーカーを無視して素通しします。
+
+```yaml
+llm:
+  prompt_cache_enabled: true
 ```
 
 ## 解決順序
 
 各設定について、Reyn は（優先度が低い方から、後の層が前を上書き）マージします:
 
-1. **組み込みデフォルト** — reyn 同梱の値（例: `model: standard`）。
+1. **組み込みデフォルト** — reyn 同梱の値（例: `llm.model: standard`）。
 2. `~/.reyn/config.yaml`（ユーザーグローバル）
 3. `reyn.yaml`（プロジェクト、コミット対象）
 4. `reyn.local.yaml`（プロジェクト、gitignored — マシンローカルの上書き + `reyn config set` が書いた値）

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -12,11 +12,12 @@ Project-level configuration. Checked in to git. Personal overrides go in `reyn.l
 ## Minimal example
 
 ```yaml
-model: standard
-models:
-  light:    gemini-flash-lite
-  standard: openai/gpt-4o
-  strong:   anthropic/claude-3-5-sonnet-20241022
+llm:
+  model: standard
+  models:
+    light:    gemini-flash-lite
+    standard: openai/gpt-4o
+    strong:   anthropic/claude-3-5-sonnet-20241022
 ```
 
 ## Top-level keys
@@ -65,9 +66,6 @@ aren't.
 
 | Key | Type | Written on / reload | Description |
 |-----|------|-----|-------------|
-| `model` | string | PRJ only · **restart** | Default model class. Resolved via `models`. Override with `--model`. |
-| `models` | map | PRJ only · **restart** | Class name → LiteLLM model string **or** dict (see below). |
-| `model_class_by_purpose` | map | PRJ only · **restart** | Per-purpose model-class override (`router` / `control_ir` / `tool` / `judge`). Unset purpose → `model`. `compaction` is NOT a valid key (#3785) — compaction always follows the conversation model. See below. |
 | `output_language` | string | PRJ only · **restart** | Default output language code (e.g. `en`, `ja`). Override with `--output-language`. |
 | `safety` | map | PRJ only · **restart** | Runtime bounds **and content-layer defenses**: loop-detection caps, timeouts, on-limit policy, the untrusted-content threat scan + fence (`safety.threat_scan`, FP-0050), and operator bounds on the LLM spawn tree (`safety.spawn`, a DoS guard). See below. |
 | `cost` | map | PRJ only · **restart** | Budget caps and rate limits (per-agent, daily, monthly). See below. |
@@ -89,10 +87,8 @@ aren't.
 | `external_transports` | map | PRJ only · **restart** | Inbound transport → MCP tool routing for chat (Slack / LINE / Discord etc.). See below. |
 | `multimodal` | map | PRJ only · **restart** | Binary media (image/audio) size cap, on-oversize behaviour, artefact storage paths, and the `base_url` those artefacts are served under. See below. |
 | `permissions` | map | PRJ only · **restart** | Default permission policy. See below. |
-| `prompt_cache_enabled` | bool | PRJ only · **restart** | Attach Anthropic prompt-cache markers to system prompts. Default `true`. |
 | `project_context_path` | string | PRJ only · **restart** | Markdown file injected into every phase system prompt. Unset (default): auto-resolves the cross-tool standard — `AGENTS.md` if present, else `REYN.md` (legacy fallback). Set an explicit path to pin one file; set `""` to disable. See note below. |
-| `api_base` | string | PRJ only · **restart** | LiteLLM proxy base URL. Typically set in `reyn.local.yaml` (gitignored). |
-| `llm` | map | PRJ only · **restart** | LLM-layer config: routing (#1829) and retry (#1835). |
+| `llm` | map | PRJ only · **restart** | LLM-layer config: model selection (`llm.model` default class, `llm.models` class → LiteLLM string map, `llm.model_class_by_purpose` per-purpose override, `llm.api_base` proxy URL, `llm.prompt_cache_enabled`), plus routing (#1829) and retry (#1835). See below. |
 | `delegation` | map | PRJ only · **restart** | Cross-agent delegation policy (#2081). |
 | `cost_warn` | map | PRJ only · **restart** | High-cost-model gate (#1830 / FP-0052): warns before an expensive model is selected — and, despite the name, **can block it** (`cost_warn.block_on_high_cost`). See below. |
 | `offload` | map | PRJ only · **restart** | Opt-in switch for the tool-result size gates. |
@@ -115,9 +111,19 @@ aren't.
 > set `project_context_path` to that path; set it to `""` to inject no project
 > context at all.
 
-## `models` block
+## `llm` block
 
-Each entry under `models:` maps a class name to a LiteLLM model string **or** a dict that declares per-class LLM parameters.
+LLM-layer config: model selection (`llm.model` / `llm.models` /
+`llm.model_class_by_purpose` — this section — plus `llm.api_base` /
+`llm.prompt_cache_enabled` below), and `llm.router` / `llm.retry` (further
+below: opt-in litellm.Router + Reyn self-retry backoff timing). #4174 T3:
+model selection moved here from top-level `model:` / `models:` /
+`model_class_by_purpose:` keys of the same name — same shapes, only the
+nesting changed.
+
+### `llm.models` block
+
+Each entry under `llm.models:` maps a class name to a LiteLLM model string **or** a dict that declares per-class LLM parameters.
 
 ### Model classes vs model names — the resolution rule
 
@@ -135,10 +141,11 @@ In one line: **a `_class` / tier position takes a class name (closed-world); a `
 If a str value **contains `/`**, it is treated as a literal LiteLLM model string:
 
 ```yaml
-models:
-  light:    gemini-flash-lite
-  standard: openai/gpt-4o
-  strong:   anthropic/claude-3-5-sonnet-20241022
+llm:
+  models:
+    light:    gemini-flash-lite
+    standard: openai/gpt-4o
+    strong:   anthropic/claude-3-5-sonnet-20241022
 ```
 
 All existing `reyn.yaml` files using str form continue to work without change.
@@ -149,8 +156,9 @@ If a str value **has no `/`**, it is a shorthand for `{extends: <name>}`.  The n
 is resolved against the flat namespace (user entries + built-in catalog):
 
 ```yaml
-models:
-  standard: claude-sonnet-thinking     # equivalent to: standard: {extends: claude-sonnet-thinking}
+llm:
+  models:
+    standard: claude-sonnet-thinking     # equivalent to: standard: {extends: claude-sonnet-thinking}
 ```
 
 An unknown shorthand (name not in user entries or built-ins) is a startup error.
@@ -158,17 +166,18 @@ An unknown shorthand (name not in user entries or built-ins) is a startup error.
 ### dict form — plain kwargs
 
 ```yaml
-models:
-  standard: gemini-flash-lite   # str form still OK alongside dict entries
+llm:
+  models:
+    standard: gemini-flash-lite   # str form still OK alongside dict entries
 
-  strong:
-    model: anthropic/claude-3-7-sonnet      # required
-    temperature: 0.0
-    max_completion_tokens: 16000             # preferred over max_tokens — see note
-    extra_body:
-      thinking:
-        type: enabled
-        budget_tokens: 8000
+    strong:
+      model: anthropic/claude-3-7-sonnet      # required
+      temperature: 0.0
+      max_completion_tokens: 16000             # preferred over max_tokens — see note
+      extra_body:
+        thinking:
+          type: enabled
+          budget_tokens: 8000
 ```
 
 | Field | Required | Description |
@@ -200,13 +209,14 @@ completion funnel (`recorded_acompletion`). `stream:` is the operator's answer,
 and it **wins over the query in both directions**:
 
 ```yaml
-models:
-  my-new-model:
-    model: some-model-too-new-for-litellm
-    stream: true      # stream, whatever the catalog says
-  picky-endpoint:
-    model: openai/gpt-5
-    stream: false     # never stream, even though the catalog allows it
+llm:
+  models:
+    my-new-model:
+      model: some-model-too-new-for-litellm
+      stream: true      # stream, whatever the catalog says
+    picky-endpoint:
+      model: openai/gpt-5
+      stream: false     # never stream, even though the catalog allows it
 ```
 
 Omit the field to leave the decision to reyn. That is the right default; set it
@@ -245,10 +255,11 @@ Set how much the model is allowed to "think" before answering. Declared per mode
 definition so it's explicit and easy to understand:
 
 ```yaml
-models:
-  light:
-    model: gemini-flash-lite
-    reasoning_effort: low      # minimal | low | medium | high | disable | none
+llm:
+  models:
+    light:
+      model: gemini-flash-lite
+      reasoning_effort: low      # minimal | low | medium | high | disable | none
 ```
 
 - **Valid values**: `minimal`, `low`, `medium`, `high`, `disable`, `none`. An invalid
@@ -267,12 +278,13 @@ models:
   optional *summary*, which is **opt-in**. For those models pass the dict form to
   request the summary text:
   ```yaml
-  models:
-    strong:
-      model: openai/gpt-5
-      reasoning_effort:
-        effort: medium      # the budget level (validated, same set as above)
-        summary: detailed   # opt into summary text → rides into reasoning_content
+  llm:
+    models:
+      strong:
+        model: openai/gpt-5
+        reasoning_effort:
+          effort: medium      # the budget level (validated, same set as above)
+          summary: detailed   # opt into summary text → rides into reasoning_content
   ```
   litellm's GPT-5 transformation reads `{effort, summary}`. **Provider difference**:
   Gemini exposes raw reasoning text natively from the string form; OpenAI needs the
@@ -308,22 +320,23 @@ Use `extends` to inherit from another class and override specific fields.  The r
 name is resolved against the same flat namespace (user entries + built-in catalog).
 
 ```yaml
-models:
-  # Inherit claude-sonnet-thinking built-in, reduce budget_tokens from 8000 → 4000.
-  # extra_body.thinking.type: enabled is carried from the base (deep merge).
-  reasoning-light:
-    extends: claude-sonnet-thinking
-    extra_body:
-      thinking:
-        budget_tokens: 4000
+llm:
+  models:
+    # Inherit claude-sonnet-thinking built-in, reduce budget_tokens from 8000 → 4000.
+    # extra_body.thinking.type: enabled is carried from the base (deep merge).
+    reasoning-light:
+      extends: claude-sonnet-thinking
+      extra_body:
+        thinking:
+          budget_tokens: 4000
 
-  # Multi-level: reasoning-heavy extends the user-defined reasoning-light above.
-  reasoning-heavy:
-    extends: reasoning-light
-    extra_body:
-      thinking:
-        budget_tokens: 16000
-    max_completion_tokens: 32000
+    # Multi-level: reasoning-heavy extends the user-defined reasoning-light above.
+    reasoning-heavy:
+      extends: reasoning-light
+      extra_body:
+        thinking:
+          budget_tokens: 16000
+      max_completion_tokens: 32000
 ```
 
 **Deep merge**: nested dicts are merged recursively.  Only the keys you specify under
@@ -359,7 +372,7 @@ is a convenience starting point; your `reyn.yaml` is always the source of truth.
 
 See [Reference: built-in models](../builtin-models.md) for per-entry details.
 
-### `model_class_by_purpose` — per-purpose model class
+### `llm.model_class_by_purpose` — per-purpose model class
 
 Reyn makes several internal LLM calls beyond the main agent reply, each tied to a
 logical **purpose**. By default every purpose uses your configured `model` (the
@@ -374,13 +387,14 @@ specific purpose; an unset purpose falls back to `model`.
 | `judge` | Output-judging / evaluation calls. |
 
 ```yaml
-model: standard                  # the default class for every purpose
-models:
-  standard: openai/gpt-5.4
-  light:    openai/gpt-4o-mini
-model_class_by_purpose:
-  router: light                  # opt INTO a cheaper per-turn router (an explicit choice)
-  # tool / judge unset → follow `model` (gpt-5.4)
+llm:
+  model: standard                  # the default class for every purpose
+  models:
+    standard: openai/gpt-5.4
+    light:    openai/gpt-4o-mini
+  model_class_by_purpose:
+    router: light                  # opt INTO a cheaper per-turn router (an explicit choice)
+    # tool / judge unset → follow `model` (gpt-5.4)
 ```
 
 **Cost note**: the router runs on every turn, so the cheap-router optimisation is
@@ -1496,16 +1510,15 @@ Any string field in any section of `reyn.yaml` (or `reyn.local.yaml` / `~/.reyn/
 
 ```yaml
 # reyn.yaml — ${VAR} works in every string field
-models:
-  default-sonnet:
-    model: claude-sonnet-4-5
-    api_key: ${ANTHROPIC_API_KEY}          # LLM API key — resolved from secrets.env or shell
-    extra_body:
-      headers:
-        Authorization: ${LITELLM_PROXY_TOKEN}
-
-litellm:
-  api_base: ${LITELLM_API_BASE}            # LiteLLM proxy URL
+llm:
+  models:
+    default-sonnet:
+      model: claude-sonnet-4-5
+      api_key: ${ANTHROPIC_API_KEY}          # LLM API key — resolved from secrets.env or shell
+      extra_body:
+        headers:
+          Authorization: ${LITELLM_PROXY_TOKEN}
+  api_base: ${LITELLM_API_BASE}            # LiteLLM proxy URL (#4174 T3: nests under llm:, not a separate litellm: key)
 
 mcp:
   servers:
@@ -1540,20 +1553,36 @@ API keys and tokens MUST come from environment variables, not from literal value
 
 Never paste token values inline in `reyn.yaml` or `reyn.local.yaml` — they are committed to git and readable by anyone with repo access.
 
-## Proxy / `api_base`
+## `llm` block
+
+### Proxy / `llm.api_base`
 
 If you route models through a local LiteLLM proxy, put the URL in `reyn.local.yaml` (gitignored), not `reyn.yaml`. You can reference an env var here too:
 
 ```yaml
 # reyn.local.yaml
-api_base: ${LITELLM_API_BASE}    # or literal: http://localhost:4000
+llm:
+  api_base: ${LITELLM_API_BASE}    # or literal: http://localhost:4000
+```
+
+### `llm.prompt_cache_enabled`
+
+When `true` (the default), reyn attaches Anthropic-style `cache_control`
+markers to the system prompt so providers that support prompt caching
+(Anthropic, AWS Bedrock Claude) can reuse the prefix across calls. Providers
+that don't recognize the marker ignore it (Gemini / OpenAI proxies
+pass-through).
+
+```yaml
+llm:
+  prompt_cache_enabled: true
 ```
 
 ## Resolution order
 
 For each setting, reyn merges these sources, lowest priority first — later layers override earlier:
 
-1. **Built-in defaults** — the values shipped with reyn (e.g. `model: standard`).
+1. **Built-in defaults** — the values shipped with reyn (e.g. `llm.model: standard`).
 2. `~/.reyn/config.yaml` — user-global.
 3. `reyn.yaml` — project, committed.
 4. `reyn.local.yaml` — project, gitignored (machine-local overrides + values written by `reyn config set`).

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -49,13 +49,6 @@
 
 
 # -----------------------------------------------------------------------------
-# model: default model class when --model is not specified on the CLI
-# Built-in default: "standard"
-# -----------------------------------------------------------------------------
-# model: standard
-
-
-# -----------------------------------------------------------------------------
 # output_language: forced LLM reply language (chat router enforces strictly).
 # Unset (default) → no directive added (= LLM follows user message language).
 # Examples: "ja", "en"
@@ -71,15 +64,23 @@
 
 
 # -----------------------------------------------------------------------------
-# models: model-class → LiteLLM model string. A class reference (no "/")
-# resolves against the built-in catalog or ``reyn.yaml`` ``models:``; a
+# llm: the LLM-layer domain — model selection (#4174 T3: model / models /
+# model_class_by_purpose / api_base / prompt_cache_enabled moved here from
+# top-level keys of the same name) + litellm.Router resilience (#1829) +
+# self-retry backoff timing (#1835).
+#
+# llm.model: default model class when --model is not specified on the CLI.
+# Built-in default: "standard".
+#
+# llm.models: model-class → LiteLLM model string. A class reference (no "/")
+# resolves against the built-in catalog or ``reyn.yaml`` ``llm.models:``; a
 # string containing "/" is passed through to LiteLLM as-is.
-# -----------------------------------------------------------------------------
+#
 # An entry may also be a MAPPING. ``model`` is the only required key; every
 # other key except ``extends`` / ``api_base`` / ``provider`` is forwarded to
 # ``litellm.acompletion`` unchanged and unvalidated (a typo therefore surfaces
 # as a litellm failure, not a reyn config error). Full field table:
-# docs/reference/config/reyn-yaml.md § `models` block.
+# docs/reference/config/reyn-yaml.md § `llm` block.
 #
 # The passthrough is also the escape hatch for when litellm does not RECOGNISE
 # a model (``my-new-model`` below). Litellm fetches its model catalog over the
@@ -116,38 +117,16 @@
 #
 #   EmptyLLMResponseError: LLM returned a 200 response with empty choices
 #   (model=...); provider response: <...CustomStreamWrapper object...>
-# -----------------------------------------------------------------------------
-# models:
-#   light:    openai/gpt-4o-mini
-#   standard: claude-sonnet            # built-in catalog reference
 #
-#   strong:                            # mapping form
-#     model: anthropic/claude-3-7-sonnet
-#     temperature: 0.0
-#     max_completion_tokens: 16000     # preferred over max_tokens
+# llm.model_class_by_purpose: per-purpose model-class override (#1672). Reyn
+# makes internal LLM calls beyond the main reply, each tied to a purpose
+# (router / control_ir / tool / judge). By DEFAULT every purpose follows
+# `llm.model` (no hidden cheaper tier). Override a purpose here; an unset
+# purpose falls back to `llm.model`. The per-turn router is a common cost
+# knob — opt into a cheaper class explicitly. `compaction` is NOT a valid key
+# (#3785) — compaction always follows the conversation's active model; a
+# config that still sets it fails to load.
 #
-#   my-new-model:
-#     model: some-model-too-new-for-litellm
-#     allowed_openai_params: ["tool_choice"]
-#     stream: true                     # reyn field — the catalog has no row to read
-
-
-# -----------------------------------------------------------------------------
-# model_class_by_purpose: per-purpose model-class override (#1672).
-# Reyn makes internal LLM calls beyond the main reply, each tied to a purpose
-# (router / control_ir / tool / judge). By DEFAULT every purpose
-# follows `model` (no hidden cheaper tier). Override a purpose here; an unset
-# purpose falls back to `model`. The per-turn router is a common cost knob —
-# opt into a cheaper class explicitly:
-# `compaction` is NOT a valid key (#3785) — compaction always follows the
-# conversation's active model; a config that still sets it fails to load.
-# -----------------------------------------------------------------------------
-# model_class_by_purpose:
-#   router: light            # cheaper per-turn router (explicit opt-in)
-#   # control_ir / tool / judge unset → follow `model`
-
-
-# -----------------------------------------------------------------------------
 # llm.router: litellm.Router provider-resilience (#1829). DEFAULT OFF
 # (use=false → direct litellm.acompletion, byte-identical to no-Router).
 # When on, the Router owns infra-exception retry (with native Retry-After
@@ -155,8 +134,35 @@
 # self-implemented retry/cooldown/fallback. `use` / `num_retries` supersede the
 # legacy REYN_LLM_USE_ROUTER / REYN_LLM_ROUTER_NUM_RETRIES env vars (which remain
 # a back-compat fallback when this block is absent).
+#
+# llm.retry: backoff timing for the Reyn self-retry layer (#1835).
+#
+# llm.api_base: LiteLLM proxy / direct provider base URL. Empty (default) →
+# providers' own endpoints. A local proxy is the most common override.
+#
+# llm.prompt_cache_enabled: when true (default), attach Anthropic-style
+# ``cache_control`` markers to the system prompt so providers that support
+# prompt caching (Anthropic, AWS Bedrock Claude) can reuse the prefix across
+# calls. Ignored by providers that don't recognize the marker.
 # -----------------------------------------------------------------------------
 # llm:
+#   model: standard
+#   models:
+#     light:    openai/gpt-4o-mini
+#     standard: claude-sonnet            # built-in catalog reference
+#
+#     strong:                            # mapping form
+#       model: anthropic/claude-3-7-sonnet
+#       temperature: 0.0
+#       max_completion_tokens: 16000     # preferred over max_tokens
+#
+#     my-new-model:
+#       model: some-model-too-new-for-litellm
+#       allowed_openai_params: ["tool_choice"]
+#       stream: true                     # reyn field — the catalog has no row to read
+#   model_class_by_purpose:
+#     router: light            # cheaper per-turn router (explicit opt-in)
+#     # control_ir / tool / judge unset → follow `model`
 #   router:
 #     use: false             # master switch (REYN_LLM_USE_ROUTER fallback)
 #     num_retries: 3         # infra-exception retries (Retry-After aware)
@@ -182,14 +188,8 @@
 #     respect_retry_after: true  # honour provider Retry-After header on 429/503.
 #                            # Caps the wait at llm_retry_max_backoff (16 s).
 #                            # Falls back to jittered backoff when header absent.
-
-
-# -----------------------------------------------------------------------------
-# api_base: LiteLLM proxy / direct provider base URL.
-# Empty (default) → providers' own endpoints. A local proxy is the most
-# common override:
-# -----------------------------------------------------------------------------
-# api_base: http://localhost:4000
+#   api_base: http://localhost:4000
+#   prompt_cache_enabled: true
 
 
 # -----------------------------------------------------------------------------
@@ -703,15 +703,6 @@
 #   cpu_threads: 4
 #   num_workers: 1
 #   max_duration_s: 300.0       # auto-cancel recordings longer than this
-
-
-# -----------------------------------------------------------------------------
-# prompt_cache_enabled: when true (default), attach Anthropic-style
-# ``cache_control`` markers to the system prompt so providers that support
-# prompt caching (Anthropic, AWS Bedrock Claude) can reuse the prefix
-# across calls. Ignored by providers that don't recognize the marker.
-# -----------------------------------------------------------------------------
-# prompt_cache_enabled: true
 
 
 # -----------------------------------------------------------------------------

--- a/src/reyn/config/config_schema.py
+++ b/src/reyn/config/config_schema.py
@@ -226,6 +226,38 @@ _RENAMED_CONFIG_KEYS: "dict[str, RenamedKeyHint]" = {
              "a new top-level `gateway:` block (same field names, just "
              "renested there)",
     ),
+    # #4174 T3. All 5 are plain renames — same shape, only the top-level key
+    # moved under `llm:` (which already existed for router/retry) — so
+    # `destination` is set on each and `reyn config migrate` auto-rewrites
+    # them. `llm:` itself is a known key (LLMConfig), so these entries are
+    # only reached when the OLD top-level key is used — `unknown_config_keys`
+    # never recurses past a key it already knows, so `llm.model` etc. being
+    # valid doesn't shadow `model` still being flagged at the top level.
+    "model": RenamedKeyHint(
+        note="`model:` moved to `llm.model:` (LLM-domain settings — "
+             "model selection now lives alongside `llm.router`/`llm.retry`)",
+        destination="llm.model",
+    ),
+    "models": RenamedKeyHint(
+        note="`models:` moved to `llm.models:` (same shape — map of model "
+             "class name to LiteLLM model string)",
+        destination="llm.models",
+    ),
+    "model_class_by_purpose": RenamedKeyHint(
+        note="`model_class_by_purpose:` moved to "
+             "`llm.model_class_by_purpose:` (same shape — purpose → model "
+             "class)",
+        destination="llm.model_class_by_purpose",
+    ),
+    "api_base": RenamedKeyHint(
+        note="`api_base:` moved to `llm.api_base:` (LiteLLM proxy base URL)",
+        destination="llm.api_base",
+    ),
+    "prompt_cache_enabled": RenamedKeyHint(
+        note="`prompt_cache_enabled:` moved to `llm.prompt_cache_enabled:` "
+             "(same bool)",
+        destination="llm.prompt_cache_enabled",
+    ),
 }
 
 

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -168,10 +168,92 @@ class RetryConfig:
 
 @dataclass
 class LLMConfig:
-    """``llm:`` — LLM-layer config (#1829 router, #1835 retry)."""
+    """``llm:`` — LLM-layer config (#1829 router, #1835 retry, #4174 T3 the
+    model-selection domain).
+
+    #4174 T3: ``model`` / ``models`` / ``model_class_by_purpose`` / ``api_base``
+    / ``prompt_cache_enabled`` moved here from top-level ``ReynConfig`` fields —
+    they were always LLM-domain settings scattered at the top level while
+    ``llm.router`` / ``llm.retry`` (also LLM-domain) already lived in their own
+    block. Plain rename, same shapes, registered in
+    ``config_schema._RENAMED_CONFIG_KEYS`` so ``reyn config migrate`` rewrites
+    old top-level keys automatically.
+    """
 
     router: RouterConfig = field(default_factory=RouterConfig)
     retry: RetryConfig = field(default_factory=RetryConfig)
+    # #1672 default model class used when a phase has no model_class.
+    model: str = field(
+        default="standard",
+        metadata={"desc": "Default model class used when a phase has no model_class."},
+    )
+    # Map of model class names to LiteLLM model strings.
+    models: dict[str, "str | dict"] = field(
+        default_factory=dict,
+        metadata={"desc": "Map of model class names to LiteLLM model strings."},
+    )
+    # #1672 per-purpose model-class override (router / control_ir / tool / judge).
+    # Unset purpose -> `model` (see MODEL_CLASS_PURPOSES / ReynConfig.model_class_for).
+    model_class_by_purpose: dict[str, str] = field(default_factory=dict)
+    # LiteLLM proxy: non-secret base URL only. API keys must be env vars
+    # (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) — never stored in config files.
+    api_base: str = field(
+        default="",
+        metadata={"desc": "LiteLLM proxy base URL. Set this if you route requests through a local proxy."},
+    )
+    # Attach Anthropic-style cache_control markers to the system prompt so
+    # providers that support prompt caching (Anthropic, AWS Bedrock Claude) can
+    # reuse the prefix across calls. Ignored by providers that don't recognize
+    # cache_control (Gemini / OpenAI proxies pass-through).
+    prompt_cache_enabled: bool = True
+
+
+# #1672: the logical purposes whose model class is configurable via
+# ``model_class_by_purpose``. A typo'd key would silently never apply (the call
+# sites look up fixed keys), so the parser warns on an unknown key rather than
+# hard-failing (forward-compatible — a future purpose key is a warn, not a crash).
+# #3785: ``compaction`` deliberately excluded — see
+# ``_build_model_class_by_purpose``'s dedicated (hard-failing) handling below,
+# not the generic unknown-key warn path.
+MODEL_CLASS_PURPOSES: frozenset[str] = frozenset({
+    "router", "control_ir", "tool", "judge",
+})
+
+
+def _build_model_class_by_purpose(raw: object) -> dict[str, str]:
+    """#1672: parse ``llm.model_class_by_purpose`` (purpose → model class).
+    Unknown purpose keys WARN (not error) — a typo would silently never apply,
+    so flag it decision-enablingly while staying forward-compatible with future
+    purposes.
+
+    #3785: ``compaction`` is the ONE exception — it used to be a valid key
+    (removed) and its presence is not a typo but a stale belief ("compaction
+    runs on its own model"), which a warning would leave uncorrected (the
+    config keeps silently doing nothing every session). Refuses to load
+    instead, with the remedy in the message.
+    """
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, str] = {}
+    for k, v in raw.items():
+        key = str(k)
+        if key == "compaction":
+            raise ValueError(
+                "llm.model_class_by_purpose.compaction is no longer "
+                "configurable (#3785) — compaction always follows the "
+                "conversation's active model now (it did not track a "
+                "`/model` switch before, which this removal fixes). Remove "
+                "this key from your reyn.yaml/reyn.local.yaml."
+            )
+        if key not in MODEL_CLASS_PURPOSES:
+            import logging
+            logging.getLogger(__name__).warning(
+                "llm.model_class_by_purpose.%s is not a known purpose %s — "
+                "it will never be applied; check for a typo.",
+                key, sorted(MODEL_CLASS_PURPOSES),
+            )
+        out[key] = str(v)
+    return out
 
 
 def _build_retry_config(raw: object) -> RetryConfig:
@@ -240,14 +322,36 @@ def _build_router_config(raw: object) -> RouterConfig:
 
 
 def _build_llm_config(raw: object) -> LLMConfig:
-    """Parse ``llm:`` from reyn.yaml. None/missing → defaults."""
+    """Parse ``llm:`` from reyn.yaml. None/missing → defaults.
+
+    #4174 T3: also parses ``model`` / ``models`` / ``model_class_by_purpose`` /
+    ``api_base`` / ``prompt_cache_enabled`` — moved here from top-level
+    ``ReynConfig`` fields (see ``LLMConfig``'s own docstring)."""
     if raw is None:
         return LLMConfig()
     if not isinstance(raw, dict):
         raise ValueError(f"llm must be a mapping, got {type(raw).__name__}")
+    _models_raw = raw.get("models")
+    if _models_raw is not None and not isinstance(_models_raw, dict):
+        import logging
+        logging.getLogger(__name__).warning(
+            "llm.models must be a mapping; got %s — ignoring it.",
+            type(_models_raw).__name__,
+        )
+        _models_raw = {}
     return LLMConfig(
         router=_build_router_config(raw.get("router")),
         retry=_build_retry_config(raw.get("retry")),
+        model=str(raw.get("model", "standard")),
+        models={
+            str(k): (v if isinstance(v, dict) else str(v))
+            for k, v in (_models_raw or {}).items()
+        },
+        model_class_by_purpose=_build_model_class_by_purpose(
+            raw.get("model_class_by_purpose"),
+        ),
+        api_base=str(raw.get("api_base") or ""),
+        prompt_cache_enabled=bool(raw.get("prompt_cache_enabled", True)),
     )
 
 

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -41,7 +41,7 @@ from reyn.config.media import (  # #1682 #3 cross-section
 from reyn.config.observability import (
     _build_observability_config,
 )
-from reyn.config.root import ReynConfig, _build_model_class_by_purpose  # #1682 #3 cross-section
+from reyn.config.root import ReynConfig  # #1682 #3 cross-section
 from reyn.runtime.budget.budget import CostConfig, CostLimitConfig
 
 
@@ -143,7 +143,10 @@ def build_policy_tier_config(cwd: Path | None = None) -> dict:
     called from both places").
     """
     cwd = (cwd or Path.cwd()).resolve()
-    merged: dict = {"model": "standard", "models": {}, "permissions": {}, "mcp": {}}
+    # #4174 T3: model/models seed moved under llm — _build_llm_config's own
+    # defaults (model="standard", models={}) apply when llm/llm.model/
+    # llm.models are absent, so no seed is needed for them here anymore.
+    merged: dict = {"permissions": {}, "mcp": {}}
 
     from reyn.builtin.registry import build_builtin_config
     merged = _merge(merged, build_builtin_config(), tier_label="builtin")
@@ -261,6 +264,13 @@ def _merge(base: dict, override: dict, *, tier_label: str | None = None) -> dict
     for key, val in override.items():
         if val is None:
             continue
+        # #4174 T3: top-level `models:` is a renamed (now-unknown) key — this
+        # branch still shallow-merges it if present (harmless: the merged
+        # raw dict is never read into ReynConfig anymore, only surfaced by
+        # the unknown-key walk), so a legacy config's cross-tier behavior
+        # doesn't change shape while the operator migrates. The LIVE
+        # location is `llm.models`, handled in the `key == "llm"` branch
+        # below.
         if key in ("models", "permissions") and isinstance(val, dict):
             result[key] = {**result.get(key, {}), **val}
         elif key == "mcp" and isinstance(val, dict):
@@ -343,6 +353,12 @@ def _merge(base: dict, override: dict, *, tier_label: str | None = None) -> dict
             for sub_key, sub_val in val.items():
                 if sub_key == "router" and isinstance(sub_val, dict):
                     merged_llm["router"] = {**existing.get("router", {}), **sub_val}
+                # #4174 T3: llm.models shallow-merges by key, same as the
+                # legacy top-level `models:` special-case above — a project
+                # tier adding one model class must not drop a user-global
+                # class it didn't mention.
+                elif sub_key == "models" and isinstance(sub_val, dict):
+                    merged_llm["models"] = {**existing.get("models", {}), **sub_val}
                 else:
                     merged_llm[sub_key] = sub_val
             result["llm"] = merged_llm
@@ -760,7 +776,9 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
     # inline copies (``invocation_context.py`` / ``web/deps.py``) are now
     # redundant but harmless (same ``setdefault`` value); their removal + a
     # single-writer AST/CI guard is #2683.
-    _api_base = str(merged.get("api_base") or "")
+    # #4174 T3: ``api_base`` moved from top-level to ``llm.api_base``.
+    _llm_raw = merged.get("llm")
+    _api_base = str((_llm_raw.get("api_base") if isinstance(_llm_raw, dict) else None) or "")
     if _api_base:
         _os_for_mcp.environ.setdefault("LITELLM_API_BASE", _api_base)
 
@@ -780,24 +798,13 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
     cost_warn = _build_cost_warn_config(merged.get("cost_warn"))
     offload = _build_offload_config(merged.get("offload"))
     render_template = _build_render_template_config(merged.get("render_template"))
+    # #4174 T3: model / models / model_class_by_purpose / api_base /
+    # prompt_cache_enabled moved from top-level ReynConfig fields into
+    # ``llm:`` — _build_llm_config parses all of it (router/retry AND the
+    # T3 fields) from the SAME raw ``llm`` dict, in one place.
     _cfg = ReynConfig(
-        model=str(merged.get("model", "standard")),
         output_language=output_language,
-        models={
-            str(k): (v if isinstance(v, dict) else str(v))
-            for k, v in _as_config_dict(merged.get("models"), "models").items()
-        },
-        model_class_by_purpose=_build_model_class_by_purpose(
-            merged.get("model_class_by_purpose"),
-        ),
         llm=_build_llm_config(merged.get("llm")),
-        api_base=str(merged.get("api_base") or ""),
-        # prompt_cache_enabled / project_context_path were declared as
-        # ReynConfig fields + consumed (llm.py / session.py / agent.py /
-        # _read_project_context) but never read here, so operator config was
-        # silently ignored (always the dataclass default = a no-op set). Wire
-        # them through merged so the operator-set value actually takes effect.
-        prompt_cache_enabled=bool(merged.get("prompt_cache_enabled", True)),
         # Absent → None (auto-resolve AGENTS.md → REYN.md in
         # load_project_context). Present → pin that path ("" disables).
         project_context_path=(

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -80,10 +80,6 @@ def _empty_external_transports():
 
 @dataclass
 class ReynConfig:
-    model: str = field(
-        default="standard",
-        metadata={"desc": "Default model class used when a phase has no model_class."},
-    )
     # Optional. None = user did not configure; downstream callers decide
     # how to handle (chat router skips the language directive in its
     # system prompt; absent means the router defaults to "ja" preserving the
@@ -95,51 +91,19 @@ class ReynConfig:
         default=None,
         metadata={"desc": "Language code injected into the context frame for all LLM outputs."},
     )
-    models: dict[str, str | dict] = field(
-        default_factory=dict,
-        metadata={"desc": "Map of model class names to LiteLLM model strings."},
-    )
     # #1829: LLM-layer config — the litellm.Router resilience surface
     # (llm.router.*: use / num_retries / fallbacks / cooldown_time /
-    # allowed_fails). Default OFF (router.use=False → direct litellm.acompletion).
+    # allowed_fails), AND (#4174 T3) the model-selection domain: model /
+    # models / model_class_by_purpose / api_base / prompt_cache_enabled —
+    # see LLMConfig's own docstring for the T3 move.
     llm: LLMConfig = field(
         default_factory=LLMConfig,
-        metadata={"desc": "LLM-layer config (litellm.Router resilience: llm.router.*)."},
-    )
-    # #1672: per-purpose model-class override. The mapping from a logical call
-    # purpose (router / control_ir / tool / judge) to a model CLASS was
-    # hardcoded in code (router="light", control_ir/tool="standard"), so the
-    # user could set what a class resolves to but NOT which class each purpose
-    # uses — the owner's "don't do things users can't customize" complaint. This
-    # map exposes it: an UNSET purpose falls back to ``model`` (the configured
-    # main), so by default routing follows the configured model — no hidden
-    # cheaper tier. Setting e.g. ``router: light`` is the explicit opt-in to the
-    # cheap per-turn router. Explicit per-call model selection (phase frontmatter
-    # model_class) still wins over this fallback.
-    #
-    # #3785: ``compaction`` is NOT a valid key here anymore — compaction always
-    # follows the conversation's active model (no separate purpose override was
-    # ever kept in sync with a ``/model`` switch; see
-    # ``Session._rebuild_derived_model_engines_for_model``). A config that still
-    # sets ``model_class_by_purpose.compaction`` fails to load
-    # (``_build_model_class_by_purpose`` below) rather than silently ignoring
-    # or warning — the key's presence is itself evidence of a wrong belief
-    # ("compaction runs on a separate model") that a warning would leave intact.
-    model_class_by_purpose: dict[str, str] = field(
-        default_factory=dict,
         metadata={"desc": (
-            "Per-purpose model class override (router / control_ir / tool / "
-            "judge). Unset purpose → the `model` default. `compaction` is not "
-            "a valid key (#3785) — compaction always follows the conversation "
-            "model."
+            "LLM-layer config: litellm.Router resilience (llm.router.*) + "
+            "model selection (llm.model / llm.models / "
+            "llm.model_class_by_purpose / llm.api_base / "
+            "llm.prompt_cache_enabled)."
         )},
-    )
-    # LiteLLM proxy: non-secret base URL only.
-    # API keys must be set as environment variables (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.)
-    # — never stored in config files.
-    api_base: str = field(
-        default="",
-        metadata={"desc": "LiteLLM proxy base URL. Set this if you route requests through a local proxy."},
     )
     # Pre-declared permissions (same structure as phase frontmatter). Values are
     # "allow" (pre-approve, skip the interactive prompt) or "deny" (block outright).
@@ -216,11 +180,6 @@ class ReynConfig:
     # Voice input (Whisper) settings for the chat TUI. Optional feature gated
     # by the `reyn[voice]` extras; the OS itself never depends on this block.
     voice: VoiceConfig = field(default_factory=VoiceConfig)
-    # When true, attach Anthropic-style cache_control markers to the system
-    # prompt so providers that support prompt caching (Anthropic, AWS Bedrock
-    # Claude) can reuse the prefix across calls. Ignored by providers that
-    # don't recognize cache_control (Gemini / OpenAI proxies pass-through).
-    prompt_cache_enabled: bool = True
     # Path (relative to project root) of a markdown file whose content is
     # injected into the system prompt for every phase. Use this to put
     # project-wide background, conventions, or references somewhere all
@@ -396,57 +355,16 @@ class ReynConfig:
     def model_class_for(self, purpose: str) -> str:
         """#1672: the model CLASS for a logical call *purpose*.
 
-        A per-purpose override in ``model_class_by_purpose`` wins; otherwise the
-        configured default class ``model`` (so unset purposes follow the user's
-        configured model — no hidden cheaper tier). Explicit per-call selections
-        ( ``op.model``, phase frontmatter ``model_class``) are applied by
-        the caller BEFORE this fallback and still win.
+        A per-purpose override in ``llm.model_class_by_purpose`` wins;
+        otherwise the configured default class ``llm.model`` (so unset
+        purposes follow the user's configured model — no hidden cheaper
+        tier). Explicit per-call selections (``op.model``, phase frontmatter
+        ``model_class``) are applied by the caller BEFORE this fallback and
+        still win.
+
+        #4174 T3: ``model_class_by_purpose`` / ``model`` moved from top-level
+        ``ReynConfig`` fields to ``llm.*`` (see ``LLMConfig``'s own
+        docstring) — this method's own signature/behavior is unchanged, only
+        where it reads from.
         """
-        return self.model_class_by_purpose.get(purpose, self.model)
-
-
-# #1672: the logical purposes whose model class is configurable via
-# ``model_class_by_purpose``. A typo'd key would silently never apply (the call
-# sites look up fixed keys), so the parser warns on an unknown key rather than
-# hard-failing (forward-compatible — a future purpose key is a warn, not a crash).
-# #3785: ``compaction`` deliberately excluded — see
-# ``_build_model_class_by_purpose``'s dedicated (hard-failing) handling below,
-# not the generic unknown-key warn path.
-MODEL_CLASS_PURPOSES: frozenset[str] = frozenset({
-    "router", "control_ir", "tool", "judge",
-})
-
-
-def _build_model_class_by_purpose(raw: object) -> dict[str, str]:
-    """#1672: parse ``model_class_by_purpose`` (purpose → model class). Unknown
-    purpose keys WARN (not error) — a typo would silently never apply, so flag it
-    decision-enablingly while staying forward-compatible with future purposes.
-
-    #3785: ``compaction`` is the ONE exception — it used to be a valid key
-    (removed) and its presence is not a typo but a stale belief ("compaction
-    runs on its own model"), which a warning would leave uncorrected (the
-    config keeps silently doing nothing every session). Refuses to load
-    instead, with the remedy in the message.
-    """
-    if not isinstance(raw, dict):
-        return {}
-    out: dict[str, str] = {}
-    for k, v in raw.items():
-        key = str(k)
-        if key == "compaction":
-            raise ValueError(
-                "model_class_by_purpose.compaction is no longer configurable "
-                "(#3785) — compaction always follows the conversation's "
-                "active model now (it did not track a `/model` switch before, "
-                "which this removal fixes). Remove this key from your "
-                "reyn.yaml/reyn.local.yaml."
-            )
-        if key not in MODEL_CLASS_PURPOSES:
-            import logging
-            logging.getLogger(__name__).warning(
-                "model_class_by_purpose.%s is not a known purpose %s — it will "
-                "never be applied; check for a typo.",
-                key, sorted(MODEL_CLASS_PURPOSES),
-            )
-        out[key] = str(v)
-    return out
+        return self.llm.model_class_by_purpose.get(purpose, self.llm.model)

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -657,7 +657,7 @@ def _run(args: argparse.Namespace) -> None:
             safety=safety,
             mcp_servers=session_cfg.config.mcp,
             output_language=output_language,
-            prompt_cache_enabled=session_cfg.config.prompt_cache_enabled,
+            prompt_cache_enabled=session_cfg.config.llm.prompt_cache_enabled,
             project_context=project_context,
             project_context_path=project_context_path,
             agent_role=profile.role,

--- a/src/reyn/interfaces/cli/commands/config.py
+++ b/src/reyn/interfaces/cli/commands/config.py
@@ -91,9 +91,9 @@ def _show() -> None:
     import yaml
     config = load_config()
     effective = {
-        "model":           config.model,
-        "models":          config.models,
-        "api_base":        config.api_base or "(not set)",
+        "model":           config.llm.model,
+        "models":          config.llm.models,
+        "api_base":        config.llm.api_base or "(not set)",
         "output_language": config.output_language or "(not set — chat router skips language directive; phase paths default to ja)",
         "permissions":     config.permissions,
         "mcp":             config.mcp if config.mcp else "(not configured)",

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -487,11 +487,11 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
     project_root = _find_project_root(Path.cwd()) or Path.cwd()
     config = load_config()
     resolver = ModelResolver(
-        config.models,
-        default_class=config.model,
-        purpose_classes=config.model_class_by_purpose,
+        config.llm.models,
+        default_class=config.llm.model,
+        purpose_classes=config.llm.model_class_by_purpose,
     )
-    model = config.model
+    model = config.llm.model
     output_language = config.output_language
     safety = config.safety
     project_context = load_project_context(config, project_root)
@@ -547,7 +547,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 safety=safety,
                 mcp_servers=config.mcp,
                 output_language=output_language,
-                prompt_cache_enabled=config.prompt_cache_enabled,
+                prompt_cache_enabled=config.llm.prompt_cache_enabled,
                 project_context=project_context,
                 project_context_path=project_context_path,
                 agent_role=profile.role,

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -463,7 +463,7 @@ def run_serve(args: argparse.Namespace) -> None:
             safety=safety,
             mcp_servers=session_cfg.config.mcp,
             output_language=output_language,
-            prompt_cache_enabled=session_cfg.config.prompt_cache_enabled,
+            prompt_cache_enabled=session_cfg.config.llm.prompt_cache_enabled,
             project_context=project_context,
             project_context_path=project_context_path,
             agent_role=profile.role,

--- a/src/reyn/interfaces/cli/commands/support_bundle.py
+++ b/src/reyn/interfaces/cli/commands/support_bundle.py
@@ -177,10 +177,11 @@ def _meta(session, since_raw, manifest) -> dict:
     try:
         from reyn.config import load_config
         cfg = load_config()
+        _llm = getattr(cfg, "llm", None)
         config_summary = {
-            "model": getattr(cfg, "model", None),
-            "models": list(getattr(cfg, "models", {}) or {}),
-            "api_base_set": bool(getattr(cfg, "api_base", "")),
+            "model": getattr(_llm, "model", None),
+            "models": list(getattr(_llm, "models", {}) or {}),
+            "api_base_set": bool(getattr(_llm, "api_base", "")),
         }
     except Exception as exc:  # never let config-load break the bundle
         config_summary = {"_unavailable": str(exc)}

--- a/src/reyn/interfaces/cli/invocation_context.py
+++ b/src/reyn/interfaces/cli/invocation_context.py
@@ -27,16 +27,16 @@ class InvocationContext:
         # idempotent ``setdefault``); a single-writer AST guard now enforces this.
         config = load_config()
         return cls(config=config, resolver=ModelResolver(
-            config.models,
-            default_class=config.model,
-            purpose_classes=config.model_class_by_purpose,
+            config.llm.models,
+            default_class=config.llm.model,
+            purpose_classes=config.llm.model_class_by_purpose,
         ))
 
     # ── argparse-aware setting resolution (CLI > config) ─────────────────────
 
     def model_for(self, args: argparse.Namespace) -> tuple[str, str]:
         """Return (model_class_or_string, resolved_litellm_string)."""
-        m = getattr(args, "model", None) or self.config.model
+        m = getattr(args, "model", None) or self.config.llm.model
         return m, self.resolver.resolve(m).model
 
     def output_language_for(self, args: argparse.Namespace) -> str | None:

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -311,11 +311,11 @@ def _get_registry():
 
         from reyn.llm.model_resolver import ModelResolver
         resolver = ModelResolver(
-            config.models,
-            default_class=config.model,
-            purpose_classes=config.model_class_by_purpose,
+            config.llm.models,
+            default_class=config.llm.model,
+            purpose_classes=config.llm.model_class_by_purpose,
         )
-        model = config.model
+        model = config.llm.model
         output_language = config.output_language
 
         # registry is referenced inside the factory closure — defined below.
@@ -355,7 +355,7 @@ def _get_registry():
                 safety=config.safety,
                 mcp_servers=config.mcp,
                 output_language=output_language,
-                prompt_cache_enabled=config.prompt_cache_enabled,
+                prompt_cache_enabled=config.llm.prompt_cache_enabled,
                 project_context=project_context,
                 project_context_path=project_context_path,
                 agent_role=profile.role,

--- a/src/reyn/llm/model_resolver.py
+++ b/src/reyn/llm/model_resolver.py
@@ -2,7 +2,8 @@
 ModelResolver: resolves model class names to LiteLLM model strings.
 
 Standard classes: light, standard, strong.
-Mapping is provided by ReynConfig.models (loaded from reyn.yaml).
+Mapping is provided by ReynConfig.llm.models (loaded from reyn.yaml, #4174 T3:
+moved from top-level ReynConfig.models).
 Unknown names pass through unchanged (backward compatible with raw LiteLLM strings).
 
 PR-MODEL-SPEC-EXTENDS: adds ``extends`` field + built-in catalog support.
@@ -163,7 +164,9 @@ class ModelSpec:
 
     @classmethod
     def from_config(cls, value: object) -> "ModelSpec":
-        """Parse a reyn.yaml models: entry into a ModelSpec.
+        """Parse a reyn.yaml llm.models: entry into a ModelSpec.
+
+        #4174 T3: moved from top-level `models:` — same entry shape.
 
         Accepted forms:
           str  -> ModelSpec(model=value, kwargs={})
@@ -297,17 +300,21 @@ class ModelResolver:
         """Build a ModelResolver.
 
         Args:
-            mapping:  User-declared models from reyn.yaml (``ReynConfig.models``).
+            mapping:  User-declared models from reyn.yaml (``ReynConfig.llm.models``,
+                      #4174 T3: moved from top-level ``.models``).
             builtin:  Built-in catalog.  Defaults to ``BUILTIN_MODELS``.
                       User entries in *mapping* override entries with the same
                       name.  Pass ``{}`` to disable built-ins (useful in tests).
             default_class: #1672 — the configured default model class
-                      (``ReynConfig.model``) returned by ``class_for_purpose`` for
-                      any unset purpose. Defaults to ``"standard"`` so resolvers
-                      built without it stay byte-identical to the old hardcodes.
+                      (``ReynConfig.llm.model``, #4174 T3: moved from top-level
+                      ``.model``) returned by ``class_for_purpose`` for any unset
+                      purpose. Defaults to ``"standard"`` so resolvers built
+                      without it stay byte-identical to the old hardcodes.
             purpose_classes: #1672 — per-purpose class overrides
-                      (``ReynConfig.model_class_by_purpose``). A purpose present
-                      here wins over ``default_class`` in ``class_for_purpose``.
+                      (``ReynConfig.llm.model_class_by_purpose``, #4174 T3: moved
+                      from top-level ``.model_class_by_purpose``). A purpose
+                      present here wins over ``default_class`` in
+                      ``class_for_purpose``.
         """
         if builtin is None:
             builtin = BUILTIN_MODELS
@@ -359,7 +366,9 @@ class ModelResolver:
     def _warn_on_partial_tier_declaration(
         self, mapping: dict[str, Any], builtin: dict[str, str | dict],
     ) -> None:
-        """#3374: warn when ``models:`` declares SOME but not ALL generic tiers.
+        """#3374: warn when ``llm.models:`` declares SOME but not ALL generic tiers.
+
+        #4174 T3: moved from top-level ``models:`` — same shape.
 
         The built-in tier aliases (#3368) mean an undeclared tier still resolves,
         which is the point — but it resolves to *reyn's* default rather than the
@@ -394,12 +403,12 @@ class ModelResolver:
         import logging
 
         logging.getLogger(__name__).warning(
-            "reyn.yaml `models:` declares the %s tier(s) but omits %s — the "
+            "reyn.yaml `llm.models:` declares the %s tier(s) but omits %s — the "
             "omitted tier(s) still resolve, via reyn's built-in defaults: %s. "
             "A project that maps some tiers usually means to map all of them, "
             "so an omitted tier is typically an oversight: those calls silently "
             "use a different model than the tiers you declared. To take "
-            "control, add under `models:` in reyn.yaml:\n%s",
+            "control, add under `llm.models:` in reyn.yaml:\n%s",
             ", ".join(declared),
             ", ".join(missing),
             "; ".join(f"{t} -> {self._resolved[t].model}" for t in missing),
@@ -415,7 +424,7 @@ class ModelResolver:
         # gemini-2.5-flash-lite` bypassing the class system) — but it is
         # ALSO what a mistyped or unregistered CLASS name silently falls
         # into: nothing here can tell the two apart, so a typo or a config
-        # that failed to load its `models:` section (see `_load_yaml`) never
+        # that failed to load its `llm.models:` section (see `_load_yaml`) never
         # surfaces as an error here — only much later, as a confusing raw
         # provider-side rejection once litellm itself receives the
         # unresolved name (#3368). Logged (not raised) so the passthrough
@@ -433,7 +442,7 @@ class ModelResolver:
                 "model class %r not found among known classes (%s) — passing it "
                 "through unchanged as a literal LiteLLM model string. If this "
                 "was meant to be a configured class, check reyn.yaml/"
-                "reyn.local.yaml's `models:` section for a typo or a load "
+                "reyn.local.yaml's `llm.models:` section for a typo or a load "
                 "failure. (This warning fires once per distinct name.)",
                 name, ", ".join(sorted(self._resolved)) or "none",
             )
@@ -510,9 +519,10 @@ class ModelResolver:
         This is the "standard gate" promotion of :meth:`is_known_class` — every
         op- or phase-supplied model field (``op.model``) routes through here rather
         than each call site re-implementing the guard. Operator-config model
-        references (``cfg.model`` etc., from reyn.yaml) deliberately do NOT use
-        this gate: literal LiteLLM strings there are an intentional
-        backward-compat passthrough (see :meth:`resolve`).
+        references (``cfg.llm.model`` etc., from reyn.yaml — #4174 T3: moved
+        from top-level ``cfg.model``) deliberately do NOT use this gate:
+        literal LiteLLM strings there are an intentional backward-compat
+        passthrough (see :meth:`resolve`).
         """
         if requested and not self.is_known_class(requested):
             import logging
@@ -520,7 +530,7 @@ class ModelResolver:
             logging.getLogger(__name__).warning(
                 "%s: model %r is not a known model class — ignoring and using "
                 "%r instead. Use a model class (e.g. light / standard / strong, "
-                "or one defined in reyn.yaml models:) so the proxy config stays "
+                "or one defined in reyn.yaml llm.models:) so the proxy config stays "
                 "the single source of truth.",
                 where or "model selection", requested, fallback or "standard",
             )

--- a/src/reyn/runtime/registry_bootstrap.py
+++ b/src/reyn/runtime/registry_bootstrap.py
@@ -130,7 +130,7 @@ def build_agent_registry_from_project(
       widening.
     - **``interactive=not non_interactive``** on the ``PermissionResolver`` —
       a one-shot caller has no one to answer an interactive approval prompt.
-    - **Default model tier** (``config.model``) + a fresh ``ModelResolver``
+    - **Default model tier** (``config.llm.model``) + a fresh ``ModelResolver``
       built straight from ``config`` — no CLI ``--model`` surface for v1.
 
     ``agent_name``, if given, is not verified to exist here (registry
@@ -169,9 +169,9 @@ def build_agent_registry_from_project(
     # hot-reload IN-set.
     project_context_path = resolve_project_context_path(config, project_root)
     resolver = ModelResolver(
-        config.models,
-        default_class=config.model,
-        purpose_classes=config.model_class_by_purpose,
+        config.llm.models,
+        default_class=config.llm.model,
+        purpose_classes=config.llm.model_class_by_purpose,
     )
     factory_config = SessionFactoryConfig.from_config(config, project_root)
     ws_base_dir = project_root
@@ -193,13 +193,13 @@ def build_agent_registry_from_project(
             # operator; None (default / non-spawn / detached) = self-bound fail-closed.
             intervention_bridge=intervention_bridge,
             agent_name=profile.name,
-            model=config.model,
+            model=config.llm.model,
             resolver=resolver,
             permission_resolver=perm_resolver,
             safety=config.safety,
             mcp_servers=config.mcp,
             output_language=config.output_language,
-            prompt_cache_enabled=config.prompt_cache_enabled,
+            prompt_cache_enabled=config.llm.prompt_cache_enabled,
             project_context=project_context,
             project_context_path=project_context_path,
             agent_role=profile.role,

--- a/tests/cli/test_agent_list_hides_archived.py
+++ b/tests/cli/test_agent_list_hides_archived.py
@@ -75,7 +75,7 @@ def test_list_from_a_subdirectory_still_finds_the_project_agents(
     would print the "no agents yet" message (it would look under
     `<subdir>/.reyn/agents/`, which is empty/absent) instead of listing the
     real agent created at the project root."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     reg = AgentRegistry(project_root=tmp_path, session_factory=_no_factory)
     reg.create("alpha", role="coordinator")
 

--- a/tests/config/test_4174_t0_unknown_config_key_warn.py
+++ b/tests/config/test_4174_t0_unknown_config_key_warn.py
@@ -27,10 +27,14 @@ def test_a_well_formed_config_produces_no_unknown_key_warning(tmp_path, caplog) 
     """Tier 2: #4174 T0 accept-side (lead-coder's explicit false-positive-noise
     concern) — a real, valid reyn.yaml touching several nested sections
     never trips the warning. If it did, operators would learn to ignore the
-    warning entirely, defeating its purpose."""
+    warning entirely, defeating its purpose.
+
+    #4174 T3: `model:` moved under `llm:` — this fixture uses the live
+    location so the accept-side guard isn't itself tripping the T3 rename."""
     cfg = _load(
         tmp_path,
-        "model: standard\n"
+        "llm:\n"
+        "  model: standard\n"
         "sandbox:\n"
         "  mode: strict\n"
         "  policy:\n"
@@ -58,18 +62,22 @@ def test_an_unrecognized_top_level_key_warns_not_applied(tmp_path, caplog) -> No
     ), messages
 
 
-def test_llm_model_is_flagged_as_a_real_pre_existing_dead_key(tmp_path, caplog) -> None:
-    """Tier 2: #4174 T0 — architect's finding (confirmed live, not a T1-T6
-    rename artifact): `_build_llm_config` only reads raw.get("router")/
-    raw.get("retry"); LLMConfig has no `model` field, so an operator writing
-    `llm: {model: ...}` today has it silently discarded. T0's recursive walk
-    catches this as an ordinary unknown key (llm.model) without any
-    special-casing — proving T0 repairs an EXISTING defect, not just future
-    renames."""
+def test_llm_model_is_now_a_known_key_not_flagged(tmp_path, caplog) -> None:
+    """Tier 2: #4174 T3 — accept-side, superseding this test's former pre-T3
+    shape. Architect's #4174 T0 finding was that `llm.model` was a real,
+    pre-existing dead key (`_build_llm_config` only read `router`/`retry`;
+    LLMConfig had no `model` field, so an operator writing `llm: {model:
+    ...}` had it silently discarded, caught by T0's unknown-key walk with no
+    special-casing needed). T3 closed that gap by giving `LLMConfig` a real
+    `model` field and having `_build_llm_config` parse it — so the SAME
+    input that used to warn "NOT APPLIED" must now warn about nothing AND
+    the value must actually reach `cfg.llm.model`, or T3 only moved the
+    silence rather than fixing it."""
     cfg = _load(tmp_path, "llm:\n  model: standard\n  router:\n    use: false\n", caplog)
     assert cfg is not None
+    assert cfg.llm.model == "standard"
     messages = [r.message for r in caplog.records]
-    assert any("llm.model" in m and "NOT APPLIED" in m for m in messages), messages
+    assert not any("llm.model" in m and "NOT APPLIED" in m for m in messages), messages
 
 
 def test_unknown_sandbox_policy_key_warning_names_the_effective_policy(

--- a/tests/config/test_4231_c_disabled_by_dependency_config_keys.py
+++ b/tests/config/test_4231_c_disabled_by_dependency_config_keys.py
@@ -112,7 +112,7 @@ def test_validate_reports_the_disabled_key_with_all_four_elements(project, capsy
 
     _write_yaml(
         project / "reyn.yaml",
-        "model: standard\naction_retrieval:\n  universal_wrappers_enabled: true\n",
+        "llm:\n  model: standard\naction_retrieval:\n  universal_wrappers_enabled: true\n",
     )
     _validate()
     out = capsys.readouterr().out
@@ -129,7 +129,7 @@ def test_validate_does_not_flag_universal_category_scheme(project, capsys):
 
     _write_yaml(
         project / "reyn.yaml",
-        "model: standard\n"
+        "llm:\n  model: standard\n"
         "action_retrieval:\n  universal_wrappers_enabled: true\n"
         "tool_use:\n  scheme: universal-category\n",
     )

--- a/tests/config/test_action_retrieval_config.py
+++ b/tests/config/test_action_retrieval_config.py
@@ -209,7 +209,7 @@ def test_load_config_without_action_retrieval_uses_defaults(tmp_path: Path) -> N
     ``universal_wrappers_enabled: false`` in reyn.yaml.
     """
     (tmp_path / "reyn.yaml").write_text(
-        "model: standard\n",
+        "llm:\n  model: standard\n",
         encoding="utf-8",
     )
 
@@ -254,7 +254,7 @@ def test_load_config_hot_list_n_explicit_opt_in(tmp_path: Path) -> None:
     """Tier 2: N=0 default flip — explicit hot_list_n: 10 in reyn.yaml enables
     the hot-list (symmetric pin: default off, explicit on)."""
     (tmp_path / "reyn.yaml").write_text(
-        "model: standard\naction_retrieval:\n  hot_list_n: 10\n",
+        "llm:\n  model: standard\naction_retrieval:\n  hot_list_n: 10\n",
         encoding="utf-8",
     )
     cfg = load_config(cwd=tmp_path)
@@ -263,6 +263,6 @@ def test_load_config_hot_list_n_explicit_opt_in(tmp_path: Path) -> None:
 
 def test_load_config_hot_list_n_default_is_zero(tmp_path: Path) -> None:
     """Tier 2: N=0 default flip — bare reyn.yaml with no hot_list_n gives 0."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     cfg = load_config(cwd=tmp_path)
     assert cfg.action_retrieval.hot_list_n == 0

--- a/tests/config/test_config_cascade.py
+++ b/tests/config/test_config_cascade.py
@@ -37,15 +37,15 @@ def test_legacy_dot_reyn_config_emits_warning(tmp_path, monkeypatch, capsys):
     """
     # Create a minimal project root.
     reyn_yaml = tmp_path / "reyn.yaml"
-    _write_yaml(reyn_yaml, {"model": "standard"})
+    _write_yaml(reyn_yaml, {"llm": {"model": "standard"}})
 
     # Write a .reyn/config.yaml with a sentinel value.
     legacy_cfg = tmp_path / ".reyn" / "config.yaml"
-    _write_yaml(legacy_cfg, {"model": "legacy-only-model"})
+    _write_yaml(legacy_cfg, {"llm": {"model": "legacy-only-model"}})
 
     # Write a reyn.local.yaml with a different sentinel.
     local_yaml = tmp_path / "reyn.local.yaml"
-    _write_yaml(local_yaml, {"model": "local-model"})
+    _write_yaml(local_yaml, {"llm": {"model": "local-model"}})
 
     monkeypatch.chdir(tmp_path)
 
@@ -62,8 +62,8 @@ def test_legacy_dot_reyn_config_emits_warning(tmp_path, monkeypatch, capsys):
     assert ".reyn/config.yaml" in captured.err or str(legacy_cfg) in captured.err
 
     # Legacy file value must NOT override anything — reyn.local.yaml wins.
-    assert cfg.model == "local-model", (
-        f"Expected 'local-model' from reyn.local.yaml, got {cfg.model!r}. "
+    assert cfg.llm.model == "local-model", (
+        f"Expected 'local-model' from reyn.local.yaml, got {cfg.llm.model!r}. "
         "The legacy .reyn/config.yaml must not be loaded."
     )
 
@@ -75,10 +75,10 @@ def test_legacy_dot_reyn_config_not_loaded_when_no_local_yaml(tmp_path, monkeypa
     override values from reyn.yaml.
     """
     reyn_yaml = tmp_path / "reyn.yaml"
-    _write_yaml(reyn_yaml, {"model": "project-model"})
+    _write_yaml(reyn_yaml, {"llm": {"model": "project-model"}})
 
     legacy_cfg = tmp_path / ".reyn" / "config.yaml"
-    _write_yaml(legacy_cfg, {"model": "legacy-only-model"})
+    _write_yaml(legacy_cfg, {"llm": {"model": "legacy-only-model"}})
 
     # No reyn.local.yaml — default from reyn.yaml should survive.
     monkeypatch.chdir(tmp_path)
@@ -92,8 +92,8 @@ def test_legacy_dot_reyn_config_not_loaded_when_no_local_yaml(tmp_path, monkeypa
     assert "deprecated" in captured.err.lower() or "ADR-0031" in captured.err
 
     # Legacy value must not bleed in.
-    assert cfg.model == "project-model", (
-        f"Expected 'project-model', got {cfg.model!r}. "
+    assert cfg.llm.model == "project-model", (
+        f"Expected 'project-model', got {cfg.llm.model!r}. "
         "The legacy .reyn/config.yaml value must not be applied."
     )
 
@@ -101,7 +101,7 @@ def test_legacy_dot_reyn_config_not_loaded_when_no_local_yaml(tmp_path, monkeypa
 def test_no_warning_when_dot_reyn_config_absent(tmp_path, monkeypatch, capsys):
     """Tier 2: no deprecation warning is emitted when .reyn/config.yaml does not exist."""
     reyn_yaml = tmp_path / "reyn.yaml"
-    _write_yaml(reyn_yaml, {"model": "standard"})
+    _write_yaml(reyn_yaml, {"llm": {"model": "standard"}})
 
     monkeypatch.chdir(tmp_path)
 
@@ -117,18 +117,18 @@ def test_no_warning_when_dot_reyn_config_absent(tmp_path, monkeypatch, capsys):
 def test_reyn_local_yaml_still_loaded(tmp_path, monkeypatch):
     """Tier 2: reyn.local.yaml is loaded and overrides reyn.yaml (3-layer cascade intact)."""
     reyn_yaml = tmp_path / "reyn.yaml"
-    _write_yaml(reyn_yaml, {"model": "standard"})
+    _write_yaml(reyn_yaml, {"llm": {"model": "standard"}})
 
     local_yaml = tmp_path / "reyn.local.yaml"
-    _write_yaml(local_yaml, {"model": "strong"})
+    _write_yaml(local_yaml, {"llm": {"model": "strong"}})
 
     monkeypatch.chdir(tmp_path)
 
     from reyn.config import load_config
 
     cfg = load_config(tmp_path)
-    assert cfg.model == "strong", (
-        f"Expected 'strong' from reyn.local.yaml, got {cfg.model!r}."
+    assert cfg.llm.model == "strong", (
+        f"Expected 'strong' from reyn.local.yaml, got {cfg.llm.model!r}."
     )
 
 

--- a/tests/config/test_config_loader_malformed.py
+++ b/tests/config/test_config_loader_malformed.py
@@ -25,15 +25,17 @@ def _load(tmp_path: Path, yaml_text: str):
 
 
 def test_models_as_string_does_not_crash(tmp_path) -> None:
-    """Tier 2: `models: <string>` defaults to empty instead of crashing."""
-    cfg = _load(tmp_path, "models: not-a-dict\n")
-    assert dict(cfg.models) == {}
+    """Tier 2: `llm.models: <string>` defaults to empty instead of crashing.
+
+    #4174 T3: `models:` moved under `llm:`."""
+    cfg = _load(tmp_path, "llm:\n  models: not-a-dict\n")
+    assert dict(cfg.llm.models) == {}
 
 
 def test_models_as_list_does_not_crash(tmp_path) -> None:
-    """Tier 2: `models: [..]` defaults to empty instead of crashing."""
-    cfg = _load(tmp_path, "models: [1, 2, 3]\n")
-    assert dict(cfg.models) == {}
+    """Tier 2: `llm.models: [..]` defaults to empty instead of crashing."""
+    cfg = _load(tmp_path, "llm:\n  models: [1, 2, 3]\n")
+    assert dict(cfg.llm.models) == {}
 
 
 def test_permissions_as_list_does_not_crash(tmp_path) -> None:
@@ -62,8 +64,8 @@ def test_mcp_as_list_does_not_crash(tmp_path) -> None:
 
 def test_valid_models_still_loads(tmp_path) -> None:
     """Tier 2: a well-formed models block is unaffected by the guard (regression)."""
-    cfg = _load(tmp_path, "models:\n  light: openai/gpt-4o\n  standard: claude-sonnet\n")
-    assert dict(cfg.models) == {"light": "openai/gpt-4o", "standard": "claude-sonnet"}
+    cfg = _load(tmp_path, "llm:\n  models:\n    light: openai/gpt-4o\n    standard: claude-sonnet\n")
+    assert dict(cfg.llm.models) == {"light": "openai/gpt-4o", "standard": "claude-sonnet"}
 
 
 def test_fail_loud_sections_still_raise_clear_error(tmp_path) -> None:
@@ -94,5 +96,5 @@ def test_yaml_parse_error_logs_warning_and_falls_back(tmp_path, caplog) -> None:
     (tmp_path / "reyn.yaml").write_text("models: [unterminated\n", encoding="utf-8")
     with caplog.at_level(logging.WARNING, logger="reyn.config.loader"):
         cfg = load_config(tmp_path)
-    assert dict(cfg.models) == {}
+    assert dict(cfg.llm.models) == {}
     assert any("reyn.yaml" in r.message for r in caplog.records)

--- a/tests/config/test_config_mcp_merge_1146.py
+++ b/tests/config/test_config_mcp_merge_1146.py
@@ -26,7 +26,7 @@ from reyn.config import load_config
 
 
 def _root(tmp_path: Path) -> Path:
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     return tmp_path
 
 
@@ -72,7 +72,7 @@ def test_mcp_servers_union_preserved_across_layers(tmp_path: Path) -> None:
     """
     root = tmp_path
     (root / "reyn.yaml").write_text(
-        "model: standard\n"
+        "llm:\n  model: standard\n"
         "mcp:\n  search_threshold: 5\n  servers:\n    alpha:\n      type: stdio\n      command: a\n",
         encoding="utf-8",
     )

--- a/tests/config/test_fp0009_b_cron_config.py
+++ b/tests/config/test_fp0009_b_cron_config.py
@@ -66,7 +66,7 @@ def test_cron_config_default_empty() -> None:
 
 def test_no_cron_block_gives_empty_jobs(tmp_path: Path) -> None:
     """Tier 1: reyn.yaml with no cron: block → ReynConfig.cron.jobs == []."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     cfg = load_config(cwd=tmp_path)
     assert cfg.cron.jobs == []
 
@@ -194,7 +194,7 @@ cron:
 
 def test_empty_cron_block_gives_empty_jobs(tmp_path: Path) -> None:
     """Tier 1: empty cron: block (no jobs key) → CronConfig(jobs=[])."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\ncron: {}\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\ncron: {}\n", encoding="utf-8")
     cfg = load_config(cwd=tmp_path)
     assert cfg.cron.jobs == []
 

--- a/tests/config/test_pipe_proxy_bootstrap_2682.py
+++ b/tests/config/test_pipe_proxy_bootstrap_2682.py
@@ -50,9 +50,10 @@ def _restore_litellm_api_base():
 
 
 def _write_project(root, *, api_base: str | None) -> None:
-    lines = ["model: standard", "models:", f"  standard: {_PSEUDO_MODEL}"]
+    # #4174 T3: model/models/api_base moved under `llm:`.
+    lines = ["llm:", "  model: standard", "  models:", f"    standard: {_PSEUDO_MODEL}"]
     if api_base is not None:
-        lines.insert(0, f"api_base: {api_base}")
+        lines.append(f"  api_base: {api_base}")
     (root / "reyn.yaml").write_text("\n".join(lines) + "\n")
 
 
@@ -76,7 +77,7 @@ def test_load_config_exports_litellm_api_base(tmp_path, monkeypatch) -> None:
 
     config = load_config()
 
-    assert config.api_base == _PROXY
+    assert config.llm.api_base == _PROXY
     assert os.environ.get("LITELLM_API_BASE") == _PROXY
 
 
@@ -88,7 +89,7 @@ def test_load_config_no_api_base_leaves_env_unset(tmp_path, monkeypatch) -> None
 
     config = load_config()
 
-    assert config.api_base == ""
+    assert config.llm.api_base == ""
     assert "LITELLM_API_BASE" not in os.environ
 
 

--- a/tests/config/test_project_context_agents_md.py
+++ b/tests/config/test_project_context_agents_md.py
@@ -90,7 +90,7 @@ def test_yaml_omitted_resolves_to_none_default(tmp_path: Path) -> None:
     """
     from reyn.config import load_config
 
-    (tmp_path / "reyn.yaml").write_text("prompt_cache_enabled: true\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  prompt_cache_enabled: true\n", encoding="utf-8")
     _write(tmp_path, "AGENTS.md", _AGENTS)
     cfg = load_config(tmp_path)
     assert cfg.project_context_path is None

--- a/tests/config/test_web_auth_config_contract.py
+++ b/tests/config/test_web_auth_config_contract.py
@@ -31,7 +31,7 @@ def test_gateway_auth_non_default_values_round_trip(tmp_path, monkeypatch):
     cfg = _load(
         tmp_path,
         (
-            "model: standard\n"
+            "llm:\n  model: standard\n"
             "gateway:\n"
             "  auth:\n"
             "    token: my-secret-token\n"
@@ -50,7 +50,7 @@ def test_gateway_auth_non_default_values_round_trip(tmp_path, monkeypatch):
 
 def test_gateway_auth_defaults_are_secure(tmp_path, monkeypatch):
     """Tier 1: a missing gateway.auth section defaults to no token + loopback token required."""
-    cfg = _load(tmp_path, "model: standard\n", monkeypatch)
+    cfg = _load(tmp_path, "llm:\n  model: standard\n", monkeypatch)
     auth = cfg.gateway.auth
     assert auth.token is None
     assert auth.require_token_on_loopback is True
@@ -63,7 +63,7 @@ def test_require_token_on_loopback_truthy_strings(tmp_path, monkeypatch, value):
     """Tier 1: an interpolated truthy string for require_token_on_loopback parses True."""
     cfg = _load(
         tmp_path,
-        f"model: standard\ngateway:\n  auth:\n    require_token_on_loopback: '{value}'\n",
+        f"llm:\n  model: standard\ngateway:\n  auth:\n    require_token_on_loopback: '{value}'\n",
         monkeypatch,
     )
     assert cfg.gateway.auth.require_token_on_loopback is True

--- a/tests/core/test_2575_pipeline_disk_registration.py
+++ b/tests/core/test_2575_pipeline_disk_registration.py
@@ -335,7 +335,7 @@ def test_from_config_builds_populated_registry_from_project_root(tmp_path: Path)
 
     _write(tmp_path / "pipelines", "hello.yaml", _HELLO_DSL)
     (tmp_path / "reyn.yaml").write_text(
-        "model: standard\npipelines:\n  entries:\n    hello:\n      path: pipelines/hello.yaml\n",
+        "llm:\n  model: standard\npipelines:\n  entries:\n    hello:\n      path: pipelines/hello.yaml\n",
         encoding="utf-8",
     )
     config = load_config(tmp_path)
@@ -372,7 +372,7 @@ def test_from_config_without_project_root_is_empty(tmp_path: Path, monkeypatch) 
 
     _write(tmp_path / "pipelines", "hello.yaml", _HELLO_DSL)
     (tmp_path / "reyn.yaml").write_text(
-        "model: standard\npipelines:\n  entries:\n    hello:\n      path: pipelines/hello.yaml\n",
+        "llm:\n  model: standard\npipelines:\n  entries:\n    hello:\n      path: pipelines/hello.yaml\n",
         encoding="utf-8",
     )
     monkeypatch.chdir(tmp_path)

--- a/tests/core/test_2581_pipeline_hotreload.py
+++ b/tests/core/test_2581_pipeline_hotreload.py
@@ -57,7 +57,7 @@ def _make_session(tmp_path: Path, *, agent_name: str = "test-agent") -> Session:
     production build-once path. A bare ``model: standard`` reyn.yaml (no
     ``pipelines:`` block) is also valid and yields an empty registry."""
     if not (tmp_path / "reyn.yaml").exists():
-        (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+        (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     from reyn.config.loader import load_config
     from reyn.data.pipelines.registry import build_pipeline_registry
     cfg = load_config(tmp_path)
@@ -164,7 +164,7 @@ async def test_hotreload_changes_pipeline_description_on_live_registry(
 @pytest.mark.asyncio
 async def test_hotreload_seam_registered(tmp_path: Path) -> None:
     """Tier 2: the Session registers the pipelines seam on the HotReloader."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     session = make_session(
         agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
         snapshot_path=tmp_path / "snap.json",

--- a/tests/core/test_2761_pr2_hotreload_immediate_apply.py
+++ b/tests/core/test_2761_pr2_hotreload_immediate_apply.py
@@ -72,7 +72,7 @@ def _make_session(tmp_path: Path, *, agent_name: str = "pr2-agent") -> Session:
     """Minimal real Session rooted at *tmp_path* (chdir before calling). Builds
     ``available_skills`` + ``pipeline_registry`` from ``load_config`` so entries already
     written to ``.reyn/config/*.yaml`` are adopted — mirroring session-factory."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     from reyn.config.loader import load_config
     from reyn.data.pipelines.registry import build_pipeline_registry
     from reyn.data.skills.registry import build_skill_registry

--- a/tests/core/test_2761_pr3_mcp_immediate_probe.py
+++ b/tests/core/test_2761_pr3_mcp_immediate_probe.py
@@ -101,7 +101,7 @@ def _Ctx(root: Path, rs: "RouterCallerState | None") -> ToolContext:
 
 
 def _session(tmp: Path) -> Session:
-    (tmp / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     return make_session(
         agent_name="mcp-pr3",
         state_log=StateLog(tmp / "s.wal"),

--- a/tests/core/test_config_separation_mcp_yaml.py
+++ b/tests/core/test_config_separation_mcp_yaml.py
@@ -37,7 +37,7 @@ def test_load_config_reads_dynamic_mcp_yaml(tmp_path, monkeypatch):
     from reyn.config import load_config
 
     # Plant a reyn.yaml so _find_project_root finds tmp_path.
-    _write_yaml(tmp_path / "reyn.yaml", "model: standard\n")
+    _write_yaml(tmp_path / "reyn.yaml", "llm:\n  model: standard\n")
     _write_yaml(
         tmp_path / ".reyn" / "config" / "mcp.yaml",
         "mcp:\n  servers:\n    sqlite:\n      type: stdio\n      command: npx\n",
@@ -63,7 +63,7 @@ def test_load_config_dynamic_mcp_yaml_overrides_reyn_yaml(tmp_path, monkeypatch)
 
     _write_yaml(
         tmp_path / "reyn.yaml",
-        "model: standard\n"
+        "llm:\n  model: standard\n"
         "mcp:\n  servers:\n    git:\n      type: stdio\n      command: old-cmd\n",
     )
     _write_yaml(
@@ -89,7 +89,7 @@ def test_load_config_dynamic_mcp_yaml_and_reyn_yaml_servers_union(
 
     _write_yaml(
         tmp_path / "reyn.yaml",
-        "model: standard\n"
+        "llm:\n  model: standard\n"
         "mcp:\n  servers:\n    legacy:\n      type: stdio\n      command: legacy-cmd\n",
     )
     _write_yaml(
@@ -116,7 +116,7 @@ def test_load_config_works_without_dynamic_mcp_yaml(tmp_path, monkeypatch):
 
     _write_yaml(
         tmp_path / "reyn.yaml",
-        "model: standard\n"
+        "llm:\n  model: standard\n"
         "mcp:\n  servers:\n    only-in-reyn:\n      type: stdio\n      command: x\n",
     )
 

--- a/tests/core/test_fp0066_p1a_embedding_enabled_gate.py
+++ b/tests/core/test_fp0066_p1a_embedding_enabled_gate.py
@@ -257,7 +257,7 @@ def test_bare_mcp_search_threshold_key_is_ignored_not_erroring(tmp_path) -> None
     from reyn.config import load_config
 
     (tmp_path / "reyn.yaml").write_text(
-        "model: standard\nmcp:\n  search_threshold: 5\n", encoding="utf-8",
+        "llm:\n  model: standard\nmcp:\n  search_threshold: 5\n", encoding="utf-8",
     )
     cfg = load_config(cwd=tmp_path)
     # No derived field reads it anymore; it just survives in the raw dict.

--- a/tests/core/test_mcp_hot_reload_2372.py
+++ b/tests/core/test_mcp_hot_reload_2372.py
@@ -26,7 +26,7 @@ from tests._support.agent_session import make_session
 def _session(tmp_path: Path) -> Session:
     # load_config resolves the project root by walking up for reyn.yaml (the marker gating the
     # dynamic .reyn/config/mcp.yaml read); a Reyn project always has one.
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     s = make_session(
         agent_name="alice", state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",

--- a/tests/core/test_mcp_install_ux_fixes_318_319_320.py
+++ b/tests/core/test_mcp_install_ux_fixes_318_319_320.py
@@ -213,7 +213,7 @@ def test_install_command_warns_on_tmp_args_on_darwin(tmp_path, reyn_console_scri
     # #1442: install now resolves a project root and fails loud outside one
     # (error-not-silent-cwd), so give tmp_path a reyn.yaml — the #320 /tmp-args
     # warning fires inside the source install, past project resolution.
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     result = subprocess.run(
         [
             reyn_bin, "mcp", "install",

--- a/tests/core/test_mcp_install_workspace_1442.py
+++ b/tests/core/test_mcp_install_workspace_1442.py
@@ -38,7 +38,7 @@ from reyn.tools.types import RouterCallerState, ToolContext
 
 def test_resolve_project_root_from_explicit_project(tmp_path):
     """Tier 2: #1442 A — --project resolves to that root (not cwd)."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     assert _resolve_install_project_root(str(tmp_path)) == tmp_path.resolve()
 
 

--- a/tests/core/test_offload_config_gate_pr3.py
+++ b/tests/core/test_offload_config_gate_pr3.py
@@ -61,7 +61,7 @@ def test_load_config_reads_offload_enabled_true(tmp_path):
 
     _write_yaml(
         tmp_path / "reyn.yaml",
-        "model: standard\noffload:\n  enabled: true\n",
+        "llm:\n  model: standard\noffload:\n  enabled: true\n",
     )
     config = load_config(cwd=tmp_path)
     assert config.offload.enabled is True

--- a/tests/core/test_present_registry_fp0054_prc.py
+++ b/tests/core/test_present_registry_fp0054_prc.py
@@ -123,7 +123,7 @@ def test_config_roundtrip_named_template_reaches_registry(tmp_path: Path) -> Non
     NON-default blueprint value) is loaded through the full config cascade + built
     into the registry under its entry name, with the blueprint structurally
     validated (mirrors the skills/pipelines disk round-trip)."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     cfg_dir = tmp_path / ".reyn" / "config"
     cfg_dir.mkdir(parents=True)
     (cfg_dir / "presentations.yaml").write_text(
@@ -355,7 +355,7 @@ def _make_session(tmp_path: Path) -> Session:
     """Minimal real Session whose presentation registry is built from the current
     config cascade (mirrors SessionFactoryConfig.from_config's build-once path)."""
     if not (tmp_path / "reyn.yaml").exists():
-        (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+        (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     cfg = load_config(tmp_path)
     return make_session(
         agent_name="prc-test",

--- a/tests/core/test_render_template_bounds_config_2679.py
+++ b/tests/core/test_render_template_bounds_config_2679.py
@@ -67,7 +67,7 @@ def test_operator_yaml_bounds_cap_the_op_through_a_real_session(tmp_path: Path) 
     regression is now caught.
     """
     (tmp_path / "reyn.yaml").write_text(
-        "model: standard\n"
+        "llm:\n  model: standard\n"
         "render_template:\n"
         "  max_output_chars: 20\n"
         "  wall_clock_seconds: 1.5\n"

--- a/tests/core/test_web_fetch_config_session_wiring_4274.py
+++ b/tests/core/test_web_fetch_config_session_wiring_4274.py
@@ -83,7 +83,7 @@ def test_tight_max_download_bytes_reaches_the_op_through_both_builders(
     1000-byte response (default cap is 10 MiB — this response would pass
     uncapped)."""
     (tmp_path / "reyn.yaml").write_text(
-        "model: standard\nweb_fetch:\n  max_download_bytes: 5\n"
+        "llm:\n  model: standard\nweb_fetch:\n  max_download_bytes: 5\n"
     )
 
     cfg = load_config(cwd=tmp_path)
@@ -126,7 +126,7 @@ def test_default_config_leaves_the_response_uncapped_through_a_real_session(
     default (10 MiB), so the same 1000-byte response is NOT capped through
     either builder — the operator config is opt-in, default behaviour
     unchanged by #4274's wiring."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n")
 
     cfg = load_config(cwd=tmp_path)
     assert cfg.web_fetch == WebFetchConfig()

--- a/tests/interfaces/test_3368_mcp_serve_config_anchored_to_project.py
+++ b/tests/interfaces/test_3368_mcp_serve_config_anchored_to_project.py
@@ -33,9 +33,10 @@ from reyn.interfaces.cli.commands.mcp import _anchor_project_root
 from reyn.interfaces.cli.invocation_context import InvocationContext
 
 _PROJECT_YAML = """\
-model: standard
-models:
-  standard: openai/probe-standard-model
+llm:
+  model: standard
+  models:
+    standard: openai/probe-standard-model
 permissions:
   file.read: allow
 """

--- a/tests/interfaces/test_3595_s5_session_does_not_interpret_text.py
+++ b/tests/interfaces/test_3595_s5_session_does_not_interpret_text.py
@@ -232,7 +232,7 @@ def _one_session_registry(tmp_path, monkeypatch) -> "tuple[AgentRegistry, Sessio
     that would run it, which is what lets both legs assert on a real effect."""
     monkeypatch.chdir(tmp_path)
     state_log = StateLog(tmp_path / "state.wal")
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     holder: dict = {}
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None):

--- a/tests/interfaces/test_4235_validate_in_set.py
+++ b/tests/interfaces/test_4235_validate_in_set.py
@@ -42,7 +42,7 @@ def test_an_unknown_in_set_key_is_reported_in_its_own_labeled_section(
     same top-level dict) is reported under the IN-SET section, separately
     from the policy-tier section, with IN-set-specific remedy text (no
     restart, no 'reyn config migrate' mention)."""
-    _write_yaml(project / "reyn.yaml", "model: standard\n")
+    _write_yaml(project / "reyn.yaml", "llm:\n  model: standard\n")
     _write_yaml(
         project / ".reyn" / "config" / "hooks.yaml",
         "totally_bogus_in_set_key: 1\n",
@@ -103,7 +103,7 @@ def test_a_well_formed_in_set_produces_no_findings(project, capsys):
     """Tier 2: accept-side — real, valid IN-set files touching several
     registries never trip the new section (a false positive here would
     teach operators to ignore the report, the same #4174 T0 concern)."""
-    _write_yaml(project / "reyn.yaml", "model: standard\n")
+    _write_yaml(project / "reyn.yaml", "llm:\n  model: standard\n")
     _write_yaml(
         project / ".reyn" / "config" / "mcp.yaml",
         "mcp:\n  servers: {}\n",

--- a/tests/interfaces/test_config_migrate_mcp_command.py
+++ b/tests/interfaces/test_config_migrate_mcp_command.py
@@ -64,7 +64,7 @@ def test_migrate_no_legacy_entries_is_noop(project, capsys):
     """Tier 2: no ``mcp.servers`` anywhere → command prints "nothing to
     migrate" and doesn't write any files.
     """
-    _write_yaml(project / "reyn.yaml", "model: standard\n")
+    _write_yaml(project / "reyn.yaml", "llm:\n  model: standard\n")
 
     _run_migrate()
 
@@ -83,7 +83,7 @@ def test_migrate_moves_reyn_yaml_servers_to_dynamic(project, capsys):
     """
     _write_yaml(
         project / "reyn.yaml",
-        "model: standard\n"
+        "llm:\n  model: standard\n"
         "mcp:\n  servers:\n    sqlite:\n      type: stdio\n      command: npx\n",
     )
 
@@ -97,7 +97,7 @@ def test_migrate_moves_reyn_yaml_servers_to_dynamic(project, capsys):
 
     # Source file no longer has mcp.servers — model stays.
     src = yaml.safe_load((project / "reyn.yaml").read_text())
-    assert src.get("model") == "standard"
+    assert src.get("llm", {}).get("model") == "standard"
     # Empty mcp section dropped entirely.
     assert "mcp" not in src
 
@@ -113,7 +113,7 @@ def test_migrate_moves_from_both_reyn_yaml_and_local(project, capsys):
     """
     _write_yaml(
         project / "reyn.yaml",
-        "model: standard\n"
+        "llm:\n  model: standard\n"
         "mcp:\n  servers:\n    sqlite:\n      type: stdio\n      command: npx\n",
     )
     _write_yaml(
@@ -172,7 +172,7 @@ def test_migrate_dry_run_does_not_write_files(project, capsys):
     """
     _write_yaml(
         project / "reyn.yaml",
-        "model: standard\n"
+        "llm:\n  model: standard\n"
         "mcp:\n  servers:\n    sqlite:\n      type: stdio\n      command: npx\n",
     )
 

--- a/tests/interfaces/test_config_schema_enforcement_1056.py
+++ b/tests/interfaces/test_config_schema_enforcement_1056.py
@@ -14,9 +14,14 @@ remaining enforcement gap:
     default-valued round-trip passes trivially for such a field; a non-default
     value exposes it.
   - **Every** free-form dict leaf accepts an arbitrary sub-key.
-  - The 6 top-level descriptions migrated out of the deleted ``CONFIG_FIELDS``
-    allowlist into ``field(metadata={'desc': ...})`` are preserved (regression
-    guard for the list deletion + metadata migration).
+  - The 6 descriptions migrated out of the deleted ``CONFIG_FIELDS`` allowlist
+    into ``field(metadata={'desc': ...})`` are preserved (regression guard for
+    the list deletion + metadata migration). #4174 T3 moved 3 of the 6
+    (``model`` / ``models`` / ``api_base``) from top-level ``ReynConfig``
+    fields to nested ``LLMConfig`` fields (``llm.model`` etc.) — the guard
+    keys below use the schema-walk's dotted path, and the anchoring test
+    checks each key's OWN dataclass (``ReynConfig`` for the 3 that stayed
+    top-level, ``LLMConfig`` for the 3 that moved), not just ``ReynConfig``.
 
 These iterate the *live* ``walk_config_schema()`` output rather than a
 hardcoded key list, so they auto-extend as config fields are added/removed —
@@ -87,9 +92,9 @@ def _nondefault_candidate(node: SchemaNode) -> object | None:
 # Top-level fields whose human descriptions were migrated from the (now
 # deleted) hand-maintained ``CONFIG_FIELDS`` allowlist into field metadata.
 _MIGRATED_DESC_KEYS = (
-    "model",
-    "models",
-    "api_base",
+    "llm.model",
+    "llm.models",
+    "llm.api_base",
     "output_language",
     "permissions",
 )
@@ -97,7 +102,7 @@ _MIGRATED_DESC_KEYS = (
 
 def _project_root(tmp_path: Path) -> Path:
     """Create a minimal reyn.yaml so _find_project_root / load_config succeed."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     return tmp_path
 
 
@@ -144,7 +149,7 @@ def test_every_scalar_leaf_takes_effect_on_nondefault_set(tmp_path: Path) -> Non
                 continue
             root = tmp_path / f"leaf{i}"
             root.mkdir()
-            (root / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+            (root / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
             os.chdir(root)
             _set(node.key, yaml.safe_dump(cand, default_flow_style=True).strip())
             try:
@@ -229,12 +234,25 @@ def test_migrated_desc_keys_are_real_reynconfig_fields() -> None:
     """Tier 2: the migrated-desc guard list stays anchored to real fields.
 
     Prevents the description guard above from going silently vacuous if a field
-    is renamed — every name in ``_MIGRATED_DESC_KEYS`` must remain a real
-    top-level ``ReynConfig`` field.
+    is renamed — every dotted key in ``_MIGRATED_DESC_KEYS`` must remain a
+    real field on the dataclass its OWN path names: a bare name (no dot) is a
+    top-level ``ReynConfig`` field; a dotted ``llm.<leaf>`` name (#4174 T3:
+    ``model`` / ``models`` / ``api_base`` moved from top-level to nested)
+    must be a real ``LLMConfig`` field instead.
     """
-    field_names = {f.name for f in dataclasses.fields(ReynConfig)}
-    stale = [k for k in _MIGRATED_DESC_KEYS if k not in field_names]
+    from reyn.config import LLMConfig
+
+    reyn_field_names = {f.name for f in dataclasses.fields(ReynConfig)}
+    llm_field_names = {f.name for f in dataclasses.fields(LLMConfig)}
+    stale = []
+    for k in _MIGRATED_DESC_KEYS:
+        if "." in k:
+            prefix, leaf = k.split(".", 1)
+            if prefix != "llm" or leaf not in llm_field_names:
+                stale.append(k)
+        elif k not in reyn_field_names:
+            stale.append(k)
     assert not stale, (
-        f"_MIGRATED_DESC_KEYS names that are no longer ReynConfig fields "
-        f"(update the guard): {stale}"
+        f"_MIGRATED_DESC_KEYS names that are no longer real fields on the "
+        f"dataclass their own path names (update the guard): {stale}"
     )

--- a/tests/interfaces/test_config_schema_introspection.py
+++ b/tests/interfaces/test_config_schema_introspection.py
@@ -33,7 +33,7 @@ from reyn.config.config_schema import (
 
 def _project_root(tmp_path: Path) -> Path:
     """Create a minimal reyn.yaml so _find_project_root succeeds."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     return tmp_path
 
 
@@ -76,8 +76,9 @@ def test_walk_includes_free_form_dict_leaves() -> None:
     """Tier 2: known free-form dict fields are present with is_dict_leaf=True."""
     nodes = walk_config_schema()
     dict_keys = {n.key for n in nodes if n.is_dict_leaf}
-    # permissions, mcp, models are the three documented free-form dicts at top level
-    for expected in ("permissions", "mcp", "models"):
+    # permissions, mcp are top-level free-form dicts; llm.models moved there
+    # from top-level `models` (#4174 T3).
+    for expected in ("permissions", "mcp", "llm.models"):
         assert expected in dict_keys, f"{expected!r} not in dict_leaf keys: {sorted(dict_keys)}"
 
 
@@ -261,13 +262,14 @@ def test_get_nested_key_resolves_correctly(tmp_path: Path, capsys) -> None:
 
 
 def test_get_top_level_scalar(tmp_path: Path, capsys) -> None:
-    """Tier 2: _get('model') prints 'standard'."""
+    """Tier 2: _get('llm.model') prints 'standard' (#4174 T3: moved from
+    top-level `model`)."""
     root = _project_root(tmp_path)
     old_cwd = os.getcwd()
     os.chdir(root)
     try:
         from reyn.interfaces.cli.commands.config import _get
-        _get("model")
+        _get("llm.model")
         captured = capsys.readouterr()
         assert "standard" in captured.out
         assert captured.err == ""

--- a/tests/interfaces/test_config_validate_migrate_command_4174.py
+++ b/tests/interfaces/test_config_validate_migrate_command_4174.py
@@ -46,7 +46,7 @@ def test_validate_reports_no_findings_on_a_well_formed_config(project, capsys):
     category (a well-formed config trips neither)."""
     from reyn.interfaces.cli.commands.config import _validate
 
-    _write_yaml(project / "reyn.yaml", "model: standard\nsandbox:\n  mode: strict\n")
+    _write_yaml(project / "reyn.yaml", "llm:\n  model: standard\nsandbox:\n  mode: strict\n")
     _validate()
     out = capsys.readouterr().out
     assert "No unknown, renamed, or disabled-by-dependency config keys found." in out
@@ -64,16 +64,19 @@ def test_validate_reports_an_unrecognized_top_level_key(project, capsys):
     assert "totally_made_up_top_level_key" in out
 
 
-def test_validate_reports_llm_model_as_a_real_pre_existing_dead_key(project, capsys):
-    """Tier 2: #4174 T0 — architect's confirmed live pre-existing defect
-    (LLMConfig has no `model` field) surfaces through the CLI report too,
-    not just the startup warning — same underlying walk."""
+def test_validate_reports_llm_model_as_known_not_flagged(project, capsys):
+    """Tier 2: #4174 T3 — accept-side, superseding this test's former pre-T3
+    shape (architect's #4174 T0 finding: `LLMConfig` had no `model` field, so
+    `llm: {model: ...}` was silently discarded and flagged unknown by the CLI
+    report too, same walk as the startup warning). T3 gave `LLMConfig` a real
+    `model` field, so the SAME input must now report clean."""
     from reyn.interfaces.cli.commands.config import _validate
 
     _write_yaml(project / "reyn.yaml", "llm:\n  model: standard\n")
     _validate()
     out = capsys.readouterr().out
-    assert "llm.model" in out
+    assert "llm.model" not in out
+    assert "No unknown, renamed, or disabled-by-dependency config keys found." in out
 
 
 def test_validate_subcommand_is_registered():
@@ -111,7 +114,7 @@ def test_migrate_reports_nothing_to_migrate_when_registry_is_empty(
     from reyn.interfaces.cli.commands.config import _migrate
 
     monkeypatch.setattr("reyn.config.config_schema._RENAMED_CONFIG_KEYS", {})
-    _write_yaml(project / "reyn.yaml", "model: standard\n")
+    _write_yaml(project / "reyn.yaml", "llm:\n  model: standard\n")
     _migrate()
     out = capsys.readouterr().out
     assert "No config key renames are registered yet" in out
@@ -133,7 +136,7 @@ def test_migrate_reports_nothing_to_migrate_when_config_has_no_renamed_key(
             note="moved to new_top_level_key", destination="new_top_level_key",
         )},
     )
-    _write_yaml(project / "reyn.yaml", "model: standard\n")
+    _write_yaml(project / "reyn.yaml", "llm:\n  model: standard\n")
     _migrate()
     out = capsys.readouterr().out
     assert "nothing to migrate" in out.lower()
@@ -152,7 +155,7 @@ def test_migrate_rewrites_an_unambiguous_plain_rename(project, capsys, monkeypat
             note="moved to new.nested.key", destination="new.nested.key",
         )},
     )
-    _write_yaml(project / "reyn.yaml", "model: standard\nold_flat_key: hello\n")
+    _write_yaml(project / "reyn.yaml", "llm:\n  model: standard\nold_flat_key: hello\n")
 
     from reyn.interfaces.cli.commands.config import _migrate
     _migrate()

--- a/tests/interfaces/test_dogfood_base_dir_cwd_4204.py
+++ b/tests/interfaces/test_dogfood_base_dir_cwd_4204.py
@@ -29,7 +29,7 @@ def test_base_dir_resolves_to_project_root_from_a_subdirectory(
     """Tier 2: launched from a subdirectory, the dogfood storage dir still
     anchors on the project root (the `reyn.yaml` ancestor), not the
     subdirectory."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     subdir = tmp_path / "src" / "nested"
     subdir.mkdir(parents=True)
     monkeypatch.chdir(subdir)
@@ -44,7 +44,7 @@ def test_runs_and_baselines_dirs_share_the_same_fix(
     """Tier 2: both derived dirs delegate to _dogfood_base_dir(), so they
     inherit the fix — a real witness that the delegation wasn't
     shadowed/duplicated somewhere."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     subdir = tmp_path / "src" / "nested"
     subdir.mkdir(parents=True)
     monkeypatch.chdir(subdir)

--- a/tests/interfaces/test_events_purge_cwd_4204.py
+++ b/tests/interfaces/test_events_purge_cwd_4204.py
@@ -57,7 +57,7 @@ def test_purge_from_a_subdirectory_still_reaches_the_project_events(
     prints "No events directory at <phantom path>" and the real
     `old_file` survives untouched — the exact silent-no-op architect
     named."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     events_dir = tmp_path / ".reyn" / "events"
     old_file = _write_event_file(events_dir, "2026-01-01")
     new_file = _write_event_file(events_dir, "2026-06-01")

--- a/tests/interfaces/test_fp0009_b_web_lifespan.py
+++ b/tests/interfaces/test_fp0009_b_web_lifespan.py
@@ -65,7 +65,7 @@ def _make_bare_app():
 @pytest.mark.asyncio
 async def test_no_cron_block_scheduler_is_none(tmp_path, monkeypatch):
     """Tier 2: lifespan sets cron_scheduler=None when reyn.yaml has no cron: block."""
-    _write_reyn_yaml(tmp_path, "model: standard\n")
+    _write_reyn_yaml(tmp_path, "llm:\n  model: standard\n")
     monkeypatch.chdir(tmp_path)
 
     app = _make_bare_app()
@@ -84,7 +84,7 @@ async def test_empty_cron_jobs_scheduler_is_none(tmp_path, monkeypatch):
     """Tier 2: lifespan sets cron_scheduler=None when cron.jobs is empty."""
     _write_reyn_yaml(
         tmp_path,
-        "model: standard\ncron:\n  jobs: []\n",
+        "llm:\n  model: standard\ncron:\n  jobs: []\n",
     )
     monkeypatch.chdir(tmp_path)
 
@@ -105,7 +105,7 @@ async def test_all_jobs_disabled_scheduler_is_none(tmp_path, monkeypatch):
     _write_reyn_yaml(
         tmp_path,
         (
-            "model: standard\n"
+            "llm:\n  model: standard\n"
             "cron:\n"
             "  jobs:\n"
             "    - name: nightly_disabled\n"
@@ -135,7 +135,7 @@ async def test_enabled_job_scheduler_is_cron_scheduler_instance(tmp_path, monkey
     _write_reyn_yaml(
         tmp_path,
         (
-            "model: standard\n"
+            "llm:\n  model: standard\n"
             "cron:\n"
             "  jobs:\n"
             "    - name: far_future_job\n"
@@ -188,7 +188,7 @@ async def test_shutdown_stops_scheduler(tmp_path, monkeypatch):
     _write_reyn_yaml(
         tmp_path,
         (
-            "model: standard\n"
+            "llm:\n  model: standard\n"
             "cron:\n"
             "  jobs:\n"
             "    - name: stop_test_job\n"
@@ -234,7 +234,7 @@ async def test_run_registry_is_set_in_lifespan(tmp_path, monkeypatch):
     """Tier 2: lifespan sets app.state.run_registry (FP-0001 not regressed by move)."""
     from reyn.interfaces.web.run_registry import RunRegistry
 
-    _write_reyn_yaml(tmp_path, "model: standard\n")
+    _write_reyn_yaml(tmp_path, "llm:\n  model: standard\n")
     monkeypatch.chdir(tmp_path)
 
     app = _make_bare_app()
@@ -270,7 +270,7 @@ async def test_malformed_cron_schedule_does_not_prevent_boot(tmp_path, monkeypat
     _write_reyn_yaml(
         tmp_path,
         (
-            "model: standard\n"
+            "llm:\n  model: standard\n"
             "cron:\n"
             "  jobs:\n"
             "    - name: bad_job\n"

--- a/tests/interfaces/test_litellm_api_base_load_config_seam_2683.py
+++ b/tests/interfaces/test_litellm_api_base_load_config_seam_2683.py
@@ -56,13 +56,13 @@ def test_invocation_context_seam_still_exports_api_base() -> None:
     api_base = "http://localhost:4000/reyn-2683-seam"
     with TemporaryDirectory() as td:
         project = Path(td)
-        (project / "reyn.yaml").write_text(f"api_base: {api_base}\n", encoding="utf-8")
+        (project / "reyn.yaml").write_text(f"llm:\n  api_base: {api_base}\n", encoding="utf-8")
         with _clean_env_and_cwd(project):
             # Real seam, no mock: from_args → load_config() → the single writer.
             ctx = InvocationContext.from_args(argparse.Namespace())
             # Config carries the value AND the env var was materialized — proving
             # the removed inline copy's job is now done by load_config().
-            assert ctx.config.api_base == api_base
+            assert ctx.config.llm.api_base == api_base
             assert os.environ.get(_KEY) == api_base
 
 
@@ -70,9 +70,9 @@ def test_absent_api_base_leaves_env_unset() -> None:
     """Tier 2: no api_base configured → the seam leaves LITELLM_API_BASE unset."""
     with TemporaryDirectory() as td:
         project = Path(td)
-        (project / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+        (project / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
         with _clean_env_and_cwd(project):
             ctx = InvocationContext.from_args(argparse.Namespace())
-            assert not ctx.config.api_base
+            assert not ctx.config.llm.api_base
             # The ``if _api_base`` guard means no empty/spurious export.
             assert _KEY not in os.environ

--- a/tests/interfaces/test_memory_cli_project_root_3716.py
+++ b/tests/interfaces/test_memory_cli_project_root_3716.py
@@ -47,7 +47,7 @@ def test_project_reyn_root_walks_up_to_the_real_project_root(tmp_path, monkeypat
     not fabricate one under the subdirectory."""
     project_root = tmp_path / "my-project"
     (project_root / "src" / "deep" / "subdir").mkdir(parents=True)
-    (project_root / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (project_root / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     monkeypatch.chdir(project_root / "src" / "deep" / "subdir")
 
     assert _project_reyn_root() == project_root / ".reyn"
@@ -61,7 +61,7 @@ def test_layer_dir_uses_the_project_root_not_raw_cwd(tmp_path, monkeypatch):
     project_root = tmp_path / "my-project"
     subdir = project_root / "some" / "nested" / "cwd"
     subdir.mkdir(parents=True)
-    (project_root / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (project_root / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     monkeypatch.chdir(subdir)
 
     args = argparse.Namespace(agent=None)

--- a/tests/interfaces/test_reyn_embeddings_cli.py
+++ b/tests/interfaces/test_reyn_embeddings_cli.py
@@ -171,7 +171,7 @@ def test_status_from_a_subdirectory_still_reads_the_project_index(
     real ``run_status`` CLI dispatch (not the pure ``_collect_status_rows``
     helper other tests here call directly), so it exercises the actual
     defect site."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     _write_index_db(
         _unified_index_dir(tmp_path),
         class_name="light",

--- a/tests/interfaces/test_web_auth_lifespan_wiring.py
+++ b/tests/interfaces/test_web_auth_lifespan_wiring.py
@@ -32,7 +32,7 @@ async def test_lifespan_builds_auth_context_from_configured_token(tmp_path, monk
     monkeypatch.delenv(TOKEN_ENV_VAR, raising=False)
     _write_reyn_yaml(
         tmp_path,
-        "model: standard\ngateway:\n  auth:\n    token: operator-configured-secret\n",
+        "llm:\n  model: standard\ngateway:\n  auth:\n    token: operator-configured-secret\n",
     )
     monkeypatch.chdir(tmp_path)
 
@@ -54,7 +54,7 @@ async def test_lifespan_generates_token_when_none_configured(tmp_path, monkeypat
     unauthenticated instead of gated).
     """
     monkeypatch.delenv(TOKEN_ENV_VAR, raising=False)
-    _write_reyn_yaml(tmp_path, "model: standard\n")
+    _write_reyn_yaml(tmp_path, "llm:\n  model: standard\n")
     monkeypatch.chdir(tmp_path)
 
     from reyn.interfaces.web.server import _lifespan

--- a/tests/interfaces/test_web_run_dir_cwd_4204.py
+++ b/tests/interfaces/test_web_run_dir_cwd_4204.py
@@ -31,7 +31,7 @@ def test_uds_run_dir_created_at_the_project_root_from_a_subdirectory(
     UDS mode is the minimal path to isolate this (no token generation, no
     TLS provisioning branch to also stand up) — `_apply_auth_startup`
     returns early right after `run_dir.mkdir()` for a UDS bind."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     subdir = tmp_path / "src" / "nested"
     subdir.mkdir(parents=True)
     monkeypatch.chdir(subdir)

--- a/tests/interfaces/test_web_scoped_capabilities_1401.py
+++ b/tests/interfaces/test_web_scoped_capabilities_1401.py
@@ -162,7 +162,7 @@ def test_factory_threads_holder_to_build_scoped_chat_session():
 
 
 def _write_reyn_yaml(tmp_path: Path, *, permissions: dict | None = None) -> None:
-    lines = ["model: standard"]
+    lines = ["llm:\n  model: standard"]
     if permissions is not None:
         lines.append("permissions:")
         for key, value in permissions.items():

--- a/tests/llm/test_model_class_by_purpose_1672.py
+++ b/tests/llm/test_model_class_by_purpose_1672.py
@@ -12,11 +12,12 @@ No mocks: real `ReynConfig` / `ModelResolver` instances + `load_config` round-tr
 """
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
 
 import pytest
 
-from reyn.config import ReynConfig, load_config
+from reyn.config import LLMConfig, ReynConfig, load_config
 from reyn.llm.model_resolver import ModelResolver, resolve_purpose_class
 
 # ── ReynConfig.model_class_for ─────────────────────────────────────────────────
@@ -25,7 +26,9 @@ from reyn.llm.model_resolver import ModelResolver, resolve_purpose_class
 def test_config_unset_purpose_follows_model() -> None:
     """Tier 2: #1672 — an unset purpose falls back to `model` (the configured
     main) — the owner's default: routing follows the configured model."""
-    cfg = ReynConfig(model="strong", model_class_by_purpose={})
+    cfg = dataclasses.replace(
+        ReynConfig(), llm=LLMConfig(model="strong", model_class_by_purpose={}),
+    )
     assert cfg.model_class_for("router") == "strong"
     assert cfg.model_class_for("control_ir") == "strong"
 
@@ -33,7 +36,10 @@ def test_config_unset_purpose_follows_model() -> None:
 def test_config_override_wins() -> None:
     """Tier 2: #1672 — a per-purpose override wins over `model` (the explicit
     cheap-router opt-in)."""
-    cfg = ReynConfig(model="strong", model_class_by_purpose={"router": "light"})
+    cfg = dataclasses.replace(
+        ReynConfig(),
+        llm=LLMConfig(model="strong", model_class_by_purpose={"router": "light"}),
+    )
     assert cfg.model_class_for("router") == "light"
     # other purposes still follow `model`
     assert cfg.model_class_for("judge") == "strong"
@@ -93,19 +99,22 @@ def _write(path: Path, text: str) -> None:
 
 def test_yaml_round_trip_non_default(tmp_path, monkeypatch) -> None:
     """Tier 2: #1672 — model_class_by_purpose parses from reyn.yaml (a NON-default
-    value pins the parser wiring, not a trivial empty round-trip)."""
+    value pins the parser wiring, not a trivial empty round-trip).
+
+    #4174 T3: model/models/model_class_by_purpose moved under `llm:`."""
     monkeypatch.chdir(tmp_path)
     _write(tmp_path / "reyn.yaml", """
-model: strong
-models:
-  strong: gemini/gemini-2.5-pro
-  light: openai/gpt-4o-mini
-model_class_by_purpose:
-  router: light
-  control_ir: strong
+llm:
+  model: strong
+  models:
+    strong: gemini/gemini-2.5-pro
+    light: openai/gpt-4o-mini
+  model_class_by_purpose:
+    router: light
+    control_ir: strong
 """.lstrip())
     cfg = load_config(cwd=tmp_path)
-    assert cfg.model_class_by_purpose == {"router": "light", "control_ir": "strong"}
+    assert cfg.llm.model_class_by_purpose == {"router": "light", "control_ir": "strong"}
     # And the helper resolves through it.
     assert cfg.model_class_for("router") == "light"
     assert cfg.model_class_for("compaction") == "strong"  # unset → model
@@ -118,13 +127,14 @@ def test_yaml_unknown_purpose_warns_but_loads(tmp_path, monkeypatch, caplog) -> 
 
     monkeypatch.chdir(tmp_path)
     _write(tmp_path / "reyn.yaml", """
-model: standard
-model_class_by_purpose:
-  rooter: light
+llm:
+  model: standard
+  model_class_by_purpose:
+    rooter: light
 """.lstrip())
     with caplog.at_level(logging.WARNING):
         cfg = load_config(cwd=tmp_path)
-    assert "rooter" in cfg.model_class_by_purpose  # preserved (not dropped)
+    assert "rooter" in cfg.llm.model_class_by_purpose  # preserved (not dropped)
     assert any("rooter" in r.getMessage() and "purpose" in r.getMessage()
                for r in caplog.records), "expected a typo warning naming the bad key"
 
@@ -143,9 +153,10 @@ def test_yaml_compaction_purpose_key_refuses_to_load(tmp_path, monkeypatch) -> N
     """
     monkeypatch.chdir(tmp_path)
     _write(tmp_path / "reyn.yaml", """
-model: standard
-model_class_by_purpose:
-  compaction: strong
+llm:
+  model: standard
+  model_class_by_purpose:
+    compaction: strong
 """.lstrip())
     with pytest.raises(ValueError, match="model_class_by_purpose.compaction"):
         load_config(cwd=tmp_path)

--- a/tests/llm/test_model_resolver.py
+++ b/tests/llm/test_model_resolver.py
@@ -216,17 +216,20 @@ def test_is_known_class_mixed_mapping():
 
 
 def test_reyn_config_models_accepts_dict_form():
-    """Tier 2: ReynConfig.models field allows dict-form values through config layer."""
-    from reyn.config import ReynConfig
-    cfg = ReynConfig(models={
+    """Tier 2: ReynConfig.llm.models field allows dict-form values through
+    config layer (#4174 T3: moved from top-level `.models`)."""
+    import dataclasses
+
+    from reyn.config import LLMConfig, ReynConfig
+    cfg = dataclasses.replace(ReynConfig(), llm=LLMConfig(models={
         "light": "openai/gemini-2.5-flash-lite",
         "strong": {
             "model": "anthropic/claude-3-7-sonnet",
             "temperature": 0.0,
             "extra_body": {"thinking": {"type": "enabled", "budget_tokens": 8000}},
         },
-    })
-    r = ModelResolver(cfg.models)
+    }))
+    r = ModelResolver(cfg.llm.models)
     light_spec = r.resolve("light")
     assert light_spec.model == "openai/gemini-2.5-flash-lite"
     assert light_spec.kwargs == {}
@@ -345,7 +348,7 @@ def test_partial_tier_declaration_warns_naming_tier_and_its_fallback_model(
     )
 
     # (c) tells the operator what to write to take control.
-    assert "reyn.yaml" in msg and "models:" in msg
+    assert "reyn.yaml" in msg and "llm.models:" in msg
     assert f"{omitted}: {fallback_model}" in msg, (
         f"warning must include a copy-pasteable `{omitted}: <model>` line: {msg}"
     )

--- a/tests/llm/test_stream_key_rejected_at_config_load_3627.py
+++ b/tests/llm/test_stream_key_rejected_at_config_load_3627.py
@@ -90,18 +90,23 @@ def test_a_model_class_stream_field_is_accepted_and_consumed():
 def test_the_stream_field_survives_the_reyn_config_models_layer():
     """Tier 1: it arrives through the real ``reyn.local.yaml`` load path.
 
-    Asserted through ``ReynConfig.models`` -> ``ModelResolver`` rather than a
-    hand-built mapping, because an operator writes YAML — a field that parsed
-    in isolation but was dropped by the config layer would look identical from
-    a unit test and do nothing in a real run.
+    Asserted through ``ReynConfig.llm.models`` -> ``ModelResolver`` rather than
+    a hand-built mapping, because an operator writes YAML — a field that
+    parsed in isolation but was dropped by the config layer would look
+    identical from a unit test and do nothing in a real run.
+
+    #4174 T3: ``models`` moved from a top-level ``ReynConfig`` field to
+    ``ReynConfig.llm.models``.
     """
-    from reyn.config import ReynConfig
+    import dataclasses
 
-    cfg = ReynConfig(models={
+    from reyn.config import LLMConfig, ReynConfig
+
+    cfg = dataclasses.replace(ReynConfig(), llm=LLMConfig(models={
         "gpt-5.6-luna": {"model": "gpt-5.6-luna", "stream": True},
-    })
+    }))
 
-    spec = ModelResolver(cfg.models).resolve("gpt-5.6-luna")
+    spec = ModelResolver(cfg.llm.models).resolve("gpt-5.6-luna")
 
     assert spec.stream is True
     assert "stream" not in spec.kwargs

--- a/tests/mcp/test_2597_s2a_mcp_connection_service.py
+++ b/tests/mcp/test_2597_s2a_mcp_connection_service.py
@@ -207,7 +207,7 @@ async def test_remove_session_teardown_closes_held_connections(tmp_path: Path):
     from reyn.runtime.registry import AgentRegistry
     from reyn.runtime.session import Session
 
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     cfg_path = tmp_path / ".reyn" / "config" / "mcp.yaml"
     cfg_path.parent.mkdir(parents=True, exist_ok=True)
     cfg_path.write_text(yaml.safe_dump({"mcp": {"servers": {"srv": _CFG}}}), encoding="utf-8")

--- a/tests/runtime/test_2548_skill_hotreload_toggle_pr_b.py
+++ b/tests/runtime/test_2548_skill_hotreload_toggle_pr_b.py
@@ -42,7 +42,7 @@ def _make_session(tmp_path: Path, *, agent_name: str = "test-agent") -> Session:
     Builds ``available_skills`` from ``load_config`` so that skills declared in
     ``.reyn/config/skills.yaml`` (written before this call) are included — mirroring
     what ``SessionFactoryConfig.from_config`` does in production."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     from reyn.config.loader import load_config
     from reyn.data.skills.registry import build_skill_registry
     cfg = load_config()
@@ -158,7 +158,7 @@ async def test_hotreload_noop_when_skills_unchanged(
 @pytest.mark.asyncio
 async def test_hotreload_seam_registered(tmp_path: Path) -> None:
     """Tier 2: the Session registers the skills seam on the HotReloader."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     session = make_session(
         agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
         snapshot_path=tmp_path / "snap.json",

--- a/tests/runtime/test_2548_skill_registry_pr_a.py
+++ b/tests/runtime/test_2548_skill_registry_pr_a.py
@@ -289,7 +289,7 @@ def test_merge_skills_base_survives_when_override_has_no_skills() -> None:
 
 def test_load_config_reads_dynamic_skills_yaml(tmp_path: Path) -> None:
     """Tier 1: load_config reads .reyn/config/skills.yaml as the dynamic skills layer."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     skills_cfg_dir = tmp_path / ".reyn" / "config"
     skills_cfg_dir.mkdir(parents=True)
     (skills_cfg_dir / "skills.yaml").write_text(
@@ -311,7 +311,7 @@ def test_load_config_reads_dynamic_skills_yaml(tmp_path: Path) -> None:
 def test_load_config_skills_explicit_wins_over_dynamic_layer(tmp_path: Path) -> None:
     """Tier 1: explicit skills in reyn.yaml survive + later dynamic layer entry wins on collision."""
     (tmp_path / "reyn.yaml").write_text(
-        "model: standard\n"
+        "llm:\n  model: standard\n"
         "skills:\n  entries:\n"
         "    static-skill:\n      path: skills/static/SKILL.md\n      description: from reyn.yaml\n"
         "    shared:\n      path: skills/shared-static/SKILL.md\n      description: static version\n",
@@ -489,7 +489,7 @@ def test_e2e_config_to_system_prompt_universal_scheme(tmp_path: Path) -> None:
     from reyn.runtime.router_system_prompt import build_system_prompt
 
     (tmp_path / "reyn.yaml").write_text(
-        "model: standard\n"
+        "llm:\n  model: standard\n"
         "skills:\n  entries:\n"
         "    pdf-filler:\n      path: skills/pdf-filler/SKILL.md\n"
         "      description: Fill PDF forms from structured data\n",
@@ -535,7 +535,7 @@ def test_e2e_retrieval_scheme_does_not_clobber_skills_block(tmp_path: Path) -> N
     from reyn.tools.schemes.retrieval import RetrievalScheme
 
     (tmp_path / "reyn.yaml").write_text(
-        "model: standard\n"
+        "llm:\n  model: standard\n"
         "skills:\n  entries:\n"
         "    data-cleaner:\n      path: skills/data-cleaner/SKILL.md\n"
         "      description: Normalize and dedupe tabular data\n",
@@ -585,7 +585,7 @@ def test_e2e_enumerate_scheme_threads_skills(tmp_path: Path) -> None:
     from reyn.runtime.router_system_prompt import build_system_prompt
 
     (tmp_path / "reyn.yaml").write_text(
-        "model: standard\n"
+        "llm:\n  model: standard\n"
         "skills:\n  entries:\n"
         "    linter:\n      path: skills/linter/SKILL.md\n"
         "      description: Run project linters and summarize findings\n",
@@ -617,7 +617,7 @@ def test_e2e_no_skills_config_omits_section(tmp_path: Path) -> None:
     """Tier 2: a config with no skills → registry empty → SP has no ## Skills section."""
     from reyn.runtime.router_system_prompt import build_system_prompt
 
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     old = os.getcwd()
     os.chdir(tmp_path)
     try:

--- a/tests/runtime/test_3036_spawned_session_mcp_refresh.py
+++ b/tests/runtime/test_3036_spawned_session_mcp_refresh.py
@@ -64,7 +64,7 @@ def _make_registry(tmp_path: Path) -> AgentRegistry:
     (main + every programmatic spawn) starts with this EMPTY snapshot; only the fix
     under test (a spawn-time `refresh_mcp_servers()` call) can make a freshly
     spawned session see a server installed after the registry was built."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     state_log = StateLog(tmp_path / "wal.jsonl")
     holder: dict = {}
 

--- a/tests/runtime/test_3093_pipeline_registry_spawn_propagation.py
+++ b/tests/runtime/test_3093_pipeline_registry_spawn_propagation.py
@@ -108,7 +108,7 @@ def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
     from reyn.data.pipelines.registry import build_pipeline_registry
 
     if not (tmp_path / "reyn.yaml").exists():
-        (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+        (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     holder: dict = {}
     frozen_registry = build_pipeline_registry(load_config(tmp_path).pipelines, tmp_path)
 

--- a/tests/runtime/test_3097_config_projection_refresh_family_gate.py
+++ b/tests/runtime/test_3097_config_projection_refresh_family_gate.py
@@ -60,7 +60,7 @@ def _make_registry(tmp_path: Path) -> AgentRegistry:
     boot-time closure — captures every projection ONCE (empty/default), before any
     install writes fresher config. Only a spawn-time refresh can make a freshly
     spawned session see config written after the registry was built."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     state_log = StateLog(tmp_path / "wal.jsonl")
     holder: dict = {}
 
@@ -88,7 +88,7 @@ async def test_vacuity_guard_registered_seams_nonempty(tmp_path: Path, monkeypat
     hot-reload seams (a completeness gate over an accidentally-empty set would be
     trivially, uselessly green)."""
     monkeypatch.chdir(tmp_path)
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     session = make_session(
         agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
         snapshot_path=tmp_path / "snap.json",
@@ -111,7 +111,7 @@ async def test_refresh_config_projections_covers_every_registered_seam_except_cr
     coverage is structural (derives from the SAME registry), not a maintained
     marker list that a future addition could silently miss."""
     monkeypatch.chdir(tmp_path)
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     session = make_session(
         agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
         snapshot_path=tmp_path / "snap.json",
@@ -152,7 +152,7 @@ async def test_cron_excluded_from_family_gate(tmp_path: Path, monkeypatch) -> No
     active filter, not a no-op that happens to never see cron for some other
     reason."""
     monkeypatch.chdir(tmp_path)
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     session = make_session(
         agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
         snapshot_path=tmp_path / "snap.json",

--- a/tests/runtime/test_3546_pipeline_driver_narrowing_inheritance.py
+++ b/tests/runtime/test_3546_pipeline_driver_narrowing_inheritance.py
@@ -170,7 +170,7 @@ def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
     """Real ``AgentRegistry`` + real ``Session`` factory (the harness shape
     ``tests/runtime/test_3093_pipeline_registry_spawn_propagation.py`` uses)."""
     if not (tmp_path / "reyn.yaml").exists():
-        (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+        (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     holder: dict = {}
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:

--- a/tests/runtime/test_3553_agent_step_worker_narrowing_inheritance.py
+++ b/tests/runtime/test_3553_agent_step_worker_narrowing_inheritance.py
@@ -112,7 +112,7 @@ def _registry(tmp_path: Path, scripted: "_WritesOnceLLM") -> AgentRegistry:
     real ``PermissionResolver`` (with ``file.write`` approved, so a denial observed
     below is the capability narrowing and not the write gate)."""
     if not (tmp_path / "reyn.yaml").exists():
-        (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+        (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     holder: dict = {}
     resolver = ModelResolver({"standard": "gemini/gemini-2.5-flash-lite"})

--- a/tests/runtime/test_3556_session_spawn_narrowing_inheritance.py
+++ b/tests/runtime/test_3556_session_spawn_narrowing_inheritance.py
@@ -151,7 +151,7 @@ def _registry(tmp_path: Path, scripted: "_WritesOnceLLM") -> AgentRegistry:
     ``PermissionResolver`` (with ``file.write`` approved, so a denial observed below is
     the capability narrowing and not the write gate)."""
     if not (tmp_path / "reyn.yaml").exists():
-        (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+        (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     holder: dict = {}
     resolver = ModelResolver({"standard": "gemini/gemini-2.5-flash-lite"})

--- a/tests/runtime/test_3561_spawn_session_seam_reachability.py
+++ b/tests/runtime/test_3561_spawn_session_seam_reachability.py
@@ -153,7 +153,7 @@ def _registry(
     auto-vanish, and its real-litellm-name resolver so a spawned session's
     model-support pre-check has a name to resolve."""
     if not (tmp_path / "reyn.yaml").exists():
-        (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+        (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     holder: dict = {}
     resolver = ModelResolver({"standard": "gemini/gemini-2.5-flash-lite"})

--- a/tests/runtime/test_3562_slash_session_new_narrowing_inheritance.py
+++ b/tests/runtime/test_3562_slash_session_new_narrowing_inheritance.py
@@ -157,7 +157,7 @@ def _registry(tmp_path: Path, scripted: "_WritesOnceLLM") -> AgentRegistry:
     un-narrowed control.
     """
     if not (tmp_path / "reyn.yaml").exists():
-        (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+        (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     holder: dict = {}
     resolver = ModelResolver({"standard": "gemini/gemini-2.5-flash-lite"})

--- a/tests/runtime/test_3595_s2_pipeline_nudge_origin.py
+++ b/tests/runtime/test_3595_s2_pipeline_nudge_origin.py
@@ -104,7 +104,7 @@ async def test_a_pipeline_nudge_turn_cannot_execute_a_slash_command(
     """
     monkeypatch.chdir(tmp_path)
     state_log = StateLog(tmp_path / "state.wal")
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     holder: dict = {}
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:

--- a/tests/runtime/test_3595_step1b_external_producer_slash_reachability.py
+++ b/tests/runtime/test_3595_step1b_external_producer_slash_reachability.py
@@ -111,7 +111,7 @@ def _registry(
     real-litellm-name resolver so a spawned session's model-support pre-check has a
     name to resolve."""
     if not (tmp_path / "reyn.yaml").exists():
-        (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+        (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     holder: dict = {}
     resolver = ModelResolver({"standard": "gemini/gemini-2.5-flash-lite"})

--- a/tests/runtime/test_3793_stage2_agui_decoupled_and_is_attached_removed.py
+++ b/tests/runtime/test_3793_stage2_agui_decoupled_and_is_attached_removed.py
@@ -178,7 +178,7 @@ async def test_real_agui_endpoint_boot_does_not_touch_registry_focus(tmp_path, m
 
     monkeypatch.chdir(tmp_path)
     state_log = StateLog(tmp_path / "state.wal")
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None):
         return make_session(

--- a/tests/runtime/test_4200_2_spawn_time_base_dir_write.py
+++ b/tests/runtime/test_4200_2_spawn_time_base_dir_write.py
@@ -40,7 +40,7 @@ async def _registry_with_live_parent(
     style — the registry's own agent-level "main" session is a
     non-loading accessor and is never auto-constructed by ``create()``
     alone, so a genuinely-live spawner needs to come from a real spawn)."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     holder: dict = {}
 

--- a/tests/runtime/test_4200_session_base_dir_resolution.py
+++ b/tests/runtime/test_4200_session_base_dir_resolution.py
@@ -162,7 +162,7 @@ async def test_a_spawned_childs_op_context_resolves_the_childs_own_override_not_
     child's op-context would resolve the PARENT's base_dir instead."""
     project_root = tmp_path / "project"
     (project_root / "reyn.yaml").parent.mkdir(parents=True, exist_ok=True)
-    (project_root / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (project_root / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     state_log = StateLog(project_root / ".reyn" / "wal.jsonl")
     parent_base_dir = tmp_path / "parent-base-dir"
     parent_base_dir.mkdir(parents=True)

--- a/tests/runtime/test_4244_pipeline_hooks_add_denied.py
+++ b/tests/runtime/test_4244_pipeline_hooks_add_denied.py
@@ -56,7 +56,7 @@ from tests._support.agent_session import make_session
 
 
 def _registry(tmp_path: Path) -> AgentRegistry:
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     holder: dict = {}
 

--- a/tests/runtime/test_fp0041_prb_cron_message_shape.py
+++ b/tests/runtime/test_fp0041_prb_cron_message_shape.py
@@ -165,7 +165,7 @@ def test_load_config_reads_dynamic_cron_yaml(tmp_path, monkeypatch):
     """
     from reyn.config import load_config
 
-    _write_yaml(tmp_path / "reyn.yaml", "model: standard\n")
+    _write_yaml(tmp_path / "reyn.yaml", "llm:\n  model: standard\n")
     _write_yaml(
         tmp_path / ".reyn" / "config" / "cron.yaml",
         "cron:\n  jobs:\n"
@@ -190,7 +190,7 @@ def test_load_config_unions_legacy_and_dynamic_cron_jobs(tmp_path, monkeypatch):
 
     _write_yaml(
         tmp_path / "reyn.yaml",
-        "model: standard\n"
+        "llm:\n  model: standard\n"
         "cron:\n  jobs:\n"
         "    - name: static_job\n      to: static_agent\n      message: run\n"
         "      schedule: '0 * * * *'\n",
@@ -220,7 +220,7 @@ def test_load_config_dynamic_cron_yaml_overrides_legacy_on_name_collision(
 
     _write_yaml(
         tmp_path / "reyn.yaml",
-        "model: standard\n"
+        "llm:\n  model: standard\n"
         "cron:\n  jobs:\n"
         "    - name: shared\n      to: old_agent\n      message: old message\n"
         "      schedule: '0 * * * *'\n",
@@ -251,7 +251,7 @@ def test_load_config_works_without_dynamic_cron_yaml(tmp_path, monkeypatch):
 
     _write_yaml(
         tmp_path / "reyn.yaml",
-        "model: standard\n"
+        "llm:\n  model: standard\n"
         "cron:\n  jobs:\n"
         "    - name: static_only\n      to: some_agent\n      message: run\n"
         "      schedule: '0 * * * *'\n",

--- a/tests/runtime/test_fp0041_prd2_outbox_interceptor.py
+++ b/tests/runtime/test_fp0041_prd2_outbox_interceptor.py
@@ -366,7 +366,7 @@ def test_reyn_config_external_transports_defaults_to_empty(tmp_path, monkeypatch
     """
     from reyn.config import load_config
 
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
     cfg = load_config(cwd=tmp_path)
 
@@ -384,7 +384,7 @@ def test_reyn_config_external_transports_parses_well_formed_yaml(
     from reyn.config import load_config
 
     (tmp_path / "reyn.yaml").write_text(
-        "model: standard\n"
+        "llm:\n  model: standard\n"
         "external_transports:\n"
         "  slack:\n"
         "    mcp_tool: slack__chat_postMessage\n"

--- a/tests/runtime/test_list_mcp_servers_canonical_shape.py
+++ b/tests/runtime/test_list_mcp_servers_canonical_shape.py
@@ -34,7 +34,7 @@ from tests._support.agent_session import make_session
 
 
 def _session(tmp_path: Path) -> Session:
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     (tmp_path / "reyn.local.yaml").write_text(
         "mcp:\n  servers:\n"
         "    s1:\n      command: /usr/bin/true\n      description: server 1\n"

--- a/tests/runtime/test_plugin_slash_surface.py
+++ b/tests/runtime/test_plugin_slash_surface.py
@@ -89,7 +89,7 @@ def _make_session(
     writes OUTSIDE the workspace (``~/.reyn/plugins/``), so exercising that
     path for real requires the operator-equivalent explicit
     ``sandbox.policy.write_paths`` grant, supplied here."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     session = make_session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),

--- a/tests/security/test_fp0016_c_auth_config.py
+++ b/tests/security/test_fp0016_c_auth_config.py
@@ -269,7 +269,7 @@ auth:
 def test_load_config_without_auth_block_uses_defaults(tmp_path: Path) -> None:
     """Tier 2: omitting auth: block in reyn.yaml → empty AuthConfig."""
     (tmp_path / "reyn.yaml").write_text(
-        "model: standard\n",
+        "llm:\n  model: standard\n",
         encoding="utf-8",
     )
 

--- a/tests/web/test_auth_gate_middleware.py
+++ b/tests/web/test_auth_gate_middleware.py
@@ -54,7 +54,7 @@ def _reset_singletons() -> None:
 @pytest.fixture()
 def tmp_project(tmp_path: Path) -> Path:
     """A minimal project root so the real budget/config/registry deps resolve."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     agent_dir = tmp_path / ".reyn" / "agents" / "default"
     agent_dir.mkdir(parents=True)
     (agent_dir / "profile.yaml").write_text(

--- a/tests/web/test_openui_shell.py
+++ b/tests/web/test_openui_shell.py
@@ -37,7 +37,7 @@ httpx = pytest.importorskip("httpx", reason="httpx not installed (needed by Test
 def tmp_project(tmp_path: Path) -> Path:
     """Minimal project root with one agent, one local design, and reyn.yaml."""
     # reyn.yaml
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
 
     # Agent
     agents_dir = tmp_path / ".reyn" / "agents" / "default"

--- a/tests/web/test_resources_router.py
+++ b/tests/web/test_resources_router.py
@@ -50,7 +50,7 @@ def tmp_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     agents_dir = reyn_dir / "agents" / "researcher"
     agents_dir.mkdir(parents=True)
 
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     (agents_dir / "profile.yaml").write_text(
         "name: researcher\nrole: ''\ncreated_at: '2026-01-01T00:00:00+00:00'\n",
         encoding="utf-8",

--- a/tests/web/test_smoke.py
+++ b/tests/web/test_smoke.py
@@ -98,7 +98,7 @@ def tmp_project(tmp_path: Path) -> Path:
     agents_dir.mkdir(parents=True)
 
     # Minimal reyn.yaml so _find_project_root() matches this directory.
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
 
     # Minimal agent profile.
     (agents_dir / "profile.yaml").write_text(

--- a/tests/web/test_surface_registry.py
+++ b/tests/web/test_surface_registry.py
@@ -67,7 +67,7 @@ def _restore_server_singleton():
 @pytest.fixture()
 def tmp_project(tmp_path: Path) -> Path:
     """A minimal project root so the real budget/config/registry deps resolve."""
-    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
     agent_dir = tmp_path / ".reyn" / "agents" / "default"
     agent_dir.mkdir(parents=True)
     (agent_dir / "profile.yaml").write_text(


### PR DESCRIPTION
**[tui-coder]** — #4174 T3: consolidate the LLM domain (`model` / `models` / `model_class_by_purpose` / `api_base` / `prompt_cache_enabled`) into the existing `llm:` block.

Closes #4174.

## What

Plain rename, same shapes — each field just moves under `llm:` (which already held `llm.router`/`llm.retry`, #1829/#1835). Registered as 5 `RenamedKeyHint` entries with `destination=` set, so `reyn config migrate` auto-rewrites all 5 automatically. **No compatibility layer, no dual-read path** (condition ④): the old top-level keys become unrecognized/reported by `reyn config validate`, never silently accepted alongside the new location.

`LLMConfig` (`infra.py`) grows the 5 fields, plus `MODEL_CLASS_PURPOSES` / `_build_model_class_by_purpose` (moved here from `root.py`). `_build_llm_config` parses all of it from the single `llm:` raw dict. `ReynConfig.model_class_for()` keeps its exact public signature/behavior — only its internal reads move to `self.llm.*`. `loader.py`'s `_merge()` gained an `llm.models` shallow-merge branch mirroring the old top-level `models:` special-case (a project tier adding one model class must not drop a user-global class it didn't mention) — `model_class_by_purpose` intentionally does **not** get this treatment (matches its pre-T3 full-override-per-tier behavior).

**Real, live-checked end-to-end**: `reyn config validate` → `reyn config migrate` → re-`validate` → `reyn config get llm.model` all verified against a scratch project with all 5 old keys set.

## Production call sites (condition ② — T4's lesson applied)

~31 `src/` call sites updated (`registry_bootstrap.py`, `invocation_context.py`, `cli/commands/{config,dogfood,chat,mcp}.py`, `web/deps.py`, `model_resolver.py`'s own docstrings/messages). **Two `getattr(cfg, "model"/"models"/"api_base", ...)`-shaped sites in `support_bundle.py`** — structurally invisible to any `config.model`-style grep, the same class T4's two `getattr(config, "web", None)` sites were. Found by directly auditing every getattr-shaped call site the reference-enumeration subagent flagged up front, not by the regression sweep this time (both are metadata-only informational fields with zero test coverage that would have caught a silent break otherwise).

The **full** `tests/core/ tests/runtime/ tests/interfaces/ tests/web/ tests/llm/ tests/config/ tests/scripts/` regression sweep (not a grep-scoped subset) caught one more real site grep/enumeration missed: `test_3368_mcp_serve_config_anchored_to_project.py` wrote a top-level `model:`/`models:` fixture whose value the test actually asserts on (a bare-class-name passthrough vs. the project's real `models:` map) — fixed to the `llm.*` shape.

## Tests

- 3 constructor-kwarg / `.model_class_by_purpose` direct-access test files updated: `dataclasses.replace(ReynConfig(), llm=LLMConfig(...))` instead of `ReynConfig(model=...)` directly, since these 5 fields are no longer top-level `ReynConfig` kwargs.
- ~15 functional tests updated to the `llm.*` shape (config cascade, malformed-loader guards, pipe-proxy `LITELLM_API_BASE` bootstrap, T0 unknown-key warn — including **flipping** `test_llm_model_is_flagged_as_a_real_pre_existing_dead_key` to its accept-side mirror now that `llm.model` is a real, populated field, not a dead one — CLI schema introspection/enforcement, mcp-serve project-anchoring).
- `test_config_schema_enforcement_1056.py`'s two `CONFIG_FIELDS`-migrated-desc guard tests needed re-anchoring: `model`/`models`/`api_base`'s operator-facing `desc` metadata moved from `ReynConfig field(...)` onto the equivalent `LLMConfig field(...)` — **a real regression this test caught**: these 3 fields would otherwise have silently lost their `reyn config fields` description entirely.
- 60 test files' `model: standard` yaml-fixture boilerplate (pure filler to make a fixture non-empty; none of them assert on the value) renested under `llm:` in the same PR — the mechanical part, per lead-coder's framing during review ("if 60 files hand-write the same fixture, the next config rename rewrites the same 60 sites again"). Consolidating into a shared fixture helper is deferred to **#4284** (filed this session) rather than bundled into an already-large diff — the ③ decision (mechanical rewrite now, consolidation later, tracked separately, not silently deferred).

## Docs

`reyn-yaml.md` + `.ja.md`: the `## \`models\` block` / `### model_class_by_purpose` / `## Proxy / api_base` sections consolidated into (or made a second occurrence of) `## \`llm\` block`; every worked-example YAML snippet re-nested (51 EN + 39 JA fenced blocks re-verified parseable); the top-level key table rows removed for the 5 moved fields, folded into `llm`'s own row description; `reyn.local.yaml.example`'s matching sections merged the same way. A pre-existing doc typo (`litellm:` used instead of `llm:` in the `${VAR}`-interpolation `api_base` example, both EN and JA) was also fixed while touching that exact block.

`docs/deep-dives/proposals/` has **zero** residual mentions of the old flat `model:`/`models:` shape (checked fresh via grep at push time) — nothing to name.

## ⚠️ Owner action required after merge

Per issue #4286 (autonomous-run plan): **lead-coder will run `reyn config migrate` on the owner's own config files exclusively** —

- `~/Workspace/reyn_dev/user/reyn.yaml` (`model:` × 8, `models:` × 12)
- `~/Workspace/reyn_dev/user/reyn.local.yaml` (`api_base:` × 1, `models:` × 3)

via backup → dry-run → execute → validate-clean → present the diff in the morning report. **tui-coder does not touch these files** — this PR only changes the repo's own schema/tests/docs.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/mypy_ratchet.py` — 0 findings
- [x] `python scripts/test_tier_audit.py --strict <69 changed test files>` — 585/585 OK
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] Real end-to-end `reyn config validate`/`migrate`/re-`validate`/`get llm.model` against a scratch project — verified
- [x] `tests/config/ tests/llm/` + the directly-touched `interfaces`/`scripts` files — 900+ pass
- [x] Full `tests/core/ tests/runtime/ tests/interfaces/ tests/web/ tests/llm/ tests/config/ tests/scripts/` regression sweep — **7527 passed, 6 skipped, 15 deselected, 4 failed**. 3 of the 4 are the pre-existing, unrelated `#3869` setproctitle failures (same names as #4281's sweep — `test_codeact_proctitle_3869.py::test_codeact_child_process_is_named_reyn_codeact`, `test_proctitle_3869.py::test_ps_reports_the_new_name_for_a_live_process`, `test_proctitle_3869.py::test_setting_the_title_reports_whether_it_took_effect` — environmental, `setproctitle` not installed in this venv). The 4th (`test_3368_mcp_serve_config_anchored_to_project.py`) was a real T3 regression, fixed in this PR (see above). 15 deselected = `tests/core/test_web_search_unified.py`'s deselected items — that file hangs on a real live-network connection to a search backend on this machine (confirmed via `lsof`, unrelated to T3; a network/environment issue, not a code issue) and was excluded from this local sweep run; CI's isolated environment doesn't have this network path.
- [x] Post-rebase (onto `origin/main` after #4288/#4289/#4290 landed): re-verified all renames survived — real import + `LLMConfig()` construction + ruff + mypy_ratchet all re-run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
