### PR TITLE
fix(#4174 T3 follow-up): feature-map.md's models-block anchor -> llm.models

### DIFF
--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -448,7 +448,7 @@ Main reference: **[`reyn.yaml`](reference/config/reyn-yaml.md)**
 | `embedding` | Model classes / batch_size / cost_warn_threshold | [RAG concepts](concepts/data-retrieval/rag.md) |
 | `voice` ⚠️ | Whisper model / language / device config still parses, but has no consumer since the Textual TUI it was built for was deleted (replaced by the inline CUI) — currently unavailable | [Voice concepts](concepts/tools-integrations/voice.md) |
 | `events` | Rotation size/age + cleanup_period_days | [Events reference](reference/runtime/events.md) |
-| `models` | Class → LiteLLM model string with `extends` chain | [reyn-yaml § models](reference/config/reyn-yaml.md#models-block) |
+| `models` | Class → LiteLLM model string with `extends` chain | [reyn-yaml § llm.models](reference/config/reyn-yaml.md#llmmodels-block) |
 | `permissions` | Project-wide default capability policy | [Permissions config](reference/config/permissions.md) |
 | `multi-agent` | Agent and topology defaults | [Multi-agent config](reference/config/multi-agent.md) |
 | `state_dir` | Runtime state directory (default `.reyn/`) | [State dir](reference/config/state-dir.md) |


### PR DESCRIPTION
**[tui-coder]** — Fixes the `docs build (strict)` failure lead-coder flagged on #4294 (which is unrelated — the failure is a T3-caused regression on `main`, surfacing on the first PR whose CI ran after T3 merged).

## Root cause

T3 (#4292) renamed `## \`models\` block` → `### \`llm.models\` block` (nested under `## \`llm\` block`) but missed `docs/feature-map.md`'s own cross-reference, which still links `reyn-yaml.md#models-block` — an anchor that no longer exists after the rename.

`scripts/check_doc_anchors.py` (run as part of the `docs build (strict)` CI job) caught it: `ANCHOR_NOT_FOUND: feature-map.md -> reference/config/reyn-yaml.md#models-block`.

## Verified

`mkdocs build --strict -f .mkdocs/mkdocs.yml` — was `ANCHOR_NOT_FOUND` before this fix, exit 0 clean after (checked against a fresh local install of `pip install -e ".[docs]"`).

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean, no `ANCHOR_NOT_FOUND`

🤖 Generated with [Claude Code](https://claude.com/claude-code)