### PR TITLE
feat(#4282): OAuth-configured http moves to the official mcp SDK, fastmcp retired from the MCP client path

### DIFF
--- a/src/reyn/mcp/_fastmcp_boundary.py
+++ b/src/reyn/mcp/_fastmcp_boundary.py
@@ -6,6 +6,24 @@ Python SDK v2 target, #3698) had to find and change every one of those call
 sites individually. This module makes them one seam — a future swap edits
 THIS file's function bodies, not 6 scattered call sites.
 
+## #4282: `client.py`'s 5 accessors retired, `elicitation.py`'s 1 remains
+
+#3698 stage 1 + #4282 moved every `client.py` call site (`initialize`,
+transport construction, OAuth) off fastmcp entirely — `import_fastmcp_
+client`/`import_stdio_transport`/`import_streamable_http_transport`/
+`import_sse_transport`/`import_oauth` are gone, along with the `client.py`
+methods that were their only callers. `import_elicit_result` remains: it
+is NOT part of the client-transport swap — `fastmcp.client.elicitation.
+ElicitResult` is a strict subclass of the official SDK's own
+`mcp.types.ElicitResult` (verified via its MRO), so returning one from
+`elicitation.py`'s handler satisfies the official SDK's `ElicitationFnT`
+return-type contract unmodified; there was no reason to touch it. This
+module itself is NOT deletable while that one accessor still has a
+consumer — see `client.py`'s own module docstring for why `fastmcp` (and
+therefore this seam) stays a required reyn dependency regardless of the
+client-transport swap (unrelated server-side fastmcp usage elsewhere in
+the codebase).
+
 ## Why the accessors are functions, not module-level re-exports
 
 Every site here was a DEFERRED import (inside a method body, not at module
@@ -41,45 +59,6 @@ existed to (honestly) describe.
 from __future__ import annotations
 
 from typing import Any
-
-
-def import_fastmcp_client() -> "type[Any]":
-    """``fastmcp.Client`` — client.py's ``initialize()``, wrapped there in a
-    try/except that raises a reyn-specific "package required" error on
-    ``ImportError`` (unchanged by this function; the caller still wraps
-    THIS call the same way)."""
-    from fastmcp import Client
-
-    return Client
-
-
-def import_stdio_transport() -> "type[Any]":
-    """``fastmcp.client.transports.StdioTransport`` — client.py's ``_open_stdio``."""
-    from fastmcp.client.transports import StdioTransport
-
-    return StdioTransport
-
-
-def import_streamable_http_transport() -> "type[Any]":
-    """``fastmcp.client.transports.StreamableHttpTransport`` — client.py's
-    ``_open_http``."""
-    from fastmcp.client.transports import StreamableHttpTransport
-
-    return StreamableHttpTransport
-
-
-def import_sse_transport() -> "type[Any]":
-    """``fastmcp.client.transports.SSETransport`` — client.py's ``_open_sse``."""
-    from fastmcp.client.transports import SSETransport
-
-    return SSETransport
-
-
-def import_oauth() -> "type[Any]":
-    """``fastmcp.client.auth.OAuth`` — client.py's ``_build_oauth_auth``."""
-    from fastmcp.client.auth import OAuth
-
-    return OAuth
 
 
 def import_elicit_result() -> "type[Any]":

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -1,48 +1,59 @@
 """
-MCP client (v#2597 S1; #3698 stage 1).
+MCP client (v#2597 S1; #3698 stage 1; #4282 stage 2 — fastmcp retired).
 
 Supports two transports today: ``stdio`` and ``http`` (Streamable HTTP);
-``sse`` uses the SSE client (previously ``NotImplementedError`` — a free
-win from the original fastmcp swap: no incremental cost to wire once
-FastMCP's own transport inference existed).
+``sse`` uses the SSE client.
 
-#3698 stage 1: ``stdio`` and non-OAuth-configured ``http``/``sse`` now go
-through the official ``mcp`` SDK DIRECTLY (``mcp.client.session.
-ClientSession`` + ``mcp.client.{stdio,streamable_http,sse}``) — fastmcp is
-no longer in those paths at all. An OAuth-configured ``http`` server still
-goes through fastmcp's ``Client`` (:meth:`_initialize_fastmcp`), split out
-to its own issue (#4282) rather than attempted here — the official SDK's
-``OAuthClientProvider`` needs a caller-supplied browser-redirect +
-localhost-callback implementation fastmcp currently provides internally,
-PLUS a second adapter for reyn's own token storage (fastmcp's
-``AsyncKeyValue`` protocol vs. the official SDK's ``TokenStorage``
-protocol — genuinely different shapes, not a rename) — materially more
-than the method-name/kwarg differences the other transports needed. The
-"OAuth 2.1" section below is still accurate for that path.
+#4282: EVERY transport — ``stdio``, ``http``/``sse`` with or without OAuth
+configured — now goes through the official ``mcp`` SDK DIRECTLY
+(``mcp.client.session.ClientSession`` + ``mcp.client.{stdio,
+streamable_http,sse}``). fastmcp is no longer constructed anywhere in this
+module. #3698 stage 1 had already migrated stdio and non-OAuth http/sse;
+#4282 closed the remaining OAuth-configured-http gap by building the
+official SDK's own ``mcp.client.auth.OAuthClientProvider`` directly
+instead of fastmcp's ``OAuth`` wrapper around it — this needed two things
+fastmcp provided internally: a browser-redirect + localhost-callback
+implementation (now :mod:`reyn.mcp.oauth_browser_flow`, built from
+starlette/uvicorn — zero NEW dependency surface, since fastmcp's own
+``fastmcp-slim[server]`` requirement already pulls both in unconditionally
+regardless of reyn's own optional ``[web]`` extra — verified by reading
+``fastmcp``'s/``fastmcp-slim``'s declared requirements directly, not
+assumed) and a token-storage adapter matching the official SDK's simpler
+``TokenStorage`` protocol (``get_tokens``/``set_tokens``/
+``get_client_info``/``set_client_info``, scoped per ``server_url`` — see
+:mod:`reyn.mcp.oauth_token_storage`, rewritten from fastmcp's
+``AsyncKeyValue``-shaped adapter, which became dead code once fastmcp's
+``OAuth`` was no longer constructed anywhere).
 
-⚠️ **This module is a HYBRID, not a completed migration** — a state a
-future reader could easily misread as "done" without this paragraph:
-  - ``fastmcp`` stays a REQUIRED dependency (not optional, not vendored)
-    until #4282 lands, because the OAuth path still needs it.
-  - The ``mcp<2.0`` pin (owned by ``fastmcp-slim``'s own dependency
-    constraint, not reyn's) CANNOT be relaxed until #4282 lands either —
-    #3698's own stage 2 (adopting ``mcp>=2.0`` for ``2026-07-28`` support)
-    is gated on #4282, not on "the remaining transports": there are no
-    remaining transports once this PR lands, only the remaining
-    DEPENDENCY that #4282 removes.
-  - Do not read "stage 1 landed" as "fastmcp can be removed from
-    pyproject.toml" — that is #4282's own landing condition, not this
-    one's.
+This module (the MCP CLIENT path) no longer imports ``fastmcp`` for
+transport/session/OAuth construction — only :mod:`reyn.mcp.elicitation`
+still imports one fastmcp type (``fastmcp.client.elicitation.
+ElicitResult``, a strict subclass of ``mcp.types.ElicitResult`` — verified
+via its MRO — so it satisfies the official SDK's ``ElicitationFnT``
+return-type contract unmodified; kept rather than switched to the SDK's
+own base type, since switching would touch elicitation.py for no
+behavioral gain).
+
+⚠️ **``fastmcp`` stays a REQUIRED reyn dependency — do NOT read this
+module's fastmcp-free CLIENT path as "fastmcp can be removed from
+pyproject.toml."** That premise (repeated through #3698/#4282's own
+planning) turned out to be wrong: ``src/reyn/builtin/plugins/rag/scripts/
+chunker_server.py`` and ``vector_store_server.py`` build MCP SERVERS via
+``fastmcp.FastMCP()`` directly — entirely unrelated to the CLIENT path
+this module owns. The ``mcp<2.0`` pin (``fastmcp-slim[server]``'s own
+floor) is equally unremovable for the same reason. Discovered while
+finishing #4282's own cleanup sweep, reported before touching
+``pyproject.toml`` — see the PR body / issue thread for the correction
+to the earlier "stage 2 is gated on #4282" framing.
 
 Each ``MCPClient`` owns a single connection opened on :meth:`initialize` and
-torn down on :meth:`close`. The official-SDK path holds it open via an
-``contextlib.AsyncExitStack`` (see :meth:`_initialize_stdio`'s docstring for
-why — the SDK expresses the SAME connection as two SEPARATE async context
-managers, not fastmcp's one reentrant object); the fastmcp/OAuth path still
-enters ``fastmcp.Client`` directly. Either way, the connection stays open
-for the object's lifetime (matching the previous hand-rolled client's
-caching semantics on ``OpContext.mcp_clients`` / the pool's subprocess-reuse
-contract — persistent-subprocess semantics for stdio either way).
+torn down on :meth:`close`, held open via a ``contextlib.AsyncExitStack``
+(see :meth:`_initialize_stdio`'s docstring for why — the official SDK
+expresses one connection as TWO separate async context managers, not a
+single reentrant object) for the object's lifetime (matching the previous
+hand-rolled client's caching semantics on ``OpContext.mcp_clients`` / the
+pool's subprocess-reuse contract — persistent-subprocess semantics for
+stdio either way).
 
 Environment variable expansion:
   ``${VAR_NAME}`` in any string config value is replaced with
@@ -57,11 +68,11 @@ Capability / version gate (#2597 capability slice):
   across reyn, :meth:`initialize` captures both ONCE, right after the
   handshake completes. #3698 stage 1 re-measured this against the official
   SDK directly (live probe, not read from docs): ``ClientSession.
-  initialize()`` RETURNS the ``mcp.types.InitializeResult`` directly (a plain
-  return value, not a property read off a separate object the way fastmcp's
-  ``Client.initialize_result`` — populated by ``client.__aenter__()``,
-  verified against fastmcp 3.4.2 — worked; that description stays accurate
-  for the OAuth/fastmcp path only). :meth:`supports` answers "did the server
+  initialize()`` RETURNS the ``mcp.types.InitializeResult`` directly (a
+  plain return value — #4282 removed the last path, fastmcp's OAuth
+  transport, that instead read it off a separate ``Client.
+  initialize_result`` property populated by ``client.__aenter__()``; every
+  path is the plain-return-value shape now). :meth:`supports` answers "did the server
   advertise capability X" (conservative False before initialize / on a
   missing result); :func:`require_capability` is the enforcement seam —
   call it before issuing a request for a gated feature so an unsupported
@@ -74,21 +85,22 @@ Capability / version gate (#2597 capability slice):
   matrix, just makes the version + capabilities readable and gated.
 
 Elicitation (#2597 slice ③ — server->client ``elicitation/create``):
-  an optional ``elicitation_handler`` (constructor kwarg, same shape as
-  ``message_handler``) — on the fastmcp/OAuth path, forwarded verbatim to
-  ``fastmcp.Client(..., elicitation_handler=...)``. #3698 stage 1: on the
-  official-SDK path, ``_adapt_elicitation_handler`` wraps it first — reyn's
-  own handler is shaped ``(message, response_type, params, context)``
-  (fastmcp's ``ElicitationHandler`` protocol), while the official SDK's
-  ``ElicitationFnT`` is ``(context, params)`` — 2 args, opposite order,
-  entirely different shape (measured by reading both protocols directly,
-  not assumed). Passing ANY non-None (adapted or not) handler is itself
-  what declares the ``elicitation`` client capability during the initialize
-  handshake, on both paths. See :mod:`reyn.mcp.elicitation` for the handler
-  that routes a server's structured question through reyn's consent path
-  (:class:`~reyn.mcp.connection_service.MCPConnectionService` builds one per
-  held connection); this module only plumbs the constructor kwarg through
-  (adapted or not).
+  an optional ``elicitation_handler`` (constructor kwarg) — reyn's own
+  handler is shaped ``(message, response_type, params, context)``
+  (fastmcp's old ``ElicitationHandler`` protocol, kept as reyn's own
+  handler shape rather than churning every caller when the transport
+  changed), while the official SDK's ``ElicitationFnT`` is ``(context,
+  params)`` — 2 args, opposite order, entirely different shape (measured
+  by reading both protocols directly, not assumed). ``_adapt_elicitation_
+  handler`` wraps it to bridge the two on every transport now (#4282:
+  there is no longer a fastmcp path that would take it unadapted). Passing
+  ANY non-None handler is itself what declares the ``elicitation`` client
+  capability during the initialize handshake. See
+  :mod:`reyn.mcp.elicitation` for the handler that routes a server's
+  structured question through reyn's consent path
+  (:class:`~reyn.mcp.connection_service.MCPConnectionService` builds one
+  per held connection); this module only plumbs the constructor kwarg
+  through, adapted.
 
 OAuth 2.1 (#2597 slice ④ — the umbrella's LAST slice, hosted MCP servers like
 GitHub MCP / Atlassian that require browser-based OAuth rather than a static
@@ -106,29 +118,33 @@ bearer token):
   existing lazy-validate-at-connect-time posture (``type``/``url`` are
   validated the same way).
 
-  :meth:`_open_http` builds a ``fastmcp.client.auth.OAuth(mcp_url=url,
-  scopes=..., client_id=..., client_secret=..., token_storage=
-  MCPOAuthTokenStorage())`` (see :mod:`reyn.mcp.oauth_token_storage` for the
-  exact verified FastMCP contract — NOT the ``mcp.client.auth.TokenStorage``
-  ABC the umbrella issue originally assumed; FastMCP 3.4.2 instead wants a
-  generic ``key_value.aio`` ``AsyncKeyValue`` store) and passes it as
-  ``StreamableHttpTransport(url, headers=..., auth=oauth)`` — FastMCP's own
-  ``OAuth`` object IS an ``httpx.Auth`` (via ``OAuthClientProvider``), so it
-  slots into the same ``auth=`` parameter ``StreamableHttpTransport`` already
-  exposed (unused pre-④). FastMCP's ``OAuth`` runs the full Authorization
-  Code Grant + PKCE + browser-open + localhost-callback dance internally on
-  first use — reyn does NOT reimplement any of that; it only supplies the
-  token_storage backend + the pre-flight headless check below.
+  :meth:`_build_oauth_provider` builds the official SDK's
+  ``mcp.client.auth.OAuthClientProvider(server_url=url, client_metadata=...,
+  storage=MCPOAuthTokenStorage(url), redirect_handler=..., callback_handler=
+  ..., timeout=...)`` directly (#4282: fastmcp's own ``OAuth`` wrapper
+  around this same class is no longer in the path) and passes it as
+  ``streamablehttp_client(url, headers=..., auth=provider)`` —
+  ``OAuthClientProvider`` IS an ``httpx.Auth``, so it slots into the SDK
+  transport's own ``auth=`` kwarg directly, no wrapper object needed.
+  ``redirect_handler``/``callback_handler`` (the browser-open + localhost-
+  callback round trip fastmcp's ``OAuth`` ran internally) are reyn's own
+  implementation now — :mod:`reyn.mcp.oauth_browser_flow`, built from
+  starlette/uvicorn (both already core reyn dependencies). A static
+  ``client_id`` (skip Dynamic Client Registration) is supported by
+  pre-seeding the token storage's ``client_info`` before constructing the
+  provider — see :meth:`_build_oauth_provider`'s own docstring for how
+  that suppresses DCR (verified by reading the official SDK's
+  ``async_auth_flow`` directly).
 
-  Headless graceful failure: before constructing ``OAuth``,
-  :meth:`_open_http` checks :func:`~reyn.mcp.oauth_token_storage.
+  Headless graceful failure: before constructing the provider,
+  :meth:`_build_oauth_provider` checks :func:`~reyn.mcp.oauth_token_storage.
   has_stored_token` for this URL. If no usable token is cached AND this
   client is running non-interactively (``non_interactive`` constructor kwarg,
   or auto-detected via ``sys.stdin.isatty()`` when not explicitly passed —
   mirrors ``reyn.runtime.session``'s own ``non_interactive`` flag's "no user
-  to ask" rationale), :meth:`_open_http` raises :class:`MCPError` immediately
-  with a clear message rather than let FastMCP open a browser + wait (bounded
-  only by ``OAuth``'s own ``callback_timeout``, default 300s) for a callback
+  to ask" rationale), it raises :class:`MCPError` immediately with a clear
+  message rather than let the OAuth flow open a browser + wait (bounded
+  only by the provider's own ``timeout``, default 300s) for a callback
   nobody can complete.
 """
 from __future__ import annotations
@@ -522,19 +538,18 @@ def _is_transport_death(exc: BaseException) -> bool:
     own logic needed ZERO code changes — it already reads
     ``mcp.shared.exceptions.McpError``/``mcp.types.CONNECTION_CLOSED``
     directly from the official SDK, never through a fastmcp-shaped
-    wrapper, so the classification below is unchanged for the
-    stdio/non-OAuth-http/sse call sites that now go through
-    ``ClientSession`` directly. Re-confirmed live against the official
-    SDK path (``_initialize_stdio`` + a killed-subprocess probe): the
+    wrapper. Re-confirmed live against the official SDK path
+    (``_initialize_stdio`` + a killed-subprocess probe): the
     ``McpError``/``CONNECTION_CLOSED`` branch fires exactly the same way
     as it did for fastmcp, since both sit on the same underlying
-    ``mcp.shared.session.BaseSession`` receive loop. The
+    ``mcp.shared.session.BaseSession`` receive loop. **#4282**: fastmcp is
+    no longer constructed anywhere in this module, so the
     ``RuntimeError("Server session was closed unexpectedly")`` branch
-    remains fastmcp-specific (fastmcp's ``Client._context_manager`` wraps
-    the error in this exact message) — it is dead weight for the
-    stdio/non-OAuth-http/sse call sites now that they bypass fastmcp
-    entirely, but is kept because the OAuth-http path (``_initialize_fastmcp``)
-    still routes through fastmcp's ``Client`` and can still raise it:
+    fastmcp's own ``Client._context_manager`` used to wrap a closed session
+    in — dead weight since #3698 for the transports it had already
+    migrated — is now dead for EVERY transport and has been removed
+    outright rather than kept "just in case" (no test pinned it; nothing
+    in this codebase can raise that exact message anymore):
 
       - ``mcp.shared.exceptions.McpError`` whose ``.error.code`` equals
         ``mcp.types.CONNECTION_CLOSED`` (``-32000``). ``mcp.shared.session.
@@ -548,15 +563,6 @@ def _is_transport_death(exc: BaseException) -> bool:
         ``MCPError('MCP tools/call error: Connection closed')`` whose
         ``__cause__`` was ``McpError(error=ErrorData(code=-32000,
         message='Connection closed', ...))`` — exactly this branch.
-      - ``RuntimeError("Server session was closed unexpectedly")`` — fastmcp's
-        ``Client._context_manager`` (client.py) wraps a
-        ``anyio.ClosedResourceError`` leaking out of the session's context
-        scope in this EXACT message. Not observed directly in the stdio-die
-        probe above (that death surfaced via the McpError branch instead),
-        but included defensively per fastmcp's own source — a different
-        failure timing (e.g. mid-``initialize``, or the read stream closing
-        while the caller is inside the ``async with`` scope rather than
-        mid-request) could route through this wrapper instead.
       - Raw ``anyio.ClosedResourceError`` / ``anyio.BrokenResourceError`` /
         ``ConnectionError`` — defensive: these are anyio's/stdlib's own
         dead-stream / dead-socket signal types; not observed leaking
@@ -578,8 +584,6 @@ def _is_transport_death(exc: BaseException) -> bool:
     import anyio
 
     if isinstance(exc, (anyio.ClosedResourceError, anyio.BrokenResourceError, ConnectionError)):
-        return True
-    if isinstance(exc, RuntimeError) and str(exc) == "Server session was closed unexpectedly":
         return True
     try:
         from mcp.shared.exceptions import McpError as _SdkMcpError
@@ -640,7 +644,8 @@ def _extract_stdio_child_pid(stdio_cm: "Any") -> int | None:
 # ── Client ───────────────────────────────────────────────────────────────────
 
 class MCPClient:
-    """Thin async wrapper around ``fastmcp.Client``.
+    """Thin async wrapper around the official ``mcp`` SDK's ``ClientSession``
+    (#4282: fastmcp is no longer constructed anywhere in this class).
 
     Construct with the *raw* server config dict from ``reyn.yaml`` (the
     caller is responsible for env-var expansion via :func:`expand_env`).
@@ -674,7 +679,7 @@ class MCPClient:
             )
         # #2597 slice ④: 'auth' (OAuth) only makes sense over Streamable HTTP —
         # reject it eagerly at construction time for stdio/sse rather than
-        # silently ignoring it (only _open_http ever reads 'auth').
+        # silently ignoring it (only _build_oauth_provider ever reads 'auth').
         if config.get("auth") and srv_type != "http":
             raise ValueError(
                 f"MCP server 'auth' config is only supported for 'http' "
@@ -721,40 +726,45 @@ class MCPClient:
         # docstring rather than left for a reader to discover from the wiring.
         self._emit_event: Callable[..., Any] | None = emit_event
         # #2597 S2b: optional async server->client notifications bridge — a
-        # ReynMCPMessageHandler (#3698 P3: composes fastmcp's message-handler
-        # contract rather than subclassing it — see reyn.mcp.message_handler's
-        # module docstring) that receives tools/prompts list_changed +
+        # ReynMCPMessageHandler (#3698 P3: composes the message-handler
+        # contract fastmcp originally defined, rather than subclassing it —
+        # see reyn.mcp.message_handler's module docstring) that receives
+        # tools/prompts list_changed +
         # progress notifications on this client's held connection and emits them onto
         # reyn's EventLog. None (default) preserves pre-S2b behaviour — no bridge, no
         # behaviour change for callers that don't pass one (e.g. the ephemeral
         # per-call MCPClientPool path never installs a handler).
         self._message_handler: Any = message_handler
-        # #2597 slice ③: optional FastMCP ``ElicitationHandler`` (see
-        # ``reyn.mcp.elicitation.build_elicitation_handler``) — routes a
-        # server->client ``elicitation/create`` request through reyn's
-        # consent path. Passing ANY non-None handler to ``fastmcp.Client``
-        # is itself what causes FastMCP to declare the ``elicitation`` client
-        # capability during the initialize handshake (D6 — held connections
-        # always install one; the ephemeral per-call ``MCPClientPool`` path
-        # never does, same None-default no-op pattern as ``message_handler``).
+        # #2597 slice ③: optional elicitation handler (see
+        # ``reyn.mcp.elicitation.build_elicitation_handler``, shaped to
+        # fastmcp's original ``ElicitationHandler`` protocol — reyn kept
+        # that shape as its own rather than churning callers when the
+        # transport changed; ``_adapt_elicitation_handler`` bridges it to
+        # the official SDK's own shape) — routes a server->client
+        # ``elicitation/create`` request through reyn's consent path.
+        # Passing ANY non-None handler is itself what declares the
+        # ``elicitation`` client capability during the initialize handshake
+        # (D6 — held connections always install one; the ephemeral per-call
+        # ``MCPClientPool`` path never does, same None-default no-op
+        # pattern as ``message_handler``).
         self._elicitation_handler: Any = elicitation_handler
-        # #2597 slice ④: explicit override for the headless-OAuth pre-flight check
-        # in _open_http (see module docstring's "Headless graceful failure").
-        # None (default) means auto-detect via sys.stdin.isatty() at the point
-        # _open_http actually needs the answer — see _is_non_interactive().
+        # #2597 slice ④: explicit override for the headless-OAuth pre-flight
+        # check in _build_oauth_provider (see module docstring's "Headless
+        # graceful failure"). None (default) means auto-detect via
+        # sys.stdin.isatty() at the point _build_oauth_provider actually
+        # needs the answer — see _is_non_interactive().
         self._non_interactive_override: bool | None = non_interactive
-        self._client: Any = None  # official mcp.ClientSession (stdio) or fastmcp.Client (http/sse, pending #3698 stage 1) when initialized
-        # #3698 stage 1: holds the entered stdio_client + ClientSession async
-        # context managers open for this object's lifetime — the official
-        # SDK's connection lifecycle is a pair of async context managers, not
-        # fastmcp.Client's single reentrant __aenter__/close() object, so an
-        # AsyncExitStack is what reproduces the same "open once, use across
-        # many calls, close later" pattern (live-verified: initialize() then
-        # TWO separate call_tool()s against the SAME held session, then a
-        # clean stack.aclose() — see the commit message for the probe). None
-        # until initialize() actually opens a stdio connection; the http/sse
-        # paths still use fastmcp's own Client (pending stage-1 follow-up
-        # commits) and leave this None.
+        self._client: Any = None  # official mcp.ClientSession when initialized
+        # #3698 stage 1 / #4282: holds the entered transport + ClientSession
+        # async context managers open for this object's lifetime — the
+        # official SDK's connection lifecycle is a pair of async context
+        # managers, not fastmcp.Client's old single reentrant
+        # __aenter__/close() object, so an AsyncExitStack is what reproduces
+        # the same "open once, use across many calls, close later" pattern
+        # (live-verified: initialize() then TWO separate call_tool()s
+        # against the SAME held session, then a clean stack.aclose() — see
+        # the commit message for the probe). None until initialize()
+        # actually opens a connection (every transport now).
         self._exit_stack: "Any | None" = None
         self._initialized = False
         # Captures subprocess stderr for stdio transport so initialize
@@ -776,19 +786,19 @@ class MCPClient:
         # #3848 stage 1: the allowlisted env wrap_command() computes (#3850),
         # carried through instead of being silently dropped the way it was
         # before this — _sandbox_wrap_stdio used to project only .argv out of
-        # WrappedCommand. NOT yet consumed by _open_stdio's actual launch
+        # WrappedCommand. NOT yet consumed by _initialize_stdio's actual launch
         # (the owner ruling's default is "pass everything", which #3850's
         # allowlist is narrower than) — this is the seam stage 2's opt-in
         # whitelist/blacklist config will read from. None when the wrap
         # failed (fail-open with a warning + audit-event, #3821) — there is
         # no allowlisted value to offer in that case.
         self._sandbox_env: dict[str, str] | None = None
-        # #2597 capability/version gate: captured in initialize() right after
-        # ``client.__aenter__()`` completes FastMCP's initialize handshake (verified
-        # against fastmcp 3.4.2: ``fastmcp.Client.initialize_result`` is populated at
-        # that point — see client.py module docstring's fact-check). None until then
-        # (or if the server's InitializeResult was unavailable — handled defensively,
-        # never raises).
+        # #2597 capability/version gate: captured right after the official
+        # SDK's ClientSession.initialize() handshake completes (a plain
+        # return value — see the module docstring's "Capability / version
+        # gate" section). None until then (or if the server's
+        # InitializeResult was unavailable — handled defensively, never
+        # raises).
         self._negotiated_version: str | None = None
         self._server_capabilities: Any = None  # mcp.types.ServerCapabilities | None
         # #2714 belt-and-suspenders: the OS pid of the stdio subprocess this client
@@ -893,46 +903,27 @@ class MCPClient:
                 break
         return items
 
-    @property
-    def _uses_official_sdk(self) -> bool:
-        """#3698 stage 1: True once ``self._client`` is the official SDK's
-        ``ClientSession`` directly (stdio, migrated) rather than fastmcp's
-        ``Client`` (http/sse, pending their own stage-1 commits). The two
-        expose a few operations under different names/paths for the SAME
-        protocol call (``call_tool_mcp`` vs ``call_tool``, ``.session.
-        subscribe_resource`` vs ``.subscribe_resource`` directly) — this is
-        the single dispatch point every such call site branches on, so the
-        distinction disappears in one place once http/sse migrate too rather
-        than needing to be re-found at each call site. ``self._exit_stack``
-        is only ever set by ``_initialize_stdio`` — a reliable proxy with no
-        separate bookkeeping."""
-        return self._exit_stack is not None
-
     async def initialize(self) -> None:
         """Open the transport and complete the MCP handshake.
 
         Idempotent: a second call is a no-op.
 
-        #3698 stage 1: ``stdio``/``http``/``sse`` all go through the official
-        ``mcp`` SDK directly now (:meth:`_initialize_stdio` /
-        :meth:`_initialize_http_or_sse`) — fastmcp is only still in the path
-        for an OAuth-configured http server (:meth:`_initialize_fastmcp`),
-        pending OAuth's own follow-up commit: the official SDK's
-        ``OAuthClientProvider`` needs a ``redirect_handler``/
-        ``callback_handler`` pair implementing the actual browser-flow
-        orchestration fastmcp's own ``OAuth`` class currently does
-        internally — a materially bigger, separately-scoped lift than the
-        method-name/kwarg-shape differences the other transports needed
-        (flagged to lead-coder before starting it).
+        #4282: every transport — ``stdio``, ``http``/``sse`` with or
+        without OAuth configured — now goes through the official ``mcp``
+        SDK directly (:meth:`_initialize_stdio` /
+        :meth:`_initialize_http_or_sse`). fastmcp is no longer constructed
+        anywhere in this dispatch; see the module docstring's HYBRID
+        warning for what that does and does NOT mean yet (``fastmcp``
+        stays a declared dependency until this PR also removes it from
+        ``pyproject.toml`` — a separate, later step in the same PR, not a
+        follow-up).
         """
         if self._initialized:
             return
         if self._type == "stdio":
             await self._initialize_stdio()
-        elif self._type in ("http", "sse") and not self._config.get("auth"):
-            await self._initialize_http_or_sse()
         else:
-            await self._initialize_fastmcp()
+            await self._initialize_http_or_sse()
 
     async def _initialize_stdio(self) -> None:
         """#3698 stage 1: stdio via the official ``mcp`` SDK, no fastmcp.
@@ -1124,6 +1115,13 @@ class MCPClient:
         stack = AsyncExitStack()
         try:
             if self._type == "http":
+                # #4282: OAuth (if configured — __init__ already rejects it
+                # for sse) is now built as the official SDK's own
+                # OAuthClientProvider (an httpx.Auth) and passed straight
+                # into streamablehttp_client's own auth= kwarg, same as any
+                # other httpx.Auth — no more fastmcp Client/transport
+                # wrapper needed to carry it.
+                auth = await self._build_oauth_provider(url)
                 # Deliberately the deprecated headers/timeout/auth-kwarg
                 # `streamablehttp_client`, not its replacement
                 # `streamable_http_client` — the latter takes a pre-built
@@ -1134,7 +1132,9 @@ class MCPClient:
                 from mcp.client.streamable_http import streamablehttp_client
 
                 read, write, _get_session_id = await stack.enter_async_context(
-                    streamablehttp_client(url, headers=headers, timeout=read_timeout)
+                    streamablehttp_client(
+                        url, headers=headers, timeout=read_timeout, auth=auth,
+                    )
                 )
             else:
                 from mcp.client.sse import sse_client
@@ -1181,144 +1181,6 @@ class MCPClient:
         self._client = session
         self._exit_stack = stack
         self._initialized = True
-        if init_result is not None:
-            self._negotiated_version = str(init_result.protocolVersion)
-            self._server_capabilities = init_result.capabilities
-        else:
-            self._negotiated_version = None
-            self._server_capabilities = None
-
-    async def _initialize_fastmcp(self) -> None:
-        """http/sse transports — unchanged fastmcp path, pending #3698 stage
-        1's own follow-up commits for these two transports."""
-        try:
-            from reyn.mcp._fastmcp_boundary import import_fastmcp_client
-
-            FastMCPClient = import_fastmcp_client()
-        except ImportError as exc:
-            raise MCPError(
-                "The 'fastmcp' package is required for MCP support. "
-                "It is a core reyn dependency, so this usually means a broken "
-                "install — reinstall reyn (e.g. pip install -e .)."
-            ) from exc
-
-        try:
-            transport = self._open_transport()
-            client_kwargs: dict[str, Any] = {}
-            if self._type in ("http", "sse"):
-                # Client-level default read timeout — see _open_http docstring:
-                # the pre-swap connect-level ``timeout=`` kwarg on
-                # ``streamablehttp_client`` maps to FastMCP's Client-level
-                # default ``read_timeout_seconds`` (same knob call_tool's
-                # per-call ``timeout_seconds`` overrides).
-                client_kwargs["timeout"] = self._config.get("timeout", 30)
-            # #3028: bound the handshake itself, on EVERY transport. Distinct from
-            # the ``timeout`` above in both scope and reach:
-            #
-            #   * scope — ``timeout`` is the session's default read timeout, so it
-            #     bounds every later ``call_tool`` too. Reusing it to bound a launch
-            #     would silently cap tool RUNTIME as a side effect, killing the
-            #     legitimately long call (a RAG ingest over a large folder) to fix a
-            #     launch bug. ``init_timeout`` is FastMCP's dedicated handshake knob
-            #     (``Client.initialize()`` wraps ``session.initialize()`` in
-            #     ``anyio.fail_after``), so it bounds the launch and nothing else.
-            #   * reach — it is set unconditionally, not under the http/sse branch.
-            #     stdio was the transport that hung (#3028) precisely because it fell
-            #     through both: no ``timeout``, and FastMCP's ``client_init_timeout``
-            #     defaults to None = disabled. HTTP only looked protected because its
-            #     ``timeout`` happens to bound the handshake's read as one more
-            #     request — an accident of the read timeout, not a handshake bound.
-            #     Setting this for all three makes "we give up eventually" a property
-            #     of the client rather than of which transport you happened to pick.
-            client_kwargs["init_timeout"] = self._config.get(
-                "init_timeout", _DEFAULT_INIT_TIMEOUT_SECONDS
-            )
-            # #2597 S2b: install the notifications bridge, if one was supplied. Passed
-            # as a constructor kwarg per FastMCP's own contract (Client(transport,
-            # message_handler=...)); ReynMCPMessageHandler's weakref binding to THIS
-            # client is completed via bind_client() right below — see
-            # reyn/mcp/message_handler.py's module docstring ("two-phase client
-            # binding") for why that two-step is necessary.
-            if self._message_handler is not None:
-                client_kwargs["message_handler"] = self._message_handler
-            # #2597 slice ③: same constructor-kwarg contract as message_handler —
-            # FastMCP's ``Client(transport, elicitation_handler=...)``.
-            if self._elicitation_handler is not None:
-                client_kwargs["elicitation_handler"] = self._elicitation_handler
-            client = FastMCPClient(transport, **client_kwargs)
-            if self._message_handler is not None:
-                self._message_handler.bind_client(client)
-            await client.__aenter__()
-        except MCPError:
-            self.close_stderr_capture()
-            raise
-        except Exception as exc:
-            tail = self.read_stderr_tail()
-            self.close_stderr_capture()
-            # #1344/#1339-D migration hint: a sandboxed stdio server defaults to
-            # the single-source network posture (DEFAULT_SANDBOX_NETWORK); the
-            # operator isolates a server with `network: false`. If a server was
-            # isolated and fails init for a network reason, point the operator at
-            # the knob rather than leave an opaque error.
-            from reyn.security.sandbox.policy import DEFAULT_SANDBOX_NETWORK
-
-            hint = ""
-            # #3698 stage 1: the stdio-gated hints below are now unreachable —
-            # this method only ever runs for http/sse (stdio moved to
-            # _initialize_stdio above) — kept as dead-but-harmless conditions
-            # rather than restructured, since this whole method is itself
-            # temporary pending http/sse's own stage-1 follow-up commits.
-            if self._type == "stdio" and not self._config.get(
-                "network", DEFAULT_SANDBOX_NETWORK
-            ):
-                hint = (
-                    "\nHint (#1344): this MCP server is sandboxed with network "
-                    "DISABLED (`network: false` in its config). If it needs "
-                    "network access, set `network: true` (or remove the override)."
-                )
-            # #2976: same shape as the network hint — a sandbox write denial is
-            # the one failure the operator can always fix, but ONLY if the error
-            # names the knob. This is what makes the per-runtime default map
-            # (_RUNTIME_DEFAULT_WRITE_PATHS) safe to leave incomplete: an unknown
-            # runtime, or a relocated cache (XDG_CACHE_HOME / npm_config_cache),
-            # surfaces as "add this path" rather than an opaque EPERM.
-            if self._type == "stdio" and _looks_like_write_denial(tail):
-                hint += (
-                    "\nHint (#2976): the sandbox DENIED a write to a path outside "
-                    "this server's granted write scope (the stderr below names "
-                    "the exact path). A launcher that bootstraps into a per-user "
-                    "cache needs that cache granted. Add the path to this "
-                    "server's `write_paths` in its MCP config, e.g.\n"
-                    "    write_paths: [\"~/.npm\"]\n"
-                    "Declaring `write_paths` replaces the built-in per-runtime "
-                    "defaults; the server's working directory is always granted."
-                )
-            if tail:
-                # #2976: the hint goes BEFORE the stderr dump, not after it. The
-                # message is later summarised by pool.describe_fault(limit=600),
-                # which truncates from the END — a trailing hint is therefore the
-                # FIRST thing dropped, and precisely on the verbose failures that
-                # need it most (npm's cache EPERM alone exceeds the limit, which
-                # is how this was found: the hint reached uvx's short error and
-                # was silently cut from npx's long one). The actionable knob
-                # outranks the tail of a log the operator can re-read.
-                raise MCPError(
-                    f"MCP initialize failed: {exc}{hint}\n"
-                    f"--- subprocess stderr (tail) ---\n{tail}"
-                ) from exc
-            raise MCPError(f"MCP initialize failed: {exc}{hint}") from exc
-
-        self._client = client
-        self._initialized = True
-        # #2597 capability/version gate: read the negotiated version + capabilities
-        # right after the handshake completes. ``initialize_result`` is populated by
-        # ``client.__aenter__()`` above (fastmcp 3.4.2: ``Client.initialize_result``
-        # property backed by ``_session_state.initialize_result``, set inside
-        # ``Client.initialize()`` which ``__aenter__`` calls) — but read it
-        # defensively: None here would mean FastMCP's own contract changed
-        # underneath us, not a reyn bug, so degrade to "unknown" (supports() ->
-        # False, negotiated_version -> None) rather than raise.
-        init_result = getattr(client, "initialize_result", None)
         if init_result is not None:
             self._negotiated_version = str(init_result.protocolVersion)
             self._server_capabilities = init_result.capabilities
@@ -1373,38 +1235,25 @@ class MCPClient:
         # server never advertised "tools" rather than let the request reach the
         # server and bounce back as a confusing raw protocol error.
         require_capability(self, "tools")
-        # #3698 stage 1: fastmcp's call_tool_mcp and the official SDK's plain
-        # call_tool take the SAME two concepts (a progress callback, a
-        # per-call read timeout) under DIFFERENT kwarg names
-        # (progress_handler/timeout vs progress_callback/read_timeout_seconds
-        # — measured by reading ClientSession.call_tool's own signature) —
-        # NOT interchangeable via **kwargs, so each branch builds its own.
+        # #4282: fastmcp is gone from every live path (OAuth was the last
+        # holdout) — self._client is always the official SDK's
+        # ClientSession now, so this only ever builds ONE kwargs shape.
+        # progress_callback / read_timeout_seconds are ClientSession.
+        # call_tool's own kwarg names (measured by reading its signature).
         kwargs: dict[str, Any] = {}
-        if self._uses_official_sdk:
-            if progress_callback is not None:
-                kwargs["progress_callback"] = progress_callback
-            if timeout_seconds is not None:
-                from datetime import timedelta
-                kwargs["read_timeout_seconds"] = timedelta(seconds=timeout_seconds)
-        else:
-            if progress_callback is not None:
-                kwargs["progress_handler"] = progress_callback
-            if timeout_seconds is not None:
-                from datetime import timedelta
-                kwargs["timeout"] = timedelta(seconds=timeout_seconds)
+        if progress_callback is not None:
+            kwargs["progress_callback"] = progress_callback
+        if timeout_seconds is not None:
+            from datetime import timedelta
+            kwargs["read_timeout_seconds"] = timedelta(seconds=timeout_seconds)
         try:
-            # call_tool_mcp (not FastMCP's raise_on_error-by-default call_tool)
-            # returns the RAW mcp.types.CallToolResult unchanged — same object
-            # shape _result_to_dict already flattens, so op_runtime/mcp.py's
-            # consumed shape stays byte-identical. #3698 stage 1: the official
-            # SDK's OWN plain call_tool() is already the raw/no-raise variant
-            # (measured by reading ClientSession.call_tool's source: it
-            # returns CallToolResult unconditionally, never raises on
-            # isError) — no _mcp-suffixed name exists there to begin with.
-            if self._uses_official_sdk:
-                result = await self._client.call_tool(name, args or {}, **kwargs)
-            else:
-                result = await self._client.call_tool_mcp(name, args or {}, **kwargs)
+            # ClientSession.call_tool() is already the raw/no-raise variant
+            # fastmcp needed a call_tool_mcp-suffixed method to reach
+            # (measured by reading its source: it returns CallToolResult
+            # unconditionally, never raises on isError) — same object shape
+            # _result_to_dict already flattens, so op_runtime/mcp.py's
+            # consumed shape stays byte-identical to the pre-#3698 one.
+            result = await self._client.call_tool(name, args or {}, **kwargs)
         except Exception as exc:
             _classify_and_raise(exc, f"MCP tools/call error: {exc}")
         return self._annotate_write_denial(_result_to_dict(result))
@@ -1454,24 +1303,19 @@ class MCPClient:
     async def list_tools(self) -> list[dict[str, Any]]:
         """Return the tools advertised by this server as plain dicts.
 
-        Uses FastMCP's auto-paginating ``Client.list_tools()`` (follows
-        ``nextCursor`` up to a 250-page guard) instead of a single page-1
-        request — #2597 S1 free win: servers with >1 page of tools no
-        longer silently truncate.
-
-        #3698 stage 1: the official SDK's raw ``ClientSession.list_tools()``
-        has no such auto-pagination (measured: it returns ONE
-        ``ListToolsResult`` page, not a flat list) — see
-        :meth:`_paginate_official_sdk`, which reproduces fastmcp's behavior.
+        The official SDK's raw ``ClientSession.list_tools()`` returns ONE
+        ``ListToolsResult`` page, not an auto-paginated flat list (measured
+        — see :meth:`_paginate_official_sdk`, which reproduces the
+        auto-pagination fastmcp's old convenience wrapper did, following
+        ``nextCursor`` up to a 250-page guard) — #2597 S1's free win
+        (servers with >1 page of tools no longer silently truncate)
+        preserved across #3698/#4282's transport swap.
         """
         await self.initialize()
         # #2597 capability/version gate: same seam as call_tool — see there.
         require_capability(self, "tools")
         try:
-            if self._uses_official_sdk:
-                tools = await self._paginate_official_sdk(self._client.list_tools, "tools")
-            else:
-                tools = await self._client.list_tools()
+            tools = await self._paginate_official_sdk(self._client.list_tools, "tools")
         except Exception as exc:
             _classify_and_raise(exc, f"MCP tools/list error: {exc}")
         return [_tool_to_dict(t) for t in tools]
@@ -1481,19 +1325,16 @@ class MCPClient:
     async def list_resources(self) -> list[dict[str, Any]]:
         """Return the resources advertised by this server as plain dicts.
 
-        Mirrors :meth:`list_tools`: uses FastMCP's auto-paginating
-        ``Client.list_resources()`` (follows ``nextCursor``) and gates on the
-        ``"resources"`` capability before issuing the request.
+        Mirrors :meth:`list_tools`: paginates via :meth:`_paginate_official_sdk`
+        (follows ``nextCursor``) and gates on the ``"resources"`` capability
+        before issuing the request.
         """
         await self.initialize()
         require_capability(self, "resources")
         try:
-            if self._uses_official_sdk:
-                resources = await self._paginate_official_sdk(
-                    self._client.list_resources, "resources",
-                )
-            else:
-                resources = await self._client.list_resources()
+            resources = await self._paginate_official_sdk(
+                self._client.list_resources, "resources",
+            )
         except Exception as exc:
             _classify_and_raise(exc, f"MCP resources/list error: {exc}")
         return [_resource_to_dict(r) for r in resources]
@@ -1505,12 +1346,9 @@ class MCPClient:
         await self.initialize()
         require_capability(self, "resources")
         try:
-            if self._uses_official_sdk:
-                templates = await self._paginate_official_sdk(
-                    self._client.list_resource_templates, "resourceTemplates",
-                )
-            else:
-                templates = await self._client.list_resource_templates()
+            templates = await self._paginate_official_sdk(
+                self._client.list_resource_templates, "resourceTemplates",
+            )
         except Exception as exc:
             _classify_and_raise(exc, f"MCP resources/templates/list error: {exc}")
         return [_resource_to_dict(t) for t in templates]
@@ -1520,27 +1358,20 @@ class MCPClient:
         its contents flattened to a dict: ``{"contents": [...]}`` — each
         entry a flattened ``TextResourceContents``/``BlobResourceContents``.
 
-        Uses FastMCP's raw ``read_resource_mcp`` (not the convenience
-        ``read_resource``, which strips the ``ReadResourceResult`` envelope
-        down to just ``.contents``) so the shape-flattening lives in ONE
-        place (:func:`_read_resource_result_to_dict`), mirroring how
-        :meth:`call_tool` uses ``call_tool_mcp`` for the same reason.
-
-        #3698 stage 1: the official SDK's OWN plain ``read_resource`` never
-        had fastmcp's convenience-stripping layer to begin with — it already
-        returns the full ``ReadResourceResult`` (live-verified: called
-        against the real echo server's ``resource://pid``, ``.contents``
-        reachable directly, no fastmcp in the path). ``uri`` is typed
-        ``AnyUrl`` on that method but accepts a plain ``str`` — pydantic
-        coerces it at the request-params model boundary (also live-verified).
+        ``ClientSession.read_resource`` returns the full
+        ``ReadResourceResult`` (live-verified: called against the real echo
+        server's ``resource://pid``, ``.contents`` reachable directly) —
+        the shape-flattening lives in ONE place
+        (:func:`_read_resource_result_to_dict`), mirroring how
+        :meth:`call_tool` flattens ``CallToolResult`` for the same reason.
+        ``uri`` is typed ``AnyUrl`` on that method but accepts a plain
+        ``str`` — pydantic coerces it at the request-params model boundary
+        (live-verified).
         """
         await self.initialize()
         require_capability(self, "resources")
         try:
-            if self._uses_official_sdk:
-                result = await self._client.read_resource(uri)
-            else:
-                result = await self._client.read_resource_mcp(uri)
+            result = await self._client.read_resource(uri)
         except Exception as exc:
             _classify_and_raise(exc, f"MCP resources/read error: {exc}")
         return _read_resource_result_to_dict(result)
@@ -1550,17 +1381,14 @@ class MCPClient:
     async def list_prompts(self) -> list[dict[str, Any]]:
         """Return the prompts advertised by this server as plain dicts.
 
-        Mirrors :meth:`list_resources`: uses FastMCP's auto-paginating
-        ``Client.list_prompts()`` (follows ``nextCursor``) and gates on the
-        ``"prompts"`` capability before issuing the request.
+        Mirrors :meth:`list_resources`: paginates via
+        :meth:`_paginate_official_sdk` (follows ``nextCursor``) and gates
+        on the ``"prompts"`` capability before issuing the request.
         """
         await self.initialize()
         require_capability(self, "prompts")
         try:
-            if self._uses_official_sdk:
-                prompts = await self._paginate_official_sdk(self._client.list_prompts, "prompts")
-            else:
-                prompts = await self._client.list_prompts()
+            prompts = await self._paginate_official_sdk(self._client.list_prompts, "prompts")
         except Exception as exc:
             _classify_and_raise(exc, f"MCP prompts/list error: {exc}")
         return [_prompt_to_dict(p) for p in prompts]
@@ -1570,24 +1398,17 @@ class MCPClient:
         dict: ``{"description": str | None, "messages": [...]}`` — each entry
         a flattened ``PromptMessage``.
 
-        Uses FastMCP's raw ``get_prompt_mcp`` (not the convenience
-        ``get_prompt``, which additionally supports background-task /
-        version kwargs this slice does not need) so the shape-flattening
-        lives in ONE place (:func:`_get_prompt_result_to_dict`), mirroring
-        how :meth:`read_resource` uses ``read_resource_mcp`` for the same
-        reason.
-
-        #3698 stage 1: the official SDK's OWN plain ``get_prompt`` has no
-        such extra convenience kwargs to begin with — same signature shape
-        (``name``, ``arguments``), full ``GetPromptResult`` returned.
+        ``ClientSession.get_prompt`` takes the same ``name``/``arguments``
+        shape and returns the full ``GetPromptResult`` — the
+        shape-flattening lives in ONE place
+        (:func:`_get_prompt_result_to_dict`), mirroring how
+        :meth:`read_resource` flattens ``ReadResourceResult`` for the
+        same reason.
         """
         await self.initialize()
         require_capability(self, "prompts")
         try:
-            if self._uses_official_sdk:
-                result = await self._client.get_prompt(name=name, arguments=arguments)
-            else:
-                result = await self._client.get_prompt_mcp(name=name, arguments=arguments)
+            result = await self._client.get_prompt(name=name, arguments=arguments)
         except Exception as exc:
             _classify_and_raise(exc, f"MCP prompts/get error: {exc}")
         return _get_prompt_result_to_dict(result)
@@ -1610,15 +1431,15 @@ class MCPClient:
         module docstring for the full fact-check). This is a REFUSAL, the same
         shape as :func:`require_capability` — not a transport failure.
 
-        **#3698 stage 1 re-measurement**: this declaration was already reading
-        ``mcp.types.ServerCapabilities``/``ResourcesCapability`` directly — the
-        official SDK's own types, not a fastmcp-shaped projection — since
+        **#3698/#4282 re-measurement**: this declaration was always reading
+        ``mcp.types.ServerCapabilities``/``ResourcesCapability`` directly —
+        the official SDK's own types, not a fastmcp-shaped projection.
         ``self._server_capabilities`` is populated from ``ClientSession.
-        initialize()``'s ``InitializeResult.capabilities`` on the stdio/
-        non-OAuth-http/sse path (and from fastmcp's ``Client.initialize_result.
-        capabilities`` — same underlying SDK type — on the OAuth/fastmcp path).
-        No code or behavior change; re-confirmed by re-reading both call sites'
-        population code, not just this predicate's read side.
+        initialize()``'s ``InitializeResult.capabilities`` on every
+        transport now (#4282 closed the last path — OAuth-configured http —
+        that instead read it off fastmcp's ``Client.initialize_result.
+        capabilities``, same underlying SDK type). No code or behavior
+        change; re-confirmed by re-reading the population code.
         """
         server = self.server_name or "<unknown>"
         version = self.negotiated_version or "<unknown>"
@@ -1638,41 +1459,32 @@ class MCPClient:
         :meth:`_require_resources_subscribe_capability`) — a server may support
         reading resources without supporting subscriptions to them.
 
-        Uses the RAW ``mcp.ClientSession.subscribe_resource`` (verified: FastMCP's
-        ``Client`` has no subscribe convenience method of its own — only the
-        underlying ``mcp.ClientSession``, reached via ``Client.session``, does).
-        The notification itself carries no payload (just ``uri``) — callers
-        re-read the resource to see the new content; see
-        :mod:`reyn.mcp.message_handler`'s ``on_resource_updated`` for the
-        EventLog bridge.
-
-        #3698 stage 1: once ``self._client`` IS the ``ClientSession`` directly
-        (stdio), the ``.session`` indirection fastmcp needed is gone — call
-        the method on ``self._client`` itself.
+        ``self._client`` IS the ``ClientSession`` directly (#4282: every
+        transport, OAuth included), so ``subscribe_resource`` is called on
+        it directly — no ``.session`` indirection needed (that was
+        fastmcp's own ``Client`` exposing it only via ``Client.session``,
+        never on ``Client`` itself). The notification itself carries no
+        payload (just ``uri``) — callers re-read the resource to see the
+        new content; see :mod:`reyn.mcp.message_handler`'s
+        ``on_resource_updated`` for the EventLog bridge.
         """
         await self.initialize()
         require_capability(self, "resources")
         self._require_resources_subscribe_capability()
         try:
-            if self._uses_official_sdk:
-                await self._client.subscribe_resource(uri)
-            else:
-                await self._client.session.subscribe_resource(uri)
+            await self._client.subscribe_resource(uri)
         except Exception as exc:
             _classify_and_raise(exc, f"MCP resources/subscribe error: {exc}")
 
     async def unsubscribe_resource(self, uri: str) -> None:
         """Unsubscribe from server-pushed updates for ``uri``. Same gating as
-        :meth:`subscribe_resource`; mirrors it via the raw
+        :meth:`subscribe_resource`; mirrors it via
         ``mcp.ClientSession.unsubscribe_resource``."""
         await self.initialize()
         require_capability(self, "resources")
         self._require_resources_subscribe_capability()
         try:
-            if self._uses_official_sdk:
-                await self._client.unsubscribe_resource(uri)
-            else:
-                await self._client.session.unsubscribe_resource(uri)
+            await self._client.unsubscribe_resource(uri)
         except Exception as exc:
             _classify_and_raise(exc, f"MCP resources/unsubscribe error: {exc}")
 
@@ -1694,7 +1506,6 @@ class MCPClient:
             self.close_stderr_capture()
             self._reap_child_process()  # nothing opened, or already closed once — still idempotent
             return
-        client = self._client
         exit_stack = self._exit_stack
         self._client = None
         self._exit_stack = None
@@ -1706,17 +1517,16 @@ class MCPClient:
         self._negotiated_version = None
         self._server_capabilities = None
         try:
-            # #3698 stage 1: stdio was opened via self._exit_stack (the official
-            # SDK's stdio_client + ClientSession, entered as two separate async
-            # context managers — see _initialize_stdio) — closing means exiting
-            # THAT stack, not calling .close() on the ClientSession object
-            # (which has no such method; only __aexit__ via the stack it was
-            # entered through). http/sse still open via fastmcp's Client,
-            # which owns its own close().
-            if exit_stack is not None:
-                await exit_stack.aclose()
-            else:
-                await client.close()
+            # #4282: every transport (stdio, http/sse with or without OAuth)
+            # opens via self._exit_stack now — the official SDK's transport
+            # + ClientSession, entered as two separate async context
+            # managers (see _initialize_stdio / _initialize_http_or_sse) —
+            # closing means exiting THAT stack. ClientSession itself has no
+            # .close() method; only __aexit__ via the stack it was entered
+            # through. exit_stack is always set alongside self._client (both
+            # init paths set them together), so this is no longer a branch.
+            assert exit_stack is not None  # narrows the type; see comment above
+            await exit_stack.aclose()
         except (Exception, asyncio.CancelledError):
             # Best-effort graceful cleanup; transport may already be down. The
             # belt-and-suspenders reap in the finally still terminates the OS
@@ -1847,22 +1657,6 @@ class MCPClient:
             pass
 
     # ── transport dispatch ──────────────────────────────────────────────────
-
-    def _open_transport(self) -> "Any":
-        """Build the ``fastmcp.client.transports.ClientTransport`` for this server.
-
-        Unlike the pre-swap ``mcp`` SDK version, this returns a constructed
-        transport OBJECT (not an entered async context manager / stream
-        tuple) — FastMCP's ``Client(transport)`` owns opening it.
-        """
-        if self._type == "stdio":
-            return self._open_stdio()
-        if self._type == "http":
-            return self._open_http()
-        if self._type == "sse":
-            return self._open_sse()
-        # Unreachable due to __init__ validation, but keep defensive.
-        raise ValueError(f"Unsupported MCP server type: {self._type!r}")
 
     def _build_mcp_sandbox_policy(self):
         """SandboxPolicy for a sandboxed stdio MCP server (#1344).
@@ -2049,58 +1843,9 @@ class MCPClient:
         self._sandbox_env = wrapped.env
         return wrapped.argv[0], list(wrapped.argv[1:])
 
-    def _open_stdio(self) -> "Any":
-        from reyn.mcp._fastmcp_boundary import import_stdio_transport
-
-        StdioTransport = import_stdio_transport()
-
-        command = self._config.get("command")
-        if not command:
-            raise MCPError("stdio MCP server config requires 'command'")
-        args = list(self._config.get("args") or [])
-        # #1344: wrap the server subprocess in the platform sandbox (Seatbelt)
-        # so an LLM-invoked MCP tool cannot escape the sandbox via the server.
-        command, args = self._sandbox_wrap_stdio(command, args)
-        # #3848 stage 1: self._sandbox_env (the allowlisted env, now carried
-        # through rather than dropped) is intentionally NOT consumed here —
-        # the owner ruling's default is "pass everything" (unchanged), which
-        # the allowlist is narrower than. Stage 2's opt-in whitelist mode
-        # will read self._sandbox_env; opt-in blacklist mode will filter
-        # os.environ against an operator-declared name set instead.
-        env = self._config.get("env")
-        # Subprocess stderr capture for diagnostic readback on init
-        # failure. FastMCP's ``StdioTransport`` accepts ``log_file`` (a
-        # Path or TextIO) and passes it straight through to the underlying
-        # ``anyio.open_process(stderr=...)``, which requires a real
-        # fileno — ``io.StringIO`` doesn't work. ``tempfile.TemporaryFile``
-        # auto-deletes on close. Text-mode + utf-8 matches the SDK's
-        # default (= sys.stderr). On failure to open the temp file we
-        # fall through to no capture (= behavior degrades gracefully
-        # to the pre-fix opaque error wording, never blocks the call).
-        try:
-            self._stderr_capture = tempfile.TemporaryFile(
-                mode="w+t", encoding="utf-8",
-            )
-        except Exception:  # noqa: BLE001 — temp-file failure is non-fatal
-            self._stderr_capture = None
-            log_file = None
-        else:
-            log_file = self._stderr_capture
-        return StdioTransport(
-            command=command,
-            args=args,
-            env=dict(env) if env else None,
-            cwd=self._config.get("cwd"),
-            # keep_alive=True matches the pre-swap subprocess-reuse contract:
-            # MCPClient/pool open once and hold the same transport/subprocess
-            # for the object's lifetime (a359 P2 task-affine caching).
-            keep_alive=True,
-            log_file=log_file,
-        )
-
     def _is_non_interactive(self) -> bool:
         """Resolve the effective headless/non-interactive posture for the
-        #2597 slice ④ OAuth pre-flight check (see :meth:`_build_oauth_auth`).
+        #2597 slice ④ OAuth pre-flight check (see :meth:`_build_oauth_provider`).
 
         The explicit constructor kwarg wins when given; otherwise auto-detect
         via ``sys.stdin.isatty()`` — no attached TTY means there is no human
@@ -2116,15 +1861,18 @@ class MCPClient:
         except Exception:  # noqa: BLE001
             return True
 
-    def _build_oauth_auth(self, url: str) -> "Any":
-        """Build the ``fastmcp.client.auth.OAuth`` object for ``self._config
-        ["auth"]``, or return None if this server config carries no ``auth``
-        key at all (the pre-④ static-bearer-via-``headers`` path, unchanged).
+    async def _build_oauth_provider(self, url: str) -> "Any":
+        """Build the official SDK's ``mcp.client.auth.OAuthClientProvider``
+        for ``self._config["auth"]``, or return None if this server config
+        carries no ``auth`` key at all (the pre-④ static-bearer-via-
+        ``headers`` path, unchanged). #4282: replaces the retired
+        ``_build_oauth_auth`` (which built fastmcp's ``OAuth`` object) — the
+        validation contract below is unchanged from it.
 
-        See the module docstring's "OAuth 2.1 (#2597 slice ④)" section for
-        the full contract this implements. Raises :class:`MCPError` eagerly
-        (this module's existing lazy-validate-at-connect-time posture, same
-        as the ``type``/``url`` checks above) for: a non-``oauth`` ``auth``
+        See the module docstring's "OAuth 2.1" section for the full
+        contract this implements. Raises :class:`MCPError` eagerly (this
+        module's existing lazy-validate-at-connect-time posture, same as
+        the ``type``/``url`` checks above) for: a non-``oauth`` ``auth``
         type, an ``auth`` key on a non-``http`` transport, or a headless
         caller with no cached token yet.
         """
@@ -2153,8 +1901,8 @@ class MCPClient:
             )
         # Note: the http-only restriction is already enforced eagerly in
         # __init__ (config.get("auth") + srv_type != "http" raises there) —
-        # this method is only ever reached via _open_http, so self._type is
-        # guaranteed "http" here.
+        # this method is only ever reached via _initialize_http_or_sse's
+        # http branch, so self._type is guaranteed "http" here.
 
         from reyn.mcp.oauth_token_storage import (
             MCPOAuthTokenStorage,
@@ -2171,85 +1919,73 @@ class MCPClient:
                 "subsequent headless/non-interactive runs."
             )
 
-        from reyn.mcp._fastmcp_boundary import import_oauth
+        from mcp.client.auth import OAuthClientProvider
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata
+        from pydantic import AnyHttpUrl
 
-        OAuth = import_oauth()
-
-        scopes = auth_cfg.get("scopes")
-        return OAuth(
-            mcp_url=url,
-            scopes=scopes,
-            client_id=auth_cfg.get("client_id"),
-            client_secret=auth_cfg.get("client_secret"),
-            token_storage=MCPOAuthTokenStorage(),
+        from reyn.mcp.oauth_browser_flow import (
+            find_available_port,
+            redirect_handler,
+            run_callback_server,
         )
 
-    def _open_http(self) -> "Any":
-        """Open the Streamable HTTP transport.
+        storage = MCPOAuthTokenStorage(url)
 
-        Reads from ``self._config``:
-          - ``url`` (required) — full MCP endpoint URL.
-          - ``headers`` (optional dict[str, str]) — HTTP headers sent on
-            every request to the server. Used for ``Authorization: Bearer
-            <token>`` and API-key style auth required by hosted MCP servers
-            (GitHub MCP, Atlassian MCP, internal enterprise MCPs).  This is
-            FP-0016 Component A. Values are passed through verbatim;
-            ``${VAR}`` interpolation is the caller's responsibility (the
-            standard load_config path applies ``expand_env`` recursively
-            across the whole merged config — see ADR-0030).
-          - ``auth`` (optional — #2597 slice ④) — ``"oauth"`` or
-            ``{"type": "oauth", "scopes": [...], "client_id": ..., "client_secret":
-            ...}``. Mutually additive with ``headers`` (both can be set; a
-            server that also needs a static header alongside OAuth is
-            supported). See :meth:`_build_oauth_auth`.
-          - ``timeout`` (optional, default 30) — request timeout in seconds.
-            FastMCP's ``StreamableHttpTransport`` has no per-transport
-            connect timeout (its ``sse_read_timeout`` ctor kwarg is
-            deprecated/unused by the new streamable-http client); the
-            equivalent bound is the ``Client``-level default read timeout
-            (``fastmcp.Client(transport, timeout=...)``), which flows into
-            every request's ``read_timeout_seconds`` exactly like the
-            per-call ``timeout_seconds`` kwarg on :meth:`call_tool` — same
-            SDK knob, applied as this transport's default instead of the
-            old connect-level timeout.
-        """
-        from reyn.mcp._fastmcp_boundary import import_streamable_http_transport
+        scopes = auth_cfg.get("scopes")
+        if isinstance(scopes, list):
+            scope_str = " ".join(scopes)
+        elif scopes:
+            scope_str = str(scopes)
+        else:
+            scope_str = ""
 
-        StreamableHttpTransport = import_streamable_http_transport()
+        port = find_available_port()
+        redirect_uri = f"http://127.0.0.1:{port}/callback"
+        client_metadata = OAuthClientMetadata(
+            client_name="reyn",
+            redirect_uris=[AnyHttpUrl(redirect_uri)],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            scope=scope_str,
+        )
 
-        url = self._config.get("url")
-        if not url:
-            raise MCPError("http MCP server config requires 'url'")
-        headers = {
-            str(k): str(v) for k, v in (self._config.get("headers") or {}).items()
-        }
-        # FP-0016 Component E: inject the agent_id as X-Reyn-Agent-Id so
-        # downstream MCP servers can attribute requests to a specific
-        # Reyn agent (= RBAC + audit trail requirement per the issue
-        # シナリオ 5 Enterprise Agent ID pattern). Explicit operator
-        # headers win when they already set the field — operators may
-        # need to spoof in tests or proxy in production.
-        if self._agent_id and "X-Reyn-Agent-Id" not in headers:
-            headers["X-Reyn-Agent-Id"] = self._agent_id
-        auth = self._build_oauth_auth(url)
-        return StreamableHttpTransport(url, headers=headers, auth=auth)
+        # Static client_id (skip Dynamic Client Registration) — mirrors
+        # fastmcp's own OAuth._bind's static-client-info shortcut. Pre-
+        # seeding storage.set_client_info() BEFORE constructing the
+        # provider works because OAuthClientProvider only runs DCR when
+        # ``self.context.client_info`` is still None after ``_initialize()``
+        # loads it via ``storage.get_client_info()`` (verified by reading
+        # ``mcp/client/auth/oauth2.py``'s async_auth_flow directly: "Step 4:
+        # Register client or use URL-based client ID" is gated on
+        # ``if not self.context.client_info:``).
+        client_id = auth_cfg.get("client_id")
+        client_secret = auth_cfg.get("client_secret")
+        if client_id:
+            metadata_dict = client_metadata.model_dump(exclude_none=True)
+            metadata_dict.setdefault(
+                "token_endpoint_auth_method",
+                "client_secret_post" if client_secret else "none",
+            )
+            static_info = OAuthClientInformationFull(
+                client_id=client_id, client_secret=client_secret, **metadata_dict,
+            )
+            await storage.set_client_info(static_info)
 
-    def _open_sse(self) -> "Any":
-        """Open the SSE transport (#2597 S1 free win — FastMCP ships it, so no
-        incremental cost to wire vs. leaving the pre-swap ``NotImplementedError``)."""
-        from reyn.mcp._fastmcp_boundary import import_sse_transport
+        callback_timeout = float(auth_cfg.get("callback_timeout", 300.0))
 
-        SSETransport = import_sse_transport()
+        async def _callback_handler() -> tuple[str, str | None]:
+            return await run_callback_server(
+                host="127.0.0.1", port=port, timeout=callback_timeout,
+            )
 
-        url = self._config.get("url")
-        if not url:
-            raise MCPError("sse MCP server config requires 'url'")
-        headers = {
-            str(k): str(v) for k, v in (self._config.get("headers") or {}).items()
-        }
-        if self._agent_id and "X-Reyn-Agent-Id" not in headers:
-            headers["X-Reyn-Agent-Id"] = self._agent_id
-        return SSETransport(url, headers=headers)
+        return OAuthClientProvider(
+            server_url=url,
+            client_metadata=client_metadata,
+            storage=storage,
+            redirect_handler=redirect_handler,
+            callback_handler=_callback_handler,
+            timeout=callback_timeout,
+        )
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────

--- a/src/reyn/mcp/oauth_browser_flow.py
+++ b/src/reyn/mcp/oauth_browser_flow.py
@@ -1,0 +1,128 @@
+"""MCP OAuth browser-authorization flow — #4282 (fastmcp retired for the
+client's OAuth path in favour of the official ``mcp`` SDK's
+``mcp.client.auth.OAuthClientProvider`` directly).
+
+``OAuthClientProvider`` needs the caller to supply TWO callbacks
+(``redirect_handler``/``callback_handler``) implementing the actual
+browser-based Authorization Code Grant round trip — fastmcp's own ``OAuth``
+class did this internally (``uvicorn.Server`` + a Starlette app in
+``fastmcp.client.oauth_callback``). This module is reyn's OWN equivalent,
+built from starlette/uvicorn directly — **both already core reyn
+dependencies** (see ``pyproject.toml``), so this is zero new dependency
+surface, not a new one. fastmcp's own callback-server module is
+deliberately NOT imported here: importing it would keep a live dependency
+on fastmcp exactly where #4282's whole point is to drop it.
+
+Lifecycle (live-verified against a real bound localhost listener + a real
+httpx GET before this was written, not assumed from reading uvicorn's API
+alone): a ``uvicorn.Server`` is run via ``await server.serve()`` inside an
+``anyio.create_task_group()`` in the SAME task/call tree as the rest of the
+OAuth flow (mirrors fastmcp's own approach) — poll ``server.started`` until
+the listener is actually up (uvicorn does not expose an awaitable "ready"
+signal), then wait for the single ``/callback`` request (or the configured
+timeout) via an ``anyio.Event``, then ``server.should_exit = True`` to stop
+serving and let the task group exit cleanly.
+"""
+from __future__ import annotations
+
+import logging
+import socket
+import webbrowser
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class OAuthCallbackTimeout(Exception):
+    """Raised when no ``/callback`` request arrived within ``timeout`` seconds."""
+
+
+def find_available_port(host: str = "127.0.0.1") -> int:
+    """Return an ephemeral port currently free on ``host``.
+
+    Same bind-port-0-then-release approach fastmcp's own
+    ``find_available_port`` uses — there is a narrow TOCTOU window between
+    releasing the socket here and the callback server re-binding it, but
+    it is the standard, unavoidable approach for "let the OS pick a free
+    port" without holding the socket open across the two separate libraries
+    (this module's port-finder vs. uvicorn's own bind) involved.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind((host, 0))
+        return s.getsockname()[1]
+
+
+async def redirect_handler(authorization_url: str) -> None:
+    """``OAuthClientProvider``'s ``redirect_handler`` contract: open the
+    authorization URL in the operator's browser. No pre-flight validity
+    check (fastmcp's own does one — a GET before opening, to catch a bad
+    ``client_id`` early) — deliberately out of scope here: this module's
+    job is opening the browser, not validating the server's response
+    shape; the browser itself surfaces a bad-client error to the operator
+    directly, same as it would for a bad password or any other login
+    failure."""
+    logger.info("MCP OAuth authorization URL: %s", authorization_url)
+    webbrowser.open(authorization_url)
+
+
+async def run_callback_server(
+    *, host: str, port: int, timeout: float
+) -> tuple[str, str | None]:
+    """``OAuthClientProvider``'s ``callback_handler`` contract: run a
+    localhost HTTP server on ``host``:``port`` until the browser redirects
+    back to ``/callback?code=...&state=...`` (or ``?error=...``), then
+    return ``(code, state)``.
+
+    Raises :class:`OAuthCallbackTimeout` if no callback request arrives
+    within ``timeout`` seconds, or the underlying error (e.g. a
+    ``RuntimeError`` built from an ``?error=`` query param the
+    authorization server sent) on an explicit failure response.
+    """
+    import anyio
+    import uvicorn
+    from starlette.applications import Starlette
+    from starlette.responses import PlainTextResponse
+    from starlette.routing import Route
+
+    result: dict[str, Any] = {}
+    received = anyio.Event()
+
+    async def _callback(request: Any) -> Any:
+        params = request.query_params
+        if "error" in params:
+            result["error"] = RuntimeError(
+                f"MCP OAuth authorization failed: {params.get('error')} "
+                f"({params.get('error_description', 'no description')})"
+            )
+            received.set()
+            return PlainTextResponse(
+                "Authorization failed — you may close this window.", status_code=400,
+            )
+        result["code"] = params.get("code")
+        result["state"] = params.get("state")
+        received.set()
+        return PlainTextResponse("Authorization complete — you may close this window.")
+
+    app = Starlette(routes=[Route("/callback", _callback, methods=["GET"])])
+    config = uvicorn.Config(app, host=host, port=port, log_level="warning")
+    server = uvicorn.Server(config)
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(server.serve)
+        try:
+            while not server.started:
+                await anyio.sleep(0.01)
+            try:
+                with anyio.fail_after(timeout):
+                    await received.wait()
+            except TimeoutError as exc:
+                raise OAuthCallbackTimeout(
+                    f"MCP OAuth callback timed out after {timeout}s — no browser "
+                    "redirect arrived at the local callback server."
+                ) from exc
+        finally:
+            server.should_exit = True
+
+    if "error" in result:
+        raise result["error"]
+    return result["code"], result.get("state")

--- a/src/reyn/mcp/oauth_token_storage.py
+++ b/src/reyn/mcp/oauth_token_storage.py
@@ -1,59 +1,86 @@
-"""MCP OAuth token storage — #2597 slice ④ (OAuth 2.1 + Streamable HTTP completion).
+"""MCP OAuth token storage — #2597 slice ④ (OAuth 2.1 + Streamable HTTP),
+rewritten for #3698 stage 2 / #4282 (fastmcp's ``OAuth`` retired in favour of
+the official ``mcp`` SDK's ``mcp.client.auth.OAuthClientProvider`` directly).
 
-FastMCP's browser-based OAuth helper (``fastmcp.client.auth.OAuth`` — verified
-against the installed fastmcp 3.4.2 source at
-``fastmcp/client/auth/oauth.py``) does NOT implement its own bare
-``mcp.client.auth.TokenStorage`` (get_tokens/set_tokens/get_client_info/
-set_client_info) as the module docstring of the umbrella issue originally
-assumed. Instead ``OAuth(..., token_storage=...)`` takes a
-``key_value.aio.protocols.AsyncKeyValue``-conforming store (the
-``key-value-aio`` package's generic async KV protocol: ``get``/``put``/
-``delete``/``ttl`` + ``*_many`` bulk variants, each keyed by ``(key,
-collection)``) and wraps it internally in its own
-``TokenStorageAdapter(async_key_value, server_url)`` — a ``PydanticAdapter``
-that serialises ``mcp.shared.auth.OAuthToken`` / ``OAuthClientInformationFull``
-to/from plain JSON-safe dicts before calling ``get``/``put`` on whatever store
-we hand it, under two collections (``"mcp-oauth-token"``,
-``"mcp-oauth-client-info"``) plus one bare key (``"<url>/token_expiry"``,
-collection ``"mcp-oauth-token-expiry"``) it manages directly on the KV store
-for the ABSOLUTE access-token expiry (added upstream to fix a stale-relative-
-``expires_in`` bug on reload). :class:`MCPOAuthTokenStorage` below is reyn's
-implementation of that ``AsyncKeyValue`` protocol — NOT FastMCP's assumed
-``TokenStorage`` ABC — verified by reading ``fastmcp/client/auth/oauth.py``
-and ``key_value/aio/protocols/key_value.py`` directly (see this module's PR
-for the read-out).
+:class:`MCPOAuthTokenStorage` below implements the official SDK's OWN
+``mcp.client.auth.TokenStorage`` protocol (``get_tokens``/``set_tokens``/
+``get_client_info``/``set_client_info`` — verified by reading the installed
+``mcp`` SDK's ``mcp/client/auth/oauth2.py`` directly) — NOT fastmcp's
+``key_value.aio.protocols.AsyncKeyValue`` shape this module used pre-#4282.
 
-Storage location — the reyn-dir-layout "outside" bucket (see
+Why the double adapter this module previously carried is gone: fastmcp's
+``OAuth(token_storage=...)`` wanted an ``AsyncKeyValue``-conforming store
+(``get``/``put``/``delete``/``ttl`` + ``*_many`` bulk variants, keyed by
+``(key, collection)``) that IT wrapped internally in its own
+``TokenStorageAdapter`` before handing the (simpler) ``TokenStorage`` shape
+down to ``OAuthClientProvider``. Now that ``OAuthClientProvider`` is
+constructed directly (#4282: fastmcp.Client is no longer built for ANY
+transport, OAuth included — see :mod:`reyn.mcp.client`'s module docstring),
+nothing in reyn's process ever asks for the ``AsyncKeyValue`` shape again —
+carrying both would be dead code for a caller that no longer exists.
+``TokenStorage`` is also structurally simpler: ONE instance is bound to ONE
+``server_url`` (passed to ``OAuthClientProvider.__init__``, not to each
+storage call), so there is no ``(key, collection)`` parameter to plumb here
+either.
+
+Storage location — unchanged, the reyn-dir-layout "outside" bucket (see
 ``docs/reference/runtime/reyn-dir-layout.md``): tokens land in the SAME
 ``~/.reyn/oauth_tokens.json`` (chmod 600) that reyn's existing RFC 8628
 device-grant store (:mod:`reyn.security.secrets.oauth`, FP-0016 Component
-B/C — merged before this slice) already reads/writes. This module reuses
-THAT module's ``_read_store``/``_write_store``/``_default_oauth_path``
-helpers (single-file read-modify-write + chmod 600 enforcement) rather than
-introducing a second on-disk JSON-store implementation — "grep existing
-mechanism first" — and namespaces every entry it writes under an
-``"mcp:"``-prefixed compound key (``mcp:<collection>::<key>``) so MCP OAuth
-entries can never collide with the device-grant module's provider-keyed
-entries in the same file. Neither store is under ``.reyn/`` (project-scoped
-recovery-core) — both are ``~/.reyn/`` (operator/user-owned, outside bucket):
-never written through a WAL-emitting op, never captured by rewind/PITR, and
-this module contains no logging of token VALUES (only keys/URLs ever appear
-in any warning/error text).
+B/C) already reads/writes, reusing THAT module's ``_read_store``/
+``_write_store``/``_default_oauth_path`` helpers. Neither store is under
+``.reyn/`` (project-scoped recovery-core) — both are ``~/.reyn/``
+(operator/user-owned, outside bucket): never written through a WAL-emitting
+op, never captured by rewind/PITR, and this module logs no token VALUES
+(only keys/URLs ever appear in any warning/error text).
 
-Headless / no-token graceful failure: FastMCP's ``OAuth`` opens a browser +
-a localhost callback server to complete the FIRST authorization — that only
-works with an attached interactive session. :func:`has_stored_token` lets
+Key scheme — a NEW, disjoint namespace from the pre-#4282 AsyncKeyValue
+compound-key scheme (``mcp:<collection>::<key>``): every key here is
+prefixed ``mcp-oauth2:``. This is a deliberate clean break, not an oversight
+— per the owner's standing "no backward-compat, no migration" ruling
+(CLAUDE.md), an entry written under the OLD scheme is simply never looked up
+under the NEW one; no migration script is written, and reauthentication
+via the browser flow is the expected (and only) recovery path. **This is
+NOT a silent-failure risk for a caller who upgrades reyn with an old token
+file on disk**: the OLD entries just don't exist under the new keys, so
+:func:`has_stored_token` reports False and the normal
+"needs authentication" path runs — the same path a first-ever run takes.
+The failure mode this module DOES guard against explicitly (per lead-coder's
+review condition on #4282) is a NEW-scheme entry whose stored JSON shape no
+longer round-trips through ``OAuthToken``/``OAuthClientInformationFull``
+(e.g. a FUTURE reyn version changes what it stores) — :meth:`get_tokens`/
+:meth:`get_client_info` catch that specific case and emit a clear
+``logging.warning`` naming the server + the fact that re-authentication is
+needed, rather than letting a raw ``pydantic.ValidationError`` propagate
+from deep inside the SDK's OAuth flow, or (the worse alternative) silently
+swallowing it and returning None with no trace at all.
+
+Expiry tracking — the official SDK's own ``OAuthContext`` does NOT persist
+``token_expiry_time`` across a process restart (verified by reading
+``mcp/client/auth/oauth2.py``'s ``_initialize()``: it restores
+``current_tokens`` from storage but never calls ``update_token_expiry()``
+on the restored value) — a reloaded token is treated as valid until a real
+401 triggers the SDK's own reactive full-reauth path. That is the SDK's own
+design choice and not this module's to work around. This module tracks its
+OWN best-effort absolute expiry (``time.time() + expires_in`` at write time)
+SEPARATELY, for exactly one purpose: :func:`has_stored_token`'s headless
+pre-flight check in :mod:`reyn.mcp.client`, so a non-interactive caller with
+an obviously-expired cached token gets reyn's own clear
+"run interactively to re-authenticate" ``MCPError`` immediately, instead of
+proceeding to a request that will 401 and then have the SDK attempt a
+browser-flow re-auth that a headless caller can never complete.
+
+Headless / no-token graceful failure: :func:`has_stored_token` lets
 :mod:`reyn.mcp.client` check, BEFORE constructing the transport, whether a
 usable token is already cached for a given MCP server URL; if not, and the
 caller is running non-interactively, ``client.py`` raises a clear
-``MCPError`` instead of letting FastMCP hang (bounded only by its own
-``callback_timeout``, default 300s) waiting for a browser round-trip nobody
-can complete.
+``MCPError`` instead of letting the OAuth flow hang waiting for a browser
+round-trip nobody can complete.
 """
 from __future__ import annotations
 
+import logging
 import time
-from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -63,63 +90,58 @@ from reyn.security.secrets.oauth import (
     _write_store,
 )
 
-# Same collection + key-shape FastMCP's ``TokenStorageAdapter._get_token_cache_key``
-# uses (``f"{server_url}/tokens"``, collection ``"mcp-oauth-token"``) — verified
-# against the installed fastmcp 3.4.2 source. Duplicated here (not imported) so
-# :func:`has_stored_token` can answer the "do we already have a token" question
-# with a plain synchronous file read, without instantiating FastMCP's OAuth /
-# PydanticAdapter machinery just to ask.
-_TOKEN_COLLECTION = "mcp-oauth-token"
+logger = logging.getLogger(__name__)
+
+# Disjoint from the pre-#4282 AsyncKeyValue compound-key prefix ("mcp:") —
+# see module docstring's "Key scheme" section for why this is a deliberate
+# clean break, not an oversight.
+_KEY_PREFIX = "mcp-oauth2"
 
 
-def _mcp_compound_key(key: str, collection: str | None) -> str:
-    """Namespace ``(key, collection)`` into the single flat dict the shared
-    ``oauth_tokens.json`` file stores, prefixed so MCP OAuth entries can never
-    collide with :mod:`reyn.security.secrets.oauth`'s device-grant keys."""
-    return f"mcp:{collection or '_default'}::{key}"
+def _tokens_key(server_url: str) -> str:
+    return f"{_KEY_PREFIX}:{server_url.rstrip('/')}:tokens"
 
 
-def _server_token_key(mcp_url: str) -> str:
-    """Mirror FastMCP's ``TokenStorageAdapter._get_token_cache_key`` exactly:
-    the URL is right-stripped of a trailing slash first (verified against
-    ``OAuth._bind``, which does ``mcp_url = mcp_url.rstrip("/")`` before
-    constructing its ``TokenStorageAdapter``)."""
-    return f"{mcp_url.rstrip('/')}/tokens"
+def _client_info_key(server_url: str) -> str:
+    return f"{_KEY_PREFIX}:{server_url.rstrip('/')}:client_info"
 
 
 def has_stored_token(mcp_url: str, *, path: Path | None = None) -> bool:
-    """Return True iff a (not-yet-expired-by-our-own-TTL) OAuth token is
-    already cached for ``mcp_url``. Used by :mod:`reyn.mcp.client` to decide,
-    BEFORE opening a transport, whether a non-interactive caller can proceed
-    without hitting FastMCP's browser flow. Never raises; a corrupt/missing
-    store answers False (= "no usable token yet", the conservative default —
-    same posture as :class:`~reyn.mcp.client.MCPClient.supports`)."""
+    """Return True iff a (not-yet-expired-by-our-own-tracking) OAuth token
+    is already cached for ``mcp_url``. Never raises; a corrupt/missing store
+    or an entry in an unrecognized shape answers False (= "no usable token
+    yet", the conservative default — same posture as
+    :class:`~reyn.mcp.client.MCPClient.supports`) — the caller then takes
+    the normal "needs authentication" path, which is the correct fallback
+    either way."""
     store_path = path if path is not None else _default_oauth_path()
     data = _read_store(store_path)
-    entry = data.get(_mcp_compound_key(_server_token_key(mcp_url), _TOKEN_COLLECTION))
+    entry = data.get(_tokens_key(mcp_url))
     if not isinstance(entry, dict):
         return False
     expires_at = entry.get("_expires_at")
     if expires_at is not None and time.time() >= expires_at:
         return False
-    return isinstance(entry.get("_value"), dict)
+    value = entry.get("_value")
+    return isinstance(value, dict) and bool(value.get("access_token"))
 
 
 class MCPOAuthTokenStorage:
-    """``key_value.aio.protocols.AsyncKeyValue``-conforming store FastMCP's
-    ``OAuth(token_storage=...)`` accepts (see module docstring for the exact
-    verified contract). Backed by the shared ``~/.reyn/oauth_tokens.json``
-    (outside bucket, chmod 600) via :mod:`reyn.security.secrets.oauth`'s
-    ``_read_store``/``_write_store`` helpers — a full-file read-modify-write
-    per call, which is fine at OAuth's write frequency (login + occasional
-    refresh, not a hot path).
+    """``mcp.client.auth.TokenStorage``-conforming store for ONE MCP server
+    (bound to ``server_url`` at construction — matches
+    ``OAuthClientProvider.__init__(server_url, ..., storage=...)``'s
+    per-instance-per-server contract). Backed by the shared
+    ``~/.reyn/oauth_tokens.json`` (outside bucket, chmod 600) via
+    :mod:`reyn.security.secrets.oauth`'s ``_read_store``/``_write_store``
+    helpers — a full-file read-modify-write per call, which is fine at
+    OAuth's write frequency (login + occasional refresh, not a hot path).
 
-    Never logs token values: every method here only ever formats *keys* /
-    *collection names* into anything user-visible (there is nothing
-    user-visible in this class at all — it's pure file I/O).
+    Never logs token VALUES: every log line here only ever formats the
+    server URL / key names into anything user-visible.
     """
 
-    def __init__(self, *, path: Path | None = None) -> None:
+    def __init__(self, server_url: str, *, path: Path | None = None) -> None:
+        self._server_url = server_url
         self._path = path if path is not None else _default_oauth_path()
 
     def _load(self) -> dict[str, Any]:
@@ -128,86 +150,73 @@ class MCPOAuthTokenStorage:
     def _save(self, data: dict[str, Any]) -> None:
         _write_store(self._path, data)
 
-    async def get(self, key: str, *, collection: str | None = None) -> dict[str, Any] | None:
-        value, _ttl = await self.ttl(key, collection=collection)
-        return value
+    async def get_tokens(self) -> "Any | None":
+        """Return the stored ``mcp.shared.auth.OAuthToken``, or None if
+        absent / unreadable / no longer valid against the current schema.
 
-    async def ttl(
-        self, key: str, *, collection: str | None = None
-    ) -> tuple[dict[str, Any] | None, float | None]:
-        entry = self._load().get(_mcp_compound_key(key, collection))
+        A ``pydantic.ValidationError`` while re-hydrating an on-disk entry
+        is caught and logged at WARNING (naming the server + "format
+        changed, re-authentication required") rather than propagating raw
+        from inside the SDK's OAuth flow, or being silently swallowed —
+        see the module docstring's expiry/failure-mode section."""
+        entry = self._load().get(_tokens_key(self._server_url))
         if not isinstance(entry, dict):
-            return None, None
-        expires_at = entry.get("_expires_at")
+            return None
         value = entry.get("_value")
         if not isinstance(value, dict):
-            return None, None
-        if expires_at is not None:
-            remaining = expires_at - time.time()
-            if remaining <= 0:
-                return None, None
-            return dict(value), remaining
-        return dict(value), None
+            return None
+        expires_at = entry.get("_expires_at")
+        if expires_at is not None and time.time() >= expires_at:
+            return None
+        from mcp.shared.auth import OAuthToken
 
-    async def put(
-        self,
-        key: str,
-        value: Mapping[str, Any],
-        *,
-        collection: str | None = None,
-        ttl: float | None = None,
-    ) -> None:
+        try:
+            return OAuthToken.model_validate(value)
+        except Exception:
+            logger.warning(
+                "Stored MCP OAuth token for %r is in an unrecognized format "
+                "(schema changed since it was written) — treating as absent; "
+                "re-authenticate via the browser flow to refresh it.",
+                self._server_url,
+            )
+            return None
+
+    async def set_tokens(self, tokens: "Any") -> None:
         data = self._load()
-        data[_mcp_compound_key(key, collection)] = {
-            "_value": dict(value),
-            "_expires_at": (time.time() + float(ttl)) if ttl is not None else None,
+        expires_at = (
+            time.time() + float(tokens.expires_in)
+            if tokens.expires_in is not None
+            else None
+        )
+        data[_tokens_key(self._server_url)] = {
+            "_value": tokens.model_dump(mode="json", exclude_none=True),
+            "_expires_at": expires_at,
         }
         self._save(data)
 
-    async def delete(self, key: str, *, collection: str | None = None) -> bool:
+    async def get_client_info(self) -> "Any | None":
+        """Return the stored ``mcp.shared.auth.OAuthClientInformationFull``,
+        or None if absent / unreadable — same defensive posture as
+        :meth:`get_tokens`."""
+        entry = self._load().get(_client_info_key(self._server_url))
+        if not isinstance(entry, dict):
+            return None
+        from mcp.shared.auth import OAuthClientInformationFull
+
+        try:
+            return OAuthClientInformationFull.model_validate(entry)
+        except Exception:
+            logger.warning(
+                "Stored MCP OAuth client registration for %r is in an "
+                "unrecognized format (schema changed since it was written) — "
+                "treating as absent; dynamic client registration will run again.",
+                self._server_url,
+            )
+            return None
+
+    async def set_client_info(self, client_info: "Any") -> None:
         data = self._load()
-        compound = _mcp_compound_key(key, collection)
-        if compound not in data:
-            return False
-        del data[compound]
+        data[_client_info_key(self._server_url)] = client_info.model_dump(
+            mode="json", exclude_none=True
+        )
         self._save(data)
-        return True
-
-    async def get_many(
-        self, keys: Sequence[str], *, collection: str | None = None
-    ) -> list[dict[str, Any] | None]:
-        return [await self.get(k, collection=collection) for k in keys]
-
-    async def ttl_many(
-        self, keys: Sequence[str], *, collection: str | None = None
-    ) -> list[tuple[dict[str, Any] | None, float | None]]:
-        return [await self.ttl(k, collection=collection) for k in keys]
-
-    async def put_many(
-        self,
-        keys: Sequence[str],
-        values: Sequence[Mapping[str, Any]],
-        *,
-        collection: str | None = None,
-        ttl: float | None = None,
-    ) -> None:
-        data = self._load()
-        expires_at = (time.time() + float(ttl)) if ttl is not None else None
-        for k, v in zip(keys, values):
-            data[_mcp_compound_key(k, collection)] = {
-                "_value": dict(v),
-                "_expires_at": expires_at,
-            }
-        self._save(data)
-
-    async def delete_many(self, keys: Sequence[str], *, collection: str | None = None) -> int:
-        data = self._load()
-        removed = 0
-        for k in keys:
-            compound = _mcp_compound_key(k, collection)
-            if compound in data:
-                del data[compound]
-                removed += 1
-        if removed:
-            self._save(data)
-        return removed

--- a/tests/core/test_3070_mcp_probe_error_surfaced.py
+++ b/tests/core/test_3070_mcp_probe_error_surfaced.py
@@ -26,9 +26,9 @@ text as content). Three swallow points hid that real exception end to end:
      ABSENCE, never WHY.
 
 Each test below pins one closed swallow point. Real `EventLog` / `MCPClient`
-/ `PipelineExecutor` / `SchemaRegistry` throughout (only the deepest fastmcp
-transport is faked, mirroring `test_mcp_progress_and_timeout.py`'s own
-precedent for this exact seam) -- no mocks of reyn's own collaborators.
+/ `PipelineExecutor` / `SchemaRegistry` throughout (only the deepest SDK
+client transport is faked, mirroring `test_mcp_progress_and_timeout.py`'s
+own precedent for this exact seam) -- no mocks of reyn's own collaborators.
 """
 from __future__ import annotations
 
@@ -96,15 +96,18 @@ def _bypass_initialize(client: MCPClient, fake_fastmcp_client: Any) -> None:
 
 
 class _ErroringFastMCPClient:
-    """Stands in for the deepest `fastmcp.Client` transport (see
+    """Stands in for the deepest ``mcp.ClientSession`` transport (see
     `test_mcp_progress_and_timeout.py`'s own precedent for faking this ONE
-    seam): the tool call itself REPORTS an error (as a real FastMCP-wrapped
-    ImportError would from a missing `builtin-rag` extra), it does not raise."""
+    seam, #4282: renamed from ``call_tool_mcp`` to the official SDK's own
+    ``call_tool`` once fastmcp was no longer constructed anywhere in
+    client.py): the tool call itself REPORTS an error (as a real
+    SDK-wrapped ImportError would from a missing `builtin-rag` extra), it
+    does not raise."""
 
     def __init__(self, error_text: str) -> None:
         self._error_text = error_text
 
-    async def call_tool_mcp(
+    async def call_tool(
         self, name: str, arguments: "dict | None" = None, **kwargs: Any,
     ) -> Any:
         # `_result_to_dict` (reyn.mcp.client) reads `.content`/`.isError` as
@@ -173,7 +176,7 @@ def test_mcp_completed_event_carries_no_error_text_on_success() -> None:
     client = MCPClient({"type": "stdio", "command": "/bin/true"})
 
     class _OkFastMCPClient:
-        async def call_tool_mcp(self, name: str, arguments=None, **kwargs: Any) -> Any:
+        async def call_tool(self, name: str, arguments=None, **kwargs: Any) -> Any:
             class _Result:
                 content = [{"type": "text", "text": "ok"}]
                 isError = False

--- a/tests/core/test_fp0016_e_agent_id.py
+++ b/tests/core/test_fp0016_e_agent_id.py
@@ -106,32 +106,64 @@ def test_event_log_agent_id_property_readable() -> None:
 # ── 3. MCPClient X-Reyn-Agent-Id header ────────────────────────────────────
 
 
-def test_mcp_client_injects_x_reyn_agent_id_header() -> None:
-    """Tier 2: MCPClient(agent_id=...) adds X-Reyn-Agent-Id to HTTP headers.
+def _capture_http_headers(monkeypatch) -> dict:
+    """#4282: the pre-#4282 form of the three tests below inspected the
+    constructed ``StreamableHttpTransport`` object's ``.headers`` directly
+    (via the now-removed ``_open_http``); ``_initialize_http_or_sse`` calls
+    ``mcp.client.streamable_http.streamablehttp_client(url, headers=...)``
+    inline instead. Captures the REAL function's kwargs by wrapping it
+    (still calls through to the real one) rather than faking the SDK —
+    same seam ``test_config_mcp_headers.py`` already established."""
+    import mcp.client.streamable_http as sh_mod
 
-    #2597 S1: inspects the real ``StreamableHttpTransport.headers`` built by
-    ``_open_http()`` directly (a real fastmcp object), not a mocked SDK call.
-    """
+    captured: dict = {}
+    real_fn = sh_mod.streamablehttp_client
+
+    def _capturing(url, headers=None, timeout=30, **kwargs):
+        captured["headers"] = headers
+        return real_fn(url, headers=headers, timeout=timeout, **kwargs)
+
+    monkeypatch.setattr(sh_mod, "streamablehttp_client", _capturing)
+    return captured
+
+
+def _initialize_and_swallow_connect_failure(client) -> None:
+    import asyncio
+
+    from reyn.mcp.client import MCPError
+
+    try:
+        asyncio.run(client.initialize())
+    except MCPError:
+        pass  # expected — example.com is not a real MCP server
+    finally:
+        asyncio.run(client.close())
+
+
+def test_mcp_client_injects_x_reyn_agent_id_header(monkeypatch) -> None:
+    """Tier 2: MCPClient(agent_id=...) adds X-Reyn-Agent-Id to HTTP headers."""
     from reyn.mcp.client import MCPClient
 
+    captured = _capture_http_headers(monkeypatch)
     client = MCPClient(
-        {"type": "http", "url": "https://example.com/mcp"},
+        {"type": "http", "url": "https://example.com/mcp", "init_timeout": 1},
         agent_id="reyn/test-agent",
     )
-    transport = client._open_http()
-    assert transport.headers.get("X-Reyn-Agent-Id") == "reyn/test-agent"
+    _initialize_and_swallow_connect_failure(client)
+    assert captured["headers"].get("X-Reyn-Agent-Id") == "reyn/test-agent"
 
 
-def test_mcp_client_no_agent_id_no_header() -> None:
+def test_mcp_client_no_agent_id_no_header(monkeypatch) -> None:
     """Tier 2: agent_id=None → no X-Reyn-Agent-Id header (= backwards compat)."""
     from reyn.mcp.client import MCPClient
 
-    client = MCPClient({"type": "http", "url": "https://example.com/mcp"})
-    transport = client._open_http()
-    assert "X-Reyn-Agent-Id" not in transport.headers
+    captured = _capture_http_headers(monkeypatch)
+    client = MCPClient({"type": "http", "url": "https://example.com/mcp", "init_timeout": 1})
+    _initialize_and_swallow_connect_failure(client)
+    assert "X-Reyn-Agent-Id" not in captured["headers"]
 
 
-def test_mcp_client_operator_header_wins() -> None:
+def test_mcp_client_operator_header_wins(monkeypatch) -> None:
     """Tier 2: operator-set X-Reyn-Agent-Id in config wins over agent_id arg.
 
     Operators may need to spoof for tests or proxy in production; respect
@@ -139,16 +171,18 @@ def test_mcp_client_operator_header_wins() -> None:
     """
     from reyn.mcp.client import MCPClient
 
+    captured = _capture_http_headers(monkeypatch)
     client = MCPClient(
         {
             "type": "http",
             "url": "https://example.com/mcp",
             "headers": {"X-Reyn-Agent-Id": "reyn/spoofed"},
+            "init_timeout": 1,
         },
         agent_id="reyn/auto",
     )
-    transport = client._open_http()
-    assert transport.headers["X-Reyn-Agent-Id"] == "reyn/spoofed"
+    _initialize_and_swallow_connect_failure(client)
+    assert captured["headers"]["X-Reyn-Agent-Id"] == "reyn/spoofed"
 
 
 # ── 4. OpContext.agent_id field ────────────────────────────────────────────

--- a/tests/core/test_mcp_progress_and_timeout.py
+++ b/tests/core/test_mcp_progress_and_timeout.py
@@ -2,16 +2,16 @@
 timeout wire-up (issue #264 (a)+(b)).
 
 Pins the contract that the MCP SDK's ``progress_callback`` and
-``read_timeout_seconds`` features — which were present at the SDK
-level but unused by the Reyn integration before this PR — are now
-forwarded end-to-end:
+``read_timeout_seconds`` features are forwarded end-to-end:
 
   1. ``MCPClient.call_tool`` accepts ``progress_callback`` /
-     ``timeout_seconds`` kwargs and passes them to the FastMCP client
-     (#2597 S1: ``fastmcp.Client.call_tool_mcp(progress_handler=...,
-     timeout=...)``, which itself forwards to the SDK session's
-     ``call_tool(progress_callback=..., read_timeout_seconds=...)`` —
-     same underlying SDK parameter names one layer down).
+     ``timeout_seconds`` kwargs and passes them to the official SDK's
+     ``ClientSession.call_tool(progress_callback=..., read_timeout_
+     seconds=...)`` directly (#4282: every transport goes through the
+     official SDK now — the fastmcp-shaped ``call_tool_mcp(progress_
+     handler=..., timeout=...)`` branch these fakes originally exercised
+     was removed once fastmcp was no longer constructed anywhere in
+     ``client.py``).
   2. ``op_runtime.mcp._execute`` builds a progress callback that emits
      ``mcp_progress`` events on the run's EventLog so subscribers can
      observe what the MCP server is doing.
@@ -19,11 +19,10 @@ forwarded end-to-end:
      server's raw config dict (the per-server entry under
      ``mcp.servers.<name>``) and forwards it to ``MCPClient.call_tool``.
 
-The fakes below stand in for ``fastmcp.Client`` (``client._client``, the
-post-#2597 attribute) rather than the old ``mcp.ClientSession``
-(``client._session``) — they fake ``call_tool_mcp(name, arguments,
-progress_handler=None, timeout=None, meta=None)``, FastMCP's own method
-signature, which ``MCPClient.call_tool`` calls directly.
+The fakes below stand in for ``mcp.ClientSession`` (``client._client``) —
+they fake ``call_tool(name, arguments, progress_callback=None,
+read_timeout_seconds=None)``, the official SDK's own method signature,
+which ``MCPClient.call_tool`` calls directly.
 """
 from __future__ import annotations
 
@@ -53,7 +52,7 @@ class _StubPool:
 class _FakeServerCapabilities:
     """Stand-in for ``mcp.types.ServerCapabilities`` — advertises "tools" only
     (non-None), matching the transport-level fakes in this file, which only ever
-    exercise ``call_tool_mcp``. #2597 capability/version gate: the tests below
+    exercise ``call_tool``. #2597 capability/version gate: the tests below
     hand-construct a half-initialised ``MCPClient`` that bypasses the real
     ``initialize()`` handshake (see each test), so ``supports("tools")`` must be
     primed the same way ``_initialized``/``_client`` are, or the gate added in
@@ -93,10 +92,11 @@ def test_call_tool_signature_accepts_progress_callback_and_timeout() -> None:
     assert params["timeout_seconds"].default is None
 
 
-def test_call_tool_passes_progress_callback_and_timedelta_to_fastmcp_client() -> None:
+def test_call_tool_passes_progress_callback_and_timedelta_to_official_sdk() -> None:
     """Tier 2: when both kwargs are set, ``MCPClient.call_tool`` forwards them
-    to ``self._client.call_tool_mcp`` using FastMCP's parameter names
-    (``progress_handler`` and ``timeout`` as a ``timedelta``).
+    to ``self._client.call_tool`` using the official SDK's own parameter
+    names (``progress_callback`` and ``read_timeout_seconds`` as a
+    ``timedelta``).
     """
     captured: dict[str, Any] = {}
 
@@ -110,7 +110,7 @@ def test_call_tool_passes_progress_callback_and_timedelta_to_fastmcp_client() ->
             return {"content": [], "isError": False}
 
     class _FakeFastMCPClient:
-        async def call_tool_mcp(
+        async def call_tool(
             self,
             name: str,
             arguments: dict[str, Any] | None = None,
@@ -141,17 +141,17 @@ def test_call_tool_passes_progress_callback_and_timedelta_to_fastmcp_client() ->
 
     assert captured["name"] == "demo"
     assert captured["arguments"] == {"x": 1}
-    assert captured["kwargs"].get("progress_handler") is _on_progress
-    read_to = captured["kwargs"].get("timeout")
+    assert captured["kwargs"].get("progress_callback") is _on_progress
+    read_to = captured["kwargs"].get("read_timeout_seconds")
     assert isinstance(read_to, timedelta)
     assert read_to == timedelta(seconds=4.5)
 
 
 def test_call_tool_omits_kwargs_when_none_for_backwards_compat() -> None:
-    """Tier 2: with default-None kwargs, neither ``progress_handler`` nor
-    ``timeout`` is added to the FastMCP client call — preserves pre-#264
-    behaviour exactly so configs that omit the new keys see no observable
-    change.
+    """Tier 2: with default-None kwargs, neither ``progress_callback`` nor
+    ``read_timeout_seconds`` is added to the SDK client call — preserves
+    pre-#264 behaviour exactly so configs that omit the new keys see no
+    observable change.
     """
     captured: dict[str, Any] = {}
 
@@ -160,7 +160,7 @@ def test_call_tool_omits_kwargs_when_none_for_backwards_compat() -> None:
             return {"content": [], "isError": False}
 
     class _FakeFastMCPClient:
-        async def call_tool_mcp(
+        async def call_tool(
             self,
             name: str,
             arguments: dict[str, Any] | None = None,
@@ -174,8 +174,8 @@ def test_call_tool_omits_kwargs_when_none_for_backwards_compat() -> None:
 
     asyncio.run(client.call_tool("demo", {"x": 1}))
 
-    assert "progress_handler" not in captured["kwargs"]
-    assert "timeout" not in captured["kwargs"]
+    assert "progress_callback" not in captured["kwargs"]
+    assert "read_timeout_seconds" not in captured["kwargs"]
 
 
 # ── 2. op_runtime.mcp emits mcp_progress events from the SDK callback ──
@@ -195,7 +195,7 @@ def test_op_handler_progress_callback_emits_mcp_progress_event() -> None:
             return {"content": [], "isError": False}
 
     class _CapturingFastMCPClient:
-        async def call_tool_mcp(
+        async def call_tool(
             self,
             name: str,
             arguments: dict[str, Any] | None = None,
@@ -204,10 +204,10 @@ def test_op_handler_progress_callback_emits_mcp_progress_event() -> None:
             # Capture the callback the op handler passed; FastMCP would
             # invoke this with (progress, total, message) when the server
             # sends notifications/progress.
-            captured_callback["cb"] = kwargs.get("progress_handler")
-            captured_callback["timeout"] = kwargs.get("timeout")
+            captured_callback["cb"] = kwargs.get("progress_callback")
+            captured_callback["read_timeout_seconds"] = kwargs.get("read_timeout_seconds")
             # Simulate two progress notifications mid-call.
-            cb = kwargs.get("progress_handler")
+            cb = kwargs.get("progress_callback")
             if cb is not None:
                 await cb(0.25, 1.0, "starting")
                 await cb(1.0, 1.0, "done")
@@ -268,13 +268,13 @@ def test_op_handler_reads_call_timeout_from_server_config() -> None:
             return {"content": [], "isError": False}
 
     class _CapturingFastMCPClient:
-        async def call_tool_mcp(
+        async def call_tool(
             self,
             name: str,
             arguments: dict[str, Any] | None = None,
             **kwargs: Any,
         ) -> _FakeResult:
-            captured["timeout"] = kwargs.get("timeout")
+            captured["read_timeout_seconds"] = kwargs.get("read_timeout_seconds")
             return _FakeResult()
 
     from reyn.core.op_runtime.context import OpContext
@@ -303,7 +303,7 @@ def test_op_handler_reads_call_timeout_from_server_config() -> None:
     op = MCPIROp(kind="mcp", server="demo", tool="thing", args={})
     asyncio.run(mcp_op_handler._execute(op, ctx))
 
-    read_to = captured["timeout"]
+    read_to = captured["read_timeout_seconds"]
     assert isinstance(read_to, timedelta)
     assert read_to == timedelta(seconds=7.5)
 
@@ -331,7 +331,7 @@ def test_op_handler_call_timeout_default_finite_and_optout() -> None:
                 return {"content": [], "isError": False}
 
         class _CapturingFastMCPClient:
-            async def call_tool_mcp(
+            async def call_tool(
                 self,
                 name: str,
                 arguments: dict[str, Any] | None = None,
@@ -359,12 +359,12 @@ def test_op_handler_call_timeout_default_finite_and_optout() -> None:
         asyncio.run(mcp_op_handler._execute(op, ctx))
 
         if expect_forwarded:
-            assert "timeout" in captured["kwargs"], (
+            assert "read_timeout_seconds" in captured["kwargs"], (
                 f"cfg {cfg!r} should forward a FINITE default timeout (hung-server "
                 f"guard), got kwargs={captured['kwargs']}"
             )
         else:
-            assert "timeout" not in captured["kwargs"], (
+            assert "read_timeout_seconds" not in captured["kwargs"], (
                 f"cfg {cfg!r} is an explicit opt-out (<=0) → NO timeout, "
                 f"got kwargs={captured['kwargs']}"
             )
@@ -375,16 +375,16 @@ def test_op_handler_call_timeout_default_finite_and_optout() -> None:
 
 def test_mcp_client_call_tool_forwards_progress_and_timeout_kwargs() -> None:
     """Tier 2: source-level pin that ``MCPClient.call_tool`` constructs the
-    FastMCP client kwargs from ``progress_callback`` / ``timeout_seconds``
-    (#2597 S1: forwarded as FastMCP's own ``progress_handler`` / ``timeout``
-    parameter names). Catches a future refactor that quietly drops the
-    kwargs without noticing the round-trip tests still pass (=
-    belt-and-suspenders for the behavioural test above).
+    SDK client kwargs from ``progress_callback`` / ``timeout_seconds``
+    (#4282: forwarded as the official SDK's own ``progress_callback`` /
+    ``read_timeout_seconds`` parameter names). Catches a future refactor
+    that quietly drops the kwargs without noticing the round-trip tests
+    still pass (= belt-and-suspenders for the behavioural test above).
     """
     src = inspect.getsource(MCPClient.call_tool)
-    # Both kwargs must appear in the FastMCP kwargs builder.
+    # Both kwargs must appear in the SDK kwargs builder.
     assert "progress_callback" in src
-    assert "progress_handler" in src
+    assert "read_timeout_seconds" in src
     assert "timedelta" in src, (
-        "timeout_seconds must be converted to a timedelta before the FastMCP call"
+        "timeout_seconds must be converted to a timedelta before the SDK call"
     )

--- a/tests/mcp/test_config_mcp_headers.py
+++ b/tests/mcp/test_config_mcp_headers.py
@@ -114,17 +114,45 @@ def test_mcp_headers_optional_back_compat(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_mcp_headers_reach_http_transport() -> None:
-    """Tier 2: framework boundary — a config with resolved headers reaches the real
-    ``StreamableHttpTransport`` with the exact post-expansion header dict.
+def _capture_streamablehttp_client_kwargs(monkeypatch) -> dict:
+    """#4282: the pre-#4282 form of the two tests below inspected the
+    constructed ``fastmcp.client.transports.StreamableHttpTransport``
+    object's ``.headers``/``.url`` directly (via the now-removed
+    ``_open_transport``); that helper no longer exists —
+    ``_initialize_http_or_sse`` calls ``mcp.client.streamable_http.
+    streamablehttp_client(url, headers=..., ...)`` inline instead. Captures
+    the REAL function's kwargs by wrapping it (still calls through to the
+    real one, so the connection attempt proceeds exactly as it would
+    unmodified) rather than faking the SDK — same seam
+    ``test_mcp_client_stderr_capture.py``'s stdio_client patch already
+    established, applied to the http transport function instead."""
+    import mcp.client.streamable_http as sh_mod
 
-    This pins the contract: whatever the caller puts in ``cfg['headers']``, MCPClient
-    passes through to the transport — no filtering, no rewriting. Inspects the
-    transport's own public ``.headers`` / ``.url`` attributes (a real fastmcp object
-    built by ``_open_transport()``), not a mocked SDK call.
+    captured: dict = {}
+    real_fn = sh_mod.streamablehttp_client
+
+    def _capturing(url, headers=None, timeout=30, **kwargs):
+        captured["url"] = url
+        captured["headers"] = headers
+        return real_fn(url, headers=headers, timeout=timeout, **kwargs)
+
+    monkeypatch.setattr(sh_mod, "streamablehttp_client", _capturing)
+    return captured
+
+
+def test_mcp_headers_reach_http_transport(monkeypatch) -> None:
+    """Tier 2: framework boundary — a config with resolved headers reaches the
+    real ``streamablehttp_client`` call with the exact post-expansion header
+    dict. This pins the contract: whatever the caller puts in
+    ``cfg['headers']``, MCPClient passes through unfiltered/unrewritten. The
+    target host doesn't exist, so ``initialize()`` fails at connect time —
+    the headers are already captured by then.
     """
-    from reyn.mcp.client import MCPClient
+    import asyncio
 
+    from reyn.mcp.client import MCPClient, MCPError
+
+    captured = _capture_streamablehttp_client_kwargs(monkeypatch)
     cfg = {
         "type": "http",
         "url": "https://api.example.com/mcp",
@@ -133,24 +161,40 @@ def test_mcp_headers_reach_http_transport() -> None:
             "X-API-Version": "2024-01-01",
         },
         "timeout": 45,
+        "init_timeout": 1,
     }
 
     client = MCPClient(cfg)
-    transport = client._open_transport()
+    try:
+        asyncio.run(client.initialize())
+    except MCPError:
+        pass  # expected — api.example.com is not a real MCP server
+    finally:
+        asyncio.run(client.close())
 
-    assert transport.url == "https://api.example.com/mcp"
-    assert transport.headers == {
+    assert captured["url"] == "https://api.example.com/mcp"
+    assert captured["headers"] == {
         "Authorization": "Bearer abc123",
         "X-API-Version": "2024-01-01",
     }
 
 
-def test_mcp_headers_default_empty_when_omitted() -> None:
-    """Tier 2: framework boundary — an http MCP config without ``headers`` yields
-    an empty header dict at the transport (no spurious headers injected)."""
-    from reyn.mcp.client import MCPClient
+def test_mcp_headers_default_empty_when_omitted(monkeypatch) -> None:
+    """Tier 2: framework boundary — an http MCP config without ``headers``
+    reaches ``streamablehttp_client`` with an empty header dict (no
+    spurious headers injected)."""
+    import asyncio
 
-    cfg = {"type": "http", "url": "http://x/mcp"}
+    from reyn.mcp.client import MCPClient, MCPError
+
+    captured = _capture_streamablehttp_client_kwargs(monkeypatch)
+    cfg = {"type": "http", "url": "http://x/mcp", "init_timeout": 1}
     client = MCPClient(cfg)
-    transport = client._open_transport()
-    assert transport.headers == {}
+    try:
+        asyncio.run(client.initialize())
+    except MCPError:
+        pass
+    finally:
+        asyncio.run(client.close())
+
+    assert captured["headers"] == {}

--- a/tests/mcp/test_mcp_client.py
+++ b/tests/mcp/test_mcp_client.py
@@ -175,7 +175,26 @@ def test_env_var_expansion(monkeypatch) -> None:
 
 def test_env_var_expansion_stdio_env(monkeypatch) -> None:
     """Tier 1: framework boundary — expand_env in a stdio env dict propagates expanded
-    values into the real subprocess's environment (proven by the subprocess echoing it back)."""
+    values into the real subprocess's environment.
+
+    #4282: the pre-#4282 form of this test inspected the constructed
+    ``fastmcp.client.transports.StdioTransport`` object's ``.env`` directly
+    (via the now-removed ``_open_transport``); that helper no longer
+    exists — ``_initialize_stdio`` builds
+    ``mcp.client.stdio.StdioServerParameters`` inline instead. The command
+    here (a bare ``python -c ...`` printing text) is not a real MCP server,
+    so driving this through a full ``initialize()`` would fail at the
+    handshake for an unrelated reason; captures the REAL
+    ``StdioServerParameters`` class's kwargs by wrapping it (still
+    constructs the real object — the same seam
+    ``test_mcp_client_stderr_capture.py``'s
+    ``test_initialize_failure_includes_stderr_tail_in_error`` and
+    ``test_mcp_client_sandbox_wrap.py``'s env test both already use) rather
+    than faking the SDK type, and lets the (expected) handshake failure
+    happen and get swallowed — the env is already captured before that
+    point."""
+    import mcp.client.stdio as stdio_mod
+
     monkeypatch.setenv("MY_TOKEN", "t0k")
     cfg = expand_env(
         {
@@ -189,11 +208,25 @@ def test_env_var_expansion_stdio_env(monkeypatch) -> None:
         }
     )
     assert cfg["env"]["API_TOKEN"] == "t0k"
-    # Direct transport-object assertion (real fastmcp.client.transports.StdioTransport,
-    # not a mock): the env dict is forwarded verbatim to the transport.
+
+    captured: dict = {}
+    real_params_cls = stdio_mod.StdioServerParameters
+
+    def _capturing_params(*args, **kwargs):
+        captured.update(kwargs)
+        return real_params_cls(*args, **kwargs)
+
+    monkeypatch.setattr(stdio_mod, "StdioServerParameters", _capturing_params)
+
     client = MCPClient(cfg)
-    transport = client._open_transport()
-    assert transport.env["API_TOKEN"] == "t0k"
+    try:
+        asyncio.run(client.initialize())
+    except MCPError:
+        pass  # expected — the command isn't a real MCP server
+    finally:
+        asyncio.run(client.close())
+
+    assert captured.get("env", {}).get("API_TOKEN") == "t0k"
 
 
 def test_close_releases_resources() -> None:

--- a/tests/mcp/test_mcp_client_stderr_capture.py
+++ b/tests/mcp/test_mcp_client_stderr_capture.py
@@ -10,15 +10,16 @@ stderr to a ``tempfile.TemporaryFile`` and includes the tail in the
 ``MCPError`` raised on init failure.
 
 This file pins the contract independently of the mcp SDK:
-  1. ``_open_stdio()`` creates a temp file and passes it as
-     ``errlog`` to ``stdio_client`` (= verified via signature
-     introspection + the stand-in in ``test_mcp_client.py``).
-  2. ``read_stderr_tail()`` returns captured text up to the configured
+  1. ``read_stderr_tail()`` returns captured text up to the configured
      byte cap; truncates with a ``...(truncated)`` prefix.
-  3. ``close_stderr_capture()`` is idempotent and never raises.
-  4. ``read_stderr_tail()`` on a missing / closed capture returns ``""``.
-  5. The init-failure branch in ``initialize()`` enriches MCPError
-     with the captured tail when present.
+  2. ``close_stderr_capture()`` is idempotent and never raises.
+  3. ``read_stderr_tail()`` on a missing / closed capture returns ``""``.
+  4. The init-failure branch in ``_initialize_stdio()`` enriches MCPError
+     with the captured tail when present — this ALSO proves the capture
+     gets allocated and written to (#4282: the standalone allocation-only
+     test that used to target ``_open_stdio()`` directly was removed as
+     redundant with this one once ``_open_stdio`` itself was removed —
+     see git history if you need the old form).
 
 End-to-end repro of a self-made server crash is out of scope (= would
 require spinning a subprocess); the SDK-level integration is verified
@@ -134,32 +135,6 @@ def test_http_transport_does_not_allocate_capture() -> None:
     client = _client("http")
     assert client.stderr_capture is None
     client.close_stderr_capture()  # safe
-
-
-# ── 5. open_stdio sets up the capture as a side effect ──────────────────
-
-
-def test_open_stdio_allocates_stderr_capture() -> None:
-    """Tier 2: calling _open_stdio sets _stderr_capture to a TemporaryFile.
-
-    Doesn't actually exercise the mcp SDK; we just observe the
-    side-effect on the client instance. The returned context manager
-    isn't entered.
-    """
-    pytest.importorskip("mcp")  # requires the optional dep
-    client = _client()
-    assert client.stderr_capture is None
-    cm = client._open_stdio()
-    try:
-        assert client.stderr_capture is not None
-        # writable text file with utf-8
-        client.stderr_capture.write("hello")
-        client.stderr_capture.flush()
-        assert client.read_stderr_tail() == "hello"
-    finally:
-        client.close_stderr_capture()
-        # cm is an async generator; we never entered it so no awaitable cleanup needed
-        del cm
 
 
 def test_initialize_failure_includes_stderr_tail_in_error(monkeypatch) -> None:

--- a/tests/mcp/test_mcp_oauth_2597_s4.py
+++ b/tests/mcp/test_mcp_oauth_2597_s4.py
@@ -1,18 +1,30 @@
-"""Tests for #2597 slice ④ — MCP OAuth 2.1 + Streamable HTTP completion.
+"""Tests for #2597 slice ④ — MCP OAuth 2.1 + Streamable HTTP (#4282 rewrite:
+fastmcp's ``OAuth`` retired for the official SDK's ``OAuthClientProvider``
+directly).
 
 Real instances only, per the testing policy: no ``mock.patch`` / ``MagicMock``
 on collaborators. The full browser-based OAuth Authorization Code Grant +
 PKCE round-trip needs a real authorization server and a human to click
-"Allow" — that is a manual/dogfood step (see the PR's Test plan), NOT
-something a unit test fakes. These tests instead exercise the real WIRING
-with real components: real ``load_config``, the real
-``fastmcp.client.auth.OAuth`` object (built and inspected, never invoked),
-the real ``StreamableHttpTransport``, and real file I/O against a tmp
-``oauth_tokens.json``.
+"Allow" — that is a manual/dogfood step, NOT something a unit test fakes.
+
+#4282 rewrite rationale (lead-coder review): the pre-#4282 version of this
+file inspected the REAL ``fastmcp.client.auth.OAuth`` object's own fields
+(``.mcp_url``, ``.context.client_metadata.scope``, ...) — pinning a THIRD
+PARTY's object shape under reyn's name (Tier question ①'s "whose bug is it
+if this fails" test: a fastmcp/SDK field rename fails it, not a reyn bug).
+Rebuilding the SAME shape of test against the NEW SDK's
+``OAuthClientProvider`` would carry the same defect forward with a
+different dependency. Rewritten to ask reyn's own three questions instead
+(lead-coder, verbatim): ① a configured token storage path actually gets a
+token written to it; ② a stored token is reused on the next connection (no
+re-authentication triggered); ③ an orphaned/corrupt token fails legibly,
+not silently. All three are reyn's promises — if they fail, it's reyn's
+bug, not the SDK's.
 """
 from __future__ import annotations
 
 import asyncio
+import logging
 from pathlib import Path
 
 import pytest
@@ -28,6 +40,12 @@ def oauth_store_path(tmp_path, monkeypatch) -> Path:
     p = tmp_path / "oauth_tokens.json"
     monkeypatch.setenv("REYN_OAUTH_TOKENS_PATH", str(p))
     return p
+
+
+def _token(access_token: str, *, expires_in: int | None = None):
+    from mcp.shared.auth import OAuthToken
+
+    return OAuthToken(access_token=access_token, token_type="Bearer", expires_in=expires_in)
 
 
 # ── (a) config parses + validates via the real load_config ────────────────
@@ -59,24 +77,14 @@ def test_oauth_server_config_parses_via_load_config(tmp_path, monkeypatch) -> No
     assert server_cfg["auth"]["scopes"] == ["repo", "read:org"]
     assert server_cfg["auth"]["client_id"] == "my-client-id"
 
-    # And the parsed dict, fed straight into MCPClient, builds an OAuth
-    # transport auth object without raising (this client never connects).
-    client = MCPClient(dict(server_cfg), non_interactive=False)
-    transport = client._open_transport()
-    from fastmcp.client.auth import OAuth
 
-    assert isinstance(transport.auth, OAuth)
-
-
-def test_bare_oauth_string_shorthand_parses() -> None:
-    """Tier 1: ``auth: oauth`` (bare string) is shorthand for ``{"type": "oauth"}``."""
+def test_bare_oauth_string_shorthand_parses(oauth_store_path) -> None:
+    """Tier 1: ``auth: oauth`` (bare string) is shorthand for ``{"type": "oauth"}``
+    — builds a provider without raising."""
     cfg = {"type": "http", "url": "https://example.com/mcp", "auth": "oauth"}
     client = MCPClient(cfg, non_interactive=False)
-    transport = client._open_transport()
-    from fastmcp.client.auth import OAuth
-
-    assert isinstance(transport.auth, OAuth)
-    assert transport.auth.mcp_url == "https://example.com/mcp"
+    provider = asyncio.run(client._build_oauth_provider(cfg["url"]))
+    assert provider is not None
 
 
 def test_unsupported_auth_type_rejected() -> None:
@@ -84,7 +92,7 @@ def test_unsupported_auth_type_rejected() -> None:
     cfg = {"type": "http", "url": "https://example.com/mcp", "auth": {"type": "saml"}}
     client = MCPClient(cfg, non_interactive=False)
     with pytest.raises(MCPError, match="saml"):
-        client._open_transport()
+        asyncio.run(client._build_oauth_provider(cfg["url"]))
 
 
 def test_auth_on_stdio_server_rejected_at_construction() -> None:
@@ -99,206 +107,152 @@ def test_auth_on_sse_server_rejected_at_construction() -> None:
         MCPClient({"type": "sse", "url": "https://x/sse", "auth": "oauth"})
 
 
-# ── (b) TokenStorage round-trips through oauth_tokens.json (outside bucket) ─
+# ── (b) reyn's own contract ① — a token gets saved to the configured path ──
 
 
 def test_token_storage_round_trips_through_outside_bucket_file(oauth_store_path) -> None:
     """Tier 2: MCPOAuthTokenStorage persists + reloads a token through the
-    real oauth_tokens.json file, 0600-permissioned, keyed per server URL —
-    the SAME on-disk file reyn.security.secrets.oauth's device-grant store
-    uses (outside bucket, per reyn-dir-layout.md), never a private in-memory
-    dict a test would need to reach into."""
-    storage_a = MCPOAuthTokenStorage(path=oauth_store_path)
-    non_default_value = {
-        "access_token": "at-nondefault-9f3c",
-        "refresh_token": "rt-nondefault-2b71",
-        "token_type": "Bearer",
-    }
+    real oauth_tokens.json file, 0600-permissioned — the SAME on-disk file
+    reyn.security.secrets.oauth's device-grant store uses (outside bucket,
+    per reyn-dir-layout.md). A FRESH storage instance (same path) reads
+    back the same value — proves it round-trips through the file, not an
+    in-process cache."""
+    url = "https://server-a.example.com/mcp"
+    storage_a = MCPOAuthTokenStorage(url, path=oauth_store_path)
 
-    async def _round_trip() -> None:
-        await storage_a.put(
-            "https://server-a.example.com/tokens",
-            non_default_value,
-            collection="mcp-oauth-token",
-        )
-
-    asyncio.run(_round_trip())
+    asyncio.run(storage_a.set_tokens(_token("at-nondefault-9f3c")))
 
     assert oauth_store_path.exists()
     assert oct(oauth_store_path.stat().st_mode & 0o777) == "0o600"
 
-    # A FRESH storage instance (same path) reads back the same value —
-    # proves it round-trips through the file, not an in-process cache.
-    storage_b = MCPOAuthTokenStorage(path=oauth_store_path)
-
-    async def _reload() -> dict:
-        return await storage_b.get(
-            "https://server-a.example.com/tokens", collection="mcp-oauth-token"
-        )
-
-    reloaded = asyncio.run(_reload())
-    assert reloaded == non_default_value
+    storage_b = MCPOAuthTokenStorage(url, path=oauth_store_path)
+    reloaded = asyncio.run(storage_b.get_tokens())
+    assert reloaded is not None
+    assert reloaded.access_token == "at-nondefault-9f3c"
 
 
 def test_token_storage_per_server_keying_does_not_collide(oauth_store_path) -> None:
-    """Tier 2: two different server URLs under the same collection are
-    stored independently — writing server B's token must not disturb
-    server A's (per-server keying invariant)."""
-    storage = MCPOAuthTokenStorage(path=oauth_store_path)
+    """Tier 2: two different server URLs are stored independently — writing
+    server B's token must not disturb server A's (per-server keying
+    invariant, now expressed via TWO separate MCPOAuthTokenStorage
+    instances, one per server_url, matching OAuthClientProvider's own
+    per-instance-per-server contract)."""
+    storage_a = MCPOAuthTokenStorage("https://server-a.example.com/mcp", path=oauth_store_path)
+    storage_b = MCPOAuthTokenStorage("https://server-b.example.com/mcp", path=oauth_store_path)
 
-    async def _write_both() -> None:
-        await storage.put(
-            "https://server-a.example.com/tokens",
-            {"access_token": "token-a-4471"},
-            collection="mcp-oauth-token",
-        )
-        await storage.put(
-            "https://server-b.example.com/tokens",
-            {"access_token": "token-b-8823"},
-            collection="mcp-oauth-token",
-        )
+    asyncio.run(storage_a.set_tokens(_token("token-a-4471")))
+    asyncio.run(storage_b.set_tokens(_token("token-b-8823")))
 
-    asyncio.run(_write_both())
+    a = asyncio.run(storage_a.get_tokens())
+    b = asyncio.run(storage_b.get_tokens())
+    assert a.access_token == "token-a-4471"
+    assert b.access_token == "token-b-8823"
 
-    async def _read_both():
-        a = await storage.get(
-            "https://server-a.example.com/tokens", collection="mcp-oauth-token"
-        )
-        b = await storage.get(
-            "https://server-b.example.com/tokens", collection="mcp-oauth-token"
-        )
-        return a, b
 
-    a, b = asyncio.run(_read_both())
-    assert a == {"access_token": "token-a-4471"}
-    assert b == {"access_token": "token-b-8823"}
+def test_client_info_round_trips_through_outside_bucket_file(oauth_store_path) -> None:
+    """Tier 2: static client_id registration (get_client_info/set_client_info)
+    round-trips the same way tokens do — the second half of TokenStorage's
+    4-method contract."""
+    from mcp.shared.auth import OAuthClientInformationFull
+
+    url = "https://server-e.example.com/mcp"
+    storage_a = MCPOAuthTokenStorage(url, path=oauth_store_path)
+    info = OAuthClientInformationFull(
+        client_id="static-client-123",
+        redirect_uris=["http://127.0.0.1:9/callback"],
+    )
+    asyncio.run(storage_a.set_client_info(info))
+
+    storage_b = MCPOAuthTokenStorage(url, path=oauth_store_path)
+    reloaded = asyncio.run(storage_b.get_client_info())
+    assert reloaded is not None
+    assert reloaded.client_id == "static-client-123"
+
+
+# ── (c) reyn's own contract ② — a stored token is reused, no re-auth ───────
+
+
+def test_headless_with_stored_token_proceeds(oauth_store_path) -> None:
+    """Tier 1: once a token IS cached for this exact server URL, a
+    non-interactive client builds the OAuth provider without raising — the
+    pre-flight check is scoped to "no token yet", not "always block
+    headless". This is reyn's own re-use promise: a cached token means no
+    browser flow is even attempted."""
+    url = "https://mcp.example.com/mcp"
+    asyncio.run(MCPOAuthTokenStorage(url, path=oauth_store_path).set_tokens(_token("at-cached-7742")))
+
+    cfg = {"type": "http", "url": url, "auth": {"type": "oauth"}}
+    client = MCPClient(cfg, non_interactive=True)
+    provider = asyncio.run(client._build_oauth_provider(url))  # must not raise
+    assert provider is not None
 
 
 def test_has_stored_token_reflects_real_store_state(oauth_store_path) -> None:
     """Tier 2: has_stored_token() is a thin, real (non-mocked) read of the
     same file MCPOAuthTokenStorage writes — used by the headless pre-flight
-    check in client.py."""
+    check in client.py to decide whether re-use is possible."""
     url = "https://server-c.example.com/mcp"
     assert has_stored_token(url, path=oauth_store_path) is False
 
-    storage = MCPOAuthTokenStorage(path=oauth_store_path)
-
-    async def _write() -> None:
-        # Mirrors FastMCP's own TokenStorageAdapter key shape exactly
-        # (f"{url.rstrip('/')}/tokens", collection "mcp-oauth-token") —
-        # verified against the installed fastmcp 3.4.2 source.
-        await storage.put(
-            f"{url}/tokens",
-            {"access_token": "at-real-6620"},
-            collection="mcp-oauth-token",
-        )
-
-    asyncio.run(_write())
+    asyncio.run(MCPOAuthTokenStorage(url, path=oauth_store_path).set_tokens(_token("at-real-6620")))
     assert has_stored_token(url, path=oauth_store_path) is True
 
 
 def test_expired_token_entry_not_reported_as_stored(oauth_store_path) -> None:
-    """Tier 2: a TTL'd-out entry must not be reported as a usable token —
-    has_stored_token() checks the real (not-a-private-field) expiry the
-    entry carries."""
+    """Tier 2: an expired entry must not be reported as a usable token —
+    has_stored_token() checks reyn's own tracked expiry (see
+    oauth_token_storage.py's module docstring for why reyn tracks this
+    itself rather than relying on the SDK's own reload behavior)."""
     url = "https://server-d.example.com/mcp"
-    storage = MCPOAuthTokenStorage(path=oauth_store_path)
-
-    async def _write_expired() -> None:
-        await storage.put(
-            f"{url}/tokens",
-            {"access_token": "at-expiring-3391"},
-            collection="mcp-oauth-token",
-            ttl=-1,  # already expired
+    asyncio.run(
+        MCPOAuthTokenStorage(url, path=oauth_store_path).set_tokens(
+            _token("at-expiring-3391", expires_in=-1)  # already expired
         )
-
-    asyncio.run(_write_expired())
+    )
     assert has_stored_token(url, path=oauth_store_path) is False
 
 
-# ── (c) an OAuth-configured server builds the right transport/auth object ──
+# ── (d) reyn's own contract ③ — an orphaned/corrupt token fails legibly ────
 
 
-def test_http_oauth_server_builds_real_oauth_transport_auth(oauth_store_path) -> None:
-    """Tier 1: inspect the REAL fastmcp.client.auth.OAuth object attached to
-    the REAL StreamableHttpTransport (mirrors the ②a header tests that
-    inspect the real StreamableHttpTransport) — proves the config->transport
-    wiring, not a hand-rolled fake. Uses only PUBLIC surface: ``mcp_url``,
-    the public ``context.client_metadata.scope`` (never the leading-
-    underscore ``_scopes``/``_client_id`` ctor-cache fields), and a real
-    round trip through the public ``token_storage_adapter.get_tokens()`` /
-    ``set_tokens()`` to prove the storage binding — never reaching into
-    ``token_storage_adapter``'s private ``_key_value_store``."""
-    cfg = {
-        "type": "http",
-        "url": "https://mcp.example.com/mcp",
-        "auth": {
-            "type": "oauth",
-            "scopes": ["a", "b"],
-            "client_id": "client-123",
-            "client_secret": "secret-456",
-        },
-    }
-    client = MCPClient(cfg, non_interactive=False)
-    transport = client._open_transport()
+def test_corrupt_token_entry_is_treated_as_absent_not_a_crash(
+    oauth_store_path, caplog,
+) -> None:
+    """Tier 1: a stored entry whose JSON shape no longer round-trips through
+    OAuthToken (e.g. a future reyn version changes what it stores, or the
+    file was hand-edited) is treated as absent — get_tokens() returns None,
+    never raises — AND the failure is LOGGED clearly (naming the server +
+    that re-authentication is needed), not silently swallowed. This is the
+    condition lead-coder set on #4282: "静かに失敗しないこと"."""
+    import json
 
-    from fastmcp.client.auth import OAuth
+    url = "https://server-f.example.com/mcp"
+    storage = MCPOAuthTokenStorage(url, path=oauth_store_path)
+    # Write a garbage entry directly under the SAME key storage.set_tokens
+    # would use, bypassing the normal write path to simulate corruption /
+    # a future schema change.
+    from reyn.mcp.oauth_token_storage import _tokens_key
 
-    assert isinstance(transport.auth, OAuth)
-    assert transport.auth.mcp_url == "https://mcp.example.com/mcp"
-    # public dataclass field on the public `context` attribute
-    assert transport.auth.context.client_metadata.scope == "a b"
+    oauth_store_path.parent.mkdir(parents=True, exist_ok=True)
+    oauth_store_path.write_text(
+        json.dumps({_tokens_key(url): {"_value": {"not_a_real_field": 123}, "_expires_at": None}}),
+        encoding="utf-8",
+    )
+    oauth_store_path.chmod(0o600)
 
-    # Prove the OAuth object's storage really is bound to OUR
-    # MCPOAuthTokenStorage / oauth_store_path — round-trip a token through
-    # the built object's OWN public token_storage_adapter, then confirm a
-    # separate MCPOAuthTokenStorage pointed at the same path sees it.
-    from mcp.shared.auth import OAuthToken
+    with caplog.at_level(logging.WARNING, logger="reyn.mcp.oauth_token_storage"):
+        result = asyncio.run(storage.get_tokens())
 
-    async def _round_trip() -> None:
-        await transport.auth.token_storage_adapter.set_tokens(
-            OAuthToken(access_token="at-wiring-proof-5510", token_type="Bearer")
-        )
-
-    asyncio.run(_round_trip())
-
-    independent_storage = MCPOAuthTokenStorage(path=oauth_store_path)
-
-    async def _read_independently() -> dict:
-        return await independent_storage.get(
-            "https://mcp.example.com/mcp/tokens", collection="mcp-oauth-token"
-        )
-
-    seen = asyncio.run(_read_independently())
-    assert seen is not None
-    assert seen["access_token"] == "at-wiring-proof-5510"
-
-
-# ── (d) static bearer / header auth regression — unaffected by slice ④ ─────
-
-
-def test_static_bearer_header_auth_unaffected(oauth_store_path) -> None:
-    """Tier 1: pre-④ static bearer auth (headers, no 'auth' key at all) still
-    builds a transport with auth=None and the header intact — the ④ wiring
-    is additive, never a behavior change for the existing header-auth path."""
-    cfg = {
-        "type": "http",
-        "url": "https://mcp.example.com/mcp",
-        "headers": {"Authorization": "Bearer static-token-abc"},
-    }
-    client = MCPClient(cfg)
-    transport = client._open_transport()
-    assert transport.auth is None
-    assert transport.headers["Authorization"] == "Bearer static-token-abc"
-
-
-# ── (e) headless + no stored token -> clear MCPError, never a hang ─────────
+    assert result is None
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("unrecognized format" in m for m in messages), messages
+    assert any(url in m for m in messages), messages
 
 
 def test_headless_no_token_raises_clear_mcp_error_not_hang(oauth_store_path) -> None:
     """Tier 1: a non-interactive caller with no cached token gets a clear,
-    immediate MCPError instead of FastMCP opening a browser + waiting on a
-    localhost callback nobody can complete."""
+    immediate MCPError instead of the OAuth flow opening a browser + waiting
+    on a localhost callback nobody can complete."""
     cfg = {
         "type": "http",
         "url": "https://mcp.example.com/mcp",
@@ -306,50 +260,40 @@ def test_headless_no_token_raises_clear_mcp_error_not_hang(oauth_store_path) -> 
     }
     client = MCPClient(cfg, non_interactive=True)
     with pytest.raises(MCPError, match="requires OAuth authentication"):
-        client._open_transport()
-
-
-def test_headless_with_stored_token_proceeds(oauth_store_path) -> None:
-    """Tier 1: once a token IS cached for this exact server URL, the same
-    non-interactive client builds the transport without raising — the
-    pre-flight check is scoped to "no token yet", not "always block
-    headless"."""
-    url = "https://mcp.example.com/mcp"
-    storage = MCPOAuthTokenStorage(path=oauth_store_path)
-
-    async def _seed() -> None:
-        await storage.put(
-            f"{url}/tokens",
-            {"access_token": "at-cached-7742"},
-            collection="mcp-oauth-token",
-        )
-
-    asyncio.run(_seed())
-
-    cfg = {"type": "http", "url": url, "auth": {"type": "oauth"}}
-    client = MCPClient(cfg, non_interactive=True)
-    transport = client._open_transport()  # must not raise
-    from fastmcp.client.auth import OAuth
-
-    assert isinstance(transport.auth, OAuth)
+        asyncio.run(client._build_oauth_provider(cfg["url"]))
 
 
 def test_interactive_client_with_no_token_does_not_raise_preflight_error(
     oauth_store_path,
 ) -> None:
     """Tier 1: an explicitly interactive client (non_interactive=False) is
-    allowed to proceed to FastMCP's own browser flow even with no cached
-    token — the headless guard only fires for non-interactive callers."""
+    allowed to proceed to the browser flow even with no cached token — the
+    headless guard only fires for non-interactive callers."""
     cfg = {
         "type": "http",
         "url": "https://mcp.example.com/mcp",
         "auth": {"type": "oauth"},
     }
     client = MCPClient(cfg, non_interactive=False)
-    transport = client._open_transport()  # must not raise
-    from fastmcp.client.auth import OAuth
+    provider = asyncio.run(client._build_oauth_provider(cfg["url"]))  # must not raise
+    assert provider is not None
 
-    assert isinstance(transport.auth, OAuth)
+
+# ── (e) static bearer / header auth regression — unaffected by OAuth ───────
+
+
+def test_static_bearer_header_auth_unaffected(oauth_store_path) -> None:
+    """Tier 1: a server with NO 'auth' key (the pre-④ static-bearer-via-
+    headers path) builds no OAuth provider at all — the ④ wiring is
+    additive, never a behavior change for the existing header-auth path."""
+    cfg = {
+        "type": "http",
+        "url": "https://mcp.example.com/mcp",
+        "headers": {"Authorization": "Bearer static-token-abc"},
+    }
+    client = MCPClient(cfg)
+    provider = asyncio.run(client._build_oauth_provider(cfg["url"]))
+    assert provider is None
 
 
 # ── never write OAuth tokens into any rewind/recovery-core path ────────────
@@ -371,18 +315,10 @@ def test_oauth_tokens_never_land_under_dot_reyn_recovery_core(
     project_reyn_dir = tmp_path / "project" / ".reyn"
     project_reyn_dir.mkdir(parents=True)
     oauth_path = tmp_path / "outside-bucket" / "oauth_tokens.json"
-    storage = MCPOAuthTokenStorage(path=oauth_path)
+    storage = MCPOAuthTokenStorage("https://mcp.example.com/mcp", path=oauth_path)
 
-    async def _write() -> None:
-        await storage.put(
-            "https://mcp.example.com/tokens",
-            {"access_token": "at-isolation-check-1123"},
-            collection="mcp-oauth-token",
-        )
-
-    asyncio.run(_write())
+    asyncio.run(storage.set_tokens(_token("at-isolation-check-1123")))
 
     assert oauth_path.exists()
-    # Nothing was written anywhere under the project's .reyn/ tree.
     written_under_dot_reyn = list(project_reyn_dir.rglob("*"))
     assert written_under_dot_reyn == []

--- a/tests/security/test_mcp_client_sandbox_wrap.py
+++ b/tests/security/test_mcp_client_sandbox_wrap.py
@@ -1,24 +1,39 @@
 """Tier 2: stdio MCP server subprocess is sandbox-wrapped (#1344, uniformly
 rerouted through the abstraction #2620).
 
-The MCP server launched by ``_open_stdio`` must run under the platform sandbox
-so an LLM-invoked MCP tool cannot escape via the server. ``_sandbox_wrap_stdio``
-now routes UNIFORMLY through ``backend.wrap_command()`` — no per-backend-name
-branching. This file pins: the Seatbelt command-wrap (macOS), the Landlock
-re-exec shim (Linux, #1344-E), NoopBackend's argv-unchanged PASSTHROUGH (still
-routed THROUGH the abstraction — the owner-acceptable no-enforcement case, NOT
-a bypass), the per-server network default (single-source
-DEFAULT_SANDBOX_NETWORK, #1339-D) with operator opt-in / opt-out, and the
-temp-profile cleanup.
+The MCP server launched by ``_initialize_stdio`` must run under the platform
+sandbox so an LLM-invoked MCP tool cannot escape via the server.
+``_sandbox_wrap_stdio`` now routes UNIFORMLY through ``backend.wrap_command()``
+— no per-backend-name branching. This file pins: the Seatbelt command-wrap
+(macOS), the Landlock re-exec shim (Linux, #1344-E), NoopBackend's
+argv-unchanged PASSTHROUGH (still routed THROUGH the abstraction — the
+owner-acceptable no-enforcement case, NOT a bypass), the per-server network
+default (single-source DEFAULT_SANDBOX_NETWORK, #1339-D) with operator
+opt-in / opt-out, and the temp-profile cleanup.
 
 No mocks: the REAL ``NoopBackend`` / ``SeatbeltBackend`` / ``LandlockBackend``
 classes are used (monkeypatched in as ``get_default_backend``'s return value) —
 ``wrap_command`` is pure/local-I/O-only and does not require the host platform
 to match (SeatbeltBackend.wrap_command builds an SBPL profile as plain text;
 it does not itself invoke ``sandbox-exec``).
+
+#4282 / architect finding #4287: #3698 stage 1 moved stdio's live
+initialize path from fastmcp's ``_open_stdio``/``_open_transport`` (this
+file's original target) to ``_initialize_stdio`` — but the witness here
+kept pointing at ``_sandbox_wrap_stdio`` called DIRECTLY, never at
+``_initialize_stdio``'s own call to it. Every test above this comment still
+correctly exercises ``_sandbox_wrap_stdio`` itself (a real, still-live
+method — nothing wrong with those); what was missing was proof that
+``_initialize_stdio`` actually CALLS it on the real live path. Measured:
+deleting the call site in ``_initialize_stdio`` left every pre-#4287 test
+in this file green (#4283 landed with a security suite that would not have
+caught it). ``test_initialize_stdio_actually_invokes_the_sandbox_wrap``
+and the retargeted env test below close that gap — both falsify-verified
+(stripping the call site under test sends them RED; see each docstring).
 """
 from __future__ import annotations
 
+import asyncio
 import sys
 import warnings
 from pathlib import Path
@@ -28,6 +43,9 @@ import pytest
 from reyn.mcp.client import MCPClient
 from reyn.security.sandbox.backends.landlock import LandlockBackend
 from reyn.security.sandbox.backends.seatbelt import SeatbeltBackend
+from tests._support.paths import REPO_ROOT
+
+_ECHO_SERVER = REPO_ROOT / "tests" / "_support" / "mcp_fastmcp_echo_server.py"
 from reyn.security.sandbox.noop_backend import NoopBackend
 
 
@@ -240,22 +258,86 @@ def test_sandbox_env_is_none_when_the_wrap_itself_fails(monkeypatch):
     assert client.sandbox_env is None  # second call failed -> reset, not stale
 
 
-def test_open_stdio_env_is_still_driven_by_config_not_sandbox_env(monkeypatch):
+def test_initialize_stdio_env_is_still_driven_by_config_not_sandbox_env(monkeypatch):
     """Tier 2: #3848 stage 1 — carrying the allowlist through must NOT change
     today's default launch behavior (owner ruling: default stays "pass
-    everything"). _open_stdio's real StdioTransport(env=...) call is driven
-    ONLY by self._config.get("env"), never by self._sandbox_env, in this
-    stage. Real StdioTransport throughout — construction is pure attribute
-    storage (no I/O, no subprocess spawn until connect()), so there is no
-    reason to fake it."""
+    everything"). #4282/#4287: retargeted from the removed ``_open_stdio``
+    to the live ``_initialize_stdio`` path — its real
+    ``StdioServerParameters(env=...)`` call is driven ONLY by
+    ``self._config.get("env")``, never by ``self._sandbox_env``, in this
+    stage. Captures the REAL ``mcp.client.stdio.StdioServerParameters``
+    class's kwargs by wrapping it (still constructs the real object,
+    exactly what ``_initialize_stdio`` would build unmodified) rather than
+    faking the SDK type — same seam
+    ``test_initialize_failure_includes_stderr_tail_in_error`` in
+    ``test_mcp_client_stderr_capture.py`` already established (a local
+    ``from mcp.client.stdio import ...`` re-resolves the source module's
+    attribute on every call, so patching it there is what a fresh call
+    actually sees). A real connection to the real echo server (same
+    fixture ``test_mcp_client.py`` uses) drives ``initialize()`` end to
+    end — the NoopBackend keeps the sandbox wrap itself a passthrough so
+    only the env-plumbing claim is under test here."""
+    import mcp.client.stdio as stdio_mod
+
     backend = NoopBackend()
     _patch_backend(monkeypatch, backend)
-    client = _stdio_client()
+    captured: dict = {}
+    real_params_cls = stdio_mod.StdioServerParameters
 
-    transport = client._open_stdio()
+    def _capturing_params(*args, **kwargs):
+        captured.update(kwargs)
+        return real_params_cls(*args, **kwargs)
+
+    monkeypatch.setattr(stdio_mod, "StdioServerParameters", _capturing_params)
+
+    cfg = {"type": "stdio", "command": sys.executable, "args": [str(_ECHO_SERVER)]}
+    client = MCPClient(cfg)
+
+    async def _run() -> None:
+        await client.initialize()
+        await client.close()
+
+    asyncio.run(_run())
 
     # config declared no `env:` key -> today's default (env=None, full
     # parent inherit) must be untouched by the now-populated _sandbox_env.
     assert client.sandbox_env is not None  # the mechanism DID run
-    assert transport.env is None  # but did not drive the real launch
-    client.close_stderr_capture()
+    assert captured.get("env") is None  # but did not drive the real launch
+
+
+def test_initialize_stdio_actually_invokes_the_sandbox_wrap(monkeypatch):
+    """Tier 2: #4287 (architect finding on #4283) — every OTHER test in this
+    file calls ``_sandbox_wrap_stdio`` DIRECTLY, which proves the method
+    itself works but never proves ``_initialize_stdio`` (the live path
+    since #3698 stage 1 moved stdio off fastmcp's ``_open_stdio``) actually
+    CALLS it. Falsify-verified: commenting out client.py's
+    ``command, args = self._sandbox_wrap_stdio(command, args)`` line inside
+    ``_initialize_stdio`` leaves every pre-#4287 test in this file green
+    while THIS one goes red (``calls`` stays empty even though the
+    connection still succeeds unwrapped) — reproduced by hand before
+    writing this docstring, not assumed.
+
+    Spies on the SUT's own method (wraps, still delegates to the real
+    implementation for every call) rather than faking a collaborator — the
+    subprocess really is sandbox-wrapped by NoopBackend's real (passthrough)
+    ``wrap_command``; only the CALL itself is additionally recorded."""
+    backend = NoopBackend()
+    _patch_backend(monkeypatch, backend)
+    cfg = {"type": "stdio", "command": sys.executable, "args": [str(_ECHO_SERVER)]}
+    client = MCPClient(cfg)
+    calls = []
+    real_wrap = client._sandbox_wrap_stdio
+
+    def _spy(command, args):
+        calls.append((command, args))
+        return real_wrap(command, args)
+
+    client._sandbox_wrap_stdio = _spy
+
+    async def _run() -> None:
+        await client.initialize()
+        await client.close()
+
+    asyncio.run(_run())
+
+    assert calls == [(sys.executable, [str(_ECHO_SERVER)])]


### PR DESCRIPTION
**[e2e-coder]** — #4282: the last gap #3698 stage 1 left open — an OAuth-configured `http` server — now goes through the official `mcp` SDK directly. Fastmcp is fully retired from the MCP **client** path (`reyn.mcp.client`). Includes #4287 (architect finding on #4283's own landing) folded in per lead-coder's instruction.

## What moved

`_build_oauth_provider` constructs the official SDK's `mcp.client.auth.OAuthClientProvider` directly (an `httpx.Auth`, passed to `streamablehttp_client(..., auth=provider)`), replacing fastmcp's `OAuth` wrapper around the same class. Two things fastmcp provided internally needed reyn's own implementation:

- **Browser-redirect + localhost-callback flow** — new `reyn.mcp.oauth_browser_flow` (starlette/uvicorn). Live-verified end-to-end (real bound listener + real httpx GET) before writing production code. **Zero new dependency surface**: fastmcp's own `fastmcp-slim[server]` requirement already pulls both in unconditionally — verified by reading fastmcp/fastmcp-slim's declared requirements directly.
- **Token storage** — `MCPOAuthTokenStorage` rewritten from fastmcp's `AsyncKeyValue`-shaped adapter to the official SDK's own, simpler `TokenStorage` protocol (`get_tokens`/`set_tokens`/`get_client_info`/`set_client_info`, scoped per `server_url`). The double adapter this module carried pre-#4282 is gone because nothing constructs fastmcp's `OAuth` class anymore. New key scheme (`mcp-oauth2:` prefix), per the owner's no-backward-compat ruling — old entries are simply not found under the new keys (same as a first-ever run), never migrated. **Condition set by lead-coder's review**: an entry whose stored shape no longer round-trips is logged at WARNING (naming the server + "re-authenticate"), never silently swallowed.

`_initialize_fastmcp`/`_open_transport`/`_open_stdio`/`_open_http`/`_open_sse`/`_build_oauth_auth` are deleted (genuinely unreachable once every transport dispatches through `_initialize_stdio`/`_initialize_http_or_sse`); `_uses_official_sdk` and its 10 `if`/`else` call sites collapse to their official-SDK-only bodies.

## Test rewrite (lead-coder's explicit condition)

`tests/mcp/test_mcp_oauth_2597_s4.py` rewritten top to bottom. The pre-#4282 version inspected the real `fastmcp.client.auth.OAuth` object's own fields (`mcp_url`, `context.client_metadata.scope`, ...) — pinning a THIRD PARTY's object shape under reyn's name, the exact defect the six-questions Tier-1 check exists to catch, and one that would have carried forward unchanged if rebuilt against the new SDK's object with the same shape. Rewritten to reyn's own three promises instead (lead-coder, verbatim): (1) a configured token storage path actually gets a token written to it, (2) a stored token is reused on the next connection (no re-auth triggered), (3) an orphaned/corrupt token fails legibly, not silently.

Every other test file with a fastmcp-shaped fake (`call_tool_mcp` / `progress_handler`/`timeout` kwarg names, `_open_transport`/`_open_http`/`_open_stdio` direct calls) is updated to the official SDK's shape: `test_mcp_client.py`, `test_config_mcp_headers.py`, `test_fp0016_e_agent_id.py`, `test_mcp_progress_and_timeout.py`, `test_3070_mcp_probe_error_surfaced.py`. Swept via `grep` across the whole repo for every remaining reference to the retired symbols, not just the files pytest happened to fail on first.

## #4287 (architect finding, folded in per lead-coder)

Every test in `tests/security/test_mcp_client_sandbox_wrap.py` called `_sandbox_wrap_stdio` **directly** — proving the method works, never that `_initialize_stdio` (the live path since #3698 stage 1) actually **calls** it. #4283 landed with a security suite that would not have caught a stripped call site. Two new tests close the gap, both **falsify-verified by hand** (commented out the call site in `_initialize_stdio`, confirmed the two new tests go red while all 13 pre-existing tests stay green, then restored): `test_initialize_stdio_actually_invokes_the_sandbox_wrap` (a spy on the SUT's own method, still delegates to the real implementation — not a faked collaborator) and `test_initialize_stdio_env_is_still_driven_by_config_not_sandbox_env` (retargeted from the removed `_open_stdio`).

## ⚠️ Correction to the #3698/#4282 planning narrative

Discovered while finishing this PR's own cleanup sweep, **reported to lead-coder before touching `pyproject.toml`**: **`fastmcp` cannot be removed from `pyproject.toml`.** `src/reyn/builtin/plugins/rag/scripts/chunker_server.py` and `vector_store_server.py` build MCP **servers** via `fastmcp.FastMCP()` directly — entirely unrelated to the CLIENT path #3698/#4282 migrated. The `mcp<2.0` pin (`fastmcp-slim[server]`'s own floor) is equally unremovable for the same reason. This corrects the "stage 2 is gated on #4282" framing repeated through the night — stage 2 (`mcp>=2.0`) was never actually reachable via the client-path work alone.

`_fastmcp_boundary.py` is **kept** (not deleted) for the same reason: `reyn.mcp.elicitation` still imports one fastmcp type (`fastmcp.client.elicitation.ElicitResult`, a strict subclass of the official SDK's own `mcp.types.ElicitResult` — verified via its MRO, so it satisfies the SDK's `ElicitationFnT` return-type contract unmodified). The module's docstring documents this; the 5 now-dead client-transport accessors are removed from it, the 1 live one stays.

## Verification

Local 5-gate battery, all green: `ruff check src tests`, `test_tier_audit.py --strict` (88 tests across every touched test file), `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py`.

`tests/mcp/` full bucket: 156 passed. 15-file cross-directory consumer sweep (builtin/core/interfaces/runtime/security): 170 passed, 14 skipped. Both re-run after every fix round, not just once at the end. Rebased cleanly onto current `main` post-`#4283` merge (a clean cherry-pick — no conflicts — since the branch content matched byte-for-byte at the fork point); full gate battery + sweep re-verified on the rebased state before this push.

## Test plan

- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict <88 tests across every touched file>`
- [x] `python scripts/verify_module_docstrings.py` (client.py, oauth_token_storage.py, oauth_browser_flow.py, _fastmcp_boundary.py)
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `tests/mcp/` full bucket (156 passed)
- [x] 15-file consumer sweep across builtin/core/interfaces/runtime/security (170 passed, 14 skipped)
- [x] (skipped — no TUI/visual surface touched by this PR)
- [x] falsify-verified both new #4287 tests by hand (strip call site → red; restore → green)

part of #3698

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
