### PR TITLE
feat(#3846 ③): present's image component renders real pixels via textual-image

### DIFF
--- a/docs/reference/runtime/present.ja.md
+++ b/docs/reference/runtime/present.ja.md
@@ -63,7 +63,7 @@ guard/renderer の分割）については [コンセプト: Present レイヤ](
 | `keyvalue` | `rows: [{label, value}]` |
 | `table` | `rows`（bind → 配列）, `columns: [{header, path}]` |
 | `list` | `items`（bind → 配列）, `item_path?`（項目単位パス） |
-| `image` | `src`, `alt?` — v1 では `[image: <alt>]` という dim テキストのプレースホルダーのみ描画され、マルチモーダル配送経路へはまだルーティングされない |
+| `image` | `src`, `alt?` — TUI（`textual_chat`）は `src` を取得し（owner 裁定 C — client 自身が URL を取得、#3846）実ピクセルを描画する（Kitty/WezTerm の実ピクセル、または Sixel。それ以外は半ブロック/unicode 近似 — 端末ごとに自動判定、#3846 ③）。resolution stage の無いサーフェス（`reyn chat --cui`、`reyn pipe`）は `[image: <alt>]` という dim テキストのプレースホルダーを表示する。取得/デコード失敗時は区別可能な `[image failed: ...]` 状態を表示し、プレースホルダーと同じテキストにはならない |
 
 v1 に**対話コンポーネント**（ボタン / フォーム）は存在しない。
 

--- a/docs/reference/runtime/present.md
+++ b/docs/reference/runtime/present.md
@@ -73,7 +73,7 @@ All components are read-only. A blueprint node is `{"component": <name>, ...slot
 | `keyvalue` | `rows: [{label, value}]` |
 | `table` | `rows` (bind → array), `columns: [{header, path}]` |
 | `list` | `items` (bind → array), `item_path?` (per-item path) |
-| `image` | `src`, `alt?` — v1 renders an `[image: <alt>]` dim-text placeholder only, not yet routed to the multimodal delivery path |
+| `image` | `src`, `alt?` — the TUI (`textual_chat`) fetches `src` (owner-decided delivery form C — client fetches the URL itself, #3846) and renders REAL pixels (Kitty/WezTerm true pixels or Sixel, half-block/unicode approximation otherwise, auto-detected per-terminal — #3846 ③). Surfaces without a resolution stage (plain `reyn chat --cui`, `reyn pipe`) show an `[image: <alt>]` dim-text placeholder; a failed fetch/decode shows a distinguishable `[image failed: ...]` state, never the same placeholder text. |
 
 There are **no interactive components** (no buttons / forms) in v1.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,7 +227,16 @@ dependencies = [
     # approximation only — see #3970's own reinvention-comparison for why a
     # hand-rolled half-block renderer is not a "lighter version" of this
     # (different feature, not a smaller implementation of the same one).
-    "textual-image>=0.13",
+    # Floor is 0.12 (not 0.13+): 0.13.0+ declares `Requires-Python >=3.12`,
+    # unsatisfiable on reyn's own Python 3.11 CI leg/support floor — a real
+    # install-stage failure caught only by testing a CLEAN venv on 3.11 (a
+    # venv with the package already installed, or a 3.12-only check, both
+    # stay green and miss this). Verified 0.12.0 has the identical API
+    # surface this file uses (`renderable.Image(pil_image, width=...)`, the
+    # same import-time no-textual / terminal-auto-detection module
+    # structure, and the same TextualImage-constructor-forces-eager-decode
+    # behavior `present_renderer.py`'s decode-failure path relies on).
+    "textual-image>=0.12",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,6 +208,26 @@ dependencies = [
                               # Windows backend writes CF_UNICODETEXT directly.
                               # Linux still needs xclip/xsel/wl-clipboard on
                               # PATH — pyperclip does not vendor them either.
+    # #3846 ③ / #3970: owner-approved REGULAR dependency (not extra) —
+    # "入れた瞬間に効く" (UX/predictability > a silent text-only fallback,
+    # owner's own standing policy). pip resolvability measured (#3970):
+    # manylinux(3.11/3.12) / win_amd64(3.11) / macosx_11_0_arm64(3.12) all
+    # have prebuilt wheels (no compiler needed); the one gap is
+    # macosx_10_9_x86_64 (Intel Mac, source build needs libjpeg/zlib
+    # headers) — neither CI nor the owner's machine is affected.
+    "pillow>=11.0",
+    # `textual_image.renderable` (NOT `.widget`) — measured (#3970): imports
+    # NO textual module at all (0/147 `sys.modules` entries), a real Rich
+    # renderable (`__rich_console__`) buildable straight from a PIL.Image
+    # already in this process — same shape `present_renderer.py` already
+    # returns for every other node kind. pillow is the dominant dependency
+    # weight either way (14MB); textual-image itself is close to free on top
+    # of it and is the ONLY option of the measured candidates that reaches
+    # real pixels (Kitty/WezTerm TGP, Sixel) rather than a half-block/unicode
+    # approximation only — see #3970's own reinvention-comparison for why a
+    # hand-rolled half-block renderer is not a "lighter version" of this
+    # (different feature, not a smaller implementation of the same one).
+    "textual-image>=0.13",
 ]
 
 [project.urls]

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -4554,6 +4554,31 @@ async def run_textual_chat(
     regardless. Returns so the driver's caller can tear the transport down
     + print the cost summary.
     """
+    # #3846 ③: trigger textual_image.renderable's ONE-TIME, process-global
+    # terminal-capability auto-detection HERE — strictly BEFORE
+    # app.run_async() hands stdin to Textual. That auto-detection (Sixel/TGP
+    # support) sends a raw escape sequence to the real terminal and
+    # synchronously reads the reply off `sys.__stdout__`/stdin; the LIBRARY'S
+    # OWN docstring (`textual_image.renderable.sixel.query_terminal_support`)
+    # warns this "will not work anymore once Textual is started" — Textual
+    # runs its own stdin-reading thread that races (and usually wins) this
+    # read once the app loop is live. `present_renderer.py`'s `_render_image`
+    # imports `textual_image.renderable` lazily (its own "No I/O" module
+    # invariant), which would otherwise defer this exact query to the first
+    # image actually presented — i.e. DURING a live app.run_async() session,
+    # guaranteeing the query loses the race and every image in the TUI falls
+    # back to unicode/half-block even on a real Kitty/WezTerm/Sixel terminal.
+    # Importing here, before Textual owns stdin, lets the query succeed and
+    # the module-level `Image` binding (see that module's own `__init__.py`)
+    # resolve to the real terminal's actual capability once, for the whole
+    # process. A missing/failed import is swallowed — image nodes simply
+    # keep falling back to the pre-③ status-line text, same as an
+    # environment without pillow/textual-image at all.
+    try:
+        import textual_image.renderable  # noqa: F401,PLC0415
+    except Exception:
+        pass
+
     # #3671: the framework's own startup begins here — terminal setup, first
     # layout, first paint. Everything before it is reyn assembling things;
     # everything after it is Textual, and the two were indistinguishable while

--- a/src/reyn/interfaces/repl/present_renderer.py
+++ b/src/reyn/interfaces/repl/present_renderer.py
@@ -118,19 +118,32 @@ def _render_node(node: dict, image_cache: "dict[str, Any] | None" = None) -> "An
 
 
 def _render_image(node: dict, image_cache: "dict[str, Any] | None") -> "Any":
-    """The `image` component (#3846 ②) — a PURE dict lookup, never a fetch.
+    """The `image` component (#3846 ②/③) — a PURE dict lookup + in-memory
+    decode, never a fetch.
 
     `image_cache` (an app-owned `dict[str, ImageResolution]`, see
     `core/present/image_fetch.py`) is populated ELSEWHERE, by a resolution
     stage kicked off when the frame first arrives (`TextualChatApp.
     _begin_image_resolutions` -> `ReynPresenter.begin_image_resolution`) —
     this module's own docstring bans doing that fetch here (the "Pure: ...
-    No I/O" invariant). `image_cache=None` (every non-TUI caller — plain
-    ``ConsoleChatRenderer``, `reyn pipe`'s `StdoutPresentationRenderer`, and
-    every existing test that calls this function without the new kwarg) gets
-    the pre-#3846 `[image: alt]` text, byte-identical — no resolution stage
-    exists on those surfaces yet (#3846 ③ tracks plain's own sync-fetch
-    follow-up; ③ tracks real pixel rendering, a separate deps decision)."""
+    No I/O" invariant); decoding the already-fetched bytes via PIL is pure
+    CPU, not I/O, so it stays within that invariant. `image_cache=None`
+    (every non-TUI caller — plain ``ConsoleChatRenderer``, `reyn pipe`'s
+    `StdoutPresentationRenderer`, and every existing test that calls this
+    function without the new kwarg) gets the pre-#3846 `[image: alt]` text,
+    byte-identical — no resolution stage exists on those surfaces yet.
+
+    #3846 ③: on a successful resolution, renders REAL pixels via
+    `textual_image.renderable.Image` (owner-approved regular dep, #3970) —
+    Kitty/WezTerm true pixels or Sixel when the terminal supports either,
+    half-block/unicode approximation otherwise (that fallback selection is
+    `textual_image`'s own, made once per process — see
+    `interfaces/inline/textual_chat/app.py`'s `run_textual_chat` for WHY the
+    triggering import must happen there and not lazily here). Falls back to
+    a status-line `Text` if decoding fails (a genuinely non-image or
+    corrupt body) or if `pillow`/`textual-image` are unavailable for any
+    reason (defensive — they are regular deps, so this should not happen in
+    a normal install)."""
     from rich.text import Text
 
     alt = node.get("alt") or ""
@@ -139,16 +152,31 @@ def _render_image(node: dict, image_cache: "dict[str, Any] | None") -> "Any":
     if image_cache is None or not isinstance(src, str) or src not in image_cache:
         return Text(f"[image: {label}]", style="dim")
     res = image_cache[src]
-    if res.ok:
-        # V1 renders a LOADED status line, not real pixels (#3846 ③, a
-        # separate textual-image/pillow-deps decision) — see this
-        # function's own docstring for why that split is deliberate.
+    if not res.ok:
+        return Text(f"[image failed: {label} — {res.error}]", style="dim")
+    try:
+        import io
+
+        from PIL import Image as PILImage
+        from textual_image.renderable import Image as TextualImage
+
+        pil_image = PILImage.open(io.BytesIO(res.body))
+        # `PILImage.open()` alone only parses the header (lazy decode) — a
+        # truncated/corrupt body can open cleanly and only fail once pixel
+        # data is actually read. No separate `.load()` call is needed here
+        # to force that: `TextualImage`'s own constructor reads the pixel
+        # data eagerly (`PixelData.__init__`), so a bad body already raises
+        # HERE, inside this `try`, not later at paint time (verified: a
+        # truncated PNG that `open()` accepts raises `OSError` from
+        # `TextualImage(...)` itself).
+        return TextualImage(pil_image, width="auto")
+    except Exception as exc:
+        # Anything from a corrupt/unsupported body to a missing optional dep
+        # (defensive only — pillow/textual-image are regular deps) degrades
+        # to the pre-③ status line rather than breaking the render loop.
         return Text(
-            f"[image loaded: {label} — {len(res.body)} bytes, "
-            f"{res.content_type or 'unknown type'}]",
-            style="dim",
+            f"[image loaded but could not render: {label} — {exc}]", style="dim",
         )
-    return Text(f"[image failed: {label} — {res.error}]", style="dim")
 
 
 def render_presentation_nodes(

--- a/src/reyn/interfaces/repl/present_renderer.py
+++ b/src/reyn/interfaces/repl/present_renderer.py
@@ -117,6 +117,39 @@ def _render_node(node: dict, image_cache: "dict[str, Any] | None" = None) -> "An
     return Text(f"<unsupported present component {component!r}>", style="dim")
 
 
+class _SafeImageRenderable:
+    """Wraps a `textual_image` renderable so a PRINT-TIME failure degrades to
+    a status line instead of propagating and breaking the render loop.
+
+    Rich's `__rich_console__` protocol is a generator Console.print() only
+    iterates once it knows the real render width — so a failure inside it
+    happens LATER than `_render_image`'s own `try/except` (which only wraps
+    `TextualImage(...)` construction) can see. This is not hypothetical: a
+    real `textual-image` 0.12.0 bug (the version pip resolves on reyn's
+    Python 3.11 floor — 0.13+ requires >=3.12) raises `ValueError('height
+    and width must be > 0')` from inside `__rich_console__` for a very
+    small source image (reproduced: 8x8 and 1x1 fail, 16x16 does not) —
+    `TextualImage(...)` construction itself never raises for these, so the
+    pre-existing `try/except` in `_render_image` never sees it; this wrapper
+    is the only thing standing between that bug and an uncaught exception
+    reaching whatever Console the presenter/renderer layer owns."""
+
+    def __init__(self, inner: "Any", label: str) -> None:
+        self._inner = inner
+        self._label = label
+
+    def __rich_console__(self, console: "Any", options: "Any"):
+        from rich.text import Text
+
+        try:
+            yield from self._inner.__rich_console__(console, options)
+        except Exception as exc:
+            yield Text(
+                f"[image loaded but could not render: {self._label} — {exc}]",
+                style="dim",
+            )
+
+
 def _render_image(node: dict, image_cache: "dict[str, Any] | None") -> "Any":
     """The `image` component (#3846 ②/③) — a PURE dict lookup + in-memory
     decode, never a fetch.
@@ -169,7 +202,7 @@ def _render_image(node: dict, image_cache: "dict[str, Any] | None") -> "Any":
         # HERE, inside this `try`, not later at paint time (verified: a
         # truncated PNG that `open()` accepts raises `OSError` from
         # `TextualImage(...)` itself).
-        return TextualImage(pil_image, width="auto")
+        return _SafeImageRenderable(TextualImage(pil_image, width="auto"), label)
     except Exception as exc:
         # Anything from a corrupt/unsupported body to a missing optional dep
         # (defensive only — pillow/textual-image are regular deps) degrades

--- a/tests/core/test_3846_3_textual_image_eager_import_ordering.py
+++ b/tests/core/test_3846_3_textual_image_eager_import_ordering.py
@@ -1,0 +1,65 @@
+"""Tier 2: #3846 ③ — `run_textual_chat` triggers `textual_image.renderable`'s
+import BEFORE `app.run_async()`, not lazily during the live session.
+
+`textual_image.renderable`'s terminal-capability auto-detection
+(Sixel/TGP query) is a one-time, process-global, module-import-time side
+effect that reads raw stdin with a synchronous escape-sequence round-trip.
+The library's OWN docstring
+(`textual_image.renderable.sixel.query_terminal_support`) warns this "will
+not work anymore once Textual is started" — Textual's own stdin-reading
+thread races (and usually wins) that read once the app loop is live.
+`present_renderer.py`'s `_render_image` imports the SAME module lazily (its
+own "No I/O" invariant), so if `run_textual_chat` did not ALSO trigger the
+import eagerly, the first image ever presented would trigger it for the
+first time DURING a live `app.run_async()` session — guaranteeing the
+auto-detection loses the race and every image falls back to unicode/
+half-block even on a real Kitty/WezTerm/Sixel terminal.
+
+This only tests reyn's own ORDERING contract (the import statement runs
+before `TextualChatApp.run_async` is awaited) — not the underlying terminal
+query's own behavior, network reachability, or actual pixel output (all
+third-party/environment properties, not reyn's to test)."""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_textual_image_renderable_is_imported_before_app_run_async(monkeypatch) -> None:
+    """Tier 2: falsify-verified — moving the eager import to AFTER
+    `app.run_async(...)` in `run_textual_chat` makes this go RED (confirmed
+    by temporarily reordering the two statements during development)."""
+    import reyn.interfaces.inline.textual_chat.app as app_module
+
+    # Force a real "not yet imported" starting state so this test observes
+    # a genuine before/after transition, not a false pass from an earlier
+    # test (or import elsewhere in this process) having already cached it.
+    sys.modules.pop("textual_image.renderable", None)
+    sys.modules.pop("textual_image", None)
+
+    seen_before_run_async: list[bool] = []
+
+    class _FakeApp:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+        async def run_async(self, *, inline: bool) -> None:
+            seen_before_run_async.append("textual_image.renderable" in sys.modules)
+
+    monkeypatch.setattr(app_module, "TextualChatApp", _FakeApp)
+
+    from tests._support.textual_chat_test_helpers import QueueTransport
+
+    try:
+        await app_module.run_textual_chat(transport=QueueTransport())
+    finally:
+        sys.modules.pop("textual_image.renderable", None)
+        sys.modules.pop("textual_image", None)
+
+    assert seen_before_run_async == [True], (
+        "textual_image.renderable was not imported before TextualChatApp."
+        "run_async() was called — the terminal-capability query would race "
+        "Textual's own stdin reader and lose"
+    )

--- a/tests/core/test_3846_image_resolution_e2e.py
+++ b/tests/core/test_3846_image_resolution_e2e.py
@@ -142,7 +142,13 @@ async def test_loaded_state_replaces_the_placeholder_after_resolution(monkeypatc
     from PIL import Image as PILImage
 
     buf = io.BytesIO()
-    PILImage.new("RGB", (4, 4), color=(200, 20, 60)).save(buf, format="PNG")
+    # 32x32, not e.g. 4x4: a real textual-image 0.12.0 bug (the version pip
+    # resolves on reyn's own Python 3.11 floor) raises at PRINT time for a
+    # very small source image — a tiny fixture here would make this
+    # SUCCESS-path test exercise the failure path instead, depending on
+    # which textual-image version pip resolved (see present_renderer's own
+    # test file for the dedicated, version-independent failure-path test).
+    PILImage.new("RGB", (32, 32), color=(200, 20, 60)).save(buf, format="PNG")
     body = buf.getvalue()
     monkeypatch.setattr(
         httpx, "AsyncClient", _client_factory(_StreamResp(body=body, content_type="image/png"))

--- a/tests/core/test_3846_image_resolution_e2e.py
+++ b/tests/core/test_3846_image_resolution_e2e.py
@@ -1,11 +1,13 @@
-"""Tier 2: #3846 ①②③(scoped) — end-to-end image `src` resolution through the
+"""Tier 2: #3846 ①②③ — end-to-end image `src` resolution through the
 REAL TextualChatApp -> ReynPresenter -> render_presentation_nodes chain.
 
 Drives a real ``kind="presentation"`` frame with an ``image`` component node
 through ``TextualChatApp`` (not a hand-authored unit call), confirming:
 - the placeholder renders BEFORE resolution settles;
 - the SAME entry re-renders with the loaded state AFTER the background
-  fetch completes (proves the redraw-trigger, not just the cache write);
+  fetch completes (proves the redraw-trigger, not just the cache write) —
+  #3846 ③'s real-pixel rendering path (a real PNG body, not a magic-byte
+  stub) is exercised here;
 - a failed fetch renders a distinguishable failure state, not the same
   placeholder text a fetch that never started would show (the #3688 "two
   different things look the same" class).
@@ -122,7 +124,7 @@ async def test_loaded_state_replaces_the_placeholder_after_resolution(monkeypatc
     """Tier 2: ★ the redraw witness — after the background fetch settles, the
     entry's ``revision`` (flowview's own public, monotonic "was ``.update()``
     called" counter — bumped by NOTHING else in this test) has advanced, AND
-    the SAME entry now renders the loaded state.
+    the SAME entry now renders the loaded (real-pixel, #3846 ③) state.
 
     ``revision`` is the load-bearing half: calling ``present()`` directly (as
     :func:`_entry_text` does, to read content) would show the loaded state
@@ -130,8 +132,18 @@ async def test_loaded_state_replaces_the_placeholder_after_resolution(monkeypatc
     of this test asserted content only and stayed GREEN with
     ``entry.update()`` deleted from the implementation (caught by falsifying
     it directly). Content is still asserted too — a bumped revision with the
-    WRONG content displayed would be an equally real bug."""
-    body = b"\x89PNG-bytes-here"
+    WRONG content displayed would be an equally real bug.
+
+    A REAL PNG body (not a bare magic-byte stub) is required here: ③ decodes
+    the fetched body via PIL before rendering, so a fake body now degrades
+    to the failure-to-render text — this test's own job is the SUCCESS path."""
+    import io
+
+    from PIL import Image as PILImage
+
+    buf = io.BytesIO()
+    PILImage.new("RGB", (4, 4), color=(200, 20, 60)).save(buf, format="PNG")
+    body = buf.getvalue()
     monkeypatch.setattr(
         httpx, "AsyncClient", _client_factory(_StreamResp(body=body, content_type="image/png"))
     )
@@ -149,9 +161,15 @@ async def test_loaded_state_replaces_the_placeholder_after_resolution(monkeypatc
             "entry.revision never advanced — the redraw trigger did not fire"
         )
         text = await _entry_text(app, entry)
-        assert "[image loaded: a cat" in text, text
-        assert str(len(body)) in text, text
+        # Real-pixel rendering is a third party's promise (textual_image's
+        # own — see the module docstring rule against pinning it), so this
+        # only asserts what's reyn's own to keep: the placeholder is gone,
+        # no failure/decode-error text appeared, and SOMETHING non-empty
+        # replaced it (the loaded state, not a crash swallowed to blank).
         assert "[image: a cat]" not in text, "the placeholder never cleared: " + text
+        assert "could not render" not in text, text
+        assert "[image failed" not in text, text
+        assert text.strip(), "loaded state rendered empty output"
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_present_renderer_fp0054_prb.py
+++ b/tests/core/test_present_renderer_fp0054_prb.py
@@ -94,7 +94,16 @@ def test_unsupported_component_does_not_crash_the_render_loop() -> None:
 # ── 1b. #3846 ③ — image_cache real-pixel rendering ───────────────────────────
 
 
-def _png_bytes(*, size: tuple = (4, 4), color: tuple = (200, 20, 60)) -> bytes:
+def _png_bytes(*, size: tuple = (32, 32), color: tuple = (200, 20, 60)) -> bytes:
+    """A real PNG for the SUCCESS render path. 32x32, not e.g. 4x4: a real
+    `textual-image` 0.12.0 bug (the version pip resolves on reyn's own
+    Python 3.11 floor — 0.13+ requires >=3.12) raises at print time for a
+    very small source image (reproduced: 8x8 and 1x1 fail, 16x16 does not)
+    — a tiny fixture here would make "did the success path render" tests
+    exercise the FAILURE path instead on a 3.11 install, depending on which
+    textual-image version pip happened to resolve. See
+    `test_safe_image_renderable_catches_a_print_time_failure` for the
+    dedicated (version-independent) test of that failure path."""
     import io as _io
 
     from PIL import Image as PILImage
@@ -106,20 +115,20 @@ def _png_bytes(*, size: tuple = (4, 4), color: tuple = (200, 20, 60)) -> bytes:
 
 def test_image_with_resolved_cache_renders_real_pixels_not_the_status_line() -> None:
     """Tier 1: #3846 ③ — a successfully-resolved image (a real ImageResolution
-    in `image_cache`) is wrapped in a `textual_image.renderable.Image`
-    instance, not the pre-③ `[image loaded: ...]` status-line `Text`. This
-    is reyn's OWN dispatch decision (which renderable class `_render_image`
-    picks) — a fact about reyn's wiring, not textual_image's rendering
-    behavior (a third party's promise this file does not pin). Checked on
-    the render-model OBJECT (`Group.renderables`), not on printed glyph
-    output — a Console.print of either class produces terminal-formatted
-    text, so a text-content-only assertion here cannot tell "real pixel
-    path wired" apart from "still the old status line" (confirmed by
-    deliberately reverting `_render_image` to the pre-③ Text return and
-    seeing string-only assertions here stay green — falsify-verified)."""
-    from textual_image.renderable import Image as TextualImage
-
+    in `image_cache`) is wrapped in reyn's own `_SafeImageRenderable` (in
+    turn wrapping a `textual_image.renderable.Image`), not the pre-③
+    `[image loaded: ...]` status-line `Text`. This is reyn's OWN dispatch
+    decision (which renderable class `_render_image` picks) — a fact about
+    reyn's wiring, not textual_image's rendering behavior (a third party's
+    promise this file does not pin). Checked on the render-model OBJECT
+    (`Group.renderables`), not on printed glyph output — a Console.print of
+    either class produces terminal-formatted text, so a text-content-only
+    assertion here cannot tell "real pixel path wired" apart from "still
+    the old status line" (confirmed by deliberately reverting
+    `_render_image` to the pre-③ Text return and seeing string-only
+    assertions here stay green — falsify-verified)."""
     from reyn.core.present.image_fetch import ImageResolution
+    from reyn.interfaces.repl.present_renderer import _SafeImageRenderable
 
     nodes = validate_blueprint({"component": "image", "src": "http://x/y.png", "alt": "a photo"})
     resolved = resolve_bindings(nodes, {}, surface="inline-cui")
@@ -128,8 +137,8 @@ def test_image_with_resolved_cache_renders_real_pixels_not_the_status_line() -> 
     }
     group = render_presentation_nodes(resolved.nodes, image_cache=image_cache)
     (renderable,) = group.renderables
-    assert isinstance(renderable, TextualImage), (
-        f"expected a textual_image renderable, got {type(renderable)!r}"
+    assert isinstance(renderable, _SafeImageRenderable), (
+        f"expected reyn's own image-render wrapper, got {type(renderable)!r}"
     )
 
     # And the printed output is still sane through the real pipeline: no
@@ -141,6 +150,40 @@ def test_image_with_resolved_cache_renders_real_pixels_not_the_status_line() -> 
     assert "could not render" not in out
     assert "[image failed" not in out
     assert out.strip()
+
+
+def test_safe_image_renderable_catches_a_print_time_failure() -> None:
+    """Tier 1: #3846 ③ — `_SafeImageRenderable` degrades to a status line
+    when the WRAPPED renderable's `__rich_console__` raises, not just when
+    `TextualImage(...)`'s own constructor raises.
+
+    This matters because Rich's `__rich_console__` protocol is a generator
+    Console.print() only iterates once it knows the real render width — a
+    failure there happens LATER than `_render_image`'s `try/except` (which
+    only wraps construction) can see. Real instance found during
+    implementation: `textual-image` 0.12.0 (the version pip resolves on
+    reyn's own Python 3.11 floor) raises `ValueError('height and width must
+    be > 0')` from inside `__rich_console__` for a very small source image
+    — `TextualImage(...)` construction itself never raises for these.
+    Tested here against a FAKE inner renderable (reyn's own wrapper
+    behavior, not textual_image's version-specific bug — the dev
+    environment's installed textual_image version may not reproduce that
+    bug at all, so pinning this test to it would be flaky-by-environment)."""
+    from rich.console import Console as _Console
+
+    from reyn.interfaces.repl.present_renderer import _SafeImageRenderable
+
+    class _RaisingInner:
+        def __rich_console__(self, console: object, options: object):
+            raise ValueError("height and width must be > 0")
+            yield  # pragma: no cover — makes this a generator function
+
+    wrapped = _SafeImageRenderable(_RaisingInner(), "a photo")
+    console = _Console(width=100, file=io.StringIO(), force_terminal=True, color_system=None)
+    console.print(wrapped)  # must not raise
+    out = console.file.getvalue()
+    assert "could not render" in out
+    assert "a photo" in out
 
 
 def test_image_with_undecodable_body_falls_back_to_a_distinct_status_line() -> None:

--- a/tests/core/test_present_renderer_fp0054_prb.py
+++ b/tests/core/test_present_renderer_fp0054_prb.py
@@ -91,6 +91,98 @@ def test_unsupported_component_does_not_crash_the_render_loop() -> None:
     assert "not-a-real-component" in out
 
 
+# ── 1b. #3846 ③ — image_cache real-pixel rendering ───────────────────────────
+
+
+def _png_bytes(*, size: tuple = (4, 4), color: tuple = (200, 20, 60)) -> bytes:
+    import io as _io
+
+    from PIL import Image as PILImage
+
+    buf = _io.BytesIO()
+    PILImage.new("RGB", size, color=color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_image_with_resolved_cache_renders_real_pixels_not_the_status_line() -> None:
+    """Tier 1: #3846 ③ — a successfully-resolved image (a real ImageResolution
+    in `image_cache`) is wrapped in a `textual_image.renderable.Image`
+    instance, not the pre-③ `[image loaded: ...]` status-line `Text`. This
+    is reyn's OWN dispatch decision (which renderable class `_render_image`
+    picks) — a fact about reyn's wiring, not textual_image's rendering
+    behavior (a third party's promise this file does not pin). Checked on
+    the render-model OBJECT (`Group.renderables`), not on printed glyph
+    output — a Console.print of either class produces terminal-formatted
+    text, so a text-content-only assertion here cannot tell "real pixel
+    path wired" apart from "still the old status line" (confirmed by
+    deliberately reverting `_render_image` to the pre-③ Text return and
+    seeing string-only assertions here stay green — falsify-verified)."""
+    from textual_image.renderable import Image as TextualImage
+
+    from reyn.core.present.image_fetch import ImageResolution
+
+    nodes = validate_blueprint({"component": "image", "src": "http://x/y.png", "alt": "a photo"})
+    resolved = resolve_bindings(nodes, {}, surface="inline-cui")
+    image_cache = {
+        "http://x/y.png": ImageResolution(ok=True, body=_png_bytes(), content_type="image/png"),
+    }
+    group = render_presentation_nodes(resolved.nodes, image_cache=image_cache)
+    (renderable,) = group.renderables
+    assert isinstance(renderable, TextualImage), (
+        f"expected a textual_image renderable, got {type(renderable)!r}"
+    )
+
+    # And the printed output is still sane through the real pipeline: no
+    # placeholder, no failure text, non-empty.
+    console = Console(width=100, file=io.StringIO(), force_terminal=True, color_system=None)
+    console.print(group)
+    out = console.file.getvalue()
+    assert "[image: a photo]" not in out
+    assert "could not render" not in out
+    assert "[image failed" not in out
+    assert out.strip()
+
+
+def test_image_with_undecodable_body_falls_back_to_a_distinct_status_line() -> None:
+    """Tier 1: #3846 ③ — a resolved-but-not-actually-an-image body (corrupt,
+    truncated, or a non-image content type mislabeled by the server) fails
+    to decode and falls back to a status line naming the failure — never a
+    crash, never the same text as a genuine fetch failure or the
+    never-resolved placeholder (the #3688 "different things read as the
+    same" class).
+
+    Uses a TRUNCATED real PNG (valid header, cut off mid-pixel-data), not
+    plain garbage bytes: garbage fails at `PILImage.open()`'s header sniff
+    alone, which would leave the LAZY-decode failure path unexercised — a
+    truncated body passes `open()` (the header parses fine; PIL decodes
+    lazily) and only fails once pixel data is actually read, which
+    `TextualImage(...)`'s own constructor does eagerly (verified directly:
+    `open()` on this exact body returns a valid `Image`; constructing
+    `TextualImage` from it raises `OSError: image file is truncated`) — the
+    case `_render_image`'s `try` block exists to catch."""
+    from rich.console import Console
+
+    from reyn.core.present.image_fetch import ImageResolution
+
+    truncated_png = _png_bytes(size=(50, 50))
+    truncated_png = truncated_png[: len(truncated_png) // 2]
+
+    nodes = validate_blueprint({"component": "image", "src": "http://x/y.png", "alt": "a photo"})
+    resolved = resolve_bindings(nodes, {}, surface="inline-cui")
+    image_cache = {
+        "http://x/y.png": ImageResolution(
+            ok=True, body=truncated_png, content_type="image/png",
+        ),
+    }
+    console = Console(width=100, file=io.StringIO(), force_terminal=True, color_system=None)
+    console.print(render_presentation_nodes(resolved.nodes, image_cache=image_cache))
+    out = console.file.getvalue()
+    assert "could not render" in out
+    assert "a photo" in out
+    assert "[image: a photo]" not in out
+    assert "[image failed" not in out  # distinct from a FETCH failure (res.ok=False)
+
+
 # ── 2. INVARIANT-LOCK: Rich markup never interpreted, full real pipeline ────
 
 


### PR DESCRIPTION
**[tui-coder]** — #3846 ③: `present`'s `image` component renders real pixels via `textual-image`.

Closes #3846.

## Dependencies

Owner-decided (#3970): `pillow` + `textual-image` as **REGULAR** dependencies (not extras) — "入れた瞬間に効く" (UX/predictability over a silent text-only fallback, owner's own standing policy). pip resolvability measured in #3970: manylinux(3.11/3.12) / win_amd64(3.11) / macosx_11_0_arm64(3.12) all have prebuilt wheels; the one gap (macosx_10_9_x86_64, Intel Mac) affects neither CI nor the owner's machine.

## What

`_render_image` (`present_renderer.py`) decodes a resolved image's fetched bytes via PIL and wraps them in `textual_image.renderable.Image` — Kitty/WezTerm real pixels or Sixel where the terminal supports either, half-block/unicode approximation otherwise (`textual_image`'s own per-terminal auto-detection, made once per process). Decoding stays within the module's "No I/O" invariant (pure CPU on already-fetched bytes). Falls back to a distinguishable status-line `Text` on decode failure (corrupt/truncated body) or if `pillow`/`textual-image` are unavailable for any reason (defensive only — they are regular deps).

## A real architectural finding: the eager-import ordering fix

`textual_image.renderable`'s terminal-capability auto-detection (Sixel/TGP support) sends a raw escape sequence to the terminal and synchronously reads the reply off `sys.__stdout__`/stdin — a one-time, process-global, import-time side effect. **The library's own docstring** (`textual_image.renderable.sixel.query_terminal_support`) warns this *"will not work anymore once Textual is started"* — Textual runs its own stdin-reading thread that races (and usually wins) this read once the app loop is live.

`present_renderer.py`'s `_render_image` imports `textual_image.renderable` lazily (matching this module's own "No I/O" invariant), which would otherwise defer this exact query to the first image actually presented — i.e. **during a live `app.run_async()` session**, guaranteeing the query loses the race and every image in the TUI falls back to unicode/half-block even on a real Kitty/WezTerm/Sixel terminal.

Fixed by triggering the import in `run_textual_chat` (`textual_chat/app.py`), strictly before `app.run_async()` hands stdin to Textual — verified via a dedicated ordering test (falsify-verified: reverting to no eager import, or moving it after `app.run_async()`, both go RED).

## CI caught 2 more real bugs (`textual-image>=0.13` unsatisfiable on Python 3.11 + a structural try/except placement error)

**Bug 1 — the version floor.** `textual-image>=0.13` (0.13.0/0.13.1/0.13.2) all declare `Requires-Python >=3.12` — unsatisfiable on reyn's own Python 3.11 CI leg, so `pip install -e ".[dev]"` failed at the INSTALL stage (surfacing as 8 simultaneously-red checks — ruff/mypy/pytest-3.11/the sandbox suite/dev==wheel-parity — none of which ran a single test, they all died at install). Caught because my dev venv already had the package installed and so only ever exercised "after install" — a clean-venv-per-Python-version check (`pip install -e ".[dev]"` from scratch) is what actually reproduces it. Floor lowered to `>=0.12`; verified 0.12.0's API surface this file uses is identical to 0.13.2's.

**Bug 2 — a structural try/except placement error, NOT a 0.12.0-specific one.** Verifying "does the downgraded version behave the same" surfaced a real difference: `textual-image` 0.12.0 raises `ValueError('height and width must be > 0')` for a very small source image (reproduced: 8x8/1x1 fail, 16x16 does not). The important part isn't the version — **it's WHERE the exception happens**. Rich renderables are lazily evaluated: `TextualImage(...)` construction just builds a "recipe"; the actual pixel work happens inside `__rich_console__`, a generator Console.print() only iterates once it knows the real render width. `_render_image`'s original `try/except` wrapped only the *construction* call — structurally unable to catch anything `__rich_console__` raises, on ANY version, for ANY reason. 0.12.0's small-image bug is simply what exposed a pre-existing placement error; a future floor bump to 0.13+ does **not** make this wrapper obsolete — any Rich renderable can still raise at print time for its own reasons.

Fixed with `_SafeImageRenderable`, wrapping `__rich_console__` itself (not the constructor) so a print-time failure degrades to the same fallback status-line `Text` the decode-failure path already uses. Verified against the real bug end-to-end in a clean Python 3.11 + textual-image 0.12.0 venv (a 4x4 image that used to crash now renders the fallback text, no exception). The new unit test (`test_safe_image_renderable_catches_a_print_time_failure`) exercises the wrapper against a FAKE raising inner renderable rather than the real bug — the installed `textual_image` version in any given dev environment may or may not reproduce it, so pinning the test to the real bug would be flaky-by-environment.

Both test files' PNG fixtures bumped from 4x4 to 32x32 (safely above the 16x16 threshold) so the SUCCESS-path tests actually exercise success on 0.12.0, not accidentally the failure path depending on which `textual-image` version pip resolved.

## Tests (falsify-verified throughout — including 2 self-corrections caught during my own review)

- `test_image_with_resolved_cache_renders_real_pixels_not_the_status_line`: checks the render-model **object** (`Group.renderables`) for a `textual_image.renderable.Image` instance, not printed glyph output. **Self-caught issue**: my first draft asserted only on printed string content ("no placeholder text", "non-empty output") — falsify-verifying it (reverting `_render_image` to the pre-③ `Text` return) showed the test **stayed green**, because a `Console.print()` of either class produces terminal-formatted text and string-only assertions can't distinguish "real pixel path wired" from "still the old status line". Rewritten to check the object type instead; re-falsified, now correctly goes RED on the same revert.
- `test_image_with_undecodable_body_falls_back_to_a_distinct_status_line`: uses a **truncated real PNG** (not garbage bytes), so the decode actually fails inside the `try` block rather than at `PILImage.open()`'s header sniff. **Second self-caught issue**: while building this test I found the original `pil_image.load()` call (meant to "force the decode now") is **redundant** — `textual_image.renderable.Image`'s own constructor already reads pixel data eagerly (`PixelData.__init__`), so a truncated body raises from `TextualImage(...)` itself regardless of whether `.load()` is called (verified directly in a scratch script). The dead `.load()` line was removed and its comment corrected to describe the real mechanism.
- `test_textual_image_renderable_is_imported_before_app_run_async`: the ordering test described above.
- `test_loaded_state_replaces_the_placeholder_after_resolution` (existing e2e test): updated to use a real PNG body instead of a bare magic-byte stub — ③'s real decode step correctly rejects the old fake bytes, which is the test catching real behavior, not a false failure.

## Docs

`present.md` / `present.ja.md`'s `image` component row updated from "v1 renders a placeholder only" to describe the real pixel-rendering path + the plain-surface placeholder fallback + the distinguishable failure state.

## ⚠️ Known limitation — owner verification required (this is the whole point of the issue)

Real pixel rendering on an actual Kitty/WezTerm/Sixel terminal has **NOT** been visually confirmed — this environment has no real TTY. This PR's own falsify-verification proves the **wiring** is correct (the right object reaches the right renderer, in the right order relative to Textual's stdin ownership) — it cannot prove pixels actually appear on the owner's terminal, which is a third-party rendering promise this environment cannot observe. Per lead-coder's explicit condition on this issue: *"③ は「実物が見えること」が価値の全部なので、私には判定できません"* — the Visual test-plan item below is left **unchecked**, per CLAUDE.md's standing Visual-gate waiver (does not block merge; the owner confirms after, on `main`).

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/mypy_ratchet.py` — 0 findings, verified in BOTH a clean Python 3.11 venv (`textual-image` 0.12.0, the real CI scenario) and the Python 3.12 dev venv (0.13.2) — the two Python versions resolve genuinely different `textual-image` releases, so one venv's green is not sufficient
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 22/22 OK
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] Falsify-verified all 4 new/changed unit-level assertions (2 caught real weaknesses in my own first draft, described above; the print-time-failure guard is falsify-verified against the real bug in the clean 3.11 venv)
- [x] `tests/core/test_present_op_fp0054_pra.py`, `test_3846_image_fetch.py`, `test_present_renderer_fp0054_prb.py`, `test_3846_image_resolution_e2e.py`, `test_3846_image_url_schemes_config.py`, `test_3846_3_textual_image_eager_import_ordering.py`, `tests/runtime/test_2770_intervention_present_unification.py`, `tests/repo/test_present_sink_ast_guard_2708.py` — 77/77 pass, re-verified in BOTH the clean Python 3.11 venv and the Python 3.12 dev venv
- [x] Full `tests/core/ tests/runtime/ tests/interfaces/ tests/repo/` regression sweep (network-hanging `test_web_search_no_deny_config_does_not_raise` deselected — unrelated pre-existing issue, #4293, fix pending in a separate PR) — 5845 passed, 6 skipped (documented optional-extra skips), 0 failed
- [x] Post-rebase (onto `origin/main` after #4296/#4298 landed): re-verified imports + ruff + mypy_ratchet + the scoped test run, all clean
- [x] Clean-venv `pip install -e ".[dev,mcp,web,fs-watch,observability,builtin-rag]"` (matching CI's exact pytest-job install command) succeeds on BOTH a from-scratch Python 3.11 venv and Python 3.12 venv — the actual bug class this PR's second commit fixes
- [ ] **Owner visually confirms real pixels render on a real Kitty/WezTerm/Sixel terminal** — left unchecked, see "Known limitation" above; not a merge blocker per the standing Visual-item waiver

🤖 Generated with [Claude Code](https://claude.com/claude-code)

