### PR TITLE
fix(#4204 bucket C): recovery-core write-gate anchors on project root, not launch-subdirectory cwd

### DIFF
--- a/src/reyn/api/safe/file.py
+++ b/src/reyn/api/safe/file.py
@@ -180,6 +180,43 @@ def _check_read(path: str) -> None:
         )
 
 
+def _project_root_for_gate() -> str:
+    """Walk up from ``os.getcwd()`` looking for ``reyn.yaml``, same
+    algorithm as ``reyn.config.loader._find_project_root`` — deliberately
+    NOT imported from there (or from ``reyn.security.permissions``): this
+    module runs inside the python-harness SUBPROCESS (see the module-level
+    comment above ``_RECOVERY_CORE_WRITE_PREFIXES``), and stays
+    self-contained rather than depending on the rest of the reyn package
+    being importable there. Falls back to ``os.getcwd()`` if no ancestor
+    carries ``reyn.yaml`` (mirrors ``_find_project_root(...) or
+    Path.cwd()``, the convention every other correctly-behaving reyn call
+    site uses).
+
+    #4204 bucket C: this module's cwd-anchored write-gate check
+    (``_is_canonical_protected_write``/``_is_under_recovery_core_prefix``
+    below) previously used raw ``os.getcwd()`` directly. Reachability
+    confirmed live: ``codeact_runner.py``'s ``Runner.run(cwd=...)`` reads
+    it from ``exec_ctx.extra.get("cwd")`` (``_content_fence_cell.py``),
+    and NOTHING in the codebase ever populates that key — grepped for
+    every producer, zero hits — so ``cwd`` is always ``None``, and
+    ``subprocess.Popen(cwd=None)`` inherits the PARENT reyn process's own
+    cwd. A subdirectory launch (this issue's condition ①) therefore
+    reaches this subprocess unchanged, and the write-gate's ``os.getcwd()``
+    silently anchored to the wrong directory — the recovery-core
+    write-gate could fail to fire for the real ``.reyn/config``/``.reyn/
+    state`` (or fire for a phantom ``<subdir>/.reyn/config`` that doesn't
+    exist), the same class of defect this issue's other buckets found.
+    """
+    current = _os.path.realpath(_os.getcwd())
+    while True:
+        if _os.path.exists(_os.path.join(current, "reyn.yaml")):
+            return current
+        parent = _os.path.dirname(current)
+        if parent == current:
+            return _os.getcwd()
+        current = parent
+
+
 def _is_canonical_protected_write(path: str) -> bool:
     """Return True if ``path`` resolves to one of the #571 protected paths.
 
@@ -188,9 +225,9 @@ def _is_canonical_protected_write(path: str) -> bool:
     explicitly in ``_write_paths`` (not via a parent-directory prefix).
     """
     abs_path = _os.path.realpath(path)
-    cwd = _os.getcwd()
+    root = _project_root_for_gate()
     for rel in _CANONICAL_PROTECTED_WRITE_PATHS:
-        if abs_path == _os.path.realpath(_os.path.join(cwd, rel)):
+        if abs_path == _os.path.realpath(_os.path.join(root, rel)):
             return True
     return False
 
@@ -199,12 +236,17 @@ def _is_under_recovery_core_prefix(path: str) -> bool:
     """#2248 PR-C: True if ``path`` is under a recovery-core write-gate prefix
     (``.reyn/config/`` or ``.reyn/state/``) — a raw file.write there requires an explicit
     declaration (the dedicated WAL-emitting ops provide it), never the broad ``.reyn/``
-    default zone. Mirrors ``permissions._is_under_recovery_core_prefix``."""
+    default zone. Mirrors ``permissions._is_under_recovery_core_prefix``.
+
+    #4204 bucket C: anchored on the actual project root (see
+    :func:`_project_root_for_gate`), not raw ``os.getcwd()`` — a
+    subdirectory launch used to silently anchor this gate to the wrong
+    directory."""
     abs_path = _os.path.realpath(path)
-    cwd = _os.getcwd()
+    root = _project_root_for_gate()
     for prefix in _RECOVERY_CORE_WRITE_PREFIXES:
-        root = _os.path.realpath(_os.path.join(cwd, prefix))
-        if abs_path == root or abs_path.startswith(root + _os.sep):
+        gate_root = _os.path.realpath(_os.path.join(root, prefix))
+        if abs_path == gate_root or abs_path.startswith(gate_root + _os.sep):
             return True
     return False
 

--- a/tests/security/test_2248_prc_write_gate_prefix.py
+++ b/tests/security/test_2248_prc_write_gate_prefix.py
@@ -90,3 +90,36 @@ def test_safe_file_allows_non_recovery_core_reyn_write(tmp_path, monkeypatch):
     )
     safe_file._check_write(str(tmp_path / ".reyn" / "memory" / "note.md"))  # must not raise
     safe_file._check_write(str(tmp_path / ".reyn" / "cache" / "x.db"))  # must not raise
+
+
+def test_safe_file_recovery_core_gate_anchors_on_project_root_not_launch_subdir(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: #4204 bucket C — the recovery-core write-gate must anchor on the
+    PROJECT root (walked up via reyn.yaml), not the raw process cwd, so a
+    ``reyn`` launched from a subdirectory still gates the REAL
+    ``.reyn/config``/``.reyn/state`` — not a phantom
+    ``<subdir>/.reyn/config`` that doesn't exist, and not silently letting
+    the real path through unguarded.
+
+    STRIP-FALSIFY: replacing ``_project_root_for_gate()`` with a bare
+    ``os.getcwd()`` (the pre-#4204 form) makes this go RED — the gate
+    would anchor at ``<project>/subdir/.reyn/config``, which does not
+    prefix-match the real target path under ``<project>/.reyn/config``, so
+    ``_is_under_recovery_core_prefix`` returns False and the raw write is
+    wrongly ALLOWED via the broad ``.reyn/`` zone."""
+    (tmp_path / "reyn.yaml").write_text("mcp:\n  servers: {}\n", encoding="utf-8")
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    monkeypatch.chdir(subdir)  # the operator launched reyn from here, not tmp_path
+
+    from reyn.api.safe import file as safe_file
+
+    safe_file._set_permission_context(
+        read_paths=[str(tmp_path)],
+        write_paths=[str(tmp_path / ".reyn"), str(tmp_path / "reyn")],
+    )
+    # The REAL recovery-core path (under the project root, not the launch
+    # subdirectory) must still be gated — a raw write is DENIED.
+    with pytest.raises(PermissionError):
+        safe_file._check_write(str(tmp_path / ".reyn" / "config" / "mcp.yaml"))


### PR DESCRIPTION
**[e2e-coder]** — #4204 bucket C: `reyn.api.safe.file`'s recovery-core write-gate (`.reyn/config/`, `.reyn/state/`) was anchoring on raw `os.getcwd()` inside the codeact python-step subprocess, whose cwd was never explicitly set to project root anywhere in the codebase.

## Reachability (architect flagged this bucket as unverified — measured before fixing)

`codeact_runner.Runner.run(cwd=...)` reads `cwd` from `exec_ctx.extra.get("cwd")` (`_content_fence_cell.py`). Grepped every producer of that `"cwd"` key across the whole codebase — **zero hits**. So `cwd` is always `None`, and `subprocess.Popen(cwd=None)` inherits the **parent reyn process's own cwd**. A `reyn` launched from a subdirectory (this issue's condition ①) reaches this subprocess unchanged, and the write-gate silently anchored to the wrong directory: a raw write to the real `<project>/.reyn/config/...` didn't prefix-match a gate root computed from `<project>/<subdir>/.reyn/config/...`, so the gate failed to fire.

## Fix

`_project_root_for_gate()` walks up from `os.getcwd()` looking for `reyn.yaml` — same algorithm as `reyn.config.loader._find_project_root`, but deliberately self-contained (no `reyn` package import), matching this module's own pre-existing design constraint (it runs inside an isolated subprocess where importing the rest of the reyn package "is not always available", per the file's own comment). Falls back to `os.getcwd()` when no ancestor carries `reyn.yaml`.

## Falsify

Reverted `_project_root_for_gate()` to a bare `os.getcwd()` by hand, confirmed the new test goes RED (`DID NOT RAISE PermissionError` — the real `.reyn/config` write was wrongly allowed) while all 5 pre-existing tests in the same file stayed green, then restored the fix.

## Scope

Bucket C only. Buckets B (`permissions.py`'s `project_root`/`file_zone_root` split — architect explicitly flagged this as needing a concrete repro constructed first, a real design question about which root a divergent path should resolve against), D (SP's displayed cwd), and E (`$PWD` staleness) are separate and not addressed here — will follow, one bucket at a time, per lead-coder's sequencing.

## Verification

Local 5-gate battery all green. `tests/security/test_2248_prc_write_gate_prefix.py`: 6 passed. 5-file consumer sweep (`tests/api/` + `tests/security/`): 68 passed; 1 pre-existing, unrelated failure in `test_reyn_api_relocate_311.py` confirmed via `git stash` to reproduce identically on unmodified `main` (test-ordering pollution from an earlier import in the same pytest process, not caused by this change).

## Test plan

- [x] `ruff check src/reyn/api/safe/file.py tests/security/test_2248_prc_write_gate_prefix.py`
- [x] `python scripts/test_tier_audit.py --strict tests/security/test_2248_prc_write_gate_prefix.py`
- [x] `python scripts/verify_module_docstrings.py src/reyn/api/safe/file.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `tests/security/test_2248_prc_write_gate_prefix.py` (6 passed)
- [x] consumer sweep across `tests/api/` + `tests/security/` (68 passed, 1 pre-existing unrelated failure confirmed via stash-diff against main)
- [x] falsify-verified by hand (strip → red; restore → green)
- [x] (skipped — no TUI/visual surface touched)

part of #4204

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
