### PR TITLE
fix(#4204 bucket D): SP's displayed cwd now matches the base_dir real exec ops actually anchor on

### DIFF
--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -957,13 +957,34 @@ class RouterHostAdapter:
         against the container repo_dir (frame mismatch + host path leak).
 
         Resolution order (getattr-guarded for forward compat):
-        1. backend.repo_dir  — ContainerBackend (e.g. DockerEnvironmentBackend)
-        2. os.getcwd()       — HostBackend or no backend
+        1. backend.repo_dir      — ContainerBackend (e.g. DockerEnvironmentBackend)
+        2. workspace.base_dir    — HostBackend or no backend (#4204 bucket D)
+        3. os.getcwd()           — defensive fallback if base_dir is unresolvable
+
+        #4204 bucket D: step 2 used to be a bare ``os.getcwd()`` — but the
+        REAL host-side exec op (``sandboxed_exec``, see
+        ``op_runtime/sandboxed_exec.py``) anchors its subprocess's cwd on
+        ``ctx.workspace.base_dir``, not the raw process cwd (measured by
+        reading that op's own source directly). These diverge exactly when
+        reyn is launched from a subdirectory of the project (this issue's
+        condition ①) — the SP told the agent one cwd while every real exec
+        op ran somewhere else, with no way for the agent to detect the
+        mismatch. ``self._op_ctx_source``'s ``workspace_base_dir_fn``
+        supplier is the SAME source ``build_router_op_context`` reads for
+        the real ``OpContext.workspace.base_dir`` value (one supplier, one
+        answer — see ``RouterOpContextSource``'s own docstring for why a
+        supplier, not a snapshot, matters here: a spawned session's real
+        base_dir is fixed up AFTER construction).
         """
         import os
         repo_dir = getattr(self._environment_backend, "repo_dir", None)
         if repo_dir:
             return str(repo_dir)
+        base_dir_fn = getattr(self._op_ctx_source, "_workspace_base_dir_fn", None)
+        if base_dir_fn is not None:
+            base_dir = base_dir_fn()
+            if base_dir:
+                return str(base_dir)
         return os.getcwd()
 
     def get_environment_info(self) -> dict:

--- a/tests/runtime/test_cwd_sandbox_aware_1477.py
+++ b/tests/runtime/test_cwd_sandbox_aware_1477.py
@@ -76,3 +76,49 @@ def test_get_cwd_container_differs_from_host(tmp_path: Path) -> None:
     )
     assert adapter.get_cwd() == container_path
     assert adapter.get_cwd() != os.getcwd()
+
+
+def test_get_cwd_with_host_backend_uses_workspace_base_dir_over_process_cwd(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: #4204 bucket D — when a HostBackend is present AND the
+    session's real workspace_base_dir differs from the process's raw cwd
+    (the subdirectory-launch case this issue tracks), get_cwd() reports
+    the base_dir — matching what sandboxed_exec.py's real op actually
+    anchors its subprocess cwd on (``ctx.workspace.base_dir``) — not the
+    process cwd the SP would otherwise show.
+
+    STRIP-FALSIFY: reverting get_cwd()'s workspace_base_dir_fn branch
+    (the pre-#4204 form) makes this go RED — it would return the
+    subdirectory (process cwd) instead of the real project root."""
+    project_root = tmp_path
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    monkeypatch.chdir(subdir)  # the operator launched reyn from here
+
+    backend = _FakeHostBackend()
+    adapter = _make_adapter(
+        universal_wrappers_enabled=False,
+        agent_workspace_dir=tmp_path / "agents" / "test",
+        environment_backend=backend,
+        workspace_base_dir=project_root,
+    )
+    assert adapter.get_cwd() == str(project_root)
+    assert adapter.get_cwd() != os.getcwd()  # os.getcwd() is the subdir
+
+
+def test_get_cwd_falls_back_to_os_getcwd_when_base_dir_unresolvable(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #4204 bucket D — when no workspace_base_dir supplier is wired
+    at all (test hosts / adapters built without one), get_cwd() falls back
+    to os.getcwd() — the pre-#4204 behavior is preserved as the defensive
+    floor, not silently broken for callers that don't supply one."""
+    backend = _FakeHostBackend()
+    adapter = _make_adapter(
+        universal_wrappers_enabled=False,
+        agent_workspace_dir=tmp_path / "agents" / "test",
+        environment_backend=backend,
+        # workspace_base_dir intentionally omitted (None) — no supplier wired.
+    )
+    assert adapter.get_cwd() == os.getcwd()


### PR DESCRIPTION
**[e2e-coder]** — #4204 bucket D: `RouterHostAdapter.get_cwd()` (the agent-visible cwd shown in the SP Environment section) fell back to a bare `os.getcwd()` whenever no container backend was present — but real host-side exec ops anchor on `ctx.workspace.base_dir` instead.

## Reachability (measured, not assumed)

`sandboxed_exec.py`'s real op does `cwd = str(ctx.workspace.base_dir)` — read directly from that op's own source. This diverges from `os.getcwd()` exactly when reyn is launched from a subdirectory of the project (this issue's condition ①): the SP told the agent one cwd while every real exec op ran somewhere else, with no way for the agent to detect the mismatch.

**Bonus**: `is_git_repo` (`get_environment_info`) calls `self.get_cwd()` too, so this same fix also corrects architect's related "追加H" finding (git-repo detection following the wrong root) — no separate change needed there.

## Fix

`get_cwd()` now checks `self._op_ctx_source`'s `workspace_base_dir_fn` supplier before falling back to `os.getcwd()` — the same supplier `build_router_op_context` reads for the real `OpContext.workspace.base_dir` value. Resolution order: 1) `backend.repo_dir` (container, unchanged), 2) `workspace.base_dir` (host, **new**), 3) `os.getcwd()` (defensive fallback when no supplier is wired at all).

## Falsify

Reverted `get_cwd()` to skip the `workspace_base_dir_fn` branch by hand, confirmed the new test goes RED (returned the launch subdirectory instead of the real project root) while the other 5 tests in the same file stayed green, then restored the fix.

## Scope

Bucket D only (+ bucket H for free, same call site). Bucket B (a real design question architect flagged as needing a repro constructed first) and bucket E (`$PWD` staleness) remain, one at a time.

## Verification

Local 5-gate battery all green. `tests/runtime/test_cwd_sandbox_aware_1477.py`: 6 passed. 7-file targeted sweep (get_cwd/base_dir/sysinfo-adjacent): 49 passed. Full `tests/runtime/`: 1679 passed, 1 pre-existing unrelated failure confirmed via `git stash` to reproduce identically on unmodified `main` (`test_session_pure_extraction_3679_s1.py`'s subprocess-import test — an environmental PYTHONPATH issue).

## Test plan

- [x] `ruff check src/reyn/runtime/services/router_host_adapter.py tests/runtime/test_cwd_sandbox_aware_1477.py`
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_cwd_sandbox_aware_1477.py`
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/services/router_host_adapter.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `tests/runtime/test_cwd_sandbox_aware_1477.py` (6 passed)
- [x] 7-file targeted sweep (49 passed) + full `tests/runtime/` (1679 passed, 1 pre-existing unrelated failure confirmed via stash-diff)
- [x] falsify-verified by hand (strip → red; restore → green)
- [x] (skipped — no TUI/visual surface touched)

part of #4204

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
