### PR TITLE
fix(#4304): remove 7 third-party-property tests found via region review

### DIFF
--- a/tests/interfaces/test_conversation_pane_boundary_3692.py
+++ b/tests/interfaces/test_conversation_pane_boundary_3692.py
@@ -180,7 +180,11 @@ async def test_motions_reach_flowview_not_witnessing_flowviews_own_contract() ->
         await pilot.press("l")
         await pilot.pause()
         after_col = _cursor_col(flow, cursor_row)
-        assert after_col == before_col + 1, (
+        # #4304 (part of #3880): weakened from `== before_col + 1` — that pinned
+        # flowview's own cursor-right STEP MAGNITUDE (its business, would break
+        # on any upstream retune), not reyn's actual claim, which per this
+        # test's own docstring is only that the key REACHED flowview's action.
+        assert after_col != before_col, (
             f"'l' did not reach flowview's cursor-right action: "
             f"{before_col!r} -> {after_col!r}"
         )

--- a/tests/interfaces/test_copy_mode_3507.py
+++ b/tests/interfaces/test_copy_mode_3507.py
@@ -93,27 +93,11 @@ async def _seeded(pilot, app, texts=("older reply", "newest reply")):
     return app.query_one(FlowView)
 
 
-@pytest.mark.asyncio
-async def test_c_shows_the_cursor_on_the_highlighted_entry() -> None:
-    """Tier 2b: ``c`` from the conversation pane shows flowview's text cursor
-    (0.13's ``toggle_cursor``, retargeted from the removed 0.7.0 "enter copy
-    mode" surface — #3692 PR-A), and it starts on the entry the highlight is
-    already on — so the cursor appears where the user was looking rather than
-    at the top of the log."""
-    app = TextualChatApp(transport=_Transport())
-    async with app.run_test(size=(80, 20)) as pilot:
-        flow = await _seeded(pilot, app)
-        assert not flow.cursor_visible, "test setup: cursor already visible"
-        started_on = flow.current
-        assert started_on is not None and started_on.item.text == "newest reply"
-
-        await pilot.press("c")
-        await pilot.pause()
-        assert flow.cursor_visible, "'c' did not show the text cursor"
-        assert flow.current is started_on, (
-            "showing the text cursor moved the highlight off the entry the "
-            "user was on"
-        )
+# test_c_shows_the_cursor_on_the_highlighted_entry removed (#4304, part of #3880):
+# per this module's own docstring, reyn declares NO binding for "c" — it falls
+# through entirely to flowview's own default keymap. Both asserts (cursor_visible
+# flips, current is preserved) pinned flowview's own toggle_cursor behavior, not
+# any reyn wiring — if either failed, it would be flowview's bug, not reyn's.
 
 
 @pytest.mark.asyncio

--- a/tests/interfaces/test_textual_chat_esc_sufficiency_3365.py
+++ b/tests/interfaces/test_textual_chat_esc_sufficiency_3365.py
@@ -357,11 +357,12 @@ async def test_esc_with_an_active_selection_cancels_it_and_stays_on_the_pane() -
             f"Esc with an active selection bubbled past the pane instead of "
             f"being consumed by it: {app.focused!r}"
         )
-        after = flow.screen.get_selected_text() or ""
-        assert len(after) == len(baseline), (
-            f"Esc did not cancel the visual selection back to the bare-cursor "
-            f"baseline width ({baseline!r}): {after!r}"
-        )
+        # A trailing assert on the selection-width-after-Esc (`len(after) ==
+        # len(baseline)`) was removed here (#4304, part of #3880): it pinned
+        # flowview's own cursor_cancel binding collapsing a visual selection
+        # back to baseline width — reyn's own claim is only that Esc reaches
+        # the pane (asserted above), not what flowview's own cursor_cancel does
+        # with it.
 
 
 @pytest.mark.asyncio

--- a/tests/interfaces/test_textual_chat_phase2b_live_tool_3283.py
+++ b/tests/interfaces/test_textual_chat_phase2b_live_tool_3283.py
@@ -460,44 +460,12 @@ async def test_running_body_animates_live_then_stops_on_settle() -> None:
         assert entry.state is EntryState.SUCCESS
 
 
-@pytest.mark.asyncio
-async def test_offscreen_running_tool_is_not_animated() -> None:
-    """Tier 2b: an OFF-SCREEN RUNNING tool is not animated (viewport gating).
-
-    ``animate_entry`` auto-pauses when the entry scrolls out of the viewport, and
-    an off-screen entry is not repainted, so a RUNNING tool pushed above the fold
-    neither spins nor recomputes. Push a started tool, then enough later frames to
-    scroll it off the top (a small viewport, STICKY_BOTTOM anchor), confirm it is
-    OFF-SCREEN via the public ``visible_range()``, and assert its present-count is
-    frozen across a pause."""
-    transport = QueueTransport()
-    presenter = _CountingPresenter()  # held locally — assert on its PUBLIC count
-    app = _fast_app(transport=transport, presenter=presenter)
-    async with app.run_test(size=(80, 8)) as pilot:
-        await pilot.pause()
-        await transport.push(_started("op-off"))
-        await pilot.pause(0.1)
-        # Fill past the fold with many later rows, then scroll to the bottom so
-        # the started tool (row 0) is above the visible range.
-        for i in range(40):
-            await transport.push(OutboxMessage(kind="agent", text=f"line {i}"))
-        await pilot.pause()
-        flow = app.query_one(FlowView)
-        flow.scroll_to_bottom()
-        await pilot.pause()
-
-        entries = flow.entries
-        idx = next(i for i, e in enumerate(entries) if e.item.meta.get("op_id") == "op-off")
-        start, stop = flow.visible_range()
-        assert not (start <= idx < stop), (
-            f"precondition: started row must be off-screen, got idx={idx} in [{start},{stop})"
-        )
-
-        baseline = presenter.present_counts.get("op-off", 0)
-        await pilot.pause(0.4)
-        assert presenter.present_counts.get("op-off", 0) == baseline, (
-            "off-screen RUNNING tool was animated (viewport gating failed)"
-        )
+# test_offscreen_running_tool_is_not_animated removed (#4304, part of #3880):
+# per this test's own docstring, "animate_entry auto-pauses when the entry
+# scrolls out of the viewport" is flowview's own track_visibility mechanism —
+# reyn only registers the animate_entry callback, it does not implement the
+# off-screen pause decision itself. If this failed, it would be flowview's
+# viewport-gating bug, not reyn's.
 
 
 # ── Gate 4: no regression ─────────────────────────────────────────────────────

--- a/tests/interfaces/test_textual_chat_phase4_right_gutter_3283.py
+++ b/tests/interfaces/test_textual_chat_phase4_right_gutter_3283.py
@@ -48,8 +48,6 @@ import re
 from typing import AsyncIterator
 
 import pytest
-from textual.geometry import Offset
-from textual.selection import Selection
 from textual_flowview import EntryState, FlowModel, FlowView
 
 from reyn.interfaces.inline.textual_chat import (
@@ -195,16 +193,6 @@ class QueueTransport(ClientTransport):
 
     async def shutdown(self) -> None:  # pragma: no cover - trivial
         pass
-
-
-def _full_selection(flow: "FlowView[OutboxMessage]") -> Selection:
-    """A :class:`Selection` spanning the FlowView's ENTIRE virtual content
-    (every row of every entry, not just the painted viewport) — the installed
-    textual-flowview pin's ``get_selection`` requires explicit bounds (unlike
-    a newer upstream ``Selection(None, None)`` "to the edge" form), so this
-    reads the widget's own public ``virtual_size`` to build them."""
-    height = max(0, flow.virtual_size.height - 1)
-    return Selection(Offset(0, 0), Offset(flow.virtual_size.width, height))
 
 
 def _painted_lines(flow: "FlowView[OutboxMessage]") -> "list[str]":
@@ -467,13 +455,10 @@ async def test_right_gutter_wired_end_to_end_settled_tool_vs_plain_row() -> None
         assert agent_lines, f"no rendered row found for the agent row: {lines!r}"
         assert not any(re.search(r"\d+[smh]$", ln) for ln in agent_lines), agent_lines
 
-        # Complement: a SELECTION over the same rows yields the body text and
-        # no gutter glyph — flowview 0.9.0 confines selection to the body.
-        result = flow.get_selection(_full_selection(flow))
-        assert result is not None
-        selected, _sep = result
-        assert "grep" in selected, selected
-        assert not re.search(r"\d+[smh]\s*$", selected, re.MULTILINE), selected
+        # A "Complement" block asserting flow.get_selection() excludes the
+        # gutter glyphs was removed here (#4304, part of #3880): per its own
+        # comment, that's "flowview 0.9.0 confines selection to the body" —
+        # flowview's own selection-scoping contract, not any reyn behavior.
 
 
 # ── Gate 3: left gutter unchanged (#3273 state contract) ──────────────────────
@@ -663,12 +648,10 @@ async def test_narrow_terminal_keeps_gutters_fixed_and_squashes_the_body() -> No
             assert region.y >= 0
             assert region.y + region.height <= screen_height
 
-        # The right gutter stays WIRED (never conditionally dropped below a
-        # width threshold) — proven on the PUBLIC rendered surface: the
-        # RUNNING tool row's elapsed label is still readable in the composed
-        # row text even at this extreme width (flowview's own body-width
-        # floor absorbs the squeeze instead of hiding the gutter).
-        painted = "\n".join(_painted_lines(flow))
-        assert re.search(r"\d+[smh]\s*$", painted, re.MULTILINE), (
-            f"elapsed label not found in narrow-terminal render:\n{painted!r}"
-        )
+        # A trailing assert on the elapsed label's continued readability was
+        # removed here (#4304, part of #3880): its own comment described it as
+        # pinning "flowview's own body-width floor absorbs the squeeze" — while
+        # reyn's own "never conditionally hide the gutter" decision is also
+        # causally present, the assertion itself measured flowview's floor
+        # formula's output, not reyn's decision directly. The mount/containment
+        # checks above (reyn's own layout not crashing at extreme width) stay.

--- a/tests/mcp/test_config_mcp_headers.py
+++ b/tests/mcp/test_config_mcp_headers.py
@@ -8,9 +8,10 @@ Component A scope:
   - ``headers: dict[str, str]`` is accepted on http-mode MCP server configs.
   - ``${VAR}`` tokens inside header values resolve at config-load time.
   - The headers dict reaches the real ``StreamableHttpTransport`` verbatim
-    (post-expand) — #2597 S1: inspected via the transport's own public
-    ``.headers`` attribute (a real ``fastmcp`` object), not a mocked SDK entry
-    point.
+    (post-expand) — #2597 S1, updated for #4282's fastmcp-to-official-SDK
+    migration: inspected via the kwargs the real ``streamablehttp_client``
+    call site is invoked with (captured at that boundary, not a mocked SDK
+    entry point — see ``_capture_streamablehttp_client_kwargs`` below).
   - Missing / empty ``headers`` is fine — no header is sent (back-compat).
 """
 from __future__ import annotations

--- a/tests/security/test_sandbox_landlock.py
+++ b/tests/security/test_sandbox_landlock.py
@@ -140,36 +140,13 @@ async def test_landlock_runs_echo() -> None:
     assert result.stdout == b"hi\n"
 
 
-@pytest.mark.skipif(sys.platform != "linux", reason="LandlockBackend is Linux-only")
-@pytest.mark.asyncio
-async def test_landlock_blocks_writes_outside_policy() -> None:
-    """Tier 2: on Linux with landlock, writing outside write_paths yields non-zero returncode."""
-    try:
-        import landlock  # noqa: F401
-    except ImportError:
-        pytest.skip("landlock package not installed")
-
-    backend = LandlockBackend()
-    if not backend.available():
-        pytest.skip("LandlockBackend not available on this kernel")
-
-    import os
-    import tempfile
-
-    # Create a temp dir that is NOT in write_paths.
-    with tempfile.TemporaryDirectory() as restricted_dir:
-        target = os.path.join(restricted_dir, "should_fail.txt")
-        policy = SandboxPolicy(
-            write_paths=[],  # no write paths — kernel should deny
-            network=False,
-            timeout_seconds=10,
-        )
-        # Attempt to write a file outside allowed write_paths.
-        result = await backend.run(
-            ["/bin/sh", "-c", f"echo test > {target}"],
-            policy,
-        )
-        # The write should be blocked by Landlock (EACCES/EPERM → non-zero exit):
-        # WRITE_FILE/MAKE_* are in the HANDLED set but granted on no path (empty
-        # write_paths), so writes are denied everywhere (#1693).
-        assert result.returncode != 0
+# test_landlock_blocks_writes_outside_policy removed (#4304, part of #3880): the
+# only assert was `result.returncode != 0`, with no positive control (a grant-path
+# write succeeding) and no check of reyn's own Ruleset construction — if it failed,
+# whose bug is it was undecidable (the Linux kernel's Landlock LSM vs reyn's
+# construction vs the shim crashing before exec, all producing the same signature).
+# The same claim is already correctly proven, twice, with the falsifying controls
+# this test lacked: test_shim_denies_a_write_outside_write_paths
+# (test_landlock_exec_shim_1344e.py) and
+# test_write_axis_deny_leg_fires_against_landlock_and_fails_against_noop
+# (test_sandbox_axis_contract_2983.py).


### PR DESCRIPTION
**[docs-maintainer]** — #4304: removes/weakens the 7 third-party-property test findings from #3878's region review (sandbox 1, flowview/TTE 6). Zero were found via the static-signal approach (0/30-7/30 across 5 categories, all rejected) — all 7 came from manually reviewing the 4 named regions where third-party properties actually live.

## Commits (region-separated, per the dispatch)

1. **sandbox** — `test_landlock_blocks_writes_outside_policy` removed whole. Names its correctly-formed twins (`test_shim_denies_a_write_outside_write_paths`, `test_write_axis_deny_leg_fires_against_landlock_and_fails_against_noop`) as the reason it's safe to remove — the same claim is already proven with the falsifying controls this one lacked.
2. **flowview/TTE** — 6 locations across 5 files, careful about partial removal (condition ④ in the dispatch — the riskiest part):
   - 2 whole-test removals (`test_copy_mode_3507.py`, `test_textual_chat_phase2b_live_tool_3283.py`) — each test's OWN docstring already stated the behavior under test is flowview's, not reyn's.
   - 3 partial removals — kept the legitimate half of each test (`test_textual_chat_esc_sufficiency_3365.py`'s focus assert, `test_textual_chat_phase4_right_gutter_3283.py`'s mount/containment checks ×2).
   - 1 weakened assertion (`test_conversation_pane_boundary_3692.py`) — `after_col == before_col + 1` (pins flowview's exact step magnitude) → `after_col != before_col` (proves reyn's actual claim: the key reached flowview's action — matches this test's own stated intent, which the old assert violated).
3. **doc fix** (separate, unrelated to the Tier-4 sweep) — `test_config_mcp_headers.py`'s module docstring still described the pre-#4282 fastmcp `.headers`-attribute inspection; test bodies were already rewritten to capture `streamablehttp_client` kwargs, docstring wasn't updated to match.

## Verification

**Same-reason-green**, all 7 changed test files (53 passed, 1 skipped — the skip is pre-existing platform-gated, unrelated):
```
python -m pytest <7 files> -q → 53 passed, 1 skipped
```

## Test plan
- [x] Each candidate: "if this assert fails, whose bug is it?" answered in the commit message
- [x] Partial removals verified — kept assert still exercises reyn's own claim, not flowview's
- [x] Sandbox commit names its twin tests by name
- [x] `ruff check` on all 7 files — clean
- [x] `python scripts/test_tier_audit.py --strict <7 files>` — 50/50 OK, 0 Tier-4
- [x] `python scripts/mypy_ratchet.py` — OK (baseline unchanged)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK (baseline unchanged)
- [x] Scoped pytest — 53 passed, 1 skipped (pre-existing)

part of #3880
