### PR TITLE
fix(#4204 bucket E): sandboxed children get a $PWD matching their real cwd

### DIFF
--- a/src/reyn/security/sandbox/backends/landlock.py
+++ b/src/reyn/security/sandbox/backends/landlock.py
@@ -433,6 +433,12 @@ class LandlockBackend:
         env = resolve_passthrough_env(policy)
         if "PATH" not in env and "PATH" in os.environ:
             env["PATH"] = os.environ["PATH"]
+        # #4204 bucket E: see NoopBackend.run's matching comment — a direct
+        # exec (no shell) never resets $PWD the way a real shell would, so
+        # the whole parent env's stale value would otherwise leak through
+        # unmodified to a child whose actual cwd is `cwd`.
+        if cwd:
+            env["PWD"] = cwd
 
         # THE shared builder — the same call the landlock_exec shim makes, so the
         # two seams cannot drift apart again (#2980).

--- a/src/reyn/security/sandbox/backends/seatbelt.py
+++ b/src/reyn/security/sandbox/backends/seatbelt.py
@@ -309,6 +309,12 @@ class SeatbeltBackend:
         env = resolve_passthrough_env(policy)
         if "PATH" not in env and "PATH" in os.environ:
             env["PATH"] = os.environ["PATH"]
+        # #4204 bucket E: see NoopBackend.run's matching comment — a direct
+        # exec (no shell) never resets $PWD the way a real shell would, so
+        # the whole parent env's stale value would otherwise leak through
+        # unmodified to a child whose actual cwd is `cwd`.
+        if cwd:
+            env["PWD"] = cwd
 
         loop = asyncio.get_running_loop()
 

--- a/src/reyn/security/sandbox/noop_backend.py
+++ b/src/reyn/security/sandbox/noop_backend.py
@@ -140,6 +140,16 @@ class NoopBackend:
         _warn_once()
 
         env = _build_env(policy)
+        # #4204 bucket E: a real shell resets $PWD to its own cwd at startup;
+        # a direct exec (no shell in between) does not — the whole parent
+        # env passes through (resolve_passthrough_env, #3901 PR-B ④)
+        # unmodified, so a stale $PWD (reyn's own launch directory) would
+        # otherwise reach a child whose ACTUAL cwd is `cwd` (e.g. a
+        # subdirectory-launch's real project root, #4204 condition ①). A
+        # tool that trusts $PWD instead of calling getcwd() would see the
+        # wrong directory with no way to detect it.
+        if cwd:
+            env["PWD"] = cwd
 
         if cancel_event is None:
             # No cancel support: original blocking path (byte-identical).

--- a/tests/security/test_4204_bucket_e_pwd_matches_cwd.py
+++ b/tests/security/test_4204_bucket_e_pwd_matches_cwd.py
@@ -1,0 +1,69 @@
+"""Tier 2: #4204 bucket E — a sandboxed child's $PWD matches its real cwd.
+
+A real shell resets $PWD to its own cwd at startup; a direct exec (no
+shell in between, as every sandbox backend does) does not. The whole
+parent env passes through unmodified (resolve_passthrough_env, #3901
+PR-B ④), so a stale $PWD (reyn's own launch directory) would otherwise
+reach a child whose ACTUAL cwd is the `cwd` param the backend was called
+with (e.g. a subdirectory-launch's real project root, #4204 condition
+①) — a tool that trusts $PWD instead of calling getcwd() sees the wrong
+directory with no way to detect it.
+
+Real subprocess throughout: NoopBackend.run() spawns a REAL python
+interpreter that reads its own os.environ["PWD"] and prints it — the
+only way to observe what a child ACTUALLY receives, not what we intended
+to pass.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from reyn.security.sandbox import SandboxPolicy
+from reyn.security.sandbox.noop_backend import NoopBackend
+
+
+def test_noop_backend_sets_pwd_to_match_the_real_cwd(tmp_path, monkeypatch) -> None:
+    """Tier 2: NoopBackend.run(cwd=X) gives the child env["PWD"] == X, even
+    when the reyn PROCESS's own os.environ["PWD"] (inherited from its
+    launch shell) says something else entirely.
+
+    STRIP-FALSIFY: removing the `env["PWD"] = cwd` line in
+    NoopBackend.run (the pre-#4204 form) makes this go RED — the child
+    would report the STALE parent PWD (or none at all), not tmp_path."""
+    # Simulate reyn's own process having a stale $PWD from its launch shell
+    # (a real, different directory from the sandboxed child's actual cwd).
+    stale_launch_dir = str(tmp_path.parent)
+    monkeypatch.setenv("PWD", stale_launch_dir)
+
+    backend = NoopBackend()
+    result = asyncio.run(
+        backend.run(
+            [sys.executable, "-c", "import os; print(os.environ.get('PWD', ''), end='')"],
+            SandboxPolicy(),
+            cwd=str(tmp_path),
+        )
+    )
+
+    reported_pwd = result.stdout.decode()
+    assert reported_pwd == str(tmp_path)
+    assert reported_pwd != stale_launch_dir
+
+
+def test_noop_backend_omits_pwd_override_when_no_cwd_given(tmp_path, monkeypatch) -> None:
+    """Tier 2: when the caller passes no cwd at all (cwd=None), the child's
+    $PWD is whatever the parent env already carried — no override is
+    invented out of nowhere. Confirms the fix is conditional on cwd being
+    known, not an unconditional PWD stamp."""
+    monkeypatch.setenv("PWD", str(tmp_path))
+
+    backend = NoopBackend()
+    result = asyncio.run(
+        backend.run(
+            [sys.executable, "-c", "import os; print(os.environ.get('PWD', ''), end='')"],
+            SandboxPolicy(),
+            cwd=None,
+        )
+    )
+
+    assert result.stdout.decode() == str(tmp_path)


### PR DESCRIPTION
**[e2e-coder]** — #4204 bucket E: reyn's `src/` tree has zero references to `PWD` anywhere. Every sandbox backend's env passes the whole parent `os.environ` through (`resolve_passthrough_env`, #3901 PR-B ④) — including a stale `$PWD`, since a direct exec (no shell in between, exactly what every backend's `subprocess.Popen(cwd=..., env=...)` is) never resets it the way a real shell does at startup.

## The gap

A sandboxed child's `cwd=` can legitimately differ from reyn's own launch directory (e.g. the real project root vs. a subdirectory launch — this issue's condition ①), while `$PWD` in its env still said the OLD value. A tool inside that child trusting `$PWD` instead of calling `getcwd()` sees the wrong directory with no way to detect the mismatch.

## Fix

All 3 backends (`NoopBackend`, `SeatbeltBackend`, `LandlockBackend`) now set `env["PWD"] = cwd` right after building the passthrough env, whenever a `cwd` was actually given — the same one-line fix in all 3, since all 3 build env identically via the `resolve_passthrough_env` chokepoint (sibling-path sweep, not just the first one found).

## Falsify

Reverted `NoopBackend.run()`'s `env["PWD"] = cwd` line by hand, confirmed the new test goes RED — the spawned child (a **real** python subprocess) reported the stale monkeypatched `$PWD` instead of its actual cwd — while the accept-side sibling test (`cwd=None` → no override invented) stayed green, then restored the fix.

## Scope

This fixes the confirmed, reachable `sandboxed_exec` path (all three backends' `run()` methods). `wrap_command()`'s downstream callers (e.g. MCP stdio launch, which builds its own env separately and controls its own cwd) are a related but distinct call path not addressed here.

This closes #4204's four assigned buckets (B/C/D/E) except **bucket B**, which architect explicitly flagged as needing someone to construct a concrete repro before fixing (a real design question about which root — `project_root` vs `file_zone_root` — a divergent path should resolve against) — reported separately, not silently dropped.

## Verification

Local 5-gate battery all green. New test file: 2 passed (real subprocess throughout, no mocks). Full `tests/security/`: 727 passed, 27 skipped.

## Test plan

- [x] `ruff check src/reyn/security/sandbox/ tests/security/test_4204_bucket_e_pwd_matches_cwd.py`
- [x] `python scripts/test_tier_audit.py --strict tests/security/test_4204_bucket_e_pwd_matches_cwd.py`
- [x] `python scripts/verify_module_docstrings.py` (noop_backend.py, seatbelt.py, landlock.py)
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] new test file (2 passed)
- [x] full `tests/security/` (727 passed, 27 skipped)
- [x] falsify-verified by hand (strip → red; restore → green)
- [x] (skipped — no TUI/visual surface touched)

part of #4204

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
