### PR TITLE
fix(#4097): remove 4 dead F401 imports in src/reyn/tools

### DIFF
--- a/src/reyn/tools/dispatch.py
+++ b/src/reyn/tools/dispatch.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 from reyn.tools.registry import ToolRegistry
-from reyn.tools.types import ToolContext, ToolDefinition, ToolResult
+from reyn.tools.types import ToolContext, ToolResult
 
 
 class ToolNotFound(KeyError):

--- a/src/reyn/tools/mcp.py
+++ b/src/reyn/tools/mcp.py
@@ -636,7 +636,6 @@ async def _handle_describe_mcp_tool(
 # ── ToolDefinitions ───────────────────────────────────────────────────────────
 
 from reyn.core.offload.canonical import (  # noqa: E402
-    CANONICAL_TODO,
     describe_mcp_tool_to_canonical,
     list_mcp_prompts_to_canonical,
     list_mcp_resource_templates_to_canonical,

--- a/src/reyn/tools/plugin_management_verbs.py
+++ b/src/reyn/tools/plugin_management_verbs.py
@@ -89,7 +89,6 @@ async def _handle_plugin_install(
     """Install/promote a plugin. Delegates to op_runtime/plugin_install.handle
     via build_legacy_op_context (same bridge pattern as every other install
     verb)."""
-    from pathlib import Path
 
     from reyn.core.op_runtime.plugin_install import handle as plugin_install_handle
     from reyn.core.op_runtime.plugin_install import plugins_root

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -67,7 +67,7 @@ the membership table and dispatch it through the unified ToolRegistry.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Collection, Final, Mapping
+from typing import TYPE_CHECKING, Any, Final, Mapping
 
 from reyn.tools.descriptions import catalog as _catalog_descriptions
 from reyn.tools.descriptions import discovery


### PR DESCRIPTION
**[tui-coder]** — Pilot directory for the per-directory F401 rollout (#4097), per lead-coder's reconciled direction: 95% of the 450 raw F401 hits are genuinely dead imports → `ruff --fix`, one directory per PR, avoiding `session.py`/`config/*.py` until last (hot files e2e-coder's #4206 T1 may independently touch tonight).

`src/reyn/tools` has 4 hits, all confirmed genuinely dead (none are the `get_type_hints()` forward-ref pattern — that's confined to `src/reyn/config/*.py`, excluded from this rollout, tracked separately for `__all__`/reasoned-noqa treatment).

## Changes
- `ruff check --select F401 --fix src/reyn/tools` — 4 fixes:
  - `dispatch.py`: unused `ToolDefinition` import
  - `mcp.py`: unused `CANONICAL_TODO` import
  - `plugin_management_verbs.py`: unused local `Path` import
  - `universal_catalog.py`: unused `Collection` import

Part of #4097. Gate reactivation (removing `F401` from `pyproject.toml`'s ignore list) happens in a final PR once all directories are clean.

## Test plan
- [x] `ruff check src/reyn/tools` — clean
- [x] `python scripts/mypy_ratchet.py` — no new findings (211/215 baselined, unchanged)
- [x] `python scripts/verify_module_docstrings.py` on the 4 changed files — OK
- [x] `pytest tests/tools -q` — 941 passed
- [x] `pytest tests/mcp -q` — 156 passed
- [x] `pytest tests -k "universal_catalog or plugin_management or dispatch" -q` — 371 passed, 2 skipped (unrelated missing-extra skips, #4104)

🤖 Generated with [Claude Code](https://claude.com/claude-code)