### PR TITLE
fix(#4097): remove 4 dead F401 imports in src/reyn/security

### DIFF
--- a/src/reyn/security/sandbox/backends/seatbelt.py
+++ b/src/reyn/security/sandbox/backends/seatbelt.py
@@ -27,7 +27,6 @@ import shutil
 import signal
 import subprocess
 import tempfile
-from pathlib import Path
 
 from reyn.security.sandbox._subprocess_io import communicate_capped, kill_process_tree
 from reyn.security.sandbox.backend import (

--- a/src/reyn/security/sandbox/noop_backend.py
+++ b/src/reyn/security/sandbox/noop_backend.py
@@ -20,7 +20,6 @@ from ._subprocess_io import communicate_capped, kill_process_tree
 from .backend import (
     AxisEnforcement,
     AxisEnforcementDeclaration,
-    SandboxBackend,
     SandboxResult,
     WrappedCommand,
 )

--- a/src/reyn/security/secrets/oauth.py
+++ b/src/reyn/security/secrets/oauth.py
@@ -494,7 +494,6 @@ async def _post_device_authorization(
     (space-separated). Returns the JSON object including ``device_code``,
     ``user_code``, ``verification_uri``, ``expires_in``, and ``interval``.
     """
-    import httpx
 
     payload: dict[str, str] = {"client_id": provider.client_id}
     if provider.scopes:

--- a/src/reyn/security/secrets/store.py
+++ b/src/reyn/security/secrets/store.py
@@ -8,7 +8,6 @@ The file is always written with chmod 600 after modification.
 """
 from __future__ import annotations
 
-import stat
 from pathlib import Path
 
 from .loader import _default_secrets_path, _parse_dotenv


### PR DESCRIPTION
**[tui-coder]** — Second directory in the per-directory F401 rollout (#4097). Same pattern as #4310.

`src/reyn/security` has 4 hits, all confirmed genuinely dead (none are the config `get_type_hints()` forward-ref pattern, and none touch the sandbox axis-witness gate mechanism `enforcement_self_test` — see CLAUDE.md's 2-layer gate rule, checked explicitly since this directory includes `sandbox/`).

## Changes
- `ruff check --select F401 --fix src/reyn/security` — 4 fixes:
  - `sandbox/backends/seatbelt.py`: unused `pathlib.Path`
  - `sandbox/noop_backend.py`: unused `SandboxBackend` import (grepped — not referenced anywhere else in the file)
  - `secrets/oauth.py`: unused local `import httpx` (the function takes `http_client` as a typed parameter; `httpx` itself unused in the body)
  - `secrets/store.py`: unused `stat` import

Part of #4097.

## Test plan
- [x] `ruff check src/reyn/security` — clean
- [x] `python scripts/mypy_ratchet.py` — no new findings (211/215 baselined, unchanged)
- [x] `python scripts/verify_module_docstrings.py` on the 4 changed files — OK
- [x] `pytest tests/security -q` — 727 passed, 26 skipped (pre-existing platform skips, unrelated)
- [x] `python scripts/sandbox_landlock_deny_gate.py` — unaffected; Linux-only gate correctly refuses on this Darwin host

🤖 Generated with [Claude Code](https://claude.com/claude-code)