### PR TITLE
fix(#4097): remove 5 dead F401 imports in src/reyn/dev

### DIFF
--- a/src/reyn/dev/dogfood/compare.py
+++ b/src/reyn/dev/dogfood/compare.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from reyn.dev.dogfood.runner import RunResult
 
-from reyn.dev.dogfood.runner import OUTCOME_ORDER, _outcome_rank
+from reyn.dev.dogfood.runner import _outcome_rank
 
 # ---------------------------------------------------------------------------
 # Data classes

--- a/src/reyn/dev/dogfood/interpretation.py
+++ b/src/reyn/dev/dogfood/interpretation.py
@@ -28,7 +28,6 @@ so the run never fails on this auxiliary surface.
 """
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING
 
 # reyn.prompt.dogfood (SP prompt-package, Phase 3 §H) — imported and re-bound

--- a/src/reyn/dev/dogfood/runner.py
+++ b/src/reyn/dev/dogfood/runner.py
@@ -21,11 +21,8 @@ without a live LLM. ``--replay`` mode (F5) also populates this seam.
 """
 from __future__ import annotations
 
-import asyncio
 import json
-import math
 import os
-import shutil
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone


### PR DESCRIPTION
**[tui-coder]** — Third directory in the per-directory F401 rollout (#4097). Same pattern as #4310/#4311.

`src/reyn/dev` has 5 hits, all confirmed genuinely dead. Checked per lead-coder's note: no `# noqa: E402`-marked import block was emptied by this change (all 5 are plain top-of-file stdlib/internal imports, not part of a mid-file guarded block).

## Changes
- `ruff check --select F401 --fix src/reyn/dev` — 5 fixes:
  - `dogfood/compare.py`: unused `OUTCOME_ORDER` (sibling `_outcome_rank` on the same import line is used, left in place)
  - `dogfood/interpretation.py`: unused `json`
  - `dogfood/runner.py`: unused `asyncio`, `math`, `shutil`

Part of #4097.

## Test plan
- [x] `ruff check src/reyn/dev` — clean
- [x] `python scripts/mypy_ratchet.py` — no new findings (211/215 baselined, unchanged)
- [x] `python scripts/verify_module_docstrings.py` on the 3 changed files — OK
- [x] `pytest tests/dev -q` — 257 passed, 1 skipped (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)