### PR TITLE
fix(#4097): remove 11 dead F401 imports (typing.Literal) in src/reyn/core

### DIFF
--- a/src/reyn/core/op_runtime/__init__.py
+++ b/src/reyn/core/op_runtime/__init__.py
@@ -12,8 +12,6 @@ is call-site agnostic.
 """
 from __future__ import annotations
 
-from typing import Literal
-
 from reyn.core.events.event_schema import RETIRED_PHASE_FIELD
 from reyn.schemas.models import Op
 

--- a/src/reyn/core/op_runtime/ask_user.py
+++ b/src/reyn/core/op_runtime/ask_user.py
@@ -9,8 +9,6 @@ the handler emits a free-text `UserIntervention` and awaits the answer.
 """
 from __future__ import annotations
 
-from typing import Literal
-
 from reyn.core.events.event_schema import RETIRED_PHASE_FIELD
 from reyn.schemas.models import AskUserIROp
 from reyn.user_intervention import InterventionChoice, UserIntervention

--- a/src/reyn/core/op_runtime/compact.py
+++ b/src/reyn/core/op_runtime/compact.py
@@ -17,8 +17,6 @@ emits its own events).
 """
 from __future__ import annotations
 
-from typing import Literal
-
 from reyn.core.events.event_schema import RETIRED_PHASE_FIELD
 from reyn.schemas.models import CompactIROp
 

--- a/src/reyn/core/op_runtime/file.py
+++ b/src/reyn/core/op_runtime/file.py
@@ -5,7 +5,7 @@ import asyncio
 import re
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 from reyn.builtin.docs import read_builtin_body_bytes
 from reyn.data.text_codec import decode_text_or_none, encode_text

--- a/src/reyn/core/op_runtime/index_drop.py
+++ b/src/reyn/core/op_runtime/index_drop.py
@@ -19,8 +19,6 @@ P6 event: emits `index_dropped` after completion (audit trail).
 """
 from __future__ import annotations
 
-from typing import Literal
-
 from reyn.data.index import SqliteIndexBackend
 from reyn.data.index.source_manifest import get_source_manifest
 from reyn.schemas.models import IndexDropIROp

--- a/src/reyn/core/op_runtime/index_query.py
+++ b/src/reyn/core/op_runtime/index_query.py
@@ -10,7 +10,6 @@ UX gap fix E: SQLite read errors wrapped with actionable hint message.
 from __future__ import annotations
 
 import sqlite3
-from typing import Literal
 
 from reyn.data.index import SqliteIndexBackend
 from reyn.schemas.models import IndexQueryIROp

--- a/src/reyn/core/op_runtime/mcp.py
+++ b/src/reyn/core/op_runtime/mcp.py
@@ -7,8 +7,6 @@ with pre-PR32 reyn.yaml files.
 """
 from __future__ import annotations
 
-from typing import Literal
-
 from reyn.schemas.models import MCPIROp
 
 from . import register

--- a/src/reyn/core/op_runtime/mcp_drop_server.py
+++ b/src/reyn/core/op_runtime/mcp_drop_server.py
@@ -32,7 +32,6 @@ recorded via event (P6), preserving the audit trail.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal
 
 from reyn.schemas.models import MCPDropServerIROp
 

--- a/src/reyn/core/op_runtime/mcp_install.py
+++ b/src/reyn/core/op_runtime/mcp_install.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from reyn.schemas.models import MCPInstallIROp
 

--- a/src/reyn/core/op_runtime/sandboxed_exec.py
+++ b/src/reyn/core/op_runtime/sandboxed_exec.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Literal
 
 from reyn.schemas.models import SandboxedExecIROp
 from reyn.security.sandbox import SandboxPolicy

--- a/src/reyn/core/op_runtime/web.py
+++ b/src/reyn/core/op_runtime/web.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import asyncio
 import html.parser
-from typing import Literal
 
 from reyn._network import build_async_http_client
 from reyn.schemas.models import WebFetchIROp, WebSearchIROp


### PR DESCRIPTION
**[tui-coder]** — Fourth directory in the per-directory F401 rollout (#4097).

`src/reyn/core` has 11 hits, all the identical shape: `from typing import Literal` left over from a past refactor, genuinely unused in all 11 `op_runtime/` handler files (grepped each — no other reference, no string-annotation use, no re-export semantics). Not the config `get_type_hints()` forward-ref pattern (no cross-module dependency here).

Per lead-coder's note on #4310/#4311: checked that no `# noqa: E402`-marked import block was emptied by this change — the (unrelated) `noqa: E402` blocks in `op_runtime/__init__.py` (eager handler-registration imports) are untouched by this diff.

## Changes
- `ruff check --select F401 --fix src/reyn/core` — fixed 10/11 automatically.
- `op_runtime/__init__.py`'s `Literal` isn't ruff-autofixable in an `__init__.py` by default; removed manually after confirming (grep) it carries no `__all__`/re-export semantics either, then re-ran `ruff --fix` for the resulting import-sort (I001) fallout across the touched files.

## Test plan
- [x] `ruff check src/reyn/core` — clean
- [x] `python scripts/mypy_ratchet.py` — no new findings (211/215 baselined, unchanged)
- [x] `python scripts/verify_module_docstrings.py` on all 11 changed files — OK
- [x] `pytest tests/core -q` — 2507 passed, 1 skipped, 4 deselected. The 4 deselected tests (`test_3846_3_textual_image_eager_import_ordering`, `test_3846_image_resolution_e2e`, 2x `test_present_renderer_fp0054_prb`) fail on this dev venv for a pre-existing, unrelated reason — `PIL`/`pillow` isn't installed locally (added as a dependency in #3846③/#4300 but this venv predates that `pip install -e .`). Confirmed by reproducing the identical 4 failures on an **unmodified** checkout via `git stash` before committing — not caused by this diff.

Part of #4097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)