### PR TITLE
fix(#4097): remove 11 dead F401 imports in src/reyn/interfaces

### DIFF
--- a/src/reyn/interfaces/cli/commands/agent.py
+++ b/src/reyn/interfaces/cli/commands/agent.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.profile import AgentProfile
-from reyn.runtime.registry import DEFAULT_AGENT_NAME, AgentRegistry, _validate_agent_name
+from reyn.runtime.registry import DEFAULT_AGENT_NAME, AgentRegistry
 
 
 def register(sub) -> None:

--- a/src/reyn/interfaces/cli/commands/audit.py
+++ b/src/reyn/interfaces/cli/commands/audit.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import stat
 from dataclasses import asdict, dataclass
 from pathlib import Path

--- a/src/reyn/interfaces/cli/commands/cron.py
+++ b/src/reyn/interfaces/cli/commands/cron.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import sys
-from pathlib import Path
 
 
 def register(sub) -> None:
@@ -236,7 +235,7 @@ async def _run_scheduler() -> None:
     # reyn.core.events.asyncio_diagnostics.
     install_asyncio_exception_handler(asyncio.get_running_loop())
 
-    from reyn.runtime.cron import CronJob, CronScheduler
+    from reyn.runtime.cron import CronScheduler
 
     job_configs = _load_jobs()
     jobs = _jobs_to_cron_jobs(job_configs)

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -460,7 +460,6 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
       events are harvested by filesystem scan after the turn, not by
       chain-id filtering.
     """
-    import asyncio
     import shutil
     from dataclasses import replace
     from pathlib import Path
@@ -944,7 +943,6 @@ def run_publish(args: argparse.Namespace) -> None:
     try:
         from reyn.dev.dogfood.publish import (
             _DEFAULT_TEMPLATE_PATH,
-            DEFAULT_CATEGORY_SLUG,
             DEFAULT_REPO,
             PublishConfig,
             detect_repo_from_git,

--- a/src/reyn/interfaces/cli/invocation_context.py
+++ b/src/reyn/interfaces/cli/invocation_context.py
@@ -60,7 +60,6 @@ class InvocationContext:
         safety.timeout fields while preserving everything else from the loaded
         config.
         """
-        from reyn.config import TimeoutConfig
         base = self.config.safety
         llm_timeout = getattr(args, "llm_timeout", None)
         llm_max_retries = getattr(args, "llm_max_retries", None)

--- a/src/reyn/interfaces/slash/__init__.py
+++ b/src/reyn/interfaces/slash/__init__.py
@@ -29,7 +29,7 @@ so registered commands are immediately available everywhere.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterable
 
 if TYPE_CHECKING:

--- a/src/reyn/interfaces/slash/image.py
+++ b/src/reyn/interfaces/slash/image.py
@@ -19,7 +19,6 @@ do not leak into subsequent turns.
 """
 from __future__ import annotations
 
-import base64
 from pathlib import Path
 from typing import TYPE_CHECKING
 

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -28,7 +28,6 @@ footgun where a client kills the server).
 """
 from __future__ import annotations
 
-import asyncio
 from typing import AsyncIterator, Awaitable, Callable
 
 from reyn.interfaces.transport.agui.protocol import (

--- a/src/reyn/interfaces/web/routers/a2a.py
+++ b/src/reyn/interfaces/web/routers/a2a.py
@@ -37,7 +37,6 @@ Spec reference: https://google.github.io/A2A/
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import uuid
 from typing import Any


### PR DESCRIPTION
**[tui-coder]** — Fifth directory in the per-directory F401 rollout (#4097).

`src/reyn/interfaces` has 11 hits, all confirmed genuinely dead. 2 weren't ruff-autofixable (removing one name out of a multi-name import) — fixed manually after confirming the surrounding import's other names stay used and no `noqa` comment was touched:
- `cli/commands/dogfood.py::run_publish`'s `try/except ImportError` block: removed only the unused `DEFAULT_CATEGORY_SLUG`, kept `DEFAULT_REPO`/`PublishConfig`/etc. (all used later in the function) and the guard structure intact.
- `slash/__init__.py`: removed unused `field` from `from dataclasses import dataclass, field`.

## Changes
9/11 auto-fixed via `ruff --select F401 --fix`; the 2 above fixed by hand.

## Test plan
- [x] `ruff check src/reyn/interfaces` — clean
- [x] `python scripts/mypy_ratchet.py` — no new findings (211/215 baselined, unchanged)
- [x] `python scripts/verify_module_docstrings.py` on all 9 changed files — OK
- [x] `pytest tests/interfaces -q` — 1616 passed, 3 skipped (pre-existing)
- [x] `pytest tests/cli -q` — 64 passed

Part of #4097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)