### PR TITLE
fix(#4097): remove 3 dead F401 imports in src/reyn/data

### DIFF
--- a/src/reyn/data/index/coordinator.py
+++ b/src/reyn/data/index/coordinator.py
@@ -87,7 +87,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Mapping
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from reyn.data.index import ChunkRecord, IndexBackend, WriteResult, get_backend
 from reyn.data.index.backend import cache_dir_for_source

--- a/src/reyn/data/index/source_manifest.py
+++ b/src/reyn/data/index/source_manifest.py
@@ -11,7 +11,7 @@ import json
 import os
 import time
 from contextlib import asynccontextmanager
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, AsyncIterator, Literal
 


### PR DESCRIPTION
**[tui-coder]** — Sixth directory in the per-directory F401 rollout (#4097). Small, mechanical, same pattern as prior PRs.

## Changes
- `index/coordinator.py`: unused `typing.Mapping`
- `index/source_manifest.py`: unused `dataclasses.asdict`, `dataclasses.field`

## Test plan
- [x] `ruff check src/reyn/data` — clean
- [x] `python scripts/mypy_ratchet.py` — no new findings
- [x] `pytest tests/data -q` — 174 passed

Part of #4097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)