### PR TITLE
fix(#4097): remove 2 dead F401 imports in src/reyn/schemas

### DIFF
--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Annotated, Any, Literal, Union
 
-from pydantic import BaseModel, Field, model_serializer, model_validator
-
-from reyn.security.permissions.permissions import PermissionDecl
+from pydantic import BaseModel, Field, model_validator
 
 
 class FileIROp(BaseModel):


### PR DESCRIPTION
**[tui-coder]** — Seventh directory in the per-directory F401 rollout (#4097).

`schemas/models.py` hosts `OP_KIND_MODEL_MAP` (the doc-sync target CLAUDE.md names for `control-ir.md`) — confirmed this diff doesn't touch that map or any op-kind entry, pure unused-import removal.

## Changes
- `models.py`: unused `pydantic.model_serializer`, unused `PermissionDecl`

## Test plan
- [x] `ruff check src/reyn/schemas` — clean
- [x] `python scripts/mypy_ratchet.py` — no new findings
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] `pytest tests/runtime tests/observability -q` — 1695 passed, 1 skipped, 1 pre-existing failure (`test_session_pure_extraction_3679_s1.py`, `ModuleNotFoundError: reyn.runtime.session_pure`) — confirmed identical on an unmodified `origin/main` checkout via `git stash` before committing, unrelated to this diff.

Part of #4097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)