### PR TITLE
feat(#4206 T1): model-class ceiling — ②bounding axis, the model key

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -406,6 +406,27 @@ configurable here but never tracked a `/model` switch mid-session, so it always
 follows the conversation's active model now, and a config that still sets this
 key is refused with a remedy rather than silently ignored.
 
+### `llm.model_max_class` — model-class ceiling (#4206 T1)
+
+`model_max_class` declares an operator ceiling on the model class any call may
+use (`light` / `standard` / `strong`, the same cost order every tier list
+uses). It is **restrict-only, reject-not-clamp** — the same shape as
+`sandbox.max_timeout_seconds`'s LLM-extensible ceiling: a call whose resolved
+class exceeds the ceiling is REJECTED, naming the actual ceiling, before
+`litellm.acompletion` is ever invoked — never silently downgraded to a
+cheaper class.
+
+```yaml
+llm:
+  model: standard
+  model_max_class: standard    # a call resolving to "strong" is rejected
+```
+
+Unset (default) means unbounded — byte-identical to every deployment before
+this field existed. Enforcement happens once, inside `recorded_acompletion`
+(the single #1190 cost-observability chokepoint every LLM call passes
+through) — a new call site cannot forget to apply it.
+
 ## `llm` block
 
 LLM-layer config: **`llm.router`** (opt-in litellm.Router) and

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -127,6 +127,13 @@
 # (#3785) — compaction always follows the conversation's active model; a
 # config that still sets it fails to load.
 #
+# llm.model_max_class: operator-declared CEILING (#4206 T1) on the model
+# class any call may use (light/standard/strong, same order every tier list
+# uses) — restrict-only, reject-not-clamp (same shape as
+# `sandbox.max_timeout_seconds`'s LLM-extensible ceiling). Unset (default) =
+# unbounded. A call whose resolved class exceeds this is REJECTED before
+# litellm is ever touched, naming the actual ceiling in the error.
+#
 # llm.router: litellm.Router provider-resilience (#1829). DEFAULT OFF
 # (use=false → direct litellm.acompletion, byte-identical to no-Router).
 # When on, the Router owns infra-exception retry (with native Retry-After
@@ -163,6 +170,7 @@
 #   model_class_by_purpose:
 #     router: light            # cheaper per-turn router (explicit opt-in)
 #     # control_ir / tool / judge unset → follow `model`
+#   model_max_class: standard  # ceiling — a call resolving to "strong" is rejected
 #   router:
 #     use: false             # master switch (REYN_LLM_USE_ROUTER fallback)
 #     num_retries: 3         # infra-exception retries (Retry-After aware)

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -195,6 +195,16 @@ class LLMConfig:
     # #1672 per-purpose model-class override (router / control_ir / tool / judge).
     # Unset purpose -> `model` (see MODEL_CLASS_PURPOSES / ReynConfig.model_class_for).
     model_class_by_purpose: dict[str, str] = field(default_factory=dict)
+    # #4206 T1 (②bounding, ``model`` key): operator-declared CEILING on the
+    # model class a call may use — restrict-only, reject-not-clamp (same
+    # shape as #3903①'s ``SandboxPolicy.max_timeout_seconds``). ``None``
+    # (default) means unbounded, byte-identical to before this field existed.
+    # Enforced at ``recorded_acompletion`` (#1190 chokepoint), never at a
+    # call site, so a future call site cannot forget it.
+    model_max_class: "str | None" = field(
+        default=None,
+        metadata={"desc": "Ceiling on the model class calls may use (light/standard/strong). Unset = unbounded."},
+    )
     # LiteLLM proxy: non-secret base URL only. API keys must be env vars
     # (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) — never stored in config files.
     api_base: str = field(
@@ -254,6 +264,25 @@ def _build_model_class_by_purpose(raw: object) -> dict[str, str]:
             )
         out[key] = str(v)
     return out
+
+
+def _build_model_max_class(raw: object) -> "str | None":
+    """#4206 T1: parse ``llm.model_max_class`` — a ceiling, so (unlike
+    ``model_class_by_purpose``'s per-key warn-only tolerance) an unrecognized
+    value is a hard fail-fast, not a silent pass-through: a ceiling that
+    silently doesn't apply is a widened bound, not a typo you can shrug off.
+    """
+    if raw is None:
+        return None
+    from reyn.llm.model_resolver import STANDARD_CLASSES
+
+    value = str(raw)
+    if value not in STANDARD_CLASSES:
+        raise ValueError(
+            f"llm.model_max_class must be one of {list(STANDARD_CLASSES)}, "
+            f"got {value!r}"
+        )
+    return value
 
 
 def _build_retry_config(raw: object) -> RetryConfig:
@@ -350,6 +379,7 @@ def _build_llm_config(raw: object) -> LLMConfig:
         model_class_by_purpose=_build_model_class_by_purpose(
             raw.get("model_class_by_purpose"),
         ),
+        model_max_class=_build_model_max_class(raw.get("model_max_class")),
         api_base=str(raw.get("api_base") or ""),
         prompt_cache_enabled=bool(raw.get("prompt_cache_enabled", True)),
     )

--- a/src/reyn/dev/dogfood/interpretation.py
+++ b/src/reyn/dev/dogfood/interpretation.py
@@ -140,6 +140,10 @@ async def generate_interpretation(
             model=model,
             messages=messages,
             purpose="dogfood",
+            # #4206 T1: caller passes a raw model string, not a
+            # class_for_purpose-resolved class — not subject to the
+            # ②bounding model-class ceiling axis.
+            model_class=None,
             recorder=None,
             extra_kwargs={"timeout": timeout, "num_retries": 1},
         )

--- a/src/reyn/dev/dogfood/verifiers/reply.py
+++ b/src/reyn/dev/dogfood/verifiers/reply.py
@@ -56,6 +56,10 @@ async def _default_judge_fn(rubric: list[str], reply_text: str) -> dict:
         model="gemini-2.5-flash-lite",
         messages=messages,
         purpose="dogfood",
+        # #4206 T1: a fixed literal model string, never resolved via
+        # class_for_purpose — not subject to the ②bounding model-class
+        # ceiling axis.
+        model_class=None,
         recorder=None,
         response_format={"type": "json_object"},
         fallback_without_response_format=True,

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -490,6 +490,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
         config.llm.models,
         default_class=config.llm.model,
         purpose_classes=config.llm.model_class_by_purpose,
+        model_max_class=config.llm.model_max_class,  # #4206 T1 (②bounding)
     )
     model = config.llm.model
     output_language = config.output_language

--- a/src/reyn/interfaces/cli/invocation_context.py
+++ b/src/reyn/interfaces/cli/invocation_context.py
@@ -30,6 +30,7 @@ class InvocationContext:
             config.llm.models,
             default_class=config.llm.model,
             purpose_classes=config.llm.model_class_by_purpose,
+            model_max_class=config.llm.model_max_class,  # #4206 T1 (②bounding)
         ))
 
     # ── argparse-aware setting resolution (CLI > config) ─────────────────────

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -314,6 +314,7 @@ def _get_registry():
             config.llm.models,
             default_class=config.llm.model,
             purpose_classes=config.llm.model_class_by_purpose,
+            model_max_class=config.llm.model_max_class,  # #4206 T1 (②bounding)
         )
         model = config.llm.model
         output_language = config.output_language

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1993,6 +1993,8 @@ async def recorded_acompletion(
     model: str,
     messages: list,
     purpose: str,
+    model_class: "str | None",
+    model_class_ceiling: "str | None" = None,
     recorder: object | None = None,
     agent: str | None = None,
     response_format: dict | None = None,
@@ -2018,6 +2020,27 @@ async def recorded_acompletion(
     Replay-safe: the call still bottoms out at ``litellm.acompletion``, which
     ``LLMReplay`` monkeypatches.
 
+    ``model_class`` / ``model_class_ceiling`` (#4206 T1 — ②bounding axis,
+    ``model``): REQUIRED (no default) so a caller must explicitly say
+    whether THIS call is subject to class-based ceiling enforcement —
+    ``model_class=None`` opts a call OUT (e.g. compaction, which follows
+    ``Session.model`` directly and never goes through ``class_for_purpose``,
+    #3785; or the dogfood/eval auxiliary surfaces, which use a fixed literal
+    model string, not a class). A caller that forgets to pass it gets a
+    ``TypeError`` at the call site, not a silently-unenforced bound — the
+    same "no default that means the same thing as forgetting" discipline
+    #4271 applied to ``timeout``. The check runs HERE, inside the #1190
+    chokepoint, deliberately — not at each call site — so a NEW call site
+    added later cannot forget to enforce it (#3903①'s
+    reject-not-clamp shape, moved to the one place enforcement cannot be
+    bypassed by construction, not by convention). ``model_class_ceiling``
+    defaults to ``None`` (unbounded) — the compat default every other
+    bounding axis in reyn uses; a caller only supplies a real ceiling when
+    one is actually configured. When ``model_class`` is over ceiling, this
+    function raises :class:`~reyn.llm.model_resolver.
+    ModelClassExceedsCeilingError` BEFORE ``litellm.acompletion`` is ever
+    called — no partial call, no charge, no record.
+
     ``on_content_delta`` (#3288 ③b): an OPT-IN, per-call callback invoked
     SYNCHRONOUSLY with each non-empty content-delta string as ``_stream_and_reconstruct``
     (③a) drains the chunk stream — never invoked on the whole-collect (non-streaming)
@@ -2029,6 +2052,18 @@ async def recorded_acompletion(
     unaffected either way — this is purely an additional notification channel, not a
     change to what this function returns or records.
     """
+    # #4206 T1: enforce BEFORE anything else — before ensure_litellm_ready(),
+    # before litellm is even imported, so a rejected call touches litellm in
+    # NO way (falsify target: litellm.acompletion is provably never invoked).
+    if model_class is not None and model_class_ceiling is not None:
+        from reyn.llm.model_resolver import (
+            ModelClassExceedsCeilingError,
+            model_class_exceeds_ceiling,
+        )
+
+        if model_class_exceeds_ceiling(model_class, model_class_ceiling):
+            raise ModelClassExceedsCeilingError(model_class, model_class_ceiling, purpose)
+
     # perf: litellm's own import is ~1.5s and is kept off the chat startup
     # path (input box renders before any LLM use). ``ensure_litellm_ready``
     # is the single chokepoint that applies the #2929 console-log routing +
@@ -2501,6 +2536,8 @@ async def call_llm_tools(
     emit_cost_events: bool = False,  # #1683: forwarded to recorded_acompletion (chat opts in)
     response_format: "dict | None" = None,  # 0062: RouterLoop's separate no-tools structured-answer turn ONLY — every op-loop tool-decision call leaves this None (ADR-0035 D2 separate-decide preserved: never combined with a non-empty `tools`)
     on_content_delta: "Callable[[str], None] | None" = None,  # #3288 ③b: forwarded to recorded_acompletion — see its docstring
+    model_class: "str | None" = None,  # #4206 T1: forwarded to recorded_acompletion — see its docstring (None = not subject to ceiling enforcement)
+    model_class_ceiling: "str | None" = None,  # #4206 T1: the caller's effective ceiling, if any (None = unbounded)
 ) -> LLMToolCallResult:
     """Tool-use variant of call_llm. Returns raw assistant message.
 
@@ -2527,6 +2564,14 @@ async def call_llm_tools(
     ``on_content_delta`` (#3288 ③b): forwarded verbatim to ``recorded_acompletion``
     — see its docstring. ``None`` (every call site except ``RouterLoop``'s
     primary reply call) is byte-identical to before ③b.
+
+    ``model_class`` / ``model_class_ceiling`` (#4206 T1): forwarded verbatim to
+    ``recorded_acompletion`` — see its docstring for the ②bounding enforcement
+    contract. Defaulted to ``None`` here (unlike ``recorded_acompletion``'s own
+    required param) because this wrapper has many pre-existing non-RouterLoop
+    callers (tests, other op-loop shapes) that are not subject to the ceiling
+    axis at all; ``RouterLoop`` — the one caller whose calls ARE class-based —
+    passes its resolved ``router_model`` class explicitly at every call site.
     """
     # Normalize model to ModelSpec — accept both str (backward compat) and ModelSpec.
     spec: ModelSpec = model if isinstance(model, ModelSpec) else ModelSpec(model=model, kwargs={})
@@ -2684,6 +2729,8 @@ async def call_llm_tools(
             response_format=response_format,  # 0062: None for every op-loop tool call
             on_content_delta=on_content_delta,  # #3288 ③b: forwarded straight through
             stream_override=spec.stream,  # operator policy from the model class
+            model_class=model_class,  # #4206 T1: forwarded straight through
+            model_class_ceiling=model_class_ceiling,  # #4206 T1: forwarded straight through
         )
 
     # #2210 HIGH layer: when the per-call HTTP timeout + the Router/Reyn retries are ALL

--- a/src/reyn/llm/model_resolver.py
+++ b/src/reyn/llm/model_resolver.py
@@ -48,6 +48,17 @@ def model_class_exceeds_ceiling(class_name: str, ceiling: "str | None") -> bool:
     a ceiling to also constrain custom class names would need a richer
     per-class cost declaration — out of #4206 T1's scope (one axis: the 3
     standard tiers).
+
+    Scope limit (#4324, part of #4206): this axis only ever sees a class
+    when the CALLER resolved one via ``class_for_purpose``/``model_class``.
+    A caller that received an explicit raw model string (e.g.
+    ``--router-model openai/gpt-4o`` bypassing class resolution entirely)
+    has nothing to compare — the ceiling is a silent no-op for that call, by
+    construction, not a bug in this predicate. Likewise a call that declared
+    ``model_class=None`` (dogfood's real-cost calls included, not just
+    compaction) is permanently outside the axis. "a ceiling is configured"
+    does NOT mean "every LLM spend is bounded" — only class-resolved calls
+    are.
     """
     if ceiling is None:
         return False

--- a/src/reyn/llm/model_resolver.py
+++ b/src/reyn/llm/model_resolver.py
@@ -31,6 +31,31 @@ from reyn.llm.builtin_models import BUILTIN_MODELS, BUILTIN_TIER_ALIASES
 #: drift shape that bit #3363's key sweep.
 STANDARD_CLASSES = tuple(BUILTIN_TIER_ALIASES)
 
+
+def model_class_exceeds_ceiling(class_name: str, ceiling: "str | None") -> bool:
+    """#4206 T1 (②bounding): True iff *class_name* is strictly MORE expensive
+    than *ceiling*, per ``STANDARD_CLASSES``'s own cost order (light <
+    standard < strong — the same order ``BUILTIN_TIER_ALIASES``, its single
+    producer, already declares its keys in).
+
+    ``ceiling=None`` means no ceiling is configured (the compat default —
+    every other bounding axis in reyn defaults to unbounded) -> always
+    False, never a violation. A *class_name* or *ceiling* that is not one
+    of the three known tiers (e.g. a raw ``provider/model`` string, or a
+    project-declared custom class name outside light/standard/strong) is
+    NOT comparable on this axis -> also False: this predicate can only
+    judge violations it can actually order, never guess. Callers that need
+    a ceiling to also constrain custom class names would need a richer
+    per-class cost declaration — out of #4206 T1's scope (one axis: the 3
+    standard tiers).
+    """
+    if ceiling is None:
+        return False
+    if class_name not in STANDARD_CLASSES or ceiling not in STANDARD_CLASSES:
+        return False
+    return STANDARD_CLASSES.index(class_name) > STANDARD_CLASSES.index(ceiling)
+
+
 #: #1650: valid values for the per-model ``reasoning_effort`` field. These are
 #: litellm's accepted reasoning-effort levels for the gemini provider, each of
 #: which maps to a native thinking budget (low→1024, medium→2048, high→4096,
@@ -239,6 +264,26 @@ def _deep_merge(base: dict, override: dict) -> dict:
     return result
 
 
+class ModelClassExceedsCeilingError(ValueError):
+    """#4206 T1: raised by :func:`reyn.llm.llm.recorded_acompletion` when a
+    call's declared ``model_class`` exceeds the caller's effective
+    ``model_class_ceiling`` (##bounding axis — restrict-only, reject-not-
+    clamp, same shape as #3903①'s ``timeout_seconds`` ceiling). Carries the
+    actual ceiling so the caller can build a legible error naming it,
+    mirroring #3903①'s "reject with the real max named" contract rather
+    than a bare denial."""
+
+    def __init__(self, requested: str, ceiling: str, purpose: str) -> None:
+        self.requested = requested
+        self.ceiling = ceiling
+        self.purpose = purpose
+        super().__init__(
+            f"model class {requested!r} (purpose={purpose!r}) exceeds this "
+            f"session's configured ceiling of {ceiling!r}. Use {ceiling!r} "
+            f"or a cheaper class, or ask the operator to raise the ceiling."
+        )
+
+
 def model_family(model: str) -> str:
     """#1791 A2: coarse model-family classifier for SP gating (the SINGLE place
     family is classified — do NOT scatter ``"gemini" in x`` across SP builders).
@@ -296,6 +341,7 @@ class ModelResolver:
         builtin: dict[str, str | dict] | None = None,
         default_class: str = "standard",
         purpose_classes: dict[str, str] | None = None,
+        model_max_class: "str | None" = None,
     ) -> None:
         """Build a ModelResolver.
 
@@ -315,7 +361,14 @@ class ModelResolver:
                       from top-level ``.model_class_by_purpose``). A purpose
                       present here wins over ``default_class`` in
                       ``class_for_purpose``.
+            model_max_class: #4206 T1 (②bounding, ``model`` key) — the
+                      project-declared ceiling (``ReynConfig.llm.model_max_class``).
+                      ``None`` (default) means unbounded, byte-identical to
+                      before this field existed. Exposed via ``class_ceiling()``;
+                      enforcement itself happens at ``recorded_acompletion``, not
+                      here — this class only carries the configured value.
         """
+        self._model_max_class = model_max_class
         if builtin is None:
             builtin = BUILTIN_MODELS
 
@@ -447,6 +500,15 @@ class ModelResolver:
                 name, ", ".join(sorted(self._resolved)) or "none",
             )
         return ModelSpec(model=name, kwargs={})
+
+    def class_ceiling(self) -> "str | None":
+        """#4206 T1: the project-declared ``model_max_class`` ceiling, or
+        ``None`` when unbounded. Read by a caller (RouterLoop) that already
+        knows the resolved class it's about to use, and passes both to
+        ``recorded_acompletion`` for enforcement — this accessor does not
+        itself enforce anything.
+        """
+        return self._model_max_class
 
     def class_for_purpose(self, purpose: str) -> str:
         """#1672: the model CLASS for a logical call *purpose* (router / control_ir

--- a/src/reyn/runtime/registry_bootstrap.py
+++ b/src/reyn/runtime/registry_bootstrap.py
@@ -172,6 +172,7 @@ def build_agent_registry_from_project(
         config.llm.models,
         default_class=config.llm.model,
         purpose_classes=config.llm.model_class_by_purpose,
+        model_max_class=config.llm.model_max_class,  # #4206 T1 (②bounding)
     )
     factory_config = SessionFactoryConfig.from_config(config, project_root)
     ws_base_dir = project_root

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1077,8 +1077,19 @@ class RouterLoop:
         # config-aware ModelResolver. Explicit router_model still wins, so the
         # chat router follows config from this single resolution point.
         from reyn.llm.model_resolver import resolve_purpose_class
+        _resolver = getattr(host, "resolver", None)
         self.router_model = resolve_purpose_class(
-            router_model, getattr(host, "resolver", None), "router",
+            router_model, _resolver, "router",
+        )
+        # #4206 T1 (②bounding): the project-declared ceiling, if any — read
+        # once here (not re-fetched per call) since the resolver is
+        # process-wide and its ceiling doesn't change mid-session. A host
+        # whose resolver has no ``class_ceiling`` (a test double / stub) is
+        # unbounded, same as today.
+        self._model_class_ceiling = (
+            _resolver.class_ceiling()
+            if _resolver is not None and hasattr(_resolver, "class_ceiling")
+            else None
         )
         self.budget = budget
         # When set, RouterLoop skips ``build_system_prompt(host=...)`` and uses
@@ -2052,6 +2063,11 @@ class RouterLoop:
                         # (③a's capability gate decides whether this ever fires —
                         # a non-streaming call never invokes it).
                         on_content_delta=self._emit_agent_delta,
+                        # #4206 T1 (②bounding): this call resolved its model
+                        # class via ``class_for_purpose`` (self.router_model)
+                        # — subject to the ceiling.
+                        model_class=self.router_model,
+                        model_class_ceiling=self._model_class_ceiling,
                     )
                 # Record the fresh result for future resume hit. Defensive:
                 # never let recording failure break the loop. NOT for a
@@ -2737,6 +2753,10 @@ class RouterLoop:
                     trace_caller="router_structured_output",
                     emit_cost_events=True,
                     response_format=self._response_format,
+                    # #4206 T1 (②bounding): same router-purpose class as the
+                    # main tool-turn call.
+                    model_class=self.router_model,
+                    model_class_ceiling=self._model_class_ceiling,
                 )
             except Exception as exc:
                 if attempt == 0:
@@ -2820,6 +2840,10 @@ class RouterLoop:
             trace_caller="router_force_close",
             # #1683: chat path emits cost events for the TUI cost tab.
             emit_cost_events=True,
+            # #4206 T1 (②bounding): the wrap-up call still resolves the
+            # router-purpose class — same ceiling applies.
+            model_class=self.router_model,
+            model_class_ceiling=self._model_class_ceiling,
         )
 
     async def _force_close_call_with_retry(

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1083,13 +1083,15 @@ class RouterLoop:
         )
         # #4206 T1 (②bounding): the project-declared ceiling, if any — read
         # once here (not re-fetched per call) since the resolver is
-        # process-wide and its ceiling doesn't change mid-session. A host
-        # whose resolver has no ``class_ceiling`` (a test double / stub) is
-        # unbounded, same as today.
+        # process-wide and its ceiling doesn't change mid-session. No
+        # ``hasattr`` fallback here (unlike ``resolve_purpose_class`` above):
+        # that fallback's failure direction is a harmless value default
+        # ("standard"); this one's is a WIDENING one — a resolver that can't
+        # answer ``class_ceiling()`` would silently make the ceiling
+        # disappear. A host whose ``resolver`` is not a real ``ModelResolver``
+        # should raise (fail loud), not go unbounded (lead-coder review, #4318).
         self._model_class_ceiling = (
-            _resolver.class_ceiling()
-            if _resolver is not None and hasattr(_resolver, "class_ceiling")
-            else None
+            _resolver.class_ceiling() if _resolver is not None else None
         )
         self.budget = budget
         # When set, RouterLoop skips ``build_system_prompt(host=...)`` and uses

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -1118,6 +1118,10 @@ class CompactionEngine:
             model=self._model,
             messages=messages,
             purpose="compaction",
+            # #4206 T1 / #3785: compaction always follows Session.model
+            # directly, never class_for_purpose — not subject to the
+            # ②bounding model-class ceiling axis.
+            model_class=None,
             recorder=self._recorder,
             agent=self._recorder_agent,
             response_format=response_format,

--- a/tests/core/test_cost_chokepoint_1190.py
+++ b/tests/core/test_cost_chokepoint_1190.py
@@ -53,6 +53,7 @@ def test_recorded_acompletion_records_with_purpose(monkeypatch) -> None:
     resp = asyncio.run(recorded_acompletion(
         model="gemini/gemini-2.5-flash-lite", messages=[{"role": "user", "content": "hi"}],
         purpose="compaction", recorder=rec, agent="a1",
+        model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
     ))
     assert resp.choices[0].message.content == "ok", "returns the RAW litellm response"
     # one record, tagged compaction (behavioral — the recorded purpose sequence).
@@ -76,6 +77,7 @@ def test_recorded_acompletion_no_record_when_recorder_none(monkeypatch) -> None:
     resp = asyncio.run(recorded_acompletion(
         model="m", messages=[{"role": "user", "content": "x"}],
         purpose="dogfood", recorder=None,
+        model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
     ))
     assert called["n"] == 1 and resp.choices[0].message.content == "ok"
 
@@ -96,6 +98,7 @@ def test_recorded_acompletion_response_format_fallback(monkeypatch) -> None:
     rec = _Recorder()
     asyncio.run(recorded_acompletion(
         model="m", messages=[{"role": "user", "content": "x"}], purpose="judge",
+        model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
         recorder=rec, response_format={"type": "json_object"},
         fallback_without_response_format=True,
     ))
@@ -156,6 +159,7 @@ def test_recorded_acompletion_rejects_unknown_purpose() -> None:
         asyncio.run(recorded_acompletion(
             model="m", messages=[{"role": "user", "content": "x"}],
             purpose="compcation",  # typo of "compaction"
+            model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
             recorder=None,
         ))
     # every advertised purpose is accepted (guards against the list drifting out

--- a/tests/core/test_llm_request_error_1676.py
+++ b/tests/core/test_llm_request_error_1676.py
@@ -53,6 +53,7 @@ def _call(monkeypatch, **extra_kwargs):
             model="gpt-5.4",
             messages=[{"role": "user", "content": "hi"}],
             purpose="main",
+            model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
             recorder=None,
             extra_kwargs=extra_kwargs,
         )

--- a/tests/core/test_llm_request_event_1669.py
+++ b/tests/core/test_llm_request_event_1669.py
@@ -57,6 +57,7 @@ def _call(monkeypatch, **extra_kwargs):
             model="gpt-5.4",
             messages=[{"role": "user", "content": "secret message body"}],
             purpose="main",
+            model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
             recorder=None,
             response_format={"type": "json_object"},
             extra_kwargs=extra_kwargs,

--- a/tests/core/test_responses_api_routing_1678.py
+++ b/tests/core/test_responses_api_routing_1678.py
@@ -89,6 +89,7 @@ def test_openai_reasoning_combo_model_passed_through_unchanged(monkeypatch) -> N
     asyncio.run(recorded_acompletion(
         model="openai/gpt-5.4", messages=[{"role": "user", "content": "hi"}],
         purpose="main", recorder=None,
+        model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
         extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
     ))
     assert captured["model"] == "openai/gpt-5.4"
@@ -108,6 +109,7 @@ def test_gemini_combo_model_passed_through_unchanged(monkeypatch) -> None:
     asyncio.run(recorded_acompletion(
         model="gemini/gemini-2.5-flash-lite", messages=[{"role": "user", "content": "hi"}],
         purpose="main", recorder=None,
+        model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
         extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
     ))
     assert captured["model"] == "gemini/gemini-2.5-flash-lite"
@@ -178,6 +180,7 @@ def test_openai_shaped_405_raises_decision_enabling_error(monkeypatch) -> None:
         asyncio.run(recorded_acompletion(
             model="openai/gpt-5.4", messages=[{"role": "user", "content": "hi"}],
             purpose="main", recorder=None,
+            model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
             extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
         ))
     msg = str(ei.value).lower()
@@ -208,6 +211,7 @@ def test_gemini_shaped_405_is_not_wrapped_since_provider_unbridgeable(monkeypatc
         asyncio.run(recorded_acompletion(
             model="gemini/gemini-2.5-flash-lite", messages=[{"role": "user", "content": "hi"}],
             purpose="main", recorder=None,
+            model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
             extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
         ))
 
@@ -224,6 +228,7 @@ def test_405_without_tools_or_reasoning_effort_not_wrapped(monkeypatch) -> None:
         asyncio.run(recorded_acompletion(
             model="openai/gpt-5.4", messages=[{"role": "user", "content": "hi"}],
             purpose="main", recorder=None,
+            model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
             extra_kwargs={"reasoning_effort": "low"},  # no tools
         ))
 
@@ -243,6 +248,7 @@ def test_405_still_captures_raw_via_1676(monkeypatch) -> None:
         asyncio.run(recorded_acompletion(
             model="openai/gpt-5.4", messages=[{"role": "user", "content": "hi"}],
             purpose="main", recorder=None,
+            model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
             extra_kwargs={"tools": [{"type": "function"}], "reasoning_effort": "low"},
         ))
     (err,) = [e for e in collected if e.type == "llm_request_error"]

--- a/tests/core/test_usage_provenance_3351.py
+++ b/tests/core/test_usage_provenance_3351.py
@@ -95,6 +95,7 @@ def _run_turn(tracker: BudgetTracker, chain_id: str) -> Any:
     with active_turn(chain_id):
         return asyncio.run(recorded_acompletion(
             model=_MODEL, messages=_MESSAGES, purpose="main",
+            model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
             recorder=tracker, agent="alpha", emit_cost_events=True,
         ))
 
@@ -292,6 +293,7 @@ def test_a_non_streamed_call_records_the_provider_as_the_origin(monkeypatch, tmp
     with active_turn("turn-whole"):
         asyncio.run(recorded_acompletion(
             model="o1-pro", messages=_MESSAGES, purpose="main",
+            model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
             recorder=tracker, agent="alpha",
         ))
 

--- a/tests/dev/test_llm_streaming_equivalence_3288.py
+++ b/tests/dev/test_llm_streaming_equivalence_3288.py
@@ -138,6 +138,7 @@ def test_stream_equals_whole_result(monkeypatch) -> None:
     streamed = asyncio.run(recorded_acompletion(
         model="gpt-4o-mini", messages=[{"role": "user", "content": "weather?"}],
         purpose="main", recorder=None, extra_kwargs={"tools": _TOOLS},
+        model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
     ))
     # Witness: the streaming reconstruction loop actually pulled all 5
     # scripted chunks off the async generator — proves this exercised the
@@ -155,6 +156,7 @@ def test_stream_equals_whole_result(monkeypatch) -> None:
     whole = asyncio.run(recorded_acompletion(
         model="o1-pro", messages=[{"role": "user", "content": "weather?"}],
         purpose="main", recorder=None, extra_kwargs={"tools": _TOOLS},
+        model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
     ))
 
     s_msg = streamed.choices[0].message
@@ -199,6 +201,7 @@ def test_stream_path_actually_used_for_capable_model(monkeypatch) -> None:
     asyncio.run(recorded_acompletion(
         model="gpt-4o-mini", messages=[{"role": "user", "content": "weather?"}],
         purpose="main", recorder=None, extra_kwargs={"tools": _TOOLS},
+        model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
     ))
     assert seen == [True], "capable model + tools must select the streaming branch"
     assert chunk_witness == [1, 1, 1, 1, 1], (

--- a/tests/llm/test_cache_token_capture_1772.py
+++ b/tests/llm/test_cache_token_capture_1772.py
@@ -134,6 +134,7 @@ def test_cost_event_carries_flat_cache_tokens(monkeypatch, _reset_event_log) -> 
         model="openai/gpt-4o",
         messages=[{"role": "user", "content": "hi"}],
         purpose="main",
+        model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
         recorder=None,
         emit_cost_events=True,
     ))

--- a/tests/llm/test_llm_router_s3b_1829.py
+++ b/tests/llm/test_llm_router_s3b_1829.py
@@ -182,6 +182,7 @@ async def test_cost_records_actual_model_on_fallback() -> None:
         await recorded_acompletion(
             model=_PRIMARY, messages=[{"role": "user", "content": "x"}],
             purpose="dogfood", recorder=tracker,
+            model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
         )
     assert [m.rsplit("/", 1)[-1] for m in _recorded_models(tracker)] == [
         _FALLBACK.rsplit("/", 1)[-1]
@@ -244,6 +245,7 @@ async def test_fallback_declared_under_the_prefixed_class_name_still_resolves_un
         await recorded_acompletion(
             model=_PRIMARY, messages=[{"role": "user", "content": "x"}],
             purpose="dogfood", recorder=tracker,
+            model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
         )
     assert _recorded_models(tracker) == [bare_fallback], (
         "a fallback declared under the operator's prefixed class-name spelling "
@@ -277,6 +279,7 @@ async def test_cost_records_requested_model_when_router_off() -> None:
         await recorded_acompletion(
             model=_PRIMARY, messages=[{"role": "user", "content": "x"}],
             purpose="dogfood", recorder=tracker,
+            model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
         )
     recorded = _recorded_models(tracker)
     assert [m.rsplit("/", 1)[-1] for m in recorded] == [_PRIMARY.rsplit("/", 1)[-1]], (

--- a/tests/llm/test_llm_streaming_delta_emission_3288.py
+++ b/tests/llm/test_llm_streaming_delta_emission_3288.py
@@ -83,6 +83,7 @@ def test_on_content_delta_fires_per_real_content_chunk(monkeypatch) -> None:
     result = asyncio.run(recorded_acompletion(
         model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}],
         purpose="main", recorder=None,
+        model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
         on_content_delta=deltas.append,
     ))
 
@@ -113,6 +114,7 @@ def test_on_content_delta_never_fires_on_the_whole_collect_path(monkeypatch) -> 
         # ③a's own equivalence test uses for the whole-collect branch.
         model="o1-pro", messages=[{"role": "user", "content": "hi"}],
         purpose="main", recorder=None,
+        model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
         on_content_delta=deltas.append,
     ))
 
@@ -138,6 +140,7 @@ def test_failing_on_content_delta_does_not_break_the_call(monkeypatch) -> None:
     result = asyncio.run(recorded_acompletion(
         model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}],
         purpose="main", recorder=None,
+        model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
         on_content_delta=_boom,
     ))
 
@@ -230,6 +233,7 @@ def test_silent_zero_delta_stream_logs_once_per_stream(monkeypatch, caplog) -> N
         result = asyncio.run(recorded_acompletion(
             model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}],
             purpose="main", recorder=None,
+            model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
             on_content_delta=deltas.append,
         ))
 
@@ -279,6 +283,7 @@ def test_default_shaped_gemini_call_actually_enters_the_streaming_branch(monkeyp
     result = asyncio.run(recorded_acompletion(
         model="gemini/gemini-2.5-flash-lite", messages=[{"role": "user", "content": "hi"}],
         purpose="main", recorder=None,
+        model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
         on_content_delta=deltas.append,
         # The default-config primary-reply shape: tools attached AND
         # reasoning_effort set (reyn.yaml's default model classes all carry
@@ -307,6 +312,7 @@ def test_silent_zero_delta_guard_does_not_fire_when_deltas_do(monkeypatch, caplo
         asyncio.run(recorded_acompletion(
             model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}],
             purpose="main", recorder=None,
+            model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
             on_content_delta=lambda _t: None,
         ))
 

--- a/tests/llm/test_llm_streaming_usage_single_emission_3288.py
+++ b/tests/llm/test_llm_streaming_usage_single_emission_3288.py
@@ -87,6 +87,7 @@ def test_usage_recorded_exactly_once_when_streamed(monkeypatch) -> None:
     response = asyncio.run(recorded_acompletion(
         model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}],
         purpose="main", recorder=rec, agent="a1",
+        model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
     ))
     # Witness: all 4 scripted chunks were actually consumed — the usage
     # summation this test pins genuinely ran across chunks, not via the
@@ -138,5 +139,6 @@ def test_usage_recorded_once_for_whole_collect_baseline(monkeypatch) -> None:
     asyncio.run(recorded_acompletion(
         model="o1-pro", messages=[{"role": "user", "content": "hi"}],
         purpose="main", recorder=rec, agent="a1",
+        model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
     ))
     assert [c["purpose"] for c in rec.calls] == ["main"]

--- a/tests/llm/test_model_class_by_purpose_1672.py
+++ b/tests/llm/test_model_class_by_purpose_1672.py
@@ -160,3 +160,40 @@ llm:
 """.lstrip())
     with pytest.raises(ValueError, match="model_class_by_purpose.compaction"):
         load_config(cwd=tmp_path)
+
+
+# ── #4206 T1: llm.model_max_class (②bounding ceiling) ─────────────────────────
+
+
+def test_yaml_model_max_class_round_trip(tmp_path, monkeypatch) -> None:
+    """Tier 2: #4206 T1 — model_max_class parses from reyn.yaml and is exposed
+    on LLMConfig; a config that never sets it stays None (unbounded, byte-
+    identical to before this field existed)."""
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path / "reyn.yaml", """
+llm:
+  model: standard
+  model_max_class: light
+""".lstrip())
+    cfg = load_config(cwd=tmp_path)
+    assert cfg.llm.model_max_class == "light"
+
+    _write(tmp_path / "reyn.yaml", "llm:\n  model: standard\n")
+    cfg2 = load_config(cwd=tmp_path)
+    assert cfg2.llm.model_max_class is None
+
+
+def test_yaml_model_max_class_rejects_unknown_value(tmp_path, monkeypatch) -> None:
+    """Tier 2: #4206 T1 — an unrecognized model_max_class value fails to load
+    (hard fail-fast, unlike model_class_by_purpose's per-key warn-only
+    tolerance): a ceiling that silently doesn't apply is a widened bound, so
+    it cannot be treated as a shrug-off-able typo the way an unused purpose
+    key can."""
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path / "reyn.yaml", """
+llm:
+  model: standard
+  model_max_class: extra-strong
+""".lstrip())
+    with pytest.raises(ValueError, match="model_max_class"):
+        load_config(cwd=tmp_path)

--- a/tests/llm/test_model_class_ceiling_4206.py
+++ b/tests/llm/test_model_class_ceiling_4206.py
@@ -1,0 +1,189 @@
+"""Tier 2: OS invariant — #4206 T1 ②bounding axis, the ``model`` key.
+
+``recorded_acompletion`` (the #1190 cost-observability chokepoint every
+`litellm.acompletion` call passes through, AST-guard enforced) additionally
+enforces a caller-declared ``model_class`` against an optional
+``model_class_ceiling`` — restrict-only, reject-not-clamp, the same shape as
+#3903①'s ``SandboxPolicy.max_timeout_seconds``. A call whose class exceeds the
+ceiling is REJECTED before ``litellm.acompletion`` is ever invoked; a call
+that opts out (``model_class=None``) is untouched by this axis entirely.
+
+Real instances + a scripted ``litellm.acompletion`` (a plain async callable,
+not a mock) throughout, per the repo testing policy.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import litellm
+import pytest
+
+from reyn.llm.llm import recorded_acompletion
+from reyn.llm.model_resolver import (
+    STANDARD_CLASSES,
+    ModelClassExceedsCeilingError,
+    ModelResolver,
+    model_class_exceeds_ceiling,
+)
+
+# ---------------------------------------------------------------------------
+# model_class_exceeds_ceiling — pure predicate
+# ---------------------------------------------------------------------------
+
+
+def test_model_class_exceeds_ceiling_orders_by_standard_classes() -> None:
+    """Tier 1: contract — the predicate orders strictly by STANDARD_CLASSES'
+    own declared order (light < standard < strong), for every pair."""
+    assert list(STANDARD_CLASSES) == ["light", "standard", "strong"]
+    results = {
+        (cls, ceiling): model_class_exceeds_ceiling(cls, ceiling)
+        for cls in STANDARD_CLASSES
+        for ceiling in STANDARD_CLASSES
+    }
+    # Only a class STRICTLY more expensive than the ceiling violates.
+    assert results[("light", "light")] is False
+    assert results[("light", "standard")] is False
+    assert results[("light", "strong")] is False
+    assert results[("standard", "light")] is True
+    assert results[("standard", "standard")] is False
+    assert results[("standard", "strong")] is False
+    assert results[("strong", "light")] is True
+    assert results[("strong", "standard")] is True
+    assert results[("strong", "strong")] is False
+
+
+def test_model_class_exceeds_ceiling_none_ceiling_never_violates() -> None:
+    """Tier 1: contract — ceiling=None (unbounded, the compat default) is
+    never a violation, regardless of class_name."""
+    for cls in (*STANDARD_CLASSES, "custom-class", "openai/gpt-4o"):
+        assert model_class_exceeds_ceiling(cls, None) is False
+
+
+def test_model_class_exceeds_ceiling_unknown_names_not_comparable() -> None:
+    """Tier 1: contract — a class_name or ceiling outside the 3 standard tiers
+    (a raw provider/model string, or a project-declared custom class) is not
+    comparable on this axis — never a violation, since there is nothing to
+    order it against."""
+    assert model_class_exceeds_ceiling("openai/gpt-4o", "light") is False
+    assert model_class_exceeds_ceiling("strong", "custom-tier") is False
+    assert model_class_exceeds_ceiling("custom-a", "custom-b") is False
+
+
+# ---------------------------------------------------------------------------
+# recorded_acompletion enforcement — falsify + accept-side
+# ---------------------------------------------------------------------------
+
+
+def _resp():
+    from types import SimpleNamespace
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+    )
+
+
+def test_recorded_acompletion_rejects_over_ceiling_without_calling_litellm(monkeypatch) -> None:
+    """Tier 2: falsify direction — a call whose model_class exceeds the
+    configured ceiling is rejected BEFORE litellm.acompletion is ever
+    invoked (no partial call, no charge). Spies on litellm.acompletion so a
+    reject that nonetheless slipped through and called it would fail this
+    assertion, not just the exception-type assertion."""
+    called = {"n": 0}
+
+    async def _spy(model, messages, **kw):  # noqa: ANN001, ANN003
+        called["n"] += 1
+        return _resp()
+    monkeypatch.setattr(litellm, "acompletion", _spy)
+
+    with pytest.raises(ModelClassExceedsCeilingError) as excinfo:
+        asyncio.run(recorded_acompletion(
+            model="anthropic/claude-opus-5", messages=[{"role": "user", "content": "hi"}],
+            purpose="main", model_class="strong", model_class_ceiling="light",
+            recorder=None,
+        ))
+    assert called["n"] == 0, "litellm.acompletion must never be invoked on a rejected call"
+    assert excinfo.value.requested == "strong"
+    assert excinfo.value.ceiling == "light"
+
+
+def test_recorded_acompletion_allows_at_or_under_ceiling(monkeypatch) -> None:
+    """Tier 2: accept-side — a call whose class is AT or under the ceiling
+    proceeds normally (this axis must not false-positive)."""
+    called = {"n": 0}
+
+    async def _fake(model, messages, **kw):  # noqa: ANN001, ANN003
+        called["n"] += 1
+        return _resp()
+    monkeypatch.setattr(litellm, "acompletion", _fake)
+
+    for cls in ("light", "standard"):
+        resp = asyncio.run(recorded_acompletion(
+            model="openai/gpt-4o-mini", messages=[{"role": "user", "content": "hi"}],
+            purpose="main", model_class=cls, model_class_ceiling="standard",
+            recorder=None,
+        ))
+        assert resp.choices[0].message.content == "ok"
+    assert called["n"] == 2
+
+
+def test_recorded_acompletion_model_class_none_bypasses_ceiling(monkeypatch) -> None:
+    """Tier 2: accept-side — model_class=None (a caller that declared itself
+    OUT of the axis, e.g. compaction #3785) is never enforced, even against a
+    configured ceiling that its literal model string would otherwise exceed
+    were it class-based."""
+    called = {"n": 0}
+
+    async def _fake(model, messages, **kw):  # noqa: ANN001, ANN003
+        called["n"] += 1
+        return _resp()
+    monkeypatch.setattr(litellm, "acompletion", _fake)
+
+    resp = asyncio.run(recorded_acompletion(
+        model="anthropic/claude-opus-5", messages=[{"role": "user", "content": "hi"}],
+        purpose="compaction", model_class=None, model_class_ceiling="light",
+        recorder=None,
+    ))
+    assert resp.choices[0].message.content == "ok"
+    assert called["n"] == 1
+
+
+def test_recorded_acompletion_model_class_required_no_default() -> None:
+    """Tier 1: contract — model_class has NO default (#4271 precedent): a
+    caller that forgets to pass it gets a TypeError at the call site, not a
+    silently-unenforced bound."""
+    with pytest.raises(TypeError):
+        recorded_acompletion(  # type: ignore[call-arg]
+            model="m", messages=[{"role": "user", "content": "hi"}], purpose="main",
+        )
+
+
+# ---------------------------------------------------------------------------
+# ModelResolver.class_ceiling() — a pure read, resolution/display unaffected
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_class_ceiling_read_does_not_affect_resolution() -> None:
+    """Tier 2: accept-side, direction ② — a configured ceiling is a value
+    ``class_ceiling()`` exposes for a CALLER to compare; it does not itself
+    gate ``resolve()`` / ``class_for_purpose()``. A display-only read (e.g.
+    Session.active_model_class(), the model picker) must keep working
+    unchanged even when the active/declared class is above the ceiling —
+    only the actual LLM call (recorded_acompletion) is blocked."""
+    resolver = ModelResolver(
+        {"strong": "anthropic/claude-opus-5"},
+        default_class="strong",
+        model_max_class="light",  # ceiling BELOW the configured default
+    )
+    assert resolver.class_ceiling() == "light"
+    # resolution/display still resolves the (over-ceiling) default normally —
+    # this axis never touches resolve()/class_for_purpose().
+    assert resolver.class_for_purpose("router") == "strong"
+    assert resolver.resolve("strong").model == "anthropic/claude-opus-5"
+
+
+def test_resolver_class_ceiling_defaults_to_none() -> None:
+    """Tier 1: contract — a resolver built without model_max_class (every
+    pre-#4206 construction site, and any caller that doesn't pass it) is
+    unbounded, byte-identical to before this field existed."""
+    resolver = ModelResolver({})
+    assert resolver.class_ceiling() is None

--- a/tests/llm/test_per_class_api_base_309.py
+++ b/tests/llm/test_per_class_api_base_309.py
@@ -102,6 +102,7 @@ def test_per_class_routing_overrides_global_proxy(monkeypatch) -> None:
     asyncio.run(recorded_acompletion(
         model="gemini/x", messages=[{"role": "user", "content": "hi"}],
         purpose="main", recorder=None,
+        model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
         routing={"api_base": "https://PERCLASS.endpoint", "custom_llm_provider": "openai", "api_key": "k"},
     ))
     assert box["api_base"] == "https://PERCLASS.endpoint"  # per-class, not GLOBAL
@@ -117,5 +118,6 @@ def test_global_proxy_used_when_no_per_class_routing(monkeypatch) -> None:
     asyncio.run(recorded_acompletion(
         model="gemini/x", messages=[{"role": "user", "content": "hi"}],
         purpose="main", recorder=None,  # routing defaults None → global
+        model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
     ))
     assert box["api_base"] == "https://GLOBAL.proxy"

--- a/tests/llm/test_reasoning_native_history_1652.py
+++ b/tests/llm/test_reasoning_native_history_1652.py
@@ -90,6 +90,7 @@ async def test_recorded_acompletion_enables_modify_params(monkeypatch) -> None:
         model="openai/gpt-4o",
         messages=[{"role": "user", "content": "hi"}],
         purpose="main",
+        model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
         recorder=None,
     )
     assert litellm.modify_params is True

--- a/tests/llm/test_streaming_usage_provider_supplied_3348.py
+++ b/tests/llm/test_streaming_usage_provider_supplied_3348.py
@@ -159,6 +159,7 @@ def test_gemini_streamed_call_records_the_providers_own_token_counts(monkeypatch
     tracker = BudgetTracker(CostConfig())
     response = asyncio.run(recorded_acompletion(
         model=_GATED_MODEL, messages=_MESSAGES, purpose="main",
+        model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
         recorder=tracker, agent="alpha",
     ))
 

--- a/tests/llm/test_turn_cost_attribution_3339.py
+++ b/tests/llm/test_turn_cost_attribution_3339.py
@@ -252,11 +252,13 @@ def test_ambient_turn_scope_reaches_the_cost_chokepoint(monkeypatch) -> None:
             await recorded_acompletion(
                 model=_MODEL, messages=[{"role": "user", "content": "hi"}],
                 purpose="main", recorder=tracker, agent="alpha",
+                model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
             )
         assert get_active_turn_chain_id() is None, "scope must not outlive the turn"
         await recorded_acompletion(
             model=_MODEL, messages=[{"role": "user", "content": "hi"}],
             purpose="main", recorder=tracker, agent="alpha",
+            model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
         )
 
     asyncio.run(_call())

--- a/tests/llm/test_wire_toolpair_repair.py
+++ b/tests/llm/test_wire_toolpair_repair.py
@@ -262,6 +262,7 @@ async def test_recorded_acompletion_repairs_before_provider_call(monkeypatch):
     with pytest.raises(_StopBeforeProvider):
         await recorded_acompletion(
             model="openai/gpt-4o", messages=assembled, purpose="main", routing={},
+            model_class=None,  # #4206 T1: not subject to the axis (pre-existing call)
         )
 
     wire = captured["messages"]


### PR DESCRIPTION
**[e2e-coder]** — #4206 T1: model-class ceiling — ②bounding axis, the `model` key.

First vertical slice of the ②bounding config axis (#4206): an operator-declared
CEILING on the model class any LLM call may use, enforced restrict-only /
reject-not-clamp — the same shape as #3903①'s `SandboxPolicy.max_timeout_seconds`
ceiling. Design confirmed by lead-coder over 3 rounds of broker-mediated
iteration (spawn-time → resolve-time; resolver-state → session-state; the
chokepoint verified to be `recorded_acompletion`, not `_rebuild_derived_model_engines_for_model`
as I first proposed).

## Mechanism

- `model_resolver.py`: `model_class_exceeds_ceiling()` (pure predicate,
  ordered by `STANDARD_CLASSES`' own `light < standard < strong` order) +
  `ModelClassExceedsCeilingError`.
- `llm.py`: `recorded_acompletion()` — the #1190 cost-observability chokepoint
  every `litellm.acompletion` call passes through (AST-guard enforced) — gains
  a **required** (no default) `model_class` param + an optional
  `model_class_ceiling`. Enforcement runs before `litellm` is even imported,
  so a rejected call touches litellm in NO way. `model_class=None` explicitly
  opts a call OUT (compaction #3785, dogfood/eval literal-model-string
  surfaces) — no default that means the same thing as forgetting, per the
  #4271 precedent lead-coder cited for `timeout`.
- `llm.py`: `call_llm_tools()` forwards `model_class`/`model_class_ceiling`
  (defaulted `None` here — this wrapper has many non-`RouterLoop` callers not
  subject to the axis at all).

## The one key (`model`)

- `config/infra.py`: `LLMConfig.model_max_class` (`llm.model_max_class` in
  `reyn.yaml`) — the project-declared ceiling. Unset = unbounded (byte-
  identical to before). Hard fail-fast on an unrecognized value (unlike
  `model_class_by_purpose`'s per-key warn-only tolerance) — a ceiling that
  silently doesn't apply is a widened bound, not a shrug-off-able typo.
- `model_resolver.py`: `ModelResolver` gains `model_max_class` +
  `class_ceiling()` — a pure read a caller compares against, never itself
  gating `resolve()`/`class_for_purpose()` (display/resolution stays
  unaffected by a ceiling declaration).
- All 5 `ModelResolver` construction sites (`registry_bootstrap`, `web/deps`,
  `cli/invocation_context`, `cli/commands/dogfood`, + tests) thread the new
  field.
- `router_loop.py`: `RouterLoop` resolves the ceiling once at construction
  and passes `model_class=self.router_model` + the ceiling at all 3
  `call_llm_tools` call sites (main tool-turn, structured-answer turn,
  force-close wrap-up) — every `RouterLoop` LLM call is now subject to the
  axis by construction.

## Test sweep

Every pre-existing `recorded_acompletion` call site (src + 15 test files)
updated to pass `model_class=None` (not subject to the axis). `call_llm_tools`
callers needed no changes (default `None` there).

New tests (`tests/llm/test_model_class_ceiling_4206.py`):
- `model_class_exceeds_ceiling`: full 3×3 `STANDARD_CLASSES` ordering,
  `ceiling=None` never violates, unknown names not comparable.
- **Falsify** (lead-coder's explicit ask): a rejected call never invokes
  `litellm.acompletion` (spied) — hand-verified RED when the enforcement
  block is stripped, restored GREEN.
- **Accept-side** ①: at/under-ceiling calls proceed; `model_class=None`
  bypasses the axis entirely; the required-param `TypeError` contract.
- **Accept-side** ②: `ModelResolver.class_ceiling()` is a pure read —
  `resolve()`/`class_for_purpose()` keep working unchanged even when the
  configured default is above the ceiling (display axis untouched, per
  lead-coder's explicit two-direction spec).

Also extended `tests/llm/test_model_class_by_purpose_1672.py` with a
`reyn.yaml` round-trip + an unknown-value fail-fast test for
`model_max_class`.

## Docs

`reyn.local.yaml.example` + `docs/reference/config/reyn-yaml.md` updated
(`test_config_mirror_coverage_1056.py` enforces this — caught the gap on
first scoped run).

## Scope

T2+ (remaining ②bounding keys, agent/session narrowing, reconciliation with
#4174 axis C for `chat.render_mode`/`gutters`) explicitly deferred per
lead-coder's scoping: "先に書くと、T1の実装がT分解の記述をfalsifyします."

## Test plan

- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict <changed test files>`
- [x] `python scripts/verify_module_docstrings.py <changed src files>`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] Scoped `pytest tests/llm tests/core tests/config tests/runtime tests/dev`
      — 5333 passed, 6 skipped, 4 failed (pre-existing `ModuleNotFoundError:
      PIL` / textual-image env issue, unrelated to this diff — confirmed by
      reading the failure tracebacks).
- [x] Falsify: stripped the enforcement block by hand, confirmed
      `test_recorded_acompletion_rejects_over_ceiling_without_calling_litellm`
      goes RED; restored, confirmed GREEN.
- [ ] Visual/manual — N/A (no UI surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

- [x] 🔴 (lead-coder) `router_loop.py` の `hasattr(_resolver, "class_ceiling")` を落とす — 無い場合に上限が黙って消える（widening）。`_resolver is not None` だけにし、本物でない resolver は `AttributeError` で落とす。[review comment](https://github.com/tya5/reyn/pull/4318#issuecomment-5255365620) — fixed in f58118121, `tests/runtime/` full sweep (1676 tests) confirms no existing test double lacked `class_ceiling()`.
- [x] 🔴 (lead-coder) この軸が効く範囲の残渣 1 つ＋ follow-up issue（生のモデル文字列指定と `model_class=None` の呼び出しは軸の外）。dogfood 2 本を軸の外に置いた判断の説明も。
  — Residue added to `model_class_exceeds_ceiling()`'s docstring (f58118121); follow-up issue #4324 (`part of #4206`) opened.
  Dogfood answer: **intentional, principled exclusion — not "existing call, so None."** Both `interpretation.py` and
  `verifiers/reply.py` call with a fixed literal model string (`DEFAULT_MODEL` / a hardcoded `"gemini-2.5-flash-lite"`),
  never resolved via `class_for_purpose` — there is no class to compare, the same structural reason a raw
  `--router-model` string bypasses the axis (#4324). It's real-cost spend, so it's worth a separate call: whether it
  should be threaded onto a class (so this axis covers it) or bounded by a different mechanism (a budget-style cap) is
  exactly the open question #4324 leaves for whoever picks it up — not resolved here.

