### PR TITLE
fix(#4097): remove 1 dead F401 import in src/reyn/services; keep 1 as a re-export (noqa)

### DIFF
--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -44,7 +44,6 @@ Drop priority when over budget:
 """
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import json
 import logging

--- a/src/reyn/services/turn_budget/engine.py
+++ b/src/reyn/services/turn_budget/engine.py
@@ -34,7 +34,9 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from reyn.prompt.turn_budget import WRAP_UP_SYSTEM_PROMPT as _WRAP_UP_SYSTEM_PROMPT
-from reyn.prompt.turn_budget import wrap_up_system_prompt
+from reyn.prompt.turn_budget import (
+    wrap_up_system_prompt,  # noqa: F401 — re-exported via __init__.py's __all__, engine.py itself doesn't call it
+)
 from reyn.services.compaction.engine import estimate_tokens
 
 if TYPE_CHECKING:


### PR DESCRIPTION
**[tui-coder]** — Eighth directory in the per-directory F401 rollout (#4097). This one caught a real false-positive, not confined to `config/*.py`.

## Changes
- `compaction/engine.py`: unused `asyncio`, genuinely dead, removed.
- `turn_budget/engine.py`: ruff flagged `wrap_up_system_prompt` as unused within this file — but `turn_budget/__init__.py` does `from .engine import (..., wrap_up_system_prompt)` and re-exports it via `__all__`. Removing it broke the re-export: **`mypy_ratchet.py` caught it** (`attr-defined` in `turn_budget/__init__.py`, since `engine.py` no longer had the name to re-export). Reverted the removal, kept the import with a reasoned `# noqa: F401` explaining the re-export dependency.

This is the same *class* of false positive as the `config/*.py` `get_type_hints()` pattern flagged in #4097's reconciliation — a cross-module re-export ruff can't see — but this instance lives outside `config/`, so the "17 known exclusions are all in config" assumption doesn't fully hold; worth a note for whoever does the final gate-reactivation sweep.

## Test plan
- [x] `ruff check src/reyn/services` — clean
- [x] `python scripts/mypy_ratchet.py` — no new findings (confirmed both ways: failed with the bad removal, clean after reverting it — see commit message)
- [x] `pytest tests/services -q` — 107 passed
- [x] `pytest tests/llm -q` — 725 passed

Part of #4097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)