### PR TITLE
fix(#4097): remove 1 dead F401 import in src/reyn/environment

### DIFF
--- a/src/reyn/environment/container_launcher.py
+++ b/src/reyn/environment/container_launcher.py
@@ -46,7 +46,6 @@ from pathlib import Path
 from typing import Any
 
 from reyn.environment.container_backend import SyncRunner, _sync_runner
-from reyn.security.sandbox.backend import SandboxResult
 
 # The bundled reyn base image (#1324): a minimal generic agent runtime built ON
 # DEMAND from reyn_base.Dockerfile (local-build, no registry). The tag is local


### PR DESCRIPTION
**[tui-coder]** — Ninth directory in the per-directory F401 rollout (#4097).

## Changes
- `container_launcher.py`: unused `SandboxResult` import. Checked for the re-export pattern found in #4319 (grepped for any downstream `from ...container_launcher import ... SandboxResult`) — none, safe to remove.

## Test plan
- [x] `ruff check src/reyn/environment` — clean
- [x] `python scripts/mypy_ratchet.py` — no new findings
- [x] `pytest tests/environment -q` — 89 passed, 10 skipped (pre-existing)

Part of #4097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)