### PR TITLE
fix(#4097): remove 1 dead F401 import in src/reyn/hooks

### DIFF
--- a/src/reyn/hooks/render.py
+++ b/src/reyn/hooks/render.py
@@ -85,7 +85,6 @@ import json
 import logging
 from dataclasses import dataclass
 
-from jinja2 import TemplateError
 from jinja2.sandbox import SandboxedEnvironment
 
 from reyn.hooks.schema import PushBlock


### PR DESCRIPTION
**[tui-coder]** — Tenth directory in the per-directory F401 rollout (#4097).

## Changes
- `render.py`: unused `jinja2.TemplateError` import. Checked for the re-export pattern found in #4319 — none downstream.

## Test plan
- [x] `ruff check src/reyn/hooks` — clean
- [x] `python scripts/mypy_ratchet.py` — no new findings
- [x] `pytest tests/hooks -q` — 323 passed

Part of #4097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)