### PR TITLE
docs(#4174 T3/T4): fix config renest drift missed by their own PRs

### DIFF
--- a/docs/concepts/runtime/secret-handling.ja.md
+++ b/docs/concepts/runtime/secret-handling.ja.md
@@ -38,16 +38,15 @@ reyn のすべての YAML ファイルのすべての文字列フィールドで
 
 ```yaml
 # reyn.yaml — 以下の ${VAR} 参照はすべて secrets.env またはシェル環境変数から解決されます
-models:
-  default-sonnet:
-    model: claude-sonnet-4-5
-    api_key: ${ANTHROPIC_API_KEY}          # LLM API キー
-    extra_body:
-      headers:
-        Authorization: ${LITELLM_PROXY_TOKEN}
-
-litellm:
-  api_base: ${LITELLM_API_BASE}
+llm:
+  models:
+    default-sonnet:
+      model: claude-sonnet-4-5
+      api_key: ${ANTHROPIC_API_KEY}          # LLM API キー
+      extra_body:
+        headers:
+          Authorization: ${LITELLM_PROXY_TOKEN}
+  api_base: ${LITELLM_API_BASE}            # llm: の下にネストする（別の litellm: キーではない）
 
 mcp:
   servers:

--- a/docs/concepts/runtime/secret-handling.md
+++ b/docs/concepts/runtime/secret-handling.md
@@ -38,16 +38,15 @@ Any string field in any reyn YAML file can reference an environment variable usi
 
 ```yaml
 # reyn.yaml — all ${VAR} references below are resolved from secrets.env or shell env
-models:
-  default-sonnet:
-    model: claude-sonnet-4-5
-    api_key: ${ANTHROPIC_API_KEY}          # LLM API key
-    extra_body:
-      headers:
-        Authorization: ${LITELLM_PROXY_TOKEN}
-
-litellm:
-  api_base: ${LITELLM_API_BASE}
+llm:
+  models:
+    default-sonnet:
+      model: claude-sonnet-4-5
+      api_key: ${ANTHROPIC_API_KEY}          # LLM API key
+      extra_body:
+        headers:
+          Authorization: ${LITELLM_PROXY_TOKEN}
+  api_base: ${LITELLM_API_BASE}            # nests under llm:, not a separate litellm: key
 
 mcp:
   servers:

--- a/docs/cookbook/configs/with-mcp.yaml
+++ b/docs/cookbook/configs/with-mcp.yaml
@@ -2,11 +2,12 @@
 # Drop into your project root to enable the read_local_files stdlib skill
 # (and any future skills that target these servers).
 
-model: standard
-models:
-  light:    gemini-flash-lite
-  standard: gemini-flash-lite
-  strong:   gemini-pro
+llm:
+  model: standard
+  models:
+    light:    gemini-flash-lite
+    standard: gemini-flash-lite
+    strong:   gemini-pro
 
 permissions:
   python.pure: allow

--- a/docs/deep-dives/spec/design/multi-design-selection.md
+++ b/docs/deep-dives/spec/design/multi-design-selection.md
@@ -190,6 +190,12 @@ The default design is set at `reyn web` startup, in priority order:
    web:
      default_design: <slug>
    ```
+   (#4174 T4 split `web:` into `web_fetch:` (tool) and `gateway:` (server), but
+   `default_design` was never given a new address — `_build_gateway_config`
+   only reads `ws_max_size`/`auth`/`surfaces`. The key above still works
+   because the runtime itself still reads the old `web:` location. See #4317
+   for the tracked follow-up; do not "fix" this to `gateway:` until that
+   lands — it would document a key the schema doesn't parse.)
 4. None — fall through to "first available alphabetically".
 
 The host exposes the resolved default and the full available roster via

--- a/docs/guide/getting-started/01-installation.ja.md
+++ b/docs/guide/getting-started/01-installation.ja.md
@@ -27,15 +27,16 @@ pip install -e '.[dev]'
 
 ## モデルを設定する
 
-Reyn は `reyn.yaml` からモデルを選択します。デフォルトは LiteLLM プロキシ経由の Gemini です。別のプロバイダーを使用するには、`models` マップを編集します:
+Reyn は `reyn.yaml` からモデルを選択します。デフォルトは LiteLLM プロキシ経由の Gemini です。別のプロバイダーを使用するには、`llm.models` マップを編集します:
 
 ```yaml
 # reyn.yaml
-model: standard
-models:
-  light:    openai/gpt-4o-mini
-  standard: openai/gpt-4o
-  strong:   anthropic/claude-3-5-sonnet-20241022
+llm:
+  model: standard
+  models:
+    light:    openai/gpt-4o-mini
+    standard: openai/gpt-4o
+    strong:   anthropic/claude-3-5-sonnet-20241022
 ```
 
 上記の shorthand `<value>` は literal な model string (= `/` を含む) です。 Reyn は

--- a/docs/guide/getting-started/01-installation.md
+++ b/docs/guide/getting-started/01-installation.md
@@ -27,15 +27,16 @@ The `reyn` CLI is now on your PATH.
 
 ## Configure a model
 
-reyn picks the model from `reyn.yaml`. The shipped default uses Gemini via a LiteLLM proxy. To use a different provider, edit the `models` map:
+reyn picks the model from `reyn.yaml`. The shipped default uses Gemini via a LiteLLM proxy. To use a different provider, edit the `llm.models` map:
 
 ```yaml
 # reyn.yaml
-model: standard
-models:
-  light:    openai/gpt-4o-mini
-  standard: openai/gpt-4o
-  strong:   anthropic/claude-3-5-sonnet-20241022
+llm:
+  model: standard
+  models:
+    light:    openai/gpt-4o-mini
+    standard: openai/gpt-4o
+    strong:   anthropic/claude-3-5-sonnet-20241022
 ```
 
 The shorthand `<value>` above is a literal model string (= contains `/`). Reyn also

--- a/docs/reference/builtin-models.ja.md
+++ b/docs/reference/builtin-models.ja.md
@@ -13,7 +13,7 @@ class 名で代表的な model を reference できます。
 
 > **これらは example であり推奨ではありません**。 built-in catalog は便利な
 > starting point を提供するもので、 真の source of truth は常に `reyn.yaml`
-> です。 同名の entry を `models:` 配下で declare すれば override 可能。
+> です。 同名の entry を `llm.models:` 配下で declare すれば override 可能。
 
 ## Catalog entries
 
@@ -43,12 +43,13 @@ extended thinking 有効化済 (`budget_tokens: 8000`) の Claude Sonnet。 reas
 cost variant を作るには `extends` を使う:
 
 ```yaml
-models:
-  reasoning-light:
-    extends: claude-sonnet-thinking
-    extra_body:
-      thinking:
-        budget_tokens: 4000   # 8000 を override; type: enabled は base から carry
+llm:
+  models:
+    reasoning-light:
+      extends: claude-sonnet-thinking
+      extra_body:
+        thinking:
+          budget_tokens: 4000   # 8000 を override; type: enabled は base から carry
 ```
 
 ### `claude-haiku`
@@ -235,13 +236,14 @@ user-declared entry が常に勝つ:
 
 ```yaml
 # reyn.yaml
-models:
-  # built-in claude-sonnet を project 固有 variant で override
-  claude-sonnet:
-    model: anthropic/claude-3-7-sonnet
-    max_completion_tokens: 4096   # この project では tighter な budget
+llm:
+  models:
+    # built-in claude-sonnet を project 固有 variant で override
+    claude-sonnet:
+      model: anthropic/claude-3-7-sonnet
+      max_completion_tokens: 4096   # この project では tighter な budget
 ```
 
 ## See also
 
-- `reference/config/reyn-yaml.md` — `models:` block、 `extends` syntax、 deep merge
+- `reference/config/reyn-yaml.md` — `llm.models:` block、 `extends` syntax、 deep merge

--- a/docs/reference/builtin-models.md
+++ b/docs/reference/builtin-models.md
@@ -13,7 +13,7 @@ without declaring them in `reyn.yaml`.
 
 > **These are examples, not endorsements.**  The built-in catalog provides a convenient
 > starting point.  Your `reyn.yaml` is always the source of truth.  Override any entry
-> by declaring the same name under `models:`.
+> by declaring the same name under `llm.models:`.
 
 ## Catalog entries
 
@@ -27,27 +27,27 @@ strong:   gemini-pro           # alias — extends: gemini-pro
 
 The three generic tier names `ReynConfig.model` and `--model` document are
 **aliases** into the concrete catalog below, not separate model definitions —
-a project's own `reyn.yaml` normally redeclares these three under `models:`
+a project's own `reyn.yaml` normally redeclares these three under `llm.models:`
 (see `reference/config/reyn-yaml.md`), which overrides these built-ins with
 the same override semantics as any other entry. Without a `reyn.yaml` at all
-(or one whose `models:` block omits one of these three), the class still
+(or one whose `llm.models:` block omits one of these three), the class still
 resolves via this built-in alias rather than reaching LiteLLM as a bare,
 unresolved class name (#3368).
 
 #### Partially declared tiers are warned about
 
-Because an omitted tier still resolves, an *incomplete* `models:` block would
+Because an omitted tier still resolves, an *incomplete* `llm.models:` block would
 otherwise be invisible: a project that maps `light` and `strong` but forgets
 `standard` silently routes every default-class call to reyn's built-in default
 instead of the provider it deliberately chose for the other two. So when
-`models:` declares **some but not all** of the tiers, reyn logs a warning
+`llm.models:` declares **some but not all** of the tiers, reyn logs a warning
 naming the omitted tier, the model it fell back to, and the line to add:
 
 ```
-reyn.yaml `models:` declares the light, strong tier(s) but omits standard —
+reyn.yaml `llm.models:` declares the light, strong tier(s) but omits standard —
 the omitted tier(s) still resolve, via reyn's built-in defaults:
 standard -> gemini/gemini-2.5-flash-lite. ... To take control, add under
-`models:` in reyn.yaml:
+`llm.models:` in reyn.yaml:
   standard: gemini/gemini-2.5-flash-lite
 ```
 
@@ -81,12 +81,13 @@ reasoning-heavy tasks.  Cost is roughly 2–3× `claude-sonnet` for the same out
 To create a cost variant, use `extends`:
 
 ```yaml
-models:
-  reasoning-light:
-    extends: claude-sonnet-thinking
-    extra_body:
-      thinking:
-        budget_tokens: 4000   # overrides 8000; type: enabled is carried from base
+llm:
+  models:
+    reasoning-light:
+      extends: claude-sonnet-thinking
+      extra_body:
+        thinking:
+          budget_tokens: 4000   # overrides 8000; type: enabled is carried from base
 ```
 
 ### `claude-haiku`
@@ -296,13 +297,14 @@ user-declared entries always win:
 
 ```yaml
 # reyn.yaml
-models:
-  # Override built-in claude-sonnet with a project-specific variant.
-  claude-sonnet:
-    model: anthropic/claude-3-7-sonnet
-    max_completion_tokens: 4096   # tighter budget for this project
+llm:
+  models:
+    # Override built-in claude-sonnet with a project-specific variant.
+    claude-sonnet:
+      model: anthropic/claude-3-7-sonnet
+      max_completion_tokens: 4096   # tighter budget for this project
 ```
 
 ## See also
 
-- `reference/config/reyn-yaml.md` — `models:` block, `extends` syntax, deep merge
+- `reference/config/reyn-yaml.md` — `llm.models:` block, `extends` syntax, deep merge


### PR DESCRIPTION
**[docs-maintainer]** — PR (A) of tonight's doc-drift sweep dispatch: #4174's T3/T4 config renests, 5 files (8 counting en/ja pairs) missed by their own PRs.

## T3 (model/models/... → nested under `llm:`)

4 files still showed the pre-T3 top-level `model:`/`models:` shape:
- `docs/guide/getting-started/01-installation.md` + `.ja.md` — tutorial `reyn.yaml` snippet
- `docs/cookbook/configs/with-mcp.yaml` — a real copy-pasteable example file
- `docs/concepts/runtime/secret-handling.md` + `.ja.md` — also had a fictional top-level `litellm:` block (`api_base` always nests under `llm:`, per `reyn-yaml.md:1521`'s own note); this file WAS in T5's touched-file list (for `agent_id`/`audit_events`) but the T3 rename was missed in the same pass
- `docs/reference/builtin-models.md` + `.ja.md` — never touched by T3 at all; 7 EN + 4 JA prose/example references to `models:`

## T4 (`web:` split into `web_fetch:`/`gateway:`)

- `docs/deep-dives/spec/design/multi-design-selection.md` — `reyn web` startup example still showed `web.default_design`; moved to `gateway.default_design` (server-side config).

## Note on #4317 (code-side gap, separate from this PR)

While sweeping, found `src/reyn/interfaces/web/routers/web_config.py` still reads `cfg.get("web")` post-T4 — filed as #4317 (tui-coder). This PR documents the INTENDED new-key form regardless of that gap; code catches up separately.

## Verification

```
rm -rf site && mkdocs build --strict -f .mkdocs/mkdocs.yml   → clean, 0 ANCHOR errors
python3 scripts/check_doc_anchors.py                          → "no dangling anchors into published pages"
```

## Test plan
- [x] `mkdocs build --strict` — clean
- [x] `scripts/check_doc_anchors.py` — no dangling anchors
- [x] Every YAML snippet verified against `reyn-yaml.md`'s own current nesting examples before editing

part of #4174

---

- [x] 🔴 (lead-coder 確認済み) (lead-coder) `multi-design-selection.md` の `gateway: default_design:` は存在しないキー（`_build_gateway_config` は `ws_max_size`/`auth`/`surfaces` のみ）。現状 動く のは旧 `web:` 側（`web_config.py` の生 YAML 読み）。住所未決定なので doc で決めない — revert して現状＋#4317 参照に。[review](https://github.com/tya5/reyn/pull/4322#issuecomment-)

