### PR TITLE
docs(#3698/#3846③): fix MCP-SDK and present-image drift missed by their own PRs

### DIFF
--- a/docs/concepts/runtime/present.ja.md
+++ b/docs/concepts/runtime/present.ja.md
@@ -57,7 +57,7 @@ view は**宣言的なコンポーネントツリー**であり、コードで�
 | `keyvalue` | ラベル/値の行カード |
 | `table` | 行 × 列 |
 | `list` | 箇条書き |
-| `image` | v1 では `[image: <alt>]` という dim テキストのプレースホルダーのみ描画される — マルチモーダル配送経路へはまだルーティングされない |
+| `image` | TUI が URL を自ら fetch し実ピクセルを描画する（Kitty/WezTerm/Sixel、フォールバックは half-block/unicode、端末ごとに自動検出 — #3846 ③）。resolution stage を持たない surface（`--cui`、`reyn pipe`）は `[image: <alt>]` という dim テキストのプレースホルダーにフォールバックする |
 
 データは **JSON Pointer (RFC 6901)** のパスバインディングで view に結合され、`{"$bind":
 "<pointer>"}` として構造的に表現される。`table` / `list` のパスは**行相対**（各反復行に対する

--- a/docs/concepts/runtime/present.md
+++ b/docs/concepts/runtime/present.md
@@ -61,7 +61,7 @@ A view is a **declarative component tree**, never code. It is built from a fixed
 | `keyvalue` | a card of label/value rows |
 | `table` | rows × columns |
 | `list` | a bullet list |
-| `image` | v1 renders an `[image: <alt>]` dim-text placeholder only — not yet routed to the multimodal delivery path |
+| `image` | the TUI fetches the URL itself and renders REAL pixels (Kitty/WezTerm/Sixel, half-block/unicode fallback, auto-detected per-terminal — #3846 ③); surfaces without a resolution stage (`--cui`, `reyn pipe`) fall back to an `[image: <alt>]` dim-text placeholder |
 
 Data is joined to the view by **JSON Pointer (RFC 6901)** path bindings — expressed
 structurally as `{"$bind": "<pointer>"}`. `table` and `list` paths resolve **row-relative**

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -568,7 +568,7 @@ logic. Design: [content-threat scan proposal](deep-dives/proposals/0050-content-
 |---------|-------------|---------------|
 | stdio transport | Subprocess `StdioServerParameters` — implemented | [Concepts: MCP](concepts/tools-integrations/mcp.md) |
 | HTTP transport | Streamable HTTP with request headers — implemented | [Concepts: MCP](concepts/tools-integrations/mcp.md) |
-| SSE transport | FastMCP's `SSETransport` — implemented (#2597 S1) | [Concepts: MCP](concepts/tools-integrations/mcp.md) |
+| SSE transport | The official `mcp` SDK's `sse_client` — implemented (#2597 S1; migrated off FastMCP's `SSETransport` at #4283/#4298/#4299) | [Concepts: MCP](concepts/tools-integrations/mcp.md) |
 | `mcp serve` | Expose Reyn agents as an MCP server over stdio JSON-RPC 2.0 | [reyn mcp CLI](reference/cli/mcp.md) |
 | `mcp install` | Fetch from registry, gate permissions, write config, store secrets. Three chat verbs: `mcp_install_registry` (official registry), `mcp_install_package` (npm/pypi/docker/github URL), `mcp_install_local` (direct command). CLI: `reyn mcp install <SERVER_ID>` or `--source <SPEC>`. | [Concepts: MCP](concepts/tools-integrations/mcp.md) · [reyn mcp CLI](reference/cli/mcp.md) |
 | Secret management | Per-server env vars in `~/.reyn/secrets.env` | [reyn secret CLI](reference/cli/secret.md) |

--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -1027,7 +1027,7 @@ mcp:
 
 サーバーは設定ソースをまたいでマージされます: `~/.reyn/config.yaml` ⊕ `reyn.yaml` ⊕ `reyn.local.yaml`。マージは `mcp.servers` キーの shallow union です。マシンごとの `reyn.local.yaml` が残りを再宣言せずに単一サーバーを追加・上書きできます。
 
-MCP ランタイムはコアインストールに同梱されます。`fastmcp` はコア依存（MCP クライアントは各セッションで構築されます）なので extra は不要です。（既存の `pip install -e ".[mcp]"` が解決し続けられるよう、空の `[mcp]` extra を後方互換エイリアスとして残しています。）
+MCP ランタイムはコアインストールに同梱されます。各セッションの MCP クライアントは公式 `mcp` SDK の上に直接構築されるようになりました（#4283/#4298/#4299: クライアント経路から `fastmcp` は完全に退役）。この `mcp` SDK がコア依存なので extra は不要です。（`fastmcp` 自体がコア依存として残っているのは、`tests/_support/` の MCP サーバー test-double が今も fastmcp のサーバーフレームワークに依存しているためだけです——これらを公式 SDK のサーバー API へ移植することが #4302 自身のスコープであり、依存を外す実際の前提条件です。以前の下書きが誤って主張していた「同梱 RAG プラグインのため」ではありません——RAG プラグインの `requirements.txt` は register-only で、reyn が読み込みも install もしません。既存の `pip install -e ".[mcp]"` が解決し続けられるよう、空の `[mcp]` extra を後方互換エイリアスとして残しています。）
 
 [コンセプト: MCP](../../concepts/tools-integrations/mcp.md) でプロトコル概要を参照してください。
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -1776,7 +1776,7 @@ mcp:
 
 Servers are merged across config sources: `~/.reyn/config.yaml` ⊕ `reyn.yaml` ⊕ `reyn.local.yaml`. The merge is a shallow union on `mcp.servers` keys — a per-machine `reyn.local.yaml` can add or override a single server without re-stating the rest.
 
-The MCP runtime ships in the core install — `fastmcp` is a core dependency (the MCP client is constructed by every session), so no extra is required. (A now-empty `[mcp]` extra is retained as a back-compat alias so existing `pip install -e ".[mcp]"` invocations keep resolving.)
+The MCP runtime ships in the core install — every session's MCP client is now built directly on the official `mcp` SDK (#4283/#4298/#4299: `fastmcp` retired from the client path entirely), which is a core dependency, so no extra is required. (`fastmcp` itself stays a core dependency ONLY because `tests/_support/`'s MCP server test-doubles still build on its server framework — porting those to the official SDK's server API is #4302's own scope and the actual precondition for dropping it; not, as an earlier draft of this note wrongly claimed, the bundled RAG plugin, whose `requirements.txt` is register-only and never read or installed by reyn. A now-empty `[mcp]` extra is retained as a back-compat alias so existing `pip install -e ".[mcp]"` invocations keep resolving.)
 
 See [Concepts: MCP](../../concepts/tools-integrations/mcp.md) for the protocol overview and How-to: use an MCP server for the end-to-end quickstart.
 


### PR DESCRIPTION
**[docs-maintainer]** — PR (B) of tonight's doc-drift sweep dispatch: the MCP fastmcp→official-SDK migration (#3698/#4283/#4298/#4299) and #3846③'s present image rendering — 5 files.

## MCP client fastmcp → official SDK (3 files)

Exactly the "true after #4283 alone, false after #4298/#4299" shape lead-coder named:
- `docs/reference/config/reyn-yaml.md` + `.ja.md` — "fastmcp is a core dependency (the MCP client is constructed by every session)" predates the whole migration and was never revisited.
- `docs/feature-map.md` — "SSE transport: FastMCP's `SSETransport`" — the client's SSE path now goes through the official SDK's `sse_client`.

Both now correctly credit the official `mcp` SDK, and note fastmcp's real remaining role (the bundled RAG plugin's own MCP *servers*, unrelated to the client — the thing that made `pyproject.toml`'s fastmcp pin still legitimate).

## present's image component (2 files)

`docs/concepts/runtime/present.md` + `.ja.md` still said v1 image blocks only render a dim-text `[image: <alt>]` placeholder, "not yet routed to the multimodal delivery path." The reference sibling doc (already updated by #4300) has been accurate for a while — the TUI fetches the URL and renders real pixels, falling back to the placeholder only on surfaces without a resolution stage. Brought the concepts doc in line with its own reference sibling.

## Verification

```
rm -rf site && mkdocs build --strict -f .mkdocs/mkdocs.yml   → clean, 0 ANCHOR errors
python3 scripts/check_doc_anchors.py                          → "no dangling anchors into published pages"
```

## Test plan
- [x] `mkdocs build --strict` — clean
- [x] `scripts/check_doc_anchors.py` — no dangling anchors
- [x] Each replacement verified against the current source of truth (`src/reyn/mcp/client.py`'s own docstring for the SDK claim, the reference sibling doc for the present.md wording)

part of #3698

---

- [x] 🔴 (lead-coder 確認済み) (lead-coder) `reyn-yaml.md`+`.ja.md`: 「fastmcp が残るのは同梱 RAG プラグインの MCP サーバーのため」は偽。実際は `tests/_support/` の server test-double（#4303 が `pyproject.toml:202` に記載、#4302 が落とす前提条件）。RAG プラグインの requirements.txt は register-only で reyn は install しない。

