### PR TITLE
fix(#4317): restore the dead REYN_FETCH_ALLOW_PRIVATE_IPS export + sweep stale web.fetch/web.* comment references

### DIFF
--- a/src/reyn/_http_limits.py
+++ b/src/reyn/_http_limits.py
@@ -2,7 +2,7 @@
 
 Single source of truth for the download-byte cap used by the urllib-based HTTP
 helpers (``reyn.api.safe.http`` / ``reyn.mcp.registry``)
-and the ``web.fetch.max_download_bytes`` config default. Stdlib-only (no reyn
+and the ``web_fetch.max_download_bytes`` config default. Stdlib-only (no reyn
 imports) so any layer — config, api, mcp — can import it without a cycle.
 
 A bare ``response.read()`` materialises the ENTIRE body into memory, so a

--- a/src/reyn/_ssrf_guard.py
+++ b/src/reyn/_ssrf_guard.py
@@ -20,7 +20,7 @@ Policy (lead-approved, #1956):
     fetch has no legitimate use for these.
   - **deny by default, operator opt-in** — private RFC1918 / ULA
     (``10/8``, ``172.16/12``, ``192.168/16``, ``fc00::/7``). Allowed only when
-    ``allow_private`` is True (``web.fetch.allow_private_ips: true``, for
+    ``allow_private`` is True (``web_fetch.allow_private_ips: true``, for
     enterprise internal-fetch).
 
 Resolution is DNS-aware: the host is resolved and EVERY returned IP is checked
@@ -160,7 +160,7 @@ def assert_fetch_host_allowed(host: str, *, allow_private: bool) -> None:
 def resolve_allow_private() -> bool:
     """Operator opt-in for private-IP fetches, from the config→env export.
 
-    The config loader exports ``web.fetch.allow_private_ips`` into
+    The config loader exports ``web_fetch.allow_private_ips`` into
     ``REYN_FETCH_ALLOW_PRIVATE_IPS``; the safe.http subprocess and the
     config-less registry main-process modules read it here. Absent / unset →
     ``False`` (deny private — fail-secure even if a sandbox strips the env).

--- a/src/reyn/api/safe/http.py
+++ b/src/reyn/api/safe/http.py
@@ -83,7 +83,7 @@ def _check_host(url: str) -> None:
 
     L1: the declared ``http_hosts`` allowlist. L2 (#1956 SSRF): the host's
     resolved IP must not be link-local / metadata / loopback / private (private
-    allowed only via the ``web.fetch.allow_private_ips`` operator opt-in). L2
+    allowed only via the ``web_fetch.allow_private_ips`` operator opt-in). L2
     runs on the allowlisted host too — an allowlisted host can still resolve to,
     or (via a redirect hop) BE, an internal IP. ``SSRFBlocked`` is a
     ``PermissionError`` subclass, so callers catching ``PermissionError`` handle

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -747,7 +747,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
             if urls:
                 _os_for_mcp.environ["REYN_MCP_REGISTRY_URLS"] = ",".join(urls)
 
-    # #1956: propagate ``web.fetch.allow_private_ips`` into the
+    # #1956: propagate ``web_fetch.allow_private_ips`` into the
     # ``REYN_FETCH_ALLOW_PRIVATE_IPS`` env var so the config-less SSRF-guard
     # surfaces read the operator opt-in: the safe.http subprocess (inherits
     # parent env) and the registry main-process modules (reyn.mcp.registry /
@@ -755,10 +755,19 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
     # export above. Explicit operator-set env var wins; absent → unset → the
     # guard's fail-secure deny-private default. Only the truthy case is exported
     # (deny is the default, so a False/absent value leaves the var unset).
+    #
+    # #4174 T4/#4317: was ``merged.get("web").get("fetch")`` (the pre-T4
+    # nested key) — T4 split ``web:`` into a top-level ``web_fetch:``
+    # scalar-namespace (see :func:`reyn.config.media._build_web_fetch_config`,
+    # already reading the correct top-level key below at ``web_fetch=``) and
+    # a top-level ``gateway:`` block. This export block was never updated,
+    # so ``merged.get("web")`` always resolved to the unknown-key ``None``
+    # after T4 landed and the export silently stopped firing — fail-secure
+    # (the guard's own deny-private default took over), but "configured yet
+    # not applied" is its own bug distinct from a hole.
     if not _os_for_mcp.environ.get("REYN_FETCH_ALLOW_PRIVATE_IPS"):
-        _web_cfg = merged.get("web")
-        _fetch_cfg = _web_cfg.get("fetch") if isinstance(_web_cfg, dict) else None
-        _ap = _fetch_cfg.get("allow_private_ips") if isinstance(_fetch_cfg, dict) else None
+        _web_fetch_cfg = merged.get("web_fetch")
+        _ap = _web_fetch_cfg.get("allow_private_ips") if isinstance(_web_fetch_cfg, dict) else None
         if _ap is True or (isinstance(_ap, str) and _ap.strip().lower() in ("1", "true", "yes", "on")):
             _os_for_mcp.environ["REYN_FETCH_ALLOW_PRIVATE_IPS"] = "1"
 

--- a/src/reyn/config/media.py
+++ b/src/reyn/config/media.py
@@ -225,7 +225,7 @@ def _build_auth_config(raw: object) -> AuthConfig:
 
 
 def _build_surfaces_config(raw: object) -> SurfacesConfig:
-    """Parse the ``web.surfaces:`` sub-section (mirrors ``_build_web_fetch_config``).
+    """Parse the ``gateway.surfaces:`` sub-section (mirrors ``_build_web_fetch_config``).
 
     Accepts both a long form (``{a2a: {enabled: true}}``) and a tolerated
     short form (``{a2a: true}``). Malformed / missing input returns an empty

--- a/src/reyn/core/op_runtime/web.py
+++ b/src/reyn/core/op_runtime/web.py
@@ -190,9 +190,9 @@ def _resolve_ssl_verify(ctx: OpContext) -> bool | str:
     """Resolve the SSL verify value for httpx from config + env fallback.
 
     Priority (highest → lowest):
-      1. ``web.fetch.ca_bundle`` set in config → returns the CA bundle path (str).
-      2. ``web.fetch.verify_ssl`` set to False → returns False (disable SSL check).
-      3. ``web.fetch.verify_ssl`` set to True  → returns True (force SSL check).
+      1. ``web_fetch.ca_bundle`` set in config → returns the CA bundle path (str).
+      2. ``web_fetch.verify_ssl`` set to False → returns False (disable SSL check).
+      3. ``web_fetch.verify_ssl`` set to True  → returns True (force SSL check).
       4. Both unset (None) → falls through to litellm.get_ssl_verify()
          (= SSL_VERIFY env → litellm.ssl_verify → SSL_CERT_FILE → True).
     """
@@ -277,14 +277,14 @@ async def handle_web_fetch(op: WebFetchIROp, ctx: OpContext) -> dict:
             "kind": "web_fetch", "url": op.url, "status": "too_large",
             "error": (
                 f"response body ({n} bytes) exceeds the {_max_dl}-byte download "
-                f"cap (web.fetch.max_download_bytes)"
+                f"cap (web_fetch.max_download_bytes)"
             ),
         }
 
     _REDIRECT_CODES = (301, 302, 303, 307, 308)
     body = b""
     try:
-        # SSL verification — priority: reyn.yaml web.fetch config → env-var chain.
+        # SSL verification — priority: reyn.yaml web_fetch config → env-var chain.
         # #1956: follow_redirects=False — we follow manually so each hop is gated.
         # #1972/#3075: pin_ssrf=True routes through PinnedAsyncHTTPTransport,
         # which pins each hop's connect to the pre-validated IP
@@ -431,7 +431,7 @@ async def handle_web_fetch(op: WebFetchIROp, ctx: OpContext) -> dict:
     # ``next_start`` in this result, i.e. it told the model "there is more, resume
     # at N" while ``start_index`` was absent from the tool schema (measured: never
     # present, `git log -S` on this file is empty) — the model could not act on it.
-    # Download volume is still bounded, by ``web.fetch.max_download_bytes``, above.
+    # Download volume is still bounded, by ``web_fetch.max_download_bytes``, above.
     total_length = len(content)
 
     ctx.events.emit(

--- a/src/reyn/interfaces/cli/commands/web.py
+++ b/src/reyn/interfaces/cli/commands/web.py
@@ -106,7 +106,7 @@ def register(sub) -> None:
     )
     # FP-0058 P2: per-surface opt-in/opt-out mount toggles. Repeatable
     # per-surface flags (NOT a comma-list) — `--enable a2a --enable mcp`.
-    # Precedence: CLI > `web.surfaces` config > secure-default. Surface
+    # Precedence: CLI > `gateway.surfaces` config > secure-default. Surface
     # names: agui / webui / health / api / resources (secure-default ON),
     # a2a / mcp (secure-default OFF, opt-in). See
     # reyn.interfaces.web.surfaces.build_registry for the authoritative list.
@@ -227,7 +227,7 @@ def run(args: argparse.Namespace) -> None:
     # Explicit WebSocket frame ceiling: previously this relied on uvicorn's
     # implicit ~16 MiB default, which a uvicorn version bump or operator server
     # override could silently drop. Pin it from config (operator-tunable via
-    # web.ws_max_size) so the inbound-frame bound is explicit + version-independent.
+    # gateway.ws_max_size) so the inbound-frame bound is explicit + version-independent.
     from reyn.config import load_config
     _config = load_config()
     _ws_max_size = _config.gateway.ws_max_size
@@ -254,7 +254,7 @@ def _apply_auth_startup(args: argparse.Namespace, config) -> dict:
       - **Loopback TCP**: browser surface; a token is generated (Jupyter-style)
         when none is configured and embedded in the printed launch URL.
       - **Non-loopback TCP**: T3 network. **Fail-closed** — refuses to start
-        without an explicitly configured ``web.auth.token``. Provisions
+        without an explicitly configured ``gateway.auth.token``. Provisions
         self-signed TLS (TOFU) when the operator supplies no certificate and
         prints the fingerprint to pin.
 

--- a/src/reyn/interfaces/web/server.py
+++ b/src/reyn/interfaces/web/server.py
@@ -7,7 +7,7 @@ Every hosted **surface** — AG-UI, the OpenUI web shell (`/`, `/static/*`,
 resource-fetch routes, A2A, MCP — is mounted through the FP-0058 P2
 :mod:`reyn.interfaces.web.surfaces` ``SurfaceSpec`` registry
 (``mount_all``), which resolves each surface's opt-in/opt-out posture
-(CLI ``--enable``/``--disable`` > ``web.surfaces`` config > secure-default)
+(CLI ``--enable``/``--disable`` > ``gateway.surfaces`` config > secure-default)
 before mounting it. See that module for the secure-default table and the
 per-surface mount functions. The webhook plugin surface (FP-0041) is
 mounted separately, unchanged, via its own ``webhooks.yaml`` opt-in.
@@ -387,7 +387,7 @@ def create_app() -> FastAPI:
 
     # Core surfaces (AG-UI / OpenUI web shell / health / REST /api / resources /
     # A2A / MCP): each resolved enabled/disabled (CLI --enable/--disable >
-    # web.surfaces config > secure-default) and mounted via the SAME
+    # gateway.surfaces config > secure-default) and mounted via the SAME
     # mount(app, config) -> APIRouter | None seam the plugin loader above already
     # used — see reyn.interfaces.web.surfaces for the registry, the secure-default
     # table, and the strip-gate falsification note.

--- a/src/reyn/interfaces/web/surfaces.py
+++ b/src/reyn/interfaces/web/surfaces.py
@@ -36,10 +36,10 @@ by this module.
 ``REYN_WEB_ENABLE_SURFACES`` / ``REYN_WEB_DISABLE_SURFACES`` comma-separated
 env vars, mirroring the existing ``REYN_WEB_*`` CLI→server propagation
 pattern used by ``--default-design`` / ``--eager-embedding-build``) beat the
-``web.surfaces.<name>.enabled`` config, which beats the secure-default table
+``gateway.surfaces.<name>.enabled`` config, which beats the secure-default table
 above::
 
-    CLI (--enable/--disable) > web.surfaces config > secure-default
+    CLI (--enable/--disable) > gateway.surfaces config > secure-default
 
 Resolution happens once, at server-module-import time (``mount_all`` is
 called from ``server.py`` at import, matching where the surfaces were

--- a/tests/config/test_4317_web_fetch_allow_private_ips_env_export.py
+++ b/tests/config/test_4317_web_fetch_allow_private_ips_env_export.py
@@ -34,7 +34,14 @@ def test_web_fetch_allow_private_ips_true_exports_the_env_var(
     real loader, sets REYN_FETCH_ALLOW_PRIVATE_IPS so the config-less SSRF-guard
     surfaces (safe.http subprocess / registry main-process modules) see the
     operator's opt-in."""
-    monkeypatch.delenv("REYN_FETCH_ALLOW_PRIVATE_IPS", raising=False)
+    # monkeypatch.setenv (not delenv) — delenv on a var that was never set
+    # records nothing to restore, so load_config()'s raw os.environ[...] = "1"
+    # write below would leak REYN_FETCH_ALLOW_PRIVATE_IPS=1 into every later
+    # test in this worker (caught by lead-coder's review: the SSRF guard's
+    # deny-private default would silently flip to opt-in process-wide).
+    # setenv("") IS tracked for teardown restore and "" is falsy, so the
+    # export block below still fires exactly as if the var were absent.
+    monkeypatch.setenv("REYN_FETCH_ALLOW_PRIVATE_IPS", "")
     (tmp_path / "reyn.yaml").write_text(
         "llm:\n  model: standard\nweb_fetch:\n  allow_private_ips: true\n"
     )
@@ -50,6 +57,11 @@ def test_web_fetch_allow_private_ips_absent_leaves_the_env_var_unset(
     """Tier 2c: the fail-secure default — no `web_fetch.allow_private_ips` in
     yaml, and no pre-set env var, leaves REYN_FETCH_ALLOW_PRIVATE_IPS unset (the
     guard's own deny-private default governs)."""
+    # delenv is fine here (unlike the test above): this config has no
+    # web_fetch.allow_private_ips, so load_config()'s export block never
+    # performs a raw os.environ write — there's nothing for monkeypatch to
+    # fail to track, and using setenv("") instead would pre-seed the var and
+    # break the `is None` assertion below.
     monkeypatch.delenv("REYN_FETCH_ALLOW_PRIVATE_IPS", raising=False)
     (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n")
 

--- a/tests/config/test_4317_web_fetch_allow_private_ips_env_export.py
+++ b/tests/config/test_4317_web_fetch_allow_private_ips_env_export.py
@@ -1,0 +1,72 @@
+"""Tier 2c: `load_config()` exports `REYN_FETCH_ALLOW_PRIVATE_IPS` from the real
+`web_fetch.allow_private_ips` yaml key (#4317).
+
+#4174 T4 split the old `web:` key into top-level `web_fetch:` / `gateway:`
+blocks. `loader.py`'s `REYN_FETCH_ALLOW_PRIVATE_IPS` export (#1956 — the
+config-less SSRF-guard surfaces' only entry point: the `safe.http` subprocess
+and the registry main-process modules) was never updated to the new key name —
+it kept reading `merged.get("web").get("fetch")`, which is always `None` post-T4
+(`web:` is now an unknown key), so the export silently stopped firing. Fail-secure
+(the guard's own deny-private default took over) but "configured yet not
+applied" is its own bug, not a hole.
+
+This pins the REAL loader behavior end to end: write a `web_fetch.allow_private_ips:
+true` yaml, run it through the real `load_config()`, assert the env var comes out
+set. No assertion on the OLD key's non-effect — a deleted key not doing anything
+is not this test's job (six questions § 2: that's self-evident, not a behavior
+this file owns).
+
+Falsify-verified: reverting `loader.py`'s export block to read
+`merged.get("web").get("fetch")` (the pre-fix shape) makes this go RED.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from reyn.config.loader import load_config
+
+
+def test_web_fetch_allow_private_ips_true_exports_the_env_var(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2c: `web_fetch.allow_private_ips: true` in reyn.yaml, through the
+    real loader, sets REYN_FETCH_ALLOW_PRIVATE_IPS so the config-less SSRF-guard
+    surfaces (safe.http subprocess / registry main-process modules) see the
+    operator's opt-in."""
+    monkeypatch.delenv("REYN_FETCH_ALLOW_PRIVATE_IPS", raising=False)
+    (tmp_path / "reyn.yaml").write_text(
+        "llm:\n  model: standard\nweb_fetch:\n  allow_private_ips: true\n"
+    )
+
+    load_config(cwd=tmp_path)
+
+    assert os.environ.get("REYN_FETCH_ALLOW_PRIVATE_IPS") == "1"
+
+
+def test_web_fetch_allow_private_ips_absent_leaves_the_env_var_unset(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2c: the fail-secure default — no `web_fetch.allow_private_ips` in
+    yaml, and no pre-set env var, leaves REYN_FETCH_ALLOW_PRIVATE_IPS unset (the
+    guard's own deny-private default governs)."""
+    monkeypatch.delenv("REYN_FETCH_ALLOW_PRIVATE_IPS", raising=False)
+    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n")
+
+    load_config(cwd=tmp_path)
+
+    assert os.environ.get("REYN_FETCH_ALLOW_PRIVATE_IPS") is None
+
+
+def test_operator_set_env_var_wins_over_config(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2c: an explicit operator-set env var is never overwritten by the
+    config-derived export — the loader only sets the var when it isn't already
+    present."""
+    monkeypatch.setenv("REYN_FETCH_ALLOW_PRIVATE_IPS", "0")
+    (tmp_path / "reyn.yaml").write_text(
+        "llm:\n  model: standard\nweb_fetch:\n  allow_private_ips: true\n"
+    )
+
+    load_config(cwd=tmp_path)
+
+    assert os.environ.get("REYN_FETCH_ALLOW_PRIVATE_IPS") == "0"

--- a/tests/core/test_web_fetch_download_cap_1913.py
+++ b/tests/core/test_web_fetch_download_cap_1913.py
@@ -5,7 +5,7 @@ extracted-text cap applied — so a hostile URL (or a benign one that redirects
 to a huge payload) could exhaust memory. (#3580 ③ later removed web_fetch's
 own extracted-text cap entirely, which makes THIS bound the only size gate on
 the fetch itself.) web_fetch now
-streams with a byte ceiling (`web.fetch.max_download_bytes`), rejecting a
+streams with a byte ceiling (`web_fetch.max_download_bytes`), rejecting a
 response whose `Content-Length` exceeds the cap (early, before download) or
 whose streamed body runs past it (chunked / no Content-Length).
 

--- a/tests/core/test_web_fetch_no_self_truncation_3580.py
+++ b/tests/core/test_web_fetch_no_self_truncation_3580.py
@@ -19,7 +19,7 @@ and 「既存機能があるのに別機構を足すな」 (don't add a second m
 already exists). The surviving ceiling on what a fetch puts into the model's
 context is the OS-level tool-result cap (``offload.enabled``, shipped ``false``),
 which is unchanged by this file. Download volume is still bounded separately by
-``web.fetch.max_download_bytes`` (10 MiB).
+``web_fetch.max_download_bytes`` (10 MiB).
 
 The tests below therefore assert the SEAM, not the absent field: a body far over
 the old cap arrives whole from the handler, and then behaves like any other tool


### PR DESCRIPTION
**[tui-coder]** — #4317 ①③: behavior recovery + comment sweep. ② (`default_design`'s new address) is a separate PR per lead-coder's suggested split — coming next.

## ① Behavior fix

T4 (#4174) split the old `web:` key into top-level `web_fetch:` / `gateway:` blocks. `loader.py`'s `REYN_FETCH_ALLOW_PRIVATE_IPS` export (#1956 — the config-less SSRF-guard surfaces' only entry point: the `safe.http` subprocess and registry main-process modules) was never updated — it kept reading `merged.get("web").get("fetch")`, which is always `None` post-T4 (`web:` is now an unknown key), so the export silently stopped firing. Fail-secure (the guard's own deny-private default took over) but "configured yet not applied" is its own bug.

Fixed: `loader.py` now reads `merged.get("web_fetch")` directly — the same top-level key `_build_web_fetch_config` already reads correctly at `loader.py:831` (that half of T4 was done; only this export block was missed).

## ③ Consumer-sweep completeness

Per the issue's explicit ask, measured completeness first (subagent sweep across ~12 pattern variants: direct/indirect `.get("web")`, `getattr`, dynamic key-building, dotted old-key mentions). Confirmed **no other behavior-affecting stale-key consumer exists anywhere in `src/`** — the only other one is `web_config.py`'s `default_design` read, which needs a new-address decision (② — separate PR).

Swept every remaining comment/docstring/error-string reference to the old `web.fetch.*`/`web.auth`/`web.ws_max_size`/`web.surfaces` key names, ~20 sites: `config/media.py`, `_ssrf_guard.py`, `_http_limits.py`, `api/safe/http.py`, `core/op_runtime/web.py` (including a **user-visible error string**, checked no test pins its exact text), `cli/commands/web.py`, `interfaces/web/surfaces.py`, `interfaces/web/server.py`, and 2 test docstrings.

## Test plan
- [x] New `tests/config/test_4317_web_fetch_allow_private_ips_env_export.py` pins the REAL loader behavior via `load_config()` — 3 cases (config → env set, absent → unset/fail-secure, operator-set env var never overwritten)
- [x] Falsify-verified: reverting `loader.py`'s export to the pre-fix shape makes the primary test go RED
- [x] `ruff check src tests` — clean
- [x] `python scripts/mypy_ratchet.py` — no new findings
- [x] `python scripts/test_tier_audit.py --strict` on the new test file — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — clean
- [x] `pytest tests/config tests/http_safety` + the web_fetch/SSRF-adjacent test files + a `tests/interfaces` web/surfaces slice — 369 passed

part of #4174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

- [x] 🔴 (lead-coder 確認済み: setenv("") へ変更、姉妹テストは delenv のままが正しい) (lead-coder) テスト 1・2 本目の `monkeypatch.delenv(..., raising=False)` を `monkeypatch.setenv("REYN_FETCH_ALLOW_PRIVATE_IPS", "")` に。元々存在しない変数の delenv は復元対象を記録しないので、`load_config()` がセットした `=1` が後続テストに漏れ、同一ワーカーで SSRF ガードの deny-private 既定が opt-in 状態になる（実測済み）。空文字は falsy なので export の発火は変わらない。

