### PR TITLE
fix(#4097): remove 1 dead F401 import in src/reyn/llm

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING, Callable, Coroutine, NamedTuple, TypeVar, Unio
 
 logger = logging.getLogger(__name__)
 from reyn.core.turn_scope import get_active_turn_chain_id
-from reyn.llm.json_parse import loads_lenient
 from reyn.llm.litellm_bootstrap import ensure_litellm_ready
 from reyn.llm.model_resolver import ModelSpec
 from reyn.llm.pricing import TokenUsage, UsageSource, estimate_cost, parse_usage_source


### PR DESCRIPTION
**[tui-coder]** — Eleventh directory in the per-directory F401 rollout (#4097). Was held back pending e2e-coder's #4206 T1 (which touches `llm.py`) — that landed as #4318, confirmed it doesn't touch this file, no other open PR references `llm.py`, so proceeding now.

## Changes
- `llm.py`: unused `loads_lenient` import — genuinely dead in this file specifically (grepped: still correctly used in `services/compaction/engine.py` and its own dedicated test suite, `tests/llm/test_llm_json_loads_lenient.py`).

## Test plan
- [x] `ruff check src/reyn/llm` — clean
- [x] `python scripts/mypy_ratchet.py` — no new findings
- [x] `pytest tests/llm -q` — 736 passed

Part of #4097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)