### PR TITLE
refactor(#4284): extract MINIMAL_REYN_YAML shared fixture constant

### DIFF
--- a/tests/_support/minimal_reyn_yaml.py
+++ b/tests/_support/minimal_reyn_yaml.py
@@ -1,0 +1,28 @@
+"""#4284: the shared minimal-`reyn.yaml` fixture literal.
+
+`llm.model` is the one field `load_config` requires to resolve a usable
+config in most of these tests — every other section is optional. Before
+this, ~60 test files hand-wrote the literal `"llm:\n  model: standard\n"`
+(or the pre-#4174-T3 `"model: standard\n"`) as fixture boilerplate to make
+a `reyn.yaml` non-empty/loadable, with no assertion on the model value
+itself. #4174 T3 (LLM domain -> `llm:` consolidation) had to touch every
+one of those ~60 sites' literal text in the same PR it moved the schema
+field — the next schema rename under `llm:` would do the same rewrite
+again. This constant is the single site a future rename touches instead.
+
+A `write_minimal_reyn_yaml(path)` FUNCTION form was considered and
+rejected: surveying the call sites found the majority write this as a
+standalone `write_text()` call, but a real minority (~15 sites) CONCATENATE
+it with additional YAML content (`MINIMAL_REYN_YAML + "offload:\n  enabled:
+true\n"`) — a plain string constant composes naturally for both shapes; a
+function would need an `extra=` parameter to support the concatenating
+sites, which is more surface for the same job.
+
+NOT for tests that assert on the model value itself (`cfg.llm.model ==
+"standard"` or similar) — those tests are testing the field this fixture
+happens to also satisfy, and moving their literal out from under them
+would make the fixture-vs-subject distinction harder to see, not easier.
+"""
+from __future__ import annotations
+
+MINIMAL_REYN_YAML = "llm:\n  model: standard\n"

--- a/tests/cli/test_agent_list_hides_archived.py
+++ b/tests/cli/test_agent_list_hides_archived.py
@@ -15,6 +15,7 @@ import argparse
 import sys
 from pathlib import Path
 
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 from tests._support.paths import REPO_ROOT
 
 _SRC = REPO_ROOT / "src"
@@ -75,7 +76,7 @@ def test_list_from_a_subdirectory_still_finds_the_project_agents(
     would print the "no agents yet" message (it would look under
     `<subdir>/.reyn/agents/`, which is empty/absent) instead of listing the
     real agent created at the project root."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     reg = AgentRegistry(project_root=tmp_path, session_factory=_no_factory)
     reg.create("alpha", role="coordinator")
 

--- a/tests/config/test_4231_c_disabled_by_dependency_config_keys.py
+++ b/tests/config/test_4231_c_disabled_by_dependency_config_keys.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import pytest
 
 from reyn.config.config_schema import disabled_config_keys
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 # ── the pure primitive ───────────────────────────────────────────────────
 
@@ -112,7 +113,7 @@ def test_validate_reports_the_disabled_key_with_all_four_elements(project, capsy
 
     _write_yaml(
         project / "reyn.yaml",
-        "llm:\n  model: standard\naction_retrieval:\n  universal_wrappers_enabled: true\n",
+        MINIMAL_REYN_YAML + "action_retrieval:\n  universal_wrappers_enabled: true\n",
     )
     _validate()
     out = capsys.readouterr().out
@@ -129,7 +130,7 @@ def test_validate_does_not_flag_universal_category_scheme(project, capsys):
 
     _write_yaml(
         project / "reyn.yaml",
-        "llm:\n  model: standard\n"
+        MINIMAL_REYN_YAML +
         "action_retrieval:\n  universal_wrappers_enabled: true\n"
         "tool_use:\n  scheme: universal-category\n",
     )

--- a/tests/config/test_action_retrieval_config.py
+++ b/tests/config/test_action_retrieval_config.py
@@ -36,6 +36,7 @@ from reyn.config import (
     _build_action_retrieval_config,
     load_config,
 )
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 # ── 1. Default values ─────────────────────────────────────────────────────
 
@@ -209,7 +210,7 @@ def test_load_config_without_action_retrieval_uses_defaults(tmp_path: Path) -> N
     ``universal_wrappers_enabled: false`` in reyn.yaml.
     """
     (tmp_path / "reyn.yaml").write_text(
-        "llm:\n  model: standard\n",
+        MINIMAL_REYN_YAML,
         encoding="utf-8",
     )
 
@@ -254,7 +255,7 @@ def test_load_config_hot_list_n_explicit_opt_in(tmp_path: Path) -> None:
     """Tier 2: N=0 default flip — explicit hot_list_n: 10 in reyn.yaml enables
     the hot-list (symmetric pin: default off, explicit on)."""
     (tmp_path / "reyn.yaml").write_text(
-        "llm:\n  model: standard\naction_retrieval:\n  hot_list_n: 10\n",
+        MINIMAL_REYN_YAML + "action_retrieval:\n  hot_list_n: 10\n",
         encoding="utf-8",
     )
     cfg = load_config(cwd=tmp_path)
@@ -263,6 +264,6 @@ def test_load_config_hot_list_n_explicit_opt_in(tmp_path: Path) -> None:
 
 def test_load_config_hot_list_n_default_is_zero(tmp_path: Path) -> None:
     """Tier 2: N=0 default flip — bare reyn.yaml with no hot_list_n gives 0."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     cfg = load_config(cwd=tmp_path)
     assert cfg.action_retrieval.hot_list_n == 0

--- a/tests/config/test_config_mcp_merge_1146.py
+++ b/tests/config/test_config_mcp_merge_1146.py
@@ -23,10 +23,11 @@ import os
 from pathlib import Path
 
 from reyn.config import load_config
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 def _root(tmp_path: Path) -> Path:
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     return tmp_path
 
 
@@ -72,7 +73,7 @@ def test_mcp_servers_union_preserved_across_layers(tmp_path: Path) -> None:
     """
     root = tmp_path
     (root / "reyn.yaml").write_text(
-        "llm:\n  model: standard\n"
+        MINIMAL_REYN_YAML +
         "mcp:\n  search_threshold: 5\n  servers:\n    alpha:\n      type: stdio\n      command: a\n",
         encoding="utf-8",
     )

--- a/tests/config/test_fp0009_b_cron_config.py
+++ b/tests/config/test_fp0009_b_cron_config.py
@@ -21,6 +21,7 @@ from reyn.config import (
     _build_cron_config,
     load_config,
 )
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 # ── 1. CronJobConfig — direct construction ──────────────────────────────────
 
@@ -66,7 +67,7 @@ def test_cron_config_default_empty() -> None:
 
 def test_no_cron_block_gives_empty_jobs(tmp_path: Path) -> None:
     """Tier 1: reyn.yaml with no cron: block → ReynConfig.cron.jobs == []."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     cfg = load_config(cwd=tmp_path)
     assert cfg.cron.jobs == []
 
@@ -194,7 +195,7 @@ cron:
 
 def test_empty_cron_block_gives_empty_jobs(tmp_path: Path) -> None:
     """Tier 1: empty cron: block (no jobs key) → CronConfig(jobs=[])."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\ncron: {}\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML + "cron: {}\n", encoding="utf-8")
     cfg = load_config(cwd=tmp_path)
     assert cfg.cron.jobs == []
 

--- a/tests/config/test_web_auth_config_contract.py
+++ b/tests/config/test_web_auth_config_contract.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
 
 def _load(tmp_path: Path, yaml: str, monkeypatch):
     (tmp_path / "reyn.yaml").write_text(yaml, encoding="utf-8")
@@ -31,7 +33,7 @@ def test_gateway_auth_non_default_values_round_trip(tmp_path, monkeypatch):
     cfg = _load(
         tmp_path,
         (
-            "llm:\n  model: standard\n"
+            MINIMAL_REYN_YAML +
             "gateway:\n"
             "  auth:\n"
             "    token: my-secret-token\n"
@@ -50,7 +52,7 @@ def test_gateway_auth_non_default_values_round_trip(tmp_path, monkeypatch):
 
 def test_gateway_auth_defaults_are_secure(tmp_path, monkeypatch):
     """Tier 1: a missing gateway.auth section defaults to no token + loopback token required."""
-    cfg = _load(tmp_path, "llm:\n  model: standard\n", monkeypatch)
+    cfg = _load(tmp_path, MINIMAL_REYN_YAML, monkeypatch)
     auth = cfg.gateway.auth
     assert auth.token is None
     assert auth.require_token_on_loopback is True
@@ -63,7 +65,7 @@ def test_require_token_on_loopback_truthy_strings(tmp_path, monkeypatch, value):
     """Tier 1: an interpolated truthy string for require_token_on_loopback parses True."""
     cfg = _load(
         tmp_path,
-        f"llm:\n  model: standard\ngateway:\n  auth:\n    require_token_on_loopback: '{value}'\n",
+        MINIMAL_REYN_YAML + f"gateway:\n  auth:\n    require_token_on_loopback: '{value}'\n",
         monkeypatch,
     )
     assert cfg.gateway.auth.require_token_on_loopback is True

--- a/tests/core/test_2575_pipeline_disk_registration.py
+++ b/tests/core/test_2575_pipeline_disk_registration.py
@@ -42,6 +42,8 @@ from typing import Any
 
 import pytest
 
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
 
 def _read_events_of_kind(events_dir: Path, kind: str) -> list[dict]:
     """Read every JSONL event of *kind* from anywhere under *events_dir*.
@@ -335,7 +337,7 @@ def test_from_config_builds_populated_registry_from_project_root(tmp_path: Path)
 
     _write(tmp_path / "pipelines", "hello.yaml", _HELLO_DSL)
     (tmp_path / "reyn.yaml").write_text(
-        "llm:\n  model: standard\npipelines:\n  entries:\n    hello:\n      path: pipelines/hello.yaml\n",
+        MINIMAL_REYN_YAML + "pipelines:\n  entries:\n    hello:\n      path: pipelines/hello.yaml\n",
         encoding="utf-8",
     )
     config = load_config(tmp_path)
@@ -372,7 +374,7 @@ def test_from_config_without_project_root_is_empty(tmp_path: Path, monkeypatch) 
 
     _write(tmp_path / "pipelines", "hello.yaml", _HELLO_DSL)
     (tmp_path / "reyn.yaml").write_text(
-        "llm:\n  model: standard\npipelines:\n  entries:\n    hello:\n      path: pipelines/hello.yaml\n",
+        MINIMAL_REYN_YAML + "pipelines:\n  entries:\n    hello:\n      path: pipelines/hello.yaml\n",
         encoding="utf-8",
     )
     monkeypatch.chdir(tmp_path)

--- a/tests/core/test_2581_pipeline_hotreload.py
+++ b/tests/core/test_2581_pipeline_hotreload.py
@@ -43,6 +43,7 @@ from reyn.runtime.services.pipeline_executor_driver import PipelineExecutorDrive
 from reyn.runtime.session import Session
 from reyn.runtime.session_params import PresentationWiring
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -57,7 +58,7 @@ def _make_session(tmp_path: Path, *, agent_name: str = "test-agent") -> Session:
     production build-once path. A bare ``model: standard`` reyn.yaml (no
     ``pipelines:`` block) is also valid and yields an empty registry."""
     if not (tmp_path / "reyn.yaml").exists():
-        (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+        (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     from reyn.config.loader import load_config
     from reyn.data.pipelines.registry import build_pipeline_registry
     cfg = load_config(tmp_path)
@@ -164,7 +165,7 @@ async def test_hotreload_changes_pipeline_description_on_live_registry(
 @pytest.mark.asyncio
 async def test_hotreload_seam_registered(tmp_path: Path) -> None:
     """Tier 2: the Session registers the pipelines seam on the HotReloader."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     session = make_session(
         agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
         snapshot_path=tmp_path / "snap.json",

--- a/tests/core/test_2761_pr2_hotreload_immediate_apply.py
+++ b/tests/core/test_2761_pr2_hotreload_immediate_apply.py
@@ -48,6 +48,7 @@ from reyn.runtime.session_params import CapabilityScope
 from reyn.security.permissions.permissions import PermissionDecl
 from tests._support.agent_session import make_session
 from tests._support.events import collect_events
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -72,7 +73,7 @@ def _make_session(tmp_path: Path, *, agent_name: str = "pr2-agent") -> Session:
     """Minimal real Session rooted at *tmp_path* (chdir before calling). Builds
     ``available_skills`` + ``pipeline_registry`` from ``load_config`` so entries already
     written to ``.reyn/config/*.yaml`` are adopted — mirroring session-factory."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     from reyn.config.loader import load_config
     from reyn.data.pipelines.registry import build_pipeline_registry
     from reyn.data.skills.registry import build_skill_registry

--- a/tests/core/test_2761_pr3_mcp_immediate_probe.py
+++ b/tests/core/test_2761_pr3_mcp_immediate_probe.py
@@ -48,6 +48,7 @@ from reyn.security.permissions.permissions import PermissionDecl
 from reyn.tools.mcp_verbs import _handle_mcp_install_local
 from reyn.tools.types import RouterCallerState, ToolContext
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 from tests._support.paths import REPO_ROOT
 
 _PID_SERVER = REPO_ROOT / "tests" / "_support" / "mcp_tools_only_pid_server.py"
@@ -101,7 +102,7 @@ def _Ctx(root: Path, rs: "RouterCallerState | None") -> ToolContext:
 
 
 def _session(tmp: Path) -> Session:
-    (tmp / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     return make_session(
         agent_name="mcp-pr3",
         state_log=StateLog(tmp / "s.wal"),

--- a/tests/core/test_config_separation_mcp_yaml.py
+++ b/tests/core/test_config_separation_mcp_yaml.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
 
 def _write_yaml(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -37,7 +39,7 @@ def test_load_config_reads_dynamic_mcp_yaml(tmp_path, monkeypatch):
     from reyn.config import load_config
 
     # Plant a reyn.yaml so _find_project_root finds tmp_path.
-    _write_yaml(tmp_path / "reyn.yaml", "llm:\n  model: standard\n")
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)
     _write_yaml(
         tmp_path / ".reyn" / "config" / "mcp.yaml",
         "mcp:\n  servers:\n    sqlite:\n      type: stdio\n      command: npx\n",
@@ -63,7 +65,7 @@ def test_load_config_dynamic_mcp_yaml_overrides_reyn_yaml(tmp_path, monkeypatch)
 
     _write_yaml(
         tmp_path / "reyn.yaml",
-        "llm:\n  model: standard\n"
+        MINIMAL_REYN_YAML +
         "mcp:\n  servers:\n    git:\n      type: stdio\n      command: old-cmd\n",
     )
     _write_yaml(
@@ -89,7 +91,7 @@ def test_load_config_dynamic_mcp_yaml_and_reyn_yaml_servers_union(
 
     _write_yaml(
         tmp_path / "reyn.yaml",
-        "llm:\n  model: standard\n"
+        MINIMAL_REYN_YAML +
         "mcp:\n  servers:\n    legacy:\n      type: stdio\n      command: legacy-cmd\n",
     )
     _write_yaml(
@@ -116,7 +118,7 @@ def test_load_config_works_without_dynamic_mcp_yaml(tmp_path, monkeypatch):
 
     _write_yaml(
         tmp_path / "reyn.yaml",
-        "llm:\n  model: standard\n"
+        MINIMAL_REYN_YAML +
         "mcp:\n  servers:\n    only-in-reyn:\n      type: stdio\n      command: x\n",
     )
 

--- a/tests/core/test_fp0066_p1a_embedding_enabled_gate.py
+++ b/tests/core/test_fp0066_p1a_embedding_enabled_gate.py
@@ -38,6 +38,7 @@ from reyn.tools.universal_catalog import (
     SEARCH_ACTIONS,
     is_search_available,
 )
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 def _run(coro):
@@ -257,7 +258,7 @@ def test_bare_mcp_search_threshold_key_is_ignored_not_erroring(tmp_path) -> None
     from reyn.config import load_config
 
     (tmp_path / "reyn.yaml").write_text(
-        "llm:\n  model: standard\nmcp:\n  search_threshold: 5\n", encoding="utf-8",
+        MINIMAL_REYN_YAML + "mcp:\n  search_threshold: 5\n", encoding="utf-8",
     )
     cfg = load_config(cwd=tmp_path)
     # No derived field reads it anymore; it just survives in the raw dict.

--- a/tests/core/test_mcp_hot_reload_2372.py
+++ b/tests/core/test_mcp_hot_reload_2372.py
@@ -21,12 +21,13 @@ import yaml
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 def _session(tmp_path: Path) -> Session:
     # load_config resolves the project root by walking up for reyn.yaml (the marker gating the
     # dynamic .reyn/config/mcp.yaml read); a Reyn project always has one.
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     s = make_session(
         agent_name="alice", state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",

--- a/tests/core/test_mcp_install_ux_fixes_318_319_320.py
+++ b/tests/core/test_mcp_install_ux_fixes_318_319_320.py
@@ -42,6 +42,7 @@ from reyn.core.registry.source_resolver import (
     _strip_mcp_prefix,
     resolve,
 )
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 # ── #318: type: stdio in every install ────────────────────────────────
 
@@ -213,7 +214,7 @@ def test_install_command_warns_on_tmp_args_on_darwin(tmp_path, reyn_console_scri
     # #1442: install now resolves a project root and fails loud outside one
     # (error-not-silent-cwd), so give tmp_path a reyn.yaml — the #320 /tmp-args
     # warning fires inside the source install, past project resolution.
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     result = subprocess.run(
         [
             reyn_bin, "mcp", "install",

--- a/tests/core/test_mcp_install_workspace_1442.py
+++ b/tests/core/test_mcp_install_workspace_1442.py
@@ -32,13 +32,14 @@ from reyn.tools.mcp_verbs import (
     _handle_mcp_install_registry,
 )
 from reyn.tools.types import RouterCallerState, ToolContext
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 # ── Layer A: --project + resolve-once + fail-loud ───────────────────────────
 
 
 def test_resolve_project_root_from_explicit_project(tmp_path):
     """Tier 2: #1442 A — --project resolves to that root (not cwd)."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     assert _resolve_install_project_root(str(tmp_path)) == tmp_path.resolve()
 
 

--- a/tests/core/test_offload_config_gate_pr3.py
+++ b/tests/core/test_offload_config_gate_pr3.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from reyn.config import CompactionConfig, OffloadConfig, _build_offload_config
 from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
 from reyn.runtime.services.context_budget_advisor import ContextBudgetAdvisor
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 def _write_yaml(path: Path, content: str) -> None:
@@ -61,7 +62,7 @@ def test_load_config_reads_offload_enabled_true(tmp_path):
 
     _write_yaml(
         tmp_path / "reyn.yaml",
-        "llm:\n  model: standard\noffload:\n  enabled: true\n",
+        MINIMAL_REYN_YAML + "offload:\n  enabled: true\n",
     )
     config = load_config(cwd=tmp_path)
     assert config.offload.enabled is True

--- a/tests/core/test_present_registry_fp0054_prc.py
+++ b/tests/core/test_present_registry_fp0054_prc.py
@@ -36,6 +36,7 @@ from reyn.schemas.models import ALL_OP_KINDS, PresentIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 from tests._support.agent_session import make_session
 from tests._support.events import collect_events
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 # A named template (operator config) whose value is a blueprint — the same
 # declarative component tree an inline blueprint is.
@@ -123,7 +124,7 @@ def test_config_roundtrip_named_template_reaches_registry(tmp_path: Path) -> Non
     NON-default blueprint value) is loaded through the full config cascade + built
     into the registry under its entry name, with the blueprint structurally
     validated (mirrors the skills/pipelines disk round-trip)."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     cfg_dir = tmp_path / ".reyn" / "config"
     cfg_dir.mkdir(parents=True)
     (cfg_dir / "presentations.yaml").write_text(
@@ -355,7 +356,7 @@ def _make_session(tmp_path: Path) -> Session:
     """Minimal real Session whose presentation registry is built from the current
     config cascade (mirrors SessionFactoryConfig.from_config's build-once path)."""
     if not (tmp_path / "reyn.yaml").exists():
-        (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+        (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     cfg = load_config(tmp_path)
     return make_session(
         agent_name="prc-test",

--- a/tests/core/test_render_template_bounds_config_2679.py
+++ b/tests/core/test_render_template_bounds_config_2679.py
@@ -34,6 +34,7 @@ from reyn.config.loader import load_config
 from reyn.core.op_runtime.render_template import handle
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 class _RenderOp:
@@ -67,7 +68,7 @@ def test_operator_yaml_bounds_cap_the_op_through_a_real_session(tmp_path: Path) 
     regression is now caught.
     """
     (tmp_path / "reyn.yaml").write_text(
-        "llm:\n  model: standard\n"
+        MINIMAL_REYN_YAML +
         "render_template:\n"
         "  max_output_chars: 20\n"
         "  wall_clock_seconds: 1.5\n"

--- a/tests/core/test_web_fetch_config_session_wiring_4274.py
+++ b/tests/core/test_web_fetch_config_session_wiring_4274.py
@@ -54,6 +54,7 @@ from reyn.config.loader import load_config
 from reyn.core.op_runtime.web import handle_web_fetch
 from reyn.schemas.models import WebFetchIROp
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 _BODY = b"X" * 1000  # well over a 5-byte cap, well under the 10 MiB default
 
@@ -83,7 +84,7 @@ def test_tight_max_download_bytes_reaches_the_op_through_both_builders(
     1000-byte response (default cap is 10 MiB — this response would pass
     uncapped)."""
     (tmp_path / "reyn.yaml").write_text(
-        "llm:\n  model: standard\nweb_fetch:\n  max_download_bytes: 5\n"
+        MINIMAL_REYN_YAML + "web_fetch:\n  max_download_bytes: 5\n"
     )
 
     cfg = load_config(cwd=tmp_path)
@@ -126,7 +127,7 @@ def test_default_config_leaves_the_response_uncapped_through_a_real_session(
     default (10 MiB), so the same 1000-byte response is NOT capped through
     either builder — the operator config is opt-in, default behaviour
     unchanged by #4274's wiring."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML)
 
     cfg = load_config(cwd=tmp_path)
     assert cfg.web_fetch == WebFetchConfig()

--- a/tests/interfaces/test_3595_s5_session_does_not_interpret_text.py
+++ b/tests/interfaces/test_3595_s5_session_does_not_interpret_text.py
@@ -39,6 +39,7 @@ from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 from reyn.runtime.turn_origin import TurnOrigin
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 from tests._support.paths import REPO_ROOT
 from tests._support.slash import RecordingTransport, drain_display, local_transport
 
@@ -232,7 +233,7 @@ def _one_session_registry(tmp_path, monkeypatch) -> "tuple[AgentRegistry, Sessio
     that would run it, which is what lets both legs assert on a real effect."""
     monkeypatch.chdir(tmp_path)
     state_log = StateLog(tmp_path / "state.wal")
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     holder: dict = {}
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None):

--- a/tests/interfaces/test_4235_validate_in_set.py
+++ b/tests/interfaces/test_4235_validate_in_set.py
@@ -17,6 +17,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
 
 def _write_yaml(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -42,7 +44,7 @@ def test_an_unknown_in_set_key_is_reported_in_its_own_labeled_section(
     same top-level dict) is reported under the IN-SET section, separately
     from the policy-tier section, with IN-set-specific remedy text (no
     restart, no 'reyn config migrate' mention)."""
-    _write_yaml(project / "reyn.yaml", "llm:\n  model: standard\n")
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
     _write_yaml(
         project / ".reyn" / "config" / "hooks.yaml",
         "totally_bogus_in_set_key: 1\n",
@@ -103,7 +105,7 @@ def test_a_well_formed_in_set_produces_no_findings(project, capsys):
     """Tier 2: accept-side — real, valid IN-set files touching several
     registries never trip the new section (a false positive here would
     teach operators to ignore the report, the same #4174 T0 concern)."""
-    _write_yaml(project / "reyn.yaml", "llm:\n  model: standard\n")
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
     _write_yaml(
         project / ".reyn" / "config" / "mcp.yaml",
         "mcp:\n  servers: {}\n",

--- a/tests/interfaces/test_config_migrate_mcp_command.py
+++ b/tests/interfaces/test_config_migrate_mcp_command.py
@@ -27,6 +27,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
 
 def _write_yaml(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -64,7 +66,7 @@ def test_migrate_no_legacy_entries_is_noop(project, capsys):
     """Tier 2: no ``mcp.servers`` anywhere → command prints "nothing to
     migrate" and doesn't write any files.
     """
-    _write_yaml(project / "reyn.yaml", "llm:\n  model: standard\n")
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
 
     _run_migrate()
 
@@ -113,8 +115,8 @@ def test_migrate_moves_from_both_reyn_yaml_and_local(project, capsys):
     """
     _write_yaml(
         project / "reyn.yaml",
-        "llm:\n  model: standard\n"
-        "mcp:\n  servers:\n    sqlite:\n      type: stdio\n      command: npx\n",
+        MINIMAL_REYN_YAML
+        + "mcp:\n  servers:\n    sqlite:\n      type: stdio\n      command: npx\n",
     )
     _write_yaml(
         project / "reyn.local.yaml",
@@ -172,8 +174,8 @@ def test_migrate_dry_run_does_not_write_files(project, capsys):
     """
     _write_yaml(
         project / "reyn.yaml",
-        "llm:\n  model: standard\n"
-        "mcp:\n  servers:\n    sqlite:\n      type: stdio\n      command: npx\n",
+        MINIMAL_REYN_YAML
+        + "mcp:\n  servers:\n    sqlite:\n      type: stdio\n      command: npx\n",
     )
 
     _run_migrate(dry_run=True)

--- a/tests/interfaces/test_config_schema_enforcement_1056.py
+++ b/tests/interfaces/test_config_schema_enforcement_1056.py
@@ -44,6 +44,7 @@ from reyn.config.config_schema import (
     resolve_config_value,
     walk_config_schema,
 )
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 # Fields that silently COERCE an invalid value back to their default (rather
 # than raising a validation error), so a generic "<default>_nd" candidate can't
@@ -102,7 +103,7 @@ _MIGRATED_DESC_KEYS = (
 
 def _project_root(tmp_path: Path) -> Path:
     """Create a minimal reyn.yaml so _find_project_root / load_config succeed."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     return tmp_path
 
 
@@ -149,7 +150,7 @@ def test_every_scalar_leaf_takes_effect_on_nondefault_set(tmp_path: Path) -> Non
                 continue
             root = tmp_path / f"leaf{i}"
             root.mkdir()
-            (root / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+            (root / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
             os.chdir(root)
             _set(node.key, yaml.safe_dump(cand, default_flow_style=True).strip())
             try:

--- a/tests/interfaces/test_config_schema_introspection.py
+++ b/tests/interfaces/test_config_schema_introspection.py
@@ -26,6 +26,7 @@ from reyn.config.config_schema import (
     resolve_config_value,
     walk_config_schema,
 )
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 # ---------------------------------------------------------------------------
 # Helper: write a minimal reyn.yaml so load_config() has a project root
@@ -33,7 +34,7 @@ from reyn.config.config_schema import (
 
 def _project_root(tmp_path: Path) -> Path:
     """Create a minimal reyn.yaml so _find_project_root succeeds."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     return tmp_path
 
 

--- a/tests/interfaces/test_config_validate_migrate_command_4174.py
+++ b/tests/interfaces/test_config_validate_migrate_command_4174.py
@@ -15,6 +15,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
 
 def _write_yaml(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -46,7 +48,7 @@ def test_validate_reports_no_findings_on_a_well_formed_config(project, capsys):
     category (a well-formed config trips neither)."""
     from reyn.interfaces.cli.commands.config import _validate
 
-    _write_yaml(project / "reyn.yaml", "llm:\n  model: standard\nsandbox:\n  mode: strict\n")
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML + "sandbox:\n  mode: strict\n")
     _validate()
     out = capsys.readouterr().out
     assert "No unknown, renamed, or disabled-by-dependency config keys found." in out
@@ -72,7 +74,7 @@ def test_validate_reports_llm_model_as_known_not_flagged(project, capsys):
     `model` field, so the SAME input must now report clean."""
     from reyn.interfaces.cli.commands.config import _validate
 
-    _write_yaml(project / "reyn.yaml", "llm:\n  model: standard\n")
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
     _validate()
     out = capsys.readouterr().out
     assert "llm.model" not in out
@@ -114,7 +116,7 @@ def test_migrate_reports_nothing_to_migrate_when_registry_is_empty(
     from reyn.interfaces.cli.commands.config import _migrate
 
     monkeypatch.setattr("reyn.config.config_schema._RENAMED_CONFIG_KEYS", {})
-    _write_yaml(project / "reyn.yaml", "llm:\n  model: standard\n")
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
     _migrate()
     out = capsys.readouterr().out
     assert "No config key renames are registered yet" in out
@@ -136,7 +138,7 @@ def test_migrate_reports_nothing_to_migrate_when_config_has_no_renamed_key(
             note="moved to new_top_level_key", destination="new_top_level_key",
         )},
     )
-    _write_yaml(project / "reyn.yaml", "llm:\n  model: standard\n")
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
     _migrate()
     out = capsys.readouterr().out
     assert "nothing to migrate" in out.lower()
@@ -155,7 +157,7 @@ def test_migrate_rewrites_an_unambiguous_plain_rename(project, capsys, monkeypat
             note="moved to new.nested.key", destination="new.nested.key",
         )},
     )
-    _write_yaml(project / "reyn.yaml", "llm:\n  model: standard\nold_flat_key: hello\n")
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML + "old_flat_key: hello\n")
 
     from reyn.interfaces.cli.commands.config import _migrate
     _migrate()

--- a/tests/interfaces/test_dogfood_base_dir_cwd_4204.py
+++ b/tests/interfaces/test_dogfood_base_dir_cwd_4204.py
@@ -21,6 +21,7 @@ from reyn.interfaces.cli.commands.dogfood import (
     _dogfood_base_dir,
     _runs_dir,
 )
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 def test_base_dir_resolves_to_project_root_from_a_subdirectory(
@@ -29,7 +30,7 @@ def test_base_dir_resolves_to_project_root_from_a_subdirectory(
     """Tier 2: launched from a subdirectory, the dogfood storage dir still
     anchors on the project root (the `reyn.yaml` ancestor), not the
     subdirectory."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     subdir = tmp_path / "src" / "nested"
     subdir.mkdir(parents=True)
     monkeypatch.chdir(subdir)
@@ -44,7 +45,7 @@ def test_runs_and_baselines_dirs_share_the_same_fix(
     """Tier 2: both derived dirs delegate to _dogfood_base_dir(), so they
     inherit the fix — a real witness that the delegation wasn't
     shadowed/duplicated somewhere."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     subdir = tmp_path / "src" / "nested"
     subdir.mkdir(parents=True)
     monkeypatch.chdir(subdir)

--- a/tests/interfaces/test_events_purge_cwd_4204.py
+++ b/tests/interfaces/test_events_purge_cwd_4204.py
@@ -20,6 +20,7 @@ import argparse
 from pathlib import Path
 
 from reyn.interfaces.cli.commands.events import run_purge
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 def _write_event_file(events_dir: Path, date_str: str) -> Path:
@@ -57,7 +58,7 @@ def test_purge_from_a_subdirectory_still_reaches_the_project_events(
     prints "No events directory at <phantom path>" and the real
     `old_file` survives untouched — the exact silent-no-op architect
     named."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     events_dir = tmp_path / ".reyn" / "events"
     old_file = _write_event_file(events_dir, "2026-01-01")
     new_file = _write_event_file(events_dir, "2026-06-01")

--- a/tests/interfaces/test_fp0009_b_web_lifespan.py
+++ b/tests/interfaces/test_fp0009_b_web_lifespan.py
@@ -23,6 +23,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
 # Skip entire module if fastapi / httpx are not installed (same guard as
 # the other web tests).
 pytest.importorskip("fastapi", reason="fastapi not installed ([web] extra missing)")
@@ -65,7 +67,7 @@ def _make_bare_app():
 @pytest.mark.asyncio
 async def test_no_cron_block_scheduler_is_none(tmp_path, monkeypatch):
     """Tier 2: lifespan sets cron_scheduler=None when reyn.yaml has no cron: block."""
-    _write_reyn_yaml(tmp_path, "llm:\n  model: standard\n")
+    _write_reyn_yaml(tmp_path, MINIMAL_REYN_YAML)
     monkeypatch.chdir(tmp_path)
 
     app = _make_bare_app()
@@ -84,7 +86,7 @@ async def test_empty_cron_jobs_scheduler_is_none(tmp_path, monkeypatch):
     """Tier 2: lifespan sets cron_scheduler=None when cron.jobs is empty."""
     _write_reyn_yaml(
         tmp_path,
-        "llm:\n  model: standard\ncron:\n  jobs: []\n",
+        MINIMAL_REYN_YAML + "cron:\n  jobs: []\n",
     )
     monkeypatch.chdir(tmp_path)
 
@@ -105,7 +107,7 @@ async def test_all_jobs_disabled_scheduler_is_none(tmp_path, monkeypatch):
     _write_reyn_yaml(
         tmp_path,
         (
-            "llm:\n  model: standard\n"
+            MINIMAL_REYN_YAML +
             "cron:\n"
             "  jobs:\n"
             "    - name: nightly_disabled\n"
@@ -135,7 +137,7 @@ async def test_enabled_job_scheduler_is_cron_scheduler_instance(tmp_path, monkey
     _write_reyn_yaml(
         tmp_path,
         (
-            "llm:\n  model: standard\n"
+            MINIMAL_REYN_YAML +
             "cron:\n"
             "  jobs:\n"
             "    - name: far_future_job\n"
@@ -188,7 +190,7 @@ async def test_shutdown_stops_scheduler(tmp_path, monkeypatch):
     _write_reyn_yaml(
         tmp_path,
         (
-            "llm:\n  model: standard\n"
+            MINIMAL_REYN_YAML +
             "cron:\n"
             "  jobs:\n"
             "    - name: stop_test_job\n"
@@ -234,7 +236,7 @@ async def test_run_registry_is_set_in_lifespan(tmp_path, monkeypatch):
     """Tier 2: lifespan sets app.state.run_registry (FP-0001 not regressed by move)."""
     from reyn.interfaces.web.run_registry import RunRegistry
 
-    _write_reyn_yaml(tmp_path, "llm:\n  model: standard\n")
+    _write_reyn_yaml(tmp_path, MINIMAL_REYN_YAML)
     monkeypatch.chdir(tmp_path)
 
     app = _make_bare_app()
@@ -270,7 +272,7 @@ async def test_malformed_cron_schedule_does_not_prevent_boot(tmp_path, monkeypat
     _write_reyn_yaml(
         tmp_path,
         (
-            "llm:\n  model: standard\n"
+            MINIMAL_REYN_YAML +
             "cron:\n"
             "  jobs:\n"
             "    - name: bad_job\n"

--- a/tests/interfaces/test_litellm_api_base_load_config_seam_2683.py
+++ b/tests/interfaces/test_litellm_api_base_load_config_seam_2683.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from reyn.interfaces.cli.invocation_context import InvocationContext
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 _KEY = "LITELLM_API_BASE"
 
@@ -70,7 +71,7 @@ def test_absent_api_base_leaves_env_unset() -> None:
     """Tier 2: no api_base configured → the seam leaves LITELLM_API_BASE unset."""
     with TemporaryDirectory() as td:
         project = Path(td)
-        (project / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+        (project / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
         with _clean_env_and_cwd(project):
             ctx = InvocationContext.from_args(argparse.Namespace())
             assert not ctx.config.llm.api_base

--- a/tests/interfaces/test_memory_cli_project_root_3716.py
+++ b/tests/interfaces/test_memory_cli_project_root_3716.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 from reyn.data.memory.memory_paths import memory_dir
 from reyn.interfaces.cli.commands.memory import _layer_dir, _project_reyn_root
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 def test_memory_dir_respects_an_explicit_root():
@@ -47,7 +48,7 @@ def test_project_reyn_root_walks_up_to_the_real_project_root(tmp_path, monkeypat
     not fabricate one under the subdirectory."""
     project_root = tmp_path / "my-project"
     (project_root / "src" / "deep" / "subdir").mkdir(parents=True)
-    (project_root / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (project_root / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     monkeypatch.chdir(project_root / "src" / "deep" / "subdir")
 
     assert _project_reyn_root() == project_root / ".reyn"
@@ -61,7 +62,7 @@ def test_layer_dir_uses_the_project_root_not_raw_cwd(tmp_path, monkeypatch):
     project_root = tmp_path / "my-project"
     subdir = project_root / "some" / "nested" / "cwd"
     subdir.mkdir(parents=True)
-    (project_root / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (project_root / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     monkeypatch.chdir(subdir)
 
     args = argparse.Namespace(agent=None)

--- a/tests/interfaces/test_reyn_embeddings_cli.py
+++ b/tests/interfaces/test_reyn_embeddings_cli.py
@@ -51,6 +51,7 @@ from reyn.interfaces.cli.commands.embeddings import (
     run_rebuild,
     run_status,
 )
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 def _unified_index_dir(project_root: Path) -> Path:
@@ -171,7 +172,7 @@ def test_status_from_a_subdirectory_still_reads_the_project_index(
     real ``run_status`` CLI dispatch (not the pure ``_collect_status_rows``
     helper other tests here call directly), so it exercises the actual
     defect site."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     _write_index_db(
         _unified_index_dir(tmp_path),
         class_name="light",

--- a/tests/interfaces/test_web_auth_lifespan_wiring.py
+++ b/tests/interfaces/test_web_auth_lifespan_wiring.py
@@ -15,6 +15,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
 pytest.importorskip("fastapi", reason="fastapi not installed ([web] extra missing)")
 
 from fastapi import FastAPI  # noqa: E402
@@ -32,7 +34,7 @@ async def test_lifespan_builds_auth_context_from_configured_token(tmp_path, monk
     monkeypatch.delenv(TOKEN_ENV_VAR, raising=False)
     _write_reyn_yaml(
         tmp_path,
-        "llm:\n  model: standard\ngateway:\n  auth:\n    token: operator-configured-secret\n",
+        MINIMAL_REYN_YAML + "gateway:\n  auth:\n    token: operator-configured-secret\n",
     )
     monkeypatch.chdir(tmp_path)
 
@@ -54,7 +56,7 @@ async def test_lifespan_generates_token_when_none_configured(tmp_path, monkeypat
     unauthenticated instead of gated).
     """
     monkeypatch.delenv(TOKEN_ENV_VAR, raising=False)
-    _write_reyn_yaml(tmp_path, "llm:\n  model: standard\n")
+    _write_reyn_yaml(tmp_path, MINIMAL_REYN_YAML)
     monkeypatch.chdir(tmp_path)
 
     from reyn.interfaces.web.server import _lifespan

--- a/tests/interfaces/test_web_run_dir_cwd_4204.py
+++ b/tests/interfaces/test_web_run_dir_cwd_4204.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from reyn.config.media import AuthConfig, GatewayConfig
 from reyn.config.root import ReynConfig
 from reyn.interfaces.cli.commands.web import _apply_auth_startup
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 def test_uds_run_dir_created_at_the_project_root_from_a_subdirectory(
@@ -31,7 +32,7 @@ def test_uds_run_dir_created_at_the_project_root_from_a_subdirectory(
     UDS mode is the minimal path to isolate this (no token generation, no
     TLS provisioning branch to also stand up) — `_apply_auth_startup`
     returns early right after `run_dir.mkdir()` for a UDS bind."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     subdir = tmp_path / "src" / "nested"
     subdir.mkdir(parents=True)
     monkeypatch.chdir(subdir)

--- a/tests/interfaces/test_web_scoped_capabilities_1401.py
+++ b/tests/interfaces/test_web_scoped_capabilities_1401.py
@@ -42,6 +42,7 @@ from reyn.interfaces.web.deps import (
 )
 from reyn.security.permissions.permissions import PermissionDecl
 from reyn.security.sandbox.policy import SandboxPolicy
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 from tests._support.paths import REPO_ROOT
 
 _SRC = REPO_ROOT / "src" / "reyn"
@@ -162,7 +163,7 @@ def test_factory_threads_holder_to_build_scoped_chat_session():
 
 
 def _write_reyn_yaml(tmp_path: Path, *, permissions: dict | None = None) -> None:
-    lines = ["llm:\n  model: standard"]
+    lines = [MINIMAL_REYN_YAML.rstrip("\n")]
     if permissions is not None:
         lines.append("permissions:")
         for key, value in permissions.items():

--- a/tests/mcp/test_2597_s2a_mcp_connection_service.py
+++ b/tests/mcp/test_2597_s2a_mcp_connection_service.py
@@ -19,6 +19,7 @@ from reyn.mcp.client import MCPError
 from reyn.mcp.connection_service import MCPConnectionService
 from reyn.mcp.pool import MCPClientPool
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 from tests._support.paths import REPO_ROOT
 
 _SUPPORT_DIR = REPO_ROOT / "tests" / "_support"
@@ -207,7 +208,7 @@ async def test_remove_session_teardown_closes_held_connections(tmp_path: Path):
     from reyn.runtime.registry import AgentRegistry
     from reyn.runtime.session import Session
 
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     cfg_path = tmp_path / ".reyn" / "config" / "mcp.yaml"
     cfg_path.parent.mkdir(parents=True, exist_ok=True)
     cfg_path.write_text(yaml.safe_dump({"mcp": {"servers": {"srv": _CFG}}}), encoding="utf-8")

--- a/tests/runtime/test_2548_skill_hotreload_toggle_pr_b.py
+++ b/tests/runtime/test_2548_skill_hotreload_toggle_pr_b.py
@@ -30,6 +30,7 @@ from reyn.data.skills.registry import SkillEntry
 from reyn.runtime.session import Session
 from reyn.runtime.session_params import CapabilityScope
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -42,7 +43,7 @@ def _make_session(tmp_path: Path, *, agent_name: str = "test-agent") -> Session:
     Builds ``available_skills`` from ``load_config`` so that skills declared in
     ``.reyn/config/skills.yaml`` (written before this call) are included — mirroring
     what ``SessionFactoryConfig.from_config`` does in production."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     from reyn.config.loader import load_config
     from reyn.data.skills.registry import build_skill_registry
     cfg = load_config()
@@ -158,7 +159,7 @@ async def test_hotreload_noop_when_skills_unchanged(
 @pytest.mark.asyncio
 async def test_hotreload_seam_registered(tmp_path: Path) -> None:
     """Tier 2: the Session registers the skills seam on the HotReloader."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     session = make_session(
         agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
         snapshot_path=tmp_path / "snap.json",

--- a/tests/runtime/test_2548_skill_registry_pr_a.py
+++ b/tests/runtime/test_2548_skill_registry_pr_a.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from reyn.config.loader import _merge, load_config
 from reyn.data.skills.registry import SkillEntry, build_skill_registry
 from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 # ── SkillEntry dataclass ──────────────────────────────────────────────────────
 
@@ -289,7 +290,7 @@ def test_merge_skills_base_survives_when_override_has_no_skills() -> None:
 
 def test_load_config_reads_dynamic_skills_yaml(tmp_path: Path) -> None:
     """Tier 1: load_config reads .reyn/config/skills.yaml as the dynamic skills layer."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     skills_cfg_dir = tmp_path / ".reyn" / "config"
     skills_cfg_dir.mkdir(parents=True)
     (skills_cfg_dir / "skills.yaml").write_text(
@@ -311,7 +312,7 @@ def test_load_config_reads_dynamic_skills_yaml(tmp_path: Path) -> None:
 def test_load_config_skills_explicit_wins_over_dynamic_layer(tmp_path: Path) -> None:
     """Tier 1: explicit skills in reyn.yaml survive + later dynamic layer entry wins on collision."""
     (tmp_path / "reyn.yaml").write_text(
-        "llm:\n  model: standard\n"
+        MINIMAL_REYN_YAML +
         "skills:\n  entries:\n"
         "    static-skill:\n      path: skills/static/SKILL.md\n      description: from reyn.yaml\n"
         "    shared:\n      path: skills/shared-static/SKILL.md\n      description: static version\n",
@@ -489,7 +490,7 @@ def test_e2e_config_to_system_prompt_universal_scheme(tmp_path: Path) -> None:
     from reyn.runtime.router_system_prompt import build_system_prompt
 
     (tmp_path / "reyn.yaml").write_text(
-        "llm:\n  model: standard\n"
+        MINIMAL_REYN_YAML +
         "skills:\n  entries:\n"
         "    pdf-filler:\n      path: skills/pdf-filler/SKILL.md\n"
         "      description: Fill PDF forms from structured data\n",
@@ -535,7 +536,7 @@ def test_e2e_retrieval_scheme_does_not_clobber_skills_block(tmp_path: Path) -> N
     from reyn.tools.schemes.retrieval import RetrievalScheme
 
     (tmp_path / "reyn.yaml").write_text(
-        "llm:\n  model: standard\n"
+        MINIMAL_REYN_YAML +
         "skills:\n  entries:\n"
         "    data-cleaner:\n      path: skills/data-cleaner/SKILL.md\n"
         "      description: Normalize and dedupe tabular data\n",
@@ -585,7 +586,7 @@ def test_e2e_enumerate_scheme_threads_skills(tmp_path: Path) -> None:
     from reyn.runtime.router_system_prompt import build_system_prompt
 
     (tmp_path / "reyn.yaml").write_text(
-        "llm:\n  model: standard\n"
+        MINIMAL_REYN_YAML +
         "skills:\n  entries:\n"
         "    linter:\n      path: skills/linter/SKILL.md\n"
         "      description: Run project linters and summarize findings\n",
@@ -617,7 +618,7 @@ def test_e2e_no_skills_config_omits_section(tmp_path: Path) -> None:
     """Tier 2: a config with no skills → registry empty → SP has no ## Skills section."""
     from reyn.runtime.router_system_prompt import build_system_prompt
 
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     old = os.getcwd()
     os.chdir(tmp_path)
     try:

--- a/tests/runtime/test_3036_spawned_session_mcp_refresh.py
+++ b/tests/runtime/test_3036_spawned_session_mcp_refresh.py
@@ -44,6 +44,7 @@ from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 def _install_server_in_config(project_root: Path, name: str) -> None:
@@ -64,7 +65,7 @@ def _make_registry(tmp_path: Path) -> AgentRegistry:
     (main + every programmatic spawn) starts with this EMPTY snapshot; only the fix
     under test (a spawn-time `refresh_mcp_servers()` call) can make a freshly
     spawned session see a server installed after the registry was built."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     state_log = StateLog(tmp_path / "wal.jsonl")
     holder: dict = {}
 

--- a/tests/runtime/test_3093_pipeline_registry_spawn_propagation.py
+++ b/tests/runtime/test_3093_pipeline_registry_spawn_propagation.py
@@ -82,6 +82,7 @@ from reyn.runtime.session_params import PresentationWiring
 from reyn.tools.pipeline_verbs import _handle_run_pipeline
 from reyn.tools.types import RouterCallerState, ToolContext
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 def _scripted_llm():
@@ -108,7 +109,7 @@ def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
     from reyn.data.pipelines.registry import build_pipeline_registry
 
     if not (tmp_path / "reyn.yaml").exists():
-        (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+        (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     holder: dict = {}
     frozen_registry = build_pipeline_registry(load_config(tmp_path).pipelines, tmp_path)
 

--- a/tests/runtime/test_3097_config_projection_refresh_family_gate.py
+++ b/tests/runtime/test_3097_config_projection_refresh_family_gate.py
@@ -53,6 +53,7 @@ from reyn.runtime.session import Session
 from reyn.runtime.session_params import PresentationWiring
 from reyn.runtime.spawn_routing import ReviewedNA
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 def _make_registry(tmp_path: Path) -> AgentRegistry:
@@ -60,7 +61,7 @@ def _make_registry(tmp_path: Path) -> AgentRegistry:
     boot-time closure — captures every projection ONCE (empty/default), before any
     install writes fresher config. Only a spawn-time refresh can make a freshly
     spawned session see config written after the registry was built."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     state_log = StateLog(tmp_path / "wal.jsonl")
     holder: dict = {}
 
@@ -88,7 +89,7 @@ async def test_vacuity_guard_registered_seams_nonempty(tmp_path: Path, monkeypat
     hot-reload seams (a completeness gate over an accidentally-empty set would be
     trivially, uselessly green)."""
     monkeypatch.chdir(tmp_path)
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     session = make_session(
         agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
         snapshot_path=tmp_path / "snap.json",
@@ -111,7 +112,7 @@ async def test_refresh_config_projections_covers_every_registered_seam_except_cr
     coverage is structural (derives from the SAME registry), not a maintained
     marker list that a future addition could silently miss."""
     monkeypatch.chdir(tmp_path)
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     session = make_session(
         agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
         snapshot_path=tmp_path / "snap.json",
@@ -152,7 +153,7 @@ async def test_cron_excluded_from_family_gate(tmp_path: Path, monkeypatch) -> No
     active filter, not a no-op that happens to never see cron for some other
     reason."""
     monkeypatch.chdir(tmp_path)
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     session = make_session(
         agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
         snapshot_path=tmp_path / "snap.json",

--- a/tests/runtime/test_3546_pipeline_driver_narrowing_inheritance.py
+++ b/tests/runtime/test_3546_pipeline_driver_narrowing_inheritance.py
@@ -155,6 +155,7 @@ from reyn.runtime.spawn_routing import AuditOnlyNoSurface
 from reyn.tools.pipeline_verbs import _handle_run_pipeline
 from reyn.tools.types import RouterCallerState, ToolContext
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 from tests._support.paths import REPO_ROOT
 
 _DENIED_TOOL = "p3546_denied_step"
@@ -170,7 +171,7 @@ def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
     """Real ``AgentRegistry`` + real ``Session`` factory (the harness shape
     ``tests/runtime/test_3093_pipeline_registry_spawn_propagation.py`` uses)."""
     if not (tmp_path / "reyn.yaml").exists():
-        (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+        (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     holder: dict = {}
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:

--- a/tests/runtime/test_3553_agent_step_worker_narrowing_inheritance.py
+++ b/tests/runtime/test_3553_agent_step_worker_narrowing_inheritance.py
@@ -62,6 +62,7 @@ from reyn.runtime.session_params import PresentationWiring
 from reyn.runtime.spawn_routing import AuditOnlyNoSurface
 from reyn.security.permissions.capability_profile import compose_narrowing_mappings
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 from tests._support.permissions import make_resolver
 
 #: The capability under test: a real, catalog-listed, side-effecting tool whose
@@ -112,7 +113,7 @@ def _registry(tmp_path: Path, scripted: "_WritesOnceLLM") -> AgentRegistry:
     real ``PermissionResolver`` (with ``file.write`` approved, so a denial observed
     below is the capability narrowing and not the write gate)."""
     if not (tmp_path / "reyn.yaml").exists():
-        (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+        (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     holder: dict = {}
     resolver = ModelResolver({"standard": "gemini/gemini-2.5-flash-lite"})

--- a/tests/runtime/test_3556_session_spawn_narrowing_inheritance.py
+++ b/tests/runtime/test_3556_session_spawn_narrowing_inheritance.py
@@ -81,6 +81,7 @@ from reyn.security.permissions.effective import tool_contextually_denied
 from reyn.tools.session_spawn import _handle as _handle_session_spawn
 from reyn.tools.types import RouterCallerState, ToolContext
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 from tests._support.permissions import make_resolver
 
 #: The capability under test: a real, catalog-listed, side-effecting tool whose effect
@@ -151,7 +152,7 @@ def _registry(tmp_path: Path, scripted: "_WritesOnceLLM") -> AgentRegistry:
     ``PermissionResolver`` (with ``file.write`` approved, so a denial observed below is
     the capability narrowing and not the write gate)."""
     if not (tmp_path / "reyn.yaml").exists():
-        (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+        (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     holder: dict = {}
     resolver = ModelResolver({"standard": "gemini/gemini-2.5-flash-lite"})

--- a/tests/runtime/test_3561_spawn_session_seam_reachability.py
+++ b/tests/runtime/test_3561_spawn_session_seam_reachability.py
@@ -110,6 +110,7 @@ from reyn.runtime.session_api import run_agent_step
 from reyn.runtime.session_params import PresentationWiring
 from reyn.runtime.spawn_routing import AuditOnlyNoSurface
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 from tests._support.permissions import make_resolver
 from tests._support.slash import RecordingTransport
 
@@ -153,7 +154,7 @@ def _registry(
     auto-vanish, and its real-litellm-name resolver so a spawned session's
     model-support pre-check has a name to resolve."""
     if not (tmp_path / "reyn.yaml").exists():
-        (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+        (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     holder: dict = {}
     resolver = ModelResolver({"standard": "gemini/gemini-2.5-flash-lite"})

--- a/tests/runtime/test_3562_slash_session_new_narrowing_inheritance.py
+++ b/tests/runtime/test_3562_slash_session_new_narrowing_inheritance.py
@@ -74,6 +74,7 @@ from reyn.runtime.spawn_routing import AuditOnlyNoSurface
 from reyn.runtime.transport import SystemRef
 from reyn.runtime.turn_origin import TurnOrigin
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 from tests._support.permissions import make_resolver
 from tests._support.slash import RecordingTransport
 
@@ -157,7 +158,7 @@ def _registry(tmp_path: Path, scripted: "_WritesOnceLLM") -> AgentRegistry:
     un-narrowed control.
     """
     if not (tmp_path / "reyn.yaml").exists():
-        (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+        (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     holder: dict = {}
     resolver = ModelResolver({"standard": "gemini/gemini-2.5-flash-lite"})

--- a/tests/runtime/test_3595_s2_pipeline_nudge_origin.py
+++ b/tests/runtime/test_3595_s2_pipeline_nudge_origin.py
@@ -46,6 +46,7 @@ from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 from reyn.runtime.turn_origin import TurnOrigin
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 from tests._support.slash import local_transport
 
 AGENT = "s2-nudge-agent"
@@ -104,7 +105,7 @@ async def test_a_pipeline_nudge_turn_cannot_execute_a_slash_command(
     """
     monkeypatch.chdir(tmp_path)
     state_log = StateLog(tmp_path / "state.wal")
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     holder: dict = {}
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:

--- a/tests/runtime/test_3595_step1b_external_producer_slash_reachability.py
+++ b/tests/runtime/test_3595_step1b_external_producer_slash_reachability.py
@@ -62,6 +62,7 @@ from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 from reyn.runtime.session_params import PresentationWiring
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 from tests._support.permissions import make_resolver
 from tests._support.slash import RecordingTransport
 
@@ -111,7 +112,7 @@ def _registry(
     real-litellm-name resolver so a spawned session's model-support pre-check has a
     name to resolve."""
     if not (tmp_path / "reyn.yaml").exists():
-        (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+        (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     holder: dict = {}
     resolver = ModelResolver({"standard": "gemini/gemini-2.5-flash-lite"})

--- a/tests/runtime/test_3793_stage2_agui_decoupled_and_is_attached_removed.py
+++ b/tests/runtime/test_3793_stage2_agui_decoupled_and_is_attached_removed.py
@@ -44,6 +44,7 @@ from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 def _registry(tmp_path):
@@ -178,7 +179,7 @@ async def test_real_agui_endpoint_boot_does_not_touch_registry_focus(tmp_path, m
 
     monkeypatch.chdir(tmp_path)
     state_log = StateLog(tmp_path / "state.wal")
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None):
         return make_session(

--- a/tests/runtime/test_4200_2_spawn_time_base_dir_write.py
+++ b/tests/runtime/test_4200_2_spawn_time_base_dir_write.py
@@ -30,6 +30,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 async def _registry_with_live_parent(
@@ -40,7 +41,7 @@ async def _registry_with_live_parent(
     style — the registry's own agent-level "main" session is a
     non-loading accessor and is never auto-constructed by ``create()``
     alone, so a genuinely-live spawner needs to come from a real spawn)."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     holder: dict = {}
 

--- a/tests/runtime/test_4200_session_base_dir_resolution.py
+++ b/tests/runtime/test_4200_session_base_dir_resolution.py
@@ -28,6 +28,7 @@ from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 from reyn.runtime.spawn_routing import AuditOnlyNoSurface
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 def _write_config(path: Path, base_dir: "Path | str") -> None:
@@ -162,7 +163,7 @@ async def test_a_spawned_childs_op_context_resolves_the_childs_own_override_not_
     child's op-context would resolve the PARENT's base_dir instead."""
     project_root = tmp_path / "project"
     (project_root / "reyn.yaml").parent.mkdir(parents=True, exist_ok=True)
-    (project_root / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (project_root / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     state_log = StateLog(project_root / ".reyn" / "wal.jsonl")
     parent_base_dir = tmp_path / "parent-base-dir"
     parent_base_dir.mkdir(parents=True)

--- a/tests/runtime/test_4244_pipeline_hooks_add_denied.py
+++ b/tests/runtime/test_4244_pipeline_hooks_add_denied.py
@@ -53,10 +53,11 @@ from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.services.pipeline_executor_driver import PipelineExecutorDriver
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 def _registry(tmp_path: Path) -> AgentRegistry:
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     holder: dict = {}
 

--- a/tests/runtime/test_fp0041_prb_cron_message_shape.py
+++ b/tests/runtime/test_fp0041_prb_cron_message_shape.py
@@ -37,6 +37,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
 
 def _write_yaml(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -165,7 +167,7 @@ def test_load_config_reads_dynamic_cron_yaml(tmp_path, monkeypatch):
     """
     from reyn.config import load_config
 
-    _write_yaml(tmp_path / "reyn.yaml", "llm:\n  model: standard\n")
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)
     _write_yaml(
         tmp_path / ".reyn" / "config" / "cron.yaml",
         "cron:\n  jobs:\n"
@@ -190,7 +192,7 @@ def test_load_config_unions_legacy_and_dynamic_cron_jobs(tmp_path, monkeypatch):
 
     _write_yaml(
         tmp_path / "reyn.yaml",
-        "llm:\n  model: standard\n"
+        MINIMAL_REYN_YAML +
         "cron:\n  jobs:\n"
         "    - name: static_job\n      to: static_agent\n      message: run\n"
         "      schedule: '0 * * * *'\n",
@@ -220,7 +222,7 @@ def test_load_config_dynamic_cron_yaml_overrides_legacy_on_name_collision(
 
     _write_yaml(
         tmp_path / "reyn.yaml",
-        "llm:\n  model: standard\n"
+        MINIMAL_REYN_YAML +
         "cron:\n  jobs:\n"
         "    - name: shared\n      to: old_agent\n      message: old message\n"
         "      schedule: '0 * * * *'\n",
@@ -251,7 +253,7 @@ def test_load_config_works_without_dynamic_cron_yaml(tmp_path, monkeypatch):
 
     _write_yaml(
         tmp_path / "reyn.yaml",
-        "llm:\n  model: standard\n"
+        MINIMAL_REYN_YAML +
         "cron:\n  jobs:\n"
         "    - name: static_only\n      to: some_agent\n      message: run\n"
         "      schedule: '0 * * * *'\n",

--- a/tests/runtime/test_fp0041_prd2_outbox_interceptor.py
+++ b/tests/runtime/test_fp0041_prd2_outbox_interceptor.py
@@ -54,6 +54,7 @@ from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.session import Session
 from reyn.runtime.transport import ExternalRef, TuiRef
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 def _make_session(tmp_path: Path, *, agent_name: str = "alpha") -> Session:
@@ -366,7 +367,7 @@ def test_reyn_config_external_transports_defaults_to_empty(tmp_path, monkeypatch
     """
     from reyn.config import load_config
 
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     monkeypatch.chdir(tmp_path)
     cfg = load_config(cwd=tmp_path)
 
@@ -384,7 +385,7 @@ def test_reyn_config_external_transports_parses_well_formed_yaml(
     from reyn.config import load_config
 
     (tmp_path / "reyn.yaml").write_text(
-        "llm:\n  model: standard\n"
+        MINIMAL_REYN_YAML +
         "external_transports:\n"
         "  slack:\n"
         "    mcp_tool: slack__chat_postMessage\n"

--- a/tests/runtime/test_list_mcp_servers_canonical_shape.py
+++ b/tests/runtime/test_list_mcp_servers_canonical_shape.py
@@ -31,10 +31,11 @@ from reyn.runtime.session import Session
 from reyn.tools import get_default_registry
 from reyn.tools.scheme import ExecutionResult
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 
 def _session(tmp_path: Path) -> Session:
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     (tmp_path / "reyn.local.yaml").write_text(
         "mcp:\n  servers:\n"
         "    s1:\n      command: /usr/bin/true\n      description: server 1\n"

--- a/tests/runtime/test_plugin_slash_surface.py
+++ b/tests/runtime/test_plugin_slash_surface.py
@@ -39,6 +39,7 @@ from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.session import Session
 from reyn.security.permissions.permissions import PermissionResolver
 from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 from tests._support.slash import slash_ctx
 
 
@@ -89,7 +90,7 @@ def _make_session(
     writes OUTSIDE the workspace (``~/.reyn/plugins/``), so exercising that
     path for real requires the operator-equivalent explicit
     ``sandbox.policy.write_paths`` grant, supplied here."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     session = make_session(
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),

--- a/tests/security/test_fp0016_c_auth_config.py
+++ b/tests/security/test_fp0016_c_auth_config.py
@@ -20,6 +20,7 @@ from reyn.config import (
     _build_auth_config,
     load_config,
 )
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 
 # ── 1. Default values ─────────────────────────────────────────────────────────
 
@@ -269,7 +270,7 @@ auth:
 def test_load_config_without_auth_block_uses_defaults(tmp_path: Path) -> None:
     """Tier 2: omitting auth: block in reyn.yaml → empty AuthConfig."""
     (tmp_path / "reyn.yaml").write_text(
-        "llm:\n  model: standard\n",
+        MINIMAL_REYN_YAML,
         encoding="utf-8",
     )
 

--- a/tests/web/test_auth_gate_middleware.py
+++ b/tests/web/test_auth_gate_middleware.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
 # Ensure the worktree src is importable even when the main-tree src appears
 # earlier on sys.path (editable-install collision) — mirrors the sibling
 # route-mount tests so the fully-mounted worktree app is the one under test.
@@ -54,7 +56,7 @@ def _reset_singletons() -> None:
 @pytest.fixture()
 def tmp_project(tmp_path: Path) -> Path:
     """A minimal project root so the real budget/config/registry deps resolve."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     agent_dir = tmp_path / ".reyn" / "agents" / "default"
     agent_dir.mkdir(parents=True)
     (agent_dir / "profile.yaml").write_text(

--- a/tests/web/test_openui_shell.py
+++ b/tests/web/test_openui_shell.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 from tests._support.paths import REPO_ROOT
 
 # ---------------------------------------------------------------------------
@@ -37,7 +38,7 @@ httpx = pytest.importorskip("httpx", reason="httpx not installed (needed by Test
 def tmp_project(tmp_path: Path) -> Path:
     """Minimal project root with one agent, one local design, and reyn.yaml."""
     # reyn.yaml
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
 
     # Agent
     agents_dir = tmp_path / ".reyn" / "agents" / "default"

--- a/tests/web/test_resources_router.py
+++ b/tests/web/test_resources_router.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 import pytest
 
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 from tests._support.paths import REPO_ROOT
 
 # Same path-bootstrap pattern as tests/web/test_smoke.py — keep the
@@ -50,7 +51,7 @@ def tmp_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     agents_dir = reyn_dir / "agents" / "researcher"
     agents_dir.mkdir(parents=True)
 
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     (agents_dir / "profile.yaml").write_text(
         "name: researcher\nrole: ''\ncreated_at: '2026-01-01T00:00:00+00:00'\n",
         encoding="utf-8",

--- a/tests/web/test_smoke.py
+++ b/tests/web/test_smoke.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import pytest
 
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 from tests._support.paths import REPO_ROOT
 
 # ---------------------------------------------------------------------------
@@ -98,7 +99,7 @@ def tmp_project(tmp_path: Path) -> Path:
     agents_dir.mkdir(parents=True)
 
     # Minimal reyn.yaml so _find_project_root() matches this directory.
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
 
     # Minimal agent profile.
     (agents_dir / "profile.yaml").write_text(

--- a/tests/web/test_surface_registry.py
+++ b/tests/web/test_surface_registry.py
@@ -34,6 +34,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
 fastapi = pytest.importorskip("fastapi", reason="fastapi not installed ([web] extra missing)")
 httpx = pytest.importorskip("httpx", reason="httpx not installed (needed by TestClient)")
 
@@ -67,7 +69,7 @@ def _restore_server_singleton():
 @pytest.fixture()
 def tmp_project(tmp_path: Path) -> Path:
     """A minimal project root so the real budget/config/registry deps resolve."""
-    (tmp_path / "reyn.yaml").write_text("llm:\n  model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
     agent_dir = tmp_path / ".reyn" / "agents" / "default"
     agent_dir.mkdir(parents=True)
     (agent_dir / "profile.yaml").write_text(


### PR DESCRIPTION
**[docs-maintainer]** — part of #4284 (shared `MINIMAL_REYN_YAML` fixture extraction).

## What

~60 test files hand-wrote the literal `"llm:\n  model: standard\n"` (or the
pre-#4174-T3 `"model: standard\n"`) as fixture boilerplate to make a
`reyn.yaml` loadable, with no assertion on the model value itself. #4174 T3
had to touch every one of those sites' literal text in the same PR that moved
the schema field; the next schema rename under `llm:` would repeat that
churn.

- New `tests/_support/minimal_reyn_yaml.py`: `MINIMAL_REYN_YAML` string
  constant.
- 61 test files migrated to import and use it — some as a standalone
  `write_text()`, some via string concatenation with additional YAML.

## Population re-measurement (per brief point ①)

Did **not** trust the issue body's "~60" estimate or a single grep shape.
Two independent literal-shape searches:

- `grep -c 'llm:\\n  model:'` (Python single-line-escaped form) → 62 files.
- A second, broader pattern (`^\s*model:\s*(standard|light|strong)` style)
  caught 3 more files using a materially different literal shape (triple-
  quoted multi-line YAML blocks / list-building patterns) that the first
  grep missed entirely.

Total candidate population: **65 files**.

## Constant vs. function (per brief point ②)

Surveyed call-site shapes across the 65 files before deciding: 69 standalone
occurrences, 13 same-line-concatenated, 19 adjacent-line-concatenated (101
total occurrences). A `write_minimal_reyn_yaml(path)` function was
considered and rejected — the majority write this as a standalone call, but
a real minority (~15 sites) concatenate it with extra YAML. A plain string
constant composes naturally for both shapes; a function would need an
`extra=` parameter to support the concatenating sites for no added benefit.

## Excluded — model-value-asserting sites (per brief point ③)

Of the 65 candidates, **4 files/sites are explicitly out of scope** because
the model value itself is what the test asserts on, not incidental fixture
boilerplate. Not silently swept into the mechanical migration:

1. `tests/config/test_4174_t0_unknown_config_key_warn.py` — **whole file**
   excluded. Its entire point is verifying `cfg.llm.model` reaches correctly
   post-T3 ("the value must actually reach `cfg.llm.model`, or T3 only moved
   the field name").
2. `tests/interfaces/test_3368_mcp_serve_config_anchored_to_project.py` —
   **whole file** excluded. Its custom
   `models: standard: openai/probe-standard-model` mapping is load-bearing
   to its `ModelResolver` assertions (owner-reported bug #3368's root-cause
   narrative — "You passed model=standard" litellm error).
3. `tests/llm/test_model_class_by_purpose_1672.py` — **whole file**
   excluded. Every YAML block is a distinct, purpose-built fixture varying
   `model`/`models`/`model_class_by_purpose` values specifically to exercise
   the parser under test (Tier 2, #1672).
4. `tests/interfaces/test_config_migrate_mcp_command.py` — **one function
   only** excluded (`test_migrate_moves_reyn_yaml_servers_to_dynamic`): its
   fixture write feeds
   `assert src.get("llm", {}).get("model") == "standard"`. The file's other
   3 sites (`test_migrate_no_legacy_entries_is_noop`,
   `test_migrate_moves_from_both_reyn_yaml_and_local`,
   `test_migrate_dry_run_does_not_write_files` — pure fixture boilerplate)
   were migrated normally.

**Net: 61 files touched** (65 candidates − 3 whole-file exclusions − 1 file
that's in the 61 but partially excluded at function granularity).

## Verification

- `ruff check` — clean (0 errors after `--fix`, re-verified clean without
  `--fix`).
- `python scripts/mypy_ratchet.py` — clean, no new findings (211/215
  baselined, unchanged).
- `python scripts/test_tier_audit.py --strict <61 files>` — 507 tests
  inspected, 507 OK, 0 Tier-4 violations.
- `python scripts/check_tests_path_literal_reference.py` — clean, 118/118
  baselined.
- `python scripts/verify_module_docstrings.py tests/_support/minimal_reyn_yaml.py`
  — OK, no refactor-narrative violation.
- Scoped `pytest` across all 61 touched files: **514 passed, 0 failed**
  (caught and fixed one bulk-substitution artifact along the way — see
  below).

## Bulk-substitution self-caught bugs (transparency note)

The mechanical migration was done via an automated script; two classes of
bugs were caught by running full syntax-parse + a real pytest pass before
opening this PR, not assumed clean from the script's own reported counts:

- 9 files lost the `+` operator between `MINIMAL_REYN_YAML` and the next
  concatenated string literal on adjacent-line-concat sites (a
  `SyntaxError`) — fixed by re-inserting the missing `+`.
- `tests/config/test_web_auth_config_contract.py` had an f-string prefix
  glued directly onto the constant name (`fMINIMAL_REYN_YAML + "..."`,
  `NameError` at runtime, not a `SyntaxError`, so it only surfaced at
  pytest time) — fixed to
  `MINIMAL_REYN_YAML + f"gateway:\n  auth:\n    require_token_on_loopback: '{value}'\n"`.

All 61 files independently re-verified to `ast.parse()` cleanly and to
correctly import `MINIMAL_REYN_YAML` before this PR was opened.

## Test plan

- [x] `ruff check` clean
- [x] `mypy_ratchet.py` clean
- [x] `test_tier_audit.py --strict` clean (507/507)
- [x] `check_tests_path_literal_reference.py` clean
- [x] scoped `pytest` on all touched files: 514 passed, 0 failed
- [x] excluded files/sites confirmed untouched via `git diff --stat` (zero
      diff on the 3 whole-file exclusions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
