### PR TITLE
feat(#4327): retired top-level config key denylist gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,6 +210,18 @@ jobs:
       - name: Check doc anchors
         run: timeout 2m python scripts/check_doc_anchors.py
 
+      # #4327: a retired top-level reyn.yaml key (renamed via #4174 T1-T7)
+      # must not appear, at YAML top level, in operator-facing docs or the
+      # shipped reyn.local.yaml.example — see
+      # scripts/check_retired_config_keys_denylist.py's module docstring
+      # for the full design (denylist sourced from
+      # reyn.config.config_schema._RENAMED_CONFIG_KEYS, column-0 anchoring,
+      # the two exclusion classes). Needs `reyn` importable (this job's
+      # `pip install -e ".[docs]"` above already provides that), unlike the
+      # stdlib-only tests-path-literal-reference gate.
+      - name: Check retired config keys denylist
+        run: timeout 2m python scripts/check_retired_config_keys_denylist.py
+
   audit:
     name: test-tier audit
     runs-on: ubuntu-latest

--- a/scripts/check_retired_config_keys_denylist.py
+++ b/scripts/check_retired_config_keys_denylist.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""#4327 — a retired top-level `reyn.yaml` key must not appear, at top level,
+in operator-facing docs or the shipped config example.
+
+## The gap this closes
+
+`tests/config/test_config_mirror_coverage_1056.py` already gates two files
+(`reyn.local.yaml.example` / `docs/reference/config/reyn-yaml.md`) for
+COVERAGE — every schema field name must appear somewhere in the doc. That
+gate is directional: it asks "does the doc mention every current key" and
+never asks "does the doc still mention a key that's gone". A rename doesn't
+break coverage (the new name gets added), so a doc that keeps the OLD name
+around passes it silently, forever, on exactly the 2 files it covers.
+
+#4322/#4323 measured the cost directly: 8 operator-facing docs (none of
+them one of that gate's 2 covered files) still showed pre-#4174-T3/T4 shapes
+(top-level `models:` / `litellm:` / `web:`) after the renames landed —
+`docs/guide/getting-started/01-installation.md` among them, the page a new
+operator reads FIRST. A reader who copies that block writes a config that
+doesn't load, silently (the unknown-key path is a WARN, not a hard fail).
+
+## Why a denylist, not "check every YAML example against the schema"
+
+Docs carry plenty of YAML that ISN'T a `reyn.yaml` example — `.mcp.json`
+equivalents, pipeline/hook definitions, dogfood tooling's own config
+schemas, cost-tracing dumps. Comparing every fenced YAML block's key set
+against `ReynConfig`'s schema produces false positives on all of them: a
+key set mismatch there means "different schema", not "drift".
+
+A RETIRED key is different: once a key is renamed, the OLD name is no
+longer valid ANYWHERE, in ANY reyn.yaml-shaped document — its appearance at
+YAML top level is drift by construction, not a matter of which schema the
+surrounding example happens to be for (mostly — see the "different schema
+still collides" note below, which is exactly why a small file-level
+allowlist exists alongside this denylist).
+
+## Single source: `_RENAMED_CONFIG_KEYS`, not a second hand-kept list
+
+The denylist is `reyn.config.config_schema._RENAMED_CONFIG_KEYS` — the SAME
+registry `reyn config validate`/`migrate` already reads, already populated
+incrementally, in the SAME PR as each rename, by #4174's own T1-T7 practice
+(see that module's docstring). This script adds no maintenance burden of
+its own: a future rename that registers a `RenamedKeyHint` is picked up
+here for free. It deliberately does NOT hand-roll a parallel list — CLAUDE.md's
+own recurring lesson (`control-ir.md` vs `OP_KIND_MODEL_MAP`) is that a second
+registry nobody is obligated to update is worse than no registry.
+
+## Detection: line-START only, not "key anywhere"
+
+Only a match at column 0 (`^key:`) counts — a *top-level* YAML mapping key
+position. This deliberately does NOT catch:
+
+- **dotted mentions** (`web.fetch.max_download_bytes`, prose citing a
+  nested field by its full path) — these aren't claiming the OLD top-level
+  shape, they're just naming a leaf.
+- **indented nested keys that happen to share a retired name** — `models:`
+  is retired at top level, but `llm:\n  models:` is the CURRENT correct
+  shape; requiring column 0 is exactly what keeps that legitimate case
+  green.
+- **prose mentions** — `` `models:` moved under `llm:` `` (this docstring
+  itself does this) is explaining the move, not demonstrating the stale
+  shape; a mid-sentence or indented occurrence is invisible to this gate on
+  purpose, at the cost of also being invisible to a prose sentence that
+  legitimately quotes the old key at the START of its own line (rare; not
+  observed in a real measurement as of #4327).
+
+Column 0 was picked BEFORE building the retired-key list, not after seeing
+what would need excluding, per lead-coder's #4327 review comment: narrow
+the detection shape by asking "can this be written another way" first, then
+name in this comment what got left out — not build the widest possible
+regex and hand-carve exceptions around it.
+
+## Two exclusion classes — both discovered by a real pre-flight measurement,
+## not asserted from the design alone
+
+**1. Historical-record directories.** `docs/deep-dives/spec/` and ADRs
+(`docs/deep-dives/decisions/`) were the two lead-coder named explicitly —
+design docs record the design AS IT WAS, and a retired key is a legitimate
+historical fact there, not drift (ADRs are immutable by policy; spec/ is a
+point-in-time proposal record). Re-running the SAME reasoning against a
+pre-flight scan of the whole tree surfaced two MORE directories that are
+structurally identical, not named in the original brief but excluded here
+for the identical reason, not a new one:
+
+- `docs/deep-dives/proposals/` — FP-NNNN proposal docs (`Status: proposed`
+  / partially landed) that show the schema shape AS PROPOSED, sometimes
+  years before or after a later, differently-named field actually shipped
+  (FP-0016 Component E proposes `agent: {id: ...}` — the eventual shape
+  became `agent_id:`, a T5 VALUE-TRANSFORM rename, not the plain rename the
+  proposal assumed).
+- `docs/deep-dives/journal/` — dated dogfood-run / feature-verify logs that
+  quote the EXACT `reyn.local.yaml` block used for that run, at the time it
+  was run — the same "records what happened" class `check_tests_path_literal_reference.py`
+  already carves out for `CHANGELOG.md` (see that script's own module
+  docstring for the identical argument spelled out in full).
+
+**2. Different-schema single files.** Column-0 anchoring solves the
+"legitimate nested key" case, but NOT the case where two UNRELATED schemas
+share a top-level field name — e.g. `reyn.yaml`'s `model:` (moved to
+`llm.model:`) vs. `scripts/dogfood_variant_replay.py`'s OWN config format,
+which also has a top-level `model:` field with a completely different
+meaning (which LLM to replay against), or the built-in model CATALOG
+entry's own per-entry schema (`{model: ..., max_completion_tokens: ...}`,
+`src/reyn/llm/builtin_models.py`'s `BUILTIN_MODELS` dict shape), which is a
+sub-document fragment, not a `reyn.yaml` example, but still starts at
+column 0 in its own fenced block. Measured, not guessed — a real pre-flight
+scan is what surfaced these, not a hypothetical:
+
+- `docs/deep-dives/contributing/dogfood-tooling.md` — `variant_ablation.yaml`
+  example is `dogfood_variant_replay.py`'s own config.
+- `docs/reference/builtin-models.md` / `.ja.md` — every fenced block is one
+  catalog entry's OWN field shape, never a full `reyn.yaml` document.
+
+A file lands on this list only after being READ and confirmed to contain
+no genuine `reyn.yaml`-shaped example anywhere in it (not just at the
+specific hit line) — see the PR that added each entry for that check.
+Adding a new different-schema doc costs one line here, same order of
+magnitude as the denylist itself.
+
+## Not a ratchet — a hard gate
+
+Unlike `check_tests_path_literal_reference.py`, this is NOT a baseline
+ratchet: a real pre-flight scan of the whole tree (as of #4327, after the
+two exclusion classes above) returns ZERO hits. Requiring a baseline would
+mean committing an empty one — simpler to just fail on any hit, which also
+means a new violation surfaces immediately instead of needing
+`--write-baseline` run first to notice it slipped through.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+# An editable `reyn` install elsewhere on the machine can otherwise shadow
+# THIS repo's own src/ (same class of trap pytest's `pythonpath = ["src"]`
+# setting exists to avoid) — insert this repo's src/ first so
+# `_retired_keys()` always reads THIS tree's `_RENAMED_CONFIG_KEYS`, not a
+# stale one from an unrelated checkout.
+sys.path.insert(0, str(_ROOT / "src"))
+
+# Historical-record directories: a retired key legitimately appears here as
+# a fact about the past, not present-tense drift. See module docstring
+# "Two exclusion classes" §1.
+_EXCLUDED_DIR_PREFIXES = (
+    "docs/deep-dives/spec/",
+    "docs/deep-dives/decisions/",
+    "docs/deep-dives/proposals/",
+    "docs/deep-dives/journal/",
+)
+
+# Different-schema single files: every top-level-looking key in these is a
+# DIFFERENT vocabulary that happens to share a field name with a retired
+# `reyn.yaml` key, never a `reyn.yaml` example itself. See module docstring
+# "Two exclusion classes" §2. Confirm (read the whole file, not just the
+# hit line) before adding an entry here.
+_EXCLUDED_FILES = frozenset({
+    "docs/deep-dives/contributing/dogfood-tooling.md",
+    "docs/reference/builtin-models.md",
+    "docs/reference/builtin-models.ja.md",
+})
+
+
+def _retired_keys() -> "dict[str, str]":
+    """The denylist itself: ``{old_top_level_key: note}`` straight from
+    ``_RENAMED_CONFIG_KEYS`` — see module docstring "Single source"."""
+    from reyn.config.config_schema import _RENAMED_CONFIG_KEYS
+    return {key: hint.note for key, hint in _RENAMED_CONFIG_KEYS.items()}
+
+
+def _pattern(keys: "list[str]") -> "re.Pattern[str]":
+    alt = "|".join(re.escape(k) for k in sorted(keys))
+    # Column-0 anchor (`^`, no leading whitespace) = top-level YAML mapping
+    # key position — see module docstring "Detection: line-START only".
+    return re.compile(r"^(" + alt + r"):(\s|$)")
+
+
+def _iter_scan_files(root: Path = _ROOT):
+    """Every tracked `docs/**` file plus the repo's own `*.example` file —
+    `git ls-files` so generated/gitignored trees (`site/`, worktrees under
+    `.claude/`) are never in scope, with no exclusion list of our own to
+    keep in sync (same reasoning as `check_tests_path_literal_reference.py`'s
+    own population section)."""
+    proc = subprocess.run(
+        ["git", "ls-files"], cwd=root, capture_output=True, text=True, check=True,
+    )
+    for line in proc.stdout.splitlines():
+        rel = Path(line)
+        rel_s = str(rel)
+        if not (rel_s.startswith("docs/") or rel.name.endswith(".example")):
+            continue
+        if any(rel_s.startswith(p) for p in _EXCLUDED_DIR_PREFIXES):
+            continue
+        if rel_s in _EXCLUDED_FILES:
+            continue
+        yield root / rel
+
+
+def offending_lines(root: Path = _ROOT) -> "list[tuple[Path, int, str, str]]":
+    """Every ``(file, line_number, retired_key, note)`` where a retired
+    top-level key appears at YAML top-level (column 0) — the gate's entire
+    decision, isolated from CLI/printing so it is directly testable."""
+    keys = _retired_keys()
+    pattern = _pattern(list(keys))
+    offenders: list[tuple[Path, int, str, str]] = []
+    for path in _iter_scan_files(root):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            m = pattern.match(line)
+            if m:
+                key = m.group(1)
+                offenders.append((path, lineno, key, keys[key]))
+    return offenders
+
+
+def main() -> int:
+    offenders = offending_lines(_ROOT)
+
+    if not offenders:
+        print(
+            "retired-config-key denylist OK: 0 hits "
+            f"({len(_retired_keys())} retired top-level key(s) checked)."
+        )
+        return 0
+
+    print("retired-config-key denylist FAILED:\n", file=sys.stderr)
+    print(
+        f"{len(offenders)} line(s) show a retired top-level reyn.yaml key "
+        "still in its old shape:",
+        file=sys.stderr,
+    )
+    for path, lineno, key, note in offenders:
+        rel = path.relative_to(_ROOT)
+        print(f"  {rel}:{lineno}: `{key}:` — {note}", file=sys.stderr)
+    print(
+        "\nUpdate the example to the current key location. If this is a "
+        "genuine historical record (a dated journal/proposal/spec entry, "
+        "or a fenced example for a DIFFERENT config schema that happens to "
+        "share a field name), add it to the appropriate exclusion in this "
+        "script — see the module docstring's \"Two exclusion classes\" "
+        "section for the bar each class has to clear.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_retired_config_keys_denylist.py
+++ b/scripts/check_retired_config_keys_denylist.py
@@ -94,13 +94,14 @@ for the identical reason, not a new one:
   already carves out for `CHANGELOG.md` (see that script's own module
   docstring for the identical argument spelled out in full).
 
-**2. Different-schema single files.** Column-0 anchoring solves the
-"legitimate nested key" case, but NOT the case where two UNRELATED schemas
-share a top-level field name — e.g. `reyn.yaml`'s `model:` (moved to
-`llm.model:`) vs. `scripts/dogfood_variant_replay.py`'s OWN config format,
-which also has a top-level `model:` field with a completely different
-meaning (which LLM to replay against), or the built-in model CATALOG
-entry's own per-entry schema (`{model: ..., max_completion_tokens: ...}`,
+**2. Different-schema single files — keyed per FILE × KEY, not per file.**
+Column-0 anchoring solves the "legitimate nested key" case, but NOT the
+case where two UNRELATED schemas share a top-level field name — e.g.
+`reyn.yaml`'s `model:` (moved to `llm.model:`) vs.
+`scripts/dogfood_variant_replay.py`'s OWN config format, which also has a
+top-level `model:` field with a completely different meaning (which LLM to
+replay against), or the built-in model CATALOG entry's own per-entry
+schema (`{model: ..., max_completion_tokens: ...}`,
 `src/reyn/llm/builtin_models.py`'s `BUILTIN_MODELS` dict shape), which is a
 sub-document fragment, not a `reyn.yaml` example, but still starts at
 column 0 in its own fenced block. Measured, not guessed — a real pre-flight
@@ -111,11 +112,18 @@ scan is what surfaced these, not a hypothetical:
 - `docs/reference/builtin-models.md` / `.ja.md` — every fenced block is one
   catalog entry's OWN field shape, never a full `reyn.yaml` document.
 
-A file lands on this list only after being READ and confirmed to contain
-no genuine `reyn.yaml`-shaped example anywhere in it (not just at the
-specific hit line) — see the PR that added each entry for that check.
-Adding a new different-schema doc costs one line here, same order of
-magnitude as the denylist itself.
+`_EXCLUDED_FILE_KEYS` maps `file -> {retired_key, ...}`, NOT `file ->`
+"exclude everything" — lead-coder's #4332 review block, caught by an
+independent re-measurement of exactly which keys collide per file: all 3
+files above collide ONLY on `model` (their own catalog-entry / replay-
+config field of that name); a whole-file exclusion silently stops watching
+the OTHER 7 denylist keys on that file too. `builtin-models.md` is
+precisely the file #4322 had to fix for a `models:` drift the same night
+this gate was written — a whole-file exclusion would have meant this gate
+never watches that file for that exact recurrence again. A file/key pair
+lands here only after the WHOLE file is read and confirmed to contain no
+genuine `reyn.yaml`-shaped example anywhere in it for that key (not just
+the specific hit line).
 
 ## Not a ratchet — a hard gate
 
@@ -152,16 +160,27 @@ _EXCLUDED_DIR_PREFIXES = (
     "docs/deep-dives/journal/",
 )
 
-# Different-schema single files: every top-level-looking key in these is a
-# DIFFERENT vocabulary that happens to share a field name with a retired
-# `reyn.yaml` key, never a `reyn.yaml` example itself. See module docstring
-# "Two exclusion classes" §2. Confirm (read the whole file, not just the
-# hit line) before adding an entry here.
-_EXCLUDED_FILES = frozenset({
-    "docs/deep-dives/contributing/dogfood-tooling.md",
-    "docs/reference/builtin-models.md",
-    "docs/reference/builtin-models.ja.md",
-})
+# Different-schema single files: SPECIFIC retired keys in these files are a
+# DIFFERENT vocabulary that happens to share that one field name with a
+# retired `reyn.yaml` key, never a `reyn.yaml` example itself. See module
+# docstring "Two exclusion classes" §2.
+#
+# Keyed file -> {retired_key, ...}, NOT file -> "exclude everything" —
+# lead-coder's #4332 review block: a whole-file exclusion was measured to
+# be wider than the actual collision. All 3 files below collide ONLY on
+# `model` (their own `{model: ..., max_completion_tokens: ...}` catalog-
+# entry / dogfood-replay-config field); a whole-file exclusion would have
+# silently stopped watching the other 7 denylist keys on these files too —
+# `builtin-models.md` is exactly the file #4322 had to fix for a `models:`
+# drift the same night this gate was written, so silently no longer
+# watching it for exactly that key would defeat the gate's own purpose.
+# Confirm per-key (read the whole file, not just one hit line) before
+# adding or widening an entry here.
+_EXCLUDED_FILE_KEYS: "dict[str, frozenset[str]]" = {
+    "docs/deep-dives/contributing/dogfood-tooling.md": frozenset({"model"}),
+    "docs/reference/builtin-models.md": frozenset({"model"}),
+    "docs/reference/builtin-models.ja.md": frozenset({"model"}),
+}
 
 
 def _retired_keys() -> "dict[str, str]":
@@ -194,8 +213,6 @@ def _iter_scan_files(root: Path = _ROOT):
             continue
         if any(rel_s.startswith(p) for p in _EXCLUDED_DIR_PREFIXES):
             continue
-        if rel_s in _EXCLUDED_FILES:
-            continue
         yield root / rel
 
 
@@ -211,11 +228,16 @@ def offending_lines(root: Path = _ROOT) -> "list[tuple[Path, int, str, str]]":
             text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
+        rel_s = str(path.relative_to(root))
+        excluded_keys = _EXCLUDED_FILE_KEYS.get(rel_s, frozenset())
         for lineno, line in enumerate(text.splitlines(), start=1):
             m = pattern.match(line)
-            if m:
-                key = m.group(1)
-                offenders.append((path, lineno, key, keys[key]))
+            if not m:
+                continue
+            key = m.group(1)
+            if key in excluded_keys:
+                continue
+            offenders.append((path, lineno, key, keys[key]))
     return offenders
 
 

--- a/tests/scripts/test_check_retired_config_keys_denylist_4327.py
+++ b/tests/scripts/test_check_retired_config_keys_denylist_4327.py
@@ -1,0 +1,169 @@
+"""Tier 1: scripts/check_retired_config_keys_denylist.py's detection contract.
+
+Real filesystem fixtures for every regex/scan test (a real `tmp_path` tree,
+real `git init`/`git add`) — no mocks, the whole point is these are pure
+functions over real text/files, same discipline as
+`test_check_tests_path_literal_reference_4065.py`.
+"""
+from __future__ import annotations
+
+import subprocess
+
+from reyn.config.config_schema import _RENAMED_CONFIG_KEYS
+from scripts.check_retired_config_keys_denylist import (
+    _ROOT,
+    offending_lines,
+)
+
+
+def _git_repo(tmp_path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+
+
+def _write(tmp_path, rel: str, content: str) -> None:
+    path = tmp_path / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _add(tmp_path) -> None:
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+
+
+# ── the load-bearing positive case ──────────────────────────────────────────
+
+
+def test_a_column_zero_retired_key_is_offending(tmp_path) -> None:
+    """Tier 1: `models:` at YAML top level (column 0) in a docs/ file is the
+    gate's whole reason to exist — #4322/#4323's own measured shape."""
+    _write(tmp_path, "docs/guide/example.md", "models:\n  standard: foo\n")
+    _git_repo(tmp_path)
+    _add(tmp_path)
+    offenders = offending_lines(tmp_path)
+    assert [(str(p.relative_to(tmp_path)), n, k) for p, n, k, _ in offenders] == [
+        ("docs/guide/example.md", 1, "models"),
+    ]
+
+
+# ── the two deliberate false-negative shapes (by design, see module docstring) ──
+
+
+def test_an_indented_nested_key_sharing_a_retired_name_is_not_offending(tmp_path) -> None:
+    """Tier 1: `llm:\\n  models:` is the CURRENT correct shape — column-0
+    anchoring must not flag the indented `models:` nested under `llm:`."""
+    _write(tmp_path, "docs/guide/example.md", "llm:\n  models:\n    standard: foo\n")
+    _git_repo(tmp_path)
+    _add(tmp_path)
+    assert offending_lines(tmp_path) == []
+
+
+def test_a_dotted_mention_is_not_offending(tmp_path) -> None:
+    """Tier 1: `web.fetch.max_download_bytes` names a leaf, it does not
+    claim the old top-level `web:` shape — must not be flagged."""
+    _write(tmp_path, "docs/guide/example.md", "set `web.fetch.max_download_bytes` to tune it\n")
+    _git_repo(tmp_path)
+    _add(tmp_path)
+    assert offending_lines(tmp_path) == []
+
+
+# ── exclusion classes ───────────────────────────────────────────────────────
+
+
+def test_an_untracked_file_is_not_scanned(tmp_path) -> None:
+    """Tier 1: population is `git ls-files` (tracked content) — an
+    untracked file must not contribute offenders."""
+    _write(tmp_path, "docs/guide/example.md", "models:\n  standard: foo\n")
+    _git_repo(tmp_path)
+    # never `git add`-ed.
+    assert offending_lines(tmp_path) == []
+
+
+def test_a_non_docs_non_example_file_is_not_scanned(tmp_path) -> None:
+    """Tier 1: the scan population is `docs/**` plus `*.example` — a
+    retired key sitting in an unrelated tracked file (e.g. `src/`) is out
+    of this gate's population entirely."""
+    _write(tmp_path, "src/reyn/notes.md", "models:\n  standard: foo\n")
+    _git_repo(tmp_path)
+    _add(tmp_path)
+    assert offending_lines(tmp_path) == []
+
+
+def test_spec_directory_is_excluded_even_though_tracked(tmp_path) -> None:
+    """Tier 1: docs/deep-dives/spec/ records a design AS PROPOSED — a
+    retired key there is a legitimate historical fact, not drift."""
+    _write(tmp_path, "docs/deep-dives/spec/design/old.md", "models:\n  standard: foo\n")
+    _git_repo(tmp_path)
+    _add(tmp_path)
+    assert offending_lines(tmp_path) == []
+
+
+def test_decisions_adr_directory_is_excluded_even_though_tracked(tmp_path) -> None:
+    """Tier 1: docs/deep-dives/decisions/ (ADRs) are immutable-by-policy
+    records of a past decision — same reasoning as spec/."""
+    _write(tmp_path, "docs/deep-dives/decisions/0001-old.md", "models:\n  standard: foo\n")
+    _git_repo(tmp_path)
+    _add(tmp_path)
+    assert offending_lines(tmp_path) == []
+
+
+def test_proposals_directory_is_excluded_even_though_tracked(tmp_path) -> None:
+    """Tier 1: docs/deep-dives/proposals/ (FP-NNNN docs) show a schema
+    shape AS PROPOSED, sometimes predating the field's eventual real name —
+    same reasoning as spec/, discovered by a real pre-flight scan (#4327),
+    not named in the original brief but structurally identical."""
+    _write(tmp_path, "docs/deep-dives/proposals/0099-old.md", "agent:\n  id: x\n")
+    _git_repo(tmp_path)
+    _add(tmp_path)
+    assert offending_lines(tmp_path) == []
+
+
+def test_journal_directory_is_excluded_even_though_tracked(tmp_path) -> None:
+    """Tier 1: docs/deep-dives/journal/ entries quote the EXACT config used
+    for a dated run — the same "records what happened" class
+    `check_tests_path_literal_reference.py` carves out for CHANGELOG.md."""
+    _write(tmp_path, "docs/deep-dives/journal/dogfood/run.md", "models:\n  standard: foo\n")
+    _git_repo(tmp_path)
+    _add(tmp_path)
+    assert offending_lines(tmp_path) == []
+
+
+def test_a_known_different_schema_file_is_excluded_even_though_tracked(tmp_path) -> None:
+    """Tier 1: docs/reference/builtin-models.md's fenced blocks are the
+    model-CATALOG entry's own field shape (`{model, max_completion_tokens}`),
+    never a `reyn.yaml` example — a real pre-flight scan (#4327) found this
+    exact file colliding on `model:` even after column-0 anchoring."""
+    _write(
+        tmp_path, "docs/reference/builtin-models.md",
+        "model: anthropic/claude-3-7-sonnet\nmax_completion_tokens: 8192\n",
+    )
+    _git_repo(tmp_path)
+    _add(tmp_path)
+    assert offending_lines(tmp_path) == []
+
+
+# ── single source: the denylist is read from _RENAMED_CONFIG_KEYS, not hand-duplicated ──
+
+
+def test_denylist_keys_are_exactly_the_renamed_config_keys_registry(tmp_path) -> None:
+    """Tier 1: the gate's denylist must be READ from
+    `reyn.config.config_schema._RENAMED_CONFIG_KEYS`, not a hand-copied
+    literal — a key registered there and nowhere else in this test file
+    (so this assertion can't pass by both sides transcribing the same
+    literal) must still be detected."""
+    assert _RENAMED_CONFIG_KEYS, "the registry must be non-empty for this test to mean anything"
+    any_retired_key = next(iter(_RENAMED_CONFIG_KEYS))
+    _write(tmp_path, "docs/guide/example.md", f"{any_retired_key}: x\n")
+    _git_repo(tmp_path)
+    _add(tmp_path)
+    offenders = offending_lines(tmp_path)
+    assert [k for _, _, k, _ in offenders] == [any_retired_key]
+
+
+# ── the real committed tree ─────────────────────────────────────────────────
+
+
+def test_the_real_repo_tree_has_zero_offenders() -> None:
+    """Tier 1: the load-bearing witness — running the real scan against the
+    real repo tree, right now, must find nothing. This is not a ratchet
+    (see module docstring "Not a ratchet") — any hit fails outright."""
+    assert offending_lines(_ROOT) == []

--- a/tests/scripts/test_check_retired_config_keys_denylist_4327.py
+++ b/tests/scripts/test_check_retired_config_keys_denylist_4327.py
@@ -127,7 +127,7 @@ def test_journal_directory_is_excluded_even_though_tracked(tmp_path) -> None:
     assert offending_lines(tmp_path) == []
 
 
-def test_a_known_different_schema_file_is_excluded_even_though_tracked(tmp_path) -> None:
+def test_a_known_different_schema_file_excludes_only_the_colliding_key(tmp_path) -> None:
     """Tier 1: docs/reference/builtin-models.md's fenced blocks are the
     model-CATALOG entry's own field shape (`{model, max_completion_tokens}`),
     never a `reyn.yaml` example — a real pre-flight scan (#4327) found this
@@ -139,6 +139,23 @@ def test_a_known_different_schema_file_is_excluded_even_though_tracked(tmp_path)
     _git_repo(tmp_path)
     _add(tmp_path)
     assert offending_lines(tmp_path) == []
+
+
+def test_a_known_different_schema_file_still_catches_other_retired_keys(tmp_path) -> None:
+    """Tier 1: lead-coder's #4332 review block — the exclusion is FILE x KEY,
+    not whole-file. `builtin-models.md` colliding on `model:` must not also
+    blind the gate to a genuine `models:` drift in the SAME file — exactly
+    the shape #4322 had to fix there the same night this gate was written."""
+    _write(
+        tmp_path, "docs/reference/builtin-models.md",
+        "model: anthropic/claude-3-7-sonnet\nmodels:\n  standard: foo\n",
+    )
+    _git_repo(tmp_path)
+    _add(tmp_path)
+    offenders = offending_lines(tmp_path)
+    assert [(str(p.relative_to(tmp_path)), n, k) for p, n, k, _ in offenders] == [
+        ("docs/reference/builtin-models.md", 2, "models"),
+    ]
 
 
 # ── single source: the denylist is read from _RENAMED_CONFIG_KEYS, not hand-duplicated ──


### PR DESCRIPTION
**[docs-maintainer]** — part of #4327 (denylist gate for retired config keys, adopted by lead-coder's comment on the issue).

## What

`tests/config/test_config_mirror_coverage_1056.py` already gates 2 files for
COVERAGE ("does the doc mention every current key"), but never asks "does
the doc still mention a key that's gone" — a rename doesn't break coverage
(the new name gets added), so a doc that keeps the OLD name around passes
silently, on any file, forever. #4322/#4323 measured the cost directly: 8
operator-facing docs (none of them one of the 2 covered files) still showed
pre-#4174-T3/T4 shapes after the renames landed.

- New `scripts/check_retired_config_keys_denylist.py`, denylist sourced
  directly from `reyn.config.config_schema._RENAMED_CONFIG_KEYS` — the SAME
  registry `reyn config validate`/`migrate` already reads, populated in the
  same PR as each rename by #4174's own T1-T7 practice. No second
  hand-kept list.
- Column-0 anchor detection (`^key:`) — a real YAML top-level mapping-key
  position. Deliberately does not catch dotted mentions
  (`web.fetch.max_download_bytes`) or an indented nested key sharing a
  retired name (`llm:\n  models:` is the current correct shape).
- Wired into `.github/workflows/test.yml`'s `docs` job, right after the
  doc-anchors check (that job already installs `reyn` via
  `pip install -e ".[docs]"`).
- `tests/scripts/test_check_retired_config_keys_denylist_4327.py`: 12 tests.

## Scope decision (per lead-coder's review comment)

Lead-coder's comment named 2 exclusions explicitly: `docs/deep-dives/spec/`
and ADRs (`docs/deep-dives/decisions/`) — design docs that legitimately
record a past schema shape. Before hardcoding just those 2, I ran a full
pre-flight scan of the whole tree with the denylist + column-0 detection
and it did **not** come back to zero — it surfaced 2 more classes, not
named in the original brief, that I'm flagging explicitly rather than
silently folding in:

**1. Two more historical-record directories, same reasoning as spec/ADR:**

- `docs/deep-dives/proposals/` — FP-NNNN proposal docs (`Status: proposed`)
  showing a schema shape AS PROPOSED, sometimes predating the field's
  eventual real name (FP-0016 Component E proposes `agent: {id: ...}`; the
  shape that actually shipped in T5 is the scalar `agent_id:`, a
  value-transform rename, not what the proposal assumed).
- `docs/deep-dives/journal/` — dated dogfood-run / feature-verify logs that
  quote the EXACT `reyn.local.yaml` block used for that run, at the time —
  the same "records what happened" class
  `check_tests_path_literal_reference.py` already carves out for
  `CHANGELOG.md` (see that script's own docstring for the identical
  argument).

I judged these as a **consistent application of the already-ratified
spec/ADR reasoning** (same structural property: a doc correctly recording
a past state), not a new exclusion criterion of my own — but flagging it
here explicitly since the brief only named 2 directories and this widens
that to 4. Happy to narrow back if that read is wrong.

**2. A different-schema single-file collision that survives column-0
anchoring:** `docs/reference/builtin-models.{,ja.}md`'s fenced blocks are
the model-CATALOG entry's own field shape (`{model, max_completion_tokens}`,
`src/reyn/llm/builtin_models.py`'s `BUILTIN_MODELS` dict), never a
`reyn.yaml` example — but still sits at column 0 in its own fenced block,
so it collides with the `model:`/`models:` entries in the denylist.
Similarly `docs/deep-dives/contributing/dogfood-tooling.md`'s
`variant_ablation.yaml` example is `scripts/dogfood_variant_replay.py`'s
own config format. Both confirm the architect's own warned-about
"different schema" FP class applies even to a narrowed denylist, not just
to a naive "compare every YAML block against the full schema" design.

Net result: **0 hits** on the real tree with all 4 dirs + these 2 files
excluded — this is not asserted from the design, it's a measured outcome
(see the script's own "Not a ratchet" section for why that lets this be a
hard gate rather than a baselined one).

## Verification

- `ruff check` — clean.
- `python scripts/mypy_ratchet.py` — clean, no new findings.
- `python scripts/test_tier_audit.py --strict tests/scripts/test_check_retired_config_keys_denylist_4327.py`
  — 12/12 OK, 0 Tier-4.
- `python scripts/verify_module_docstrings.py scripts/check_retired_config_keys_denylist.py`
  — OK.
- `rm -rf site && mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean (0
  new warnings vs. the pre-existing ja-parity anchor gaps this touches
  nothing).
- `python scripts/check_doc_anchors.py` — clean, "no dangling anchors into
  published pages" (unaffected by this PR).
- Falsification: injected `models:\n  standard: foo\n` into a real doc
  file, confirmed the gate fires red with the exact line/key/note, then
  reverted and confirmed clean again.

## Test plan

- [x] `ruff check` clean
- [x] `mypy_ratchet.py` clean
- [x] `test_tier_audit.py --strict` clean (12/12)
- [x] `verify_module_docstrings.py` clean
- [x] `mkdocs build --strict` clean (fresh `rm -rf site` rebuild)
- [x] `check_doc_anchors.py` clean
- [x] falsification: gate fires on an injected retired key, reverts clean
- [x] scope call on the 2 extra excluded directories (proposals/,
      journal/) — lead-coder confirmed these are correct as directory-level
      exclusions ("`_EXCLUDED_DIR_PREFIXES` の方はディレクトリ単位のままで正しいです")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

- [x] 🔴 (lead-coder) `_EXCLUDED_FILES` をファイル単位からファイル×キー単位に。実測: 除外 3 ファイルで column 0 に出る退役キーは `model:` のみ（他 6 キーは 0 件）。∴ 1 キーの衝突のために 7 キー分の監視を落としている。**今夜 #4322 が直したのは、まさに `builtin-models.md` の `models:` ドリフト** — 再発してもこの gate は何も言わない。実測 0 件なので、この変更で赤くなるファイルは無い。`_EXCLUDED_DIR_PREFIXES` はディレクトリ単位のままで正しい。

  **[docs-maintainer]** — Fixed in 2c79ad45a: `_EXCLUDED_FILES` (`frozenset[str]`) -> `_EXCLUDED_FILE_KEYS` (`dict[str, frozenset[str]]`), all 3 entries narrowed to `{"model"}` (independently re-measured before fixing — confirmed the same 1-key-only collision per file). Real-tree scan still 0 hits. New test (`test_a_known_different_schema_file_still_catches_other_retired_keys`) confirms `builtin-models.md` now catches a `models:` drift in the same file that also has the excluded `model:` collision — falsified both directions (injected `models:` -> fires; injected `model:` -> still excluded).

