### PR TITLE
feat(#4333): wire the sandbox 3-tuple axis contract into CI

### DIFF
--- a/.github/workflows/sandbox-landlock-deny-gate.yml
+++ b/.github/workflows/sandbox-landlock-deny-gate.yml
@@ -92,3 +92,30 @@ jobs:
       # visible rather than silently absorbed into a pass count.
       - name: Network-gate + io_uring + representative-MCP-server tests (#3030)
         run: python -m pytest tests/security/test_sandbox_seccomp_network_3030.py -v -rs --timeout=180
+
+      # #4333: the 3-tuple axis contract (deny / exception-boundary /
+      # workload) is the RICHER of CLAUDE.md's two deliberately-separate
+      # sandbox witness layers — `enforcement_self_test` (production, deny
+      # leg only, write+spawn axes only, every host) is the other, and this
+      # PR does not touch it (CLAUDE.md names only the direction "fold a
+      # new axis/leg INTO enforcement_self_test" as forbidden; running the
+      # already-existing CI-conformance layer somewhere real is the
+      # opposite of that). Before this step, the 3-tuple contract's
+      # network-axis arms had no job anywhere that both HAD Landlock
+      # available (this job, uniquely, does) AND collected the file — a
+      # declared-vs-actual gap, not a design gap: the design already put
+      # the richer contract in CI, CI just never actually ran it.
+      #
+      # All 3 files skip for the identical root cause
+      # (`LandlockBackend().available()` False — no Linux kernel Landlock
+      # support / package), independently confirmed per-file before adding
+      # this step, not inferred from "same uncovered set": test_sandbox_axis_contract_2983.py's
+      # `@requires_landlock` group (6 arms), test_sandbox_landlock.py's
+      # `test_landlock_runs_echo` (1), test_subprocess_cancel_1470.py's 2
+      # Landlock cancel arms. Same `requires_landlock`-equivalent skip-
+      # safety as the two steps above: the FATAL gate script already ran
+      # this job to completion, so a skip here would mean the gate script
+      # itself should have FATALed and didn't — -rs makes the actual ran/
+      # skipped split legible rather than inferred from a pass count.
+      - name: Sandbox 3-tuple axis-contract CI-conformance tests (#4333, previously never run anywhere)
+        run: python -m pytest tests/security/test_sandbox_axis_contract_2983.py tests/security/test_sandbox_landlock.py tests/security/test_subprocess_cancel_1470.py -v -rs --timeout=120


### PR DESCRIPTION
**[docs-maintainer]** — part of #4331 / #4333 (sandbox 3-tuple axis contract — CI wiring).

## What

CLAUDE.md's Hard rules deliberately split sandbox axis witness into 2
layers: `enforcement_self_test` (the production gate — deny leg only,
write/spawn axes only, every host) and the richer 3-tuple contract (deny /
exception-boundary / workload,
`tests/security/test_sandbox_axis_contract_2983.py`), documented as
"CI-conformance-only". Lead-coder measured (independently re-verified by
me before implementing, not reused as-is): the CI side of that split was
never actually wired. `.github/workflows/sandbox-landlock-deny-gate.yml`
(the one job with both the `sandbox-linux` extra and a real Landlock-
capable runner) only ran 2 pytest files; the axis-contract file's
`@requires_landlock`-gated group skips in every other job and was never
collected here — network-axis 3-tuple coverage existed nowhere.

- Added a 3rd pytest step to the deny-gate job, same `-v -rs --timeout=120`
  shape as the 2 existing steps:
  `tests/security/test_sandbox_axis_contract_2983.py` +
  `tests/security/test_sandbox_landlock.py` +
  `tests/security/test_subprocess_cancel_1470.py`.

## `enforcement_self_test` is NOT touched

CLAUDE.md forbids folding a new axis/leg INTO `enforcement_self_test` —
this PR does the opposite: it runs the already-existing, already-separate
CI-conformance layer somewhere real. The production gate's blast radius
(deny leg, write+spawn axes, every host) is unchanged by this PR — zero
lines in `enforcement_self_test` or its callers are touched.

## Independent re-measurement (not reused from the issue/backlog-watcher's diff)

Confirmed via both static grep AND a live local `pytest -rs` run (macOS,
Landlock unavailable — same skip path CI would hit without the
`sandbox-linux` extra):

- `test_sandbox_axis_contract_2983.py`: 6 `@requires_landlock` arms.
- `test_subprocess_cancel_1470.py`: 2 Landlock-only cancel arms.
- `test_sandbox_landlock.py`: **1** arm (`test_landlock_runs_echo`) — the
  issue text estimated `(2)` here. Live-measured local count is 1, not 2
  (confirmed by both `grep` and an actual `pytest -rs` run showing exactly
  9 skips total = 6+2+1). Flagging the discrepancy rather than silently
  going with either number.

All 9 share the identical root cause
(`LandlockBackend().available()` False), confirmed per-file, not inferred
from "same uncovered set".

Note: backlog-watcher independently produced a diff for this same issue
(posted as an issue comment after I'd already started) — it lands on the
exact same 3-file group and reasoning, which I take as convergent
confirmation rather than a reason to copy it verbatim; this PR's step was
authored and verified independently before I read that comment.

## What I could NOT verify locally (needs this PR's own CI run)

I have no Linux/Landlock-capable environment locally, so:

- **Whether these 3 files actually RUN (not skip) on the deny-gate job's
  runner** — the existing 2 steps already prove that runner has Landlock
  available, but I have not personally witnessed these 3 NEW files avoid
  the skip path there. **Test plan below has this as an explicit
  unchecked item** — will paste the actual `-rs` skip-count from this PR's
  own CI run before considering it verified, not assume success from the
  existing steps' precedent.
- **The added wall-clock cost** to the already-heavy deny-gate job — will
  measure and report from the real run.

## Test plan

- [x] YAML syntax valid (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Skip-reason root cause independently confirmed per file (grep + live
      local `pytest -rs`, not reused from the issue body)
- [x] CI's own run of this job (run 31513835399, job 93853943346):
      confirmed via the actual `-rs` output, not inferred from green.
      New step's own summary: `34 passed, 2 skipped in 1.56s`. The 2
      skips are `test_subprocess_cancel_1470.py:152`/`:172` —
      `SeatbeltBackend macOS only`, expected and unrelated to this PR
      (they're the file's OWN macOS-only arms, correctly skipping on this
      Linux runner). **Zero Landlock-availability skips** — all 9 arms
      this PR set out to cover (6 axis-contract + 1 landlock.py + 2
      subprocess-cancel) ran for real for the first time.
- [x] Wall-clock cost measured from the run: new step ran
      16:44:19.467Z -> ~16:44:23.30Z (pytest's own reported `1.56s`,
      ~4s including process startup) — negligible against the job's
      total 1m39s (dominated by the `sandbox-linux` extra's ~46s pip
      install, unrelated to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

