### PR TITLE
feat(#4331): pytest skip census in the CI job summary, not a gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,36 @@ jobs:
         # run that was going to happen anyway, so the measurement costs no
         # extra CI cycle; it is also the exact input a duration-balanced
         # shard split would need.
-        run: timeout 12m python -m pytest -q -n auto --timeout=120 -rs --durations=25
+        #
+        # `set -o pipefail` + `| tee /tmp/pytest-output.log` (#4331): the
+        # census step below needs this run's own `-rs` output to parse —
+        # `tee` gives it a file without changing what prints to the CI log.
+        # `set -o pipefail` is explicit (not relied on as a shell default)
+        # so this step's pass/fail still reflects pytest's own exit code,
+        # not `tee`'s (which always succeeds) — this step must keep failing
+        # the job exactly as before; only the informational step below is
+        # allowed to be silent about failure.
+        run: |
+          set -o pipefail
+          timeout 12m python -m pytest -q -n auto --timeout=120 -rs --durations=25 | tee /tmp/pytest-output.log
+
+      # #4331: what a green run above does NOT say — the skip census (count
+      # + reason breakdown) and the collection-error count, on the SAME
+      # surface (this job's own summary page) a human reads the green
+      # result on. Lead-coder's #4331 ruling explicitly rejected a doc line
+      # instead: a hardcoded count goes stale the moment the population
+      # shifts, and nobody opens a doc at the moment they're reading a
+      # green check — the fix has to live where the green already is.
+      #
+      # `if: always()`: the census must appear whether the run above passed
+      # or failed — visibility here does not depend on the gate's own
+      # result. `scripts/pytest_skip_census.py` never exits nonzero (see its
+      # own module docstring "Not a gate") — condition 3 from the issue:
+      # this step must never turn red over a skip count, or "reduce skips"
+      # becomes a pressure that eats correct-by-design optional-extra skips.
+      - name: Test-coverage census (#4331 — informational, not a gate)
+        if: always()
+        run: python scripts/pytest_skip_census.py /tmp/pytest-output.log >> "$GITHUB_STEP_SUMMARY"
 
   lint:
     name: ruff

--- a/scripts/check_tests_path_literal_reference_baseline.json
+++ b/scripts/check_tests_path_literal_reference_baseline.json
@@ -445,6 +445,11 @@
     "class": "never-existed"
   },
   {
+    "file": "scripts/pytest_skip_census.py",
+    "literal": "tests/foo.py",
+    "class": "never-existed"
+  },
+  {
     "file": "scripts/test_tier_audit.py",
     "literal": "tests/test_foo.py",
     "class": "never-existed"
@@ -577,6 +582,16 @@
   {
     "file": "tests/scripts/test_flat_tests_disposition_check_3879.py",
     "literal": "tests/x/test_a.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_pytest_skip_census_4331.py",
+    "literal": "tests/broken.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_pytest_skip_census_4331.py",
+    "literal": "tests/foo.py",
     "class": "never-existed"
   },
   {

--- a/scripts/pytest_skip_census.py
+++ b/scripts/pytest_skip_census.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""#4331 — surface what a green pytest run does NOT say, on the same
+screen the green is read on.
+
+## The gap this closes
+
+`tests/interfaces/test_text_effect_cache_3860.py` had 7 `@requires_tte`
+arms; CI has no `effects` extra, so the whole file skipped, and green said
+nothing about it. Measured (#4331, backlog-watcher): a real CI run carries
+**63 skipped / 10801 passed, 0 collection errors** — a real, nonzero
+population of tests a green run is silent about, split across skip
+reasons nobody had counted before this issue: sandbox-kernel-feature
+unavailability (~20, some already covered by a separate CI-only job, some
+not — see #4333), macOS-only (~15, #3881's own scope), optional-extra
+absence (~16, correct-by-design but never declared as such anywhere in
+`docs/`), and everything else (~12).
+
+CLAUDE.md's test-review Q4 names exactly this shape: "skip / collection
+error / zero collected all wear green's colour." Q4 blocks on the
+SILENCE, not the skip itself — an optional-extra skip is correct design.
+What was missing was a place a human reading the green result would
+actually see the number.
+
+## Why a doc line was rejected (lead-coder's #4331 ruling)
+
+A doc saying "CI skips ~63 tests because X" goes stale the moment the
+population shifts, and — the sharper problem — nobody opens that doc at
+the moment they're reading a green check. The fix has to live on the
+SAME SURFACE as the green: the job summary GitHub already renders next to
+the checks list. This script's whole job is producing that surface's
+content, computed fresh from the run that just happened, never a
+hardcoded count.
+
+## Not a gate
+
+This script's exit code is always 0 (see `main`'s final `return 0` — a
+parse failure degrades to an apologetic summary line, never a nonzero
+exit) — #4331's condition 3, explicit: "件数がいくつでも赤にしないでください
+… 見えるようにするだけが目的です". A CI step running this must never be
+allowed to fail the job over a skip count; skip census is purely
+informational, positioned next to the checks a human already reads, not
+a new check of its own.
+
+## Population: parsed from the SAME run's own pytest output, not re-run
+
+Takes the log file the actual `pytest -rs` invocation already produced
+(piped there via `tee` in the calling workflow step) and parses two
+things pytest's own `-r` summary already prints for free:
+
+- Every ``SKIPPED [N] path:line: reason`` line — pytest's own count of
+  how many collected test IDs hit that exact skip call site. Summed and
+  cross-checked against the final ``"... skipped ..."`` summary line so a
+  parsing bug in THIS script is visible (a mismatch prints loudly) rather
+  than silently under/over-counting.
+- Collection errors — lines pytest emits starting with ``ERROR `` when a
+  file fails to import/collect. #4331's condition 2, explicit: skip
+  counts do NOT include collection errors (a file that fails to collect
+  contributes 0 to the skipped tally, not 1), so a collection-error count
+  needs its OWN, separate line on the same summary or that population
+  stays invisible even after this script ships.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# pytest's own `-r` short-summary line for a skip:
+#   SKIPPED [1] tests/foo.py:123: some reason text
+# `loc` (path:line) never contains whitespace; `reason` starts right after
+# the first ": " that follows it — matching `\S+` for `loc` is exact, not
+# a heuristic, because pytest itself only ever emits this one fixed shape.
+_SKIP_LINE_RE = re.compile(r"^SKIPPED \[(\d+)\] (\S+): (.*)$")
+
+# pytest's own final result line, e.g. "10801 passed, 63 skipped, 37
+# warnings in 214.11s" or "3 failed, 40 passed, 2 skipped in 1.2s" — used
+# only as a CROSS-CHECK against the summed SKIPPED-line counts above, so a
+# bug in this script's own parsing surfaces as a printed mismatch instead
+# of a silently wrong number.
+_TOTAL_SKIPPED_RE = re.compile(r"(\d+) skipped")
+_TOTAL_ERRORS_RE = re.compile(r"(\d+) error")
+
+# A collection error: pytest prints a line starting with "ERROR " (not
+# indented, not "ERRORS" the section header) naming the file that failed
+# to collect. Distinct from a SKIPPED test — a file that fails to collect
+# contributes ZERO to the skipped tally, which is exactly why #4331's
+# condition 2 requires this be counted and shown separately.
+_COLLECTION_ERROR_RE = re.compile(r"^ERROR (\S+)")
+
+
+def parse_census(log_text: str) -> "dict":
+    """Everything the summary needs, computed from one pytest log's text —
+    isolated from CLI/output so it is directly testable against a fixture
+    string, no subprocess or real pytest run required."""
+    skip_reason_counts: "dict[str, int]" = {}
+    summed_skips = 0
+    for line in log_text.splitlines():
+        m = _SKIP_LINE_RE.match(line)
+        if m:
+            n, _loc, reason = int(m.group(1)), m.group(2), m.group(3)
+            skip_reason_counts[reason] = skip_reason_counts.get(reason, 0) + n
+            summed_skips += n
+
+    collection_errors = sorted({
+        m.group(1) for line in log_text.splitlines()
+        if (m := _COLLECTION_ERROR_RE.match(line))
+    })
+
+    total_match = _TOTAL_SKIPPED_RE.findall(log_text)
+    reported_total_skipped = int(total_match[-1]) if total_match else None
+
+    error_match = _TOTAL_ERRORS_RE.findall(log_text)
+    reported_total_errors = int(error_match[-1]) if error_match else None
+
+    return {
+        "skip_reason_counts": skip_reason_counts,
+        "summed_skips": summed_skips,
+        "reported_total_skipped": reported_total_skipped,
+        "collection_errors": collection_errors,
+        "reported_total_errors": reported_total_errors,
+    }
+
+
+def render_markdown(census: "dict") -> str:
+    """The job-summary markdown — every number computed fresh from THIS
+    run, nothing hardcoded (#4331 condition 1)."""
+    lines = ["## Test-coverage census (#4331 — informational, not a gate)", ""]
+
+    summed = census["summed_skips"]
+    reported = census["reported_total_skipped"]
+    lines.append(f"**{summed} test(s) skipped** this run.")
+    if reported is not None and reported != summed:
+        lines.append(
+            f"⚠️ parse mismatch: pytest's own summary line reports "
+            f"{reported} skipped, but the per-reason SKIPPED lines summed "
+            f"to {summed} — this script's parsing may be incomplete "
+            "(check for a skip line shape not matched by `_SKIP_LINE_RE`)."
+        )
+    lines.append("")
+
+    if census["skip_reason_counts"]:
+        lines.append("| count | reason |")
+        lines.append("|---:|---|")
+        for reason, count in sorted(
+            census["skip_reason_counts"].items(), key=lambda kv: -kv[1]
+        ):
+            escaped = reason.replace("|", "\\|")
+            lines.append(f"| {count} | {escaped} |")
+        lines.append("")
+
+    errors = census["collection_errors"]
+    lines.append(f"**Collection errors: {len(errors)}.**")
+    if errors:
+        lines.append(
+            "⚠️ a file that fails to collect contributes 0 to the skipped "
+            "tally above — these are invisible in the skip breakdown:"
+        )
+        for path in errors:
+            lines.append(f"- `{path}`")
+    else:
+        lines.append(
+            "(0 is the expected/healthy value — a skip census alone "
+            "cannot see a file that failed to collect; this line is what "
+            "makes that population visible instead of silently absent.)"
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    if not argv:
+        print("usage: pytest_skip_census.py <pytest-output-log-path>", file=sys.stderr)
+        return 0  # never gate — see module docstring "Not a gate"
+
+    log_path = Path(argv[0])
+    try:
+        log_text = log_path.read_text(encoding="utf-8", errors="replace")
+        census = parse_census(log_text)
+        print(render_markdown(census))
+    except Exception as exc:  # noqa: BLE001 — deliberate: never fail the job over this
+        print(
+            f"## Test-coverage census (#4331)\n\n"
+            f"⚠️ census step itself failed to produce a report: {exc!r} "
+            "(not a gate — the pytest run above is unaffected).",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_pytest_skip_census_4331.py
+++ b/tests/scripts/test_pytest_skip_census_4331.py
@@ -1,0 +1,117 @@
+"""Tier 1: scripts/pytest_skip_census.py's parsing/rendering contract.
+
+Pure-function tests over fixture log text — no subprocess, no real pytest
+run required, same discipline as the other `tests/scripts/` gate tests.
+"""
+from __future__ import annotations
+
+from scripts.pytest_skip_census import main, parse_census, render_markdown
+
+_SAMPLE_LOG = """\
+tests/foo.py::test_a SKIPPED [ 50%]
+tests/foo.py::test_b SKIPPED [100%]
+=========================== short test summary info ============================
+SKIPPED [1] tests/foo.py:10: optional extra not installed
+SKIPPED [1] tests/foo.py:20: optional extra not installed
+========================= 3 passed, 2 skipped in 0.10s =========================
+"""
+
+
+def test_skip_lines_are_summed_and_grouped_by_reason() -> None:
+    """Tier 1: two SKIPPED lines sharing the same reason text aggregate
+    into one census row, counts summed — the whole point of a census
+    (not a raw dump of every location)."""
+    census = parse_census(_SAMPLE_LOG)
+    assert census["skip_reason_counts"] == {"optional extra not installed": 2}
+    assert census["summed_skips"] == 2
+
+
+def test_summed_skips_cross_checked_against_pytests_own_total() -> None:
+    """Tier 1: the summed per-reason count must match pytest's own final
+    summary line — this is the self-check that makes a parsing bug in
+    THIS script visible rather than a silently wrong number."""
+    census = parse_census(_SAMPLE_LOG)
+    assert census["reported_total_skipped"] == census["summed_skips"] == 2
+
+
+def test_a_reason_mismatch_shows_up_as_a_warning_in_the_rendered_markdown() -> None:
+    """Tier 1: the load-bearing self-check — if `reported_total_skipped`
+    diverges from the summed count, the rendered markdown must say so."""
+    census = parse_census(_SAMPLE_LOG)
+    census["reported_total_skipped"] = 999  # simulate an undercounting bug
+    md = render_markdown(census)
+    assert "parse mismatch" in md
+    assert "999" in md
+
+
+def test_collection_errors_are_separate_from_skip_count() -> None:
+    """Tier 1: #4331 condition 2 — a file that fails to collect
+    contributes ZERO to the skipped tally (it never emits a SKIPPED
+    line), so it must be counted and shown on its own, not folded into
+    the skip total."""
+    log = _SAMPLE_LOG + "ERROR tests/broken.py\n"
+    census = parse_census(log)
+    assert census["collection_errors"] == ["tests/broken.py"]
+    assert census["summed_skips"] == 2  # unaffected by the collection error
+
+
+def test_zero_collection_errors_is_stated_explicitly_not_silently_absent() -> None:
+    """Tier 1: #4331's own motivating case — 0 collection errors must be
+    a VISIBLE, stated fact in the rendered output, not the absence of a
+    line (an absent line reads the same whether nobody checked or 0 was
+    confirmed — #4331's entire complaint about the pre-existing state)."""
+    census = parse_census(_SAMPLE_LOG)
+    md = render_markdown(census)
+    assert "Collection errors: 0" in md
+
+
+def test_a_reason_containing_a_pipe_character_does_not_break_the_markdown_table() -> None:
+    """Tier 1: a skip reason is free text and can legitimately contain
+    `|` (e.g. a type union in a docstring-derived reason) — must not
+    corrupt the markdown table's column structure."""
+    log = (
+        "SKIPPED [1] tests/foo.py:5: needs str | None support\n"
+        "1 skipped in 0.01s\n"
+    )
+    census = parse_census(log)
+    md = render_markdown(census)
+    assert "needs str \\| None support" in md
+
+
+def test_no_skips_at_all_renders_without_a_table() -> None:
+    """Tier 1: a run with 0 skips must not render an empty/broken
+    markdown table — no reason entries means no table section at all."""
+    census = parse_census("5 passed in 0.05s\n")
+    assert census["skip_reason_counts"] == {}
+    md = render_markdown(census)
+    assert "| count | reason |" not in md
+    assert "0 test(s) skipped" in md
+
+
+# ── never a gate — main() always returns 0 ──────────────────────────────────
+
+
+def test_main_returns_zero_even_with_no_args() -> None:
+    """Tier 1: #4331 condition 3 — this must never fail the CI job it
+    runs in. Missing the log-path argument is a usage error, not a
+    reason to exit nonzero."""
+    assert main([]) == 0
+
+
+def test_main_returns_zero_for_a_nonexistent_log_path(tmp_path) -> None:
+    """Tier 1: a missing/unreadable log file degrades to an apologetic
+    summary line, never a nonzero exit — same "not a gate" contract as
+    the no-args case."""
+    missing = tmp_path / "does-not-exist.log"
+    assert main([str(missing)]) == 0
+
+
+def test_main_writes_a_real_census_for_a_real_log_file(tmp_path, capsys) -> None:
+    """Tier 1: the CLI's own load-bearing path — given a real log file,
+    stdout must contain the rendered census, not just an empty success."""
+    log_path = tmp_path / "pytest-output.log"
+    log_path.write_text(_SAMPLE_LOG, encoding="utf-8")
+    assert main([str(log_path)]) == 0
+    out = capsys.readouterr().out
+    assert "2 test(s) skipped" in out
+    assert "optional extra not installed" in out


### PR DESCRIPTION
**[docs-maintainer]** — part of #4331 (skip census surfaced in the CI job summary — informational, not a gate).

## What

Measured (backlog-watcher, #4331): a real CI run carries `63 skipped /
10801 passed / 0 collection errors` — a real, nonzero population a green
run says nothing about. CLAUDE.md's test-review Q4 names this exact shape
("skip / collection error / zero collected all wear green's colour"). Q4
blocks on the SILENCE, not the skip itself — an optional-extra skip is
correct design.

Lead-coder's ruling explicitly rejected a doc line for this: a hardcoded
count goes stale the moment the population shifts, and nobody opens a doc
at the moment they're reading a green check. The fix has to live on the
SAME surface as the green — the job summary GitHub Actions already
renders next to the checks list.

## Implementation

- New `scripts/pytest_skip_census.py`: parses a pytest `-rs` log's own
  `SKIPPED [N] path:line: reason` lines (grouped/summed by reason,
  cross-checked against pytest's own final `"N skipped"` summary line so
  a bug in this script's own parsing surfaces as a printed mismatch, not
  a silently wrong number) and its `ERROR <path>` collection-error lines
  — counted **separately**, since a file that fails to collect
  contributes 0 to the skipped tally and would otherwise stay invisible.
  Renders markdown. **Never exits nonzero** — condition 3 from the issue.
- `.github/workflows/test.yml`'s "Run tests" step now tees its own
  output to `/tmp/pytest-output.log` (`set -o pipefail` made explicit in
  the run block, not relied on as a shell default, so the step's
  pass/fail still reflects pytest's own exit code, not `tee`'s). A new
  `if: always()` step feeds that log to the census script and appends
  its markdown to `$GITHUB_STEP_SUMMARY`.
- No hardcoded counts anywhere — every number is computed fresh from the
  run that just happened (condition 1).
- `tests/scripts/test_pytest_skip_census_4331.py`: 10 tests.

## The 3 conditions from the issue, addressed

1. **No hardcoded numbers** — the script parses the actual log text every
   time; nothing pinned in the workflow YAML or the script itself.
2. **Collection-error count on the same surface** — a separate, always-
   present "Collection errors: N" line, explicitly stated even at 0 (the
   0 case is #4331's own motivating complaint: an absent line reads the
   same whether nobody checked or 0 was confirmed).
3. **Not a gate** — `main()` always returns 0; the new step runs with
   `if: always()` and its own command can never fail the job. Verified
   locally: the exact `set -o pipefail | tee` pipeline still propagates
   pytest's real exit code on both a passing and a failing dry run, so
   the EXISTING "Run tests" gate is unaffected by this change.

## Verification

- `ruff check` — clean.
- `python scripts/mypy_ratchet.py` — clean, no new findings.
- `python scripts/test_tier_audit.py --strict tests/scripts/test_pytest_skip_census_4331.py`
  — 10/10 OK, 0 Tier-4.
- `python scripts/verify_module_docstrings.py scripts/pytest_skip_census.py`
  — OK.
- `python scripts/check_tests_path_literal_reference.py` — clean.
- YAML syntax valid.
- Local dry run of the exact pipeline shape (`set -o pipefail; pytest |
  tee log`) confirms exit-code propagation on both a passing run (exit 0)
  and a synthetic failing run (exit 1, not swallowed by `tee`).
- Will paste the real job summary's rendered census from this PR's own
  CI run once it completes — see Test plan.

## Test plan

- [x] `ruff check` clean
- [x] `mypy_ratchet.py` clean
- [x] `test_tier_audit.py --strict` clean (10/10)
- [x] `verify_module_docstrings.py` clean
- [x] `check_tests_path_literal_reference.py` clean
- [x] YAML syntax valid
- [x] local pipefail dry run: exit code correctly propagates through `tee`
      on both pass and fail
- [x] confirmed from this PR's own CI run
      (run 31515281299, both `pytest (Python 3.11)` and `pytest (Python
      3.12)` jobs): the "Test-coverage census" step completed
      successfully (`conclusion: success`) on both matrix legs, right
      after "Run tests" also succeeded. **Caveat, stated precisely
      rather than overclaimed**: I could not directly view the rendered
      `$GITHUB_STEP_SUMMARY` page content itself — GitHub's Actions log/
      summary UI requires authenticated session access that my fetch
      tooling doesn't carry, and `gh api`/`gh run view --json` expose no
      field for step-summary content. What I DID verify directly: (a)
      the step's own exit code, via the real run, not inferred; (b) the
      exact `set -o pipefail | tee` pipeline shape, dry-run locally
      against this repo's own real pytest output, producing correct
      markdown byte-for-byte (shown earlier in this PR's history). The
      gap between (a)+(b) and "I looked at the actual rendered GitHub
      page" is real and I'm not closing it with an inference — flagging
      it rather than claiming a direct observation I didn't make.

- [x] 🔴 RED fix (lead-coder diagnosed): this PR's OWN new files introduced
      3 illustrative `tests/...py`-shaped literals that tripped
      `check_tests_path_literal_reference.py` (#4065) — not a stale
      baseline. `tests/foo.py` / `tests/broken.py` appear only as
      synthetic pytest `-rs` sample-output text in
      `scripts/pytest_skip_census.py`'s module docstring and
      `tests/scripts/test_pytest_skip_census_4331.py`'s fixtures, never a
      real file reference. Fixed in 612b719e3 via
      `--write-baseline` per the gate's own sanctioned illustrative-
      literal path; explanation recorded here per lead-coder's request
      (the baseline JSON schema itself has no per-entry comment field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


