### PR TITLE
fix(#4285): correct the test's own subject-framing to reyn's contract, not the SDK's

### DIFF
--- a/tests/mcp/test_mcp_client_stderr_capture.py
+++ b/tests/mcp/test_mcp_client_stderr_capture.py
@@ -194,20 +194,31 @@ def test_initialize_failure_includes_stderr_tail_in_error(monkeypatch) -> None:
 
 
 def test_initialize_failure_with_real_subprocess_captures_its_actual_stderr() -> None:
-    """Tier 2: #4285 — end-to-end witness of the OFFICIAL SDK's real
-    ``errlog`` handoff, not reyn's own wiring of it.
+    """Tier 2: #4285 — the subject is reyn's own boundary contract with the
+    ``mcp`` SDK, NOT the SDK's own redirect implementation.
+
+    Framed carefully because the naive framing ("does the SDK correctly
+    redirect a child's stderr into errlog?") is a THIRD-PARTY property — the
+    exact discriminator #3872 and #4291 both had to strip out of a test
+    tonight. The question this test actually asks is reyn's own: **does the
+    ``errlog`` reyn passes to ``stdio_client`` end up carrying the stderr of
+    the child reyn told the SDK to start** — i.e. did #3698's fastmcp→SDK
+    swap silently change the contract reyn depends on. If this assertion
+    fails, that's reyn's problem either way: either reyn is no longer passing
+    ``errlog`` correctly, or reyn is depending on an SDK contract that no
+    longer holds — both are reyn's own integration boundary to notice, not
+    the SDK's internals to verify.
 
     The test above (``test_initialize_failure_includes_stderr_tail_in_error``)
-    proves reyn's OWN contract: whatever text lands in the ``errlog`` file
-    ``stdio_client`` is given gets surfaced into the ``MCPError`` message —
-    but it drives that via a fake CM that writes into the file handle
-    directly, never starting a real child process. It never witnesses that
-    a real subprocess's actual stderr output REACHES that file in the first
-    place — post-#3698 that plumbing is the official ``mcp`` SDK's
-    ``mcp.client.stdio.stdio_client``'s job, not reyn's; a regression there
-    (or in a future SDK upgrade) would go undetected by the fake-CM test
-    alone. This spins a REAL child process that writes to stderr and exits
-    nonzero, closing that gap.
+    proves the OTHER half of reyn's contract: whatever text lands in the
+    ``errlog`` file gets surfaced into the ``MCPError`` message — but it
+    drives that via a fake CM that writes into the file handle directly,
+    never starting a real child process, so it never witnesses the handoff
+    THIS test covers: a real subprocess's actual stderr output reaching that
+    file in the first place. This spins a REAL child process that writes to
+    stderr and exits nonzero — no fake CM, no wait-budget constant (the
+    subprocess's own exit is the only thing waited on, via
+    ``asyncio.run``'s normal await chain).
     """
     pytest.importorskip("mcp")
     client = MCPClient({


### PR DESCRIPTION
**[tui-coder]** — Correction to already-merged #4309 (part of #4285/#3698).

## What was wrong

#4309's docstring stated the test's subject as "witness of the OFFICIAL SDK's real errlog handoff, not reyn's own wiring of it" — exactly the third-party-property framing lead-coder's #4285 dispatch explicitly warns against (the same discriminator #3872/#4291 both had to strip out of a different test tonight). The test's own *assertion* was already correctly scoped (it asserts on `MCPError`'s message content, reyn's own output) — only the docstring's stated subject was inverted from what makes this legitimately reyn's test.

## Fix

Reframed the docstring to state explicitly: this asks whether the `errlog` reyn passes to `stdio_client` ends up carrying the stderr of the child reyn told the SDK to start — reyn's own integration boundary with the `mcp` SDK, not a verification of the SDK's internal redirect implementation. If it fails, that's reyn's problem either way (reyn stopped passing `errlog` correctly, or reyn depends on an SDK contract that silently changed) — never "the SDK has a bug."

No test logic touched — docstring only. Re-verified the form requirements from lead-coder's original #4285 dispatch:
- **Real subprocess** (`sys.executable -c "..."`, writes to stderr, exits nonzero) — no fake CM.
- **No wait-budget constant** — the only thing awaited is the subprocess's own exit, via `asyncio.run`'s normal await chain.
- **Falsify-verified**: removing the `errlog=` kwarg from the `stdio_client()` call in `src/reyn/mcp/client.py` makes this test go RED (`MCPError` message degrades to the generic "Connection closed", missing the real child's stderr text). Restored, confirmed green again (9/9 in the file).

## Test plan
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict` — OK, 9/9
- [x] `python scripts/mypy_ratchet.py` — no new findings
- [x] `pytest tests/mcp/test_mcp_client_stderr_capture.py` — 9 passed
- [x] Falsify-verified against the real production wiring

part of #3698

🤖 Generated with [Claude Code](https://claude.com/claude-code)
