### PR TITLE
fix(#4337): reyn-dir-layout.md's config/ table listed 5 files, real is 7+1

### DIFF
--- a/docs/reference/runtime/reyn-dir-layout.md
+++ b/docs/reference/runtime/reyn-dir-layout.md
@@ -100,12 +100,12 @@ mixed in at the top level) should know things moved:
 |---|---|
 | `.reyn/mcp.yaml`, `.reyn/cron.yaml`, `.reyn/hooks.yaml` | `.reyn/config/<x>.yaml` |
 | `.reyn/index/sources.yaml` | `.reyn/config/index/sources.yaml` |
+| `.reyn/index/` (data), `.reyn/action_index/`, `.reyn/registry-cache/` | `.reyn/cache/…` |
+| `.reyn/approvals.yaml` | **unchanged** (top-level — it is *persist*, not recovery-core config) |
 
 `integrations.yaml` is deliberately absent from this table (#4337): no reader/writer for it
 exists at either the old or the new location, so there is nothing that actually moved — see
 the `config/` entry above.
-| `.reyn/index/` (data), `.reyn/action_index/`, `.reyn/registry-cache/` | `.reyn/cache/…` |
-| `.reyn/approvals.yaml` | **unchanged** (top-level — it is *persist*, not recovery-core config) |
 
 ## <a id="recovery-core"></a>Recovery-core: what the WAL + snapshot generators write
 

--- a/docs/reference/runtime/reyn-dir-layout.md
+++ b/docs/reference/runtime/reyn-dir-layout.md
@@ -46,8 +46,13 @@ Everything else is excluded, by one of four reasons:
 │   ├── mcp.yaml            MCP servers   (mcp_install / mcp_drop_server)
 │   ├── cron.yaml           cron jobs     (cron_register / …)
 │   ├── hooks.yaml          push hooks    (hooks_add)
-│   ├── integrations.yaml   integrations
-│   └── index/sources.yaml  index source manifest (index ops)
+│   ├── skills.yaml         skill install/registration entries (skill_install, #2548 PR-B)
+│   ├── pipelines.yaml      pipeline install/registration entries (pipeline_install)
+│   ├── presentations.yaml  presentation-template entries (presentation_install, FP-0054 PR-C)
+│   ├── index/sources.yaml  index source manifest (index ops)
+│   └── integrations.yaml   ⏳ designed, not yet wired — no reader/writer exists (#4337);
+│                           `external_transports` config is read from reyn.yaml's own
+│                           `external_transports:` section only
 ├── memory/                 PERSIST — agent knowledge; survives rewind, never reverted
 ├── approvals.yaml          PERSIST — user-authored permission grants; survive rewind
 ├── events/ traces/ logs/   AUDIT — append-only forensic record; never restored
@@ -93,8 +98,12 @@ mixed in at the top level) should know things moved:
 
 | Was | Now |
 |---|---|
-| `.reyn/mcp.yaml`, `.reyn/cron.yaml`, `.reyn/hooks.yaml`, `.reyn/integrations.yaml` | `.reyn/config/<x>.yaml` |
+| `.reyn/mcp.yaml`, `.reyn/cron.yaml`, `.reyn/hooks.yaml` | `.reyn/config/<x>.yaml` |
 | `.reyn/index/sources.yaml` | `.reyn/config/index/sources.yaml` |
+
+`integrations.yaml` is deliberately absent from this table (#4337): no reader/writer for it
+exists at either the old or the new location, so there is nothing that actually moved — see
+the `config/` entry above.
 | `.reyn/index/` (data), `.reyn/action_index/`, `.reyn/registry-cache/` | `.reyn/cache/…` |
 | `.reyn/approvals.yaml` | **unchanged** (top-level — it is *persist*, not recovery-core config) |
 

--- a/src/reyn/runtime/external_routing.py
+++ b/src/reyn/runtime/external_routing.py
@@ -9,9 +9,11 @@ calls happen on the MCP server side.
 Components:
 
   ``ExternalTransportRouting`` — config dataclass mapping transport
-    name → MCP tool name + args template. Parsed from
-    ``reyn.yaml`` / ``.reyn/integrations.yaml`` ``external_transports``
-    section.
+    name → MCP tool name + args template. Parsed from ``reyn.yaml``'s
+    own ``external_transports`` section (#4337: an earlier draft of this
+    docstring also named ``.reyn/integrations.yaml`` as a source — no
+    reader for that path was ever wired; ``reyn.yaml`` is the only real
+    source).
 
   ``route_to_mcp(transport, destination, text, ...)`` — async
     routing function. Looks up the MCP tool from config, builds
@@ -248,7 +250,7 @@ async def route_to_mcp(
             mcp_tool="",
             detail=(
                 f"No external_transports entry for {transport!r}; "
-                f"add it under reyn.yaml or .reyn/integrations.yaml."
+                f"add it under reyn.yaml's external_transports: section."
             ),
         )
     args = build_mcp_args(


### PR DESCRIPTION
**[docs-maintainer]** — part of #4215 / #4337 (`reyn-dir-layout.md`'s config/ table under-lists reality).

## What

`docs/reference/runtime/reyn-dir-layout.md`'s config/ tree listed 5 files
(mcp/cron/hooks/integrations/index-sources). 3 real files were missing
entirely: `skills.yaml` (`skill_install.py:96`), `pipelines.yaml`
(`pipeline_install.py:100`), `presentations.yaml`
(`presentation_install.py:64`). This table is read by whoever decides
where a NEW subsystem's data belongs — an incomplete population reads as
"config/ only holds these 5 kinds", the same shape #4327 closed (a doc
used as the population instead of reality), just the opposite direction.

## A second, deeper problem the issue's "5 → 8" count had missed

Per lead-coder's own instruction — use the real side (the path the op's
code returns) as canonical — I independently re-measured before trusting
the issue's stated count, and that canon caught something the "5 → 8"
framing had missed: **`integrations.yaml`, one of the EXISTING 5 entries,
has zero reader/writer/installer anywhere in `src/reyn/` or `tests/`.**
Its only 2 mentions in the whole repo are both in
`src/reyn/runtime/external_routing.py` — a docstring line and a
user-facing error message — and that module's own docstring says "Wiring
is intentionally NOT included in this PR." `external_transports` config
is read from `reyn.yaml`'s own `external_transports:` section only.

I flagged this to lead-coder before implementing (see issue comments);
they independently re-confirmed via a different grep and ruled: keep the
entry but mark it unwired (mirroring `time-travel.md`'s own "designed,
not yet wired" phrasing for pending features, rather than deleting it —
deleting loses *why* it doesn't exist and the same prose likely gets
rewritten later), and fix the user-visible error message so an operator
following its advice doesn't do nothing.

Real count: **7 wired files + 1 documented-as-unwired entry**, not a flat
"8".

## Changes

- `docs/reference/runtime/reyn-dir-layout.md`:
  - config/ tree now lists all 7 real files, plus `integrations.yaml`
    marked `⏳ designed, not yet wired — no reader/writer exists`.
  - "Move map" table's claim that `.reyn/integrations.yaml` moved to
    `.reyn/config/integrations.yaml` removed — nothing moved, since
    neither location was ever real (doc and code didn't even agree on
    the phantom path: doc said nested under `config/`, code's error
    message said top-level `.reyn/integrations.yaml` — neither is real
    so there's no ground truth to prefer).
- `src/reyn/runtime/external_routing.py`:
  - The "unconfigured transport" error message no longer tells an
    operator to "add it under reyn.yaml or .reyn/integrations.yaml" —
    following the second half does nothing.
  - Module docstring's component summary corrected the same way, with a
    note explaining why (#4337) so a future reader doesn't reintroduce
    the same claim.

## Point 3 from the issue (`_HOT_RELOAD_FILES`)

Confirmed independently: `_HOT_RELOAD_FILES` (`config/loader.py`) does
**not** list `integrations.yaml` (or `index/sources.yaml`) — it's the
narrower "hot-reload IN-set", not "everything in config/", and its own
docstring already states that scope explicitly ("the runtime-mutable
`.reyn/*.yaml` registries — the only files the hot-reload mechanism
re-reads"). Legible as answering a different question, not a defect — no
fix needed there.

No `.ja.md` sibling exists for this doc — no mirror obligation.

## Verification

- `ruff check` — clean.
- `python scripts/mypy_ratchet.py` — clean, no new findings.
- `rm -rf site && mkdocs build --strict` — clean (fresh rebuild; only
  pre-existing ja-parity anchor gaps, unaffected by this change).
- `python scripts/check_doc_anchors.py` — clean.
- Scoped pytest across the 3 files exercising `external_routing.py`
  (`test_external_outbox_interceptor_wiring.py`,
  `test_fp0041_prd2_outbox_interceptor.py`,
  `test_fp0041_prc_external_routing.py`): **37 passed**, confirming the
  error-message text change doesn't break anything asserting on it.

## Test plan

- [x] `ruff check` clean
- [x] `mypy_ratchet.py` clean
- [x] `mkdocs build --strict` clean (fresh rebuild)
- [x] `check_doc_anchors.py` clean
- [x] scoped pytest (37 passed) across `external_routing.py`'s test
      coverage
- [x] `integrations.yaml` discrepancy flagged to lead-coder BEFORE
      implementing, independently re-confirmed by them, ruling recorded
      in the issue comments and reflected in this diff
- [x] 🔴 RED/render fix (lead-coder caught via GFM-syntax derivation, not
      by viewing the render — flagged that distinction explicitly): the
      `integrations.yaml` explanatory paragraph had landed BETWEEN the
      Move-map table's data rows, splitting one GFM table into two — the
      trailing 2 rows lost their header and rendered as raw pipe text.
      `mkdocs --strict` still passed (syntactically valid, wrong render)
      — same "gate answers a different question" shape as tonight's
      other findings. Fixed in bac350322: moved the paragraph after all
      4 rows. **Verified by directly reading the built HTML**, not
      inferred from the Markdown source: `grep -c "<table>"` on the
      built page + confirmed the Move-map section is exactly one
      `<table>` with a single `<thead>` covering all 4 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

- [x] 🔴 (lead-coder 確認済み: 段落を表の後ろへ、build して <table> 単一を実測) (lead-coder) `integrations.yaml` の注記段落が**移行表の途中**に入っており、表が 2 つに割れる（残り 2 行がヘッダを失い、パイプ込みの生テキストで描画される）。`mkdocs --strict` は通る＝構文エラーではなく意味が変わるだけ。段落を表の**後ろ**へ。私は描画を見ていないので、build して `<table>` が 1 つか 2 つかで確定してください。


