### PR TITLE
fix(#4295): reyn config migrate no longer deletes every comment in the file

### DIFF
--- a/src/reyn/config/migrate_check.py
+++ b/src/reyn/config/migrate_check.py
@@ -1,0 +1,67 @@
+"""Verify a text-level config migrate rewrite before it is trusted (#4295).
+
+``migrate_text.rewrite_text`` only ever moves the specific lines a rename
+targets — everything else in the file is untouched by construction. But
+"untouched by construction" is a claim about the CODE, not a proof about a
+given INPUT file; a shape the line-based extractor didn't anticipate could
+still silently produce a value-losing result. This module is the
+independent check: re-parse the rewritten text and the original text, apply
+the SAME rename mapping to the original's PARSED structure (the same
+dotted-path move ``_migrate`` already used before #4295), and assert the
+two are equal, key for key. A mismatch means "don't trust this rewrite" —
+the caller falls back to reporting the affected keys as needing manual
+migration rather than writing a file that might be silently wrong.
+"""
+from __future__ import annotations
+
+import yaml
+
+
+def _pop_dotted(d: dict, dotted: str):
+    parts = dotted.split(".")
+    node = d
+    for part in parts[:-1]:
+        if not isinstance(node, dict) or part not in node:
+            return False, None
+        node = node[part]
+    if not isinstance(node, dict) or parts[-1] not in node:
+        return False, None
+    return True, node.pop(parts[-1])
+
+
+def _set_dotted(d: dict, dotted: str, value) -> None:
+    parts = dotted.split(".")
+    node = d
+    for part in parts[:-1]:
+        nxt = node.get(part)
+        if not isinstance(nxt, dict):
+            nxt = {}
+            node[part] = nxt
+        node = nxt
+    node[parts[-1]] = value
+
+
+def verify_rewrite(
+    original_text: str, rewritten_text: str, renames: dict[str, str],
+) -> bool:
+    """True iff applying `renames` structurally to `original_text`'s parsed
+    form matches what `rewritten_text` actually parses to. Malformed YAML on
+    either side (should never happen — `rewrite_text` only moves lines, it
+    doesn't invent syntax) is treated as a verification FAILURE, not an
+    exception the caller must separately guard."""
+    try:
+        original = yaml.safe_load(original_text) or {}
+        rewritten = yaml.safe_load(rewritten_text) or {}
+    except Exception:
+        return False
+    if not isinstance(original, dict) or not isinstance(rewritten, dict):
+        return False
+
+    expected = dict(original)
+    for old_key, new_key in renames.items():
+        found, value = _pop_dotted(expected, old_key)
+        if not found:
+            continue
+        _set_dotted(expected, new_key, value)
+
+    return expected == rewritten

--- a/src/reyn/config/migrate_text.py
+++ b/src/reyn/config/migrate_text.py
@@ -1,0 +1,256 @@
+"""Comment-preserving text-level rewrite for ``reyn config migrate`` (#4295).
+
+``_migrate`` used to round-trip the WHOLE file through ``yaml.safe_load`` +
+``yaml.dump`` to apply a handful of key renames. PyYAML's loader has no
+comment model at all — every operator comment, and every bit of the
+operator's own formatting choices (flow-style lists, quoting, blank-line
+grouping) on keys it never even touched, was silently discarded on every
+migrate run. The owner hit this directly on their own 51-line ``reyn.yaml``:
+migrate produced 17 lines, and every explanatory comment (API-key warnings,
+rename history, why a key was removed) was gone with no warning that
+anything but the moved keys had changed.
+
+This module rewrites ONLY the renamed keys' own lines, byte-for-byte
+untouched everywhere else — no round-trip through a YAML dumper at all, so
+nothing an operator wrote (comment, flow list, quote style) on a key this
+migrate run doesn't touch can be reformatted, let alone dropped.
+
+Scope, deliberately narrow — anything outside it is refused, not guessed at
+(the operator gets "migrate this by hand" instead of a silently wrong file):
+  - Only TOP-LEVEL (column-0) keys are moved — no old key with a dot in it
+    (a nested source) is supported.
+  - A destination is either a bare key (``new_name``, same depth) or exactly
+    one level of nesting (``parent.child``). Two or more dots is refused.
+  - The key must be found in an unambiguous top-level ``key:`` line — inside
+    a flow mapping (``{a: 1}``), inside a comment, or duplicated is refused.
+
+Every rewrite is verified before it is trusted: the new text is itself
+re-parsed and compared, key for key, against applying the SAME rename to the
+ORIGINAL parsed structure (`config_migrate_check.verify_rewrite`) — if they
+disagree, the rewrite is rejected and the caller reports "needs manual
+review" instead of writing a file that might be silently wrong.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+
+@dataclass
+class _Chunk:
+    """One renamed key's own lines, extracted verbatim (leading comments +
+    the key line + its block value if any) — never reformatted, only moved
+    and, for the key line only, renamed."""
+
+    lines: list[str]
+    key_line_index: int  # index within `lines` of the actual `key:` line
+
+
+@dataclass
+class RewriteResult:
+    text: str | None  # None when refused
+    applied: list[tuple[str, str]] = field(default_factory=list)
+    refused: list[str] = field(default_factory=list)  # old_key names refused
+
+
+_TOP_LEVEL_KEY_RE = re.compile(r"^([A-Za-z0-9_.\-]+):(.*)$")
+_COMMENT_ONLY_RE = re.compile(r"^\s*#")
+_BLANK_RE = re.compile(r"^\s*$")
+
+
+def _indent(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def _find_top_level_key(lines: list[str], key: str) -> int | None:
+    """Return the line index of the unambiguous top-level `key:` line, or
+    None if not found / found more than once (refuse rather than guess)."""
+    hits = [
+        i for i, line in enumerate(lines)
+        if not _COMMENT_ONLY_RE.match(line)
+        and (m := _TOP_LEVEL_KEY_RE.match(line))
+        and m.group(1) == key
+    ]
+    if len(hits) != 1:
+        return None
+    return hits[0]
+
+
+def _block_extent(lines: list[str], key_line_idx: int) -> int:
+    """Return the EXCLUSIVE end index of `key`'s value block starting right
+    after its own line. A same-line scalar/flow value has an empty block
+    (returns key_line_idx + 1). A block value (nothing but whitespace/comment
+    after the colon) extends through every following line that is blank or
+    indented past column 0, stopping at the next column-0 non-blank line."""
+    key_line = lines[key_line_idx]
+    m = _TOP_LEVEL_KEY_RE.match(key_line)
+    assert m is not None
+    trailing = m.group(2).strip()
+    if trailing and not trailing.startswith("#"):
+        return key_line_idx + 1  # same-line scalar/flow value, no block
+    i = key_line_idx + 1
+    while i < len(lines):
+        line = lines[i]
+        if _BLANK_RE.match(line):
+            i += 1
+            continue
+        if _indent(line) == 0:
+            break
+        i += 1
+    return i
+
+
+def _leading_comment_start(lines: list[str], key_line_idx: int) -> int:
+    """Return the start index of the contiguous run of column-0 comment
+    lines directly above `key_line_idx` (no blank line breaking the run) —
+    the operator's own explanation of that key, which moves WITH it."""
+    i = key_line_idx - 1
+    while i >= 0 and _indent(lines[i]) == 0 and _COMMENT_ONLY_RE.match(lines[i]):
+        i -= 1
+    return i + 1
+
+
+def _extract_chunk(lines: list[str], old_key: str) -> tuple[_Chunk, int, int] | None:
+    """Find + extract `old_key`'s chunk (leading comments + key line + block).
+    Returns (chunk, start_idx, end_idx) [start, end) in the ORIGINAL lines,
+    or None if the key can't be unambiguously located."""
+    key_idx = _find_top_level_key(lines, old_key)
+    if key_idx is None:
+        return None
+    start = _leading_comment_start(lines, key_idx)
+    end = _block_extent(lines, key_idx)
+    chunk_lines = lines[start:end]
+    return _Chunk(lines=chunk_lines, key_line_index=key_idx - start), start, end
+
+
+def _rename_key_line(chunk: _Chunk, new_leaf: str) -> _Chunk:
+    """Return a copy of `chunk` with its key line's key token renamed to
+    `new_leaf` (the trailing value/comment on that line is untouched)."""
+    key_line = chunk.lines[chunk.key_line_index]
+    m = _TOP_LEVEL_KEY_RE.match(key_line)
+    assert m is not None
+    new_key_line = f"{new_leaf}:{m.group(2)}"
+    new_lines = list(chunk.lines)
+    new_lines[chunk.key_line_index] = new_key_line
+    return _Chunk(lines=new_lines, key_line_index=chunk.key_line_index)
+
+
+def _reindent(chunk: _Chunk, extra_spaces: int) -> _Chunk:
+    return _Chunk(
+        lines=[
+            (" " * extra_spaces + line) if line.strip() else line
+            for line in chunk.lines
+        ],
+        key_line_index=chunk.key_line_index,
+    )
+
+
+def rewrite_text(text: str, renames: dict[str, str]) -> RewriteResult:
+    """Apply `renames` (old_key -> destination) to `text`, in place, moving
+    only the renamed keys' own lines — see module docstring for scope.
+
+    `destination` is either `new_name` (same depth) or `parent.child` (one
+    level of nesting under `parent:`, created if absent, appended to if
+    present). Anything outside that scope is refused per-key: the return's
+    `refused` list names which old keys need manual migration; `applied`
+    names which were rewritten. `text` is returned unmodified (`.text` is
+    the caller's file content either way) when NOTHING could be applied.
+    """
+    lines = text.split("\n")
+    had_trailing_newline = text.endswith("\n")
+    if had_trailing_newline and lines and lines[-1] == "":
+        lines = lines[:-1]
+
+    applied: list[tuple[str, str]] = []
+    refused: list[str] = []
+
+    # ── extract every renamed key's chunk first (positions are stable
+    # since we haven't mutated `lines` yet) ────────────────────────────
+    extractions: dict[str, tuple[_Chunk, int, int]] = {}
+    for old_key, destination in renames.items():
+        if old_key.count(".") > 0:
+            refused.append(old_key)  # nested source key — out of scope
+            continue
+        dots = destination.count(".")
+        if dots > 1:
+            refused.append(old_key)  # more than one level of nesting — out of scope
+            continue
+        found = _extract_chunk(lines, old_key)
+        if found is None:
+            refused.append(old_key)
+            continue
+        extractions[old_key] = found
+
+    if not extractions:
+        return RewriteResult(text=None if refused else text, refused=refused)
+
+    # ── group by destination parent (None = same-depth rename) ─────────
+    same_depth: list[tuple[str, str]] = []  # (old_key, new_key)
+    by_parent: dict[str, list[tuple[str, str]]] = {}
+    for old_key in extractions:
+        destination = renames[old_key]
+        if "." in destination:
+            parent, child = destination.split(".", 1)
+            by_parent.setdefault(parent, []).append((old_key, child))
+        else:
+            same_depth.append((old_key, destination))
+
+    # ── determine which ORIGINAL-line index is being removed, and what
+    # (if anything) gets inserted starting at which ORIGINAL index — both
+    # computed against the ORIGINAL, untouched `lines`, then applied in a
+    # single forward pass so no index-shift bookkeeping is needed ────────
+    removed_ranges = [
+        (extractions[old_key][1], extractions[old_key][2])
+        for old_key in extractions
+    ]
+
+    # First pass: does `parent` already exist as a top-level key in the
+    # ORIGINAL text (not counting what we're about to remove — a renamed
+    # key can never itself be named `parent`, since parents here are new
+    # namespaces like `llm`, not any of the old top-level keys)?
+    inserts_at: dict[int, list[str]] = {}
+
+    same_depth_lines: list[str] = []
+    for old_key, new_key in same_depth:
+        chunk, _s, _e = extractions[old_key]
+        renamed = _rename_key_line(chunk, new_key)
+        same_depth_lines.extend(renamed.lines)
+        applied.append((old_key, new_key))
+    if same_depth:
+        anchor = min(extractions[old_key][1] for old_key, _new_key in same_depth)
+        inserts_at.setdefault(anchor, []).extend(same_depth_lines)
+
+    for parent, members in by_parent.items():
+        member_lines: list[str] = []
+        for old_key, child in members:
+            chunk, _s, _e = extractions[old_key]
+            renamed = _rename_key_line(chunk, child)
+            reindented = _reindent(renamed, 2)
+            member_lines.extend(reindented.lines)
+            applied.append((old_key, f"{parent}.{child}"))
+        existing_idx = _find_top_level_key(lines, parent)
+        if existing_idx is not None:
+            block_end = _block_extent(lines, existing_idx)
+            # Append to the existing block. `block_end` is an index into the
+            # ORIGINAL lines that is NOT itself part of any removed range
+            # (it's the first line after the parent's own block) — safe to
+            # use as an insertion anchor directly.
+            inserts_at.setdefault(block_end, []).extend(member_lines)
+        else:
+            anchor = min(extractions[old_key][1] for old_key, _child in members)
+            inserts_at.setdefault(anchor, []).extend([f"{parent}:", *member_lines])
+
+    new_lines: list[str] = []
+    for i, line in enumerate(lines):
+        if i in inserts_at:
+            new_lines.extend(inserts_at[i])
+        if any(start <= i < end for start, end in removed_ranges):
+            continue
+        new_lines.append(line)
+    if len(lines) in inserts_at:  # an insertion anchored at end-of-file
+        new_lines.extend(inserts_at[len(lines)])
+
+    result_text = "\n".join(new_lines)
+    if had_trailing_newline:
+        result_text += "\n"
+    return RewriteResult(text=result_text, applied=applied, refused=refused)

--- a/src/reyn/interfaces/cli/commands/config.py
+++ b/src/reyn/interfaces/cli/commands/config.py
@@ -451,58 +451,85 @@ def _migrate(*, dry_run: bool = False) -> None:
             return False, None
         return True, node.pop(parts[-1])
 
-    def _set_dotted(d: dict, dotted: str, value) -> None:
-        parts = dotted.split(".")
-        node = d
-        for part in parts[:-1]:
-            nxt = node.get(part)
-            if not isinstance(nxt, dict):
-                nxt = {}
-                node[part] = nxt
-            node = nxt
-        node[parts[-1]] = value
-
     def _label(path: Path) -> str:
         try:
             return str(path.relative_to(project_root)) if project_root else str(path)
         except ValueError:
             return str(path)
 
+    from reyn.config.migrate_check import verify_rewrite
+    from reyn.config.migrate_text import rewrite_text
+
+    _VALUE_TRANSFORM = "value transform, not a plain rename"
+    _UNSUPPORTED_SHAPE = (
+        "could not confidently rewrite this key's YAML in place "
+        "(unsupported shape — e.g. nested source key, >1 level of nesting "
+        "in the destination, or the key wasn't found in an unambiguous "
+        "top-level form)"
+    )
+    _VERIFY_FAILED = (
+        "the rewrite's own self-check disagreed with the expected result — "
+        "refused rather than risk writing a wrong value"
+    )
+
     any_changes = False
-    manual_found: list[tuple[str, str]] = []
+    manual_found: list[tuple[str, str, str]] = []  # (label, old_key, reason)
     for path in candidates:
         cfg = _read(path)
         if not cfg:
             continue
-        changed_here = []
-        for old_key, new_key in auto_rewritable.items():
-            found, value = _pop_dotted(cfg, old_key)
-            if not found:
-                continue
-            _set_dotted(cfg, new_key, value)
-            changed_here.append((old_key, new_key))
+        # Peek (on the PARSED structure) which auto-rewritable keys are
+        # actually present in this file — decides WHAT to attempt, not
+        # how to write it (that part moved to the text-level rewrite
+        # below, #4295: yaml.safe_load + yaml.dump round-tripped the
+        # WHOLE file through PyYAML's comment-blind loader, silently
+        # dropping every operator comment on every migrate run — not
+        # just on the renamed keys, on every key in the file).
+        present_here = {
+            old_key: new_key for old_key, new_key in auto_rewritable.items()
+            if _pop_dotted(dict(cfg), old_key)[0]  # peek, don't mutate
+        }
         for old_key in needs_manual:
             found, _value = _pop_dotted(dict(cfg), old_key)  # peek, don't mutate
             if found:
-                manual_found.append((_label(path), old_key))
-        if not changed_here:
+                manual_found.append((_label(path), old_key, _VALUE_TRANSFORM))
+        if not present_here:
             continue
+
+        raw_text = path.read_text(encoding="utf-8")
+        result = rewrite_text(raw_text, present_here)
+        # Refused per-key (out of this rewriter's deliberately narrow
+        # scope — see migrate_text's module docstring) fall back to
+        # manual review rather than being silently skipped.
+        for old_key in result.refused:
+            manual_found.append((_label(path), old_key, _UNSUPPORTED_SHAPE))
+        if not result.applied or result.text is None:
+            continue
+        applied_map = dict(result.applied)
+        if not verify_rewrite(raw_text, result.text, applied_map):
+            # The independent structural re-check disagrees with the
+            # text-level rewrite — refuse to write a file we can't
+            # confirm is value-preserving. #4295's hard requirement:
+            # never silently corrupt an operator's config.
+            for old_key in applied_map:
+                manual_found.append((_label(path), old_key, _VERIFY_FAILED))
+            continue
+
         any_changes = True
         print(f"{_label(path)}:")
-        for old_key, new_key in changed_here:
+        for old_key, new_key in result.applied:
             print(f"  {old_key} -> {new_key}")
         if not dry_run:
-            path.write_text(
-                yaml.dump(cfg, allow_unicode=True, default_flow_style=False, sort_keys=False),
-                encoding="utf-8",
-            )
+            path.write_text(result.text, encoding="utf-8")
 
     if manual_found:
-        print("\nThe following renamed key(s) need manual review (value "
-              "transform, not a plain rename — see 'reyn config validate' "
-              "for guidance):")
-        for label, old_key in manual_found:
-            print(f"  {label}: {old_key} — {_RENAMED_CONFIG_KEYS[old_key].note}")
+        print("\nThe following renamed key(s) need manual review:")
+        for label, old_key, reason in manual_found:
+            note = (
+                _RENAMED_CONFIG_KEYS[old_key].note
+                if reason is _VALUE_TRANSFORM else reason
+            )
+            print(f"  {label}: {old_key} — {note}")
 
     if not any_changes and not manual_found:
         print("No renamed keys found in your config — nothing to migrate.")

--- a/tests/interfaces/test_config_validate_migrate_command_4174.py
+++ b/tests/interfaces/test_config_validate_migrate_command_4174.py
@@ -148,13 +148,22 @@ def test_migrate_rewrites_an_unambiguous_plain_rename(project, capsys, monkeypat
     """Tier 2: #4174 T0b — an entry whose hint has a non-None
     ``destination`` (a plain rename, no value transform) is auto-rewritten
     in place, old key removed (lead-coder's block on #4190: the decision
-    is a typed field, not a syntactic proxy)."""
+    is a typed field, not a syntactic proxy).
+
+    Destination is one level of nesting (``new_parent.key``), not two
+    (``new.nested.key`` as this test originally used) — #4295's
+    comment-preserving text rewrite deliberately supports only 0 or 1
+    levels of destination nesting (every currently-registered real rename
+    is one of those two shapes; see ``migrate_text``'s module docstring
+    for why deeper nesting is refused rather than guessed at). This test's
+    own intent (a plain rename WITH nesting is auto-rewritten) is
+    unaffected by narrowing the example to a supported shape."""
     from reyn.config.config_schema import RenamedKeyHint
 
     monkeypatch.setattr(
         "reyn.config.config_schema._RENAMED_CONFIG_KEYS",
         {"old_flat_key": RenamedKeyHint(
-            note="moved to new.nested.key", destination="new.nested.key",
+            note="moved to new_parent.key", destination="new_parent.key",
         )},
     )
     _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML + "old_flat_key: hello\n")
@@ -165,9 +174,9 @@ def test_migrate_rewrites_an_unambiguous_plain_rename(project, capsys, monkeypat
     import yaml
     cfg = yaml.safe_load((project / "reyn.yaml").read_text())
     assert "old_flat_key" not in cfg
-    assert cfg["new"]["nested"]["key"] == "hello"
+    assert cfg["new_parent"]["key"] == "hello"
     out = capsys.readouterr().out
-    assert "old_flat_key -> new.nested.key" in out
+    assert "old_flat_key -> new_parent.key" in out
 
 
 def test_migrate_dry_run_does_not_write(project, capsys, monkeypatch) -> None:
@@ -262,3 +271,235 @@ def test_migrate_subcommand_is_registered():
     args = parser.parse_args(["config", "migrate", "--dry-run"])
     assert args.config_cmd == "migrate"
     assert args.dry_run is True
+
+
+# ── #4295: comment-preserving rewrite ────────────────────────────────────
+#
+# The owner hit this directly: `yaml.safe_load` + `yaml.dump` round-tripped
+# the WHOLE file through PyYAML's comment-blind loader on every migrate run,
+# silently dropping every operator comment (API-key warnings, rename
+# history, why a key was removed) — not just on the renamed keys, on the
+# whole file. `_migrate` now rewrites only the renamed keys' own lines via
+# `reyn.config.migrate_text.rewrite_text`, verified against an independent
+# structural re-check (`reyn.config.migrate_check.verify_rewrite`) before
+# ever being written.
+
+
+def test_migrate_preserves_a_leading_comment_on_an_in_place_rename(
+    project, monkeypatch,
+) -> None:
+    """Tier 2: #4295 — a same-depth rename keeps the operator's own
+    explanatory comment directly above the key, unchanged."""
+    from reyn.config.config_schema import RenamedKeyHint
+
+    monkeypatch.setattr(
+        "reyn.config.config_schema._RENAMED_CONFIG_KEYS",
+        {"events": RenamedKeyHint(
+            note="moved to audit_events", destination="audit_events",
+        )},
+    )
+    _write_yaml(project / "reyn.yaml", (
+        "# API keys must be set as environment variables — never in config files.\n"
+        "events:\n"
+        "  keep_days: 30\n"
+    ))
+
+    from reyn.interfaces.cli.commands.config import _migrate
+    _migrate()
+
+    text = (project / "reyn.yaml").read_text()
+    assert "# API keys must be set as environment variables" in text
+    assert "audit_events:" in text
+    assert "events:" not in text.replace("audit_events:", "")
+
+
+def test_migrate_preserves_an_inline_comment_on_an_in_place_rename(
+    project, monkeypatch,
+) -> None:
+    """Tier 2: #4295 — the owner's report explicitly named inline
+    (same-line, ``key: value  # comment``) comments as also lost; this
+    pins them surviving specifically, not just leading ones."""
+    from reyn.config.config_schema import RenamedKeyHint
+
+    monkeypatch.setattr(
+        "reyn.config.config_schema._RENAMED_CONFIG_KEYS",
+        {"api_base": RenamedKeyHint(
+            note="moved to llm.api_base", destination="llm.api_base",
+        )},
+    )
+    _write_yaml(project / "reyn.yaml", (
+        "llm:\n  router:\n    use: false\n"
+        "api_base: http://localhost:8000  # ← 追加\n"
+    ))
+
+    from reyn.interfaces.cli.commands.config import _migrate
+    _migrate()
+
+    text = (project / "reyn.yaml").read_text()
+    assert "# ← 追加" in text
+    assert "http://localhost:8000" in text
+
+
+def test_migrate_creates_a_new_parent_block_preserving_comments_and_a_nested_value(
+    project, monkeypatch,
+) -> None:
+    """Tier 2: #4295 — a nesting move (`model`/`models` -> `llm.*`) creates
+    a NEW `llm:` block, carrying the moved keys' own leading comments and a
+    multi-line nested mapping value (`models:`'s own sub-keys), correctly
+    re-indented as children of `llm:`."""
+    from reyn.config.config_schema import RenamedKeyHint
+
+    monkeypatch.setattr(
+        "reyn.config.config_schema._RENAMED_CONFIG_KEYS",
+        {
+            "model": RenamedKeyHint(note="moved to llm.model", destination="llm.model"),
+            "models": RenamedKeyHint(note="moved to llm.models", destination="llm.models"),
+        },
+    )
+    _write_yaml(project / "reyn.yaml", (
+        "# FP-0014 renamed python.pure -> python.safe\n"
+        "model: standard\n"
+        "models:\n"
+        "  standard: openai/gpt-4\n"
+        "  light: openai/gpt-4-mini\n"
+        "allowed_openai_params: [\"tool_choice\"]\n"
+    ))
+
+    from reyn.interfaces.cli.commands.config import _migrate
+    _migrate()
+
+    text = (project / "reyn.yaml").read_text()
+    assert "llm:" in text
+    assert "# FP-0014 renamed python.pure -> python.safe" in text
+    # The nested value's own sub-keys survived, re-indented under `llm:`.
+    assert "    standard: openai/gpt-4" in text
+    assert "    light: openai/gpt-4-mini" in text
+    # A key this migrate run never touched keeps its exact original
+    # (flow-style) formatting — #4295's second finding: the old
+    # yaml.dump round-trip reformatted EVERY key in the file, not just
+    # the renamed ones (`["tool_choice"]` became block-style).
+    assert 'allowed_openai_params: ["tool_choice"]' in text
+
+    import yaml
+    cfg = yaml.safe_load(text)
+    assert cfg["llm"]["model"] == "standard"
+    assert cfg["llm"]["models"] == {"standard": "openai/gpt-4", "light": "openai/gpt-4-mini"}
+    assert cfg["allowed_openai_params"] == ["tool_choice"]
+
+
+def test_migrate_appends_to_an_existing_parent_block(project, monkeypatch) -> None:
+    """Tier 2: #4295 — when the destination's parent block already exists
+    (an operator who already has an `llm:` section), the moved key is
+    APPENDED to it rather than creating a conflicting second `llm:` key
+    (which would be invalid YAML)."""
+    from reyn.config.config_schema import RenamedKeyHint
+
+    monkeypatch.setattr(
+        "reyn.config.config_schema._RENAMED_CONFIG_KEYS",
+        {"api_base": RenamedKeyHint(
+            note="moved to llm.api_base", destination="llm.api_base",
+        )},
+    )
+    _write_yaml(project / "reyn.yaml", (
+        "llm:\n  router:\n    use: false\n"
+        "api_base: http://localhost:8000\n"
+    ))
+
+    from reyn.interfaces.cli.commands.config import _migrate
+    _migrate()
+
+    import yaml
+    text = (project / "reyn.yaml").read_text()
+    assert text.count("llm:") == 1  # never a second top-level llm: key
+    cfg = yaml.safe_load(text)
+    assert cfg["llm"]["router"]["use"] is False
+    assert cfg["llm"]["api_base"] == "http://localhost:8000"
+
+
+def test_migrate_refuses_an_unsupported_shape_and_leaves_the_file_untouched(
+    project, capsys, monkeypatch,
+) -> None:
+    """Tier 2: #4295 — a destination with more than one level of nesting is
+    out of this rewriter's deliberately narrow scope (see
+    ``migrate_text``'s module docstring); it's reported as needing manual
+    review, and the file is left completely untouched rather than
+    partially rewritten."""
+    from reyn.config.config_schema import RenamedKeyHint
+
+    monkeypatch.setattr(
+        "reyn.config.config_schema._RENAMED_CONFIG_KEYS",
+        {"old_key": RenamedKeyHint(
+            note="moved to a.b.c", destination="a.b.c",
+        )},
+    )
+    original = "# a comment\nold_key: hello\n"
+    _write_yaml(project / "reyn.yaml", original)
+
+    from reyn.interfaces.cli.commands.config import _migrate
+    _migrate()
+
+    text = (project / "reyn.yaml").read_text()
+    assert text == original, "file must be byte-identical when the rewrite is refused"
+    out = capsys.readouterr().out
+    assert "manual review" in out.lower()
+    assert "old_key" in out
+
+
+def test_migrate_value_identity_survives_a_multi_key_rewrite(project, monkeypatch) -> None:
+    """Tier 2: #4295, the load-bearing test — every value in a config with
+    several renamed keys (mixing same-depth and nesting-move destinations)
+    is bit-for-bit preserved after migrate, checked by flattening both the
+    pre- and post-migrate parsed structures and comparing (the same manual
+    technique used to verify the owner's real recovered file, now
+    automated instead of one-off)."""
+    from reyn.config.config_schema import RenamedKeyHint
+
+    monkeypatch.setattr(
+        "reyn.config.config_schema._RENAMED_CONFIG_KEYS",
+        {
+            "events": RenamedKeyHint(note="-> audit_events", destination="audit_events"),
+            "model": RenamedKeyHint(note="-> llm.model", destination="llm.model"),
+            "api_base": RenamedKeyHint(note="-> llm.api_base", destination="llm.api_base"),
+        },
+    )
+    original_text = (
+        "# a leading comment\n"
+        "model: standard\n"
+        "api_base: http://localhost:8000  # inline\n"
+        "events:\n  keep_days: 30\n"
+        "unrelated_key: [1, 2, 3]\n"
+    )
+    _write_yaml(project / "reyn.yaml", original_text)
+
+    import yaml
+    before = yaml.safe_load(original_text)
+
+    from reyn.interfaces.cli.commands.config import _migrate
+    _migrate()
+
+    after = yaml.safe_load((project / "reyn.yaml").read_text())
+
+    def _flatten(d, prefix="") -> dict:
+        out = {}
+        for k, v in d.items():
+            key = f"{prefix}.{k}" if prefix else k
+            if isinstance(v, dict):
+                out.update(_flatten(v, key))
+            else:
+                out[key] = v
+        return out
+
+    before_flat = _flatten(before)
+    after_flat = _flatten(after)
+    # Apply the SAME renames to the "before" side, then the two flattened
+    # maps must be identical — no value silently changed or dropped.
+    renamed_before = {
+        (
+            k.replace("events", "audit_events", 1) if k.startswith("events")
+            else k.replace("model", "llm.model", 1) if k == "model"
+            else k.replace("api_base", "llm.api_base", 1) if k == "api_base"
+            else k
+        ): v
+        for k, v in before_flat.items()
+    }
+    assert renamed_before == after_flat

--- a/tests/interfaces/test_config_validate_migrate_command_4174.py
+++ b/tests/interfaces/test_config_validate_migrate_command_4174.py
@@ -503,3 +503,12 @@ def test_migrate_value_identity_survives_a_multi_key_rewrite(project, monkeypatc
         for k, v in before_flat.items()
     }
     assert renamed_before == after_flat
+    # Concrete values too, not just the equality check above — lead-coder's
+    # nit: the two sides use different derivation methods (rename-the-flat-
+    # dict vs. re-parse-the-file), so a concrete assert here isn't the
+    # transcribed-implementation trap (six questions §2); it's a second,
+    # independent statement of what "correct" means.
+    assert after_flat["llm.model"] == "standard"
+    assert after_flat["llm.api_base"] == "http://localhost:8000"
+    assert after_flat["audit_events.keep_days"] == 30
+    assert after_flat["unrelated_key"] == [1, 2, 3]


### PR DESCRIPTION
**[tui-coder]** — Implemented form 1 (line-level rewrite, no new dependency) per lead-coder's lean — it handles every currently-registered rename shape cleanly, including the nesting-into-`llm:` case that was the concrete worry.

## Form decision: form 1 worked, form 2 (ruamel.yaml) not needed

Tried the actual registered renames end to end: `events` -> `audit_events` (same-depth) and `model`/`models`/`model_class_by_purpose`/`api_base`/`prompt_cache_enabled` -> `llm.*` (nesting move, including `models:`'s own multi-line nested mapping value). Both worked correctly, comments and all — see the smoke test output in the commit message. Form 1's scope is deliberately narrow (only top-level source keys, only 0-or-1-level destinations) since anything deeper needs real YAML-structure awareness a line scanner can't safely guess at — but every real registered rename fits inside that scope today, so form 2's dependency isn't needed.

## The two required guarantees

1. **Refuse rather than corrupt**: anything outside the rewriter's scope (a nested source key, >1 level of destination nesting, an ambiguous/duplicate key) is refused per-key and reported as "needs manual review" — never silently guessed at.
2. **Verify before trust**: every rewrite is independently re-checked (`migrate_check.verify_rewrite`) by re-parsing both texts and comparing the renamed structure key-for-key. A mismatch refuses the write.

## Test plan
- [x] `ruff check` — clean
- [x] `python scripts/mypy_ratchet.py` — no new findings
- [x] `python scripts/test_tier_audit.py --strict` — OK, 17/17
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] Individual asserts throughout ("this comment is present", "this value is present") — no golden file, per instruction
- [x] Falsify-verified: reverted `_migrate` to the old `yaml.dump` round-trip, confirmed the 4 new comment/formatting tests go RED (reproducing the owner's exact symptom), restored, confirmed green
- [x] `pytest tests/interfaces/test_config_validate_migrate_command_4174.py` — 17 passed
- [x] `pytest tests/interfaces -k config` — 107 passed
- [x] `pytest tests/config` — 159 passed

part of #4174

🤖 Generated with [Claude Code](https://claude.com/claude-code)
