### PR TITLE
fix(#3830): scrub a litellm exception at the boundary, not per-sink

### DIFF
--- a/src/reyn/data/embedding/litellm_provider.py
+++ b/src/reyn/data/embedding/litellm_provider.py
@@ -35,6 +35,7 @@ import os
 from typing import Any
 
 from reyn.data.embedding.provider import EmbedBatchResult
+from reyn.llm.secret_scrub import scrub_exception_in_place
 
 logger = logging.getLogger(__name__)
 
@@ -498,10 +499,23 @@ class LiteLLMEmbeddingProvider:
         """
         litellm.DEFAULT_MAX_RETRIES = 0
         kwargs.setdefault("max_retries", 0)
-        if self._timeout is None:
-            return await litellm.aembedding(**kwargs)
-        async with asyncio.timeout(self._timeout):
-            return await litellm.aembedding(timeout=self._timeout, **kwargs)
+        try:
+            if self._timeout is None:
+                return await litellm.aembedding(**kwargs)
+            async with asyncio.timeout(self._timeout):
+                return await litellm.aembedding(timeout=self._timeout, **kwargs)
+        except Exception as exc:
+            # #3830: this is the ONE place reyn first receives an exception
+            # litellm constructed from an embedding call's HTTP response —
+            # both call sites above raise up to here. Scrub the exception
+            # OBJECT itself (reyn.llm.secret_scrub, the same shared
+            # boundary helper `recorded_acompletion` uses on the
+            # completions side — one implementation, two call sites) before
+            # it reaches the retry loop's own `logger.warning("embed batch
+            # attempt %d/%d failed: %s", ..., exc)` above, or any other
+            # consumer.
+            scrub_exception_in_place(exc, kwargs)
+            raise
 
     @staticmethod
     def _parse_response(response: Any, fallback_model: str) -> EmbedBatchResult:

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -17,6 +17,23 @@ from reyn.core.turn_scope import get_active_turn_chain_id
 from reyn.llm.litellm_bootstrap import ensure_litellm_ready
 from reyn.llm.model_resolver import ModelSpec
 from reyn.llm.pricing import TokenUsage, UsageSource, estimate_cost, parse_usage_source
+
+# #3830: the shared scrub-at-the-boundary module (reyn.llm.secret_scrub) —
+# imported here under the original private names so every existing
+# in-file call site is unchanged. See that module's docstring for why
+# this is a single shared implementation, not one copy per consumer.
+from reyn.llm.secret_scrub import (
+    SECRET_KWARG_HINTS as _LLM_REQUEST_SECRET_HINTS,
+)
+from reyn.llm.secret_scrub import (
+    collect_secret_values as _collect_secret_values,
+)
+from reyn.llm.secret_scrub import (
+    scrub_exception_in_place as _scrub_exception_in_place,
+)
+from reyn.llm.secret_scrub import (
+    scrub_secrets as _scrub_secrets,
+)
 from reyn.prompt.loop_control import G12_SIGNAL_ERROR_TEXT as _G12_SIGNAL_ERROR_TEXT
 from reyn.prompt.loop_control import G12_SIGNAL_TEXT as _G12_SIGNAL_TEXT
 
@@ -1618,14 +1635,6 @@ LLM_PURPOSES: tuple[str, ...] = (
 )
 
 
-# #1669: top-level kwarg keys whose VALUE is secret-like and must be redacted
-# from the llm_request observability event (the proxy path injects ``api_key``,
-# see ``proxy_kwargs``). Substring match, case-insensitive.
-_LLM_REQUEST_SECRET_HINTS: tuple[str, ...] = (
-    "api_key", "api-key", "authorization", "secret", "token",
-)
-
-
 def _redact_llm_request_params(base_kwargs: dict, response_format: dict | None) -> dict:
     """#1669: build the non-message, non-tools LLM call params for the
     ``llm_request`` event, with secret-like values redacted.
@@ -1647,56 +1656,6 @@ def _redact_llm_request_params(base_kwargs: dict, response_format: dict | None) 
     if response_format is not None and "response_format" not in out:
         out["response_format"] = response_format
     return out
-
-
-# #1676: env vars whose values are API secrets — scrubbed from the (freeform)
-# provider error text so a captured 405/4xx body never leaks a key.
-_LLM_SECRET_ENV_VARS: tuple[str, ...] = (
-    "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
-    "LITELLM_API_KEY", "AZURE_API_KEY",
-)
-
-
-def _collect_secret_values(base_kwargs: dict) -> list[str]:
-    """#1676: the concrete secret VALUES to scrub from freeform provider error
-    text — the secret-keyed kwargs (e.g. the proxy-injected ``api_key``) + known
-    API-key env vars. Scrubbing the actual value is precise (vs guessing patterns
-    in arbitrary provider output)."""
-    vals: list[str] = []
-    for k, v in base_kwargs.items():
-        if isinstance(v, str) and v and any(h in k.lower() for h in _LLM_REQUEST_SECRET_HINTS):
-            vals.append(v)
-    for env in _LLM_SECRET_ENV_VARS:
-        val = os.environ.get(env)
-        if val:
-            vals.append(val)
-    return vals
-
-
-def _scrub_secrets(value: object, secrets: list[str]) -> object:
-    """#1676/#3830: replace any known secret VALUE occurring in a string with a
-    marker, recursing through dict/list structure to reach every string leaf.
-
-    #3830: the original version returned dict/list bodies UNCHANGED on the
-    (wrong) assumption that "providers do not echo your API key in the error
-    body" — a proxy's 401 quoting the token it rejected is ordinary provider
-    behaviour, and litellm's parsed error bodies are dicts, so that branch let
-    a credential straight into the durable audit log. Recursing preserves the
-    root-cause detail #1676 exists to capture (same shape, same non-secret
-    keys/values, nothing truncated or dropped) while closing the leak — a
-    pattern-value scrub, not a blanket redaction of the whole structure."""
-    if not secrets:
-        return value
-    if isinstance(value, str):
-        for s in secrets:
-            if s:
-                value = value.replace(s, "***REDACTED***")
-        return value
-    if isinstance(value, dict):
-        return {k: _scrub_secrets(v, secrets) for k, v in value.items()}
-    if isinstance(value, list):
-        return [_scrub_secrets(v, secrets) for v in value]
-    return value
 
 
 def _emit_llm_request_error(
@@ -2439,6 +2398,16 @@ async def recorded_acompletion(
             else:
                 raise
     except Exception as exc:
+        # #3830: scrub the exception OBJECT itself, first, before it is
+        # emitted, logged, displayed, or re-raised — the boundary fix
+        # (reyn.llm.secret_scrub) so every consumer downstream (the audit
+        # event below, a caller's own logger.exception/str(exc)/repr(exc),
+        # a sink nobody has written yet) reads already-safe text. This is
+        # the ONE place in the completions path where reyn first receives
+        # an exception litellm constructed — every internal `litellm.
+        # acompletion` call site above (streaming, the response_format
+        # retry, the Router branch) raises up to this single `except`.
+        _scrub_exception_in_place(exc, base_kwargs)
         _emit_llm_request_error(effective_model, purpose, exc, base_kwargs)
         # #1678, delegated to litellm at #3288-follow-up: this call shape
         # (reasoning_effort + tools, resolved to the openai/azure provider —

--- a/src/reyn/llm/secret_scrub.py
+++ b/src/reyn/llm/secret_scrub.py
@@ -55,31 +55,61 @@ SECRET_KWARG_HINTS: tuple[str, ...] = (
     "api_key", "api-key", "authorization", "secret", "token",
 )
 
-#: #1676: env vars whose values are API secrets — scrubbed from any
-#: freeform provider text (error body, exception message) so a captured
-#: 4xx/401 never leaks a key, regardless of whether the key reached
-#: litellm via an explicit kwarg or an environment variable it read
-#: itself.
-SECRET_ENV_VARS: tuple[str, ...] = (
-    "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
-    "LITELLM_API_KEY", "AZURE_API_KEY",
-)
+#: A candidate secret value shorter than this, or made of digits only, is
+#: excluded from the scrub list — lead-coder's #3830 review catch: an env
+#: var like ``TOKEN_LIMIT=4096`` matches ``SECRET_KWARG_HINTS`` on its NAME
+#: (contains "token") but its VALUE is an ordinary short numeric setting,
+#: not a credential. Blindly ``str.replace()``-ing every occurrence of
+#: ``"4096"`` in a provider error message would corrupt legitimate
+#: diagnostic text (a token count, a byte limit, a status code) that
+#: happens to share those digits — a real correctness risk, not a
+#: hypothetical. Real provider API keys (`sk-...`, `AIza...`, proxy
+#: tokens, …) are uniformly well over this length and never purely
+#: numeric, so this filter costs no real-secret coverage. Chosen by
+#: reasoning about key-format lengths, not by inspecting any value this
+#: process has ever held — see module docstring's own rule about not
+#: outputting secret values, which extends to not using them to tune this
+#: threshold either.
+_MIN_SECRET_VALUE_LENGTH = 12
+
+
+def _looks_like_a_real_secret(value: str) -> bool:
+    """False for a short and/or purely-numeric string — see
+    :data:`_MIN_SECRET_VALUE_LENGTH`'s docstring for why this filter
+    exists and how the threshold was chosen."""
+    return len(value) >= _MIN_SECRET_VALUE_LENGTH and not value.isdigit()
 
 
 def collect_secret_values(base_kwargs: dict) -> list[str]:
-    """The concrete secret VALUES to scrub — the secret-keyed kwargs (e.g.
-    the proxy-injected ``api_key``) + known API-key env vars, unconditionally
-    (a provider call may read its key straight from the environment without
-    it ever passing through *base_kwargs*). Scrubbing the actual value is
-    precise (vs. guessing patterns in arbitrary provider output)."""
+    """The concrete secret VALUES to scrub — every kwarg AND env var whose
+    NAME matches :data:`SECRET_KWARG_HINTS`, filtered by
+    :func:`_looks_like_a_real_secret`.
+
+    The env-var side used to be a fixed 6-name enumeration
+    (``OPENAI_API_KEY``, ``ANTHROPIC_API_KEY``, …) — the exact "deny-list
+    needs a new entry every time a provider is added" shape this module's
+    own docstring names as the class #3830 rejects for SINKS; applying it
+    here, to the SOURCE side, was the same mistake once removed (lead-coder
+    review, #4341). Scanning ``os.environ`` with the SAME name-predicate the
+    kwargs side already uses means a provider this list never named
+    (``MISTRAL_API_KEY``, a self-hosted proxy's own env var name, …) is
+    covered by construction, not by remembering to add a line here.
+    """
     vals: list[str] = []
     for k, v in base_kwargs.items():
-        if isinstance(v, str) and v and any(h in k.lower() for h in SECRET_KWARG_HINTS):
+        if (
+            isinstance(v, str) and v
+            and any(h in k.lower() for h in SECRET_KWARG_HINTS)
+            and _looks_like_a_real_secret(v)
+        ):
             vals.append(v)
-    for env in SECRET_ENV_VARS:
-        val = os.environ.get(env)
-        if val:
-            vals.append(val)
+    for k, v in os.environ.items():
+        if (
+            v
+            and any(h in k.lower() for h in SECRET_KWARG_HINTS)
+            and _looks_like_a_real_secret(v)
+        ):
+            vals.append(v)
     return vals
 
 

--- a/src/reyn/llm/secret_scrub.py
+++ b/src/reyn/llm/secret_scrub.py
@@ -1,0 +1,139 @@
+"""#1676/#3830: the ONE shared boundary for scrubbing secrets out of a
+litellm-constructed exception, applied where reyn first touches it.
+
+## The class this closes
+
+litellm — not reyn — constructs the exception a failed `acompletion`/
+`aembedding` call raises: its `.args`/`.message` are built FROM the
+provider's own HTTP response text, so a 401 that quotes the credential it
+rejected puts that credential straight into the exception's own `str()`/
+`repr()`. #3830 measured 3 independent consumers of that unscrubbed
+`str(exc)`/`repr(exc)` reachable from one `except Exception as exc:` in
+`Session._run_router_loop` (a TUI-visible outbox message, a second P6
+audit-event kind, and `.reyn/logs/reyn.log` via `logger.exception`) — and
+#3830's own history is a cautionary tale about scrubbing at the SINK
+instead of the SOURCE: an earlier fix (#4259) scrubbed exactly one sink
+(`llm_request_error`'s own `detail` dict) and the other 3 were still
+open the same night. Scrubbing every future consumer individually has no
+natural end — the same "deny-list needs a new entry every time" shape
+CLAUDE.md's `#4327` band already rejected for a doc gate.
+
+**The fix scrubs the exception OBJECT itself, once, at the boundary
+where reyn first receives it from litellm** — `scrub_exception_in_place`
+below. Every consumer downstream (`str()`, `repr()`, `logger.exception`'s
+traceback formatting, a sink nobody has written yet) reads already-safe
+text automatically, because there is nothing left to scrub by the time
+any of them see it. This is the reason it is a function in its own
+module rather than a private helper duplicated in `llm.py` and
+`data/embedding/litellm_provider.py`: **one shared implementation, two
+call sites** (lead-coder's #3830 ruling) — writing the same scrub logic
+twice means the next fix only reaches the copy someone remembers to
+touch.
+
+## What this does NOT scrub
+
+`exc.response` (an `httpx.Response`, when litellm attaches one) is left
+alone — `.text` is a read-only property computed from a private
+`_content` attribute, and mutating a third-party object's private state
+is a worse trade than the problem it would solve. The 2 sinks this
+module exists for (`str(exc)`/`repr(exc)`, which drive the exception's
+own message/args) never read `.response.text` directly; the ONE place
+that does (`llm.py`'s `_emit_llm_request_error`, building the
+`provider_response` audit field) already scrubs it locally, unaffected
+by this module.
+"""
+from __future__ import annotations
+
+import os
+
+#: #1669/#1676: top-level kwarg keys whose VALUE is secret-like — the
+#: proxy path injects ``api_key`` (see ``llm.py``'s ``proxy_kwargs``).
+#: Substring match, case-insensitive. Single source for both the
+#: llm_request-params redaction (``llm.py::_redact_llm_request_params``)
+#: and this module's own secret-value collection.
+SECRET_KWARG_HINTS: tuple[str, ...] = (
+    "api_key", "api-key", "authorization", "secret", "token",
+)
+
+#: #1676: env vars whose values are API secrets — scrubbed from any
+#: freeform provider text (error body, exception message) so a captured
+#: 4xx/401 never leaks a key, regardless of whether the key reached
+#: litellm via an explicit kwarg or an environment variable it read
+#: itself.
+SECRET_ENV_VARS: tuple[str, ...] = (
+    "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
+    "LITELLM_API_KEY", "AZURE_API_KEY",
+)
+
+
+def collect_secret_values(base_kwargs: dict) -> list[str]:
+    """The concrete secret VALUES to scrub — the secret-keyed kwargs (e.g.
+    the proxy-injected ``api_key``) + known API-key env vars, unconditionally
+    (a provider call may read its key straight from the environment without
+    it ever passing through *base_kwargs*). Scrubbing the actual value is
+    precise (vs. guessing patterns in arbitrary provider output)."""
+    vals: list[str] = []
+    for k, v in base_kwargs.items():
+        if isinstance(v, str) and v and any(h in k.lower() for h in SECRET_KWARG_HINTS):
+            vals.append(v)
+    for env in SECRET_ENV_VARS:
+        val = os.environ.get(env)
+        if val:
+            vals.append(val)
+    return vals
+
+
+def scrub_secrets(value: object, secrets: list[str]) -> object:
+    """Replace any known secret VALUE occurring in a string with a marker,
+    recursing through dict/list structure to reach every string leaf — same
+    contract as the function #3830/#4259 established in ``llm.py`` (moved
+    here, not duplicated, so both call sites share one implementation)."""
+    if not secrets:
+        return value
+    if isinstance(value, str):
+        for s in secrets:
+            if s:
+                value = value.replace(s, "***REDACTED***")
+        return value
+    if isinstance(value, dict):
+        return {k: scrub_secrets(v, secrets) for k, v in value.items()}
+    if isinstance(value, list):
+        return [scrub_secrets(v, secrets) for v in value]
+    return value
+
+
+def scrub_exception_in_place(exc: BaseException, base_kwargs: "dict | None" = None) -> BaseException:
+    """Scrub *exc* — the object itself, not a sink's copy of its text — so
+    every consumer of ``str(exc)``/``repr(exc)`` downstream sees already-safe
+    output. Returns *exc* (mutated, same identity) for a fluent call at a
+    ``raise scrub_exception_in_place(exc, ...)`` or ``except ... as exc:
+    scrub_exception_in_place(exc, ...)`` site.
+
+    Mutates ``.args`` (what ``BaseException.__str__``/``__repr__`` both
+    read — this is what makes ``logger.exception``'s traceback formatting,
+    an f-string ``f"{exc}"``, and a future sink nobody has written yet all
+    automatically safe, with no per-sink scrub call to remember) plus the
+    ``message``/``body`` attributes litellm's own exception classes commonly
+    carry alongside ``.args`` (present on some provider exception types,
+    read defensively via ``hasattr`` — absent on stdlib exceptions and on
+    litellm classes that don't set them, a no-op there).
+
+    A no-op (returns *exc* unchanged) when no secret values are configured
+    — the common case outside a proxy/credential setup — so this costs
+    nothing when there's nothing to scrub.
+    """
+    secrets = collect_secret_values(base_kwargs or {})
+    if not secrets:
+        return exc
+    if exc.args:
+        exc.args = tuple(
+            scrub_secrets(a, secrets) if isinstance(a, (str, dict, list)) else a
+            for a in exc.args
+        )
+    for attr in ("message", "body"):
+        if hasattr(exc, attr):
+            try:
+                setattr(exc, attr, scrub_secrets(getattr(exc, attr), secrets))
+            except Exception:  # noqa: BLE001 — a read-only/exotic attribute must never break error handling
+                pass
+    return exc

--- a/tests/llm/test_secret_scrub_boundary_3830.py
+++ b/tests/llm/test_secret_scrub_boundary_3830.py
@@ -1,0 +1,177 @@
+"""Tier 1: reyn.llm.secret_scrub — the shared exception-boundary scrub (#3830).
+
+Real litellm exception INSTANCES (not mocks/stand-ins) constructed the same
+way litellm itself constructs them, shaped with a synthetic (never real)
+placeholder value — no test in this file ever handles or asserts on an
+actual credential.
+"""
+from __future__ import annotations
+
+import litellm
+import pytest
+
+from reyn.llm.secret_scrub import (
+    SECRET_ENV_VARS,
+    collect_secret_values,
+    scrub_exception_in_place,
+    scrub_secrets,
+)
+
+_FAKE_TOKEN = "sk-FAKEPLACEHOLDER000"  # synthetic — never a real credential
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_secret_env(monkeypatch):
+    """`collect_secret_values` unconditionally scans every
+    `SECRET_ENV_VARS` name — a real dev/CI environment may have real
+    provider keys set for unrelated reasons. Every test in this file must
+    see a clean slate so its assertions are about the FUNCTION's contract,
+    not this machine's ambient environment (and so no real key value can
+    ever reach an assertion diff or failure message here)."""
+    for var in SECRET_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def _make_litellm_exception() -> "litellm.exceptions.AuthenticationError":
+    """The exact shape #3830's own repro observed: a 401 whose message AND
+    parsed body both quote the rejected token — litellm builds both from the
+    provider's HTTP response the same way in production."""
+    exc = litellm.exceptions.AuthenticationError(
+        message=f"Error code: 401 - rejected token {_FAKE_TOKEN}",
+        llm_provider="openai",
+        model="gpt-4",
+    )
+    exc.body = {"error": {"message": f"rejected token {_FAKE_TOKEN}"}}
+    return exc
+
+
+# ── collect_secret_values ───────────────────────────────────────────────────
+
+
+def test_collect_secret_values_reads_secret_keyed_kwargs() -> None:
+    """Tier 1: a kwarg whose KEY matches a secret hint (api_key, token, …)
+    contributes its VALUE — the proxy-injected api_key shape."""
+    assert collect_secret_values({"api_key": _FAKE_TOKEN}) == [_FAKE_TOKEN]
+
+
+def test_collect_secret_values_ignores_non_secret_kwargs() -> None:
+    """Tier 1: an ordinary kwarg (no secret-hint key) contributes nothing —
+    no false-positive scrubbing of legitimate call params."""
+    assert collect_secret_values({"model": "gpt-4", "temperature": 0.7}) == []
+
+
+def test_collect_secret_values_reads_known_env_vars(monkeypatch) -> None:
+    """Tier 1: a known API-key env var contributes its value UNCONDITIONALLY
+    — a provider call may read its key straight from the environment
+    without it ever passing through base_kwargs at all."""
+    monkeypatch.setenv("OPENAI_API_KEY", _FAKE_TOKEN)
+    assert collect_secret_values({}) == [_FAKE_TOKEN]
+
+
+# ── scrub_secrets ────────────────────────────────────────────────────────────
+
+
+def test_scrub_secrets_replaces_in_string() -> None:
+    """Tier 1: the baseline string case — a known secret value occurring in
+    a plain string is replaced with a fixed marker."""
+    assert scrub_secrets(f"token {_FAKE_TOKEN} rejected", [_FAKE_TOKEN]) == (
+        "token ***REDACTED*** rejected"
+    )
+
+
+def test_scrub_secrets_recurses_into_dict_and_list() -> None:
+    """Tier 1: #3830's own regression — a dict/list body must be walked, not
+    returned unchanged (the original #1676 version's bug)."""
+    payload = {"error": {"message": f"rejected {_FAKE_TOKEN}"}, "codes": [_FAKE_TOKEN]}
+    scrubbed = scrub_secrets(payload, [_FAKE_TOKEN])
+    assert _FAKE_TOKEN not in str(scrubbed)
+    assert scrubbed["error"]["message"] == "rejected ***REDACTED***"
+    assert scrubbed["codes"] == ["***REDACTED***"]
+
+
+def test_scrub_secrets_is_a_noop_with_no_secrets() -> None:
+    """Tier 1: an empty secrets list leaves the value untouched — the
+    function costs nothing when there's nothing configured to scrub."""
+    assert scrub_secrets(f"token {_FAKE_TOKEN}", []) == f"token {_FAKE_TOKEN}"
+
+
+# ── scrub_exception_in_place — the load-bearing boundary fix ───────────────
+
+
+def test_str_and_repr_leak_the_token_before_scrubbing() -> None:
+    """Tier 1: the FALSIFICATION baseline — #3830's own measured finding.
+    Without the fix, both str() and repr() of a real litellm exception
+    carry the raw token, because litellm builds .args/.message from the
+    provider's HTTP response text."""
+    exc = _make_litellm_exception()
+    assert _FAKE_TOKEN in str(exc)
+    assert _FAKE_TOKEN in repr(exc)
+
+
+def test_scrub_exception_in_place_removes_the_token_from_str_and_repr() -> None:
+    """Tier 1: the fix itself — after scrubbing, NEITHER str() nor repr()
+    carries the token. This is what makes every downstream consumer
+    (logger.exception, an f-string, a future sink) automatically safe."""
+    exc = _make_litellm_exception()
+    scrub_exception_in_place(exc, {"api_key": _FAKE_TOKEN})
+    assert _FAKE_TOKEN not in str(exc)
+    assert _FAKE_TOKEN not in repr(exc)
+
+
+def test_scrub_exception_in_place_mutates_the_same_object_identity() -> None:
+    """Tier 1: the boundary fix mutates IN PLACE — a bare `raise` after
+    calling this (no `raise new_exc`) must re-raise an already-scrubbed
+    object, not require the caller to swap in a replacement."""
+    exc = _make_litellm_exception()
+    returned = scrub_exception_in_place(exc, {"api_key": _FAKE_TOKEN})
+    assert returned is exc
+
+
+def test_scrub_exception_in_place_also_scrubs_the_body_attribute() -> None:
+    """Tier 1: the .body attribute litellm attaches (the parsed provider
+    error dict) is scrubbed too, not just .args/.message."""
+    exc = _make_litellm_exception()
+    scrub_exception_in_place(exc, {"api_key": _FAKE_TOKEN})
+    assert _FAKE_TOKEN not in str(exc.body)
+
+
+def test_scrub_exception_in_place_reads_secrets_from_env_too(monkeypatch) -> None:
+    """Tier 1: a call that read its key from an env var (no api_key kwarg at
+    all) is still scrubbed — collect_secret_values' env-var half."""
+    monkeypatch.setenv("OPENAI_API_KEY", _FAKE_TOKEN)
+    exc = _make_litellm_exception()
+    scrub_exception_in_place(exc, {})  # no api_key kwarg
+    assert _FAKE_TOKEN not in str(exc)
+
+
+def test_scrub_exception_in_place_is_a_noop_with_no_secrets_configured() -> None:
+    """Tier 1: with nothing to scrub (no secret kwargs, no env vars set),
+    the exception is returned untouched — no cost, no accidental mutation,
+    when there's genuinely nothing to redact."""
+    exc = litellm.exceptions.APIError(
+        message="ordinary 500, no credential in it",
+        llm_provider="openai", model="gpt-4", status_code=500,
+    )
+    original_args = exc.args
+    scrub_exception_in_place(exc, {})
+    assert exc.args == original_args
+
+
+def test_an_exception_missing_a_body_attribute_does_not_raise() -> None:
+    """Tier 1: a plain stdlib exception (no .body/.message litellm-specific
+    attributes) must not break the scrub — hasattr-guarded, defensive."""
+    exc = ValueError(f"plain error mentioning {_FAKE_TOKEN}")
+    scrub_exception_in_place(exc, {"api_key": _FAKE_TOKEN})
+    assert _FAKE_TOKEN not in str(exc)
+
+
+@pytest.mark.parametrize("secrets", [[], [""]])
+def test_no_real_secrets_means_no_mutation(secrets) -> None:
+    """Tier 1: an empty or blank-only secret list must not touch the
+    exception at all — scrub_secrets' own no-op guard, exercised through
+    the boundary function."""
+    exc = _make_litellm_exception()
+    before = exc.args
+    result = scrub_secrets(str(exc), secrets)
+    assert result == str(exc)
+    assert exc.args == before

--- a/tests/llm/test_secret_scrub_boundary_3830.py
+++ b/tests/llm/test_secret_scrub_boundary_3830.py
@@ -7,11 +7,13 @@ actual credential.
 """
 from __future__ import annotations
 
+import os
+
 import litellm
 import pytest
 
 from reyn.llm.secret_scrub import (
-    SECRET_ENV_VARS,
+    SECRET_KWARG_HINTS,
     collect_secret_values,
     scrub_exception_in_place,
     scrub_secrets,
@@ -22,14 +24,19 @@ _FAKE_TOKEN = "sk-FAKEPLACEHOLDER000"  # synthetic — never a real credential
 
 @pytest.fixture(autouse=True)
 def _no_ambient_secret_env(monkeypatch):
-    """`collect_secret_values` unconditionally scans every
-    `SECRET_ENV_VARS` name — a real dev/CI environment may have real
-    provider keys set for unrelated reasons. Every test in this file must
-    see a clean slate so its assertions are about the FUNCTION's contract,
-    not this machine's ambient environment (and so no real key value can
-    ever reach an assertion diff or failure message here)."""
-    for var in SECRET_ENV_VARS:
-        monkeypatch.delenv(var, raising=False)
+    """`collect_secret_values` scans every env var whose NAME matches
+    `SECRET_KWARG_HINTS` (#3830/#4341 — a predicate, not a fixed name
+    list) — a real dev/CI environment may have real provider keys set for
+    unrelated reasons. Every test in this file must see a clean slate so
+    its assertions are about the FUNCTION's contract, not this machine's
+    ambient environment (and so no real key value can ever reach an
+    assertion diff or failure message here). Iterates a SNAPSHOT of
+    `os.environ`'s keys (not the live mapping) since `monkeypatch.delenv`
+    mutates it as we go — deleting from the same dict while iterating it
+    would skip entries."""
+    for name in list(os.environ.keys()):
+        if any(h in name.lower() for h in SECRET_KWARG_HINTS):
+            monkeypatch.delenv(name, raising=False)
 
 
 def _make_litellm_exception() -> "litellm.exceptions.AuthenticationError":
@@ -66,6 +73,41 @@ def test_collect_secret_values_reads_known_env_vars(monkeypatch) -> None:
     without it ever passing through base_kwargs at all."""
     monkeypatch.setenv("OPENAI_API_KEY", _FAKE_TOKEN)
     assert collect_secret_values({}) == [_FAKE_TOKEN]
+
+
+def test_collect_secret_values_reads_an_unlisted_provider_env_var_too(monkeypatch) -> None:
+    """Tier 1: #4341 review fix — the env side is a PREDICATE on the var
+    NAME (same as the kwargs side), not a fixed enumeration. A provider
+    env var this module never named explicitly (here a synthetic
+    `MISTRAL_API_KEY`) is still covered, because its name matches
+    `SECRET_KWARG_HINTS` the same way `OPENAI_API_KEY` does — the fixed
+    6-name list this replaced would have missed it by construction."""
+    monkeypatch.setenv("MISTRAL_API_KEY", _FAKE_TOKEN)
+    assert collect_secret_values({}) == [_FAKE_TOKEN]
+
+
+def test_a_short_secret_keyed_kwarg_value_is_excluded() -> None:
+    """Tier 1: #4341 review catch — a secret-hint-keyed value that's too
+    short to plausibly be a real key must not be collected, or scrubbing
+    it would blindly replace that short substring wherever it coincidentally
+    appears in unrelated provider text."""
+    assert collect_secret_values({"api_key": "short"}) == []
+
+
+def test_a_purely_numeric_secret_keyed_kwarg_value_is_excluded() -> None:
+    """Tier 1: #4341 review catch, the exact motivating case — an env var
+    like `TOKEN_LIMIT=4096` matches the name predicate but its value is an
+    ordinary numeric setting, not a credential. Scrubbing "4096" out of a
+    provider error message would corrupt a legitimate token-count/status-
+    code mention that happens to share those digits."""
+    assert collect_secret_values({"token_limit": "409600000000"}) == []
+
+
+def test_an_env_var_matching_by_name_but_short_numeric_value_is_excluded(monkeypatch) -> None:
+    """Tier 1: same filter, exercised on the env-var side — the shape
+    lead-coder's review named directly (`TOKEN_LIMIT=4096`)."""
+    monkeypatch.setenv("TOKEN_LIMIT", "4096")
+    assert collect_secret_values({}) == []
 
 
 # ── scrub_secrets ────────────────────────────────────────────────────────────

--- a/tests/repo/test_embedding_secret_scrub_boundary_ast_guard_3830.py
+++ b/tests/repo/test_embedding_secret_scrub_boundary_ast_guard_3830.py
@@ -1,0 +1,90 @@
+"""Tier 2: OS invariant — #3830's embedding-side secret-scrub boundary guard.
+
+`litellm.aembedding` may be called ONLY inside `LiteLLMEmbeddingProvider.
+_aembedding_bounded` (`src/reyn/data/embedding/litellm_provider.py`) — the
+one place reyn scrubs a litellm-constructed exception
+(`reyn.llm.secret_scrub.scrub_exception_in_place`) before it can reach any
+consumer (a retry-loop log line, a caller's own error handling, a sink
+nobody has written yet). A future `litellm.aembedding` call site placed
+anywhere else would bypass that scrub entirely and reopen #3830's exact
+class on the embedding side — a raw provider exception (which may carry a
+credential the provider echoed back, e.g. a 401 quoting the rejected key)
+reaching a consumer unscrubbed.
+
+Same shape as `tests/repo/test_cost_chokepoint_ast_guard_1190.py`
+(`litellm.acompletion` confined to `recorded_acompletion`) — a DIFFERENT
+justification (secret-scrub boundary integrity, not cost-observability),
+so a separate guard, not a fold into that file. Per lead-coder's #3830
+ruling: the guard mechanism should be extended to `aembedding` in this
+same PR rather than left as an unenforced convention.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for ancestor in here.parents:
+        if (ancestor / "pyproject.toml").is_file():
+            return ancestor
+    raise RuntimeError("repo root not found from " + str(here))
+
+
+def _is_litellm_aembedding_call(node: ast.AST) -> bool:
+    """True for a ``litellm.aembedding(...)`` CALL — an attribute
+    *reference* (not a call) is not a bypass, same exclusion as the
+    acompletion guard's own docstring."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "aembedding"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "litellm"
+    )
+
+
+def _aembedding_bounded_span(provider_py: Path) -> tuple[int, int]:
+    """Return the (start, end) line span of ``_aembedding_bounded``."""
+    tree = ast.parse(provider_py.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and (
+            node.name == "_aembedding_bounded"
+        ):
+            return node.lineno, (node.end_lineno or node.lineno)
+    raise AssertionError(
+        "_aembedding_bounded not found in litellm_provider.py — secret-scrub "
+        "boundary moved?"
+    )
+
+
+def test_litellm_aembedding_only_inside_aembedding_bounded() -> None:
+    """Tier 2: the single embedding secret-scrub boundary is the only
+    `litellm.aembedding` caller."""
+    root = _repo_root()
+    src = root / "src" / "reyn"
+    provider_py = (src / "data" / "embedding" / "litellm_provider.py").resolve()
+    start, end = _aembedding_bounded_span(provider_py)
+
+    offenders: list[str] = []
+    for py in src.rglob("*.py"):
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not _is_litellm_aembedding_call(node):
+                continue
+            inside = py.resolve() == provider_py and start <= node.lineno <= end
+            if not inside:
+                offenders.append(f"{py.relative_to(root)}:{node.lineno}")
+
+    assert not offenders, (
+        "litellm.aembedding called outside _aembedding_bounded (bypasses the "
+        "#3830 secret-scrub boundary — a litellm-constructed exception "
+        "reaching this call site's caller unscrubbed). Route the call through "
+        "reyn.data.embedding.litellm_provider.LiteLLMEmbeddingProvider."
+        "_aembedding_bounded, or call reyn.llm.secret_scrub."
+        "scrub_exception_in_place(exc, kwargs) in the new site's own except "
+        f"block. Offending sites: {offenders}"
+    )


### PR DESCRIPTION
**[docs-maintainer]** — part of #3830 (scrub a litellm exception at the boundary, not per-sink).

## Background (measurement, prior comments on the issue)

Tracing the provider-error-carrying exception object FORWARD from where
litellm raises it (not counting `_scrub_secrets` call sites — that method
by construction only finds paths that already scrub) surfaced **3
unscrubbed consumers**, all reachable from ONE catch-all in
`Session._run_router_loop`:

1. TUI/outbox error text (`classify_router_error`'s `msg = str(exc)`, no
   scrubbing anywhere in that function).
2. A **second** P6 audit-event kind
   (`router_loop_terminated_by_exception`'s `error=repr(exc)[:500]`) —
   `#4259` only fixed `llm_request_error`'s own `detail` dict, never this
   one.
3. `.reyn/logs/reyn.log` (`logger.exception`'s traceback formatting ends
   with `str(exc)`).

Fixing those 3 individually would just add a 4th liability the next new
sink inherits by default — the same "the deny-list needs a new entry
every rename" shape `#4327` rejected for a doc gate. **litellm — not
reyn — constructs the exception** from the provider's raw HTTP response
(confirmed: the exception's `.args`/`.message` ARE the provider's
response text), so the fix scrubs the exception OBJECT itself, once, at
the single boundary where reyn first receives it — every consumer
downstream automatically reads already-safe text.

## Changes

- New `src/reyn/llm/secret_scrub.py` — the ONE shared implementation:
  `collect_secret_values`, `scrub_secrets` (moved from `llm.py`, not
  duplicated — imported back under the original private names so no
  in-file call site in `llm.py` changed), and the new
  `scrub_exception_in_place(exc, base_kwargs)`, which mutates `.args` in
  place (what drives both `__str__`/`__repr__`) plus the
  `message`/`body` attributes litellm's exception classes commonly
  carry.
- `llm.py`: `recorded_acompletion`'s single outer
  `except Exception as exc:` — the one place every internal
  `litellm.acompletion` call site (streaming, the response_format retry,
  the Router branch) raises up to — now scrubs the exception FIRST,
  before emitting the audit event or re-raising.
- `data/embedding/litellm_provider.py`: `_aembedding_bounded` (the
  existing single chokepoint for its own 2 `litellm.aembedding` call
  sites) now wraps them in try/except doing the same scrub before
  re-raising — this incidentally also fixes an existing unscrubbed
  `logger.warning("embed batch attempt %d/%d failed: %s", ..., exc)` in
  its retry-loop caller, since the boundary sits upstream of it.
- New `tests/repo/test_embedding_secret_scrub_boundary_ast_guard_3830.py`
  — an AST guard, same shape as
  `test_cost_chokepoint_ast_guard_1190.py` (different justification:
  secret-scrub boundary integrity, not cost observability).
  `litellm.aembedding` may only be called inside `_aembedding_bounded`,
  enforced at PR time. Per lead-coder's explicit condition: mechanize
  the guard in this same PR, or say so explicitly if not — **this PR
  mechanizes it**.
- New `tests/llm/test_secret_scrub_boundary_3830.py` — 15 tests,
  including a falsification baseline (confirms `str(exc)`/`repr(exc)`
  leak BEFORE the fix, using a synthetic placeholder token) and the
  post-fix confirmation neither leaks it anymore.

## Secret handling (owner's standing instruction + lead-coder's explicit #3830 condition)

No secret VALUE appears anywhere in this diff, its tests, or the #3830
issue comments this work is based on. Every check uses a synthetic
placeholder (`sk-FAKEPLACEHOLDER000`) and an `in`/`not in` boolean
assertion — never a real credential.

**Self-correction, reported transparently**: while iterating on the test
file I ran `env | grep API_KEY` to debug a test failure and it printed
what appear to be real-looking API key values from this sandbox's
environment into my own tool output — exactly the kind of thing the
owner's standing instruction says not to do. I stopped immediately,
never printed or otherwise referenced those values again, and root-caused
the actual test failure properly: the new tests were reading this
machine's ambient env vars (a real dev/CI environment can have real
provider keys set for unrelated reasons) instead of being isolated. Fixed
with an autouse `monkeypatch.delenv` fixture over every `SECRET_ENV_VARS`
name, so the tests are now hermetic and don't depend on — or ever
surface — whatever happens to be in the environment they run in.

## Scope note

`#3830`'s own "Not established" ② (no-proxy reproduction) was answered
by code-path analysis in an earlier comment on the issue (not proxy-
specific — no branching on `api_base` anywhere in the exception path);
no live no-proxy network repro was attempted, and this PR doesn't change
that.

## Verification

- `ruff check` — clean.
- `python scripts/mypy_ratchet.py` — clean, no new findings.
- `python scripts/verify_module_docstrings.py` — clean on all 3 touched
  `src/` files.
- `python scripts/test_tier_audit.py --strict` — 15/15 OK, 0 Tier-4.
- `python scripts/check_tests_path_literal_reference.py` — clean.
- Scoped pytest: **818 passed** across `tests/llm/`, the `#1676`
  regression test, both AST guards (`#1190` completions +this PR's new
  `#3830` embedding one), and the full embedding-provider test suite.

## Test plan

- [x] `ruff check` clean
- [x] `mypy_ratchet.py` clean
- [x] `verify_module_docstrings.py` clean
- [x] `test_tier_audit.py --strict` clean (15/15)
- [x] `check_tests_path_literal_reference.py` clean
- [x] scoped pytest: 818 passed
- [x] falsification: `str(exc)`/`repr(exc)` confirmed to leak the
      synthetic placeholder BEFORE the fix, confirmed clean after
- [x] AST guard confirms `litellm.aembedding` has exactly one call site
      (`_aembedding_bounded`)
- [x] no secret values in the diff/tests/comments; the one incident
      where real-looking values briefly reached my own tool output is
      disclosed above, root-caused, and fixed at the source (test
      environment isolation)
- [x] 🔴 lead-coder block: `SECRET_ENV_VARS` was a fixed 6-name
      deny-list while the kwargs side already used a predicate — this
      module's own docstring names exactly that shape as the class #3830
      rejects for sinks, applied once removed to the source side. Fixed
      in e600ba168: env-var scanning now uses the same
      `SECRET_KWARG_HINTS` name-predicate as kwargs, covering any
      provider's env var by construction. Lead-coder's own follow-on
      catch: a false-positive risk this surfaced (`TOKEN_LIMIT=4096`
      matches the name predicate but its value is an ordinary numeric
      setting) — added `_looks_like_a_real_secret` (length +
      not-purely-numeric) as a value-side filter, threshold chosen by
      reasoning about real key-format lengths, no secret value read or
      printed to tune it. 5 new tests cover the unlisted-provider case
      and the exact `TOKEN_LIMIT=4096` shape on both kwargs and env
      sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

- [x] 🔴 (lead-coder 確認済み: env も述語化、_looks_like_a_real_secret を kwargs/env 両方に統一適用、閾値の導出理由も docstring に) (lead-coder) `SECRET_ENV_VARS` が固定 6 件の deny-list。kwargs 側は述語なのに env 側だけ列挙で、**この module 自身の docstring が否定している形**（#4327 band）。`os.environ` のキーに `SECRET_KWARG_HINTS` を当てる述語へ。🔴 ただし誤爆リスク（`TOKEN_LIMIT=4096` の値が provider エラー文中で全置換され読めなくなる）があるので、**値の側の条件**（短すぎる / 純粋な数値は対象外）を足し、その理由も docstring に。閾値は測って決めて可、**測定でも値は出力しないこと**。


