### PR TITLE
fix(#4343): prefix-match fallback for partially-masked secrets + reyn.log reachability

### DIFF
--- a/src/reyn/llm/secret_scrub.py
+++ b/src/reyn/llm/secret_scrub.py
@@ -72,6 +72,28 @@ SECRET_KWARG_HINTS: tuple[str, ...] = (
 #: threshold either.
 _MIN_SECRET_VALUE_LENGTH = 12
 
+#: #4343: how many LEADING characters of a known secret value are also
+#: tried as a standalone match — see :func:`scrub_secrets`'s "already
+#: partially masked" fallback. Derived from :data:`_MIN_SECRET_VALUE_LENGTH`
+#: itself (two-thirds of it, floor-divided: 12 * 2 // 3 == 8), the SAME
+#: no-value-inspection discipline that constant's own docstring states —
+#: chosen by reasoning about the trade-off shape, not by looking at what
+#: any real provider's masking actually reveals:
+#:   - too SHORT (close to a bare provider prefix like ``sk-``, 3-4 chars)
+#:     risks matching ordinary text that happens to start the same way —
+#:     the over-redaction failure mode, the false-positive twin of the
+#:     ``TOKEN_LIMIT=4096`` problem the length filter above already guards.
+#:   - too LONG (close to the FULL ``_MIN_SECRET_VALUE_LENGTH``) stops
+#:     matching once an upstream masker (litellm's own exception
+#:     construction, observed structurally in #4343 — not by value —
+#:     to sometimes reveal only a short leading span before masking the
+#:     rest) has already replaced the tail with its own marker characters.
+#: Deriving it as a fraction of the existing threshold ties the two
+#: constants together instead of adding an unrelated magic number, and
+#: keeps both adjustable from one place if real-world masking behavior
+#: (still not inspected here) is measured later and this needs revisiting.
+_SECRET_PREFIX_LENGTH = _MIN_SECRET_VALUE_LENGTH * 2 // 3
+
 
 def _looks_like_a_real_secret(value: str) -> bool:
     """False for a short and/or purely-numeric string — see
@@ -114,16 +136,33 @@ def collect_secret_values(base_kwargs: dict) -> list[str]:
 
 
 def scrub_secrets(value: object, secrets: list[str]) -> object:
-    """Replace any known secret VALUE occurring in a string with a marker,
-    recursing through dict/list structure to reach every string leaf — same
-    contract as the function #3830/#4259 established in ``llm.py`` (moved
-    here, not duplicated, so both call sites share one implementation)."""
+    """Replace any known secret VALUE (or, failing that, its known PREFIX)
+    occurring in a string with a marker, recursing through dict/list
+    structure to reach every string leaf — same contract as the function
+    #3830/#4259 established in ``llm.py`` (moved here, not duplicated, so
+    both call sites share one implementation).
+
+    #4343: the full-value pass alone misses a secret that an upstream
+    intermediary (litellm's own exception construction, for one measured
+    case) has ALREADY partially masked by the time reyn's exact-match
+    ``str.replace`` runs — the full known value is no longer a literal
+    substring of the text once its tail has been replaced by someone
+    else's mask characters, so nothing matches and the marker never
+    appears. The prefix pass is still "the actual value at hand", not
+    pattern-guessing: it derives from the SAME known secret this function
+    was already given, just a leading slice of it — never a guessed
+    format like "anything starting with sk-" (this module's own docstring
+    rejects that class of scrubbing).
+    """
     if not secrets:
         return value
     if isinstance(value, str):
         for s in secrets:
             if s:
                 value = value.replace(s, "***REDACTED***")
+        for s in secrets:
+            if s and len(s) >= _SECRET_PREFIX_LENGTH:
+                value = value.replace(s[:_SECRET_PREFIX_LENGTH], "***REDACTED***")
         return value
     if isinstance(value, dict):
         return {k: scrub_secrets(v, secrets) for k, v in value.items()}

--- a/tests/llm/test_secret_scrub_boundary_3830.py
+++ b/tests/llm/test_secret_scrub_boundary_3830.py
@@ -137,6 +137,36 @@ def test_scrub_secrets_is_a_noop_with_no_secrets() -> None:
     assert scrub_secrets(f"token {_FAKE_TOKEN}", []) == f"token {_FAKE_TOKEN}"
 
 
+def test_scrub_secrets_catches_a_value_an_upstream_intermediary_already_partially_masked(
+) -> None:
+    """Tier 1: #4343 — a known secret value that no longer appears IN FULL
+    (because something upstream of reyn — litellm's own exception
+    construction, measured structurally in #4343's dogfood pass, not by
+    inspecting a real value — already replaced its tail with masking
+    characters before reyn ever sees the text) is still caught, via its
+    known PREFIX.
+
+    ``masked`` below is a SYNTHETIC string shaped like that class of
+    upstream masking (prefix visible, tail replaced by asterisks) — not a
+    literal reproduction of any specific provider's real format, since
+    this module's own discipline is deriving from the known VALUE, not
+    from an inspected real-world mask pattern."""
+    masked = f"Incorrect API key provided: {_FAKE_TOKEN[:8]}{'*' * 10}"
+    scrubbed = scrub_secrets(masked, [_FAKE_TOKEN])
+    assert _FAKE_TOKEN[:8] not in scrubbed, f"prefix survived unredacted: {scrubbed!r}"
+    assert "***REDACTED***" in scrubbed
+
+
+def test_scrub_secrets_full_value_match_still_wins_when_both_could_apply() -> None:
+    """Tier 1: #4343 accept-side — when the FULL value is still present
+    (the common case, no upstream masking involved), the full-value pass
+    replaces it; the prefix pass finding nothing left to match afterward
+    is not a second, redundant redaction artifact in the output."""
+    scrubbed = scrub_secrets(f"token {_FAKE_TOKEN} rejected", [_FAKE_TOKEN])
+    assert scrubbed == "token ***REDACTED*** rejected"
+    assert scrubbed.count("REDACTED") == 1
+
+
 # ── scrub_exception_in_place — the load-bearing boundary fix ───────────────
 
 


### PR DESCRIPTION
**[tui-coder]** — Prefix-match fallback for `secret_scrub.py` + live `.reyn/logs/reyn.log` reachability measurement.

## Background

Dogfood pass 2 (lead-coder dispatch) deliberately triggered a real provider failure and checked the 3 sinks #3830 named (TUI/outbox text, `.reyn/events`, `.reyn/logs/reyn.log`). The corrected finding (after an initial methodologically-flawed synthetic-exception test was self-caught and redone): the exact-match scrub is correct, but a case exists where litellm's own exception construction has already partially masked a known secret's tail before reyn ever sees the text — the full value is then no longer a literal substring, so the exact-match `.replace()` finds nothing.

## ① The fix

`scrub_secrets` gets a second pass after the full-value replace: try each known secret's leading `_SECRET_PREFIX_LENGTH` characters too. Still "the actual value at hand" — never a guessed pattern like "starts with sk-", so the module's own no-pattern-guessing rule stays intact.

`_SECRET_PREFIX_LENGTH = _MIN_SECRET_VALUE_LENGTH * 2 // 3` (= 8) — same no-real-value-inspection discipline `_MIN_SECRET_VALUE_LENGTH` itself documents, derived as a fraction of that existing constant. Reasoning is in the code comment (trade-off shape: too short over-redacts ordinary text, too long stops matching once the tail is masked).

Two new tests: the partial-mask case now redacts, and the common full-value case still wins (no duplicate redaction artifact when both passes could apply).

## ② `.reyn/logs/reyn.log` live-reachability measurement (the remaining open item from dogfood pass 2)

Dogfood's own harness never reaches this sink — its non-interactive invocation keeps `is_interactive=False`, so `_setup_interactive_logging` (which routes the root logger to the file) is never installed. That's a "not exercised" gap, distinct from "verified safe."

Built a standalone pty-driven session (real TTY on both stdin/stdout, sanitized ambient env so no real credential could leak in, an explicit synthetic fake key) against a scratch project pointed at an unreachable `api_base`. Confirmed:
- `.reyn/logs/reyn.log` DOES get written to by a real interactive session (`session.py`'s top-level router-loop exception handler logs via `logger.exception`).
- That handler logs the SAME exception object `llm.py`'s `recorded_acompletion` already scrubbed in place — so the file sink inherits safety by construction, same as the other two sinks #3830 already covered.
- This particular error class (connection-refused) carries no secret text at all, so it didn't itself exercise the redaction — it exercises reachability, not content-scrubbing. No leak observed; no `***REDACTED***` expected or seen for this run (correctly — nothing to redact here).

No code changes for ②; it's a measurement, recorded here because it closes the "not exercised" gap lead-coder flagged.

## Test plan

- [x] `ruff check src/reyn/llm/secret_scrub.py tests/llm/test_secret_scrub_boundary_3830.py` — clean
- [x] `python scripts/mypy_ratchet.py` — OK, 211 findings, all baselined
- [x] `python scripts/test_tier_audit.py --strict tests/llm/test_secret_scrub_boundary_3830.py` — OK, 20 tests, 0 errors
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/verify_module_docstrings.py src/reyn/llm/secret_scrub.py` — OK
- [x] `pytest tests/llm tests/repo/test_embedding_secret_scrub_boundary_ast_guard_3830.py -q` — 758 passed
- [x] Falsify-verified: reverted the prefix-match pass, confirmed the new partial-mask test fails with the exact expected message, restored, confirmed green again
- [x] Live pty-driven `.reyn/logs/reyn.log` reachability check — see ② above

Not merging — holding for lead-coder's TESTS-READY per this repo's convention.

Both dispatched items (① the fix, ② the reachability measurement) are done, so this is intended as the closing PR for the issue. Closes #4343.
