### PR TITLE
docs(verification-hazards): §12 needed an active trigger, not just an instance

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -406,6 +406,20 @@ or *a* seam/registry/mechanism among others that might exist? A silent
 axis (the one you didn't have to name because you only found one instance
 of it) is the one this section is about.
 
+⚠️ **This trigger's own force is grammatical, and grammar is language-
+specific.** "*The* seam" vs. "*a* seam" forces the axis question into the
+open because English requires an article either way — there is no
+article-free way to write the sentence. A language without articles (仮に
+日本語で書けば「seam を列挙した」) can state the same finding with the axis
+question left completely unmarked; nothing in the sentence's grammar forces
+it to surface, so the trigger has nothing to catch. #3896's own finding was
+written in Japanese — the language of the person this trigger would most
+need to reach the moment it existed. Writing in a language without
+articles: say explicitly whether it is 「唯一の X」("the only X — checked
+that no other exists") or 「X の一つ」("one of possibly several X — did not
+check for others") — the distinction the article carries for free in
+English has to be spelled out by hand where grammar won't carry it.
+
 **Apply**: before trusting a registry-enumerated coverage claim, name the
 axis the registry actually counts (usually identity/name) and ask whether
 the known defect classes live on that axis or a different one (a shape, a

--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -385,6 +385,27 @@ allow-list gate needs its OWN allow-listed target proven correct by a second,
 independent assertion** — "the gate's target exists" is not the same claim
 as "the gate's target still does what the gate assumes."
 
+This trap doesn't need a gate to recur — the same asymmetry lives in a
+conclusion, not just in code: investigating whether a tool was reachable
+under a config mode, a reviewer enumerated ONE seam that strips entries
+(`ExposureDeviation.excluded_names`, six module-level construction sites,
+the tool in none of them) and concluded the tool was reachable — a
+conclusion about the *seam axis* drawn from counting one seam. A second,
+architecturally separate strip seam existed one layer away
+(`_WRAPPER_SUPERSEDED_BASE_TOOLS` in `router_tools.py`, #3429) and DID
+name the tool. The retraction's own words: "`excluded_names` が唯一の
+seam」と書いたのは私の誤りです。registry を1本列挙して、seamの軸について
+結論しました" (#3896) — this doc already named the exact shape, and having
+read it did not stop the same session from doing it anyway, because
+nothing in the moment of writing "I enumerated the seam" asked whether
+"the seam" meant *a* seam or *every* seam.
+
+🔴 **Active trigger**: before writing "I counted/enumerated all the X," stop
+and say out loud which axis X names — is X *the* seam/registry/mechanism,
+or *a* seam/registry/mechanism among others that might exist? A silent
+axis (the one you didn't have to name because you only found one instance
+of it) is the one this section is about.
+
 **Apply**: before trusting a registry-enumerated coverage claim, name the
 axis the registry actually counts (usually identity/name) and ask whether
 the known defect classes live on that axis or a different one (a shape, a


### PR DESCRIPTION
**[docs-maintainer]** — small lead-coder follow-up dispatch (architect's observation from #3896).

## What

§12 ("Coverage has two axes, and enumerating a registry only closes one")
already describes the exact trap architect's own #3896 measurement fell
into: enumerated ONE seam that strips tool entries
(`ExposureDeviation.excluded_names`, six module-level construction
sites) and concluded the tool was reachable — a conclusion about the
SEAM AXIS drawn from counting one seam. A second, architecturally
separate strip seam existed one layer away
(`_WRAPPER_SUPERSEDED_BASE_TOOLS`, `router_tools.py`, #3429) and DID name
the tool. Architect's own retraction: 「`excluded_names` が唯一の seam と
書いたのは私の誤りです。registry を1本列挙して、seamの軸について結論しま
した」.

Having the doc already describe this exact shape did not stop the same
session from doing it — CLAUDE.md's own "Pre-conclusion observation
checklist" works because it's an ACTIVE trigger a reader hits in the
moment of writing a conclusion ("結論/パターン/100%と書こうとしたら止ま
れ"), not just a worked example to have once read. §12 had the example
without the trigger.

## Change

- Added #3896 as a new instance under §12.
- One active-trigger sentence: before writing "I counted/enumerated all
  the X," name whether X is THE seam/registry/mechanism or A
  seam/registry/mechanism among possibly others.

## Scope (explicit constraint from the dispatch)

Deliberately scoped to §12 only. The need for a trigger was observed for
this ONE section (a session that had read it still fell in) — extending
triggers to every section in the doc would be designing for an
unobserved shape, the same discipline used earlier tonight for #4343
(don't build for a failure mode you haven't measured).

## Verification

- `rm -rf site && mkdocs build --strict` — clean (fresh rebuild).
- `python scripts/check_doc_anchors.py` — clean.
- No `.ja.md` sibling exists for this doc — no mirror obligation.

## Update (same PR, second commit)

architect's own follow-up: the "the seam" vs "a seam" trigger works
because English GRAMMAR forces an article choice — there's no
article-free way to write the sentence, so the axis question surfaces
whether the writer means to raise it or not. A language without articles
(architect's own findings are written in Japanese — the language of the
person this trigger would most need to reach) can state the identical
finding with the axis question completely unmarked. Added one more line:
when writing without articles, say explicitly 「唯一の X」vs「X の一つ」—
spelling out by hand what English gets for free from grammar. Same
section only, per lead-coder's explicit instruction.

## Test plan

- [x] `mkdocs build --strict` clean (fresh rebuild)
- [x] `check_doc_anchors.py` clean
- [x] scoped to exactly one section, per the explicit dispatch constraint
- [x] second addition (grammar-specificity) also scoped to the same
      section only, re-verified `mkdocs build --strict` + `check_doc_anchors.py`
      clean after the second commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

