### PR TITLE
fix(#4347): stop naming OPENAI_API_KEY in proxy_kwargs()/routing_for_spec()

### DIFF
--- a/src/reyn/data/embedding/litellm_provider.py
+++ b/src/reyn/data/embedding/litellm_provider.py
@@ -105,12 +105,19 @@ def _proxy_kwargs() -> dict[str, Any]:
 
     Reads LITELLM_API_BASE from env (same env var as call_llm uses) so the
     same proxy serves both completions and embeddings.
+
+    #4347: no ``api_key`` here — mirrors ``llm.proxy_kwargs()``'s own fix.
+    Naming ``OPENAI_API_KEY`` specifically meant every other provider's user
+    got nothing from this line, the same "reyn can't enumerate providers
+    litellm already abstracts" argument #3905 applied elsewhere. litellm
+    resolves the key itself when set, and raises its own named, actionable
+    error when it isn't — reyn supplying a ``"dummy"`` fallback was silently
+    swallowing that message.
     """
     api_base = os.environ.get("LITELLM_API_BASE")
     if not api_base:
         return {}
-    api_key = os.environ.get("OPENAI_API_KEY", "dummy")
-    return {"api_base": api_base, "custom_llm_provider": "openai", "api_key": api_key}
+    return {"api_base": api_base, "custom_llm_provider": "openai"}
 
 
 # ---------------------------------------------------------------------------

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1410,12 +1410,24 @@ def proxy_kwargs() -> dict:
     api_base is read from LITELLM_API_BASE (set by CLI from reyn.yaml).
     API keys are read automatically by litellm from provider env vars
     (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) — never passed explicitly here.
+
+    #4347: an earlier version DID read+pass ``OPENAI_API_KEY`` explicitly
+    (7efd505f6) without updating this docstring, so doc and code disagreed.
+    Removed on the owner's own framing: litellm abstracts 100+ providers, so
+    reyn naming ONE provider's env var here means every OTHER provider's user
+    (ANTHROPIC_API_KEY-only, etc.) got nothing from this line — the same
+    "reyn can't enumerate providers litellm already abstracts" argument
+    #3905 applied to ``_PROVIDER_ENV_VARS`` and closed there, not here.
+    Measured on a live proxy (#4347's issue comments, armB/armC): omitting
+    ``api_key`` entirely lets litellm resolve OPENAI_API_KEY itself when set
+    (proxy call succeeds, reyn passed nothing), and when unset litellm raises
+    its own named-and-actionable error telling the operator what to set —
+    which the removed ``"dummy"`` fallback was silently swallowing.
     """
     api_base = os.environ.get("LITELLM_API_BASE")
     if not api_base:
         return {}
-    api_key = os.environ.get("OPENAI_API_KEY", "dummy")
-    return {"api_base": api_base, "custom_llm_provider": "openai", "api_key": api_key}
+    return {"api_base": api_base, "custom_llm_provider": "openai"}
 
 
 # #1829 S2: loop-aware single-deployment Router cache. A ``litellm.Router`` binds
@@ -1604,8 +1616,10 @@ def routing_for_spec(spec: "ModelSpec | None") -> dict | None:
     Enables simultaneous multi-provider use (e.g. router=light on a Gemini proxy
     + capable on Anthropic-direct):
       - ``api_base`` set → route to that endpoint; ``custom_llm_provider`` =
-        ``spec.provider`` or ``"openai"`` (OpenAI-compatible proxy). api_key from
-        OPENAI_API_KEY (litellm standard — never a literal secret in config).
+        ``spec.provider`` or ``"openai"`` (OpenAI-compatible proxy). No
+        ``api_key`` here (#4347, mirrors ``proxy_kwargs()``'s own fix) —
+        litellm resolves it itself from OPENAI_API_KEY (litellm standard —
+        never a literal secret in config).
       - ``provider`` set, no ``api_base`` → DIRECT to that provider (no api_base
         override); litellm resolves the key from its standard env var
         (ANTHROPIC_API_KEY / GEMINI_API_KEY / …). This opts the class OUT of the
@@ -1620,7 +1634,6 @@ def routing_for_spec(spec: "ModelSpec | None") -> dict | None:
         return {
             "api_base": api_base,
             "custom_llm_provider": provider or "openai",
-            "api_key": os.environ.get("OPENAI_API_KEY", "dummy"),
         }
     if provider:
         return {"custom_llm_provider": provider}

--- a/tests/llm/test_per_class_api_base_309.py
+++ b/tests/llm/test_per_class_api_base_309.py
@@ -23,14 +23,19 @@ from reyn.llm.model_resolver import ModelSpec
 # ── routing_for_spec resolution ──────────────────────────────────────────────
 
 
-def test_routing_api_base_is_proxy_route(monkeypatch) -> None:
-    """Tier 2: api_base set → proxy route (custom_llm_provider openai default)."""
-    monkeypatch.setenv("OPENAI_API_KEY", "k-proxy")
+def test_routing_api_base_is_proxy_route() -> None:
+    """Tier 2: api_base set → proxy route (custom_llm_provider openai default).
+
+    #4347: no api_key in the returned dict — naming OPENAI_API_KEY specifically
+    meant every other provider's user got nothing from it (litellm abstracts
+    100+ providers; reyn can't enumerate them, same argument #3905 applied
+    elsewhere). litellm resolves the key itself, or raises its own named,
+    actionable error when none is set — no longer silently swallowed by a
+    ``"dummy"`` fallback."""
     r = routing_for_spec(ModelSpec(model="openai/x", api_base="https://proxy.local"))
     assert r == {
         "api_base": "https://proxy.local",
         "custom_llm_provider": "openai",
-        "api_key": "k-proxy",
     }
 
 


### PR DESCRIPTION
**[tui-coder]** — ① implementation for #4347: stop naming `OPENAI_API_KEY` in `proxy_kwargs()` / `routing_for_spec()` / embedding's `_proxy_kwargs()`.

## Scope

Exactly ① from the issue. ②(`llm.router.credentials`/`api_key_env`), ③(`secret_scrub`'s `os.environ` scan), ④(onboarding output) are untouched — owner-decision-pending or a different axis, per lead-coder's explicit "don't touch" list.

## What changed

3 sites read `os.environ.get("OPENAI_API_KEY", "dummy")` and forwarded it as `api_key` to litellm:
- `llm.py:proxy_kwargs()`
- `llm.py:routing_for_spec()`
- `data/embedding/litellm_provider.py:_proxy_kwargs()`

All 3 now omit `api_key` from the returned dict entirely (no fallback, key not passed at all — distinct from passing `api_key=""`, which overrides litellm's own env-var fallback instead of getting out of its way).

## Why

The reasoning went through several rounds on the issue before landing here (full history in the issue comments) — the short version: litellm abstracts 100+ providers, and naming one provider's env var (`OPENAI_API_KEY`) here meant every other provider's user got nothing from this line. Same argument #3905 already applied to `_PROVIDER_ENV_VARS` and closed there — these 3 sites are the same mechanism, not previously swept.

`proxy_kwargs()`'s docstring already said *"API keys are read automatically by litellm from provider env vars ... never passed explicitly here"* — that line was false (the code beneath it explicitly read+passed one), introduced by `7efd505f6` without updating the docstring. It's simply true now; left unedited per instruction, only a `#4347` rationale note added below it.

## Live-proxy witness (the load-bearing test-plan item)

Run directly against this checkout's own real local litellm proxy (`localhost:4000`, dev setup already running), through `recorded_acompletion` — the actual call path, not a synthetic/mocked one. No real credential ever inspected; only success vs. exception-type observed.

- **`OPENAI_API_KEY` set in env, not passed by reyn** → call succeeds (litellm resolves it itself from env; reyn passed nothing).
- **`OPENAI_API_KEY` unset entirely, not passed by reyn** → litellm raises its own named, actionable `AuthenticationError` telling the operator exactly what to set (`api_key` param or `OPENAI_API_KEY` env var).

The second arm is the previously-hidden case: the removed `"dummy"` fallback was silently swallowing litellm's own informative error. This is an improvement (a real, actionable error now surfaces to the operator) — not a functional regression, even though it changes what happens when neither `OPENAI_API_KEY` nor a real provider credential is set on a proxy that itself requires one.

## Test plan

- [x] `ruff check` on all 3 touched files — clean
- [x] `python scripts/mypy_ratchet.py` — OK, 211 findings, all baselined
- [x] `python scripts/test_tier_audit.py --strict tests/llm/test_per_class_api_base_309.py` — OK, 8 tests, 0 errors
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/verify_module_docstrings.py` on both touched src files — OK
- [x] `pytest tests/llm tests/core/test_responses_api_routing_1678.py tests/core/test_embed_bound_cancel_3043.py tests/repo/test_litellm_api_base_single_writer_ast_guard_2683.py tests/core/test_embed_attempts_observation_3047.py tests/data/test_embedding_provider.py -q` — 825 passed
- [x] Live-proxy witness (both arms above) — see section above
- [x] Updated `test_routing_api_base_is_proxy_route` (the one test asserting `api_key` presence in `routing_for_spec`'s return) to match the new no-`api_key` contract

Not merging — holding for lead-coder's TESTS-READY per this repo's convention. `part of #4347` (② ③ ④ remain open).
