### PR TITLE
fix(#3848): remove the dead sandbox_env field, stage 2 is never landing

### DIFF
--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -800,16 +800,6 @@ class MCPClient:
         # Invoked in close_stderr_capture(). None when the backend's wrap owns
         # no such resource (Noop / Landlock).
         self._sandbox_cleanup: Callable[[], None] | None = None
-        # #3848 stage 1: the allowlisted env wrap_command() computes (#3850),
-        # carried through instead of being silently dropped the way it was
-        # before this — _sandbox_wrap_stdio used to project only .argv out of
-        # WrappedCommand. NOT yet consumed by _initialize_stdio's actual launch
-        # (the owner ruling's default is "pass everything", which #3850's
-        # allowlist is narrower than) — this is the seam stage 2's opt-in
-        # whitelist/blacklist config will read from. None when the wrap
-        # failed (fail-open with a warning + audit-event, #3821) — there is
-        # no allowlisted value to offer in that case.
-        self._sandbox_env: dict[str, str] | None = None
         # #2597 capability/version gate: captured right after the official
         # SDK's ClientSession.initialize() handshake completes (a plain
         # return value — see the module docstring's "Capability / version
@@ -833,16 +823,6 @@ class MCPClient:
         the caller didn't supply one at construction. Used only for error-message
         context (:func:`require_capability`) — never for lookup."""
         return self._server_name
-
-    @property
-    def sandbox_env(self) -> "dict[str, str] | None":
-        """The allowlisted env ``wrap_command()`` computed for this client's
-        stdio launch (#3848 stage 1), or ``None`` if the wrap failed or
-        hasn't run yet. NOT the env actually used to launch the subprocess
-        in this stage — see ``self._sandbox_env``'s own docstring for why;
-        this accessor exists so the mechanism is inspectable through a
-        public surface rather than only via private state."""
-        return self._sandbox_env
 
     @property
     def negotiated_version(self) -> str | None:
@@ -1816,10 +1796,26 @@ class MCPClient:
         silently unsandboxed" is true of the warning on every path, and of the
         audit trail only where a sink was wired.
 
-        #3848 stage 1: also stores ``self._sandbox_env`` (the allowlisted env
-        ``wrap_command()`` computes, #3850) — carried through rather than
-        dropped, but not yet CONSUMED by ``_open_stdio``'s actual launch (see
-        ``self._sandbox_env``'s own docstring for why).
+        #3848: ``wrapped.env`` (the allowlisted env ``wrap_command()``
+        computes, #3850) is deliberately NOT carried into the launch here —
+        an earlier stage held it for a planned stage 2 that never landed
+        (owner ruling, #3848's closing comment). MCP stdio's actual launch
+        (``_open_stdio``) passes ``env=None`` when the operator's own
+        per-server config doesn't set one, and the OFFICIAL ``mcp`` SDK fills
+        that with its own narrow ``DEFAULT_INHERITED_ENV_VARS`` allowlist
+        (``HOME``/``LOGNAME``/``PATH``/``SHELL``/``TERM``/``USER``) — this is
+        CORRECT and deliberately different from reyn's own sandbox path
+        (``resolve_passthrough_env``, which passes everything by default,
+        owner ruling B): the trust relationship is not the same. reyn's own
+        sandbox path launches a command on the OPERATOR's behalf — the same
+        trust level as the operator typing it into their own shell, so
+        "pass everything" is correct there. MCP stdio launches a THIRD
+        PARTY's server program — the SDK limiting what that program inherits
+        is the SDK correctly exercising its OWN responsibility, and reyn
+        substituting a wider allowlist (or reyn's own "pass everything")
+        would be reyn overriding a decision that isn't reyn's to make. Do
+        not apply ruling B here — the two paths differ on WHO is trusted,
+        not on what mechanism sandboxes them.
         """
         from reyn.security.sandbox import get_default_backend
 
@@ -1853,11 +1849,9 @@ class MCPClient:
                         command,
                         emit_exc,
                     )
-            self._sandbox_env = None
             return command, args
 
         self._sandbox_cleanup = wrapped.cleanup
-        self._sandbox_env = wrapped.env
         return wrapped.argv[0], list(wrapped.argv[1:])
 
     def _is_non_interactive(self) -> bool:

--- a/tests/security/test_mcp_client_sandbox_wrap.py
+++ b/tests/security/test_mcp_client_sandbox_wrap.py
@@ -207,68 +207,21 @@ def test_profile_cleaned_on_close(monkeypatch):
     client.close_stderr_capture()
 
 
-# ── #3848 stage 1: the allowlisted env wrap_command() computes (#3850) is
-# carried through to the client instance instead of being silently dropped —
-# _sandbox_wrap_stdio used to project only .argv out of WrappedCommand. Not
-# yet CONSUMED by _open_stdio's actual launch (owner ruling: default stays
-# "pass everything"). These pin that the MECHANISM is genuinely reached, not
-# just that observable behavior is unchanged — a dead/no-op mechanism would
-# produce the identical "everything still passes through" result under
-# today's default, so asserting only the final launch behavior would not
-# distinguish "wired and working" from "still silently dropped". ──────────
-
-
-def test_sandbox_env_is_captured_from_the_real_allowlist(monkeypatch):
-    """Tier 2: #3848 stage 1 — after a successful wrap, client.sandbox_env
-    equals the SAME allowlisted env wrap_command() itself computed (#3850) —
-    not a copy, not a re-derivation, the real value the mechanism produced.
-    Strip the `self._sandbox_env = wrapped.env` assignment and this goes RED
-    (client.sandbox_env stays None even though the wrap succeeded)."""
-    backend = NoopBackend()
-    _patch_backend(monkeypatch, backend)
-    client = _stdio_client()
-    client._sandbox_wrap_stdio("my-mcp", ["--flag"])
-
-    expected = backend.wrap_command(["my-mcp", "--flag"], client._build_mcp_sandbox_policy()).env
-    assert client.sandbox_env is not None
-    assert client.sandbox_env == expected
-
-
-def test_sandbox_env_is_none_when_the_wrap_itself_fails(monkeypatch):
-    """Tier 2: #3848 stage 1 — the fail-open (backend-probe-failure) path
-    explicitly RESETS _sandbox_env to None rather than leaving a stale value
-    from a previous successful call. A fresh client already starts at None
-    (__init__'s own default), so a successful wrap runs FIRST here — without
-    the explicit reset in the except branch, a second, failing call would
-    silently keep the first call's real allowlist value, which is the
-    dangerous direction (a caller reading _sandbox_env after a failed wrap
-    would see a value that was never actually applied to THIS launch)."""
-
-    def _boom(config=None):
-        raise RuntimeError("backend probe exploded")
-
-    _patch_backend(monkeypatch, NoopBackend())
-    client = _stdio_client()
-    client._sandbox_wrap_stdio("my-mcp", ["--flag"])
-    assert client.sandbox_env is not None  # first call: real value captured
-
-    monkeypatch.setattr("reyn.security.sandbox.get_default_backend", _boom)
-    with pytest.warns(UserWarning, match="UNSANDBOXED"):
-        client._sandbox_wrap_stdio("my-mcp", ["--flag"])
-    assert client.sandbox_env is None  # second call failed -> reset, not stale
-
-
-def test_initialize_stdio_env_is_still_driven_by_config_not_sandbox_env(monkeypatch):
-    """Tier 2: #3848 stage 1 — carrying the allowlist through must NOT change
-    today's default launch behavior (owner ruling: default stays "pass
-    everything"). #4282/#4287: retargeted from the removed ``_open_stdio``
-    to the live ``_initialize_stdio`` path — its real
-    ``StdioServerParameters(env=...)`` call is driven ONLY by
-    ``self._config.get("env")``, never by ``self._sandbox_env``, in this
-    stage. Captures the REAL ``mcp.client.stdio.StdioServerParameters``
-    class's kwargs by wrapping it (still constructs the real object,
-    exactly what ``_initialize_stdio`` would build unmodified) rather than
-    faking the SDK type — same seam
+def test_initialize_stdio_env_is_driven_by_config_alone(monkeypatch):
+    """Tier 2: ``_initialize_stdio``'s real ``StdioServerParameters(env=...)``
+    call is driven ONLY by ``self._config.get("env")`` — nothing else
+    computes or substitutes an env for the real launch. (#3848 closed with
+    no fix needed, owner ruling: the official ``mcp`` SDK's own
+    ``DEFAULT_INHERITED_ENV_VARS`` allowlist is correct here as-is, and an
+    earlier stage-1 mechanism that held a WIDER allowlist for a planned
+    stage 2 that never landed — ``self._sandbox_env`` — was removed; see
+    ``_sandbox_wrap_stdio``'s own docstring for why MCP stdio's trust
+    relationship differs from reyn's own sandbox path.) #4282/#4287:
+    retargeted from the removed ``_open_stdio`` to the live
+    ``_initialize_stdio`` path. Captures the REAL
+    ``mcp.client.stdio.StdioServerParameters`` class's kwargs by wrapping it
+    (still constructs the real object, exactly what ``_initialize_stdio``
+    would build unmodified) rather than faking the SDK type — same seam
     ``test_initialize_failure_includes_stderr_tail_in_error`` in
     ``test_mcp_client_stderr_capture.py`` already established (a local
     ``from mcp.client.stdio import ...`` re-resolves the source module's
@@ -299,10 +252,9 @@ def test_initialize_stdio_env_is_still_driven_by_config_not_sandbox_env(monkeypa
 
     asyncio.run(_run())
 
-    # config declared no `env:` key -> today's default (env=None, full
-    # parent inherit) must be untouched by the now-populated _sandbox_env.
-    assert client.sandbox_env is not None  # the mechanism DID run
-    assert captured.get("env") is None  # but did not drive the real launch
+    # config declared no `env:` key -> today's default: env=None, so the
+    # official SDK fills its own DEFAULT_INHERITED_ENV_VARS allowlist.
+    assert captured.get("env") is None
 
 
 def test_initialize_stdio_actually_invokes_the_sandbox_wrap(monkeypatch):


### PR DESCRIPTION
**[tui-coder]** — Owner-ruling cleanup for #3848: the reported leak turned out not to exist (the SDK's own narrow allowlist is correct), leaving a dead field from the stage-1 groundwork to remove.

## Background

Issue history (full detail in the issue comments): what looked like "MCP stdio's normal path passes the parent's whole environment to the child, unfiltered" was measured against fastmcp-era behavior. On current `main` (post-#4283, official SDK), the live path passes `env=None` when the operator hasn't set a per-server `env:`, and the official `mcp` SDK fills that with its own narrow `DEFAULT_INHERITED_ENV_VARS` allowlist (`HOME`/`LOGNAME`/`PATH`/`SHELL`/`TERM`/`USER`) — not "everything." Owner ruling: that's correct as-is, and reyn has no reason to touch it — "if the SDK is already limiting to 6 vars, don't pass everything, and don't second-guess the SDK's own allowlist either."

## What changed

`self._sandbox_env` / the `sandbox_env` property (`mcp/client.py`) held the allowlisted env `wrap_command()` computes (#3850) — carried through from an earlier stage-1 slice for a planned stage 2 that would consume it in the real launch. Stage 2 is not landing (owner ruling above), so:

- Removed the field, the property, and both assignment sites in `_sandbox_wrap_stdio`.
- `_sandbox_wrap_stdio`'s docstring now records WHY not to reintroduce this: MCP stdio's trust relationship differs from reyn's own sandbox path (`resolve_passthrough_env`, which passes everything by default under ruling B). reyn's own sandbox path launches a command on the **operator's own behalf** — same trust level as their own shell, so "pass everything" is correct there. MCP stdio launches a **third party's** server program — the SDK limiting what that program inherits is the SDK correctly exercising its own responsibility, not something reyn should override. This distinction is written down specifically because the same "apply ruling B here too" proposal was floated and retracted during this issue's own investigation — the next person reasoning the same way now finds the answer already there.
- Deleted the 2 tests that only pinned the now-removed mechanism was captured/reset (`test_sandbox_env_is_captured_from_the_real_allowlist`, `test_sandbox_env_is_none_when_the_wrap_itself_fails`) — six-questions ③: nobody but those tests themselves would have missed the mechanism.
- Kept and trimmed the third test that referenced the removed property (`test_initialize_stdio_env_is_still_driven_by_config_not_sandbox_env` → renamed `test_initialize_stdio_env_is_driven_by_config_alone`) — its remaining claim ("the real launch's env comes from operator config alone") is still real and worth pinning on its own; only the now-meaningless `sandbox_env is not None` assertion was dropped.

## Test plan

- [x] `ruff check src/reyn/mcp/client.py tests/security/test_mcp_client_sandbox_wrap.py` — clean
- [x] `python scripts/mypy_ratchet.py` — OK, 211 findings, all baselined
- [x] `python scripts/test_tier_audit.py --strict tests/security/test_mcp_client_sandbox_wrap.py` — OK, 13 tests, 0 errors
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/verify_module_docstrings.py src/reyn/mcp/client.py` — OK
- [x] `pytest tests/security tests/mcp -q` — 884 passed, 26 skipped (unrelated)
- [x] Confirmed no remaining reference to `sandbox_env`/`_sandbox_env` anywhere in `src/`, `tests/`, or `docs/` (grep swept before opening this PR)

Not merging — holding for lead-coder's TESTS-READY per this repo's convention.

Enumerated before writing the closing keyword: `gh pr list --state all --search "3848 in:body"` returns only #3853 and #3850, both already MERGED — no open `part of #3848` work remains. Closes #3848.
