### PR TITLE
fix(#4347): onboarding text shows one example, not an enumeration

### DIFF
--- a/docs/guide/getting-started/01-installation.ja.md
+++ b/docs/guide/getting-started/01-installation.ja.md
@@ -45,13 +45,15 @@ built-in catalog (例: `claude-sonnet-thinking` / `gemini-flash-lite`) も ship 
 派生できます。 詳細は `reference/config/reyn-yaml.md` + `reference/builtin-models.md`
 を参照。
 
-対応する API キーをエクスポートします:
+あなたの provider の API キーをエクスポートします。例:
 
 ```bash
 export OPENAI_API_KEY=sk-...
-# または
-export ANTHROPIC_API_KEY=sk-ant-...
 ```
+
+litellm が provider ごとの変数を自動で解決します — あなたの provider が
+どの変数名を使うかは [litellm の provider docs](https://docs.litellm.ai/docs/providers)
+を参照してください。
 
 !!! warning "API キーは絶対にコミットしない"
     キーは環境変数にのみ保存します。`reyn.yaml` はチェックインします。プロキシ URL は `reyn.local.yaml` や `~/.reyn/config.yaml`（gitignored）に書きます。

--- a/docs/guide/getting-started/01-installation.md
+++ b/docs/guide/getting-started/01-installation.md
@@ -44,13 +44,15 @@ ships a built-in catalog (e.g. `claude-sonnet-thinking`, `gemini-flash-lite`) th
 you can reference by short name, and a dict form with `extends` for cost variants.
 See `reference/config/reyn-yaml.md` and `reference/builtin-models.md` for details.
 
-Then export the matching API key:
+Then export your provider's API key, e.g.:
 
 ```bash
 export OPENAI_API_KEY=sk-...
-# or
-export ANTHROPIC_API_KEY=sk-ant-...
 ```
+
+litellm resolves your provider's own variable automatically — see
+[litellm's provider docs](https://docs.litellm.ai/docs/providers) for the
+name yours expects.
 
 !!! warning "Never commit API keys"
     Keys belong only in environment variables. `reyn.yaml` is checked in; put proxy URLs in `reyn.local.yaml` or `~/.reyn/config.yaml` (gitignored).

--- a/reyn.yaml
+++ b/reyn.yaml
@@ -1,8 +1,9 @@
 # Reyn project configuration
 # Committed to git. For personal overrides, use reyn.local.yaml (gitignored).
 # api_base (proxy URL) belongs in reyn.local.yaml or ~/.reyn/config.yaml.
-# API keys must be set as environment variables — never in config files:
-#   OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, etc.
+# API keys must be set as environment variables — never in config files —
+# e.g. OPENAI_API_KEY. litellm resolves your provider's own variable
+# automatically; see https://docs.litellm.ai/docs/providers.
 
 # Default model class when --model is not specified
 model: standard

--- a/src/reyn/interfaces/cli/commands/init.py
+++ b/src/reyn/interfaces/cli/commands/init.py
@@ -71,9 +71,15 @@ def run(args: argparse.Namespace) -> None:
     print("  1. Edit reyn.yaml          — set model mappings for your provider")
     print("  2. Edit reyn.local.yaml    — set api_base if using a proxy (gitignored)")
     print("     (copy from reyn.local.yaml.example if present)")
-    print("  3. Export your API key:")
+    # #4347: an example, not an enumeration — litellm resolves the actual
+    # provider's env var itself; naming a fixed set here reads as "these are
+    # the supported providers" to anyone using a different one. One example
+    # (owner ruling: even 2 items starts reading as a coverage table) plus a
+    # pointer to litellm's own provider docs, which won't go stale as
+    # litellm adds providers reyn never has to know about by name.
+    print("  3. Export your provider's API key, e.g.:")
     print("       export OPENAI_API_KEY=sk-...")
-    print("       export ANTHROPIC_API_KEY=sk-ant-...")
+    print("     (see https://docs.litellm.ai/docs/providers for other providers)")
     print("  4. Try one of these:")
     print("       reyn chat                              # talk to the agent")
     print()

--- a/src/reyn/interfaces/cli/templates.py
+++ b/src/reyn/interfaces/cli/templates.py
@@ -98,10 +98,10 @@ REYN_LOCAL_CONFIG_TEMPLATE = """\
 # LiteLLM proxy base URL (omit if calling providers directly)
 # api_base: http://localhost:4000
 
-# API keys must be set as environment variables, not here:
+# API keys must be set as environment variables, not here — e.g.:
 #   export OPENAI_API_KEY=sk-...
-#   export ANTHROPIC_API_KEY=sk-ant-...
-#   export GEMINI_API_KEY=...
+# litellm resolves your provider's own variable automatically; see
+# https://docs.litellm.ai/docs/providers for the name yours expects.
 
 # Override model mappings for your local setup (optional)
 # models:


### PR DESCRIPTION
**[tui-coder]** — ④ implementation for #4347 (owner ruling: proceed) — onboarding/setup text shows one example, not an enumeration.

## Background

Full measurement + 3 wording proposals already posted as an issue comment before this PR: https://github.com/tya5/reyn/issues/4347#issuecomment-5260894575 (a full sweep of every "export/set a specific provider env var" site in the repo — not just `init.py`/`templates.py` — plus confirmation of litellm's real canonical redirect target). Owner ruling landed on the middle ground: keep a minimal example (not zero), redirect the rest, stop trying to enumerate.

## What changed

4 sites, same shape everywhere — one example + a pointer to litellm's own provider index:

- `src/reyn/interfaces/cli/commands/init.py` — `reyn init`'s printed "Next steps"
- `src/reyn/interfaces/cli/templates.py` — `REYN_LOCAL_CONFIG_TEMPLATE`, written into every generated `reyn.local.yaml.example`
- `reyn.yaml` (repo's own committed config header — same pattern, tracked/operator-visible, comment-only change)
- `docs/guide/getting-started/01-installation.md` + `.ja.md` mirror (same PR — falsifying the same claim in both languages, not a blanket en/ja obligation)

Redirect target: `https://docs.litellm.ai/docs/providers` — litellm's real per-provider index (each provider links to its own page documenting that provider's env var name). Verified live (`curl` 200) immediately before landing. `docs.litellm.ai/docs/set_keys` was considered and rejected — it's itself only a partial 5-provider example list, not an exhaustive canonical table, so pointing there would just relocate the same problem.

## Deliberately NOT touched

`docs/guide/for-users/protect-credentials-in-shell-commands.md`'s 6-name list — different purpose (illustrating the *shape* of a risky env var name for shell-history-exposure awareness, not "which providers reyn supports"), and it already self-caveats in place: *"This list is not the boundary of what's risky — it's an example of the shape... reyn has no way to enumerate all of them for you."* Already the target pattern; nothing to fix there.

`tests/interfaces/test_2686_pipe_llm_credential_precheck.py` / `tests/conftest.py`'s 4-name `_PROVIDER_KEYS` — a different feature (#2686's credential precheck), not onboarding text. Out of scope.

## Test plan

- [x] `ruff check` on both touched `src/` files — clean
- [x] `python scripts/mypy_ratchet.py` — OK, 211 findings, all baselined
- [x] `python scripts/verify_module_docstrings.py` on both touched `src/` files — OK
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean build, no new warnings touching the changed files
- [x] `python scripts/check_doc_anchors.py` — "no dangling anchors into published pages"
- [x] Confirmed no test pins the old printed/template text (swept `tests/` before editing)
- [x] Confirmed the redirect URL is live (`curl -s -o /dev/null -w "%{http_code}" https://docs.litellm.ai/docs/providers` → `200`)

**Visual — real `reyn init` output** (lead-coder has no TTY; this is the reviewable surface):

```
  Created   reyn.yaml
  Created   reyn.local.yaml.example  (.gitignore created: added .reyn/, reyn.local.yaml)

Next steps:
  1. Edit reyn.yaml          — set model mappings for your provider
  2. Edit reyn.local.yaml    — set api_base if using a proxy (gitignored)
     (copy from reyn.local.yaml.example if present)
  3. Export your provider's API key, e.g.:
       export OPENAI_API_KEY=sk-...
     (see https://docs.litellm.ai/docs/providers for other providers)
  4. Try one of these:
       reyn chat                              # talk to the agent

MCP servers (optional):
  To use MCP-backed tools/servers, uncomment the mcp:
  block in reyn.yaml.  Full example: docs/cookbook/configs/with-mcp.yaml
  Setup guide:          docs/guide/use-an-mcp-server.md
```

**Real generated `reyn.local.yaml.example` content:**

```yaml
# Local environment overrides — gitignored, never commit.

# LiteLLM proxy base URL (omit if calling providers directly)
# api_base: http://localhost:4000

# API keys must be set as environment variables, not here — e.g.:
#   export OPENAI_API_KEY=sk-...
# litellm resolves your provider's own variable automatically; see
# https://docs.litellm.ai/docs/providers for the name yours expects.

# Override model mappings for your local setup (optional)
# models:
#   light:    openai/gemini-2.5-flash-lite
#   standard: openai/gemini-2.5-flash-lite
#   strong:   openai/gemini-2.5-flash-lite
```

Not merging — holding for lead-coder's TESTS-READY per this repo's convention. `part of #4347` (③ remains owner-decision-pending).
