### PR TITLE
docs(#4359): Case B (local litellm proxy) needs a client-side api_key too

### DIFF
--- a/docs/guide/for-users/enable-semantic-search.md
+++ b/docs/guide/for-users/enable-semantic-search.md
@@ -96,6 +96,8 @@ Restart the proxy after editing.
 export LITELLM_API_BASE=http://localhost:4000   # your proxy's address
 ```
 
+**"No API key" describes the local model, not the client call.** The transport reyn's litellm client uses for any OpenAI-compatible endpoint — proxy included — still requires *some* non-empty `api_key` value to construct the request; this is [litellm's own documented requirement for the OpenAI-compatible provider](https://docs.litellm.ai/docs/providers/openai_compatible), not something reyn adds. If you don't already have `OPENAI_API_KEY` set (e.g. from a prior Case A setup), running `reyn secret set OPENAI_API_KEY` with any placeholder string satisfies it — your local proxy only validates that value if you've set its own [`general_settings.master_key`](https://docs.litellm.ai/docs/proxy/virtual_keys), which Step 2 above never did.
+
 **Naming rule (read before choosing a model name):** when `LITELLM_API_BASE` is set, reyn strips the resolved model string's leading `provider/` segment before sending it to the proxy — `openai/foo` arrives at the proxy as plain `foo`. So the proxy's `model_list[].model_name` must equal **everything after the first `/`** of whichever reyn-side model string you use:
 
 - **(a) Simplest — no class edit needed, just enable.** Keep the built-in `standard` class (`openai/text-embedding-3-small`, the default `embedding.default_class`) and register the proxy's `model_name` as `text-embedding-3-small` (as in Step 2 above) — the local model now answers under reyn's default class name:

--- a/src/reyn/builtin/plugins/rag/skills/build-and-query-rag-corpus/references/configure-local-embedding-model.md
+++ b/src/reyn/builtin/plugins/rag/skills/build-and-query-rag-corpus/references/configure-local-embedding-model.md
@@ -42,6 +42,19 @@ Restart the proxy after editing.
 export LITELLM_API_BASE=http://localhost:4000   # your proxy's address
 ```
 
+**"No API key" describes the local model, not the client call.** The
+transport reyn's litellm client uses for any OpenAI-compatible endpoint --
+proxy included -- still requires *some* non-empty `api_key` value to
+construct the request; this is
+[litellm's own documented requirement for the OpenAI-compatible
+provider](https://docs.litellm.ai/docs/providers/openai_compatible), not
+something reyn adds. If you don't already have `OPENAI_API_KEY` set (e.g.
+from a prior Case A setup), running `reyn secret set OPENAI_API_KEY` with
+any placeholder string satisfies it -- your local proxy only validates
+that value if you've set its own
+[`general_settings.master_key`](https://docs.litellm.ai/docs/proxy/virtual_keys),
+which Step 2 above never did.
+
 **Naming rule (read before choosing a model name):** when
 `LITELLM_API_BASE` is set, reyn strips the resolved model string's leading
 `provider/` segment before sending it to the proxy -- `openai/foo` arrives


### PR DESCRIPTION
**[docs-maintainer]** — Closes #4359 (Case B, the last remaining item).

Enumerated before writing the closing keyword: `gh pr list --state all --search "#4359 in:body"` returns exactly one other PR, #4360, already MERGED (`part of #4359`). No other open PR/issue references #4359 — this one completes it.

## Investigation order (per lead-coder's guidance, not probe-first)

1. **litellm's own docs first**, not the installed package: `docs.litellm.ai/docs/providers/openai_compatible` confirms — quoting — "This library requires an API key for all requests, either through the `api_key` parameter or the `OPENAI_API_KEY` environment variable," even for an unauthenticated local endpoint, and explicitly suggests a fake key as the workaround (or switching to a provider-specific integration reyn doesn't use). `docs.litellm.ai/docs/proxy/virtual_keys` confirms `master_key` is optional and validation is conditional on it being set.
2. **Where the docs didn't answer**: neither litellm doc page states outright whether an *unconfigured* proxy validates an arbitrary Authorization value — inferred from the master_key page's own phrasing ("if set, all calls require it") rather than an explicit unauthenticated-proxy statement.
3. **Installed implementation**: traced `openai/_client.py` (the actual dependency pinned via litellm's floor, `litellm>=1.89.3`, `.venv` has 1.89.3) — `_enforce_credentials` defaults `True`, raising `OpenAIError("Missing credentials...")` unless `api_key` or `OPENAI_API_KEY` is set. Traced litellm's `_get_openai_client` → confirms it passes `api_key=None` straight through to the SDK when `_proxy_kwargs()` supplies none (current reyn behavior, `litellm_provider.py:85-102`, #4347's fix — no more `"dummy"` injection). `reyn secret set OPENAI_API_KEY` is reyn's existing, already-documented mechanism for forwarding a value litellm resolves itself — no code change needed, this is a doc-only fix.
4. **No live execution needed** — steps 1–3 fully answered the question from primary sources; nothing remained ambiguous enough to require running a real proxy.

## Conclusion

Case B (no API key, local model) is accurate about the *model* needing no key — it is **not** accurate that the *client call* needs none: litellm's OpenAI-compatible transport (what `_proxy_kwargs()` uses, `custom_llm_provider="openai"`) always needs a non-empty `api_key` value, satisfied for an unauthenticated local proxy with any placeholder. Neither Case B doc mentioned this at all since #4348/#4356 removed reyn's own `"dummy"` fallback injection — a reader following the doc literally with zero `OPENAI_API_KEY` set anywhere would hit `OpenAIError("Missing credentials...")` before ever reaching their local proxy.

## Changes

- `docs/guide/for-users/enable-semantic-search.md` (Case B, after Step 3).
- `src/reyn/builtin/plugins/rag/skills/build-and-query-rag-corpus/references/configure-local-embedding-model.md` (Case B, after Step 3) — the RAG-plugin sibling.

Both framed as **litellm's contract, not reyn's decision** (per #4351's precedent, and this session's night-long axis discipline): point at litellm's own docs for what it requires, and at reyn's existing `reyn secret set OPENAI_API_KEY` mechanism for satisfying it — no new reyn-side default or injected value is prescribed.

## Verification

- `rm -rf site && mkdocs build --strict` — clean (fresh rebuild).
- `python scripts/check_doc_anchors.py` — clean.
- The `src/.../references/` file is skill-bundled content, not part of the mkdocs site (linked via raw GitHub URL from the guide) — confirmed it isn't in `mkdocs.yml`'s nav, so the strict build doesn't cover it; reviewed by hand for formatting consistency with its existing style (`--` em-dash convention, wrap width).

## Test plan

- [x] litellm official docs consulted first (2 pages, both quoted above).
- [x] Doc-gap identified before touching source.
- [x] Installed implementation (`litellm_provider.py`, litellm's own `.venv` install, openai SDK's `_client.py`) read to confirm the mechanism, not assumed.
- [x] No live execution was needed — primary-source reading fully resolved the question.
- [x] Framed as litellm's contract per lead-coder's explicit instruction, not "what reyn passes."
- [x] `mkdocs build --strict` clean.
- [x] `check_doc_anchors.py` clean.
- [x] This is the last open item on #4359 — issue can close once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
