### PR TITLE
feat(3671): break tui-boot into construct/compose/hydrate/other

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1251,205 +1251,210 @@ class TextualChatApp(App):
         self._cursor_position = value
 
     def compose(self) -> ComposeResult:
-        # Held so the frame pump can start/stop the per-entry BODY animation
-        # (``animate_entry``/``stop_entry_animation``) that drives a RUNNING tool
-        # row's live spinner + elapsed (Phase ②).
-        self._flow: "FlowView[OutboxMessage]" = _CursorFlowView(
-            model=self.conversation,
-            presenter=self._presenter,
-            decorator=ReynGutter(
-                frame_period=_RUNNING_FRAME_PERIOD,
-                # The app's own injectable clock, as the right gutter already
-                # takes — production passes ``time.monotonic``, so this is the
-                # same behaviour, and it lets a test drive the blink instead of
-                # sleeping through a real frame period.
-                clock=self._clock,
-                # #3530: blink a reply that is still receiving chunks. Read
-                # live off ``_streaming_replies`` each repaint — the same
-                # record the terminal completion frame pops — so the marker
-                # can never disagree with whether the stream is actually
-                # still open.
-                is_streaming=self._is_streaming_entry,
-            ),
-            gutter_width=_GUTTER_WIDTH,
-            # Phase ④ (#3283): the RIGHT gutter shows per-entry elapsed time
-            # (tool rows) AND the row's turn's real prompt/completion token
-            # split (agent reply rows, via the keyed per-turn lookup) — see
-            # ReynRightGutter and its two halves for the content-set decisions.
-            # additive flowview params; the LEFT gutter/state contract above is
-            # untouched.
-            right_decorator=ReynRightGutter(
-                clock=self._clock,
-                usage_lookup=self._turn_usage,
-                # #3490, moved to this side by #3526 (owner directive): the
-                # addressed-row rail. Read live off the view each repaint (not
-                # pushed in on every move) so the gutter can never hold a stale
-                # copy of which entry is current.
-                is_marked=self._is_addressed_entry,
-            ),
-            right_gutter_width=RIGHT_GUTTER_WIDTH,
-            spacing=1,
-            anchor=Anchor.STICKY_BOTTOM,
-            # Native running-blink: FlowView owns the animation clock and
-            # re-invokes the time-based ReynGutter each tick (no app-side timer).
-            animation_fps=self.ANIMATION_FPS,
-            # #3476 ②: a fresh session previously opened onto a blank void
-            # above the composer (owner design review). flowview 0.6.0's
-            # empty state shows this hint across the viewport while the model
-            # has no entries and clears itself the moment the first entry
-            # lands — no app-side show/hide wiring to drift.
-            empty=empty_state_hint(),
-            empty_align="middle",
-            # #3476 ④: fire ReachedTop while the top edge is still a few rows
-            # away, so the next history page is in place by the time the user
-            # actually arrives at it.
-            reach_threshold=3,
-            # #3476 ⑥: the keyboard cursor (the visual affordance #3470
-            # deferred to this PR). Reached the SAME way #3470 already
-            # established — Shift+Tab focus-cycling into FlowView, Esc back
-            # out (#3399 gate) — never a new focus path. flowview owns
-            # ↑/↓/PageUp/PageDown/Home/End moving the cursor once FlowView
-            # has focus; while it doesn't, those keys are unaffected (the
-            # composer's own PageUp/PageDown delegation, #3470, calls
-            # actions on ``self._flow`` directly and never depends on this
-            # flag).
-            # #3624: flowview 0.11.0 unified this with mouse-driven selection
-            # (a click now moves+commits the SAME cursor) — ``selectable=``
-            # is the current name (``highlight=`` was removed in 0.12.0).
-            # See ``_CursorFlowView``/``KeyCommitted`` above for how
-            # reyn keeps the copy-on-Enter/Space intent without also copying
-            # on a click.
-            selectable=True,
-            # #3507 / flowview 0.8.0 (#7), #3692 PR-A (flowview 0.13's yank,
-            # renamed from copy_yank): the text cursor's yank writes through
-            # THIS sink instead of the default OSC 52. reyn already owns a local
-            # clipboard path (``pbcopy``/``xclip``/``wl-copy``/``xsel``) that
-            # works on macOS Terminal and through tmux, where OSC 52 silently
-            # does not — and unlike OSC 52 its result is observable, so a failed
-            # yank can be reported instead of looking like it worked. Upstream
-            # added this per-view seam for exactly this case; the alternative
-            # (overriding ``App.copy_to_clipboard``) caught every
-            # Textual-originated copy in the app to fix one widget's.
-            clipboard=self._write_clipboard,
-            # flowview 0.17.0 / #4171: without this, `*`/`n`/`N` search reads
-            # rows through the render path, so an entry that has never
-            # scrolled into view has no Presentation yet and search sees the
-            # "Loading..." placeholder instead of its content — silently
-            # missing matches above the rendered window. This hands flowview
-            # the raw message text so it can search the whole model directly,
-            # not just what's been rendered. Deliberately `msg.text`, not
-            # what the gutter decorates onto it — the gutter prefix is
-            # decoration, not message content, and a match there would be a
-            # confusing result to land a search cursor on.
-            search_text=lambda msg: msg.text,
-        )
-        # #3352: apply the configured START state. flowview has no constructor
-        # parameter for gutter visibility (both flags initialise True), so the
-        # only way to open with one hidden is to set it here — before mount,
-        # where ``set_gutter_visible`` short-circuits its relayout and geometry
-        # syncs on its own at mount time. No flash: nothing has painted yet.
-        left_start, right_start = self._gutter_start
-        self._flow.set_gutter_visible("left", left_start)
-        self._flow.set_gutter_visible("right", right_start)
-        yield self._flow
-        # #3299 P1: the grouped intervention panel sits BETWEEN the flow and
-        # the input row (region order shared with the sibling #3300 queue arc,
-        # plus #3362's rewind picker: conversation / intervention panel /
-        # rewind picker / sent-queue / input).
-        # Collapsed by default (``display=False`` — see
-        # ``InterventionPanel.on_mount``); shown + auto-focused only while an
-        # intervention is pending (:meth:`_present_intervention`).
-        self._iv_panel = InterventionPanel(id="intervention-panel")
-        yield self._iv_panel
-        # #3362: the /rewind checkpoint picker sits between the intervention
-        # panel and the sent-queue — same collapsed-by-default region shape
-        # (``display=False`` in its ``on_mount``), shown only while a bare
-        # ``/rewind`` is offering checkpoints.
-        self._rewind_picker = RewindPicker(id="rewind-picker")
-        yield self._rewind_picker
-        # #3300 P2b: the sent-queue region sits BETWEEN the intervention
-        # panel and the input row (region order: conversation / intervention
-        # panel / rewind picker / sent-queue / input — the intervention/queue/
-        # input ordering was pinned by the architect design pass so the sibling
-        # #3299/#3300 P1 coders never collide on this zone; #3362 added the
-        # rewind picker above the queue, inside the same zone).
-        # Collapsed by default (``display=False`` — see ``SentQueue.on_mount``);
-        # shown while at least one message is queued, undispatched.
-        # #3693: the live-turn line sits between the rewind picker and the
-        # queue, so the zone reads past (conversation) -> now (this) -> next
-        # (queue) -> the line being typed. Non-focusable, so Tab/Esc still walk
-        # the same path to the composer they did before it existed.
-        #: #3777: how many entries THIS TURN has produced, counted as they
-        #: arrive rather than derived from two reads of the model. The baseline
-        #: is the turn's start, which the reader saw; the previous counter's
-        #: baseline was the moment the reader scrolled away, which they did
-        #: not, so its number could never be interpreted. Reset by
-        #: :meth:`_reset_turn_entries` at turn start and nowhere else — in
-        #: particular NOT on a scroll edge.
-        self._turn_entries = 0
-        self._activity = ActivityRow(id="activity-row", clock=self._clock)
-        yield self._activity
-        self._sent_queue = SentQueue(id="sent-queue")
-        yield self._sent_queue
-        # #3354: the / and : completion popup sits DIRECTLY above the input row
-        # (the last region before the composer), so the candidate list grows
-        # upward out of the line being typed — the same direction and adjacency
-        # the retired inline app's completion menu had. Collapsed by default
-        # (``display=False`` — see ``CompletionPopup.on_mount``).
-        self._completion = CompletionPopup(id="completion")
-        yield self._completion
-        # #3476 ⑤ (ctrl+n since #3692 PR-B ③): the search bar — the last
-        # chrome region before the composer (collapsed by default; the
-        # completion popup above it can never be open at the same time,
-        # since completion follows COMPOSER typing and the search bar owns
-        # focus while visible).
-        self._search_bar = SearchBar(id="search-bar")
-        yield self._search_bar
-        with Horizontal(id="inputrow"):
-            yield Static("❯", id="inputgutter")
-            yield Composer(
-                # ``<key> to <verb> · <key> to <verb>`` (#3801), the shape
-                # ``rewind_picker`` already used. The previous form separated
-                # the two clauses with a comma and gave the second one a
-                # different grammar ("for a newline"), so the two halves of one
-                # hint read as two kinds of statement.
-                # "add a line", not "break the line": measured on a real
-                # terminal, the longer wording truncated at 65 columns where
-                # the pre-#3801 text fit at 60. This one costs one column over
-                # the old text rather than five. ("to newline" is shorter still
-                # and was rejected — it reads as a typo, and a hint nobody
-                # trusts is worse than a hint that wraps.)
-                placeholder=(
-                    "Type a message — enter to send · shift+enter to add a line…"
-                )
+        # #3671: reyn builds the ENTIRE widget tree in this generator —
+        # see startup_timing.py's mark_app_constructed docstring for why
+        # this is inside tui-boot's own breakdown, not Textual's boot.
+        from reyn.runtime.startup_timing import stage  # noqa: PLC0415
+        with stage("tui-boot:compose"):
+            # Held so the frame pump can start/stop the per-entry BODY animation
+            # (``animate_entry``/``stop_entry_animation``) that drives a RUNNING tool
+            # row's live spinner + elapsed (Phase ②).
+            self._flow: "FlowView[OutboxMessage]" = _CursorFlowView(
+                model=self.conversation,
+                presenter=self._presenter,
+                decorator=ReynGutter(
+                    frame_period=_RUNNING_FRAME_PERIOD,
+                    # The app's own injectable clock, as the right gutter already
+                    # takes — production passes ``time.monotonic``, so this is the
+                    # same behaviour, and it lets a test drive the blink instead of
+                    # sleeping through a real frame period.
+                    clock=self._clock,
+                    # #3530: blink a reply that is still receiving chunks. Read
+                    # live off ``_streaming_replies`` each repaint — the same
+                    # record the terminal completion frame pops — so the marker
+                    # can never disagree with whether the stream is actually
+                    # still open.
+                    is_streaming=self._is_streaming_entry,
+                ),
+                gutter_width=_GUTTER_WIDTH,
+                # Phase ④ (#3283): the RIGHT gutter shows per-entry elapsed time
+                # (tool rows) AND the row's turn's real prompt/completion token
+                # split (agent reply rows, via the keyed per-turn lookup) — see
+                # ReynRightGutter and its two halves for the content-set decisions.
+                # additive flowview params; the LEFT gutter/state contract above is
+                # untouched.
+                right_decorator=ReynRightGutter(
+                    clock=self._clock,
+                    usage_lookup=self._turn_usage,
+                    # #3490, moved to this side by #3526 (owner directive): the
+                    # addressed-row rail. Read live off the view each repaint (not
+                    # pushed in on every move) so the gutter can never hold a stale
+                    # copy of which entry is current.
+                    is_marked=self._is_addressed_entry,
+                ),
+                right_gutter_width=RIGHT_GUTTER_WIDTH,
+                spacing=1,
+                anchor=Anchor.STICKY_BOTTOM,
+                # Native running-blink: FlowView owns the animation clock and
+                # re-invokes the time-based ReynGutter each tick (no app-side timer).
+                animation_fps=self.ANIMATION_FPS,
+                # #3476 ②: a fresh session previously opened onto a blank void
+                # above the composer (owner design review). flowview 0.6.0's
+                # empty state shows this hint across the viewport while the model
+                # has no entries and clears itself the moment the first entry
+                # lands — no app-side show/hide wiring to drift.
+                empty=empty_state_hint(),
+                empty_align="middle",
+                # #3476 ④: fire ReachedTop while the top edge is still a few rows
+                # away, so the next history page is in place by the time the user
+                # actually arrives at it.
+                reach_threshold=3,
+                # #3476 ⑥: the keyboard cursor (the visual affordance #3470
+                # deferred to this PR). Reached the SAME way #3470 already
+                # established — Shift+Tab focus-cycling into FlowView, Esc back
+                # out (#3399 gate) — never a new focus path. flowview owns
+                # ↑/↓/PageUp/PageDown/Home/End moving the cursor once FlowView
+                # has focus; while it doesn't, those keys are unaffected (the
+                # composer's own PageUp/PageDown delegation, #3470, calls
+                # actions on ``self._flow`` directly and never depends on this
+                # flag).
+                # #3624: flowview 0.11.0 unified this with mouse-driven selection
+                # (a click now moves+commits the SAME cursor) — ``selectable=``
+                # is the current name (``highlight=`` was removed in 0.12.0).
+                # See ``_CursorFlowView``/``KeyCommitted`` above for how
+                # reyn keeps the copy-on-Enter/Space intent without also copying
+                # on a click.
+                selectable=True,
+                # #3507 / flowview 0.8.0 (#7), #3692 PR-A (flowview 0.13's yank,
+                # renamed from copy_yank): the text cursor's yank writes through
+                # THIS sink instead of the default OSC 52. reyn already owns a local
+                # clipboard path (``pbcopy``/``xclip``/``wl-copy``/``xsel``) that
+                # works on macOS Terminal and through tmux, where OSC 52 silently
+                # does not — and unlike OSC 52 its result is observable, so a failed
+                # yank can be reported instead of looking like it worked. Upstream
+                # added this per-view seam for exactly this case; the alternative
+                # (overriding ``App.copy_to_clipboard``) caught every
+                # Textual-originated copy in the app to fix one widget's.
+                clipboard=self._write_clipboard,
+                # flowview 0.17.0 / #4171: without this, `*`/`n`/`N` search reads
+                # rows through the render path, so an entry that has never
+                # scrolled into view has no Presentation yet and search sees the
+                # "Loading..." placeholder instead of its content — silently
+                # missing matches above the rendered window. This hands flowview
+                # the raw message text so it can search the whole model directly,
+                # not just what's been rendered. Deliberately `msg.text`, not
+                # what the gutter decorates onto it — the gutter prefix is
+                # decoration, not message content, and a match there would be a
+                # confusing result to land a search cursor on.
+                search_text=lambda msg: msg.text,
             )
-        # #4194: the config-warning indicator, mounted BEFORE MenuBar so it
-        # sits above the menu row in compose order (measured, headless
-        # ``App.run_test``: this ordering plus `1fr` FlowView is what leaves
-        # the always-visible last row — MenuBar/StatusLine — untouched,
-        # exactly where #2280's halt banner already depends on it staying).
-        # Conditionally yielded, not yielded-then-hidden: `unknown_config_key_count`
-        # is fixed for the whole session (reyn.yaml needs a restart to
-        # change), so there is no later render tick that would need to grow
-        # this row in — an operator on a clean config never pays even the
-        # empty-row layout cost the #4194 measurement confirmed a present
-        # row would take.
-        config_warning = config_warning_text(
-            getattr(self._config, "unknown_config_key_count", 0)
-        )
-        if config_warning is not None:
-            yield ConfigWarningLine(config_warning, id="config-warning")
-        # Bottom chrome: a focusable menu row that also carries the slim
-        # status-values segment (#3326: MenuBar owns placing StatusLine on
-        # whichever row has room, collapsing the two previously-separate rows
-        # into one whenever the terminal is wide enough), then a drawer
-        # (ContentSwitcher) that stays collapsed until a menu item opens it
-        # downward. Phase 4 fills each pane from its canonical reyn source; each
-        # pane is rebuilt from a fresh snapshot when opened (:meth:`_refresh_pane`).
-        yield MenuBar(_MENU_TABS, id="menubar", status_text=self._status_text())
-        with ScrollableDrawer(initial=None, id="drawer"):
-            for tid, _label in _MENU_TABS:
-                yield build_drawer_pane(tid, self._pane_rows(tid))
+            # #3352: apply the configured START state. flowview has no constructor
+            # parameter for gutter visibility (both flags initialise True), so the
+            # only way to open with one hidden is to set it here — before mount,
+            # where ``set_gutter_visible`` short-circuits its relayout and geometry
+            # syncs on its own at mount time. No flash: nothing has painted yet.
+            left_start, right_start = self._gutter_start
+            self._flow.set_gutter_visible("left", left_start)
+            self._flow.set_gutter_visible("right", right_start)
+            yield self._flow
+            # #3299 P1: the grouped intervention panel sits BETWEEN the flow and
+            # the input row (region order shared with the sibling #3300 queue arc,
+            # plus #3362's rewind picker: conversation / intervention panel /
+            # rewind picker / sent-queue / input).
+            # Collapsed by default (``display=False`` — see
+            # ``InterventionPanel.on_mount``); shown + auto-focused only while an
+            # intervention is pending (:meth:`_present_intervention`).
+            self._iv_panel = InterventionPanel(id="intervention-panel")
+            yield self._iv_panel
+            # #3362: the /rewind checkpoint picker sits between the intervention
+            # panel and the sent-queue — same collapsed-by-default region shape
+            # (``display=False`` in its ``on_mount``), shown only while a bare
+            # ``/rewind`` is offering checkpoints.
+            self._rewind_picker = RewindPicker(id="rewind-picker")
+            yield self._rewind_picker
+            # #3300 P2b: the sent-queue region sits BETWEEN the intervention
+            # panel and the input row (region order: conversation / intervention
+            # panel / rewind picker / sent-queue / input — the intervention/queue/
+            # input ordering was pinned by the architect design pass so the sibling
+            # #3299/#3300 P1 coders never collide on this zone; #3362 added the
+            # rewind picker above the queue, inside the same zone).
+            # Collapsed by default (``display=False`` — see ``SentQueue.on_mount``);
+            # shown while at least one message is queued, undispatched.
+            # #3693: the live-turn line sits between the rewind picker and the
+            # queue, so the zone reads past (conversation) -> now (this) -> next
+            # (queue) -> the line being typed. Non-focusable, so Tab/Esc still walk
+            # the same path to the composer they did before it existed.
+            #: #3777: how many entries THIS TURN has produced, counted as they
+            #: arrive rather than derived from two reads of the model. The baseline
+            #: is the turn's start, which the reader saw; the previous counter's
+            #: baseline was the moment the reader scrolled away, which they did
+            #: not, so its number could never be interpreted. Reset by
+            #: :meth:`_reset_turn_entries` at turn start and nowhere else — in
+            #: particular NOT on a scroll edge.
+            self._turn_entries = 0
+            self._activity = ActivityRow(id="activity-row", clock=self._clock)
+            yield self._activity
+            self._sent_queue = SentQueue(id="sent-queue")
+            yield self._sent_queue
+            # #3354: the / and : completion popup sits DIRECTLY above the input row
+            # (the last region before the composer), so the candidate list grows
+            # upward out of the line being typed — the same direction and adjacency
+            # the retired inline app's completion menu had. Collapsed by default
+            # (``display=False`` — see ``CompletionPopup.on_mount``).
+            self._completion = CompletionPopup(id="completion")
+            yield self._completion
+            # #3476 ⑤ (ctrl+n since #3692 PR-B ③): the search bar — the last
+            # chrome region before the composer (collapsed by default; the
+            # completion popup above it can never be open at the same time,
+            # since completion follows COMPOSER typing and the search bar owns
+            # focus while visible).
+            self._search_bar = SearchBar(id="search-bar")
+            yield self._search_bar
+            with Horizontal(id="inputrow"):
+                yield Static("❯", id="inputgutter")
+                yield Composer(
+                    # ``<key> to <verb> · <key> to <verb>`` (#3801), the shape
+                    # ``rewind_picker`` already used. The previous form separated
+                    # the two clauses with a comma and gave the second one a
+                    # different grammar ("for a newline"), so the two halves of one
+                    # hint read as two kinds of statement.
+                    # "add a line", not "break the line": measured on a real
+                    # terminal, the longer wording truncated at 65 columns where
+                    # the pre-#3801 text fit at 60. This one costs one column over
+                    # the old text rather than five. ("to newline" is shorter still
+                    # and was rejected — it reads as a typo, and a hint nobody
+                    # trusts is worse than a hint that wraps.)
+                    placeholder=(
+                        "Type a message — enter to send · shift+enter to add a line…"
+                    )
+                )
+            # #4194: the config-warning indicator, mounted BEFORE MenuBar so it
+            # sits above the menu row in compose order (measured, headless
+            # ``App.run_test``: this ordering plus `1fr` FlowView is what leaves
+            # the always-visible last row — MenuBar/StatusLine — untouched,
+            # exactly where #2280's halt banner already depends on it staying).
+            # Conditionally yielded, not yielded-then-hidden: `unknown_config_key_count`
+            # is fixed for the whole session (reyn.yaml needs a restart to
+            # change), so there is no later render tick that would need to grow
+            # this row in — an operator on a clean config never pays even the
+            # empty-row layout cost the #4194 measurement confirmed a present
+            # row would take.
+            config_warning = config_warning_text(
+                getattr(self._config, "unknown_config_key_count", 0)
+            )
+            if config_warning is not None:
+                yield ConfigWarningLine(config_warning, id="config-warning")
+            # Bottom chrome: a focusable menu row that also carries the slim
+            # status-values segment (#3326: MenuBar owns placing StatusLine on
+            # whichever row has room, collapsing the two previously-separate rows
+            # into one whenever the terminal is wide enough), then a drawer
+            # (ContentSwitcher) that stays collapsed until a menu item opens it
+            # downward. Phase 4 fills each pane from its canonical reyn source; each
+            # pane is rebuilt from a fresh snapshot when opened (:meth:`_refresh_pane`).
+            yield MenuBar(_MENU_TABS, id="menubar", status_text=self._status_text())
+            with ScrollableDrawer(initial=None, id="drawer"):
+                for tid, _label in _MENU_TABS:
+                    yield build_drawer_pane(tid, self._pane_rows(tid))
 
     def _snapshot(self) -> "dict | None":
         """The live status snapshot (model/agent/cost/ctx) off the client read
@@ -1732,7 +1737,11 @@ class TextualChatApp(App):
         # pane. Restored turns render resolved (never RUNNING) through the exact
         # same presenter/gutter path a live frame does. Must run before
         # ``run_worker`` so the prior turns sit ABOVE the first live frame.
-        self._hydrate_from_history()
+        # #3671: bracketed — owner suspected this scales with history size.
+        from reyn.runtime.startup_timing import stage  # noqa: PLC0415
+
+        with stage("tui-boot:hydrate"):
+            self._hydrate_from_history()
         # The running-blink gutter animates off FlowView's NATIVE animation clock
         # (``animation_fps`` wired in :meth:`compose`), not an app-side timer — so
         # there is nothing to start/pause here. The blink is ADDITIVE: a frozen
@@ -4579,17 +4588,21 @@ async def run_textual_chat(
     except Exception:
         pass
 
-    # #3671: the framework's own startup begins here — terminal setup, first
-    # layout, first paint. Everything before it is reyn assembling things;
-    # everything after it is Textual, and the two were indistinguishable while
-    # both sat inside ``unaccounted``.
-    from reyn.runtime.startup_timing import mark_app_constructed  # noqa: PLC0415
+    # #3671: the ``tui-boot`` span begins here. Owner git-bash re-measurement
+    # (25.5s startup, tui-boot = 93.7%) showed this span is NOT purely
+    # Textual's own boot — reyn's __init__/compose()/on_mount() all run
+    # inside it — so it is now broken into named sub-stages
+    # (``tui-boot:construct``/``:compose``/``:hydrate``/``:other``,
+    # startup_timing.py's ``_TUI_BOOT_NAMED_STAGES``) rather than left as
+    # one opaque bracket.
+    from reyn.runtime.startup_timing import mark_app_constructed, stage  # noqa: PLC0415
 
     mark_app_constructed()
-    app = TextualChatApp(
-        transport=transport,
-        read_model=read_model,
-        agent_name=agent_name,
-        config=config,
-    )
+    with stage("tui-boot:construct"):
+        app = TextualChatApp(
+            transport=transport,
+            read_model=read_model,
+            agent_name=agent_name,
+            config=config,
+        )
     await app.run_async(inline=inline)

--- a/src/reyn/runtime/startup_timing.py
+++ b/src/reyn/runtime/startup_timing.py
@@ -137,6 +137,27 @@ _CLIENT_PREP_NAMED_STAGES: "tuple[str, ...]" = (
 )
 
 
+#: #3671 follow-up (owner git-bash re-measurement: ``tui-boot`` = 93.7% of a
+#: 25.5s startup, previously a single unbroken span). The SAME shape as
+#: ``_CLIENT_PREP_NAMED_STAGES`` above, and the SAME #3735 discipline
+#: applies: these are narrow brackets around specific reyn calls inside
+#: ``tui-boot`` (``TextualChatApp.__init__``, ``compose()``,
+#: ``_hydrate_from_history()``) — not the whole span. ``tui-boot`` itself
+#: stays the wide ground-truth bracket (recorded unconditionally in
+#: :func:`mark_first_frame`, exactly as before this breakdown existed —
+#: not replaced, not removed, per the owner's own explicit ask not to lose
+#: the number already being compared to the macOS baseline in
+#: ``session.py``'s history), and whatever these three do NOT explain of
+#: it is recorded as ``tui-boot:other`` — never spilling into the
+#: process-wide ``unaccounted``, which stays reserved for stages outside
+#: this bracket's own concern.
+_TUI_BOOT_NAMED_STAGES: "tuple[str, ...]" = (
+    "tui-boot:construct",
+    "tui-boot:compose",
+    "tui-boot:hydrate",
+)
+
+
 #: When the lazily-imported ``run_textual_chat`` module finished importing
 #: (``textual``/``textual_flowview`` and everything they pull in — NOT
 #: covered by the ``import`` stage above, which closes at ``mark_cli_reached``
@@ -165,12 +186,21 @@ def mark_tui_import_done() -> None:
 
 
 def mark_app_constructed() -> None:
-    """Record that the TUI object exists and the framework is about to boot.
+    """Record that the TUI object is about to be constructed.
 
-    Paired with :func:`mark_first_frame` to bracket the framework's own startup
-    — terminal setup, first layout, first paint — as ``tui-boot``. Two marks
-    rather than a ``with`` block because the region spans a return out of one
-    function and into a framework callback, which no context manager can hold.
+    Paired with :func:`mark_first_frame` to bracket ``tui-boot``. #3671
+    follow-up (owner real-machine re-measurement, git-bash: ``tui-boot`` =
+    93.7% of a 25.5s startup): this docstring used to call the span "the
+    framework's own startup — terminal setup, first layout, first paint",
+    which is INACCURATE — the owner's own question ("does reyn's own
+    callback run inside that one chunk?") caught it. The span also runs
+    ``TextualChatApp.__init__``, ``compose()`` (reyn builds the entire
+    widget tree here), and ``on_mount()`` (theme setup + reyn's own
+    ``_hydrate_from_history()``) — reyn's code, not Textual's, for most of
+    it. See ``_TUI_BOOT_NAMED_STAGES`` for the breakdown this now supports.
+    Two marks rather than a ``with`` block because the region spans a
+    return out of one function and into a framework callback, which no
+    context manager can hold.
 
     Also closes ``client-prep:app-construct`` (P4, paired with
     :func:`mark_tui_import_done`) — #3671's original single ``client-prep``
@@ -229,12 +259,21 @@ def mark_first_frame() -> None:
     Idempotent: only the FIRST call counts. A surface that re-mounts (a session
     switch, a resize that rebuilds the app) must not move the end of startup to
     a later moment and shrink every share that came before it.
+
+    #3671 follow-up: also computes ``tui-boot:other`` — see
+    ``_TUI_BOOT_NAMED_STAGES``'s own docstring for why (the same
+    #3735-shaped "keep the wide bracket as ground truth, name what the
+    narrow sub-brackets do NOT explain" discipline ``client-prep:other``
+    already established, applied to this span).
     """
     global _FIRST_FRAME_AT
     if _FIRST_FRAME_AT is None:
         _FIRST_FRAME_AT = time.perf_counter()
         if _APP_CONSTRUCTED_AT is not None:
-            TIMING.record("tui-boot", _FIRST_FRAME_AT - _APP_CONSTRUCTED_AT)
+            wide = _FIRST_FRAME_AT - _APP_CONSTRUCTED_AT
+            TIMING.record("tui-boot", wide)
+            named = sum(TIMING.elapsed(s) for s in _TUI_BOOT_NAMED_STAGES)
+            TIMING.record("tui-boot:other", max(0.0, wide - named))
 
 
 def first_frame_reached() -> bool:
@@ -301,6 +340,10 @@ STAGES: "tuple[str, ...]" = (
     "client-prep:app-construct",
     "client-prep:other",
     "tui-boot",
+    "tui-boot:construct",
+    "tui-boot:compose",
+    "tui-boot:hydrate",
+    "tui-boot:other",
 )
 
 
@@ -347,7 +390,23 @@ class StartupTiming:
 
     @property
     def total_seconds(self) -> float:
-        return sum(self._elapsed.values())
+        """Sum of every recorded stage EXCEPT ``tui-boot`` itself.
+
+        #3671 follow-up: ``tui-boot`` is the wide ground-truth bracket for
+        the SAME span its own ``tui-boot:construct``/``:compose``/
+        ``:hydrate``/``:other`` sub-stages break down exactly (see
+        ``_TUI_BOOT_NAMED_STAGES``) — summing both the wide bracket AND its
+        full breakdown would count that one interval twice, inflating
+        ``total_seconds`` past ``wall_seconds`` and making
+        ``unaccounted_seconds`` clamp to 0 even when a real coverage gap
+        exists elsewhere in the startup. Excluded here rather than never
+        recorded (the ``client-prep`` precedent) because ``tui-boot`` is
+        also printed as its own report line — an operator already compares
+        it directly to a known macOS baseline (``session.py``'s history) —
+        and removing that line would look like "this step took no time"
+        under this module's own stated design rule.
+        """
+        return sum(v for k, v in self._elapsed.items() if k != "tui-boot")
 
     def unaccounted_seconds(self, wall_seconds: float) -> float:
         """Wall time the stages do not explain.

--- a/tests/runtime/test_startup_timing_3671.py
+++ b/tests/runtime/test_startup_timing_3671.py
@@ -377,6 +377,74 @@ def test_named_substages_plus_other_equal_the_wide_span(monkeypatch) -> None:
     assert abs(named_sum - (wall_end - wall_start)) < 0.02
 
 
+def test_tui_boot_named_substages_plus_other_equal_the_wide_span(monkeypatch) -> None:
+    """Tier 2: #3671 follow-up — the SAME coverage invariant as
+    ``test_named_substages_plus_other_equal_the_wide_span`` above, applied
+    to ``tui-boot``'s own breakdown (owner git-bash re-measurement:
+    ``tui-boot`` was a single unbroken 23.9s span). The 3 named sub-stages
+    (``tui-boot:construct``/``:compose``/``:hydrate``) plus
+    ``tui-boot:other`` must sum to the wide ``mark_app_constructed`` ->
+    ``mark_first_frame`` span exactly, not merely be less than or equal to
+    it — the #3735 regression shape this module's whole ``:other`` pattern
+    exists to prevent."""
+    import time
+
+    from reyn.runtime import startup_timing
+
+    monkeypatch.setattr(startup_timing, "_ASYNC_ENTERED_AT", None)
+    monkeypatch.setattr(startup_timing, "_TUI_IMPORT_DONE_AT", None)
+    monkeypatch.setattr(startup_timing, "_APP_CONSTRUCTED_AT", None)
+    monkeypatch.setattr(startup_timing, "_FIRST_FRAME_AT", None)
+    monkeypatch.setattr(startup_timing, "TIMING", StartupTiming())
+    stages = ("tui-boot:construct", "tui-boot:compose", "tui-boot:hydrate", "tui-boot:other")
+
+    wall_start = time.perf_counter()
+    startup_timing.mark_app_constructed()
+    with stage("tui-boot:construct"):
+        time.sleep(0.01)
+    time.sleep(0.01)  # the gap a narrow-bracket-only regression would drop
+    with stage("tui-boot:compose"):
+        time.sleep(0.01)
+    with stage("tui-boot:hydrate"):
+        time.sleep(0.01)
+    startup_timing.mark_first_frame()
+    wall_end = time.perf_counter()
+
+    named_sum = sum(startup_timing.TIMING.elapsed(name) for name in stages)
+    assert abs(named_sum - (wall_end - wall_start)) < 0.02
+
+
+def test_total_seconds_does_not_double_count_tui_boot(monkeypatch) -> None:
+    """Tier 2: #3671 follow-up — ``tui-boot`` (the wide bracket) and its own
+    ``tui-boot:construct``/``:compose``/``:hydrate``/``:other`` breakdown
+    measure the SAME interval. ``total_seconds`` (and therefore
+    ``unaccounted_seconds``, which subtracts it from wall time) must count
+    that interval once, not twice — falsification: summing both naively
+    would put ``total_seconds`` at roughly double the real span, clamping
+    ``unaccounted_seconds`` to 0 even when a genuine coverage gap exists
+    elsewhere in the startup."""
+    from reyn.runtime import startup_timing
+
+    monkeypatch.setattr(startup_timing, "_APP_CONSTRUCTED_AT", None)
+    monkeypatch.setattr(startup_timing, "_FIRST_FRAME_AT", None)
+    timing = StartupTiming()
+    monkeypatch.setattr(startup_timing, "TIMING", timing)
+
+    startup_timing.mark_app_constructed()
+    with stage("tui-boot:construct"):
+        pass
+    with stage("tui-boot:compose"):
+        pass
+    with stage("tui-boot:hydrate"):
+        pass
+    startup_timing.mark_first_frame()
+
+    wide = timing.elapsed("tui-boot")
+    assert wide > 0.0, "tui-boot must have actually recorded something to test against"
+    # total_seconds must be close to the wide span alone, not ~2x it.
+    assert timing.total_seconds < wide * 1.5
+
+
 def test_unaccounted_warning_line_appears_when_coverage_is_bad() -> None:
     """Tier 2: #3735 — the report self-flags a large `unaccounted` share
     instead of leaving it to blend in with the other rows. This is the "gate"

--- a/tests/runtime/test_startup_timing_3671.py
+++ b/tests/runtime/test_startup_timing_3671.py
@@ -341,10 +341,24 @@ def test_named_substages_plus_other_equal_the_wide_span(monkeypatch) -> None:
     """Tier 2: coverage invariant — #3671's original single `client-prep` lump
     (`mark_app_constructed` minus `mark_async_entered`) must still be fully
     explained after being broken into 4 named sub-stages + `client-prep:other`
-    (#3735 fix): their sum must equal the wide span, not merely be LESS than
-    or equal to it. Measured against the test's OWN wall clock (not the
-    module's private timestamps) so this is a public-surface witness, not an
-    assertion on internal state."""
+    (#3735 fix): summing them must account for every injected interval,
+    including the gaps NOT wrapped by any `with stage(...)` — the #3735
+    regression shape this module's whole `:other` pattern exists to prevent.
+
+    Lower-bound against the KNOWN injected sleep total, not an upper-bound
+    wall-clock tolerance (lead-coder review on #4363 — the same fix already
+    applied to `test_tui_boot_named_substages_plus_other_equal_the_wide_span`
+    above). `client-prep` has no independently RECORDED wide span the way
+    `tui-boot` does (`tui-boot`'s own wide bracket is recorded
+    unconditionally in `mark_first_frame`; `client-prep`'s never was), so
+    there is no public value to compare against for an exact equality the
+    same way. A monotonic `>=` against the known sleep total is immune to
+    scheduler jitter in either direction — the same shape as
+    `test_the_context_manager_records_elapsed_time` above — and still
+    catches the regression: a broken `:other` computation that drops the
+    unbracketed gaps reports LESS than the known total, not merely a
+    different one.
+    """
     import time
 
     from reyn.runtime import startup_timing
@@ -357,8 +371,8 @@ def test_named_substages_plus_other_equal_the_wide_span(monkeypatch) -> None:
         "client-prep:transport", "client-prep:read-model",
         "client-prep:tui-import", "client-prep:app-construct", "client-prep:other",
     )
+    injected_sleep_total = 0.06  # 6 x time.sleep(0.01) below, bracketed and not
 
-    wall_start = time.perf_counter()
     startup_timing.mark_async_entered()
     time.sleep(0.01)
     with stage("client-prep:transport"):
@@ -371,10 +385,9 @@ def test_named_substages_plus_other_equal_the_wide_span(monkeypatch) -> None:
     startup_timing.mark_tui_import_done()
     time.sleep(0.01)
     startup_timing.mark_app_constructed()
-    wall_end = time.perf_counter()
 
     named_sum = sum(startup_timing.TIMING.elapsed(name) for name in stages)
-    assert abs(named_sum - (wall_end - wall_start)) < 0.02
+    assert named_sum >= injected_sleep_total
 
 
 def test_tui_boot_named_substages_plus_other_equal_the_wide_span(monkeypatch) -> None:

--- a/tests/runtime/test_startup_timing_3671.py
+++ b/tests/runtime/test_startup_timing_3671.py
@@ -386,7 +386,16 @@ def test_tui_boot_named_substages_plus_other_equal_the_wide_span(monkeypatch) ->
     ``tui-boot:other`` must sum to the wide ``mark_app_constructed`` ->
     ``mark_first_frame`` span exactly, not merely be less than or equal to
     it — the #3735 regression shape this module's whole ``:other`` pattern
-    exists to prevent."""
+    exists to prevent.
+
+    Compared against the RECORDED ``tui-boot`` value, not the test's own
+    wall clock — ``mark_first_frame`` computes ``:other = max(0, wide -
+    named)`` from that exact same recorded ``wide``, so the two sides are
+    exactly equal by construction and need no time-based tolerance (lead-
+    coder review on #4363: a wall-clock tolerance is an environment-
+    dependent constant, which the owner's standing no-time-limit rule for
+    tests forbids; the falsification power is unchanged — a narrow-bracket-
+    only regression that drops a gap still fails this exactly)."""
     import time
 
     from reyn.runtime import startup_timing
@@ -398,7 +407,6 @@ def test_tui_boot_named_substages_plus_other_equal_the_wide_span(monkeypatch) ->
     monkeypatch.setattr(startup_timing, "TIMING", StartupTiming())
     stages = ("tui-boot:construct", "tui-boot:compose", "tui-boot:hydrate", "tui-boot:other")
 
-    wall_start = time.perf_counter()
     startup_timing.mark_app_constructed()
     with stage("tui-boot:construct"):
         time.sleep(0.01)
@@ -408,10 +416,9 @@ def test_tui_boot_named_substages_plus_other_equal_the_wide_span(monkeypatch) ->
     with stage("tui-boot:hydrate"):
         time.sleep(0.01)
     startup_timing.mark_first_frame()
-    wall_end = time.perf_counter()
 
     named_sum = sum(startup_timing.TIMING.elapsed(name) for name in stages)
-    assert abs(named_sum - (wall_end - wall_start)) < 0.02
+    assert named_sum == startup_timing.TIMING.elapsed("tui-boot")
 
 
 def test_total_seconds_does_not_double_count_tui_boot(monkeypatch) -> None:


### PR DESCRIPTION
**[tui-coder]** — part of #3671

## What

Breaks `tui-boot` into four named sub-stages, mirroring the same bracket-and-residual shape `client-prep:other` already established (the #3735 discipline: keep the wide bracket as ground truth, name what narrow sub-brackets do NOT explain as `:other` rather than letting it silently fall out of measurement).

Owner git-bash re-measurement: total startup 25.5s, of which `tui-boot` alone was 23.9s (94%) — previously a single opaque span with no internal breakdown.

- `tui-boot:construct` — `TextualChatApp.__init__`
- `tui-boot:compose` — `compose()`, which builds the entire widget tree
- `tui-boot:hydrate` — `on_mount()`'s `_hydrate_from_history()` call (#3273)
- `tui-boot:other` — residual = wide − sum(named), computed in `mark_first_frame()`

`tui-boot` itself is untouched as the wide ground-truth bracket — still recorded unconditionally, still printed as its own report line, so the number already being compared against the owner's macOS baseline does not move or disappear. The invariant this PR must hold: named sub-stages + `:other` always sum to exactly `tui-boot`, never spilling into the separate process-wide `unaccounted` bucket. Covered by `test_tui_boot_named_substages_plus_other_equal_the_wide_span`.

## Double-counting fix

Adding `tui-boot`'s own breakdown alongside the pre-existing unconditional `tui-boot` recording would make `StartupTiming.total_seconds` sum that one interval twice — inflating `total_seconds` past wall time and clamping `unaccounted_seconds` to 0 even when a genuine coverage gap exists elsewhere. Fixed by excluding `tui-boot` from `total_seconds`'s sum (kept as its own printed line, unlike `client-prep` which is never separately recorded). Falsify-verified: reverted the exclusion, confirmed `test_total_seconds_does_not_double_count_tui_boot` failed with the predicted ~2x inflation, restored.

## Doc-accuracy fix (same PR, per CLAUDE.md's doc-drift rule)

`mark_app_constructed()`'s docstring called the span "the framework's own startup — terminal setup, first layout, first paint" — inaccurate, since the span also runs reyn's own `TextualChatApp.__init__`, `compose()` (builds the entire widget tree), and `on_mount()` (theme setup + `_hydrate_from_history()`). The construction site's comment in `app.py` made the same claim. Both rewritten to name what's actually inside the bracket — this PR's own breakdown is what makes the inaccuracy fixable.

## Scope

Instrumentation only. No behavior change.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_startup_timing_3671.py` — 27/27 OK, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py` on both changed `src/` files — OK
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] Falsify-verified the double-counting fix (reverted → confirmed predicted failure shape → restored → confirmed green)
- [x] `pytest tests/interfaces tests/runtime tests/core/test_3846_3_textual_image_eager_import_ordering.py tests/repo/test_stream_client_single_writer_boundary.py` — 3307 passed, 4 skipped, 1 failed (`test_textual_image_renderable_is_imported_before_app_run_async`, pre-existing on `main`, unrelated to this change — textual_image import-ordering)
- [ ] Visual (waived per owner's standing waiver, 2026-08-08 — merge proceeds, owner confirms after on `main`)

Held for lead-coder's TESTS-READY / explicit merge approval, not self-merging. Owner intends to re-measure on the git-bash machine once this lands.



---

## Reviewer's blocking item (lead-coder)

- [x] 🔴 **`test_tui_boot_named_substages_plus_other_equal_the_wide_span` の許容幅 `< 0.02` を外す。** 環境依存の定数で、owner の恒久指示「テストは時間の上限を持たない」に触れます。★不要でもあります — 比較対象をテストの壁時計から**記録された `tui-boot`** に変えれば `named + other == wide` は厳密に成立し（`:other = max(0, wide - named)`）、falsification の力は変わりません。詳細はレビューコメントに。
  → Fixed in `4150590df` — assertion now compares `named_sum == startup_timing.TIMING.elapsed("tui-boot")` (exact, no tolerance). Falsify-verified: the gap-drop regression this test targets still fails the exact-equality check the same way it failed the old tolerance check.
- [x] 🔴 **Same shape in the pre-existing sibling test** — `test_named_substages_plus_other_equal_the_wide_span` (client-prep side) still had `abs(named_sum - (wall_end - wall_start)) < 0.02`. Fixing only the new mechanism and leaving the old one is the #3905 shape (lead-coder review, follow-up).
  → Fixed in `a56e7bc53`. `client-prep` has no independently recorded wide span the way `tui-boot` does, and using the private `_ASYNC_ENTERED_AT`/`_APP_CONSTRUCTED_AT` timestamps would contradict this test's own stated design intent ("a public-surface witness, not an assertion on internal state") — so the tolerance was replaced with a monotonic `>=` against the known injected `time.sleep()` total instead, the same non-flaky pattern `test_the_context_manager_records_elapsed_time` already uses in this file. Falsify-verified: simulating the #3735 gap-drop regression (sum without `:other`) measures ~0.048s against a 0.06s floor and correctly fails; the real sum measures ~0.071s and passes.


