### PR TITLE
feat(4362): route bare warnings.warn output to reyn.log, not stderr

### DIFF
--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -338,6 +338,21 @@ def _setup_interactive_logging(project_root: Path) -> None:
     the FIRST real litellm use — see ``reyn.llm.litellm_bootstrap.
     ensure_litellm_ready`` — which reads the file handler this function
     installs (so the routing still works whenever litellm is first touched).
+
+    #4362: also captures ``warnings.warn`` output via
+    ``logging.captureWarnings(True)`` — this docstring's own opening line
+    already declared "route library warnings ... so they don't corrupt the
+    live region", but the mechanism below only ever routed *logging*
+    records; a bare ``warnings.warn`` (the stdlib's own mechanism for
+    library warnings, e.g. an unclosed-client ``ResourceWarning``) still
+    went straight to stderr and corrupted the live region exactly as
+    described. This closes that declared-vs-implemented gap — it does not
+    change WHERE any warning's root cause lives (#4365 tracks a real
+    litellm client-cleanup gap this does NOT fix, only reroutes the
+    resulting warning's ink). Scoped to the same ``is_interactive`` guard
+    as the rest of this function — both of this module's two call sites
+    are gated by it, so an embedder or non-interactive run never has its
+    own warnings redirected.
     """
     log_dir = project_root / ".reyn" / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
@@ -347,6 +362,7 @@ def _setup_interactive_logging(project_root: Path) -> None:
         format="%(asctime)s %(name)s %(levelname)s %(message)s",
         force=True,  # safe: the interactive path has no prior logging setup
     )
+    logging.captureWarnings(True)
 
 
 def _run_remote(

--- a/tests/interfaces/test_inline_interactive_logging.py
+++ b/tests/interfaces/test_inline_interactive_logging.py
@@ -15,6 +15,7 @@ real-litellm-use chokepoint).
 from __future__ import annotations
 
 import logging
+import warnings
 
 from reyn.interfaces.cli.commands.chat import _setup_interactive_logging
 
@@ -34,5 +35,62 @@ def test_interactive_logging_redirects_root_logger_to_file(tmp_path) -> None:
             h.flush()
         assert "canary-marker-7f3a" in log_file.read_text()
     finally:
+        # #4362: _setup_interactive_logging now also calls
+        # logging.captureWarnings(True), whose own on/off guard
+        # (logging._warnings_showwarning) is a THIRD piece of process-global
+        # state alongside root's handlers/level — left uncleared here, an
+        # earlier-run test's leftover guard silently no-ops the NEXT test's
+        # own captureWarnings(True) call (found via
+        # test_interactive_logging_routes_warnings_warn_to_the_file_not_stderr
+        # failing only when run after this test, never in isolation).
+        logging.captureWarnings(False)
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)
+
+
+def test_interactive_logging_routes_warnings_warn_to_the_file_not_stderr(
+    tmp_path, capsys,
+) -> None:
+    """Tier 2: #4362 — a bare `warnings.warn(...)` (the stdlib's own library-
+    warning mechanism, not a logging call) also lands in .reyn/logs/reyn.log
+    instead of stderr.
+
+    This docstring's function-under-test already declared "route library
+    warnings ... so they don't corrupt the live region" before #4362 —
+    `logging.basicConfig` alone only ever redirected *logging* records, so a
+    bare `warnings.warn` (e.g. the ResourceWarning an unclosed async client
+    emits) still reached stderr uncaught. `logging.captureWarnings(True)`
+    closes that gap.
+
+    Both sides checked, not just "not on stderr" (test-review Q3: a capsys
+    check alone stays green even if captureWarnings is silently dropped,
+    because nothing here would force the warning to fire AND land somewhere
+    observable) — the warning is actually fired via bare `warnings.warn`,
+    then BOTH absence from stderr AND presence in the log file are asserted.
+    `warnings.simplefilter("always")` forces the fire regardless of Python's
+    default once-per-location dedup, so an earlier test in the same process
+    already having triggered this exact warning can't make it silently not
+    fire here.
+    """
+    root = logging.getLogger()
+    saved_handlers, saved_level = root.handlers[:], root.level
+    try:
+        _setup_interactive_logging(tmp_path)
+        log_file = tmp_path / ".reyn" / "logs" / "reyn.log"
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            warnings.warn(
+                "resource-warning-marker-9c1e", category=ResourceWarning, stacklevel=1,
+            )
+
+        for h in root.handlers:
+            h.flush()
+
+        captured = capsys.readouterr()
+        assert "resource-warning-marker-9c1e" not in captured.err
+        assert "resource-warning-marker-9c1e" in log_file.read_text()
+    finally:
+        logging.captureWarnings(False)
         root.handlers[:] = saved_handlers
         root.setLevel(saved_level)

--- a/tests/llm/test_litellm_lazy_load.py
+++ b/tests/llm/test_litellm_lazy_load.py
@@ -141,6 +141,11 @@ def test_first_use_quiets_litellm_banners(tmp_path) -> None:
         ensure_litellm_ready()  # first real use
         assert litellm.suppress_debug_info is True
     finally:
+        # #4362: _setup_interactive_logging also calls
+        # logging.captureWarnings(True) now; its own on/off guard
+        # (logging._warnings_showwarning) is process-global, same class of
+        # leak as root's handlers/level below.
+        logging.captureWarnings(False)
         root.handlers[:] = saved_handlers
         root.setLevel(saved_level)
         litellm.suppress_debug_info = saved_suppress
@@ -201,6 +206,9 @@ def test_first_use_routes_litellm_logger_to_file_not_console(tmp_path) -> None:
             h.flush()
         assert "runtime-marker-9a1b-not-a-mock" in log_file.read_text()
     finally:
+        # #4362: same process-global captureWarnings guard leak as
+        # test_first_use_quiets_litellm_banners above.
+        logging.captureWarnings(False)
         root.handlers[:] = saved_root_handlers
         root.setLevel(saved_root_level)
         litellm_logger.handlers[:] = saved_litellm_handlers


### PR DESCRIPTION
**[tui-coder]** — part of #4362

## What

`_setup_interactive_logging`'s own docstring already declared: "the inline CUI owns the terminal; route library warnings / tracebacks to a log file so they don't corrupt the live region." The mechanism only ever routed *logging* records (`basicConfig`). A bare `warnings.warn(...)` — the stdlib's own separate library-warning channel, e.g. an unclosed-client `ResourceWarning` — still went straight to stderr and corrupted the live region exactly as the docstring said it shouldn't. This closes that declared-vs-implemented gap.

Adds `logging.captureWarnings(True)` right after the existing `basicConfig(force=True)` call, inside the same `is_interactive` guard already covering the rest of the function.

## Why this is the right layer (architect's #4362 investigation)

The `ResourceWarning` this masks comes from a litellm-cached `AsyncOpenAI` client that isn't covered by any of litellm's own 3 cleanup branches (`close_litellm_async_clients()`) — confirmed the same shape reproduces with reyn entirely out of the loop (a bare `litellm.acompletion(...)` call, no reyn involvement). Adding a reyn-side branch for `AsyncOpenAI` specifically would create an open-ended obligation to track every client type litellm's own cache grows to hold — the wrong layer for reyn to own (same shape, reversed direction, as #4348/#4355's api_key/pricing decisions). **#4365 tracks the actual litellm-side gap.** This PR only governs reyn's own output surface — the one thing within reyn's own remit regardless of how many third parties leak into it.

## Acceptance conditions (lead-coder, #4362 issue thread)

1. **Demonstrated via execution that the warning MOVED, not disappeared** — both stderr-silence AND `reyn.log`-presence, not just one:
   - Real out-of-process script, `warnings.warn(ResourceWarning, "live-demo-marker-4362")` after calling `_setup_interactive_logging`:
     - stderr: empty
     - `.reyn/logs/reyn.log`: `2026-08-12 12:46:20,652 py.warnings WARNING <stdin>:10: ResourceWarning: live-demo-marker-4362`
   - Same two-sided check as a new test, `test_interactive_logging_routes_warnings_warn_to_the_file_not_stderr` (fires a real `warnings.warn`, not a mock; per test-review Q3, a stderr-silence check alone would stay green even if `captureWarnings` were silently dropped).
2. **Confirmed the `is_interactive`-only premise still holds before adding this** — grepped every `_setup_interactive_logging` call site repo-wide: exactly 2, both in `chat.py`, both gated by `is_interactive`. An embedder or non-interactive run never has its own warnings redirected.
3. **#4365 tracks the actual gap** — see "Why this is the right layer" above. This PR reroutes the symptom's ink; it does not fix the underlying litellm cleanup gap.
4. **Does not touch `AsyncOpenAI._client._transport.client.closed`** or any other private third-party attribute — this PR only routes reyn's own output, it does not judge a client's liveness.

## Incidental fix: cross-test global-state leak this change exposed

Two existing in-process tests calling `_setup_interactive_logging` (`test_first_use_quiets_litellm_banners`, `test_first_use_routes_litellm_logger_to_file_not_console`) restored root logger handlers/level in `finally` but never called `logging.captureWarnings(False)`. Since that guard (`logging._warnings_showwarning`) is a process-global one-shot, running a test after either of those silently no-ops the NEXT test's own `captureWarnings(True)` call. Found by the new test failing only when run after `test_interactive_logging_redirects_root_logger_to_file` in the same file, never in isolation (falsify-verified: reverted the production line, confirmed the new test fails with the exact predicted "stderr silent, log empty" shape, restored). All three now restore it.

## Scope

Instrumentation/output-routing only. Does not touch client lifecycle or litellm cleanup logic.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_inline_interactive_logging.py tests/llm/test_litellm_lazy_load.py` — 12/12 OK, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/cli/commands/chat.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] Falsify-verified the new test (reverted `captureWarnings(True)` → confirmed predicted failure shape → restored → confirmed green)
- [x] Live out-of-process execution demonstrating both stderr-silence and `reyn.log`-presence (see above)
- [x] `pytest tests/interfaces tests/llm` — 2353 passed, 3 skipped (2 pre-existing optional-`voice`-extra skips, 1 unrelated), 0 failed
- [ ] Visual (waived per owner's standing waiver, 2026-08-08 — merge proceeds, owner confirms after on `main`)

Held for lead-coder's TESTS-READY / explicit merge approval, not self-merging.
