### PR TITLE
feat(4349): reyn config migrate reports removed catalog shorthand values

### DIFF
--- a/src/reyn/config/legacy_model_catalog_4349.py
+++ b/src/reyn/config/legacy_model_catalog_4349.py
@@ -1,0 +1,71 @@
+"""Frozen snapshot of the built-in model catalog #4349 removes (`reyn config
+migrate` only — never imported by the runtime resolution path).
+
+#4349 deletes ``reyn.llm.builtin_models.BUILTIN_MODELS`` and the "resolve a
+bare class name against a built-in catalog" behavior it powered — an
+operator's ``reyn.yaml`` referencing a catalog shorthand by name (e.g.
+``models: {standard: claude-sonnet-thinking}``, or ``extends:
+claude-sonnet``) resolves successfully today and would silently fail (or
+resolve to nothing) once the catalog is gone.
+
+Per architect ruling on #4349 (relayed via lead-coder): the migration path is
+a hard requirement of the removal, not an optional follow-up, and the
+correspondence table it depends on may ONLY live here — ``reyn config
+migrate`` is the one caller allowed to know what these old shorthand names
+used to mean. It is a DEAD, ONE-TIME snapshot of ``BUILTIN_MODELS`` as it
+stood immediately before #4349 deleted it — not re-exported, not read by any
+resolution code path, and not kept in sync with anything going forward (the
+whole point of the removal is that reyn stops tracking a third-party
+catalog). A future model naming change on any provider's side does NOT
+update this file; it exists only so `reyn config migrate` can tell an
+operator what their OLD shorthand used to mean.
+
+Tier aliases (``light``/``standard``/``strong``) are deliberately EXCLUDED —
+those were never something an operator wrote as a `models:` VALUE (writing
+``standard: standard`` would be circular); they were the zero-config
+fallback `models:` block's own KEYS, which `reyn.yaml`'s project template
+already declares literally. Only the named catalog entries an operator could
+plausibly have referenced by shorthand — as a `models:` tier's value or an
+`extends:` target — are captured here.
+"""
+from __future__ import annotations
+
+#: old catalog key -> the structured value an operator's `models:` tier (or
+#: `extends:` target) should become. Frozen at #4349; see module docstring.
+LEGACY_MODEL_CATALOG: "dict[str, dict]" = {
+    "claude-sonnet": {
+        "model": "anthropic/claude-3-7-sonnet",
+        "max_completion_tokens": 8192,
+    },
+    "claude-sonnet-thinking": {
+        "model": "anthropic/claude-3-7-sonnet",
+        "max_completion_tokens": 16000,
+        "extra_body": {
+            "thinking": {"type": "enabled", "budget_tokens": 8000},
+        },
+    },
+    "claude-haiku": {
+        "model": "anthropic/claude-3-5-haiku",
+        "max_completion_tokens": 4096,
+    },
+    "gpt-4o-mini": {"model": "openai/gpt-4o-mini"},
+    "gpt-4o": {"model": "openai/gpt-4o"},
+    "gemini-flash-lite": {
+        "model": "gemini/gemini-2.5-flash-lite",
+        "reasoning_effort": "low",
+    },
+    "gemini-pro": {
+        "model": "gemini/gemini-2.5-pro",
+        "reasoning_effort": "medium",
+    },
+    "gemini-3.1-flash-preview": {
+        "model": "gemini/gemini-3.1-flash-preview",
+        "reasoning_effort": "low",
+    },
+    "gemini-2.0-flash": {
+        "model": "gemini/gemini-2.0-flash",
+        "extra_body": {
+            "thinking_config": {"thinking_budget": 0},
+        },
+    },
+}

--- a/src/reyn/interfaces/cli/commands/config.py
+++ b/src/reyn/interfaces/cli/commands/config.py
@@ -399,23 +399,42 @@ def _migrate(*, dry_run: bool = False) -> None:
     distinction as a TYPE field, not a syntactic proxy like "does the hint
     string contain a space", so a future T1-T6 entry can't accidentally
     become auto-rewritten by writing a space-free note that was never
-    meant as a destination). ``_RENAMED_CONFIG_KEYS`` is empty today
-    (T1-T6 populate it incrementally); ``_RENAMED_SANDBOX_POLICY_KEYS`` is
+    meant as a destination). ``_RENAMED_SANDBOX_POLICY_KEYS`` is
     intentionally NOT auto-rewritten by this command — an operator on an
     old sandbox.policy key sees the guidance via ``reyn config validate``
     and fixes it by hand.
+
+    #4349 follow-up: ALSO reports (never auto-rewrites) ``models:`` /
+    ``llm.models:`` tier values, and ``extends:`` targets, that reference a
+    now-deleted built-in catalog shorthand (see
+    ``legacy_model_catalog_4349.LEGACY_MODEL_CATALOG``, a frozen one-time
+    snapshot — see its own module docstring for why it may not be re-derived
+    from anything live). Report-only rather than auto-rewrite, same
+    reasoning as the ``needs_manual`` renames above: turning a scalar
+    (``standard: claude-sonnet-thinking``) into a multi-key block value
+    is a shape of edit ``migrate_text.rewrite_text`` was deliberately never
+    built to attempt (its own docstring's scope is same-depth or one-level
+    renames of a KEY, never a VALUE's own type changing from scalar to
+    block) — guessing at an operator's indentation/comment style for a
+    brand-new nested block risks writing something subtly wrong to a file
+    ``reyn config migrate`` has no way to ask the operator to double-check
+    before it's already been written. This check runs independently of
+    ``_RENAMED_CONFIG_KEYS`` being non-empty — the two migrations are
+    unrelated and one being empty must not silently suppress the other.
     """
     import yaml
 
     from reyn.config import _find_project_root
     from reyn.config.config_schema import _RENAMED_CONFIG_KEYS
+    from reyn.config.legacy_model_catalog_4349 import LEGACY_MODEL_CATALOG
 
     if not _RENAMED_CONFIG_KEYS:
         print(
             "No config key renames are registered yet (nothing to migrate "
-            "— #4174 T1-T6 populate this registry incrementally)."
+            "on that front — #4174 T1-T6 populate this registry "
+            "incrementally). Checking for legacy catalog shorthand values "
+            "separately below."
         )
-        return
 
     # Only entries with a non-None `destination` (a plain rename, no value
     # transform) are safe to auto-rewrite — see the docstring above.
@@ -456,6 +475,32 @@ def _migrate(*, dry_run: bool = False) -> None:
             return str(path.relative_to(project_root)) if project_root else str(path)
         except ValueError:
             return str(path)
+
+    # #4349: report (never auto-rewrite — see docstring above) `models:` /
+    # `llm.models:` tier values and `extends:` targets that reference a
+    # deleted catalog shorthand. Scans whichever location currently holds
+    # the mapping — a project may not have run the (separate, auto-rewritten)
+    # `models:` -> `llm.models:` key-rename yet, so both are checked.
+    catalog_findings: "list[tuple[str, str, str, dict]]" = []  # (label, tier_key, old_name, suggestion)
+    for path in candidates:
+        cfg = _read(path)
+        if not cfg:
+            continue
+        models_block = cfg.get("models")
+        if not isinstance(models_block, dict):
+            llm_block = cfg.get("llm")
+            models_block = llm_block.get("models") if isinstance(llm_block, dict) else None
+        if not isinstance(models_block, dict):
+            continue
+        for tier_key, value in models_block.items():
+            if isinstance(value, str) and "/" not in value and value in LEGACY_MODEL_CATALOG:
+                catalog_findings.append((_label(path), tier_key, value, LEGACY_MODEL_CATALOG[value]))
+            elif isinstance(value, dict):
+                extends_target = value.get("extends")
+                if isinstance(extends_target, str) and extends_target in LEGACY_MODEL_CATALOG:
+                    catalog_findings.append(
+                        (_label(path), tier_key, extends_target, LEGACY_MODEL_CATALOG[extends_target])
+                    )
 
     from reyn.config.migrate_check import verify_rewrite
     from reyn.config.migrate_text import rewrite_text
@@ -531,8 +576,24 @@ def _migrate(*, dry_run: bool = False) -> None:
             )
             print(f"  {label}: {old_key} — {note}")
 
-    if not any_changes and not manual_found:
-        print("No renamed keys found in your config — nothing to migrate.")
+    if catalog_findings:
+        print(
+            "\nThe following model reference(s) use a removed built-in "
+            "catalog shorthand (#4349) and need manual review — replace "
+            "the shorthand with the literal value shown, e.g.\n"
+            "  models:\n"
+            "    <tier>: <the 'model' line below, plus any other lines shown>\n"
+        )
+        for label, tier_key, old_name, suggestion in catalog_findings:
+            suggestion_yaml = yaml.dump(
+                suggestion, allow_unicode=True, default_flow_style=False, sort_keys=False,
+            )
+            indented = "\n".join(f"      {line}" for line in suggestion_yaml.splitlines())
+            print(f"  {label}: models.{tier_key} references '{old_name}' — replace with:")
+            print(indented)
+
+    if not any_changes and not manual_found and not catalog_findings:
+        print("No renamed keys or legacy catalog shorthand values found — nothing to migrate.")
         return
     if any_changes:
         if dry_run:

--- a/tests/interfaces/test_config_validate_migrate_command_4174.py
+++ b/tests/interfaces/test_config_validate_migrate_command_4174.py
@@ -514,6 +514,104 @@ def test_migrate_value_identity_survives_a_multi_key_rewrite(project, monkeypatc
     assert after_flat["unrelated_key"] == [1, 2, 3]
 
 
+# ── #4349: legacy built-in-catalog shorthand values ──────────────────────
+#
+# `reyn config migrate` also detects (report-only — never auto-rewrite, see
+# `_migrate`'s docstring) `models:` / `llm.models:` tier values (and
+# `extends:` targets) that reference a shorthand name from the now-deleted
+# built-in catalog (`legacy_model_catalog_4349.LEGACY_MODEL_CATALOG`).
+
+
+def test_migrate_flags_a_legacy_catalog_shorthand_model_value(
+    project, capsys,
+) -> None:
+    """Tier 2: #4349 — a `models:` tier whose value is a bare catalog
+    shorthand (no `/`, matches `LEGACY_MODEL_CATALOG`) is reported with the
+    literal replacement value, not silently left alone or auto-rewritten."""
+    from reyn.interfaces.cli.commands.config import _migrate
+
+    _write_yaml(
+        project / "reyn.yaml",
+        "llm:\n  model: standard\n  models:\n    standard: claude-sonnet-thinking\n",
+    )
+    _migrate()
+
+    import yaml
+    cfg = yaml.safe_load((project / "reyn.yaml").read_text())
+    # Report-only: the file is untouched.
+    assert cfg["llm"]["models"]["standard"] == "claude-sonnet-thinking"
+
+    out = capsys.readouterr().out
+    assert "models.standard" in out
+    assert "claude-sonnet-thinking" in out
+    assert "anthropic/claude-3-7-sonnet" in out
+
+
+def test_migrate_flags_a_legacy_catalog_shorthand_extends_target(
+    project, capsys,
+) -> None:
+    """Tier 2: #4349 — an `extends:` target referencing a deleted catalog
+    shorthand is ALSO flagged, not just a bare scalar tier value."""
+    from reyn.interfaces.cli.commands.config import _migrate
+
+    _write_yaml(
+        project / "reyn.yaml",
+        (
+            "llm:\n"
+            "  model: standard\n"
+            "  models:\n"
+            "    standard:\n"
+            "      extends: gemini-pro\n"
+            "      max_completion_tokens: 999\n"
+        ),
+    )
+    _migrate()
+
+    out = capsys.readouterr().out
+    assert "models.standard" in out
+    assert "gemini-pro" in out
+    assert "gemini/gemini-2.5-pro" in out
+
+
+def test_migrate_does_not_flag_an_already_literal_model_string(
+    project, capsys,
+) -> None:
+    """Tier 2: #4349 accept-side — a `models:` tier value that is already a
+    real `provider/model` literal (contains `/`) is not a catalog
+    shorthand and must not be flagged."""
+    from reyn.interfaces.cli.commands.config import _migrate
+
+    _write_yaml(
+        project / "reyn.yaml",
+        "llm:\n  model: standard\n  models:\n    standard: openai/gpt-4o\n",
+    )
+    _migrate()
+
+    out = capsys.readouterr().out
+    assert "openai/gpt-4o" not in out
+    assert "models.standard references" not in out
+
+
+def test_migrate_catalog_check_runs_even_with_an_empty_rename_registry(
+    project, capsys, monkeypatch,
+) -> None:
+    """Tier 2: #4349 — the catalog-shorthand check is independent of
+    `_RENAMED_CONFIG_KEYS`; an empty rename registry must not silently
+    suppress it (the two migrations are unrelated concerns)."""
+    from reyn.interfaces.cli.commands.config import _migrate
+
+    monkeypatch.setattr("reyn.config.config_schema._RENAMED_CONFIG_KEYS", {})
+    _write_yaml(
+        project / "reyn.yaml",
+        "llm:\n  model: standard\n  models:\n    standard: claude-haiku\n",
+    )
+    _migrate()
+
+    out = capsys.readouterr().out
+    assert "claude-haiku" in out
+    assert "anthropic/claude-3-5-haiku" in out
+
+
 def test_migrate_does_not_leave_a_doubled_blank_line_between_merged_chunks(
     project, monkeypatch,
 ) -> None:


### PR DESCRIPTION
**[tui-coder]** — part of #4349

## What

Architect ruling on #4349 (relayed via lead-coder, broker): the migration path for operators referencing the built-in model catalog by shorthand name (e.g. `models: {standard: claude-sonnet-thinking}`, or `extends: claude-sonnet`) is a hard requirement of the catalog's removal, not an optional follow-up. The correspondence table it depends on may only live inside `reyn config migrate` — never re-exposed via the runtime resolution path #4349 (PR #4358) deletes.

- Adds `legacy_model_catalog_4349.py`: a frozen, one-time snapshot of the built-in catalog as it stood immediately before #4349 deletes it. Not imported by any resolution code path, not kept in sync with anything going forward — see the module's own docstring for why.
- Extends `reyn config migrate` to scan `models:` / `llm.models:` tier values (and `extends:` targets) for a shorthand name matching that frozen table, reporting the exact literal replacement. **Report-only, never auto-rewritten.**

## Why report-only, not auto-rewrite

`migrate_text.rewrite_text` (the existing comment-preserving rewriter) was deliberately scoped to same-depth/one-level KEY renames only — never a VALUE's own type changing from scalar to a multi-key block. Guessing at an operator's indentation/comment style for a brand-new nested block risks writing something subtly wrong to their file with no way to ask them to double-check before it's already written. This mirrors the existing `needs_manual` reporting path `_RENAMED_CONFIG_KEYS` entries with `destination=None` already use, for the same reason.

## Independence from the rename registry

The catalog check runs regardless of whether `_RENAMED_CONFIG_KEYS` is populated — the two migrations are unrelated concerns. The original `_migrate()` had an early `return` that fired before any catalog check could run at all when the registry was empty; restructured so an empty rename registry can't silently suppress the (unrelated) catalog check.

## Conditions from lead-coder's dispatch — all satisfied

- 🔴 **Does not touch any operator's real external config** — every test uses a synthetic `tmp_path` fixture.
- 🔴 **The correspondence table lives only in `legacy_model_catalog_4349.py`** — never re-exposed through the runtime resolution path (the whole point of the removal).
- 🔴 **Does not reference `docs/reference/builtin-models.md`** — that doc is deleted in the same arc as the catalog itself; referencing it as a migration-time pointer would already be broken by the time an operator tries to follow it.

## Scope / hold

**PR opened, merge held** — same treatment as #4358, per lead-coder's explicit instruction. The remaining open question is the owner's release-ordering decision (does `migrate`'s catalog-shorthand support need to land before/with #4358's catalog removal — very likely yes, since an operator can't migrate shorthand they can no longer resolve either way once the catalog is gone). Not self-merging.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_config_validate_migrate_command_4174.py` — 22/22 OK, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/cli/commands/config.py src/reyn/config/legacy_model_catalog_4349.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] Falsify-verified the new detection (broke the catalog-membership check → confirmed predicted "nothing flagged" shape → restored → confirmed green)
- [x] `pytest tests/interfaces tests/config` — 1787 passed, 3 skipped (2 pre-existing optional-`voice`-extra skips, 1 unrelated), 0 failed
- [ ] Visual (waived per owner's standing waiver, 2026-08-08 — merge proceeds, owner confirms after on `main`)

Held for lead-coder's TESTS-READY / explicit merge approval, not self-merging.



---

## Reviewer's blocking item (lead-coder)

- [ ] 🔴 **出力に `reasoning_effort` が含まれることを assert するテストを 1 本足す。** 現在のテスト 2 本は**モデル文字列だけ**を pin しており（`anthropic/claude-3-7-sonnet` / `gemini/gemini-2.5-pro`）、**operator が実際に失うもの（`reasoning_effort`）は出力側で一度も assert されていません**。∴ 報告が「モデル文字列だけ」に退化してもテストは緑のまま ＝ **この弧の出発点となった事故がそのまま戻ります**。`gemini-pro` を使う test 2 が最短（カタログは `reasoning_effort: medium` を持っています）。詳細はレビューコメントに。
