### PR TITLE
docs: fix reyn.local.yaml.example drift (stale path, 5 retired keys)

### DIFF
--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -4,12 +4,12 @@
 # Copy this file to ``reyn.local.yaml`` (which is gitignored) and uncomment the
 # blocks you want to set. Any field omitted falls back to (a) ``reyn.yaml`` if
 # the project sets it, (b) ``~/.reyn/config.yaml`` for user-global defaults,
-# (c) the built-in defaults declared in ``src/reyn/config.py``.
+# (c) the built-in defaults declared in ``src/reyn/config/root.py``.
 #
 #   cp reyn.local.yaml.example reyn.local.yaml
 #
 # Sections are ordered to mirror ``ReynConfig`` field order so a future
-# version-sync diff against ``src/reyn/config.py`` is straightforward.
+# version-sync diff against ``src/reyn/config/root.py`` is straightforward.
 #
 # API keys are NEVER stored in YAML. Set them as environment variables — the
 # variable name is determined by the LiteLLM provider prefix in ``models:``:
@@ -54,13 +54,6 @@
 # Examples: "ja", "en"
 # -----------------------------------------------------------------------------
 # output_language: ja
-
-
-# -----------------------------------------------------------------------------
-# shell_allowed: whether ``shell`` op is unblocked without per-call permission.
-# Default false — operator approves each shell call interactively.
-# -----------------------------------------------------------------------------
-# shell_allowed: false
 
 
 # -----------------------------------------------------------------------------
@@ -358,20 +351,6 @@
 
 
 # -----------------------------------------------------------------------------
-# skill_search: BM25 skill pre-filter.
-# When the catalog has more than ``threshold`` skills, the router narrows
-# ``invoke_skill.name`` enum to the top-``top_k`` BM25 keyword matches before
-# building the tools list. Defaults: threshold 20 / top_k 5 / backend "bm25".
-# (``embedding`` / ``hybrid`` backends reserved for Components C/D.)
-# -----------------------------------------------------------------------------
-# skill_search:
-#   threshold: 20
-#   top_k: 5
-#   backend: bm25
-
-
-
-# -----------------------------------------------------------------------------
 # agent_id: runtime identity used in audit events and the
 # ``X-Reyn-Agent-Id`` outbound HTTP header.
 # Default: ``reyn/<hostname>``. Set explicitly for multi-agent fleets.
@@ -647,27 +626,6 @@
 
 
 # -----------------------------------------------------------------------------
-# time_travel: cost knobs for the time-travel (rewind/resume) feature (#1582).
-#
-# workspace_capture (default true): when true, every checkpoint boundary (turn /
-# plan-step) captures the workspace into a shadow-git generation so a rewind can
-# restore the repo files too. This is time-travel's LARGEST constant cost (a
-# ``git add -A`` + commit per boundary; in container mode a ``docker exec`` per
-# boundary). Set to false for "runtime-only rewind": rewind/checkout restore the
-# agent + conversation state but NOT repo files — a documented escape for large
-# workspaces / container runs / no-file-rewind use. Run-level (read at startup).
-# -----------------------------------------------------------------------------
-# time_travel:
-#   workspace_capture: true
-#   # act_turn_capture (default false): opt-in per-step capture. When true, each
-#   # skill-run op (step_completed) also snapshots the workspace (a cheap
-#   # write-tree) so a rewind can land mid-skill-run, not just at turn/plan-step
-#   # boundaries. High-frequency (per op) → opt-in. No-op when workspace_capture
-#   # is false.
-#   act_turn_capture: false
-
-
-# -----------------------------------------------------------------------------
 # tool_use: the chat-layer tool-use scheme x transport selector (#1593;
 # FP-0066 P4b, #3247). ``scheme`` is the PRESENTATION axis (category /
 # enumerate-all / retrieval — how capabilities are shown/discovered);
@@ -918,28 +876,6 @@
 
 
 # -----------------------------------------------------------------------------
-# eval: trace export adapters. Empty list (default) =
-# no export. Supported types:
-#   - file        : local JSONL dumps under ``path``
-#   - langfuse    : push to a Langfuse instance (public_key / secret_key / host)
-#   - otlp        : push to an OTLP collector (endpoint)
-#   - ietf_audit  : IETF-shaped audit trail under ``path``
-# -----------------------------------------------------------------------------
-# eval:
-#   exporters:
-#     - type: file
-#       path: .reyn/traces/
-#     - type: langfuse
-#       public_key: ${LANGFUSE_PUBLIC_KEY}
-#       secret_key: ${LANGFUSE_SECRET_KEY}
-#       host: https://your-langfuse.example.com
-#     - type: otlp
-#       endpoint: http://localhost:4317
-#     - type: ietf_audit
-#       path: .reyn/audit-trail/
-
-
-# -----------------------------------------------------------------------------
 # sandbox: which enforcement backend to use + what to do when the
 # requested backend isn't available on the host platform, plus the
 # operator-level sandbox policy applied to sandboxed ops.
@@ -1057,20 +993,6 @@
 #       - { kind: mcp:approval-server:approved }
 #     policy: { capacity: 10, overflow: reject, ttl: 5m }
 #     emit: { kind: composed:deploy_approved }
-
-
-# -----------------------------------------------------------------------------
-# self_improvement: skill_improver behavior knobs.
-#
-#   on_propose:   ask_user (default; pause + prompt before applying)
-#                 auto      (skip prompt; for CI / unattended)
-#                 disabled  (do not apply; log dry-run event)
-#   max_versions: cap on ``.reyn/skill-versions/<name>/v<N>.md`` snapshots
-#                 (default 10; oldest deleted when exceeded; 0 = disable pruning)
-# -----------------------------------------------------------------------------
-# self_improvement:
-#   on_propose: ask_user
-#   max_versions: 10
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
**[docs-maintainer]** — `reyn.local.yaml.example` inspection, dispatched by lead-coder (their own call, no owner ruling needed).

## ① Confirmed drift (as flagged) — fixed

Header's 2 references to `src/reyn/config.py` → `src/reyn/config/root.py` (`ReynConfig` lives there; `config.py` as a file doesn't exist — `config/` is a package).

## ② Classification of the 7 unmatched names — independently measured, not reused from lead-coder's own extraction

Lead-coder's column-0 `# key:` extraction found 7 names absent from `ReynConfig`'s field list. Traced each individually (source read + git history), not just re-run the same grep:

**5 genuinely retired** (zero hits anywhere in `src/` for the key name or its documented sub-fields) — all 5 blocks deleted:
- `shell_allowed` — superseded by `permissions: {exec: allow|deny}` (#3226 Phase 3).
- `eval` — eval-export subsystem removed outright (#2513, owner GO).
- `self_improvement` / `skill_search` — removed together (#2439/#2444). `docs/feature-map.md` was already purged of both in #2484 — this example file was the *one place* the drift survived.
- `time_travel` — no trace of the key or its sub-fields (`workspace_capture`/`act_turn_capture`) anywhere in `src/`. The rewind FEATURE is alive and documented (`docs/concepts/runtime/time-travel.md`, `/rewind`); only this specific cost-knob surface was never wired — consistent with ADR-0038's explicit decision not to wire the adjacent retention-config surface (#3987/#4336 removed the unwired `RetentionPolicy.from_config`).

**2 false positives, not retired settings at all** — no action needed, but worth naming since they're exactly this session's "search pattern decided the census" trap:
- `downstream` — not a YAML key at all; a comment sentence in the `observability:` block wraps such that "downstream:" lands at column 0 by coincidence (the actual sentence is "...this is a LOSSY, fire-and-forget downstream: it maps P6 audit-events to OTLP spans/metrics/logs off-loop and fail-open...").
- `enabled` — a nested field (`offload.enabled`), not a bare top-level key; the one column-0 hit is inside a wrapped prose sentence too ("...All apply only while\n# enabled: true.").

Both are artifacts of a naive column-0-anchored extraction that can't distinguish a real YAML key declaration from a comment sentence that happens to wrap with a colon-suffixed word at the line start.

## ③ Gate-mechanism assessment — assessment only, nothing built

`scripts/check_retired_config_keys_denylist.py` (#4327) **already exists** and is exactly this class of check — I ran it before and after my fix; it passed with 0 hits both times, which is worth explaining since 5 genuinely-stale blocks were sitting in this file the whole time:

- Its denylist source, `_RENAMED_CONFIG_KEYS`, is scoped to **T1-T7 renames with a tracked destination** (the same registry `reyn config validate`/`migrate` reads) — by design, not an oversight (see that script's own module docstring, "Single source" section).
- It structurally does **not** cover (a) `shell_allowed` — an older, pre-#4174 subsumption into `permissions` that was never registered as a rename, and (b) pure removals with no destination at all (`eval`/`self_improvement`/`skill_search`/`time_travel` — deleted outright, never renamed anywhere).
- `shell_allowed` could plausibly be added to `_RENAMED_CONFIG_KEYS` with `destination=None` (manual-review shape, same treatment as the existing `agent`/`web` entries) since it's a real value-transform rename, not a plain move.
- Pure removals are a different question the existing registry's design doesn't address at all — catching "this key isn't a rename, it's just gone" would need a different mechanism (e.g. a historical denylist of dead keys, independent of the rename-hint registry), not a natural extension of the current one.

Per lead-coder's explicit instruction, no new mechanism built here — this is assessment only for a separate discussion.

## Verification

- `ruff check src tests` — clean.
- `rm -rf site && mkdocs build --strict` — clean (fresh rebuild).
- `python scripts/check_doc_anchors.py` — clean.
- `python scripts/check_retired_config_keys_denylist.py` — clean (0 hits, before and after).
- `pytest tests/config/test_config_mirror_coverage_1056.py` — 5 passed (confirms the deletions don't affect the OTHER-direction schema-coverage gate).
- Repo-wide sweep (`docs/`) for the same 5 retired keys or their sub-fields elsewhere — none found.

## Test plan

- [x] Header path fixed (`src/reyn/config.py` → `src/reyn/config/root.py`), both occurrences.
- [x] All 7 unmatched names individually traced to source + git history, not re-run from lead-coder's own extraction.
- [x] 5 confirmed-retired blocks deleted; 2 false positives left untouched with the reasoning recorded here.
- [x] Gate-mechanism question answered (existing gate found, its scope explained, no new mechanism built).
- [x] Full gate suite clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
