### PR TITLE
fix(4376): bound ReynPresenter._image_cache by total bytes, not session lifetime

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -452,8 +452,88 @@ class ReynPresenter:
         # begin_image_resolution's own docstring. A plain dict (present() is
         # only ever awaited from the app's own single-threaded event loop, so
         # no lock is needed for this read/write pattern).
+        #
+        # #4376: reyn's chat FlowView model never sheds an individual entry
+        # mid-session (only a full ``conversation.clear()`` on session
+        # switch) — so there is no "left the model" signal to bind this
+        # cache's lifetime to, the way flowview's own v0.17.0 memory-control
+        # guide recommends for ITS OWN caches. Falling back to a total-byte
+        # cap instead (see :meth:`_store_image_resolution`): without one,
+        # every unique image `src` a session has ever resolved stays cached
+        # for the session's full lifetime — #3876/#3872's class of bug
+        # (unbounded accumulation, no eviction path), this time via image
+        # bodies (up to 5MB each, ``image_fetch.DEFAULT_MAX_BYTES``) instead
+        # of a list().
         self._image_cache: "dict[str, object]" = {}
         self._image_inflight: "set[str]" = set()
+        from reyn.core.present.image_fetch import DEFAULT_MAX_BYTES
+
+        # Derived from DEFAULT_MAX_BYTES rather than a fresh magic number —
+        # lead-coder's explicit requirement (#4376): a per-entry cap and a
+        # total cap that are independently-chosen numbers drift out of sync
+        # the moment only one of them is retuned. 10x is a starting bound
+        # (matches DEFAULT_MAX_BYTES's own "a starting number, not a
+        # measured one" spirit) — room for a normal chat's worth of images
+        # without holding every image body a long session has ever shown.
+        self._image_cache_byte_cap = DEFAULT_MAX_BYTES * 10
+        self._image_cache_bytes = 0
+
+    def _store_image_resolution(self, src: str, resolution: object) -> None:
+        """The ONE mutation point for :attr:`_image_cache` writes (#4376),
+        wrapping the dict assignment every call site used to do directly.
+        Enforces :attr:`_image_cache_byte_cap` by evicting the OLDEST
+        entries (FIFO — dict preserves insertion order, and `del` + re-
+        assign moves an updated key to the end) until the new total fits.
+
+        A single very-large entry (already itself over the cap — the file
+        size cap is per-entry, so this cannot happen with a well-behaved
+        fetch, but a future change to either constant should not corrupt
+        state) is kept rather than evicted-then-immediately-re-evicted:
+        with everything else already gone, evicting it too would leave the
+        src the caller JUST resolved unexpectedly absent from its own
+        cache.
+        """
+        body = getattr(resolution, "body", b"")
+        size = len(body) if isinstance(body, (bytes, bytearray)) else 0
+        if src in self._image_cache:
+            old_body = getattr(self._image_cache[src], "body", b"")
+            self._image_cache_bytes -= (
+                len(old_body) if isinstance(old_body, (bytes, bytearray)) else 0
+            )
+            del self._image_cache[src]  # re-inserted below, now the newest
+        self._image_cache[src] = resolution
+        self._image_cache_bytes += size
+        while self._image_cache_bytes > self._image_cache_byte_cap and len(self._image_cache) > 1:
+            oldest_src = next(iter(self._image_cache))
+            evicted = self._image_cache.pop(oldest_src)
+            evicted_body = getattr(evicted, "body", b"")
+            self._image_cache_bytes -= (
+                len(evicted_body) if isinstance(evicted_body, (bytes, bytearray)) else 0
+            )
+
+    @property
+    def image_cache_size_bytes(self) -> int:
+        """Public, snapshot-style read of the current total cached image
+        body bytes (#4376) — mirrors ``HookBus.subscriber_count``'s own
+        "public, non-private surface for tests/observability" pattern, so
+        the bound this class enforces on itself is externally checkable
+        without reaching into :attr:`_image_cache` directly."""
+        return self._image_cache_bytes
+
+    @property
+    def image_cache_byte_cap(self) -> int:
+        """Public, read-only view of the total-byte cap this instance
+        enforces (#4376) — set once at construction, derived from
+        ``image_fetch.DEFAULT_MAX_BYTES``."""
+        return self._image_cache_byte_cap
+
+    def has_cached_image(self, src: str) -> bool:
+        """Whether *src* currently has a settled resolution in the cache
+        (#4376) — the same membership check :meth:`begin_image_resolution`
+        uses internally, exposed so a caller (or a test) can observe
+        whether an entry survived eviction without reaching into
+        :attr:`_image_cache` directly."""
+        return src in self._image_cache
 
     def begin_image_resolution(
         self,
@@ -499,11 +579,11 @@ class ReynPresenter:
             body, content_type = await fetch_image_bytes(
                 src, allowed_schemes=allowed_schemes
             )
-            self._image_cache[src] = ImageResolution(
-                ok=True, body=body, content_type=content_type
+            self._store_image_resolution(
+                src, ImageResolution(ok=True, body=body, content_type=content_type)
             )
         except ImageFetchError as exc:
-            self._image_cache[src] = ImageResolution(ok=False, error=str(exc))
+            self._store_image_resolution(src, ImageResolution(ok=False, error=str(exc)))
         except Exception:
             # Cosmetic (a failed image render must never break the pump) —
             # same guard shape as _begin_running_indicator's own try/except.
@@ -512,8 +592,8 @@ class ReynPresenter:
             logging.getLogger(__name__).exception(
                 "textual chat: image resolution crashed for %r", src
             )
-            self._image_cache[src] = ImageResolution(
-                ok=False, error="internal error resolving the image"
+            self._store_image_resolution(
+                src, ImageResolution(ok=False, error="internal error resolving the image")
             )
         finally:
             self._image_inflight.discard(src)

--- a/tests/core/test_4376_image_cache_bounded.py
+++ b/tests/core/test_4376_image_cache_bounded.py
@@ -1,0 +1,118 @@
+"""Tier 2: #4376 — ReynPresenter._image_cache is bounded by total bytes, not
+left to accumulate for a session's full lifetime.
+
+lead-coder's discovery while investigating #4374: every unique image `src` a
+chat session resolved stayed cached forever (`begin_image_resolution`'s 3
+write sites had zero eviction paths) — up to 5MB/entry
+(`image_fetch.DEFAULT_MAX_BYTES`), the same "unbounded accumulation, no
+eviction path" shape as #3876 (413MB) / #3872 (10GB).
+
+Model-membership binding (flowview's own v0.17.0 memory-control guide
+pattern — shed a cache entry when its owning entry leaves the model) was
+considered first but is not available here: reyn's chat FlowView model never
+removes an individual entry mid-session (only a full `conversation.clear()`
+on session switch — see presenter.py's own docstring at the fix site). The
+fallback is a total-byte cap derived from `DEFAULT_MAX_BYTES` (never a fresh
+magic number), enforced by `_store_image_resolution`, the single mutation
+point every `begin_image_resolution` write path now goes through.
+
+Per lead-coder's explicit six-question-⑤ requirement: these tests assert
+what BOUNDS the cache (the total never exceeds the cap; an evicted entry is
+observably gone), not "insert N, N remain" — the latter would still pass a
+regression that changed the eviction policy's shape as long as the COUNT
+happened to match, without actually proving anything is bounded.
+"""
+from __future__ import annotations
+
+from reyn.core.present.image_fetch import DEFAULT_MAX_BYTES, ImageResolution
+from reyn.interfaces.inline.textual_chat.presenter import ReynPresenter
+
+
+def _resolution(nbytes: int) -> ImageResolution:
+    return ImageResolution(ok=True, body=b"x" * nbytes, content_type="image/png")
+
+
+def test_total_cached_bytes_never_exceeds_the_cap() -> None:
+    """Tier 2: #4376 — inserting enough entries to exceed the byte cap keeps
+    the running total AT OR UNDER the cap, not merely "some bound decided by
+    how many happened to fit" — this is the actual invariant the fix
+    provides, checked directly against the cap it declares."""
+    presenter = ReynPresenter()
+    entry_size = DEFAULT_MAX_BYTES  # the largest single entry the fetch layer allows
+    # Enough entries to comfortably exceed the cap several times over.
+    n_entries = (presenter.image_cache_byte_cap // entry_size) + 5
+
+    for i in range(n_entries):
+        presenter._store_image_resolution(f"src-{i}", _resolution(entry_size))
+        assert presenter.image_cache_size_bytes <= presenter.image_cache_byte_cap, (
+            f"cache exceeded its own byte cap after inserting src-{i}: "
+            f"{presenter.image_cache_size_bytes} > {presenter.image_cache_byte_cap}"
+        )
+
+
+def test_the_cap_is_derived_from_the_shared_per_entry_constant() -> None:
+    """Tier 2: #4376 — lead-coder's explicit requirement: the total cap must
+    be DERIVED from `DEFAULT_MAX_BYTES` (the per-entry fetch cap), not an
+    independently-chosen number that could silently drift out of sync with
+    it. Asserts the actual divisibility relationship, not just "it's some
+    number bigger than one entry" — a derived-but-then-hardcoded constant
+    would still pass a weaker check."""
+    presenter = ReynPresenter()
+    assert presenter.image_cache_byte_cap % DEFAULT_MAX_BYTES == 0
+    assert presenter.image_cache_byte_cap >= DEFAULT_MAX_BYTES
+
+
+def test_an_evicted_entry_is_observably_gone_and_a_later_request_would_refetch() -> None:
+    """Tier 2: #4376 — the oldest entry, once evicted to make room, is no
+    longer reported as cached (`has_cached_image` — the same membership
+    check `begin_image_resolution` itself uses to decide whether to start a
+    new fetch). This is the real, observable consequence a caller sees, not
+    an assertion on `_image_cache`'s raw contents."""
+    presenter = ReynPresenter()
+    entry_size = DEFAULT_MAX_BYTES
+    n_to_overflow = (presenter.image_cache_byte_cap // entry_size) + 3
+
+    presenter._store_image_resolution("oldest", _resolution(entry_size))
+    assert presenter.has_cached_image("oldest")
+
+    for i in range(n_to_overflow):
+        presenter._store_image_resolution(f"filler-{i}", _resolution(entry_size))
+
+    assert not presenter.has_cached_image("oldest"), (
+        "the oldest entry should have been evicted once enough newer "
+        "entries pushed the total over the byte cap"
+    )
+    # The most recently stored entry must survive — the cap bounds the
+    # TOTAL, it must not evict what was just asked for.
+    assert presenter.has_cached_image(f"filler-{n_to_overflow - 1}")
+
+
+def test_re_storing_an_existing_src_does_not_double_count_its_old_size() -> None:
+    """Tier 2: #4376 — falsifies the double-counting shape a naive
+    "always add, never subtract the old value" implementation would have:
+    re-resolving the SAME src (e.g. a retry after a transient failure) must
+    replace, not accumulate, its contribution to the tracked total."""
+    presenter = ReynPresenter()
+    small = DEFAULT_MAX_BYTES // 4
+
+    presenter._store_image_resolution("retried", _resolution(small))
+    after_first = presenter.image_cache_size_bytes
+    presenter._store_image_resolution("retried", _resolution(small))
+    after_second = presenter.image_cache_size_bytes
+
+    assert after_second == after_first, (
+        f"re-storing the same src changed the tracked total "
+        f"({after_first} -> {after_second}) — the old entry's bytes were "
+        f"not correctly subtracted before adding the new ones"
+    )
+
+
+def test_a_single_entry_under_the_cap_evicts_nothing() -> None:
+    """Tier 2: #4376 accept-side — the eviction loop must not fire when
+    nothing needs evicting (guards against an off-by-one that evicts on
+    every insert regardless of total)."""
+    presenter = ReynPresenter()
+    presenter._store_image_resolution("only", _resolution(DEFAULT_MAX_BYTES))
+
+    assert presenter.has_cached_image("only")
+    assert presenter.image_cache_size_bytes == DEFAULT_MAX_BYTES


### PR DESCRIPTION
**[tui-coder]** — part of #4376

## What

Self-discovered while investigating #4374 (flowview memory-control guide compliance): `ReynPresenter._image_cache` retained every unique image `src` a chat session resolved forever — up to 5MB/entry (`image_fetch.DEFAULT_MAX_BYTES`), no eviction path at any of `begin_image_resolution`'s 3 write sites. Same "unbounded accumulation, no eviction path" shape as #3876 (413MB) and #3872 (10GB).

## Design — why byte-bounded, not model-membership-bound

Considered binding the cache's lifetime to flow-model membership first (the pattern flowview's own v0.17.0 memory-control guide uses for its own caches: shed an entry when it leaves the model). **Not available here** — reyn's chat FlowView model never removes an individual entry mid-session, only a full `conversation.clear()` on session switch. There is no "left the model" signal to bind to.

Falls back to a total-byte cap instead, per lead-coder's explicit requirement: **derived from `image_fetch.DEFAULT_MAX_BYTES` (10x), never a fresh magic number** — a per-entry cap and an independently-chosen total cap drift out of sync the moment only one gets retuned.

`_store_image_resolution` is now the single mutation point every write site goes through, evicting the oldest entries (FIFO — dict insertion order) until the new total fits.

## Test discipline (lead-coder's explicit six-question-⑤ requirement)

Tests assert what BOUNDS the cache — the total never exceeds the cap, and an evicted entry is observably absent via the same membership check `begin_image_resolution` itself uses (`has_cached_image`) — not "insert N, N remain". The latter would still pass a regression that changed the eviction policy's shape as long as the count happened to match; it doesn't show what's actually bounding anything.

Two small public read surfaces added (`image_cache_size_bytes`, `has_cached_image`, `image_cache_byte_cap`), mirroring `HookBus`'s existing "public, non-private surface for tests/observability" pattern already established in this codebase — so the bound is externally checkable without reaching into `_image_cache` directly (no private-state assertions).

## Scope

Fixes the cache growth vector only. Does not touch flowview's own (already-compliant) caching, and does not touch the fetch/decode path.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/core/test_4376_image_cache_bounded.py` — 5/5 OK, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/presenter.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] Falsify-verified (neutered the eviction loop → confirmed 2/5 tests failed with the predicted "oldest entry survives, cache exceeds cap" shape → restored → confirmed green)
- [x] `.venv/bin/python -m pytest tests/core tests/interfaces` — 4140 passed, 5 skipped (pre-existing optional-extra / unrelated), 0 failed
- [ ] Visual (waived per owner's standing waiver, 2026-08-08 — merge proceeds, owner confirms after on `main`)

Per lead-coder's explicit instruction: this fix does not need owner sign-off (unbounded accumulation is an existing structural discipline violation, not a judgment call) — held for lead-coder's TESTS-READY only, not self-merging.



---

## Reviewer's blocking item (lead-coder)

- [x] 🔴 ~~**`conversation.clear()`（`app.py:3595`）で `_image_cache` も落とす。**~~ ★**lead-coder が取り下げました** — `_image_cache` は `src` をキーにした内容アドレス指定のキャッシュでセッション同一性を持たず、`_streaming_catchup`（`app.py:1158`「holds no session identity」∴ 意図的に登録簿へ入れない）と同じ側でした。正しさの問題は無く、メモリはこの PR が既に有界化しています。理由の全文はレビューコメントに。
