### PR TITLE
feat(4215): bridge a spawned pipeline driver's hook events to its parent

### DIFF
--- a/docs/deep-dives/proposals/0059-hook-event-redesign.md
+++ b/docs/deep-dives/proposals/0059-hook-event-redesign.md
@@ -130,9 +130,10 @@ reyn の `HookDispatcher`(`hooks/dispatcher.py:58-350`)= v0.1 の Sync 経路の
 ### 3.3 Bus の scope — **per-Session(v1 確定)** [review-pass 追加]
 
 v0.1 は Bus の scope(1 session 内か、多 session を抱える server process 全体か)を定義していない — これは根本のアーキ判断:
-- **v1 = per-Session**。現行 `HookDispatcher` の locality(Session ごとに構築、DI closure が Session method に束縛)と一致し、session 間 isolation が構造的に保たれる(他 session の event を観測できない = spoofing/漏洩の新面を開かない)。`llm:<session_id>:*` namespace とも自然に整合。
+- **v1 = per-Session**。現行 `HookDispatcher` の locality(Session ごとに構築、DI closure が Session method に束縛)と一致し、session 間 isolation が既定では保たれる(他 session の event を無条件には観測できない = spoofing/漏洩の新面を無条件には開かない)。`llm:<session_id>:*` namespace とも自然に整合。
 - external source(cron/webhook)は現行通り **target Session を resolve してからその session の Bus に投入**(Ingress Adapter の責務、§6)。
 - **cross-session の event 観測/合成は v1 非対象**(将来: broker 級の設計が要る — 到着順 vs causal 順の補正、session 間の信頼境界。v0.1 §10 の Seq 分散問題はこの将来項に属する)。既存の cross-session **push**(hook action が別 session の inbox へ)はそのまま(action の宛先であって event の観測ではない)。
+- **#4215 ②追記(2026-08-12)**: 上の「session 間 isolation が構造的に保たれる」は、無条件の隔離ではなく **既定の隔離** と読み替える。owner 裁定(#4215、訂正後の枠): 懸念は「他の subscribe を受けてはいけない」ではなく「**受けない選択肢が無いこと**」。∴ **spawn した親が、子の bus を明示的に subscribe し自分の bus へ再 publish する経路**(`reyn.hooks.bus.bridge_child_bus_to_parent`、`session_api._spawn_pipeline_driver_session` の ATTACHED spawn のみ)を、狭い・opt-in な例外として追加した。デフォルトは変わらない(誰も subscribe しなければ `publish` の no-subscriber happy path のまま、コストゼロ)。`HookDispatcher` は経由しない(`dispatch_bus_event` 自身が「bus 由来の event を bus へ re-publish するのは二重配信」と明記している通り)。この橋渡しは spawn 時に明示的に選ばれた経路のみで発生し、任意の session が任意の他 session を無条件に観測できる形には拡張されていない。
 
 ---
 

--- a/src/reyn/hooks/bus.py
+++ b/src/reyn/hooks/bus.py
@@ -239,4 +239,50 @@ class HookBus:
         return {state.subscriber_id: state.drop_count for state in self._subscribers}
 
 
-__all__ = ["HookBus", "HookBusSubscription"]
+async def bridge_child_bus_to_parent(child_bus: "HookBus", parent_bus: "HookBus") -> None:
+    """#4215 ②: forward every :class:`HookEvent` *child_bus* broadcasts onto
+    *parent_bus* — the one narrow, opt-in exception to this module's own
+    "no cross-session Bus" claim (see the module docstring's Per-Session
+    scope section, and its ``#3.3``-referencing update).
+
+    Owner ruling on #4215 (corrected framing, lead-coder's relay): the
+    concern was never "a parent must not be able to observe a child" — it
+    was "there must be a CHOICE, not a structural impossibility". This
+    bridge is what makes that choice available: a parent that never
+    subscribes to its own bus pays nothing extra for it (``publish``'s own
+    no-subscriber happy path, module docstring above); a parent that DOES
+    subscribe now sees its children's hook events too, by construction, the
+    same way the existing ``SpawnBridgePresentationConsumer`` /
+    ``SpawnBridgeInterventionListener`` pattern makes a child's present/
+    ask_user reach the parent by construction.
+
+    Run as a background task (``asyncio.create_task``), one per bridged
+    spawn — see ``session_api._spawn_pipeline_driver_session`` for the
+    call site and ``Session._hook_bus_bridge_task`` for where the task
+    handle is held (so it survives past the spawn call and is cancellable
+    at session teardown).
+
+    Deliberately does NOT go through either session's ``HookDispatcher`` —
+    ``HookDispatcher.dispatch_bus_event``'s own docstring already
+    documents why re-publishing a bus-originated event back onto a bus is
+    wrong: it would be a duplicate delivery to any sibling
+    Composer/subscriber correlating on the same kind. This function calls
+    ``parent_bus.publish`` directly, the SAME sync, non-blocking,
+    never-raises call any other publisher uses — the child's own publish
+    call is never held up by it (``HookBus.publish`` never blocks its
+    caller), and neither is the parent's own Sync hook dispatch (this
+    bridge never touches ``HookDispatcher`` at all, so there is nothing on
+    the parent's await path for a child event to wait behind).
+
+    Runs until cancelled (the intended shutdown path — see
+    ``AgentRegistry.remove_session``'s ``aclose_hook_bus_bridge``-shaped
+    teardown) or until ``child_bus``'s owning session's own subscription is
+    otherwise closed.
+    """
+    async with child_bus.subscribe() as subscription:
+        while True:
+            event = await subscription.get()
+            parent_bus.publish(event)
+
+
+__all__ = ["HookBus", "HookBusSubscription", "bridge_child_bus_to_parent"]

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2111,6 +2111,17 @@ class AgentRegistry:
             aclose_event_store = getattr(session, "aclose_event_store", None)
             if callable(aclose_event_store):
                 await aclose_event_store()
+            # #4215 ②: cancel this session's own hook-bus->parent bridge
+            # task, if it is one (bridged children only —
+            # session_api._spawn_pipeline_driver_session's attached path;
+            # every other session's own attribute stays None and this is a
+            # no-op). Bare cancel(), not awaited, mirroring the
+            # self._tasks/_forward_tasks cancellation a few lines below —
+            # the bridge's own loop has nothing to flush on cancellation
+            # (it only forwards live events, nothing durable).
+            bridge_task = getattr(session, "_hook_bus_bridge_task", None)
+            if bridge_task is not None and not bridge_task.done():
+                bridge_task.cancel()
         for task_dict in (self._tasks, self._forward_tasks):
             task = task_dict.pop((name, sid), None)
             if task is not None:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1258,6 +1258,16 @@ class Session:
         self._fs_watcher = _hook_bundle.fs_watcher
         self._composer_registry = _hook_bundle.composer_registry
         self._composed_consumer = _hook_bundle.composed_consumer
+        # #4215 ②: holds the background task bridging THIS session's own
+        # hook-bus events to a PARENT session's bus, when one is spawned
+        # (session_api._spawn_pipeline_driver_session, attached path only).
+        # None for every session that is not a bridged child (the default —
+        # main sessions, detached spawns). Held here (not a local variable at
+        # the spawn site) so it survives past the spawn call and so
+        # AgentRegistry.remove_session has something to cancel at teardown —
+        # see HookBus's own module docstring for why this is a narrow, opt-in
+        # exception to "no cross-session Bus", not a removal of that claim.
+        self._hook_bus_bridge_task: "asyncio.Task | None" = None
         self._hot_reloader = _hook_bundle.hot_reloader
         # Publish as the process-wide active reloader so the hooks-write LLM-op can request_reload (#2073 S3, see session-construction.md#family-3-hook-event-reactivity)
         from reyn.runtime.hot_reload import set_active_hot_reloader
@@ -1476,6 +1486,16 @@ class Session:
         self._audit_events.add_subscriber(new_store)
         self.events_dir = events_dir
         self._event_store = new_store
+
+    @property
+    def has_hook_bus_bridge_to_parent(self) -> bool:
+        """#4215 ②: read-only public surface for whether
+        ``_hook_bus_bridge_task`` is set — lets a caller/test observe
+        whether THIS session's hook-bus events are being forwarded to a
+        parent's bus (an ATTACHED pipeline driver spawn) without reaching
+        into the "private" attribute, mirroring ``non_interactive``'s own
+        pattern just below."""
+        return self._hook_bus_bridge_task is not None
 
     @property
     def non_interactive(self) -> bool:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1488,16 +1488,6 @@ class Session:
         self._event_store = new_store
 
     @property
-    def has_hook_bus_bridge_to_parent(self) -> bool:
-        """#4215 ②: read-only public surface for whether
-        ``_hook_bus_bridge_task`` is set — lets a caller/test observe
-        whether THIS session's hook-bus events are being forwarded to a
-        parent's bus (an ATTACHED pipeline driver spawn) without reaching
-        into the "private" attribute, mirroring ``non_interactive``'s own
-        pattern just below."""
-        return self._hook_bus_bridge_task is not None
-
-    @property
     def non_interactive(self) -> bool:
         """#2585 PR2: read-only public surface for ``_non_interactive`` (set at
         construction from the frontend's session_factory, and force-overridden

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -604,6 +604,21 @@ async def _spawn_pipeline_driver_session(
             f"pipeline launch: spawned driver-session ({reply_to_agent!r}, "
             f"{sid!r}) not found in the registry"
         )
+    if attached_parent_session is not None:
+        # #4215 ②: bridge this driver's hook-bus events to the PARENT's
+        # bus, non-blocking, same ATTACHED-only condition as the
+        # presentation/intervention BridgeToParent routing above — a
+        # detached spawn (AuditOnlyNoSurface) has no live parent to bridge
+        # to. See bridge_child_bus_to_parent's own docstring for why this
+        # goes through neither session's HookDispatcher, and Session.
+        # _hook_bus_bridge_task for where teardown cancels it.
+        import asyncio
+
+        from reyn.hooks.bus import bridge_child_bus_to_parent
+
+        session._hook_bus_bridge_task = asyncio.create_task(
+            bridge_child_bus_to_parent(session._hook_bus, attached_parent_session._hook_bus)
+        )
     driver = PipelineExecutorDriver(
         work_order, registry=registry, state_log=state_log,
         notify_reply=notify_reply,

--- a/tests/runtime/test_4215_hook_bus_bridge.py
+++ b/tests/runtime/test_4215_hook_bus_bridge.py
@@ -103,7 +103,10 @@ async def test_attached_spawn_bridges_child_hook_events_to_the_parent(tmp_path: 
                 payload={"marker": "reyn-4215-probe"},
             )
             driver._hook_bus.publish(probe)
-            received = await asyncio.wait_for(parent_sub.get(), timeout=5.0)
+            # Unbounded — a genuine hang here is a real defect the CI
+            # kill-switch is the correct place to catch (owner's standing
+            # rule: tests carry no time limit of their own).
+            received = await parent_sub.get()
 
         assert received.payload.get("marker") == "reyn-4215-probe"
     finally:
@@ -117,16 +120,16 @@ async def test_detached_spawn_starts_no_bridge_task(tmp_path: Path) -> None:
     this, a detached driver would silently subscribe to nothing useful (its
     own events forwarded nowhere) while still paying a live task's cost.
 
-    Observed via ``HookBus.subscriber_count`` (already public) rather than
-    a dedicated Session-level property — a public surface is a means to
-    avoid a private-state assertion, not a goal in itself, and a session's
-    own hook-bus subscriber count already says everything this test needs
-    without growing Session's own public member ceiling for a single
-    test's sake."""
+    Checked at TASK-CREATION time, not via a later effect
+    (``subscriber_count``, which only changes once a bridge task has
+    actually RUN its own ``subscribe()`` call): ``asyncio.create_task``
+    registers the task with the event loop SYNCHRONOUSLY, before it ever
+    gets a chance to run — its existence is visible immediately, with no
+    wait needed to rule it out."""
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     reg = _agent_registry(tmp_path, state_log)
 
-    driver, _rid, _sid = await _spawn_pipeline_driver_session(
+    _driver, _rid, _sid = await _spawn_pipeline_driver_session(
         reg,
         pipeline=_noop_pipeline(),
         pipeline_name="noop",
@@ -137,14 +140,12 @@ async def test_detached_spawn_starts_no_bridge_task(tmp_path: Path) -> None:
         notify_reply=False,
         attached_parent_session=None,
     )
-    # Give a wrongly-started bridge task a real chance to subscribe before
-    # asserting its absence (same "don't race a real async effect" shape
-    # as the other tests in this file).
-    await asyncio.sleep(0.1)
-    subscriber_count = driver._hook_bus.subscriber_count
-    assert subscriber_count == 0, (
-        "a DETACHED spawn must not start a hook-bus bridge task — nothing "
-        "should have subscribed to the driver's own bus"
+    bridge_tasks = [
+        t for t in asyncio.all_tasks()
+        if "bridge_child_bus_to_parent" in repr(t.get_coro())
+    ]
+    assert bridge_tasks == [], (
+        "a DETACHED spawn must not start a hook-bus bridge task at all"
     )
 
 

--- a/tests/runtime/test_4215_hook_bus_bridge.py
+++ b/tests/runtime/test_4215_hook_bus_bridge.py
@@ -1,0 +1,211 @@
+"""Tier 2: #4215 ② — an ATTACHED pipeline driver's hook-bus events reach the
+PARENT session's own bus, non-blocking, without going through either
+session's HookDispatcher.
+
+Owner ruling on #4215 (corrected framing, relayed by lead-coder): the
+concern was never "a parent must not observe a child" — it was "there must
+be a CHOICE, not a structural impossibility". `bridge_child_bus_to_parent`
+(`reyn.hooks.bus`) is that choice: wired ONLY at the ATTACHED spawn
+(`session_api._spawn_pipeline_driver_session`, mirroring the existing
+`SpawnBridgePresentationConsumer`/`SpawnBridgeInterventionListener`
+pattern), a background task that subscribes to the child's bus and calls
+`parent_bus.publish` directly for every event — never through
+`HookDispatcher` (whose own `dispatch_bus_event` already documents why
+re-publishing a bus-originated event onto a bus would double-deliver it).
+
+Real `AgentRegistry`/`Session`/`StateLog` throughout — no collaborator
+mocks, matching this arc's own established discipline (test_2708_p32a's own
+module docstring).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import Pipeline, ToolStep
+from reyn.hooks.bus import HookBus, bridge_child_bus_to_parent
+from reyn.hooks.event import HookEvent
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.runtime.session_api import _spawn_pipeline_driver_session
+from reyn.runtime.session_params import PresentationWiring
+from tests._async_wait import wait_until
+from tests._support.agent_session import make_session
+
+
+def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
+    """Mirrors test_2708_p32a_spawn_bridge_intervention.py's own factory —
+    the widened factory protocol accepting BOTH spawn overrides."""
+    holder: dict = {}
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
+        return make_session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            presentation_wiring=PresentationWiring(
+                presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge,
+            ),
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    if not reg.exists("worker"):
+        reg.create("worker")
+    return reg
+
+
+def _noop_pipeline() -> Pipeline:
+    # A single step is enough — this test never runs the pipeline to
+    # completion, only spawns its driver-session.
+    return Pipeline(steps=[ToolStep(name="noop", args={}, output="out")])
+
+
+@pytest.mark.asyncio
+async def test_attached_spawn_bridges_child_hook_events_to_the_parent(tmp_path: Path) -> None:
+    """Tier 2: an event published on the CHILD driver's hook-bus is observed
+    on the PARENT's bus — the real, end-to-end consequence of the bridge
+    task the ATTACHED spawn now starts."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log)
+    parent = reg.get_or_load("worker")
+
+    driver, _rid, _sid = await _spawn_pipeline_driver_session(
+        reg,
+        pipeline=_noop_pipeline(),
+        pipeline_name="noop",
+        input=None,
+        reply_to_agent="worker",
+        reply_to_sid="main",
+        state_log=state_log,
+        notify_reply=False,
+        attached_parent_session=parent,
+    )
+    try:
+        assert driver.has_hook_bus_bridge_to_parent, (
+            "an ATTACHED spawn must start the child->parent bridge task"
+        )
+        # The bridge task's own `child_bus.subscribe()` must actually run
+        # before a publish on the child can reach it — HookBus is a
+        # broadcast bus with no replay for a subscriber that registers
+        # late (bus.py's own module docstring). `asyncio.create_task`
+        # schedules but does not immediately run the new task, so wait for
+        # its subscription to actually register (the public
+        # `subscriber_count` surface) rather than publishing on a race.
+        await wait_until(lambda: driver._hook_bus.subscriber_count >= 1)
+
+        async with parent._hook_bus.subscribe() as parent_sub:
+            probe = HookEvent(
+                kind="builtin:external:test_probe",
+                payload={"marker": "reyn-4215-probe"},
+            )
+            driver._hook_bus.publish(probe)
+            received = await asyncio.wait_for(parent_sub.get(), timeout=5.0)
+
+        assert received.payload.get("marker") == "reyn-4215-probe"
+    finally:
+        driver._hook_bus_bridge_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_detached_spawn_starts_no_bridge_task(tmp_path: Path) -> None:
+    """Tier 2: scope guard — a DETACHED spawn (no live parent to bridge to,
+    `attached_parent_session=None`) starts no bridge task at all. Without
+    this, a detached driver would silently subscribe to nothing useful (its
+    own events forwarded nowhere) while still paying a live task's cost."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log)
+
+    driver, _rid, _sid = await _spawn_pipeline_driver_session(
+        reg,
+        pipeline=_noop_pipeline(),
+        pipeline_name="noop",
+        input=None,
+        reply_to_agent="worker",
+        reply_to_sid="main",
+        state_log=state_log,
+        notify_reply=False,
+        attached_parent_session=None,
+    )
+    assert not driver.has_hook_bus_bridge_to_parent
+
+
+@pytest.mark.asyncio
+async def test_removing_the_child_session_cancels_its_bridge_task(tmp_path: Path) -> None:
+    """Tier 2: teardown — AgentRegistry.remove_session cancels a bridged
+    child's bridge task. Without this, every attached pipeline run would
+    leak one live background task per invocation for the life of the
+    process (the exact class of bug the #4376 image-cache fix, landed
+    minutes before this, exists to prevent for a different resource)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log)
+    parent = reg.get_or_load("worker")
+
+    driver, _rid, sid = await _spawn_pipeline_driver_session(
+        reg,
+        pipeline=_noop_pipeline(),
+        pipeline_name="noop",
+        input=None,
+        reply_to_agent="worker",
+        reply_to_sid="main",
+        state_log=state_log,
+        notify_reply=False,
+        attached_parent_session=parent,
+    )
+    task = driver._hook_bus_bridge_task
+    assert task is not None and not task.done()
+
+    await reg.remove_session("worker", sid)
+
+    await wait_until(lambda: task.done())
+    assert task.cancelled()
+
+
+def test_bridge_child_bus_to_parent_never_touches_a_hook_dispatcher() -> None:
+    """Tier 2: bridge_child_bus_to_parent's own contract — it takes exactly
+    two HookBus instances, nothing dispatcher-shaped. A future edit routing
+    it through a HookDispatcher (the double-delivery bug
+    dispatch_bus_event's own docstring warns against) would change this
+    signature, which this test pins directly rather than trusting the
+    docstring alone."""
+    import inspect
+
+    sig = inspect.signature(bridge_child_bus_to_parent)
+    # `from __future__ import annotations` (bus.py) makes every annotation a
+    # plain string at runtime, not the class object, and the source itself
+    # quotes each one ("HookBus") — strip both layers of quoting rather
+    # than pin the exact quote style, which isn't this test's subject.
+    param_types = [str(p.annotation).strip("'\"") for p in sig.parameters.values()]
+    assert param_types == ["HookBus", "HookBus"], (
+        f"bridge_child_bus_to_parent's signature changed shape: {param_types!r} "
+        "— if this now accepts a dispatcher, re-read dispatch_bus_event's own "
+        "docstring on why that would double-deliver."
+    )
+
+
+@pytest.mark.asyncio
+async def test_bridge_publish_never_blocks_the_child(tmp_path: Path) -> None:
+    """Tier 2: HookBus.publish is documented as synchronous and
+    non-blocking (bus.py's own module docstring) — this exercises that
+    property specifically THROUGH the bridge: publishing many events in a
+    tight loop on the child returns immediately regardless of whether the
+    bridge task has had a chance to drain any of them yet."""
+    child = HookBus()
+    parent = HookBus()
+    bridge = asyncio.ensure_future(bridge_child_bus_to_parent(child, parent))
+    try:
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        for i in range(50):
+            child.publish(
+                HookEvent(kind="builtin:external:test_probe", payload={"i": i})
+            )
+        elapsed = loop.time() - start
+        assert elapsed < 0.5, (
+            f"50 publishes on the bridged child took {elapsed:.3f}s — "
+            "publish must never block on the bridge task draining"
+        )
+    finally:
+        bridge.cancel()

--- a/tests/runtime/test_4215_hook_bus_bridge.py
+++ b/tests/runtime/test_4215_hook_bus_bridge.py
@@ -83,17 +83,18 @@ async def test_attached_spawn_bridges_child_hook_events_to_the_parent(tmp_path: 
         notify_reply=False,
         attached_parent_session=parent,
     )
+    # The bridge task's own `child_bus.subscribe()` must actually run
+    # before a publish on the child can reach it — HookBus is a broadcast
+    # bus with no replay for a subscriber that registers late (bus.py's
+    # own module docstring). `asyncio.create_task` schedules but does not
+    # immediately run the new task, so wait for its subscription to
+    # actually register (the public `subscriber_count` surface, reached
+    # via `driver._hook_bus` — the established convention roughly 20
+    # other tests in this repo already use, since there is no public
+    # `hook_bus` property). This wait doubles as the "a bridge task
+    # started" proof itself — no dedicated public surface needed for
+    # that fact alone.
     try:
-        assert driver.has_hook_bus_bridge_to_parent, (
-            "an ATTACHED spawn must start the child->parent bridge task"
-        )
-        # The bridge task's own `child_bus.subscribe()` must actually run
-        # before a publish on the child can reach it — HookBus is a
-        # broadcast bus with no replay for a subscriber that registers
-        # late (bus.py's own module docstring). `asyncio.create_task`
-        # schedules but does not immediately run the new task, so wait for
-        # its subscription to actually register (the public
-        # `subscriber_count` surface) rather than publishing on a race.
         await wait_until(lambda: driver._hook_bus.subscriber_count >= 1)
 
         async with parent._hook_bus.subscribe() as parent_sub:
@@ -114,7 +115,14 @@ async def test_detached_spawn_starts_no_bridge_task(tmp_path: Path) -> None:
     """Tier 2: scope guard — a DETACHED spawn (no live parent to bridge to,
     `attached_parent_session=None`) starts no bridge task at all. Without
     this, a detached driver would silently subscribe to nothing useful (its
-    own events forwarded nowhere) while still paying a live task's cost."""
+    own events forwarded nowhere) while still paying a live task's cost.
+
+    Observed via ``HookBus.subscriber_count`` (already public) rather than
+    a dedicated Session-level property — a public surface is a means to
+    avoid a private-state assertion, not a goal in itself, and a session's
+    own hook-bus subscriber count already says everything this test needs
+    without growing Session's own public member ceiling for a single
+    test's sake."""
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     reg = _agent_registry(tmp_path, state_log)
 
@@ -129,7 +137,15 @@ async def test_detached_spawn_starts_no_bridge_task(tmp_path: Path) -> None:
         notify_reply=False,
         attached_parent_session=None,
     )
-    assert not driver.has_hook_bus_bridge_to_parent
+    # Give a wrongly-started bridge task a real chance to subscribe before
+    # asserting its absence (same "don't race a real async effect" shape
+    # as the other tests in this file).
+    await asyncio.sleep(0.1)
+    subscriber_count = driver._hook_bus.subscriber_count
+    assert subscriber_count == 0, (
+        "a DETACHED spawn must not start a hook-bus bridge task — nothing "
+        "should have subscribed to the driver's own bus"
+    )
 
 
 @pytest.mark.asyncio
@@ -138,7 +154,14 @@ async def test_removing_the_child_session_cancels_its_bridge_task(tmp_path: Path
     child's bridge task. Without this, every attached pipeline run would
     leak one live background task per invocation for the life of the
     process (the exact class of bug the #4376 image-cache fix, landed
-    minutes before this, exists to prevent for a different resource)."""
+    minutes before this, exists to prevent for a different resource).
+
+    Observed via ``HookBus.subscriber_count`` (already public), not the
+    task object itself: cancelling ``bridge_child_bus_to_parent`` unwinds
+    its ``async with child_bus.subscribe()`` block, which calls
+    ``close()`` — the count going back to 0 IS the externally-visible
+    consequence of the cancel actually running (same reasoning as the
+    scope-guard test above)."""
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     reg = _agent_registry(tmp_path, state_log)
     parent = reg.get_or_load("worker")
@@ -154,13 +177,11 @@ async def test_removing_the_child_session_cancels_its_bridge_task(tmp_path: Path
         notify_reply=False,
         attached_parent_session=parent,
     )
-    task = driver._hook_bus_bridge_task
-    assert task is not None and not task.done()
+    await wait_until(lambda: driver._hook_bus.subscriber_count >= 1)
 
     await reg.remove_session("worker", sid)
 
-    await wait_until(lambda: task.done())
-    assert task.cancelled()
+    await wait_until(lambda: driver._hook_bus.subscriber_count == 0)
 
 
 def test_bridge_child_bus_to_parent_never_touches_a_hook_dispatcher() -> None:

--- a/tests/runtime/test_4215_hook_bus_bridge.py
+++ b/tests/runtime/test_4215_hook_bus_bridge.py
@@ -207,26 +207,39 @@ def test_bridge_child_bus_to_parent_never_touches_a_hook_dispatcher() -> None:
 
 
 @pytest.mark.asyncio
-async def test_bridge_publish_never_blocks_the_child(tmp_path: Path) -> None:
+async def test_bridge_publish_does_not_wait_on_the_bridge_task(tmp_path: Path) -> None:
     """Tier 2: HookBus.publish is documented as synchronous and
     non-blocking (bus.py's own module docstring) — this exercises that
-    property specifically THROUGH the bridge: publishing many events in a
-    tight loop on the child returns immediately regardless of whether the
-    bridge task has had a chance to drain any of them yet."""
+    property specifically THROUGH the bridge, structurally rather than by
+    a wall-clock budget.
+
+    lead-coder review on #4378: the earlier version asserted `elapsed <
+    0.5` — a time-limit-shaped assertion the owner's standing rule bans
+    (tests carry no time limit of their own; a slow runner fails it even
+    when the mechanism is correct, measuring "is this machine fast"
+    rather than "does publish wait"). Publish's non-blocking-ness is
+    already guaranteed BY TYPE (it is a plain `def`, not `async def` —
+    this PR cannot break that), so what is actually worth pinning here is
+    narrower: that the bridge's own background task never gets a chance
+    to run DURING the publish loop.
+
+    No `await` appears between the publish loop and the check below — on
+    a single-threaded event loop, that means `bridge` (scheduled via
+    `ensure_future` but never yet resumed) structurally CANNOT have run
+    even its first line in between, so it cannot have drained or
+    forwarded anything yet. The parent's subscription queue being empty
+    at that exact point is therefore a deterministic consequence of the
+    event loop's own scheduling model, not a race against a clock."""
     child = HookBus()
     parent = HookBus()
     bridge = asyncio.ensure_future(bridge_child_bus_to_parent(child, parent))
     try:
-        loop = asyncio.get_running_loop()
-        start = loop.time()
-        for i in range(50):
-            child.publish(
-                HookEvent(kind="builtin:external:test_probe", payload={"i": i})
-            )
-        elapsed = loop.time() - start
-        assert elapsed < 0.5, (
-            f"50 publishes on the bridged child took {elapsed:.3f}s — "
-            "publish must never block on the bridge task draining"
-        )
+        async with parent.subscribe() as parent_sub:
+            for i in range(50):
+                child.publish(
+                    HookEvent(kind="builtin:external:test_probe", payload={"i": i})
+                )
+            with pytest.raises(asyncio.QueueEmpty):
+                parent_sub.get_nowait()
     finally:
         bridge.cancel()


### PR DESCRIPTION
**[tui-coder]** — part of #4215

## What

②, the sole remaining item on #4215 (① and ③ already landed — see the issue's own status-correction note): a spawned pipeline driver's hook-bus events reach its parent, non-blocking, on the same ATTACHED-only condition `SpawnBridgePresentationConsumer`/`SpawnBridgeInterventionListener` already use for present/ask_user routing.

## Motivation — corrected framing (lead-coder's explicit instruction)

Owner's ruling, corrected: the concern was never *"a parent must not observe a child"* — it was *"there must be a CHOICE, not a structural impossibility."* `HookBus` is per-Session by design (proposal 0059 §3.3): no subscriber on one session's bus can observe another's. This PR adds the one narrow, opt-in exception the corrected framing calls for. The issue body's own ②-section still carries the older, "must not be observed" framing — this implementation and its docs deliberately do not repeat that language.

## Design

- `reyn.hooks.bus.bridge_child_bus_to_parent`: a background task that subscribes to the child's bus and calls `parent_bus.publish` directly for every event — **never through either session's `HookDispatcher`**. `dispatch_bus_event`'s own docstring already documents why re-publishing a bus-originated event back onto a bus is wrong (duplicate delivery to any sibling subscriber correlating on the same kind); this bridge routes around that entirely.
- `HookBus.publish` is already synchronous and non-blocking (its own module docstring) — the child's own publish call is never held up by a slow parent-side subscriber, and the bridge never touches the parent's own Sync hook dispatch either.
- Wired at the one real spawn call site with both parent and child `Session` objects in scope: `session_api._spawn_pipeline_driver_session`, gated on `attached_parent_session is not None`.
- Task handle held on the child `Session` itself (`_hook_bus_bridge_task`), so it survives past the spawn call and `AgentRegistry.remove_session` has something to cancel at teardown — otherwise every attached pipeline run leaks one live background task per invocation for the process's lifetime.
- `Session.has_hook_bus_bridge_to_parent`: a public read-only property mirroring `non_interactive`'s own pattern, so callers/tests observe the bridge without a private-state assertion (caught by `test_tier_audit.py --strict` on the first pass — fixed before this PR was opened).

## Doc update (same PR, per CLAUDE.md's doc-drift rule)

`docs/deep-dives/proposals/0059-hook-event-redesign.md` §3.3 (and the two `bus.py` docstring echoes it inspired) now describe session isolation as the **default**, not an unconditional structural guarantee — this bridge is precisely a reviewed, narrow, opt-in exception, not a removal of the claim. Any session that never subscribes to its own bus still pays nothing extra (`publish`'s own no-subscriber happy path); the bridge only exists on spawn sites that explicitly choose `BridgeToParent` routing.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_4215_hook_bus_bridge.py` — 5/5 OK, 0 Tier-4 violations (first pass caught 2 private-state assertions, fixed via `has_hook_bus_bridge_to_parent`)
- [x] `python scripts/verify_module_docstrings.py` on all 4 changed `src/` files — OK
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] Falsify-verified both the spawn-site wiring (broke it → 2/2 integration tests failed with the predicted "no bridge" shape → restored → green) and teardown cancellation (broke it → the removal test hung exactly as predicted, confirming it isn't a vacuous pass → restored → green)
- [x] `pytest tests/runtime tests/hooks tests/core/test_pipeline_is6_attached.py tests/core/test_2708_p31_spawn_bridge_present.py` — 2021 passed, 1 skipped, 1 failed (`test_session_pure_importable_without_first_importing_session`, a pre-existing environment-local `.pth`-shadowing issue unrelated to this change — confirmed the same import succeeds cleanly with `PYTHONPATH` set correctly)
- [ ] Visual (waived per owner's standing waiver, 2026-08-08 — merge proceeds, owner confirms after on `main`; not really applicable here — no UI surface changes)

Real `AgentRegistry`/`Session`/`StateLog` throughout the new tests — no collaborator mocks, matching this arc's own established discipline (`test_2708_p32a_spawn_bridge_intervention.py`'s own module docstring).

Held for lead-coder's TESTS-READY / explicit merge approval, not self-merging.



---

## Reviewer's blocking item #2 (lead-coder)

- [ ] 🔴 **`test_bridge_publish_never_blocks_the_child` の `assert elapsed < 0.5` を外す。** owner 恒久指示「**テストは時間の上限を持たない・分解せよ**」に当たります。`0.5` は環境依存で、**遅いランナーでは機構が正しくても赤**になります ＝ 「非ブロック性」ではなく「そのマシンが速いこと」を測っています。★**代替（時間非依存）**: bridge に制御を渡さずに N 回 publish → **親の受信数 0 ∧ 子のキューに N 件** を assert（＝ publish が drain を待っていないことの直接の witness）。★測れないと判断したら**テスト自体を落として構いません** — 非ブロック性は `publish` が `async def` でないことで型として担保済です。詳細はレビューコメントに。
