### PR TITLE
fix(4383): reyn events replay no longer silently drops unhandled kinds

### DIFF
--- a/src/reyn/interfaces/cli/commands/events.py
+++ b/src/reyn/interfaces/cli/commands/events.py
@@ -109,7 +109,8 @@ def run_replay(args: argparse.Namespace) -> None:
     else:
         files = _collect_files(target, since=since, until=until)
 
-    count = 0
+    matched = 0
+    rendered = 0
     for f in files:
         for lineno, raw in _iter_lines(f):
             event_type = raw.get("type", "")
@@ -122,11 +123,21 @@ def run_replay(args: argparse.Namespace) -> None:
             except Exception as e:
                 print(f"[{f}:{lineno}] Event parse error: {e}", file=sys.stderr)
                 continue
-            logger(event)
-            count += 1
+            matched += 1
+            if logger(event):
+                rendered += 1
 
     where = str(target) if target.is_file() else f"{target} ({len(files)} files)"
-    print(f"\n({count} events replayed from {where})")
+    # #4383: "matched" (found by --filter/--skip) and "rendered" (actually
+    # printed a line) are reported separately — before this they were the
+    # SAME number (matched only), so a handler-less event type being
+    # silently dropped read as "N events replayed" with no indication
+    # anything had been found-but-not-shown. The generic fallback
+    # (reporters.ConsoleLogger._render_unhandled) means rendered == matched
+    # for essentially every real filter now; this line stays honest for
+    # the narrow cases where a handler exists but declines to print (e.g.
+    # --conversation-only handlers reached without --conversation set).
+    print(f"\n({matched} matched, {rendered} rendered from {where})")
 
 
 def _iter_lines(path: Path) -> Iterator[tuple[int, dict]]:

--- a/src/reyn/reporters/__init__.py
+++ b/src/reyn/reporters/__init__.py
@@ -14,10 +14,56 @@ class ConsoleLogger:
     def __init__(self, conversation: bool = False) -> None:
         self.conversation = conversation
 
-    def __call__(self, event: Event) -> None:
+    def __call__(self, event: Event) -> bool:
+        """Render *event*. Returns whether anything was actually printed
+        (#4383) — ``reyn events`` replay uses this to report how many
+        MATCHED events actually RENDERED, not just how many were found.
+
+        Before this: an event type with no dedicated ``on_<type>`` handler
+        was silently dropped (only 11 of 211 declared audit-event kinds
+        have one — 5.2%), and the replay summary's own count included the
+        dropped ones too, so "N events replayed" read as "N shown" when it
+        actually meant "N found, possibly 0 shown" — the owner's own
+        real-environment report: 21 events matched, 0 lines printed, no
+        indication anything had been dropped at all.
+
+        A handler-less type now falls through to :meth:`_render_unhandled`
+        (a generic one-line fallback) rather than being dropped — this
+        method wraps the handler call in a stdout capture (not a change to
+        any of the 11 existing handlers' own bodies) purely to detect
+        whether printing genuinely happened, for the caller's own matched-
+        vs-rendered accounting; the captured output is still written to
+        the real stdout unchanged, byte for byte.
+        """
+        import io
+        from contextlib import redirect_stdout
+
         handler = getattr(self, f"on_{event.type}", None)
-        if handler:
-            handler(event.data)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            if handler is not None:
+                handler(event.data)
+            else:
+                self._render_unhandled(event)
+        output = buf.getvalue()
+        if output:
+            import sys
+            sys.stdout.write(output)
+        return bool(output)
+
+    def _render_unhandled(self, event: Event) -> None:
+        """#4383: generic one-line fallback for a declared audit-event kind
+        this module has no dedicated ``on_<type>`` renderer for (~200 of
+        211 kinds, before this fix silently dropped by :meth:`__call__`).
+        Prints the kind plus a bounded set of its own top-level data
+        fields as ``key=value`` — never a full JSON dump (a replay is meant
+        to be skimmed line by line, not re-inspected as raw payload; an
+        operator who needs the full record already has the source JSONL).
+        Bounded to the first 6 fields so one wide event (e.g. a payload
+        carrying a large embedded blob) cannot turn a scan of thousands of
+        events into an unreadable wall of text."""
+        fields = " ".join(f"{k}={v!r}" for k, v in list(event.data.items())[:6])
+        print(f"[{event.type}] {fields}".rstrip())
 
     # ── Workflow ───────────────────────────────────────────────────────────────
 

--- a/tests/interfaces/test_4383_events_replay_unhandled_fallback.py
+++ b/tests/interfaces/test_4383_events_replay_unhandled_fallback.py
@@ -1,0 +1,136 @@
+"""Tier 2: #4383 — `reyn events` replay no longer silently drops an event
+type ConsoleLogger has no dedicated `on_<type>` handler for.
+
+Owner's real-environment report: `reyn events --filter compaction_shrink_recovered`
+matched 21 events, printed 0 lines, and the summary line ("21 events
+replayed") read as success — nothing distinguished "found and shown" from
+"found and dropped". Root cause: `ConsoleLogger.__call__` (reporters/__init__.py)
+only has dedicated renderers for 11 of the 211 declared audit-event kinds;
+everything else fell through `getattr(self, f"on_{event.type}", None)`
+returning `None` and was silently skipped.
+
+Drives the REAL `run_replay` CLI entry point against a REAL JSONL file (not
+a hand-called ConsoleLogger unit test) — the bug was in the combination
+(replay counts everything, ConsoleLogger renders almost nothing, the
+summary conflates the two), which only a real end-to-end pass through
+`run_replay` actually exercises.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def _write_events(path: Path, events: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for e in events:
+            f.write(json.dumps(e) + "\n")
+
+
+def _replay_args(target: Path, *, filter_types: "list[str] | None" = None) -> argparse.Namespace:
+    return argparse.Namespace(
+        target=str(target),
+        filter_types=filter_types or [],
+        skip_types=[],
+        conversation=False,
+        since=None,
+        until=None,
+    )
+
+
+def test_an_unhandled_event_type_now_renders_a_fallback_line(tmp_path, capsys) -> None:
+    """Tier 2: #4383 — `tool_called` (the issue's own reproduction case,
+    no dedicated ConsoleLogger.on_tool_called) prints at least one line on
+    replay, not zero. RED before the fix: ConsoleLogger silently dropped
+    it, and the old summary ("103 events replayed") gave no sign anything
+    had been skipped."""
+    from reyn.interfaces.cli.commands.events import run_replay
+
+    events_file = tmp_path / "events.jsonl"
+    _write_events(events_file, [
+        {"type": "tool_called", "data": {"tool": "shell", "call_id": "abc123"}},
+    ])
+
+    run_replay(_replay_args(events_file))
+    out = capsys.readouterr().out
+
+    assert "tool_called" in out, (
+        "an event type with no dedicated ConsoleLogger handler must still "
+        "produce a visible line — it must not be silently dropped"
+    )
+
+
+def test_matched_and_rendered_counts_are_reported_separately(tmp_path, capsys) -> None:
+    """Tier 2: #4383 — the summary line distinguishes how many events
+    MATCHED the filter from how many actually RENDERED a line, so a future
+    silent-drop regression is visible as matched != rendered rather than
+    reading as an ordinary success count (the owner's own misread:
+    "21 events replayed" looked like 21 shown, not 21 found-and-discarded)."""
+    from reyn.interfaces.cli.commands.events import run_replay
+
+    events_file = tmp_path / "events.jsonl"
+    _write_events(events_file, [
+        {"type": "tool_called", "data": {"tool": "shell"}},
+        {"type": "tool_called", "data": {"tool": "file_read"}},
+        {"type": "tool_called", "data": {"tool": "grep"}},
+    ])
+
+    run_replay(_replay_args(events_file))
+    out = capsys.readouterr().out
+
+    assert "3 matched" in out
+    assert "3 rendered" in out, (
+        "with the fallback renderer in place, every matched event should "
+        "also render — this pins the fix, not just the wording"
+    )
+
+
+def test_a_handler_backed_event_type_still_renders_through_its_own_handler(tmp_path, capsys) -> None:
+    """Tier 2: #4383 accept-side — an event type WITH a dedicated
+    ConsoleLogger handler (shell_started, one of the 11) renders through
+    its own specific formatting, not the generic fallback. The fallback
+    must only catch the ~200 handler-less kinds, not shadow the 11 real
+    renderers."""
+    from reyn.interfaces.cli.commands.events import run_replay
+
+    events_file = tmp_path / "events.jsonl"
+    _write_events(events_file, [
+        {"type": "shell_started", "data": {"cmd": "ls -la", "timeout": 30}},
+    ])
+
+    run_replay(_replay_args(events_file))
+    out = capsys.readouterr().out
+
+    # The dedicated on_shell_started format ("[shell] <cmd> (timeout=...)"),
+    # not the generic fallback's "[shell_started] cmd='ls -la' ..." shape.
+    assert "[shell] ls -la" in out
+    assert "(timeout=30s)" in out
+    assert "[shell_started]" not in out, (
+        "a handler-backed event type must render via ITS OWN handler, "
+        "not fall through to the generic unhandled-type fallback"
+    )
+
+
+def test_the_fallback_line_bounds_the_number_of_fields_shown(tmp_path, capsys) -> None:
+    """Tier 2: #4383 — the fallback renders a BOUNDED number of top-level
+    fields, not a full dump of an arbitrarily wide payload. Without a
+    bound, one event carrying a large embedded structure could turn a
+    routine scan of thousands of events into an unreadable wall of text
+    (the same class of concern this whole issue is about — a viewing tool
+    that technically shows data but not usably)."""
+    from reyn.interfaces.cli.commands.events import run_replay
+
+    events_file = tmp_path / "events.jsonl"
+    wide_data = {f"field_{i}": f"value_{i}" for i in range(20)}
+    _write_events(events_file, [{"type": "tool_called", "data": wide_data}])
+
+    run_replay(_replay_args(events_file))
+    out = capsys.readouterr().out
+
+    shown = sum(1 for i in range(20) if f"field_{i}=" in out)
+    assert 0 < shown <= 6, (
+        f"expected a bounded number of fields (1-6), got {shown} — the "
+        "fallback must not dump an arbitrarily wide payload verbatim"
+    )


### PR DESCRIPTION
**[tui-coder]** — part of #4383

## What

Owner's real-environment report, **directly blocking their diagnosis of #4381**: `reyn events --filter compaction_shrink_recovered` matched 21 events, printed 0 lines. The summary line ("21 events replayed") gave no indication anything had been dropped — the owner read it as "the filter isn't working"; lead-coder nearly read it as "no such events." Both are misreads of the same underlying defect.

**Root cause**: `ConsoleLogger.__call__` (`reporters/__init__.py`) only has a dedicated `on_<type>` renderer for 11 of the 211 declared audit-event kinds (5.2%). Everything else fell through `getattr(self, f"on_{event.type}", None)` returning `None` and was silently skipped — found, counted, never shown.

## Fix (both parts of lead-coder's proposal)

1. **Generic one-line fallback** (`_render_unhandled`) for any event type without a dedicated handler: the kind plus its first 6 top-level data fields as `key=value`. Bounded so one event carrying a wide payload can't turn a scan of thousands of events into an unreadable wall of text. The 11 existing handlers are untouched — the fallback only catches what they don't.
2. **`__call__` now returns whether it actually printed something** (captured via a stdout redirect around the handler call, not a change to any of the 11 handlers' own bodies), so `run_replay` reports **`"N matched, M rendered"`** instead of a single conflated count. A future silent-drop regression now shows up as `matched != rendered` rather than reading as an ordinary success number.

## Live demonstration (owner's exact reported case)

```
$ reyn events events.jsonl --filter compaction_shrink_recovered
[compaction_shrink_recovered] consecutive=3 recovered_tokens=500

(1 matched, 1 rendered from events.jsonl)
```

Previously produced nothing but `(1 events replayed from events.jsonl)`.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_4383_events_replay_unhandled_fallback.py` — 4/4 OK, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py` on both changed `src/` files — OK
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] Falsify-verified: reverted to the original getattr-returns-None-drops behavior, confirmed 3 of 4 new tests failed with the exact predicted shape (no fallback line, "0 rendered", accept-side test correctly unaffected), restored, confirmed green
- [x] Live-demonstrated the owner's exact reported case (see above)
- [x] `pytest tests/interfaces tests/core/test_pipeline_call_primitive.py tests/core/test_pipeline_fold_primitive.py tests/dev/test_fp0036_e2e_full_pipeline.py` — 1650 passed, 3 skipped (pre-existing optional-extra), 0 failed
- [ ] Visual — n/a, CLI-only output change

Held for lead-coder's TESTS-READY / explicit merge approval, not self-merging. Given this directly blocks the owner's active diagnosis of #4381, flagging for priority review.
