### PR TITLE
fix(4381): classify HTTP 413 by status code, surface the real cause

### DIFF
--- a/docs/reference/runtime/pipeline-dsl.md
+++ b/docs/reference/runtime/pipeline-dsl.md
@@ -452,8 +452,11 @@ IS the reply. For an autonomous run-once agent step, it meant the step ended
 mid-edit with no diagnosable trace: no logged LLM response, `req=resp+1`,
 nothing to point a fix at. The fix logs the full traceback (`logger.exception`)
 AND emits a `router_loop_terminated_by_exception` audit event (`chain_id`,
-`error_type`, `repr(exc)[:500]`) — both kept unconditionally, on top of the
-(unchanged) classified outbox summary.
+`error_type`, `repr(exc)[:500]`, and — #4381 stage 1 — `cause`, the deepest
+`__cause__` in the exception chain's type name, so reyn's own wrapper type
+(e.g. `ContextOverflowError`) never hides what actually happened underneath
+it) — both kept unconditionally, on top of the (unchanged) classified outbox
+summary.
 
 **#2732 — the classified-summary path silently produced a successful-looking
 empty answer for agent steps.** The catch-all `except Exception` in

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -260,6 +260,23 @@ def _ts_iso_to_epoch(ts: str | None) -> float | None:
         return None
 
 
+def _deepest_cause(exc: BaseException) -> "BaseException | None":
+    """#4381 stage 1 (B): the DEEPEST ``__cause__`` in *exc*'s chain, or
+    ``None`` if *exc* has no ``__cause__`` at all (it IS the root — the
+    common case for most exceptions, which never wrap another).
+
+    A pure helper (no session state) so the "reyn's own wrapper type is
+    not what actually happened" gap can be tested directly, without
+    driving a full turn through ``_run_router_loop``'s except block. See
+    that call site's own comment for the concrete motivating case
+    (``ContextOverflowError`` wrapping the real ``APIError`` that never
+    reached ``reyn.log``)."""
+    root = exc
+    while root.__cause__ is not None:
+        root = root.__cause__
+    return root if root is not exc else None
+
+
 def _extract_tool_call_records(
     messages: "list[ChatMessage]",
 ) -> list[tuple[str, float]]:
@@ -6132,9 +6149,25 @@ class Session:
             # trace (req=resp+1, no logged response). Surface the FULL exception
             # (stderr traceback + a P6 event) so the root error is primary-evidence
             # for the fix; the classified summary still goes to the outbox unchanged.
+            #
+            # #4381 stage 1 (B): reyn's own retry_loop re-wraps a real failure into
+            # ContextOverflowError/UnrecoveredError at each escalation (router_loop_
+            # driver.py's `raise X(...) from original_exc` chain) — so this except's
+            # own `exc` is often reyn's OWN wrapper type, not what actually happened
+            # (owner's real-environment observation: reyn.log showed only
+            # `ContextOverflowError`, while the audit trail's `compaction_shrink_
+            # recovered.cause` — a SEPARATE event, from a SEPARATE code path — held
+            # the real answer, `APIError`, the whole time). Walking `__cause__` to
+            # the end of the chain (every wrap site in that file uses `from`, so the
+            # chain is always intact) and naming it explicitly here means an operator
+            # reading EITHER `reyn.log` or this ONE audit event's own `cause` field
+            # gets the real answer without needing to know a second event exists.
+            _root_cause = _deepest_cause(exc)
+            _cause_name = type(_root_cause).__name__ if _root_cause is not None else None
             logger.exception(
-                "router loop terminated by unhandled exception (chain_id=%s)",
+                "router loop terminated by unhandled exception (chain_id=%s)%s",
                 chain_id,
+                f" — cause: {_cause_name}: {_root_cause}" if _root_cause is not None else "",
             )
             try:
                 self._audit_events.emit(
@@ -6142,6 +6175,7 @@ class Session:
                     chain_id=chain_id,
                     error_type=type(exc).__name__,
                     error=repr(exc)[:500],
+                    cause=_cause_name,
                 )
             except Exception:  # noqa: BLE001 — instrumentation must never break the path
                 pass

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -724,7 +724,31 @@ def is_context_overflow_error(exc: BaseException) -> bool:
     ``services.compaction.engine``'s own recover-classification, #3783
     stage 3, a deliberately separate question living in this same module
     but not this function).
+
+    #4381 stage 1: HTTP 413 (Request Entity Too Large — a request-BODY-byte
+    limit, a different dimension entirely from the token-count limit
+    ``ContextWindowExceededError`` represents) used to reach this predicate
+    ONLY through the ``"too large"`` keyword fallback — the exact
+    "stronger signal available, but not used" gap this function's own
+    docstring already warns against. litellm/openai exceptions carry a
+    real ``status_code`` attribute (``openai.APIStatusError.status_code``,
+    set from the underlying ``httpx.Response`` — a status LiteLLM's proxy
+    cannot flatten away the way it can flatten a typed exception class),
+    checked here as the SAME kind of definitive, type-adjacent signal the
+    ``ContextWindowExceededError`` isinstance check above already is.
+    Classification for 413 is UNCHANGED by this (it already matched via
+    the keyword) — recovery behaviour for it is #4381's later stages
+    (deliberately untouched here); what changes is that the match no
+    longer depends on the exception's message text containing "too large"
+    at all, so a differently-worded 413 (a different provider/proxy, a
+    non-English locale) is now caught too.
     """
+    # #4381 stage 1: checked BEFORE the litellm import below (and so
+    # regardless of whether that import succeeds) — a plain attribute
+    # read needs no litellm dependency at all, and this signal must not
+    # be weaker than the fallback it is meant to replace.
+    if getattr(exc, "status_code", None) == 413:
+        return True
     try:
         from reyn.llm.litellm_bootstrap import ensure_litellm_ready
         ensure_litellm_ready()

--- a/tests/core/test_4381_stage1_overflow_classification.py
+++ b/tests/core/test_4381_stage1_overflow_classification.py
@@ -1,0 +1,112 @@
+"""Tier 2: #4381 stage 1 — classification and reporting fixes only, no
+recovery-behaviour change (owner ruling: A/B are dependency-free and
+independent of the layer/tool-contract design questions still awaiting
+architect ruling for later stages).
+
+A. is_context_overflow_error (services/compaction/engine.py) checks HTTP
+413 via a real status_code attribute BEFORE falling back to the
+"too large" keyword match — the same "type before string" principle the
+function's own docstring already states for ContextWindowExceededError,
+now applied to 413 too. Root cause of the original bug (owner's real-
+environment observation): a 413 ("Request Entity Too Large" — a request-
+BODY-byte limit, not the token-count limit the retry_loop's shrink logic
+actually addresses) only matched via the loose keyword fallback, making
+classification depend entirely on the exact wording of a provider's error
+message.
+
+B. Session._run_router_loop's top-level exception handler now surfaces
+the DEEPEST __cause__ in the exception chain — both in the reyn.log line
+and as a `cause` field on the router_loop_terminated_by_exception audit
+event — so an operator sees what actually happened (e.g. APIError) rather
+than only reyn's own wrapper type (ContextOverflowError), which is what
+owner's real-environment reyn.log showed before this fix.
+"""
+from __future__ import annotations
+
+from reyn.runtime.session import _deepest_cause
+from reyn.services.compaction.engine import is_context_overflow_error
+
+
+class _FakeStatusError(Exception):
+    """A minimal stand-in for openai.APIStatusError's own shape (a plain
+    `status_code` attribute set from the underlying HTTP response) —
+    deliberately NOT a litellm/openai exception subclass, so this test
+    exercises the ATTRIBUTE check on its own, independent of whichever
+    litellm exception hierarchy happens to be installed."""
+
+    def __init__(self, message: str, *, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def test_413_is_classified_via_status_code_with_no_overflow_wording() -> None:
+    """Tier 2: #4381 A — a 413 error whose MESSAGE contains none of
+    _CONTEXT_OVERFLOW_KEYWORDS is still classified as overflow, because
+    status_code is checked before the keyword fallback ever runs. Proves
+    the classification is no longer dependent on message wording at all."""
+    # Deliberately worded to avoid every _CONTEXT_OVERFLOW_KEYWORDS entry
+    # ("too large" included — a real 413 message often says exactly that,
+    # which is precisely why the OLD code accidentally classified it
+    # right; this test needs a message that could NOT have matched the
+    # keyword fallback, to isolate the new type-based path).
+    exc = _FakeStatusError("Upstream proxy rejected the request body", status_code=413)
+    from reyn.services.compaction.engine import _CONTEXT_OVERFLOW_KEYWORDS
+    assert not any(kw in exc.args[0].lower() for kw in _CONTEXT_OVERFLOW_KEYWORDS)
+
+    assert is_context_overflow_error(exc) is True
+
+
+def test_a_non_413_status_code_with_no_keywords_is_not_overflow() -> None:
+    """Tier 2: #4381 A accept-side — a differently-coded HTTP error (400,
+    not 413) with no overflow-shaped wording is NOT classified as
+    overflow. The 413 check must not become a blanket "any status_code
+    means overflow" — it targets exactly 413."""
+    exc = _FakeStatusError("Bad request", status_code=400)
+    assert is_context_overflow_error(exc) is False
+
+
+def test_413_classification_does_not_require_litellm_to_be_importable(monkeypatch) -> None:
+    """Tier 2: #4381 A — the status_code check must not depend on litellm
+    being importable (a plain attribute read needs no litellm dependency
+    at all); simulates litellm import failure and confirms 413 is still
+    caught."""
+    import reyn.services.compaction.engine as engine_mod
+
+    def _raise_import_error():
+        raise ImportError("simulated: litellm unavailable")
+
+    monkeypatch.setattr(
+        "reyn.llm.litellm_bootstrap.ensure_litellm_ready", _raise_import_error,
+    )
+    exc = _FakeStatusError("Request Entity Too Large", status_code=413)
+    assert engine_mod.is_context_overflow_error(exc) is True
+
+
+def test_deepest_cause_walks_a_multi_level_chain() -> None:
+    """Tier 2: #4381 B — _deepest_cause returns the ROOT of a chain, not
+    just the immediate __cause__, matching retry_loop's own multi-level
+    wrap-and-re-raise shape (CompactionOverflowError/ContextOverflowError
+    wrapping the original provider exception, then re-wrapped again by
+    router_loop_driver's own "Router context overflow after bounded
+    shrink" ContextOverflowError)."""
+    root = ValueError("Request Entity Too Large")
+    middle = RuntimeError("compaction overflow")
+    middle.__cause__ = root
+    outer = RuntimeError("router context overflow after bounded shrink")
+    outer.__cause__ = middle
+
+    result = _deepest_cause(outer)
+
+    assert result is root
+    assert type(result).__name__ == "ValueError"
+
+
+def test_deepest_cause_returns_none_when_there_is_no_cause() -> None:
+    """Tier 2: #4381 B accept-side — an exception that IS its own root
+    (no __cause__ at all — the common case for most exceptions) returns
+    None, not itself. The caller (Session._run_router_loop) uses this to
+    decide whether to print anything extra at all; returning the
+    exception itself here would make every plain exception look like it
+    has a "different" cause from itself."""
+    plain = ValueError("just a plain error, never wrapped")
+    assert _deepest_cause(plain) is None


### PR DESCRIPTION
**[tui-coder]** — part of #4381

Stage 1 of #4381 (lead-coder's explicit ordering) — **classification and reporting only, no recovery-behaviour change**. Items ④⑤ (which layer cuts a huge tool result, how to tell the LLM) and item 0 (retry-loop idempotency) remain owner/architect-pending and are deliberately untouched here.

## What

Owner's real-environment observation: `retry_loop` shrunk context 3 times (`iteration 0/1/2`) for the same underlying error and never recovered. `reyn.log` showed only `ContextOverflowError` — no way to see the actual cause without separately pulling the `compaction_shrink_recovered` audit event's own `cause` field.

**A.** `is_context_overflow_error` (`services/compaction/engine.py`) now checks a plain `status_code == 413` attribute **before** the litellm import and **before** the keyword fallback — the same "type before string" principle its own docstring already states for `litellm.ContextWindowExceededError`, now applied to HTTP 413 (a request-BODY-byte limit — a genuinely different dimension from the token-count limit the keyword match was built for). Classification for a real 413 is unchanged (it already matched via `"too large"`); what changes is the match no longer depends on the exception's message text at all, so a differently-worded 413 (different provider/proxy, non-English locale) is caught too. Checked outside the litellm `try`/`except` so it works even when litellm can't be imported.

**B.** `Session._run_router_loop`'s top-level exception handler now walks the `__cause__` chain to its root (every wrap-and-re-raise site in `retry_loop` already uses `raise ... from exc`, so the chain is always intact) and surfaces that root's type name both in the `reyn.log` line and as a new `cause` field on the `router_loop_terminated_by_exception` audit event. Extracted to a pure helper (`_deepest_cause`) so this is directly testable without driving a full turn through the router loop.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/core/test_4381_stage1_overflow_classification.py` — 5/5 OK, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py` on both changed `src/` files — OK
- [x] `python scripts/mypy_ratchet.py` — OK, no new findings
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] Falsify-verified both: reverted the `status_code` check → confirmed the 413-classification test failed with the predicted shape → restored; reverted `_deepest_cause` to a no-op → confirmed the chain-walking test failed with the predicted shape → restored. Both green.
- [x] `pytest tests/llm/test_chat_compaction_engine_11axis.py tests/core/test_3783_stage3_invert_default_to_recover.py tests/core/test_4381_stage1_overflow_classification.py tests/core/test_session_lifecycle_events_1800.py tests/runtime` — 1732 passed, 1 skipped, 0 failed (1 pre-existing environment-local `.pth`-shadowing failure unrelated to this change, already reported/confirmed by lead-coder independently)
- [ ] Visual — n/a, no UI surface changes

Held for lead-coder's TESTS-READY / explicit merge approval, not self-merging.



---

## Reviewer's blocking item (lead-coder)

- [ ] 🔴 **`docs/reference/runtime/pipeline-dsl.md:454` の field 列挙に `cause` を足す。** 同 doc は `router_loop_terminated_by_exception` の field を **`chain_id` / `error_type` / `repr(exc)[:500]` と列挙**しており、この PR が `cause` を足すことで**着地の瞬間に不完全**になります（CLAUDE.md hard rule: 同じ PR で直す）。★`events.md:183` の方は**種別名の列挙のみ**なので影響ありません。詳細はレビューコメントに。
