### PR TITLE
docs(#4389): section_token_caps is an LLM hint, not an enforced bound

### DIFF
--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -356,9 +356,24 @@ def estimate_tokens_for_any_turn(
 
 @dataclass
 class HistoryChunkToCompact:
-    """Input to the compaction engine."""
+    """Input to the compaction engine.
+
+    #4389: ``section_token_caps`` is a HINT to the LLM only — it is
+    serialised straight into the compaction prompt's user content (see
+    ``CompactionEngine.compact``) so the model can use it as *guidance* on
+    how much room each section has. It does NOT bound anything
+    deterministically, and a caller passing a tighter value here has no
+    effect on what actually gets trimmed. The value that IS enforced,
+    deterministically, is ``CompactionEngine._budgets.body_budget`` —
+    computed once at ``CompactionEngine.__init__`` from ``CompactionConfig``
+    (see ``compute_budgets``/``ComputedBudgets.section_caps``) and applied to
+    ``topic_arc`` via the T2 (LLM re-summarize) / T3 (``hard_truncate_summary``)
+    passes in ``compact``, independent of whatever this field says on a given
+    call. Confirmed live (real LLM): setting ``topic_arc`` here to ~40 tokens
+    had zero effect on the actual trim.
+    """
     new_turns: list[dict]                          # [{role, text, seq, ...}]
-    section_token_caps: dict                       # {topic_arc, decisions, ...}
+    section_token_caps: dict                       # {topic_arc, decisions, ...} — LLM hint only, see docstring above
     previous_summary: dict | None = None           # prior ChatSummary or None
 
 


### PR DESCRIPTION
**[tui-coder]** — #4389 ①: doc-only fix.

`HistoryChunkToCompact.section_token_caps` is serialised straight into the compaction prompt's user content as **guidance to the LLM only**. The value actually **enforced deterministically** is `CompactionEngine._budgets.body_budget`, computed once at `__init__` from `CompactionConfig` — independent of whatever `section_token_caps` a given call passes.

Confirmed live with a real LLM (gemini/gemini-2.5-flash-lite) as part of the owner-requested compaction summary-quality verification that produced #4389: tightening `topic_arc`'s cap to ~40 tokens on a single call had **zero effect** on what was actually trimmed.

This PR only adds the docstring clarifying the distinction (no behavior change). #4389 ② (renaming `section_token_caps` → something like `section_token_hints`) is explicitly deferred per the issue — renaming ripples to call sites and needs separate judgment.

part of #4389

## Test plan
- [x] `ruff check src/reyn/services/compaction/engine.py` — clean
- [x] `python scripts/verify_module_docstrings.py src/reyn/services/compaction/engine.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (211/215 baselined, unaffected)
- [x] Scoped pytest (`tests/llm/test_chat_compaction_engine_11axis.py`, `tests/llm/test_compaction_resolver_aware_1172.py`, `tests/core/test_resummarize_3tier_271.py`) — 43 passed
- [x] No test changes in this PR (docstring only) — no falsify-verify needed
- [ ] Visual — n/a (no UI surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)