### PR TITLE
fix(4391): reyn init's generated config fails its own validate

### DIFF
--- a/src/reyn/interfaces/cli/templates.py
+++ b/src/reyn/interfaces/cli/templates.py
@@ -5,15 +5,18 @@ REYN_YAML_TEMPLATE = """\
 # Reyn project configuration — commit this file.
 # Local overrides belong in reyn.local.yaml (gitignored) — never commit secrets here.
 
-# Default model class when --model is not specified.
-model: standard
+# LLM model selection (#4174 T3: model / models live under llm.*, not
+# top-level).
+llm:
+  # Default model class when --model is not specified.
+  model: standard
 
-# Model class → LiteLLM model string.
-# Three standard tiers. Edit to match your provider.
-models:
-  light:    openai/gpt-4o-mini
-  standard: openai/gpt-4o
-  strong:   openai/gpt-4o
+  # Model class → LiteLLM model string.
+  # Three standard tiers. Edit to match your provider.
+  models:
+    light:    openai/gpt-4o-mini
+    standard: openai/gpt-4o
+    strong:   openai/gpt-4o
 
 # output_language: en          # en | ja | zh | ...
 
@@ -95,17 +98,22 @@ permissions:
 REYN_LOCAL_CONFIG_TEMPLATE = """\
 # Local environment overrides — gitignored, never commit.
 
-# LiteLLM proxy base URL (omit if calling providers directly)
-# api_base: http://localhost:4000
-
 # API keys must be set as environment variables, not here — e.g.:
 #   export OPENAI_API_KEY=sk-...
 # litellm resolves your provider's own variable automatically; see
 # https://docs.litellm.ai/docs/providers for the name yours expects.
 
-# Override model mappings for your local setup (optional)
-# models:
-#   light:    openai/gemini-2.5-flash-lite
-#   standard: openai/gemini-2.5-flash-lite
-#   strong:   openai/gemini-2.5-flash-lite
+# LLM model selection overrides (#4174 T3: model / models / api_base live
+# under llm.*, not top-level). Uncomment the fields you want — both live
+# under the same `llm:` key, so uncomment this header once.
+
+# llm:
+#   # LiteLLM proxy base URL (omit if calling providers directly)
+#   api_base: http://localhost:4000
+#
+#   # Override model mappings for your local setup (optional)
+#   models:
+#     light:    openai/gemini-2.5-flash-lite
+#     standard: openai/gemini-2.5-flash-lite
+#     strong:   openai/gemini-2.5-flash-lite
 """

--- a/tests/interfaces/test_4391_init_template_passes_validate.py
+++ b/tests/interfaces/test_4391_init_template_passes_validate.py
@@ -15,14 +15,21 @@ unrecognized keys become 3 the instant `api_base:` is activated).
 file — the generator's own output had never been run through its own
 validator. This closes that gap for both templates, including the
 commented-out block, not just what a static read of the template can see.
+
+Asserts the structured result of ``unknown_config_keys`` directly, not
+``_validate()``'s printed message — the earlier draft asserted on the
+display string, which is a Tier-4 exact-formatting pin (a punctuation
+edit to that string would fail all three tests for a reason unrelated to
+#4391's actual defect). ``_validate()`` is still called on the CLI path so
+the test also exercises the real command, but the pass/fail decision
+lives on the same structured result the printed message is itself derived
+from (lead-coder review, #4392).
 """
 from __future__ import annotations
 
 from pathlib import Path
 
 import pytest
-
-_CLEAN_VALIDATE_MSG = "No unknown, renamed, or disabled-by-dependency config keys found."
 
 
 @pytest.fixture()
@@ -61,43 +68,48 @@ def _uncomment_last_paragraph(template: str) -> str:
     return "\n".join(lines)
 
 
-def test_generated_reyn_yaml_passes_validate_unedited(project, capsys):
+def _assert_generated_config_is_clean(project: Path) -> None:
+    """Run the real `_validate()` (CLI path, still exercised) and then
+    assert on the SAME structured result its own report is derived from —
+    not the printed message. `build_policy_tier_config` re-reads whatever
+    was just written to *project*, the same construction `_validate()` and
+    `load_config`'s own startup warning both use."""
+    from reyn.config.config_schema import unknown_config_keys
+    from reyn.config.loader import build_policy_tier_config
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _validate()
+    assert unknown_config_keys(build_policy_tier_config(project)) == {}
+
+
+def test_generated_reyn_yaml_passes_validate_unedited(project):
     """Tier 2: `reyn init`'s `reyn.yaml` output, byte-for-byte, is what a
     brand-new project has — it must validate clean with zero edits."""
-    from reyn.interfaces.cli.commands.config import _validate
     from reyn.interfaces.cli.templates import REYN_YAML_TEMPLATE
 
     (project / "reyn.yaml").write_text(REYN_YAML_TEMPLATE, encoding="utf-8")
-    _validate()
-    out = capsys.readouterr().out
-    assert _CLEAN_VALIDATE_MSG in out
+    _assert_generated_config_is_clean(project)
 
 
-def test_generated_reyn_local_yaml_example_passes_validate_as_shipped(project, capsys):
+def test_generated_reyn_local_yaml_example_passes_validate_as_shipped(project):
     """Tier 2: `REYN_LOCAL_CONFIG_TEMPLATE` as `reyn init` writes it
     (entirely commented out) contributes nothing active — validating it
     unedited must stay clean, same as an absent file."""
-    from reyn.interfaces.cli.commands.config import _validate
     from reyn.interfaces.cli.templates import REYN_LOCAL_CONFIG_TEMPLATE
 
     (project / "reyn.local.yaml").write_text(REYN_LOCAL_CONFIG_TEMPLATE, encoding="utf-8")
-    _validate()
-    out = capsys.readouterr().out
-    assert _CLEAN_VALIDATE_MSG in out
+    _assert_generated_config_is_clean(project)
 
 
-def test_generated_reyn_local_yaml_example_passes_validate_once_activated(project, capsys):
+def test_generated_reyn_local_yaml_example_passes_validate_once_activated(project):
     """Tier 2: #4391's real defect — a stale key hidden inside a comment
     block is invisible to every unknown-key walk until an operator
     uncomments it. This activates the block exactly as an operator would
     (uncomment, nothing else) and validates that result, not the raw
     (still-commented) template `_passes_validate_as_shipped` above
     already covers."""
-    from reyn.interfaces.cli.commands.config import _validate
     from reyn.interfaces.cli.templates import REYN_LOCAL_CONFIG_TEMPLATE
 
     activated = _uncomment_last_paragraph(REYN_LOCAL_CONFIG_TEMPLATE)
     (project / "reyn.local.yaml").write_text(activated, encoding="utf-8")
-    _validate()
-    out = capsys.readouterr().out
-    assert _CLEAN_VALIDATE_MSG in out
+    _assert_generated_config_is_clean(project)

--- a/tests/interfaces/test_4391_init_template_passes_validate.py
+++ b/tests/interfaces/test_4391_init_template_passes_validate.py
@@ -1,0 +1,103 @@
+"""Tier 2: the config `reyn init` generates passes `reyn config validate`
+clean, including the fields that only reach validate once a user activates
+them (#4391).
+
+`reyn init`'s generated `reyn.yaml`, un-edited, failed `reyn config
+validate` — the template had never migrated past the pre-#4174-T3
+top-level `model:`/`models:` shape. `REYN_LOCAL_CONFIG_TEMPLATE`'s
+`api_base:`/`models:` example was additionally wrong INSIDE a comment
+block, so no `unknown_config_keys` walk (validate's own, or the startup
+warning's) ever saw it — it only bit an operator the moment they
+uncommented it to actually use a proxy (#4391's own reproduction: 2
+unrecognized keys become 3 the instant `api_base:` is activated).
+
+`git grep -l REYN_YAML_TEMPLATE -- tests/` returned nothing before this
+file — the generator's own output had never been run through its own
+validator. This closes that gap for both templates, including the
+commented-out block, not just what a static read of the template can see.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_CLEAN_VALIDATE_MSG = "No unknown, renamed, or disabled-by-dependency config keys found."
+
+
+@pytest.fixture()
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+    monkeypatch.setattr(
+        "reyn.config._find_project_root", lambda _cwd: tmp_path,
+    )
+    monkeypatch.setattr(
+        "reyn.config.loader._find_project_root", lambda _cwd: tmp_path,
+    )
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _uncomment_last_paragraph(template: str) -> str:
+    """Strip the `# ` (or bare `#`) prefix from every line of the LAST
+    blank-line-delimited paragraph in *template* — the commented-out
+    example YAML block `REYN_LOCAL_CONFIG_TEMPLATE` ships, isolated from
+    the prose paragraphs above it. Mirrors exactly what an operator does
+    by hand: uncomment the block they want to use, leave the rest."""
+    paragraphs = template.split("\n\n")
+    block = paragraphs[-1]
+    lines = []
+    for line in block.splitlines():
+        stripped = line.lstrip()
+        assert stripped.startswith("#"), (
+            f"expected the last paragraph to be all comment lines, got: {line!r}"
+        )
+        rest = stripped[1:]
+        if rest.startswith(" "):
+            rest = rest[1:]
+        lines.append(rest)
+    return "\n".join(lines)
+
+
+def test_generated_reyn_yaml_passes_validate_unedited(project, capsys):
+    """Tier 2: `reyn init`'s `reyn.yaml` output, byte-for-byte, is what a
+    brand-new project has — it must validate clean with zero edits."""
+    from reyn.interfaces.cli.commands.config import _validate
+    from reyn.interfaces.cli.templates import REYN_YAML_TEMPLATE
+
+    (project / "reyn.yaml").write_text(REYN_YAML_TEMPLATE, encoding="utf-8")
+    _validate()
+    out = capsys.readouterr().out
+    assert _CLEAN_VALIDATE_MSG in out
+
+
+def test_generated_reyn_local_yaml_example_passes_validate_as_shipped(project, capsys):
+    """Tier 2: `REYN_LOCAL_CONFIG_TEMPLATE` as `reyn init` writes it
+    (entirely commented out) contributes nothing active — validating it
+    unedited must stay clean, same as an absent file."""
+    from reyn.interfaces.cli.commands.config import _validate
+    from reyn.interfaces.cli.templates import REYN_LOCAL_CONFIG_TEMPLATE
+
+    (project / "reyn.local.yaml").write_text(REYN_LOCAL_CONFIG_TEMPLATE, encoding="utf-8")
+    _validate()
+    out = capsys.readouterr().out
+    assert _CLEAN_VALIDATE_MSG in out
+
+
+def test_generated_reyn_local_yaml_example_passes_validate_once_activated(project, capsys):
+    """Tier 2: #4391's real defect — a stale key hidden inside a comment
+    block is invisible to every unknown-key walk until an operator
+    uncomments it. This activates the block exactly as an operator would
+    (uncomment, nothing else) and validates that result, not the raw
+    (still-commented) template `_passes_validate_as_shipped` above
+    already covers."""
+    from reyn.interfaces.cli.commands.config import _validate
+    from reyn.interfaces.cli.templates import REYN_LOCAL_CONFIG_TEMPLATE
+
+    activated = _uncomment_last_paragraph(REYN_LOCAL_CONFIG_TEMPLATE)
+    (project / "reyn.local.yaml").write_text(activated, encoding="utf-8")
+    _validate()
+    out = capsys.readouterr().out
+    assert _CLEAN_VALIDATE_MSG in out


### PR DESCRIPTION
**[docs-maintainer]** — part of #4391 (dispatched by lead-coder; owner-reported, lead-coder reproduced).

## What

`reyn init` in a fresh directory generates a `reyn.yaml` that `reyn config validate` immediately rejects, un-edited — 2 unrecognized top-level keys (`model`/`models`, pre-#4174-T3 shape). `REYN_LOCAL_CONFIG_TEMPLATE`'s commented-out `api_base:`/`models:` example carried the identical stale shape, invisible to every unknown-key walk while commented — it only bites an operator the instant they uncomment it to actually use a proxy (lead-coder's own reproduction: unrecognized count goes 2 → 3 the moment `api_base:` is activated).

## Root cause (why this survived 4 config-sweep passes)

`src/reyn/interfaces/cli/templates.py` was never migrated past the pre-#4174-T3 top-level shape, and nothing structurally could have caught it: `git grep -l REYN_YAML_TEMPLATE -- tests/` returns zero files before this PR — the generator's own output had never been run through its own validator. Same family as #4373 (`.example`'s stale reference survived because nothing checked the example against the schema) — that one was the reference-doc side, this is the generator side.

## Changes

1. **`REYN_YAML_TEMPLATE`**: `model:`/`models:` moved under `llm:`.
2. **`REYN_LOCAL_CONFIG_TEMPLATE`**: `api_base:`/`models:` moved under a commented `llm:` block — both fields share one `llm:` key, so uncommenting each independently as two separate blocks would otherwise produce two colliding top-level `llm:` keys (a YAML parser keeps only the last one, silently dropping the first). The block is now its own blank-line-delimited paragraph, separated from the prose explanation above it — this is also what makes the new test's "uncomment exactly what an operator would" step well-defined rather than a blind whole-file transform (a blind strip-every-`#` of the WHOLE template breaks on the prose paragraphs, which aren't valid YAML on their own — verified empirically before writing the test, not assumed).
3. **New test** (`tests/interfaces/test_4391_init_template_passes_validate.py`, Tier 2, 3 cases):
   - `reyn.yaml` as generated → clean validate.
   - `reyn.local.yaml.example` as generated (fully commented) → clean validate (trivial but a real regression guard).
   - `reyn.local.yaml.example`'s commented `llm:` block, uncommented exactly as an operator would (nothing else touched) → clean validate. **This is the case that actually closes the "only bites the activator" gap** — the as-shipped case alone passes trivially since nothing in a fully-commented file is active.

Per lead-coder's six-question answers in the issue: no key names in any assert (the expected value is the clean-report message, not a transcription of the schema — confirmed I didn't write `"llm.model"` or similar into any assertion).

No migration mechanism added — unreleased product, #4372 already confirmed zero external adopters of the affected surface.

## Verification

- `ruff check` — clean.
- `python scripts/test_tier_audit.py --strict tests/interfaces/test_4391_init_template_passes_validate.py` — 3/3 OK, 0 Tier-4.
- `python scripts/verify_module_docstrings.py src/reyn/interfaces/cli/templates.py` — OK.
- `python scripts/mypy_ratchet.py` — OK, no new findings.
- `python scripts/check_tests_path_literal_reference.py` — OK.
- `rm -rf site && mkdocs build --strict` — clean.
- `pytest tests/interfaces/test_config_validate_migrate_command_4174.py tests/interfaces/test_4391_init_template_passes_validate.py` — 21 passed.

## Test plan

- [x] Reproduced the original defect first (confirmed `reyn.yaml` as generated fails validate before the fix).
- [x] Both templates fixed to the current `llm.*` schema shape.
- [x] Structural test added covering the "hidden in a comment" case, not just the visible one.
- [x] No key names in any assert.
- [x] Full gate suite clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**[lead-coder]** — レビュアの blocking 項目（本文に追記。著者が対応後にチェックしてください）

- [x] 🔴 **期待値を表示文字列から構造化された結果へ移す（3 本とも）。** ← 対応済み（`unknown_config_keys(build_policy_tier_config(project)) == {}` へ移動、`_validate()` 呼び出しは維持）。 現状 `_CLEAN_VALIDATE_MSG` の substring 一致 ＝ **exact formatting の pin**（CLAUDE.md が Tier 4 として名指す形）で、**その文の句読点を 1 文字直すと 3 本とも赤**になり、赤の理由が「テンプレートが壊れた」ではなくなります。`_validate()` の中で同じ判断をしている `unknown_config_keys(build_policy_tier_config())` が構造化された面です（`_validate()` の呼び出し自体は残して構いません — assert の対象だけ移す）。

⚪ **これ以外は良い**（六問の詳細はレビューコメント参照）。**doc 追随は不要**と確認済 — `01-installation.md` / `reyn-yaml.md` は既に正しい `llm:` 形で、**doc が正しくコードが古い逆向きの drift** でした。

