### PR TITLE
perf(#4387): bound the per-turn untrusted-taint scan to the uncompacted tail

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2721,6 +2721,26 @@ class Session:
         (never latched at turn start), so a status-bar read is as of NOW; only the
         loaded profile is cached, and a profile file does not change mid-session.
 
+        #4387 Phase A: the scan this re-derivation runs is bounded to the
+        UNCOMPACTED tail (``seq > self._compaction_watermark()``, the same
+        bound ``_uncompacted_tool_call_records`` already uses), not all of
+        ``self.history``. ``metas_have_untrusted``'s own docstring already
+        promises "the until-compaction scope for free" from being handed
+        only "the live, un-compacted entries" — this call site was actually
+        violating that contract (it passed the FULL unfiltered history,
+        so real deployments never got the promised self-clear-on-compaction
+        at all, only an O(session-length) scan on every turn once
+        narrowing was opted into, #3501). Bounding to the watermark fixes
+        both: the freshness/self-clearing property this method's own tests
+        pin (``test_turn_context_denial_self_clears_when_the_taint_leaves_
+        the_context``) becomes what actually happens in a compacting
+        session, not just an unenforced docstring claim, and the re-scan on
+        every turn is now proportional to the uncompacted tail rather than
+        total session length. Entries with ``seq == 0`` (pre-#3704 legacy
+        rows with no assigned coordinate) are always included — never
+        excluded from a taint check just because they predate seq
+        tracking.
+
         #3501: OPT-IN. This returns ``None`` — no narrowing at all — unless the
         operator set ``safety.threat_scan.capability_narrowing`` to something other
         than ``off``. It is the SINGLE place the opt-in is read, so the live gate,
@@ -2737,7 +2757,9 @@ class Session:
         threat_scan = getattr(self._safety, "threat_scan", None)
         if threat_scan is None or not threat_scan.narrowing_engaged():
             return None
-        if not metas_have_untrusted(m.meta for m in self.history):
+        watermark = self._compaction_watermark()
+        active = (m for m in self.history if m.seq == 0 or m.seq > watermark)
+        if not metas_have_untrusted(m.meta for m in active):
             return None
         if self._untrusted_contextual_cache is None:
             root = self._perm.project_root if self._perm is not None else Path.cwd()
@@ -6285,6 +6307,16 @@ class Session:
                 return m
         return None
 
+    def _compaction_watermark(self) -> int:
+        """The latest summary's ``covers_through_seq`` (0 if none yet) — seqs
+        at or below this are considered compacted out. #4387 Phase A:
+        factored out of :meth:`_uncompacted_tool_call_records` so
+        :meth:`_ephemeral_contextual_for_turn` can bound its own scan the
+        same way, rather than duplicating the ``_latest_summary`` +
+        ``covers_through_seq`` lookup inline."""
+        latest = self._latest_summary()
+        return int((latest.meta or {}).get("covers_through_seq", 0)) if latest is not None else 0
+
     def _uncompacted_tool_call_records(self) -> list[tuple[str, float]]:
         """Return ``(action_name, ts_epoch)`` records from the
         portion of history that has NOT yet been folded into a
@@ -6293,15 +6325,9 @@ class Session:
         Used by RouterLoop to build the hot-list each turn without
         relying on a parallel per-call write log; the compacted table
         in :class:`~reyn.tools.action_usage_tracker.ActionUsageTracker`
-        already covers the older portion. The watermark is the latest
-        summary's ``covers_through_seq`` (= seqs at or below it are
-        considered compacted out).
+        already covers the older portion.
         """
-        latest = self._latest_summary()
-        watermark = (
-            int((latest.meta or {}).get("covers_through_seq", 0))
-            if latest is not None else 0
-        )
+        watermark = self._compaction_watermark()
         live = [m for m in self.history if m.seq > watermark]
         return _extract_tool_call_records(live)
 

--- a/tests/runtime/test_3380_tool_tab_ephemeral_narrowing.py
+++ b/tests/runtime/test_3380_tool_tab_ephemeral_narrowing.py
@@ -155,6 +155,53 @@ def test_turn_context_denial_self_clears_when_the_taint_leaves_the_context(
     assert _UNTRUSTED_DENIED_TOOL in _tools(cleared, "authorized")
 
 
+def test_narrowing_self_clears_when_a_real_compaction_covers_the_taint(
+    tmp_path,
+) -> None:
+    """Tier 2: #4387 Phase A — ``_ephemeral_contextual_for_turn`` bounds its
+    ``metas_have_untrusted`` scan to ``seq > self._compaction_watermark()``
+    instead of scanning all of ``self.history`` forever. Proven against a
+    REAL compaction watermark (a ``role="summary"`` entry appended via
+    ``_append_history`` with ``covers_through_seq`` at the tainted entry's
+    own seq — the exact shape ``CompactionController``'s
+    ``make_summary_message`` produces), not by physically removing the
+    entry from ``self.history`` the way
+    ``test_turn_context_denial_self_clears_when_the_taint_leaves_the_context``
+    above does. The tainted raw entry stays PRESENT in ``self.history``
+    throughout this test; only the watermark moves past its seq — so a
+    pre-fix scan (unbounded) would still see it and stay narrowed forever,
+    while the bounded scan correctly treats it as compacted out.
+    """
+    s = _session(tmp_path)
+    s._append_history(
+        ChatMessage(role="user", content="<<<EXTERNAL>>> hi", meta={"external_source": True})
+    )
+    tainted_seq = s.history[-1].seq
+    assert tainted_seq > 0, "a real _append_history call must assign a coordinate"
+    assert _UNTRUSTED_DENIED_TOOL in _tools(
+        s.capability_visibility_state(), "denied_by_turn_context"
+    ), "control arm: the taint must engage narrowing before any compaction"
+
+    s._append_history(
+        ChatMessage(
+            role="summary", content="summarised",
+            meta={"structured": {}, "covers_through_seq": tainted_seq},
+        )
+    )
+
+    cleared = s.capability_visibility_state()
+    assert not _tools(cleared, "denied_by_turn_context"), (
+        "a compaction watermark covering the tainted entry's seq must clear the "
+        "narrowing even though the raw entry is still physically present in "
+        "self.history"
+    )
+    assert _UNTRUSTED_DENIED_TOOL in _tools(cleared, "authorized")
+    assert any((m.meta or {}).get("external_source") for m in s.history), (
+        "sanity: the tainted entry is still physically present — the clearing "
+        "above is due to watermark bounding, not removal"
+    )
+
+
 def test_every_floored_tool_stays_denied_at_the_live_gate(tmp_path) -> None:
     """Tier 2: the ephemeral floor rejects EVERY name it floors at the live gate,
     not just the one the constant above happens to witness.


### PR DESCRIPTION
**[tui-coder]** — #4387 Phase A.

`Session._ephemeral_contextual_for_turn` re-derives capability narrowing from `self.history` on every turn (freshness by design — never latched at turn start). It scanned **all** of `self.history` unconditionally, forever — O(session-length) on every turn once #3501's opt-in narrowing is engaged, and one of the ≥6 full-scan consumers found while mapping #4387's actual goal (lazy-loading `history.jsonl` at startup): this scan alone would force a full read every turn, blocking that work.

**Beyond perf, a latent correctness bug**: `metas_have_untrusted`'s own docstring already promises 'the caller passes the live, un-compacted entries... gives the until-compaction scope for free' — but the call site violated that contract, passing the full unfiltered history. So the documented self-clear-on-compaction property never actually held in a real compacting session, only in tests that simulate it by directly removing entries from `self.history`.

**Fix**: bound the scan to `seq > self._compaction_watermark()` — the same `covers_through_seq`-derived bound `_uncompacted_tool_call_records` already uses, extracted into a small shared `_compaction_watermark()` helper. `seq == 0` (pre-#3704 legacy rows) always included. Still a live re-derivation, no new mutable state — preserves the freshness contract the existing sibling test pins, now correctly proportional to the uncompacted tail and now actually honoring the until-compaction scope its docstring always claimed.

**New test**, falsify-verified (RED without the fix, GREEN with it): `test_narrowing_self_clears_when_a_real_compaction_covers_the_taint` — proves the self-clear via a REAL compaction watermark (a `role=summary` entry with `covers_through_seq` at the tainted entry's seq), tainted raw entry still physically present in `self.history` throughout.

Phase B (the actual lazy history-load) is separate, tracked on #4387 — this PR only removes one of its blockers.

part of #4387

## Test plan
- [x] `ruff check src tests/runtime/test_3380_tool_tab_ephemeral_narrowing.py` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_3380_tool_tab_ephemeral_narrowing.py` — 8/8 OK, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (211/215 baselined)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] Falsify-verify: reverted `session.py`'s fix, confirmed the new test goes RED (real assertion failure, not a collection error); restored, confirmed GREEN
- [x] Scoped pytest — 87 passed (`test_1909_*`, `test_3501_*`, `test_untrusted_profile_1827_s4`, `test_3546_*`, `test_context_auto_1827_s4b`, `test_3380_*`, `test_chat_compaction_engine_11axis`)
- [ ] Visual — n/a (no UI surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)