### PR TITLE
perf(#4387): bound Session.load_history()'s startup read

### DIFF
--- a/src/reyn/runtime/history_tail_reader.py
+++ b/src/reyn/runtime/history_tail_reader.py
@@ -1,0 +1,147 @@
+"""#4387 Phase B ①: a bounded, reverse-seeking reader for ``history.jsonl``.
+
+``Session.load_history()`` used to read the WHOLE file forward, building a
+``ChatMessage`` for every line ever written — on a long-running session
+(owner's real environment: 500MB, #4387) that means every restart re-loads
+the entire conversation into memory, which never shrinks even though
+compaction keeps what's SENT to the LLM small (compaction shrinks
+``build_history``'s output, never ``self.history`` or the file it's read
+from).
+
+This module reads backward from EOF instead, stopping once a
+``role="summary"`` line has been seen AND at least ``min_lines`` complete
+lines have been collected (a reasonable startup scrollback floor even when
+the latest compaction happened close to EOF — mirrors ``#3476④``'s own
+``_HYDRATE_PAGE_FRAMES=200``). Reading PAST ``min_lines`` to reach a summary
+that's further back is always safe — more history in memory is never
+incorrect, only more expensive — so ``min_lines`` is a floor, never a cap.
+
+**Without ever finding a summary, this reads the ENTIRE file** (falls all
+the way back to BOF) rather than stopping at ``min_lines`` — deliberately
+conservative. A ``min_lines``-only stop cannot distinguish "no compaction
+has EVER run" (everything in the file is uncompacted, so
+``Session._compaction_watermark()``-bounded consumers need ALL of it, not
+just the last ``min_lines``) from "there IS a summary, just further back
+than ``min_lines``" — both look identical short of BOF, so BOF is the only
+safe fallback. This is not worse than the pre-#4387 always-full-read for
+that rare case, and a session that HAS compacted at least once (the
+realistic shape once a session is old/large enough to matter, since
+compaction keeps re-firing as the token budget refills) gets the bounded
+read.
+
+Older entries this reader doesn't return are NOT lost: ``history.jsonl`` is
+append-only, so anything left unread here is still on disk, reachable later
+via the extend-on-demand path (#4387 Phase B ②, not yet implemented).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def read_last_line(path: Path, *, chunk_size: int = 8192) -> "str | None":
+    """The last complete line of *path*, or ``None`` if missing/empty.
+
+    Cheap (bounded by one line's length, not file size) — mirrors
+    ``budget.py``'s ``BudgetTracker.tail_boundary``. Used to decide, BEFORE
+    committing to a bounded tail read, whether the file's last entry has a
+    real assigned ``seq`` (post-#3704: every append does) — if it does not,
+    ``load_history`` falls back to a full forward read rather than trust a
+    partial tail slice for ``_next_seq`` derivation (see that module's own
+    reasoning)."""
+    if not path.is_file():
+        return None
+    size = path.stat().st_size
+    if size == 0:
+        return None
+    read_size = min(chunk_size, size)
+    with path.open("rb") as f:
+        f.seek(size - read_size)
+        buf = f.read(read_size)
+    search_end = len(buf) - 1 if buf.endswith(b"\n") else len(buf)
+    idx = buf.rfind(b"\n", 0, search_end)
+    if idx == -1:
+        if read_size < size:
+            return read_last_line(path, chunk_size=chunk_size * 4)
+        line_bytes = buf
+    else:
+        line_bytes = buf[idx + 1:]
+    line = line_bytes.decode("utf-8", errors="replace").strip()
+    return line or None
+
+
+def read_history_tail(
+    path: Path, *, min_lines: int = 200, chunk_size: int = 65536,
+) -> list[str]:
+    """Read *path* backward from EOF, returning raw JSON-line strings in
+    FILE order (oldest line in the returned slice first). Empty list if the
+    file is missing or empty. See module docstring for the stop condition.
+    """
+    if not path.is_file():
+        return []
+    size = path.stat().st_size
+    if size == 0:
+        return []
+
+    collected: list[str] = []
+    seen_summary = False
+    pos = size
+    # Bytes read from the START of the previous (further-back) chunk that
+    # didn't yet complete a line when that chunk was split — prefixed onto
+    # the NEXT (even-further-back) read so a line straddling a chunk
+    # boundary is never mis-split. Grows without bound only in the
+    # pathological case of one line longer than chunk_size, same tolerance
+    # ``budget.py``'s ``tail_boundary`` gives that case.
+    carry = b""
+
+    with path.open("rb") as f:
+        while pos > 0:
+            read_size = min(chunk_size, pos)
+            pos -= read_size
+            f.seek(pos)
+            buf = f.read(read_size) + carry
+            parts = buf.split(b"\n")
+            if pos > 0:
+                # parts[0] may be a partial line — carry it into the next
+                # (further-back) read rather than treating it as complete.
+                carry = parts[0]
+                complete = parts[1:]
+            else:
+                carry = b""
+                complete = parts
+
+            # Checked PER LINE, not just per chunk: a chunk can (and for a
+            # small file, on the very first read, always does) contain far
+            # more than min_lines — stopping only at chunk boundaries would
+            # silently ignore the floor whenever one read covers the whole
+            # remaining file.
+            #
+            # Stop condition is (seen_summary AND collected >= min_lines) —
+            # NEVER "collected >= min_lines" alone. Without a summary, we
+            # cannot tell "no compaction has EVER run" (everything is
+            # uncompacted, so a short-circuit here would violate the
+            # watermark-completeness invariant every bounded consumer
+            # depends on) apart from "the summary is just further back than
+            # min_lines" (test_read_history_tail_reads_past_the_floor_to_
+            # include_the_latest_summary) — both look identical until BOF is
+            # actually reached, so BOF is the only safe fallback stop.
+            done = False
+            for raw in reversed(complete):
+                line = raw.decode("utf-8", errors="replace").strip()
+                if not line:
+                    continue
+                collected.append(line)
+                if not seen_summary:
+                    try:
+                        if json.loads(line).get("role") == "summary":
+                            seen_summary = True
+                    except (json.JSONDecodeError, AttributeError):
+                        pass
+                if len(collected) >= min_lines and seen_summary:
+                    done = True
+                    break
+            if done:
+                break
+
+    collected.reverse()
+    return collected

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -238,6 +238,13 @@ def _exec_gate_backend_name(sandbox_backend: Any, sandbox_config: Any) -> str | 
 # see docs/concepts/runtime/intervention-delivery.md#the-single-construction-seam
 DEFAULT_CHAT_CHANNEL_ID = "tui"
 
+# #4387 Phase B ①: the minimum number of lines ``load_history``'s bounded
+# path reads even when the latest compaction watermark is very close to
+# EOF — a reasonable startup scrollback floor so a freshly-compacted
+# session doesn't hydrate to a near-empty view. Mirrors #3476④'s own
+# ``_HYDRATE_PAGE_FRAMES=200`` (the TUI's view-layer paging window).
+_HISTORY_HYDRATE_MIN_LINES = 200
+
 
 # EMPTY_STOP_RETRY_DIRECTIVE (router_loop.py) is imported function-locally at the
 # construction site below: router_loop imports from session, so a module-level
@@ -3198,23 +3205,73 @@ class Session:
             depth=depth, chain_id=chain_id, responder_sid=responder_sid,
         )
 
+    def _append_parsed_history_line(self, line: str) -> None:
+        """Parse one ``history.jsonl`` line and append it to ``self.history``
+        — the per-line body shared by both of :meth:`load_history`'s paths.
+        Malformed lines are skipped (byte-identical to the pre-#4387
+        behavior), never raised."""
+        try:
+            raw = json.loads(line)
+            # Read-time migration for pre-#383 entries (legacy text + media
+            # shape → new content shape).
+            raw = _migrate_legacy_chat_message(raw)
+            self.history.append(ChatMessage(**raw))
+        except Exception:
+            pass
+
     def load_history(self) -> None:
+        """#4387 Phase B ①: hydrate ``self.history`` at startup WITHOUT
+        necessarily reading the whole (potentially huge — owner's real
+        environment measured 500MB) file. Two paths:
+
+        FAST (the common case, post-#3704): peek the file's last complete
+        line cheaply (:func:`read_last_line`, bounded by one line's length).
+        If it carries a real assigned ``seq`` (every append does, post-#3704
+        — see #3704's own history), a bounded backward read
+        (:func:`read_history_tail`) is safe: it is GUARANTEED to include
+        everything since the latest compaction (the same
+        ``_compaction_watermark()`` bound Phase A's narrowing-taint fix
+        already assumes) plus a minimum scrollback floor, and ``_next_seq``
+        derives from that one peeked line directly — O(1), no scan.
+
+        FALLBACK (rare — a file whose last write predates #3704, or one
+        that fails to parse): the ORIGINAL full forward read + full
+        ``max(seq)`` scan, byte-identical to the pre-#4387 behavior. This is
+        the path ``test_3704_seq_assigned_to_every_role.py``'s interleaved
+        ``seq == 0`` fixture exercises — that test needs no change.
+
+        Entries this doesn't load are NOT lost: ``history.jsonl`` is
+        append-only, so anything left unread here stays on disk, reachable
+        later via the on-demand extend path (#4387 Phase B ②, not yet
+        implemented).
+        """
         if not self.history_path.exists():
             return
+        from reyn.runtime.history_tail_reader import read_history_tail, read_last_line
+
+        last_line = read_last_line(self.history_path)
+        last_seq = 0
+        if last_line is not None:
+            try:
+                last_seq = int(json.loads(last_line).get("seq", 0) or 0)
+            except (json.JSONDecodeError, AttributeError, TypeError, ValueError):
+                last_seq = 0
+
+        if last_seq > 0:
+            for line in read_history_tail(
+                self.history_path, min_lines=_HISTORY_HYDRATE_MIN_LINES,
+            ):
+                self._append_parsed_history_line(line)
+            self._next_seq = last_seq + 1
+            return
+
+        # Fallback: full forward read, full scan — see docstring above.
         with self.history_path.open("r", encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if not line:
                     continue
-                try:
-                    raw = json.loads(line)
-                    # Read-time migration for pre-#383 entries (legacy
-                    # text + media shape → new content shape).
-                    raw = _migrate_legacy_chat_message(raw)
-                    self.history.append(ChatMessage(**raw))
-                except Exception:
-                    continue
-        # Initialize the seq counter past any seqs already in the file.
+                self._append_parsed_history_line(line)
         # #3704: entries persisted before the role-gate removal (assistant/
         # tool turns from the old buggy path) have seq==0 and stay that
         # way forever — nothing re-derives or backfills a coordinate for

--- a/tests/runtime/test_3137_cold_start_history_completeness_sweep.py
+++ b/tests/runtime/test_3137_cold_start_history_completeness_sweep.py
@@ -20,14 +20,29 @@ crash-recovery — gets a fully-populated ``self.history`` before any consumer
 ``_uncompacted_tool_call_records``, the MCP ``send_to_agent_impl`` baseline
 read, the TUI restore projection, ``ChatReadModel.conversation_history``)
 can observe it — there is no async gap between construction and
-``load_history()`` where a partial-history race could open. ``load_history()``
-itself reads ``history.jsonl`` in full (no lazy/tail read), so "complete"
-means "everything durable on disk at construction time", not "whatever a
-partial replay bucket happened to reach" — #2946 items 1/2/4 (topology-lazy /
-restore_all-bucketing / StateLog-tail-read) touch WAL-derived AgentSnapshot
-state, a SEPARATE substrate from the ``history.jsonl``-derived chat log (see
+``load_history()`` where a partial-history race could open.
+
+**#4387 Phase B ① UPDATE**: ``load_history()`` no longer always reads
+``history.jsonl`` in full — on a file whose last entry carries a real
+assigned ``seq`` (every append does, post-#3704), it reads backward and
+stops once it has collected AT LEAST ``_HISTORY_HYDRATE_MIN_LINES`` (200)
+lines AND has seen the latest ``role="summary"`` entry (or BOF). So
+"complete" for a cold start now means "everything since the latest
+compaction, plus a 200-line minimum floor" — NOT "the entire file" once a
+session exceeds that floor with no compaction having run. This test's own
+fixture (5 turns, no summary) stays well under the floor, so the bounded
+read reaches BOF anyway and this test's completeness assertion still holds
+byte-for-byte — it is not testing the general "whole file" claim the
+sentence above used to make, only "small session ⟹ still fully loaded",
+which remains true. A future test asserting completeness on a fixture
+LARGER than the floor would need to also account for the watermark/floor
+bound, not assume unconditional full-file completeness. #2946 items 1/2/4
+(topology-lazy / restore_all-bucketing / StateLog-tail-read) still touch
+WAL-derived AgentSnapshot state, a SEPARATE substrate from the
+``history.jsonl``-derived chat log (see
 ``interfaces/inline/textual_chat/restore.py``'s docstring: the chat log is
-"derived-at-read... NOT WAL-event-reconstructed state").
+"derived-at-read... NOT WAL-event-reconstructed state") — unaffected by
+this update.
 
 The two intentional exceptions — ``reyn chat --fresh`` / ``--no-restore`` —
 deliberately SKIP the ``load_history()`` call so the session starts with a

--- a/tests/runtime/test_4387_bounded_history_hydration.py
+++ b/tests/runtime/test_4387_bounded_history_hydration.py
@@ -1,0 +1,178 @@
+"""Tier 2: #4387 Phase B ① — ``Session.load_history()``'s bounded startup
+read, and the two pure helpers it's built on (``read_history_tail`` /
+``read_last_line`` in ``reyn.runtime.history_tail_reader``).
+
+Owner's real environment: ``history.jsonl`` reached 500MB, and every
+restart re-expanded the whole file into ``self.history`` (never shrinks,
+never bounded). This bounds the STARTUP read: everything since the latest
+compaction watermark, plus a minimum scrollback floor
+(``_HISTORY_HYDRATE_MIN_LINES``), falling back to the original full-file
+read when the file's last entry has no real ``seq`` (pre-#3704 data).
+
+Real ``Session`` + real ``history.jsonl`` files throughout — no mocks. The
+pure-function tests write raw JSON lines directly (this module's own
+concern: line framing, not ``ChatMessage`` shape) and go through
+``Session._append_history`` wherever the production write format matters.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.history_tail_reader import read_history_tail, read_last_line
+from reyn.runtime.session import _HISTORY_HYDRATE_MIN_LINES
+from tests._support.agent_session import make_session
+
+# ---------------------------------------------------------------------------
+# read_last_line / read_history_tail — pure functions, plain files
+# ---------------------------------------------------------------------------
+
+
+def test_read_last_line_missing_and_empty_file(tmp_path: Path) -> None:
+    """Tier 2: missing or empty file → None, never an exception."""
+    assert read_last_line(tmp_path / "nope.jsonl") is None
+    empty = tmp_path / "empty.jsonl"
+    empty.write_text("")
+    assert read_last_line(empty) is None
+
+
+def test_read_last_line_returns_the_final_complete_line(tmp_path: Path) -> None:
+    """Tier 2: the last line, trailing newline stripped."""
+    p = tmp_path / "h.jsonl"
+    p.write_text('{"a": 1}\n{"a": 2}\n{"a": 3}\n')
+    assert read_last_line(p) == '{"a": 3}'
+
+
+def test_read_history_tail_without_any_summary_reads_the_whole_file(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: with NO summary anywhere in the file, the bounded read cannot
+    safely stop at ``min_lines`` alone — it can't tell "no compaction has
+    ever run" (everything is uncompacted, so watermark-bounded consumers
+    need ALL of it) from "the summary is just further back" short of BOF.
+    Deliberately conservative: reads to BOF, same as the pre-#4387 full
+    read, for this specific (rare, once a session is old enough to have
+    compacted at least once) shape."""
+    p = tmp_path / "h.jsonl"
+    total = _HISTORY_HYDRATE_MIN_LINES + 50
+    p.write_text("\n".join(json.dumps({"i": i}) for i in range(total)) + "\n")
+
+    tail = read_history_tail(p, min_lines=_HISTORY_HYDRATE_MIN_LINES)
+
+    assert [json.loads(line)["i"] for line in tail] == list(range(total))
+
+
+def test_read_history_tail_reads_past_the_floor_to_include_the_latest_summary(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: a summary further back than ``min_lines`` extends the read —
+    the compaction-watermark invariant (everything since the latest
+    compaction) always wins over the floor, never the other way around."""
+    p = tmp_path / "h.jsonl"
+    lines = [json.dumps({"i": i, "role": "user"}) for i in range(20)]
+    lines[5] = json.dumps({"i": 5, "role": "summary", "covers_through_seq": 5})
+    p.write_text("\n".join(lines) + "\n")
+
+    # min_lines=3 is smaller than "distance back to the summary" (14 lines
+    # from EOF) — the read must still reach the summary, not stop at 3.
+    tail = read_history_tail(p, min_lines=3)
+
+    parsed = [json.loads(line) for line in tail]
+    assert parsed[0]["role"] == "summary" and parsed[0]["i"] == 5
+    # Content equality (not just a count) — the summary line itself PLUS
+    # everything after it, nothing more and nothing less.
+    assert parsed == [json.loads(ln) for ln in lines[5:]]
+
+
+def test_read_history_tail_short_file_returns_everything(tmp_path: Path) -> None:
+    """Tier 2: a file with fewer than ``min_lines`` total lines is read in
+    full — the same shape ``test_3137_...``'s small fixture relies on."""
+    p = tmp_path / "h.jsonl"
+    p.write_text("\n".join(json.dumps({"i": i}) for i in range(5)) + "\n")
+
+    tail = read_history_tail(p, min_lines=_HISTORY_HYDRATE_MIN_LINES)
+
+    assert [json.loads(line)["i"] for line in tail] == [0, 1, 2, 3, 4]
+
+
+# ---------------------------------------------------------------------------
+# Session.load_history() — the two real paths, end to end
+# ---------------------------------------------------------------------------
+
+
+def test_load_history_fast_path_bounds_a_long_compacted_session(tmp_path) -> None:
+    """Tier 2: a session that HAS compacted (the realistic shape once a
+    session is old/large enough to matter — compaction keeps re-firing as
+    the token budget refills) with turns after the latest summary exceeding
+    the hydrate floor — cold start loads only since that summary, not the
+    whole file, and ``_next_seq`` is still correct (derived from the last
+    entry's real seq, not a full scan)."""
+    s1 = make_session(agent_name="alpha", workspace_base_dir=tmp_path)
+    # A pre-summary region (would NOT be loaded by the bounded read) ...
+    for i in range(50):
+        s1._append_history(ChatMessage(role="user", content=f"old turn {i}"))
+    summary_seq = s1.history[-1].seq
+    s1._append_history(ChatMessage(
+        role="summary", content="summarised",
+        meta={"structured": {}, "covers_through_seq": summary_seq},
+    ))
+    # ... then more turns than the hydrate floor AFTER that summary.
+    post_total = _HISTORY_HYDRATE_MIN_LINES + 30
+    for i in range(post_total):
+        s1._append_history(ChatMessage(role="user", content=f"turn {i}"))
+    total_on_disk = 50 + 1 + post_total
+    on_disk = [ln for ln in s1.history_path.read_text().splitlines() if ln.strip()]
+    assert len(on_disk) == total_on_disk, "sanity: every entry is durable on disk"
+
+    s2 = make_session(agent_name="alpha", workspace_base_dir=tmp_path)
+    s2.load_history()
+
+    assert len(s2.history) < total_on_disk, (
+        "the bounded startup read must not have loaded the whole file"
+    )
+    assert s2.history[0].role == "summary", (
+        "the loaded tail must start at (include) the latest summary — the "
+        "watermark every bounded consumer depends on"
+    )
+    assert [m.content for m in s2.history[1:]] == [f"turn {i}" for i in range(post_total)], (
+        "everything after the summary must be present, in order"
+    )
+    assert "old turn 0" not in [m.content for m in s2.history], (
+        "the pre-summary region must NOT be loaded by the bounded read"
+    )
+    # _next_seq correctness: an appended turn continues the coordinate space.
+    s2._append_history(ChatMessage(role="user", content="new turn"))
+    assert s2.history[-1].seq == total_on_disk + 1
+
+
+def test_load_history_falls_back_to_full_scan_when_last_entry_has_no_seq(
+    tmp_path,
+) -> None:
+    """Tier 2: a file whose LAST written entry has ``seq == 0`` (simulating
+    data that predates #3704, or any file the fast-path peek can't trust)
+    falls back to the original full forward read — every entry loaded,
+    ``_next_seq`` derived from a full scan, not just the peeked line."""
+    s1 = make_session(agent_name="alpha", workspace_base_dir=tmp_path)
+    for i in range(_HISTORY_HYDRATE_MIN_LINES + 10):
+        s1._append_history(ChatMessage(role="user", content=f"turn {i}"))
+    # Append one more line by hand with seq stamped to 0 — the exact legacy
+    # shape #3704's own fixture uses, at the position that matters for the
+    # fast-path's peek (the file's last line).
+    with s1.history_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps({"role": "user", "content": "legacy tail", "seq": 0}) + "\n")
+
+    s2 = make_session(agent_name="alpha", workspace_base_dir=tmp_path)
+    s2.load_history()
+
+    total_on_disk = _HISTORY_HYDRATE_MIN_LINES + 11
+    assert len(s2.history) == total_on_disk, (
+        "the fallback path must load the ENTIRE file, not just a bounded tail"
+    )
+    assert s2.history[-1].content == "legacy tail"
+    assert s2.history[-1].seq == 0
+    # _next_seq must still be derived correctly (max real seq + 1, ignoring
+    # the trailing seq==0 entry) — the same #3704 invariant, now reached via
+    # the fallback branch rather than the only branch.
+    s2._append_history(ChatMessage(role="user", content="new turn"))
+    assert s2.history[-1].seq == _HISTORY_HYDRATE_MIN_LINES + 10 + 1


### PR DESCRIPTION
**[tui-coder]** — #4387 Phase B, PR① (of 2-3, per the posted design: https://github.com/tya5/reyn/issues/4387#issuecomment-5264220134).

Owner's real environment: `history.jsonl` reached 500MB, and every restart re-expanded the ENTIRE file into `self.history` (never shrinks — compaction only shrinks what's SENT to the LLM, never `self.history` or the file it's read from). Every restart re-pays the full cost.

**`load_history()` now has two paths**:

- **FAST** (the common case once a session has compacted at least once): peek the file's last complete line cheaply (`read_last_line`). If it carries a real assigned `seq` (every append does, post-#3704), a bounded backward read (`read_history_tail`) is safe — it always includes everything since the latest compaction watermark (the same bound `Session._compaction_watermark()`, Phase A's #4393 fix, already assumes) plus a minimum scrollback floor (`_HISTORY_HYDRATE_MIN_LINES=200`, mirrors #3476④'s own `_HYDRATE_PAGE_FRAMES`). `_next_seq` derives from the one peeked line directly — O(1), no scan. Without a summary anywhere in the file, it deliberately falls back to BOF rather than the floor — can't distinguish 'never compacted' from 'summary is further back' short of BOF.
- **FALLBACK** (rare — a file whose last write predates #3704): the ORIGINAL full read + full scan, byte-identical to pre-#4387 behavior. `test_3704_seq_assigned_to_every_role.py`'s interleaved `seq==0` fixture exercises exactly this path — no change needed there.

Older entries a bounded read doesn't load are **not lost** — `history.jsonl` is append-only; on-demand extension for TUI paging/`/copy`/search/WAL-rewind-visibility is PR② (not yet implemented).

**Same-PR doc-drift fix** (CLAUDE.md hard rule): `test_3137_cold_start_history_completeness_sweep.py`'s module docstring asserted `load_history()` reads the file in full unconditionally — corrected; its own small fixture (5 turns, no summary) stays under the hydrate floor so its assertion still holds, but the general claim needed fixing in the same PR that falsifies it.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` on both touched test files — 8/8 OK, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py src/reyn/runtime/history_tail_reader.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (211/215 baselined)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] Falsify-verify: temporarily reverted `load_history()`'s body to the old always-full-read; the new bounded-consumer test failed for real (`281 < 281` — not loaded fewer than the full file); restored, confirmed GREEN
- [x] Scoped pytest — 79 passed (`test_4387_bounded_history_hydration`, `test_3137_*`, `test_3704_*`, `test_multisession_history_isolation_2348`, `test_3310_n2_reset_hydrate`, `test_chat_message_e_full_schema`, `test_slash_rewind_self_cancel_3362`, `test_fp0036_live_runner`, `test_textual_chat_phase5_3273`, `test_chat_cli_flags`), plus 48 more in a compaction-adjacent sweep (`test_slash_compact_191`, `test_chat_compaction_engine_11axis`, `test_compaction_controller_invariants`, `test_compaction_controller_tool_aware`)
- [ ] Visual — n/a (no UI surface)

part of #4387

🤖 Generated with [Claude Code](https://claude.com/claude-code)