### PR TITLE
fix(#4375): retired-key gate covers removed (not just renamed) keys + .example comment lines

### DIFF
--- a/docs/reference/cli/config.md
+++ b/docs/reference/cli/config.md
@@ -30,7 +30,7 @@ reyn config migrate-mcp [--dry-run]
 | `get <key>` | Print the value of a single dot-path key. |
 | `set <key> <value>` | Write a key to `reyn.local.yaml`. Value is parsed as YAML. |
 | `validate` | Report unrecognized/renamed keys (policy tier + the hot-reload IN-set) and known keys currently disabled by another key's value. Never fails the exit code — see [Notes](#notes). |
-| `migrate [--dry-run]` | Rewrite renamed top-level config keys to their current location, in place, in whichever file each was found. |
+| `migrate [--dry-run]` | Rewrite renamed top-level config keys to their current location, in place, in whichever file each was found. Also reports (never auto-deletes) any REMOVED key with no successor — #4375. |
 | `migrate-mcp [--dry-run]` | Move legacy `mcp.servers` entries out of `reyn.yaml`/`reyn.local.yaml`/`~/.reyn/config.yaml` into `.reyn/mcp.yaml` (#470 config separation). |
 
 ## Exit codes
@@ -49,15 +49,18 @@ never gates (owner ruling: warn, never hard-fail, anywhere). It checks three thi
 each printed as its own labeled section (never merged into one list — the fix differs
 per section, and merging would lose "which one do I fix, and how"):
 
-- **Unrecognized/renamed keys, policy tier** (`reyn.yaml` / `reyn.local.yaml` /
+- **Unrecognized/renamed/removed keys, policy tier** (`reyn.yaml` / `reyn.local.yaml` /
   `~/.reyn/config.yaml`) — the same check `load_config`'s own startup warning runs.
   Fix: edit the file and restart, or run `reyn config migrate` for a renamed key with
-  an automatic destination.
+  an automatic destination. A REMOVED key (#4375 — no successor exists, unlike a
+  rename) is reported in its own "REMOVED ... delete them" section — `migrate` never
+  auto-rewrites it (there is no destination) and never auto-deletes it either; the
+  operator's next action is "delete this line", not "rewrite it".
 - **Known keys currently disabled by another key's value** — the key is real and
   correctly spelled, but the current configuration makes it a no-op (e.g.
   `action_retrieval.universal_wrappers_enabled` has no effect while `tool_use.scheme`
   resolves to `enumerate-all`). Each entry names the key it depends on and the fix.
-- **Unrecognized/renamed keys, the hot-reload IN-set** (`.reyn/{mcp,cron,hooks,skills,
+- **Unrecognized/renamed/removed keys, the hot-reload IN-set** (`.reyn/{mcp,cron,hooks,skills,
   pipelines,presentations}.yaml`) — same unknown-key check, run against the merged
   IN-set instead of the policy tier. Fix: edit the `.reyn/*.yaml` file directly — it
   applies on the next turn automatically, no restart and no `reyn config migrate`

--- a/scripts/check_retired_config_keys_denylist.py
+++ b/scripts/check_retired_config_keys_denylist.py
@@ -34,21 +34,38 @@ surrounding example happens to be for (mostly — see the "different schema
 still collides" note below, which is exactly why a small file-level
 allowlist exists alongside this denylist).
 
-## Single source: `_RENAMED_CONFIG_KEYS`, not a second hand-kept list
+## Single source: `_RENAMED_CONFIG_KEYS` + `_REMOVED_CONFIG_KEYS`, not a
+## second hand-kept list
 
-The denylist is `reyn.config.config_schema._RENAMED_CONFIG_KEYS` — the SAME
-registry `reyn config validate`/`migrate` already reads, already populated
-incrementally, in the SAME PR as each rename, by #4174's own T1-T7 practice
-(see that module's docstring). This script adds no maintenance burden of
-its own: a future rename that registers a `RenamedKeyHint` is picked up
-here for free. It deliberately does NOT hand-roll a parallel list — CLAUDE.md's
-own recurring lesson (`control-ir.md` vs `OP_KIND_MODEL_MAP`) is that a second
-registry nobody is obligated to update is worse than no registry.
+The denylist is the UNION of `reyn.config.config_schema._RENAMED_CONFIG_KEYS`
+and `_REMOVED_CONFIG_KEYS` (#4375) — the SAME registries `reyn config
+validate`/`migrate` already read, already populated incrementally, in the
+SAME PR as each rename or removal (#4174's T1-T7 practice for renames;
+#4375's own practice for removals — see that module's docstring). This
+script adds no maintenance burden of its own: a future rename or removal
+that registers a hint is picked up here for free. It deliberately does NOT
+hand-roll a parallel list — CLAUDE.md's own recurring lesson (`control-ir.md`
+vs `OP_KIND_MODEL_MAP`) is that a second registry nobody is obligated to
+update is worse than no registry.
+
+#4375 also closed the gate's OWN gap this registry split exposed: #4373 had
+hand-fixed 2 retired keys (`shell_allowed` / `skill_search`) that were never
+in `_RENAMED_CONFIG_KEYS` at all — they were REMOVED, not renamed, so the
+old rename-only denylist could never have caught them regardless of scan
+scope. Both are in `_REMOVED_CONFIG_KEYS`'s population now.
 
 ## Detection: line-START only, not "key anywhere"
 
 Only a match at column 0 (`^key:`) counts — a *top-level* YAML mapping key
-position. This deliberately does NOT catch:
+position. #4375, ruling ②: `*.example` files ALSO match `# key:` (a single
+optional leading `#` + at most one space, still column-0 anchored — see
+`_pattern`'s own docstring) — a `.example` file presents every optional
+field commented-out, so a stale commented-out top-level example is that
+file's version of the same drift a bare top-level key is everywhere else
+(#4392's real crash: an operator uncommenting a stale block). `docs/**`
+stays bare-only — a doc explaining a rename in prose must not itself trip
+the gate. Column 0 (bare or `.example`-commented) deliberately does NOT
+catch:
 
 - **dotted mentions** (`web.fetch.max_download_bytes`, prose citing a
   nested field by its full path) — these aren't claiming the OLD top-level
@@ -180,20 +197,62 @@ _EXCLUDED_FILE_KEYS: "dict[str, frozenset[str]]" = {
     "docs/deep-dives/contributing/dogfood-tooling.md": frozenset({"model"}),
     "docs/reference/builtin-models.md": frozenset({"model"}),
     "docs/reference/builtin-models.ja.md": frozenset({"model"}),
+    # #4375: `reyn agent show`'s OWN CLI output shape (`name:` /
+    # `created_at:` / `workspace:` / `role:`), not a `reyn.yaml` example —
+    # `workspace` is #4375's own removed-key population, and this is
+    # exactly the collision architect measured 532 candidates of (a
+    # common word legitimately used by a different schema). Confirmed by
+    # reading the whole file: this is the ONLY retired-key collision in
+    # either file, and it appears once, inside the `reyn agent show`
+    # sample output block.
+    "docs/reference/cli/agent.md": frozenset({"workspace"}),
+    "docs/reference/cli/agent.ja.md": frozenset({"workspace"}),
 }
 
 
 def _retired_keys() -> "dict[str, str]":
-    """The denylist itself: ``{old_top_level_key: note}`` straight from
-    ``_RENAMED_CONFIG_KEYS`` — see module docstring "Single source"."""
-    from reyn.config.config_schema import _RENAMED_CONFIG_KEYS
-    return {key: hint.note for key, hint in _RENAMED_CONFIG_KEYS.items()}
+    """The denylist itself: ``{old_top_level_key: note}`` — the UNION of
+    ``_RENAMED_CONFIG_KEYS`` (moved) and ``_REMOVED_CONFIG_KEYS`` (deleted,
+    no successor) — see module docstring "Single source". #4375: a
+    RETIRED key is retired either way; the two registries exist because
+    the operator's remedy differs (rewrite vs. delete), not because this
+    gate cares — both describe a key that must not appear in a current
+    ``reyn.yaml`` example, which is this gate's only question. The two
+    key-sets are disjoint by construction (each dict is populated once,
+    in the PR that renames or removes that key — nothing writes the same
+    key into both)."""
+    from reyn.config.config_schema import _REMOVED_CONFIG_KEYS, _RENAMED_CONFIG_KEYS
+    return {
+        key: hint.note
+        for key, hint in (*_RENAMED_CONFIG_KEYS.items(), *_REMOVED_CONFIG_KEYS.items())
+    }
 
 
-def _pattern(keys: "list[str]") -> "re.Pattern[str]":
+def _pattern(keys: "list[str]", *, allow_comment_prefix: bool) -> "re.Pattern[str]":
     alt = "|".join(re.escape(k) for k in sorted(keys))
     # Column-0 anchor (`^`, no leading whitespace) = top-level YAML mapping
     # key position — see module docstring "Detection: line-START only".
+    if allow_comment_prefix:
+        # #4375, lead-coder's ruling ②: `.example` files ONLY — an OPTIONAL
+        # `# ` (exactly one space, or none) before the key. Measured
+        # against the real file rather than assumed: `reyn.local.yaml.example`
+        # marks a TOP-LEVEL commented key as `# key:` (one space) and a
+        # NESTED one as `#   key:` (3+ spaces, mirroring the 2-space YAML
+        # indent it would have if uncommented — `# llm:` then `#   model:`
+        # for `llm.model`). A bare `\s*` here would match the nested form
+        # too and reintroduce exactly the false positive column-0 anchoring
+        # exists to avoid (caught by running this gate against the real
+        # file during development — `#   model:` under `# llm:` matched
+        # before this was narrowed to `#?` with NO wildcard span). In a
+        # `.example` file the comment IS the body — every optional field is
+        # presented commented-out — so this is the file's normal shape, not
+        # prose; #4392's real crash (an operator uncommenting a stale
+        # `api_base:`/`models:` block) was invisible to the bare-only
+        # pattern for exactly this reason. NOT applied to `docs/**` —
+        # ruling ② keeps that scope as prose (a doc explaining a move,
+        # `` `model:` moved to `llm.model:` ``, would otherwise itself
+        # trip the gate — #3559's "the disciplined party pays" shape).
+        return re.compile(r"^#?(?: )?(" + alt + r"):(\s|$)")
     return re.compile(r"^(" + alt + r"):(\s|$)")
 
 
@@ -221,7 +280,12 @@ def offending_lines(root: Path = _ROOT) -> "list[tuple[Path, int, str, str]]":
     top-level key appears at YAML top-level (column 0) — the gate's entire
     decision, isolated from CLI/printing so it is directly testable."""
     keys = _retired_keys()
-    pattern = _pattern(list(keys))
+    key_list = list(keys)
+    # #4375, lead-coder's ruling ②: two patterns, chosen per file — see
+    # `_pattern`'s own docstring for why `.example` alone gets the
+    # comment-prefix form.
+    bare_pattern = _pattern(key_list, allow_comment_prefix=False)
+    example_pattern = _pattern(key_list, allow_comment_prefix=True)
     offenders: list[tuple[Path, int, str, str]] = []
     for path in _iter_scan_files(root):
         try:
@@ -229,6 +293,7 @@ def offending_lines(root: Path = _ROOT) -> "list[tuple[Path, int, str, str]]":
         except (OSError, UnicodeDecodeError):
             continue
         rel_s = str(path.relative_to(root))
+        pattern = example_pattern if path.name.endswith(".example") else bare_pattern
         excluded_keys = _EXCLUDED_FILE_KEYS.get(rel_s, frozenset())
         for lineno, line in enumerate(text.splitlines(), start=1):
             m = pattern.match(line)

--- a/src/reyn/config/config_schema.py
+++ b/src/reyn/config/config_schema.py
@@ -170,6 +170,79 @@ class RenamedKeyHint:
     destination: "str | None" = None
 
 
+@_dataclass(frozen=True)
+class RemovedKeyHint:
+    """The reason an unknown config key isn't valid, when it was DELETED
+    with no successor — a distinct category from :class:`RenamedKeyHint`
+    (#4375, lead-coder's ruling ①).
+
+    ``_RENAMED_CONFIG_KEYS`` is a table of "where did this move to" —
+    every entry there has, or could have, a destination. A key that was
+    genuinely removed has none, and putting it in that table either
+    leaves no way to write an honest hint (no destination to name) or
+    invites writing a false one. The operator's next action differs by
+    kind, not just degree: a rename says "rewrite this to Y"; a removal
+    says "delete this, there is no Y" — encoding it as a separate type
+    makes that difference structural instead of something a hint's
+    author has to remember to phrase correctly each time (same reasoning
+    :class:`RenamedKeyHint`'s own ``destination`` field already applies
+    to the rewrite-vs-manual-review distinction).
+
+    Deliberately carries no ``destination`` field at all — unlike
+    :class:`RenamedKeyHint` where ``destination=None`` is a valid state
+    (a value-transform rename, manual review only), a removed key MUST
+    stay unrewritable; making the field simply not exist here makes that
+    unrepresentable-wrong rather than merely a convention.
+    """
+
+    note: str
+
+
+#: #4375: top-level ``ReynConfig`` keys that existed at some point in the
+#: schema's own history and were deleted with NO successor key — a
+#: DIFFERENT population than :data:`_RENAMED_CONFIG_KEYS` (which only
+#: covers keys that MOVED). Derived by architect's #4375 measurement: a
+#: union of every top-level field name across all ~148 historical
+#: revisions of the schema's own module (``git log --follow``), minus the
+#: 33 that are still current, minus the 8 that are registered renames
+#: above — 17 remain, confirmed real (not a false-positive population)
+#: because #4373's two hand-found stale keys (``shell_allowed`` /
+#: ``skill_search``) are both in this list. Individual per-key removal
+#: provenance (which PR deleted each one, and why) was NOT traced — #4375
+#: measured the SCHEMA'S OWN population, not each key's history, and an
+#: operator needs "delete this, it's gone" more than a specific PR
+#: citation. Same co-location discipline as ``_RENAMED_CONFIG_KEYS``: a
+#: future removal adds its entry here in the SAME PR as the removal.
+_REMOVED_CONFIG_KEYS: "dict[str, RemovedKeyHint]" = {
+    key: RemovedKeyHint(
+        note=f"`{key}:` no longer exists in the schema and has no "
+             "replacement key (traced via #4375: a union of every "
+             "top-level key across the config schema's own revision "
+             "history, 58 that ever existed vs. 33 current) — delete "
+             "it from your config."
+    )
+    for key in (
+        "eval",
+        "limits",
+        "max_phase_visits",
+        "mcp_search_threshold",
+        "multi_agent",
+        "plan",
+        "plan_resume_raw",
+        "python",
+        "routerloop_convergence_skills",
+        "self_improvement",
+        "shell_allowed",
+        "skill_resume",
+        "skill_search",
+        "state_dir",
+        "time_travel",
+        "tool_calls_op_loop_skills",
+        "workspace",
+    )
+}
+
+
 #: #4174 T0: a renamed config key (dotted, any level) -> a :class:`RenamedKeyHint`,
 #: so an unknown-key warning can NAME the destination ("`model:` moved to
 #: `llm.model:`") rather than just say "unknown", and ``reyn config migrate``
@@ -332,7 +405,7 @@ def _schema_index() -> "tuple[frozenset[str], frozenset[str], frozenset[str]]":
 
 def unknown_config_keys(
     raw: "dict | None", *, prefix: str = "",
-) -> "dict[str, RenamedKeyHint | None]":
+) -> "dict[str, RenamedKeyHint | RemovedKeyHint | None]":
     """Return ``{dotted_key: hint_or_None}`` for every key in *raw*
     (recursively, at every nesting level) that is not a valid
     ``ReynConfig`` field — #4174 T0's ONE unknown-key implementation,
@@ -348,18 +421,27 @@ def unknown_config_keys(
     duplicated).
 
     A ``None`` hint means "this key matches none of the known keys — see
-    ``reyn config fields``" (today's ONLY case: no rename has landed yet).
-    A :class:`RenamedKeyHint` means the key was intentionally renamed (see
+    ``reyn config fields``" (a typo, or a key that never existed at all).
+    A :class:`RenamedKeyHint` means the key MOVED (see
     :data:`_RENAMED_CONFIG_KEYS`) — its ``note`` is always shown; its
     ``destination`` tells ``reyn config migrate`` whether it's safe to
-    auto-rewrite. Collects every unknown key in one pass — callers must NOT
+    auto-rewrite. A :class:`RemovedKeyHint` (#4375) means the key was
+    DELETED with no successor (see :data:`_REMOVED_CONFIG_KEYS`) — its
+    ``note`` says so; it carries no ``destination`` because there is
+    nowhere to rewrite it TO. Both hint types expose ``.note``, so a
+    caller that only prints the note (every current call site) needs no
+    ``isinstance`` branch; a caller that acts on ``destination`` (``reyn
+    config migrate``) already only ever reads ``_RENAMED_CONFIG_KEYS``
+    directly for that, never this function's combined result, so a
+    ``RemovedKeyHint`` reaching that code is not a case it has to guard
+    against. Collects every unknown key in one pass — callers must NOT
     early-return on the first hit (owner requirement: report all problems
     at once, not one-fix-restart-repeat).
     """
     if not isinstance(raw, dict):
         return {}
     namespaces, dict_leaves, scalar_leaves = _schema_index()
-    result: "dict[str, RenamedKeyHint | None]" = {}
+    result: "dict[str, RenamedKeyHint | RemovedKeyHint | None]" = {}
     for key, value in raw.items():
         dotted = f"{prefix}.{key}" if prefix else key
         if dotted in scalar_leaves:
@@ -374,7 +456,9 @@ def unknown_config_keys(
             if isinstance(value, dict):
                 result.update(unknown_config_keys(value, prefix=dotted))
             continue
-        result[dotted] = _RENAMED_CONFIG_KEYS.get(dotted)
+        result[dotted] = (
+            _RENAMED_CONFIG_KEYS.get(dotted) or _REMOVED_CONFIG_KEYS.get(dotted)
+        )
     return result
 
 

--- a/src/reyn/interfaces/cli/commands/config.py
+++ b/src/reyn/interfaces/cli/commands/config.py
@@ -404,16 +404,28 @@ def _migrate(*, dry_run: bool = False) -> None:
     intentionally NOT auto-rewritten by this command — an operator on an
     old sandbox.policy key sees the guidance via ``reyn config validate``
     and fixes it by hand.
+
+    #4375: a key in ``_REMOVED_CONFIG_KEYS`` (deleted, no successor) is
+    reported in its OWN section, never folded into ``needs_manual`` above
+    — lead-coder's ruling ①: a rename's remedy is "rewrite to Y"; a
+    removed key's remedy is "delete it, there is no Y". Mixing the two
+    into one "needs manual review" list would make that difference
+    illegible (the operator would have to read each note to find out
+    which action applies). Never auto-rewritten (no destination exists to
+    rewrite to) and never auto-DELETED either — this command only ever
+    writes a value TO a key, deleting an operator's line unasked is a
+    different, more destructive class of edit this command doesn't do.
     """
     import yaml
 
     from reyn.config import _find_project_root
-    from reyn.config.config_schema import _RENAMED_CONFIG_KEYS
+    from reyn.config.config_schema import _REMOVED_CONFIG_KEYS, _RENAMED_CONFIG_KEYS
 
-    if not _RENAMED_CONFIG_KEYS:
+    if not _RENAMED_CONFIG_KEYS and not _REMOVED_CONFIG_KEYS:
         print(
-            "No config key renames are registered yet (nothing to migrate "
-            "— #4174 T1-T6 populate this registry incrementally)."
+            "No config key renames or removals are registered yet "
+            "(nothing to migrate — #4174 T1-T6 / #4375 populate these "
+            "registries incrementally)."
         )
         return
 
@@ -474,6 +486,7 @@ def _migrate(*, dry_run: bool = False) -> None:
 
     any_changes = False
     manual_found: list[tuple[str, str, str]] = []  # (label, old_key, reason)
+    removed_found: list[tuple[str, str]] = []  # (label, old_key) — #4375
     for path in candidates:
         cfg = _read(path)
         if not cfg:
@@ -493,6 +506,14 @@ def _migrate(*, dry_run: bool = False) -> None:
             found, _value = _pop_dotted(dict(cfg), old_key)  # peek, don't mutate
             if found:
                 manual_found.append((_label(path), old_key, _VALUE_TRANSFORM))
+        # #4375: removed keys are detected and reported, never rewritten
+        # (there is no destination) and never auto-deleted (this command
+        # only ever writes a rewrite TO a key, not removes an operator's
+        # line unasked) — see the docstring's "removed key" scope note.
+        for old_key in _REMOVED_CONFIG_KEYS:
+            found, _value = _pop_dotted(dict(cfg), old_key)  # peek, don't mutate
+            if found:
+                removed_found.append((_label(path), old_key))
         if not present_here:
             continue
 
@@ -531,8 +552,19 @@ def _migrate(*, dry_run: bool = False) -> None:
             )
             print(f"  {label}: {old_key} — {note}")
 
-    if not any_changes and not manual_found:
-        print("No renamed keys found in your config — nothing to migrate.")
+    if removed_found:
+        if manual_found:
+            print()
+        # #4375, lead-coder's ruling ①: "delete", not "review" — a removed
+        # key has no destination to migrate TO, so this is its own section
+        # rather than folded into "needs manual review" above (that phrase
+        # implies a rewrite path exists; this key has none).
+        print("\nThe following key(s) were REMOVED (no successor) — delete them:")
+        for label, old_key in removed_found:
+            print(f"  {label}: {old_key} — {_REMOVED_CONFIG_KEYS[old_key].note}")
+
+    if not any_changes and not manual_found and not removed_found:
+        print("No renamed or removed keys found in your config — nothing to migrate.")
         return
     if any_changes:
         if dry_run:

--- a/tests/config/test_4174_t0_unknown_config_key_warn.py
+++ b/tests/config/test_4174_t0_unknown_config_key_warn.py
@@ -106,6 +106,23 @@ def test_unknown_sandbox_policy_key_warning_names_the_effective_policy(
     )
 
 
+def test_a_removed_top_level_key_warns_delete_not_rewrite(tmp_path, caplog) -> None:
+    """Tier 2: #4375 — a key registered in ``_REMOVED_CONFIG_KEYS`` (deleted,
+    no successor) is reachable through the SAME real ``load_config`` path
+    every other unknown-key case in this file goes through, and its
+    warning says the key was removed (not "renamed" or "unrecognized"
+    generically) — the real end-to-end wiring, not just
+    ``unknown_config_keys()`` in isolation (already covered by
+    ``config_schema``'s own direct-call tests)."""
+    from reyn.config.config_schema import _REMOVED_CONFIG_KEYS
+    assert _REMOVED_CONFIG_KEYS, "the registry must be non-empty for this test to mean anything"
+    any_removed_key = next(iter(_REMOVED_CONFIG_KEYS))
+    cfg = _load(tmp_path, f"{any_removed_key}: 1\n", caplog)
+    assert cfg is not None  # did not raise
+    messages = [r.message for r in caplog.records]
+    assert any(any_removed_key in m and "no longer exists" in m for m in messages), messages
+
+
 def test_renamed_sandbox_policy_key_warning_names_the_destination(
     tmp_path, caplog,
 ) -> None:

--- a/tests/interfaces/test_config_validate_migrate_command_4174.py
+++ b/tests/interfaces/test_config_validate_migrate_command_4174.py
@@ -66,6 +66,25 @@ def test_validate_reports_an_unrecognized_top_level_key(project, capsys):
     assert "totally_made_up_top_level_key" in out
 
 
+def test_validate_reports_a_removed_key_via_the_same_generic_hint_note(
+    project, capsys,
+):
+    """Tier 2: #4375 — a removed key reaches ``reyn config validate``'s
+    report through the SAME generic ``if hint: print(hint.note)`` path
+    every other hint type already uses (no ``isinstance`` branch needed —
+    ``RemovedKeyHint`` exposes ``.note`` same as ``RenamedKeyHint``)."""
+    from reyn.config.config_schema import _REMOVED_CONFIG_KEYS
+    from reyn.interfaces.cli.commands.config import _validate
+
+    assert _REMOVED_CONFIG_KEYS, "the registry must be non-empty for this test to mean anything"
+    any_removed_key = next(iter(_REMOVED_CONFIG_KEYS))
+    _write_yaml(project / "reyn.yaml", f"{any_removed_key}: 1\n")
+    _validate()
+    out = capsys.readouterr().out
+    assert any_removed_key in out
+    assert "no longer exists" in out
+
+
 def test_validate_reports_llm_model_as_known_not_flagged(project, capsys):
     """Tier 2: #4174 T3 — accept-side, superseding this test's former pre-T3
     shape (architect's #4174 T0 finding: `LLMConfig` had no `model` field, so
@@ -100,26 +119,32 @@ def test_validate_subcommand_is_registered():
 def test_migrate_reports_nothing_to_migrate_when_registry_is_empty(
     project, capsys, monkeypatch,
 ):
-    """Tier 2: #4174 T0b — with ``_RENAMED_CONFIG_KEYS`` empty, ``reyn
-    config migrate`` says so explicitly rather than silently doing nothing
-    with no output (lead-coder's explicit requirement: must not be
-    silently vacuous).
+    """Tier 2: #4174 T0b — with BOTH ``_RENAMED_CONFIG_KEYS`` and
+    ``_REMOVED_CONFIG_KEYS`` empty, ``reyn config migrate`` says so
+    explicitly rather than silently doing nothing with no output
+    (lead-coder's explicit requirement: must not be silently vacuous).
 
-    Injects an empty registry explicitly (the same ``monkeypatch.setattr``
+    Injects both registries empty explicitly (the same ``monkeypatch.setattr``
     seam the sibling test below already uses for a non-empty one) — #4174
-    T5 populated ``_RENAMED_CONFIG_KEYS`` for real, which falsified this
-    test's original premise that the module-global registry was ITSELF
+    T5 populated ``_RENAMED_CONFIG_KEYS`` for real, and #4375 populated
+    ``_REMOVED_CONFIG_KEYS`` for real, which falsified this test's
+    original premise that the module-global registries were THEMSELVES
     empty at the time the test ran. What this test actually verifies is
-    "what `migrate` says when the registry is empty", not "is the
-    registry currently empty" — those are different claims, and only the
-    first one is this test's to make."""
+    "what `migrate` says when both registries are empty", not "are the
+    registries currently empty" — those are different claims, and only
+    the first one is this test's to make. #4375: the early-return guard
+    now checks both registries (a removed-key population alone is enough
+    to make "nothing is registered" false), so this test must empty both
+    or it silently starts asserting the WRONG code path's message instead
+    of failing loudly — caught by running it against #4375's own change."""
     from reyn.interfaces.cli.commands.config import _migrate
 
     monkeypatch.setattr("reyn.config.config_schema._RENAMED_CONFIG_KEYS", {})
+    monkeypatch.setattr("reyn.config.config_schema._REMOVED_CONFIG_KEYS", {})
     _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
     _migrate()
     out = capsys.readouterr().out
-    assert "No config key renames are registered yet" in out
+    assert "No config key renames or removals are registered yet" in out
 
 
 def test_migrate_reports_nothing_to_migrate_when_config_has_no_renamed_key(
@@ -229,6 +254,39 @@ def test_migrate_flags_a_value_transforming_rename_for_manual_review(
     out = capsys.readouterr().out
     assert "manual review" in out.lower()
     assert "old_inverting_key" in out
+
+
+def test_migrate_flags_a_removed_key_as_delete_not_manual_review(
+    project, capsys, monkeypatch,
+) -> None:
+    """Tier 2: #4375, lead-coder's ruling ① — a key present in
+    ``_REMOVED_CONFIG_KEYS`` is NOT auto-rewritten (there is no
+    destination to rewrite to) and is reported in its OWN "REMOVED ...
+    delete them" section, distinct from the value-transform-rename
+    "needs manual review" section above — the operator's next action
+    differs (rewrite vs. delete), so the two must not read as the same
+    kind of finding."""
+    from reyn.config.config_schema import RemovedKeyHint
+
+    monkeypatch.setattr("reyn.config.config_schema._RENAMED_CONFIG_KEYS", {})
+    monkeypatch.setattr(
+        "reyn.config.config_schema._REMOVED_CONFIG_KEYS",
+        {"old_dead_key": RemovedKeyHint(note="deleted, no successor")},
+    )
+    _write_yaml(project / "reyn.yaml", "old_dead_key: true\n")
+
+    from reyn.interfaces.cli.commands.config import _migrate
+    _migrate()
+
+    import yaml
+    cfg = yaml.safe_load((project / "reyn.yaml").read_text())
+    # Untouched — this command never deletes an operator's line unasked.
+    assert cfg["old_dead_key"] is True
+    out = capsys.readouterr().out
+    assert "REMOVED" in out
+    assert "delete them" in out
+    assert "old_dead_key" in out
+    assert "needs manual review" not in out.lower()
 
 
 def test_migrate_does_not_rewrite_a_space_free_note_with_no_destination(

--- a/tests/scripts/test_check_retired_config_keys_denylist_4327.py
+++ b/tests/scripts/test_check_retired_config_keys_denylist_4327.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import subprocess
 
-from reyn.config.config_schema import _RENAMED_CONFIG_KEYS
+from reyn.config.config_schema import _REMOVED_CONFIG_KEYS, _RENAMED_CONFIG_KEYS
 from scripts.check_retired_config_keys_denylist import (
     _ROOT,
     offending_lines,
@@ -174,6 +174,80 @@ def test_denylist_keys_are_exactly_the_renamed_config_keys_registry(tmp_path) ->
     _add(tmp_path)
     offenders = offending_lines(tmp_path)
     assert [k for _, _, k, _ in offenders] == [any_retired_key]
+
+
+def test_denylist_also_includes_the_removed_config_keys_registry(tmp_path) -> None:
+    """Tier 1: #4375 — a key registered ONLY in `_REMOVED_CONFIG_KEYS`
+    (deleted, no successor — never in `_RENAMED_CONFIG_KEYS`) must still be
+    detected. This is the gate's own #4373 witness: `shell_allowed` /
+    `skill_search` were retired keys the OLD rename-only denylist could
+    never have caught, by construction, regardless of scan scope — because
+    they were never a rename at all."""
+    assert _REMOVED_CONFIG_KEYS, "the registry must be non-empty for this test to mean anything"
+    any_removed_key = next(iter(_REMOVED_CONFIG_KEYS))
+    assert any_removed_key not in _RENAMED_CONFIG_KEYS, (
+        "test precondition: the two registries must be disjoint, or this "
+        "test can't tell which one actually caught the key"
+    )
+    _write(tmp_path, "docs/guide/example.md", f"{any_removed_key}: x\n")
+    _git_repo(tmp_path)
+    _add(tmp_path)
+    offenders = offending_lines(tmp_path)
+    assert [k for _, _, k, _ in offenders] == [any_removed_key]
+
+
+# ── #4375 ruling ②: `.example` comment-line scanning ────────────────────────
+
+
+def test_a_commented_out_top_level_retired_key_in_dot_example_is_offending(
+    tmp_path,
+) -> None:
+    """Tier 1: #4375 — a retired key commented out at column 0 (`# key:`,
+    ONE leading space) in a `.example` file is offending. This is the
+    #4392 real-crash shape: a stale commented-out example is invisible to
+    every unknown-key check while commented, and only bites the operator
+    the moment they uncomment it to actually use the block."""
+    any_retired_key = next(iter(_RENAMED_CONFIG_KEYS))
+    _write(tmp_path, "reyn.local.yaml.example", f"# {any_retired_key}: x\n")
+    _git_repo(tmp_path)
+    _add(tmp_path)
+    offenders = offending_lines(tmp_path)
+    assert [k for _, _, k, _ in offenders] == [any_retired_key]
+
+
+def test_a_commented_out_nested_key_in_dot_example_is_not_offending(tmp_path) -> None:
+    """Tier 1: #4375 — a retired key commented out at NESTED position
+    (`#   key:`, 2+ leading spaces after `#`, mirroring the YAML indent it
+    would have if uncommented) in a `.example` file is NOT offending —
+    same "indented nested key sharing a retired name" exclusion the bare
+    (non-`.example`) case already has, applied to the comment-prefixed
+    form too. This is the false positive a naive `#\\s*` (unbounded
+    whitespace) pattern would reintroduce: `reyn.local.yaml.example`'s own
+    real convention marks a NESTED commented key with extra leading
+    spaces (`# llm:` then `#   model:` for `llm.model`)."""
+    any_retired_key = next(iter(_RENAMED_CONFIG_KEYS))
+    _write(
+        tmp_path, "reyn.local.yaml.example",
+        f"# llm:\n#   {any_retired_key}: x\n",
+    )
+    _git_repo(tmp_path)
+    _add(tmp_path)
+    offenders = offending_lines(tmp_path)
+    assert offenders == []
+
+
+def test_a_commented_out_retired_key_in_docs_is_not_offending(tmp_path) -> None:
+    """Tier 1: #4375 ruling ② — the comment-prefix form applies ONLY to
+    `.example` files. A `docs/**` file's `# key:` stays invisible (prose
+    scope, unchanged from before this PR) — a doc explaining a rename in
+    prose (`` # models: moved to llm.models ``) must not itself trip the
+    gate (#3559's "the disciplined party pays" shape)."""
+    any_retired_key = next(iter(_RENAMED_CONFIG_KEYS))
+    _write(tmp_path, "docs/guide/example.md", f"# {any_retired_key}: x\n")
+    _git_repo(tmp_path)
+    _add(tmp_path)
+    offenders = offending_lines(tmp_path)
+    assert offenders == []
 
 
 # ── the real committed tree ─────────────────────────────────────────────────


### PR DESCRIPTION
**[e2e-coder]** — implements lead-coder's #4375 ruling on architect's
measurement (population confirmed 17, not estimated).

## Population (architect's measurement, not re-derived here)

Docs-derived candidates (532) were nearly all false positives (different
schemas sharing a field name). Correct population: a union of every
top-level key across ~148 historical revisions of the config schema's own
module (`git log --follow`) — 58 that ever existed, 33 current, 25 gone.
8 are already-registered renames (`_RENAMED_CONFIG_KEYS`, complete, no
gaps); 17 are genuine removals with no successor. #4373's own two
hand-found stale keys (`shell_allowed`, `skill_search`) are both in that
17 — the witness that the population is real.

## Three rulings, all implemented

**① 17 removed keys get their OWN type, not folded into `_RENAMED_CONFIG_KEYS`.**
New `RemovedKeyHint` (no `destination` field at all — unrepresentable-wrong,
not just undocumented) + `_REMOVED_CONFIG_KEYS`. `unknown_config_keys()`
checks both registries. `reyn config migrate` reports removed keys in
their own "REMOVED ... delete them" section — never auto-rewritten (no
destination) and never auto-deleted (this command only ever writes a
rewrite TO a key). `reyn config validate` needed no change — it already
only reads `hint.note` generically.

**② `.example` comment-line scanning, scoped to `*.example` only.**
Real witness: #4392, an operator who uncommented a stale
`api_base:`/`models:` block and hit the exact crash this closes.
`docs/**` stays bare-only (a prose rename explanation must not itself
trip the gate).

Caught during development, not assumed: a naive `#` + unbounded
whitespace pattern re-introduced the exact false positive column-0
anchoring exists to prevent — `reyn.local.yaml.example` marks a NESTED
commented key with extra leading spaces (`# llm:` then `#   model:` for
`llm.model`). Narrowed to an optional SINGLE space only after running the
pattern against the real file and reading what it matched.

**③ File-level allowlist stays mandatory** (already existed). Extended
for one real collision the new population surfaced:
`docs/reference/cli/agent.{md,ja.md}`'s `reyn agent show` sample output
uses `workspace:` as its own field (`name`/`created_at`/`workspace`/`role`),
not a `reyn.yaml` shape. Confirmed by reading the whole file for other
collisions (none) before adding.

## Consumer sweep caught a real regression

`tests/interfaces/test_config_validate_migrate_command_4174.py`'s
"registry is empty" test only emptied `_RENAMED_CONFIG_KEYS`, not
`_REMOVED_CONFIG_KEYS` (now genuinely 17 entries) — the early-return
guard checks both now, so the test silently started asserting the wrong
message. Fixed by emptying both.

## Not in scope

Architect's own comment named a 3rd hole — `reyn init`'s embedded config
template (`templates.py`, a Python string literal, invisible to this
gate's docs/\*\*+\*.example scan by construction) — #4392 already fixed
and pinned THAT one file; whether other embedded templates exist
elsewhere was explicitly left unmeasured by architect and isn't this
PR's job.

## Test plan

- [x] `ruff check src tests scripts` — green.
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — green (43 tests inspected).
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — green.
- [x] `python scripts/mypy_ratchet.py` — green.
- [x] `python scripts/check_tests_path_literal_reference.py` — green.
- [x] Falsify: reverted `config_schema.py` + the gate script, confirmed
      the new tests fail (`ImportError` on `_REMOVED_CONFIG_KEYS`);
      restored, confirmed green. Same for `cli/commands/config.py`'s
      change against its own new test.
- [x] Gate script run directly against the real repo tree: `0 hits, 25
      retired keys checked (8 renamed + 17 removed)`.
- [x] Scoped regression sweep (240 tests): `tests/config/`,
      `test_config_validate_migrate_command_4174.py`,
      `test_config_warning_chrome_4194.py`, `test_sandbox_factory.py`,
      `test_check_retired_config_keys_denylist_4327.py` — all pass.
- [ ] Visual/manual — N/A (no UI surface).

No auto-merge armed on this PR (touches `tests/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**[lead-coder]** — レビュアの blocking 項目

- [x] 🔴 `docs/reference/cli/config.md`（`:33` の表と `:54` の Fix 行）に、migrate が removed キーを「書き換え」ではなく「削除」として扱うことを追記（`.ja.md` に同じ主張があれば同時に）。現状は「renamed だけ」と読め、本 PR の設計の要点（operator の次の一手が rename と removed で違う）が doc に現れていません。 -- 対応: 3934af8b4（`.ja.md`は存在しないので対象外）。

