### PR TITLE
fix(#4387): MCP reply-harvest baseline survives a history prepend

### DIFF
--- a/src/reyn/mcp/server.py
+++ b/src/reyn/mcp/server.py
@@ -104,11 +104,33 @@ async def _get_session(
     return registry.get_or_load(name)
 
 
+def _history_baseline_seq(session) -> int:
+    """The ``seq`` watermark to capture BEFORE dispatching a request, so
+    ``_new_agent_history_entries`` can later ask "what's new since then" by
+    coordinate rather than by list position (#4387 architect review on
+    Phase B ②: ``session.history[baseline:]`` — a captured ``len()`` —
+    silently returns the WRONG (older) slice once anything can prepend to
+    ``self.history``, which Phase B's on-demand older-entry loading will do
+    for other consumers; this reads the wrong thing without raising, so it
+    would ship broken).
+
+    Mirrors ``load_history``'s own ``max(seq)`` derivation rather than just
+    reading the last entry's ``seq`` — safe even for a session whose most
+    recent entry happens to be legacy ``seq == 0`` data (pre-#3704): any
+    newly-appended entry always gets a real ``seq`` strictly greater than
+    every ``seq`` that already exists, so the max over everything currently
+    held is always a valid watermark, regardless of ordering quirks in old
+    data.
+    """
+    return max((m.seq for m in session.history if m.seq), default=0)
+
+
 def _new_agent_history_entries(
-    session, baseline: int, *, chain_id: str | None = None,
+    session, baseline_seq: int, *, chain_id: str | None = None,
 ) -> list[str]:
-    """Return text of every history entry past `baseline` whose role is
-    ``agent``. Order-preserving.
+    """Return text of every history entry with ``seq > baseline_seq`` whose
+    role is ``agent``. Order-preserving (``self.history`` is append-ordered
+    by construction; a coordinate-based filter over it stays in that order).
 
     When ``chain_id`` is provided, only entries whose ``meta["chain_id"]``
     matches are returned. This scopes reply harvesting to the caller's
@@ -116,7 +138,9 @@ def _new_agent_history_entries(
     A2A FastAPI router) don't pick up each other's replies.
     """
     out: list[str] = []
-    for msg in session.history[baseline:]:
+    for msg in session.history:
+        if msg.seq <= baseline_seq:
+            continue
         # Issue #383: role rename "agent" → "assistant"; tolerate both.
         if msg.role not in ("assistant", "agent") or not msg.text:
             continue
@@ -127,12 +151,19 @@ def _new_agent_history_entries(
 
 
 async def _await_turn_complete(
-    session, *, baseline: int, timeout: float
+    session, *, baseline_seq: int, timeout: float
 ) -> bool:
     """Wait until the agent has produced at least one new ``role="agent"``
-    history entry past ``baseline`` AND the run loop is back to idle
-    (inbox empty, run loop back to idle). Returns True on completion,
+    history entry with ``seq > baseline_seq`` AND the run loop is back to
+    idle (inbox empty, run loop back to idle). Returns True on completion,
     False on timeout.
+
+    Unused today (dead code — no call site), but fixed alongside
+    ``_new_agent_history_entries`` (#4387 architect review) rather than
+    left as a landmine: it has the exact same ``session.history[baseline:]``
+    position-index shape, which silently returns the WRONG slice once
+    anything can prepend to ``self.history`` — see
+    ``_history_baseline_seq``'s docstring.
 
     The negative-signal-only approach (= "looks idle, no work in flight")
     used to false-positive: between ``submit_user_text`` returning and
@@ -150,7 +181,8 @@ async def _await_turn_complete(
         # bypassed read-time migration.
         has_reply = any(
             msg.role in ("assistant", "agent")
-            for msg in session.history[baseline:]
+            for msg in session.history
+            if msg.seq > baseline_seq
         )
         is_idle = session.inbox.empty()
         if has_reply and is_idle:
@@ -253,7 +285,7 @@ async def send_to_agent_impl(
     # protects THIS session's history, and an agent can have more than one
     # live session; see agent_locks.py's own docstring).
     async with _get_agent_lock(agent_name, sid):
-        baseline = len(session.history)
+        baseline_seq = _history_baseline_seq(session)
         bus = MessageBus()
         # issue #268 Phase 2: when the override exposes a stable
         # ``channel_id`` (= A2AInterventionBus does), register it as
@@ -282,7 +314,7 @@ async def send_to_agent_impl(
                 if override_channel_id is not None:
                     session.unregister_intervention_listener(override_channel_id)
         new_replies = _new_agent_history_entries(
-            session, baseline, chain_id=chain_id,
+            session, baseline_seq, chain_id=chain_id,
         )
 
     # idle = MessageBus returned quiescently (all tasks done, inbox empty).

--- a/src/reyn/mcp/server.py
+++ b/src/reyn/mcp/server.py
@@ -50,16 +50,6 @@ if TYPE_CHECKING:
 # before returning whatever partial output has accumulated.
 DEFAULT_SEND_TIMEOUT_SECONDS: float = 60.0
 
-# Polling interval while waiting for the agent's run loop to drain its
-# inbox and return to idle. Small enough that latency feels instant;
-# large enough that the loop is essentially free.
-_IDLE_POLL_INTERVAL_SECONDS: float = 0.05
-
-# Brief grace period AFTER inbox is empty, before we declare the turn
-# done. Without it we can race the router and miss the final
-# ``kind="agent"`` outbox push.
-_IDLE_GRACE_SECONDS: float = 0.05
-
 
 # Per-(agent, sid) serialization lock (proposal 0067 P1, #3978 — rekeyed
 # from agent_name alone; this lock protects THIS session's history, and an
@@ -148,52 +138,6 @@ def _new_agent_history_entries(
             continue
         out.append(msg.text)
     return out
-
-
-async def _await_turn_complete(
-    session, *, baseline_seq: int, timeout: float
-) -> bool:
-    """Wait until the agent has produced at least one new ``role="agent"``
-    history entry with ``seq > baseline_seq`` AND the run loop is back to
-    idle (inbox empty, run loop back to idle). Returns True on completion,
-    False on timeout.
-
-    Unused today (dead code — no call site), but fixed alongside
-    ``_new_agent_history_entries`` (#4387 architect review) rather than
-    left as a landmine: it has the exact same ``session.history[baseline:]``
-    position-index shape, which silently returns the WRONG slice once
-    anything can prepend to ``self.history`` — see
-    ``_history_baseline_seq``'s docstring.
-
-    The negative-signal-only approach (= "looks idle, no work in flight")
-    used to false-positive: between ``submit_user_text`` returning and
-    the run loop's ``inbox.get()`` actually picking up the message,
-    there's a window where the inbox briefly looks empty even though
-    nothing has been processed yet. Adding the positive signal (= a
-    new agent reply landed in history) closes that race — we only
-    declare done once the agent has measurably emitted something AND
-    the run loop has parked.
-    """
-    deadline = asyncio.get_event_loop().time() + timeout
-    while True:
-        # Issue #383: assistant replies now have role="assistant". "agent"
-        # kept in the predicate for any pre-#383 history entry that
-        # bypassed read-time migration.
-        has_reply = any(
-            msg.role in ("assistant", "agent")
-            for msg in session.history
-            if msg.seq > baseline_seq
-        )
-        is_idle = session.inbox.empty()
-        if has_reply and is_idle:
-            # Grace period to absorb a possible second `agent_response`
-            # follow-up in the same turn (= multi-iteration router loops).
-            await asyncio.sleep(_IDLE_GRACE_SECONDS)
-            if session.inbox.empty():
-                return True
-        if asyncio.get_event_loop().time() >= deadline:
-            return False
-        await asyncio.sleep(_IDLE_POLL_INTERVAL_SECONDS)
 
 
 async def list_agents_impl(registry: "AgentRegistry") -> list[dict]:

--- a/tests/mcp/test_4387_history_baseline_seq_survives_prepend.py
+++ b/tests/mcp/test_4387_history_baseline_seq_survives_prepend.py
@@ -1,0 +1,105 @@
+"""Tier 2: #4387 architect review (Phase B ②) — MCP's reply-harvest baseline
+survives a prepend to ``session.history``.
+
+``send_to_agent_impl`` captures a "baseline" before dispatching a request,
+then later asks "what's new since then". It used to capture ``len(session.
+history)`` and read ``session.history[baseline:]`` — a POSITION index. #4387
+Phase B's on-demand older-entry loading (not yet implemented) will PREPEND
+older entries to ``self.history`` for other consumers (TUI scrollback paging,
+``_active_branch_history``); a position index silently reads the WRONG slice
+once anything can prepend — no exception, just old messages reported as "the
+new reply".
+
+Fixed to capture a ``seq`` watermark (``_history_baseline_seq``) and filter by
+coordinate (``msg.seq > baseline_seq``) instead — immune to a prepend by
+construction, since ``seq`` is a property of each entry, not its position.
+
+Real ``ChatMessage`` instances, real list mutation (a plain ``insert(0, ...)``
+stands in for what ``_load_older_entries`` will eventually do — the shape
+under test is "prepend changes positions but not seqs", not that primitive's
+own not-yet-written implementation).
+"""
+from __future__ import annotations
+
+from reyn.mcp.server import _history_baseline_seq, _new_agent_history_entries
+from reyn.runtime.chat_message import ChatMessage
+
+
+def _msg(role: str, content: str, seq: int) -> ChatMessage:
+    return ChatMessage(role=role, content=content, seq=seq)
+
+
+class _FakeSession:
+    def __init__(self, history: "list[ChatMessage]") -> None:
+        self.history = history
+
+
+def test_baseline_seq_filters_correctly_after_a_prepend() -> None:
+    """Tier 2: the exact failure shape architect named. Capture a baseline,
+    prepend OLDER entries (as on-demand loading will), append a genuinely
+    NEW reply, then harvest — must return only the new reply, never any of
+    the prepended older ones."""
+    s = _FakeSession([
+        _msg("user", "hi", seq=10),
+        _msg("assistant", "hello", seq=11),
+    ])
+    baseline_seq = _history_baseline_seq(s)
+    assert baseline_seq == 11
+
+    # Simulate Phase B's on-demand older-entry load: entries OLDER than
+    # anything currently held get PREPENDED — positions shift, seqs don't.
+    s.history.insert(0, _msg("assistant", "ancient reply", seq=3))
+    s.history.insert(0, _msg("user", "ancient question", seq=2))
+
+    # The real new reply, appended normally after the baseline was captured.
+    s.history.append(_msg("assistant", "genuinely new reply", seq=12))
+
+    harvested = _new_agent_history_entries(s, baseline_seq)
+
+    assert harvested == ["genuinely new reply"], (
+        "must harvest exactly the post-baseline reply — not the prepended "
+        "ancient one, which now sits at a list position >= the old "
+        "position-based baseline would have used"
+    )
+
+
+def test_baseline_seq_matches_the_position_based_answer_without_a_prepend() -> None:
+    """Tier 2: accept-side — with NO prepend (today's only real shape, since
+    Phase B ② isn't implemented yet), the seq-based filter agrees with what
+    the old position-based slice would have returned. The fix changes HOW
+    the answer is computed, not what it is, in the case that already works."""
+    s = _FakeSession([
+        _msg("user", "hi", seq=1),
+        _msg("assistant", "hello", seq=2),
+    ])
+    baseline_seq = _history_baseline_seq(s)
+    old_style_baseline_len = len(s.history)
+
+    s.history.append(_msg("assistant", "reply A", seq=3))
+    s.history.append(_msg("user", "more", seq=4))
+    s.history.append(_msg("assistant", "reply B", seq=5))
+
+    seq_based = _new_agent_history_entries(s, baseline_seq)
+    position_based = [
+        m.text for m in s.history[old_style_baseline_len:]
+        if m.role in ("assistant", "agent") and m.text
+    ]
+    assert seq_based == position_based == ["reply A", "reply B"]
+
+
+def test_baseline_seq_respects_chain_id_filter() -> None:
+    """Tier 2: the ``chain_id`` scoping (concurrent callers on the same
+    session) still works under the seq-based filter — unrelated axis, must
+    not have been dropped by the rewrite."""
+    s = _FakeSession([_msg("user", "hi", seq=1)])
+    baseline_seq = _history_baseline_seq(s)
+
+    reply_a = _msg("assistant", "for chain A", seq=2)
+    reply_a.meta["chain_id"] = "chain-a"
+    reply_b = _msg("assistant", "for chain B", seq=3)
+    reply_b.meta["chain_id"] = "chain-b"
+    s.history.extend([reply_a, reply_b])
+
+    assert _new_agent_history_entries(s, baseline_seq, chain_id="chain-a") == [
+        "for chain A"
+    ]


### PR DESCRIPTION
**[tui-coder]** — #4387 Phase B ②a — standalone prerequisite, found during architect's design review (not the `_load_older_entries` primitive itself, which comes after this).

Architect's review of Phase B ②'s design (on-demand older-entry loading, not yet implemented) found a real consumer the original design discussion missed: `send_to_agent_impl` captured `baseline = len(session.history)` and later read `session.history[baseline:]` — a **position index**. Once anything can **prepend** older entries to `self.history` (Phase B ②'s whole point, for TUI scrollback paging / `_active_branch_history`), that position index silently reads the **wrong (older) slice** — no exception, an old message just gets reported as 'the new reply'.

Fixed to capture a `seq` watermark (`_history_baseline_seq`, mirroring `load_history`'s own `max(seq)` derivation) and filter `session.history` by `msg.seq > baseline_seq` instead — immune to a prepend by construction, since `seq` is a property of each entry, not its position.

`_await_turn_complete` had the exact same shape but no call site (genuinely dead code, confirmed via pyright's unused-symbol flag) — fixed alongside rather than left as a landmine for whoever revives it.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 3/3 OK, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py src/reyn/mcp/server.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (211/215 baselined)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] Falsify-verify: temporarily reverted `_new_agent_history_entries` to the old position-based body; the new prepend test failed for real (`assert [] == ['genuinely new reply']`); restored, confirmed GREEN
- [x] Scoped pytest — 46 passed (`test_mcp_server_progress_271`, `test_a2a`, `test_mcp_sse`, `test_a2a_bus_stamping_268_phase2`, `test_4189_list_agents_impl_real_consumer`, `test_mcp_iv_support_270_phase_b`, plus the new file)
- [ ] Visual — n/a (no UI surface)

part of #4387

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**[lead-coder]** — レビュアの blocking 項目

- [x] 🔴 `_await_turn_complete` を修正ではなく★削除する。呼び出し元 0 件（`git grep` で確認）で、PR 自身が dead code と明記しています。「landmine として残すより直す」は、誰も実行しない経路が★正しく見える状態で残るという別の landmine を作ります（CLAUDE.md の #3850 の教訓）。判別子は「今 prepend で壊れるか」ではなく「★誰かが呼ぶか」です。


⚪ **上の箱は★レビュア（lead-coder）が閉じました** — `pull/4404/head` で `_await_turn_complete` が **0 hit**（完全に削除済）であることを直接確認した結果です。
