### PR TITLE
feat(#4387): on-demand older-entry loading for WAL rewind visibility

### DIFF
--- a/src/reyn/core/events/snapshot_generations.py
+++ b/src/reyn/core/events/snapshot_generations.py
@@ -228,6 +228,30 @@ def is_active_seq(state_log: StateLog, seq: int) -> bool:
     return _make_is_active(_abandoned_intervals(_rewind_records(state_log)))(seq)
 
 
+def earliest_relevant_wal_seq(state_log: StateLog) -> "int | None":
+    """The lowest ``wal_seq`` any abandoned interval's active-check could
+    possibly need to compare against, or ``None`` if the session has never
+    rewound. #4387 Phase B ②: a consumer holding only a BOUNDED in-memory
+    prefix of ``self.history`` (``Session._active_branch_history``, once
+    ``load_history()`` stopped always reading the whole file) needs to know
+    whether it must extend backward before running ``is_active(seq)`` over
+    what it has — anything with ``seq`` at or below this value is where an
+    abandoned interval's own boundary sits, so a caller already holding
+    everything down to (and including) this value has enough to answer
+    correctly for every seq it will actually test.
+
+    Deliberately the interval LOWER bounds only (each ``(lo, hi)``'s
+    ``lo``), not every seq ever mentioned: ``_make_is_active``'s own check
+    is ``lo < seq < hi`` — a seq at or below every ``lo`` is active by
+    construction, off every interval it could possibly be inside, so
+    nothing OLDER than the lowest ``lo`` changes the answer for it.
+    """
+    abandoned = _abandoned_intervals(_rewind_records(state_log))
+    if not abandoned:
+        return None
+    return min(lo for lo, _hi in abandoned)
+
+
 def build_active_predicate(state_log: StateLog) -> Callable[[int], bool]:
     """Build a reusable ``is_active(seq)`` predicate — ONE derivation for MANY seqs.
 

--- a/src/reyn/runtime/history_tail_reader.py
+++ b/src/reyn/runtime/history_tail_reader.py
@@ -37,6 +37,47 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+def _iter_raw_lines_reverse(path: Path, *, chunk_size: int) -> "Iterator[str]":
+    """Yield *path*'s lines one at a time, newest-first, reading backward
+    from EOF in growing-safe chunks. Shared by :func:`read_history_tail`
+    and :func:`read_history_before` (#4387 Phase B ②) so the carry/split
+    handling — the part actually worth getting wrong once, not twice —
+    lives in one place. Caller decides when to stop (this generator itself
+    never stops early; it exhausts to BOF unless the caller breaks)."""
+    size = path.stat().st_size
+    if size == 0:
+        return
+    pos = size
+    # Bytes read from the START of the previous (further-back) chunk that
+    # didn't yet complete a line when that chunk was split — prefixed onto
+    # the NEXT (even-further-back) read so a line straddling a chunk
+    # boundary is never mis-split. Grows without bound only in the
+    # pathological case of one line longer than chunk_size, same tolerance
+    # ``budget.py``'s ``tail_boundary`` gives that case.
+    carry = b""
+    with path.open("rb") as f:
+        while pos > 0:
+            read_size = min(chunk_size, pos)
+            pos -= read_size
+            f.seek(pos)
+            buf = f.read(read_size) + carry
+            parts = buf.split(b"\n")
+            if pos > 0:
+                carry = parts[0]
+                complete = parts[1:]
+            else:
+                carry = b""
+                complete = parts
+            for raw in reversed(complete):
+                line = raw.decode("utf-8", errors="replace").strip()
+                if line:
+                    yield line
 
 
 def read_last_line(path: Path, *, chunk_size: int = 8192) -> "str | None":
@@ -79,69 +120,64 @@ def read_history_tail(
     """
     if not path.is_file():
         return []
-    size = path.stat().st_size
-    if size == 0:
-        return []
 
     collected: list[str] = []
     seen_summary = False
-    pos = size
-    # Bytes read from the START of the previous (further-back) chunk that
-    # didn't yet complete a line when that chunk was split — prefixed onto
-    # the NEXT (even-further-back) read so a line straddling a chunk
-    # boundary is never mis-split. Grows without bound only in the
-    # pathological case of one line longer than chunk_size, same tolerance
-    # ``budget.py``'s ``tail_boundary`` gives that case.
-    carry = b""
+    # Stop condition is (seen_summary AND collected >= min_lines) — NEVER
+    # "collected >= min_lines" alone. Without a summary, we cannot tell
+    # "no compaction has EVER run" (everything is uncompacted, so a
+    # short-circuit here would violate the watermark-completeness invariant
+    # every bounded consumer depends on) apart from "the summary is just
+    # further back than min_lines" (test_read_history_tail_reads_past_the_
+    # floor_to_include_the_latest_summary) — both look identical until BOF
+    # is actually reached, so BOF is the only safe fallback stop.
+    for line in _iter_raw_lines_reverse(path, chunk_size=chunk_size):
+        collected.append(line)
+        if not seen_summary:
+            try:
+                if json.loads(line).get("role") == "summary":
+                    seen_summary = True
+            except (json.JSONDecodeError, AttributeError):
+                pass
+        if len(collected) >= min_lines and seen_summary:
+            break
 
-    with path.open("rb") as f:
-        while pos > 0:
-            read_size = min(chunk_size, pos)
-            pos -= read_size
-            f.seek(pos)
-            buf = f.read(read_size) + carry
-            parts = buf.split(b"\n")
-            if pos > 0:
-                # parts[0] may be a partial line — carry it into the next
-                # (further-back) read rather than treating it as complete.
-                carry = parts[0]
-                complete = parts[1:]
-            else:
-                carry = b""
-                complete = parts
+    collected.reverse()
+    return collected
 
-            # Checked PER LINE, not just per chunk: a chunk can (and for a
-            # small file, on the very first read, always does) contain far
-            # more than min_lines — stopping only at chunk boundaries would
-            # silently ignore the floor whenever one read covers the whole
-            # remaining file.
-            #
-            # Stop condition is (seen_summary AND collected >= min_lines) —
-            # NEVER "collected >= min_lines" alone. Without a summary, we
-            # cannot tell "no compaction has EVER run" (everything is
-            # uncompacted, so a short-circuit here would violate the
-            # watermark-completeness invariant every bounded consumer
-            # depends on) apart from "the summary is just further back than
-            # min_lines" (test_read_history_tail_reads_past_the_floor_to_
-            # include_the_latest_summary) — both look identical until BOF is
-            # actually reached, so BOF is the only safe fallback stop.
-            done = False
-            for raw in reversed(complete):
-                line = raw.decode("utf-8", errors="replace").strip()
-                if not line:
-                    continue
-                collected.append(line)
-                if not seen_summary:
-                    try:
-                        if json.loads(line).get("role") == "summary":
-                            seen_summary = True
-                    except (json.JSONDecodeError, AttributeError):
-                        pass
-                if len(collected) >= min_lines and seen_summary:
-                    done = True
-                    break
-            if done:
-                break
+
+def read_history_before(
+    path: Path, *, before_seq: int, min_lines: int = 200, chunk_size: int = 65536,
+) -> list[str]:
+    """#4387 Phase B ②: read *path* backward from EOF, SKIPPING every line
+    whose ``seq >= before_seq`` (already held in memory by whoever is
+    calling this — see ``Session._load_older_entries``), then collecting
+    up to ``min_lines`` further lines older than that. Returns raw JSON-line
+    strings in FILE order (oldest first). Empty list if the file is
+    missing/empty, or if BOF is reached before any qualifying line is seen.
+
+    Unlike :func:`read_history_tail`, this has NO safety floor analogous to
+    "must include a summary" — a caller extending an ALREADY-loaded prefix
+    backward is, by construction, not making a fresh completeness claim
+    about compaction watermarks (that invariant was already satisfied by
+    whatever got the caller its current ``self.history`` in the first
+    place); it is only answering "give me up to N more lines older than
+    what I already have," which ``min_lines`` alone answers correctly.
+    """
+    if not path.is_file():
+        return []
+
+    collected: list[str] = []
+    for line in _iter_raw_lines_reverse(path, chunk_size=chunk_size):
+        try:
+            seq = int(json.loads(line).get("seq", 0) or 0)
+        except (json.JSONDecodeError, AttributeError, TypeError, ValueError):
+            seq = 0
+        if seq >= before_seq:
+            continue
+        collected.append(line)
+        if len(collected) >= min_lines:
+            break
 
     collected.reverse()
     return collected

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2842,10 +2842,39 @@ class Session:
         anchors drop out); fork-switch makes an alternate branch's anchors active;
         the future/other-branch turns stay in the file, just outside the visible
         prefix. Turns without an anchor (pre-#2360 entries, or no state_log) are
-        always visible (backward-compatible, no migration)."""
+        always visible (backward-compatible, no migration).
+
+        #4387 Phase B ②: since ``load_history()`` no longer necessarily
+        loads the whole file, this extends ``self.history`` BACKWARD first
+        (:meth:`_load_older_entries`) whenever the active branch's own
+        abandoned-interval bounds reach further back than what's currently
+        in memory — see ``earliest_relevant_wal_seq``'s own docstring for
+        why its return value is the exact threshold that makes the filter
+        below correct. A session that has never rewound
+        (``earliest_relevant_wal_seq`` returns ``None``) never triggers
+        this — the common case pays nothing extra.
+        """
         if self._state_log is None:
             return self.history
-        from reyn.core.events.snapshot_generations import build_active_predicate
+        from reyn.core.events.snapshot_generations import (
+            build_active_predicate,
+            earliest_relevant_wal_seq,
+        )
+
+        threshold = earliest_relevant_wal_seq(self._state_log)
+        if threshold is not None:
+            while True:
+                loaded_wal_seqs: "list[int]" = [
+                    m.meta["wal_seq"] for m in self.history
+                    if isinstance(m.meta, dict) and isinstance(m.meta.get("wal_seq"), int)
+                ]
+                earliest_loaded = min(loaded_wal_seqs) if loaded_wal_seqs else None
+                if earliest_loaded is not None and earliest_loaded <= threshold:
+                    break
+                oldest_seq = self.history[0].seq if self.history else 0
+                extended = self._load_older_entries(before_seq=oldest_seq)
+                if extended == 0:
+                    break  # BOF reached — nothing older exists on disk
 
         # #2941: hoisted OUT of the per-message loop below. The abandoned-interval
         # predicate depends only on the state_log's rewind records, never on a
@@ -3205,19 +3234,54 @@ class Session:
             depth=depth, chain_id=chain_id, responder_sid=responder_sid,
         )
 
-    def _append_parsed_history_line(self, line: str) -> None:
-        """Parse one ``history.jsonl`` line and append it to ``self.history``
-        — the per-line body shared by both of :meth:`load_history`'s paths.
-        Malformed lines are skipped (byte-identical to the pre-#4387
-        behavior), never raised."""
+    def _parse_history_line(self, line: str) -> "ChatMessage | None":
+        """Parse one ``history.jsonl`` line into a ``ChatMessage``, or
+        ``None`` if malformed (skipped, never raised — byte-identical to
+        the pre-#4387 behavior). Pure: does not touch ``self.history``."""
         try:
             raw = json.loads(line)
             # Read-time migration for pre-#383 entries (legacy text + media
             # shape → new content shape).
             raw = _migrate_legacy_chat_message(raw)
-            self.history.append(ChatMessage(**raw))
+            return ChatMessage(**raw)
         except Exception:
-            pass
+            return None
+
+    def _append_parsed_history_line(self, line: str) -> None:
+        """Parse one ``history.jsonl`` line and append it to ``self.history``
+        — the per-line body shared by both of :meth:`load_history`'s paths."""
+        msg = self._parse_history_line(line)
+        if msg is not None:
+            self.history.append(msg)
+
+    def _load_older_entries(self, *, before_seq: int, min_lines: int = _HISTORY_HYDRATE_MIN_LINES) -> int:
+        """#4387 Phase B ②: extend ``self.history`` BACKWARD from
+        ``history.jsonl``, prepending up to ``min_lines`` entries older
+        than ``before_seq`` (typically ``self.history[0].seq`` — "give me
+        more of what I don't have yet"). Returns the count actually
+        prepended (0 if none qualify, e.g. already at the file's start).
+
+        Called by consumers that need to look further back than what a
+        bounded :meth:`load_history` loaded at startup — currently
+        :meth:`_active_branch_history` when a rewind/branch-switch cut
+        references a ``wal_seq`` older than anything in memory. Prepending
+        never evicts anything already loaded (Phase B is "load lazily,"
+        not "unload") — see the module docstring on why that is currently
+        UNBOUNDED (a deep rewind can pull most of a huge file back into
+        memory) and left that way deliberately: bounding it caps how far
+        back a rewind can reach, which is an owner-facing capability
+        question, not one this stage answers.
+        """
+        from reyn.runtime.history_tail_reader import read_history_before
+
+        lines = read_history_before(
+            self.history_path, before_seq=before_seq, min_lines=min_lines,
+        )
+        if not lines:
+            return 0
+        parsed = [m for line in lines if (m := self._parse_history_line(line)) is not None]
+        self.history[0:0] = parsed
+        return len(parsed)
 
     def load_history(self) -> None:
         """#4387 Phase B ①: hydrate ``self.history`` at startup WITHOUT

--- a/tests/core/test_4387_active_branch_history_extend_on_demand.py
+++ b/tests/core/test_4387_active_branch_history_extend_on_demand.py
@@ -1,0 +1,185 @@
+"""Tier 2: #4387 Phase B ② — ``Session._active_branch_history`` extends
+``self.history`` backward on demand when a rewind's cut point is older than
+what's currently in memory.
+
+Phase B ① (#4400) made ``load_history()`` load only a BOUNDED tail at
+startup rather than the whole file. ``_active_branch_history`` (#2360's
+rewind-visibility filter) only ever looked at ``self.history`` — before
+Phase B ①, that was always the complete file, so a rewind past the
+compaction watermark still worked by accident. Once ``self.history`` can
+be a genuine prefix, a rewind whose cut point references content older
+than that prefix would (without this fix) silently show FEWER turns than
+the active branch actually contains, or none at all — not a crash, just a
+wrong answer, the same "silent, not loud" failure shape architect's
+Phase B ② review flagged for ``mcp/server.py``'s position index.
+
+Real ``Session`` + real ``StateLog`` + the real ``checkout`` reset-record
+primitive throughout — same seam ``test_conversation_rewind_2360.py``
+already established. The "bounded load" precondition is simulated by
+truncating ``self.history`` directly after real turns are appended (the
+same technique ``test_3380_...``'s sibling tests already use to simulate
+"this content is not currently in memory" — see that file's own
+``s.history = [...]`` precedent), NOT by re-deriving Phase B ①'s own
+tail-selection logic, which is already covered by
+``test_4387_bounded_history_hydration.py``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.snapshot_generations import REWIND_KIND, checkout
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+
+def _session(tmp_path: Path, state_log: StateLog) -> Session:
+    s = make_session(
+        agent_name="alice", state_log=state_log,
+        snapshot_path=tmp_path / "alice_snapshot.json",
+    )
+    s.register_intervention_listener("test")
+    return s
+
+
+async def _turn(session: Session, state_log: StateLog, text: str) -> int:
+    """Mirrors test_conversation_rewind_2360.py's own helper: advance the
+    WAL (real turn processing), then append the turn, real coordinates
+    throughout."""
+    await state_log.append("step_completed")
+    session._append_history(ChatMessage(role="user", content=text))
+    return session.history[-1].meta["wal_seq"]
+
+
+def _visible_texts(session: Session) -> "list[str | list[dict]]":
+    return [m.content for m in session._active_branch_history()]
+
+
+@pytest.mark.asyncio
+async def test_rewind_past_a_bounded_prefix_extends_backward(tmp_path, monkeypatch):
+    """Tier 2: 10 real turns appended, self.history then truncated to only
+    the last 3 (simulating a bounded startup load) — a real rewind to
+    BEFORE that truncated prefix must still show the correct active turns,
+    not an empty/wrong result."""
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    s = _session(tmp_path, state_log)
+    anchors = [await _turn(s, state_log, f"turn {i}") for i in range(1, 11)]
+
+    on_disk = s.history_path.read_text()
+    for i in range(1, 11):
+        assert f"turn {i}" in on_disk, f"sanity: turn {i} must be durable on disk"
+
+    # Simulate a bounded startup load: only the last 3 turns are in memory.
+    s.history = s.history[-3:]
+    assert [m.content for m in s.history] == ["turn 8", "turn 9", "turn 10"]
+
+    # Rewind to after turn 3 — entirely OLDER than what's currently loaded.
+    await checkout(state_log, target_seq=anchors[2])
+
+    assert _visible_texts(s) == ["turn 1", "turn 2", "turn 3"], (
+        "the active branch (turns 1-3) must be visible even though none of "
+        "them were in the bounded self.history before the rewind"
+    )
+    # And the entries that got pulled back in are now genuinely IN self.history
+    # (not just returned transiently) — _load_older_entries prepends, doesn't
+    # hand back a throwaway view.
+    assert [m.content for m in s.history[:3]] == ["turn 1", "turn 2", "turn 3"]
+
+
+@pytest.mark.asyncio
+async def test_no_rewind_never_touches_disk_beyond_what_is_loaded(tmp_path, monkeypatch):
+    """Tier 2: accept-side — a session that has NEVER rewound (the
+    overwhelming common case) must not trigger any backward extension, even
+    with a truncated self.history. earliest_relevant_wal_seq returning None
+    is what keeps this cheap for every ordinary turn."""
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    s = _session(tmp_path, state_log)
+    for i in range(1, 11):
+        await _turn(s, state_log, f"turn {i}")
+
+    s.history = s.history[-3:]  # bounded load, but no rewind ever happened
+
+    assert _visible_texts(s) == ["turn 8", "turn 9", "turn 10"], (
+        "with no rewind, the bounded prefix IS the correct active view — "
+        "no backward extension should have been triggered"
+    )
+    assert [m.content for m in s.history] == ["turn 8", "turn 9", "turn 10"], (
+        "self.history must stay untouched (no extension fired)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_extend_backward_survives_wal_truncation_below_the_rewind_record(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: CLAUDE.md recovery-feature PR gate (truncate-falsify).
+    ``_load_older_entries``/``earliest_relevant_wal_seq`` (this PR's new
+    consumer-level code) read WAL-derived state through the SAME
+    ``_abandoned_intervals``/``_rewind_records`` primitive
+    ``test_rewind_index_incremental_2939.py`` already truncate-falsifies at
+    the ``StateLog`` level — this test proves the NEW consumer built on top
+    of it (``Session._active_branch_history``'s extend-backward wiring)
+    doesn't break under the production truncation call
+    (``always_keep_kinds=frozenset({REWIND_KIND})``, which protects the
+    reset-record — the documented correct usage, per
+    ``StateLog.truncate_below``'s own docstring on why ``REWIND_KIND`` must
+    survive: dropping it "causes abandoned conversation turns to reappear
+    in the LLM context").
+
+    Set X (a rewind hiding turns 4-10) → truncate the WAL below the
+    reset-record's own seq, WITH the record protected → reconstruct
+    (``_active_branch_history``, which now has to extend self.history
+    backward past the bounded 3-turn prefix) → X survives (turns 4-10 stay
+    hidden, turns 1-3 correctly visible from the extended prefix).
+    """
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    s = _session(tmp_path, state_log)
+    anchors = [await _turn(s, state_log, f"turn {i}") for i in range(1, 11)]
+    s.history = s.history[-3:]  # bounded load: only turns 8-10 in memory
+
+    await checkout(state_log, target_seq=anchors[2])  # hide turns 4-10
+    # Grow the WAL further so there's real content past the rewind to
+    # truncate BELOW (truncate_below's min_keep_seq must be > the rewind
+    # record's own seq for this to be a meaningful drop, not a no-op).
+    for i in range(11, 14):
+        await _turn(s, state_log, f"turn {i}")
+
+    assert _visible_texts(s) == [f"turn {i}" for i in (1, 2, 3, 11, 12, 13)], (
+        "sanity: turns 4-10 abandoned, 1-3 + 11-13 active, before truncation"
+    )
+
+    kept_kinds_before = {e.get("kind") for e in state_log.iter_from(0)}
+    assert REWIND_KIND in kept_kinds_before, "sanity: a reset-record exists to protect"
+
+    # Truncate below a point PAST the reset-record's own seq, protecting it —
+    # the real production call (registry.py's own retention path).
+    await state_log.truncate_below(anchors[-1], always_keep_kinds=frozenset({REWIND_KIND}))
+    await state_log.flush()
+
+    surviving_kinds = [e.get("kind") for e in state_log.iter_from(0)]
+    assert REWIND_KIND in surviving_kinds, (
+        "test premise: the reset-record must have survived truncation, "
+        "otherwise this isn't testing what it claims to"
+    )
+
+    # Reconstruct: a FRESH bounded self.history again (as if the process
+    # just restarted and load_history() gave only the newest turns), then
+    # ask _active_branch_history to answer from the (now-truncated) WAL.
+    # (self.history already grew via the extend-backward call above, so
+    # re-truncate explicitly by content rather than assuming a slice.)
+    s.history = [m for m in s.history if m.content in ("turn 11", "turn 12", "turn 13")]
+    assert [m.content for m in s.history] == ["turn 11", "turn 12", "turn 13"], (
+        "sanity: the reconstructed bounded prefix is exactly the newest 3 turns"
+    )
+
+    assert _visible_texts(s) == ["turn 1", "turn 2", "turn 3", "turn 11", "turn 12", "turn 13"], (
+        "X survives truncation: turns 4-10 must STILL be hidden and 1-3 "
+        "STILL correctly recovered by extend-backward, using the "
+        "truncated-but-REWIND_KIND-protected WAL"
+    )


### PR DESCRIPTION
**[tui-coder]** — #4387 Phase B ② main body (PR② of the design posted at https://github.com/tya5/reyn/issues/4387#issuecomment-5264220134, updated per architect's review). #4404 (mcp/server.py's position-index fix) was the standalone prerequisite this PR builds on.

`Session.load_history()` (Phase B ①, #4400) now loads only a bounded tail at startup, but `_active_branch_history` (#2360's rewind-visibility filter) only ever looked at `self.history` — before Phase B ①, that was always the whole file, so a rewind past what's currently loaded worked by accident. Once `self.history` is a genuine prefix, such a rewind would silently show fewer turns than the active branch actually contains (or none at all) — not a crash, the same "silent, not loud" shape architect's review flagged for `mcp/server.py`'s position index.

## New primitives

- `history_tail_reader.read_history_before(path, before_seq, min_lines)`: reads backward from EOF, skipping lines already known to be loaded (`seq >= before_seq`), collecting up to `min_lines` older ones. Shares the reverse-chunk-reading mechanics with `read_history_tail` via a new `_iter_raw_lines_reverse` generator (factored out rather than duplicated).
- `snapshot_generations.earliest_relevant_wal_seq(state_log)`: the lowest `wal_seq` any abandoned-interval's active-check could need — `None` if the session has never rewound. A session that never rewinds (the overwhelming common case) never triggers backward extension.
- `Session._load_older_entries(before_seq, min_lines)`: prepends up to `min_lines` older `ChatMessage`s. Never evicts anything already loaded (load lazily, not unload).
- `Session._active_branch_history()` now extends `self.history` backward, in a loop, until the earliest loaded `wal_seq` is at or below the threshold (or BOF), BEFORE running the existing branch-visibility filter.

## Deliberately UNBOUNDED (explicit, not an oversight)

A deep rewind can pull most of a huge file back into memory, reintroducing the class of problem #4387 exists to fix. Bounding this primitive caps how far back a rewind can reach — an owner-facing capability question (architect's own framing), raised when Phase B's bounding stage is designed, not decided here.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 3/3 OK, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py` on all 3 touched src files — OK
- [x] `python scripts/mypy_ratchet.py` — OK (211/215 baselined)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] **Truncate-falsify (CLAUDE.md recovery-feature PR gate)**: `test_extend_backward_survives_wal_truncation_below_the_rewind_record` — the underlying WAL-truncation behavior (`REWIND_KIND` protection) is already falsified at the `StateLog` level by `test_rewind_index_incremental_2939.py`; this proves the NEW consumer-level code (the extend-backward wiring) survives the production truncation call (`always_keep_kinds=frozenset({REWIND_KIND})`)
- [x] Falsify-verify (all 3 new tests): disabled the extend-backward branch; the bounded-prefix rewind test failed for real (returned `[]` where 3 turns were expected) and the truncate-falsify test failed at its own sanity check; restored, confirmed GREEN
- [x] Scoped pytest — 89 passed (rewind/branch/snapshot-generation suite, Phase B ① tests, mcp baseline-seq tests, plus the 3 new tests)
- [ ] Visual — n/a (no UI surface)

part of #4387

🤖 Generated with [Claude Code](https://claude.com/claude-code)
