### PR TITLE
fix(#4395): stop re-attempting a failed litellm import on every call

### DIFF
--- a/src/reyn/data/embedding/litellm_provider.py
+++ b/src/reyn/data/embedding/litellm_provider.py
@@ -389,8 +389,37 @@ class LiteLLMEmbeddingProvider:
                 # be the FIRST litellm import in the process — funnel it through
                 # ensure_litellm_ready() so litellm's import-time console log
                 # routing (#2929) wraps it too (idempotent; cheap on 2nd+ call).
-                from reyn.llm.litellm_bootstrap import ensure_litellm_ready
-                ensure_litellm_ready()
+                # #4395 PR-1: check success BEFORE `import litellm` — that used
+                # to be an unconditional bare import right after the
+                # chokepoint call, independently re-attempting (and
+                # re-failing) litellm's own slow, unbounded import on EVERY
+                # retry-loop iteration while it kept failing (a failed
+                # import isn't cached by Python; only this chokepoint's own
+                # attempt was) — doubling the cost of every already-retried
+                # attempt in this loop. `import litellm` below now only ever
+                # runs once success is confirmed, so it's always a cheap
+                # sys.modules cache hit. The existing `except Exception`
+                # below already handles this failure exactly like any other
+                # attempt failure — same retry/backoff behavior, half the
+                # redundant work per iteration.
+                from reyn.llm.litellm_bootstrap import (
+                    LitellmUnavailableError,
+                    ensure_litellm_ready,
+                )
+                # #4395: `asyncio.to_thread`, not an in-loop call — this is
+                # `async def`, and a synchronous `ensure_litellm_ready()`
+                # here blocks the WHOLE event loop for as long as the
+                # underlying import takes, not just this coroutine (lead-
+                # coder correction, #4395: PR-1 must land this call site
+                # already-awaitable so PR-2's dedicated-thread mechanism
+                # slots in behind the same await point without a rewrite
+                # of this call site).
+                if await asyncio.to_thread(ensure_litellm_ready) is None:
+                    raise LitellmUnavailableError(
+                        "import litellm failed — see the reyn.llm."
+                        "litellm_bootstrap warn-once log line for the "
+                        "underlying cause",
+                    )
                 import litellm
                 response = await self._aembedding_bounded(
                     litellm,

--- a/src/reyn/llm/litellm_bootstrap.py
+++ b/src/reyn/llm/litellm_bootstrap.py
@@ -11,10 +11,19 @@ stderr, so an interactive CUI session's terminal is never corrupted by a
 litellm banner or warning.
 
 ``ensure_litellm_ready()`` is the ONE place that should perform this
-first-import work. Callers that need the ``litellm`` module still do their own
-``import litellm`` afterward (cheap — Python caches the module), but calling
-``ensure_litellm_ready()`` first guarantees the log-routing patch is active
-for whichever call site happens to import litellm first in a given process.
+first-import work — and (#4395 PR-1) the ONE place the actual ``import
+litellm`` statement should live. Callers use the module it RETURNS
+(``None`` on failure) rather than doing their own separate ``import
+litellm`` afterward. An earlier version of this paragraph claimed a
+caller's own subsequent bare ``import litellm`` was "cheap — Python
+caches the module" — true only when the import SUCCEEDED. Python does
+NOT cache a FAILED import (a module whose top-level code raises is
+evicted from ``sys.modules``), so a caller doing its own redundant bare
+``import litellm`` right after this function would re-attempt — and
+re-fail — the exact same slow, unbounded network-touching import this
+function had JUST attempted, silently doubling the cost of every
+failure. See ``ensure_litellm_ready()``'s own docstring for the full
+success/failure contract this fixed.
 
 #3671: this module also owns the #3434 client-cache "pre-existing keys"
 baseline (:func:`reset_client_cache_baseline`/:func:`client_cache_baseline`)
@@ -34,7 +43,7 @@ from __future__ import annotations
 import contextlib
 import logging
 from concurrent.futures import Future
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -89,6 +98,18 @@ _ready_registry: "dict[str, Future]" = {}
 # reading, invalidating its baseline mid-call.
 _baseline_generation = 0
 _baseline_registry: "dict[int, Future]" = {}
+
+
+class LitellmUnavailableError(Exception):
+    """#4395 PR-1: raised by a call site with NO safe fallback (a real
+    completion or embedding call — `llm.py`'s `recorded_acompletion`,
+    `litellm_provider.py`'s `embed_batch`) when `ensure_litellm_ready()`
+    returns `None`. A clear, explicit failure instead of letting a
+    redundant, un-gated bare `import litellm` raise whatever exception
+    litellm's own failed import happened to produce — same underlying
+    cause, a legible error instead of an incidental one. Retriable: the
+    NEXT call gets a fresh attempt (see `ensure_litellm_ready()`'s own
+    docstring — a failure is not permanently cached)."""
 
 
 @contextlib.contextmanager
@@ -162,73 +183,140 @@ def _litellm_import_logs_to_file() -> "Iterator[None]":
             logger.propagate = True
 
 
-def ensure_litellm_ready() -> None:
-    """Idempotent first-touch chokepoint: import litellm + apply its one-time setup.
+_litellm_import_failure_warned = False
 
-    Runs at most once per process. Wraps the (possibly first-ever) ``import
-    litellm`` in ``_litellm_import_logs_to_file`` (preserving the interactive
-    CUI's clean-terminal guarantee — #2929) and sets
-    ``litellm.suppress_debug_info = True`` (litellm prints "Give Feedback /
-    Get Help" banners straight to stderr on a provider error, NOT via
+
+def ensure_litellm_ready() -> "Any | None":
+    """Idempotent first-touch chokepoint: import litellm + apply its
+    one-time setup, returning the imported module — or ``None`` if the
+    import itself failed.
+
+    #4395 (PR-1, the minimal fix): this function's OWN internal ``import
+    litellm`` is the single place that attempt happens; call sites should
+    use the RETURNED module rather than performing their own separate
+    ``import litellm`` afterward. Before this fix, the docstring here
+    claimed "callers still do their own ``import litellm`` afterward
+    (cheap — Python caches the module)" — true only when the import
+    SUCCEEDED. Python does NOT cache a FAILED import (a module whose
+    top-level code raises is evicted from ``sys.modules``), so 4 call
+    sites doing their own redundant bare ``import litellm`` right after
+    calling this function (``model_budget.py``, ``model_cost_rate.py``,
+    ``llm.py``, ``litellm_provider.py``) were each independently
+    re-attempting — and re-failing — the exact same slow, unbounded
+    network-touching import this function had JUST attempted, turning
+    one slow attempt per call into two. A live owner repro (py-spy
+    stack) caught the event-loop/UI thread blocked inside exactly this
+    redundant second attempt. A separate 3 sites in ``pricing.py``
+    bypassed this chokepoint entirely — a different failure mode (never
+    calling this function at all, not a redundant second attempt after
+    calling it).
+
+    THE UNDERLYING MISTAKE (not just the stale prose above): the old
+    docstring's false premise came from conflating two DIFFERENT
+    guarantees — "this chokepoint's one-time setup (log routing,
+    ``suppress_debug_info``, ``aiohttp_trust_env``) has run" is NOT the
+    same guarantee as "``import litellm`` will now succeed for you too".
+    A call site may only assume the SECOND from this function's actual
+    RETURN VALUE (the module, or ``None``) — never from the fact that
+    this function was merely called, or that it didn't raise, or from
+    any other side effect of having reached this chokepoint once before.
+    This is the general shape to watch for at any chokepoint: "setup ran"
+    and "the resource is usable" are separate claims, and only the
+    second is what a caller with no fallback actually needs.
+
+    On SUCCESS: returns the module, and stays ``True``-flagged for the
+    rest of the process — a successfully imported module is real,
+    permanent state (``sys.modules`` itself never re-runs it), so caching
+    "ready" forever is correct. On FAILURE: returns ``None``, and does
+    NOT cache the failure — the next call gets a fresh ownership round
+    and genuinely retries, because an environmental failure (a proxy
+    down) can clear, and callers with no fallback (a real completion or
+    embedding call) must keep trying on the next turn, not be
+    permanently locked out after one bad attempt. Emits a WARNED-ONCE
+    (not every failure — #3368's own "warn once, not every call" lesson)
+    log line the first time this happens in the process, so a
+    permanently-unusable environment is visible rather than silently
+    degrading every downstream fallback with no signal at all.
+
+    Wraps the (possibly first-ever) ``import litellm`` in
+    ``_litellm_import_logs_to_file`` (preserving the interactive CUI's
+    clean-terminal guarantee — #2929) and sets
+    ``litellm.suppress_debug_info = True`` (litellm prints "Give Feedback
+    / Get Help" banners straight to stderr on a provider error, NOT via
     ``logging``, so the file redirect above doesn't catch them; this
     suppresses them instead).
 
-    Call this before any bare ``import litellm`` in a lazy call site that
-    might be the first one to run in a given process — it costs one boolean
-    check on every call after the first, so it is cheap to call defensively.
-
     #3075 chokepoint coverage: this is the sole place the
-    ``litellm.aiohttp_trust_env = True`` flip is applied, and BOTH litellm
-    egress families reach it before their first real call — the completion
-    path via ``recorded_acompletion`` (``reyn.llm.llm``, the #1190 single
-    ``litellm.acompletion`` chokepoint, which calls this before the
-    ``acompletion``) and the embedding path via
-    ``LiteLLMEmbeddingProvider.embed_batch`` (``reyn.data.embedding.
-    litellm_provider``, which calls this before ``_aembedding_bounded`` →
-    ``litellm.aembedding``). So the proxy-trust flip covers every
+    ``litellm.aiohttp_trust_env = True`` flip is applied, and BOTH
+    litellm egress families reach it before their first real call — the
+    completion path via ``recorded_acompletion`` (``reyn.llm.llm``, the
+    #1190 single ``litellm.acompletion`` chokepoint) and the embedding
+    path via ``LiteLLMEmbeddingProvider.embed_batch`` (``reyn.data.
+    embedding.litellm_provider``). So the proxy-trust flip covers every
     litellm-originated request, not just chat.
     """
-    global _litellm_ready
+    global _litellm_ready, _litellm_import_failure_warned
     # Unlocked fast-path read keeps the "cheap on every call after the
-    # first" property this docstring promises — after the owner's Future
-    # resolves this flag is the only thing subsequent calls ever touch.
-    # NOTE: still falls through to `_capture_client_cache_baseline` below —
-    # the process-wide-once setup and the per-`run_async`-call baseline
-    # (#3671/#3434) are different lifetimes, so this early return must not
-    # skip the second one.
-    if not _litellm_ready:
-        my_future: "Future[None]" = Future()
-        winning_future = _ready_registry.setdefault("ready", my_future)
-        if winning_future is not my_future:
-            # Someone else already owns setup — wait for THEM to finish, not
-            # a lock, so we block only as long as the real work actually
-            # takes, never past it (the "started, not finished" bug this
-            # replaces).
-            winning_future.result()
-        else:
-            # We won ownership. Do the real work, then release every waiter.
-            try:
-                with _litellm_import_logs_to_file():
-                    try:
-                        import litellm
-                        litellm.suppress_debug_info = True
-                        # #3075 fix 1: litellm's aiohttp transport defaults
-                        # aiohttp_trust_env=False, so it is proxy-blind even when the
-                        # operator's standard HTTP(S)_PROXY/NO_PROXY env is set — the
-                        # highest-volume egress reyn originates (every LLM/embedding call)
-                        # was the sharpest non-conformer in the #3075 enumeration. Flipping
-                        # this makes litellm read the standard proxy env like every other
-                        # conforming egress; it already honours SSL_CERT_FILE/
-                        # REQUESTS_CA_BUNDLE via get_ssl_verify(), so this is the one
-                        # missing piece for full conformance.
-                        litellm.aiohttp_trust_env = True
-                    except Exception:  # noqa: BLE001 — best-effort; never block the caller on this
-                        pass
-            finally:
+    # first success" property this docstring promises. NOTE: still falls
+    # through to `_capture_client_cache_baseline` below — the
+    # process-wide-once setup and the per-`run_async`-call baseline
+    # (#3671/#3434) are different lifetimes, so this early return must
+    # not skip the second one.
+    if _litellm_ready:
+        _capture_client_cache_baseline()
+        import sys
+        return sys.modules.get("litellm")
+
+    my_future: "Future[Any | None]" = Future()
+    winning_future = _ready_registry.setdefault("ready", my_future)
+    if winning_future is not my_future:
+        # Someone else already owns this attempt — wait for THEM to
+        # finish, not a lock, so we block only as long as the real work
+        # actually takes, never past it (the "started, not finished" bug
+        # this replaces).
+        result = winning_future.result()
+    else:
+        # We won ownership. Do the real work, then release every waiter.
+        result = None
+        try:
+            with _litellm_import_logs_to_file():
+                try:
+                    import litellm
+                    litellm.suppress_debug_info = True
+                    # #3075 fix 1: litellm's aiohttp transport defaults
+                    # aiohttp_trust_env=False, so it is proxy-blind even when the
+                    # operator's standard HTTP(S)_PROXY/NO_PROXY env is set — the
+                    # highest-volume egress reyn originates (every LLM/embedding call)
+                    # was the sharpest non-conformer in the #3075 enumeration. Flipping
+                    # this makes litellm read the standard proxy env like every other
+                    # conforming egress; it already honours SSL_CERT_FILE/
+                    # REQUESTS_CA_BUNDLE via get_ssl_verify(), so this is the one
+                    # missing piece for full conformance.
+                    litellm.aiohttp_trust_env = True
+                    result = litellm
+                except Exception:  # noqa: BLE001 — best-effort; never block the caller on this
+                    result = None
+        finally:
+            if result is not None:
                 _litellm_ready = True
-                my_future.set_result(None)
+            else:
+                # NOT cached — clear ownership so the NEXT call gets a
+                # fresh attempt instead of being permanently stuck on
+                # this one failure (see docstring: callers with no
+                # fallback must keep retrying across turns).
+                _ready_registry.pop("ready", None)
+                if not _litellm_import_failure_warned:
+                    _litellm_import_failure_warned = True
+                    logging.getLogger(__name__).warning(
+                        "import litellm failed — falling back where a "
+                        "fallback exists, retrying on the next call "
+                        "where it doesn't. This is a warn-once notice, "
+                        "not a record of a permanent failure.",
+                    )
+            my_future.set_result(result)
 
     _capture_client_cache_baseline()
+    return result
 
 
 def reset_client_cache_baseline() -> None:

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Callable, Coroutine, NamedTuple, TypeVar, Unio
 
 logger = logging.getLogger(__name__)
 from reyn.core.turn_scope import get_active_turn_chain_id
-from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+from reyn.llm.litellm_bootstrap import LitellmUnavailableError, ensure_litellm_ready
 from reyn.llm.model_resolver import ModelSpec
 from reyn.llm.pricing import TokenUsage, UsageSource, estimate_cost, parse_usage_source
 from reyn.prompt.loop_control import G12_SIGNAL_ERROR_TEXT as _G12_SIGNAL_ERROR_TEXT
@@ -2002,8 +2002,34 @@ async def recorded_acompletion(
     # path (input box renders before any LLM use). ``ensure_litellm_ready``
     # is the single chokepoint that applies the #2929 console-log routing +
     # ``suppress_debug_info`` the first time ANY call site touches litellm.
-    ensure_litellm_ready()
-    import litellm
+    # #4395 PR-1: use the module it RETURNS rather than a separate bare
+    # ``import litellm`` — that used to independently re-attempt (and
+    # re-fail) litellm's own slow, unbounded import on every completion
+    # call while it kept failing (a failed import isn't cached by Python;
+    # only this chokepoint's own attempt was). No fallback exists here —
+    # a real completion genuinely needs litellm — so failure surfaces as
+    # an explicit, legible error instead of whatever incidental exception
+    # a redundant re-attempt would have produced. Retriable on the NEXT
+    # call (`ensure_litellm_ready()`'s own docstring: a failure is not
+    # permanently cached — an environmental cause can clear, and this
+    # path has no fallback to fall permanently back to).
+    #
+    # #4395: called via ``asyncio.to_thread`` rather than awaited/called
+    # directly in-loop — this function is ``async def`` and a synchronous
+    # ``ensure_litellm_ready()`` call here blocks the WHOLE event loop
+    # (animation + input, not just this coroutine) for as long as the
+    # underlying import takes, which is exactly the owner-reported freeze
+    # (lead-coder correction, #4395: PR-1 must land this call site in an
+    # already-awaitable form so PR-2's dedicated-thread/cooldown mechanism
+    # slots in behind the same await point — writing it as an in-loop
+    # blocking call here would force PR-2 to rewrite every caller instead
+    # of just the chokepoint).
+    litellm = await asyncio.to_thread(ensure_litellm_ready)
+    if litellm is None:
+        raise LitellmUnavailableError(
+            "import litellm failed — see the reyn.llm.litellm_bootstrap "
+            "warn-once log line for the underlying cause",
+        )
 
     # #1652/②: canonical litellm mechanism for reasoning continuity across tool
     # turns — when a thinking-enabled request carries an assistant turn whose

--- a/src/reyn/llm/model_budget.py
+++ b/src/reyn/llm/model_budget.py
@@ -43,11 +43,19 @@ def _lookup_max_input(model: str) -> "int | None":
     (e.g. provider-prefix-strip, #1162).
     """
     try:
-        # perf: route through the single litellm-first-touch chokepoint (see
-        # litellm_bootstrap module docstring) so #2929's console-log routing
-        # is active regardless of which call site touches litellm first.
+        # #4395 PR-1: check ensure_litellm_ready()'s own success/failure
+        # BEFORE doing `import litellm` — that used to be an unconditional
+        # bare import right after calling the chokepoint, which
+        # independently re-attempted (and re-failed) the exact same slow,
+        # unbounded import on every call while litellm kept failing (a
+        # failed import isn't cached by Python; only this chokepoint's
+        # own attempt was). `import litellm` below now only ever runs
+        # once success is confirmed, so it's always a cheap sys.modules
+        # cache hit — never a repeat of the failing attempt. See
+        # litellm_bootstrap.py's own docstring for the full contract.
         from reyn.llm.litellm_bootstrap import ensure_litellm_ready
-        ensure_litellm_ready()
+        if ensure_litellm_ready() is None:
+            return None
         import litellm
         info = litellm.get_model_info(model)
         max_input = info.get("max_input_tokens")

--- a/src/reyn/llm/model_cost_rate.py
+++ b/src/reyn/llm/model_cost_rate.py
@@ -28,12 +28,16 @@ def get_input_cost_per_1m_usd(model: str) -> float | None:
     an unknown cost as "no warning needed" rather than crashing the session.
     """
     try:
-        # perf: route through the single litellm-first-touch chokepoint so the
-        # #2929 console-log routing is active regardless of whether this
-        # session-start check or a later LLM call is the first real litellm
-        # touch in the process (see litellm_bootstrap module docstring).
+        # #4395 PR-1: check ensure_litellm_ready()'s own success/failure
+        # BEFORE doing `import litellm` — see model_budget.py's identical
+        # fix and litellm_bootstrap.py's own docstring for the full
+        # reasoning (a redundant unconditional bare import independently
+        # re-attempts, and re-fails, litellm's own slow unbounded import
+        # every call while it keeps failing; gating it behind a confirmed
+        # success makes it always a cheap sys.modules cache hit instead).
         from reyn.llm.litellm_bootstrap import ensure_litellm_ready
-        ensure_litellm_ready()
+        if ensure_litellm_ready() is None:
+            return None
         import litellm
         entry = litellm.model_cost.get(model, {})
         per_token = entry.get("input_cost_per_token")

--- a/src/reyn/llm/pricing.py
+++ b/src/reyn/llm/pricing.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Any
 
 
 class UsageSource(str, Enum):
@@ -211,10 +212,28 @@ class TokenUsage:
         )
 
 
-def _usage_object_for(usage: TokenUsage):
+def _usage_object_for(litellm_module: "Any", usage: TokenUsage):
     """Build a ``litellm.types.utils.Usage`` carrying the cache breakdown so
     ``litellm.cost_per_token`` prices cached tokens at the cache rate instead
     of the full input rate.
+
+    #4395: takes the ALREADY-confirmed litellm module (``ensure_litellm_
+    ready()``'s own return value) as a parameter and reads ``Usage`` off it
+    via attribute access, rather than this function doing its own separate
+    ``from litellm.types.utils import Usage`` statement — lead-coder found
+    (with a live measurement) that THAT statement, on its own, in a process
+    where litellm was never successfully imported before, triggers the full
+    parent-package import AND litellm's ``default_encoding`` module-level
+    tiktoken sync fetch — the exact #4395 hazard, in a form (``from litellm.
+    X import Y``, not ``import litellm`` / ``from litellm import``) neither
+    this PR's nor architect's own site census had grepped for. Reading
+    ``litellm_module.types.utils.Usage`` off the confirmed module instead
+    means this function can no longer independently touch litellm at all —
+    it is structurally incapable of bypassing the chokepoint, not just
+    reliant on its current caller happening to gate it first (verified
+    empirically: ``litellm.types.utils`` is already a populated attribute
+    on the module object after a plain successful ``import litellm`` — no
+    separate submodule import statement is needed).
 
     Provider-convention note: reyn's ``TokenUsage.prompt_tokens`` ALREADY
     INCLUDES ``cached_tokens`` and ``cache_creation_tokens`` as subsets — this
@@ -233,9 +252,7 @@ def _usage_object_for(usage: TokenUsage):
     (``text_tokens = prompt_tokens - cache_hit - cache_creation``), which is
     the correct convention for reyn's already-normalized TokenUsage.
     """
-    from litellm.types.utils import Usage
-
-    return Usage(
+    return litellm_module.types.utils.Usage(
         prompt_tokens=usage.prompt_tokens,
         completion_tokens=usage.completion_tokens,
         prompt_tokens_details={
@@ -266,6 +283,17 @@ def estimate_cost(
         return 0.0, None
 
     try:
+        # #4395 PR-1: route through the sole chokepoint (this bare `import
+        # litellm` never did before) so a failure isn't independently
+        # re-attempted — it was previously bypassing ensure_litellm_ready()
+        # entirely, meaning EVERY cost-estimation call (which runs every
+        # turn, unlike model_budget's occasional lookups) re-attempted
+        # litellm's own slow, unbounded import on every failure. `None`
+        # here is already this function's own documented "cost unknown"
+        # sentinel (see the docstring above) — no new fallback shape.
+        from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+        if ensure_litellm_ready() is None:
+            return None, None
         import litellm
 
         # #1829 S2 (option 3): a ``litellm.model_cost`` entry can EXIST with None
@@ -282,7 +310,7 @@ def estimate_cost(
 
         prompt_cost, completion_cost = litellm.cost_per_token(
             model=model,
-            usage_object=_usage_object_for(usage),
+            usage_object=_usage_object_for(litellm, usage),
         )
         total_cost = prompt_cost + completion_cost
 
@@ -433,6 +461,15 @@ def estimate_cost_breakdown(
         return CostBreakdown()
 
     try:
+        # #4395 PR-1: route through the sole chokepoint — see estimate_cost's
+        # identical fix above for the full reasoning (this bare `import
+        # litellm` never went through ensure_litellm_ready() before,
+        # independently re-attempting litellm's own slow import on every
+        # failed cost-breakdown call). `None` is already this function's
+        # own documented "unpriced/unknown" sentinel.
+        from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+        if ensure_litellm_ready() is None:
+            return None
         import litellm
 
         entry = litellm.model_cost.get(model)
@@ -501,6 +538,15 @@ def estimate_embedding_cost(
         return 0.0, None
 
     try:
+        # #4395 PR-1: route through the sole chokepoint — same fix and
+        # reasoning as estimate_cost/estimate_cost_breakdown above (this
+        # bare `import litellm` never went through ensure_litellm_ready()
+        # either — a 4th site, beyond the 3 originally measured for this
+        # file, found while fixing the other 3). `None` is already this
+        # function's own documented "unpriced/unknown" sentinel.
+        from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+        if ensure_litellm_ready() is None:
+            return None, None
         import litellm
 
         entry = litellm.model_cost.get(model)

--- a/tests/llm/test_4395_litellm_import_not_recached_on_failure.py
+++ b/tests/llm/test_4395_litellm_import_not_recached_on_failure.py
@@ -1,0 +1,157 @@
+"""Tier 2: `ensure_litellm_ready()` returns the imported litellm module
+(or `None` on failure), a failure is NOT cached — the next call gets a
+genuinely fresh attempt — and a failure is warned exactly once, not on
+every call (#4395 PR-1).
+
+THE BUG: a live owner repro (py-spy stack) caught the event-loop/UI
+thread blocked inside `import litellm`. The chokepoint's own docstring
+claimed a caller's subsequent bare `import litellm` was "cheap — Python
+caches the module" — true only on SUCCESS. A FAILED import is NOT
+cached by Python (a module whose top-level code raises is evicted from
+`sys.modules`), so `model_budget.py` / `model_cost_rate.py` / `llm.py` /
+`litellm_provider.py` / 3 sites in `pricing.py` each doing their OWN
+redundant bare `import litellm` right after calling this chokepoint were
+independently re-attempting — and re-failing — the exact same slow,
+unbounded import, turning one attempt into two per call.
+
+Uses `builtins.__import__` patching to simulate a genuine import
+failure — the same class of technique already used elsewhere in this
+session's own #4399 falsify tests (blocking real sockets to prove a
+network attempt was genuinely made/prevented) — not a mock of any reyn
+object, an interception of Python's own import mechanism to control a
+third-party package's outcome deterministically.
+"""
+from __future__ import annotations
+
+import builtins
+import logging
+
+import pytest
+
+import reyn.llm.litellm_bootstrap as lb_mod
+from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+
+
+@pytest.fixture(autouse=True)
+def _clean_litellm_bootstrap_state():
+    """Tier 2 hygiene: this module's readiness state is process-global —
+    reset the ownership registry and the warn-once latch between tests so
+    one test's failure doesn't leave the NEXT test seeing a stale
+    "already warned" or "already owned" state.
+
+    `_litellm_ready` is ALSO forced False for the duration of every test in
+    this file, restored after. In production, "ready" is real, permanent
+    state (a success is never re-attempted) — but that fast path
+    (`if _litellm_ready: return sys.modules.get("litellm")`) bypasses the
+    `__import__` patch these tests rely on entirely, so any test that ran
+    AFTER a real, successful litellm import elsewhere in the same pytest
+    session would see the fast path short-circuit before ever reaching the
+    patched import machinery — a test-isolation bug (a prior process-wide
+    success leaking into a test that means to force a fresh failure), not
+    a change to what "ready" means in production.
+    """
+    original_ready = lb_mod._litellm_ready
+    lb_mod._litellm_ready = False
+    lb_mod._ready_registry.pop("ready", None)
+    lb_mod._litellm_import_failure_warned = False
+    yield
+    lb_mod._litellm_ready = original_ready
+    lb_mod._ready_registry.pop("ready", None)
+    lb_mod._litellm_import_failure_warned = False
+
+
+@pytest.fixture()
+def _force_litellm_import_failure(monkeypatch):
+    """Makes every `import litellm` statement in the process raise, and
+    reports how many times it was actually attempted — a REAL
+    interception of Python's own import mechanism (not a mock of
+    reyn's own object model), so `ensure_litellm_ready()`'s real code
+    path (its own inner `import litellm`) is genuinely exercised."""
+    real_import = builtins.__import__
+    attempts = {"n": 0}
+
+    def _failing_import(name, *args, **kwargs):
+        if name == "litellm":
+            attempts["n"] += 1
+            raise RuntimeError("simulated persistent litellm import failure")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _failing_import)
+    return attempts
+
+
+def test_a_failed_import_returns_none_not_raise(_force_litellm_import_failure):
+    """Tier 2: `ensure_litellm_ready()` never raises on its own failure —
+    matches its own documented contract (callers decide what to do with
+    `None`, e.g. a fallback or their own explicit error)."""
+    result = ensure_litellm_ready()
+    assert result is None
+
+
+def test_a_failed_import_is_not_cached_the_next_call_retries_fresh(
+    _force_litellm_import_failure,
+):
+    """Tier 2: THE core defect this PR-1 fixes at the chokepoint level —
+    a failure must not be permanently remembered as "done" the way a
+    success is; the caller with no fallback (a real completion) needs to
+    keep trying on the NEXT turn, not be locked out forever after one
+    environmental blip."""
+    ensure_litellm_ready()
+    after_first = _force_litellm_import_failure["n"]
+    ensure_litellm_ready()
+    after_second = _force_litellm_import_failure["n"]
+    assert after_second > after_first, (
+        "the second call must trigger a genuinely fresh import attempt, "
+        "not reuse a cached failure result"
+    )
+
+
+def test_a_failure_is_warned_exactly_once_across_repeated_calls(
+    _force_litellm_import_failure, caplog,
+):
+    """Tier 2: landing condition — a permanently-failing environment must
+    be VISIBLE (not silently degrade every fallback with zero signal),
+    but warned once, not on every call (#3368's own "warn every time
+    punishes the disciplined caller" trap)."""
+    with caplog.at_level(logging.WARNING, logger=lb_mod.__name__):
+        for _ in range(5):
+            ensure_litellm_ready()
+    warning_messages = [
+        r.getMessage() for r in caplog.records if "import litellm failed" in r.getMessage()
+    ]
+    # A single warn-once notice, not one per failing call — asserted by
+    # unpacking into exactly one binding (canonical idiom: a wrong COUNT
+    # fails the unpack itself, not a len(...) == N format pin).
+    (single_warning,) = warning_messages
+    assert "import litellm failed" in single_warning
+
+
+def test_a_success_after_a_failure_is_returned_and_cached(monkeypatch):
+    """Tier 2: recovery — once litellm genuinely imports (a proxy came
+    back up, in the real scenario), the result is the real module and
+    stays cached (a real success is permanent — `sys.modules` itself
+    never re-runs a successfully imported module)."""
+    real_import = builtins.__import__
+    state = {"fail": True, "attempts": 0}
+
+    def _flaky_import(name, *args, **kwargs):
+        if name == "litellm":
+            state["attempts"] += 1
+            if state["fail"]:
+                raise RuntimeError("simulated transient failure")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _flaky_import)
+
+    assert ensure_litellm_ready() is None
+    state["fail"] = False
+    result = ensure_litellm_ready()
+    assert result is not None
+    assert result.__name__ == "litellm"
+
+    attempts_after_success = state["attempts"]
+    ensure_litellm_ready()
+    assert state["attempts"] == attempts_after_success, (
+        "a successful import must be cached — a later call must not "
+        "attempt the import again"
+    )


### PR DESCRIPTION
**[docs-maintainer]** — PR-1 of the #4395 arc: minimal, non-threading fix for the owner-reported UI freeze.

## What

A live owner repro (py-spy stack) caught the event-loop/UI thread blocked inside `import litellm`. `ensure_litellm_ready()`'s own docstring claimed a caller's subsequent bare `import litellm` was "cheap — Python caches the module" — true only on **success**. Python does **not** cache a **failed** import (a module whose top-level code raises is evicted from `sys.modules`), so every call site doing its own redundant bare `import litellm` right after calling the chokepoint was independently re-attempting — and re-failing — the exact same slow, unbounded, network-touching import. One attempt became two per call, every call, for as long as the environment stayed broken (e.g. a proxy timeout).

## The 6 sites (Test plan — full enumeration, not just a count)

**Set A** — called `ensure_litellm_ready()` then did their own separate `import litellm` right after:
- `src/reyn/llm/model_budget.py:56-59` (`_lookup_max_input`) — has a safe fallback (128K default), stays synchronous.
- `src/reyn/llm/model_cost_rate.py:38-41` (`get_input_cost_per_1m_usd`) — has a safe fallback (`None` = "no warning"), stays synchronous.
- `src/reyn/llm/llm.py:2016` (`recorded_acompletion`) — **no fallback**, a real completion genuinely needs litellm.
- `src/reyn/data/embedding/litellm_provider.py:405-415` (embed retry loop) — no fallback within one attempt (existing `except Exception` around the whole attempt already retries).

**Set B** — bypassed the chokepoint entirely, never called `ensure_litellm_ready()` at all:
- `src/reyn/llm/pricing.py`: `estimate_cost`, `estimate_cost_breakdown`, and **`estimate_embedding_cost`** — this third one is a 4th site beyond the 3 originally measured; found independently while fixing the other two. Flagging the discrepancy transparently rather than silently reconciling it.

## Fix

- `ensure_litellm_ready()` now **returns the imported module** (or `None` on failure) instead of always returning `None`. Callers check the return value *before* their own `import litellm`, so that bare import only ever runs after a confirmed success — always a cheap `sys.modules` cache hit, never a repeat of a failing attempt.
- A failure is **no longer cached as "ready"**. This also fixes an independently-found, real, pre-existing bug: the original code set `_litellm_ready = True` in a bare `finally:` block regardless of whether the internal import actually succeeded — meaning the #2929 log-routing / `aiohttp_trust_env` setup silently never re-applied even after eventual recovery. Now only a genuine success sets it.
- A persistent failure is **warned exactly once** (`_litellm_import_failure_warned`), not once per call — landing condition: the degradation must be visible, but not flood logs (#3368's "warn every time punishes the disciplined caller" trap).
- `llm.py`'s `recorded_acompletion` and `litellm_provider.py`'s embed-retry loop — both `async def`, both no-fallback sites — now call `ensure_litellm_ready()` via `asyncio.to_thread(...)` rather than in-loop. **This is a lead-coder correction mid-PR** (owner: "does waiting on the UI loop differ from waiting on a dedicated thread?" — yes: waiting in-loop stops the whole event loop, animation and input included, not just the one coroutine). PR-1's *scope* is unchanged (still these same 6 sites + the one-time warn), but writing these two call sites as an in-loop blocking wait would have forced a follow-up PR to rewrite every caller; `asyncio.to_thread` keeps them in an already-awaitable form so a dedicated background-thread/cooldown mechanism can slot in behind the same await point later.

## Explicitly out of scope for this PR

- The dedicated background-thread / cooldown warming mechanism itself (so a *first* call after a failure doesn't block at all) is a **separate, deferred follow-up PR** — not included here. This PR only eliminates the redundant double-attempt and makes the two no-fallback call sites genuinely awaitable.
- `llm.py` / `litellm_provider.py` intentionally remain **blocking-until-resolved** on the underlying import outcome (just off the event loop now) — there is no fallback for a real completion or embedding call, so this is not a gap, it matches the architect's own landing condition that these two sites must keep retrying until they get a result.

## Test plan

- [x] 4 new tests in `tests/llm/test_4395_litellm_import_not_recached_on_failure.py` (Tier 2), using `builtins.__import__` patching (real import-machinery interception, not a mock of any reyn object) to simulate a genuine `import litellm` failure:
  - a failed import returns `None`, never raises
  - a failed import is **not cached** — the next call genuinely re-attempts
  - a persistent failure is warned exactly once across 5 calls
  - a success *after* a prior failure is returned and stays cached (no re-attempt on the next call)
- [x] Falsified: stashed all 6 modified files together, confirmed 3/4 new tests failed against the reverted code with genuine assertion errors, restored, confirmed all 4 pass again.
- [x] `ruff check` on all 7 changed files — clean.
- [x] `python scripts/mypy_ratchet.py` — 211/215 baselined, no new findings.
- [x] `python scripts/test_tier_audit.py --strict tests/llm/test_4395_litellm_import_not_recached_on_failure.py` — 0 Tier-4 violations (one `len(...) == 1` format-pin was caught and fixed to a tuple-unpack idiom before this PR was opened).
- [x] `python scripts/verify_module_docstrings.py` on all 6 changed src files — clean.
- [x] `python scripts/check_tests_path_literal_reference.py` — clean (121/121 baselined).
- [x] `pytest tests/llm/ tests/data/test_embedding_provider.py tests/core/test_embed_bound_cancel_3043.py tests/core/test_embed_attempts_observation_3047.py` — 702 passed, no regressions.
- [ ] Visual/manual (owner env) — per the standing waiver (CLAUDE.md, 2026-08-08), left unchecked; owner confirms after merge on `main`.

## Arc note

`part of #4395` (not closing — this is PR-1 of a multi-PR arc; the deferred background-thread mechanism is a separate follow-up PR not yet opened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**[lead-coder]** — レビュアの blocking 項目

- [x] 🔴 `src/reyn/llm/pricing.py:236` の `from litellm.types.utils import Usage` を継ぎ目経由に。★サブモジュール import でも親パッケージの `__init__.py` が実行され、`default_encoding`（tiktoken の同期取得）が走ることを実測しました。`import litellm` という形をしていないため grep の網から外れていた 1 箇所です。


⚪ **上の箱は★レビュア（lead-coder）が閉じました** — `pull/4413/head` を直接引いた結果です。★対応の形が要求以上でした: 「継ぎ目経由にする」ではなく **`ensure_litellm_ready()` の戻り値（確認済みモジュール）を引数で受け取り `Usage` を属性アクセスで読む** —— ∴ **この関数は★litellm に独立に触れること自体が構造的に不可能**になっており、「呼び出し元がゲートしてくれること」に依存していません。
