### PR TITLE
perf(#4403): RouterHistoryBuffer.build_history's elide total is incremental

### DIFF
--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -14,7 +14,12 @@ Also owns the module-level helpers:
   - _read_pathref_image
 
 history_fn dependency: a zero-arg callable that returns the raw history list
-(all ChatMessages including summaries), passed as ``lambda: self.history``.
+(all ChatMessages including summaries) — passed in production as
+``Session._active_branch_history`` (#2360's WAL-rewind-visibility filter,
+NOT a bare ``lambda: self.history``; the two differ after a rewind, and
+#4387 Phase B ② made that filtered view able to shrink/reorder call-to-call
+by extending ``self.history`` backward on demand — see
+``_incremental_elide_total``'s own docstring for why that matters here).
 """
 from __future__ import annotations
 
@@ -241,6 +246,23 @@ class RouterHistoryBuffer:
         # ``None`` (a legacy/test double with no workspace access) degrades to
         # "never refresh location tokens" — _serialise_turn's own None-check.
         self._project_dir_fn = project_dir_fn
+        # #4403: incremental elide-total cache. build_history() used to
+        # re-estimate EVERY turn's token count on EVERY call just to check
+        # "total <= effective_trigger" — O(session length) per turn, forever
+        # (compaction shrinks what's SENT to the LLM, never self.history).
+        # Measured (real litellm tokenizer, the config default): 5.13ms/turn
+        # -> 559s at 108,896 turns (#4403). ``_TOKEN_CACHE_MAXSIZE=8192``'s
+        # per-(model,text) cache cannot help here regardless of size: this
+        # loop visits turns in the SAME order every call, so an 8192-entry
+        # FIFO always evicts the early turns before a 100k-turn pass reaches
+        # them again next call — 100% miss, not a tuning problem.
+        # See ``_incremental_elide_total``'s own docstring for the
+        # invalidation contract these three fields exist to support.
+        self._cached_elide_total: int = 0
+        self._cached_elide_turn_count: int = 0
+        self._cached_elide_last_seq: "int | None" = None
+        self._cached_elide_model: "str | None" = None
+        self._cached_elide_use_chars4: "bool | None" = None
 
     @property
     def _model(self) -> str:
@@ -358,6 +380,74 @@ class RouterHistoryBuffer:
             self._compaction_controller, self._model, self._events,
         )
 
+    def _incremental_elide_total(
+        self, turns: list, wire_turns: list[dict], *, use_chars4: bool,
+    ) -> int:
+        """#4403: the ``total`` build_history needs for its "total <=
+        effective_trigger" elide decision, computed incrementally instead
+        of re-estimating every turn every call.
+
+        ``turns`` (``ChatMessage`` list, pre-serialise) is what
+        ``self._history_fn()`` (``Session._active_branch_history``)
+        returned THIS call — append-only in the common case, but NOT
+        guaranteed monotonic: a rewind/branch-switch can make it shorter
+        or reorder it (``_active_branch_history`` re-derives WAL-branch
+        visibility fresh every call). The cache's validity check is
+        therefore structural, not a bare length comparison:
+
+          - ``len(turns) < cached_turn_count`` -> definitely shrank
+            (rewind past the cached boundary) -> recompute from scratch.
+          - the ``seq`` at the cached boundary position no longer matches
+            what was cached -> the prefix itself changed (branch-switch
+            landing on a same-length-but-different list) -> recompute.
+          - model or use_chars4 changed since the cache was built -> the
+            cached per-turn costs were measured against a different
+            tokenizer -> recompute (an O(1) check, not a reason to distrust
+            the whole mechanism).
+          - otherwise -> the cached prefix is still exactly what it was:
+            add only the cost of the turns appended since, an O(k) pass
+            where k is genuinely new turns, not O(session length).
+
+        Every fallback path recomputes correctly (just not cheaply) — this
+        is a performance cache, not a source of truth: a wrong invalidation
+        guess costs CPU, never correctness, because the ``else`` branch
+        always re-derives ``total`` from the real ``wire_turns`` this call
+        actually has.
+        """
+        from reyn.services.compaction.engine import estimate_tokens_for_any_turn
+
+        model = self._model
+        cache_valid = (
+            len(turns) >= self._cached_elide_turn_count
+            and self._cached_elide_model == model
+            and self._cached_elide_use_chars4 == use_chars4
+            and (
+                self._cached_elide_turn_count == 0
+                or (
+                    turns[self._cached_elide_turn_count - 1].seq
+                    == self._cached_elide_last_seq
+                )
+            )
+        )
+        if cache_valid:
+            new_wire_turns = wire_turns[self._cached_elide_turn_count:]
+            total = self._cached_elide_total + sum(
+                estimate_tokens_for_any_turn(wt, model, use_chars4=use_chars4)
+                for wt in new_wire_turns
+            )
+        else:
+            total = sum(
+                estimate_tokens_for_any_turn(wt, model, use_chars4=use_chars4)
+                for wt in wire_turns
+            )
+
+        self._cached_elide_total = total
+        self._cached_elide_turn_count = len(turns)
+        self._cached_elide_last_seq = turns[-1].seq if turns else None
+        self._cached_elide_model = model
+        self._cached_elide_use_chars4 = use_chars4
+        return total
+
     # ── Public API ────────────────────────────────────────────────────────────
 
     def build_history(self) -> list[dict]:
@@ -385,11 +475,7 @@ class RouterHistoryBuffer:
         Only user/agent conversational turns are included; ``summary``
         remains Reyn-internal and is filtered out.
         """
-        from reyn.services.compaction.engine import (
-            estimate_tokens_for_any_turn,
-            trim_head,
-            trim_tail,
-        )
+        from reyn.services.compaction.engine import trim_head, trim_tail
 
         history = self._history_fn()
         # E-full (#383): include tool-turn entries (= assistant w/ tool_calls,
@@ -479,10 +565,19 @@ class RouterHistoryBuffer:
         # divergence PR-B closed.
         wire_turns = [self._serialise_turn(m) for m in turns]
 
-        total = sum(
-            estimate_tokens_for_any_turn(wt, self._model, use_chars4=use_chars4)
-            for wt in wire_turns
-        )
+        # #4403: the elide-check TOTAL — not the serialise pass above, #3185
+        # already measured and closed that as cheap — is computed
+        # incrementally rather than re-estimating every turn's token cost on
+        # every single call. Measured (real litellm tokenizer, the config
+        # default use_chars4_estimate=False): 5.13ms/turn -> 559s at
+        # 108,896 turns, because build_history() re-summed ALL of them EVERY
+        # call. _TOKEN_CACHE_MAXSIZE=8192's per-(model,text) cache cannot
+        # help here regardless of size: this loop visits turns in the SAME
+        # order every call, so an 8192-entry FIFO always evicts the early
+        # turns before a 100k-turn pass reaches them again next call — 100%
+        # miss, not a tuning problem. See _incremental_elide_total's own
+        # docstring for the invalidation contract.
+        total = self._incremental_elide_total(turns, wire_turns, use_chars4=use_chars4)
         # #2957 PR-B (co-vet follow-up): emit the elide side's own internal
         # total as a public P6 audit-event — the ONLY way a test (or an
         # operator inspecting `reyn events`) can observe what THIS method

--- a/tests/runtime/test_4403_incremental_elide_total.py
+++ b/tests/runtime/test_4403_incremental_elide_total.py
@@ -1,0 +1,172 @@
+"""Tier 2: #4403 — ``RouterHistoryBuffer``'s elide-check total is computed
+incrementally, not by re-estimating every turn's token cost on every call.
+
+Measured (real litellm tokenizer, the config default
+``use_chars4_estimate=False``): 5.13ms/turn -> 559s at 108,896 turns,
+because ``build_history()`` re-summed ALL turns EVERY call to check "total
+<= effective_trigger". ``_TOKEN_CACHE_MAXSIZE=8192``'s per-(model,text)
+cache could not help: the loop visits turns in the SAME order every call,
+so an 8192-entry FIFO always evicts the early turns before a 100k-turn
+pass reaches them again next call — 100% miss.
+
+Correctness is proven by comparing the incremental total (observed via the
+real ``elide_evaluated`` audit event, the SAME public observation point
+``test_2957_prb_elide_advisor_token_unification.py`` already established —
+never the private ``_cached_elide_*`` fields) against a from-scratch
+canonical recompute, across the real invalidation triggers: growth (the
+common case), and shrink/reorder (simulating a rewind, #4387's own concern
+for this ``history_fn``).
+
+Cost is proven by counting real ``estimate_tokens_for_any_turn`` calls via
+a counting wrapper (mirrors ``test_compaction_token_cache_incremental.py``'s
+own ``_counting_token_counter`` technique for this exact module) — the
+SECOND call over a grown history must cost proportionally to the NEW
+turns only, not the whole conversation again.
+
+Real ``RouterHistoryBuffer`` + real ``ChatMessage`` throughout — no fakes.
+"""
+from __future__ import annotations
+
+from reyn.config import CompactionConfig
+from reyn.core.events.events import EventLog
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
+
+_MODEL = "gpt-3.5-turbo"
+
+
+def _turns(n: int, *, start: int = 1) -> list[ChatMessage]:
+    return [
+        ChatMessage(role="user", content=f"turn {i} " + ("x" * 40), seq=i)
+        for i in range(start, start + n)
+    ]
+
+
+def _make_buf(history: list[ChatMessage], events: EventLog) -> RouterHistoryBuffer:
+    return RouterHistoryBuffer(
+        history_fn=lambda: history,
+        compaction=CompactionConfig(use_chars4_estimate=True),
+        compaction_controller=None,
+        model_fn=lambda: _MODEL,
+        events=events,
+        media_store=None,
+        router_host=None,
+        action_retrieval=None,
+        non_interactive=True,
+    )
+
+
+def _latest_elide_total(events: EventLog, collected: list) -> int:
+    matches = [e for e in collected if e.type == "elide_evaluated"]
+    assert matches, "build_history() must have emitted elide_evaluated"
+    return matches[-1].data["total"]
+
+
+def _subscribed(events: EventLog) -> list:
+    collected: list = []
+    events.add_subscriber(lambda e: collected.append(e))
+    return collected
+
+
+def test_incremental_total_matches_a_from_scratch_recompute_after_growth() -> None:
+    """Tier 2: append new turns (the common case — a real conversation
+    extending), call build_history() again — the incrementally-derived
+    total must equal what a FRESH buffer (no cache) computes from scratch
+    over the exact same (now-longer) history."""
+    history = _turns(50)
+    events = EventLog()
+    collected = _subscribed(events)
+    buf = _make_buf(history, events)
+    buf.build_history()  # first call: populates the cache
+
+    history.extend(_turns(30, start=51))  # grow — mutates the SAME list history_fn reads
+    buf.build_history()  # second call: must extend incrementally
+    incremental_total = _latest_elide_total(events, collected)
+
+    fresh_events = EventLog()
+    fresh_collected = _subscribed(fresh_events)
+    fresh_buf = _make_buf(list(history), fresh_events)  # independent buffer, no cache
+    fresh_buf.build_history()
+    canonical_total = _latest_elide_total(fresh_events, fresh_collected)
+
+    assert incremental_total == canonical_total
+
+
+def test_incremental_total_recomputes_correctly_after_a_shrink() -> None:
+    """Tier 2: #4387's own concern for this history_fn — a rewind can make
+    the ``turns`` list SHORTER than what was cached. The cache must detect
+    this and recompute from scratch, not silently keep serving a total
+    that includes turns no longer present."""
+    history = _turns(50)
+    events = EventLog()
+    collected = _subscribed(events)
+    buf = _make_buf(history, events)
+    buf.build_history()
+
+    history[:] = _turns(10)  # shrink — simulates a rewind cutting most turns
+    buf.build_history()
+    incremental_total = _latest_elide_total(events, collected)
+
+    fresh_events = EventLog()
+    fresh_collected = _subscribed(fresh_events)
+    fresh_buf = _make_buf(list(history), fresh_events)
+    fresh_buf.build_history()
+    canonical_total = _latest_elide_total(fresh_events, fresh_collected)
+
+    assert incremental_total == canonical_total
+
+
+def test_incremental_total_recomputes_when_the_prefix_reorders_at_the_same_length() -> None:
+    """Tier 2: #4387's harder rewind case — a branch-switch can produce a
+    SAME-LENGTH but DIFFERENT list (the boundary seq no longer matches what
+    was cached). Length alone cannot catch this; the seq check must."""
+    history = _turns(20)
+    events = EventLog()
+    collected = _subscribed(events)
+    buf = _make_buf(history, events)
+    buf.build_history()
+
+    # Same length, but the entry at the cached boundary position now has a
+    # DIFFERENT seq (as if turn 20 belonged to an abandoned branch and a
+    # different turn 20 from another branch is now active).
+    history[:] = _turns(19) + [ChatMessage(role="user", content="alt turn 20", seq=999)]
+    buf.build_history()
+    incremental_total = _latest_elide_total(events, collected)
+
+    fresh_events = EventLog()
+    fresh_collected = _subscribed(fresh_events)
+    fresh_buf = _make_buf(list(history), fresh_events)
+    fresh_buf.build_history()
+    canonical_total = _latest_elide_total(fresh_events, fresh_collected)
+
+    assert incremental_total == canonical_total
+
+
+def test_second_call_over_a_grown_history_estimates_only_the_new_turns(monkeypatch) -> None:
+    """Tier 2: the actual cost claim — counts real
+    estimate_tokens_for_any_turn calls via a counting wrapper (mirrors
+    test_compaction_token_cache_incremental.py's own technique for this
+    module). The second call, after 30 new turns were appended to an
+    existing 50, must cost ~30 calls, not ~80."""
+    import reyn.services.compaction.engine as engine_module
+
+    real_fn = engine_module.estimate_tokens_for_any_turn
+    call_count = {"n": 0}
+
+    def _counting(wt, model, *, use_chars4):
+        call_count["n"] += 1
+        return real_fn(wt, model, use_chars4=use_chars4)
+
+    history = _turns(50)
+    events = EventLog()
+    buf = _make_buf(history, events)
+    buf.build_history()  # first call — cold cache, cost not counted (wrapper not installed yet)
+
+    monkeypatch.setattr(engine_module, "estimate_tokens_for_any_turn", _counting)
+    history.extend(_turns(30, start=51))
+    buf.build_history()  # second call — must only estimate the 30 NEW turns
+
+    assert call_count["n"] == 30, (
+        f"expected exactly 30 new-turn estimates (incremental), got {call_count['n']} "
+        "(80 would mean the cache re-estimated the whole history again)"
+    )


### PR DESCRIPTION
**[tui-coder]** — #4403: `RouterHistoryBuffer.build_history()` re-estimated EVERY turn's token cost on EVERY call just to check `"total <= effective_trigger"` — O(session length) per turn, forever (compaction shrinks what's SENT to the LLM, never `self.history`).

**Measured** (real litellm tokenizer, the config default `use_chars4_estimate=False`): 5.13ms/turn → 559s at 108,896 turns. `_TOKEN_CACHE_MAXSIZE=8192`'s per-(model,text) cache cannot help regardless of size: this loop visits turns in the SAME order every call, so an 8192-entry FIFO always evicts the early turns before a 100k-turn pass reaches them again next call — 100% miss, not a tuning problem. Not related to owner's current ~20s symptom (already traced to #4395/tiktoken) — this bites once `self.history` genuinely grows large, which owner's real environment has (500MB).

## Fix

New `_incremental_elide_total`: caches the total plus a boundary marker (turn count + the `ChatMessage.seq` at that position). Each call either extends the cache by summing only the turns appended since (the common case), or recomputes from scratch when the boundary check fails — shrink, or a same-length reorder (both real for this buffer's `history_fn`, which is `Session._active_branch_history`, #2360's WAL-rewind-visibility filter: #4387 Phase B ② made that filtered view able to shrink/reorder call-to-call). Every fallback path recomputes correctly, just not cheaply — a performance cache, not a source of truth. Model/`use_chars4` changes also invalidate.

Same shape as Phase A's untrusted-taint watermark technique, per lead-coder's own framing.

**Does NOT touch `wire_turns` serialisation** — #3185's own "measured, closed won't-fix" territory (serialising every candidate turn is already cheap for text; that analysis is about materialisation cost, a different question from the token-*estimation* cost that actually scales badly here).

**Same-PR doc-drift fix**: the module docstring's `"history_fn ... passed as lambda: self.history"` was stale — production passes `Session._active_branch_history`, which can shrink/reorder (exactly why this cache needs a real invalidation check, not just a length comparison).

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 4/4 OK, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (211/215 baselined)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] 4 new tests: incremental total matches a from-scratch canonical recompute after growth / shrink / same-length reorder (observed via the real `elide_evaluated` audit event, never private `_cached_elide_*` fields), plus a call-counting test proving the actual cost claim (30 new-turn estimates after growth, not 80)
- [x] Falsify-verify: reverted to the always-full-recompute body; the cost-counting test failed for real (80 calls where 30 was expected); restored, confirmed GREEN
- [x] Scoped pytest — 169 passed total (29 in the direct-consumer sweep + 140 in the broader elide/rewind/compaction sweep)
- [ ] Visual — n/a (no UI surface)

part of #4403

🤖 Generated with [Claude Code](https://claude.com/claude-code)
