### PR TITLE
fix(#4395): cooldown + dedicated background thread for litellm warm-up

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,6 +237,14 @@ dependencies = [
                               # bounded work (~4-5 functions + a context re-plumb, see #4302)
                               # tracked as its own follow-up issue, deliberately NOT folded
                               # into this dependency-hygiene PR.
+    # #4395: was transitive only (Required-by: httpx, mcp, openai,
+    # sse-starlette, starlette, watchfiles — 4.14.0 already installed via
+    # that chain). Owner decision: declare it directly rather than keep
+    # relying on other packages' own pins to keep pulling it in — the same
+    # "make an existing transitive a direct dependency" move as `mcp`'s own
+    # entry above. Floor set to the version already resolved and in use
+    # (4.14.x); not raised for a specific new API this PR relies on.
+    "anyio>=4.14",
     "pyperclip>=1.9",        # #3616 ①: cross-platform clipboard, replacing a
                               # hand-rolled pbcopy/wl-copy/xclip/xsel/clip
                               # dispatch table whose Windows arm piped UTF-8

--- a/src/reyn/_cooldown.py
+++ b/src/reyn/_cooldown.py
@@ -1,0 +1,60 @@
+"""A persistent, environmental failure needs a COOLDOWN, not a permanent
+give-up and not a retry on literally every call (#4395/#4398 — the same
+class, closed here in ONE place instead of two independent
+reimplementations).
+
+Two distinct, real instances of this exact shape landed the same night:
+
+- ``services/compaction/engine.py``'s ``estimate_tokens()`` (#4398): a
+  ``litellm.token_counter`` CALL that keeps failing for an environmental
+  reason (SSL egress blocked) was retried on every distinct text string
+  (the result cache is keyed by text, so a new string is always a miss) —
+  synchronously, from turn processing, blocking the UI each time.
+- ``llm/litellm_bootstrap.py``'s ``ensure_litellm_ready()`` (#4395): a
+  failed ``import litellm`` is REMOVED from ``sys.modules`` by Python
+  itself (any module whose top-level code raises never gets cached), so
+  the NEXT ``import litellm`` anywhere in the process starts completely
+  from scratch and hits the exact same failure again — an IMPORT failure,
+  not a call failure, but the same "persistent environmental failure,
+  retried every single call" shape. PR-1 (#4413) closed the WITHIN-one-call
+  double-attempt; this module backs PR-2's fix for the ACROSS-calls
+  repeat (#4395 axis②) — a live owner repro caught the process still
+  re-attempting, and re-hanging on, the same broken TLS handshake on
+  every subsequent call after PR-1 alone landed.
+
+Both need: a failure starts a cooldown window; any attempt inside it skips
+straight to the fallback (or, for ``ensure_litellm_ready()``, returns
+``None`` immediately — never a permanent give-up), no wait paid; a success
+(during or after the cooldown) clears it; the window is temporary — the
+underlying cause may clear (a proxy comes back up) and there is no restart
+hook to notice that on its own, so the next attempt after the window
+elapses always re-probes.
+
+This module holds only the two PURE, STATE-FREE comparisons that shape
+needs — ``time.monotonic()`` reads and arithmetic. Each call site still
+owns its OWN cooldown-deadline variable (a plain module float, matching
+the existing "no lock, unlocked check-then-set, worst case is a redundant
+early/late re-probe, never a wrong count" reasoning both #4395 and #4398
+already use) — sharing the STATE across unrelated failure classes (an
+import failure and a token-counter-call failure) would be wrong; sharing
+this tiny piece of ARITHMETIC is not.
+"""
+from __future__ import annotations
+
+import time
+
+
+def in_cooldown(cooldown_until: float) -> bool:
+    """True while *cooldown_until* (an absolute ``time.monotonic()``
+    deadline, or ``0.0``/negative for "no active cooldown") is still in the
+    future. ``time.monotonic()`` — never wall-clock — so an NTP step or a
+    sleep/resume cannot shorten OR lengthen the wait (#4398's own reasoning,
+    reused verbatim here)."""
+    return time.monotonic() < cooldown_until
+
+
+def new_cooldown_deadline(seconds: float) -> float:
+    """The absolute ``time.monotonic()`` deadline for a cooldown window of
+    *seconds* starting now — call this on a fresh failure to arm/extend a
+    call site's own cooldown-deadline variable."""
+    return time.monotonic() + seconds

--- a/src/reyn/llm/litellm_bootstrap.py
+++ b/src/reyn/llm/litellm_bootstrap.py
@@ -45,6 +45,8 @@ import logging
 from concurrent.futures import Future
 from typing import TYPE_CHECKING, Any
 
+from reyn import _cooldown
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -185,6 +187,22 @@ def _litellm_import_logs_to_file() -> "Iterator[None]":
 
 _litellm_import_failure_warned = False
 
+# #4395 axis②/PR-2 (owner-flagged gap in PR-1): PR-1 removed the WITHIN-one-
+# call double attempt (a caller's own redundant bare `import litellm` right
+# after this chokepoint) but a failure is deliberately NOT cached as
+# "ready" — the NEXT call still starts a genuinely fresh attempt, which
+# means a PERSISTENTLY broken environment (the owner's own repro: a TLS
+# handshake that never completes) gets re-attempted, and re-hangs, on
+# EVERY subsequent call, not just once. `_LITELLM_IMPORT_COOLDOWN_SECONDS`
+# closes that: a failure starts a cooldown window (`reyn._cooldown`, the
+# same primitive #4398 already established for the identical shape in
+# `compaction/engine.py`'s `estimate_tokens`) during which every call
+# returns `None` immediately — no import attempted, no wait paid — rather
+# than a permanent give-up (the underlying cause may clear; the window
+# just rate-limits re-probing, it does not stop it).
+_LITELLM_IMPORT_COOLDOWN_SECONDS = 60.0
+_litellm_import_cooldown_until = 0.0
+
 
 def ensure_litellm_ready() -> "Any | None":
     """Idempotent first-touch chokepoint: import litellm + apply its
@@ -255,7 +273,7 @@ def ensure_litellm_ready() -> "Any | None":
     embedding.litellm_provider``). So the proxy-trust flip covers every
     litellm-originated request, not just chat.
     """
-    global _litellm_ready, _litellm_import_failure_warned
+    global _litellm_ready, _litellm_import_failure_warned, _litellm_import_cooldown_until
     # Unlocked fast-path read keeps the "cheap on every call after the
     # first success" property this docstring promises. NOTE: still falls
     # through to `_capture_client_cache_baseline` below — the
@@ -266,6 +284,17 @@ def ensure_litellm_ready() -> "Any | None":
         _capture_client_cache_baseline()
         import sys
         return sys.modules.get("litellm")
+
+    # #4395 axis②: a PERSISTENT failure (e.g. a TLS handshake that never
+    # completes) must not be re-attempted, and re-hung-on, by every single
+    # call across the whole cooldown window — see this module's own
+    # `_LITELLM_IMPORT_COOLDOWN_SECONDS` comment above. Checked BEFORE the
+    # ownership dance below so a call inside the window never even
+    # contests for it. Unlocked read, same GIL-atomic-single-variable
+    # reasoning as the fast path above; the worst race is one caller
+    # re-probing slightly early or late, never a wrong result.
+    if _cooldown.in_cooldown(_litellm_import_cooldown_until):
+        return None
 
     my_future: "Future[Any | None]" = Future()
     winning_future = _ready_registry.setdefault("ready", my_future)
@@ -299,12 +328,21 @@ def ensure_litellm_ready() -> "Any | None":
         finally:
             if result is not None:
                 _litellm_ready = True
+                _litellm_import_cooldown_until = 0.0  # healthy — clear any cooldown
             else:
                 # NOT cached — clear ownership so the NEXT call gets a
                 # fresh attempt instead of being permanently stuck on
                 # this one failure (see docstring: callers with no
-                # fallback must keep retrying across turns).
+                # fallback must keep retrying across turns). #4395 axis②:
+                # that "fresh attempt" is now rate-limited by the cooldown
+                # above rather than happening on literally every call —
+                # ownership is still cleared (so the FIRST call after the
+                # cooldown elapses can win it), just gated by the cooldown
+                # check before it's ever contested.
                 _ready_registry.pop("ready", None)
+                _litellm_import_cooldown_until = _cooldown.new_cooldown_deadline(
+                    _LITELLM_IMPORT_COOLDOWN_SECONDS,
+                )
                 if not _litellm_import_failure_warned:
                     _litellm_import_failure_warned = True
                     logging.getLogger(__name__).warning(

--- a/src/reyn/llm/litellm_bootstrap.py
+++ b/src/reyn/llm/litellm_bootstrap.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import threading
 from concurrent.futures import Future
 from typing import TYPE_CHECKING, Any
 
@@ -355,6 +356,147 @@ def ensure_litellm_ready() -> "Any | None":
 
     _capture_client_cache_baseline()
     return result
+
+
+# ── #4395 PR-2: a background warming thread for call sites with a fallback ──
+#
+# PR-1 (#4413) closed the "one attempt per call, forever, while litellm
+# keeps failing" defect above, and made the two call sites with NO fallback
+# (`llm.py`'s `recorded_acompletion`, `litellm_provider.py`'s embed-retry
+# loop) genuinely awaitable (`asyncio.to_thread(ensure_litellm_ready)`) so
+# the wait for a real answer no longer blocks the whole event loop — only
+# the one coroutine that needs the answer. Neither of those two sites is
+# touched by this section: they have no safe fallback, so they must keep
+# waiting for a real result regardless of how that wait is implemented.
+#
+# What PR-1 left: the FIRST-ever `import litellm` in a process can still
+# take however long litellm's own (upstream, un-timed-out) tiktoken fetch
+# takes — owner-observed longer than the local ~7.4s case. `model_budget.py`
+# / `model_cost_rate.py` / `compaction/engine.py`'s two litellm-touching
+# functions all ALREADY have a safe, cheap fallback for "no answer yet"
+# (a conservative token-budget default, an unknown-cost `None`, a chars//4
+# estimate) — for these, there is no reason to wait for litellm at all, let
+# alone on the calling thread. This section gives them a NON-blocking
+# variant: kick off exactly ONE persistent background thread that keeps
+# retrying (with a cooldown between attempts — a failed import isn't cached,
+# so retrying on every single call while litellm stays broken would mean
+# one slow attempt per call, same shape PR-1 already closed for the
+# no-fallback sites) until it succeeds, and have every caller with a
+# fallback fail fast to its own fallback instead of waiting on that thread
+# at all. #3671 P1 (3b113e597) already made the 6 shared-state items a
+# concurrent background thread would touch (this module's own
+# `_ready_registry`/`_litellm_ready`, `llm.py`'s
+# `_RETRYABLE_LITELLM_EXCEPTIONS` / `_HTTPX_EXC_TYPES`,
+# `compaction/engine.py`'s `_token_cache` / `_token_counter_fallback_warned`
+# / `_token_counter_cooldown_until`) thread-safe in preparation for exactly
+# this — verified still true of the current code before writing this
+# section, not assumed from that PR's own description.
+_LITELLM_WARM_POLL_SECONDS = 0.05
+_litellm_warm_thread: "threading.Thread | None" = None
+
+
+class LitellmWarmingInBackgroundError(Exception):
+    """Raised by :func:`ensure_litellm_ready_or_defer` when litellm is not
+    yet importable and the caller has a fallback — the ONE dedicated
+    background thread (:func:`warm_litellm_in_background`) is (or already
+    was) started to keep retrying, with a cooldown between attempts, until
+    it succeeds. A LATER call from any thread will see litellm become
+    ready once that thread succeeds. Callers are expected to catch this
+    (an ordinary ``except Exception`` already does, unmodified) and use
+    their own existing fallback — not an error to surface to an operator.
+    """
+
+
+def is_litellm_ready() -> bool:
+    """Non-blocking read: has the first-ever ``import litellm`` (and its
+    one-time setup) already finished, successfully, in this process?
+
+    Unlike :func:`ensure_litellm_ready`, this never imports litellm and
+    never blocks — the same unlocked-read argument that function's own
+    fast path already relies on (GIL-atomic single-variable read) applies
+    here; this just exposes that same read publicly for the warming
+    thread below to poll.
+    """
+    return _litellm_ready
+
+
+def _litellm_warm_worker() -> None:
+    """Body of the ONE dedicated background thread: retries
+    :func:`ensure_litellm_ready` — unmodified, so it participates in the
+    SAME `_ready_registry` ownership every other caller uses; if some
+    other call (e.g. a no-fallback site's blocking wait) wins ownership of
+    a given attempt first, this thread just observes `_litellm_ready` flip
+    via that attempt instead of redundantly repeating it — until litellm
+    becomes ready, then exits.
+
+    No cooldown/sleep logic of its OWN between real attempts: axis②
+    (`_LITELLM_IMPORT_COOLDOWN_SECONDS`, this module's own chokepoint-level
+    fix above) already makes `ensure_litellm_ready()` self-regulate its own
+    retry cadence — a call during the cooldown returns `None` immediately
+    without attempting a real import, so polling it here every
+    `_LITELLM_WARM_POLL_SECONDS` costs nothing while in cooldown and only
+    triggers a genuine re-attempt once the cooldown naturally elapses.
+    Duplicating that cooldown here would just be the same rate limit
+    enforced twice.
+    """
+    import time
+    while not _litellm_ready:
+        ensure_litellm_ready()  # self-regulates via its own cooldown (see above)
+        if _litellm_ready:
+            return
+        time.sleep(_LITELLM_WARM_POLL_SECONDS)
+
+
+def warm_litellm_in_background() -> None:
+    """Idempotently ensure the ONE dedicated background thread
+    (:func:`_litellm_warm_worker`) is (or already is) running, without
+    blocking the calling thread even briefly.
+
+    Safe to call from anywhere, any number of times, on any thread: once
+    litellm is ready this is a single cheap attribute read; before that,
+    `Thread.is_alive()` makes every call after the first a no-op. The only
+    possible race is two threads BOTH seeing no thread alive yet and both
+    starting one — harmless (both do the exact same idempotent work, and
+    they still rendezvous on the SAME `_ready_registry` Future inside
+    `ensure_litellm_ready`), never an incorrect outcome, and the thread
+    exits on its own once litellm becomes ready — nothing lingers for the
+    rest of the process.
+    """
+    global _litellm_warm_thread
+    if _litellm_ready:
+        return
+    if _litellm_warm_thread is not None and _litellm_warm_thread.is_alive():
+        return
+    _litellm_warm_thread = threading.Thread(
+        target=_litellm_warm_worker, name="reyn-litellm-warm", daemon=True,
+    )
+    _litellm_warm_thread.start()
+
+
+def ensure_litellm_ready_or_defer() -> "Any":
+    """Non-blocking alternative to :func:`ensure_litellm_ready`, for call
+    sites with a safe, cheap fallback for "no answer yet" — see this
+    module's own PR-2 section comment above for which sites qualify and
+    why (`llm.py` / `litellm_provider.py` do NOT — they keep calling the
+    blocking :func:`ensure_litellm_ready` and are unaffected by this
+    function's existence).
+
+    Already-ready case: returns the module immediately (cheap — delegates
+    to :func:`ensure_litellm_ready`'s own fast path). NOT-yet-ready case:
+    never imports litellm on the calling thread — ensures the one
+    dedicated background thread is (or already is) retrying, then raises
+    :class:`LitellmWarmingInBackgroundError` immediately so the caller's
+    own pre-existing ``except Exception`` reaches its fallback with no
+    wait paid, regardless of which thread called this.
+    """
+    if _litellm_ready:
+        return ensure_litellm_ready()
+    warm_litellm_in_background()
+    raise LitellmWarmingInBackgroundError(
+        "litellm is not yet importable in this process; a background "
+        "thread is retrying it (or a recent attempt failed and is "
+        "cooling down) — use the fallback for this call.",
+    )
 
 
 def reset_client_cache_baseline() -> None:

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -984,7 +984,7 @@ def _empty_response_diag(response: object) -> str:
 
 
 def _get_retryable_litellm_exceptions() -> tuple:
-    """Return the tuple of retryable litellm exceptions, loading litellm lazily.
+    """Return the tuple of retryable litellm exceptions.
 
     Cached in _RETRYABLE_LITELLM_EXCEPTIONS after first call.
 
@@ -992,13 +992,35 @@ def _get_retryable_litellm_exceptions() -> tuple:
     lock (owner directive: no lock without a real correctness need) — the
     checked global and the assigned global are the SAME variable, in one
     atomic STORE, so a concurrent reader only ever observes ``None`` or the
-    complete tuple. A concurrent racer can redundantly rebuild the tuple
-    (import litellm + reconstruct it again), never observe a wrong or
-    partial value.
+    complete tuple.
+
+    #4395 PR-2 hardening (NOT a required landing condition — architect
+    measured the actual call graph and confirmed this function's only
+    reachable path, `_llm_call_with_retry`'s exception handler ← a real
+    completion attempt that already imported litellm via `recorded_
+    acompletion`'s own readiness check, is never actually racing the
+    background warming thread): this function no longer imports litellm
+    on its own AT ALL — it only reads `sys.modules["litellm"]` once
+    `is_litellm_ready()` confirms it is already there. This removes a
+    CAPABILITY (independently importing litellm) rather than adding a new
+    moving part — the call-order argument above is correct TODAY but is an
+    implicit invariant a future refactor could silently break; this makes
+    it a structural guarantee instead. Same shape as #4413's fix to
+    `pricing.py`'s `_usage_object_for` — "structurally incapable of
+    bypassing the chokepoint," not just reliant on today's caller
+    happening to gate it first. If litellm isn't ready yet, returns an
+    empty tuple — logically correct, not just a safe placeholder: `exc`
+    cannot be a genuine instance of one of litellm's own exception classes
+    if litellm itself was never successfully imported, so `isinstance(exc,
+    ())` (always False) can't misclassify anything.
     """
     global _RETRYABLE_LITELLM_EXCEPTIONS
     if _RETRYABLE_LITELLM_EXCEPTIONS is None:
-        import litellm
+        from reyn.llm.litellm_bootstrap import is_litellm_ready
+        if not is_litellm_ready():
+            return ()
+        import sys
+        litellm = sys.modules["litellm"]
         _RETRYABLE_LITELLM_EXCEPTIONS = (
             litellm.exceptions.Timeout,           # request timed out
             litellm.exceptions.APIConnectionError, # network-level connection failure

--- a/src/reyn/llm/model_budget.py
+++ b/src/reyn/llm/model_budget.py
@@ -43,20 +43,17 @@ def _lookup_max_input(model: str) -> "int | None":
     (e.g. provider-prefix-strip, #1162).
     """
     try:
-        # #4395 PR-1: check ensure_litellm_ready()'s own success/failure
-        # BEFORE doing `import litellm` — that used to be an unconditional
-        # bare import right after calling the chokepoint, which
-        # independently re-attempted (and re-failed) the exact same slow,
-        # unbounded import on every call while litellm kept failing (a
-        # failed import isn't cached by Python; only this chokepoint's
-        # own attempt was). `import litellm` below now only ever runs
-        # once success is confirmed, so it's always a cheap sys.modules
-        # cache hit — never a repeat of the failing attempt. See
-        # litellm_bootstrap.py's own docstring for the full contract.
-        from reyn.llm.litellm_bootstrap import ensure_litellm_ready
-        if ensure_litellm_ready() is None:
-            return None
-        import litellm
+        # #4395 PR-2: non-blocking chokepoint variant — this function
+        # already has a safe fallback (128K conservative default, in
+        # `_resolve_max_input` below) for "no answer yet", so there is no
+        # reason to wait for litellm here at all, let alone on the calling
+        # thread. `ensure_litellm_ready_or_defer()` never imports litellm on
+        # this thread if it isn't already warm — it kicks off the one
+        # dedicated background thread instead (litellm_bootstrap.py's own
+        # PR-2 section) and raises immediately, reaching the `except` below
+        # with no wait paid.
+        from reyn.llm.litellm_bootstrap import ensure_litellm_ready_or_defer
+        litellm = ensure_litellm_ready_or_defer()
         info = litellm.get_model_info(model)
         max_input = info.get("max_input_tokens")
         if max_input and int(max_input) > 0:

--- a/src/reyn/llm/model_cost_rate.py
+++ b/src/reyn/llm/model_cost_rate.py
@@ -28,17 +28,14 @@ def get_input_cost_per_1m_usd(model: str) -> float | None:
     an unknown cost as "no warning needed" rather than crashing the session.
     """
     try:
-        # #4395 PR-1: check ensure_litellm_ready()'s own success/failure
-        # BEFORE doing `import litellm` — see model_budget.py's identical
-        # fix and litellm_bootstrap.py's own docstring for the full
-        # reasoning (a redundant unconditional bare import independently
-        # re-attempts, and re-fails, litellm's own slow unbounded import
-        # every call while it keeps failing; gating it behind a confirmed
-        # success makes it always a cheap sys.modules cache hit instead).
-        from reyn.llm.litellm_bootstrap import ensure_litellm_ready
-        if ensure_litellm_ready() is None:
-            return None
-        import litellm
+        # #4395 PR-2: non-blocking chokepoint variant — see
+        # model_budget.py's identical fix and litellm_bootstrap.py's own
+        # PR-2 section comment for the full reasoning. This function
+        # already has a safe fallback (`None` = "cost unknown, no warning")
+        # for "no answer yet", so there is no reason to wait for litellm at
+        # all here.
+        from reyn.llm.litellm_bootstrap import ensure_litellm_ready_or_defer
+        litellm = ensure_litellm_ready_or_defer()
         entry = litellm.model_cost.get(model, {})
         per_token = entry.get("input_cost_per_token")
         if per_token is None:

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -53,6 +53,10 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from reyn.llm.json_parse import loads_lenient
+from reyn.llm.litellm_bootstrap import (
+    LitellmWarmingInBackgroundError,
+    ensure_litellm_ready_or_defer,
+)
 from reyn.prompt import compaction as _prompt_compaction
 
 if TYPE_CHECKING:
@@ -202,14 +206,23 @@ def estimate_tokens(text: str, model: str, *, use_chars4: bool = False) -> int:
     in_cooldown = time.monotonic() < _token_counter_cooldown_until
     if not in_cooldown:
         try:
-            # perf/log-routing chokepoint: per-turn token sizing runs BEFORE
-            # the first completion, so this can be the FIRST litellm import
-            # in the process — funnel it through ensure_litellm_ready() so
-            # litellm's import-time console log routing (#2929) wraps it too
-            # (idempotent; cheap on 2nd+ call).
-            from reyn.llm.litellm_bootstrap import ensure_litellm_ready
-            ensure_litellm_ready()
-            import litellm
+            # #4395 PR-2: non-blocking chokepoint variant — per-turn token
+            # sizing runs BEFORE the first completion, so this can be the
+            # FIRST litellm import in the process, and this function already
+            # has a safe, cheap fallback (chars//4, below) for "no answer
+            # yet". `ensure_litellm_ready_or_defer()` returns immediately
+            # (never imports litellm on THIS thread) if litellm isn't warm,
+            # kicking off the one dedicated background thread instead — see
+            # litellm_bootstrap.py's own PR-2 section comment. Also fixes a
+            # residual instance of PR-1's own defect at this exact site: the
+            # old code called `ensure_litellm_ready()` and then did its own
+            # unconditional `import litellm` right after WITHOUT checking
+            # the return value — on a failure this re-attempted (and
+            # re-failed) litellm's own slow, unbounded import on every call
+            # outside its cooldown window, the same double-attempt shape
+            # PR-1 fixed everywhere else but missed here (this module wasn't
+            # part of PR-1's diff).
+            litellm = ensure_litellm_ready_or_defer()
             m = model or "gpt-3.5-turbo"
             count = litellm.token_counter(model=m, text=text or "")
             # #2961: litellm.token_counter returns 0 (not an exception) for
@@ -799,12 +812,23 @@ def is_context_overflow_error(exc: BaseException) -> bool:
     if getattr(exc, "status_code", None) == 413:
         return True
     try:
-        from reyn.llm.litellm_bootstrap import ensure_litellm_ready
-        ensure_litellm_ready()
-        import litellm
+        # #4395 PR-2: non-blocking chokepoint variant — this classifier
+        # already falls back to the keyword search below when litellm's own
+        # exception class isn't available, so "litellm not warm yet" is a
+        # safe case to defer rather than block on (see
+        # litellm_bootstrap.py's own PR-2 section comment). In practice this
+        # path runs only AFTER a real completion call already failed, so
+        # litellm is almost always already warm by the time this runs — the
+        # defer path exists for correctness, not because this specific site
+        # is where the reported freeze occurred. Also fixes the same
+        # residual PR-1-shaped double-attempt-on-failure defect
+        # ``estimate_tokens`` above had (this module wasn't part of PR-1's
+        # diff): the old code ignored ``ensure_litellm_ready()``'s return
+        # value and did its own unconditional ``import litellm`` right after.
+        litellm = ensure_litellm_ready_or_defer()
         if isinstance(exc, litellm.ContextWindowExceededError):
             return True
-    except ImportError:
+    except (ImportError, LitellmWarmingInBackgroundError):
         pass
     return any(kw in str(exc).lower() for kw in _CONTEXT_OVERFLOW_KEYWORDS)
 

--- a/tests/llm/test_4395_axis2_litellm_import_cooldown.py
+++ b/tests/llm/test_4395_axis2_litellm_import_cooldown.py
@@ -1,0 +1,141 @@
+"""Tier 2: a failed `import litellm` starts a cooldown window — a call
+made WHILE still inside it returns `None` immediately without attempting
+a fresh import; a call made AFTER it elapses does attempt again (#4395
+axis②/PR-2).
+
+THE GAP: PR-1 (#4413) closed the WITHIN-one-call double attempt (a
+caller's own redundant bare `import litellm` right after the chokepoint)
+but deliberately did NOT cache a failure — by design, the NEXT call
+starts a genuinely fresh attempt. A live owner repro (py-spy stack, AFTER
+PR-1 had already landed) caught the process still blocked inside a TLS
+handshake at `litellm_bootstrap.py`'s own internal `import litellm` line
+— PR-1 removed the duplicate attempt WITHIN one call, but a persistently
+broken environment (the owner's own case: a handshake that never
+completes) was still being re-attempted, and re-hung-on, on EVERY
+subsequent call, not just once. This file covers the fix: a failure now
+starts a cooldown (`reyn._cooldown`, the same primitive #4398 already
+established for the identical shape in `compaction/engine.py`'s
+`estimate_tokens`) during which every call returns `None` immediately.
+
+Uses `builtins.__import__` patching (not `unittest.mock`) — same
+technique as `test_4395_litellm_import_not_recached_on_failure.py`.
+"""
+from __future__ import annotations
+
+import builtins
+
+import pytest
+
+import reyn.llm.litellm_bootstrap as lb_mod
+from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+
+
+@pytest.fixture(autouse=True)
+def _clean_litellm_bootstrap_state():
+    """Tier 2 hygiene — see the identical fixture in
+    test_4395_litellm_import_not_recached_on_failure.py for the full
+    "why force _litellm_ready False" reasoning; this file additionally
+    resets the cooldown deadline so no test in this file starts inside a
+    cooldown armed by an earlier test."""
+    original_ready = lb_mod._litellm_ready
+    original_cooldown_until = lb_mod._litellm_import_cooldown_until
+    lb_mod._litellm_ready = False
+    lb_mod._ready_registry.pop("ready", None)
+    lb_mod._litellm_import_failure_warned = False
+    lb_mod._litellm_import_cooldown_until = 0.0
+    yield
+    lb_mod._litellm_ready = original_ready
+    lb_mod._ready_registry.pop("ready", None)
+    lb_mod._litellm_import_failure_warned = False
+    lb_mod._litellm_import_cooldown_until = original_cooldown_until
+
+
+@pytest.fixture()
+def _force_litellm_import_failure(monkeypatch):
+    """Makes every `import litellm` statement in the process raise, and
+    reports how many times it was actually attempted."""
+    real_import = builtins.__import__
+    attempts = {"n": 0}
+
+    def _failing_import(name, *args, **kwargs):
+        if name == "litellm":
+            attempts["n"] += 1
+            raise RuntimeError("simulated persistent litellm import failure")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _failing_import)
+    return attempts
+
+
+def test_a_call_during_the_cooldown_returns_none_without_attempting_import(
+    _force_litellm_import_failure,
+):
+    """Tier 2: THE core fix. A call made immediately after a failure (well
+    within the default cooldown window) must not attempt `import litellm`
+    again at all — the owner-observed defect was exactly this: every
+    subsequent call re-attempting, and re-hanging on, the same broken
+    network operation."""
+    ensure_litellm_ready()
+    after_first = _force_litellm_import_failure["n"]
+
+    result = ensure_litellm_ready()  # still well within the cooldown window
+
+    assert result is None
+    assert _force_litellm_import_failure["n"] == after_first, (
+        "a call during the cooldown must not attempt a fresh import"
+    )
+
+
+def test_a_call_after_the_cooldown_elapses_attempts_again(
+    _force_litellm_import_failure,
+):
+    """Tier 2: the cooldown RATE-LIMITS retrying, it does not permanently
+    give up — the underlying cause may clear (a proxy comes back), and
+    there is no restart hook to notice that on its own, so the first call
+    after the window elapses must re-probe. Simulates elapsed time via a
+    direct, real manipulation of the module's own deadline variable (the
+    thing the cooldown check actually reads), not a sleep — matches
+    testing.md's ban on a straight-line `sleep(N)` to make an assertion
+    pass."""
+    ensure_litellm_ready()
+    after_first = _force_litellm_import_failure["n"]
+
+    lb_mod._litellm_import_cooldown_until = 0.0  # simulate: cooldown has elapsed
+    ensure_litellm_ready()
+    after_second = _force_litellm_import_failure["n"]
+
+    assert after_second > after_first, (
+        "a call after the cooldown has elapsed must attempt a fresh import"
+    )
+
+
+def test_the_cooldown_check_never_imports_litellm_itself(monkeypatch):
+    """Tier 2: accept-side — the cooldown check itself is a cheap
+    `time.monotonic()` comparison, not something that could itself touch
+    litellm's import machinery (which would defeat the whole point)."""
+    import reyn._cooldown as cooldown_mod
+
+    calls = {"n": 0}
+    real_in_cooldown = cooldown_mod.in_cooldown
+
+    def _counting_in_cooldown(deadline):
+        calls["n"] += 1
+        return real_in_cooldown(deadline)
+
+    monkeypatch.setattr(cooldown_mod, "in_cooldown", _counting_in_cooldown)
+    monkeypatch.setattr(lb_mod, "_cooldown", cooldown_mod)
+
+    real_import = builtins.__import__
+
+    def _fail_only_on_litellm(name, *args, **kwargs):
+        if name == "litellm":
+            raise AssertionError("import litellm must not be attempted while checking cooldown")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fail_only_on_litellm)
+    lb_mod._litellm_import_cooldown_until = lb_mod._cooldown.new_cooldown_deadline(60.0)
+
+    result = ensure_litellm_ready()
+
+    assert result is None
+    assert calls["n"] == 1

--- a/tests/llm/test_4395_litellm_import_not_recached_on_failure.py
+++ b/tests/llm/test_4395_litellm_import_not_recached_on_failure.py
@@ -20,6 +20,16 @@ session's own #4399 falsify tests (blocking real sockets to prove a
 network attempt was genuinely made/prevented) — not a mock of any reyn
 object, an interception of Python's own import mechanism to control a
 third-party package's outcome deterministically.
+
+#4395 axis②/PR-2 added a cooldown between repeated failed attempts (a
+gap this PR-1 file's own tests originally missed — a live owner repro
+caught the process still re-attempting, and re-hanging on, the same
+broken TLS handshake on every subsequent call after PR-1 alone landed).
+This file's own autouse fixture resets `_litellm_import_cooldown_until`
+to 0.0 before every test so PR-1's tests keep exercising "not
+PERMANENTLY cached" without being rate-limited by that cooldown; the
+cooldown's own rate-limiting behavior is covered by the dedicated
+cooldown test file instead, not duplicated here.
 """
 from __future__ import annotations
 
@@ -51,13 +61,16 @@ def _clean_litellm_bootstrap_state():
     a change to what "ready" means in production.
     """
     original_ready = lb_mod._litellm_ready
+    original_cooldown_until = lb_mod._litellm_import_cooldown_until
     lb_mod._litellm_ready = False
     lb_mod._ready_registry.pop("ready", None)
     lb_mod._litellm_import_failure_warned = False
+    lb_mod._litellm_import_cooldown_until = 0.0
     yield
     lb_mod._litellm_ready = original_ready
     lb_mod._ready_registry.pop("ready", None)
     lb_mod._litellm_import_failure_warned = False
+    lb_mod._litellm_import_cooldown_until = original_cooldown_until
 
 
 @pytest.fixture()
@@ -88,21 +101,30 @@ def test_a_failed_import_returns_none_not_raise(_force_litellm_import_failure):
     assert result is None
 
 
-def test_a_failed_import_is_not_cached_the_next_call_retries_fresh(
+def test_a_failed_import_is_not_permanently_cached_past_its_cooldown(
     _force_litellm_import_failure,
 ):
     """Tier 2: THE core defect this PR-1 fixes at the chokepoint level —
     a failure must not be permanently remembered as "done" the way a
     success is; the caller with no fallback (a real completion) needs to
-    keep trying on the NEXT turn, not be locked out forever after one
-    environmental blip."""
+    keep trying eventually, not be locked out forever after one
+    environmental blip. #4395 axis②/PR-2 added a COOLDOWN between
+    attempts (see the dedicated cooldown test file) — a call made WHILE
+    still in cooldown does NOT retry (that is now the correct,
+    intentional behavior, the opposite of this test's own pre-PR-2
+    premise); this test simulates the cooldown having already elapsed
+    (a direct, real manipulation of the module's own deadline variable,
+    not a sleep) to isolate "not cached past its cooldown" from "rate-
+    limited during its cooldown", which the dedicated cooldown test file
+    covers separately."""
     ensure_litellm_ready()
     after_first = _force_litellm_import_failure["n"]
+    lb_mod._litellm_import_cooldown_until = 0.0  # simulate: cooldown has elapsed
     ensure_litellm_ready()
     after_second = _force_litellm_import_failure["n"]
     assert after_second > after_first, (
-        "the second call must trigger a genuinely fresh import attempt, "
-        "not reuse a cached failure result"
+        "a call made after the cooldown has elapsed must trigger a "
+        "genuinely fresh import attempt, not reuse a cached failure result"
     )
 
 
@@ -145,6 +167,13 @@ def test_a_success_after_a_failure_is_returned_and_cached(monkeypatch):
 
     assert ensure_litellm_ready() is None
     state["fail"] = False
+    # #4395 axis②/PR-2: the first failure above armed a cooldown — clear it
+    # (a direct, real manipulation of the module's own deadline variable,
+    # not a sleep) so this recovery attempt is not itself rate-limited;
+    # the cooldown mechanism's own behavior is covered by the dedicated
+    # cooldown test file, this test is specifically about "a SUCCESS,
+    # once attempted, stays cached."
+    lb_mod._litellm_import_cooldown_until = 0.0
     result = ensure_litellm_ready()
     assert result is not None
     assert result.__name__ == "litellm"

--- a/tests/llm/test_4395_pr2_litellm_warm_thread.py
+++ b/tests/llm/test_4395_pr2_litellm_warm_thread.py
@@ -26,7 +26,6 @@ module's own function, not a mock of any object model.
 from __future__ import annotations
 
 import threading
-import time
 
 import pytest
 
@@ -89,23 +88,29 @@ def _clean_litellm_bootstrap_state():
 
 
 def test_repeated_calls_during_a_persistent_failure_never_block(monkeypatch):
-    """Tier 2: THE core defect. Every call must return in effectively zero
-    time, even while litellm keeps failing to import on every attempt."""
+    """Tier 2: THE core defect — the CALLING thread must never itself
+    attempt the import; only the dedicated background worker thread may.
+    Observed at the CAUSE (which thread actually invoked the fake import
+    function), not an inferred EFFECT (elapsed wall-clock time — a
+    time-based assertion this repo's testing policy bans; "fast" is a
+    consequence of "never attempted here", not the thing itself)."""
+    calling_thread_names: list[str] = []
+
     def _always_failing_ensure_ready():
+        calling_thread_names.append(threading.current_thread().name)
         return None  # matches the real function's own contract: never
         # raises, returns None on failure, does not flip `_litellm_ready`.
 
     monkeypatch.setattr(lb_mod, "ensure_litellm_ready", _always_failing_ensure_ready)
 
-    start = time.monotonic()
+    this_thread_name = threading.current_thread().name
     for _ in range(20):
         with pytest.raises(LitellmWarmingInBackgroundError):
             ensure_litellm_ready_or_defer()
-    elapsed = time.monotonic() - start
 
-    assert elapsed < 1.0, (
-        f"20 calls during a persistent failure took {elapsed:.3f}s — the "
-        f"calling thread must never wait on the import attempt"
+    assert this_thread_name not in calling_thread_names, (
+        "the calling thread must never itself invoke ensure_litellm_ready — "
+        "only the dedicated background worker thread may"
     )
     _let_worker_thread_finish_and_reap_it()
 

--- a/tests/llm/test_4395_pr2_litellm_warm_thread.py
+++ b/tests/llm/test_4395_pr2_litellm_warm_thread.py
@@ -1,0 +1,186 @@
+"""Tier 2: `ensure_litellm_ready_or_defer()` never blocks the calling
+thread, and exactly ONE dedicated background thread owns retrying a
+failed `import litellm` — not one thread per call (#4395 PR-2, owner
+design).
+
+THE BUG: a live owner repro (py-spy stack) caught the event-loop/UI
+thread itself blocked inside the FIRST-EVER `import litellm` — which
+transitively runs tiktoken's own un-timed-out network fetch at litellm's
+OWN import time (#4395 PR-1 already fixed the no-fallback call sites'
+own "wait on the UI loop" shape via `asyncio.to_thread`; this PR
+addresses the sites that have a safe fallback and so should not wait on
+litellm AT ALL). Moving the import "onto a worker thread" is not itself
+the fix (Python's own import lock already serializes concurrent imports
+of the SAME module safely) — the actual requirement is that a caller
+with a fallback never blocks even briefly, and (verified necessary by
+Python's own semantics: a module whose top-level code raises is evicted
+from `sys.modules`, so a failed import is retried from scratch on the
+next attempt) that a persistently-failing environment does not spawn an
+unbounded number of worker threads, one per call.
+
+Uses a REAL callable substituting for `reyn.llm.litellm_bootstrap.
+ensure_litellm_ready` (`monkeypatch.setattr`, not `unittest.mock`) to
+control its outcome deterministically — an interception of this
+module's own function, not a mock of any object model.
+"""
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+import reyn.llm.litellm_bootstrap as lb_mod
+from reyn.llm.litellm_bootstrap import (
+    LitellmWarmingInBackgroundError,
+    ensure_litellm_ready_or_defer,
+)
+
+
+class _FakeLitellmModule:
+    """A real, distinguishable stand-in for the module `ensure_litellm_
+    ready()` would normally return on success — lets a test simulate "the
+    import just succeeded" without performing a real import."""
+
+
+def _let_worker_thread_finish_and_reap_it() -> None:
+    """End-of-test helper: flips `_litellm_ready` True directly (as the
+    real `ensure_litellm_ready()` only does after a genuine success) and
+    waits for the CURRENT worker thread (if any) to notice and exit
+    before returning. Every test that simulates a persistent FAILURE
+    must call this before finishing, or the worker thread it started
+    keeps polling for up to the test's own (possibly long) cooldown
+    value — outliving the test, `monkeypatch`'s own auto-revert, and
+    lingering as a `reyn-litellm-warm`-named thread `threading.
+    enumerate()` would show to every LATER test in the same pytest
+    process. The worker's own SHORT internal poll interval
+    (`_LITELLM_WARM_POLL_SECONDS`, independent of whatever cooldown the
+    test configured) means it notices this within a fraction of a second
+    regardless of the test's own cooldown value."""
+    lb_mod._litellm_ready = True
+    thread = lb_mod._litellm_warm_thread
+    if thread is not None:
+        thread.join(timeout=10)
+        assert not thread.is_alive(), "worker thread did not finish within the reap timeout"
+
+
+@pytest.fixture(autouse=True)
+def _clean_litellm_bootstrap_state():
+    """Tier 2 hygiene: reset the module-global worker-thread handle and
+    `_litellm_ready` flag for the duration of each test in this file,
+    restoring the real pre-test state afterward — without this, a test
+    running after litellm has genuinely, successfully imported earlier
+    in the same pytest session would see `_litellm_ready` already True
+    and never exercise the not-yet-ready path at all."""
+    prior_thread = lb_mod._litellm_warm_thread
+    if prior_thread is not None and prior_thread.is_alive():
+        prior_thread.join(timeout=5)
+    lb_mod._litellm_warm_thread = None
+    original_ready = lb_mod._litellm_ready
+    lb_mod._litellm_ready = False
+    try:
+        yield
+    finally:
+        thread = lb_mod._litellm_warm_thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=5)
+        lb_mod._litellm_warm_thread = None
+        lb_mod._litellm_ready = original_ready
+
+
+def test_repeated_calls_during_a_persistent_failure_never_block(monkeypatch):
+    """Tier 2: THE core defect. Every call must return in effectively zero
+    time, even while litellm keeps failing to import on every attempt."""
+    def _always_failing_ensure_ready():
+        return None  # matches the real function's own contract: never
+        # raises, returns None on failure, does not flip `_litellm_ready`.
+
+    monkeypatch.setattr(lb_mod, "ensure_litellm_ready", _always_failing_ensure_ready)
+
+    start = time.monotonic()
+    for _ in range(20):
+        with pytest.raises(LitellmWarmingInBackgroundError):
+            ensure_litellm_ready_or_defer()
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1.0, (
+        f"20 calls during a persistent failure took {elapsed:.3f}s — the "
+        f"calling thread must never wait on the import attempt"
+    )
+    _let_worker_thread_finish_and_reap_it()
+
+
+def test_exactly_one_worker_thread_regardless_of_call_volume(monkeypatch):
+    """Tier 2: owner's condition — a persistently failing environment must
+    not accumulate one thread per call. This is the test that would have
+    failed against a respawn-per-caller design."""
+    def _always_failing_ensure_ready():
+        return None
+
+    monkeypatch.setattr(lb_mod, "ensure_litellm_ready", _always_failing_ensure_ready)
+
+    for _ in range(20):
+        with pytest.raises(LitellmWarmingInBackgroundError):
+            ensure_litellm_ready_or_defer()
+
+    warm_threads = [t for t in threading.enumerate() if t.name == "reyn-litellm-warm"]
+    # Exactly 1 thread, not "at most 1" — asserted by unpacking into exactly
+    # one binding (canonical idiom: a wrong COUNT fails the unpack itself,
+    # not a len(...) == N format pin).
+    (single_thread,) = warm_threads
+    assert single_thread.name == "reyn-litellm-warm"
+    _let_worker_thread_finish_and_reap_it()
+
+
+def test_a_success_is_picked_up_by_the_next_call(monkeypatch):
+    """Tier 2: recovery — once the dedicated worker thread succeeds
+    (litellm becomes ready), the NEXT deferred call must succeed
+    normally, not keep raising."""
+    fake_module = _FakeLitellmModule()
+
+    def _succeeding_ensure_ready():
+        lb_mod._litellm_ready = True
+        return fake_module
+
+    monkeypatch.setattr(lb_mod, "ensure_litellm_ready", _succeeding_ensure_ready)
+
+    assert not lb_mod.is_litellm_ready()
+    with pytest.raises(LitellmWarmingInBackgroundError):
+        ensure_litellm_ready_or_defer()
+
+    # Wait for the worker thread to actually run and succeed — bounded,
+    # unconditional wait on the condition itself, not a fixed sleep.
+    thread = lb_mod._litellm_warm_thread
+    assert thread is not None
+    thread.join(timeout=10)
+    assert not thread.is_alive(), "worker thread did not finish within the join timeout"
+
+    assert lb_mod.is_litellm_ready()
+    result = ensure_litellm_ready_or_defer()  # must NOT raise now
+    assert result is fake_module
+
+
+def test_already_ready_case_never_touches_the_worker_thread(monkeypatch):
+    """Tier 2: accept-side — when litellm is ALREADY ready, this function
+    must behave like the plain `ensure_litellm_ready()` and never spawn a
+    worker thread at all (the common case, after the first successful
+    import in a process)."""
+    lb_mod._litellm_ready = True
+    fake_module = _FakeLitellmModule()
+    call_count = {"n": 0}
+
+    def _counting_ensure_ready():
+        call_count["n"] += 1
+        return fake_module
+
+    monkeypatch.setattr(lb_mod, "ensure_litellm_ready", _counting_ensure_ready)
+
+    result = ensure_litellm_ready_or_defer()  # must not raise
+
+    assert result is fake_module
+    assert call_count["n"] == 1, (
+        "the already-ready fast path must still call ensure_litellm_ready() "
+        "once (cheap baseline-capture housekeeping)"
+    )
+    warm_threads = [t for t in threading.enumerate() if t.name == "reyn-litellm-warm"]
+    assert warm_threads == [], "no worker thread should be spawned when litellm is already ready"

--- a/tests/llm/test_litellm_lazy_load.py
+++ b/tests/llm/test_litellm_lazy_load.py
@@ -269,24 +269,40 @@ def test_sibling_first_import_routes_import_time_warning_to_file(tmp_path, out_o
     stderr StreamHandler and the import-time warning leaks to the console —
     the assertion `not in result.stderr` would fail. (Confirmed by removing
     the wire and re-running: the warning appears on stderr.)
+
+    #4395 PR-2: ``estimate_tokens`` now calls the NON-blocking
+    ``ensure_litellm_ready_or_defer()`` — the FIRST call in a process with
+    litellm not yet ready no longer imports inline; it kicks off the one
+    dedicated background thread and falls back to chars//4 immediately.
+    That thread does the exact same ``ensure_litellm_ready()`` call this
+    test cares about (so the #2929 routing still applies), just off the
+    calling thread — waits for it to actually finish (bounded, unconditional
+    wait on the condition itself) before asserting, instead of assuming the
+    single ``estimate_tokens`` call already did the import synchronously.
     """
     project_root = tmp_path
     script = f"""
-        import os, sys
+        import os, sys, time
         os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "False"
         os.environ["LITELLM_MODEL_COST_MAP_URL"] = "http://127.0.0.1:1/unreachable.json"
 
         from pathlib import Path
         from reyn.interfaces.cli.commands.chat import _setup_interactive_logging
+        from reyn.llm.litellm_bootstrap import is_litellm_ready
         from reyn.services.compaction.engine import estimate_tokens
 
         _setup_interactive_logging(Path({str(project_root)!r}))
         assert "litellm" not in sys.modules, "litellm imported before the sibling call"
         # SIBLING-FIRST: the very first litellm import in this process happens
-        # inside estimate_tokens (via its ensure_litellm_ready wire), NOT via
-        # recorded_acompletion / ensure_litellm_ready called directly.
+        # inside estimate_tokens (via its ensure_litellm_ready_or_defer wire),
+        # NOT via recorded_acompletion / ensure_litellm_ready called directly.
+        # #4395 PR-2: this defers to the background warming thread rather
+        # than importing inline — wait for that thread to finish.
         estimate_tokens("some text to size", "gpt-3.5-turbo")
-        assert "litellm" in sys.modules, "sibling call did not import litellm"
+        deadline = time.monotonic() + 10.0
+        while not is_litellm_ready() and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert "litellm" in sys.modules, "sibling call's background warm did not import litellm"
         """
     result = _run(out_of_process_reyn, script)
     assert result.returncode == 0, result.stderr

--- a/tests/llm/test_litellm_lazy_load.py
+++ b/tests/llm/test_litellm_lazy_load.py
@@ -276,8 +276,9 @@ def test_sibling_first_import_routes_import_time_warning_to_file(tmp_path, out_o
     dedicated background thread and falls back to chars//4 immediately.
     That thread does the exact same ``ensure_litellm_ready()`` call this
     test cares about (so the #2929 routing still applies), just off the
-    calling thread — waits for it to actually finish (bounded, unconditional
-    wait on the condition itself) before asserting, instead of assuming the
+    calling thread — waits for it to actually finish (unbounded wait on the
+    condition itself, no wait-budget constant of this test's own; CI's own
+    kill switch is the backstop) before asserting, instead of assuming the
     single ``estimate_tokens`` call already did the import synchronously.
     """
     project_root = tmp_path
@@ -299,8 +300,11 @@ def test_sibling_first_import_routes_import_time_warning_to_file(tmp_path, out_o
         # #4395 PR-2: this defers to the background warming thread rather
         # than importing inline — wait for that thread to finish.
         estimate_tokens("some text to size", "gpt-3.5-turbo")
-        deadline = time.monotonic() + 10.0
-        while not is_litellm_ready() and time.monotonic() < deadline:
+        # Unbounded wait on the condition itself — no wait-budget constant
+        # of this test's own (CI's own --timeout=120 kill switch is the
+        # backstop; a script needing longer than that to warm should be
+        # investigated, not silently capped here).
+        while not is_litellm_ready():
             time.sleep(0.05)
         assert "litellm" in sys.modules, "sibling call's background warm did not import litellm"
         """

--- a/tests/llm/test_thread_safety_startup_shared_state_3671.py
+++ b/tests/llm/test_thread_safety_startup_shared_state_3671.py
@@ -104,11 +104,22 @@ def test_token_cache_eviction_is_fifo_not_lru(monkeypatch):
     regardless of how recently it was read. Driven entirely through the
     PUBLIC ``estimate_tokens`` surface (never the private cache dict): a
     cache hit/miss is observed indirectly, via whether the underlying
-    ``litellm.token_counter`` gets called again for the same input."""
+    ``litellm.token_counter`` gets called again for the same input.
+
+    #4395 PR-2: ``estimate_tokens`` now calls the NON-blocking
+    ``ensure_litellm_ready_or_defer()`` — its real, intended behavior on
+    the very FIRST call in a process with litellm not yet ready is to
+    defer to the background warming thread and fall back immediately
+    (never block), so this test's own real-world precondition (litellm
+    already ready, matching every call after the process's first) is
+    made explicit here rather than left to incidental test-order luck."""
     import litellm
 
+    from reyn.llm.litellm_bootstrap import ensure_litellm_ready
     from reyn.services.compaction import engine as compaction_engine
 
+    ensure_litellm_ready()  # real precondition: litellm already ready
+    monkeypatch.setattr(compaction_engine, "_token_counter_cooldown_until", 0.0)
     monkeypatch.setattr(compaction_engine, "_TOKEN_CACHE_MAXSIZE", 2)
     compaction_engine._token_cache.clear()
 
@@ -237,10 +248,23 @@ def test_retryable_litellm_exceptions_consistent_under_concurrency(monkeypatch):
     "same shape as the others": the checked global and the assigned global
     are the SAME variable, in one atomic STORE, so a reader only ever
     observes ``None`` or the complete tuple — a concurrent racer can
-    redundantly rebuild it (import litellm + reconstruct the tuple again),
-    never observe a wrong or partial value."""
-    from reyn.llm import llm as llm_module
+    redundantly rebuild it (never a wrong or partial value).
 
+    #4395 PR-2 (architect measurement): this function no longer imports
+    litellm on its own AT ALL — it only reads `sys.modules["litellm"]`
+    once `is_litellm_ready()` confirms it is already there (a second,
+    independent `import litellm` from this function would contend on
+    CPython's own per-module import lock with the dedicated background
+    warming thread's own in-flight import, blocking main for the exact
+    duration that thread exists to avoid). This test's own real-world
+    precondition — this function is only ever reached AFTER a real
+    completion attempt already ran (and so already imported litellm) —
+    is made explicit here rather than left to incidental test-order luck:
+    litellm is confirmed ready BEFORE the concurrent workers start."""
+    from reyn.llm import llm as llm_module
+    from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+
+    ensure_litellm_ready()  # real precondition: litellm already ready
     monkeypatch.setattr(llm_module, "_RETRYABLE_LITELLM_EXCEPTIONS", None)
 
     results: list[tuple] = []

--- a/tests/services/test_compaction_token_cache_incremental.py
+++ b/tests/services/test_compaction_token_cache_incremental.py
@@ -59,7 +59,22 @@ def _clean_token_cache():
     assertions aren't polluted by entries other tests warmed. Setup/teardown,
     not an assertion (Tier 4 forbids asserting on private state, not touching
     it for isolation — the same pattern as this session's `_clean_task_polls`
-    for `_TASK_POLLS`)."""
+    for `_TASK_POLLS`).
+
+    #4395 PR-2: `estimate_tokens()` now calls the NON-blocking
+    `ensure_litellm_ready_or_defer()` — its real, intended behavior on the
+    very FIRST call in a process with litellm not yet ready is to defer to
+    the background warming thread and fall back to chars//4 immediately
+    (never block), which would make every test below observe the wrong
+    call count for the `_counting_token_counter` fake below (it never gets
+    invoked at all). Every test in this file's own real-world precondition
+    — litellm already ready, matching every call after the process's
+    first — is made explicit here rather than left to incidental
+    test-order luck, and any cooldown a PRIOR test's simulated failure
+    armed is cleared too."""
+    from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+    ensure_litellm_ready()  # real precondition: litellm already ready
+    engine_mod._token_counter_cooldown_until = 0.0
     engine_mod._token_cache.clear()
     yield
     engine_mod._token_cache.clear()


### PR DESCRIPTION
**[docs-maintainer]** — PR-2 of the #4395 arc: cooldown + a dedicated background thread, in ONE PR per owner decision (split framing kept losing — see history below), 2 commits for revert granularity.

## Why one PR, two commits

Lead-coder's own account, quoted because it explains the shape of this PR directly: cooldown alone only rate-limits retrying — it can't save the *first* attempt in a process, and the owner's own py-spy at both the startup freeze and the per-message freeze showed the **identical** ssl/tiktoken stack. Cooldown and the owned thread close two different axes of the same defect (frequency vs. who-waits) and neither alone closes the owner's report. Landing them separately would have re-created the exact gap that made PR-1-alone insufficient. Commits are split so a revert of the thread mechanism (the larger, more behavior-changing half) doesn't have to take the cooldown fix down with it.

## Commit ① — cooldown (`fix(#4395): cooldown a persistently-failing litellm import (axis②)`)

PR-1 (#4413) removed the WITHIN-one-call double attempt but deliberately left a failure un-cached — by design, the next call gets a genuinely fresh attempt. A live owner repro **after PR-1 had already landed** caught the process still hanging inside a TLS handshake at `litellm_bootstrap.py`'s own `import litellm` line — every subsequent call was re-attempting, and re-hanging on, the same broken environment. "Not permanently cached" and "retried on literally every call" are different things; PR-1 only fixed the first.

Fix: a failure now arms a cooldown (`reyn._cooldown`, the same primitive #4398 established for the identical shape in `estimate_tokens`) — a call during the window returns `None` immediately, no import attempted. A success clears it. Not a permanent give-up: the underlying cause may clear, and the first call after the window elapses always re-probes.

**Does not help the first attempt in a process** — that one still pays the real cost once. That's commit ②'s job.

## Commit ② — dedicated background thread (`fix(#4395): dedicated background thread warms litellm for fallback-having call sites`)

Adds to `litellm_bootstrap.py`: `is_litellm_ready()` (non-blocking read), `warm_litellm_in_background()` (idempotently starts exactly ONE daemon thread that retries the unmodified, cooldown-gated `ensure_litellm_ready()` until it succeeds, then exits), `ensure_litellm_ready_or_defer()` (the non-blocking entry point — returns immediately if already ready, else kicks off the thread and raises `LitellmWarmingInBackgroundError` for the caller's own existing fallback to catch).

**Converted call sites** (all three already had a safe, cheap fallback):
- `model_budget.py`'s `_lookup_max_input` (fallback: 128K conservative default)
- `model_cost_rate.py`'s `get_input_cost_per_1m_usd` (fallback: `None` = unknown cost)
- `compaction/engine.py`'s `estimate_tokens` + `is_context_overflow_error` (fallback: chars//4 / keyword search) — also found and fixed a residual instance of PR-1's own defect here: this module wasn't part of PR-1's diff, and both functions were still doing `ensure_litellm_ready(); import litellm` unconditionally, ignoring the return value.

**`llm.py` / `litellm_provider.py` unchanged** — no fallback exists for a real completion/embedding call, so they keep the blocking `ensure_litellm_ready()`, already off the event loop via PR-1's own `asyncio.to_thread` conversion.

**Startup path, verified structurally (not assumed)**: `_ensure_turn_budget_engine` is lazy (#3671 follow-up — confirmed NOT called at Session construction). `maybe_emit_model_cost_warn(..., action="session_start")` (`session.py`'s `run()`) IS called synchronously on the startup path, cost-warn `enabled=True` by default, and resolves through `model_cost_rate.py` — converted above. So session startup's own first litellm touch now kicks off the background thread immediately instead of blocking main — closing the owner's startup freeze report via the SAME conversion that closes the per-message one, not a separate fix.

## Hardening, not required (`llm.py`'s `_get_retryable_litellm_exceptions`)

Flagged mid-review as a possible second chokepoint-bypass, then **retracted by both architect and lead-coder** after architect traced the actual call graph: this function's only reachable path (`_llm_call_with_retry`'s exception handler) is only ever reached after `recorded_acompletion`'s own readiness check already succeeded or raised — never actually racing the background thread. Kept the conversion anyway (architect's re-affirmation after the retraction): it removes a *capability* (independently importing litellm) rather than adding a moving part, same shape as #4413's `pricing.py` fix — "structurally incapable of bypassing," not reliant on today's call order staying the same forever. Two existing tests updated to state their own real precondition (litellm already ready) explicitly instead of relying on incidental test-order luck across the suite — valuable independent of the retracted threat model.

## Test plan

- [x] New: `tests/llm/test_4395_pr2_litellm_warm_thread.py` (4 tests) — no-block-during-persistent-failure (20 calls <1s), exactly-one-worker-thread-under-load (falsifies an earlier respawn-per-caller draft), success-picked-up-by-next-call, already-ready-never-spawns-a-thread.
- [x] New: `tests/llm/test_4395_axis2_litellm_import_cooldown.py` (3 tests) — during-cooldown-no-reattempt, after-cooldown-reattempts, cooldown-check-itself-never-imports-litellm.
- [x] Updated `tests/llm/test_4395_litellm_import_not_recached_on_failure.py` (PR-1's own file): 2 of its 4 tests' premise went stale under the new cooldown (back-to-back calls no longer both retry) — fixed to simulate cooldown-elapsed via direct deadline manipulation, not a sleep.
- [x] Updated `tests/llm/test_thread_safety_startup_shared_state_3671.py`, `tests/services/test_compaction_token_cache_incremental.py`, `tests/llm/test_litellm_lazy_load.py`: the non-blocking conversion means the FIRST call to a converted site in a process now defers instead of blocking inline — these files' own real preconditions (litellm already ready, or wait for the background thread) made explicit rather than left to incidental test-order luck. Genuine behavior-change-driven fixes, not workarounds.
- [x] Falsified: `test_exactly_one_worker_thread_regardless_of_call_volume` is the test that would have failed against an earlier, corrected respawn-per-caller design.
- [x] `ruff check` — clean on every changed file.
- [x] `python scripts/mypy_ratchet.py` — 211/215 baselined, no new findings (pyright-only noise from litellm's own missing stubs is pre-existing, unrelated to this diff).
- [x] `python scripts/test_tier_audit.py --strict` on every changed/new test file — 0 Tier-4 violations (1 `len(warm_threads) == 1` caught and fixed to a tuple-unpack idiom before this PR was opened).
- [x] `python scripts/verify_module_docstrings.py` — clean.
- [x] `python scripts/check_tests_path_literal_reference.py` — clean.
- [x] Broad sweep: `tests/llm/`, embedding-adjacent, compaction/model-budget/model-cost-warn/context-budget/token-budget-adjacent test files — 1000+ tests, all passing after the precondition fixes above.
- [ ] Visual/manual (owner env) — per the standing waiver (CLAUDE.md, 2026-08-08), left unchecked; owner confirms after merge on `main`.

## Arc note

`part of #4395` (not closing — #4415, the full 12-site reachability classification, is explicitly scoped as a separate, non-urgent follow-up after this PR per lead-coder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**[lead-coder]** — レビュアの blocking 項目（★時間依存の 2 箇所）

- [x] 🔴 `assert elapsed < 1.0` を削除し、★「呼び出しスレッドが import を試みていない」を assert に（fake が `threading.current_thread().name` を記録し `"MainThread" not in calls`）。速さは結果であって主張ではありません。
- [x] 🔴 `deadline = time.monotonic() + 10.0` の待ち予算を外す（`while not is_litellm_ready(): sleep(0.05)` ── CI の 120s kill が backstop）。★worker thread を公開の観測点にできるなら join の方が良い。


⚪ **上の 2 箱は★レビュア（lead-coder）が閉じました** — `pull/4417/head` を直接引いた結果です（①`elapsed` の assert が消え `threading.current_thread().name` の記録に置換、docstring に「not an inferred EFFECT」まで明記／②`deadline` / `monotonic() +` が **0 hit**）。
