### PR TITLE
fix(#4395): router_loop.py precheck + cooldown opt-out for no-fallback callers

### DIFF
--- a/src/reyn/data/embedding/litellm_provider.py
+++ b/src/reyn/data/embedding/litellm_provider.py
@@ -413,8 +413,11 @@ class LiteLLMEmbeddingProvider:
                 # coder correction, #4395: PR-1 must land this call site
                 # already-awaitable so PR-2's dedicated-thread mechanism
                 # slots in behind the same await point without a rewrite
-                # of this call site).
-                if await asyncio.to_thread(ensure_litellm_ready) is None:
+                # of this call site). `ignore_cooldown=True` (PR-2 follow-
+                # up): this loop has no fallback within one attempt — the
+                # axis② cooldown protects fallback-having callers, not
+                # this one; see `ensure_litellm_ready()`'s own docstring.
+                if await asyncio.to_thread(ensure_litellm_ready, ignore_cooldown=True) is None:
                     raise LitellmUnavailableError(
                         "import litellm failed — see the reyn.llm."
                         "litellm_bootstrap warn-once log line for the "

--- a/src/reyn/llm/litellm_bootstrap.py
+++ b/src/reyn/llm/litellm_bootstrap.py
@@ -205,10 +205,30 @@ _LITELLM_IMPORT_COOLDOWN_SECONDS = 60.0
 _litellm_import_cooldown_until = 0.0
 
 
-def ensure_litellm_ready() -> "Any | None":
+def ensure_litellm_ready(*, ignore_cooldown: bool = False) -> "Any | None":
     """Idempotent first-touch chokepoint: import litellm + apply its
     one-time setup, returning the imported module — or ``None`` if the
     import itself failed.
+
+    ``ignore_cooldown`` (#4395 PR-2 follow-up, lead-coder review): the
+    axis② cooldown below exists to protect callers WITH a safe fallback
+    (``ensure_litellm_ready_or_defer()``'s own callers — a conservative
+    default, an unknown-cost ``None``, chars//4) from repeatedly re-
+    attempting, and re-hanging on, the same broken import. A caller with
+    NO fallback (a real completion/embedding call, or a structured-output
+    precheck that genuinely needs an answer) was ALREADY a "must wait,
+    there is nowhere else to go" site before axis② existed — for THAT
+    caller, the cooldown is not a protection, it is a regression: a
+    transient failure that would have cleared and succeeded on retry
+    instead hard-fails immediately, without even attempting, for the
+    rest of the cooldown window. Pass ``ignore_cooldown=True`` from a
+    no-fallback call site to skip the axis② gate below and always make a
+    genuine attempt — this does NOT reintroduce axis①'s original bug
+    (within-call double-attempt) or spawn a duplicate concurrent import:
+    the `_ready_registry` ownership dance immediately below still applies
+    unchanged, so a genuine attempt already in flight (from the
+    background warming thread, or another no-fallback caller) is still
+    joined via the SAME `Future`, never independently repeated.
 
     #4395 (PR-1, the minimal fix): this function's OWN internal ``import
     litellm`` is the single place that attempt happens; call sites should
@@ -294,7 +314,11 @@ def ensure_litellm_ready() -> "Any | None":
     # contests for it. Unlocked read, same GIL-atomic-single-variable
     # reasoning as the fast path above; the worst race is one caller
     # re-probing slightly early or late, never a wrong result.
-    if _cooldown.in_cooldown(_litellm_import_cooldown_until):
+    # `ignore_cooldown` (see this function's own docstring): a no-fallback
+    # caller opts out of this gate entirely — it was already a "must
+    # wait" site before axis② existed, and the cooldown protects
+    # fallback-having callers, not this one.
+    if not ignore_cooldown and _cooldown.in_cooldown(_litellm_import_cooldown_until):
         return None
 
     my_future: "Future[Any | None]" = Future()

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -2046,7 +2046,17 @@ async def recorded_acompletion(
     # slots in behind the same await point — writing it as an in-loop
     # blocking call here would force PR-2 to rewrite every caller instead
     # of just the chokepoint).
-    litellm = await asyncio.to_thread(ensure_litellm_ready)
+    #
+    # ``ignore_cooldown=True`` (#4395 PR-2 follow-up, lead-coder review):
+    # the axis② cooldown protects callers WITH a safe fallback from
+    # repeatedly re-attempting a broken import — this call site has NO
+    # fallback and was already a "must wait" site before axis② existed.
+    # Without this flag, a single earlier failure would hard-fail EVERY
+    # completion for the next 60s without even attempting one, silently
+    # dropping any transient failure that would have cleared and
+    # succeeded on retry. See ``ensure_litellm_ready()``'s own docstring
+    # for the full reasoning.
+    litellm = await asyncio.to_thread(ensure_litellm_ready, ignore_cooldown=True)
     if litellm is None:
         raise LitellmUnavailableError(
             "import litellm failed — see the reyn.llm.litellm_bootstrap "

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1742,7 +1742,10 @@ class RouterLoop:
         # is ever wasted on it, whether this turn is a no-capability agent's sole
         # call or a tool-using agent's multi-round turn.
         if self._response_format is not None:
-            from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+            from reyn.llm.litellm_bootstrap import (
+                LitellmUnavailableError,
+                ensure_litellm_ready,
+            )
             from reyn.llm.llm import proxy_kwargs, routing_for_spec
             from reyn.runtime.errors import StructuredOutputUnsupportedModelError
             _spec_fn = getattr(host, "resolve_model_spec", None)
@@ -1763,8 +1766,27 @@ class RouterLoop:
                 if _extra.get("api_base") and "/" in _precheck_spec.model
                 else _precheck_spec.model
             )
-            ensure_litellm_ready()
-            import litellm
+            # #4395: this precheck genuinely needs a real answer (no fallback
+            # exists — structured-output support must actually be known
+            # before the turn's first LLM call) and PREVIOUSLY did its own
+            # unconditional `import litellm` right after `ensure_litellm_
+            # ready()` without checking its return value — a #4395-shaped
+            # double-attempt-on-failure site missed by every census so far
+            # (this call site was in neither PR-1's Set A/B nor #4415's
+            # in-progress recount). `run_loop` is `async def`, so a
+            # synchronous call here blocked the WHOLE event loop for as
+            # long as the underlying import took — via `asyncio.to_thread`
+            # instead, matching `llm.py`'s own `recorded_acompletion` fix
+            # (#4413): only the coroutine waits, not the loop.
+            # `ignore_cooldown=True`: this precheck has no fallback — the
+            # axis② cooldown protects fallback-having callers, not this
+            # one; see `ensure_litellm_ready()`'s own docstring.
+            litellm = await asyncio.to_thread(ensure_litellm_ready, ignore_cooldown=True)
+            if litellm is None:
+                raise LitellmUnavailableError(
+                    "import litellm failed — see the reyn.llm.litellm_bootstrap "
+                    "warn-once log line for the underlying cause",
+                )
             if not litellm.supports_response_schema(_precheck_model):
                 raise StructuredOutputUnsupportedModelError(
                     f"model {_precheck_model!r} does not support structured output "

--- a/tests/llm/test_4395_axis2_litellm_import_cooldown.py
+++ b/tests/llm/test_4395_axis2_litellm_import_cooldown.py
@@ -109,6 +109,45 @@ def test_a_call_after_the_cooldown_elapses_attempts_again(
     )
 
 
+def test_ignore_cooldown_attempts_even_during_the_window(
+    _force_litellm_import_failure,
+):
+    """Tier 2: a no-fallback caller (lead-coder review, post-#4417) must
+    still get a genuine attempt during the cooldown — the cooldown exists
+    to protect callers WITH a safe fallback from repeatedly re-attempting;
+    a caller with no fallback was already a "must wait" site before axis②
+    existed, and silently hard-failing it without even trying would
+    regress a transient failure that would have cleared on retry into an
+    unconditional failure for the whole cooldown window."""
+    ensure_litellm_ready()
+    after_first = _force_litellm_import_failure["n"]
+
+    result = ensure_litellm_ready(ignore_cooldown=True)  # still within the cooldown window
+
+    assert result is None  # the (simulated) import genuinely failed again
+    assert _force_litellm_import_failure["n"] > after_first, (
+        "ignore_cooldown=True must attempt a fresh import even during the "
+        "cooldown window"
+    )
+
+
+def test_ignore_cooldown_false_by_default_still_respects_the_window(
+    _force_litellm_import_failure,
+):
+    """Tier 2: accept-side — the default (no-arg) call keeps respecting
+    the cooldown; `ignore_cooldown` is opt-in, not a silent global
+    behavior change for every caller."""
+    ensure_litellm_ready()
+    after_first = _force_litellm_import_failure["n"]
+
+    result = ensure_litellm_ready()  # default: ignore_cooldown=False
+
+    assert result is None
+    assert _force_litellm_import_failure["n"] == after_first, (
+        "the default call must still respect the cooldown"
+    )
+
+
 def test_the_cooldown_check_never_imports_litellm_itself(monkeypatch):
     """Tier 2: accept-side — the cooldown check itself is a cheap
     `time.monotonic()` comparison, not something that could itself touch


### PR DESCRIPTION
**[docs-maintainer]** — PR-3 of the #4395 arc: two findings from lead-coder's live post-#4417 measurement (owner still slow after pulling #4417).

## Finding 1 — `router_loop.py:1766`, a genuinely new chokepoint-bypass site

Live-measured, in neither PR-1's Set A/B nor #4415's in-progress recount. `RouterLoop.run_loop`'s structured-output support precheck (gated on `response_format is not None`) called `ensure_litellm_ready()` and ignored its return value, then did its own unconditional `import litellm` right after — the exact double-attempt-on-failure shape PR-1 fixed everywhere else, missed here because this module wasn't part of PR-1's diff. `run_loop` is `async def`; the synchronous call blocked the whole event loop for as long as the import took.

Fixed the same way as `llm.py`'s `recorded_acompletion` (#4413): `await asyncio.to_thread(ensure_litellm_ready)`, raising `LitellmUnavailableError` on failure — no fallback exists here, structured-output support must actually be known before the turn's first LLM call.

## Finding 2 — axis② cooldown was silently applying to no-fallback callers too

A design gap in #4417's own cooldown, found during review of finding 1's fix (checking whether the same `LitellmUnavailableError` a completion sees could mean two different things to a caller):

```
import genuinely failed        → None → LitellmUnavailableError   (correct)
in cooldown, never even tried  → None → SAME LitellmUnavailableError  (regression)
```

The cooldown was built to protect callers **with a safe fallback** from repeatedly re-attempting a broken import (`estimate_tokens` etc., via `ensure_litellm_ready_or_defer()`). It was never meant to apply to a caller with **no fallback** (a real completion, an embedding call, or finding 1's own precheck) — those were already "must wait, nowhere else to go" sites before axis② existed. Without an opt-out, a single earlier failure hard-fails **every** subsequent no-fallback call for the next 60s **without even attempting one** — silently downgrading "slow but eventually works" (pre-#4417 behavior for these sites) into "fails fast, permanently, for a full cooldown window", in any environment where the underlying cause is transient rather than permanent.

Fix: `ensure_litellm_ready(ignore_cooldown: bool = False)`. `ensure_litellm_ready_or_defer()` and the background warming thread's own internal retries are **unchanged** — they keep respecting the cooldown (that's exactly what it's for). Only the 3 no-fallback call sites now pass `ignore_cooldown=True`:
- `llm.py`'s `recorded_acompletion`
- `litellm_provider.py`'s embed retry loop
- `router_loop.py`'s precheck (finding 1, this PR)

This does **not** reintroduce axis①'s original within-call double-attempt bug, or spawn a duplicate concurrent import: the `_ready_registry` single-owner Future dance is entirely unchanged — a genuine attempt already in flight (from the background thread, or another no-fallback caller) is still joined via the same Future, never independently repeated. `ignore_cooldown=True` only skips the early-return gate; it doesn't bypass ownership.

## Test plan

- [x] New: `test_ignore_cooldown_attempts_even_during_the_window` — a no-fallback-style call genuinely attempts (and can genuinely succeed or fail) even while a fallback-having caller would be cooldown-gated.
- [x] New: `test_ignore_cooldown_false_by_default_still_respects_the_window` — accept-side: the default call (no opt-in) is unchanged.
- [x] Falsified: `test_ignore_cooldown_attempts_even_during_the_window` fails against pre-fix `litellm_bootstrap.py` with `TypeError: unexpected keyword argument 'ignore_cooldown'`.
- [x] `ruff check`, `python scripts/mypy_ratchet.py` (211/215 baselined, no new findings), `python scripts/test_tier_audit.py --strict` (0 Tier-4), `python scripts/verify_module_docstrings.py`, `python scripts/check_tests_path_literal_reference.py` — all clean.
- [x] Broad sweep: `tests/llm/`, embedding-adjacent, compaction, structured-output (`test_0060_phase2_f3b_builtin_content.py`, `test_pipeline_r5_run_agent_step.py`, `test_0062_structured_output.py`) — 751 passed.
- [ ] Visual/manual (owner env) — per the standing waiver (CLAUDE.md, 2026-08-08), left unchecked; owner confirms after merge on `main`.

## Arc note

`part of #4395`. `#4415` (the full 29-site reachability recount, architect's AST-based pass) remains a separate, non-urgent follow-up — not superseded by this PR; `router_loop.py:1766` was found independently via live measurement, not via #4415's own enumeration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
