### PR TITLE
feat(#4422): a failed litellm import names a cause and a remedy

### DIFF
--- a/scripts/diag_tiktoken_cache.py
+++ b/scripts/diag_tiktoken_cache.py
@@ -11,113 +11,60 @@ verbatim into an issue/chat from an environment where nothing else can
 leave (the reason this script exists at all: #4395's owner-side repro
 couldn't run a one-off diagnostic command that shows paths).
 
-Distinguishes the 3 ways tiktoken's own cache-hit check
-(``tiktoken/load.py``) can miss, matching #4395's own A/B/C:
+#4422: the judgment itself (locate the cache dir, resolve the expected
+cl100k blob hash, compare) now lives in :mod:`reyn._tiktoken_diag`, shared
+with ``reyn.llm.litellm_bootstrap``'s own runtime failure-message —
+this script is a thin print wrapper over :func:`reyn._tiktoken_diag.diagnose`,
+not a second copy of the algorithm.
 
-  A. bundled_file_exists=False  -> the cache file was never written at all
-     (a fresh install, or something cleared the cache dir).
-  B. sha256_matches=False (bundled_file_exists=True) -> the cached file's
-     content doesn't match what THIS installed tiktoken expects — a
-     version mismatch between whatever wrote the cache and the tiktoken
-     now running. tiktoken deletes a mismatched file and re-fetches over
-     the network on every call until this is resolved.
-  C. custom_cache_dir_set=True -> operator/litellm set
-     CUSTOM_TIKTOKEN_CACHE_DIR themselves; if that path doesn't already
-     have a valid cache, this script's other flags describe THAT
-     directory, not tiktoken's default.
+**Behavior change from the pre-#4422 version**: this script now imports
+``reyn`` (to reach ``reyn._tiktoken_diag``), so it observes the SAME
+environment ``ensure_litellm_ready`` itself sees — including
+``reyn/__init__.py``'s own ``TIKTOKEN_CACHE_DIR``/``CUSTOM_TIKTOKEN_CACHE_DIR``
+redirect, which runs unconditionally before any ``reyn.*`` code, this
+script included, can execute at all. That is deliberate: "why did reyn's
+own litellm import just fail" (the #4422 use case) needs reyn's OWN view,
+not tiktoken's un-redirected default. An operator who specifically wants
+tiktoken's RAW pre-reyn default (bypassing the redirect entirely) needs a
+plain interpreter that never imports ``reyn`` — this script is no longer
+that; run the four ``reyn._tiktoken_diag`` functions by hand from such an
+interpreter instead if that isolated reading is what's needed.
 
 This is a read-only probe: it locates the currently-effective cache
 directory and inspects a candidate file already inside it (if present) —
-it never fetches anything, never writes anything, and never imports
-``litellm``\'s or ``reyn``\'s own package init (so it reports what tiktoken
-would ACTUALLY see, unaffected by reyn's own #4395 TIKTOKEN_CACHE_DIR fix
-in ``reyn/__init__.py`` — run with ``-c`` or from a plain interpreter
-outside this repo's own import chain for that isolated read; run normally
-to see the value reyn itself would set).
+it never fetches anything, never writes anything.
 
 No test file for this script (operator tool, not a reyn invariant — see
-CLAUDE.md's test-review question 1: this fits no Tier). If the underlying
-CACHE MECHANISM itself needs a test, that belongs on ``reyn/__init__.py``'s
-own TIKTOKEN_CACHE_DIR default, not here.
+CLAUDE.md's test-review question 1: this fits no Tier). The judgment
+ALGORITHM it now delegates to is exercised for real by
+``tests/llm/test_4422_litellm_import_failure_diagnosis.py`` (the runtime
+consumer this script shares it with); if the underlying CACHE MECHANISM
+itself needs a test, that belongs on ``reyn/__init__.py``'s own
+TIKTOKEN_CACHE_DIR default, not here.
 """
 from __future__ import annotations
 
-import hashlib
-import importlib.metadata as metadata
-import inspect
-import os
-import re
 import sys
-import tempfile
-
-
-def _installed_version(dist_name: str) -> str:
-    try:
-        return metadata.version(dist_name)
-    except metadata.PackageNotFoundError:
-        return "(not installed)"
-
-
-def _effective_cache_dir() -> "tuple[str, bool]":
-    """Mirrors tiktoken/load.py's own resolution order — returns
-    (cache_dir, came_from_env). Never printed; used only to locate the
-    candidate file for the hash check below."""
-    if "TIKTOKEN_CACHE_DIR" in os.environ:
-        return os.environ["TIKTOKEN_CACHE_DIR"], True
-    if "DATA_GYM_CACHE_DIR" in os.environ:
-        return os.environ["DATA_GYM_CACHE_DIR"], True
-    return os.path.join(tempfile.gettempdir(), "data-gym-cache"), False
-
-
-def _cl100k_expectation() -> "tuple[str, str] | None":
-    """(blobpath, expected_hash) for cl100k_base, read from the INSTALLED
-    tiktoken_ext package's own source text — never hardcoded here, so this
-    stays correct across a tiktoken version bump without editing this
-    script. Static source read only (inspect.getsource), never calls the
-    function — calling it would itself fetch/read the real cache file,
-    defeating the point of a side-effect-free probe."""
-    try:
-        from tiktoken_ext.openai_public import cl100k_base
-    except ImportError:
-        return None
-    src = inspect.getsource(cl100k_base)
-    hash_match = re.search(r'expected_hash="([0-9a-f]+)"', src)
-    url_match = re.search(r'"(https://[^"]+)"', src)
-    if not hash_match or not url_match:
-        return None
-    return url_match.group(1), hash_match.group(1)
 
 
 def main() -> int:
-    print("litellm:", _installed_version("litellm"))
-    print("tiktoken:", _installed_version("tiktoken"))
-    print(
-        "custom_cache_dir_set:",
-        bool(os.getenv("CUSTOM_TIKTOKEN_CACHE_DIR")),
-    )
+    from reyn._tiktoken_diag import diagnose
 
-    expectation = _cl100k_expectation()
-    if expectation is None:
+    d = diagnose()
+    print("litellm:", d.litellm_version)
+    print("tiktoken:", d.tiktoken_version)
+    print("custom_cache_dir_set:", d.custom_cache_dir_set)
+
+    if d.bundled_file_exists is None:
         print("bundled_file_exists: (unknown — could not read tiktoken_ext source)")
         print("sha256_matches: (unknown — could not read tiktoken_ext source)")
         return 0
 
-    blobpath, expected_hash = expectation
-    cache_dir, _ = _effective_cache_dir()
-    cache_key = hashlib.sha1(blobpath.encode()).hexdigest()
-    cache_path = os.path.join(cache_dir, cache_key)
-
-    exists = os.path.exists(cache_path)
-    print("bundled_file_exists:", exists)
-
-    if not exists:
+    print("bundled_file_exists:", d.bundled_file_exists)
+    if d.sha256_matches is None:
         print("sha256_matches: (not applicable — file does not exist)")
-        return 0
-
-    with open(cache_path, "rb", buffering=0) as f:
-        data = f.read()
-    actual_hash = hashlib.sha256(data).hexdigest()
-    print("sha256_matches:", actual_hash == expected_hash)
+    else:
+        print("sha256_matches:", d.sha256_matches)
     return 0
 
 

--- a/src/reyn/_tiktoken_diag.py
+++ b/src/reyn/_tiktoken_diag.py
@@ -1,0 +1,152 @@
+"""Shared tiktoken-cache diagnosis core (#4399 origin, #4422 extraction).
+
+The judgment logic here originally lived entirely inside
+``scripts/diag_tiktoken_cache.py`` (#4399), a standalone operator CLI. #4422
+needs the SAME judgment inside a runtime failure message
+(``reyn.llm.litellm_bootstrap.ensure_litellm_ready``'s warn-once log line) —
+"don't re-derive it, reuse it" only holds if there is ONE function both
+callers share, so this module is that extraction: the script now imports
+:func:`diagnose` from here instead of owning a second copy that could drift.
+
+**Why this couldn't just stay `scripts/`-only and be imported from
+`src/reyn/...`**: ``scripts/`` ships in a repo checkout, not in an installed
+(non-editable) ``reyn`` package — a runtime import from ``src/reyn/`` reaching
+into ``scripts/`` would work in this repo's own dev venv and break for every
+other install. A ``src/reyn/`` module is the only shape both callers can
+legally import.
+
+**Why this doesn't reintroduce the script's own documented "isolated read"
+concern**: by the time ANY ``reyn.*`` code can run at all — including this
+module — ``reyn/__init__.py``'s own ``TIKTOKEN_CACHE_DIR``/
+``CUSTOM_TIKTOKEN_CACHE_DIR`` ``setdefault`` calls have ALREADY executed
+(Python runs a package's ``__init__.py`` before any of its submodules); there
+is no "import reyn without triggering it" mode available to runtime code in
+the first place. The script's diagnosis, once it imports this module, sees
+the SAME env `ensure_litellm_ready` itself sees — which is the useful view
+for "why did reyn's own litellm import just fail", the actual #4422 use case.
+An operator who specifically wants tiktoken's RAW pre-reyn default (bypassing
+reyn's redirect entirely) still can, by not invoking this script and instead
+running the resolution by hand in a plain interpreter that never imports
+`reyn` at all — worth restating explicitly here since the script's own
+docstring used to promise a mode this refactor changes.
+
+Read-only, side-effect-free: locates the currently-effective tiktoken cache
+directory and inspects a candidate file already inside it, if present — never
+fetches, never writes.
+"""
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata as metadata
+import inspect
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+
+
+def installed_version(dist_name: str) -> str:
+    """The installed version of *dist_name*, or ``"(not installed)"``."""
+    try:
+        return metadata.version(dist_name)
+    except metadata.PackageNotFoundError:
+        return "(not installed)"
+
+
+def effective_cache_dir() -> "tuple[str, bool]":
+    """Mirrors ``tiktoken/load.py``'s own resolution order — returns
+    ``(cache_dir, came_from_env)``. Used only to locate the candidate file
+    for the hash check in :func:`diagnose`."""
+    if "TIKTOKEN_CACHE_DIR" in os.environ:
+        return os.environ["TIKTOKEN_CACHE_DIR"], True
+    if "DATA_GYM_CACHE_DIR" in os.environ:
+        return os.environ["DATA_GYM_CACHE_DIR"], True
+    return os.path.join(tempfile.gettempdir(), "data-gym-cache"), False
+
+
+def cl100k_expectation() -> "tuple[str, str] | None":
+    """``(blobpath, expected_hash)`` for ``cl100k_base``, read from the
+    INSTALLED ``tiktoken_ext`` package's own source text — never hardcoded
+    here, so this stays correct across a tiktoken version bump without
+    editing this module. Static source read only (``inspect.getsource``),
+    never calls the function — calling it would itself fetch/read the real
+    cache file, defeating the point of a side-effect-free probe."""
+    try:
+        from tiktoken_ext.openai_public import cl100k_base
+    except ImportError:
+        return None
+    src = inspect.getsource(cl100k_base)
+    hash_match = re.search(r'expected_hash="([0-9a-f]+)"', src)
+    url_match = re.search(r'"(https://[^"]+)"', src)
+    if not hash_match or not url_match:
+        return None
+    return url_match.group(1), hash_match.group(1)
+
+
+@dataclass(frozen=True)
+class TiktokenCacheDiagnosis:
+    """The 3 flags #4395/#4399 distinguish, plus the two version strings.
+
+    ``bundled_file_exists`` / ``sha256_matches`` are ``None`` when unknown
+    (``cl100k_expectation()`` could not read the installed ``tiktoken_ext``
+    source) or not applicable (``sha256_matches`` when the file does not
+    exist at all) — a caller must not treat ``None`` as ``False``, the same
+    "unknown is not failure" distinction the original script's prints made
+    ("(unknown — ...)" / "(not applicable — ...)" as text, not a boolean).
+    """
+
+    litellm_version: str
+    tiktoken_version: str
+    custom_cache_dir_set: bool
+    bundled_file_exists: "bool | None"
+    sha256_matches: "bool | None"
+
+
+def diagnose() -> TiktokenCacheDiagnosis:
+    """Run the #4395/#4399 judgment once and return it as data.
+
+    Distinguishes the 3 ways tiktoken's own cache-hit check
+    (``tiktoken/load.py``) can miss:
+
+      A. ``bundled_file_exists=False`` — the cache file was never written at
+         all (a fresh install, or something cleared the cache dir).
+      B. ``sha256_matches=False`` (``bundled_file_exists=True``) — the cached
+         file's content doesn't match what THIS installed tiktoken expects —
+         a version mismatch between whatever wrote the cache and the
+         tiktoken now running. tiktoken deletes a mismatched file and
+         re-fetches over the network on every call until this is resolved.
+      C. ``custom_cache_dir_set=True`` — operator/litellm set
+         ``CUSTOM_TIKTOKEN_CACHE_DIR`` themselves; if that path doesn't
+         already have a valid cache, the other two flags describe THAT
+         directory, not tiktoken's default.
+    """
+    litellm_version = installed_version("litellm")
+    tiktoken_version = installed_version("tiktoken")
+    custom_cache_dir_set = bool(os.getenv("CUSTOM_TIKTOKEN_CACHE_DIR"))
+
+    expectation = cl100k_expectation()
+    if expectation is None:
+        return TiktokenCacheDiagnosis(
+            litellm_version, tiktoken_version, custom_cache_dir_set, None, None,
+        )
+
+    blobpath, expected_hash = expectation
+    cache_dir, _ = effective_cache_dir()
+    cache_key = hashlib.sha1(blobpath.encode()).hexdigest()
+    cache_path = os.path.join(cache_dir, cache_key)
+
+    if not os.path.exists(cache_path):
+        return TiktokenCacheDiagnosis(
+            litellm_version, tiktoken_version, custom_cache_dir_set, False, None,
+        )
+
+    with open(cache_path, "rb", buffering=0) as f:
+        data = f.read()
+    actual_hash = hashlib.sha256(data).hexdigest()
+    return TiktokenCacheDiagnosis(
+        litellm_version, tiktoken_version, custom_cache_dir_set,
+        True, actual_hash == expected_hash,
+    )
+
+
+__all__ = ["TiktokenCacheDiagnosis", "diagnose"]

--- a/src/reyn/llm/litellm_bootstrap.py
+++ b/src/reyn/llm/litellm_bootstrap.py
@@ -220,6 +220,81 @@ _TIKTOKEN_IMPORT_EGRESS_NAME = "tiktoken-import"
 _TIKTOKEN_IMPORT_TIMEOUT_SECONDS = 30.0
 
 
+def _diagnose_import_failure_for_log() -> str:
+    """#4422: turn an ``import litellm`` failure's warn-once log line from
+    "it's broken" into "here's why, and what to try" — reusing #4399's own
+    judgment (:func:`reyn._tiktoken_diag.diagnose`) rather than re-deriving
+    it. Owner + lead-coder spent real hours tracing a real environment's
+    ``import litellm`` failure back to a missing/mismatched tiktoken cache
+    file before this existed; the fix this issue asks for is making reyn
+    say that in ONE line instead of requiring the same multi-hour trace
+    again for the next operator who hits it.
+
+    Three outcomes, matching lead-coder's own review correction (do NOT
+    assert "tiktoken deleted this" as fact when the file is merely absent
+    — absence has more than one cause, and only a DIRECT sha256-mismatch
+    reading is confirmed present-tense fact):
+
+    - bundled_file_exists is False: the cache file is not there NOW. This
+      does not by itself prove why (never written, or deleted after a past
+      mismatch, are both consistent with "not there now") — phrased as a
+      possibility, not asserted, with the same remedy (reinstall) that
+      also serves as the operator's own diagnostic: if the file exists
+      afterward, it was (A) a missing-bundle case; if it goes missing
+      again on next use, that is itself evidence of (B).
+    - bundled_file_exists is True and sha256_matches is False: this IS a
+      directly observed, present-tense mismatch (not inferred) between the
+      installed litellm's bundled blob and what the installed tiktoken
+      expects — tiktoken will delete and re-fetch this exact file on next
+      use, statable as fact because it was just read.
+    - Anything else (including "unknown" — the diagnosis itself could not
+      read the installed tiktoken_ext source): no cache-specific signal:
+      fall back to the #4418 network/cert remedy for a `requests.get`
+      failure with no other explanation available.
+
+    Never raises — this augments a WARN, and a broken diagnostic reading
+    must not turn one warning into two (or a startup crash) when the
+    unaugmented message alone was already good enough for #4395's own
+    original fix.
+    """
+    try:
+        from reyn._tiktoken_diag import diagnose
+
+        d = diagnose()
+    except Exception:  # noqa: BLE001 — best-effort; the plain WARN above already fired
+        return (
+            "(tiktoken-cache diagnosis unavailable — check SSL_VERIFY / "
+            "SSL_CERT_FILE / REQUESTS_CA_BUNDLE if this looks like a "
+            "network/certificate failure.)"
+        )
+
+    if d.bundled_file_exists is False:
+        return (
+            "tiktoken's cache file was not found (litellm=%s, tiktoken=%s) — "
+            "possibly never written, or removed after a past version "
+            "mismatch; not something this check alone can distinguish. Try: "
+            "pip install --force-reinstall --no-deps litellm — if the file "
+            "is present afterward, this was a missing-bundle case; if it "
+            "disappears again on next use, that itself confirms a version "
+            "mismatch." % (d.litellm_version, d.tiktoken_version)
+        )
+    if d.bundled_file_exists is True and d.sha256_matches is False:
+        return (
+            "tiktoken's cache file does not match what the installed "
+            "tiktoken (%s) expects from litellm's bundle (litellm=%s) — a "
+            "version mismatch. tiktoken will delete and re-fetch this file "
+            "over the network on next use. Try: pip install "
+            "--force-reinstall --no-deps litellm to realign the two "
+            "versions." % (d.tiktoken_version, d.litellm_version)
+        )
+    return (
+        "no tiktoken-cache-specific signal found (litellm=%s, tiktoken=%s) "
+        "— if this looks like a network/certificate failure, check "
+        "SSL_VERIFY / SSL_CERT_FILE / REQUESTS_CA_BUNDLE."
+        % (d.litellm_version, d.tiktoken_version)
+    )
+
+
 @contextlib.contextmanager
 def _third_party_import_egress_honours_standard_env(
     events: "EventLog | None",
@@ -499,7 +574,8 @@ def ensure_litellm_ready(
                         "import litellm failed — falling back where a "
                         "fallback exists, retrying on the next call "
                         "where it doesn't. This is a warn-once notice, "
-                        "not a record of a permanent failure.",
+                        "not a record of a permanent failure. %s",
+                        _diagnose_import_failure_for_log(),
                     )
             my_future.set_result(result)
 

--- a/tests/llm/test_4422_litellm_import_failure_diagnosis.py
+++ b/tests/llm/test_4422_litellm_import_failure_diagnosis.py
@@ -1,0 +1,271 @@
+"""Tier 2: #4422 — an ``import litellm`` failure's warn-once log line names
+a CAUSE and a remedy, instead of just "it's broken."
+
+Owner + lead-coder spent real hours tracing a real environment's failed
+``import litellm`` back to a missing/mismatched tiktoken cache file (#4395,
+#4399) before this existed — the fix is making reyn say that in one line so
+the next operator (owner's own question: "everyone else who isn't me, what
+are THEY supposed to do?") doesn't need the same multi-hour trace.
+
+Two collaborators, both real, no mocks:
+
+- :mod:`reyn._tiktoken_diag` — the shared judgment #4399's own
+  ``scripts/diag_tiktoken_cache.py`` used to own alone; ``diagnose()`` is
+  exercised here against REAL files on disk (a real cache dir under
+  ``tmp_path``, a real copy of litellm's own bundled tokenizer blob — the
+  same seeding mechanism ``reyn/__init__.py`` itself uses), not a fake
+  return value, for the two branches that can be produced without a real
+  network fetch.
+- ``reyn.llm.litellm_bootstrap._diagnose_import_failure_for_log`` — the
+  message-selection logic. Its 3 outcome branches are driven via a
+  monkeypatched ``reyn._tiktoken_diag.diagnose`` returning a real
+  ``TiktokenCacheDiagnosis`` instance (the module's own public return
+  type, not an invented shape) — legitimate because the branch SELECTION
+  is reyn's own logic under test, while the underlying file-system read
+  ``diagnose()`` performs is already covered by the ``_tiktoken_diag``
+  tests above; and one end-to-end test (real ``import litellm`` failure,
+  forced via ``builtins.__import__`` patching — the same technique
+  ``test_4395_litellm_import_not_recached_on_failure.py`` already
+  established) proving the diagnosis is ACTUALLY appended to the real
+  warn-once log line, not just callable in isolation.
+
+lead-coder's review correction (owner's own question forced it): a MISSING
+cache file must never be asserted as "tiktoken deleted this" — absence has
+more than one cause, and only a directly-read sha256 MISMATCH is a
+present-tense, confirmed fact. The missing-file branch's own test asserts
+the message does NOT claim deletion happened.
+"""
+from __future__ import annotations
+
+import builtins
+import hashlib
+import importlib.util
+import logging
+import os
+
+import pytest
+
+import reyn.llm.litellm_bootstrap as lb_mod
+from reyn._tiktoken_diag import TiktokenCacheDiagnosis, cl100k_expectation, diagnose
+from reyn.llm.litellm_bootstrap import _diagnose_import_failure_for_log, ensure_litellm_ready
+
+pytestmark = pytest.mark.skipif(
+    cl100k_expectation() is None,
+    reason="tiktoken_ext.openai_public.cl100k_base not importable in this environment",
+)
+
+
+def _real_bundled_blob_path() -> "str | None":
+    """A REAL bundled cl100k cache blob shipped inside the installed
+    litellm package (the same file ``reyn/__init__.py``'s own seeding step
+    copies from), or ``None`` if litellm isn't installed / ships none —
+    the only way to produce a file with a genuinely CORRECT sha256 without
+    a real network fetch (the hash's preimage isn't otherwise derivable)."""
+    spec = importlib.util.find_spec("litellm")
+    if spec is None or not spec.submodule_search_locations:
+        return None
+    tokenizers_dir = os.path.join(
+        next(iter(spec.submodule_search_locations)), "litellm_core_utils", "tokenizers",
+    )
+    expectation = cl100k_expectation()
+    if expectation is None:
+        return None
+    blobpath, _ = expectation
+    cache_key = hashlib.sha1(blobpath.encode()).hexdigest()
+    candidate = os.path.join(tokenizers_dir, cache_key)
+    return candidate if os.path.isfile(candidate) else None
+
+
+# ── reyn._tiktoken_diag.diagnose(): real filesystem, no network ────────────
+
+
+def test_diagnose_reports_missing_cache_file(tmp_path, monkeypatch):
+    """Tier 2: an empty cache dir -> bundled_file_exists=False, sha256_matches
+    is None (not applicable — nothing to hash)."""
+    monkeypatch.setenv("TIKTOKEN_CACHE_DIR", str(tmp_path))
+    monkeypatch.delenv("CUSTOM_TIKTOKEN_CACHE_DIR", raising=False)
+
+    d = diagnose()
+
+    assert d.bundled_file_exists is False
+    assert d.sha256_matches is None
+
+
+def test_diagnose_reports_a_matching_cache_file(tmp_path, monkeypatch):
+    """Tier 2: a real, correctly-named, correctly-hashed cache file (copied
+    from litellm's own bundle — real bytes, real sha256, no fetch) ->
+    bundled_file_exists=True, sha256_matches=True."""
+    blob = _real_bundled_blob_path()
+    if blob is None:
+        pytest.skip("no real bundled cl100k blob available in this environment")
+    monkeypatch.setenv("TIKTOKEN_CACHE_DIR", str(tmp_path))
+    monkeypatch.delenv("CUSTOM_TIKTOKEN_CACHE_DIR", raising=False)
+    expectation = cl100k_expectation()
+    assert expectation is not None
+    blobpath, _ = expectation
+    cache_key = hashlib.sha1(blobpath.encode()).hexdigest()
+    (tmp_path / cache_key).write_bytes(open(blob, "rb").read())
+
+    d = diagnose()
+
+    assert d.bundled_file_exists is True
+    assert d.sha256_matches is True
+
+
+def test_diagnose_reports_a_mismatched_cache_file(tmp_path, monkeypatch):
+    """Tier 2: a file present at the right name but WRONG content (the
+    #4395 failure-mode B shape — a real, direct mismatch reading) ->
+    bundled_file_exists=True, sha256_matches=False."""
+    monkeypatch.setenv("TIKTOKEN_CACHE_DIR", str(tmp_path))
+    monkeypatch.delenv("CUSTOM_TIKTOKEN_CACHE_DIR", raising=False)
+    expectation = cl100k_expectation()
+    assert expectation is not None
+    blobpath, _ = expectation
+    cache_key = hashlib.sha1(blobpath.encode()).hexdigest()
+    (tmp_path / cache_key).write_bytes(b"not the real blob content")
+
+    d = diagnose()
+
+    assert d.bundled_file_exists is True
+    assert d.sha256_matches is False
+
+
+def test_diagnose_reports_unknown_when_the_expectation_is_unreadable(monkeypatch):
+    """Tier 2: accept-side — when the installed tiktoken_ext source can't be
+    read (a real branch reyn's own code takes, not a third-party promise:
+    diagnose() must not crash or fabricate a verdict when its OWN
+    precondition fails), both flags come back None (unknown), never a
+    fabricated True/False."""
+    monkeypatch.setattr("reyn._tiktoken_diag.cl100k_expectation", lambda: None)
+
+    d = diagnose()
+
+    assert d.bundled_file_exists is None
+    assert d.sha256_matches is None
+
+
+# ── litellm_bootstrap._diagnose_import_failure_for_log(): message shape ────
+
+
+def _diagnosis(**overrides) -> TiktokenCacheDiagnosis:
+    base = dict(
+        litellm_version="1.0.0", tiktoken_version="0.9.0",
+        custom_cache_dir_set=False, bundled_file_exists=None, sha256_matches=None,
+    )
+    base.update(overrides)
+    return TiktokenCacheDiagnosis(**base)
+
+
+def test_missing_file_message_never_asserts_deletion_as_fact(monkeypatch):
+    """Tier 2: lead-coder's review correction — a MISSING file is a
+    present-tense "not found," never an asserted-as-fact "was deleted."
+    Absence has more than one cause; only a direct mismatch READING (the
+    next test) is a confirmed fact."""
+    monkeypatch.setattr(
+        "reyn._tiktoken_diag.diagnose",
+        lambda: _diagnosis(bundled_file_exists=False, sha256_matches=None),
+    )
+
+    message = _diagnose_import_failure_for_log()
+
+    assert "not found" in message
+    assert "was deleted" not in message and "has been deleted" not in message, (
+        f"must not assert deletion as a confirmed fact for a merely-absent file: {message!r}"
+    )
+    assert "--force-reinstall" in message, "must offer the remedy that also self-diagnoses"
+
+
+def test_mismatch_message_states_the_confirmed_present_tense_fact(monkeypatch):
+    """Tier 2: a DIRECT sha256 mismatch reading IS a confirmed, present-tense
+    fact (the file was just read) — this branch may state it as such,
+    unlike the missing-file branch above."""
+    monkeypatch.setattr(
+        "reyn._tiktoken_diag.diagnose",
+        lambda: _diagnosis(bundled_file_exists=True, sha256_matches=False),
+    )
+
+    message = _diagnose_import_failure_for_log()
+
+    assert "mismatch" in message.lower()
+    assert "--force-reinstall" in message
+
+
+def test_no_cache_signal_message_falls_back_to_network_cert_remedy(monkeypatch):
+    """Tier 2: matching (or unknown) cache state carries no diagnostic
+    signal of its own — the message falls back to the #4418 network/cert
+    remedy rather than claiming a cause it has no evidence for."""
+    monkeypatch.setattr(
+        "reyn._tiktoken_diag.diagnose",
+        lambda: _diagnosis(bundled_file_exists=True, sha256_matches=True),
+    )
+
+    message = _diagnose_import_failure_for_log()
+
+    assert "SSL_VERIFY" in message
+
+
+def test_a_broken_diagnosis_read_never_raises_past_the_warn(monkeypatch):
+    """Tier 2: this augments a WARN — a broken diagnostic must not turn one
+    warning into a startup-time exception."""
+    def _raising():
+        raise RuntimeError("simulated diagnosis failure")
+
+    monkeypatch.setattr("reyn._tiktoken_diag.diagnose", _raising)
+
+    message = _diagnose_import_failure_for_log()  # must not raise
+
+    assert "SSL_VERIFY" in message
+
+
+# ── end-to-end: the diagnosis actually reaches the real warn-once line ─────
+
+
+@pytest.fixture(autouse=True)
+def _clean_litellm_bootstrap_state():
+    """Same hygiene as test_4395_litellm_import_not_recached_on_failure.py's
+    own fixture — this module's readiness/warn state is process-global."""
+    original_ready = lb_mod._litellm_ready
+    original_cooldown_until = lb_mod._litellm_import_cooldown_until
+    lb_mod._litellm_ready = False
+    lb_mod._ready_registry.pop("ready", None)
+    lb_mod._litellm_import_failure_warned = False
+    lb_mod._litellm_import_cooldown_until = 0.0
+    yield
+    lb_mod._litellm_ready = original_ready
+    lb_mod._ready_registry.pop("ready", None)
+    lb_mod._litellm_import_failure_warned = False
+    lb_mod._litellm_import_cooldown_until = original_cooldown_until
+
+
+def test_a_real_failed_import_carries_the_diagnosis_in_its_log_line(monkeypatch, caplog):
+    """Tier 2: end-to-end wiring — a REAL forced ``import litellm`` failure
+    (``builtins.__import__`` patched, the same technique #4395's own test
+    file established — not a mock of any reyn object) produces a warn-once
+    log line that carries diagnosis content beyond the original plain
+    "import litellm failed" sentence, proving the two are actually wired
+    together in production code, not just independently callable."""
+    real_import = builtins.__import__
+
+    def _failing_import(name, *args, **kwargs):
+        if name == "litellm":
+            raise RuntimeError("simulated persistent litellm import failure")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _failing_import)
+    monkeypatch.setattr(
+        "reyn._tiktoken_diag.diagnose",
+        lambda: _diagnosis(bundled_file_exists=False, sha256_matches=None),
+    )
+
+    with caplog.at_level(logging.WARNING, logger=lb_mod.__name__):
+        result = ensure_litellm_ready()
+
+    assert result is None
+    warning_messages = [
+        r.getMessage() for r in caplog.records if "import litellm failed" in r.getMessage()
+    ]
+    (single_warning,) = warning_messages
+    assert "not found" in single_warning, (
+        f"the diagnosis text must reach the real log line, not just be callable "
+        f"in isolation: {single_warning!r}"
+    )


### PR DESCRIPTION
**[tui-coder]** — feat(#4422): a failed litellm import names a cause and a remedy

## What

Owner's own question forced this: "everyone else who isn't me, what are THEY supposed to do?" — the `pip install --force-reinstall --no-deps litellm` fix lead-coder walked the owner through by hand (#4395/#4399) never reaches the next operator who hits the same failure, because `ensure_litellm_ready()`'s warn-once log line just says "import litellm failed" with no cause.

## Fix

- Reuses #4399's own judgment (locate tiktoken's cache dir, resolve the expected cl100k blob hash, compare) rather than re-deriving it — extracted from `scripts/diag_tiktoken_cache.py` into a new shared module, `src/reyn/_tiktoken_diag.py`, since a `src/reyn/` runtime path cannot import from `scripts/` (it ships in a repo checkout, not an installed non-editable `reyn` package). The script is now a thin print wrapper over `reyn._tiktoken_diag.diagnose()`.
  - **Noted behavior change in the script's own docstring**: it now imports `reyn` (to reach the shared module), so it sees the SAME env `ensure_litellm_ready` sees, not tiktoken's raw pre-redirect default — deliberate, since "why did reyn's own import just fail" is the actual #4422 use case. An operator who wants the raw pre-reyn reading needs a plain interpreter that never imports `reyn`.
- `ensure_litellm_ready()`'s warn-once WARNING now appends one of three messages:
  - cache file missing → reinstall remedy, phrased as a *possibility* (not asserted as "was deleted" — lead-coder's review correction after the owner's own question: absence alone isn't proof of deletion) that also self-diagnoses.
  - cache file present but sha256 mismatch → states the mismatch as fact (directly read) + the same remedy.
  - no cache-specific signal → falls back to the #4418 network/cert remedy (`SSL_VERIFY`/`SSL_CERT_FILE`/`REQUESTS_CA_BUNDLE`).
  - Never raises past the WARN it augments.
- Log-only — whether this also surfaces on the conv-pane is a separate, still-open owner:decide call (#4380); this PR only touches the existing `logging.warning()` call.

## Depends on

Built on top of #4419 (`_diagnose_import_failure_for_log` sits next to that PR's `_third_party_import_egress_honours_standard_env` and the fallback message references its `SSL_VERIFY` remedy) — #4419 merged to `main` while this PR was in progress, so this is now based directly on `main` and the diff is exactly the #4422-specific delta (confirmed via `git diff --stat` against `main`'s tip).

## Test plan

- [x] 9 new tests, real collaborators (no mocks): `reyn._tiktoken_diag.diagnose()` against real files on disk (including a real copy of litellm's own bundled tokenizer blob for the "matches" case — a genuinely correct sha256 can't be produced any other way without a real fetch); message-selection branches via a monkeypatched `diagnose()` returning the real `TiktokenCacheDiagnosis` type; one end-to-end test forcing a real `import litellm` failure (`builtins.__import__` patching, same technique as `test_4395_litellm_import_not_recached_on_failure.py`) reading the diagnosis off the real warn-once log line via `caplog`.
- [x] Falsify-verified: reverted the warn call to its pre-#4422 form, confirmed the end-to-end test RED, restored, confirmed GREEN.
- [x] `ruff check`, `mypy_ratchet.py`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `check_tests_path_literal_reference.py` — all clean.
- [x] Full regression sweep (70 tests: egress completeness, litellm cooldown/lazy-load, RegistryClient) — all passed.
- [ ] (skipped — log-only change, nothing to visually verify)

part of #4422

🤖 Generated with [Claude Code](https://claude.com/claude-code)
