### PR TITLE
feat(#4387): TUI scrollback paging / search page in from disk (Phase B ②, remaining consumers)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1201,6 +1201,17 @@ class TextualChatApp(App):
         # switch), so a switch can never page in the previous session's
         # leftovers.
         self._older_frames: "list[OutboxMessage]" = []
+        # #4387 Phase B ② (remaining consumers): the running total of frames
+        # already accounted for (materialised into ``self.conversation`` PLUS
+        # whatever remains in ``self._older_frames``) as of the last
+        # ``project_restored_frames`` call over the currently loaded message
+        # log. :meth:`_extend_older_frames_from_disk` uses this to cut a
+        # freshly re-projected (now possibly longer) frame list at the right
+        # boundary — projection is not 1:1 with messages (some project to
+        # nothing, tool-call correlation looks back a message), so this must
+        # be a frame-count delta, never a raw-message-count one. Reset
+        # alongside ``self._older_frames`` on every hydrate/switch.
+        self._history_frame_count = 0
         # #3490: the entries the addressed-row rail is currently painted on.
         # flowview's Highlighted/Selected report only the entry MOVED TO, so the
         # one moved AWAY from is tracked here — it needs its gutter re-derived
@@ -1833,6 +1844,10 @@ class TextualChatApp(App):
         # small at realistic history sizes — this is deliberate owner-chosen
         # forward infrastructure, and the split costs one slice.
         self._older_frames = frames[:-_HYDRATE_PAGE_FRAMES]
+        # #4387 Phase B ②: the boundary :meth:`_extend_older_frames_from_disk`
+        # cuts future re-projections at — see its own docstring for why this
+        # must be a frame count, not the message count ``messages`` carries.
+        self._history_frame_count = len(frames)
         tail = frames[-_HYDRATE_PAGE_FRAMES:]
         # #3476 ②: batch append — ``extend`` reflows the view ONCE for the
         # whole appended page instead of once per entry (flowview 0.6.0;
@@ -1864,6 +1879,47 @@ class TextualChatApp(App):
             if msg.kind == "agent":
                 self._recent_replies.appendleft(msg.text)
 
+    def _extend_older_frames_from_disk(self) -> bool:
+        """#4387 Phase B ② (remaining consumers): when ``self._older_frames``
+        (#3476 ④'s lazily-held prefix) is exhausted, ask the read model for
+        MORE of ``history.jsonl``
+        (:meth:`~reyn.interfaces.repl.read_model.ChatReadModel.load_older_conversation_history`)
+        before concluding the true start of the conversation was reached —
+        closing the gap #4387 Phase B ① opened when ``Session.load_history()``
+        stopped necessarily loading the whole file at startup.
+
+        Re-projects the FULL (now possibly longer) message log rather than
+        projecting only the newly-read messages: :func:`project_restored_frames`
+        is NOT 1:1 with messages (some — ``system``/``summary`` — project to
+        nothing; tool-call correlation looks back at the PRECEDING message),
+        so slicing the raw message list at the read model's own returned
+        count would cut in the wrong place. Slicing the re-projected FRAME
+        list at the delta against ``self._history_frame_count`` (the running
+        total already accounted for) is the only cut that is correct
+        regardless of how projection folds messages. Returns whether any new
+        frames became available (``False`` = true start of history, or the
+        read model/projection failed — fully guarded, same as
+        :meth:`_hydrate_from_history`)."""
+        if self._read_model is None:
+            return False
+        try:
+            extended = self._read_model.load_older_conversation_history()
+        except Exception:
+            logger.exception("textual chat: history backward-extend failed")
+            return False
+        if extended <= 0:
+            return False
+        try:
+            messages = self._read_model.conversation_history()
+            frames = project_restored_frames(messages)
+        except Exception:
+            logger.exception("textual chat: history backward-extend projection failed")
+            return False
+        new_prefix = frames[: len(frames) - self._history_frame_count]
+        self._older_frames = new_prefix + self._older_frames
+        self._history_frame_count = len(frames)
+        return bool(new_prefix)
+
     def on_flow_view_reached_top(self, event: "FlowView.ReachedTop") -> None:
         """#3476 ④: page the next-older slice of the restored history in when
         the user scrolls near the top. ``insert_many(0, …)`` reflows once and
@@ -1871,9 +1927,16 @@ class TextualChatApp(App):
         the page lands invisibly above. Fires once per approach and re-arms on
         retreat (flowview's edge-trigger contract); with nothing left to page
         in this is a no-op. Live frames are unaffected — they append at the
-        bottom through the frame pump, never through this path."""
+        bottom through the frame pump, never through this path.
+
+        #4387 Phase B ② (remaining consumers): when the held prefix is
+        exhausted this no longer concludes "nothing more exists" on the
+        spot — it asks :meth:`_extend_older_frames_from_disk` for more of
+        ``history.jsonl`` first, so a real conversation start and a merely
+        bounded in-memory load are no longer indistinguishable to the user."""
         if not self._older_frames:
-            return
+            if not self._extend_older_frames_from_disk():
+                return
         page = self._older_frames[-_HYDRATE_PAGE_FRAMES:]
         try:
             entries = self.conversation.insert_many(0, page)
@@ -1892,7 +1955,17 @@ class TextualChatApp(App):
         history — a hit that exists in history but not in the materialised
         page would read as "no match", a lie — and the measured full-hydrate
         cost is negligible (#3476 issue comment), so search-open simply pays
-        it all at once rather than teaching search a second, virtual domain."""
+        it all at once rather than teaching search a second, virtual domain.
+
+        #4387 Phase B ② (remaining consumers): "full restored history" used
+        to mean only what #4387 Phase B ① bounded ``load_history()`` loaded
+        at startup — a hit older than that tail silently read as "no match"
+        too, contradicting this very docstring's promise. Drains
+        :meth:`_extend_older_frames_from_disk` to the true start of
+        ``history.jsonl`` FIRST, so what gets materialised really is the
+        full history, not just the bounded in-memory slice of it."""
+        while self._extend_older_frames_from_disk():
+            pass
         if not self._older_frames:
             return
         rest = self._older_frames

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -102,7 +102,7 @@ from .presenter import (
     ReynPresenter,
     _neutralized_label,
 )
-from .restore import project_restored_frames
+from .restore import RESUME_DIVIDER, project_restored_frames
 from .rewind_picker import RewindPicker
 from .search_bar import SearchBar
 from .sent_queue import SentQueue
@@ -1899,7 +1899,25 @@ class TextualChatApp(App):
         regardless of how projection folds messages. Returns whether any new
         frames became available (``False`` = true start of history, or the
         read model/projection failed — fully guarded, same as
-        :meth:`_hydrate_from_history`)."""
+        :meth:`_hydrate_from_history`).
+
+        ``project_restored_frames`` unconditionally prepends ONE
+        :data:`.restore.RESUME_DIVIDER` row whenever its own input is
+        non-empty — correct for a single call, but this method calls it
+        AGAIN on every extension, and flowview has no primitive to REMOVE
+        or reposition an already-painted row (only ``append``/``insert``/
+        ``insert_many``). So the FIRST divider a non-empty projection ever
+        produced (at ``_hydrate_from_history`` time, or an earlier extend)
+        is permanent — it stays exactly where it landed. Every LATER
+        extend's own fresh divider is a would-be DUPLICATE and is stripped
+        before slicing, so the pane only ever carries the ONE divider its
+        first non-empty projection produced. This means the divider is NOT
+        guaranteed to sit at the true chronological front once extension
+        has happened (there is no way to move it there without a removal
+        primitive) — an accepted, cosmetic-only limitation: the actual
+        conversation CONTENT before and after it is still complete and in
+        order, which is what this method's own correctness claim is about.
+        """
         if self._read_model is None:
             return False
         try:
@@ -1915,8 +1933,24 @@ class TextualChatApp(App):
         except Exception:
             logger.exception("textual chat: history backward-extend projection failed")
             return False
-        new_prefix = frames[: len(frames) - self._history_frame_count]
+        divider_already_shown = self._history_frame_count > 0
+        if (
+            divider_already_shown
+            and frames
+            and frames[0].kind == "system"
+            and frames[0].text == RESUME_DIVIDER
+        ):
+            content = frames[1:]
+            already_known = self._history_frame_count - 1
+        else:
+            content = frames
+            already_known = self._history_frame_count
+        new_prefix = content[: len(content) - already_known]
         self._older_frames = new_prefix + self._older_frames
+        # The running total this method's OWN slicing bound reads next time
+        # always represents the FULL logical projection (divider + every
+        # message) — whether or not a duplicate divider was actually
+        # painted, exactly one is logically accounted for.
         self._history_frame_count = len(frames)
         return bool(new_prefix)
 

--- a/src/reyn/interfaces/inline/textual_chat/restore.py
+++ b/src/reyn/interfaces/inline/textual_chat/restore.py
@@ -143,8 +143,13 @@ RESTORED_META_KEY = "_restored"
 
 #: Leading divider row announcing that what follows is the resumed prior
 #: conversation (operator legibility — the Product-Think lens). Emitted once,
-#: only when there is at least one restored turn.
-_RESUME_DIVIDER = "⤺ resumed previous conversation"
+#: only when there is at least one restored turn. Public (#4387 Phase B ②):
+#: ``app.py``'s ``_extend_older_frames_from_disk`` needs to recognise and
+#: strip a SECOND divider a later re-projection call would otherwise add —
+#: this module only ever inserts ONE per call, but a caller re-projecting
+#: the growing log MULTIPLE times (disk-extension) must dedupe across calls
+#: itself, which needs the exact text this module uses.
+RESUME_DIVIDER = "⤺ resumed previous conversation"
 
 
 def _failure_meta(m: "ChatMessage") -> "dict[str, object] | None":
@@ -347,9 +352,9 @@ def project_restored_frames(
     if not frames:
         return frames
     divider = OutboxMessage(
-        kind="system", text=_RESUME_DIVIDER, meta={RESTORED_META_KEY: True}
+        kind="system", text=RESUME_DIVIDER, meta={RESTORED_META_KEY: True}
     )
     return [divider, *frames]
 
 
-__all__ = ["RESTORED_META_KEY", "project_restored_frames"]
+__all__ = ["RESTORED_META_KEY", "RESUME_DIVIDER", "project_restored_frames"]

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -134,6 +134,37 @@ class ChatReadModel(ABC):
         method's; passing a target here on a remote client is accepted but
         inert."""
 
+    @abstractmethod
+    def load_older_conversation_history(
+        self,
+        *,
+        agent: "str | None" = None,
+        session_id: "str | None" = None,
+    ) -> int:
+        """#4387 Phase B ② (remaining consumers): extend the ON-DISK-backed
+        prefix of :meth:`conversation_history` further into the past, for a
+        caller that has exhausted what it already paged in and needs to know
+        whether more exists — the Textual app's scrollback-top paging
+        (:meth:`~reyn.interfaces.inline.textual_chat.app.ChatApp.on_flow_view_reached_top`)
+        and search-open (:meth:`~reyn.interfaces.inline.textual_chat.app.ChatApp._materialise_all_older`).
+
+        Unlike ``conversation_history``, which only slices what is ALREADY
+        loaded, this actually reads more of ``history.jsonl`` (via
+        :meth:`~reyn.runtime.session.Session.extend_history_backward`) —
+        because #4387 Phase B ① bounded ``Session.load_history()``'s
+        startup read to a tail, a caller that wants to page further back
+        than that tail needs a way to ask for more, not just re-slice the
+        same bounded list. Returns the count of NEWLY available turns (0 =
+        the true start of the conversation was reached — the caller's ONLY
+        way to distinguish that from "just haven't paged that far yet").
+        The caller then re-reads ``conversation_history()`` for the full
+        (now-longer) list.
+
+        **Frame-sufficiency boundary**, same as ``conversation_history``: a
+        remote client holds no session and no on-disk history to extend
+        into — the remote impl always returns 0 (already-exhausted, never a
+        fabricated count)."""
+
     def completion_session(self) -> "object | None":
         """The LOCAL ``Session`` the TUI's completion popup needs (#3354), or
         ``None`` when this client holds none.
@@ -236,6 +267,30 @@ class RegistryReadModel(ChatReadModel):
         if limit is not None and limit >= 0:
             return history[-limit:]
         return history
+
+    def load_older_conversation_history(
+        self,
+        *,
+        agent: "str | None" = None,
+        session_id: "str | None" = None,
+    ) -> int:
+        # Same target-resolution shape as ``conversation_history`` above —
+        # the currently attached session unless a specific (agent,
+        # session_id) is named.
+        if agent is not None:
+            s = (
+                self._registry.get_session(agent, session_id)
+                if session_id is not None
+                else self._registry.get_session(agent)
+            )
+        else:
+            s = self._attached()
+        if s is None:
+            return 0
+        extend = getattr(s, "extend_history_backward", None)
+        if extend is None:
+            return 0
+        return extend()
 
 
 def project_remote_snapshot(values: "dict | None") -> dict:
@@ -366,6 +421,17 @@ class RemoteReadModel(ChatReadModel):
         # switch-hydrate is #3310 N3's job, not this accessor's. Restore-on-
         # restart / switch-rehydrate is a local-attach affordance today.
         return []
+
+    def load_older_conversation_history(
+        self,
+        *,
+        agent: "str | None" = None,
+        session_id: "str | None" = None,
+    ) -> int:
+        # Frame-sufficiency: no session, no on-disk history to extend into.
+        # 0 reads as "nothing more to load," never a fabricated count — the
+        # same graceful-degrade every other session-local accessor here uses.
+        return 0
 
 
 __all__ = [

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -3283,6 +3283,29 @@ class Session:
         self.history[0:0] = parsed
         return len(parsed)
 
+    def extend_history_backward(self, *, min_lines: int = _HISTORY_HYDRATE_MIN_LINES) -> int:
+        """#4387 Phase B ② (remaining consumers): the PUBLIC paging primitive
+        for callers outside ``Session`` itself — TUI scrollback paging and
+        in-conversation search, via
+        :meth:`reyn.interfaces.repl.read_model.RegistryReadModel.load_older_conversation_history`.
+
+        Thin wrapper over :meth:`_load_older_entries`, deriving ``before_seq``
+        from ``self.history[0].seq`` — "give me more of what's already oldest
+        in memory," the generic paging shape. This differs from
+        :meth:`_active_branch_history`'s own internal use of the private
+        primitive, which derives ``before_seq`` from the WAL rewind
+        threshold instead (a specific correctness bound, not "one more
+        page") — that call stays on the private method directly since it is
+        still ``Session``'s own internal correctness mechanism, not a
+        paging request from outside.
+
+        Returns the count of entries prepended (0 = the file's start was
+        already reached — the sole "nothing more to load" signal a paging
+        caller needs).
+        """
+        oldest_seq = self.history[0].seq if self.history else 0
+        return self._load_older_entries(before_seq=oldest_seq, min_lines=min_lines)
+
     def load_history(self) -> None:
         """#4387 Phase B ①: hydrate ``self.history`` at startup WITHOUT
         necessarily reading the whole (potentially huge — owner's real

--- a/tests/interfaces/test_3300_p2b_sentqueue_render.py
+++ b/tests/interfaces/test_3300_p2b_sentqueue_render.py
@@ -167,6 +167,9 @@ class _SnapshotSeededReadModel(ChatReadModel):
     def conversation_history(self, *, limit: "int | None" = None):
         return []
 
+    def load_older_conversation_history(self, *, agent=None, session_id=None):
+        return 0
+
 
 # ---------------------------------------------------------------------------
 # 1. Materialize + promote (the core lifecycle)

--- a/tests/interfaces/test_3338_tui_status_chrome_liveness.py
+++ b/tests/interfaces/test_3338_tui_status_chrome_liveness.py
@@ -593,6 +593,9 @@ class _MutableSnapshotReadModel(ChatReadModel):
     def conversation_history(self, *, limit=None, agent=None, session_id=None):
         return []
 
+    def load_older_conversation_history(self, *, agent=None, session_id=None):
+        return 0
+
 
 class _EventOnlyTransport(ClientTransport):
     """A real, minimal :class:`ClientTransport` fed one frame at a time. The

--- a/tests/interfaces/test_3354_composer_completion.py
+++ b/tests/interfaces/test_3354_composer_completion.py
@@ -171,6 +171,9 @@ class SessionReadModel(ChatReadModel):
     def conversation_history(self, *, limit=None, agent=None, session_id=None):
         return []
 
+    def load_older_conversation_history(self, *, agent=None, session_id=None):
+        return 0
+
 
 def _real_session(tmp_path: Path, *, skills=None):
     """A real ``Session`` with ``skills`` registered — the object a

--- a/tests/interfaces/test_3595_s4_slash_handler_seam.py
+++ b/tests/interfaces/test_3595_s4_slash_handler_seam.py
@@ -399,7 +399,15 @@ def test_no_slash_module_reaches_the_session_outbox() -> None:
 #: is not a regression. What it catches is the one move that would make the
 #: residue registry above look finished while nothing was fixed — publishing a
 #: private member so a handler can keep reaching for it under a new name.
-_PUBLIC_MEMBER_CEILING = 104
+#:
+#: Raised 104 -> 105 for #4387 Phase B ②'s ``extend_history_backward`` — NOT a
+#: slash-handler reach-in (this gate's own failure mode): it is the sanctioned
+#: external accessor :mod:`reyn.interfaces.repl.read_model`'s
+#: ``RegistryReadModel`` needs for TUI scrollback paging / search, the SAME
+#: kind of thin public wrapper ``conversation_history`` already is over
+#: ``self.history`` — a read-model seam reads ``Session`` through public
+#: members by design, unlike a slash handler reaching into private state.
+_PUBLIC_MEMBER_CEILING = 105
 
 
 def test_session_public_surface_does_not_grow() -> None:

--- a/tests/interfaces/test_4387_read_model_load_older_conversation_history.py
+++ b/tests/interfaces/test_4387_read_model_load_older_conversation_history.py
@@ -1,0 +1,144 @@
+"""Tier 2: #4387 Phase B ② (remaining consumers) — the read-model seam itself
+(``ChatReadModel.load_older_conversation_history``), independent of the TUI
+paging/search consumers ``test_4387_tui_paging_extends_from_disk.py`` drives
+it through.
+
+``RegistryReadModel`` — real ``AgentRegistry`` + real ``Session`` (durable
+``history.jsonl``), no fakes: delegates to ``Session.extend_history_backward``
+for the attached session (agent/session_id omitted) and for an EXPLICITLY
+targeted, non-attached session (#3310 N2's own targeting shape,
+``conversation_history``'s sibling contract this method mirrors).
+
+``RemoteReadModel`` — the frame-sufficiency accept side: a remote client
+holds no session and no on-disk history to extend into, so this always
+degrades to ``0`` (never a fabricated count), regardless of what a caller
+passes.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.interfaces.repl.read_model import RegistryReadModel, RemoteReadModel
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        s = make_session(
+            agent_name=profile.name, snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+        s.load_history()
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    reg.create("beta")
+    return reg
+
+
+def _append_turns(s: Session, n: int) -> None:
+    for i in range(n):
+        s._append_history(ChatMessage(role="user", content=f"question {i}"))
+        s._append_history(ChatMessage(role="assistant", content=f"answer {i}"))
+
+
+@pytest.mark.asyncio
+async def test_load_older_conversation_history_extends_the_attached_session(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: ``agent``/``session_id`` omitted -> the currently attached
+    session (byte-identical targeting rule to ``conversation_history``'s own
+    documented contract) — real disk-backed extension, real count returned."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        s = reg.get_session("alpha")
+        assert s is not None
+        _append_turns(s, 10)  # 20 durable messages
+        s.history = s.history[-3:]
+
+        rm = RegistryReadModel(reg)
+        extended = rm.load_older_conversation_history()
+
+        assert extended == 17, f"expected all 17 older messages, got {extended}"
+        assert len(rm.conversation_history()) == 20, (
+            "conversation_history() must reflect the extended (now-longer) log"
+        )
+    finally:
+        await reg.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_load_older_conversation_history_targets_a_non_attached_session(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: #3310 N2's own targeting shape — ``agent`` (and optionally
+    ``session_id``) resolve a session OTHER than the currently attached one,
+    matching ``conversation_history``'s documented behavior exactly."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")  # "alpha" is attached...
+        beta = reg.get_or_load("beta")  # ...but "beta" (loaded, not attached) is the target
+        _append_turns(beta, 10)
+        beta.history = beta.history[-3:]
+
+        rm = RegistryReadModel(reg)
+        extended = rm.load_older_conversation_history(agent="beta")
+
+        assert extended == 17
+        assert len(rm.conversation_history(agent="beta")) == 20
+        # The ATTACHED session ("alpha") must be untouched by a call
+        # explicitly targeting "beta".
+        alpha = reg.get_session("alpha")
+        assert alpha is not None
+        assert alpha.history == [], (
+            "the attached-but-not-targeted session must be untouched by a "
+            f"call explicitly targeting a different agent: {alpha.history!r}"
+        )
+    finally:
+        await reg.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_load_older_conversation_history_returns_zero_at_the_true_start(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: the caller's sole "nothing more exists" signal — a second
+    call once the true start is reached returns 0, not a repeat count."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        s = reg.get_session("alpha")
+        assert s is not None
+        _append_turns(s, 3)
+        s.history = s.history[-2:]
+
+        rm = RegistryReadModel(reg)
+        first = rm.load_older_conversation_history()
+        second = rm.load_older_conversation_history()
+
+        assert first == 4
+        assert second == 0
+    finally:
+        await reg.shutdown()
+
+
+def test_remote_read_model_always_degrades_to_zero() -> None:
+    """Tier 1: frame-sufficiency accept side — a remote client holds no
+    session and no on-disk history to extend into; every call (targeted or
+    not) degrades to 0, never a fabricated count."""
+    rm = RemoteReadModel(transport=None)
+
+    assert rm.load_older_conversation_history() == 0
+    assert rm.load_older_conversation_history(agent="anything", session_id="main") == 0

--- a/tests/interfaces/test_4387_tui_paging_extends_from_disk.py
+++ b/tests/interfaces/test_4387_tui_paging_extends_from_disk.py
@@ -1,0 +1,264 @@
+"""Tier 2b: #4387 Phase B ② (remaining consumers) — TUI scrollback paging and
+in-conversation search actually page BEYOND what #4387 Phase B ① bounded
+``Session.load_history()``'s startup read to, via the real
+``RegistryReadModel.load_older_conversation_history`` -> ``Session.
+extend_history_backward`` -> ``history_tail_reader.read_history_before`` chain.
+
+The existing #3476 paging/search suites (``test_lazy_history_paging_3476.py``,
+``test_search_bar_3476.py``) both use a hand-rolled ``_HistoryReadModel``
+fake over a synthetic in-memory ``list[ChatMessage]`` — real for what THEY
+cover (paging/search over whatever ``conversation_history()`` already
+returns), but neither ever exercises a ``self.history`` that is BOUNDED
+smaller than the full log, so neither would catch a regression in the real
+disk-extension wiring this file's own PR adds. This file closes that gap:
+a REAL ``AgentRegistry`` + real ``Session`` (durable ``history.jsonl``,
+written via ``Session._append_history``, the same seam
+``test_4387_extend_history_backward.py`` uses) + the real
+``RegistryReadModel`` — no fakes anywhere in the read path.
+
+``self.history`` is truncated directly after real turns are appended,
+simulating "this is what a BOUNDED ``load_history()`` startup read left in
+memory" — the same technique ``test_4387_active_branch_history_extend_on_
+demand.py`` already established for this exact precondition.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+from textual.widgets import Static
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.restore import RESUME_DIVIDER, project_restored_frames
+from reyn.interfaces.repl.read_model import RegistryReadModel
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+
+class _Transport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` — no live frames needed for
+    a restore/paging/search test (mirrors the #3476 suites' own shape)."""
+
+    def __init__(self) -> None:
+        self.submitted: list[str] = []
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        await asyncio.Event().wait()
+        yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
+
+    async def submit_user_text(self, text: str) -> None:
+        self.submitted.append(text)
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: OutboxMessage) -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    """Mirrors ``test_3310_n2_reset_hydrate.py``'s own helper — a real
+    ``AgentRegistry`` whose session factory builds a real ``Session`` with
+    ``load_history()`` called at load time, same as production attach."""
+
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        s = make_session(
+            agent_name=profile.name,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+        s.load_history()
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    return reg
+
+
+def _append_turns(s: Session, n: int, *, needle: "str | None" = None) -> None:
+    """Real, durable turns (user+assistant pairs), via ``_append_history`` —
+    written to ``history.jsonl`` on disk AND appended to ``s.history``, the
+    same seam ``test_4387_extend_history_backward.py`` uses. An optional
+    ``needle`` is planted as the FIRST (oldest) turn's user text."""
+    if needle is not None:
+        s._append_history(ChatMessage(role="user", content=needle))
+        s._append_history(ChatMessage(role="assistant", content="old reply"))
+    for i in range(n):
+        s._append_history(ChatMessage(role="user", content=f"question {i}"))
+        s._append_history(ChatMessage(role="assistant", content=f"answer {i}"))
+
+
+def _texts(app: TextualChatApp) -> "list[str]":
+    return [entry.item.text for entry in app.conversation]
+
+
+def _content_texts(texts: "list[str]") -> "list[str]":
+    """``texts`` with the ``RESUME_DIVIDER`` chrome row(s) filtered out.
+
+    ``project_restored_frames`` (#3273-owned, outside #4387②'s scope)
+    unconditionally prepends ONE divider row per call, always at the
+    front of THAT call's own output — correct for the single-shot
+    ``project_restored_frames(full_log)`` this test compares against, but
+    flowview offers no way to REMOVE or reposition an already-painted row,
+    so once disk-extension has run at least once the app's own divider
+    (painted by the FIRST non-empty projection, #4387②'s
+    ``_extend_older_frames_from_disk`` dedupes duplicates but cannot move
+    it) may sit at a different position than the canonical single-shot
+    projection's. This test's actual correctness claim is CONTENT
+    reachability + ORDER, not the divider's cosmetic exact position — so
+    comparisons here compare content only."""
+    return [t for t in texts if t != RESUME_DIVIDER]
+
+
+def _count_text(app: TextualChatApp) -> str:
+    return str(app.query_one("#search-count", Static).render())
+
+
+def _addressed_text(app: TextualChatApp) -> "str | None":
+    entry = app.query_one(FlowView).current
+    return None if entry is None else entry.item.text
+
+
+async def _type(pilot, text: str) -> None:
+    for ch in text:
+        await pilot.press(ch)
+    await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_scrolling_to_top_extends_from_disk_beyond_the_bounded_load(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2b: ``self.history`` bounded to the newest few turns (simulating
+    #4387 Phase B ①'s bounded startup load) — scrolling to the top must
+    still recover the FULL durable history from disk via
+    ``load_older_conversation_history``, not stop at the in-memory bound."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        s = reg.get_session("alpha")
+        assert s is not None
+        _append_turns(s, 20)  # 40 durable messages
+        full_log = list(s.history)
+        s.history = s.history[-4:]  # bounded load: only the newest 4 in memory
+        assert len(s.history) < len(full_log), (
+            "test setup: self.history must be genuinely bounded below the full "
+            "durable log, or there is nothing left to page in from disk — this "
+            "would make the test vacuous"
+        )
+
+        app = TextualChatApp(
+            transport=_Transport(), read_model=RegistryReadModel(reg), agent_name="alpha",
+        )
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            expected_full = [f.text for f in project_restored_frames(full_log)]
+            # NOT asserted here: "fewer than the full log materialised right after
+            # mount." With this little content, FlowView's own ReachedTop can fire
+            # on mount itself (the viewport already shows everything painted so
+            # far) — a legitimate scroll-position trigger, not a bug — so the
+            # extension may already be complete before the explicit scroll loop
+            # below ever runs. What this test actually proves is the END STATE:
+            # the full durable log is reachable, whether recovery happened at
+            # mount or via an explicit scroll.
+            flow = app.query_one(FlowView)
+            for _ in range(8):  # more rounds than there are pages
+                flow.scroll_to_top()
+                await pilot.pause()
+                await pilot.pause()
+                if len(_texts(app)) == len(expected_full):
+                    break
+                flow.scroll_to_bottom()
+                await pilot.pause()
+
+            assert _content_texts(_texts(app)) == _content_texts(expected_full), (
+                "scrolling to the top did not recover the full durable history "
+                f"from disk ({len(_texts(app))} of {len(expected_full)} frames) "
+                "— the bounded in-memory prefix was silently treated as "
+                "'the true start of the conversation'"
+            )
+    finally:
+        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_search_finds_a_match_only_on_disk_beyond_the_bounded_load(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2b: the real correctness gap #4387 Phase B ① opened for search —
+    a needle that lives ONLY in the durable log on disk, older than
+    anything currently in ``self.history``, must still be found when
+    search opens (``_materialise_all_older`` now drains
+    ``load_older_conversation_history`` to the true start FIRST, closing
+    the gap where a hit older than the bounded startup load silently read
+    as 'no match')."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        s = reg.get_session("alpha")
+        assert s is not None
+        _append_turns(s, 60, needle="needle-only-on-disk")  # oldest turn
+        # Bounded load large enough that it does NOT all fit in one screen
+        # (100x30) — with only a handful of in-memory messages, flowview's
+        # own ReachedTop can fire immediately on mount (everything painted
+        # so far already fits the viewport), which would extend from disk
+        # before this test's own search-open step ever runs, making the
+        # search-specific gap this test targets unreachable to falsify.
+        s.history = s.history[-40:]  # needle (the oldest turn) is NOT in memory
+        assert not any(m.content == "needle-only-on-disk" for m in s.history), (
+            "test setup: the needle must be genuinely bounded out of memory"
+        )
+
+        app = TextualChatApp(
+            transport=_Transport(), read_model=RegistryReadModel(reg), agent_name="alpha",
+        )
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            assert not any(
+                "needle-only-on-disk" in (e.item.text or "") for e in app.conversation
+            ), "test setup: the needle must not already be materialised"
+
+            await pilot.press("ctrl+n")
+            await _type(pilot, "needle")
+
+            selected = _addressed_text(app)
+            assert selected is not None and "needle-only-on-disk" in selected, (
+                f"a match living only on disk (beyond the bounded in-memory "
+                f"load) was not found by search (selected: {selected!r})"
+            )
+            assert _count_text(app) == "1/1"
+    finally:
+        await asyncio.wait_for(reg.shutdown(), timeout=5.0)

--- a/tests/interfaces/test_lazy_history_paging_3476.py
+++ b/tests/interfaces/test_lazy_history_paging_3476.py
@@ -111,6 +111,9 @@ class _HistoryReadModel(ChatReadModel):
     def conversation_history(self, *, limit=None):
         return self._messages[-limit:] if limit is not None else list(self._messages)
 
+    def load_older_conversation_history(self, *, agent=None, session_id=None):
+        return 0
+
 
 def _turns(n_turns: int) -> "list[ChatMessage]":
     return [

--- a/tests/interfaces/test_search_bar_3476.py
+++ b/tests/interfaces/test_search_bar_3476.py
@@ -104,6 +104,9 @@ class _HistoryReadModel(ChatReadModel):
     def conversation_history(self, *, limit=None):
         return self._messages[-limit:] if limit is not None else list(self._messages)
 
+    def load_older_conversation_history(self, *, agent=None, session_id=None):
+        return 0
+
 
 def _count_text(app: TextualChatApp) -> str:
     """The painted match-count label, via the widget's public render."""

--- a/tests/interfaces/test_textual_chat_attach_state_3671_p3.py
+++ b/tests/interfaces/test_textual_chat_attach_state_3671_p3.py
@@ -225,6 +225,9 @@ class _NoneReadModel(ChatReadModel):
     def conversation_history(self, *, limit=None):
         return []
 
+    def load_older_conversation_history(self, *, agent=None, session_id=None):
+        return 0
+
 
 @pytest.mark.asyncio
 async def test_submit_blocked_while_unattached_preserves_typed_text():

--- a/tests/interfaces/test_textual_chat_copy_rewind_3362.py
+++ b/tests/interfaces/test_textual_chat_copy_rewind_3362.py
@@ -107,6 +107,9 @@ class _PickerReadModel(ChatReadModel):
     def conversation_history(self, *, limit=None, agent=None, session_id=None):
         return self._messages[-limit:] if limit is not None else list(self._messages)
 
+    def load_older_conversation_history(self, *, agent=None, session_id=None):
+        return 0
+
 
 class _RemoteishReadModel(_PickerReadModel):
     """The REMOTE shape: command-UI is not on the AG-UI wire, so

--- a/tests/interfaces/test_textual_chat_phase1_3273.py
+++ b/tests/interfaces/test_textual_chat_phase1_3273.py
@@ -214,6 +214,7 @@ class RM(ChatReadModel):
     @property
     def history_path(self): return Path("/tmp/reyn_isolation_history")
     def conversation_history(self, *, limit=None): return []
+    def load_older_conversation_history(self, *, agent=None, session_id=None): return 0
 
 
 class R(ChatRenderer):

--- a/tests/interfaces/test_textual_chat_phase4_3273.py
+++ b/tests/interfaces/test_textual_chat_phase4_3273.py
@@ -216,6 +216,9 @@ class _SnapshotReadModel(ChatReadModel):
     def conversation_history(self, *, limit=None):
         return []
 
+    def load_older_conversation_history(self, *, agent=None, session_id=None):
+        return 0
+
 
 class ScriptedTransport(ClientTransport):
     """A real, minimal :class:`ClientTransport`. ``end=False`` keeps the stream

--- a/tests/interfaces/test_textual_chat_phase4_turn_cost_gutter_3283.py
+++ b/tests/interfaces/test_textual_chat_phase4_turn_cost_gutter_3283.py
@@ -685,6 +685,9 @@ class _TurnUsageReadModel(ChatReadModel):
     def conversation_history(self, *, limit=None, agent=None, session_id=None):
         return []
 
+    def load_older_conversation_history(self, *, agent=None, session_id=None):
+        return 0
+
 
 class _QueueTransport(ClientTransport):
     """A real :class:`ClientTransport` fed one frame at a time from a queue, so

--- a/tests/runtime/test_4387_extend_history_backward.py
+++ b/tests/runtime/test_4387_extend_history_backward.py
@@ -1,0 +1,84 @@
+"""Tier 2: #4387 Phase B ② (remaining consumers) — ``Session.extend_history_backward``,
+the PUBLIC paging primitive external callers (the TUI's scrollback paging /
+search, via ``RegistryReadModel.load_older_conversation_history``) use to page
+further back than what Phase B ① (#4400) bounded ``load_history()``'s startup
+read to.
+
+This is a thin public wrapper over the already-tested private
+``_load_older_entries`` (see ``test_4387_active_branch_history_extend_on_demand.py``
+for the WAL-rewind-driven internal caller, ``_active_branch_history``) — what's
+new here is the "give me one more page" derivation (``before_seq`` from
+``self.history[0].seq``) and the public/external-consumer surface itself, not
+the underlying disk-read mechanism.
+
+Real ``Session`` + real durable ``history.jsonl`` (via ``_append_history``,
+same seam every other #4387 test in this arc uses) — no fakes.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+
+def _session(tmp_path: Path) -> Session:
+    return make_session(agent_name="alice", snapshot_path=tmp_path / "snapshot.json")
+
+
+def _append_turns(s: Session, n: int, *, start: int = 1) -> None:
+    for i in range(start, start + n):
+        s._append_history(ChatMessage(role="user", content=f"turn {i}"))
+
+
+def test_extend_backward_pages_in_content_older_than_the_bounded_prefix(tmp_path, monkeypatch):
+    """Tier 2: 10 real, durable turns; ``self.history`` truncated to the
+    newest 3 (simulating Phase B ①'s bounded startup load) — one call must
+    prepend exactly the 7 older turns, in the correct oldest-first order."""
+    monkeypatch.chdir(tmp_path)
+    s = _session(tmp_path)
+    _append_turns(s, 10)
+    s.history = s.history[-3:]
+    assert [m.content for m in s.history] == ["turn 8", "turn 9", "turn 10"]
+
+    extended = s.extend_history_backward(min_lines=200)
+
+    assert extended == 7, f"expected all 7 older turns prepended in one call, got {extended}"
+    assert [m.content for m in s.history] == [f"turn {i}" for i in range(1, 11)], (
+        "extend_history_backward must PREPEND (not replace) — the already-loaded "
+        "newest 3 turns must still be present, in order, after the older 7"
+    )
+
+
+def test_extend_backward_returns_zero_at_the_true_start_of_history(tmp_path, monkeypatch):
+    """Tier 2: the caller's ONLY "nothing more exists" signal — calling again
+    once every entry is already loaded must return 0, not re-derive/duplicate
+    anything already in ``self.history``."""
+    monkeypatch.chdir(tmp_path)
+    s = _session(tmp_path)
+    _append_turns(s, 5)
+    s.history = s.history[-2:]
+
+    first = s.extend_history_backward(min_lines=200)
+    assert first == 3
+    second = s.extend_history_backward(min_lines=200)
+
+    assert second == 0, "already at the file's start — must signal exhaustion, not repeat"
+    assert [m.content for m in s.history] == [f"turn {i}" for i in range(1, 6)], (
+        "a second (BOF) call must not duplicate or reorder what's already loaded"
+    )
+
+
+def test_extend_backward_on_an_unbounded_session_is_a_correct_no_op(tmp_path, monkeypatch):
+    """Tier 2: accept-side — a session whose ``self.history`` already holds
+    everything on disk (never bounded) must return 0 too, the same signal as
+    true-BOF, since there is genuinely nothing older to page in."""
+    monkeypatch.chdir(tmp_path)
+    s = _session(tmp_path)
+    _append_turns(s, 4)  # self.history is NOT truncated — already complete
+
+    extended = s.extend_history_backward(min_lines=200)
+
+    assert extended == 0
+    assert [m.content for m in s.history] == [f"turn {i}" for i in range(1, 5)]

--- a/tests/runtime/test_textual_chat_phase5_3273.py
+++ b/tests/runtime/test_textual_chat_phase5_3273.py
@@ -94,6 +94,9 @@ class _HistoryReadModel(ChatReadModel):
     def conversation_history(self, *, limit=None):
         return self._messages[-limit:] if limit is not None else list(self._messages)
 
+    def load_older_conversation_history(self, *, agent=None, session_id=None):
+        return 0
+
 
 class ScriptedTransport(ClientTransport):
     """A real, minimal :class:`ClientTransport`. ``end=False`` keeps the stream


### PR DESCRIPTION
**[tui-coder]** — feat(#4387): TUI scrollback paging / search page in from disk (Phase B ②, remaining consumers)

## What

Completes #4387 Phase B ②'s remaining scope: **TUI scrollback paging** (`on_flow_view_reached_top`) and **in-conversation search-open** (`_materialise_all_older`) now ask the read model for more of `history.jsonl` before concluding "true start of conversation" / "no match" — closing the real correctness gap Phase B ① opened when `Session.load_history()` stopped necessarily loading the whole file at startup.

`/copy` needed no wiring — its reply ring is self-contained and ordinal-addressed, well within the hydrate floor (confirmed by an earlier Explore pass on this arc).

## Production wiring (2 commits on this branch)

- `Session.extend_history_backward()` — public thin wrapper over the already-merged `_load_older_entries` (#4387 Phase B ②b), for external callers. Bumps `Session`'s public surface 104→105 (`_PUBLIC_MEMBER_CEILING`, raised with justification in the same file — the read-model seam reads `Session` through public members by design, not the slash-handler reach-in failure mode that gate exists to catch).
- `ChatReadModel.load_older_conversation_history()` (abstract) + `RegistryReadModel` (delegates to `Session.extend_history_backward`) + `RemoteReadModel` (degrades to 0, frame-sufficiency boundary). 11 hand-rolled `ChatReadModel` test-fixture subclasses updated with a stub implementation.
- `app.py`'s new `_extend_older_frames_from_disk()` helper, wired into both consumers.

## Bug found and fixed by this PR's own new tests

`project_restored_frames` unconditionally prepends ONE `RESUME_DIVIDER` row whenever its input is non-empty — correct for a single call, but `_extend_older_frames_from_disk` re-projects the FULL message log on every extension, and flowview has no primitive to remove or reposition an already-painted row. A second extension's own fresh divider would land as a genuine **duplicate**, misaligning every row after it.

Fixed by detecting and stripping a redundant divider whenever `self._history_frame_count` shows one was already accounted for by a prior hydrate/extend call — the pane only ever carries the ONE divider its first non-empty projection produced. **Accepted, documented limitation**: that divider's exact position is not guaranteed to stay at the true chronological front once extension has happened (no way to relocate an already-painted row) — cosmetic-only, not a content-order gap. `RESUME_DIVIDER` promoted from `restore.py`-private to public so `app.py` can recognise/dedupe it.

## Test plan

- [x] 5 new tests, real collaborators throughout (real `AgentRegistry` + real `Session` + real durable `history.jsonl` + the real `RegistryReadModel`/`RemoteReadModel` — no fakes):
  - `test_4387_read_model_load_older_conversation_history.py` (4): extends the attached session and an explicitly-targeted non-attached one (#3310 N2's own targeting shape), returns 0 at the true start, `RemoteReadModel` always degrades to 0.
  - `test_4387_tui_paging_extends_from_disk.py` (2): a real mounted `TextualChatApp` recovers the FULL durable history via scrolling, and search finds a match living only on disk beyond the bounded in-memory load — the specific gap this PR closes. Neither existing #3476 paging/search suite would have caught a regression here (both use a synthetic in-memory fake that never exercises a genuinely-bounded `self.history`).
- [x] Falsify-verified: reverted the read-model wiring → 3/4 read-model tests RED; reverted the divider-dedup fix → the paging test RED (misaligned content, confirmed via exact diff); restored both, confirmed GREEN.
- [x] Full regression sweep across every #4387/#3476/#3310/#3595-adjacent suite — 210 passed.
- [x] `ruff check`, `mypy_ratchet.py`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `check_tests_path_literal_reference.py` — all clean.
- [ ] (skipped — visual gate per the standing waiver; owner confirms on `main` post-merge)

part of #4387

🤖 Generated with [Claude Code](https://claude.com/claude-code)
