### PR TITLE
fix(#4421): litellm import seam — finish migration, land the AST gate

### DIFF
--- a/src/reyn/data/embedding/litellm_provider.py
+++ b/src/reyn/data/embedding/litellm_provider.py
@@ -417,13 +417,17 @@ class LiteLLMEmbeddingProvider:
                 # up): this loop has no fallback within one attempt — the
                 # axis② cooldown protects fallback-having callers, not
                 # this one; see `ensure_litellm_ready()`'s own docstring.
-                if await asyncio.to_thread(ensure_litellm_ready, ignore_cooldown=True) is None:
+                litellm = await asyncio.to_thread(ensure_litellm_ready, ignore_cooldown=True)
+                if litellm is None:
                     raise LitellmUnavailableError(
                         "import litellm failed — see the reyn.llm."
                         "litellm_bootstrap warn-once log line for the "
                         "underlying cause",
                     )
-                import litellm
+                # #4395/#4421 (seam alignment): reads the module off the
+                # return value rather than a separate `import litellm` —
+                # the only form the litellm-import gate allows outside
+                # `litellm_bootstrap.py` itself.
                 response = await self._aembedding_bounded(
                     litellm,
                     model=effective_model,

--- a/src/reyn/llm/litellm_bootstrap.py
+++ b/src/reyn/llm/litellm_bootstrap.py
@@ -547,6 +547,17 @@ def ensure_litellm_ready(
                     # REQUESTS_CA_BUNDLE via get_ssl_verify(), so this is the one
                     # missing piece for full conformance.
                     litellm.aiohttp_trust_env = True
+                    # #4395/#4421 (seam alignment): `litellm.litellm_core_
+                    # utils.logging_worker` is NOT one of the submodules
+                    # litellm's own `__init__` eagerly populates as an
+                    # attribute (unlike e.g. `litellm.types.utils` or
+                    # `litellm.llms.custom_httpx.http_handler`, verified
+                    # empirically) — imported here, once, inside the ONE
+                    # place `import litellm` itself is allowed, so
+                    # `llm.py`'s `shutdown_logging()` can read it via plain
+                    # attribute access afterward instead of needing its
+                    # own submodule import statement outside the seam.
+                    import litellm.litellm_core_utils.logging_worker  # noqa: F401
                     result = litellm
                 except Exception:  # noqa: BLE001 — best-effort; never block the caller on this
                     result = None

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -487,23 +487,21 @@ async def shutdown_logging() -> None:
     race (a shutdown racing a still-in-flight warm-up could grab a
     genuinely incomplete module). Both the call-site guard and this
     function's own body were fixed the same way as #4423: gate on
-    ``is_litellm_ready()`` (the real "genuinely finished" signal) before
-    touching litellm at all. ``litellm.litellm_core_utils.logging_worker``
-    is not one of the submodules litellm's own ``__init__`` eagerly
-    populates as an attribute (unlike e.g. ``litellm.types.utils``), so
-    this still needs its own ``import`` statement for that specific
-    submodule — but only ever reached AFTER ``is_litellm_ready()``
-    confirms the TOP-level package finished initializing, so this is a
-    normal, non-racing import (the top package's own import lock has
-    already been released; importing one of its submodules afterward
-    behaves like any other already-safe-to-import module).
+    ``is_litellm_ready()`` (the real "genuinely finished" signal) and read
+    the confirmed module's attributes — never a fresh ``import`` of any
+    kind, including a submodule. ``litellm.litellm_core_utils.logging_
+    worker`` is not one of the submodules litellm's own ``__init__``
+    eagerly populates, so ``ensure_litellm_ready()`` itself now imports it
+    once, inside the chokepoint (#4421 seam alignment) — this function
+    never needs an ``import`` statement of its own at all.
     """
     from reyn.llm.litellm_bootstrap import is_litellm_ready
     if not is_litellm_ready():
         return
     try:
-        import litellm.litellm_core_utils.logging_worker as _logging_worker_mod
-        await _logging_worker_mod.GLOBAL_LOGGING_WORKER.clear_queue()
+        import sys
+        litellm = sys.modules["litellm"]
+        await litellm.litellm_core_utils.logging_worker.GLOBAL_LOGGING_WORKER.clear_queue()
     except Exception:
         # Best-effort: never raise from shutdown.
         pass
@@ -578,7 +576,20 @@ async def _close_litellm_async_clients(pre_existing_keys: frozenset) -> None:
     alternative (not hiding at all) reintroduces the #3434 defect this
     function exists to fix, which is the worse failure mode.
     """
-    import litellm
+    # #4395/#4421: bare `import litellm` → `is_litellm_ready()` gate + read
+    # the confirmed module. The docstring above already argues this is
+    # call-order-safe (the call site never invokes this function unless
+    # `client_cache_baseline()` is non-None, which only happens after a
+    # genuine litellm touch this call) — but "safe by call order" is
+    # exactly the shape #4415/#4417 showed can go stale silently when a
+    # NEW call path is added later. Gating structurally costs nothing here
+    # (this function already tolerates litellm being unavailable — return
+    # early) and removes the dependency on that argument staying true.
+    from reyn.llm.litellm_bootstrap import is_litellm_ready
+    if not is_litellm_ready():
+        return
+    import sys
+    litellm = sys.modules["litellm"]
 
     cache = getattr(litellm, "in_memory_llm_clients_cache", None)
     cache_dict = getattr(cache, "cache_dict", None)
@@ -590,10 +601,7 @@ async def _close_litellm_async_clients(pre_existing_keys: frozenset) -> None:
         del cache_dict[key]
     try:
         try:
-            from litellm.llms.custom_httpx.async_client_cleanup import (
-                close_litellm_async_clients,
-            )
-            await close_litellm_async_clients()
+            await litellm.llms.custom_httpx.async_client_cleanup.close_litellm_async_clients()
         except Exception:
             # Best-effort: never raise from shutdown.
             pass
@@ -1595,7 +1603,22 @@ def _single_deployment_router(model: str, *, original_model: "str | None" = None
     lookup and the runtime kwarg must agree — see the docstring's own
     caution against fixing only one).
     """
-    import litellm as _ll
+    # #4395/#4421: bare `import litellm as _ll` → read the confirmed
+    # module. Reached only from an already-gated completion path
+    # (`recorded_acompletion`'s own readiness check runs first), but "safe
+    # by call order" is exactly the shape #4415/#4417 showed can go stale
+    # silently — no bare import outside the chokepoint, structurally.
+    # There is no fallback for a Router construction (the return value is
+    # used immediately for a real completion), so a not-ready state raises
+    # explicitly rather than proceeding with a broken reference.
+    from reyn.llm.litellm_bootstrap import LitellmUnavailableError, is_litellm_ready
+    if not is_litellm_ready():
+        raise LitellmUnavailableError(
+            "import litellm failed — see the reyn.llm.litellm_bootstrap "
+            "warn-once log line for the underlying cause",
+        )
+    import sys
+    _ll = sys.modules["litellm"]
     rcfg = _resolved_router_config()
     loop = asyncio.get_running_loop()
     per_loop = _ROUTERS_BY_LOOP.get(loop)
@@ -1808,12 +1831,19 @@ def _may_need_responses_endpoint(model: str) -> bool:
     provider identity) is a property of the MODEL, not of the transport used
     to reach it.
 
-    Any lookup failure (unmapped model, litellm internal error) is caught and
-    treated as "does not need it" — conservative in the direction that
-    matters for a diagnostic (never claim a model needs an endpoint reyn
-    can't confirm it resolves to)."""
+    Any lookup failure (unmapped model, litellm internal error, litellm not
+    yet ready — #4395/#4421: no bare ``import litellm`` outside the
+    chokepoint, so "not ready" is now one more lookup failure this
+    function already tolerates) is caught and treated as "does not need
+    it" — conservative in the direction that matters for a diagnostic
+    (never claim a model needs an endpoint reyn can't confirm it resolves
+    to)."""
     try:
-        import litellm  # noqa: PLC0415
+        from reyn.llm.litellm_bootstrap import is_litellm_ready
+        if not is_litellm_ready():
+            return False
+        import sys
+        litellm = sys.modules["litellm"]
 
         _, provider, _, _ = litellm.get_llm_provider(model=model, custom_llm_provider=None)
         return provider in (
@@ -1942,8 +1972,16 @@ def _streaming_capability(model: str, has_tools: bool) -> "bool | None":
     only thing call sites ask.
     """
     try:
-        import litellm  # noqa: PLC0415
-        from litellm.utils import supports_native_streaming  # noqa: PLC0415
+        # #4395/#4421: no bare `import litellm` outside the chokepoint —
+        # "not ready" maps to the SAME `None` ("the catalog does not say")
+        # this function already returns for an absent-from-catalog model;
+        # both are "cannot confirm", not "confirmed no".
+        from reyn.llm.litellm_bootstrap import is_litellm_ready
+        if not is_litellm_ready():
+            return None
+        import sys
+        litellm = sys.modules["litellm"]
+        supports_native_streaming = litellm.utils.supports_native_streaming
         try:
             litellm.get_model_info(model=model, custom_llm_provider=None)
         except Exception:  # noqa: BLE001 — absent from the catalog, nothing more

--- a/tests/security/test_4421_litellm_import_seam.py
+++ b/tests/security/test_4421_litellm_import_seam.py
@@ -1,0 +1,176 @@
+"""Tier 1: reyn's own (host) code never imports ``litellm`` directly outside
+the ONE designated seam (#4421).
+
+``litellm_bootstrap.py``'s ``ensure_litellm_ready()`` is the sole chokepoint
+that should ever execute ``import litellm`` (or any ``from litellm...``
+statement) — every other file reads the module it RETURNS. This gate turns
+that convention into an enforced invariant, closing the class #4395/#4421
+found (not the individual sites): "litellm-touching code can (a) bypass the
+chokepoint — ignore the cooldown/warming-thread machinery entirely, or (b)
+grab a genuinely incomplete module — Python places a module into
+``sys.modules`` at the START of import, before its top-level code finishes,
+so a second, independent import statement racing the dedicated background
+warming thread (#4417) can observe a partially-initialized module (the
+owner's own live repro: ``AttributeError: module 'litellm' has no attribute
+'exceptions'``)."
+
+**Order note (#4421's own 3-step plan):** this gate is step 3, landed only
+AFTER every production call site was migrated to route through the seam
+(#4413/#4417/#4420/#4423/#4425) — landing it first would fail red on
+sites nobody had touched yet. The full census confirming zero remaining
+production offenders was re-run immediately before writing this gate, not
+assumed from an earlier count (#4415's own classification went stale once
+mid-arc, from #4417 landing after it was written — re-measured here
+against the code this gate actually walks, not inherited from a prior
+count).
+
+**Scope, and why**: this gate scans ``src/reyn`` only, not ``tests/`` —
+mirrors #4410's own ``reyn.api.safe`` gate precedent
+(``test_4410_host_never_imports_safe_surface.py``). Tests legitimately
+import ``litellm`` directly to construct real exception/response instances
+to test against (the pattern this same arc found breaks in 2 test files
+when it ISN'T paired with an explicit ``ensure_litellm_ready()``
+precondition — see ``verification-hazards.md`` §22) — scanning ``tests/``
+would fail on exactly the thing those tests are supposed to do. The
+concern this gate protects against is specifically the HOST's own
+production code reaching for litellm outside the one place equipped to
+handle a broken/still-warming environment.
+
+**Excluded within ``src/reyn``:**
+- ``litellm_bootstrap.py`` itself — the seam.
+- ``dev/testing/`` — LLMReplay (``replay.py``) and the sibling-coverage
+  probe (``network_gate.py``) both need their OWN direct litellm touch to
+  monkeypatch ``litellm.acompletion``/``litellm.aembedding`` at the exact
+  boundary reyn's own source code calls (that IS their job — a test-replay
+  seam is not a production litellm-touching one, #4415's own "dev-only, 6
+  sites" bucket). Scanning them would fail this gate on infrastructure
+  built to intercept litellm, not to bypass it.
+
+**Known limit** (mirrors #4410's own framing): this gate can only ever see
+reyn's OWN import statements — a third-party library that touches litellm
+internally, or code that reaches litellm via ``sys.modules`` lookup /
+``getattr`` rather than a literal ``import``/``from`` statement, is
+invisible to an AST scan by construction. Architect's own #4415 recount
+found exactly this gap once already (an attribute-access path an earlier
+count had not measured). This gate closes the "a literal import statement
+outside the seam" half of the class, not the whole class.
+"""
+from __future__ import annotations
+
+import ast
+
+from tests._support.paths import REPO_ROOT
+
+
+def _imports_litellm(node: ast.AST) -> "str | None":
+    """Return a short description if *node* imports ``litellm`` (the
+    package itself, or any of its submodules) in any form — ``import
+    litellm``, ``import litellm.llms.custom_httpx.http_handler``, ``from
+    litellm import X``, ``from litellm.X import Y`` — else ``None``.
+    Relative imports (``node.level`` set) cannot reach an absolute
+    top-level package and are correctly never flagged."""
+    if isinstance(node, ast.Import):
+        for alias in node.names:
+            if alias.name == "litellm" or alias.name.startswith("litellm."):
+                return f"import {alias.name}"
+        return None
+    if isinstance(node, ast.ImportFrom):
+        if node.level:  # relative import — cannot reach litellm from outside it
+            return None
+        module = node.module or ""
+        if module == "litellm" or module.startswith("litellm."):
+            return f"from {module} import ..."
+        return None
+    return None
+
+
+def _seam_scan_root_and_exclusions():
+    root = REPO_ROOT
+    src = root / "src" / "reyn"
+    seam_file = (src / "llm" / "litellm_bootstrap.py").resolve()
+    dev_testing_dir = (src / "dev" / "testing").resolve()
+    return root, src, seam_file, dev_testing_dir
+
+
+def test_no_litellm_import_outside_the_seam() -> None:
+    """Tier 1: no file under src/reyn (outside litellm_bootstrap.py and
+    dev/testing/) imports litellm in any form. See module docstring for
+    the contract, scope decision, and this gate's own limit."""
+    root, src, seam_file, dev_testing_dir = _seam_scan_root_and_exclusions()
+
+    offenders: list[str] = []
+    for py in src.rglob("*.py"):
+        resolved = py.resolve()
+        if resolved == seam_file:
+            continue
+        if resolved == dev_testing_dir or dev_testing_dir in resolved.parents:
+            continue
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.Import, ast.ImportFrom)):
+                continue
+            found = _imports_litellm(node)
+            if found:
+                offenders.append(f"{py.relative_to(root)}:{node.lineno} ({found})")
+
+    assert not offenders, (
+        "reyn's own (host) code must never import litellm outside "
+        "litellm_bootstrap.py — that is the sole chokepoint equipped to "
+        "handle a not-yet-warm or persistently-broken environment "
+        "(cooldown, the dedicated background warming thread, the "
+        "log-routing/egress setup). A second, independent import "
+        "statement can bypass all of that, or — since #4417's warming "
+        "thread landed — grab a genuinely incomplete module mid-import "
+        "(#4395's owner-observed 'litellm has no attribute exceptions'). "
+        f"Route through ensure_litellm_ready() instead. Offending sites: {offenders}"
+    )
+
+
+def test_the_scan_actually_finds_something_when_offered_a_real_violation() -> None:
+    """Tier 1: positive guard — the AST detector recognizes a real
+    violation, so the assertion above isn't vacuously green because
+    _imports_litellm never matches anything (mirrors #4410's own
+    positive-twin pattern for its structural guard)."""
+    samples = {
+        "import litellm": "import litellm\n",
+        "import litellm.llms.custom_httpx.http_handler": "import litellm.llms.custom_httpx.http_handler\n",
+        "from litellm import exceptions": "from litellm import exceptions\n",
+        "from litellm.exceptions import AuthenticationError": "from litellm.exceptions import AuthenticationError\n",
+        "from litellm.utils import supports_native_streaming": "from litellm.utils import supports_native_streaming\n",
+    }
+    for label, source in samples.items():
+        tree = ast.parse(source)
+        matches = [
+            found for node in ast.walk(tree)
+            if (found := _imports_litellm(node)) is not None
+        ]
+        assert matches, f"detector failed to recognize a real violation: {label!r}"
+
+    # And the accept side: an unrelated import must NOT be flagged, and
+    # neither must a relative import (cannot reach litellm from inside a
+    # package anyway).
+    tree = ast.parse(
+        "import reyn.llm.pricing\n"
+        "from reyn.runtime.session import Session\n"
+        "from . import litellm_bootstrap\n"
+    )
+    assert not any(_imports_litellm(node) for node in ast.walk(tree)), (
+        "detector false-positived on an unrelated or relative import"
+    )
+
+
+def test_the_seam_file_itself_is_excluded_not_silently_unreachable() -> None:
+    """Tier 1: accept-side for the exclusion itself — litellm_bootstrap.py
+    genuinely DOES import litellm (that's its whole job); this confirms
+    the scan's exclusion list is doing real work (skipping a file that
+    would otherwise fail the gate), not merely pointing at a path that
+    happens not to exist or not to import litellm at all."""
+    _root, _src, seam_file, _dev_testing_dir = _seam_scan_root_and_exclusions()
+    assert seam_file.is_file(), "the seam file path itself must exist"
+    tree = ast.parse(seam_file.read_text(encoding="utf-8"))
+    found_any = any(_imports_litellm(node) for node in ast.walk(tree))
+    assert found_any, (
+        "litellm_bootstrap.py no longer contains any litellm import — the "
+        "exclusion in the main gate test is not actually exercised; if "
+        "this fires, either the seam moved or the detector itself broke"
+    )


### PR DESCRIPTION
**[docs-maintainer]** — #4421: the seam+gate structural fix, steps 2 and 3.

## The class this closes (owner's own framing)

> litellm に直接触るコードは (a) 継ぎ目を迂回できる (b) 未完成のモジュールを掴める

**(a)**: bypasses `ensure_litellm_ready()`'s cooldown/warming-thread machinery entirely. **(b)** is new — born from #4417's background warming thread: Python places a module into `sys.modules` at the *start* of import, before its top-level code finishes, so a second import racing the warming thread can observe a genuinely incomplete module (#4395's owner-observed live repro: `AttributeError: module 'litellm' has no attribute 'exceptions'`).

## Step 2 — finish migrating the remaining sites

A fresh AST census of `src/reyn` (not inherited from #4415's own count, which had already gone stale once mid-arc) found 6 more production sites doing their own `import litellm` outside `litellm_bootstrap.py`:

- `llm.py`'s `_close_litellm_async_clients`, `_single_deployment_router`, `_may_need_responses_endpoint`, `_streaming_capability` — all "call-order safe" in the exact shape #4415/#4417 already showed can go stale silently. Converted to explicit `is_litellm_ready()` gates rather than relying on the call-order argument staying true forever. `_single_deployment_router` has no fallback (a Router construction feeds straight into a real completion) — a not-ready state now raises `LitellmUnavailableError` explicitly. The other two already had a broad except-fallback; "not ready" now maps to the same conservative answer they already return for other lookup failures.
- `litellm_provider.py`'s embed-retry loop — already correctly gated, but still had a separate `import litellm` statement after the check; converted to read the return value directly (matches `pricing.py`'s #4413 conversion).
- `litellm_bootstrap.py` itself: `litellm.litellm_core_utils.logging_worker` isn't one of the submodules litellm's own `__init__` eagerly populates as an attribute (verified empirically, unlike `litellm.types.utils`) — now imported once inside `ensure_litellm_ready()`'s own setup, so `shutdown_logging()` reads it via plain attribute access afterward, no import statement of its own.

**Re-census after: zero** `import litellm` / `from litellm...` statements remain in `src/reyn` outside `litellm_bootstrap.py` (excluding `dev/testing/`'s LLMReplay — a test-replay seam, not a production one, #4415's own "dev-only" bucket).

## Step 3 — the gate

`tests/security/test_4421_litellm_import_seam.py`, an AST-based scan mirroring #4410's own `reyn.api.safe` import-boundary gate precedent exactly: a detector function, the main scan, a positive-twin accept-side test (proving the detector isn't vacuously green), and a third test new here — proving the seam-file *exclusion* is actually exercised (not pointing at a path that happens not to import litellm). Landed only now, after the census above confirmed zero remaining offenders — landing it earlier would have failed red on unmigrated sites (per lead-coder's explicit ordering).

**Known limit** (same framing as #4410's own): this gate sees literal import statements only. It does not close the attribute-access form architect flagged as a separate axis (#4415's own stated limit) — that needs runtime detection, not a static gate.

## Scope note — the "1-turn, 0 network calls" canary is NOT in this PR

The design discussion on the #4421 issue settled on a second, complementary mechanism: a runtime canary asserting litellm's own import-time tiktoken fetch causes zero egress in the default (bundled-cache-present) state, with the observation window set to **one full turn** (not one import) so it also covers the 9 call-order-safe sites the import-only window would miss.

Checked `dev/testing/replay.py` as instructed before starting: `LLMReplay.install()` monkeypatches `litellm.acompletion`/`litellm.aembedding`, so a replayed turn's own completion calls are already network-free — but `install()` itself does `import litellm`, meaning the canary still needs its own network-observation harness wrapped around *that* import specifically (likely building on #4419's own `_third_party_import_egress_honours_standard_env` machinery). That's a distinct, substantial piece of work from the AST gate landed here — flagging transparently rather than silently shipping a partial "gate" under the same name. Reported to lead-coder for scoping/priority before starting it as a follow-up.

## Test plan

- [x] Falsified: injected a real `import litellm` into `pricing.py`, confirmed the gate fails with the exact offending line named (`src/reyn/llm/pricing.py:637 (import litellm)`), reverted, confirmed green.
- [x] `ruff check`, `python scripts/mypy_ratchet.py` (211/215 baselined), `python scripts/test_tier_audit.py --strict` (0 Tier-4), `python scripts/verify_module_docstrings.py`, `python scripts/check_tests_path_literal_reference.py` — all clean.
- [x] Broad sweep: `tests/llm/`, `tests/security/` (the full directory, including the new gate), embedding-adjacent — 1459 passed, 26 skipped (unrelated missing extras), 0 failed. (One transient timing-margin flake in `test_measured_startup_latency_delta_from_deferring_litellm` under parallel background load — reproduced clean in isolation and on a clean re-run of the full scoped sweep; pre-existing test, unrelated to this diff.)
- [ ] Visual/manual (owner env) — per the standing waiver (CLAUDE.md, 2026-08-08), left unchecked; owner confirms after merge on `main`.

## Arc note

`part of #4421`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
