### PR TITLE
feat(#4380): 6 more lifecycle kinds reach the conv pane, one bundles

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1048,6 +1048,19 @@ class TextualChatApp(App):
         # deterministic args_hash, meta["op_id"]) so a later completion/failure
         # frame transitions the SAME entry RUNNING → SUCCESS/ERROR (CC parity).
         self._running_tools: "dict[object, Entry[OutboxMessage]]" = {}
+        # #4380: the most recently appended lifecycle marker eligible for
+        # count-bundling (currently only ``permission_denied``, the ONE
+        # kind owner ruled bundles — see ``_ingest_frame``'s own docstring
+        # for the full rule). ``None`` whenever the immediately-preceding
+        # frame was anything else — the bundle chain resets on ANY other
+        # frame, by design (owner: "something happened in between" IS the
+        # fact, not a defect to work around). Tuple shape:
+        # ``(bundle_key, entry, count, base_text)`` — ``base_text`` is the
+        # marker's own text BEFORE any ``×N`` suffix, kept separately so
+        # re-deriving the bumped text never re-parses a previous bump.
+        self._last_lifecycle_marker: (
+            "tuple[object, Entry[OutboxMessage], int, str] | None"
+        ) = None
         #: #4187: voice input. ``None`` until F2 is first pressed — lazy so an
         #: install without the ``reyn[voice]`` extra never pays anything for a
         #: key nobody used (mirrors ``text_effect``'s import-on-press shape).
@@ -3133,9 +3146,41 @@ class TextualChatApp(App):
         — is appended as its own entry: an ``intervention`` frame routes to
         :meth:`_present_intervention` (the panel, #3299 P1), everything else to
         :meth:`_apply_lifecycle_state`, so nothing regresses for the
-        plain-fallback turn sequence."""
+        plain-fallback turn sequence.
+
+        #4380: a ``kind="system"`` lifecycle marker carrying
+        ``meta["lifecycle_bundle_key"]`` (currently only
+        ``lifecycle_forwarder.on_permission_denied`` sets this — the ONE
+        marker kind owner ruled bundles) does not append a second row when
+        it matches ``self._last_lifecycle_marker``'s key: it bumps that
+        row's count in place, mirroring ``_coalesce_tool_result``'s own
+        precedent (find the existing entry, ``set_item(replace(...))``, no
+        new append) — the SAME, most-conservative rule that precedent
+        established, applied to a different kind. Compares ONLY against
+        the immediately-preceding frame, never a turn-wide buffer: if
+        anything else — a different marker, a tool call, an agent reply —
+        landed in between, the chain resets and the next matching marker
+        starts its own new row. This is not a limitation to work around:
+        two identical denials with something else between them are not
+        the same fact as two BACK-TO-BACK ones, and the display should
+        say so."""
         kind = msg.kind
         meta = msg.meta or {}
+        bundle_key = meta.get("lifecycle_bundle_key") if kind == "system" else None
+        if bundle_key is not None:
+            last = self._last_lifecycle_marker
+            if last is not None and last[0] == bundle_key:
+                _prev_key, entry, count, base_text = last
+                count += 1
+                entry.set_item(replace(entry.item, text=f"{base_text} ×{count}"))
+                self._last_lifecycle_marker = (bundle_key, entry, count, base_text)
+                return
+        # Any frame that reaches here — bundle-eligible-but-non-matching,
+        # or not bundle-eligible at all — breaks whatever chain was in
+        # progress. Set below (bundle-eligible, first occurrence) or left
+        # ``None`` (everything else) at each of this method's own append/
+        # coalesce points, never left stale from a PRIOR call.
+        self._last_lifecycle_marker = None
         # A pipeline's step frames fold into ONE row, keyed by the run. A
         # 15-step run emits 30 of them (a started/completed pair per step), and
         # appended individually they bury the conversation they are progress
@@ -3179,6 +3224,11 @@ class TextualChatApp(App):
         # #3712: an entry just arrived. Counted HERE, by the thing that
         # produced it — not reconstructed later from two reads of the model.
         self._note_entry_landed()
+        if bundle_key is not None:
+            # First occurrence of this bundle key (no matching PRECEDING
+            # row above, or the chain had already reset) — this row now
+            # becomes the one a later match bumps.
+            self._last_lifecycle_marker = (bundle_key, entry, 1, msg.text)
         if kind == "presentation":
             self._begin_image_resolutions(entry, msg)
         if kind == "intervention":

--- a/src/reyn/runtime/lifecycle_forwarder.py
+++ b/src/reyn/runtime/lifecycle_forwarder.py
@@ -237,12 +237,134 @@ class ChatLifecycleForwarder:
             else:
                 self._enqueue("[✗ router cap hit]")
 
-    def _enqueue(self, text: str) -> None:
+    # ── Force close (#4380) ────────────────────────────────────────────
+    # Two DISTINCT mechanisms despite the similar names — traced before
+    # implementing (issue #4380 comment thread) because the obvious guess
+    # ("one event, two co-firing halves") turned out to be wrong:
+    #   force_close_triggered      — layer①, router_loop.py: an IN-LOOP,
+    #     per-iteration cumulative-budget cutoff (``should_force_close``).
+    #     Fires at most once per turn (it ends the turn on the same
+    #     iteration it fires).
+    #   router_force_close_handoff — layer②, router_loop_driver.py: an
+    #     OUTER retry, reached ONLY when the wrap-up ITSELF still doesn't
+    #     fit (a ``_ContextOverflowError`` from the whole ``run_loop``).
+    #     Fires at most once per turn (``_MAX_FORCE_CLOSE_HANDOFFS = 1``).
+    # No call site emits both for the same turn — they are never a pair to
+    # bundle; each is its own, independent, at-most-once-per-turn marker.
+
+    def on_force_close_triggered(self, data: dict) -> None:
+        """Surface a ``[✗ force close: …]`` marker — layer① (in-loop) cutoff.
+
+        ``should_force_close`` decided the accumulated cost/tokens already
+        exceed the session's cumulative cap, so this turn's wrap-up
+        suppresses further tool calls and ends early. Without this marker
+        a short/truncated-looking reply has no visible reason attached to
+        it — the user sees a turn end, not WHY.
+        """
+        self._enqueue("[✗ force close: turn ended early to stay within budget]")
+
+    def on_router_force_close_handoff(self, data: dict) -> None:
+        """Surface a ``[✗ force close (retry): …]`` marker — layer② (outer)
+        handoff, the rarer of the two (measured 0 real-world fires as of
+        #4380's own trace — an edge case, not dead code: still worth a
+        marker for the operator who DOES hit it).
+
+        Fires when even the wrap-up itself doesn't fit and the driver
+        consolidates/drops older history to retry once. ``dropped_seq_ranges``
+        names how much was cut; kept out of the marker text itself (an
+        internal seq range means nothing to a user) — the audit event
+        still carries it in full for anyone reading ``.reyn/events``.
+        """
+        self._enqueue(
+            "[✗ force close (retry): history consolidated to continue]"
+        )
+
+    # ── Turn cancelled (#4380) ────────────────────────────────────────────
+
+    def on_turn_cancelled(self, data: dict) -> None:
+        """Surface a ``[✗ turn cancelled]`` marker.
+
+        Before #4380 this had ZERO live visibility: ``router_loop.py``'s own
+        cancel path persists "Turn interrupted by user." via
+        ``append_history_entry``, which is explicitly documented as having
+        "no outbox side-effect" (``router_host_adapter.py``) — visible only
+        on the NEXT restore (``restore.py`` rescues the ``meta["kind"] ==
+        "turn_cancelled"`` entry from the blanket system/summary skip). A
+        user watching the CURRENT session saw nothing at all when they
+        cancelled a turn. This is a genuinely new gap, not a duplicate of
+        that history entry — the two never both render in the same
+        session's lifetime (this one live, that one only after a restart).
+        """
+        self._enqueue("[✗ turn cancelled]")
+
+    # ── Chain timeout (#4380) ────────────────────────────────────────────
+
+    def on_chain_timeout(self, data: dict) -> None:
+        """Surface a ``[✗ chain timeout: waiting on …]`` marker.
+
+        ``waiting_on`` (sorted agent list) + ``timeout_seconds`` come
+        straight off the audit event (``docs/reference/runtime/events.md``'s
+        own documented payload for this kind). A turn that spawned MULTIPLE
+        concurrent delegate chains can fire this once per chain that times
+        out — each is its own independent event (different ``chain_id``,
+        different agents waited on), so each gets its OWN marker, never
+        bundled with another chain's timeout (#4380: only same-(kind, path,
+        reason) ``permission_denied`` bundles; this does not).
+        """
+        waiting = data.get("waiting_on") or []
+        agents = ", ".join(str(a) for a in waiting) if waiting else "?"
+        timeout_s = data.get("timeout_seconds")
+        suffix = f" ({timeout_s}s)" if timeout_s is not None else ""
+        self._enqueue(f"[✗ chain timeout: waiting on {agents}{suffix}]")
+
+    # ── Permission / intervention denied (#4380) ─────────────────────────
+
+    def on_permission_denied(self, data: dict) -> None:
+        """Surface a ``[✗ permission denied: …]`` marker — the ONE kind of
+        this issue's 6 that BUNDLES repeats (owner ruling, #4380): a turn
+        that hits the same denial (same op ``kind``, same ``path``, same
+        ``reason``) repeatedly collapses to one line with a count on the
+        conv-pane side (:meth:`~reyn.interfaces.inline.textual_chat.app.
+        TextualChatApp._ingest_frame`'s ``_last_lifecycle_marker`` coalesce —
+        mirrors ``_coalesce_tool_result``'s own precedent: compare only
+        against the immediately-preceding row, never a turn-wide buffer).
+        A DIFFERENT ``path`` or ``reason`` for the SAME op ``kind`` is a
+        DIFFERENT fact and must NOT collapse into the same line (owner's
+        own constraint, applied literally) — the bundle key carries all
+        three fields for exactly that reason. The audit log itself is
+        UNCHANGED — one event per denial, always; only the DISPLAY
+        collapses consecutive identical ones.
+        """
+        kind = str(data.get("kind") or "?")
+        path = data.get("path")
+        reason = str(data.get("reason") or "")
+        suffix = f" {path}" if path else ""
+        text = f"[✗ permission denied: {kind}{suffix}]"
+        self._enqueue(
+            text,
+            meta={"lifecycle_bundle_key": ("permission_denied", kind, path, reason)},
+        )
+
+    def on_intervention_denied(self, data: dict) -> None:
+        """Surface a ``[✗ intervention denied: …]`` marker — deliberately
+        NOT bundled (#4380 ruling): a different ``intervention_id`` is a
+        different unanswered question, even when the ``kind`` (ask_user /
+        permission / safety-limit) matches — collapsing those would lose
+        which questions went unanswered, not just how many.
+        """
+        kind = str(data.get("kind") or "?")
+        self._enqueue(f"[✗ intervention denied: {kind}]")
+
+    def _enqueue(self, text: str, *, meta: "dict | None" = None) -> None:
         # Fire-and-forget: lifecycle markers are advisory, never block the
         # session loop. Uses ``kind="system"`` so the conv pane's
         # ``_render_system_message`` path styles it as a dim marker line.
+        # ``meta`` (#4380): optional — carries ``lifecycle_bundle_key`` for
+        # the ONE marker kind (``permission_denied``) the conv pane
+        # coalesces consecutive repeats of; every other caller omits it
+        # (``None`` -> ``{}``, byte-identical to every pre-#4380 marker).
         try:
-            self.outbox.put_nowait(OutboxMessage(kind="system", text=text))
+            self.outbox.put_nowait(OutboxMessage(kind="system", text=text, meta=meta or {}))
         except asyncio.QueueFull:
             pass
 

--- a/tests/interfaces/test_4380_ingest_frame_bundles_permission_denied.py
+++ b/tests/interfaces/test_4380_ingest_frame_bundles_permission_denied.py
@@ -1,0 +1,235 @@
+"""Tier 2b: #4380 — ``TextualChatApp._ingest_frame`` bundles CONSECUTIVE
+``permission_denied`` lifecycle markers into one row with a count, instead
+of appending a new row per denial.
+
+Owner ruling (#4380): of the 6 new markers this issue adds, only
+``permission_denied`` bundles, and only its "same (kind, path, reason)"
+repeats — never a different capability/path/reason, and never across an
+intervening frame (compare against the IMMEDIATELY-PRECEDING row only,
+the same conservative rule ``_coalesce_tool_result`` already established
+for tool-call rows — mirrored here, not reinvented).
+
+Driven through the REAL frame pump (a queue-backed ``ClientTransport`` +
+a real mounted ``TextualChatApp``), not a direct ``_ingest_frame(...)``
+call — the production path is ``transport.frames()`` -> ``_pump_frames``
+-> ``_ingest_frame``, and this file exercises exactly that, the same
+shape ``test_pipeline_single_flow_entry_3641.py``'s sibling app-level
+tests and ``test_3310_n2_reset_hydrate.py``'s ``QueueTransport`` use.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.repl.read_model import ChatReadModel
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _NoHistoryReadModel(ChatReadModel):
+    """A real, minimal :class:`ChatReadModel` — no restored history needed
+    for these tests (every marker arrives as a LIVE frame)."""
+
+    def snapshot(self, config=None):
+        return None
+
+    def intervention_head(self):
+        return None
+
+    def pending_command_ui(self):
+        return None
+
+    def clear_pending_command_ui(self) -> None:
+        return None
+
+    @property
+    def has_command_ui_region(self) -> bool:
+        return True
+
+    @property
+    def history_path(self):
+        from pathlib import Path
+        return Path("/tmp/reyn_4380_input_history")
+
+    def conversation_history(self, *, limit=None, agent=None, session_id=None):
+        return []
+
+    def load_older_conversation_history(self, *, agent=None, session_id=None):
+        return 0
+
+
+class QueueTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` a test drives frame-by-frame
+    (mirrors ``test_3310_n2_reset_hydrate.py``'s own helper of the same
+    name/shape)."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue" = asyncio.Queue()
+        self.submitted: list[str] = []
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        while True:
+            yield await self._queue.get()
+
+    def push_display(self, msg: OutboxMessage) -> None:
+        self._queue.put_nowait(DisplayFrame(msg))
+
+    async def submit_user_text(self, text: str) -> str:
+        self.submitted.append(text)
+        return ""
+
+    async def answer_intervention_text(self, text: str, *, intervention_id=None) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str, *, intervention_id=None) -> bool:
+        return True
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self):
+        return None
+
+    def put_display(self, msg: OutboxMessage) -> None:
+        self.push_display(msg)
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def cancel_queued(self, msg_id: str) -> bool:  # pragma: no cover - trivial
+        return False
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _denial_marker(kind: str, path: str, reason: str) -> OutboxMessage:
+    """The exact shape ``lifecycle_forwarder.on_permission_denied`` emits —
+    same text template, same ``lifecycle_bundle_key`` meta shape."""
+    return OutboxMessage(
+        kind="system",
+        text=f"[✗ permission denied: {kind} {path}]",
+        meta={"lifecycle_bundle_key": ("permission_denied", kind, path, reason)},
+    )
+
+
+def _texts(app: TextualChatApp) -> "list[str]":
+    return [entry.item.text for entry in app.conversation]
+
+
+@pytest.mark.asyncio
+async def test_consecutive_identical_denials_bundle_into_one_row_with_a_count() -> None:
+    """Tier 2b: 3 back-to-back same-(kind, path, reason) denials -> ONE row,
+    ending in ``×3`` — not 3 separate rows."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, read_model=_NoHistoryReadModel())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        for _ in range(3):
+            transport.push_display(_denial_marker("file.write", "/etc/passwd", "denied by policy"))
+            await pilot.pause()
+
+        rows = _texts(app)
+        assert rows == ["[✗ permission denied: file.write /etc/passwd] ×3"], (
+            f"expected exactly one bundled row, got: {rows!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_denial_for_a_different_path_starts_its_own_row() -> None:
+    """Tier 2b: owner's own constraint applied — same op kind, DIFFERENT
+    path, must NOT bundle (a different capability denial is a different
+    fact, not a repeat of the first)."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, read_model=_NoHistoryReadModel())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        transport.push_display(_denial_marker("file.write", "/a", "denied by policy"))
+        await pilot.pause()
+        transport.push_display(_denial_marker("file.write", "/b", "denied by policy"))
+        await pilot.pause()
+
+        rows = _texts(app)
+        assert rows == [
+            "[✗ permission denied: file.write /a]",
+            "[✗ permission denied: file.write /b]",
+        ]
+
+
+@pytest.mark.asyncio
+async def test_a_denial_for_a_different_reason_starts_its_own_row() -> None:
+    """Tier 2b: owner's own correction to the original (kind, path)
+    proposal — same kind AND path, DIFFERENT reason, must NOT bundle."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, read_model=_NoHistoryReadModel())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        transport.push_display(_denial_marker("file.write", "/a", "denied by policy"))
+        await pilot.pause()
+        transport.push_display(_denial_marker("file.write", "/a", "sandbox violation"))
+        await pilot.pause()
+
+        rows = _texts(app)
+        assert rows == [
+            "[✗ permission denied: file.write /a]",
+            "[✗ permission denied: file.write /a]",
+        ]
+
+
+@pytest.mark.asyncio
+async def test_an_intervening_frame_breaks_the_bundle_chain() -> None:
+    """Tier 2b: the most conservative rule — compare ONLY against the
+    immediately-preceding row. Two identical denials with an unrelated
+    frame between them must NOT bundle (owner: "something happened in
+    between" is a real fact, not a defect to paper over)."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, read_model=_NoHistoryReadModel())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        transport.push_display(_denial_marker("file.write", "/a", "denied by policy"))
+        await pilot.pause()
+        transport.push_display(OutboxMessage(kind="agent", text="unrelated reply"))
+        await pilot.pause()
+        transport.push_display(_denial_marker("file.write", "/a", "denied by policy"))
+        await pilot.pause()
+
+        rows = _texts(app)
+        assert rows == [
+            "[✗ permission denied: file.write /a]",
+            "unrelated reply",
+            "[✗ permission denied: file.write /a]",
+        ], f"an intervening frame must reset the bundle chain, got: {rows!r}"
+
+
+@pytest.mark.asyncio
+async def test_the_audit_relevant_flowview_entry_count_shrinks_with_bundling() -> None:
+    """Tier 2b: the DISPLAY collapses — proven directly against the real
+    FlowView entry count (not just the text list), the same public surface
+    ``test_pipeline_single_flow_entry_3641.py``'s sibling ONE-ROW claim is
+    proven against elsewhere in this suite."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, read_model=_NoHistoryReadModel())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        for _ in range(6):
+            transport.push_display(_denial_marker("file.write", "/etc/passwd", "denied by policy"))
+            await pilot.pause()
+
+        entries = list(app.query_one(FlowView).entries)
+        # Unpacking into exactly one binding is itself the "exactly one
+        # entry" assertion — a wrong COUNT fails the unpack, not a bare
+        # ``len(...) == N`` format pin (same idiom this file's sibling
+        # producer-side test file uses for "warned exactly once").
+        (only_entry,) = entries
+        assert only_entry.item.text.endswith("×6")

--- a/tests/runtime/test_4380_lifecycle_forwarder_new_markers.py
+++ b/tests/runtime/test_4380_lifecycle_forwarder_new_markers.py
@@ -1,0 +1,180 @@
+"""Tier 2: ChatLifecycleForwarder — 6 new markers (#4380).
+
+The audit-event side already declares/emits all 6 kinds (``force_close_
+triggered``, ``router_force_close_handoff``, ``turn_cancelled``,
+``chain_timeout``, ``permission_denied``, ``intervention_denied``) — a
+real owner-reported gap was that NONE of them reached the conv pane, so an
+operator watching the LIVE session saw nothing when any of these fired
+(only the Events tab, closed by default). Owner ruling (#4380): add all 6,
+dim, same visual weight as the existing ``[↑]``/``[✗]``/``[⚠]`` markers —
+"don't stand out." One (``permission_denied``) additionally bundles
+consecutive repeats (a separate PR concern, covered by
+``test_4380_ingest_frame_bundles_permission_denied.py`` — this file pins
+only the PRODUCER side: that the emitted marker's TEXT and ``meta`` are
+correct, not the app-side coalescing that consumes ``meta["lifecycle_
+bundle_key"]``).
+
+Traced before writing (issue #4380 comment thread), not guessed:
+``force_close_triggered``/``router_force_close_handoff`` are two
+INDEPENDENT mechanisms (different files, different layers) that never
+co-fire for the same turn — an earlier hypothesis that they were "one
+event, two co-firing halves" was checked against the actual call sites
+and found wrong before any code was written.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from reyn.runtime.lifecycle_forwarder import ChatLifecycleForwarder
+from reyn.schemas.models import Event
+
+
+def _drain(q: asyncio.Queue) -> list[Any]:
+    items: list[Any] = []
+    while not q.empty():
+        items.append(q.get_nowait())
+    return items
+
+
+def _fire(event_type: str, data: dict) -> list[Any]:
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type=event_type, data=data))
+    return _drain(q)
+
+
+def test_force_close_triggered_emits_a_dim_system_marker() -> None:
+    """Tier 2: layer① in-loop cumulative-budget cutoff gets a live marker —
+    previously silent (only visible via the Events tab)."""
+    msgs = _fire("force_close_triggered", {"chain_id": "c1", "iteration": 3})
+    (only,) = msgs
+    assert only.kind == "system"
+    assert only.text == "[✗ force close: turn ended early to stay within budget]"
+
+
+def test_router_force_close_handoff_emits_a_distinct_marker() -> None:
+    """Tier 2: layer② outer-retry handoff — a DIFFERENT marker text than
+    force_close_triggered's, since they are different mechanisms (traced,
+    not assumed) that a user needs to be able to tell apart."""
+    msgs = _fire(
+        "router_force_close_handoff",
+        {
+            "covers_through_seq": 40,
+            "consolidation_chars": 1200,
+            "dropped_seq_ranges": [[10, 20]],
+        },
+    )
+    (only,) = msgs
+    assert only.kind == "system"
+    assert only.text == "[✗ force close (retry): history consolidated to continue]"
+    assert only.text != "[✗ force close: turn ended early to stay within budget]"
+
+
+def test_turn_cancelled_emits_a_marker() -> None:
+    """Tier 2: previously ZERO live visibility (router_loop.py's own
+    history-append has no outbox side-effect — only visible on the NEXT
+    restore). This is the genuinely new gap, closed here."""
+    msgs = _fire("turn_cancelled", {"chain_id": "c1"})
+    (only,) = msgs
+    assert only.kind == "system"
+    assert only.text == "[✗ turn cancelled]"
+
+
+def test_chain_timeout_emits_a_marker_naming_who_it_waited_on() -> None:
+    """Tier 2: waiting_on + timeout_seconds surface — the documented
+    payload (events.md's own table for this kind), not invented fields."""
+    msgs = _fire(
+        "chain_timeout",
+        {
+            "chain_id": "c1",
+            "waiting_on": ["planner", "reviewer"],
+            "timeout_seconds": 120,
+            "origin_agent": "alpha",
+        },
+    )
+    (only,) = msgs
+    assert only.kind == "system"
+    assert only.text == "[✗ chain timeout: waiting on planner, reviewer (120s)]"
+
+
+def test_chain_timeout_degrades_gracefully_with_no_waiting_on() -> None:
+    """Tier 2: accept-side — a malformed/absent waiting_on still produces a
+    marker (never a KeyError from a forward-compat event-shape drift)."""
+    msgs = _fire("chain_timeout", {"chain_id": "c1"})
+    (only,) = msgs
+    assert only.text == "[✗ chain timeout: waiting on ?]"
+
+
+def test_permission_denied_emits_a_marker_and_carries_the_bundle_key() -> None:
+    """Tier 2: the ONE kind of the 6 that bundles (owner ruling) — the
+    marker must carry ``meta["lifecycle_bundle_key"]`` = (kind, path,
+    reason) verbatim, since app.py's own coalescing keys off exactly this
+    tuple. Getting the key's SHAPE wrong here would silently break
+    bundling without failing this producer-side test on its own."""
+    msgs = _fire(
+        "permission_denied",
+        {
+            "run_id": "r1", "actor": "alpha", "phase": "",
+            "kind": "file.write", "path": "/etc/passwd", "reason": "denied by policy",
+        },
+    )
+    (only,) = msgs
+    assert only.kind == "system"
+    assert only.text == "[✗ permission denied: file.write /etc/passwd]"
+    assert only.meta.get("lifecycle_bundle_key") == (
+        "permission_denied", "file.write", "/etc/passwd", "denied by policy",
+    )
+
+
+def test_permission_denied_with_different_path_has_a_different_bundle_key() -> None:
+    """Tier 2: owner's own constraint, applied literally — same op kind,
+    DIFFERENT path, must produce a DIFFERENT bundle key (never conflated
+    as "the same denial")."""
+    msgs_a = _fire(
+        "permission_denied",
+        {"kind": "file.write", "path": "/a", "reason": "denied by policy"},
+    )
+    msgs_b = _fire(
+        "permission_denied",
+        {"kind": "file.write", "path": "/b", "reason": "denied by policy"},
+    )
+    assert msgs_a[0].meta["lifecycle_bundle_key"] != msgs_b[0].meta["lifecycle_bundle_key"]
+
+
+def test_permission_denied_with_different_reason_has_a_different_bundle_key() -> None:
+    """Tier 2: same kind AND same path, DIFFERENT reason — owner's own
+    correction to the original (kind, path) proposal: "reason を足す"."""
+    msgs_a = _fire(
+        "permission_denied",
+        {"kind": "file.write", "path": "/a", "reason": "denied by policy"},
+    )
+    msgs_b = _fire(
+        "permission_denied",
+        {"kind": "file.write", "path": "/a", "reason": "sandbox violation"},
+    )
+    assert msgs_a[0].meta["lifecycle_bundle_key"] != msgs_b[0].meta["lifecycle_bundle_key"]
+
+
+def test_intervention_denied_emits_a_marker_with_no_bundle_key() -> None:
+    """Tier 2: owner ruling — NOT bundled. The marker must carry no
+    ``lifecycle_bundle_key`` at all, so app.py's coalescing never
+    accidentally treats two different unanswered questions as one repeat."""
+    msgs = _fire(
+        "intervention_denied",
+        {"intervention_id": "iv1", "kind": "ask_user", "run_id": "r1", "actor": "alpha", "reason": "session lost"},
+    )
+    (only,) = msgs
+    assert only.kind == "system"
+    assert only.text == "[✗ intervention denied: ask_user]"
+    assert "lifecycle_bundle_key" not in only.meta
+
+
+def test_unrelated_event_types_are_dropped() -> None:
+    """Tier 1: existing accept-side guard, re-affirmed with the new kinds
+    absent from the dispatch — an event this forwarder has no ``on_<kind>``
+    handler for produces nothing (mirrors the file's own pre-existing
+    ``test_unrelated_event_types_are_dropped``-style coverage for the
+    original 9 kinds)."""
+    msgs = _fire("some_unrelated_kind", {"anything": 1})
+    assert msgs == []


### PR DESCRIPTION
**[tui-coder]** — feat(#4380): 6 more lifecycle kinds reach the conv pane, one bundles

## Premise (per lead-coder's instruction — the fact-enumeration this PR builds on)

Before any design/code, I enumerated the CURRENT 14 marker kinds `lifecycle_forwarder.py` already surfaces and their `[↑]`/`[⚠]`/`[✗]`/`[↻]` weight convention: https://github.com/tya5/reyn/issues/4380#issuecomment-5267308947

Then, after the owner's ruling on WHICH 6 kinds + weight, I traced every one of those 6 kinds' actual emission sites before writing code — full trace posted to the issue thread. One finding **corrected the assumed design**: `force_close_triggered` and `router_force_close_handoff` were assumed to be "one event, two co-firing halves" (a bundle candidate); tracing the actual call sites showed they're two independent mechanisms (different files, different layers) that never fire together for the same turn — so no bundling rule was built for that pair, because there's no real case to bundle.

## What

- **6 new markers** (`lifecycle_forwarder.py`): `force_close_triggered`, `router_force_close_handoff`, `turn_cancelled`, `chain_timeout`, `permission_denied`, `intervention_denied` — all dim, same `[✗ …]` weight as the existing family (owner: "don't stand out").
- **`turn_cancelled` closes a genuinely NEW gap**, not a duplicate: the existing history-append (`router_loop.py`'s "Turn interrupted by user.") has explicitly no outbox side-effect (`router_host_adapter.py`'s own docstring) — it was only ever visible on the NEXT restore, never live in the current session.
- **Only `permission_denied` bundles** (owner ruling, after I flagged that the assumed force-close pairing doesn't exist): consecutive identical `(kind, path, reason)` denials collapse into one row with a count. `reason` was owner's own addition to my initial `(kind, path)` proposal — same capability/path, different reason, is still a different fact. `intervention_denied` is explicitly **not** bundled (my recommendation, owner adopted it) — a different `intervention_id` is a different unanswered question even when `kind` matches.

## Bundling mechanism

`lifecycle_forwarder.py` is a pure producer (writes to an `asyncio.Queue`, holds no `FlowView` reference) — the bundling had to live on the **consumer** side. New `self._last_lifecycle_marker` tracker in `app.py`'s `_ingest_frame`, mirroring `_coalesce_tool_result`'s own established precedent (find the existing entry, `entry.set_item(replace(...))`, no second append) rather than inventing a new mechanism. Deliberately the **most conservative** rule available — compares only against the **immediately-preceding row**, never a turn-wide buffer, no new turn-boundary tracking added. An intervening frame (a different marker, a tool call, an agent reply) resets the chain. Per the owner's own framing this is correct, not a limitation: two identical denials with something else between them are not the same fact as two back-to-back ones.

**What stays unbroken** (owner's explicit constraints):
- Counts are never dropped.
- Different reasons/paths never collapse into one line, even for the same op kind.
- The audit log itself is unchanged — one event per denial, always; only the DISPLAY collapses.

## Test plan

- [x] 15 new tests, real collaborators throughout (real `ChatLifecycleForwarder` + `Event`; real mounted `TextualChatApp` + a queue-backed `ClientTransport` driving the actual frame pump — no direct `_ingest_frame(...)` calls, no mocks):
  - `tests/runtime/test_4380_lifecycle_forwarder_new_markers.py` (10) — producer side.
  - `tests/interfaces/test_4380_ingest_frame_bundles_permission_denied.py` (5) — consumer side, including the real `FlowView` entry count shrinking, not just the text list.
- [x] Falsify-verified: reverted the bundling block to a no-op → 2/5 consumer-side tests RED with the exact expected mismatch; restored, confirmed GREEN.
- [x] Full regression sweep — every lifecycle-forwarder/pipeline/tool-call suite (113) + every #4387-paging-adjacent suite this shared `_ingest_frame`/`app.py` code path touches (210) — both green.
- [x] `ruff check`, `mypy_ratchet.py`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `check_tests_path_literal_reference.py` — all clean.
- [ ] (skipped — per the standing waiver; owner has left for the day, visual gate does not block merge)

**Test plan / TESTS-READ**: this PR touches `tests/` — holding for a reviewer's TESTS-READ note before merge, no self-merge.

part of #4380

🤖 Generated with [Claude Code](https://claude.com/claude-code)
