### PR TITLE
fix(#4357): the CUI names unmapped config keys instead of a bare count

### DIFF
--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -164,7 +164,9 @@ def build_policy_tier_config(cwd: Path | None = None) -> dict:
     return merged
 
 
-def _warn_unknown_config_keys(policy_tier_merged: dict) -> int:
+def _warn_unknown_config_keys(
+    policy_tier_merged: dict,
+) -> "dict[str, Any]":
     """#4174 T0: log ONE warning naming every unknown/renamed config key
     found in the policy-tier config (``user_global`` + ``project`` +
     ``project_local`` merged — the operator-editable files; the 5
@@ -184,17 +186,26 @@ def _warn_unknown_config_keys(policy_tier_merged: dict) -> int:
     LOOSER, not silently inert like an ordinary dropped key, so an
     operator relying on it must see what's actually in force.
 
-    Returns the unknown-key count (#4194: the log-only warning is invisible
-    in the interactive CUI — ``_setup_interactive_logging`` redirects all
-    logs to a file, per architect's live measurement — so the count is
-    also returned for :func:`load_config` to attach to the ``ReynConfig``
-    it builds, giving the CUI's bottom chrome something to read).
+    Returns the full ``{dotted_key: hint_or_None}`` dict — #4357: this
+    used to return only the bare COUNT (#4194: the log-only warning is
+    invisible in the interactive CUI — ``_setup_interactive_logging``
+    redirects all logs to a file, per architect's live measurement — so
+    the count was returned for :func:`load_config` to attach to the
+    ``ReynConfig`` it builds). The count alone gave the CUI's bottom
+    chrome something to show, but not WHICH keys — an operator reading
+    "3 config keys not applied" cannot act on it without separately
+    running ``reyn config validate``, and #4357 measured that in practice
+    nobody did (5 real instances of a moved key going unfixed for months,
+    including this repo's own ``reyn.yaml``). ``unknown_config_keys()``
+    already carries per-key ``RenamedKeyHint``/``RemovedKeyHint`` detail
+    (#4375/#4402) — the data was never the gap, only how far it traveled.
+    Callers that only need the count use ``len(...)`` on the return value.
     """
     from reyn.config import config_schema
 
     unknown = config_schema.unknown_config_keys(policy_tier_merged)
     if not unknown:
-        return 0
+        return {}
 
     import logging
     log = logging.getLogger(__name__)
@@ -222,7 +233,7 @@ def _warn_unknown_config_keys(policy_tier_merged: dict) -> int:
         )
 
     log.warning("Unrecognized config key(s) found:\n" + "\n".join(f"  - {line}" for line in lines))
-    return len(unknown)
+    return unknown
 
 
 def _as_config_dict(val: object, key: str) -> dict:
@@ -653,7 +664,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # registry files below are merged in — those are checked separately
         # at their own load points (runtime.hot_reload.validate_in_set),
         # not duplicated here.
-        unknown_config_key_count = _warn_unknown_config_keys(merged)
+        unknown_config_keys_found = _warn_unknown_config_keys(merged)
 
         # Issue #470: dynamic MCP registry separated from static config.
         # ``.reyn/mcp.yaml`` carries op-managed server entries; merged
@@ -720,7 +731,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # #4174 T0: no project root — only builtin + user_global are in
         # `merged`, still worth checking (a mistyped ~/.reyn/config.yaml
         # key should not go unreported just because there's no project).
-        unknown_config_key_count = _warn_unknown_config_keys(merged)
+        unknown_config_keys_found = _warn_unknown_config_keys(merged)
 
     # ADR-0030: apply ${VAR} interpolation across all string fields of the
     # merged config dict.  At this point os.environ already contains values
@@ -863,7 +874,12 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # #4194: policy-tier unknown-key count — see the field's own
         # docstring in root.py for why this is `schema_internal` (a
         # runtime-computed fact, not an operator-settable key).
-        unknown_config_key_count=unknown_config_key_count,
+        unknown_config_key_count=len(unknown_config_keys_found),
+        # #4357: the full `{dotted_key: hint}` dict the count above is
+        # derived from — see the field's own docstring in root.py for why
+        # the count alone wasn't enough (an operator can't act on a bare
+        # number).
+        unknown_config_keys=unknown_config_keys_found,
     )
     _validate_retrieval_scheme_embedding(_cfg)
     _validate_skill_visibility(_cfg)

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -352,6 +352,23 @@ class ReynConfig:
         default=0, metadata={"schema_internal": True},
     )
 
+    # #4357: the full `{dotted_key: RenamedKeyHint | RemovedKeyHint | None}`
+    # dict `unknown_config_key_count` above is derived from (`len(...)`) —
+    # attached alongside the count, not instead of it, so existing readers
+    # of the count are unaffected. Same `schema_internal` reasoning as the
+    # count: a runtime-computed FACT about the config the operator wrote,
+    # never a `reyn.yaml` key itself. Motivation: the bare count gave the
+    # CUI's bottom chrome something to show, but not WHICH keys — #4357
+    # measured that in practice this meant nobody acted on it (5 real
+    # instances of a moved key going unfixed for months, including this
+    # repo's own `reyn.yaml`, discovered independently of the count
+    # existing at all). `RenamedKeyHint`/`RemovedKeyHint` already carry
+    # the exact destination/removal note (#4375/#4402) — this field is
+    # what lets the CUI chrome actually show it instead of a number.
+    unknown_config_keys: dict = field(
+        default_factory=dict, metadata={"schema_internal": True},
+    )
+
     def model_class_for(self, purpose: str) -> str:
         """#1672: the model CLASS for a logical call *purpose*.
 

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1463,8 +1463,12 @@ class TextualChatApp(App):
             # this row in — an operator on a clean config never pays even the
             # empty-row layout cost the #4194 measurement confirmed a present
             # row would take.
+            # #4357: `keys=` passes the actual `{key: hint}` dict so the line
+            # names the offending keys (and destinations, where known)
+            # instead of only a bare count.
             config_warning = config_warning_text(
-                getattr(self._config, "unknown_config_key_count", 0)
+                getattr(self._config, "unknown_config_key_count", 0),
+                keys=getattr(self._config, "unknown_config_keys", None),
             )
             if config_warning is not None:
                 yield ConfigWarningLine(config_warning, id="config-warning")

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -1354,7 +1354,15 @@ def status_line_text(
     return base
 
 
-def config_warning_text(count: int) -> "str | None":
+#: #4357: how many unknown-key NAMES the chrome line shows inline before
+#: falling back to "N more" — bounded deliberately (owner ruling, #4380:
+#: "show everything" was rejected there for a 197-item case). 3 is enough
+#: to make the common "a handful of moved keys" case immediately
+#: actionable without the line growing unboundedly with the population.
+_CONFIG_WARNING_INLINE_KEY_CAP = 3
+
+
+def config_warning_text(count: int, keys: "dict | None" = None) -> "str | None":
     """The bottom-chrome config-warning indicator's text, or ``None`` when
     there is nothing to show (#4194).
 
@@ -1362,9 +1370,8 @@ def config_warning_text(count: int) -> "str | None":
     properties, form left to the implementer: ①doesn't
     scroll away with the conversation ②stays visible for as long as the
     condition holds ③directs the operator to ``reyn config validate`` for
-    the 4-element detail (result / destination / full list / fix command) —
-    this line deliberately carries NONE of that detail itself, only a count
-    and the command name. Scope: the POLICY TIER only (``reyn.yaml`` /
+    the 4-element detail (result / destination / full list / fix command).
+    Scope: the POLICY TIER only (``reyn.yaml`` /
     ``reyn.local.yaml`` / ``~/.reyn/config.yaml``) — the same scope
     ``reyn config validate`` itself checks (``config.py``'s ``_validate``
     uses ``build_policy_tier_config``), so the indicator's own guidance is
@@ -1374,12 +1381,29 @@ def config_warning_text(count: int) -> "str | None":
     (lead-coder's explicit scoping call, #4194) — deliberately not counted
     here; that remaining silence is real and tracked separately (#4235).
 
+    ``keys`` (#4357, optional — ``ReynConfig.unknown_config_keys``): when
+    given, up to :data:`_CONFIG_WARNING_INLINE_KEY_CAP` key names are shown
+    inline (RENAMED keys with a known destination first — the ones an
+    operator can act on immediately by name — then any remaining unknown/
+    removed keys), with a "+N more" suffix past the cap. This line
+    previously carried NONE of that detail (architect's original #4194
+    design, quoted verbatim in this docstring's history) — #4357 measured
+    that in practice this meant nobody acted on the warning: 5 real
+    instances of a moved key went unfixed for months, including this
+    repo's own ``reyn.yaml``, because "N config keys not applied" names no
+    key to fix. Still bounded (never "show everything" — #4380's own
+    197-item rejection applies here too) and still ends by pointing at
+    ``reyn config validate`` for the full list, so property ③ above is
+    unchanged; ``keys=None`` (the pre-#4357 call shape) falls back to the
+    original count-only line byte-for-byte.
+
     ``count`` (not a snapshot dict, unlike :func:`status_line_text`): this
     value is CONFIG-derived, not session/live-state-derived — it is fixed
     for the whole session lifetime once ``load_config()`` runs (``reyn.yaml``
     changes need a restart to take effect, unlike the hot-reload IN-set),
     so there is no live snapshot to route through, only
-    ``ReynConfig.unknown_config_key_count`` itself.
+    ``ReynConfig.unknown_config_key_count`` / ``ReynConfig.
+    unknown_config_keys`` themselves.
 
     ``⚠`` matches the existing ``HALTED`` banner glyph above (same
     single-cell-width class of symbol, same "something needs attention"
@@ -1387,7 +1411,26 @@ def config_warning_text(count: int) -> "str | None":
     if not count:
         return None
     plural = "" if count == 1 else "s"
-    return f"⚠ {count} config key{plural} not applied → reyn config validate"
+    base = f"⚠ {count} config key{plural} not applied"
+    if not keys:
+        return f"{base} → reyn config validate"
+
+    # #4357: destination-bearing (renamed) keys first — an operator can
+    # act on "`model` → `llm.model`" immediately; a bare unknown/removed
+    # key still names the key, just not where it goes.
+    from reyn.config.config_schema import RenamedKeyHint
+
+    ordered = sorted(
+        keys.items(),
+        key=lambda item: 0 if isinstance(item[1], RenamedKeyHint) and item[1].destination else 1,
+    )
+    shown = []
+    for key, hint in ordered[:_CONFIG_WARNING_INLINE_KEY_CAP]:
+        destination = getattr(hint, "destination", None)
+        shown.append(f"`{key}` → `{destination}`" if destination else f"`{key}`")
+    remaining = len(ordered) - len(shown)
+    names = ", ".join(shown) + (f" (+{remaining} more)" if remaining > 0 else "")
+    return f"{base}: {names} → reyn config validate"
 
 
 def build_drawer_pane(tab_id: str, rows: "Sequence[str]") -> Widget:

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -358,6 +358,10 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         # nothing meaningful to report here; 0 degrades gracefully (no
         # indicator shown) rather than fabricating a count.
         "unknown_config_key_count": 0,
+        # #4357: same reasoning — an empty dict degrades gracefully to the
+        # count-only (here, no-indicator-at-all) fallback in
+        # config_warning_text, never a fabricated key list.
+        "unknown_config_keys": {},
     }
 
 

--- a/src/reyn/interfaces/repl/status.py
+++ b/src/reyn/interfaces/repl/status.py
@@ -462,6 +462,13 @@ def _snapshot(registry, config=None):
         "unknown_config_key_count": (
             getattr(config, "unknown_config_key_count", 0) if config is not None else 0
         ),
+        # #4357: the full {key: hint} dict the count above is derived from
+        # — kept alongside it in this snapshot for the same reason (a
+        # future consumer of this snapshot dict gets the actionable detail
+        # for free, not just the count).
+        "unknown_config_keys": (
+            getattr(config, "unknown_config_keys", {}) if config is not None else {}
+        ),
         # #2285: session-scoped capability visibility + hook applicability toggles.
         # #3378: ``visibility_items`` is ``None`` when the session wires no visibility
         # seam (or it raised) and a possibly-empty LIST when it does — the renderer

--- a/tests/interfaces/test_config_warning_chrome_4194.py
+++ b/tests/interfaces/test_config_warning_chrome_4194.py
@@ -180,3 +180,111 @@ async def test_indicator_absent_when_config_is_none():
     app = TextualChatApp(transport=_Transport())
     async with app.run_test(size=(90, 24)):
         assert len(app.query("ConfigWarningLine")) == 0
+
+
+# ---------------------------------------------------------------------------
+# #4357: the indicator names the offending keys, not just a bare count
+# ---------------------------------------------------------------------------
+
+
+def test_config_warning_text_names_a_renamed_key_and_its_destination():
+    """Tier 2: #4357 — with ``keys=`` given, the line names the key AND
+    its destination (``` `model` → `llm.model` ```) instead of only a
+    count. #4357's own finding: a bare count gave an operator nothing to
+    act on — 5 real instances of a moved key went unfixed for months,
+    including this repo's own reyn.yaml, because "N keys not applied"
+    names no key to fix."""
+    from reyn.config.config_schema import RenamedKeyHint
+    from reyn.interfaces.inline.textual_chat.chrome import config_warning_text
+
+    text = config_warning_text(
+        1, keys={"model": RenamedKeyHint(note="moved", destination="llm.model")},
+    )
+    assert text is not None
+    assert "`model`" in text
+    assert "`llm.model`" in text
+    assert text.endswith("→ reyn config validate")
+
+
+def test_config_warning_text_falls_back_to_count_only_without_keys():
+    """Tier 2b: accept-side — ``keys=None`` (the pre-#4357 call shape,
+    still used wherever a caller has no dict handy) renders byte-identical
+    to the original count-only line."""
+    from reyn.interfaces.inline.textual_chat.chrome import config_warning_text
+
+    assert config_warning_text(2) == "⚠ 2 config keys not applied → reyn config validate"
+    assert config_warning_text(2, keys=None) == config_warning_text(2)
+    assert config_warning_text(2, keys={}) == config_warning_text(2)
+
+
+def test_config_warning_text_caps_inline_names_and_counts_the_rest():
+    """Tier 2: #4357 — never "show everything" (#4380's own 197-item
+    rejection applies here too): past the inline cap, remaining keys
+    collapse to a "+N more" suffix rather than growing the line
+    unboundedly with the population."""
+    from reyn.config.config_schema import RenamedKeyHint
+    from reyn.interfaces.inline.textual_chat.chrome import (
+        _CONFIG_WARNING_INLINE_KEY_CAP,
+        config_warning_text,
+    )
+
+    keys = {
+        f"key{i}": RenamedKeyHint(note="moved", destination=f"llm.key{i}")
+        for i in range(_CONFIG_WARNING_INLINE_KEY_CAP + 2)
+    }
+    text = config_warning_text(len(keys), keys=keys)
+    assert text is not None
+    shown = text.count("→ `llm.key")  # one arrow per inline-shown renamed key
+    assert shown == _CONFIG_WARNING_INLINE_KEY_CAP
+    assert "+2 more" in text
+    assert text.endswith("→ reyn config validate")
+
+
+def test_config_warning_text_shows_a_removed_key_by_name_with_no_destination():
+    """Tier 2: accept-side for a RemovedKeyHint (#4375) — a genuinely
+    removed key (no successor) is still named, just without a
+    destination arrow, distinguishing it from a renamed key's shape."""
+    from reyn.config.config_schema import RemovedKeyHint
+    from reyn.interfaces.inline.textual_chat.chrome import config_warning_text
+
+    text = config_warning_text(
+        1, keys={"workspace": RemovedKeyHint(note="deleted, no replacement")},
+    )
+    assert text is not None
+    assert "`workspace`" in text
+    assert "→ `" not in text.split("workspace")[1].split(",")[0]  # no destination for THIS key
+
+
+def test_reyn_config_unknown_config_keys_defaults_to_empty_dict():
+    """Tier 2: accept-side — ``ReynConfig.unknown_config_keys`` defaults
+    to ``{}`` (never ``None``), so every caller (``config_warning_text``'s
+    own ``keys=`` param, the status-snapshot dict) can treat it as a plain
+    dict unconditionally, no ``None``-check needed at each read site."""
+    config = ReynConfig()
+    assert config.unknown_config_keys == {}
+
+
+def test_load_config_attaches_the_real_hint_dict_not_just_a_count():
+    """Tier 2: THE core #4357 fix, end to end — a real unmapped top-level
+    key in a real reyn.yaml produces a ``ReynConfig.unknown_config_keys``
+    dict an operator (or the chrome renderer) can read the key name AND
+    destination from, not only a count. Real filesystem, real loader —
+    no mocked collaborator."""
+    import tempfile
+    from pathlib import Path
+
+    from reyn.config.config_schema import RenamedKeyHint
+    from reyn.config.loader import load_config
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / ".git").mkdir()
+        (root / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+
+        config = load_config(cwd=root)
+
+    assert config.unknown_config_key_count == 1
+    assert "model" in config.unknown_config_keys
+    hint = config.unknown_config_keys["model"]
+    assert isinstance(hint, RenamedKeyHint)
+    assert hint.destination == "llm.model"


### PR DESCRIPTION
**[docs-maintainer]** — #4357: the CUI names unmapped config keys, instead of only a count.

## Measurement, before any implementation (lead-coder's 3-point brief)

**① Population re-measured, not inherited from filing time.** Repo-internal population is now **0** — root `reyn.yaml` + 3 dogfood fixtures already fixed by #4358 (confirmed by reading the current files); `tests/mcp/test_cli_pipe.py`'s cited sites already correctly nested under `llm:` (grepped every `"model"`/`"models"` key in the file). What's left is the *class* — an operator can never see WHICH key was dropped — not the specific instances the issue was filed against.

**② Warning path traced.** `loader.py`'s `_warn_unknown_config_keys()` calls `config_schema.unknown_config_keys()`, which already returns per-key `RenamedKeyHint`(destination+note)/`RemovedKeyHint`(note) detail (#4375/#4402 built it). **The gap was never the data — only how far it traveled**: one `log.warning` call (file-only, per `_setup_interactive_logging`'s pre-config-load redirect) and a bare `int` count attached to `ReynConfig` for the CUI chrome to render as a number with no key names.

**③ Relationship with #4402 checked by reading its actual PR body.** Different axis, not overlapping — #4402's gate is a static grep/AST scan over `docs/**` and `*.example` files (documentation/examples shouldn't teach stale key names), never touching the runtime loader path. This issue is about a real `config.yaml`/`reyn.yaml`'s unmapped key at *load time* — same underlying registries, different surface.

## A standing ruling the brief didn't flag, found while reading `loader.py` directly

`_warn_unknown_config_keys()`'s own docstring names an owner ruling: *"warn, never hard-fail, anywhere — including sandbox.policy (no special case)"* (accumulated across #4174's spec revisions). The issue's proposed raise-ification directly conflicts with this, and no overriding owner comment is present in the issue thread. **Confirmed with lead-coder before implementing**: raise is treated as NOT approved (a separate issue if someone wants to ask owner to override the standing ruling); this PR's scope is surfacing only, which is compatible with the ruling in either direction — still warn, just with more information.

## The fix

- `_warn_unknown_config_keys()` returns the full `{dotted_key: hint}` dict instead of a bare count. Log-file warning unchanged; callers needing only the count use `len(...)`.
- `ReynConfig` gains `unknown_config_keys: dict` (`schema_internal`, same reasoning as the existing `unknown_config_key_count`) **alongside** the count, not instead of it — every existing reader is unaffected.
- `chrome.py`'s `config_warning_text()` gains an optional `keys=` param: up to 3 key names inline (renamed keys with a known destination first — `` `model` → `llm.model` `` — then remaining unknown/removed keys), "+N more" past the cap. `keys=None` (the pre-#4357 shape) renders **byte-identical** to the original count-only line. Still bounded (never "show everything" — #4380's own 197-item rejection applies here too) and still ends by pointing at `reyn config validate`, so architect's #4194 ruling's 3 properties (doesn't scroll away / stays visible / points to validate) are unchanged — only the line's own content grew.
- `status.py`/`read_model.py` updated for parity with the existing count field.

## Test plan

- [x] 6 new tests in `tests/interfaces/test_config_warning_chrome_4194.py`: renamed-key-with-destination shown / accept-side `keys=None` and `keys={}` fall back byte-identical / inline cap + "+N more" / removed-key shown without a destination arrow / `ReynConfig.unknown_config_keys` defaults to `{}` / end-to-end `load_config()` with a real unmapped key.
- [x] Falsified: stashed all 6 source files together, confirmed the 6 new tests fail (the 6 pre-existing tests in the same file pass unaffected — the back-compat fallback genuinely works), restored, confirmed all 12 green.
- [x] `ruff check`, `python scripts/mypy_ratchet.py` (211/215 baselined), `python scripts/test_tier_audit.py --strict` (0 Tier-4, 12/12), `python scripts/verify_module_docstrings.py`, `python scripts/check_tests_path_literal_reference.py` — all clean.
- [x] Broad sweep: `tests/config/` (full), `tests/interfaces/` (full directory) — 1641 + 172 passed, 7 skipped (unrelated missing extras), 0 failed.
- [ ] Visual/manual (owner env) — per the standing waiver (CLAUDE.md, 2026-08-08), left unchecked; owner confirms after merge on `main`.

## Issue title

Updated — "5 files, several months" was resolved by #4358 before this PR landed; what remains is the class.

## Arc note

`part of #4357`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
