### PR TITLE
fix(#4431): read_file/edit_file not_found suggestions signal their own cap

### DIFF
--- a/src/reyn/core/op_runtime/file.py
+++ b/src/reyn/core/op_runtime/file.py
@@ -88,7 +88,7 @@ async def _read_image_file(op: FileIROp, ctx: OpContext, *, mime_type: str) -> d
             "kind": "file", "op": "read", "path": op.path,
             "status": "not_found",
             "error": f"file not found: {op.path}",
-            "suggestions": _nearby_files(ctx.workspace, op.path),
+            **_suggestions_fields(ctx.workspace, op.path),
             "content": "",
         }
 
@@ -167,12 +167,18 @@ def _nearest_existing_ancestor(ws, start: str) -> "str | None":
     return None
 
 
-def _nearby_files(ws, path: str, *, max_results: int = _NOT_FOUND_SUGGESTIONS_LIMIT) -> list[str]:
+def _nearby_files(
+    ws, path: str, *, max_results: int = _NOT_FOUND_SUGGESTIONS_LIMIT
+) -> "tuple[list[str], int]":
     """List sibling files under the parent of *path*, for use as not_found suggestions.
 
-    Returns project-relative paths from ``Workspace.glob_files`` when the
-    parent directory exists (possibly empty — "no neighbours" legitimately
-    yields ``[]``).
+    Returns ``(suggestions, total_before_cap)`` — project-relative paths from
+    ``Workspace.glob_files_with_total`` when the parent directory exists
+    (possibly empty — "no neighbours" legitimately yields ``([], 0)``).
+    #4431: was the plain (silently-capped) ``glob_files`` — a directory with
+    more than ``_NOT_FOUND_SUGGESTIONS_LIMIT`` siblings always showed exactly
+    8 with no sign more existed. ``_with_total`` is the same #2998 fix the
+    ``glob`` op already uses; the caller reports the cap the same way.
 
     #3629: when the parent directory itself does NOT exist — a rename, a
     move, or a plugin reinstall to a different location, exactly the case
@@ -183,7 +189,7 @@ def _nearby_files(ws, path: str, *, max_results: int = _NOT_FOUND_SUGGESTIONS_LI
     nearest EXISTING ancestor (see :func:`_nearest_existing_ancestor`) as a
     single suggestion, so the model can discover the current structure
     on the spot instead of guessing a replacement path. Permission denials
-    and OS errors at any point still degrade to ``[]``, never raise.
+    and OS errors at any point still degrade to ``([], 0)``, never raise.
     """
     parent = str(Path(path).parent) if str(Path(path).parent) not in ("", ".") else "."
     if parent != ".":
@@ -193,12 +199,27 @@ def _nearby_files(ws, path: str, *, max_results: int = _NOT_FOUND_SUGGESTIONS_LI
             parent_stat = None
         if parent_stat is None or not parent_stat.get("is_dir"):
             ancestor = _nearest_existing_ancestor(ws, parent)
-            return [f"{ancestor}/"] if ancestor is not None else []
+            single = [f"{ancestor}/"] if ancestor is not None else []
+            return single, len(single)
     pattern = f"{parent}/*" if parent != "." else "*"
     try:
-        return ws.glob_files(pattern, max_results=max_results)
+        glob_result = ws.glob_files_with_total(pattern, max_results=max_results)
+        return glob_result.matches, glob_result.total
     except (PermissionError, OSError):
-        return []
+        return [], 0
+
+
+def _suggestions_fields(ws, path: str) -> dict:
+    """Build the ``suggestions`` (+ optional truncation signal) block shared by
+    every ``not_found`` result. #4431: extracted so the #2998-style truncation
+    report (``suggestions_truncated`` / ``suggestions_total``) is written once,
+    not re-derived at each of the 3 call sites with a chance to drift apart."""
+    suggestions, total = _nearby_files(ws, path)
+    fields: dict = {"suggestions": suggestions}
+    if total > len(suggestions):
+        fields["suggestions_truncated"] = True
+        fields["suggestions_total"] = total
+    return fields
 
 
 def _read_inline_cap(ctx: OpContext) -> int:
@@ -358,7 +379,6 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
             # not a fresh, independently-resolved lookup.
             raw_bytes, found = ctx.workspace.read_file_bytes(_resolved_read_path)
         if not found:
-            suggestions = _nearby_files(ctx.workspace, op.path)
             ctx.events.emit("tool_executed", op="read_file", path=op.path, found=False)
             return {
                 "kind": "file",
@@ -366,7 +386,7 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
                 "path": op.path,
                 "status": "not_found",
                 "error": f"file not found: {op.path}",
-                "suggestions": suggestions,
+                **_suggestions_fields(ctx.workspace, op.path),
                 "content": "",
             }
         # #1452 decode ladder (extends the #1449 binary guard): BOM → UTF-8 fast
@@ -758,14 +778,13 @@ def _execute_edit_sync(op: FileIROp, ctx: OpContext) -> tuple[dict, int | None, 
 
     raw_bytes, found = ctx.workspace.read_file_bytes(op.path)
     if not found:
-        suggestions = _nearby_files(ctx.workspace, op.path)
         return {
             "kind": "file",
             "op": "edit",
             "path": op.path,
             "status": "not_found",
             "error": f"file not found: {op.path}",
-            "suggestions": suggestions,
+            **_suggestions_fields(ctx.workspace, op.path),
         }, None, None
 
     # #1452: decode via the shared codec ladder so a non-UTF-8 text file can be

--- a/tests/core/test_op_runtime_file_not_found_suggestions.py
+++ b/tests/core/test_op_runtime_file_not_found_suggestions.py
@@ -101,6 +101,41 @@ def test_read_not_found_capped_at_limit(tmp_path, monkeypatch):
     )
 
 
+def test_read_not_found_signals_the_cap_when_it_actually_cuts(tmp_path, monkeypatch):
+    """Tier 2: #4431 — a directory with more siblings than the 8-suggestion cap
+    must SAY so (``suggestions_truncated`` + ``suggestions_total``), not just
+    silently show 8 of 20 with no sign the other 12 exist (owner ruling:
+    a silent cap with no config knob needs the loss to be visible instead —
+    mirrors the ``glob`` op's own #2998 ``truncated``/``total_count`` fields)."""
+    monkeypatch.chdir(tmp_path)
+    for i in range(20):
+        (tmp_path / f"file{i:02d}.md").write_text("x", encoding="utf-8")
+
+    ctx = _make_ctx(tmp_path)
+    result = _run(handle(_read("missing.md"), ctx))
+
+    assert result["status"] == "not_found"
+    assert result["suggestions_truncated"] is True
+    assert result["suggestions_total"] == 20
+
+
+def test_read_not_found_no_truncation_signal_when_everything_fits(tmp_path, monkeypatch):
+    """Tier 2: accept-side twin — with siblings at or under the cap, no
+    truncation actually happened, so ``suggestions_truncated`` must NOT
+    appear (a present-but-False flag would still read as "something was
+    cut"; only its outright absence says nothing was)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "alpha.md").write_text("a", encoding="utf-8")
+    (tmp_path / "beta.md").write_text("b", encoding="utf-8")
+
+    ctx = _make_ctx(tmp_path)
+    result = _run(handle(_read("missing.md"), ctx))
+
+    assert result["status"] == "not_found"
+    assert "suggestions_truncated" not in result
+    assert "suggestions_total" not in result
+
+
 def test_read_ok_still_returns_ok_shape(tmp_path, monkeypatch):
     """Tier 2: existing file read path returns status='ok' with content; no error or suggestions field bloat."""
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
**[docs-maintainer]** — #4431 item ③, PR 1 of 4: `read_file`/`edit_file` not_found suggestions signal their own cap.

## Scope (per lead-coder's brief)

One of the 10 flagged silent-and-no-config-knob sites: `core/op_runtime/file.py`'s `_NOT_FOUND_SUGGESTIONS_LIMIT` (8). A directory with more than 8 siblings always showed exactly 8 suggestions, with no sign more existed — indistinguishable from a directory that genuinely only had 8. Owner ruling (#4381-motivated): a silent cap with no config knob needs the loss to be visible instead.

## The fix

- `_nearby_files` now uses `Workspace.glob_files_with_total` (the existing #2998 mechanism `glob_entries`/the `glob` op already rely on for this exact problem) instead of the silently-capped `glob_files`, returning `(suggestions, total_before_cap)`.
- All 3 not_found result builders (`read_file`, `edit_file`, the binary-image path) go through a new `_suggestions_fields` helper so the `suggestions_truncated`/`suggestions_total` fields are written once, not re-derived at each call site with room to drift.
- **Absence convention, not present-and-False**: `suggestions_truncated` only appears when the cap actually cut something — a directory with ≤8 siblings gets no such key at all, matching `op_runtime/file.py`'s own established pattern for this same "was this loss real" question elsewhere in the file.
- No config knob needed — 8 already has a rationale comment (mirrors `invoke_action`'s own ~8-suggestion shape for "did you mean" narration); only the visibility half was missing.

## Test plan

- [x] 2 new tests in `tests/core/test_op_runtime_file_not_found_suggestions.py`: the truncation-signal case (20 siblings → `suggestions_truncated=True`, `suggestions_total=20`) and its accept-side twin (2 siblings → both keys absent). 11 pre-existing tests untouched and still pass (the shape change is additive).
- [x] Falsified: stashed `file.py`, confirmed the 2 new tests go RED (`KeyError`) while the 11 pre-existing tests stay GREEN; restored, confirmed all 13 GREEN.
- [x] `ruff check`, `python scripts/mypy_ratchet.py` (211/215 baselined, unchanged), `python scripts/test_tier_audit.py --strict` (0 Tier-4, this file's tests all OK), `python scripts/verify_module_docstrings.py`, `python scripts/check_tests_path_literal_reference.py` — all clean.
- [x] Broad sweep: `tests/core/` (full, 2534 passed / 1 skipped, 0 failures) — 1 unrelated pre-existing failure exists elsewhere in `tests/runtime/` (`test_session_pure_extraction_3679_s1.py`, a stale `reyn.runtime.session_pure` import reference), confirmed via `git stash` to pre-date this diff entirely; reported separately, not in scope here.
- [ ] Visual/manual (owner env) — per the standing waiver (CLAUDE.md, 2026-08-08), left unchecked; owner confirms after merge on `main`.

## Sibling PRs (same #4431 item ③, independent call paths — not stacked)

- `web.py` `_HtmlPreviewParser` outline-truncation visibility
- `reyn_repo.py` glob/grep visibility (3 constants, 1 PR per lead-coder's own grouping — same call path)
- `knowledge_ingest.py` repo-ingest skip visibility (new `repo_ingest_files_skipped` audit-event kind)

## Arc note

`part of #4431`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
