### PR TITLE
fix(#4431): web_fetch HTML outline preview signals its own truncation cap

### DIFF
--- a/src/reyn/core/op_runtime/web.py
+++ b/src/reyn/core/op_runtime/web.py
@@ -76,6 +76,16 @@ class _HtmlPreviewParser(html.parser.HTMLParser):
     """
 
     _HEADING_TAGS = {"h1", "h2", "h3"}
+    # #4431: preview-only cap, not a data-loss point — this class builds a
+    # PREVIEW (title/outline/first_paragraph), and the caller already has the
+    # full `extracted_text` alongside it (see `_generate_web_fetch_preview`),
+    # so a heading past #8 is never lost, only left out of the outline
+    # summary. 8 has no measured basis beyond "a preview should stay short";
+    # unlike a hard data cap this doesn't need a config knob (owner ruling:
+    # a knob is for values a real environment could need widened — a preview
+    # length is a display choice, not a correctness bound). What it DID need
+    # (and lacked) is visibility: `result()` now reports `outline_truncated`
+    # so a page with more headings doesn't read as "this IS the whole outline".
     _OUTLINE_MAX = 8
 
     def __init__(self) -> None:
@@ -83,6 +93,7 @@ class _HtmlPreviewParser(html.parser.HTMLParser):
         self._title_parts: list[str] = []
         self._in_title = False
         self._outline: list[tuple[str, list[str]]] = []  # (tag, buf)
+        self._heading_count = 0  # ALL headings seen, uncapped — #4431 visibility
         self._current_heading: tuple[str, list[str]] | None = None
         self._first_paragraph_parts: list[str] = []
         self._in_first_paragraph = False
@@ -92,8 +103,10 @@ class _HtmlPreviewParser(html.parser.HTMLParser):
     def handle_starttag(self, tag: str, attrs: object) -> None:
         if tag == "title":
             self._in_title = True
-        elif tag in self._HEADING_TAGS and len(self._outline) < self._OUTLINE_MAX:
-            self._current_heading = (tag, [])
+        elif tag in self._HEADING_TAGS:
+            self._heading_count += 1
+            if len(self._outline) < self._OUTLINE_MAX:
+                self._current_heading = (tag, [])
         elif (
             tag == "p"
             and not self._first_paragraph_done
@@ -136,12 +149,19 @@ class _HtmlPreviewParser(html.parser.HTMLParser):
         first_paragraph = " ".join(self._first_paragraph_parts).strip()
         if len(first_paragraph) > 280:
             first_paragraph = first_paragraph[:277] + "…"
-        return {
+        out: dict = {
             "title": title,
             "outline": outline,
             "first_paragraph": first_paragraph,
             "link_count": self._link_count,
         }
+        # #4431: the page's own full text is available alongside this preview
+        # (see _generate_web_fetch_preview) — nothing is lost — but the
+        # OUTLINE itself must say when it isn't the whole heading list.
+        if self._heading_count > len(self._outline):
+            out["outline_truncated"] = True
+            out["outline_heading_count"] = self._heading_count
+        return out
 
 
 def _generate_web_fetch_preview(

--- a/tests/core/test_web_fetch_outline_truncation_visibility_4431.py
+++ b/tests/core/test_web_fetch_outline_truncation_visibility_4431.py
@@ -1,0 +1,61 @@
+"""Tier 2: _HtmlPreviewParser's outline cap must be visible when it cuts (#4431).
+
+``_OUTLINE_MAX`` caps the outline preview `_HtmlPreviewParser` builds for a
+web_fetch result. Before #4431 a page with more headings than the cap silently
+dropped the rest — the outline read as "the whole document's heading
+structure" when it was really "the first N". Per the owner's #4381-motivated
+ruling (a silent cap with no config knob needs the loss to be visible instead —
+this cap doesn't need a config knob, since the full page text is available
+alongside the preview and a preview length is a display choice, not a
+correctness bound), `result()` now reports `outline_truncated` +
+`outline_heading_count` whenever the cap actually cut something.
+"""
+from __future__ import annotations
+
+from reyn.core.op_runtime.web import _HtmlPreviewParser
+
+_OUTLINE_MAX = _HtmlPreviewParser._OUTLINE_MAX
+
+
+def _headings_html(n: int) -> str:
+    return "".join(f"<h2>Heading {i}</h2><p>body</p>" for i in range(n))
+
+
+def test_outline_signals_truncation_past_the_cap():
+    """Tier 2: more headings than _OUTLINE_MAX → outline_truncated + the real total."""
+    parser = _HtmlPreviewParser()
+    parser.feed(_headings_html(_OUTLINE_MAX + 4))
+
+    result = parser.result()
+
+    assert len(result["outline"]) == _OUTLINE_MAX
+    assert result["outline_truncated"] is True
+    assert result["outline_heading_count"] == _OUTLINE_MAX + 4
+
+
+def test_outline_no_truncation_signal_when_everything_fits():
+    """Tier 2: accept-side twin — at or under the cap, nothing was cut, so the
+    flag must be ABSENT (not present-and-False), matching op_runtime/file.py's
+    own #4431 not_found suggestions convention (only outright absence says
+    nothing was truncated)."""
+    parser = _HtmlPreviewParser()
+    under_cap = [f"Heading {i}" for i in range(_OUTLINE_MAX - 1)]
+    parser.feed("".join(f"<h2>{h}</h2><p>body</p>" for h in under_cap))
+
+    result = parser.result()
+
+    assert [o.split(": ", 1)[1] for o in result["outline"]] == under_cap
+    assert "outline_truncated" not in result
+    assert "outline_heading_count" not in result
+
+
+def test_outline_exactly_at_the_cap_is_not_truncated():
+    """Tier 2: boundary — exactly _OUTLINE_MAX headings is the whole document,
+    not a cut."""
+    parser = _HtmlPreviewParser()
+    parser.feed(_headings_html(_OUTLINE_MAX))
+
+    result = parser.result()
+
+    assert len(result["outline"]) == _OUTLINE_MAX
+    assert "outline_truncated" not in result


### PR DESCRIPTION
**[docs-maintainer]** — #4431 item ③, PR 2 of 4: web_fetch HTML outline preview signals its own truncation cap.

## Scope (per lead-coder's brief)

`core/op_runtime/web.py`'s `_HtmlPreviewParser._OUTLINE_MAX` (8) — one of the 10 flagged sites, and flagged with an extra note: no rationale comment for the value 8 either. A page with more than 8 headings always showed exactly 8 in the outline, with no sign more existed.

## The fix

- Added a rationale comment: 8 has no measured basis beyond "a preview should stay short" — a display choice, not a correctness bound, since the caller (`_generate_web_fetch_preview`) already has the full `extracted_text` alongside the outline preview. Per the owner's ruling, that's why this constant does NOT need a config knob (unlike a value that bounds real data loss).
- `_HtmlPreviewParser` now tracks `_heading_count` (every heading tag seen, uncapped) alongside the capped `_outline` list; `result()` reports `outline_truncated` + `outline_heading_count` only when the cap actually cut something — absent, not present-and-False, otherwise (matches the sibling PR's `file.py` convention for the same question).

## Test plan

- [x] New file `tests/core/test_web_fetch_outline_truncation_visibility_4431.py`: past-the-cap case, accept-side twin (under cap → no flag), and the exact-boundary case (headings == cap is not a cut). All reference the real `_OUTLINE_MAX` constant rather than a hardcoded literal.
- [x] Falsified: stashed `web.py`, confirmed the past-the-cap test goes RED (`KeyError: 'outline_truncated'`); restored, confirmed all 3 GREEN.
- [x] `ruff check`, `python scripts/mypy_ratchet.py` (unchanged), `python scripts/test_tier_audit.py --strict` (0 Tier-4 — fixed 3 findings during authoring: missing per-test Tier-line prefixes, and a `len(...) == 8` literal replaced with `== _OUTLINE_MAX`), `python scripts/verify_module_docstrings.py`, `python scripts/check_tests_path_literal_reference.py` — all clean.
- [x] Broad sweep: this file + `tests/core/test_web_fetch_extractor_selection.py` + `tests/core/test_web_fetch_download_cap_1913.py` + `tests/core/test_web_fetch_ssl_config.py` (22 passed, 1 skipped — missing `trafilatura` extra, pre-existing/unrelated); full `tests/core/` also run clean (2534 passed / 1 skipped) as part of the combined pre-split sweep.
- [ ] Visual/manual (owner env) — per the standing waiver (CLAUDE.md, 2026-08-08), left unchecked; owner confirms after merge on `main`.

## Sibling PRs (same #4431 item ③, independent call paths — not stacked)

- #4435 `file.py` not_found suggestions visibility
- `reyn_repo.py` glob/grep visibility
- `knowledge_ingest.py` repo-ingest skip visibility

## Arc note

`part of #4431`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
