### PR TITLE
fix(#4431): reyn_repo_glob/reyn_repo_grep signal every silent cap they hit

### DIFF
--- a/src/reyn/runtime/reyn_repo.py
+++ b/src/reyn/runtime/reyn_repo.py
@@ -358,6 +358,12 @@ def read_text(
 
 _MAX_GLOB_MATCHES = 200
 _MAX_GREP_RESULTS = 50
+# #4431: no measured basis for 200 beyond "wide enough for a grep line
+# to read as a real preview, narrow enough that one match can't eat the
+# result on its own" — a per-match display choice, not a correctness
+# bound (the full line is always in the source file the ``path``/``line``
+# already names), so this doesn't need a config knob, only the
+# ``snippet_truncated`` marker `grep_entries` now sets per over-length match.
 _GREP_SNIPPET_CHARS = 200
 # Same skip-set the listing path applies (= canonical exclusion for
 # noise / build artifacts). Used by both glob and grep so the surfaces
@@ -393,14 +399,19 @@ def _iter_files_under(root: Path):
 def glob_entries(root: Path, pattern: str) -> dict:
     """Build the ``reyn_repo_glob`` result dict.
 
-    Returns ``{pattern, matches: [str, ...], count: int}`` where each
-    match is a repo-root-relative path. Capped at ``_MAX_GLOB_MATCHES``
-    so a careless ``**`` doesn't blow up the LLM context.
+    Returns ``{pattern, matches: [str, ...], count: int, truncated: bool}``
+    where each match is a repo-root-relative path. Capped at
+    ``_MAX_GLOB_MATCHES`` so a careless ``**`` doesn't blow up the LLM
+    context. #4431: ``truncated`` names the cap the same way
+    :func:`grep_entries` already does — a `**` match set is unbounded by
+    construction (unlike the read cap, which #2998-style totals a bounded
+    directory listing), so this reports THAT more exist, not how many.
     """
     cleaned = (pattern or "").strip()
     if not cleaned:
         return {"error": "reyn_repo_glob: pattern must be non-empty."}
     matches: list[str] = []
+    truncated = False
     try:
         for p in root.glob(cleaned):
             if not p.is_file():
@@ -413,11 +424,15 @@ def glob_entries(root: Path, pattern: str) -> dict:
                 continue
             matches.append(str(p.relative_to(root)))
             if len(matches) >= _MAX_GLOB_MATCHES:
+                truncated = True
                 break
     except (ValueError, OSError) as exc:
         return {"error": f"reyn_repo_glob: pattern {pattern!r} failed: {exc}"}
     matches.sort()
-    return {"pattern": pattern, "matches": matches, "count": len(matches)}
+    return {
+        "pattern": pattern, "matches": matches, "count": len(matches),
+        "truncated": truncated,
+    }
 
 
 def grep_entries(
@@ -430,10 +445,18 @@ def grep_entries(
 ) -> dict:
     """Build the ``reyn_repo_grep`` result dict.
 
-    Returns ``{pattern, matches: [{path, line, snippet}, ...], count: int,
-    truncated: bool}``. ``path`` scopes the search to a sub-tree (default
-    repo root). ``glob`` filters which files are searched (default = all
-    text files under scope).
+    Returns ``{pattern, matches: [{path, line, snippet, ...}, ...], count:
+    int, truncated: bool, skipped_large_file_count: int}``. ``path`` scopes
+    the search to a sub-tree (default repo root). ``glob`` filters which
+    files are searched (default = all text files under scope).
+
+    #4431: two independent cuts happen here, and both must say so —
+    ``truncated`` (the pre-existing ``max_results`` cap on MATCH count) and
+    ``skipped_large_file_count`` (files over ``_MAX_READ_BYTES`` excluded
+    from the scan entirely — before this fix a file above the cap read as
+    "no matches" indistinguishably from a file that was genuinely searched
+    and empty). A per-match ``snippet_truncated`` flag is set when a single
+    line is cut to ``_GREP_SNIPPET_CHARS``.
     """
     import re
 
@@ -469,13 +492,18 @@ def grep_entries(
 
     matches: list[dict] = []
     truncated = False
+    skipped_large_file_count = 0
     for fp in candidates:
         if len(matches) >= max_results:
             truncated = True
             break
         # Skip files larger than the read cap — same discipline as read_text.
+        # #4431: was a bare `continue` — a file this big now COUNTS itself
+        # (skipped_large_file_count) instead of silently reading as "no
+        # matches found", indistinguishable from a file actually searched.
         try:
             if fp.stat().st_size > _MAX_READ_BYTES:
+                skipped_large_file_count += 1
                 continue
         except OSError:
             continue
@@ -485,12 +513,16 @@ def grep_entries(
             continue
         for line_no, line in enumerate(text.splitlines(), start=1):
             if compiled.search(line):
-                snippet = line.strip()[:_GREP_SNIPPET_CHARS]
-                matches.append({
+                stripped = line.strip()
+                snippet = stripped[:_GREP_SNIPPET_CHARS]
+                match: dict = {
                     "path": str(fp.relative_to(root)),
                     "line": line_no,
                     "snippet": snippet,
-                })
+                }
+                if len(stripped) > _GREP_SNIPPET_CHARS:
+                    match["snippet_truncated"] = True
+                matches.append(match)
                 if len(matches) >= max_results:
                     truncated = True
                     break
@@ -500,6 +532,7 @@ def grep_entries(
         "matches": matches,
         "count": len(matches),
         "truncated": truncated,
+        "skipped_large_file_count": skipped_large_file_count,
     }
 
 

--- a/tests/runtime/test_reyn_repo_glob_grep.py
+++ b/tests/runtime/test_reyn_repo_glob_grep.py
@@ -182,3 +182,84 @@ def test_glob_skip_set_matches_list_entries_set() -> None:
     assert ".git" in _SKIP_DIR_NAMES
     assert "__pycache__" in _SKIP_DIR_NAMES
     assert ".venv" in _SKIP_DIR_NAMES
+
+
+# ── 5. #4431 — silent-cap visibility (own tmp_path root, not the real repo) ─
+
+
+def test_glob_truncated_flag_when_cap_hit(tmp_path: Path) -> None:
+    """Tier 2: #4431 — more matches than _MAX_GLOB_MATCHES (200) sets
+    `truncated`, mirroring grep's own contract (owner ruling: a silent cap
+    with no config knob must make the cut visible instead)."""
+    from reyn.runtime.reyn_repo import _MAX_GLOB_MATCHES
+
+    for i in range(_MAX_GLOB_MATCHES + 5):
+        (tmp_path / f"file{i:04d}.md").write_text("x", encoding="utf-8")
+
+    result = glob_entries(tmp_path, "*.md")
+
+    assert result["count"] == _MAX_GLOB_MATCHES
+    assert result["truncated"] is True
+
+
+def test_glob_no_truncation_signal_under_cap(tmp_path: Path) -> None:
+    """Tier 2: accept-side twin — under the cap, `truncated` is False, not
+    just absent (this function has always returned it unconditionally;
+    #4431 doesn't change that shape, only adds a True case)."""
+    (tmp_path / "alpha.md").write_text("a", encoding="utf-8")
+    (tmp_path / "beta.md").write_text("b", encoding="utf-8")
+
+    result = glob_entries(tmp_path, "*.md")
+
+    assert result["count"] == 2
+    assert result["truncated"] is False
+
+
+def test_grep_snippet_truncated_marks_only_long_lines(tmp_path: Path) -> None:
+    """Tier 2: #4431 — a matching line longer than _GREP_SNIPPET_CHARS (200)
+    is cut with NO prior marker; `snippet_truncated` now says so per-match,
+    and a short match must NOT carry the key at all (absence = nothing cut,
+    same convention `truncated`'s sibling fields use elsewhere in #4431)."""
+    from reyn.runtime.reyn_repo import _GREP_SNIPPET_CHARS
+
+    long_line = "needle " + ("x" * (_GREP_SNIPPET_CHARS + 50))
+    (tmp_path / "long.txt").write_text(long_line, encoding="utf-8")
+    (tmp_path / "short.txt").write_text("needle short line", encoding="utf-8")
+
+    result = grep_entries(tmp_path, pattern="needle", max_results=10)
+
+    by_path = {m["path"]: m for m in result["matches"]}
+    assert by_path["long.txt"]["snippet_truncated"] is True
+    assert len(by_path["long.txt"]["snippet"]) == _GREP_SNIPPET_CHARS
+    assert "snippet_truncated" not in by_path["short.txt"]
+
+
+def test_grep_counts_files_skipped_for_size(tmp_path: Path) -> None:
+    """Tier 2: #4431 — a file over `_MAX_READ_BYTES` is excluded from the
+    scan entirely (pre-existing behaviour); before this fix that read
+    identically to "searched, no matches". `skipped_large_file_count` now
+    distinguishes the two."""
+    from reyn.runtime.reyn_repo import _MAX_READ_BYTES
+
+    (tmp_path / "huge.txt").write_text(
+        "needle\n" + ("x" * (_MAX_READ_BYTES + 1)), encoding="utf-8"
+    )
+    (tmp_path / "normal.txt").write_text("needle here too", encoding="utf-8")
+
+    result = grep_entries(tmp_path, pattern="needle", max_results=10)
+
+    assert result["skipped_large_file_count"] == 1
+    matched_paths = {m["path"] for m in result["matches"]}
+    assert "huge.txt" not in matched_paths
+    assert "normal.txt" in matched_paths
+
+
+def test_grep_zero_skipped_large_files_when_none_are_big(tmp_path: Path) -> None:
+    """Tier 2: accept-side twin — `skipped_large_file_count` is 0 (present,
+    not absent — this function has always returned every field
+    unconditionally, e.g. `truncated`) when nothing was actually skipped."""
+    (tmp_path / "normal.txt").write_text("needle here", encoding="utf-8")
+
+    result = grep_entries(tmp_path, pattern="needle", max_results=10)
+
+    assert result["skipped_large_file_count"] == 0


### PR DESCRIPTION
**[docs-maintainer]** — #4431 item ③, PR 3 of 4: `reyn_repo_glob`/`reyn_repo_grep` signal every silent cap they hit.

## Scope (per lead-coder's brief)

Three named constants, all in `runtime/reyn_repo.py`, grouped into one PR per lead-coder's own instruction ("`reyn_repo.py` の3件は同じ経路なので1本"):

- `_MAX_READ_BYTES` (256KB) — checked first. **Already compliant**: rationale comment ("Reyn's docs/source files are well under this... ~256KB ≈ 50K tokens worst case") AND a loud structured error naming the exact byte count + how to work around it (`offset`/`limit` slicing) when `read_text` hits it. No fix needed there.
- `_MAX_GLOB_MATCHES` (200) — `glob_entries` capped silently with no `truncated` field at all, unlike `grep_entries` in the same file which already had one.
- `_MAX_GREP_RESULTS` / `_GREP_SNIPPET_CHARS` (50 / 200) — lead-coder flagged both as lacking a rationale comment. `_MAX_GREP_RESULTS`'s match-count cap was already visible (`truncated`); `_GREP_SNIPPET_CHARS`'s per-match line truncation was NOT (no marker at all on a cut snippet).
- A related discovery while reading the call site: `grep_entries`'s per-file size skip (`fp.stat().st_size > _MAX_READ_BYTES: continue`) is a SEPARATE silent cut from all of the above — a file over the size cap read identically to "searched, no matches found", with zero signal it was excluded from the scan at all.

## The fix

- `glob_entries` now returns `truncated: bool`, mirroring `grep_entries`'s existing contract.
- `grep_entries` now returns `skipped_large_file_count: int` (always present, 0 when nothing was skipped — matches this function's pre-existing convention of returning every field unconditionally, e.g. `truncated`).
- Each grep match now carries `snippet_truncated: True` when its line was cut to `_GREP_SNIPPET_CHARS` (absent when the line fit — the newer, greenfield convention this PR's sibling `file.py`/`web.py` PRs also use).
- Rationale comment added for `_GREP_SNIPPET_CHARS`: a per-match display choice, not a correctness bound (the full line is always recoverable via the `path`/`line` the match already names), so no config knob is needed per the owner's either/or ruling.

## Test plan

- [x] 5 new tests in `tests/runtime/test_reyn_repo_glob_grep.py`: glob truncation signal + accept-side twin, snippet truncation on a long match (short match has no key), size-skip count + accept-side twin (0, not absent).
- [x] Falsified: stashed `reyn_repo.py`, confirmed all 5 new tests go RED (`KeyError`); restored, confirmed all 17 GREEN (12 pre-existing + 5 new).
- [x] `ruff check`, `python scripts/mypy_ratchet.py` (unchanged), `python scripts/test_tier_audit.py --strict` (0 Tier-4), `python scripts/verify_module_docstrings.py`, `python scripts/check_tests_path_literal_reference.py` — all clean.
- [x] Broad sweep: this file + `tests/runtime/test_reyn_repo_resolver.py` + `tests/runtime/test_0061_repo_self_access_parity.py` + `tests/core/test_fp0056_file_reyn_repo_canonical.py` + `tests/tools/test_reyn_repo_unified.py` (77 passed); full `tests/runtime/` also run clean (1732 passed / 1 skipped) except one PRE-EXISTING failure confirmed unrelated via `git stash` (`test_session_pure_extraction_3679_s1.py`, a stale `reyn.runtime.session_pure` import — not in this diff, not this PR's scope).
- [ ] Visual/manual (owner env) — per the standing waiver (CLAUDE.md, 2026-08-08), left unchecked; owner confirms after merge on `main`.

## Sibling PRs (same #4431 item ③, independent call paths — not stacked)

- #4435 `file.py` not_found suggestions visibility
- #4436 `web.py` outline preview visibility
- `knowledge_ingest.py` repo-ingest skip visibility

## Arc note

`part of #4431`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
