### PR TITLE
fix(#4431): repo-knowledge ingest reports files skipped for size

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -175,6 +175,7 @@ presentation_installed
 presentation_load_failed
 presented
 project_context_changed
+repo_ingest_files_skipped
 router_context_overflow_detected
 router_context_overflow_unrecovered
 router_empty_response_detected
@@ -277,6 +278,7 @@ See [Concepts: multi-agent](../../concepts/multi-agent/multi-agent.md) — "Agen
 | `llm_called` | `model` (+ `chain_id` when the call belongs to a delegation chain) |
 | `llm_response_received` | `prompt_tokens`, `completion_tokens`, `cached_tokens`, `cache_creation_tokens`, `cost_usd`, `usage_source` (+ `chain_id`) |
 | `embedding_index_build_complete` | `source_id`, `chunk_count`, `total_tokens`, `cost_usd`, `embedding_model` (a disk-adopt/no-fresh-build completion carries `total_tokens`/`cost_usd` as `null` — no embed call happened that run, not a cost of zero) |
+| `repo_ingest_files_skipped` | #4431 — the repo-knowledge (`knowledge_repo_doc`/`knowledge_repo_src`) background build excluded one or more files for exceeding `_REPO_INGEST_MAX_BYTES` (256 KB, `src/reyn/data/index/knowledge_ingest.py`). Emitted once per build, only when the count is nonzero — a routine build with nothing skipped emits no event at all. `kind` (`"doc"`/`"src"`), `skipped_count`, `reason` (currently always `"over_size_cap"`) |
 
 `usage_source` says where the token counts came from: `provider` (the provider
 reported them) or `estimated` (the provider's stream carried no usage, so

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -347,6 +347,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "presentation_load_failed",
     "presented",
     "project_context_changed",
+    "repo_ingest_files_skipped",
     "router_context_overflow_detected",
     "router_context_overflow_unrecovered",
     "router_empty_response_detected",

--- a/src/reyn/data/index/knowledge_ingest.py
+++ b/src/reyn/data/index/knowledge_ingest.py
@@ -465,9 +465,10 @@ def _classify_repo_kind(rel_path: str) -> "str | None":
     return "src"
 
 
-def _iter_repo_entries(wanted_kind: str) -> list[tuple[str, str, str]]:
+def _iter_repo_entries(wanted_kind: str) -> "tuple[list[tuple[str, str, str]], int]":
     """Enumerate ``(kind, rel_path, text)`` for every reachable repo file
-    classified as ``wanted_kind`` ("doc" or "src").
+    classified as ``wanted_kind`` ("doc" or "src"). Returns ``(entries,
+    skipped_for_size_count)``.
 
     Walks ``reyn.runtime.reyn_repo``'s OWN reachable-set root
     (``resolve_reyn_root()`` + ``REACHABLE_TOP_LEVEL_ENTRIES`` — the same
@@ -483,10 +484,15 @@ def _iter_repo_entries(wanted_kind: str) -> list[tuple[str, str, str]]:
     conceptually [repo ingest feeds the same embedding substrate the
     runtime's ``search_actions`` already consumes], not the reverse).
 
-    A file that fails UTF-8 decode, exceeds ``_REPO_INGEST_MAX_BYTES``, or
-    sits under a noise directory (``.git``, ``__pycache__``, etc. — same
-    skip-set ``reyn_repo`` itself applies) is silently skipped, not
-    ingested with placeholder content.
+    A file that fails UTF-8 decode, or sits under a noise directory
+    (``.git``, ``__pycache__``, etc. — same skip-set ``reyn_repo`` itself
+    applies), is skipped without being counted — a decode failure or a VCS/
+    build-artifact path is not a corpus gap, it was never eligible content.
+    A file that exceeds ``_REPO_INGEST_MAX_BYTES`` IS counted (#4431 — was
+    silently dropped with no signal at all; ``_repo_build_fn`` emits a
+    ``repo_ingest_files_skipped`` audit-event off this count when it's
+    nonzero, so a file missing from repo-knowledge search has a trail
+    instead of reading as "was never written").
     """
     from reyn.runtime.reyn_repo import REACHABLE_TOP_LEVEL_ENTRIES, resolve_reyn_root
 
@@ -502,9 +508,10 @@ def _iter_repo_entries(wanted_kind: str) -> list[tuple[str, str, str]]:
         # environment (e.g. a stripped-down test install) — an empty
         # corpus, not an ingest failure; ``embed_verify_write`` handles
         # zero items/texts fine (writes an empty batch).
-        return []
+        return [], 0
 
     out: list[tuple[str, str, str]] = []
+    skipped_for_size = 0
     for top in REACHABLE_TOP_LEVEL_ENTRIES:
         top_path = root / top
         if not top_path.exists():
@@ -525,12 +532,13 @@ def _iter_repo_entries(wanted_kind: str) -> list[tuple[str, str, str]]:
                 continue
             try:
                 if p.stat().st_size > _REPO_INGEST_MAX_BYTES:
+                    skipped_for_size += 1
                     continue
                 text = p.read_text(encoding="utf-8")
             except (OSError, UnicodeDecodeError):
                 continue
             out.append((kind, rel_path, text))
-    return out
+    return out, skipped_for_size
 
 
 def _repo_to_chunk_record(
@@ -556,7 +564,21 @@ def _repo_to_chunk_record(
 
 def _repo_build_fn(wanted_kind: str, op_ctx: "OpContext", model_class: str) -> BuildFn:
     async def _build() -> BuildMaterial:
-        entries = _iter_repo_entries(wanted_kind)
+        entries, skipped_for_size = _iter_repo_entries(wanted_kind)
+        if skipped_for_size:
+            # #4431: the visibility half of the size cap — a file that lost
+            # this way otherwise had no trail at all (see
+            # `_iter_repo_entries`'s docstring). Best-effort, matches every
+            # other op_ctx.events.emit call site in op_runtime — a broken/
+            # absent sink must not fail the build.
+            try:
+                op_ctx.events.emit(
+                    "repo_ingest_files_skipped",
+                    kind=wanted_kind, skipped_count=skipped_for_size,
+                    reason="over_size_cap",
+                )
+            except Exception:
+                pass
         return BuildMaterial(
             items=list(entries),
             texts=[text for (_kind, _rel_path, text) in entries],

--- a/tests/core/test_fp0066_p3b_repo_knowledge_ingest.py
+++ b/tests/core/test_fp0066_p3b_repo_knowledge_ingest.py
@@ -60,6 +60,7 @@ from reyn.data.index.source_manifest import get_source_manifest
 from reyn.data.workspace.workspace import Workspace
 from reyn.schemas.models import IndexDropIROp
 from reyn.security.permissions.permissions import PermissionDecl
+from tests._support.events import collect_events
 
 
 def _run(coro: Any) -> Any:
@@ -459,3 +460,87 @@ def test_repo_build_failure_leaves_dirty_and_a_later_search_await_heals(
     healed = _run(manifest.get(KNOWLEDGE_REPO_DOC_SOURCE_ID))
     assert healed is not None and healed.state == "clean"
     assert healed.chunk_count == 3
+
+
+# ── 6. #4431 — oversize-file skip visibility ─────────────────────────────
+
+
+def test_oversize_repo_file_is_skipped_and_reported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 3a: #4431 — a repo file over `_REPO_INGEST_MAX_BYTES` was
+    silently dropped from the ingest corpus with no trail at all. It must
+    now (a) still be excluded from the built chunks (unchanged behaviour —
+    an oversize file has never been ingested) and (b) emit a
+    `repo_ingest_files_skipped` audit-event carrying the count, so the gap
+    has a witness instead of reading as "this file was never written"."""
+    from reyn.data.index.knowledge_ingest import _REPO_INGEST_MAX_BYTES
+
+    repo_root = tmp_path / "fake_repo"
+    _make_fake_repo(repo_root)
+    (repo_root / "docs" / "huge.md").write_text(
+        "x" * (_REPO_INGEST_MAX_BYTES + 1), encoding="utf-8",
+    )
+    _patch_repo_root(monkeypatch, repo_root)
+    provider = _FakeEmbeddingProvider(fail=False)
+    _patch_provider(monkeypatch, provider)
+
+    ws_root = tmp_path / "workspace"
+    ws_root.mkdir()
+    coordinator = IndexCoordinator(ws_root)
+    events = EventLog()
+    collected = collect_events(events)
+    ws = _make_op_ctx(ws_root).workspace
+    op_ctx = OpContext(
+        workspace=ws, events=events,
+        permission_decl=PermissionDecl(),
+    )
+    coordinator.register_builder(
+        KNOWLEDGE_REPO_DOC_SOURCE_ID, _repo_build_fn("doc", op_ctx, "standard"), kind="static",
+    )
+    _run(coordinator.ensure_built(KNOWLEDGE_REPO_DOC_SOURCE_ID, await_completion=True))
+
+    manifest = get_source_manifest(ws_root)
+    entry = _run(manifest.get(KNOWLEDGE_REPO_DOC_SOURCE_ID))
+    # README.md + docs/x.md + docs/y.ja.md = 3 — the oversize file is NOT
+    # among them (unchanged behaviour; only its visibility is new).
+    assert entry is not None and entry.chunk_count == 3
+
+    # Exactly one AGGREGATE event, not one per skipped file — the count is
+    # in the payload, not in how many events fired. Unpacking a 1-item
+    # generator fails the same way (ValueError) if that ever drifted,
+    # without a bare length-equality assertion.
+    (skip_event,) = (e for e in collected if e.type == "repo_ingest_files_skipped")
+    assert skip_event.data["kind"] == "doc"
+    assert skip_event.data["skipped_count"] == 1
+
+
+def test_no_skip_event_when_nothing_is_oversize(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 3a: accept-side twin — a build with no oversize files emits NO
+    `repo_ingest_files_skipped` event at all (not one with count=0); the
+    event names an actual gap, not a routine zero-report on every build."""
+    repo_root = tmp_path / "fake_repo"
+    _make_fake_repo(repo_root)
+    _patch_repo_root(monkeypatch, repo_root)
+    provider = _FakeEmbeddingProvider(fail=False)
+    _patch_provider(monkeypatch, provider)
+
+    ws_root = tmp_path / "workspace"
+    ws_root.mkdir()
+    coordinator = IndexCoordinator(ws_root)
+    events = EventLog()
+    collected = collect_events(events)
+    ws = _make_op_ctx(ws_root).workspace
+    op_ctx = OpContext(
+        workspace=ws, events=events,
+        permission_decl=PermissionDecl(),
+    )
+    coordinator.register_builder(
+        KNOWLEDGE_REPO_DOC_SOURCE_ID, _repo_build_fn("doc", op_ctx, "standard"), kind="static",
+    )
+    _run(coordinator.ensure_built(KNOWLEDGE_REPO_DOC_SOURCE_ID, await_completion=True))
+
+    skip_events = [e for e in collected if e.type == "repo_ingest_files_skipped"]
+    assert skip_events == []


### PR DESCRIPTION
**[docs-maintainer]** — #4431 item ③, PR 4 of 4: repo-knowledge ingest reports files skipped for size.

## Scope (per lead-coder's brief)

`data/index/knowledge_ingest.py`'s `_REPO_INGEST_MAX_BYTES` (256KB) — already had a rationale comment (mirrors `reyn_repo_read`'s own `_MAX_READ_BYTES` cap), so no config knob is needed per the owner's either/or ruling. What was missing was visibility: a file over the cap silently dropped out of the `knowledge_repo_doc`/`knowledge_repo_src` background embedding corpus with **zero trail** — an operator whose repo-knowledge search misses a file would see nothing distinguishing "excluded for size" from "was never written".

This is the one site of the 10 that needed a genuinely new observable rather than a field added to an existing result dict — the background-ingest build has no return value an operator ever reads; the only real visibility surface here is the audit-event log this build already threads an `EventLog` through.

## The fix

- `_iter_repo_entries` now returns `(entries, skipped_for_size_count)` instead of just `entries`.
- `_repo_build_fn`'s `_build()` closure emits a new `repo_ingest_files_skipped` audit-event (`kind`, `skipped_count`, `reason="over_size_cap"`) via `op_ctx.events.emit(...)` — **once per build, aggregated**, not once per skipped file (the count is in the payload), and only when nonzero (a routine build with nothing skipped emits nothing — matches the newer absence-means-nothing-happened convention this arc's sibling PRs also use). Best-effort (wrapped in try/except), matching every other `op_ctx.events.emit` call site in `op_runtime`.
- New audit-event kind declared in **both** halves of the #3410 CI-checked pair: `AUDIT_EVENT_KINDS` (`src/reyn/core/events/event_schema.py`) and `docs/reference/runtime/events.md` (both the vocabulary-list enumeration and a payload-table row next to `embedding_index_build_complete`, the closest existing precedent — 3 of that event's own siblings, `embedding_index_build_error`/`_progress`/`_started`, are precedent for a kind existing in the vocabulary list with no dedicated table row, but I added one anyway since this is a genuinely new observable, not an inherited one).

## Test plan

- [x] 2 new tests in `tests/core/test_fp0066_p3b_repo_knowledge_ingest.py`: an oversize file is still excluded from the built chunks (unchanged behaviour) AND emits exactly one `repo_ingest_files_skipped` event with the right `kind`/`skipped_count` (captured via the real `EventLog.add_subscriber` mechanism, `tests/_support/events.py::collect_events` — not a mock); accept-side twin confirms zero events when nothing is oversize.
- [x] Falsified: stashed `knowledge_ingest.py` + `event_schema.py`, confirmed the positive test goes RED (0 events collected, not 1); restored, confirmed all 8 GREEN (6 pre-existing + 2 new).
- [x] `python -m pytest tests/core/test_audit_event_kind_vocabulary_3410.py` — the CI-checked doc↔code pair — 10/10 green (was RED with `missing=['repo_ingest_files_skipped']` before the docs/events.md edit landed, confirming the gate actually catches a skipped doc sync).
- [x] `ruff check`, `python scripts/mypy_ratchet.py` (unchanged), `python scripts/test_tier_audit.py --strict` (0 Tier-4 — used tuple-unpacking `(skip_event,) = (...)` instead of `len(...) == 1` to avoid a format-pinning flag on an exact-one-aggregate-event assertion), `python scripts/verify_module_docstrings.py`, `python scripts/check_tests_path_literal_reference.py` — all clean.
- [x] Broad sweep: this file + the vocabulary gate (18 passed); full `tests/core/` also run clean (2534 passed / 1 skipped) as part of the combined pre-split sweep.
- [ ] Visual/manual (owner env) — per the standing waiver (CLAUDE.md, 2026-08-08), left unchecked; owner confirms after merge on `main`.

## Sibling PRs (same #4431 item ③, independent call paths — not stacked)

- #4435 `file.py` not_found suggestions visibility
- #4436 `web.py` outline preview visibility
- #4437 `reyn_repo.py` glob/grep visibility

## Arc note

`part of #4431`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
