### PR TITLE
feat(#4434): session-scoped policy-derivation cache, stage 1 (Seatbelt + Landlock)

### DIFF
--- a/src/reyn/environment/container_backend.py
+++ b/src/reyn/environment/container_backend.py
@@ -555,6 +555,22 @@ class DockerEnvironmentBackend:
         """
         return None
 
+    def session_artifact_outside_write_scope(self, policy: SandboxPolicy) -> bool:
+        """Vacuously True (#4434): neither ``wrap_command`` nor ``run`` below
+        writes a policy-derived representation to disk — the policy travels
+        into fixed container-launch flags (``--read-only``/``--tmpfs
+        /tmp``/``--network none``) baked at container-creation time, not
+        into a file this backend re-reads per call — so there is no on-disk
+        artifact a sandboxed child could rewrite. Still bears the contract
+        (owner ruling, #4434: the sandbox abstraction means every backend
+        answers it, not just the ones that currently have something to
+        cache) — caught missing this method entirely on #4439's first CI
+        run (this class lives in ``environment/``, a different directory
+        from the other 3 backends, and a hand-typed backend census missed
+        it; see ``test_sandbox_session_artifact_contract_4434.py``'s
+        registry-derived census for the structural fix)."""
+        return True
+
     def wrap_command(self, argv: list[str], policy: SandboxPolicy) -> WrappedCommand:
         """Prepend a ``docker exec`` invocation to *argv* for a PERSISTENT-process
         launch (e.g. a stdio MCP server, #2620) inside the SAME container

--- a/src/reyn/security/sandbox/_derivation_cache.py
+++ b/src/reyn/security/sandbox/_derivation_cache.py
@@ -1,0 +1,91 @@
+"""Process-wide, identity-keyed cache for a backend's policy-DERIVED
+representation (#4434 stage 1).
+
+The contract this exists for lives on ``SandboxBackend`` (see
+``backend.py``'s ``session_artifact_outside_write_scope`` docstring for the
+security precondition that gates writing a derivation to disk): a policy is
+already a session constant (``resolve_sandbox_policy`` is called from only 3
+non-per-op sites — config/loader.py, router_op_context.py,
+tools/exec.py — and the resulting object is stored on a session-scoped
+context and passed BY REFERENCE into every ``wrap_command``/``run`` call), so
+re-deriving the SAME representation from the SAME policy object on every call
+is pure waste. This module is where "derive once per (backend, policy)" is
+actually enforced, mirroring ``self_test.py``'s own process-global probe
+cache — the SAME structural reason applies here: ``get_default_backend()``
+builds a FRESH backend instance per call (including once per op, from
+``sandboxed_exec.py``), so a cache living on ``self`` never survives across
+calls; it has to live at module scope, in ONE place both callers share.
+
+Keyed by ``(backend_name, id(policy))``, not by policy CONTENT — a plain
+``SandboxPolicy`` dataclass is unhashable (list fields, no ``frozen=True``),
+and the real call pattern above means identity is both sufficient (the same
+object really is reused across a session) and simpler (no need to serialize
+a policy just to compute a cache key). Identity keys age out via a
+``weakref`` callback on *policy* itself rather than TTL/size eviction — once
+the policy object is garbage-collected, its cache entry is removed in the
+SAME step, so a future object that happens to be allocated at the same
+``id()`` can never collide with a stale entry.
+"""
+from __future__ import annotations
+
+import threading
+import weakref
+from typing import Any, Callable, TypeVar
+
+from .policy import SandboxPolicy
+
+T = TypeVar("T")
+
+_CACHE: dict[tuple[str, int], Any] = {}
+# Keeps each policy's weakref ALIVE — a `weakref.ref(obj, cb)` whose return
+# value is discarded is, in CPython, itself immediately collected (nothing
+# holds it), which silently disarms *cb*: confirmed live, a bare
+# `weakref.ref(f, cb); del f; gc.collect()` never fires `cb` unless the ref
+# object itself is kept somewhere. This dict is that "somewhere" — its own
+# entry is removed by the SAME evictor callback that clears ``_CACHE``.
+_REFS: dict[tuple[str, int], "weakref.ref[SandboxPolicy]"] = {}
+_LOCK = threading.Lock()
+
+
+def cached_derivation(
+    backend_name: str, policy: SandboxPolicy, compute: "Callable[[], T]",
+) -> T:
+    """Return the cached derivation for ``(backend_name, policy)``, computing
+    it via *compute* exactly once per (backend, policy object) per process.
+
+    *compute* runs under the lock — derivations are cold-path, cheap-to-rare
+    operations (a JSON dump; a temp-file write on a cache miss), so holding
+    the lock across it trades a small amount of contention for never racing
+    two callers into computing (and, for Seatbelt, WRITING) the same
+    derivation twice.
+    """
+    key = (backend_name, id(policy))
+    with _LOCK:
+        if key in _CACHE:
+            return _CACHE[key]
+        value = compute()
+        _CACHE[key] = value
+        _REFS[key] = weakref.ref(policy, _evictor(key))
+        return value
+
+
+def _evictor(key: tuple[str, int]) -> "Callable[[Any], None]":
+    def _evict(_ref: "Any") -> None:
+        with _LOCK:
+            _CACHE.pop(key, None)
+            _REFS.pop(key, None)
+
+    return _evict
+
+
+def _reset_cache_for_tests() -> None:
+    """Test hook: drop the process-global derivation cache."""
+    with _LOCK:
+        _CACHE.clear()
+        _REFS.clear()
+
+
+def _cache_size_for_tests() -> int:
+    """Test hook: current entry count, for asserting eviction actually ran."""
+    with _LOCK:
+        return len(_CACHE)

--- a/src/reyn/security/sandbox/backend.py
+++ b/src/reyn/security/sandbox/backend.py
@@ -259,3 +259,47 @@ class SandboxBackend(Protocol):
         ``cancelled=True``. None = no cancel-awareness (#1470).
         """
         ...
+
+
+def all_concrete_backend_classes() -> "tuple[type, ...]":
+    """Return every class reyn ships that implements the ``SandboxBackend``
+    Protocol — the single source of truth for "which backends bear this
+    Protocol's contract" (#4434, lead-coder correction: a TEST re-deriving
+    this via a filesystem/AST scan tripped ``file-depth-reference-gate.yml``
+    — a scan rooted via ``Path(__file__).resolve().parents[N]`` breaks the
+    moment the scanning file itself moves to a different depth under
+    ``tests/`` — and, independently, doing a directory walk to answer "who
+    implements this Protocol" duplicates work a stable list here does once).
+
+    Deliberately NOT auto-discovered (`Protocol` is structural typing, not a
+    registry — there is no zero-effort way to enumerate every conforming
+    class without scanning). A new backend's author is expected to add it
+    HERE, in the Protocol's own home module, where a reader implementing
+    the Protocol is far more likely to notice a companion registry than a
+    scan-based test living in an unrelated ``tests/`` file — this is how
+    #4439's own CI caught ``DockerEnvironmentBackend`` missing from an
+    earlier, ad-hoc test-side list (it lives in ``environment/``, a
+    different directory from the other 3, which a directory-scoped hand
+    list silently excluded).
+
+    ``DockerEnvironmentBackend`` is included even though it is NOT part of
+    ``get_default_backend()``'s own name-based selection table — it is
+    reachable only via explicit injection (an ``OpContext.sandbox_backend``
+    a caller constructs directly, e.g. ``sandboxed_exec.py``'s own
+    docstring on "an injected instance wins over name-based auto-
+    selection"), never via ``sandbox.backend: "docker"`` config. "Every
+    backend that bears the Protocol's contract" is a broader question than
+    "every backend ``get_default_backend()`` can select" — this function
+    answers the former.
+
+    Imports are deferred (not module-level) to avoid a real import cycle:
+    ``environment.container_backend`` imports FROM this module
+    (``AxisEnforcement`` etc.), so this module cannot import it back at
+    top-level without a cycle.
+    """
+    from reyn.environment.container_backend import DockerEnvironmentBackend  # noqa: PLC0415
+    from reyn.security.sandbox.backends.landlock import LandlockBackend  # noqa: PLC0415
+    from reyn.security.sandbox.backends.seatbelt import SeatbeltBackend  # noqa: PLC0415
+    from reyn.security.sandbox.noop_backend import NoopBackend  # noqa: PLC0415
+
+    return (SeatbeltBackend, LandlockBackend, NoopBackend, DockerEnvironmentBackend)

--- a/src/reyn/security/sandbox/backend.py
+++ b/src/reyn/security/sandbox/backend.py
@@ -191,6 +191,30 @@ class SandboxBackend(Protocol):
         """
         ...
 
+    def session_artifact_outside_write_scope(self, policy: SandboxPolicy) -> bool:
+        """#4434 (stage 1): True iff any on-disk artifact this backend may
+        cache/reuse ACROSS calls for *policy* (e.g. Seatbelt's generated SBPL
+        ``.sb`` profile) lives outside every write scope *policy* itself
+        grants.
+
+        Every backend bears this contract, not just the one that currently
+        has something to cache (owner correction, #4434: "the sandbox
+        abstraction means every backend needs the abstract contract" — a
+        Seatbelt-only precondition would leave a future backend's own
+        session-scoped artifact unguarded by construction). A backend that
+        produces no such artifact (Landlock re-execs via argv, no cleanup
+        resource of its own; NoopBackend wraps nothing) trivially satisfies
+        this and returns True unconditionally — there is nothing a
+        sandboxed child could rewrite.
+
+        Callers derive the answer from *policy* itself (e.g. resolving
+        ``policy.write_paths`` the same way the backend's own enforcement
+        does), never from a literal path comparison — the whole point is
+        that relocating either side (the cached artifact, or an operator's
+        write grant) is caught by construction.
+        """
+        ...
+
     def wrap_command(self, argv: list[str], policy: SandboxPolicy) -> WrappedCommand:
         """Return a command-level sandbox wrap of *argv* for a persistent-process
         launch (e.g. a stdio MCP server) that cannot go through the one-shot

--- a/src/reyn/security/sandbox/backends/landlock.py
+++ b/src/reyn/security/sandbox/backends/landlock.py
@@ -384,6 +384,21 @@ class LandlockBackend:
         self._available = True
         return True
 
+    def session_artifact_outside_write_scope(self, policy: SandboxPolicy) -> bool:
+        """Vacuously True (#4434, architect ruling): Landlock DOES derive a
+        policy representation once per session now
+        (``landlock_exec._cached_policy_json``), same as Seatbelt — the axis
+        that matters is derivation vs application, not "does it touch a
+        file". Landlock's derivation travels via argv straight into the
+        child's own argv, never written to disk, so there is no on-disk
+        artifact a sandboxed child could rewrite and this security clause
+        (which only bites when a derivation is materialised as a file) is
+        vacuous here — self-consciously so, not "not implemented". Still
+        bears the contract: a future Landlock change that starts writing a
+        derivation to disk would need to answer this honestly, no longer
+        vacuously."""
+        return True
+
     def wrap_command(self, argv: list[str], policy: SandboxPolicy) -> WrappedCommand:
         """Prepend the ``landlock_exec`` re-exec shim to *argv* for a
         persistent-process launch (e.g. a stdio MCP server, #1344 follow-up E).

--- a/src/reyn/security/sandbox/backends/seatbelt.py
+++ b/src/reyn/security/sandbox/backends/seatbelt.py
@@ -27,7 +27,9 @@ import shutil
 import signal
 import subprocess
 import tempfile
+from pathlib import Path
 
+from reyn.security.sandbox._derivation_cache import cached_derivation
 from reyn.security.sandbox._subprocess_io import communicate_capped, kill_process_tree
 from reyn.security.sandbox.backend import (
     AxisEnforcement,
@@ -185,6 +187,93 @@ def _build_sbpl_profile(policy: SandboxPolicy) -> str:
     return "\n".join(lines) + "\n"
 
 
+# A dedicated subdirectory of the OS temp dir, not the temp dir's root — this
+# keeps the safety check below crisp (one directory to test, not "wherever
+# tempfile.mkstemp happens to land") and keeps reyn's cached profiles visually
+# distinguishable from other processes' temp files.
+_CACHE_SUBDIR_NAME = "reyn-sandbox-profiles"
+
+
+def _seatbelt_cache_dir() -> Path:
+    """Return the directory session-cached SBPL profiles are written under.
+
+    A function, not a module-level constant, so :func:`_profile_is_safe_to_cache`
+    below always re-derives the CURRENT value rather than a value captured at
+    import time — ``tempfile.gettempdir()`` itself never changes within a
+    process, but this keeps the two functions symmetric and re-testable.
+    """
+    return Path(tempfile.gettempdir()) / _CACHE_SUBDIR_NAME
+
+
+def _profile_is_safe_to_cache(policy: SandboxPolicy) -> bool:
+    """True iff :func:`_seatbelt_cache_dir` falls OUTSIDE every write scope
+    *policy* itself grants (#4434's load-bearing precondition, architect
+    ruling: caching a profile turns its lifetime from "one call" to "the
+    session" — a sandboxed child that could WRITE to the cache path could
+    rewrite the profile that governs the NEXT command, i.e. write the key to
+    its own cage from inside it).
+
+    Derives the check from *policy.write_paths* itself (via the same
+    ``expand_policy_path`` + ``resolve`` every emitted ``(allow file-write*
+    (subpath ...))`` rule in :func:`_build_sbpl_profile` uses) rather than a
+    literal path comparison — a relocation of either side (the cache
+    directory, or an operator's write_paths) is caught by construction,
+    where a hardcoded path-string comparison would need to be remembered and
+    updated by hand.
+
+    Only the SUBPATH direction is unsafe: a write grant on ``write_paths``
+    makes that path and everything BELOW it writable, never anything above
+    it, so the cache dir being an *ancestor* of a write_paths entry is fine
+    (e.g. cache dir ``/tmp/reyn-sandbox-profiles`` and a write grant on
+    ``/tmp/reyn-sandbox-profiles/../workspace`` never overlaps the cache
+    dir's own files).
+    """
+    cache_dir = _seatbelt_cache_dir().resolve(strict=False)
+    for raw in policy.write_paths:
+        write_scope = expand_policy_path(raw).resolve(strict=False)
+        if cache_dir == write_scope or cache_dir.is_relative_to(write_scope):
+            return False
+    return True
+
+
+def _cached_profile_path(policy: SandboxPolicy, profile_text: str) -> tuple[str, bool]:
+    """Return ``(profile_path, is_cached)`` for *profile_text*.
+
+    Delegates the "derive once per (backend, policy object)" bookkeeping to
+    :func:`~reyn.security.sandbox._derivation_cache.cached_derivation`
+    (#4434 — shared across every backend that needs this, not Seatbelt-only:
+    see that module's docstring for why identity-keyed, not content-keyed).
+
+    When :func:`_profile_is_safe_to_cache` cannot prove the cache directory
+    is outside *policy*'s own write scope, the UNSAFE fallback path below
+    deliberately bypasses the shared cache entirely rather than caching the
+    "don't cache" answer — memoizing that answer under this policy's
+    identity would hand a SECOND caller the same path a first caller's
+    ``cleanup()`` had already unlinked (each unsafe call gets its own
+    private ``tempfile.NamedTemporaryFile``, unlinked on cleanup, byte-for-
+    byte the pre-#4434 behaviour). ``is_cached`` tells the caller whether
+    the returned path is a shared, session-lifetime file (do NOT unlink it
+    in ``cleanup()``) or a private, call-scoped one (DO unlink it).
+    """
+    if not _profile_is_safe_to_cache(policy):
+        with tempfile.NamedTemporaryFile(
+            suffix=".sb", mode="w", delete=False, encoding="utf-8",
+        ) as fh:
+            fh.write(profile_text)
+            return fh.name, False
+
+    def _write_cached() -> str:
+        cache_dir = _seatbelt_cache_dir()
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        fd, path = tempfile.mkstemp(suffix=".sb", dir=str(cache_dir))
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(profile_text)
+        return path
+
+    path = cached_derivation("seatbelt", policy, _write_cached)
+    return path, True
+
+
 class SeatbeltBackend:
     """macOS sandbox-exec backend (FP-0017 Component C).
 
@@ -252,22 +341,39 @@ class SeatbeltBackend:
 
         return enforcement_self_test(self)
 
+    def session_artifact_outside_write_scope(self, policy: SandboxPolicy) -> bool:
+        """#4434: delegates to :func:`_profile_is_safe_to_cache` — the ONE
+        real implementation of the ``SandboxBackend`` contract (Seatbelt is
+        the only backend that caches a filesystem artifact across calls;
+        see that Protocol method's own docstring)."""
+        return _profile_is_safe_to_cache(policy)
+
     def wrap_command(self, argv: list[str], policy: SandboxPolicy) -> WrappedCommand:
         """Prepend ``sandbox-exec -f <profile>`` to *argv* for a persistent-process
-        launch (e.g. a stdio MCP server, #1344). The SBPL profile is written to a
-        temp ``.sb`` file; the returned ``cleanup`` unlinks it — the caller invokes
-        it once the wrapped subprocess is torn down (mirrors ``run()``'s own
-        temp-profile lifecycle, above). ``env`` is the SAME allowlisted build
-        ``run()`` uses (#3822) — a caller launching the wrapped argv with this
-        env gets the identical env-scoping ``run()``'s callers get."""
+        launch (e.g. a stdio MCP server, #1344).
+
+        #4434 (stage 1): the SBPL profile is now a SESSION-scoped cache keyed
+        on *policy* (via :func:`_cached_profile_path`) rather than a fresh
+        temp file every call — an unchanged policy within one process renders
+        the identical bytes every time (architect measurement), so repeat
+        calls reuse the same on-disk path instead of regenerating + rewriting
+        it. Only genuinely per-call state (the OS temp file itself, when the
+        cache precondition can't be proven for *policy*'s write scope) still
+        gets its own unlink-on-cleanup; a CACHED path is shared across every
+        caller using this policy in the process, so ``cleanup()`` here must
+        NOT unlink it — a second caller reusing the same policy would then
+        launch ``sandbox-exec -f <a path that no longer exists>``. Cached
+        files are cleaned up at process exit (OS temp-dir housekeeping),
+        matching the profile's new session-scoped lifetime rather than the
+        old per-call one. ``env`` is the SAME allowlisted build ``run()``
+        uses (#3822) — a caller launching the wrapped argv with this env
+        gets the identical env-scoping ``run()``'s callers get."""
         profile_text = _build_sbpl_profile(policy)
-        with tempfile.NamedTemporaryFile(
-            suffix=".sb", mode="w", delete=False, encoding="utf-8",
-        ) as fh:
-            fh.write(profile_text)
-            profile_path = fh.name
+        profile_path, is_cached = _cached_profile_path(policy, profile_text)
 
         def _cleanup() -> None:
+            if is_cached:
+                return
             try:
                 os.unlink(profile_path)
             except OSError:

--- a/src/reyn/security/sandbox/landlock_exec.py
+++ b/src/reyn/security/sandbox/landlock_exec.py
@@ -41,6 +41,7 @@ import json
 import os
 import sys
 
+from ._derivation_cache import cached_derivation
 from .backends.seccomp import load_seccomp_filter, preload_native_dependency
 from .policy import SandboxPolicy
 
@@ -51,6 +52,20 @@ def _policy_to_json(policy: SandboxPolicy) -> str:
     """Serialize a SandboxPolicy to a single JSON arg (round-trips via
     :func:`_policy_from_json`)."""
     return json.dumps(dataclasses.asdict(policy), separators=(",", ":"))
+
+
+def _cached_policy_json(policy: SandboxPolicy) -> str:
+    """#4434: Landlock's policy-DERIVED representation (the JSON blob the
+    shim's ``--policy`` arg carries) is bound by the same "derive once per
+    session" contract Seatbelt's SBPL text is — architect ruling: the axis
+    is derivation vs application, not "does it touch a file", and Landlock's
+    ``build_landlock_exec_argv`` was re-deriving this JSON on every call. No
+    file is ever written (the derivation travels via argv, straight into the
+    child's own argv), so the write-scope security precondition
+    (``SandboxBackend.session_artifact_outside_write_scope``) is vacuously
+    satisfied here — there is nothing on disk a sandboxed child could
+    rewrite — but the derive-once duty itself still applies."""
+    return cached_derivation("landlock", policy, lambda: _policy_to_json(policy))
 
 
 def _policy_from_json(s: str) -> SandboxPolicy:
@@ -65,7 +80,8 @@ def build_landlock_exec_argv(
     """Return ``(executable, argv)`` that runs ``command`` under this Landlock
     policy via the re-exec shim.
 
-    Pure (no side effects) — the COMMAND-level wrap analog of the Seatbelt
+    No side effects beyond the process-wide derivation cache (#4434) — the
+    COMMAND-level wrap analog of the Seatbelt
     ``("sandbox-exec", ["-f", <profile>, command, *args])`` wrap. The returned
     ``executable`` is the current interpreter so the shim is import-resolvable
     in the same environment; ``--`` separates the shim args from the target.
@@ -74,7 +90,7 @@ def build_landlock_exec_argv(
         "-m",
         _MODULE,
         "--policy",
-        _policy_to_json(policy),
+        _cached_policy_json(policy),
         "--",
         command,
         *args,

--- a/src/reyn/security/sandbox/noop_backend.py
+++ b/src/reyn/security/sandbox/noop_backend.py
@@ -115,6 +115,15 @@ class NoopBackend:
         """
         return None
 
+    def session_artifact_outside_write_scope(self, policy: SandboxPolicy) -> bool:
+        """Trivially True (#4434): ``wrap_command`` below returns *argv*
+        UNCHANGED — no profile, no wrapper argv, no on-disk artifact of any
+        kind — so there is nothing a sandboxed child could rewrite. Still
+        bears the contract (owner correction, #4434): a future NoopBackend
+        change that starts writing something would need to answer this
+        honestly, not inherit a silent pass by omission."""
+        return True
+
     def wrap_command(self, argv: list[str], policy: SandboxPolicy) -> WrappedCommand:
         """Passthrough: argv is returned UNCHANGED — no enforcement — but the
         call still went THROUGH the sandbox abstraction (the owner-acceptable

--- a/tests/security/test_codeact_runner_1593.py
+++ b/tests/security/test_codeact_runner_1593.py
@@ -240,8 +240,9 @@ def test_seatbelt_resolve_spawn_delegates_to_wrap_command(monkeypatch) -> None:
     assert "PYTHONPATH" not in resolved_policy.env_deny_names
 
     # Same shape as a direct wrap_command() call: sandbox-exec -f <profile> <base_argv>.
-    # The profile PATH differs (each call gets its own fresh temp file), so compare
-    # everything else — the exact same code path codeact now runs.
+    # The profile PATH differs (#4434: each DISTINCT policy OBJECT gets its own
+    # session-cache entry, even when two objects render identical SBPL text), so
+    # compare everything else — the exact same code path codeact now runs.
     direct = backend.wrap_command(base_argv, SandboxPolicy(network=False, timeout_seconds=30.0))
     assert argv[0] == direct.argv[0] == "sandbox-exec"
     assert argv[1] == direct.argv[1] == "-f"
@@ -250,8 +251,14 @@ def test_seatbelt_resolve_spawn_delegates_to_wrap_command(monkeypatch) -> None:
     profile_path = argv[2]
     assert os.path.exists(profile_path)
     cleanup()
-    assert not os.path.exists(profile_path)  # cleanup unlinks the temp profile
-    direct.cleanup()  # tidy up the independently-created profile too
+    # #4434: this policy has no write_paths, so it's safe to session-cache —
+    # cleanup() on a cached profile is a no-op (a second caller reusing the
+    # same policy object would still need the file); it does NOT unlink.
+    assert os.path.exists(profile_path)
+    os.unlink(profile_path)
+    direct.cleanup()  # no-op too (direct is also cacheable) — tidy up by hand
+    if os.path.exists(direct.argv[2]):
+        os.unlink(direct.argv[2])
 
 
 def test_landlock_resolve_spawn_now_wraps_via_abstraction(monkeypatch) -> None:

--- a/tests/security/test_landlock_exec_shim_1344e.py
+++ b/tests/security/test_landlock_exec_shim_1344e.py
@@ -95,6 +95,60 @@ def test_policy_json_roundtrips_all_fields():
     assert _policy_from_json(_policy_to_json(pol)) == pol
 
 
+@pytest.fixture(autouse=True)
+def _reset_derivation_cache():
+    """Clean process-wide derivation cache per test — see
+    test_sandbox_seatbelt.py's identical fixture for why (id() reuse across
+    tests, not a production concern)."""
+    from reyn.security.sandbox import _derivation_cache
+
+    _derivation_cache._reset_cache_for_tests()
+    yield
+    _derivation_cache._reset_cache_for_tests()
+
+
+def test_build_argv_derives_the_policy_json_only_once_per_policy_object(monkeypatch):
+    """Tier 2: #4434 — Landlock is bound by the SAME "derive once per
+    session" contract Seatbelt's SBPL text is (architect ruling: the axis is
+    derivation vs application, not "does it touch a file"). Two
+    ``build_landlock_exec_argv`` calls with the SAME policy OBJECT must
+    derive the JSON exactly once — witnessed by counting real calls to
+    ``_policy_to_json`` via monkeypatch, not by comparing the two output
+    strings (which would pass even if both calls independently re-derived
+    identical JSON — see test_policy_json_call_count_flips_red_when_the_cache_is_bypassed
+    below for the strip-falsify half of this pair)."""
+    import reyn.security.sandbox.landlock_exec as le
+
+    calls = []
+    real = le._policy_to_json
+    monkeypatch.setattr(le, "_policy_to_json", lambda p: (calls.append(1), real(p))[1])
+
+    pol = SandboxPolicy(write_paths=["/ws"])
+    _exe1, argv1 = build_landlock_exec_argv(pol, "cmd", [])
+    _exe2, argv2 = build_landlock_exec_argv(pol, "cmd", [])
+    json1 = argv1[argv1.index("--policy") + 1]
+    json2 = argv2[argv2.index("--policy") + 1]
+    assert json1 == json2
+    assert calls == [1]
+
+
+def test_policy_json_call_count_flips_red_when_the_cache_is_bypassed(monkeypatch):
+    """Tier 2: strip-falsify — calling the UNCACHED ``_policy_to_json``
+    directly, twice, DOES re-derive each time — proves the previous test's
+    ``calls == [1]`` assertion is actually discriminating cached-vs-not,
+    not a tautology that would pass regardless of whether caching exists."""
+    import reyn.security.sandbox.landlock_exec as le
+
+    calls = []
+    real = le._policy_to_json
+    monkeypatch.setattr(le, "_policy_to_json", lambda p: (calls.append(1), real(p))[1])
+
+    pol = SandboxPolicy(write_paths=["/ws"])
+    le._policy_to_json(pol)
+    le._policy_to_json(pol)
+    assert calls == [1, 1]
+
+
 def test_parse_args_recovers_policy_and_target():
     """Tier 2: _parse_args inverts build_landlock_exec_argv (the shim sees the
     same policy + target the wrap encoded). The leading ``-m <module>`` is

--- a/tests/security/test_sandbox_seatbelt.py
+++ b/tests/security/test_sandbox_seatbelt.py
@@ -327,3 +327,131 @@ async def test_seatbelt_allows_socketpair_sendto_but_denies_addressed_sendto_whe
 def test_seatbelt_conforms_to_sandbox_backend_protocol():
     """Tier 2: SeatbeltBackend satisfies the runtime-checkable SandboxBackend Protocol."""
     assert isinstance(SeatbeltBackend(), SandboxBackend)
+
+
+# ─── 6. Session-scoped profile cache (#4434 stage 1) ─────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_derivation_cache():
+    """Every test in this module gets a clean process-wide derivation cache —
+    without this, a policy object from an earlier test could still be alive
+    (e.g. held by a still-open temp-file handle) and collide by id() with a
+    freshly-constructed policy in a LATER test, since id() reuse is exactly
+    the failure mode ``_derivation_cache``'s weakref eviction exists to
+    close for production, not for a same-process test run reusing whatever
+    ids happen to be free."""
+    from reyn.security.sandbox import _derivation_cache
+
+    _derivation_cache._reset_cache_for_tests()
+    yield
+    _derivation_cache._reset_cache_for_tests()
+
+
+def test_seatbelt_cache_dir_is_outside_a_realistic_write_scope():
+    """Tier 2: #4434's load-bearing precondition, derived from the policy
+    object (via the same expand_policy_path + resolve every emitted SBPL
+    write-grant uses) — not a literal path comparison. Exercises the 3 real
+    write_paths shapes issue #4434 measured (config/loader.py's empty
+    default, router_op_context.py's workspace dir, and an explicit path)."""
+    from pathlib import Path
+
+    from reyn.security.sandbox.backends.seatbelt import (
+        _profile_is_safe_to_cache,
+        _seatbelt_cache_dir,
+    )
+
+    cache_dir = _seatbelt_cache_dir().resolve(strict=False)
+
+    for write_paths in ([], [str(Path.cwd())], ["~/some/workspace"]):
+        policy = SandboxPolicy(write_paths=write_paths)
+        assert _profile_is_safe_to_cache(policy) is True
+        for raw in policy.write_paths:
+            write_scope = expand_policy_path(raw).resolve(strict=False)
+            assert cache_dir != write_scope
+            assert not cache_dir.is_relative_to(write_scope)
+
+
+def test_seatbelt_cache_unsafe_when_write_scope_relocates_onto_the_cache_dir():
+    """Tier 2: strip-falsify — moving a policy's write_paths to cover the
+    cache directory — the exact relocation #4434's precondition exists to
+    catch — flips ``_profile_is_safe_to_cache`` to False. Proves the check
+    is a real, live derivation from the policy object, not a check that
+    would stay green regardless of what write_paths says."""
+    from reyn.security.sandbox.backends.seatbelt import (
+        _profile_is_safe_to_cache,
+        _seatbelt_cache_dir,
+    )
+
+    cache_dir = _seatbelt_cache_dir()
+
+    # Exact match — the write grant covers the cache dir itself.
+    assert _profile_is_safe_to_cache(SandboxPolicy(write_paths=[str(cache_dir)])) is False
+    # write_scope is an ANCESTOR of the cache dir (grant on the PARENT) —
+    # cache_dir is a descendant of the grant, so it's covered too: unsafe.
+    assert _profile_is_safe_to_cache(
+        SandboxPolicy(write_paths=[str(cache_dir.parent)]),
+    ) is False
+    # write_scope is a DESCENDANT of the cache dir (grant on a CHILD) — the
+    # subpath grant covers only that child and below, never its own parent
+    # (the cache dir itself), so this is safe.
+    assert _profile_is_safe_to_cache(
+        SandboxPolicy(write_paths=[str(cache_dir / "nested")]),
+    ) is True
+
+
+def test_seatbelt_wrap_command_reuses_the_same_profile_path_for_the_same_policy():
+    """Tier 2: #4434 — two wrap_command() calls with the SAME policy object
+    return the same on-disk profile path (the session-cache hit), and the
+    file's content matches what _build_sbpl_profile derives for that policy
+    — a real, on-disk witness that the cached path is not a stale/blank
+    file, not just path-string equality."""
+    from reyn.security.sandbox.backends.seatbelt import _build_sbpl_profile
+
+    backend = SeatbeltBackend()
+    policy = SandboxPolicy(write_paths=[])
+
+    wrapped1 = backend.wrap_command(["/bin/echo", "hi"], policy)
+    wrapped2 = backend.wrap_command(["/bin/echo", "hi"], policy)
+
+    path1 = wrapped1.argv[wrapped1.argv.index("-f") + 1]
+    path2 = wrapped2.argv[wrapped2.argv.index("-f") + 1]
+    assert path1 == path2
+
+    with open(path1, encoding="utf-8") as fh:
+        assert fh.read() == _build_sbpl_profile(policy)
+
+    # cleanup() on a cached path must be a no-op (a second caller sharing
+    # this policy still needs the file); confirmed by asserting it survives.
+    wrapped1.cleanup()
+    assert __import__("os").path.exists(path1)
+
+    import os
+
+    os.unlink(path1)
+
+
+def test_seatbelt_wrap_command_does_not_cache_when_write_scope_is_unsafe():
+    """Tier 2: strip-falsify — a policy whose write_paths covers the cache
+    directory gets an UNCACHED, per-call profile (pre-#4434 behaviour) —
+    two calls get DIFFERENT paths, and cleanup() DOES unlink. Proves the
+    safety check is load-bearing on the actual wrap_command() path, not
+    just on the helper function in isolation."""
+    from reyn.security.sandbox.backends.seatbelt import _seatbelt_cache_dir
+
+    backend = SeatbeltBackend()
+    policy = SandboxPolicy(write_paths=[str(_seatbelt_cache_dir())])
+
+    wrapped1 = backend.wrap_command(["/bin/echo", "hi"], policy)
+    wrapped2 = backend.wrap_command(["/bin/echo", "hi"], policy)
+
+    path1 = wrapped1.argv[wrapped1.argv.index("-f") + 1]
+    path2 = wrapped2.argv[wrapped2.argv.index("-f") + 1]
+    assert path1 != path2
+
+    import os
+
+    assert os.path.exists(path1)
+    wrapped1.cleanup()
+    assert not os.path.exists(path1)
+    wrapped2.cleanup()

--- a/tests/security/test_sandbox_session_artifact_contract_4434.py
+++ b/tests/security/test_sandbox_session_artifact_contract_4434.py
@@ -11,120 +11,54 @@ self-consciously rather than by accident (e.g. the enumeration silently
 shrinking to fewer backends, or a backend inheriting an unimplemented default
 that happens to return something truthy).
 
-#4439 CI (this arc's own PR) caught the census hand-typed here missing a 4th
-implementer, ``DockerEnvironmentBackend`` — it lives under ``environment/``,
-a DIFFERENT directory from the other 3 (``security/sandbox/``), so a
-directory-scoped hand list silently excluded it. The fix is structural, not
-"add the 4th name": the census below is derived from an AST scan of the
-WHOLE ``src/reyn`` tree for any class defining every ``SandboxBackend``
-method by name — a real, repo-wide source, not a hand-maintained list a 5th
-implementer could miss the same way.
+#4439 CI (this arc's own PR) caught TWO successive shapes of this census
+being wrong, in order:
+  1. a hand-typed 3-tuple missed ``DockerEnvironmentBackend`` (lives under
+     ``environment/``, a different directory from the other 3).
+  2. the fix for (1) — an AST scan of ``src/reyn`` rooted at
+     ``Path(__file__).resolve().parents[N]`` — tripped
+     ``file-depth-reference-gate.yml`` (lead-coder correction): that kind of
+     reference breaks the moment the SCANNING file itself moves to a
+     different depth under ``tests/``, and doing a directory walk from a
+     test to answer "who implements this Protocol" duplicates work a
+     stable source should do once.
+
+The actual fix (both times) is structural, not "patch the list": the census
+now reads ``reyn.security.sandbox.backend.all_concrete_backend_classes()`` —
+a single, explicit registry living in the Protocol's own home module — so a
+future backend author has one place to update, discoverable at the same
+place they implement the Protocol, and no test needs to re-derive it via a
+filesystem/AST scan of any kind.
 """
 from __future__ import annotations
 
-import ast
-import pathlib
-
-from reyn.security.sandbox.backend import SandboxBackend
+from reyn.environment.container_backend import DockerEnvironmentBackend
+from reyn.security.sandbox.backend import SandboxBackend, all_concrete_backend_classes
 from reyn.security.sandbox.backends.landlock import LandlockBackend
 from reyn.security.sandbox.backends.seatbelt import SeatbeltBackend
 from reyn.security.sandbox.noop_backend import NoopBackend
 from reyn.security.sandbox.policy import SandboxPolicy
 
-_REPO_SRC = pathlib.Path(__file__).resolve().parents[2] / "src" / "reyn"
-
-# The exact SandboxBackend Protocol method names (backend.py) — a class
-# defining every one of these, structurally, is a real implementer. This is
-# an AST scan (no import/construction needed), so it also finds classes like
-# DockerEnvironmentBackend whose __init__ requires real arguments.
-_PROTOCOL_METHOD_NAMES = frozenset(
-    {"available", "self_test", "wrap_command", "run", "session_artifact_outside_write_scope"},
-)
-
-
-def _scan_backend_class_locations() -> "list[tuple[str, str]]":
-    """Return ``(relative_file_path, class_name)`` for every class under
-    ``src/reyn`` that defines ALL of ``_PROTOCOL_METHOD_NAMES`` — excludes
-    the Protocol definition itself (``SandboxBackend``, whose bases include
-    ``Protocol``)."""
-    found: "list[tuple[str, str]]" = []
-    for path in sorted(_REPO_SRC.rglob("*.py")):
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.ClassDef):
-                continue
-            is_protocol_def = any("Protocol" in ast.dump(b) for b in node.bases)
-            if is_protocol_def:
-                continue
-            method_names = {
-                n.name for n in node.body
-                if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
-            }
-            if _PROTOCOL_METHOD_NAMES.issubset(method_names):
-                found.append((str(path.relative_to(_REPO_SRC)), node.name))
-    return found
-
 
 def test_the_concrete_backend_enumeration_has_not_silently_shrunk():
-    """Tier 2: vacuity guard — the AST-derived census of every class under
-    ``src/reyn`` structurally implementing the full SandboxBackend Protocol
-    names exactly the 4 real implementers. If a future backend is added (or
-    one is accidentally removed / fails to implement a method), this
-    assertion is what goes RED — not a hand-typed list a 5th implementer in
-    a new directory could miss the same way #4439's CI caught the 4th."""
-    found = _scan_backend_class_locations()
-    assert {cls_name for _path, cls_name in found} == {
+    """Tier 2: vacuity guard — ``all_concrete_backend_classes()`` names
+    exactly the 4 real implementers. If a future backend is added (or one
+    is accidentally removed / renamed in the registry), this assertion is
+    what goes RED — not a test silently covering fewer backends and
+    staying green regardless."""
+    found = all_concrete_backend_classes()
+    assert {cls.__name__ for cls in found} == {
         "SeatbeltBackend", "LandlockBackend", "NoopBackend", "DockerEnvironmentBackend",
     }
-
-
-def test_every_scanned_backend_class_is_importable_and_conforms_to_the_protocol():
-    """Tier 2: every class the AST scan found is actually importable from
-    the module the scan found it in, and — where constructible with no
-    arguments — satisfies the runtime-checkable SandboxBackend Protocol.
-    Closes the gap a pure AST scan alone leaves open: a class could define
-    all 5 method NAMES without their signatures actually matching the
-    Protocol (isinstance() checks that structurally, AST scanning doesn't).
-    ``DockerEnvironmentBackend`` requires real constructor args (container,
-    repo_dir) — it's exempted from the isinstance leg here and covered
-    directly by its own dedicated test below instead."""
-    import importlib
-
-    found = _scan_backend_class_locations()
-    assert found, "AST scan found zero backend classes — collection itself is broken"
-
-    for rel_path, cls_name in found:
-        module_name = "reyn." + rel_path[:-3].replace("/", ".")
-        module = importlib.import_module(module_name)
-        cls = getattr(module, cls_name)
-        if cls_name == "DockerEnvironmentBackend":
-            continue  # covered by test_docker_backend_implements_the_contract below
-        assert isinstance(cls(), SandboxBackend), (
-            f"{module_name}.{cls_name} defines every Protocol method NAME but "
-            "does not structurally satisfy SandboxBackend"
-        )
-
-
-def test_docker_backend_implements_the_contract():
-    """Tier 2: DockerEnvironmentBackend (#4439 CI's own catch — see module
-    docstring) answers session_artifact_outside_write_scope, vacuously True
-    (docker exec never writes a policy-derived file to the host)."""
-    from reyn.environment.container_backend import DockerEnvironmentBackend
-
-    backend = DockerEnvironmentBackend(container="reyn-test-container", repo_dir="/repo")
-    assert isinstance(backend, SandboxBackend)
-    result = backend.session_artifact_outside_write_scope(SandboxPolicy(write_paths=["/repo"]))
-    assert result is True
 
 
 def test_every_backend_implements_the_contract_and_conforms_to_the_protocol():
     """Tier 2: every concrete backend (a) satisfies the runtime-checkable
     SandboxBackend Protocol (which now includes
     session_artifact_outside_write_scope) and (b) returns a real bool, not
-    None/NotImplemented, for a representative policy — a backend that
-    forgot to override the Protocol method would fail (a). Scoped to the 3
+    None/NotImplemented, for a representative policy. Scoped to the 3
     no-arg-constructible backends; DockerEnvironmentBackend has its own
-    dedicated test above."""
+    dedicated test below (its constructor requires real arguments)."""
     policy = SandboxPolicy(write_paths=["/some/workspace"])
     for cls in (SeatbeltBackend, LandlockBackend, NoopBackend):
         backend = cls()
@@ -134,6 +68,19 @@ def test_every_backend_implements_the_contract_and_conforms_to_the_protocol():
             f"{cls.__name__}.session_artifact_outside_write_scope() returned "
             f"{result!r}, not a bool"
         )
+
+
+def test_docker_backend_implements_the_contract():
+    """Tier 2: DockerEnvironmentBackend (#4439 CI's own catch — see module
+    docstring) is IN the registry and answers
+    session_artifact_outside_write_scope, vacuously True (docker exec never
+    writes a policy-derived file to the host)."""
+    assert DockerEnvironmentBackend in all_concrete_backend_classes()
+
+    backend = DockerEnvironmentBackend(container="reyn-test-container", repo_dir="/repo")
+    assert isinstance(backend, SandboxBackend)
+    result = backend.session_artifact_outside_write_scope(SandboxPolicy(write_paths=["/repo"]))
+    assert result is True
 
 
 def test_only_seatbelt_answers_non_vacuously_today():

--- a/tests/security/test_sandbox_session_artifact_contract_4434.py
+++ b/tests/security/test_sandbox_session_artifact_contract_4434.py
@@ -1,0 +1,83 @@
+"""Tier 2: SandboxBackend.session_artifact_outside_write_scope contract (#4434
+stage 1) — every concrete backend bears this contract (owner ruling: the
+sandbox abstraction means every backend needs the abstract contract, not just
+the one implementation that currently has real content to protect).
+
+This file's job is the CROSS-backend piece two single-backend test files
+(test_sandbox_seatbelt.py, test_landlock_exec_shim_1344e.py) cannot cover on
+their own: that the full concrete-backend set is actually exercised, and that
+a backend answering "vacuously True" (nothing on disk to protect) does so
+self-consciously rather than by accident (e.g. the enumeration silently
+shrinking to fewer backends, or a backend inheriting an unimplemented default
+that happens to return something truthy).
+"""
+from __future__ import annotations
+
+from reyn.security.sandbox.backend import SandboxBackend
+from reyn.security.sandbox.backends.landlock import LandlockBackend
+from reyn.security.sandbox.backends.seatbelt import SeatbeltBackend
+from reyn.security.sandbox.noop_backend import NoopBackend
+from reyn.security.sandbox.policy import SandboxPolicy
+
+# The same 3 concrete classes get_default_backend() (security/sandbox/__init__.py)
+# lazy-imports and dispatches to for backend="seatbelt"/"landlock"/"noop" — this
+# list is not independently invented, it mirrors that function's own registry.
+_ALL_BACKEND_CLASSES = (SeatbeltBackend, LandlockBackend, NoopBackend)
+
+
+def test_the_concrete_backend_enumeration_has_not_silently_shrunk():
+    """Tier 2: vacuity guard — the census this file's other tests iterate
+    over names exactly the 3 concrete backends get_default_backend()
+    dispatches to. If a future change removes a backend class from this
+    enumeration (accidentally or via an import failure this file doesn't
+    otherwise notice), this is the assertion that goes RED instead of every
+    downstream test silently covering fewer backends and staying green
+    regardless."""
+    assert {cls.__name__ for cls in _ALL_BACKEND_CLASSES} == {
+        "SeatbeltBackend", "LandlockBackend", "NoopBackend",
+    }
+
+
+def test_every_backend_implements_the_contract_and_conforms_to_the_protocol():
+    """Tier 2: every concrete backend (a) satisfies the runtime-checkable
+    SandboxBackend Protocol (which now includes
+    session_artifact_outside_write_scope) and (b) returns a real bool, not
+    None/NotImplemented, for a representative policy — a backend that
+    forgot to override the Protocol method would fail (a).
+    """
+    policy = SandboxPolicy(write_paths=["/some/workspace"])
+    for cls in _ALL_BACKEND_CLASSES:
+        backend = cls()
+        assert isinstance(backend, SandboxBackend), f"{cls.__name__} breaks Protocol conformance"
+        result = backend.session_artifact_outside_write_scope(policy)
+        assert isinstance(result, bool), (
+            f"{cls.__name__}.session_artifact_outside_write_scope() returned "
+            f"{result!r}, not a bool"
+        )
+
+
+def test_only_seatbelt_answers_non_vacuously_today():
+    """Tier 2: names which backend's answer is a REAL derivation from
+    *policy* (Seatbelt: materialises a file, so relocating write_paths onto
+    the cache dir must flip its answer) versus VACUOUSLY True regardless of
+    *policy* (Landlock, Noop: nothing is ever written to disk, so no
+    write_paths value can make their answer False today). Distinguishing
+    the two here is the point of this file — a vacuous True and a
+    load-bearing True read identically as a bare boolean; this test is what
+    tells them apart, so a future backend added to _ALL_BACKEND_CLASSES
+    that silently returns a vacuous True while actually writing a file
+    would be caught by test_seatbelt_cache_unsafe_when_write_scope_relocates_onto_the_cache_dir's
+    OWN discipline being absent for it, not by this test — but this test at
+    least documents which backends currently claim vacuity, so a reviewer
+    adding a 4th backend has a checklist to extend."""
+    from reyn.security.sandbox.backends.seatbelt import _seatbelt_cache_dir
+
+    adversarial_policy = SandboxPolicy(write_paths=[str(_seatbelt_cache_dir())])
+    assert SeatbeltBackend().session_artifact_outside_write_scope(adversarial_policy) is False
+
+    # Landlock/Noop never touch disk, so even this adversarial policy (which
+    # only means anything relative to SEATBELT's own cache dir) can't flip
+    # them — their vacuous True is unconditional, which is exactly what
+    # "vacuous" means here, not a gap in the check.
+    assert LandlockBackend().session_artifact_outside_write_scope(adversarial_policy) is True
+    assert NoopBackend().session_artifact_outside_write_scope(adversarial_policy) is True

--- a/tests/security/test_sandbox_session_artifact_contract_4434.py
+++ b/tests/security/test_sandbox_session_artifact_contract_4434.py
@@ -10,8 +10,20 @@ a backend answering "vacuously True" (nothing on disk to protect) does so
 self-consciously rather than by accident (e.g. the enumeration silently
 shrinking to fewer backends, or a backend inheriting an unimplemented default
 that happens to return something truthy).
+
+#4439 CI (this arc's own PR) caught the census hand-typed here missing a 4th
+implementer, ``DockerEnvironmentBackend`` — it lives under ``environment/``,
+a DIFFERENT directory from the other 3 (``security/sandbox/``), so a
+directory-scoped hand list silently excluded it. The fix is structural, not
+"add the 4th name": the census below is derived from an AST scan of the
+WHOLE ``src/reyn`` tree for any class defining every ``SandboxBackend``
+method by name — a real, repo-wide source, not a hand-maintained list a 5th
+implementer could miss the same way.
 """
 from __future__ import annotations
+
+import ast
+import pathlib
 
 from reyn.security.sandbox.backend import SandboxBackend
 from reyn.security.sandbox.backends.landlock import LandlockBackend
@@ -19,23 +31,90 @@ from reyn.security.sandbox.backends.seatbelt import SeatbeltBackend
 from reyn.security.sandbox.noop_backend import NoopBackend
 from reyn.security.sandbox.policy import SandboxPolicy
 
-# The same 3 concrete classes get_default_backend() (security/sandbox/__init__.py)
-# lazy-imports and dispatches to for backend="seatbelt"/"landlock"/"noop" — this
-# list is not independently invented, it mirrors that function's own registry.
-_ALL_BACKEND_CLASSES = (SeatbeltBackend, LandlockBackend, NoopBackend)
+_REPO_SRC = pathlib.Path(__file__).resolve().parents[2] / "src" / "reyn"
+
+# The exact SandboxBackend Protocol method names (backend.py) — a class
+# defining every one of these, structurally, is a real implementer. This is
+# an AST scan (no import/construction needed), so it also finds classes like
+# DockerEnvironmentBackend whose __init__ requires real arguments.
+_PROTOCOL_METHOD_NAMES = frozenset(
+    {"available", "self_test", "wrap_command", "run", "session_artifact_outside_write_scope"},
+)
+
+
+def _scan_backend_class_locations() -> "list[tuple[str, str]]":
+    """Return ``(relative_file_path, class_name)`` for every class under
+    ``src/reyn`` that defines ALL of ``_PROTOCOL_METHOD_NAMES`` — excludes
+    the Protocol definition itself (``SandboxBackend``, whose bases include
+    ``Protocol``)."""
+    found: "list[tuple[str, str]]" = []
+    for path in sorted(_REPO_SRC.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            is_protocol_def = any("Protocol" in ast.dump(b) for b in node.bases)
+            if is_protocol_def:
+                continue
+            method_names = {
+                n.name for n in node.body
+                if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+            }
+            if _PROTOCOL_METHOD_NAMES.issubset(method_names):
+                found.append((str(path.relative_to(_REPO_SRC)), node.name))
+    return found
 
 
 def test_the_concrete_backend_enumeration_has_not_silently_shrunk():
-    """Tier 2: vacuity guard — the census this file's other tests iterate
-    over names exactly the 3 concrete backends get_default_backend()
-    dispatches to. If a future change removes a backend class from this
-    enumeration (accidentally or via an import failure this file doesn't
-    otherwise notice), this is the assertion that goes RED instead of every
-    downstream test silently covering fewer backends and staying green
-    regardless."""
-    assert {cls.__name__ for cls in _ALL_BACKEND_CLASSES} == {
-        "SeatbeltBackend", "LandlockBackend", "NoopBackend",
+    """Tier 2: vacuity guard — the AST-derived census of every class under
+    ``src/reyn`` structurally implementing the full SandboxBackend Protocol
+    names exactly the 4 real implementers. If a future backend is added (or
+    one is accidentally removed / fails to implement a method), this
+    assertion is what goes RED — not a hand-typed list a 5th implementer in
+    a new directory could miss the same way #4439's CI caught the 4th."""
+    found = _scan_backend_class_locations()
+    assert {cls_name for _path, cls_name in found} == {
+        "SeatbeltBackend", "LandlockBackend", "NoopBackend", "DockerEnvironmentBackend",
     }
+
+
+def test_every_scanned_backend_class_is_importable_and_conforms_to_the_protocol():
+    """Tier 2: every class the AST scan found is actually importable from
+    the module the scan found it in, and — where constructible with no
+    arguments — satisfies the runtime-checkable SandboxBackend Protocol.
+    Closes the gap a pure AST scan alone leaves open: a class could define
+    all 5 method NAMES without their signatures actually matching the
+    Protocol (isinstance() checks that structurally, AST scanning doesn't).
+    ``DockerEnvironmentBackend`` requires real constructor args (container,
+    repo_dir) — it's exempted from the isinstance leg here and covered
+    directly by its own dedicated test below instead."""
+    import importlib
+
+    found = _scan_backend_class_locations()
+    assert found, "AST scan found zero backend classes — collection itself is broken"
+
+    for rel_path, cls_name in found:
+        module_name = "reyn." + rel_path[:-3].replace("/", ".")
+        module = importlib.import_module(module_name)
+        cls = getattr(module, cls_name)
+        if cls_name == "DockerEnvironmentBackend":
+            continue  # covered by test_docker_backend_implements_the_contract below
+        assert isinstance(cls(), SandboxBackend), (
+            f"{module_name}.{cls_name} defines every Protocol method NAME but "
+            "does not structurally satisfy SandboxBackend"
+        )
+
+
+def test_docker_backend_implements_the_contract():
+    """Tier 2: DockerEnvironmentBackend (#4439 CI's own catch — see module
+    docstring) answers session_artifact_outside_write_scope, vacuously True
+    (docker exec never writes a policy-derived file to the host)."""
+    from reyn.environment.container_backend import DockerEnvironmentBackend
+
+    backend = DockerEnvironmentBackend(container="reyn-test-container", repo_dir="/repo")
+    assert isinstance(backend, SandboxBackend)
+    result = backend.session_artifact_outside_write_scope(SandboxPolicy(write_paths=["/repo"]))
+    assert result is True
 
 
 def test_every_backend_implements_the_contract_and_conforms_to_the_protocol():
@@ -43,10 +122,11 @@ def test_every_backend_implements_the_contract_and_conforms_to_the_protocol():
     SandboxBackend Protocol (which now includes
     session_artifact_outside_write_scope) and (b) returns a real bool, not
     None/NotImplemented, for a representative policy — a backend that
-    forgot to override the Protocol method would fail (a).
-    """
+    forgot to override the Protocol method would fail (a). Scoped to the 3
+    no-arg-constructible backends; DockerEnvironmentBackend has its own
+    dedicated test above."""
     policy = SandboxPolicy(write_paths=["/some/workspace"])
-    for cls in _ALL_BACKEND_CLASSES:
+    for cls in (SeatbeltBackend, LandlockBackend, NoopBackend):
         backend = cls()
         assert isinstance(backend, SandboxBackend), f"{cls.__name__} breaks Protocol conformance"
         result = backend.session_artifact_outside_write_scope(policy)
@@ -60,16 +140,8 @@ def test_only_seatbelt_answers_non_vacuously_today():
     """Tier 2: names which backend's answer is a REAL derivation from
     *policy* (Seatbelt: materialises a file, so relocating write_paths onto
     the cache dir must flip its answer) versus VACUOUSLY True regardless of
-    *policy* (Landlock, Noop: nothing is ever written to disk, so no
-    write_paths value can make their answer False today). Distinguishing
-    the two here is the point of this file — a vacuous True and a
-    load-bearing True read identically as a bare boolean; this test is what
-    tells them apart, so a future backend added to _ALL_BACKEND_CLASSES
-    that silently returns a vacuous True while actually writing a file
-    would be caught by test_seatbelt_cache_unsafe_when_write_scope_relocates_onto_the_cache_dir's
-    OWN discipline being absent for it, not by this test — but this test at
-    least documents which backends currently claim vacuity, so a reviewer
-    adding a 4th backend has a checklist to extend."""
+    *policy* (Landlock, Noop, Docker: nothing is ever written to disk, so no
+    write_paths value can make their answer False today)."""
     from reyn.security.sandbox.backends.seatbelt import _seatbelt_cache_dir
 
     adversarial_policy = SandboxPolicy(write_paths=[str(_seatbelt_cache_dir())])

--- a/tests/security/test_sandbox_wrap_command_2620.py
+++ b/tests/security/test_sandbox_wrap_command_2620.py
@@ -8,8 +8,12 @@ MCPClient caller, covered separately in test_mcp_client_sandbox_wrap.py):
 
 - NoopBackend: argv unchanged, no cleanup — passthrough THROUGH the
   abstraction, not a bypass.
-- SeatbeltBackend: prepends sandbox-exec -f <profile>; cleanup unlinks the
-  temp profile.
+- SeatbeltBackend: prepends sandbox-exec -f <profile>. #4434 (stage 1): for a
+  policy whose write scope provably excludes the session-cache directory, the
+  profile is a SHARED, session-lifetime file and cleanup() is a no-op (a
+  second caller reusing the same policy still needs it); only when that
+  precondition can't be proven does cleanup() unlink a private, per-call
+  file — see test_sandbox_seatbelt.py's own #4434 section for both cases.
 - LandlockBackend: prepends the landlock_exec re-exec shim; no cleanup
   resource owned.
 
@@ -50,10 +54,16 @@ def test_noop_wrap_command_does_not_mutate_input_argv():
     assert argv == ["cmd", "a"]  # caller's list untouched
 
 
-def test_seatbelt_wrap_command_prepends_sandbox_exec(tmp_path):
+def test_seatbelt_wrap_command_prepends_sandbox_exec():
     """Tier 2: SeatbeltBackend.wrap_command prepends sandbox-exec -f <profile>,
     the profile is a real deny-default SBPL, and the trailing argv is the
-    original command unchanged."""
+    original command unchanged.
+
+    #4434 (stage 1): a bare ``SandboxPolicy()`` (empty write_paths) is safe
+    to session-cache, so its profile is SHARED — cleanup() on it is a no-op
+    by design (a second caller reusing this policy still needs the file);
+    see test_seatbelt_wrap_command_does_not_cache_when_write_scope_is_unsafe
+    in test_sandbox_seatbelt.py for the DOES-unlink case."""
     backend = SeatbeltBackend()
     wrapped = backend.wrap_command(["my-server", "--flag"], SandboxPolicy())
     assert wrapped.argv[0] == "sandbox-exec"
@@ -67,15 +77,29 @@ def test_seatbelt_wrap_command_prepends_sandbox_exec(tmp_path):
     assert wrapped.cleanup is not None
     assert profile_path.exists()
     wrapped.cleanup()
-    assert not profile_path.exists()  # cleanup unlinks the temp profile
+    assert profile_path.exists()  # cached (session-lifetime): cleanup() is a no-op
+
+    import os
+
+    os.unlink(profile_path)  # tidy up the shared cache file this test wrote
 
 
 def test_seatbelt_wrap_command_cleanup_idempotent():
-    """Tier 2: calling cleanup twice must not raise (best-effort unlink)."""
+    """Tier 2: calling cleanup twice must not raise, on both the cached
+    (no-op) path and the uncached (best-effort unlink) path."""
+    from reyn.security.sandbox.backends.seatbelt import _seatbelt_cache_dir
+
     backend = SeatbeltBackend()
-    wrapped = backend.wrap_command(["cmd"], SandboxPolicy())
-    wrapped.cleanup()
-    wrapped.cleanup()  # must not raise on a missing file
+
+    cached = backend.wrap_command(["cmd"], SandboxPolicy())
+    cached.cleanup()
+    cached.cleanup()  # no-op both times — must not raise
+
+    uncached = backend.wrap_command(
+        ["cmd"], SandboxPolicy(write_paths=[str(_seatbelt_cache_dir())]),
+    )
+    uncached.cleanup()
+    uncached.cleanup()  # must not raise on a missing file
 
 
 def test_landlock_wrap_command_uses_reexec_shim():


### PR DESCRIPTION
**[e2e-coder]** — implements architect's final design for #4434 (stage 1), after 3 rounds of scope correction on the issue, all read in full before implementing (not from a stale broker relay).

Closes #4434

## What this does

Every `SandboxPolicy` object is already a session constant (only 3 non-per-op call sites of `resolve_sandbox_policy`, each storing the result on a session-scoped context and passing it by reference into every op). Re-deriving the same policy-derived representation on every `wrap_command`/`run` call was pure waste — this PR makes "derive once per (backend, policy object) per process" a real `SandboxBackend` Protocol contract, not a Seatbelt-only optimization (owner: "it's the sandbox abstraction, so every backend needs the abstract contract").

- **New**: `_derivation_cache.py` — process-wide, identity-keyed cache (mirrors `self_test.py`'s own process-global cache; required because `get_default_backend()` builds a fresh instance per op, so a cache on `self` never survives).
- **New Protocol method**: `SandboxBackend.session_artifact_outside_write_scope(policy)` — the security precondition (a cached on-disk artifact must never fall inside the policy's own write scope, or a sandboxed child could rewrite the profile governing the next command).
- **Seatbelt**: the SBPL profile is now cached per (session, policy object), written under a dedicated cache dir ONLY when provably outside the policy's write scope (derived from the policy object, never a literal path comparison). Falls back to the old uncached-and-unlinked-on-cleanup path otherwise.
- **Landlock**: `build_landlock_exec_argv`'s policy→JSON derivation now goes through the same cache — no file is ever written (travels via argv), so the security clause is vacuously satisfied, but the derive-once duty is real (architect: the axis is derivation vs application, not "does it touch a file" — a correction posted mid-implementation, read before continuing).
- **Noop/Landlock**: implement the Protocol method, vacuously True, self-consciously documented as such (not a silent inherited default).

## Non-goals (architect, explicit)

Stage 2 (persistent sandboxed process), stage 3 (fork/exec elimination), the container exec-per-op path, and seccomp filter *application* (irrevocable per-child by construction — caching it has no meaning, not "not yet done").

## Test plan / CLAUDE.md 6 questions

- `test_seatbelt_wrap_command_reuses_the_same_profile_path_for_the_same_policy` / `test_seatbelt_wrap_command_does_not_cache_when_write_scope_is_unsafe`: **Tier 2**. Not the implementation transcribed — asserts on-disk content + real cleanup side effects, not internal state. **Q3**: every consumer of `wrap_command` for a persistent-process launch (stdio MCP, CodeAct). Would stay green having never run only if collection itself broke — both execute real file I/O.
- `test_seatbelt_cache_unsafe_when_write_scope_relocates_onto_the_cache_dir`: **Tier 2, strip-falsify**. Exercises exact-match, ancestor, and descendant relocations of the cache dir — the ancestor/descendant asymmetry is the actual SBPL `subpath` semantics, not incidental.
- `test_build_argv_derives_the_policy_json_only_once_per_policy_object` / its strip-falsify twin `test_policy_json_call_count_flips_red_when_the_cache_is_bypassed`: **Tier 2**. The twin exists because "two calls return equal strings" alone doesn't discriminate cached-vs-independently-re-derived-but-deterministic — the twin proves the call-counter would actually catch a bypass.
- `test_sandbox_session_artifact_contract_4434.py` (3 tests): **Tier 2, vacuity guard**. `test_the_concrete_backend_enumeration_has_not_silently_shrunk` answers Q3 directly — a reviewer relying on "all backends checked" would be wrongly reassured if the census silently shrank; asserted against an explicit named set, not a bare count (test_tier_audit flagged the bare-count form as Tier 4 format-pinning — fixed, not worked around).
- Weakref eviction: isolated-repro'd live that an unstored `weakref.ref(obj, cb)` never fires `cb` (confirmed via a throwaway script before writing the fix, not assumed from memory) — fixed by holding the ref in a companion dict.
- 2 pre-existing tests (`test_sandbox_wrap_command_2620.py`, `test_codeact_runner_1593.py`) broke on this branch — their premise ("cleanup() unlinks the profile") is now false for the default/safe-to-cache case. Fixed with an explanation of the new no-op-on-cache semantics in the same PR, not silently patched around or deferred.

Falsify-verified end to end: `tests/security/` + `test_2978_deny_always_wins.py` — **751 passed, 26 skipped**, on a fresh `main` base (this branch was rebuilt off `origin/main` after the design churn, not carried over from a stale checkout).

Local gates: ruff / `test_tier_audit.py --strict` / `verify_module_docstrings.py` / `mypy_ratchet.py` / `check_tests_path_literal_reference.py` — all clean, path-literal gate re-run immediately before this push.

## Manual / Visual

- [ ] (skipped — no visual/TTY surface; this is a security/backend-internal change)

⚠️ Touches `tests/` — self-merge is blocked pending a TESTS-READ note from a reviewing session (lead-coder's own instruction on the issue).
