### PR TITLE
fix(#4431): a truncated load_skill result can actually be resumed

### DIFF
--- a/src/reyn/core/op_runtime/load_skill.py
+++ b/src/reyn/core/op_runtime/load_skill.py
@@ -258,10 +258,45 @@ async def handle(op: LoadSkillIROp, ctx: OpContext) -> dict:
         history_fields["skill_source_path"] = op.path
 
     if len(content) > cap:
-        truncated_content = content[:cap]
+        # #4431 (architect correction): was a bare `content[:cap]` char slice
+        # with NO resume position returned at all — the note pointed at "the
+        # full body is on disk" but gave no way to continue from where this
+        # read stopped. load_skill is deliberately NOT a paginated reader
+        # (module docstring) — the fix is not to add offset/limit here, it's
+        # to make the escape hatch this note already promises actually work:
+        # `read_file` (same file, since `op.path` is a real on-disk path for
+        # every provenance class this module and file.py share the same
+        # builtin/plugin bypass for) already supports a 0-indexed LINE
+        # `offset` (#4381/#4432 fixed its own char_offset-within-a-line
+        # sibling). Whole-line accumulation (mirroring op_runtime/file.py's
+        # own #1209/#2335 algorithm) so `next_offset` names a genuine line
+        # boundary `read_file(path=op.path, offset=next_offset)` can resume
+        # from without re-showing or dropping a partial line.
+        all_lines = content.splitlines(keepends=True)
+        shown: list[str] = []
+        acc = 0
+        next_offset = 0
+        for i, line in enumerate(all_lines):
+            if shown and acc + len(line) > cap:
+                next_offset = i
+                break
+            if not shown and len(line) > cap:
+                # A single line alone exceeds the cap (e.g. a minified/
+                # one-line body) — char-truncate it so `content` stays
+                # genuinely bounded; `read_file(offset=0)` on resume hits
+                # this exact same line and returns ITS OWN `next_char_offset`
+                # (file.py's #2335 mechanism), so no new field is needed here.
+                shown.append(line[:cap])
+                acc += cap
+                next_offset = i
+                break
+            shown.append(line)
+            acc += len(line)
+            next_offset = i + 1
+        truncated_content = "".join(shown)
         ctx.events.emit(
             "tool_executed", op="load_skill", path=op.path,
-            truncated=True, total_chars=len(content),
+            truncated=True, total_chars=len(content), next_offset=next_offset,
         )
         return {
             "kind": "load_skill",
@@ -269,11 +304,13 @@ async def handle(op: LoadSkillIROp, ctx: OpContext) -> dict:
             "status": "truncated",
             "content": truncated_content,
             "total_chars": len(content),
+            "next_offset": next_offset,
             "_truncated": True,
             "note": (
                 f"content truncated to fit context ({len(truncated_content)} of "
-                f"{len(content)} chars shown); the full skill body is on disk at "
-                f"{op.path!r}."
+                f"{len(content)} chars shown); the full skill body is on disk "
+                f"at {op.path!r} — continue reading with "
+                f"read_file(path={op.path!r}, offset={next_offset})."
             ),
             **enc_field,
             **history_fields,

--- a/tests/core/test_op_runtime_load_skill_3247.py
+++ b/tests/core/test_op_runtime_load_skill_3247.py
@@ -466,3 +466,79 @@ def test_file_module_carries_no_skill_load_import(tmp_path):
     assert not hasattr(file_module, "is_skill_body_path")
     assert not hasattr(file_module, "load_skill_body")
     assert not hasattr(file_module, "_config_registered_skill_body_provenance")
+
+
+# ── #4431 (architect correction): truncated load_skill can resume ──────────
+#
+# load_skill shared file.py's read-bounding cap (control_ir_inline_cap) but
+# had no `char_offset`/`next_offset` support at all — a truncated skill body
+# told the model "the full body is on disk at <path>" with no way to
+# actually continue reading it. Distinct from #4431 item ③ (say a cut
+# happened) — load_skill already said so via `_truncated`; this is the
+# OUTPUT-side gap ③ doesn't cover: saying it happened is not the same as
+# being able to read the rest.
+
+
+def test_load_skill_truncated_result_carries_a_resumable_offset(tmp_path):
+    """Tier 2: an unbounded load_skill over the cap returns `next_offset` —
+    the exact field a resuming `read_file(path=..., offset=next_offset)`
+    call needs (mirrors file.py's own #1209/#2335 shape, the established
+    precedent — no new field name invented)."""
+    ctx, _events = _make_ctx(tmp_path)
+    big = "".join(f"line {i} {'.' * 60}\n" for i in range(400))
+    from reyn.core.context_builder import MAX_CONTROL_IR_RESULT_INLINE_BYTES
+    assert len(big) > MAX_CONTROL_IR_RESULT_INLINE_BYTES  # ensure over the floor cap
+    ctx.workspace.write_file("SKILL.md", big)
+
+    result = _run(load_skill_handle(LoadSkillIROp(kind="load_skill", path="SKILL.md"), ctx))
+
+    assert result["status"] == "truncated"
+    assert result["_truncated"] is True
+    assert isinstance(result["next_offset"], int) and result["next_offset"] > 0
+    assert str(result["next_offset"]) in result["note"]
+    assert "read_file" in result["note"]
+
+
+def test_load_skill_resume_via_read_file_recovers_the_exact_remainder(tmp_path):
+    """Tier 2: end-to-end — the note's own remedy actually works. Reading the
+    same path via `read_file(offset=next_offset)` picks up EXACTLY where
+    load_skill's truncated content left off (no gap, no duplicated line) —
+    concatenating the two recovers the original body byte-for-byte. This is
+    the "assert both the count and the content" discipline (#4437's own
+    review note): a plausible-looking `next_offset` that off-by-ones would
+    still pass a bare "field is present" check but fail this one."""
+    ctx, _events = _make_ctx(tmp_path)
+    # Sized to overflow the cap just enough for ONE truncation round (both
+    # load_skill and read_file share the same window-derived cap) — a
+    # bigger body would need this test to loop resume calls, which is a
+    # real thing a caller can do but not what THIS assertion is pinning.
+    big = "".join(f"line {i} {'.' * 60}\n" for i in range(130))
+    from reyn.core.context_builder import MAX_CONTROL_IR_RESULT_INLINE_BYTES
+    assert len(big) > MAX_CONTROL_IR_RESULT_INLINE_BYTES
+    ctx.workspace.write_file("SKILL.md", big)
+
+    first = _run(load_skill_handle(LoadSkillIROp(kind="load_skill", path="SKILL.md"), ctx))
+    assert first["status"] == "truncated"
+
+    rest = _run(file_handle(
+        FileIROp(kind="file", op="read", path="SKILL.md", offset=first["next_offset"]), ctx,
+    ))
+    assert rest["status"] == "ok", (
+        f"test body sized wrong — resume itself truncated again: {rest}"
+    )
+    assert first["content"] + rest["content"] == big
+
+
+def test_load_skill_under_cap_is_unaffected(tmp_path):
+    """Tier 2: accept-side twin — a small skill body is unchanged: no
+    `next_offset`, no `_truncated`, `status="ok"` as before this fix."""
+    ctx, _events = _make_ctx(tmp_path)
+    small = "---\nname: probe\n---\nsmall body\n"
+    ctx.workspace.write_file("SKILL.md", small)
+
+    result = _run(load_skill_handle(LoadSkillIROp(kind="load_skill", path="SKILL.md"), ctx))
+
+    assert result["status"] == "ok"
+    assert result["content"] == small
+    assert "next_offset" not in result
+    assert "_truncated" not in result


### PR DESCRIPTION
**[docs-maintainer]** — #4431 new item (architect correction): a truncated `load_skill` result can actually be resumed.

## Scope

Separate axis from #4431 item ③ (say a cut happened — `load_skill` already did, via `status="truncated"`/`_truncated`/`note`). This is the OUTPUT-side gap: the note pointed at "the full body is on disk at `<path>`" with **no resume position at all** — 0 fields, not even a half-working one.

Per lead-coder's explicit instruction, checked the OUTPUT side directly rather than assuming "#4432's read_file pattern, same shape": `read_file` (pre-#4432) had computed `next_char_offset` but the schema/handler never forwarded it — "returned but couldn't receive." `load_skill` was a different failure: it returned **nothing** to resume from.

## The fix

`load_skill` stays deliberately non-paginated (module docstring: "load the whole thing, not a general paginated reader") — so the fix isn't new `offset`/`limit` params on `load_skill` itself. It's making the note's own promised escape hatch (`read_file` on the same path — every provenance class `load_skill` supports, `load_skill` and `file.py` already share the same builtin/plugin bypass helpers) actually usable:

- Truncation now accumulates **whole lines** (mirroring `op_runtime/file.py`'s own #1209/#2335 algorithm), replacing the old bare `content[:cap]` char slice that could cut mid-line.
- Returns `next_offset` — the exact 0-indexed line number `read_file`'s existing `offset` param needs. Reused that field name rather than inventing a new one (no new shape, per lead-coder's own instruction).
- A single oversized line (content[:cap] edge case) needs no new field either — resuming via `read_file(offset=0)` on that same line hits `read_file`'s own #2335 char-truncation and returns ITS `next_char_offset`, composing through existing machinery.
- Note text now says exactly what to call: `read_file(path=<path>, offset=<next_offset>)`.

## Test plan

- [x] 3 new tests in `tests/core/test_op_runtime_load_skill_3247.py`: `next_offset` present + in the note text (over-cap case); **end-to-end resume** — reading the SAME path via `read_file(offset=next_offset)` recovers the exact remainder, concatenation equals the original body byte-for-byte (not just "a field is present" — a plausible-looking but off-by-one `next_offset` would pass a bare presence check and fail this one); accept-side twin (under cap → unchanged `status="ok"`, no `next_offset`/`_truncated`).
- [x] Falsified twice (once per test-body-size iteration, since the first body was too large and made the RESUME read ALSO truncate — a real bug in my test, not the fix, caught and fixed before landing): stashed `load_skill.py`, confirmed both new positive tests RED (`KeyError: 'next_offset'`); restored, confirmed all 16 GREEN.
- [x] `ruff check`, `python scripts/mypy_ratchet.py` (unchanged), `python scripts/test_tier_audit.py --strict` (0 Tier-4 — renamed one test to drop a literal `byte_identical` in its name, a bounded-life-scaffold keyword false-triggering on a permanent behavioral-contract test), `python scripts/verify_module_docstrings.py`, `python scripts/check_tests_path_literal_reference.py` — all clean.
- [x] Broad sweep: this file + `test_read_bounding_structural_signal_1209.py` + `tests/plugins/test_skill_load.py` (36 passed); full `tests/core/` also run clean (2544 passed / 1 skipped, 0 failures).
- [ ] Visual/manual (owner env) — per the standing waiver (CLAUDE.md, 2026-08-08), left unchecked; owner confirms after merge on `main`.

## Arc note

`part of #4431`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
