### PR TITLE
fix(#4397): tests no longer carry their own subprocess.run wait-budget

### DIFF
--- a/tests/cli/test_httpx_lazy_load_cli_entry.py
+++ b/tests/cli/test_httpx_lazy_load_cli_entry.py
@@ -30,11 +30,13 @@ import textwrap
 
 def _run(src_root: str, script: str) -> subprocess.CompletedProcess:
     env = {**os.environ, "PYTHONPATH": src_root}
+    # #4397: no timeout= here — a hung subprocess is CI's own per-test
+    # pytest-timeout kill switch's job, not a shorter test-owned bound
+    # duplicating it (testing.md).
     return subprocess.run(
         [sys.executable, "-c", textwrap.dedent(script)],
         capture_output=True,
         text=True,
-        timeout=30,
         env=env,
     )
 

--- a/tests/core/test_2978_deny_always_wins.py
+++ b/tests/core/test_2978_deny_always_wins.py
@@ -109,7 +109,7 @@ def test_deny_wins_over_overlapping_write_grant_read_and_write(tmp_path):
     def _run(argv: list[str]) -> int:
         wrapped = backend.wrap_command(argv, policy)
         try:
-            return subprocess.run(wrapped.argv, capture_output=True, timeout=30).returncode
+            return subprocess.run(wrapped.argv, capture_output=True).returncode  # #4397: no test-owned timeout
         finally:
             wrapped.cleanup()
 
@@ -136,7 +136,7 @@ def test_read_deny_and_write_deny_are_independent_axes(tmp_path):
     def _run(policy: SandboxPolicy, argv: list[str]) -> int:
         wrapped = backend.wrap_command(argv, policy)
         try:
-            return subprocess.run(wrapped.argv, capture_output=True, timeout=30).returncode
+            return subprocess.run(wrapped.argv, capture_output=True).returncode  # #4397: no test-owned timeout
         finally:
             wrapped.cleanup()
 

--- a/tests/core/test_4395_tiktoken_cache_dir_default.py
+++ b/tests/core/test_4395_tiktoken_cache_dir_default.py
@@ -59,11 +59,11 @@ def _run(
     env = {**os.environ, "PYTHONPATH": src_root, **env_overrides}
     for key in unset:
         env.pop(key, None)
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     return subprocess.run(
         [sys.executable, "-c", code],
         capture_output=True,
         text=True,
-        timeout=30,
         env=env,
     )
 

--- a/tests/core/test_mcp_install_ux_fixes_318_319_320.py
+++ b/tests/core/test_mcp_install_ux_fixes_318_319_320.py
@@ -215,6 +215,7 @@ def test_install_command_warns_on_tmp_args_on_darwin(tmp_path, reyn_console_scri
     # (error-not-silent-cwd), so give tmp_path a reyn.yaml — the #320 /tmp-args
     # warning fires inside the source install, past project resolution.
     (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     result = subprocess.run(
         [
             reyn_bin, "mcp", "install",
@@ -225,7 +226,6 @@ def test_install_command_warns_on_tmp_args_on_darwin(tmp_path, reyn_console_scri
         cwd=str(tmp_path),
         capture_output=True,
         text=True,
-        timeout=30,
     )
     combined = result.stdout + result.stderr
     assert "/tmp" in combined

--- a/tests/core/test_python_harness_no_litellm_import.py
+++ b/tests/core/test_python_harness_no_litellm_import.py
@@ -20,11 +20,11 @@ import time
 
 def _run(src_root: str, code: str) -> subprocess.CompletedProcess:
     env = {**os.environ, "PYTHONPATH": src_root}
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     return subprocess.run(
         [sys.executable, "-c", code],
         capture_output=True,
         text=True,
-        timeout=30,
         env=env,
     )
 

--- a/tests/environment/test_devcontainer_build_e2e_1341.py
+++ b/tests/environment/test_devcontainer_build_e2e_1341.py
@@ -58,15 +58,15 @@ def _write_build_devcontainer(ws: Path, marker: str, *, extra_run: str = "") -> 
 
 
 def _exec(container_id: str, *cmd: str) -> subprocess.CompletedProcess:
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     return subprocess.run(
         ["docker", "exec", container_id, *cmd],
-        capture_output=True, timeout=60, check=False,
+        capture_output=True, check=False,
     )
 
 
 def _rmi(tag: str) -> None:
-    subprocess.run(["docker", "rmi", "-f", tag], capture_output=True,
-                   timeout=60, check=False)
+    subprocess.run(["docker", "rmi", "-f", tag], capture_output=True, check=False)
 
 
 def test_build_based_devcontainer_builds_and_runs(tmp_path: Path) -> None:
@@ -94,7 +94,7 @@ def test_build_based_devcontainer_builds_and_runs(tmp_path: Path) -> None:
         # the content-addressed image tag actually exists locally
         inspect = subprocess.run(
             ["docker", "image", "inspect", tag],
-            capture_output=True, timeout=60, check=False,
+            capture_output=True, check=False,
         )
         assert inspect.returncode == 0
     finally:

--- a/tests/environment/test_environment_import_no_circular_3867.py
+++ b/tests/environment/test_environment_import_no_circular_3867.py
@@ -40,11 +40,11 @@ def test_environment_is_importable_as_the_first_reyn_import(out_of_process_reyn)
     initializing. Reproduces via a fresh interpreter where `reyn.environment`
     is the FIRST reyn import (in-process, other already-imported reyn modules
     would mask the partial-init race)."""
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     result = subprocess.run(
         [sys.executable, "-c", "import reyn.environment; print('OK')"],
         capture_output=True,
         text=True,
-        timeout=30,
         env={**os.environ, "PYTHONPATH": out_of_process_reyn},
     )
     assert result.returncode == 0, (
@@ -59,11 +59,11 @@ def test_data_workspace_is_importable_as_the_first_reyn_import(out_of_process_re
     """Tier 2: #3867 — the reverse direction: `reyn.data.workspace` (which
     constructs a `HostBackend` from `reyn.environment.host_backend`) must also
     be importable standalone, first, in a fresh interpreter."""
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     result = subprocess.run(
         [sys.executable, "-c", "import reyn.data.workspace; print('OK')"],
         capture_output=True,
         text=True,
-        timeout=30,
         env={**os.environ, "PYTHONPATH": out_of_process_reyn},
     )
     assert result.returncode == 0, (

--- a/tests/environment/test_mount_e2e_1332.py
+++ b/tests/environment/test_mount_e2e_1332.py
@@ -53,10 +53,10 @@ pytestmark = [
 
 def _container_exists(container_id: str) -> bool:
     """True if a container with ``container_id`` still exists (running or not)."""
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     res = subprocess.run(
         ["docker", "ps", "-a", "-q", "--filter", f"id={container_id}"],
         capture_output=True,
-        timeout=30,
         check=False,
     )
     return bool(res.stdout.strip())
@@ -79,11 +79,11 @@ def _require_shared_bind_mount(tmp_path_factory: pytest.TempPathFactory) -> None
     """
     probe_dir = tmp_path_factory.mktemp("mount_probe")
     (probe_dir / "sentinel").write_text("mount-ok")
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     res = subprocess.run(
         ["docker", "run", "--rm", "-v", f"{probe_dir}:/probe:ro", _E2E_IMAGE,
          "cat", "/probe/sentinel"],
         capture_output=True,
-        timeout=180,
         check=False,
     )
     if res.returncode != 0 or res.stdout.strip() != b"mount-ok":

--- a/tests/interfaces/test_textual_chat_phase1_3273.py
+++ b/tests/interfaces/test_textual_chat_phase1_3273.py
@@ -242,12 +242,12 @@ def test_plain_path_survives_flowview_absence() -> None:
     import subprocess
     import sys
 
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     proc = subprocess.run(
         [sys.executable, "-c", _ISOLATION_SUBPROCESS],
         cwd=str(_REPO_ROOT),
         capture_output=True,
         text=True,
-        timeout=60,
     )
     assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
     assert "ISOLATION_OK" in proc.stdout, f"stdout={proc.stdout}\nstderr={proc.stderr}"

--- a/tests/interfaces/test_textual_chat_phase3_3273.py
+++ b/tests/interfaces/test_textual_chat_phase3_3273.py
@@ -266,12 +266,12 @@ def test_phase3_chrome_imports_stay_tty_only() -> None:
     import subprocess
     import sys
 
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     proc = subprocess.run(
         [sys.executable, "-c", _ISOLATION_SUBPROCESS],
         cwd=str(_REPO_ROOT),
         capture_output=True,
         text=True,
-        timeout=60,
     )
     assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
     assert "ISOLATION_OK" in proc.stdout, f"stdout={proc.stdout}\nstderr={proc.stderr}"

--- a/tests/interfaces/test_textual_chat_phase4_3273.py
+++ b/tests/interfaces/test_textual_chat_phase4_3273.py
@@ -405,12 +405,12 @@ def test_phase4_wiring_imports_stay_tty_only() -> None:
     import subprocess
     import sys
 
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     proc = subprocess.run(
         [sys.executable, "-c", _ISOLATION_SUBPROCESS],
         cwd=str(_REPO_ROOT),
         capture_output=True,
         text=True,
-        timeout=60,
     )
     assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
     assert "ISOLATION_OK" in proc.stdout, f"stdout={proc.stdout}\nstderr={proc.stderr}"

--- a/tests/llm/test_litellm_lazy_load.py
+++ b/tests/llm/test_litellm_lazy_load.py
@@ -29,11 +29,11 @@ def _run(
     env = {**os.environ, "PYTHONPATH": src_root}
     if extra_env:
         env.update(extra_env)
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     return subprocess.run(
         [sys.executable, "-c", textwrap.dedent(script)],
         capture_output=True,
         text=True,
-        timeout=30,
         env=env,
     )
 

--- a/tests/llm/test_llm_run_async_client_cache_scope_3434.py
+++ b/tests/llm/test_llm_run_async_client_cache_scope_3434.py
@@ -99,11 +99,11 @@ def test_run_async_never_imports_litellm_without_an_llm_call(out_of_process_reyn
         print("OK")
         """
     env = {**os.environ, "PYTHONPATH": out_of_process_reyn}
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     result = subprocess.run(
         [sys.executable, "-c", textwrap.dedent(script)],
         capture_output=True,
         text=True,
-        timeout=30,
         env=env,
     )
     assert result.returncode == 0, result.stderr
@@ -155,11 +155,11 @@ def test_constructing_a_session_never_imports_litellm(tmp_path, out_of_process_r
         print("OK")
         """
     env = {**os.environ, "PYTHONPATH": out_of_process_reyn}
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     result = subprocess.run(
         [sys.executable, "-c", textwrap.dedent(script)],
         capture_output=True,
         text=True,
-        timeout=30,
         env=env,
     )
     assert result.returncode == 0, result.stderr

--- a/tests/mcp/test_fastmcp_core_dep_import_chain.py
+++ b/tests/mcp/test_fastmcp_core_dep_import_chain.py
@@ -44,11 +44,11 @@ def test_mcp_import_chain_succeeds_and_fastmcp_is_not_installed(out_of_process_r
         "import fastmcp;"
         "print('FASTMCP_PRESENT')"
     )
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     result = subprocess.run(
         [sys.executable, "-c", code],
         capture_output=True,
         text=True,
-        timeout=60,
         env={**os.environ, "PYTHONPATH": out_of_process_reyn},
     )
     assert result.returncode != 0, (
@@ -71,7 +71,6 @@ def test_mcp_import_chain_succeeds_and_fastmcp_is_not_installed(out_of_process_r
         [sys.executable, "-c", code_ok],
         capture_output=True,
         text=True,
-        timeout=60,
         env={**os.environ, "PYTHONPATH": out_of_process_reyn},
     )
     assert result_ok.returncode == 0, (

--- a/tests/runtime/test_4366_capability_census_scheme_registry_import.py
+++ b/tests/runtime/test_4366_capability_census_scheme_registry_import.py
@@ -67,8 +67,9 @@ def test_capability_visibility_state_survives_a_fresh_interpreter_with_no_router
         )
         print("SURVIVED")
     """)
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     result = subprocess.run(
-        [sys.executable, "-c", code], capture_output=True, text=True, timeout=60,
+        [sys.executable, "-c", code], capture_output=True, text=True,
     )
     assert result.returncode == 0, (
         f"stdout: {result.stdout}\nstderr: {result.stderr}"

--- a/tests/runtime/test_session_pure_extraction_3679_s1.py
+++ b/tests/runtime/test_session_pure_extraction_3679_s1.py
@@ -86,12 +86,12 @@ def test_session_pure_importable_without_first_importing_session():
     initialize) would raise the same
     "cannot import name ... from partially initialized module" this stage
     is fixing."""
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     proc = subprocess.run(
         [sys.executable, "-c", "import reyn.runtime.session_pure; print('OK')"],
         cwd=str(_REPO_ROOT),
         capture_output=True,
         text=True,
-        timeout=30,
     )
     assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
     assert "OK" in proc.stdout

--- a/tests/runtime/test_textual_chat_phase5_3273.py
+++ b/tests/runtime/test_textual_chat_phase5_3273.py
@@ -700,12 +700,12 @@ def test_phase5_accessor_imports_stay_tty_only() -> None:
     import subprocess
     import sys
 
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     proc = subprocess.run(
         [sys.executable, "-c", _ISOLATION_SUBPROCESS],
         cwd=str(_REPO_ROOT),
         capture_output=True,
         text=True,
-        timeout=60,
     )
     assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
     assert "ISOLATION_OK" in proc.stdout, f"stdout={proc.stdout}\nstderr={proc.stderr}"

--- a/tests/scripts/test_3233_inprocess_env_identity.py
+++ b/tests/scripts/test_3233_inprocess_env_identity.py
@@ -116,13 +116,13 @@ def test_a_decoy_reyn_cached_before_pytest_starts_makes_startup_exit_nonzero(
         [str(site_hook), str(tmp_path / "decoy_src"), env.get("PYTHONPATH", "")]
     )
 
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     proc = subprocess.run(
         [sys.executable, "-m", "pytest", "--collect-only", "-q", "--no-header"],
         cwd=_REPO_ROOT,
         env=env,
         capture_output=True,
         text=True,
-        timeout=120,
     )
 
     assert proc.returncode != 0, (

--- a/tests/scripts/test_reyn_web_proc.py
+++ b/tests/scripts/test_reyn_web_proc.py
@@ -86,8 +86,9 @@ def test_group_kill_reaps_child_processes(tmp_path):
 
 def test_selftest_entrypoint_passes():
     """Tier 2: the module's own --selftest smoke returns 0 (spawn->alive->killed)."""
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     result = subprocess.run(
-        [sys.executable, str(SCRIPT)], capture_output=True, text=True, timeout=60
+        [sys.executable, str(SCRIPT)], capture_output=True, text=True
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert "killed_after_context=True" in result.stdout

--- a/tests/security/test_2976_mcp_sandbox_write_paths.py
+++ b/tests/security/test_2976_mcp_sandbox_write_paths.py
@@ -173,7 +173,8 @@ def test_tilde_write_grant_actually_permits_the_write(tmp_path):
             SandboxPolicy(write_paths=[f"~/{target_dir.name}"], deny_subprocess=False),
         )
         try:
-            result = subprocess.run(wrapped.argv, capture_output=True, timeout=30)
+            # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
+            result = subprocess.run(wrapped.argv, capture_output=True)
         finally:
             wrapped.cleanup()
 
@@ -242,7 +243,8 @@ def test_default_mcp_policy_still_denies_credential_paths(deny_path):
     policy = MCPClient(_stdio(command="npx"))._build_mcp_sandbox_policy()
     wrapped = backend.wrap_command([*probe, str(target)], policy)
     try:
-        result = subprocess.run(wrapped.argv, capture_output=True, timeout=30)
+        # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
+        result = subprocess.run(wrapped.argv, capture_output=True)
     finally:
         wrapped.cleanup()
 

--- a/tests/security/test_landlock_exec_shim_1344e.py
+++ b/tests/security/test_landlock_exec_shim_1344e.py
@@ -134,8 +134,9 @@ def test_main_subprocess_refuses_when_unavailable(out_of_process_reyn: str):
     # Run the shim against the reyn under test (not a venv-installed copy) by
     # pinning PYTHONPATH to this checkout's src root (env-dependent path lesson).
     env = {**os.environ, "PYTHONPATH": out_of_process_reyn}
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     proc = subprocess.run(
-        [exe, *argv], capture_output=True, text=True, timeout=30, env=env,
+        [exe, *argv], capture_output=True, text=True, env=env,
     )
     assert proc.returncode == 2  # the refuse exit code
     assert "Landlock unavailable" in proc.stderr
@@ -168,11 +169,11 @@ def _shim_run(
     from reyn.security.sandbox.backends.landlock import LandlockBackend
 
     wrapped = LandlockBackend().wrap_command(argv, policy)
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     return subprocess.run(
         wrapped.argv,
         capture_output=True,
         text=True,
-        timeout=60,
         stdin=subprocess.DEVNULL,
         env={"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "PYTHONPATH": src_root},
     )

--- a/tests/security/test_sandbox_seccomp_network_3030.py
+++ b/tests/security/test_sandbox_seccomp_network_3030.py
@@ -95,11 +95,11 @@ def _shim_run(
     from reyn.security.sandbox.backends.landlock import LandlockBackend
 
     wrapped = LandlockBackend().wrap_command(argv, policy)
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     return subprocess.run(
         wrapped.argv,
         capture_output=True,
         text=True,
-        timeout=60,
         stdin=subprocess.DEVNULL,
         env={"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "PYTHONPATH": src_root},
     )
@@ -353,9 +353,10 @@ def _bare_io_uring_supported() -> bool:
     arm below cannot distinguish "denied by our filter" from "ENOSYS" and must
     be skipped rather than mis-scored."""
     try:
+        # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
         proc = subprocess.run(
             [sys.executable, "-c", _IO_URING_PROBE_SRC],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True, text=True,
         )
     except Exception:  # noqa: BLE001
         return False
@@ -659,9 +660,10 @@ async def test_markitdown_mcp_starts_and_responds_under_seccomp_allowlist(
         pytest.skip("uvx not on PATH")
 
     try:
+        # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
         subprocess.run(
             [uvx, "markitdown-mcp", "--help"],
-            capture_output=True, timeout=120, check=False,
+            capture_output=True, check=False,
         )
     except Exception as exc:  # noqa: BLE001
         pytest.skip(f"could not prewarm uvx's markitdown-mcp cache: {exc!r}")

--- a/tests/services/test_3027_budget_guard_survives_optimize.py
+++ b/tests/services/test_3027_budget_guard_survives_optimize.py
@@ -46,7 +46,8 @@ def _run(src_root: str, script: str, *, optimize: bool) -> subprocess.CompletedP
     args += ["-c", script]
     env = dict(os.environ)
     env["PYTHONPATH"] = src_root + os.pathsep + env.get("PYTHONPATH", "")
-    return subprocess.run(args, capture_output=True, text=True, timeout=60, env=env)
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
+    return subprocess.run(args, capture_output=True, text=True, env=env)
 
 
 def test_effective_trigger_guard_fires_under_dash_o(out_of_process_reyn) -> None:

--- a/tests/web/test_openui_shell.py
+++ b/tests/web/test_openui_shell.py
@@ -361,6 +361,7 @@ def test_design_file_stdlib_warm(tmp_project: Path, monkeypatch: pytest.MonkeyPa
 
 def test_web_help_includes_default_design(out_of_process_reyn) -> None:
     """Tier 2b: `reyn web --help` mentions --default-design."""
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     result = subprocess.run(
         [sys.executable, "-c",
          "from reyn._cli import main; import sys; sys.argv=['reyn','web','--help']; main()"],
@@ -370,7 +371,6 @@ def test_web_help_includes_default_design(out_of_process_reyn) -> None:
             **__import__("os").environ,
             "PYTHONPATH": out_of_process_reyn,
         },
-        timeout=15,
     )
     assert result.returncode == 0, f"reyn web --help failed:\n{result.stderr}"
     assert "default-design" in result.stdout.lower(), (

--- a/tests/web/test_smoke.py
+++ b/tests/web/test_smoke.py
@@ -66,6 +66,7 @@ def test_reyn_web_help(out_of_process_reyn) -> None:
     Uses the reyn._cli:main entry point directly so we don't depend on the
     installed `reyn` shim, which may point to the wrong editable install.
     """
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     result = subprocess.run(
         [sys.executable, "-c",
          "from reyn._cli import main; import sys; sys.argv=['reyn','web','--help']; main()"],
@@ -75,7 +76,6 @@ def test_reyn_web_help(out_of_process_reyn) -> None:
             **__import__("os").environ,
             "PYTHONPATH": out_of_process_reyn,
         },
-        timeout=15,
     )
     assert result.returncode == 0, f"reyn web --help failed:\n{result.stderr}"
     assert "host" in result.stdout.lower() or "port" in result.stdout.lower(), (


### PR DESCRIPTION
**[docs-maintainer]** — #4397: tests no longer carry their own `subprocess.run` wait-budget.

## Scope

testing.md's ban on tests carrying their own wait-budget constant applies to `subprocess.run(..., timeout=N)`, not just the bounded-poll `wait_until`-style class the already-resolved #4099/#4275 covered. Direct policy violation, no ambiguity — filed as tracking-only per the arc-closure remainder rule.

**Checked before assuming, not inherited from the issue's own claim**: confirmed CI's kill switch is genuinely equivalent protection before removing anything. `--timeout=120` (`test.yml`) / `--timeout=120`–`180` (`sandbox-landlock-deny-gate.yml`) is `pytest-timeout`, **signal-based, per-test** (not a whole-job budget) — it correctly interrupts a blocking `subprocess.run()` (SIGALRM is delivered to the main thread mid-`communicate()`), so removing the call's own `timeout=` loses no real protection; a test needing more than that should be decomposed, not given a shorter private ceiling that fails the TEST instead of the JOB on a legitimately-slow-but-not-hung run.

## Population

Built via a real scan for `subprocess.run(` followed by a `timeout=` kwarg anywhere within the call (not a flat `grep` — the issue itself warned a naive grep line-match could miss/misattribute multi-line calls). **36 sites across 25 files** — every one removed; no other `subprocess.run` argument touched.

**Scope boundary, not silently widened**: the same sweep surfaced `asyncio.wait_for(..., timeout=N)` sites (`test_textual_chat_phase1_3273.py`, `test_textual_chat_phase5_3273.py`) — a related but DIFFERENT sub-class the filed issue doesn't name (subprocess.run specifically, not asyncio.wait_for). Left untouched rather than expanding into unfiled scope; flagging as a possible future issue, not fixing here.

## 2 pre-existing failures found during the broad sweep — NOT this PR's scope

Both confirmed unrelated via `git stash` (byte-identical failure on the stashed/clean tree, before any of my edits):
- `tests/runtime/test_session_pure_extraction_3679_s1.py::test_session_pure_importable_without_first_importing_session` — `ModuleNotFoundError: No module named 'reyn.runtime.session_pure'` (a stale import reference to a module that doesn't exist on `main`).
- `tests/mcp/test_fastmcp_core_dep_import_chain.py::test_mcp_import_chain_succeeds_and_fastmcp_is_not_installed` — `fastmcp` IS importable in this dev machine's `out_of_process_reyn` interpreter (the test asserts it should NOT be, per #4302's core-dependency removal).

Reported here for triage, not fixed — outside #4397's scope and I have no standing evidence on whether either reproduces in CI's clean-checkout environment vs. only this local machine's site-packages state.

## Test plan

- [x] All 36 sites verified via a re-scan after editing: `subprocess.run(...timeout=...)` count in `tests/` is **0**.
- [x] `ruff check tests` — clean.
- [x] `python scripts/test_tier_audit.py --strict` on all 24 touched test files — 175 tests inspected, 0 Tier-4 violations.
- [x] `python scripts/mypy_ratchet.py` (unchanged, 211/215 baselined), `python scripts/check_tests_path_literal_reference.py` — clean. (`verify_module_docstrings.py` N/A — no `src/` files touched.)
- [x] Ran all 24 touched files directly: 172 passed, 26 skipped (docker/Landlock/macOS-gated, expected on this machine), 2 pre-existing failures (both confirmed unrelated above).
- [ ] Visual/manual (owner env) — per the standing waiver (CLAUDE.md, 2026-08-08), left unchecked; owner confirms after merge on `main`.

**tests/ touched — TESTS-READ wait, no self-merge.**

## Arc note

Closes #4397 — enumerated first (`gh pr list --search "4397 in:body"`, 0 results): no other open PR claims partial scope on this issue, and the population re-scan above confirms 0 remaining sites, so this is genuinely the complete fix, not a partial one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
