### PR TITLE
feat(#4421): runtime gate — one turn, default config, zero real sockets

### DIFF
--- a/src/reyn/dev/testing/runtime_network_probe.py
+++ b/src/reyn/dev/testing/runtime_network_probe.py
@@ -1,0 +1,136 @@
+"""Runtime (not static) gate: one full router turn, under reyn's DEFAULT
+config, reaches zero real sockets (#4421 step ③).
+
+WHY A RUNTIME GATE, NOT JUST THE #4428 AST WALK
+    #4428 closed literal ``import litellm`` / ``from litellm import ...``
+    outside the seam (``litellm_bootstrap.py``) — a STATIC gate, walking
+    source text. It is blind by construction to code that reaches litellm
+    through ``sys.modules["litellm"]`` or ``getattr(module, name)`` — no
+    import statement exists for an AST walk to see (architect's #4415
+    recount hit exactly this blind spot once already, counting via AST and
+    missing an attribute-access site).
+
+    This module does not try to out-guess every such spelling. It instead
+    measures the OUTCOME both spellings share when they misbehave: a real
+    socket connection during a turn reyn's own contract says should stay
+    fully local (a completion served from a fixture/replay, not a live
+    provider). A mechanism gate over the outcome covers every syntax that
+    could produce it — the trade reyn's own architect named for this exact
+    axis: "静的（コードに全数・機構に盲目）と実行時（機構に全数・経路に盲目）
+    の二枚が要る" — this is the second sheet, not a replacement for the first.
+
+WHY THIS NEEDS A SUBPROCESS, NOT AN IN-PROCESS PATCH
+    A pytest worker process runs many tests; by the time any single test
+    calls this, ``litellm`` may already sit in ``sys.modules`` from an
+    earlier test's import, so re-importing it in-process is a no-op and
+    measures nothing about import-time network reach. ``NetworkReachProbe``
+    is written to be usable from a **spawned subprocess script** (`python
+    -c "..."`), started before ``litellm`` (or even ``reyn``) has ever been
+    imported in that process — see ``tests/llm/test_4421_runtime_network_
+    gate.py`` for the actual spawn, and
+    ``tests/llm/test_litellm_lazy_load.py`` for the established subprocess
+    pattern this reuses (real subprocess, not a mock of ``sys.modules``).
+
+WHAT COUNTS AS "REACH"
+    ``socket.socket.connect``/``connect_ex`` — the one chokepoint every
+    Python HTTP client (``requests``, ``httpx``, ``aiohttp``, litellm's own
+    transports) ultimately calls to open a real TCP connection, regardless
+    of which higher-level library or call spelling got there. Patched at
+    this level (not ``litellm.acompletion``/``aembedding``, which
+    ``reyn.dev.testing.network_gate`` already wraps for pytest-pinned
+    tests) so this catches litellm's OWN import-time / first-call network
+    reach too, not just reyn's calls into litellm — measured directly
+    (2026-08-13): a naive probe that imports ``litellm`` before ``reyn``
+    (skipping ``reyn/__init__.py``'s own ``LITELLM_LOCAL_MODEL_COST_MAP``
+    ``setdefault``) sees 8 real connect attempts to
+    ``raw.githubusercontent.com`` (litellm's remote model-cost-map fetch,
+    ``litellm_core_utils/get_model_cost_map.py``) purely from ``import
+    litellm`` — a real, measured hazard this gate is built to keep caught,
+    not a hypothetical.
+
+A DENIED CONNECT, NOT A SILENTLY-ALLOWED ONE
+    ``connect``/``connect_ex`` raise ``OSError`` on the attempt (mirroring
+    what an offline CI runner would do anyway) rather than letting it
+    through — a probe that only counted successful connections would pass
+    on a machine with no network path to the target and never notice the
+    attempt was made at all.
+"""
+from __future__ import annotations
+
+import socket
+from typing import Any
+
+
+class RealNetworkReachDuringOneTurn(RuntimeError):
+    """A real socket connect was attempted during a probed turn.
+
+    Per #4421's landing condition (architect, non-negotiable): the message
+    must NAME REYN'S OWN REMEDY, not just report that a third-party network
+    reach occurred — "an outbound call happened" alone tells the next
+    reader nothing about whose problem it is (Q1's "third-party promise"
+    shape, applied to a runtime gate instead of a test assertion).
+    :meth:`NetworkReachProbe.assert_clean` builds this message; do not
+    raise this class directly with a bare description.
+    """
+
+
+class NetworkReachProbe:
+    """Context manager: patch ``socket.socket.connect``/``connect_ex`` to
+    record (and block) every attempt for the duration of the ``with`` block.
+
+    Usable standalone (construct, use as a context manager, read
+    ``.attempts`` or call :meth:`assert_clean`) — no pytest dependency, so a
+    subprocess script spawned via ``python -c`` can import and use it
+    directly.
+    """
+
+    def __init__(self) -> None:
+        self.attempts: list[tuple[str, Any]] = []
+        self._orig_connect: Any = None
+        self._orig_connect_ex: Any = None
+
+    def __enter__(self) -> "NetworkReachProbe":
+        self._orig_connect = socket.socket.connect
+        self._orig_connect_ex = socket.socket.connect_ex
+
+        def _record_connect(_sock_self: Any, address: Any) -> None:
+            self.attempts.append(("connect", address))
+            raise OSError(f"NetworkReachProbe: blocked real connect to {address!r}")
+
+        def _record_connect_ex(_sock_self: Any, address: Any) -> int:
+            self.attempts.append(("connect_ex", address))
+            raise OSError(f"NetworkReachProbe: blocked real connect_ex to {address!r}")
+
+        socket.socket.connect = _record_connect  # type: ignore[method-assign]
+        socket.socket.connect_ex = _record_connect_ex  # type: ignore[method-assign]
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        socket.socket.connect = self._orig_connect  # type: ignore[method-assign]
+        socket.socket.connect_ex = self._orig_connect_ex  # type: ignore[method-assign]
+
+    def assert_clean(self, *, context: str) -> None:
+        """Raise :class:`RealNetworkReachDuringOneTurn` (naming reyn's own
+        known suppression points) if any attempt was recorded; no-op
+        otherwise. Call after the probed turn completes."""
+        if not self.attempts:
+            return
+        detail = "; ".join(f"{kind} -> {addr!r}" for kind, addr in self.attempts)
+        raise RealNetworkReachDuringOneTurn(
+            f"{context}: reyn's assumption that a default-configured run "
+            f"reaches litellm with zero real network calls has become "
+            f"invalid ({len(self.attempts)} attempt(s): {detail}).\n"
+            "Reyn-side remedy: this almost certainly means a litellm "
+            "import-time or first-call remote fetch is no longer "
+            "suppressed by one of reyn's two known suppression points — "
+            "check both: (1) `LITELLM_LOCAL_MODEL_COST_MAP=True`, set in "
+            "`src/reyn/__init__.py` before anything else can `import "
+            "litellm` (blocks litellm's own remote model-cost-map fetch, "
+            "`litellm_core_utils/get_model_cost_map.py`); (2) the bundled "
+            "tiktoken cache litellm ships (see `reyn._tiktoken_diag` / "
+            "`reyn.llm.litellm_bootstrap._diagnose_import_failure_for_log`, "
+            "#4422). If neither explains this attempt's target, litellm "
+            "has grown a NEW remote-fetch surface reyn does not suppress "
+            "yet — that surface is the actual reyn-side fix this gate is "
+            "naming, not this test."
+        )

--- a/tests/llm/test_4421_runtime_network_gate.py
+++ b/tests/llm/test_4421_runtime_network_gate.py
@@ -1,0 +1,247 @@
+"""Tier 2: #4421 step ③ — one full router turn, under reyn's DEFAULT config,
+reaches zero real sockets.
+
+#4428 closed literal ``import litellm`` outside the seam via a STATIC (AST)
+gate — blind by construction to a ``sys.modules``/``getattr`` reach with no
+import statement for it to see. This is the second, RUNTIME sheet architect
+named as still required: a mechanism gate over the OUTCOME (a real socket
+opened) rather than the syntax that could produce it, so it covers every
+spelling that reaches litellm, not just the ones #4428 can parse.
+
+Real subprocess (not an in-process patch): a pytest worker may already have
+``litellm`` in ``sys.modules`` from an earlier test, which would make
+re-importing it here a silent no-op and prove nothing about import-time
+network reach. Same shape ``tests/llm/test_litellm_lazy_load.py`` already
+established for this exact class of "process-level fact" test.
+
+Real router loop, no live provider: the LLM's own completion is served by a
+hand-authored ``litellm.ModelResponse`` (a
+``reyn.dev.testing.replay.LLMReplay`` subclass with key-matching bypassed —
+no genuine recorded fixture exists for this scenario and no API credits are
+spent recording one) — everything downstream of that one call (router loop,
+tool dispatch, permission gate) is real, unmocked reyn code. ``permissions.
+file.write: deny`` makes the one scripted ``write_file`` call resolve
+without any interactive JIT prompt, so the whole turn completes in one
+round trip suitable for a non-interactive subprocess.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _run(
+    src_root: str, script: str, cwd: Path, *, unset_env: tuple[str, ...] = (),
+) -> subprocess.CompletedProcess:
+    """Every embedded script below is written flush-left (column 0) —
+    deliberately, so nothing here needs to reconcile different fragments'
+    indentation (``textwrap.dedent`` over a concatenation of differently
+    indented triple-quoted strings is fragile; an earlier draft of this
+    file hit exactly that as a real ``IndentationError``, not a hypothetical).
+
+    ``unset_env``: this PARENT pytest process has almost certainly already
+    imported ``reyn`` itself (an earlier test, or pytest's own collection),
+    which sets ``LITELLM_LOCAL_MODEL_COST_MAP`` in the parent's own
+    ``os.environ`` — inherited by every child by default. The falsify test
+    needs a child that genuinely lacks it (matching a real cold process
+    that hasn't run reyn's bootstrap yet), so it strips it explicitly
+    rather than relying on child-process import order alone, which the
+    inherited env var would silently defeat."""
+    env = {k: v for k, v in os.environ.items() if k not in unset_env}
+    env["PYTHONPATH"] = src_root
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+        cwd=str(cwd),
+    )
+
+
+# Flush-left on purpose (see `_run`'s docstring).
+_SCRIPTED_TURN_SETUP = """
+import itertools
+import sys
+from pathlib import Path
+
+import litellm
+from reyn.dev.testing.replay import LLMReplay
+
+_TOOL_CALL_RESPONSE = {
+    "id": "gen-1", "created": 1700000000, "model": "fake/4421-gate",
+    "object": "chat.completion", "system_fingerprint": None,
+    "choices": [{
+        "finish_reason": "tool_calls", "index": 0,
+        "message": {
+            "content": None, "role": "assistant",
+            "tool_calls": [{
+                "index": 0, "id": "call_1", "type": "function",
+                "function": {
+                    "name": "write_file",
+                    "arguments": '{"path": "/etc/reyn_4421_gate.txt", "content": "x"}',
+                },
+            }],
+            "function_call": None,
+        },
+    }],
+    "usage": {"completion_tokens": 8, "prompt_tokens": 20, "total_tokens": 28,
+              "completion_tokens_details": None, "prompt_tokens_details": None},
+}
+
+
+class _ScriptedReplay(LLMReplay):
+    # No genuine fixture exists for this scenario (see module docstring) —
+    # _replay is fully overridden to always serve the same canned tool
+    # call, regardless of what was actually asked.
+    def __init__(self):
+        super().__init__(Path("/dev/null"), mode="replay")
+        self._plan_iter = itertools.repeat(_TOOL_CALL_RESPONSE)
+
+    def _replay(self, key, model, messages, observed, request):
+        return litellm.ModelResponse(**next(self._plan_iter))
+
+
+def run_one_turn():
+    from reyn.interfaces.cli import main
+
+    replay = _ScriptedReplay()
+    replay.install()
+    try:
+        sys.argv = ["reyn", "run-once", "--model", "fake/4421-gate"]
+        try:
+            main()
+        except SystemExit:
+            pass
+    finally:
+        replay.restore()
+"""
+
+
+@pytest.fixture
+def _default_project(tmp_path: Path) -> Path:
+    """A project whose ``reyn.yaml`` carries only what makes the scripted
+    turn resolve without an interactive prompt (``permissions.file.write:
+    deny`` denies the one scripted ``write_file`` call outright) — no
+    tiktoken-cache / cost-map tampering, so the probe measures reyn's real
+    DEFAULT behaviour, not an artificially narrowed one."""
+    (tmp_path / "reyn.yaml").write_text(
+        "llm:\n  models:\n    standard: fake/4421-gate\n"
+        "permissions:\n  file:\n    write: deny\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_one_turn_under_default_config_reaches_zero_real_sockets(
+    _default_project: Path, out_of_process_reyn: str,
+) -> None:
+    """Tier 2: import reyn (production bootstrap order) -> import litellm ->
+    drive one full router turn (scripted completion, real everything else)
+    -> assert zero real ``socket.connect``/``connect_ex`` attempts.
+
+    Decisive, not just descriptive: a failure here means litellm (or reyn's
+    own call into it) reached a real socket during a turn reyn's contract
+    says stays fully local — caught via
+    :class:`reyn.dev.testing.runtime_network_probe.NetworkReachProbe`, which
+    raises naming reyn's own known suppression points (architect's landing
+    condition: the message must say what REYN should do, never just that a
+    network reach happened)."""
+    script = (
+        "import sys\n"
+        "sys.stdin = open('/dev/null')\n"
+        # `reyn` FIRST — production ordering. `reyn/__init__.py` sets
+        # LITELLM_LOCAL_MODEL_COST_MAP=True (setdefault) before litellm is
+        # ever imported; importing litellm first would skip that and
+        # produce a FALSE positive (litellm's own remote cost-map fetch)
+        # rather than a real reyn gap — measured directly (2026-08-13): 8
+        # real connect attempts to raw.githubusercontent.com when this
+        # ordering is skipped.
+        "import reyn\n"
+        "from reyn.dev.testing.runtime_network_probe import NetworkReachProbe\n"
+        + _SCRIPTED_TURN_SETUP
+        + "\n"
+        "with NetworkReachProbe() as probe:\n"
+        "    run_one_turn()\n"
+        "\n"
+        "probe.assert_clean(context='one router turn, default config')\n"
+        "print('OK')\n"
+    )
+    result = _run(out_of_process_reyn, script, cwd=_default_project)
+    assert result.returncode == 0, (
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    assert "OK" in result.stdout
+
+
+def test_skipping_reyns_bootstrap_order_really_does_reach_the_network(
+    _default_project: Path, out_of_process_reyn: str,
+) -> None:
+    """Tier 2: falsify-verify half 1/2 — importing litellm BEFORE reyn
+    (skipping ``reyn/__init__.py``'s ``LITELLM_LOCAL_MODEL_COST_MAP``
+    ``setdefault`` on purpose, the exact ordering mistake this gate exists
+    to catch) really does reach a real socket. Uses a RAW inline socket
+    patch here, not :class:`NetworkReachProbe` — that class lives inside
+    the ``reyn`` package, so importing IT would import ``reyn`` first and
+    silently defeat the "litellm before reyn" ordering this test exists to
+    falsify against (measured: an earlier draft of this file did exactly
+    that and the probe never fired)."""
+    script = """
+import socket
+attempts = []
+def _rec(self, addr):
+    attempts.append(addr)
+    raise OSError("blocked")
+socket.socket.connect = _rec
+socket.socket.connect_ex = _rec
+
+import litellm  # BEFORE reyn — no LITELLM_LOCAL_MODEL_COST_MAP set yet
+import reyn  # noqa: F401 — too late; the fetch already happened above
+
+assert attempts, "expected import litellm (with no reyn bootstrap yet) to reach the network"
+print("REACHED", len(attempts))
+"""
+    result = _run(
+        out_of_process_reyn, script, cwd=_default_project,
+        unset_env=("LITELLM_LOCAL_MODEL_COST_MAP",),
+    )
+    assert result.returncode == 0, (
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    assert "REACHED" in result.stdout, (
+        f"litellm-before-reyn must actually reach the network, or this whole "
+        f"gate is unfalsifiable: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def test_assert_clean_names_reyns_own_remedy() -> None:
+    """Tier 1: falsify-verify half 2/2 — :meth:`NetworkReachProbe.
+    assert_clean`'s failure message names reyn's own known suppression
+    points (architect's landing condition, #4421), not just "a network
+    call happened". In-process (no subprocess needed): this checks the
+    MESSAGE CONTRACT of a plain method, not process-level import-order
+    facts — the other half of this pair checks the fact, this half checks
+    the contract, and neither needs the other's setup."""
+    from reyn.dev.testing.runtime_network_probe import (
+        NetworkReachProbe,
+        RealNetworkReachDuringOneTurn,
+    )
+
+    probe = NetworkReachProbe()
+    probe.attempts.append(("connect", ("185.199.108.133", 443)))
+
+    with pytest.raises(RealNetworkReachDuringOneTurn) as excinfo:
+        probe.assert_clean(context="test context")
+
+    msg = str(excinfo.value)
+    assert "test context" in msg
+    assert "remedy" in msg.lower(), (
+        f"message must name reyn's own remedy, not just report the reach: {msg}"
+    )
+    assert "LITELLM_LOCAL_MODEL_COST_MAP" in msg, (
+        f"message must name the specific known suppression point: {msg}"
+    )

--- a/tests/llm/test_4421_runtime_network_gate.py
+++ b/tests/llm/test_4421_runtime_network_gate.py
@@ -53,11 +53,11 @@ def _run(
     inherited env var would silently defeat."""
     env = {k: v for k, v in os.environ.items() if k not in unset_env}
     env["PYTHONPATH"] = src_root
+    # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     return subprocess.run(
         [sys.executable, "-c", script],
         capture_output=True,
         text=True,
-        timeout=60,
         env=env,
         cwd=str(cwd),
     )


### PR DESCRIPTION
**[tui-coder]** — #4421 step ③: the runtime gate (1 turn, default config, 0 real sockets)

## What

Adds the RUNTIME sheet architect flagged as still required after #4428 closed the static (AST) half. #4428 walks source text — blind by construction to litellm reached via `sys.modules`/`getattr` (no import statement for an AST walk to see). This gate instead checks the OUTCOME: a real socket opened during one router turn under reyn's default config. Mechanism, not syntax — covers every spelling that could reach litellm's network surface, not just the ones an AST walk can parse.

`reyn.dev.testing.runtime_network_probe.NetworkReachProbe` patches `socket.socket.connect`/`connect_ex` (the one chokepoint every HTTP client ultimately calls) — catches litellm's own import-time network reach too, not just reyn's calls into it.

## Prerequisite measurement (architect flagged this as unmeasured before implementing)

> `dev/testing/replay.py` で実通信なしに1ターン通せるか — 実装前にここを確かめてください

Confirmed directly, not assumed: `LLMReplay` (key-matching bypassed, no genuine fixture for this scenario) drives a real router loop / permission gate / dispatch through `reyn run-once`, with **zero** real network calls, when reyn's own bootstrap ordering is respected.

**Also measured, and worth recording since it nearly produced a false-positive gate**: a naive probe that imports `litellm` BEFORE `reyn` (skipping `reyn/__init__.py`'s own `LITELLM_LOCAL_MODEL_COST_MAP` `setdefault`) sees **8 real connect attempts to `raw.githubusercontent.com`** — litellm's own remote model-cost-map fetch (`litellm_core_utils/get_model_cost_map.py`), triggered purely by `import litellm`, independent of anything reyn's own code does. The gate's test suite documents and falsifies against exactly this ordering trap.

## Landing condition (architect, non-negotiable)

> 赤のメッセージが「reyn 側の対処」を名指しすること

`NetworkReachProbe.assert_clean`'s message names both of reyn's known suppression points (`LITELLM_LOCAL_MODEL_COST_MAP`, the bundled tiktoken cache / #4422's diagnosis) — CLAUDE.md's Q1 "third-party promise" discriminator, applied to a gate message instead of a test assertion.

## Test plan

- [x] `test_one_turn_under_default_config_reaches_zero_real_sockets` — real subprocess (a pytest worker may already have `litellm` in `sys.modules` from an earlier test, making an in-process re-import measure nothing), real router turn via `run-once`, zero real sockets.
- [x] Falsify-verified as a genuinely independent pair (not one test doing both jobs):
  - `test_skipping_reyns_bootstrap_order_really_does_reach_the_network` — subprocess, a RAW inline socket patch (deliberately NOT `NetworkReachProbe`, which lives inside the `reyn` package and would silently defeat the "litellm before reyn" ordering by importing `reyn` first — an earlier draft of this PR hit exactly that and had to be restructured).
  - `test_assert_clean_names_reyns_own_remedy` — in-process, no subprocess, checks the message CONTRACT against a manually populated `.attempts` list.
- [x] Gates clean: `ruff check`, `mypy_ratchet.py`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `check_tests_path_literal_reference.py`.
- [x] Regression sweep (`network_gate` / `litellm_lazy_load` / #4395 / #4418 / #4422 keyword scope, 58 passed + this PR's 3) clean except one pre-existing, unrelated flake (`test_4395_token_counter_persistent_failure_cooldown::test_persistent_failure_skips_the_next_call_entirely` — a process-global 60s cooldown leaking across tests sharing a worker; reproduces identically on `main` before this change, confirmed via the same keyword-scoped run on `main`, not touched by this PR).
- [x] Review round 1 (lead-coder): `_run()`'s `subprocess.run(..., timeout=60)` was testing.md's banned test-owned wait-budget shape, and would have reintroduced a 36th site into the population #4442's sweep already measured as 0-remaining (#4442 has since merged) — order didn't save it, that sweep had already run before this PR existed. Fixed: dropped `timeout=`, same residual wording #4442 uses everywhere else (`# #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.`). Checked for a hang path this could open: none — stdin is already redirected to `/dev/null` before `run-once` (which reads all of stdin) runs, and the completion call is fully served by the scripted `LLMReplay` subclass, never reaching real network. Verified 3 passed in 8.4s (externally timed via `timeout 120`, not asserted inside the test itself).
- [ ] (skipped — per the standing waiver; visual gate does not block merge)

**tests/ touched — TESTS-READ wait, no self-merge.**

**Not in this PR** — #4421's other two open axes (step ② naming: "e2e が見つけた「返り値のフィールド名」"; the token-counting-litellm-requirement count lead-coder asked for) are untouched; `part of #4421`, not `Closes`.

part of #4421

🤖 Generated with [Claude Code](https://claude.com/claude-code)


