### PR TITLE
TEMP falsify #4297 — do not merge

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -587,7 +587,7 @@ what happens afterwards. Both `continuity` and `display` default **on**.
 > path; litellm auto-manages that when it's left on the wire — a known
 > provider-dependency, not implemented here (proxy + Gemini reality).
 
-## `safety` block
+## `safety` config block
 
 Unified stop-condition namespace. Each value can be overridden per-invocation by the matching CLI flag. (The old top-level `limits:` key is gone; `safety:` is the single source of truth.)
 


### PR DESCRIPTION
**[docs-maintainer]** — Throwaway falsify PR for #4297. Deliberately breaks reyn-yaml.md's `safety-block` anchor (mirrors #4292's exact shape). Confirms `docs build (strict)` — now a required status check — genuinely blocks merge. Will close without merging once observed.