### PR TITLE
fix(#4446): session_pure's out-of-process import test now pins PYTHONPATH

### DIFF
--- a/tests/runtime/test_session_pure_extraction_3679_s1.py
+++ b/tests/runtime/test_session_pure_extraction_3679_s1.py
@@ -29,6 +29,7 @@ Three things pinned here, matching the stage-1 acceptance conditions
 from __future__ import annotations
 
 import inspect
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -75,7 +76,7 @@ def test_session_module_no_longer_has_the_old_private_names():
     assert not hasattr(session_mod, "_merge_memory_indexes")
 
 
-def test_session_pure_importable_without_first_importing_session():
+def test_session_pure_importable_without_first_importing_session(out_of_process_reyn):
     """Tier 2: acceptance condition ③ — `reyn.runtime.session_pure` is
     importable standalone, in a FRESH subprocess, without
     `reyn.runtime.session` (or anything that imports it) already loaded
@@ -85,13 +86,24 @@ def test_session_pure_importable_without_first_importing_session():
     back, importing it FIRST (before `session.py` has a chance to partially
     initialize) would raise the same
     "cannot import name ... from partially initialized module" this stage
-    is fixing."""
+    is fixing.
+
+    #4446: was missing `out_of_process_reyn` (and its PYTHONPATH pin) — a
+    spawned subprocess re-resolves `reyn` from the ambient venv, not from
+    this checkout's in-process `sys.path` (`pythonpath = ["src"]` only
+    affects THIS process). Without the pin, a machine whose ambient venv
+    has an editable install pointing at a DIFFERENT checkout silently reads
+    that one instead — exactly the #3231/#3024 incident `out_of_process_reyn`
+    exists to close, which every sibling subprocess-spawning test in this
+    repo already requests. This one just never had.
+    """
     # #4397: no timeout= — CI's own per-test pytest-timeout is the kill switch.
     proc = subprocess.run(
         [sys.executable, "-c", "import reyn.runtime.session_pure; print('OK')"],
         cwd=str(_REPO_ROOT),
         capture_output=True,
         text=True,
+        env={**os.environ, "PYTHONPATH": out_of_process_reyn},
     )
     assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
     assert "OK" in proc.stdout


### PR DESCRIPTION
**[docs-maintainer]** — #4446: `session_pure`'s out-of-process import test now pins `PYTHONPATH`.

## Root cause, determined before touching anything (per the issue's own instruction)

Two candidates named in the issue: ① a refactor (#3679) left a scaffold test pointing at a since-deleted module, or ② an environment-specific import failure. Checked directly:

```
$ echo $PYTHONPATH
(empty)
$ python3 -c "import reyn; print(reyn.__file__)"
/Users/.../junk/claude_sandbox/sandbox_2/src/reyn/__init__.py   # NOT this checkout
```

`reyn.runtime.session_pure` is real, current, and correctly used by every other test in the same file (and by #4441/#4442's own in-process work this session) — this is class **②**, not ①. root `conftest.py`'s own module docstring names the exact mechanism: `pyproject.toml`'s `pythonpath = ["src"]` only puts this checkout's `src/` on **this process's** `sys.path` — a spawned subprocess gets no such favor and re-resolves `reyn` from the ambient venv, which on this machine has an editable install pointing at an unrelated, stale checkout. This is the **exact #3231/#3024 incident** the repo already has a purpose-built guard for.

## Why CI stayed green (the issue's other question)

CI runs in a clean checkout with a complete venv installed FROM that checkout — no stray ambient editable install exists there, so the subprocess correctly resolves the right `reyn` and the test passes. This is a **local-machine-only** failure, not a CI blind spot and not a stale scaffold — `main` staying green was the correct, honest signal here, not a false one.

## The fix

The test was simply missing `out_of_process_reyn` — the exact fixture this codebase already built for this exact failure mode (`tests/conftest.py`, `#3024`), which every sibling subprocess-spawning test in the repo already requests (I touched ~10 of them in #4397 alone). Added the fixture param and pinned its value into the spawn's `env={"PYTHONPATH": ...}`, matching the established pattern — no new mechanism invented.

## Test plan

- [x] Falsified: stashed the fix, confirmed `test_session_pure_importable_without_first_importing_session` RED with the exact `ModuleNotFoundError: No module named 'reyn.runtime.session_pure'` this issue reported (the other 5 tests in the file unaffected); restored, confirmed all 6 GREEN on this same machine, with the same stale ambient install still in place — the fix genuinely neutralizes the machine-dependence, not just happens to pass.
- [x] `ruff check`, `python scripts/mypy_ratchet.py` (unchanged), `python scripts/test_tier_audit.py --strict` (0 Tier-4), `python scripts/check_tests_path_literal_reference.py` — all clean. (`verify_module_docstrings.py` N/A — no `src/` files touched.)
- [x] Broad sweep: `tests/runtime/` (full) — 1721 passed, 1 skipped, 0 failures.
- [ ] Visual/manual (owner env) — per the standing waiver (CLAUDE.md, 2026-08-08), left unchecked; owner confirms after merge on `main`.

**tests/ touched — TESTS-READ wait, no self-merge.**

## Arc note

Closes #4446 — a single, self-contained root-cause fix; no other open PR claims partial scope (checked via `gh issue list --search "4446 in:body"`, only match is an unrelated CLOSED issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
