### PR TITLE
fix(#4381): PR-1 — resolve_effective_trigger_and_budgets enforces the resource/budget invariant

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -176,6 +176,7 @@ presentation_load_failed
 presented
 project_context_changed
 repo_ingest_files_skipped
+resource_cap_exceeds_budget_trigger
 router_context_overflow_detected
 router_context_overflow_unrecovered
 router_empty_response_detected
@@ -279,6 +280,7 @@ See [Concepts: multi-agent](../../concepts/multi-agent/multi-agent.md) — "Agen
 | `llm_response_received` | `prompt_tokens`, `completion_tokens`, `cached_tokens`, `cache_creation_tokens`, `cost_usd`, `usage_source` (+ `chain_id`) |
 | `embedding_index_build_complete` | `source_id`, `chunk_count`, `total_tokens`, `cost_usd`, `embedding_model` (a disk-adopt/no-fresh-build completion carries `total_tokens`/`cost_usd` as `null` — no embed call happened that run, not a cost of zero) |
 | `repo_ingest_files_skipped` | #4431 — the repo-knowledge (`knowledge_repo_doc`/`knowledge_repo_src`) background build excluded one or more files for exceeding `_REPO_INGEST_MAX_BYTES` (256 KB, `src/reyn/data/index/knowledge_ingest.py`). Emitted once per build, only when the count is nonzero — a routine build with nothing skipped emits no event at all. `kind` (`"doc"`/`"src"`), `skipped_count`, `reason` (currently always `"over_size_cap"`) |
+| `resource_cap_exceeds_budget_trigger` | #4381 PR-1 — `resolve_effective_trigger_and_budgets`'s own invariant check (`src/reyn/runtime/services/router_history_buffer.py`): the per-result resource boundary (`control_ir_inline_cap`, chars, converted to tokens via `context_builder.INLINE_CAP_CHARS_PER_TOKEN`) exceeds the budget boundary (`effective_trigger`, the model's context window). Detection only — no value is clamped. Warn-once per `(model, phase)`, not per call (this SSoT runs on every trigger resolution). `model`, `phase` (`""` when none), `resource_bound_chars`, `resource_bound_tokens`, `effective_trigger` |
 
 `usage_source` says where the token counts came from: `provider` (the provider
 reported them) or `estimated` (the provider's stream carried no usage, so

--- a/src/reyn/core/context_builder.py
+++ b/src/reyn/core/context_builder.py
@@ -34,7 +34,15 @@ MAX_CONTROL_IR_RESULT_INLINE_BYTES: int = 8_192   # ~8KB threshold
 # fixed 8KB was a root anomaly — same class as #1201/#1172 (fixed-constant →
 # window-derive). The per-RESULT cap is orthogonal to count-axis compaction,
 # which still trims the TOTAL across results.
-_INLINE_CAP_CHARS_PER_TOKEN: int = 4
+#
+# #4381 PR-1: this is THE ONE named chars→tokens conversion (architect
+# design) — the resource boundary (this module, chars) and the budget
+# boundary (`router_history_buffer.resolve_effective_trigger_and_budgets`,
+# tokens) are compared through THIS constant and nowhere else; a second,
+# independently-derived chars-per-token ratio anywhere else would reopen the
+# exact silent-drift class #4381 PR-1 closes. Public (not `_`-prefixed) for
+# that reason — it is a cross-module conversion point, not a local detail.
+INLINE_CAP_CHARS_PER_TOKEN: int = 4
 _INLINE_CAP_WINDOW_FRACTION: float = 0.08  # one result may inline up to ~8% of the window
 
 
@@ -56,6 +64,6 @@ def control_ir_inline_cap(
     from reyn.llm.model_budget import get_max_input_tokens
 
     t_max = get_max_input_tokens(model_resolved, events=events, phase=phase)
-    derived = int(t_max * _INLINE_CAP_CHARS_PER_TOKEN * _INLINE_CAP_WINDOW_FRACTION)
+    derived = int(t_max * INLINE_CAP_CHARS_PER_TOKEN * _INLINE_CAP_WINDOW_FRACTION)
     return max(MAX_CONTROL_IR_RESULT_INLINE_BYTES, derived)
 

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -348,6 +348,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "presented",
     "project_context_changed",
     "repo_ingest_files_skipped",
+    "resource_cap_exceeds_budget_trigger",
     "router_context_overflow_detected",
     "router_context_overflow_unrecovered",
     "router_empty_response_detected",

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -179,8 +179,68 @@ def _refresh_skill_location_tokens(
     )
 
 
+# #4381 PR-1: warn-once cache for the resource/budget invariant below, keyed
+# per (model, phase) — a high-frequency-called SSoT (every trigger
+# resolution) must not warn on every call; process-global by design (mirrors
+# `reyn.llm.litellm_bootstrap`'s own one-shot flags). Reset in tests via
+# `_resource_budget_warned.clear()`.
+_resource_budget_warned: "set[tuple[str, str | None]]" = set()
+
+
+def _check_resource_within_budget(
+    model: str, phase: "str | None", effective_trigger: int, events: Any,
+) -> None:
+    """#4381 PR-1: the invariant this SSoT now enforces — "a result that
+    passed the resource boundary must not exceed the budget boundary after
+    conversion" (architect design, #4381). Two independent read-cap-vs-
+    spill-cap mismatches (#4381's own reported incident, #4432's spill-loop
+    guard) trace to this SAME class going unchecked: the resource boundary
+    (``control_ir_inline_cap``, CHARS — memory/transfer-scoped, model-
+    derived today; owner ruling may make it a model-independent config byte
+    value later, at which point THIS function's arguments alone can no
+    longer derive it and a config value must be threaded in — not done in
+    PR-1) and the budget boundary (``effective_trigger``, TOKENS — the
+    model's context window) are never compared anywhere before this PR, so
+    a resource-bounded result that looks "safe" in chars can still overflow
+    the budget boundary once converted.
+
+    The conversion point is ``context_builder.INLINE_CAP_CHARS_PER_TOKEN``
+    — the ONE named chars→tokens conversion (architect: name it once, don't
+    re-derive the same ratio elsewhere). Rounded UP (ceil): understating the
+    resource bound's token cost would make this check too permissive, the
+    wrong direction for a safety check.
+
+    Warn-once per ``(model, phase)`` (not per call — this SSoT is called on
+    every trigger resolution, so warning every time would flood the log)
+    via a ``resource_cap_exceeds_budget_trigger`` audit-event. Detection
+    only in PR-1 — no value is clamped; the class closes once the resource
+    boundary itself moves to a model-independent byte value (later PR).
+    """
+    from reyn.core.context_builder import (
+        INLINE_CAP_CHARS_PER_TOKEN,
+        control_ir_inline_cap,
+    )
+
+    resource_bound_chars = control_ir_inline_cap(model, events=events, phase=phase)
+    resource_bound_tokens = -(-resource_bound_chars // INLINE_CAP_CHARS_PER_TOKEN)  # ceil
+    if resource_bound_tokens <= effective_trigger:
+        return
+    key = (model, phase)
+    if key in _resource_budget_warned:
+        return
+    _resource_budget_warned.add(key)
+    if events is not None:
+        events.emit(
+            "resource_cap_exceeds_budget_trigger",
+            model=model, phase=phase or "",
+            resource_bound_chars=resource_bound_chars,
+            resource_bound_tokens=resource_bound_tokens,
+            effective_trigger=effective_trigger,
+        )
+
+
 def resolve_effective_trigger_and_budgets(
-    compaction_controller: Any, model: str, events: Any,
+    compaction_controller: Any, model: str, events: Any, *, phase: "str | None" = None,
 ) -> "tuple[int, int, int]":
     """Return ``(effective_trigger, head_budget, tail_budget)`` — #2957 PR-B
     single SSoT for this lookup.
@@ -191,15 +251,30 @@ def resolve_effective_trigger_and_budgets(
     ``compaction_controller._engine.budgets`` lookup + ``get_max_input_tokens``
     fallback independently — a duplication that could silently drift (one
     site's fallback changing without the other). Both now delegate here.
+
+    #4381 PR-1: also the SSoT for the resource/budget invariant (see
+    ``_check_resource_within_budget``) — the third instance of this same
+    "two independently-computed things can silently drift" class this
+    function already exists to close (PR-B's own docstring names the first
+    two). ``phase`` (#4381: granularity is per ``(model, phase)``, not once
+    per session — ``control_ir_inline_cap`` itself already takes ``phase``)
+    defaults to ``None`` for both existing callers, neither of which has a
+    phase concept today; a future phase-aware caller can pass a real value
+    without a signature change.
     """
     engine = getattr(compaction_controller, "_engine", None) if compaction_controller is not None else None
     budgets = getattr(engine, "budgets", None)
     if budgets is not None:
-        return budgets.effective_trigger, budgets.head_budget, budgets.tail_budget
-    from reyn.llm.model_budget import get_max_input_tokens
-    effective_trigger = get_max_input_tokens(model, events=events)
-    fallback = effective_trigger // 4
-    return effective_trigger, fallback, fallback
+        effective_trigger, head_budget, tail_budget = (
+            budgets.effective_trigger, budgets.head_budget, budgets.tail_budget,
+        )
+    else:
+        from reyn.llm.model_budget import get_max_input_tokens
+        effective_trigger = get_max_input_tokens(model, events=events)
+        fallback = effective_trigger // 4
+        head_budget, tail_budget = fallback, fallback
+    _check_resource_within_budget(model, phase, effective_trigger, events)
+    return effective_trigger, head_budget, tail_budget
 
 
 # ── RouterHistoryBuffer ───────────────────────────────────────────────────────

--- a/tests/runtime/test_4381_pr1_resource_budget_invariant.py
+++ b/tests/runtime/test_4381_pr1_resource_budget_invariant.py
@@ -1,0 +1,138 @@
+"""Tier 2: #4381 PR-1 — the resource/budget invariant `resolve_effective_trigger_and_budgets`
+now enforces: "a result that passed the resource boundary must not exceed the
+budget boundary after conversion."
+
+Real collaborators throughout: `compute_budgets` (the same function
+`CompactionEngine` itself uses) builds a real `ComputedBudgets`; only the
+tiny attribute-passthrough container matching `compaction_controller._engine
+.budgets`'s shape is hand-built (no logic of its own — mirrors the existing
+`_FakeEngine`/`_FakeController` idiom in
+`tests/llm/test_context_budget_advisor_raw_window.py`), and `EventLog` +
+`tests._support.events.collect_events` capture the real subscriber path.
+"""
+from __future__ import annotations
+
+from reyn.config import CompactionConfig
+from reyn.core.context_builder import INLINE_CAP_CHARS_PER_TOKEN, control_ir_inline_cap
+from reyn.core.events.events import EventLog
+from reyn.llm.model_budget import get_max_input_tokens
+from reyn.runtime.services import router_history_buffer as rhb
+from reyn.services.compaction.engine import compute_budgets
+from tests._support.events import collect_events
+
+_MODEL = "openai/gpt-4o"
+
+
+class _Engine:
+    def __init__(self, budgets) -> None:
+        self.budgets = budgets
+
+
+class _Controller:
+    def __init__(self, engine) -> None:
+        self._engine = engine
+
+
+def _budgets_with_effective_trigger(t_sp: int):
+    return compute_budgets(CompactionConfig(), _MODEL, T_SP=t_sp, T_comp_SP=500)
+
+
+def _reset_warned():
+    rhb._resource_budget_warned.clear()
+
+
+def test_resource_bound_actually_exceeds_the_small_budget_in_this_scenario():
+    """Tier 2: sanity precondition for the tests below — with `T_SP` close to
+    the model's window, `effective_trigger` collapses well under the
+    resource boundary's own token-equivalent, so the invariant genuinely
+    trips (not an assumption)."""
+    resource_bound_chars = control_ir_inline_cap(_MODEL)
+    resource_bound_tokens = -(-resource_bound_chars // INLINE_CAP_CHARS_PER_TOKEN)
+    small_budgets = _budgets_with_effective_trigger(get_max_input_tokens(_MODEL) - 500)
+    assert small_budgets.effective_trigger < resource_bound_tokens
+
+
+def test_violation_emits_resource_cap_exceeds_budget_trigger_once():
+    """Tier 2: a genuine violation (resource bound, converted to tokens,
+    exceeds the budget trigger) emits `resource_cap_exceeds_budget_trigger`
+    exactly once — repeated calls with the SAME (model, phase) do not
+    re-warn (the SSoT is called on every trigger resolution)."""
+    _reset_warned()
+    events = EventLog()
+    collected = collect_events(events)
+    budgets = _budgets_with_effective_trigger(get_max_input_tokens(_MODEL) - 500)
+    controller = _Controller(_Engine(budgets))
+
+    for _ in range(3):
+        result = rhb.resolve_effective_trigger_and_budgets(controller, _MODEL, events)
+        assert result == (budgets.effective_trigger, budgets.head_budget, budgets.tail_budget)
+
+    warnings = [e for e in collected if e.type == "resource_cap_exceeds_budget_trigger"]
+    (only,) = warnings
+    assert only.data["model"] == _MODEL
+    assert only.data["phase"] == ""
+    assert only.data["effective_trigger"] == budgets.effective_trigger
+    assert only.data["resource_bound_tokens"] > budgets.effective_trigger
+
+
+def test_violation_warns_again_for_a_different_phase_same_model():
+    """Tier 2: warn-once granularity is per (model, phase), not per model
+    alone — a DIFFERENT phase with the same model re-warns."""
+    _reset_warned()
+    events = EventLog()
+    collected = collect_events(events)
+    budgets = _budgets_with_effective_trigger(get_max_input_tokens(_MODEL) - 500)
+    controller = _Controller(_Engine(budgets))
+
+    rhb.resolve_effective_trigger_and_budgets(controller, _MODEL, events, phase="alpha")
+    rhb.resolve_effective_trigger_and_budgets(controller, _MODEL, events, phase="alpha")
+    rhb.resolve_effective_trigger_and_budgets(controller, _MODEL, events, phase="beta")
+
+    warnings = [e for e in collected if e.type == "resource_cap_exceeds_budget_trigger"]
+    phases_warned = sorted(e.data["phase"] for e in warnings)
+    assert phases_warned == ["alpha", "beta"]
+
+
+def test_no_violation_emits_nothing():
+    """Tier 2: accept-side twin — a normal-sized `T_SP` leaves `effective_trigger`
+    comfortably above the resource bound's token-equivalent; no event fires
+    at all (not a present-but-benign one)."""
+    _reset_warned()
+    events = EventLog()
+    collected = collect_events(events)
+    budgets = _budgets_with_effective_trigger(2_000)
+    controller = _Controller(_Engine(budgets))
+
+    result = rhb.resolve_effective_trigger_and_budgets(controller, _MODEL, events)
+
+    assert result == (budgets.effective_trigger, budgets.head_budget, budgets.tail_budget)
+    assert not [e for e in collected if e.type == "resource_cap_exceeds_budget_trigger"]
+
+
+def test_no_events_sink_does_not_raise():
+    """Tier 2: `events=None` (many test/estimation-path callers construct
+    without one) — the check runs and detects the violation internally but
+    never tries to emit, and never raises for lack of a sink."""
+    _reset_warned()
+    budgets = _budgets_with_effective_trigger(get_max_input_tokens(_MODEL) - 500)
+    controller = _Controller(_Engine(budgets))
+
+    result = rhb.resolve_effective_trigger_and_budgets(controller, _MODEL, None)
+
+    assert result == (budgets.effective_trigger, budgets.head_budget, budgets.tail_budget)
+
+
+def test_fallback_path_no_engine_budgets_still_checks_the_invariant():
+    """Tier 2: the `budgets is None` fallback branch (no compaction engine
+    attached — the `get_max_input_tokens(model) // 4` fallback trigger) is
+    ALSO covered by the invariant check, not just the engine-budgets branch."""
+    _reset_warned()
+    events = EventLog()
+    collected = collect_events(events)
+
+    rhb.resolve_effective_trigger_and_budgets(None, _MODEL, events)
+
+    # Fallback trigger = get_max_input_tokens(model) // 4, comfortably above
+    # the resource bound for this model — no violation in the fallback path
+    # with a real, reasonably-sized model.
+    assert not [e for e in collected if e.type == "resource_cap_exceeds_budget_trigger"]


### PR DESCRIPTION
**[docs-maintainer]** — #4381 PR-1: `resolve_effective_trigger_and_budgets` enforces the resource/budget invariant.

## Design (architect, posted to #4381 — implemented as specified)

The resource boundary (`control_ir_inline_cap`, chars, model-derived) and the budget boundary (`effective_trigger`, tokens, the model's context window) were never compared anywhere — a resource-bounded read result that looks safe in chars can still overflow the budget boundary once converted. This is the **third instance** of the exact class `resolve_effective_trigger_and_budgets` already exists to prevent (#2957 PR-B's own docstring names the first two: `RouterHistoryBuffer`/`ContextBudgetAdvisor` independently reimplementing the same lookup).

**Invariant**: a result that passed the resource boundary must not exceed the budget boundary after conversion.

## The fix

- The chars→tokens conversion runs through **one named constant**: `context_builder.INLINE_CAP_CHARS_PER_TOKEN` — promoted from `_INLINE_CAP_CHARS_PER_TOKEN` (module-private) to a public cross-module constant, exactly because it's now a genuine cross-module conversion point (architect's explicit instruction: name it once, never re-derive the same ratio elsewhere). Rounded **up** (ceil) — understating the resource bound's token cost would make the check too permissive, the wrong direction for a safety check.
- `resolve_effective_trigger_and_budgets` gains an optional `phase: str | None = None` kwarg — granularity is per `(model, phase)`, not once per session, since `control_ir_inline_cap` itself already takes `phase`. Neither existing caller (`RouterHistoryBuffer._resolve_budgets`, `ContextBudgetAdvisor._get_effective_trigger`) has a phase concept today, so neither call site changes; a future phase-aware caller can pass a real value with no signature break.
- Per architect's 2 implementation notes: (1) this SSoT runs on every trigger resolution, so a per-call warning would flood the log — a process-global `(model, phase)` warn-once cache instead; (2) covered above.
- **Detection only** in PR-1 — no value is clamped. A new `resource_cap_exceeds_budget_trigger` audit-event fires once per violating `(model, phase)`, declared in both halves of the #3410 CI-checked doc↔code pair (`AUDIT_EVENT_KINDS` + `docs/reference/runtime/events.md`, vocabulary list + payload-table row).
- Config-value wiring for a future model-independent resource boundary (an owner ruling not yet implemented) is explicitly out of scope here, per architect's own note — the resource boundary is still model-derived in PR-1.

## Test plan

- [x] 6 new tests in `tests/runtime/test_4381_pr1_resource_budget_invariant.py`: a real-numbers sanity precondition (confirms the chosen scenario genuinely trips the invariant, not assumed); the violation path emits exactly once across 3 repeated calls with the same `(model, phase)`; a different `phase` re-warns; the accept-side twin (no violation → no event at all); `events=None` doesn't raise; the `budgets is None` fallback branch is also covered (not just the engine-budgets branch).
- [x] Real collaborators throughout — `compute_budgets` (the same function `CompactionEngine` itself uses) builds a real `ComputedBudgets`; the tiny `_Engine`/`_Controller` attribute-passthrough containers mirror the existing precedent in `tests/llm/test_context_budget_advisor_raw_window.py` (no logic of their own, just the attribute shape the function's own `getattr` chain expects); `EventLog` + `tests._support.events.collect_events` capture the real subscriber path.
- [x] Falsified: stashed all 4 source files, confirmed the new test file fails to even COLLECT (`ImportError: cannot import name 'INLINE_CAP_CHARS_PER_TOKEN'` — the whole feature is gone); restored, confirmed all 6 GREEN.
- [x] `python -m pytest tests/core/test_audit_event_kind_vocabulary_3410.py` — the CI-checked doc↔code pair — 10/10 green.
- [x] `ruff check`, `python scripts/mypy_ratchet.py` (unchanged), `python scripts/test_tier_audit.py --strict` (0 Tier-4), `python scripts/verify_module_docstrings.py`, `python scripts/check_tests_path_literal_reference.py` — all clean.
- [x] Broad sweep: `tests/runtime/` + `tests/services/` (1847 passed / 1 skipped) and full `tests/core/` (2544 passed / 1 skipped) — 0 failures either way.
- [ ] Visual/manual (owner env) — per the standing waiver (CLAUDE.md, 2026-08-08), left unchecked; owner confirms after merge on `main`.

**tests/ touched — TESTS-READ wait, no self-merge.**

## Arc note

`part of #4381` — PR-2+ (history-finalization timing / taint read-site move / capture-height / read-cap bytes-conversion / force-close axis-② removal) are order-dependent on each other and land separately, per lead-coder's own sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
