### PR TITLE
fix(#4445): asyncio.wait_for(..., timeout=N) tests carry a wait budget

### DIFF
--- a/tests/interfaces/test_textual_chat_phase1_3273.py
+++ b/tests/interfaces/test_textual_chat_phase1_3273.py
@@ -222,11 +222,15 @@ class R(ChatRenderer):
     def message(self, msg): R.n += 1
 
 
-asyncio.run(asyncio.wait_for(
+# #4445: no timeout= — same #4397 family (a test-owned wait-budget
+# constant), same rule even though this runs inside the subprocess this
+# module's own outer `subprocess.run` spawns (that call already carries
+# no timeout= of its own, per the same #4397 fix) — CI's own per-test
+# pytest-timeout is the kill switch either way.
+asyncio.run(
     run_chat_client(transport=T(), renderer=R(), read_model=RM(),
                     agent_name="default", is_tty=False),
-    timeout=10.0,
-))
+)
 assert R.n >= 2, "plain path did not render the conversation"
 assert "textual_flowview" not in sys.modules, "flowview imported during plain run"
 print("ISOLATION_OK")
@@ -267,10 +271,12 @@ async def test_plain_fallback_equivalence_same_turn_sequence() -> None:
     # Plain side: drive the real output loop with a recording renderer.
     renderer = _RecordingRenderer()
     plain_transport = ScriptedTransport(_CONVERSATION, end=True)
-    await asyncio.wait_for(
-        run_output_loop(plain_transport, renderer, None, command_ui_region=True),
-        timeout=5.0,
-    )
+    # #4445: no timeout= — same #4397 family; CI's own per-test
+    # pytest-timeout is the kill switch. `plain_transport` is a finite
+    # scripted sequence (`end=True`), so `run_output_loop` returns on its
+    # own once drained — the timeout was never load-bearing for a real
+    # condition here.
+    await run_output_loop(plain_transport, renderer, None, command_ui_region=True)
 
     # App side: feed the identical script through the app's frame pump.
     app_transport = ScriptedTransport(_CONVERSATION, end=False)

--- a/tests/runtime/test_textual_chat_phase5_3273.py
+++ b/tests/runtime/test_textual_chat_phase5_3273.py
@@ -567,7 +567,10 @@ async def test_restore_source_is_authoritative_chat_log_gate_na(tmp_path, monkey
         assert session.history_path.name == "history.jsonl"
         assert session.history_path.exists(), "the source file is history.jsonl on disk"
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        # #4445: no timeout= — same #4397 family (a test-owned wait-budget
+        # constant); CI's own per-test pytest-timeout is the kill switch.
+        # `reg.shutdown()` awaited directly, unbounded.
+        await reg.shutdown()
 
 
 @pytest.mark.asyncio
@@ -593,7 +596,10 @@ async def test_retention_is_resume_equivalent(tmp_path, monkeypatch) -> None:
             "limit must keep the most-recent N turns (resume-equivalent)"
         )
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        # #4445: no timeout= — same #4397 family (a test-owned wait-budget
+        # constant); CI's own per-test pytest-timeout is the kill switch.
+        # `reg.shutdown()` awaited directly, unbounded.
+        await reg.shutdown()
 
 
 @pytest.mark.asyncio
@@ -661,7 +667,10 @@ async def test_typed_failure_flag_round_trips_through_disk_history(tmp_path, mon
             "result": "Error: disk full at 03:14, retrying write"
         }
     finally:
-        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+        # #4445: no timeout= — same #4397 family (a test-owned wait-budget
+        # constant); CI's own per-test pytest-timeout is the kill switch.
+        # `reg.shutdown()` awaited directly, unbounded.
+        await reg.shutdown()
 
 
 # ── Tier 2c: import isolation preserved (accessor adds no always-loaded import) ─


### PR DESCRIPTION
**[tui-coder]** — #4445: `asyncio.wait_for(..., timeout=N)` is the same 4397 family — checked before fixing

## Judgment (this issue's actual first job, per dispatch)

Checked whether these 2 files are genuinely the same family as issue 4397 (landed as #4442) before touching anything:

- **testing.md's "no exception" ruling is unconditional on the wait MECHANISM**, not scoped to `subprocess.run` — "a test carries no time limit of its own... not a wait budget written into the test body" applies identically to `asyncio.wait_for(coro, timeout=N)`.
- **"wait_for's timeout is mandatory" resolves cleanly**: `timeout` has no default (`inspect.signature` confirms), but it accepts `None` — meaning "wait unboundedly," the same semantics dropping the wrapper entirely gets. So "replace with a different wait mechanism" (lead-coder's flagged possibility) wasn't actually needed — a bare `await coro` does the same job, simpler.
- **One real nuance, checked and found NOT to create an exception**: one site (`test_textual_chat_phase1_3273.py`'s `_ISOLATION_SUBPROCESS` embedded script) runs inside a CHILD subprocess, several process boundaries away from CI's per-test pytest-timeout signal — unlike the in-process sites, there's no guarantee that signal reaches this coroutine's process. testing.md's own text already anticipates and rejects this as grounds for an exception ("the kill does not promise cleanup... nothing may treat the kill switch as a safety net to lean on" — a stated KNOWN limitation, not an unaddressed one). Fixed identically to the other 3 sites, not carved out.

**Conclusion: same family. Fixed, not closed.**

## What changed (4 sites, same fix)

- `tests/interfaces/test_textual_chat_phase1_3273.py`: the `_ISOLATION_SUBPROCESS` embedded script's `asyncio.run(...)` call, and `test_plain_fallback_equivalence_same_turn_sequence`'s `run_output_loop` await (a finite scripted transport — the timeout was never load-bearing for a real condition).
- `tests/runtime/test_textual_chat_phase5_3273.py`: 3 identical `finally: await asyncio.wait_for(reg.shutdown(), timeout=5.0)` teardown sites, all replaced with a bare `await reg.shutdown()`.

## Test plan

- [x] Verified 75 passed (full `#3273` keyword scope) both before and after the change.
- [x] Gates clean: `ruff check`, `mypy_ratchet.py`, `test_tier_audit.py --strict`, `check_tests_path_literal_reference.py`.
- [ ] (skipped — per the standing waiver; visual gate does not block merge)

**tests/ touched — TESTS-READ wait, no self-merge.**

Closes #4445

🤖 Generated with [Claude Code](https://claude.com/claude-code)
