### PR TITLE
fix(#4381): PR-2 stage 3 — in-flight untrusted-taint latch

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3614,6 +3614,18 @@ class RouterLoop:
             }
             if external_source:
                 _tool_meta["external_source"] = True
+                # #4381 PR-2 stage ③: the SAME update point as the meta stamp
+                # above — not a second, independently-set signal. The meta
+                # stamp only becomes visible to `_effective_contextual_for_turn`
+                # once THIS history entry is persisted (`_append_entry` below);
+                # this in-flight flag closes the gap for the CURRENT turn's
+                # own remaining iterations, which see it immediately. Getattr-
+                # guarded: a host that never wired the callback (most test
+                # construction, phase hosts) behaves as a no-op, same
+                # convention as every other optional host method.
+                _mark_untrusted = getattr(host, "mark_untrusted_in_flight", None)
+                if _mark_untrusted is not None:
+                    _mark_untrusted()
             # #73 (Option C, co-vet-directed): stamp the ALREADY-KNOWN success/failure
             # classification as a typed field — never re-derived downstream from the
             # rendered ``content_str`` (a display string is not a stable data contract;

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -222,6 +222,10 @@ class RouterHostAdapter:
         #3792. Async callback ``(msg_id: str) -> None`` —
         ``Session.commit_mid_turn_injection``. Same ``None``-default contract
         as ``peek_mid_turn_injection``.
+    mark_untrusted_in_flight:
+        #4381 PR-2 stage ③. Sync callback ``() -> None`` —
+        ``Session._mark_untrusted_in_flight``. Same ``None``-default contract
+        as ``peek_mid_turn_injection``.
     """
 
     # RouterLoopHost Protocol attributes (non-property)
@@ -301,6 +305,13 @@ class RouterHostAdapter:
         # exactly like a phase host (no-op seam).
         peek_mid_turn_injection: "Callable[[], Awaitable[dict | None]] | None" = None,
         commit_mid_turn_injection: "Callable[[str], Awaitable[None]] | None" = None,
+        # #4381 PR-2 stage ③: sync callback () -> None — Session.
+        # _mark_untrusted_in_flight. Bare, no shared-consumer partner (mirrors
+        # peek/commit_mid_turn_injection's own bare-ness above). None-default
+        # so pre-existing hand-built adapters (tests, other call sites) stay
+        # valid; router_loop.py getattr-guards the call, same as every other
+        # optional host method.
+        mark_untrusted_in_flight: "Callable[[], None] | None" = None,
         # Proposal 0067 P1' (#3978): mark_task_pending — bare, no shared-
         # consumer partner (same reasoning as the peek/commit pair above).
         # None-default so pre-existing hand-built adapters stay valid;
@@ -567,6 +578,8 @@ class RouterHostAdapter:
         # #3792
         self._peek_mid_turn_injection_cb = peek_mid_turn_injection
         self._commit_mid_turn_injection_cb = commit_mid_turn_injection
+        # #4381 PR-2 stage ③
+        self._mark_untrusted_in_flight_cb = mark_untrusted_in_flight
         # Proposal 0067 P1' (#3978)
         self._mark_task_pending_cb = mark_task_pending
         # FP-0034 PR-3b-iii
@@ -1844,6 +1857,22 @@ class RouterHostAdapter:
             tool_call_id=tool_call_id,
             name=name,
         ))
+
+    def mark_untrusted_in_flight(self) -> None:
+        """#4381 PR-2 stage ③: forward to ``Session._mark_untrusted_in_flight``
+        when wired.
+
+        None-safe (pre-existing hand-built adapters, most test construction)
+        — behaves exactly like a host that never implemented the hook, same
+        convention as ``peek_mid_turn_injection`` above. Called from
+        ``router_loop.py``'s tool-result production, at the SAME line that
+        stamps ``external_source`` onto the persisted ``ChatMessage.meta``
+        (single update point — no second, independently-maintained taint
+        signal to drift out of sync with the one ``metas_have_untrusted``
+        reads once the entry lands in history).
+        """
+        if self._mark_untrusted_in_flight_cb is not None:
+            self._mark_untrusted_in_flight_cb()
 
     async def peek_mid_turn_injection(self) -> "dict | None":
         """#3792: forwards to ``Session.peek_mid_turn_injection`` when wired.

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1022,6 +1022,18 @@ class Session:
         self._attended: bool = True
         # Lazily-resolved minimal _untrusted profile cache (#1827 S4b, see docs/reference/runtime/session-construction.md#capability-permission-visibility)
         self._untrusted_contextual_cache = None
+        # #4381 PR-2 stage ③: per-turn in-flight taint latch — set the moment
+        # router_loop.py stamps `external_source` on a tool-result's meta
+        # (RouterHostAdapter.mark_untrusted_in_flight, same update point, no
+        # second signal to drift), reset at each turn's start
+        # (`_run_router_loop`). Closes the gap `_ephemeral_contextual_for_turn`'s
+        # `self.history` scan alone cannot see: a same-turn tool result whose
+        # history entry has not yet landed (relevant once #4381's later PR
+        # defers that commit to after the turn's response). Monotonic for the
+        # turn's own remaining iterations, matching the existing
+        # `_untrusted_latched` per-iteration latch's own "narrows, never
+        # un-narrows mid-turn" discipline.
+        self._in_flight_untrusted_this_turn: bool = False
         # excluded_categories (#1667) + the visibility override (#2285) are owned by
         # CapabilityVisibility, constructed below (see #3121 step3 Extract Class).
         # Session-scoped hook APPLICABILITY override, per-session by construction (#2285, see session-construction.md#capability-permission-visibility)
@@ -2783,7 +2795,10 @@ class Session:
             return None
         watermark = self._compaction_watermark()
         active = (m for m in self.history if m.seq == 0 or m.seq > watermark)
-        if not metas_have_untrusted(m.meta for m in active):
+        # #4381 PR-2 stage ③: history scan OR the in-flight latch — the
+        # latch covers a same-turn tool result whose history entry has not
+        # landed yet (see the flag's own docstring in __init__ for why).
+        if not (metas_have_untrusted(m.meta for m in active) or self._in_flight_untrusted_this_turn):
             return None
         if self._untrusted_contextual_cache is None:
             root = self._perm.project_root if self._perm is not None else Path.cwd()
@@ -2792,6 +2807,20 @@ class Session:
                 origin=UNTRUSTED_NARROWING_ORIGIN,
             )[0]
         return self._untrusted_contextual_cache
+
+    def _mark_untrusted_in_flight(self) -> None:
+        """#4381 PR-2 stage ③: set the per-turn in-flight taint latch.
+
+        Wired into ``RouterHostAdapter`` as ``mark_untrusted_in_flight`` and
+        called by ``router_loop.py`` at the SAME point it stamps
+        ``external_source`` onto a tool-result's persisted meta — see that
+        call site's own comment for why this is not a second, independently-
+        maintained signal. Reset to ``False`` at the top of
+        ``_run_router_loop`` (each new turn); never cleared mid-turn (the
+        same "narrows, never un-narrows before the turn boundary" property
+        ``_untrusted_latched`` already has for the per-iteration rung).
+        """
+        self._in_flight_untrusted_this_turn = True
 
     # ── persistence ─────────────────────────────────────────────────────────────
 
@@ -4324,6 +4353,8 @@ class Session:
             # #3792: mid-turn CLIENT_INPUT injection.
             peek_mid_turn_injection=self._inbox_arbiter.peek_mid_turn_injection,
             commit_mid_turn_injection=self._commit_mid_turn_injection,
+            # #4381 PR-2 stage ③: in-flight taint latch.
+            mark_untrusted_in_flight=self._mark_untrusted_in_flight,
             # Proposal 0067 P1' (#3978)
             mark_task_pending=lambda: setattr(self, "current_task", CurrentTask()),
             universal_wrappers_enabled=self._action_retrieval.universal_wrappers_enabled,
@@ -8111,6 +8142,10 @@ class Session:
             _arm_stall_trace(_stall_seconds)
         try:
             self._last_turn_chain_id = chain_id
+            # #4381 PR-2 stage ③: reset the in-flight taint latch for the
+            # NEW turn — never cleared mid-turn (see the flag's own
+            # docstring in __init__).
+            self._in_flight_untrusted_this_turn = False
             await self._router_host.maybe_refresh_mcp_tools_from_yaml()
             self._router_host.maybe_reload_mcp_tools_cache_from_disk()
             await self._router_host.ensure_mcp_tools_cached(

--- a/tests/llm/test_4381_pr2_stage3_in_flight_untrusted_flag.py
+++ b/tests/llm/test_4381_pr2_stage3_in_flight_untrusted_flag.py
@@ -1,0 +1,195 @@
+"""Tier 2: #4381 PR-2 stage ③ — the in-flight untrusted-taint latch.
+
+architect's corrected design (posted to #4381, after the docs-maintainer's own
+question surfaced a flaw in the first draft): the resource this PR touches is
+NOT "no witness exists" — ``meta`` already carries ``external_source`` at
+``router_loop.py``'s tool-result production, a persisted PROJECTION of the
+taint, not its origin. The real problem is TIMING: ``_ephemeral_contextual_
+for_turn`` (the per-iteration re-narrow check, #1909/#3501) reads
+``self.history``, which only reflects what has already been COMMITTED — and
+a LATER PR (#4381 ①, not yet implemented) will defer that commit to after
+the turn's model response, opening a same-turn window where a tool result's
+taint is real but invisible to the history scan.
+
+This file pins the fix in isolation, ahead of ① landing: a single in-flight
+boolean latch, set at the SAME line ``router_loop.py`` stamps
+``external_source`` onto the persisted meta (no second, independently-
+maintained signal), read by ``_ephemeral_contextual_for_turn``'s gate as an
+OR alongside the history scan. Since ① does not exist yet, the "history has
+not landed" precondition is constructed directly (monkeypatching the
+captured ``RouterHostAdapter._append_history_cb`` to silently drop ONLY the
+tainted tool-result entry) — the SAME technique
+``test_1909_intra_turn_opt_in_narrowing.py``'s own compaction-survival test
+already uses to construct an analogous "the record isn't there" edge case,
+not a departure from this suite's established idiom.
+
+Real ``Session`` + real history + real tool registry + scripted
+``call_llm_tools`` throughout — no ``_FakeMessage``/hand-rolled host
+stand-in (#2957 PR-A precedent, same as this file's sibling).
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+from tests._support.untrusted_narrowing import narrowing_on
+
+_USAGE = TokenUsage(prompt_tokens=10, completion_tokens=5)
+
+_REMEMBER_ARGS = {
+    "slug": "y", "name": "n", "description": "d", "type": "user", "body": "x",
+}
+
+
+def _tool_call_result(calls: list[dict]) -> LLMToolCallResult:
+    tool_calls = [
+        {
+            "id": c.get("id", f"tc_{i}"),
+            "type": "function",
+            "function": {"name": c["name"], "arguments": json.dumps(c.get("args", {}))},
+        }
+        for i, c in enumerate(calls)
+    ]
+    return LLMToolCallResult(
+        content=None, tool_calls=tool_calls, finish_reason="tool_calls", usage=_USAGE,
+    )
+
+
+def _text_result(text: str) -> LLMToolCallResult:
+    return LLMToolCallResult(content=text, tool_calls=[], finish_reason="stop", usage=_USAGE)
+
+
+def _scripted_llm(rounds: list):
+    state = {"n": 0}
+
+    async def _call(**kwargs: Any) -> LLMToolCallResult:
+        idx = state["n"]
+        r = rounds[idx]
+        state["n"] += 1
+        return r
+    return _call
+
+
+def _make() -> Session:
+    return make_session(agent_name="test_agent", safety=narrowing_on("iteration"))
+
+
+def _simulate_deferred_commit(session: Session) -> None:
+    """Wrap the ALREADY-CAPTURED ``RouterHostAdapter._append_history_cb`` so
+    an ``external_source``-tagged tool-result entry is silently dropped
+    instead of committed — simulating what a FUTURE deferred-commit PR (①)
+    will produce: the entry's taint is real (the in-flight flag still fires,
+    from its own separate call site) but not yet visible to a history scan.
+
+    Must patch the CAPTURED callback object, not ``session._append_history``
+    itself — ``RouterHostAdapter.__init__`` bound the method ONCE at Session
+    construction, so patching the instance attribute after the fact would
+    not be observed by the callback the adapter already holds.
+    """
+    real_cb = session._router_host._append_history_cb
+
+    def _drop_untrusted_tool_result(msg: Any) -> None:
+        if msg.role == "tool" and (msg.meta or {}).get("external_source"):
+            return
+        real_cb(msg)
+
+    session._router_host._append_history_cb = _drop_untrusted_tool_result
+
+
+@pytest.mark.asyncio
+async def test_flag_denies_when_history_has_not_landed_yet(tmp_path, monkeypatch):
+    """Tier 2: ★ positive control. With the tainted tool-result's history
+    entry simulated as not-yet-committed, the SAME-turn next dispatch
+    (``remember_shared``) is still denied — the in-flight flag alone, with
+    zero history support, is sufficient."""
+    monkeypatch.chdir(tmp_path)
+    session = _make()
+    _simulate_deferred_commit(session)
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools",
+        _scripted_llm([
+            _tool_call_result([{"name": "list_memory", "args": {"path": ""}, "id": "tc_ext"}]),
+            _tool_call_result([{"name": "remember_shared", "args": _REMEMBER_ARGS, "id": "tc_denied"}]),
+            _text_result("done"),
+        ]),
+    )
+
+    await session._handle_inbox_text("look something up then remember it", chain_id="c1")
+
+    assert not any((m.meta or {}).get("external_source") for m in session.history), (
+        "the simulated deferred-commit must have actually kept the tainted "
+        "entry out of history — otherwise this test proves nothing about "
+        "the flag (it would pass even via the ordinary history scan)"
+    )
+    (denied_msg,) = [m for m in session.history if m.tool_call_id == "tc_denied"]
+    assert "tool_excluded" in str(denied_msg.content)
+    assert "remember_shared" in str(denied_msg.content)
+
+
+@pytest.mark.asyncio
+async def test_falsify_without_the_flag_the_same_window_is_open(tmp_path, monkeypatch):
+    """Tier 2: ★ falsify — the EXACT same setup as the positive control
+    above, but with the flag-setting call itself neutralized. The denial
+    must NOT happen: this proves the positive control's denial genuinely
+    depends on the flag, not on some other, accidental mechanism (a bare
+    "it denied" assertion with no falsify twin would pass even if the flag
+    did nothing at all)."""
+    monkeypatch.chdir(tmp_path)
+    session = _make()
+    _simulate_deferred_commit(session)
+    # Neutralize ONLY the flag-setting path — RouterHostAdapter.
+    # mark_untrusted_in_flight forwards to this callback; a no-op leaves the
+    # gate with nothing but the (deliberately blinded) history scan.
+    session._router_host._mark_untrusted_in_flight_cb = None
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools",
+        _scripted_llm([
+            _tool_call_result([{"name": "list_memory", "args": {"path": ""}, "id": "tc_ext"}]),
+            _tool_call_result([{"name": "remember_shared", "args": _REMEMBER_ARGS, "id": "tc_allowed"}]),
+            _text_result("done"),
+        ]),
+    )
+
+    await session._handle_inbox_text("look something up then remember it", chain_id="c1")
+
+    assert not any((m.meta or {}).get("external_source") for m in session.history), (
+        "sanity: the deferred-commit simulation must still be in effect"
+    )
+    (msg,) = [m for m in session.history if m.tool_call_id == "tc_allowed"]
+    assert "tool_excluded" not in str(msg.content), (
+        "with the flag neutralized and history blinded, the same-turn "
+        "window is genuinely open — this is the exact failure mode #4381 "
+        "PR-2 exists to close, reproduced deliberately here as the flag's "
+        "own falsify twin"
+    )
+
+
+# ── order-falsify (architect's 3rd adversarial angle) — NOT WRITTEN ────────
+#
+# architect's design names a THIRD failure mode: at turn end, clearing the
+# in-flight flag BEFORE the deferred commit lands opens a window where BOTH
+# signals are false (flag already cleared, history not yet committed).
+#
+# This test cannot be meaningfully written against the CURRENT codebase.
+# Today there is no "commit" step separate from immediate persistence to
+# reorder against the flag's clear — router_loop.py's tool-result append is
+# synchronous and unconditional (§① has not landed), so by the time ANY
+# turn-boundary flag-clear could run, every one of that turn's history
+# entries is already, unconditionally, on disk. There is no reachable code
+# path today where "clear" and "commit" could race, so a test asserting one
+# would either not compile against real functions or would vacuously pass
+# with a hand-built stand-in — the exact "third-party promise" / "constructs
+# its own configuration" shape CLAUDE.md's test-review discipline (Tier
+# question ③) rules out.
+#
+# This is exactly the material #4381 ①'s own brief needs: whichever PR
+# implements the deferred commit must land the "commit, THEN clear" runtime
+# ordering, and MUST include this order-falsify test (swap the two steps,
+# confirm a same-turn dispatch inside the window is wrongly allowed) as its
+# own acceptance condition — it cannot be satisfied here, before ① exists.


### PR DESCRIPTION
**[docs-maintainer]** — #4381 PR-2 stage ③: in-flight untrusted-taint latch.

## Design (architect, corrected — posted after a clarifying question surfaced a flaw in the first draft)

The resource this stage touches is **not** "no witness exists" — `meta` already carries `external_source` at `router_loop.py`'s tool-result production, a persisted **projection** of the taint, not its origin. The real problem is **timing**: `_ephemeral_contextual_for_turn` (the per-iteration re-narrow check, #1909/#3501) reads `self.history`, which only reflects what has already been **committed**. A later PR (PR-2 stage 1, not yet implemented) will defer that commit to after the turn's model response, opening a same-turn window where a tool result's taint is real but invisible to the history scan — closing that window is the whole point of this stage, landed **ahead of** the deferral per the owner's own order-safety requirement (confirmed and adopted after I flagged the risk of landing them together).

## The fix

- `Session._in_flight_untrusted_this_turn: bool` — a single in-flight latch, reset at each turn's start (`_run_router_loop`), never cleared mid-turn (same "narrows, never un-narrows before the turn boundary" property `_untrusted_latched` already has for the per-iteration rung).
- Set at the **same line** `router_loop.py` stamps `external_source` onto the persisted meta — no second, independently-maintained signal to drift out of sync.
- Wired through `RouterHostAdapter.mark_untrusted_in_flight` — the exact shape the existing `peek_mid_turn_injection`/`commit_mid_turn_injection` pair already uses (bare param, `None`-default, `getattr`-guarded call site). Passes the measured consumer-set param gate (#3482, `tests/runtime/test_router_host_adapter_param_gate_3482.py`) unchanged.
- `_ephemeral_contextual_for_turn`'s gate: `metas_have_untrusted(...) or self._in_flight_untrusted_this_turn` — history scan OR the flag, per architect's own predicate.

## Test plan — 2 of the 3 adversarial angles the design calls for

1. **Positive control**: with the tainted entry's history commit simulated as not-yet-landed (the exact precondition PR-2 stage 1 will introduce — constructed by patching the *already-captured* `RouterHostAdapter._append_history_cb`, since `Session._append_history` was bound once at construction and a later instance-attribute patch would not be observed by that callback), the same-turn next dispatch is still denied — the flag alone, zero history support, is sufficient.
2. **Falsify**: the identical setup with the flag-setting callback neutralized — the denial does **not** happen, proving #1 genuinely depends on the flag and isn't vacuous.
3. **Order-falsify (architect's 3rd angle) — explicitly NOT written.** The runtime race it targets (clearing the flag before the deferred commit lands) has no reachable code path today, since PR-2 stage 1 (the deferral) doesn't exist yet — a test against it would either not compile against real functions or vacuously pass against a hand-built stand-in. Documented in the test file itself as the acceptance-condition material PR-2 stage 1's own brief needs, per the owner's explicit instruction to state the reason rather than force the test.

## Verification

- [x] Falsified: stashed all 3 source files, confirmed `test_flag_denies_when_history_has_not_landed_yet` RED (a genuinely different failure — without the fix `remember_shared` isn't excluded at all, it fails later on an unrelated write-permission path, confirming the flag mechanism is what makes exclusion happen); restored, confirmed both new tests GREEN.
- [x] Sibling suite unaffected: `test_1909_intra_turn_opt_in_narrowing.py` / `test_1909_external_tool_result_narrowing.py` / `test_3501_untrusted_narrowing_opt_in.py` / `test_3378_advertise_enforce_agreement.py` / `test_3380_tool_tab_ephemeral_narrowing.py` — 42/42 green (today's immediate-commit behavior means the flag is always redundant-but-harmless alongside an already-correct history scan; this is the expected no-observable-change sanity check).
- [x] `ruff check`, `python scripts/mypy_ratchet.py` (unchanged, 211/215 baselined), `python scripts/test_tier_audit.py --strict` (0 Tier-4), `python scripts/verify_module_docstrings.py`, `python scripts/check_tests_path_literal_reference.py` — all clean.
- [x] Broad sweep: `tests/llm/` + `tests/runtime/` (2415 passed / 1 skipped) and `tests/security/` + `tests/services/` (855 passed / 26 skipped) — 0 failures.
- [ ] Visual/manual (owner env) — per the standing waiver (CLAUDE.md, 2026-08-08), left unchecked; owner confirms after merge on `main`.

**tests/ touched — TESTS-READ wait, no self-merge.**

## Arc note

`part of #4381` — stage 1 (defer the commit itself, the "①" original scope) needs its own brief once the exact mechanics (does every `role="tool"` append defer, does `role="assistant"`'s own `tool_calls` message, how `build_history()` depends on the turn's in-progress state) are nailed down; this stage closing first is what makes that later stage's own order-falsify test (item 3 above) writable at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
