### PR TITLE
docs(#4448): rule 4 — a commit message is a separate closing-keyword surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,6 +376,20 @@ These rules then keep multi-session work coherent:
    **Reviewer recovery angle:** an unexpected issue auto-close triggered by a
    sub-PR merge is almost always a closing-keyword false positive. Reopen the
    issue and verify the arc is not half-done before assuming completion.
+   **This rule's checks all read the PR body — a `git commit` message is a
+   SEPARATE surface the same keyword-plus-number matching applies to, and
+   fixing it costs more.** `scripts/check_pr_closing_intent.py` scans every
+   individual commit message in the PR too (not just the body), because a
+   squash-merge's default commit message is the *concatenation* of the PR's
+   own commit messages — a closing keyword sitting in any one of them
+   appears in that default squash body regardless of what the PR body says
+   (#3187: the PR body was clean; an intermediate commit's message wasn't;
+   the squash-merge auto-closed the wrong issue). Editing the PR body does
+   NOT fix a commit-message violation — the gate stays red until the
+   offending commit is `amend`ed (or the history is rebased) and
+   force-pushed, real extra cost a body edit never needs (#4443 hit this
+   directly). The avoidance is the same single rule as the body's own: never
+   place a closing keyword next to an issue number, in either surface.
 5. **No blanket en/ja mirror obligation.** JA docs are a curated, intentionally
    partial subset (614 EN files vs 125 JA, repo-wide) — a PR is not required to
    touch a `.ja.md` file just because an EN sibling exists or just changed. Do


### PR DESCRIPTION
**[docs-maintainer]** — #4448: CLAUDE.md rule 4 — a commit message is a separate closing-keyword surface.

## Scope

Real incident (#4443): a PR body was clean ("part of #4397"), but a commit message contained the keyword+number pair (a lead-coder review comment had it; the implementer copied it verbatim into the commit body). `scripts/check_pr_closing_intent.py`'s own docstring already documents WHY it scans individual commit messages, not just the body — a squash-merge's default commit message concatenates the PR's own commit messages, so a violation in any one of them survives into the squash body regardless of what the PR body says (the same shape #3187 hit in production, cited in that script's own docstring).

Rule 4 previously wrote every check as if the PR body were the only surface. Fixing a body-only violation is a body edit; fixing a commit-message violation needs an `amend` (or rebase) + force-push — real, larger cost the rule didn't warn about, and #4443 paid it directly.

## The fix

One paragraph appended to rule 4, naming the second surface and its higher fix cost. Deliberately does **not** duplicate rule 7's existing "handed-off text is also subject to this" point — the actual gap here is narrower and more specific: commit messages specifically (a surface `check_pr_closing_intent.py` scans by design, not merely "text someone might paste elsewhere").

## Verification

- [x] Self-grepped the diff and the full commit message for keyword+number adjacency (`grep -inE "close|fix(e[sd])?|resolve"`) before every push, per rule 4's own discipline — clean; the two `#N` references in the new paragraph (#3187, #4443) sit inside prose describing what happened, never adjacent to a closing keyword.
- [x] `python scripts/check_tests_path_literal_reference.py` — clean (no `tests/` files touched, ran anyway per the standing pre-push discipline).
- [x] No code changed — doc-only, no `ruff`/`mypy`/test-tier/module-docstring gates apply.
- [ ] Visual/manual (owner env) — N/A, doc-text-only change with no rendered UI surface; left unchecked per the standing waiver regardless.

Not `tests/`-touching — no TESTS-READ gate; self-mergeable once CI is green.

## Arc note

Closes #4448 — enumerated first (`gh pr list --search "4448 in:body"`, 0 results): no other PR claims partial scope, and this is the sole, complete change for the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
