### PR TITLE
docs(#4381): ADR-0042 — force-close layer② removal recorded as a superseding decision

### DIFF
--- a/docs/deep-dives/decisions/0036-history-compaction-force-close-unification.md
+++ b/docs/deep-dives/decisions/0036-history-compaction-force-close-unification.md
@@ -1,6 +1,6 @@
 # ADR-0036 (#1092) — chat/plan/phase within-unit history + compaction + force-close unification (Fork 1: RouterLoop convergence)
 
-**Status**: ACCEPTED (user GO 2026-06-02 "懸念点なし、進められるなら進めて"; e2e technical review APPROVE, 3 precisions folded).
+**Status**: ACCEPTED — **"Implementation note: PR-F2b force-close handoff cap" superseded by [ADR-0042](0042-force-close-layer2-removal.md)** (2026-08-12); every other part stands unchanged. (user GO 2026-06-02 "懸念点なし、進められるなら進めて"; e2e technical review APPROVE, 3 precisions folded).
 **Track**: #1092 (umbrella). **Canonical contract / staging**: GitHub issue **#1234** (FD1–FD7 + staging PR-A..E + test discipline + scope boundary).
 **Builds on**: **ADR-0035** (#1212 — phase op-loop / separate-decide / frame-fed; a landed file at `docs/deep-dives/decisions/0035-phase-tool-calls-unification.md`). This ADR **PRESERVES** #1212's separate-decide and converges only the within-unit act-loop history representation (frame-fed → RouterLoop message-history).
 **Recon foundation**: e2e DEEP_DIVE.md / DEEP_DIVE_2.md / DEEP_DIVE_3.md (primary-evidence flow-trace on main).

--- a/docs/deep-dives/decisions/0042-force-close-layer2-removal.md
+++ b/docs/deep-dives/decisions/0042-force-close-layer2-removal.md
@@ -1,0 +1,79 @@
+# ADR-0042 (#4381) — force-close layer② removal: spill replaces the consolidate-and-retry path
+
+**Status**: ACCEPTED + IMPLEMENTED (2026-08-12, landed in [#4454](https://github.com/tya5/reyn/pull/4454)).
+**Supersedes**: [ADR-0036](0036-history-compaction-force-close-unification.md) — **its "Implementation note: PR-F2b force-close handoff cap" section ONLY**. Every other part of 0036 (the within-unit history convergence, the shared `CompactionEngine`, FD1–FD7) stands unchanged.
+**Track**: #4381 (overflow recovery), PR-4.
+
+## Decision
+
+Owner ruling, verbatim (2026-08-12):
+
+> **２の force close 廃止して spill にしよう。予算のための force close は残すで良い**
+
+## 🔴 Scope boundary — there are TWO force-closes, and only one is removed
+
+This is the single most important line in this ADR, because the two share a name and a
+`grep` for `force.close` returns both.
+
+| | what it bounds | axis | fate |
+|---|---|---|---|
+| **layer① — turn-budget force-close** (`force_close_triggered`) | cumulative **cost/budget** for the turn | cost | ✅ **UNCHANGED, still live** |
+| **layer② — driver force-close handoff** (`router_force_close_handoff`) | **context size** overflow after bounded shrink | context size | ❌ **removed** |
+
+**layer① remains implemented and is not affected by this decision.** Its live surfaces:
+
+```
+src/reyn/prompt/turn_budget.py             the wrap-up system prompt (T_wrap_SP)
+src/reyn/core/events/event_schema.py:256   "force_close_triggered" (a declared audit-event kind)
+src/reyn/llm/llm.py:2765                   the tools=[] path used by the wrap-up call
+src/reyn/observability/otel_exporter.py:117  limit_denied — "a force-close is imminent"
+```
+
+∴ **doc prose describing "bounded loops with graceful force-close" (charter, `agent-engineering/reliability-engineering.md`, `system-design.md`) is CORRECT and must not be purged.** It describes layer①. A drift-purge pass that greps `force-close` and deletes the hits would remove the description of a live mechanism. (This ADR exists partly to make that mistake expensive to make: the architect's own first pass on #4454 read those 11 doc hits as residue before checking `src/`.)
+
+## What was removed
+
+```
+_force_close_handoff / _force_close_wrap_up        runtime/services/router_loop_driver.py
+_is_force_close_consolidation                      the durable F2a covers-respecting reset
+                                                   in RouterHistoryBuffer.build_history
+_MAX_FORCE_CLOSE_HANDOFFS                          both declarations (router_loop_driver.py
+                                                   and the orphan duplicate in session.py)
+```
+
+## Material that informed the ruling (evidence, not the decision itself)
+
+⚠️ **Recorded as READ, not measured by this ADR's author** — the figures below are quoted from
+`router_loop_driver.py`'s own pre-removal docstring (`:305-320`):
+
+- The handoff **fired 0 times in real use** — after 61 apparent firings turned out to be
+  test-fixture contamination.
+- When it did fire, the F2a consolidation caused **permanent loss of `head`**.
+
+∴ the mechanism cost a real, irreversible loss and delivered no observed recovery. **The decision
+is the owner's; this material is why it was put in front of them.**
+
+## Consequence — what the system does now
+
+An overflow that survives `_run_with_shrink`'s own bounded shrink attempts is **unrecovered on the
+first attempt**; there is no consolidating retry. What keeps an oversized single result from
+reaching that point at all is the **spill** family (#4381, e.g. [#4432](https://github.com/tya5/reyn/pull/4432)):
+a tool result that would not fit is written to disk and replaced by a reference, with a working
+resume position, rather than being consolidated after the fact.
+
+**This is a deliberate trade**: the removed mechanism recovered *after* the overflow at the cost of
+silently destroying `head`; spill prevents the overflow *before* it happens and destroys nothing.
+
+## Open (not decided here)
+
+- The **resource-bound / budget-bound unit separation** and the ordering invariant between the read
+  cap and the spill trigger (#4381 PR-1, landed in `resolve_effective_trigger_and_budgets`) is a
+  neighbouring decision, not this one.
+- Whether `_run_with_shrink`'s own shrink ladder should change is untouched by this ADR.
+
+## See also
+
+- [ADR-0036](0036-history-compaction-force-close-unification.md) — the superseded section, kept as
+  historical record of the removed mechanism's reasoning (its body carries a supersession note added
+  by #4454; this ADR is the record the `decisions/README.md` immutability rule actually asks for).
+- #4381 (umbrella), #1092 (0036's own umbrella).

--- a/docs/deep-dives/decisions/README.md
+++ b/docs/deep-dives/decisions/README.md
@@ -118,7 +118,8 @@ new ADR.
 | ADR | Topic |
 |---|---|
 | [0035](0035-phase-tool-calls-unification.md) | Phase op-execution via native tool_calls (Phase ↔ chat/planner unification) (**Accepted, fully implemented** 2026-06-02) |
-| [0036](0036-history-compaction-force-close-unification.md) | Chat/plan/phase within-unit history + compaction + force-close unification (Fork 1: RouterLoop convergence) (**Accepted**) |
+| [0036](0036-history-compaction-force-close-unification.md) | Chat/plan/phase within-unit history + compaction + force-close unification (Fork 1: RouterLoop convergence) (**Accepted**) — the PR-F2b force-close handoff cap section superseded by [0042](0042-force-close-layer2-removal.md); the rest stands unchanged |
+| [0042](0042-force-close-layer2-removal.md) | force-close layer② removal — spill replaces the consolidate-and-retry path; **layer① (turn-budget force-close) is unaffected and still live** (**Accepted + Implemented** 2026-08-12; supersedes 0036's PR-F2b section only; see [#4381](https://github.com/tya5/reyn/issues/4381)) |
 | [0039](0039-thin-client-single-writer-server.md) | N thin CUI clients × one single-writer server — UI-path unification, four-surface separation (Proposed) |
 
 ## Format


### PR DESCRIPTION
**[architect]** — lead-coder の指示（朝を待たずに書く）で作成。**#4454 が撤去した force-close layer② を、`decisions/README.md` の不変規則が要求する形で記録します。**

## なぜ必要か

**#4454 は ADR-0036 の本文に supersede 注記を追加しました。** 規則が要求しているのはそれではありません:

> `decisions/README.md:14-16` — ADRs are **immutable** once accepted. New facts that contradict a decision get a **new ADR that supersedes the old one** (the old one keeps its historical value with **status updated to "superseded by ADR-XXXX"**).

∴ **必要なのは (a) 新しい superseding ADR と (b) 旧 ADR の status 行更新**。本文への注記は (a) でも (b) でもありません。**部分 supersede の前例は ADR-0034 / 0041**（「Components 1–3 superseded by 0041; Components 4–5 stand unchanged」）。

⚠️ **この repo は既に一度この穴で刺されています** — ADR-0041 自身が「written after the fact 2026-08-10 to close a **3-month doc/code gap**」と書いています。今回は撤去当日に閉じます。

## 変更

```
新規  0042-force-close-layer2-removal.md
      決定（owner 逐語）／撤去された物／材料（★READ ラベル付き）／帰結／未決
更新  0036  ★status 行のみ（超えられた 1 節を名指し、残りは有効と明記）★本文は不触
更新  README  0036 の行を更新 ＋ 0042 の行を ★0035/0036 と同じ話題区に追加
```

## 🔴 ADR が scope boundary から始まる理由

**2 つの force-close が同じ名前を共有しており、`grep force.close` は両方を返します。**

```
layer① turn-budget（force_close_triggered）  ★コスト軸   ✅ 変更なし・現役
layer② driver handoff（router_force_close_handoff）★文脈サイズ軸 ❌ 撤去
```

∴ **charter / `reliability-engineering.md` / `system-design.md` の「bounded loops with graceful force-close」は★正しい記述で、drift-purge の対象ではありません**（layer① の説明）。

⚠️ **この誤りは実際に起きかけました** — **私（architect）が #4454 の確認で `force-close` を全文検索し、docs の 11 件を残渣と読みかけました。** `src/` を見て layer① が生きている（`prompt/turn_budget.py` / `event_schema.py:256` / `llm.py:2765` / `otel_exporter.py:117`）と分かって止まりました。**ADR がこの区別を先頭に置くのは、次の drift-purge がこの誤りを安く踏めないようにするためです。**

## 材料の扱い

**撤去の根拠（実発火 0 回 ／ head の恒久喪失）は ★READ ラベル**で記載しました — **`router_loop_driver.py` の撤去前 docstring からの引用であって、私が測定したものではありません。** 決定は owner のもので、材料は「なぜ owner の前に置かれたか」を説明するだけです。

## Test plan

- [x] `decisions/README.md` の規則を引用元で確認（:14-16）
- [x] 部分 supersede の前例を index で確認（0034 / 0041 の行）
- [x] 0036 の本文が変更されていないことを確認（diff は status 行 1 行のみ）
- [x] layer① が src/ で生きていることを確認（4 箇所、ADR に列挙）
- [x] 索引の行を ★話題区で配置（最初 multi-agent 区に入れてしまい、0035/0036 の区へ移動）
- [x] `part of #4381` を使用（closing キーワードなし）
- [ ] (skipped — コード変更なし ∴ pytest / ruff / mypy の対象外)

part of #4381

🤖 Generated with [Claude Code](https://claude.com/claude-code)