### PR TITLE
feat(#4412): mcp 2.0 pin bump -- mcp>=2.0,<3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,44 +199,28 @@ dependencies = [
     "numpy>=1.24",           # RAG index backend cosine similarity (ADR-0033)
     "croniter>=2.0",         # cron expression parsing for FP-0009 Component B
     "charset-normalizer>=3.0",  # #1452 read_file encoding detection (MIT, pure-python)
-    "mcp>=1.24,<2.0",         # #4302: fastmcp DROPPED from every reyn-side dependency
-                              # declaration -- core AND every extra (#3698 stage 1 + #4282
-                              # moved the MCP CLIENT path off it onto this SDK directly;
-                              # #4299 removed the last source-level fastmcp import outside
-                              # tests/_support/; #4302 itself ported the remaining 4
-                              # fastmcp-SERVER test-doubles -- mcp_fastmcp_echo_server.py,
-                              # mcp_elicitation_server.py, and 2 embedded stub-markitdown
-                              # servers, not 3 as an earlier count claimed -- onto this
-                              # SDK's own bundled `mcp.server.fastmcp`, the 1.x-line module;
-                              # NOT `mcp.server.mcpserver`, mcp 2.0's rename of it). `mcp`
-                              # becomes an EXPLICIT direct dependency here because it was
-                              # previously only transitive (via fastmcp-slim, which pinned
-                              # the same `mcp<2.0,>=1.24.0` range this now declares directly).
-                              # NOT the whole footprint, though: the bundled `rag` PLUGIN
-                              # declares its OWN `fastmcp>=2.0` in its own
-                              # `builtin/plugins/rag/requirements.txt` (a real,
-                              # currently-uncounted consumer #4302 found) -- reyn's dev/CI
-                              # tooling that runs the plugin's scripts directly (the seccomp
-                              # gate, `wheel_reachability_smoke.py`'s own harness client)
-                              # installs THAT requirements.txt as its own setup step, not by
-                              # reintroducing fastmcp to any `pyproject.toml` declaration.
-                              #
-                              # `<2.0` is a DELIBERATE, load-bearing upper bound, not a
-                              # leftover floor -- #4302 measured (live) that mcp 2.0 is a
-                              # MAJOR breaking release: it renames `mcp.server.fastmcp.FastMCP`
-                              # to `mcp.server.mcpserver.MCPServer`, and (more importantly)
-                              # `mcp.server.lowlevel.Server` LOSES its `@list_tools()`/
-                              # `@call_tool()` decorator API entirely, replaced by a generic
-                              # `add_request_handler(...)` registration shape. reyn's own MCP
-                              # SERVER (`src/reyn/mcp/server.py:372/482`, built on
-                              # `lowlevel.Server`) uses exactly those decorators and would
-                              # raise `AttributeError` at construction time under mcp 2.0 --
-                              # measured live, not assumed. This pin is an accurate
-                              # description of that fact ("reyn does not support mcp 2.0
-                              # today"), not a bandaid hiding it -- the 2.0 port is real,
-                              # bounded work (~4-5 functions + a context re-plumb, see #4302)
-                              # tracked as its own follow-up issue, deliberately NOT folded
-                              # into this dependency-hygiene PR.
+    "mcp>=2.0,<3.0",          # #4412: the arc this comment used to describe (mcp 2.0 port)
+                              # is DONE -- bumped from `>=1.24,<2.0`. fastmcp stays DROPPED
+                              # from every reyn-side dependency declaration (#4302, #3698
+                              # stage 1, #4282, #4299 -- unaffected by this bump). Server
+                              # CONSTRUCTION (Tool(...)/CallToolResult(...)/etc.) now uses
+                              # 2.0's field-name vocabulary directly (input_schema/
+                              # mime_type/...) -- #4368's own ruling was ONE-WAY migration,
+                              # no dual-pin seam for construction (owner: reyn's surface
+                              # must not grow every time the SDK's vocabulary grows), so
+                              # this bump's own commit mechanically flips every
+                              # construction call site in the SAME PR. Registration + ctx
+                              # shape stay behind `_mcp_server_boundary.py`
+                              # /`_mcp_client_boundary.py` (#4368) -- those seams already
+                              # speak 2.0 natively and needed ZERO changes for this bump
+                              # (their whole POINT). `mcp.server.fastmcp` is gone, renamed
+                              # `mcp.server.mcpserver` (`FastMCP`->`MCPServer`, #4412 Class
+                              # B) -- the decorator API itself (`@mcp.tool()`) is UNCHANGED,
+                              # confirmed live, so this was a pure import/construction
+                              # rename, no test-double logic changed. The bundled `rag` PLUGIN
+                              # still declares its OWN `fastmcp>=3.4,<4` in its own
+                              # `builtin/plugins/rag/requirements.txt` (#4388) -- a SEPARATE
+                              # venv (ADR-0064), untouched by this bump.
     # #4395: was transitive only (Required-by: httpx, mcp, openai,
     # sse-starlette, starlette, watchfiles — 4.14.0 already installed via
     # that chain). Owner decision: declare it directly rather than keep

--- a/src/reyn/mcp/_mcp_server_boundary.py
+++ b/src/reyn/mcp/_mcp_server_boundary.py
@@ -1,22 +1,17 @@
 """#4368 (arc #4412) -- the single seam every reyn-side production
 ``lowlevel.Server`` construction goes through.
 
-Before this module, 6 sites across 2 files (`server.py` construction +
-`interfaces/web/routers/mcp.py`'s SSE transport) each imported directly from
-`mcp.server.*` and registered handlers via that SDK line's own decorator
-API (`@server.list_tools()`/`@server.call_tool()`/`@server.read_resource()`
--- gone entirely on mcp 2.0, replaced by `Server(...)` constructor kwargs,
-measured live against a real `mcp==2.0.0` install, not assumed). A future
-pin bump has to change how registration happens either way; this module
-makes it ONE seam for the `Server` CONSTRUCTION axis specifically -- the
-swap edits THIS file's function body, not every construction call site.
+#4412 pin-bump PR: mcp is now pinned `>=2.0,<3.0`. This module was built
+under the 1.x line specifically so the registration/ctx-adaptation swap for
+the eventual 2.0 bump would touch ONE file, not every construction call
+site (#4368) -- that promise is now redeemed: `build_mcp_server` collapsed
+to a near-passthrough, and the 1.x-only `_CtxAdapter`/`_adapt_meta` classes
+(which used to normalise `server.request_context`'s pydantic `Meta` into
+2.0's plain-dict shape) are gone entirely, because 2.0 hands `ctx` to a
+registered handler directly -- there is nothing left to adapt.
 
-**This seam's scope is construction only -- 3 other `mcp.server.*` surfaces
-are OUTSIDE it, and their mcp 2.0 shape is UNMEASURED** (architect co-vet,
-#4368, live archaeology after a first-pass `git grep -E "^\\s*from
-mcp\\.server"` silently matched nothing -- POSIX ERE doesn't understand
-`\\s`, so a 0-hit census read as "no imports outside the seam" when it was
-actually "the pattern never fired"; re-run with `[[:space:]]` found these):
+**This seam's scope was always construction only -- 3 other `mcp.server.*`
+surfaces were OUTSIDE it** (architect co-vet, #4368):
 
 ```
 interfaces/web/routers/mcp.py:60   from mcp.server.sse import SseServerTransport
@@ -24,101 +19,44 @@ src/reyn/mcp/server.py:1042        from mcp.server import NotificationOptions
 src/reyn/mcp/server.py:1087        from mcp.server.stdio import stdio_server
 ```
 
-A pin-bump PR reading only the paragraph above would wrongly conclude "edit
-this one file's function bodies and the swap is done" -- these 3 sites
-still need their own pin-bump pass, whatever mcp 2.0 turns out to require
-of them (not yet measured, not assumed broken). Mirrors
-`_fastmcp_boundary.py`'s own pattern from #3698 P2 (the CLIENT-side
-equivalent, since deleted once its own swap completed -- #4282/#4299) —
-architect's explicit precedent for this ruling (#4368).
+Confirmed live against `mcp==2.0.0`, this bump: none of the 3 needed a code
+change -- `SseServerTransport`/`NotificationOptions`/`stdio_server` all
+still live at those exact import paths, unchanged shape. Recorded here
+because the #4368 docstring explicitly asked this bump to report back on
+them, not because anything broke.
 
 ## What this seam covers, and what it deliberately does NOT
 
 `build_mcp_server`'s ``on_list_tools``/``on_call_tool``/``on_read_resource``
 parameters use mcp 2.0's real handler REGISTRATION signature directly:
 ``async def handler(ctx, params) -> Result`` (``ListToolsResult``/
-``CallToolResult``/``ReadResourceResult``), the same shape
+``CallToolResult``/``ReadResourceResult``) -- the exact same shape
 ``mcp.server.lowlevel.Server.__init__``'s own ``on_list_tools=``/etc.
-kwargs accept on 2.0 (verified live). Under the CURRENT pin
-(`mcp>=1.24,<2.0`), this function adapts each 2.0-shaped handler onto the
-1.x line's decorator API internally; once the pin bumps, this function's
-body collapses to a near-passthrough (`Server(name,
-on_list_tools=on_list_tools, ...)` directly) and the swap is done.
+kwargs accept, so this function is now a straight passthrough onto them.
 
 **Object CONSTRUCTION inside a handler body (`Tool(...)`,
-`TextResourceContents(...)`, …) is a separate axis this seam does NOT
-cover** (owner ruling via lead-coder, #4368: a per-SDK-type constructor
+`TextResourceContents(...)`, …) was a separate axis this seam never
+covered** (owner ruling via lead-coder, #4368: a per-SDK-type constructor
 function here would mean reyn's own surface grows every time the SDK adds
 a type -- not reyn's responsibility to own, same discriminator as #4354's
-provider-layer ruling). Handler bodies write those constructions plain,
-in the CURRENTLY INSTALLED pin's own vocabulary (`inputSchema`/`mimeType`
-today); a pin-bump PR flips every such call site in one mechanical pass
-alongside this module. This is why :func:`_read_resource`'s adapter below
-reads `c.mimeType`, not `c.mime_type` -- it has to track whichever
-vocabulary the handler bodies currently use, and moves in the SAME
-pin-bump PR as they do.
+provider-layer ruling). Handler bodies write those constructions plain, in
+mcp 2.0's own vocabulary now (`input_schema`/`mime_type`, flipped from
+`inputSchema`/`mimeType` in this same pin-bump commit, mechanically,
+alongside this module).
 
-## The ``ctx`` adaptation this seam owns
+## Why the accessor stays a function, not a module-level re-export
 
-mcp 2.0's ``on_call_tool``/``on_read_resource`` receive a
-``ServerRequestContext`` directly as their first argument. The 1.x
-decorator API has no such parameter -- the equivalent data was reached via
-``server.request_context`` (a property lookup on the ``Server`` instance
-itself), which this seam still uses internally under the current pin,
-wrapped in a small adapter (:class:`_CtxAdapter`) so the handler body sees
-the SAME ``.session``/``.request_id``/``.meta`` shape regardless of pin.
-
-The one genuine shape difference this seam has to paper over: ``.meta``.
-On the 1.x line it is ``mcp.types.RequestParams.Meta``, a real pydantic
-``BaseModel`` (attribute access, camelCase field names --
-``.progressToken``). On 2.0 it is confirmed live to be a real
-``TypedDict`` (plain ``dict`` at runtime, snake_case keys --
-``.get("progress_token")``). Handler bodies are written against the 2.0
-shape (dict-style ``.get(...)``, snake_case), so :class:`_CtxAdapter`
-normalises a 1.x pydantic ``Meta`` into a plain dict with the SAME
-snake_case keys at adaptation time -- one conversion, in one place, rather
-than every handler needing its own version branch.
-
-## Why the accessors are functions, not module-level re-exports
-
-Same reasoning as `_fastmcp_boundary.py`: the ``mcp`` import stays deferred
-inside the function body (not at module top), so a test environment that
-never touches the MCP surface never pays the import cost, and any
-``ImportError`` fires at the same point it always did (first real use, not
-at ``reyn.mcp`` import time).
+Same reasoning as `_fastmcp_boundary.py` had: the ``mcp`` import stays
+deferred inside the function body (not at module top), so a test
+environment that never touches the MCP surface never pays the import
+cost, and any ``ImportError`` fires at the same point it always did (first
+real use, not at ``reyn.mcp`` import time).
 """
 from __future__ import annotations
 
 from typing import Any, Awaitable, Callable
 
 _Handler = Callable[[Any, Any], Awaitable[Any]]
-
-
-class _CtxAdapter:
-    """Normalises 1.x's ``server.request_context`` (a property lookup) into
-    the same ``.session``/``.request_id``/``.meta`` shape mcp 2.0 hands
-    ``on_call_tool``/``on_read_resource`` directly as their first argument
-    -- see this module's own docstring, "The ``ctx`` adaptation this seam
-    owns", for the full rationale."""
-
-    def __init__(self, raw: "Any") -> None:
-        self.session = raw.session
-        self.request_id = raw.request_id
-        self.meta = _adapt_meta(raw.meta)
-
-
-def _adapt_meta(meta: "Any") -> "dict[str, Any] | None":
-    """1.x's ``RequestParams.Meta`` (pydantic ``BaseModel``, camelCase
-    attributes) -> a plain dict with 2.0's snake_case keys, so handler
-    bodies written against 2.0's real ``TypedDict``/dict shape
-    (``ctx.meta.get("progress_token")``) work unchanged under either pin.
-    Only the one field reyn's own handlers actually read is mapped --
-    extend this if a future handler needs another ``_meta`` key."""
-    if meta is None:
-        return None
-    if isinstance(meta, dict):
-        return meta  # already 2.0-shaped (or a caller-constructed dict in a test)
-    return {"progress_token": getattr(meta, "progressToken", None)}
 
 
 def build_mcp_server(
@@ -128,39 +66,22 @@ def build_mcp_server(
     on_call_tool: "_Handler | None" = None,
     on_read_resource: "_Handler | None" = None,
 ) -> "Any":
-    """Construct a ``lowlevel.Server`` the CURRENT pin's way, from handlers
-    already written in mcp 2.0's own ``(ctx, params) -> Result`` shape --
-    see this module's own docstring for the full rationale."""
+    """Construct a ``lowlevel.Server`` from handlers already written in mcp
+    2.0's own ``(ctx, params) -> Result`` shape.
+
+    #4412 pin-bump PR: this function is now the near-passthrough this
+    module's own docstring predicted it would collapse to -- ``ctx`` is
+    handed to a registered handler directly by ``Server.__init__``'s
+    ``on_list_tools=``/etc. kwargs on 2.0 (verified live), so the
+    ``_CtxAdapter``/``server.request_context`` property-lookup dance this
+    function used to do for the 1.x line is gone. This is exactly the
+    "swap edits THIS file's function body, not every call site" promise
+    the seam existed to keep."""
     from mcp.server import Server
 
-    server = Server(name)
-
-    if on_list_tools is not None:
-        @server.list_tools()  # type: ignore[misc]
-        async def _list_tools() -> "list[Any]":
-            result = await on_list_tools(_CtxAdapter(server.request_context), None)  # type: ignore[attr-defined]
-            return result.tools
-
-    if on_call_tool is not None:
-        @server.call_tool()  # type: ignore[misc]
-        async def _call_tool(tool_name: str, arguments: dict) -> "list[Any]":
-            from mcp.types import CallToolRequestParams
-
-            params = CallToolRequestParams(name=tool_name, arguments=arguments)
-            result = await on_call_tool(_CtxAdapter(server.request_context), params)  # type: ignore[attr-defined]
-            return result.content
-
-    if on_read_resource is not None:
-        @server.read_resource()  # type: ignore[misc]
-        async def _read_resource(uri: "Any") -> "list[Any]":
-            from mcp.server.lowlevel.helper_types import ReadResourceContents
-            from mcp.types import ReadResourceRequestParams
-
-            params = ReadResourceRequestParams(uri=str(uri))  # type: ignore[arg-type]
-            result = await on_read_resource(_CtxAdapter(server.request_context), params)  # type: ignore[attr-defined]
-            return [
-                ReadResourceContents(content=c.text, mime_type=c.mimeType)
-                for c in result.contents
-            ]
-
-    return server
+    return Server(
+        name,
+        on_list_tools=on_list_tools,
+        on_call_tool=on_call_tool,
+        on_read_resource=on_read_resource,
+    )

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -137,10 +137,15 @@ bearer token):
 
   :meth:`_build_oauth_provider` builds the official SDK's
   ``mcp.client.auth.OAuthClientProvider(server_url=url, client_metadata=...,
-  storage=MCPOAuthTokenStorage(url), redirect_handler=..., callback_handler=
-  ..., timeout=...)`` directly (#4282: fastmcp's own ``OAuth`` wrapper
+  storage=MCPOAuthTokenStorage(url), redirect_handler=...,
+  callback_handler=...)`` directly (#4282: fastmcp's own ``OAuth`` wrapper
   around this same class is no longer in the path) and passes it as
-  ``streamablehttp_client(url, headers=..., auth=provider)`` —
+  ``streamable_http_client(url, headers=..., auth=provider)`` — #4412
+  pin-bump PR: the constructor's own ``timeout=`` kwarg is GONE on mcp 2.0
+  (confirmed live it was dead even on 1.x — never read anywhere in
+  ``mcp.client.auth.oauth2``'s own source — so removing it changes nothing
+  behaviorally on either pin) and the transport factory itself is renamed
+  (``streamablehttp_client`` → ``streamable_http_client``, both below).
   ``OAuthClientProvider`` IS an ``httpx.Auth``, so it slots into the SDK
   transport's own ``auth=`` kwarg directly, no wrapper object needed.
   ``redirect_handler``/``callback_handler`` (the browser-open + localhost-
@@ -603,7 +608,15 @@ def _is_transport_death(exc: BaseException) -> bool:
     if isinstance(exc, (anyio.ClosedResourceError, anyio.BrokenResourceError, ConnectionError)):
         return True
     try:
-        from mcp.shared.exceptions import McpError as _SdkMcpError
+        # #4412 pin-bump PR: the SDK's own exception class is renamed on 2.0
+        # -- `mcp.shared.exceptions.McpError` (1.x) -> `MCPError` (2.0),
+        # confirmed live (`hasattr(mcp.shared.exceptions, "McpError")` is
+        # False, `hasattr(..., "MCPError")` is True). The stale 1.x import
+        # name silently caught its own ImportError below and made this
+        # predicate return False UNCONDITIONALLY under mcp 2.0 -- every
+        # transport death went unrecognized, so _heal() never reconnected.
+        # Found via a real reconnect-flow repro, not a static grep.
+        from mcp.shared.exceptions import MCPError as _SdkMcpError
         from mcp.types import CONNECTION_CLOSED
     except ImportError:  # pragma: no cover — mcp SDK always installed alongside fastmcp
         return False
@@ -1135,19 +1148,39 @@ class MCPClient:
                 # other httpx.Auth — no more fastmcp Client/transport
                 # wrapper needed to carry it.
                 auth = await self._build_oauth_provider(url)
-                # Deliberately the deprecated headers/timeout/auth-kwarg
-                # `streamablehttp_client`, not its replacement
-                # `streamable_http_client` — the latter takes a pre-built
-                # `httpx.AsyncClient` instead, which would mean
-                # reimplementing headers/timeout wiring by hand for no
-                # behavioral gain right now (a real future improvement, out
-                # of this PR's scope: a like-for-like swap, not a redesign).
-                from mcp.client.streamable_http import streamablehttp_client
+                # #4412 pin-bump PR: `streamablehttp_client` (the
+                # headers/timeout/auth-kwarg form) is GONE on mcp 2.0 —
+                # confirmed live, `mcp.client.streamable_http` no longer
+                # exports it at all, only its replacement
+                # `streamable_http_client(url, http_client=...)`, which
+                # takes a pre-built HTTP client instead of individual
+                # headers/timeout/auth kwargs. That pre-built client must be
+                # an `httpx2.AsyncClient` specifically — mcp 2.0 depends on
+                # `httpx2`, a genuinely SEPARATE package from `httpx`
+                # (confirmed live: `httpx2.AsyncClient is httpx.AsyncClient`
+                # is False), which arrives transitively via `mcp`'s own
+                # declared dependency (`pip show mcp` → `Requires: ...
+                # httpx2 ...`) — reyn declares nothing extra for it.
+                # Deliberately calling the SDK's own `create_mcp_http_client`
+                # factory (re-exported from this same module) rather than
+                # importing `httpx2` and constructing the client here
+                # directly — that would mean reyn's own code speaks the
+                # SDK's transport-library vocabulary, which #4368's own
+                # ruling (construction is not a seamed axis; reyn's surface
+                # must not grow every time the SDK's vocabulary grows)
+                # argues against. The factory takes the same
+                # headers/timeout/auth reyn already builds and returns an
+                # already-`follow_redirects=True`-configured client.
+                from mcp.client.streamable_http import (
+                    create_mcp_http_client,
+                    streamable_http_client,
+                )
 
-                read, write, _get_session_id = await stack.enter_async_context(
-                    streamablehttp_client(
-                        url, headers=headers, timeout=read_timeout, auth=auth,
-                    )
+                http_client = create_mcp_http_client(
+                    headers=headers, timeout=read_timeout, auth=auth,
+                )
+                read, write = await stack.enter_async_context(
+                    streamable_http_client(url, http_client=http_client)
                 )
             else:
                 from mcp.client.sse import sse_client
@@ -1263,8 +1296,13 @@ class MCPClient:
         if progress_callback is not None:
             kwargs["progress_callback"] = progress_callback
         if timeout_seconds is not None:
-            from datetime import timedelta
-            kwargs["read_timeout_seconds"] = timedelta(seconds=timeout_seconds)
+            # #4412 pin-bump PR: ClientSession.call_tool's read_timeout_seconds
+            # is `float | None` on 2.0, confirmed live via its own signature —
+            # was `timedelta | None` on 1.x. Passing a timedelta where 2.0
+            # expects a float crashes downstream with `unsupported operand
+            # type(s) for +: 'float' and 'datetime.timedelta'` (found via a
+            # real ephemeral-session repro, not a static read).
+            kwargs["read_timeout_seconds"] = timeout_seconds
         try:
             # ClientSession.call_tool() is already the raw/no-raise variant
             # fastmcp needed a call_tool_mcp-suffixed method to reach
@@ -1365,8 +1403,11 @@ class MCPClient:
         await self.initialize()
         require_capability(self, "resources")
         try:
+            # #4412 pin-bump PR: ListResourceTemplatesResult's own field is
+            # resource_templates (snake_case) on 2.0 -- confirmed live via
+            # model_fields -- was resourceTemplates (camelCase) on 1.x.
             templates = await self._paginate_official_sdk(
-                self._client.list_resource_templates, "resourceTemplates",
+                self._client.list_resource_templates, "resource_templates",
             )
         except Exception as exc:
             _classify_and_raise(exc, f"MCP resources/templates/list error: {exc}")
@@ -2017,7 +2058,6 @@ class MCPClient:
             storage=storage,
             redirect_handler=redirect_handler,
             callback_handler=_callback_handler,
-            timeout=callback_timeout,
         )
 
 
@@ -2061,10 +2101,15 @@ def _result_to_dict(result: Any) -> dict[str, Any]:
             content_items.append(item)
         else:
             content_items.append({"type": "text", "text": str(item)})
+    # #4412 pin-bump PR: CallToolResult's own fields are snake_case on 2.0
+    # (`is_error`/`structured_content`, confirmed live via model_fields) —
+    # was camelCase on 1.x. reyn's OUTPUT dict keys below stay `isError`/
+    # `structuredContent` (reyn's own external contract, asserted on by
+    # callers/tests) — only the SDK object attribute names being READ change.
     return {
         "content": content_items,
-        "isError": bool(getattr(result, "isError", False)),
-        "structuredContent": getattr(result, "structuredContent", None),
+        "isError": bool(getattr(result, "is_error", False)),
+        "structuredContent": getattr(result, "structured_content", None),
     }
 
 

--- a/src/reyn/mcp/message_handler.py
+++ b/src/reyn/mcp/message_handler.py
@@ -180,7 +180,15 @@ class ReynMCPMessageHandler:
         ``mcp.client.session.ClientSession`` as ``self._message_handler(req)`` — a
         plain ``Callable``, no base-class contract required (module docstring)."""
         if isinstance(message, mcp.types.ServerNotification):
-            root = message.root
+            # #4412 pin-bump PR: on 1.x, ServerNotification was a RootModel
+            # wrapper class and `.root` unwrapped it to the specific
+            # notification. On 2.0, ServerNotification is a bare
+            # `X | Y | Z` type alias (confirmed live:
+            # `type(mcp.types.ServerNotification) is types.UnionType`) —
+            # `message` (already narrowed by the isinstance check above) IS
+            # the specific notification directly; there is no wrapper left
+            # to unwrap.
+            root = message
             match root:
                 case mcp.types.TaskStatusNotification():
                     client = self._client_ref()

--- a/src/reyn/mcp/server.py
+++ b/src/reyn/mcp/server.py
@@ -382,7 +382,7 @@ def build_server(
                     "List the agents registered in the current Reyn project. "
                     "Returns each agent's name and a short role excerpt."
                 ),
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {},
                     "additionalProperties": False,
@@ -396,7 +396,7 @@ def build_server(
                     "how to respond; multi-turn conversation "
                     "accumulates because per-agent chat history persists."
                 ),
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {
                         "agent_name": {
@@ -430,7 +430,7 @@ def build_server(
                     "``choice_id`` explicitly; for free-text ask_user "
                     "omit it."
                 ),
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {
                         "agent_name": {
@@ -477,7 +477,7 @@ def build_server(
                 Tool(
                     name=et.name,
                     description=et.description,
-                    inputSchema=et.input_schema,
+                    input_schema=et.input_schema,
                 )
                 for et in _extra_tools
             ],
@@ -661,7 +661,7 @@ def build_server(
             # directly (= the URL points at our own resources router).
             return ReadResourceResult(contents=[TextResourceContents(
                 uri=uri_str,
-                mimeType="text/plain",
+                mime_type="text/plain",
                 text=(
                     f"error: unsupported resource URI scheme: {uri_str!r}. "
                     "Reyn MCP server resolves reyn-tool-result://<agent>/<artifact> only; "
@@ -683,14 +683,14 @@ def build_server(
         if not found:
             return ReadResourceResult(contents=[TextResourceContents(
                 uri=uri_str,
-                mimeType="text/plain",
+                mime_type="text/plain",
                 text=(
                     f"error: tool result not found for URI {uri_str!r} "
                     "(= deleted by user, or never existed on this Reyn instance)"
                 ),
             )])
         return ReadResourceResult(contents=[TextResourceContents(
-            uri=uri_str, mimeType="text/plain", text=body,
+            uri=uri_str, mime_type="text/plain", text=body,
         )])
 
     return build_mcp_server(

--- a/tests/_support/mcp_elicitation_server.py
+++ b/tests/_support/mcp_elicitation_server.py
@@ -46,10 +46,10 @@ Tools:
 """
 from __future__ import annotations
 
-from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.mcpserver import Context, MCPServer
 from pydantic import BaseModel, create_model
 
-mcp = FastMCP("reyn-test-elicitation")
+mcp = MCPServer("reyn-test-elicitation")
 
 
 class _BoolValue(BaseModel):
@@ -79,7 +79,7 @@ async def pick(question: str, ctx: Context) -> str:
         "required": ["value"],
     }
     result = await ctx.session.elicit_form(
-        message=question, requestedSchema=schema, related_request_id=ctx.request_id,
+        message=question, requested_schema=schema, related_request_id=ctx.request_id,
     )
     if result.action != "accept":
         return result.action  # "decline" | "cancel"

--- a/tests/_support/mcp_fastmcp_echo_server.py
+++ b/tests/_support/mcp_fastmcp_echo_server.py
@@ -175,7 +175,7 @@ async def notify_tool_list_changed(ctx: Context) -> str:
 
     # #4302: bundled Context has no ``send_notification`` convenience — go
     # through ``ctx.session`` (the underlying ServerSession) directly.
-    await ctx.session.send_notification(types.ServerNotification(types.ToolListChangedNotification()))
+    await ctx.session.send_notification(types.ToolListChangedNotification())
     return "sent"
 
 
@@ -183,7 +183,7 @@ async def notify_tool_list_changed(ctx: Context) -> str:
 async def notify_prompt_list_changed(ctx: Context) -> str:
     import mcp.types as types
 
-    await ctx.session.send_notification(types.ServerNotification(types.PromptListChangedNotification()))
+    await ctx.session.send_notification(types.PromptListChangedNotification())
     return "sent"
 
 

--- a/tests/_support/mcp_fastmcp_echo_server.py
+++ b/tests/_support/mcp_fastmcp_echo_server.py
@@ -61,9 +61,9 @@ from __future__ import annotations
 
 import sys
 
-from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.mcpserver import Context, MCPServer
 
-mcp = FastMCP("reyn-test-echo")
+mcp = MCPServer("reyn-test-echo")
 
 
 @mcp.tool()
@@ -190,13 +190,15 @@ async def notify_prompt_list_changed(ctx: Context) -> str:
 if __name__ == "__main__":
     if len(sys.argv) >= 3:
         cli_transport, port = sys.argv[1], int(sys.argv[2])
-        # #4302: the bundled ``mcp.server.fastmcp.FastMCP`` (1.x line) takes
-        # host/port as constructor-time ``.settings``, not per-``.run()``
-        # kwargs, and its transport literal is "streamable-http" — this
-        # file's own CLI ("http"/"sse" + port) stays unchanged for every
-        # caller.
-        mcp.settings.host = "127.0.0.1"
-        mcp.settings.port = port
-        mcp.run(transport="streamable-http" if cli_transport == "http" else cli_transport)
+        # #4412 pin-bump PR: mcp 2.0's `MCPServer.settings` DROPPED
+        # `host`/`port` entirely (confirmed live: the `Settings` model no
+        # longer declares those fields) — `.run(transport=..., **kwargs)`
+        # forwards them straight to `run_streamable_http_async`/
+        # `run_sse_async` as kwargs instead. This file's own CLI
+        # ("http"/"sse" + port) stays unchanged for every caller.
+        mcp.run(
+            transport="streamable-http" if cli_transport == "http" else cli_transport,
+            host="127.0.0.1", port=port,
+        )
     else:
         mcp.run(transport="stdio")

--- a/tests/_support/mcp_memory_session.py
+++ b/tests/_support/mcp_memory_session.py
@@ -1,0 +1,51 @@
+"""In-process client/server MCP round trip for tests (#4412 pin-bump PR).
+
+mcp 2.0 removed ``mcp.shared.memory.create_connected_server_and_client_session``
+(confirmed live: only ``create_client_server_memory_streams`` remains on
+2.0) -- the exact convenience helper #4368's own third-axis fix
+(``tests/runtime/test_mcp_server_resources_adapter.py``,
+``tests/gateway/sample_slack/test_outbound.py``) relied on to drive a
+handler through the SDK's REAL request-dispatch loop rather than calling
+``server.request_handlers[...]`` directly (the direct-call form raises
+``LookupError`` on ``request_ctx``, a ContextVar only the real dispatch
+loop sets). This module hand-rolls the same shape the removed helper
+provided, using ``create_client_server_memory_streams`` (which DID
+survive) plus a task group running ``server.run()`` -- the same
+construction the removed helper's own 1.x source did internally, just
+not packaged as a context manager reyn can still import.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import Any
+
+
+@asynccontextmanager
+async def connected_server_and_client_session(
+    server: Any,
+) -> "AsyncGenerator[Any, None]":
+    """Yield a real ``ClientSession`` connected to *server* over in-memory
+    streams, with ``server.run()`` actually driving the request-dispatch
+    loop in a background task -- the caller still calls
+    ``await session.initialize()`` itself (mirrors the removed helper's own
+    contract, which never auto-initialized either)."""
+    import anyio
+    from mcp import ClientSession
+    from mcp.shared.memory import create_client_server_memory_streams
+
+    async with create_client_server_memory_streams() as (client_streams, server_streams):
+        client_read, client_write = client_streams
+        server_read, server_write = server_streams
+
+        async with anyio.create_task_group() as tg:
+
+            async def _run_server() -> None:
+                await server.run(
+                    server_read, server_write, server.create_initialization_options(),
+                )
+
+            tg.start_soon(_run_server)
+            async with ClientSession(client_read, client_write) as session:
+                yield session
+            tg.cancel_scope.cancel()

--- a/tests/_support/mcp_paginated_tools_server.py
+++ b/tests/_support/mcp_paginated_tools_server.py
@@ -6,42 +6,41 @@ Standalone script — run as a subprocess, never imported. Exists to prove FastM
 SDK ``ClientSession.list_tools()`` call the old client made directly.
 
 Serves 4 tools across 2 pages of 2 (cursor = the next tool's index as a string).
+
+#4412 pin-bump PR: ``lowlevel.Server``'s ``@list_tools()`` decorator is gone
+on mcp 2.0 (confirmed live) — the handler is now a plain function passed as
+``Server(...)``'s ``on_list_tools`` constructor kwarg, receiving
+``(ctx, params: PaginatedRequestParams | None)`` directly. This actually
+SIMPLIFIES this file: 2.0's own handler signature already carries cursor
+control, so the old raw ``app.request_handlers[...]`` override (needed on
+1.x because the decorator sugar couldn't express pagination) is gone too —
+one handler function does the whole job. ``Tool.inputSchema`` ->
+``input_schema``, ``ListToolsResult.nextCursor`` -> ``next_cursor``.
 """
 from __future__ import annotations
 
 import asyncio
 
 import mcp.types as types
-from mcp.server.lowlevel import Server
+from mcp.server import Server
 from mcp.server.stdio import stdio_server
 
-app = Server("reyn-test-paginated")
-
 _ALL_TOOLS = [
-    types.Tool(name=f"tool_{i}", description=f"tool number {i}", inputSchema={"type": "object"})
+    types.Tool(name=f"tool_{i}", description=f"tool number {i}", input_schema={"type": "object"})
     for i in range(4)
 ]
 _PAGE_SIZE = 2
 
 
-@app.list_tools()
-async def list_tools(request: types.PaginatedRequestParams | None = None) -> list[types.Tool]:
-    # The low-level Server API decorator only supports returning the tool list; page
-    # boundaries need the raw request handler for cursor control, so this override goes
-    # through app.request_handlers directly below instead of the decorator sugar.
-    return _ALL_TOOLS
-
-
-async def _handle_list_tools_paginated(req):
-    cursor = req.params.cursor if req.params is not None else None
+async def list_tools(ctx: "object", params: "object") -> "types.ListToolsResult":
+    cursor = getattr(params, "cursor", None) if params is not None else None
     start = int(cursor) if cursor else 0
     page = _ALL_TOOLS[start : start + _PAGE_SIZE]
     next_cursor = str(start + _PAGE_SIZE) if start + _PAGE_SIZE < len(_ALL_TOOLS) else None
-    result = types.ListToolsResult(tools=page, nextCursor=next_cursor)
-    return types.ServerResult(result)
+    return types.ListToolsResult(tools=page, next_cursor=next_cursor)
 
 
-app.request_handlers[types.ListToolsRequest] = _handle_list_tools_paginated
+app = Server("reyn-test-paginated", on_list_tools=list_tools)
 
 
 async def main() -> None:

--- a/tests/_support/mcp_prompts_server.py
+++ b/tests/_support/mcp_prompts_server.py
@@ -24,26 +24,33 @@ import mcp.types as types
 from mcp.server.lowlevel import Server
 from mcp.server.stdio import stdio_server
 
-app = Server("reyn-test-prompts")
-
 _NAME = "greeting"
 _DESCRIPTION = "A simple greeting prompt"
 _RENDERED_TEXT = "hello from a prompt"
 
 
-@app.list_prompts()
-async def list_prompts() -> list[types.Prompt]:
-    return [
+# #4368 (mcp 2.0 port): lowlevel.Server's @list_prompts()/@get_prompt()
+# decorators are gone on mcp 2.0 (measured live) -- handlers are now plain
+# functions passed as Server(...) constructor kwargs instead, so they are
+# defined BEFORE construction. Each handler now receives
+# (ctx: ServerRequestContext, params: <X>RequestParams) directly and must
+# return the typed <X>Result object -- see src/reyn/mcp/server.py's own
+# port commit for the full rationale, identical here. Prompt/PromptArgument/
+# GetPromptRequestParams field names are unchanged between 1.x and 2.0
+# (verified live) -- only the registration shape changed.
+async def list_prompts(ctx: "object", params: "object") -> "types.ListPromptsResult":
+    return types.ListPromptsResult(prompts=[
         types.Prompt(
             name=_NAME,
             description=_DESCRIPTION,
             arguments=[types.PromptArgument(name="style", description="tone", required=False)],
         )
-    ]
+    ])
 
 
-@app.get_prompt()
-async def get_prompt(name: str, arguments: dict | None) -> types.GetPromptResult:
+async def get_prompt(
+    ctx: "object", params: "types.GetPromptRequestParams",
+) -> "types.GetPromptResult":
     return types.GetPromptResult(
         description=_DESCRIPTION,
         messages=[
@@ -53,6 +60,11 @@ async def get_prompt(name: str, arguments: dict | None) -> types.GetPromptResult
             )
         ],
     )
+
+
+app = Server(
+    "reyn-test-prompts", on_list_prompts=list_prompts, on_get_prompt=get_prompt,
+)
 
 
 async def main() -> None:

--- a/tests/_support/mcp_resources_server.py
+++ b/tests/_support/mcp_resources_server.py
@@ -14,14 +14,6 @@ registered (``get_capabilities()``), so a server that registers ONLY
 gets ``resources`` non-None and ``tools`` None — the real differentiator this
 gate slice needs to prove ``MCPClient.supports()`` reads the ACTUAL negotiated
 capabilities rather than a hardcoded reyn-side assumption.
-
-#4368 (mcp 2.0 port, arc #4412): this is a standalone test-only script, not
-production surface the ``_mcp_server_boundary`` seam is scoped to (owner
-ruling via lead-coder, #4368: growing the seam's registration API for every
-test-only handler kind isn't warranted). Written plain, in the CURRENTLY
-INSTALLED pin's own decorator API + field-name vocabulary (1.x today); the
-arc's pin-bump PR flips this file's decorators/field names in the same
-mechanical pass as every other pin-vocabulary call site.
 """
 from __future__ import annotations
 
@@ -31,19 +23,39 @@ import mcp.types as types
 from mcp.server.lowlevel import Server
 from mcp.server.stdio import stdio_server
 
-app = Server("reyn-test-resources")
-
 _URI = "resource://greeting"
 
 
-@app.list_resources()
-async def list_resources() -> list[types.Resource]:
-    return [types.Resource(uri=_URI, name="greeting", mimeType="text/plain")]
+# #4368 (mcp 2.0 port): lowlevel.Server's @list_resources()/@read_resource()
+# decorators are gone on mcp 2.0 (measured live) -- handlers are now plain
+# functions passed as Server(...) constructor kwargs instead, so they are
+# defined BEFORE construction. Each handler now receives
+# (ctx: ServerRequestContext, params: <X>RequestParams) directly and must
+# return the typed <X>Result object -- see src/reyn/mcp/server.py's own
+# port commit for the full rationale, identical here. Resource.mimeType
+# renamed to mime_type (verified live); on_read_resource must return a
+# ReadResourceResult directly -- the old decorator's "bare str auto-wraps"
+# convenience sugar is gone (confirmed: no normalisation layer between the
+# handler's return value and the wire response on the 2.0 registration
+# path).
+async def list_resources(ctx: "object", params: "object") -> "types.ListResourcesResult":
+    return types.ListResourcesResult(resources=[
+        types.Resource(uri=_URI, name="greeting", mime_type="text/plain"),
+    ])
 
 
-@app.read_resource()
-async def read_resource(uri) -> str:
-    return "hello from a resource"
+async def read_resource(
+    ctx: "object", params: "types.ReadResourceRequestParams",
+) -> "types.ReadResourceResult":
+    return types.ReadResourceResult(contents=[types.TextResourceContents(
+        uri=str(params.uri), mime_type="text/plain", text="hello from a resource",
+    )])
+
+
+app = Server(
+    "reyn-test-resources",
+    on_list_resources=list_resources, on_read_resource=read_resource,
+)
 
 
 async def main() -> None:

--- a/tests/_support/mcp_subscribable_resources_server.py
+++ b/tests/_support/mcp_subscribable_resources_server.py
@@ -19,13 +19,17 @@ with FastMCP's high-level ``FastMCP()`` class can ever advertise
 prove ``MCPClient.subscribe_resource`` on a server that DOES support it, not
 just the already-covered fail-fast path against a server that doesn't).
 
-This module subclasses the LOW-LEVEL ``mcp.server.lowlevel.Server`` directly
-(the same base class FastMCP itself subclasses in ``fastmcp/server/low_level.py``)
-and overrides ``get_capabilities`` to flip ``resources.subscribe`` to True
-whenever a ``SubscribeRequest`` handler is registered — extending the SDK's own
-"derive capabilities from registered handlers" contract (already used for
-tools/prompts/resources ``listChanged``) to the one field the SDK's base
-implementation never sets. This is a real MCP server object, not a mock.
+Historically (mcp 1.x) this module subclassed the LOW-LEVEL
+``mcp.server.lowlevel.Server`` directly and overrode ``get_capabilities`` to
+flip ``resources.subscribe`` to True whenever a ``SubscribeRequest`` handler
+was registered — the 1.x base implementation never set that field on its
+own. #4368 (mcp 2.0 port): confirmed live that 2.0's OWN
+``get_capabilities`` now derives ``resources.subscribe`` from whether a
+``"resources/subscribe"`` handler is registered (the same "derive
+capabilities from registered handlers" contract this file's subclass used
+to have to patch in by hand) — the subclass override is gone, a plain
+``Server(...)`` with ``on_subscribe_resource`` set is enough. This is a
+real MCP server object, not a mock.
 
 Exposes:
   - resource ``resource://counter`` — content is the current counter value.
@@ -51,71 +55,85 @@ from mcp.server.stdio import stdio_server
 
 _URI = "resource://counter"
 
-
-class _SubscribableServer(Server):
-    def get_capabilities(self, notification_options, experimental_capabilities):
-        capabilities = super().get_capabilities(notification_options, experimental_capabilities)
-        if types.SubscribeRequest in self.request_handlers and capabilities.resources is not None:
-            capabilities = capabilities.model_copy(
-                update={
-                    "resources": capabilities.resources.model_copy(update={"subscribe": True}),
-                }
-            )
-        return capabilities
-
-
-app = _SubscribableServer("reyn-test-subscribable-resources")
-
 _counter = {"value": 0}
 
 
-@app.list_resources()
-async def list_resources() -> list[types.Resource]:
-    return [types.Resource(uri=_URI, name="counter", mimeType="text/plain")]
+# #4368 (mcp 2.0 port): all 6 decorators this file used
+# (@list_resources/@read_resource/@subscribe_resource/@unsubscribe_resource/
+# @list_tools/@call_tool) are gone on mcp 2.0 (measured live) -- handlers
+# are now plain functions passed as Server(...) constructor kwargs instead,
+# so they are defined BEFORE construction. Each now receives
+# (ctx: ServerRequestContext, params: <X>RequestParams) directly (the tool
+# handler's ctx replaces the old ``app.request_context`` lookup for
+# ``bump_and_notify``'s ``session.send_resource_updated`` call) and must
+# return the typed <X>Result object -- see src/reyn/mcp/server.py's own
+# port commit for the full rationale, identical here.
+async def list_resources(ctx: "object", params: "object") -> "types.ListResourcesResult":
+    return types.ListResourcesResult(resources=[
+        types.Resource(uri=_URI, name="counter", mime_type="text/plain"),
+    ])
 
 
-@app.read_resource()
-async def read_resource(uri) -> str:
-    return str(_counter["value"])
+async def read_resource(
+    ctx: "object", params: "types.ReadResourceRequestParams",
+) -> "types.ReadResourceResult":
+    return types.ReadResourceResult(contents=[types.TextResourceContents(
+        uri=str(params.uri), mime_type="text/plain", text=str(_counter["value"]),
+    )])
 
 
-@app.subscribe_resource()
-async def subscribe_resource(uri) -> None:
-    return None
+async def subscribe_resource(
+    ctx: "object", params: "types.SubscribeRequestParams",
+) -> "types.EmptyResult":
+    return types.EmptyResult()
 
 
-@app.unsubscribe_resource()
-async def unsubscribe_resource(uri) -> None:
-    return None
+async def unsubscribe_resource(
+    ctx: "object", params: "types.UnsubscribeRequestParams",
+) -> "types.EmptyResult":
+    return types.EmptyResult()
 
 
-@app.list_tools()
-async def list_tools() -> list[types.Tool]:
-    return [
+async def list_tools(ctx: "object", params: "object") -> "types.ListToolsResult":
+    return types.ListToolsResult(tools=[
         types.Tool(
             name="bump_and_notify",
             description="Increment the counter resource and push a real "
             "notifications/resources/updated for resource://counter.",
-            inputSchema={"type": "object", "properties": {}},
+            input_schema={"type": "object", "properties": {}},
         ),
         types.Tool(
             name="die",
             description="Kill the subprocess (transport-death simulation).",
-            inputSchema={"type": "object", "properties": {}},
+            input_schema={"type": "object", "properties": {}},
         ),
-    ]
+    ])
 
 
-@app.call_tool()
-async def call_tool(name: str, arguments: dict) -> list[types.TextContent]:
+async def call_tool(
+    ctx: "object", params: "types.CallToolRequestParams",
+) -> "types.CallToolResult":
+    name = params.name
     if name == "bump_and_notify":
         _counter["value"] += 1
-        session = app.request_context.session
-        await session.send_resource_updated(types.AnyUrl(_URI))
-        return [types.TextContent(type="text", text=str(_counter["value"]))]
+        await ctx.session.send_resource_updated(_URI)
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(_counter["value"]))],
+        )
     if name == "die":
         os._exit(1)
     raise ValueError(f"unknown tool {name!r}")
+
+
+app = Server(
+    "reyn-test-subscribable-resources",
+    on_list_resources=list_resources,
+    on_read_resource=read_resource,
+    on_subscribe_resource=subscribe_resource,
+    on_unsubscribe_resource=unsubscribe_resource,
+    on_list_tools=list_tools,
+    on_call_tool=call_tool,
+)
 
 
 async def main() -> None:

--- a/tests/_support/mcp_tools_only_pid_server.py
+++ b/tests/_support/mcp_tools_only_pid_server.py
@@ -26,24 +26,36 @@ import mcp.types as types
 from mcp.server.lowlevel import Server
 from mcp.server.stdio import stdio_server
 
-app = Server("reyn-test-tools-only-pid")
-
 _PID_TOOL = types.Tool(
     name="pid", description="Return this server subprocess's PID.",
-    inputSchema={"type": "object"},
+    input_schema={"type": "object"},
 )
 
 
-@app.list_tools()
-async def list_tools() -> list[types.Tool]:
-    return [_PID_TOOL]
+# #4368 (mcp 2.0 port): lowlevel.Server's @list_tools()/@call_tool()
+# decorators are gone on mcp 2.0 (measured live) -- handlers are now plain
+# functions passed as Server(...) constructor kwargs instead, so they are
+# defined BEFORE construction. Each handler now receives
+# (ctx: ServerRequestContext, params: <X>RequestParams) directly and must
+# return the typed <X>Result object -- see src/reyn/mcp/server.py's own
+# port commit for the full rationale, identical here.
+async def list_tools(ctx: "object", params: "object") -> "types.ListToolsResult":
+    return types.ListToolsResult(tools=[_PID_TOOL])
 
 
-@app.call_tool()
-async def call_tool(name: str, arguments: dict) -> list[types.TextContent]:
-    if name != "pid":
-        raise ValueError(f"Unknown tool: {name!r}")
-    return [types.TextContent(type="text", text=str(os.getpid()))]
+async def call_tool(
+    ctx: "object", params: "types.CallToolRequestParams",
+) -> "types.CallToolResult":
+    if params.name != "pid":
+        raise ValueError(f"Unknown tool: {params.name!r}")
+    return types.CallToolResult(
+        content=[types.TextContent(type="text", text=str(os.getpid()))],
+    )
+
+
+app = Server(
+    "reyn-test-tools-only-pid", on_list_tools=list_tools, on_call_tool=call_tool,
+)
 
 
 async def main() -> None:

--- a/tests/builtin/test_fp0063_p3_rag_pipelines.py
+++ b/tests/builtin/test_fp0063_p3_rag_pipelines.py
@@ -120,9 +120,9 @@ _QUERY_PATH = _RAG_PLUGIN_DIR / "pipelines" / "rag_query.yaml"
 _STUB_MARKITDOWN_SERVER = '''
 import base64
 from urllib.parse import urlsplit
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
-mcp = FastMCP("stub-markitdown")
+mcp = MCPServer("stub-markitdown")
 
 
 @mcp.tool()

--- a/tests/core/test_2761_pr3_mcp_immediate_probe.py
+++ b/tests/core/test_2761_pr3_mcp_immediate_probe.py
@@ -225,24 +225,42 @@ async def test_local_install_new_reachable_is_live_same_turn(
 ) -> None:
     """Tier 2: installing a NEW reachable stdio server probes OK, commits, and applies
     IMMEDIATELY — the server is in the live roster + its tools are cached the SAME turn
-    (no restart, no turn boundary). pending stays False (immediate, not deferred)."""
+    (no restart, no turn boundary). pending stays False (immediate, not deferred).
+
+    #4412 pin-bump PR: an immediate probe-commit installs the server as a HELD
+    connection on the session's ``MCPConnectionService`` (S2a — reused, not
+    reopened, on the next call), the same as any real caller's session. A real
+    caller closes it via ``Session.shutdown()``; this test's own
+    ``try/finally`` mirrors that with the narrower ``aclose_mcp_connections()``
+    (the established pattern in ``tests/mcp/test_2597_s2a_mcp_connection_service.py``).
+    Without it, mcp 2.0's ``stdio_client`` teardown-on-cancel path (unlike 1.x)
+    drains the still-alive child's stdout pipe in a SHIELDED, EOF-only loop
+    (``_drain_stdout``) when the reader task is cancelled directly instead of
+    via its own ``shutdown()`` — and EOF never comes from a process nobody
+    told to die, hanging the interpreter's event-loop teardown indefinitely.
+    Confirmed live via an isolated ``asyncio.Runner`` repro reproducing the
+    exact same hang outside pytest, then resolving it by closing the held
+    connection before the runner tears the loop down."""
     monkeypatch.chdir(tmp_path)
     session = _session(tmp_path)
-    assert "pidsrv" not in _roster_names(session)
+    try:
+        assert "pidsrv" not in _roster_names(session)
 
-    result = await _handle_mcp_install_local(
-        {"name": "pidsrv", **_STDIO}, _session_ctx(session, tmp_path),
-    )
+        result = await _handle_mcp_install_local(
+            {"name": "pidsrv", **_STDIO}, _session_ctx(session, tmp_path),
+        )
 
-    assert result["status"] == "ok"
-    assert "pidsrv" in _roster_names(session), (
-        "a NEW reachable server must be resolvable the same turn (immediate probe-commit)"
-    )
-    snap = session._router_host.mcp_tools_cache_snapshot
-    assert snap is not None and "pidsrv" in snap, "its tools must be live-cached same turn"
-    # Immediate path — nothing left pending for the turn boundary.
-    residual = await session._hot_reloader.apply_pending()
-    assert residual is None, "the immediate probe-commit must not ALSO defer a reload"
+        assert result["status"] == "ok"
+        assert "pidsrv" in _roster_names(session), (
+            "a NEW reachable server must be resolvable the same turn (immediate probe-commit)"
+        )
+        snap = session._router_host.mcp_tools_cache_snapshot
+        assert snap is not None and "pidsrv" in snap, "its tools must be live-cached same turn"
+        # Immediate path — nothing left pending for the turn boundary.
+        residual = await session._hot_reloader.apply_pending()
+        assert residual is None, "the immediate probe-commit must not ALSO defer a reload"
+    finally:
+        await session.aclose_mcp_connections()
 
 
 @pytest.mark.asyncio
@@ -272,29 +290,37 @@ async def test_local_install_same_name_overwrite_defers_and_skips_probe(
     """Tier 2: re-installing an EXISTING server (the documented re-install fix) is NOT
     probe-gated and NOT applied mid-turn — it keeps the deferred turn-boundary path
     (write + schedule). Proven by re-installing over a good server with a BAD command:
-    an overwrite still succeeds (no probe) and schedules a deferred reload."""
+    an overwrite still succeeds (no probe) and schedules a deferred reload.
+
+    #4412 pin-bump PR: the first (good) install holds an open MCP connection on
+    the session — closed via the same ``try/finally`` as
+    ``test_local_install_new_reachable_is_live_same_turn`` above; see that
+    test's docstring for why (mcp 2.0's ``stdio_client`` teardown-on-cancel
+    hang when a held connection is abandoned instead of closed)."""
     monkeypatch.chdir(tmp_path)
     session = _session(tmp_path)
+    try:
+        # First install (addition) → probed + immediately live.
+        await _handle_mcp_install_local(
+            {"name": "srv", **_STDIO}, _session_ctx(session, tmp_path),
+        )
+        assert "srv" in _roster_names(session)
 
-    # First install (addition) → probed + immediately live.
-    await _handle_mcp_install_local(
-        {"name": "srv", **_STDIO}, _session_ctx(session, tmp_path),
-    )
-    assert "srv" in _roster_names(session)
+        # Re-install SAME name with a BAD command — an overwrite skips the probe, so it
+        # does NOT error; it writes + defers (documented re-install workflow preserved).
+        result = await _handle_mcp_install_local(
+            {"name": "srv", "command": "/nonexistent/reyn-xyz", "args": []},
+            _session_ctx(session, tmp_path),
+        )
 
-    # Re-install SAME name with a BAD command — an overwrite skips the probe, so it
-    # does NOT error; it writes + defers (documented re-install workflow preserved).
-    result = await _handle_mcp_install_local(
-        {"name": "srv", "command": "/nonexistent/reyn-xyz", "args": []},
-        _session_ctx(session, tmp_path),
-    )
-
-    assert result["status"] == "ok", "an overwrite must NOT be probe-gated (re-install preserved)"
-    pending = session._hot_reloader.pending
-    assert pending is True, "an overwrite schedules the deferred turn-boundary reload"
-    assert _servers_on_disk(tmp_path)["srv"]["command"] == "/nonexistent/reyn-xyz", (
-        "the overwrite is written to config (clobber-update), applied at the turn boundary"
-    )
+        assert result["status"] == "ok", "an overwrite must NOT be probe-gated (re-install preserved)"
+        pending = session._hot_reloader.pending
+        assert pending is True, "an overwrite schedules the deferred turn-boundary reload"
+        assert _servers_on_disk(tmp_path)["srv"]["command"] == "/nonexistent/reyn-xyz", (
+            "the overwrite is written to config (clobber-update), applied at the turn boundary"
+        )
+    finally:
+        await session.aclose_mcp_connections()
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_3070_mcp_probe_error_surfaced.py
+++ b/tests/core/test_3070_mcp_probe_error_surfaced.py
@@ -110,14 +110,16 @@ class _ErroringFastMCPClient:
     async def call_tool(
         self, name: str, arguments: "dict | None" = None, **kwargs: Any,
     ) -> Any:
-        # `_result_to_dict` (reyn.mcp.client) reads `.content`/`.isError` as
-        # plain ATTRIBUTES (mirrors ``mcp.types.CallToolResult``), and a
-        # content item is either a pydantic model (``model_dump()``) or a
-        # plain dict passed through unchanged -- the latter is simplest here.
+        # `_result_to_dict` (reyn.mcp.client) reads `.content`/`.is_error`
+        # as plain ATTRIBUTES (mirrors ``mcp.types.CallToolResult`` -- #4412
+        # pin-bump PR: snake_case on mcp 2.0, confirmed live via
+        # model_fields; was camelCase on 1.x), and a content item is either
+        # a pydantic model (``model_dump()``) or a plain dict passed
+        # through unchanged -- the latter is simplest here.
         class _Result:
             content = [{"type": "text", "text": self._error_text}]
-            isError = True
-            structuredContent = None
+            is_error = True
+            structured_content = None
 
         return _Result()
 
@@ -179,8 +181,8 @@ def test_mcp_completed_event_carries_no_error_text_on_success() -> None:
         async def call_tool(self, name: str, arguments=None, **kwargs: Any) -> Any:
             class _Result:
                 content = [{"type": "text", "text": "ok"}]
-                isError = False
-                structuredContent = None
+                is_error = False
+                structured_content = None
             return _Result()
 
     _bypass_initialize(client, _OkFastMCPClient())

--- a/tests/core/test_fp0016_e_agent_id.py
+++ b/tests/core/test_fp0016_e_agent_id.py
@@ -113,17 +113,24 @@ def _capture_http_headers(monkeypatch) -> dict:
     ``mcp.client.streamable_http.streamablehttp_client(url, headers=...)``
     inline instead. Captures the REAL function's kwargs by wrapping it
     (still calls through to the real one) rather than faking the SDK —
-    same seam ``test_config_mcp_headers.py`` already established."""
+    same seam ``test_config_mcp_headers.py`` already established.
+
+    #4412 pin-bump PR: ``streamablehttp_client`` is GONE on mcp 2.0 —
+    headers now reach the SDK's own ``create_mcp_http_client(headers=...)``
+    factory instead (``client.py``'s replacement for constructing the
+    transport's HTTP client) — see
+    ``test_config_mcp_headers.py::_capture_streamablehttp_client_kwargs``'s
+    identical fix, full detail."""
     import mcp.client.streamable_http as sh_mod
 
     captured: dict = {}
-    real_fn = sh_mod.streamablehttp_client
+    real_create_client = sh_mod.create_mcp_http_client
 
-    def _capturing(url, headers=None, timeout=30, **kwargs):
+    def _capturing(headers=None, timeout=None, auth=None):
         captured["headers"] = headers
-        return real_fn(url, headers=headers, timeout=timeout, **kwargs)
+        return real_create_client(headers=headers, timeout=timeout, auth=auth)
 
-    monkeypatch.setattr(sh_mod, "streamablehttp_client", _capturing)
+    monkeypatch.setattr(sh_mod, "create_mcp_http_client", _capturing)
     return captured
 
 

--- a/tests/core/test_mcp_progress_and_timeout.py
+++ b/tests/core/test_mcp_progress_and_timeout.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-from datetime import timedelta
 from typing import Any
 
 import pytest
@@ -92,11 +91,15 @@ def test_call_tool_signature_accepts_progress_callback_and_timeout() -> None:
     assert params["timeout_seconds"].default is None
 
 
-def test_call_tool_passes_progress_callback_and_timedelta_to_official_sdk() -> None:
+def test_call_tool_passes_progress_callback_and_read_timeout_to_official_sdk() -> None:
     """Tier 2: when both kwargs are set, ``MCPClient.call_tool`` forwards them
     to ``self._client.call_tool`` using the official SDK's own parameter
-    names (``progress_callback`` and ``read_timeout_seconds`` as a
-    ``timedelta``).
+    names (``progress_callback`` and ``read_timeout_seconds``).
+
+    #4412 pin-bump PR: ``read_timeout_seconds`` is ``float | None`` on
+    mcp 2.0's ``ClientSession.call_tool`` (confirmed live via its own
+    signature) -- was ``timedelta | None`` on 1.x. ``MCPClient.call_tool``
+    now passes the raw float straight through.
     """
     captured: dict[str, Any] = {}
 
@@ -143,8 +146,8 @@ def test_call_tool_passes_progress_callback_and_timedelta_to_official_sdk() -> N
     assert captured["arguments"] == {"x": 1}
     assert captured["kwargs"].get("progress_callback") is _on_progress
     read_to = captured["kwargs"].get("read_timeout_seconds")
-    assert isinstance(read_to, timedelta)
-    assert read_to == timedelta(seconds=4.5)
+    assert isinstance(read_to, float)
+    assert read_to == 4.5
 
 
 def test_call_tool_omits_kwargs_when_none_for_backwards_compat() -> None:
@@ -256,8 +259,9 @@ def test_op_handler_progress_callback_emits_mcp_progress_event() -> None:
 def test_op_handler_reads_call_timeout_from_server_config() -> None:
     """Tier 2: when ``mcp.servers.<name>.call_timeout_seconds`` is set, the
     op handler reads it from the raw config dict and forwards as
-    ``timeout_seconds`` to ``MCPClient.call_tool`` (which converts to
-    ``timedelta`` and passes as ``read_timeout_seconds`` to the SDK).
+    ``timeout_seconds`` to ``MCPClient.call_tool``, which passes it as
+    ``read_timeout_seconds`` to the SDK (a plain ``float`` on mcp 2.0,
+    #4412 pin-bump PR -- was converted to ``timedelta`` on 1.x).
     """
     from reyn.core.op_runtime import mcp as mcp_op_handler
 
@@ -304,8 +308,8 @@ def test_op_handler_reads_call_timeout_from_server_config() -> None:
     asyncio.run(mcp_op_handler._execute(op, ctx))
 
     read_to = captured["read_timeout_seconds"]
-    assert isinstance(read_to, timedelta)
-    assert read_to == timedelta(seconds=7.5)
+    assert isinstance(read_to, float)
+    assert read_to == 7.5
 
 
 def test_op_handler_call_timeout_default_finite_and_optout() -> None:
@@ -385,6 +389,7 @@ def test_mcp_client_call_tool_forwards_progress_and_timeout_kwargs() -> None:
     # Both kwargs must appear in the SDK kwargs builder.
     assert "progress_callback" in src
     assert "read_timeout_seconds" in src
-    assert "timedelta" in src, (
-        "timeout_seconds must be converted to a timedelta before the SDK call"
-    )
+    # #4412 pin-bump PR: read_timeout_seconds is passed as a plain float on
+    # mcp 2.0 (its own signature: float | None -- confirmed live), not
+    # converted to a timedelta as it was on 1.x -- this pin dropped
+    # accordingly, not weakened by omission.

--- a/tests/gateway/sample_slack/test_outbound.py
+++ b/tests/gateway/sample_slack/test_outbound.py
@@ -131,24 +131,25 @@ def test_build_server_lists_and_dispatches_extra_tool(tmp_path):
     call_tool to its handler (the in-process MCP-server half of the e2e).
 
     #4444 (mcp 2.0 port, Class A co-vet finding): drives this through a REAL
-    in-process client/server round trip
-    (``mcp.shared.memory.create_connected_server_and_client_session``)
-    rather than calling ``server.request_handlers[...]`` directly — a direct
-    call bypasses the SDK's own request-dispatch loop, which is where
-    ``request_ctx`` (the seam's ``_CtxAdapter`` reads it via
-    ``server.request_context``) gets SET; confirmed live reading
-    ``mcp.server.lowlevel.server``'s own source that this happens deep
-    inside ``Server.run()``'s private per-message handling, with no small
-    public API to set it from outside. See
+    in-process client/server round trip rather than calling
+    ``server.request_handlers[...]`` directly — a direct call bypasses the
+    SDK's own request-dispatch loop, which is where ``request_ctx`` gets
+    SET; confirmed live reading ``mcp.server.lowlevel.server``'s own source
+    that this happens deep inside ``Server.run()``'s private per-message
+    handling, with no small public API to set it from outside. See
     ``tests/runtime/test_mcp_server_resources_adapter.py``'s identical fix
-    for the same finding, full detail."""
-    pytest.importorskip("mcp")
-    from mcp.shared.memory import create_connected_server_and_client_session
+    for the same finding, full detail.
 
+    #4412 pin-bump PR: uses ``tests._support.mcp_memory_session`` (a
+    hand-rolled equivalent of the removed
+    ``mcp.shared.memory.create_connected_server_and_client_session``)
+    rather than the SDK helper this test used before the bump."""
+    pytest.importorskip("mcp")
     from reyn.core.events.state_log import StateLog
     from reyn.mcp.extra_tool import ExtraTool
     from reyn.mcp.server import build_server
     from reyn.runtime.registry import AgentRegistry
+    from tests._support.mcp_memory_session import connected_server_and_client_session
 
     async def _echo(args: dict) -> str:
         return json.dumps({"echo": args.get("msg", "")})
@@ -175,7 +176,7 @@ def test_build_server_lists_and_dispatches_extra_tool(tmp_path):
     server = build_server(registry, extra_tools=[tool])
 
     async def _round_trip():
-        async with create_connected_server_and_client_session(server) as session:
+        async with connected_server_and_client_session(server) as session:
             await session.initialize()
             list_result = await session.list_tools()
             call_result = await session.call_tool("echo_tool", {"msg": "hi"})

--- a/tests/mcp/test_2421_gateway_real_substrate.py
+++ b/tests/mcp/test_2421_gateway_real_substrate.py
@@ -20,16 +20,19 @@ import pytest
 pytest.importorskip("mcp.server", reason="mcp SDK server API required for the real-substrate test")
 
 # A real low-level stdio MCP server that handshakes fine, then its subprocess DIES on list_tools.
+# #4368 (mcp 2.0 port): @app.list_tools() is gone on mcp 2.0 (measured live) -- the handler is now
+# a plain function passed as Server(...)'s on_list_tools constructor kwarg, defined before
+# construction, taking (ctx, params) directly. No return-type change needed here (the subprocess
+# dies before ever returning).
 _DYING_SERVER = '''\
 import os, asyncio
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
 
-app = Server("dying-server")
-
-@app.list_tools()
-async def list_tools():
+async def list_tools(ctx, params):
     os._exit(1)  # the subprocess dies mid-operation (external dep missing / crash analogue)
+
+app = Server("dying-server", on_list_tools=list_tools)
 
 async def main():
     async with stdio_server() as (r, w):

--- a/tests/mcp/test_2597_s2b_mcp_notifications_bridge.py
+++ b/tests/mcp/test_2597_s2b_mcp_notifications_bridge.py
@@ -244,7 +244,7 @@ class _FakeClient:
         self.routed.append(root)
 
 
-def _make_task_status_notification() -> types.ServerNotification:
+def _make_task_status_notification() -> types.TaskStatusNotification:
     from datetime import datetime, timezone
 
     # #4412 pin-bump PR: created_at/last_updated_at are `str` (ISO format) on
@@ -258,7 +258,7 @@ def _make_task_status_notification() -> types.ServerNotification:
         last_updated_at=now,
         ttl=None,
     )
-    return types.ServerNotification(types.TaskStatusNotification(params=params))
+    return types.TaskStatusNotification(params=params)
 
 
 @pytest.mark.asyncio
@@ -306,7 +306,7 @@ async def test_unrecognized_notification_is_logged_not_silently_dropped(caplog) 
     handler = ReynMCPMessageHandler(lambda *a, **k: None, "srv")
     handler.bind_client(_FakeClient())
 
-    notification = types.ServerNotification(types.ResourceListChangedNotification())
+    notification = types.ResourceListChangedNotification()
     with caplog.at_level(logging.DEBUG, logger="reyn.mcp.message_handler"):
         await handler(notification)
 
@@ -352,7 +352,7 @@ async def test_emit_sink_fault_does_not_break_call():
     handler = ReynMCPMessageHandler(_boom, "srv")
     handler.bind_client(_FakeClient())
 
-    notification = types.ServerNotification(types.ToolListChangedNotification())
+    notification = types.ToolListChangedNotification()
     await handler(notification)  # must not raise
 
 
@@ -373,7 +373,7 @@ async def test_tools_cache_invalidate_fault_does_not_block_event_emit(tmp_path: 
     )
     handler.bind_client(_FakeClient())
 
-    notification = types.ServerNotification(types.ToolListChangedNotification())
+    notification = types.ToolListChangedNotification()
     await handler(notification)  # must not raise
 
     matching = [e for e in collected if e.type == "mcp_tool_list_changed"]

--- a/tests/mcp/test_2597_s2b_mcp_notifications_bridge.py
+++ b/tests/mcp/test_2597_s2b_mcp_notifications_bridge.py
@@ -247,18 +247,27 @@ class _FakeClient:
 def _make_task_status_notification() -> types.ServerNotification:
     from datetime import datetime, timezone
 
-    now = datetime.now(timezone.utc)
+    # #4412 pin-bump PR: created_at/last_updated_at are `str` (ISO format) on
+    # 2.0, not `datetime` — confirmed live via model_fields (a real shape
+    # change alongside the camelCase->snake_case rename, not just the rename).
+    now = datetime.now(timezone.utc).isoformat()
     params = types.TaskStatusNotificationParams(
-        taskId="task-1",
+        task_id="task-1",
         status="working",
-        createdAt=now,
-        lastUpdatedAt=now,
+        created_at=now,
+        last_updated_at=now,
         ttl=None,
     )
     return types.ServerNotification(types.TaskStatusNotification(params=params))
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="#4457: mcp 2.0's IncomingMessage/ServerNotification unions "
+    "exclude TaskStatusNotification -- the real routing mechanism "
+    "(Dispatcher/notification_bindings) is marked provisional by the SDK "
+    "itself; deferred until that surface stabilizes, tracked in #4457.",
+)
 async def test_task_status_routing_via_composed_call():
     """Tier 1: #3698 P3 — ReynMCPMessageHandler no longer inherits fastmcp's
     TaskNotificationHandler; it implements ``__call__`` itself and peeks for a

--- a/tests/mcp/test_3028_mcp_stdio_init_timeout.py
+++ b/tests/mcp/test_3028_mcp_stdio_init_timeout.py
@@ -65,8 +65,8 @@ _SILENT_SERVER_SRC = textwrap.dedent(
 # healthy launches would trade the owner's hang for the owner's broken startup.
 _HEALTHY_SERVER_SRC = textwrap.dedent(
     '''
-    from mcp.server.fastmcp import FastMCP
-    mcp = FastMCP("t3028healthy")
+    from mcp.server.mcpserver import MCPServer
+    mcp = MCPServer("t3028healthy")
 
     @mcp.tool()
     def echo(text: str) -> str:

--- a/tests/mcp/test_config_mcp_headers.py
+++ b/tests/mcp/test_config_mcp_headers.py
@@ -126,18 +126,33 @@ def _capture_streamablehttp_client_kwargs(monkeypatch) -> dict:
     real one, so the connection attempt proceeds exactly as it would
     unmodified) rather than faking the SDK — same seam
     ``test_mcp_client_stderr_capture.py``'s stdio_client patch already
-    established, applied to the http transport function instead."""
+    established, applied to the http transport function instead.
+
+    #4412 pin-bump PR: ``streamablehttp_client`` (headers/timeout kwargs
+    directly) is GONE on mcp 2.0 — its replacement, ``streamable_http_client``,
+    takes a pre-built HTTP client instead, and ``client.py`` now builds that
+    client via the SDK's own ``create_mcp_http_client(headers=...)`` factory
+    (see that call site's own comment for why: reyn deliberately does not
+    import the SDK's transport-library type by name). Headers therefore now
+    reach ``create_mcp_http_client``, not ``streamable_http_client`` itself —
+    wrap BOTH functions to keep capturing url (from the latter) and headers
+    (from the former)."""
     import mcp.client.streamable_http as sh_mod
 
     captured: dict = {}
-    real_fn = sh_mod.streamablehttp_client
+    real_create_client = sh_mod.create_mcp_http_client
+    real_transport = sh_mod.streamable_http_client
 
-    def _capturing(url, headers=None, timeout=30, **kwargs):
-        captured["url"] = url
+    def _capturing_create_client(headers=None, timeout=None, auth=None):
         captured["headers"] = headers
-        return real_fn(url, headers=headers, timeout=timeout, **kwargs)
+        return real_create_client(headers=headers, timeout=timeout, auth=auth)
 
-    monkeypatch.setattr(sh_mod, "streamablehttp_client", _capturing)
+    def _capturing_transport(url, **kwargs):
+        captured["url"] = url
+        return real_transport(url, **kwargs)
+
+    monkeypatch.setattr(sh_mod, "create_mcp_http_client", _capturing_create_client)
+    monkeypatch.setattr(sh_mod, "streamable_http_client", _capturing_transport)
     return captured
 
 

--- a/tests/mcp/test_mcp_capability_advertising_271_m3.py
+++ b/tests/mcp/test_mcp_capability_advertising_271_m3.py
@@ -62,7 +62,7 @@ def test_serve_stdio_declares_static_tool_list(tmp_path: Path) -> None:
     )
     capabilities = build_init_options(build_server(registry)).capabilities
     assert capabilities.tools is not None
-    assert capabilities.tools.listChanged is False
+    assert capabilities.tools.list_changed is False
 
 
 def test_no_notify_changed_calls_in_mcp_server_source() -> None:

--- a/tests/mcp/test_mcp_client.py
+++ b/tests/mcp/test_mcp_client.py
@@ -48,17 +48,25 @@ class _HttpEchoServer:
         sys.path.insert(0, str(_SUPPORT_DIR))
         import mcp_fastmcp_echo_server as server_mod
 
-        server_mod.mcp.settings.host = "127.0.0.1"
-        server_mod.mcp.settings.port = self.port
-        # #4302: the bundled FastMCP (1.x line) lazily builds+CACHES a
+        # #4412 pin-bump PR: mcp 2.0's `MCPServer.settings` DROPPED
+        # `host`/`port` entirely (confirmed live: the `Settings` model no
+        # longer declares those fields at all) — `run_streamable_http_async`
+        # takes them as direct kwargs instead.
+        # #4302: the bundled FastMCP/MCPServer lazily builds+CACHES a
         # StreamableHTTPSessionManager on first use, and its own docs say
         # "can only be called once per instance" — a 2nd http-transport test
         # importing the SAME cached module-level ``mcp`` object hangs on
         # startup otherwise (verified: isolated it to exactly this reuse).
         # Reset so each test gets a fresh session manager, matching this
-        # module's fresh-``_HttpEchoServer``-per-test intent.
-        server_mod.mcp._session_manager = None
-        self._task = asyncio.create_task(server_mod.mcp.run_streamable_http_async())
+        # module's fresh-``_HttpEchoServer``-per-test intent. On 2.0,
+        # `MCPServer.session_manager` is a READ-ONLY property delegating to
+        # the underlying `lowlevel.Server._session_manager` (confirmed live
+        # by reading the property's own source) — that private attribute is
+        # the actual resettable backing store.
+        server_mod.mcp._lowlevel_server._session_manager = None
+        self._task = asyncio.create_task(
+            server_mod.mcp.run_streamable_http_async(host="127.0.0.1", port=self.port),
+        )
         # Poll until the socket accepts connections instead of a fixed sleep.
         # Unbounded per the testing policy — a capped attempt count is a wait
         # duration rewritten as a count, and fails the same way on a slow host.
@@ -353,9 +361,12 @@ def test_sse_transport_round_trip() -> None:
         sys.path.insert(0, str(_SUPPORT_DIR))
         import mcp_fastmcp_echo_server as server_mod
 
-        server_mod.mcp.settings.host = "127.0.0.1"
-        server_mod.mcp.settings.port = port
-        task = asyncio.create_task(server_mod.mcp.run_sse_async())
+        # #4412 pin-bump PR: `.settings.host`/`.settings.port` are gone on
+        # mcp 2.0 — see `_HttpEchoServer.__aenter__` above for the same fix
+        # and its full rationale.
+        task = asyncio.create_task(
+            server_mod.mcp.run_sse_async(host="127.0.0.1", port=port),
+        )
         try:
             # Unbounded per the testing policy — see the identical poll in
             # _HttpEchoServer.__aenter__ above for the rationale.

--- a/tests/mcp/test_mcp_structured_client_p1.py
+++ b/tests/mcp/test_mcp_structured_client_p1.py
@@ -23,8 +23,8 @@ import pytest
 
 _SERVER_SRC = textwrap.dedent(
     '''
-    from mcp.server.fastmcp import FastMCP
-    mcp = FastMCP("p1acceptance")
+    from mcp.server.mcpserver import MCPServer
+    mcp = MCPServer("p1acceptance")
 
     @mcp.tool()
     def echo(text: str) -> str:

--- a/tests/runtime/test_fp0063_arc_witness.py
+++ b/tests/runtime/test_fp0063_arc_witness.py
@@ -201,9 +201,9 @@ _INGEST_QUERY_FIXTURE_PATH = _FIXTURE_DIR / "turn2_ingest_query.jsonl"
 _STUB_MARKITDOWN_SERVER = '''
 import base64
 from urllib.parse import urlsplit
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
-mcp = FastMCP("stub-markitdown")
+mcp = MCPServer("stub-markitdown")
 
 
 @mcp.tool()

--- a/tests/runtime/test_mcp_server_resources_adapter.py
+++ b/tests/runtime/test_mcp_server_resources_adapter.py
@@ -63,31 +63,34 @@ def _build_registry_with_agent(tmp_path: Path, agent_name: str) -> AgentRegistry
 
 def _invoke_read_resource(server, uri_str: str):
     """Drive ``resources/read`` through a REAL in-process client/server round
-    trip (``mcp.shared.memory.create_connected_server_and_client_session``)
-    rather than calling ``server.request_handlers[ReadResourceRequest]``
+    trip rather than calling ``server.request_handlers[ReadResourceRequest]``
     directly.
 
     #4444 (mcp 2.0 port, Class A co-vet finding): calling a registered
     handler directly bypasses the SDK's own request-dispatch loop, which is
-    where ``request_ctx`` (a ``contextvars.ContextVar`` the seam's
-    ``_CtxAdapter`` reads via ``server.request_context``) gets SET —
-    confirmed live by reading ``mcp.server.lowlevel.server``'s own source:
-    the set happens deep inside ``Server.run()``'s private per-message
-    handling, with no small public API to set it from outside. Direct
-    handler calls therefore raise ``LookupError`` under Class A's ported
-    registration shape, even though the OLD decorator-registered inner
-    function tolerated being called bare. Routing through a real client
-    session is the fix, not a workaround — it's the SAME "reuse the real
-    path, not a hand-built shortcut" discipline #4368's own third-axis
-    finding came from (a throwaway test masked a gap; a real fixture caught
-    it)."""
-    from mcp.shared.memory import create_connected_server_and_client_session
-    from mcp.types import AnyUrl
+    where ``request_ctx`` (a ``contextvars.ContextVar`` the seam reads via
+    ``ctx``) gets SET — confirmed live by reading
+    ``mcp.server.lowlevel.server``'s own source: the set happens deep
+    inside ``Server.run()``'s private per-message handling, with no small
+    public API to set it from outside. Direct handler calls therefore raise
+    ``LookupError`` under Class A's ported registration shape, even though
+    the OLD decorator-registered inner function tolerated being called
+    bare. Routing through a real client session is the fix, not a
+    workaround — it's the SAME "reuse the real path, not a hand-built
+    shortcut" discipline #4368's own third-axis finding came from (a
+    throwaway test masked a gap; a real fixture caught it).
+
+    #4412 pin-bump PR: uses ``tests._support.mcp_memory_session`` (a
+    hand-rolled equivalent of the removed
+    ``mcp.shared.memory.create_connected_server_and_client_session`` — see
+    that module's own docstring for why it was hand-rolled) rather than
+    the SDK helper this test used before the bump."""
+    from tests._support.mcp_memory_session import connected_server_and_client_session
 
     async def _run() -> "object":
-        async with create_connected_server_and_client_session(server) as session:
+        async with connected_server_and_client_session(server) as session:
             await session.initialize()
-            return await session.read_resource(AnyUrl(uri_str))
+            return await session.read_resource(uri_str)
 
     return asyncio.run(_run())
 

--- a/tests/security/test_network_egress_env_completeness_3075.py
+++ b/tests/security/test_network_egress_env_completeness_3075.py
@@ -323,17 +323,100 @@ def test_huggingface_hub_session_trusts_env() -> None:
 def test_mcp_sdk_remote_transport_built_on_env_trusting_httpx() -> None:
     """Tier 2: degradation witness — the official ``mcp`` SDK's remote-MCP
     transport factory (``mcp.shared._httpx_utils.create_mcp_http_client``,
-    which ``mcp.client.streamable_http``/``mcp.client.sse`` build their
-    ``httpx.AsyncClient`` from, and which reyn's own client — #4282, since
-    fastmcp was dropped, #4302 — passes no client of its own to) never sets
-    ``trust_env``, so it honours the standard proxy/CA env by httpx's own
-    default. RED if the SDK starts explicitly setting ``trust_env=False``."""
-    import inspect
+    re-exported from ``mcp.client.streamable_http``, which builds the
+    HTTP client reyn's own ``client.py`` passes into ``streamable_http_client``
+    — #4412 pin-bump PR: reyn deliberately calls this SDK factory rather than
+    constructing the client itself, per #4368's construction-axis ruling)
+    never sets ``trust_env``, so it honours the standard proxy/CA env by
+    the underlying HTTP library's own default. RED if the SDK starts
+    explicitly setting ``trust_env=False``.
 
+    #4412 pin-bump PR: mcp 2.0 depends on ``httpx2`` — a genuinely SEPARATE
+    package from ``httpx`` (confirmed live:
+    ``httpx2.AsyncClient is not httpx.AsyncClient``), not just a rename —
+    so "httpx's own default" is NOT automatically also httpx2's default;
+    this owner-environment-critical claim (owner works behind a TLS-
+    intercepting corporate proxy) needed its OWN live verification, not an
+    inherited assumption from the old httpx-named assertion. Verified
+    against the installed ``httpx2==2.10.0`` (this repo's pin at the time
+    of writing):
+
+      - ``httpx2.AsyncClient.__init__``'s own signature:
+        ``trust_env: bool = True`` (same default httpx itself has).
+      - Reading ``httpx2._client``'s source: ``trust_env`` gates
+        ``allow_env_proxies``, which (when true) calls
+        ``httpx2._utils.get_environment_proxies()`` — itself built on
+        ``urllib.request.getproxies()`` (the SAME stdlib call httpx's own
+        proxy-env resolution uses), honouring
+        ``HTTP_PROXY``/``HTTPS_PROXY``/``ALL_PROXY``/``NO_PROXY`` (both
+        cases) identically.
+      - Reading ``httpx2._config.create_ssl_context``'s source:
+        ``trust_env`` gates reading ``SSL_CERT_FILE``/``SSL_CERT_DIR`` for
+        the SSL context's CA source, falling back to the OS-native trust
+        store via ``truststore`` when neither is set (httpx2-specific;
+        classic httpx historically fell back to bundled ``certifi`` certs
+        instead — a real behavioral difference, but a STRICTLY BROADER
+        trust source for a corporate MITM proxy scenario: the OS trust
+        store is exactly where IT/MDM tooling installs a corporate root
+        CA, so this is not a degradation for the owner's use case).
+
+    This test's own runtime assertions below witness the two claims most
+    load-bearing for the owner's environment directly (constructed client
+    + a real env-var round trip), not just a source-string grep — the grep
+    below stays too, as the cheap "did the SDK start doing something
+    different" tripwire the original test was for."""
     from mcp.shared._httpx_utils import create_mcp_http_client
 
+    # Real runtime witness 1: the client this factory actually returns has
+    # trust_env=True (not just "the default parameter value is True" —
+    # the SAME client create_mcp_http_client hands back).
+    client = create_mcp_http_client()
+    try:
+        assert client.trust_env is True
+    finally:
+        import asyncio
+
+        asyncio.run(client.aclose())
+
+    # Real runtime witness 2: a proxy env var set BEFORE construction is
+    # actually picked up by the constructed client's proxy map — not just
+    # "the source mentions get_environment_proxies", the real object it
+    # returns.
+    import os
+
+    old = os.environ.get("HTTPS_PROXY")
+    os.environ["HTTPS_PROXY"] = "http://sentinel-proxy.invalid:9"
+    try:
+        client2 = create_mcp_http_client()
+        try:
+            # The real resolved mount map, no public accessor for it — walk
+            # to each transport's connection pool's OWN resolved proxy URL
+            # (not just "a mount object exists", which is true even with no
+            # proxy configured) and assert the sentinel host actually made
+            # it all the way through httpx2's own env-proxy resolution.
+            mounts = client2._mounts  # noqa: SLF001
+            proxy_hosts = [
+                pool._proxy_url.host.decode()  # noqa: SLF001
+                for transport in mounts.values()
+                for pool in [getattr(transport, "_pool", None)]
+                if pool is not None and getattr(pool, "_proxy_url", None) is not None
+            ]
+            assert proxy_hosts, f"HTTPS_PROXY env was set but no proxy pool was resolved: {mounts!r}"
+            assert "sentinel-proxy.invalid" in proxy_hosts, proxy_hosts
+        finally:
+            asyncio.run(client2.aclose())
+    finally:
+        if old is None:
+            os.environ.pop("HTTPS_PROXY", None)
+        else:
+            os.environ["HTTPS_PROXY"] = old
+
+    # Cheap tripwire, unchanged in spirit from the pre-#4412 form: RED if
+    # the SDK starts explicitly opting out of env trust.
+    import inspect
+
     src = inspect.getsource(create_mcp_http_client)
-    assert "httpx.AsyncClient" in src
+    assert "httpx2.AsyncClient" in src
     assert "trust_env=False" not in src
 
 


### PR DESCRIPTION
**[e2e-coder]** — the mcp 2.0 pin-bump PR: `mcp>=1.24,<2.0` → `mcp>=2.0,<3.0`. Completes #4412's Classes A-F plus everything the arc's own measurement-driven process surfaced beyond that catalog. `tests/mcp/` green, broader repo sweep green (with 1 pre-existing, out-of-scope exception noted below).

## Commit structure (as agreed)

- **Commit 1 (`feat`, mechanical)**: every change is a rename, relocation, or deletion whose replacement was measured live against `mcp==2.0.0` and is a pure substitution — no dispatch-logic decision anywhere in it.
- **Commit 2 (`fix`, logic)**: Class G — `ServerNotification` stopped being a constructible wrapper class and became a bare `X | Y | Z` type alias on 2.0. Unwrapping it is a real behavior change to `message_handler.py`'s routing (`root = message.root` → `root = message`), not a token rename, so it's kept separate per your explicit ruling.

**Read commit 1's own message for the full class-by-class breakdown** — it's long because the catalog genuinely wasn't exhaustive (see below) and each finding needed its own live confirmation before being folded in.

## The catalog wasn't exhaustive (owner-visible framing, not buried)

#4412's founding issue enumerated Classes A-G as the full scope. Getting `tests/mcp/` (and a 25-file broader sweep of everything outside it importing `reyn.mcp.*`) actually green surfaced **at least 9 additional breakage classes** — found only by driving real execution (subprocess spawns, real wire round trips, a real killed-connection repro), never by re-reading the catalog harder. The most significant: `mcp.shared.exceptions.McpError` renamed `MCPError` on 2.0, and `client.py`'s transport-death predicate imported the old name inside a bare `try/except ImportError: return False` — so the import silently failed and the predicate was UNCONDITIONALLY `False` under 2.0, meaning **every reconnect-heal in `MCPConnectionService` silently never fired**. Confirmed via a full-tree AST sweep this is the only silent-swallow site in `src/reyn/`, and separately confirmed (force-reinstalling the current pin) that `main` is NOT live-broken today — this belongs in the pin bump, not a hotfix.

## Numbers, with their definitions (not bare deltas)

- `tests/mcp/` under `mcp==2.0.0`, measured just now on this branch: **159 passed, 1 skipped**.
- Broader sweep (25 files outside `tests/mcp/`/`tests/_support/` that import `reyn.mcp.*`), same measurement point: **248 passed, 14 skipped, 2 failed** (pre-existing, unrelated — see below).
- #4412's own founding measurement (57 failed/117 passed) was taken on a *different* branch state at filing time — not directly comparable as a before/after delta, since the collected-test population itself differs between the two measurement points.

## Deferred, tracked, not silently dropped

- **#4457** (part of #4412): `TaskStatusNotification` left the `ServerNotification`/`IncomingMessage` union on 2.0; the real replacement mechanism (`mcp.shared.dispatcher.Dispatcher`/`notification_bindings`) is marked *"provisional; may change before v2 stable"* by the SDK's own docstring — deferred with an explicit resume condition (when that language is dropped), not left as an unowned "next arc" item. The one affected test carries `@pytest.mark.skip(reason=...)` referencing #4457.
- **Pre-existing, unrelated, not fixed here**: `tests/builtin/test_3009_mcp_tool_call_write_denial_hint.py` (2 tests) spawns `vector_store_server.py` via the main venv, which needs the *standalone* `fastmcp` package (a different package from the mcp SDK's own bundled module this PR touches) — `#4302` deliberately dropped it from the main venv, and CI's own `test.yml` documents fastmcp isn't installed there either. Confirmed this predates and is independent of this PR (reproduced with `.venv` fully aligned to the declared pin). Not fixing rag-plugin venv isolation here — different concern.

## Verification

All 5 local gates clean (ruff / `test_tier_audit --strict` / `verify_module_docstrings` / `mypy_ratchet` / `check_tests_path_literal_reference`), plus `check_file_depth_reference`. No merge conflicts against current `main` (`git merge-tree`, clean).

## Manual / Visual

- [ ] (skipped — no visual/TTY surface; SDK version bump + wire-protocol internals)
