### PR TITLE
feat(#4381): PR-5 — read cap becomes a resource bound (bytes, model-independent, config)

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -1732,6 +1732,21 @@ render_template:
 
 The defaults are generous enough for real reports / configs and tight enough that a runaway generator stops quickly. Omitting the block leaves both at their defaults (behaviour unchanged).
 
+## `read_cap` block
+
+The per-result inline cap for `file.read` and `load_skill` (#4381 PR-5, architect design). This is a **resource bound**, not a budget bound — a role split the codebase draws deliberately: a resource bound protects a fixed physical resource (memory, transfer size) and is measured in **bytes**, **model-independent**; a budget bound protects the model's context window, is measured in tokens, and is derived from the resolved model (offload's spill trigger, compaction, reactive shrink all live on that side). Before this split, the same cap was scaled by the resolved model's input window and counted in characters — both were defects: window-scaling conflated the two roles, and counting a byte-denominated resource in characters drifted up to ~3× for non-ASCII content.
+
+```yaml
+read_cap:
+  inline_bytes: 10240   # 10 KiB — ceiling on a single inline read/load result
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `inline_bytes` | int | `10240` | Ceiling, in bytes, on what `file.read` / `load_skill` return inline before truncating. A non-positive or non-numeric value falls back to the default. |
+
+**Why 10 KiB**: both consumers gained a resume mechanism the same night this default was chosen — `file.read` via `char_offset` (#4432), `load_skill` via deferring to `read_file(offset=next_offset)` (#4431). A truncated read loses at most one round-trip, not the rest of the content, which is what makes a small default safe rather than arbitrary. Omitting the block keeps this default (behaviour unchanged).
+
 ## MCP servers
 
 External tool servers reyn can call via the [Model Context Protocol](../../concepts/tools-integrations/mcp.md). Each entry under `mcp.servers:` is keyed by a short name (the same name the skill declares in `permissions.mcp` and emits in `mcp` ops).

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -626,6 +626,25 @@
 
 
 # -----------------------------------------------------------------------------
+# read_cap: the per-result inline cap for file.read / load_skill (#4381 PR-5,
+# architect design). A RESOURCE BOUND — unit is BYTES, model-INDEPENDENT
+# (never scaled by the resolved model's context window), protecting memory/
+# transfer, not the model's token budget (that's a separate, budget-bound
+# concern: offload/compaction/reactive-shrink). Omit the block to keep the
+# 10 KiB default below (unchanged behaviour); a non-positive/non-numeric
+# value falls back to that default too.
+#
+# Why 10 KiB: both file.read (char_offset, #4432) and load_skill (defers to
+# read_file(offset=next_offset), #4431) gained a resume mechanism the same
+# night this default was set — a truncated read loses at most one
+# round-trip, not the rest of the content, which is what makes a small
+# default a safe default rather than an arbitrary one.
+# -----------------------------------------------------------------------------
+# read_cap:
+#   inline_bytes: 10240   # 10 KiB — ceiling on a single inline read/load result
+
+
+# -----------------------------------------------------------------------------
 # tool_use: the chat-layer tool-use scheme x transport selector (#1593;
 # FP-0066 P4b, #3247). ``scheme`` is the PRESENTATION axis (category /
 # enumerate-all / retrieval — how capabilities are shown/discovered);

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -408,6 +408,70 @@ def _build_render_template_config(raw: object) -> "RenderTemplateConfig":
 
 
 @dataclass
+class ReadCapConfig:
+    """`read_cap:` — the RESOURCE-BOUND per-result inline cap (#4381 PR-5,
+    architect design).
+
+    Shares ONE cap value across ``file.py``'s read op and ``load_skill.py``
+    (both call ``context_builder.control_ir_inline_cap`` — architect: "同じ
+    整理が当たり... read_file と同じ扱いへ一緒に移る").
+
+    **Unit is BYTES, not characters** — the architect's own correction:
+    "文字は資源境界の単位として使わないこと。多バイト文字で8192文字≒24KBに
+    なり、資源を守る量として3倍ぶれる." A resource bound protects memory/
+    transfer/disk, which are byte-denominated regardless of encoding; a
+    char-denominated cap drifts against that by up to ~3x for non-ASCII
+    content (exactly the drift #4381 traced).
+
+    **Model-INDEPENDENT** (owner ruling) — this used to scale with the
+    resolved model's context window (#1209's window-derive), but a resource
+    bound protects a fixed physical resource, not a model-relative budget;
+    scaling it by model window conflated the two ROLEs #4381's design
+    closes (resource bound = bytes/model-independent/config;
+    budget bound = tokens/model-derived — see ``context_builder.
+    INLINE_CAP_BYTES_PER_TOKEN``, the ONE named conversion point between
+    them, consulted by ``router_history_buffer._check_resource_within_
+    budget``, PR-1/#4451).
+
+    **Why 10 KiB is the shipped default, not the prior 8 KB floor's own
+    number carried forward** (architect, #4381): a cap's affordable size is
+    a function of whether a truncated read has a way BACK IN, not of
+    "what other tools use." Both consumers gained a resume mechanism the
+    same night this design was written — ``read_file`` via ``char_offset``
+    (#4432 wired the schema all the way to the op layer) and
+    ``load_skill`` via deferring to ``read_file(path, offset=next_offset)``
+    instead of inventing its own offset (#4441) — so a truncated read here
+    loses at most ONE round-trip, not the rest of the content. That is the
+    property that justifies a SMALL cap; it is checkable in THIS repo's
+    own code (both resume paths exist and are tested), not an external
+    claim like "another tool uses N" that a reader could dispute without
+    being able to verify it against reyn's own behaviour.
+    """
+    inline_bytes: int = 10_240   # 10 KiB
+
+
+def _build_read_cap_config(raw: object) -> "ReadCapConfig":
+    """Parse the `read_cap:` section (#4381 PR-5).
+
+    Missing or malformed -> default (10_240 bytes). A non-numeric or
+    non-positive value falls back to the default -- same discipline as
+    ``_build_render_template_config``: an operator typo must not silently
+    disable the cap (zero/negative would truncate everything or never fire).
+    """
+    if not isinstance(raw, dict):
+        return ReadCapConfig()
+    defaults = ReadCapConfig()
+    inline_bytes = raw.get("inline_bytes", defaults.inline_bytes)
+    try:
+        inline_bytes = int(inline_bytes)
+        if inline_bytes <= 0:
+            inline_bytes = defaults.inline_bytes
+    except (TypeError, ValueError):
+        inline_bytes = defaults.inline_bytes
+    return ReadCapConfig(inline_bytes=inline_bytes)
+
+
+@dataclass
 class SpawnConfig:
     """`safety.spawn:` — operator bounds on the LLM spawn tree (#2103 C3).
 

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -12,6 +12,7 @@ from reyn.config.chat import (  # #1682 #3 cross-section
     _build_cost_config,  # #1682 #3: cost builder lives in chat
     _build_cost_warn_config,
     _build_offload_config,
+    _build_read_cap_config,
     _build_render_template_config,
     _build_safety_config,
 )
@@ -818,6 +819,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
     cost_warn = _build_cost_warn_config(merged.get("cost_warn"))
     offload = _build_offload_config(merged.get("offload"))
     render_template = _build_render_template_config(merged.get("render_template"))
+    read_cap = _build_read_cap_config(merged.get("read_cap"))
     # #4174 T3: model / models / model_class_by_purpose / api_base /
     # prompt_cache_enabled moved from top-level ReynConfig fields into
     # ``llm:`` — _build_llm_config parses all of it (router/retry AND the
@@ -848,6 +850,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         cost_warn=cost_warn,
         offload=offload,
         render_template=render_template,
+        read_cap=read_cap,
         web_fetch=_build_web_fetch_config(merged.get("web_fetch")),
         gateway=_build_gateway_config(merged.get("gateway")),
         multimodal=_build_multimodal_config(merged.get("multimodal")),

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -33,6 +33,7 @@ from reyn.config.chat import (
     LoopConfig,
     OffloadConfig,
     OnLimitConfig,
+    ReadCapConfig,
     ReasoningConfig,
     RenderTemplateConfig,
     SafetyConfig,
@@ -212,6 +213,11 @@ class ReynConfig:
     # FP-0055 / #2679: operator-tunable output bounds for the render_template op
     # (max_output_chars / wall_clock_seconds). Default → the safe in-handler bounds.
     render_template: RenderTemplateConfig = field(default_factory=RenderTemplateConfig)
+    # #4381 PR-5: the resource-bound per-result inline cap (file.py read op +
+    # load_skill.py, both consult context_builder.control_ir_inline_cap) —
+    # bytes, model-independent, config-driven (architect design). Default
+    # 10 KiB.
+    read_cap: ReadCapConfig = field(default_factory=ReadCapConfig)
     # FP-0022 follow-up: declarative SSL config for web_fetch + MCP registry.
     # Priority: web_fetch.ca_bundle → web_fetch.verify_ssl → SSL_VERIFY env →
     # litellm.ssl_verify → SSL_CERT_FILE → True (default).

--- a/src/reyn/core/context_builder.py
+++ b/src/reyn/core/context_builder.py
@@ -14,56 +14,114 @@ was deleted — its last caller (the ContextFrame-driven phase path,
 offload (``reyn.runtime.services.tool_result_cap.cap_tool_result`` →
 ``.reyn/tool-results/`` via ``MediaStore``), unified onto the canonical
 tool-result mapper (``reyn.core.offload.canonical``) by #2648. Only
-``control_ir_inline_cap`` below survives — it is still the shared window-derived
-read-bounding cap consulted by ``file.py`` / ``load_skill.py``.
+``control_ir_inline_cap`` below survives — it is still the shared read-
+bounding cap consulted by ``file.py`` / ``load_skill.py``.
+
+#4381 PR-5 (architect design, owner ruling) — the RESOURCE-BOUND / BUDGET-
+BOUND role split:
+
+    resource bound   unit = BYTES, model-INDEPENDENT, config-driven
+                      protects: memory / transfer / disk
+                      members: THIS cap, load_skill's cap (shares it),
+                               offload's ``max_inline_bytes``
+    budget bound      unit = TOKENS, model-derived
+                      protects: the model's context window
+                      members: offload/spill trigger, compaction,
+                               reactive shrink
+
+Before PR-5 this cap was window-derived (scaled with the resolved model's
+input window, #1209) and counted in CHARACTERS. Both were architect-
+identified defects: scaling a resource bound by model window conflates the
+two roles above (a resource bound protects a fixed physical resource, not
+a model-relative budget), and counting a byte-denominated resource in
+characters drifts by up to ~3x for non-ASCII content ("多バイト文字で8192
+文字≒24KBになり、資源を守る量として3倍ぶれる"). Both are fixed here: the
+cap is now a plain config value (``ReadCapConfig.inline_bytes``,
+model-independent) and the byte/text-length distinction is the caller's
+job (``op_runtime/file.py`` / ``load_skill.py`` measure UTF-8 encoded
+byte length against this cap, never ``len(str)``).
+
+The ONE named conversion point between the two roles is
+:data:`INLINE_CAP_BYTES_PER_TOKEN` below, consulted by
+``router_history_buffer._check_resource_within_budget`` (PR-1, #4451) —
+never re-derive an equivalent ratio anywhere else (the exact silent-drift
+class #4381 exists to close).
 """
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from reyn.config.chat import ReadCapConfig
 
 # ── control_ir_result per-result inline-cap constant (C5 — FP-0008) ────────────
-# The floor for the window-derived per-result read-bounding cap (below). Also
-# doubles as the model-unresolved default (no model context → this fixed
-# 8KB floor).
-MAX_CONTROL_IR_RESULT_INLINE_BYTES: int = 8_192   # ~8KB threshold
+# The model-independent default resource bound, in BYTES — used whenever no
+# ``ReadCapConfig`` is available (a caller with no config context, or a
+# ``ReadCapConfig`` was never threaded to it). #4381 PR-5: previously also
+# the FLOOR for a window-derived cap that scaled with the model's input
+# window (#1209) — that derivation is gone; this is now the cap, full stop,
+# unless config overrides it via ``read_cap.inline_bytes``.
+MAX_CONTROL_IR_RESULT_INLINE_BYTES: int = 10_240   # 10 KiB default
 
-# Window-derived inline cap (#1209). The fixed 8KB above is a FLOOR; the
-# effective per-result offload trigger scales with the model's input window so
-# that a normal file read (e.g. a 150KB source file under a 1M-token window)
-# stays INLINE instead of being offloaded out of the editing model's view. The
-# fixed 8KB was a root anomaly — same class as #1201/#1172 (fixed-constant →
-# window-derive). The per-RESULT cap is orthogonal to count-axis compaction,
-# which still trims the TOTAL across results.
-#
-# #4381 PR-1: this is THE ONE named chars→tokens conversion (architect
-# design) — the resource boundary (this module, chars) and the budget
+# #4381 PR-1/PR-5: the ONE named bytes→tokens conversion (architect design)
+# — the resource boundary (this module, BYTES as of PR-5) and the budget
 # boundary (`router_history_buffer.resolve_effective_trigger_and_budgets`,
-# tokens) are compared through THIS constant and nowhere else; a second,
-# independently-derived chars-per-token ratio anywhere else would reopen the
-# exact silent-drift class #4381 PR-1 closes. Public (not `_`-prefixed) for
+# TOKENS) are compared through THIS constant and nowhere else; a second,
+# independently-derived bytes-per-token ratio anywhere else would reopen
+# the exact silent-drift class #4381 closes. Public (not `_`-prefixed) for
 # that reason — it is a cross-module conversion point, not a local detail.
-INLINE_CAP_CHARS_PER_TOKEN: int = 4
-_INLINE_CAP_WINDOW_FRACTION: float = 0.08  # one result may inline up to ~8% of the window
+#
+# Superseded name: PR-1 introduced this as ``INLINE_CAP_CHARS_PER_TOKEN``
+# (chars-per-token, matching the cap's char-denominated unit at the time).
+# PR-5 made the cap byte-denominated, so a *chars*-per-token ratio applied
+# to a *bytes* value would silently reopen the exact unit-drift class this
+# constant exists to prevent — renamed rather than reused with a new
+# meaning under the old name (a literal ~4 bytes-per-token approximation
+# for UTF-8-mixed text is the same rough average commonly used for chars,
+# so the NUMBER is unchanged; only the unit label is corrected).
+INLINE_CAP_BYTES_PER_TOKEN: int = 4
 
 
-def control_ir_inline_cap(
-    model_resolved: str | None,
-    *,
-    events: Any = None,
-    phase: str | None = None,
-) -> int:
-    """Window-derived per-result inline cap in chars, floored at the fixed 8KB.
+def control_ir_inline_cap(config: "ReadCapConfig | None" = None) -> int:
+    """The resource-bound per-result inline cap, in BYTES.
 
-    ``model_resolved`` MUST be a litellm model string (already class-resolved).
-    A raw model CLASS like ``"standard"`` mis-resolves to the fallback window
-    (the #1201/#1172 bug) — callers pass the resolved string. ``None`` (no model
-    context) falls back to the fixed floor.
+    #4381 PR-5: model-independent — no longer derived from a resolved
+    model's context window (#1209's window-derive was itself the defect
+    architect's role-split closes: a resource bound protects a fixed
+    physical resource, not a model-relative budget). ``config=None``
+    (no ``ReadCapConfig`` threaded to the caller) falls back to
+    :data:`MAX_CONTROL_IR_RESULT_INLINE_BYTES`.
     """
-    if not model_resolved:
+    if config is None:
         return MAX_CONTROL_IR_RESULT_INLINE_BYTES
-    from reyn.llm.model_budget import get_max_input_tokens
+    return config.inline_bytes
 
-    t_max = get_max_input_tokens(model_resolved, events=events, phase=phase)
-    derived = int(t_max * INLINE_CAP_CHARS_PER_TOKEN * _INLINE_CAP_WINDOW_FRACTION)
-    return max(MAX_CONTROL_IR_RESULT_INLINE_BYTES, derived)
 
+def byte_safe_prefix(text: str, max_bytes: int) -> str:
+    """The longest prefix of ``text`` whose UTF-8 encoding is <= ``max_bytes``,
+    never splitting a multi-byte codepoint.
+
+    #4381 PR-5: the resource bound is byte-denominated (see module
+    docstring); a caller char-truncating with ``text[:max_bytes]`` was the
+    exact ~3x drift architect's design closes (a multi-byte character
+    counted as "1" against a byte budget) — this is the shared, tested
+    replacement both ``op_runtime/file.py`` and ``load_skill.py`` use for
+    their single-oversized-segment truncation branch.
+
+    O(n): encode once, slice the encoded bytes at ``max_bytes``, then back
+    off up to 3 bytes (the longest a UTF-8 codepoint can be minus one) if
+    the cut landed mid-codepoint — a decode error there is expected, not
+    exceptional, so this backs off rather than re-encoding a shrinking
+    prefix in a loop (which would be O(n log n) for a very large single
+    oversized line/segment, the exact case this helper exists for).
+    """
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text
+    truncated = encoded[:max_bytes]
+    for _ in range(4):  # UTF-8's longest codepoint is 4 bytes
+        try:
+            return truncated.decode("utf-8")
+        except UnicodeDecodeError:
+            truncated = truncated[:-1]
+    return ""

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     import asyncio
     from collections.abc import Awaitable, Callable, Sequence
 
-    from reyn.config import MultimodalConfig, SandboxConfig, WebFetchConfig
+    from reyn.config import MultimodalConfig, ReadCapConfig, SandboxConfig, WebFetchConfig
     from reyn.core.events.events import EventLog
     from reyn.core.events.state_log import StateLog
     from reyn.core.op_runtime.render_template import RenderTemplateBounds
@@ -188,6 +188,19 @@ class OpContext:
     # operator's `web_fetch:` block in reyn.yaml (verify_ssl / allow_private_ips /
     # max_download_bytes) was silently ignored before this and now takes effect.
     web_fetch_config: "WebFetchConfig | None" = None
+
+    # #4381 PR-5: the resource-bound per-result inline cap (architect
+    # design — bytes, model-independent, config-driven). Consulted by
+    # file.py's read op and load_skill.py via
+    # ``context_builder.control_ir_inline_cap(ctx.read_cap_config)``.
+    # None (no ReynConfig threaded, e.g. a direct-OpContext test
+    # construction) falls back to context_builder's own model-independent
+    # default (``MAX_CONTROL_IR_RESULT_INLINE_BYTES``) — same
+    # backward-compatible shape as ``multimodal_config`` above. Reaches
+    # every chat-router OpContext via SessionFactoryConfig.read_cap_config
+    # → Session._read_cap_config → RouterOpContextSource →
+    # build_router_op_context (mirrors #4274's ``web_fetch_config`` wiring).
+    read_cap_config: "ReadCapConfig | None" = None
 
     # FP-0017 follow-up: declarative sandbox config for sandboxed_exec op.
     # Callers that have a ReynConfig available should pass config.sandbox here.

--- a/src/reyn/core/op_runtime/file.py
+++ b/src/reyn/core/op_runtime/file.py
@@ -223,24 +223,17 @@ def _suggestions_fields(ws, path: str) -> dict:
 
 
 def _read_inline_cap(ctx: OpContext) -> int:
-    """Window-derived inline cap (chars) for an unbounded read (#1209).
+    """The resource-bound inline cap (BYTES) for an unbounded read.
 
-    Resolves ``ctx.model`` (a CLASS like ``"standard"``) to its litellm string
-    BEFORE deriving the window (resolve-before-window — the #1172-correct path;
-    a raw class mis-resolves to the fallback window), then reuses the shared
-    ``control_ir_inline_cap`` — the same window-derived read-bounding cap
-    ``load_skill`` bounds its body against, so both read verbs cut at one
-    place. Falls back to the fixed floor when there is no resolver.
+    #4381 PR-5: model-independent (owner ruling) — reuses the shared
+    ``control_ir_inline_cap``, the same cap ``load_skill`` bounds its body
+    against, so both read verbs cut at one place. Reads ``ctx.read_cap_
+    config``; falls back to the fixed default when no config was threaded
+    to this context (see ``control_ir_inline_cap``'s own docstring).
     """
     from reyn.core.context_builder import control_ir_inline_cap
 
-    model_str: str | None = None
-    if ctx.resolver is not None:
-        try:
-            model_str = ctx.resolver.resolve(ctx.model).model
-        except Exception:
-            model_str = None
-    return control_ir_inline_cap(model_str, events=ctx.events, phase=ctx.actor)
+    return control_ir_inline_cap(ctx.read_cap_config)
 
 
 async def handle(op: FileIROp, ctx: OpContext) -> dict:
@@ -428,7 +421,10 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
             # file_read's source already lives on disk at op.path, so duplicating it into an offload
             # file is wasteful (owner steer). Fall through to the self-bounding truncation below —
             # truncate inline + surface a re-read hint; the full content stays at op.path.
-            if len(joined) <= cap:
+            # #4381 PR-5: measured in BYTES (the cap's own unit — architect design)
+            # via UTF-8 encoding, not len(str) — a char count drifts up to ~3x for
+            # multi-byte content against a byte-denominated cap.
+            if len(joined.encode("utf-8")) <= cap:
                 ctx.events.emit("tool_executed", op="read_file", path=op.path)
                 return {
                     "kind": "file",
@@ -442,34 +438,49 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
         # #1209 read-bounding (keep-in-decide-context, not offloaded-out-of-view) + #2335 char-level
         # truncation. Accumulate WHOLE lines from (start_line, start_char); a multi-line overflow
         # stops at the LINE boundary (byte-identical to pre-#2335 — next_char_offset stays absent);
-        # a SINGLE line/segment that alone exceeds the cap is CHAR-truncated so `content` is
-        # GENUINELY ≤ cap (#2335 fix), its tail paged via next_char_offset.
+        # a SINGLE line/segment that alone exceeds the cap is TRUNCATED so `content` is GENUINELY
+        # <= cap (#2335 fix), its tail paged via next_char_offset.
+        #
+        # #4381 PR-5: ``cap`` is now BYTES (architect design — a resource bound protects
+        # memory/transfer, byte-denominated regardless of encoding). ``acc``/the per-segment
+        # overflow checks below measure UTF-8 encoded byte length, never len(str) — a
+        # char-denominated accumulator would silently under-count multi-byte content by up
+        # to ~3x, the exact drift this PR closes. The single-oversized-segment branch uses
+        # ``context_builder.byte_safe_prefix`` (never a raw ``seg[:cap]`` char slice, which
+        # could both overshoot the byte budget AND split a multi-byte codepoint mid-character).
+        from reyn.core.context_builder import byte_safe_prefix
+
         all_lines = content.splitlines(keepends=True)
         start_line = op.offset or 0
         start_char = op.char_offset or 0
         shown: list[str] = []
-        acc = 0
+        acc = 0  # bytes
         next_offset: "int | None" = None
         next_char_offset: "int | None" = None
         i = start_line
         seg_start = start_char
         while i < len(all_lines):
             seg = all_lines[i][seg_start:]
-            if shown and acc + len(seg) > cap:
+            seg_bytes = len(seg.encode("utf-8"))
+            if shown and acc + seg_bytes > cap:
                 # A subsequent line overflows → stop at the LINE boundary (exclude it; the
                 # continuation is a normal line read at its start). Pre-#2335 behavior.
                 next_offset = i
                 break
-            if not shown and len(seg) > cap:
-                # #2335: a single line/segment ALONE exceeds the cap → char-truncate for an honest
-                # bound; its tail resumes mid-line via next_char_offset.
-                shown.append(seg[:cap])
-                acc += cap
+            if not shown and seg_bytes > cap:
+                # #2335/#4381: a single line/segment ALONE exceeds the cap → byte-safe
+                # truncate for an honest bound; its tail resumes mid-line via
+                # next_char_offset (a CHARACTER offset — file.py's own read contract —
+                # derived from the truncated prefix's own char length, not the byte cap
+                # value itself, since those two numbers now differ).
+                truncated = byte_safe_prefix(seg, cap)
+                shown.append(truncated)
+                acc += len(truncated.encode("utf-8"))
                 next_offset = i
-                next_char_offset = seg_start + cap
+                next_char_offset = seg_start + len(truncated)
                 break
             shown.append(seg)
-            acc += len(seg)
+            acc += seg_bytes
             i += 1
             seg_start = 0
 
@@ -530,10 +541,11 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
                     f"chars shown); the full file is on disk at {op.path!r} — re-read from "
                     f"offset {next_offset}"
                     + (
-                        # #4381: when a SINGLE line was itself char-truncated, plain
-                        # `offset=next_offset` restarts that same line from char 0 and
-                        # truncates identically — an infinite loop. The resume call
-                        # MUST also pass char_offset=next_char_offset; say so.
+                        # #4381: when a SINGLE line was itself truncated (byte-safe,
+                        # #4381 PR-5), plain `offset=next_offset` restarts that same
+                        # line from char 0 and truncates identically — an infinite
+                        # loop. The resume call MUST also pass
+                        # char_offset=next_char_offset; say so.
                         f" and char_offset {next_char_offset}"
                         if next_char_offset is not None else ""
                     )

--- a/src/reyn/core/op_runtime/load_skill.py
+++ b/src/reyn/core/op_runtime/load_skill.py
@@ -235,15 +235,14 @@ async def handle(op: LoadSkillIROp, ctx: OpContext) -> dict:
     # limit windowing — this is a dedicated "load the whole thing" verb, not
     # a general paginated reader), but an oversized body is still
     # self-bounding rather than blowing the context unconditionally.
-    from reyn.core.context_builder import control_ir_inline_cap
+    #
+    # #4381 PR-5: the cap is a RESOURCE BOUND (bytes, model-independent,
+    # config-driven — architect design) — shares `ctx.read_cap_config` with
+    # `file.py`'s own read op (`load_skill` "同じ整理が当たり... read_file
+    # と同じ扱いへ一緒に移る" — architect). No more model resolution here.
+    from reyn.core.context_builder import byte_safe_prefix, control_ir_inline_cap
 
-    model_str: "str | None" = None
-    if ctx.resolver is not None:
-        try:
-            model_str = ctx.resolver.resolve(ctx.model).model
-        except Exception:
-            model_str = None
-    cap = control_ir_inline_cap(model_str, events=ctx.events, phase=ctx.actor)
+    cap = control_ir_inline_cap(ctx.read_cap_config)
 
     # #3629: `content_history`/`token_map` (set above, only when
     # `load_skill_body` ran) ride along in the SAME field shape regardless of
@@ -252,12 +251,14 @@ async def handle(op: LoadSkillIROp, ctx: OpContext) -> dict:
     history_fields: dict = {}
     if content_history is not None:
         history_fields["content_history"] = (
-            content_history[:cap] if len(content_history) > cap else content_history
+            byte_safe_prefix(content_history, cap)
+            if len(content_history.encode("utf-8")) > cap
+            else content_history
         )
         history_fields["token_map"] = location_token_map
         history_fields["skill_source_path"] = op.path
 
-    if len(content) > cap:
+    if len(content.encode("utf-8")) > cap:
         # #4431 (architect correction): was a bare `content[:cap]` char slice
         # with NO resume position returned at all — the note pointed at "the
         # full body is on disk" but gave no way to continue from where this
@@ -272,26 +273,31 @@ async def handle(op: LoadSkillIROp, ctx: OpContext) -> dict:
         # own #1209/#2335 algorithm) so `next_offset` names a genuine line
         # boundary `read_file(path=op.path, offset=next_offset)` can resume
         # from without re-showing or dropping a partial line.
+        #
+        # #4381 PR-5: measured in BYTES (UTF-8 encoded length), never
+        # len(str) — see file.py's own truncation loop, mirrored here.
         all_lines = content.splitlines(keepends=True)
         shown: list[str] = []
-        acc = 0
+        acc = 0  # bytes
         next_offset = 0
         for i, line in enumerate(all_lines):
-            if shown and acc + len(line) > cap:
+            line_bytes = len(line.encode("utf-8"))
+            if shown and acc + line_bytes > cap:
                 next_offset = i
                 break
-            if not shown and len(line) > cap:
+            if not shown and line_bytes > cap:
                 # A single line alone exceeds the cap (e.g. a minified/
-                # one-line body) — char-truncate it so `content` stays
-                # genuinely bounded; `read_file(offset=0)` on resume hits
-                # this exact same line and returns ITS OWN `next_char_offset`
-                # (file.py's #2335 mechanism), so no new field is needed here.
-                shown.append(line[:cap])
-                acc += cap
+                # one-line body) — byte-safe truncate it so `content` stays
+                # genuinely bounded (never split a multi-byte codepoint);
+                # `read_file(offset=0)` on resume hits this exact same line
+                # and returns ITS OWN `next_char_offset` (file.py's #2335
+                # mechanism), so no new field is needed here.
+                shown.append(byte_safe_prefix(line, cap))
+                acc += len(shown[-1].encode("utf-8"))
                 next_offset = i
                 break
             shown.append(line)
-            acc += len(line)
+            acc += line_bytes
             next_offset = i + 1
         truncated_content = "".join(shown)
         ctx.events.emit(

--- a/src/reyn/runtime/factory_config.py
+++ b/src/reyn/runtime/factory_config.py
@@ -39,6 +39,10 @@ class SessionFactoryConfig:
     # site until this field existed. Same shape as multimodal_config: a plain value,
     # not a per-turn supplier (WebFetchConfig doesn't change mid-session).
     web_fetch_config: Any
+    # #4381 PR-5: reyn.yaml read_cap.* (inline_bytes) — the resource-bound
+    # per-result inline cap (file.py's read op + load_skill.py). Same
+    # shape as web_fetch_config: a plain value, not a per-turn supplier.
+    read_cap_config: Any
     action_retrieval_config: Any
     embedding_config: Any
     router_config: Any
@@ -116,6 +120,8 @@ class SessionFactoryConfig:
             multimodal_config=config.multimodal,
             # #4274: the previously-dead web_fetch.* config, now threaded live.
             web_fetch_config=config.web_fetch,
+            # #4381 PR-5: the resource-bound read cap config.
+            read_cap_config=config.read_cap,
             action_retrieval_config=config.action_retrieval,
             embedding_config=config.embedding,
             router_config=config.llm.router,

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -61,6 +61,7 @@ def build_router_op_context(
     presentation_registry: Any = None,  # FP-0054 PR-C: operator named-template registry (hot-reloadable)
     multimodal_config: Any = None,  # #364
     web_fetch_config: Any = None,  # #4274: reyn.yaml web_fetch.* → the web_fetch op's SSL/SSRF/size gates
+    read_cap_config: Any = None,  # #4381 PR-5: reyn.yaml read_cap.* → file.py's/load_skill.py's read op cap
     media_store: Any = None,  # #383
     compact_now: Any = None,  # #272/#1128
     run_id: str | None = None,  # chat router is outside run scope (#FP-0021)
@@ -160,6 +161,7 @@ def build_router_op_context(
         presentation_registry=presentation_registry,
         multimodal_config=multimodal_config,
         web_fetch_config=web_fetch_config,  # #4274
+        read_cap_config=read_cap_config,  # #4381 PR-5
         media_store=media_store,
         compact_now=compact_now,
         sandbox_backend=sandbox_backend,
@@ -242,6 +244,7 @@ class RouterOpContextSource:
         presentation_registry_fn: Any,
         multimodal_config: Any,
         web_fetch_config: Any,  # #4274: reyn.yaml web_fetch.* — plain value, same shape as multimodal_config
+        read_cap_config: Any = None,  # #4381 PR-5: reyn.yaml read_cap.* — plain value, same shape as web_fetch_config
         media_store_fn: Any,
         compact_now: Any,
         threat_scan: Any,
@@ -274,6 +277,7 @@ class RouterOpContextSource:
         self._presentation_registry_fn = presentation_registry_fn
         self._multimodal_config = multimodal_config
         self._web_fetch_config = web_fetch_config
+        self._read_cap_config = read_cap_config
         self._media_store_fn = media_store_fn
         self._compact_now = compact_now
         self._threat_scan = threat_scan
@@ -339,6 +343,7 @@ class RouterOpContextSource:
             presentation_registry=self._resolve(self._presentation_registry_fn),
             multimodal_config=self._multimodal_config,
             web_fetch_config=self._web_fetch_config,  # #4274
+            read_cap_config=self._read_cap_config,  # #4381 PR-5
             media_store=self._resolve(self._media_store_fn),
             compact_now=self._compact_now,
             cancel_event=self._cancel_event,

--- a/src/reyn/runtime/scoped_session_factory.py
+++ b/src/reyn/runtime/scoped_session_factory.py
@@ -163,6 +163,7 @@ def build_scoped_chat_session(
         ),
         multimodal_config=factory_config.multimodal_config,
         web_fetch_config=factory_config.web_fetch_config,  # #4274
+        read_cap_config=factory_config.read_cap_config,  # #4381 PR-5
         action_retrieval_config=factory_config.action_retrieval_config,
         embedding_config=factory_config.embedding_config,
         router_config=factory_config.router_config,

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -174,41 +174,53 @@ _resource_budget_warned: "set[tuple[str, str | None]]" = set()
 
 
 def _check_resource_within_budget(
-    model: str, phase: "str | None", effective_trigger: int, events: Any,
+    model: str,
+    phase: "str | None",
+    effective_trigger: int,
+    events: Any,
+    read_cap_config: Any = None,
 ) -> None:
-    """#4381 PR-1: the invariant this SSoT now enforces — "a result that
+    """#4381 PR-1/PR-5: the invariant this SSoT enforces — "a result that
     passed the resource boundary must not exceed the budget boundary after
     conversion" (architect design, #4381). Two independent read-cap-vs-
     spill-cap mismatches (#4381's own reported incident, #4432's spill-loop
     guard) trace to this SAME class going unchecked: the resource boundary
-    (``control_ir_inline_cap``, CHARS — memory/transfer-scoped, model-
-    derived today; owner ruling may make it a model-independent config byte
-    value later, at which point THIS function's arguments alone can no
-    longer derive it and a config value must be threaded in — not done in
-    PR-1) and the budget boundary (``effective_trigger``, TOKENS — the
-    model's context window) are never compared anywhere before this PR, so
-    a resource-bounded result that looks "safe" in chars can still overflow
-    the budget boundary once converted.
+    (``control_ir_inline_cap``, BYTES as of PR-5 — memory/transfer-scoped,
+    model-INDEPENDENT config value as of PR-5) and the budget boundary
+    (``effective_trigger``, TOKENS — the model's context window) are never
+    compared anywhere before PR-1, so a resource-bounded result that looks
+    "safe" can still overflow the budget boundary once converted.
 
-    The conversion point is ``context_builder.INLINE_CAP_CHARS_PER_TOKEN``
-    — the ONE named chars→tokens conversion (architect: name it once, don't
-    re-derive the same ratio elsewhere). Rounded UP (ceil): understating the
-    resource bound's token cost would make this check too permissive, the
-    wrong direction for a safety check.
+    ``read_cap_config`` (PR-5): the ``ReadCapConfig`` to check against —
+    threaded from ``RouterHistoryBuffer`` (the caller with a live config
+    reference). ``None`` (a caller with no config threaded, e.g.
+    ``ContextBudgetAdvisor``'s own call today) falls back to
+    ``control_ir_inline_cap``'s own ``config=None`` default
+    (``MAX_CONTROL_IR_RESULT_INLINE_BYTES``) — a known, flagged gap, not a
+    silent one: a config value that DIFFERS from the shipped default is
+    only checked via the caller that threads it.
+
+    The conversion point is ``context_builder.INLINE_CAP_BYTES_PER_TOKEN``
+    — the ONE named bytes→tokens conversion (architect: name it once,
+    don't re-derive the same ratio elsewhere; PR-5 renamed this from
+    ``INLINE_CAP_CHARS_PER_TOKEN`` since the resource bound switched from
+    chars to bytes — reusing the old name under a new unit would silently
+    reopen the exact drift class this constant exists to prevent). Rounded
+    UP (ceil): understating the resource bound's token cost would make
+    this check too permissive, the wrong direction for a safety check.
 
     Warn-once per ``(model, phase)`` (not per call — this SSoT is called on
     every trigger resolution, so warning every time would flood the log)
     via a ``resource_cap_exceeds_budget_trigger`` audit-event. Detection
-    only in PR-1 — no value is clamped; the class closes once the resource
-    boundary itself moves to a model-independent byte value (later PR).
+    only — no value is clamped.
     """
     from reyn.core.context_builder import (
-        INLINE_CAP_CHARS_PER_TOKEN,
+        INLINE_CAP_BYTES_PER_TOKEN,
         control_ir_inline_cap,
     )
 
-    resource_bound_chars = control_ir_inline_cap(model, events=events, phase=phase)
-    resource_bound_tokens = -(-resource_bound_chars // INLINE_CAP_CHARS_PER_TOKEN)  # ceil
+    resource_bound_bytes = control_ir_inline_cap(read_cap_config)
+    resource_bound_tokens = -(-resource_bound_bytes // INLINE_CAP_BYTES_PER_TOKEN)  # ceil
     if resource_bound_tokens <= effective_trigger:
         return
     key = (model, phase)
@@ -219,14 +231,19 @@ def _check_resource_within_budget(
         events.emit(
             "resource_cap_exceeds_budget_trigger",
             model=model, phase=phase or "",
-            resource_bound_chars=resource_bound_chars,
+            resource_bound_bytes=resource_bound_bytes,
             resource_bound_tokens=resource_bound_tokens,
             effective_trigger=effective_trigger,
         )
 
 
 def resolve_effective_trigger_and_budgets(
-    compaction_controller: Any, model: str, events: Any, *, phase: "str | None" = None,
+    compaction_controller: Any,
+    model: str,
+    events: Any,
+    *,
+    phase: "str | None" = None,
+    read_cap_config: Any = None,
 ) -> "tuple[int, int, int]":
     """Return ``(effective_trigger, head_budget, tail_budget)`` — #2957 PR-B
     single SSoT for this lookup.
@@ -247,6 +264,12 @@ def resolve_effective_trigger_and_budgets(
     defaults to ``None`` for both existing callers, neither of which has a
     phase concept today; a future phase-aware caller can pass a real value
     without a signature change.
+
+    ``read_cap_config`` (#4381 PR-5): the ``ReadCapConfig`` to check the
+    resource bound against — threaded from ``RouterHistoryBuffer``, which
+    has a live config reference; ``ContextBudgetAdvisor``'s own call
+    passes none today (falls back to the shipped default — see
+    ``_check_resource_within_budget``'s own docstring for what that means).
     """
     engine = getattr(compaction_controller, "_engine", None) if compaction_controller is not None else None
     budgets = getattr(engine, "budgets", None)
@@ -259,7 +282,7 @@ def resolve_effective_trigger_and_budgets(
         effective_trigger = get_max_input_tokens(model, events=events)
         fallback = effective_trigger // 4
         head_budget, tail_budget = fallback, fallback
-    _check_resource_within_budget(model, phase, effective_trigger, events)
+    _check_resource_within_budget(model, phase, effective_trigger, events, read_cap_config)
     return effective_trigger, head_budget, tail_budget
 
 
@@ -287,6 +310,7 @@ class RouterHistoryBuffer:
         non_interactive: bool,
         reasoning: Any = None,            # ReasoningConfig — .continuity / .recent_turns (#1652/②)
         project_dir_fn: "Callable[[], Any] | None" = None,  # #3629: zero-arg → CURRENT workspace base_dir
+        read_cap: Any = None,             # #4381 PR-5: ReadCapConfig — the resource bound to check budgets against
     ) -> None:
         self._history_fn = history_fn
         self._compaction = compaction
@@ -297,6 +321,9 @@ class RouterHistoryBuffer:
         self._router_host = router_host
         self._action_retrieval = action_retrieval
         self._non_interactive = non_interactive
+        # #4381 PR-5: threaded into resolve_effective_trigger_and_budgets's
+        # resource/budget invariant check (_check_resource_within_budget).
+        self._read_cap = read_cap
         # #1652/②: cross-turn reasoning rides the wire assistant messages
         # (native re-attach) instead of a router-SP text section. ReasoningConfig
         # gates it (.continuity) and bounds it (.recent_turns). None → off.
@@ -439,6 +466,7 @@ class RouterHistoryBuffer:
         """
         return resolve_effective_trigger_and_budgets(
             self._compaction_controller, self._model, self._events,
+            read_cap_config=self._read_cap,
         )
 
     def _incremental_elide_total(

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -29,6 +29,7 @@ from reyn.config import (  # noqa: F401
     MultimodalConfig,
     OffloadConfig,
     OnLimitConfig,
+    ReadCapConfig,
     RenderTemplateConfig,
     RouterConfig,
     SafetyConfig,
@@ -914,6 +915,9 @@ class Session:
         offload_config: OffloadConfig | None = None,
         # render_template output bounds (FP-0055 / #2679) — see docs/reference/runtime/session-construction.md#family-4-cost-budget
         render_template_config: RenderTemplateConfig | None = None,
+        # #4381 PR-5: the resource-bound per-result inline cap (file.py read op +
+        # load_skill.py). None → context_builder's own model-independent default.
+        read_cap_config: "ReadCapConfig | None" = None,
         state_log: StateLog | None = None,
         budget_tracker: BudgetTracker | None = None,
         snapshot_path: "Path | None" = None,
@@ -1036,6 +1040,10 @@ class Session:
         self._multimodal_config = multimodal_config
         # #4274: stored so RouterOpContextSource can thread it into OpContext.web_fetch_config.
         self._web_fetch_config = web_fetch_config
+        # #4381 PR-5: threaded into RouterHistoryBuffer (read_cap=) for the
+        # resource/budget invariant check, and into OpContext.read_cap_config
+        # for file.py's/load_skill.py's own read op (via RouterOpContextSource).
+        self._read_cap_config = read_cap_config
         # Single MediaStore instance per Session (#383 PR-C, see session-construction.md#multimodal-media)
         from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
         if multimodal_config is not None:
@@ -4199,6 +4207,7 @@ class Session:
             presentation_registry_fn=lambda: self._presentation_registry,
             multimodal_config=self._multimodal_config,
             web_fetch_config=self._web_fetch_config,  # #4274
+            read_cap_config=self._read_cap_config,  # #4381 PR-5
             media_store_fn=lambda: self._media_store,  # #383/#2409
             compact_now=self._compact_now_for_op,  # #272/#1128
             threat_scan=self._safety.threat_scan,  # FP-0050/#1822
@@ -4477,6 +4486,7 @@ class Session:
             # value ``ctx.workspace.base_dir`` resolves to for the ops this
             # buffer's history entries came from).
             project_dir_fn=lambda: self._workspace_base_dir or Path.cwd(),
+            read_cap=self._read_cap_config,  # #4381 PR-5
         )
 
         # #3671 follow-up: a DEFERRED closure, not an eager construction —

--- a/tests/core/test_op_runtime_load_skill_3247.py
+++ b/tests/core/test_op_runtime_load_skill_3247.py
@@ -487,7 +487,7 @@ def test_load_skill_truncated_result_carries_a_resumable_offset(tmp_path):
     ctx, _events = _make_ctx(tmp_path)
     big = "".join(f"line {i} {'.' * 60}\n" for i in range(400))
     from reyn.core.context_builder import MAX_CONTROL_IR_RESULT_INLINE_BYTES
-    assert len(big) > MAX_CONTROL_IR_RESULT_INLINE_BYTES  # ensure over the floor cap
+    assert len(big.encode("utf-8")) > MAX_CONTROL_IR_RESULT_INLINE_BYTES  # ensure over the cap
     ctx.workspace.write_file("SKILL.md", big)
 
     result = _run(load_skill_handle(LoadSkillIROp(kind="load_skill", path="SKILL.md"), ctx))
@@ -509,12 +509,13 @@ def test_load_skill_resume_via_read_file_recovers_the_exact_remainder(tmp_path):
     still pass a bare "field is present" check but fail this one."""
     ctx, _events = _make_ctx(tmp_path)
     # Sized to overflow the cap just enough for ONE truncation round (both
-    # load_skill and read_file share the same window-derived cap) — a
-    # bigger body would need this test to loop resume calls, which is a
-    # real thing a caller can do but not what THIS assertion is pinning.
-    big = "".join(f"line {i} {'.' * 60}\n" for i in range(130))
+    # load_skill and read_file share the same config-driven, byte-
+    # denominated cap — #4381 PR-5) — a bigger body would need this test to
+    # loop resume calls, which is a real thing a caller can do but not what
+    # THIS assertion is pinning.
+    big = "".join(f"line {i} {'.' * 60}\n" for i in range(150))
     from reyn.core.context_builder import MAX_CONTROL_IR_RESULT_INLINE_BYTES
-    assert len(big) > MAX_CONTROL_IR_RESULT_INLINE_BYTES
+    assert len(big.encode("utf-8")) > MAX_CONTROL_IR_RESULT_INLINE_BYTES
     ctx.workspace.write_file("SKILL.md", big)
 
     first = _run(load_skill_handle(LoadSkillIROp(kind="load_skill", path="SKILL.md"), ctx))

--- a/tests/core/test_read_bounding_structural_signal_1209.py
+++ b/tests/core/test_read_bounding_structural_signal_1209.py
@@ -1,12 +1,14 @@
-"""Tier 2: OS invariant — #1209 read-bounding + window-derived offload cap + structural signaling.
+"""Tier 2: OS invariant — #1209 read-bounding + structural signaling.
 
 The fixed 8 KB control_ir inline cap (`context_builder.py`) offloaded `file.read`
 content out of the editing model's decide context, starving the apply phase
 (astropy-13236: the model fabricated `old_string`s for a file it could not see).
 This pins the OS behavior fix:
 
-  (cap) the per-result inline cap is WINDOW-DERIVED (floored at 8 KB), so a normal
-        file read stays inline on a large window instead of being offloaded;
+  (cap) the per-result inline cap is a RESOURCE BOUND (#4381 PR-5: bytes,
+        model-independent, config-driven — NOT window-derived; #1209's
+        original window-derivation was itself the defect architect's
+        resource/budget role-split later closed);
   (1)   an UNBOUNDED `file.read` over the cap is truncated to a head window with a
         STRUCTURAL truncation signal in SEPARATE fields (not embedded in content),
         bound-only-when-over (small reads + explicit offset/limit unchanged).
@@ -14,7 +16,7 @@ This pins the OS behavior fix:
 #2396 Step 4: point (2) of the original pin — that an offloaded control_ir_result carries an
 explicit `_offload_status` flag — was dropped along with `offload_control_ir_result` itself (dead,
 retired in #2396 Step 4; its last caller, the ContextFrame-driven phase path, was removed by earlier
-convergence steps). `control_ir_inline_cap` — the window-derived cap this file still pins — survives
+convergence steps). `control_ir_inline_cap` — the resource-bound cap this file still pins — survives
 as the shared read-bounding cap consulted by `file.py` / `load_skill.py`.
 
 Real Workspace + EventLog, no collaborator mocks; cap helper tested as a pure
@@ -25,6 +27,7 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
+from reyn.config import ReadCapConfig
 from reyn.core.context_builder import (
     MAX_CONTROL_IR_RESULT_INLINE_BYTES,
     control_ir_inline_cap,
@@ -52,26 +55,35 @@ def _run(coro):
     return asyncio.run(coro)
 
 
-# ── cap helper: window-derive + floor ───────────────────────────────────────
+# ── cap helper: config-driven, model-independent (#4381 PR-5) ────────────────
 
-def test_inline_cap_window_derived_above_floor() -> None:
-    """Tier 2: a known large-window model derives a cap well above the 8 KB floor."""
-    cap = control_ir_inline_cap("gemini/gemini-2.5-flash-lite")
-    assert cap > MAX_CONTROL_IR_RESULT_INLINE_BYTES, (
-        f"window-derived cap should exceed the 8 KB floor, got {cap}"
-    )
-    # 1M-token window × 4 chars/token × 0.08 ≈ 320 KB → a 150 KB file stays inline.
-    assert cap >= 150_000, f"cap should keep a 150 KB file inline, got {cap}"
+def test_inline_cap_is_model_independent() -> None:
+    """Tier 2: #4381 PR-5 (owner ruling) — the cap no longer takes a model at
+    all; an explicit ``ReadCapConfig`` is honored VERBATIM, with no
+    window-style scaling applied anywhere in this path."""
+    cap = control_ir_inline_cap(ReadCapConfig(inline_bytes=999_999))
+    assert cap == 999_999, f"an explicit config value must be returned verbatim, got {cap}"
 
 
-def test_inline_cap_none_is_floor() -> None:
-    """Tier 2: no model context → the fixed 8 KB floor (backward-compat)."""
+def test_inline_cap_none_is_the_shipped_default() -> None:
+    """Tier 2: no ``ReadCapConfig`` threaded to the caller → the shipped
+    model-independent default (backward-compat for a direct-OpContext
+    construction with no ReynConfig, e.g. many tests in this module)."""
     assert control_ir_inline_cap(None) == MAX_CONTROL_IR_RESULT_INLINE_BYTES
 
 
-def test_inline_cap_floor_guard_for_unknown_model() -> None:
-    """Tier 2: an unrecognized model never derives below the floor."""
-    assert control_ir_inline_cap("nonexistent/model-xyz") >= MAX_CONTROL_IR_RESULT_INLINE_BYTES
+def test_inline_cap_honors_a_small_explicit_config_with_no_floor_clamp() -> None:
+    """Tier 2: accept-side — an operator-set SMALL cap (e.g. tighter than the
+    shipped default) is NOT floor-clamped back up. #1209's original
+    window-derivation floored the cap at 8 KB so a large-window model could
+    never go below it; #4381 PR-5 removed that clamp along with the
+    window-derivation itself — the cap is now whatever config says, full
+    stop (an operator choosing a smaller value is a deliberate choice, not
+    a value this layer second-guesses; ``_build_read_cap_config``'s own
+    positive-value guard is the only clamp left, and it only rejects
+    zero/negative, not "small")."""
+    small = ReadCapConfig(inline_bytes=100)
+    assert control_ir_inline_cap(small) == 100
 
 
 # ── (1) read-bounding: bound-only-when-over, structural fields separate ──────
@@ -85,7 +97,11 @@ def test_unbounded_read_over_cap_truncates_with_structural_fields(tmp_path: Path
     """
     ctx = _make_ctx(tmp_path)
     big = "".join(f"line {i} ................................................\n" for i in range(400))
-    assert len(big) > MAX_CONTROL_IR_RESULT_INLINE_BYTES  # ensure over the floor cap
+    # #4381 PR-5: the cap is BYTES; this fixture is pure ASCII so char count
+    # == byte count, but the comparison is written byte-explicit (not
+    # len(str)) so it stays correct if this fixture ever grows non-ASCII
+    # content.
+    assert len(big.encode("utf-8")) > MAX_CONTROL_IR_RESULT_INLINE_BYTES  # ensure over the cap
     ctx.workspace.write_file("big.py", big)
 
     res = _run(handle(FileIROp(kind="file", op="read", path="big.py"), ctx))
@@ -96,7 +112,7 @@ def test_unbounded_read_over_cap_truncates_with_structural_fields(tmp_path: Path
     assert res["total_chars"] == len(big)
     # structural signal is in separate fields, NOT embedded in the content text
     assert "TRUNCATED" not in res["content"]
-    assert len(res["content"]) <= MAX_CONTROL_IR_RESULT_INLINE_BYTES
+    assert len(res["content"].encode("utf-8")) <= MAX_CONTROL_IR_RESULT_INLINE_BYTES
 
 
 def test_unbounded_read_under_cap_returns_full_ok(tmp_path: Path) -> None:

--- a/tests/runtime/test_4381_pr1_resource_budget_invariant.py
+++ b/tests/runtime/test_4381_pr1_resource_budget_invariant.py
@@ -2,6 +2,15 @@
 now enforces: "a result that passed the resource boundary must not exceed the
 budget boundary after conversion."
 
+#4381 PR-5 update: the resource boundary moved from a window-derived,
+model-dependent CHAR count to a fixed, model-INDEPENDENT config BYTE value
+(`ReadCapConfig.inline_bytes`) — so a "genuine violation" scenario can no
+longer be engineered by picking a model with a huge window (the old
+approach); every test below builds an EXPLICIT small/large `ReadCapConfig`
+and threads it in via `read_cap_config=`, rather than pinning the shipped
+default's exact number (owner/architect: the default value itself is a
+separate, still-open decision — these tests must survive it changing).
+
 Real collaborators throughout: `compute_budgets` (the same function
 `CompactionEngine` itself uses) builds a real `ComputedBudgets`; only the
 tiny attribute-passthrough container matching `compaction_controller._engine
@@ -12,15 +21,24 @@ tiny attribute-passthrough container matching `compaction_controller._engine
 """
 from __future__ import annotations
 
-from reyn.config import CompactionConfig
-from reyn.core.context_builder import INLINE_CAP_CHARS_PER_TOKEN, control_ir_inline_cap
+from reyn.config import CompactionConfig, ReadCapConfig
+from reyn.core.context_builder import INLINE_CAP_BYTES_PER_TOKEN, control_ir_inline_cap
 from reyn.core.events.events import EventLog
-from reyn.llm.model_budget import get_max_input_tokens
 from reyn.runtime.services import router_history_buffer as rhb
 from reyn.services.compaction.engine import compute_budgets
 from tests._support.events import collect_events
 
 _MODEL = "openai/gpt-4o"
+# A HUGE resource bound (bytes) whose token-equivalent deliberately EXCEEDS
+# any reasonable effective_trigger — the invariant is "resource bound must
+# not exceed budget after conversion", so a huge resource bound is what
+# TRIPS it (a result that fits under this cap can still overflow a smaller
+# model budget). Makes a "genuine violation" scenario trivial to construct
+# without depending on the shipped default's exact number.
+_HUGE_CAP = ReadCapConfig(inline_bytes=10_000_000)  # -> 2_500_000 tokens
+# A tiny resource bound whose token-equivalent is comfortably UNDER any
+# reasonable effective_trigger — the accept-side "no violation" case.
+_TINY_CAP = ReadCapConfig(inline_bytes=40)  # -> ceil(40/4) = 10 tokens
 
 
 class _Engine:
@@ -42,14 +60,14 @@ def _reset_warned():
 
 
 def test_resource_bound_actually_exceeds_the_small_budget_in_this_scenario():
-    """Tier 2: sanity precondition for the tests below — with `T_SP` close to
-    the model's window, `effective_trigger` collapses well under the
-    resource boundary's own token-equivalent, so the invariant genuinely
+    """Tier 2: sanity precondition for the tests below — with a HUGE
+    ``ReadCapConfig``, the resource boundary's own token-equivalent is
+    LARGER than a normal ``effective_trigger``, so the invariant genuinely
     trips (not an assumption)."""
-    resource_bound_chars = control_ir_inline_cap(_MODEL)
-    resource_bound_tokens = -(-resource_bound_chars // INLINE_CAP_CHARS_PER_TOKEN)
-    small_budgets = _budgets_with_effective_trigger(get_max_input_tokens(_MODEL) - 500)
-    assert small_budgets.effective_trigger < resource_bound_tokens
+    resource_bound_bytes = control_ir_inline_cap(_HUGE_CAP)
+    resource_bound_tokens = -(-resource_bound_bytes // INLINE_CAP_BYTES_PER_TOKEN)
+    normal_budgets = _budgets_with_effective_trigger(2_000)
+    assert normal_budgets.effective_trigger < resource_bound_tokens
 
 
 def test_violation_emits_resource_cap_exceeds_budget_trigger_once():
@@ -60,11 +78,13 @@ def test_violation_emits_resource_cap_exceeds_budget_trigger_once():
     _reset_warned()
     events = EventLog()
     collected = collect_events(events)
-    budgets = _budgets_with_effective_trigger(get_max_input_tokens(_MODEL) - 500)
+    budgets = _budgets_with_effective_trigger(2_000)
     controller = _Controller(_Engine(budgets))
 
     for _ in range(3):
-        result = rhb.resolve_effective_trigger_and_budgets(controller, _MODEL, events)
+        result = rhb.resolve_effective_trigger_and_budgets(
+            controller, _MODEL, events, read_cap_config=_HUGE_CAP,
+        )
         assert result == (budgets.effective_trigger, budgets.head_budget, budgets.tail_budget)
 
     warnings = [e for e in collected if e.type == "resource_cap_exceeds_budget_trigger"]
@@ -81,12 +101,18 @@ def test_violation_warns_again_for_a_different_phase_same_model():
     _reset_warned()
     events = EventLog()
     collected = collect_events(events)
-    budgets = _budgets_with_effective_trigger(get_max_input_tokens(_MODEL) - 500)
+    budgets = _budgets_with_effective_trigger(2_000)
     controller = _Controller(_Engine(budgets))
 
-    rhb.resolve_effective_trigger_and_budgets(controller, _MODEL, events, phase="alpha")
-    rhb.resolve_effective_trigger_and_budgets(controller, _MODEL, events, phase="alpha")
-    rhb.resolve_effective_trigger_and_budgets(controller, _MODEL, events, phase="beta")
+    rhb.resolve_effective_trigger_and_budgets(
+        controller, _MODEL, events, phase="alpha", read_cap_config=_HUGE_CAP,
+    )
+    rhb.resolve_effective_trigger_and_budgets(
+        controller, _MODEL, events, phase="alpha", read_cap_config=_HUGE_CAP,
+    )
+    rhb.resolve_effective_trigger_and_budgets(
+        controller, _MODEL, events, phase="beta", read_cap_config=_HUGE_CAP,
+    )
 
     warnings = [e for e in collected if e.type == "resource_cap_exceeds_budget_trigger"]
     phases_warned = sorted(e.data["phase"] for e in warnings)
@@ -94,19 +120,37 @@ def test_violation_warns_again_for_a_different_phase_same_model():
 
 
 def test_no_violation_emits_nothing():
-    """Tier 2: accept-side twin — a normal-sized `T_SP` leaves `effective_trigger`
-    comfortably above the resource bound's token-equivalent; no event fires
-    at all (not a present-but-benign one)."""
+    """Tier 2: accept-side twin — a TINY resource bound leaves
+    `effective_trigger` comfortably ABOVE the resource bound's
+    token-equivalent; no event fires at all (not a present-but-benign
+    one)."""
     _reset_warned()
     events = EventLog()
     collected = collect_events(events)
     budgets = _budgets_with_effective_trigger(2_000)
     controller = _Controller(_Engine(budgets))
 
-    result = rhb.resolve_effective_trigger_and_budgets(controller, _MODEL, events)
+    result = rhb.resolve_effective_trigger_and_budgets(
+        controller, _MODEL, events, read_cap_config=_TINY_CAP,
+    )
 
     assert result == (budgets.effective_trigger, budgets.head_budget, budgets.tail_budget)
     assert not [e for e in collected if e.type == "resource_cap_exceeds_budget_trigger"]
+
+
+def test_no_read_cap_config_falls_back_to_the_shipped_default():
+    """Tier 2: accept-side — omitting ``read_cap_config`` entirely (a
+    caller with no config threaded, e.g. ``ContextBudgetAdvisor``'s own
+    call today) must not raise, and resolves via ``control_ir_inline_cap``'s
+    own ``config=None`` default rather than crashing on a missing arg."""
+    _reset_warned()
+    events = EventLog()
+    budgets = _budgets_with_effective_trigger(2_000)
+    controller = _Controller(_Engine(budgets))
+
+    result = rhb.resolve_effective_trigger_and_budgets(controller, _MODEL, events)
+
+    assert result == (budgets.effective_trigger, budgets.head_budget, budgets.tail_budget)
 
 
 def test_no_events_sink_does_not_raise():
@@ -114,10 +158,12 @@ def test_no_events_sink_does_not_raise():
     without one) — the check runs and detects the violation internally but
     never tries to emit, and never raises for lack of a sink."""
     _reset_warned()
-    budgets = _budgets_with_effective_trigger(get_max_input_tokens(_MODEL) - 500)
+    budgets = _budgets_with_effective_trigger(2_000)
     controller = _Controller(_Engine(budgets))
 
-    result = rhb.resolve_effective_trigger_and_budgets(controller, _MODEL, None)
+    result = rhb.resolve_effective_trigger_and_budgets(
+        controller, _MODEL, None, read_cap_config=_HUGE_CAP,
+    )
 
     assert result == (budgets.effective_trigger, budgets.head_budget, budgets.tail_budget)
 
@@ -130,9 +176,9 @@ def test_fallback_path_no_engine_budgets_still_checks_the_invariant():
     events = EventLog()
     collected = collect_events(events)
 
-    rhb.resolve_effective_trigger_and_budgets(None, _MODEL, events)
+    rhb.resolve_effective_trigger_and_budgets(None, _MODEL, events, read_cap_config=_TINY_CAP)
 
     # Fallback trigger = get_max_input_tokens(model) // 4, comfortably above
-    # the resource bound for this model — no violation in the fallback path
-    # with a real, reasonably-sized model.
+    # the TINY resource bound's token-equivalent — no violation in the
+    # fallback path with a real, reasonably-sized model.
     assert not [e for e in collected if e.type == "resource_cap_exceeds_budget_trigger"]


### PR DESCRIPTION
**[tui-coder]** — #4381 PR-5: the read cap becomes a RESOURCE BOUND (bytes, model-independent, config-driven), per architect's design (#4431/#4381 comments) and owner ruling.

## Design (architect, restated)

Every cap declares its unit and ROLE. Comparison/ordering happens only within the same role; a cross-role relationship goes through one named conversion point.

| | unit | derivation | protects |
|---|---|---|---|
| **resource bound** | BYTES | model-independent, config | memory / transfer / disk |
| **budget bound** | TOKENS | model-derived | the model's context window |

`control_ir_inline_cap()` was still a resource-bound member scaled by the resolved model's input window (#1209's own original derivation) and counted in CHARACTERS — both were the exact defects this role-split closes: window-scaling a resource bound conflates the two roles, and char-counting a byte-denominated resource drifts up to ~3x for non-ASCII content.

## What changed

- `control_ir_inline_cap(config: ReadCapConfig | None = None) -> int` — no model/events/phase args; returns `config.inline_bytes` or the shipped 10 KiB default. Unit is bytes.
- New `byte_safe_prefix(text, max_bytes)` — UTF-8-safe truncation helper, O(n) (encode once, slice, back off ≤3 bytes on a mid-codepoint cut). Replaces `text[:cap]` char-slicing at both truncation sites (`file.py`, `load_skill.py`).
- `INLINE_CAP_CHARS_PER_TOKEN` → `INLINE_CAP_BYTES_PER_TOKEN` (renamed, same value 4 — the unit changed, so reusing the old name would silently reopen the drift class this PR closes).
- New `ReadCapConfig`/`read_cap:` config section (mirrors `RenderTemplateConfig`'s dataclass + `_build_*_config` shape). Deliberately NOT folded into `OffloadConfig` — offload is opt-in (`enabled: true`), the read cap is unconditionally active.
- Threaded via the blessed `SessionFactoryConfig`/`web_fetch_config` pattern (#4274 precedent) so all 5 factory sites pick it up automatically, type-enforced: `ReynConfig.read_cap` → `SessionFactoryConfig` → `scoped_session_factory.py` → `Session.__init__` → `router_op_context.py` → `OpContext.read_cap_config`.
- `router_history_buffer.py` (PR-1, #4451) gained `read_cap_config` threading through `resolve_effective_trigger_and_budgets`/`_check_resource_within_budget`; `resource_bound_chars` → `resource_bound_bytes` on the emitted event.
- `file.py` / `load_skill.py` truncation loops now measure UTF-8 byte length, never `len(str)`.

## Known, explicitly-flagged gap

`ContextBudgetAdvisor`'s own call to `resolve_effective_trigger_and_budgets` is **not** threaded with `read_cap_config` — falls back to the default via `control_ir_inline_cap(None)`. Documented in `_check_resource_within_budget`'s own docstring as a known, flagged gap. Smaller, deliberately deferred to a follow-up rather than expanding this PR's blast radius.

## Falsify-verify note

While rewriting `test_4381_pr1_resource_budget_invariant.py` for explicit `ReadCapConfig`s (no more picking a model by window size — the resource bound doesn't vary by model at all anymore), I initially assigned `_HUGE_CAP`/`_TINY_CAP` backwards to the violation/no-violation scenarios. Caught via real test failures showing the opposite of expected event-firing behavior (the invariant fires when the resource bound, converted to tokens, EXCEEDS the budget trigger — i.e. too LARGE, not too small), fixed, re-verified all 7 tests green.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 27 tests, 0 errors/warnings
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (baselined, no new findings)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK, re-run fresh right before push per CLAUDE.md
- [x] Full regression: `pytest tests/core/ tests/runtime/ tests/tools/ tests/builtin/` — 5285 passed, 3 skipped (unrelated), 0 failed
- [ ] (skipped — no user-visible/TTY behavior change; config-schema + internal cap-mechanism change only, no CUI surface touched)

## Closing-intent enumeration

`gh pr list --state all --search "#4381 in:body"` shows multiple `part of #4381` PRs already merged (PR-1 #4451, PR-2 stage3 #4453, PR-4 #4454) plus this one — the umbrella issue is not yet fully closed by this PR, so this uses `part of #4381`, not `Closes`.

part of #4381

🤖 Generated with [Claude Code](https://claude.com/claude-code)
