### PR TITLE
fix(#4302): tighten fastmcp-import-boundary gate now that the boundary module is gone

### DIFF
--- a/scripts/check_fastmcp_import_boundary.py
+++ b/scripts/check_fastmcp_import_boundary.py
@@ -3,15 +3,28 @@
 the convention half).
 
 P2 (#4053) introduced ``src/reyn/mcp/_fastmcp_boundary.py`` as the single
-seam every reyn-side ``fastmcp`` import goes through, but nothing stopped a
+seam every reyn-side ``fastmcp`` import went through, but nothing stopped a
 future direct ``import fastmcp`` anywhere else in ``src/reyn/mcp/`` — the PR
 said so explicitly ("this boundary is a convention, not an enforcement"),
 scoped to land once P3 (#4055) removed the one remaining inheritance-based
 exception (``message_handler.py``'s subclass of ``fastmcp.client.tasks.
 TaskNotificationHandler``, which genuinely needed a direct import at the
-time). Post-P3, the boundary's own starting population is verified zero —
-``_fastmcp_boundary.py`` is the ONLY file under ``src/reyn/mcp/`` that
-imports ``fastmcp`` — so this gate has nothing to grandfather.
+time). Post-P3, the boundary's own starting population was verified zero —
+``_fastmcp_boundary.py`` was the ONLY file under ``src/reyn/mcp/`` that
+imported ``fastmcp`` — so this gate had nothing to grandfather.
+
+#4302: ``_fastmcp_boundary.py`` itself no longer exists — the MCP client
+stack retired its last fastmcp dependency entirely (#4282/#4299/#3698 P3),
+so the seam it existed to hold has nothing left to route through it. The
+invariant this gate enforces tightened as a result: not "only the boundary
+module may import fastmcp" (there is no longer a module for which that is
+true) but "no file under ``src/reyn/mcp/`` imports fastmcp, period" — still
+a real, live check (a regression reintroducing ``import fastmcp`` anywhere
+in this directory still trips it; verified by a live strip-falsify: adding
+a throwaway ``import fastmcp`` file here flips this script's exit code to 1,
+confirming the AST scan itself, not just the docstring, is current). Kept
+scanning the whole directory rather than narrowing to zero files so a
+regression is still caught, not just documented as impossible.
 
 ## Scope: ``src/reyn/mcp/`` only, not the whole repo
 
@@ -39,7 +52,6 @@ from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parent.parent
 _MCP_DIR = _ROOT / "src" / "reyn" / "mcp"
-_BOUNDARY_FILE = "_fastmcp_boundary.py"
 
 
 def _imports_fastmcp_directly(path: Path) -> bool:
@@ -63,16 +75,20 @@ def _imports_fastmcp_directly(path: Path) -> bool:
 
 
 def offending_files(mcp_dir: Path = _MCP_DIR) -> "list[Path]":
-    """Every ``.py`` file directly under *mcp_dir* (not ``_fastmcp_boundary.py``
-    itself) that imports ``fastmcp`` directly — the gate's entire decision,
-    isolated from CLI/printing so it is directly testable."""
-    offenders = []
-    for path in sorted(mcp_dir.glob("*.py")):
-        if path.name == _BOUNDARY_FILE:
-            continue
-        if _imports_fastmcp_directly(path):
-            offenders.append(path)
-    return offenders
+    """Every ``.py`` file directly under *mcp_dir* that imports ``fastmcp``
+    directly — the gate's entire decision, isolated from CLI/printing so it
+    is directly testable.
+
+    #4302: no filename is exempt anymore. ``_fastmcp_boundary.py`` (the one
+    file this used to skip) no longer exists — the client stack's last
+    fastmcp dependency was retired entirely, so there is no longer a
+    legitimate place under this directory for a direct ``import fastmcp``
+    to live."""
+    return [
+        path
+        for path in sorted(mcp_dir.glob("*.py"))
+        if _imports_fastmcp_directly(path)
+    ]
 
 
 def main(argv: "list[str] | None" = None) -> int:
@@ -80,24 +96,21 @@ def main(argv: "list[str] | None" = None) -> int:
     offenders = offending_files(_MCP_DIR)
 
     if not offenders:
-        print(
-            "OK: no file under src/reyn/mcp/ imports fastmcp directly except "
-            "_fastmcp_boundary.py."
-        )
+        print("OK: no file under src/reyn/mcp/ imports fastmcp directly.")
         return 0
 
     print("fastmcp-import-boundary gate FAILED:\n", file=sys.stderr)
     print(
-        f"{len(offenders)} file(s) under src/reyn/mcp/ import fastmcp directly, "
-        "outside the boundary module (#3698 P2/P3):",
+        f"{len(offenders)} file(s) under src/reyn/mcp/ import fastmcp directly "
+        "(#3698 P2/P3, #4302):",
         file=sys.stderr,
     )
     for path in offenders:
         print(f"  {path.relative_to(_ROOT)}", file=sys.stderr)
     print(
-        "\nAdd an accessor function to src/reyn/mcp/_fastmcp_boundary.py "
-        "instead and import from there — that module is the single seam a "
-        "future SDK swap edits, not scattered call sites.\n"
+        "\nThe MCP client stack has no fastmcp dependency left at all "
+        "(#4282/#4299/#3698 P3) — reach for the official mcp SDK directly "
+        "instead of reintroducing fastmcp here.\n"
         "\nThis gate's own starting population is zero, so any hit here is "
         "a new regression, not inherited debt.",
         file=sys.stderr,

--- a/tests/scripts/test_check_fastmcp_import_boundary_3698.py
+++ b/tests/scripts/test_check_fastmcp_import_boundary_3698.py
@@ -13,8 +13,7 @@ from scripts.check_fastmcp_import_boundary import offending_files
 
 def test_a_direct_module_level_import_is_flagged(tmp_path: Path) -> None:
     """Tier 2: THE case #3698 P2/P3 warned would go unnoticed — a future
-    direct `import fastmcp` outside the boundary module."""
-    (tmp_path / "_fastmcp_boundary.py").write_text("X = 1\n", encoding="utf-8")
+    direct `import fastmcp` reintroduced anywhere under this directory."""
     (tmp_path / "client.py").write_text("import fastmcp\n", encoding="utf-8")
     offenders = offending_files(tmp_path)
     assert offenders == [tmp_path / "client.py"]
@@ -23,7 +22,6 @@ def test_a_direct_module_level_import_is_flagged(tmp_path: Path) -> None:
 def test_a_from_fastmcp_submodule_import_is_flagged(tmp_path: Path) -> None:
     """Tier 2: `from fastmcp.client.auth import OAuth` shape — a submodule
     import, not the bare package name."""
-    (tmp_path / "_fastmcp_boundary.py").write_text("X = 1\n", encoding="utf-8")
     (tmp_path / "client.py").write_text(
         "from fastmcp.client.auth import OAuth\n", encoding="utf-8"
     )
@@ -32,11 +30,9 @@ def test_a_from_fastmcp_submodule_import_is_flagged(tmp_path: Path) -> None:
 
 
 def test_a_deferred_function_local_import_is_also_flagged(tmp_path: Path) -> None:
-    """Tier 2: a deferred (function-local) import is in scope too — the
-    boundary module itself uses deferred imports for the same reason
-    (preserving timing), so a NEW direct import elsewhere must be caught
-    regardless of whether it's module-level or deferred."""
-    (tmp_path / "_fastmcp_boundary.py").write_text("X = 1\n", encoding="utf-8")
+    """Tier 2: a deferred (function-local) import is in scope too — a NEW
+    direct import must be caught regardless of whether it's module-level
+    or deferred, since a regression could reach for either shape."""
     (tmp_path / "client.py").write_text(
         "def f():\n    from fastmcp import Client\n    return Client\n",
         encoding="utf-8",
@@ -45,21 +41,10 @@ def test_a_deferred_function_local_import_is_also_flagged(tmp_path: Path) -> Non
     assert offenders == [tmp_path / "client.py"]
 
 
-def test_the_boundary_module_itself_is_exempt(tmp_path: Path) -> None:
-    """Tier 2: `_fastmcp_boundary.py` is where these imports are SUPPOSED to
-    live — never flagged, no matter how many it has."""
-    (tmp_path / "_fastmcp_boundary.py").write_text(
-        "import fastmcp\nfrom fastmcp.client.auth import OAuth\n", encoding="utf-8"
-    )
-    offenders = offending_files(tmp_path)
-    assert offenders == []
-
-
 def test_an_import_of_an_unrelated_package_is_not_flagged(tmp_path: Path) -> None:
     """Tier 2: `import mcp.types` (the lower-level protocol-spec package
     fastmcp itself wraps, not fastmcp) must not false-positive — only a
     module named exactly `fastmcp` or `fastmcp.<sub>` counts."""
-    (tmp_path / "_fastmcp_boundary.py").write_text("X = 1\n", encoding="utf-8")
     (tmp_path / "message_handler.py").write_text(
         "import mcp.types\nfrom mcp.types import ServerNotification\n",
         encoding="utf-8",
@@ -75,7 +60,6 @@ def test_a_package_named_fastmcp_prefixed_is_not_confused_with_fastmcp(
     hypothetical unrelated package whose name merely STARTS WITH the same
     letters (e.g. `fastmcplib`, not a real package, but the rule must not
     match on a bare substring) is not flagged."""
-    (tmp_path / "_fastmcp_boundary.py").write_text("X = 1\n", encoding="utf-8")
     (tmp_path / "client.py").write_text("import fastmcplib\n", encoding="utf-8")
     offenders = offending_files(tmp_path)
     assert offenders == []
@@ -85,9 +69,9 @@ def test_the_real_repo_tree_is_currently_clean() -> None:
     """Tier 2: the gate's own starting population — verified against the
     real, current tree (not assumed), matching the sibling gates' own
     "run it before shipping it" discipline. #3698 P3 removed the last
-    remaining direct fastmcp import outside the boundary module
-    (message_handler.py's inheritance-based one); this asserts it stayed
-    removed."""
+    remaining direct fastmcp import (message_handler.py's inheritance-based
+    one); #4302 later confirmed the client stack's fastmcp dependency is
+    gone entirely, not just relocated. This asserts it stayed removed."""
     from scripts.check_fastmcp_import_boundary import _MCP_DIR, _ROOT
 
     assert _MCP_DIR == _ROOT / "src" / "reyn" / "mcp"


### PR DESCRIPTION
**[e2e-coder]** — Follow-up to lead-coder's #4302 re-measure check: tightens `check_fastmcp_import_boundary.py` now that `_fastmcp_boundary.py` no longer exists.

## What this addresses

While re-measuring #4302's own state post-#4459, I flagged `_fastmcp_boundary.py`'s dead name reference in this gate as "harmless." Lead-coder pushed back correctly: harmless depends on whether the gate is still watching something real, or spinning idle on a search for something that's gone — the exact #4428/#4439/#4459 pattern seen 3 times tonight.

## Live falsification (not assumed)

Added a throwaway `import fastmcp` file under `src/reyn/mcp/`, ran the gate: exit 1 (still catches a real regression). Removed it: exit 0. **The core check is real** — only the exclusion clause (skip a file literally named `_fastmcp_boundary.py`) is dead, since production never writes that filename anymore.

## Fix

Removed the exclusion clause and `_BOUNDARY_FILE` constant entirely — the invariant tightened from "only the boundary module may import fastmcp" to "no file may, period" (simpler and stronger now that there's no seam left to exempt). Updated the module docstring with the live-falsify evidence. Deleted `test_the_boundary_module_itself_is_exempt` — dead functionality with no real caller (six-question review: "who would miss it" = nobody, since no production file is ever named `_fastmcp_boundary.py` again). Fixed 2 other tests' docstrings that narrated the now-gone boundary module's own reasoning.

## Verification

- 6/6 tests pass (was 7, minus the deleted dead-exemption test)
- Gate itself green on the real tree
- Re-ran the live strip-falsify on the final committed version: temporary `import fastmcp` file → exit 1; removed → exit 0
- ruff / tier-audit --strict / mypy_ratchet / path-literal-reference / module-docstring-verify all green

part of #4302 (the checklist item this closes out); toward closing that issue once this lands.

## Test plan
- [x] `ruff check` on changed files
- [x] `test_tier_audit.py --strict` on the changed test file
- [x] `mypy_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] `verify_module_docstrings.py`
- [x] `pytest tests/scripts/test_check_fastmcp_import_boundary_3698.py` (6/6 passed)
- [x] Live strip-falsify: gate still catches a real `import fastmcp` regression
- [ ] Visual: n/a (script + test only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
