### PR TITLE
feat(#4464): image preparation off the event loop + a visible preparing entry

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -3528,21 +3528,64 @@ class TextualChatApp(App):
         will call ``.update()`` on once settled" (the presenter has no
         reference to any Entry/FlowView on its own; the app owns those).
         Fully guarded, same rationale as :meth:`_begin_running_indicator`:
-        a broken image render must never break the frame pump."""
+        a broken image render must never break the frame pump.
+
+        #4464: if at least one image node actually needs resolving (not
+        already cached from a prior resolution — same-src reuse across
+        entries is real, e.g. a repeated screenshot URL), starts the SAME
+        live spinner + elapsed indicator :meth:`_begin_running_indicator`
+        already gives a RUNNING tool row — no new visual vocabulary, per the
+        owner's explicit "受入条件" for #4464. Each image's
+        ``on_settled`` callback re-checks every image src this SAME entry
+        still owns; only once none remain unresolved does it stop the
+        animation and strip :data:`_RUNNING_SINCE_KEY` (mirroring
+        :meth:`_coalesce_tool_result`'s own settle-time stripping) — an
+        entry with two images doesn't flip back to static after the FIRST
+        one settles while the second is still preparing."""
         try:
             nodes = (msg.meta or {}).get("nodes") or []
             allowed = list(
                 getattr(getattr(self._config, "chat", None), "image_url_schemes", None)
                 or []
             ) or None
-            for node in nodes:
-                if not isinstance(node, dict) or node.get("component") != "image":
-                    continue
-                src = node.get("src")
-                if isinstance(src, str) and src:
-                    self._presenter.begin_image_resolution(
-                        entry, src, allowed_schemes=allowed
+            image_srcs = [
+                node.get("src")
+                for node in nodes
+                if isinstance(node, dict)
+                and node.get("component") == "image"
+                and isinstance(node.get("src"), str)
+                and node.get("src")
+            ]
+            needs_resolution = [
+                src for src in image_srcs if not self._presenter.has_cached_image(src)
+            ]
+            if needs_resolution:
+                self._begin_running_indicator(entry)
+
+            def _on_image_settled(settled_entry: object) -> None:
+                if any(not self._presenter.has_cached_image(s) for s in image_srcs):
+                    return  # another image on this entry is still resolving
+                try:
+                    self._flow.stop_entry_animation(settled_entry)  # type: ignore[arg-type]
+                except Exception:
+                    logger.exception(
+                        "textual chat: could not stop image-preparing animation"
                     )
+                try:
+                    item = settled_entry.item  # type: ignore[attr-defined]
+                    stripped = {
+                        k: v for k, v in (item.meta or {}).items() if k != _RUNNING_SINCE_KEY
+                    }
+                    settled_entry.set_item(replace(item, meta=stripped))  # type: ignore[attr-defined]
+                except Exception:
+                    logger.exception(
+                        "textual chat: could not settle image-preparing entry"
+                    )
+
+            for src in image_srcs:
+                self._presenter.begin_image_resolution(
+                    entry, src, allowed_schemes=allowed, on_settled=_on_image_settled,
+                )
         except Exception:
             logger.exception("textual chat: could not start image resolution")
 

--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -346,6 +346,8 @@ def _body_and_background(
     *,
     neutralize_body: bool = False,
     image_cache: "dict[str, object] | None" = None,
+    decoded_image_cache: "dict[str, object] | None" = None,
+    now: float | None = None,
 ) -> "tuple[RenderableType, str | None]":
     """The body renderable + optional full-row background for one display frame.
 
@@ -354,7 +356,22 @@ def _body_and_background(
 
     ``image_cache`` (#3846, default None) is forwarded to the ``presentation``
     kind's ``render_presentation_nodes`` call — see that function's own
-    docstring for why it must stay a pure dict lookup.
+    docstring for why it must stay a pure dict lookup. ``decoded_image_cache``
+    (#4464, default None) is forwarded alongside it — see
+    :func:`~reyn.interfaces.repl.present_renderer.render_presentation_nodes`'s
+    own docstring for what it skips.
+
+    ``now`` (#4464, default None) — when the entry carries
+    :data:`_RUNNING_SINCE_KEY` (stamped by :meth:`TextualChatApp.
+    _begin_running_indicator`, called for a ``presentation`` entry that still
+    has an image resolving — see ``_begin_image_resolutions``), an extra
+    :func:`_running_indicator` line is appended below the rendered nodes,
+    reusing the EXACT SAME live-indicator convention the RUNNING tool-call
+    row already uses (no new visual vocabulary — the owner's explicit
+    "受入条件" for #4464 bans inventing one). A blank/unresolved image node
+    otherwise renders its ordinary ``[image: alt]`` placeholder — this line
+    is the only ADDITIONAL signal that something is actively in flight
+    rather than merely not-yet-requested.
 
     Reuses the plain renderer's per-kind body construction (markdown for the
     agent reply, the tool-summary helpers for tool rows, the ``_KIND_LINE`` body
@@ -386,7 +403,14 @@ def _body_and_background(
     meta = msg.meta or {}
     if kind == "presentation":
         from reyn.interfaces.repl.present_renderer import render_presentation_nodes
-        return render_presentation_nodes(meta.get("nodes", []), image_cache=image_cache), None
+        body = render_presentation_nodes(
+            meta.get("nodes", []),
+            image_cache=image_cache,
+            decoded_image_cache=decoded_image_cache,
+        )
+        if meta.get(_RUNNING_SINCE_KEY) is not None and now is not None:
+            body = Group(body, _running_indicator(msg, now))
+        return body, None
     if meta.get(_PIPELINE_RUN_KEY) is not None:
         return _pipeline_row(meta), None
     # kind == "intervention" is intercepted earlier, in ``ReynPresenter.present``
@@ -466,6 +490,15 @@ class ReynPresenter:
         # of a list().
         self._image_cache: "dict[str, object]" = {}
         self._image_inflight: "set[str]" = set()
+        # #4464: the DECODED renderable (a `textual_image.renderable.Image`),
+        # keyed by src — populated by `_resolve_image` on a background
+        # thread once the fetch settles, so the CPU-heavy PIL decode +
+        # `TextualImage(...)` construction (measured directly: ~100-300ms
+        # for a large real photo) never runs on the event loop. Evicted in
+        # lockstep with `_image_cache` (see `_store_image_resolution`) —
+        # a separate cap of its own would drift from the byte cap that
+        # already governs image lifetime here.
+        self._decoded_image_cache: "dict[str, object]" = {}
         from reyn.core.present.image_fetch import DEFAULT_MAX_BYTES
 
         # Derived from DEFAULT_MAX_BYTES rather than a fresh magic number —
@@ -506,6 +539,12 @@ class ReynPresenter:
         while self._image_cache_bytes > self._image_cache_byte_cap and len(self._image_cache) > 1:
             oldest_src = next(iter(self._image_cache))
             evicted = self._image_cache.pop(oldest_src)
+            # #4464: evict the decoded renderable in lockstep — an entry
+            # missing from `_image_cache` but lingering in
+            # `_decoded_image_cache` would be a leak this byte cap exists
+            # to prevent (same #3876/#3872 class the module docstring
+            # already names for the raw-bytes cache).
+            self._decoded_image_cache.pop(oldest_src, None)
             evicted_body = getattr(evicted, "body", b"")
             self._image_cache_bytes -= (
                 len(evicted_body) if isinstance(evicted_body, (bytes, bytearray)) else 0
@@ -535,12 +574,21 @@ class ReynPresenter:
         :attr:`_image_cache` directly."""
         return src in self._image_cache
 
+    def has_decoded_image(self, src: str) -> bool:
+        """Whether *src* currently has a pre-decoded renderable cached
+        (#4464) — mirrors :meth:`has_cached_image`'s own public-accessor
+        pattern, exposed so a caller (or a test) can observe whether the
+        background-thread decode has populated :attr:`_decoded_image_cache`
+        without reaching into it directly."""
+        return src in self._decoded_image_cache
+
     def begin_image_resolution(
         self,
         entry: object,
         src: str,
         *,
         allowed_schemes: "list[str] | None" = None,
+        on_settled: "Callable[[object], None] | None" = None,
     ) -> None:
         """Kick a background fetch for `src` if it is not already cached or
         in flight (#3846 ②) — the ONE mutation point for :attr:`_image_cache`.
@@ -558,17 +606,34 @@ class ReynPresenter:
         ``.update()`` on — the caller (``TextualChatApp``, which already
         depends on flowview) passes the real, correctly-typed object; this
         module only needs the one method.
+
+        ``on_settled`` (#4464, default None) is called with ``entry`` once
+        THIS resolution settles (ok or failed) — the presenter has no
+        ``FlowView`` reference of its own (see this method's own
+        ``entry``-untyped rationale above), so it cannot stop the app's own
+        running-indicator animation itself; the app supplies this callback
+        instead, mirroring how it already supplies ``entry``. Called
+        unconditionally alongside ``entry.update()``, from the same
+        ``finally`` block.
         """
         if src in self._image_cache or src in self._image_inflight:
             return
         import asyncio
 
         self._image_inflight.add(src)
-        asyncio.create_task(self._resolve_image(entry, src, allowed_schemes))
+        asyncio.create_task(
+            self._resolve_image(entry, src, allowed_schemes, on_settled)
+        )
 
     async def _resolve_image(
-        self, entry: object, src: str, allowed_schemes: "list[str] | None",
+        self,
+        entry: object,
+        src: str,
+        allowed_schemes: "list[str] | None",
+        on_settled: "Callable[[object], None] | None" = None,
     ) -> None:
+        import asyncio
+
         from reyn.core.present.image_fetch import (
             ImageFetchError,
             ImageResolution,
@@ -582,6 +647,25 @@ class ReynPresenter:
             self._store_image_resolution(
                 src, ImageResolution(ok=True, body=body, content_type=content_type)
             )
+            # #4464: the CPU-heavy PIL decode + `TextualImage(...)`
+            # construction (measured directly: ~100-300ms for a large real
+            # photo, versus ~10ms for the sixel-encode `_render_image`'s own
+            # inline fallback still does at PAINT time) runs on a background
+            # thread — `_render_image` then only has to WRAP the already-
+            # built renderable (a cache hit), so no CPU-heavy step is left
+            # on the event loop for a resolved image. A decode failure here
+            # is silently skipped (not stored as a separate failure state):
+            # `_render_image`'s own inline fallback re-attempts the SAME
+            # decode on the SAME bytes synchronously and produces the
+            # established "[image loaded but could not render: ...]" text
+            # — one failure path, not two, for identical bytes.
+            try:
+                from reyn.interfaces.repl.present_renderer import decode_image_body
+
+                decoded = await asyncio.to_thread(decode_image_body, body)
+                self._decoded_image_cache[src] = decoded
+            except Exception:
+                pass
         except ImageFetchError as exc:
             self._store_image_resolution(src, ImageResolution(ok=False, error=str(exc)))
         except Exception:
@@ -601,6 +685,11 @@ class ReynPresenter:
                 entry.update()  # type: ignore[attr-defined]
             except Exception:
                 pass
+            if on_settled is not None:
+                try:
+                    on_settled(entry)
+                except Exception:
+                    pass
 
     def _measure(self, renderable: RenderableType, width: int) -> int:
         self._probe.size = (max(width, 1), 200)
@@ -680,7 +769,11 @@ class ReynPresenter:
         if item.kind == "tool_call_started" and meta.get(_RUNNING_SINCE_KEY) is not None:
             return self._present_running_tool(item, width)
         body, background = _body_and_background(
-            item, neutralize_body=self._neutralize_body, image_cache=self._image_cache
+            item,
+            neutralize_body=self._neutralize_body,
+            image_cache=self._image_cache,
+            decoded_image_cache=self._decoded_image_cache,
+            now=self._clock(),
         )
         return Presentation(
             height=self._measure(body, width),

--- a/src/reyn/interfaces/repl/present_renderer.py
+++ b/src/reyn/interfaces/repl/present_renderer.py
@@ -91,7 +91,11 @@ def _render_code_or_diff(node: dict, *, lexer: str) -> "Any":
     return Syntax(node.get("text", ""), lexer, word_wrap=True, background_color="default")
 
 
-def _render_node(node: dict, image_cache: "dict[str, Any] | None" = None) -> "Any":
+def _render_node(
+    node: dict,
+    image_cache: "dict[str, Any] | None" = None,
+    decoded_image_cache: "dict[str, Any] | None" = None,
+) -> "Any":
     from rich.markdown import Markdown
     from rich.text import Text
 
@@ -112,7 +116,7 @@ def _render_node(node: dict, image_cache: "dict[str, Any] | None" = None) -> "An
     if component == "list":
         return _render_list(node)
     if component == "image":
-        return _render_image(node, image_cache)
+        return _render_image(node, image_cache, decoded_image_cache)
     # Unregistered/future component — never crash the render loop over one bad node.
     return Text(f"<unsupported present component {component!r}>", style="dim")
 
@@ -214,7 +218,36 @@ class _SafeImageRenderable:
         return Measurement(1, options.max_width)
 
 
-def _render_image(node: dict, image_cache: "dict[str, Any] | None") -> "Any":
+def decode_image_body(body: bytes) -> "Any":
+    """Decode a fetched image body into a `textual_image.renderable.Image`
+    (#4464) — the CPU-heavy step `_render_image`'s own inline fallback below
+    does synchronously; extracted here so the presenter (`ReynPresenter.
+    _resolve_image`, `interfaces/inline/textual_chat/presenter.py`) can run
+    it via `asyncio.to_thread` instead of on the event loop, WITHOUT
+    duplicating the decode logic across the two modules.
+
+    Raises on a corrupt/undecodable body or a missing optional dep (PIL /
+    textual-image) — the caller (both this module's own inline fallback and
+    the presenter's off-thread path) is responsible for turning that into
+    the established distinguishable failure state; this function itself
+    stays a pure decode step with no fallback text of its own."""
+    import io
+
+    from PIL import Image as PILImage
+    from textual_image.renderable import Image as TextualImage
+
+    pil_image = PILImage.open(io.BytesIO(body))
+    # See `_render_image`'s own inline fallback for why no separate
+    # `.load()` call is needed — `TextualImage`'s constructor reads pixel
+    # data eagerly, so a bad body already raises HERE.
+    return TextualImage(pil_image, width="auto")
+
+
+def _render_image(
+    node: dict,
+    image_cache: "dict[str, Any] | None",
+    decoded_image_cache: "dict[str, Any] | None" = None,
+) -> "Any":
     """The `image` component (#3846 ②/③) — a PURE dict lookup + in-memory
     decode, never a fetch.
 
@@ -229,6 +262,18 @@ def _render_image(node: dict, image_cache: "dict[str, Any] | None") -> "Any":
     `StdoutPresentationRenderer`, and every existing test that calls this
     function without the new kwarg) gets the pre-#3846 `[image: alt]` text,
     byte-identical — no resolution stage exists on those surfaces yet.
+
+    `decoded_image_cache` (#4464, an app-owned `dict[str, TextualImage]`,
+    default None) is consulted FIRST when present — the presenter's own
+    `_resolve_image` now does the PIL decode + `TextualImage(...)`
+    construction (the CPU-heavy step this docstring already called out) on
+    a background thread (`asyncio.to_thread`) as part of "preparing" an
+    image, so THIS function's own job shrinks to "wrap the already-built
+    renderable" on the cache-hit path — no decode work left to do here at
+    all. Falling through to the inline decode below on a cache MISS (the
+    key absent, or `decoded_image_cache=None` entirely) keeps every
+    existing caller's behavior unchanged — this is an accelerator, not a
+    new required input.
 
     #3846 ③: on a successful resolution, renders REAL pixels via
     `textual_image.renderable.Image` (owner-approved regular dep, #3970) —
@@ -251,22 +296,18 @@ def _render_image(node: dict, image_cache: "dict[str, Any] | None") -> "Any":
     res = image_cache[src]
     if not res.ok:
         return Text(f"[image failed: {label} — {res.error}]", style="dim")
+    if decoded_image_cache is not None and src in decoded_image_cache:
+        return _SafeImageRenderable(decoded_image_cache[src], label)
     try:
-        import io
-
-        from PIL import Image as PILImage
-        from textual_image.renderable import Image as TextualImage
-
-        pil_image = PILImage.open(io.BytesIO(res.body))
-        # `PILImage.open()` alone only parses the header (lazy decode) — a
-        # truncated/corrupt body can open cleanly and only fail once pixel
-        # data is actually read. No separate `.load()` call is needed here
-        # to force that: `TextualImage`'s own constructor reads the pixel
-        # data eagerly (`PixelData.__init__`), so a bad body already raises
-        # HERE, inside this `try`, not later at paint time (verified: a
-        # truncated PNG that `open()` accepts raises `OSError` from
-        # `TextualImage(...)` itself).
-        return _SafeImageRenderable(TextualImage(pil_image, width="auto"), label)
+        # #4464: this inline decode is now a FALLBACK (the presenter's
+        # `_resolve_image` decodes on a background thread via the SAME
+        # `decode_image_body` helper and populates `decoded_image_cache`
+        # above on the hit path) — kept so callers with no
+        # `decoded_image_cache` (every pre-#4464 caller, and any future one
+        # that doesn't opt in) still work byte-identically, just back on the
+        # event loop for this CPU step as before. See `decode_image_body`'s
+        # own docstring for why a bad body raises HERE, not at paint time.
+        return _SafeImageRenderable(decode_image_body(res.body), label)
     except Exception as exc:
         # Anything from a corrupt/unsupported body to a missing optional dep
         # (defensive only — pillow/textual-image are regular deps) degrades
@@ -277,7 +318,10 @@ def _render_image(node: dict, image_cache: "dict[str, Any] | None") -> "Any":
 
 
 def render_presentation_nodes(
-    nodes: list[dict], *, image_cache: "dict[str, Any] | None" = None
+    nodes: list[dict],
+    *,
+    image_cache: "dict[str, Any] | None" = None,
+    decoded_image_cache: "dict[str, Any] | None" = None,
 ) -> "Any":
     """Convert a `ResolvedPresentation.nodes` render model into ONE Rich renderable
     (a `Group` of per-node renderables) — the one-shot inline block `present` prints
@@ -285,7 +329,9 @@ def render_presentation_nodes(
     invariant every branch here must preserve.
 
     `image_cache` (#3846 ②, default None) is forwarded to the `image`
-    component branch — see :func:`_render_image`."""
+    component branch — see :func:`_render_image`. `decoded_image_cache`
+    (#4464, default None) is forwarded alongside it — see that function's
+    own docstring for what it lets this render pass skip."""
     from rich.console import Group
 
     return Group(*[_render_node(node, image_cache) for node in nodes])

--- a/src/reyn/interfaces/repl/present_renderer.py
+++ b/src/reyn/interfaces/repl/present_renderer.py
@@ -334,7 +334,9 @@ def render_presentation_nodes(
     own docstring for what it lets this render pass skip."""
     from rich.console import Group
 
-    return Group(*[_render_node(node, image_cache) for node in nodes])
+    return Group(*[
+        _render_node(node, image_cache, decoded_image_cache) for node in nodes
+    ])
 
 
 class StdoutPresentationRenderer:

--- a/tests/core/test_present_renderer_fp0054_prb.py
+++ b/tests/core/test_present_renderer_fp0054_prb.py
@@ -152,6 +152,89 @@ def test_image_with_resolved_cache_renders_real_pixels_not_the_status_line() -> 
     assert out.strip()
 
 
+def test_render_image_uses_a_warm_decoded_cache_without_decoding_again() -> None:
+    """Tier 2: #4464 lead-coder review block — a warm ``decoded_image_cache``
+    entry must actually be USED, not merely handed in ("渡された ≠ 使った",
+    #3859's own shape: a value present-but-ignored reads identical to a
+    value that mattered, until something asserts the DIFFERENCE). Before
+    this test, deleting `_render_image`'s cache-hit branch entirely left
+    every existing test green — none of them distinguished "decoded from
+    the cache" from "decoded fresh from `res.body`" because both paths
+    produce an equivalent-looking `_SafeImageRenderable`.
+
+    Proven two ways at once, both through PUBLIC surface (no private-state
+    assertion — the sentinel's identity is witnessed by its OWN print-time
+    behavior, not by reaching into `_SafeImageRenderable._inner`):
+
+    1. Behavior — `decode_image_body` is monkeypatched with a call-counting
+       spy; it must be called ZERO times, proving decode never ran on the
+       (deliberately garbage) cached bytes.
+    2. Content — the sentinel wrapped for render is a plain `object()` with
+       no `__rich_console__` of its own, so printing it produces
+       `_SafeImageRenderable`'s OWN print-time-failure text naming THAT
+       specific `AttributeError` — a fresh decode of the garbage `res.body`
+       would instead fail at `PILImage.open()` with a DIFFERENT, PIL-shaped
+       error, so the printed text distinguishes which object was actually
+       wrapped without touching `_inner` directly.
+
+    Falsify-verified: commenting out the cache-hit branch (falling straight
+    to the inline decode) makes the spy record a call AND changes the
+    printed failure text to a PIL decode error — this test goes RED on
+    both assertions with the exact real bug lead-coder's block named."""
+    from reyn.core.present.image_fetch import ImageResolution
+    from reyn.interfaces.repl.present_renderer import _SafeImageRenderable
+
+    calls: list[bytes] = []
+
+    def _spy(body: bytes):
+        calls.append(body)
+        raise RuntimeError("decode_image_body should not have been called")
+
+    import reyn.interfaces.repl.present_renderer as present_renderer_module
+    original = present_renderer_module.decode_image_body
+    present_renderer_module.decode_image_body = _spy
+    try:
+        sentinel = object()  # stands in for a pre-decoded TextualImage
+        nodes = validate_blueprint(
+            {"component": "image", "src": "http://x/y.png", "alt": "a photo"}
+        )
+        resolved = resolve_bindings(nodes, {}, surface="inline-cui")
+        image_cache = {
+            "http://x/y.png": ImageResolution(
+                ok=True, body=b"deliberately-not-a-real-png", content_type="image/png"
+            ),
+        }
+        decoded_image_cache = {"http://x/y.png": sentinel}
+
+        group = render_presentation_nodes(
+            resolved.nodes,
+            image_cache=image_cache,
+            decoded_image_cache=decoded_image_cache,
+        )
+        (renderable,) = group.renderables
+        assert isinstance(renderable, _SafeImageRenderable)
+
+        console = Console(width=100, file=io.StringIO(), force_terminal=True, color_system=None)
+        console.print(group)
+        out = console.file.getvalue()
+
+        assert not calls, (
+            f"decode_image_body was called {len(calls)} time(s) — "
+            "the cache-hit branch was bypassed"
+        )
+        # The sentinel `object()` has no `__rich_console__` — printing it
+        # fails with THIS specific AttributeError, distinguishing "the
+        # cached sentinel was wrapped" from "the garbage bytes were
+        # (attempted to be) decoded fresh" (which would fail differently,
+        # at PIL's own header sniff, if the cache-hit branch were bypassed
+        # and our raising spy didn't intervene first).
+        assert "__rich_console__" in out, (
+            f"expected the sentinel's own print-time AttributeError, got: {out}"
+        )
+    finally:
+        present_renderer_module.decode_image_body = original
+
+
 def test_safe_image_renderable_catches_a_print_time_failure() -> None:
     """Tier 1: #3846 ③ — `_SafeImageRenderable` degrades to a status line
     when the WRAPPED renderable's `__rich_console__` raises, not just when

--- a/tests/interfaces/test_4464_image_prep_off_thread_and_indicator.py
+++ b/tests/interfaces/test_4464_image_prep_off_thread_and_indicator.py
@@ -1,0 +1,294 @@
+"""Tier 2: #4464 — image preparation runs off the event loop and shows a
+"preparing" flowview entry, reusing the RUNNING-tool live-indicator
+convention (no new visual vocabulary — the owner's explicit acceptance
+criterion for this issue).
+
+Owner's 3 requirements (quoted in #4464), each with its own test below:
+
+1. Preparing an image must not stall other UI updates / conversation
+   progress — :func:`test_image_decode_does_not_block_the_event_loop`.
+2. The decode step runs via ``asyncio.to_thread`` (flowview's own
+   ``FlowPresenter.present`` is already ``async`` and runs inside a Textual
+   worker — the NEW piece #4464 adds is threading the CPU-heavy decode
+   itself, not the already-async fetch) — the SAME test above witnesses
+   this directly (a synchronous decode would block the loop; a threaded one
+   does not), plus :func:`test_decoded_image_is_cached_after_resolution`
+   confirms the decode actually ran and its result is cached, not merely
+   that the loop stayed responsive for unrelated reasons.
+3. A "preparing" flowview entry must be VISIBLE while resolving, reusing
+   the existing ``_begin_running_indicator``/``_running_indicator``
+   convention (``tests/interfaces/test_textual_chat_phase2b_live_tool_3283.py``'s
+   own precedent) — :func:`test_presentation_entry_shows_the_running_indicator_while_resolving`
+   and :func:`test_multi_image_entry_stays_preparing_until_every_image_settles`.
+
+Real ``TextualChatApp`` + a real ``QueueTransport`` + a real ``ReynPresenter``
+throughout (mirrors ``test_3846_image_resolution_e2e.py``'s own established
+idiom) — ``httpx.AsyncClient`` is monkeypatched with a real-shaped stand-in
+(pin_ssrf's loopback denial is unconditional, so there is no real reachable
+collaborator to hit from CI), gated on a controllable ``asyncio.Event`` so
+the test can inspect the IN-FLIGHT state before releasing the fetch.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import httpx
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat._meta_keys import RUNNING_SINCE_KEY
+from reyn.interfaces.inline.textual_chat.presenter import ReynPresenter
+from reyn.runtime.outbox import OutboxMessage
+from tests._async_wait import wait_until
+from tests._support.textual_chat_test_helpers import QueueTransport
+
+
+def _png_bytes(size: tuple[int, int] = (32, 32)) -> bytes:
+    import io
+
+    from PIL import Image as PILImage
+
+    buf = io.BytesIO()
+    PILImage.new("RGB", size, color=(10, 20, 30)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+class _StreamResp:
+    def __init__(self, *, body: bytes, gate: "asyncio.Event | None" = None) -> None:
+        self.headers = httpx.Headers({"content-type": "image/png"})
+        self.status_code = 200
+        self._body = body
+        self._gate = gate
+
+    def raise_for_status(self) -> None:
+        pass
+
+    async def aiter_bytes(self):  # noqa: ANN201
+        if self._gate is not None:
+            await self._gate.wait()
+        yield self._body
+
+
+class _StreamCtx:
+    def __init__(self, resp: "_StreamResp") -> None:
+        self._resp = resp
+
+    async def __aenter__(self) -> _StreamResp:
+        return self._resp
+
+    async def __aexit__(self, *a: object) -> None:
+        return None
+
+
+def _client_factory(resp: "_StreamResp"):
+    class _Client:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_Client":
+            return self
+
+        async def __aexit__(self, *a: object) -> None:
+            return None
+
+        def stream(self, method: str, url: str) -> _StreamCtx:
+            return _StreamCtx(resp)
+
+    return _Client
+
+
+def _presentation_frame(src: str, alt: str = "a photo") -> OutboxMessage:
+    return OutboxMessage(
+        kind="presentation",
+        text="",
+        meta={"nodes": [{"component": "image", "src": src, "alt": alt}]},
+    )
+
+
+async def _entry_text(app: TextualChatApp, entry: object) -> str:
+    import io
+
+    from rich.console import Console
+
+    presentation = await app._presenter.present(entry.item, width=100)
+    buf = io.StringIO()
+    Console(file=buf, color_system=None, width=100).print(presentation.renderable)
+    return buf.getvalue()
+
+
+# ── 1+2: decode runs off the event loop ─────────────────────────────────────
+
+class _FakeEntry:
+    """The minimal surface `_resolve_image` calls on its `entry` param
+    (`.update()`) — a real `textual_flowview.Entry` needs a live `FlowModel`
+    to construct, which this presenter-only test has no reason to stand up
+    (mirrors `begin_image_resolution`'s own module docstring: the presenter
+    only ever calls `.update()` on it)."""
+
+    def update(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_image_decode_does_not_block_the_event_loop(monkeypatch) -> None:
+    """Tier 2: #4464 requirement 1+2 — a slow decode must not stall a
+    concurrent coroutine. Patches ``decode_image_body`` to a genuinely
+    CPU-blocking call (``time.sleep``, not ``asyncio.sleep`` — the real
+    failure mode is synchronous CPU work on the loop, and only a real
+    blocking call reproduces that); a concurrent ticking task must keep
+    advancing THROUGHOUT the decode if — and only if — it actually runs on
+    a background thread via ``asyncio.to_thread``.
+
+    Falsifiable directly: reverting ``_resolve_image`` to call
+    ``decode_image_body`` inline (no ``asyncio.to_thread``) would freeze
+    the ticking task for the full sleep duration, and this test would fail
+    (the tick count during the window would stay ~0 instead of climbing)."""
+    monkeypatch.setattr(
+        "reyn.interfaces.repl.present_renderer.decode_image_body",
+        lambda body: (time.sleep(0.15) or object()),
+    )
+    presenter = ReynPresenter()
+    ticks = 0
+    stop = False
+
+    async def _ticker() -> None:
+        nonlocal ticks
+        while not stop:
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+    ticker_task = asyncio.create_task(_ticker())
+    entry = _FakeEntry()
+    try:
+        monkeypatch.setattr(
+            httpx, "AsyncClient", _client_factory(_StreamResp(body=_png_bytes()))
+        )
+        await presenter._resolve_image(entry, "https://example.com/x.png", None)
+    finally:
+        stop = True
+        await ticker_task
+
+    assert ticks >= 5, (
+        f"only {ticks} event-loop ticks landed during a 150ms decode — "
+        "the decode likely ran synchronously on the loop, blocking it"
+    )
+    assert presenter.has_decoded_image("https://example.com/x.png")
+
+
+@pytest.mark.asyncio
+async def test_decoded_image_is_cached_after_resolution(monkeypatch) -> None:
+    """Tier 2: #4464 requirement 2's own positive witness — after a real
+    fetch+decode settles, the decoded renderable is cached (public
+    accessor, not private-state), so a later render can skip the decode
+    entirely (`_render_image`'s own cache-hit branch, #4463's PR)."""
+    monkeypatch.setattr(
+        httpx, "AsyncClient", _client_factory(_StreamResp(body=_png_bytes()))
+    )
+    presenter = ReynPresenter()
+    entry = _FakeEntry()
+    src = "https://example.com/y.png"
+    assert not presenter.has_decoded_image(src)
+    await presenter._resolve_image(entry, src, None)
+    assert presenter.has_decoded_image(src)
+
+
+# ── 3: preparing entry is visible ───────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_presentation_entry_shows_the_running_indicator_while_resolving(
+    monkeypatch,
+) -> None:
+    """Tier 2: #4464 requirement 3 — a presentation entry with an unresolved
+    image carries the SAME `_RUNNING_SINCE_KEY` marker and renders the SAME
+    `_running_indicator` line a RUNNING tool row already does (no new
+    visual vocabulary) — then settles once resolution completes.
+
+    Gates the fetch on a controllable `asyncio.Event` so the IN-FLIGHT
+    state is inspected deterministically (no sleep-and-hope)."""
+    gate = asyncio.Event()
+    monkeypatch.setattr(
+        httpx, "AsyncClient", _client_factory(_StreamResp(body=_png_bytes(), gate=gate))
+    )
+    app = TextualChatApp(transport=QueueTransport())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._ingest_frame(_presentation_frame("https://example.com/z.png"))
+        await pilot.pause()
+        entry = list(app.query_one(FlowView).entries)[-1]
+
+        assert (entry.item.meta or {}).get(RUNNING_SINCE_KEY) is not None, (
+            "an in-flight image resolution must stamp the same RUNNING_SINCE_KEY "
+            "marker a RUNNING tool row uses"
+        )
+        text = await _entry_text(app, entry)
+        assert "elapsed" in text, (
+            f"expected the shared _running_indicator line ('elapsed Ns'), got: {text}"
+        )
+
+        gate.set()  # let the fetch complete
+        await wait_until(lambda: (entry.item.meta or {}).get(RUNNING_SINCE_KEY) is None)
+        settled_text = await _entry_text(app, entry)
+        assert "elapsed" not in settled_text, (
+            f"the running indicator must clear once resolution settles: {settled_text}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_multi_image_entry_stays_preparing_until_every_image_settles(
+    monkeypatch,
+) -> None:
+    """Tier 2: #4464 — an entry with TWO images does not settle (drop the
+    running indicator) until BOTH resolve, not just the first. Real
+    behavior, not a declared intent: the fast image is a real httpx
+    response that returns immediately; the slow one is gated on the SAME
+    controllable event as the single-image test above."""
+    gate = asyncio.Event()
+    fast_body = _png_bytes((8, 8))
+    slow_body = _png_bytes((16, 16))
+
+    class _MultiClient:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_MultiClient":
+            return self
+
+        async def __aexit__(self, *a: object) -> None:
+            return None
+
+        def stream(self, method: str, url: str) -> _StreamCtx:
+            if "slow" in url:
+                return _StreamCtx(_StreamResp(body=slow_body, gate=gate))
+            return _StreamCtx(_StreamResp(body=fast_body))
+
+    monkeypatch.setattr(httpx, "AsyncClient", _MultiClient)
+    app = TextualChatApp(transport=QueueTransport())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        msg = OutboxMessage(
+            kind="presentation",
+            text="",
+            meta={"nodes": [
+                {"component": "image", "src": "https://example.com/fast.png", "alt": "fast"},
+                {"component": "image", "src": "https://example.com/slow.png", "alt": "slow"},
+            ]},
+        )
+        app._ingest_frame(msg)
+        await pilot.pause()
+        entry = list(app.query_one(FlowView).entries)[-1]
+
+        await wait_until(lambda: app._presenter.has_cached_image("https://example.com/fast.png"))
+        # The fast image settled, but the slow one has not — the entry must
+        # STILL be marked preparing (this is the real bug a naive
+        # "strip on first settle" implementation would have).
+        assert (entry.item.meta or {}).get(RUNNING_SINCE_KEY) is not None, (
+            "entry settled after only ONE of two images resolved"
+        )
+
+        gate.set()
+        await wait_until(lambda: (entry.item.meta or {}).get(RUNNING_SINCE_KEY) is None)
+        presenter = app._presenter
+        assert presenter.has_cached_image("https://example.com/slow.png")


### PR DESCRIPTION
**[tui-coder]** — #4464: image preparation off the event loop + a visible preparing entry.

owner's 3 requirements (verbatim, quoted in #4464):
1. Preparing an image must not stall other UI updates / conversation progress.
2. Use flowview's own async-callback support.
3. A "preparing" state must be visible as a flowview entry — reusing the existing running-tool convention, not inventing a new one.

## 1+2: decode runs off the event loop

lead-coder's own investigation (quoted in the issue) found the fetch itself was already non-blocking (`asyncio.create_task` + `await fetch_image_bytes`, real httpx async) — the CPU cost left on the loop was the PIL decode + `TextualImage(...)` construction (measured directly: ~100-300ms for a large real photo vs ~10ms for the sixel-encode step at paint time). `ReynPresenter._resolve_image` now runs that decode via `asyncio.to_thread`, through a new shared `decode_image_body(body)` helper (`present_renderer.py`) so the logic isn't duplicated between the off-thread path and `_render_image`'s own inline fallback (kept for every pre-#4464 caller with no `decoded_image_cache` threaded).

The decoded renderable is cached in a new `ReynPresenter._decoded_image_cache` dict (evicted in lockstep with `_image_cache`'s own byte-cap eviction — #4376's own class of bug, a lingering entry after eviction), exposed via a new public `has_decoded_image(src)` accessor mirroring `has_cached_image`'s established pattern. `_render_image` consults it FIRST — a cache hit skips decode entirely at render time.

## 3: the preparing state is visible

`_begin_image_resolutions` (app.py) now calls the EXISTING `_begin_running_indicator` (the same mechanism a RUNNING tool-call row already uses) when at least one image node needs resolving — stamping the same `_RUNNING_SINCE_KEY` marker and starting the same per-entry `animate_entry` ticker. `_body_and_background`'s presentation branch appends the EXISTING `_running_indicator(msg, now)` line (spinner + elapsed) below the rendered nodes when that marker is present — the SAME function a RUNNING tool row's own live body already calls, not a new one.

Each image's `on_settled` callback (threaded through `begin_image_resolution`/`_resolve_image`, since the presenter itself has no `FlowView` reference to stop an animation with) re-checks every image src the SAME entry owns; only once none remain unresolved does it call `stop_entry_animation` + strip `_RUNNING_SINCE_KEY` (mirroring `_coalesce_tool_result`'s own settle-time stripping) — an entry with two images doesn't flip back to static after only the first settles.

## Live verify (real turn, real WezTerm window, personally inspected)

A single window-scoped `screencapture -l <windowID>` (never full-screen) captured mid-preparation of a real 4.2MB photo through a real turn (real LLM via the local litellm proxy → real router loop → real `present` op → real TUI paint) shows, simultaneously:
- the reused running-indicator (`⠹ elapsed 0s`) on the still-preparing image entry, and
- freshly-typed text sitting live in the input box — proof the UI was not frozen during preparation.

Posted to #4464 for the owner's morning review: https://github.com/tya5/reyn/issues/4464

## Tests (all falsify-verified)

- `test_image_decode_does_not_block_the_event_loop` — patches `decode_image_body` to a genuinely CPU-blocking `time.sleep(0.15)`; asserts a concurrent ticking coroutine keeps advancing throughout. Falsify-verified: reverting `_resolve_image` to call `decode_image_body` inline reproduces 0 ticks during the window.
- `test_decoded_image_is_cached_after_resolution` — the positive witness for `has_decoded_image`.
- `test_presentation_entry_shows_the_running_indicator_while_resolving` — gates the fetch on a controllable `asyncio.Event`; asserts `_RUNNING_SINCE_KEY` + the `elapsed` text are present mid-flight and gone after settle. Real `TextualChatApp` + `QueueTransport`.
- `test_multi_image_entry_stays_preparing_until_every_image_settles` — two images, one fast/one gated; asserts the entry stays marked preparing after only the FAST one settles. Falsify-verified: a naive "strip-on-first-settle" `on_settled` (no per-src recheck) makes this test fail with the exact real bug reproduced.

## Test plan

- [x] 4 new tests, all falsify-verified — see above
- [x] Regression: `tests/interfaces/test_4464_*`, `tests/core/test_3846_*`, `test_present_renderer_fp0054_prb.py`, `test_present_op_fp0054_pra.py`, `test_4376_image_cache_bounded.py`, `test_textual_chat_phase2_3273.py`, `test_textual_chat_phase2b_live_tool_3283.py`, `test_textual_chat_row_contrast_3367.py`, `test_textual_chat_orphan_sweep_72.py` — 118 passed
- [x] `ruff check`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py` — all clean, path-literal gate re-run fresh right before push per CLAUDE.md
- [x] Visual: real turn, real WezTerm window, window-scoped screenshot, personally inspected, posted to #4464 for the owner's morning review (owner is asleep)

part of #4464

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

- [x] 🔴 **[lead-coder]**（reviewer 確認済 — 追加テストを読み、falsify の形も確認しました。実際に DEAD 分岐が見つかっており、block の目的は果たされています）`_render_image` の cache-hit 分岐を witness するテストが 1 本足りない — 今は分岐を削っても 4 本とも緑（渡された ≠ 使った、#3859 の形）。cache を温めた状態で `_render_image` を呼び、decode が走らないことを 1 本。falsify も同時に取れる。

- [x] **[tui-coder]** 追加: `test_render_image_uses_a_warm_decoded_cache_without_decoding_again`（call-counting spy + printed-text witness、private state不使用）。**このテストを書く過程で実バグを発見** — `render_presentation_nodes`が`decoded_image_cache`を`_render_node`に一切渡していなかった（作業ツリー再構築時の再構成漏れ）。cache-hit分岐自体はDEADだった。修正しfalsify-verified、119 passed、gate全clean。


