### PR TITLE
docs(#4431): three append-only remainders — budget-config unit, ratio-4 caveat, gate limit

### DIFF
--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -298,6 +298,20 @@ class OffloadConfig:
     ``structured_inline_max_chars`` / ``structured_preview_chars``
         The same two questions for a STRUCTURED (dict/list) result: the size at
         which it goes to its own ref, and how much of it stays inline.
+
+    #4381's resource-vs-budget ROLE split (see ``ReadCapConfig`` above): every
+    field here is BUDGET-role — ``cap_ceil_tokens``/``cap_alpha`` are TOKENS,
+    model-derived via ``effective_trigger``; ``max_inline_bytes``,
+    ``preview_head_chars``/``preview_tail_chars``, and
+    ``structured_inline_max_chars``/``structured_preview_chars`` name their
+    own unit already (bytes/chars) but are still budget-role — they bound
+    what stays in the conversation the model reads, not a resource-role
+    physical ceiling like ``ReadCapConfig``'s. This is stated explicitly
+    (#4431 follow-up) because the unit being IMPLICIT is exactly the shape
+    #4381's loop happened in: two caps compared without either side naming
+    its own ROLE or unit. Any cross-ROLE comparison against a resource-role
+    value MUST go through ``context_builder.INLINE_CAP_BYTES_PER_TOKEN``,
+    never a second independently-derived ratio.
     """
     enabled: bool = False
     max_inline_bytes: int = 16_384

--- a/src/reyn/core/context_builder.py
+++ b/src/reyn/core/context_builder.py
@@ -79,6 +79,12 @@ MAX_CONTROL_IR_RESULT_INLINE_BYTES: int = 10_240   # 10 KiB default
 # meaning under the old name (a literal ~4 bytes-per-token approximation
 # for UTF-8-mixed text is the same rough average commonly used for chars,
 # so the NUMBER is unchanged; only the unit label is corrected).
+#
+# #4431 follow-up (architect, explicit): the NUMBER 4 itself has never been
+# empirically verified against a real tokenizer — carrying it forward under
+# a corrected unit label is "put the ONE existing value behind the ONE named
+# conversion point," not a claim that 4 is the right ratio. Do not read this
+# constant's existence as evidence the value was measured.
 INLINE_CAP_BYTES_PER_TOKEN: int = 4
 
 

--- a/tests/security/test_4421_litellm_import_seam.py
+++ b/tests/security/test_4421_litellm_import_seam.py
@@ -54,6 +54,19 @@ invisible to an AST scan by construction. Architect's own #4415 recount
 found exactly this gap once already (an attribute-access path an earlier
 count had not measured). This gate closes the "a literal import statement
 outside the seam" half of the class, not the whole class.
+
+**#4421's own follow-up, #4450: the excluded files' insides are not
+watched either.** This gate treats ``litellm_bootstrap.py`` as trusted
+once it's on the exclusion list — it never inspects what that seam file's
+own body does. #4450 found a real bug entirely INSIDE that excluded file
+(``_capture_client_cache_baseline()``'s own unconditional second
+``import litellm``, reopening the exact race #4419 closed, on the
+first-import-failure path) that this gate could not have caught: the
+statement triggering it lives in the one file this gate is built to
+ignore. The scope this docstring already states above ("this gate scans
+``src/reyn`` only, not ``tests/``" / the third-party-touch limit) is
+still accurate — it just doesn't cover this angle, which #4450 made
+concrete rather than hypothetical.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
**[docs-maintainer]** — Three small append-only additions (lead-coder dispatch, while PR-2b sits on `owner:decide`). None rewrite existing text — all are pure additions to docstrings/comments that are still accurate as written.

## 1. `OffloadConfig` (`src/reyn/config/chat.py`) — name it explicitly as #4381's BUDGET-role config

Appended a paragraph stating every field here is BUDGET-role (tokens, model-derived via `effective_trigger`), naming the unit explicitly. #4431's own settled note: the unit being implicit is exactly the shape the #4381 loop happened in — two caps compared without either side naming its own ROLE/unit.

## 2. `context_builder.INLINE_CAP_BYTES_PER_TOKEN` — the literal `4` is unverified

Appended a comment above the constant: the number itself has never been empirically measured against a real tokenizer. Carrying it forward under the corrected (bytes, not chars) unit label names the ONE conversion point (architect's own instruction) — it is not a claim the ratio is correct.

## 3. `tests/security/test_4421_litellm_import_seam.py`'s "Known limit" section

Appended: the gate's excluded files (`litellm_bootstrap.py`) are trusted wholesale once on the exclusion list — their own insides are never inspected. #4450 found a real bug entirely inside that excluded file (`_capture_client_cache_baseline()`'s own unconditional second `import litellm`) this gate could not have caught by construction — the statement lives in the one file the gate is built to ignore.

## Also posted

A "settled / remaining" note to #4431 itself: architect's own undetermined item ("A's implementation site — unconfirmed whether config resolution sees both") is now settled by #4451 (PR-1, SSoT) + #4460 (PR-5, byte resource bound) — the issue's own undetermined list had gone stale.

## Unrelated finding, flagged separately (not in this PR)

`scripts/mypy_ratchet.py` currently fails on `main` itself (4 new file/code pairs under `src/reyn/mcp/`) — confirmed via `git stash` that it's pre-existing, unrelated to this diff, and traces to the recent mcp 2.0 pin-bump landings (#4459/#4465). Reporting to lead-coder separately rather than folding an unrelated fix into this append-only PR.

part of #4431

## Test plan

- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict tests/security/test_4421_litellm_import_seam.py` — 3/3 OK
- [x] `verify_module_docstrings.py` on both edited src files — clean
- [x] `check_tests_path_literal_reference.py` — clean
- [x] `pytest tests/security/test_4421_litellm_import_seam.py` — 3 passed
- [x] `pytest tests/core/ -k "chat_config or offload"` — 47 passed (scoped safety check around the edited `OffloadConfig` docstring)
- [x] (skipped — `mypy_ratchet.py` is pre-existing red on `main`, unrelated to this diff; see note above)
