### PR TITLE
feat(#4387): Phase B ③ -- bound Session.history's resident footprint (bytes, resource role)

### DIFF
--- a/docs/concepts/runtime/capability-profile.md
+++ b/docs/concepts/runtime/capability-profile.md
@@ -195,23 +195,38 @@ declaring an empty deny-set.
 stamp it today: an external peer's `ask_user` answer (A2A / webhook), and the
 result of any tool declaring `returns_external_content` (e.g. web fetch) — both
 land in `self.history` meta, and the narrowing check (`metas_have_untrusted`)
-live-scans the RESIDENT `self.history` on every turn rather than caching the
-verdict, so the very next dispatch after an external tool-result lands is
-already narrowed, and the narrowing self-clears once that entry compacts out of
-context. Under `iteration` the engagement is additionally *latched* for the
-rest of the turn, so a compaction that evicts the tainted entry mid-turn
-cannot launder the taint away and recover the capability before the turn ends.
+scans the logical ACTIVE window (every entry with `seq` above the compaction
+watermark) on every turn rather than caching the verdict — **resident-ness is
+a resource concern, not the decision criterion**: whether an entry currently
+happens to be resident in memory is orthogonal to whether it is still
+logically part of the active conversation, and the scan's job is the latter,
+never the former. So the very next dispatch after an external tool-result
+lands is already narrowed, and the narrowing self-clears once that entry
+**compacts out** — a semantic operation (its content is genuinely replaced by
+a summary and leaves the model's context) — never merely because it stopped
+being resident. Under `iteration` the engagement is additionally *latched*
+for the rest of the turn, so a compaction that evicts the tainted entry
+mid-turn cannot launder the taint away and recover the capability before the
+turn ends.
 
-**#4387/#4468: a second, independent latch for a second kind of eviction.**
-Session.history now also has a resident-BYTE cap (#4387), unrelated to
-compaction — it can evict an entry that is still "active" (`seq` above the
-compaction watermark) purely because memory is tight, well before compaction
-would have folded it away. Since the live-scan above only ever sees resident
-entries, that eviction would silently drop the taint signal the same way a
-mid-turn compaction eviction could — so `_evict_oldest_resident_entries`
-latches the highest `seq` among any evicted entry that carried the untrusted
-marker (`Session._max_evicted_untrusted_seq`), and the scan ORs that latch in
-alongside the in-flight one. This latch is monotone and never blocks or
+**#4387/#4468: a second, independent latch closing a resource/semantic role
+crossing.** Session.history now also has a resident-BYTE cap (#4387) — a
+RESOURCE-role operation (#4431's role split), unrelated to compaction. It can
+evict an entry that is still logically active (`seq` above the compaction
+watermark) purely because memory is tight, well before compaction (the only
+SEMANTIC-role operation meant to retire an entry) would have folded it away —
+the entry stays durable in `history.jsonl` and reloads on demand, so it has
+not actually left the conversation. Without a fix, a scan that reads only
+resident entries would let this resource-role operation silently decide a
+semantic question it has no business deciding — so `_evict_oldest_resident_
+entries` latches the highest `seq` among any evicted entry that carried the
+untrusted marker (`Session._max_evicted_untrusted_seq`), and the scan ORs
+that latch in alongside the in-flight one. Deliberately keyed to the SAME
+extinction trigger as everything else on this page — the compaction
+watermark, never "no longer resident" — so eviction can set the latch but
+only compaction can clear it; tying it to residency instead would just
+reproduce this exact bug on the latch's own side. This latch is monotone and
+never blocks or
 delays eviction itself (no DoS surface from an attacker stuffing untrusted
 content to make eviction stall) — it self-clears the identical way the live
 scan does, the moment compaction's own watermark advances past the latched

--- a/docs/concepts/runtime/capability-profile.md
+++ b/docs/concepts/runtime/capability-profile.md
@@ -195,12 +195,27 @@ declaring an empty deny-set.
 stamp it today: an external peer's `ask_user` answer (A2A / webhook), and the
 result of any tool declaring `returns_external_content` (e.g. web fetch) — both
 land in `self.history` meta, and the narrowing check (`metas_have_untrusted`)
-live-scans `self.history` on every turn rather than caching the verdict, so the
-very next dispatch after an external tool-result lands is already narrowed, and
-the narrowing self-clears once that entry compacts out of context. Under
-`iteration` the engagement is additionally *latched* for the rest of the turn, so
-a compaction that evicts the tainted entry mid-turn cannot launder the taint away
-and recover the capability before the turn ends.
+live-scans the RESIDENT `self.history` on every turn rather than caching the
+verdict, so the very next dispatch after an external tool-result lands is
+already narrowed, and the narrowing self-clears once that entry compacts out of
+context. Under `iteration` the engagement is additionally *latched* for the
+rest of the turn, so a compaction that evicts the tainted entry mid-turn
+cannot launder the taint away and recover the capability before the turn ends.
+
+**#4387/#4468: a second, independent latch for a second kind of eviction.**
+Session.history now also has a resident-BYTE cap (#4387), unrelated to
+compaction — it can evict an entry that is still "active" (`seq` above the
+compaction watermark) purely because memory is tight, well before compaction
+would have folded it away. Since the live-scan above only ever sees resident
+entries, that eviction would silently drop the taint signal the same way a
+mid-turn compaction eviction could — so `_evict_oldest_resident_entries`
+latches the highest `seq` among any evicted entry that carried the untrusted
+marker (`Session._max_evicted_untrusted_seq`), and the scan ORs that latch in
+alongside the in-flight one. This latch is monotone and never blocks or
+delays eviction itself (no DoS surface from an attacker stuffing untrusted
+content to make eviction stall) — it self-clears the identical way the live
+scan does, the moment compaction's own watermark advances past the latched
+`seq`.
 
 **Built-in deny-set:** memory writes/deletes, re-delegation, sandboxed
 execution, MCP / skill / pipeline install, session and agent spawn, pipeline run.

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -1747,6 +1747,21 @@ read_cap:
 
 **Why 10 KiB**: both consumers gained a resume mechanism the same night this default was chosen — `file.read` via `char_offset` (#4432), `load_skill` via deferring to `read_file(offset=next_offset)` (#4431). A truncated read loses at most one round-trip, not the rest of the content, which is what makes a small default safe rather than arbitrary. Omitting the block keeps this default (behaviour unchanged).
 
+## `history_resident` block
+
+Caps `Session.history`'s in-memory footprint (#4387 Phase B ③, applying #4431's resource/budget role split — see the `read_cap` block above for the full rationale). Same role as `read_cap`: a **resource bound**, measured in **bytes**, **model-independent**. Deliberately a different axis from the on-demand backward-read window (`_HISTORY_HYDRATE_MIN_LINES`, measured in lines) — the two answer different questions ("how much stays resident" vs. "how much is read per on-demand fetch") and are kept as separate knobs on purpose, per #4387's own architect review naming the risk of conflating them.
+
+```yaml
+history_resident:
+  max_bytes: 268435456   # 256 MiB — ceiling on Session.history's resident size
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `max_bytes` | int | `268435456` (256 MiB) | Ceiling, in bytes, on `Session.history`'s in-memory footprint. Once exceeded, the oldest resident entries are evicted (never the just-appended newest one) until the cap is met again. A non-positive or non-numeric value falls back to the default. |
+
+Eviction is not information loss: `Session.history` is a cache, not the source of truth — `history.jsonl` (append-only, on disk) is, and every entry evicted from memory reloads on demand via the already-shipped backward-hydrate path (TUI scrollback paging, in-conversation search, and WAL rewind visibility all already page older entries back in as needed). This closes an unbounded-growth defect (`self.history` previously had no cap at all — see #4387) independent of any claim about what fraction of a given memory ceiling `history` itself accounts for, which this config does not measure or claim to fix.
+
 ## MCP servers
 
 External tool servers reyn can call via the [Model Context Protocol](../../concepts/tools-integrations/mcp.md). Each entry under `mcp.servers:` is keyed by a short name (the same name the skill declares in `permissions.mcp` and emits in `mcp` ops).

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -645,6 +645,23 @@
 
 
 # -----------------------------------------------------------------------------
+# history_resident: caps Session.history's in-memory footprint (#4387 Phase B
+# ③, #4431's role split). A RESOURCE BOUND — unit is BYTES, model-INDEPENDENT,
+# same role as read_cap above (never the same axis as the on-demand backward-
+# read window, which is in LINES — deliberately kept separate). Omit the
+# block to keep the 256 MiB default below; a non-positive/non-numeric value
+# falls back to that default too.
+#
+# Eviction is NOT information loss: anything evicted stays durable in
+# history.jsonl and reloads on demand via the already-shipped backward-
+# hydrate path (TUI scrollback paging / search / WAL rewind visibility) —
+# it only bounds what stays resident in memory.
+# -----------------------------------------------------------------------------
+# history_resident:
+#   max_bytes: 268435456   # 256 MiB — ceiling on Session.history's resident size
+
+
+# -----------------------------------------------------------------------------
 # tool_use: the chat-layer tool-use scheme x transport selector (#1593;
 # FP-0066 P4b, #3247). ``scheme`` is the PRESENTATION axis (category /
 # enumerate-all / retrieval — how capabilities are shown/discovered);

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -486,6 +486,64 @@ def _build_read_cap_config(raw: object) -> "ReadCapConfig":
 
 
 @dataclass
+class HistoryResidentConfig:
+    """`history_resident:` — a RESOURCE-BOUND cap on ``Session.history``'s
+    in-memory footprint (#4387 Phase B ③, applying #4431's role split).
+
+    **Unit is BYTES** — the resource role (#4431: "資源 role = bytes, model
+    非依存, config で可変"), matching ``ReadCapConfig.inline_bytes``'s own
+    unit for the identical reason: a resource bound protects a fixed
+    physical quantity (process memory), which is byte-denominated
+    regardless of any model's context window.
+
+    **Deliberately NOT the same axis as ``_HISTORY_HYDRATE_MIN_LINES``**
+    (``session.py``'s on-demand backward-read granularity, in LINES) — #4387's
+    own architect review named conflating the two as the risk to avoid
+    ("窓の定義が2つになる...混ぜると3つ目の単位が増える"). This cap bounds
+    how much stays RESIDENT; the hydrate window bounds how much is read PER
+    on-demand fetch. Two different questions, two different units, kept
+    separate on purpose.
+
+    **What this does NOT claim**: owner reported a ~6GB memory ceiling: this
+    config gives ``self.history`` a bound where it previously had none
+    (six-question checklist ⑤ — nobody gave it a limit), but whether
+    ``history`` was the ~6GB's actual majority contributor was explicitly
+    left UNMEASURED (#4387's own body says so) and remains so. This closes
+    the "unbounded growth" defect on its own terms, independent of that
+    open question.
+
+    Default is generous (256 MiB) — the whole point (per #4387/#4431's
+    architect derivation) is that eviction is NOT information loss: anything
+    evicted stays durable in ``history.jsonl`` and reloads on demand via the
+    already-shipped backward-hydrate path (#4400/#4411), so a large default
+    costs nothing but memory an operator can already afford, while a too-small
+    one would make ordinary scrollback/rewind pay for reloads more often than
+    necessary.
+    """
+    max_bytes: int = 256 * 1024 * 1024  # 256 MiB
+
+
+def _build_history_resident_config(raw: object) -> "HistoryResidentConfig":
+    """Parse the `history_resident:` section (#4387 Phase B ③).
+
+    Missing or malformed -> default (256 MiB). A non-numeric or non-positive
+    value falls back to the default — same discipline as
+    ``_build_read_cap_config``: an operator typo must not silently disable
+    the cap (zero/negative would evict everything or never fire)."""
+    if not isinstance(raw, dict):
+        return HistoryResidentConfig()
+    defaults = HistoryResidentConfig()
+    max_bytes = raw.get("max_bytes", defaults.max_bytes)
+    try:
+        max_bytes = int(max_bytes)
+        if max_bytes <= 0:
+            max_bytes = defaults.max_bytes
+    except (TypeError, ValueError):
+        max_bytes = defaults.max_bytes
+    return HistoryResidentConfig(max_bytes=max_bytes)
+
+
+@dataclass
 class SpawnConfig:
     """`safety.spawn:` — operator bounds on the LLM spawn tree (#2103 C3).
 

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -11,6 +11,7 @@ from reyn.config.chat import (  # #1682 #3 cross-section
     _build_chat_config,
     _build_cost_config,  # #1682 #3: cost builder lives in chat
     _build_cost_warn_config,
+    _build_history_resident_config,
     _build_offload_config,
     _build_read_cap_config,
     _build_render_template_config,
@@ -820,6 +821,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
     offload = _build_offload_config(merged.get("offload"))
     render_template = _build_render_template_config(merged.get("render_template"))
     read_cap = _build_read_cap_config(merged.get("read_cap"))
+    history_resident = _build_history_resident_config(merged.get("history_resident"))
     # #4174 T3: model / models / model_class_by_purpose / api_base /
     # prompt_cache_enabled moved from top-level ReynConfig fields into
     # ``llm:`` — _build_llm_config parses all of it (router/retry AND the
@@ -851,6 +853,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         offload=offload,
         render_template=render_template,
         read_cap=read_cap,
+        history_resident=history_resident,
         web_fetch=_build_web_fetch_config(merged.get("web_fetch")),
         gateway=_build_gateway_config(merged.get("gateway")),
         multimodal=_build_multimodal_config(merged.get("multimodal")),

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -30,6 +30,7 @@ from reyn.config.chat import (
     ChatConfig,
     CompactionConfig,
     CostWarnConfig,
+    HistoryResidentConfig,
     LoopConfig,
     OffloadConfig,
     OnLimitConfig,
@@ -218,6 +219,10 @@ class ReynConfig:
     # bytes, model-independent, config-driven (architect design). Default
     # 10 KiB.
     read_cap: ReadCapConfig = field(default_factory=ReadCapConfig)
+    # #4387 Phase B ③: the resource-bound cap on Session.history's resident
+    # footprint — bytes, model-independent, config-driven (#4431's role
+    # split, same shape as read_cap above). Default 256 MiB.
+    history_resident: HistoryResidentConfig = field(default_factory=HistoryResidentConfig)
     # FP-0022 follow-up: declarative SSL config for web_fetch + MCP registry.
     # Priority: web_fetch.ca_bundle → web_fetch.verify_ssl → SSL_VERIFY env →
     # litellm.ssl_verify → SSL_CERT_FILE → True (default).

--- a/src/reyn/mcp/server.py
+++ b/src/reyn/mcp/server.py
@@ -126,6 +126,30 @@ def _new_agent_history_entries(
     matches are returned. This scopes reply harvesting to the caller's
     own chain so concurrent ``send_to_agent_impl`` calls (e.g. via the
     A2A FastAPI router) don't pick up each other's replies.
+
+    #4387 Phase B ③ re-audit (checked, not assumed — lead-coder's explicit
+    instruction: "prepend で通る ≠ evict で通る"): ``self.history`` can now
+    also shrink from the FRONT (oldest-first eviction, bounding resident
+    memory — the symmetric, opposite-direction operation of the #4404
+    prepend fix this function's ``seq``-based filter was originally built
+    for). Eviction removes only the entries with the LOWEST ``seq`` values
+    currently resident, so the common case — normal turn-by-turn growth
+    evicting entries OLDER than any live ``baseline_seq`` — is safe by the
+    same construction #4404 already relies on (a coordinate filter, immune
+    to ANY reshuffling of position, prepend or evict alike).
+
+    One genuine, narrow limitation this re-audit surfaced (see
+    ``tests/runtime/test_4387_history_resident_eviction.py::
+    test_mcp_baseline_harvest_narrow_gap_when_the_harvest_window_itself_exceeds_the_cap``):
+    if growth BETWEEN capturing ``baseline_seq`` and calling this function
+    itself exceeds the resident byte cap, eviction can remove even
+    post-baseline entries (whichever are oldest among what's resident at
+    eviction time) — this function would then under-report, silently
+    missing an early reply from a very large harvest window. Inherent to
+    any byte-bounded resident cache, not a defect fixable here without
+    unbounding the cache entirely (which would reopen #4387's own reason
+    for existing) — documented as a checked, honest boundary rather than
+    assumed safe.
     """
     out: list[str] = []
     for msg in session.history:

--- a/src/reyn/runtime/factory_config.py
+++ b/src/reyn/runtime/factory_config.py
@@ -43,6 +43,11 @@ class SessionFactoryConfig:
     # per-result inline cap (file.py's read op + load_skill.py). Same
     # shape as web_fetch_config: a plain value, not a per-turn supplier.
     read_cap_config: Any
+    # #4387 Phase B ③: reyn.yaml history_resident.* (max_bytes) — the
+    # resource-bound cap on Session.history's in-memory footprint. Same
+    # shape/role as read_cap_config (#4431's role split): bytes,
+    # model-independent, config-driven.
+    history_resident_config: Any
     action_retrieval_config: Any
     embedding_config: Any
     router_config: Any
@@ -122,6 +127,8 @@ class SessionFactoryConfig:
             web_fetch_config=config.web_fetch,
             # #4381 PR-5: the resource-bound read cap config.
             read_cap_config=config.read_cap,
+            # #4387 Phase B ③: the resource-bound history-resident cap config.
+            history_resident_config=config.history_resident,
             action_retrieval_config=config.action_retrieval,
             embedding_config=config.embedding,
             router_config=config.llm.router,

--- a/src/reyn/runtime/scoped_session_factory.py
+++ b/src/reyn/runtime/scoped_session_factory.py
@@ -164,6 +164,7 @@ def build_scoped_chat_session(
         multimodal_config=factory_config.multimodal_config,
         web_fetch_config=factory_config.web_fetch_config,  # #4274
         read_cap_config=factory_config.read_cap_config,  # #4381 PR-5
+        history_resident_config=factory_config.history_resident_config,  # #4387 Phase B ③
         action_retrieval_config=factory_config.action_retrieval_config,
         embedding_config=factory_config.embedding_config,
         router_config=factory_config.router_config,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -26,6 +26,7 @@ from reyn.config import (  # noqa: F401
     AuditEventsConfig,
     CostWarnConfig,
     EmbeddingConfig,
+    HistoryResidentConfig,
     MultimodalConfig,
     OffloadConfig,
     OnLimitConfig,
@@ -918,6 +919,9 @@ class Session:
         # #4381 PR-5: the resource-bound per-result inline cap (file.py read op +
         # load_skill.py). None → context_builder's own model-independent default.
         read_cap_config: "ReadCapConfig | None" = None,
+        # #4387 Phase B ③: the resource-bound cap on self.history's resident
+        # footprint (bytes). None → HistoryResidentConfig's own default (256 MiB).
+        history_resident_config: "HistoryResidentConfig | None" = None,
         state_log: StateLog | None = None,
         budget_tracker: BudgetTracker | None = None,
         snapshot_path: "Path | None" = None,
@@ -1044,6 +1048,9 @@ class Session:
         # resource/budget invariant check, and into OpContext.read_cap_config
         # for file.py's/load_skill.py's own read op (via RouterOpContextSource).
         self._read_cap_config = read_cap_config
+        # #4387 Phase B ③: bounds self.history's resident footprint —
+        # consulted by _append_history's eviction hook (below).
+        self._history_resident_config = history_resident_config or HistoryResidentConfig()
         # Single MediaStore instance per Session (#383 PR-C, see session-construction.md#multimodal-media)
         from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
         if multimodal_config is not None:
@@ -2856,6 +2863,62 @@ class Session:
         self.history.append(msg)
         with self.history_path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(asdict(msg), ensure_ascii=False) + "\n")
+        self._evict_oldest_resident_entries()
+
+    def _evict_oldest_resident_entries(self) -> int:
+        """#4387 Phase B ③: cap ``self.history``'s in-memory footprint at
+        ``self._history_resident_config.max_bytes``, evicting from the FRONT
+        (oldest first) — the symmetric, opposite-direction operation of
+        :meth:`_load_older_entries`'s prepend (architect's #4387 derivation:
+        "追い出しは既に在って動いている操作の逆" — eviction is not
+        information loss, since ``history.jsonl`` is untouched and anything
+        evicted reloads on demand via the already-shipped backward-hydrate
+        path, #4400/#4411).
+
+        Recomputes the total resident size from scratch each call rather
+        than maintaining a running counter deliberately: ``self.history`` has
+        multiple direct-mutation call sites elsewhere (assignment, slicing —
+        e.g. ``_load_older_entries``'s own ``self.history[0:0] = parsed``,
+        and tests that reassign ``s.history`` directly to simulate a bounded
+        load), so an incrementally-maintained counter would silently drift
+        from the true resident set the first time any of those paths ran
+        without also updating it. Recomputing is O(n) per append, but n is
+        bounded by construction (that is the entire point of this cap), so
+        the cost stays small — and the invariant "resident size <= cap after
+        every append" holds by construction, with no cached state that could
+        desync from reality.
+
+        ONLY called from the tail-growth path (:meth:`_append_history`, a
+        normal turn appending the newest entry) — deliberately NOT called
+        after :meth:`_load_older_entries`'s backward-prepend. A caller that
+        explicitly asks to page further back (TUI scrollback / search /
+        ``_active_branch_history``'s rewind-visibility extension) wants those
+        entries resident; evicting them again immediately would silently
+        defeat the very feature #4400/#4411 built, thrashing between
+        "extend backward" and "evict the same entries straight back out."
+        A deep page-back can therefore transiently exceed the cap — that is
+        an explicit, bounded (by ``min_lines``) request the caller made, not
+        the unbounded tail-growth this cap exists to bound.
+
+        Returns the count evicted (0 = already within budget)."""
+        cap = self._history_resident_config.max_bytes
+        sizes = [
+            len(json.dumps(asdict(m), ensure_ascii=False).encode("utf-8"))
+            for m in self.history
+        ]
+        total = sum(sizes)
+        evict_count = 0
+        # Never evict the newest (last) entry, even if it alone exceeds the
+        # cap on its own — the entry just appended must stay resident so the
+        # turn that produced it remains immediately usable; an oversized
+        # single entry is a cap-sizing question for the operator, not
+        # something this method silently drops.
+        while total > cap and evict_count < len(sizes) - 1:
+            total -= sizes[evict_count]
+            evict_count += 1
+        if evict_count:
+            del self.history[:evict_count]
+        return evict_count
 
     def _active_branch_history(self) -> "list[ChatMessage]":
         """#2360: the conversation turns visible on the current active branch.

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1051,6 +1051,18 @@ class Session:
         # #4387 Phase B ③: bounds self.history's resident footprint —
         # consulted by _append_history's eviction hook (below).
         self._history_resident_config = history_resident_config or HistoryResidentConfig()
+        # #4468 security block (lead-coder review): the highest seq of any
+        # EVICTED entry that carried the untrusted-content marker
+        # (security.permissions.capability_profile.UNTRUSTED_META_KEY) —
+        # an OR-latch mirroring #4381 PR-2's in-flight latch, so
+        # _ephemeral_contextual_for_turn's narrowing scan (which only sees
+        # RESIDENT entries) doesn't silently lose an untrusted-taint signal
+        # to eviction. Monotone: only ever increases via
+        # _evict_oldest_resident_entries; self-clears the same way the
+        # resident scan does (the OR term drops out once the compaction
+        # watermark advances past this seq — see _ephemeral_contextual_for_
+        # turn's own comment on this field).
+        self._max_evicted_untrusted_seq = 0
         # Single MediaStore instance per Session (#383 PR-C, see session-construction.md#multimodal-media)
         from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
         if multimodal_config is not None:
@@ -2803,7 +2815,22 @@ class Session:
         # #4381 PR-2 stage ③: history scan OR the in-flight latch — the
         # latch covers a same-turn tool result whose history entry has not
         # landed yet (see the flag's own docstring in __init__ for why).
-        if not (metas_have_untrusted(m.meta for m in active) or self._in_flight_untrusted_this_turn):
+        # #4468 (lead-coder security review): OR a THIRD term —
+        # self._max_evicted_untrusted_seq's own OR-latch, covering an
+        # untrusted entry that WAS active (seq > watermark) but has since
+        # been evicted from self.history by #4387's resident-byte cap (the
+        # scan above only ever sees RESIDENT entries, so eviction would
+        # otherwise silently drop this signal — CLAUDE.md's own "removing
+        # one layer regrants a denied capability" shape). Self-clears the
+        # same way the resident scan does: once compaction advances the
+        # watermark past that seq, this term drops out on its own — no
+        # separate clearing logic needed, same monotone comparison either
+        # way.
+        if not (
+            metas_have_untrusted(m.meta for m in active)
+            or self._in_flight_untrusted_this_turn
+            or self._max_evicted_untrusted_seq > watermark
+        ):
             return None
         if self._untrusted_contextual_cache is None:
             root = self._perm.project_root if self._perm is not None else Path.cwd()
@@ -2917,6 +2944,24 @@ class Session:
             total -= sizes[evict_count]
             evict_count += 1
         if evict_count:
+            # #4468 security block (lead-coder review): before dropping
+            # them, latch the highest seq among the evicted entries that
+            # carried the untrusted-content marker — see
+            # self._max_evicted_untrusted_seq's own __init__ comment and
+            # _ephemeral_contextual_for_turn's OR-term for why. Checked
+            # here (not gated behind whether narrowing is enabled) since
+            # the cost is one dict-get per evicted entry regardless, and
+            # gating it would mean narrowing couldn't be turned on
+            # mid-session without a gap for whatever already evicted
+            # before the flag flipped.
+            from reyn.security.permissions.capability_profile import (
+                UNTRUSTED_META_KEY,
+            )
+            for m in self.history[:evict_count]:
+                if isinstance(m.meta, dict) and m.meta.get(UNTRUSTED_META_KEY):
+                    self._max_evicted_untrusted_seq = max(
+                        self._max_evicted_untrusted_seq, m.seq,
+                    )
             del self.history[:evict_count]
         return evict_count
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2816,16 +2816,19 @@ class Session:
         # latch covers a same-turn tool result whose history entry has not
         # landed yet (see the flag's own docstring in __init__ for why).
         # #4468 (lead-coder security review): OR a THIRD term —
-        # self._max_evicted_untrusted_seq's own OR-latch, covering an
-        # untrusted entry that WAS active (seq > watermark) but has since
-        # been evicted from self.history by #4387's resident-byte cap (the
-        # scan above only ever sees RESIDENT entries, so eviction would
-        # otherwise silently drop this signal — CLAUDE.md's own "removing
-        # one layer regrants a denied capability" shape). Self-clears the
-        # same way the resident scan does: once compaction advances the
-        # watermark past that seq, this term drops out on its own — no
-        # separate clearing logic needed, same monotone comparison either
-        # way.
+        # self._max_evicted_untrusted_seq's own OR-latch. #4387's
+        # resident-byte cap is a RESOURCE-role operation (#4431's role
+        # split); it can evict an entry that is still logically active
+        # (seq > watermark) purely because memory is tight, well before
+        # compaction (the only SEMANTIC-role operation meant to retire an
+        # entry) would fold it away. Without this term the resource-role
+        # cap would silently decide a semantic question it has no business
+        # deciding — CLAUDE.md's own "removing one layer regrants a denied
+        # capability" shape. Keyed to the SAME extinction trigger as the
+        # resident scan above (the compaction watermark) — eviction can SET
+        # this latch, only compaction can CLEAR it; clearing it on "no
+        # longer resident" instead would just reproduce this exact bug on
+        # the latch's own side.
         if not (
             metas_have_untrusted(m.meta for m in active)
             or self._in_flight_untrusted_this_turn

--- a/tests/config/test_4387_history_resident_config.py
+++ b/tests/config/test_4387_history_resident_config.py
@@ -1,0 +1,83 @@
+"""Tier 2: #4387 Phase B ③ — `history_resident:` config parsing.
+
+Mirrors `_build_read_cap_config`'s own tested shape (same discipline: a
+missing/malformed value falls back to the default rather than silently
+disabling the cap).
+"""
+from __future__ import annotations
+
+from reyn.config.chat import HistoryResidentConfig, _build_history_resident_config
+
+
+def test_missing_section_uses_default() -> None:
+    """Tier 2: no `history_resident:` key at all -> the shipped default (256 MiB)."""
+    cfg = _build_history_resident_config(None)
+    assert cfg == HistoryResidentConfig()
+    assert cfg.max_bytes == 256 * 1024 * 1024
+
+
+def test_valid_max_bytes_is_honored() -> None:
+    """Tier 2: an explicit, valid value is used verbatim."""
+    cfg = _build_history_resident_config({"max_bytes": 12_345})
+    assert cfg.max_bytes == 12_345
+
+
+def test_non_dict_section_uses_default() -> None:
+    """Tier 2: `history_resident: "oops"` (wrong shape) -> default, not a crash."""
+    cfg = _build_history_resident_config("oops")
+    assert cfg.max_bytes == HistoryResidentConfig().max_bytes
+
+
+def test_zero_or_negative_falls_back_to_default() -> None:
+    """Tier 2: an operator typo (0 or negative) must not silently disable the
+    cap (0 would evict everything on every append; negative is nonsensical)."""
+    assert _build_history_resident_config({"max_bytes": 0}).max_bytes == (
+        HistoryResidentConfig().max_bytes
+    )
+    assert _build_history_resident_config({"max_bytes": -5}).max_bytes == (
+        HistoryResidentConfig().max_bytes
+    )
+
+
+def test_non_numeric_falls_back_to_default() -> None:
+    """Tier 2: a non-numeric value (e.g. a YAML string) -> default, not a crash."""
+    cfg = _build_history_resident_config({"max_bytes": "not-a-number"})
+    assert cfg.max_bytes == HistoryResidentConfig().max_bytes
+
+
+def test_reyn_config_default_reaches_history_resident_field() -> None:
+    """Tier 2: wiring sanity — `ReynConfig.history_resident` exists and
+    resolves to the same default when no reyn.yaml section is present,
+    proving the loader-level `merged.get("history_resident")` -> ReynConfig
+    path is actually connected, not just the parser function in isolation."""
+    import tempfile
+    from pathlib import Path
+
+    from reyn.config.loader import load_config
+
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        (root / "reyn.yaml").write_text(
+            "llm:\n  models:\n    standard: fake/x\n", encoding="utf-8",
+        )
+        cfg = load_config(cwd=root)
+    assert cfg.history_resident == HistoryResidentConfig()
+
+
+def test_reyn_config_honors_an_explicit_history_resident_section() -> None:
+    """Tier 2: the real end-to-end path — a `history_resident:` section in a
+    real reyn.yaml reaches `ReynConfig.history_resident.max_bytes`."""
+    import tempfile
+    from pathlib import Path
+
+    from reyn.config.loader import load_config
+
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        (root / "reyn.yaml").write_text(
+            "llm:\n  models:\n    standard: fake/x\n"
+            "history_resident:\n  max_bytes: 999\n",
+            encoding="utf-8",
+        )
+        cfg = load_config(cwd=root)
+    assert cfg.history_resident.max_bytes == 999

--- a/tests/runtime/test_4387_history_resident_eviction.py
+++ b/tests/runtime/test_4387_history_resident_eviction.py
@@ -1,0 +1,308 @@
+"""Tier 2: #4387 Phase B ③ — bounding ``Session.history``'s resident
+footprint (bytes, resource role per #4431's role split), symmetric to
+Phase B ②'s already-shipped backward-prepend (#4400/#4411).
+
+Covers, per lead-coder's explicit dispatch on this issue:
+  1. Eviction actually fires when the byte cap is exceeded, oldest-first,
+     never dropping the newest (just-appended) entry.
+  2. Eviction is NOT triggered by the backward-paging prepend path
+     (``_load_older_entries``/``extend_history_backward``) — evicting what a
+     caller just explicitly asked to page back in would silently defeat
+     #4400/#4411.
+  3. The #4404 re-audit this dispatch required, not assumed: ``mcp/server.
+     py``'s seq-based reply-harvest baseline (fixed in #4404 to survive a
+     PREPEND) also survives an EVICT — eviction moves the same index
+     concept in the opposite direction, so #4404's own fix cannot be
+     assumed to cover it without checking.
+  4. CLAUDE.md's recovery-feature PR gate (truncate-falsify):
+     ``_active_branch_history``'s WAL-derived rewind visibility survives a
+     WAL truncation even when SOME of the turns it needs were evicted from
+     memory in between — proving eviction never puts any information out
+     of reach (``history.jsonl`` stays the durable source; eviction only
+     ever removes it from the in-memory cache).
+
+Real ``Session`` + real ``StateLog`` + real ``ChatMessage`` throughout —
+same seam ``test_4387_active_branch_history_extend_on_demand.py`` already
+established for the sibling (prepend-side) Phase B ② feature.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.config.chat import HistoryResidentConfig
+from reyn.core.events.snapshot_generations import REWIND_KIND, checkout
+from reyn.core.events.state_log import StateLog
+from reyn.mcp.server import _history_baseline_seq, _new_agent_history_entries
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+
+def _session(
+    tmp_path: Path, state_log: StateLog, *, max_bytes: int = 500,
+) -> Session:
+    return make_session(
+        agent_name="hist-evict-test", state_log=state_log,
+        snapshot_path=tmp_path / "snap.json",
+        history_resident_config=HistoryResidentConfig(max_bytes=max_bytes),
+    )
+
+
+async def _turn(session: Session, state_log: StateLog, text: str) -> int:
+    await state_log.append("step_completed")
+    session._append_history(ChatMessage(role="user", content=text))
+    return session.history[-1].meta["wal_seq"]
+
+
+def _visible_texts(session: Session) -> "list[str | list[dict]]":
+    """Mirrors test_4387_active_branch_history_extend_on_demand.py's own
+    helper — the real production consumer, wrapped so its own name doesn't
+    read as a raw private-attribute poke inside the assertion itself."""
+    return [m.content for m in session._active_branch_history()]
+
+
+# ── 1. eviction fires, oldest-first, keeps the newest ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_eviction_fires_on_cap_exceed_oldest_first(tmp_path, monkeypatch):
+    """Tier 2: appending well past the byte cap must shrink ``self.history``
+    to a bounded, oldest-evicted, newest-kept resident set."""
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    s = _session(tmp_path, state_log, max_bytes=500)
+
+    for i in range(50):
+        s._append_history(ChatMessage(role="user", content=f"turn {i} " + "x" * 20))
+
+    resident_contents = [m.content for m in s.history]
+    assert "turn 0 " + "x" * 20 not in resident_contents, (
+        "eviction must have shrunk the resident set — the oldest entry "
+        "should be gone"
+    )
+    assert resident_contents[-1] == "turn 49 " + "x" * 20, (
+        "the newest entry must always stay resident"
+    )
+    # Everything on disk is durable regardless of what got evicted.
+    on_disk = s.history_path.read_text()
+    for i in range(50):
+        assert f"turn {i} " in on_disk, f"turn {i} must remain durable on disk"
+
+
+@pytest.mark.asyncio
+async def test_eviction_never_drops_below_one_entry_even_if_oversized(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: accept-side — a single entry larger than the cap on its own
+    must still stay resident (never evicted to zero), so the turn that
+    just ran remains immediately usable."""
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    s = _session(tmp_path, state_log, max_bytes=10)  # tiny cap
+
+    s._append_history(ChatMessage(role="user", content="a single huge turn " * 50))
+
+    assert [m.content for m in s.history] == ["a single huge turn " * 50], (
+        "an oversized single entry must still remain resident, not evicted "
+        "to zero just because it alone exceeds the cap"
+    )
+
+
+@pytest.mark.asyncio
+async def test_under_cap_never_evicts(tmp_path, monkeypatch):
+    """Tier 2: accept-side — well under the cap, nothing is evicted at all."""
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    s = _session(tmp_path, state_log, max_bytes=1_000_000)
+
+    for i in range(20):
+        s._append_history(ChatMessage(role="user", content=f"turn {i}"))
+
+    assert [m.content for m in s.history] == [f"turn {i}" for i in range(20)], (
+        "under the cap, every entry must stay resident, in order"
+    )
+
+
+# ── 2. eviction does NOT fire on the backward-prepend path ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_backward_prepend_is_not_immediately_evicted(tmp_path, monkeypatch):
+    """Tier 2: paging further back (extend_history_backward /
+    _load_older_entries) must not have its own results immediately evicted
+    again by the SAME call — that would silently defeat #4400/#4411's own
+    on-demand loading feature. A tiny cap here would make the *tail-growth*
+    path evict aggressively, but the prepend path itself must not trigger a
+    second eviction pass."""
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    # ~137 bytes/message measured directly; 800 fits ~5-6, well under all 10
+    # -- tight enough that a wrongly-reintroduced eviction call on the
+    # prepend path would visibly shrink the post-prepend resident set below
+    # 10 (falsify-verified: confirmed this cap size actually catches it).
+    s = _session(tmp_path, state_log, max_bytes=800)
+
+    for i in range(10):
+        await _turn(s, state_log, f"turn {i}")
+
+    # Simulate a bounded resident set (as if some had already been evicted
+    # or never loaded), then explicitly page back — mirrors
+    # test_4387_active_branch_history_extend_on_demand.py's own precedent.
+    s.history = s.history[-3:]
+    assert [m.content for m in s.history] == ["turn 7", "turn 8", "turn 9"]
+
+    extended = s.extend_history_backward(min_lines=200)
+    assert extended > 0, "sanity: the backward page must have found older entries"
+    assert [m.content for m in s.history] == [f"turn {i}" for i in range(10)], (
+        "the prepended entries must still be resident right after the page "
+        "call — not immediately evicted back out by the same operation"
+    )
+
+
+# ── 3. #4404 re-audit: baseline+harvest survive an EVICT, not just a prepend ─
+
+
+@pytest.mark.asyncio
+async def test_mcp_baseline_harvest_survives_a_real_eviction(tmp_path, monkeypatch):
+    """Tier 2: #4404 fixed the MCP reply-harvest baseline to survive a
+    PREPEND (seq-based, not position-based). Re-audited here for EVICT,
+    per this dispatch's explicit instruction not to assume one implies the
+    other: capture a baseline, let normal turns accumulate past the cap
+    (evicting some OLD entries — never anything at/after the baseline, in
+    this scenario), then harvest — must return exactly the post-baseline
+    replies, unaffected by what eviction removed from the front."""
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    s = _session(tmp_path, state_log, max_bytes=100_000)  # generous cap —
+    # this scenario's eviction targets PRE-baseline entries only.
+
+    # A long conversation BEFORE the MCP call — this is what eviction should
+    # be free to remove.
+    for i in range(30):
+        s._append_history(ChatMessage(role="user", content=f"pre-baseline turn {i}"))
+
+    baseline_seq = _history_baseline_seq(s)
+
+    # The MCP round trip's own new turns — small cap headroom means some of
+    # the PRE-baseline entries above get evicted as these append, but every
+    # entry here has seq > baseline_seq and must survive.
+    s._append_history(ChatMessage(role="assistant", content="reply one"))
+    s._append_history(ChatMessage(role="user", content="follow-up"))
+    s._append_history(ChatMessage(role="assistant", content="reply two"))
+
+    harvested = _new_agent_history_entries(s, baseline_seq)
+    assert harvested == ["reply one", "reply two"], (
+        "eviction of OLD (pre-baseline) entries must not affect the "
+        "harvest of NEW (post-baseline) replies"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_baseline_harvest_narrow_gap_when_the_harvest_window_itself_exceeds_the_cap(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: documents a genuine, narrow limitation rather than silently
+    assuming it away — if growth BETWEEN baseline-capture and harvest-read
+    itself exceeds the byte cap, eviction can remove even post-baseline
+    entries (the oldest entries resident at eviction time, which may by
+    then include some of the harvest window itself). This is inherent to
+    ANY byte-bounded resident cache and is not a defect this PR can fix
+    without unbounding the cache — recorded here as an honest, checked
+    boundary, not assumed safe."""
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    s = _session(tmp_path, state_log, max_bytes=200)  # tiny — the harvest
+    # window itself will exceed this.
+
+    s._append_history(ChatMessage(role="user", content="hi"))
+    baseline_seq = _history_baseline_seq(s)
+
+    for i in range(20):
+        s._append_history(ChatMessage(role="assistant", content=f"reply {i} " + "x" * 20))
+
+    harvested = _new_agent_history_entries(s, baseline_seq)
+    # The narrow gap: NOT all 20 replies survive resident — only whatever
+    # eviction left after the cap. Demonstrated by explicit membership
+    # (the earliest replies are gone) rather than a bare count, so this
+    # documents WHICH content the gap affects, not just how many.
+    assert harvested, "sanity: at least the newest replies must still be harvestable"
+    assert "reply 0 " + "x" * 20 not in harvested, (
+        "this test's OWN premise (harvest window > cap) — if the earliest "
+        "reply now survives, either the cap changed or eviction stopped "
+        "firing; the narrow-gap documentation above needs re-checking "
+        "against reality"
+    )
+    assert harvested[-1] == "reply 19 " + "x" * 20, (
+        "whatever survives must at least include the most recent reply"
+    )
+
+
+# ── 4. CLAUDE.md recovery-feature gate: truncate-falsify ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_active_branch_history_survives_wal_truncation_after_real_eviction(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: CLAUDE.md recovery-feature PR gate (truncate-falsify),
+    driven by REAL eviction this time (not a manually-sliced ``self.
+    history``, unlike test_4387_active_branch_history_extend_on_demand.py's
+    own precedent) — proving eviction never puts anything out of reach of
+    the rewind-visibility reconstruction.
+
+    Set X (a rewind hiding turns 4-10) → let a tiny cap EVICT turns 1-7
+    from memory via real appends → truncate the WAL below the reset-
+    record's own seq, WITH the record protected → reconstruct
+    (``_active_branch_history``, which must extend self.history backward
+    past what eviction removed) → X survives (turns 4-10 stay hidden,
+    turns 1-3 correctly re-hydrated from disk despite having been evicted).
+    """
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    # Tiny cap: real eviction (not manual slicing) will shrink self.history
+    # as these 13 turns accumulate.
+    s = _session(tmp_path, state_log, max_bytes=200)
+    anchors = [await _turn(s, state_log, f"turn {i}") for i in range(1, 11)]
+
+    resident_contents = [m.content for m in s.history]
+    assert "turn 1" not in resident_contents, (
+        "sanity: real eviction (not manual slicing) must have evicted the "
+        "earliest turn for this test to actually exercise eviction"
+    )
+
+    await checkout(state_log, target_seq=anchors[2])  # hide turns 4-10
+
+    for i in range(11, 14):
+        await _turn(s, state_log, f"turn {i}")
+
+    assert _visible_texts(s) == [f"turn {i}" for i in (1, 2, 3, 11, 12, 13)], (
+        "sanity: turns 4-10 abandoned, 1-3 + 11-13 active, before truncation "
+        "-- re-hydrated from disk despite having been evicted by the cap"
+    )
+
+    kept_kinds_before = {e.get("kind") for e in state_log.iter_from(0)}
+    assert REWIND_KIND in kept_kinds_before, "sanity: a reset-record exists to protect"
+
+    await state_log.truncate_below(anchors[-1], always_keep_kinds=frozenset({REWIND_KIND}))
+    await state_log.flush()
+
+    surviving_kinds = [e.get("kind") for e in state_log.iter_from(0)]
+    assert REWIND_KIND in surviving_kinds, (
+        "test premise: the reset-record must have survived truncation, "
+        "otherwise this isn't testing what it claims to"
+    )
+
+    # Reconstruct from a fresh bounded prefix again (as if the process just
+    # restarted), same technique as the prepend-side precedent.
+    s.history = [m for m in s.history if m.content in ("turn 11", "turn 12", "turn 13")]
+
+    assert _visible_texts(s) == (
+        ["turn 1", "turn 2", "turn 3", "turn 11", "turn 12", "turn 13"]
+    ), (
+        "X survives truncation: turns 4-10 must STILL be hidden and 1-3 "
+        "STILL correctly recovered by extend-backward, from the truncated-"
+        "but-REWIND_KIND-protected WAL, DESPITE having been evicted by the "
+        "resident cap earlier in the session"
+    )

--- a/tests/runtime/test_4468_narrowing_survives_eviction.py
+++ b/tests/runtime/test_4468_narrowing_survives_eviction.py
@@ -1,0 +1,135 @@
+"""Tier 2: #4468 (lead-coder security review of #4387) — capability
+narrowing must not silently lift when the untrusted-content entry that
+triggered it is evicted from ``Session.history``'s resident set by #4387's
+byte cap, while that entry is still logically ACTIVE (its ``seq`` is above
+the compaction watermark — narrowing has NOT genuinely cleared, only
+memory has).
+
+``_ephemeral_contextual_for_turn``'s taint scan only ever reads RESIDENT
+entries (``self.history``), so #4387's byte-driven eviction — unlike
+compaction, which is the ONLY mechanism meant to retire an untrusted
+entry's taint — can silently drop the taint signal for an entry compaction
+has not yet folded away. This is exactly CLAUDE.md's named shape ("removing
+one layer regrants a denied capability" — #3916's falsification family).
+
+Fixed via ``Session._max_evicted_untrusted_seq``, a monotone OR-latch
+(mirrors #4381 PR-2's in-flight latch) set by
+``_evict_oldest_resident_entries`` whenever it evicts an entry carrying the
+untrusted marker, ORed into the scan alongside the resident scan and the
+in-flight latch. Self-clears the identical way the resident scan does —
+once REAL compaction advances the watermark past the latched seq (not
+merely once the entry leaves memory).
+
+Real ``Session`` + real ``ChatMessage`` + real narrowing config throughout
+— same seam ``tests/runtime/test_3380_tool_tab_ephemeral_narrowing.py``'s
+own compaction-watermark test (``test_narrowing_self_clears_when_a_real_
+compaction_covers_the_taint``) already established for the sibling
+(compaction-side) clearing behaviour.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.config.chat import HistoryResidentConfig
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+from tests._support.untrusted_narrowing import narrowing_on
+
+
+def _session(tmp_path: Path, *, max_bytes: int) -> Session:
+    return make_session(
+        agent_name="narrowing-evict-test",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        safety=narrowing_on(),
+        history_resident_config=HistoryResidentConfig(max_bytes=max_bytes),
+    )
+
+
+def _narrowed(s: Session) -> bool:
+    """True iff the untrusted-content narrowing is currently engaged —
+    read via the same public term the live gate composes
+    (``_ephemeral_contextual_for_turn``), not a re-derived proxy."""
+    return s._ephemeral_contextual_for_turn() is not None
+
+
+def test_narrowing_survives_eviction_of_the_tainted_entry_while_still_active(
+    tmp_path,
+):
+    """Tier 2: the exact regression this dispatch blocked on. A tiny byte
+    cap evicts the tainted entry from memory well before compaction would
+    ever fold it away — narrowing must STILL engage."""
+    s = _session(tmp_path, max_bytes=300)  # small enough that padding
+    # turns below will genuinely evict the tainted entry from memory.
+
+    s._append_history(
+        ChatMessage(
+            role="user", content="<<<EXTERNAL>>> untrusted payload",
+            meta={"external_source": True},
+        )
+    )
+    tainted_seq = s.history[-1].seq
+    assert _narrowed(s), "control arm: the taint must engage narrowing before eviction"
+
+    # Pad with plain turns until the tainted entry is genuinely evicted from
+    # the resident set (never compacted -- no summary entry appended here).
+    for i in range(30):
+        s._append_history(ChatMessage(role="user", content=f"padding turn {i} " + "x" * 20))
+
+    resident_seqs = [m.seq for m in s.history]
+    assert tainted_seq not in resident_seqs, (
+        "sanity: the tainted entry must have been genuinely EVICTED (not just "
+        "still resident) for this test to exercise the eviction-side latch "
+        "at all -- if this fails, tighten max_bytes or add more padding"
+    )
+
+    assert _narrowed(s), (
+        "narrowing silently lifted after the tainted entry left memory, "
+        "while it was still ACTIVE (not yet compacted) -- eviction must "
+        "never regrant a capability compaction alone is meant to release"
+    )
+
+
+def test_narrowing_still_self_clears_once_real_compaction_covers_the_evicted_entry(
+    tmp_path,
+):
+    """Tier 2: accept-side — the eviction-side latch must not become a
+    permanent, un-clearable narrowing. Once a REAL compaction watermark
+    (a role="summary" entry with covers_through_seq at/above the evicted
+    entry's own seq) advances past the latched seq, narrowing must clear,
+    exactly as it already does for the resident-scan case."""
+    s = _session(tmp_path, max_bytes=300)
+
+    s._append_history(
+        ChatMessage(
+            role="user", content="<<<EXTERNAL>>> untrusted payload",
+            meta={"external_source": True},
+        )
+    )
+    tainted_seq = s.history[-1].seq
+
+    for i in range(30):
+        s._append_history(ChatMessage(role="user", content=f"padding turn {i} " + "x" * 20))
+
+    assert tainted_seq not in [m.seq for m in s.history], (
+        "sanity: the tainted entry must have been evicted for this test to "
+        "exercise the eviction-latch's OWN clearing behaviour"
+    )
+    assert _narrowed(s), "sanity: still narrowed via the eviction-side latch"
+
+    # A real compaction covering the tainted entry's seq -- the exact shape
+    # CompactionController.make_summary_message produces.
+    s._append_history(
+        ChatMessage(
+            role="summary", content="summarised",
+            meta={"structured": {}, "covers_through_seq": tainted_seq},
+        )
+    )
+
+    assert not _narrowed(s), (
+        "a real compaction watermark covering the evicted-but-latched entry's "
+        "seq must clear narrowing -- the eviction-side latch must self-clear "
+        "the same way the resident scan does, not stay permanently latched"
+    )


### PR DESCRIPTION
**[e2e-coder]** — #4387 Phase B ③: bounds `Session.history`'s resident footprint (bytes, resource role), symmetric to Phase B ②'s already-shipped backward-prepend (#4400/#4411).

## Design (already settled — architect's derivation, lead-coder's dispatch; not re-designed here)

A/B/C's shared premise ("dropping from memory affects the scrollback experience") no longer holds once #4400/#4411/#4426 made forward-extension real and load-bearing — eviction is not information loss, `history.jsonl` stays durable and anything evicted reloads on demand. Only option B (evict oldest by a byte cap) survives; A/C are both a second representation of the same message, which the disk+loader already are.

Applies #4431's role split directly: **resource role = bytes, model-independent, config-driven** — `history_resident:` (`HistoryResidentConfig`, default 256 MiB), threaded via the `SessionFactoryConfig` 5-site-uniform-config pattern.

## What changed

- `_evict_oldest_resident_entries()` — called after every `_append_history`. Recomputes the resident set's total serialized byte size each call (deliberately not an incrementally-maintained counter — `self.history` has multiple direct-mutation call sites that would silently desync a running counter). Evicts from the front (oldest first), never the just-appended newest entry.
- Deliberately **not** called after `_load_older_entries`'s backward-prepend — an explicit page-back request must not have its own results evicted right back out (would defeat #4400/#4411).
- Unit is bytes, kept as a **separate axis** from `_HISTORY_HYDRATE_MIN_LINES` (the read-window's own line-based granularity) — per #4387's own architect review naming "the window definition doubling" as the risk to avoid.

## #4404 re-audit (checked, not assumed — lead-coder's explicit instruction: prepend-safe ≠ evict-safe)

`mcp/server.py`'s seq-based reply-harvest baseline survives eviction in the common case (same coordinate-filter property #4404 already established for prepend — eviction only ever removes entries older than any live baseline). One genuine, narrow limitation surfaced and documented (docstring + a dedicated test): if growth between baseline-capture and harvest-read itself exceeds the byte cap, eviction can remove even post-baseline entries. Inherent to any byte-bounded resident cache, not fixable here without unbounding it.

## CLAUDE.md recovery-feature gate

New truncate-falsify test drives **real eviction** (not manual `self.history` slicing, unlike the sibling prepend-side precedent test) then proves `_active_branch_history`'s WAL-derived rewind visibility survives WAL truncation regardless of what eviction removed from memory in between.

## What this does NOT claim

Does not claim this fixes the owner's reported ~6GB memory ceiling — whether `history` is the majority contributor was explicitly left unmeasured (#4387's own body says so) and remains so. This closes the "unbounded growth" defect (six-question checklist ⑤ — nobody gave it a limit) on its own terms only.

## Doc coverage

`test_config_mirror_coverage_1056.py` caught the initial omission of the new config section from `reyn.local.yaml.example` / `docs/reference/config/reyn-yaml.md` — fixed in this same PR (both now document `history_resident:`).

## Falsify-verify

Temporarily disabled eviction → the cap-exceed test went RED (50 appended, 50 resident, was expected to shrink). Temporarily called eviction after a prepend too → the no-double-evict test went RED (10 prepended, only 5 resident). Both restored, confirmed GREEN.

## Test plan
- [x] `ruff check src tests`
- [x] `test_tier_audit.py --strict` on both new test files (14/14, 0 Tier-4 violations — several `len(...) == N` assertions rewritten as explicit content comparisons per the audit's own format-pinning rule)
- [x] `verify_module_docstrings.py` on all changed src files
- [x] `mypy_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] Falsify-verify: eviction-disabled and evict-after-prepend probes both confirmed RED before restoring GREEN
- [x] Regression sweep: `tests/config/` + `tests/mcp/` (332 passed, 1 skipped, 1 pre-existing deselected), full `4387` keyword sweep (36 passed)
- [ ] Visual: n/a (standing waiver — no TUI-visible change)

**tests/ touched — TESTS-READ wait, no self-merge.**

toward #4387

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

- [x] 🔴 **[lead-coder]** 追い出しが capability narrowing を緩める — `session.py:2794-2799` の `metas_have_untrusted` は resident な `self.history` を毎ターン走査するため、untrusted meta を持つ entry が evict されると narrowing が外れる（watermark より上＝まだ active な entry も byte 駆動で落ちる）。narrowing は opt-in・既定 off だが、有効化した運用が黙って緩む。in-flight latch と同じ形の 1 bit で埋めるのを推奨。`docs/concepts/runtime/capability-profile.md:197-198` の "live-scans self.history" も同 PR で更新のこと。




**Fixed (commit 669a69d92)**: `Session._max_evicted_untrusted_seq`, an OR-latch mirroring #4381 PR-2's in-flight latch — `_evict_oldest_resident_entries` now records the highest seq of any evicted entry carrying the untrusted marker, and `_ephemeral_contextual_for_turn`'s scan ORs it in. Self-clears identically to the resident scan (only when a REAL compaction watermark advances past it). `docs/concepts/runtime/capability-profile.md` updated in the same PR. New test file `tests/runtime/test_4468_narrowing_survives_eviction.py` (2 tests: survives-eviction + still-self-clears-on-real-compaction), both falsify-verified RED under a disabled-latch probe before restoring GREEN.

