### PR TITLE
feat(#4477): warn-once when the compaction batch cap can't fit head+tail's own budget

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -58,6 +58,7 @@ compact_op_completed
 compact_op_failed
 compact_op_requested
 compact_op_unavailable
+compaction_batch_cap_below_head_tail_budget
 compaction_check
 compaction_completed
 compaction_failed
@@ -444,6 +445,7 @@ mostly informational.
 
 | Kind | When | Key payload |
 |------|------|-------------|
+| `compaction_batch_cap_below_head_tail_budget` | #4477 — `resolve_effective_trigger_and_budgets`'s 4th resource/budget invariant instance (`src/reyn/runtime/services/router_history_buffer.py`, siblings to `resource_cap_exceeds_budget_trigger` below): the compaction batch read's own byte cap (`history_tail_reader.COMPACTION_BATCH_MAX_BYTES`, 8 MiB) is smaller than `head_budget + tail_budget`'s own combined token footprint converted to bytes via `context_builder.INLINE_CAP_BYTES_PER_TOKEN` — meaning a compaction pass would produce zero candidates every time (head+tail trimming alone consumes the whole batch), permanently stalling `covers_through_seq`. Confirmed reachable against real, currently-cataloged litellm models (>8 MiB combined at the shipped `component_weights` default). Detection only — no value is clamped. Warn-once per `(model, phase)`. `model`, `phase` (`""` when none), `head_budget`, `tail_budget`, `combined_bytes`, `compaction_batch_max_bytes` |
 | `compaction_check` | The compaction gate ran for a turn. `outcome` records the decision — e.g. `too_few_turns`, `below_min_batch`, `pre_frame_overflow`, `already_running`, `forced_sync`, `forced_sync_no_turns`, `compaction_input_gap_invariant_violated` (#4472: candidates are read directly from the durable `history.jsonl`, never residency-gated, so this should never fire under normal operation — a defensive invariant, not a routine branch; a hit means something else narrowed the durable read out from under compaction, reopening #4470's silent-coverage-claim defect through a new path). `outcome="forced_sync"` also carries `batch_truncated` (#4472: `True` when the durable read's own per-call byte cap capped this pass short of the full uncovered range — the pass still only claims coverage of what it actually examined; a large backlog needs multiple passes, each with `batch_truncated=True` until the final one). Some outcomes also carry `turns`, `head`, `tail`. | `outcome`, plus outcome-specific fields |
 | `compaction_failed` | A compaction attempt raised. | `error` |
 | `compaction_shrink_recovered` | (#3783 stage 2) `retry_loop`'s bounded shrink ladder caught a context-overflow (compaction-call or main-call) and is about to shrink and retry. Fires once per recovered iteration, not once per turn — a turn that shrinks 3 times emits 3 of these. | `cause` (the caught exception's class name), `iteration` (0-based ladder position), `consecutive` (how many times in a row `cause` has recovered without a different cause or a success in between) |

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -230,6 +230,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "compact_op_failed",
     "compact_op_requested",
     "compact_op_unavailable",
+    "compaction_batch_cap_below_head_tail_budget",
     "compaction_check",
     "compaction_completed",
     "compaction_failed",

--- a/src/reyn/runtime/history_tail_reader.py
+++ b/src/reyn/runtime/history_tail_reader.py
@@ -146,8 +146,16 @@ def read_history_tail(
     return collected
 
 
+# #4477: named so `router_history_buffer._check_compaction_batch_within_
+# budget` (the 4th resource/budget-role comparison instance, #4381 PR-1's
+# own class) can compare against the SAME value this function actually
+# defaults to — a second, independently-typed `8 * 1024 * 1024` literal
+# would silently drift from this one the day either changes.
+COMPACTION_BATCH_MAX_BYTES: int = 8 * 1024 * 1024
+
+
 def read_history_after(
-    path: Path, *, after_seq: int, max_bytes: int = 8 * 1024 * 1024,
+    path: Path, *, after_seq: int, max_bytes: int = COMPACTION_BATCH_MAX_BYTES,
 ) -> "tuple[list[str], bool]":
     """#4472 (batched, per architect's + lead-coder's independent review of
     the first draft): read *path* FORWARD from BOF, skipping every line

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -172,6 +172,11 @@ def _refresh_skill_location_tokens(
 # `_resource_budget_warned.clear()`.
 _resource_budget_warned: "set[tuple[str, str | None]]" = set()
 
+# #4477: warn-once cache for the compaction-batch/head+tail-budget invariant
+# below — the 4th instance of this SSoT's resource/budget comparison class.
+# Reset in tests via `_compaction_batch_budget_warned.clear()`.
+_compaction_batch_budget_warned: "set[tuple[str, str | None]]" = set()
+
 
 def _check_resource_within_budget(
     model: str,
@@ -237,6 +242,69 @@ def _check_resource_within_budget(
         )
 
 
+def _check_compaction_batch_within_budget(
+    model: str, phase: "str | None", head_budget: int, tail_budget: int, events: Any,
+) -> None:
+    """#4477: the 4th instance of the resource/budget comparison class
+    ``_check_resource_within_budget`` (#4381 PR-1) already established —
+    same conversion point (``INLINE_CAP_BYTES_PER_TOKEN``), same warn-once
+    shape, different pair: ``read_history_after``'s own per-call byte cap
+    (``COMPACTION_BATCH_MAX_BYTES`` — a RESOURCE bound, #4472/#4475) vs
+    ``head_budget + tail_budget`` (a BUDGET bound, model-context-window-
+    derived, #4431's role split).
+
+    **Why this check exists at all — measured, not assumed** (architect's
+    #4475 follow-up review + this issue's own explicit first task, before
+    any warn mechanism was written): if the batch cap is smaller than
+    ``head_budget + tail_budget``'s own combined token footprint (in
+    bytes), a compaction pass produces ZERO candidates every time — head
+    and tail trimming alone consume the whole small batch, leaving no
+    middle. Worse than merely "no progress": zero candidates means no
+    summary, means ``covers_through_seq`` never advances, means the NEXT
+    pass reads the IDENTICAL window and produces the IDENTICAL zero — a
+    genuine, permanent STALL, the exact class #4470/#4471/#4472 exist to
+    close, reachable through this specific resource/budget combination.
+
+    Confirmed LIVE (not theoretical) against this repo's own installed
+    litellm catalog (verified 2026-08-13): ``component_weights``'s shipped
+    default (head=10, tail=15, of 100 total ⇒ 25% combined) times
+    ``INLINE_CAP_BYTES_PER_TOKEN`` (4) means the worst-case
+    ``head_budget + tail_budget`` in BYTES equals the model's own
+    ``max_input_tokens`` numerically (0.25 × 4 = 1). At least 5 models in
+    the installed litellm catalog exceed ``COMPACTION_BATCH_MAX_BYTES``
+    (8 MiB = 8,388,608) at this weighting — e.g.
+    ``oci/meta.llama-4-scout-17b-16e-instruct`` at 10,485,760 tokens (a
+    real, currently-selectable model, not a hypothetical) — so this is a
+    REACHABLE misconfiguration, not a defensive-only guard.
+
+    Warn-once per ``(model, phase)``, same reasoning as the sibling check
+    above (a high-frequency SSoT). Detection only — no value is clamped;
+    unlike the resource-bound/budget check above, there is no obvious safe
+    clamp direction here (shrinking the batch cap further only worsens the
+    stall; growing it is an operator/model-choice decision, not something
+    this call site should silently do).
+    """
+    from reyn.core.context_builder import INLINE_CAP_BYTES_PER_TOKEN
+    from reyn.runtime.history_tail_reader import COMPACTION_BATCH_MAX_BYTES
+
+    combined_tokens = head_budget + tail_budget
+    combined_bytes = combined_tokens * INLINE_CAP_BYTES_PER_TOKEN
+    if combined_bytes <= COMPACTION_BATCH_MAX_BYTES:
+        return
+    key = (model, phase)
+    if key in _compaction_batch_budget_warned:
+        return
+    _compaction_batch_budget_warned.add(key)
+    if events is not None:
+        events.emit(
+            "compaction_batch_cap_below_head_tail_budget",
+            model=model, phase=phase or "",
+            head_budget=head_budget, tail_budget=tail_budget,
+            combined_bytes=combined_bytes,
+            compaction_batch_max_bytes=COMPACTION_BATCH_MAX_BYTES,
+        )
+
+
 def resolve_effective_trigger_and_budgets(
     compaction_controller: Any,
     model: str,
@@ -265,6 +333,14 @@ def resolve_effective_trigger_and_budgets(
     phase concept today; a future phase-aware caller can pass a real value
     without a signature change.
 
+    #4477: also the SSoT for a FOURTH instance of the same class —
+    ``_check_compaction_batch_within_budget`` — comparing
+    ``head_budget + tail_budget`` (already computed here) against
+    #4472/#4475's own compaction-batch byte cap. Confirmed reachable
+    (see that function's own docstring for the live measurement) before
+    being added — the class's own established discipline: don't build an
+    unreachable-machinery warn.
+
     ``read_cap_config`` (#4381 PR-5): the ``ReadCapConfig`` to check the
     resource bound against — threaded from ``RouterHistoryBuffer``, which
     has a live config reference; ``ContextBudgetAdvisor``'s own call
@@ -283,6 +359,9 @@ def resolve_effective_trigger_and_budgets(
         fallback = effective_trigger // 4
         head_budget, tail_budget = fallback, fallback
     _check_resource_within_budget(model, phase, effective_trigger, events, read_cap_config)
+    # #4477: 4th instance of the resource/budget comparison class — the
+    # compaction batch's own byte cap vs head+tail's combined token budget.
+    _check_compaction_batch_within_budget(model, phase, head_budget, tail_budget, events)
     return effective_trigger, head_budget, tail_budget
 
 

--- a/tests/runtime/test_4477_compaction_batch_budget_invariant.py
+++ b/tests/runtime/test_4477_compaction_batch_budget_invariant.py
@@ -13,17 +13,29 @@ the worst-case `head_budget + tail_budget` in BYTES equals the model's own
 repo's installed litellm catalog exceed `COMPACTION_BATCH_MAX_BYTES`
 (8 MiB) at this weighting -- e.g. `oci/meta.llama-4-scout-17b-16e-instruct`
 at 10,485,760 max_input_tokens, a real, currently-selectable model, not a
-hypothetical. This test drives that EXACT model through the real
-`compute_budgets` path (the same function `CompactionEngine` itself uses)
-to prove the check fires for a genuinely reachable configuration, not a
-synthetic one.
+hypothetical.
 
-Real collaborators throughout, same idiom as
-`tests/runtime/test_4381_pr1_resource_budget_invariant.py` (this check's
-own sibling/precedent): `compute_budgets` builds a real `ComputedBudgets`;
-only the tiny attribute-passthrough `_Engine`/`_Controller` containers are
-hand-built (no logic of their own); `EventLog` + `collect_events` capture
-the real subscriber path.
+**Split per lead-coder's PR review** (the precondition test below is the
+ONLY one that touches the real litellm catalog): the reachability WITNESS
+(does this actually happen in reality) is a separate concern from the
+BEHAVIOR under test (reyn's own warn-once logic). The precondition test
+IS #4477's entire justification and stays real-catalog-dependent on
+purpose. The behavior tests (warn fires once, per-phase granularity,
+accept-side silence, no-sink safety) are reyn's own logic, not litellm's
+catalog content -- keeping them real-catalog-dependent would mean (a) a
+third party changing that model's advertised window could turn reyn's own
+correct logic red (the "third-party's property" hazard CLAUDE.md's test
+review names), and (b) adding a second CI exposure to the exact blocking
+litellm-warm-up class #4395 fixed earlier the same night. Rewritten to
+drive synthetic, hand-built `ComputedBudgets` instead -- the subject under
+test is reyn's own comparison + warn-once cache, which needs a
+`head_budget`/`tail_budget` pair, not a real model resolution.
+
+Real collaborators throughout for what's actually under test: `EventLog` +
+`collect_events` capture the real subscriber path; `_Engine`/`_Controller`
+are the same tiny attribute-passthrough containers
+`test_4381_pr1_resource_budget_invariant.py` already established (no logic
+of their own).
 """
 from __future__ import annotations
 
@@ -32,16 +44,32 @@ from reyn.core.context_builder import INLINE_CAP_BYTES_PER_TOKEN
 from reyn.core.events.events import EventLog
 from reyn.runtime.history_tail_reader import COMPACTION_BATCH_MAX_BYTES
 from reyn.runtime.services import router_history_buffer as rhb
-from reyn.services.compaction.engine import compute_budgets
+from reyn.services.compaction.engine import ComputedBudgets, compute_budgets
 from tests._support.events import collect_events
 
-# A real, currently-cataloged model whose max_input_tokens (10,485,760)
-# is large enough that the shipped component_weights default (25% combined
+# A real, currently-cataloged model whose max_input_tokens (10,485,760) is
+# large enough that the shipped component_weights default (25% combined
 # head+tail) converts to MORE than COMPACTION_BATCH_MAX_BYTES (8 MiB) --
-# confirmed via direct litellm.model_cost inspection, not assumed.
+# confirmed via direct litellm.model_cost inspection, not assumed. Used
+# ONLY by the precondition/reachability test below.
 _HUGE_WINDOW_MODEL = "oci/meta.llama-4-scout-17b-16e-instruct"
-# An ordinary model whose window is far too small to ever trip this check.
-_NORMAL_MODEL = "openai/gpt-4o"
+_ORDINARY_MODEL = "openai/gpt-4o"
+
+# Synthetic budgets for the behavior tests -- deliberately round numbers,
+# not derived from any real model. Combined = 3,000,000 tokens *
+# INLINE_CAP_BYTES_PER_TOKEN(4) = 12,000,000 bytes > COMPACTION_BATCH_MAX_
+# BYTES (8,388,608) -- exceeds by construction, not by coincidence.
+_EXCEEDING_BUDGETS = ComputedBudgets(
+    main_pool=5_000_000, head_budget=2_000_000, body_budget=1_000_000,
+    tail_budget=1_000_000, new_msg_budget=500_000, B_M=4_000_000,
+    main_M_room=1_500_000, effective_trigger=1_500_000,
+)
+# Combined = 200 tokens * 4 = 800 bytes, comfortably under the cap.
+_UNDER_BUDGETS = ComputedBudgets(
+    main_pool=1_000, head_budget=100, body_budget=400,
+    tail_budget=100, new_msg_budget=200, B_M=800,
+    main_M_room=700, effective_trigger=700,
+)
 
 
 class _Engine:
@@ -54,28 +82,30 @@ class _Controller:
         self._engine = engine
 
 
-def _budgets_for(model: str):
-    # `get_max_input_tokens` (inside `compute_budgets`) resolves the real
-    # litellm catalog value only once litellm itself is warm — deferring
-    # otherwise, per `litellm_bootstrap.py`'s own non-blocking design
-    # (#4395 PR-2). This test's whole premise depends on the REAL catalog
-    # value (10,485,760 for the huge-window model), not the 128K
-    # conservative fallback, so force the blocking warm-up first.
-    from reyn.llm.litellm_bootstrap import ensure_litellm_ready
-
-    ensure_litellm_ready()
-    return compute_budgets(CompactionConfig(), model, T_SP=2_000, T_comp_SP=500)
-
-
 def _reset_warned():
     rhb._compaction_batch_budget_warned.clear()
 
 
 def test_the_huge_window_models_own_budgets_actually_exceed_the_batch_cap():
-    """Tier 2: sanity precondition — with the real, shipped defaults, the
-    chosen model's own head_budget + tail_budget really does exceed
-    COMPACTION_BATCH_MAX_BYTES once converted to bytes. Not assumed."""
-    budgets = _budgets_for(_HUGE_WINDOW_MODEL)
+    """Tier 2: the SOLE real-litellm-catalog-dependent test in this file —
+    the reachability WITNESS #4477's own existence depends on. Confirms,
+    against the REAL installed catalog and the REAL compute_budgets path
+    (the same function CompactionEngine itself uses), that a real,
+    currently-selectable model's own head_budget + tail_budget genuinely
+    exceeds COMPACTION_BATCH_MAX_BYTES once converted to bytes. Not
+    assumed, and deliberately the ONLY place in this file that pays the
+    real litellm-catalog-resolution cost."""
+    from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+
+    # get_max_input_tokens (inside compute_budgets) resolves the real
+    # litellm catalog value only once litellm itself is warm -- deferring
+    # otherwise, per litellm_bootstrap.py's own non-blocking design (#4395
+    # PR-2). This precondition's whole point depends on the REAL catalog
+    # value (10,485,760), not the 128K conservative fallback, so force the
+    # blocking warm-up -- acceptable ONLY here, where paying that cost is
+    # the entire point of the test.
+    ensure_litellm_ready()
+    budgets = compute_budgets(CompactionConfig(), _HUGE_WINDOW_MODEL, T_SP=2_000, T_comp_SP=500)
     combined_bytes = (budgets.head_budget + budgets.tail_budget) * INLINE_CAP_BYTES_PER_TOKEN
     assert combined_bytes > COMPACTION_BATCH_MAX_BYTES, (
         f"test precondition failed: {_HUGE_WINDOW_MODEL}'s combined "
@@ -87,53 +117,59 @@ def test_the_huge_window_models_own_budgets_actually_exceed_the_batch_cap():
     )
 
 
-def test_a_reachable_large_window_model_emits_the_warning_once():
-    """Tier 2: a genuinely reachable configuration (a real, currently-
-    selectable model whose own window makes head+tail exceed the batch
-    cap) emits compaction_batch_cap_below_head_tail_budget exactly once —
-    repeated calls with the SAME (model, phase) do not re-warn (the SSoT
-    is called on every trigger resolution)."""
+def test_a_reachable_configuration_emits_the_warning_once():
+    """Tier 2: synthetic budgets whose combined head+tail footprint
+    exceeds the batch cap by construction — the SAME shape the
+    precondition test above proved is reachable, but driven through
+    reyn's own logic without touching the real litellm catalog (the
+    subject under test here is the warn-once cache, not litellm's
+    catalog content). Emits compaction_batch_cap_below_head_tail_budget
+    exactly once — repeated calls with the SAME (model, phase) do not
+    re-warn (the SSoT is called on every trigger resolution)."""
     _reset_warned()
     events = EventLog()
     collected = collect_events(events)
-    budgets = _budgets_for(_HUGE_WINDOW_MODEL)
-    controller = _Controller(_Engine(budgets))
+    controller = _Controller(_Engine(_EXCEEDING_BUDGETS))
 
     for _ in range(3):
         result = rhb.resolve_effective_trigger_and_budgets(
-            controller, _HUGE_WINDOW_MODEL, events,
+            controller, _ORDINARY_MODEL, events,
         )
-        assert result == (budgets.effective_trigger, budgets.head_budget, budgets.tail_budget)
+        assert result == (
+            _EXCEEDING_BUDGETS.effective_trigger,
+            _EXCEEDING_BUDGETS.head_budget,
+            _EXCEEDING_BUDGETS.tail_budget,
+        )
 
     warnings = [
         e for e in collected
         if e.type == "compaction_batch_cap_below_head_tail_budget"
     ]
     (only,) = warnings
-    assert only.data["model"] == _HUGE_WINDOW_MODEL
+    assert only.data["model"] == _ORDINARY_MODEL
     assert only.data["phase"] == ""
-    assert only.data["head_budget"] == budgets.head_budget
-    assert only.data["tail_budget"] == budgets.tail_budget
+    assert only.data["head_budget"] == _EXCEEDING_BUDGETS.head_budget
+    assert only.data["tail_budget"] == _EXCEEDING_BUDGETS.tail_budget
     assert only.data["combined_bytes"] > only.data["compaction_batch_max_bytes"]
 
 
 def test_warns_again_for_a_different_phase_same_model():
     """Tier 2: warn-once granularity is per (model, phase), not per model
-    alone — a DIFFERENT phase with the same model re-warns."""
+    alone — a DIFFERENT phase with the same synthetic exceeding budgets
+    re-warns."""
     _reset_warned()
     events = EventLog()
     collected = collect_events(events)
-    budgets = _budgets_for(_HUGE_WINDOW_MODEL)
-    controller = _Controller(_Engine(budgets))
+    controller = _Controller(_Engine(_EXCEEDING_BUDGETS))
 
     rhb.resolve_effective_trigger_and_budgets(
-        controller, _HUGE_WINDOW_MODEL, events, phase="alpha",
+        controller, _ORDINARY_MODEL, events, phase="alpha",
     )
     rhb.resolve_effective_trigger_and_budgets(
-        controller, _HUGE_WINDOW_MODEL, events, phase="alpha",
+        controller, _ORDINARY_MODEL, events, phase="alpha",
     )
     rhb.resolve_effective_trigger_and_budgets(
-        controller, _HUGE_WINDOW_MODEL, events, phase="beta",
+        controller, _ORDINARY_MODEL, events, phase="beta",
     )
 
     warnings = [
@@ -144,24 +180,22 @@ def test_warns_again_for_a_different_phase_same_model():
     assert phases_warned == ["alpha", "beta"]
 
 
-def test_an_ordinary_model_emits_nothing():
-    """Tier 2: accept-side twin — an ordinary model's head+tail budget
-    stays comfortably under the batch cap; no event fires at all (not a
-    present-but-benign one)."""
+def test_budgets_under_the_cap_emit_nothing():
+    """Tier 2: accept-side twin — synthetic budgets whose combined
+    head+tail footprint stays comfortably under the batch cap; no event
+    fires at all (not a present-but-benign one)."""
     _reset_warned()
     events = EventLog()
     collected = collect_events(events)
-    budgets = _budgets_for(_NORMAL_MODEL)
-    combined_bytes = (budgets.head_budget + budgets.tail_budget) * INLINE_CAP_BYTES_PER_TOKEN
-    assert combined_bytes <= COMPACTION_BATCH_MAX_BYTES, (
-        "sanity: this test's own premise -- an ordinary model must NOT "
-        "exceed the batch cap"
+    controller = _Controller(_Engine(_UNDER_BUDGETS))
+
+    result = rhb.resolve_effective_trigger_and_budgets(controller, _ORDINARY_MODEL, events)
+
+    assert result == (
+        _UNDER_BUDGETS.effective_trigger,
+        _UNDER_BUDGETS.head_budget,
+        _UNDER_BUDGETS.tail_budget,
     )
-    controller = _Controller(_Engine(budgets))
-
-    result = rhb.resolve_effective_trigger_and_budgets(controller, _NORMAL_MODEL, events)
-
-    assert result == (budgets.effective_trigger, budgets.head_budget, budgets.tail_budget)
     assert not [
         e for e in collected
         if e.type == "compaction_batch_cap_below_head_tail_budget"
@@ -173,9 +207,12 @@ def test_no_events_sink_does_not_raise():
     without one) — the check runs and detects the violation internally
     but never tries to emit, and never raises for lack of a sink."""
     _reset_warned()
-    budgets = _budgets_for(_HUGE_WINDOW_MODEL)
-    controller = _Controller(_Engine(budgets))
+    controller = _Controller(_Engine(_EXCEEDING_BUDGETS))
 
-    result = rhb.resolve_effective_trigger_and_budgets(controller, _HUGE_WINDOW_MODEL, None)
+    result = rhb.resolve_effective_trigger_and_budgets(controller, _ORDINARY_MODEL, None)
 
-    assert result == (budgets.effective_trigger, budgets.head_budget, budgets.tail_budget)
+    assert result == (
+        _EXCEEDING_BUDGETS.effective_trigger,
+        _EXCEEDING_BUDGETS.head_budget,
+        _EXCEEDING_BUDGETS.tail_budget,
+    )

--- a/tests/runtime/test_4477_compaction_batch_budget_invariant.py
+++ b/tests/runtime/test_4477_compaction_batch_budget_invariant.py
@@ -1,0 +1,181 @@
+"""Tier 2: #4477 — the 4th instance of #4381 PR-1's resource/budget
+comparison class: `resolve_effective_trigger_and_budgets`'s
+`head_budget + tail_budget` (a BUDGET bound, model-context-window-derived)
+vs `history_tail_reader.COMPACTION_BATCH_MAX_BYTES` (a RESOURCE bound,
+#4472/#4475's compaction-batch byte cap).
+
+Reachability confirmed LIVE before this check was written (lead-coder's
+explicit dispatch: "the first task is measuring, not implementing a warn"):
+with the shipped `component_weights` default (head=10, tail=15, of 100
+total -> 25% of `main_pool` combined) and `INLINE_CAP_BYTES_PER_TOKEN=4`,
+the worst-case `head_budget + tail_budget` in BYTES equals the model's own
+`max_input_tokens` numerically (0.25 x 4 = 1). At least 5 models in this
+repo's installed litellm catalog exceed `COMPACTION_BATCH_MAX_BYTES`
+(8 MiB) at this weighting -- e.g. `oci/meta.llama-4-scout-17b-16e-instruct`
+at 10,485,760 max_input_tokens, a real, currently-selectable model, not a
+hypothetical. This test drives that EXACT model through the real
+`compute_budgets` path (the same function `CompactionEngine` itself uses)
+to prove the check fires for a genuinely reachable configuration, not a
+synthetic one.
+
+Real collaborators throughout, same idiom as
+`tests/runtime/test_4381_pr1_resource_budget_invariant.py` (this check's
+own sibling/precedent): `compute_budgets` builds a real `ComputedBudgets`;
+only the tiny attribute-passthrough `_Engine`/`_Controller` containers are
+hand-built (no logic of their own); `EventLog` + `collect_events` capture
+the real subscriber path.
+"""
+from __future__ import annotations
+
+from reyn.config import CompactionConfig
+from reyn.core.context_builder import INLINE_CAP_BYTES_PER_TOKEN
+from reyn.core.events.events import EventLog
+from reyn.runtime.history_tail_reader import COMPACTION_BATCH_MAX_BYTES
+from reyn.runtime.services import router_history_buffer as rhb
+from reyn.services.compaction.engine import compute_budgets
+from tests._support.events import collect_events
+
+# A real, currently-cataloged model whose max_input_tokens (10,485,760)
+# is large enough that the shipped component_weights default (25% combined
+# head+tail) converts to MORE than COMPACTION_BATCH_MAX_BYTES (8 MiB) --
+# confirmed via direct litellm.model_cost inspection, not assumed.
+_HUGE_WINDOW_MODEL = "oci/meta.llama-4-scout-17b-16e-instruct"
+# An ordinary model whose window is far too small to ever trip this check.
+_NORMAL_MODEL = "openai/gpt-4o"
+
+
+class _Engine:
+    def __init__(self, budgets) -> None:
+        self.budgets = budgets
+
+
+class _Controller:
+    def __init__(self, engine) -> None:
+        self._engine = engine
+
+
+def _budgets_for(model: str):
+    # `get_max_input_tokens` (inside `compute_budgets`) resolves the real
+    # litellm catalog value only once litellm itself is warm — deferring
+    # otherwise, per `litellm_bootstrap.py`'s own non-blocking design
+    # (#4395 PR-2). This test's whole premise depends on the REAL catalog
+    # value (10,485,760 for the huge-window model), not the 128K
+    # conservative fallback, so force the blocking warm-up first.
+    from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+
+    ensure_litellm_ready()
+    return compute_budgets(CompactionConfig(), model, T_SP=2_000, T_comp_SP=500)
+
+
+def _reset_warned():
+    rhb._compaction_batch_budget_warned.clear()
+
+
+def test_the_huge_window_models_own_budgets_actually_exceed_the_batch_cap():
+    """Tier 2: sanity precondition — with the real, shipped defaults, the
+    chosen model's own head_budget + tail_budget really does exceed
+    COMPACTION_BATCH_MAX_BYTES once converted to bytes. Not assumed."""
+    budgets = _budgets_for(_HUGE_WINDOW_MODEL)
+    combined_bytes = (budgets.head_budget + budgets.tail_budget) * INLINE_CAP_BYTES_PER_TOKEN
+    assert combined_bytes > COMPACTION_BATCH_MAX_BYTES, (
+        f"test precondition failed: {_HUGE_WINDOW_MODEL}'s combined "
+        f"head+tail budget ({combined_bytes} bytes) does not exceed the "
+        f"batch cap ({COMPACTION_BATCH_MAX_BYTES}) -- either the model's "
+        "own catalog entry changed, or component_weights' shipped default "
+        "changed; this test needs a different model/weights to exercise "
+        "the real condition"
+    )
+
+
+def test_a_reachable_large_window_model_emits_the_warning_once():
+    """Tier 2: a genuinely reachable configuration (a real, currently-
+    selectable model whose own window makes head+tail exceed the batch
+    cap) emits compaction_batch_cap_below_head_tail_budget exactly once —
+    repeated calls with the SAME (model, phase) do not re-warn (the SSoT
+    is called on every trigger resolution)."""
+    _reset_warned()
+    events = EventLog()
+    collected = collect_events(events)
+    budgets = _budgets_for(_HUGE_WINDOW_MODEL)
+    controller = _Controller(_Engine(budgets))
+
+    for _ in range(3):
+        result = rhb.resolve_effective_trigger_and_budgets(
+            controller, _HUGE_WINDOW_MODEL, events,
+        )
+        assert result == (budgets.effective_trigger, budgets.head_budget, budgets.tail_budget)
+
+    warnings = [
+        e for e in collected
+        if e.type == "compaction_batch_cap_below_head_tail_budget"
+    ]
+    (only,) = warnings
+    assert only.data["model"] == _HUGE_WINDOW_MODEL
+    assert only.data["phase"] == ""
+    assert only.data["head_budget"] == budgets.head_budget
+    assert only.data["tail_budget"] == budgets.tail_budget
+    assert only.data["combined_bytes"] > only.data["compaction_batch_max_bytes"]
+
+
+def test_warns_again_for_a_different_phase_same_model():
+    """Tier 2: warn-once granularity is per (model, phase), not per model
+    alone — a DIFFERENT phase with the same model re-warns."""
+    _reset_warned()
+    events = EventLog()
+    collected = collect_events(events)
+    budgets = _budgets_for(_HUGE_WINDOW_MODEL)
+    controller = _Controller(_Engine(budgets))
+
+    rhb.resolve_effective_trigger_and_budgets(
+        controller, _HUGE_WINDOW_MODEL, events, phase="alpha",
+    )
+    rhb.resolve_effective_trigger_and_budgets(
+        controller, _HUGE_WINDOW_MODEL, events, phase="alpha",
+    )
+    rhb.resolve_effective_trigger_and_budgets(
+        controller, _HUGE_WINDOW_MODEL, events, phase="beta",
+    )
+
+    warnings = [
+        e for e in collected
+        if e.type == "compaction_batch_cap_below_head_tail_budget"
+    ]
+    phases_warned = sorted(e.data["phase"] for e in warnings)
+    assert phases_warned == ["alpha", "beta"]
+
+
+def test_an_ordinary_model_emits_nothing():
+    """Tier 2: accept-side twin — an ordinary model's head+tail budget
+    stays comfortably under the batch cap; no event fires at all (not a
+    present-but-benign one)."""
+    _reset_warned()
+    events = EventLog()
+    collected = collect_events(events)
+    budgets = _budgets_for(_NORMAL_MODEL)
+    combined_bytes = (budgets.head_budget + budgets.tail_budget) * INLINE_CAP_BYTES_PER_TOKEN
+    assert combined_bytes <= COMPACTION_BATCH_MAX_BYTES, (
+        "sanity: this test's own premise -- an ordinary model must NOT "
+        "exceed the batch cap"
+    )
+    controller = _Controller(_Engine(budgets))
+
+    result = rhb.resolve_effective_trigger_and_budgets(controller, _NORMAL_MODEL, events)
+
+    assert result == (budgets.effective_trigger, budgets.head_budget, budgets.tail_budget)
+    assert not [
+        e for e in collected
+        if e.type == "compaction_batch_cap_below_head_tail_budget"
+    ]
+
+
+def test_no_events_sink_does_not_raise():
+    """Tier 2: events=None (many test/estimation-path callers construct
+    without one) — the check runs and detects the violation internally
+    but never tries to emit, and never raises for lack of a sink."""
+    _reset_warned()
+    budgets = _budgets_for(_HUGE_WINDOW_MODEL)
+    controller = _Controller(_Engine(budgets))
+
+    result = rhb.resolve_effective_trigger_and_budgets(controller, _HUGE_WINDOW_MODEL, None)
+
+    assert result == (budgets.effective_trigger, budgets.head_budget, budgets.tail_budget)


### PR DESCRIPTION
**[e2e-coder]** — #4477: warn-once when the compaction batch cap can't fit head+tail's own budget — measured before implementing, per lead-coder's explicit instruction.

## Measurement (the actual first task, per dispatch)

With the shipped `component_weights` default (head=10, tail=15, of 100 total → 25% combined) and `INLINE_CAP_BYTES_PER_TOKEN=4`, the worst-case `head_budget + tail_budget` in BYTES equals the model's own `max_input_tokens` numerically (0.25 × 4 = 1). Queried this repo's installed litellm catalog directly: **at least 5 models exceed `COMPACTION_BATCH_MAX_BYTES` (8 MiB)** at this weighting — `oci/meta.llama-4-scout-17b-16e-instruct` (10,485,760 tokens) among them, a real, currently-selectable model.

**Verdict: REACHABLE.** This is not an "unreachable, safe to skip" case (the #4458-style "don't build unreachable machinery" exit doesn't apply) — the warn is implemented.

## What changed

- `_check_compaction_batch_within_budget` — the 4th instance of #4381 PR-1's resource/budget comparison class (same conversion point, `INLINE_CAP_BYTES_PER_TOKEN`; same warn-once-per-`(model, phase)` shape as its sibling `_check_resource_within_budget`), wired into `resolve_effective_trigger_and_budgets` right after the existing check.
- New closed-vocabulary audit-event kind `compaction_batch_cap_below_head_tail_budget` — declared in `AUDIT_EVENT_KINDS`, documented in `events.md`, emitted, all in this PR (CLAUDE.md's three-part rule).
- `COMPACTION_BATCH_MAX_BYTES` extracted as a named module constant (`history_tail_reader.py`) so both the reader's own default and this check compare against the SAME value — never two independently-typed `8 * 1024 * 1024` literals that could drift apart.

## Test

New `test_4477_compaction_batch_budget_invariant.py` (mirrors `test_4381_pr1_resource_budget_invariant.py`'s own idiom — real `compute_budgets`, the same function `CompactionEngine` itself uses, + `collect_events`' real subscriber path): drives the EXACT measured model through the real budget-computation path, proving the check fires for a genuinely reachable configuration; warn-once-per-`(model, phase)` semantics; an ordinary model (`openai/gpt-4o`) emits nothing.

## Falsify-verify

Temporarily removed the new check's call site — both reachability-dependent tests went RED (missing warning events). Restored, confirmed GREEN.

## Test plan
- [x] `ruff check src tests`
- [x] `test_tier_audit.py --strict` on the new test file (5/5, 0 Tier-4 violations)
- [x] `verify_module_docstrings.py`
- [x] `mypy_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] `test_audit_event_kind_vocabulary_3410.py` (the CI-checked doc↔code pair for the closed audit-event-kind vocabulary) — 10/10 passed
- [x] Falsify-verify: check-disabled probe went RED, restored GREEN
- [x] Regression sweep: #4381/#4477/compaction-controller/compact-slash/#4470/#4472 test files (60 passed)
- [ ] Visual: n/a (no TUI-visible change)

**tests/ touched — TESTS-READ wait, no self-merge.**

toward #4387; Closes #4477

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

- [x] 🔴 **[lead-coder]**（reviewer 確認済 — 実カタログ依存は precondition 1 本に閉じ込め、挙動は合成 ComputedBudgets。accept 側 2 本も追加）挙動テスト 2 本（warn-once / per-phase 粒度）が litellm の実カタログに依存している（`_budgets_for` → `ensure_litellm_ready()`）。主語は reyn の warn-once ロジックなので合成 budgets で渡すこと。①第三者がモデルを落とせば reyn が正しくても赤（Q1 の「第三者の性質」）②今夜直した #4395 と同じ面（blocking な litellm warm-up）を CI に増やす。到達可能性の witness である precondition テスト 1 本だけ実カタログ依存で残す。

