### PR TITLE
feat(#4478): media/tool-results storage measurement + spill-manifest self-prune

### DIFF
--- a/src/reyn/data/workspace/media_store.py
+++ b/src/reyn/data/workspace/media_store.py
@@ -41,7 +41,11 @@ contract Phase 1 = "(a) Persistent until user delete"):
   - **Disk usage grows unboundedly.** Documented operational caveat —
     operators are expected to ``ls -la .reyn/tool-results/`` and clean
     up periodically. The browsable filename convention makes manual
-    audit straightforward.
+    audit straightforward. :meth:`MediaStore.storage_stats` (#4478
+    Phase 1) gives a scripted read of this instead of a manual ``ls``:
+    file counts + byte totals per directory, policy-independent — it
+    exists to SUPPLY the measurement evidence Phase 2 is gated on, it
+    does not itself decide anything.
   - **Phase 2 reservation.** When measurement surfaces a real disk
     pressure or stale-handle problem (= not just hypothetical), Phase 2
     adds a config-driven policy: TTL / LRU / session-end / mixed. The
@@ -51,7 +55,16 @@ contract Phase 1 = "(a) Persistent until user delete"):
 
 Out of scope (= future work):
   - Phase 2 cleanup policy (= TTL / max-N / session boundary). Trigger
-    is measurement evidence, not hypothesis.
+    is measurement evidence, not hypothesis — #4478 lands the
+    measurement (``storage_stats``) without the policy. A future Phase
+    2's own acceptance criteria MUST cover the user-visible side, not
+    just "no consumer crashes": every read consumer already tolerates
+    a missing file (404 / ``None`` / a silently dropped content block —
+    #4478's own consumer sweep confirmed this), but a silently dropped
+    block is a scrollback image or tool-result the USER sees vanish
+    with no explanation, not a safe no-op. "Does this crash" is not
+    "is this a good experience" — Phase 2 needs to answer the second
+    question too, not just the first.
   - Cross-host RPC dispatcher for ``resource_uri`` (= #385 β core
     impl sub-task 3, pending scheme arbitration).
 """
@@ -191,6 +204,39 @@ class MediaStoreConfig:
     tool_results_dir: str = ".reyn/tool-results"
 
 
+@dataclass(frozen=True)
+class MediaStorageStats:
+    """#4478 Phase 1: policy-independent on-disk footprint snapshot for
+    :meth:`MediaStore.storage_stats`. Measurement only — no field here
+    implies or drives any eviction; see that method's docstring."""
+    media_file_count: int
+    media_bytes: int
+    tool_result_file_count: int
+    tool_result_bytes: int
+
+
+def _dir_stats(directory: Path) -> tuple[int, int]:
+    """(file_count, total_bytes) for the flat, single-level layout both
+    storage dirs use (see the module docstring's filename convention —
+    neither dir nests subdirectories). Missing directory → ``(0, 0)``,
+    same as "nothing written yet" rather than an error; a file that
+    disappears mid-scan (a concurrent delete) is skipped rather than
+    raising, since this is a best-effort snapshot, not a transactional
+    read."""
+    if not directory.is_dir():
+        return 0, 0
+    count = 0
+    total = 0
+    for entry in directory.iterdir():
+        try:
+            if entry.is_file():
+                count += 1
+                total += entry.stat().st_size
+        except OSError:
+            continue
+    return count, total
+
+
 # #385 β core impl sub-task 1: cross-host capable resource URI scheme.
 # A path-ref minted with ``agent_name`` set carries this scheme so a
 # downstream consumer (= another agent / a different host) can dispatch
@@ -324,6 +370,7 @@ class MediaStore:
         if not manifest.exists():
             return set()
         paths: "set[Path]" = set()
+        stale = False
         try:
             for line in manifest.read_text(encoding="utf-8").splitlines():
                 line = line.strip()
@@ -331,12 +378,49 @@ class MediaStore:
                     continue
                 try:
                     entry = json.loads(line)
-                    paths.add(Path(entry["path"]))
+                    p = Path(entry["path"])
                 except (json.JSONDecodeError, KeyError, TypeError):
                     continue  # one malformed line never invalidates the rest
+                # #4478: an entry whose target no longer exists on disk (the
+                # artifact was manually deleted, or GC'd by a future Phase 2
+                # policy) protects nothing — is_tool_result_spill only needs
+                # to answer "is THIS path a spill I wrote", and a re-read of
+                # a now-missing path already fails on its own, normally,
+                # with no re-spill loop to guard against. Dropping it here
+                # is what bounds this manifest's otherwise-unbounded growth
+                # (lead-coder's #4478 dispatch, concern ②: it is read in
+                # full on every MediaStore construction).
+                if p.exists():
+                    paths.add(p)
+                else:
+                    stale = True
         except OSError:
             return set()  # best-effort — an unreadable manifest degrades to empty, not a crash
+        if stale:
+            self._persist_spill_manifest(paths)
         return paths
+
+    def _persist_spill_manifest(self, paths: "set[Path]") -> None:
+        """#4478: rewrite the MANIFEST ONLY — the ledger of which paths
+        this store has spilled, under ``.reyn/cache/``. Never touches an
+        artifact under ``tool_results_dir`` itself; an entry only reaches
+        this rewrite because :meth:`_load_spill_manifest` already found its
+        target file gone from disk (deleted by something else, out of
+        scope for this store). This prune deletes zero bytes of anyone's
+        actual content — it only stops re-reading a manifest line that
+        stopped meaning anything the moment its file disappeared.
+        Best-effort, same as the append path in :meth:`save_tool_result` —
+        a write failure here (e.g. a read-only ``.reyn/cache/``) must
+        never fail construction; it only means this process's prune
+        didn't stick and the next one retries."""
+        manifest = self._spill_manifest_path()
+        try:
+            manifest.write_text(
+                "".join(json.dumps({"path": str(p)}) + "\n" for p in sorted(paths)),
+                encoding="utf-8",
+            )
+        except OSError:
+            pass
 
     def is_tool_result_spill(self, path: "str | Path") -> bool:
         """#4381: whether *path* is a file THIS store itself wrote via
@@ -676,3 +760,21 @@ class MediaStore:
     def tool_results_dir(self) -> Path:
         """Absolute path of the tool result text storage directory."""
         return self._tool_results_dir
+
+    def storage_stats(self) -> "MediaStorageStats":
+        """#4478 Phase 1: a read-only, policy-independent snapshot of this
+        store's on-disk footprint. Never deletes, never evicts — this is
+        the measurement surface the module docstring's own "Phase 2
+        reservation" names as the precondition for any future TTL/max-N/
+        session-end policy ("trigger is measurement evidence, not
+        hypothesis"). Mirrors the chat presenter's own public
+        ``image_cache_size_bytes``-style snapshot-read pattern (#4376),
+        applied here to on-disk rather than in-memory storage."""
+        media_count, media_bytes = _dir_stats(self._media_dir)
+        tr_count, tr_bytes = _dir_stats(self._tool_results_dir)
+        return MediaStorageStats(
+            media_file_count=media_count,
+            media_bytes=media_bytes,
+            tool_result_file_count=tr_count,
+            tool_result_bytes=tr_bytes,
+        )

--- a/src/reyn/interfaces/cli/commands/__init__.py
+++ b/src/reyn/interfaces/cli/commands/__init__.py
@@ -17,6 +17,7 @@ from . import embeddings as embeddings
 from . import events as events
 from . import init as init
 from . import mcp as mcp
+from . import media as media
 from . import memory as memory
 from . import permissions as permissions
 from . import pipe as pipe
@@ -30,4 +31,4 @@ from . import web as web
 # Order is the order shown in `reyn --help`.
 # `source` (reyn source list/describe/rm) retired FP-0066 P1c — user-facing
 # in-core RAG source creation/management is gone; user RAG = FP-0063 plugin.
-ALL = [init, config, run_once, chat, agent, topology, memory, permissions, auth, events, web, mcp, pipe, plugin, secret, cron, dogfood, embeddings, support_bundle, audit]
+ALL = [init, config, run_once, chat, agent, topology, memory, permissions, auth, events, web, mcp, media, pipe, plugin, secret, cron, dogfood, embeddings, support_bundle, audit]

--- a/src/reyn/interfaces/cli/commands/media.py
+++ b/src/reyn/interfaces/cli/commands/media.py
@@ -1,0 +1,52 @@
+"""`reyn media stats` — read-only on-disk footprint report for
+``.reyn/media/`` and ``.reyn/tool-results/`` (#4478 Phase 1).
+
+Exists so ``MediaStore.storage_stats`` — the measurement `media_store.py`'s
+own module docstring names as the precondition for any future Phase 2
+eviction policy ("trigger is measurement evidence, not hypothesis") — has an
+actual caller. A measurement method with no reader is the shape this repo
+has hit repeatedly: declared, implemented, tested, invoked by nobody. This
+command is that reader: an operator (or a script) runs it to decide whether
+disk pressure is real BEFORE any TTL/max-N policy gets designed. No
+deletion, no policy, no threshold — see `media_store.py` for why those stay
+out of scope here.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def register(sub) -> None:
+    p = sub.add_parser(
+        "media", help="Inspect Reyn-managed media / tool-result storage",
+    )
+    media_sub = p.add_subparsers(dest="media_command", metavar="<subcommand>")
+    media_sub.required = True
+    stats_p = media_sub.add_parser(
+        "stats",
+        help=(
+            "Print on-disk file counts + byte totals for "
+            ".reyn/media/ and .reyn/tool-results/"
+        ),
+    )
+    stats_p.add_argument(
+        "--project-root",
+        default=".",
+        help="Project root containing .reyn/ (default: current directory).",
+    )
+    stats_p.set_defaults(func=run_stats)
+
+
+def run_stats(args: argparse.Namespace) -> None:
+    from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
+
+    project_root = Path(args.project_root).resolve()
+    store = MediaStore(MediaStoreConfig(), project_root=project_root)
+    stats = store.storage_stats()
+    print(f"{'directory':<16}{'files':>10}{'bytes':>16}")
+    print(f"{'media/':<16}{stats.media_file_count:>10}{stats.media_bytes:>16,}")
+    print(
+        f"{'tool-results/':<16}"
+        f"{stats.tool_result_file_count:>10}{stats.tool_result_bytes:>16,}",
+    )

--- a/tests/data/test_4478_media_storage_stats.py
+++ b/tests/data/test_4478_media_storage_stats.py
@@ -1,0 +1,134 @@
+"""Tier 2: #4478 Phase 1 — ``MediaStore.storage_stats`` (policy-independent
+on-disk footprint measurement) and the spill-manifest self-prune.
+
+Both are measurement/hygiene only — neither deletes an artifact under
+``media_dir``/``tool_results_dir``. See ``media_store.py``'s own module
+docstring for why any actual eviction policy (TTL/max-N) stays out of
+scope until real measurement evidence exists.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
+
+
+def _store(tmp_path: Path, agent_name: str | None = None) -> MediaStore:
+    return MediaStore(MediaStoreConfig(), project_root=tmp_path, agent_name=agent_name)
+
+
+# ── storage_stats ─────────────────────────────────────────────────────────
+
+
+def test_storage_stats_reports_zero_on_a_fresh_project(tmp_path):
+    """Tier 2: neither directory exists yet — stats report all-zero, not
+    an error."""
+    stats = _store(tmp_path).storage_stats()
+    assert stats.media_file_count == 0
+    assert stats.media_bytes == 0
+    assert stats.tool_result_file_count == 0
+    assert stats.tool_result_bytes == 0
+
+
+def test_storage_stats_counts_files_and_bytes_written_through_the_real_api(tmp_path):
+    """Tier 2: writes via save_image/save_tool_result — the real production
+    call paths, not hand-placed files — and confirms storage_stats reflects
+    them exactly."""
+    store = _store(tmp_path)
+    img_a = b"\x89PNG" + b"\x00" * 100
+    img_b = b"\x89PNG" + b"\x00" * 50
+    store.save_image(img_a, mime_type="image/png", chain_id="c1", tool="web_fetch", seq=1)
+    store.save_image(img_b, mime_type="image/png", chain_id="c1", tool="web_fetch", seq=2)
+    store.save_tool_result("hello world", chain_id="c1", tool="exec", seq=1)
+
+    stats = store.storage_stats()
+    assert stats.media_file_count == 2
+    assert stats.media_bytes == len(img_a) + len(img_b)
+    assert stats.tool_result_file_count == 1
+    assert stats.tool_result_bytes == len(b"hello world")
+
+
+def test_storage_stats_never_deletes_or_writes_anything(tmp_path):
+    """Tier 2: (accept-side) calling storage_stats repeatedly does not
+    change the directory contents — this is a read, not a side-effecting
+    scan."""
+    store = _store(tmp_path)
+    store.save_image(b"x" * 10, mime_type="image/png", chain_id="c", tool="t", seq=1)
+    before = sorted(p.name for p in store.media_dir.iterdir())
+
+    store.storage_stats()
+    store.storage_stats()
+
+    after = sorted(p.name for p in store.media_dir.iterdir())
+    assert after == before
+
+
+# ── spill-manifest self-prune (#4478 condition ②: prunes the LEDGER only) ──
+
+
+def _manifest_path(tmp_path: Path) -> Path:
+    return tmp_path / ".reyn" / "cache" / "tool_result_spills.jsonl"
+
+
+def test_prune_drops_a_manifest_entry_whose_file_was_deleted_out_of_band(tmp_path):
+    """Tier 2: a spill written in an earlier process, then deleted by
+    something outside MediaStore (the documented "user/operator deletes
+    out-of-band" lifecycle) — the NEXT construction's manifest load drops
+    the now-stale entry rather than carrying it forever."""
+    store = _store(tmp_path)
+    block = store.save_tool_result("big output", chain_id="c1", tool="exec", seq=1)
+    spilled_path = tmp_path / block["path"]
+    assert spilled_path.exists()
+
+    # Out-of-band deletion — NOT via MediaStore.
+    spilled_path.unlink()
+
+    # A fresh construction (= a later process) reloads the manifest.
+    reopened = _store(tmp_path)
+    assert not reopened.is_tool_result_spill(block["path"])
+
+    # The manifest ON DISK was rewritten to drop the stale line too — a
+    # yet-later construction doesn't need to re-discover the same staleness.
+    manifest_lines = _manifest_path(tmp_path).read_text(encoding="utf-8").splitlines()
+    assert manifest_lines == []
+
+
+def test_prune_keeps_a_manifest_entry_whose_file_still_exists(tmp_path):
+    """Tier 2: (accept-side) the prune must not touch a live entry — this
+    is the mirror of the drop test above."""
+    store = _store(tmp_path)
+    block = store.save_tool_result("still here", chain_id="c1", tool="exec", seq=1)
+
+    reopened = _store(tmp_path)
+    assert reopened.is_tool_result_spill(block["path"])
+    manifest_paths = {
+        json.loads(line)["path"]
+        for line in _manifest_path(tmp_path).read_text(encoding="utf-8").splitlines()
+    }
+    assert manifest_paths == {str((tmp_path / block["path"]).resolve())}
+
+
+def test_prune_never_deletes_the_referenced_artifact_itself(tmp_path):
+    """Tier 2: #4478 condition ② — the prune rewrites the MANIFEST (the
+    ledger under .reyn/cache/), never a file under tool_results_dir. This
+    is the falsifiable form of "prune deletes zero bytes of anyone's
+    actual content": construct a mixed manifest (one live entry, one
+    entry a test writes by hand pointing at a path that never existed)
+    and confirm the live artifact survives the prune untouched."""
+    store = _store(tmp_path)
+    block = store.save_tool_result("keep me", chain_id="c1", tool="exec", seq=1)
+    live_path = tmp_path / block["path"]
+
+    # Hand-append a manifest line for a path that was never written —
+    # simulates a manifest entry surviving from an artifact deleted
+    # before this test's own store even started.
+    manifest = _manifest_path(tmp_path)
+    ghost = tmp_path / ".reyn" / "tool-results" / "ghost.txt"
+    with manifest.open("a", encoding="utf-8") as f:
+        f.write(json.dumps({"path": str(ghost.resolve())}) + "\n")
+
+    _store(tmp_path)  # triggers the prune
+
+    assert live_path.exists()
+    assert live_path.read_text(encoding="utf-8") == "keep me"

--- a/tests/interfaces/test_4478_media_cli.py
+++ b/tests/interfaces/test_4478_media_cli.py
@@ -1,0 +1,72 @@
+"""Tier 2: #4478 Phase 1 — ``reyn media stats`` CLI contract.
+
+Gives ``MediaStore.storage_stats`` an actual caller (lead-coder's #4478
+review condition ①: a measurement surface with no reader is a mechanism
+nobody uses, the shape flagged repeatedly this session). No mocks — drives
+the real ``run_stats`` against real on-disk state under ``tmp_path``.
+"""
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
+from reyn.interfaces.cli.commands.media import register, run_stats
+
+
+def test_stats_reports_zero_on_a_fresh_project(tmp_path: Path, monkeypatch, capsys):
+    """Tier 2: no .reyn/media or .reyn/tool-results yet — reports zeros,
+    does not error or create the directories as a side effect."""
+    monkeypatch.chdir(tmp_path)
+    run_stats(Namespace(project_root="."))
+    out = capsys.readouterr().out
+    assert "media/" in out
+    assert "tool-results/" in out
+    assert not (tmp_path / ".reyn" / "media").exists()
+    assert not (tmp_path / ".reyn" / "tool-results").exists()
+
+
+def test_stats_reflects_real_writes(tmp_path: Path, monkeypatch, capsys):
+    """Tier 2: files written through the real MediaStore API show up in the
+    CLI's printed counts/totals."""
+    store = MediaStore(MediaStoreConfig(), project_root=tmp_path)
+    store.save_image(b"x" * 30, mime_type="image/png", chain_id="c", tool="t", seq=1)
+    store.save_tool_result("hello", chain_id="c", tool="t", seq=1)
+
+    monkeypatch.chdir(tmp_path)
+    run_stats(Namespace(project_root="."))
+    out = capsys.readouterr().out
+
+    media_line = next(line for line in out.splitlines() if line.startswith("media/"))
+    tr_line = next(line for line in out.splitlines() if line.startswith("tool-results/"))
+    assert "1" in media_line and "30" in media_line
+    assert "1" in tr_line and str(len("hello")) in tr_line
+
+
+def test_stats_honors_an_explicit_project_root(tmp_path: Path, capsys):
+    """Tier 2: --project-root overrides cwd — the CLI does not implicitly
+    assume the current directory is the project."""
+    store = MediaStore(MediaStoreConfig(), project_root=tmp_path)
+    store.save_image(b"y" * 7, mime_type="image/png", chain_id="c", tool="t", seq=1)
+
+    run_stats(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+    media_line = next(line for line in out.splitlines() if line.startswith("media/"))
+    assert "1" in media_line and "7" in media_line
+
+
+def test_media_stats_is_registered_on_the_reyn_parser():
+    """Tier 2: (reachability) 'reyn media stats' is wired into the real
+    top-level parser, not just importable in isolation — this is the exact
+    shape ('declared, implemented, tested, invoked by nobody') #4478's
+    review flagged; asserts the subcommand is actually reachable through
+    argparse, the real entry point an operator uses."""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    sub.required = True
+    register(sub)
+
+    args = parser.parse_args(["media", "stats", "--project-root", "/tmp"])
+    assert args.func is run_stats


### PR DESCRIPTION
**[e2e-coder]** — part of #4478 (media/tool-results GC). Scope: Phase 1 measurement only, agreed with lead-coder (see broker + issue comment).

## What
- `MediaStore.storage_stats()` — read-only, policy-independent file-count/byte-total snapshot for `media_dir`/`tool_results_dir`. Never deletes.
- `reyn media stats` CLI — gives `storage_stats` an actual reader (review condition ①: a measurement method with no caller is a mechanism nobody uses).
- Spill manifest (`.reyn/cache/tool_result_spills.jsonl`) self-prunes entries whose target file no longer exists, at load time — bounds its per-construction read cost (review condition ②'s startup-cost half). Rewrites the manifest ledger only; never touches an artifact under `tool_results_dir`.
- Module docstring: names `storage_stats` as the Phase 2 measurement-evidence supplier, and records that a future Phase 2's acceptance criteria must cover the user-visible side of eviction (a silently dropped content block is a scrollback artifact vanishing on the user, not a safe no-op) — review condition ②'s other half.

## What this explicitly does NOT do
No TTL / max-N / session-end auto-deletion. `media_store.py`'s own module docstring states the Phase 2 trigger is "measurement evidence, not hypothesis" — none exists yet — and the exact numbers are an owner call per CLAUDE.md's "no unjustified constant without a knob" rule.

## Consumer enumeration (lead-coder's precondition, full detail on issue #4478)
All 3 read paths for these directories already treat a missing file as a normal case:
- `router_history_buffer.py` path-ref rehydration → `found=False` → block dropped silently, no crash.
- `interfaces/web/routers/resources.py` (`reyn web` gateway) → 404, already documented as "deleted by the user" being expected.
- `mcp/server.py`'s MCP resource serving → same `read_tool_result`/`found` contract as above.

`reyn-dir-layout.md` classifies both dirs as **audit** ("kept as a record, never restored") — confirmed by direct read, not memory — so this is consistent with that classification; not part of the recovery/restore path.

## Test plan
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict` on both new test files — 0 errors
- [x] `python scripts/verify_module_docstrings.py` on changed src files — OK
- [x] `python scripts/mypy_ratchet.py` — no new findings (212/215 baselined, unchanged)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/data/ tests/interfaces/test_4478_media_cli.py tests/runtime/test_router_ctx_media_store_2409.py` — 166+ passed, 0 failed
- [x] Falsify-verified the manifest-prune: mixed live+ghost manifest, confirmed live artifact survives byte-for-byte (`test_prune_never_deletes_the_referenced_artifact_itself`)
- [ ] Visual — n/a, no UI surface

part of #4478
