### PR TITLE
feat(#4476): history.jsonl storage measurement, same surface as #4485

### DIFF
--- a/src/reyn/interfaces/cli/commands/__init__.py
+++ b/src/reyn/interfaces/cli/commands/__init__.py
@@ -17,13 +17,13 @@ from . import embeddings as embeddings
 from . import events as events
 from . import init as init
 from . import mcp as mcp
-from . import media as media
 from . import memory as memory
 from . import permissions as permissions
 from . import pipe as pipe
 from . import plugin as plugin
 from . import run_once as run_once
 from . import secret as secret
+from . import storage as storage
 from . import support_bundle as support_bundle
 from . import topology as topology
 from . import web as web
@@ -31,4 +31,4 @@ from . import web as web
 # Order is the order shown in `reyn --help`.
 # `source` (reyn source list/describe/rm) retired FP-0066 P1c — user-facing
 # in-core RAG source creation/management is gone; user RAG = FP-0063 plugin.
-ALL = [init, config, run_once, chat, agent, topology, memory, permissions, auth, events, web, mcp, media, pipe, plugin, secret, cron, dogfood, embeddings, support_bundle, audit]
+ALL = [init, config, run_once, chat, agent, topology, memory, permissions, auth, events, web, mcp, storage, pipe, plugin, secret, cron, dogfood, embeddings, support_bundle, audit]

--- a/src/reyn/interfaces/cli/commands/media.py
+++ b/src/reyn/interfaces/cli/commands/media.py
@@ -1,15 +1,23 @@
 """`reyn media stats` — read-only on-disk footprint report for
-``.reyn/media/`` and ``.reyn/tool-results/`` (#4478 Phase 1).
+``.reyn/media/``, ``.reyn/tool-results/`` (#4478 Phase 1), and every
+``history.jsonl`` under ``.reyn/agents/`` (#4476 Phase 1).
 
-Exists so ``MediaStore.storage_stats`` — the measurement `media_store.py`'s
-own module docstring names as the precondition for any future Phase 2
-eviction policy ("trigger is measurement evidence, not hypothesis") — has an
-actual caller. A measurement method with no reader is the shape this repo
-has hit repeatedly: declared, implemented, tested, invoked by nobody. This
-command is that reader: an operator (or a script) runs it to decide whether
-disk pressure is real BEFORE any TTL/max-N policy gets designed. No
-deletion, no policy, no threshold — see `media_store.py` for why those stay
-out of scope here.
+Exists so these measurement methods — each named by their own subsystem's
+module docstring as the precondition for a future Phase 2 eviction/retention
+policy ("trigger is measurement evidence, not hypothesis") — have an actual
+caller. A measurement method with no reader is the shape this repo has hit
+repeatedly: declared, implemented, tested, invoked by nobody. This command
+is that reader: an operator (or a script) runs it to decide whether disk
+pressure is real BEFORE any TTL/max-N/retention policy gets designed. No
+deletion, no policy, no threshold — see `media_store.py` and
+`history_tail_reader.py` for why those stay out of scope here.
+
+#4476 lands on this SAME surface rather than a second command (lead-coder
+review: "揃える" — align to what #4485 already built) — both are the same
+shape (policy-independent bytes/count snapshot feeding an eventual owner
+retention decision), so one operator-facing place to look is more honest
+than two commands that answer the same underlying question for different
+subsystems.
 """
 from __future__ import annotations
 
@@ -19,7 +27,7 @@ from pathlib import Path
 
 def register(sub) -> None:
     p = sub.add_parser(
-        "media", help="Inspect Reyn-managed media / tool-result storage",
+        "media", help="Inspect Reyn-managed media / tool-result / history storage",
     )
     media_sub = p.add_subparsers(dest="media_command", metavar="<subcommand>")
     media_sub.required = True
@@ -27,7 +35,7 @@ def register(sub) -> None:
         "stats",
         help=(
             "Print on-disk file counts + byte totals for "
-            ".reyn/media/ and .reyn/tool-results/"
+            ".reyn/media/, .reyn/tool-results/, and every history.jsonl"
         ),
     )
     stats_p.add_argument(
@@ -40,13 +48,22 @@ def register(sub) -> None:
 
 def run_stats(args: argparse.Namespace) -> None:
     from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
+    from reyn.runtime.history_tail_reader import aggregate_history_stats
 
     project_root = Path(args.project_root).resolve()
     store = MediaStore(MediaStoreConfig(), project_root=project_root)
     stats = store.storage_stats()
+    hist = aggregate_history_stats(project_root)
+
     print(f"{'directory':<16}{'files':>10}{'bytes':>16}")
     print(f"{'media/':<16}{stats.media_file_count:>10}{stats.media_bytes:>16,}")
     print(
         f"{'tool-results/':<16}"
         f"{stats.tool_result_file_count:>10}{stats.tool_result_bytes:>16,}",
+    )
+    print()
+    print(f"{'':<16}{'files':>10}{'bytes':>16}{'turns':>12}")
+    print(
+        f"{'history.jsonl':<16}"
+        f"{hist.file_count:>10}{hist.total_bytes:>16,}{hist.total_lines:>12,}",
     )

--- a/src/reyn/interfaces/cli/commands/storage.py
+++ b/src/reyn/interfaces/cli/commands/storage.py
@@ -1,6 +1,13 @@
-"""`reyn media stats` — read-only on-disk footprint report for
+"""`reyn storage stats` — read-only on-disk footprint report for
 ``.reyn/media/``, ``.reyn/tool-results/`` (#4478 Phase 1), and every
 ``history.jsonl`` under ``.reyn/agents/`` (#4476 Phase 1).
+
+Named ``storage``, not ``media`` (renamed from the original #4485 name once
+#4476 landed on the same command — lead-coder review on #4488): once
+``history.jsonl`` reports through here too, "media" no longer describes
+what the command covers. ``storage`` is the name all three share — "how
+much of reyn's own on-disk footprint currently exists" — and stays correct
+as more subsystems land measurement here.
 
 Exists so these measurement methods — each named by their own subsystem's
 module docstring as the precondition for a future Phase 2 eviction/retention
@@ -27,11 +34,11 @@ from pathlib import Path
 
 def register(sub) -> None:
     p = sub.add_parser(
-        "media", help="Inspect Reyn-managed media / tool-result / history storage",
+        "storage", help="Inspect Reyn-managed media / tool-result / history storage",
     )
-    media_sub = p.add_subparsers(dest="media_command", metavar="<subcommand>")
-    media_sub.required = True
-    stats_p = media_sub.add_parser(
+    storage_sub = p.add_subparsers(dest="storage_command", metavar="<subcommand>")
+    storage_sub.required = True
+    stats_p = storage_sub.add_parser(
         "stats",
         help=(
             "Print on-disk file counts + byte totals for "

--- a/src/reyn/runtime/history_tail_reader.py
+++ b/src/reyn/runtime/history_tail_reader.py
@@ -32,10 +32,16 @@ read.
 Older entries this reader doesn't return are NOT lost: ``history.jsonl`` is
 append-only, so anything left unread here is still on disk, reachable later
 via the extend-on-demand path (#4387 Phase B ②, not yet implemented).
+
+#4476 Phase 1 adds a small, separate section at the end of this module:
+policy-independent measurement (bytes/line counts across every
+``history.jsonl``) that reads to no truncation path — see that section's
+own header comment for why it lives here rather than a new module.
 """
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -304,3 +310,73 @@ def read_history_before(
 
     collected.reverse()
     return collected
+
+
+# ── #4476 Phase 1: read-only measurement, no truncation ─────────────────
+#
+# retention.py:84-87's own docstring states ``history.jsonl`` is "append-only
+# and never floor-truncated" — this file has NO deletion path today, by
+# design (branch visibility / compaction's own watermark / TUI scrollback
+# all depend on old lines still being readable, per #4476's own issue body).
+# The owner-measured 500MB figure (#4387) is a single point — one
+# environment, one moment — too thin to set a retention policy from. This
+# section exists ONLY to widen that single point into an actual measured
+# population, same order as #4478/#4485: land the measurement, let evidence
+# accumulate, THEN an owner-set policy (never invented here) decides
+# anything. See this module's own docstring for why truncation isn't safe
+# to add casually, and :func:`read_history_after`'s docstring for the
+# ``covers_through_seq`` floor a Phase 2 truncation would eventually have to
+# respect.
+
+
+@dataclass(frozen=True)
+class HistoryStorageStats:
+    """#4476 Phase 1: policy-independent snapshot of every discovered
+    ``history.jsonl``'s on-disk footprint under a project's ``.reyn/agents/``
+    tree. Measurement only — no field here implies or drives any deletion."""
+    file_count: int
+    total_bytes: int
+    total_lines: int
+
+
+def history_file_stats(path: Path) -> "tuple[int, int]":
+    """``(bytes, lines)`` for one ``history.jsonl``. ``bytes`` is the exact
+    on-disk file size (``stat().st_size``); ``lines`` counts non-empty
+    JSONL lines (= turns), the same "blank line is not an entry" rule
+    :func:`read_history_after` already uses — so this count agrees with
+    what a durable-store reader actually sees, not a raw ``wc -l``.
+    Missing file → ``(0, 0)``, matching "nothing written yet" rather than
+    an error."""
+    if not path.is_file():
+        return 0, 0
+    total_bytes = path.stat().st_size
+    lines = 0
+    with path.open("r", encoding="utf-8") as f:
+        for raw in f:
+            if raw.strip():
+                lines += 1
+    return total_bytes, lines
+
+
+def aggregate_history_stats(project_root: Path) -> HistoryStorageStats:
+    """#4476 Phase 1: sum :func:`history_file_stats` over every
+    ``history.jsonl`` found anywhere under ``<project_root>/.reyn/agents/``
+    (``**/history.jsonl`` — covers both a top-level agent's own file and any
+    nested spawned-session workspace, without hardcoding the exact nesting
+    depth, which is an internal detail of ``registry.py`` this module has no
+    reason to duplicate). A project with no ``.reyn/agents/`` yet returns
+    all-zero, not an error."""
+    agents_dir = project_root / ".reyn" / "agents"
+    if not agents_dir.is_dir():
+        return HistoryStorageStats(file_count=0, total_bytes=0, total_lines=0)
+    file_count = 0
+    total_bytes = 0
+    total_lines = 0
+    for hist_path in sorted(agents_dir.glob("**/history.jsonl")):
+        b, lines = history_file_stats(hist_path)
+        file_count += 1
+        total_bytes += b
+        total_lines += lines
+    return HistoryStorageStats(
+        file_count=file_count, total_bytes=total_bytes, total_lines=total_lines,
+    )

--- a/tests/interfaces/test_4478_media_cli.py
+++ b/tests/interfaces/test_4478_media_cli.py
@@ -1,9 +1,10 @@
-"""Tier 2: #4478 Phase 1 — ``reyn media stats`` CLI contract.
+"""Tier 2: #4478/#4476 Phase 1 — ``reyn media stats`` CLI contract.
 
-Gives ``MediaStore.storage_stats`` an actual caller (lead-coder's #4478
-review condition ①: a measurement surface with no reader is a mechanism
-nobody uses, the shape flagged repeatedly this session). No mocks — drives
-the real ``run_stats`` against real on-disk state under ``tmp_path``.
+Gives ``MediaStore.storage_stats`` and ``aggregate_history_stats`` an actual
+caller (lead-coder's #4478 review condition ①: a measurement surface with
+no reader is a mechanism nobody uses, the shape flagged repeatedly this
+session; #4476 lands on this SAME surface per the same review). No mocks —
+drives the real ``run_stats`` against real on-disk state under ``tmp_path``.
 """
 from __future__ import annotations
 
@@ -53,6 +54,23 @@ def test_stats_honors_an_explicit_project_root(tmp_path: Path, capsys):
     out = capsys.readouterr().out
     media_line = next(line for line in out.splitlines() if line.startswith("media/"))
     assert "1" in media_line and "7" in media_line
+
+
+def test_stats_reflects_a_real_history_jsonl(tmp_path: Path, monkeypatch, capsys):
+    """Tier 2: #4476 — a history.jsonl under .reyn/agents/<name>/ shows up
+    in the same command's output, not a separate one."""
+    hist = tmp_path / ".reyn" / "agents" / "alice" / "history.jsonl"
+    hist.parent.mkdir(parents=True)
+    hist.write_text('{"seq": 1}\n{"seq": 2}\n{"seq": 3}\n', encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    run_stats(Namespace(project_root="."))
+    out = capsys.readouterr().out
+
+    hist_line = next(line for line in out.splitlines() if line.startswith("history.jsonl"))
+    assert "1" in hist_line  # 1 file found
+    assert "3" in hist_line  # 3 turns
+    assert str(hist.stat().st_size) in hist_line
 
 
 def test_media_stats_is_registered_on_the_reyn_parser():

--- a/tests/interfaces/test_4488_storage_cli.py
+++ b/tests/interfaces/test_4488_storage_cli.py
@@ -1,10 +1,13 @@
-"""Tier 2: #4478/#4476 Phase 1 — ``reyn media stats`` CLI contract.
+"""Tier 2: #4478/#4476 Phase 1 — ``reyn storage stats`` CLI contract.
 
 Gives ``MediaStore.storage_stats`` and ``aggregate_history_stats`` an actual
 caller (lead-coder's #4478 review condition ①: a measurement surface with
 no reader is a mechanism nobody uses, the shape flagged repeatedly this
-session; #4476 lands on this SAME surface per the same review). No mocks —
-drives the real ``run_stats`` against real on-disk state under ``tmp_path``.
+session; #4476 lands on this SAME surface per the same review). Command
+renamed ``media`` → ``storage`` on lead-coder's #4488 review, once
+``history.jsonl`` reporting made the original name mismatch what it covers
+— this is that rename's follow-through test file. No mocks — drives the
+real ``run_stats`` against real on-disk state under ``tmp_path``.
 """
 from __future__ import annotations
 
@@ -12,7 +15,7 @@ from argparse import Namespace
 from pathlib import Path
 
 from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
-from reyn.interfaces.cli.commands.media import register, run_stats
+from reyn.interfaces.cli.commands.storage import register, run_stats
 
 
 def test_stats_reports_zero_on_a_fresh_project(tmp_path: Path, monkeypatch, capsys):
@@ -73,8 +76,8 @@ def test_stats_reflects_a_real_history_jsonl(tmp_path: Path, monkeypatch, capsys
     assert str(hist.stat().st_size) in hist_line
 
 
-def test_media_stats_is_registered_on_the_reyn_parser():
-    """Tier 2: (reachability) 'reyn media stats' is wired into the real
+def test_storage_stats_is_registered_on_the_reyn_parser():
+    """Tier 2: (reachability) 'reyn storage stats' is wired into the real
     top-level parser, not just importable in isolation — this is the exact
     shape ('declared, implemented, tested, invoked by nobody') #4478's
     review flagged; asserts the subcommand is actually reachable through
@@ -86,5 +89,5 @@ def test_media_stats_is_registered_on_the_reyn_parser():
     sub.required = True
     register(sub)
 
-    args = parser.parse_args(["media", "stats", "--project-root", "/tmp"])
+    args = parser.parse_args(["storage", "stats", "--project-root", "/tmp"])
     assert args.func is run_stats

--- a/tests/runtime/test_4476_history_storage_stats.py
+++ b/tests/runtime/test_4476_history_storage_stats.py
@@ -2,7 +2,7 @@
 (`history_file_stats`/`aggregate_history_stats`).
 
 Read-only, policy-independent — feeds the SAME "measurement first, owner
-decides retention numbers later" order as #4478/#4485 (`reyn media stats`).
+decides retention numbers later" order as #4478/#4485 (`reyn storage stats`).
 No truncation/deletion is introduced anywhere in this file or by the
 functions it tests.
 """

--- a/tests/runtime/test_4476_history_storage_stats.py
+++ b/tests/runtime/test_4476_history_storage_stats.py
@@ -1,0 +1,127 @@
+"""Tier 2: #4476 Phase 1 — history.jsonl storage measurement
+(`history_file_stats`/`aggregate_history_stats`).
+
+Read-only, policy-independent — feeds the SAME "measurement first, owner
+decides retention numbers later" order as #4478/#4485 (`reyn media stats`).
+No truncation/deletion is introduced anywhere in this file or by the
+functions it tests.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.runtime.history_tail_reader import (
+    aggregate_history_stats,
+    history_file_stats,
+)
+
+
+def _write_history(path: Path, lines: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n" if lines else "", encoding="utf-8")
+
+
+# ── history_file_stats (single file) ────────────────────────────────────
+
+
+def test_missing_file_reports_zero(tmp_path: Path):
+    """Tier 2: no history.jsonl yet — (0, 0), not an error."""
+    b, lines = history_file_stats(tmp_path / "does-not-exist" / "history.jsonl")
+    assert (b, lines) == (0, 0)
+
+
+def test_counts_bytes_and_nonempty_lines(tmp_path: Path):
+    """Tier 2: byte count matches on-disk size exactly; line count skips
+    blank lines, matching read_history_after's own "blank isn't an entry"
+    rule."""
+    hist = tmp_path / "history.jsonl"
+    content_lines = [
+        '{"seq": 1, "role": "user"}',
+        "",  # blank — must not be counted as a turn
+        '{"seq": 2, "role": "assistant"}',
+        '{"seq": 3, "role": "user"}',
+    ]
+    _write_history(hist, content_lines)
+
+    b, lines = history_file_stats(hist)
+    assert b == hist.stat().st_size
+    assert lines == 3
+
+
+def test_never_writes_to_the_file_it_measures(tmp_path: Path):
+    """Tier 2: (accept-side) measuring is a pure read — the file's own
+    mtime/content must be unchanged after the call."""
+    hist = tmp_path / "history.jsonl"
+    _write_history(hist, ['{"seq": 1}'])
+    before = hist.read_bytes()
+
+    history_file_stats(hist)
+    history_file_stats(hist)
+
+    assert hist.read_bytes() == before
+
+
+# ── aggregate_history_stats (project-wide) ──────────────────────────────
+
+
+def test_aggregate_reports_zero_with_no_agents_dir(tmp_path: Path):
+    """Tier 2: a fresh project with no .reyn/agents/ yet — all-zero, no
+    error, and no directory created as a side effect."""
+    stats = aggregate_history_stats(tmp_path)
+    assert stats.file_count == 0
+    assert stats.total_bytes == 0
+    assert stats.total_lines == 0
+    assert not (tmp_path / ".reyn").exists()
+
+
+def test_aggregate_sums_across_multiple_agents(tmp_path: Path):
+    """Tier 2: two separate agents' history.jsonl files — totals are the
+    sum across both, and file_count reflects both being found."""
+    agents = tmp_path / ".reyn" / "agents"
+    _write_history(
+        agents / "alice" / "history.jsonl",
+        ['{"seq": 1}', '{"seq": 2}'],
+    )
+    _write_history(
+        agents / "bob" / "history.jsonl",
+        ['{"seq": 1}', '{"seq": 2}', '{"seq": 3}'],
+    )
+
+    stats = aggregate_history_stats(tmp_path)
+    assert stats.file_count == 2
+    assert stats.total_lines == 5
+    expected_bytes = (
+        (agents / "alice" / "history.jsonl").stat().st_size
+        + (agents / "bob" / "history.jsonl").stat().st_size
+    )
+    assert stats.total_bytes == expected_bytes
+
+
+def test_aggregate_finds_a_nested_spawned_session_history_too(tmp_path: Path):
+    """Tier 2: a spawned sub-session's own history.jsonl (nested under
+    agents/<name>/state/sessions/<sid>/, registry.py's own layout) is
+    discovered by the recursive glob, not just a top-level agent file."""
+    agents = tmp_path / ".reyn" / "agents"
+    _write_history(agents / "alice" / "history.jsonl", ['{"seq": 1}'])
+    _write_history(
+        agents / "alice" / "state" / "sessions" / "sub1" / "history.jsonl",
+        ['{"seq": 1}', '{"seq": 2}'],
+    )
+
+    stats = aggregate_history_stats(tmp_path)
+    assert stats.file_count == 2
+    assert stats.total_lines == 3
+
+
+def test_aggregate_never_writes_anything(tmp_path: Path):
+    """Tier 2: (accept-side) calling aggregate_history_stats repeatedly
+    does not mutate any discovered file or create new ones."""
+    agents = tmp_path / ".reyn" / "agents"
+    _write_history(agents / "alice" / "history.jsonl", ['{"seq": 1}'])
+    before_names = sorted(p.name for p in agents.rglob("*") if p.is_file())
+
+    aggregate_history_stats(tmp_path)
+    aggregate_history_stats(tmp_path)
+
+    after_names = sorted(p.name for p in agents.rglob("*") if p.is_file())
+    assert after_names == before_names


### PR DESCRIPTION
**[e2e-coder]** — part of #4476. Scope: Phase 1 measurement only, same order and same surface as #4478/#4485.

## What
- `history_tail_reader.py`: `history_file_stats(path)` — `(bytes, non-blank-line count)` for one `history.jsonl`. `aggregate_history_stats(project_root)` — sums that over every `history.jsonl` found under `.reyn/agents/**` (a nested spawned-session's own file is counted too, not just a top-level agent's).
- `reyn media stats` extended to print the aggregate — lands on the **same command** #4485 built rather than a new one, per lead-coder's review on #4478 ("揃える").
- No truncation, no deletion, no threshold. `history.jsonl` has no deletion path today by design: branch visibility (`is_active_seq`), compaction's `covers_through_seq` watermark, and TUI scrollback paging all depend on old lines staying readable — `retention.py`'s own docstring already states "append-only and never floor-truncated."

## Why measurement first
The only real data point today is the owner's own measured 500MB (#4387) — one environment, one moment, too thin to set a retention policy from. This PR exists to widen that into an actual measured population; the retention *number* stays an owner call.

## Phase 2 precondition (recorded, not implemented)
Any future truncation floor must stay **below `covers_through_seq`** — #4475 assumes "above `prev_cover` is always readable"; truncating above it reproduces #4470. Also: a future acceptance criterion must cover what a user sees when history they scroll back to has vanished (#4478's own condition ②, same family — #4479 is the sibling for events rotation/deletion).

## Test plan
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict` on both touched/new test files — 0 errors
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] `python scripts/mypy_ratchet.py` — no new findings (212/215 baselined, unchanged)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/interfaces/test_4478_media_cli.py tests/data/test_4478_media_storage_stats.py tests/runtime/test_4476_history_storage_stats.py tests/runtime/test_4472_compaction_reads_durable_store.py tests/runtime/test_4477_compaction_batch_budget_invariant.py tests/runtime/test_4387_bounded_history_hydration.py tests/interfaces/test_4387_tui_paging_extends_from_disk.py` — 47 passed, 0 failed
- [x] Accept-side tests confirm `history_file_stats`/`aggregate_history_stats` never write to what they measure
- [x] (skipped — n/a, no UI surface)

part of #4476


---

- [x] 🔴 **[lead-coder]**（reviewer 確認済 — media.py は removed、storage.py に git mv、#4485 由来のテストも追随、残存参照は「もはや media では説明できない」旨の説明文のみ）`reyn media stats` → **`reyn storage stats`** に rename（module も `media.py` → `storage.py`、#4485 で入った呼び出し・テストも追随）。この PR が history.jsonl を同じ面に載せた結果、`media` という名前が対象（media/ ／ tool-results/ ／ history）とずれる。今が最も安い直し時（`reyn media` は今夜生えたもので外部利用者が無く、reference page も未 landed — docs の #4490 は hold 済）。ずれの出所は私の指示（「別コマンドを増やさない方向で」）で、名前を見直すところまで言っていなかった点。


