### PR TITLE
fix(#4486): scope empty-response detection to the turn, not the response

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -372,14 +372,33 @@ def _build_media_followup_message(
 
 
 def _is_empty_router_response(response: Any) -> bool:
-    """OS-side detection: model emitted no text and no tool calls.
+    """Is THIS ONE response empty — no text, no tool calls?
 
     Provider-level glitch (observed with weak models such as
-    gemini-2.5-flash-lite at ~50% rate — ADR-0021 / B7-G12).  This is
-    NOT recovered by Reyn — surfaced to the user as an explicit failure
-    for user-side handling (no retry, no context change, no model switch).
+    gemini-2.5-flash-lite at ~50% rate — ADR-0021 / B7-G12).
 
     Trigger: finish_reason=="stop", content empty, tool_calls empty.
+
+    **This predicate's subject is deliberately narrow — one response, no
+    turn context** (its only argument is ``response``, structurally unable
+    to ask "did the LLM already produce something earlier THIS turn?").
+    The call site (`run()`, near the "Option F" block) is what answers the
+    real question ADR-0021 needs — "did this TURN produce nothing?" — by
+    additionally gating on `_tool_calls_attempted` (#4486: a tool call
+    already dispatched this turn means the model may correctly have
+    nothing further to add — e.g. `present`'s entire contract is that the
+    tool call itself is the answer — and that is not the glitch this
+    function detects). Do not fold that gating in here: a caller that only
+    wants "is this single response empty" (there are none today, but the
+    predicate's name promises exactly that) would silently gain turn-scoped
+    behavior it never asked for.
+
+    **Retry note** (#4486 drift fix — this docstring previously claimed
+    Reyn does not retry at all, which stopped matching production the
+    moment B42-NF-W6-1 landed): the OS-level retry decision is NOT made
+    here either — see the "Option F" block at the `_is_empty_router_response`
+    call site, and `empty_stop_retry_auto` (default `True` in production,
+    `router_loop_driver.py`) for the actual current behavior.
     """
     if response is None:
         return True
@@ -2427,19 +2446,38 @@ class RouterLoop:
             # Option F (ADR-0021): detect empty-stop before treating as text reply.
             # Empty-stop = finish_reason="stop", content empty, no tool calls.
             # This is a provider-level glitch (observed at ~50% rate with weak
-            # models — B7-G12 measurement).  Reyn does NOT retry, change context,
-            # or switch models.  Responsibility: observe + surface to user.
+            # models — B7-G12 measurement). Reyn does not change context or
+            # switch models when it fires.  #4486 drift fix: this comment
+            # previously also said "does NOT retry" — that stopped matching
+            # production the moment B42-NF-W6-1 shipped `empty_stop_retry_auto`
+            # (see below; the real driver, `router_loop_driver.py`, wires it
+            # `True`, so a retry attempt IS the default production behavior,
+            # not an opt-in one).
             #
-            # B42-NF-W6-1: when a continuation directive is configured AND the
-            # ``REYN_EMPTY_STOP_RETRY`` env var opts in, attempt ONE retry per
-            # turn with the directive appended as a synthetic user message
-            # before re-entering the loop. The retry path matches the
-            # Anthropic-recommended "continuation prompts as last resort"
-            # pattern (= platform.claude.com handling-stop-reasons docs) and
-            # the Hermes-agent #9400 community implementation. Without the
-            # env var, behaviour is unchanged from the original "observe +
-            # surface" policy.
+            # #4486: this is turn-scoped, not response-scoped — a tool call
+            # dispatched EARLIER this turn (`_tool_calls_attempted > 0`) means
+            # an otherwise-"empty" response may be the model correctly having
+            # nothing further to add (e.g. `present`'s entire contract is that
+            # the tool call itself is the answer), not ADR-0021's glitch
+            # (calibrated against a turn's very FIRST response, no preceding
+            # tool call). `_is_empty_router_response` itself can't tell these
+            # apart — its only argument is the one `response` — so the turn
+            # context is supplied HERE, at the call site, not folded into that
+            # narrower predicate. architect ruling (#4486): the asymmetry
+            # decides it — a false positive here ASSERTS a failure that never
+            # happened (a completed, successful turn reads as broken to the
+            # user); a false negative only drops a trailing summary line, on
+            # work already done. Deliberately `_tool_calls_attempted` (a
+            # per-turn monotonic count, reset once at the top of `run()`, only
+            # ever incremented — never "did the immediately preceding response
+            # have tool_calls", which would miss the tool -> empty -> resume ->
+            # empty shape: the resume round's own response has no tool_calls).
+            # Not merged with #4453's taint latch despite the same per-turn/
+            # monotonic SHAPE — different STATE, different reset trigger
+            # (compaction there, turn boundary here).
             if _is_empty_router_response(result):
+                if _tool_calls_attempted > 0:
+                    return self._total_usage
                 # P6: emit audit event — state change must be observable.
                 self.host.events.emit(
                     "router_empty_response_detected",
@@ -2451,9 +2489,13 @@ class RouterLoop:
                     caller_hint="router",
                     model=host.resolve_model(self.router_model),
                 )
-                # B42-NF-W6-1 detect-and-retry: env-var-gated, directive-gated,
-                # max 1 retry per turn. Trace-patch-replay verified 0/10 →
-                # 10/10 narration recovery on the W6-S1 plan-step empty stop.
+                # B42-NF-W6-1 detect-and-retry: directive-gated, auto- or
+                # env-var-gated, max 1 retry per turn (`empty_stop_retry_auto`
+                # is the real production switch — see the module-docstring
+                # note above; the env var is a secondary opt-in for callers
+                # that construct RouterLoop without it). Trace-patch-replay
+                # verified 0/10 → 10/10 narration recovery on the W6-S1
+                # plan-step empty stop.
                 if (
                     self._empty_stop_retry_directive
                     and _empty_stop_retries < 1

--- a/tests/llm/test_router_empty_response.py
+++ b/tests/llm/test_router_empty_response.py
@@ -11,6 +11,13 @@ no content, no tool calls) produces:
 
 Normal (non-empty) responses must NOT emit the new event (regression guard).
 
+#4486: an empty response that follows a tool call ALREADY dispatched this
+turn is a separate, turn-scoped case — no failure message, no retry (the
+model may correctly have nothing further to add once a tool call already
+answered the turn). Covered separately below; does not change ADR-0021's
+original (first-response, no-preceding-tool-call) detection, which the rest
+of this file still exercises unchanged.
+
 No unittest.mock.MagicMock / AsyncMock / patch-with-new_callable used.
 _ScriptedLLM is a real callable — see testing policy.
 """
@@ -476,3 +483,82 @@ async def test_tool_call_reply_does_not_emit_empty_response_event(monkeypatch):
         "No router_empty_response_detected event on normal tool-call path"
     )
     assert scripted.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_empty_response_after_a_tool_call_this_turn_is_not_the_glitch_failure(
+    monkeypatch,
+):
+    """Tier 2: #4486 architect ruling — an empty response AFTER a tool call
+    already fired this turn is NOT ADR-0021's provider-glitch failure state.
+    The model may correctly have nothing further to add (e.g. `present`'s
+    entire contract is that the tool call itself is the answer); the OS must
+    not assert a failure that did not happen. No `router_empty_response_*`
+    event, no outbox failure message, no retry (`call_llm_tools` called
+    exactly twice: the tool-call round + the empty round — never a third,
+    retry-injected call)."""
+    host = FakeRouterHost()
+    loop = make_loop(host)
+    scripted = _ScriptedLLM([
+        tool_result([{"name": "list_actions", "args": {}}]),
+        empty_stop_result(),
+    ])
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", scripted)
+
+    await loop.run("show me something", [])
+
+    empty_events = [
+        e for e in host.events.emitted
+        if e["type"].startswith("router_empty_response")
+    ]
+    assert not empty_events, (
+        f"expected no empty-response detection/retry event after a tool "
+        f"call this turn, got: {empty_events}"
+    )
+    assert not host.outbox, f"expected no failure message in outbox, got: {host.outbox}"
+    assert scripted.call_count == 2, (
+        "expected exactly the tool-call round + the empty round — a third "
+        "call would mean the (now-exempted) retry path still fired"
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_response_after_a_tool_call_stays_exempt_even_with_retry_auto_on(
+    monkeypatch,
+):
+    """Tier 2: #4486 — the turn-scoped exemption takes priority over the
+    empty-stop retry, even when `empty_stop_retry_auto=True` (production's
+    own default — `router_loop_driver.py`). Without this ordering, a
+    tool-call-only turn would still burn a retry round-trip before landing
+    on the same (correct) silent-completion outcome — this proves it
+    doesn't, by asserting the SAME two-call count as the auto-off case
+    above (`make_loop`'s default)."""
+    from reyn.prompt.loop_control import EMPTY_STOP_RETRY_DIRECTIVE
+    from reyn.runtime.router_loop import RouterLoop
+
+    host = FakeRouterHost()
+    loop = RouterLoop(
+        host=host, chain_id="chain-test", max_iterations=5,
+        empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE,
+        empty_stop_retry_auto=True,
+    )
+    scripted = _ScriptedLLM([
+        tool_result([{"name": "list_actions", "args": {}}]),
+        empty_stop_result(),
+    ])
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", scripted)
+
+    await loop.run("show me something", [])
+
+    empty_events = [
+        e for e in host.events.emitted
+        if e["type"].startswith("router_empty_response")
+    ]
+    assert not empty_events, (
+        f"expected no empty-response detection/retry event, got: {empty_events}"
+    )
+    assert not host.outbox, f"expected no failure message in outbox, got: {host.outbox}"
+    assert scripted.call_count == 2, (
+        "the exemption must win before the retry check runs — a retry "
+        "would make this 3, not 2"
+    )


### PR DESCRIPTION
**[tui-coder]** — Closes #4486

architect ruling (a): fix the detector's subject, not add a synthetic ack to `present()` (option (b), rejected). lead-coder's implementation assignment, following architect's decision on #4486.

## What was wrong

`_is_empty_router_response(response)` can only ask "is THIS response empty" — its only argument is one response, structurally unable to ask "did the model already produce something earlier this turn." ADR-0021's detection was calibrated against a turn's very *first* response (no preceding tool call, ~50% empty rate on weak models — B7-G12). Once a tool call has already fired this turn (e.g. `present`, whose entire contract is that the tool call itself is the answer), an empty follow-up may just mean the model correctly has nothing further to add.

Reproduced directly in #4486: a scripted tool-call-then-empty-response turn, run through the real `RouterLoop` with production's own `empty_stop_retry_auto=True` wiring, showed the OS inject a `"resume"` retry directive and then surface "The model returned an empty response. Please try rephrasing your request or check your configuration." — a false failure on a turn that had already completed successfully.

## Fix

Gate on `_tool_calls_attempted` (the existing per-turn monotonic count, reset once at the top of `run()`, incremented only on an Execute round) **at the call site**, not inside `_is_empty_router_response` itself — the predicate's name promises "is this one response empty," and folding turn-scope in would silently change that contract for any future caller.

Deliberately **not** "did the immediately preceding response have `tool_calls`" — per architect's explicit warning, that would miss the `tool -> empty -> resume -> empty` shape, since the resume round's own response has no `tool_calls` of its own.

Deliberately **not merged** with #4453's taint latch despite the same per-turn/monotonic shape — different state, different reset trigger (compaction there, turn boundary here — per architect's explicit note).

## Also fixed (same-PR drift, per lead-coder + architect)

`_is_empty_router_response`'s docstring and the "Option F" block comment both claimed Reyn does not retry at all — stopped matching production the moment B42-NF-W6-1 shipped `empty_stop_retry_auto` (every production `RouterLoop` construction site, `router_loop_driver.py`, passes `True`). Both updated to describe current behavior.

## Falsify-verify

Both new tests fail with the fix reverted — a real `IndexError` from the scripted LLM running past its 2-call script (the old code burns a 3rd retry call before surfacing the failure). The original ADR-0021 glitch detection (first response, no preceding tool call) is unchanged and still covered by every pre-existing test in the file — verified unchanged/still green.

## Test plan

- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/llm/test_router_empty_response.py` — 18/18 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (212/215 baselined, no new)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/llm/test_router_empty_response.py tests/llm/test_router_loop_empty_stop_retry.py tests/runtime/test_chat_router_empty_stop_directive_wired.py` — 27 passed
- [x] `pytest tests/llm/ tests/runtime/` (full) — 2418 passed, 1 skipped (unrelated optional-dependency extra)
- [x] Falsify-verify — new tests genuinely fail (real `IndexError`) with the fix reverted
- [ ] Visual — N/A, no rendering change

tests/ touched — TESTS-READ wait, no self-merge.