### PR TITLE
feat(#4482 PR-1 slice): normalize_ref_path — the one canonicalization fn

### DIFF
--- a/src/reyn/data/workspace/ref_path_normalize.py
+++ b/src/reyn/data/workspace/ref_path_normalize.py
@@ -1,0 +1,64 @@
+"""#4482 PR-1: the ONE path-canonicalization function ref minting and the
+ref → path lookup table both call — architect's review named this the
+implementation hazard: "正規化を1箇所に置き、ref→pathの対応表と同じ関数を
+使うこと... 2箇所に分かれると同じファイルに2つのrefが生まれます" (put
+normalization in ONE place, used by both mint and lookup — split it across
+two and the same file gets two different refs). Same shape this session has
+hit repeatedly tonight: two call sites independently holding the same
+invariant drift apart (#2957 PR-B, #4451).
+
+Ref identity is ``(session, absolute path)`` 1:1 (architect's #4482 ruling —
+content-hash identity was rejected: it conflicts with the owner's own
+"don't copy, open the original" decision, since a content-hash ref can only
+stay resolvable across a content change by having captured the bytes at
+mint time). This module owns the "absolute path" half of that pair — the
+session half is the caller's own scope, not this function's concern.
+
+## Three axes, one canonical form
+
+- **relative vs absolute** — a relative path is resolved against
+  ``project_root``, matching :class:`MediaStore`'s own established
+  convention (``(self._project_root / p).resolve()`` else ``p.resolve()``).
+- **symlink** — ``Path.resolve()`` follows symlinks and collapses ``.``/
+  ``..`` components, so a symlink and its real target normalize to the
+  identical form.
+- **case** — folded via ``os.path.normcase`` (stdlib): a no-op on POSIX,
+  lowercases on Windows. **Deliberately NOT a real per-file filesystem
+  probe** for macOS's case-insensitive-but-case-preserving DEFAULT (or a
+  case-insensitive Linux mount): that would need to stat an alternate-case
+  variant of every path at normalize time, a real I/O cost paid on every
+  call for a condition with no measured instance yet — the same
+  "measurement before mechanism" discipline #4478/#4476 both applied
+  tonight. ``os.path.normcase`` is the honest stdlib answer for what
+  Python itself considers case-normalization; the one known gap this
+  leaves (macOS's default) is named here, not silently absent.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def normalize_ref_path(path: "str | Path", project_root: Path) -> Path:
+    """Canonical on-disk identity for *path*, relative to *project_root*.
+
+    Two calls with different spellings of the SAME file (one relative, one
+    absolute; one through a symlink, one direct; case-differing on a
+    case-insensitive filesystem per :mod:`os.path`'s own ``normcase``)
+    return the IDENTICAL ``Path``. This is what makes ref minting
+    idempotent — the ref → path table keys on this function's output, never
+    the caller's raw string, so "same path, different spelling" can never
+    mint two refs for one file.
+
+    Does not require *path* to exist — a caller minting a ref for a
+    just-written file and a caller looking up an existing ref both get a
+    normalized form; only the LOOKUP side needs to additionally check
+    existence (a target that's vanished is a resolution failure, a
+    different, later question than "does today's spelling normalize the
+    way an earlier spelling did").
+    """
+    p = Path(path)
+    if not p.is_absolute():
+        p = project_root / p
+    resolved = p.resolve()
+    return Path(os.path.normcase(str(resolved)))

--- a/tests/data/test_4482_ref_path_normalize.py
+++ b/tests/data/test_4482_ref_path_normalize.py
@@ -1,0 +1,104 @@
+"""Tier 2: #4482 PR-1 — ``normalize_ref_path``, the single canonicalization
+function both ref minting and the ref → path lookup table will call
+(architect's review: split across two call sites and the same file gets
+two refs). This test file exercises the function directly, in isolation
+from the ref table itself (not written yet — this is the independent,
+no-dependency slice of PR-1).
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.data.workspace.ref_path_normalize import normalize_ref_path
+
+
+def test_relative_and_absolute_spellings_normalize_identically(tmp_path: Path):
+    """Tier 2: the acceptance criterion, verbatim — a relative path and its
+    absolute spelling of the SAME file must not diverge."""
+    target = tmp_path / "sub" / "report.pptx"
+    target.parent.mkdir()
+    target.write_bytes(b"x")
+
+    via_relative = normalize_ref_path("sub/report.pptx", tmp_path)
+    via_absolute = normalize_ref_path(target, tmp_path)
+
+    assert via_relative == via_absolute
+
+
+def test_symlink_normalizes_to_the_same_form_as_its_target(tmp_path: Path):
+    """Tier 2: the acceptance criterion, verbatim — a symlink and its real
+    target must not diverge."""
+    real = tmp_path / "real.txt"
+    real.write_bytes(b"x")
+    link = tmp_path / "link.txt"
+    link.symlink_to(real)
+
+    assert normalize_ref_path(link, tmp_path) == normalize_ref_path(real, tmp_path)
+
+
+def test_dot_and_dotdot_components_collapse(tmp_path: Path):
+    """Tier 2: '.'/'..' spellings of the same file normalize identically —
+    Path.resolve()'s own collapsing, exercised through this function."""
+    target = tmp_path / "a" / "b" / "file.txt"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"x")
+
+    messy = tmp_path / "a" / "b" / ".." / "b" / "." / "file.txt"
+    clean = target
+
+    assert normalize_ref_path(messy, tmp_path) == normalize_ref_path(clean, tmp_path)
+
+
+def test_idempotent_normalizing_twice_is_a_noop(tmp_path: Path):
+    """Tier 2: (accept-side) normalizing an already-normalized path returns
+    the same value — normalization is a fixed point, not a one-shot
+    transform that could drift on re-application."""
+    target = tmp_path / "file.txt"
+    target.write_bytes(b"x")
+
+    once = normalize_ref_path(target, tmp_path)
+    twice = normalize_ref_path(once, tmp_path)
+    assert once == twice
+
+
+def test_case_differing_paths_diverge_on_a_case_sensitive_filesystem():
+    """Tier 2: (accept-side, POSIX) two different-case spellings are
+    DIFFERENT files on a case-sensitive filesystem (the CI/Linux default)
+    — os.path.normcase is a no-op there, so this function must not
+    conflate them. Confirms the documented scope: this function folds
+    case only where os.path.normcase itself would."""
+    if sys.platform == "win32":
+        pytest.skip("this accept-side case only holds where normcase is a no-op (POSIX)")
+
+    project_root = Path("/tmp")
+    lower = normalize_ref_path("Report.PPTX", project_root)
+    upper = normalize_ref_path("report.pptx", project_root)
+    assert str(lower) != str(upper)
+
+
+def test_does_not_require_the_path_to_exist(tmp_path: Path):
+    """Tier 2: normalization is pure path algebra — a not-yet-written
+    (or already-deleted) target still normalizes, no exception. Existence
+    is the LOOKUP side's separate concern, not this function's."""
+    missing = tmp_path / "does" / "not" / "exist.txt"
+    result = normalize_ref_path(missing, tmp_path)
+    assert result.is_absolute()
+
+
+def test_windows_style_case_folding_documented_via_normcase(tmp_path: Path, monkeypatch):
+    """Tier 2: this function's case-folding behavior is exactly
+    os.path.normcase's — verified by making normcase itself report a
+    folded form (simulating what Windows' real normcase does) and
+    confirming normalize_ref_path's output reflects it, rather than
+    re-implementing its own case logic that could drift from the stdlib
+    one it claims to delegate to."""
+    target = tmp_path / "File.TXT"
+    target.write_bytes(b"x")
+
+    monkeypatch.setattr(os.path, "normcase", str.lower)
+    result = normalize_ref_path(target, tmp_path)
+    assert str(result) == str(target.resolve()).lower()


### PR DESCRIPTION
**[e2e-coder]** — part of #4482 (PR-1). Just the independent slice lead-coder suggested while the #4488/#4493 rebase chain drains: the single path-canonicalization function.

## What
`normalize_ref_path(path, project_root) -> Path` — the ONE function both ref minting and the ref → path lookup table will call (architect's #4482 review: splitting normalization across two call sites mints two refs for the same file — same class as #2957 PR-B's drift, #4451).

Three axes → one canonical form:
- **relative/absolute**: resolved against `project_root` (matches `MediaStore`'s own established convention)
- **symlink**: `Path.resolve()` follows it — a symlink and its target normalize identically
- **case**: delegated to `os.path.normcase` (stdlib) — a no-op on POSIX, lowercases on Windows. Deliberately not a real filesystem probe for macOS's case-insensitive-but-preserving default (or a case-insensitive Linux mount) — that's an unmeasured condition; named as a known gap in the docstring rather than solved with unrequested machinery, same "evidence before mechanism" discipline #4478/#4476 both applied tonight.

Standalone module rather than folded into `media_store.py` — the ref-table's own file layout isn't decided yet, so this stays the least presumptuous shape until it exists to import it.

## Test plan
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 0 errors
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] `python scripts/mypy_ratchet.py` — no new findings (212/215 baselined, unchanged)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/data/test_4482_ref_path_normalize.py` — 7 passed, including both acceptance criteria verbatim (relative/absolute and symlink spellings normalize identically) and an accept-side test that case DOES still diverge on a case-sensitive filesystem (the documented scope, not silently over-promised)
- [x] (skipped — n/a, no UI surface)

part of #4482

