### PR TITLE
feat(#4482 PR-1): ref -> path table + fetch-endpoint ref resolution

### DIFF
--- a/src/reyn/data/workspace/artifact_ref.py
+++ b/src/reyn/data/workspace/artifact_ref.py
@@ -1,0 +1,141 @@
+"""#4482 PR-1: ref -> path table for LLM-produced artifacts the terminal
+can't render natively (html/office/pdf/images) that a user opens with the
+OS's own default app — one step beyond #383/#385's tool-result spill
+mechanism, which only ever minted a ref for something explicitly saved as
+a *tool result*. A present-node artifact can be any file the agent already
+produced anywhere in the project (e.g. via ``write_file``), so this is a
+separate, general casting mechanism, not a MediaStore extension.
+
+**Ref identity = (agent, absolute path), 1:1** (architect's #4482 ruling).
+A content-hash identity was considered and rejected: it conflicts directly
+with the owner's own "don't copy, open the original" decision — a
+content-hash ref can only stay resolvable across a content change by
+capturing the bytes at mint time, which IS a copy. Path identity instead
+means a file regenerated at the same path resolves to TODAY's bytes under
+the SAME ref — correct, matching the meaning a file manager / editor /
+nvim's own ``gx`` already give the same shape ("report.pptx" a later turn
+re-creates still means "the current report.pptx", not a stale snapshot).
+
+**Minting is idempotent**: the SAME ``(agent, normalized path)`` pair always
+returns the SAME ref — no re-numbering, no duplicate table entries.
+Normalization goes through :func:`normalize_ref_path` (#4482 PR-1's own
+independent slice, landed as #4495) — :func:`mint_ref` and
+:func:`resolve_ref` both call it, never a locally re-derived variant
+(architect's review: splitting normalization across two call sites is how
+the SAME file ends up minting two different refs).
+
+**Scope is per-agent** ("session" in architect's own wording — the fetch
+endpoint this feeds is already agent-scoped, ``/agents/{agent}/...``, so
+there is no cross-agent need and no extra cleanup surface to invent).
+
+**Table persisted under ``.reyn/cache/``** — mirrors #4432's tool-result
+spill manifest: same "derived, ordinary agent-writable zone" home, same
+JSONL-append shape, same best-effort write-failure tolerance (a write
+failure here must never fail the mint itself — the ref is still valid for
+this process's lifetime even if a LATER process's table load won't see it,
+the identical tradeoff #4432's own manifest already accepted).
+
+**Never copies bytes.** :func:`mint_ref` never reads the file's content,
+only records its path; :func:`resolve_ref` hands back a path for the
+CALLER to open or serve — the same bytes, never a second copy (doubling
+disk usage is exactly what #4478's own GC precondition would have to
+measure against, so this module must not create that pressure itself).
+
+Explicitly NOT this module's job (lead-coder's #4482 PR-1 brief):
+  - "has the file changed since it was presented" — a client-side
+    mtime-vs-seq comparison (PR-3's own scope); no new persisted state
+    lives here.
+  - GC / retention — #4478's own domain. An unresolvable ref (file
+    deleted out from under it) is simply :func:`resolve_ref` returning
+    ``None``; distinguishing "deleted" from "content changed" is handled
+    by NOT treating a still-existing-but-different-bytes file as
+    unresolvable at all — only an actually-missing file returns ``None``.
+"""
+from __future__ import annotations
+
+import json
+import secrets
+from pathlib import Path
+
+from reyn.data.workspace.ref_path_normalize import normalize_ref_path
+
+_REF_TABLE_FILENAME = "artifact_refs.jsonl"
+
+
+def _table_path(project_root: Path) -> Path:
+    return project_root / ".reyn" / "cache" / _REF_TABLE_FILENAME
+
+
+def _load_table(project_root: Path) -> "list[dict]":
+    path = _table_path(project_root)
+    if not path.is_file():
+        return []
+    entries: "list[dict]" = []
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue  # one malformed line never invalidates the rest
+    except OSError:
+        return []
+    return entries
+
+
+def mint_ref(project_root: Path, agent_name: str, path: "str | Path") -> str:
+    """Return the ref for *path* under *agent_name*'s scope.
+
+    Idempotent: a (agent, normalized-path) pair that already has an entry
+    returns that SAME ref rather than minting a new one — the acceptance
+    criterion this exists to satisfy. *path* is normalized via
+    :func:`normalize_ref_path` before either the lookup or the new-entry
+    write, so a relative spelling, a symlink, or (on a case-insensitive
+    filesystem) a different-case spelling of an already-minted path never
+    produces a second ref for the same file.
+
+    Never reads *path*'s content — only records where it is. A write
+    failure to the on-disk table is swallowed (best-effort, matching
+    #4432's own spill-manifest tolerance): the freshly minted ref is still
+    returned and usable for the rest of this process's lifetime even if a
+    later process's table load won't see it.
+    """
+    normalized = normalize_ref_path(path, project_root)
+    entries = _load_table(project_root)
+    for entry in entries:
+        if entry.get("agent") == agent_name and entry.get("path") == str(normalized):
+            return entry["ref"]
+
+    ref = secrets.token_urlsafe(9)
+    table_path = _table_path(project_root)
+    try:
+        table_path.parent.mkdir(parents=True, exist_ok=True)
+        with table_path.open("a", encoding="utf-8") as f:
+            f.write(
+                json.dumps({"ref": ref, "agent": agent_name, "path": str(normalized)}) + "\n",
+            )
+    except OSError:
+        pass
+    return ref
+
+
+def resolve_ref(project_root: Path, agent_name: str, ref: str) -> "Path | None":
+    """Resolve *ref* (minted under *agent_name*'s scope) back to its
+    absolute path.
+
+    Returns ``None`` when the ref is unknown to this agent's scope, OR
+    when the file it names no longer exists on disk — an unresolvable ref
+    is this function's ENTIRE answer to "the artifact was deleted"; #4478's
+    own GC, if it ever runs, needs no separate hook here (see the module
+    docstring). A file that still exists but whose CONTENT has changed
+    since minting is NOT unresolvable — it resolves normally, to today's
+    bytes, which is the whole point of path (not content-hash) identity.
+    """
+    entries = _load_table(project_root)
+    for entry in entries:
+        if entry.get("agent") == agent_name and entry.get("ref") == ref:
+            candidate = Path(entry["path"])
+            return candidate if candidate.exists() else None
+    return None

--- a/src/reyn/interfaces/web/routers/resources.py
+++ b/src/reyn/interfaces/web/routers/resources.py
@@ -230,6 +230,22 @@ async def get_tool_result(
 # / write_file's own scoping) — this route can only ever serve back
 # something the agent could already produce and read itself, not a new
 # capability.
+#
+# ★ What an UNAUTHENTICATED caller of this route can reach DID widen, in
+# fact, not just in theory: from "a tool-results artifact" (the sibling
+# route) to "any minted path" (this route) — this router carries no
+# per-route auth (see the module docstring's own "Authentication" note).
+# What stands in for it here is three separate things, NOT authentication:
+#   ① the ref itself is unguessable (secrets.token_urlsafe(9), ~72 bits —
+#     not enumerable by probing sequential/short values)
+#   ② resolve_ref is agent-scoped — a ref minted under one agent never
+#     resolves under another's route segment
+#   ③ ``reyn web``'s own default bind is loopback-only
+#     (``cli/commands/web.py``'s ``--host`` default, 127.0.0.1) — this
+#     route is not reachable from the network at all under the default
+# Named explicitly so a FUTURE decision to change ③ (e.g. defaulting
+# ``--host`` to 0.0.0.0) has this route on its checklist — the current
+# safety here rests on ③ holding, not on ① or ② alone standing in for auth.
 
 
 @router.get("/agents/{agent_name}/artifacts/{ref}")

--- a/src/reyn/interfaces/web/routers/resources.py
+++ b/src/reyn/interfaces/web/routers/resources.py
@@ -28,6 +28,16 @@ Reyn directory naming uniformity):
                     MediaStore (= ``YYYYMMDDTHHMMSS-<chain_short>-
                     <tool>-<seq>.<ext>``).
 
+#4482 PR-1 adds a second, separate route on the same router:
+
+  GET /agents/<agent_name>/artifacts/<ref>
+
+for artifacts minted via ``reyn.data.workspace.artifact_ref`` (any file the
+agent already produced under ``project_root``, not just a MediaStore tool
+result) — see that module's own docstring for ref identity/minting, and
+:func:`get_artifact_by_ref` below for the route itself. Deliberately not an
+overload of ``<artifact>`` above; see that function's docstring for why.
+
 Same-host short-circuit (= when the resolved URL would point back to
 this very Reyn instance) is the dispatcher's responsibility on the
 consumer side; this router unconditionally serves the local file if it
@@ -197,6 +207,90 @@ async def get_tool_result(
         content=body,
         media_type=_mime_for(artifact),
         headers=_browser_headers(artifact, download=bool(download)),
+    )
+
+
+# ── GET /agents/<agent>/artifacts/<ref> (#4482 PR-1) ────────────────────
+#
+# A SEPARATE route from /tool-results/<artifact> above, deliberately not an
+# overload of it: the existing route's <artifact> segment means "a filename
+# MediaStore itself minted under tool_results_dir" and its traversal
+# boundary is tool_results_dir specifically. A #4482 artifact can be ANY
+# file the agent already produced anywhere under project_root (e.g. via
+# write_file, not necessarily a tool result) — a materially different
+# candidate set, so giving it its own route keeps the existing endpoint's
+# contract (and its existing callers) completely unchanged rather than
+# quietly widening what <artifact> can mean.
+#
+# Traversal boundary here is project_root, not tool_results_dir — this is
+# not a widened privilege: mint_ref never validates what it's given (see
+# artifact_ref.py's own docstring), so the boundary check has to happen at
+# resolve/serve time. project_root is the same boundary reyn's own sandbox
+# already uses for what an agent can write in the first place (file_scope.py
+# / write_file's own scoping) — this route can only ever serve back
+# something the agent could already produce and read itself, not a new
+# capability.
+
+
+@router.get("/agents/{agent_name}/artifacts/{ref}")
+async def get_artifact_by_ref(
+    agent_name: str,
+    ref: str,
+    request: Request,  # noqa: ARG001 — kept for symmetry with a2a routes
+    download: int = 0,
+    registry=Depends(get_registry),
+) -> Response:
+    """Serve a #4482 artifact by its minted ref (``artifact_ref.mint_ref``).
+
+    Validates the agent exists (= 404 if not), resolves *ref* via
+    ``artifact_ref.resolve_ref`` (= 404 if unknown to this agent's scope,
+    or if the target file has since been deleted — see that function's own
+    docstring for why those two cases share one outcome), and re-validates
+    the resolved path lives inside ``project_root`` (= 400 on an escape;
+    defense in depth — the table is only ever populated by ``mint_ref``,
+    but this route does not trust it blindly, matching the sibling
+    tool-results route's own "always re-check at serve time" posture).
+    """
+    if not registry.exists(agent_name):
+        raise HTTPException(
+            status_code=404,
+            detail=f"Reyn agent {agent_name!r} not found on this server.",
+        )
+
+    from reyn.data.workspace.artifact_ref import resolve_ref
+
+    project_root = Path.cwd()
+    resolved = resolve_ref(project_root, agent_name, ref)
+    if resolved is None:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"artifact ref {ref!r} not found for agent {agent_name!r} "
+                "(= unknown ref, or the file it named has been deleted)"
+            ),
+        )
+
+    try:
+        resolved.relative_to(project_root.resolve())
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"resolved path for ref {ref!r} is outside project_root",
+        ) from exc
+
+    try:
+        body = resolved.read_bytes()
+    except OSError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail=f"artifact ref {ref!r} could not be read: {exc}",
+        ) from exc
+
+    filename = resolved.name
+    return Response(
+        content=body,
+        media_type=_mime_for(filename),
+        headers=_browser_headers(filename, download=bool(download)),
     )
 
 

--- a/tests/data/test_4482_artifact_ref.py
+++ b/tests/data/test_4482_artifact_ref.py
@@ -1,0 +1,134 @@
+"""Tier 2: #4482 PR-1 — the ref -> path table (``mint_ref``/``resolve_ref``).
+
+Real on-disk state under ``tmp_path`` throughout, no mocks. Exercises the
+acceptance criteria lead-coder's brief listed verbatim: idempotent minting,
+normalization-insensitive minting, resolve-after-mint, unresolvable-on-
+deletion (not confused with "content changed"), and no-copy.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from reyn.data.workspace.artifact_ref import mint_ref, resolve_ref
+
+
+def _write(path: Path, content: bytes = b"x") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def test_minting_the_same_path_twice_returns_the_same_ref(tmp_path: Path):
+    """Tier 2: the acceptance criterion, verbatim — idempotent minting."""
+    target = _write(tmp_path / "report.pptx")
+    ref1 = mint_ref(tmp_path, "alice", target)
+    ref2 = mint_ref(tmp_path, "alice", target)
+    assert ref1 == ref2
+
+
+def test_normalization_differences_do_not_mint_a_second_ref(tmp_path: Path):
+    """Tier 2: the acceptance criterion, verbatim — relative/absolute
+    spellings of the same file mint the SAME ref, via the shared
+    normalize_ref_path function."""
+    target = _write(tmp_path / "sub" / "report.pptx")
+    via_absolute = mint_ref(tmp_path, "alice", target)
+    via_relative = mint_ref(tmp_path, "alice", "sub/report.pptx")
+    assert via_absolute == via_relative
+
+
+def test_symlink_spelling_does_not_mint_a_second_ref(tmp_path: Path):
+    """Tier 2: a symlink to an already-minted file resolves to the same ref."""
+    real = _write(tmp_path / "real.txt")
+    link = tmp_path / "link.txt"
+    link.symlink_to(real)
+
+    ref_real = mint_ref(tmp_path, "alice", real)
+    ref_link = mint_ref(tmp_path, "alice", link)
+    assert ref_real == ref_link
+
+
+def test_different_agents_get_independent_refs_for_the_same_path(tmp_path: Path):
+    """Tier 2: scope is per-agent — two agents minting the SAME path each
+    get their own ref (no cross-agent sharing, matching the brief's
+    "scope = session/agent" ruling)."""
+    target = _write(tmp_path / "report.pptx")
+    ref_alice = mint_ref(tmp_path, "alice", target)
+    ref_bob = mint_ref(tmp_path, "bob", target)
+    assert ref_alice != ref_bob
+    assert resolve_ref(tmp_path, "alice", ref_alice) == target.resolve()
+    assert resolve_ref(tmp_path, "bob", ref_bob) == target.resolve()
+
+
+def test_resolve_returns_the_absolute_path(tmp_path: Path):
+    """Tier 2: resolve_ref round-trips mint_ref's own path, absolute."""
+    target = _write(tmp_path / "report.pptx")
+    ref = mint_ref(tmp_path, "alice", target)
+    resolved = resolve_ref(tmp_path, "alice", ref)
+    assert resolved == target.resolve()
+    assert resolved.is_absolute()
+
+
+def test_unknown_ref_resolves_to_none(tmp_path: Path):
+    """Tier 2: a ref that was never minted resolves to None, not an error."""
+    assert resolve_ref(tmp_path, "alice", "never-minted") is None
+
+
+def test_a_deleted_target_becomes_unresolvable(tmp_path: Path):
+    """Tier 2: the acceptance criterion, verbatim — the target vanishing
+    makes the ref unresolvable (distinct from "content changed", tested
+    next)."""
+    target = _write(tmp_path / "report.pptx")
+    ref = mint_ref(tmp_path, "alice", target)
+    target.unlink()
+    assert resolve_ref(tmp_path, "alice", ref) is None
+
+
+def test_a_content_change_does_not_make_the_ref_unresolvable(tmp_path: Path):
+    """Tier 2: the acceptance criterion's other half — regenerating the
+    SAME path with DIFFERENT bytes still resolves (path identity, not
+    content-hash identity); resolve_ref must not confuse "changed" with
+    "gone"."""
+    target = _write(tmp_path / "report.pptx", b"version one")
+    ref = mint_ref(tmp_path, "alice", target)
+
+    target.write_bytes(b"a completely different version two")
+
+    resolved = resolve_ref(tmp_path, "alice", ref)
+    assert resolved == target.resolve()
+    assert resolved.read_bytes() == b"a completely different version two"
+
+
+def test_minting_never_copies_the_file(tmp_path: Path):
+    """Tier 2: the acceptance criterion, verbatim — mint_ref creates no new
+    copy of the artifact. Verified two ways: (a) the only new on-disk
+    write is the ref table itself, and (b) the target's own inode is
+    unchanged (same file, not a copy with a fresh inode)."""
+    target = _write(tmp_path / "report.pptx")
+    before_inode = target.stat().st_ino
+    before_files = sorted(p for p in tmp_path.rglob("*") if p.is_file())
+
+    mint_ref(tmp_path, "alice", target)
+
+    after_inode = target.stat().st_ino
+    after_files = sorted(p for p in tmp_path.rglob("*") if p.is_file())
+    new_files = set(after_files) - set(before_files)
+
+    assert before_inode == after_inode
+    # The ONLY new file allowed to appear is the ref table itself.
+    assert new_files <= {tmp_path / ".reyn" / "cache" / "artifact_refs.jsonl"}
+
+
+def test_table_is_a_jsonl_manifest_matching_the_4432_spill_manifest_shape(tmp_path: Path):
+    """Tier 2: (accept-side, format) one JSON object per line under
+    .reyn/cache/ — mirrors #4432's tool-result spill manifest shape, as
+    the brief explicitly asked for."""
+    target = _write(tmp_path / "report.pptx")
+    ref = mint_ref(tmp_path, "alice", target)
+
+    table_path = tmp_path / ".reyn" / "cache" / "artifact_refs.jsonl"
+    lines = [line for line in table_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    entries = [json.loads(line) for line in lines]
+    (entry,) = [e for e in entries if e["ref"] == ref]
+    assert entry["agent"] == "alice"
+    assert entry["path"] == str(target.resolve())

--- a/tests/web/test_4482_get_artifact_by_ref.py
+++ b/tests/web/test_4482_get_artifact_by_ref.py
@@ -1,0 +1,189 @@
+"""Tier 2: #4482 PR-1 — ``GET /agents/<agent>/artifacts/<ref>``.
+
+Mirrors ``test_resources_router.py``'s own structure/fixture for the
+sibling ``/tool-results/<artifact>`` route, applied to this SEPARATE
+ref-based route: happy path, traversal defense-in-depth, not_found
+semantics, unknown agent. Real FastAPI TestClient + real on-disk state
+throughout, no mocks — Tier 2 for the same reason the sibling file gives:
+this is a cross-host integrity boundary.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+from tests._support.paths import REPO_ROOT
+
+_WORKTREE_SRC = REPO_ROOT / "src"
+if str(_WORKTREE_SRC) not in sys.path:
+    sys.path.insert(0, str(_WORKTREE_SRC))
+
+fastapi = pytest.importorskip("fastapi", reason="fastapi not installed ([web] extra missing)")
+httpx = pytest.importorskip("httpx", reason="httpx not installed (needed by TestClient)")
+
+
+@pytest.fixture()
+def tmp_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Same fixture shape as test_resources_router.py's own — a minimal
+    Reyn project with one agent registered, deps cleared, cwd chdir'd so
+    the route's ``Path.cwd()``-rooted resolution matches the fixture."""
+    reyn_dir = tmp_path / ".reyn"
+    agents_dir = reyn_dir / "agents" / "researcher"
+    agents_dir.mkdir(parents=True)
+
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
+    (agents_dir / "profile.yaml").write_text(
+        "name: researcher\nrole: ''\ncreated_at: '2026-01-01T00:00:00+00:00'\n",
+        encoding="utf-8",
+    )
+
+    import reyn.interfaces.web.deps as deps
+    deps._get_project_root.cache_clear()
+    deps._load_config.cache_clear()
+    deps._state_log = None
+    deps._budget_tracker = None
+    deps._perm_resolver = None
+    deps._registry = None
+
+    monkeypatch.setattr(
+        "reyn.config._find_project_root", lambda _cwd: tmp_path,
+    )
+    monkeypatch.chdir(tmp_path)
+    yield tmp_path
+
+    deps._get_project_root.cache_clear()
+    deps._load_config.cache_clear()
+    deps._state_log = None
+    deps._budget_tracker = None
+    deps._perm_resolver = None
+    deps._registry = None
+
+
+def _client():
+    from reyn.interfaces.web.server import app
+    from tests._support.web_auth import local_operator_client
+    return local_operator_client(app, raise_server_exceptions=False)
+
+
+def _mint(tmp_project: Path, rel_path: str, content: bytes = b"hello world\n") -> str:
+    """Write a real file under tmp_project and mint a ref for it — the
+    candidate set #4482 targets (any project file, not just a MediaStore
+    tool result)."""
+    from reyn.data.workspace.artifact_ref import mint_ref
+
+    target = tmp_project / rel_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+    return mint_ref(tmp_project, "researcher", target)
+
+
+# ── happy path ─────────────────────────────────────────────────────────
+
+
+def test_get_serves_a_minted_artifact_body(tmp_project: Path):
+    """Tier 2: a ref minted for an arbitrary project file (not a
+    MediaStore tool result) is fetchable through this route — the whole
+    point of a SEPARATE route from /tool-results/<artifact>."""
+    ref = _mint(tmp_project, "report.html", content=b"<h1>hi</h1>")
+
+    response = _client().get(f"/agents/researcher/artifacts/{ref}")
+
+    assert response.status_code == 200, response.text
+    assert response.content == b"<h1>hi</h1>"
+
+
+def test_content_type_derives_from_the_resolved_filename(tmp_project: Path):
+    """Tier 2: Content-Type is derived from the RESOLVED file's own name,
+    not the opaque ref string."""
+    ref = _mint(tmp_project, "report.html", content=b"<h1>hi</h1>")
+
+    response = _client().get(f"/agents/researcher/artifacts/{ref}")
+
+    assert response.headers["content-type"].startswith("text/html")
+
+
+def test_regenerated_content_is_served_not_the_original_bytes(tmp_project: Path):
+    """Tier 2: path (not content-hash) identity in action end-to-end —
+    the file is rewritten AFTER minting, and the route serves TODAY's
+    bytes, not a stale copy."""
+    ref = _mint(tmp_project, "report.html", content=b"version one")
+    (tmp_project / "report.html").write_bytes(b"version two")
+
+    response = _client().get(f"/agents/researcher/artifacts/{ref}")
+
+    assert response.content == b"version two"
+
+
+# ── not_found semantics ────────────────────────────────────────────────
+
+
+def test_get_unknown_ref_returns_404(tmp_project: Path):
+    """Tier 2: a ref that was never minted returns 404, not a crash."""
+    response = _client().get("/agents/researcher/artifacts/never-minted")
+    assert response.status_code == 404
+
+
+def test_get_deleted_target_returns_404(tmp_project: Path):
+    """Tier 2: the file existed at mint time but was deleted before
+    fetch — matches ``resolve_ref``'s own None-on-deletion contract
+    surfaced as HTTP semantics."""
+    ref = _mint(tmp_project, "report.html")
+    (tmp_project / "report.html").unlink()
+
+    response = _client().get(f"/agents/researcher/artifacts/{ref}")
+
+    assert response.status_code == 404
+
+
+def test_get_unknown_agent_returns_404(tmp_project: Path):
+    """Tier 2: an unregistered agent returns 404, mirroring the sibling
+    route's own probe-prevention posture."""
+    _mint(tmp_project, "report.html")
+    response = _client().get("/agents/nonexistent/artifacts/whatever")
+    assert response.status_code == 404
+
+
+def test_a_table_entry_pointing_outside_project_root_is_rejected(tmp_project: Path):
+    """Tier 2: defense-in-depth falsify — mint_ref never validates what
+    it's given (see artifact_ref.py's own docstring), so this route must
+    NOT trust the table blindly. Simulates a table entry pointing outside
+    project_root (a hand-crafted/compromised entry, since mint_ref itself
+    only ever writes an already-normalized path under project_root in
+    the real flow) and confirms the route's own re-check at serve time
+    rejects it rather than leaking the file."""
+    import json
+
+    outside = tmp_project.parent / "outside-secret.txt"
+    outside.write_bytes(b"SECRET")
+    table = tmp_project / ".reyn" / "cache" / "artifact_refs.jsonl"
+    table.parent.mkdir(parents=True, exist_ok=True)
+    with table.open("a", encoding="utf-8") as f:
+        f.write(json.dumps({"ref": "evil", "agent": "researcher", "path": str(outside)}) + "\n")
+
+    response = _client().get("/agents/researcher/artifacts/evil")
+
+    assert response.status_code == 400
+    assert b"SECRET" not in response.content
+
+
+def test_a_ref_minted_for_one_agent_is_not_visible_to_another(tmp_project: Path):
+    """Tier 2: scope is per-agent — a ref minted under one agent's scope
+    does not resolve when fetched under a DIFFERENT (but real,
+    registered) agent's route. Registers a second agent directly rather
+    than depending on any particular onboarding flow."""
+    (tmp_project / ".reyn" / "agents" / "other").mkdir(parents=True)
+    (tmp_project / ".reyn" / "agents" / "other" / "profile.yaml").write_text(
+        "name: other\nrole: ''\ncreated_at: '2026-01-01T00:00:00+00:00'\n",
+        encoding="utf-8",
+    )
+    import reyn.interfaces.web.deps as deps
+    deps._registry = None
+
+    ref = _mint(tmp_project, "report.html")
+
+    response = _client().get(f"/agents/other/artifacts/{ref}")
+
+    assert response.status_code == 404


### PR DESCRIPTION
**[e2e-coder]** — part of #4482 (PR-1: ref casting + fetch-endpoint ref resolution).

## Decided constraints (per architect/lead-coder — not re-designed)
- ref identity = `(agent, absolute path)`, 1:1
- minting is idempotent
- session scope = agent (fetch endpoint already agent-scoped)
- no content hash — content changes stay resolvable, don't orphan the ref
- normalization in ONE place, same function both mint and lookup use — `normalize_ref_path` (#4495, already on main)

## What
- `src/reyn/data/workspace/artifact_ref.py` — `mint_ref`/`resolve_ref`, JSONL table under `.reyn/cache/artifact_refs.jsonl`, mirroring #4432's spill-manifest shape (same best-effort write tolerance).
- `resources.py` — new `GET /agents/<agent>/artifacts/<ref>` route.

## Design choice needing your eyes: new route, not an overload
The existing `/tool-results/<artifact>` route's candidate set is "a MediaStore-minted filename under `tool_results_dir`"; #4482's candidate set is "any file the agent produced anywhere under `project_root`" (e.g. via `write_file`, not necessarily a tool result). Rather than overload the existing `<artifact>` param with two different resolution strategies, I added a **separate** route (`/artifacts/<ref>`) and left the existing endpoint's contract completely untouched. Traversal boundary widens from `tool_results_dir` to `project_root` for the new route — not a new privilege (it's the same boundary `write_file`'s own sandbox scoping already uses; this route can only ever serve back something the agent could already produce and read itself) but flagging the choice explicitly since it's the one part of this PR with real security surface.

Re-validated at serve time regardless of what the table says (defense in depth) — falsify-tested with a hand-crafted table entry pointing outside `project_root` (`test_a_table_entry_pointing_outside_project_root_is_rejected`), confirms 400 and no body leak.

## Scoping note
`mcp/server.py`'s own resource-serving is **not** wired to ref resolution here — the brief named "取得口" (the fetch endpoint) singular, and `resources.py`'s HTTP route is the one measured in the design thread. Left MCP wiring as a follow-up rather than silently widening this PR.

## Explicitly out of scope (brief's own exclusions)
- "changed since presented" state — PR-3's own scope (client-side mtime-vs-seq comparison, no new persisted state)
- GC/retention — #4478's domain; an unresolvable ref is this module's entire answer to a GC'd file

## Test plan
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict` on both new test files — 0 errors
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] `python scripts/mypy_ratchet.py` — no new findings (212/215 baselined, unchanged)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/data/test_4482_artifact_ref.py tests/web/test_4482_get_artifact_by_ref.py tests/web/test_resources_router.py tests/data/test_4482_ref_path_normalize.py` — 35 passed, 0 failed, no regression on the sibling route's own suite
- [x] Every acceptance criterion in the brief has its own test (idempotent / normalization-insensitive / resolve round-trip / deleted-unresolvable / content-change-still-resolvable / no-copy via same-inode check)
- [x] Traversal defense-in-depth falsify-verified (crafted table entry, confirmed 400 + no leak)
- [x] (skipped — n/a, no UI surface)

part of #4482


---

- [x] 🔴 **[lead-coder]**（reviewer 確認済 — 「NOT authentication」の明言、3 枚の列挙、`--host` 既定の出典まで記載）docstring に 1 行: unauthenticated な surface に出せる範囲が「tool-results の成果物」から「minted な path すべて」に広がったこと、それを塞いでいるのは ①推測不能な ref（72bit）②agent スコープ ③`--host` 既定 127.0.0.1 の 3 枚であって**認証ではない**こと。将来 `--host 0.0.0.0` を既定にする議論が出た時に、この route がその判断に掛かることが見えるように。

