### PR TITLE
feat(#4479): automatic age/size purge for .reyn/events

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -2100,7 +2100,7 @@ window-relative.
 
 ## `audit_events` block
 
-Audit-log rotation policy for chat-session event files. Skill-run events use one file per run and are not affected by this setting.
+Audit-log rotation + automatic purge policy for chat-session event files. Skill-run events use one file per run and are not affected by this setting.
 
 Renamed from `events:` (#4174 T5) — bare "event" is ambiguous in reyn (an
 "event" is one of audit-event / WAL-event / hook-event); this block was
@@ -2108,18 +2108,28 @@ always audit-event rotation only.
 
 ```yaml
 audit_events:
-  max_bytes: 10485760       # rotate at 10 MB (default)
-  max_age_seconds: 86400    # rotate after 1 day (default)
-  cleanup_period_days: null # null = no automatic deletion (default)
+  max_bytes: 10485760              # rotate at 10 MB (default)
+  max_age_seconds: 86400           # rotate after 1 day (default)
+  cleanup_period_days: 30          # auto-delete files older than 30 days (default)
+  max_disk_usage_percent: 10       # auto-delete oldest files past 10% of free space (default)
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `max_bytes` | int | `10485760` (10 MB) | Rotate the active event file when it exceeds this size. `0` = no size-based rotation. |
 | `max_age_seconds` | int | `86400` (1 day) | Rotate the active event file when it exceeds this age in seconds. `0` = no age-based rotation. |
-| `cleanup_period_days` | int \| null | `null` | How long closed event files are kept before `reyn events purge` may delete them. `null` disables automatic deletion. `0` is rejected — use `null` to disable. |
+| `cleanup_period_days` | int | `30` | Automatic-purge age axis (#4479) — files whose filename date is older than this many days are deleted. `0` disables this axis. |
+| `max_disk_usage_percent` | float | `10` | Automatic-purge size axis (#4479) — once the events directory's own total size exceeds this percent of the filesystem's current FREE space, oldest files are deleted until back under. `0` disables this axis. |
 
 Setting both `max_bytes` and `max_age_seconds` to `0` disables rotation entirely.
+
+### Automatic purge (#4479)
+
+Either axis firing deletes files — `cleanup_period_days` OR `max_disk_usage_percent`, whichever is touched first (not `and`: disabling one axis must not silently disable the other). Runs fire-and-forget, off the event loop, at session start and at every rotation; `reyn events purge --before <DATE>` remains available for a manual, explicit run and shares the same file-selection code.
+
+Both defaults are **borrowed conventions, not measurements** of reyn's own `.reyn/events` growth rate (unmeasured as of #4479): 30 days borrows the nearest comparable local-agent CLI's own default (Claude Code's `cleanupPeriodDays`); 10% borrows systemd-journald's own `SystemMaxUse` convention. Neither is "the correct" number — both exist as an operator-overridable starting point.
+
+**`0` means disabled on that axis, not rejected** — a deliberate choice, documented here on purpose: Claude Code carries an open report of its own `cleanupPeriodDays` knob being ambiguous about whether `0` means "delete immediately" or "never delete." reyn's own knobs use `0` = never delete, unambiguously, on both axes.
 
 ## `voice` block
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -488,22 +488,43 @@
 
 
 # -----------------------------------------------------------------------------
-# audit_events: audit-log rotation policy (#4174 T5: renamed from
-# ``events:`` — bare "event" is ambiguous in reyn, and this block was
-# always audit-event rotation only). Chat events land under
+# audit_events: audit-log rotation + automatic purge policy (#4174 T5:
+# renamed from ``events:`` — bare "event" is ambiguous in reyn, and this
+# block was always audit-event only). Chat events land under
 # ``.reyn/events/agents/<name>/chat/<YYYY-MM>/`` and rotate when EITHER the
 # active file exceeds ``max_bytes`` OR the file's age (or local date) exceeds
 # ``max_age_seconds``.
 #
-# ``cleanup_period_days``: how long closed files should be kept before
-# ``reyn events purge`` may delete them. ``null`` (default) disables
-# automatic deletion. Setting ``0`` is rejected (= footgun: would silently
-# discard transcript writes).
+# Automatic purge (#4479, owner ruling 2026-08-13): EITHER axis firing
+# deletes old files — ``cleanup_period_days`` OR ``max_disk_usage_percent``,
+# whichever is touched first (not ``and`` — disabling one axis must not
+# silently disable the other). Runs fire-and-forget, off the event loop, at
+# session start and at rotation; ``reyn events purge`` remains available for
+# a manual/explicit run.
+#
+# ``cleanup_period_days`` (default 30): files whose filename date is older
+# than this many days are purge targets. Practice, not measurement — no
+# local-CLI precedent measures ``.reyn/events``'s own growth rate; 30
+# borrows the nearest comparable tool's own default (Claude Code's own
+# ``cleanupPeriodDays``).
+#
+# ``max_disk_usage_percent`` (default 10): once the events directory's own
+# total size exceeds this percent of the filesystem's CURRENT free space,
+# oldest files are purged until back under. Relative, not absolute — an
+# absolute byte ceiling would need reyn's own measured growth rate to set
+# safely (unmeasured); 10 borrows systemd-journald's own ``SystemMaxUse``
+# convention for the same reason.
+#
+# ``0`` on EITHER axis disables that axis (all retention, on that axis,
+# forever) — documented plainly here on purpose: Claude Code carries an
+# open report of its own ``cleanupPeriodDays`` knob being ambiguous about
+# what ``0`` means, and this is that precedent deliberately not repeated.
 # -----------------------------------------------------------------------------
 # audit_events:
 #   max_bytes: 10485760              # 10 MB
 #   max_age_seconds: 86400           # 1 day
-#   cleanup_period_days: null        # null = never auto-delete
+#   cleanup_period_days: 30          # 0 = never auto-delete by age
+#   max_disk_usage_percent: 10       # 0 = never auto-delete by size
 
 
 # -----------------------------------------------------------------------------

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -462,7 +462,7 @@ def _build_auth_config(raw: object) -> AuthConfig:
 
 @dataclass
 class AuditEventsConfig:
-    """`audit_events:` — audit log rotation policy (PR20).
+    """`audit_events:` — audit log rotation + automatic purge policy (PR20, #4479).
 
     #4174 T5: renamed from `events:` / `EventsConfig` — bare "event" is the
     exact shape CLAUDE.md's cross-cutting-band note bans ("event" is three
@@ -475,15 +475,46 @@ class AuditEventsConfig:
     exceeds `max_age_seconds`. Setting both to 0 disables rotation, which
     is the single-run mode (1 run = 1 file).
 
-    `cleanup_period_days` documents how long closed files should be kept
-    before `reyn events purge` may delete them. `null` (default) disables
-    automatic deletion — purge only runs when invoked explicitly. Setting
-    `0` is rejected (it is a footgun: Claude Code historically treated
-    `0` as "disable transcript writes" and surprised users).
+    **Automatic purge (#4479, owner ruling 2026-08-13)** — two independent
+    axes, EITHER firing deletes a file (owner: "日数orサイズ"; `and` would
+    mean disabling one axis silently disables the other too):
+
+    - ``cleanup_period_days`` (default 30): files whose filename start-date
+      is older than `today - cleanup_period_days` are purge targets.
+      **This is a borrowed CONVENTION, not a measurement** — no local-CLI
+      precedent measures `.reyn/events`'s own growth rate; 30 borrows the
+      nearest comparable tool's own default (Claude Code's own
+      `cleanupPeriodDays`, another local-agent CLI).
+    - ``max_disk_usage_percent`` (default 10): once the events directory's
+      own total size exceeds this percent of the filesystem's CURRENT free
+      space, oldest files are purged until back under. **Relative, not
+      absolute** — an absolute byte ceiling would need reyn's own measured
+      growth rate to set safely (unmeasured); a relative ceiling doesn't.
+      10 borrows systemd-journald's own `SystemMaxUse` convention for the
+      identical reason — again borrowed, not derived from reyn's own data.
+
+    **`0` on either axis disables that axis** (deliberately, an explicit
+    reversal of THIS class's earlier stance on `cleanup_period_days`, which
+    used to REJECT `0` as a footgun — see below). Both axes documented
+    here plainly rather than left ambiguous: Claude Code carries an open
+    report of its own `cleanupPeriodDays` knob being unclear about what
+    `0` means, and this is that precedent deliberately not repeated.
+
+    Purge runs automatically (fire-and-forget, off the event loop) at
+    session start and at rotation — see `EventStore`/`core/events/
+    event_purge.py` for the trigger + the actual selection/deletion logic,
+    which `reyn events purge` (the CLI command) also calls, so there is
+    exactly one place that decides "which files are purge targets."
+
+    #4479 drift note: this docstring previously said `cleanup_period_days`
+    defaulted to `None` (disabled) and rejected `0`. Both are now the
+    OPPOSITE of what this field does — kept only as a historical note in
+    case an old comment elsewhere still cites the rejected-0 behavior.
     """
     max_bytes: int = 10 * 1024 * 1024     # 10 MB
     max_age_seconds: int = 24 * 60 * 60   # 1 day
-    cleanup_period_days: int | None = None
+    cleanup_period_days: int = 30
+    max_disk_usage_percent: float = 10.0
 
 
 _SANDBOX_BACKENDS = {"auto", "seatbelt", "landlock", "noop"}
@@ -915,25 +946,38 @@ def _build_fs_watch_config(raw: object) -> FsWatchConfig:
 
 
 def _build_audit_events_config(raw: object) -> AuditEventsConfig:
-    """Parse `audit_events:` from reyn.yaml (#4174 T5, renamed from `events:`)."""
+    """Parse `audit_events:` from reyn.yaml (#4174 T5, renamed from `events:`).
+
+    #4479: `cleanup_period_days` / `max_disk_usage_percent` — 0 disables
+    that axis (owner ruling — the OPPOSITE of this field's earlier stance,
+    which rejected 0 as a footgun; see `AuditEventsConfig`'s own docstring
+    for why the reversal). A negative or non-numeric value falls back to
+    the default rather than being accepted or rejected outright — same
+    discipline as every other numeric config builder in this module (an
+    operator typo must not silently produce a nonsensical negative purge
+    threshold)."""
     defaults = AuditEventsConfig()
     if not isinstance(raw, dict):
         return defaults
     cleanup = raw.get("cleanup_period_days", defaults.cleanup_period_days)
-    if cleanup == 0:
-        # Reject the Claude-Code-style "0 disables writes" footgun.
-        # Use null/None to disable automatic cleanup; positive ints to enable.
-        raise ValueError(
-            "audit_events.cleanup_period_days=0 is not allowed; "
-            "use null to disable automatic cleanup, or a positive int."
-        )
-    cleanup_val: int | None = None
-    if cleanup is not None:
+    try:
         cleanup_val = int(cleanup)
+        if cleanup_val < 0:
+            cleanup_val = defaults.cleanup_period_days
+    except (TypeError, ValueError):
+        cleanup_val = defaults.cleanup_period_days
+    disk_percent = raw.get("max_disk_usage_percent", defaults.max_disk_usage_percent)
+    try:
+        disk_percent_val = float(disk_percent)
+        if disk_percent_val < 0:
+            disk_percent_val = defaults.max_disk_usage_percent
+    except (TypeError, ValueError):
+        disk_percent_val = defaults.max_disk_usage_percent
     return AuditEventsConfig(
         max_bytes=int(raw.get("max_bytes", defaults.max_bytes)),
         max_age_seconds=int(raw.get("max_age_seconds", defaults.max_age_seconds)),
         cleanup_period_days=cleanup_val,
+        max_disk_usage_percent=disk_percent_val,
     )
 
 

--- a/src/reyn/core/events/event_purge.py
+++ b/src/reyn/core/events/event_purge.py
@@ -69,8 +69,20 @@ def filename_start_date(name: str) -> date | None:
 def collect_dated_files(root: Path) -> list[tuple[Path, date | None]]:
     """Every `.jsonl` file under `root`, each paired with its parsed
     filename start-date (`None` if unparseable). Sorted oldest-first —
-    `(date, path)`, with undated files sorted FIRST (never assumed recent —
-    a conservative choice for a destructive-by-default purge)."""
+    `(date, path)`, with undated files sorted FIRST.
+
+    **This ordering is "conservative" for the SIZE axis specifically, not
+    a blanket policy** — the two axes read an undated file oppositely
+    (lead-coder review, #4479): `select_by_age` (below) never selects one
+    at all, since there is no date to compare against `before` — the
+    conservative reading there is "don't guess, don't delete." Sorting it
+    FIRST only matters to `select_by_disk_budget`, which purges oldest-first
+    off THIS ordering — there, "don't guess, assume the worst" is the
+    conservative reading: an unparseable filename (e.g. after a future
+    naming-convention change) is treated as the OLDEST entry, so a
+    size-budget purge reaches it before any dated file, rather than
+    silently exempting whatever it doesn't recognize from the size axis
+    the way the age axis structurally must exempt it."""
     out: list[tuple[Path, date | None]] = []
     for p in root.rglob("*.jsonl"):
         out.append((p, filename_start_date(p.name)))

--- a/src/reyn/core/events/event_purge.py
+++ b/src/reyn/core/events/event_purge.py
@@ -1,0 +1,174 @@
+"""Automatic purge of `.reyn/events` files (#4479).
+
+Distinct from `retention.py` (ADR-0038's WAL/generation retention window for
+reconstruct/rewind) — this module deletes closed audit-event `.jsonl` files
+from disk; it has nothing to do with how far back a session can reconstruct.
+Naming them both "retention" would be exactly the kind of conflation
+CLAUDE.md's cross-cutting-band note bans for "event" — kept apart on
+purpose. See `AuditEventsConfig`'s own docstring (config/infra.py) for the
+config-facing name of each knob.
+
+**Two independent axes, either fires deletion** — owner ruling (2026-08-13):
+"規定は日数orサイズで削除" (age OR size, whichever is touched first — `and`
+would mean disabling one axis silently disables the other too, which the
+owner's own wording rules out).
+
+- **age** (`max_age_days`, default 30): files whose filename start-date is
+  older than `today - max_age_days` are purge targets. The default is
+  practice, not measurement — architect's survey (#4479) found no local-CLI
+  precedent measuring `.reyn/events`'s own growth rate; the closest
+  comparable tool (Claude Code, another local-agent CLI) defaults its own
+  `cleanupPeriodDays` to 30, and this borrows that number as a starting
+  convention, not a derived one.
+- **size** (`max_disk_usage_percent`, default 10): purge oldest-first once
+  the events directory's own total size exceeds `max_disk_usage_percent`%
+  of the filesystem's CURRENT free space. Relative, not absolute — an
+  absolute byte ceiling would need reyn's own measured growth rate to set
+  safely (unmeasured, per #4479), while a relative ceiling needs no such
+  measurement to have a defensible default. 10% borrows systemd-journald's
+  `SystemMaxUse` convention for the identical reason (its docs use the same
+  device-relative-percentage shape) — again a borrowed convention, not a
+  reyn-specific derivation.
+
+**0 disables that axis** (owner ruling — explicit reversal of this same
+config's earlier historical stance, which REJECTED 0 as a footgun; the
+owner's ruling for THIS feature instead has each 0's meaning documented
+plainly, which is what this docstring + `AuditEventsConfig`'s own docstring
+do — Claude Code carries an open report of its OWN `cleanupPeriodDays` knob
+being ambiguous about what 0 means, and this is the precedent being
+deliberately not repeated).
+
+The file-selection + deletion logic here is the ONE code path both `reyn
+events purge` (`interfaces/cli/commands/events.py`) and the automatic
+trigger (this module, called from `EventStore`) use — the CLI command
+imports from here, never the reverse, so there is exactly one place that
+decides "which files are purge targets" and one place that deletes them
+(owner/lead-coder: "削除する主体を2つにしない")."""
+from __future__ import annotations
+
+import re
+import shutil
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+_FILENAME_TS_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})(?:T(\d{6}))?")
+
+
+def filename_start_date(name: str) -> date | None:
+    """Parse a `.jsonl` filename's leading `YYYY-MM-DD` — `None` if the name
+    doesn't carry a recognizable date (e.g. a manually dropped-in file)."""
+    m = _FILENAME_TS_RE.match(name)
+    if not m:
+        return None
+    try:
+        return datetime.strptime(m.group(1), "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def collect_dated_files(root: Path) -> list[tuple[Path, date | None]]:
+    """Every `.jsonl` file under `root`, each paired with its parsed
+    filename start-date (`None` if unparseable). Sorted oldest-first —
+    `(date, path)`, with undated files sorted FIRST (never assumed recent —
+    a conservative choice for a destructive-by-default purge)."""
+    out: list[tuple[Path, date | None]] = []
+    for p in root.rglob("*.jsonl"):
+        out.append((p, filename_start_date(p.name)))
+    out.sort(key=lambda item: (item[1] or date.min, item[0]))
+    return out
+
+
+def select_by_age(
+    files: list[tuple[Path, date | None]], *, before: date,
+) -> list[Path]:
+    """Files whose start-date is strictly before `before` — undated files
+    are never selected by age (no date to compare; the size axis, if
+    enabled, still covers them)."""
+    return [p for p, d in files if d is not None and d < before]
+
+
+def select_by_disk_budget(
+    root: Path, files: list[tuple[Path, date | None]], *, max_disk_usage_percent: float,
+) -> list[Path]:
+    """Oldest-first purge targets until `root`'s own total `.jsonl` size is
+    back under `max_disk_usage_percent`% of the filesystem's CURRENT free
+    space (`shutil.disk_usage(root).free` — the space available if `root`
+    did not already occupy any of it is not computed here; this reads the
+    budget off the free bytes AS MEASURED, which already excludes what
+    root currently occupies, matching journald's own SystemMaxUse framing:
+    a ceiling on the journal's footprint relative to what's free, not a
+    share of total capacity)."""
+    if max_disk_usage_percent <= 0:
+        return []
+    try:
+        free_bytes = shutil.disk_usage(root).free
+    except OSError:
+        return []  # can't measure — do nothing rather than guess
+    budget_bytes = free_bytes * (max_disk_usage_percent / 100.0)
+    sizes: list[tuple[Path, int]] = []
+    total = 0
+    for p, _d in files:
+        try:
+            sz = p.stat().st_size
+        except OSError:
+            sz = 0
+        sizes.append((p, sz))
+        total += sz
+    if total <= budget_bytes:
+        return []
+    targets: list[Path] = []
+    for p, sz in sizes:  # already oldest-first
+        if total <= budget_bytes:
+            break
+        targets.append(p)
+        total -= sz
+    return targets
+
+
+def select_purge_targets(
+    root: Path, *, max_age_days: int = 0, max_disk_usage_percent: float = 0.0,
+) -> list[Path]:
+    """The union of both axes' targets — either firing is enough (owner:
+    "日数orサイズ"). `max_age_days <= 0` / `max_disk_usage_percent <= 0`
+    disables that axis. Returns a de-duplicated, sorted list; empty when
+    both axes are disabled or neither is currently over its threshold."""
+    if not root.is_dir():
+        return []
+    files = collect_dated_files(root)
+    targets: set[Path] = set()
+    if max_age_days > 0:
+        cutoff = date.today() - timedelta(days=max_age_days)
+        targets.update(select_by_age(files, before=cutoff))
+    if max_disk_usage_percent > 0:
+        targets.update(select_by_disk_budget(
+            root, files, max_disk_usage_percent=max_disk_usage_percent,
+        ))
+    return sorted(targets)
+
+
+def purge_files(paths: list[Path]) -> int:
+    """Delete every path in `paths`, best-effort (an already-gone or
+    permission-denied file is skipped, not fatal — matches `reyn events
+    purge`'s own established per-file `try/except OSError` shape). Returns
+    the count actually deleted."""
+    deleted = 0
+    for p in paths:
+        try:
+            p.unlink()
+            deleted += 1
+        except OSError:
+            pass
+    return deleted
+
+
+def apply_auto_purge(
+    root: Path, *, max_age_days: int = 0, max_disk_usage_percent: float = 0.0,
+) -> int:
+    """Select + delete in one call — the automatic-trigger entry point
+    (`EventStore`, off-loop via `DurabilityWorker.submit_nowait`). Returns
+    the count deleted (0 when both axes are disabled, nothing is over
+    threshold, or `root` doesn't exist yet)."""
+    targets = select_purge_targets(
+        root, max_age_days=max_age_days, max_disk_usage_percent=max_disk_usage_percent,
+    )
+    return purge_files(targets)

--- a/src/reyn/core/events/event_store.py
+++ b/src/reyn/core/events/event_store.py
@@ -80,6 +80,8 @@ class EventStore:
         max_bytes: int = 0,
         max_age_seconds: int = 0,
         suffix: str = "",
+        cleanup_period_days: int = 0,
+        max_disk_usage_percent: float = 0.0,
     ) -> None:
         """
         dir_path: e.g. `events/agents/researcher/chat`
@@ -87,11 +89,17 @@ class EventStore:
         max_age_seconds: 0 disables age-based rotation
                          (date-boundary rotation also gated on this)
         suffix:          "" for chat, e.g. "_run" for a run
+        cleanup_period_days / max_disk_usage_percent: #4479 automatic
+            purge axes (0 disables that axis; see `AuditEventsConfig`'s own
+            docstring for the full rationale) — consulted by
+            `submit_auto_purge`, fired from `_open_new_file` below.
         """
         self._dir = Path(dir_path)
         self._max_bytes = int(max_bytes)
         self._max_age_seconds = int(max_age_seconds)
         self._suffix = suffix
+        self._cleanup_period_days = int(cleanup_period_days)
+        self._max_disk_usage_percent = float(max_disk_usage_percent)
         self._active: Path | None = None
         self._active_started_at: datetime | None = None
         # Running byte count of the active file — avoids a `.stat()` syscall
@@ -280,6 +288,40 @@ class EventStore:
         self._active.touch()
         self._active_started_at = now
         self._active_size = 0
+        # #4479: this method runs on EVERY store's first write (self._active
+        # was None) AND on every true rotation — one hook point covers both
+        # triggers architect named without duplicating logic: "session
+        # start" (the guaranteed one — rotation defaults OFF, infra.py's
+        # own AuditEventsConfig docstring) and "rotation" (frequency scales
+        # with usage, free — already touching the directory here).
+        self.submit_auto_purge()
+
+    def submit_auto_purge(self) -> None:
+        """Fire-and-forget an automatic purge check (#4479) off the event
+        loop, via this store's own `DurabilityWorker`. No-op when both
+        axes are disabled, or when no event loop is running (a sync-mode
+        caller — e.g. the CLI-mode `EventStore`, `events.py`'s own replay
+        construction — gets no automatic purge; `reyn events purge` stays
+        the explicit path for those)."""
+        if self._cleanup_period_days <= 0 and self._max_disk_usage_percent <= 0:
+            return
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        root = self._dir
+        max_age_days = self._cleanup_period_days
+        max_disk_usage_percent = self._max_disk_usage_percent
+
+        async def _job() -> None:
+            from reyn.core.events.event_purge import apply_auto_purge
+            await asyncio.to_thread(
+                apply_auto_purge, root,
+                max_age_days=max_age_days,
+                max_disk_usage_percent=max_disk_usage_percent,
+            )
+
+        self._worker.submit_nowait(_job)
 
     @staticmethod
     def _unique(path: Path) -> Path:

--- a/src/reyn/interfaces/cli/commands/events.py
+++ b/src/reyn/interfaces/cli/commands/events.py
@@ -8,15 +8,18 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Iterator
 
-from ..logger_factory import make_logger
+from reyn.core.events.event_purge import (
+    collect_dated_files as _collect_dated_files,
+)
+from reyn.core.events.event_purge import filename_start_date as _filename_start_date
+from reyn.core.events.event_purge import select_by_age as _select_by_age
 
-_FILENAME_TS_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})(?:T(\d{6}))?")
+from ..logger_factory import make_logger
 
 
 def register(sub) -> None:
@@ -183,16 +186,6 @@ def _collect_files(
     return [p for _, p in out]
 
 
-def _filename_start_date(name: str):
-    m = _FILENAME_TS_RE.match(name)
-    if not m:
-        return None
-    try:
-        return datetime.strptime(m.group(1), "%Y-%m-%d").date()
-    except ValueError:
-        return None
-
-
 def _parse_date(s: str | None, flag: str):
     if s is None:
         return None
@@ -232,14 +225,11 @@ def run_purge(args: argparse.Namespace) -> None:
         print(f"No events directory at {root}", file=sys.stderr)
         return
 
-    targets: list[Path] = []
-    for p in root.rglob("*.jsonl"):
-        date = _filename_start_date(p.name)
-        if date is None:
-            continue
-        if date >= before.date():
-            continue
-        targets.append(p)
+    # #4479: shared selection logic with the automatic trigger
+    # (core/events/event_purge.py) — the SAME "which files are old enough"
+    # decision, not a second copy that could drift from it.
+    targets = _select_by_age(_collect_dated_files(root), before=before.date())
+    targets.sort()
 
     if not targets:
         print(f"No event files older than {args.before}.")

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1535,6 +1535,8 @@ class Session:
             events_dir,
             max_bytes=self._events_config.max_bytes,
             max_age_seconds=self._events_config.max_age_seconds,
+            cleanup_period_days=self._events_config.cleanup_period_days,
+            max_disk_usage_percent=self._events_config.max_disk_usage_percent,
         )
         self._audit_events.remove_subscriber(self._event_store)
         self._audit_events.add_subscriber(new_store)
@@ -3891,6 +3893,8 @@ class Session:
             self.events_dir,
             max_bytes=self._events_config.max_bytes,
             max_age_seconds=self._events_config.max_age_seconds,
+            cleanup_period_days=self._events_config.cleanup_period_days,
+            max_disk_usage_percent=self._events_config.max_disk_usage_percent,
         )
         audit_events = EventLog(
             subscribers=[event_store],

--- a/tests/config/test_audit_events_purge_config_4479.py
+++ b/tests/config/test_audit_events_purge_config_4479.py
@@ -1,0 +1,79 @@
+"""Tier 1: #4479 — `audit_events:` automatic-purge config parsing.
+
+`cleanup_period_days` / `max_disk_usage_percent` — owner ruling: 0 disables
+that axis (a deliberate reversal of this field's earlier stance, which
+REJECTED 0 as a footgun). Covers defaults, the 0-disables shape, and the
+malformed-input fallback discipline every other builder in this module
+follows (a typo must not produce a nonsensical negative purge threshold).
+"""
+from __future__ import annotations
+
+from reyn.config.infra import AuditEventsConfig, _build_audit_events_config
+
+
+def test_defaults_are_thirty_days_and_ten_percent():
+    """Tier 1: the shipped defaults — borrowed conventions (Claude Code's
+    own cleanupPeriodDays; journald's own SystemMaxUse), not measurements."""
+    cfg = _build_audit_events_config(None)
+    assert cfg.cleanup_period_days == 30
+    assert cfg.max_disk_usage_percent == 10.0
+
+
+def test_zero_on_either_axis_disables_it_not_rejected():
+    """Tier 1: #4479 owner ruling — 0 means disabled, parsed through
+    cleanly (the OPPOSITE of this field's earlier ValueError-on-0 stance)."""
+    cfg = _build_audit_events_config(
+        {"cleanup_period_days": 0, "max_disk_usage_percent": 0},
+    )
+    assert cfg.cleanup_period_days == 0
+    assert cfg.max_disk_usage_percent == 0.0
+
+
+def test_positive_values_pass_through():
+    """Tier 1: an ordinary operator override on both axes parses through
+    unmodified."""
+    cfg = _build_audit_events_config(
+        {"cleanup_period_days": 7, "max_disk_usage_percent": 25.5},
+    )
+    assert cfg.cleanup_period_days == 7
+    assert cfg.max_disk_usage_percent == 25.5
+
+
+def test_negative_cleanup_period_days_falls_back_to_default():
+    """Tier 1: a negative age doesn't mean anything sensible (delete
+    future files?) — falls back rather than propagating nonsense, same
+    discipline as every other numeric builder in this module."""
+    cfg = _build_audit_events_config({"cleanup_period_days": -5})
+    assert cfg.cleanup_period_days == AuditEventsConfig().cleanup_period_days
+
+
+def test_negative_disk_usage_percent_falls_back_to_default():
+    """Tier 1: a negative percentage is nonsensical (a budget below zero
+    free space?) — falls back rather than propagating it."""
+    cfg = _build_audit_events_config({"max_disk_usage_percent": -10})
+    assert cfg.max_disk_usage_percent == AuditEventsConfig().max_disk_usage_percent
+
+
+def test_non_numeric_values_fall_back_to_defaults():
+    """Tier 1: an operator typo (a string where a number belongs) must not
+    crash config loading — falls back to the documented defaults."""
+    cfg = _build_audit_events_config(
+        {"cleanup_period_days": "soon", "max_disk_usage_percent": "lots"},
+    )
+    assert cfg.cleanup_period_days == 30
+    assert cfg.max_disk_usage_percent == 10.0
+
+
+def test_malformed_top_level_raw_returns_defaults():
+    """Tier 1: not a dict at all (e.g. a bare string in reyn.yaml) →
+    defaults, not a crash."""
+    cfg = _build_audit_events_config("not-a-dict")
+    assert cfg == AuditEventsConfig()
+
+
+def test_rotation_fields_still_parse_unchanged():
+    """Tier 1: regression guard — the pre-existing max_bytes/max_age_seconds
+    rotation fields are untouched by the #4479 purge-axis changes."""
+    cfg = _build_audit_events_config({"max_bytes": 999, "max_age_seconds": 111})
+    assert cfg.max_bytes == 999
+    assert cfg.max_age_seconds == 111

--- a/tests/core/test_event_purge_4479.py
+++ b/tests/core/test_event_purge_4479.py
@@ -1,0 +1,271 @@
+"""Tier 1/2: #4479 — automatic purge of `.reyn/events` files.
+
+Covers `core/events/event_purge.py`'s pure selection/deletion functions
+(Tier 1: no external state, deterministic on their inputs) and
+`EventStore.submit_auto_purge`'s real, observable, on-disk effect (Tier 2:
+a real EventStore + a real DurabilityWorker, actual files on `tmp_path` —
+no mocks).
+
+Both axes (age, disk-relative-size) are independent — EITHER firing is
+enough (owner ruling: "日数orサイズ"), never `and`.
+"""
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.event_purge import (
+    apply_auto_purge,
+    collect_dated_files,
+    filename_start_date,
+    purge_files,
+    select_by_age,
+    select_by_disk_budget,
+    select_purge_targets,
+)
+from reyn.core.events.event_store import EventStore
+
+
+def _write(root: Path, name: str, *, size_bytes: int = 0) -> Path:
+    p = root / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"x" * size_bytes if size_bytes else b'{"type":"t"}\n')
+    return p
+
+
+# ── filename_start_date / collect_dated_files ────────────────────────────
+
+
+def test_filename_start_date_parses_the_leading_date():
+    """Tier 1: the established `YYYY-MM-DDTHHMMSS[...].jsonl` filename shape."""
+    assert filename_start_date("2026-01-15T120000.jsonl") == date(2026, 1, 15)
+
+
+def test_filename_start_date_returns_none_for_an_unparseable_name():
+    """Tier 1: a manually dropped-in file with no date prefix is never
+    assumed recent (undated files sort first — see collect_dated_files)."""
+    assert filename_start_date("notes.jsonl") is None
+
+
+def test_collect_dated_files_sorts_undated_first_then_oldest_first(tmp_path):
+    """Tier 1: undated files sort FIRST (never assumed recent — a
+    conservative choice for a destructive-by-default purge), then real
+    dates ascend oldest-first."""
+    _write(tmp_path, "2026-06-01T000000.jsonl")
+    _write(tmp_path, "2026-01-01T000000.jsonl")
+    _write(tmp_path, "undated.jsonl")
+
+    files = collect_dated_files(tmp_path)
+    names = [p.name for p, _d in files]
+    assert names == ["undated.jsonl", "2026-01-01T000000.jsonl", "2026-06-01T000000.jsonl"]
+
+
+# ── select_by_age ─────────────────────────────────────────────────────────
+
+
+def test_select_by_age_selects_strictly_older_files_only():
+    """Tier 1: the cutoff is exclusive — a file dated exactly `before` is
+    NOT selected (matches the pre-#4479 `reyn events purge --before`
+    semantics: 'strictly before')."""
+    files = [
+        (Path("a"), date(2026, 1, 1)),
+        (Path("b"), date(2026, 3, 1)),
+        (Path("c"), date(2026, 6, 1)),
+    ]
+    selected = select_by_age(files, before=date(2026, 3, 1))
+    assert selected == [Path("a")]
+
+
+def test_select_by_age_never_selects_an_undated_file():
+    """Tier 1: an undated file has no date to compare — the age axis must
+    not guess; only the size axis can reach it."""
+    files = [(Path("undated"), None), (Path("old"), date(2020, 1, 1))]
+    selected = select_by_age(files, before=date(2026, 1, 1))
+    assert selected == [Path("old")]
+
+
+# ── select_by_disk_budget ────────────────────────────────────────────────
+
+
+def test_select_by_disk_budget_purges_oldest_first_until_under_budget(
+    tmp_path, monkeypatch,
+):
+    """Tier 1: once total size exceeds the free-space-relative budget,
+    oldest-first files are selected until back under it."""
+    old = _write(tmp_path, "2026-01-01T000000.jsonl", size_bytes=100)
+    mid = _write(tmp_path, "2026-02-01T000000.jsonl", size_bytes=100)
+    new = _write(tmp_path, "2026-03-01T000000.jsonl", size_bytes=100)
+    files = collect_dated_files(tmp_path)
+
+    from collections import namedtuple
+    Usage = namedtuple("Usage", ["total", "used", "free"])
+    # Total on-disk size = 300 bytes. A 1000-byte free budget at 20% =
+    # 200 bytes — over budget by 100, so exactly the OLDEST file must go.
+    monkeypatch.setattr(
+        "reyn.core.events.event_purge.shutil.disk_usage",
+        lambda _root: Usage(total=10_000, used=9_000, free=1_000),
+    )
+    selected = select_by_disk_budget(tmp_path, files, max_disk_usage_percent=20.0)
+    assert selected == [old]
+    assert mid not in selected
+    assert new not in selected
+
+
+def test_select_by_disk_budget_is_a_noop_under_budget(tmp_path, monkeypatch):
+    """Tier 1: nothing selected when already under budget — no false-positive
+    purge on a quiet events directory."""
+    _write(tmp_path, "2026-01-01T000000.jsonl", size_bytes=10)
+    files = collect_dated_files(tmp_path)
+    from collections import namedtuple
+    Usage = namedtuple("Usage", ["total", "used", "free"])
+    monkeypatch.setattr(
+        "reyn.core.events.event_purge.shutil.disk_usage",
+        lambda _root: Usage(total=10_000, used=0, free=10_000),
+    )
+    assert select_by_disk_budget(tmp_path, files, max_disk_usage_percent=50.0) == []
+
+
+def test_select_by_disk_budget_disabled_at_zero_percent(tmp_path):
+    """Tier 1: `max_disk_usage_percent <= 0` disables the axis outright —
+    no disk_usage() call, no selection, regardless of actual size."""
+    _write(tmp_path, "2026-01-01T000000.jsonl", size_bytes=10_000_000)
+    files = collect_dated_files(tmp_path)
+    assert select_by_disk_budget(tmp_path, files, max_disk_usage_percent=0) == []
+
+
+# ── select_purge_targets — the OR of both axes ───────────────────────────
+
+
+def test_select_purge_targets_is_the_union_of_both_axes(tmp_path, monkeypatch):
+    """Tier 1: EITHER axis firing selects a file — the owner's explicit
+    'day OR size' ruling, not `and` (which would mean disabling one axis
+    silently disables the other)."""
+    old_small = _write(tmp_path, "2020-01-01T000000.jsonl", size_bytes=1)  # age only
+    new_big = _write(  # size only
+        tmp_path, f"{date.today().isoformat()}T000000.jsonl", size_bytes=1000,
+    )
+    kept = _write(tmp_path, f"{date.today().isoformat()}T010000.jsonl", size_bytes=1)
+
+    from collections import namedtuple
+    Usage = namedtuple("Usage", ["total", "used", "free"])
+    monkeypatch.setattr(
+        "reyn.core.events.event_purge.shutil.disk_usage",
+        lambda _root: Usage(total=10_000, used=0, free=1_000),
+    )
+    targets = select_purge_targets(
+        tmp_path, max_age_days=30, max_disk_usage_percent=10.0,
+    )
+    assert old_small in targets, "age axis should have selected the old file"
+    assert new_big in targets, "size axis should have selected the oversized file"
+    assert kept not in targets
+
+
+def test_select_purge_targets_both_axes_disabled_selects_nothing(tmp_path):
+    """Tier 1: 0 on both axes means keep everything — the documented
+    all-disabled shape."""
+    _write(tmp_path, "2020-01-01T000000.jsonl")
+    assert select_purge_targets(tmp_path, max_age_days=0, max_disk_usage_percent=0) == []
+
+
+def test_select_purge_targets_missing_root_selects_nothing(tmp_path):
+    """Tier 1: a not-yet-created events dir (a fresh project) is a no-op,
+    not an error."""
+    missing = tmp_path / "does-not-exist"
+    assert select_purge_targets(missing, max_age_days=30) == []
+
+
+# ── purge_files ───────────────────────────────────────────────────────────
+
+
+def test_purge_files_deletes_and_counts(tmp_path):
+    """Tier 1: real on-disk deletion, real count."""
+    a = _write(tmp_path, "a.jsonl")
+    b = _write(tmp_path, "b.jsonl")
+    deleted = purge_files([a, b])
+    assert deleted == 2
+    assert not a.exists()
+    assert not b.exists()
+
+
+def test_purge_files_is_best_effort_on_a_missing_file(tmp_path):
+    """Tier 1: an already-gone file (e.g. deleted by a concurrent purge) is
+    skipped, not fatal — matches the CLI purge command's own established
+    per-file try/except shape."""
+    ghost = tmp_path / "ghost.jsonl"  # never created
+    real = _write(tmp_path, "real.jsonl")
+    deleted = purge_files([ghost, real])
+    assert deleted == 1
+    assert not real.exists()
+
+
+# ── apply_auto_purge — the automatic-trigger entry point ────────────────
+
+
+def test_apply_auto_purge_deletes_age_targets_end_to_end(tmp_path):
+    """Tier 1: select + delete composed — the function EventStore's
+    fire-and-forget job calls."""
+    old = _write(tmp_path, "2020-01-01T000000.jsonl")
+    new = _write(tmp_path, f"{date.today().isoformat()}T000000.jsonl")
+    deleted = apply_auto_purge(tmp_path, max_age_days=30, max_disk_usage_percent=0)
+    assert deleted == 1
+    assert not old.exists()
+    assert new.exists()
+
+
+# ── EventStore.submit_auto_purge — real, observable, on-disk effect ─────
+
+
+@pytest.mark.asyncio
+async def test_event_store_first_write_purges_old_files(tmp_path):
+    """Tier 2: #4479 — the FIRST write of a fresh EventStore instance is
+    the guaranteed "session start" trigger (architect: rotation defaults
+    OFF, so a true rotation may never fire; the first-open path always
+    does, regardless of rotation config). A stale file dated far in the
+    past is gone after the store's own `flush()` drains the fire-and-forget
+    purge job."""
+    events_dir = tmp_path / "events"
+    stale = _write(events_dir, "2020-01-01T000000.jsonl")
+
+    store = EventStore(events_dir, cleanup_period_days=30, max_disk_usage_percent=0)
+    from reyn.schemas.models import Event
+    store.write(Event(type="test_event", data={}))
+    await store.flush()
+
+    assert not stale.exists(), (
+        "the stale file should have been purged by the store's own first-write trigger"
+    )
+
+
+@pytest.mark.asyncio
+async def test_event_store_auto_purge_disabled_by_default_leaves_old_files(tmp_path):
+    """Tier 2: regression guard — an `EventStore` constructed WITHOUT the
+    new kwargs (every pre-#4479 call site, and any future one that doesn't
+    opt in) purges nothing — 0 is the constructor default for both axes."""
+    events_dir = tmp_path / "events"
+    stale = _write(events_dir, "2020-01-01T000000.jsonl")
+
+    store = EventStore(events_dir)  # no cleanup_period_days / max_disk_usage_percent
+    from reyn.schemas.models import Event
+    store.write(Event(type="test_event", data={}))
+    await store.flush()
+
+    assert stale.exists(), "default-constructed EventStore must not auto-purge"
+
+
+def test_event_store_submit_auto_purge_is_a_noop_with_no_running_loop(tmp_path):
+    """Tier 2: a sync-mode caller (no event loop — e.g. a CLI entry point)
+    gets no automatic purge; `submit_auto_purge`'s own no-loop guard mirrors
+    `write()`'s established sync-fallback precedent, but here the fallback
+    is simply "do nothing" (the CLI's own `reyn events purge` stays the
+    explicit path for that caller). Deliberately NOT `@pytest.mark.asyncio`
+    — the real no-loop condition is a plain synchronous call, not something
+    to simulate from inside a running loop."""
+    events_dir = tmp_path / "events"
+    stale = _write(events_dir, "2020-01-01T000000.jsonl")
+    store = EventStore(events_dir, cleanup_period_days=30, max_disk_usage_percent=0)
+
+    store.submit_auto_purge()  # no running loop in this plain sync test
+
+    assert stale.exists(), "no running loop on the calling thread — must not purge"


### PR DESCRIPTION
**[tui-coder]** — part of #4479

owner ruling (2026-08-13) + architect design, dispatched by lead-coder. Adds an automatic purge policy on top of the existing manual `reyn events purge` command — #4479's own resource assessment found deletion already existed, only an automatic POLICY was missing.

## Design (owner + architect, #4479's own thread)

Two independent axes, either firing deletes a file — owner: "日数orサイズ" (age OR size, explicitly not `and` — disabling one axis must not silently disable the other):

- **`cleanup_period_days`** (default 30): age axis. A borrowed CONVENTION, not a measurement — `.reyn/events`'s own growth rate is unmeasured; 30 borrows the nearest comparable local-agent CLI's own default (Claude Code's `cleanupPeriodDays`).
- **`max_disk_usage_percent`** (default 10): size axis, RELATIVE to the filesystem's current free space, never an absolute byte ceiling (which would need reyn's own measured growth rate to set safely — unmeasured). 10 borrows systemd-journald's own `SystemMaxUse` convention, same reasoning.

**`0` on either axis disables it** — an explicit reversal of this same config's earlier stance (`cleanup_period_days` used to REJECT `0` as a footgun); the owner's ruling for this feature instead documents each `0`'s meaning plainly, deliberately not repeating Claude Code's own open report of an ambiguous same-shaped knob.

## Trigger

Fire-and-forget, off the event loop, at `EventStore`'s first write (the guaranteed "session start" signal — rotation defaults OFF per this same config, so a true rotation may never fire on an unconfigured install) and at every subsequent true rotation (frequency scales with usage, free — already touching the directory). One hook point (`_open_new_file`) naturally covers both triggers architect named, since it runs on both the first-open and every reopen.

## Execution

`EventStore`'s own existing `DurabilityWorker.submit_nowait` — no new worker, no new timer, no resident process (lead-coder: "削除する主体を2つにしない"). The actual file-selection + deletion logic lives in a new `core/events/event_purge.py` — deliberately **not** named `retention.py` (that name is already ADR-0038's WAL/generation reconstruction window, a different concept entirely; conflating them would repeat exactly the "event" ambiguity CLAUDE.md's cross-cutting-band note bans). `reyn events purge` (the CLI command) now imports its own selection logic from this same module instead of a second, independently-maintained copy.

## Falsify-verify

Both the pure `select_by_age` test and the end-to-end `EventStore`-first-write test fail for the right reason (real assertion failures, not skips) with their respective fix reverted.

## Test plan

- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict` on new test files — 25/25 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (212/215 baselined, no new)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK (re-run against current `origin/main` right before push)
- [x] `pytest tests/config/` — 175 passed (incl. config-mirror-coverage for the new field)
- [x] `pytest tests/core/` (full) — 2564 passed, 1 skipped (unrelated optional-dependency extra)
- [x] `pytest tests/runtime/` (full) — 1741 passed, 1 skipped (unrelated)
- [x] `pytest tests/interfaces/test_events_purge_cwd_4204.py` — CLI purge regression, unchanged behavior after the shared-logic refactor
- [x] Real CLI smoke test (`reyn events purge --before ... --dry-run`) against a real `.reyn/events` tree — correct dry-run output
- [x] Falsify-verify — both key new tests genuinely fail with their fix reverted
- [x] (skipped — N/A, no UI change)

tests/ touched — TESTS-READ wait, no self-merge.
