### PR TITLE
WIP feat(#4482 PR-2b): artifact component wiring — catalog + binding + handle()

### DIFF
--- a/src/reyn/core/op_runtime/present.py
+++ b/src/reyn/core/op_runtime/present.py
@@ -218,6 +218,21 @@ async def handle(op: PresentIROp, ctx: OpContext) -> dict:
         fallback_stage=fallback_stage,
     )
 
+    # 3.5. #4482 PR-2b: resolve any "artifact" node's raw source/content
+    #    strings (resolve_bindings only bound them — it stays pure/I/O-free,
+    #    see binding.py's own "artifact" branch comment) into the final
+    #    OS-derived payload. This is the layer that legitimately has
+    #    project_root (ctx.workspace.base_dir) / agent_name (ctx.actor) —
+    #    lead-coder's ruling on where this step belongs, not inside
+    #    resolve_bindings or _resolve_presentation. Rewrites rendered.nodes
+    #    only — the audit event above already carries refs + stats, never
+    #    node content, so ordering relative to it does not matter; placed
+    #    here because THIS is the only thing that needs it.
+    from reyn.core.present.artifact_payload import apply_artifact_resolution
+    rendered.nodes = apply_artifact_resolution(
+        rendered.nodes, ctx.workspace.base_dir, ctx.actor,
+    )
+
     # 4. Hand the actually-rendered model to the wired surface (PR-B). Fire-and-
     #    continue: the op's ack (below) is already fully derived from the stats,
     #    not from anything the renderer does — a renderer failure must never be

--- a/src/reyn/core/present/artifact_payload.py
+++ b/src/reyn/core/present/artifact_payload.py
@@ -1,0 +1,145 @@
+"""#4482 PR-2: present payload construction for an "artifact" — an
+LLM-produced file the terminal can't render natively (html/office/pdf/
+images), which a user opens with the OS's own default app.
+
+**① server/client payload shape** (architect's final corrected form, #4482
+issue thread)::
+
+    payload := {
+      media_type  : <IANA, OPTIONAL, best-effort> (None -> "application/octet-stream")
+      name        : <str>  required for a source-backed artifact, absent for inline
+      description : <str, optional>
+      body        : Inline | Reference
+    }
+    Inline    := {"inline": <str>}            # text-serialized only, never base64
+    Reference := {"ref": <str>, "size": <int>}
+
+**② agent-facing slots** — an agent says EITHER:
+  - ``source`` + ``description`` — the OS derives ``media_type``/``name``/
+    ``ref``/which body shape from the real file (:func:`build_source_artifact_payload`).
+  - ``media_type`` + ``content`` + ``description`` directly — there is no
+    real file for the OS to derive anything from, so the agent NAMES
+    ``media_type`` itself (:func:`build_inline_artifact_payload`). "Don't
+    let the agent write ``media_type``" is the SOURCE case's rule, whose
+    reason ("the OS can derive it from the real file") doesn't apply when
+    there is no real file.
+
+**Invariants** (architect's ruling, unchanged from PR-1, #4482):
+
+1. **Never put a raw filesystem path on the wire.** The payload carries a
+   ``ref`` only (Reference body) or fully-materialized text (Inline body)
+   — never a path string. Local-host resolution is the transport layer's
+   own optimization, not this function's concern.
+2. **No reyn-specific extension table.** ``mimetypes.guess_type()``'s
+   result, unmodified. Two NARROWER tables already exist —
+   ``op_runtime/file.py``'s ``_IMAGE_EXTENSIONS`` and ``slash/image.py``'s
+   own copy of it — but both answer a different, narrower question
+   (whether ``read_file``'s BINARY read path should fire) and neither is
+   reused here: this module derives a general ``media_type`` for a
+   present payload, which stdlib ``mimetypes`` already answers directly,
+   without adding a THIRD hand-maintained table (#4431's own class).
+3. **Inline vs Reference for a source-backed artifact is decided by
+   OBSERVATION, never by a media_type table lookup.** ``media_type`` is
+   unreliable for this call: architect's own measurement found stdlib
+   ``mimetypes`` resolves ``.pptx``/``.docx``/``.xlsx`` to ``None`` on a
+   minimal host (no ``/etc/mime.types``) — exactly the formats motivating
+   this feature. The decision is: stat the file (never read it for this
+   step) — above the probe limit, Reference, no further read needed;
+   otherwise read ONLY that many bytes and attempt a UTF-8 decode —
+   success is Inline, failure is Reference. The amount ever read is
+   therefore structurally bounded regardless of the real file's size.
+4. **No inline byte cap for agent-DECLARED inline content** (the
+   :func:`build_inline_artifact_payload` path). The model's own output-
+   token ceiling already bounds what an agent can write inline — a
+   second, reyn-side byte cap would just repeat that same bound under a
+   different error message, to the same caller (the model itself) that
+   already gets told when it overruns the first one.
+"""
+from __future__ import annotations
+
+import mimetypes
+from pathlib import Path
+
+from reyn.data.workspace.artifact_ref import mint_ref
+from reyn.data.workspace.ref_path_normalize import normalize_ref_path
+
+# The size boundary between "read a bounded probe and try to inline it"
+# and "too big, go straight to Reference" for a SOURCE-backed artifact
+# (invariant 3 above). Reuses MultimodalConfig.max_bytes's own value
+# (config/media.py) — the existing, already owner-approved media-size
+# bound — rather than inventing a new number for a closely related
+# question ("how much binary content is reasonable to inline/decode").
+# If real usage later shows this needs its own, different value, that is
+# a config knob to ADD then, backed by evidence — not a number to invent
+# now without any (CLAUDE.md: no unjustified constant without a knob).
+INLINE_PROBE_MAX_BYTES = 5_000_000
+
+
+def _derive_media_type(name: str) -> "str | None":
+    """``mimetypes.guess_type()``'s result, unmodified — invariant 2. No
+    reyn-specific table, no fallback table, no override list."""
+    guessed, _encoding = mimetypes.guess_type(name)
+    return guessed
+
+
+def build_source_artifact_payload(
+    project_root: Path,
+    agent_name: str,
+    source: "str | Path",
+    *,
+    description: "str | None" = None,
+    probe_max_bytes: int = INLINE_PROBE_MAX_BYTES,
+) -> dict:
+    """Build a payload for a ``source``-backed artifact (agent gives a
+    path; the OS derives everything else — invariant/slot ②).
+
+    Raises ``FileNotFoundError`` if *source* does not resolve to a real
+    file — the caller decides how to surface that (e.g. as a present-node
+    render error), this function's own job stops at "can I even see it".
+    """
+    resolved = normalize_ref_path(source, project_root)
+    if not resolved.is_file():
+        raise FileNotFoundError(f"artifact source {source!r} is not a file")
+
+    name = resolved.name
+    media_type = _derive_media_type(name)
+    size = resolved.stat().st_size
+
+    body: "dict | None" = None
+    if size <= probe_max_bytes:
+        probe = resolved.read_bytes()[:probe_max_bytes]
+        try:
+            inline_text = probe.decode("utf-8")
+        except UnicodeDecodeError:
+            body = None
+        else:
+            body = {"inline": inline_text}
+
+    if body is None:
+        ref = mint_ref(project_root, agent_name, resolved)
+        body = {"ref": ref, "size": size}
+
+    payload: dict = {"media_type": media_type, "name": name, "body": body}
+    if description is not None:
+        payload["description"] = description
+    return payload
+
+
+def build_inline_artifact_payload(
+    media_type: str,
+    content: str,
+    *,
+    description: "str | None" = None,
+) -> dict:
+    """Build a payload for agent-DECLARED inline content (no real file
+    exists — slot ②'s other form). The agent names ``media_type`` itself
+    (invariant/slot ②'s own carve-out) since there is no file for the OS
+    to derive it from. No ``name`` slot — there is no real-file identity
+    to name, and nothing is ever opened for this form, so the "user sees
+    what they're about to open" requirement this whole feature exists for
+    (#4482's own single stated requirement) doesn't apply to it. No byte
+    cap (invariant 4)."""
+    payload: dict = {"media_type": media_type, "body": {"inline": content}}
+    if description is not None:
+        payload["description"] = description
+    return payload

--- a/src/reyn/core/present/artifact_payload.py
+++ b/src/reyn/core/present/artifact_payload.py
@@ -2,6 +2,21 @@
 LLM-produced file the terminal can't render natively (html/office/pdf/
 images), which a user opens with the OS's own default app.
 
+★ Isolation note (temporary, deliberate — not an oversight): as of this
+PR, nothing in ``core/present/catalog.py`` or ``core/present/binding.py``
+calls this module yet. The "artifact" component/slot naming (architect's
+#4482 ruling: ``component="artifact"``; agent-writable slots ``source`` /
+``content`` / ``media_type`` / ``description``, with ``name`` NOT a slot)
+was decided in a follow-up comment landing alongside this PR's merge, and
+the actual catalog-gate + binding-resolution wiring is PR-2b, a separate
+PR — not silently deferred, named here so this module's "no caller yet"
+state reads as a known, temporary staging point rather than the
+"declared/implemented/tested/invoked-by-nobody" shape this session has
+flagged repeatedly elsewhere tonight.
+
+**① server/client payload shape** (architect's final corrected form, #4482
+issue thread)::
+
 **① server/client payload shape** (architect's final corrected form, #4482
 issue thread)::
 

--- a/src/reyn/core/present/artifact_payload.py
+++ b/src/reyn/core/present/artifact_payload.py
@@ -2,20 +2,17 @@
 LLM-produced file the terminal can't render natively (html/office/pdf/
 images), which a user opens with the OS's own default app.
 
-★ Isolation note (temporary, deliberate — not an oversight): as of this
-PR, nothing in ``core/present/catalog.py`` or ``core/present/binding.py``
-calls this module yet. The "artifact" component/slot naming (architect's
-#4482 ruling: ``component="artifact"``; agent-writable slots ``source`` /
-``content`` / ``media_type`` / ``description``, with ``name`` NOT a slot)
-was decided in a follow-up comment landing alongside this PR's merge, and
-the actual catalog-gate + binding-resolution wiring is PR-2b, a separate
-PR — not silently deferred, named here so this module's "no caller yet"
-state reads as a known, temporary staging point rather than the
-"declared/implemented/tested/invoked-by-nobody" shape this session has
-flagged repeatedly elsewhere tonight.
-
-**① server/client payload shape** (architect's final corrected form, #4482
-issue thread)::
+PR-2b wires this module in: ``catalog.py``'s ``CATALOG`` gates the
+``"artifact"`` component's own structural rules (exactly one of
+source/content; media_type required alongside content, forbidden
+alongside source), ``binding.py``'s ``resolve_bindings`` resolves an
+``artifact`` node's raw slot values (bind-or-literal, same as ``image``'s
+own ``src``) WITHOUT touching disk (stays pure — see that function's own
+"artifact" branch comment for why), and :func:`apply_artifact_resolution`
+below is the separate post-processing pass — run by
+``op_runtime/present.py``'s ``handle()``, the layer that actually has
+``project_root``/``agent_name`` — that turns those raw values into the
+final OS-derived payload this module's other two functions build.
 
 **① server/client payload shape** (architect's final corrected form, #4482
 issue thread)::
@@ -158,3 +155,58 @@ def build_inline_artifact_payload(
     if description is not None:
         payload["description"] = description
     return payload
+
+
+def apply_artifact_resolution(
+    nodes: "list[dict]", project_root: Path, agent_name: str,
+) -> "list[dict]":
+    """#4482 PR-2b: the post-processing pass that turns a
+    ``resolve_bindings``-produced ``"artifact"`` node's raw
+    source/content/media_type/description STRINGS into the final
+    OS-derived payload (:func:`build_source_artifact_payload` /
+    :func:`build_inline_artifact_payload`).
+
+    Deliberately NOT part of ``resolve_bindings`` itself — see that
+    function's own "artifact" branch comment for why (lead-coder's
+    ruling: ``replay.py``'s re-render must stay disk-state-independent,
+    so this pass only runs in a layer that legitimately HAS
+    ``project_root``/``agent_name`` — ``op_runtime/present.py``'s
+    ``handle()``, not the pure binding-resolution layer).
+
+    Every non-``"artifact"`` node passes through completely unchanged.
+    An ``"artifact"`` node missing what it needs (both ``source`` AND
+    ``content`` soft-missed at binding time, or ``content`` resolved but
+    ``media_type`` didn't) is left as a bare ``{"component": "artifact"}``
+    — present's own soft-skip philosophy, never a hard failure from a
+    binding miss. A ``source`` file that has vanished since the agent
+    referenced it (:func:`build_source_artifact_payload` raising
+    ``FileNotFoundError``) becomes an explicit ``error`` marker rather
+    than propagating an exception through op execution — the same shape
+    :func:`reyn.data.workspace.artifact_ref.resolve_ref` already
+    established for a GC'd/deleted target (missing is unresolvable, not
+    a crash).
+    """
+    out: "list[dict]" = []
+    for node in nodes:
+        if node.get("component") != "artifact":
+            out.append(node)
+            continue
+        description = node.get("description")
+        if "source" in node:
+            try:
+                payload = build_source_artifact_payload(
+                    project_root, agent_name, node["source"], description=description,
+                )
+            except FileNotFoundError:
+                out.append({"component": "artifact", "error": "source_not_found"})
+                continue
+        elif "content" in node and "media_type" in node:
+            payload = build_inline_artifact_payload(
+                node["media_type"], node["content"], description=description,
+            )
+        else:
+            out.append({"component": "artifact"})
+            continue
+        payload["component"] = "artifact"
+        out.append(payload)
+    return out

--- a/src/reyn/core/present/binding.py
+++ b/src/reyn/core/present/binding.py
@@ -376,5 +376,20 @@ def resolve_bindings(
                     rendered["src"] = val
             if "alt" in node:
                 rendered["alt"] = _guard_maybe(node["alt"], neut, out, path=f"{loc}.alt")
+        elif component == "artifact":
+            # #4482 PR-2b: resolve_bindings stays pure/I/O-free (lead-coder's
+            # ruling — replay.py's own re-render must not start depending on
+            # "the disk's state at replay time", only on the P6 event's own
+            # data). This only resolves source/content/media_type/description
+            # to their bound-or-literal STRING values, same as image's own
+            # `src` — the OS-derivation (media_type/name/body from a real
+            # file) is a LATER, separate pass
+            # (`artifact_payload.apply_artifact_resolution`) run by a layer
+            # that actually has project_root/agent_name (op_runtime/present.py).
+            for slot in ("source", "content", "media_type", "description"):
+                if slot in node:
+                    val = _render_text_slot(node[slot], doc, out, neut, loc=f"{loc}.{slot}")
+                    if val is not _MISSING:
+                        rendered[slot] = val
         out.nodes.append(rendered)
     return out

--- a/src/reyn/core/present/catalog.py
+++ b/src/reyn/core/present/catalog.py
@@ -6,7 +6,28 @@ not from policy layered on top. A blueprint is data (a component tree), never
 code; the LLM authors *labels + path bindings* only.
 
 Catalog (all read-only): ``text`` / ``markdown`` / ``code`` / ``diff`` /
-``keyvalue`` / ``table`` / ``list`` / ``image``.
+``keyvalue`` / ``table`` / ``list`` / ``image`` / ``artifact``.
+
+``artifact`` (#4482 PR-2b, naming ratified by architect): an LLM-produced
+file the terminal can't render natively (html/office/pdf/binary images),
+which a user opens with the OS's own default app. Structural rules
+(architect's ruling, enforced here so a malformed blueprint is a hard
+rejection, never a guess at render time):
+
+- exactly ONE of ``source`` / ``content`` — never both, never neither.
+  ``source`` points at a real file (a literal path or a ``$bind``
+  pointer); ``content`` is text the agent hands over directly (no real
+  file exists).
+- ``media_type`` is allowed ONLY alongside ``content``, and REQUIRED
+  there — declaring it alongside ``source`` is rejected (the OS derives
+  ``media_type`` from the real file in that case, see
+  ``artifact_payload.py``, and an agent-declared value there could
+  disagree with it); omitting it alongside ``content`` is also rejected
+  (with no real file, there is nothing for the OS to derive it from).
+- ``description`` is always optional.
+- ``name`` is deliberately NOT a slot — for ``source`` the OS fills it
+  (the file's own basename); for ``content`` there is no real-file
+  identity to name at all.
 
 Bindings are expressed structurally as ``{"$bind": "<json-pointer>"}`` — a
 single-key object whose value is an RFC 6901 JSON Pointer **string**. This makes
@@ -36,6 +57,7 @@ CATALOG: dict[str, frozenset[str]] = {
     "table":    frozenset({"rows", "columns"}),
     "list":     frozenset({"items", "item_path"}),
     "image":    frozenset({"src", "alt"}),
+    "artifact": frozenset({"source", "content", "media_type", "description"}),
 }
 
 # The text-family components — a whole-body (plain-text ref) binding may only bind
@@ -142,7 +164,38 @@ def _validate_node(node: Any, *, path: str) -> dict:
     elif component == "image":
         if "src" in normalized:
             _validate_slot_value(normalized["src"], where=f"{path}.src")
+    elif component == "artifact":
+        _validate_artifact_slots(normalized, path=path)
     return normalized
+
+
+def _validate_artifact_slots(normalized: dict, *, path: str) -> None:
+    """#4482 PR-2b — the artifact component's own structural rules
+    (architect's ruling): exactly one of source/content, media_type only
+    alongside content. See the module docstring's ``artifact`` section
+    for the full rationale."""
+    has_source = "source" in normalized
+    has_content = "content" in normalized
+    if has_source == has_content:
+        raise PresentBlueprintError(
+            f"{path}: artifact needs EXACTLY ONE of 'source' or 'content' "
+            f"(got {'both' if has_source else 'neither'})"
+        )
+    has_media_type = "media_type" in normalized
+    if has_media_type and has_source:
+        raise PresentBlueprintError(
+            f"{path}.media_type: not allowed alongside 'source' — the OS "
+            "derives media_type from the real file in that case; a "
+            "declared value here could disagree with it"
+        )
+    if has_content and not has_media_type:
+        raise PresentBlueprintError(
+            f"{path}: 'media_type' is required alongside 'content' — with "
+            "no real file, there is nothing for the OS to derive it from"
+        )
+    for slot in ("source", "content", "media_type", "description"):
+        if slot in normalized:
+            _validate_slot_value(normalized[slot], where=f"{path}.{slot}")
 
 
 def _validate_kv_rows(rows: Any, *, path: str) -> list:

--- a/tests/core/test_4482_pr2_artifact_payload.py
+++ b/tests/core/test_4482_pr2_artifact_payload.py
@@ -1,0 +1,168 @@
+"""Tier 2: #4482 PR-2 — present artifact payload construction
+(``build_source_artifact_payload``/``build_inline_artifact_payload``).
+
+Exercises architect's final corrected design directly: media_type is
+best-effort (mimetypes only, never a reyn-specific table), Inline/Reference
+is decided by observation (stat + bounded UTF-8-decode probe, not a
+media_type lookup), and the agent-declared-inline path lets the agent name
+media_type (the one case the OS can't derive it).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.core.present.artifact_payload import (
+    build_inline_artifact_payload,
+    build_source_artifact_payload,
+)
+
+
+def _write(path: Path, content: bytes) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+# ── build_source_artifact_payload ───────────────────────────────────────
+
+
+def test_small_utf8_text_file_is_inlined(tmp_path: Path):
+    """Tier 2: invariant 3 — a small, UTF-8-decodable file inlines its
+    text directly, no ref minted."""
+    target = _write(tmp_path / "notes.txt", "hello, world\n".encode("utf-8"))
+
+    payload = build_source_artifact_payload(tmp_path, "alice", target)
+
+    assert payload["body"] == {"inline": "hello, world\n"}
+    assert payload["name"] == "notes.txt"
+
+
+def test_binary_content_becomes_a_reference(tmp_path: Path):
+    """Tier 2: invariant 3 — content that fails UTF-8 decode is a
+    Reference, regardless of size."""
+    target = _write(tmp_path / "image.png", b"\x89PNG\r\n\x1a\n" + b"\xff\xfe\x00" * 5)
+
+    payload = build_source_artifact_payload(tmp_path, "alice", target)
+
+    assert "ref" in payload["body"]
+    assert payload["body"]["size"] == target.stat().st_size
+
+
+def test_a_file_larger_than_the_probe_limit_is_a_reference_without_reading_it(
+    tmp_path: Path,
+):
+    """Tier 2: invariant 3 — above the probe limit, this function goes
+    straight to Reference without a decode attempt, even for content that
+    WOULD have decoded as UTF-8 if read (proves the stat-first short
+    circuit, not just "big files happen to be binary")."""
+    target = _write(tmp_path / "huge.txt", b"a" * 10)  # valid UTF-8 content
+
+    payload = build_source_artifact_payload(tmp_path, "alice", target, probe_max_bytes=5)
+
+    assert "ref" in payload["body"]
+    assert payload["body"]["size"] == 10
+
+
+def test_media_type_is_derived_via_stdlib_mimetypes_only(tmp_path: Path):
+    """Tier 2: invariant 2 — media_type comes from mimetypes.guess_type,
+    not a reyn-specific table. .html resolves; an unrecognized extension
+    resolves to None (best-effort, not a hard requirement)."""
+    html = _write(tmp_path / "report.html", b"<h1>x</h1>")
+    unknown = _write(tmp_path / "report.pptx", b"PK\x03\x04" + b"\x00" * 20)
+
+    html_payload = build_source_artifact_payload(tmp_path, "alice", html)
+    pptx_payload = build_source_artifact_payload(tmp_path, "alice", unknown)
+
+    assert html_payload["media_type"] == "text/html"
+    # pptx is exactly the format architect measured stdlib mimetypes
+    # resolving to None on a minimal host -- best-effort, not a failure.
+    assert pptx_payload["media_type"] in (None, "application/vnd.openxmlformats-officedocument.presentationml.presentation")
+
+
+def test_missing_source_raises_file_not_found(tmp_path: Path):
+    """Tier 2: a source that doesn't resolve to a real file raises,
+    rather than silently returning a bogus payload."""
+    try:
+        build_source_artifact_payload(tmp_path, "alice", tmp_path / "nope.txt")
+        raise AssertionError("expected FileNotFoundError")
+    except FileNotFoundError:
+        pass
+
+
+def test_description_is_omitted_when_not_given(tmp_path: Path):
+    """Tier 2: (accept-side) description is optional — absent input means
+    an absent key, not a null-valued one."""
+    target = _write(tmp_path / "notes.txt", b"x")
+    payload = build_source_artifact_payload(tmp_path, "alice", target)
+    assert "description" not in payload
+
+
+def test_description_is_carried_through_when_given(tmp_path: Path):
+    """Tier 2: description, when given, passes through unchanged."""
+    target = _write(tmp_path / "notes.txt", b"x")
+    payload = build_source_artifact_payload(
+        tmp_path, "alice", target, description="the quarterly report",
+    )
+    assert payload["description"] == "the quarterly report"
+
+
+def test_reference_body_resolves_via_the_same_ref_table_pr1_built(tmp_path: Path):
+    """Tier 2: (integration) the minted ref genuinely round-trips through
+    artifact_ref.resolve_ref — this function doesn't invent its own,
+    parallel resolution mechanism."""
+    from reyn.data.workspace.artifact_ref import resolve_ref
+
+    target = _write(tmp_path / "image.png", b"\x89PNG" + b"\xff\xfe" * 5)
+    payload = build_source_artifact_payload(tmp_path, "alice", target)
+
+    resolved = resolve_ref(tmp_path, "alice", payload["body"]["ref"])
+    assert resolved == target.resolve()
+
+
+def test_no_path_string_appears_anywhere_in_the_payload(tmp_path: Path):
+    """Tier 2: invariant 1, falsified directly — neither the raw nor the
+    normalized absolute path string appears anywhere in the payload
+    (name is a basename, body is inline text or an opaque ref)."""
+    target = _write(tmp_path / "sub" / "report.pptx", b"PK\x03\x04binary\xff\xfe")
+    payload = build_source_artifact_payload(tmp_path, "alice", target)
+
+    serialized = repr(payload)
+    assert str(target.resolve()) not in serialized
+    assert str(target) not in serialized
+
+
+# ── build_inline_artifact_payload ───────────────────────────────────────
+
+
+def test_inline_payload_carries_the_agent_declared_media_type():
+    """Tier 2: slot ②'s carve-out — with no real file, the agent names
+    media_type itself."""
+    payload = build_inline_artifact_payload("text/csv", "a,b,c\n1,2,3\n")
+    assert payload["media_type"] == "text/csv"
+    assert payload["body"] == {"inline": "a,b,c\n1,2,3\n"}
+
+
+def test_inline_payload_has_no_name_slot():
+    """Tier 2: invariant — inline content has no real-file identity, so
+    there is no name slot to fill (nothing is ever opened for this
+    form)."""
+    payload = build_inline_artifact_payload("text/plain", "hello")
+    assert "name" not in payload
+
+
+def test_inline_payload_has_no_size_cap():
+    """Tier 2: invariant 4 — no reyn-side byte cap on agent-declared
+    inline content, however large; the model's own output-token ceiling
+    is the only bound."""
+    huge = "x" * 2_000_000
+    payload = build_inline_artifact_payload("text/plain", huge)
+    assert payload["body"]["inline"] == huge
+
+
+def test_inline_payload_description_is_optional():
+    """Tier 2: (accept-side) same optional-description contract as the
+    source-backed form."""
+    payload = build_inline_artifact_payload("text/plain", "x")
+    assert "description" not in payload
+    payload_with = build_inline_artifact_payload("text/plain", "x", description="a note")
+    assert payload_with["description"] == "a note"


### PR DESCRIPTION
**[e2e-coder]** — WIP/draft, pushed at a clean point per owner-directed pause (broker restart). Do not merge yet.

## Status
Implemented, existing regression suites green (153 tests: `test_present_op_fp0054_pra.py`, `test_present_renderer_fp0054_prb.py`, `test_present_default_viewer_nested_3630.py`, `test_4482_pr2_artifact_payload.py`, plus 12 more present-adjacent files), but **no dedicated tests for this PR's own new code yet**:

- `catalog.py` — `"artifact"` component + structural rules (exactly one of source/content; media_type required alongside content, forbidden alongside source) — architect's ratified naming and rules, verbatim.
- `binding.py` — `resolve_bindings`'s new `"artifact"` branch resolves source/content/media_type/description as bind-or-literal strings only (same idiom as `image`'s own `src`) — stays pure/I/O-free (lead-coder's ruling: `replay.py`'s re-render must not depend on live disk state).
- `artifact_payload.py` — `apply_artifact_resolution(nodes, project_root, agent_name)`, the post-processing pass (deliberately NOT inside `resolve_bindings`) that turns a resolved `"artifact"` node into the final OS-derived payload via PR-2's (#4505) `build_source_artifact_payload`/`build_inline_artifact_payload`. `FileNotFoundError` → explicit `{"error": "source_not_found"}` marker (not a propagated exception, matching `artifact_ref.resolve_ref`'s own shape). A soft binding-miss → bare `{"component": "artifact"}` (present's existing soft-skip philosophy).
- `op_runtime/present.py` — `handle()` calls `apply_artifact_resolution` on `rendered.nodes` using `ctx.workspace.base_dir`/`ctx.actor`, right before handing the render model to the surface renderer.

## Next step (resuming after the pause)
Write dedicated tests for: catalog structural-rule rejections (both/neither source+content, media_type+source, missing media_type+content), the binding.py artifact branch's bind-vs-literal resolution + soft-miss, `apply_artifact_resolution`'s own behavior (source→Reference/Inline via PR-2, content→inline, FileNotFoundError→error marker, non-artifact passthrough), and an end-to-end `handle()` test exercising a real artifact node through the full op. Then the usual local-gate sweep (ruff/tier-audit/docstring-verify/mypy_ratchet/path-literal) before marking ready for review.

part of #4482