### PR TITLE
docs(#4489): add reference/cli/support-bundle.md, 5th and final of the real gap

### DIFF
--- a/.mkdocs/mkdocs.yml
+++ b/.mkdocs/mkdocs.yml
@@ -151,6 +151,7 @@ nav:
               - reference/cli/memory.md
               - reference/cli/cron.md
               - reference/cli/storage.md
+              - reference/cli/support-bundle.md
               - reference/cli/common-flags.md
       - Runtime:
           - reference/runtime/control-ir.md

--- a/docs/reference/cli/support-bundle.md
+++ b/docs/reference/cli/support-bundle.md
@@ -1,0 +1,70 @@
+---
+type: reference
+topic: cli
+audience: [human, agent]
+applies_to: [reyn support-bundle]
+---
+
+# `reyn support-bundle`
+
+Assemble a **redacted** diagnostic bundle (#1833) — a single zip an operator can
+hand to support without leaking secrets. Collects the three observability
+artifacts reyn already writes (LLM payload trace, WAL, event logs), filters by
+session/time window, redacts every line through the existing secret-redaction
+layer, and packs the result plus a secrets-free `meta.json`. No new redaction
+logic and no provider calls — this command is the missing *assembly* +
+*redaction-at-the-exit*, not a new diagnostic mechanism.
+
+## Synopsis
+
+```
+reyn support-bundle [--session <id>] [--since <iso|Nd|Nh|Nm>] [-o <path>]
+```
+
+## Flags
+
+| Flag | Notes |
+|---|---|
+| `--session ID` | Only include records whose `session`/`session_id`/`run_id`/`agent_id`/`agent`/`chain_id` field matches. Best-effort: a record with none of those fields is still included (favors completeness for diagnostics — redaction handles safety regardless of what's included). |
+| `--since ISO\|Nd\|Nh\|Nm` | Only include records at/after this time. Accepts ISO-8601 or a relative window (`7d`, `12h`, `30m`). An overflowing relative window (e.g. absurdly large `Nd`) exits with a clear error rather than an uncaught traceback. |
+| `-o, --output PATH` | Output zip path. Default `support-bundle.zip`. |
+
+```bash
+reyn support-bundle
+reyn support-bundle --session abc123 --since 7d -o incident.zip
+```
+
+## What goes in the bundle
+
+Three artifact classes, collected distinctly (#1833):
+
+- **`trace/`** — the LLM payload trace, if `$REYN_LLM_TRACE_DUMP` is set and points
+  at a real file.
+- **`wal/`** — the WAL / crash-recovery log, `.reyn/state/**/*.jsonl` (the StateLog,
+  PR21). Lives under `state/`, not `events/` — collected separately so the bundle
+  stays complete.
+- **`events/`** — the P6 audit logs, `.reyn/events/**/*.jsonl`.
+
+Plus a top-level `meta.json`: reyn's own version, generation timestamp, the
+`--session`/`--since` filters applied, a redacted config summary (model, configured
+model classes, whether `api_base` is set — never the value), a per-file manifest
+(arcname + line count), and an explicit note on how redaction was applied.
+
+A run that finds nothing (`REYN_LLM_TRACE_DUMP` unset, no `.reyn/events/`) still
+writes a valid (empty-manifest) zip and prints a note explaining why.
+
+## Redaction
+
+Every collected line — trace, WAL, and event log alike — is run through the
+**existing** `reyn.llm.llm._redact_secrets` layer before it's written into the zip:
+a parseable JSON object is redacted recursively; a non-JSON or non-object line is
+wrapped and redacted the same way. Redaction is **default ON**; the only way to
+disable it is `REYN_LLM_TRACE_REDACT=off` — do not share a bundle generated with
+redaction off.
+
+## Related
+
+- [`reyn events`](events.md) — inspect/purge the same `.reyn/events/` audit logs
+  this command bundles (unfiltered, unredacted — for local inspection, not sharing)
+- [`reyn audit`](audit.md) — a different diagnostic surface (a static safety scan,
+  not an artifact bundle)

--- a/docs/reference/cli/support-bundle.md
+++ b/docs/reference/cli/support-bundle.md
@@ -8,11 +8,12 @@ applies_to: [reyn support-bundle]
 # `reyn support-bundle`
 
 Assemble a **redacted** diagnostic bundle (#1833) — a single zip an operator can
-hand to support without leaking secrets. Collects the three observability
-artifacts reyn already writes (LLM payload trace, WAL, event logs), filters by
-session/time window, redacts every line through the existing secret-redaction
-layer, and packs the result plus a secrets-free `meta.json`. No new redaction
-logic and no provider calls — this command is the missing *assembly* +
+hand to support with **known** secret patterns masked. Collects the three
+observability artifacts reyn already writes (LLM payload trace, WAL, event logs),
+filters by session/time window, redacts every line through the existing
+secret-redaction layer, and packs the result plus a `meta.json` (itself passed
+through the same redaction). No new redaction logic and no provider calls — this
+command is the missing *assembly* +
 *redaction-at-the-exit*, not a new diagnostic mechanism.
 
 ## Synopsis
@@ -25,7 +26,7 @@ reyn support-bundle [--session <id>] [--since <iso|Nd|Nh|Nm>] [-o <path>]
 
 | Flag | Notes |
 |---|---|
-| `--session ID` | Only include records whose `session`/`session_id`/`run_id`/`agent_id`/`agent`/`chain_id` field matches. Best-effort: a record with none of those fields is still included (favors completeness for diagnostics — redaction handles safety regardless of what's included). |
+| `--session ID` | Only include records whose `session`/`session_id`/`run_id`/`agent_id`/`agent`/`chain_id` field matches. Best-effort: a record with none of those fields is still included (favors completeness for diagnostics — filtering scopes the bundle, it is not the safety mechanism; see [Redaction](#redaction) for what actually masks secrets, and its limits). |
 | `--since ISO\|Nd\|Nh\|Nm` | Only include records at/after this time. Accepts ISO-8601 or a relative window (`7d`, `12h`, `30m`). An overflowing relative window (e.g. absurdly large `Nd`) exits with a clear error rather than an uncaught traceback. |
 | `-o, --output PATH` | Output zip path. Default `support-bundle.zip`. |
 
@@ -58,9 +59,22 @@ writes a valid (empty-manifest) zip and prints a note explaining why.
 Every collected line — trace, WAL, and event log alike — is run through the
 **existing** `reyn.llm.llm._redact_secrets` layer before it's written into the zip:
 a parseable JSON object is redacted recursively; a non-JSON or non-object line is
-wrapped and redacted the same way. Redaction is **default ON**; the only way to
-disable it is `REYN_LLM_TRACE_REDACT=off` — do not share a bundle generated with
-redaction off.
+wrapped and redacted the same way.
+
+**This masks known patterns, not every secret.** The default pattern set
+(`_DEFAULT_REDACT_PATTERNS`) matches exactly 4 shapes: an OpenAI-style `sk-` key, a
+Slack `xoxb-` token, an `Authorization: Bearer` token, and a PEM private key block.
+A secret that doesn't match one of those shapes — an internal auth token, a DB
+connection string, a password, a credential embedded in a URL — is **not** masked.
+Extend the set for your own environment via `REYN_LLM_TRACE_REDACT_PATTERNS`
+(comma-separated regexes).
+
+**Redaction is default ON, but a global switch turns it off entirely**:
+`REYN_LLM_TRACE_REDACT=off` disables `_redact_secrets` completely — every line goes
+into the bundle unmasked, not just the 4 known patterns. This is a real footgun: if
+`off` is set for trace debugging and left set, the next `support-bundle` run bundles
+everything raw with no warning. Check `REYN_LLM_TRACE_REDACT` is unset (or not
+`off`) before sharing a bundle.
 
 ## Related
 


### PR DESCRIPTION
**[docs-maintainer]** — 5th and final content page for #4489 (the real gap turned out to be 5, not 6 — see the correction below).

## What this adds

`docs/reference/cli/support-bundle.md` — covers `reyn support-bundle`'s `--session`/`--since`/`-o` flags, the 3 artifact classes collected (LLM trace, WAL, event logs), the `meta.json` manifest, and the redaction contract (existing `_redact_secrets` layer, default ON).

## Correction, mid-arc

While starting `run_once.md` (originally counted as one of the "6 missing pages"), I found `docs/reference/cli/run-once.md` **already existed**, complete and accurate, under the command's actual hyphenated name — I had only checked by Python module filename (`run_once.py`), not by the real CLI command name (`reyn run-once`). The gap was genuinely 5 pages, not 6. Caught and reported before committing anything wrong (no bad commit ever entered history). Verified this page (`support-bundle.md`) has no pre-existing hyphenated counterpart before writing it — same check, applied correctly this time.

## Verification

- Read `support_bundle.py`'s full source (`_collect_files`, `_redacted_jsonl`, `_meta`, `run()`), not summarized from the module docstring alone.
- Both linked pages (`events.md`, `audit.md`) confirmed to exist before linking.
- `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean, no Aborted line.
- `ruff check src tests` — clean.

part of #4489

## Test plan

- [x] `mkdocs build --strict` — clean, no Aborted line (read directly)
- [x] `ruff check src tests` — clean
- [x] Verified content against `support_bundle.py` source directly
- [x] Confirmed both linked pages exist
- [x] Confirmed no pre-existing hyphenated counterpart page for this command (the exact mistake caught on `run-once.md`)
- [x] (skipped — docs-only page, no runtime behavior change, no test to run)


---

- [x] 🔴 **[lead-coder]** doc が実装より強い保証をしている。①「既知のパターン（sk- / xoxb- / Bearer / PEM 鍵）をマスクする。**網羅ではない**」②「**`REYN_LLM_TRACE_REDACT=off` が立っているとマスクされない**」の 2 行を追記。`_redact_secrets` は "Mask **known** sensitive patterns" であって秘密の除去ではなく、「without leaking secrets」は operator に安全性を誤認させる。
  ✅ 対応済み（commit `24251b7b4`）: top-of-page claim を「known secret patterns masked」に弱め、Redaction節に①既知4パターンのみ（網羅ではない、`REYN_LLM_TRACE_REDACT_PATTERNS`で拡張可）②`REYN_LLM_TRACE_REDACT=off`で全ラインが無マスクで入る、を明記。`--session`フラグ説明の同種の言い過ぎも合わせて修正。

