### PR TITLE
feat(#4482 PR-2b): artifact component wiring — catalog + binding + handle()

### DIFF
--- a/src/reyn/core/op_runtime/present.py
+++ b/src/reyn/core/op_runtime/present.py
@@ -218,6 +218,21 @@ async def handle(op: PresentIROp, ctx: OpContext) -> dict:
         fallback_stage=fallback_stage,
     )
 
+    # 3.5. #4482 PR-2b: resolve any "artifact" node's raw source/content
+    #    strings (resolve_bindings only bound them — it stays pure/I/O-free,
+    #    see binding.py's own "artifact" branch comment) into the final
+    #    OS-derived payload. This is the layer that legitimately has
+    #    project_root (ctx.workspace.base_dir) / agent_name (ctx.actor) —
+    #    lead-coder's ruling on where this step belongs, not inside
+    #    resolve_bindings or _resolve_presentation. Rewrites rendered.nodes
+    #    only — the audit event above already carries refs + stats, never
+    #    node content, so ordering relative to it does not matter; placed
+    #    here because THIS is the only thing that needs it.
+    from reyn.core.present.artifact_payload import apply_artifact_resolution
+    rendered.nodes = apply_artifact_resolution(
+        rendered.nodes, ctx.workspace.base_dir, ctx.actor,
+    )
+
     # 4. Hand the actually-rendered model to the wired surface (PR-B). Fire-and-
     #    continue: the op's ack (below) is already fully derived from the stats,
     #    not from anything the renderer does — a renderer failure must never be

--- a/src/reyn/core/present/artifact_payload.py
+++ b/src/reyn/core/present/artifact_payload.py
@@ -2,20 +2,17 @@
 LLM-produced file the terminal can't render natively (html/office/pdf/
 images), which a user opens with the OS's own default app.
 
-★ Isolation note (temporary, deliberate — not an oversight): as of this
-PR, nothing in ``core/present/catalog.py`` or ``core/present/binding.py``
-calls this module yet. The "artifact" component/slot naming (architect's
-#4482 ruling: ``component="artifact"``; agent-writable slots ``source`` /
-``content`` / ``media_type`` / ``description``, with ``name`` NOT a slot)
-was decided in a follow-up comment landing alongside this PR's merge, and
-the actual catalog-gate + binding-resolution wiring is PR-2b, a separate
-PR — not silently deferred, named here so this module's "no caller yet"
-state reads as a known, temporary staging point rather than the
-"declared/implemented/tested/invoked-by-nobody" shape this session has
-flagged repeatedly elsewhere tonight.
-
-**① server/client payload shape** (architect's final corrected form, #4482
-issue thread)::
+PR-2b wires this module in: ``catalog.py``'s ``CATALOG`` gates the
+``"artifact"`` component's own structural rules (exactly one of
+source/content; media_type required alongside content, forbidden
+alongside source), ``binding.py``'s ``resolve_bindings`` resolves an
+``artifact`` node's raw slot values (bind-or-literal, same as ``image``'s
+own ``src``) WITHOUT touching disk (stays pure — see that function's own
+"artifact" branch comment for why), and :func:`apply_artifact_resolution`
+below is the separate post-processing pass — run by
+``op_runtime/present.py``'s ``handle()``, the layer that actually has
+``project_root``/``agent_name`` — that turns those raw values into the
+final OS-derived payload this module's other two functions build.
 
 **① server/client payload shape** (architect's final corrected form, #4482
 issue thread)::
@@ -158,3 +155,58 @@ def build_inline_artifact_payload(
     if description is not None:
         payload["description"] = description
     return payload
+
+
+def apply_artifact_resolution(
+    nodes: "list[dict]", project_root: Path, agent_name: str,
+) -> "list[dict]":
+    """#4482 PR-2b: the post-processing pass that turns a
+    ``resolve_bindings``-produced ``"artifact"`` node's raw
+    source/content/media_type/description STRINGS into the final
+    OS-derived payload (:func:`build_source_artifact_payload` /
+    :func:`build_inline_artifact_payload`).
+
+    Deliberately NOT part of ``resolve_bindings`` itself — see that
+    function's own "artifact" branch comment for why (lead-coder's
+    ruling: ``replay.py``'s re-render must stay disk-state-independent,
+    so this pass only runs in a layer that legitimately HAS
+    ``project_root``/``agent_name`` — ``op_runtime/present.py``'s
+    ``handle()``, not the pure binding-resolution layer).
+
+    Every non-``"artifact"`` node passes through completely unchanged.
+    An ``"artifact"`` node missing what it needs (both ``source`` AND
+    ``content`` soft-missed at binding time, or ``content`` resolved but
+    ``media_type`` didn't) is left as a bare ``{"component": "artifact"}``
+    — present's own soft-skip philosophy, never a hard failure from a
+    binding miss. A ``source`` file that has vanished since the agent
+    referenced it (:func:`build_source_artifact_payload` raising
+    ``FileNotFoundError``) becomes an explicit ``error`` marker rather
+    than propagating an exception through op execution — the same shape
+    :func:`reyn.data.workspace.artifact_ref.resolve_ref` already
+    established for a GC'd/deleted target (missing is unresolvable, not
+    a crash).
+    """
+    out: "list[dict]" = []
+    for node in nodes:
+        if node.get("component") != "artifact":
+            out.append(node)
+            continue
+        description = node.get("description")
+        if "source" in node:
+            try:
+                payload = build_source_artifact_payload(
+                    project_root, agent_name, node["source"], description=description,
+                )
+            except FileNotFoundError:
+                out.append({"component": "artifact", "error": "source_not_found"})
+                continue
+        elif "content" in node and "media_type" in node:
+            payload = build_inline_artifact_payload(
+                node["media_type"], node["content"], description=description,
+            )
+        else:
+            out.append({"component": "artifact"})
+            continue
+        payload["component"] = "artifact"
+        out.append(payload)
+    return out

--- a/src/reyn/core/present/binding.py
+++ b/src/reyn/core/present/binding.py
@@ -376,5 +376,20 @@ def resolve_bindings(
                     rendered["src"] = val
             if "alt" in node:
                 rendered["alt"] = _guard_maybe(node["alt"], neut, out, path=f"{loc}.alt")
+        elif component == "artifact":
+            # #4482 PR-2b: resolve_bindings stays pure/I/O-free (lead-coder's
+            # ruling — replay.py's own re-render must not start depending on
+            # "the disk's state at replay time", only on the P6 event's own
+            # data). This only resolves source/content/media_type/description
+            # to their bound-or-literal STRING values, same as image's own
+            # `src` — the OS-derivation (media_type/name/body from a real
+            # file) is a LATER, separate pass
+            # (`artifact_payload.apply_artifact_resolution`) run by a layer
+            # that actually has project_root/agent_name (op_runtime/present.py).
+            for slot in ("source", "content", "media_type", "description"):
+                if slot in node:
+                    val = _render_text_slot(node[slot], doc, out, neut, loc=f"{loc}.{slot}")
+                    if val is not _MISSING:
+                        rendered[slot] = val
         out.nodes.append(rendered)
     return out

--- a/src/reyn/core/present/catalog.py
+++ b/src/reyn/core/present/catalog.py
@@ -6,7 +6,28 @@ not from policy layered on top. A blueprint is data (a component tree), never
 code; the LLM authors *labels + path bindings* only.
 
 Catalog (all read-only): ``text`` / ``markdown`` / ``code`` / ``diff`` /
-``keyvalue`` / ``table`` / ``list`` / ``image``.
+``keyvalue`` / ``table`` / ``list`` / ``image`` / ``artifact``.
+
+``artifact`` (#4482 PR-2b, naming ratified by architect): an LLM-produced
+file the terminal can't render natively (html/office/pdf/binary images),
+which a user opens with the OS's own default app. Structural rules
+(architect's ruling, enforced here so a malformed blueprint is a hard
+rejection, never a guess at render time):
+
+- exactly ONE of ``source`` / ``content`` — never both, never neither.
+  ``source`` points at a real file (a literal path or a ``$bind``
+  pointer); ``content`` is text the agent hands over directly (no real
+  file exists).
+- ``media_type`` is allowed ONLY alongside ``content``, and REQUIRED
+  there — declaring it alongside ``source`` is rejected (the OS derives
+  ``media_type`` from the real file in that case, see
+  ``artifact_payload.py``, and an agent-declared value there could
+  disagree with it); omitting it alongside ``content`` is also rejected
+  (with no real file, there is nothing for the OS to derive it from).
+- ``description`` is always optional.
+- ``name`` is deliberately NOT a slot — for ``source`` the OS fills it
+  (the file's own basename); for ``content`` there is no real-file
+  identity to name at all.
 
 Bindings are expressed structurally as ``{"$bind": "<json-pointer>"}`` — a
 single-key object whose value is an RFC 6901 JSON Pointer **string**. This makes
@@ -36,6 +57,7 @@ CATALOG: dict[str, frozenset[str]] = {
     "table":    frozenset({"rows", "columns"}),
     "list":     frozenset({"items", "item_path"}),
     "image":    frozenset({"src", "alt"}),
+    "artifact": frozenset({"source", "content", "media_type", "description"}),
 }
 
 # The text-family components — a whole-body (plain-text ref) binding may only bind
@@ -142,7 +164,38 @@ def _validate_node(node: Any, *, path: str) -> dict:
     elif component == "image":
         if "src" in normalized:
             _validate_slot_value(normalized["src"], where=f"{path}.src")
+    elif component == "artifact":
+        _validate_artifact_slots(normalized, path=path)
     return normalized
+
+
+def _validate_artifact_slots(normalized: dict, *, path: str) -> None:
+    """#4482 PR-2b — the artifact component's own structural rules
+    (architect's ruling): exactly one of source/content, media_type only
+    alongside content. See the module docstring's ``artifact`` section
+    for the full rationale."""
+    has_source = "source" in normalized
+    has_content = "content" in normalized
+    if has_source == has_content:
+        raise PresentBlueprintError(
+            f"{path}: artifact needs EXACTLY ONE of 'source' or 'content' "
+            f"(got {'both' if has_source else 'neither'})"
+        )
+    has_media_type = "media_type" in normalized
+    if has_media_type and has_source:
+        raise PresentBlueprintError(
+            f"{path}.media_type: not allowed alongside 'source' — the OS "
+            "derives media_type from the real file in that case; a "
+            "declared value here could disagree with it"
+        )
+    if has_content and not has_media_type:
+        raise PresentBlueprintError(
+            f"{path}: 'media_type' is required alongside 'content' — with "
+            "no real file, there is nothing for the OS to derive it from"
+        )
+    for slot in ("source", "content", "media_type", "description"):
+        if slot in normalized:
+            _validate_slot_value(normalized[slot], where=f"{path}.{slot}")
 
 
 def _validate_kv_rows(rows: Any, *, path: str) -> list:

--- a/tests/core/test_4482_pr2b_artifact_wiring.py
+++ b/tests/core/test_4482_pr2b_artifact_wiring.py
@@ -1,0 +1,274 @@
+"""Tier 1/2: #4482 PR-2b — the "artifact" present component's wiring:
+catalog.py's structural gate, binding.py's pure resolution branch,
+artifact_payload.apply_artifact_resolution's post-processing pass, and
+op_runtime/present.py's handle() end-to-end.
+
+Real Workspace + PermissionResolver + EventLog throughout (matches
+test_present_op_fp0054_pra.py's own established policy) — no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.present import handle
+from reyn.core.present import PresentBlueprintError, resolve_bindings, validate_blueprint
+from reyn.core.present.artifact_payload import apply_artifact_resolution
+from reyn.data.workspace.artifact_ref import resolve_ref
+from reyn.data.workspace.workspace import Workspace
+from reyn.schemas.models import PresentIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+
+
+def _resolver(tmp_path: Path) -> PermissionResolver:
+    return PermissionResolver(config_permissions={}, project_root=tmp_path, interactive=False)
+
+
+def _ctx(tmp_path: Path) -> "tuple[OpContext, EventLog]":
+    events = EventLog()
+    resolver = _resolver(tmp_path)
+    ws = Workspace(events=events, permission_resolver=resolver, base_dir=tmp_path)
+    ctx = OpContext(
+        workspace=ws, events=events, permission_decl=PermissionDecl(),
+        permission_resolver=resolver, actor="alice", intervention_bus=None,
+    )
+    return ctx, events
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── catalog.py: structural gate ──────────────────────────────────────────
+
+
+def test_source_alone_is_valid():
+    """Tier 1: accept-side — source + description, no media_type."""
+    nodes = validate_blueprint(
+        {"component": "artifact", "source": "report.pptx", "description": "the report"},
+    )
+    assert nodes[0]["source"] == "report.pptx"
+
+
+def test_content_with_media_type_is_valid():
+    """Tier 1: accept-side — content + media_type together."""
+    nodes = validate_blueprint(
+        {"component": "artifact", "content": "a,b\n1,2\n", "media_type": "text/csv"},
+    )
+    assert nodes[0]["content"] == "a,b\n1,2\n"
+    assert nodes[0]["media_type"] == "text/csv"
+
+
+def test_both_source_and_content_is_rejected():
+    """Tier 1: exactly one of source/content — both is a hard rejection."""
+    with pytest.raises(PresentBlueprintError):
+        validate_blueprint({"component": "artifact", "source": "x", "content": "y"})
+
+
+def test_neither_source_nor_content_is_rejected():
+    """Tier 1: exactly one of source/content — neither is a hard rejection."""
+    with pytest.raises(PresentBlueprintError):
+        validate_blueprint({"component": "artifact", "description": "no target"})
+
+
+def test_media_type_alongside_source_is_rejected():
+    """Tier 1: media_type is forbidden alongside source — the OS derives it
+    from the real file in that case."""
+    with pytest.raises(PresentBlueprintError):
+        validate_blueprint(
+            {"component": "artifact", "source": "x", "media_type": "text/csv"},
+        )
+
+
+def test_content_without_media_type_is_rejected():
+    """Tier 1: media_type is REQUIRED alongside content — with no real
+    file, there is nothing for the OS to derive it from."""
+    with pytest.raises(PresentBlueprintError):
+        validate_blueprint({"component": "artifact", "content": "just text"})
+
+
+def test_name_is_not_an_accepted_slot():
+    """Tier 1: name is deliberately not a slot — the OS fills it, the
+    agent cannot write it."""
+    with pytest.raises(PresentBlueprintError):
+        validate_blueprint(
+            {"component": "artifact", "source": "x", "name": "sneaky.txt"},
+        )
+
+
+# ── binding.py: pure resolution ──────────────────────────────────────────
+
+
+def test_resolve_bindings_resolves_a_literal_source():
+    """Tier 1: a literal source string passes through resolve_bindings
+    unchanged (same as image's own src literal path)."""
+    nodes = validate_blueprint({"component": "artifact", "source": "report.pptx"})
+    out = resolve_bindings(nodes, {})
+    assert out.nodes[0]["source"] == "report.pptx"
+
+
+def test_resolve_bindings_resolves_a_bound_source():
+    """Tier 1: a $bind source resolves against the doc, same as any other
+    text-family slot."""
+    nodes = validate_blueprint({"component": "artifact", "source": {"$bind": "/path"}})
+    out = resolve_bindings(nodes, {"path": "output/report.pptx"})
+    assert out.nodes[0]["source"] == "output/report.pptx"
+    assert out.bindings_resolved == 1
+
+
+def test_resolve_bindings_soft_misses_an_unresolvable_source_binding():
+    """Tier 1: a source binding that misses is soft-skipped (present's
+    universal miss semantics) — the resolved node simply lacks 'source',
+    not a hard failure."""
+    nodes = validate_blueprint({"component": "artifact", "source": {"$bind": "/absent"}})
+    out = resolve_bindings(nodes, {})
+    assert "source" not in out.nodes[0]
+    assert out.bindings_dropped
+
+
+def test_resolve_bindings_resolves_content_and_media_type():
+    """Tier 1: content + media_type both resolve as literal text-family
+    slots."""
+    nodes = validate_blueprint(
+        {"component": "artifact", "content": "a,b\n1,2\n", "media_type": "text/csv"},
+    )
+    out = resolve_bindings(nodes, {})
+    assert out.nodes[0]["content"] == "a,b\n1,2\n"
+    assert out.nodes[0]["media_type"] == "text/csv"
+
+
+def test_resolve_bindings_never_touches_disk(tmp_path: Path):
+    """Tier 2: resolve_bindings stays pure/I/O-free for the artifact
+    branch — a source pointing at a path that does not exist on disk
+    still resolves to that STRING without raising (no filesystem access
+    happens here; only apply_artifact_resolution touches disk)."""
+    nodes = validate_blueprint(
+        {"component": "artifact", "source": str(tmp_path / "does-not-exist.txt")},
+    )
+    out = resolve_bindings(nodes, {})
+    assert out.nodes[0]["source"] == str(tmp_path / "does-not-exist.txt")
+
+
+# ── artifact_payload.apply_artifact_resolution ──────────────────────────
+
+
+def test_apply_resolution_builds_a_reference_for_a_binary_source(tmp_path: Path):
+    """Tier 2: a resolved 'source' node becomes the real OS-derived
+    payload (PR-2's build_source_artifact_payload) — binary content
+    becomes a Reference whose ref round-trips through PR-1's resolve_ref."""
+    target = tmp_path / "image.png"
+    target.write_bytes(b"\x89PNG" + b"\xff\xfe" * 5)
+    nodes = [{"component": "artifact", "source": str(target)}]
+
+    out = apply_artifact_resolution(nodes, tmp_path, "alice")
+
+    assert out[0]["component"] == "artifact"
+    assert out[0]["name"] == "image.png"
+    ref = out[0]["body"]["ref"]
+    assert resolve_ref(tmp_path, "alice", ref) == target.resolve()
+
+
+def test_apply_resolution_builds_inline_for_content(tmp_path: Path):
+    """Tier 2: a resolved 'content'+'media_type' node becomes an inline
+    payload (PR-2's build_inline_artifact_payload) — no ref minted, no
+    disk touched."""
+    nodes = [{"component": "artifact", "content": "a,b\n1,2\n", "media_type": "text/csv"}]
+
+    out = apply_artifact_resolution(nodes, tmp_path, "alice")
+
+    assert out[0]["body"] == {"inline": "a,b\n1,2\n"}
+    assert out[0]["media_type"] == "text/csv"
+    assert "name" not in out[0]
+
+
+def test_apply_resolution_marks_a_missing_source_as_an_error_not_a_crash(tmp_path: Path):
+    """Tier 2: a source pointing at a file that doesn't exist becomes an
+    explicit error marker, never a propagated exception through op
+    execution — matches artifact_ref.resolve_ref's own missing-is-
+    unresolvable shape."""
+    nodes = [{"component": "artifact", "source": str(tmp_path / "gone.txt")}]
+
+    out = apply_artifact_resolution(nodes, tmp_path, "alice")
+
+    assert out[0] == {"component": "artifact", "error": "source_not_found"}
+
+
+def test_apply_resolution_passes_through_a_soft_missed_artifact_node(tmp_path: Path):
+    """Tier 2: an artifact node with neither source nor content resolved
+    (both bindings soft-missed upstream) is left as a bare marker, not
+    an error and not a crash."""
+    nodes = [{"component": "artifact"}]
+    out = apply_artifact_resolution(nodes, tmp_path, "alice")
+    assert out == [{"component": "artifact"}]
+
+
+def test_apply_resolution_leaves_non_artifact_nodes_completely_unchanged(tmp_path: Path):
+    """Tier 2: (accept-side) a text/image/table node passes through
+    apply_artifact_resolution byte-for-byte — this pass only touches
+    'artifact' nodes."""
+    nodes = [
+        {"component": "text", "text": "hello"},
+        {"component": "image", "src": "a.png", "alt": "x"},
+    ]
+    out = apply_artifact_resolution(nodes, tmp_path, "alice")
+    assert out == nodes
+
+
+# ── op_runtime/present.py: handle() end-to-end ───────────────────────────
+
+
+def test_handle_resolves_a_real_artifact_end_to_end(tmp_path: Path):
+    """Tier 2: the full path — a present op with an artifact blueprint,
+    a real file under the op's own project_root, resolved through
+    handle() into the final OS-derived payload on the rendered node."""
+    target = tmp_path / "report.html"
+    target.write_bytes(b"<h1>hi</h1>")
+    ctx, events = _ctx(tmp_path)
+    op = PresentIROp(
+        kind="present",
+        data_inline={},
+        blueprint={"component": "artifact", "source": str(target)},
+    )
+
+    ack = _run(handle(op, ctx))
+
+    assert ack["status"] == "ok"
+
+
+def test_handle_end_to_end_reaches_the_renderer_with_the_built_payload(tmp_path: Path):
+    """Tier 2: the RENDERED model (not just the ack) carries the final
+    OS-derived artifact payload — confirms the wiring reaches the actual
+    render surface, not just the ack path."""
+    target = tmp_path / "report.html"
+    target.write_bytes(b"<h1>hi</h1>")
+    ctx, events = _ctx(tmp_path)
+
+    class _RecordingRenderer:
+        surface_name = "inline-cui"
+
+        def __init__(self) -> None:
+            self.rendered: list = []
+
+        def render(self, resolved) -> None:
+            self.rendered.append(resolved)
+
+    renderer = _RecordingRenderer()
+    ctx.presentation_renderer = renderer
+
+    op = PresentIROp(
+        kind="present",
+        data_inline={},
+        blueprint={"component": "artifact", "source": str(target)},
+    )
+    _run(handle(op, ctx))
+
+    (resolved,) = renderer.rendered
+    node = resolved.nodes[0]
+    assert node["component"] == "artifact"
+    assert node["media_type"] == "text/html"
+    assert node["name"] == "report.html"
+    assert node["body"] == {"inline": "<h1>hi</h1>"}


### PR DESCRIPTION
**[e2e-coder]** — part of #4482 (PR-2b: artifact component wiring — catalog + binding + handle()). Replaces the closed draft #4507 (same content, rebase conflict resolved by reapplying the net diff onto fresh main; dedicated tests now added).

## What
- `catalog.py` — `"artifact"` component + architect's ratified structural rules: exactly one of `source`/`content` (both/neither rejected); `media_type` required alongside `content`, forbidden alongside `source`; `name` is not a slot at all.
- `binding.py` — `resolve_bindings`'s new `"artifact"` branch resolves `source`/`content`/`media_type`/`description` as bind-or-literal strings only (same idiom as `image`'s own `src`) — **stays pure/I/O-free**, per lead-coder's ruling: `replay.py`'s re-render must not start depending on live disk state, only on the P6 event's own data.
- `artifact_payload.py` — new `apply_artifact_resolution(nodes, project_root, agent_name)`, the post-processing pass (deliberately **not** inside `resolve_bindings`) that turns a resolved `"artifact"` node into the final OS-derived payload via PR-2's (#4505, merged) `build_source_artifact_payload`/`build_inline_artifact_payload`. A missing source becomes an explicit `{"error": "source_not_found"}` marker rather than a propagated exception (matches `artifact_ref.resolve_ref`'s own missing-is-unresolvable shape); a soft binding-miss stays a bare `{"component": "artifact"}` (present's existing soft-skip philosophy).
- `op_runtime/present.py` — `handle()` calls `apply_artifact_resolution` on `rendered.nodes` using `ctx.workspace.base_dir`/`ctx.actor` (the layer that legitimately has project_root/agent_name), right before handing the render model to the surface renderer.

## Test plan
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 0 errors (19 new tests)
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] `python scripts/mypy_ratchet.py` — no new findings (212/215 baselined, unchanged)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/core/test_4482_pr2b_artifact_wiring.py` — 19 passed (catalog structural rules ×7, binding.py resolution ×5, apply_artifact_resolution ×5, end-to-end handle() ×2)
- [x] Full present-op regression sweep (17 files, 172 tests) — green, no breakage
- [x] End-to-end test confirms the RENDERED model (not just the ack) carries the final built payload — `test_handle_end_to_end_reaches_the_renderer_with_the_built_payload`
- [x] (skipped — n/a, no UI surface)

part of #4482
