### PR TITLE
docs(#4354): note what degrades if litellm's Router misbehaves

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -457,6 +457,23 @@ On the Router path, retry count is **config-only**: `num_retries` is taken from
 budget has a single source. (On the direct, non-Router path the per-call
 `max_retries` is unchanged.)
 
+**What degrades if litellm's Router misbehaves** (#4354 follow-up — owner's
+"delegate what litellm already does" ruling means reyn increasingly relies on
+litellm's own retry/fallback/cooldown machinery working correctly, not a
+reason by itself to stop delegating): `num_retries` / `fallbacks` /
+`cooldown_time` / `allowed_fails` / `retry_policy` above are all config reyn
+merely HANDS to `litellm.Router` — reyn keeps no parallel bookkeeping of
+deployment health, cooldown state, or which fallback fired. If the Router's
+own cooldown/fallback logic misbehaves (wrong deployment skipped, a cooldown
+that never clears, a fallback chain that doesn't fire), reyn has no
+independent view to detect or override it — debugging that is inspecting
+litellm's own Router state/logs, not reyn's, since (post-#4347/#4354) reyn no
+longer holds a second copy of per-deployment credential/rotation state to
+cross-check against. This is the same shape #4398's `chars//4` token-count
+fallback names for `token_counter`'s own failure mode: delegating is the
+right call, but the doc should say what the delegation costs when the
+delegated-to system is wrong, not just that delegating is correct.
+
 ### `llm.retry` fields
 
 Controls the **timing** of the Reyn self-retry layer only (semantic-retry


### PR DESCRIPTION
**[e2e-coder]** — Closes #4354.

## Context
The actual removal (`llm.router.credentials` / `api_key_env`) already merged as #4356, before this session. Issue #4354 stayed open for the follow-up lead-coder attached when accepting it: doc the degradation cost of delegating retry/fallback/cooldown to litellm's Router, not just that delegating is the right call.

## What
One paragraph added to `docs/reference/config/reyn-yaml.md`'s `llm.router` section: reyn keeps no parallel bookkeeping of Router deployment health/cooldown/fallback state (post-#4347/#4354) — if litellm's own Router logic misbehaves, there's no reyn-side view to detect or override it; debugging means inspecting litellm's own state, not reyn's.

## Explicitly not touched
The broader "does the same argument apply to `fallbacks`/`cooldown_time`/`num_retries`/`use`" question stays an owner decision per the issue body ("`llm.router` 全体の扱いは owner 判断として残す") — not expanded here.

## Test plan
- [x] `ruff check docs/` — clean (no code touched)
- [x] Read the rendered section in place to confirm the addition fits the existing prose flow
- [x] (skipped — n/a, no UI surface, no code)

Closes #4354
