### PR TITLE
feat(#4496 PR-1): audit_seq + emitter — monotonic per-execution audit sequencing

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -261,7 +261,9 @@ Every event has:
   "timestamp": "2026-04-30T10:00:00.123456+00:00",
   "data": {
     ... // kind-specific payload; may include agent_id / run_id when the
-        // emitting EventLog was configured with them (see below)
+        // emitting EventLog was configured with them (see below), plus
+        // audit_seq / emitter on every event from a session-path EventLog
+        // (see "Audit sequence" below)
   }
 }
 ```
@@ -271,6 +273,56 @@ Every event has:
 Every event emitted from a session whose `agent_id` is configured (in `reyn.yaml`) automatically carries an `agent_id` field in its payload. The default value is `reyn/<hostname>`. This enables RBAC and multi-agent audit trails per SOC2 / ISO 27001 / METI v1.1 requirements.
 
 See [Concepts: multi-agent](../../concepts/multi-agent/multi-agent.md) — "Agent ID propagation" for details.
+
+## Audit sequence (`audit_seq` / `emitter`, all events)
+
+Every event carries `emitter` (a string identifying **one execution** of an
+`EventLog` — not the session's stable identity, a fresh token minted at
+construction time, one per real process run) and, when that EventLog tracks
+sequencing (the default), a monotonically increasing `audit_seq` starting
+at 1.
+
+**`audit_seq` is NOT the WAL's `seq`.** The WAL's `seq` is a recovery
+coordinate (where replay resumes reconstructing in-memory state);
+`audit_seq` is purely an audit-continuity witness — a subscriber uses it to
+detect a DROPPED event (`(emitter, audit_seq)` pairs with a gap in the
+number) without needing in-order delivery. The two are deliberately
+different names for two different concepts (this repo has hit the "same
+name, two meanings" defect class more than once — see CLAUDE.md).
+
+**Monotonic per `emitter`, never across emitters.** Reconstructing global
+ordering across two different emitters (two sessions, or two runs of the
+same session) is not this field's job — that would require cross-process
+coordination at the point of emission, which the audit band deliberately
+does not impose (a synchronization point on the execution path, for
+audit's sake, is the opposite of what the band exists to be). A reader
+groups events by `emitter` first, then checks each group's own
+`audit_seq` run for gaps.
+
+**A new process execution is a new `emitter`, never a resumed count.** If a
+session's `EventLog` reused a stable identity (e.g. the session_id alone)
+across a restart, a fresh process would re-emit `audit_seq` 1..N under the
+SAME emitter a prior process already used — a reader could no longer tell
+"event 5 is missing" from "this is a new run's own event 5". A fresh
+`EventLog` instance is constructed exactly once per real process execution
+and never reloaded across a restart, so minting `emitter` once at
+construction (rather than deriving it from any longer-lived identity)
+gives per-execution uniqueness by construction, with no counter to persist
+or reconcile across a restart.
+
+**Neither field is caller-settable per emit call** (unlike `agent_id`/
+`run_id` above, which follow a caller-wins convention) — `EventLog.emit`
+always overwrites both, even if a caller's own `data` happens to include
+same-named keys. Numbering the events is `emit`'s own job, done in exactly
+one place; letting a caller influence it would open a path to skip or
+forge a number, which would defeat the gap-detection contract 3 exists
+for.
+
+**`.reyn/events/direct/cli/` is out of gap-detection scope.** A one-off CLI
+event (`emit_cli_event`, no active session) carries `emitter: "cli"` but no
+`audit_seq` at all — a single event from a single process invocation is
+not a series a gap can be detected in, so a meaningless `audit_seq: 1`
+every time is omitted rather than emitted.
 
 ## LLM and context
 

--- a/src/reyn/core/events/events.py
+++ b/src/reyn/core/events/events.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextvars
 import logging
+import secrets
 from datetime import date
 from pathlib import Path
 from typing import Callable
@@ -47,6 +48,8 @@ class EventLog:
         *,
         agent_id: str | None = None,
         run_id: str | None = None,
+        emitter: str | None = None,
+        track_audit_seq: bool = True,
     ) -> None:
         # #3868 PR-1: a folded derived state for `present`'s "was this ref
         # already read this session?" question (source.py's compute_ingested),
@@ -74,6 +77,38 @@ class EventLog:
         # TUI) can distinguish events from a parent agent turn versus a
         # sub-agent turn (which inherits the parent's subscriber list).
         self._run_id = run_id
+        # #4496 PR-1 (architect's contract 3): every audit-event carries a
+        # monotonic `audit_seq` per `emitter`, so a subscriber can detect a
+        # gap (a dropped event) without needing delivery-order guarantees —
+        # NOT the WAL's own `seq` (a different concept: WAL seq is the
+        # recovery coordinate; audit_seq is purely an audit-continuity
+        # witness — see events.md and CLAUDE.md's own warning against
+        # reusing that name for a second thing).
+        #
+        # `emitter` identifies ONE execution of a session, not the session
+        # itself (a session_id is stable across restarts — reusing it would
+        # let two different process runs both emit `audit_seq` 1..N under
+        # the same emitter, making a genuine gap indistinguishable from "a
+        # new run started"). Measured directly, not assumed: the session's
+        # own audit EventLog (session.py's `audit_events = EventLog(...)`)
+        # passes `agent_id` only, `run_id` stays unset there — so `run_id`
+        # is NOT a reliable per-execution identity for this specific
+        # EventLog instance, and this can't just alias it. A fresh EventLog
+        # is constructed exactly once per real process execution (never
+        # reloaded/reused across a restart), so a random token minted HERE,
+        # once, at construction, is already unique per execution BY
+        # CONSTRUCTION — no dependency on any other field being populated.
+        # `emitter=` lets a caller override this (e.g. `emit_cli_event`
+        # passing the literal `"cli"` label for its one-off, non-
+        # continuous events — see that function's own construction site).
+        self._emitter = emitter if emitter is not None else secrets.token_hex(8)
+        # CLI one-off events have no continuity to protect (one event, one
+        # process, never a second call from the same EventLog instance) —
+        # architect's own ruling: "a series of exactly one has no meaning
+        # for gap-detection", so `track_audit_seq=False` omits the key
+        # entirely rather than always stamping a meaningless `1`.
+        self._track_audit_seq = track_audit_seq
+        self._audit_seq = 0
 
     @property
     def subscribers(self) -> list[Callable[[Event], None]]:
@@ -106,6 +141,15 @@ class EventLog:
         """The run_id this EventLog stamps onto emitted events (issue #134)."""
         return self._run_id
 
+    @property
+    def emitter(self) -> str:
+        """The emitter label this EventLog stamps onto every emitted event
+        (#4496 PR-1, contract 3) — auto-generated at construction when not
+        explicitly given. Public read-only view, same rationale as
+        ``agent_id``/``run_id`` above: lets a caller confirm identity
+        without reaching into private state."""
+        return self._emitter
+
     def add_subscriber(self, fn: Callable[[Event], None]) -> None:
         self._subscribers.append(fn)
 
@@ -137,6 +181,17 @@ class EventLog:
         # row when a child agent shares the parent's subscriber list.
         if self._run_id and "run_id" not in data:
             data = {**data, "run_id": self._run_id}
+        # #4496 PR-1: emitter + audit_seq are ALWAYS this EventLog's own —
+        # deliberately NOT caller-wins (unlike agent_id/run_id above).
+        # Letting a caller supply either would open a path to skip a
+        # number or forge one, which would make a real gap indistinguishable
+        # from an intentional skip — the exact failure mode contract 3
+        # exists to prevent. Overwrites any caller-supplied same-named key
+        # rather than merely defaulting it.
+        data = {**data, "emitter": self._emitter}
+        if self._track_audit_seq:
+            self._audit_seq += 1
+            data["audit_seq"] = self._audit_seq
         event = Event(type=type, data=data)
         # #3868 PR-1: fold this event's contribution to `_ingested` at emit
         # time (a dict update) instead of re-scanning full history at every
@@ -237,5 +292,12 @@ def emit_cli_event(kind: str, **payload) -> None:
     # Use a date-named suffix so each day's CLI events land in one predictable file.
     # max_bytes=0 / max_age_seconds=0 disables rotation — the suffix IS the date.
     store = EventStore(cli_dir, max_bytes=0, max_age_seconds=0, suffix=f"_{today}")
-    event_log = EventLog(subscribers=[store])
+    # #4496 PR-1: a one-off CLI event has no continuity to protect — a
+    # single event from a single process is not a series a gap can be
+    # detected in, so audit_seq is omitted entirely (architect's ruling)
+    # rather than always stamping a meaningless `1`. `emitter="cli"` is a
+    # legible label (not a random per-instance token — nothing needs to
+    # distinguish one CLI invocation's emitter from another's, since
+    # neither carries a sequence to compare).
+    event_log = EventLog(subscribers=[store], emitter="cli", track_audit_seq=False)
     event_log.emit(kind, **payload)

--- a/tests/core/test_4496_pr1_audit_seq.py
+++ b/tests/core/test_4496_pr1_audit_seq.py
@@ -1,0 +1,131 @@
+"""Tier 2: #4496 PR-1 — audit-event monotonic sequencing (contract 3).
+
+Architect's own witness list (issue comment): (1) same emitter, consecutive
+events, audit_seq +1; (2) a different emitter starts at 1 without disturbing
+the first emitter's own continuity; (3) the caller cannot influence numbering
+(emit has no seq-accepting parameter, and a caller-supplied same-named key
+is overwritten, never honored).
+"""
+from __future__ import annotations
+
+from reyn.core.events.events import EventLog, emit_cli_event
+
+
+def test_same_emitter_consecutive_events_increment_by_one():
+    """Tier 2: witness ① — two emits on the SAME EventLog get audit_seq 1, 2."""
+    log = EventLog()
+    e1 = log.emit("tool_executed", op="read")
+    e2 = log.emit("tool_executed", op="read")
+    assert e1.data["audit_seq"] == 1
+    assert e2.data["audit_seq"] == 2
+    assert e1.data["emitter"] == e2.data["emitter"]
+
+
+def test_a_different_emitter_starts_at_one_independently():
+    """Tier 2: witness ② — a second EventLog (= a different execution
+    instance) starts its own count at 1, and the first EventLog's
+    continuity is unaffected by the second's existence."""
+    log_a = EventLog()
+    log_b = EventLog()
+
+    a1 = log_a.emit("tool_executed", op="read")
+    b1 = log_b.emit("tool_executed", op="read")
+    a2 = log_a.emit("tool_executed", op="read")
+
+    assert a1.data["audit_seq"] == 1
+    assert a2.data["audit_seq"] == 2
+    assert b1.data["audit_seq"] == 1
+    assert a1.data["emitter"] != b1.data["emitter"]
+
+
+def test_two_fresh_event_logs_get_different_emitter_tokens():
+    """Tier 2: (accept-side) construction-time uniqueness — two EventLog
+    instances constructed with no explicit emitter never collide, the
+    property this whole design leans on (a fresh instance per real
+    process execution)."""
+    instances = [EventLog() for _ in range(50)]
+    tokens = {log.emitter for log in instances}
+    assert len(tokens) == len(instances), "two fresh EventLogs collided on emitter"
+
+
+def test_caller_cannot_supply_audit_seq_and_have_it_win():
+    """Tier 2: witness ③ — a caller passing audit_seq=... in the emit call
+    does NOT win; the EventLog's own counter always overwrites it. This is
+    the falsifiable form of "the caller cannot influence numbering" — if
+    emit ever became caller-wins for this field (the same convention
+    agent_id/run_id use), this test catches it."""
+    log = EventLog()
+    log.emit("tool_executed", op="read")  # audit_seq 1, consumed
+    forged = log.emit("tool_executed", op="read", audit_seq=9999)
+    assert forged.data["audit_seq"] == 2
+
+
+def test_caller_cannot_supply_emitter_and_have_it_win():
+    """Tier 2: same non-caller-wins guarantee for the emitter field itself
+    — a forged emitter string must not let an event masquerade as
+    belonging to a different execution's sequence."""
+    log = EventLog(emitter="real-emitter")
+    forged = log.emit("tool_executed", op="read", emitter="someone-else")
+    assert forged.data["emitter"] == "real-emitter"
+
+
+def test_emit_has_no_seq_accepting_keyword_parameter():
+    """Tier 2: witness ③, mechanical form — emit's own signature has no
+    audit_seq/emitter positional/keyword slot a caller could target; both
+    only ever arrive via **data, which the two tests above already prove
+    gets overwritten. This test would fail if a future edit turned emit
+    into `def emit(self, type, *, audit_seq=None, **data)`, silently
+    reopening the caller-wins path."""
+    import inspect
+
+    sig = inspect.signature(EventLog.emit)
+    assert "audit_seq" not in sig.parameters
+    assert "emitter" not in sig.parameters
+
+
+def test_audit_seq_is_a_distinct_name_from_the_wal_seq():
+    """Tier 2: architect's naming mandate, falsified directly — the key is
+    literally 'audit_seq', never bare 'seq' (which the WAL already owns
+    for a different concept)."""
+    log = EventLog()
+    event = log.emit("tool_executed", op="read")
+    assert "audit_seq" in event.data
+    assert "seq" not in event.data
+
+
+def test_emitter_is_explicitly_overridable_at_construction():
+    """Tier 2: (accept-side) a caller MAY set emitter at construction time
+    (unlike per-emit-call, which is locked) — the seam emit_cli_event uses
+    for its own "cli" label."""
+    log = EventLog(emitter="my-label")
+    event = log.emit("tool_executed", op="read")
+    assert event.data["emitter"] == "my-label"
+
+
+# ── emit_cli_event: one-off, no continuity ───────────────────────────────
+
+
+def test_cli_event_carries_the_cli_emitter_label(tmp_path, monkeypatch):
+    """Tier 2: emit_cli_event's own events carry emitter='cli', a legible
+    label rather than a random per-call token — architect's ruling."""
+    (tmp_path / ".reyn").mkdir()
+    monkeypatch.chdir(tmp_path)
+    emit_cli_event("secret_set", key="X")
+
+    written = list((tmp_path / ".reyn" / "events" / "direct" / "cli").rglob("*.jsonl"))
+    assert written
+    content = written[0].read_text(encoding="utf-8")
+    assert '"emitter": "cli"' in content or '"emitter":"cli"' in content
+
+
+def test_cli_event_carries_no_audit_seq(tmp_path, monkeypatch):
+    """Tier 2: architect's ruling, verbatim — a one-off CLI event has no
+    continuity to protect, so audit_seq is omitted entirely rather than
+    always stamping a meaningless 1."""
+    (tmp_path / ".reyn").mkdir()
+    monkeypatch.chdir(tmp_path)
+    emit_cli_event("secret_set", key="X")
+
+    written = list((tmp_path / ".reyn" / "events" / "direct" / "cli").rglob("*.jsonl"))
+    content = written[0].read_text(encoding="utf-8")
+    assert "audit_seq" not in content

--- a/tests/interfaces/test_agui_multi_content_streaming_3288.py
+++ b/tests/interfaces/test_agui_multi_content_streaming_3288.py
@@ -300,13 +300,28 @@ async def _collect(gen) -> list:
 
 
 async def _via_in_process(script) -> list:
+    # #4511: forward each script EventFrame's own Event straight to
+    # subscribers, rather than re-emitting it through fake.audit_events
+    # (a real EventLog). Re-emitting used to be a harmless passthrough
+    # (this EventLog has no agent_id/run_id configured, so nothing got
+    # added) -- but EventLog.emit now ALWAYS stamps audit_seq/emitter
+    # (#4496 PR-1), which only this path re-emits through, diverging from
+    # _via_agui's _frame_source(script) below (which consumes the SAME
+    # script's Event objects untouched, never routing through .emit() at
+    # all). Both helpers must treat the script's Event objects as
+    # already-final so this test's own comparison stays about transport
+    # reconstruction, not EventLog's stamping (which has its own coverage,
+    # test_4496_pr1_audit_seq.py) -- matches production, where both
+    # transports subscribe to ONE session EventLog.emit() call and see
+    # identical data either way.
     fake = _FakeRegistry()
     transport = InProcessTransport(fake, intervention_channel="tui")
     transport.start()
     try:
         for f in script:
             if isinstance(f, EventFrame):
-                fake.audit_events.emit(f.event.type, **f.event.data)
+                for sub in fake.audit_events.subscribers:
+                    sub(f.event)
             else:
                 fake.repl_outbox.put_nowait(f.message)
         fake.repl_outbox.put_nowait(OutboxMessage(kind="__end__", text=""))


### PR DESCRIPTION
**[e2e-coder]** — part of #4496 (PR-1 of 4 — see architect's staged-rollout comment). Closes nothing yet (PR-2/3/4 remain for the backend abstraction itself); this lands contract 3 alone, standalone value per architect's own framing.

## What
- `EventLog.__init__` gains `emitter`/`track_audit_seq` params. `emitter` auto-mints a fresh `secrets.token_hex(8)` at construction when not given.
- `EventLog.emit` stamps `emitter` always and `audit_seq` (1, 2, 3…) when `track_audit_seq` is True (default) — both **overwrite** any caller-supplied same-named `data` key (deliberately not the `agent_id`/`run_id` caller-wins convention — letting a caller influence numbering would defeat gap-detection).
- `emit_cli_event`: `emitter="cli"`, `track_audit_seq=False` — a one-off CLI event has no continuity to protect (architect's ruling), so `audit_seq` is omitted rather than always stamping a meaningless `1`.
- `docs/reference/runtime/events.md`: new "Audit sequence" section (the CLAUDE.md 3-point-set discipline; payload drift isn't CI-checked, per #4461).

## A finding worth flagging: `run_id` isn't populated where architect expected it
Architect's design assumed the session-level audit `EventLog` already carries a `run_id` usable as the per-execution identity (`emitter = session_id + run_id`, avoiding a new field). I measured this directly before implementing: `session.py`'s own `audit_events = EventLog(subscribers=[event_store], agent_id=self._agent.agent_id)` construction passes **only** `agent_id` — `run_id` stays unset on this specific instance. Rather than build on that unverified premise, I went with a self-contained fix: `emitter` mints its own fresh token at `EventLog.__init__`, which is unique by construction (a fresh `EventLog` is built exactly once per real process execution, never reloaded across a restart) — no dependency on `run_id`'s actual lifetime on this call site.

## Test plan
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 0 errors (10 new tests)
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] `python scripts/mypy_ratchet.py` — no new findings (212/215 baselined, unchanged)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/test_tier_audit.py` / `pytest tests/core/test_audit_event_kind_vocabulary_3410.py` — the CI-checked kind↔doc pair stays green (no new kind added, this PR only adds payload fields)
- [x] `pytest tests/core/test_4496_pr1_audit_seq.py` — 10 passed, covering all 3 of architect's own witnesses (same-emitter +1, cross-emitter independence + non-interference, caller-cannot-influence-numbering — both a behavioral test AND a mechanical `inspect.signature` test)
- [x] Full events-test regression sweep (16 files, 175 tests) — green, no breakage
- [x] (skipped — n/a, no UI surface)

part of #4496
