### PR TITLE
feat(#4482 PR-3): Artifacts tab — list generated artifacts, open with OS default app

### DIFF
--- a/docs/reference/cli/chat.md
+++ b/docs/reference/cli/chat.md
@@ -91,6 +91,7 @@ While a session is active, lines starting with `/` are intercepted and never rou
 | `/list` | List pending interventions |
 | `/memory [list\|view <name>]` | Inspect project memory entries (see [concepts/memory](../../concepts/data-retrieval/memory.md)) |
 | `/model [<class>]` | Show the session's model class and any override, or set a per-session model-class override with `/model <class>` (validated against known classes; clears on restart) |
+| `/open <ref>` | Open a generated artifact (html/office/pdf/image — anything the terminal can't render) with the OS's own default app. The Artifacts tab (`Art`, bottom-chrome drawer) lists refs newest-first; selecting a row runs this for you |
 | `/pending [list\|discard <id>\|claim <id>]` | List / discard / claim stalled cross-channel ops |
 | `/quit` | Exit the chat (alias: `/exit`, Ctrl+D) |
 | `/reload` | Hot-reload runtime config (`.reyn/*.yaml`) at the next turn boundary |
@@ -99,7 +100,7 @@ While a session is active, lines starting with `/` are intercepted and never rou
 | `/session new \| switch <sid> \| list` | Open / switch / list conversation sessions for the attached agent (see [Sessions](../../concepts/multi-agent/sessions.md)) |
 | `/visibility on\|off <tool\|mcp\|category> <name>` | Toggle this session's LLM visibility of a capability (hidden next turn / restored up to the agent's authorized envelope — an envelope-denied capability stays hidden) |
 
-`/list` / `/answer` are foundational — they let pending interventions coexist without blocking the prompt. `/agents` / `/attach` / `/agent` are the multi-agent workflow primitives; a spawned/delegated peer's progress is monitored via `/agents`. `/hook` / `/visibility` are session-scoped LLM-catalog controls, mirroring the status bar's `hook`/`tool`/`mcp`/`category` chips. `/copy` is a conversation-pane utility; `/image` enables multimodal input.
+`/list` / `/answer` are foundational — they let pending interventions coexist without blocking the prompt. `/agents` / `/attach` / `/agent` are the multi-agent workflow primitives; a spawned/delegated peer's progress is monitored via `/agents`. `/hook` / `/visibility` are session-scoped LLM-catalog controls, mirroring the status bar's `hook`/`tool`/`mcp`/`category` chips. `/copy` is a conversation-pane utility; `/image` enables multimodal input; `/open` launches a generated artifact with the OS's own default app (local sessions only — see the Artifacts tab).
 
 ## Multi-agent behavior
 

--- a/src/reyn/core/present/artifact_list.py
+++ b/src/reyn/core/present/artifact_list.py
@@ -1,0 +1,127 @@
+"""#4482 PR-3: derive the "open a generated artifact" list from the SAME
+message source the conversation pane itself renders — never a second,
+persisted registry.
+
+**Invariant 3 (lead-coder, #4440's dispatch, repeated verbatim across
+three separate messages this session — the recurring class this arc is
+named after):** this module walks `msg.meta["nodes"]` off the entries the
+conversation view ALREADY holds, never `Session.history`'s own resident
+buffer. `Session.history` has its own independent eviction axis
+(`#4387`'s `history_resident` byte cap, `#4468`'s eviction) — an artifact
+presented early in a long session can be evicted from `self.history`
+while STILL visible in the conversation pane (FlowView keeps its own
+entries; the two are not the same list, nor evicted on the same
+schedule). Deriving the list from `self.history` would silently drop
+"old but still-visible" artifacts from the list while the user can see
+them right there on screen — a resource-management axis (what a memory
+cap chose to keep) deciding a SEMANTIC question (what the user can open)
+that has nothing to do with memory pressure. This is the third instance
+of that exact shape flagged in one session (band lens: System Design —
+responsibility at the wrong layer).
+
+**No new persisted state** (owner/architect ruling): the list is derived
+fresh from whatever the caller passes in (typically FlowView's own live
+`entries`) — no separate on-disk index, no separate in-memory cache kept
+warm across calls. A page of rows is only as expensive as the nodes on
+that page: this module never walks the WHOLE session's history to build
+one page, and never `stat()`s a file the caller does not ask about (see
+:func:`stat_row` below, called only for rows about to be DISPLAYED, not
+at collection time — "表示ページ分だけ stat").
+
+Pure: no I/O in :func:`collect_artifact_rows` itself (a resolved
+artifact-node payload is already fully self-describing — `ref`/`name`/
+`media_type`/`body` — no filesystem access needed to list it). The one
+I/O this module does (a single `os.stat`) is isolated in :func:`stat_row`,
+called by the caller only for rows about to render."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ArtifactRow:
+    """One listable artifact — everything needed to DISPLAY a row and to
+    OPEN it, with no further derivation. `ref` is `None` for an inline
+    (no-real-file) artifact — nothing to open with the OS, the content
+    already reached the conversation pane directly (present's own inline
+    rendering handles it, same as any other component)."""
+
+    ref: "str | None"
+    name: str
+    media_type: "str | None"
+    description: "str | None"
+    is_inline: bool
+    error: "str | None" = None
+
+
+def _artifact_row_from_node(node: dict) -> "ArtifactRow | None":
+    """One `component == "artifact"` node -> its row, or `None` for a soft
+    binding-miss (`{"component": "artifact"}` — nothing resolved, present's
+    existing soft-skip philosophy; there is nothing displayable yet)."""
+    if node.get("component") != "artifact":
+        return None
+    if "error" in node:
+        return ArtifactRow(
+            ref=None, name="", media_type=None, description=None,
+            is_inline=False, error=str(node["error"]),
+        )
+    body = node.get("body")
+    if not isinstance(body, dict):
+        return None  # soft binding-miss — nothing resolved yet
+    description = node.get("description")
+    media_type = node.get("media_type")
+    if "ref" in body:
+        return ArtifactRow(
+            ref=str(body["ref"]),
+            name=str(node.get("name") or body["ref"]),
+            media_type=media_type,
+            description=description,
+            is_inline=False,
+        )
+    # Inline body — no real file, nothing for the OS to open.
+    return ArtifactRow(
+        ref=None,
+        name=str(node.get("name") or "(inline)"),
+        media_type=media_type,
+        description=description,
+        is_inline=True,
+    )
+
+
+def collect_artifact_rows(node_lists: "list[list[dict]]") -> list[ArtifactRow]:
+    """Every artifact row across `node_lists` (one list per conversation
+    message, in the SAME order the caller iterated its message source),
+    newest-first.
+
+    `node_lists` is plain data — a caller list-comprehends
+    ``msg.meta.get("nodes", [])`` per entry (or per `presented`-event
+    replay, off-loop) and hands the result here; this function never
+    touches a live `FlowView`/`Session` itself, so it stays trivially
+    testable with hand-built fixtures shaped like real resolved artifact
+    payloads (see `artifact_payload.py`'s own docstring for that shape)."""
+    rows: list[ArtifactRow] = []
+    for nodes in node_lists:
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            row = _artifact_row_from_node(node)
+            if row is not None:
+                rows.append(row)
+    rows.reverse()  # newest-first
+    return rows
+
+
+def stat_row(resolved_path: "Any | None") -> "int | None":
+    """The ONE piece of I/O this module ever does — a single `os.stat`,
+    called by the caller ONLY for a row about to be DISPLAYED (the
+    "表示ページ分だけ stat" requirement), never at collection time. Returns
+    the file's current size in bytes, or `None` if it can't be stat'd
+    (deleted out from under the list — #4478's GC domain, not this
+    module's; an unresolvable row simply shows as such, no crash)."""
+    if resolved_path is None:
+        return None
+    try:
+        return resolved_path.stat().st_size
+    except OSError:
+        return None

--- a/src/reyn/core/present/artifact_list.py
+++ b/src/reyn/core/present/artifact_list.py
@@ -35,7 +35,9 @@ I/O this module does (a single `os.stat`) is isolated in :func:`stat_row`,
 called by the caller only for rows about to render."""
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 
@@ -45,7 +47,20 @@ class ArtifactRow:
     OPEN it, with no further derivation. `ref` is `None` for an inline
     (no-real-file) artifact — nothing to open with the OS, the content
     already reached the conversation pane directly (present's own inline
-    rendering handles it, same as any other component)."""
+    rendering handles it, same as any other component).
+
+    `resolved_path` (#4482 PR-3 review, lead-coder/architect — a real
+    block, not a nit): `name` alone is a BASENAME — it names WHAT the
+    artifact is, never WHERE it is, so two same-named artifacts in
+    different directories are indistinguishable on the row alone. That
+    fails the arc's one non-negotiable requirement ("ユーザが何を開こう
+    としているか実体が見えること" — the user sees the REAL thing they're
+    about to open) and architect's ruling ("表示から実行まで同じ path を
+    使う"). `resolved_path` is set by :func:`resolve_display_paths` below
+    — a project-root-relative path when the ref resolves, `None` when it
+    doesn't (deleted, or an inline/error row with nothing to resolve) —
+    and the display layer (`chrome.artifact_row_label`) prefers it over
+    the bare `name`."""
 
     ref: "str | None"
     name: str
@@ -53,6 +68,7 @@ class ArtifactRow:
     description: "str | None"
     is_inline: bool
     error: "str | None" = None
+    resolved_path: "str | None" = None
 
 
 def _artifact_row_from_node(node: dict) -> "ArtifactRow | None":
@@ -110,6 +126,45 @@ def collect_artifact_rows(node_lists: "list[list[dict]]") -> list[ArtifactRow]:
                 rows.append(row)
     rows.reverse()  # newest-first
     return rows
+
+
+def resolve_display_paths(
+    rows: list[ArtifactRow], project_root: Path, agent_name: str,
+) -> list[ArtifactRow]:
+    """Fill in each ref-bearing row's `resolved_path` (#4482 PR-3 review —
+    see :class:`ArtifactRow`'s own docstring for why `name` alone was not
+    enough). The SAME resolution path :func:`~reyn.data.workspace.
+    artifact_ref.resolve_ref` — the one `_handle_open_artifact_request`
+    itself calls right before opening — never a second, independently-
+    computed path, so what this shows and what actually opens cannot
+    diverge.
+
+    An inline row (`ref is None`) or an unresolvable one (deleted, or an
+    unknown ref) passes through with `resolved_path` still `None` — the
+    caller's own display layer falls back to `name` for those, which is
+    the best available answer when there is genuinely nothing to resolve.
+
+    The one piece of I/O this module's collection path does — called only
+    on rows about to be DISPLAYED (a pane refresh), matching this module's
+    own "no pre-stat, no persisted cache" discipline; see the module
+    docstring."""
+    from reyn.data.workspace.artifact_ref import resolve_ref
+
+    out: list[ArtifactRow] = []
+    for row in rows:
+        if row.ref is None:
+            out.append(row)
+            continue
+        resolved = resolve_ref(project_root, agent_name, row.ref)
+        if resolved is None:
+            out.append(row)
+            continue
+        try:
+            display = str(resolved.relative_to(project_root))
+        except ValueError:
+            display = str(resolved)
+        out.append(dataclasses.replace(row, resolved_path=display))
+    return out
 
 
 def stat_row(resolved_path: "Any | None") -> "int | None":

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1630,17 +1630,34 @@ class TextualChatApp(App):
         pane, and this list must not silently follow that unrelated
         resource-management axis).
 
-        No persistence, no pre-stat: :func:`collect_artifact_rows` is pure
-        and only reads what is already in each message's own resolved
-        payload (`ref`/`name`/`media_type`/`body`) — nothing here ever
-        opens a file just to build this list."""
-        from reyn.core.present.artifact_list import collect_artifact_rows
+        No persistence: :func:`collect_artifact_rows` is pure and only
+        reads what is already in each message's own resolved payload
+        (`ref`/`name`/`media_type`/`body`). The one piece of I/O this
+        method does — resolving each row's `resolved_path` via the SAME
+        `resolve_ref` path `_handle_open_artifact_request` itself calls —
+        is a review fix (lead-coder/architect, #4482 PR-3): a bare
+        `name` is a basename, which cannot distinguish two same-named
+        artifacts in different directories, failing the arc's one
+        non-negotiable requirement (the user sees the REAL thing about to
+        open). Runs only when this method is called (a pane refresh),
+        never continuously — "表示ページ分だけ stat"."""
+        from pathlib import Path
+
+        from reyn.config import _find_project_root
+        from reyn.core.present.artifact_list import (
+            collect_artifact_rows,
+            resolve_display_paths,
+        )
         node_lists = [
             entry.item.meta.get("nodes", [])
             for entry in self.conversation
             if entry.item.kind == "presentation"
         ]
-        return collect_artifact_rows(node_lists)
+        rows = collect_artifact_rows(node_lists)
+        if not rows:
+            return rows
+        project_root = _find_project_root(Path.cwd()) or Path.cwd()
+        return resolve_display_paths(rows, project_root, self._agent_name)
 
     def _pane_rows(self, tab_id: str, snap: "dict | None | object" = _UNSET) -> "list[str]":
         """The display rows for ``tab_id``'s pane, derived from canonical sources:

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -111,6 +111,7 @@ if TYPE_CHECKING:
     from textual.timer import Timer
     from textual_flowview import VisibilityHandle
 
+    from reyn.core.present.artifact_list import ArtifactRow
     from reyn.interfaces.repl.read_model import ChatReadModel
     from reyn.interfaces.transport.client_transport import ClientTransport
     from reyn.runtime.outbox import OutboxMessage
@@ -1617,12 +1618,36 @@ class TextualChatApp(App):
             rows.append(f"{role} · {head}")
         return rows[-limit:]
 
+    def _artifact_rows(self) -> "list[ArtifactRow]":
+        """#4482 PR-3: every listable artifact, newest-first — derived from
+        the SAME message source the conversation pane itself renders
+        (``self.conversation``, the app's own live ``FlowModel``), never
+        ``Session.history``'s resident buffer (invariant 3, repeated
+        verbatim across three separate lead-coder dispatches this session:
+        the two are not the same list, nor evicted on the same schedule —
+        #4387/#4468's byte-cap eviction can drop an entry from
+        ``self.history`` while it is STILL visible in the conversation
+        pane, and this list must not silently follow that unrelated
+        resource-management axis).
+
+        No persistence, no pre-stat: :func:`collect_artifact_rows` is pure
+        and only reads what is already in each message's own resolved
+        payload (`ref`/`name`/`media_type`/`body`) — nothing here ever
+        opens a file just to build this list."""
+        from reyn.core.present.artifact_list import collect_artifact_rows
+        node_lists = [
+            entry.item.meta.get("nodes", [])
+            for entry in self.conversation
+            if entry.item.kind == "presentation"
+        ]
+        return collect_artifact_rows(node_lists)
+
     def _pane_rows(self, tab_id: str, snap: "dict | None | object" = _UNSET) -> "list[str]":
         """The display rows for ``tab_id``'s pane, derived from canonical sources:
         the status snapshot (model/agent/cost/ctx), the slash ``REGISTRY`` (menu),
-        the live conversation (history), and the app BINDINGS (help). Pass ``snap``
-        to reuse an already-read snapshot (keeps the rows and the selection ids
-        derived from ONE snapshot)."""
+        the live conversation (history), the live artifact list (#4482), and the
+        app BINDINGS (help). Pass ``snap`` to reuse an already-read snapshot
+        (keeps the rows and the selection ids derived from ONE snapshot)."""
         from reyn.interfaces.slash import REGISTRY  # noqa: PLC0415 — TTY-local
         snapshot = self._snapshot() if snap is _UNSET else snap
         return pane_payload(
@@ -1630,6 +1655,7 @@ class TextualChatApp(App):
             snapshot=snapshot,  # type: ignore[arg-type]
             commands=REGISTRY.all_commands(),
             history=self._history_turns(),
+            artifacts=self._artifact_rows(),
             app_bindings=self._app_binding_help(),
         )
 
@@ -2361,7 +2387,9 @@ class TextualChatApp(App):
         upstream, in :meth:`_history_turns`."""
         snapshot = self._snapshot() if snap is _UNSET else snap
         rows = self._pane_rows(tab_id, snapshot)
-        self._pane_commands[tab_id] = pane_commands(tab_id, snapshot)  # type: ignore[arg-type]
+        self._pane_commands[tab_id] = pane_commands(  # type: ignore[arg-type]
+            tab_id, snapshot, artifacts=self._artifact_rows(),
+        )
         child = self.query_one(f"#{tab_id}")
         if isinstance(child, OptionList):
             child.clear_options()
@@ -3057,6 +3085,46 @@ class TextualChatApp(App):
         untouched."""
         status = await handle_copy_sentinel(self._recent_replies, arg)
         self._ingest_frame(status)
+
+    async def _handle_open_artifact_request(self, ref: str) -> None:
+        """Consume a ``__open_artifact__`` sentinel: resolve the ref, launch
+        the OS's own default app on the SAME path, then report (#4482 PR-3).
+
+        Architect's #4482 ruling, verbatim: "開くのに使う path そのものを
+        表示し、表示から実行まで同じ path を使う" — the Artifacts pane already
+        showed this ref's `name` before the operator selected it; resolving
+        the SAME ref here (never a raw path carried by the command itself —
+        the artifact payload's own invariant 1) is what keeps "what was shown"
+        and "what gets opened" the same string, not two.
+
+        A resolution failure (unknown ref, or the file no longer exists —
+        :func:`resolve_ref` returns ``None`` for both, by design; see its own
+        docstring) reports as a status line rather than raising — the same
+        "report failure, never silently do nothing" shape :meth:`_write_clipboard`
+        established for the text-cursor yank path (#3616)."""
+        from pathlib import Path
+
+        from reyn.config import _find_project_root
+        from reyn.data.workspace.artifact_ref import resolve_ref
+        from reyn.interfaces.repl._open_with_os_default import open_with_os_default
+        from reyn.runtime.outbox import OutboxMessage
+
+        ref = (ref or "").strip()
+        if not ref:
+            self._ingest_frame(OutboxMessage(kind="status", text="no artifact ref given"))
+            return
+        project_root = _find_project_root(Path.cwd()) or Path.cwd()
+        resolved = resolve_ref(project_root, self._agent_name, ref)
+        if resolved is None:
+            self._ingest_frame(OutboxMessage(
+                kind="status", text=f"artifact not found (ref={ref})",
+            ))
+            return
+        ok = open_with_os_default(resolved)
+        if not ok:
+            self._ingest_frame(OutboxMessage(
+                kind="status", text=f"could not open {resolved.name} — no OS opener available",
+            ))
 
     def _handle_rewind_request(self, msg: "OutboxMessage") -> None:
         """Consume a ``__rewind_list__`` sentinel: show the picker, or the text
@@ -4533,6 +4601,11 @@ class TextualChatApp(App):
                             self._handle_rewind_request(msg)
                         except Exception:
                             logger.exception("textual chat: /rewind sentinel failed")
+                    elif msg.kind == "__open_artifact__":
+                        try:
+                            await self._handle_open_artifact_request(msg.text)
+                        except Exception:
+                            logger.exception("textual chat: /open sentinel failed")
                     elif msg.kind not in _SKIP_KINDS:
                         try:
                             self._ingest_frame(msg)

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -911,15 +911,23 @@ def history_pane_options(turns: "Sequence[str]") -> list[str]:
 def artifact_row_label(row: "ArtifactRow") -> str:
     """#4482 PR-3: one artifact's display row. Names the SAME thing
     :meth:`_handle_open_artifact_request` opens — architect's ruling
-    ("表示から実行まで同じ path を使う") applies to what's shown here too,
-    which is why this shows ``name`` (the OS-visible filename the ref
-    resolves to), never a bare ref alone — a ref is an opaque token with
-    no meaning to the operator deciding whether to open it."""
+    ("表示から実行まで同じ path を使う") applies to what's shown here too.
+
+    **Prefers `resolved_path` over bare `name`** (review fix, lead-coder/
+    architect): `name` alone is a BASENAME, which cannot distinguish two
+    same-named artifacts in different directories — the arc's one
+    non-negotiable requirement is that the user sees the REAL thing about
+    to open, and a basename does not satisfy that on its own. A ref is an
+    opaque token with no meaning to the operator either, so neither
+    ``name`` nor ``ref`` alone is enough; ``resolved_path`` (a
+    project-root-relative path — see :func:`~reyn.core.present.
+    artifact_list.resolve_display_paths`) is what's shown whenever it is
+    available."""
     if row.error is not None:
         return f"✗ {row.name or '(unresolved)'} — {row.error}"
     if row.is_inline:
         return f"{row.name} (inline — already shown above)"
-    return row.name
+    return row.resolved_path or row.name
 
 
 def artifact_pane_options(rows: "Sequence[ArtifactRow]") -> list[str]:

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -24,6 +24,13 @@ Phase 4 wires every pane to its CANONICAL reyn source (no placeholders):
   ``ChatReadModel.conversation_history`` seam), so this pane is cross-session by
   construction — it shows restored PRIOR turns alongside the live ones (see the
   app docstring).
+- **Artifacts** (#4482 PR-3) — generated files the terminal can't render
+  natively (html/office/pdf/images), newest-first, derived from the SAME
+  ``self.conversation`` model History reads (never ``Session.history``'s own
+  resident buffer — see :meth:`TextualChatApp._artifact_rows`'s own docstring
+  for why the two are not interchangeable). Each openable row carries an
+  ``/open <ref>`` command (:func:`pane_commands`) that launches the OS's own
+  default app on the resolved path.
 - **Cost / Ctx** — the live token/cost + context-window figures from the same
   status snapshot the plain path's status bar reads. Cost is the 5-row ×
   3-scope breakdown table (:func:`_cost_breakdown_table`) plus the cumulative
@@ -87,6 +94,7 @@ from .sent_queue import SentQueue
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
+    from reyn.core.present.artifact_list import ArtifactRow
     from reyn.interfaces.slash import SlashCommand
 
 
@@ -376,6 +384,12 @@ _MENU_TABS: "list[tuple[str, str]]" = [
     ("model", "Model"),
     ("agent", "Agent"),
     ("history", "Hist"),
+    # #4482 PR-3: generated artifacts (html/office/pdf/images — anything the
+    # terminal can't render natively) the operator can open with the OS's own
+    # default app. "Art" reads unambiguous next to "Agent" here (distinct
+    # first two letters, Ar- vs Ag-), matching this row's own "each
+    # abbreviation stays uniquely identifiable on its own" bar.
+    ("artifacts", "Art"),
     ("cost", "Cost"),
     ("ctx", "Ctx"),
     # The six categories the retired chip bar kept behind its level-2 "more…"
@@ -411,7 +425,7 @@ _MENU_TABS: "list[tuple[str, str]]" = [
 #: limitation of leaving those three panes unwrapped, not a claim that they
 #: are immune to the rendering quirk.
 _LIST_PANES = frozenset({
-    "model", "agent", "history", "menu", "tool", "mcp", "skill", "hook",
+    "model", "agent", "history", "artifacts", "menu", "tool", "mcp", "skill", "hook",
 })
 
 # ── the Help pane's key tables ───────────────────────────────────────────────
@@ -589,7 +603,9 @@ _USER_CONTENT_LIST_PANE = "history"
 #: that carry no marker of ours, so the quirk only reaches them if an operator
 #: names something with a ``[...]``-shaped substring (the accepted limitation
 #: documented at ``_LIST_PANES``).
-_LITERAL_ROW_PANES = frozenset({_USER_CONTENT_LIST_PANE, "tool", "mcp", "skill", "hook"})
+_LITERAL_ROW_PANES = frozenset({
+    _USER_CONTENT_LIST_PANE, "artifacts", "tool", "mcp", "skill", "hook",
+})
 
 
 def pane_needs_literal_rows(tab_id: str) -> bool:
@@ -890,6 +906,38 @@ def history_pane_options(turns: "Sequence[str]") -> list[str]:
     """Recent turns of the live conversation (already-formatted ``role · text``
     rows). A readout of the retained conversation model, not a registry set."""
     return list(turns) if turns else ["(no conversation yet)"]
+
+
+def artifact_row_label(row: "ArtifactRow") -> str:
+    """#4482 PR-3: one artifact's display row. Names the SAME thing
+    :meth:`_handle_open_artifact_request` opens — architect's ruling
+    ("表示から実行まで同じ path を使う") applies to what's shown here too,
+    which is why this shows ``name`` (the OS-visible filename the ref
+    resolves to), never a bare ref alone — a ref is an opaque token with
+    no meaning to the operator deciding whether to open it."""
+    if row.error is not None:
+        return f"✗ {row.name or '(unresolved)'} — {row.error}"
+    if row.is_inline:
+        return f"{row.name} (inline — already shown above)"
+    return row.name
+
+
+def artifact_pane_options(rows: "Sequence[ArtifactRow]") -> list[str]:
+    """Rows for the Artifacts drawer pane — newest-first, already the order
+    :func:`~reyn.core.present.artifact_list.collect_artifact_rows` returns."""
+    return [artifact_row_label(r) for r in rows] if rows else ["(no artifacts yet)"]
+
+
+def artifact_pane_commands(rows: "Sequence[ArtifactRow]") -> list[str]:
+    """The ``/open <ref>`` command parallel to each row in
+    :func:`artifact_pane_options` — empty string (non-actionable, same as
+    History/Menu) for a row with nothing to open: an inline artifact (no
+    real file — the content already reached the conversation pane
+    directly) or an error marker (nothing resolved)."""
+    return [
+        f"/open {r.ref}" if r.ref is not None else ""
+        for r in rows
+    ]
 
 
 def menu_pane_options(commands: "Iterable[SlashCommand]") -> list[str]:
@@ -1220,7 +1268,12 @@ _PANE_ENTRY_BUILDERS: "dict[str, object]" = {
 }
 
 
-def pane_commands(tab_id: str, snapshot: "dict | None" = None) -> list[str]:
+def pane_commands(
+    tab_id: str,
+    snapshot: "dict | None" = None,
+    *,
+    artifacts: "Sequence[ArtifactRow]" = (),
+) -> list[str]:
     """The slash command parallel to each row of ``tab_id``'s pane — index-aligned
     with :func:`pane_payload`'s rows for the same ``snapshot``, ``[]`` for a pane
     with no actionable rows. An empty string marks an inert row (a read-only
@@ -1228,8 +1281,10 @@ def pane_commands(tab_id: str, snapshot: "dict | None" = None) -> list[str]:
 
     This is what makes the restored categories OPERABLE rather than merely visible
     (#3338): the app maps a selected row straight onto ``/model`` / ``/attach`` /
-    ``/session switch`` / ``/visibility`` / ``/hook`` and submits it through the
-    same transport seam a typed slash uses."""
+    ``/session switch`` / ``/visibility`` / ``/hook`` / ``/open`` (#4482) and
+    submits it through the same transport seam a typed slash uses."""
+    if tab_id == "artifacts":
+        return artifact_pane_commands(artifacts)
     builder = _PANE_ENTRY_BUILDERS.get(tab_id)
     if builder is None:
         return []
@@ -1242,6 +1297,7 @@ def pane_payload(
     snapshot: "dict | None" = None,
     commands: "Iterable[SlashCommand]" = (),
     history: "Sequence[str]" = (),
+    artifacts: "Sequence[ArtifactRow]" = (),
     app_bindings: "Iterable[tuple[str, str]]" = (),
 ) -> list[str]:
     """The display rows for ``tab_id``'s drawer pane, derived from canonical reyn
@@ -1255,6 +1311,8 @@ def pane_payload(
         return [row for row, _cmd in builder(snap)]  # type: ignore[operator]
     if tab_id == "history":
         return history_pane_options(history)
+    if tab_id == "artifacts":
+        return artifact_pane_options(artifacts)
     if tab_id == "menu":
         return menu_pane_options(commands)
     if tab_id == "cost":

--- a/src/reyn/interfaces/repl/_open_with_os_default.py
+++ b/src/reyn/interfaces/repl/_open_with_os_default.py
@@ -1,0 +1,52 @@
+"""Open a local file with the OS's own default application (#4482 PR-3) —
+the same affordance nvim's `gx` or a file manager double-click give, never
+a reyn-chosen viewer.
+
+Sibling to `_clipboard.py` (same module, same shape): a thin per-platform
+dispatch to the OS's own opener (`open` / `xdg-open` / `os.startfile`),
+never a reyn-maintained handler table. `open`/`xdg-open`/`start` all pick
+the handler FROM THE FILE'S EXTENSION — architect's #4482 review named
+this explicitly: "拡張子が権限の実体である" (the extension IS the
+permission surface). This module does not — and must not — second-guess
+that: it launches the OS's own resolved handler, whatever that is on this
+machine, for whatever extension the file actually has. A `.pptx` opening
+in an office suite with macro support is that suite's own capability, not
+something this function grants or could withhold — nvim's `gx` carries
+the identical residue and does not gate on it either.
+
+Returns whether the OS ACCEPTED the request (the process launched) — never
+whether the opened application itself succeeded internally, which this
+process has no visibility into (same success bar as `copy_to_clipboard`).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def open_with_os_default(path: "str | Path") -> bool:
+    """Launch `path` with the OS's own default application for its
+    extension. Never raises — a missing opener binary, a nonexistent path,
+    or any other launch failure returns `False` rather than propagating,
+    matching `copy_to_clipboard`'s own established failure contract (the
+    caller reports it, this function just tells whether it happened)."""
+    target = str(path)
+    try:
+        if sys.platform == "darwin":
+            subprocess.Popen(
+                ["open", target], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+        elif sys.platform == "win32":
+            import os
+            os.startfile(target)  # type: ignore[attr-defined]
+        else:
+            subprocess.Popen(
+                ["xdg-open", target], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+        return True
+    except Exception:
+        return False
+
+
+__all__ = ["open_with_os_default"]

--- a/src/reyn/interfaces/slash/__init__.py
+++ b/src/reyn/interfaces/slash/__init__.py
@@ -306,6 +306,7 @@ from reyn.interfaces.slash import image as _image_mod  # noqa: E402, F401
 from reyn.interfaces.slash import matrix as _matrix_mod  # noqa: E402, F401
 from reyn.interfaces.slash import memory as _memory_mod  # noqa: E402, F401
 from reyn.interfaces.slash import model as _model_mod  # noqa: E402, F401
+from reyn.interfaces.slash import open_artifact as _open_artifact_mod  # noqa: E402, F401
 from reyn.interfaces.slash import pending as _pending_mod  # noqa: E402, F401
 from reyn.interfaces.slash import plugin as _plugin_mod  # noqa: E402, F401
 from reyn.interfaces.slash import quit as _quit_mod  # noqa: E402, F401

--- a/src/reyn/interfaces/slash/open_artifact.py
+++ b/src/reyn/interfaces/slash/open_artifact.py
@@ -1,0 +1,36 @@
+"""/open — open a generated artifact with the OS's own default app.
+
+#4482 PR-3. Takes the `ref` displayed on the artifact's list row and
+NOTHING else — architect's #4482 ruling: "開くのに使う path そのものを表示
+し、表示から実行まで同じ path を使う" (show the exact path used to open,
+and use that SAME path to execute). This command carries a ref, never a
+raw path (the artifact payload itself never puts a raw filesystem path on
+the wire — `artifact_payload.py`'s own invariant 1), and the client-side
+handler resolves that SAME ref to a path and opens exactly that.
+
+Sentinel-forwarding, matching `/copy`'s own established shape: this
+command's whole job is parsing the argument and forwarding it as an
+OutboxMessage the TUI's own output loop intercepts — the actual ref
+resolution + OS-launch happens client-side (needs `project_root`/
+`agent_name`, both readily available there, and "launch a local
+application" only makes sense on the machine the user is sitting at).
+
+Usage::
+
+    /open <ref>
+"""
+from __future__ import annotations
+
+from reyn.interfaces.slash import SlashContext, slash
+from reyn.runtime.outbox import OutboxMessage
+
+
+@slash(
+    "open",
+    summary="Open a generated artifact with the OS default app",
+    usage="/open <ref>",
+)
+async def open_cmd(ctx: "SlashContext", args: str) -> None:
+    ctx.transport.put_display(OutboxMessage(
+        kind="__open_artifact__", text=(args or "").strip(),
+    ))

--- a/src/reyn/interfaces/transport/agui/protocol.py
+++ b/src/reyn/interfaces/transport/agui/protocol.py
@@ -180,6 +180,11 @@ _REYN = "_reyn"
 CONTROL_FILTER_KINDS: "frozenset[str]" = frozenset({
     "__end__",
     "__session_switch_request__",
+    # #4482 PR-3: /open <ref> — local-only by construction (launching an OS
+    # app on the machine the client is running on); mirrors outbox.py's
+    # CONTROL_KINDS entry, kept in sync with it deliberately (see that
+    # module's own comment for why it's control-filtered, not profiled).
+    "__open_artifact__",
 })
 
 # Reserved frontend-tool namespace for the HITL round-trip (ADR-0039 P3, D6/R4).

--- a/src/reyn/runtime/outbox.py
+++ b/src/reyn/runtime/outbox.py
@@ -88,6 +88,16 @@ CONTROL_KINDS: "frozenset[str]" = frozenset({
     # `/session switch <sid>`: consumed at registry._forwarder (swallowed with
     # `continue` → attach_session); the AG-UI emitter also fail-safe-filters it.
     "__session_switch_request__",
+    # #4482 PR-3: `/open <ref>` sentinel — client-side ref-resolve + OS-launch
+    # (interfaces.inline.textual_chat.app._handle_open_artifact_request).
+    # Control-filtered (unlike /copy · /rewind's PROFILED forwarding) because
+    # "launch a local application" is local-only by construction — remote
+    # handling is explicitly deferred (owner ruling, #4482: "ローカル前提で
+    # 進めてください", remote tracked separately as #4494) — forwarding this
+    # on the wire today would just be a sentinel no remote client has a
+    # handler for, the exact silent-no-op shape the /copy·/rewind comment
+    # above warns about, not a real remote capability.
+    "__open_artifact__",
 })
 
 # The complete closed vocabulary of valid OutboxMessage.kind values.

--- a/tests/core/test_artifact_list_4482.py
+++ b/tests/core/test_artifact_list_4482.py
@@ -1,5 +1,9 @@
 """Tier 1: #4482 PR-3 — deriving the "open an artifact" list from resolved
-present nodes (`core/present/artifact_list.py`), pure functions only.
+present nodes (`core/present/artifact_list.py`).
+
+`collect_artifact_rows` is pure; `resolve_display_paths`/`stat_row` are the
+two functions that do real (isolated, caller-gated) I/O — see the module's
+own docstring for why that split exists.
 
 Fixtures are shaped like real `artifact_payload.py` (#4505/PR-2) output —
 `{"component": "artifact", "media_type": ..., "name": ..., "body": {...}}`
@@ -11,8 +15,10 @@ from __future__ import annotations
 from reyn.core.present.artifact_list import (
     ArtifactRow,
     collect_artifact_rows,
+    resolve_display_paths,
     stat_row,
 )
+from reyn.data.workspace.artifact_ref import mint_ref
 
 
 def _ref_node(name: str, ref: str, *, media_type: str = "text/html", description=None) -> dict:
@@ -137,3 +143,62 @@ def test_stat_row_returns_none_for_a_missing_file(tmp_path):
     out from under the list — #4478's GC domain) fails gracefully."""
     ghost = tmp_path / "gone.pptx"
     assert stat_row(ghost) is None
+
+
+# ── resolve_display_paths ────────────────────────────────────────────────
+
+
+def test_resolve_display_paths_sets_a_project_relative_path(tmp_path):
+    """Tier 1: #4482 PR-3 review fix — a resolvable ref gets a real,
+    project-root-relative `resolved_path`, via the SAME `resolve_ref`
+    the open path itself calls (real mint, real file, real resolve — no
+    hand-built fixture standing in for the resolution)."""
+    sub = tmp_path / "reports"
+    sub.mkdir()
+    target = sub / "q1.pptx"
+    target.write_text("bytes")
+    ref = mint_ref(tmp_path, "default", target)
+
+    row = ArtifactRow(ref=ref, name="q1.pptx", media_type=None, description=None, is_inline=False)
+    resolved = resolve_display_paths([row], tmp_path, "default")
+    assert resolved[0].resolved_path == "reports/q1.pptx"
+
+
+def test_resolve_display_paths_disambiguates_same_named_files(tmp_path):
+    """Tier 1: the exact failure mode the review named — two files with
+    the SAME basename in different directories must resolve to
+    DIFFERENT display paths, not the same ambiguous name twice."""
+    dir_a, dir_b = tmp_path / "a", tmp_path / "b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+    (dir_a / "report.pptx").write_text("a")
+    (dir_b / "report.pptx").write_text("b")
+    ref_a = mint_ref(tmp_path, "default", dir_a / "report.pptx")
+    ref_b = mint_ref(tmp_path, "default", dir_b / "report.pptx")
+
+    rows = [
+        ArtifactRow(ref=ref_a, name="report.pptx", media_type=None, description=None, is_inline=False),
+        ArtifactRow(ref=ref_b, name="report.pptx", media_type=None, description=None, is_inline=False),
+    ]
+    resolved = resolve_display_paths(rows, tmp_path, "default")
+    paths = {r.resolved_path for r in resolved}
+    assert paths == {"a/report.pptx", "b/report.pptx"}
+
+
+def test_resolve_display_paths_leaves_an_unresolvable_ref_alone(tmp_path):
+    """Tier 1: an unknown/deleted ref's `resolved_path` stays `None` — the
+    display layer falls back to `name`, the best available answer when
+    there is genuinely nothing to resolve."""
+    row = ArtifactRow(
+        ref="unknown-ref", name="ghost.pptx", media_type=None, description=None, is_inline=False,
+    )
+    resolved = resolve_display_paths([row], tmp_path, "default")
+    assert resolved[0].resolved_path is None
+
+
+def test_resolve_display_paths_leaves_an_inline_row_alone(tmp_path):
+    """Tier 1: an inline row (`ref is None`) has nothing to resolve — no
+    resolve_ref call, `resolved_path` stays `None`."""
+    row = ArtifactRow(ref=None, name="(inline)", media_type=None, description=None, is_inline=True)
+    resolved = resolve_display_paths([row], tmp_path, "default")
+    assert resolved[0].resolved_path is None

--- a/tests/core/test_artifact_list_4482.py
+++ b/tests/core/test_artifact_list_4482.py
@@ -1,0 +1,139 @@
+"""Tier 1: #4482 PR-3 — deriving the "open an artifact" list from resolved
+present nodes (`core/present/artifact_list.py`), pure functions only.
+
+Fixtures are shaped like real `artifact_payload.py` (#4505/PR-2) output —
+`{"component": "artifact", "media_type": ..., "name": ..., "body": {...}}`
+— not hand-waved shortcuts, so a schema drift in the payload builder would
+show up here as a shape these tests stop recognizing.
+"""
+from __future__ import annotations
+
+from reyn.core.present.artifact_list import (
+    ArtifactRow,
+    collect_artifact_rows,
+    stat_row,
+)
+
+
+def _ref_node(name: str, ref: str, *, media_type: str = "text/html", description=None) -> dict:
+    node = {
+        "component": "artifact", "media_type": media_type, "name": name,
+        "body": {"ref": ref, "size": 123},
+    }
+    if description is not None:
+        node["description"] = description
+    return node
+
+
+def _inline_node(name: str, *, media_type: str = "text/plain") -> dict:
+    return {
+        "component": "artifact", "media_type": media_type, "name": name,
+        "body": {"inline": "hello"},
+    }
+
+
+def test_collects_a_reference_backed_artifact():
+    """Tier 1: a source-backed (ref) artifact node becomes an openable row."""
+    rows = collect_artifact_rows([[_ref_node("report.pptx", "abc123")]])
+    assert rows == [ArtifactRow(
+        ref="abc123", name="report.pptx", media_type="text/html",
+        description=None, is_inline=False,
+    )]
+
+
+def test_inline_artifact_has_no_ref_and_is_marked_inline():
+    """Tier 1: an inline (no-real-file) artifact has nothing for the OS to
+    open — ref is None, is_inline is True, distinguishable from a
+    reference-backed row."""
+    rows = collect_artifact_rows([[_inline_node("snippet.txt")]])
+    assert rows[0].ref is None
+    assert rows[0].is_inline is True
+
+
+def test_soft_binding_miss_produces_no_row():
+    """Tier 1: `{"component": "artifact"}` alone (present's existing
+    soft-skip shape for an unresolved binding) yields nothing displayable
+    yet — not a crash, not a blank row."""
+    rows = collect_artifact_rows([[{"component": "artifact"}]])
+    assert rows == []
+
+
+def test_error_marker_still_produces_a_row_naming_the_failure():
+    """Tier 1: a `source_not_found` error marker (apply_artifact_resolution's
+    own shape for a missing file) is still LISTED — distinguishable from a
+    healthy row (error set, ref None) so the user sees why it can't open,
+    rather than the row silently vanishing."""
+    node = {"component": "artifact", "error": "source_not_found"}
+    rows = collect_artifact_rows([[node]])
+    assert rows[0].error == "source_not_found"
+    assert rows[0].ref is None
+
+
+def test_non_artifact_nodes_are_ignored():
+    """Tier 1: a present node from any other component (image/text/table/…)
+    never contributes a row — this list is artifact-only."""
+    rows = collect_artifact_rows([[{"component": "text", "text": "hi"}]])
+    assert rows == []
+
+
+def test_order_is_newest_first_across_messages():
+    """Tier 1: the list reads newest-first — `node_lists` is walked in the
+    caller's own (oldest-to-newest) message order and REVERSED, so the
+    caller (FlowView entries, oldest-first) needs no pre-sorting of its
+    own."""
+    rows = collect_artifact_rows([
+        [_ref_node("first.pptx", "ref-1")],
+        [_ref_node("second.pptx", "ref-2")],
+        [_ref_node("third.pptx", "ref-3")],
+    ])
+    assert [r.name for r in rows] == ["third.pptx", "second.pptx", "first.pptx"]
+
+
+def test_order_is_newest_first_within_one_message_too():
+    """Tier 1: multiple artifact nodes in the SAME message (e.g. an agent
+    presenting two files in one turn) also come out newest-first — the
+    later node in that message's own node list is "newer" within the turn."""
+    rows = collect_artifact_rows([
+        [_ref_node("a.pptx", "ref-a"), _ref_node("b.pptx", "ref-b")],
+    ])
+    assert [r.name for r in rows] == ["b.pptx", "a.pptx"]
+
+
+def test_empty_input_yields_empty_list():
+    """Tier 1: no messages, or messages with no nodes at all, is a no-op —
+    not an error."""
+    assert collect_artifact_rows([]) == []
+    assert collect_artifact_rows([[], []]) == []
+
+
+def test_a_malformed_node_entry_is_skipped_not_fatal():
+    """Tier 1: a non-dict entry in a node list (should never happen given
+    the catalog's own structural gate, but this module doesn't trust its
+    caller blindly) is skipped rather than raising."""
+    rows = collect_artifact_rows([["not-a-dict", _ref_node("ok.pptx", "ref-ok")]])
+    assert [r.name for r in rows] == ["ok.pptx"]
+
+
+# ── stat_row ──────────────────────────────────────────────────────────────
+
+
+def test_stat_row_returns_none_for_a_none_path():
+    """Tier 1: no resolved path (e.g. a deleted or unresolvable ref) — no
+    I/O attempted, None returned."""
+    assert stat_row(None) is None
+
+
+def test_stat_row_returns_the_real_size(tmp_path):
+    """Tier 1: a real file's current size, read via a single stat() call —
+    this test is the one place in this file real filesystem I/O happens,
+    matching the module's own claim that stat_row is its ONLY I/O."""
+    p = tmp_path / "real.pptx"
+    p.write_bytes(b"x" * 42)
+    assert stat_row(p) == 42
+
+
+def test_stat_row_returns_none_for_a_missing_file(tmp_path):
+    """Tier 1: a path that resolved once but no longer exists (deleted
+    out from under the list — #4478's GC domain) fails gracefully."""
+    ghost = tmp_path / "gone.pptx"
+    assert stat_row(ghost) is None

--- a/tests/core/test_open_with_os_default_4482.py
+++ b/tests/core/test_open_with_os_default_4482.py
@@ -1,0 +1,59 @@
+"""Tier 1/2: #4482 PR-3 — `open_with_os_default` (`interfaces/repl/
+_open_with_os_default.py`), the OS-opener dispatch.
+
+Real subprocess launch via a fake `open`/`xdg-open` binary on PATH (same
+technique `test_copy_mode_3507.py`'s clipboard tests use) — proves the
+REAL platform-selection branch fires and REAL argv reaches a real
+subprocess, not a claim about the function's own internal logic in
+isolation."""
+from __future__ import annotations
+
+import os
+import stat
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from reyn.interfaces.repl._open_with_os_default import open_with_os_default
+
+
+def _install_fake_opener(tmp_path, monkeypatch, *, name: str) -> Path:
+    """A fake `open`/`xdg-open` on PATH that records the path it was
+    called with, for real subprocess-launch verification."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    sink = tmp_path / "opened.txt"
+    script = bindir / name
+    script.write_text(f"#!/bin/sh\necho \"$1\" > {sink}\n")
+    script.chmod(script.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setenv("PATH", str(bindir) + os.pathsep + os.environ["PATH"])
+    return sink
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="darwin/linux opener path only")
+def test_real_subprocess_launch_reaches_the_target_path(tmp_path, monkeypatch):
+    """Tier 2: the actual platform opener (`open` on darwin, `xdg-open`
+    elsewhere) is invoked with the real target path — a real subprocess
+    launch, verified via a fake binary on PATH that writes what it
+    received."""
+    opener_name = "open" if sys.platform == "darwin" else "xdg-open"
+    sink = _install_fake_opener(tmp_path, monkeypatch, name=opener_name)
+    target = tmp_path / "report.pptx"
+    target.write_text("fake pptx bytes")
+
+    ok = open_with_os_default(target)
+    assert ok is True
+
+    while not sink.exists():  # unbounded — CI's own timeout is the backstop
+        time.sleep(0.05)
+    assert sink.read_text().strip() == str(target)
+
+
+def test_returns_false_when_the_opener_binary_is_missing(monkeypatch, tmp_path):
+    """Tier 1: no opener on PATH at all — Popen raises FileNotFoundError,
+    caught and reported as False, never propagated to the caller."""
+    monkeypatch.setenv("PATH", str(tmp_path))  # an empty directory, no opener binaries
+    ok = open_with_os_default(tmp_path / "whatever.pptx")
+    assert ok is False

--- a/tests/interfaces/test_artifact_list_and_open_4482.py
+++ b/tests/interfaces/test_artifact_list_and_open_4482.py
@@ -18,7 +18,11 @@ from textual_flowview import FlowView
 
 from reyn.data.workspace.artifact_ref import mint_ref
 from reyn.interfaces.inline.textual_chat import TextualChatApp
-from reyn.interfaces.inline.textual_chat.chrome import artifact_pane_commands, artifact_pane_options
+from reyn.interfaces.inline.textual_chat.chrome import (
+    artifact_pane_commands,
+    artifact_pane_options,
+    artifact_row_label,
+)
 from reyn.runtime.outbox import OutboxMessage
 from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
 from tests._support.textual_chat_test_helpers import QueueTransport
@@ -75,6 +79,53 @@ async def test_newest_artifact_sorts_first_across_multiple_presentations():
 
         rows = app._artifact_rows()
         assert [r.name for r in rows] == ["second.pptx", "first.pptx"]
+
+
+@pytest.mark.asyncio
+async def test_same_named_artifacts_in_different_directories_are_distinguishable(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: #4482 PR-3 review block (lead-coder/architect) — a bare
+    basename cannot tell two same-named artifacts in different
+    directories apart, failing the arc's one non-negotiable requirement
+    (the user sees the REAL thing about to open). This proves the FIX:
+    with real refs minted against two REAL files both named
+    `report.pptx` in different subdirectories, the row labels differ
+    (each shows its own project-root-relative path), not the same
+    ambiguous `report.pptx` twice."""
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    dir_a = tmp_path / "q1"
+    dir_a.mkdir()
+    file_a = dir_a / "report.pptx"
+    file_a.write_text("q1 report")
+    ref_a = mint_ref(tmp_path, "default", file_a)
+
+    dir_b = tmp_path / "q2"
+    dir_b.mkdir()
+    file_b = dir_b / "report.pptx"
+    file_b.write_text("q2 report")
+    ref_b = mint_ref(tmp_path, "default", file_b)
+
+    app = TextualChatApp(transport=QueueTransport())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._ingest_frame(_presentation_frame(name="report.pptx", ref=ref_a))
+        await pilot.pause()
+        app._ingest_frame(_presentation_frame(name="report.pptx", ref=ref_b))
+        await pilot.pause()
+
+        rows = app._artifact_rows()
+        labels = [artifact_row_label(r) for r in rows]
+        assert len(set(labels)) == 2, (
+            f"same-named artifacts in different directories must show "
+            f"distinguishable rows, got: {labels}"
+        )
+        assert "q1/report.pptx" in labels
+        assert "q2/report.pptx" in labels
+        # And neither label is the bare, ambiguous basename alone.
+        assert "report.pptx" not in labels
 
 
 @pytest.mark.asyncio

--- a/tests/interfaces/test_artifact_list_and_open_4482.py
+++ b/tests/interfaces/test_artifact_list_and_open_4482.py
@@ -1,0 +1,134 @@
+"""Tier 2: #4482 PR-3 — the Artifacts tab (list + open) through the REAL
+TextualChatApp, a REAL FlowView, and a REAL `artifact_ref` mint/resolve
+round-trip. No mocks of reyn's own logic — only a fake OS-opener binary on
+PATH (the same technique `test_copy_mode_3507.py`'s clipboard tests use;
+launching a REAL external application from a test is neither possible nor
+desirable, so the boundary this test owns is "reyn resolved the right path
+and launched a subprocess with it", not "an app window opened").
+"""
+from __future__ import annotations
+
+import os
+import stat
+import sys
+import time
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.data.workspace.artifact_ref import mint_ref
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.chrome import artifact_pane_commands, artifact_pane_options
+from reyn.runtime.outbox import OutboxMessage
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+from tests._support.textual_chat_test_helpers import QueueTransport
+
+
+def _presentation_frame(*, name: str, ref: str, media_type: str = "text/html") -> OutboxMessage:
+    return OutboxMessage(
+        kind="presentation",
+        text="",
+        meta={"nodes": [{
+            "component": "artifact",
+            "media_type": media_type,
+            "name": name,
+            "body": {"ref": ref, "size": 999},
+        }]},
+    )
+
+
+@pytest.mark.asyncio
+async def test_artifact_row_appears_in_the_pane_after_a_real_presentation_frame():
+    """Tier 2: a real `presentation` frame carrying a resolved artifact node,
+    ingested through the real app, produces a real Artifacts-pane row —
+    exercising `_artifact_rows()` -> `collect_artifact_rows` against a REAL
+    `self.conversation` FlowModel (invariant 3's own source), not a hand-built
+    fixture list."""
+    app = TextualChatApp(transport=QueueTransport())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._ingest_frame(_presentation_frame(name="report.pptx", ref="abc123"))
+        await pilot.pause()
+
+        rows = app._artifact_rows()
+        assert [r.name for r in rows] == ["report.pptx"]
+        assert rows[0].ref == "abc123"
+
+        pane_rows = artifact_pane_options(rows)
+        assert pane_rows == ["report.pptx"]
+        pane_cmds = artifact_pane_commands(rows)
+        assert pane_cmds == ["/open abc123"]
+
+
+@pytest.mark.asyncio
+async def test_newest_artifact_sorts_first_across_multiple_presentations():
+    """Tier 2: two separate presentation turns, newest artifact first —
+    exercising real FlowView entry ORDER (`self.conversation` iteration),
+    not a synthetic list the pure module was already unit-tested against."""
+    app = TextualChatApp(transport=QueueTransport())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._ingest_frame(_presentation_frame(name="first.pptx", ref="ref-1"))
+        await pilot.pause()
+        app._ingest_frame(_presentation_frame(name="second.pptx", ref="ref-2"))
+        await pilot.pause()
+
+        rows = app._artifact_rows()
+        assert [r.name for r in rows] == ["second.pptx", "first.pptx"]
+
+
+@pytest.mark.asyncio
+async def test_open_artifact_end_to_end_resolves_the_real_ref_and_launches_the_opener(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: the full `/open <ref>` path — sentinel dispatch, REAL
+    `resolve_ref` (against a REAL minted ref, REAL project_root), REAL
+    subprocess launch to a fake opener on PATH. Proves the ref shown on
+    the row is the SAME ref that ends up opening the SAME file
+    (architect's #4482 requirement) — not by inspection of the code, but
+    by observing the actual file the fake opener received."""
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
+    target = tmp_path / "report.pptx"
+    target.write_text("fake pptx bytes")
+    ref = mint_ref(tmp_path, "default", target)  # the SAME mint the real
+    # artifact_payload.py pipeline would have performed when presenting it
+
+    opener_name = "open" if sys.platform == "darwin" else "xdg-open"
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    sink = tmp_path / "opened.txt"
+    script = bindir / opener_name
+    script.write_text(f"#!/bin/sh\necho \"$1\" > {sink}\n")
+    script.chmod(script.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setenv("PATH", str(bindir) + os.pathsep + os.environ["PATH"])
+    monkeypatch.chdir(tmp_path)
+
+    app = TextualChatApp(transport=QueueTransport())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._ingest_frame(_presentation_frame(name="report.pptx", ref=ref))
+        await pilot.pause()
+
+        await app._handle_open_artifact_request(ref)
+        await pilot.pause()
+
+        while not sink.exists():  # unbounded — CI's own timeout is the backstop
+            time.sleep(0.05)
+        assert sink.read_text().strip() == str(target)
+
+
+@pytest.mark.asyncio
+async def test_open_artifact_with_an_unresolvable_ref_reports_not_found(tmp_path, monkeypatch):
+    """Tier 2: a ref that resolves to nothing (unknown, or the file is
+    gone) reports a status line — never a silent no-op, never a crash."""
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    app = TextualChatApp(transport=QueueTransport())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app._handle_open_artifact_request("does-not-exist")
+        await pilot.pause()
+
+        entry = list(app.query_one(FlowView).entries)[-1]
+        assert "not found" in entry.item.text


### PR DESCRIPTION
**[tui-coder]** — part of #4482 (PR-3 of the arc)

Prerequisites landed: PR-1 (#4498, ref->path table + fetch endpoint), PR-2 (#4505, present artifact payload construction), PR-2b (#4509, catalog/binding wiring + `handle()`).

## What this adds

An **Artifacts** tab (bottom-chrome drawer, label `Art`) listing every resolved `component="artifact"` present node, newest-first, with an `/open <ref>` action per row that launches the OS's own default app (`open`/`xdg-open`/`os.startfile`) on the resolved path — the same affordance nvim's `gx` or a file manager double-click give, never a reyn-chosen viewer.

## Invariant 3 (repeated verbatim across the whole #4482 dispatch thread)

The list is derived from `self.conversation` — the app's own live `FlowModel`, the SAME message source the conversation pane itself renders — **never** `Session.history`'s resident buffer, which has its own independent eviction axis (#4387/#4468) that can silently drop a still-visible artifact from a list built off it. `_artifact_rows()`'s own docstring records this explicitly.

## No new persisted state (owner/architect ruling)

`core/present/artifact_list.py`'s `collect_artifact_rows` is pure, deriving the list fresh from each message's already-resolved payload — no separate on-disk index, no cache kept warm across calls. Deliberately named apart from `core/events/retention.py` (ADR-0038's WAL/generation reconstruction window) — same "retention" word, unrelated concept, the exact conflation CLAUDE.md's cross-cutting-band note bans for "event".

## Architect's ruling, satisfied structurally

> 開くのに使う path そのものを表示し、表示から実行まで同じ path を使う

The row shows `name` (never a bare ref), the `/open <ref>` command carries the SAME ref shown on the row, and `_handle_open_artifact_request` resolves that ref via the one path both PR-1's fetch endpoint and this client use (`artifact_ref.resolve_ref`) — never a second, independently-maintained path-resolution path.

## Local-only by construction

`__open_artifact__` is control-filtered (`outbox.py`'s `CONTROL_KINDS`, mirrored in `agui/protocol.py`'s `CONTROL_FILTER_KINDS` — kept in sync deliberately), not profiled/forwarded like `/copy`/`/rewind`: "launch a local application" is local-only, and remote handling is explicitly deferred (owner ruling → tracked separately as #4494).

## Extension = permission surface (unchanged, not second-guessed)

`open`/`xdg-open`/`start` all pick the handler FROM THE FILE'S EXTENSION (architect: "拡張子が権限の実体である") — `_open_with_os_default.py` does not, and must not, second-guess that.

## Falsify-verify

A real bug caught by the end-to-end test itself before this commit — `_handle_open_artifact_request`'s not-found branch used `OutboxMessage` without a local import (every other sentinel handler in this file does its own), raising `NameError` at runtime. Fixed in the same commit, confirmed by re-running the test that caught it.

## Test plan

- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict` on new test files — 18/18 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (212/215 baselined, no new)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK (re-run against current `origin/main` right before push)
- [x] `pytest tests/interfaces/` (full) — 1658 passed, 3 skipped (unrelated optional-dependency extras)
- [x] `pytest tests/core/` outbox+protocol+agui+slash subset — 32 passed
- [x] Falsify-verify — real `NameError` caught and fixed, confirmed by the same test
- [x] (skipped — N/A, no way to visually confirm a TUI drawer tab pre-merge; will confirm on `main` post-merge)

tests/ touched — TESTS-READ wait, no self-merge.


---

- [x] 🔴 **[lead-coder]**（reviewer 確認済 — `resolved_path`（project_root 相対）を表示し、`_handle_open_artifact_request` が開く直前に呼ぶ**同じ** `resolve_ref` を再利用。同名ファイルの区別を falsify 済）行に出るのが `row.name` ＝ **basename のみ**（`artifact_payload.py:119` `name = resolved.name`）。architect の裁定「開くのに使う path そのものを表示し、表示から実行まで同じ path を使う」と #4482 本文の唯一の要件「ユーザが何を開こうとしているか**実体が見える**こと」に届いていない — 同名の成果物が別ディレクトリに在ると行から区別できず、どこに在るか分からないまま OS アプリを起動することになる。client は開く直前に `resolve_ref` でパスを持つので、**解決済みパス（または project_root 相対）を行か確認に出す**こと。線に載せない invariant とは矛盾しない。

