### PR TITLE
fix(#4515): stop config_schema from falsely reporting external_transports as unknown

### DIFF
--- a/src/reyn/config/config_schema.py
+++ b/src/reyn/config/config_schema.py
@@ -420,6 +420,27 @@ def unknown_config_keys(
     is the one example — #3823's own vocabulary, folded in rather than
     duplicated).
 
+    **#4515 incident**: recursing into a namespace assumes the RAW config
+    shape mirrors the DATACLASS shape exactly, one nesting level per
+    field. That broke for ``external_transports`` — its field type
+    (``ExternalTransportRouting``) wraps a single ``transports: dict``
+    field for the wrapper's own ``.get(name)`` convenience, but the real
+    reyn.yaml has no ``transports:`` key at all (the operator writes
+    ``external_transports: {broker: {...}}`` directly). The walk
+    registered the dict-leaf one level too deep
+    (``external_transports.transports``), so EVERY real transport name
+    matched none of ``namespaces``/``dict_leaves``/``scalar_leaves`` and
+    was reported "not recognized ... NOT APPLIED" — while
+    ``loader.py``'s ``_build_external_transports_config`` was, in fact,
+    applying it correctly the whole time. A false "not applied" is worse
+    than no warning: an operator reads it as "this setting does
+    nothing" and deletes working config (architect hit this directly
+    setting up reyn-gpt, #4501). Fixed via ``field(metadata={'dict_leaf':
+    True})`` (see :func:`_is_dict_leaf_override`) — a reusable escape
+    hatch for the whole SHAPE class (a wrapper dataclass around one dict
+    field whose own name never appears in real config), not a
+    single-field patch.
+
     A ``None`` hint means "this key matches none of the known keys — see
     ``reyn config fields``" (a typo, or a key that never existed at all).
     A :class:`RenamedKeyHint` means the key MOVED (see
@@ -723,8 +744,23 @@ def _walk(
         dotkey = f"{prefix}.{fname}" if prefix else fname
         inner = _unwrap_optional(ftype)
 
-        if _is_dict_type(inner):
+        if _is_dict_type(inner) or _is_dict_leaf_override(dc_field):
             # Free-form dict leaf — operator may set arbitrary sub-keys.
+            # #4515: `_is_dict_leaf_override` covers a field whose TYPE is a
+            # dataclass wrapper around exactly one dict field (e.g.
+            # `ExternalTransportRouting(transports: dict)`) but whose REAL
+            # reyn.yaml shape has no nested wrapper key — the operator writes
+            # `external_transports: {broker: {...}}` directly, never
+            # `external_transports: {transports: {broker: {...}}}`. Without
+            # this override the recursion below registers the dict-leaf as
+            # `external_transports.transports` (matching the DATACLASS, not
+            # the real config), so every real transport name looks unknown —
+            # a false "NOT APPLIED" warning on config that IS applied (see
+            # `unknown_config_keys`'s own docstring for the full incident).
+            # Emitted at THIS field's own dotkey (the wrapper), never the
+            # inner field's — the wrapper class itself stays unchanged (its
+            # `.transports`/`.get()` convenience API is a separate concern
+            # from what the operator-facing schema shape is).
             desc = _field_desc(dc_field)
             default = _field_default(dc_field)
             nodes.append(SchemaNode(
@@ -771,4 +807,24 @@ def _is_schema_internal(f: dataclasses.Field) -> bool:  # type: ignore[type-arg]
     meta = getattr(f, "metadata", None)
     if meta and isinstance(meta, typing.Mapping):
         return bool(meta.get("schema_internal", False))
+    return False
+
+
+def _is_dict_leaf_override(f: dataclasses.Field) -> bool:  # type: ignore[type-arg]
+    """True when a dataclass-typed field should be schema-classified as a
+    free-form dict leaf (#4515) rather than recursed into as a namespace.
+
+    A field flags itself with ``field(metadata={'dict_leaf': True})`` when
+    its TYPE is a wrapper dataclass around exactly one dict field but its
+    REAL reyn.yaml shape has no nested key matching that wrapped field's
+    name — the wrapper exists for the TYPE's own consumers (a
+    ``.get(name)`` convenience method, e.g.), not because the operator
+    ever writes that extra nesting level. Without this override,
+    ``_walk`` would recurse into the wrapper and register the dict-leaf
+    one level too deep, so every real operator-written sub-key falsely
+    reads as unknown (see :func:`unknown_config_keys`'s own docstring for
+    the #4515 incident this fixes)."""
+    meta = getattr(f, "metadata", None)
+    if meta and isinstance(meta, typing.Mapping):
+        return bool(meta.get("dict_leaf", False))
     return False

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -280,8 +280,19 @@ class ReynConfig:
     # LINE / Discord etc.). Empty by default; operator declares
     # transport → MCP tool mapping in reyn.yaml ``external_transports``.
     # See ``reyn.runtime.external_routing.ExternalTransportRouting``.
+    # #4515: ``dict_leaf`` metadata — ``ExternalTransportRouting`` wraps a
+    # single ``transports: dict`` field for its own consumers'
+    # ``.get(name)`` convenience, but the real reyn.yaml shape has no
+    # nested ``transports:`` key (the operator writes
+    # ``external_transports: {broker: {...}}`` directly). Without this
+    # flag the schema walk recurses into the wrapper and registers the
+    # dict-leaf as ``external_transports.transports`` — one level too
+    # deep — so every real transport name falsely reads as an unknown
+    # key (config_schema.py's ``unknown_config_keys`` docstring has the
+    # full incident this fixes).
     external_transports: "ExternalTransportRouting" = field(
         default_factory=lambda: _empty_external_transports(),
+        metadata={"dict_leaf": True},
     )
     # #2548 PR-A: skill registry config. Raw dict passed to
     # reyn.data.skills.registry.build_skill_registry at session /

--- a/tests/config/test_external_transports_schema_4515.py
+++ b/tests/config/test_external_transports_schema_4515.py
@@ -1,0 +1,124 @@
+"""Tier 1/2: #4515 — a real `external_transports:` config was falsely
+reported "not recognized ... NOT APPLIED", when `loader.py`'s
+`_build_external_transports_config` was in fact applying it correctly.
+
+Root cause: `ReynConfig.external_transports`'s field TYPE
+(`ExternalTransportRouting`) wraps a single `transports: dict` field for
+the wrapper's own `.get(name)` convenience — but the real reyn.yaml shape
+has no nested `transports:` key at all (`external_transports: {broker:
+{...}}` directly). The schema walk recursed into the wrapper and
+registered the dict-leaf one level too deep
+(`external_transports.transports`), so every real transport name matched
+none of the known-key sets.
+
+Fixed via `field(metadata={'dict_leaf': True})` — a reusable escape hatch
+(`config_schema._is_dict_leaf_override`) for the whole shape class, not a
+single-field patch. `mcp`/`skills`/`pipelines`/`presentations` were
+audited as the "family" (lead-coder's own instruction) and confirmed
+NOT to share this bug — they're declared as bare `dict` fields directly
+on `ReynConfig`, never wrapped in an intermediate dataclass, so they
+never had the mismatch in the first place.
+"""
+from __future__ import annotations
+
+from reyn.config import config_schema
+from reyn.config.loader import _warn_unknown_config_keys
+
+
+def test_external_transports_with_a_real_transport_name_is_not_flagged_unknown():
+    """Tier 1: #4515's own reproduction — a real `broker` transport under
+    `external_transports:` must not be reported unknown."""
+    result = config_schema.unknown_config_keys({
+        "external_transports": {
+            "broker": {"mcp_tool": "broker__post_message", "args_template": {}},
+        },
+    })
+    assert result == {}
+
+
+def test_external_transports_is_a_dict_leaf_at_its_own_key():
+    """Tier 1: the schema registers `external_transports` itself as a
+    dict-leaf — never a deeper `external_transports.transports` node
+    that no real config ever reaches."""
+    by_key = {n.key: n for n in config_schema.walk_config_schema()}
+    assert by_key["external_transports"].is_dict_leaf is True
+    assert "external_transports.transports" not in by_key
+
+
+def test_external_transports_is_a_known_top_level_key():
+    """Tier 1: regression guard for `known_top_level_keys()`, the OTHER
+    consumer of the same schema walk (#4174 T0's single-source-of-truth
+    requirement)."""
+    assert "external_transports" in config_schema.known_top_level_keys()
+
+
+def test_a_genuinely_unknown_key_is_still_flagged():
+    """Tier 1: the fix does not over-broaden — an actually-unknown
+    top-level key is still reported (the fix targets the ONE mismatched
+    field, not the detector in general)."""
+    result = config_schema.unknown_config_keys({"totally_bogus_key": 1})
+    assert "totally_bogus_key" in result
+
+
+def test_sandbox_policy_invalid_sub_key_is_still_flagged():
+    """Tier 1: regression guard — `sandbox.policy`'s own registered
+    freeform-leaf validator (an unrelated dict-leaf mechanism, #3823)
+    still rejects a truly invalid sub-key; the #4515 fix does not touch
+    it."""
+    result = config_schema.unknown_config_keys({
+        "sandbox": {"policy": {"not_a_real_policy_key": 1}},
+    })
+    assert "sandbox.policy.not_a_real_policy_key" in result
+
+
+def test_end_to_end_warn_unknown_config_keys_no_longer_flags_a_real_transport():
+    """Tier 2: the REAL operator-visible symptom (#4515's own
+    reproduction) through `_warn_unknown_config_keys` — the exact
+    function that generates "config key ... is not recognized ... it was
+    NOT APPLIED" — no longer flags a real `external_transports:` block."""
+    result = _warn_unknown_config_keys({
+        "external_transports": {
+            "broker": {"mcp_tool": "broker__post_message", "args_template": {}},
+        },
+    })
+    assert result == {}
+
+
+# ── family sweep (lead-coder: "1 つ直して終わりにしない ── 族で探す") ──────
+
+
+def test_mcp_servers_arbitrary_name_still_recognized():
+    """Tier 1: `mcp:` (bare dict field, no wrapper dataclass) never had
+    the #4515 mismatch — confirmed as part of the family sweep, not
+    assumed."""
+    result = config_schema.unknown_config_keys({
+        "mcp": {"servers": {"my_server": {"command": "foo"}}},
+    })
+    assert result == {}
+
+
+def test_llm_router_fallbacks_arbitrary_name_still_recognized():
+    """Tier 1: `llm.router.fallbacks` — its builder reads
+    `raw.get("fallbacks", ...)`, matching the schema's own nesting
+    exactly (unlike external_transports's builder, which received the
+    whole section with no wrapper key). Confirmed, not assumed."""
+    result = config_schema.unknown_config_keys({
+        "llm": {"router": {"fallbacks": {"gpt-4": ["gpt-3.5"]}}},
+    })
+    assert result == {}
+
+
+def test_auth_providers_arbitrary_name_still_recognized():
+    """Tier 1: `auth.providers` — same audit as above."""
+    result = config_schema.unknown_config_keys({
+        "auth": {"providers": {"github": {"client_id": "x"}}},
+    })
+    assert result == {}
+
+
+def test_gateway_surfaces_enabled_arbitrary_name_still_recognized():
+    """Tier 1: `gateway.surfaces.enabled` — same audit as above."""
+    result = config_schema.unknown_config_keys({
+        "gateway": {"surfaces": {"enabled": {"web_ui": True}}},
+    })
+    assert result == {}


### PR DESCRIPTION
**[tui-coder]** — Closes #4515 (severity:high)

lead-coder reproduced and dispatched. A real `external_transports:<name>` config was reported "config key ... is not recognized ... it was NOT APPLIED" while `loader.py`'s own `_build_external_transports_config` was applying it correctly the whole time. A false "not applied" is worse than no warning: an operator reads it as "this setting does nothing" and deletes working config — architect hit this directly setting up reyn-gpt (#4501).

## Root cause

`ReynConfig.external_transports`'s field TYPE (`ExternalTransportRouting`) wraps a single `transports: dict` field for the wrapper's own `.get(name)` convenience, but the real reyn.yaml shape has no nested `transports:` key at all — the operator writes `external_transports: {broker: {...}}` directly. `config_schema`'s walk recursed into the wrapper (a nested dataclass) and registered the dict-leaf one level too deep (`external_transports.transports`), so every real transport name matched none of the known-key sets.

## Fix

`field(metadata={'dict_leaf': True})` on the `ReynConfig` field itself — a reusable escape hatch (`_is_dict_leaf_override`, mirroring the existing `schema_internal` metadata-flag pattern) for the whole SHAPE class (a wrapper dataclass around one dict field whose own name never appears in real config), not a single-field patch. `external_transports` is now registered as ONE dict-leaf node at its own key, matching real config exactly.

## Family sweep (lead-coder's explicit instruction — "1つ直して終わりにしない ── 族で探す")

Audited every other "arbitrary name as key" section (`mcp.servers`, `llm.router.fallbacks`/`retry_policy`, `auth.providers`, `gateway.surfaces.enabled`) and confirmed none share this mismatch:
- `mcp`/`skills`/`pipelines`/`presentations` are declared as bare `dict` fields directly on `ReynConfig` (no wrapper dataclass, no mismatch possible).
- The others' builders read `raw.get(<wrapped-field-name>)`, matching the schema's own nesting exactly (unlike `external_transports`'s builder, which received the whole section with no wrapper key).

## Falsify-verify

3 of the 10 new tests fail with the metadata flag reverted, reproducing the exact operator-visible warning text (`config key 'external_transports.broker' is not recognized — it was NOT APPLIED`).

## Test plan

- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict` on the new test file — one Tier-4 format-pin (`len(nodes) == 1`) self-caught and fixed before final pass; 10/10 OK
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (212/215 baselined, no new)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/config/` (full) — 185 passed
- [x] `pytest` config-schema/external-routing/outbox-interceptor subset (`tests/interfaces/` + `tests/runtime/` + `tests/web/`) — 300 passed
- [x] `pytest tests/core/` config-related subset — 125 passed
- [x] Falsify-verify — 3/10 new tests genuinely fail with the fix reverted, reproducing the exact warning text
- [x] (skipped — N/A, no UI change; config-load warning text only)

tests/ touched — TESTS-READ wait, no self-merge.
