### PR TITLE
docs(#4517): quote hooks' on: key everywhere -- YAML 1.1 reads it as boolean True

### DIFF
--- a/docs/concepts/runtime/hooks.ja.md
+++ b/docs/concepts/runtime/hooks.ja.md
@@ -87,7 +87,7 @@ message ベースの `cron:` ジョブが自身のセッションに配送され
 
 ```yaml
 hooks:
-  - on: mcp_resource_updated
+  - "on": mcp_resource_updated
     matcher: {server: "github", uri: "file:///repo/**"}
     template_push:
       message: "{{ uri }} changed on {{ server }}."
@@ -135,7 +135,7 @@ C と同じですが、`wake: true` フラグがランループに新しいタ�
 
 ```yaml
 hooks:
-  - on: mcp_resource_updated
+  - "on": mcp_resource_updated
     matcher: {uri: "file:///repo/docs/**"}
     pipeline_launch:
       name: reindex_docs
@@ -268,19 +268,19 @@ exec: <コマンド> [rc=N]
 
 ```yaml
 hooks:
-  - on: turn_end
+  - "on": turn_end
     template_push:
       message: "Run complete. Check for pending tasks."
       wake: true
 
-  - on: session_start
+  - "on": session_start
     exec: ["touch", "/tmp/reyn-session-started"]   # argv のみ — シェルリダイレクト(">>")は行われない
 
   - name: dynamic
-    on: turn_end
+    "on": turn_end
     exec_capture: ["scripts/decide-next.sh"]   # {"push_when":true,"wake":true,"message":"..."} を出力
 
-  - on: mcp_resource_updated
+  - "on": mcp_resource_updated
     matcher: {server: "github", uri: "file:///repo/docs/**"}
     pipeline_launch:
       name: reindex_docs

--- a/docs/concepts/runtime/hooks.md
+++ b/docs/concepts/runtime/hooks.md
@@ -369,7 +369,7 @@ against the firing event's template vars **before** the hook's action runs:
 
 ```yaml
 hooks:
-  - on: mcp_resource_updated
+  - "on": mcp_resource_updated
     matcher: {server: "github", uri: "file:///repo/**"}
     template_push:
       message: "{{ uri }} changed on {{ server }}."
@@ -459,7 +459,7 @@ built from the firing event's template vars:
 
 ```yaml
 hooks:
-  - on: mcp_resource_updated
+  - "on": mcp_resource_updated
     matcher: {uri: "file:///repo/docs/**"}
     pipeline_launch:
       name: reindex_docs
@@ -656,19 +656,19 @@ matcher-narrowed `mcp_resource_updated` `pipeline_launch`:
 
 ```yaml
 hooks:
-  - on: turn_end
+  - "on": turn_end
     template_push:
       message: "Run complete. Check for pending tasks."
       wake: true
 
-  - on: session_start
+  - "on": session_start
     exec: ["touch", "/tmp/reyn-session-started"]   # argv only — no shell redirection (">>")
 
   - name: dynamic
-    on: turn_end
+    "on": turn_end
     exec_capture: ["scripts/decide-next.sh"]   # emits {"push_when":true,"wake":true,"message":"..."}
 
-  - on: mcp_resource_updated
+  - "on": mcp_resource_updated
     matcher: {server: "github", uri: "file:///repo/docs/**"}
     pipeline_launch:
       name: reindex_docs
@@ -768,7 +768,7 @@ by, this Sync consumer.
 
 ```yaml
 hooks:
-  - on: composed:deploy_approved      # a composed event as a Sync on: target
+  - "on": composed:deploy_approved      # a composed event as a Sync on: target
     exec: ["reyn", "deploy.sh"]
 
 composers:
@@ -946,7 +946,7 @@ composers:
     emit: { kind: composed:deploy_approved }
 
 hooks:
-  - on: composed:deploy_approved
+  - "on": composed:deploy_approved
     template_push:
       message: "Deploy artifact {{ inputs[0].artifact }} approved — proceeding."
       wake: false

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -1037,16 +1037,16 @@
 # -----------------------------------------------------------------------------
 # hooks:
 #   - name: next_step          # optional label → the [hook:next_step] attribution
-#     on: turn_end             #   (absent → defaults to the hook-point, e.g. [hook:turn_end])
+#     "on": turn_end             #   (absent → defaults to the hook-point, e.g. [hook:turn_end])
 #     template_push:
 #       message: "Turn complete — consider the next step."
 #       wake: false
-#   - on: session_start
+#   - "on": session_start
 #     shell_exec: "echo session-started >> /tmp/reyn-hooks.log"
 #   - name: dynamic            # stdout decides whether/what/how to push
-#     on: turn_end
+#     "on": turn_end
 #     shell_push: "scripts/decide-next.sh"   # emits e.g. {"push_when":true,"wake":true,"message":"..."}
-#   - on: composed:deploy_approved   # subscribe to a composer's output (below) — a
+#   - "on": composed:deploy_approved   # subscribe to a composer's output (below) — a
 #     shell_exec: "reyn deploy.sh"   # Sync side-effect triggered by the composition.
 
 


### PR DESCRIPTION
**[docs-maintainer]** — Doc-side fix for #4517 (YAML 1.1 reads an unquoted `on:` key as boolean `True`, silently dropping the hook — copying the doc's own example triggers it).

## Scope, measured beyond the issue's own citation

The issue cited `hooks.ja.md:90,138,271,276` (4 lines) and `reyn.local.yaml.example:1040` (1 line). Measured the full population by concept (every literal, copyable `on:` YAML-key occurrence across all 3 files — fenced ` ```yaml ` blocks in `hooks.md`/`hooks.ja.md`, and the commented example block in `reyn.local.yaml.example`), not by re-grepping the cited lines:

- `docs/concepts/runtime/hooks.md`: **8** occurrences — not covered by the issue's citation at all (English doc; the issue only measured the ja sibling).
- `docs/concepts/runtime/hooks.ja.md`: **6** occurrences (2 more than the issue's own 4-line citation: 280, 283 were missed).
- `reyn.local.yaml.example`: **4** occurrences (issue cited only 1040: 1044/1047/1049 were missed). Left line 1017's field-name *description* prose unquoted — same style as the other unquoted field-name descriptions around it, not a literal copyable YAML line.

Deliberately did **not** touch line 771's trailing comment ("a Sync `on:` target") or line 202's inline prose mention — neither is a standalone copyable YAML key.

## Verification

- Falsify-verified the fix directly: `yaml.safe_load('hooks:\n  - "on": session_start\n    run: echo hi\n')` now returns `{'hooks': [{'on': 'session_start', ...}]}` — `'on'` is a string key, not `True`.
- Swept for the sibling YAML 1.1 boolean-literal risk architect flagged (`yes`/`no`/`off`/`y`/`n` as a key or bare value) across all 3 files — no hits.
- `mkdocs build --strict -f .mkdocs/mkdocs.yml` — no error/Aborted line.
- `ruff check src tests` — clean.

The code-side fix (warn on a `True` key in a hook entry) is handled separately per lead-coder's split — this PR is doc-only.

part of #4517

## Test plan

- [x] `mkdocs build --strict` — clean, no Aborted/error line (read directly)
- [x] `ruff check src tests` — clean
- [x] Falsify-verified: `yaml.safe_load` on the fixed form returns a string `'on'` key
- [x] Swept for yes/no/off/y/n sibling risk — no hits
- [x] (skipped — docs-only edit, no runtime behavior change, no test to run)
