### PR TITLE
feat(#4517): warn when an unquoted hooks 'on:' hits PyYAML's YAML-1.1 boolean trap

### DIFF
--- a/src/reyn/hooks/loader.py
+++ b/src/reyn/hooks/loader.py
@@ -213,6 +213,27 @@ def _parse_entry(
     # ``{True: 'turn_end', ...}``.  Try the string key first (= quoted
     # ``"on"``), then fall back to the boolean key ``True`` so that both
     # ``on: turn_end`` and ``"on": turn_end`` work.
+    #
+    # #4517: the fallback above means an unquoted ``on:`` never breaks the
+    # entry — but it also means the operator gets NO signal that they hit
+    # PyYAML's YAML-1.1 bareword trap, until a future edit or a stricter
+    # YAML loader elsewhere silently drops the same hook. A `True` key on
+    # a hook entry has exactly one cause — there is no OTHER way to write
+    # a hook entry that produces a literal `True` key (the entry is
+    # user-authored YAML with a small, closed field vocabulary, none of
+    # which is a bareword truthy literal) — so this warning has ZERO false
+    # positives (architect's own #4517 requirement), unlike an ordinary
+    # "did you mean" heuristic. Fires only when the STRING key is absent
+    # (an operator who wrote `"on":` — quoted — never sees this, matching
+    # #4515's own "warn only the entries that need it" discipline).
+    if "on" not in raw and True in raw:
+        _log.warning(
+            "hooks[%d]: the 'on:' key is unquoted and PyYAML (YAML 1.1) "
+            "parsed it as the boolean True, not the string 'on' — this "
+            "hook still works (a compatibility fallback reads it), but "
+            "quote it (\"on\": %r) to avoid depending on that fallback.",
+            entry_index, raw[True],
+        )
     on_raw = raw.get("on", raw.get(True))
     if on_raw is None:
         raise HookConfigError(

--- a/tests/hooks/test_1800_hook_config_schema.py
+++ b/tests/hooks/test_1800_hook_config_schema.py
@@ -414,3 +414,67 @@ hooks:
     # ── Hooks at other points are empty (no stray registrations) ─────────
     assert registry.hooks_for("session_end") == []
     assert registry.hooks_for("turn_start") == []
+
+
+# ---------------------------------------------------------------------------
+# #4517 — unquoted `on:` parses as the boolean True key (YAML 1.1 / PyYAML)
+# ---------------------------------------------------------------------------
+
+
+def test_on_key_from_real_unquoted_yaml_still_loads_via_the_true_key_fallback():
+    """Tier 1: #4517's own reproduction, through REAL yaml.safe_load — an
+    unquoted ``on: session_start`` parses to a ``True`` key (PyYAML is a
+    YAML 1.1 implementation; `on`/`off`/`yes`/`no` are boolean literals
+    there), and the loader's existing fallback (`raw.get("on",
+    raw.get(True))`) still resolves it correctly. This was previously
+    UNTESTED despite being real, invoked code — a genuine coverage gap
+    the #4517 investigation surfaced, not a new behavior."""
+    import yaml
+
+    raw = yaml.safe_load(
+        "hooks:\n  - on: session_start\n    exec: [echo, hi]\n"
+    )
+    assert True in raw["hooks"][0], "the fixture itself must reproduce the True-key shape"
+    registry = load_hooks(raw["hooks"])
+    (hd,) = registry.hooks_for("session_start")
+    assert hd.exec == ("echo", "hi")
+
+
+def test_true_key_hook_entry_logs_a_warning(caplog):
+    """Tier 2: #4517 — a hook entry with a `True` key (the unquoted `on:`
+    trap) logs a warning naming the entry index, even though the hook
+    still loads correctly via the fallback. Zero false positives by
+    construction: a `True` key has exactly one cause in a hand-authored
+    hook entry (an unquoted `on:`/`off:`/`yes:`/`no:` bareword) — there is
+    no other field whose YAML spelling produces a literal `True` key."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="reyn.hooks.loader"):
+        load_hooks([{True: "session_start", "exec": ["echo", "hi"]}])
+    assert any(
+        "hooks[0]" in r.message and "True" in r.message for r in caplog.records
+    ), f"expected a warning naming the True-key trap, got: {[r.message for r in caplog.records]}"
+
+
+def test_quoted_on_key_never_logs_the_warning(caplog):
+    """Tier 2: accept-side — an operator who correctly quoted `"on":`
+    never sees this warning (it fires only when the string key is
+    ABSENT). Same discipline #4515's own accept-side test established:
+    a false positive here would train operators to ignore the warning."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="reyn.hooks.loader"):
+        load_hooks([{"on": "session_start", "exec": ["echo", "hi"]}])
+    assert not any("True" in r.message for r in caplog.records), (
+        f"a correctly-quoted 'on:' must never trigger the True-key warning, "
+        f"got: {[r.message for r in caplog.records]}"
+    )
+
+
+def test_a_hook_entry_with_neither_on_nor_true_key_still_raises_not_warns():
+    """Tier 1: regression guard — a genuinely missing `on` (no string key,
+    no True key either) still raises HookConfigError as before; the new
+    warning path only intercepts the SPECIFIC True-key shape, it does not
+    change the missing-on error path."""
+    with pytest.raises(HookConfigError, match="\\.on is required"):
+        load_hooks([{"exec": ["echo", "hi"]}])


### PR DESCRIPTION
**[tui-coder]** — Closes #4517 (severity:high; doc side #4519 already merged)

Code side of the arc. Doc fixes (#4519, already landed) only help operators who haven't written the config yet — someone who already copied the old unquoted example is not helped by a doc edit.

## What's happening

`yaml.safe_load("hooks:\n  - on: session_start\n...")` parses to `{True: 'session_start', ...}` — PyYAML is a YAML 1.1 implementation, where `on`/`off`/`yes`/`no` are boolean literals.

`_parse_entry`'s existing `raw.get("on", raw.get(True))` fallback (pre-existing, real code — confirmed via `git log`, added dedicated test coverage for it in this PR since it had none) means the hook still loads and registers correctly either way — **this is not a functional break**. What was missing is any SIGNAL that the operator hit the trap at all: no error, no warning, nothing.

## Fix

`_parse_entry` now logs a warning whenever a hook entry has a `True` key with no `"on"` string key — **zero false positives by construction**: a hand-authored hook entry's field vocabulary has no other way to produce a literal `True` key. The `yes`/`no`/`off`/`y`/`n` family sweep was already done by lead-coder/docs-maintainer while scoping #4517, with no other matches found. An operator who correctly quotes `"on":` never sees the warning (accept-side test included, matching #4515's own accept-side discipline).

## Falsify-verify

The new warning test fails with the warning call reverted (no log record produced); the fallback-still-works test and the quoted-key accept-side test are unaffected by the revert.

## Test plan

- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict` on the changed test file — 32/32 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (212/215 baselined, no new)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/hooks/` (full) — 327 passed
- [x] `pytest tests/runtime/` hook-related subset — 60 passed
- [x] Falsify-verify — new test genuinely fails with the warning reverted
- [x] (skipped — N/A, log-line change only, no UI)

tests/ touched — TESTS-READ wait, no self-merge.