### PR TITLE
feat(#4517): warn when an unquoted hooks 'on:' hits PyYAML's YAML-1.1 boolean trap

### DIFF
--- a/src/reyn/hooks/loader.py
+++ b/src/reyn/hooks/loader.py
@@ -213,6 +213,55 @@ def _parse_entry(
     # ``{True: 'turn_end', ...}``.  Try the string key first (= quoted
     # ``"on"``), then fall back to the boolean key ``True`` so that both
     # ``on: turn_end`` and ``"on": turn_end`` work.
+    #
+    # #4517: the fallback above means an unquoted ``on:`` never breaks the
+    # entry — but it also means the operator gets NO signal that they hit
+    # PyYAML's YAML-1.1 bareword trap, until a future edit or a stricter
+    # YAML loader elsewhere silently drops the same hook. A `True` key on
+    # a hook entry has exactly one cause — there is no OTHER way to write
+    # a hook entry that produces a literal `True` key (the entry is
+    # user-authored YAML with a small, closed field vocabulary, none of
+    # which is a bareword truthy literal) — so this warning has ZERO false
+    # positives (architect's own #4517 requirement), unlike an ordinary
+    # "did you mean" heuristic. Fires only when the STRING key is absent
+    # (an operator who wrote `"on":` — quoted — never sees this, matching
+    # #4515's own "warn only the entries that need it" discipline).
+    if "on" not in raw and True in raw:
+        # #4517 architect ruling (2026-08-13, reversed from an earlier same-
+        # day "this would be a design regression" call after re-examining
+        # the premise): the fallback below is a compatibility SHIM for a
+        # spelling pitfall, not two equally-intended spellings — nobody
+        # deliberately writes a boolean key wanting a hook point; `on:`
+        # reads naturally as the string, and YAML 1.1 (PyYAML) made it a
+        # bool. A canonical form therefore exists ("on":, quoted), so
+        # nudging toward it is not a regression against "so that both ...
+        # work" (that comment describes what still RUNS, not a declaration
+        # that both spellings are equally correct).
+        #
+        # Three conditions from that ruling, all load-bearing — do not
+        # relax without re-checking with architect/lead-coder:
+        #   1. Never say "broken" / "NOT APPLIED" — this hook DID apply.
+        #      Saying otherwise repeats #4515's own just-fixed false-report
+        #      shape (asserting a failure that didn't happen).
+        #   2. Never share `_warn_unknown_config_keys`'s (config/loader.py)
+        #      channel or phrasing — that warning means "not applied"; this
+        #      one means "applied, via a fallback" — the same look would
+        #      make an operator read this as that.
+        #   3. Never fire for the quoted `"on":` form (this `if` already
+        #      only reaches here when the string key is absent).
+        # Plus: name that pre-#4519 docs taught the unquoted spelling —
+        # an operator who copied the OLD example did nothing wrong.
+        _log.warning(
+            "hooks[%d]: applied via a compatibility fallback — the 'on:' "
+            "key here is unquoted, and PyYAML (YAML 1.1) parses that as "
+            "the boolean True rather than the string 'on'. This hook DID "
+            "register and will fire normally; nothing failed. Older reyn "
+            "docs/examples showed this exact unquoted spelling before "
+            "#4519, so this is not a mistake on your part. Quoting the "
+            "key (\"on\": %r) is recommended so the hook no longer depends "
+            "on this fallback.",
+            entry_index, raw[True],
+        )
     on_raw = raw.get("on", raw.get(True))
     if on_raw is None:
         raise HookConfigError(

--- a/tests/hooks/test_1800_hook_config_schema.py
+++ b/tests/hooks/test_1800_hook_config_schema.py
@@ -414,3 +414,96 @@ hooks:
     # ── Hooks at other points are empty (no stray registrations) ─────────
     assert registry.hooks_for("session_end") == []
     assert registry.hooks_for("turn_start") == []
+
+
+# ---------------------------------------------------------------------------
+# #4517 — unquoted `on:` parses as the boolean True key (YAML 1.1 / PyYAML)
+# ---------------------------------------------------------------------------
+
+
+def test_on_key_from_real_unquoted_yaml_still_loads_via_the_true_key_fallback():
+    """Tier 1: #4517's own reproduction, through REAL yaml.safe_load — an
+    unquoted ``on: session_start`` parses to a ``True`` key (PyYAML is a
+    YAML 1.1 implementation; `on`/`off`/`yes`/`no` are boolean literals
+    there), and the loader's existing fallback (`raw.get("on",
+    raw.get(True))`) still resolves it correctly. This was previously
+    UNTESTED despite being real, invoked code — a genuine coverage gap
+    the #4517 investigation surfaced, not a new behavior."""
+    import yaml
+
+    raw = yaml.safe_load(
+        "hooks:\n  - on: session_start\n    exec: [echo, hi]\n"
+    )
+    assert True in raw["hooks"][0], "the fixture itself must reproduce the True-key shape"
+    registry = load_hooks(raw["hooks"])
+    (hd,) = registry.hooks_for("session_start")
+    assert hd.exec == ("echo", "hi")
+
+
+def test_true_key_hook_entry_logs_a_warning(caplog):
+    """Tier 2: #4517 — a hook entry with a `True` key (the unquoted `on:`
+    trap) logs a warning naming the entry index, even though the hook
+    still loads correctly via the fallback. Zero false positives by
+    construction: a `True` key has exactly one cause in a hand-authored
+    hook entry (an unquoted `on:`/`off:`/`yes:`/`no:` bareword) — there is
+    no other field whose YAML spelling produces a literal `True` key."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="reyn.hooks.loader"):
+        load_hooks([{True: "session_start", "exec": ["echo", "hi"]}])
+    assert any(
+        "hooks[0]" in r.message and "True" in r.message for r in caplog.records
+    ), f"expected a warning naming the True-key trap, got: {[r.message for r in caplog.records]}"
+
+
+def test_true_key_warning_never_claims_the_hook_failed(caplog):
+    """Tier 2: #4517 — architect's post-reversal ruling, condition 1 —
+    the warning must never say the hook is broken or "NOT APPLIED"; it
+    DID register and WILL fire. Saying otherwise would repeat #4515's
+    own just-fixed false-report shape (asserting a failure that never
+    happened) — the opposite mistake in the opposite direction."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="reyn.hooks.loader"):
+        load_hooks([{True: "session_start", "exec": ["echo", "hi"]}])
+    (record,) = [r for r in caplog.records if "hooks[0]" in r.message]
+    lowered = record.message.lower()
+    assert "not applied" not in lowered
+    assert "broken" not in lowered
+    assert "applied" in lowered, "must affirmatively say the hook DID apply"
+
+
+def test_true_key_warning_names_the_pre_4519_docs(caplog):
+    """Tier 1: #4517 — lead-coder's accepted-cost condition (④) — the
+    warning names that older reyn docs (pre-#4519) taught this exact
+    unquoted spelling, so an operator who copied it did nothing wrong."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="reyn.hooks.loader"):
+        load_hooks([{True: "session_start", "exec": ["echo", "hi"]}])
+    (record,) = [r for r in caplog.records if "hooks[0]" in r.message]
+    assert "4519" in record.message or "docs" in record.message.lower()
+
+
+def test_quoted_on_key_never_logs_the_warning(caplog):
+    """Tier 2: accept-side — an operator who correctly quoted `"on":`
+    never sees this warning (it fires only when the string key is
+    ABSENT). Same discipline #4515's own accept-side test established:
+    a false positive here would train operators to ignore the warning."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="reyn.hooks.loader"):
+        load_hooks([{"on": "session_start", "exec": ["echo", "hi"]}])
+    assert not any("True" in r.message for r in caplog.records), (
+        f"a correctly-quoted 'on:' must never trigger the True-key warning, "
+        f"got: {[r.message for r in caplog.records]}"
+    )
+
+
+def test_a_hook_entry_with_neither_on_nor_true_key_still_raises_not_warns():
+    """Tier 1: regression guard — a genuinely missing `on` (no string key,
+    no True key either) still raises HookConfigError as before; the new
+    warning path only intercepts the SPECIFIC True-key shape, it does not
+    change the missing-on error path."""
+    with pytest.raises(HookConfigError, match="\\.on is required"):
+        load_hooks([{"exec": ["echo", "hi"]}])


### PR DESCRIPTION
**[tui-coder]** — Closes #4517 (severity:high; doc side #4519 already merged)

Reopened after a same-day design-call reversal — recorded in full in the commit message. Original #4520 was closed because the fallback's comment ("so that both ... work") read as declaring both spellings equally valid, making a warning look like #4515's own just-fixed false-positive shape. architect reversed after re-examining: nobody deliberately writes the boolean-literal spelling wanting a hook point — the two spellings are equally functional but not equally intended, and #4519's own doc fix already establishes `"on":` as canonical. Reopened with three explicit conditions (+ a fourth from lead-coder's accepted counter-argument), all implemented and tested below.

## What's happening

`yaml.safe_load("hooks:\n  - on: session_start\n...")` parses to `{True: 'session_start', ...}` — PyYAML is a YAML 1.1 implementation, where `on`/`off`/`yes`/`no` are boolean literals. `_parse_entry`'s existing `raw.get("on", raw.get(True))` fallback (pre-existing, real code — confirmed via `git log`; added dedicated test coverage for it here since it had none) means the hook still loads and registers correctly either way — not a functional break. What was missing is any signal the operator hit the trap.

## The four conditions (all implemented)

1. Never say "broken" / "NOT APPLIED" — the hook DID apply.
2. Never share `_warn_unknown_config_keys`'s wording/channel — distinct module, distinct phrasing ("applied via a compatibility fallback" vs. "is not recognized ... NOT APPLIED").
3. Never fire for the quoted `"on":` form.
4. Name that pre-#4519 docs taught this exact unquoted spelling — not the operator's fault.

## Falsify-verify

Reverting to the old, condition-violating wording ("NOT APPLIED ... broken") makes three tests fail for the right reason — two catch the forbidden phrasing directly, one fails because the reverted message doesn't mention the pre-#4519 docs either.

## Test plan

- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict` on the changed test file — 34/34 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (212/215 baselined, no new)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/hooks/` (full) — 329 passed
- [x] Falsify-verify — 3/34 tests genuinely fail with the pre-condition wording reinstated
- [x] (skipped — N/A, log-line change only, no UI)

tests/ touched — TESTS-READ wait, no self-merge.