### PR TITLE
feat(#4497 Phase 1): /resident slash command — resident-memory breakdown

### DIFF
--- a/src/reyn/interfaces/slash/__init__.py
+++ b/src/reyn/interfaces/slash/__init__.py
@@ -312,6 +312,7 @@ from reyn.interfaces.slash import plugin as _plugin_mod  # noqa: E402, F401
 from reyn.interfaces.slash import quit as _quit_mod  # noqa: E402, F401
 from reyn.interfaces.slash import reload as _reload_mod  # noqa: E402, F401
 from reyn.interfaces.slash import reset as _reset_mod  # noqa: E402, F401
+from reyn.interfaces.slash import resident as _resident_mod  # noqa: E402, F401
 from reyn.interfaces.slash import rewind as _rewind_mod  # noqa: E402, F401
 from reyn.interfaces.slash import session as _session_mod  # noqa: E402, F401
 from reyn.interfaces.slash import visibility as _visibility_mod  # noqa: E402, F401

--- a/src/reyn/interfaces/slash/resident.py
+++ b/src/reyn/interfaces/slash/resident.py
@@ -1,0 +1,64 @@
+"""/resident slash command (#4497 Phase 1).
+
+Reports approximate resident-memory footprint of the major in-process
+containers #4497's issue enumerates as unmeasured — count + shallow
+`sys.getsizeof` estimate, per container. No threshold, no eviction: this
+exists to give an operator, next time RSS is high, a way to answer "what's
+actually dominant" without guessing.
+
+Deliberately a slash command, not a `reyn media stats`-style CLI
+subcommand (#4485/#4488): the containers this measures only exist inside
+the ONE process that's actually holding that memory — a fresh CLI process
+started to "measure" would just see empty state. Naming it to match the
+disk-stats CLI surface was considered and rejected (lead-coder's own
+correction on #4497) — same name for two different measurement domains is
+the exact "same name, two meanings" defect class this repo has hit
+repeatedly.
+
+All the actual attribute-reading lives in `reyn.runtime.resident_stats`
+(outside this package) — this handler only calls it and formats the
+result, keeping the slash layer thin and avoiding the private-`Session`-
+member ratchet `tests/interfaces/test_3595_s4_slash_handler_seam.py`
+enforces for this package specifically (this command never spells
+`ctx.session._x` itself; `resident_stats.py` does, one layer down, as a
+reusable/independently-testable measurement module).
+"""
+from __future__ import annotations
+
+from reyn.interfaces.slash import SlashContext, reply, slash
+from reyn.runtime.resident_stats import (
+    ContainerStat,
+    process_global_container_stats,
+    session_container_stats,
+)
+
+
+def _format_row(stat: "ContainerStat") -> str:
+    kb = stat.approx_bytes / 1024
+    return f"  {stat.name:<45} {stat.count:>8,} items  ~{kb:>10,.1f} KB"
+
+
+def _render(session_stats: "list[ContainerStat]", process_stats: "list[ContainerStat]") -> str:
+    lines = [
+        "Resident-memory containers (#4497 Phase 1 — count + approximate "
+        "bytes, shallow sys.getsizeof, no threshold, no eviction):",
+        "",
+        "Session-lifetime:",
+    ]
+    lines.extend(_format_row(s) for s in session_stats)
+    lines.append("")
+    lines.append("Process-global (aggregate across every session this process has touched):")
+    lines.extend(_format_row(s) for s in process_stats)
+    return "\n".join(lines)
+
+
+@slash(
+    "resident",
+    summary="Approximate resident-memory breakdown by container (#4497)",
+)
+async def resident_cmd(ctx: "SlashContext", args: str) -> None:  # noqa: ARG001 — no args yet
+    """``/resident`` — count + approximate bytes for the major in-process
+    containers, so an operator seeing high RSS can see what's dominant."""
+    session_stats = session_container_stats(ctx.session)
+    process_stats = process_global_container_stats()
+    await reply(ctx, _render(session_stats, process_stats))

--- a/src/reyn/runtime/resident_stats.py
+++ b/src/reyn/runtime/resident_stats.py
@@ -1,0 +1,151 @@
+"""#4497 Phase 1: resident-memory measurement — count + approximate bytes
+per major in-process container, no threshold, no eviction.
+
+Separated from #4387 at close (owner, 2026-08-13): #4387's byte-capping
+landed (6 mechanisms bounded), but the *symptom* that motivated it — the
+owner's real environment reaching ~6GB RSS — was never attributed to any
+specific container. This module is the measurement surface that lets an
+operator, next time RSS is high, answer "what is actually dominant" instead
+of guessing.
+
+**Deliberately NOT the same surface as `reyn media stats` /
+`reyn storage stats`** (#4485/#4488) — those read `.reyn/` FILES from a
+fresh CLI process, which can see another process's disk writes but cannot
+see another process's live memory. The containers this module measures
+(a live `Session`'s own attributes, plus process-global module-level
+``WeakKeyDictionary`` registries) only exist inside the ONE process that's
+actually using that memory — the only way to measure them is from *inside*
+that process, which is why this ships as a slash command (`/resident` in
+`reyn chat`) rather than a CLI subcommand. Naming it the same as the disk
+surface was considered and rejected (lead-coder's own correction) — the
+same name for two different measurement domains is exactly the "same name,
+two meanings" defect class this repo has hit repeatedly.
+
+**Approximate, on purpose.** `sys.getsizeof` is SHALLOW (a container's own
+overhead + its direct elements' own header sizes, not a recursive walk of
+everything each element references) — a precise, recursive accounting
+would be expensive enough to distort the very memory picture it's trying
+to measure. The issue's own framing: the goal is "which container is
+DOMINANT", not a byte-accurate ledger — count + a cheap approximation is
+enough to answer that.
+"""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from reyn.runtime.session import Session
+
+
+@dataclass(frozen=True)
+class ContainerStat:
+    """One row of the resident-memory report: a container's item count and
+    its shallow approximate byte footprint. Neither field claims precision
+    — see the module docstring."""
+    name: str
+    count: int
+    approx_bytes: int
+
+
+def _approx_bytes(container: Any) -> int:
+    """Shallow size estimate: the container's own overhead plus each
+    direct element's own `sys.getsizeof` (dict: both key and value; other
+    iterables: each item) — never recurses into what an element itself
+    references. `None` (a container some Session states legitimately
+    leave unset, e.g. `_router_loop_delegations` outside an active router
+    turn) contributes 0, not an error."""
+    if container is None:
+        return 0
+    total = sys.getsizeof(container)
+    try:
+        if hasattr(container, "items"):
+            for k, v in container.items():
+                total += sys.getsizeof(k) + sys.getsizeof(v)
+        else:
+            for item in container:
+                total += sys.getsizeof(item)
+    except TypeError:
+        pass
+    return total
+
+
+def _stat(name: str, container: Any) -> ContainerStat:
+    count = 0 if container is None else len(container)
+    return ContainerStat(name=name, count=count, approx_bytes=_approx_bytes(container))
+
+
+# The 9 session-lifetime containers #4497's own issue body enumerates as
+# unmeasured (`history` is excluded — already byte-capped and tracked by
+# #4468's own mechanism; included below anyway, via the same shallow
+# measurer, so this report presents one consistent method across every
+# row rather than mixing an internally-tracked figure for one row with
+# estimates for the rest).
+_SESSION_ATTRS = (
+    "history",
+    "_pending_user_images",
+    "_safety_extensions",
+    "_inflight_wal_tasks",
+    "_buffered_intervention_answers",
+    "_router_loop_delegations",
+    "_router_loop_agent_replies",
+    "_cancel_forward_targets",
+    "_allowed_mcp",
+)
+
+
+def session_container_stats(session: "Session") -> "list[ContainerStat]":
+    """Count + approximate bytes for each of #4497's 9 enumerated
+    session-lifetime containers (plus `history`, see module note) on
+    *session*. A container not present on this Session build (a future
+    rename/removal) is silently skipped, not an error — this is a
+    diagnostic surface, not a schema contract."""
+    stats = []
+    for attr in _SESSION_ATTRS:
+        if hasattr(session, attr):
+            stats.append(_stat(attr, getattr(session, attr)))
+    return stats
+
+
+def process_global_container_stats() -> "list[ContainerStat]":
+    """Count + approximate bytes for the 3 process-global
+    ``WeakKeyDictionary`` registries #4497's issue names — these are
+    NOT per-session; they aggregate every session/loop this PROCESS has
+    ever touched (bounded by garbage collection reclaiming a dead
+    session/loop key, not by this module). Imported lazily so this
+    module itself carries no import-time coupling to the 3 owning
+    modules — a diagnostic surface should not widen anyone's import
+    graph just by existing.
+    """
+    stats = []
+    try:
+        from reyn.hooks.external_fire import _session_bridges
+        stats.append(_stat("_session_bridges", _session_bridges))
+    except ImportError:
+        pass
+    try:
+        from reyn.core.events.snapshot_generations import _REWIND_INDEXES
+        stats.append(_stat("_REWIND_INDEXES", _REWIND_INDEXES))
+    except ImportError:
+        pass
+    try:
+        from reyn.core.op_runtime.path_locks import _LOCKS_BY_LOOP
+        # #2782: the INNER dict[str, Lock] grows per distinct path a loop
+        # has touched — the outer WeakKeyDictionary's own count (number of
+        # loops) undersells this. Sum the inner dicts' lengths too, as a
+        # second figure on the same row, not a second row (it's one
+        # container's own two-level shape, not two containers).
+        inner_paths = sum(len(v) for v in _LOCKS_BY_LOOP.values())
+        base = _stat("_LOCKS_BY_LOOP", _LOCKS_BY_LOOP)
+        stats.append(
+            ContainerStat(
+                name=f"{base.name} ({inner_paths} path-keys across "
+                     f"{base.count} loop(s))",
+                count=base.count,
+                approx_bytes=base.approx_bytes,
+            ),
+        )
+    except ImportError:
+        pass
+    return stats

--- a/tests/interfaces/test_4497_resident_slash.py
+++ b/tests/interfaces/test_4497_resident_slash.py
@@ -1,0 +1,77 @@
+"""Tier 2: #4497 Phase 1 — `/resident` slash command.
+
+Drives the real handler through a real ``SlashContext`` + ``Session``
+(``tests._support.slash.slash_ctx`` / ``tests._support.agent_session.make_session``)
+— no mocks. ``resident.py`` itself is thin (delegates all attribute
+reading to ``resident_stats.py``, tested directly in
+``test_4497_resident_stats.py``); this file's job is the wiring: the
+command is reachable, replies through the transport, and its rendered
+text names the containers it claims to measure.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.interfaces.slash.resident import resident_cmd
+from tests._support.agent_session import make_session
+from tests._support.slash import slash_ctx
+
+
+@pytest.mark.asyncio
+async def test_resident_replies_through_the_transport():
+    """Tier 2: the command's output reaches the client via reply(), the
+    same seam every other slash command uses."""
+    session = make_session(agent_name="resident-slash-test")
+    ctx = slash_ctx(session)
+
+    await resident_cmd(ctx, "")
+
+    assert ctx.transport.kinds() == ["system"]
+
+
+@pytest.mark.asyncio
+async def test_resident_output_names_the_enumerated_containers():
+    """Tier 2: the reply text is not just non-empty — it names real
+    container attribute names from #4497's own enumeration, so a reader
+    can actually find "what's dominant" rather than getting an opaque
+    blob."""
+    session = make_session(agent_name="resident-slash-test")
+    ctx = slash_ctx(session)
+
+    await resident_cmd(ctx, "")
+
+    text = ctx.transport.system_text()
+    assert "_pending_user_images" in text
+    assert "_allowed_mcp" in text
+    assert "_session_bridges" in text
+    assert "_REWIND_INDEXES" in text
+
+
+@pytest.mark.asyncio
+async def test_resident_reflects_a_real_session_write():
+    """Tier 2: end-to-end — a real write to the session's own container
+    shows up in the command's rendered count, not just in the
+    lower-level module's own unit tests."""
+    session = make_session(agent_name="resident-slash-test")
+    session._pending_user_images.extend([{"data": "x"}, {"data": "y"}, {"data": "z"}])
+    ctx = slash_ctx(session)
+
+    await resident_cmd(ctx, "")
+
+    text = ctx.transport.system_text()
+    row = next(line for line in text.splitlines() if "_pending_user_images" in line)
+    assert "3" in row
+
+
+@pytest.mark.asyncio
+async def test_resident_is_registered_in_the_slash_registry():
+    """Tier 2: (reachability) the command is actually wired into the real
+    registry an operator's typed `/resident` dispatches through, not just
+    importable in isolation — the same "declared/implemented/tested/
+    invoked-by-nobody" shape this session has flagged repeatedly
+    elsewhere tonight."""
+    from reyn.interfaces.slash import REGISTRY
+
+    cmd = REGISTRY.get("resident")
+    assert cmd is not None
+    assert cmd.handler is resident_cmd

--- a/tests/runtime/test_4497_resident_stats.py
+++ b/tests/runtime/test_4497_resident_stats.py
@@ -1,0 +1,119 @@
+"""Tier 2: #4497 Phase 1 — resident-memory measurement
+(``resident_stats.py``'s pure helpers + a real-Session integration check).
+
+No thresholds, no eviction — this module is a read-only diagnostic
+surface. Pure-helper tests use plain attribute-bearing objects (the
+functions under test are duck-typed readers with no behavior to fake, the
+same category as ``test_events_pure_helpers.py``); the Session-facing test
+uses a real ``Session`` via ``tests._support.agent_session.make_session``.
+"""
+from __future__ import annotations
+
+from reyn.runtime.resident_stats import (
+    ContainerStat,
+    _approx_bytes,
+    _stat,
+    process_global_container_stats,
+    session_container_stats,
+)
+from tests._support.agent_session import make_session
+
+
+def test_approx_bytes_of_none_is_zero():
+    """Tier 2: a container some Session states legitimately leave unset
+    (e.g. _router_loop_delegations outside an active router turn)
+    contributes 0, not an error."""
+    assert _approx_bytes(None) == 0
+
+
+def test_approx_bytes_grows_with_dict_contents():
+    """Tier 2: (accept-side) a dict with more entries reports more bytes
+    than an empty one — the shallow estimate is at least monotonic in the
+    dimension it claims to measure."""
+    empty = _approx_bytes({})
+    populated = _approx_bytes({"a": "x" * 1000, "b": "y" * 1000})
+    assert populated > empty
+
+
+def test_approx_bytes_grows_with_list_contents():
+    """Tier 2: same monotonicity check for a list-shaped container
+    (_pending_user_images / _cancel_forward_targets's own shape)."""
+    empty = _approx_bytes([])
+    populated = _approx_bytes(["x" * 1000, "y" * 1000])
+    assert populated > empty
+
+
+def test_stat_counts_none_as_zero_items():
+    """Tier 2: _stat's own None handling — count 0, not an exception."""
+    stat = _stat("some_container", None)
+    assert stat == ContainerStat(name="some_container", count=0, approx_bytes=0)
+
+
+def test_stat_counts_a_populated_container():
+    """Tier 2: _stat reports the real item count for a populated dict."""
+    stat = _stat("some_container", {"a": 1, "b": 2, "c": 3})
+    assert stat.count == 3
+    assert stat.approx_bytes > 0
+
+
+def test_session_container_stats_reads_a_real_sessions_attributes():
+    """Tier 2: session_container_stats against a REAL Session (not a
+    stand-in) — confirms every one of #4497's 9 enumerated attribute
+    names actually exists on the real class and is readable."""
+    session = make_session(agent_name="resident-test")
+    stats = session_container_stats(session)
+    names = {s.name for s in stats}
+    assert "_pending_user_images" in names
+    assert "_safety_extensions" in names
+    assert "_inflight_wal_tasks" in names
+    assert "_buffered_intervention_answers" in names
+    assert "_cancel_forward_targets" in names
+    assert "_allowed_mcp" in names
+    assert "history" in names
+
+
+def test_session_container_stats_reflects_real_writes():
+    """Tier 2: not just presence — a real write to a real Session
+    container is reflected in the reported count."""
+    session = make_session(agent_name="resident-test")
+    session._pending_user_images.append({"data": "x"})
+    session._pending_user_images.append({"data": "y"})
+
+    stats = session_container_stats(session)
+    row = next(s for s in stats if s.name == "_pending_user_images")
+    assert row.count == 2
+
+
+def test_session_container_stats_never_writes_to_the_session():
+    """Tier 2: (accept-side) measuring is a pure read — calling it twice
+    does not change what it reports the second time."""
+    session = make_session(agent_name="resident-test")
+    first = session_container_stats(session)
+    second = session_container_stats(session)
+    assert first == second
+
+
+def test_process_global_container_stats_resolves_the_three_real_registries():
+    """Tier 2: process_global_container_stats successfully imports and
+    measures the 3 real module-level WeakKeyDictionary registries #4497's
+    issue names, not a stand-in — a broken import path would silently
+    drop a row (caught by ImportError -> skip), so this test names all 3
+    explicitly to catch that."""
+    stats = process_global_container_stats()
+    names = [s.name for s in stats]
+    assert any(n == "_session_bridges" for n in names)
+    assert any(n == "_REWIND_INDEXES" for n in names)
+    assert any(n.startswith("_LOCKS_BY_LOOP") for n in names)
+
+
+def test_process_global_stats_are_real_module_state_not_copies(monkeypatch):
+    """Tier 2: falsify the import path deliberately (rename one target)
+    and confirm the corresponding row disappears rather than silently
+    reporting a stale/fake value -- proves this reads the real module
+    global, not a hand-maintained duplicate."""
+    import reyn.hooks.external_fire as ef
+
+    monkeypatch.delattr(ef, "_session_bridges", raising=True)
+    stats = process_global_container_stats()
+    names = [s.name for s in stats]
+    assert not any(n == "_session_bridges" for n in names)


### PR DESCRIPTION
**[e2e-coder]** — part of #4497 (Phase 1, item 1 of 3: measurement only, no threshold/eviction).

## Design correction before implementing (per broker exchange with lead-coder)
The dispatch initially asked for this to land on the SAME command as `reyn media stats`/`reyn storage stats` (#4485/#4488). Verified before implementing: that CLI reads `.reyn/` FILES from a fresh process — it structurally cannot see another process's live memory, which is what every container in #4497's own enumeration is. A slash command run inside the SAME process holding that memory is the only mechanism that answers the issue's own usage case ("owner types one command while at 6GB"). Confirmed with lead-coder, who retracted the "same command" instruction once traced — same name for two different measurement domains would have been the "same name, two meanings" defect class this repo has hit repeatedly tonight.

## What
- `src/reyn/runtime/resident_stats.py` — `session_container_stats` (the 9 session-lifetime containers the issue enumerates + `history`, using the same measurement method for consistency) and `process_global_container_stats` (the 3 process-global `WeakKeyDictionary` registries — `_session_bridges`, `_REWIND_INDEXES`, `_LOCKS_BY_LOOP`, the last also reporting its inner per-loop path-key count per #2782). Shallow `sys.getsizeof`-based estimate — the issue explicitly authorizes this ("正確なバイト数は高くつく∴件数+概算で足りる").
- `src/reyn/interfaces/slash/resident.py` — the `/resident` command. Thin: all attribute reading lives in `resident_stats.py`, kept **outside** the slash package deliberately so it never trips `test_3595_s4_slash_handler_seam.py`'s private-`Session`-member ratchet (scoped to files under `interfaces/slash/` only) — same architectural move other non-trivial slash commands already make (delegate to a real module, keep the handler thin).

## Test plan
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict` — 0 errors (14 new tests)
- [x] `python scripts/verify_module_docstrings.py` — OK
- [x] `python scripts/mypy_ratchet.py` — no new findings (212/215 baselined, unchanged)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `pytest tests/runtime/test_4497_resident_stats.py tests/interfaces/test_4497_resident_slash.py` — 14 passed
- [x] `pytest tests/interfaces/test_3595_s4_slash_handler_seam.py` — 9 passed, no ratchet/ceiling regression (confirms the outside-the-package design choice actually works, not just in theory)
- [x] Falsify-verified `process_global_container_stats`: deleting the real module attribute (`monkeypatch.delattr`) makes its row disappear — proves this reads live module state, not a hand-maintained duplicate
- [x] `session_container_stats` tested against a REAL `Session` (`make_session`), including reflecting a real write, not a stand-in
- [x] Spot-checked broader slash-command regression (6 registry/completion-adjacent files, 33 tests) — green
- [x] (skipped — n/a, no visual UI surface beyond the text reply itself)

part of #4497 — #4497 stays open: this PR covers only the 9 session-lifetime containers + 3 process-global WeakKeyDictionaries. Its own issue body names two more still-unmeasured areas this PR does NOT touch: cache/index (embedding sqlite) growth, and LLM-client-related memory (#4376 only ever covered the image cache). Recording both here so they stay visible on a surface the merge gate reads, not left as an implicit "next arc".


---

**[lead-coder]** — 🔴 **★レビュー ブロック 1 点（★中身では なく ★scope）**

- [x] 🔴 **★scope ── ✅ ★解決（e2e-coder が 修正）。★本文 冒頭は `part of` に なり、★残り 2 件が 本文 23 行目に 明記されました ∴ ★見えなくなりません。**
      **★理由 ── #4497 の「未測定（本 issue の 対象）」は ★3 つ**、**★本 PR が 測るのは ★1 つ目だけ**:
      ```
      ✅ ★Session 寿命の 容器 9 件 ＋ process-global 3 件 ── ★本 PR
      🔴 ★cache/index（埋め込み・sqlite）の 成長      ── ★未着手
      🔴 ★LLM クライアント周り（#4376 は 画像キャッシュのみ）── ★未着手
      ```
      ⚠️ **★このまま merge すると ★残り 2 つが ★見えなくなります**
      —— **★閉じるのは「終わった」ではなく ★「見えなくなる」の 方が 先に 効きます。**
      ⚪ **★残り 2 つを 別 issue に 出すか、#4497 を 開けたまま にするか は お任せします。**

## ✅ ★中身は 通ります（★テスト 6 問、私が 読みました）

```
① Tier ── ★2 で 妥当。`_approx_bytes` の 単調性は ★第三者の性質では ない
          （★実装が 要素を 自分で 足している ∴ ★足す行を 消せば 落ちる＝reyn の バグ）
② 転記   ── ★無し
③ 誰が困る ── ★/resident の 利用者。★falsify（delattr）は ★実モジュールを 剥がしており
             ★テスト自身が 組んだ 構成では ない
④ 走らず緑 ── ★該当なし（★optional extra 依存 なし、★14 件 実行を 確認）
⑤ 累積   ── ★無し（★1 回の 読み取り、★保持しない）
⑥ 宣言と 実体 ── ★一致
```
⚪ **★1 点 記録のみ（★ブロックしません）**: テストが `session._pending_user_images` に
**★直接 書いています**が、**★この機能の 測定対象 自体が private 容器**であり、
**★assert は 出力側**に 立っています ∴ **「private state を assert するな」には 当たりません。**


