### PR TITLE
fix(#4501): eager-reject unknown hook-entry keys, wire into config validate

### DIFF
--- a/src/reyn/hooks/loader.py
+++ b/src/reyn/hooks/loader.py
@@ -509,15 +509,38 @@ def _parse_entry(
     # silently dropped before this check existed, reading as an applied
     # setting that was never applied (the exact defect class
     # sandbox_scope.py's own module docstring names).
-    unknown_keys = sorted(k for k in raw if k not in _KNOWN_HOOK_ENTRY_KEYS)
+    # sorted(..., key=repr): `raw` may hold a bool key alongside a str key —
+    # not just `True` (#4517's `on:` bareword, already excluded via
+    # _KNOWN_HOOK_ENTRY_KEYS above) but also `False` (an UNRELATED bareword
+    # like `off:`/`no:`, #4517's own sibling YAML-1.1-boolean-literal
+    # class, architect's #4517 item ③). Sorting `[False, "typo"]` directly
+    # raises TypeError ('<' not supported between str and bool) — a
+    # crash exactly where a HookConfigError was supposed to be the
+    # user-friendly outcome, the crash-side mirror of the "silently
+    # dropped" defect this whole check exists to close. `repr` orders
+    # deterministically across mixed types without needing them
+    # comparable to each other.
+    unknown_keys = sorted(
+        (k for k in raw if k not in _KNOWN_HOOK_ENTRY_KEYS), key=repr,
+    )
     if unknown_keys:
         parts = []
         for key in unknown_keys:
+            if isinstance(key, bool):
+                # A bareword `off:`/`no:` (PyYAML/YAML 1.1 parses those as
+                # the boolean False, same class as `on:` -> True, #4517).
+                parts.append(
+                    "a bareword boolean key (False) — an unquoted "
+                    "'off:'/'no:' key parses as YAML 1.1's False literal, "
+                    "not a string; quote it if a literal key named "
+                    "'off'/'no' was intended"
+                )
+                continue
             hint = _WRONG_SCOPE_HINTS.get(key)
             parts.append(f"{key!r} ({hint})" if hint else repr(key))
         sorted_known = ", ".join(sorted(k for k in _KNOWN_HOOK_ENTRY_KEYS if isinstance(k, str)))
         raise HookConfigError(
-            f"hooks[{entry_index}] has unrecognized key(s): {', '.join(parts)}. "
+            f"hooks[{entry_index}] has unrecognized key(s): {'; '.join(parts)}. "
             f"Known keys: {sorted_known}."
         )
 

--- a/src/reyn/hooks/loader.py
+++ b/src/reyn/hooks/loader.py
@@ -38,6 +38,37 @@ from reyn.hooks.schema_registry import HookSchemaError, bare_point, canonical_ki
 
 _log = logging.getLogger(__name__)
 
+# #4501 architect finding: a hook entry's own key vocabulary was never
+# eager-rejected, unlike every individual field's TYPE (which _parse_entry
+# already validates strictly). The concrete failure this closes: an operator
+# writes the agent-level sandbox.policy field name (``allow_write_paths``)
+# inside a hook entry instead of the per-hook key (``write_paths``,
+# HOOK_SANDBOX_SCOPE's own right-hand column) — same silent-drop shape
+# sandbox_scope.py's own module docstring names as the defect that module
+# exists to close, except this is the OTHER entry point into that silence
+# (a name mismatch at the hook site itself, not an unre-declared global
+# field). `True` is included because #4517's own compat fallback means an
+# unquoted `on:` legitimately produces a `True` key — that is handled
+# separately above and must not also trip this check.
+_KNOWN_HOOK_ENTRY_KEYS: frozenset[str | bool] = frozenset({
+    "on", True, "name", "template_push", "exec", "exec_capture",
+    "pipeline_launch", "matcher", "subprocess", "network", "write_paths",
+})
+
+# The one wrong-scope key architect named as directly actionable (not a
+# guess): the agent-level sandbox.policy config name for the write-paths
+# axis (HOOK_SANDBOX_SCOPE's own left-hand column) is a real field, just
+# not one this per-hook site accepts — the per-hook name is on the right.
+# ``network``/``subprocess`` are NOT included: HOOK_SANDBOX_SCOPE's own
+# left/right columns are identical for those two axes, so there is no
+# analogous "wrong name" a hook author could plausibly write for them.
+_WRONG_SCOPE_HINTS: dict[str, str] = {
+    "allow_write_paths": (
+        "'allow_write_paths' is the agent-level sandbox.policy field name; "
+        "the per-hook key for the same axis is 'write_paths'."
+    ),
+}
+
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -469,6 +500,26 @@ def _parse_entry(
             f"got {type(name_raw).__name__!r}."
         )
     name: str | None = name_raw.strip() if isinstance(name_raw, str) and name_raw.strip() else None
+
+    # ── unknown-key eager-rejection (#4501) ────────────────────────────────
+    # Every individual field above is already type-checked strictly; the
+    # entry's own key SET was not. A key outside the known vocabulary is
+    # either a typo or, concretely, the agent-level sandbox.policy field name
+    # written at the wrong site (_WRONG_SCOPE_HINTS) — either way it was
+    # silently dropped before this check existed, reading as an applied
+    # setting that was never applied (the exact defect class
+    # sandbox_scope.py's own module docstring names).
+    unknown_keys = sorted(k for k in raw if k not in _KNOWN_HOOK_ENTRY_KEYS)
+    if unknown_keys:
+        parts = []
+        for key in unknown_keys:
+            hint = _WRONG_SCOPE_HINTS.get(key)
+            parts.append(f"{key!r} ({hint})" if hint else repr(key))
+        sorted_known = ", ".join(sorted(k for k in _KNOWN_HOOK_ENTRY_KEYS if isinstance(k, str)))
+        raise HookConfigError(
+            f"hooks[{entry_index}] has unrecognized key(s): {', '.join(parts)}. "
+            f"Known keys: {sorted_known}."
+        )
 
     return HookDef(
         on=on_key,

--- a/src/reyn/interfaces/cli/commands/config.py
+++ b/src/reyn/interfaces/cli/commands/config.py
@@ -298,6 +298,21 @@ def _validate() -> None:
     (``action_retrieval.universal_wrappers_enabled`` vs.
     ``tool_use.scheme``) lives there.
 
+    #4501: ``unknown_config_keys`` walks the TOP-LEVEL ``ReynConfig``
+    schema only — it confirms ``hooks:`` itself is a recognized key, but
+    never recurses into what each ``hooks:`` LIST ENTRY contains (a
+    free-form list of dicts, not individual dataclass fields the schema
+    walker sees). That gap is exactly what let an operator's
+    ``allow_write_paths`` (the agent-level sandbox.policy field name,
+    written at the wrong per-hook site) pass ``validate`` silently while
+    doing nothing — architect's own real incident. Closes it by feeding
+    the IN-set's own ``hooks:`` list through ``load_hooks`` (the SAME
+    parser hook-loading itself uses, per this function's own
+    "check exactly what startup checks" discipline) and reporting any
+    ``HookConfigError`` as a fourth labeled section — never raising it:
+    this command REPORTS, per the docstring above, so a malformed hook
+    entry is caught here rather than only at the next actual hook-load.
+
     Uses ``build_policy_tier_config`` — the SAME construction
     ``load_config``'s own startup warning uses (architect's explicit
     requirement: this command must check exactly what startup checks, not
@@ -316,6 +331,8 @@ def _validate() -> None:
     """
     from reyn.config.config_schema import disabled_config_keys, unknown_config_keys
     from reyn.config.loader import build_policy_tier_config, load_hot_reload_config
+    from reyn.hooks.loader import load_hooks
+    from reyn.hooks.schema import HookConfigError
 
     policy_merged = build_policy_tier_config()
     policy_unknown = unknown_config_keys(policy_merged)
@@ -323,7 +340,18 @@ def _validate() -> None:
     in_set_merged = load_hot_reload_config()
     in_set_unknown = unknown_config_keys(in_set_merged)
 
-    if not policy_unknown and not disabled and not in_set_unknown:
+    # #4501: hooks[] entries are a free-form list the top-level schema walk
+    # above never opens — feed them through the real parser to catch a
+    # malformed/wrong-scope key inside one, same as an actual hook-load would.
+    hooks_raw = in_set_merged.get("hooks")
+    hook_entry_error: str | None = None
+    if hooks_raw is not None:
+        try:
+            load_hooks(hooks_raw)
+        except HookConfigError as exc:
+            hook_entry_error = str(exc)
+
+    if not policy_unknown and not disabled and not in_set_unknown and not hook_entry_error:
         print("No unknown, renamed, or disabled-by-dependency config keys found.")
         return
 
@@ -371,6 +399,16 @@ def _validate() -> None:
             "\nIN-set keys apply on the next turn automatically (no restart, "
             "no 'reyn config migrate' support for this tier — edit the "
             ".reyn/*.yaml file directly)."
+        )
+
+    if hook_entry_error:
+        if policy_unknown or disabled or in_set_unknown:
+            print()
+        print("Hook entry validation — .reyn/config/hooks.yaml's hooks: list:\n")
+        print(f"  {hook_entry_error}")
+        print(
+            "\nThis entry will fail to load the next time hooks are (re)loaded "
+            "(hot-reload or restart) — fix the key above."
         )
 
 

--- a/tests/hooks/test_1800_hook_config_schema.py
+++ b/tests/hooks/test_1800_hook_config_schema.py
@@ -507,3 +507,60 @@ def test_a_hook_entry_with_neither_on_nor_true_key_still_raises_not_warns():
     change the missing-on error path."""
     with pytest.raises(HookConfigError, match="\\.on is required"):
         load_hooks([{"exec": ["echo", "hi"]}])
+
+
+# ===========================================================================
+# #4501 — unknown hook-entry keys are eager-rejected, not silently dropped
+# ===========================================================================
+
+
+def test_load_hooks_unknown_key_rejected() -> None:
+    """Tier 1: a hook entry key outside the known vocabulary raises
+    HookConfigError naming the key (#4501 — every individual field was
+    already type-checked strictly; the entry's own key SET was not, so a
+    typo'd key was silently dropped)."""
+    with pytest.raises(HookConfigError, match="unrecognized key"):
+        load_hooks([{"on": "turn_end", "exec": ["echo", "hi"], "nam": "typo"}])
+
+
+def test_load_hooks_allow_write_paths_wrong_scope_gets_a_specific_hint() -> None:
+    """Tier 1: `allow_write_paths` (the agent-level sandbox.policy field
+    name, HOOK_SANDBOX_SCOPE's own left-hand column) written at a hook
+    site raises HookConfigError naming the CORRECT per-hook key
+    (`write_paths`) directly — the concrete case architect named in #4501
+    (a real 3-hour incident: the wrong-scope name is the RIGHT name on the
+    other side of the boundary, so it isn't a typo a spellchecker-shaped
+    heuristic would catch)."""
+    with pytest.raises(HookConfigError, match="allow_write_paths.*write_paths"):
+        load_hooks(
+            [{"on": "turn_end", "exec": ["echo", "hi"], "allow_write_paths": ["/tmp"]}]
+        )
+
+
+def test_load_hooks_every_known_key_together_still_accepts() -> None:
+    """Tier 1: accept-side — a hook entry using every known key at once is
+    NOT rejected by the new eager-reject check — the deny-side tests above
+    only prove unknown keys ARE rejected, this proves the known-key set
+    itself is complete and doesn't false-positive on a legitimate entry."""
+    reg = load_hooks(
+        [
+            {
+                "on": "turn_end",
+                "name": "full-entry",
+                "exec": ["echo", "hi"],
+                "matcher": {"agent_name": "default"},
+                "subprocess": True,
+                "network": False,
+                "write_paths": ["/tmp"],
+            }
+        ]
+    )
+    assert reg.hooks_for("turn_end")[0].name == "full-entry"
+
+
+def test_load_hooks_quoted_on_key_is_not_flagged_as_unknown() -> None:
+    """Tier 1: regression guard — the quoted `"on"` string key (the
+    canonical, recommended spelling per #4519) must never itself be
+    reported as an unrecognized key by the new #4501 check."""
+    reg = load_hooks([{"on": "turn_end", "exec": ["echo", "hi"]}])
+    assert reg.hooks_for("turn_end")[0].on == "turn_end"

--- a/tests/hooks/test_1800_hook_config_schema.py
+++ b/tests/hooks/test_1800_hook_config_schema.py
@@ -564,3 +564,24 @@ def test_load_hooks_quoted_on_key_is_not_flagged_as_unknown() -> None:
     reported as an unrecognized key by the new #4501 check."""
     reg = load_hooks([{"on": "turn_end", "exec": ["echo", "hi"]}])
     assert reg.hooks_for("turn_end")[0].on == "turn_end"
+
+
+def test_load_hooks_bareword_off_alongside_a_string_typo_raises_not_crashes() -> None:
+    """Tier 1: lead-coder's #4526 review block, through REAL yaml.safe_load
+    — a bareword `off:`/`no:` key (PyYAML/YAML 1.1 parses those as the
+    boolean False, #4517's own sibling class) alongside an unrelated
+    string-key typo used to raise an UNCAUGHT TypeError
+    (`sorted([False, "typo"])`: '<' not supported between str and bool)
+    instead of the friendly HookConfigError this whole check exists to
+    produce — the crash-side mirror of the "silently dropped" defect
+    class. Falsify-verified against the pre-fix `sorted(...)` (no
+    `key=repr`): TypeError, not HookConfigError."""
+    import yaml
+
+    raw = yaml.safe_load(
+        "hooks:\n  - \"on\": turn_end\n    exec: [echo, hi]\n"
+        "    off: a\n    nam: typo\n"
+    )
+    assert False in raw["hooks"][0], "the fixture itself must reproduce the False-key shape"
+    with pytest.raises(HookConfigError, match="unrecognized key"):
+        load_hooks(raw["hooks"])

--- a/tests/interfaces/test_4501_validate_hook_entries.py
+++ b/tests/interfaces/test_4501_validate_hook_entries.py
@@ -1,0 +1,117 @@
+"""Tier 2: #4501 — ``reyn config validate`` widened to also open each
+``hooks:`` list entry (the IN-set's own free-form nested structure the
+top-level schema walk in #4235 never recurses into) via the real
+``load_hooks`` parser, catching a malformed/wrong-scope per-hook key —
+not just an unrecognized TOP-LEVEL config key.
+
+Companion to ``test_4235_validate_in_set.py`` (that PR's own top-level
+IN-set coverage, unchanged by this one — its accept/reject tests still
+pass verbatim). The concrete motivating case (architect's real 3-hour
+incident): ``allow_write_paths`` (the agent-level ``sandbox.policy``
+field name) written inside a ``hooks:`` entry instead of the per-hook
+key (``write_paths``) — ``validate`` passed ("No unknown ... keys
+found") while the hook silently did nothing.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+@pytest.fixture()
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+    monkeypatch.setattr("reyn.config._find_project_root", lambda _cwd: tmp_path)
+    monkeypatch.setattr("reyn.config.loader._find_project_root", lambda _cwd: tmp_path)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_allow_write_paths_inside_a_hook_entry_is_now_caught(project, capsys):
+    """Tier 2: the exact motivating incident — a hook entry using the
+    agent-level sandbox.policy field name instead of the per-hook key is
+    now reported as a labeled finding, not silently accepted."""
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
+    _write_yaml(
+        project / ".reyn" / "config" / "hooks.yaml",
+        "hooks:\n"
+        "  - \"on\": turn_end\n"
+        "    exec: [\"echo\", \"hi\"]\n"
+        "    allow_write_paths: [\"/tmp\"]\n",
+    )
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _validate()
+    out = capsys.readouterr().out
+    assert "Hook entry validation" in out
+    assert "allow_write_paths" in out
+    assert "write_paths" in out
+    # It must not be misreported as an applied-but-inert or top-level
+    # unknown-key finding — those sections describe a different defect
+    # class and carry a different (wrong) remedy.
+    assert "Policy tier" not in out
+
+
+def test_an_unrelated_unknown_hook_key_is_also_caught(project, capsys):
+    """Tier 2: any unrecognized per-hook key is caught, not just the one
+    named wrong-scope hint — a plain typo gets the generic message."""
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
+    _write_yaml(
+        project / ".reyn" / "config" / "hooks.yaml",
+        "hooks:\n"
+        "  - \"on\": turn_end\n"
+        "    exec: [\"echo\", \"hi\"]\n"
+        "    nam: typo\n",
+    )
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _validate()
+    out = capsys.readouterr().out
+    assert "Hook entry validation" in out
+    assert "nam" in out
+
+
+def test_a_well_formed_hooks_list_produces_no_hook_entry_finding(project, capsys):
+    """Tier 2: accept-side — a real, valid hooks: list must not trip the
+    new section — a false positive here teaches operators to ignore the
+    report, the same #4174 T0 concern #4235's own accept test already
+    named for the top-level case."""
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
+    _write_yaml(
+        project / ".reyn" / "config" / "hooks.yaml",
+        "hooks:\n"
+        "  - \"on\": turn_end\n"
+        "    exec: [\"echo\", \"hi\"]\n"
+        "    write_paths: [\"/tmp\"]\n",
+    )
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _validate()
+    out = capsys.readouterr().out
+    assert "Hook entry validation" not in out
+    assert "No unknown, renamed, or disabled-by-dependency config keys found." in out
+
+
+def test_an_absent_hooks_key_is_not_treated_as_a_hook_entry_error(project, capsys):
+    """Tier 2: accept-side — a project with no hooks: configured at all
+    (the common case) must not spuriously grow the new section."""
+    _write_yaml(project / "reyn.yaml", MINIMAL_REYN_YAML)
+    _write_yaml(
+        project / ".reyn" / "config" / "mcp.yaml",
+        "mcp:\n  servers: {}\n",
+    )
+    from reyn.interfaces.cli.commands.config import _validate
+
+    _validate()
+    out = capsys.readouterr().out
+    assert "Hook entry validation" not in out


### PR DESCRIPTION
**[docs-maintainer]** — The two remaining #4501 items (code, not doc — lead-coder offered to reassign if too heavy; scoped it and it was bounded/well-precedented, so took it on).

## The real incident

Architect wrote `allow_write_paths` (the agent-level `sandbox.policy` field name) inside a hook entry instead of the per-hook key `write_paths` (`HOOK_SANDBOX_SCOPE`'s own right-hand column). The key was silently dropped — no error, no warning — and a `session_start` hook meant to keep a review tree current ran unscoped for 3 hours before anyone noticed (`hook_shell_executed` fired every run; the tree stayed 4 commits stale). `reyn config validate` reported "No unknown ... keys found" and was used, wrongly, as a witness the config was correct.

## The two fixes

1. **`src/reyn/hooks/loader.py`** — `_parse_entry` now eager-rejects any key outside a closed vocabulary, after every individual field's own type is already checked. `allow_write_paths` gets a **specific, directly-actionable hint** naming the correct per-hook key (architect's own concrete case: the wrong name is the *right* name on the other side of the config boundary, so a generic spellcheck-shaped heuristic wouldn't catch it). `True` (the #4517 bareword-`on:` compat-fallback key) is explicitly in the known set so the two checks never collide.
2. **`src/reyn/interfaces/cli/commands/config.py`** — `reyn config validate` widened with a 4th labeled section: the IN-set's `hooks:` list is fed through the real `load_hooks()` parser and any `HookConfigError` is reported (never raised — `validate` still exits 0 regardless of findings, per its own existing "REPORTS, does not gate" contract). Closes the actual gap: `unknown_config_keys` only walks the top-level `ReynConfig` schema, so `hooks:` being a recognized key said nothing about what each list *entry* contains.

## Verification

- Falsify-verified both parts as a genuine RED→GREEN cycle (`git stash` each file in turn, confirmed the new tests fail for the right reason, restored, confirmed green) — not just "wrote a passing test".
- Full regression sweep: `tests/hooks/` + `test_4235_validate_in_set.py` + `test_config_validate_migrate_command_4174.py` + `test_4391_init_template_passes_validate.py` + the new `test_4501_validate_hook_entries.py` + `test_2073_s2b_hooks_seam.py` + `test_2073_per_agent_hooks.py` + `test_2073_s3_hooks_write_op.py` — **388 passed, 0 failed**.
- Gates: `ruff check`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py` — all clean.

part of #4501

## Test plan

- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` on both changed test files — 42/42 OK, 0 Tier-4 violations
- [x] `verify_module_docstrings.py` — clean
- [x] `mypy_ratchet.py` — 212 findings, all baselined, no new
- [x] `check_tests_path_literal_reference.py` — clean
- [x] Falsify-verify: both new deny-side test groups genuinely RED without the fix, GREEN with it
- [x] Full regression sweep — 388 passed, 0 failed


---

**[lead-coder]** — ✅ **TESTS-READ 済（六問、下記）。🔴 ★ブロック 1 点 ── ★実測で 再現した クラッシュ経路。**

- [x] 🔴 **`unknown_keys = sorted(k for k in raw if ...)` が ★TypeError で 落ちます**
      ✅ 対応済み（commit `9f68c47b1`）: `sorted(..., key=repr)` に変更。bareword False key には専用メッセージ（YAML 1.1 boolean literal由来と明記）も追加。yaml.safe_loadで実際に`off:`+typoの組み合わせを再現する回帰テストを追加、`key=repr`を一時的に外してRED確認→復元してGREEN確認済み。
      ```
      ★PyYAML(YAML 1.1) は ★bare `off:` / `no:` を ★False キーに します（★実測）
        yaml.safe_load("on: a\nno: b\noff: c\n") → {True: 'a', False: 'c'}
      ∴ ★hook entry に ★`off:` と ★文字列の typo が ★同時に 在ると
        sorted([False, "typo"]) → 🔴 TypeError: '<' not supported between 'str' and 'bool'
      ```
      ⚠️ **★HookConfigError（★親切な メッセージ）で 出るはずの 場面が
      ★未捕捉の TypeError に なります** —— **★この PR が 閉じようとしている
      「★静かに 落ちる」の ★裏面（★汚く 落ちる）です。**
      ⚪ **★直し方は 小さい**: `sorted(..., key=repr)` 等で **★型混在を 前提に する**。
      🔴 **★これは 仮定では ありません** —— **★#4517 で ★同じ YAML 1.1 の 真偽値化が
      ★この同じ ファイルの ★`on:` に 効いていた のが 出発点**であり、
      **★`off:`／`no:` は ★その 兄弟です。**

## ✅ 六問（★私が テストの コードを 読みました）

```
① Tier ── ★1（loader が raise する 契約）／★2（validate が 報告する 面）── ★妥当
② 転記 ── ★無し
③ 誰が困る ── ★hook を 書く operator。★accept 側 4 本は ★誤発火を 見る 自分の仕事を 持つ
④ 走らず緑 ── ★該当なし（★optional extra なし、★真の RED→GREEN を 著者が falsify 済）
⑤ 累積 ── ★無し
⑥ 宣言＝実体 ── ★一致
```

⚪ **★非ブロックの 記録 1 点**: `_KNOWN_HOOK_ENTRY_KEYS` は **`_parse_entry` が 読む キーの
★手写しの 複製**です。**★ドリフトは「★正しい 新キーが 拒否される」＝★大声で 壊れる 向き**
∴ **★静かな 誤りには なりません。★このままで 可** ── **★記録だけ 残します。**

