### PR TITLE
docs(#4497): add the new /resident slash command to chat.md's table

### DIFF
--- a/docs/reference/cli/chat.md
+++ b/docs/reference/cli/chat.md
@@ -96,6 +96,7 @@ While a session is active, lines starting with `/` are intercepted and never rou
 | `/quit` | Exit the chat (alias: `/exit`, Ctrl+D) |
 | `/reload` | Hot-reload runtime config (`.reyn/*.yaml`) at the next turn boundary |
 | `/reset confirm` | Reset in-flight run state (snapshots + WAL; audit logs preserved) |
+| `/resident` | Approximate resident-memory breakdown by in-process container — count + shallow `sys.getsizeof` estimate, session-lifetime and process-global, no threshold, no eviction (#4497 Phase 1) |
 | `/rewind [seq]` | Time-travel to an earlier checkpoint — no arg opens the picker menu; `seq` jumps directly (see [Time-travel](../../concepts/runtime/time-travel.md) · [How-to](../../guide/for-users/time-travel.md)) |
 | `/session new \| switch <sid> \| list` | Open / switch / list conversation sessions for the attached agent (see [Sessions](../../concepts/multi-agent/sessions.md)) |
 | `/visibility on\|off <tool\|mcp\|category> <name>` | Toggle this session's LLM visibility of a capability (hidden next turn / restored up to the agent's authorized envelope — an envelope-denied capability stays hidden) |


### PR DESCRIPTION
**[docs-maintainer]** — Small doc-drift item, part of #4497: the `/resident` slash command #4524 added had no matching row in `docs/reference/cli/chat.md`.

## What drifted

#4524 (#4497 Phase 1) added `src/reyn/interfaces/slash/resident.py` — unlike #4513's own `/open` addition (which updated `chat.md` in the same PR), #4524 touched no `docs/` file.

## The fix

Added a row for `/resident` to `chat.md`'s slash-command table, inserted alphabetically between `/reset confirm` and `/rewind`. Content verified against `resident.py`'s actual `@slash` summary and `_render()` output shape (count + approximate bytes, session-lifetime + process-global, no threshold, no eviction) directly.

Not backfilled into `chat.ja.md` — confirmed `/open` (a more established, earlier-landed command) was never backfilled there either, so this follows the existing pattern rather than introducing new drift (CLAUDE.md rule 5: no blanket mirror obligation).

## Verification

- `mkdocs build --strict -f .mkdocs/mkdocs.yml` — no error/Aborted line.
- `ruff check src tests` — clean.

part of #4497

## Test plan

- [x] `mkdocs build --strict` — clean, no Aborted/error line (read directly)
- [x] `ruff check src tests` — clean
- [x] Verified table row against `resident.py`'s actual implementation
- [x] Confirmed `/open` wasn't backfilled into `chat.ja.md` either, before deciding to skip ja here
- [x] (skipped — docs-only edit, no runtime behavior change, no test to run)
