### PR TITLE
docs(#2448): remove per-chain-cap references left stale by the #2448 removal

### DIFF
--- a/docs/reference/config/budget.ja.md
+++ b/docs/reference/config/budget.ja.md
@@ -110,9 +110,6 @@ Usage (process invocation):
     tokens:       12,450 / 50,000  (warn at 40,000)
     cost:         $0.0187 / $2.00     (warn at $1.60)
 
-  Per-chain skill calls:
-    chain-abc/direct_llm:  2 / 5
-
   Rate limit (last minute):
     openai/gpt-4o:  14 / 60  (warn at 48)
 

--- a/docs/reference/config/budget.md
+++ b/docs/reference/config/budget.md
@@ -128,9 +128,6 @@ Usage (process invocation):
     tokens:       12,450 / 50,000  (warn at 40,000)
     cost:         $0.0187 / $2.00     (warn at $1.60)
 
-  Per-chain skill calls:
-    chain-abc/direct_llm:  2 / 5
-
   Rate limit (last minute):
     openai/gpt-4o:  14 / 60  (warn at 48)
 


### PR DESCRIPTION
**[docs-maintainer]** — Picking up part of a noted-but-out-of-scope item #4527 flagged explicitly. **Scoped down**: `feature-map.md`'s own row is #4530's (tui-coder) — lead-coder showed the same source (#4529) to both of us without flagging the overlap. This PR now keeps only `budget.md`/`budget.ja.md`, which #4530 doesn't touch.

## What drifted

`#2448` ("refactor(#2439): remove dead budget per-chain skill-spawn cap subsystem") removed the per-chain-skill-spawn-cap machinery entirely — confirmed directly against current source: no `per_chain`/`Per-chain` content anywhere in `src/reyn/interfaces/slash/budget.py` (the `/budget` command's own implementation), only historical comments elsewhere referencing the now-removed `per_chain_skill_calls` dimension by name.

Two stale spots:
- `docs/reference/config/budget.md`'s own `/budget` example **output** block still showed a "Per-chain skill calls: chain-abc/direct_llm: 2 / 5" section — presented as literal command output a user would actually see, which it can't produce anymore.
- `docs/reference/config/budget.ja.md` — the identical stale block, found while checking for the en sibling's own drift (not required by CLAUDE.md's no-mirror-obligation rule, but a real, present falsified claim in the ja doc itself, not a mirror-parity exercise).

`budget.md`'s own "Legacy note" (already correctly describing the ledger compat shim for pre-removal spawn records) was left untouched — it's already accurate, not stale.

## Verification

- `mkdocs build --strict -f .mkdocs/mkdocs.yml` — no error/Aborted line.
- `ruff check src tests` — clean.

part of #2448

## Test plan

- [x] `mkdocs build --strict` — clean, no Aborted/error line (read directly)
- [x] `ruff check src tests` — clean
- [x] Verified against `budget.py`'s actual current implementation, not the commit message alone
- [x] Confirmed no overlap with #4530 (feature-map.md untouched by this PR)
- [x] (skipped — docs-only edit, no runtime behavior change, no test to run)
