### PR TITLE
docs(#4529): drop the outline's own "Per-chain caps" entry, the 5th stale site

### DIFF
--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -118,7 +118,6 @@ mindmap
       Compaction secret redact
     💰 Budget and Cost
       Per-agent caps
-      Per-chain caps
       Rate limits
       Daily/monthly quotas
       High-cost model warn


### PR DESCRIPTION
**[lead-coder]** — part of #4529. **★5 番目の 現場。★3 人の grep が 全部 通り過ぎました。**

## 何を 直したか

```
docs/feature-map.md:121  ── ★冒頭の アウトライン（★表でも 散文でもない ★字下げ 1 行）
      Per-agent caps
-     Per-chain caps      ← ★これ
      Rate limits
```

## ★なぜ 4 回 探して 残ったか

```
★私(#4529 起票)      ── ★表の行 の 形で grep      → 2 箇所
★tui-coder(#4530)   ── ★表 ＋ 散文             → ＋2 箇所（要約行・blurb）
★docs-maintainer(#4531) ── ★出力例             → ＋2 箇所（budget.md / ja）
🔴 ★誰も ★字下げだけの アウトライン行 を 探していません
```
⚪ **★同じ 主張が ★4 つの 別々の 書式で 書かれていた** ── **★表の行／★散文／★コマンド出力例／
★アウトライン。★形を 1 つ 想定した 検索は、★その形しか 見つけません。**

## 実測（★2026-08-13、origin/main）

```
✅ ★src/ の `per_chain_skill_calls`  ── hit 0
✅ ★src/ の `skill_calls_per_chain`  ── hit 0
   ── ★#2448 が subsystem ごと 削除済
✅ ★残る hit は 全て「★レガシー注記」の 形（★正しい）
   budget.md:331 / budget.ja.md:191 / state-dir.md:61 / state-dir.ja.md:87
   ── ★「過去の ledger に 残っている ことがある／今は 書かれない」
```

## Test plan

- [x] `git grep` on `origin/main` で ★残存を 再確認（★上記）
- [x] ★doc のみ・★1 行削除 ∴ ★test 変更なし
- [ ] (Visual — 該当なし)
