### PR TITLE
fix(#2582): per-internal-sub-step durability for compositional-do fan-out items

### DIFF
--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -16,21 +16,32 @@ non-linear primitives are now implemented; ``refine`` (a pipeline-level
 construct, not a step kind) stays out of scope.
 
 **Fan-out recovery commit unit = the ITEM (READ THIS before touching
-``for_each`` recovery).** ``for_each`` runs ``do`` over each list item as an
-ISOLATED concurrent sub-scope (Hard rule 6: read-only ctx, no sibling comm), a
-coordinator recording each item's result AS IT LANDS via ``asyncio.as_completed``
-(never bare ``gather``). The recovery commit unit is the ITEM: a LANDED item is
+``for_each``/``parallel`` recovery).** ``for_each`` runs ``do`` over each list
+item (``parallel`` runs each named branch) as an ISOLATED concurrent sub-scope
+(Hard rule 6: read-only ctx, no sibling comm), a coordinator recording each
+item's/branch's result AS IT LANDS via ``asyncio.as_completed`` (never bare
+``gather``). The recovery commit unit is the ITEM/BRANCH: a LANDED one is
 exactly-once (its key is durable before the next boundary; resume replays it,
-never re-runs it). A single-step ``do`` (the common case) therefore has NO
-recovery gap — it is exactly-once identical to a durable step. The ONE gap: a
-COMPOSITIONAL ``do`` (``call``/``match``/``fold``) that is IN-FLIGHT at a crash
-re-runs ATOMICALLY on resume (its item key was never recorded), so its already-
-completed INTERNAL side effects may re-fire — because item tasks record through a
-NO-OP recorder (only the single coordinator coroutine calls the real ``record``,
-serialized by construction, avoiding the read-modify-write race concurrent
-per-task recording would cause). Per-internal-sub-step durability for
-compositional fan-out items (a lock-guarded serialized-recorder path) is a
-tracked follow-up, not a silent gap.
+never re-runs it). A single-step ``do`` has always been exactly-once this way.
+
+**#2582: the compositional-``do`` (``call``/``match``/``fold``) gap is CLOSED.**
+Previously an item/branch task recorded through a NO-OP recorder (only the
+coordinator coroutine ever called the real ``record``), so a crash mid-item
+lost the compositional ``do``'s internal progress and re-ran it ATOMICALLY on
+resume — its already-completed INTERNAL side effects re-fired. Each item/branch
+task now gets its OWN real recorder
+(:func:`_make_fan_out_sub_step_recorder`) that journals its compositional
+``do``'s internal sub-steps durably AS THEY LAND, same as the top-level/single-
+``call`` path already did. The read-modify-write race that motivated the
+original no-op design (concurrent tasks racing to write
+``completed_step_results``) is closed by :class:`_FanOutRecordBox`'s ONE
+``asyncio.Lock``, shared by every writer touching a given fan-out step's state
+— the coordinator's own end-of-item/branch record calls AND every item/branch's
+sub-step recorder. A mid-item crash now replays its completed internal
+sub-step(s) on resume instead of re-firing them; a within-process ``retry(n)``
+gets the identical benefit (a failed attempt's already-durable sub-steps are
+not re-run on the next attempt either) since both paths share the same
+``_run_scope`` replay-by-key check.
 
 **Dispatch tables (R7 — the parallel-primitive seam).** Step execution is a
 ``dict``-dispatch keyed by the step's dataclass type
@@ -701,6 +712,80 @@ def _is_dropped_marker(value: Any) -> bool:
     return isinstance(value, dict) and set(value) == {_FAN_OUT_DROPPED_KEY, "error"}
 
 
+class _FanOutRecordBox:
+    """#2582: the fan-out coordinator's growing ``completed_step_results``, plus
+    the ONE ``asyncio.Lock`` serializing every writer that touches it — the
+    coordinator's own end-of-item/branch record calls AND the per-item/branch
+    sub-step recorders :func:`_make_fan_out_sub_step_recorder` hands to a
+    compositional ``do`` (``call``/``match``/``fold``). A plain local variable
+    cannot be shared this way: item/branch tasks are separate coroutines, and
+    reassigning a nested function's enclosing-scope name needs an object to
+    mutate (``nonlocal`` only rebinds inside the SAME lexical function), so this
+    is threaded explicitly instead.
+
+    The lock exists for the SAME reason the original no-op recorder did (see the
+    module docstring's "commit unit = the ITEM"): two concurrent writers must
+    never both read ``state_log.last_durable_seq`` and race to
+    ``submit_durable`` before either advances it — whichever write lands second
+    would silently clobber the first's generation at the SAME seq. Serializing
+    every writer through this one lock (dict-merge + the durable write, as one
+    critical section) closes that race, so per-internal-sub-step durability can
+    be added SAFELY on top of the concurrent fan-out this already was."""
+
+    __slots__ = ("value", "lock")
+
+    def __init__(self, initial: "dict[str, Any]") -> None:
+        self.value = initial
+        self.lock = asyncio.Lock()
+
+
+def _make_fan_out_sub_step_recorder(
+    box: "_FanOutRecordBox", outer_record: Recorder, item_prefix: str,
+) -> Recorder:
+    """#2582: a REAL (no longer no-op) per-item/per-branch recorder for a
+    compositional ``do`` reached from inside ``for_each``/``parallel``. Closes
+    the documented atomic-re-run gap — a compositional ``do``'s internal
+    sub-steps (``call``/``match``/``fold``'s own ``_run_scope`` recursion) now
+    journal durably as they land, instead of only the item/branch's FINAL
+    result being recorded once the whole task returns. On resume, a mid-item
+    crash therefore replays its already-completed internal sub-step(s) instead
+    of re-firing them (the SAME ``_run_scope`` replay-by-key check the
+    top-level/single-``call`` path already relies on — see ``for_each`` items
+    with a single-step ``do`` were already exactly-once; this extends the SAME
+    mechanism one level deeper).
+
+    Filters to keys under ``item_prefix + "."`` ONLY: a compositional runner
+    only ever grows its OWN sub-scope's dotted keys, never the item/branch's
+    own bare label key (the coordinator records that separately once the task
+    returns) — so this recorder can never race the coordinator over the SAME
+    key, and per-item state stays isolated (Hard rule 6). The trailing dot is
+    load-bearing: without it, item 1's filter would ALSO match item 10's keys
+    (``"...for_each.1"`` is a plain string prefix of ``"...for_each.10..."``).
+
+    ``forwarded`` (closed over per call to this factory, i.e. per item/branch)
+    tracks which keys THIS item has already pushed into ``box``, so a later
+    call — ``_run_scope`` re-invokes ``record`` once per newly-completed
+    sub-step, each call carrying the item's WHOLE local snapshot, not just the
+    delta — only forwards the genuinely new key(s), never re-merges (and
+    re-writes a generation for) ones already durable."""
+    prefix = item_prefix + "."
+    forwarded: "set[str]" = set()
+
+    async def _record(*, completed_step_results: "dict[str, Any]", durable: bool) -> None:
+        new_keys = {
+            k: v for k, v in completed_step_results.items()
+            if k.startswith(prefix) and k not in forwarded
+        }
+        if not new_keys:
+            return
+        async with box.lock:
+            box.value = {**box.value, **new_keys}
+            forwarded.update(new_keys)
+            await outer_record(completed_step_results=box.value, durable=durable)
+
+    return _record
+
+
 class SpawnBudget:
     """S5 guard (c) — a per-RUN monotonic session-spawn counter. Constructed ONCE
     per top-level ``run``/``resume`` and shared BY REFERENCE across every nested
@@ -1334,16 +1419,20 @@ async def _run_for_each_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
 
     Resolve the list source, then a SINGLE coordinator coroutine fans ``do`` out
     over the items via ``asyncio.as_completed`` gated by a ``Semaphore`` (S5 guard
-    a), recording each item's result AS IT LANDS (only the coordinator ever calls
-    the real ``record`` — item tasks use a NO-OP recorder, so there is no
-    concurrent read-modify-write race on ``completed_step_results``; see the
-    module docstring's "commit unit = the ITEM"). ``on_error`` decides an item
-    failure: ``continue`` records a DROPPED kind-marker (so resume never re-runs
-    it); ``retry(n)`` re-runs the item up to ``n`` more times then falls back to
-    ``abort``; ``abort`` cancels the still-pending items and fails the step (the
-    already-landed items stay durably recorded, so a resume after an abort-crash
-    skips them). After every item index has a key, ``collect`` runs ONCE over the
-    filtered ordered results and its result is this step's N2 return value.
+    a), recording each item's result AS IT LANDS. #2582: every writer — the
+    coordinator's own end-of-item record AND each item's compositional-``do``
+    sub-step recorder (:func:`_make_fan_out_sub_step_recorder`) — goes through
+    the SAME :class:`_FanOutRecordBox` lock, so concurrent items cannot race the
+    read-modify-write of ``completed_step_results`` (see the module docstring's
+    "commit unit = the ITEM"). ``on_error`` decides an item failure: ``continue``
+    records a DROPPED kind-marker (so resume never re-runs it); ``retry(n)``
+    re-runs the item up to ``n`` more times then falls back to ``abort``;
+    ``abort`` cancels the still-pending items and fails the step (the
+    already-landed items — including a still-in-flight compositional item's
+    already-durable internal sub-steps — stay durably recorded, so a resume
+    after an abort-crash skips them). After every item index has a key,
+    ``collect`` runs ONCE over the filtered ordered results and its result is
+    this step's N2 return value.
 
     S5 guards: (a) the ``Semaphore`` caps live concurrency; (b) ``fan_out_depth``
     is +1'd through ``_RunDeps`` into every item/collect sub-scope, failing the
@@ -1353,13 +1442,13 @@ async def _run_for_each_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
     deps = inv.deps
     context = inv.context
     label = inv.step_label
-    completed = inv.completed_step_results
+    box = _FanOutRecordBox(inv.completed_step_results)
 
     # Full-completion replay: if collect already ran (its key is present) the whole
     # for_each is done — replay its N2 result, execute nothing.
     collect_key = f"{label}.for_each.collect"
-    if collect_key in completed:
-        return completed[collect_key], False, completed
+    if collect_key in box.value:
+        return box.value[collect_key], False, box.value
 
     source = _resolve_list_source(step, context, label, "for_each")
     n = len(source)
@@ -1380,11 +1469,6 @@ async def _run_for_each_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
     outer_stores = context["ctx"]
     outer_pipe = context["pipe"]
 
-    async def _noop_record(**_kw: Any) -> None:
-        # Item tasks NEVER record: only the single coordinator does (serialized),
-        # so concurrent items cannot race the read-modify-write of the snapshot.
-        return None
-
     async def _run_item(item_idx: int, item: Any) -> "tuple[int, Any, bool, Exception | None]":
         # Retry(n) re-runs INSIDE the same task (same semaphore slot — a retry
         # does not raise live concurrency). Any Exception is an item failure
@@ -1392,15 +1476,27 @@ async def _run_for_each_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
         # abort-cancel propagates out and the task is gathered in the finally).
         attempts = 1 + (on_err.retries if on_err.kind == "retry" else 0)
         last_exc: "Exception | None" = None
+        item_label = f"{label}.for_each.{item_idx}"
         for _attempt in range(attempts):
             item_ctx = {"ctx": dict(outer_stores), "pipe": outer_pipe, "item": item}
             runner = STEP_DISPATCH.get(type(step.do))
             if runner is None:  # pragma: no cover - Step is a closed union
                 raise PipelineExecutionError(f"unknown step type: {step.do!r}")
+            # #2582: a REAL recorder (not a no-op) — a compositional `do`
+            # (call/match/fold) journals its own internal sub-steps durably
+            # AS THEY LAND, through the shared `box` lock. A leaf `do`
+            # (transform/tool/agent) never calls `record` at all (leaf
+            # runners don't — see the module docstring), so this changes
+            # nothing for the single-step case the exactly-once item-commit
+            # gate already covers. A retried attempt re-reads `box.value`
+            # fresh, so a sub-step durably recorded by a FAILED prior
+            # attempt replays (does not re-fire) on the next attempt too —
+            # the same exactly-once mechanism, not crash-recovery-only.
             do_inv = _StepInvocation(
                 executor=inv.executor, step=step.do, context=item_ctx,
-                step_label=f"{label}.for_each.{item_idx}", deps=child_deps,
-                completed_step_results=completed, record=_noop_record,
+                step_label=item_label, deps=child_deps,
+                completed_step_results=box.value,
+                record=_make_fan_out_sub_step_recorder(box, inv.record, item_label),
             )
             try:
                 result, durable, _ = await runner(do_inv)
@@ -1423,7 +1519,7 @@ async def _run_for_each_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
 
     # Only items whose key is ABSENT run (resume re-runs exactly the absent ones;
     # a present success key replays, a present dropped-marker stays dropped).
-    pending = [i for i in range(n) if f"{label}.for_each.{i}" not in completed]
+    pending = [i for i in range(n) if f"{label}.for_each.{i}" not in box.value]
     any_durable = False
     if pending:
         effective_max_parallel = step.max_parallel or min(len(pending), _DEFAULT_MAX_PARALLEL)
@@ -1438,19 +1534,24 @@ async def _run_for_each_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
             for fut in asyncio.as_completed(tasks):
                 item_idx, result, durable, exc = await fut
                 key = f"{label}.for_each.{item_idx}"
+                # #2582: the coordinator's own end-of-item write shares `box.lock`
+                # with the item's own sub-step recorder, so the two can never race
+                # each other's read-modify-write of `box.value`.
                 if exc is None:
-                    completed = {**completed, key: result}
-                    any_durable = any_durable or durable
-                    await inv.record(completed_step_results=completed, durable=durable)
+                    async with box.lock:
+                        box.value = {**box.value, key: result}
+                        any_durable = any_durable or durable
+                        await inv.record(completed_step_results=box.value, durable=durable)
                 elif on_err.kind == "continue":
                     # DROP the failed item: record a kind-marker (NOT absent — else
                     # resume re-runs it forever; NOT bare None — a legit result).
-                    completed = {
-                        **completed,
-                        key: {_FAN_OUT_DROPPED_KEY: True, "error": str(exc)},
-                    }
-                    any_durable = True  # a drop MUST survive to resume (awaited-durable)
-                    await inv.record(completed_step_results=completed, durable=True)
+                    async with box.lock:
+                        box.value = {
+                            **box.value,
+                            key: {_FAN_OUT_DROPPED_KEY: True, "error": str(exc)},
+                        }
+                        any_durable = True  # a drop MUST survive to resume (awaited-durable)
+                        await inv.record(completed_step_results=box.value, durable=True)
                 else:
                     # abort (incl. retry(n) exhausted): the landed items above are
                     # already durably recorded; fail the step now.
@@ -1467,7 +1568,7 @@ async def _run_for_each_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
             await asyncio.gather(*tasks, return_exceptions=True)
 
     # collect runs ONCE over the ordered surviving results (dropped filtered out).
-    results_list = _for_each_results(completed, label, n)
+    results_list = _for_each_results(box.value, label, n)
     collect_ctx = {"ctx": outer_stores, "pipe": results_list}
     collect_runner = STEP_DISPATCH.get(type(step.collect))
     if collect_runner is None:  # pragma: no cover - Step is a closed union
@@ -1475,13 +1576,13 @@ async def _run_for_each_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
     collect_inv = _StepInvocation(
         executor=inv.executor, step=step.collect, context=collect_ctx,
         step_label=collect_key, deps=child_deps,
-        completed_step_results=completed, record=inv.record,
+        completed_step_results=box.value, record=inv.record,
     )
-    collect_result, collect_durable, completed = await collect_runner(collect_inv)
-    completed = {**completed, collect_key: collect_result}
+    collect_result, collect_durable, box.value = await collect_runner(collect_inv)
+    box.value = {**box.value, collect_key: collect_result}
     any_durable = any_durable or collect_durable
-    await inv.record(completed_step_results=completed, durable=collect_durable)
-    return collect_result, any_durable, completed
+    await inv.record(completed_step_results=box.value, durable=collect_durable)
+    return collect_result, any_durable, box.value
 
 
 def _parallel_results(
@@ -1524,23 +1625,24 @@ def _parallel_branch_errors(
 async def _run_parallel_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str, Any]]":
     """The heterogeneous NAMED-branch fan-out runner (S5-bounded) — reuses the
     EXACT fan-out substrate :func:`_run_for_each_step` established (concurrent
-    recovery via a single serializing coordinator + a NO-OP recorder inside
-    each branch task, the ``__fan_out_dropped__`` kind-marker, the
-    fan_out_depth/SpawnBudget S5 guards). The one structural difference: the
-    source is a STATIC FINITE dict of DISTINCT named branches (each its own
-    heterogeneous Step) rather than one ``do`` re-invoked per list item, so
-    every branch runs concurrently with NO Semaphore (the branch count IS the
-    bound — there is no ``max_parallel`` field), and ``collect`` runs ONCE
-    over the NAMED MAP of surviving branch results (:func:`_parallel_results`),
-    not an ordered list.
+    recovery via a single serializing coordinator, #2582's :class:`_FanOutRecordBox`
+    lock shared with each branch's compositional-``do`` sub-step recorder, the
+    ``__fan_out_dropped__`` kind-marker, the fan_out_depth/SpawnBudget S5 guards).
+    The one structural difference: the source is a STATIC FINITE dict of DISTINCT
+    named branches (each its own heterogeneous Step) rather than one ``do``
+    re-invoked per list item, so every branch runs concurrently with NO Semaphore
+    (the branch count IS the bound — there is no ``max_parallel`` field), and
+    ``collect`` runs ONCE over the NAMED MAP of surviving branch results
+    (:func:`_parallel_results`), not an ordered list.
 
     ``on_error`` (optional, default ``abort`` — normalized the same way
     ``for_each.on_error`` is, via :func:`_parse_on_error`) decides a branch
     failure: ``continue`` records a DROPPED kind-marker (so resume never
     re-runs it); ``retry(n)`` re-runs the branch's Step up to ``n`` more times
     then falls back to ``abort``; ``abort`` cancels the still-pending branches
-    and fails the step (the already-landed branches stay durably recorded, so
-    a resume after an abort-crash skips them).
+    and fails the step (the already-landed branches — including a still-in-
+    flight compositional branch's already-durable internal sub-steps — stay
+    durably recorded, so a resume after an abort-crash skips them).
 
     S5 guards: (b) ``fan_out_depth`` is +1'd through ``_RunDeps`` into every
     branch/collect sub-scope, failing the step if it would exceed
@@ -1550,13 +1652,13 @@ async def _run_parallel_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
     deps = inv.deps
     context = inv.context
     label = inv.step_label
-    completed = inv.completed_step_results
+    box = _FanOutRecordBox(inv.completed_step_results)
 
     # Full-completion replay: if collect already ran (its key is present) the
     # whole parallel is done — replay its N2 result, execute nothing.
     collect_key = f"{label}.parallel.collect"
-    if collect_key in completed:
-        return completed[collect_key], False, completed
+    if collect_key in box.value:
+        return box.value[collect_key], False, box.value
 
     names = list(step.branches)
     on_err = _parse_on_error(step.on_error)
@@ -1577,13 +1679,6 @@ async def _run_parallel_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
     outer_stores = context["ctx"]
     outer_pipe = context["pipe"]
 
-    async def _noop_record(**_kw: Any) -> None:
-        # Branch tasks NEVER record: only the single coordinator does
-        # (serialized), so concurrent branches cannot race the
-        # read-modify-write of the snapshot (identical to for_each's item
-        # tasks).
-        return None
-
     async def _run_branch(name: str) -> "tuple[str, Any, bool, Exception | None]":
         branch_step = step.branches[name]
         # Retry(n) re-runs INSIDE the same task. Any Exception is a branch
@@ -1591,15 +1686,19 @@ async def _run_parallel_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
         # propagates out and the task is gathered in the finally).
         attempts = 1 + (on_err.retries if on_err.kind == "retry" else 0)
         last_exc: "Exception | None" = None
+        branch_label = f"{label}.parallel.{name}"
         for _attempt in range(attempts):
             branch_ctx = {"ctx": dict(outer_stores), "pipe": outer_pipe}
             runner = STEP_DISPATCH.get(type(branch_step))
             if runner is None:  # pragma: no cover - Step is a closed union
                 raise PipelineExecutionError(f"unknown step type: {branch_step!r}")
+            # #2582: same real, lock-serialized sub-step recorder for_each's
+            # item tasks now use — see the matching comment in _run_item.
             branch_inv = _StepInvocation(
                 executor=inv.executor, step=branch_step, context=branch_ctx,
-                step_label=f"{label}.parallel.{name}", deps=child_deps,
-                completed_step_results=completed, record=_noop_record,
+                step_label=branch_label, deps=child_deps,
+                completed_step_results=box.value,
+                record=_make_fan_out_sub_step_recorder(box, inv.record, branch_label),
             )
             try:
                 result, durable, _ = await runner(branch_inv)
@@ -1623,7 +1722,7 @@ async def _run_parallel_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
     # Only branches whose key is ABSENT run (resume re-runs exactly the absent
     # ones; a present success key replays, a present dropped-marker stays
     # dropped).
-    pending = [n for n in names if f"{label}.parallel.{n}" not in completed]
+    pending = [n for n in names if f"{label}.parallel.{n}" not in box.value]
     any_durable = False
     if pending:
         # No Semaphore: the branch set is statically finite (there is no
@@ -1633,20 +1732,24 @@ async def _run_parallel_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
             for fut in asyncio.as_completed(tasks):
                 name, result, durable, exc = await fut
                 key = f"{label}.parallel.{name}"
+                # #2582: shares `box.lock` with each branch's own sub-step
+                # recorder — see the matching comment in _run_for_each_step.
                 if exc is None:
-                    completed = {**completed, key: result}
-                    any_durable = any_durable or durable
-                    await inv.record(completed_step_results=completed, durable=durable)
+                    async with box.lock:
+                        box.value = {**box.value, key: result}
+                        any_durable = any_durable or durable
+                        await inv.record(completed_step_results=box.value, durable=durable)
                 elif on_err.kind == "continue":
                     # DROP the failed branch: record a kind-marker (NOT absent
                     # — else resume re-runs it forever; NOT bare None — a
                     # legit branch result).
-                    completed = {
-                        **completed,
-                        key: {_FAN_OUT_DROPPED_KEY: True, "error": str(exc)},
-                    }
-                    any_durable = True  # a drop MUST survive to resume (awaited-durable)
-                    await inv.record(completed_step_results=completed, durable=True)
+                    async with box.lock:
+                        box.value = {
+                            **box.value,
+                            key: {_FAN_OUT_DROPPED_KEY: True, "error": str(exc)},
+                        }
+                        any_durable = True  # a drop MUST survive to resume (awaited-durable)
+                        await inv.record(completed_step_results=box.value, durable=True)
                 else:
                     # abort (incl. retry(n) exhausted): the landed branches
                     # above are already durably recorded; fail the step now.
@@ -1665,11 +1768,11 @@ async def _run_parallel_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
 
     # collect runs ONCE over the NAMED MAP of surviving results (dropped
     # filtered out).
-    results_map = _parallel_results(completed, label, names)
+    results_map = _parallel_results(box.value, label, names)
     # #3070: inject the dropped branches' real error text under the reserved
     # key ONLY when at least one branch actually dropped — a `collect` step
     # that never fails a branch sees no shape change at all.
-    branch_errors = _parallel_branch_errors(completed, label, names)
+    branch_errors = _parallel_branch_errors(box.value, label, names)
     if branch_errors:
         results_map = {**results_map, PARALLEL_BRANCH_ERRORS_KEY: branch_errors}
     collect_ctx = {"ctx": outer_stores, "pipe": results_map}
@@ -1679,13 +1782,13 @@ async def _run_parallel_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
     collect_inv = _StepInvocation(
         executor=inv.executor, step=step.collect, context=collect_ctx,
         step_label=collect_key, deps=child_deps,
-        completed_step_results=completed, record=inv.record,
+        completed_step_results=box.value, record=inv.record,
     )
-    collect_result, collect_durable, completed = await collect_runner(collect_inv)
-    completed = {**completed, collect_key: collect_result}
+    collect_result, collect_durable, box.value = await collect_runner(collect_inv)
+    box.value = {**box.value, collect_key: collect_result}
     any_durable = any_durable or collect_durable
-    await inv.record(completed_step_results=completed, durable=collect_durable)
-    return collect_result, any_durable, completed
+    await inv.record(completed_step_results=box.value, durable=collect_durable)
+    return collect_result, any_durable, box.value
 
 
 # Dispatch table: step dataclass type -> its runner. A future primitive ADDS an

--- a/tests/core/test_pipeline_for_each_primitive.py
+++ b/tests/core/test_pipeline_for_each_primitive.py
@@ -21,11 +21,11 @@ Hard rule 6, N2) — ``fold``'s parallel, isolated sibling built on the same
      resume from the generation FILE → completed items REPLAY exactly-once (their
      side-effect file is unchanged), the dropped item STAYS dropped (not re-run),
      only absent items run, ``collect`` runs ONCE.
-  5. the documented COMPOSITIONAL-``do`` recovery gap: a ``call``-``do`` item
-     in-flight at crash re-runs ATOMICALLY on resume (its completed internal side
-     effects re-fire) — a known, TESTED contract, not a silent surprise (the
-     module docstring's "commit unit = the ITEM"; follow-up issue tracks closing
-     it).
+  5. #2582's truncate-falsify gate for the COMPOSITIONAL-``do`` case: a
+     ``call``-``do`` item in-flight at crash now journals its internal
+     sub-steps durably AS THEY LAND (closing the prior atomic-re-run gap —
+     the module docstring's "commit unit = the ITEM" section), verified
+     surviving WAL truncation exactly like the single-step gate above.
   6. S5 guards — (b) a ``for_each`` nested deeper than ``max_fan_out_depth``
      FAILS the step (does not spawn); (c) a fan-out spawning more ephemeral
      sessions than ``max_pipeline_spawns`` FAILS the step (the per-run
@@ -435,19 +435,25 @@ async def test_resume_after_full_fan_out_replays_with_zero_new_side_effects(tmp_
     assert resumed.pipe_data == {"text": "", "structured": {"wrote": "COLLECT"}}
 
 
-# ── the DOCUMENTED compositional-do atomic-re-run gap (commit unit = the ITEM) ─
+# ── #2582: the compositional-do CLOSED gap (per-internal-sub-step durability) ─
 
 
 @pytest.mark.asyncio
-async def test_compositional_do_item_reruns_atomically_on_crash(tmp_path: Path):
-    """Tier 2: DOCUMENTS the known fan-out recovery gap (module docstring's "commit
-    unit = the ITEM"). A ``call``-``do`` item crashed MID-ITEM (its callee wrote
-    sub-step 0's side effect, sub-step 1 failed) re-runs ATOMICALLY on resume —
-    because item tasks record through a NO-OP recorder, the item's internal
-    progress is never journaled, so the completed internal side effect RE-FIRES.
-    This is a TESTED contract, not a silent surprise; a follow-up issue tracks
-    closing it (per-internal-sub-step durability). A single-step ``do`` has no such
-    gap (see the truncate-falsify test above)."""
+async def test_truncate_falsify_compositional_do_sub_step_survives_mid_item_crash(
+    tmp_path: Path,
+):
+    """Tier 2: MANDATORY CLAUDE.md recovery-feature truncate-falsify gate for
+    #2582. A ``call``-``do`` item crashes MID-ITEM (its callee's sub-step 0
+    durably writes its side effect, sub-step 1 then fails). Per-item recorders
+    (:func:`~reyn.core.pipeline.executor._make_fan_out_sub_step_recorder`) now
+    journal sub-step 0 durably AS IT LANDS — not only once the whole item
+    completes. The WAL is truncated BELOW sub-step 0's own recording event.
+    Resume from the generation FILE (never WAL replay) must still see
+    sub-step 0 as complete and NOT re-fire its side effect.
+
+    RED (pre-#2582): X-a would be written a SECOND time on resume — the item
+    re-ran atomically from scratch because item tasks recorded through a
+    no-op recorder, so nothing was durable until the whole item landed."""
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     out_file = tmp_path / "out.txt"
     crash = {"X-b"}  # the callee's 2nd sub-step fails in phase 1
@@ -470,23 +476,43 @@ async def test_compositional_do_item_reruns_atomically_on_crash(tmp_path: Path):
     with pytest.raises(PipelineExecutionError):
         await PipelineExecutor().run(
             pipeline, None,
-            tool_dispatch=dispatch, state_log=state_log, run_id="run-fe-comp",
+            tool_dispatch=dispatch, state_log=state_log, run_id="run-fe-comp-tf",
             pipeline_registry=registry,
         )
     await state_log.flush()
     assert out_file.read_text(encoding="utf-8").splitlines() == ["X-a"]
 
-    # RESUME disarmed: the item re-runs WHOLE (its key was never recorded), so X-a
-    # is written AGAIN (the documented internal-side-effect re-fire).
+    # The sub-step's own generation is on disk: sub-step 0's callee key is
+    # durably present even though the item — and the whole for_each — never
+    # completed.
+    from reyn.core.events.pipeline_recovery import latest_pipeline_state
+    snap = latest_pipeline_state("run-fe-comp-tf", state_log)
+    assert snap["completed_step_results"]["0.for_each.0.call.0"] == {
+        "text": "", "structured": {"wrote": "X-a"},
+    }
+    assert "0.for_each.0.call.1" not in snap["completed_step_results"]
+
+    # WAL head climbs past the crash-state seqs, then GC truncates below 40 —
+    # sub-step 0's own WAL entry is dropped from wal.jsonl (the falsify:
+    # recovery must come from the generation FILE, never WAL replay).
+    for i in range(50):
+        await state_log.append("inbox_put", n=100 + i)
+    await state_log.truncate_below(40)
+    await state_log.flush()
+    surviving = {e["seq"] for e in state_log.iter_from(0)}
+    assert all(s >= 40 for s in surviving), "sub-step 0's WAL entry is truncated away"
+
+    # RESUME with the crash disarmed: sub-step 0 REPLAYS (does not re-fire) —
+    # only sub-step 1 (X-b) executes.
     crash.clear()
     await PipelineExecutor().resume(
-        "run-fe-comp", pipeline=pipeline,
+        "run-fe-comp-tf", pipeline=pipeline,
         tool_dispatch=dispatch, state_log=state_log, pipeline_registry=registry,
     )
     lines = out_file.read_text(encoding="utf-8").splitlines()
-    assert lines == ["X-a", "X-a", "X-b"], (
-        "a compositional-do item re-runs atomically on resume — X-a re-fires "
-        "(the documented commit-unit=ITEM gap; single-step do has no such gap)"
+    assert lines == ["X-a", "X-b"], (
+        "#2582: a compositional-do item's completed internal sub-step must "
+        "NOT re-fire on resume — X-a must be written exactly once"
     )
 
 

--- a/tests/core/test_pipeline_parallel_primitive.py
+++ b/tests/core/test_pipeline_parallel_primitive.py
@@ -6,9 +6,10 @@ Every Appendix-B non-linear primitive (``call``/``match``/``fold``/
 
 ``parallel`` is ``for_each``'s static-branch-set sibling — it reuses the EXACT
 SAME fan-out substrate (concurrent recovery via a single serializing
-coordinator + a NO-OP recorder inside branch tasks, the
-``__fan_out_dropped__`` kind-marker, the ``fan_out_depth``/``SpawnBudget`` S5
-guards). Structural differences covered here:
+coordinator, #2582's ``_FanOutRecordBox`` lock shared with each branch's
+compositional-``do`` sub-step recorder, the ``__fan_out_dropped__``
+kind-marker, the ``fan_out_depth``/``SpawnBudget`` S5 guards). Structural
+differences covered here:
 
   1. happy path — a STATIC dict of heterogeneous NAMED branches runs
      CONCURRENTLY; ``collect`` runs ONCE over the NAMED MAP ``results.NAME``
@@ -665,18 +666,28 @@ async def test_parallel_of_agent_branches_within_spawn_cap_succeeds(tmp_path: Pa
     assert scripted.calls == 3
 
 
-# ── compositional-do (branch) recovery gap, documented, mirrors for_each ─────
+# ── #2582: the compositional branch CLOSED gap, mirrors for_each ─────────────
 
 
 @pytest.mark.asyncio
-async def test_compositional_branch_reruns_atomically_on_crash(tmp_path: Path):
-    """Tier 2: DOCUMENTS the known fan-out recovery gap (module docstring's
-    "commit unit = the ITEM/BRANCH"). A ``call``-branch crashed MID-BRANCH
-    (its callee wrote sub-step 0's side effect, sub-step 1 failed) re-runs
-    ATOMICALLY on resume — because branch tasks record through a NO-OP
-    recorder, the branch's internal progress is never journaled, so the
-    completed internal side effect RE-FIRES. A single-step branch has no such
-    gap (see the truncate-falsify test above)."""
+async def test_truncate_falsify_compositional_branch_sub_step_survives_mid_branch_crash(
+    tmp_path: Path,
+):
+    """Tier 2: MANDATORY CLAUDE.md recovery-feature truncate-falsify gate for
+    #2582, the ``parallel`` counterpart of
+    ``test_pipeline_for_each_primitive.py``'s matching test. A ``call``-branch
+    crashes MID-BRANCH (its callee's sub-step 0 durably writes its side
+    effect, sub-step 1 then fails). The per-branch recorder (the SAME
+    :func:`~reyn.core.pipeline.executor._make_fan_out_sub_step_recorder`
+    ``for_each`` items use) now journals sub-step 0 durably AS IT LANDS. The
+    WAL is truncated BELOW sub-step 0's own recording event. Resume from the
+    generation FILE (never WAL replay) must still see sub-step 0 as complete
+    and NOT re-fire its side effect.
+
+    RED (pre-#2582): X-a would be written a SECOND time on resume — the
+    branch re-ran atomically from scratch because branch tasks recorded
+    through a no-op recorder, so nothing was durable until the whole branch
+    landed."""
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     out_file = tmp_path / "out.txt"
     crash = {"X-b"}  # the callee's 2nd sub-step fails in phase 1
@@ -698,22 +709,41 @@ async def test_compositional_branch_reruns_atomically_on_crash(tmp_path: Path):
     with pytest.raises(PipelineExecutionError):
         await PipelineExecutor().run(
             pipeline, None,
-            tool_dispatch=dispatch, state_log=state_log, run_id="run-par-comp",
+            tool_dispatch=dispatch, state_log=state_log, run_id="run-par-comp-tf",
             pipeline_registry=registry,
         )
     await state_log.flush()
     assert out_file.read_text(encoding="utf-8").splitlines() == ["X-a"]
 
-    # RESUME disarmed: the branch re-runs WHOLE (its key was never recorded),
-    # so X-a is written AGAIN (the documented internal-side-effect re-fire).
+    # The sub-step's own generation is on disk: sub-step 0's callee key is
+    # durably present even though the branch — and the whole parallel — never
+    # completed.
+    from reyn.core.events.pipeline_recovery import latest_pipeline_state
+    snap = latest_pipeline_state("run-par-comp-tf", state_log)
+    assert snap["completed_step_results"]["0.parallel.x.call.0"] == {
+        "text": "", "structured": {"wrote": "X-a"},
+    }
+    assert "0.parallel.x.call.1" not in snap["completed_step_results"]
+
+    # WAL head climbs past the crash-state seqs, then GC truncates below 40 —
+    # sub-step 0's own WAL entry is dropped from wal.jsonl (the falsify:
+    # recovery must come from the generation FILE, never WAL replay).
+    for i in range(50):
+        await state_log.append("inbox_put", n=100 + i)
+    await state_log.truncate_below(40)
+    await state_log.flush()
+    surviving = {e["seq"] for e in state_log.iter_from(0)}
+    assert all(s >= 40 for s in surviving), "sub-step 0's WAL entry is truncated away"
+
+    # RESUME with the crash disarmed: sub-step 0 REPLAYS (does not re-fire) —
+    # only sub-step 1 (X-b) executes.
     crash.clear()
     await PipelineExecutor().resume(
-        "run-par-comp", pipeline=pipeline,
+        "run-par-comp-tf", pipeline=pipeline,
         tool_dispatch=dispatch, state_log=state_log, pipeline_registry=registry,
     )
     lines = out_file.read_text(encoding="utf-8").splitlines()
-    assert lines == ["X-a", "X-a", "X-b"], (
-        "a compositional branch re-runs atomically on resume — X-a re-fires "
-        "(the documented commit-unit=BRANCH gap; single-step branch has no "
-        "such gap)"
+    assert lines == ["X-a", "X-b"], (
+        "#2582: a compositional branch's completed internal sub-step must "
+        "NOT re-fire on resume — X-a must be written exactly once"
     )


### PR DESCRIPTION
**[tui-coder]** — part of #2582.

## What
Closes the documented `for_each`/`parallel` fan-out atomic-re-run gap ("commit unit = the ITEM", module docstring). A compositional `do` (`call`/`match`/`fold`) reached from inside `for_each`/`parallel` that crashes mid-item used to re-run WHOLE on resume — item/branch tasks recorded through a no-op recorder, so only the coordinator's own end-of-item write was ever durable; a completed internal side effect (e.g. sub-step 0 of a 2-step callee) re-fired.

## How
- `_FanOutRecordBox`: the fan-out coordinator's growing `completed_step_results` plus the ONE `asyncio.Lock` serializing every writer that touches it.
- `_make_fan_out_sub_step_recorder`: a REAL (no longer no-op) per-item/branch recorder handed to a compositional `do`, filtered to that item's own dotted-key prefix (trailing-dot-guarded so item 1 can't swallow item 10's keys), forwarding only genuinely-new keys.
- The lock closes the EXACT race the original no-op design existed to avoid: two concurrent writers racing `state_log.last_durable_seq` + `submit_durable` could otherwise silently clobber each other's generation at the same seq.
- A single-step `do` is unaffected — leaf runners (`transform`/`tool`/`agent`) never call `record` at all.
- A within-process `retry(n)` gets the same benefit for free: a failed attempt's already-durable sub-steps replay instead of re-firing on the next attempt (same `_run_scope` replay-by-key mechanism, not crash-recovery-only).

## Alternative considered and rejected: keep single-writer ownership via a queue
Considered: keep the ORIGINAL ownership model (only the coordinator coroutine ever calls the real `record`) by having each item/branch task **push** its newly-completed sub-step key onto a queue instead of calling `record` itself, and have the coordinator **drain** that queue — placed next to its existing `asyncio.as_completed(tasks)` loop — as the one writer.

Rejected, for a durability-timing reason rather than a stylistic one: `_run_scope` calls `await record(...)` and only proceeds to the item's NEXT sub-step once that await returns — the await IS the durability contract (`durable=True` routes through `state_log.submit_durable`, which the caller waits on before continuing). A queue push can honor that contract in only two ways, and neither keeps single-writer ownership for free:
- **Fire-and-forget push** (the task doesn't wait for the coordinator's drain before continuing) breaks the contract: `_run_scope`'s `await record(...)` would return before the sub-step is actually durable, reopening a crash window between "sub-step landed in the queue" and "coordinator drained + persisted it" — the identical hazard this PR closes, just relocated one level down.
- **Push that blocks until the coordinator's drain has actually persisted it** preserves the contract, but the coordinator then needs a SECOND loop running concurrently with `asyncio.as_completed(tasks)` to service the queue promptly (otherwise an item blocks on its own sub-step's durability while the coordinator is busy awaiting a DIFFERENT item's completion) — a rendezvous with a synchronous ack is functionally a mutex by another name, at the cost of a second coordination primitive (an extra concurrent drain loop, plus reasoning about its interleaving with the existing `as_completed` loop) for no extra guarantee over `asyncio.Lock`.

In short: true single-writer-with-synchronous-ack is isomorphic to the lock this PR already uses; true single-writer-with-fire-and-forget reopens the exact gap being closed. The lock is the more direct way to get the same mutual-exclusion guarantee without inventing a second, harder-to-reason-about coordination primitive alongside it. Framed against the "serialization/ownership/atomicity before a lock" instruction: the ORIGINAL design's single ownership held only because there was exactly one writer BY CONSTRUCTION (item tasks could not call the real `record` at all — a coarser guarantee than needed once mid-flight durability is required). Once an item's own in-progress compositional `do` is the ONLY party that knows, synchronously, when its own sub-step lands, moving write ownership back to the coordinator requires ferrying that same synchronous knowledge across a queue — which is where the isomorphism above applies.

## Scope: `for_each` AND `parallel`
The issue names only `for_each`, but `_run_parallel_step`'s own docstring says it "reuses the EXACT fan-out substrate `_run_for_each_step` established" — it has the byte-identical `_noop_record` and the identical gap. Verified this directly: the existing `test_compositional_branch_reruns_atomically_on_crash` failed with the exact same re-fire shape before this fix. Fixing only `for_each` would leave an identical, now-undocumented residual bug in `parallel`, so both are fixed here (CLAUDE.md's doc/family-sweep discipline — "don't fix one and stop").

## Tests
The prior tests (`test_compositional_do_item_reruns_atomically_on_crash` / `test_compositional_branch_reruns_atomically_on_crash`) asserted the re-fire as a documented, accepted gap — that assertion is now false. Both are **replaced** (not flipped) with the CLAUDE.md-mandated recovery-feature truncate-falsify gate:
- Set X (sub-step 0 durably recorded mid-item, crash before sub-step 1).
- Truncate the WAL below the source events.
- Resume from the generation FILE only (never WAL replay).
- Assert X survives (sub-step 0 replays, does not re-fire; only sub-step 1 runs).

Falsify-verified: reverted the executor fix, confirmed both new tests fail for the right reason (`TypeError: 'NoneType' object is not subscriptable` — no generation was ever durably recorded, matching the pre-fix behavior exactly), then restored the fix and confirmed green.

## Verification
- `pytest tests/core/test_pipeline*.py` — 278 passed.
- `ruff check src tests` — clean.
- `python scripts/test_tier_audit.py --strict tests/core/test_pipeline_for_each_primitive.py tests/core/test_pipeline_parallel_primitive.py` — 35/35 OK, 0 Tier-4 violations.
- `python scripts/verify_module_docstrings.py src/reyn/core/pipeline/executor.py` — OK.
- `python scripts/mypy_ratchet.py` — OK (212 findings, all baselined).
- `python scripts/check_tests_path_literal_reference.py` — OK.
- Doc sweep: grepped `docs/` for the gap's prior language ("NO-OP recorder", "commit unit is the ITEM", "internal side effect...re-fire") — 0 hits outside `executor.py`. Two docs (`docs/concepts/runtime/pipelines.md`, `docs/feature-map.md`) already claimed exactly-once recovery "including mid-`call`/`fold`/`for_each` state" — that claim was previously an overclaim for the compositional-fan-out case and is now accurate as a result of this fix, so no doc edit was needed.

## Acceptance (from #2582)
- [x] A compositional-`do` item crashed mid-item resumes replaying its completed internal sub-steps exactly-once (internal side effect does NOT re-fire).
- [x] CLAUDE.md truncate-falsify gate over a compositional `do` (extended the existing single-step gate) — for BOTH `for_each` and `parallel`.
- [x] No regression to the single-step exactly-once path or the concurrent no-race coordinator (full pipeline suite green).

## Test plan
- [x] `ruff check` — clean.
- [x] `pytest` (scoped to affected files) — 278 passed.
- [x] Falsify-verify — reverted fix, confirmed both new tests fail for the right reason, restored.
- [x] (skipped — N/A, no `tests/` file renamed, no path-literal drift)
- [x] Visual — N/A, no UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**[lead-coder]** — ✅ **TESTS-READ 済。★仕事は 良いです。🔴 ★ブロック 1 点 ── ★ロックの 正当化を 求めます。**

- [x] 🔴 **★なぜ ★所有権（★単一書き手）では なく ★`asyncio.Lock` なのか、★PR 本文に 書いてください。**
      ```
      ★owner 恒久指示（memory pin）
         「★ロックより 先に ★直列化／★所有権／★不可分化 を 検討せよ。
           ★ロックは『★不変条件を 2 変数に 割った』欠陥を ★隠す」
      ★あなたの docstring 自身が ★元の 設計を こう 書いています:
         「only the single coordinator coroutine calls the real record,
           ★serialized by construction」
      ∴ ★元は ★所有権で 解けていた もの を、★ロックに 置き換えています
      ```
      ⚠️ **★私は「ロックが 誤り」と 言っていません** —— **★中間状態を ★その場で 耐久化する
      以上、★書き手が 増えるのは 必然に 見えます。**
      🔴 **★求めているのは ★退けた 選択肢の 記録**です:
      ```
      ★代案（★所有権を 保つ 形）
         ★item は ★queue に 増分を push する だけ ／ ★書くのは ★coordinator 1 人の まま
         ── ★as_completed の 隣に ★drain を 置く
      ★これを 採らなかった 理由は 何ですか
         （★遅延？ ★複雑さ？ ★drain 点が 無い？）
      ```
      ⚪ **★答えが「★検討して、★これこれの 理由で 退けた」なら ★通します** ——
      **★記録が 無いまま ロックが 入ると、★次に 触る人が ★同じ判断を ★ゼロから やります。**

      → **[tui-coder] 対応済** — 上の「Alternative considered and rejected: keep single-writer ownership via a queue」節に記録しました。要旨: queueへのpushが fire-and-forget なら `_run_scope`のawait durability契約が崩れて同じgapが場所を変えて再発、同期ackにするなら coordinator側にas_completedと並走する2本目のdrainループが要り、それはlockと機能的に同型（rendezvous=mutexの一種）でありながら調整プリミティブが1つ増えるだけ。ゆえにlockが最小構成という結論です。

## ✅ 六問（★テストの コードを 読みました）

```
① Tier ── ★2（★OS 不変条件: ★resume で 内部 sub-step が 再発火しない）── ★妥当
② 転記 ── ★無し
③ 誰が困る ── ★compositional `do` を 使う pipeline の 利用者
             ── ★「gap を document する」だった 2 本を ★消して ★正の 証明に 置換した のは 正しい
                （★前提が 崩れた test を ★repair せず ★役割ごと 入れ替えた）
④ 走らず緑 ── ★該当なし
⑤ 累積 ── ★無し
⑥ 宣言＝実体 ── ★一致
```

## ✅ ★特に 良い 点

```
✅ ★CLAUDE.md の ★recovery-feature truncate-falsify gate を ★自分から 満たしている
   ── `truncate_below(40)` → ★sub-step 0 の WAL entry が 消えた ことを ★assert してから resume
   ── ★for_each 版と parallel 版の ★2 本
✅ ★issue は for_each のみ ★あなたは `_run_parallel_step` が ★同じ substrate を 共有して
   いる ことを 実測し ★両方 直した ── ★#4529 で 私が 落とした「★同じ主張の 別の 書式」の
   ★正しい 側の 動き
✅ ★trailing dot が load-bearing（item 1 が item 10 に 一致する）── ★コメントに 残っている
```

