### PR TITLE
docs(#4538): config.md's own "three things" claim missed my #4526 4th section

### DIFF
--- a/docs/reference/cli/config.md
+++ b/docs/reference/cli/config.md
@@ -45,7 +45,7 @@ reyn config migrate-mcp [--dry-run]
 `reyn config set` always writes to `reyn.local.yaml` (gitignored) — never to `reyn.yaml`.
 
 `reyn config validate` always exits `0`, even when it reports findings — it REPORTS, it
-never gates (owner ruling: warn, never hard-fail, anywhere). It checks three things,
+never gates (owner ruling: warn, never hard-fail, anywhere). It checks four things,
 each printed as its own labeled section (never merged into one list — the fix differs
 per section, and merging would lose "which one do I fix, and how"):
 
@@ -66,6 +66,13 @@ per section, and merging would lose "which one do I fix, and how"):
   applies on the next turn automatically, no restart and no `reyn config migrate`
   support for this tier (a different remedy than the policy tier above, which is
   exactly why this is its own section).
+- **Hook entry validation, the IN-set's `hooks:` list** (#4501) — the IN-set's own
+  unknown-key check above only walks the TOP-LEVEL config schema, so `hooks:` itself
+  being a recognized key says nothing about what each list *entry* contains. This
+  section feeds `.reyn/config/hooks.yaml`'s `hooks:` list through the real
+  `load_hooks` parser and reports any `HookConfigError` (e.g. an unrecognized
+  per-hook key). Fix: edit the offending hook entry directly in
+  `.reyn/config/hooks.yaml`.
 
 `reyn config migrate` only rewrites an entry whose registered rename has an automatic
 destination (a plain rename, no value transform); a rename that also transforms the


### PR DESCRIPTION
**[docs-maintainer]** — #4538's doc-drift sweep across the 10 mechanism changes that landed on main tonight. One real finding, one PR.

## Method (per the dispatch's own instruction — report what was searched, not just what was found)

For each PR, searched **multiple forms**, not one: table rows, prose paragraphs, command-output examples, indented outlines, and ja siblings — the exact lesson #4529 demonstrated (the same stale claim was spread across 4 different formats a single-form grep missed 3 of).

| PR | Searched | Result |
|---|---|---|
| `4f77a523b` #4537 request_attach/request_session_switch | `agui-transport.md`/`.ja.md`'s existing "control sentinels" section (table + prose) | **0 — correctly so.** PR is explicitly add-only, sentinel path unchanged; the doc still describes current behavior accurately. Documenting the new seams now would be premature (same reasoning as #4482 PR-3's staged deferral). |
| `5bcd5761b` #4536 for_each/parallel per-sub-step durability | `pipeline-dsl.md`/`.ja.md` for "atomic"/"re-run"/"resume"/"durab" near `for_each`/`parallel` | **0.** No doc ever asserted the old whole-item-rerun-on-crash gap as documented behavior — this was an internal correctness fix, not a doc-visible contract change. |
| `fe05570ce` #4533 threat_scan shadow-default / `_narrowing_per_iteration` guard removal | All 14 files mentioning `ThreatScanConfig`/`threat_scan`/`fence_enabled`; separately, `_narrowing_per_iteration` by name | **0.** `reyn-yaml.md` already correctly stated "Default-on" (`true`) — the shadow-default bug was in *unreachable* internal getattr fallbacks, never in what's documented. No doc names the internal function that was simplified/removed. |
| `1dbef1398` #4526 hook-entry unknown-key rejection + `config validate` widening | `docs/reference/cli/config.md` | **✅ 1 finding, fixed here.** My own #4526 PR added a 4th labeled section to `reyn config validate`'s output but never checked `config.md`'s own "Notes" section, which explicitly said *"It checks three things"* and enumerated exactly 3 bullets. |
| `cec1cbe2b` #4527 `cost.*.extension_calls` removal | Repo-wide `git grep` for `extension_calls`, outside `deep-dives/proposals`/`journal` | **0 (already correct).** Both `feature-map.md` and `reyn-yaml.md` already accurately describe the removal — no ja sibling ever documented this field, so no drift there either (rule 5, no gap). |
| `b15cde05b`/`c5362f9c9`/`f9d5c7efb` #4529 per-chain-cap cleanup | Repo-wide `git grep` for `Per-chain`/`per_chain_skill` | **0 (already correct)** — the 4-format sweep (table/prose/output-example/outline) landed across #4530/#4531/#4532; this PR confirms nothing remains. |

## What this PR fixes

`docs/reference/cli/config.md`'s "Notes" section: "three things" → "four things", plus the missing 4th bullet (hook entry validation, `.reyn/config/hooks.yaml`'s `hooks:` list, #4501). Verified the exact section label against the real `print()` call in `config.py:407` ("Hook entry validation") rather than paraphrasing.

## Verification

- `mkdocs build --strict -f .mkdocs/mkdocs.yml` — no error/Aborted line.
- `ruff check src tests` — clean.

part of #4538

## Test plan

- [x] `mkdocs build --strict` — clean, no Aborted/error line (read directly)
- [x] `ruff check src tests` — clean
- [x] Verified the new bullet's wording against the actual `print()` call, not paraphrased
- [x] (skipped — docs-only edit, no runtime behavior change, no test to run)
