### PR TITLE
feat(status-bar): mark the tab/status boundary with a │ separator

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -1582,6 +1582,24 @@ _TAB_H_PADDING = 2
 #: packed row (#3326).
 _STATUS_H_PADDING = 2
 
+#: The boundary marker prepended to the status-values text ONLY when it
+#: SHARES a row with Tab widgets (owner feedback: the tab/status boundary
+#: was unmarked — a padding gap alone, indistinguishable from ordinary
+#: inter-tab spacing at a glance). Matches the SAME ``│`` delimiter
+#: :func:`status_line_text` already uses between its own fields, so the
+#: line reads as one consistent ``│``-delimited style rather than
+#: introducing a second glyph. Never applied when StatusLine has its own
+#: row (nothing to separate from there) — see :func:`_merged_status_text`.
+_STATUS_SEPARATOR = "│ "
+
+
+def _merged_status_text(text: str) -> str:
+    """The status-values text as rendered when :class:`StatusLine` shares a
+    row with Tab widgets — prefixed with :data:`_STATUS_SEPARATOR`. Guarded
+    on non-empty ``text``: an empty status has nothing to mark a boundary
+    before, so no bare separator glyph renders mid-row."""
+    return f"{_STATUS_SEPARATOR}{text}" if text else text
+
 
 def pack_menu_rows(
     items: "Sequence[tuple[str, str]]", width: int
@@ -1623,13 +1641,21 @@ def status_fits_last_row(
     """True if the status-values segment fits alongside the last packed tab row.
 
     Pure, mirroring :func:`pack_menu_rows`'s testability-without-mounting
-    convention (#3326). ``rows`` is the output of :func:`pack_menu_rows`; an
+    convention (#3326). ``rows`` is the output of :func:`pack_menu_rows``; an
     empty ``rows`` (no tabs at all) trivially fits if the text alone fits
-    ``width``. Never truncates or squeezes — the caller falls back to giving
+    ``width`` — no :data:`_STATUS_SEPARATOR` in that case (nothing to
+    separate from). When ``rows`` is non-empty, the cell width includes the
+    separator's length too (rendered ONLY in the merged case — see
+    :func:`_merged_status_text`), so a fit predicted here matches what
+    actually mounts byte-for-byte; omitting it would under-count the row and
+    risk exactly the off-screen overflow #3326's own geometry guard exists
+    to catch. Never truncates or squeezes — the caller falls back to giving
     the status segment its own row when this returns ``False``."""
     status_cell = status_text_len + _STATUS_H_PADDING
     if not rows:
         return status_cell <= width
+    if status_text_len:
+        status_cell += len(_STATUS_SEPARATOR)
     used = sum(len(label) + _TAB_H_PADDING for _tab_id, label in rows[-1])
     return used + status_cell <= width
 
@@ -1700,6 +1726,13 @@ class MenuBar(Widget, can_focus=True):
         self._packed_width = -1
         self._last_seen_width = -1
         self._status_text = status_text
+        #: True iff StatusLine currently shares a row with Tab widgets — set
+        #: by :meth:`_repack` (:func:`status_fits_last_row`'s decision),
+        #: read by :meth:`update_status`'s no-remount fast path so the
+        #: boundary separator (:func:`_merged_status_text`) stays applied
+        #: consistently across BOTH the initial mount and every later
+        #: in-place text update, not just the mount.
+        self._merged = False
         #: The highlighted tab id. Seeded to the first item so the row has a
         #: highlight from the very first frame (before any resize has landed).
         self.active = self._items[0][0] if self._items else ""
@@ -1715,12 +1748,13 @@ class MenuBar(Widget, can_focus=True):
         self._packed_width = width
         rows = pack_menu_rows(self._items, width)
         merge_status = status_fits_last_row(rows, width, len(self._status_text))
+        self._merged = merge_status
         self.remove_children()
         menu_rows = [
             Horizontal(
                 *(Tab(label, id=tab_id) for tab_id, label in row),
                 *(
-                    [StatusLine(self._status_text, classes="-shared")]
+                    [StatusLine(_merged_status_text(self._status_text), classes="-shared")]
                     if merge_status and i == len(rows) - 1
                     else []
                 ),
@@ -1743,7 +1777,10 @@ class MenuBar(Widget, can_focus=True):
         values and far longer than the steady-state text — so a length change
         forces a fresh repack rather than an in-place ``Static.update``. An
         unchanged length (the common case: cost/ctx ticking within the same
-        format) updates the mounted widget directly, no remount."""
+        format) updates the mounted widget directly, no remount — going
+        through :func:`_merged_status_text` (a no-op when ``self._merged`` is
+        False) so the tab/status boundary separator stays present on every
+        tick, not just the frame that first merged the row."""
         changed_len = len(text) != len(self._status_text)
         self._status_text = text
         if not self.is_mounted:
@@ -1753,7 +1790,8 @@ class MenuBar(Widget, can_focus=True):
             self._repack(self._last_seen_width)
         else:
             try:
-                self.query_one(StatusLine).update(text)
+                display = _merged_status_text(text) if self._merged else text
+                self.query_one(StatusLine).update(display)
             except NoMatches:
                 pass
 

--- a/tests/interfaces/test_3338_tui_status_chrome_liveness.py
+++ b/tests/interfaces/test_3338_tui_status_chrome_liveness.py
@@ -806,8 +806,14 @@ def test_status_fits_last_row_pure() -> None:
     """Tier 1: :func:`status_fits_last_row` (#3326) — pure fit-decision helper.
 
     Mirrors the existing #3338 ``pack_menu_rows`` pure-function convention:
-    testable without mounting anything."""
+    testable without mounting anything. The fit math includes
+    ``_STATUS_SEPARATOR``'s length whenever ``rows`` is non-empty AND the
+    status text is non-empty — the boundary marker
+    (:func:`_merged_status_text`) IS rendered in that case, so the predicted
+    fit must account for it byte-for-byte (an under-count here would predict
+    a fit the real merged row overflows)."""
     from reyn.interfaces.inline.textual_chat.chrome import (
+        _STATUS_SEPARATOR,
         pack_menu_rows,
         status_fits_last_row,
     )
@@ -823,11 +829,15 @@ def test_status_fits_last_row_pure() -> None:
     # nearly full) is what gets checked.
     narrow_rows = pack_menu_rows(_MENU_TABS, 40)
     last_row_used = sum(len(label) + 2 for _tid, label in narrow_rows[-1])
-    max_fitting_len = 40 - last_row_used - 2  # 2 == _STATUS_H_PADDING
+    # 2 == _STATUS_H_PADDING; len(_STATUS_SEPARATOR) == the boundary marker
+    # rendered ONLY because status_text_len > 0 here (a merge with tabs
+    # present and non-empty text).
+    max_fitting_len = 40 - last_row_used - 2 - len(_STATUS_SEPARATOR)
     assert status_fits_last_row(narrow_rows, 40, status_text_len=max_fitting_len) is True
     assert status_fits_last_row(narrow_rows, 40, status_text_len=max_fitting_len + 1) is False
 
-    # No tabs at all: fits iff the text alone fits the width.
+    # No tabs at all: fits iff the text alone fits the width — no separator
+    # (nothing to separate from without a tab row to merge onto).
     assert status_fits_last_row([], 20, status_text_len=15) is True
     assert status_fits_last_row([], 20, status_text_len=25) is False
 
@@ -888,6 +898,98 @@ async def test_status_line_on_screen_and_merge_matches_prediction(
         assert actually_merged == predicted_merge, (
             f"at {screen_size} (content_width={content_width}): predicted "
             f"merge={predicted_merge} but the live tree shows merged={actually_merged}"
+        )
+
+
+def _merged_in_live_tree(line: StatusLine) -> bool:
+    """Public-surface merge check — mirrors
+    ``test_status_line_on_screen_and_merge_matches_prediction``'s own
+    technique (StatusLine's parent row also carrying Tab children), so this
+    reads the ACTUAL mounted tree rather than :class:`MenuBar`'s private
+    ``_merged`` bookkeeping."""
+    from textual.widgets import Tab
+
+    parent_row = line.parent
+    return bool(list(parent_row.query(Tab))) if parent_row is not None else False
+
+
+@pytest.mark.asyncio
+async def test_status_separator_present_only_when_merged_and_survives_live_updates(
+    tmp_path,
+) -> None:
+    """Tier 2b: owner feedback — the tab/status boundary was unmarked (a
+    padding gap alone, indistinguishable from ordinary inter-tab spacing).
+    Two invariants:
+
+    1. When StatusLine SHARES a row with Tab widgets, its rendered text
+       starts with :data:`_STATUS_SEPARATOR` — the boundary is now visibly
+       marked, not just padded.
+    2. When StatusLine has its OWN row (no tabs to share with — forced here
+       by mounting a bare :class:`MenuBar` with a single tab far wider than
+       the screen, its PUBLIC constructor's ordinary input, not a private-
+       state poke), the separator is ABSENT — there is nothing to mark a
+       boundary against.
+
+    Also covers :meth:`MenuBar.update_status`'s no-remount fast path (an
+    unchanged-length tick): the separator must survive a LIVE update, not
+    just the initial mount — a bug scoped to only the mount-time render
+    path would pass invariant 1 above and still regress on the very next
+    cost/ctx tick."""
+    from textual.app import App, ComposeResult
+
+    from reyn.interfaces.inline.textual_chat import StatusLine, TextualChatApp
+    from reyn.interfaces.inline.textual_chat.chrome import _STATUS_SEPARATOR
+
+    snap, _session, _registry = await _real_snapshot(tmp_path)
+    snap["cost_agent"] = 0.0100
+    read_model = _MutableSnapshotReadModel(snap)
+    transport = _EventOnlyTransport()
+    app = TextualChatApp(transport=transport, read_model=read_model)
+
+    # A very wide screen: trivially enough room for all 13 (abbreviated)
+    # tabs + a short status string on one row (the merged case) — 100
+    # columns measured NOT wide enough for this fixture's tabs+status
+    # combination, so this deliberately goes wider rather than assuming.
+    async with app.run_test(size=(220, 30)) as pilot:
+        await pilot.pause()
+        line = app.query_one(StatusLine)
+        assert _merged_in_live_tree(line), "test setup expected a merge at 220 columns"
+        rendered = str(line.render())
+        assert rendered.startswith(_STATUS_SEPARATOR), (
+            f"merged StatusLine missing the boundary separator: {rendered!r}"
+        )
+
+        # A live, unchanged-length tick (the common cost/ctx-only update
+        # path) — the separator must still be there afterward, not only at
+        # mount.
+        read_model.snap["cost_agent"] = 0.0200
+        await transport.push_event(_llm_response_event())
+        await pilot.pause()
+        await pilot.pause()
+        after = str(app.query_one(StatusLine).render())
+        assert after.startswith(_STATUS_SEPARATOR), (
+            f"separator lost after a live update_status tick: {after!r}"
+        )
+        assert after != rendered, "status text did not actually change"
+
+    # A single tab far wider than the screen forces status onto its OWN
+    # row (nothing merges) — the separator must be ABSENT there. A bare
+    # MenuBar mounted directly (its public constructor's ordinary input),
+    # not the full TextualChatApp — no private-state reach-in needed to
+    # force this shape.
+    class _BareMenuBarApp(App):
+        def compose(self) -> ComposeResult:
+            yield MenuBar([("x", "x" * 90)], status_text="model m │ agent a", id="menubar")
+
+    async with _BareMenuBarApp().run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        line2 = pilot.app.query_one(StatusLine)
+        assert not _merged_in_live_tree(line2), (
+            "test setup expected NO merge with a 90-char tab"
+        )
+        rendered2 = str(line2.render())
+        assert not rendered2.startswith(_STATUS_SEPARATOR), (
+            f"unmerged StatusLine wrongly carries the boundary separator: {rendered2!r}"
         )
 
 


### PR DESCRIPTION
**[tui-coder]** — direct owner feedback (not from an issue): "ステータスバーにあるタブとステータスの境界がわからないんだけど '|' 挟めないの？" (can't tell the boundary between tabs and status in the status bar — can't insert a '|'?).

## What
The bottom-chrome status-values segment (`model │ agent │ cost │ ctx`) shares a row with the wrapped menu tabs whenever the terminal is wide enough (`MenuBar._repack`'s merge case, #3326), but the boundary between the last tab and the status segment was unmarked — a padding gap only, visually indistinguishable from ordinary inter-tab spacing.

## How
- Prepends the SAME `│` delimiter `status_line_text` already uses between its own fields, so the merged row reads as one consistent `│`-delimited style rather than introducing a second glyph.
- Applied ONLY when `StatusLine` actually shares a row with tabs — when it has its own row (no merge), there's nothing to mark a boundary against, so no separator renders.
- `status_fits_last_row` now accounts for the separator's added width when predicting whether status fits alongside tabs — an under-count would predict a fit the real merged row then overflows, exactly the kind of off-screen defect #3326's own geometry guard exists to catch.
- `MenuBar._merged` tracks the current merge state so `update_status()`'s no-remount fast path (the common cost/ctx-only tick) keeps applying the separator consistently, not just at the frame that first merged the row.

## Tests
- Updated `test_status_fits_last_row_pure`'s width math for the separator's added cell width.
- Added `test_status_separator_present_only_when_merged_and_survives_live_updates`: separator present when merged, absent when unmerged, and survives a live `update_status()` tick (a fix scoped to only the mount-time render path would still regress on the very next cost/ctx tick).
  - The unmerged case mounts a bare `MenuBar` directly (its public constructor's ordinary input — a single tab far wider than the screen), not a private-state poke.
  - The merge check uses the SAME public-tree technique (`StatusLine`'s parent row's `Tab` children) the existing geometry-guard test already relies on — no `._merged` private-attribute assertion.

Falsify-verified: reverted the `chrome.py` fix, confirmed both the updated and the new test fail for the right reason (`ImportError` on the now-missing `_STATUS_SEPARATOR`), then restored and confirmed green.

## Verification
- `pytest tests/interfaces/test_3338_tui_status_chrome_liveness.py` — 31 passed.
- `pytest tests/interfaces/ -k "menubar or status_line or chrome or MenuBar or StatusLine"` — 62 passed (wider textual_chat sweep, no regressions).
- `ruff check src tests` — clean.
- `python scripts/test_tier_audit.py --strict tests/interfaces/test_3338_tui_status_chrome_liveness.py` — 27/27 OK, 0 Tier-4 violations.
- `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/chrome.py` — OK.
- `python scripts/mypy_ratchet.py` — OK.
- `python scripts/check_tests_path_literal_reference.py` — OK.
- Colour policy: no new colour introduced — the separator glyph inherits `StatusLine`'s existing `color: @quiet@` palette token.

## Test plan
- [x] `ruff check` — clean.
- [x] `pytest` (scoped) — 31 + wider 62-test sweep passed.
- [x] Falsify-verify — reverted, confirmed both tests fail for the right reason, restored.
- [x] (skipped — N/A, no `tests/` file renamed, no path-literal drift)
- [x] Visual — N/A per the standing owner waiver (2026-08-08): proceeding with the main merge even for visual gates; the operator confirms after, on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**[lead-coder]** — ✅ **TESTS-READ 済。★通します（★武装します）。⚪ ★非ブロックの 注記 1 点。**

## ✅ 六問

```
① Tier ── ★2（merge した 時だけ 境界標を 出す、という 表示契約）── ★妥当
② 転記 ── ★該当なし ── ★assert は ★定数と 一致 では なく
          「★merged の 時 ★prefix が 在り、★非 merged の 時 ★無い」＝ ★分岐の 主張
③ 誰が困る ── ★owner（★この 依頼の 出所）。★非 merge 側の accept test も 自分の 仕事を 持つ
④ 走らず緑 ── ★該当なし（★live tree で merge を 実際に 確認してから assert）
⑤ 累積 ── ★無し
⑥ 宣言＝実体 ── ★一致
```
⚪ **★live 更新後も prefix が 残る（`after != rendered` で ★中身が 実際に 変わった ことも 確認）
まで 見ている のが 良い** —— **★「1 回 描けた」で 止めていません。**

## ⚪ ★非ブロックの 注記 ── ★区切り文字の 出所が ★2 つ に なりました

```
★新   chrome.py  _STATUS_SEPARATOR = "│ "        ── ★定数
🔴 ★既存 chrome.py:1395 / 1397 / 1414-1415 / 1419 ── ★f-string の ★リテラル `│`
∴ ★同じ「区切り」に ★2 つの 出所 ── ★片方だけ 変えても ★どちらの test も 落ちません
   ── ★#4537 で 私が 指摘した ★契約の 二重転記 と ★同じ 形
⚠️ ★この PR の 主題（★1 行を ★一貫した │ 区切りに 見せる）が ★まさに それ
```
🔴 **★ブロックしません** —— **★owner が ★見たい もの であり、★見る 面は main だけ**
（**★visual gate の 恒久 waiver**）。**★退行の 向きも ★見た目の 不整合 まで。**
⚪ **★次に この 行を 触る PR で、★両方を 1 つの 定数から 組み立てて ください**
（**★同ファイル・5 行 程度**）。**★ここに 書いた ので 消えません。**
