### PR TITLE
docs(#4534): __attach_request__ was retired in PR-2, agui-transport.md still called it "genuinely live"

### DIFF
--- a/docs/reference/runtime/agui-transport.ja.md
+++ b/docs/reference/runtime/agui-transport.ja.md
@@ -88,7 +88,6 @@ client は 1 つの順序付き SSE ストリームを消費し、各 event を�
 | `intervention`    | `CUSTOM`           | プロンプトが表示される。reyn client はそれをネイティブに描画し、id で回答する(「Human-in-the-loop answering」参照) |
 | `presentation`    | `CUSTOM`           | `present` op の render-node モデル(*present-on-wire* 参照) |
 | `__copy_last_reply__` / `__rewind_list__` | `CUSTOM` | クライアント消費センチネル — 転送される(*control sentinels* 参照) |
-| `__attach_request__` | `CUSTOM`        | 転送される — live なワイヤー kind(*control sentinels* 参照) |
 | `__end__` / `__session_switch_request__` | *(フィルタ)* | 転送されない(*control sentinels* 参照) |
 
 これら以外の display kind もすべて損失なく round-trip する(`CUSTOM` にフォールバックし
@@ -118,13 +117,15 @@ display kind を誤って落としてしまう):
     (`_SessionFrameSource._drain_one_session`: セッション switch-follow、解決できない
     sid の場合は silent drop)ため、その source から emitter に到達しない。フィルタ
     エントリは、消費しない frame source に対する fail-safe。
-- **転送され、実際に live**: `__attach_request__` は profiled `CUSTOM` display event
-  として **実際にワイヤーへ出る**。registry forwarder の `continue` はこれを妨げない —
-  forwarder と AG-UI tap は同一 `session.outbox_hub` の独立した 2 つの subscriber であり、
-  hub は全 subscription に全メッセージを fan-out するので、`continue` は
-  「`repl_outbox`(ローカル REPL sink)に再投函しない」だけを意味する。リモート
-  クライアントはこの kind を許容する必要があり、reyn クライアントは表示上スキップする
-  ので会話ペインに素のセンチネルは出ない(リモートの attach-label *同期* は別機構)。
+- **廃止済み**(#4534 PR-2): `__attach_request__` はもう存在しない。`/agent new`と
+  `/attach`は今や named operation である`ClientTransport.request_attach`を経由する
+  (display channel のセンチネルではない — #3595 S5 の原則「client が解釈し、server が
+  名前つき操作を実行する」を`run_slash_command`と同じ形で適用)。本docの以前の版は
+  `__attach_request__`を「転送され、実際に live」と記述していたが、それはPR-2着地前は
+  正確だった。`__session_switch_request__`は★別のセンチネルで、上記の通り引き続き
+  filterされている——その移行(PR-2b)は、消費が二重目的(`agui/endpoint.py`の
+  mid-stream switch-follow、#3310 N3も駆動する)であるため別途段階的に進められており、
+  本docではまだ扱っていない。
 
 > #3362 で訂正。本節は以前、両センチネルとも registry forwarder が swallow するため
 > 「AG-UI tap に到達しない」と記述していたが、いずれも到達する。forwarder の
@@ -400,7 +401,6 @@ display 行のテキストである。
 | `reyn.display.system`             | reyn chrome 行 — 永続化されるライフサイクル/ステータスマーカー(compaction / budget / cost-warn) |
 | `reyn.display.__copy_last_reply__` | `/copy` センチネル — 転送される(クライアント側クリップボードコピー);*control sentinels* 参照 |
 | `reyn.display.__rewind_list__`    | `/rewind` センチネル — 転送される(クライアント側 rewind ピッカー);*control sentinels* 参照 |
-| `reyn.display.__attach_request__` | attach-request センチネル — 実際に emit される;reyn クライアントは表示上スキップ;*control sentinels* 参照 |
 | `reyn.display.tool_call_started`  | tool-call 開始のトレース行                              |
 | `reyn.display.tool_call_completed`| tool-call 完了のトレース行                              |
 | `reyn.display.tool_call_failed`   | tool-call 失敗のトレース行                              |

--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -101,7 +101,6 @@ of the renderer's two entry points (display vs working-indicator). The mapping:
 | `intervention`    | `CUSTOM`           | a prompt is displayed; the reyn client draws it natively and answers it by id (see "Human-in-the-loop answering") |
 | `presentation`    | `CUSTOM`           | a `present` op's render-node model (see *present-on-wire*) |
 | `__copy_last_reply__` / `__rewind_list__` | `CUSTOM` | client-consumed sentinels — forwarded (see *control sentinels*) |
-| `__attach_request__` | `CUSTOM`        | forwarded — a live wire kind (see *control sentinels*) |
 | `__end__` / `__session_switch_request__` | *(filtered)* | NOT forwarded (see *control sentinels*) |
 
 Any other display kind still round-trips losslessly (it falls back to `CUSTOM` and
@@ -134,14 +133,17 @@ renderable display kinds):
     drop for an unresolvable sid), so it never reaches the emitter from that
     source; the filter entry is a fail-safe covering a frame source that does not
     consume it.
-- **Forwarded, and genuinely live**: `__attach_request__` **is** emitted on the
-  wire as a profiled `CUSTOM` display event. The registry forwarder's `continue`
-  does not prevent this: the forwarder and the AG-UI tap are two independent
-  subscribers of the same `session.outbox_hub`, which fans every message out to
-  every subscription, so the `continue` only means "not re-posted to
-  `repl_outbox`" (the local REPL sink). A remote client must tolerate the kind;
-  the reyn client skips it for display so no bare sentinel lands in the
-  conversation pane. (Remote attach-label *sync* is a separate mechanism.)
+- **Retired** (#4534 PR-2): `__attach_request__` no longer exists. `/agent new`
+  and `/attach` now go through `ClientTransport.request_attach` — a named
+  operation, not a display-channel sentinel (#3595 S5's own principle: the
+  client interprets, the server executes a named operation, the same shape
+  `run_slash_command` already applied). Earlier revisions of this doc described
+  `__attach_request__` as "forwarded, and genuinely live" on the wire — that was
+  accurate before PR-2 landed. `__session_switch_request__` is a **separate**
+  sentinel, still filtered as described above — its own migration (PR-2b) is
+  staged separately because its consumption is dual-purpose (it also drives
+  `agui/endpoint.py`'s mid-stream switch-follow, #3310 N3), not yet documented
+  here.
 
 > Corrected in #3362. This section previously stated that both sentinels "never
 > reach the AG-UI tap" because the registry forwarder swallows them. Both do
@@ -564,7 +566,6 @@ A reyn display frame with no standard AG-UI analog. `value` is `{"text": <string
 | `reyn.display.system`             | a reyn chrome line — a persisted lifecycle/status marker (compaction / budget / cost-warn) |
 | `reyn.display.__copy_last_reply__` | the `/copy` sentinel — forwarded (client-side clipboard copy); see *control sentinels* |
 | `reyn.display.__rewind_list__`    | the `/rewind` sentinel — forwarded (client-side rewind picker); see *control sentinels* |
-| `reyn.display.__attach_request__` | the attach-request sentinel — really emitted; the reyn client skips it for display; see *control sentinels* |
 | `reyn.display.tool_call_started`  | a tool-call start trace line                           |
 | `reyn.display.tool_call_completed`| a tool-call completion trace line                     |
 | `reyn.display.tool_call_failed`   | a tool-call failure trace line                        |


### PR DESCRIPTION
**[docs-maintainer]** — Same-night doc drift: #4541 (#4534 PR-2) fully retired `__attach_request__`, but `agui-transport.md` (en+ja) still described it as "genuinely live" on the wire.

## What drifted

`/agent new` and `/attach` now go through `ClientTransport.request_attach` (a named operation, #3595 S5's own principle) instead of the `__attach_request__` display-channel sentinel — every consumption site was removed in the same PR. Confirmed via `grep -rn "__attach_request__" src/`: no live construction site remains, only historical/retirement comments.

## The fix

Removed the two now-nonexistent table entries (the display-kind mapping table and the `reyn.display.<kind>` events table) and rewrote the "control sentinels" prose paragraph to state the retirement plainly, naming the replacement mechanism at a high level — deliberately **not** a full contract writeup for `request_attach` yet, since PR-2b (which migrates `__session_switch_request__` and ports its switch-follow behavior) is still pending; a fuller section rewrite waits until both retirements land, matching the same staged-deferral reasoning #4482 PR-3 used.

`__session_switch_request__` itself is untouched — PR-2 explicitly did not migrate it (that's PR-2b, per #4541's own commit message).

## Verification

- `mkdocs build --strict -f .mkdocs/mkdocs.yml` — no error/Aborted line.
- `ruff check src tests` — clean.
- `grep -rn "__attach_request__" src/` confirmed no live construction site before writing "retired" as fact.

part of #4534

## Test plan

- [x] `mkdocs build --strict` — clean, no Aborted/error line (read directly)
- [x] `ruff check src tests` — clean
- [x] Confirmed no live `__attach_request__` construction site in `src/` before writing the retirement claim
- [x] Confirmed `__session_switch_request__` (PR-2b, still pending) left untouched
- [x] (skipped — docs-only edit, no runtime behavior change, no test to run)
