### PR TITLE
feat(#4534 PR-2b): migrate /session switch off the sentinel, port switch-follow

### DIFF
--- a/docs/reference/runtime/agui-transport.ja.md
+++ b/docs/reference/runtime/agui-transport.ja.md
@@ -88,7 +88,7 @@ client は 1 つの順序付き SSE ストリームを消費し、各 event を�
 | `intervention`    | `CUSTOM`           | プロンプトが表示される。reyn client はそれをネイティブに描画し、id で回答する(「Human-in-the-loop answering」参照) |
 | `presentation`    | `CUSTOM`           | `present` op の render-node モデル(*present-on-wire* 参照) |
 | `__copy_last_reply__` / `__rewind_list__` | `CUSTOM` | クライアント消費センチネル — 転送される(*control sentinels* 参照) |
-| `__end__` / `__session_switch_request__` | *(フィルタ)* | 転送されない(*control sentinels* 参照) |
+| `__end__` | *(フィルタ)* | 転送されない(*control sentinels* 参照) |
 
 これら以外の display kind もすべて損失なく round-trip する(`CUSTOM` にフォールバックし
 `_reyn` から再構成される)— 新しい display kind がワイヤー上で静かに消えることは決してない。
@@ -113,24 +113,17 @@ display kind を誤って落としてしまう):
 - **フィルタ**(`CONTROL_FILTER_KINDS`、明示的 allowlist — emitter はワイヤーイベントを出さない):
   - `__end__` — ストリーム終端(emitter はこれで return する。クライアントのループもストリーム
     クローズで終わる)。
-  - `__session_switch_request__` — **AG-UI tap 自身** がこのセンチネルを消費する
-    (`_SessionFrameSource._drain_one_session`: セッション switch-follow、解決できない
-    sid の場合は silent drop)ため、その source から emitter に到達しない。フィルタ
-    エントリは、消費しない frame source に対する fail-safe。
-- **廃止済み**(#4534 PR-2): `__attach_request__` はもう存在しない。`/agent new`と
-  `/attach`は今や named operation である`ClientTransport.request_attach`を経由する
+  - `__open_artifact__` — 構造上ローカル専用(クライアントが動くマシン上で OS アプリを
+    起動する;*#4482* 参照)。
+- **廃止済み**(#4534 PR-2 / PR-2b): `__attach_request__` と `__session_switch_request__`
+  はもう存在しない。`/agent new`・`/attach`・`/session switch` はすべて今や named
+  operation である `ClientTransport.request_attach` / `request_session_switch` を経由する
   (display channel のセンチネルではない — #3595 S5 の原則「client が解釈し、server が
-  名前つき操作を実行する」を`run_slash_command`と同じ形で適用)。本docの以前の版は
-  `__attach_request__`を「転送され、実際に live」と記述していたが、それはPR-2着地前は
-  正確だった。`__session_switch_request__`は★別のセンチネルで、上記の通り引き続き
-  filterされている——その移行(PR-2b)は、消費が二重目的(`agui/endpoint.py`の
-  mid-stream switch-follow、#3310 N3も駆動する)であるため別途段階的に進められており、
-  本docではまだ扱っていない。
-
-> #3362 で訂正。本節は以前、両センチネルとも registry forwarder が swallow するため
-> 「AG-UI tap に到達しない」と記述していたが、いずれも到達する。forwarder の
-> `continue` は subscriber-local である。実 forwarder + 実 tap で計測
-> (`tests/interfaces/test_agui_control_filter.py`)。
+  名前つき操作を実行する」を `run_slash_command` と同じ形で適用)。本 doc の以前の版は
+  `__attach_request__` を「転送され、実際に live」、`__session_switch_request__` を
+  「tap が消費しフィルタされる」と記述していたが、それぞれ各 PR 着地前は正確だった。
+  セッション switch-follow(下記)ももう outbox からセンチネルを消費せず、
+  `registry.add_attach_listener` に直接 subscribe する。
 
 #### Text lifecycle(適合する triplet — plain と streamed)
 

--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -101,7 +101,7 @@ of the renderer's two entry points (display vs working-indicator). The mapping:
 | `intervention`    | `CUSTOM`           | a prompt is displayed; the reyn client draws it natively and answers it by id (see "Human-in-the-loop answering") |
 | `presentation`    | `CUSTOM`           | a `present` op's render-node model (see *present-on-wire*) |
 | `__copy_last_reply__` / `__rewind_list__` | `CUSTOM` | client-consumed sentinels — forwarded (see *control sentinels*) |
-| `__end__` / `__session_switch_request__` | *(filtered)* | NOT forwarded (see *control sentinels*) |
+| `__end__` | *(filtered)* | NOT forwarded (see *control sentinels*) |
 
 Any other display kind still round-trips losslessly (it falls back to `CUSTOM` and
 is reconstructed from `_reyn`) — a new display kind can never silently vanish on
@@ -128,27 +128,19 @@ renderable display kinds):
   no wire event):
   - `__end__` — the stream terminator (the emitter returns on it; the client's
     loop also ends when the stream closes).
-  - `__session_switch_request__` — the **AG-UI tap itself** consumes this one
-    (`_SessionFrameSource._drain_one_session`: session switch-follow, or a silent
-    drop for an unresolvable sid), so it never reaches the emitter from that
-    source; the filter entry is a fail-safe covering a frame source that does not
-    consume it.
-- **Retired** (#4534 PR-2): `__attach_request__` no longer exists. `/agent new`
-  and `/attach` now go through `ClientTransport.request_attach` — a named
-  operation, not a display-channel sentinel (#3595 S5's own principle: the
-  client interprets, the server executes a named operation, the same shape
-  `run_slash_command` already applied). Earlier revisions of this doc described
-  `__attach_request__` as "forwarded, and genuinely live" on the wire — that was
-  accurate before PR-2 landed. `__session_switch_request__` is a **separate**
-  sentinel, still filtered as described above — its own migration (PR-2b) is
-  staged separately because its consumption is dual-purpose (it also drives
-  `agui/endpoint.py`'s mid-stream switch-follow, #3310 N3), not yet documented
-  here.
-
-> Corrected in #3362. This section previously stated that both sentinels "never
-> reach the AG-UI tap" because the registry forwarder swallows them. Both do
-> reach it; the forwarder's `continue` is subscriber-local. Measured with the
-> real forwarder + real tap in `tests/interfaces/test_agui_control_filter.py`.
+  - `__open_artifact__` — local-only by construction (launches an OS app on the
+    machine the client is running on; see *#4482*).
+- **Retired** (#4534 PR-2 / PR-2b): `__attach_request__` and
+  `__session_switch_request__` no longer exist. `/agent new`, `/attach`, and
+  `/session switch` all go through `ClientTransport.request_attach` /
+  `request_session_switch` — named operations, not display-channel sentinels
+  (#3595 S5's own principle: the client interprets, the server executes a
+  named operation, the same shape `run_slash_command` already applied).
+  Earlier revisions of this doc described `__attach_request__` as "forwarded,
+  and genuinely live" on the wire, and `__session_switch_request__` as
+  tap-consumed-and-filtered — both accurate before their respective PRs
+  landed. Session-switch follow (below) no longer consumes a sentinel off
+  the outbox either; it subscribes to `registry.add_attach_listener` directly.
 
 #### The session-switch barrier (`reyn.event.session_attached`, #3310 N1/N2)
 
@@ -211,13 +203,20 @@ switch as a **logical reconnect**, entirely within the remote transport
 (the registry's own `attach`/`attach_session` + `repl_outbox` barrier are
 untouched and not involved):
 
-- `_SessionFrameSource` (`endpoint.py`) independently observes the SAME
-  `__session_switch_request__` sentinel the registry forwarder consumes for
-  the local REPL (both are subscribers of the same session's `outbox_hub`
-  fan-out — see *the control-sentinel dispositions* above). On seeing it, it
-  **enqueues the `session_attached` `EventFrame` onto this connection's own
-  queue BEFORE re-pointing itself at the target session** (`registry.get_session`
-  + subscribing to the new session's audit-events) — the SAME vocabulary N1
+- `_SessionFrameSource` (`endpoint.py`) subscribes to
+  `registry.add_attach_listener(agent_name, ...)` (#4534 PR-2b — ported off the
+  retired `__session_switch_request__` sentinel, whose in-band arrival on
+  `session.outbox_hub` this source used to observe directly; `attach_session`
+  now flips focus out-of-band, so the source instead registers a synchronous
+  callback the registry fires from `_announce_session_attached`'s own no-await
+  critical section). The callback hands the target sid to a per-connection
+  `asyncio.Queue`, which `_drain_one_session`'s drain loop dual-waits
+  alongside `sub.get()` (`asyncio.wait(..., return_when=FIRST_COMPLETED)`) —
+  the second wait source an in-flight blocked `await sub.get()` needs to be
+  interrupted by an out-of-band signal. On seeing the sid, it **enqueues the
+  `session_attached` `EventFrame` onto this connection's own queue BEFORE
+  re-pointing itself at the target session** (`registry.get_session` +
+  subscribing to the new session's audit-events) — the SAME vocabulary N1
   defined, an independent per-connection equivalent since `repl_outbox` never
   reaches a remote surface. This ordering (announce, then subscribe) is
   load-bearing, not incidental: the new session's audit-event subscriber does
@@ -229,9 +228,9 @@ untouched and not involved):
   that floods the target session's own audit-event stream the instant the
   switch is triggered). It never calls `registry.attach_session` itself, so
   it cannot race or double-apply that side effect — it only re-points THIS
-  connection's own view. A registry-less construction (every pre-N3 unit test)
-  degrades byte-identically: the sentinel falls through to the generic
-  `DisplayFrame` path, where `CONTROL_FILTER_KINDS` already drops it silently.
+  connection's own view. A registry-less / agent_name-less construction
+  (most existing unit tests) registers no listener at all, so no switch-follow
+  ever happens for that connection.
 - `AgUiEmitter`, on observing a `session_attached` `EventFrame` flow through
   `stream()`, re-fires the SAME reconnect protocol it uses at connect
   (`_reconnect_snapshot_chunks`: `MESSAGES_SNAPSHOT` then `STATE_SNAPSHOT`)

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -133,23 +133,16 @@ logger = logging.getLogger(__name__)
 # the :class:`~reyn.interfaces.inline.textual_chat.rewind_picker.RewindPicker`
 # region + a text fallback) and are gone from this set.
 #
-# The one that REMAINS is a fail-safe, not a live path. ``/attach`` and
+# Both former entries are retired (#4534 PR-2 / PR-2b). ``/attach`` and
 # ``/session switch`` now go through ``ClientTransport.request_attach`` /
-# ``request_session_switch`` (#4534 PR-2) — typed operations, not a
-# display-channel sentinel; ``__attach_request__`` retired from this set
-# with them (#4534 PR-2: nothing constructs that kind anymore).
-#
-# ``__session_switch_request__`` is left here as a fail-safe pending #4534's
-# switch-follow port (the AG-UI remote tap's mid-stream re-point used to
-# consume this same sentinel off the outbox — see
-# ``transport/agui/endpoint.py``'s ``_SessionFrameSource``, which is why the
-# kind is not yet fully retired). If a future change removes it there too,
-# remove it here in the same PR.
-_SKIP_KINDS = frozenset(
-    {
-        "__session_switch_request__",
-    }
-)
+# ``request_session_switch`` — typed operations, not a display-channel
+# sentinel — and the AG-UI remote tap's mid-stream switch-follow
+# (``transport/agui/endpoint.py``'s ``_SessionFrameSource``) subscribes to
+# ``registry.add_attach_listener`` directly instead of consuming a sentinel
+# off the outbox. Nothing constructs either kind anymore, so this set is
+# currently empty — kept (not deleted) as the documented extension point for
+# a future control sentinel that needs skipping here.
+_SKIP_KINDS: "frozenset[str]" = frozenset()
 
 # Turn-end event types (#72): when one of these lands on the EVENT-tag frame
 # path, any tool row still RUNNING is a confirmed ORPHAN — its completion frame

--- a/src/reyn/interfaces/slash/agent.py
+++ b/src/reyn/interfaces/slash/agent.py
@@ -59,7 +59,12 @@ async def _create_agent(ctx: "SlashContext", name: str) -> None:
 
     #4534 PR-2: uses the same ``request_attach`` named-operation seam as
     ``/attach`` (until #191 lands, the header label won't refresh — same
-    constraint as /attach).
+    constraint as /attach). The reply is ordered AFTER the call and reads
+    its return (lead-coder review, #4534 remainder): ``request_attach``'s
+    ``False`` is ambiguous by transport (AG-UI's is "unknown" — an
+    unconfirmed remote ack; in-process's is a definitive local failure), so
+    the reply on ``False`` says "could not confirm", never "failed" — the
+    wording that would be true for one transport and wrong for the other.
     """
     name = name.strip()
     if not name:
@@ -81,8 +86,14 @@ async def _create_agent(ctx: "SlashContext", name: str) -> None:
         # verbatim so the user sees exactly what's wrong with the name.
         await reply_error(ctx, str(exc))
         return
-    await reply(ctx, f"created agent {name!r}; attaching…")
-    await ctx.transport.request_attach(name)
+    attached = await ctx.transport.request_attach(name)
+    if attached:
+        await reply(ctx, f"created agent {name!r}; attaching…")
+    else:
+        await reply(
+            ctx,
+            f"created agent {name!r}; could not confirm the attach — try /attach {name}",
+        )
 
 
 async def _edit_agent(ctx: "SlashContext", args: str) -> None:

--- a/src/reyn/interfaces/slash/agents.py
+++ b/src/reyn/interfaces/slash/agents.py
@@ -91,6 +91,13 @@ async def attach_cmd(ctx: "SlashContext", args: str) -> None:
     a typed request to whichever transport holds the session (local:
     direct ``registry.attach``; remote: a wire call the server executes),
     not a display-channel sentinel a REPL loop has to specially detect.
+
+    The success reply is ordered AFTER the call and reads its return
+    (lead-coder review, #4534 remainder): ``request_attach``'s ``False`` is
+    ambiguous by transport (AG-UI's is "unknown" — an unconfirmed remote
+    ack; in-process's is a definitive local failure), so the reply on
+    ``False`` says "could not confirm", never "failed" — the wording that
+    would be true for one transport and wrong for the other.
     """
     name = args.strip()
     if not name:
@@ -115,7 +122,11 @@ async def attach_cmd(ctx: "SlashContext", args: str) -> None:
     # produced no in-pane feedback — the user had to run ``/agents``
     # to confirm the switch happened. The actual attach runs through
     # ClientTransport.request_attach (#4534 PR-2); this reply is a
-    # separate, visible breadcrumb. (The header label refresh is
+    # separate, visible breadcrumb, ordered AFTER the call so it reflects
+    # what the call actually reports. (The header label refresh is
     # blocked by a separate registry-forwarder bug — see #191.)
-    await reply(ctx, f"attached to {name!r}")
-    await ctx.transport.request_attach(name)
+    attached = await ctx.transport.request_attach(name)
+    if attached:
+        await reply(ctx, f"attached to {name!r}")
+    else:
+        await reply(ctx, f"could not confirm attach to {name!r}")

--- a/src/reyn/interfaces/slash/session.py
+++ b/src/reyn/interfaces/slash/session.py
@@ -11,10 +11,10 @@ Stage 3; this is the REPL wiring.
                           per-session capability narrowing (#2103-S1a), composed
                           the same way the three sibling spawn sites compose
                           theirs, and the reply names what it inherited.
-  /session switch <sid> → focus another session of the attached agent. Routed
-                          through the registry forwarder (like ``/attach``) so
-                          the focus flip + display re-wire are sequenced, not
-                          raced against the output loop.
+  /session switch <sid> → focus another session of the attached agent, via
+                          ``ClientTransport.request_session_switch`` (#4534
+                          PR-2b — a typed request, not a display-channel
+                          sentinel a forwarder has to specially detect).
   /session list         → list the attached agent's sessions (``*`` = focused).
 
 Byte-identical when unused: a session that never runs ``/session`` keeps the
@@ -24,7 +24,6 @@ routing for non-REPL transports (web / A2A) is Stage 4b.
 from __future__ import annotations
 
 from reyn.interfaces.slash import SlashContext, reply, reply_error, slash
-from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.spawn_routing import ReviewedNA
 from reyn.security.permissions.capability_profile import compose_narrowing_mappings
 
@@ -182,13 +181,19 @@ async def session_cmd(ctx: "SlashContext", args: str) -> None:
                 " partial prefixes are not supported. Try /session list.",
             )
             return
-        # Visible breadcrumb; the actual focus flip is driven by the sentinel
-        # below (the registry forwarder consumes it → attach_session), mirroring
-        # /attach so display re-wiring is sequenced on the registry side.
-        await reply(ctx, f"switching to session {rest!r}")
-        ctx.transport.put_display(OutboxMessage(
-            kind="__session_switch_request__", text=rest,
-        ))
+        # #4534 PR-2b: the actual focus flip goes through the named-operation
+        # seam (request_session_switch -> registry.attach_session), not the
+        # retired __session_switch_request__ display-channel sentinel — see
+        # ClientTransport.request_session_switch's own docstring for why.
+        # The reply is ordered AFTER the call and reads its return
+        # (lead-coder review, #4534 remainder): False is ambiguous by
+        # transport (AG-UI's is "unknown"; in-process's is definitive), so
+        # the reply on False says "could not confirm", never "failed".
+        switched = await ctx.transport.request_session_switch(rest)
+        if switched:
+            await reply(ctx, f"switching to session {rest!r}")
+        else:
+            await reply(ctx, f"could not confirm the switch to session {rest!r}")
         return
 
     if sub == "list":

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -197,15 +197,15 @@ class AgUiTransport(ClientTransport):
         return bool((result or {}).get("ran"))
 
     async def request_attach(self, agent_name: str) -> bool:
-        # #4534 PR-1: same shape as run_slash_command above, a second typed
-        # payload alongside it — the ADD-ONLY half of retiring the
-        # __attach_request__ display-channel sentinel. The server re-
-        # resolves agent_name against its own registry.
+        # #4534 PR-1/PR-2: same shape as run_slash_command above, a second
+        # typed payload alongside it — retires the __attach_request__
+        # display-channel sentinel. The server re-resolves agent_name
+        # against its own registry.
         result = await self._send({"type": "attach_request", "agent_name": agent_name})
         return bool((result or {}).get("attached"))
 
     async def request_session_switch(self, session_id: str) -> bool:
-        # #4534 PR-1: mirrors request_attach above, retiring
+        # #4534 PR-1/PR-2b: mirrors request_attach above, retiring
         # __session_switch_request__.
         result = await self._send(
             {"type": "session_switch_request", "session_id": session_id},

--- a/src/reyn/interfaces/transport/agui/emitter.py
+++ b/src/reyn/interfaces/transport/agui/emitter.py
@@ -132,13 +132,12 @@ class AgUiEmitter:
             # Control sentinels in CONTROL_FILTER_KINDS are NOT forwarded on the
             # AG-UI wire — the explicit per-entry allowlist (protocol.py), not the
             # negation of any forward-set. It holds only ``__end__`` (the stream
-            # terminator; returns below) and ``__session_switch_request__`` (which
-            # the registry already swallows upstream — a fail-safe). Client-consumed
-            # sentinels ``__copy_last_reply__`` / ``__rewind_list__`` are DELIBERATELY
-            # NOT here: the client consumes them over the transport stream (real
-            # clipboard copy / rewind picker), so they are forwarded as profiled
-            # CUSTOM events — filtering them would make remote /copy / /rewind
-            # silent no-ops.
+            # terminator; returns below) and ``__open_artifact__`` (local-only by
+            # construction). Client-consumed sentinels ``__copy_last_reply__`` /
+            # ``__rewind_list__`` are DELIBERATELY NOT here: the client consumes
+            # them over the transport stream (real clipboard copy / rewind
+            # picker), so they are forwarded as profiled CUSTOM events —
+            # filtering them would make remote /copy / /rewind silent no-ops.
             is_control = (
                 isinstance(frame, DisplayFrame)
                 and frame.message.kind in CONTROL_FILTER_KINDS

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -217,27 +217,40 @@ class _SessionFrameSource:
     the renderer-relevant ``session.audit_events`` subset as EventFrames onto one
     ordered queue.
 
-    **Session-switch follow (#3310 N3).** This source is bound to ONE session
-    object at construction, but a remote client can switch which of the
-    agent's sessions it is viewing (``/session switch <sid>``, the same
-    ``__session_switch_request__`` sentinel ``registry._forwarder`` consumes
-    for the local REPL — see ``interfaces/slash/session.py``). This source
-    ALSO sees that sentinel (it fans out off ``session.outbox_hub``, the same
-    hub the registry forwarder subscribes to) and, when ``registry`` +
-    ``agent_name`` are supplied, reacts to it independently: it re-points
-    itself at the target session (:meth:`_peek_session`'s public counterpart,
-    ``registry.get_session``) and synthesizes the SAME ``session_attached``
-    audit-event #3310 N1 emits on ``repl_outbox`` — the barrier the emitter
-    (``AgUiEmitter``) uses to re-fire the reconnect protocol for the new
-    session (its ``backlog_provider``). This is a PARALLEL, independent
-    reaction to a message the registry's own forwarder already handles for
-    the local REPL — it never calls ``registry.attach_session`` itself, so it
-    cannot race or double-apply that side effect; it only re-points THIS
-    connection's own view. A registry-less / agent_name-less construction (as
-    every existing unit test builds this class) degrades to the pre-N3
-    behavior byte-identically: the sentinel falls through to the generic
-    ``DisplayFrame`` path, where the emitter's ``CONTROL_FILTER_KINDS``
-    already silently drops it (a fail-safe, per ``protocol.py``).
+    **Session-switch follow (#3310 N3, ported #4534 PR-2b).** This source is
+    bound to ONE session object at construction, but a remote client can
+    switch which of the agent's sessions it is viewing (``/session switch
+    <sid>``, now ``ClientTransport.request_session_switch`` →
+    ``registry.attach_session`` — see ``interfaces/slash/session.py``).
+    ``attach_session`` calls ``registry`` directly, out-of-band from this
+    source's own ``session.outbox_hub`` subscription (unlike the retired
+    ``__session_switch_request__`` sentinel, which arrived IN-BAND on that
+    same hub). So this source instead SUBSCRIBES to the switch — when
+    ``registry`` + ``agent_name`` are supplied, :meth:`_bind`'s caller
+    registers :meth:`_on_attach_announced` via
+    ``registry.add_attach_listener`` — and reacts by re-pointing itself at
+    the target session (``registry.get_session``) and synthesizing the SAME
+    ``session_attached`` audit-event #3310 N1 emits on ``repl_outbox`` — the
+    barrier the emitter (``AgUiEmitter``) uses to re-fire the reconnect
+    protocol for the new session (its ``backlog_provider``). This is a
+    PARALLEL, independent reaction to the switch the registry's own
+    ``attach_session`` already performed — it never calls
+    ``registry.attach_session`` itself, so it cannot race or double-apply
+    that side effect; it only re-points THIS connection's own view. A
+    registry-less / agent_name-less construction (as most existing unit
+    tests build this class) degrades to no switch-follow at all — no
+    listener is registered, so nothing but the ordinary ``DisplayFrame`` /
+    ``EventFrame`` stream ever reaches :attr:`_q`.
+
+    **The listener fires synchronously** (``registry``'s own no-await
+    critical section — see ``add_attach_listener``'s docstring), so it
+    cannot itself do the re-point (that needs ``await sub.close()``-adjacent
+    bookkeeping and races the in-flight ``await sub.get()`` this source's
+    drain loop is blocked in). It only hands the sid to
+    :attr:`_switch_signal`, an ``asyncio.Queue`` :meth:`_drain_one_session`
+    dual-waits alongside ``sub.get()`` (``asyncio.wait(...,
+    return_when=FIRST_COMPLETED)``) — the second wait source a blocked
+    in-flight await needs to be interrupted by an out-of-band signal.
 
     ★No per-client "which frames has this connection already seen"
     bookkeeping (design constraint, #3310 issue thread — rejected as state
@@ -260,7 +273,15 @@ class _SessionFrameSource:
         self._sub = None
         self._session = None
         self._events = None
+        # #4534 PR-2b: the switch-follow signal — registry.add_attach_listener
+        # feeds this from its own synchronous critical section;
+        # _drain_one_session dual-waits it alongside sub.get().
+        self._switch_signal: "asyncio.Queue[str]" = asyncio.Queue()
+        self._listening_for = ""
         self._bind(session)
+        if self._registry is not None and self._agent_name:
+            self._registry.add_attach_listener(self._agent_name, self._on_attach_announced)
+            self._listening_for = self._agent_name
 
     def _bind(self, session) -> None:
         """Point this source at ``session``'s own audit-event stream (the
@@ -284,21 +305,29 @@ class _SessionFrameSource:
         if getattr(event, "type", None) in self._forward:
             self._q.put_nowait(EventFrame(event))
 
+    def _on_attach_announced(self, sid: str) -> None:
+        """Registry callback (#4534 PR-2b) — synchronous, no ``await``: hand
+        the sid to :attr:`_switch_signal` and return, mirroring
+        :meth:`_on_audit_event`'s own idiom."""
+        self._switch_signal.put_nowait(sid)
+
     def start(self) -> None:
         self._drain_task = asyncio.create_task(self._drain_outbox())
 
     def close(self) -> None:
         self._unbind(self._session)
+        if self._registry is not None and self._listening_for:
+            self._registry.remove_attach_listener(self._listening_for, self._on_attach_announced)
         if self._sub is not None:
             self._sub.close()
         if self._drain_task is not None:
             self._drain_task.cancel()
 
     def _resolve_switch_target(self, sid: str):
-        """The target session for a ``__session_switch_request__`` sentinel,
-        or ``None`` when this source is registry-less (pre-N3 degrade), the
-        sid names no loaded session, or the sid is already the current one
-        (a no-op switch)."""
+        """The target session for a switch-follow signal, or ``None`` when
+        this source is registry-less (no switch-follow), the sid names no
+        loaded session, or the sid is already the current one (a no-op
+        switch)."""
         if self._registry is None or not sid:
             return None
         target = self._registry.get_session(self._agent_name, sid)
@@ -325,50 +354,94 @@ class _SessionFrameSource:
                 return
 
     async def _drain_one_session(self) -> bool:
+        """Drain ``self._sub`` (the current session's outbox_hub
+        subscription) until it ends or a switch-follow signal re-points this
+        source at a different session.
+
+        #4534 PR-2b: dual-waits ``sub.get()`` alongside
+        ``self._switch_signal.get()`` (``asyncio.wait(...,
+        return_when=FIRST_COMPLETED)``) — the switch signal now arrives
+        OUT-OF-BAND (a registry callback, not a message on this same
+        subscription), so the task genuinely blocked in ``await sub.get()``
+        needs a second wait source to be interrupted by it. ``asyncio.wait``
+        does not cancel the loser; a signal that arrives after ``sub.get()``
+        already won stays queued for the next iteration (no message loss on
+        that side). The narrow remaining race is the reverse: if BOTH
+        complete in the same tick, the switch is processed first and the
+        already-fetched outbox message is dropped rather than requeued —
+        accepted (documented, not silently absorbed): the two are produced
+        by independent event-loop callbacks (the hub's fan-out vs. the
+        registry's synchronous notify), so simultaneous readiness needs both
+        callbacks to run in the same iteration, which a real switch (an
+        operator-paced action) essentially never coincides with a message
+        arriving in the exact same tick.
+        """
         sub = self._sub
-        while True:
-            msg = await sub.get()
-            if msg is None:
-                self._q.put_nowait(DisplayFrame(OutboxMessage(kind="__end__", text="")))
-                return False
-            if msg.kind == "__session_switch_request__":
-                target = self._resolve_switch_target(msg.text)
-                if target is not None:
-                    old_session = self._session
-                    self._unbind(old_session)
-                    sub.close()
-                    # ★Barrier ordering (co-vet #3310 N3 (a)): the announce
-                    # is enqueued BEFORE ``_bind(target)`` makes the new
-                    # session's audit-event subscriber live. ``_bind`` calls
-                    # ``add_subscriber`` synchronously, and ``_on_audit_event``
-                    # is itself synchronous (``_q.put_nowait`` — no await),
-                    # so an audit-event the new session emits CANNOT reach
-                    # ``_q`` before its subscriber exists. Emitting the
-                    # announce first, THEN subscribing, therefore makes
-                    # "barrier before any of the new session's own frames"
-                    # hold BY CONSTRUCTION regardless of whether an ``await``
-                    # is ever later introduced between the two steps — not
-                    # merely true today because there happens to be none
-                    # (the SAME barrier property N1 built for
-                    # ``AgentRegistry.attach``/``attach_session``, applied
-                    # here to the ORDER of two synchronous calls rather than
-                    # a flip + a queue put). The announce payload depends
-                    # only on ``self._agent_name``/``msg.text``, never on
-                    # ``_bind``'s result, so reordering is free.
-                    self._q.put_nowait(
-                        EventFrame(
-                            Event(
-                                type="session_attached",
-                                data={"agent": self._agent_name, "session_id": msg.text},
+        get_task: "asyncio.Task | None" = None
+        switch_task: "asyncio.Task | None" = None
+        try:
+            while True:
+                if get_task is None:
+                    get_task = asyncio.create_task(sub.get())
+                if switch_task is None:
+                    switch_task = asyncio.create_task(self._switch_signal.get())
+                done, _ = await asyncio.wait(
+                    {get_task, switch_task}, return_when=asyncio.FIRST_COMPLETED,
+                )
+                if switch_task in done:
+                    sid = switch_task.result()
+                    switch_task = None
+                    target = self._resolve_switch_target(sid)
+                    if target is not None:
+                        if get_task is not None and not get_task.done():
+                            get_task.cancel()
+                        get_task = None
+                        old_session = self._session
+                        self._unbind(old_session)
+                        sub.close()
+                        # ★Barrier ordering (co-vet #3310 N3 (a)): the announce
+                        # is enqueued BEFORE ``_bind(target)`` makes the new
+                        # session's audit-event subscriber live. ``_bind`` calls
+                        # ``add_subscriber`` synchronously, and ``_on_audit_event``
+                        # is itself synchronous (``_q.put_nowait`` — no await),
+                        # so an audit-event the new session emits CANNOT reach
+                        # ``_q`` before its subscriber exists. Emitting the
+                        # announce first, THEN subscribing, therefore makes
+                        # "barrier before any of the new session's own frames"
+                        # hold BY CONSTRUCTION regardless of whether an ``await``
+                        # is ever later introduced between the two steps — not
+                        # merely true today because there happens to be none
+                        # (the SAME barrier property N1 built for
+                        # ``AgentRegistry.attach``/``attach_session``, applied
+                        # here to the ORDER of two synchronous calls rather than
+                        # a flip + a queue put). The announce payload depends
+                        # only on ``self._agent_name``/``sid``, never on
+                        # ``_bind``'s result, so reordering is free.
+                        self._q.put_nowait(
+                            EventFrame(
+                                Event(
+                                    type="session_attached",
+                                    data={"agent": self._agent_name, "session_id": sid},
+                                )
                             )
                         )
-                    )
-                    self._bind(target)
-                    return True
-                continue  # registry-less / unknown / no-op sid: drop silently
-            self._q.put_nowait(DisplayFrame(msg))
-            if msg.kind == "__end__":
-                return False
+                        self._bind(target)
+                        return True
+                    continue  # unresolved / no-op sid: drop silently, keep draining
+                if get_task in done:
+                    msg = get_task.result()
+                    get_task = None
+                    if msg is None:
+                        self._q.put_nowait(DisplayFrame(OutboxMessage(kind="__end__", text="")))
+                        return False
+                    self._q.put_nowait(DisplayFrame(msg))
+                    if msg.kind == "__end__":
+                        return False
+        finally:
+            if get_task is not None and not get_task.done():
+                get_task.cancel()
+            if switch_task is not None and not switch_task.done():
+                switch_task.cancel()
 
     async def frames(self):
         while True:
@@ -674,9 +747,9 @@ async def agui_submit(request: Request, agent_name: str):
     elif ptype == "attach_request":
         # #4534 PR-1: the remote execution side, mirroring slash_command
         # above — a typed payload naming the target agent, re-resolved
-        # against THIS process's registry (never the raw
-        # __attach_request__ sentinel string). ADD-ONLY: the sentinel
-        # path is unchanged and still live.
+        # against THIS process's registry (never a raw sentinel string).
+        # The __attach_request__ display-channel sentinel this replaces is
+        # retired (#4534 PR-2) — this is the only path now.
         target = str(payload.get("agent_name", "")).strip()
         attached = False
         if target and registry.exists(target):
@@ -684,8 +757,11 @@ async def agui_submit(request: Request, agent_name: str):
             attached = True
         return JSONResponse({"status": "ok", "attached": attached})
     elif ptype == "session_switch_request":
-        # #4534 PR-1: mirrors attach_request above, retiring
-        # __session_switch_request__.
+        # #4534 PR-1: mirrors attach_request above. The
+        # __session_switch_request__ sentinel this replaces is retired
+        # (#4534 PR-2b) — _SessionFrameSource's switch-follow now subscribes
+        # to registry.add_attach_listener directly instead of consuming a
+        # sentinel off the outbox (see that class's own docstring).
         target_sid = str(payload.get("session_id", "")).strip()
         switched = False
         if target_sid:

--- a/src/reyn/interfaces/transport/agui/protocol.py
+++ b/src/reyn/interfaces/transport/agui/protocol.py
@@ -129,39 +129,17 @@ _REYN = "_reyn"
 # renderable display kinds like ``presentation`` / ``reasoning`` / ``system`` /
 # ``user`` that happen to be absent from it). Each entry is a standalone decision:
 #
-# - ``__end__``                    — the stream terminator; the emitter returns on
-#                                    it (the client's loop also ends on stream close).
-# - ``__session_switch_request__`` — produces ZERO wire events, but NOT because of
-#                                    this set: the AG-UI tap itself consumes the
-#                                    sentinel first (``_SessionFrameSource._
-#                                    drain_one_session`` — switch-follow for a
-#                                    resolvable sid, ``continue`` for an
-#                                    unresolvable one, #3310 N3), so it never
-#                                    becomes a DisplayFrame from that source. This
-#                                    entry is a genuine FAIL-SAFE, covering a frame
-#                                    source that does NOT consume it (the pre-N3
-#                                    degrade path, and any future tap).
+# - ``__end__`` — the stream terminator; the emitter returns on it (the
+#   client's loop also ends on stream close).
 #
-# ★What the registry forwarder's ``continue`` does NOT do (corrected #3362 — this
-# comment previously gave the wrong REASON in three places, and a first attempt at
-# the correction got the ``__session_switch_request__`` leg wrong in the other
-# direction before a strip caught it): it does not keep anything off this wire.
-# ``registry._forwarder`` and ``endpoint._SessionFrameSource`` are two INDEPENDENT
-# subscribers of the same ``session.outbox_hub``, and the hub "fans every message
-# out to every subscription, so each surface receives the FULL stream in order"
-# (``runtime/outbox_hub.py``). A ``continue`` in the forwarder is SUBSCRIBER-LOCAL:
-# it means "not re-posted to ``repl_outbox``" (the LOCAL REPL sink) and nothing
-# more. BOTH sentinels therefore reach the AG-UI tap; what happens next is decided
-# per-kind by the tap and by this set, never by the forwarder.
-#
-# Measured with the real registry forwarder + real tap, not reasoned
-# (``tests/interfaces/test_agui_control_filter.py``'s reachability gate):
-#   - ``__attach_request__``          → lands on the wire.
-#   - ``__session_switch_request__``  → does not. Removing it from this set alone
-#     changes nothing (the tap already consumed it); removing it from this set AND
-#     removing the tap's consumption puts it on the wire — which is what makes
-#     "tap = the active mechanism, this set = the backstop" a measurement rather
-#     than a reading of the code.
+# #4534 retired both of this set's former sentinel entries — PR-2's
+# ``__attach_request__`` and PR-2b's ``__session_switch_request__``. Neither
+# ``/attach`` nor ``/session switch`` posts an ``OutboxMessage`` anymore;
+# both go through ``ClientTransport.request_attach`` /
+# ``request_session_switch`` (typed operations), and
+# ``endpoint._SessionFrameSource``'s switch-follow now subscribes to
+# ``registry.add_attach_listener`` directly rather than consuming a sentinel
+# off this wire's source stream — see that class's own docstring.
 #
 # NOT here (deliberately forwarded — profiled CUSTOM display names):
 # - ``__copy_last_reply__`` / ``__rewind_list__`` are consumed by the CLIENT over
@@ -170,16 +148,8 @@ _REYN = "_reyn"
 #   picker. In the thin-client model transport IS the AG-UI wire, so filtering them
 #   would make remote ``/copy`` / ``/rewind`` silent no-ops. They MUST reach the
 #   wire (``_reyn``-lossless; generic clients ignore-unknown safely).
-# - ``__attach_request__`` is a LIVE WIRE KIND: it is not in this set, so it is
-#   emitted as a profiled CUSTOM display event on every remote connection. Its
-#   profile entry is what that emission uses — not a dormant fail-safe. A remote
-#   client must tolerate it; the reyn client skips it for display
-#   (``textual_chat/app.py``'s ``_SKIP_KINDS``) so a bare sentinel never lands in
-#   the conversation pane. (Remote attach-label SYNC is still designed in P6b —
-#   that is a separate mechanism from this sentinel merely being on the wire.)
 CONTROL_FILTER_KINDS: "frozenset[str]" = frozenset({
     "__end__",
-    "__session_switch_request__",
     # #4482 PR-3: /open <ref> — local-only by construction (launching an OS
     # app on the machine the client is running on); mirrors outbox.py's
     # CONTROL_KINDS entry, kept in sync with it deliberately (see that

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -210,17 +210,15 @@ class ClientTransport(ABC):
         """Attach to a different agent (the ``/attach`` seam); ``True`` iff it
         happened (#4534 PR-1).
 
-        The ADD-ONLY half of retiring the ``__attach_request__`` display-
-        channel sentinel (#3595 S5's own principle — "client interprets,
-        server executes a named operation" — applied here the same way
-        :meth:`run_slash_command` already applies it for slash commands):
-        a typed request naming the target directly, not a magic string
-        smuggled through the outbox/display stream that ``registry.
-        _forwarder``/the AG-UI transport have to specially detect. The
-        sentinel path is UNCHANGED and still live in this PR — this method
-        is a second, parallel way to reach the SAME ``registry.attach``
-        operation, not a replacement yet (existing call sites migrate in a
-        later PR once this path has its own coverage).
+        Retires the ``__attach_request__`` display-channel sentinel (#4534
+        PR-2 — #3595 S5's own principle, "client interprets, server executes
+        a named operation", applied here the same way :meth:`run_slash_command`
+        already applies it for slash commands): a typed request naming the
+        target directly, not a magic string smuggled through the
+        outbox/display stream that ``registry._forwarder``/the AG-UI
+        transport had to specially detect. This is now the only way
+        ``/attach`` and ``/agent new`` reach ``registry.attach`` — nothing
+        constructs the sentinel anymore.
 
         ``False`` means "did not happen here" (no attached session / no
         execution side / unknown agent on the far end) — mirrors
@@ -237,10 +235,10 @@ class ClientTransport(ABC):
         """Switch the focused conversation session (the ``/session switch``
         seam); ``True`` iff it happened (#4534 PR-1).
 
-        Same shape and same ADD-ONLY status as :meth:`request_attach` —
-        see that method's docstring for the shared rationale. This one
-        retires ``__session_switch_request__`` (in a later PR), reaching
-        ``registry.attach_session`` directly instead.
+        Same shape as :meth:`request_attach` — see that method's docstring
+        for the shared rationale. Retires the ``__session_switch_request__``
+        sentinel (#4534 PR-2b), reaching ``registry.attach_session``
+        directly instead.
 
         NOT abstract, same reasoning as :meth:`request_attach`.
         """

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -203,21 +203,18 @@ class InProcessTransport(ClientTransport):
         )
 
     async def request_attach(self, agent_name: str) -> bool:
-        # #4534 PR-1: the local execution side, calling the SAME
-        # registry.attach() operation registry._forwarder's
-        # __attach_request__ branch calls today (that sentinel path is
-        # unchanged, still live) — this is a second, direct way to reach
-        # it, not a replacement of it yet.
+        # #4534 PR-1/PR-2: the local execution side — calls registry.attach()
+        # directly. Retires the __attach_request__ sentinel (PR-2); this is
+        # now the only path /attach and /agent new use.
         if not agent_name or not self._registry.exists(agent_name):
             return False
         await self._registry.attach(agent_name)
         return True
 
     async def request_session_switch(self, session_id: str) -> bool:
-        # #4534 PR-1: mirrors request_attach above; calls registry.
-        # attach_session directly, the same operation the
-        # __session_switch_request__ sentinel branch calls. Graceful on a
-        # bad/vanished sid, matching the sentinel path's own tolerance.
+        # #4534 PR-1/PR-2b: mirrors request_attach above; calls registry.
+        # attach_session directly. Retires the __session_switch_request__
+        # sentinel (PR-2b); graceful on a bad/vanished sid.
         s = self._attached()
         if s is None or not session_id:
             return False

--- a/src/reyn/runtime/outbox.py
+++ b/src/reyn/runtime/outbox.py
@@ -76,7 +76,7 @@ _PROFILED_DISPLAY_KINDS: "frozenset[str]" = frozenset({
 # Every kind FORWARDED to the AG-UI wire as a display frame (standard or CUSTOM).
 DISPLAY_KINDS: "frozenset[str]" = _STANDARD_DISPLAY_KINDS | _PROFILED_DISPLAY_KINDS
 
-# control-filtered (2): emitter-FILTERED control sentinels
+# control-filtered (1): emitter-FILTERED control sentinels
 # (== protocol.CONTROL_FILTER_KINDS) — consumed as signals, NEVER forwarded on
 # the wire. Each documented with its consumption locus:
 CONTROL_KINDS: "frozenset[str]" = frozenset({
@@ -84,9 +84,6 @@ CONTROL_KINDS: "frozenset[str]" = frozenset({
     # _SessionFrameSource loops all return on it; the AG-UI emitter returns
     # (ends the SSE stream). Never rendered.
     "__end__",
-    # `/session switch <sid>`: consumed at registry._forwarder (swallowed with
-    # `continue` → attach_session); the AG-UI emitter also fail-safe-filters it.
-    "__session_switch_request__",
     # #4482 PR-3: `/open <ref>` sentinel — client-side ref-resolve + OS-launch
     # (interfaces.inline.textual_chat.app._handle_open_artifact_request).
     # Control-filtered (unlike /copy · /rewind's PROFILED forwarding) because

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -360,6 +360,14 @@ class AgentRegistry:
         # Single queue the REPL drains; registry routes each attached agent's
         # outbox into here.
         self.repl_outbox: asyncio.Queue = asyncio.Queue()
+        # #4534 PR-2b: per-agent-name switch-follow subscribers — the registry
+        # analogue of OutboxHub.subscribe for a REMOTE connection watching one
+        # agent (repl_outbox is a single process-wide queue a remote surface
+        # cannot also drain without stealing frames from the local REPL, #3825's
+        # own wall). ``_announce_session_attached`` fires every listener
+        # registered for the switched agent, synchronously, from the SAME
+        # no-await critical section as the ``repl_outbox`` barrier put.
+        self._attach_listeners: "dict[str, list[Callable[[str], None]]]" = {}
         # #3671 P3 (now #3793 stage 1: moved onto self._connection): the ONE
         # place a caller doing a BACKGROUND attach (P2's
         # `chat.py._background_attach`, running off the render path) can
@@ -3284,6 +3292,33 @@ class AgentRegistry:
             except AttributeError:
                 pass
 
+    def add_attach_listener(self, agent_name: str, callback: "Callable[[str], None]") -> None:
+        """#4534 PR-2b: register a per-agent-name switch-follow subscriber.
+
+        ``callback`` is invoked with the target ``sid`` whenever
+        ``attach``/``attach_session`` switches focus for ``agent_name`` —
+        the AG-UI remote tap's per-connection replacement for consuming the
+        retired ``__session_switch_request__`` sentinel off the outbox
+        (:class:`~reyn.interfaces.transport.agui.endpoint._SessionFrameSource`).
+        Fired synchronously, with no ``await`` between the connection flip
+        and the call (:meth:`_announce_session_attached`'s own barrier
+        property, extended to every listener, not only ``repl_outbox``) —
+        ``callback`` must not block or await; its job is to hand the sid to
+        a side-channel (e.g. an ``asyncio.Queue.put_nowait``) a consumer
+        task picks up, mirroring ``_on_audit_event``'s own idiom."""
+        self._attach_listeners.setdefault(agent_name, []).append(callback)
+
+    def remove_attach_listener(self, agent_name: str, callback: "Callable[[str], None]") -> None:
+        """Undo :meth:`add_attach_listener`. A no-op if already removed
+        (connection teardown racing a registry-side cleanup is tolerated,
+        not an error)."""
+        listeners = self._attach_listeners.get(agent_name)
+        if not listeners or callback not in listeners:
+            return
+        listeners.remove(callback)
+        if not listeners:
+            del self._attach_listeners[agent_name]
+
     def _announce_session_attached(self, name: str, sid: str) -> None:
         """#3310 N1: notify the client a switch just happened, as a stream
         BARRIER on ``repl_outbox`` — the one queue every local client drains.
@@ -3319,6 +3354,13 @@ class AgentRegistry:
         self.repl_outbox.put_nowait(
             EventFrame(Event(type="session_attached", data={"agent": name, "session_id": sid}))
         )
+        # #4534 PR-2b: same no-await critical section, extended to every
+        # per-agent-name switch-follow subscriber (see add_attach_listener).
+        # Iterates a snapshot (list(...)) so a listener that unsubscribes
+        # itself mid-callback (unlikely — callbacks must not block or await
+        # — but not disallowed) never mutates the list being walked.
+        for callback in list(self._attach_listeners.get(name, ())):
+            callback(sid)
 
     async def attach(self, name: str, *, start_runner: bool = True) -> "object":
         """Switch the attached agent to `name`. Loads + starts session.run()
@@ -3428,11 +3470,6 @@ class AgentRegistry:
         Runs continuously per (name, sid) session. Only forwards when that
         session is the attached one; otherwise drops the message (transient
         kinds were already dropped at source, durable narration is in history).
-        Special kind `__session_switch_request__` is consumed here as a
-        control signal (#4534 PR-2: `__attach_request__`'s sibling branch is
-        retired — /attach now goes through `ClientTransport.request_attach`,
-        which calls `registry.attach()` directly; this branch stays until
-        PR-2b ports the AG-UI remote switch-follow it also feeds).
 
         ADR-0039 P6b: subscribes to the session's outbox *hub* (unbounded local
         sink) instead of draining ``session.outbox`` directly — so this local
@@ -3458,20 +3495,6 @@ class AgentRegistry:
                     if self._connection.is_attached(key):
                         await self.repl_outbox.put(msg)
                     return
-                if msg.kind == "__session_switch_request__":
-                    # FP-0043 Stage 4a: `/session switch <sid>` — focus another
-                    # session of the CURRENT agent (msg.text = target sid). Routed
-                    # through the forwarder so the focus flip + display re-wire
-                    # are sequenced on the registry side, not raced by a direct
-                    # call from the slash handler. Graceful on a bad sid: drop
-                    # (the slash handler validated existence + replied before
-                    # posting).
-                    if msg.text:
-                        try:
-                            await self.attach_session(name, msg.text)
-                        except KeyError:
-                            pass  # session vanished between validate + switch — no-op
-                    continue
                 if self._connection.is_attached(key):
                     await self.repl_outbox.put(msg)
                 # else: drop — session is detached, transient kinds were already

--- a/tests/interfaces/test_3310_n3_remote_switch_parity.py
+++ b/tests/interfaces/test_3310_n3_remote_switch_parity.py
@@ -11,17 +11,34 @@ era design). Two premises, both re-verified here structurally by construction
 (not merely asserted): a remote client that switches sessions had NO way to
 obtain the new session's scrollback at all.
 
-The fix (this PR): ``_SessionFrameSource`` independently detects the SAME
-``__session_switch_request__`` sentinel the registry forwarder consumes
-(fan-out off ``session.outbox_hub`` — both are subscribers), re-points itself
-at the target session, and synthesizes a ``session_attached`` EventFrame onto
-its OWN per-connection queue. ``AgUiEmitter``, on observing that EventFrame,
-treats the switch as a *logical reconnect*: it re-fires the SAME
-``MESSAGES_SNAPSHOT``/``STATE_SNAPSHOT`` protocol it uses at connect
+The fix (N3, ported off the sentinel #4534 PR-2b): ``_SessionFrameSource``
+subscribes to ``registry.add_attach_listener`` — the registry fires it,
+synchronously, from the SAME no-await critical section
+``_announce_session_attached`` uses, whenever ``attach``/``attach_session``
+switches focus for the watched agent name. The listener hands the target sid
+to a per-connection ``asyncio.Queue`` (``_switch_signal``) that
+``_drain_one_session``'s drain loop dual-waits alongside its outbox
+subscription (``asyncio.wait(..., return_when=FIRST_COMPLETED)``) — the
+second wait source an in-flight blocked ``await sub.get()`` needs to be
+interrupted by an out-of-band signal (the switch no longer arrives in-band on
+that same subscription, unlike the retired sentinel). On seeing it, the
+source re-points itself at the target session and synthesizes a
+``session_attached`` EventFrame onto its OWN per-connection queue.
+``AgUiEmitter``, on observing that EventFrame, treats the switch as a
+*logical reconnect*: it re-fires the SAME ``MESSAGES_SNAPSHOT``/
+``STATE_SNAPSHOT`` protocol it uses at connect
 (:meth:`AgUiEmitter._reconnect_snapshot_chunks`), sourcing the new backlog from
 a caller-supplied ``backlog_provider`` — here, ``session_backlog_frames``,
 which projects a session's in-memory ``ChatMessage`` history through the SAME
 ``project_restored_frames`` SSoT local restore-on-restart uses (#3273 P5).
+
+These tests drive the switch via ``registry.attach_session`` directly — the
+real op both the retired local-REPL sentinel path and the current
+``ClientTransport.request_session_switch`` seam call into; they exercise
+``_SessionFrameSource``'s own reconnect/backlog/ordering mechanics, not the
+transport-to-registry wiring. The full stack, through a real ASGI POST on an
+ALREADY-OPEN SSE stream, is
+``tests/interfaces/test_4534_pr2b_switch_follow_e2e.py``'s own claim.
 
 Gates:
 
@@ -203,9 +220,7 @@ async def test_remote_switch_has_no_scrollback_without_the_refire(tmp_path) -> N
 
         async def _switch() -> None:
             await _pump(2)
-            await session_a._put_outbox(
-                OutboxMessage(kind="__session_switch_request__", text=sid_b)
-            )
+            await reg.attach_session("alpha", sid_b)
             await _pump(5)
             await session_b._put_outbox(OutboxMessage(kind="__end__", text=""))
 
@@ -272,16 +287,12 @@ async def test_remote_switch_parity_a_b_a_with_staleness(tmp_path) -> None:
 
         async def _drive() -> None:
             await _pump(2)
-            await session_a._put_outbox(
-                OutboxMessage(kind="__session_switch_request__", text=sid_b)
-            )
+            await reg.attach_session("alpha", sid_b)
             await _pump(5)
             # A's history grows a SECOND turn while the connection is on B —
             # switching back to A must show it (fresh read, not stale cache).
             session_a.history.append(ChatMessage(role="user", content="are you there A"))
-            await session_b._put_outbox(
-                OutboxMessage(kind="__session_switch_request__", text=_DEFAULT_SID)
-            )
+            await reg.attach_session("alpha", _DEFAULT_SID)
             await _pump(5)
             await session_a._put_outbox(OutboxMessage(kind="__end__", text=""))
 
@@ -358,9 +369,7 @@ async def test_switch_announce_precedes_any_new_session_audit_event(tmp_path) ->
                 await asyncio.sleep(0)
 
         adversary_task = asyncio.create_task(_adversary())
-        await session_a._put_outbox(
-            OutboxMessage(kind="__session_switch_request__", text=sid_b)
-        )
+        await reg.attach_session("alpha", sid_b)
         await adversary_task
 
         try:
@@ -418,9 +427,7 @@ async def test_barrier_precedes_refire_on_the_wire(tmp_path) -> None:
 
         async def _switch() -> None:
             await _pump(2)
-            await session_a._put_outbox(
-                OutboxMessage(kind="__session_switch_request__", text=sid_b)
-            )
+            await reg.attach_session("alpha", sid_b)
             await _pump(5)
             await session_b._put_outbox(OutboxMessage(kind="__end__", text=""))
 

--- a/tests/interfaces/test_4534_pr2b_switch_follow_e2e.py
+++ b/tests/interfaces/test_4534_pr2b_switch_follow_e2e.py
@@ -1,0 +1,225 @@
+"""Tier 2: #4534 PR-2b — an ALREADY-OPEN remote SSE stream follows a
+``session_switch_request`` POST (the real wire entry point, not a directly
+called registry method).
+
+This is the witness lead-coder's review named explicitly: no existing test
+before this PR drove switch-follow through ``ClientTransport.
+request_session_switch``'s own wire ptype while a connection was already
+streaming — every switch-follow test in ``test_3310_n3_remote_switch_
+parity.py`` (real, still valid, but a level below the transport) calls
+``registry.attach_session`` directly, and every ``session_switch_request``
+ptype test in ``test_4534_pr1_agui_attach_switch_endpoint.py`` only asserts
+the POST's own JSON response and ``registry.attached_sid`` — neither opens a
+concurrent SSE stream to observe. Without this witness, PR-2's own call-site
+migration silently orphaned the switch-follow mechanism (nothing observed
+that the already-open stream side kept working) — this is the gate that
+would have caught it.
+
+Chains the REAL pieces: a POST to the router's own ``/agui/chat/{agent}``
+``session_switch_request`` arm (``endpoint.py``'s ``agui_submit``) ->
+``registry.attach_session`` -> ``_announce_session_attached``'s synchronous
+``add_attach_listener`` notify -> a REAL, already-``start()``ed
+``_SessionFrameSource``'s dual-wait (``_drain_one_session``) -> a REAL
+``AgUiEmitter`` mid-``stream()`` re-firing the reconnect protocol. No mocks;
+the httpx ASGI POST and the emitter's SSE generator run over the SAME
+in-memory ``AgentRegistry``.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.agui.endpoint import (
+    _SessionFrameSource,
+    session_backlog_frames,
+)
+from reyn.interfaces.transport.agui.protocol import parse_sse_blocks
+from reyn.interfaces.transport.frames import EventFrame
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.registry import AgentRegistry
+from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
+
+def _two_agent_registry(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
+    holder: dict = {}
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None):
+        return make_session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            snapshot_path=tmp_path / f"{profile.name}_snapshot.json",
+        )
+
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=state_log,
+    )
+    holder["reg"] = reg
+    reg.create("alpha")
+    return reg
+
+
+def _build_app(reg, monkeypatch):
+    from fastapi import FastAPI
+
+    from reyn.interfaces.transport.agui import endpoint as endpoint_mod
+    from reyn.interfaces.transport.agui.endpoint import router
+    from reyn.interfaces.web.auth import AuthContext
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.auth = AuthContext(token="s3cret", require_token=True)
+    monkeypatch.setattr(endpoint_mod, "get_registry", lambda: reg)
+    return app
+
+
+async def _post(app, path: str, payload: dict):
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        return await client.post(path, json=payload)
+
+
+async def _collect_until_barrier(agen) -> "list":
+    """Same shape as test_3310_n3's own helper — collect off an async
+    generator until the ``session_attached`` barrier frame is dequeued, the
+    one deterministic termination condition available (the source has no
+    natural EOF outside a real ``__end__``)."""
+    out: list = []
+    it = agen.__aiter__()
+    while True:
+        item = await it.__anext__()
+        out.append(item)
+        if isinstance(item, EventFrame) and getattr(item.event, "type", "") == "session_attached":
+            return out
+
+
+@pytest.mark.asyncio
+async def test_open_sse_stream_follows_a_session_switch_request_post(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: an already-running ``_SessionFrameSource`` re-points to
+    session B and re-fires B's backlog after a REAL ``session_switch_
+    request`` POST — driven through the wire ptype, not
+    ``registry.attach_session`` called directly by the test.
+
+    Reads ``source.frames()`` (the Frame-level stream the real
+    ``AgUiEmitter`` itself consumes) rather than ``emitter.stream()``'s
+    encoded SSE text — the wire-text-level claim (that the SAME switch
+    reaches the ENCODED output) is the companion test below."""
+    reg = _two_agent_registry(tmp_path, monkeypatch)
+    session_a = await reg.attach("alpha")
+    sid_b = reg.spawn_session("alpha", presentation_consumer=None, intervention_bridge=None)
+    session_b = reg.get_session("alpha", sid_b)
+    session_b.history.append(ChatMessage(role="assistant", content="b's reply, pre-switch"))
+
+    app = _build_app(reg, monkeypatch)
+
+    # The "already-open stream": a real source bound to session_a, started
+    # (subscribed to session_a's outbox_hub, listening on registry.
+    # add_attach_listener) BEFORE the switch POST — exactly what a connected
+    # remote client's server-side state looks like mid-stream.
+    source = _SessionFrameSource(session_a, registry=reg, agent_name="alpha")
+    source.start()
+    frames_iter = source.frames()
+
+    try:
+        # The real wire entry point — POSTs "session_switch_request", the
+        # SAME ptype ClientTransport.request_session_switch sends.
+        resp = await _post(
+            app, "/agui/chat/alpha?token=s3cret",
+            {"type": "session_switch_request", "session_id": sid_b},
+        )
+        assert resp.status_code == 200
+        assert resp.json().get("switched") is True
+        assert reg.attached_sid == sid_b
+
+        # The already-open stream (constructed BEFORE the POST) must
+        # independently observe the switch — bounded on the barrier frame's
+        # arrival (#4280 ②'s justification: a real termination condition
+        # beats an arbitrary wall-clock window).
+        collected = await _collect_until_barrier(frames_iter)
+    finally:
+        source.close()
+
+    barrier_positions = [
+        i for i, f in enumerate(collected)
+        if isinstance(f, EventFrame) and getattr(f.event, "type", "") == "session_attached"
+    ]
+    assert barrier_positions, (
+        f"the already-open stream never observed the switch — no "
+        f"session_attached EventFrame arrived within the collection window; "
+        f"collected {len(collected)} item(s): {collected!r}"
+    )
+    assert collected[barrier_positions[0]].event.data == {
+        "agent": "alpha", "session_id": sid_b,
+    }
+
+
+@pytest.mark.asyncio
+async def test_open_sse_stream_follows_a_switch_request_over_the_real_wire_text(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: same claim as above, verified on the ENCODED SSE text (not
+    just the internal Frame objects) — an already-open connection's raw
+    ``AgUiEmitter.stream()`` output carries the CUSTOM
+    ``reyn.event.session_attached`` block after a real
+    ``session_switch_request`` POST lands mid-stream."""
+    reg = _two_agent_registry(tmp_path, monkeypatch)
+    session_a = await reg.attach("alpha")
+    sid_b = reg.spawn_session("alpha", presentation_consumer=None, intervention_bridge=None)
+
+    app = _build_app(reg, monkeypatch)
+
+    def _backlog_provider(name: str, sid: str):
+        return session_backlog_frames(reg, name, sid)
+
+    source = _SessionFrameSource(session_a, registry=reg, agent_name="alpha")
+    source.start()
+    emitter = AgUiEmitter(source.frames(), lambda: None, backlog_provider=_backlog_provider)
+
+    chunks: "list[str]" = []
+    stream_iter = emitter.stream()
+    chunks.append(await stream_iter.__anext__())  # prime past the initial connect snapshot
+
+    try:
+        resp = await _post(
+            app, "/agui/chat/alpha?token=s3cret",
+            {"type": "session_switch_request", "session_id": sid_b},
+        )
+        assert resp.json().get("switched") is True
+
+        # Bounded collection: read chunks until the barrier CUSTOM event's
+        # name shows up in the accumulated text, or give up after a few
+        # scheduling turns — the barrier is guaranteed to arrive exactly
+        # once by production behaviour (asserted below), so this is a
+        # termination condition, not an arbitrary window silently truncating.
+        for _ in range(50):
+            chunk = await stream_iter.__anext__()
+            chunks.append(chunk)
+            if "reyn.event.session_attached" in "".join(chunks):
+                break
+    finally:
+        source.close()
+
+    sse_text = "".join(chunks)
+    assert "reyn.event.session_attached" in sse_text, (
+        f"the already-open stream's raw SSE text never carried the switch "
+        f"barrier event: {sse_text!r}"
+    )
+    events = parse_sse_blocks(sse_text.split("\n"))
+    barrier = [
+        ev for ev in events
+        if ev.type == "CUSTOM" and ev.data.get("name") == "reyn.event.session_attached"
+    ]
+    (barrier_event,) = barrier
+    assert barrier_event.data.get("value", {}).get("session_id") == sid_b
+    await asyncio.sleep(0)  # let source's own tasks settle before teardown

--- a/tests/interfaces/test_agui_control_filter.py
+++ b/tests/interfaces/test_agui_control_filter.py
@@ -8,84 +8,37 @@ A few ``__…__`` display sentinels get per-entry dispositions on the AG-UI wire
   IS the AG-UI wire, so they MUST reach it — filtering them would make remote
   ``/copy`` / ``/rewind`` silent no-ops.
 - **Filtered** (``CONTROL_FILTER_KINDS``, an explicit per-entry allowlist — never
-  the negation of a forward-set): ``__end__`` (the stream terminator) and
-  ``__session_switch_request__`` produce ZERO wire events. For the switch sentinel
-  the filter is a genuine FAIL-SAFE rather than the active mechanism — the AG-UI
-  tap consumes that sentinel itself (#3310 N3 switch-follow, or a silent drop for
-  an unresolvable sid), so it never reaches the emitter from that source.
-``__attach_request__`` retired (#4534 PR-2): ``/attach`` now goes through
-``ClientTransport.request_attach``, a typed operation with no display-channel
-sentinel — the forwarder's own ``__attach_request__`` branch is gone too, so
-there is no longer a live example of "forwarder swallows it for
-``repl_outbox`` yet it still reaches the wire" (that was the reachability
-point #3362 measured). The still-live mechanism that survives is
-``__session_switch_request__``'s absence from the wire: it is the TAP
-(``_SessionFrameSource._drain_one_session``) consuming it, not merely
-``CONTROL_FILTER_KINDS`` filtering it — the forwarder's ``continue`` is
-SUBSCRIBER-LOCAL (it and the AG-UI tap are independent ``outbox_hub``
-subscribers, and the hub fans every message out to every subscription), so it
-only means "not re-posted to ``repl_outbox``" and says nothing about the wire
-on its own.
+  the negation of a forward-set): ``__end__`` (the stream terminator).
+
+``__attach_request__`` / ``__session_switch_request__`` both retired (#4534
+PR-2 / PR-2b): ``/attach`` and ``/session switch`` now go through
+``ClientTransport.request_attach`` / ``request_session_switch``, typed
+operations with no display-channel sentinel — neither kind is constructed
+anywhere anymore, so this file's former reachability tests for them
+(measuring "forwarder swallows it for ``repl_outbox`` yet it still reaches
+the wire" and "the tap, not the filter, keeps the switch sentinel off the
+wire") no longer have a subject and are deleted. Session-switch follow's own
+mechanism (``registry.add_attach_listener`` → ``_SessionFrameSource``'s
+dual-wait) has its own coverage in ``test_3310_n3_remote_switch_parity.py``.
 
 Real instances only — a real ``AgUiEmitter`` over real SSE text; no mocks.
 """
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 
 from reyn.interfaces.transport.agui.emitter import AgUiEmitter
-from reyn.interfaces.transport.agui.endpoint import _SessionFrameSource
 from reyn.interfaces.transport.agui.protocol import (
     CONTROL_FILTER_KINDS,
     parse_sse_blocks,
 )
 from reyn.interfaces.transport.frames import DisplayFrame
-from reyn.runtime.budget.budget import BudgetTracker, CostConfig
 from reyn.runtime.outbox import OutboxMessage
-from reyn.runtime.profile import AgentProfile
-from reyn.runtime.registry import AgentRegistry
-from tests._support.agent_session import make_session
 
 
 async def _frame_source(frames):
     for f in frames:
         yield f
-
-
-def _registry(tmp_path):
-    """A real :class:`AgentRegistry` whose forwarder actually runs."""
-    shared = BudgetTracker(CostConfig())
-
-    def factory(profile: AgentProfile):
-        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
-        agent_dir.mkdir(parents=True, exist_ok=True)
-        return make_session(
-            agent_name=profile.name,
-            agent_role=profile.role,
-            output_language="en",
-            budget_tracker=shared,
-            snapshot_path=agent_dir / "state" / "snapshot.json",
-        )
-
-    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
-    reg.create("alpha")
-    reg.create("beta")
-    return reg
-
-
-async def _collect_all(agen) -> "list":
-    """Collect every item from an async generator until it terminates.
-
-    #4275: the caller always pushes an ``__end__`` sentinel, which
-    ``AgUiEmitter.stream()`` returns on — the stream is naturally finite, so
-    no wall-clock window is needed. If a caller regresses and never sends
-    ``__end__``, this hangs, surfaced by CI's kill switch rather than a
-    bounded window that would silently truncate the collected list instead
-    of failing.
-    """
-    return [item async for item in agen]
 
 
 async def _wire_events(frames):
@@ -122,89 +75,6 @@ async def test_client_consumed_sentinels_are_forwarded_on_the_wire() -> None:
     # Neither is in the filter set (the disposition backing the forward).
     assert "__copy_last_reply__" not in CONTROL_FILTER_KINDS
     assert "__rewind_list__" not in CONTROL_FILTER_KINDS
-
-
-@pytest.mark.asyncio
-async def test_filtered_control_sentinels_are_not_on_the_wire() -> None:
-    """Tier 2: the filtered sentinels (``__session_switch_request__`` / ``__end__``)
-    produce ZERO wire events; a surrounding ``agent`` frame is forwarded normally
-    (the filter is per-kind, not a stream-wide drop)."""
-    frames = [
-        DisplayFrame(OutboxMessage(kind="__session_switch_request__", text="s")),
-        DisplayFrame(OutboxMessage(kind="agent", text="hello")),
-        DisplayFrame(OutboxMessage(kind="__end__", text="")),
-    ]
-    events = await _wire_events(frames)
-    names = _reyn_display_names(events)
-
-    assert "reyn.display.__session_switch_request__" not in names
-    assert "reyn.display.__end__" not in names
-    assert "reyn.display.agent" in names
-
-
-@pytest.mark.asyncio
-async def test_tap_not_filter_keeps_switch_request_off_the_wire(
-    tmp_path,
-) -> None:
-    """Tier 2: REACHABILITY, through the real tap — ``__session_switch_request__``
-    is kept off the AG-UI wire by the TAP consuming it
-    (``_SessionFrameSource._drain_one_session``), not merely by
-    ``CONTROL_FILTER_KINDS`` filtering it (#3362's distinction; #4534 PR-2
-    dropped this file's former ``__attach_request__`` arm — that sentinel's
-    forwarder branch is retired, so there is no live case left of "forwarder
-    swallows it for ``repl_outbox`` yet it still reaches the wire").
-
-    Every other test in this file feeds a synthetic frame list straight to the
-    emitter, which can only ever show what the emitter does with a frame it is
-    HANDED — it cannot show whether a frame arrives at all. This test closes
-    that gap by running the REAL ``AgentRegistry`` forwarder concurrently with
-    the REAL ``_SessionFrameSource`` + emitter, and reading the wire.
-
-    Two arms:
-
-    - ``__session_switch_request__`` — **not on the wire**. Measured by strip:
-      removing the filter entry alone leaves this arm green, and only removing
-      the filter entry AND the tap's consumption turns it red — the filter is
-      a backstop for a source that does not consume it. This arm deliberately
-      does not attribute itself to the filter; the synthetic
-      ``test_filtered_control_sentinels_are_not_on_the_wire`` above is the
-      filter's own gate (and does go red when the entry is removed).
-    - an ordinary ``agent`` frame — on the wire, so a silent tap cannot make the
-      negative arm pass for the wrong reason.
-    """
-    reg = _registry(tmp_path)
-    session = await reg.attach("alpha")
-    assert reg.attached_name == "alpha"
-
-    source = _SessionFrameSource(session, registry=reg, agent_name="alpha")
-    source.start()
-    emitter = AgUiEmitter(source.frames(), lambda: None)
-
-    async def _drive() -> None:
-        await asyncio.sleep(0.2)
-        await session._put_outbox(
-            OutboxMessage(kind="__session_switch_request__", text="no-such-sid")
-        )
-        await asyncio.sleep(0.2)
-        await session._put_outbox(OutboxMessage(kind="agent", text="hello"))
-        await asyncio.sleep(0.2)
-        await session._put_outbox(OutboxMessage(kind="__end__", text=""))
-
-    task = asyncio.create_task(_drive())
-    try:
-        sse = "".join(await _collect_all(emitter.stream()))
-    finally:
-        await task
-        source.close()
-    names = _reyn_display_names(parse_sse_blocks(sse.split("\n")))
-
-    assert "reyn.display.agent" in names, (
-        f"the tap produced nothing — the arm below would be vacuous: {names}"
-    )
-    assert "reyn.display.__session_switch_request__" not in names, (
-        f"the switch sentinel leaked onto the wire (tap consumption + the "
-        f"CONTROL_FILTER_KINDS backstop both bypassed): {names}"
-    )
 
 
 @pytest.mark.asyncio

--- a/tests/interfaces/test_agui_profile_completeness.py
+++ b/tests/interfaces/test_agui_profile_completeness.py
@@ -88,7 +88,7 @@ def test_every_vocabulary_kind_is_dispositioned() -> None:
     assert {"agent", "status", "reasoning", "error"} <= VOCABULARY   # standard
     assert {"system", "user", "trace",
             "tool_call_started"} <= VOCABULARY                       # profiled CUSTOM
-    assert {"__end__", "__session_switch_request__"} <= VOCABULARY   # control-filtered
+    assert {"__end__"} <= VOCABULARY   # control-filtered
 
     leaks = {k for k in VOCABULARY if _disposition(k) == "LEAK"}
     assert not leaks, (
@@ -110,11 +110,12 @@ def test_control_sentinel_dispositions_client_consumed_forward_upstream_consumed
     - ``__copy_last_reply__`` / ``__rewind_list__`` are **client-consumed** over the
       transport stream (real client-side clipboard copy / rewind picker), so they
       are FORWARDED (profiled CUSTOM display kinds) and round-trip losslessly.
-    - ``__end__`` (terminal) and ``__session_switch_request__`` (upstream-consumed)
-      are control-filtered. ``__attach_request__`` retired (#4534 PR-2): /attach
-      now goes through ``ClientTransport.request_attach``, a typed operation with
-      no display-channel sentinel — nothing constructs that kind anymore, so it
-      carries no disposition at all."""
+    - ``__end__`` (terminal) is control-filtered. ``__attach_request__`` /
+      ``__session_switch_request__`` both retired (#4534 PR-2 / PR-2b):
+      ``/attach`` and ``/session switch`` now go through
+      ``ClientTransport.request_attach`` / ``request_session_switch``, typed
+      operations with no display-channel sentinel — neither kind is
+      constructed anywhere anymore, so neither carries a disposition at all."""
     # Client-consumed → forwarded + profiled + lossless round-trip.
     for client_kind in ("__copy_last_reply__", "__rewind_list__"):
         assert client_kind in DISPLAY_KINDS, client_kind
@@ -126,9 +127,8 @@ def test_control_sentinel_dispositions_client_consumed_forward_upstream_consumed
         assert isinstance(decoded, DisplayFrame)
         assert decoded.message.kind == client_kind
 
-    # Terminal + upstream-consumed → control-filtered.
+    # Terminal → control-filtered.
     assert _disposition("__end__") == "control"
-    assert _disposition("__session_switch_request__") == "control"
 
 
 def test_every_custom_mapped_frame_is_profiled() -> None:

--- a/tests/interfaces/test_slash_budget_session_reload_cmds.py
+++ b/tests/interfaces/test_slash_budget_session_reload_cmds.py
@@ -1,8 +1,9 @@
 """Tier 2: /cost, /budget, /session, /reload slash — handler behavioural paths.
 
 These handlers have no pure helper functions — the testable surface is the
-dispatch logic: which reply surfaces when the budget tracker is disabled, which
-sentinel is emitted on /session switch, etc.
+dispatch logic: which reply surfaces when the budget tracker is disabled, what
+the transport is asked to do on /session switch (#4534 PR-2b —
+request_session_switch, not a sentinel), etc.
 """
 from __future__ import annotations
 
@@ -255,15 +256,15 @@ async def test_session_switch_unknown_sid_replies_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_session_switch_known_sid_emits_sentinel() -> None:
-    """Tier 2: /session switch to a known sid emits the __session_switch_request__ sentinel."""
+async def test_session_switch_known_sid_requests_switch() -> None:
+    """Tier 2: /session switch to a known sid asks the transport to
+    request_session_switch with the target sid (#4534 PR-2b — the retired
+    __session_switch_request__ sentinel's named-operation replacement)."""
     reg = _FakeRegistry(get_session_result=object())
     session = _FakeSession(registry=reg)
-    await session_cmd(_ctx(session), "switch s2")  # type: ignore[arg-type]
-    assert "__session_switch_request__" in session.outbox_kinds()
-    # The sentinel text is the target sid
-    sentinel = next(m for m in session._outbox if m.kind == "__session_switch_request__")
-    assert sentinel.text == "s2"
+    ctx = _ctx(session)
+    await session_cmd(ctx, "switch s2")  # type: ignore[arg-type]
+    assert ctx.transport.session_switch_requests == ["s2"]
 
 
 @pytest.mark.asyncio

--- a/tests/interfaces/test_slash_session_1726.py
+++ b/tests/interfaces/test_slash_session_1726.py
@@ -2,12 +2,13 @@
 
 `/session new|switch <sid>|list` drives per-agent multi-session in the REPL. The
 handler reads the public registry surface (attached_name / spawn_session /
-get_session / session_ids / attached_sid) and posts a `__session_switch_request__`
-sentinel for switch (mirroring `/attach`, so the focus flip is sequenced by the
-registry forwarder). These tests exercise the command flow + the graceful-error
-paths via a stub registry + an outbox-capturing fake session — the same pattern as
-test_slash_agent. Byte-identical when unused (a session that never runs `/session`
-stays single-"main").
+get_session / session_ids / attached_sid) and asks the transport to
+`request_session_switch` for `switch` (#4534 PR-2b — a typed request, not the
+retired `__session_switch_request__` display-channel sentinel). These tests
+exercise the command flow + the graceful-error paths via a stub registry + an
+outbox-capturing fake session — the same pattern as test_slash_agent.
+Byte-identical when unused (a session that never runs `/session` stays
+single-"main").
 """
 from __future__ import annotations
 
@@ -108,14 +109,15 @@ async def test_session_new_spawns_and_reports_sid():
 
 
 @pytest.mark.asyncio
-async def test_session_switch_known_posts_sentinel():
-    """Tier 2: #1726 — `/session switch <known>` posts __session_switch_request__
-    (the focus flip is driven by the registry forwarder, mirroring /attach)."""
+async def test_session_switch_known_requests_switch():
+    """Tier 2: #1726/#4534 — `/session switch <known>` asks the transport
+    to request_session_switch with the target sid (the retired
+    __session_switch_request__ sentinel's named-operation replacement)."""
     reg = _StubRegistry(sids=("main", "s1"))
     s = _FakeSession(reg)
-    await session_cmd(_ctx(s), "switch s1")
-    switch_sids = [m.text for m in s.outbox_calls if m.kind == "__session_switch_request__"]
-    assert switch_sids == ["s1"], "exactly the one switch sentinel, carrying the target sid"
+    ctx = _ctx(s)
+    await session_cmd(ctx, "switch s1")
+    assert ctx.transport.session_switch_requests == ["s1"]
 
 
 @pytest.mark.asyncio

--- a/tests/interfaces/test_textual_chat_copy_rewind_3362.py
+++ b/tests/interfaces/test_textual_chat_copy_rewind_3362.py
@@ -27,13 +27,12 @@ Graded invariants:
    The action gate additionally pins that the picker's submission is IDENTICAL
    to a typed one, so the picker cannot grow a private action path beside the
    real one.
-4. **The remaining sentinel is still skipped** — ``__session_switch_request__``
-   is consumed UPSTREAM by ``AgentRegistry._forwarder`` (pinned by
-   ``test_3310_n3_remote_switch_parity.py``; its sibling
-   ``__attach_request__`` retired #4534 PR-2 — ``/attach`` now goes through
-   ``ClientTransport.request_attach``, a typed operation, no sentinel left to
-   skip); the TUI must keep skipping it rather than leaking a bare sentinel
-   into the conversation.
+4. **Both former sentinels retired** (#4534 PR-2 / PR-2b) — ``/attach`` and
+   ``/session switch`` now go through ``ClientTransport.request_attach`` /
+   ``request_session_switch``, typed operations; ``app._SKIP_KINDS`` no
+   longer has a sentinel entry, and neither kind is even constructible
+   (removed from the closed vocabulary). See section 4's own comment below
+   for the deleted test this leaves behind.
 
 **No real state is ever rewound here.** The app's rewind action ends at the
 ``ClientTransport.run_slash_command`` seam (#3595 S5 — a slash the app routes is
@@ -58,7 +57,6 @@ import pytest
 from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
-from reyn.interfaces.inline.textual_chat.app import _SKIP_KINDS
 from reyn.interfaces.inline.textual_chat.rewind_picker import RewindPicker
 from reyn.interfaces.repl.read_model import ChatReadModel
 from reyn.interfaces.transport.client_transport import ClientTransport
@@ -500,39 +498,17 @@ async def test_escape_dismisses_the_picker_without_rewinding() -> None:
         )
 
 
-# ── 4. the two sentinels that REMAIN skipped ──────────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_upstream_consumed_sentinel_stays_out_of_the_conversation() -> None:
-    """Tier 2: ``__session_switch_request__`` is still skipped — it never
-    leaks a bare sentinel row into the pane.
-
-    ``__attach_request__`` retired (#4534 PR-2): ``/attach`` now goes through
-    ``ClientTransport.request_attach``, a typed operation with no
-    display-channel sentinel, so it is no longer in ``_SKIP_KINDS`` and no
-    longer a constructible ``OutboxMessage`` kind at all.
-
-    ``__session_switch_request__`` is consumed by ``AgentRegistry._forwarder``
-    before it can reach a LOCAL client's frame stream (its effect arrives
-    instead as the ``session_attached`` ``EventFrame``), and — on the REMOTE
-    path — by the AG-UI tap and ``CONTROL_FILTER_KINDS`` besides, so its
-    entry here is a true fail-safe (pending #4534 PR-2b's switch-follow
-    port). A neighbouring ordinary frame must still render (so the assertion
-    cannot pass by the pump being dead)."""
-    assert _SKIP_KINDS == {"__session_switch_request__"}
-    transport = ScriptedTransport([
-        OutboxMessage(kind="__session_switch_request__", text="sid-b"),
-        OutboxMessage(kind="agent", text="a real reply"),
-    ])
-    app = TextualChatApp(transport=transport, read_model=_PickerReadModel())
-    async with app.run_test() as pilot:
-        await _settle(pilot)
-        texts = _texts(app)
-        assert "a real reply" in texts, f"the pump never ran: {texts}"
-        assert "sid-b" not in texts, (
-            f"the control sentinel leaked into the conversation: {texts}"
-        )
+# #4534 PR-2b retired the last of `_SKIP_KINDS`'s two former sentinel entries
+# (`__attach_request__` in PR-2, `__session_switch_request__` here) — neither
+# `/attach` nor `/session switch` posts an `OutboxMessage` sentinel anymore
+# (both go through `ClientTransport.request_attach`/`request_session_switch`,
+# typed operations), and neither kind is constructible at all (removed from
+# the closed vocabulary). `_SKIP_KINDS` is now empty; the falsify-verify this
+# section's test used to pin (a `__session_switch_request__` frame skipped,
+# alongside an ordinary `agent` frame confirmed to still render) confirmed RED
+# at construction time — `OutboxMessage(kind="__session_switch_request__", ...)`
+# raises `ValueError` (kind not in `VOCABULARY`) — so the test is deleted
+# rather than rewritten: there is no longer a sentinel kind left to skip.
 
 
 # ── environment sanity ────────────────────────────────────────────────────────


### PR DESCRIPTION
**[e2e-coder]**

Completes #4534's sentinel retirement (final piece after #4537 PR-1, #4541 PR-2, #4543 docs — all merged, verified via `gh pr list --search "4534 in:body"` + the #4534 issue body before writing `Closes` below).

## What
- Migrates `/session switch` from the `__session_switch_request__` display-channel sentinel to `ClientTransport.request_session_switch`.
- Ports the AG-UI remote tap's mid-stream switch-follow (`_SessionFrameSource`, #3310 N3) off that same sentinel onto a new registry-level per-agent-name subscriber (`AgentRegistry.add_attach_listener`/`remove_attach_listener`), fired synchronously from `_announce_session_attached`'s own no-await critical section.
- Retires both `__attach_request__` and `__session_switch_request__` fully — neither is a constructible `OutboxMessage` kind anymore (confirmed: `OutboxMessage(kind=...)` raises `ValueError` for both).

## Why split from PR-2, and why this shape
`__session_switch_request__` was dual-purpose — an operation request (retired in PR-1) **and** an in-band signal `_SessionFrameSource`'s switch-follow consumed off the outbox. Migrating the call site without porting switch-follow in the same PR would have silently regressed remote session-switch with **zero test coverage catching it** — no prior test drove an already-open SSE stream through the wire ptype. I found this mid-PR-2, escalated to lead-coder, who looped in architect. Ruling: port switch-follow to the new path (not drop it); split into PR-2 (landed, #4541) + this PR-2b, so main never has a broken window between removing the old mechanism and having its replacement live.

## The mechanism
The switch signal now arrives **out-of-band** (`attach_session` calls the registry directly, not via the outbox), so `_SessionFrameSource`'s drain loop dual-waits its outbox subscription alongside a new per-connection switch-signal queue (`asyncio.wait(..., return_when=FIRST_COMPLETED)`) — the second wait source an in-flight blocked `await sub.get()` needs, since closing a `HubSubscription` doesn't wake a pending `get()`. A narrow simultaneous-readiness race (documented in the code) is accepted rather than engineered around, given the window essentially never coincides with a real, operator-paced switch.

## New witness test
`tests/interfaces/test_4534_pr2b_switch_follow_e2e.py` — the test lead-coder's review named explicitly. Chains the real pieces: a POST to the router's `session_switch_request` ptype arm → `registry.attach_session` → the new listener notify → a REAL, already-running `_SessionFrameSource`'s dual-wait → a REAL `AgUiEmitter` re-firing the reconnect protocol mid-stream. Falsify-verified (stripped the listener notify, confirmed this file **and** `test_3310_n3_remote_switch_parity.py` hang/RED under CI's kill switch; restored, confirmed green).

## Also
`agent.py`/`agents.py`/`session.py`'s `request_attach`/`request_session_switch` call sites now order their reply after the call and read its return — a `False` on the AG-UI transport is "could not confirm" (ambiguous remote ack), never "failed" (lead-coder review, non-blocking on #4541, addressed here).

## Test plan
- [x] `tests/runtime/` + `tests/interfaces/` full sweep green on latest `main` (exit 0, one pre-existing PIL-optional-dependency skip elsewhere, unrelated)
- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` on changed test files — 50/50 OK
- [x] `verify_module_docstrings.py` — OK
- [x] `mypy_ratchet.py` — OK (fixed one new `var-annotated` finding from an emptied `frozenset`, no baseline changes needed)
- [x] `check_tests_path_literal_reference.py` — OK
- [x] Falsify-verify: stripped `registry`'s new listener notify, confirmed `test_3310_n3_remote_switch_parity.py` (5 tests) **and** the new e2e file (2 tests) hang under CI's timeout kill switch; restored, confirmed both green
- [x] Full-text search for both retired identifiers across `src`/`docs`/`tests` — every remaining hit is a historical/retirement comment or a deliberately-scoped test-docstring mirror, no live construction site
- [x] Closing-keyword enumeration done before writing `Closes #4534` below: `gh pr list --search "4534 in:body"` shows #4537/#4541/#4543 all MERGED, no other open PR references #4534

Closes #4534

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**[lead-coder]** — ✅ **TESTS-READ 済。★通します（★武装します）。★arc の 締め方が 正しい。**

## ✅ ★私と architect が 出した 条件、★全部 満ちています

```
✅ ★e2e が ★新経路（ptype POST）から 入る ── ★sentinel を 流す 形なら
   ★旧経路を 証明して 新経路を 未証明の まま 通します（architect の 条件）
✅ ★新しい 通知を 作らず ★到達範囲だけ 足した
   ── `_announce_session_attached` の ★同じ no-await 区間から 発火
   ── ★どちらの session から 出すかは ★既存 docstring が 既に 決めていた
✅ ★dual-wait（`asyncio.wait(FIRST_COMPLETED)` ＋ switch-signal queue）
   ── ★ロックでは なく ★待ち口を 増やす 形（owner 恒久指示に 反しない）
✅ ★私が 渡した src 3 箇所（protocol.py:159/:173、endpoint.py:678）── ★全部 消えています
✅ ★両 sentinel が ★OutboxMessage の kind として ★構築不能に なった ことまで 確認
```

## ✅ 六問

```
① Tier ── ★2（★remote が switch に 追従する、という OS 側の 約束）── ★妥当
② 転記 ── ★無し
③ 誰が困る ── ★開いた SSE で session を 切り替える 利用者。★この PR まで ★誰も 見ていなかった
④ 走らず緑 ── ★該当なし
⑤ 累積 ── ⚪ `_collect_until_barrier` は ★バリアまで 溜めます が、
          ★止まる 条件は ★機構の 側（★失敗時は ★ブロックして CI の 120s で 落ちる）
          ── ★testing.md が 明示的に 許す 形（★時間予算を テストに 持たせない）
⑥ 宣言＝実体 ── ★一致
```

## ⚪ ★非ブロックの 記録 2 点

```
⚪ ① `for callback in list(...): callback(sid)` ── ★例外を 包んでいません
   ── ★今 在る callback は `put_nowait`（★上限なし Queue）∴ ★実際には 上がらない
   🔴 ★ただし ★将来 raise する listener が 1 つ 入ると
      ★以降の listener が 飛び、★attach 自体が 壊れます（★critical path）
   ⚪ ★今 直す 必要は ありません。★2 つ目の listener が 増える 時に 思い出して ください
⚪ ② ★listener の 解除は ★SSE generator の `finally` の `source.close()` 経由
   ── ★私が endpoint.py:456-461 で 確認しました ∴ ★接続が 落ちても 漏れません
```
