### PR TITLE
fix(#3896): model router_tools's §J strip step in a mode-scoped reachability gate

### DIFF
--- a/src/reyn/tools/llm_reachability.py
+++ b/src/reyn/tools/llm_reachability.py
@@ -85,6 +85,37 @@ and a ``"hooks"`` entry to ``_CATEGORY_ACTIONS`` (route (b)) + a matching
 (so they are enumerable, not just dispatchable) + ``router_dispatched=True``
 on the two tools that did not already have it. Only cron's fate remains an
 open (A)/(B)/(C) product decision (#3464).
+
+## Exclusive-wrapper mode (#3896) — a SECOND, mode-scoped reachability set
+
+Route (a)'s AST census above answers "reachable under SOME valid parameter
+combination" — deliberately existential, per the module docstring above. It
+does NOT model ``router_tools.build_tools``'s own §J strip step
+(``_wrapper_superseded_tool_names()``, run only when
+``universal_wrappers_enabled=True``), so it cannot answer a DIFFERENT, also
+real question: "reachable when an operator actually selects exclusive-wrapper
+mode" (a category-based exposure scheme with ``universal_wrappers_enabled:
+true`` — landed, selectable today, #3429). #3896 found this gap: under that
+mode, ``spawn_session`` is stripped from direct advertisement (§J) and has NO
+catalog route (never added to ``universal_dispatch._CATEGORY_ACTIONS``) — a
+genuine capability loss the plain existential census cannot see, because
+existentially ``spawn_session`` IS reachable (under the *other* valid combo,
+wrappers off).
+
+:func:`compute_reachable_tool_names_under_exclusive_wrapper_mode` and
+:func:`compute_unreachable_router_allow_tool_names_under_exclusive_wrapper_mode`
+answer the mode-scoped question directly, by subtracting the REAL strip set
+(imported from ``router_tools``, never re-derived) from route (a) before
+union-ing with route (b). Their own closed registry,
+``UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS``, is SEPARATE from
+``UNREACHABLE_TOOL_REASONS`` above — a tool can be declared in one, the
+other, both, or neither; they answer different questions and neither
+subsumes the other. Measured result under this mode: the 5 cron tools (still
+unreachable regardless of mode) plus ``call_mcp_tool`` / ``describe_mcp_tool``
+(their own §J entries' reasons already name their replacement — this is the
+INTENDED end state, not a gap) plus ``spawn_session`` (#3896's actual finding
+— no replacement exists, an open (A)/(B)/(C) product decision, same shape as
+cron's own entry above).
 """
 from __future__ import annotations
 
@@ -125,6 +156,13 @@ UNREACHABLE_CLASSIFICATIONS: Final[frozenset[str]] = frozenset({
     # Must carry a tracking issue link; this classification is a queue
     # entry, not a resting state.
     "DEFERRED_WIRING_BUG",
+    # Unreachable under its OWN name, but by DESIGN, not by gap: a
+    # differently-named tool already covers the identical capability (named
+    # in the reason). This is the intended permanent end state, not a queue
+    # entry — nothing is pending. Distinguishes "renamed/consolidated on
+    # purpose" from PENDING_CAPABILITY_DECISION's "capability itself is
+    # withheld."
+    "SUPERSEDED_BY_CATALOG_REPLACEMENT",
 })
 
 
@@ -147,6 +185,67 @@ UNREACHABLE_TOOL_REASONS: Final[Mapping[str, UnreachableToolReason]] = {
     "cron_list": UnreachableToolReason("PENDING_CAPABILITY_DECISION", _CRON_REASON),
     "cron_enable": UnreachableToolReason("PENDING_CAPABILITY_DECISION", _CRON_REASON),
     "cron_disable": UnreachableToolReason("PENDING_CAPABILITY_DECISION", _CRON_REASON),
+}
+
+
+_SPAWN_SESSION_EXCLUSIVE_WRAPPER_REASON = (
+    "#3896: `spawn_session` is registered router=allow and IS direct-advertisable "
+    "in the default configuration (universal_wrappers_enabled=False under the "
+    "shipped default 'enumerate-all' exposure scheme), so it is correctly absent "
+    "from UNREACHABLE_TOOL_REASONS above. But router_tools.build_tools's own "
+    "section J strips it (_wrapper_superseded_tool_names() includes it as a "
+    "deliberate surface reduction) whenever universal_wrappers_enabled=True -- a "
+    "real, selectable, already-landed configuration (#3429's exclusive-wrapper "
+    "mode) -- and it has no catalog route (never added to "
+    "universal_dispatch._CATEGORY_ACTIONS), unlike delegate_to_agent's symmetric "
+    "multi_agent category route. Under that mode specifically, spawn_session is "
+    "genuinely unreachable -- a real capability loss, not a false positive. "
+    "Whether to (A) give it a catalog route (symmetric with delegate_to_agent), "
+    "(B) stop stripping it in exclusive-wrapper mode, or (C) accept the loss as "
+    "the mode's intended shape is an open product decision tracked on #3896 "
+    "itself. This entry records the interim state -- a known, tracked hole, not "
+    "a silently-passing gate -- pending that decision."
+)
+
+_CALL_MCP_TOOL_EXCLUSIVE_WRAPPER_REASON = (
+    "router_tools.py's own _WRAPPER_SUPERSEDED_BASE_TOOLS entry for "
+    "`call_mcp_tool` names its replacement: `mcp_call_tool` is the catalog's "
+    "own definition of the identical call, reachable via invoke_action "
+    "(a universal_dispatch.KNOWN_ACTION_NAMES member) whenever exclusive-wrapper "
+    "mode is on -- the same mode that strips `call_mcp_tool`'s own direct "
+    "route. Unreachable under its OWN name by design, not by gap: the LLM's "
+    "capability is unchanged, only the tool name it uses to reach it."
+)
+
+_DESCRIBE_MCP_TOOL_EXCLUSIVE_WRAPPER_REASON = (
+    "router_tools.py's own _WRAPPER_SUPERSEDED_BASE_TOOLS entry for "
+    "`describe_mcp_tool` names its replacement: #879 shipped each tool's real "
+    "inputSchema verbatim in `list_mcp_tools`'s own result precisely so no "
+    "separate describe round-trip is needed -- `list_mcp_tools` is itself a "
+    "universal_dispatch.KNOWN_ACTION_NAMES member, reachable via invoke_action "
+    "in exclusive-wrapper mode. Unreachable under its OWN name by design, not "
+    "by gap: the capability (a tool's input schema) is still obtainable, "
+    "folded into a different tool's response shape rather than a dedicated verb."
+)
+
+# #3896: a SECOND, mode-scoped closed registry -- see the module docstring's
+# "Exclusive-wrapper mode" section for why this is separate from
+# UNREACHABLE_TOOL_REASONS above (different question, not a superset/subset).
+UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS: Final[Mapping[str, UnreachableToolReason]] = {
+    "cron_register": UnreachableToolReason("PENDING_CAPABILITY_DECISION", _CRON_REASON),
+    "cron_unregister": UnreachableToolReason("PENDING_CAPABILITY_DECISION", _CRON_REASON),
+    "cron_list": UnreachableToolReason("PENDING_CAPABILITY_DECISION", _CRON_REASON),
+    "cron_enable": UnreachableToolReason("PENDING_CAPABILITY_DECISION", _CRON_REASON),
+    "cron_disable": UnreachableToolReason("PENDING_CAPABILITY_DECISION", _CRON_REASON),
+    "call_mcp_tool": UnreachableToolReason(
+        "SUPERSEDED_BY_CATALOG_REPLACEMENT", _CALL_MCP_TOOL_EXCLUSIVE_WRAPPER_REASON
+    ),
+    "describe_mcp_tool": UnreachableToolReason(
+        "SUPERSEDED_BY_CATALOG_REPLACEMENT", _DESCRIBE_MCP_TOOL_EXCLUSIVE_WRAPPER_REASON
+    ),
+    "spawn_session": UnreachableToolReason(
+        "PENDING_CAPABILITY_DECISION", _SPAWN_SESSION_EXCLUSIVE_WRAPPER_REASON
+    ),
 }
 
 
@@ -282,13 +381,72 @@ def compute_unreachable_router_allow_tool_names(
     return allow_names - reachable
 
 
+def compute_direct_advertisable_tool_names_under_exclusive_wrapper_mode(
+    *,
+    source_text: str | None = None,
+    superseded_names: frozenset[str] | None = None,
+) -> frozenset[str]:
+    """Route (a) as it actually is once ``universal_wrappers_enabled=True``
+    (#3896) — the plain AST census (:func:`compute_direct_advertisable_tool_names`)
+    minus ``router_tools.build_tools``'s own §J strip step
+    (``_wrapper_superseded_tool_names()``), which the plain census never
+    modeled. See the module docstring's "Exclusive-wrapper mode" section.
+
+    ``superseded_names`` defaults to the real strip set (imported from
+    ``router_tools``, never re-derived here); tests pass an override to
+    strip-falsify this independently of the plain census."""
+    if superseded_names is None:
+        from reyn.runtime.router_tools import _wrapper_superseded_tool_names
+
+        superseded_names = _wrapper_superseded_tool_names()
+    return compute_direct_advertisable_tool_names(source_text=source_text) - superseded_names
+
+
+def compute_reachable_tool_names_under_exclusive_wrapper_mode(
+    *,
+    source_text: str | None = None,
+    action_names: frozenset[str] | None = None,
+    superseded_names: frozenset[str] | None = None,
+) -> frozenset[str]:
+    """Union of the stripped route (a) and route (b), under exclusive-wrapper
+    mode specifically — the mode-scoped analogue of
+    :func:`compute_llm_reachable_tool_names`."""
+    return compute_direct_advertisable_tool_names_under_exclusive_wrapper_mode(
+        source_text=source_text, superseded_names=superseded_names,
+    ) | compute_invoke_action_reachable_tool_names(action_names=action_names)
+
+
+def compute_unreachable_router_allow_tool_names_under_exclusive_wrapper_mode(
+    *,
+    source_text: str | None = None,
+    action_names: frozenset[str] | None = None,
+    allow_names: frozenset[str] | None = None,
+    superseded_names: frozenset[str] | None = None,
+) -> frozenset[str]:
+    """``router="allow"`` tool names NOT reachable by either route once
+    exclusive-wrapper mode strips route (a) — the mode-scoped analogue of
+    :func:`compute_unreachable_router_allow_tool_names`. See
+    ``UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS`` for the declared,
+    tracked holes this currently finds."""
+    if allow_names is None:
+        allow_names = compute_router_allow_tool_names()
+    reachable = compute_reachable_tool_names_under_exclusive_wrapper_mode(
+        source_text=source_text, action_names=action_names, superseded_names=superseded_names,
+    )
+    return allow_names - reachable
+
+
 __all__ = [
     "UnreachableToolReason",
     "UNREACHABLE_CLASSIFICATIONS",
     "UNREACHABLE_TOOL_REASONS",
+    "UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS",
     "compute_direct_advertisable_tool_names",
+    "compute_direct_advertisable_tool_names_under_exclusive_wrapper_mode",
     "compute_invoke_action_reachable_tool_names",
     "compute_llm_reachable_tool_names",
+    "compute_reachable_tool_names_under_exclusive_wrapper_mode",
     "compute_router_allow_tool_names",
     "compute_unreachable_router_allow_tool_names",
+    "compute_unreachable_router_allow_tool_names_under_exclusive_wrapper_mode",
 ]

--- a/tests/tools/test_llm_reachability_exclusive_wrapper_mode_3896.py
+++ b/tests/tools/test_llm_reachability_exclusive_wrapper_mode_3896.py
@@ -1,0 +1,263 @@
+"""Tier 2: exclusive-wrapper-mode LLM-reachability gate (#3896).
+
+#3896 found that ``router_tools.build_tools``'s section J strip step
+(``_wrapper_superseded_tool_names()``, run whenever
+``universal_wrappers_enabled=True`` — the exclusive-wrapper mode #3429
+landed) removes ``spawn_session`` from direct advertisement with no
+compensating catalog route — a genuine capability loss under a real,
+selectable, already-landed configuration. The plain #3464 gate
+(``reyn.tools.llm_reachability.compute_unreachable_router_allow_tool_names``)
+cannot see this: its route (a) census answers "reachable under SOME valid
+parameter combination" (deliberately existential — several tools are
+correctly conditional), and ``spawn_session`` IS reachable under the OTHER
+combination (wrappers off), so it never enters that gate's unreachable set
+at all. This suite exercises the SECOND, mode-scoped computation
+(``compute_*_under_exclusive_wrapper_mode``) that models the strip step for
+real (imports ``router_tools._wrapper_superseded_tool_names()``, never
+re-derives it) and answers the mode-scoped question directly.
+
+Per lead-coder's explicit review instruction: the RED this modeling produces
+(``spawn_session`` newly unreachable under this mode) is not suppressed via
+xfail/skip — it is registered in
+``UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS``, a closed, tracked
+registry mirroring #3464's own pattern, so growth of this set is caught the
+same way #3464's own gate catches growth of its set.
+
+No mocks — everything here reads the real default ``ToolRegistry`` /
+``KNOWN_ACTION_NAMES`` / ``build_tools`` source / ``router_tools``'s own
+strip set, or passes a plain string/set override to the module's own
+testability seams.
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from reyn.tools.llm_reachability import (
+    UNREACHABLE_CLASSIFICATIONS,
+    UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS,
+    compute_direct_advertisable_tool_names,
+    compute_direct_advertisable_tool_names_under_exclusive_wrapper_mode,
+    compute_reachable_tool_names_under_exclusive_wrapper_mode,
+    compute_router_allow_tool_names,
+    compute_unreachable_router_allow_tool_names,
+    compute_unreachable_router_allow_tool_names_under_exclusive_wrapper_mode,
+)
+
+
+def _assert_exclusive_wrapper_mode_gate(unreachable: frozenset[str]) -> None:
+    """Same identity-check shape as #3464's own gate, scoped to this mode's
+    registry — factored out so both the real-state test and the
+    strip-falsify tests exercise the identical assertion."""
+    declared = frozenset(UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS)
+    undeclared = unreachable - declared
+    assert not undeclared, (
+        f"router=allow tool(s) {sorted(undeclared)} are not reachable under "
+        f"exclusive-wrapper mode (stripped direct advertisement NOR "
+        f"invoke_action) and are not declared in "
+        f"UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS -- register them "
+        f"with a reason (see src/reyn/tools/llm_reachability.py), or wire "
+        f"them into reachability under this mode if that was an oversight "
+        f"(#3896)."
+    )
+    stale = declared - unreachable
+    assert not stale, (
+        f"UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS entries "
+        f"{sorted(stale)} are declared unreachable under this mode but the "
+        f"census now finds them reachable -- remove the stale entry (its "
+        f"wiring fix should ship WITH the removal so the regression stays "
+        f"covered, not silently)."
+    )
+
+
+def test_current_unreachable_set_under_exclusive_wrapper_mode_matches_the_declared_registry() -> None:
+    """Tier 2: registry allow-set minus (stripped-direct union invoke_action)
+    equals exactly UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS' keys."""
+    unreachable = compute_unreachable_router_allow_tool_names_under_exclusive_wrapper_mode()
+    _assert_exclusive_wrapper_mode_gate(unreachable)
+
+
+def test_declared_reasons_use_the_closed_classification_and_are_nonempty() -> None:
+    """Tier 2: no entry may register a hole without a real classification +
+    a reason with actual content."""
+    assert UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS, (
+        "the registry should not be empty while #3896/#3464 are open"
+    )
+    for name, entry in UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS.items():
+        assert entry.classification in UNREACHABLE_CLASSIFICATIONS, (
+            f"{name!r} has classification {entry.classification!r}, not one "
+            f"of {sorted(UNREACHABLE_CLASSIFICATIONS)}"
+        )
+        assert isinstance(entry.reason, str) and len(entry.reason.strip()) >= 40, (
+            f"{name!r}'s reason is missing or too short to be a real "
+            f"falsifiable explanation: {entry.reason!r}"
+        )
+
+
+def test_spawn_session_is_declared_pending_capability_decision() -> None:
+    """Tier 2: #3896's own finding — spawn_session is stripped under
+    exclusive-wrapper mode with no compensating catalog route. A genuine
+    capability loss awaiting an owner (A)/(B)/(C) decision, same shape as
+    the #3464 cron entries -- not a wiring bug and not an intentional
+    supersession (there is no replacement tool)."""
+    assert "spawn_session" in UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS
+    entry = UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS["spawn_session"]
+    assert entry.classification == "PENDING_CAPABILITY_DECISION"
+    # Sanity: spawn_session IS in the #3464 gate's reachable set (existentially
+    # reachable under wrappers=off) -- confirming this mode-scoped registry is
+    # answering a genuinely different question, not a subset of #3464's own.
+    assert "spawn_session" not in compute_unreachable_router_allow_tool_names()
+
+
+def test_call_mcp_tool_and_describe_mcp_tool_are_declared_superseded_not_pending() -> None:
+    """Tier 2: unlike spawn_session, these two ARE intentionally superseded
+    by a differently-named catalog equivalent (router_tools.py's own
+    _WRAPPER_SUPERSEDED_BASE_TOOLS comments name the replacement for each)
+    -- the LLM's capability is unchanged, so nothing is pending an owner
+    decision. Distinguishing this from PENDING_CAPABILITY_DECISION is the
+    whole point of the SUPERSEDED_BY_CATALOG_REPLACEMENT classification."""
+    for name in ("call_mcp_tool", "describe_mcp_tool"):
+        assert name in UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS
+        entry = UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS[name]
+        assert entry.classification == "SUPERSEDED_BY_CATALOG_REPLACEMENT"
+
+
+def test_cron_tools_are_declared_pending_capability_decision_here_too() -> None:
+    """Tier 2: cron's unreachability is mode-independent (never advertised
+    directly, never a catalog action, regardless of universal_wrappers_enabled)
+    -- it belongs in BOTH registries, not just #3464's."""
+    cron_names = {"cron_register", "cron_unregister", "cron_list", "cron_enable", "cron_disable"}
+    assert cron_names <= set(UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS)
+    for name in cron_names:
+        assert (
+            UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS[name].classification
+            == "PENDING_CAPABILITY_DECISION"
+        )
+
+
+# ── Non-vacuity: strip-falsify each route, AND the strip-modeling itself ──
+
+
+def test_unmodeled_strip_would_hide_spawn_session_the_actual_3896_defect() -> None:
+    """Tier 2: THE regression witness for #3896 itself -- proves the strip
+    modeling is load-bearing, not decorative. Passing ``superseded_names=
+    frozenset()`` (== the OLD gate's behaviour, which never modeled section J
+    at all) makes spawn_session vanish from the mode-scoped unreachable set,
+    reproducing the exact defect #3896 reported. If this ever regressed back
+    to that shape without anyone noticing, THIS assertion is what would still
+    catch it independently of the registry-identity check above."""
+    modeled = compute_unreachable_router_allow_tool_names_under_exclusive_wrapper_mode()
+    assert "spawn_session" in modeled, (
+        "the fix itself must find spawn_session unreachable under this mode"
+    )
+
+    unmodeled = compute_unreachable_router_allow_tool_names_under_exclusive_wrapper_mode(
+        superseded_names=frozenset(),
+    )
+    assert "spawn_session" not in unmodeled, (
+        "sanity: with no strip modeled at all, spawn_session must be "
+        "reachable via the (unstripped) direct-advertisement census -- "
+        "confirming the strip step is what actually removes it, not some "
+        "other factor this test would otherwise misattribute"
+    )
+
+
+def test_strip_direct_advertisement_route_makes_the_gate_fire() -> None:
+    """Tier 2: non-vacuity -- removing a tool ONLY reachable via the
+    stripped route (a) (never routed through invoke_action, and not itself
+    in the strip set) from the AST census must produce an undeclared
+    unreachable tool under this mode too, mirroring #3464's own probe.
+
+    ``create_topology`` is confirmed to not be a catalog action and not in
+    the strip set, so it stays reachable under exclusive-wrapper mode via
+    route (a) alone -- stripping its lookup call site removes it from both
+    routes' union under this mode."""
+    from reyn.runtime.router_tools import _wrapper_superseded_tool_names, build_tools
+
+    superseded = _wrapper_superseded_tool_names()
+    assert "create_topology" not in superseded, (
+        "create_topology must not be in the strip set for this probe to be valid"
+    )
+
+    real_source = inspect.getsource(build_tools)
+    anchor = '_registry.lookup("create_topology")'
+    assert real_source.count(anchor) == 1, (
+        "strip anchor must be unique or this falsifies the wrong call site"
+    )
+    stripped_source = real_source.replace(anchor, '_registry.lookup("__stripped_3896__")')
+
+    baseline_unreachable = compute_unreachable_router_allow_tool_names_under_exclusive_wrapper_mode()
+    assert "create_topology" not in baseline_unreachable
+
+    stripped_unreachable = compute_unreachable_router_allow_tool_names_under_exclusive_wrapper_mode(
+        source_text=stripped_source,
+    )
+    assert "create_topology" in stripped_unreachable
+
+    with pytest.raises(AssertionError):
+        _assert_exclusive_wrapper_mode_gate(stripped_unreachable)
+
+
+def test_strip_invoke_action_route_makes_the_gate_fire() -> None:
+    """Tier 2: non-vacuity -- removing a tool ONLY reachable via route (b)
+    must equally produce an undeclared unreachable tool under this mode,
+    proving route (b) is load-bearing here too, not decorative.
+
+    ``search_knowledge`` is confirmed to have no direct ``lookup`` call
+    site -- invoke-route-only, so stripping it from route (b) removes it
+    from the union entirely regardless of route (a)'s strip modeling."""
+    from reyn.tools.universal_dispatch import KNOWN_ACTION_NAMES
+
+    direct_reachable = compute_direct_advertisable_tool_names()
+    assert "search_knowledge" not in direct_reachable, (
+        "search_knowledge must be invoke-route-only for this strip to be a valid probe"
+    )
+
+    baseline_unreachable = compute_unreachable_router_allow_tool_names_under_exclusive_wrapper_mode()
+    assert "search_knowledge" not in baseline_unreachable
+
+    stripped_action_names = frozenset(KNOWN_ACTION_NAMES - {"search_knowledge"})
+    stripped_unreachable = compute_unreachable_router_allow_tool_names_under_exclusive_wrapper_mode(
+        action_names=stripped_action_names,
+    )
+    assert "search_knowledge" in stripped_unreachable
+
+    with pytest.raises(AssertionError):
+        _assert_exclusive_wrapper_mode_gate(stripped_unreachable)
+
+
+def test_a_hypothetically_newly_registered_tool_with_no_route_fires_the_gate() -> None:
+    """Tier 2: non-vacuity -- a brand new router=allow ToolDefinition name
+    that was never wired anywhere is caught under this mode too."""
+    allow_names = compute_router_allow_tool_names() | {"totally_new_tool_3896"}
+    unreachable = compute_unreachable_router_allow_tool_names_under_exclusive_wrapper_mode(
+        allow_names=allow_names,
+    )
+    assert "totally_new_tool_3896" in unreachable
+    with pytest.raises(AssertionError):
+        _assert_exclusive_wrapper_mode_gate(unreachable)
+
+
+def test_direct_advertisable_under_exclusive_wrapper_mode_is_a_subset_of_the_plain_census() -> None:
+    """Tier 2: the stripped route (a) can only ever be a SUBSET of the plain
+    (existential) census -- stripping removes names, never adds any. A
+    regression that made the mode-scoped set LARGER than the plain one would
+    mean the strip modeling itself is wrong (adding names from nowhere)."""
+    plain = compute_direct_advertisable_tool_names()
+    stripped = compute_direct_advertisable_tool_names_under_exclusive_wrapper_mode()
+    assert stripped <= plain
+    assert stripped != plain, (
+        "sanity: the real strip set is non-empty, so the stripped census "
+        "must differ from the plain one on live main"
+    )
+
+
+def test_reachable_under_exclusive_wrapper_mode_matches_the_union_helper() -> None:
+    """Tier 2: the convenience union function is exactly what the
+    identity-check test manually re-derives via allow - reachable -- keeps
+    the two from silently diverging if one is edited without the other."""
+    reachable = compute_reachable_tool_names_under_exclusive_wrapper_mode()
+    unreachable = compute_unreachable_router_allow_tool_names_under_exclusive_wrapper_mode()
+    allow = compute_router_allow_tool_names()
+    assert unreachable == (allow - reachable)


### PR DESCRIPTION
**[e2e-coder]** — part of #3896

## Summary
Fixes the reachability-gate defect lead-coder identified in #3896's comment: `llm_reachability.py`'s AST census of `build_tools()` never modeled `router_tools.py`'s own §J strip step (`_wrapper_superseded_tool_names()`, run whenever `universal_wrappers_enabled=True` — #3429's landed, selectable exclusive-wrapper mode), so it counted `spawn_session` as reachable overall — true existentially (reachable when wrappers are off), but masking that under the *other* valid, real configuration it is stripped with no compensating catalog route.

This is gate-only, per lead-coder's framing: fixes are needed "regardless of which design option (A/B/C) is chosen" for #3896's actual product question. That question (give `spawn_session` a catalog route / stop stripping it / accept the loss) is untouched here.

## What
- A SECOND, mode-scoped computation (`compute_*_under_exclusive_wrapper_mode`) that imports the REAL strip set from `router_tools` (never re-derives it) and subtracts it from route (a) before unioning with route (b).
- Its own closed registry, `UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS`, mirroring #3464's own declare-with-a-reason pattern — per lead-coder's explicit instruction, the RED this modeling produces is **not suppressed via xfail/skip**; it's registered as a tracked hole.
- A new classification, `SUPERSEDED_BY_CATALOG_REPLACEMENT`, distinct from `PENDING_CAPABILITY_DECISION`: `call_mcp_tool`/`describe_mcp_tool` are *intentionally* superseded by a differently-named catalog equivalent (each entry's own `router_tools.py` comment already names the replacement) — the LLM's capability is unchanged, nothing is pending an owner decision, unlike `spawn_session`.

## Measured result
8 tools unreachable under exclusive-wrapper mode: the 5 cron tools (mode-independent, already in #3464's registry) + `call_mcp_tool` / `describe_mcp_tool` (superseded, not pending) + `spawn_session` (#3896's actual finding).

## Test plan
- [x] `tests/tools/` full sweep — 952 passed (no other consumer of `llm_reachability` exists in the repo — confirmed via grep before scoping the sweep)
- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` on the new test file — 11/11 OK
- [x] `verify_module_docstrings.py` — OK
- [x] `mypy_ratchet.py` — OK, no new findings
- [x] `check_tests_path_literal_reference.py` — OK
- [x] Regression witness: `test_unmodeled_strip_would_hide_spawn_session_the_actual_3896_defect` reproduces the exact pre-fix defect (`superseded_names=frozenset()`) and confirms `spawn_session` vanishes from the unreachable set — proves the strip modeling is load-bearing, not decorative
- [x] Non-vacuity strip-falsify (mirrors #3464's own two probes, adapted to this mode) — both fire the gate correctly
- [x] #3464's own existing gate (`test_llm_reachability_gate_3464.py`) — unchanged, still 7/7 green, confirming this is additive, not a rewrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**[lead-coder]** — ✅ **TESTS-READ 済。★通します（★武装します）。★出所を 1 つに した のが 良い。**

## ✅ ★構造として 正しい 点

```
✅ ★`router_tools._wrapper_superseded_tool_names` を ★import して 使う
   ── ★strip 集合を ★再導出していない ∴ ★向こうが 増えたら ★ここも 動く
   ── ★今夜 私が 何度も 指摘した「★契約の 二重転記」を ★最初から 避けています
✅ ★分類を 2 つに 分けた（SUPERSEDED_BY_CATALOG_REPLACEMENT / PENDING_CAPABILITY_DECISION）
   ── ★call_mcp_tool / describe_mcp_tool は ★代替が 名指しで 在る
   ── ★spawn_session だけが ★本物の 欠落
   🔴 ★3 つを まとめて いたら ★「1 つだけ 偽」が ★また 隠れました
✅ ★xfail / skip で 隠していない ── ★到達不能を ★到達不能と 宣言して 通す 形
```

## ✅ 六問

```
① Tier ── ★2（★到達可能性の 宣言 ↔ 実測 の 一致）── ★妥当
② 転記 ── ⚪ ★宣言 registry ↔ 計算結果 の 比較 ですが、★出所が 別
          （★片方は 手書き、★片方は ★router_tools 由来）∴ ★等価性 assert の 罠に 当たりません
③ 誰が困る ── ★strip 集合に ★次の tool を 足す 人（★今は 見えない ことが 問題の 出発点）
④ 走らず緑 ── ★該当なし
⑤ 累積 ── ★無し
⑥ 宣言＝実体 ── ★一致
```

## ⚪ ★非ブロックの 記録 1 点

```
★`superseded_names=frozenset()` の sanity witness
   ⚪ ★役割は 分かります（★strip が 効いている ことの 証明）
   ⚠️ ★ただし ★本命の test（★宣言 registry ↔ 計算結果）だけでも
      ★modeling を 外せば ★計算結果から spawn_session が 消え ★不一致で 落ちます
   ∴ ★同じことを ★2 度 証明しています（★害は ありません）
⚪ ★次に この file を 触る 時、★どちらか 1 本で 足りると 判断したら ★消して 構いません
```
