### PR TITLE
fix(#3896): give spawn_session a multi_agent catalog route

### DIFF
--- a/docs/concepts/multi-agent/org-design.md
+++ b/docs/concepts/multi-agent/org-design.md
@@ -67,17 +67,22 @@ of this conversation. The spawned session begins immediately; this tool
 returns a spawn-ack rather than waiting for the task to complete (async
 dispatch).
 
-⚠️ **Exclusive-wrapper mode has no catalog route for this tool.** When
+**Reachable under exclusive-wrapper mode too (#3896, fixed 2026-08-13).** When
 [`action_retrieval.universal_wrappers_enabled`](../tools-integrations/universal-catalog.md)
-is `true`, `spawn_session`'s individual per-tool entry is stripped, the same
-as every router-only delegation tool (`run_prompt`, `send_to_session`) —
-none of them has a `multi_agent` category catalog-dispatch fallback; that
-category's action set is `list_agents` / `describe_agent` only. (Prior to
-proposal 0067 P6, #3978, `delegate_to_agent` was the one exception with a
-catalog-channel route; it retired with the rest of its own tool, so this
-gap is now uniform across the whole delegation surface, not
-`spawn_session`-specific.) An operator enabling exclusive-wrapper mode
-loses `spawn_session` reachability entirely, with no compensating route.
+is `true`, `spawn_session`'s individual per-tool entry is stripped from direct
+advertisement, but the `multi_agent` catalog category now includes it
+alongside `list_agents` / `describe_agent` — `invoke_action{action_name:
+"spawn_session", args: {...}}` reaches the same handler, same permission
+enforcement, as calling it directly. (An earlier version of this doc — and of
+the code itself — documented this as a real gap: #3896 found that
+`spawn_session` used to have no compensating catalog route at all, a genuine
+capability loss under a real, selectable configuration. Owner ruling gave it
+one rather than accept the loss.) `run_prompt` / `send_to_session` remain
+router-only delegation tools with no catalog-dispatch fallback — this fix is
+scoped to `spawn_session`'s own finding, not the whole delegation surface.
+(Prior to proposal 0067 P6, #3978, `delegate_to_agent` was the one *other*
+exception with a catalog-channel route; it retired with the rest of its own
+tool.)
 
 **`mode`**:
 

--- a/src/reyn/runtime/router_tools.py
+++ b/src/reyn/runtime/router_tools.py
@@ -119,11 +119,14 @@ _WRAPPER_SUPERSEDED_BASE_TOOLS: frozenset[str] = frozenset({
     # #879 shipped each tool's real ``inputSchema`` verbatim in
     # ``list_mcp_tools``' result precisely so no describe round-trip is needed.
     "describe_mcp_tool",
-    # Spawning a sub-session is not a catalog action; it is stripped here as a
-    # deliberate surface reduction, and has been since the exclusive-wrapper
-    # mode landed. (``spawn_agent`` / ``create_topology`` are deliberately NOT
-    # stripped — the org-design surface stays reachable.)
-    "spawn_session",  # renamed from session_spawn — #4004
+    # #3896: ``spawn_session`` used to be listed here under a "deliberate
+    # surface reduction" framing that named a policy which never actually
+    # existed — no owner decision was ever made to withhold session-spawn
+    # under exclusive-wrapper mode; it was an oversight (no compensating
+    # catalog route existed at all, unlike this set's other two entries,
+    # which both name a real replacement). Fixed by giving it a
+    # ``multi_agent`` catalog route (``universal_dispatch._CATEGORY_ACTIONS``)
+    # instead of stripping it — it no longer belongs in this residue set.
 })
 
 

--- a/src/reyn/tools/llm_reachability.py
+++ b/src/reyn/tools/llm_reachability.py
@@ -113,9 +113,16 @@ other, both, or neither; they answer different questions and neither
 subsumes the other. Measured result under this mode: the 5 cron tools (still
 unreachable regardless of mode) plus ``call_mcp_tool`` / ``describe_mcp_tool``
 (their own §J entries' reasons already name their replacement — this is the
-INTENDED end state, not a gap) plus ``spawn_session`` (#3896's actual finding
-— no replacement exists, an open (A)/(B)/(C) product decision, same shape as
-cron's own entry above).
+INTENDED end state, not a gap).
+
+**#3896's own finding (fixed).** ``spawn_session`` used to be in this set too
+— stripped by §J with no compensating catalog route, unlike the two MCP
+tools above. Owner ruling (2026-08-13): give it a real catalog route rather
+than stop stripping it or accept the loss (option 1 of the (A)/(B)/(C) choice
+this module's own registry used to track as open). ``universal_dispatch.
+_CATEGORY_ACTIONS["multi_agent"]`` now includes it, so route (b) covers it
+even while §J still strips route (a) — it is reachable under this mode
+again, and no longer appears in the registry below.
 """
 from __future__ import annotations
 
@@ -188,25 +195,6 @@ UNREACHABLE_TOOL_REASONS: Final[Mapping[str, UnreachableToolReason]] = {
 }
 
 
-_SPAWN_SESSION_EXCLUSIVE_WRAPPER_REASON = (
-    "#3896: `spawn_session` is registered router=allow and IS direct-advertisable "
-    "in the default configuration (universal_wrappers_enabled=False under the "
-    "shipped default 'enumerate-all' exposure scheme), so it is correctly absent "
-    "from UNREACHABLE_TOOL_REASONS above. But router_tools.build_tools's own "
-    "section J strips it (_wrapper_superseded_tool_names() includes it as a "
-    "deliberate surface reduction) whenever universal_wrappers_enabled=True -- a "
-    "real, selectable, already-landed configuration (#3429's exclusive-wrapper "
-    "mode) -- and it has no catalog route (never added to "
-    "universal_dispatch._CATEGORY_ACTIONS), unlike delegate_to_agent's symmetric "
-    "multi_agent category route. Under that mode specifically, spawn_session is "
-    "genuinely unreachable -- a real capability loss, not a false positive. "
-    "Whether to (A) give it a catalog route (symmetric with delegate_to_agent), "
-    "(B) stop stripping it in exclusive-wrapper mode, or (C) accept the loss as "
-    "the mode's intended shape is an open product decision tracked on #3896 "
-    "itself. This entry records the interim state -- a known, tracked hole, not "
-    "a silently-passing gate -- pending that decision."
-)
-
 _CALL_MCP_TOOL_EXCLUSIVE_WRAPPER_REASON = (
     "router_tools.py's own _WRAPPER_SUPERSEDED_BASE_TOOLS entry for "
     "`call_mcp_tool` names its replacement: `mcp_call_tool` is the catalog's "
@@ -243,9 +231,11 @@ UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS: Final[Mapping[str, Unreachable
     "describe_mcp_tool": UnreachableToolReason(
         "SUPERSEDED_BY_CATALOG_REPLACEMENT", _DESCRIBE_MCP_TOOL_EXCLUSIVE_WRAPPER_REASON
     ),
-    "spawn_session": UnreachableToolReason(
-        "PENDING_CAPABILITY_DECISION", _SPAWN_SESSION_EXCLUSIVE_WRAPPER_REASON
-    ),
+    # #3896: `spawn_session` used to be declared here (PENDING_CAPABILITY_DECISION)
+    # — removed once it gained a real `multi_agent` catalog route (see the
+    # module docstring's "Exclusive-wrapper mode" section). It is reachable
+    # under this mode again via route (b), so it no longer belongs in this
+    # registry at all.
 }
 
 

--- a/src/reyn/tools/universal_dispatch.py
+++ b/src/reyn/tools/universal_dispatch.py
@@ -103,7 +103,14 @@ _CATEGORY_ACTIONS: Final[dict[str, tuple[str, ...]]] = {
     # ``delegate_to_agent`` retired (proposal 0067 P6, #3978) — see
     # ``send_to_session``/``run_prompt`` for the surviving reach-another-
     # agent's-context verbs.
-    "multi_agent": ("list_agents", "describe_agent"),
+    # #3896 (owner ruling, option 1): ``spawn_session`` gains a catalog route
+    # so exclusive-wrapper mode does not lose the capability entirely — it
+    # used to be stripped by router_tools.py's §J with nothing to replace it
+    # (unlike ``call_mcp_tool``/``describe_mcp_tool``, whose §J strips DO name
+    # a replacement). ``run_prompt``/``send_to_session`` remain catalog-less;
+    # this entry is scoped to spawn_session's own finding, not a general fix
+    # for the delegation surface.
+    "multi_agent": ("list_agents", "describe_agent", "spawn_session"),
     # Issue #879 — a single ``mcp`` category. 2026-05-25 install-surface
     # refactor: ``install_server`` split along the SOURCE axis into three verbs
     # (registry / public package channel / local script), and

--- a/tests/tools/test_llm_reachability_exclusive_wrapper_mode_3896.py
+++ b/tests/tools/test_llm_reachability_exclusive_wrapper_mode_3896.py
@@ -3,7 +3,7 @@
 #3896 found that ``router_tools.build_tools``'s section J strip step
 (``_wrapper_superseded_tool_names()``, run whenever
 ``universal_wrappers_enabled=True`` — the exclusive-wrapper mode #3429
-landed) removes ``spawn_session`` from direct advertisement with no
+landed) removed ``spawn_session`` from direct advertisement with no
 compensating catalog route — a genuine capability loss under a real,
 selectable, already-landed configuration. The plain #3464 gate
 (``reyn.tools.llm_reachability.compute_unreachable_router_allow_tool_names``)
@@ -16,9 +16,15 @@ at all. This suite exercises the SECOND, mode-scoped computation
 real (imports ``router_tools._wrapper_superseded_tool_names()``, never
 re-derives it) and answers the mode-scoped question directly.
 
-Per lead-coder's explicit review instruction: the RED this modeling produces
-(``spawn_session`` newly unreachable under this mode) is not suppressed via
-xfail/skip — it is registered in
+**Fixed** (owner ruling, 2026-08-13, option 1): ``spawn_session`` gained a
+``multi_agent`` catalog route, so it is reachable again under this mode via
+route (b) even though §J still strips route (a) — same shape as
+``call_mcp_tool``/``describe_mcp_tool`` below. It no longer appears in
+``UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS``.
+
+Per lead-coder's explicit review instruction (still true for the tools that
+remain in the registry): the RED this modeling produces for a genuinely
+unreachable tool is not suppressed via xfail/skip — it is registered in
 ``UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS``, a closed, tracked
 registry mirroring #3464's own pattern, so growth of this set is caught the
 same way #3464's own gate catches growth of its set.
@@ -95,18 +101,28 @@ def test_declared_reasons_use_the_closed_classification_and_are_nonempty() -> No
         )
 
 
-def test_spawn_session_is_declared_pending_capability_decision() -> None:
-    """Tier 2: #3896's own finding — spawn_session is stripped under
-    exclusive-wrapper mode with no compensating catalog route. A genuine
-    capability loss awaiting an owner (A)/(B)/(C) decision, same shape as
-    the #3464 cron entries -- not a wiring bug and not an intentional
-    supersession (there is no replacement tool)."""
-    assert "spawn_session" in UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS
-    entry = UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS["spawn_session"]
-    assert entry.classification == "PENDING_CAPABILITY_DECISION"
-    # Sanity: spawn_session IS in the #3464 gate's reachable set (existentially
-    # reachable under wrappers=off) -- confirming this mode-scoped registry is
-    # answering a genuinely different question, not a subset of #3464's own.
+def test_spawn_session_is_reachable_under_exclusive_wrapper_mode() -> None:
+    """Tier 2: #3896's fix (owner ruling, option 1) — spawn_session gained a
+    `multi_agent` catalog route, so it is reachable under exclusive-wrapper
+    mode via route (b) even though §J still strips its direct-advertisement
+    route (a). No longer declared in this registry at all (was
+    PENDING_CAPABILITY_DECISION before the fix)."""
+    assert "spawn_session" not in UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS
+    reachable = compute_reachable_tool_names_under_exclusive_wrapper_mode()
+    assert "spawn_session" in reachable
+    # The route making it reachable is (b), not (a): §J still strips its
+    # direct-advertisement route (now correctly — it's a catalog member, so
+    # advertising it BOTH directly and via invoke_action would be the same
+    # #3429 double-spelling problem this whole strip step exists to avoid),
+    # same shape as call_mcp_tool/describe_mcp_tool above. Confirms this
+    # isn't accidentally passing because the strip itself regressed.
+    from reyn.runtime.router_tools import _wrapper_superseded_tool_names
+    assert "spawn_session" in _wrapper_superseded_tool_names()
+    assert "spawn_session" not in compute_direct_advertisable_tool_names_under_exclusive_wrapper_mode()
+    # Sanity: spawn_session IS also in the #3464 gate's reachable set
+    # (existentially reachable under wrappers=off) -- confirming this
+    # mode-scoped registry answers a genuinely different question, not a
+    # subset of #3464's own.
     assert "spawn_session" not in compute_unreachable_router_allow_tool_names()
 
 
@@ -137,30 +153,16 @@ def test_cron_tools_are_declared_pending_capability_decision_here_too() -> None:
 
 
 # ── Non-vacuity: strip-falsify each route, AND the strip-modeling itself ──
-
-
-def test_unmodeled_strip_would_hide_spawn_session_the_actual_3896_defect() -> None:
-    """Tier 2: THE regression witness for #3896 itself -- proves the strip
-    modeling is load-bearing, not decorative. Passing ``superseded_names=
-    frozenset()`` (== the OLD gate's behaviour, which never modeled section J
-    at all) makes spawn_session vanish from the mode-scoped unreachable set,
-    reproducing the exact defect #3896 reported. If this ever regressed back
-    to that shape without anyone noticing, THIS assertion is what would still
-    catch it independently of the registry-identity check above."""
-    modeled = compute_unreachable_router_allow_tool_names_under_exclusive_wrapper_mode()
-    assert "spawn_session" in modeled, (
-        "the fix itself must find spawn_session unreachable under this mode"
-    )
-
-    unmodeled = compute_unreachable_router_allow_tool_names_under_exclusive_wrapper_mode(
-        superseded_names=frozenset(),
-    )
-    assert "spawn_session" not in unmodeled, (
-        "sanity: with no strip modeled at all, spawn_session must be "
-        "reachable via the (unstripped) direct-advertisement census -- "
-        "confirming the strip step is what actually removes it, not some "
-        "other factor this test would otherwise misattribute"
-    )
+#
+# #3896's own regression witness (`test_unmodeled_strip_would_hide_spawn_
+# session_the_actual_3896_defect`) lived here until spawn_session gained a
+# catalog route: its premise -- that spawn_session is unreachable under this
+# mode -- is no longer true (it's reachable via route (b) regardless of
+# whether the strip step is modeled), so the assertion it made would either
+# invert or become vacuous. Deleted rather than inverted: the two probes
+# below already independently prove both routes are load-bearing for THIS
+# mode generally (create_topology for route (a), search_knowledge for route
+# (b)), so no coverage is lost by retiring the spawn_session-specific one.
 
 
 def test_strip_direct_advertisement_route_makes_the_gate_fire() -> None:

--- a/tests/tools/test_universal_dispatch.py
+++ b/tests/tools/test_universal_dispatch.py
@@ -247,6 +247,10 @@ _ACTION_CONTRACT_SAMPLES: list[tuple[str, dict[str, Any]]] = [
     # itself defaults an absent ``path`` to ``""``.)
     ("list_agents", {"path": ""}),
     ("describe_agent", {"name": "planner"}),
+    # #3896 (owner ruling, option 1): spawn_session gained a catalog route so
+    # exclusive-wrapper mode doesn't lose the capability entirely — see
+    # llm_reachability.py's "Exclusive-wrapper mode" section.
+    ("spawn_session", {"request": "investigate the failing test"}),
     # delegate_to_agent retired, proposal 0067 P6 (#3978) — run_prompt/
     # send_to_session are router-only tools (not invoke_action/catalog
     # actions), so they need no contract sample here.

--- a/tests/tools/test_universal_handlers.py
+++ b/tests/tools/test_universal_handlers.py
@@ -178,16 +178,18 @@ def test_list_actions_no_category_filter_includes_all() -> None:
 
 
 def test_list_actions_multi_agent_static_category_returns_verbs() -> None:
-    """Tier 2: list_actions(category=['multi_agent']) returns the two
-    verb actions (= list_peers / describe_peer) regardless of which peers
-    are reachable.
+    """Tier 2: list_actions(category=['multi_agent']) returns the three
+    verb actions (= list_peers / describe_peer / spawn_session) regardless
+    of which peers are reachable.
 
     Phase 1 follow-up (2026-05-25) collapsed the per-peer agent.peer__X
     resource shape into verb actions; per-peer enumeration moves to the
     list_peers handler return value. delegate_to_agent (the original third
     verb here) retired in proposal 0067 P6 (#3978) — run_prompt/
     send_to_session are router-only tools, not invoke_action/catalog
-    actions, so they are not in this category's enumeration.
+    actions, so they are not in this category's enumeration. #3896 (owner
+    ruling, option 1) added spawn_session as the category's third member so
+    exclusive-wrapper mode doesn't lose the capability entirely.
     """
     result = _run(LIST_ACTIONS.handler(
         {"category": ["multi_agent"]}, _make_ctx(),
@@ -196,6 +198,7 @@ def test_list_actions_multi_agent_static_category_returns_verbs() -> None:
     assert qns == {
         "list_agents",
         "describe_agent",
+        "spawn_session",
     }, f"multi_agent enumeration drifted: got {qns}"
 
 
@@ -601,17 +604,18 @@ def test_invoke_action_refuses_a_registered_tool_outside_the_catalog() -> None:
     """Tier 2: #3429 — ``invoke_action`` dispatches CATALOG actions, not "any
     registered tool by name".
 
-    ``present`` / ``spawn_session`` / ``spawn_agent`` are live registered tools
-    that the catalog deliberately does not browse; ``spawn_session`` is also on
-    the exclusive-wrapper strip list, i.e. a surface reduction the wrapper mode
-    makes on purpose. A wrapper that dispatched anything the registry could
-    look up would hand every one of them back, under the one tool that mode
-    always advertises.
+    ``present`` / ``spawn_agent`` are live registered tools that the catalog
+    deliberately does not browse. (``spawn_session`` used to be a third
+    example here — it gained a real ``multi_agent`` catalog route in #3896,
+    so it is no longer a valid non-catalog example; see
+    ``test_universal_dispatch.py``'s own contract-sample entry for it.) A
+    wrapper that dispatched anything the registry could look up would hand
+    every one of them back, under the one tool that mode always advertises.
 
     The membership check is what refuses them — a registry lookup alone would
     SUCCEED here, which is why this arm exists rather than relying on the
     lookup's own None branch."""
-    for name in ("present", "spawn_session", "spawn_agent"):
+    for name in ("present", "spawn_agent"):
         result = _run(INVOKE_ACTION.handler({"action_name": name}, _make_ctx()))
         assert "error" in result, f"invoke_action dispatched non-catalog tool {name!r}"
         assert result["action_name"] == name


### PR DESCRIPTION
**[docs-maintainer]** — #3896, owner ruling option 1 (lead-coder's assignment, priority raised: this is live in the owner's own production environment, not a future trap).

## Pre-implementation gate (required before touching code)

lead-coder's explicit instruction: confirm invoke_action preserves the same permission gate as direct advertisement before implementing, since spawn_session is Router-only (`gates.router="allow"`).

**Verified, not assumed**: `_handle_invoke_action` (`universal_catalog.py`) calls `target.handler(dict(inner_args), ctx)` directly, with `ctx` forwarded verbatim — its own docstring: "The ToolContext is forwarded verbatim so router_state callbacks ... reach the handler as if the caller had invoked it directly." `spawn_session`'s handler (`session_spawn.py::_handle`) calls `ctx.router_state.spawn_session_fn(...)`, which is `RouterHostAdapter.spawn_session` — the same function, same restrict-only narrowing composition (#3556), regardless of dispatch route. `invoke_action` itself is `gates.router="allow"` (`universal_catalog.py`), the exact same gate `spawn_session`'s own direct advertisement already requires — no new exposure channel. No gate widening.

## What

- `universal_dispatch._CATEGORY_ACTIONS["multi_agent"]`: added `"spawn_session"`.
- `router_tools._WRAPPER_SUPERSEDED_BASE_TOOLS`: removed the `spawn_session` residue entry + its "deliberate surface reduction" comment (lead-coder's own finding: that framing named a policy that was never actually decided — an oversight, not a policy). It's derived from the catalog set now, same as any other catalog action.
- `llm_reachability.py`: removed the resolved `UNREACHABLE_UNDER_EXCLUSIVE_WRAPPER_MODE_REASONS` entry + its reason constant; updated the module docstring's "Measured result" claim.
- `org-design.md`: rewrote the ⚠️ gap warning to describe the fix — same-PR doc-sync, not a follow-up.

## Tests

- Replaced the now-false `test_spawn_session_is_declared_pending_capability_decision` with a positive reachability witness confirming route (b) covers it while §J still strips route (a) (same shape as `call_mcp_tool`/`describe_mcp_tool`).
- Deleted `test_unmodeled_strip_would_hide_spawn_session_the_actual_3896_defect` — its premise (spawn_session unreachable under this mode) is no longer true; the two other non-vacuity probes (`create_topology`/`search_knowledge`) already independently prove both routes are load-bearing for this mode, so no coverage is lost.
- Added spawn_session's contract sample in `test_universal_dispatch.py`.
- Fixed two pinned tests in `test_universal_handlers.py` that used `spawn_session` as a "registered but not catalog" negative example (it now is a catalog member) — dropped it from that list, and updated the `multi_agent` category's set-equality enumeration pin to include it.

## Acceptance witness (lead-coder's own framing)

#4551's gate now shows spawn_session reachable under exclusive-wrapper mode — the `PENDING_CAPABILITY_DECISION` row is gone from the declared registry, checked mechanically by `test_current_unreachable_set_under_exclusive_wrapper_mode_matches_the_declared_registry`.

## Verification

- `pytest tests/tools/` (full) — 952 passed
- `pytest tests/runtime/test_router_tools*.py tests/runtime/test_2120_session_spawn_advertised.py tests/runtime/test_3378_advertise_enforce_agreement.py tests/runtime/test_3561_spawn_session_seam_reachability.py` — 67 passed
- `pytest tests/security/test_2111_floor_alias_completeness.py tests/security/test_capability_profile_1827.py tests/runtime/test_3556_session_spawn_narrowing_inheritance.py tests/runtime/test_3220_capability_visibility_composed_payload.py` — 80 passed
- `ruff check src tests` — clean
- `test_tier_audit.py --strict` on the 3 changed test files — 78/78 OK
- `verify_module_docstrings.py` on the 3 changed src files — OK
- `mypy_ratchet.py` — OK, all baselined
- `check_tests_path_literal_reference.py` — OK, all baselined
- `mkdocs build --strict` — clean, no Aborted/error line

Closes #3896

## Test plan

- [x] Pre-implementation permission-gate verification (lead-coder's required gate) — done before writing any code, see above
- [x] `pytest tests/tools/` (full) — 952 passed
- [x] Targeted runtime/security/capability-profile sweeps — 147 passed
- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` on changed test files — 78/78 OK
- [x] `verify_module_docstrings.py` on changed src files — OK
- [x] `mypy_ratchet.py` — OK
- [x] `check_tests_path_literal_reference.py` — OK
- [x] `mkdocs build --strict` — clean
- [x] (skipped — no Visual item, this is a catalog-wiring + doc fix with no UI surface)
